### PR TITLE
Add python as test dependency for libgit2

### DIFF
--- a/var/spack/repos/builtin/packages/libgit2/package.py
+++ b/var/spack/repos/builtin/packages/libgit2/package.py
@@ -124,5 +124,6 @@ class Libgit2(CMakePackage):
 
         # Control tests
         args.append(self.define("BUILD_CLAR", self.run_tests))
+        args.append(self.define("BUILD_TESTS", self.run_tests))
 
         return args

--- a/var/spack/repos/builtin/packages/libgit2/package.py
+++ b/var/spack/repos/builtin/packages/libgit2/package.py
@@ -83,6 +83,7 @@ class Libgit2(CMakePackage):
     depends_on("cmake@2.8:", type="build", when="@:0.28")
     depends_on("cmake@3.5:", type="build", when="@0.99:")
     depends_on("pkgconfig", type="build")
+    depends_on("python", type="build")
 
     # Runtime Dependencies
     depends_on("libssh2", when="+ssh")

--- a/var/spack/repos/builtin/packages/libgit2/package.py
+++ b/var/spack/repos/builtin/packages/libgit2/package.py
@@ -83,7 +83,7 @@ class Libgit2(CMakePackage):
     depends_on("cmake@2.8:", type="build", when="@:0.28")
     depends_on("cmake@3.5:", type="build", when="@0.99:")
     depends_on("pkgconfig", type="build")
-    depends_on("python", type="build")
+    depends_on("python", type="test")
 
     # Runtime Dependencies
     depends_on("libssh2", when="+ssh")


### PR DESCRIPTION
Libgit2 requires python as build dependency. I was getting an error because it was falling back to system Python which is compiled with Intel compilers and thus, `libgit2` was failing because it couldn't find `libimf.so` (which doesn't make sense).