### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -76,8 +76,8 @@ class EcmwfAtlas(CMakePackage):
 
     @when("+fismahigh")
     def patch(self):
-        filter_file("http://www\.ecmwf\.int", "", "cmake/atlas-import.cmake.in")  # noqa: W605
-        filter_file("int\.ecmwf", "", "cmake/atlas-import.cmake.in")  # noqa: W605
+        filter_file("http://www.ecmwf.int", "", "cmake/atlas-import.cmake.in", string=True)
+        filter_file("int.ecmwf", "", "cmake/atlas-import.cmake.in", string=True)
         filter_file('http[^"]+', "", "cmake/atlas_export.cmake")
         patterns = [".travis.yml", "tools/install*.sh", "tools/github-sha.sh"]
         for pattern in patterns:

--- a/var/spack/repos/builtin/packages/ncview/package.py
+++ b/var/spack/repos/builtin/packages/ncview/package.py
@@ -26,9 +26,10 @@ class Ncview(AutotoolsPackage):
         patched_file = "configure"
         with keep_modification_time(patched_file):
             filter_file(
-                "if test x\$CC_TEST_SAME != x\$NETCDF_CC_TEST_SAME; then",  # noqa: W605
+                "if test x$CC_TEST_SAME != x$NETCDF_CC_TEST_SAME; then",
                 "if false; then",
                 patched_file,
+                string=True,
             )
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/py-imagecodecs/package.py
+++ b/var/spack/repos/builtin/packages/py-imagecodecs/package.py
@@ -66,11 +66,12 @@ class PyImagecodecs(PythonPackage):
         )
         # 239
         filter_file(
-            "append\('/usr/include/jxrlib'\)",  # noqa: W605
+            "append('/usr/include/jxrlib')",
             "extend(('{0}/libjxr/image', '{0}/libjxr/common', '{0}/libjxr/glue'))".format(  # noqa: E501
                 spec["jxrlib-debian"].prefix.include
             ),
             "setup.py",
+            string=True,
         )
 
         # 367


### PR DESCRIPTION
Using Python 3.12 in a freshly cloned Spack repository results in warnings such as this:
```
==> Warning: invalid escape sequence '\$'
==> Warning: invalid escape sequence '\('
==> Warning: invalid escape sequence '\.'
==> Warning: invalid escape sequence '\.'
```
These will turn into errors in 3.13, so fix them. All of them actually do not need to be regexes, so convert them into normal strings.