### PR TITLE
libluv: move conflict from neovim to libluv + problem is fixed on master

### DIFF
--- a/var/spack/repos/builtin/packages/libluv/package.py
+++ b/var/spack/repos/builtin/packages/libluv/package.py
@@ -22,14 +22,18 @@ class Libluv(CMakePackage):
     version("1.42.0-0", sha256="b5228a9d0eaacd9f862b6270c732d5c90773a28ce53b6d9e32a14050e7947f36")
     version("1.36.0-0", sha256="f2e7eb372574f25c6978c1dc74280d22efdcd7df2dda4a286c7fe7dceda26445")
 
+    # https://github.com/neovim/neovim/issues/25770
+    # up to 1.45 (included) dynamic library on macOS did not have the @rpath prefix, being not
+    # usable on this platform.
+    # from 1.46, by requiring a newer cmake version, CMP0042 is in place and it works correctly.
+    depends_on("cmake@3:", type="build")
+
     depends_on("lua-lang", type="link")
     depends_on("libuv", type="link")
 
-    # https://github.com/neovim/neovim/issues/25770
-    conflicts("libluv@1.44:1.45", when="platform=darwin")
-
     def cmake_args(self):
         args = [
+            self.define("CMAKE_POLICY_DEFAULT_CMP0042", "NEW"),
             "-DLUA_BUILD_TYPE=System",
             "-DBUILD_STATIC_LIBS=ON",
             "-DBUILD_SHARED_LIBS=ON",

--- a/var/spack/repos/builtin/packages/libluv/package.py
+++ b/var/spack/repos/builtin/packages/libluv/package.py
@@ -25,6 +25,9 @@ class Libluv(CMakePackage):
     depends_on("lua-lang", type="link")
     depends_on("libuv", type="link")
 
+    # https://github.com/neovim/neovim/issues/25770
+    conflicts("libluv@1.44:1.45", when="platform=darwin")
+
     def cmake_args(self):
         args = [
             "-DLUA_BUILD_TYPE=System",

--- a/var/spack/repos/builtin/packages/neovim/package.py
+++ b/var/spack/repos/builtin/packages/neovim/package.py
@@ -140,9 +140,6 @@ class Neovim(CMakePackage):
     # https://github.com/neovim/neovim/issues/16217#issuecomment-958590493
     conflicts("libvterm@0.2:", when="@:0.7")
 
-    # https://github.com/neovim/neovim/issues/25770
-    conflicts("libluv@1.44:", when="platform=darwin")
-
     @when("^lua")
     def cmake_args(self):
         return [self.define("PREFER_LUA", True)]


### PR DESCRIPTION
It's not a big deal, but the conflict added in #40690 belongs to `libluv` and not `neovim`.

Moreover, since it is fixed on master, I took the chance to also limit the conflict to just currently affected versions (if everything goes smoothly, 1.46 should get the fix).

@haampie: I opted for the conflict and not "forcing" the CMP0042 because if someone is actually using a very old CMake version, that workaround should not work. Hopefully, we are not going to miss much on macOS not being able to use those two specific version (1.44 and 1.45). Let me know if you prefer something different.