### PR TITLE
python: always use a venv

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -865,7 +865,7 @@ There are several different ways to use Spack packages once you have
 installed them. As you've seen, spack packages are installed into long
 paths with hashes, and you need a way to get them into your path. The
 easiest way is to use :ref:`spack load <cmd-spack-load>`, which is
-described in the next section.
+described in this section.
 
 Some more advanced ways to use Spack packages include:
 
@@ -959,7 +959,87 @@ use ``spack find --loaded``.
 You can also use ``spack load --list`` to get the same output, but it
 does not have the full set of query options that ``spack find`` offers.
 
-We'll learn more about Spack's spec syntax in the next section.
+We'll learn more about Spack's spec syntax in :ref:`a later section <sec-specs>`.
+
+
+.. _extensions:
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Python packages and virtual environments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Spack can be used to install a large number of Python extensions, which are
+typically named like ``py-*``. They are installed and used like any other package.
+To give and example:
+
+.. code-block:: console
+
+   $ spack install py-numpy
+   $ spack load py-numpy
+   $ python3
+   >>> import numpy
+
+The ``spack load`` command sets the ``PATH`` variable so that the right Python
+executable is used, and makes sure that ``numpy`` and its dependencies can be
+located in the ``PYTHONPATH``.
+
+Spack is different from other Python package managers in that it installs
+every package into its *own* prefix. This is in contrast to ``pip``, which
+installs all packages into the same prefix, be it in a virtual environment
+or not.
+
+For many users, **virtual environments** are more convenient than repeated
+``spack load`` commands, particularly when working with multiple Python
+packages. Fortunately Spack supports environments itself, which together
+with a view are no different from Python virtual environments.
+
+The recommended way of working with Python extensions such as ``py-numpy``
+is through :ref:`Environments <environments>`. The following example creates
+a Spack environment with ``numpy`` in the current working directory. It also
+puts a filesystem view in ``./view``, which is a more traditional combined
+prefix for all packages in the environment.
+
+.. code-block:: console
+
+   $ spack env create --with-view view --dir .
+   $ spack -e . add py-numpy
+   $ spack -e . concretize
+   $ spack -e . install
+
+Once done, you can run ``python3`` directly from the view:
+
+.. code-block:: console
+
+   $ ./view/bin/python3
+   >>> import numpy
+
+There is no need to set ``PYTHONPATH`` or even activate the environment.
+
+If you're used to working with Python virtual environments, you can
+activate the Spack environment view as a virtual environment:
+
+.. code-block:: console
+
+   $ source ./view/bin/activate
+   $ python3
+   >>> import numpy
+
+Similarly, Spack itself provides the ``spack env activate`` command to activate
+an environment:
+
+.. code-block:: console
+
+   $ spack env activate .
+   $ python3
+   >>> import numpy
+
+In general, there should not be much of a difference. The only advantage
+of ``spack env activate`` is that it knows about more packages than just
+Python packages, and it may set additional runtime variables that are
+not covered by the virtual environment activation script.
+
+See :ref:`environments` for a more in-depth description of Spack
+environments and customizations to views.
 
 
 .. _sec-specs:
@@ -1704,165 +1784,6 @@ The ``spack verify`` command also accepts the ``-l,--local`` option to
 check only local packages (as opposed to those used transparently from
 ``upstream`` spack instances) and the ``-j,--json`` option to output
 machine-readable json data for any errors.
-
-
-.. _extensions:
-
----------------------------
-Extensions & Python support
----------------------------
-
-Spack's installation model assumes that each package will live in its
-own install prefix.  However, certain packages are typically installed
-*within* the directory hierarchy of other packages.  For example,
-`Python <https://www.python.org>`_ packages are typically installed in the
-``$prefix/lib/python-2.7/site-packages`` directory.
-
-In Spack, installation prefixes are immutable, so this type of installation
-is not directly supported. However, it is possible to create views that
-allow you to merge install prefixes of multiple packages into a single new prefix.
-Views are a convenient way to get a more traditional filesystem structure.
-Using *extensions*, you can ensure that Python packages always share the
-same prefix in the view as Python itself. Suppose you have
-Python installed like so:
-
-.. code-block:: console
-
-   $ spack find python
-   ==> 1 installed packages.
-   -- linux-debian7-x86_64 / gcc@4.4.7 --------------------------------
-   python@2.7.8
-
-.. _cmd-spack-extensions:
-
-^^^^^^^^^^^^^^^^^^^^
-``spack extensions``
-^^^^^^^^^^^^^^^^^^^^
-
-You can find extensions for your Python installation like this:
-
-.. code-block:: console
-
-   $ spack extensions python
-   ==> python@2.7.8%gcc@4.4.7 arch=linux-debian7-x86_64-703c7a96
-   ==> 36 extensions:
-   geos          py-ipython     py-pexpect    py-pyside            py-sip
-   py-basemap    py-libxml2     py-pil        py-pytz              py-six
-   py-biopython  py-mako        py-pmw        py-rpy2              py-sympy
-   py-cython     py-matplotlib  py-pychecker  py-scientificpython  py-virtualenv
-   py-dateutil   py-mpi4py      py-pygments   py-scikit-learn
-   py-epydoc     py-mx          py-pylint     py-scipy
-   py-gnuplot    py-nose        py-pyparsing  py-setuptools
-   py-h5py       py-numpy       py-pyqt       py-shiboken
-
-   ==> 12 installed:
-   -- linux-debian7-x86_64 / gcc@4.4.7 --------------------------------
-   py-dateutil@2.4.0    py-nose@1.3.4       py-pyside@1.2.2
-   py-dateutil@2.4.0    py-numpy@1.9.1      py-pytz@2014.10
-   py-ipython@2.3.1     py-pygments@2.0.1   py-setuptools@11.3.1
-   py-matplotlib@1.4.2  py-pyparsing@2.0.3  py-six@1.9.0
-
-The extensions are a subset of what's returned by ``spack list``, and
-they are packages like any other.  They are installed into their own
-prefixes, and you can see this with ``spack find --paths``:
-
-.. code-block:: console
-
-   $ spack find --paths py-numpy
-   ==> 1 installed packages.
-   -- linux-debian7-x86_64 / gcc@4.4.7 --------------------------------
-       py-numpy@1.9.1  ~/spack/opt/linux-debian7-x86_64/gcc@4.4.7/py-numpy@1.9.1-66733244
-
-However, even though this package is installed, you cannot use it
-directly when you run ``python``:
-
-.. code-block:: console
-
-   $ spack load python
-   $ python
-   Python 2.7.8 (default, Feb 17 2015, 01:35:25)
-   [GCC 4.4.7 20120313 (Red Hat 4.4.7-11)] on linux2
-   Type "help", "copyright", "credits" or "license" for more information.
-   >>> import numpy
-   Traceback (most recent call last):
-     File "<stdin>", line 1, in <module>
-   ImportError: No module named numpy
-   >>>
-
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Using Extensions in Environments
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The recommended way of working with extensions such as ``py-numpy``
-above is through :ref:`Environments <environments>`. For example,
-the following creates an environment in the current working directory
-with a filesystem view in the ``./view`` directory:
-
-.. code-block:: console
-
-   $ spack env create --with-view view --dir .
-   $ spack -e . add py-numpy
-   $ spack -e . concretize
-   $ spack -e . install
-
-We recommend environments for two reasons. Firstly, environments
-can be activated (requires :ref:`shell-support`):
-
-.. code-block:: console
-
-   $ spack env activate .
-
-which sets all the right environment variables such as ``PATH`` and
-``PYTHONPATH``. This ensures that
-
-.. code-block:: console
-
-   $ python
-   >>> import numpy
-
-works. Secondly, even without shell support, the view ensures
-that Python can locate its extensions:
-
-.. code-block:: console
-
-   $ ./view/bin/python
-   >>> import numpy
-
-See :ref:`environments` for a more in-depth description of Spack
-environments and customizations to views.
-
-^^^^^^^^^^^^^^^^^^^^
-Using ``spack load``
-^^^^^^^^^^^^^^^^^^^^
-
-A more traditional way of using Spack and extensions is ``spack load``
-(requires :ref:`shell-support`). This will add the extension to ``PYTHONPATH``
-in your current shell, and Python itself will be available in the ``PATH``:
-
-.. code-block:: console
-
-   $ spack load py-numpy
-   $ python
-   >>> import numpy
-
-The loaded packages can be checked using ``spack find --loaded``
-
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Loading Extensions via Modules
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Apart from ``spack env activate`` and ``spack load``, you can load numpy
-through your environment modules (using ``environment-modules`` or
-``lmod``). This will also add the extension to the ``PYTHONPATH`` in
-your current shell.
-
-.. code-block:: console
-
-   $ module load <name of numpy module>
-
-If you do not know the name of the specific numpy module you wish to
-load, you can use the ``spack module tcl|lmod loads`` command to get
-the name of the module from the Spack spec.
 
 -----------------------
 Filesystem requirements

