### PR TITLE
py-h5py: reorder dependencies from newest version to oldest

### DIFF
--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -38,39 +38,39 @@ class PyH5py(PythonPackage):
     variant("mpi", default=True, description="Build with MPI support")
 
     # Python versions
-    depends_on("python@:3.9", type=("build", "run"), when="@:2.8")
-    depends_on("python@3.6:", type=("build", "run"), when="@3:3.1")
     depends_on("python@3.7:", type=("build", "run"), when="@3.2:")
+    depends_on("python@3.6:", type=("build", "run"), when="@3:3.1")
+    depends_on("python@:3.9", type=("build", "run"), when="@:2.8")
 
     # Build dependencies
-    depends_on("py-cython@0.23:0", type="build", when="@:2")
-    depends_on("py-cython@0.29:0", type=("build"), when="@3:")
-    depends_on("py-cython@0.29.14:0", type=("build"), when="@3:3.7 ^python@3.8.0:3.8")
     depends_on("py-cython@0.29.15:0", type=("build"), when="@3:3.7 ^python@3.9.0:")
+    depends_on("py-cython@0.29.14:0", type=("build"), when="@3:3.7 ^python@3.8.0:3.8")
+    depends_on("py-cython@0.29:0", type=("build"), when="@3:")
+    depends_on("py-cython@0.23:0", type="build", when="@:2")
     depends_on("py-pkgconfig", type="build")
-    depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@61:", type="build", when="@3.8.0:")
+    depends_on("py-setuptools", type="build")
     depends_on("py-wheel", type="build", when="@3:")
 
     # Build and runtime dependencies
     depends_on("py-cached-property@1.5:", type=("build", "run"), when="@:3.6 ^python@:3.7")
-    depends_on("py-numpy@1.7:", type=("build", "run"), when="@:2")
-    depends_on("py-numpy@1.14.5:", type=("build", "run"), when="@3:")
-    depends_on("py-numpy@1.17.5:", type=("build", "run"), when="@3:3.5 ^python@3.8.0:3.8")
     depends_on("py-numpy@1.19.3:", type=("build", "run"), when="@3:3.5 ^python@3.9.0:")
+    depends_on("py-numpy@1.17.5:", type=("build", "run"), when="@3:3.5 ^python@3.8.0:3.8")
+    depends_on("py-numpy@1.14.5:", type=("build", "run"), when="@3:")
+    depends_on("py-numpy@1.7:", type=("build", "run"), when="@:2")
     depends_on("py-six", type=("build", "run"), when="@:2")
 
     # Link dependencies (py-h5py v2 cannot build against HDF5 1.12 regardless
     # of API setting)
-    depends_on("hdf5@1.8.4:1.11 +hl", when="@:2")
-    depends_on("hdf5@1.8.4:1.12 +hl", when="@3:3.7")
     depends_on("hdf5@1.8.4:1.14 +hl", when="@3.8:")
+    depends_on("hdf5@1.8.4:1.12 +hl", when="@3:3.7")
+    depends_on("hdf5@1.8.4:1.11 +hl", when="@:2")
 
     # MPI dependencies
     depends_on("hdf5+mpi", when="+mpi")
     depends_on("mpi", when="+mpi")
-    depends_on("py-mpi4py", when="@:2 +mpi", type=("build", "run"))
     depends_on("py-mpi4py@3.0.2:", when="@3: +mpi", type=("build", "run"))
+    depends_on("py-mpi4py", when="@:2 +mpi", type=("build", "run"))
 
     def flag_handler(self, name, flags):
         if name == "cflags":


### PR DESCRIPTION
I think this is how it is done in most packages and should be the expected order