### PR TITLE
tty: flush immediately

### DIFF
--- a/lib/spack/llnl/util/tty/__init__.py
+++ b/lib/spack/llnl/util/tty/__init__.py
@@ -211,6 +211,7 @@ def info(message, *args, **kwargs):
                 stream.write(line + "\n")
         else:
             stream.write(indent + _output_filter(str(arg)) + "\n")
+    stream.flush()
 
 
 def verbose(message, *args, **kwargs):


### PR DESCRIPTION
When using Spack in Github Actions it sometimes looks like Spack is not progressing.

Not sure if this should be conditional on `stream == sys.stdout` or not.