### PR TITLE
Fix interaction of spec literals that propagate variants with unify:false

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1484,7 +1484,7 @@ class Environment:
         for uspec, uspec_constraints in zip(self.user_specs, self.user_specs.specs_as_constraints):
             if uspec not in old_concretized_user_specs:
                 root_specs.append(uspec)
-                args.append((i, uspec_constraints, tests))
+                args.append((i, [str(x) for x in uspec_constraints], tests))
                 i += 1
 
         # Ensure we don't try to bootstrap clingo in parallel
@@ -2400,6 +2400,7 @@ def _concretize_from_constraints(spec_constraints, tests=False):
 
 def _concretize_task(packed_arguments) -> Tuple[int, Spec, float]:
     index, spec_constraints, tests = packed_arguments
+    spec_constraints = [Spec(x) for x in spec_constraints]
     with tty.SuppressOutput(msg_enabled=False):
         start = time.time()
         spec = _concretize_from_constraints(spec_constraints, tests)

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -693,6 +693,7 @@ def test_removing_spec_from_manifest_with_exact_duplicates(
 
 
 @pytest.mark.regression("35298")
+@pytest.mark.only_clingo("Propagation not supported in the original concretizer")
 def test_variant_propagation_with_unify_false(tmp_path, mock_packages):
     """Spack distributes concretizations to different processes, when unify:false is selected and
     the number of roots is 2 or more. When that happens, the specs to be concretized need to be

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -690,3 +690,28 @@ def test_removing_spec_from_manifest_with_exact_duplicates(
     assert "zlib" in manifest.read_text()
     with ev.Environment(tmp_path) as env:
         assert len(env.user_specs) == 1
+
+
+@pytest.mark.regression("35298")
+def test_variant_propagation_with_unify_false(tmp_path, mock_packages):
+    """Spack distributes concretizations to different processes, when unify:false is selected and
+    the number of roots is 2 or more. When that happens, the specs to be concretized need to be
+    properly reconstructed on the worker process, if variant propagation was requested.
+    """
+    manifest = tmp_path / "spack.yaml"
+    manifest.write_text(
+        """
+    spack:
+      specs:
+      - parent-foo ++foo
+      - c
+      concretizer:
+        unify: false
+    """
+    )
+    with ev.Environment(tmp_path) as env:
+        env.concretize()
+
+    root = env.matching_spec("parent-foo")
+    for node in root.traverse():
+        assert node.satisfies("+foo")

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -525,6 +525,31 @@ def specfile_for(default_mock_concretization):
             ],
             "zlib@git.foo/bar",
         ),
+        # Variant propagation
+        (
+            "zlib ++foo",
+            [
+                Token(TokenType.UNQUALIFIED_PACKAGE_NAME, "zlib"),
+                Token(TokenType.PROPAGATED_BOOL_VARIANT, "++foo"),
+            ],
+            "zlib++foo",
+        ),
+        (
+            "zlib ~~foo",
+            [
+                Token(TokenType.UNQUALIFIED_PACKAGE_NAME, "zlib"),
+                Token(TokenType.PROPAGATED_BOOL_VARIANT, "~~foo"),
+            ],
+            "zlib~~foo",
+        ),
+        (
+            "zlib foo==bar",
+            [
+                Token(TokenType.UNQUALIFIED_PACKAGE_NAME, "zlib"),
+                Token(TokenType.PROPAGATED_KEY_VALUE_PAIR, "foo==bar"),
+            ],
+            "zlib foo==bar",
+        ),
     ],
 )
 def test_parse_single_spec(spec_str, tokens, expected_roundtrip):

--- a/var/spack/repos/builtin.mock/packages/client-not-foo/package.py
+++ b/var/spack/repos/builtin.mock/packages/client-not-foo/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class ClientNotFoo(Package):
+    """This package has a variant "foo", which is False by default."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/c-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    variant("foo", default=False, description="")

--- a/var/spack/repos/builtin.mock/packages/parent-foo/package.py
+++ b/var/spack/repos/builtin.mock/packages/parent-foo/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class ParentFoo(Package):
+    """This package has a variant "foo", which is True by default, and depends on another
+    package which has the same variant defaulting to False.
+    """
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/c-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    variant("foo", default=True, description="")
+
+    depends_on("client-not-foo")


### PR DESCRIPTION
refers to https://github.com/spack/spack/pull/38512#discussion_r1348242986
fixes #35298

There is a bug when using a spec literal that propagates variants, in environments using `unify:false`. The bug is due to a few facts:
1. We use a pool of worker processes to speed-up concretization when `unify:false`
2. Each worker gets a list of `Spec` objects to know what to concretize
3. Propagation is not kept on a round-trip to/from pickle (which is what we use to pass info to a worker process)

The result is that the worker process concretizes the spec _without_ propagation information. To solve this, here, we pass a spec literal (a string), and reconstruct specs directly in the worker process.

