### PR TITLE
e4s ci: disable gpu test stack

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -370,25 +370,25 @@ e4s-rocm-external-build:
 ########################################
 # GPU Testing Pipeline
 ########################################
-.gpu-tests:
-  extends: [ ".linux_x86_64_v3" ]
-  variables:
-    SPACK_CI_STACK_NAME: gpu-tests
+# .gpu-tests:
+#   extends: [ ".linux_x86_64_v3" ]
+#   variables:
+#     SPACK_CI_STACK_NAME: gpu-tests
 
-gpu-tests-generate:
-  extends: [ ".gpu-tests", ".generate-x86_64"]
-  image: ghcr.io/spack/ubuntu20.04-runner-x86_64:2023-01-01
+# gpu-tests-generate:
+#   extends: [ ".gpu-tests", ".generate-x86_64"]
+#   image: ghcr.io/spack/ubuntu20.04-runner-x86_64:2023-01-01
 
-gpu-tests-build:
-  extends: [ ".gpu-tests", ".build" ]
-  trigger:
-    include:
-      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: gpu-tests-generate
-    strategy: depend
-  needs:
-    - artifacts: True
-      job: gpu-tests-generate
+# gpu-tests-build:
+#   extends: [ ".gpu-tests", ".build" ]
+#   trigger:
+#     include:
+#       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+#         job: gpu-tests-generate
+#     strategy: depend
+#   needs:
+#     - artifacts: True
+#       job: gpu-tests-generate
 
 ########################################
 # E4S OneAPI Pipeline


### PR DESCRIPTION
We are doing significant system maintenance and our GPU runners will be inconsistently available until that is completed. Disable this stack so that CI is not held up in the meantime. @wspear