### PR TITLE
intel-oneapi-mkl: do not set __INTEL_POST_CFLAGS env variable

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -149,21 +149,6 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         else:
             return IntelOneApiStaticLibraryList(libs, system_libs)
 
-    def setup_run_environment(self, env):
-        super().setup_run_environment(env)
-
-        # Support RPATH injection to the library directories when the '-mkl' or '-qmkl'
-        # flag of the Intel compilers are used outside the Spack build environment. We
-        # should not try to take care of other compilers because the users have to
-        # provide the linker flags anyway and are expected to take care of the RPATHs
-        # flags too. We prefer the __INTEL_POST_CFLAGS/__INTEL_POST_FFLAGS flags over
-        # the PRE ones so that any other RPATHs provided by the users on the command
-        # line come before and take precedence over the ones we inject here.
-        for d in self._find_mkl_libs(self.spec.satisfies("+shared")).directories:
-            flag = "-Wl,-rpath,{0}".format(d)
-            env.append_path("__INTEL_POST_CFLAGS", flag, separator=" ")
-            env.append_path("__INTEL_POST_FFLAGS", flag, separator=" ")
-
     def setup_dependent_build_environment(self, env, dependent_spec):
         # Only if environment modifications are desired (default is +envmods)
         if self.spec.satisfies("+envmods"):


### PR DESCRIPTION
```
petsc configure breaks with spack change that now adds in __INTEL_POST_CFLAGS - as it rquires compilers not to print spurious warnings

ref: xsdk@pj02:~/spack$ ./bin/spack spec petsc~fortran~metis~hypre~hdf5 Input spec
--------------------------------
 -   petsc~fortran~hdf5~hypre~metis

Concretized
--------------------------------
[+]  petsc@3.20.1%oneapi@2022.2.0~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw~fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws+shared~strumpack~suite-sparse~sycl~tetgen~trilinos~valgrind build_system=generic clanguage=C memalign=none arch=linux-ubuntu20.04-skylake
[e]      ^diffutils@3.7%oneapi@2022.2.0 build_system=autotools arch=linux-ubuntu20.04-skylake
[+]      ^gmake@4.4.1%oneapi@2022.2.0~guile build_system=generic arch=linux-ubuntu20.04-skylake
[e]      ^intel-oneapi-mkl@2022.2.0%oneapi@2022.2.0~cluster+envmods~ilp64+shared build_system=generic mpi_family=none threads=none arch=linux-ubuntu20.04-skylake
[e]      ^intel-oneapi-mpi@2021.7.0%oneapi@2022.2.0+envmods~external-libfabric~generic-names~ilp64 build_system=generic arch=linux-ubuntu20.04-skylake
[e]      ^python@3.9.7%oneapi@2022.2.0+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=0d98e93,4c24573,ebdca64,f2fd060 arch=linux-ubuntu20.04-skylake

__INTEL_POST_CFLAGS=-Wl,-rpath,/opt/intel/oneapi/mkl/2022.2.0/lib/intel64; export __INTEL_POST_CFLAGS __INTEL_POST_FFLAGS=-Wl,-rpath,/opt/intel/oneapi/mkl/2022.2.0/lib/intel64; export __INTEL_POST_FFLAGS

Executing: /opt/intel/oneapi/mpi/2021.7.0/bin/mpiicc -E  -I/tmp/petsc-km5zdzsi/config.setCompilers  /tmp/petsc-km5zdzsi/config.setCompilers/conftest.c Possible ERROR while running preprocessor:exit code 0

stderr:
icx: warning: -Wl,-rpath,/opt/intel/oneapi/mkl/2022.2.0/lib/intel64: 'linker' input unused [-Wunused-command-line-argument]
```

Prior discussion at https://github.com/spack/spack/pull/35737#issuecomment-1796958712

Likely trigger for this change in spack: https://github.com/spack/spack/commit/e5f3ffc04fb7a1fea237226210b0cafc9246d0f2