### PR TITLE
Only build tests for proj package if required

### DIFF
--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -137,14 +137,13 @@ class CMakeBuilder(BaseBuilder, cmake.CMakeBuilder):
         ]
         if self.spec.satisfies("@6:") and self.pkg.run_tests:
             args.append(self.define("USE_EXTERNAL_GTEST", True))
-        if not self.pkg.run_tests:
-            if self.spec.satisfies("@7:"):
-                test_flag = "BUILD_TESTING"
-            elif self.spec.satisfies("@5.1:"):
-                test_flag = "PROJ_TESTS"
-            else:
-                test_flag = "PROJ4_TESTS"
-            args.append(self.define(test_flag, False))
+        if self.spec.satisfies("@7:"):
+            test_flag = "BUILD_TESTING"
+        elif self.spec.satisfies("@5.1:"):
+            test_flag = "PROJ_TESTS"
+        else:
+            test_flag = "PROJ4_TESTS"
+        args.append(self.define(test_flag, self.pkg.run_tests))
         return args
 
 

--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -85,6 +85,9 @@ class Proj(CMakePackage, AutotoolsPackage):
         when="@7:7.2.1",
     )
 
+    patch("proj.cmakelists.5.0.patch", when="@5.0")
+    patch("proj.cmakelists.5.1.patch", when="@5.1:5.2")
+
     # https://proj.org/install.html#build-requirements
     with when("build_system=cmake"):
         depends_on("cmake@3.9:", when="@6:", type="build")

--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -138,7 +138,13 @@ class CMakeBuilder(BaseBuilder, cmake.CMakeBuilder):
         if self.spec.satisfies("@6:") and self.pkg.run_tests:
             args.append(self.define("USE_EXTERNAL_GTEST", True))
         if not self.pkg.run_tests:
-            args.append(self.define("BUILD_TESTING", False))
+            if self.spec.satisfies("@7:"):
+                test_flag = "BUILD_TESTING"
+            elif self.spec.satisfies("@5.1:"):
+                test_flag = "PROJ_TESTS"
+            else:
+                test_flag = "PROJ4_TESTS"
+            args.append(self.define(test_flag, False))
         return args
 
 

--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -137,6 +137,8 @@ class CMakeBuilder(BaseBuilder, cmake.CMakeBuilder):
         ]
         if self.spec.satisfies("@6:") and self.pkg.run_tests:
             args.append(self.define("USE_EXTERNAL_GTEST", True))
+        if not self.pkg.run_tests:
+            args.append(self.define("BUILD_TESTING", False))
         return args
 
 

--- a/var/spack/repos/builtin/packages/proj/proj.cmakelists.5.0.patch
+++ b/var/spack/repos/builtin/packages/proj/proj.cmakelists.5.0.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -149,5 +149,6 @@ add_subdirectory(nad)
+ add_subdirectory(src)
+ add_subdirectory(man)
+ add_subdirectory(cmake)
+-add_subdirectory(test)
+-
++if(PROJ4_TESTS)
++  add_subdirectory(test)
++endif(PROJ4_TESTS)

--- a/var/spack/repos/builtin/packages/proj/proj.cmakelists.5.1.patch
+++ b/var/spack/repos/builtin/packages/proj/proj.cmakelists.5.1.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -159,5 +159,6 @@ add_subdirectory(nad)
+ add_subdirectory(src)
+ add_subdirectory(man)
+ add_subdirectory(cmake)
+-add_subdirectory(test)
+-
++if(PROJ_TESTS)
++  add_subdirectory(test)
++endif(PROJ_TESTS)


### PR DESCRIPTION
Even if tests are not explictly required to be built, proj build them anyway and tries to download Google Test.