### PR TITLE
feat: add HEP cloud_pipeline stack

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -786,6 +786,29 @@ ml-darwin-aarch64-mps-build:
       job: ml-darwin-aarch64-mps-generate
 
 ########################################
+# High Energy Physics (HEP) - Linux x86_64 (CPU)
+########################################
+.hep:
+  extends: [ ".linux_x86_64_v3" ]
+  variables:
+    SPACK_CI_STACK_NAME: hep
+
+hep-generate:
+  extends: [ ".hep", ".generate-x86_64"]
+  image: ghcr.io/spack/ubuntu20.04-runner-amd64-gcc-11.4:2023.08.01
+
+hep-build:
+  extends: [ ".hep", ".build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: hep-generate
+    strategy: depend
+  needs:
+    - artifacts: True
+      job: hep-generate
+
+########################################
 # AWS ParallelCluster
 ########################################
 

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -795,7 +795,6 @@ ml-darwin-aarch64-mps-build:
 
 hep-generate:
   extends: [ ".hep", ".generate-x86_64"]
-  image: ghcr.io/spack/ubuntu20.04-runner-amd64-gcc-11.4:2023.08.01
 
 hep-build:
   extends: [ ".hep", ".build" ]

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -799,8 +799,6 @@ hep-generate:
 
 hep-build:
   extends: [ ".hep", ".build" ]
-  rules:
-    - when: never
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -798,6 +798,8 @@ hep-generate:
 
 hep-build:
   extends: [ ".hep", ".build" ]
+  rules:
+    - when: never
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -795,6 +795,7 @@ ml-darwin-aarch64-mps-build:
 
 hep-generate:
   extends: [ ".hep", ".generate-x86_64"]
+  image: ghcr.io/spack/ubuntu20.04-runner-amd64-gcc-11.4:2023.08.01
 
 hep-build:
   extends: [ ".hep", ".build" ]

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -795,6 +795,7 @@ ml-darwin-aarch64-mps-build:
 
 hep-generate:
   extends: [ ".hep", ".generate-x86_64"]
+  image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4:2024.03.01
 
 hep-build:
   extends: [ ".hep", ".build" ]

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -74,6 +74,7 @@ ci:
       - dealii
       - geant4
       - rocblas
+      - root
       build-job:
         tags: [ "spack", "huge" ]
         variables:

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -72,6 +72,7 @@ ci:
 
     - match:
       - dealii
+      - geant4
       - rocblas
       build-job:
         tags: [ "spack", "huge" ]
@@ -82,6 +83,7 @@ ci:
           KUBERNETES_MEMORY_REQUEST: 19G
 
     - match:
+      - acts
       - ecp-data-vis-sdk
       - intel-tbb
       - llvm-amdgpu
@@ -102,6 +104,7 @@ ci:
       - cuda
       - dray
       - ecp-data-vis-sdk
+      - gaudi
       - gcc
       - ginkgo
       - hdf5
@@ -144,7 +147,10 @@ ci:
           KUBERNETES_MEMORY_REQUEST: "9G"
 
     - match:
+      - dd4hep
       - hipblas
+      - qt-base
+      - rivet
       - rocfft
       - umpire
       build-job:

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -200,6 +200,7 @@ ci:
 
     - match:
       - parallelio
+      - sherpa
       build-job:
         tags: [ "spack", "medium" ]
         variables:

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -150,6 +150,7 @@ ci:
       - dd4hep
       - hipblas
       - qt-base
+      - qt-declarative
       - rivet
       - rocfft
       - umpire

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -40,7 +40,7 @@ spack:
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf +madgraph5amc +python +rivet -root # pythia8 and root circularly depend
   - rivet hepmc=3
   - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +oracle +postgres +pythia6 +pythia8 +python +r +roofit +root7 +shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
-  - sherpa +analysis +blackhat +fastjet +gzip +hepmc2 +hepmc3 +hepmc3root +hztool +lhapdf +lhole +openloops +pythia +python +recola +rivet +root +ufo
+  - sherpa +analysis -blackhat +fastjet +gzip +hepmc2 +hepmc3 +hepmc3root +hztool +lhapdf +lhole +openloops +pythia +python +recola +rivet +root +ufo
   - vecgeom +gdml +geant4 +root
   - xrootd +davix +http +krb5 +python +readline +scitokens-cpp
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -10,10 +10,40 @@ spack:
       require: '%gcc target=x86_64_v3'
       providers:
         blas: [openblas]
+        mpi: [mpich]
+      variants: +mpi
     binutils:
       variants: +ld +gold +headers +libiberty ~nls
     elfutils:
       variants: +bzip2 ~nls +xz
+    hdf5:
+      variants: +fortran +hl +shared
+    libfabric:
+      variants: fabrics=sockets,tcp,udp,rxm
+    libunwind:
+      variants: +pic +xz
+    openblas:
+      variants: threads=openmp
+    xz:
+      variants: +pic
+    mesa:
+      version: [21.3.8]
+    mpi:
+      require: mpich
+    mpich:
+      require: '~wrapperrpath ~hwloc'
+    ncurses:
+      require: '@6.3 +termlib'
+    tbb:
+      require: intel-tbb
+    boost:
+      version: [1.79.0]
+      variants: +atomic +chrono +container +date_time +exception +filesystem +graph
+        +iostreams +locale +log +math +mpi +multithreaded +program_options +random
+        +regex +serialization +shared +signals +stacktrace +system +test +thread +timer
+        cxxstd=17 visibility=global
+    libffi:
+      require: "@3.4.4"
     cuda:
       version: [11.8.0]
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -61,7 +61,7 @@ spack:
   - hepmc
   - hepmc3 +interfaces +protobuf +python +rootio
   - herwig3 +njet +vbfnlo
-  - lcio +examples +jar +rootdict
+  - lcio -examples +jar +rootdict  # Note: lcio +examples ^ncurses -termlib, which leads to conflicts
   - lhapdf +python
   - madgraph5amc
   - opendatadetector

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -47,6 +47,14 @@ spack:
     cuda:
       version: [11.8.0]
 
+    # Mark geant4 data as external to prevent wasting bandwidth on GB-scale files
+    geant4-data:
+      externals:
+        - spec: geant4-data@11.1.0
+          prefix: /usr
+        - spec: geant4-data@11.0.0
+          prefix: /usr
+
   specs:
   # CPU
   - acts +analysis +binaries +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +identification +podio +pythia8 +python +tgeo

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -25,11 +25,13 @@ spack:
   - edm4hep
   - fastjet
   - fjcontrib
+  - garfieldpp +examples
   - gaudi +aida +examples +heppdt +xercesc
   - geant4 +opengl +qt +threads +vtk
   - hepmc
   - hepmc3 +interface +protobuf +python +rootio
   - herwig3 +njet +vbfnlo
+  - lcio +examples +jar +rootdict
   - lhapdf +python
   - madgraph5amc
   - opendatadetector
@@ -37,10 +39,10 @@ spack:
   - py-uproot +lz4 +xrootd +zstd
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf +madgraph5amc +python +rivet -root # pythia8 and root circularly depend
   - rivet hepmc=3
-  - root +davix +dcache +examples +fftw +fits +fortran +gdml // TODO
-  - sherpa
-  - vecgeom
-  - xrootd
+  - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +oracle +postgres +pythia6 +pythia8 +python +r +roofit +root7 +shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
+  - sherpa +analysis +blackhat +fastjet +gzip +hepmc2 +hepmc3 +hepmc3root +hztool +lhapdf +lhole +openloops +pythia +python +recola +rivet +root +ufo
+  - vecgeom +gdml +geant4 +root
+  - xrootd +davix +http +krb5 +python +readline +scitokens-cpp
 
   ci:
     pipeline-gen:

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -1,0 +1,51 @@
+spack:
+  view: false
+
+  concretizer:
+    reuse: false
+    unify: false
+
+  packages:
+    all:
+      require: '%gcc target=x86_64_v3'
+      providers:
+        blas: [openblas]
+    binutils:
+      variants: +ld +gold +headers +libiberty ~nls
+    elfutils:
+      variants: +bzip2 ~nls +xz
+    cuda:
+      version: [11.8.0]
+
+  specs:
+  # CPU
+  - acts +analysis +binaries +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +identification +podio +pythia8 +python +tgeo
+  - dd4hep +ddalign +ddcad +ddcond +dddetectors +dddigi +ddeve +ddg4 +ddrec +edm4hep +hepmc3 +lcio +utilityapps +xercesc
+  - delphes +pythia8
+  - edm4hep
+  - fastjet
+  - fjcontrib
+  - gaudi +aida +examples +heppdt +xercesc
+  - geant4 +opengl +qt +threads +vtk
+  - hepmc
+  - hepmc3 +interface +protobuf +python +rootio
+  - herwig3 +njet +vbfnlo
+  - lhapdf +python
+  - madgraph5amc
+  - opendatadetector
+  - podio +rntuple +sio
+  - py-uproot +lz4 +xrootd +zstd
+  - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf +madgraph5amc +python +rivet -root # pythia8 and root circularly depend
+  - rivet hepmc=3
+  - root +davix +dcache +examples +fftw +fits +fortran +gdml // TODO
+  - sherpa
+  - vecgeom
+  - xrootd
+
+  ci:
+    pipeline-gen:
+    - build-job:
+        image: "ghcr.io/spack/ubuntu20.04-runner-amd64-gcc-11.4:2023.08.01"
+
+  cdash:
+    build-group: HEP

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -29,7 +29,7 @@ spack:
   - gaudi +aida +examples +heppdt +xercesc
   - geant4 +opengl +qt +threads +vtk
   - hepmc
-  - hepmc3 +interface +protobuf +python +rootio
+  - hepmc3 +interfaces +protobuf +python +rootio
   - herwig3 +njet +vbfnlo
   - lcio +examples +jar +rootdict
   - lhapdf +python

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -67,7 +67,6 @@ spack:
   - edm4hep
   - fastjet
   - fjcontrib
-  - garfieldpp +examples
   - gaudi +aida +examples +heppdt +xercesc ^gdb +python
   - geant4 +opengl +qt +threads ~vtk
   - hepmc

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -67,7 +67,7 @@ spack:
   - fjcontrib
   - garfieldpp +examples
   - gaudi +aida +examples +heppdt +xercesc
-  - geant4 +opengl +qt +threads +vtk
+  - geant4 +opengl +qt +threads ~vtk
   - hepmc
   - hepmc3 +interfaces +protobuf +python +rootio
   - herwig3 +njet +vbfnlo

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -81,7 +81,7 @@ spack:
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet -root # pythia8 and root circularly depend
   - rivet hepmc=3
   - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl ~oracle +postgres +pythia6 +pythia8 +python +r +roofit +root7 +shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
-  - sherpa +analysis -blackhat +fastjet +gzip +hepmc2 +hepmc3 +hepmc3root +hztool +lhapdf +lhole +openloops +pythia ~python ~recola +rivet +root +ufo
+  - sherpa +analysis -blackhat +fastjet +gzip +hepmc2 +hepmc3 +hepmc3root +hztool +lhapdf +lhole +openloops +pythia ~python ~recola ~rivet +root +ufo
   - vecgeom +gdml +geant4 +root
   - xrootd +davix +http +krb5 +python +readline +scitokens-cpp
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -15,7 +15,7 @@ spack:
     binutils:
       variants: +ld +gold +headers +libiberty ~nls
     elfutils:
-      variants: +bzip2 ~nls +xz
+      variants: ~nls
     hdf5:
       variants: +fortran +hl +shared
     libfabric:

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -79,7 +79,7 @@ spack:
   - py-uproot +lz4 +xrootd +zstd
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf +madgraph5amc +python +rivet -root # pythia8 and root circularly depend
   - rivet hepmc=3
-  - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +oracle +postgres +pythia6 +pythia8 +python +r +roofit +root7 +shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
+  - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl ~oracle +postgres +pythia6 +pythia8 +python +r +roofit +root7 +shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
   - sherpa +analysis -blackhat +fastjet +gzip +hepmc2 +hepmc3 +hepmc3root +hztool +lhapdf +lhole +openloops +pythia +python +recola +rivet +root +ufo
   - vecgeom +gdml +geant4 +root
   - xrootd +davix +http +krb5 +python +readline +scitokens-cpp

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -79,7 +79,7 @@ spack:
   - opendatadetector
   - podio +rntuple +sio
   - py-uproot +lz4 +xrootd +zstd
-  - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf +madgraph5amc +python +rivet -root # pythia8 and root circularly depend
+  - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet -root # pythia8 and root circularly depend
   - rivet hepmc=3
   - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl ~oracle +postgres +pythia6 +pythia8 +python +r +roofit +root7 +shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
   - sherpa +analysis -blackhat +fastjet +gzip +hepmc2 +hepmc3 +hepmc3root +hztool +lhapdf +lhole +openloops +pythia ~python +recola +rivet +root +ufo

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -81,7 +81,7 @@ spack:
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet -root # pythia8 and root circularly depend
   - rivet hepmc=3
   - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl ~oracle +postgres +pythia6 +pythia8 +python +r +roofit +root7 +shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
-  - sherpa +analysis -blackhat +fastjet +gzip +hepmc2 +hepmc3 +hepmc3root +hztool +lhapdf +lhole +openloops +pythia ~python +recola +rivet +root +ufo
+  - sherpa +analysis -blackhat +fastjet +gzip +hepmc2 +hepmc3 +hepmc3root +hztool +lhapdf +lhole +openloops +pythia ~python ~recola +rivet +root +ufo
   - vecgeom +gdml +geant4 +root
   - xrootd +davix +http +krb5 +python +readline +scitokens-cpp
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -3,7 +3,7 @@ spack:
 
   concretizer:
     reuse: false
-    unify: false
+    unify: when_possible
 
   packages:
     all:

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -52,6 +52,8 @@ spack:
     # Mark geant4 data as external to prevent wasting bandwidth on GB-scale files
     geant4-data:
       externals:
+        - spec: geant4-data@11.2.0
+          prefix: /usr
         - spec: geant4-data@11.1.0
           prefix: /usr
         - spec: geant4-data@11.0.0

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -16,6 +16,8 @@ spack:
       variants: +ld +gold +headers +libiberty ~nls
     elfutils:
       variants: ~nls
+    gdb:
+      version: [14.1]
     hdf5:
       variants: +fortran +hl +shared
     libfabric:

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -82,7 +82,7 @@ spack:
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf +madgraph5amc +python +rivet -root # pythia8 and root circularly depend
   - rivet hepmc=3
   - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl ~oracle +postgres +pythia6 +pythia8 +python +r +roofit +root7 +shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
-  - sherpa +analysis -blackhat +fastjet +gzip +hepmc2 +hepmc3 +hepmc3root +hztool +lhapdf +lhole +openloops +pythia +python +recola +rivet +root +ufo
+  - sherpa +analysis -blackhat +fastjet +gzip +hepmc2 +hepmc3 +hepmc3root +hztool +lhapdf +lhole +openloops +pythia ~python +recola +rivet +root +ufo
   - vecgeom +gdml +geant4 +root
   - xrootd +davix +http +krb5 +python +readline +scitokens-cpp
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -82,6 +82,7 @@ spack:
   - rivet hepmc=3
   - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl ~oracle +postgres +pythia6 +pythia8 +python +r +roofit +root7 +shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
   - sherpa +analysis -blackhat +fastjet +gzip +hepmc2 +hepmc3 +hepmc3root +hztool +lhapdf +lhole +openloops +pythia ~python ~recola ~rivet +root +ufo
+  - thepeg ~rivet
   - vecgeom +gdml +geant4 +root
   - xrootd +davix +http +krb5 +python +readline +scitokens-cpp
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -68,7 +68,7 @@ spack:
   - fastjet
   - fjcontrib
   - garfieldpp +examples
-  - gaudi +aida +examples +heppdt +xercesc
+  - gaudi +aida +examples +heppdt +xercesc ^gdb +python
   - geant4 +opengl +qt +threads ~vtk
   - hepmc
   - hepmc3 +interfaces +protobuf +python +rootio

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -80,7 +80,7 @@ spack:
   - py-uproot +lz4 +xrootd +zstd
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet -root # pythia8 and root circularly depend
   - rivet hepmc=3
-  - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl ~oracle +postgres +pythia6 +pythia8 +python +r +roofit +root7 +shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
+  - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl ~oracle +postgres +pythia6 +pythia8 +python +r +roofit +root7 ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
   - sherpa +analysis -blackhat +fastjet +gzip +hepmc2 +hepmc3 +hepmc3root +hztool +lhapdf +lhole +openloops +pythia ~python ~recola ~rivet +root +ufo
   - thepeg ~rivet
   - vecgeom +gdml +geant4 +root

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -80,7 +80,7 @@ spack:
   - py-uproot +lz4 +xrootd +zstd
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet -root # pythia8 and root circularly depend
   - rivet hepmc=3
-  - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl ~oracle +postgres +pythia6 +pythia8 +python +r +roofit +root7 ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
+  - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl ~oracle ~postgres +pythia6 +pythia8 +python +r +roofit +root7 ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
   - sherpa +analysis -blackhat +fastjet +gzip +hepmc2 +hepmc3 +hepmc3root +hztool +lhapdf +lhole +openloops +pythia ~python ~recola ~rivet +root +ufo
   - thepeg ~rivet
   - vecgeom +gdml +geant4 +root

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -72,7 +72,7 @@ spack:
   - hepmc
   - hepmc3 +interfaces +protobuf +python +rootio
   - herwig3 +njet +vbfnlo
-  - lcio -examples +jar +rootdict  # Note: lcio +examples ^ncurses -termlib, which leads to conflicts
+  - lcio -examples ~jar +rootdict  # Note: lcio +examples ^ncurses -termlib, which leads to conflicts
   - lhapdf +python
   - madgraph5amc
   - opendatadetector

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -71,7 +71,7 @@ spack:
   - geant4 +opengl +qt +threads ~vtk
   - hepmc
   - hepmc3 +interfaces +protobuf +python +rootio
-  - herwig3 +njet +vbfnlo
+  #- herwig3 +njet +vbfnlo  # Note: herwig3 fails to find evtgen
   - lcio -examples ~jar +rootdict  # Note: lcio +examples ^ncurses -termlib, which leads to conflicts
   - lhapdf +python
   - madgraph5amc

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -11,47 +11,16 @@ spack:
       providers:
         blas: [openblas]
         mpi: [mpich]
+        tbb: [intel-tbb]
       variants: +mpi
-    binutils:
-      variants: +ld +gold +headers +libiberty ~nls
-    elfutils:
-      variants: ~nls
-    gdb:
-      version: [14.1]
-    hdf5:
-      variants: +fortran +hl +shared
-    libfabric:
-      variants: fabrics=sockets,tcp,udp,rxm
-    libunwind:
-      variants: +pic +xz
-    openblas:
-      variants: threads=openmp
-    xz:
-      variants: +pic
-    mesa:
-      version: [21.3.8]
-    mpi:
-      require: mpich
-    mpich:
-      require: '~wrapperrpath ~hwloc'
-    ncurses:
-      require: '@6.3 +termlib'
-    tbb:
-      require: intel-tbb
-    boost:
-      version: [1.79.0]
-      variants: +atomic +chrono +container +date_time +exception +filesystem +graph
-        +iostreams +locale +log +math +mpi +multithreaded +program_options +random
-        +regex +serialization +shared +signals +stacktrace +system +test +thread +timer
-        cxxstd=17 visibility=global
-    libffi:
-      require: "@3.4.4"
-    cuda:
-      version: [11.8.0]
 
     # Mark geant4 data as external to prevent wasting bandwidth on GB-scale files
     geant4-data:
       externals:
+        - spec: geant4-data@11.3.0
+          prefix: /usr
+        - spec: geant4-data@11.2.2
+          prefix: /usr
         - spec: geant4-data@11.2.0
           prefix: /usr
         - spec: geant4-data@11.1.0
@@ -61,13 +30,13 @@ spack:
 
   specs:
   # CPU
-  - acts +analysis +binaries +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +identification +podio +pythia8 +python +tgeo
+  - acts +analysis +binaries +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +podio +pythia8 +python +tgeo
   - dd4hep +ddalign +ddcad +ddcond +dddetectors +dddigi +ddeve +ddg4 +ddrec +edm4hep +hepmc3 +lcio +utilityapps +xercesc
   - delphes +pythia8
   - edm4hep
   - fastjet
   - fjcontrib
-  - gaudi +aida +examples +heppdt +xercesc ^gdb +python
+  - gaudi +aida +examples +heppdt +xercesc
   - geant4 +opengl +qt +threads ~vtk
   - hepmc
   - hepmc3 +interfaces +protobuf +python +rootio
@@ -89,7 +58,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: "ghcr.io/spack/ubuntu20.04-runner-amd64-gcc-11.4:2023.08.01"
+        image: "ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4:2024.03.01"
 
   cdash:
     build-group: HEP

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -50,7 +50,7 @@ spack:
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet -root # pythia8 and root circularly depend
   - rivet hepmc=3
   - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl ~postgres +pythia8 +python +r +roofit +root7 ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
-  - sherpa +analysis -blackhat +fastjet +gzip +hepmc2 +hepmc3 +hepmc3root +hztool +lhapdf +lhole +openloops +pythia ~python ~recola ~rivet +root +ufo
+  - sherpa +analysis -blackhat +gzip +hepmc3 +hepmc3root +lhapdf +lhole +openloops +pythia ~python ~recola ~rivet +root +ufo
   - thepeg ~rivet
   - vecgeom +gdml +geant4 +root
   - xrootd +davix +http +krb5 +python +readline +scitokens-cpp

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -36,7 +36,7 @@ spack:
   - edm4hep
   - fastjet
   - fjcontrib
-  - gaudi +aida +examples +heppdt +xercesc ^gdb +python
+  - gaudi +aida +examples +heppdt +xercesc ^gdb +debuginfod +python
   - geant4 +opengl +qt +threads ~vtk ^[virtuals=qmake] qt
   - hepmc
   - hepmc3 +interfaces +protobuf +python +rootio

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -30,14 +30,14 @@ spack:
 
   specs:
   # CPU
-  - acts +analysis +binaries +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +podio +pythia8 +python +tgeo
+  - acts +analysis +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +podio +pythia8 +python +tgeo
   - dd4hep +ddalign +ddcad +ddcond +dddetectors +dddigi +ddeve +ddg4 +ddrec +edm4hep +hepmc3 +lcio +utilityapps +xercesc
   - delphes +pythia8
   - edm4hep
   - fastjet
   - fjcontrib
   - gaudi +aida +examples +heppdt +xercesc
-  - geant4 +opengl +qt +threads ~vtk
+  - geant4 +opengl +qt +threads ~vtk ^[virtuals=qmake] qt
   - hepmc
   - hepmc3 +interfaces +protobuf +python +rootio
   #- herwig3 +njet +vbfnlo  # Note: herwig3 fails to find evtgen
@@ -49,7 +49,7 @@ spack:
   - py-uproot +lz4 +xrootd +zstd
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet -root # pythia8 and root circularly depend
   - rivet hepmc=3
-  - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl ~oracle ~postgres +pythia6 +pythia8 +python +r +roofit +root7 ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
+  - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl ~postgres +pythia8 +python +r +roofit +root7 ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
   - sherpa +analysis -blackhat +fastjet +gzip +hepmc2 +hepmc3 +hepmc3root +hztool +lhapdf +lhole +openloops +pythia ~python ~recola ~rivet +root +ufo
   - thepeg ~rivet
   - vecgeom +gdml +geant4 +root

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -36,7 +36,7 @@ spack:
   - edm4hep
   - fastjet
   - fjcontrib
-  - gaudi +aida +examples +heppdt +xercesc
+  - gaudi +aida +examples +heppdt +xercesc ^gdb +python
   - geant4 +opengl +qt +threads ~vtk ^[virtuals=qmake] qt
   - hepmc
   - hepmc3 +interfaces +protobuf +python +rootio

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -49,7 +49,7 @@ spack:
   - py-uproot +lz4 +xrootd +zstd
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet -root # pythia8 and root circularly depend
   - rivet hepmc=3
-  - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl ~postgres +pythia8 +python +r +roofit +root7 ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
+  - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl ~postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
   - sherpa +analysis -blackhat +gzip +hepmc3 +hepmc3root +lhapdf +lhole +openloops +pythia ~python ~recola ~rivet +root +ufo
   - thepeg ~rivet
   - vecgeom +gdml +geant4 +root

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -71,7 +71,7 @@ spack:
   - geant4 +opengl +qt +threads ~vtk
   - hepmc
   - hepmc3 +interfaces +protobuf +python +rootio
-  - herwig3 +njet +vbfnlo
+  - herwig3 ~evtgen +njet +vbfnlo
   - lcio -examples ~jar +rootdict  # Note: lcio +examples ^ncurses -termlib, which leads to conflicts
   - lhapdf +python
   - madgraph5amc

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -30,7 +30,7 @@ spack:
 
   specs:
   # CPU
-  - acts +analysis +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +podio +pythia8 +python +tgeo
+  - acts +analysis +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +podio +pythia8 +python +tgeo cxxstd=20
   - dd4hep +ddalign +ddcad +ddcond +dddetectors +dddigi +ddeve +ddg4 +ddrec +edm4hep +hepmc3 +lcio +utilityapps +xercesc
   - delphes +pythia8
   - edm4hep

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -71,7 +71,7 @@ spack:
   - geant4 +opengl +qt +threads ~vtk
   - hepmc
   - hepmc3 +interfaces +protobuf +python +rootio
-  - herwig3 ~evtgen +njet +vbfnlo
+  - herwig3 +njet +vbfnlo
   - lcio -examples ~jar +rootdict  # Note: lcio +examples ^ncurses -termlib, which leads to conflicts
   - lhapdf +python
   - madgraph5amc

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -47,10 +47,10 @@ spack:
   - opendatadetector
   - podio +rntuple +sio
   - py-uproot +lz4 +xrootd +zstd
-  - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet -root # pythia8 and root circularly depend
+  - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet ~root # pythia8 and root circularly depend
   - rivet hepmc=3
   - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl ~postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
-  - sherpa +analysis -blackhat +gzip +hepmc3 +hepmc3root +lhapdf +lhole +openloops +pythia ~python ~recola ~rivet +root +ufo
+  - sherpa +analysis ~blackhat +gzip +hepmc3 +hepmc3root +lhapdf +lhole +openloops +pythia ~python ~recola ~rivet +root +ufo
   - thepeg ~rivet
   - vecgeom +gdml +geant4 +root
   - xrootd +davix +http +krb5 +python +readline +scitokens-cpp

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -101,7 +101,6 @@ class Dd4hep(CMakePackage):
     with when("+ddeve"):
         depends_on("root @6.08: +x +opengl")
         depends_on("root @:6.27", when="@:1.23")
-        depends_on("root +root7", when="@1.24: ^root@6.27:")  # DDEve_Interface needs ROOT::ROOTGeomViewer
         conflicts("^root ~webgui", when="^root@6.28:")
         # For DD4hep >= 1.24, DDEve_Interface needs ROOT::ROOTGeomViewer only if ROOT >= 6.27
         requires("^root +root7 +webgui", when="@1.24: ^root @6.27:")

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -101,6 +101,7 @@ class Dd4hep(CMakePackage):
     with when("+ddeve"):
         depends_on("root @6.08: +x +opengl")
         depends_on("root @:6.27", when="@:1.23")
+        depends_on("root +root7", when="@1.24: ^root@6.27:")  # DDEve_Interface needs ROOT::ROOTGeomViewer
         conflicts("^root ~webgui", when="^root@6.28:")
         # For DD4hep >= 1.24, DDEve_Interface needs ROOT::ROOTGeomViewer only if ROOT >= 6.27
         requires("^root +root7 +webgui", when="@1.24: ^root @6.27:")

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -138,6 +138,11 @@ class Gaudi(CMakePackage):
     # The Intel VTune dependency is taken aside because it requires a license
     depends_on("intel-parallel-studio -mpi +vtune", when="+vtune")
 
+    def patch(self):
+        # ensure an empty pytest.ini is present to prevent finding one
+        # accidentally in a higher directory than the stage directory
+        touch("pytest.ini")
+
     def cmake_args(self):
         args = [
             # Note: gaudi only builds examples when testing enabled


### PR DESCRIPTION
This PR adds a high energy physics (HEP) cloud pipeline stack. The goal is to include at least the core packages in HEP, to ensure they are tested when the underlying dependencies are modified or updated. For that reason, many of the variants have been enabled, even if they are not enabled by default.

At this point it includes the following packages, but clearly could include a lot more (snapshot updated 2024-04-17):
  - acts +analysis +binaries +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +identification +podio +pythia8 +python +tgeo
  - dd4hep +ddalign +ddcad +ddcond +dddetectors +dddigi +ddeve +ddg4 +ddrec +edm4hep +hepmc3 +lcio +utilityapps +xercesc
  - delphes +pythia8
  - edm4hep
  - fastjet
  - fjcontrib
  - gaudi +aida +examples +heppdt +xercesc ^gdb +python
  - geant4 +opengl +qt +threads ~vtk
  - hepmc
  - hepmc3 +interfaces +protobuf +python +rootio
  - herwig3 +njet +vbfnlo
  - lcio -examples +jar +rootdict  # Note: lcio +examples ^ncurses -termlib, which leads to conflicts
  - lhapdf +python
  - madgraph5amc
  - opendatadetector
  - podio +rntuple +sio
  - py-uproot +lz4 +xrootd +zstd
  - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet -root # pythia8 and root circularly depend
  - rivet hepmc=3
  - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl ~oracle +postgres +pythia6 +pythia8 +python +r +roofit +root7 +shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
  - sherpa +analysis -blackhat +fastjet +gzip +hepmc2 +hepmc3 +hepmc3root +hztool +lhapdf +lhole +openloops +pythia ~python ~recola ~rivet +root +ufo
  - vecgeom +gdml +geant4 +root
  - xrootd +davix +http +krb5 +python +readline +scitokens-cpp