### PR TITLE
spack diff: allow hashes from mirrors

### DIFF
--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -200,6 +200,8 @@ def diff(parser, args):
 
     specs = []
     for spec in spack.cmd.parse_specs(args.specs):
+        # If the spec has a hash, check it before disambiguating
+        spec.replace_hash()
         if spec.concrete:
             specs.append(spec)
         else:


### PR DESCRIPTION
Previously, `spack diff /abc /def` would fail if `/abc` or `/def` comes from a spec in a binary cache that is not currently installed.