### PR TITLE
sirius: fix build error with Fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/sirius/fj.patch
+++ b/var/spack/repos/builtin/packages/sirius/fj.patch
@@ -1,0 +1,13 @@
+diff --git a/src/hamiltonian/hamiltonian.cpp b/src/hamiltonian/hamiltonian.cpp
+index 54a91df..ea66ecf 100644
+--- a/src/hamiltonian/hamiltonian.cpp
++++ b/src/hamiltonian/hamiltonian.cpp
+@@ -74,7 +74,7 @@ Hamiltonian0<T>::Hamiltonian0(Potential& potential__, bool precompute_lapw__)
+                     for (int j1 = 0; j1 <= j2; j1++) {
+                         int lm1    = type.indexb(j1).lm;
+                         int idxrf1 = type.indexb(j1).idxrf;
+-                        hmt_[ia](j1, j2) = atom.radial_integrals_sum_L3<spin_block_t::nm>(idxrf1, idxrf2,
++                        hmt_[ia](j1, j2) = atom.template radial_integrals_sum_L3<spin_block_t::nm>(idxrf1, idxrf2,
+                                                                                 type.gaunt_coefs().gaunt_vector(lm1, lm2));
+                         hmt_[ia](j2, j1) = std::conj(hmt_[ia](j1, j2));
+                     }

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -187,6 +187,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("umpire+rocm~device_alloc", when="+rocm")
 
     patch("mpi_datatypes.patch", when="@:7.2.6")
+    patch("fj.patch", when="@7.3.2: %fj")
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
The following error was encountered while building SIRIUS(<=7.3.2) with the Fujitsu compiler.
```
<path>/spack-stage-sirius-7.3.2-j6ow4kcucuasshws26fjrgwy66u3gb7l/spack-src/src/hamiltonian/hamiltonian.cpp:77:91: warning: expression resu\
lt unused [-Wunused-value]
                        hmt_[ia](j1, j2) = atom.radial_integrals_sum_L3<spin_block_t::nm>(idxrf1, idxrf2,
                                                                                          ^~~~~~
<path>/spack-stage-sirius-7.3.2-j6ow4kcucuasshws26fjrgwy66u3gb7l/spack-src/src/hamiltonian/hamiltonian.cpp:77:49: error: missing 'template\
' keyword prior to dependent template name 'radial_integrals_sum_L3'
                        hmt_[ia](j1, j2) = atom.radial_integrals_sum_L3<spin_block_t::nm>(idxrf1, idxrf2,
                                                ^
<path>/spack-stage-sirius-7.3.2-j6ow4kcucuasshws26fjrgwy66u3gb7l/spack-src/src/hamiltonian/hamiltonian.cpp:266:16: note: in instantiation \
of member function 'sirius::Hamiltonian0<double>::Hamiltonian0' requested here
template class Hamiltonian0<double>;
               ^
1 warning and 1 error generated.
make[2]: *** [src/CMakeFiles/sirius.dir/build.make:79: src/CMakeFiles/sirius.dir/hamiltonian/hamiltonian.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '<path>/spack-stage-sirius-7.3.2-j6ow4kcucuasshws26fjrgwy66u3gb7l/spack-build-j6ow4kc'
make[1]: *** [CMakeFiles/Makefile2:209: src/CMakeFiles/sirius.dir/all] Error 2
make[1]: Leaving directory '<path>/spack-stage-sirius-7.3.2-j6ow4kcucuasshws26fjrgwy66u3gb7l/spack-build-j6ow4kc'
make: *** [Makefile:139: all] Error 2
```
This is due to a compiler bug, but I would like to add a patch to work around the error until it is fixed.