### PR TITLE
builtin.repo: fix ^mkl pattern in minor packages

### DIFF
--- a/var/spack/repos/builtin/packages/arrayfire/package.py
+++ b/var/spack/repos/builtin/packages/arrayfire/package.py
@@ -79,7 +79,7 @@ class Arrayfire(CMakePackage, CudaPackage):
             ]
             args.append(self.define("CUDA_architecture_build_targets", arch_list))
 
-        if "^mkl" in self.spec:
+        if self.spec["blas"].name in INTEL_MATH_LIBRARIES:
             if self.version >= Version("3.8.0"):
                 args.append(self.define("AF_COMPUTE_LIBRARY", "Intel-MKL"))
             else:

--- a/var/spack/repos/builtin/packages/bart/package.py
+++ b/var/spack/repos/builtin/packages/bart/package.py
@@ -48,7 +48,7 @@ class Bart(MakefilePackage, CudaPackage):
         if spec["blas"].name == "openblas":
             env["OPENBLAS"] = "1"
 
-        if "^mkl" in spec:
+        elif spec["blas"].name in INTEL_MATH_LIBRARIES:
             env["MKL"] = "1"
             env["MKL_BASE"] = spec["mkl"].prefix.mkl
         else:

--- a/var/spack/repos/builtin/packages/batchedblas/package.py
+++ b/var/spack/repos/builtin/packages/batchedblas/package.py
@@ -23,7 +23,7 @@ class Batchedblas(MakefilePackage):
     def edit(self, spec, prefix):
         CCFLAGS = [self.compiler.openmp_flag, "-I./", "-O3"]
         BLAS = ["-lm", spec["blas"].libs.ld_flags]
-        if not spec.satisfies("^mkl"):
+        if spec["blas"].name not in INTEL_MATH_LIBRARIES:
             CCFLAGS.append("-D_CBLAS_")
         if spec.satisfies("%intel"):
             CCFLAGS.extend(["-Os"])

--- a/var/spack/repos/builtin/packages/ctffind/package.py
+++ b/var/spack/repos/builtin/packages/ctffind/package.py
@@ -40,7 +40,7 @@ class Ctffind(AutotoolsPackage):
     def configure_args(self):
         config_args = []
 
