### PR TITLE
qt: new version 5.15.11

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -146,7 +146,7 @@ class Qt(Package):
         "https://src.fedoraproject.org/rpms/qt5-qtlocation/raw/b6d99579de9ce5802c592b512a9f644a5e4690b9/f/qtlocation-gcc10.patch",
         sha256="78c70fbd0c74031c5f0f1f5990e0b4214fc04c5073c67ce1f23863373932ec86",
         working_dir="qtlocation",
-        when="@5.15.10 %gcc@10:",
+        when="@5.15.10: %gcc@10:",
     )
     # https://github.com/microsoft/vcpkg/issues/21055
     patch("qt5-macos12.patch", working_dir="qtbase", when="@5.14: %apple-clang@13:")

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -31,6 +31,7 @@ class Qt(Package):
 
     phases = ["configure", "build", "install"]
 
+    version("5.15.11", sha256="7426b1eaab52ed169ce53804bdd05dfe364f761468f888a0f15a308dc1dc2951")
     version("5.15.10", sha256="b545cb83c60934adc9a6bbd27e2af79e5013de77d46f5b9f5bb2a3c762bf55ca")
     version("5.15.9", sha256="26d5f36134db03abe4a6db794c7570d729c92a3fc1b0bf9b1c8f86d0573cd02f")
     version("5.15.8", sha256="776a9302c336671f9406a53bd30b8e36f825742b2ec44a57c08217bff0fa86b9")


### PR DESCRIPTION
New bugfix version of the Qt5 series, release notes at https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/5.15.11/release-note.md.

TODO:
- [x] verify patches apply cleanly
- [x] verify builds locally with usual variants