### PR TITLE
Fix bug in `which` introduced in #37762

### DIFF
--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -330,8 +330,11 @@ def which_string(*args, **kwargs):
         for candidate_item in candidate_items:
             for directory in search_paths:
                 exe = directory / candidate_item
-                if exe.is_file() and os.access(str(exe), os.X_OK):
-                    return str(exe)
+                try:
+                    if exe.is_file() and os.access(str(exe), os.X_OK):
+                        return str(exe)
+                except OSError:
+                    pass
 
     if required:
         raise CommandNotFoundError("spack requires '%s'. Make sure it is in your path." % args[0])


### PR DESCRIPTION
`Path.is_file` can throw while `os.path.isfile` does not, which wasn't ... caught in review of #37762.