### PR TITLE
Add gipaw when building quantum-espresso with cmake

### DIFF
--- a/var/spack/repos/builtin/packages/quantum-espresso/gipaw-eccee44.patch
+++ b/var/spack/repos/builtin/packages/quantum-espresso/gipaw-eccee44.patch
@@ -1,0 +1,8 @@
+--- spack-src/external/submodule_commit_hash_records.org	2023-11-15 18:38:47.485317449 -0300
++++ spack-src/external/submodule_commit_hash_records	2023-11-15 18:39:02.661861757 -0300
+@@ -5,4 +5,4 @@
+ 82005cbb65bdf5d32ca021848eec8f19da956a77 mbd
+ f72ab25fa4ea755c1b4b230ae8074b47d5509c70 pw2qmcpack
+ 1d6b187374a2d50b509e5e79e2cab01a79ff7ce1 wannier90
+-f5823521ad8fdd8b8e9e29197eedb354f9b9146d qe-gipaw
++eccee44d3caf1c930fb72ad9c741fbb743eabf45 qe-gipaw

--- a/var/spack/repos/builtin/packages/quantum-espresso/gipaw-eccee44.patch
+++ b/var/spack/repos/builtin/packages/quantum-espresso/gipaw-eccee44.patch
@@ -1,8 +1,0 @@
---- spack-src/external/submodule_commit_hash_records.org	2023-11-15 18:38:47.485317449 -0300
-+++ spack-src/external/submodule_commit_hash_records	2023-11-15 18:39:02.661861757 -0300
-@@ -5,4 +5,4 @@
- 82005cbb65bdf5d32ca021848eec8f19da956a77 mbd
- f72ab25fa4ea755c1b4b230ae8074b47d5509c70 pw2qmcpack
- 1d6b187374a2d50b509e5e79e2cab01a79ff7ce1 wannier90
--f5823521ad8fdd8b8e9e29197eedb354f9b9146d qe-gipaw
-+eccee44d3caf1c930fb72ad9c741fbb743eabf45 qe-gipaw

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -227,13 +227,8 @@ class QuantumEspresso(CMakePackage, Package):
     variant(
         "gipaw",
         default=False,
-        when="build_system=generic",
         description="Builds Gauge-Including Projector Augmented-Waves executable",
     )
-    with when("+gipaw"):
-        conflicts(
-            "@:6.3", msg="gipaw standard support available for QE 6.3 or grater version only"
-        )
 
     # Dependencies not affected by variants
     depends_on("blas")
@@ -259,6 +254,13 @@ class QuantumEspresso(CMakePackage, Package):
     # THIRD-PARTY PATCHES
     # NOTE: *SOME* third-party patches will require deactivation of
     # upstream patches using `~patch` variant
+
+    #gipaw
+    conflicts(
+        "@:6.3",
+        when="+gipaw",
+        msg="gipaw standard support available for QE 6.3 or grater version only"
+    )
 
     # Only CMake will work for @6.8: %aocc
     conflicts(
@@ -400,6 +402,8 @@ class QuantumEspresso(CMakePackage, Package):
     # extlibs_makefile updated to work with fujitsu compilers
     patch("fj-fox.patch", when="+patch %fj")
 
+    # gipaw.x will only be installed with cmake if the qe-gipaw version is >= 5c4a4ce.
+    patch("gipaw-eccee44.patch", when="+gipaw build_system=cmake")
 
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):
@@ -415,6 +419,10 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             self.define_from_variant("QE_ENABLE_PROFILE_NVTX", "nvtx"),
             self.define_from_variant("QE_ENABLE_MPI_GPU_AWARE", "mpigpu"),
         ]
+
+        if "+gipaw" in spec:
+            cmake_args.append(self.define("QE_ENABLE_PLUGINS", "gipaw"))
+            cmake_args.append(self.define("QE_ENABLE_FOX", True))
 
         if "+cuda" in self.spec:
             cmake_args.append(self.define("QE_ENABLE_OPENACC", True))

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -261,7 +261,7 @@ class QuantumEspresso(CMakePackage, Package):
         when="+gipaw",
         msg="gipaw standard support available for QE 6.3 or grater version only",
     )
