### PR TITLE
Charliecloud with SquashFUSE support

### DIFF
--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -128,8 +128,8 @@ class Charliecloud(AutotoolsPackage):
     # See https://github.com/spack/spack/pull/16049.
     conflicts("platform=darwin", msg="This package does not build on macOS")
 
-    # Squashfuse support
-    depends_on("squashfuse@0.1.105:", when="+squashfuse")
+    # Squashfuse support - only a narrow range at least through v0.35
+    depends_on("squashfuse@0.1.105:0.2.0", when="+squashfuse")
     depends_on("squashfs", type="run", when="+squashfuse")
 
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/squashfuse/package.py
+++ b/var/spack/repos/builtin/packages/squashfuse/package.py
@@ -17,6 +17,10 @@ class Squashfuse(AutotoolsPackage):
 
     version("master", branch="master")
     version("0.5.0", sha256="d7602c7a3b1d0512764547d27cb8cc99d1b21181e1c9819e76461ee96c2ab4d9")
+    version("0.4.0", sha256="646e31449b7914d2404933aea88f8d5f72c5d135d7deae3370ccb394c40d114a")
+    version("0.3.0", sha256="01f2f9639c7c5c4978efe96ba685935b8f6c9e5a7afe5e8fb21ec8b09df49278")
+    version("0.2.0", sha256="e8eea1b013b41d0a320e5a07b131bc70df14e6b3f2d3a849bdee66d100186f4f")
+    version("0.1.105", sha256="3f776892ab2044ecca417be348e482fee2839db75e35d165b53737cb8153ab1e", url="https://github.com/vasi/squashfuse/archive/refs/tags/0.1.105.tar.gz")
     version("0.1.104", sha256="aa52460559e0d0b1753f6b1af5c68cfb777ca5a13913285e93f4f9b7aa894b3a")
     version("0.1.103", sha256="42d4dfd17ed186745117cfd427023eb81effff3832bab09067823492b6b982e7")
 
@@ -51,6 +55,9 @@ class Squashfuse(AutotoolsPackage):
     depends_on("autoconf", type="build", when="@master")
     depends_on("automake", type="build", when="@master")
     depends_on("libtool", type="build", when="@master")
+    depends_on("autoconf", type="build", when="@0.1.105 build_system=autotools")
+    depends_on("automake", type="build", when="@0.1.105 build_system=autotools")
+    depends_on("libtool", type="build", when="@0.1.105 build_system=autotools")
 
     def flag_handler(self, name, flags):
         if name == "cflags" and "+min_size" in self.spec:

--- a/var/spack/repos/builtin/packages/squashfuse/package.py
+++ b/var/spack/repos/builtin/packages/squashfuse/package.py
@@ -20,7 +20,11 @@ class Squashfuse(AutotoolsPackage):
     version("0.4.0", sha256="646e31449b7914d2404933aea88f8d5f72c5d135d7deae3370ccb394c40d114a")
     version("0.3.0", sha256="01f2f9639c7c5c4978efe96ba685935b8f6c9e5a7afe5e8fb21ec8b09df49278")
     version("0.2.0", sha256="e8eea1b013b41d0a320e5a07b131bc70df14e6b3f2d3a849bdee66d100186f4f")
-    version("0.1.105", sha256="3f776892ab2044ecca417be348e482fee2839db75e35d165b53737cb8153ab1e", url="https://github.com/vasi/squashfuse/archive/refs/tags/0.1.105.tar.gz")
+    version(
+        "0.1.105",
+        sha256="3f776892ab2044ecca417be348e482fee2839db75e35d165b53737cb8153ab1e",
+        url="https://github.com/vasi/squashfuse/archive/refs/tags/0.1.105.tar.gz",
+    )
     version("0.1.104", sha256="aa52460559e0d0b1753f6b1af5c68cfb777ca5a13913285e93f4f9b7aa894b3a")
     version("0.1.103", sha256="42d4dfd17ed186745117cfd427023eb81effff3832bab09067823492b6b982e7")
 


### PR DESCRIPTION
Replaces #34847

This PR makes Charliecloud's internal SquashFUSE support functional, which requires very specific SquashFUSE versioning.  

This updated PR keeps the Squashfuse package continuing to use the manually created tarball artifacts, as requested.