--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -968,9 +968,9 @@ We'll learn more about Spack's spec syntax in :ref:`a later section <sec-specs>`
 Python packages and virtual environments
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Spack can be used to install a large number of Python extensions, which are
-typically named like ``py-*``. They are installed and used like any other package.
-To give and example:
+Spack can install a large number of Python packages. Their names are
+typically prefixed with ``py-``. Installing and using them is no
+different from any other package:
 
 .. code-block:: console
 

--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -1006,26 +1006,7 @@ prefix for all packages in the environment.
    $ spack -e . concretize
    $ spack -e . install
 
-Once done, you can run ``python3`` directly from the view:
-
-.. code-block:: console
-
-   $ ./view/bin/python3
-   >>> import numpy
-
-There is no need to set ``PYTHONPATH`` or even activate the environment.
-
-If you're used to working with Python virtual environments, you can
-activate the Spack environment view as a virtual environment:
-
-.. code-block:: console
-
-   $ source ./view/bin/activate
-   $ python3
-   >>> import numpy
-
-Similarly, Spack itself provides the ``spack env activate`` command to activate
-an environment:
+Now you can activate the environment and start using the packages:
 
 .. code-block:: console
 
@@ -1033,10 +1014,28 @@ an environment:
    $ python3
    >>> import numpy
 
-In general, there should not be much of a difference. The only advantage
-of ``spack env activate`` is that it knows about more packages than just
-Python packages, and it may set additional runtime variables that are
-not covered by the virtual environment activation script.
+The environment view is also a virtual environment, which is useful if you are
+sharing the environment with others who are unfamiliar with Spack. They can
+either use the Python executable directly:
+
+.. code-block:: console
+
+   $ ./view/bin/python3
+   >>> import numpy
+
+or use the activation script:
+
+.. code-block:: console
+
+   $ source ./view/bin/activate
+   $ python3
+   >>> import numpy
+
+In general, there should not be much difference between ``spack env activate``
+and using the virtual environment. The main advantage of ``spack env activate``
+is that it knows about more packages than just Python packages, and it may set
+additional runtime variables that are not covered by the virtual environment
+activation script.
 
 See :ref:`environments` for a more in-depth description of Spack
 environments and customizations to views.

--- a/lib/spack/docs/build_systems/pythonpackage.rst
+++ b/lib/spack/docs/build_systems/pythonpackage.rst
@@ -718,23 +718,45 @@ command-line tool, or C/C++/Fortran program with optional Python
 modules? The former should be prepended with ``py-``, while the
 latter should not.
 
-""""""""""""""""""""""
-extends vs. depends_on
-""""""""""""""""""""""
+""""""""""""""""""""""""""""""
+``extends`` vs. ``depends_on``
+""""""""""""""""""""""""""""""
 
-This is very similar to the naming dilemma above, with a slight twist.
 As mentioned in the :ref:`Packaging Guide <packaging_extensions>`,
 ``extends`` and ``depends_on`` are very similar, but ``extends`` ensures
 that the extension and extendee share the same prefix in views.
 This allows the user to import a Python module without
 having to add that module to ``PYTHONPATH``.
 
