### PR TITLE
PyTorch: build with external cpuinfo

### DIFF
--- a/var/spack/repos/builtin/packages/cpuinfo/package.py
+++ b/var/spack/repos/builtin/packages/cpuinfo/package.py
@@ -37,4 +37,5 @@ class Cpuinfo(CMakePackage):
             self.define("CPUINFO_BUILD_MOCK_TESTS", False),
             self.define("CPUINFO_BUILD_BENCHMARKS", False),
             self.define("CPUINFO_LIBRARY_TYPE", "shared"),
+            self.define("CPUINFO_LOG_LEVEL", "error"),
         ]

--- a/var/spack/repos/builtin/packages/cpuinfo/package.py
+++ b/var/spack/repos/builtin/packages/cpuinfo/package.py
@@ -17,7 +17,8 @@ class Cpuinfo(CMakePackage):
     license("BSD-2-Clause")
 
     version("main", branch="main")
-    version("2022-08-19", commit="8ec7bd91ad0470e61cf38f618cc1f270dede599c")  # py-torch@1.13
+    version("2023-01-13", commit="6481e8bef08f606ddd627e4d3be89f64d62e1b8a")  # py-torch@2.1:
+    version("2022-08-19", commit="8ec7bd91ad0470e61cf38f618cc1f270dede599c")  # py-torch@1.13:2.0
     version("2020-12-17", commit="5916273f79a21551890fd3d56fc5375a78d1598d")  # py-torch@1.8:1.12
     version("2020-06-11", commit="63b254577ed77a8004a9be6ac707f3dccc4e1fd9")  # py-torch@1.6:1.7
     version("2020-01-21", commit="0e6bde92b343c5fbcfe34ecd41abf9515d54b4a7")  # py-torch@1.5
@@ -30,9 +31,10 @@ class Cpuinfo(CMakePackage):
     depends_on("cmake@3.5:", type="build")
 
     def cmake_args(self):
+        # https://salsa.debian.org/deeplearning-team/cpuinfo/-/blob/master/debian/rules
         return [
-            self.define("BUILD_SHARED_LIBS", True),
             self.define("CPUINFO_BUILD_UNIT_TESTS", False),
             self.define("CPUINFO_BUILD_MOCK_TESTS", False),
             self.define("CPUINFO_BUILD_BENCHMARKS", False),
+            self.define("CPUINFO_LIBRARY_TYPE", "shared"),
         ]

--- a/var/spack/repos/builtin/packages/cpuinfo/package.py
+++ b/var/spack/repos/builtin/packages/cpuinfo/package.py
@@ -38,4 +38,5 @@ class Cpuinfo(CMakePackage):
             self.define("CPUINFO_BUILD_BENCHMARKS", False),
             self.define("CPUINFO_LIBRARY_TYPE", "shared"),
             self.define("CPUINFO_LOG_LEVEL", "error"),
+            self.define("CMAKE_SKIP_RPATH", True),
         ]

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -190,11 +190,10 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         depends_on("py-protobuf@:3", type=("build", "run"))
         depends_on("protobuf@:3")
     depends_on("eigen")
-    # https://github.com/pytorch/pytorch/issues/60329
-    # depends_on("cpuinfo@2023-01-13", when="@2.1:")
-    # depends_on("cpuinfo@2022-08-19", when="@1.13:2.0")
-    # depends_on("cpuinfo@2020-12-17", when="@1.8:1.12")
-    # depends_on("cpuinfo@2020-06-11", when="@1.6:1.7")
+    depends_on("cpuinfo@2023-01-13", when="@2.1:")
+    depends_on("cpuinfo@2022-08-19", when="@1.13:2.0")
+    depends_on("cpuinfo@2020-12-17", when="@1.8:1.12")
+    depends_on("cpuinfo@2020-06-11", when="@1.6:1.7")
     depends_on("sleef@3.5.1_2020-12-22", when="@1.8:")
     depends_on("sleef@3.4.0_2019-07-30", when="@1.6:1.7")
     depends_on("fp16@2020-05-14", when="@1.6:")
@@ -633,8 +632,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
             env.set("USE_SYSTEM_PYBIND11", "ON")
         if self.spec.satisfies("@1.6:"):
             # env.set("USE_SYSTEM_LIBS", "ON")
-            # https://github.com/pytorch/pytorch/issues/60329
-            # env.set("USE_SYSTEM_CPUINFO", "ON")
+            env.set("USE_SYSTEM_CPUINFO", "ON")
             env.set("USE_SYSTEM_SLEEF", "ON")
             env.set("USE_SYSTEM_GLOO", "ON")
             env.set("USE_SYSTEM_FP16", "ON")


### PR DESCRIPTION
Trying to get PyTorch to build entirely with Spack-installed deps.