### PR TITLE
acts: add v28.1.0:30.3.2

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -40,6 +40,7 @@ class Acts(CMakePackage, CudaPackage):
     # Supported Acts versions
     version("main", branch="main")
     version("master", branch="main", deprecated=True)  # For compatibility
+    version("30.3.2", commit="76826f208f5929d8326798c87263f2563d0ae7e9", submodules=True)
     version("30.3.1", commit="bbee459dd93855417d5717d53cbbb2bace7de2bb", submodules=True)
     version("30.3.0", commit="311acb9ab41c2d79a4b90b193e5b25297182d670", submodules=True)
     version("30.2.0", commit="264b0a3214cbf8ca013623fc196e2d90d647c58f", submodules=True)

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -40,6 +40,17 @@ class Acts(CMakePackage, CudaPackage):
     # Supported Acts versions
     version("main", branch="main")
     version("master", branch="main", deprecated=True)  # For compatibility
+    version("30.3.1", commit="bbee459dd93855417d5717d53cbbb2bace7de2bb", submodules=True)
+    version("30.3.0", commit="311acb9ab41c2d79a4b90b193e5b25297182d670", submodules=True)
+    version("30.2.0", commit="264b0a3214cbf8ca013623fc196e2d90d647c58f", submodules=True)
+    version("30.1.1", commit="3d43492b2775e62051e9ad31f06b91d6e2357ab9", submodules=True)
+    version("30.1.0", commit="60d9eec916f6c81373858c8d99d821861d7efeb8", submodules=True)
+    version("30.0.0", commit="00fa3fabac86a1e65198d4b94dd263b1c731a84c", submodules=True)
+    version("29.2.0", commit="b2d65308399d8f653fa8bdd73a2a203c58608358", submodules=True)
+    version("29.1.0", commit="4681c3b142db469b00ca03e92e6b237f7c89d141", submodules=True)
+    version("29.0.0", commit="9c6e4597af39f826e17d46850fdb407a48817ba6", submodules=True)
+    version("28.2.0", commit="c612e7c625f961330e383fb7856cc7398dd82881", submodules=True)
+    version("28.1.0", commit="08e51b5f93c0d09f2d1e7e4f062e715072ec3e9b", submodules=True)
     version("28.0.0", commit="0d8aa418c00e8f79bab2cf88234f3433670b447c", submodules=True)
     version("27.1.0", commit="219480220738318fbedb943cac85415687d75b66", submodules=True)
     version("27.0.0", commit="4d7029bd4e9285fcda2770aef6d78a7f833cb14f", submodules=True)

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -226,6 +226,7 @@ class Acts(CMakePackage, CudaPackage):
     variant("mlpack", default=False, description="Build MLpack plugin", when="@25:")
     variant("onnx", default=False, description="Build ONNX plugin")
     variant("odd", default=False, description="Build the Open Data Detector", when="@19.1:")
+    variant("podio", default=False, description="Build Podio plugin", when="@30.3:")
     variant(
         "profilecpu",
         default=False,
@@ -312,6 +313,8 @@ class Acts(CMakePackage, CudaPackage):
     depends_on("mlpack@3.1.1:", when="+mlpack")
     depends_on("nlohmann-json @3.9.1:", when="@0.14: +json")
     depends_on("podio @0.6:", when="@25: +edm4hep")
+    depends_on("podio @0.16:", when="@30.3: +edm4hep")
+    depends_on("podio @0.16:", when="+podio")
     depends_on("pythia8", when="+pythia8")
     depends_on("python", when="+python")
     depends_on("python@3.8:", when="+python @19.11:19")
@@ -402,6 +405,7 @@ class Acts(CMakePackage, CudaPackage):
             plugin_cmake_variant("ONNX", "onnx"),
             enable_cmake_variant("CPU_PROFILING", "profilecpu"),
             enable_cmake_variant("MEMORY_PROFILING", "profilemem"),
+            plugin_cmake_variant("PODIO", "podio"),
             example_cmake_variant("PYTHIA8", "pythia8"),
             example_cmake_variant("PYTHON_BINDINGS", "python"),
             plugin_cmake_variant("ACTSVG", "svg"),


### PR DESCRIPTION
Surprisingly no changes to the build system beyond a low-level `ACTS_SOURCELINK_SBO_SIZE` small-buffer-optimization configuration that I don't think we need to expose.

- https://github.com/acts-project/acts/releases/tag/v28.1.0
- https://github.com/acts-project/acts/releases/tag/v28.2.0
- https://github.com/acts-project/acts/releases/tag/v29.0.0
- https://github.com/acts-project/acts/releases/tag/v29.1.0
- https://github.com/acts-project/acts/releases/tag/v29.2.0
- https://github.com/acts-project/acts/releases/tag/v30.0.0
- https://github.com/acts-project/acts/releases/tag/v30.1.0
- https://github.com/acts-project/acts/releases/tag/v30.1.1
- https://github.com/acts-project/acts/releases/tag/v30.2.0
- https://github.com/acts-project/acts/releases/tag/v30.3.0
- https://github.com/acts-project/acts/releases/tag/v30.3.1
- https://github.com/acts-project/acts/releases/tag/v30.3.2