### PR TITLE
hub: add v2.14.2, update to go module

### DIFF
--- a/var/spack/repos/builtin/packages/hub/package.py
+++ b/var/spack/repos/builtin/packages/hub/package.py
@@ -6,6 +6,7 @@
 import os
 
 from spack.package import *
+from spack.version import ver
 
 
 class Hub(Package):
@@ -16,15 +17,37 @@ class Hub(Package):
     git = "https://github.com/github/hub.git"
 
     version("master", branch="master")
-    version("2.2.2", sha256="610572ee903aea1fa8622c16ab7ddef2bd1bfec9f4854447ab8e0fbdbe6a0cae")
-    version("2.2.1", sha256="9350aba6a8e3da9d26b7258a4020bf84491af69595f7484f922d75fc8b86dc10")
-    version("2.2.0", sha256="2da1351197eb5696c207f22c69a5422af052d74277b73d0b8661efb9ec1d0eb1")
-    version("1.12.4", sha256="b7fe404d7dc5f60554f088bec12de5e80229331430ea0ced46d5bf89ecae5117")
+    version("2.14.2", sha256="e19e0fdfd1c69c401e1c24dd2d4ecf3fd9044aa4bd3f8d6fd942ed1b2b2ad21a")
+    version(
+        "2.2.2",
+        sha256="610572ee903aea1fa8622c16ab7ddef2bd1bfec9f4854447ab8e0fbdbe6a0cae",
+        deprecated=True,
+    )
+    version(
+        "2.2.1",
+        sha256="9350aba6a8e3da9d26b7258a4020bf84491af69595f7484f922d75fc8b86dc10",
+        deprecated=True,
+    )
+    version(
+        "2.2.0",
+        sha256="2da1351197eb5696c207f22c69a5422af052d74277b73d0b8661efb9ec1d0eb1",
+        deprecated=True,
+    )
+    version(
+        "1.12.4",
+        sha256="b7fe404d7dc5f60554f088bec12de5e80229331430ea0ced46d5bf89ecae5117",
+        deprecated=True,
+    )
 
     extends("go")
 
     def install(self, spec, prefix):
         env = os.environ
-        env["GOPATH"] = self.stage.source_path + ":" + env["GOPATH"]
-        bash = which("bash")
-        bash(os.path.join("script", "build"), "-o", os.path.join(prefix, "bin", "hub"))
+        if spec.version < ver("2.14"):
+            env["GOPATH"] = self.stage.source_path + ":" + env["GOPATH"]
+            env["GO111MODULE"] = "off"
+            bash = which("bash")
+            bash(os.path.join("script", "build"), "-o", os.path.join(prefix, "bin", "hub"))
+            return
+        env["GO111MODULE"] = "on"
+        go("build", "-o", os.path.join(prefix, "bin", "hub"))

--- a/var/spack/repos/builtin/packages/hub/package.py
+++ b/var/spack/repos/builtin/packages/hub/package.py
@@ -6,7 +6,6 @@
 import os
 
 from spack.package import *
-from spack.version import ver
 
 
 class Hub(Package):
@@ -43,11 +42,11 @@ class Hub(Package):
 
     def install(self, spec, prefix):
         env = os.environ
-        if spec.version < ver("2.14"):
+        if spec.version < Version("2.14"):
             env["GOPATH"] = self.stage.source_path + ":" + env["GOPATH"]
             env["GO111MODULE"] = "off"
             bash = which("bash")
-            bash(os.path.join("script", "build"), "-o", os.path.join(prefix, "bin", "hub"))
+            bash(os.path.join("script", "build"), "-o", prefix.bin.hub)
             return
         env["GO111MODULE"] = "on"
-        go("build", "-o", os.path.join(prefix, "bin", "hub"))
+        go("build", "-o", prefix.bin.hub)


### PR DESCRIPTION
Hub now uses a go module to build, needs different env vars, and we're on a very, very old version before that.  Deprecate the old ones so we can clean out that old build once we pass a spack version.

Turns out the only change needed to keep all of these working was switching up the GOPATH value a bit and the GO111MODULE, so we can deprecate and move on as preferred.