### PR TITLE
ParaView: Add release candidate 5.12.0-RC1

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -28,7 +28,9 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     tags = ["e4s"]
 
     version("master", branch="master", submodules=True)
-    version("5.12.0-RC1", sha256="892eda2ae72831bbadd846be465d496ada35739779229c604cddd56e018a1aea")
+    version(
+        "5.12.0-RC1", sha256="892eda2ae72831bbadd846be465d496ada35739779229c604cddd56e018a1aea"
+    )
     version(
         "5.11.2",
         sha256="5c5d2f922f30d91feefc43b4a729015dbb1459f54c938896c123d2ac289c7a1e",

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -28,6 +28,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     tags = ["e4s"]
 
     version("master", branch="master", submodules=True)
+    version("5.12.0-RC1", sha256="892eda2ae72831bbadd846be465d496ada35739779229c604cddd56e018a1aea")
     version(
         "5.11.2",
         sha256="5c5d2f922f30d91feefc43b4a729015dbb1459f54c938896c123d2ac289c7a1e",


### PR DESCRIPTION
🎉 🎉 🎉

ParaView 5.12.0-RC1 is out

This PR updates the ParaView Spack package to include this new release ParaView v5.12.0-RC1.

Let me know if we need to change anything else in the package.

🎉 🎉 🎉