### PR TITLE
Revert "defaults/modules.yaml: hide implicits"

### DIFF
--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -46,12 +46,10 @@ modules:
     tcl:
       all:
         autoload: direct
-      hide_implicits: true
 
     # Default configurations if lmod is enabled
     lmod:
       all:
         autoload: direct
-      hide_implicits: true
       hierarchy:
         - mpi


### PR DESCRIPTION
Reverts spack/spack#40906

Still the best combination of config option, but in practice unsupported

Closes https://github.com/spack/spack/issues/40940