### PR TITLE
verilator: Fix flex for build and link, limit gcc to 7 or greater

### DIFF
--- a/var/spack/repos/builtin/packages/verilator/package.py
+++ b/var/spack/repos/builtin/packages/verilator/package.py
@@ -70,10 +70,12 @@ class Verilator(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("help2man", type="build")
     depends_on("bison", type="build")
-    depends_on("flex", type="build")
+    depends_on("flex")
     depends_on("ccache", type=("build", "run"), when="@5.018:")
     depends_on("perl", type=("build", "run"))
     depends_on("bash", type="build")
+
+    conflicts("%gcc@:6", msg="C++14 support required")
 
     # we need to fix the CXX and LINK paths, as they point to the spack
     # wrapper scripts which aren't usable without spack


### PR DESCRIPTION
Centos7 comes with gcc4 and this doesn't, after experimenting it was found that compile starts to work at gcc7.

Also need to have flex for build and link.