### PR TITLE
Only build tests for proj package if required

### DIFF
--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -137,6 +137,8 @@ class CMakeBuilder(BaseBuilder, cmake.CMakeBuilder):
         ]
         if self.spec.satisfies("@6:") and self.pkg.run_tests:
             args.append(self.define("USE_EXTERNAL_GTEST", True))
+        if not self.pkg.run_tests:
+            args.append(self.define("BUILD_TESTING", False))
         return args
 
 


### PR DESCRIPTION
Even if tests are not explictly required to be built, proj build them anyway and tries to download Google Test.