### PR TITLE
libCEED v0.12.0, Ratel v0.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/libceed/package.py
+++ b/var/spack/repos/builtin/packages/libceed/package.py
@@ -15,6 +15,7 @@ class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
     maintainers("jedbrown", "v-dobrev", "tzanio", "jeremylt")
 
     version("develop", branch="main")
+    version("0.12.0", tag="v0.12.0", commit="60ef3feef7f5137af55ea7336903743d94ee71a8")
     version("0.11.0", tag="v0.11.0", commit="8ec64e9ae9d5df169dba8c8ee61d8ec8907b8f80")
     version("0.10.1", tag="v0.10.1", commit="74532b27052d94e943eb8bc76257fbd710103614")
     version("0.9", tag="v0.9.0", commit="d66340f5aae79e564186ab7514a1cd08b3a1b06b")

--- a/var/spack/repos/builtin/packages/ratel/package.py
+++ b/var/spack/repos/builtin/packages/ratel/package.py
@@ -15,6 +15,7 @@ class Ratel(MakefilePackage, CudaPackage, ROCmPackage):
     maintainers("jedbrown", "jeremylt")
 
     version("develop", branch="main")
+    version("0.3.0", tag="v0.3.0", commit="ca2f3357e10b89fb274626fba104aad30c72774b")
     version("0.2.1", tag="v0.2.1", commit="043b61696a2407205fdfd898681467d1a7ff59e0")
     version("0.1.2", tag="v0.1.2", commit="94ad630bf897d231af7a94bf08257f6067258aae")
 
@@ -22,6 +23,8 @@ class Ratel(MakefilePackage, CudaPackage, ROCmPackage):
     depends_on("libceed@develop", when="@develop")
     depends_on("petsc@main", when="@develop")
     # released versions
+    depends_on("libceed@0.12.0:0.12", when="@0.3.0")
+    depends_on("petsc@3.20.0:3.20", when="@0.3.0")
     depends_on("libceed@0.11.0:0.11", when="@0.2.1")
     depends_on("petsc@3.18.3:3.18", when="@0.2.1")
     depends_on("libceed@0.10.1:0.10", when="@0.1.2")


### PR DESCRIPTION
libCEED and Ratel just released this morning. I put them together since Ratel depends upon the libCEED release.