### PR TITLE
Ensure global command line arguments end up in args like before

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -1023,7 +1023,7 @@ def finish_parse_and_run(parser, cmd_name, cmd, env_format_error):
     """Finish parsing after we know the command to run."""
     # add the found command to the parser and re-run then re-parse
     command = parser.add_command(cmd_name)
-    args, unknown = parser.parse_known_args(cmd)
+    args, unknown = parser.parse_known_args()
 
     # Now that we know what command this is and what its args are, determine
     # whether we can continue with a bad environment and raise if not.


### PR DESCRIPTION
Fixes a bug introduced in #17229.

Previously if you ran `spack --verbose command` the `args.verbose` option was
set accordingly in the sub-command, but with the recent changes all global
options are set  to defaults in sub commands ( `args.verbose == False`).

This was used in `spack install` to ensure that `spack --verbose install`
implied `spack install --verbose` too s.t. you wouldn't have to run `spack`
`--verbose install --verbose` -- this is relied on in Gitlab CI, which
currently shows no build logs.

I haven't checked if there are other cases where `args.<global option>` is used
in a sub command.

Maybe the global argument shouldn't be forwarded to sub commands at all, but
that's how it used to be, so let's continue to do that, cause there's no time
to fix it "properly" and the current state is definitely a regression.

