### PR TITLE
iwyu: new versions up 0.21 (depends_on llvm-17)

### DIFF
--- a/var/spack/repos/builtin/packages/iwyu/package.py
+++ b/var/spack/repos/builtin/packages/iwyu/package.py
@@ -17,6 +17,7 @@ class Iwyu(CMakePackage):
 
     homepage = "https://include-what-you-use.org"
     url = "https://include-what-you-use.org/downloads/include-what-you-use-0.13.src.tar.gz"
+    git = "https://github.com/include-what-you-use/include-what-you-use.git"
 
     maintainers("sethrj")
 
@@ -24,6 +25,9 @@ class Iwyu(CMakePackage):
 
     executables = ["^include-what-you-use$"]
 
+    version("0.21", sha256="6a351919ff89bda7c95c895472601868db3daab96a958b38e0362890d58760b6")
+    version("0.20", sha256="75fce1e6485f280f8f13f4c2d090b11d2fd2102b50857507c8413a919b7af899")
+    version("0.19", sha256="2b10157b60ea08adc08e3896b4921c73fcadd5ec4eb652b29a34129d501e5ee0")
     version("0.18", sha256="9102fc8419294757df86a89ce6ec305f8d90a818d1f2598a139d15eb1894b8f3")
     version("0.17", sha256="eca7c04f8b416b6385ed00e33669a7fa4693cd26cb72b522cde558828eb0c665")
     version("0.16", sha256="8d6fc9b255343bc1e5ec459e39512df1d51c60e03562985e0076036119ff5a1c")
@@ -35,6 +39,9 @@ class Iwyu(CMakePackage):
 
     patch("iwyu-013-cmake.patch", when="@0.13:0.14")
 
+    depends_on("llvm+clang@17.0:17", when="@0.21")
+    depends_on("llvm+clang@16.0:16", when="@0.20")
+    depends_on("llvm+clang@15.0:15", when="@0.19")
     depends_on("llvm+clang@14.0:14", when="@0.18")
     depends_on("llvm+clang@13.0:13", when="@0.17")
     depends_on("llvm+clang@12.0:12", when="@0.16")
@@ -55,7 +62,11 @@ class Iwyu(CMakePackage):
         match = re.search(r"include-what-you-use\s+(\S+)", output)
         return match.group(1) if match else None
 
-    @when("@0.14:")
+    @when("@0.19:")
+    def cmake_args(self):
+        return [self.define("CMAKE_CXX_STANDARD", 17), self.define("CMAKE_CXX_EXTENSIONS", False)]
+
+    @when("@0.14:0.18")
     def cmake_args(self):
         return [self.define("CMAKE_CXX_STANDARD", 14), self.define("CMAKE_CXX_EXTENSIONS", False)]
 


### PR DESCRIPTION
This adds new versions for iwyu, include-what-you-use, corresponding with llvm-15 through llvm-17. Only substantial change is that c++17 is required for 0.19 and later. More in release notes at https://include-what-you-use.org.