### PR TITLE
ASP-based solver: don't error for type mismatch on preferences

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1839,7 +1839,11 @@ class SpackSolverSetup:
 
             # perform validation of the variant and values
             spec = spack.spec.Spec(pkg_name)
-            spec.update_variant_validate(variant_name, values)
+            try:
+                spec.update_variant_validate(variant_name, values)
+            except spack.error.SpackError:
+                tty.debug(f"[SETUP]: rejected {str(variant)} as a preference for {pkg_name}")
+                continue
 
             for value in values:
                 self.variant_values_from_specs.add((pkg_name, variant.name, value))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1841,8 +1841,10 @@ class SpackSolverSetup:
             spec = spack.spec.Spec(pkg_name)
             try:
                 spec.update_variant_validate(variant_name, values)
-            except spack.error.SpackError:
-                tty.debug(f"[SETUP]: rejected {str(variant)} as a preference for {pkg_name}")
+            except (spack.variant.InvalidVariantValueError, KeyError, ValueError) as e:
+                tty.debug(
+                    f"[SETUP]: rejected {str(variant)} as a preference for {pkg_name}: {str(e)}"
+                )
                 continue
 
             for value in values:

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -506,6 +506,7 @@ mpich:
             assert s.satisfies("%gcc") and s.satisfies("+allow-gcc")
 
     @pytest.mark.regression("41134")
+    @pytest.mark.only_clingo("Not backporting the fix to the old concretizer")
     def test_default_preference_variant_different_type_does_not_error(self):
         """Tests that a different type for an existing variant in the 'all:' section of
         packages.yaml doesn't fail with an error.

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -504,3 +504,12 @@ mpich:
         with spack.config.override("packages:sticky-variant", {"variants": "+allow-gcc"}):
             s = Spec("sticky-variant %gcc").concretized()
             assert s.satisfies("%gcc") and s.satisfies("+allow-gcc")
+
+    @pytest.mark.regression("41134")
+    def test_default_preference_variant_different_type_does_not_error(self):
+        """Tests that a different type for an existing variant in the 'all:' section of
+        packages.yaml doesn't fail with an error.
+        """
+        with spack.config.override("packages:all", {"variants": "+foo"}):
+            s = Spec("a").concretized()
+            assert s.satisfies("foo=bar")


### PR DESCRIPTION
fixes #41134

This PR discards type mismatches or failures to validate a package preference during concretization. The values discarded are logged as debug level messages. It also adds a config audit to help users spot misconfigurations in `packages.yaml` preferences.