### PR TITLE
python: add missing gmake dependency

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -237,6 +237,7 @@ class Python(Package):
     variant("crypt", default=True, description="Build crypt module", when="@:3.12 platform=cray")
 
     if sys.platform != "win32":
+        depends_on("gmake", type="build")
         depends_on("pkgconfig@0.9.0:", type="build")
         depends_on("gettext +libxml2", when="+libxml2")
         depends_on("gettext ~libxml2", when="~libxml2")


### PR DESCRIPTION
Without it, python fails with:
```
==> python: Executing phase: 'build'
==> [2023-11-21-21:47:39.871090] 'make' '-j12' 'V=1'
==> Error: ProcessError: make: No such file or directory
    Command: 'make' '-j12' 'V=1'
```