### PR TITLE
Replace dependency `netcdf-cxx` with `netcdf-cxx4` in `vtk`

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -150,7 +150,7 @@ class Vtk(CMakePackage):
     depends_on("lz4")
     depends_on("netcdf-c~mpi", when="~mpi")
     depends_on("netcdf-c+mpi", when="+mpi")
-    depends_on("netcdf-cxx")
+    depends_on("netcdf-cxx4")
     depends_on("libpng")
     depends_on("libtiff")
     depends_on("zlib-api")


### PR DESCRIPTION
`vtk` has a dependency on `netcdf-cxx`, however this is a deprecated package
```
$ spack info netcdf-cxx
AutotoolsPackage:   netcdf-cxx

Description:
    Deprecated C++ compatibility bindings for NetCDF. These do NOT read or
    write NetCDF-4 files, and are no longer maintained by Unidata.
    Developers should migrate to current NetCDF C++ bindings, in Spack
    package netcdf-cxx4.
```
Further, `netcdf-cxx` does not correctly build on arm64 macos.

This PR updates the dependency to the newer `netcdf-cxx4` bindings