### PR TITLE
fpart: add license and variants

### DIFF
--- a/var/spack/repos/builtin/packages/fpart/package.py
+++ b/var/spack/repos/builtin/packages/fpart/package.py
@@ -27,8 +27,11 @@ class Fpart(AutotoolsPackage):
     variant("debug", default=False, description="Build with debugging support")
     # fpsync has the following run dependencies, at least one is required
     variant(
-            "fpsynctool", default="rsync", values=("rsync", "tar", "cpio"),
-            multi=True, description="Tool used by fpsync to copy files"
+            "fpsynctool",
+            default="rsync",
+            values=("rsync", "tar", "cpio"),
+            multi=True,
+            description="Tool used by fpsync to copy files"
     )
 
     depends_on("autoconf", type="build")

--- a/var/spack/repos/builtin/packages/fpart/package.py
+++ b/var/spack/repos/builtin/packages/fpart/package.py
@@ -27,19 +27,19 @@ class Fpart(AutotoolsPackage):
     variant("debug", default=False, description="Build with debugging support")
     # fpsync has the following run dependencies, at least one is required
     variant(
-        "fpsynctool",
+        "fpsynctools",
         default="rsync",
         values=("rsync", "tar", "cpio"),
         multi=True,
-        description="Tool used by fpsync to copy files",
+        description="Tools used by fpsync to copy files",
     )
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
-    depends_on("rsync", when="fpsynctool=rsync", type="run")
-    depends_on("tar", when="fpsynctool=tar", type="run")
-    depends_on("cpio", when="fpsynctool=cpio", type="run")
+    depends_on("rsync", when="fpsynctools=rsync", type="run")
+    depends_on("tar", when="fpsynctools=tar", type="run")
+    depends_on("cpio", when="fpsynctools=cpio", type="run")
 
     def configure_args(self):
         config_args = []

--- a/var/spack/repos/builtin/packages/fpart/package.py
+++ b/var/spack/repos/builtin/packages/fpart/package.py
@@ -25,14 +25,18 @@ class Fpart(AutotoolsPackage):
     variant("embfts", default=False, description="Build with embedded fts functions")
     variant("static", default=False, description="Build static binary")
     variant("debug", default=False, description="Build with debugging support")
+    # fpsync has the following run dependencies, at least one is required
+    variant(
+            "fpsynctool", default="rsync", values=("rsync", "tar", "cpio"),
+            multi=True, description="Tool used by fpsync to copy files"
+    )
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
-    # fpsync has the following run dependencies
-    depends_on("rsync", type="run")
-    depends_on("tar", type="run")
-    depends_on("cpio", type="run")
+    depends_on("rsync", when="fpsynctool=rsync", type="run")
+    depends_on("tar", when="fpsynctool=tar", type="run")
+    depends_on("cpio", when="fpsynctool=cpio", type="run")
 
     def configure_args(self):
         config_args = []

--- a/var/spack/repos/builtin/packages/fpart/package.py
+++ b/var/spack/repos/builtin/packages/fpart/package.py
@@ -17,8 +17,14 @@ class Fpart(AutotoolsPackage):
 
     maintainers("drkrynstrng")
 
+    license("BSD-2-Clause")
+
     version("master", branch="master")
     version("1.5.1", sha256="c353a28f48e4c08f597304cb4ebb88b382f66b7fabfc8d0328ccbb0ceae9220c")
+
+    variant("embfts", default=False, description="Build with embedded fts functions")
+    variant("static", default=False, description="Build static binary")
+    variant("debug", default=False, description="Build with debugging support")
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
@@ -27,3 +33,10 @@ class Fpart(AutotoolsPackage):
     depends_on("rsync", type="run")
     depends_on("tar", type="run")
     depends_on("cpio", type="run")
+
+    def configure_args(self):
+        config_args = []
+        config_args.extend(self.enable_or_disable("embfts"))
+        config_args.extend(self.enable_or_disable("static"))
+        config_args.extend(self.enable_or_disable("debug"))
+        return config_args

--- a/var/spack/repos/builtin/packages/fpart/package.py
+++ b/var/spack/repos/builtin/packages/fpart/package.py
@@ -27,11 +27,11 @@ class Fpart(AutotoolsPackage):
     variant("debug", default=False, description="Build with debugging support")
     # fpsync has the following run dependencies, at least one is required
     variant(
-            "fpsynctool",
-            default="rsync",
-            values=("rsync", "tar", "cpio"),
-            multi=True,
-            description="Tool used by fpsync to copy files"
+        "fpsynctool",
+        default="rsync",
+        values=("rsync", "tar", "cpio"),
+        multi=True,
+        description="Tool used by fpsync to copy files"
     )
 
     depends_on("autoconf", type="build")

--- a/var/spack/repos/builtin/packages/fpart/package.py
+++ b/var/spack/repos/builtin/packages/fpart/package.py
@@ -31,7 +31,7 @@ class Fpart(AutotoolsPackage):
         default="rsync",
         values=("rsync", "tar", "cpio"),
         multi=True,
-        description="Tool used by fpsync to copy files"
+        description="Tool used by fpsync to copy files",
     )
 
     depends_on("autoconf", type="build")


### PR DESCRIPTION
For the fpart package, adding license, variants for complete list of configure args, and variant for specifying the tool used by fpsync to copy files.