### PR TITLE
depfile: deal with empty / non-concrete env

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -674,18 +674,31 @@ def env_depfile(args):
     # Currently only make is supported.
     spack.cmd.require_active_env(cmd_name="env depfile")
 
+    env = ev.active_environment()
+
     # What things do we build when running make? By default, we build the
     # root specs. If specific specs are provided as input, we build those.
     filter_specs = spack.cmd.parse_specs(args.specs) if args.specs else None
     template = spack.tengine.make_environment().get_template(os.path.join("depfile", "Makefile"))
     model = depfile.MakefileModel.from_env(
-        ev.active_environment(),
+        env,
         filter_specs=filter_specs,
         pkg_buildcache=depfile.UseBuildCache.from_string(args.use_buildcache[0]),
         dep_buildcache=depfile.UseBuildCache.from_string(args.use_buildcache[1]),
         make_prefix=args.make_prefix,
         jobserver=args.jobserver,
     )
+
+    # Warn in case we're generating a depfile for an empty environment. We don't automatically
+    # concretize; the user should do that explicitly. Could be changed in the future if requested.
+    if model.empty:
+        if not env.user_specs:
+            tty.warn("no specs in the environment")
+        elif filter_specs is not None:
+            tty.warn("no concrete matching specs found in environment")
+        else:
+            tty.warn("environment is not concretized. Run `spack concretize` first")
+
     makefile = template.render(model.to_dict())
 
     # Finally write to stdout/file.

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3346,6 +3346,20 @@ post-install: $(addprefix example/post-install/,$(example/SPACK_PACKAGE_IDS))
             assert "post-install: {}".format(s.dag_hash()) in out
 
 
+def test_depfile_empty_does_not_error(tmp_path):
+    # For empty environments Spack should create a depfile that does nothing
+    make = Executable("make")
+    makefile = str(tmp_path / "Makefile")
+
+    env("create", "test")
+    with ev.read("test"):
+        env("depfile", "-o", makefile)
+
+    make("-f", makefile)
+
+    assert make.returncode == 0
+
+
 def test_unify_when_possible_works_around_conflicts():
     e = ev.create("coconcretization")
     e.unify = "when_possible"

--- a/share/spack/templates/depfile/Makefile
+++ b/share/spack/templates/depfile/Makefile
@@ -8,7 +8,7 @@ SPACK_INSTALL_FLAGS ?=
 
 {{ all_target }}: {{ env_target }}
 
-{{ env_target }}: {{ root_install_targets }}
+{{ env_target }}: {{ root_install_targets }} | {{ dirs_target }}
 	@touch $@
 
 {{ dirs_target }}:


### PR DESCRIPTION
Closes #40709 

- Add warnings when an empty depfile is created
- Make the `env` target depend on `dirs_target` so that `touch $@` doesn't error
- Use `env.all_matching_specs` to mirror behavior of `spack install`.
