### PR TITLE
go/rust bootstrap: no versions if unsupported arch

### DIFF
--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -59,7 +59,7 @@ class GoBootstrap(Package):
 
     # determine system os and architecture/target
     os = platform.system().lower()
-    target = go_targets[platform.machine().lower()]
+    target = go_targets.get(platform.machine().lower(), platform.machine().lower())
 
     # construct releases for current system configuration
     for release in go_releases:

--- a/var/spack/repos/builtin/packages/rust-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/rust-bootstrap/package.py
@@ -73,7 +73,7 @@ class RustBootstrap(Package):
 
     # Determine system os and architecture/target.
     os = platform.system().lower()
-    target = rust_targets[platform.machine().lower()]
+    target = rust_targets.get(platform.machine().lower(), platform.machine().lower())
 
     # Pre-release versions of the bootstrap compiler.
     # Note: These versions are unchecksumed since they will change


### PR DESCRIPTION
The lookup in a dictionary causes KeyError on package load for
unsupported architectures such as i386 and ppc big endian.
