### PR TITLE
spack graph: fix coloring with environments

### DIFF
--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -61,7 +61,7 @@ def graph(parser, args):
         args.dot = True
         env = ev.active_environment()
         if env:
-            specs = env.all_specs()
+            specs = env.concrete_roots()
         else:
             specs = spack.store.STORE.db.query()
 


### PR DESCRIPTION
If we use `env.all_specs()`, we won't color correctly build-only dependencies (since we'll graph all nodes explicitly). With this fix they are displayed with a different color.

For instance, in the following graph:

![environment](https://github.com/spack/spack/assets/4199709/3f100140-7327-4728-acaa-bca2b7627957)

The pure build dependencies (in red) are colored blue.