### PR TITLE
gromacs et al: fix ^mkl pattern

### DIFF
--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -9,11 +9,10 @@ import platform
 import shutil
 from os.path import basename, dirname, isdir
 
-from llnl.util.filesystem import find_headers, find_libraries, join_path
+from llnl.util.filesystem import find_headers, find_libraries, join_path, mkdirp
 from llnl.util.link_tree import LinkTree
 
 from spack.directives import conflicts, variant
-from spack.package import mkdirp
 from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable
 
@@ -212,3 +211,7 @@ class IntelOneApiStaticLibraryList:
     @property
     def ld_flags(self):
         return "{0} {1}".format(self.search_flags, self.link_flags)
+
+
+#: Tuple of Intel math libraries, exported to packages
+INTEL_MATH_LIBRARIES = ("intel-mkl", "intel-oneapi-mkl", "intel-parallel-studio")

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -50,6 +50,7 @@ from spack.build_systems.msbuild import MSBuildPackage
 from spack.build_systems.nmake import NMakePackage
 from spack.build_systems.octave import OctavePackage
 from spack.build_systems.oneapi import (
+    INTEL_MATH_LIBRARIES,
     IntelOneApiLibraryPackage,
     IntelOneApiPackage,
     IntelOneApiStaticLibraryList,

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -153,8 +153,7 @@ class IntelMkl(IntelPackage):
         multi=False,
     )
 
-    provides("blas")
-    provides("lapack")
+    provides("blas", "lapack")
     provides("lapack@3.9.0", when="@2020.4")
     provides("lapack@3.7.0", when="@11.3")
     provides("scalapack")

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -126,8 +126,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
     provides("fftw-api@3")
     provides("scalapack", when="+cluster")
     provides("mkl")
-    provides("lapack")
-    provides("blas")
+    provides("lapack", "blas")
 
     @property
     def component_dir(self):

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -536,8 +536,7 @@ class IntelParallelStudio(IntelPackage):
     provides("ipp", when="+ipp")
 
     provides("mkl", when="+mkl")
-    provides("blas", when="+mkl")
-    provides("lapack", when="+mkl")
+    provides("blas", "lapack", when="+mkl")
     provides("scalapack", when="+mkl")
 
     provides("fftw-api@3", when="+mkl@professional.2017:")

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -791,7 +791,7 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage):
             # FFTW libraries are available and enable them by default.
             if "^fftw" in spec or "^cray-fftw" in spec or "^amdfftw" in spec:
                 args.append(self.define("FFT", "FFTW3"))
-            elif "^mkl" in spec:
+            elif spec["fftw-api"].name in INTEL_MATH_LIBRARIES:
                 args.append(self.define("FFT", "MKL"))
             elif "^armpl-gcc" in spec or "^acfl" in spec:
                 args.append(self.define("FFT", "FFTW3"))

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -137,7 +137,7 @@ class R(AutotoolsPackage):
         ]
 
         if "+external-lapack" in spec:
-            if "^mkl" in spec and "gfortran" in self.compiler.fc:
+            if spec["lapack"].name in INTEL_MATH_LIBRARIES and "gfortran" in self.compiler.fc:
                 mkl_re = re.compile(r"(mkl_)intel(_i?lp64\b)")
                 config_args.extend(
                     [


### PR DESCRIPTION
fixes #40983
fixes #40985

The `^mkl` pattern was used to refer to three packages even though none of the software using it was depending on `mkl`. This pattern, which follows Hyrum's law and doesn't work anymore, is now being removed in favor of a more explicit one.

In this PR `gromacs`, `abinit`, `lammps`, and `quantum-espresso` are modified.

Intel packages are also modified to provide "lapack" and "blas" together.