### PR TITLE
hpctoolkit: Add Autotools dependencies for `@develop`

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -109,6 +109,11 @@ class Hpctoolkit(AutotoolsPackage):
         "python", default=False, description="Support unwinding Python source.", when="@2023.03:"
     )
 
+    with when("@develop build_system=autotools"):
+        depends_on("autoconf", type="build")
+        depends_on("automake", type="build")
+        depends_on("libtool", type="build")
+
     boost_libs = (
         "+atomic +chrono +date_time +filesystem +system +thread +timer"
         " +graph +regex +shared +multithreaded visibility=global"


### PR DESCRIPTION
Recently we removed the Autotools-generated files from our `develop` branch. Add the appropriate dependencies (`automake`, `autoconf`, `libtool`) when building this branch to regenerate the necessary files.

Pinging maintainer: @mwkrentel 