### PR TITLE
clingo: patch clingo to allow for build with modern msvc

### DIFF
--- a/var/spack/repos/builtin/packages/clingo/clingo_msc_1938_native_handle.patch
+++ b/var/spack/repos/builtin/packages/clingo/clingo_msc_1938_native_handle.patch
@@ -1,4 +1,16 @@
-Submodule clasp contains modified content
+From c84b07de81cc24e9ac411fc404c54a9a5120029c Mon Sep 17 00:00:00 2001
+From: Benjamin Kaufmann <benjamin.kaufmann@teufel.de>
+Date: Wed, 22 Nov 2023 08:13:46 +0100
+Subject: [PATCH] mt: Make condition_variable::native_handle() conditional.
+
+* According to the C++ standard, the presence and semantics of
+  std::condition_variable::native_handle (and native_handle_type) is
+  implementation-defined. E.g., starting with VS 2022 17.8, Microsoft's
+  implementation no longer provides them at all.
+---
+ clasp/mt/mutex.h | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
 diff --git a/clasp/clasp/mt/mutex.h b/clasp/clasp/mt/mutex.h
 index 2439888..ade899c 100644
 --- a/clasp/clasp/mt/mutex.h

--- a/var/spack/repos/builtin/packages/clingo/clingo_msc_1938_native_handle.patch
+++ b/var/spack/repos/builtin/packages/clingo/clingo_msc_1938_native_handle.patch
@@ -1,16 +1,18 @@
 Submodule clasp contains modified content
 diff --git a/clasp/clasp/mt/mutex.h b/clasp/clasp/mt/mutex.h
-index 2439888..1a998d8 100644
+index 2439888..ade899c 100644
 --- a/clasp/clasp/mt/mutex.h
 +++ b/clasp/clasp/mt/mutex.h
-@@ -39,8 +39,9 @@ struct condition_variable : private std::condition_variable {
+@@ -39,7 +39,11 @@ struct condition_variable : private std::condition_variable {
  	using base_type::notify_one;
  	using base_type::notify_all;
  	using base_type::wait;
-+#if _MSC_VER < 1938
- 	using base_type::native_handle;
--
-+#endif
+-	using base_type::native_handle;
++
++	template <typename X = std::condition_variable>
++	inline auto native_handle() -> typename X::native_handle_type {
++		return X::native_handle();
++	}
+ 
  	inline bool wait_for(unique_lock<mutex>& lock, double timeInSecs) {
  		return base_type::wait_for(lock, std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::duration<double>(timeInSecs)))
- 			== std::cv_status::no_timeout;

--- a/var/spack/repos/builtin/packages/clingo/clingo_msc_1938_native_handle.patch
+++ b/var/spack/repos/builtin/packages/clingo/clingo_msc_1938_native_handle.patch
@@ -1,0 +1,16 @@
+Submodule clasp contains modified content
+diff --git a/clasp/clasp/mt/mutex.h b/clasp/clasp/mt/mutex.h
+index 2439888..1a998d8 100644
+--- a/clasp/clasp/mt/mutex.h
++++ b/clasp/clasp/mt/mutex.h
+@@ -39,8 +39,9 @@ struct condition_variable : private std::condition_variable {
+ 	using base_type::notify_one;
+ 	using base_type::notify_all;
+ 	using base_type::wait;
++#if _MSC_VER < 1938
+ 	using base_type::native_handle;
+-
++#endif
+ 	inline bool wait_for(unique_lock<mutex>& lock, double timeInSecs) {
+ 		return base_type::wait_for(lock, std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::duration<double>(timeInSecs)))
+ 			== std::cv_status::no_timeout;

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -68,6 +68,7 @@ class Clingo(CMakePackage):
     patch("python38.patch", when="@5.3:5.4.0")
     patch("size-t.patch", when="%msvc")
     patch("vs2022.patch", when="%msvc@19.30:")
+    patch("clingo_msc_1938_native_handle.patch", when="msvc@19.38:")
 
     # TODO: Simplify this after Spack 0.21 release. The old concretizer has problems with
     # py-setuptools ^python@3.6, so we only apply the distutils -> setuptools patch for Python 3.12

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -68,7 +68,7 @@ class Clingo(CMakePackage):
     patch("python38.patch", when="@5.3:5.4.0")
     patch("size-t.patch", when="%msvc")
     patch("vs2022.patch", when="%msvc@19.30:")
-    patch("clingo_msc_1938_native_handle.patch", when="msvc@19.38:")
+    patch("clingo_msc_1938_native_handle.patch", when="%msvc@19.38:")
 
     # TODO: Simplify this after Spack 0.21 release. The old concretizer has problems with
     # py-setuptools ^python@3.6, so we only apply the distutils -> setuptools patch for Python 3.12


### PR DESCRIPTION
MSVC 19.38.* removes `native_handle` from the standard API, patch clingo to avoid the use of this

PR into Clingo: https://github.com/potassco/clasp/pull/97