### PR TITLE
abinit:	add v9.10.3

### DIFF
--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -177,7 +177,7 @@ class Abinit(AutotoolsPackage):
             if spec.satisfies("@9.8:"):
                 oapp(f"F90={spec['mpi'].mpifc}")
             else:
-                oapp(f"FC={spec['mpi'].mpifc}")            
+                oapp(f"FC={spec['mpi'].mpifc}")
 
             # MPI version:
             # let the configure script auto-detect MPI support from mpi_prefix

--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -27,6 +27,8 @@ class Abinit(AutotoolsPackage):
     homepage = "https://www.abinit.org/"
     url = "https://www.abinit.org/sites/default/files/packages/abinit-8.6.3.tar.gz"
 
+    maintainers("downloadico")
+    version("9.10.3", sha256="3f2a9aebbf1fee9855a09dd687f88d2317b8b8e04f97b2628ab96fb898dce49b")
     version("9.8.4", sha256="a086d5045f0093b432e6a044d5f71f7edf5a41a62d67b3677cb0751d330c564a")
     version("9.8.3", sha256="de823878aea2c20098f177524fbb4b60de9b1b5971b2e835ec244dfa3724589b")
     version("9.6.1", sha256="b6a12760fd728eb4aacca431ae12150609565bedbaa89763f219fcd869f79ac6")
@@ -138,17 +140,25 @@ class Abinit(AutotoolsPackage):
             oapp(f"--with-optim-flavor={self.spec.variants['optimization-flavor'].value}")
 
         if "+wannier90" in spec:
-            if "@:8" in spec:
+            if spec.satisfies("@:8"):
                 oapp(f"--with-wannier90-libs=-L{spec['wannier90'].prefix.lib} -lwannier -lm")
                 oapp(f"--with-wannier90-incs=-I{spec['wannier90'].prefix.modules}")
                 oapp(f"--with-wannier90-bins={spec['wannier90'].prefix.bin}")
                 oapp("--enable-connectors")
                 oapp("--with-dft-flavor=atompaw+libxc+wannier90")
-            else:
+            elif spec.satisfies("@:9.8"):
                 options.extend(
                     [
                         f"WANNIER90_CPPFLAGS=-I{spec['wannier90'].prefix.modules}",
                         f"WANNIER90_LIBS=-L{spec['wannier90'].prefix.lib} -lwannier",
+                    ]
+                )
+            else:
+                options.extend(
+                    [
+                        f"WANNIER90_CPPFLAGS=-I{spec['wannier90'].prefix.modules}",
+                        f"WANNIER90_LIBS=-L{spec['wannier90'].prefix.lib}"
+                        "WANNIER90_LDFLAGS=-lwannier",
                     ]
                 )
         else:
@@ -164,7 +174,10 @@ class Abinit(AutotoolsPackage):
         if "+mpi" in spec:
             oapp(f"CC={spec['mpi'].mpicc}")
             oapp(f"CXX={spec['mpi'].mpicxx}")
-            oapp(f"FC={spec['mpi'].mpifc}")
+            if spec.satisfies("@9.8:"):
+                oapp(f"F90={spec['mpi'].mpifc}")
+            else:
+                oapp(f"FC={spec['mpi'].mpifc}")            
 
             # MPI version:
             # let the configure script auto-detect MPI support from mpi_prefix


### PR DESCRIPTION
Added myself as	a maintainer.
Changed	configure arguments for specfying how to use Wannier90 for versions after 9.8.
When the mpi variant is requested, set the F90 environment variable to point to the MPI Fortran wrapper when building versions after 9.8 instead of FC.