### PR TITLE
hdf5: add v1.14.3, v1.10.11 for testing

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -74,6 +74,11 @@ class Hdf5(CMakePackage):
         preferred=True,
     )
     version(
+        "1.10.11",
+        sha256="341684c5c0976b8c7e6951735a400275a90693604464cac73e9f323c696fc79c",
+        preferred=True,
+    )
+    version(
         "1.10.10",
         sha256="a6877ab7bd5d769d2d68618fdb54beb50263dcc2a8c157fe7e2186925cdb02db",
         preferred=True,

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -41,6 +41,12 @@ class Hdf5(CMakePackage):
 
     # Odd versions are considered experimental releases
     # Even versions are maintenance versions
+    # Using tag for testing;  official release will have sha256 checksum
+    version(
+        "1.14.3",
+        tag="hdf5-1_14_3-rc1",
+        preferred=True
+    )
     version(
         "1.14.2",
         sha256="1c342e634008284a8c2794c8e7608e2eaf26d01d445fb3dfd7f33cb2fb51ac53",

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -42,11 +42,7 @@ class Hdf5(CMakePackage):
     # Odd versions are considered experimental releases
     # Even versions are maintenance versions
     # Using tag for testing;  official release will have sha256 checksum
-    version(
-        "1.14.3",
-        tag="hdf5-1_14_3-rc1",
-        preferred=True
-    )
+    version("1.14.3", tag="hdf5-1_14_3-rc1", preferred=True)
     version(
         "1.14.2",
         sha256="1c342e634008284a8c2794c8e7608e2eaf26d01d445fb3dfd7f33cb2fb51ac53",


### PR DESCRIPTION
Version 1.14.3 is added here with a tag to allow addressing any e4s testing failures before the final 1.14.3 release by next week.  The tag will be replaced in the pacakge.py file by the checksum for the final 1.14.3 release file.  Since CI testing is disabled for draft pull requests, I'll make it an official pull request with that change to come in a couple of days.

Version 1.10.11 was previously released.  