### PR TITLE
py-macs3: adding zlib dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-macs3/package.py
+++ b/var/spack/repos/builtin/packages/py-macs3/package.py
@@ -25,4 +25,4 @@ class PyMacs3(PythonPackage):
     depends_on("py-cykhash@2", type=("build", "run"))
     depends_on("py-hmmlearn@0.3:", type=("build", "run"))
 
-    depends_on("zlib-ng")
+    depends_on("zlib-api")

--- a/var/spack/repos/builtin/packages/py-macs3/package.py
+++ b/var/spack/repos/builtin/packages/py-macs3/package.py
@@ -24,3 +24,5 @@ class PyMacs3(PythonPackage):
     depends_on("py-numpy@1.19:", type=("build", "run"))
     depends_on("py-cykhash@2", type=("build", "run"))
     depends_on("py-hmmlearn@0.3:", type=("build", "run"))
+
+    depends_on("zlib-ng")


### PR DESCRIPTION
This wasn't building for me as `gcc` wasn't finding `zlib.h` ... adding `zlib-ng` as a dependency.