### PR TITLE
libevent: call autoreconf directly instead of via autogen.sh

### DIFF
--- a/var/spack/repos/builtin/packages/libevent/package.py
+++ b/var/spack/repos/builtin/packages/libevent/package.py
@@ -59,7 +59,7 @@ class Libevent(AutotoolsPackage):
         return LibraryList(libs)
 
     def autoreconf(self, spec, prefix):
-        Executable("./autogen.sh")()
+        autoreconf("--force", "--install", "--symlink")
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/41056.

The `autogen.sh` script shipped by libevent uses `which` to determine if `autoreconf` is available, but `which` isn't installed by default on all systems (e.g. Fedora). If Spack is building with `libtool @2.4.7` this causes build failures since the libtool M4 fragments in libevent are libtool 2.4.6.

~~This PR adds a patch to replace the use of `which` with `command -v`, which is a POSIX shell builtin and thus more portable.~~

~~**EDIT:** This PR fixes this by adding a build dependency on `which`.~~

**EDIT:** This PR fixes this by calling `autoreconf` directly, instead of trying to get `autogen.sh` to do so.