### PR TITLE
eccodes: add v2.32.0, v2.31.0

### DIFF
--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -72,16 +72,7 @@ class Eccodes(CMakePackage):
     )
     variant("png", default=False, description="Enable PNG support for decoding/encoding")
     variant(
-        "aec",
-        default=False,
-        when="@:2.24",
-        description="Enable Adaptive Entropy Coding for decoding/encoding",
-    )
-    variant(
-        "aec",
-        default=True,
-        when="@2.25:",
-        description="Enable Adaptive Entropy Coding for decoding/encoding",
+        "aec", default=True, description="Enable Adaptive Entropy Coding for decoding/encoding"
     )
     variant("pthreads", default=False, description="Enable POSIX threads")
     variant("openmp", default=False, description="Enable OpenMP threads")

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -48,6 +48,8 @@ class Eccodes(CMakePackage):
     maintainers("skosukhin")
 
     version("develop", branch="develop")
+    version("2.32.0", sha256="b57e8eeb0eba0c05d66fda5527c4ffa84b5ab35c46bcbc9a2227142973ccb8e6")
+    version("2.31.0", sha256="808ecd2c11fbf2c3f9fc7a36f8c2965b343f3151011b58a1d6e7cc2e6b3cac5d")
     version("2.25.0", sha256="8975131aac54d406e5457706fd4e6ba46a8cc9c7dd817a41f2aa64ce1193c04e")
     version("2.24.2", sha256="c60ad0fd89e11918ace0d84c01489f21222b11d6cad3ff7495856a0add610403")
     version("2.23.0", sha256="cbdc8532537e9682f1a93ddb03440416b66906a4cc25dec3cbd73940d194bf0c")
@@ -69,6 +71,12 @@ class Eccodes(CMakePackage):
         description="Specify JPEG2000 decoding/encoding backend",
     )
     variant("png", default=False, description="Enable PNG support for decoding/encoding")
+    variant(
+        "aec",
+        default=True,
+        when="@2.25.0:",
+        description="Enable Adaptive Entropy Coding for decoding/encoding",
+    )
     variant(
         "aec", default=False, description="Enable Adaptive Entropy Coding for decoding/encoding"
     )
@@ -114,6 +122,7 @@ class Eccodes(CMakePackage):
     depends_on("cmake@3.12:", when="@2.19:", type="build")
 
     depends_on("ecbuild", type="build", when="@develop")
+    depends_on("ecbuild@3.7:", type="build", when="@2.25:")
 
     conflicts("+openmp", when="+pthreads", msg="Cannot enable both POSIX threads and OMP")
 

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -73,12 +73,15 @@ class Eccodes(CMakePackage):
     variant("png", default=False, description="Enable PNG support for decoding/encoding")
     variant(
         "aec",
-        default=True,
-        when="@2.25.0:",
+        default=False,
+        when="@:2.24",
         description="Enable Adaptive Entropy Coding for decoding/encoding",
     )
     variant(
-        "aec", default=False, description="Enable Adaptive Entropy Coding for decoding/encoding"
+        "aec",
+        default=True,
+        when="@2.25:",
+        description="Enable Adaptive Entropy Coding for decoding/encoding",
     )
     variant("pthreads", default=False, description="Enable POSIX threads")
     variant("openmp", default=False, description="Enable OpenMP threads")


### PR DESCRIPTION
Add eccodes 2.32.0 and 2.31.0

Comment re aec variant default: https://github.com/ecmwf/eccodes/blob/develop/CMakeLists.txt#L133-L143
AEC (Adaptive Entropy Coding) provides the WMO GRIB CCSDS compression and decompression of data.
This is highly recommended from ecCodes >= 2.25.0
To force the build without it, use -DENABLE_AEC=OFF