### PR TITLE
exago: fix exago missing on PYTHONPATH when `+python`

### DIFF
--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -62,14 +62,14 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     variant("raja", default=False, description="Enable/Disable RAJA")
     variant("python", default=True, when="@1.4:", description="Enable/Disable Python bindings")
     variant("logging", default=True, description="Enable/Disable spdlog based logging")
-    
+
     conflicts(
         "+python", when="+ipopt+rocm", msg="Python bindings require -fPIC with Ipopt for rocm."
     )
-    
+
     # Adds ExaGO's python wrapper to PYTHONPATH
     extends("python", when="+python")
-    
+ 
     # Solver options
     variant("hiop", default=False, description="Enable/Disable HiOp")
     variant("ipopt", default=False, description="Enable/Disable IPOPT")

--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -69,7 +69,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
 
     # Adds ExaGO's python wrapper to PYTHONPATH
     extends("python", when="+python")
- 
+
     # Solver options
     variant("hiop", default=False, description="Enable/Disable HiOp")
     variant("ipopt", default=False, description="Enable/Disable IPOPT")

--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -62,10 +62,14 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     variant("raja", default=False, description="Enable/Disable RAJA")
     variant("python", default=True, when="@1.4:", description="Enable/Disable Python bindings")
     variant("logging", default=True, description="Enable/Disable spdlog based logging")
+    
     conflicts(
         "+python", when="+ipopt+rocm", msg="Python bindings require -fPIC with Ipopt for rocm."
     )
-
+    
+    # Adds ExaGO's python wrapper to PYTHONPATH
+    extends("python", when="+python")
+    
     # Solver options
     variant("hiop", default=False, description="Enable/Disable HiOp")
     variant("ipopt", default=False, description="Enable/Disable IPOPT")


### PR DESCRIPTION
Thanks @haampie for this.

To be clear I have not tested this, but my expectation is that `PYTHONPATH` will be updated with ExaGO's python installation in `<exago_install>/lib/python{Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages`

cc @Jayapreethi and @paulrigor as this should fix `PYTHONPATH` for our spack container work