### PR TITLE
defaults/modules.yaml: hide implicits

### DIFF
--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -46,10 +46,12 @@ modules:
     tcl:
       all:
         autoload: direct
+      hide_implicits: true
 
     # Default configurations if lmod is enabled
     lmod:
       all:
         autoload: direct
+      hide_implicits: true
       hierarchy:
         - mpi


### PR DESCRIPTION
Suggested default config:

```yaml
autoload: direct
hide_implicits: true
```

These two options make a lot of sense together, and we already have `autoload:`
`direct` to avoid broken runtime environments due to missing environment
variables from dependencies

---

Users are suggested to set `hash_length: 0` and custom projections for prettier
names, but this is something that can't be done in the default config due to
conflicts (even though hash_length: 0 only applies to explicitly installed packages
now)