### PR TITLE
improve docs for centos7

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -120,7 +120,7 @@ Spack has to install it on initial use, which is called bootstrapping.
 
 Spack provides two ways of bootstrapping ``clingo``: from pre-built binaries
 (default), or from sources. The fastest way to get started is to bootstrap from
-pre-built binaries.
+pre-built binaries. (on Centos7, users have to make sure that ``patchelf`` package is installed.)
 
 The first time you concretize a spec, Spack will bootstrap automatically:
 

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -120,7 +120,7 @@ Spack has to install it on initial use, which is called bootstrapping.
 
 Spack provides two ways of bootstrapping ``clingo``: from pre-built binaries
 (default), or from sources. The fastest way to get started is to bootstrap from
-pre-built binaries. (on Centos7, users have to make sure that ``patchelf`` package is installed.)
+pre-built binaries. (on Centos7, users should make sure that ``patchelf`` package is installed.)
 
 The first time you concretize a spec, Spack will bootstrap automatically:
 


### PR DESCRIPTION
en centos7 binary bootstrap doesn't work without `patchelf`. Also, compilation from source doesn't work due to older gcc@4.8.3. Hence patchelf should be mentioned here for centos7 users.

related issues:
https://github.com/spack/spack/issues/33015
