### PR TITLE
buildcache push --oci-output-digests <file>

### DIFF
--- a/lib/spack/spack/oci/image.py
+++ b/lib/spack/spack/oci/image.py
@@ -86,7 +86,12 @@ class ImageReference:
     __slots__ = ["domain", "name", "tag", "digest"]
 
     def __init__(
-        self, *, domain: str, name: str, tag: str = "latest", digest: Optional[Digest] = None
+        self,
+        *,
+        domain: str,
+        name: str,
+        tag: Optional[str] = "latest",
+        digest: Optional[Digest] = None,
     ):
         self.domain = domain
         self.name = name
@@ -163,6 +168,9 @@ class ImageReference:
 
     def with_tag(self, tag: str) -> "ImageReference":
         return ImageReference(domain=self.domain, name=self.name, tag=tag, digest=self.digest)
+
+    def without_tag(self) -> "ImageReference":
+        return ImageReference(domain=self.domain, name=self.name, tag=None, digest=self.digest)
 
     def uploads_url(self, digest: Optional[Digest] = None) -> str:
         url = f"https://{self.domain}/v2/{self.name}/blobs/uploads/"

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -571,7 +571,7 @@ _spack_buildcache() {
 _spack_buildcache_push() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -f --force --allow-root -a --unsigned -u --key -k --update-index --rebuild-index --spec-file --only --fail-fast --base-image -j --jobs"
+        SPACK_COMPREPLY="-h --help -f --force --allow-root -a --unsigned -u --key -k --update-index --rebuild-index --spec-file --only --fail-fast --base-image --oci-output-digests -j --jobs"
     else
         _mirrors
     fi
@@ -580,7 +580,7 @@ _spack_buildcache_push() {
 _spack_buildcache_create() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -f --force --allow-root -a --unsigned -u --key -k --update-index --rebuild-index --spec-file --only --fail-fast --base-image -j --jobs"
+        SPACK_COMPREPLY="-h --help -f --force --allow-root -a --unsigned -u --key -k --update-index --rebuild-index --spec-file --only --fail-fast --base-image --oci-output-digests -j --jobs"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -696,7 +696,7 @@ complete -c spack -n '__fish_spack_using_command buildcache' -s h -l help -f -a 
 complete -c spack -n '__fish_spack_using_command buildcache' -s h -l help -d 'show this help message and exit'
 
 # spack buildcache push
-set -g __fish_spack_optspecs_spack_buildcache_push h/help f/force a/allow-root u/unsigned k/key= update-index spec-file= only= fail-fast base-image= j/jobs=
+set -g __fish_spack_optspecs_spack_buildcache_push h/help f/force a/allow-root u/unsigned k/key= update-index spec-file= only= fail-fast base-image= oci-output-digests= j/jobs=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 1 buildcache push' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command buildcache push' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache push' -s h -l help -d 'show this help message and exit'
@@ -718,11 +718,13 @@ complete -c spack -n '__fish_spack_using_command buildcache push' -l fail-fast -
 complete -c spack -n '__fish_spack_using_command buildcache push' -l fail-fast -d 'stop pushing on first failure (default is best effort)'
 complete -c spack -n '__fish_spack_using_command buildcache push' -l base-image -r -f -a base_image
 complete -c spack -n '__fish_spack_using_command buildcache push' -l base-image -r -d 'specify the base image for the buildcache. '
+complete -c spack -n '__fish_spack_using_command buildcache push' -l oci-output-digests -r -f -a oci_output_digests
+complete -c spack -n '__fish_spack_using_command buildcache push' -l oci-output-digests -r -d 'file where uploaded OCI image digests should be logged'
 complete -c spack -n '__fish_spack_using_command buildcache push' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command buildcache push' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
 
 # spack buildcache create
-set -g __fish_spack_optspecs_spack_buildcache_create h/help f/force a/allow-root u/unsigned k/key= update-index spec-file= only= fail-fast base-image= j/jobs=
+set -g __fish_spack_optspecs_spack_buildcache_create h/help f/force a/allow-root u/unsigned k/key= update-index spec-file= only= fail-fast base-image= oci-output-digests= j/jobs=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 1 buildcache create' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command buildcache create' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache create' -s h -l help -d 'show this help message and exit'
@@ -744,6 +746,8 @@ complete -c spack -n '__fish_spack_using_command buildcache create' -l fail-fast
 complete -c spack -n '__fish_spack_using_command buildcache create' -l fail-fast -d 'stop pushing on first failure (default is best effort)'
 complete -c spack -n '__fish_spack_using_command buildcache create' -l base-image -r -f -a base_image
 complete -c spack -n '__fish_spack_using_command buildcache create' -l base-image -r -d 'specify the base image for the buildcache. '
+complete -c spack -n '__fish_spack_using_command buildcache create' -l oci-output-digests -r -f -a oci_output_digests
+complete -c spack -n '__fish_spack_using_command buildcache create' -l oci-output-digests -r -d 'file where uploaded OCI image digests should be logged'
 complete -c spack -n '__fish_spack_using_command buildcache create' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command buildcache create' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
 


### PR DESCRIPTION
In case people want to use external tools like `cosign` to sign OCI manifests,
they need to know the manifest digests, which were currently unavailable

As a stop-gap until there's clarity on what type of signing we'll implement
in Spack itself, allow users to log uploaded manifest digests in a file

The advantage of this is that

1. External tools like `docker` and `skopeo` can validate the signature (Spack can't yet)
2. Signing by manifest digest instead of tag makes it impossible to sign the
   wrong manifest when two manifests with the same tag are pushed concurrently