### PR TITLE
RAJA package: find libs

### DIFF
--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -164,9 +164,8 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     @property
     def libs(self):
-        shared = True if '+shared' in self.spec else False
-        return find_libraries(
-            'libRAJA*', root=self.prefix, shared=shared, recursive=True)
+        shared = True if "+shared" in self.spec else False
+        return find_libraries("libRAJA*", root=self.prefix, shared=shared, recursive=True)
 
     @property
     def cache_name(self):

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -164,7 +164,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     @property
     def libs(self):
-        shared = True if "+shared" in self.spec else False
+        shared = "+shared" in self.spec
         return find_libraries("libRAJA", root=self.prefix, shared=shared, recursive=True)
 
     @property

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -165,7 +165,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
     @property
     def libs(self):
         shared = True if "+shared" in self.spec else False
-        return find_libraries("libRAJA*", root=self.prefix, shared=shared, recursive=True)
+        return find_libraries("libRAJA", root=self.prefix, shared=shared, recursive=True)
 
     @property
     def cache_name(self):

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -163,6 +163,12 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
         return sys_type
 
     @property
+    def libs(self):
+        shared = True if '+shared' in self.spec else False
+        return find_libraries(
+            'libRAJA*', root=self.prefix, shared=shared, recursive=True)
+
+    @property
     def cache_name(self):
         hostname = socket.gethostname()
         if "SYS_TYPE" in env:


### PR DESCRIPTION
RAJA lib name does not match Spack's guess, define `libs` method to help dependents locate it.