### PR TITLE
fix typo in packaging guide

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2352,7 +2352,7 @@ the following at the command line of a bash shell:
 
 .. code-block:: console
 
-   $ for i in {1..12}; do nohup spack install -j 4 mpich@3.3.2 >> mpich_install.txt 2>&1 &; done
+   $ for i in {1..12}; do nohup spack install -j 4 mpich@3.3.2 >> mpich_install.txt 2>&1 & done
 
 .. note::
 


### PR DESCRIPTION
```
(base) ulrich@heisenbug:/export/dump/ulrich/myLibs/tandem/external/toml$ for i in {1..4}; do nohup spack install -j 10 tandem polynomial_degree=3 domain_dimension=2 %intel >> tandem_install.txt 2>&1 &; done
-bash: syntax error near unexpected token `;'
See also:
```
>Is this command synthax correct:
for i in {1..12}; do nohup spack install -j 4 mpich@3.3.2 >> mpich_install.txt 2>&1 &; done
ChatGPT
The syntax you've written has a small issue. The semicolon after the & is causing a problem. Here's the corrected command:
```for i in {1..12}; do nohup spack install -j 4 mpich@3.3.2 >> mpich_install.txt 2>&1 & done```
This modified command will run the spack install command 12 times in the background using nohup to avoid hang-ups when the terminal is closed. The output of each command will be appended to mpich_install.txt.