### PR TITLE
Add patch for `libffi@3.4.3:3.4.4` since failing to install using clang@15

### DIFF
--- a/var/spack/repos/builtin/packages/libffi/package.py
+++ b/var/spack/repos/builtin/packages/libffi/package.py
@@ -32,6 +32,11 @@ class Libffi(AutotoolsPackage):
     patch("clang-powerpc-3.2.1.patch", when="@3.2.1%clang platform=linux")
     # ref.: https://github.com/libffi/libffi/pull/561
     patch("powerpc-3.3.patch", when="@3.3")
+    patch(
+        "https://github.com/libffi/libffi/commit/ce077e5565366171aa1b4438749b0922fce887a4.patch?full_index=1",
+        sha256="070b1f3aa87f2b56f83aff38afc42157e1692bfaa580276ecdbad2048b818ed7",
+        when="@3.4.3:3.4.4",
+    )
 
     @property
     def headers(self):


### PR DESCRIPTION
libffi version 3.4.4, 3.4.3 are failing to install with clang@15
libffi version 3.4.2 is successful with clang@15
Note: same error with clang@16