### PR TITLE
gromacs: permit oneapi to provide sycl

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -271,7 +271,11 @@ class Gromacs(CMakePackage, CudaPackage):
     depends_on("cmake@3.18.4:3", type="build", when="@main")
     depends_on("cmake@3.16.0:3", type="build", when="%fj")
     depends_on("cuda", when="+cuda")
-    depends_on("sycl", when="+sycl")
+    requires("%oneapi",
+             "sycl",
+             policy="one_of",
+             when="+sycl",
+             msg="GROMACS SYCL support comes either from oneAPI compiler or a package that provides the virtual package `sycl`, such as AdaptiveCPP")
     depends_on("lapack")
     depends_on("blas")
     depends_on("gcc", when="%oneapi ~intel_provided_gcc")

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -276,7 +276,8 @@ class Gromacs(CMakePackage, CudaPackage):
         "sycl",
         policy="one_of",
         when="+sycl",
-        msg="GROMACS SYCL support comes either from oneAPI compiler or a package that provides the virtual package `sycl`, such as AdaptiveCPP",
+        msg="GROMACS SYCL support comes either from oneAPI compiler or a "
+        + "package that provides the virtual package `sycl`, such as AdaptiveCPP",
     )
     depends_on("lapack")
     depends_on("blas")

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -271,11 +271,13 @@ class Gromacs(CMakePackage, CudaPackage):
     depends_on("cmake@3.18.4:3", type="build", when="@main")
     depends_on("cmake@3.16.0:3", type="build", when="%fj")
     depends_on("cuda", when="+cuda")
-    requires("%oneapi",
-             "sycl",
-             policy="one_of",
-             when="+sycl",
-             msg="GROMACS SYCL support comes either from oneAPI compiler or a package that provides the virtual package `sycl`, such as AdaptiveCPP")
+    requires(
+        "%oneapi",
+        "sycl",
+        policy="one_of",
+        when="+sycl",
+        msg="GROMACS SYCL support comes either from oneAPI compiler or a package that provides the virtual package `sycl`, such as AdaptiveCPP",
+    )
     depends_on("lapack")
     depends_on("blas")
     depends_on("gcc", when="%oneapi ~intel_provided_gcc")

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -277,7 +277,7 @@ class Gromacs(CMakePackage, CudaPackage):
         policy="one_of",
         when="+sycl",
         msg="GROMACS SYCL support comes either from oneAPI compiler or a "
-        + "package that provides the virtual package `sycl`, such as AdaptiveCPP",
+        + "package that provides the virtual package `sycl`, such as AdaptiveCpp",
     )
     depends_on("lapack")
     depends_on("blas")


### PR DESCRIPTION
Previously only a package implementing the virtual package `sycl` could build the SYCL variant of the Spack GROMACS package. Currently that is only AdaptiveCPP (formerly hipSYCL). Upstream supports a build with oneAPI and now Spack does too.