### PR TITLE
openblas: Optimize flags for A64FX

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -369,7 +369,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
             # case can go away.
             args.append("TARGET=" + "RISCV64_GENERIC")
 
-        elif microarch.name == "a64fx" and self.spec.satisfies("@0.3.20:") and (self.spec.satisfies("%gcc@11:") or self.spec.satisfies("%clang")):
+        elif microarch.name == "a64fx" and self.spec.satisfies("@0.3.19:") and (self.spec.satisfies("%gcc@11:") or self.spec.satisfies("%clang")):
             # Special case for Fujitsu's A64FX
             args.append("TARGET=A64FX")
 

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -372,7 +372,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
 
         elif self.spec.satisfies("@0.3.19: target=a64fx"):
             # Special case for Fujitsu's A64FX
-            if any(self.spec.satisfies(i) for i in ["%gcc@11:", "%clang", "%fj]):
+            if any(self.spec.satisfies(i) for i in ["%gcc@11:", "%clang", "%fj"]):
                 args.append("TARGET=A64FX")
             else:
                 # fallback to armv8-a+sve without -mtune=a64fx flag

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -369,6 +369,10 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
             # case can go away.
             args.append("TARGET=" + "RISCV64_GENERIC")
 
+        elif microarch.name == "a64fx" and self.spec.satisfies("@0.3.20:") and (self.spec.satisfies("%gcc@11:") or self.spec.satisfies("%clang")):
+            # Special case for Fujitsu's A64FX
+            args.append("TARGET=A64FX")
+
         else:
             args.append("TARGET=" + microarch.name.upper())
 

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -192,6 +192,13 @@ class Openblas(CMakePackage, MakefilePackage):
         when="@0.3.21 %gcc@:9",
     )
 
+    # Fix build on A64FX for OpenBLAS v0.3.24
+    patch(
+        "https://github.com/OpenMathLib/OpenBLAS/commit/90231bfc4e4afc51f67c248328fbef0cecdbd2c2.patch?full_index=1",
+        sha256="139e314f3408dc5c080d28887471f382e829d1bd06c8655eb72593e4e7b921cc",
+        when="@0.3.24 target=a64fx",
+    )
+
     # See https://github.com/spack/spack/issues/19932#issuecomment-733452619
     # Notice: fixed on Amazon Linux GCC 7.3.1 (which is an unofficial version
     # as GCC only has major.minor releases. But the bound :7.3.0 doesn't hurt)

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -369,13 +369,15 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
             # case can go away.
             args.append("TARGET=" + "RISCV64_GENERIC")
 
-        elif (
-            microarch.name == "a64fx"
-            and self.spec.satisfies("@0.3.19:")
-            and (self.spec.satisfies("%gcc@11:") or self.spec.satisfies("%clang"))
-        ):
+        elif self.spec.satisfies("@0.3.19: target=a64fx"):
             # Special case for Fujitsu's A64FX
-            args.append("TARGET=A64FX")
+            if self.spec.satisfies("%gcc@11:"):
+                args.append("TARGET=A64FX")
+            elif self.spec.satisfies("%clang") or self.spec.satisfies("%fj"):  
+                args.append("TARGET=A64FX")
+            else:
+                # fallback to armv8-a+sve without -mtune=a64fx flag
+                args.append("TARGET=ARMV8SVE")
 
         else:
             args.append("TARGET=" + microarch.name.upper())

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -369,7 +369,11 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
             # case can go away.
             args.append("TARGET=" + "RISCV64_GENERIC")
 
-        elif microarch.name == "a64fx" and self.spec.satisfies("@0.3.19:") and (self.spec.satisfies("%gcc@11:") or self.spec.satisfies("%clang")):
+        elif (
+            microarch.name == "a64fx"
+            and self.spec.satisfies("@0.3.19:")
+            and (self.spec.satisfies("%gcc@11:") or self.spec.satisfies("%clang"))
+        ):
             # Special case for Fujitsu's A64FX
             args.append("TARGET=A64FX")
 

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -372,9 +372,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
 
         elif self.spec.satisfies("@0.3.19: target=a64fx"):
             # Special case for Fujitsu's A64FX
-            if self.spec.satisfies("%gcc@11:"):
-                args.append("TARGET=A64FX")
-            elif self.spec.satisfies("%clang") or self.spec.satisfies("%fj"):
+            if any(self.spec.satisfies(i) for i in ["%gcc@11:", "%clang", "%fj]):
                 args.append("TARGET=A64FX")
             else:
                 # fallback to armv8-a+sve without -mtune=a64fx flag

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -373,7 +373,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
             # Special case for Fujitsu's A64FX
             if self.spec.satisfies("%gcc@11:"):
                 args.append("TARGET=A64FX")
-            elif self.spec.satisfies("%clang") or self.spec.satisfies("%fj"):  
+            elif self.spec.satisfies("%clang") or self.spec.satisfies("%fj"):
                 args.append("TARGET=A64FX")
             else:
                 # fallback to armv8-a+sve without -mtune=a64fx flag


### PR DESCRIPTION
Since v0.3.19, OpenBLAS has a special case for Fujitsu's A64FX microarchitecture, which is activated with the `TARGET=A64FX` variable. This PR activates that case when correct conditions are detected.