### PR TITLE
superlu-dist:  -std=c99 prevents usage of putenv()

### DIFF
--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -134,8 +134,6 @@ class SuperluDist(CMakePackage, CudaPackage, ROCmPackage):
         flags = list(flags)
         if name == "cxxflags":
             flags.append(self.compiler.cxx11_flag)
-        if name == "cflags" and "%pgi" not in self.spec:
-            flags.append("-std=c99")
         if (
             name == "cflags"
             and (self.spec.satisfies("%xl") or self.spec.satisfies("%xl_r"))


### PR DESCRIPTION
cc: @xiaoyeli