### PR TITLE
LBANN explicit flag for shared builds

### DIFF
--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -147,10 +147,8 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     variant("unit_tests", default=False, description="Support for unit testing")
     variant("caliper", default=False, description="Support for instrumentation with caliper")
     variant(
-        "shared",
-        default=True,
-        sticky=True,
-        description="Enables the build of shared libraries")
+        "shared", default=True, sticky=True, description="Enables the build of shared libraries"
+    )
 
     # LBANN benefits from high performance linkers, but passing these in as command
     # line options forces the linker flags to unnecessarily propagate to all

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -146,6 +146,11 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     variant("asan", default=False, description="Build with support for address-sanitizer")
     variant("unit_tests", default=False, description="Support for unit testing")
     variant("caliper", default=False, description="Support for instrumentation with caliper")
+    variant(
+        "shared",
+        default=True,
+        sticky=True,
+        description="Enables the build of shared libraries")
 
     # LBANN benefits from high performance linkers, but passing these in as command
     # line options forces the linker flags to unnecessarily propagate to all
@@ -232,6 +237,8 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("dihydrogen@0.1", when="@0.101:0.101.99 +dihydrogen")
     depends_on("dihydrogen@:0.0,0.2:", when="@:0.90,0.102: +dihydrogen")
     conflicts("~dihydrogen", when="+distconv")
+
+    depends_on("hdf5+mpi", when="+distconv")
 
     for arch in CudaPackage.cuda_arch_values:
         depends_on("hydrogen cuda_arch=%s" % arch, when="+cuda cuda_arch=%s" % arch)
@@ -336,6 +343,11 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         return sys_type
 
     @property
+    def libs(self):
+        shared = True if "+shared" in self.spec else False
+        return find_libraries("liblbann", root=self.prefix, shared=shared, recursive=True)
+
+    @property
     def cache_name(self):
         hostname = socket.gethostname()
         # Get a hostname that has no node identifier
@@ -352,6 +364,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         spec = self.spec
         entries = super().initconfig_compiler_entries()
         entries.append(cmake_cache_string("CMAKE_CXX_STANDARD", "17"))
+        entries.append(cmake_cache_option("BUILD_SHARED_LIBS", "+shared" in spec))
         if not spec.satisfies("^cmake@3.23.0"):
             # There is a bug with using Ninja generator in this version
             # of CMake


### PR DESCRIPTION
Added explicit control for turning on shared library support in CMake.