### PR TITLE
hipsycl: restrict compatibility with llvm for v0.8.0

### DIFF
--- a/var/spack/repos/builtin/packages/hipsycl/package.py
+++ b/var/spack/repos/builtin/packages/hipsycl/package.py
@@ -41,7 +41,7 @@ class Hipsycl(CMakePackage):
     depends_on("llvm@9: +clang", when="+cuda")
     # hipSYCL 0.8.0 supported only LLVM 8-10:
     # (https://github.com/AdaptiveCpp/AdaptiveCpp/blob/v0.8.0/CMakeLists.txt#L29-L37)
-    depends_on("llvm@8:10", when="@=0.8.0")
+    depends_on("llvm@8:10", when="@0.8.0")
     # https://github.com/OpenSYCL/OpenSYCL/pull/918 was introduced after 0.9.4
     conflicts("^llvm@16:", when="@:0.9.4")
     # LLVM PTX backend requires cuda7:10.1 (https://tinyurl.com/v82k5qq)

--- a/var/spack/repos/builtin/packages/hipsycl/package.py
+++ b/var/spack/repos/builtin/packages/hipsycl/package.py
@@ -39,6 +39,9 @@ class Hipsycl(CMakePackage):
     depends_on("python@3:")
     depends_on("llvm@8: +clang", when="~cuda")
     depends_on("llvm@9: +clang", when="+cuda")
+    # hipSYCL 0.8.0 supported only LLVM 8-10:
+    # (https://github.com/AdaptiveCpp/AdaptiveCpp/blob/v0.8.0/CMakeLists.txt#L29-L37)
+    depends_on("llvm@8:10", when="@=0.8.0")
     # https://github.com/OpenSYCL/OpenSYCL/pull/918 was introduced after 0.9.4
     conflicts("^llvm@16:", when="@:0.9.4")
     # LLVM PTX backend requires cuda7:10.1 (https://tinyurl.com/v82k5qq)


### PR DESCRIPTION
In an environment where I had llvm 15 ([released in 2022](https://github.com/llvm/llvm-project/releases/tag/llvmorg-15.0.0)), I was getting compilation errors because hipSYCL v0.8.0 ([released in 2019](https://github.com/AdaptiveCpp/AdaptiveCpp/releases/tag/v0.8.0)) couldn't find functions that had been removed in newer versions of LLVM.