### PR TITLE
restic: add v0.16.2

### DIFF
--- a/var/spack/repos/builtin/packages/restic/package.py
+++ b/var/spack/repos/builtin/packages/restic/package.py
@@ -14,6 +14,7 @@ class Restic(Package):
 
     maintainers("alecbcs")
 
+    version("0.16.2", sha256="88165b5b89b6064df37a9964d660f40ac62db51d6536e459db9aaea6f2b2fc11")
     version("0.16.0", sha256="b91f5ef6203a5c50a72943c21aaef336e1344f19a3afd35406c00f065db8a8b9")
     version("0.15.2", sha256="52aca841486eaf4fe6422b059aa05bbf20db94b957de1d3fca019ed2af8192b7")
     version("0.15.1", sha256="fce382fdcdac0158a35daa640766d5e8a6e7b342ae2b0b84f2aacdff13990c52")


### PR DESCRIPTION
Add restic v0.16.2.

**Changelog:**
https://github.com/restic/restic/releases/tag/v0.16.2