### PR TITLE
deal.II: Require at least taskflow 3.4

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -207,7 +207,7 @@ class Dealii(CMakePackage, CudaPackage):
     depends_on("sundials@:3~pthread", when="@9.0:9.2+sundials")
     depends_on("sundials@5:5.8", when="@9.3:9.3.3+sundials")
     depends_on("sundials@5:", when="@9.3.4:+sundials")
-    depends_on("taskflow", when="@9.6:+taskflow")
+    depends_on("taskflow@3.4:", when="@9.6:+taskflow")
     depends_on("trilinos gotype=int", when="+trilinos@12.18.1:")
     # TODO: next line fixes concretization with trilinos and adol-c
     depends_on("trilinos~exodus", when="@9.0:+adol-c+trilinos")


### PR DESCRIPTION
Fixes https://github.com/xsdk-project/xsdk-issues/issues/251. The failing code in question has been fixed since taskflow 3.4.0, see https://github.com/taskflow/taskflow/commit/75454ae5a40abf1e095a2164cc555684d284bc20, so this pull request makes 3.4.0 the minimum taskflow version.