### PR TITLE
mochi-thallium: adding a few new versions

### DIFF
--- a/var/spack/repos/builtin/packages/mochi-thallium/package.py
+++ b/var/spack/repos/builtin/packages/mochi-thallium/package.py
@@ -16,6 +16,11 @@ class MochiThallium(CMakePackage):
     maintainers("mdorier")
 
     version("main", branch="main")
+    version("0.12.0", sha256="8f1a16ce08db24009807a6619a0fb73c0c9a05727634465f76370938d7492cbb")
+    version("0.11.3", sha256="d1ffd7ee1ccbcfb00f246cb29c5bc2560e59f8808609cbc19b7098aa8fc903c4")
+    version("0.11.2", sha256="4f1e57ca843b7592525c179dec73bfb603a27fbda4feaf028d636e05c1b38e36")
+    version("0.11.1", sha256="be99bec2309ce1945a777fba720175f409972cbf27b73388728a740d6406a040")
+    version("0.11.0", sha256="c216310fdef9281e1c7e3264c148c560d7f5edd15816d35866efcc543185b7ee")
     version("0.10.1", sha256="5a8dc1f1622f4186b02fbabd47a8a33ca6be3d07757010f3d63d30e9f74fec8c")
     version("0.10.0", sha256="5319e25a42deab7c639e980885fe3be717cda2c2c693a1906f5a6c79b31edef8")
     version("0.9.1", sha256="dee884d0e054c838807f9c17781acfa99b26e3be1cc527bf09ceaa997336b3e4")

--- a/var/spack/repos/builtin/packages/mochi-thallium/package.py
+++ b/var/spack/repos/builtin/packages/mochi-thallium/package.py
@@ -16,7 +16,6 @@ class MochiThallium(CMakePackage):
     maintainers("mdorier")
 
     version("main", branch="main")
-    version("0.12.0", sha256="2857c431bbaad4f6d774afb0060f985e746f9f1e9ad567818a9fb59113efc9e4")
     version("0.11.3", sha256="d1ffd7ee1ccbcfb00f246cb29c5bc2560e59f8808609cbc19b7098aa8fc903c4")
     version("0.11.2", sha256="4f1e57ca843b7592525c179dec73bfb603a27fbda4feaf028d636e05c1b38e36")
     version("0.11.1", sha256="be99bec2309ce1945a777fba720175f409972cbf27b73388728a740d6406a040")

--- a/var/spack/repos/builtin/packages/mochi-thallium/package.py
+++ b/var/spack/repos/builtin/packages/mochi-thallium/package.py
@@ -16,6 +16,7 @@ class MochiThallium(CMakePackage):
     maintainers("mdorier")
 
     version("main", branch="main")
+    version("0.12.0", sha256="2857c431bbaad4f6d774afb0060f985e746f9f1e9ad567818a9fb59113efc9e4")
     version("0.11.3", sha256="d1ffd7ee1ccbcfb00f246cb29c5bc2560e59f8808609cbc19b7098aa8fc903c4")
     version("0.11.2", sha256="4f1e57ca843b7592525c179dec73bfb603a27fbda4feaf028d636e05c1b38e36")
     version("0.11.1", sha256="be99bec2309ce1945a777fba720175f409972cbf27b73388728a740d6406a040")

--- a/var/spack/repos/builtin/packages/mochi-thallium/package.py
+++ b/var/spack/repos/builtin/packages/mochi-thallium/package.py
@@ -16,7 +16,6 @@ class MochiThallium(CMakePackage):
     maintainers("mdorier")
 
     version("main", branch="main")
-    version("0.12.0", sha256="8f1a16ce08db24009807a6619a0fb73c0c9a05727634465f76370938d7492cbb")
     version("0.11.3", sha256="d1ffd7ee1ccbcfb00f246cb29c5bc2560e59f8808609cbc19b7098aa8fc903c4")
     version("0.11.2", sha256="4f1e57ca843b7592525c179dec73bfb603a27fbda4feaf028d636e05c1b38e36")
     version("0.11.1", sha256="be99bec2309ce1945a777fba720175f409972cbf27b73388728a740d6406a040")

--- a/var/spack/repos/builtin/packages/mochi-thallium/package.py
+++ b/var/spack/repos/builtin/packages/mochi-thallium/package.py
@@ -56,6 +56,7 @@ class MochiThallium(CMakePackage):
     )
 
     depends_on("pkgconfig", type=("build"))
+    depends_on("mochi-margo@0.12.0:", when="@0.11.2:")
     depends_on("mochi-margo@0.9.8:", when="@0.10.0:")
     depends_on("mochi-margo@0.7:", when="@0.7:")
     depends_on("mochi-margo@0.6:", when="@0.5:")


### PR DESCRIPTION
This PR adds versions 0.11.0 to 0.11.3.

Note: I initially had (then removed, added back, and removed again) version 0.12.0. This version has major issues that led me to delete the release a few hours after I made it. It needs more work, so I will leave this PR open to add version 0.11.0 to 0.11.3 and do another PR later for 0.12.0.