### PR TITLE
Fix setup-env when going back and forth between instances

### DIFF
--- a/share/spack/csh/pathadd.csh
+++ b/share/spack/csh/pathadd.csh
@@ -25,7 +25,7 @@ if ($_pa_set == 1) then
     eval set _pa_old_value='$'$_pa_varname
 endif
 
-# Do the actual prepending here, if it is a dir and not already in the path
+# Do the actual prepending here, if it is a dir and not first in the path
 if ( -d $_pa_new_path && $_pa_old_value\: !~ $_pa_new_path\:* ) then
     if ("x$_pa_old_value" == "x") then
         setenv $_pa_varname $_pa_new_path

--- a/share/spack/csh/pathadd.csh
+++ b/share/spack/csh/pathadd.csh
@@ -26,7 +26,7 @@ if ($_pa_set == 1) then
 endif
 
 # Do the actual prepending here, if it is a dir and not already in the path
-if ( -d $_pa_new_path && \:$_pa_old_value\: !~ *\:$_pa_new_path\:* ) then
+if ( -d $_pa_new_path && $_pa_old_value\: !~ $_pa_new_path\:* ) then
     if ("x$_pa_old_value" == "x") then
         setenv $_pa_varname $_pa_new_path
     else

--- a/share/spack/setup-env.csh
+++ b/share/spack/setup-env.csh
@@ -17,38 +17,37 @@ if ($?_sp_initializing) then
 endif
 setenv _sp_initializing true
 
-# If SPACK_ROOT is not set, we'll try to find it ourselves.
+# find SPACK_ROOT.
 # csh/tcsh don't have a built-in way to do this, but both keep files
 # they are sourcing open. We use /proc on linux and lsof on macs to
 # find this script's full path in the current process's open files.
+
+# figure out a command to list open files
+if (-d /proc/$$/fd) then
+    set _sp_lsof = "ls -l /proc/$$/fd"
+else
+    which lsof > /dev/null
+    if ($? == 0) then
+        set _sp_lsof = "lsof -p $$"
+    endif
+endif
+
+# filter this script out of list of open files
+if ( $?_sp_lsof ) then
+    set _sp_source_file = `$_sp_lsof | sed -e 's/^[^/]*//' | grep "/setup-env.csh"`
+endif
+
+# This script is in $SPACK_ROOT/share/spack; get the root with dirname
+if ($?_sp_source_file) then
+    set _sp_share_spack = `dirname "$_sp_source_file"`
+    set _sp_share = `dirname "$_sp_share_spack"`
+    setenv SPACK_ROOT `dirname "$_sp_share"`
+endif
+
 if (! $?SPACK_ROOT) then
-    # figure out a command to list open files
-    if (-d /proc/$$/fd) then
-        set _sp_lsof = "ls -l /proc/$$/fd"
-    else
-        which lsof > /dev/null
-        if ($? == 0) then
-            set _sp_lsof = "lsof -p $$"
-        endif
-    endif
-
-    # filter this script out of list of open files
-    if ( $?_sp_lsof ) then
-        set _sp_source_file = `$_sp_lsof | sed -e 's/^[^/]*//' | grep "/setup-env.csh"`
-    endif
-
-    # This script is in $SPACK_ROOT/share/spack; get the root with dirname
-    if ($?_sp_source_file) then
-        set _sp_share_spack = `dirname "$_sp_source_file"`
-        set _sp_share = `dirname "$_sp_share_spack"`
-        setenv SPACK_ROOT `dirname "$_sp_share"`
-    endif
-
-    if (! $?SPACK_ROOT) then
-        echo "==> Error: setup-env.csh couldn't figure out where spack lives."
-        echo "    Set SPACK_ROOT to the root of your spack installation and try again."
-        exit 1
-    endif
+    echo "==> Error: setup-env.csh couldn't figure out where spack lives."
+    echo "    Set SPACK_ROOT to the root of your spack installation and try again."
+    exit 1
 endif
 
 # Command aliases point at separate source files

--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -648,7 +648,7 @@ function spack_pathadd -d "Add path to specified variable (defaults to PATH)"
         # passed to regular expression matching (`string match -r`)
         set -l _a "$pa_oldvalue"
 
-        # skip path if it is already contained in the variable
+        # skip path if it is already the first in the variable
         # note spaces in regular expression: we're matching to a space delimited
         # list of paths
         if not echo $_a | string match -q -r "^$pa_new_path *"

--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -651,7 +651,7 @@ function spack_pathadd -d "Add path to specified variable (defaults to PATH)"
         # skip path if it is already contained in the variable
         # note spaces in regular expression: we're matching to a space delimited
         # list of paths
-        if not echo $_a | string match -q -r " *$pa_new_path *"
+        if not echo $_a | string match -q -r "^$pa_new_path *"
             if test -n "$pa_oldvalue"
                 set $pa_varname $pa_new_path $pa_oldvalue
             else

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -214,9 +214,9 @@ _spack_pathadd() {
     # Do the actual prepending here.
     eval "_pa_oldvalue=\${${_pa_varname}:-}"
 
-    _pa_canonical=":$_pa_oldvalue:"
+    _pa_canonical="$_pa_oldvalue:"
     if [ -d "$_pa_new_path" ] && \
-       [ "${_pa_canonical#*:${_pa_new_path}:}" = "${_pa_canonical}" ];
+       [ "${_pa_canonical#$_pa_new_path:}" = "$_pa_canonical" ];
     then
         if [ -n "$_pa_oldvalue" ]; then
             eval "export $_pa_varname=\"$_pa_new_path:$_pa_oldvalue\""


### PR DESCRIPTION
Fix #40901.

Always prepend `spack/bin` to `PATH`, unless it's already the first.

Before, most setup-env scripts didn't prepend `spack/bin` if it is already found *somewhere* in it. This was an issue when going back and forth between two different spack instances.

Also, this PR also fixes `SPACK_ROOT`  in setup-env **csh** that was not properly updated.

Note: I think there may be other side effects when going back and forth, like modules, but for now this is less critical to me.