### PR TITLE
tests: fix issue with os.environ binding

### DIFF
--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -147,7 +147,8 @@ def test_reverse_environment_modifications(working_env):
 
     reversal = to_reverse.reversed()
 
-    os.environ = start_env.copy()
+    os.environ.clear()
+    os.environ.update(start_env)
 
     print(os.environ)
     to_reverse.apply_modifications()


### PR DESCRIPTION
Before this `spack unit-test lib/spack/spack/test/util/environment.py lib/spack/spack/test/module_parsing.py` failed.

I don't wanna figure out what's wrong with rebinding `os.environ` to something else, but mutating the instance is more sensible to me anyways; maybe in the fixture `os.environ` after yielding still refers to the original instance, somehow?