-When deciding between ``extends`` and ``depends_on``, the best rule of
-thumb is to check the installation prefix. If Python libraries are
-installed to ``<prefix>/lib/pythonX.Y/site-packages``, then you
-should use ``extends``. If Python libraries are installed elsewhere
-or the only files that get installed reside in ``<prefix>/bin``, then
-don't use ``extends``.
+Additionally, ``extends("python")`` adds a dependency on the package
+``python-venv``. This improves isolation from the system, whether
+it's during the build or at runtime: user and system site packages
+cannot accidentally be used by any package that ``extends("python")``.
+
+As a rule of thumb: if a package does not install any Python modules
+of its own, and merely puts a Python script in the ``bin`` directory,
+then there is no need for ``extends``. If the package installs modules
+in the ``site-packages`` directory, it requires ``extends``.
+
+"""""""""""""""""""""""""""""""""""""
+Executing ``python`` during the build
+"""""""""""""""""""""""""""""""""""""
+
+Whenever you need to execute a Python command or pass the path of the
+Python interpreter to the build system, it is best to use the global
+variable ``python`` directly. For example:
+
+.. code-block:: python
+
+    @run_before("install")
+    def recythonize(self):
+        python("setup.py", "clean")  # use the `python` global
+
+As mentioned in the previous section, ``extends("python")`` adds an
+automatic dependency on ``python-venv``, which is a virtual environment
+that guarantees build isolation. The ``python`` global always refers to
+the correct Python interpreter, whether the package uses ``extends("python")``
+or ``depends_on("python")``.
 
 ^^^^^^^^^^^^^^^^^^^^^
 Alternatives to Spack

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -59,12 +59,10 @@ def _try_import_from_store(
             python, *_ = candidate_spec.dependencies("python-venv")
         else:
             python, *_ = candidate_spec.dependencies("python")
-        module_paths = list(
-            {
-                os.path.join(candidate_spec.prefix, python.package.purelib),
-                os.path.join(candidate_spec.prefix, python.package.platlib),
-            }
-        )
+        module_paths = [
+            os.path.join(candidate_spec.prefix, python.package.purelib),
+            os.path.join(candidate_spec.prefix, python.package.platlib),
+        ]
         path_before = list(sys.path)
 
         # NOTE: try module_paths first and last, last allows an existing version in path

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -59,10 +59,10 @@ def _try_import_from_store(
             python, *_ = candidate_spec.dependencies("python-venv")
         else:
             python, *_ = candidate_spec.dependencies("python")
-        module_paths = {
+        module_paths = list({
             os.path.join(candidate_spec.prefix, python.package.purelib),
             os.path.join(candidate_spec.prefix, python.package.platlib),
-        }
+        })
         path_before = list(sys.path)
 
         # NOTE: try module_paths first and last, last allows an existing version in path

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -54,11 +54,15 @@ def _try_import_from_store(
     installed_specs = spack.store.STORE.db.query(query_spec, installed=True)
 
     for candidate_spec in installed_specs:
-        pkg = candidate_spec["python"].package
-        module_paths = [
-            os.path.join(candidate_spec.prefix, pkg.purelib),
-            os.path.join(candidate_spec.prefix, pkg.platlib),
-        ]
+        # previously bootstrapped specs may not have a python-venv dependency.
+        if candidate_spec.dependencies("python-venv"):
+            python, *_ = candidate_spec.dependencies("python-venv")
+        else:
+            python, *_ = candidate_spec.dependencies("python")
+        module_paths = {
+            os.path.join(candidate_spec.prefix, python.package.purelib),
+            os.path.join(candidate_spec.prefix, python.package.platlib),
+        }
         path_before = list(sys.path)
 
         # NOTE: try module_paths first and last, last allows an existing version in path

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -59,10 +59,12 @@ def _try_import_from_store(
             python, *_ = candidate_spec.dependencies("python-venv")
         else:
             python, *_ = candidate_spec.dependencies("python")
-        module_paths = list({
-            os.path.join(candidate_spec.prefix, python.package.purelib),
-            os.path.join(candidate_spec.prefix, python.package.platlib),
-        })
+        module_paths = list(
+            {
+                os.path.join(candidate_spec.prefix, python.package.purelib),
+                os.path.join(candidate_spec.prefix, python.package.platlib),
+            }
+        )
         path_before = list(sys.path)
 
         # NOTE: try module_paths first and last, last allows an existing version in path

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -41,7 +41,12 @@ def _maybe_set_python_hints(pkg: spack.package_base.PackageBase, args: List[str]
     ``find_python_hints`` for context."""
     if not getattr(pkg, "find_python_hints", False):
         return
-    pythons = pkg.spec.dependencies("python", dt.BUILD | dt.LINK)
+    spec = pkg.spec
+    # If this package depends on python-venv, we use its Python executable: it should report the
+    # correct install layout, even if the underlying Python is external. The external Python would
+    # give a layout that applies to system installations, which is not what we want.
+    deptype = dt.BUILD | dt.LINK
+    pythons = spec.dependencies("python-venv", deptype) or spec.dependencies("python", deptype)
     if len(pythons) != 1:
         return
     try:

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -371,8 +371,9 @@ class PythonPackage(PythonExtension):
 
         # Headers should only be in include or platlib, but no harm in checking purelib too
         include = self.prefix.join(self.spec["python"].package.include).join(name)
-        platlib = self.prefix.join(self.spec["python"].package.platlib).join(name)
-        purelib = self.prefix.join(self.spec["python"].package.purelib).join(name)
+        python, *_ = self.spec.dependencies("python-venv") or self.spec.dependencies("python")
+        platlib = self.prefix.join(python.package.platlib).join(name)
+        purelib = self.prefix.join(python.package.purelib).join(name)
 
         headers_list = map(fs.find_all_headers, [include, platlib, purelib])
         headers = functools.reduce(operator.add, headers_list)
@@ -391,8 +392,9 @@ class PythonPackage(PythonExtension):
         name = self.spec.name[3:]
 
         # Libraries should only be in platlib, but no harm in checking purelib too
-        platlib = self.prefix.join(self.spec["python"].package.platlib).join(name)
-        purelib = self.prefix.join(self.spec["python"].package.purelib).join(name)
+        python, *_ = self.spec.dependencies("python-venv") or self.spec.dependencies("python")
+        platlib = self.prefix.join(python.package.platlib).join(name)
+        purelib = self.prefix.join(python.package.purelib).join(name)
 
         find_all_libraries = functools.partial(fs.find_all_libraries, recursive=True)
         libs_list = map(find_all_libraries, [platlib, purelib])

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -680,7 +680,7 @@ def extends(spec, when=None, type=("build", "run"), patches=None):
 
         # When extending python, also add a dependency on python-venv. This is done so that
         # Spack environment views are Python virtual environments.
-        if spec_obj.name == "python":
+        if spec_obj.name == "python" and not pkg.name == "python-venv":
             _depends_on(pkg, "python-venv", when=when, type=("build", "run"))
 
         # TODO: the values of the extendees dictionary are not used. Remove in next refactor.

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -662,6 +662,7 @@ def _execute_redistribute(
 @directive(("extendees", "dependencies"))
 def extends(spec, when=None, type=("build", "run"), patches=None):
     """Same as depends_on, but also adds this package to the extendee list.
+    In case of Python, also adds a dependency on python-venv.
 
     keyword arguments can be passed to extends() so that extension
     packages can pass parameters to the extendee's extension
@@ -676,6 +677,11 @@ def extends(spec, when=None, type=("build", "run"), patches=None):
 
         _depends_on(pkg, spec, when=when, type=type, patches=patches)
         spec_obj = spack.spec.Spec(spec)
+
+        # When extending python, also add a dependency on python-venv. This is done so that
+        # Spack environment views are Python virtual environments.
+        if spec_obj.name == "python":
+            _depends_on(pkg, "python-venv", when=when, type=("build", "run"))
 
         # TODO: the values of the extendees dictionary are not used. Remove in next refactor.
         pkg.extendees[spec_obj.name] = (spec_obj, None)

--- a/lib/spack/spack/hooks/windows_runtime_linkage.py
+++ b/lib/spack/spack/hooks/windows_runtime_linkage.py
@@ -1,0 +1,8 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+def post_install(spec, explicit=None):
+    spec.package.windows_establish_runtime_linkage()

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1698,10 +1698,6 @@ class PackageInstaller:
             spack.package_base.PackageBase._verbose = spack.build_environment.start_build_process(
                 pkg, build_process, install_args
             )
-            # Currently this is how RPATH-like behavior is achieved on Windows, after install
-            # establish runtime linkage via Windows Runtime link object
-            # Note: this is a no-op on non Windows platforms
-            pkg.windows_establish_runtime_linkage()
             # Note: PARENT of the build process adds the new package to
             # the database, so that we don't need to re-read from file.
             spack.store.STORE.db.add(pkg.spec, spack.store.STORE.layout, explicit=explicit)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1030,16 +1030,13 @@ class _EdgeMap(collections.abc.Mapping):
         self.edges.clear()
 
 
-def _command_default_handler(descriptor, spec, cls):
+def _command_default_handler(spec: "Spec"):
     """Default handler when looking for the 'command' attribute.
 
     Tries to search for ``spec.name`` in the ``spec.home.bin`` directory.
 
     Parameters:
-        descriptor (ForwardQueryToPackage): descriptor that triggered the call
-        spec (Spec): spec that is being queried
-        cls (type(spec)): type of spec, to match the signature of the
-            descriptor ``__get__`` method
+        spec: spec that is being queried
 
     Returns:
         Executable: An executable of the command
@@ -1052,22 +1049,17 @@ def _command_default_handler(descriptor, spec, cls):
 
     if fs.is_exe(path):
         return spack.util.executable.Executable(path)
-    else:
-        msg = "Unable to locate {0} command in {1}"
-        raise RuntimeError(msg.format(spec.name, home.bin))
+    raise RuntimeError(f"Unable to locate {spec.name} command in {home.bin}")
 
 
-def _headers_default_handler(descriptor, spec, cls):
+def _headers_default_handler(spec: "Spec"):
     """Default handler when looking for the 'headers' attribute.
 
     Tries to search for ``*.h`` files recursively starting from
     ``spec.package.home.include``.
 
     Parameters:
-        descriptor (ForwardQueryToPackage): descriptor that triggered the call
-        spec (Spec): spec that is being queried
-        cls (type(spec)): type of spec, to match the signature of the
-            descriptor ``__get__`` method
+        spec: spec that is being queried
 
     Returns:
         HeaderList: The headers in ``prefix.include``
@@ -1080,12 +1072,10 @@ def _headers_default_handler(descriptor, spec, cls):
 
     if headers:
         return headers
-    else:
-        msg = "Unable to locate {0} headers in {1}"
-        raise spack.error.NoHeadersError(msg.format(spec.name, home))
+    raise spack.error.NoHeadersError(f"Unable to locate {spec.name} headers in {home}")
 
 
-def _libs_default_handler(descriptor, spec, cls):
+def _libs_default_handler(spec: "Spec"):
     """Default handler when looking for the 'libs' attribute.
 
     Tries to search for ``lib{spec.name}`` recursively starting from
@@ -1093,10 +1083,7 @@ def _libs_default_handler(descriptor, spec, cls):
     ``{spec.name}`` instead.
 
     Parameters:
-        descriptor (ForwardQueryToPackage): descriptor that triggered the call
-        spec (Spec): spec that is being queried
-        cls (type(spec)): type of spec, to match the signature of the
-            descriptor ``__get__`` method
+        spec: spec that is being queried
 
     Returns:
         LibraryList: The libraries found
@@ -1135,27 +1122,33 @@ def _libs_default_handler(descriptor, spec, cls):
         if libs:
             return libs
 
-    msg = "Unable to recursively locate {0} libraries in {1}"
-    raise spack.error.NoLibrariesError(msg.format(spec.name, home))
+    raise spack.error.NoLibrariesError(
+        f"Unable to recursively locate {spec.name} libraries in {home}"
+    )
 
 
 class ForwardQueryToPackage:
     """Descriptor used to forward queries from Spec to Package"""
 
-    def __init__(self, attribute_name, default_handler=None):
+    def __init__(
+        self,
+        attribute_name: str,
+        default_handler: Optional[Callable[["Spec"], Any]] = None,
+        _indirect: bool = False,
+    ) -> None:
         """Create a new descriptor.
 
         Parameters:
-            attribute_name (str): name of the attribute to be
-                searched for in the Package instance
-            default_handler (callable, optional): default function to be
-                called if the attribute was not found in the Package
-                instance
+            attribute_name: name of the attribute to be searched for in the Package instance
+            default_handler: default function to be called if the attribute was not found in the
+                Package instance
+            _indirect: temporarily added to redirect a query to another package.
         """
         self.attribute_name = attribute_name
         self.default = default_handler
+        self.indirect = _indirect
 
-    def __get__(self, instance, cls):
+    def __get__(self, instance: "SpecBuildInterface", cls):
         """Retrieves the property from Package using a well defined chain
         of responsibility.
 
@@ -1177,13 +1170,18 @@ class ForwardQueryToPackage:
         indicating a query failure, e.g. that library files were not found in a
         'libs' query.
         """
-        pkg = instance.package
+        # TODO: this indirection exist solely for `spec["python"].command` to actually return
+        # spec["python-venv"].command. It should be removed when `python` is a virtual.
+        if self.indirect and instance.indirect_spec:
+            pkg = instance.indirect_spec.package
+        else:
+            pkg = instance.wrapped_obj.package
         try:
             query = instance.last_query
         except AttributeError:
             # There has been no query yet: this means
             # a spec is trying to access its own attributes
-            _ = instance[instance.name]  # NOQA: ignore=F841
+            _ = instance.wrapped_obj[instance.wrapped_obj.name]  # NOQA: ignore=F841
             query = instance.last_query
 
         callbacks_chain = []
@@ -1195,7 +1193,8 @@ class ForwardQueryToPackage:
         callbacks_chain.append(lambda: getattr(pkg, self.attribute_name))
         # Final resort : default callback
         if self.default is not None:
-            callbacks_chain.append(lambda: self.default(self, instance, cls))
+            _default = self.default  # make mypy happy
+            callbacks_chain.append(lambda: _default(instance.wrapped_obj))
 
         # Trigger the callbacks in order, the first one producing a
         # value wins
@@ -1254,24 +1253,32 @@ QueryState = collections.namedtuple("QueryState", ["name", "extra_parameters", "
 class SpecBuildInterface(lang.ObjectWrapper):
     # home is available in the base Package so no default is needed
     home = ForwardQueryToPackage("home", default_handler=None)
-
-    command = ForwardQueryToPackage("command", default_handler=_command_default_handler)
-
     headers = ForwardQueryToPackage("headers", default_handler=_headers_default_handler)
-
     libs = ForwardQueryToPackage("libs", default_handler=_libs_default_handler)
+    command = ForwardQueryToPackage(
+        "command", default_handler=_command_default_handler, _indirect=True
+    )
 
-    def __init__(self, spec, name, query_parameters):
+    def __init__(self, spec: "Spec", name: str, query_parameters: List[str], _parent: "Spec"):
         super().__init__(spec)
         # Adding new attributes goes after super() call since the ObjectWrapper
         # resets __dict__ to behave like the passed object
         original_spec = getattr(spec, "wrapped_obj", spec)
         self.wrapped_obj = original_spec
-        self.token = original_spec, name, query_parameters
+        self.token = original_spec, name, query_parameters, _parent
         is_virtual = spack.repo.PATH.is_virtual(name)
         self.last_query = QueryState(
             name=name, extra_parameters=query_parameters, isvirtual=is_virtual
         )
+
+        # TODO: this ad-hoc logic makes `spec["python"].command` return
+        # `spec["python-venv"].command` and should be removed when `python` is a virtual.
+        self.indirect_spec = None
+        if spec.name == "python":
+            python_venvs = _parent.dependencies("python-venv")
+            if not python_venvs:
+                return
+            self.indirect_spec = python_venvs[0]
 
     def __reduce__(self):
         return SpecBuildInterface, self.token
@@ -4129,7 +4136,7 @@ class Spec:
             raise spack.error.SpecError("Spec version is not concrete: " + str(self))
         return self.versions[0]
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str):
         """Get a dependency from the spec by its name. This call implicitly
         sets a query state in the package being retrieved. The behavior of
         packages may be influenced by additional query parameters that are
@@ -4138,7 +4145,7 @@ class Spec:
         Note that if a virtual package is queried a copy of the Spec is
         returned while for non-virtual a reference is returned.
         """
-        query_parameters = name.split(":")
+        query_parameters: List[str] = name.split(":")
         if len(query_parameters) > 2:
             raise KeyError("key has more than one ':' symbol. At most one is admitted.")
 
@@ -4161,7 +4168,7 @@ class Spec:
         )
 
         try:
-            value = next(
+            child: Spec = next(
                 itertools.chain(
                     # Regular specs
                     (x for x in order() if x.name == name),
@@ -4178,9 +4185,9 @@ class Spec:
             raise KeyError(f"No spec with name {name} in {self}")
 
         if self._concrete:
-            return SpecBuildInterface(value, name, query_parameters)
+            return SpecBuildInterface(child, name, query_parameters, _parent=self)
 
-        return value
+        return child
 
     def __contains__(self, spec):
         """True if this spec or some dependency satisfies the spec.

--- a/lib/spack/spack/test/cmd/extensions.py
+++ b/lib/spack/spack/test/cmd/extensions.py
@@ -33,21 +33,23 @@ def test_extensions(mock_packages, python_database, config, capsys):
             packages = extensions("-s", "packages", "python")
             installed = extensions("-s", "installed", "python")
         assert "==> python@2.7.11" in output
-        assert "==> 2 extensions" in output
+        assert "==> 3 extensions" in output
         assert "py-extension1" in output
         assert "py-extension2" in output
+        assert "python-venv" in output
 
-        assert "==> 2 extensions" in packages
+        assert "==> 3 extensions" in packages
         assert "py-extension1" in packages
         assert "py-extension2" in packages
+        assert "python-venv" in packages
         assert "installed" not in packages
 
-        assert ("%s installed" % (ni if ni else "None")) in output
-        assert ("%s installed" % (ni if ni else "None")) in installed
+        assert f"{ni if ni else 'None'} installed" in output
+        assert f"{ni if ni else 'None'} installed" in installed
 
-    check_output(2)
+    check_output(3)
     ext2.package.do_uninstall(force=True)
-    check_output(1)
+    check_output(2)
 
 
 def test_extensions_no_arguments(mock_packages):

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -39,6 +39,20 @@ class Executable:
         """Add default argument(s) to the command."""
         self.exe.extend(args)
 
+    def with_default_args(self, *args):
+        """Same as add_default_arg, but returns a copy of the executable."""
+        new = self.copy()
+        new.add_default_arg(*args)
+        return new
+
+    def copy(self):
+        """Return a copy of this Executable."""
+        new = Executable(self.exe[0])
+        new.exe[:] = self.exe
+        new.default_env.update(self.default_env)
+        new.default_envmod.extend(self.default_envmod)
+        return new
+
     def add_default_env(self, key, value):
         """Set an environment variable when the command is run.
 

--- a/var/spack/repos/builtin.mock/packages/python-venv/package.py
+++ b/var/spack/repos/builtin.mock/packages/python-venv/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class PythonVenv(Package):
+    """A Spack managed Python virtual environment"""
+
+    homepage = "https://docs.python.org/3/library/venv.html"
+    has_code = False
+
+    version("1.0")
+
+    depends_on("python", type=("build", "run"))
+
+    def install(self, spec, prefix):
+        pass

--- a/var/spack/repos/builtin.mock/packages/python-venv/package.py
+++ b/var/spack/repos/builtin.mock/packages/python-venv/package.py
@@ -15,7 +15,7 @@ class PythonVenv(Package):
 
     version("1.0")
 
-    depends_on("python", type=("build", "run"))
+    extends("python")
 
     def install(self, spec, prefix):
         pass

--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -495,7 +495,7 @@ class Ascent(CMakePackage, CudaPackage):
             cfg.write("# Enable python module builds\n")
             cfg.write(cmake_cache_entry("ENABLE_PYTHON", "ON"))
             cfg.write("# python from spack \n")
-            cfg.write(cmake_cache_entry("PYTHON_EXECUTABLE", spec["python"].command.path))
+            cfg.write(cmake_cache_entry("PYTHON_EXECUTABLE", python.path))
             try:
                 cfg.write("# python module install dir\n")
                 cfg.write(cmake_cache_entry("PYTHON_MODULE_INSTALL_PREFIX", python_platlib))

--- a/var/spack/repos/builtin/packages/bohrium/package.py
+++ b/var/spack/repos/builtin/packages/bohrium/package.py
@@ -256,10 +256,6 @@ class Bohrium(CMakePackage, CudaPackage):
         cxx("-o", "test_cxxadd", file_cxxadd, *cxx_flags)
         test_cxxadd = Executable("./test_cxxadd")
 
-        # Build python test commandline
-        file_pyadd = join_path(os.path.dirname(self.module.__file__), "pyadd.py")
-        test_pyadd = Executable(spec["python"].command.path + " " + file_pyadd)
-
         # Run tests for each available stack
         for bh_stack in stacks:
             tty.info("Testing with bohrium stack '" + bh_stack + "'")
@@ -270,5 +266,6 @@ class Bohrium(CMakePackage, CudaPackage):
 
             # Python test (if +python)
             if "+python" in spec:
-                py_output = test_pyadd(output=str, env=test_env)
+                file_pyadd = join_path(os.path.dirname(self.module.__file__), "pyadd.py")
+                py_output = python(file_pyadd, output=str, env=test_env)
                 compare_output(py_output, "Success!\n")

--- a/var/spack/repos/builtin/packages/cantera/package.py
+++ b/var/spack/repos/builtin/packages/cantera/package.py
@@ -134,13 +134,9 @@ class Cantera(SConsPackage):
 
         # Python module
         if "+python" in spec:
-            args.extend(
-                ["python_package=full", "python_cmd={0}".format(spec["python"].command.path)]
-            )
+            args.extend(["python_package=full", "python_cmd={0}".format(python.path)])
             if spec["python"].satisfies("@3:"):
-                args.extend(
-                    ["python3_package=y", "python3_cmd={0}".format(spec["python"].command.path)]
-                )
+                args.extend(["python3_package=y", "python3_cmd={0}".format(python.path)])
             else:
                 args.append("python3_package=n")
         else:

--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -127,9 +127,7 @@ class ClingoBootstrap(Clingo):
         )
         python_runtime_env.unset("SPACK_ENV")
         python_runtime_env.unset("SPACK_PYTHON")
-        self.spec["python"].command(
-            spack.paths.spack_script, "solve", "--fresh", "hdf5", extra_env=python_runtime_env
-        )
+        python(spack.paths.spack_script, "solve", "--fresh", "hdf5", extra_env=python_runtime_env)
 
         # Clean the build dir.
         rmtree(self.build_directory, ignore_errors=True)

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack.compiler import UnsupportedCompilerFlag
 from spack.package import *
 
@@ -125,7 +123,4 @@ class Clingo(CMakePackage):
         return args
 
     def win_add_library_dependent(self):
-        if "+python" in self.spec:
-            return [os.path.join(self.prefix, self.spec["python"].package.platlib)]
-        else:
-            return []
+        return [python_platlib] if "+python" in self.spec else []

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -443,7 +443,7 @@ class Conduit(CMakePackage):
             cfg.write("# Enable python module builds\n")
             cfg.write(cmake_cache_entry("ENABLE_PYTHON", "ON"))
             cfg.write("# python from spack \n")
-            cfg.write(cmake_cache_entry("PYTHON_EXECUTABLE", spec["python"].command.path))
+            cfg.write(cmake_cache_entry("PYTHON_EXECUTABLE", python.path))
             try:
                 cfg.write("# python module install dir\n")
                 cfg.write(cmake_cache_entry("PYTHON_MODULE_INSTALL_PREFIX", python_platlib))

--- a/var/spack/repos/builtin/packages/dsqss/package.py
+++ b/var/spack/repos/builtin/packages/dsqss/package.py
@@ -58,7 +58,6 @@ class Dsqss(CMakePackage):
         copy(join_path(test01, "std.toml"), ".")
 
         # prepare
-        python = self.spec["python"].command
         opts = [self.spec.prefix.bin.dla_pre, "std.toml"]
         with test_part(self, "test_dla_pre", purpose="prepare dla"):
             python(*opts)

--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -156,7 +156,7 @@ class Fenics(CMakePackage):
     depends_on("py-sphinx@1.0.1:", when="+doc", type="build")
 
     def cmake_args(self):
-        args = [
+        return [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define("DOLFIN_SKIP_BUILD_TESTS", True),
             self.define_from_variant("DOLFIN_ENABLE_OPENMP", "openmp"),
@@ -179,11 +179,6 @@ class Fenics(CMakePackage):
             self.define_from_variant("DOLFIN_ENABLE_VTK", "vtk"),
             self.define_from_variant("DOLFIN_ENABLE_ZLIB", "zlib"),
         ]
-
-        if "+python" in self.spec:
-            args.append(self.define("PYTHON_EXECUTABLE", self.spec["python"].command.path))
-
-        return args
 
     # set environment for bulding python interface
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -710,9 +710,7 @@ class AutotoolsBuilder(AutotoolsBuilder):
             self.with_or_without("xerces", variant="xercesc", package="xerces-c"),
             self.with_or_without("zstd", package="zstd"),
             # Language bindings
-            self.with_or_without(
-                "python", variant="python", package="python-venv", attribute="command"
-            ),
+            self.with_or_without("python", package="python", attribute="command"),
             self.with_or_without("java", package="java"),
             self.with_or_without("jvm-lib", variant="mdb", package="java", attribute="libs"),
             self.with_or_without("jvm-lib-add-rpath", variant="mdb"),

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -710,7 +710,9 @@ class AutotoolsBuilder(AutotoolsBuilder):
             self.with_or_without("xerces", variant="xercesc", package="xerces-c"),
             self.with_or_without("zstd", package="zstd"),
             # Language bindings
-            self.with_or_without("python", package="python", attribute="command"),
+            self.with_or_without(
+                "python", variant="python", package="python-venv", attribute="command"
+            ),
             self.with_or_without("java", package="java"),
             self.with_or_without("jvm-lib", variant="mdb", package="java", attribute="libs"),
             self.with_or_without("jvm-lib-add-rpath", variant="mdb"),

--- a/var/spack/repos/builtin/packages/gurobi/package.py
+++ b/var/spack/repos/builtin/packages/gurobi/package.py
@@ -57,5 +57,4 @@ class Gurobi(Package):
     @run_after("install")
     def gurobipy(self):
         with working_dir("linux64"):
-            python = which("python")
             python("setup.py", "install", "--prefix={0}".format(self.prefix))

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -402,12 +402,8 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         )
         entries.append(cmake_cache_option("protobuf_MODULE_COMPATIBLE", True))
 
-        if spec.satisfies("^python") and "+pfe" in spec:
-            entries.append(
-                cmake_cache_path(
-                    "LBANN_PFE_PYTHON_EXECUTABLE", "{0}/python3".format(spec["python"].prefix.bin)
-                )
-            )
+        if spec.satisfies("+pfe ^python"):
+            entries.append(cmake_cache_path("LBANN_PFE_PYTHON_EXECUTABLE", python.path))
             entries.append(
                 cmake_cache_string("LBANN_PFE_PYTHONPATH", env["PYTHONPATH"])
             )  # do NOT need to sub ; for : because

--- a/var/spack/repos/builtin/packages/libcap-ng/package.py
+++ b/var/spack/repos/builtin/packages/libcap-ng/package.py
@@ -33,7 +33,7 @@ class LibcapNg(AutotoolsPackage):
 
     def setup_build_environment(self, env):
         if self.spec.satisfies("+python"):
-            env.set("PYTHON", self.spec["python"].command.path)
+            env.set("PYTHON", python.path)
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/mapserver/package.py
+++ b/var/spack/repos/builtin/packages/mapserver/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack.package import *
 
 
@@ -60,9 +58,7 @@ class Mapserver(CMakePackage):
         # prefix. This hack patches the CMakeLists.txt for the Python
         # bindings and hard-wires in the right destination. A bit ugly,
         # sorry, but I don't speak cmake.
-        pyversiondir = "python{0}".format(self.spec["python"].version.up_to(2))
-        sitepackages = os.path.join(self.spec.prefix.lib, pyversiondir, "site-packages")
-        filter_file(r"\${PYTHON_SITE_PACKAGES}", sitepackages, "mapscript/python/CMakeLists.txt")
+        filter_file(r"\${PYTHON_SITE_PACKAGES}", python_platlib, "mapscript/python/CMakeLists.txt")
 
     def cmake_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/omnitrace/package.py
+++ b/var/spack/repos/builtin/packages/omnitrace/package.py
@@ -141,7 +141,3 @@ class Omnitrace(CMakePackage):
             files = glob.glob(pattern)
             if files:
                 env.set("TAU_MAKEFILE", files[0])
-
-    def setup_run_environment(self, env):
-        if "+python" in self.spec:
-            env.prepend_path("PYTHONPATH", join_path(self.prefix.lib, "python", "site-packages"))

--- a/var/spack/repos/builtin/packages/open3d/package.py
+++ b/var/spack/repos/builtin/packages/open3d/package.py
@@ -119,7 +119,7 @@ class Open3d(CMakePackage, CudaPackage):
     def test(self):
         if "+python" in self.spec:
             self.run_test(
-                self.spec["python"].command.path,
+                python.path,
                 ["-c", "import open3d"],
                 purpose="checking import of open3d",
                 work_dir="spack-test",

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -1027,14 +1027,13 @@ class Opencv(CMakePackage, CudaPackage):
             )
 
         # Python
-        python_exe = spec["python"].command.path
         python_lib = spec["python"].libs[0]
         python_include_dir = spec["python"].headers.directories[0]
 
         if "+python3" in spec:
             args.extend(
                 [
-                    self.define("PYTHON3_EXECUTABLE", python_exe),
+                    self.define("PYTHON3_EXECUTABLE", python.path),
                     self.define("PYTHON3_LIBRARY", python_lib),
                     self.define("PYTHON3_INCLUDE_DIR", python_include_dir),
                     self.define("PYTHON2_EXECUTABLE", ""),

--- a/var/spack/repos/builtin/packages/openwsman/package.py
+++ b/var/spack/repos/builtin/packages/openwsman/package.py
@@ -31,13 +31,9 @@ class Openwsman(CMakePackage):
     def patch(self):
         """Change python install directory."""
         if self.spec.satisfies("+python"):
-            python_spec = self.spec["python"]
-            python_libdir = join_path(
-                self.spec.prefix.lib, "python" + str(python_spec.version.up_to(2)), "site-packages"
-            )
             filter_file(
                 "DESTINATION .*",
-                "DESTINATION {0} )".format(python_libdir),
+                "DESTINATION {0} )".format(python_platlib),
                 join_path("bindings", "python", "CMakeLists.txt"),
             )
 

--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -183,7 +183,7 @@ class Precice(CMakePackage):
             python_library = spec["python"].libs[0]
             python_include = spec["python"].headers.directories[0]
             numpy_include = join_path(
-                spec["py-numpy"].prefix, spec["python"].package.platlib, "numpy", "core", "include"
+                spec["py-numpy"].prefix, python_relative_platlib, "numpy", "core", "include"
             )
             cmake_args.extend(
                 [

--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -183,7 +183,7 @@ class Precice(CMakePackage):
             python_library = spec["python"].libs[0]
             python_include = spec["python"].headers.directories[0]
             numpy_include = join_path(
-                spec["py-numpy"].prefix, python_relative_platlib, "numpy", "core", "include"
+                spec["py-numpy"].package.module.python_platlib, "numpy", "core", "include"
             )
             cmake_args.extend(
                 [

--- a/var/spack/repos/builtin/packages/py-alphafold/package.py
+++ b/var/spack/repos/builtin/packages/py-alphafold/package.py
@@ -77,7 +77,7 @@ class PyAlphafold(PythonPackage, CudaPackage):
     @run_after("install")
     def install_scripts(self):
         mkdirp(self.prefix.bin)
-        shebang = "#!{0}\n".format(self.spec["python"].command)
+        shebang = f"#!{python.path}\n"
         for fname in glob.glob("run_alphafold*.py"):
             destfile = join_path(self.prefix.bin, fname)
             with open(fname, "r") as src:

--- a/var/spack/repos/builtin/packages/py-chainer/package.py
+++ b/var/spack/repos/builtin/packages/py-chainer/package.py
@@ -59,7 +59,7 @@ class PyChainer(PythonPackage):
 
         mnist_file = join_path(self.install_test_root.examples.chainermn.mnist, "train_mnist.py")
         mpirun = which(self.spec["mpi"].prefix.bin.mpirun)
-        opts = ["-n", "4", self.spec["python"].command.path, mnist_file, "-o", "."]
+        opts = ["-n", "4", python.path, mnist_file, "-o", "."]
         env["OMP_NUM_THREADS"] = "4"
 
         mpirun(*opts)

--- a/var/spack/repos/builtin/packages/py-eccodes/package.py
+++ b/var/spack/repos/builtin/packages/py-eccodes/package.py
@@ -43,5 +43,4 @@ class PyEccodes(PythonPackage):
 
     def test_selfcheck(self):
         """checking system setup"""
-        python = self.spec["python"].command
         python("-m", "eccodes", "selfcheck")

--- a/var/spack/repos/builtin/packages/py-gmxapi/package.py
+++ b/var/spack/repos/builtin/packages/py-gmxapi/package.py
@@ -49,5 +49,4 @@ class PyGmxapi(PythonPackage):
     def install_test(self):
         with working_dir("spack-test", create=True):
             # test include helper points to right location
-            python = self.spec["python"].command
             python("-m", "pytest", "-x", os.path.join(self.build_directory, "test"))

--- a/var/spack/repos/builtin/packages/py-gpaw/package.py
+++ b/var/spack/repos/builtin/packages/py-gpaw/package.py
@@ -59,7 +59,7 @@ class PyGpaw(PythonPackage):
 
         python_include = spec["python"].headers.directories[0]
         numpy_include = join_path(
-            spec["py-numpy"].prefix, python_relative_platlib, "numpy", "core", "include"
+            spec["py-numpy"].package.module.python_platlib, "numpy", "core", "include"
         )
 
         libs = blas.libs + lapack.libs + libxc.libs

--- a/var/spack/repos/builtin/packages/py-gpaw/package.py
+++ b/var/spack/repos/builtin/packages/py-gpaw/package.py
@@ -59,7 +59,7 @@ class PyGpaw(PythonPackage):
 
         python_include = spec["python"].headers.directories[0]
         numpy_include = join_path(
-            spec["py-numpy"].prefix, spec["python"].package.platlib, "numpy", "core", "include"
+            spec["py-numpy"].prefix, python_relative_platlib, "numpy", "core", "include"
         )
 
         libs = blas.libs + lapack.libs + libxc.libs

--- a/var/spack/repos/builtin/packages/py-installer/package.py
+++ b/var/spack/repos/builtin/packages/py-installer/package.py
@@ -36,6 +36,4 @@ class PyInstaller(Package, PythonExtension):
         python(*args)
 
     def setup_dependent_package(self, module, dependent_spec):
-        installer = dependent_spec["python-venv"].command
-        installer.add_default_arg("-m", "installer")
-        setattr(module, "installer", installer)
+        setattr(module, "installer", python.with_default_args("-m", "installer"))

--- a/var/spack/repos/builtin/packages/py-installer/package.py
+++ b/var/spack/repos/builtin/packages/py-installer/package.py
@@ -36,6 +36,6 @@ class PyInstaller(Package, PythonExtension):
         python(*args)
 
     def setup_dependent_package(self, module, dependent_spec):
-        installer = dependent_spec["python"].command
+        installer = dependent_spec["python-venv"].command
         installer.add_default_arg("-m", "installer")
         setattr(module, "installer", installer)

--- a/var/spack/repos/builtin/packages/py-ipykernel/package.py
+++ b/var/spack/repos/builtin/packages/py-ipykernel/package.py
@@ -89,4 +89,4 @@ class PyIpykernel(PythonPackage):
     @run_after("install")
     def install_data(self):
         """install the Jupyter kernel spec"""
-        self.spec["python"].command("-m", "ipykernel", "install", "--prefix=" + self.prefix)
+        python("-m", "ipykernel", "install", "--prefix=" + self.prefix)

--- a/var/spack/repos/builtin/packages/py-libensemble/package.py
+++ b/var/spack/repos/builtin/packages/py-libensemble/package.py
@@ -99,7 +99,6 @@ class PyLibensemble(PythonPackage):
         if not os.path.isfile(exe):
             raise SkipTest(f"{script} is missing")
 
-        python = self.spec["python"].command
         python(exe, "--comms", "local", "--nworkers", "2")
 
     def test_uniform_sampling(self):

--- a/var/spack/repos/builtin/packages/py-nanobind/package.py
+++ b/var/spack/repos/builtin/packages/py-nanobind/package.py
@@ -60,5 +60,5 @@ class PyNanobind(PythonPackage):
 
     @property
     def cmake_prefix_paths(self):
-        paths = [join_path(self.prefix, self.spec["python"].package.platlib, "nanobind", "cmake")]
+        paths = [join_path(python_platlib, "nanobind", "cmake")]
         return paths

--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -77,7 +77,9 @@ class PyPip(Package, PythonExtension):
             args.insert(0, os.path.join(whl, "pip"))
         python(*args)
 
-    def setup_dependent_package(self, module, dependent_spec):
-        pip = dependent_spec["python"].command
+    def setup_dependent_package(self, module, dependent_spec: Spec):
+        # Old installs do not depend on python-venv, fall back to underlying python.
+        pkg = "python-venv" if dependent_spec.dependencies("python-venv") else "python"
+        pip = dependent_spec[pkg].command
         pip.add_default_arg("-m", "pip")
         setattr(module, "pip", pip)

--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -78,8 +78,4 @@ class PyPip(Package, PythonExtension):
         python(*args)
 
     def setup_dependent_package(self, module, dependent_spec: Spec):
-        # Old installs do not depend on python-venv, fall back to underlying python.
-        pkg = "python-venv" if dependent_spec.dependencies("python-venv") else "python"
-        pip = dependent_spec[pkg].command
-        pip.add_default_arg("-m", "pip")
-        setattr(module, "pip", pip)
+        setattr(module, "pip", python.with_default_args("-m", "pip"))

--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -102,7 +102,6 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
 
         with working_dir("spack-test", create=True):
             # test include helper points to right location
-            python = self.spec["python"].command
             py_inc = python(
                 "-c", "import pybind11 as py; print(py.get_include())", output=str
             ).strip()

--- a/var/spack/repos/builtin/packages/py-pymol/package.py
+++ b/var/spack/repos/builtin/packages/py-pymol/package.py
@@ -58,7 +58,7 @@ class PyPymol(PythonPackage):
         script = join_path(python_platlib, "pymol", "__init__.py")
 
         shebang = "#!/bin/sh\n"
-        fdata = 'exec {0} {1} "$@"'.format(self.spec["python"].command, script)
+        fdata = f'exec {python.path} {script} "$@"'
         with open(fname, "w") as new:
             new.write(shebang + fdata)
         set_executable(fname)

--- a/var/spack/repos/builtin/packages/py-pyqt4/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt4/package.py
@@ -48,7 +48,7 @@ class PyPyqt4(SIPPackage):
             "--destdir",
             python_platlib,
             "--pyuic4-interpreter",
-            self.spec["python"].command.path,
+            python.path,
             "--sipdir",
             self.prefix.share.sip.PyQt4,
             "--stubsdir",

--- a/var/spack/repos/builtin/packages/py-pyspark/package.py
+++ b/var/spack/repos/builtin/packages/py-pyspark/package.py
@@ -25,5 +25,5 @@ class PyPyspark(PythonPackage):
     depends_on("py-py4j@0.10.9", when="@3.0.1:3.1.3", type=("build", "run"))
 
     def setup_run_environment(self, env):
-        env.set("PYSPARK_PYTHON", self.spec["python"].command.path)
-        env.set("PYSPARK_DRIVER_PYTHON", self.spec["python"].command.path)
+        env.set("PYSPARK_PYTHON", python.path)
+        env.set("PYSPARK_DRIVER_PYTHON", python.path)

--- a/var/spack/repos/builtin/packages/py-pythonsollya/package.py
+++ b/var/spack/repos/builtin/packages/py-pythonsollya/package.py
@@ -34,9 +34,4 @@ class PyPythonsollya(PythonPackage):
 
     @run_before("install")
     def patch(self):
-        filter_file(
-            "PYTHON ?= python2",
-            "PYTHON ?= " + self.spec["python"].command.path,
-            "GNUmakefile",
-            string=True,
-        )
+        filter_file("PYTHON ?= python2", f"PYTHON ?= {python.path}", "GNUmakefile", string=True)

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -406,7 +406,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         spec = self.spec
 
         # Please specify the location of python
-        env.set("PYTHON_BIN_PATH", spec["python"].command.path)
+        env.set("PYTHON_BIN_PATH", python.path)
 
         # Please input the desired Python library path to use
         env.set("PYTHON_LIB_PATH", python_platlib)

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -679,7 +679,5 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
 
     @property
     def cmake_prefix_paths(self):
-        cmake_prefix_paths = [
-            join_path(self.prefix, self.spec["python"].package.platlib, "torch", "share", "cmake")
-        ]
+        cmake_prefix_paths = [join_path(python_platlib, "torch", "share", "cmake")]
         return cmake_prefix_paths

--- a/var/spack/repos/builtin/packages/py-xdot/package.py
+++ b/var/spack/repos/builtin/packages/py-xdot/package.py
@@ -50,8 +50,7 @@ class PyXdot(PythonPackage):
             dst,
         )
         # regenerate the byte-compiled __init__.py
-        python3 = spec["python"].command
-        python3("-m", "compileall", dst)
+        python("-m", "compileall", dst)
 
     def setup_run_environment(self, env):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/python-venv/package.py
+++ b/var/spack/repos/builtin/packages/python-venv/package.py
@@ -96,6 +96,10 @@ class PythonVenv(Package):
     def setup_dependent_package(self, module, dependent_spec):
         """Called before python modules' install() methods."""
 
+        purelib, platlib = self.purelib, self.platlib
+
         module.python = self.command
-        module.python_platlib = join_path(dependent_spec.prefix, self.platlib)
-        module.python_purelib = join_path(dependent_spec.prefix, self.purelib)
+        module.python_platlib = join_path(dependent_spec.prefix, platlib)
+        module.python_purelib = join_path(dependent_spec.prefix, purelib)
+        module.python_relative_purelib = purelib
+        module.python_relative_platlib = platlib

--- a/var/spack/repos/builtin/packages/python-venv/package.py
+++ b/var/spack/repos/builtin/packages/python-venv/package.py
@@ -25,7 +25,7 @@ class PythonVenv(Package):
 
     def install(self, spec, prefix):
         # Create a virtual environment
-        spec["python"].command("-m", "venv", "--without-pip", prefix)
+        python("-m", "venv", "--without-pip", prefix)
 
     def add_files_to_view(self, view, merge_map: Dict[str, str], skip_if_exists=True):
         for src, dst in merge_map.items():

--- a/var/spack/repos/builtin/packages/python-venv/package.py
+++ b/var/spack/repos/builtin/packages/python-venv/package.py
@@ -95,11 +95,6 @@ class PythonVenv(Package):
 
     def setup_dependent_package(self, module, dependent_spec):
         """Called before python modules' install() methods."""
-
-        purelib, platlib = self.purelib, self.platlib
-
         module.python = self.command
-        module.python_platlib = join_path(dependent_spec.prefix, platlib)
-        module.python_purelib = join_path(dependent_spec.prefix, purelib)
-        module.python_relative_purelib = purelib
-        module.python_relative_platlib = platlib
+        module.python_platlib = join_path(dependent_spec.prefix, self.platlib)
+        module.python_purelib = join_path(dependent_spec.prefix, self.purelib)

--- a/var/spack/repos/builtin/packages/python-venv/package.py
+++ b/var/spack/repos/builtin/packages/python-venv/package.py
@@ -1,0 +1,87 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack.package import *
+
+
+class PythonVenv(Package):
+    """A Spack managed Python virtual environment"""
+
+    homepage = "https://docs.python.org/3/library/venv.html"
+    has_code = False
+
+    maintainers("haampie")
+
+    version("1.0")
+
+    depends_on("python", type=("build", "run"))
+
+    def install(self, spec, prefix):
+        # Create a virtual environment
+        spec["python"].command("-m", "venv", "--without-pip", prefix)
+
+        # Prefer `spack env activate` over `source activate` as it applies all required environment
+        # variable changes. The activate scripts are removed also because they contain an absolute
+        # path to python-venv's bin dir, which is incorrect in environment views.
+        bindir = self.bindir
+        for p in os.listdir(bindir):
+            if p.startswith("activate") or p.startswith("Activate"):
+                os.unlink(os.path.join(bindir, p))
+
+    @property
+    def bindir(self):
+        windows = self.spec.satisfies("platform=windows")
+        return join_path(self.prefix, "Scripts" if windows else "bin")
+
+    @property
+    def command(self):
+        """Returns a python Executable instance"""
+        return which("python3", path=self.bindir)
+
+    def _get_path(self, name) -> str:
+        return self.command(
+            "-Ec", f"import sysconfig; print(sysconfig.get_path('{name}'))", output=str
+        ).strip()
+
+    @property
+    def platlib(self) -> str:
+        """Directory for site-specific, platform-specific files."""
+        relative_platlib = os.path.relpath(self._get_path("platlib"), self.prefix)
+        assert not relative_platlib.startswith("..")
+        return relative_platlib
+
+    @property
+    def purelib(self) -> str:
+        """Directory for site-specific, non-platform-specific files."""
+        relative_purelib = os.path.relpath(self._get_path("purelib"), self.prefix)
+        assert not relative_purelib.startswith("..")
+        return relative_purelib
+
+    @property
+    def headers(self):
+        return HeaderList([])
+
+    @property
+    def libs(self):
+        return LibraryList([])
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        """Set PYTHONPATH to include the site-packages directory for the
+        extension and any other python extensions it depends on."""
+        # Packages may be installed in platform-specific or platform-independent site-packages
+        # directories
+        for directory in {self.platlib, self.purelib}:
+            path = os.path.join(dependent_spec.prefix, directory)
+            if os.path.isdir(path):
+                env.prepend_path("PYTHONPATH", path)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        """Called before python modules' install() methods."""
+
+        module.python = self.command
+        module.python_platlib = join_path(dependent_spec.prefix, self.platlib)
+        module.python_purelib = join_path(dependent_spec.prefix, self.purelib)

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1231,10 +1231,14 @@ print(json.dumps(config))
     def setup_dependent_package(self, module, dependent_spec):
         """Called before python modules' install() methods."""
 
+        purelib, platlib = self.purelib, self.platlib
+
         module.python = self.command
         module.python_include = join_path(dependent_spec.prefix, self.include)
-        module.python_platlib = join_path(dependent_spec.prefix, self.platlib)
-        module.python_purelib = join_path(dependent_spec.prefix, self.purelib)
+        module.python_platlib = join_path(dependent_spec.prefix, platlib)
+        module.python_purelib = join_path(dependent_spec.prefix, purelib)
+        module.python_relative_platlib = platlib
+        module.python_relative_purelib = purelib
 
     def test_hello_world(self):
         """run simple hello world program"""

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1230,15 +1230,10 @@ print(json.dumps(config))
 
     def setup_dependent_package(self, module, dependent_spec):
         """Called before python modules' install() methods."""
-
-        purelib, platlib = self.purelib, self.platlib
-
         module.python = self.command
         module.python_include = join_path(dependent_spec.prefix, self.include)
-        module.python_platlib = join_path(dependent_spec.prefix, platlib)
-        module.python_purelib = join_path(dependent_spec.prefix, purelib)
-        module.python_relative_platlib = platlib
-        module.python_relative_purelib = purelib
+        module.python_platlib = join_path(dependent_spec.prefix, self.platlib)
+        module.python_purelib = join_path(dependent_spec.prefix, self.purelib)
 
     def test_hello_world(self):
         """run simple hello world program"""

--- a/var/spack/repos/builtin/packages/qgis/package.py
+++ b/var/spack/repos/builtin/packages/qgis/package.py
@@ -188,9 +188,7 @@ class Qgis(CMakePackage):
     @run_before("cmake", when="^py-pyqt5")
     def fix_pyqt5_cmake(self):
         cmfile = FileFilter(join_path("cmake", "FindPyQt5.cmake"))
-        pyqtpath = join_path(
-            self.spec["py-pyqt5"].prefix, self.spec["python"].package.platlib, "PyQt5"
-        )
+        pyqtpath = join_path(self.spec["py-pyqt5"].prefix, python_relative_platlib, "PyQt5")
         cmfile.filter(
             'SET(PYQT5_MOD_DIR "${Python_SITEARCH}/PyQt5")',
             'SET(PYQT5_MOD_DIR "' + pyqtpath + '")',
@@ -210,7 +208,7 @@ class Qgis(CMakePackage):
             pyqtx = "PyQt6"
 
         sip_inc_dir = join_path(
-            self.spec["qscintilla"].prefix, self.spec["python"].package.platlib, pyqtx, "bindings"
+            self.spec["qscintilla"].prefix, python_relative_platlib, pyqtx, "bindings"
         )
         with open(join_path("python", "gui", "pyproject.toml.in"), "a") as tomlfile:
             tomlfile.write(f'\n[tool.sip.project]\nsip-include-dirs = ["{sip_inc_dir}"]\n')

--- a/var/spack/repos/builtin/packages/qgis/package.py
+++ b/var/spack/repos/builtin/packages/qgis/package.py
@@ -188,7 +188,7 @@ class Qgis(CMakePackage):
     @run_before("cmake", when="^py-pyqt5")
     def fix_pyqt5_cmake(self):
         cmfile = FileFilter(join_path("cmake", "FindPyQt5.cmake"))
-        pyqtpath = join_path(self.spec["py-pyqt5"].prefix, python_relative_platlib, "PyQt5")
+        pyqtpath = join_path(self.spec["py-pyqt5"].package.module.python_platlib, "PyQt5")
         cmfile.filter(
             'SET(PYQT5_MOD_DIR "${Python_SITEARCH}/PyQt5")',
             'SET(PYQT5_MOD_DIR "' + pyqtpath + '")',
@@ -208,7 +208,7 @@ class Qgis(CMakePackage):
             pyqtx = "PyQt6"
 
         sip_inc_dir = join_path(
-            self.spec["qscintilla"].prefix, python_relative_platlib, pyqtx, "bindings"
+            self.spec["qscintilla"].package.module.python_platlib, pyqtx, "bindings"
         )
         with open(join_path("python", "gui", "pyproject.toml.in"), "a") as tomlfile:
             tomlfile.write(f'\n[tool.sip.project]\nsip-include-dirs = ["{sip_inc_dir}"]\n')

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -101,7 +101,7 @@ class Qscintilla(QMakePackage):
         with working_dir(join_path(self.stage.source_path, "Python")):
             copy(ftoml, "pyproject.toml")
             sip_inc_dir = join_path(
-                self.spec[py_pyqtx].prefix, python_relative_platlib, pyqtx, "bindings"
+                self.spec[py_pyqtx].package.module.python_platlib, pyqtx, "bindings"
             )
 
             with open("pyproject.toml", "a") as tomlfile:

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -101,7 +101,10 @@ class Qscintilla(QMakePackage):
         with working_dir(join_path(self.stage.source_path, "Python")):
             copy(ftoml, "pyproject.toml")
             sip_inc_dir = join_path(
-                self.spec[py_pyqtx].prefix, self.spec["python"].package.platlib, pyqtx, "bindings"
+                self.spec[py_pyqtx].prefix,
+                self.spec["python-venv"].package.platlib,
+                pyqtx,
+                "bindings",
             )
 
             with open("pyproject.toml", "a") as tomlfile:

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -101,10 +101,7 @@ class Qscintilla(QMakePackage):
         with working_dir(join_path(self.stage.source_path, "Python")):
             copy(ftoml, "pyproject.toml")
             sip_inc_dir = join_path(
-                self.spec[py_pyqtx].prefix,
-                self.spec["python-venv"].package.platlib,
-                pyqtx,
-                "bindings",
+                self.spec[py_pyqtx].prefix, python_relative_platlib, pyqtx, "bindings"
             )
 
             with open("pyproject.toml", "a") as tomlfile:

--- a/var/spack/repos/builtin/packages/redland-bindings/package.py
+++ b/var/spack/repos/builtin/packages/redland-bindings/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack.package import *
 
 
@@ -27,11 +25,4 @@ class RedlandBindings(AutotoolsPackage):
     extends("python")
 
     def configure_args(self):
-        plib = self.spec["python"].prefix.lib
-        plib64 = self.spec["python"].prefix.lib64
-        mybase = self.prefix.lib
-        if os.path.isdir(plib64) and not os.path.isdir(plib):
-            mybase = self.prefix.lib64
-        pver = "python{0}".format(self.spec["python"].version.up_to(2))
-        myplib = join_path(mybase, pver, "site-packages")
-        return ["--with-python", "PYTHON_LIB={0}".format(myplib)]
+        return ["--with-python", f"PYTHON_LIB={python_platlib}"]

--- a/var/spack/repos/builtin/packages/z3/package.py
+++ b/var/spack/repos/builtin/packages/z3/package.py
@@ -53,13 +53,6 @@ class Z3(CMakePackage):
         ]
 
         if spec.satisfies("+python"):
-            args.append(
-                self.define(
-                    "CMAKE_INSTALL_PYTHON_PKG_DIR",
-                    join_path(
-                        prefix.lib, "python%s" % spec["python"].version.up_to(2), "site-packages"
-                    ),
-                )
-            )
+            args.append(self.define("CMAKE_INSTALL_PYTHON_PKG_DIR", python_platlib))
 
         return args

--- a/var/spack/repos/duplicates.test/packages/python-venv
+++ b/var/spack/repos/duplicates.test/packages/python-venv
@@ -1,0 +1,1 @@
+../../builtin.mock/packages/python-venv


### PR DESCRIPTION
_For context of this PR see the last bits of this message, this is the 3rd (?) attempt at fixing issues with Python build isolation and extension install directory layout._

This PR adds a layer of indirection to improve build isolation with and without external Python, as well as usability of environment views.

It adds `python-venv` as a dependency to all packages that `extends("python")`, which has the following advantages:

1. Build isolation: only `PYTHONPATH` is considered in builds, not user / system packages
2. Stable install layout: fixes the problem on Debian, RHEL and Fedora where external / system python produces `bin/local` subdirs in Spack install prefixes. Currently bootstrapping of `black`, `isort`, `mypy` and `flake8` is broken on Debian because of this.
3. Environment views are Python virtual environments (and if you add `py-pip` things like `pip list` work)

For a Python package `py-app`, the structure is as follows:

`py-app` depends both on `python-venv` and `python`, and `python-venv` depends on `python`.

On the file system it looks like this:

```
------------------------------------[python package]-------------------------------------

/opt/py-app/
├── bin
│   └── app                                         # shebang to python-venv python
└── lib
    └── python3.11
        └── site-packages
            └── app
                └── app.py

----------------------------------[python-venv package]----------------------------------

/opt/python-venv/ 
├── bin/
│   ├── activate                                    # venv activate script
│   └── python3.11 -> /opt/python/bin/python3.11    # symlink to underlying Python
└── pyvenv.cfg                                      # venv config file
  
-------------------------------------[python itself]-------------------------------------

/opt/python/
├── bin/
│   └── python3.11
├── include                                         # libraries and headers only in underlying python
├── lib/
│   ├── libpython3.11.so                            # libraries and headers only in underlying python
│   └── python3.11/
│       └── abc.py                                  # Python standard library
└── share
```
   

### Views with `python-venv` + `python`

Views work whether they're symlink, hardlink or copy type ([thanks to this PR](https://github.com/spack/spack/pull/42350)). They simply flatten the above directory structure:

```
/view/
├── bin
│   ├── activate                                    # copy of activate script with $VIRTUAL_ENV path rewritten
│   ├── app                                         # shebang rewritten to python in view
│   └── python3.11 -> /opt/python/bin/python3.11    # symlink to underlying Python
├── include
├── lib
│   ├── libpython3.11.so -> /opt/python/lib/libpython3.11.so
│   └── python3.11
│       ├── abc.py -> /opt/python/lib/python3.11/abc.py
│       └── site-packages
│           └── app
│               └── app.py -> /opt/py-app/lib/python3.11/site-packages/app/app.py
├── pyvenv.cfg -> /opt/python-venv/pyvenv.cfg
└── share
```

which constitutes a Python venv. In case Python is external, you conveniently still get a `bin/python3.11` pointing to system Python, which before this PR was not the case.


### `spec["python"].command`

This PR additionally makes `spec["python"].command` return `spec["python-venv"].command`. The rationale is that packages in repos we do not own do not pass the underlying python to the build system, which could still result in incorrectly computed install layouts.

Other attributes like `libs`, `headers` should be on `python` anyways and need no change. In the future we can think to make `python-venv` a "provider wrapper" for a virtual `python`, and `cpython` another provider for `python` (or something along those lines). That would ultimately just clean up internals.

### Spack environment views <=> Python venvs

After this PR, the following is a venv equivalent to `python3 -m venv ./view`:

```yaml
spack:
  specs: [py-pip]
  view: ./view
```

The next example is a venv equivalent to `python3 -m venv --without-pip ./view`:

```yaml
spack:
  specs: [python-venv]
  view: ./view
```

However, an environment that _just_ contains `python` and nothing else is _not_ a venv:

```yaml
spack:
  specs: [python]
  view: ./view
```

because there would be _no_ `./view/pyvenv.cfg` file. This should in general not be problematic, cause the view also does not contain any Python package that need to be located relative to the view.

### Bootstrap environment

Bootstrap logic is simplified with this PR. For convenience, Spack automatically re-concretizes and installs bootstrap environments that do not contain `python-venv`. That means `spack style` should just work for users on Debian, no need to `spack clean -b`.

### Possible pitfalls

1. **System Python + system Python packages**

   The `pyvenv.cfg` file contains the following line:

   ```toml
   include-system-site-packages = false
   ```

   which means that you cannot import system Python packages with if you marked `python` external.

   I think this is new behavior. If necessary, we could put a variant on `python-venv +system_packages` to indicate whether it should include system site packages or not. Such a variant would then also disable build isolation. This PR does *not*  introduce such a variant, I'm just stating this as a workaround if necessary.

### Context / Alternatives considered

This all started fixing the underlying problem of https://github.com/spack/spack/pull/31131 properly s.t. we could install setuptools from sources instead of wheel, so that it would be easier to add patches for its vendored distutils, to fix incorrect rpath flags (we currently apply those patches in `python` itself, but python 3.12 dropped distutils and recommends distutils from setuptools)

1. Previously (#40224) I tried a _temporary_ virtual environment for the build, that ensured pip could not execute hooks from unrelated user and system packages. This had two problems:
   1. shebangs of generated executables pointed to the venv and had to be patched
   2. the install layout in a venv differs from the install layout of underlying python (e.g. Debian system Python uses bin/local vs bin when run from underlying executable vs venv resp.) since the venv is no longer around, we computed incorrect PYTHONPATHs
2. Before that I've tried passing `-S` flags to pip to ensure it doesn't see hooks from user / system packages, but that doesn't really work because pip runs sub-processes that do not inherit these flags.


Closes #42445
Closes #40601
Closes #37632
Closes #35214
Closes #33923
Closes #32769
Closes #32662
Closes #42445 
Fixes #31939
Fixes #31131