### PR TITLE
Small changes for Beatnik 1.0 release

### DIFF
--- a/var/spack/repos/builtin/packages/beatnik/package.py
+++ b/var/spack/repos/builtin/packages/beatnik/package.py
@@ -14,7 +14,6 @@ class Beatnik(CMakePackage, CudaPackage, ROCmPackage):
 
     maintainers("patrickb314", "JStewart28")
 
-    # Add proper versions and checksums here.
     version("1.0", commit="ae31ef9cb44678d5ace77994b45b0778defa3d2f")
     version("develop", branch="develop")
     version("main", branch="main")

--- a/var/spack/repos/builtin/packages/beatnik/package.py
+++ b/var/spack/repos/builtin/packages/beatnik/package.py
@@ -55,7 +55,7 @@ class Beatnik(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("mpich ~rocm", when="+rocm")
     conflicts("openmpi ~cuda", when="+cuda")
     conflicts("^intel-mpi")  # Heffte won't build with intel MPI because of needed C++ MPI support
-    conflicts("^spectrum-mpi", when="^cuda@11.3:") # cuda-aware spectrum is broken with cuda 11.3:
+    conflicts("^spectrum-mpi", when="^cuda@11.3:")  # cuda-aware spectrum is broken with cuda 11.3:
 
     # Propagate CUDA and AMD GPU targets to cabana
     for cuda_arch in CudaPackage.cuda_arch_values:

--- a/var/spack/repos/builtin/packages/beatnik/package.py
+++ b/var/spack/repos/builtin/packages/beatnik/package.py
@@ -55,6 +55,7 @@ class Beatnik(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("mpich ~rocm", when="+rocm")
     conflicts("openmpi ~cuda", when="+cuda")
     conflicts("^intel-mpi")  # Heffte won't build with intel MPI because of needed C++ MPI support
+    conflicts("^spectrum-mpi", when="^cuda@11.3:") # cuda-aware spectrum is broken with cuda 11.3:
 
     # Propagate CUDA and AMD GPU targets to cabana
     for cuda_arch in CudaPackage.cuda_arch_values:

--- a/var/spack/repos/builtin/packages/beatnik/package.py
+++ b/var/spack/repos/builtin/packages/beatnik/package.py
@@ -14,8 +14,8 @@ class Beatnik(CMakePackage, CudaPackage, ROCmPackage):
 
     maintainers("patrickb314", "JStewart28")
 
-    # Add proper versions and checksums here. Will add 1.0 when a proper SHA is available
-    # version("1.0", sha256="XXX")
+    # Add proper versions and checksums here.
+    version("1.0", commit="ae31ef9cb44678d5ace77994b45b0778defa3d2f")
     version("develop", branch="develop")
     version("main", branch="main")
 

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -111,7 +111,7 @@ class Silo(AutotoolsPackage):
             if "+hdf5" in spec:
                 if spec["hdf5"].satisfies("~shared"):
                     flags.append("-ldl")
-            flags.append(spec["readline"].libs.search_flags)
+            # flags.append(spec["readline"].libs.search_flags)
 
         if "+pic" in spec:
             if name == "cflags":

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -111,7 +111,6 @@ class Silo(AutotoolsPackage):
             if "+hdf5" in spec:
                 if spec["hdf5"].satisfies("~shared"):
                     flags.append("-ldl")
-            # flags.append(spec["readline"].libs.search_flags)
 
         if "+pic" in spec:
             if name == "cflags":


### PR DESCRIPTION
Minor changes to beatnik spack specification for builing on CORAL systems with Spectrum MPI and to add a commit hash for the new 1.0 release. Also a minor change to silo removing an unneeded library search path addition.