### PR TITLE
OpenMPI: add v5.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -42,10 +42,13 @@ class Openmpi(AutotoolsPackage, CudaPackage):
 
     # Current
     version(
-        "4.1.6", sha256="f740994485516deb63b5311af122c265179f5328a0d857a567b85db00b11e415"
-    )  # libmpi.so.40.30.6
+        "5.0.0", sha256="9d845ca94bc1aeb445f83d98d238cd08f6ec7ad0f73b0f79ec1668dbfdacd613"
+    )  # libmpi.so.40.40.0
 
     # Still supported
+    version(
+        "4.1.6", sha256="f740994485516deb63b5311af122c265179f5328a0d857a567b85db00b11e415"
+    )  # libmpi.so.40.30.6
     version(
         "4.1.5", sha256="a640986bc257389dd379886fdae6264c8cfa56bc98b71ce3ae3dfbd8ce61dbe3"
     )  # libmpi.so.40.30.5


### PR DESCRIPTION
Add latest 5.0.0 release of OpenMPI. SHA from `spack checksum`.

```
$ ls -1 $(spack location -i openmpi@5.0.0)/lib | grep libmpi.so.
libmpi.so.40
libmpi.so.40.40.0
```