### PR TITLE
gromacs: fix newly added variant

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -107,7 +107,7 @@ class Gromacs(CMakePackage, CudaPackage):
     variant(
         "intel-data-center-gpu-max",
         default=False,
-        when="@2022:",
+        when="@2022: +sycl",
         description="Enable support for Intel Data Center GPU Max",
     )
     variant("nosuffix", default=False, description="Disable default suffixes")


### PR DESCRIPTION
In practice, one can only compile for the Intel Data Center Max GPU via a SYCL build and the oneAPI compiler. This is unlikely to change, so we can be explicit about that.