### PR TITLE
deal.II: Split options for compiling and installing examples

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -74,7 +74,8 @@ class Dealii(CMakePackage, CudaPackage):
         values=("default", "11", "14", "17"),
     )
     variant("doc", default=False, description="Compile with documentation")
-    variant("examples", default=True, description="Compile and install tutorial programs")
+    variant("examples", default=True, description="Install tutorial programs")
+    variant("examples_compile", default=True, description="Compile tutorial programs")
     variant("int64", default=False, description="Compile with 64 bit indices support")
     variant("mpi", default=True, description="Compile with MPI")
     variant("optflags", default=False, description="Compile using additional optimization flags")
@@ -467,7 +468,7 @@ class Dealii(CMakePackage, CudaPackage):
 
         # Examples / tutorial programs
         options.append(self.define_from_variant("DEAL_II_COMPONENT_EXAMPLES", "examples"))
-        options.append(self.define_from_variant("DEAL_II_COMPILE_EXAMPLES", "examples"))
+        options.append(self.define_from_variant("DEAL_II_COMPILE_EXAMPLES", "examples_compile"))
 
         # Enforce the specified C++ standard
         if spec.variants["cxxstd"].value != "default":


### PR DESCRIPTION
Addresses the discussion in https://github.com/spack/spack/pull/40747#discussion_r1390854950.
The description for `DEAL_II_COMPILE_EXAMPLES` reads:
```
//If set to ON, all configurable example executables will be built
// and installed as well. If set to OFF, the examples component
// only installs the source code of example steps.
```
