### PR TITLE
py-stashcp: new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-stashcp/package.py
+++ b/var/spack/repos/builtin/packages/py-stashcp/package.py
@@ -17,7 +17,4 @@ class PyStashcp(PythonPackage):
 
     version("6.1.0", sha256="40484b40aeb853eb6a5f5472daf533a176d61fa6ab839cd265ea0baa3fe63068")
 
-    depends_on("py-setuptools", type="build")
-
-    # import in stashcp.__init.py__ not listed in setup.py
-    depends_on("py-urllib3", type=("build", "run"))
+    depends_on("py-setuptools", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-stashcp/package.py
+++ b/var/spack/repos/builtin/packages/py-stashcp/package.py
@@ -19,4 +19,5 @@ class PyStashcp(PythonPackage):
 
     depends_on("py-setuptools", type="build")
 
+    # import in stashcp.__init.py__ not listed in setup.py
     depends_on("py-urllib3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-stashcp/package.py
+++ b/var/spack/repos/builtin/packages/py-stashcp/package.py
@@ -18,3 +18,5 @@ class PyStashcp(PythonPackage):
     version("6.1.0", sha256="40484b40aeb853eb6a5f5472daf533a176d61fa6ab839cd265ea0baa3fe63068")
 
     depends_on("py-setuptools", type="build")
+
+    depends_on("py-urllib3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-stashcp/package.py
+++ b/var/spack/repos/builtin/packages/py-stashcp/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyStashcp(PythonPackage):
+    """Stashcp uses geo located nearby caches in order to copy from the OSG
+    Connect's stash storage service to a job's workspace on a cluster."""
+
+    homepage = "https://github.com/opensciencegrid/StashCache"
+    pypi = "stashcp/stashcp-6.1.0.tar.gz"
+
+    maintainers("wdconinc")
+
+    version("6.1.0", sha256="40484b40aeb853eb6a5f5472daf533a176d61fa6ab839cd265ea0baa3fe63068")
+
+    depends_on("py-setuptools", type="build")


### PR DESCRIPTION
py-stashcp supports writing to Open Science Grid data federation stash caches, https://osg-htc.org/docs/data/stashcache/overview/.