### PR TITLE
env: compute env mods only for installed roots

### DIFF
--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -284,7 +284,7 @@ def test_env_modifications_error_on_activate(install_mockery, mock_fetch, monkey
 
     _, err = capfd.readouterr()
     assert "cmake-client had issues!" in err
-    assert "Warning: couldn't load runtime environment" in err
+    assert "Warning: could not load runtime environment" in err
 
 
 def test_activate_adds_transitive_run_deps_to_path(install_mockery, mock_fetch, monkeypatch):
@@ -502,12 +502,12 @@ def test_env_activate_broken_view(
     # test that Spack detects the missing package and fails gracefully
     with spack.repo.use_repositories(mock_custom_repository):
         wrong_repo = env("activate", "--sh", "test")
-        assert "Warning: couldn't load runtime environment" in wrong_repo
+        assert "Warning: could not load runtime environment" in wrong_repo
         assert "Unknown namespace: builtin.mock" in wrong_repo
 
     # test replacing repo fixes it
     normal_repo = env("activate", "--sh", "test")
-    assert "Warning: couldn't load runtime environment" not in normal_repo
+    assert "Warning: could not load runtime environment" not in normal_repo
     assert "Unknown namespace: builtin.mock" not in normal_repo
 
 

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -11,6 +11,7 @@ from llnl.util.lang import nullcontext
 
 import spack.build_environment
 import spack.config
+import spack.error
 import spack.spec
 import spack.util.environment as environment
 import spack.util.prefix as prefix


### PR DESCRIPTION
And improve the error message (load vs unload).

Of course you could have some uninstalled dependency too, but as long as
it doesn't implement `setup_run_environment` etc, I don't think it hurts
to attempt to load the root anyways, given that failure to do so is a
warning, not a fatal error.
