### PR TITLE
intel-oneapi 2024.0.0: added new version to packages

### DIFF
--- a/lib/spack/docs/build_systems/inteloneapipackage.rst
+++ b/lib/spack/docs/build_systems/inteloneapipackage.rst
@@ -53,18 +53,24 @@ Install the oneAPI compilers::
 
 Add the compilers to your ``compilers.yaml`` so spack can use them::
 
-  spack compiler add `spack location -i intel-oneapi-compilers`/compiler/latest/linux/bin/intel64
-  spack compiler add `spack location -i intel-oneapi-compilers`/compiler/latest/linux/bin
+  spack compiler add `spack location -i intel-oneapi-compilers`/compiler/latest/bin
 
 Verify that the compilers are available::
 
   spack compiler list
 
+Note that 2024 and later releases do not include ``icc``. Before 2024,
+the package layout was different::
+  
+  spack compiler add `spack location -i intel-oneapi-compilers`/compiler/latest/linux/bin/intel64
+  spack compiler add `spack location -i intel-oneapi-compilers`/compiler/latest/linux/bin
+
 The ``intel-oneapi-compilers`` package includes 2 families of
 compilers:
 
 * ``intel``: ``icc``, ``icpc``, ``ifort``. Intel's *classic*
-  compilers.
+  compilers. 2024 and later releases contain ``ifort``, but not
+  ``icc`` and ``icpc``.
 * ``oneapi``: ``icx``, ``icpx``, ``ifx``. Intel's new generation of
   compilers based on LLVM.
 
@@ -89,8 +95,8 @@ Install the oneAPI compilers::
 
 Add the compilers to your ``compilers.yaml`` so Spack can use them::
 
-  spack compiler add `spack location -i intel-oneapi-compilers`/compiler/latest/linux/bin/intel64
-  spack compiler add `spack location -i intel-oneapi-compilers`/compiler/latest/linux/bin
+  spack compiler add `spack location -i intel-oneapi-compilers`/compiler/latest/bin
+  spack compiler add `spack location -i intel-oneapi-compilers`/compiler/latest/bin
 
 Verify that the compilers are available::
 
@@ -146,8 +152,7 @@ Compilers
 To use the compilers, add some information about the installation to
 ``compilers.yaml``. For most users, it is sufficient to do::
 
-  spack compiler add /opt/intel/oneapi/compiler/latest/linux/bin/intel64
-  spack compiler add /opt/intel/oneapi/compiler/latest/linux/bin
+  spack compiler add /opt/intel/oneapi/compiler/latest/bin
 
 Adapt the paths above if you did not install the tools in the default
 location. After adding the compilers, using them is the same
@@ -155,6 +160,12 @@ as if you had installed the ``intel-oneapi-compilers`` package.
 Another option is to manually add the configuration to
 ``compilers.yaml`` as described in :ref:`Compiler configuration
 <compiler-config>`.
+
+Before 2024, the directory structure was different::
+  
+  spack compiler add /opt/intel/oneapi/compiler/latest/linux/bin/intel64
+  spack compiler add /opt/intel/oneapi/compiler/latest/linux/bin
+
 
 Libraries
 ---------

--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -6,6 +6,8 @@
 import os
 from os.path import dirname
 
+from llnl.util import tty
+
 from spack.compiler import Compiler
 
 
@@ -135,3 +137,13 @@ class Oneapi(Compiler):
         #   Executable "sycl-post-link" doesn't exist!
         if self.cxx:
             env.prepend_path("PATH", dirname(self.cxx))
+
+        # 2024 release bumped the libsycl version because of an ABI
+        # change, 2024 compilers are required.  You will see this
+        # error:
+        #
+        # /usr/bin/ld: warning: libsycl.so.7, needed by ...., not found
+        if pkg.spec.satisfies("%oneapi@:2023"):
+            for c in ["dnn"]:
+                if pkg.spec.satisfies(f"^intel-oneapi-{c}@2024:"):
+                    tty.warn(f"intel-oneapi-{c}@2024 SYCL APIs requires %oneapi@2024:")

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -64,6 +64,9 @@ spack:
       require: "%gcc"
     bison:
       require: '%gcc'
+    # sycl abi change means you need 2024 compiler to use 2024 mkl
+    intel-oneapi-mkl:
+      require: "@2023"
 
   specs:
   # CPU

