### PR TITLE
Add symlinks for hdf5 library names when built in debug mode

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -715,11 +715,12 @@ class Hdf5(CMakePackage):
     def link_debug_libs(self):
         # When build_type is Debug, the hdf5 build appends _debug to all library names.
         # Dependents of hdf5 (netcdf-c etc.) can't handle those, thus make symlinks.
-        libs = find(self.prefix.lib, "libhdf5*_debug.*", recursive=False)
-        with working_dir(self.prefix.lib):
-            for lib in libs:
-                libname = os.path.split(lib)[1]
-                os.symlink(libname, libname.replace("_debug", ""))
+        if "build_type=Debug" in self.spec:
+            libs = find(self.prefix.lib, "libhdf5*_debug.*", recursive=False)
+            with working_dir(self.prefix.lib):
+                for lib in libs:
+                    libname = os.path.split(lib)[1]
+                    os.symlink(libname, libname.replace("_debug", ""))
 
     @property
     @llnl.util.lang.memoized

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -711,6 +711,16 @@ class Hdf5(CMakePackage):
                     if not os.path.exists(tgt_filename):
                         symlink(src_filename, tgt_filename)
 
+    @run_after("install")
+    def link_debug_libs(self):
+        # When build_type is Debug, the hdf5 build appends _debug to all library names.
+        # Dependents of hdf5 (netcdf-c etc.) can't handle those, thus make symlinks.
+        libs = find(self.prefix.lib, "libhdf5*_debug.*", recursive=False)
+        with working_dir(self.prefix.lib):
+            for lib in libs:
+                libname = os.path.split(lib)[1]
+                os.symlink(libname, libname.replace("_debug", ""))
+
     @property
     @llnl.util.lang.memoized
     def _output_version(self):


### PR DESCRIPTION
## Description

When hdf5 is built in debug mode (`build_type=Debug`), the library names all have a suffix `_debug`, for example:
```
libhdf5_debug.310.0.0.dylib
```
Dependents of hdf5 can't handle those library names, for example netcdf-c and ncview are all looking for `libhdf5.*`.

This PR fixes the problem by creating symlinks in the `lib` directory (without any path information to avoid any problems with binary caching).

Note. This was with `hdf5@1.14.0`. It's possible that earlier or later versions of the package don't add the suffix to the library names, in which case the bug fix isn't necessary (but it won't do anything bad either, the list `libs` will be empty).