### PR TITLE
docker entrypoint.sh: fail multi-line RUN on first error with set -e

### DIFF
--- a/share/spack/docker/entrypoint.bash
+++ b/share/spack/docker/entrypoint.bash
@@ -51,8 +51,12 @@ case "$mode" in
         #   COPY spack.yaml .
         #   RUN spack install  # <- Spack is loaded and ready to use.
         #                      # No manual initialization necessary.
+        #   RUN <<EOT          # Supports multi-line scripts.
+        #   spack install      # Will fail on first error (set -e).
+        #   spack buildcache push
+        #   EOT
         . $SPACK_ROOT/share/spack/setup-env.sh
-        exec bash -c "$*"
+        exec bash -e -c "$*"
         ;;
 
     "interactiveshell")


### PR DESCRIPTION
In Dockerfiles, a smaller number of layers is often better, so people concatenate `RUN` commands with `&&` and escaped newlines. This is a lot of notational overhead and leads to the occasional errant backslash upon editing.

Enter here-docs for Dockerfiles in v1.4, e.g. explained in https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/. This allows one to write multi-line scripts in a `RUN` command, e.g. using the example from https://docs.docker.com/engine/reference/builder/#example-running-a-multi-line-script
```
# syntax=docker/dockerfile:1
FROM debian
RUN <<EOT bash
  set -ex
  apt-get update
  apt-get install -y vim
EOT
```
This allows the lines to be clean commands without end of line cruft like `&& \`.

However, as already clear on the example from the reference documentation, `set -ex` is often added explicitly, or just forgotten. Leaving this to the user is not always optimal, because only with `set -e` does the shell fail on the first error (e.g. `apt-get update` failing). (`set -x` prints the commands as they are run, allowing one to figure out which of the lines in the here-doc failed, rather than printing the whole here-doc.)

In spack, the shell for `RUN` commands is provided by the docker-shell mode of the `entrypoint.sh` script. It sources the setup-env.sh and execs bash.

**This PR** adds the `-e` flag to the bash shell started by entrypoint.sh to ensure that here-docs will fail on first error. This has no impact on single line `RUN` commands in Dockerfiles. It doesn't add `-x` as in the example above because it would change output.

Alternative implementations which add flexibility to `SHELL ["docker-shell"]` by allowing flags to be specified in the `SHELL` command would be backwards incompatible because we would need something like `exec bash "$*"` with `SHELL ["docker-shell", "-e", "-c"]`.