### PR TITLE
tutorial pipeline: force gcc@12.3.0

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -18,7 +18,7 @@ spack:
         - hdf5+hl+mpi ^mpich
         - trilinos
         - trilinos +hdf5 ^hdf5+hl+mpi ^mpich
-        - gcc@12
+        - gcc@12.3.0
         - mpileaks
         - lmod
         - macsio@1.1+scr ^scr@2.0.0~fortran ^silo~fortran ^hdf5~fortran


### PR DESCRIPTION
Looks like we built gcc@12.1.0 (dunno why)

Edit: I got that wrong, we are building 12.3.0 already. But this PR can't hurt cause we have to keep it in sync with ubuntu's toolchain.
