### PR TITLE
SPACK_ENV_PATH dependancy removed from iverilog-vpi

### DIFF
--- a/var/spack/repos/builtin/packages/icarus/package.py
+++ b/var/spack/repos/builtin/packages/icarus/package.py
@@ -13,6 +13,7 @@ class Icarus(AutotoolsPackage):
     url = "https://github.com/steveicarus/iverilog/archive/refs/tags/v12_0.tar.gz"
     git = "https://github.com/steveicarus/iverilog.git"
 
+    version("master", branch="master")
     version("12_0", sha256="a68cb1ef7c017ef090ebedb2bc3e39ef90ecc70a3400afb4aa94303bc3beaa7d")
     version("11_0", sha256="6327fb900e66b46803d928b7ca439409a0dc32731d82143b20387be0833f1c95")
     version("10_3", commit="453c5465895eaca4a792d18b75e9ec14db6ea50e")
@@ -38,3 +39,18 @@ class Icarus(AutotoolsPackage):
         mkdirp(join_path(prefix.lib, "ivl", "include"))
         mkdirp(join_path(prefix.share, "man"))
         mkdirp(join_path(prefix.share, "man", "man1"))
+
+    # We need to fix the CC and CXX paths, as they point to the spack
+    # wrapper scripts which aren't usable without spack
+    @run_after("install")
+    def patch_compiler(self):
+        filter_file(
+            r"^CC\s*=.*",
+            f"CC={self.compiler.cc}",
+            join_path(self.prefix.bin, "iverilog-vpi"),
+        )
+        filter_file(
+            r"^CXX\s*=.*",
+            f"CXX={self.compiler.cxx}",
+            join_path(self.prefix.bin, "iverilog-vpi"),
+        )

--- a/var/spack/repos/builtin/packages/icarus/package.py
+++ b/var/spack/repos/builtin/packages/icarus/package.py
@@ -47,12 +47,8 @@ class Icarus(AutotoolsPackage):
     @run_after("install")
     def patch_compiler(self):
         filter_file(
-            r"^CC\s*=.*",
-            f"CC={self.compiler.cc}",
-            join_path(self.prefix.bin, "iverilog-vpi"),
+            r"^CC\s*=.*", f"CC={self.compiler.cc}", join_path(self.prefix.bin, "iverilog-vpi")
         )
         filter_file(
-            r"^CXX\s*=.*",
-            f"CXX={self.compiler.cxx}",
-            join_path(self.prefix.bin, "iverilog-vpi"),
+            r"^CXX\s*=.*", f"CXX={self.compiler.cxx}", join_path(self.prefix.bin, "iverilog-vpi")
         )

--- a/var/spack/repos/builtin/packages/icarus/package.py
+++ b/var/spack/repos/builtin/packages/icarus/package.py
@@ -12,7 +12,7 @@ class Icarus(AutotoolsPackage):
     homepage = "http://www.iverilog.icarus.com"
     url = "https://github.com/steveicarus/iverilog/archive/refs/tags/v12_0.tar.gz"
     git = "https://github.com/steveicarus/iverilog.git"
-    
+
     maintainers("davekeeshan")
 
     version("master", branch="master")

--- a/var/spack/repos/builtin/packages/icarus/package.py
+++ b/var/spack/repos/builtin/packages/icarus/package.py
@@ -12,6 +12,8 @@ class Icarus(AutotoolsPackage):
     homepage = "http://www.iverilog.icarus.com"
     url = "https://github.com/steveicarus/iverilog/archive/refs/tags/v12_0.tar.gz"
     git = "https://github.com/steveicarus/iverilog.git"
+    
+    maintainers("davekeeshan")
 
     version("master", branch="master")
     version("12_0", sha256="a68cb1ef7c017ef090ebedb2bc3e39ef90ecc70a3400afb4aa94303bc3beaa7d")


### PR DESCRIPTION
iverilog-vpi needs to have the compiler fixed so that is can be used outside of spack and the SPACK_ENV_PATH is not available.  Previous to this it was getting:

```
CC="/mnt/sda/projects/spack/lib/spack/env/gcc/gcc"
CXX=/mnt/sda/projects/spack/lib/spack/env/gcc/g++
```
now it is this (or similar to your system):
```
CC=/opt/spack/linux-ubuntu22.04-skylake/gcc-11.4.0/gcc/13.2.0/bin/gcc
CXX=/opt/spack/linux-ubuntu22.04-skylake/gcc-11.4.0/gcc/13.2.0/bin/g++
```