### PR TITLE
clhep: new version 2.4.7.1

### DIFF
--- a/var/spack/repos/builtin/packages/clhep/package.py
+++ b/var/spack/repos/builtin/packages/clhep/package.py
@@ -19,6 +19,8 @@ class Clhep(CMakePackage):
 
     maintainers("drbenmorgan")
 
+    version("2.4.7.1", sha256="1c8304a7772ac6b99195f1300378c6e3ddf4ad07c85d64a04505652abb8a55f9")
+    version("2.4.7.0", sha256="7fa460030bc1a804ea7da8cce7611b93261493bbb66c3cfd3ceec935d7e1b8d3")
     version("2.4.6.4", sha256="49c89330f1903ef707d3c5d79c16a7c5a6f2c90fc290e2034ee3834809489e57")
     version("2.4.6.3", sha256="fcd007f11b10ba4af28d027222b63148d0eb44ff7a082eee353bdf921f9c684a")
     version("2.4.6.2", sha256="aded73e49bac85a5b4e86f64a0ee3d6f3cfe5551b0f7731c78b6d8f9dac6e8dc")


### PR DESCRIPTION
Just some random upgrades (https://gitlab.cern.ch/CLHEP/CLHEP/blob/develop/ChangeLog, bad pun intended).

Builds fine:
```
==> Installing clhep-2.4.7.1-wqginb264qmth3c3f2c5nvlxzdf4q76k [65/126]
==> No binary for clhep-2.4.7.1-wqginb264qmth3c3f2c5nvlxzdf4q76k found: installing from source
==> Fetching https://proj-clhep.web.cern.ch/proj-clhep/dist1/clhep-2.4.7.1.tgz
==> Ran patch() for clhep
==> clhep: Executing phase: 'cmake'
==> clhep: Executing phase: 'build'
==> clhep: Executing phase: 'install'
==> clhep: Successfully installed clhep-2.4.7.1-wqginb264qmth3c3f2c5nvlxzdf4q76k
  Stage: 3.64s.  Cmake: 0.85s.  Build: 3m 21.67s.  Install: 0.45s.  Post-install: 0.13s.  Total: 3m 26.80s
[+] /opt/software/linux-ubuntu23.10-skylake/gcc-13.2.0/clhep-2.4.7.1-wqginb264qmth3c3f2c5nvlxzdf4q76k
```