### PR TITLE
clingo: fix i out of n

### DIFF
--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -42,7 +42,9 @@ class Clingo(CMakePackage):
     # See https://github.com/potassco/clingo/blob/v5.5.2/INSTALL.md
     depends_on("cmake@3.1:", type="build")
     depends_on("cmake@3.18:", type="build", when="@5.5:")
-    depends_on("py-setuptools", when="@5.6.2:", type="build")
+
+    # Workaround for old concretizer, and python 3.12 distutils deprecation
+    depends_on("py-setuptools", type="build")
 
     depends_on("doxygen", type="build", when="+docs")
 
@@ -69,11 +71,8 @@ class Clingo(CMakePackage):
     patch("size-t.patch", when="%msvc")
     patch("vs2022.patch", when="%msvc@19.30:")
 
-    # TODO: Simplify this after Spack 0.21 release. The old concretizer has problems with
-    # py-setuptools ^python@3.6, so we only apply the distutils -> setuptools patch for Python 3.12
-    with when("@:5.6.1 ^python@3.12:"):
-        patch("setuptools-2.patch")
-        depends_on("py-setuptools", type="build")
+    # distutils deprecation patches
+    patch("setuptools-2.patch", when="@:5.6.1 ^python@3.12:")
 
     def patch(self):
         # Doxygen is optional but can't be disabled with a -D, so patch


### PR DESCRIPTION
The old concretizer just drops py-setuptools. Add it unconditionally then.

Might get us back to the issue with Python 3.6 :) :tada:  
