### PR TITLE
gloo: Add a patch for building with gcc 12

### DIFF
--- a/var/spack/repos/builtin/packages/gloo/package.py
+++ b/var/spack/repos/builtin/packages/gloo/package.py
@@ -35,6 +35,13 @@ class Gloo(CMakePackage, CudaPackage):
         sha256="8e6e9a44e0533ba4303a95a651b1934e5d73632cab08cc7d5a9435e1e64aa424",
         when="@:2023-01-16",
     )
+    # Fix building with gcc 12, see https://github.com/facebookincubator/gloo/pull/333
+    patch(
+        "https://github.com/facebookincubator/gloo/commit/4a5e339b764261d20fc409071dc7a8b8989aa195.patch?full_index=1",
+        sha256="dc8b3a9bea4693f32d6850ea2ce6ce75e1778538bfba464b50efca92bac425e3",
+        when="@2021-05-21:2022-05-18",
+    )
+
     generator("ninja")
     depends_on("cmake@2.8.12:", type="build")
 


### PR DESCRIPTION
See https://github.com/facebookincubator/gloo/issues/332 and https://github.com/facebookincubator/gloo/pull/333. Possibly some older versions also need this patch. 

For searching purposes, this is the error message:
```
  >> 62    /tmp/root/spack-stage/spack-stage-gloo-2021-05-21-lmruinvrf3axu67bta
           6ak45ayc5mexlq/spack-src/gloo/transport/tcp/device.cc:151:39: error:
            aggregate 'std::array<char, 64> hostname' has incomplete type and c
           annot be defined
     63      151 |       std::array<char, HOST_NAME_MAX> hostname;
     64          |                                       ^~~~~~~~
```