### PR TITLE
spec colors: hash in white instead of black

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -294,7 +294,7 @@ def ensure_single_spec_or_die(spec, matching_specs):
     format_string = "{name}{@version}{%compiler.name}{@compiler.version}{arch=architecture}"
     args = ["%s matches multiple packages." % spec, "Matching packages:"]
     args += [
-        colorize("  @K{%s} " % s.dag_hash(7)) + s.cformat(format_string) for s in matching_specs
+        colorize("  @w{%s} " % s.dag_hash(7)) + s.cformat(format_string) for s in matching_specs
     ]
     args += ["Use a more specific spec (e.g., prepend '/' to the hash)."]
     tty.die(*args)
@@ -305,7 +305,7 @@ def gray_hash(spec, length):
         # default to maximum hash length
         length = 32
     h = spec.dag_hash(length) if spec.concrete else "-" * length
-    return colorize("@K{%s}" % h)
+    return colorize("@w{%s}" % h)
 
 
 def display_specs_as_json(specs, deps=False):

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -192,7 +192,7 @@ def setup_env(env):
         if any(spec.dag_hash() == r.dag_hash() for r in roots):
             return color.colorize("@*{%s}" % fmt)
         elif spec in removed:
-            return color.colorize("@K{%s}" % fmt)
+            return color.colorize("@w{%s}" % fmt)
         else:
             return "%s" % fmt
 

--- a/lib/spack/spack/cmd/help.py
+++ b/lib/spack/spack/cmd/help.py
@@ -21,7 +21,7 @@ spec expression syntax:
   package [constraints] [^dependency [constraints] ...]
 
   package                           any package from 'spack list', or
-  @K{/hash}                             unique prefix or full hash of
+  @w{/hash}                             unique prefix or full hash of
                                     installed package
 
   constraints:
@@ -60,7 +60,7 @@ spec expression syntax:
 
     dependencies:
       ^dependency [constraints]     specify constraints on dependencies
-      ^@K{/hash}                        build with a specific installed
+      ^@w{/hash}                        build with a specific installed
                                     dependency
 
   examples:

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -100,7 +100,7 @@ def _process_result(result, show, required_format, kwargs):
         maxlen = max(len(s[2]) for s in result.criteria)
         color.cprint("@*{  Priority  Criterion %sInstalled  ToBuild}" % ((maxlen - 10) * " "))
 
-        fmt = "  @K{%%-8d}  %%-%ds%%9s  %%7s" % maxlen
+        fmt = "  @w{%%-8d}  %%-%ds%%9s  %%7s" % maxlen
         for i, (installed_cost, build_cost, name) in enumerate(result.criteria, 1):
             color.cprint(
                 fmt

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -131,7 +131,7 @@ ARCHITECTURE_COLOR = "@m"  #: color for highlighting architectures
 ENABLED_VARIANT_COLOR = "@B"  #: color for highlighting enabled variants
 DISABLED_VARIANT_COLOR = "r"  #: color for highlighting disabled varaints
 DEPENDENCY_COLOR = "@."  #: color for highlighting dependencies
-HASH_COLOR = "@K"  #: color for highlighting package hashes
+HASH_COLOR = "@w"  #: color for highlighting package hashes
 
 #: This map determines the coloring of specs when using color output.
 #: We make the fields different colors to enhance readability.
@@ -4597,7 +4597,7 @@ class Spec:
                     out += clr.colorize("@r{[-]}  ", color=color)
 
             if hashes:
-                out += clr.colorize("@K{%s}  ", color=color) % node.dag_hash(hashlen)
+                out += clr.colorize("@w{%s}  ", color=color) % node.dag_hash(hashlen)
 
             if show_types:
                 if cover == "nodes":


### PR DESCRIPTION
To me hashes `/abcdef` printed in "high intensity black" are hard to read.

Since "regular white" is more light gray than white, I feel like that is the better option.

Worst example of lack of contrast I've seen so far is in Gitlab CI:

![image](https://github.com/spack/spack/assets/194764/81d298df-a4b0-4a66-b21a-bb3cfcc4bd95)

but also in other terminals it's not always legible...

With this change it looks like this in Gitlab CI:

![image](https://github.com/spack/spack/assets/194764/967269ba-7b10-4440-928a-a6102eea70f5)

