### PR TITLE
GoPackage: new package base and builder

### DIFF
--- a/lib/spack/spack/build_systems/go.py
+++ b/lib/spack/spack/build_systems/go.py
@@ -1,0 +1,103 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import inspect
+import os
+
+from typing import Optional, Tuple
+
+import llnl.util.filesystem as fs
+
+from spack.directives import build_system, depends_on
+import spack.package_base
+import spack.util.url
+from ._checks import BaseBuilder
+
+
+class GoPackage(spack.package_base.PackageBase):
+    """Specialized class for packages built using Go."""
+
+    #: This attribute is used in UI queries that need to know the build
+    #: system base class
+    build_system_class = "GoPackage"
+
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = "go"
+
+    depends_on("go", type="build")
+
+    build_system("go")
+
+
+@spack.builder.builder("go")
+class GoBuilder(BaseBuilder):
+    """The Go builder provides two phases that can be overridden if required:
+
+    #. :py:meth:`~.GoBuilder.build`
+    #. :py:meth:`~.GoBuilder.install`
+    """
+
+    #: Phases of a Go package
+    phases: Tuple[str, ...] = ("build", "install")
+
+    #: Names associated with package methods in the old build-system format
+    legacy_methods = ()
+
+    #: Names associated with package attributes in the old build-system format
+    legacy_attributes = ()
+
+    #: Path of the main.go file
+    root_main_go_dir: Optional[str] = None
+
+    @property
+    def build_directory(self):
+        """Return the directory where 'main.go' resides."""
+        return self.pkg.stage.source_path
+
+    @property
+    def root_main_go_dir(self):
+        """The relative path to the directory containing main.go.
+        Defaults to the root of the extracted tarball.
+        """
+        return self.pkg.stage.source_path
+
+    @property
+    def std_go_args(self):
+        """Standard Go arguments provided as a property for
+        convenience of package writers
+        """
+        std_go_args = GoBuilder.std_args(self.pkg)
+        std_go_args += getattr(self.pkg, "go_flag_args", [])
+        return std_go_args
+
+    @staticmethod
+    def std_args(pkg):
+        """Computes the standard Go arguments for a generic package"""
+        buildmode = "default"
+
+        args = [
+            "build",
+            "-buildmode", buildmode,
+        ]
+
+        return args
+
+    def go_args(self):
+        """List of all the arguments that must be passed to go build."""
+        return []
+
+    def setup_build_environment(self, env):
+        # Point GOPATH at the top of the staging dir for the build step.
+        env.prepend_path("GOPATH", self.stage.path)
+
+    def build(self, pkg, spec, prefix):
+        """Runs ``go build`` in the source directory"""
+        options = [
+            "-C",
+            os.path.abspath(self.root_main_go_dir),
+        ]
+        options += self.std_go_args
+        options += self.go_args()
+        with fs.working_dir(self.build_directory, create=True):
+            inspect.getmodule(self.pkg).go(*options)

--- a/lib/spack/spack/build_systems/go.py
+++ b/lib/spack/spack/build_systems/go.py
@@ -4,14 +4,14 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import inspect
 import os
-
 from typing import Optional, Tuple
 
 import llnl.util.filesystem as fs
 
-from spack.directives import build_system, depends_on
 import spack.package_base
 import spack.util.url
+from spack.directives import build_system, depends_on
+
 from ._checks import BaseBuilder
 
 
@@ -76,10 +76,7 @@ class GoBuilder(BaseBuilder):
         """Computes the standard Go arguments for a generic package"""
         buildmode = "default"
 
-        args = [
-            "build",
-            "-buildmode", buildmode,
-        ]
+        args = ["build", "-buildmode", buildmode]
 
         return args
 
@@ -93,10 +90,7 @@ class GoBuilder(BaseBuilder):
 
     def build(self, pkg, spec, prefix):
         """Runs ``go build`` in the source directory"""
-        options = [
-            "-C",
-            os.path.abspath(self.root_main_go_dir),
-        ]
+        options = ["-C", os.path.abspath(self.root_main_go_dir)]
         options += self.std_go_args
         options += self.go_args()
         with fs.working_dir(self.build_directory, create=True):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -41,6 +41,7 @@ from spack.build_systems.cmake import CMakePackage, generator
 from spack.build_systems.cuda import CudaPackage
 from spack.build_systems.generic import Package
 from spack.build_systems.gnu import GNUMirrorPackage
+from spack.build_systems.go import GoPackag
 from spack.build_systems.intel import IntelPackage
 from spack.build_systems.lua import LuaPackage
 from spack.build_systems.makefile import MakefilePackage

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -41,7 +41,7 @@ from spack.build_systems.cmake import CMakePackage, generator
 from spack.build_systems.cuda import CudaPackage
 from spack.build_systems.generic import Package
 from spack.build_systems.gnu import GNUMirrorPackage
-from spack.build_systems.go import GoPackag
+from spack.build_systems.go import GoPackage
 from spack.build_systems.intel import IntelPackage
 from spack.build_systems.lua import LuaPackage
 from spack.build_systems.makefile import MakefilePackage

--- a/var/spack/repos/builtin/packages/go-scc/package.py
+++ b/var/spack/repos/builtin/packages/go-scc/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack.package import *
+
+
+class GoScc(GoPackage):
+    """
+    Sloc, Cloc and Code: scc is a very fast accurate code counter with
+    complexity calculations and COCOMO estimates written in pure Go.
+    """
+
+    homepage = "https://github.com/boyter/scc"
+    url = "https://github.com/boyter/scc/archive/refs/tags/v3.1.0.tar.gz"
+    git = "https://github.com/boyter/scc.git"
+
+    version("master", branch="master")
+    version("3.1.0", sha256="bffea99c7f178bc48bfba3c64397d53a20a751dfc78221d347aabdce3422fd20")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install("scc", prefix.bin)


### PR DESCRIPTION
This adds `GoPackage` as a package base for Go packages. It also adds `go-scc` as an example package that uses this.

More reading at:
- https://github.com/spack/spack/issues/13023
- https://github.com/spack/spack/pull/14061

TODO: fix breakage