### PR TITLE
mpich: remove unnecessary tuples and upperbounds

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -249,13 +249,13 @@ spack package at this time.""",
     # building from git requires regenerating autotools files
     depends_on("automake@1.15:", when="@develop", type="build")
     depends_on("libtool@2.4.4:", when="@develop", type="build")
-    depends_on("m4", when="@develop", type="build"),
+    depends_on("m4", when="@develop", type="build")
     depends_on("autoconf@2.67:", when="@develop", type="build")
 
     # building with "+hwloc' also requires regenerating autotools files
     depends_on("automake@1.15:", when="@3.3:3.3.99 +hwloc", type="build")
     depends_on("libtool@2.4.4:", when="@3.3:3.3.99 +hwloc", type="build")
-    depends_on("m4", when="@3.3:3.3.99 +hwloc", type="build"),
+    depends_on("m4", when="@3.3:3.3.99 +hwloc", type="build")
     depends_on("autoconf@2.67:", when="@3.3:3.3.99 +hwloc", type="build")
 
     # MPICH's Yaksa submodule requires python to configure

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -164,7 +164,7 @@ spack package at this time.""",
     patch(
         "https://github.com/pmodels/mpich/commit/8a851b317ee57366cd15f4f28842063d8eff4483.patch?full_index=1",
         sha256="d2dafc020941d2d8cab82bc1047e4a6a6d97736b62b06e2831d536de1ac01fd0",
-        when="@3.3:3.3.99 +hwloc",
+        when="@3.3 +hwloc",
     )
 
     # fix MPI_Barrier segmentation fault
@@ -253,10 +253,10 @@ spack package at this time.""",
     depends_on("autoconf@2.67:", when="@develop", type="build")
 
     # building with "+hwloc' also requires regenerating autotools files
-    depends_on("automake@1.15:", when="@3.3:3.3.99 +hwloc", type="build")
-    depends_on("libtool@2.4.4:", when="@3.3:3.3.99 +hwloc", type="build")
-    depends_on("m4", when="@3.3:3.3.99 +hwloc", type="build")
-    depends_on("autoconf@2.67:", when="@3.3:3.3.99 +hwloc", type="build")
+    depends_on("automake@1.15:", when="@3.3 +hwloc", type="build")
+    depends_on("libtool@2.4.4:", when="@3.3 +hwloc", type="build")
+    depends_on("m4", when="@3.3 +hwloc", type="build")
+    depends_on("autoconf@2.67:", when="@3.3 +hwloc", type="build")
 
     # MPICH's Yaksa submodule requires python to configure
     depends_on("python@3.0:", when="@develop", type="build")
@@ -462,7 +462,7 @@ spack package at this time.""",
     def autoreconf(self, spec, prefix):
         """Not needed usually, configure should be already there"""
         # If configure exists nothing needs to be done
-        if os.path.exists(self.configure_abs_path) and not spec.satisfies("@3.3:3.3.99 +hwloc"):
+        if os.path.exists(self.configure_abs_path) and not spec.satisfies("@3.3 +hwloc"):
             return
         # Else bootstrap with autotools
         bash = which("bash")


### PR DESCRIPTION
Found in #40894

- The trailing `,` makes the line parse as `(depends_on(...),)` i.e. a tuple, which causes these lines:
    ```python
    depends_on('m4', when='@develop', type='build'),
    depends_on('m4', when='@3.3:3.3.99 +hwloc', type='build'),
    ```

   not to be removed from the canonical code used for package hashes:

    ```python
    (depends_on('m4', when='@develop', type='build'),)
    (depends_on('m4', when='@3.3:3.3.99 +hwloc', type='build'),)
    ```

    See https://github.com/spack/spack/pull/40894#discussion_r1382894808.

- The upperbound is redundant, since:

   ```
   ~ $ spack python -c 'spack.spec.Spec("@3.3").satisfies("@3.3")'
   True
   ~ $ spack python -c 'spack.spec.Spec("@3.3.999999").satisfies("@3.3")'
   True
   ```