### PR TITLE
fix configure args for darshan-runtime

### DIFF
--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -115,9 +115,9 @@ class DarshanRuntime(AutotoolsPackage):
         if "+apmpi" in spec:
             extra_args.append("--enable-apmpi-mod")
         if "+apmpi_sync" in spec:
-            extra_args.append(["--enable-apmpi-mod", "--enable-apmpi-coll-sync"])
+            extra_args.extend(["--enable-apmpi-mod", "--enable-apmpi-coll-sync"])
         if "+apxc" in spec:
-            extra_args.append(["--enable-apxc-mod"])
+            extra_args.append("--enable-apxc-mod")
 
         extra_args.append("--with-mem-align=8")
         extra_args.append("--with-log-path-by-env=DARSHAN_LOG_DIR_PATH")


### PR DESCRIPTION
Problem: the current configure arguments are added lists to a list, and this needs to be adding strings to the same list. Solution: ensure we add each item (string) separately.

This will (partially) fix https://github.com/spack/spack/issues/40835. The second half of the issue needs further testing for the package (not specific to spack I don't think(.