### PR TITLE
qt-base: have QtBase provide qmake, not QtPackage

### DIFF
--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -33,8 +33,6 @@ class QtPackage(CMakePackage):
 
     maintainers("wdconinc", "sethrj")
 
-    provides("qmake")
-
     # Default dependencies for all qt-* components
     generator("ninja")
     depends_on("cmake@3.16:", type="build")
@@ -90,6 +88,8 @@ class QtBase(QtPackage):
 
     url = QtPackage.get_url(__qualname__)
     list_url = QtPackage.get_list_url(__qualname__)
+
+    provides("qmake")
 
     version("6.6.0", sha256="882f39ea3a40a0894cd64e515ce51711a4fab79b8c47bc0fe0279e99493a62cf")
     version("6.5.3", sha256="174021c4a630df2e7e912c2e523844ad3cb5f90967614628fd8aa15ddbab8bc5")


### PR DESCRIPTION
When `QtPackage` provides qmake, then we end up with
```
$ spack providers qmake
qmake:
qt  qt-base  qt-declarative  qt-quick3d  qt-quicktimeline  qt-shadertools  qt-svg
```
since those are all `QtPackage`-derived. Instead, we should provide qmake only in `QtBase`, resulting in
```
$ spack providers qmake
qmake:
qt  qt-base
```