### PR TITLE
libvips: requires pkg-config to find glib

### DIFF
--- a/var/spack/repos/builtin/packages/libvips/package.py
+++ b/var/spack/repos/builtin/packages/libvips/package.py
@@ -32,6 +32,7 @@ class Libvips(AutotoolsPackage):
 
     # TODO: Add more variants!
 
+    depends_on("pkg-config")
     depends_on("glib")
     depends_on("expat")
 

--- a/var/spack/repos/builtin/packages/libvips/package.py
+++ b/var/spack/repos/builtin/packages/libvips/package.py
@@ -32,7 +32,7 @@ class Libvips(AutotoolsPackage):
 
     # TODO: Add more variants!
 
-    depends_on("pkg-config")
+    depends_on("pkg-config", type="build")
     depends_on("glib")
     depends_on("expat")
 

--- a/var/spack/repos/builtin/packages/libvips/package.py
+++ b/var/spack/repos/builtin/packages/libvips/package.py
@@ -32,7 +32,7 @@ class Libvips(AutotoolsPackage):
 
     # TODO: Add more variants!
 
-    depends_on("pkg-config", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("glib")
     depends_on("expat")
 


### PR DESCRIPTION
This is a small fix for libvips, add pkg-config so it can find its dependencies on a system without that preinstalled.