### PR TITLE
Improve the error message for deprecated preferences

### DIFF
--- a/lib/spack/spack/cmd/audit.py
+++ b/lib/spack/spack/cmd/audit.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import warnings
+
 import llnl.util.tty as tty
 import llnl.util.tty.colify
 import llnl.util.tty.color as cl
@@ -52,8 +54,10 @@ def setup_parser(subparser):
 
 
 def configs(parser, args):
-    reports = spack.audit.run_group(args.subcommand)
-    _process_reports(reports)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        reports = spack.audit.run_group(args.subcommand)
+        _process_reports(reports)
 
 
 def packages(parser, args):

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -119,7 +119,7 @@ properties = {
                     "properties": ["version"],
                     "message": "setting version preferences in the 'all' section of packages.yaml "
                     "is deprecated and will be removed in v0.22\n\n\tThese preferences "
-                    "will be ignored by Spack. You can set them only in package specific sections "
+                    "will be ignored by Spack. You can set them only in package-specific sections "
                     "of the same file.\n",
                     "error": False,
                 },
@@ -167,7 +167,9 @@ properties = {
                     "message": "setting 'compiler:', 'target:' or 'provider:' preferences in "
                     "a package specific section of packages.yaml is deprecated, and will be "
                     "removed in v0.22.\n\n\tThese preferences will be ignored by Spack, and "
-                    "can be set only in the 'all' section of the same file.\n"
+                    "can be set only in the 'all' section of the same file. "
+                    "You can run:\n\n\t\t$ spack audit configs\n\n\tto get better diagnostics, "
+                    "including files:lines where the deprecated attributes are used.\n\n"
                     "\tUse requirements to enforce conditions on specific packages: "
                     f"{REQUIREMENT_URL}\n",
                     "error": False,

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -165,7 +165,7 @@ properties = {
                 "deprecatedProperties": {
                     "properties": ["target", "compiler", "providers"],
                     "message": "setting 'compiler:', 'target:' or 'provider:' preferences in "
-                    "a package specific section of packages.yaml is deprecated, and will be "
+                    "a package-specific section of packages.yaml is deprecated, and will be "
                     "removed in v0.22.\n\n\tThese preferences will be ignored by Spack, and "
                     "can be set only in the 'all' section of the same file. "
                     "You can run:\n\n\t\t$ spack audit configs\n\n\tto get better diagnostics, "

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -69,6 +69,8 @@ package_attributes = {
     "patternProperties": {r"\w+": {}},
 }
 
+REQUIREMENT_URL = "https://spack.readthedocs.io/en/latest/packages_yaml.html#package-requirements"
+
 #: Properties for inclusion in other schemas
 properties = {
     "packages": {
@@ -162,10 +164,12 @@ properties = {
                 },
                 "deprecatedProperties": {
                     "properties": ["target", "compiler", "providers"],
-                    "message": "setting compiler, target or provider preferences in a package "
-                    "specific section of packages.yaml is deprecated, and will be removed in "
-                    "v0.22.\n\n\tThese preferences will be ignored by Spack. You "
-                    "can set them only in the 'all' section of the same file.\n",
+                    "message": "setting 'compiler:', 'target:' or 'provider:' preferences in "
+                    "a package specific section of packages.yaml is deprecated, and will be "
+                    "removed in v0.22.\n\n\tThese preferences will be ignored by Spack, and "
+                    "can be set only in the 'all' section of the same file.\n"
+                    "\tUse requirements to enforce conditions on specific packages: "
+                    f"{REQUIREMENT_URL}\n",
                     "error": False,
                 },
             }


### PR DESCRIPTION
This PR improves the warning for deprecated preferences, and adds a configuration audit to get files:lines details of the issues. The result is the following:

![Screenshot from 2023-11-16 17-59-17](https://github.com/spack/spack/assets/4199709/6889311b-dfbb-49c7-afdf-ea53389040d1)

The audit is to avoid more complex analysis every time the config file is loaded.