### PR TITLE
ci: bump tutorial image and toolchain

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -621,7 +621,7 @@ aws-isc-aarch64-build:
 
 tutorial-generate:
   extends: [ ".tutorial", ".generate-x86_64"]
-  image: ghcr.io/spack/tutorial-ubuntu-22.04:v2023-05-07
+  image: ghcr.io/spack/tutorial-ubuntu-22.04:v2023-10-30
 
 tutorial-build:
   extends: [ ".tutorial", ".build" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -18,26 +18,26 @@ spack:
         - hdf5+hl+mpi ^mpich
         - trilinos
         - trilinos +hdf5 ^hdf5+hl+mpi ^mpich
-        - gcc@12.1.0
+        - gcc@12
         - mpileaks
         - lmod
         - macsio@1.1+scr ^scr@2.0.0~fortran ^silo~fortran ^hdf5~fortran
-      - ['%gcc@11.3.0']
+      - ['%gcc@11']
   - gcc_old_packages:
-    - gmake%gcc@10.4.0
+    - gmake%gcc@10
   - clang_packages:
     - matrix:
       - [gmake, tcl ^gmake@4.3]
-      - ['%clang@14.0.0']
+      - ['%clang@14']
   - gcc_spack_built_packages:
     - matrix:
       - [netlib-scalapack]
       - [^mpich, ^openmpi]
       - [^openblas, ^netlib-lapack]
-      - ['%gcc@12.1.0']
+      - ['%gcc@12']
     - matrix:
       - [py-scipy ^openblas, armadillo ^openblas, netlib-lapack, openmpi, mpich, elpa ^mpich]
-      - ['%gcc@12.1.0']
+      - ['%gcc@12']
   specs:
   - $gcc_system_packages
   - $gcc_old_packages
@@ -48,7 +48,7 @@ spack:
     pipeline-gen:
     - build-job:
         image:
-          name: ghcr.io/spack/tutorial-ubuntu-22.04:v2023-05-07
+          name: ghcr.io/spack/tutorial-ubuntu-22.04:v2023-10-30
           entrypoint: ['']
   cdash:
     build-group: Spack Tutorial


### PR DESCRIPTION
Ubuntu 22.04 bumped GCC 10, 11 and 12 to latest minor versions.
