### PR TITLE
tcl: filter compiler wrappers to avoid pointing to Spack

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -21,6 +21,7 @@ spack:
         - gcc@12.3.0
         - mpileaks
         - lmod@8.7.18
+        - environment-modules
         - macsio@1.1+scr ^scr@2.0.0~fortran ^silo~fortran ^hdf5~fortran
       - ['%gcc@11']
   - gcc_old_packages:

--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -137,6 +137,9 @@ class EnvironmentModules(Package):
                 ]
             )
 
+        if self.spec.satisfies("@4.1:"):
+            config_args.append(f"--with-pager={str(self.spec['less'].prefix.bin.less)}")
+
         configure(*config_args)
         make()
         make("install")

--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -59,13 +59,15 @@ class EnvironmentModules(Package):
 
     variant("X", default=True, description="Build with X functionality")
 
-    depends_on("autoconf", type="build", when="@main")
-    depends_on("automake", type="build", when="@main")
-    depends_on("libtool", type="build", when="@main")
-    depends_on("m4", type="build", when="@main")
-    depends_on("python", type="build", when="@main")
-    depends_on("py-sphinx@1.0:", type="build", when="@main")
-    depends_on("gzip", type="build", when="@main")
+    depends_on("less", type="build")
+    with when("@main"):
+        depends_on("autoconf", type="build")
+        depends_on("automake", type="build")
+        depends_on("libtool", type="build")
+        depends_on("m4", type="build")
+        depends_on("python", type="build")
+        depends_on("py-sphinx@1.0:", type="build")
+        depends_on("gzip", type="build")
 
     # Dependencies:
     depends_on("tcl", type=("build", "link", "run"))

--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -59,7 +59,7 @@ class EnvironmentModules(Package):
 
     variant("X", default=True, description="Build with X functionality")
 
-    depends_on("less", type="build")
+    depends_on("less", type=("build", "run"), when="@4.1:")
     with when("@main"):
         depends_on("autoconf", type="build")
         depends_on("automake", type="build")

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -37,6 +37,8 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
 
     configure_directory = "unix"
 
+    filter_compiler_wrappers("tclConfig.sh", relative_root="lib")
+    
     def install(self, spec, prefix):
         with working_dir(self.build_directory):
             make("install")

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -38,7 +38,7 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
     configure_directory = "unix"
 
     filter_compiler_wrappers("tclConfig.sh", relative_root="lib")
-    
+
     def install(self, spec, prefix):
         with working_dir(self.build_directory):
             make("install")


### PR DESCRIPTION
Currently, within:
```
<tcl-prefix>/lib/tclConfig.sh
```
we have:
```
# C compiler to use for compilation.
TCL_CC='<path-to-build-time-spack>/spack/lib/spack/env/gcc/gcc'
```
This PR inserts the underlying compiler, which is better than before, but `tcl` is not yet really relocatable.