### PR TITLE
gdrcopy: make variant for building exes

### DIFF
--- a/var/spack/repos/builtin/packages/gdrcopy/package.py
+++ b/var/spack/repos/builtin/packages/gdrcopy/package.py
@@ -28,16 +28,25 @@ class Gdrcopy(MakefilePackage, CudaPackage):
     depends_on("check")
     requires("+cuda")
 
+    variant(
+        "exes",
+        default=True,
+        description="Build and install executables",
+    )
+
     def build(self, spec, prefix):
         make("lib")
-        make("exes")
+        if "+exes" in self.spec:
+            make("exes")
 
     def install(self, spec, prefix):
         mkdir(prefix.include)
         mkdir(prefix.lib64)
         if spec.satisfies("@2.2:"):
             make("lib_install", "prefix={0}".format(self.prefix))
-            make("exes_install", "prefix={0}".format(self.prefix))
+            if "+exes" in self.spec:
+                make("exes_install", "prefix={0}".format(self.prefix))
         else:
             make("lib_install", "PREFIX={0}".format(self.prefix))
-            make("exes_install", "PREFIX={0}".format(self.prefix))
+            if "+exes" in self.spec:
+                make("exes_install", "PREFIX={0}".format(self.prefix))

--- a/var/spack/repos/builtin/packages/gdrcopy/package.py
+++ b/var/spack/repos/builtin/packages/gdrcopy/package.py
@@ -28,11 +28,7 @@ class Gdrcopy(MakefilePackage, CudaPackage):
     depends_on("check")
     requires("+cuda")
 
-    variant(
-        "exes",
-        default=True,
-        description="Build and install executables",
-    )
+    variant("exes", default=True, description="Build and install executables")
 
     def build(self, spec, prefix):
         make("lib")


### PR DESCRIPTION
Building the executables requires linking with libcuda.so from the CUDA driver, which might not be available on a machine that is just building gdrcopy for use as a library. Now such builds can proceed without unnecessary dependencies.