### PR TITLE
aluminum: make variants sticky

### DIFF
--- a/var/spack/repos/builtin/packages/aluminum/package.py
+++ b/var/spack/repos/builtin/packages/aluminum/package.py
@@ -119,12 +119,14 @@ class Aluminum(CMakePackage, CudaPackage, ROCmPackage):
         "ofi_libfabric_plugin",
         default=spack.platforms.cray.slingshot_network(),
         when="+rccl",
+        sticky=True,
         description="Builds with support for OFI libfabric enhanced RCCL/NCCL communication lib",
     )
     variant(
         "ofi_libfabric_plugin",
         default=spack.platforms.cray.slingshot_network(),
         when="+nccl",
+        sticky=True,
         description="Builds with support for OFI libfabric enhanced RCCL/NCCL communication lib",
     )
 


### PR DESCRIPTION
Set the sticky bit on the ofi_lib_fabric variant to prevent the
concretizer from getting creative and toggling it.