### PR TITLE
`spack spec`: add `-d` / `--debug-nondefaults` option

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -405,6 +405,17 @@ def no_install_status():
 
 
 @arg
+def debug_nondefaults():
+    return Args(
+        "-d",
+        "--debug-nondefaults",
+        action="store_true",
+        default=False,
+        help="show non-default decisions in red",
+    )
+
+
+@arg
 def no_checksum():
     return Args(
         "-n",

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -475,10 +475,7 @@ def print_virtuals(pkg, args):
     color.cprint(section_title("Virtual Packages: "))
     if pkg.provided:
         for when, specs in reversed(sorted(pkg.provided.items())):
-            line = "    %s provides %s" % (
-                when.colorized(),
-                ", ".join(s.colorized() for s in specs),
-            )
+            line = "    %s provides %s" % (when.cformat(), ", ".join(s.cformat() for s in specs))
             print(line)
 
     else:

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -45,7 +45,9 @@ def setup_parser(subparser):
     arguments.add_common_arguments(subparser, ["long", "very_long", "namespaces"])
 
     install_status_group = subparser.add_mutually_exclusive_group()
-    arguments.add_common_arguments(install_status_group, ["install_status", "no_install_status"])
+    arguments.add_common_arguments(
+        install_status_group, ["install_status", "no_install_status", "debug_nondefaults"]
+    )
 
     subparser.add_argument(
         "-y",
@@ -145,6 +147,7 @@ def solve(parser, args):
         "show_types": args.types,
         "status_fn": install_status_fn if args.install_status else None,
         "hashes": args.long or args.very_long,
+        "nondefaults": args.debug_nondefaults,
     }
 
     # process output options

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -32,7 +32,9 @@ for further documentation regarding the spec syntax, see:
     arguments.add_common_arguments(subparser, ["long", "very_long", "namespaces"])
 
     install_status_group = subparser.add_mutually_exclusive_group()
-    arguments.add_common_arguments(install_status_group, ["install_status", "no_install_status"])
+    arguments.add_common_arguments(
+        install_status_group, ["install_status", "no_install_status", "debug_nondefaults"]
+    )
 
     format_group = subparser.add_mutually_exclusive_group()
     format_group.add_argument(
@@ -84,6 +86,8 @@ def spec(parser, args):
     tree_kwargs = {
         "cover": args.cover,
         "format": fmt,
+        "hashes": args.long or args.very_long,
+        "nondefaults": args.debug_nondefaults,
         "hashlen": None if args.very_long else 7,
         "show_types": args.types,
         "status_fn": install_status_fn if args.install_status else None,
@@ -125,12 +129,14 @@ def spec(parser, args):
             # repeated output. This happens because parse_specs outputs concrete
             # specs for `/hash` inputs.
             if not input.concrete:
-                tree_kwargs["hashes"] = False  # Always False for input spec
+                # NOTE: can use overrides | tree_kwargs in python 3.9+
+                overrides = {"hashes": False}
+                overriden_kwargs = {**overrides, **tree_kwargs}
+
                 print("Input spec")
                 print("--------------------------------")
-                print(input.tree(**tree_kwargs))
+                print(input.tree(**overriden_kwargs))
                 print("Concretized")
                 print("--------------------------------")
 
-            tree_kwargs["hashes"] = args.long or args.very_long
             print(output.tree(**tree_kwargs))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2967,6 +2967,23 @@ class RuntimePropertyRecorder:
         self._setup.effect_rules()
 
 
+def call_on_concrete(fun):
+    """Annotation for SpecBuilder actions that indicates they should be called on concrete specs.
+
+    While building Specs, we set a lot of attributes on the Specs that are under
+    construction, but we may also just look up a concrete spec (e.g., if a specific hash
+    was reused). We don't need to set most attributes on these b/c we just look them up
+    in the DB.
+
+    Metadata attributes like concretizer weights aren't stored on the spec or in the DB
+    -- they're transient annotations for a single run. So we need their handlers to be
+    called on all specs, including concrete ones.
+
+    """
+    fun._call_on_concrete = True
+    return fun
+
+
 class SpecBuilder:
     """Class with actions to rebuild a spec from ASP results."""
 
@@ -3066,6 +3083,7 @@ class SpecBuilder:
     def node_flag(self, node, flag_type, flag):
         self._specs[node].compiler_flags.add_flag(flag_type, flag, False)
 
+    @call_on_concrete
     def node_flag_source(self, node, flag_type, source):
         self._flag_sources[(node, flag_type)].add(source)
 
@@ -3174,6 +3192,31 @@ class SpecBuilder:
     def deprecated(self, node: NodeArgument, version: str) -> None:
         tty.warn(f'using "{node.pkg}@{version}" which is a deprecated version')
 
+    @call_on_concrete
+    def version_weight(self, node: NodeArgument, weight: int):
+        self._specs[node]._weights["version_weight"] = int(weight)
+
+    @call_on_concrete
+    def provider_weight(self, node: NodeArgument, virtual: str, weight: int):
+        self._specs[node]._weights.setdefault("provider_weight", 0)
+        self._specs[node]._weights["provider_weight"] += int(weight)
+
+    @call_on_concrete
+    def variant_not_default(self, node: NodeArgument, variant: str, value: str):
+        self._specs[node]._weights[f"variant_not_default({variant})"] = bool(value)
+
+    @call_on_concrete
+    def variant_default_not_used(self, node: NodeArgument, variant: str, value: str):
+        self._specs[node]._weights[f"variant_default_not_used({variant})"] = bool(value)
+
+    @call_on_concrete
+    def node_compiler_weight(self, node: NodeArgument, weight: int):
+        self._specs[node]._weights["node_compiler_weight"] = int(weight)
+
+    @call_on_concrete
+    def node_target_weight(self, node: NodeArgument, weight: int):
+        self._specs[node]._weights["node_target_weight"] = int(weight)
+
     @staticmethod
     def sort_fn(function_tuple):
         """Ensure attributes are evaluated in the correct order.
@@ -3232,13 +3275,12 @@ class SpecBuilder:
                 if spack.repo.PATH.is_virtual(pkg):
                     continue
 
-                # if we've already gotten a concrete spec for this pkg,
-                # do not bother calling actions on it except for node_flag_source,
-                # since node_flag_source is tracking information not in the spec itself
+                # if we've already gotten a concrete spec for this pkg, do not bother
+                # calling actions on it except for certain metaata methods that add
+                # information not tracked on the spec itself.
                 spec = self._specs.get(args[0])
-                if spec and spec.concrete:
-                    if name != "node_flag_source":
-                        continue
+                if spec and spec.concrete and not getattr(action, "_call_on_concrete", None):
+                    continue
 
             action(*args)
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -175,7 +175,7 @@ pkg_fact(Package, version_declared(Version, Weight)) :- pkg_fact(Package, versio
 % We cannot use a version declared for an installed package if we end up building it
 :- pkg_fact(Package, version_declared(Version, Weight, "installed")),
    attr("version", node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
+   attr("version_weight", node(ID, Package), Weight),
    not attr("hash", node(ID, Package), _),
    internal_error("Reuse version weight used for built package").
 
@@ -215,7 +215,7 @@ possible_version_weight(node(ID, Package), Weight)
 % we can't use the weight for an external version if we don't use the
 % corresponding external spec.
 :- attr("version", node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
+   attr("version_weight", node(ID, Package), Weight),
    pkg_fact(Package, version_declared(Version, Weight, "external")),
    not external(node(ID, Package)),
    internal_error("External weight used for built package").
@@ -223,18 +223,18 @@ possible_version_weight(node(ID, Package), Weight)
 % we can't use a weight from an installed spec if we are building it
 % and vice-versa
 :- attr("version", node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
+   attr("version_weight", node(ID, Package), Weight),
    pkg_fact(Package, version_declared(Version, Weight, "installed")),
    build(node(ID, Package)),
    internal_error("Reuse version weight used for build package").
 
 :- attr("version", node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
+   attr("version_weight", node(ID, Package), Weight),
    not pkg_fact(Package, version_declared(Version, Weight, "installed")),
    not build(node(ID, Package)),
    internal_error("Build version weight used for reused package").
 
-1 { version_weight(node(ID, Package), Weight) : pkg_fact(Package, version_declared(Version, Weight)) } 1
+1 { attr("version_weight", node(ID, Package), Weight) : pkg_fact(Package, version_declared(Version, Weight)) } 1
   :- attr("version", node(ID, Package), Version),
      attr("node", node(ID, Package)),
      internal_error("version weights must exist and be unique").
@@ -583,7 +583,7 @@ do_not_impose(EffectID, node(X, Package))
 % A provider may have different possible weights depending on whether it's an external
 % or not, or on preferences expressed in packages.yaml etc. This rule ensures that
 % we select the weight, among the possible ones, that minimizes the overall objective function.
-1 { provider_weight(DependencyNode, VirtualNode, Weight) :
+1 { attr("provider_weight", DependencyNode, VirtualNode, Weight) :
     possible_provider_weight(DependencyNode, VirtualNode, Weight, _) } 1
  :- provider(DependencyNode, VirtualNode), internal_error("Package provider weights must be unique").
 
@@ -626,7 +626,7 @@ error(100, "Attempted to use external for '{0}' which does not satisfy a unique 
   :- external(node(ID, Package)),
      2 { external_version(node(ID, Package), Version, Weight) }.
 
-version_weight(PackageNode, Weight) :- external_version(PackageNode, Version, Weight).
+attr("version_weight", PackageNode, Weight) :- external_version(PackageNode, Version, Weight).
 attr("version", PackageNode, Version) :- external_version(PackageNode, Version, Weight).
 
 % if a package is not buildable, only externals or hashed specs are allowed
@@ -644,7 +644,7 @@ external(PackageNode) :- attr("external_spec_selected", PackageNode, _).
 % we can't use the weight for an external version if we don't use the
 % corresponding external spec.
 :- attr("version",  node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
+   attr("version_weight", node(ID, Package), Weight),
    pkg_fact(Package, version_declared(Version, Weight, "external")),
    not external(node(ID, Package)),
    internal_error("External weight used for internal spec").
@@ -886,7 +886,7 @@ attr("variant_value", PackageNode, Variant, Value)
 % The rules below allow us to prefer default values for variants
 % whenever possible. If a variant is set in a spec, or if it is
 % specified in an external, we score it as if it was a default value.
-variant_not_default(node(ID, Package), Variant, Value)
+attr("variant_not_default", node(ID, Package), Variant, Value)
  :- attr("variant_value", node(ID, Package), Variant, Value),
     not variant_default_value(Package, Variant, Value),
     % variants set explicitly on the CLI don't count as non-default
@@ -901,7 +901,7 @@ variant_not_default(node(ID, Package), Variant, Value)
 
 
 % A default variant value that is not used
-variant_default_not_used(node(ID, Package), Variant, Value)
+attr("variant_default_not_used", node(ID, Package), Variant, Value)
   :- variant_default_value(Package, Variant, Value),
      node_has_variant(node(ID, Package), Variant),
      not attr("variant_value", node(ID, Package), Variant, Value),
@@ -1086,7 +1086,7 @@ attr("node_target", PackageNode, Target)
  :- attr("node", PackageNode), attr("node_target_set", PackageNode, Target).
 
 % each node has the weight of its assigned target
-node_target_weight(node(ID, Package), Weight)
+attr("node_target_weight", node(ID, Package), Weight)
  :- attr("node", node(ID, Package)),
     attr("node_target", node(ID, Package), Target),
     target_weight(Target, Weight).
@@ -1213,16 +1213,12 @@ compiler_mismatch_required(PackageNode, DependencyNode)
 #defined allow_compiler/2.
 
 % compilers weighted by preference according to packages.yaml
-node_compiler_weight(node(ID, Package), Weight)
- :- node_compiler(node(ID, Package), CompilerID),
-    compiler_name(CompilerID, Compiler),
-    compiler_version(CompilerID, V),
+attr("node_compiler_weight", PackageNode, Weight)
+ :- node_compiler(PackageNode, CompilerID),
     compiler_weight(CompilerID, Weight).
 
-node_compiler_weight(node(ID, Package), 100)
- :- node_compiler(node(ID, Package), CompilerID),
-    compiler_name(CompilerID, Compiler),
-    compiler_version(CompilerID, V),
+attr("node_compiler_weight", PackageNode, 100)
+ :- node_compiler(PackageNode, CompilerID),
     not compiler_weight(CompilerID, _).
 
 % For the time being, be strict and reuse only if the compiler match one we have on the system
@@ -1359,7 +1355,7 @@ build_priority(PackageNode, 0)   :- not build(PackageNode), attr("node", Package
 % will instead build the latest bar. When we actually include transitive
 % build deps in the solve, consider using them as a preference to resolve this.
 :- attr("version", node(ID, Package), Version),
-   version_weight(node(ID, Package), Weight),
+   attr("version_weight", node(ID, Package), Weight),
    pkg_fact(Package, version_declared(Version, Weight, "installed")),
    not optimize_for_reuse().
 
@@ -1433,7 +1429,7 @@ opt_criterion(70, "version weight").
 #minimize {
     Weight@70+Priority
     : attr("root", PackageNode),
-      version_weight(PackageNode, Weight),
+      attr("version_weight", PackageNode, Weight),
       build_priority(PackageNode, Priority)
 }.
 
@@ -1442,7 +1438,7 @@ opt_criterion(65, "number of non-default variants (roots)").
 #minimize{ 0@65: #true }.
 #minimize {
     1@65+Priority,PackageNode,Variant,Value
-    : variant_not_default(PackageNode, Variant, Value),
+    : attr("variant_not_default", PackageNode, Variant, Value),
       attr("root", PackageNode),
       build_priority(PackageNode, Priority)
 }.
@@ -1452,7 +1448,7 @@ opt_criterion(60, "preferred providers for roots").
 #minimize{ 0@60: #true }.
 #minimize{
     Weight@60+Priority,ProviderNode,Virtual
-    : provider_weight(ProviderNode, Virtual, Weight),
+    : attr("provider_weight", ProviderNode, Virtual, Weight),
       attr("root", ProviderNode),
       build_priority(ProviderNode, Priority)
 }.
@@ -1462,7 +1458,7 @@ opt_criterion(55, "default values of variants not being used (roots)").
 #minimize{ 0@55: #true }.
 #minimize{
     1@55+Priority,PackageNode,Variant,Value
-    : variant_default_not_used(PackageNode, Variant, Value),
+    : attr("variant_default_not_used", PackageNode, Variant, Value),
       attr("root", PackageNode),
       build_priority(PackageNode, Priority)
 }.
@@ -1473,7 +1469,7 @@ opt_criterion(50, "number of non-default variants (non-roots)").
 #minimize{ 0@50: #true }.
 #minimize {
     1@50+Priority,PackageNode,Variant,Value
-    : variant_not_default(PackageNode, Variant, Value),
+    : attr("variant_not_default", PackageNode, Variant, Value),
       not attr("root", PackageNode),
       build_priority(PackageNode, Priority)
 }.
@@ -1485,7 +1481,7 @@ opt_criterion(45, "preferred providers (non-roots)").
 #minimize{ 0@45: #true }.
 #minimize{
     Weight@45+Priority,ProviderNode,Virtual
-    : provider_weight(ProviderNode, Virtual, Weight),
+    : attr("provider_weight", ProviderNode, Virtual, Weight),
       not attr("root", ProviderNode),
       build_priority(ProviderNode, Priority)
 }.
@@ -1534,7 +1530,7 @@ opt_criterion(25, "version badness").
 #minimize{ 0@25: #true }.
 #minimize{
     Weight@25+Priority,PackageNode
-    : version_weight(PackageNode, Weight),
+    : attr("version_weight", PackageNode, Weight),
       build_priority(PackageNode, Priority)
 }.
 
@@ -1544,7 +1540,7 @@ opt_criterion(20, "default values of variants not being used (non-roots)").
 #minimize{ 0@20: #true }.
 #minimize{
     1@20+Priority,PackageNode,Variant,Value
-    : variant_default_not_used(PackageNode, Variant, Value),
+    : attr("variant_default_not_used", PackageNode, Variant, Value),
       not attr("root", PackageNode),
       build_priority(PackageNode, Priority)
 }.
@@ -1555,7 +1551,7 @@ opt_criterion(15, "non-preferred compilers").
 #minimize{ 0@15: #true }.
 #minimize{
     Weight@15+Priority,PackageNode
-    : node_compiler_weight(PackageNode, Weight),
+    : attr("node_compiler_weight", PackageNode, Weight),
       build_priority(PackageNode, Priority)
 }.
 
@@ -1575,7 +1571,7 @@ opt_criterion(5, "non-preferred targets").
 #minimize{ 0@5: #true }.
 #minimize{
     Weight@5+Priority,PackageNode
-    : node_target_weight(PackageNode, Weight),
+    : attr("node_target_weight", PackageNode, Weight),
       build_priority(PackageNode, Priority)
 }.
 
@@ -1585,7 +1581,7 @@ opt_criterion(1, "edge wiring").
 #minimize{ 0@1: #true }.
 #minimize{
     Weight@1,ParentNode,PackageNode
-    : version_weight(PackageNode, Weight),
+    : attr("version_weight", PackageNode, Weight),
       not attr("root", PackageNode),
       depends_on(ParentNode, PackageNode)
 }.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -133,7 +133,7 @@ VERSION_COLOR = "@c"  #: color for highlighting versions
 ARCHITECTURE_COLOR = "@m"  #: color for highlighting architectures
 VARIANT_COLOR = "@B"  #: color for highlighting variants
 HASH_COLOR = "@K"  #: color for highlighting package hashes
-NONDEFAULT_COLOR = "@*R"  #: color for highlighting non-defaults in spec output
+NONDEFAULT_COLOR = "@_R"  #: color for highlighting non-defaults in spec output
 
 #: Default format for Spec.format(). This format can be round-tripped, so that:
 #:     Spec(Spec("string").format()) == Spec("string)"

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -671,6 +671,31 @@ class TestVariantMapTest:
         c["shared"] = BoolValuedVariant("shared", True)
         assert str(c) == "+shared feebar=foo foo=bar,baz foobar=fee"
 
+    def test_ordered_variants(self):
+        c = VariantMap(None)
+        c["foo"] = MultiValuedVariant("foo", "bar, baz")
+        c["foobar"] = SingleValuedVariant("foobar", "fee")
+        c["feebar"] = SingleValuedVariant("feebar", "foo")
+        c["shared"] = BoolValuedVariant("shared", True)
+
+        variants = iter(c.ordered_variants())
+
+        variant, boolean = next(variants)
+        assert variant.name == "shared"
+        assert boolean
+
+        variant, boolean = next(variants)
+        assert variant.name == "feebar"
+        assert not boolean
+
+        variant, boolean = next(variants)
+        assert variant.name == "foo"
+        assert not boolean
+
+        variant, boolean = next(variants)
+        assert variant.name == "foobar"
+        assert not boolean
+
 
 def test_disjoint_set_initialization_errors():
     # Constructing from non-disjoint sets should raise an exception

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1817,7 +1817,7 @@ _spack_restage() {
 _spack_solve() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --show -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json -c --cover -t --types --timers --stats -U --fresh --reuse --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help --show -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -d --debug-nondefaults -y --yaml -j --json -c --cover -t --types --timers --stats -U --fresh --reuse --reuse-deps --deprecated"
     else
         _all_packages
     fi
@@ -1826,7 +1826,7 @@ _spack_solve() {
 _spack_spec() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -y --yaml -j --json --format -c --cover -t --types -U --fresh --reuse --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -N --namespaces -I --install-status --no-install-status -d --debug-nondefaults -y --yaml -j --json --format -c --cover -t --types -U --fresh --reuse --reuse-deps --deprecated"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2699,7 +2699,7 @@ complete -c spack -n '__fish_spack_using_command restage' -s h -l help -f -a hel
 complete -c spack -n '__fish_spack_using_command restage' -s h -l help -d 'show this help message and exit'
 
 # spack solve
-set -g __fish_spack_optspecs_spack_solve h/help show= l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json c/cover= t/types timers stats U/fresh reuse reuse-deps deprecated
+set -g __fish_spack_optspecs_spack_solve h/help show= l/long L/very-long N/namespaces I/install-status no-install-status d/debug-nondefaults y/yaml j/json c/cover= t/types timers stats U/fresh reuse reuse-deps deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 solve' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command solve' -s h -l help -d 'show this help message and exit'
@@ -2715,6 +2715,8 @@ complete -c spack -n '__fish_spack_using_command solve' -s I -l install-status -
 complete -c spack -n '__fish_spack_using_command solve' -s I -l install-status -d 'show install status of packages'
 complete -c spack -n '__fish_spack_using_command solve' -l no-install-status -f -a install_status
 complete -c spack -n '__fish_spack_using_command solve' -l no-install-status -d 'do not show install status annotations'
+complete -c spack -n '__fish_spack_using_command solve' -s d -l debug-nondefaults -f -a debug_nondefaults
+complete -c spack -n '__fish_spack_using_command solve' -s d -l debug-nondefaults -d 'show non-default decisions in red'
 complete -c spack -n '__fish_spack_using_command solve' -s y -l yaml -f -a format
 complete -c spack -n '__fish_spack_using_command solve' -s y -l yaml -d 'print concrete spec as yaml'
 complete -c spack -n '__fish_spack_using_command solve' -s j -l json -f -a format
@@ -2737,7 +2739,7 @@ complete -c spack -n '__fish_spack_using_command solve' -l deprecated -f -a conf
 complete -c spack -n '__fish_spack_using_command solve' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack spec
-set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status y/yaml j/json format= c/cover= t/types U/fresh reuse reuse-deps deprecated
+set -g __fish_spack_optspecs_spack_spec h/help l/long L/very-long N/namespaces I/install-status no-install-status d/debug-nondefaults y/yaml j/json format= c/cover= t/types U/fresh reuse reuse-deps deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 spec' -f -k -a '(__fish_spack_specs_or_id)'
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command spec' -s h -l help -d 'show this help message and exit'
@@ -2751,6 +2753,8 @@ complete -c spack -n '__fish_spack_using_command spec' -s I -l install-status -f
 complete -c spack -n '__fish_spack_using_command spec' -s I -l install-status -d 'show install status of packages'
 complete -c spack -n '__fish_spack_using_command spec' -l no-install-status -f -a install_status
 complete -c spack -n '__fish_spack_using_command spec' -l no-install-status -d 'do not show install status annotations'
+complete -c spack -n '__fish_spack_using_command spec' -s d -l debug-nondefaults -f -a debug_nondefaults
+complete -c spack -n '__fish_spack_using_command spec' -s d -l debug-nondefaults -d 'show non-default decisions in red'
 complete -c spack -n '__fish_spack_using_command spec' -s y -l yaml -f -a format
 complete -c spack -n '__fish_spack_using_command spec' -s y -l yaml -d 'print concrete spec as YAML'
 complete -c spack -n '__fish_spack_using_command spec' -s j -l json -f -a format


### PR DESCRIPTION
Fixes  #28820.

It can be hard to tell when the concretizer has made decisions that are not the defaults for packages. This introduces a `spack spec -d` option that will highlight the nondefault options in red.

You can use this to see:
- When a selected version is not the most preferred;
- When a selected compiler is not the most preferred;
- When a nondefault variant is selected;
- When the chosen target is not the native microarchitecture; and
- When a chosen virtual provider is not the most preferred.

With `--reuse`, you'll see clearly which versions and options on reused packages are not current with the latest `package.py` files. With `--fresh`, you can see which options are forced by particular package preferences. e.g., `spack spec -d tar` shows `zstd`'s `+programs` option in red because it's off by default, but `tar` requires it via `depends_on("zstd+programs")`.

This should be useful for debugging strange/unintuitive concretizations.

Here's `spack spec -d` on my machine with reuse:

<img width="924" alt="Screenshot 2023-11-23 at 12 28 15 PM" src="https://github.com/spack/spack/assets/299842/52c0a7d3-1339-467b-ab68-ea35b1e9ee0f">

And without reuse (`--fresh`):

<img width="923" alt="Screenshot 2023-11-23 at 12 28 36 PM" src="https://github.com/spack/spack/assets/299842/abcf5e65-9f1f-44ba-a77e-32ab01d39e46">

Color refactoring:
- [x] Remove `colorize_spec()`, which uses older, now incorrect colorization logic. It is older than the current `Spec.format()` implementation and it doesn't work with `@=`. The only usages in `cmd/info.py` can be replaced wtih `Spec.cformat()`.
- [x] Remove `_SEPARATORS` AND `COLOR_FORMATS`, which are no longer needed.
- [x] Simplify `Spec.format()` code to use more readable color constants directly.
- [x] Remove unused color constants.
- [x] Remove unused parameter for `write_attribute()`
- [x] Remove unused `Spec.colorized()` method

Spec highlighting:
- [x] Modify concretizer to return optimization weights
- [x] Add `_weights` metadata to the `Spec` object
- [x] Modify `Spec.format()` to colorize nondefaults when weights are nonzero
- [x] Add tests