### PR TITLE
qwt: conflict with qt-base (Qt6)

### DIFF
--- a/var/spack/repos/builtin/packages/qwt/package.py
+++ b/var/spack/repos/builtin/packages/qwt/package.py
@@ -28,8 +28,8 @@ class Qwt(QMakePackage):
     patch("no-designer.patch", when="~designer")
     patch("no-opengl_6_1.patch", when="@6.1 ~opengl")
 
-    depends_on("qt+tools", when="+designer ^qt")
-    depends_on("qt+opengl", when="+opengl ^qt")
+    depends_on("qt+tools", when="+designer")
+    depends_on("qt+opengl", when="+opengl")
 
     # Qwt does not support Qt6; this picks the right qmake provider
     conflicts("qt-base")

--- a/var/spack/repos/builtin/packages/qwt/package.py
+++ b/var/spack/repos/builtin/packages/qwt/package.py
@@ -28,10 +28,12 @@ class Qwt(QMakePackage):
     patch("no-designer.patch", when="~designer")
     patch("no-opengl_6_1.patch", when="@6.1 ~opengl")
 
-    depends_on("qt+tools", when="+designer")
-    depends_on("qt+opengl", when="+opengl")
+    depends_on("qt+tools", when="+designer ^qt")
+    depends_on("qt+opengl", when="+opengl ^qt")
 
-    depends_on("qt")
+    # Qwt does not support Qt6; this picks the right qmake provider
+    conflicts("qt-base")
+
     # the qt@5.14.2 limitation was lifted in qwt@6.1.5
     # https://sourceforge.net/p/qwt/code/HEAD/tree/tags/qwt-6.1.6/CHANGES-6.1
     depends_on("qt@:5.14.2", when="@:6.1.4")

--- a/var/spack/repos/builtin/packages/qwt/package.py
+++ b/var/spack/repos/builtin/packages/qwt/package.py
@@ -32,7 +32,7 @@ class Qwt(QMakePackage):
     depends_on("qt+opengl", when="+opengl")
 
     # Qwt does not support Qt6; this picks the right qmake provider
-    conflicts("qt-base")
+    conflicts("^qt-base", msg="Qwt requires Qt5")
 
     # the qt@5.14.2 limitation was lifted in qwt@6.1.5
     # https://sourceforge.net/p/qwt/code/HEAD/tree/tags/qwt-6.1.6/CHANGES-6.1


### PR DESCRIPTION
Depends on #40882.

Qwt does not support Qt6 yet, but pulls in qmake default provider qt-base in e.g. https://gitlab.spack.io/spack/spack/-/jobs/8960286 leading to failing builds in e.g. https://gitlab.spack.io/spack/spack/-/jobs/8961356