--- a/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
@@ -25,6 +25,12 @@ class IntelOneapiAdvisor(IntelOneApiLibraryPackageWithSdk):
     )
 
     version(
+        "2024.0.0",
+        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/88c5bdaa-7a2d-491f-9871-7170fadc3d52/l_oneapi_advisor_p_2024.0.0.49522_offline.sh",
+        sha256="0ef3cf39c2fbb39371ac2470dad7d0d8cc0a2709c4f78dcab58d115b446c81c4",
+        expand=False,
+    )
+    version(
         "2023.2.0",
         url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/0b0e8bf2-30e4-4a26-b1ef-e369b0181b35/l_oneapi_advisor_p_2023.2.0.49489_offline.sh",
         sha256="48ab7fa2b828a273d467c8f07efd64d6cf2fcdcfe0ff567bd1d1be7a5d5d8539",

--- a/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
@@ -80,5 +80,9 @@ class IntelOneapiAdvisor(IntelOneApiLibraryPackageWithSdk):
     )
 
     @property
+    def v2_layout_versions(self):
+        return "@2024:"
+
+    @property
     def component_dir(self):
         return "advisor"

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -107,5 +107,9 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
     )
 
     @property
+    def v2_layout_versions(self):
+        return "@2021.11:"
+
+    @property
     def component_dir(self):
         return "ccl"

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -28,6 +28,12 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
     depends_on("intel-oneapi-mpi")
 
     version(
+        "2021.11.0",
+        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/9e63eba5-2b3d-4032-ad22-21f02e35b518/l_oneapi_ccl_p_2021.11.0.49161_offline.sh",
+        sha256="35fde9862d620c211064addfd3c15c4fc33bcaac6fe050163eb59a006fb9d476",
+        expand=False,
+    )
+    version(
         "2021.10.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/3230823d-f799-4d1f-8ef3-a17f086a7719/l_oneapi_ccl_p_2021.10.0.49084_offline.sh",
         sha256="482b9a083c997df496309a40ef1293807fc0ce1c7c43ebe6be2acf568087544b",

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
@@ -36,6 +36,7 @@ class IntelOneapiCompilersClassic(Package):
         "2021.8.0": "2023.0.0",
         "2021.9.0": "2023.1.0",
         "2021.10.0": "2023.2.0",
+        "2021.11.0": "2024.0.0",
     }.items():
         version(ver)
         depends_on("intel-oneapi-compilers@" + oneapi_ver, when="@" + ver, type="run")

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
@@ -38,7 +38,8 @@ class IntelOneapiCompilersClassic(Package):
         "2021.10.0": "2023.2.0",
         "2021.11.0": "2024.0.0",
     }.items():
