### PR TITLE
linux-headers: support multiple versions

### DIFF
--- a/var/spack/repos/builtin/packages/linux-headers/package.py
+++ b/var/spack/repos/builtin/packages/linux-headers/package.py
@@ -20,6 +20,10 @@ class LinuxHeaders(Package):
     version("6.2.8", sha256="fed0ad87d42f83a70ce019ff2800bc30a855e672e72bf6d54a014d98d344f665")
     version("4.9.10", sha256="bd6e05476fd8d9ea4945e11598d87bc97806bbc8d03556abbaaf809707661525")
 
+    def url_for_version(self, version):
+        url = "https://www.kernel.org/pub/linux/kernel/v{0}.x/linux-{1}.tar.xz"
+        return url.format(version.up_to(1), version)
+
     def setup_build_environment(self, env):
         # This variable is used in the Makefile. If it is defined on the
         # system, it can break the build if there is no build recipe for


### PR DESCRIPTION
The download URL for linux-headers was hardcoded to 4.x; we need to derive the correct URL from the version number.

Fixes #40334