### PR TITLE
Add Python as build dependency of Julia

### DIFF
--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -166,6 +166,7 @@ class Julia(MakefilePackage):
     depends_on("patchelf@0.13:", type="build")
     depends_on("perl", type="build")
     depends_on("libwhich", type="build")
+    depends_on("python", type="build")
 
     depends_on("blas")  # note: for now openblas is fixed...
     depends_on("curl tls=mbedtls +nghttp2 +libssh2")


### PR DESCRIPTION
As stated in https://github.com/spack/spack/pull/40863#issuecomment-1793823379, Julia seems to need Python for build (confirmed with @giordano in https://github.com/JuliaLang/julia/blob/d834a4473e6dfdcf072f8b4426c00b0d9faa2d60/Make.inc#L118) but because it fallbacks to system Python, it went unnoticed for a long time. In some cases, as in #40863, this can be a problem.

This PR adds Python as a build dependency for Julia.