### PR TITLE
Build environment cleaning and devtools repair

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1026,7 +1026,6 @@ class SetupContext:
                     run_env_mods.drop("CC", "CXX", "F77", "FC")
                 env.extend(run_env_mods)
 
-
         return env
 
     def _make_buildtime_detectable(self, dep: spack.spec.Spec, env: EnvironmentModifications):

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1016,10 +1016,17 @@ class SetupContext:
                 self._make_runnable(dspec, env)
 
             if self.should_setup_run_env & flag:
+                run_env_mods = EnvironmentModifications()
                 for spec in dspec.dependents(deptype=dt.LINK | dt.RUN):
                     if id(spec) in self.nodes_in_subdag:
-                        pkg.setup_dependent_run_environment(env, spec)
-                pkg.setup_run_environment(env)
+                        pkg.setup_dependent_run_environment(run_env_mods, spec)
+                pkg.setup_run_environment(run_env_mods)
+                run_env_dict = run_env_mods.group_by_name()
+                if self.context == Context.BUILD:
+                    run_env_mods.drop("CC", "CXX", "F77", "FC")
+                env.extend(run_env_mods)
+
+
         return env
 
     def _make_buildtime_detectable(self, dep: spack.spec.Spec, env: EnvironmentModifications):

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -596,6 +596,14 @@ class EnvironmentModifications:
             modifications[item.name].append(item)
         return modifications
 
+    def drop(self, *name) -> bool:
+        """Drop all modifications to the variable with the given name."""
+        old_mods = self.env_modifications
+        new_mods = [x for x in self.env_modifications if x.name not in name]
+        self.env_modifications = new_mods
+
+        return len(old_mods) != len(new_mods)
+
     def is_unset(self, variable_name: str) -> bool:
         """Returns True if the last modification to a variable is to unset it, False otherwise."""
         modifications = self.group_by_name()

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -977,7 +977,9 @@ class Llvm(CMakePackage, CudaPackage):
                 ninja()
                 ninja("install")
         if "+python" in self.spec:
-            install_tree("llvm/bindings/python", python_platlib)
+            if spec.version < Version("17.0.0"):
+                # llvm bindings were removed in v17: https://releases.llvm.org/17.0.1/docs/ReleaseNotes.html#changes-to-the-python-bindings
+                install_tree("llvm/bindings/python", python_platlib)
 
             if "+clang" in self.spec:
                 install_tree("clang/bindings/python", python_platlib)

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import re
+import os
 
 from spack.package import *
 
@@ -92,8 +93,16 @@ class Rust(Package):
         env.set("AR", ar.path)
 
         # Manually inject the path of openssl's certs for build.
-        certs = join_path(self.spec["openssl"].prefix, "etc/openssl/cert.pem")
-        env.set("CARGO_HTTP_CAINFO", certs)
+        certs = None
+        for p in ("etc/openssl/cert.pem", "../etc/openssl/cert.pem",
+                  "etc/ssl/certs/ca-bundle.crt", "../etc/ssl/certs/ca-bundle.crt"):
+            certs = join_path(self.spec["openssl"].prefix, p)
+            if os.path.exists(certs):
+                break
+            else:
+                certs = None
+        if certs is not None:
+            env.set("CARGO_HTTP_CAINFO", certs)
 
     def configure(self, spec, prefix):
         opts = []

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import re
 import os
+import re
 
 from spack.package import *
 
@@ -94,8 +94,12 @@ class Rust(Package):
 
         # Manually inject the path of openssl's certs for build.
         certs = None
-        for p in ("etc/openssl/cert.pem", "../etc/openssl/cert.pem",
-                  "etc/ssl/certs/ca-bundle.crt", "../etc/ssl/certs/ca-bundle.crt"):
+        for p in (
+            "etc/openssl/cert.pem",
+            "../etc/openssl/cert.pem",
+            "etc/ssl/certs/ca-bundle.crt",
+            "../etc/ssl/certs/ca-bundle.crt",
+        ):
             certs = join_path(self.spec["openssl"].prefix, p)
             if os.path.exists(certs):
                 break


### PR DESCRIPTION
The main thing here is this resolves the issue with gcc, and possibly others, setting CC and similar in their `setup_run_environment` routines.  After #40683 these get called as part of building the build environment, which is mostly what we want but was causing our compiler wrappers to be lost.

The solution we, thanks @haampie, came up with for this is to detect when one of the `run_environment` setup routines sets one of the compiler vars in a build context and drop those modifications.  We looked at setting the vars later, or re-setting them to the wrappers, but there are quite a few packages, most dealing with rocm, that do some variation of `env.set("CXX", "hipcc")` in their `setup_build_environment` and re-setting these indiscriminately would break all of them.  Doing it just for the build context and just for run environment seems to allow everything to pass without issue.

This also includes two small package repair items that happened to be in the same branch.