### PR TITLE
Updates to env remove unit tests

### DIFF
--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1012,8 +1012,8 @@ def test_bad_env_yaml_format_remove(mutable_mock_env_path):
 @pytest.mark.parametrize("answer", ["-y", ""])
 def test_multi_env_remove(mutable_mock_env_path, monkeypatch, answer):
     """Test removal (or not) of a valid and invalid environment"""
-    resp = answer == "-y"
-    monkeypatch.setattr(tty, "get_yes_or_no", lambda prompt, default: resp)
+    remove_environment = answer == "-y"
+    monkeypatch.setattr(tty, "get_yes_or_no", lambda prompt, default: remove_environment)
 
     environments = ["goodenv", "badenv"]
     for e in environments:
@@ -1021,12 +1021,11 @@ def test_multi_env_remove(mutable_mock_env_path, monkeypatch, answer):
 
     # Ensure the bad environment contains invalid yaml
     filename = mutable_mock_env_path / environments[1] / "spack.yaml"
-    with open(filename, "w") as f:
-        f.write(
-            """\
+    filename.write_text(
+        """\
     - libdwarf
 """
-        )
+    )
 
     assert all(e in env("list") for e in environments)
 
@@ -1034,7 +1033,7 @@ def test_multi_env_remove(mutable_mock_env_path, monkeypatch, answer):
     args.extend(environments)
     output = env("remove", *args, fail_on_error=False)
 
-    if resp is True:
+    if remove_environment is True:
         # Successfully removed (and reported removal) of *both* environments
         assert not all(e in env("list") for e in environments)
         assert output.count("Successfully removed") == 2

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -14,6 +14,7 @@ import pytest
 
 import llnl.util.filesystem as fs
 import llnl.util.link_tree
+import llnl.util.tty as tty
 
 import spack.cmd.env
 import spack.config
@@ -977,10 +978,9 @@ packages:
     assert any([x.satisfies("libelf@0.8.10") for x in e._get_environment_specs()])
 
 
-def test_bad_env_yaml_format(tmpdir):
-    filename = str(tmpdir.join("spack.yaml"))
-    with open(filename, "w") as f:
-        f.write(
+def test_bad_env_yaml_format(environment_from_manifest):
+    with pytest.raises(spack.config.ConfigFormatError) as e:
+        environment_from_manifest(
             """\
 spack:
   spacks:
@@ -988,19 +988,15 @@ spack:
 """
         )
 
-    with tmpdir.as_cwd():
-        with pytest.raises(spack.config.ConfigFormatError) as e:
-            env("create", "test", "./spack.yaml")
-            assert "'spacks' was unexpected" in str(e)
+        assert "'spacks' was unexpected" in str(e)
 
     assert "test" not in env("list")
 
 
-def test_bad_env_yaml_format_remove():
+def test_bad_env_yaml_format_remove(mutable_mock_env_path):
     badenv = "badenv"
     env("create", badenv)
-    tmpdir = spack.environment.environment.environment_dir_from_name(badenv, exists_ok=True)
-    filename = os.path.join(tmpdir, "spack.yaml")
+    filename = mutable_mock_env_path / "spack.yaml"
     with open(filename, "w") as f:
         f.write(
             """\
@@ -1011,6 +1007,39 @@ def test_bad_env_yaml_format_remove():
     assert badenv in env("list")
     env("remove", "-y", badenv)
     assert badenv not in env("list")
+
+
+@pytest.mark.parametrize("answer", ["-y", ""])
+def test_multi_env_remove(mutable_mock_env_path, monkeypatch, answer):
+    """Test removal (or not) of a valid and invalid environment"""
+    resp = answer == "-y"
+    monkeypatch.setattr(tty, "get_yes_or_no", lambda prompt, default: resp)
+
+    environments = ["goodenv", "badenv"]
+    for e in environments:
+        env("create", e)
+
+    # Ensure the bad environment contains invalid yaml
+    filename = mutable_mock_env_path / environments[1] / "spack.yaml"
+    with open(filename, "w") as f:
+        f.write(
+            """\
+    - libdwarf
+"""
+        )
+
+    assert all(e in env("list") for e in environments)
+
+    args = [answer] if answer else []
+    args.extend(environments)
+    output = env("remove", *args, fail_on_error=False)
+
+    if resp is True:
+        assert not all(e in env("list") for e in environments)
+        assert output.count("Successfully removed") == 2
+    else:
+        assert all(e in env("list") for e in environments)
+        assert "not remove any" in output
 
 
 def test_env_loads(install_mockery, mock_fetch):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1035,11 +1035,12 @@ def test_multi_env_remove(mutable_mock_env_path, monkeypatch, answer):
     output = env("remove", *args, fail_on_error=False)
 
     if resp is True:
+        # Successfully removed (and reported removal) of *both* environments
         assert not all(e in env("list") for e in environments)
         assert output.count("Successfully removed") == 2
     else:
+        # Not removing any of the environments
         assert all(e in env("list") for e in environments)
-        assert "not remove any" in output
 
 
 def test_env_loads(install_mockery, mock_fetch):


### PR DESCRIPTION
Depends on #40811 

This PR updates the current unit tests for removing invalid environments and adds `test_multi_env_remove` to ensure we have a multi-environment removal test case and improve test coverage of the associated part of the code.

~The one question I have at this point is whether we want to be able to force the removal of an invalid environment that is currently deemed active.  If someone modifies an environment while active, then a bunch of the commands fail (including deactivation) and you can't force it's removal.~ (deferring to a separate PR)