### PR TITLE
bootstrapping: force setuptools dependency using a variant

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -159,6 +159,9 @@ jobs:
           brew install cmake bison@2.7 tree
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # @v2
+        with:
+          python-version: "3.12"
       - name: Bootstrap clingo
         run: |
           source share/spack/setup-env.sh

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -294,7 +294,7 @@ class SourceBootstrapper(Bootstrapper):
             # This is needed to help the old concretizer taking the `setuptools` dependency
             # only when bootstrapping from sources on Python 3.12
             if spec_for_current_python() == "python@3.12":
-                concrete_spec.constrain("+force-setuptools")
+                concrete_spec.constrain("+force_setuptools")
 
             if module == "clingo":
                 # TODO: remove when the old concretizer is deprecated  # pylint: disable=fixme

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -491,6 +491,9 @@ def _add_externals_if_missing() -> None:
 
 def clingo_root_spec() -> str:
     """Return the root spec used to bootstrap clingo"""
+    # This is needed to help the old concretizer taking the `setuptools` dependency
+    if spec_for_current_python() == "python@3.12":
+        return _root_spec("clingo-bootstrap@spack+python+force-setuptools")
     return _root_spec("clingo-bootstrap@spack+python")
 
 

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -291,6 +291,10 @@ class SourceBootstrapper(Bootstrapper):
         with spack_python_interpreter():
             # Add hint to use frontend operating system on Cray
             concrete_spec = spack.spec.Spec(abstract_spec_str + " ^" + spec_for_current_python())
+            # This is needed to help the old concretizer taking the `setuptools` dependency
+            # only when bootstrapping from sources on Python 3.12
+            if spec_for_current_python() == "python@3.12":
+                concrete_spec.constrain("+force-setuptools")
 
             if module == "clingo":
                 # TODO: remove when the old concretizer is deprecated  # pylint: disable=fixme
@@ -491,9 +495,6 @@ def _add_externals_if_missing() -> None:
 
 def clingo_root_spec() -> str:
     """Return the root spec used to bootstrap clingo"""
-    # This is needed to help the old concretizer taking the `setuptools` dependency
-    if spec_for_current_python() == "python@3.12":
-        return _root_spec("clingo-bootstrap@spack+python+force-setuptools")
     return _root_spec("clingo-bootstrap@spack+python")
 
 

--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -33,11 +33,11 @@ class ClingoBootstrap(Clingo):
     )
 
     variant(
-        "force-setuptools",
+        "force_setuptools",
         default=False,
         description="Force a dependency on setuptools to help the old concretizer",
     )
-    depends_on("py-setuptools", type="build", when="+force-setuptools")
+    depends_on("py-setuptools", type="build", when="+force_setuptools")
 
     # Enable LTO
     conflicts("~ipo", when="+optimized")

--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -32,6 +32,13 @@ class ClingoBootstrap(Clingo):
         description="Enable a series of Spack-specific optimizations (PGO, LTO, mimalloc)",
     )
 
+    variant(
+        "force-setuptools",
+        default=False,
+        description="Force a dependency on setuptools to help the old concretizer",
+    )
+    depends_on("py-setuptools", type="build", when="+force-setuptools")
+
     # Enable LTO
     conflicts("~ipo", when="+optimized")
 


### PR DESCRIPTION
closes #40861

When bootstrapping clingo from sources on Python 3.12, we need to use the old concretizer and add setuptools as a dependency, due to the removal of distutils.

The old concretizer cannot deal with conditional deps so let's try to help it using a variant.