### PR TITLE
py-jsonpath-ng: version bump

### DIFF
--- a/var/spack/repos/builtin/packages/py-jsonpath-ng/package.py
+++ b/var/spack/repos/builtin/packages/py-jsonpath-ng/package.py
@@ -15,7 +15,7 @@ class PyJsonpathNg(PythonPackage):
     homepage = "https://github.com/h2non/jsonpath-ng"
     pypi = "jsonpath-ng/jsonpath-ng-1.5.2.tar.gz"
 
-    version("1.6.9", sha256="5483f8e9d74c39c9abfab554c070ae783c1c8cbadf5df60d561bc705ac68a07e")
+    version("1.6.0", sha256="5483f8e9d74c39c9abfab554c070ae783c1c8cbadf5df60d561bc705ac68a07e")
     version("1.5.3", sha256="a273b182a82c1256daab86a313b937059261b5c5f8c4fa3fc38b882b344dd567")
     version("1.5.2", sha256="144d91379be14d9019f51973bd647719c877bfc07dc6f3f5068895765950c69d")
 

--- a/var/spack/repos/builtin/packages/py-jsonpath-ng/package.py
+++ b/var/spack/repos/builtin/packages/py-jsonpath-ng/package.py
@@ -15,9 +15,11 @@ class PyJsonpathNg(PythonPackage):
     homepage = "https://github.com/h2non/jsonpath-ng"
     pypi = "jsonpath-ng/jsonpath-ng-1.5.2.tar.gz"
 
+    version("1.6.9", sha256="5483f8e9d74c39c9abfab554c070ae783c1c8cbadf5df60d561bc705ac68a07e")
+    version("1.5.3", sha256="a273b182a82c1256daab86a313b937059261b5c5f8c4fa3fc38b882b344dd567")
     version("1.5.2", sha256="144d91379be14d9019f51973bd647719c877bfc07dc6f3f5068895765950c69d")
 
     depends_on("py-setuptools", type="build")
     depends_on("py-ply", type=("build", "run"))
-    depends_on("py-decorator", type=("build", "run"))
-    depends_on("py-six", type=("build", "run"))
+    depends_on("py-decorator", type=("build", "run"), when="@:1.5")
+    depends_on("py-six", type=("build", "run"), when="@:1.5")


### PR DESCRIPTION
Pushing internal version bump to 1.5.3, adding 1.6.9 since I'm here anyway.