### PR TITLE
py-bokeh: new version 3.3.1, and supporting packages

### DIFF
--- a/var/spack/repos/builtin/packages/py-bokeh/package.py
+++ b/var/spack/repos/builtin/packages/py-bokeh/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyBokeh(PythonPackage):
     """Statistical and novel interactive HTML plots for Python"""
 
-    homepage = "https://github.com/bokeh/bokeh"
+    homepage = "https://bokeh.org/"
     pypi = "bokeh/bokeh-0.12.2.tar.gz"
 
     version("3.3.1", sha256="2a7b3702d7e9f03ef4cd801b02b7380196c70cff2773859bcb84fa565218955c")

--- a/var/spack/repos/builtin/packages/py-bokeh/package.py
+++ b/var/spack/repos/builtin/packages/py-bokeh/package.py
@@ -12,6 +12,7 @@ class PyBokeh(PythonPackage):
     homepage = "https://github.com/bokeh/bokeh"
     pypi = "bokeh/bokeh-0.12.2.tar.gz"
 
+    version("3.3.1", sha256="2a7b3702d7e9f03ef4cd801b02b7380196c70cff2773859bcb84fa565218955c")
     version("2.4.3", sha256="ef33801161af379665ab7a34684f2209861e3aefd5c803a21fbbb99d94874b03")
     version("2.4.1", sha256="d0410717d743a0ac251e62480e2ea860a7341bdcd1dbe01499a904f233c90512")
     version("2.4.0", sha256="6fa00ed8baab5cca33f4175792c309fa2536eaae7e90abee884501ba8c90fddb")
@@ -20,11 +21,15 @@ class PyBokeh(PythonPackage):
     version("0.12.2", sha256="0a840f6267b6d342e1bd720deee30b693989538c49644142521d247c0f2e6939")
 
     depends_on("py-setuptools", type="build", when="@1.3.4:")
+    depends_on("py-setuptools@64:", type="build", when="@3:")
+    depends_on("py-setuptools-git-versioning", type="build", when="@3:")
+    depends_on("py-colorama", type="build", when="@3:")
 
     depends_on("python@2.6:", type=("build", "run"), when="@0.12.2")
     depends_on("python@2.7:", type=("build", "run"), when="@1.3.4:")
     depends_on("python@3.6:", type=("build", "run"), when="@2.3.3:")
     depends_on("python@3.7:", type=("build", "run"), when="@2.4.0:")
+    depends_on("python@3.8:", type=("build", "run"), when="@3.0.0:")
 
     depends_on("py-requests@1.2.3:", type=("build", "run"), when="@0.12.2")
     depends_on("py-six@1.5.2:", type=("build", "run"), when="@:1.3.4")
@@ -33,10 +38,14 @@ class PyBokeh(PythonPackage):
     depends_on("py-jinja2@2.7:", type=("build", "run"))
     depends_on("py-jinja2@2.9:", type=("build", "run"), when="@2.3.3:")
 
+    depends_on("py-contourpy@1", type=("build", "run"), when="@3:")
+
     depends_on("py-numpy@1.7.1:", type=("build", "run"))
     depends_on("py-numpy@1.11.3:", type=("build", "run"), when="@2.3.3:")
 
     depends_on("py-packaging@16.8:", type=("build", "run"), when="@1.3.4:")
+
+    depends_on("py-pandas@1.2:", type=("build", "run"), when="@3:")
 
     depends_on("pil@4.0:", type=("build", "run"), when="@1.3.4:")
     depends_on("pil@7.1.0:", type=("build", "run"), when="@2.3.3:")
@@ -48,3 +57,5 @@ class PyBokeh(PythonPackage):
 
     depends_on("py-typing-extensions@3.7.4:", type=("build", "run"), when="@2.3.3:")
     depends_on("py-typing-extensions@3.10.0:", type=("build", "run"), when="@2.4.0:")
+
+    depends_on("py-xyzservices@2021.09.1:", type=("build", "run"), when="@3:")

