### PR TITLE
cce compiler: remove vestigial compiler names

### DIFF
--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -20,16 +20,16 @@ class Cce(Compiler):
             self.version_argument = "-V"
 
     # Subclasses use possible names of C compiler
-    cc_names = ["craycc", "cc"]
+    cc_names = ["craycc"]
 
     # Subclasses use possible names of C++ compiler
-    cxx_names = ["crayCC", "CC"]
+    cxx_names = ["crayCC"]
 
     # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ["crayftn", "ftn"]
+    f77_names = ["crayftn"]
 
     # Subclasses use possible names of Fortran 90 compiler
-    fc_names = ["crayftn", "ftn"]
+    fc_names = ["crayftn"]
 
     # MacPorts builds gcc versions with prefixes and -mp-X.Y suffixes.
     suffixes = [r"-mp-\d\.\d"]


### PR DESCRIPTION
When the cce compiler support was originally written, it could never be searched by PATH. As a result, placeholders with the Cray compiler wrapper names were put in for the compiler names (as the compiler had no executable names and could only be accessed through the wrappers).

Now that the standalone cce executables exist, those names were added to the placeholders. This results in a bug that if the Cray compiler wrappers appear in your PATH variable ahead of the cce executables, the compiler detection will detect the compiler wrappers instead of the executables. This will make the compiler execution dependent on the module environment in ways that are unintended.

This will not affect the module-based compiler detection on legacy cray systems, which do not rely on these variables.

@bvanessen this should solve your issue.

@tgamblin as we discussed on our call.