### PR TITLE
interactive disambiguate

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -294,7 +294,10 @@ def get_single_spec_or_maybe_die(
     if len(matching_specs) == 0:
         tty.die(f"Spec '{spec}' matches no packages.")
 
-    fmt = "{hash:7} {name}{@version}{compiler.name}{@compiler.version}{arch=architecture}"
+    if sys.stdin.isatty():
+        fmt = "{name}{@version}{compiler.name}{@compiler.version}{arch=architecture}{/hash:7}"
+    else:
+        fmt = "{hash:7} {name}{@version}{compiler.name}{@compiler.version}{arch=architecture}"
     args = [f"{spec.colored_str} matches multiple packages:"]
     args += [
         colorize("@*b{" f"[{i+1}]" "} ") + s.cformat(fmt) for (i, s) in enumerate(matching_specs)

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -295,9 +295,9 @@ def get_single_spec_or_maybe_die(
         tty.die(f"Spec '{spec}' matches no packages.")
 
     if sys.stdin.isatty():
-        fmt = "{name}{@version}{compiler.name}{@compiler.version}{arch=architecture}{/hash:7}"
+        fmt = "{name}{@version}{%compiler.name}{@compiler.version}{arch=architecture}{/hash:7}"
     else:
-        fmt = "{hash:7} {name}{@version}{compiler.name}{@compiler.version}{arch=architecture}"
+        fmt = "{hash:7} {name}{@version}{%compiler.name}{@compiler.version}{arch=architecture}"
     args = (
         colorize("@*b{" f"[{i+1}]" "} ") + s.cformat(fmt) for (i, s) in enumerate(matching_specs)
     )

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -294,11 +294,10 @@ def get_single_spec_or_maybe_die(
     if len(matching_specs) == 0:
         tty.die(f"Spec '{spec}' matches no packages.")
 
-    format_string = "{name}{@version}{%compiler.name}{@compiler.version}{arch=architecture}"
+    fmt = "{hash:7} {name}{@version}{compiler.name}{@compiler.version}{arch=architecture}"
     args = [f"{spec.colored_str} matches multiple packages:"]
     args += [
-        colorize("@*b{" f"[{i+1}]" "} @K{" f"{s.dag_hash(7)}" "} ") + s.cformat(format_string)
-        for (i, s) in enumerate(matching_specs)
+        colorize("@*b{" f"[{i+1}]" "} ") + s.cformat(fmt) for (i, s) in enumerate(matching_specs)
     ]
 
     if not sys.stdin.isatty():

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -298,17 +298,20 @@ def get_single_spec_or_maybe_die(
         fmt = "{name}{@version}{compiler.name}{@compiler.version}{arch=architecture}{/hash:7}"
     else:
         fmt = "{hash:7} {name}{@version}{compiler.name}{@compiler.version}{arch=architecture}"
-    args = [f"{spec.colored_str} matches multiple packages:"]
-    args += [
+    args = (
         colorize("@*b{" f"[{i+1}]" "} ") + s.cformat(fmt) for (i, s) in enumerate(matching_specs)
-    ]
+    )
 
     if not sys.stdin.isatty():
-        tty.die(*args, "Use a more specific spec (e.g., prepend '/' to the hash).")
+        tty.die(
+            f"{spec.colored_str} matches multiple packages:",
+            *args,
+            "Use a more specific spec (e.g., prepend '/' to the hash).",
+        )
 
     # Let the user pick a spec interactively
-    tty.error(*args)
-    sys.stderr.write(colorize("@*g{select match>} "))
+    tty.info(f"Select a matching spec for {spec.colored_str}:", *args, stream=sys.stderr)
+    sys.stderr.write(colorize("@*g{select>} "))
     sys.stderr.flush()
     try:
         picked = int(input().strip())

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -65,9 +65,10 @@ def disambiguate_in_view(specs, view):
             tty.die("Spec matches no installed packages.")
 
         matching_in_view = [ms for ms in matching_specs if ms in view_specs]
-        spack.cmd.ensure_single_spec_or_die("Spec", matching_in_view)
-
-        return matching_in_view[0] if matching_in_view else matching_specs[0]
+        if not matching_in_view:
+            return matching_specs[0]
+        else:
+            return spack.cmd.get_single_spec_or_maybe_die("spec", matching_in_view)
 
     # make function always return a list to keep consistency between py2/3
     return list(map(squash, map(spack.store.STORE.db.query, specs)))

--- a/share/spack/qa/setup-env-test.fish
+++ b/share/spack/qa/setup-env-test.fish
@@ -370,12 +370,14 @@ spt_contains " spack env list " spack env list -h
 spt_contains " spack env list " spack env list --help
 
 title 'Testing `spack env activate`'
-spt_contains "No such environment:" spack env activate no_such_environment
+# spt_contains "No such environment:" spack env activate no_such_environment  # See fish-shell/fish-shell #1035
+spt_fails spack env activate no_such_environment
 spt_contains "usage: spack env activate " spack env activate -h
 spt_contains "usage: spack env activate " spack env activate --help
 
 title 'Testing `spack env deactivate`'
-spt_contains "Error: No environment is currently active" spack env deactivate
+# spt_contains "Error: No environment is currently active" spack env deactivate  # See fish-shell/fish-shell #1035
+spt_fails spack env deactivate
 spt_contains "usage: spack env deactivate " spack env deactivate no_such_environment
 spt_contains "usage: spack env deactivate " spack env deactivate -h
 spt_contains "usage: spack env deactivate " spack env deactivate --help


### PR DESCRIPTION
Since stderr is not captured by the shell wrapper, we can still let users
interactively select the relevant spec when `stdin.isatty()`

![image](https://github.com/spack/spack/assets/194764/6d22bc5d-4062-4096-8a43-5829d9a542c4)


Works for `spack load` / `spack cd` / `spack location` / `spack buildcache push`/ etc... whether captured by the shell wrapper or not.

