### PR TITLE
MFEM: allow CUDA/ROCm builds with SuperLU_DIST built without CUDA/ROCm

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -309,15 +309,19 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     depends_on("gslib@1.0.7:", when="@4.3.0:+gslib")
     depends_on("suite-sparse", when="+suite-sparse")
     depends_on("superlu-dist", when="+superlu-dist")
+    # Propagate 'cuda_arch' to 'superlu-dist' without propagating the '+cuda'
+    # variant so we can build 'mfem+cuda+superlu-dist ^superlu-dist~cuda':
     for sm_ in CudaPackage.cuda_arch_values:
         depends_on(
             "superlu-dist+cuda cuda_arch={0}".format(sm_),
-            when="+superlu-dist+cuda cuda_arch={0}".format(sm_),
+            when="+superlu-dist+cuda cuda_arch={0} ^superlu-dist+cuda".format(sm_),
         )
+    # Propagate 'amdgpu_target' to 'superlu-dist' without propagating the '+rocm'
+    # variant so we can build 'mfem+rocm+superlu-dist ^superlu-dist~rocm':
     for gfx in ROCmPackage.amdgpu_targets:
         depends_on(
             "superlu-dist+rocm amdgpu_target={0}".format(gfx),
-            when="+superlu-dist+rocm amdgpu_target={0}".format(gfx),
+            when="+superlu-dist+rocm amdgpu_target={0} ^superlu-dist+rocm".format(gfx),
         )
     depends_on("strumpack@3.0.0:", when="+strumpack~shared")
     depends_on("strumpack@3.0.0:+shared", when="+strumpack+shared")

--- a/var/spack/repos/builtin/packages/mfem/test_builds.sh
+++ b/var/spack/repos/builtin/packages/mfem/test_builds.sh
@@ -31,6 +31,9 @@ petsc_spec_rocm='^petsc+rocm+mumps'
 strumpack_spec='^strumpack~slate~openmp~cuda'
 strumpack_cuda_spec='^strumpack+cuda~slate~openmp'
 strumpack_rocm_spec='^strumpack+rocm~slate~openmp~cuda'
+# superlu specs with cuda and rocm
+superlu_cuda_spec='^superlu-dist+cuda'
+superlu_rocm_spec='^superlu-dist+rocm'
 
 builds=(
     # preferred version:
@@ -136,7 +139,7 @@ builds_cuda=(
         +superlu-dist+strumpack+suite-sparse+gslib+petsc+slepc \
         +sundials+pumi+mpfr+netcdf+zlib+gnutls+libunwind+conduit+ginkgo+hiop \
         ^raja+cuda+openmp ^hiop+shared'" $strumpack_cuda_spec"' \
-        '"$petsc_spec_cuda $conduit_spec"
+        '"$superlu_cuda_spec $petsc_spec_cuda $conduit_spec"
 
     # hypre with cuda:
     # TODO: restore '+libceed' when the libCEED CUDA unit tests take less time.
@@ -148,7 +151,7 @@ builds_cuda=(
         +superlu-dist+strumpack+suite-sparse+gslib \
         +pumi+mpfr+netcdf+zlib+gnutls+libunwind+conduit+ginkgo+hiop \
         ^raja+cuda+openmp ^hiop+shared ^hypre+cuda \
-        '" $strumpack_cuda_spec $conduit_spec"
+        '" $strumpack_cuda_spec $superlu_cuda_spec $conduit_spec"
 
     #
     # same builds as above with ${mfem_dev}
@@ -173,7 +176,7 @@ builds_cuda=(
         +superlu-dist+strumpack+suite-sparse+gslib+petsc+slepc \
         +sundials+pumi+mpfr+netcdf+zlib+gnutls+libunwind+conduit+ginkgo+hiop \
         ^raja+cuda+openmp ^hiop+shared'" $strumpack_cuda_spec"' \
-        '"$petsc_spec_cuda $conduit_spec"
+        '"$superlu_cuda_spec $petsc_spec_cuda $conduit_spec"
 
     # hypre with cuda:
     # TODO: restore '+libceed' when the libCEED CUDA unit tests take less time.
@@ -185,7 +188,7 @@ builds_cuda=(
         +superlu-dist+strumpack+suite-sparse+gslib \
         +pumi+mpfr+netcdf+zlib+gnutls+libunwind+conduit+ginkgo+hiop \
         ^raja+cuda+openmp ^hiop+shared ^hypre+cuda \
-        '"$strumpack_cuda_spec $conduit_spec"
+        '"$strumpack_cuda_spec $superlu_cuda_spec $conduit_spec"
 )
 
 
@@ -208,7 +211,7 @@ builds_rocm=(
         +superlu-dist+strumpack+suite-sparse+gslib+petsc+slepc \
         +sundials+pumi+mpfr+netcdf+zlib+gnutls+libunwind+conduit \
         ^raja+rocm~openmp ^occa~cuda'" $strumpack_rocm_spec"' \
-        '"$petsc_spec_rocm $conduit_spec"
+        '"$superlu_rocm_spec $petsc_spec_rocm $conduit_spec"
 
     # hypre with rocm:
     # TODO: add back "+petsc+slepc $petsc_spec_rocm" when it works.
@@ -220,7 +223,7 @@ builds_rocm=(
         +superlu-dist+strumpack+suite-sparse+gslib \
         +pumi+mpfr+netcdf+zlib+gnutls+libunwind+conduit \
         ^raja+rocm~openmp ^occa~cuda ^hypre+rocm \
-        '"$strumpack_rocm_spec $conduit_spec"
+        '"$strumpack_rocm_spec $superlu_rocm_spec $conduit_spec"
 
     #
     # same builds as above with ${mfem_dev}


### PR DESCRIPTION
These options are needed for some xSDK builds to work.
