### PR TITLE
Patch a Makefile in epics-base to avoid failure on "perl xsubpp" 

### DIFF
--- a/var/spack/repos/builtin/packages/epics-base/package.py
+++ b/var/spack/repos/builtin/packages/epics-base/package.py
@@ -26,6 +26,7 @@ class EpicsBase(MakefilePackage):
     def patch(self):
         filter_file(r"^\s*CC\s*=.*", "CC = " + spack_cc, "configure/CONFIG.gnuCommon")
         filter_file(r"^\s*CCC\s*=.*", "CCC = " + spack_cxx, "configure/CONFIG.gnuCommon")
+        filter_file(r"\$\(PERL\)\s+\$\(XSUBPP\)", "$(XSUBPP)", "modules/ca/src/perl/Makefile")
 
     @property
     def install_targets(self):


### PR DESCRIPTION
This patch causes the Makefile for the Perl interface to epics-base to execute the chosen xsubpp as simply `$(XSUBPP)` instead of `$(PERL) $(XSUBPP)`. This avoids a bug where xsubpp was receiveing flags passed to perl as if they were filenames for xsubpp to process.

(Curiously, the above-mentioned bug does not occur when making epics-base outside of spack. I wasn't able to figure out why, but I would like to get epics-base compiling again. Thanks.)