### PR TITLE
bugfix: requirements for compiler flags

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -720,7 +720,7 @@ requirement_group_satisfied(node(ID, Package), X) :-
   activate_requirement(node(NodeID1, Package1), RequirementID),
   pkg_fact(Package1, condition_effect(ConditionID, EffectID)),
   imposed_constraint(EffectID, "node_flag_source", Package1, FlagType, Package2),
-  imposed_packages(NodeID2, Package2).
+  imposed_nodes(EffectID, node(NodeID2, Package2), node(NodeID1, Package1)).
 
 requirement_weight(node(ID, Package), Group, W) :-
   W = #min {


### PR DESCRIPTION
We have a bug computing NodeID2 in requirement node_flag_source. This leads to node_flag_source facts that erroneously use an EffectID number as a DuplicateID.