### PR TITLE
vtk-m: bump vtk-m 2.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/mr3160-rocthrust-fix.patch
+++ b/var/spack/repos/builtin/packages/vtk-m/mr3160-rocthrust-fix.patch
@@ -1,0 +1,74 @@
+From c9ec6ae6a62b9bd257e727e999987ef31384e3ac Mon Sep 17 00:00:00 2001
+From: Vicente Adolfo Bolea Sanchez <vicente.bolea@kitware.com>
+Date: Thu, 30 Nov 2023 15:55:32 -0500
+Subject: [PATCH] kokkos: let link vtkm_cont to roc::rocthrust
+
+Also reorder the declarion of the option VTKm_ENABLE_KOKKOS_THRUST
+to be set before calling VTKmDeviceAdapters.
+---
+ CMake/VTKmDeviceAdapters.cmake           |  5 +----
+ CMakeLists.txt                           | 10 +++++-----
+ vtkm/cont/kokkos/internal/CMakeLists.txt |  3 +++
+ 3 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/CMake/VTKmDeviceAdapters.cmake b/CMake/VTKmDeviceAdapters.cmake
+index fb13d0bf85..7b8bf2df9b 100644
+--- a/CMake/VTKmDeviceAdapters.cmake
++++ b/CMake/VTKmDeviceAdapters.cmake
+@@ -360,10 +360,7 @@ if(VTKm_ENABLE_KOKKOS AND NOT TARGET vtkm_kokkos)
+ 
+     # Make sure rocthrust is available if requested
+     if(VTKm_ENABLE_KOKKOS_THRUST)
+-      find_package(rocthrust)
+-      if(NOT rocthrust_FOUND)
+-        message(FATAL_ERROR "rocthrust not found. Please set VTKm_ENABLE_KOKKOS_THRUST to OFF.")
+-      endif()
++      find_package(rocthrust REQUIRED CONFIG)
+     endif()
+   endif()
+ 
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 39a9b3bc09..d8204114c7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -191,6 +191,11 @@ vtkm_option(VTKm_OVERRIDE_CTEST_TIMEOUT "Disable default ctest timeout" OFF)
+ # VTKm_ENABLE_MPI=ON.
+ cmake_dependent_option(VTKm_ENABLE_GPU_MPI "Enable GPU AWARE MPI support" OFF "VTKm_ENABLE_MPI" OFF)
+ 
++# By default: Set VTKm_ENABLE_KOKKOS_THRUST to ON if VTKm_ENABLE_KOKKOS is ON, otherwise
++# disable it (or if the user explicitly turns this option OFF)
++cmake_dependent_option(VTKm_ENABLE_KOKKOS_THRUST "Enable Kokkos thrust support (only valid with CUDA and HIP)"
++  ON "VTKm_ENABLE_KOKKOS;Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP" OFF)
++
+ mark_as_advanced(
+   VTKm_ENABLE_LOGGING
+   VTKm_NO_ASSERT
+@@ -232,11 +237,6 @@ include(VTKmBuildType)
+ # Include the vtk-m wrappers
+ include(VTKmWrappers)
+ 
+-# By default: Set VTKm_ENABLE_KOKKOS_THRUST to ON if VTKm_ENABLE_KOKKOS is ON, otherwise
+-# disable it (or if the user explicitly turns this option OFF)
+-cmake_dependent_option(VTKm_ENABLE_KOKKOS_THRUST "Enable Kokkos thrust support (only valid with CUDA and HIP)"
+-  ON "VTKm_ENABLE_KOKKOS;Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP" OFF)
+-
+ # Create vtkm_compiler_flags library. This is an interface library that
+ # holds all the C++ compiler flags that are needed for consumers and
+ # when building VTK-m.
+diff --git a/vtkm/cont/kokkos/internal/CMakeLists.txt b/vtkm/cont/kokkos/internal/CMakeLists.txt
+index 9f924b0f4b..9b731c9fdd 100644
+--- a/vtkm/cont/kokkos/internal/CMakeLists.txt
++++ b/vtkm/cont/kokkos/internal/CMakeLists.txt
+@@ -34,6 +34,9 @@ if (TARGET vtkm_kokkos)
+   elseif(TARGET vtkm_kokkos_hip)
+     set_source_files_properties(${sources} TARGET_DIRECTORY vtkm_cont PROPERTIES LANGUAGE HIP)
+     kokkos_compilation(SOURCE ${sources})
++    if (VTKm_ENABLE_KOKKOS_THRUST)
++      target_link_libraries(vtkm_cont INTERFACE roc::rocthrust)
++    endif()
+   endif()
+ 
+ else()
+-- 
+2.35.3
+

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -123,6 +123,8 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
         )
 
     depends_on("hip@3.7:", when="+rocm")
+    depends_on("rocthrust", when="+kokkos+rocm")
+    depends_on("thrust", when="+kokkos+cuda")
 
     # The rocm variant is only valid options for >= 1.7. It would be better if
     # this could be expressed as a when clause to disable the rocm variant,

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -29,12 +29,12 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version("release", branch="release")
-    version("2.1.0-rc2", sha256="94631fff9f668f40c9c797f03cf32a0d22d57111e309b1e8133c2a3f292b4af1")
     version(
-        "2.0.0",
-        sha256="32643cf3564fa77f8e2a2a5456a574b6b2355bb68918eb62ccde493993ade1a3",
+        "2.1.0",
+        sha256="9cf3522b6dc0675281a1a16839464ebd1cc5f9c08c20eabee1719b3bcfdcf41f",
         preferred=True,
     )
+    version("2.0.0", sha256="32643cf3564fa77f8e2a2a5456a574b6b2355bb68918eb62ccde493993ade1a3")
     version("1.9.0", sha256="12355dea1a24ec32767260068037adeb71abb3df2f9f920c92ce483f35ff46e4")
     version("1.8.0", sha256="fcedee6e8f4ac50dde56e8c533d48604dbfb663cea1561542a837e8e80ba8768")
     version("1.7.1", sha256="7ea3e945110b837a8c2ba49b41e45e1a1d8d0029bb472b291f7674871dbbbb63")

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -123,8 +123,8 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
         )
 
     depends_on("hip@3.7:", when="+rocm")
-    depends_on("rocthrust", when="+kokkos+rocm")
-    depends_on("thrust", when="+kokkos+cuda")
+    # CUDA thrust is already include in the CUDA pkg
+    depends_on("rocthrust", when="@2.1: +kokkos+rocm")
 
     # The rocm variant is only valid options for >= 1.7. It would be better if
     # this could be expressed as a when clause to disable the rocm variant,
@@ -148,6 +148,10 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
     # VTK-M PR#2972
     # https://gitlab.kitware.com/vtk/vtk-m/-/merge_requests/2972
     patch("vtkm-cuda-swap-conflict-pr2972.patch", when="@1.9 +cuda ^cuda@12:")
+
+    # VTK-M PR#3160
+    # https://gitlab.kitware.com/vtk/vtk-m/-/merge_requests/3160
+    patch("mr3160-rocthrust-fix.patch", when="@2.1:")
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
🎉 🎉 🎉

Finally! VTK-m v2.1.0 final release is out.

This bring exiting new features and bugfixes. Find the release notes at https://gitlab.kitware.com/vtk/vtk-m/-/blob/master/docs/changelog/2.1/release-notes.md

Let me know if we need to change anything else in the package

ViB

🎉 🎉 🎉