### PR TITLE
ruff: add version 0.1.6

### DIFF
--- a/var/spack/repos/builtin/packages/py-ruff/package.py
+++ b/var/spack/repos/builtin/packages/py-ruff/package.py
@@ -13,6 +13,8 @@ class PyRuff(PythonPackage):
     pypi = "ruff/ruff-0.0.276.tar.gz"
     git = "https://github.com/astral-sh/ruff.git"
 
+    version("0.1.6", sha256="1b09f29b16c6ead5ea6b097ef2764b42372aebe363722f1605ecbcd2b9207184")
     version("0.0.276", sha256="d456c86eb6ce9225507f24fcc7bf72fa031bb7cc750023310e62889bf4ad4b6a")
 
     depends_on("py-maturin@1", type="build")
+    depends_on("rust@1.71:", when="@0.1.6:", type="build")

--- a/var/spack/repos/builtin/packages/py-ruff/package.py
+++ b/var/spack/repos/builtin/packages/py-ruff/package.py
@@ -17,4 +17,7 @@ class PyRuff(PythonPackage):
     version("0.0.276", sha256="d456c86eb6ce9225507f24fcc7bf72fa031bb7cc750023310e62889bf4ad4b6a")
 
     depends_on("py-maturin@1", type="build")
+
+    # Found in Cargo.toml
     depends_on("rust@1.71:", when="@0.1.6:", type="build")
+    depends_on("rust@1.70:", when="@0.0.276:", type="build")


### PR DESCRIPTION
Built successfully on AlmaLinux 9, CentOS 7 and Ubuntu 22.04. The dependency with rust happens through `py-maturin` but it complained when I had < 1.71 so I guess it's better to make it explicit.