### PR TITLE
hh-suite: fix cmake_args and simd instructions

### DIFF
--- a/var/spack/repos/builtin/packages/hh-suite/package.py
+++ b/var/spack/repos/builtin/packages/hh-suite/package.py
@@ -28,12 +28,13 @@ class HhSuite(CMakePackage):
     def cmake_args(self):
         args = []
         args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+        args.append(self.define("NATIVE_ARCH", False))
         if self.spec.satisfies("+mpi"):
             args.append("-DCHECK_MPI=1")
         else:
             args.append("-DCHECK_MPI=0")
         if "avx2" in self.spec.target:
             args.append("-DHAVE_AVX2=1")
-        elif "sse2" in self.spec.target:
-            args.append("-DHAVE_SSE2=1")
+        else:
+            args.append("-DHAVE_SSE2=1")  # required by hh-suite
         return args

--- a/var/spack/repos/builtin/packages/hh-suite/package.py
+++ b/var/spack/repos/builtin/packages/hh-suite/package.py
@@ -19,7 +19,6 @@ class HhSuite(CMakePackage):
 
     version("3.3.0", sha256="dd67f7f3bf601e48c9c0bc4cf1fbe3b946f787a808bde765e9436a48d27b0964")
 
-    variant("shared", default=False, description="Build shared library")
     variant("mpi", default=True, description="Enable MPI support")
 
     depends_on("cmake@2.8.12:", type="build")
@@ -27,7 +26,7 @@ class HhSuite(CMakePackage):
 
     def cmake_args(self):
         args = []
-        args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+        args.append(self.define("BUILD_SHARED_LIBS", False))
         args.append(self.define("NATIVE_ARCH", False))
         if self.spec.satisfies("+mpi"):
             args.append("-DCHECK_MPI=1")

--- a/var/spack/repos/builtin/packages/hh-suite/package.py
+++ b/var/spack/repos/builtin/packages/hh-suite/package.py
@@ -25,11 +25,7 @@ class HhSuite(CMakePackage):
         "simd",
         default="auto",
         description="SIMD instruction set",
-        values=(
-            "auto",
-            "SSE2",
-            "AVX2"
-        ),
+        values=("auto", "SSE2", "AVX2"),
         multi=False,
     )
 
@@ -40,7 +36,9 @@ class HhSuite(CMakePackage):
         args = []
         if "+shared" in self.spec:
             args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
-            args.append(self.define("CMAKE_EXE_LINKER_FLAGS", "-static -static-libgcc -static-libstdc++"))
+            args.append(
+                self.define("CMAKE_EXE_LINKER_FLAGS", "-static -static-libgcc -static-libstdc++")
+            )
             args.append(self.define("CMAKE_FIND_LIBRARY_SUFFIXES", ".a"))
         if "+mpi" in self.spec:
             args.append("-DCHECK_MPI=1")

--- a/var/spack/repos/builtin/packages/hh-suite/package.py
+++ b/var/spack/repos/builtin/packages/hh-suite/package.py
@@ -19,15 +19,38 @@ class HhSuite(CMakePackage):
 
     version("3.3.0", sha256="dd67f7f3bf601e48c9c0bc4cf1fbe3b946f787a808bde765e9436a48d27b0964")
 
+    variant("shared", default=False, description="Build shared library")
     variant("mpi", default=True, description="Enable MPI support")
+    variant(
+        "simd",
+        default="auto",
+        description="SIMD instruction set",
+        values=(
+            "auto",
+            "SSE2",
+            "AVX2"
+        ),
+        multi=False,
+    )
 
     depends_on("cmake@2.8.12:", type="build")
     depends_on("mpi", when="+mpi")
 
-    def build_args(self, spec, prefix):
+    def cmake_args(self):
         args = []
+        if "+shared" in self.spec:
+            args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+            args.append(self.define("CMAKE_EXE_LINKER_FLAGS", "-static -static-libgcc -static-libstdc++"))
+            args.append(self.define("CMAKE_FIND_LIBRARY_SUFFIXES", ".a"))
         if "+mpi" in self.spec:
             args.append("-DCHECK_MPI=1")
         else:
             args.append("-DCHECK_MPI=0")
+        simd = self.spec.variants["simd"].value
+        if simd == "auto":
+            if "avx2" in self.spec.target:
+                simd = "AVX2"
+            elif "sse2" in self.spec.target:
+                simd = "SSE2"
+        args.append("-DHAVE_{simd}=1")
         return args

--- a/var/spack/repos/builtin/packages/hh-suite/package.py
+++ b/var/spack/repos/builtin/packages/hh-suite/package.py
@@ -23,9 +23,9 @@ class HhSuite(CMakePackage):
     variant("mpi", default=True, description="Enable MPI support")
     variant(
         "simd",
-        default="auto",
+        default="AVX2",
         description="SIMD instruction set",
-        values=("auto", "SSE2", "AVX2"),
+        values=("SSE2", "AVX2"),
         multi=False,
     )
 
@@ -44,11 +44,5 @@ class HhSuite(CMakePackage):
             args.append("-DCHECK_MPI=1")
         else:
             args.append("-DCHECK_MPI=0")
-        simd = self.spec.variants["simd"].value
-        if simd == "auto":
-            if "avx2" in self.spec.target:
-                simd = "AVX2"
-            elif "sse2" in self.spec.target:
-                simd = "SSE2"
-        args.append("-DHAVE_{simd}=1")
+        args.append(f"-DHAVE_{self.spec.variants['simd'].value}=1")
         return args

--- a/var/spack/repos/builtin/packages/hh-suite/package.py
+++ b/var/spack/repos/builtin/packages/hh-suite/package.py
@@ -21,28 +21,19 @@ class HhSuite(CMakePackage):
 
     variant("shared", default=False, description="Build shared library")
     variant("mpi", default=True, description="Enable MPI support")
-    variant(
-        "simd",
-        default="AVX2",
-        description="SIMD instruction set",
-        values=("SSE2", "AVX2"),
-        multi=False,
-    )
 
     depends_on("cmake@2.8.12:", type="build")
     depends_on("mpi", when="+mpi")
 
     def cmake_args(self):
         args = []
-        if "+shared" in self.spec:
-            args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
-            args.append(
-                self.define("CMAKE_EXE_LINKER_FLAGS", "-static -static-libgcc -static-libstdc++")
-            )
-            args.append(self.define("CMAKE_FIND_LIBRARY_SUFFIXES", ".a"))
-        if "+mpi" in self.spec:
+        args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+        if self.spec.satisfies("+mpi"):
             args.append("-DCHECK_MPI=1")
         else:
             args.append("-DCHECK_MPI=0")
-        args.append(f"-DHAVE_{self.spec.variants['simd'].value}=1")
+        if "avx2" in self.spec.target:
+            args.append("-DHAVE_AVX2=1")
+        elif "sse2" in self.spec.target:
+            args.append("-DHAVE_SSE2=1")
         return args


### PR DESCRIPTION
* Add missing `shared` and `simd` variants
* Replace `build_args` with `cmake_args`

fixes #40918