--- a/var/spack/repos/builtin/packages/py-bokeh/package.py
+++ b/var/spack/repos/builtin/packages/py-bokeh/package.py
@@ -42,6 +42,7 @@ class PyBokeh(PythonPackage):
 
     depends_on("py-numpy@1.7.1:", type=("build", "run"))
     depends_on("py-numpy@1.11.3:", type=("build", "run"), when="@2.3.3:")
+    depends_on("py-numpy@1.16:", type=("build", "run"), when="@3.1:")
 
     depends_on("py-packaging@16.8:", type=("build", "run"), when="@1.3.4:")
 

--- a/var/spack/repos/builtin/packages/py-bokeh/package.py
+++ b/var/spack/repos/builtin/packages/py-bokeh/package.py
@@ -30,6 +30,7 @@ class PyBokeh(PythonPackage):
     depends_on("python@3.6:", type=("build", "run"), when="@2.3.3:")
     depends_on("python@3.7:", type=("build", "run"), when="@2.4.0:")
     depends_on("python@3.8:", type=("build", "run"), when="@3.0.0:")
+    depends_on("python@3.9:", type=("build", "run"), when="@3.2.0:")
 
     depends_on("py-requests@1.2.3:", type=("build", "run"), when="@0.12.2")
     depends_on("py-six@1.5.2:", type=("build", "run"), when="@:1.3.4")
@@ -38,7 +39,7 @@ class PyBokeh(PythonPackage):
     depends_on("py-jinja2@2.7:", type=("build", "run"))
     depends_on("py-jinja2@2.9:", type=("build", "run"), when="@2.3.3:")
 
-    depends_on("py-contourpy@1", type=("build", "run"), when="@3:")
+    depends_on("py-contourpy@1:", type=("build", "run"), when="@3:")
 
     depends_on("py-numpy@1.7.1:", type=("build", "run"))
     depends_on("py-numpy@1.11.3:", type=("build", "run"), when="@2.3.3:")
@@ -56,7 +57,7 @@ class PyBokeh(PythonPackage):
     depends_on("py-tornado@4.3:", type=("build", "run"))
     depends_on("py-tornado@5.1:", type=("build", "run"), when="@2.3.3:")
 
-    depends_on("py-typing-extensions@3.7.4:", type=("build", "run"), when="@2.3.3:")
-    depends_on("py-typing-extensions@3.10.0:", type=("build", "run"), when="@2.4.0:")
+    depends_on("py-typing-extensions@3.7.4:", type=("build", "run"), when="@2.3.3:3.0.0")
+    depends_on("py-typing-extensions@3.10.0:", type=("build", "run"), when="@2.4.0:3.0.0")
 
     depends_on("py-xyzservices@2021.09.1:", type=("build", "run"), when="@3:")

--- a/var/spack/repos/builtin/packages/py-xyzservices/package.py
+++ b/var/spack/repos/builtin/packages/py-xyzservices/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyXyzservices(PythonPackage):
+    """xyzservices is a lightweight library providing a repository of
+    available XYZ services offering raster basemap tiles."""
+
+    homepage = "https://xyzservices.readthedocs.io/"
+    pypi = "xyzservices/xyzservices-2023.10.1.tar.gz"
+
+    license("BSD-3-Clause")
+
+    version("2023.10.1", sha256="091229269043bc8258042edbedad4fcb44684b0473ede027b5672ad40dc9fa02")
+
+    depends_on("python@3.8:", type=("build", "run"))
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools-scm", type="build")

--- a/var/spack/repos/builtin/packages/py-xyzservices/package.py
+++ b/var/spack/repos/builtin/packages/py-xyzservices/package.py
@@ -10,7 +10,7 @@ class PyXyzservices(PythonPackage):
     """xyzservices is a lightweight library providing a repository of
     available XYZ services offering raster basemap tiles."""
 
-    homepage = "https://xyzservices.readthedocs.io/"
+    homepage = "https://github.com/geopandas/xyzservices"
     pypi = "xyzservices/xyzservices-2023.10.1.tar.gz"
 
     license("BSD-3-Clause")


### PR DESCRIPTION
This adds the first bokeh v3 release in spack (a year after the first bokeh v3 release). Some extra dependencies added.