### PR TITLE
PyTorch: allow +openmp on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch-cluster/package.py
+++ b/var/spack/repos/builtin/packages/py-torch-cluster/package.py
@@ -7,24 +7,29 @@ from spack.package import *
 
 
 class PyTorchCluster(PythonPackage):
-    """This package consists of a small extension library of
-    highly optimized graph cluster algorithms for the use in
-    PyTorch."""
+    """This package consists of a small extension library of highly optimized graph cluster
+    algorithms for the use in PyTorch.
+    """
 
     homepage = "https://github.com/rusty1s/pytorch_cluster"
     url = "https://github.com/rusty1s/pytorch_cluster/archive/1.5.7.tar.gz"
 
+    version("1.6.3", sha256="0e2b08095e03cf87ce9b23b7a7352236a25d3ed92d92351dc020fd927ea8dbfe")
     version("1.5.8", sha256="95c6e81e9c4a6235e1b2152ab917021d2060ad995199f6bd7fb39986d37310f0")
     version("1.5.7", sha256="71701d2f7f3e458ebe5904c982951349fdb60e6f1654e19c7e102a226e2de72e")
 
     variant("cuda", default=False, description="Enables CUDA support")
 
-    depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-pytest-runner", type="build")
     depends_on("py-scipy", type=("build", "run"))
-    depends_on("py-torch+cuda", when="+cuda")
-    depends_on("py-torch~cuda", when="~cuda")
+    depends_on("py-torch+cuda", when="+cuda", type=("build", "link", "run"))
+    depends_on("py-torch~cuda", when="~cuda", type=("build", "link", "run"))
+
+    # https://github.com/rusty1s/pytorch_cluster/issues/120
+    depends_on("py-torch~openmp", when="@:1.5 %apple-clang", type=("build", "link", "run"))
+
+    # Historical dependencies
+    depends_on("py-pytest-runner", when="@:1.5", type="build")
 
     def setup_build_environment(self, env):
         if "+cuda" in self.spec:

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -114,9 +114,6 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     # https://github.com/pytorch/pytorch/issues/77811
     conflicts("+qnnpack", when="platform=darwin target=aarch64:")
 
-    # https://github.com/pytorch/pytorch/issues/80805
-    conflicts("+openmp", when="platform=darwin target=aarch64:")
-
     # https://github.com/pytorch/pytorch/issues/97397
     conflicts(
         "~tensorpipe",


### PR DESCRIPTION
No longer able to reproduce the original issue so I think this is safe.