### PR TITLE
handle use of an unconfigured compiler

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -329,7 +329,6 @@ def set_compiler_environment_variables(pkg, env):
     # wrapper which will emit an error if it is used.
     if compiler.cc:
         env.set("SPACK_CC", compiler.cc)
-        cc_val = os.path.join(link_dir, compiler.link_paths["cc"])
         env.set("CC", os.path.join(link_dir, compiler.link_paths["cc"]))
     else:
         env.set("CC", os.path.join(link_dir, "env", "cc"))

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -331,22 +331,22 @@ def set_compiler_environment_variables(pkg, env):
         env.set("SPACK_CC", compiler.cc)
         env.set("CC", os.path.join(link_dir, compiler.link_paths["cc"]))
     else:
-        env.set("CC", os.path.join(link_dir, "env", "cc"))
+        env.set("CC", os.path.join(link_dir, "cc"))
     if compiler.cxx:
         env.set("SPACK_CXX", compiler.cxx)
         env.set("CXX", os.path.join(link_dir, compiler.link_paths["cxx"]))
     else:
-        env.set("CC", os.path.join(link_dir, "env", "c++"))
+        env.set("CC", os.path.join(link_dir, "c++"))
     if compiler.f77:
         env.set("SPACK_F77", compiler.f77)
         env.set("F77", os.path.join(link_dir, compiler.link_paths["f77"]))
     else:
-        env.set("F77", os.path.join(link_dir, "env", "f77"))
+        env.set("F77", os.path.join(link_dir, "f77"))
     if compiler.fc:
         env.set("SPACK_FC", compiler.fc)
         env.set("FC", os.path.join(link_dir, compiler.link_paths["fc"]))
     else:
-        env.set("FC", os.path.join(link_dir, "env", "fc"))
+        env.set("FC", os.path.join(link_dir, "fc"))
 
     # Set SPACK compiler rpath flags so that our wrapper knows what to use
     env.set("SPACK_CC_RPATH_ARG", compiler.cc_rpath_arg)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -324,19 +324,30 @@ def set_compiler_environment_variables(pkg, env):
     # ttyout, ttyerr, etc.
     link_dir = spack.paths.build_env_path
 
-    # Set SPACK compiler variables so that our wrapper knows what to call
+    # Set SPACK compiler variables so that our wrapper knows what to
+    # call.  If there is no compiler configured then use a default
+    # wrapper which will emit an error if it is used.
     if compiler.cc:
         env.set("SPACK_CC", compiler.cc)
+        cc_val = os.path.join(link_dir, compiler.link_paths["cc"])
         env.set("CC", os.path.join(link_dir, compiler.link_paths["cc"]))
+    else:
+        env.set("CC", os.path.join(link_dir, "env", "cc"))
     if compiler.cxx:
         env.set("SPACK_CXX", compiler.cxx)
         env.set("CXX", os.path.join(link_dir, compiler.link_paths["cxx"]))
+    else:
+        env.set("CC", os.path.join(link_dir, "env", "c++"))
     if compiler.f77:
         env.set("SPACK_F77", compiler.f77)
         env.set("F77", os.path.join(link_dir, compiler.link_paths["f77"]))
+    else:
+        env.set("F77", os.path.join(link_dir, "env", "f77"))
     if compiler.fc:
         env.set("SPACK_FC", compiler.fc)
         env.set("FC", os.path.join(link_dir, compiler.link_paths["fc"]))
+    else:
+        env.set("FC", os.path.join(link_dir, "env", "fc"))
 
     # Set SPACK compiler rpath flags so that our wrapper knows what to use
     env.set("SPACK_CC_RPATH_ARG", compiler.cc_rpath_arg)

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -155,13 +155,13 @@ def add_compilers_to_config(compilers, scope=None, init_config=True):
     compiler_config = get_compiler_config(scope, init_config)
     for compiler in compilers:
         if not compiler.cc:
