### PR TITLE
info: improve coverage

### DIFF
--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -139,7 +139,7 @@ class VariantFormatter:
                     yield "    " + self.fmt % t
 
 
-def print_dependencies(pkg):
+def print_dependencies(pkg, args):
     """output build, link, and run package dependencies"""
 
     for deptype in ("build", "link", "run"):
@@ -152,7 +152,7 @@ def print_dependencies(pkg):
             color.cprint("    None")
 
 
-def print_detectable(pkg):
+def print_detectable(pkg, args):
     """output information on external detection"""
 
     color.cprint("")
@@ -180,7 +180,7 @@ def print_detectable(pkg):
         color.cprint("    False")
 
 
-def print_maintainers(pkg):
+def print_maintainers(pkg, args):
     """output package maintainers"""
 
     if len(pkg.maintainers) > 0:
@@ -189,7 +189,7 @@ def print_maintainers(pkg):
         color.cprint(section_title("Maintainers: ") + mnt)
 
 
-def print_phases(pkg):
+def print_phases(pkg, args):
     """output installation phases"""
 
     if hasattr(pkg.builder, "phases") and pkg.builder.phases:
@@ -201,7 +201,7 @@ def print_phases(pkg):
         color.cprint(phase_str)
 
 
-def print_tags(pkg):
+def print_tags(pkg, args):
     """output package tags"""
 
     color.cprint("")
@@ -213,7 +213,7 @@ def print_tags(pkg):
         color.cprint("    None")
 
 
-def print_tests(pkg):
+def print_tests(pkg, args):
     """output relevant build-time and stand-alone tests"""
 
     # Some built-in base packages (e.g., Autotools) define callback (e.g.,
@@ -407,12 +407,15 @@ def print_variants_by_name(pkg):
                 sys.stdout.write("\n")
 
 
-def print_variants(pkg):
+def print_variants(pkg, args):
     """output variants"""
-    print_variants_grouped_by_when(pkg)
+    if args.variants_by_name:
+        print_variants_by_name(pkg)
+    else:
+        print_variants_grouped_by_when(pkg)
 
 
-def print_versions(pkg):
+def print_versions(pkg, args):
     """output versions"""
 
     color.cprint("")
@@ -465,7 +468,7 @@ def print_versions(pkg):
                 color.cprint(line)
 
 
-def print_virtuals(pkg):
+def print_virtuals(pkg, args):
     """output virtual packages"""
 
     color.cprint("")
@@ -488,7 +491,7 @@ def print_virtuals(pkg):
         color.cprint("    None")
 
 
-def print_licenses(pkg):
+def print_licenses(pkg, args):
     """Output the licenses of the project."""
 
     color.cprint("")
@@ -523,17 +526,13 @@ def info(parser, args):
     if getattr(pkg, "homepage"):
         color.cprint(section_title("Homepage: ") + pkg.homepage)
 
-    _print_variants = (
-        print_variants_by_name if args.variants_by_name else print_variants_grouped_by_when
-    )
-
     # Now output optional information in expected order
     sections = [
         (args.all or args.maintainers, print_maintainers),
         (args.all or args.detectable, print_detectable),
         (args.all or args.tags, print_tags),
         (args.all or not args.no_versions, print_versions),
-        (args.all or not args.no_variants, _print_variants),
+        (args.all or not args.no_variants, print_variants),
         (args.all or args.phases, print_phases),
         (args.all or not args.no_dependencies, print_dependencies),
         (args.all or args.virtuals, print_virtuals),
@@ -542,6 +541,6 @@ def info(parser, args):
     ]
     for print_it, func in sections:
         if print_it:
-            func(pkg)
+            func(pkg, args)
 
     color.cprint("")

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -33,10 +33,11 @@ def print_buffer(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "pkg", ["openmpi", "trilinos", "boost", "python", "dealii", "xsdk"]  # a BundlePackage
+    "pkg", ["openmpi", "trilinos", "boost", "python", "dealii", "xsdk", "gasnet", "warpx"]
 )
-def test_it_just_runs(pkg):
-    info(pkg)
+@pytest.mark.parametrize("extra_args", [[], ["--variants-by-name"]])
+def test_it_just_runs(pkg, extra_args):
+    info(pkg, *extra_args)
 
 
 def test_info_noversion(mock_packages, print_buffer):
@@ -78,7 +79,8 @@ def test_is_externally_detectable(pkg_query, expected, parser, print_buffer):
         "gcc",  # This should ensure --test's c_names processing loop covered
     ],
 )
-def test_info_fields(pkg_query, parser, print_buffer):
+@pytest.mark.parametrize("extra_args", [[], ["--variants-by-name"]])
+def test_info_fields(pkg_query, extra_args, parser, print_buffer):
     expected_fields = (
         "Description:",
         "Homepage:",
@@ -91,7 +93,7 @@ def test_info_fields(pkg_query, parser, print_buffer):
         "Licenses:",
     )
 
-    args = parser.parse_args(["--all", pkg_query])
+    args = parser.parse_args(["--all", pkg_query] + extra_args)
     spack.cmd.info.info(parser, args)
 
     for text in expected_fields:


### PR DESCRIPTION
Tests didn't cover the new `--variants-by-name` parameter in #40998. Add some parameterization to hit that.

This changeset makes me think that the main section-printing loop in `spack info` isn't factored so well. It makes it difficult to pass different arguments to different helper functions.  I could break it out into if statements if folks think that would be cleaner.