### PR TITLE
Libfabric: Introduce OPX provider conflict for v1.20.0

### DIFF
--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -125,7 +125,12 @@ class Libfabric(AutotoolsPackage):
 
     conflicts("@1.9.0", when="platform=darwin", msg="This distribution is missing critical files")
     conflicts("fabrics=opx", when="@:1.14.99")
-    conflicts("fabrics=opx", when="@1.20.0")
+    conflicts(
+        "fabrics=opx",
+        when="@1.20.0",
+        msg="Libfabric 1.20.0 uses values in memory that are not correctly "
+        "set by OPX, resulting in undefined behavior.",
+    )
 
     flag_handler = build_system_flags
 

--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -125,6 +125,7 @@ class Libfabric(AutotoolsPackage):
 
     conflicts("@1.9.0", when="platform=darwin", msg="This distribution is missing critical files")
     conflicts("fabrics=opx", when="@:1.14.99")
+    conflicts("fabrics=opx", when="@1.20.0")
 
     flag_handler = build_system_flags
 


### PR DESCRIPTION
Small change to disallow building the OPX provider for Omni-Path networks with libfabric@1.20.0.