### PR TITLE
bison: fix possible miscompilation with %oneapi

### DIFF
--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -65,6 +65,13 @@ class Bison(AutotoolsPackage, GNUMirrorPackage):
     patch("nvhpc-3.7.patch", when="@3.7.0:3.7 %nvhpc")
 
     conflicts("%intel@:14", when="@3.4.2:", msg="Intel 14 has immature C11 support")
+    conflicts(
+        "%oneapi",
+        msg=(
+            "bison is likely miscompiled by oneapi compilers, "
+            "see https://github.com/spack/spack/issues/37172"
+        ),
+    )
 
     if sys.platform == "darwin" and macos_version() >= Version("10.13"):
         patch("secure_snprintf.patch", level=0, when="@3.0.4")


### PR DESCRIPTION
As noted in #37172, and specifically https://github.com/spack/spack/issues/37172#issuecomment-1561872297, 
krb5's install currently fails with oneapi, and a workaround is to compile bison with gcc.
The proposed workaround would e.g. allow compiling openmpi with oneapi without requiring tricks, such as manually having to specify ^bison@gcc (and looking for this solution in the issues).