### PR TITLE
py-pip: allow pip to appear multiple times in the DAG

### DIFF
--- a/var/spack/repos/builtin/packages/dxt-explorer/package.py
+++ b/var/spack/repos/builtin/packages/dxt-explorer/package.py
@@ -26,5 +26,5 @@ class DxtExplorer(PythonPackage):
 
     depends_on("darshan-util", type=("run"))
 
-    depends_on("python@3.6:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
     depends_on("py-pandas", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -15,6 +15,8 @@ class PyPip(Package, PythonExtension):
     url = "https://files.pythonhosted.org/packages/py3/p/pip/pip-20.2-py3-none-any.whl"
     list_url = "https://pypi.org/simple/pip/"
 
+    tags = ["build-tools"]
+
     maintainers("adamjstewart", "pradyunsg")
 
     version(

--- a/var/spack/repos/builtin/packages/py-pyzmq/package.py
+++ b/var/spack/repos/builtin/packages/py-pyzmq/package.py
@@ -45,6 +45,9 @@ class PyPyzmq(PythonPackage):
 
     # pyproject.toml
     depends_on("py-setuptools", type="build")
+    # https://github.com/zeromq/pyzmq/issues/1278
+    # https://github.com/zeromq/pyzmq/pull/1317
+    depends_on("py-setuptools@:59", when="@17:18.0", type="build")
     depends_on("py-packaging", type="build")
 
     # setup.py


### PR DESCRIPTION
Extracted out of #40057 

Newer versions of numpy/scipy require pip 23.1+ for `--config-settings`, while many packages still require pip 23.0 and older for `--install-option`. This PR allows multiple versions of pip to appear in a single DAG as long as it is a build dep.

Also fix bugs uncovered in CI as a result.