-        if "^mkl" in self.spec:
+        if self.spec["fftw-api"].name in INTEL_MATH_LIBRARIES:
             config_args.extend(
                 [
                     "--enable-mkl",

--- a/var/spack/repos/builtin/packages/dla-future/package.py
+++ b/var/spack/repos/builtin/packages/dla-future/package.py
@@ -44,6 +44,9 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi")
     depends_on("blaspp@2022.05.00:")
     depends_on("lapackpp@2022.05.00:")
+
+    depends_on("blas")
+    depends_on("lapack")
     depends_on("scalapack", when="+scalapack")
 
     depends_on("umpire~examples")
@@ -107,7 +110,7 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
         args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
 
         # BLAS/LAPACK
-        if "^mkl" in spec:
+        if self.spec["lapack"].name in INTEL_MATH_LIBRARIES:
             vmap = {
                 "none": "seq",
                 "openmp": "omp",

--- a/var/spack/repos/builtin/packages/fplo/package.py
+++ b/var/spack/repos/builtin/packages/fplo/package.py
@@ -83,7 +83,7 @@ class Fplo(MakefilePackage):
         filter_file(r"^\s*F90\s*=.*", "F90=" + spack_fc, *files)
 
         # patch for 64 bit integers
-        if "^mkl+ilp64" in spec:
+        if spec["mkl"].satisfies("+ilp64"):
             setuphelper = FileFilter(join_path(self.build_directory, "PYTHON", "setuphelper.py"))
             setuphelper.filter("mkl 64bit integer 32bit", "mkl 64bit integer 64bit")
 

--- a/var/spack/repos/builtin/packages/hpcc/package.py
+++ b/var/spack/repos/builtin/packages/hpcc/package.py
@@ -118,7 +118,10 @@ class Hpcc(MakefilePackage):
                 lin_alg_libs.append(join_path(spec["fftw-api"].prefix.lib, "libsfftw_mpi.so"))
                 lin_alg_libs.append(join_path(spec["fftw-api"].prefix.lib, "libsfftw.so"))
 
-            elif self.spec.variants["fft"].value == "mkl" and "^mkl" in spec:
+            elif (
+                self.spec.variants["fft"].value == "mkl"
+                and spec["fftw-api"].name in INTEL_MATH_LIBRARIES
+            ):
                 mklroot = env["MKLROOT"]
                 self.config["@LAINC@"] += " -I{0}".format(join_path(mklroot, "include/fftw"))
                 libfftw2x_cdft = join_path(

--- a/var/spack/repos/builtin/packages/itk/package.py
+++ b/var/spack/repos/builtin/packages/itk/package.py
@@ -71,7 +71,7 @@ class Itk(CMakePackage):
     )
 
     def cmake_args(self):
-        use_mkl = "^mkl" in self.spec
+        use_mkl = self.spec["fftw-api"].name in INTEL_MATH_LIBRARIES
         args = [
             self.define("BUILD_SHARED_LIBS", True),
             self.define("ITK_USE_SYSTEM_LIBRARIES", True),

--- a/var/spack/repos/builtin/packages/ldak/package.py
+++ b/var/spack/repos/builtin/packages/ldak/package.py
@@ -33,7 +33,8 @@ class Ldak(Package):
 
     requires("target=x86_64:", when="~glpk", msg="bundled qsopt is only for x86_64")
     requires(
-        *[f"^{_pkg_name}" for _pkg_name in INTEL_MATH_LIBRARIES + ("openblas",)],
+        "^openblas",
+        *[f"^{intel_pkg}" for intel_pkg in INTEL_MATH_LIBRARIES],
         policy="one_of",
         msg="Only mkl or openblas are supported for blas/lapack with ldak",
     )

--- a/var/spack/repos/builtin/packages/ldak/package.py
+++ b/var/spack/repos/builtin/packages/ldak/package.py
@@ -33,8 +33,7 @@ class Ldak(Package):
 
     requires("target=x86_64:", when="~glpk", msg="bundled qsopt is only for x86_64")
     requires(
-        "^mkl",
-        "^openblas",
+        *[f"^{_pkg_name}" for _pkg_name in INTEL_MATH_LIBRARIES + ("openblas",)],
         policy="one_of",
         msg="Only mkl or openblas are supported for blas/lapack with ldak",
     )

--- a/var/spack/repos/builtin/packages/molgw/package.py
+++ b/var/spack/repos/builtin/packages/molgw/package.py
@@ -78,7 +78,7 @@ class Molgw(MakefilePackage):
         flags["PREFIX"] = prefix
 
         # Set LAPACK and SCALAPACK
-        if "^mkl" in spec:
+        if spec["lapack"].name not in INTEL_MATH_LIBRARIES:
             flags["LAPACK"] = self._get_mkl_ld_flags(spec)
         else:
             flags["LAPACK"] = spec["lapack"].libs.ld_flags + " " + spec["blas"].libs.ld_flags
@@ -105,7 +105,7 @@ class Molgw(MakefilePackage):
         if "+scalapack" in spec:
             flags["CPPFLAGS"] = flags.get("CPPFLAGS", "") + " -DHAVE_SCALAPACK -DHAVE_MPI "
 
-        if "^mkl" in spec:
+        if spec["lapack"].name in INTEL_MATH_LIBRARIES:
             flags["CPPFLAGS"] = flags.get("CPPFLAGS", "") + " -DHAVE_MKL "
 
         # Write configuration file

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -223,7 +223,7 @@ class Mumps(Package):
         # As of version 5.2.0, MUMPS is able to take advantage
         # of the GEMMT BLAS extension. MKL and amdblis are the only
         # known BLAS implementation supported.
-        if "@5.2.0: ^mkl" in self.spec:
+        if self.spec["blas"].name in INTEL_MATH_LIBRARIES and self.spec.satifies("@5.2.0:"):
             optf.append("-DGEMMT_AVAILABLE")
 
         if "@5.2.0: ^amdblis@3.0:" in self.spec:

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -167,7 +167,7 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
         config_args = []
 
         # Required dependencies
-        if "^mkl" in spec and "gfortran" in self.compiler.fc:
+        if spec["lapack"].name in INTEL_MATH_LIBRARIES and "gfortran" in self.compiler.fc:
             mkl_re = re.compile(r"(mkl_)intel(_i?lp64\b)")
             config_args.extend(
                 [

--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -159,7 +159,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
 
         if "^fftw" in spec:
             args.append("--with-fftw-prefix=%s" % spec["fftw"].prefix)
-        elif "^mkl" in spec:
+        elif spec["fftw-api"].name in INTEL_MATH_LIBRARIES:
             # As of version 10.0, Octopus depends on fftw-api instead
             # of FFTW. If FFTW is not in the dependency tree, then
             # it ought to be MKL as it is currently the only providers

--- a/var/spack/repos/builtin/packages/q-e-sirius/package.py
+++ b/var/spack/repos/builtin/packages/q-e-sirius/package.py
@@ -93,7 +93,7 @@ class QESirius(CMakePackage):
         # Work around spack issue #19970 where spack sets
         # rpaths for MKL just during make, but cmake removes
         # them during make install.
-        if "^mkl" in self.spec:
+        if self.spec["lapack"].name in INTEL_MATH_LIBRARIES:
             args.append("-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON")
         spec = self.spec
         args.append(self.define("BLAS_LIBRARIES", spec["blas"].libs.joined(";")))

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -376,7 +376,7 @@ class Qmcpack(CMakePackage, CudaPackage):
         # Next two environment variables were introduced in QMCPACK 3.5.0
         # Prior to v3.5.0, these lines should be benign but CMake
         # may issue a warning.
-        if "^mkl" in spec:
+        if spec["lapack"].name in INTEL_MATH_LIBRARIES:
             args.append("-DENABLE_MKL=1")
             args.append("-DMKL_ROOT=%s" % env["MKLROOT"])
         else:


### PR DESCRIPTION
Edit (by @haampie) for people who got assigned as reviewer here:

The query `^mkl in spec` is `false` if your package *happens* to depend on one of these intel packages without *also* depending on the virtual `mkl`.

The virtual `mkl` is different from `blas` / `lapack`, it's for solvers like `pardiso`.

So in this PR the `^mkl in spec` pattern which was intended as "if some intel package is the blas provider" is fixed.