### PR TITLE
py-tokenizers: depend on rust@:1.72.1 when @0.11:0.13, add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-tokenizers/package.py
+++ b/var/spack/repos/builtin/packages/py-tokenizers/package.py
@@ -13,6 +13,8 @@ class PyTokenizers(PythonPackage):
     homepage = "https://github.com/huggingface/tokenizers"
     pypi = "tokenizers/tokenizers-0.6.0.tar.gz"
 
+    version("0.15.0", sha256="10c7e6e7b4cabd757da59e93f5f8d1126291d16f8b54f28510825ef56a3e5d0e")
+    version("0.14.1", sha256="ea3b3f8908a9a5b9d6fc632b5f012ece7240031c44c6d4764809f33736534166")
     version("0.13.3", sha256="2e546dbb68b623008a5442353137fbb0123d311a6d7ba52f2667c8862a75af2e")
     version("0.13.1", sha256="3333d1cee5c8f47c96362ea0abc1f81c77c9b92c6c3d11cbf1d01985f0d5cf1d")
     version("0.10.3", sha256="1a5d3b596c6d3a237e1ad7f46c472d467b0246be7fd1a364f12576eb8db8f7e6")
@@ -21,6 +23,10 @@ class PyTokenizers(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools-rust", type="build")
+
+    # will not build with rust 1.73 until 0.14.1
+    # https://github.com/huggingface/tokenizers/issues/1359
+    depends_on("py-setuptools-rust^rust@:1.72.1", when="@0.11:0.13", type="build")
 
     # A nightly or dev version of rust is required to build older versions.
     # https://github.com/huggingface/tokenizers/issues/176


### PR DESCRIPTION
Limit py-tokenizers to build with `rust@:1.72.1` when `@0.11:0.13`. Added later versions v0.14.1 and v0.15.0.