### PR TITLE
root: new version 6.30.00

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -34,6 +34,7 @@ class Root(CMakePackage):
     # Development version (when more recent than production).
 
     # Production version
+    version("6.30.00", sha256="0592c066954cfed42312957c9cb251654456064fe2d8dabdcb8826f1c0099d71")
     version("6.28.06", sha256="af3b673b9aca393a5c9ae1bf86eab2672aaf1841b658c5c6e7a30ab93c586533")
     version("6.28.04", sha256="70f7f86a0cd5e3f2a0befdc59942dd50140d990ab264e8e56c7f17f6bfe9c965")
     version("6.28.02", sha256="6643c07710e68972b00227c68b20b1016fec16f3fba5f44a571fa1ce5bb42faa")
@@ -160,9 +161,9 @@ class Root(CMakePackage):
     )
     variant("mysql", default=False, description="Enable support for MySQL databases")
     variant("opengl", default=True, description="Enable OpenGL support")
-    variant("oracle", default=False, description="Enable support for Oracle databases")
+    variant("oracle", when="@:6.30", default=False, description="Enable support for Oracle databases")
     variant("postgres", default=False, description="Enable postgres support")
-    variant("pythia6", default=False, description="Enable pythia6 support")
+    variant("pythia6", when="@:6.30", default=False, description="Enable pythia6 support")
     variant("pythia8", default=False, description="Enable pythia8 support")
     variant("python", default=True, description="Enable Python ROOT bindings")
     variant("qt4", when="@:6.17", default=False, description="Enable Qt graphics backend")
@@ -290,6 +291,7 @@ class Root(CMakePackage):
     depends_on("unuran", when="+unuran")
     depends_on("vc@1.0:", when="@6.07.04: +vc")
     depends_on("vc@1.3.0:", when="@6.09.02: +vc")
+    depends_on("vc@1.4.4:", when="@6.29.02: +vc")
     depends_on("vdt", when="+vdt")
     depends_on("veccore", when="+veccore")
     depends_on("libxml2", when="+xml")
@@ -320,6 +322,7 @@ class Root(CMakePackage):
     conflicts("+tmva", when="~mlp", msg="root+tmva requires MLP")
     conflicts("cxxstd=11", when="+root7", msg="root7 requires at least C++14")
     conflicts("cxxstd=11", when="@6.25.02:", msg="This version of root requires at least C++14")
+    conflicts("cxxstd=14", when="@6.30.00:", msg="This version of root requires at least C++17")
     conflicts(
         "cxxstd=20", when="@:6.28.02", msg="C++20 support requires root version at least 6.28.04"
     )

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -161,7 +161,9 @@ class Root(CMakePackage):
     )
     variant("mysql", default=False, description="Enable support for MySQL databases")
     variant("opengl", default=True, description="Enable OpenGL support")
-    variant("oracle", when="@:6.30", default=False, description="Enable support for Oracle databases")
+    variant(
+        "oracle", when="@:6.30", default=False, description="Enable support for Oracle databases"
+    )
     variant("postgres", default=False, description="Enable postgres support")
     variant("pythia6", when="@:6.30", default=False, description="Enable pythia6 support")
     variant("pythia8", default=False, description="Enable pythia8 support")

--- a/var/spack/repos/builtin/packages/vc/package.py
+++ b/var/spack/repos/builtin/packages/vc/package.py
@@ -13,6 +13,7 @@ class Vc(CMakePackage):
     git = "https://github.com/VcDevel/Vc.git"
     url = "https://github.com/VcDevel/Vc/archive/refs/tags/1.3.3.tar.gz"
 
+    version("1.4.4", sha256="5933108196be44c41613884cd56305df320263981fe6a49e648aebb3354d57f3")
     version("1.4.3", sha256="988ea0053f3fbf17544ca776a2749c097b3139089408b0286fa4e9e8513e037f")
     version("1.4.2", sha256="50d3f151e40b0718666935aa71d299d6370fafa67411f0a9e249fbce3e6e3952")
     version("1.4.1", sha256="7e8b57ed5ff9eb0835636203898c21302733973ff8eaede5134dd7cb87f915f6")


### PR DESCRIPTION
There is a new release of ROOT, v6.30.00, with release notes at https://root.cern/doc/v630/release-notes.html.

In addition to some deprecations of build options, this updates the C++ standard to 17 or higher (well, 20), and increases the minimum version of Vc to 1.4.4 (herewith added).

Builds:
```
[+] /opt/software/linux-ubuntu23.10-skylake/gcc-13.2.0/root-6.30.00-4pqcuk42fn76l4bnjpnsl7fhcznybeua
```