### PR TITLE
bfs: add v3.0.4

### DIFF
--- a/var/spack/repos/builtin/packages/bfs/package.py
+++ b/var/spack/repos/builtin/packages/bfs/package.py
@@ -14,6 +14,7 @@ class Bfs(MakefilePackage):
 
     maintainers("alecbcs")
 
+    version("3.0.4", sha256="7196f5a624871c91ad051752ea21043c198a875189e08c70ab3167567a72889d")
     version("3.0.2", sha256="d3456a9aeecc031064db0dbe012e55a11eb97be88d0ab33a90e570fe66457f92")
     version("3.0.1", sha256="a38bb704201ed29f4e0b989fb2ab3791ca51c3eff90acfc31fff424579bbf962")
 


### PR DESCRIPTION
Add bfs v3.0.4.

**Changelog:**
- Fixed a segfault when reporting errors under musl.

Full changelog can be found [here](https://github.com/tavianator/bfs/releases/tag/3.0.4).