### PR TITLE
MFEM: add mpi link dir

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -751,13 +751,14 @@ class Mfem(Package, CudaPackage, ROCmPackage):
                     )
                     gfortran_lib = LibraryList(libfile)
                     sp_lib += [ld_flags_from_library_list(gfortran_lib)]
-                mpi = strumpack["mpi"]
-                if ("^mpich" in strumpack) or ("^mvapich2" in strumpack):
-                    sp_lib += [ld_flags_from_dirs([mpi.prefix.lib], ["mpifort"])]
-                elif "^openmpi" in strumpack:
-                    sp_lib += [ld_flags_from_dirs([mpi.prefix.lib], ["mpi_mpifh"])]
-                elif "^spectrum-mpi" in strumpack:
-                    sp_lib += [ld_flags_from_dirs([mpi.prefix.lib], ["mpi_ibm_mpifh"])]
+                if "+mpi" in strumpack:
+                    mpi = strumpack["mpi"]
+                    if ("^mpich" in strumpack) or ("^mvapich2" in strumpack):
+                        sp_lib += [ld_flags_from_dirs([mpi.prefix.lib], ["mpifort"])]
+                    elif "^openmpi" in strumpack:
+                        sp_lib += [ld_flags_from_dirs([mpi.prefix.lib], ["mpi_mpifh"])]
+                    elif "^spectrum-mpi" in strumpack:
+                        sp_lib += [ld_flags_from_dirs([mpi.prefix.lib], ["mpi_ibm_mpifh"])]
             if "+openmp" in strumpack:
                 # The '+openmp' in the spec means strumpack will TRY to find
                 # OpenMP; if not found, we should not add any flags -- how do

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -751,12 +751,13 @@ class Mfem(Package, CudaPackage, ROCmPackage):
                     )
                     gfortran_lib = LibraryList(libfile)
                     sp_lib += [ld_flags_from_library_list(gfortran_lib)]
+                mpi = strumpack["mpi"]
                 if ("^mpich" in strumpack) or ("^mvapich2" in strumpack):
-                    sp_lib += ["-lmpifort"]
+                    sp_lib += [ld_flags_from_dirs([mpi.prefix.lib], ["mpifort"])]
                 elif "^openmpi" in strumpack:
-                    sp_lib += ["-lmpi_mpifh"]
+                    sp_lib += [ld_flags_from_dirs([mpi.prefix.lib], ["mpi_mpifh"])]
                 elif "^spectrum-mpi" in strumpack:
-                    sp_lib += ["-lmpi_ibm_mpifh"]
+                    sp_lib += [ld_flags_from_dirs([mpi.prefix.lib], ["mpi_ibm_mpifh"])]
             if "+openmp" in strumpack:
                 # The '+openmp' in the spec means strumpack will TRY to find
                 # OpenMP; if not found, we should not add any flags -- how do

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -441,7 +441,7 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
         if "~shared" in hdf5:
             if "+szip" in hdf5:
                 extra_libs.append(hdf5["szip"].libs)
-            extra_libs.append(hdf5["zlib"].libs)
+            extra_libs.append(hdf5["zlib-api"].libs)
 
         if self.spec.satisfies("@4.9.0:+shared"):
             lib_search_dirs.extend(self.spec["zlib-api"].libs.directories)


### PR DESCRIPTION
MFEM is currently adding the `-l` for the mpi fortran library but not where to find it. This fails in downstream projects who try to use their config file.

Also fixes the `netcdf-c` library needing to call the virtual package for `zlib`