### PR TITLE
tutorial stack: update for changes to the basics section for SC23

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -8,11 +8,11 @@ spack:
   definitions:
   - gcc_system_packages:
     - matrix:
-      - - gmake
-        - gmake@4.3
-        - gmake@4.3 cflags=-O3
+      - - zlib-ng
+        - zlib-ng@2.0.7
+        - zlib-ng@2.0.7 cflags=-O3
         - tcl
-        - tcl ^gmake@4.3 cflags=-O3
+        - tcl ^zlib-ng@2.0.7 cflags=-O3
         - hdf5
         - hdf5~mpi
         - hdf5+hl+mpi ^mpich
@@ -24,10 +24,10 @@ spack:
         - macsio@1.1+scr ^scr@2.0.0~fortran ^silo~fortran ^hdf5~fortran
       - ['%gcc@11']
   - gcc_old_packages:
-    - gmake%gcc@10
+    - zlib-ng%gcc@10
   - clang_packages:
     - matrix:
-      - [gmake, tcl ^gmake@4.3]
+      - [zlib-ng, tcl ^zlib-ng@2.0.7]
       - ['%clang@14']
   - gcc_spack_built_packages:
     - matrix:


### PR DESCRIPTION
The change to use `gmake` in the basics section is incompatible with the link/run deps features demonstrated. I will be updating the tutorial section to match the new specs.