### PR TITLE
PyTorch: build with external fp16

### DIFF
--- a/var/spack/repos/builtin/packages/fp16/package.py
+++ b/var/spack/repos/builtin/packages/fp16/package.py
@@ -14,7 +14,7 @@ class Fp16(CMakePackage):
     git = "https://github.com/Maratyszcza/FP16.git"
 
     version("master", branch="master")
-    version("2020-05-14", commit="4dfe081cf6bcd15db339cf2680b9281b8451eeb3")  # py-torch@1.5:1.9
+    version("2020-05-14", commit="4dfe081cf6bcd15db339cf2680b9281b8451eeb3")  # py-torch@1.5:
     version("2018-11-28", commit="febbb1c163726b5db24bed55cc9dc42529068997")  # py-torch@1.1:1.4
     version("2018-10-10", commit="34d4bf01bbf7376f2baa71b8fa148b18524d45cf")  # py-torch@1.0
     version("2018-02-25", commit="43d6d17df48ebf622587e7ed9472ea76573799b9")  # py-torch@:0.4
@@ -29,31 +29,11 @@ class Fp16(CMakePackage):
         destination="deps",
         placement="psimd",
     )
-    resource(
-        name="googletest",
-        url="https://github.com/google/googletest/archive/release-1.8.0.zip",
-        sha256="f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf",
-        destination="deps",
-        placement="googletest",
-    )
-    resource(
-        name="googlebenchmark",
-        url="https://github.com/google/benchmark/archive/v1.2.0.zip",
-        sha256="cc463b28cb3701a35c0855fbcefb75b29068443f1952b64dd5f4f669272e95ea",
-        destination="deps",
-        placement="googlebenchmark",
-    )
 
     def cmake_args(self):
         return [
             self.define("PSIMD_SOURCE_DIR", join_path(self.stage.source_path, "deps", "psimd")),
-            self.define(
-                "GOOGLETEST_SOURCE_DIR", join_path(self.stage.source_path, "deps", "googletest")
-            ),
-            self.define(
-                "GOOGLEBENCHMARK_SOURCE_DIR",
-                join_path(self.stage.source_path, "deps", "googlebenchmark"),
-            ),
-            self.define("FP16_BUILD_TESTS", self.run_tests),
-            self.define("FP16_BUILD_BENCHMARKS", self.run_tests),
+            self.define("FP16_BUILD_TESTS", False),
+            # https://github.com/Maratyszcza/FP16/issues/21
+            self.define("FP16_BUILD_BENCHMARKS", False),
         ]

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -198,8 +198,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     # depends_on("sleef@3.5.1_2020-12-22", when="@1.8:")
     # https://github.com/pytorch/pytorch/issues/60334
     # depends_on("sleef@3.4.0_2019-07-30", when="@1.6:1.7")
-    # https://github.com/Maratyszcza/FP16/issues/18
-    # depends_on("fp16@2020-05-14", when="@1.6:")
+    depends_on("fp16@2020-05-14", when="@1.6:")
     depends_on("pthreadpool@2021-04-13", when="@1.9:")
     depends_on("pthreadpool@2020-10-05", when="@1.8")
     depends_on("pthreadpool@2020-06-15", when="@1.6:1.7")
@@ -631,8 +630,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
             # env.set("USE_SYSTEM_CPUINFO", "ON")
             # https://github.com/pytorch/pytorch/issues/60270
             # env.set("USE_SYSTEM_GLOO", "ON")
-            # https://github.com/Maratyszcza/FP16/issues/18
-            # env.set("USE_SYSTEM_FP16", "ON")
+            env.set("USE_SYSTEM_FP16", "ON")
             env.set("USE_SYSTEM_PTHREADPOOL", "ON")
             env.set("USE_SYSTEM_PSIMD", "ON")
             env.set("USE_SYSTEM_FXDIV", "ON")


### PR DESCRIPTION
Trying to get PyTorch to build entirely with Spack-installed deps.