### PR TITLE
sherpa: only use enable_or_disable in v3 series

### DIFF
--- a/var/spack/repos/builtin/packages/sherpa/package.py
+++ b/var/spack/repos/builtin/packages/sherpa/package.py
@@ -217,7 +217,7 @@ class Sherpa(AutotoolsPackage):
         args.extend(self.enable_or_disable("pythia"))
         hepmc_root = lambda x: self.spec["hepmc"].prefix
         args.extend(self.enable_or_disable("hepmc2", activation_value=hepmc_root))
-        if self.spec.satisfies("@2.2.13:"):
+        if self.spec.satisfies("@3:"):
             args.extend(self.enable_or_disable("hepmc3", activation_value="prefix"))
             args.extend(self.enable_or_disable("rivet", activation_value="prefix"))
             args.extend(self.enable_or_disable("lhapdf", activation_value="prefix"))


### PR DESCRIPTION
The treatment of issue [sherpa#348](https://gitlab.com/sherpa-team/sherpa/-/issues/348) with PR [sherpa!497](https://gitlab.com/sherpa-team/sherpa/-/merge_requests/497) was merged later than anticipated, not in time for the 2.2.13 series (or any 2.2.* release). The PR was [merged](https://gitlab.com/sherpa-team/sherpa/-/commit/e5d5211cb84383a3e4ceb577720e68542afe29ac) into master, but is only in v3.0.0beta1. This bug prevents using sherpa with `-hepmc3`, `-lhapdf`, or `-rivet` (where `-rivet` is default; the others enabled by default) for all v2.2.* releases, and due to the `if` in spack, the workaround is only applied for versions up to 2.2.12 in spack. With this PR, the workaround is applied for all v2.2.* releases.

Tested that this PR causes 2.2.15 to compile Rivet support when `+rivet`, and not when `-rivet`. This does require `cxxstd` different from the default 11 (I used 14), since the Rivet headers include c++14 unique_ptr. Fixing that (specifying when which `cxxstd` is ok) will be for a different PR...