### PR TITLE
py-pyfftw: Fix older versions, add 0.13.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyfftw/fix_setup.patch
+++ b/var/spack/repos/builtin/packages/py-pyfftw/fix_setup.patch
@@ -1,0 +1,12 @@
+--- ./setup.py.orig     2023-11-12 22:24:09.000000000 -0800
++++ ./setup.py  2023-11-12 22:26:23.000000000 -0800
+@@ -785,7 +785,8 @@
+             'Topic :: Scientific/Engineering',
+             'Topic :: Scientific/Engineering :: Mathematics',
+             'Topic :: Multimedia :: Sound/Audio :: Analysis'],
+-        'cmdclass': cmdclass
++        'cmdclass': cmdclass,
++        'packages': ['pyfftw']
+     }
+
+     if using_setuptools:

--- a/var/spack/repos/builtin/packages/py-pyfftw/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfftw/package.py
@@ -10,9 +10,10 @@ class PyPyfftw(PythonPackage):
     """A pythonic wrapper around FFTW, the FFT library,
     presenting a unified interface for all the supported transforms."""
 
-    homepage = "http://hgomersall.github.com/pyFFTW"
+    homepage = "https://github.com/pyFFTW/pyFFTW"
     pypi = "pyFFTW/pyFFTW-0.10.4.tar.gz"
 
+    version("0.13.1", sha256="09155e90a0c6d0c1f2d1f3668180a7de95fb9f83fef5137a112fb05978e87320")
     version("0.12.0", sha256="60988e823ca75808a26fd79d88dbae1de3699e72a293f812aa4534f8a0a58cb0")
     version("0.11.1", sha256="05ea28dede4c3aaaf5c66f56eb0f71849d0d50f5bc0f53ca0ffa69534af14926")
     version("0.10.4", sha256="739b436b7c0aeddf99a48749380260364d2dc027cf1d5f63dafb5f50068ede1a")
@@ -22,6 +23,8 @@ class PyPyfftw(PythonPackage):
     depends_on("py-cython@0.29:0", type="build")
     depends_on("py-numpy@1.6:", type=("build", "run"), when="@:0.10.4")
     depends_on("py-numpy@1.10:1", type=("build", "run"), when="@0.11.0:")
+
+    patch("fix_setup.patch", when="@0.11.0:0.12.0")
 
     def setup_build_environment(self, env):
         env.append_flags("LDFLAGS", self.spec["fftw"].libs.search_flags)


### PR DESCRIPTION
Previous versions were broken due to issue when installing directly from git repo root (maybe the expectation was that an "sdist" was built first?), fix by patching setup.py

Adds latest 0.13.1 release which switches from setup.py to pyproject.toml and doesn't need any fix.