### PR TITLE
qt-*: provide more specific homepage url

### DIFF
--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -96,6 +96,7 @@ class QtPackage(CMakePackage):
 class QtBase(QtPackage):
     """Qt Base (Core, Gui, Widgets, Network, ...)"""
 
+    homepage = QtPackage.get_homepage("QtCore")
     url = QtPackage.get_url(__qualname__)
     list_url = QtPackage.get_list_url(__qualname__)
 

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -21,6 +21,14 @@ class QtPackage(CMakePackage):
 
     homepage = "https://www.qt.io"
 
+    # provide a more specific homepage url for git submodules of qt5
+    # containing just a single Qt module, notable exceptions are qtbase
+    # and qtdeclarative
+    @staticmethod
+    def get_homepage(qualname):
+        _url = "https://doc.qt.io/qt-6/{}-index.html"
+        return _url.format(qualname.lower())
+
     @staticmethod
     def get_url(qualname):
         _url = "https://github.com/qt/{}/archive/refs/tags/v6.2.3.tar.gz"

--- a/var/spack/repos/builtin/packages/qt-declarative/package.py
+++ b/var/spack/repos/builtin/packages/qt-declarative/package.py
@@ -11,6 +11,7 @@ from spack.pkg.builtin.qt_base import QtBase, QtPackage
 class QtDeclarative(QtPackage):
     """Qt Declarative (Quick 2)."""
 
+    homepage = QtPackage.get_homepage("QtQuick")
     url = QtPackage.get_url(__qualname__)
     list_url = QtPackage.get_list_url(__qualname__)
 

--- a/var/spack/repos/builtin/packages/qt-quick3d/package.py
+++ b/var/spack/repos/builtin/packages/qt-quick3d/package.py
@@ -11,6 +11,7 @@ from spack.pkg.builtin.qt_base import QtBase, QtPackage
 class QtQuick3d(QtPackage):
     """A new module and API for defining 3D content in Qt Quick."""
 
+    homepage = QtPackage.get_homepage(__qualname__)
     url = QtPackage.get_url(__qualname__)
     list_url = QtPackage.get_list_url(__qualname__)
 

--- a/var/spack/repos/builtin/packages/qt-quicktimeline/package.py
+++ b/var/spack/repos/builtin/packages/qt-quicktimeline/package.py
@@ -11,6 +11,7 @@ from spack.pkg.builtin.qt_base import QtBase, QtPackage
 class QtQuicktimeline(QtPackage):
     """Module for keyframe-based timeline construction."""
 
+    homepage = QtPackage.get_homepage(__qualname__)
     url = QtPackage.get_url(__qualname__)
     list_url = QtPackage.get_list_url(__qualname__)
 

--- a/var/spack/repos/builtin/packages/qt-shadertools/package.py
+++ b/var/spack/repos/builtin/packages/qt-shadertools/package.py
@@ -13,6 +13,7 @@ class QtShadertools(QtPackage):
     shader pipeline that allows Qt Quick to operate on Vulkan, Metal, and
     Direct3D, in addition to OpenGL."""
 
+    homepage = QtPackage.get_homepage(__qualname__)
     url = QtPackage.get_url(__qualname__)
     list_url = QtPackage.get_list_url(__qualname__)
 

--- a/var/spack/repos/builtin/packages/qt-svg/package.py
+++ b/var/spack/repos/builtin/packages/qt-svg/package.py
@@ -13,6 +13,7 @@ class QtSvg(QtPackage):
     two-dimensional vector graphics. Qt provides classes for rendering and
     displaying SVG drawings in widgets and on other paint devices."""
 
+    homepage = QtPackage.get_homepage(__qualname__)
     url = QtPackage.get_url(__qualname__)
     list_url = QtPackage.get_list_url(__qualname__)
 


### PR DESCRIPTION
Provide a more specific homepage for those Qt packages containing just a single Qt module.

Does not work for every Qt package, though:
- e.g. qt-base provides Core, Gui, Widgets, Network, ...