### PR TITLE
Fix an issue with using the environment variable `MACHTYPE` which is not always defined

### DIFF
--- a/var/spack/repos/builtin/packages/butterflypack/package.py
+++ b/var/spack/repos/builtin/packages/butterflypack/package.py
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import *
 from platform import machine
+
+from spack.package import *
 
 
 class Butterflypack(CMakePackage):

--- a/var/spack/repos/builtin/packages/butterflypack/package.py
+++ b/var/spack/repos/builtin/packages/butterflypack/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
+from platform import machine
 
 
 class Butterflypack(CMakePackage):
@@ -74,7 +75,7 @@ class Butterflypack(CMakePackage):
         args.append("-Denable_openmp=%s" % ("ON" if "+openmp" in spec else "OFF"))
         if "%cce" in spec:
             # Assume the proper Cray CCE module (cce) is loaded:
-            craylibs_path = env["CRAYLIBS_" + env["MACHTYPE"].capitalize()]
+            craylibs_path = env["CRAYLIBS_" + machine().upper()]
             env.setdefault("LDFLAGS", "")
             env["LDFLAGS"] += " -Wl,-rpath," + craylibs_path
 

--- a/var/spack/repos/builtin/packages/strumpack/package.py
+++ b/var/spack/repos/builtin/packages/strumpack/package.py
@@ -5,6 +5,7 @@
 
 from spack.package import *
 from spack.util.environment import set_env
+from platform import machine
 
 
 class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
@@ -172,7 +173,7 @@ class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
 
         if "%cce" in spec:
             # Assume the proper Cray CCE module (cce) is loaded:
-            craylibs_path = env["CRAYLIBS_" + env["MACHTYPE"].capitalize()]
+            craylibs_path = env["CRAYLIBS_" + machine().upper()]
             env.setdefault("LDFLAGS", "")
             env["LDFLAGS"] += " -Wl,-rpath," + craylibs_path
 

--- a/var/spack/repos/builtin/packages/strumpack/package.py
+++ b/var/spack/repos/builtin/packages/strumpack/package.py
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from platform import machine
+
 from spack.package import *
 from spack.util.environment import set_env
-from platform import machine
 
 
 class Strumpack(CMakePackage, CudaPackage, ROCmPackage):


### PR DESCRIPTION
The issue was reported here: https://github.com/spack/spack/pull/36154#issuecomment-1781854894.