-        version(ver)
+        # prefer 2021.10.0 because it is the last one that has a C compiler
+        version(ver, preferred=(ver == "2021.10.0"))
         depends_on("intel-oneapi-compilers@" + oneapi_ver, when="@" + ver, type="run")
 
     # icc@2021.6.0 does not support gcc@12 headers

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -8,6 +8,17 @@ from spack.package import *
 
 versions = [
     {
+        "version": "2024.0.0",
+        "cpp": {
+            "url": "https://registrationcenter-download.intel.com/akdlm//IRC_NAS/5c8e686a-16a7-4866-b585-9cf09e97ef36/l_dpcpp-cpp-compiler_p_2024.0.0.49524_offline.sh",
+            "sha256": "d10bad2009c98c631fbb834aae62012548daeefc806265ea567316cd9180a684",
+        },
+        "ftn": {
+            "url": "https://registrationcenter-download.intel.com/akdlm//IRC_NAS/89b0fcf9-5c00-448a-93a1-5ee4078e008e/l_fortran-compiler_p_2024.0.0.49493_offline.sh",
+            "sha256": "57faf854b8388547ee4ef2db387a9f6f3b4d0cebd67b765cf5e844a0a970d1f9",
+        },
+    },
+    {
         "version": "2023.2.1",
         "cpp": {
             "url": "https://registrationcenter-download.intel.com/akdlm//IRC_NAS/ebf5d9aa-17a7-46a4-b5df-ace004227c0e/l_dpcpp-cpp-compiler_p_2023.2.1.8_offline.sh",

--- a/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
@@ -27,6 +27,12 @@ class IntelOneapiDal(IntelOneApiLibraryPackage):
     )
 
     version(
+        "2024.0.0",
+        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/37364086-b3cd-4a54-8736-7893732c1a86/l_daal_oneapi_p_2024.0.0.49569_offline.sh",
+        sha256="45e71c7cbf38b04a34c47e36e2d86a48847f2f0485bafbc3445077a9ba3fa73c",
+        expand=False,
+    )
+    version(
         "2023.2.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/fa218373-4b06-451f-8f4c-66b7d14b8e8b/l_daal_oneapi_p_2023.2.0.49574_offline.sh",
         sha256="643c6b5a9d06bc82b610257645cde116dc0473935a3b969850fa72c6cb952eaf",

--- a/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
@@ -111,5 +111,9 @@ class IntelOneapiDal(IntelOneApiLibraryPackage):
     provides("onedal")
 
     @property
+    def v2_layout_versions(self):
+        return "@2024:"
+
+    @property
     def component_dir(self):
         return "dal"

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -108,15 +108,24 @@ class IntelOneapiDnn(IntelOneApiLibraryPackage):
     depends_on("tbb")
 
     @property
+    def v2_layout_versions(self):
+        return "@2024:"
+
+    @property
     def component_dir(self):
         return "dnnl"
 
+    def __target(self):
+        if self.v2_layout:
+            return self.component_prefix
+        else:
+            return self.component_prefix.cpu_dpcpp_gpu_dpcpp
+
     @property
     def headers(self):
-        include_path = join_path(self.component_prefix, "cpu_dpcpp_gpu_dpcpp", "include")
-        return find_headers("dnnl", include_path)
+        return find_headers("dnnl", self.__target().include)
 
     @property
     def libs(self):
-        lib_path = join_path(self.component_prefix, "cpu_dpcpp_gpu_dpcpp", "lib")
-        return find_libraries(["libdnnl", "libmkldnn"], root=lib_path, shared=True)
+        # libmkldnn was removed before 2024, but not sure when
+        return find_libraries(["libdnnl", "libmkldnn"], self.__target().lib)

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -27,6 +27,12 @@ class IntelOneapiDnn(IntelOneApiLibraryPackage):
     )
 
     version(
+        "2024.0.0",
+        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/dc309221-d210-4f3a-9406-d897df8deab8/l_onednn_p_2024.0.0.49548_offline.sh",
+        sha256="17fbd5cc5d08de33625cf2879c0cceec53c91bbcd0b863e8f29d27885bac88c9",
+        expand=False,
+    )
+    version(
         "2023.2.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2d218b97-0175-4f8c-8dba-b528cec24d55/l_onednn_p_2023.2.0.49517_offline.sh",
         sha256="96bb92b1b072e1886151b2fc0e48f27a2dc378cd92bd3f428f5166b83ae41798",

--- a/var/spack/repos/builtin/packages/intel-oneapi-dpct/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dpct/package.py
@@ -20,6 +20,12 @@ class IntelOneapiDpct(IntelOneApiPackage):
     homepage = "https://www.intel.com/content/www/us/en/developer/tools/oneapi/dpc-compatibility-tool.html#gs.2p8km6"
 
     version(
+        "2024.0.0",
+        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/6633bc4b-5356-471a-9aae-d5e63e7acd95/l_dpcpp-ct_p_2024.0.0.49394_offline.sh",
+        sha256="5fdba92edf24084187d98f083f9a6e17ee6b33ad8a736d6c9cdd3dbd4e0eab8a",
+        expand=False,
+    )
+    version(
         "2023.2.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/764119eb-2959-4b51-bb3c-3cf581c16186/l_dpcpp-ct_p_2023.2.0.49333_offline.sh",
         sha256="3b4ca40c23a5114d4c5591694e4b43960bb55329455e86d8d876c3d5a366159b",

--- a/var/spack/repos/builtin/packages/intel-oneapi-dpct/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dpct/package.py
@@ -63,5 +63,9 @@ class IntelOneapiDpct(IntelOneApiPackage):
     )
 
     @property
+    def v2_layout_versions(self):
+        return "@2024:"
+
+    @property
     def component_dir(self):
         return "dpcpp-ct"

--- a/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
@@ -84,15 +84,15 @@ class IntelOneapiDpl(IntelOneApiLibraryPackage):
     )
 
     @property
+    def v2_layout_versions(self):
+        return "@2022.3:"
+
+    @property
     def component_dir(self):
         return "dpl"
 
     @property
     def headers(self):
-        include_path = join_path(self.component_prefix, "linux", "include")
-        headers = find_headers("*", include_path, recursive=True)
-        # Force this directory to be added to include path, even
-        # though no files are here because all includes are relative
-        # to this path
-        headers.directories = [include_path]
-        return headers
+        return self.header_directories(
+            [self.component_prefix.include, self.component_prefix.linux.include]
+        )

--- a/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
@@ -23,6 +23,12 @@ class IntelOneapiDpl(IntelOneApiLibraryPackage):
     homepage = "https://github.com/oneapi-src/oneDPL"
 
     version(
+        "2022.3.0",
+        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/be027095-148a-4433-aff4-c6e8582da3ca/l_oneDPL_p_2022.3.0.49386_offline.sh",
+        sha256="1e40c6562bc41fa5a46c80c09222bf12d36d8e82f749476d0a7e97503d4659df",
+        expand=False,
+    )
+    version(
         "2022.2.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/44f88a97-7526-48f0-8515-9bf1356eb7bb/l_oneDPL_p_2022.2.0.49287_offline.sh",
         sha256="5f75e5c4e924b833a5b5d7a8cb812469d524a3ca4bda68c8ac850484dc0afd23",

--- a/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
@@ -86,5 +86,9 @@ class IntelOneapiInspector(IntelOneApiLibraryPackageWithSdk):
     )
 
     @property
+    def v2_layout_versions(self):
+        return "@2024:"
+
+    @property
     def component_dir(self):
         return "inspector"

--- a/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
@@ -25,6 +25,12 @@ class IntelOneapiInspector(IntelOneApiLibraryPackageWithSdk):
     homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/inspector.html"
 
     version(
+        "2024.0.0",
+        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/44ae6846-719c-49bd-b196-b16ce5835a1e/l_inspector_oneapi_p_2024.0.0.49433_offline.sh",
+        sha256="2b281c3a704a242aa3372284960ea8ed5ed1ba293cc2f70c2f873db3300c80a3",
+        expand=False,
+    )
+    version(
         "2023.2.0",
         url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/2a99eafd-5109-41a1-9762-aee0c7ecbeb7/l_inspector_oneapi_p_2023.2.0.49304_offline.sh",
         sha256="36b2ca94e5a69b68cbf9cbfde0a8e1aa58d02fb03f4d81db69769c96c20d4130",

--- a/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
@@ -111,5 +111,9 @@ class IntelOneapiIpp(IntelOneApiLibraryPackage):
     provides("ipp")
 
     @property
+    def v2_layout_versions(self):
+        return "@2021.10:"
+
+    @property
     def component_dir(self):
         return "ipp"

--- a/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
@@ -28,6 +28,12 @@ class IntelOneapiIpp(IntelOneApiLibraryPackage):
     )
 
     version(
+        "2021.10.0",
+        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/2d48c7d9-e716-4c73-8fe5-77a9599a405f/l_ipp_oneapi_p_2021.10.0.670_offline.sh",
+        sha256="c4ad98f96760b0a821dbcd59963c5148fd9dc4eb790af0e6e765a5f36525d202",
+        expand=False,
+    )
+    version(
         "2021.9.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/616a3fba-4ab6-4317-a17b-2be4b737fc37/l_ipp_oneapi_p_2021.9.0.49454_offline.sh",
         sha256="2c6e03dea143b6e508f5ff5f2dffb03a9d64b980453575e4a028ecd2c6aebbfe",

--- a/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
@@ -29,6 +29,12 @@ class IntelOneapiIppcp(IntelOneApiLibraryPackage):
     )
 
     version(
+        "2021.9.0",
+        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/6792a758-2d69-4ff3-ad24-233fb3bf56e4/l_ippcp_oneapi_p_2021.9.0.533_offline.sh",
+        sha256="5eca6fd18d9117f8cb7c599cee418b9cc3d7d5d5404f1350d47289095b6a1254",
+        expand=False,
+    )
+    version(
         "2021.8.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/f488397a-bd8f-449f-9127-04de8426aa35/l_ippcp_oneapi_p_2021.8.0.49493_offline.sh",
         sha256="ac380d98dc9a12007f11537a1a57a848d4ccb251c4773608b088cf677e72c6d8",

--- a/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
@@ -108,5 +108,9 @@ class IntelOneapiIppcp(IntelOneApiLibraryPackage):
     )
 
     @property
+    def v2_layout_versions(self):
+        return "@2021.9:"
+
+    @property
     def component_dir(self):
         return "ippcp"

--- a/var/spack/repos/builtin/packages/intel-oneapi-itac/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-itac/package.py
@@ -28,6 +28,12 @@ class IntelOneapiItac(IntelOneApiPackage):
     maintainers("rscohn2")
 
     version(
+        "2022.0.0",
+        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/e83526f5-7e0f-4708-9e0d-47f1e65f29aa/l_itac_oneapi_p_2022.0.0.49690_offline.sh",
+        sha256="6ab2888afcfc981273aed3df316463fbaf511faf83ee091ca79016459b03b79e",
+        expand=False,
+    )
+    version(
         "2021.10.0",
         url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/226adf12-b7f6-407e-95a9-8e9ab76d7631/l_itac_oneapi_p_2021.10.0.14_offline.sh",
         sha256="cfff2ee19c793b64074b5490a16acbe8c9767f41d391d7c71c0004fdcec501c7",

--- a/var/spack/repos/builtin/packages/intel-oneapi-itac/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-itac/package.py
@@ -65,5 +65,9 @@ class IntelOneapiItac(IntelOneApiPackage):
     )
 
     @property
+    def v2_layout_versions(self):
+        return "@2022:"
+
+    @property
     def component_dir(self):
         return "itac"

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -135,12 +135,12 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
     provides("lapack", "blas")
 
     @property
-    def component_dir(self):
-        return "mkl"
+    def v2_layout_versions(self):
+        return "@2024:"
 
     @property
-    def headers(self):
-        return find_headers("*", self.component_prefix.include)
+    def component_dir(self):
+        return "mkl"
 
     @property
     def libs(self):
@@ -204,7 +204,9 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
                     )
                 )
 