-    
+
     conflicts("+gipaw build_system=cmake", when="@:7.1")
 
     # Only CMake will work for @6.8: %aocc

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -402,6 +402,9 @@ class QuantumEspresso(CMakePackage, Package):
     # extlibs_makefile updated to work with fujitsu compilers
     patch("fj-fox.patch", when="+patch %fj")
 
+    # gipaw.x will only be installed with cmake if the qe-gipaw version is >= 5c4a4ce.
+    patch("gipaw-eccee44.patch", when="@7.2+gipaw build_system=cmake")
+
 
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -402,9 +402,6 @@ class QuantumEspresso(CMakePackage, Package):
     # extlibs_makefile updated to work with fujitsu compilers
     patch("fj-fox.patch", when="+patch %fj")
 
-    # gipaw.x will only be installed with cmake if the qe-gipaw version is >= 5c4a4ce.
-    patch("gipaw-eccee44.patch", when="+gipaw build_system=cmake")
-
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -259,7 +259,7 @@ class QuantumEspresso(CMakePackage, Package):
     conflicts(
         "@:6.3",
         when="+gipaw",
-        msg="gipaw standard support available for QE 6.3 or grater version only"
+        msg="gipaw standard support available for QE 6.3 or grater version only",
     )
 
     # Only CMake will work for @6.8: %aocc
@@ -300,7 +300,6 @@ class QuantumEspresso(CMakePackage, Package):
     patch_url = "https://raw.githubusercontent.com/QMCPACK/qmcpack/v3.13.0/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-7.0.diff"
     patch_checksum = "ef60641d8b953b4ba21d9c662b172611305bb63786996ad6e81e7609891677ff"
     patch(patch_url, sha256=patch_checksum, when="@7.0+qmcpack")
-    
 
     # 6.8
     patch_url = "https://raw.githubusercontent.com/QMCPACK/qmcpack/v3.13.0/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.8.diff"
@@ -402,6 +401,7 @@ class QuantumEspresso(CMakePackage, Package):
 
     # extlibs_makefile updated to work with fujitsu compilers
     patch("fj-fox.patch", when="+patch %fj")
+
 
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -257,10 +257,12 @@ class QuantumEspresso(CMakePackage, Package):
 
     # gipaw
     conflicts(
-        "@:6.3",
+        "@:6.2",
         when="+gipaw",
         msg="gipaw standard support available for QE 6.3 or grater version only",
     )
+    
+    conflicts("+gipaw build_system=cmake", when="@:7.1")
 
     # Only CMake will work for @6.8: %aocc
     conflicts(

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -255,7 +255,7 @@ class QuantumEspresso(CMakePackage, Package):
     # NOTE: *SOME* third-party patches will require deactivation of
     # upstream patches using `~patch` variant
 
-    #gipaw
+    # gipaw
     conflicts(
         "@:6.3",
         when="+gipaw",
@@ -300,6 +300,7 @@ class QuantumEspresso(CMakePackage, Package):
     patch_url = "https://raw.githubusercontent.com/QMCPACK/qmcpack/v3.13.0/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-7.0.diff"
     patch_checksum = "ef60641d8b953b4ba21d9c662b172611305bb63786996ad6e81e7609891677ff"
     patch(patch_url, sha256=patch_checksum, when="@7.0+qmcpack")
+    
 
     # 6.8
     patch_url = "https://raw.githubusercontent.com/QMCPACK/qmcpack/v3.13.0/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.8.diff"


### PR DESCRIPTION
gipaw.x will only be installed with cmake if the qe-gipaw version is >= 5c4a4ce. Currently, QE source uses the older f582352 one. Here a patch to the submodule_commit_hash_records to use a newer qe-gipaw version. 