### PR TITLE
Backports v0.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.20.3 (2023-10-31)
+
+## Bugfixes
+
+- Fix a bug where `spack mirror set-url` would drop configured connection info (reverts #34210)
+- Fix a minor issue with package hash computation for Python 3.12 (#40328)
+
+
 # v0.20.2 (2023-10-03)
 
 ## Features in this release

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-__version__ = "0.20.2"
+__version__ = "0.20.3.dev0"
 spack_version = __version__
 
 

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-__version__ = "0.20.3.dev0"
+__version__ = "0.20.3"
 spack_version = __version__
 
 

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -911,19 +911,13 @@ def generate_gitlab_ci_yaml(
         # --check-index-only, then the override mirror needs to be added to
         # the configured mirrors when bindist.update() is run, or else we
         # won't fetch its index and include in our local cache.
-        spack.mirror.add(
-            spack.mirror.Mirror(remote_mirror_override, name="ci_pr_mirror"),
-            cfg.default_modify_scope(),
-        )
+        spack.mirror.add("ci_pr_mirror", remote_mirror_override, cfg.default_modify_scope())
 
     shared_pr_mirror = None
     if spack_pipeline_type == "spack_pull_request":
         stack_name = os.environ.get("SPACK_CI_STACK_NAME", "")
         shared_pr_mirror = url_util.join(SHARED_PR_MIRROR_URL, stack_name)
-        spack.mirror.add(
-            spack.mirror.Mirror(shared_pr_mirror, name="ci_shared_pr_mirror"),
-            cfg.default_modify_scope(),
-        )
+        spack.mirror.add("ci_shared_pr_mirror", shared_pr_mirror, cfg.default_modify_scope())
 
     pipeline_artifacts_dir = artifacts_root
     if not pipeline_artifacts_dir:

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -449,8 +449,9 @@ def ci_rebuild(args):
     # mirror now so it's used when we check for a hash match already
     # built for this spec.
     if pipeline_mirror_url:
-        mirror = spack.mirror.Mirror(pipeline_mirror_url, name=spack_ci.TEMP_STORAGE_MIRROR_NAME)
-        spack.mirror.add(mirror, cfg.default_modify_scope())
+        spack.mirror.add(
+            spack_ci.TEMP_STORAGE_MIRROR_NAME, pipeline_mirror_url, cfg.default_modify_scope()
+        )
         pipeline_mirrors.append(pipeline_mirror_url)
 
     # Check configured mirrors for a built spec with a matching hash
@@ -465,10 +466,7 @@ def ci_rebuild(args):
             # could be installed from either the override mirror or any other configured
             # mirror (e.g. remote_mirror_url which is defined in the environment or
             # pipeline_mirror_url), which is also what we want.
-            spack.mirror.add(
-                spack.mirror.Mirror(remote_mirror_override, name="mirror_override"),
-                cfg.default_modify_scope(),
-            )
+            spack.mirror.add("mirror_override", remote_mirror_override, cfg.default_modify_scope())
         pipeline_mirrors.append(remote_mirror_override)
 
     if spack_pipeline_type == "spack_pull_request":

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -145,26 +145,7 @@ def setup_parser(subparser):
 
 def mirror_add(args):
     """Add a mirror to Spack."""
-    if (
-        args.s3_access_key_id
-        or args.s3_access_key_secret
-        or args.s3_access_token
-        or args.s3_profile
-        or args.s3_endpoint_url
-    ):
-        connection = {"url": args.url}
-        if args.s3_access_key_id and args.s3_access_key_secret:
-            connection["access_pair"] = (args.s3_access_key_id, args.s3_access_key_secret)
-        if args.s3_access_token:
-            connection["access_token"] = args.s3_access_token
-        if args.s3_profile:
-            connection["profile"] = args.s3_profile
-        if args.s3_endpoint_url:
-            connection["endpoint_url"] = args.s3_endpoint_url
-        mirror = spack.mirror.Mirror(fetch_url=connection, push_url=connection, name=args.name)
-    else:
-        mirror = spack.mirror.Mirror(args.url, name=args.name)
-    spack.mirror.add(mirror, args.scope)
+    spack.mirror.add(args.name, args.url, args.scope, args)
 
 
 def mirror_remove(args):

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -1261,6 +1261,10 @@ class Unparser:
     def visit_TypeAlias(self, node):
         self.fill("type ")
         self.dispatch(node.name)
+        if node.type_params:
+            self.write("[")
+            interleave(lambda: self.write(", "), self.dispatch, node.type_params)
+            self.write("]")
         self.write(" = ")
         self.dispatch(node.value)
 


### PR DESCRIPTION
- [x] Revert #34210 (it drops existing `endpoint_url` when updating URL info)
- [x] #40328
