### PR TITLE
py-keras: add v3.0.0

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-darwin-aarch64-mps/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-darwin-aarch64-mps/spack.yaml
@@ -24,7 +24,9 @@ spack:
 
   # Keras
   # Bazel codesign issues
-  # - py-keras
+  # - py-keras backend=tensorflow
+  # - py-keras backend=jax
+  - py-keras backend=torch
   - py-keras-applications
   - py-keras-preprocessing
   - py-keras2onnx

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cpu/spack.yaml
@@ -19,7 +19,9 @@ spack:
     - py-jaxlib
 
     # Keras
-    - py-keras
+    # - py-keras backend=tensorflow
+    - py-keras backend=jax
+    - py-keras backend=torch
     - py-keras-applications
     - py-keras-preprocessing
     - py-keras2onnx

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
@@ -22,7 +22,9 @@ spack:
     - py-jaxlib
 
     # Keras
-    - py-keras
+    # - py-keras backend=tensorflow
+    - py-keras backend=jax
+    - py-keras backend=torch
     - py-keras-applications
     - py-keras-preprocessing
     - py-keras2onnx

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
@@ -24,7 +24,9 @@ spack:
     - py-jaxlib
 
     # Keras
-    - py-keras
+    # - py-keras backend=tensorflow
+    - py-keras backend=jax
+    # - py-keras backend=torch
     - py-keras-applications
     - py-keras-preprocessing
     - py-keras2onnx

--- a/var/spack/repos/builtin/packages/py-keras/package.py
+++ b/var/spack/repos/builtin/packages/py-keras/package.py
@@ -9,18 +9,17 @@ from spack.package import *
 
 
 class PyKeras(PythonPackage):
-    """Deep Learning for humans.
+    """Multi-backend Keras.
 
