### PR TITLE
oci parsing: make image name case insensitive

### DIFF
--- a/lib/spack/spack/test/oci/image.py
+++ b/lib/spack/spack/test/oci/image.py
@@ -34,6 +34,10 @@ from spack.oci.image import Digest, ImageReference, default_tag, tag
         ("myname:1234/myimage:abc", ("myname:1234", "myimage", "abc", None)),
         ("localhost/myimage:abc", ("localhost", "myimage", "abc", None)),
         ("localhost:1234/myimage:abc", ("localhost:1234", "myimage", "abc", None)),
+        (
+            "example.com/UPPERCASE/lowercase:AbC",
+            ("example.com", "uppercase/lowercase", "AbC", None),
+        ),
     ],
 )
 def test_name_parsing(image_ref, expected):


### PR DESCRIPTION
When using Github Packages as a Spack buildcache, it's somewhat unexpected that
the `<organization>/<repo>` bit on Github is case sensitive, but the
corresponding image name needs lowercase. I couldn't find much about this in
the OCI specification, but Docker decided lowercase image names are required,
and we currently follow Docker's rules.

Since it would be possible that people interpolate their organization and repo
name in the buildcache image URL, and it would be hard to normalize in a shell
script:

```
"oci://$organization/$repository"
```

let's be a bit more forgiving and silently lowercase the image name after parsing
the entire thing with upper- and lowercase in path components enabled, instead
of pedantically throwing parsing errors.

Notice that tags apparently *can* have uppercase... Anyways, the test shows
what this commit does.

I don't think warnings about use of uppercase is something people are waiting for.