### PR TITLE
openfoam-org: fix for being able to build manually checked out repository

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -73,6 +73,7 @@ class OpenfoamOrg(Package):
     version("8", sha256="94ba11cbaaa12fbb5b356e01758df403ac8832d69da309a5d79f76f42eb008fc")
     version("7", sha256="12389cf092dc032372617785822a597aee434a50a62db2a520ab35ba5a7548b5")
     version("6", sha256="32a6af4120e691ca2df29c5b9bd7bc7a3e11208947f9bccf6087cfff5492f025")
+    version("5.x", git="https://github.com/OpenFOAM/OpenFOAM-5.x", branch="master")
     version("5.0", sha256="9057d6a8bb9fa18802881feba215215699065e0b3c5cdd0c0e84cb29c9916c89")
     version("4.1", sha256="2de18de64e7abdb1b649ad8e9d2d58b77a2b188fb5bcb6f7c2a038282081fd31")
     version("2.4.0", sha256="9529aa7441b64210c400c019dcb2e0410fcfd62a6f62d23b6c5994c4753c4465")

--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -73,7 +73,6 @@ class OpenfoamOrg(Package):
     version("8", sha256="94ba11cbaaa12fbb5b356e01758df403ac8832d69da309a5d79f76f42eb008fc")
     version("7", sha256="12389cf092dc032372617785822a597aee434a50a62db2a520ab35ba5a7548b5")
     version("6", sha256="32a6af4120e691ca2df29c5b9bd7bc7a3e11208947f9bccf6087cfff5492f025")
-    version("5.x", git="https://github.com/OpenFOAM/OpenFOAM-5.x", branch="master")
     version("5.0", sha256="9057d6a8bb9fa18802881feba215215699065e0b3c5cdd0c0e84cb29c9916c89")
     version("4.1", sha256="2de18de64e7abdb1b649ad8e9d2d58b77a2b188fb5bcb6f7c2a038282081fd31")
     version("2.4.0", sha256="9529aa7441b64210c400c019dcb2e0410fcfd62a6f62d23b6c5994c4753c4465")

--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -236,8 +236,24 @@ class OpenfoamOrg(Package):
         # to build correctly!
         parent = os.path.dirname(self.stage.source_path)
         original = os.path.basename(self.stage.source_path)
-        target = "OpenFOAM-{0}".format(self.version)
-        # Could also grep through etc/bashrc for WM_PROJECT_VERSION
+
+        # Grep for WM_PROJECT_VERSION in etc/bashrc
+        #   e.g. "export WM_PROJECT_VERSION=5.x"
+        #
+        # note: WM_PROJECT is assumed to be OpenFOAM and the project folder is assumed to
+        #       be "OpenFOAM-${WM_PROJECT_VERSION}"
+        target = None
+        with open(join_path(self.stage.source_path, "etc/bashrc"), "r") as bashrc_file:
+            import re
+
+            for line in bashrc_file.readlines():
+                m = re.match("export WM_PROJECT_VERSION=(.*)", line)
+                if m:
+                    target = f"OpenFOAM-{m.group(1)}"
+                    break
+        if target is None:
+            raise InstallError("Failed to infer projet directory name from build script.")
+
         with working_dir(parent):
             if original != target and not os.path.lexists(target):
                 os.rename(original, target)

--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -120,7 +120,7 @@ class OpenfoamOrg(Package):
         sha256="05d17e17f94e6fe8188a9c0b91ed34c9b62259414589d908c152a4c40fe6b7e2",
         when="@7",
     )
-    patch("50-etc.patch", when="@5.0:5.9")
+    patch("50-etc.patch", when="@5.0")
     patch("41-etc.patch", when="@4.1")
     patch("41-site.patch", when="@4.1:")
     patch("240-etc.patch", when="@:2.4.0")


### PR DESCRIPTION
I'm not an expert of the package and I see it is an old version, but I'm proposing this add since I addressed few requests by users asking for this specific old version.

I added this as new versions in spack because the package has few complex workaround for different versions on different repositories, and I found this to be easiest way to get the result.