### PR TITLE
Add cxx17_flag to intel.py

### DIFF
--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -86,6 +86,14 @@ class Intel(Compiler):
             return "-std=c++14"
 
     @property
+    def cxx17_flag(self):
+        # https://www.intel.com/content/www/us/en/developer/articles/news/c17-features-supported-by-c-compiler.html
+        if self.real_version < Version("19"):
+            raise UnsupportedCompilerFlag(self, "the C++17 standard", "cxx17_flag", "< 17")
+        else:
+            return "-std=c++17"
+
+    @property
     def c99_flag(self):
         if self.real_version < Version("12"):
             raise UnsupportedCompilerFlag(self, "the C99 standard", "c99_flag", "< 12")

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -89,7 +89,7 @@ class Intel(Compiler):
     def cxx17_flag(self):
         # https://www.intel.com/content/www/us/en/developer/articles/news/c17-features-supported-by-c-compiler.html
         if self.real_version < Version("19"):
-            raise UnsupportedCompilerFlag(self, "the C++17 standard", "cxx17_flag", "< 17")
+            raise UnsupportedCompilerFlag(self, "the C++17 standard", "cxx17_flag", "< 19")
         else:
             return "-std=c++17"
 


### PR DESCRIPTION
This PR adds a `cxx17_flag` property to the Intel (Classic) compiler configuration, since icpc supports C++17 since v2019 (I think there was more sparse support in prior versions, so I'm unsure of the optimal cutoff version here).