### PR TITLE
umpire: remove gcc@10.3.0 conflict

### DIFF
--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -208,11 +208,6 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     # currently only available for cuda.
     conflicts("+shared", when="+cuda")
 
-    # https://github.com/LLNL/Umpire/issues/653
-    # This range looks weird, but it ensures the concretizer looks at it as a
-    # range, not as a concrete version, so that it also matches 10.3.* versions.
-    conflicts("%gcc@10.3.0:10.3", when="+cuda")
-
     def _get_sys_type(self, spec):
         sys_type = spec.architecture
         if "SYS_TYPE" in env:


### PR DESCRIPTION
~In addition to the new version `umpire@2023.06.00` released last July,~ I took the chance to do some test builds, and verify the conflict with `gcc@10.3.0` that comes from https://github.com/LLNL/Umpire/issues/653.

Apparently, tracking down the issues (see also https://github.com/spack/spack/pull/29076#issuecomment-1045965436), I was able to see that the problem was not `gcc@10.3.0` (as it was suspected as one of the possible reasons of the failure). Indeed (by removing the conflict) I was able to build

| gcc          | cuda          | umpire             | note |
| ------------ | ------------- | ------------------ | ---- |
| `gcc@10.3.0` | `cuda@11.5.2` | `umpire@2022.03.1` | ✅   |
| `gcc@10.3.0` | `cuda@11.5.2` | `umpire@2022.03.0` | ✅   |
| `gcc@10.3.0` | `cuda@11.5.2` | `umpire@6.0.0`     | ✅   |
| `gcc@10.3.0` | `cuda@11.5.2` | `umpire@2022.10.0` | ✅   |

In addition to older versions (together with old dependencies I replicated as in the issue above)
| gcc          | cuda          | umpire         | others                                       | note |
| ------------ | ------------- | -------------- | -------------------------------------------- | ---- |
| `gcc@10.3.0` | `cuda@11.5.2` | `umpire@6.0.0` | `camp@0.2.2`                                 | ✅   |
| `gcc@10.3.0` | `cuda@11.5.2` | `umpire@6.0.0` | `camp@0.2.2` + `cub@1.12.0-rc0`              | ✅   |
| `gcc@10.3.0` | `cuda@11.5.2` | `umpire@6.0.0` | `blt@0.4.1`+ `camp@0.2.2` + `cub@1.12.0-rc0` | ✅ |

So, I experimented a bit also with CUDA versions, knowing that 
- `cuda@11.4.0` does not support `gcc@10`
- `cuda@11.4.1` supports `gcc@10`

and I temporarily removed this conflict, in order to verify that it is actually attributable to CUDA limitations and not GCC limitations.

```python
# from lib/spack/spack/build_systems/cuda.py
conflicts("%gcc@10", when="+cuda ^cuda@:11.4.0")
```

| gcc          | cuda          | umpire         | note |     |
| ------------ | ------------- | -------------- | ---- | --- |
| `gcc@10.3.0` | `cuda@11.2.0` | `umpire@6.0.0` |      | ❌  |
| `gcc@10.3.0` | `cuda@11.4.0` | `umpire@6.0.0` |      | ❌  |
| `gcc@10.3.0` | `cuda@11.4.1` | `umpire@6.0.0` |      | ✅  |

and it is confirmed that the problem is actually the CUDA compatibility and `gcc@10.3.0` is not accountable for the problem raised in umpire.

For this reason, I removed the conflict in Umpire that I added in #26028.