### PR TITLE
spack checksum: fix error when initial filter yields empty list

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -893,9 +893,9 @@ def interactive_version_filter(
     """
     # Find length of longest string in the list for padding
     version_filter = initial_verion_filter or VersionList([":"])
+    max_len = max(len(str(v)) for v in url_dict) if url_dict else 0
     sorted_and_filtered = [v for v in url_dict if v.satisfies(version_filter)]
     sorted_and_filtered.sort(reverse=True)
-    max_len = max(len(str(v)) for v in sorted_and_filtered)
     orig_url_dict = url_dict  # only copy when using editor to modify
     print_header = True
     VERSION_COLOR = spack.spec.VERSION_COLOR
@@ -903,21 +903,20 @@ def interactive_version_filter(
         if print_header:
             has_filter = version_filter != VersionList([":"])
             header = []
-            if not sorted_and_filtered:
-                header.append("No versions selected")
-            elif len(sorted_and_filtered) == len(orig_url_dict):
+            if len(orig_url_dict) > 0 and len(sorted_and_filtered) == len(orig_url_dict):
                 header.append(
                     f"Selected {llnl.string.plural(len(sorted_and_filtered), 'version')}"
                 )
             else:
                 header.append(
-                    f"Selected {len(sorted_and_filtered)} of {len(orig_url_dict)} versions"
+                    f"Selected {len(sorted_and_filtered)} of "
+                    f"{llnl.string.plural(len(orig_url_dict), 'version')}"
                 )
             if sorted_and_filtered and known_versions:
                 num_new = sum(1 for v in sorted_and_filtered if v not in known_versions)
                 header.append(f"{llnl.string.plural(num_new, 'new version')}")
             if has_filter:
-                header.append(colorize(f"Filtered by {VERSION_COLOR}{version_filter}@."))
+                header.append(colorize(f"Filtered by {VERSION_COLOR}@@{version_filter}@."))
 
             version_with_url = [
                 colorize(


### PR DESCRIPTION
Fix an issue when the initial filtered list is empty

![image](https://github.com/spack/spack/assets/194764/9bd9c063-e5ca-410e-be15-4ab053807fec)

Maybe in a bright future the command prompt could be simplified to only show  "restart" / "quit" when all versions are filtered out.