-        lib_path = self.component_prefix.lib.intel64
+        lib_path = (
+            self.component_prefix.lib if self.v2_layout else self.component_prefix.lib.intel64
+        )
         lib_path = lib_path if isdir(lib_path) else dirname(lib_path)
 
         resolved_libs = find_libraries(libs, lib_path, shared=shared)
@@ -225,5 +227,11 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
 
     @run_after("install")
     def fixup_prefix(self):
+        # The motivation was to provide a more standard layout so mkl
+        # would be more likely to work as a virtual dependence. I am
+        # not sure if this mechanism is useful and it became a problem
+        # for mpi so disabling for v2_layout.
+        if self.v2_layout:
+            return
         self.symlink_dir(self.component_prefix.include, self.prefix.include)
         self.symlink_dir(self.component_prefix.lib, self.prefix.lib)

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -26,6 +26,12 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
     )
 
     version(
+        "2024.0.0",
+        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/86d6a4c1-c998-4c6b-9fff-ca004e9f7455/l_onemkl_p_2024.0.0.49673_offline.sh",
+        sha256="2a3be7d01d75ba8cc3059f9a32ae72e5bfc93e68e72e94e79d7fa6ea2f7814de",
+        expand=False,
+    )
+    version(
         "2023.2.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/adb8a02c-4ee7-4882-97d6-a524150da358/l_onemkl_p_2023.2.0.49497_offline.sh",
         sha256="4a0d93da85a94d92e0ad35dc0fc3b3ab7f040bd55ad374c4d5ec81a57a2b872b",

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -22,6 +22,12 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
     homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/mpi-library.html"
 
     version(
+        "2021.11.0",
+        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/2c45ede0-623c-4c8e-9e09-bed27d70fa33/l_mpi_oneapi_p_2021.11.0.49513_offline.sh",
+        sha256="9a96caeb7abcf5aa08426216db38a2c7936462008b9825036266bc79cb0e30d8",
+        expand=False,
+    )
+    version(
         "2021.10.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/4f5871da-0533-4f62-b563-905edfb2e9b7/l_mpi_oneapi_p_2021.10.0.49374_offline.sh",
         sha256="ab2e97d87b139201a2e7dab9a61ac6e8927b7783b459358c4ad69a1b1c064f40",

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -114,6 +114,10 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
     provides("mpi@:3.1")
 
     @property
+    def v2_layout_versions(self):
+        return "@2021.11:"
+
+    @property
     def component_dir(self):
         return "mpi"
 
@@ -161,10 +165,9 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
 
     @property
     def headers(self):
-        headers = find_headers("*", self.component_prefix.include)
-        if "+ilp64" in self.spec:
-            headers += find_headers("*", self.component_prefix.include.ilp64)
-        return headers
+        return self.header_directories(
+            [self.component_prefix.include, self.component_prefix.include.ilp64]
+        )
 
     @property
     def libs(self):
@@ -198,6 +201,13 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
 
     @run_after("install")
     def fixup_prefix(self):
+        # The motivation was to provide a more standard layout so impi
+        # would be more likely to work as a virtual dependence.  It
+        # does not work for v2_layout because of a library conflict. I
+        # am not sure if this mechanism is useful so disabling for
+        # v2_layout rather than try to make it work.
+        if self.v2_layout:
+            return
         self.symlink_dir(self.component_prefix.include, self.prefix.include)
         self.symlink_dir(self.component_prefix.lib, self.prefix.lib)
         self.symlink_dir(self.component_prefix.lib.release, self.prefix.lib)

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -23,6 +23,12 @@ class IntelOneapiTbb(IntelOneApiLibraryPackage):
     )
 
     version(
+        "2021.11.0",
+        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/af3ad519-4c87-4534-87cb-5c7bda12754e/l_tbb_oneapi_p_2021.11.0.49527_offline.sh",
+        sha256="dd878ee979d7b6da4eb973adfebf814d9d7eed86b875d31e3662d100b2fa0956",
+        expand=False,
+    )
+    version(
         "2021.10.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c95cd995-586b-4688-b7e8-2d4485a1b5bf/l_tbb_oneapi_p_2021.10.0.49543_offline.sh",
         sha256="a10d319e67b6904d6199f8294e970124a064d9948cf7e2b5ebab94499aadc6ca",

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -107,7 +107,17 @@ class IntelOneapiTbb(IntelOneApiLibraryPackage):
     def component_dir(self):
         return "tbb"
 
+    @property
+    def v2_layout_versions(self):
+        return "@2021.11:"
+
     @run_after("install")
     def fixup_prefix(self):
+        # The motivation was to provide a more standard layout so tbb
+        # would be more likely to work as a virtual dependence. I am
+        # not sure if this mechanism is useful and it became a problem
+        # for mpi so disabling for v2_layout.
+        if self.v2_layout:
+            return
         self.symlink_dir(self.component_prefix.include, self.prefix.include)
         self.symlink_dir(self.component_prefix.lib, self.prefix.lib)

--- a/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
@@ -74,6 +74,12 @@ class IntelOneapiVpl(IntelOneApiLibraryPackage):
         expand=False,
     )
 
+    # VPL no longer releases as part of oneapi, so there will never be
+    # a 2024 release
+    @property
+    def v2_layout_versions(self):
+        return "@2024:"
+
     @property
     def component_dir(self):
         return "vpl"

--- a/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
@@ -87,5 +87,9 @@ class IntelOneapiVtune(IntelOneApiLibraryPackageWithSdk):
     )
 
     @property