-    Keras is a deep learning API written in Python, running on top of the machine
-    learning platform TensorFlow. It was developed with a focus on enabling fast
-    experimentation. Being able to go from idea to result as fast as possible is
-    key to doing good research.
+    Keras 3 is a new multi-backend implementation of the Keras API,
+    with support for TensorFlow, JAX, and PyTorch.
     """
 
     homepage = "https://keras.io"
     git = "https://github.com/keras-team/keras.git"
-    url = "https://github.com/keras-team/keras/archive/refs/tags/v2.7.0.tar.gz"
+    pypi = "keras/keras-3.0.0.tar.gz"
 
+    version("3.0.0", sha256="82a9fa4b32a049b38151d11188ed15d74f21f853f163e78da0950dce1f244ccc")
     version("2.14.0", sha256="a845d446b6ae626f61dde5ab2fa952530b6c17b4f9ed03e9362bd20172d00cca")
     version("2.13.1", sha256="b3591493cce75a69adef7b192cec6be222e76e2386d132cd4e34aa190b0ecbd5")
     version("2.12.0", sha256="6336cebb6b2b0a91f7efd3ff3a9db3a94f2abccf07a40323138afb80826aec62")
@@ -43,25 +42,48 @@ class PyKeras(PythonPackage):
     version("2.2.1", sha256="0d3cb14260a3fa2f4a5c4c9efa72226ffac3b4c50135ba6edaf2b3d1d23b11ee")
     version("2.2.0", sha256="5b8499d157af217f1a5ee33589e774127ebc3e266c833c22cb5afbb0ed1734bf")
 
-    # Supported Python versions listed in multiple places:
-    # * keras/tools/pip_package/setup.py
-    # * CONTRIBUTING.md
-    # * PKG-INFO
+    variant(
+        "backend",
+        default="tensorflow",
+        description="backend library",
+        values=["tensorflow", "jax", "torch"],
+        multi=False,
+        when="@3:",
+    )
+
+    # setup.py
+    depends_on("python@3.9:", type=("build", "run"), when="@3:")
     depends_on("python@3.8:", type=("build", "run"), when="@2.12:")
     depends_on("py-setuptools", type="build")
-
-    # Required dependencies listed in multiple places:
-    # * BUILD
-    # * WORKSPACE
     depends_on("py-absl-py", type=("build", "run"), when="@2.6:")
-    depends_on("py-h5py", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
-    depends_on("py-pandas", type=("build", "run"))
-    depends_on("pil", type=("build", "run"))
-    depends_on("py-portpicker", type=("build", "run"), when="@2.10:")
-    depends_on("py-pydot", type=("build", "run"))
+    depends_on("py-rich", type=("build", "run"), when="@3:")
+    depends_on("py-namex", type=("build", "run"), when="@3:")
+    depends_on("py-h5py", type=("build", "run"))
+    depends_on("py-dm-tree", type=("build", "run"), when="@3:")
+
+    # requirements-common.txt
     depends_on("py-scipy", type=("build", "run"))
-    depends_on("py-six", type=("build", "run"))
+    depends_on("py-pandas", type=("build", "run"))
+    depends_on("py-requests", type=("build", "run"), when="@3:")
+    depends_on("py-protobuf", type=("build", "run"), when="@2.5:")
+
+    # requirements-tensorflow-cuda.txt
+    conflicts("backend=tensorflow", msg="Requires TensorFlow 2.16, not yet released")
+    # depends_on("py-tensorflow@2.16.0", type=("build", "run"), when="@3.0.0 backend=tensorflow")
+
+    # requirements-jax-cuda.txt
+    depends_on("py-jax", type=("build", "run"), when="@3.0.0: backend=jax")
+
+    # requirements-torch-cuda.txt
+    depends_on("py-torch@2.1.0", type=("build", "run"), when="@3.0.0 backend=torch")
+    depends_on("py-torchvision@0.16.0", type=("build", "run"), when="@3.0.0 backend=torch")
+
+    # Historical dependencies
+    depends_on("py-portpicker", type=("build", "run"), when="@2.10:2")
+    depends_on("py-pyyaml", type=("build", "run"), when="@:2")
+    depends_on("py-six", type=("build", "run"), when="@:2")
+    depends_on("bazel", type="build", when="@2.5:2")
     for minor_ver in range(6, 15):
         depends_on(
             "py-tensorflow@2.{}".format(minor_ver),
@@ -73,18 +95,18 @@ class PyKeras(PythonPackage):
             type=("build", "run"),
             when="@2.{}".format(minor_ver),
         )
-    depends_on("py-pyyaml", type=("build", "run"))
-    depends_on("bazel", type="build", when="@2.5:")
-    depends_on("protobuf", type="build", when="@2.5:")
 
     def url_for_version(self, version):
-        if version >= Version("2.6"):
-            return super().url_for_version(version)
+        if Version("2.6") <= version <= Version("2"):
+            return f"https://github.com/keras-team/keras/archive/refs/tags/v{version}.tar.gz"
         else:
-            url = "https://pypi.io/packages/source/K/Keras/Keras-{0}.tar.gz"
-            return url.format(version.dotted)
+            return super().url_for_version(version)
 
-    @when("@2.5:")
+    def setup_run_environment(self, env):
+        if self.spec.satisfies("@3:"):
+            env.set("KERAS_BACKEND", self.spec.variants["backend"].value)
+
+    @when("@2.5:2")
     def patch(self):
         infile = join_path(self.package_dir, "protobuf_build.patch")
         with open(infile, "r") as source_file:
@@ -99,7 +121,7 @@ class PyKeras(PythonPackage):
             string=True,
         )
 
-    @when("@2.5:")
+    @when("@2.5:2")
     def install(self, spec, prefix):
         self.tmp_path = tempfile.mkdtemp(prefix="spack")
         env["HOME"] = self.tmp_path

--- a/var/spack/repos/builtin/packages/py-keras/package.py
+++ b/var/spack/repos/builtin/packages/py-keras/package.py
@@ -98,7 +98,7 @@ class PyKeras(PythonPackage):
         )
 
     def url_for_version(self, version):
-        if Version("2.6") <= version <= Version("2"):
+        if Version("2.6") <= version < Version("3"):
             return f"https://github.com/keras-team/keras/archive/refs/tags/v{version}.tar.gz"
         else:
             return super().url_for_version(version)

--- a/var/spack/repos/builtin/packages/py-keras/package.py
+++ b/var/spack/repos/builtin/packages/py-keras/package.py
@@ -98,10 +98,13 @@ class PyKeras(PythonPackage):
         )
 
     def url_for_version(self, version):
-        if Version("2.6") <= version < Version("3"):
-            return f"https://github.com/keras-team/keras/archive/refs/tags/v{version}.tar.gz"
+        if version >= Version("3"):
+            url = "https://files.pythonhosted.org/packages/source/k/keras/keras-{}.tar.gz"
+        elif version >= Version("2.6"):
+            url = "https://github.com/keras-team/keras/archive/refs/tags/v{}.tar.gz"
         else:
-            return super().url_for_version(version)
+            url = "https://files.pythonhosted.org/packages/source/k/keras/Keras-{}.tar.gz"
+        return url.format(version)
 
     def setup_run_environment(self, env):
         if self.spec.satisfies("@3:"):

--- a/var/spack/repos/builtin/packages/py-keras/package.py
+++ b/var/spack/repos/builtin/packages/py-keras/package.py
@@ -80,11 +80,13 @@ class PyKeras(PythonPackage):
     depends_on("py-torchvision@0.16.0", type=("build", "run"), when="@3.0.0 backend=torch")
 
     # Historical dependencies
-    depends_on("py-portpicker", type=("build", "run"), when="@2.10:2")
-    depends_on("py-pyyaml", type=("build", "run"), when="@:2")
-    depends_on("py-six", type=("build", "run"), when="@:2")
     depends_on("bazel", type="build", when="@2.5:2")
     depends_on("protobuf", type="build", when="@2.5:2")
+    depends_on("pil", type=("build", "run"), when="@:2")
+    depends_on("py-portpicker", type=("build", "run"), when="@2.10:2")
+    depends_on("py-pydot", type=("build", "run"), when="@:2")
+    depends_on("py-pyyaml", type=("build", "run"), when="@:2")
+    depends_on("py-six", type=("build", "run"), when="@:2")
     for minor_ver in range(6, 15):
         depends_on(
             "py-tensorflow@2.{}".format(minor_ver),

--- a/var/spack/repos/builtin/packages/py-keras/package.py
+++ b/var/spack/repos/builtin/packages/py-keras/package.py
@@ -66,7 +66,7 @@ class PyKeras(PythonPackage):
     depends_on("py-scipy", type=("build", "run"))
     depends_on("py-pandas", type=("build", "run"))
     depends_on("py-requests", type=("build", "run"), when="@3:")
-    depends_on("py-protobuf", type=("build", "run"), when="@2.5:")
+    depends_on("py-protobuf", type=("build", "run"), when="@3:")
 
     # requirements-tensorflow-cuda.txt
     conflicts("backend=tensorflow", msg="Requires TensorFlow 2.16, not yet released")
@@ -84,6 +84,7 @@ class PyKeras(PythonPackage):
     depends_on("py-pyyaml", type=("build", "run"), when="@:2")
     depends_on("py-six", type=("build", "run"), when="@:2")
     depends_on("bazel", type="build", when="@2.5:2")
+    depends_on("protobuf", type="build", when="@2.5:2")
     for minor_ver in range(6, 15):
         depends_on(
             "py-tensorflow@2.{}".format(minor_ver),

--- a/var/spack/repos/builtin/packages/py-namex/package.py
+++ b/var/spack/repos/builtin/packages/py-namex/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyNamex(PythonPackage):
+    """A simple utility to separate the implementation of your Python package
+    and its public API surface."""
+
+    pypi = "namex/namex-0.0.7.tar.gz"
+
+    license("Apache-2.0")
+
+    version("0.0.7", sha256="84ba65bc4d22bd909e3d26bf2ffb4b9529b608cb3f9a4336f776b04204ced69b")
+
+    depends_on("py-setuptools", type="build")


### PR DESCRIPTION
Depends on #41362 

Keras 3.0 represents a big step forward for installing Keras:

* Supports TF, JAX, and Torch backends
* No longer requires Bazel or Git to build
* All dependencies are properly documented

https://keras.io/keras_3/