### PR TITLE
r-rlang: add v1.1.1, v1.1.2

### DIFF
--- a/var/spack/repos/builtin/packages/r-rlang/package.py
+++ b/var/spack/repos/builtin/packages/r-rlang/package.py
@@ -14,6 +14,8 @@ class RRlang(RPackage):
 
     cran = "rlang"
 
+    version("1.1.2", sha256="2a0ee1dc6e5c59b283c32db5e74e869922a336197cb406fe92622b6ec66f8092")
+    version("1.1.1", sha256="5e5ec9a7796977216c39d94b1e342e08f0681746657067ba30de11b8fa8ada99")
     version("1.1.0", sha256="f89859d91c9edc05fd7ccf21163fe53ad58da907ee273a93d5ab004a8649335b")
     version("1.0.6", sha256="e6973d98a0ea301c0da1eeaa435e9e65d1c3f0b95ed68bdc2d6cb0c610166760")
     version("1.0.2", sha256="8de87c3e6fb0b3cce2dabc6908186f8e1528cc0c16b54de965fe02d405fdd7cc")


### PR DESCRIPTION
r-rlang: add v1.1.1, v1.1.2

built successfully in:
linux-ubuntu22.04-zen3 / gcc@11.4.0