### PR TITLE
Convert  .spack/spec.yaml files

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1399,6 +1399,16 @@ def _build_tarball_in_stage_dir(spec: Spec, out_url: str, stage_dir: str, option
 
     checksum, _ = _do_create_tarball(tarfile_path, binaries_dir, buildinfo)
 
+    if spec_file.endswith(".yaml"):
+        # convert old spec.yaml files to json first
+        conv_file = spec_file.replace(".yaml", ".json")
+        yf = Spec.from_specfile(spec_file)
+        with open(conv_file, "w") as out:
+            yf.to_json(out)
+
+        os.rename(spec_file, spec_file + ".orig")
+        spec_file = conv_file
+
     # add sha256 checksum to spec.json
     with open(spec_file, "r") as inputfile:
         content = inputfile.read()


### PR DESCRIPTION

Currently (as of v0.21.0) if you attempt to migrate a buildcache image of an older spack pacakge 
which has a spec.yaml file in .spack rather than a spec.json file, when you try to create a new spack
image, you get an exception: ` ValueError( ".yaml not a valid spec file type")`

This change writes the corresponding spec.json file, and renames the spec.yaml as spec.yaml.orig,
so that the buildcache creation code can continue. 

I think to get a test case for this you have to create a buildcache of a package in v0.17.0, install it into
an v0.19.0 spack instance, dump it into a second buildcache, I then install that one into a v0.21.0 spack 
instance.  This gives you an instance with a spec.yaml file.   If you then try to spack buildcache create
that, you get the exception that this patch fixes, or I can provide a buildcache to install from directly into
v0.21.0...