### PR TITLE
Add patch so that ccache can compile with the standard gcc@12 version

### DIFF
--- a/var/spack/repos/builtin/packages/ccache/fix-gcc-12.patch
+++ b/var/spack/repos/builtin/packages/ccache/fix-gcc-12.patch
@@ -1,0 +1,23 @@
+https://bugs.gentoo.org/906310
+https://bugs.gentoo.org/906942
+https://github.com/ccache/ccache/issues/1289
+https://github.com/ccache/ccache/commit/689168c292f1ed26c5f4a3070aeb649dad7facb5
+
+From 689168c292f1ed26c5f4a3070aeb649dad7facb5 Mon Sep 17 00:00:00 2001
+From: Joel Rosdahl <joel@rosdahl.net>
+Date: Tue, 1 Aug 2023 12:30:12 +0200
+Subject: [PATCH] fix: Work around GCC 12.3 bug 109241
+
+See also #1289.
+--- a/src/storage/local/LocalStorage.cpp
++++ b/src/storage/local/LocalStorage.cpp
+@@ -854,7 +854,9 @@ LocalStorage::recompress(const std::optional<int8_t> level,
+           auto l2_content_lock = get_level_2_content_lock(l1_index, l2_index);
+           l2_content_lock.make_long_lived(lock_manager);
+           if (!l2_content_lock.acquire()) {
+-            LOG("Failed to acquire content lock for {}/{}", l1_index, l2_index);
++            // LOG_RAW+fmt::format instead of LOG due to GCC 12.3 bug #109241
++            LOG_RAW(fmt::format(
++              "Failed to acquire content lock for {}/{}", l1_index, l2_index));
+             return;
+           }

--- a/var/spack/repos/builtin/packages/ccache/package.py
+++ b/var/spack/repos/builtin/packages/ccache/package.py
@@ -72,7 +72,7 @@ class Ccache(CMakePackage):
     conflicts("%clang@:7", when="@4.7:")
     conflicts("%clang@:4", when="@4.4:")
 
-    patch("fix-gcc-12.patch", when="%gcc@:12")
+    patch("fix-gcc-12.patch", when="%gcc@12")
 
     def cmake_args(self):
         return [

--- a/var/spack/repos/builtin/packages/ccache/package.py
+++ b/var/spack/repos/builtin/packages/ccache/package.py
@@ -72,6 +72,8 @@ class Ccache(CMakePackage):
     conflicts("%clang@:7", when="@4.7:")
     conflicts("%clang@:4", when="@4.4:")
 
+    patch("fix-gcc-12.patch", when="%gcc@:12")
+
     def cmake_args(self):
         return [
             self.define("ENABLE_TESTING", False),


### PR DESCRIPTION
Add patch so that ccache can compile with the standard gcc@12 version, https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=c1683082f6735325895ab84e5d16801dc7fad2f5

Conversation for the bug was captured here:

https://bugs.gentoo.org/906310