### PR TITLE
mrtrix3: Fix some issues w/ 3.0.3 and add 3.0.4

### DIFF
--- a/var/spack/repos/builtin/packages/mrtrix3/fix_includes.patch
+++ b/var/spack/repos/builtin/packages/mrtrix3/fix_includes.patch
@@ -1,0 +1,26 @@
+--- ./configure.orig    2023-11-12 14:48:25.802025918 -0800
++++ ./configure 2023-11-12 14:48:56.177057419 -0800
+@@ -571,10 +571,7 @@
+     try:
+       flags = []
+       for flag in shlex.split (execute ([ 'pkg-config' ] + pkg_config_flags.split(), RunError)[1]):
+-        if flag.startswith ('-I'):
+-          flags += [ '-idirafter', flag[2:] ]
+-        else:
+-          flags += [ flag ]
++        flags += [ flag ]
+       return flags
+     except Exception:
+       log('error running "pkg-config ' + pkg_config_flags + '"\n\n')
+@@ -1323,10 +1320,7 @@
+       for entry in qt:
+         if entry[0] != '$' and not entry == '-I.':
+           entry = entry.replace('\"','').replace("'",'')
+-          if entry.startswith('-I'):
+-            qt_cflags += [ '-idirafter', entry[2:] ]
+-          else:
+-            qt_cflags += [ entry ]
++          qt_cflags += [ entry ]
+
+       qt = qt_ldflags + qt_libs
+       qt_ldflags = []

--- a/var/spack/repos/builtin/packages/mrtrix3/package.py
+++ b/var/spack/repos/builtin/packages/mrtrix3/package.py
@@ -17,14 +17,11 @@ class Mrtrix3(Package):
     git = "https://github.com/MRtrix3/mrtrix3.git"
 
     version(
-        "3.0.4", 
+        "3.0.4",
         sha256="f1d1aa289cfc3e46e3a8eca93594b23d061c6d50a0cd03727433a7e2cd14f71a",
-    )
-    version(
-        "3.0.3",
-        sha256="6ec7d5a567d8d7338e85575a74565189a26ec8971cbe8fb24a49befbc446542e",
         preferred=True,
     )
+    version("3.0.3", sha256="6ec7d5a567d8d7338e85575a74565189a26ec8971cbe8fb24a49befbc446542e")
     version("2017-09-25", commit="72aca89e3d38c9d9e0c47104d0fb5bd2cbdb536d")
 
     depends_on("python@2.7:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/mrtrix3/package.py
+++ b/var/spack/repos/builtin/packages/mrtrix3/package.py
@@ -17,6 +17,10 @@ class Mrtrix3(Package):
     git = "https://github.com/MRtrix3/mrtrix3.git"
 
     version(
+        "3.0.4", 
+        sha256="f1d1aa289cfc3e46e3a8eca93594b23d061c6d50a0cd03727433a7e2cd14f71a",
+    )
+    version(
         "3.0.3",
         sha256="6ec7d5a567d8d7338e85575a74565189a26ec8971cbe8fb24a49befbc446542e",
         preferred=True,
@@ -27,10 +31,13 @@ class Mrtrix3(Package):
     depends_on("py-numpy", type=("build", "run"))
     depends_on("glu")
     depends_on("qt+opengl@4.7:")
-    depends_on("eigen")
+    depends_on("eigen@3.3", when="@3.0.3")
+    depends_on("eigen@3.4", when="@3.0.4:")
     depends_on("zlib-api")
     depends_on("libtiff")
     depends_on("fftw")
+
+    patch("fix_includes.patch", when="@3.0.3:")
 
     conflicts("%gcc@7:", when="@2017-09-25")  # MRtrix3/mrtrix3#1041
 

--- a/var/spack/repos/builtin/packages/mrtrix3/package.py
+++ b/var/spack/repos/builtin/packages/mrtrix3/package.py
@@ -31,13 +31,14 @@ class Mrtrix3(Package):
     depends_on("py-numpy", type=("build", "run"))
     depends_on("glu")
     depends_on("qt+opengl@4.7:")
+    # MRTrix <= 3.0.3 can't build with eigen >= 3.4 due to conflicting declarations
     depends_on("eigen@3.3", when="@3.0.3")
-    depends_on("eigen@3.4", when="@3.0.4:")
+    depends_on("eigen@3.4:", when="@3.0.4:")
     depends_on("zlib-api")
     depends_on("libtiff")
     depends_on("fftw")
 
-    patch("fix_includes.patch", when="@3.0.3:")
+    patch("fix_includes.patch", when="@3.0.3:3.0.4")
 
     conflicts("%gcc@7:", when="@2017-09-25")  # MRtrix3/mrtrix3#1041
 


### PR DESCRIPTION
Fixes issues with the 'configure' script replacing "-I <path>" args with "-idirafter <path>".  Set needed "eigen" version based on mrtrix3 version. Add 3.0.4 version.