### PR TITLE
pulseaudio: add missing m4 dependency

### DIFF
--- a/var/spack/repos/builtin/packages/pulseaudio/package.py
+++ b/var/spack/repos/builtin/packages/pulseaudio/package.py
@@ -51,6 +51,7 @@ class Pulseaudio(AutotoolsPackage):
     depends_on("openssl", when="+openssl")
     depends_on("perl-xml-parser", type="build")
     depends_on("speexdsp@1.2:")
+    depends_on("m4", type="build")
 
     def configure_args(self):
         args = [


### PR DESCRIPTION
Without this, I get
```
==> Error: ProcessError: Command exited with status 1:
    '$spack-stage/spack-stage-pulseaudio-13.0-2k4f4jxi5ql6mkqfdrysux2xxcgobs7g/spack-src/configure' '--prefix=$spack/opt/spack/linux-fedora39-skylake/gcc-13.2.1/pulseaudio-13.0-2k4f4jxi5ql6mkqfdrysux2xxcgobs7g' '--disable-systemd-daemon' '--disable-systemd-journal' '--disable-systemd-login' '--disable-udev' '--disable-waveout' '--enable-dbus' '--enable-glib2' '--with-database=gdbm' '--with-systemduserunitdir=no' 'CPPFLAGS=-I$spack/opt/spack/linux-fedora39-skylake/gcc-13.2.1/libtool-2.4.7-feohotpqynaobfwb4l3gcldi6tv2b3yi/include' 'LDFLAGS=-L$spack/opt/spack/linux-fedora39-skylake/gcc-13.2.1/libtool-2.4.7-feohotpqynaobfwb4l3gcldi6tv2b3yi/lib' '--disable-alsa' '--disable-gconf' '--disable-openssl' '--disable-x11' '--without-fftw' '--disable-asyncns' '--disable-avahi' '--disable-bluez5' '--disable-gcov' '--disable-gsettings' '--disable-gtk3' '--disable-hal-compat' '--disable-jack' '--disable-lirc' '--disable-orc' '--disable-tcpwrap'

1 error found in build log:
     58    checking minix/config.h presence... no
     59    checking for minix/config.h... no
     60    checking whether it is safe to define __EXTENSIONS__... yes
     61    checking whether $spack/lib/spack/env/gcc/g++ supports C++11 features by defa
           ult... yes
     62    checking for gm4... no
     63    checking for m4... no
  >> 64    configure: error: m4 missing
```