### PR TITLE
perl: add missing gmake dependency

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -119,6 +119,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     extendable = True
 
     if sys.platform != "win32":
+        depends_on("gmake", type="build")
         depends_on("gdbm@:1.23")
         # Bind us below gdbm-1.20 due to API change: https://github.com/Perl/perl5/issues/18915
         depends_on("gdbm@:1.19", when="@:5.35")


### PR DESCRIPTION
Without it, perl fails with:
```
First let's make sure your kit is complete.  Checking...
Locating common programs...
I can't find make or gmake, and my life depends on it.
Go find a public domain implementation or fix your PATH setting!
```