### PR TITLE
MSVC preview version breaks clingo build

### DIFF
--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -213,7 +213,8 @@ def _root_spec(spec_str: str) -> str:
     if str(spack.platforms.host()) == "darwin":
         spec_str += " %apple-clang"
     elif str(spack.platforms.host()) == "windows":
-        spec_str += " %msvc"
+        # TODO (johnwparent): Remove version constraint when clingo patch is up
+        spec_str += " %msvc@19.37"
     else:
         spec_str += " %gcc"
 

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -214,7 +214,7 @@ def _root_spec(spec_str: str) -> str:
         spec_str += " %apple-clang"
     elif str(spack.platforms.host()) == "windows":
         # TODO (johnwparent): Remove version constraint when clingo patch is up
-        spec_str += " %msvc@19.37"
+        spec_str += " %msvc@:19.37"
     else:
         spec_str += " %gcc"
 


### PR DESCRIPTION
Prevent preview versions from being used for bootstrapping clingo until patch is ready