+    def v2_layout_versions(self):
+        return "@2024:"
+
+    @property
     def component_dir(self):
         return "vtune"

--- a/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
@@ -26,6 +26,12 @@ class IntelOneapiVtune(IntelOneApiLibraryPackageWithSdk):
     homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/vtune-profiler.html"
 
     version(
+        "2024.0.0",
+        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/1722cc83-ceb2-4304-b4dc-2813780222a3/l_oneapi_vtune_p_2024.0.0.49503_offline.sh",
+        sha256="09537329bdf6e105b0e164f75dc8ae122adc99a64441f6a52225509bcff3b848",
+        expand=False,
+    )
+    version(
         "2023.2.0",
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/dfae6f23-6c90-4b9f-80e2-fa2a5037fe36/l_oneapi_vtune_p_2023.2.0.49485_offline.sh",
         sha256="482a727afe0ac6f81eff51503857c28fcb79ffdba76260399900f3397fd0adbd",


### PR DESCRIPTION
Update packages for oneapi 2024.0.0. There are 2 commits. The first commit adds the new versions. The 2nd commit are changes required to support he new versions.

Changes for 2024.0.0:
* the path for a component has changed: e.g. from `<prefix>/mkl/2023.2.0` to `<prefix>/mkl/2023.2`
* the layout inside a component has consolidated multiple directories that contain include files and libraries into a single lib/include for each component
* no longer contains updated `icc`/`icpc`. It still contains `ifort`, `icx`, `icpx`, `ifx`

There are many changes and it is difficult to test, so I may have broken support for older oneapi releases. The basic tests pass: https://github.com/rscohn2/oneapi-spack-tests/pull/41 and I manually tested against the previous oneapi release

Ideally, https://github.com/spack/spack/pull/41213 would be merged first to avoid the confusing errors when trying to use the latest classic compilers.