### PR TITLE
julia: constrain patchelf version

### DIFF
--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -163,7 +163,8 @@ class Julia(MakefilePackage):
     )
 
     # patchelf 0.13 is required because the rpath patch uses --add-rpath
-    depends_on("patchelf@0.13:", type="build")
+    # patchelf 0.18 breaks (at least) libjulia-internal.so
+    depends_on("patchelf@0.13:0.17", type="build")
     depends_on("perl", type="build")
     depends_on("libwhich", type="build")
     depends_on("python", type="build")

--- a/var/spack/repos/builtin/packages/patchelf/package.py
+++ b/var/spack/repos/builtin/packages/patchelf/package.py
@@ -19,7 +19,14 @@ class Patchelf(AutotoolsPackage):
     maintainers("haampie")
 
     version("0.18.0", sha256="64de10e4c6b8b8379db7e87f58030f336ea747c0515f381132e810dbf84a86e7")
-    version("0.17.2", sha256="20427b718dd130e4b66d95072c2a2bd5e17232e20dad58c1bea9da81fae330e0")
+    # patchelf 0.18 breaks libraries:
+    # https://github.com/spack/spack/issues/39252
+    # https://github.com/spack/spack/pull/40938
+    version(
+        "0.17.2",
+        sha256="20427b718dd130e4b66d95072c2a2bd5e17232e20dad58c1bea9da81fae330e0",
+        preferred=True,
+    )
     version("0.16.1", sha256="1a562ed28b16f8a00456b5f9ee573bb1af7c39c1beea01d94fc0c7b3256b0406")
     version("0.15.0", sha256="53a8d58ed4e060412b8fdcb6489562b3c62be6f65cee5af30eba60f4423bfa0f")
     version("0.14.5", sha256="113ada3f1ace08f0a7224aa8500f1fa6b08320d8f7df05ff58585286ec5faa6f")


### PR DESCRIPTION
patchelf@0.18 breaks (at least) `libjulea-internal.so`, leading to errors like:
```
$ julia --version
ERROR: Unable to load dependent library $SPACK/opt/spack/linux-centos8-x86_64_v3/gcc-12.3.0/julia-1.9.2-6hf5qx2q27jth2fkm6kgqmfdlhzzw6pl/bin/../lib/julia/libjulia-internal.so.1
Message:$SPACK/opt/spack/linux-centos8-x86_64_v3/gcc-12.3.0/julia-1.9.2-6hf5qx2q27jth2fkm6kgqmfdlhzzw6pl/bin/../lib/julia/libjulia-internal.so.1: ELF load command address/offset not properly aligned
```
Edit: Sounds a bit like #39252.