-            tty.warn(f"{compiler.spec} does not have a C compiler")
+            tty.debug(f"{compiler.spec} does not have a C compiler")
         if not compiler.cxx:
-            tty.warn(f"{compiler.spec} does not have a C++ compiler")
+            tty.debug(f"{compiler.spec} does not have a C++ compiler")
         if not compiler.f77:
-            tty.warn(f"{compiler.spec} does not have a Fortran77 compiler")
+            tty.debug(f"{compiler.spec} does not have a Fortran77 compiler")
         if not compiler.fc:
-            tty.warn(f"{compiler.spec} does not have a Fortran compiler")
+            tty.debug(f"{compiler.spec} does not have a Fortran compiler")
         compiler_config.append(_to_dict(compiler))
     spack.config.set("compilers", compiler_config, scope=scope)
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -154,6 +154,14 @@ def add_compilers_to_config(compilers, scope=None, init_config=True):
     """
     compiler_config = get_compiler_config(scope, init_config)
     for compiler in compilers:
+        if not compiler.cc:
+            tty.warn(f"{compiler.spec} does not have a C compiler")
+        if not compiler.cxx:
+            tty.warn(f"{compiler.spec} does not have a C++ compiler")
+        if not compiler.f77:
+            tty.warn(f"{compiler.spec} does not have a Fortran77 compiler")
+        if not compiler.fc:
+            tty.warn(f"{compiler.spec} does not have a Fortran compiler")
         compiler_config.append(_to_dict(compiler))
     spack.config.set("compilers", compiler_config, scope=scope)
 


### PR DESCRIPTION
If you configure a Fortran compiler, but not a C compiler, then spack will not set CC and it can silently use the system compiler. This can happen if you use `spack compiler find` to configure `%intel@2024`, which does not have a C compiler.

There is some logic in the wrapper to handle this case:
https://github.com/spack/spack/blob/f2192a48cebbbe926e68bb956e4613626c9d5f32/lib/spack/env/cc#L340

But it is not reached because if you do not configure a C compiler, it does not enable a compiler wrapper. This change enables a default compiler wrapper when there is no configured compiler.

Here is what you see in `spack-build-out.txt` when building a project that uses configure:

```
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a race-free mkdir -p... /usr/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking for strip... strip
checking for objdump... objdump
checking for objcopy... objcopy
checking for readelf... readelf
checking whether make supports the include directive... yes (GNU style)
checking for gcc... /localdisk/work/rscohn1/projects/spack/spack/lib/spack/env/env/c++
checking whether the C compiler works... no
configure: error: in `/tmp/rscohn1/spack-stage/spack-stage-patchelf-0.17.2-xlmkimeitojq5f7ykokllgmma6yvqm5a/spack-src':
configure: error: C compiler cannot create executables
See `config.log' for more details
```

And the `config.log` shows:
```
configure:3700: checking for gcc
configure:3732: result: /localdisk/work/rscohn1/projects/spack/spack/lib/spack/env/c++
configure:4085: checking for C compiler version
configure:4094: /localdisk/work/rscohn1/projects/spack/spack/lib/spack/env/c++ --version >&5
[spack cc] ERROR: Compiler 'intel@=2021.11.0' does not have a C++ compiler configured.
configure:4105: $? = 1
```

It isn't always convenient to examine the log files, so I also added a warning when adding a configuration with missing compilers:

```
spack compiler find /opt/intel/oneapi/compiler/2024.0/bin
==> Warning: intel@=2021.11.0 does not have a C compiler
==> Warning: intel@=2021.11.0 does not have a C++ compiler
==> Added 3 new compilers to /nfs/site/home/rscohn1/.spack/linux/compilers.yaml
    oneapi@2024.0.0  intel@2021.11.0  dpcpp@2024.0.0
==> Compilers are defined in the following files:
    /nfs/site/home/rscohn1/.spack/linux/compilers.yaml
```