### PR TITLE
conquest: add build system changes and library paths

### DIFF
--- a/var/spack/repos/builtin/packages/conquest/package.py
+++ b/var/spack/repos/builtin/packages/conquest/package.py
@@ -48,9 +48,15 @@ class Conquest(MakefilePackage):
     )
 
     build_directory = "src"
+
     # The SYSTEM variable is required above version 1.2.
     # Versions 1.2 and older should ignore it.
-    build_targets = ["SYSTEM = example"]
+    @property
+    def build_targets(self):
+        if self.version > Version("1.2"):
+            return ["SYSTEM = example", "Conquest"]
+        else:
+            return ["Conquest"]
 
     def edit(self, spec, prefix):
         fflags = "-O3 -fallow-argument-mismatch"

--- a/var/spack/repos/builtin/packages/conquest/package.py
+++ b/var/spack/repos/builtin/packages/conquest/package.py
@@ -98,3 +98,5 @@ class Conquest(MakefilePackage):
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         install("./bin/Conquest", prefix.bin)
+        if self.version > Version("1.2"):
+            install_tree("./benchmarks/", join_path(prefix, "benchmarks"))

--- a/var/spack/repos/builtin/packages/conquest/package.py
+++ b/var/spack/repos/builtin/packages/conquest/package.py
@@ -52,7 +52,6 @@ class Conquest(MakefilePackage):
     # Versions 1.2 and older should ignore it.
     build_targets = ["SYSTEM = example"]
 
-
     def edit(self, spec, prefix):
         fflags = "-O3 -fallow-argument-mismatch"
         ldflags = ""

--- a/var/spack/repos/builtin/packages/conquest/package.py
+++ b/var/spack/repos/builtin/packages/conquest/package.py
@@ -76,8 +76,10 @@ class Conquest(MakefilePackage):
             defs_file = FileFilter("./src/system/system.example.make")
             makefile = FileFilter("./src/Makefile")
             makefile.filter("SYSTEM =.*", "SYSTEM = example")
-            makefile.filter("$(info Building on SYSTEM $(SYSTEM), using makefile $(SYSTEM_PATH))",
-                            "$(info Building on SYSTEM $(SYSTEM), using spack")
+            makefile.filter(
+                "$(info Building on SYSTEM $(SYSTEM), using makefile $(SYSTEM_PATH))",
+                "$(info Building on SYSTEM $(SYSTEM), using spack",
+            )
 
         defs_file.filter(".*COMPFLAGS=.*", f"COMPFLAGS= {fflags}")
         defs_file.filter(".*LINKFLAGS=.*", f"LINKFLAGS= {ldflags}")

--- a/var/spack/repos/builtin/packages/conquest/package.py
+++ b/var/spack/repos/builtin/packages/conquest/package.py
@@ -69,17 +69,7 @@ class Conquest(MakefilePackage):
         if self.version <= Version("1.2"):
             defs_file = FileFilter("./src/system.make")
         else:
-            # Starting from 1.3 there's automated logic in the Makefile that picks
-            # from a list of possible files for system/compiler-specific definitions.
-            # This is useful for manual builds, but since the spack will do its own
-            # automation of compiler-specific flags, we need to override it.
             defs_file = FileFilter("./src/system/system.example.make")
-            makefile = FileFilter("./src/Makefile")
-            makefile.filter("SYSTEM =.*", "SYSTEM = example")
-            makefile.filter(
-                "$(info Building on SYSTEM $(SYSTEM), using makefile $(SYSTEM_PATH))",
-                "$(info Building on SYSTEM $(SYSTEM), using spack",
-            )
 
         defs_file.filter(".*COMPFLAGS=.*", f"COMPFLAGS= {fflags}")
         defs_file.filter(".*LINKFLAGS=.*", f"LINKFLAGS= {ldflags}")
@@ -94,6 +84,17 @@ class Conquest(MakefilePackage):
             defs_file.filter(
                 "MULT_KERN =.*", f"MULT_KERN = {self.spec.variants['mult_kern'].value}"
             )
+
+    def build(self, spec, prefix):
+        # Starting from 1.3 there's automated logic in the Makefile that picks
+        # from a list of possible files for system/compiler-specific definitions.
+        # This is useful for manual builds, but since the spack will do its own
+        # automation of compiler-specific flags, we will override it.
+        with working_dir("src"):
+            if self.version <= Version("1.2"):
+                make()
+            else:
+                make("SYSTEM = example")
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/conquest/package.py
+++ b/var/spack/repos/builtin/packages/conquest/package.py
@@ -63,12 +63,16 @@ class Conquest(MakefilePackage):
 
         lapack_ld = self.spec["lapack"].libs.ld_flags
         blas_ld = self.spec["blas"].libs.ld_flags
+        fftw_ld = self.spec["fftw"].libs.ld_flags
+        libxc_ld = self.spec["libxc"].libs.ld_flags
 
         defs_file = FileFilter("./src/system.make")
 
         defs_file.filter("COMPFLAGS=.*", f"COMPFLAGS= {fflags}")
         defs_file.filter("LINKFLAGS=.*", f"LINKFLAGS= {ldflags}")
-        defs_file.filter("# BLAS=.*", f"BLAS= {lapack_ld} -llapack {blas_ld} -lblas")
+        defs_file.filter("# BLAS=.*", f"BLAS= {lapack_ld} {blas_ld}")
+        defs_file.filter("FFT_LIB=.*", f"FFT_LIB={fftw_ld}")
+        defs_file.filter("XC_LIB=.*", f"XC_LIB={libxc_ld} -lxcf90 -lxc")
 
         if "+openmp" in self.spec:
             defs_file.filter("OMP_DUMMY = DUMMY", "OMP_DUMMY = ")


### PR DESCRIPTION
There's been a change in development to where files included by the makefile are kept and how they are included. This PR fixes the spack package to use them in future versions.

I also discovered on another system I was building on that I had to add the `ld_flags` of `fftw` and `libxc` (in addition to `blas` and `scalapack`) to the Makefile to link them.

Apologies, I added another thing :blush: Inputs for some common benchmarks are installed above version 1.2