### PR TITLE
py-mpi4py: fix build with Apple Clang

### DIFF
--- a/var/spack/repos/builtin/packages/py-mpi4py/package.py
+++ b/var/spack/repos/builtin/packages/py-mpi4py/package.py
@@ -17,6 +17,7 @@ class PyMpi4py(PythonPackage):
     git = "https://github.com/mpi4py/mpi4py.git"
 
     version("master", branch="master")
+    version("3.1.5", sha256="a706e76db9255135c2fb5d1ef54cb4f7b0e4ad9e33cbada7de27626205f2a153")
     version("3.1.4", sha256="17858f2ebc623220d0120d1fa8d428d033dde749c4bc35b33d81a66ad7f93480")
     version("3.1.3", sha256="f1e9fae1079f43eafdd9f817cdb3fd30d709edc093b5d5dada57a461b2db3008")
     version("3.1.2", sha256="40dd546bece8f63e1131c3ceaa7c18f8e8e93191a762cd446a8cfcf7f9cce770")
@@ -29,14 +30,11 @@ class PyMpi4py(PythonPackage):
     version("1.3.1", sha256="e7bd2044aaac5a6ea87a87b2ecc73b310bb6efe5026031e33067ea3c2efc3507")
 
     depends_on("py-setuptools@40.9:", type="build")
+    depends_on("py-cython@0.27:2", type="build")
     depends_on("mpi")
-    depends_on("py-cython@0.27.0:", type="build")
-
-    # https://github.com/mpi4py/mpi4py/pull/311
-    conflicts("^py-cython@3:")
 
     def setup_build_environment(self, env):
-        env.set("MPICC", f"{self.spec['mpi'].mpicc} -shared")
+        env.set("MPICC", self.spec['mpi'].mpicc)
 
     @run_before("install")
     def cythonize(self):

--- a/var/spack/repos/builtin/packages/py-mpi4py/package.py
+++ b/var/spack/repos/builtin/packages/py-mpi4py/package.py
@@ -34,7 +34,7 @@ class PyMpi4py(PythonPackage):
     depends_on("mpi")
 
     def setup_build_environment(self, env):
-        env.set("MPICC", self.spec['mpi'].mpicc)
+        env.set("MPICC", self.spec["mpi"].mpicc)
 
     @run_before("install")
     def cythonize(self):


### PR DESCRIPTION
Fixes #41014 

The `-shared` flag causes the following error with Apple Clang:
```
clang: error: invalid argument '-bundle' not allowed with '-dynamiclib'
```
Removing this flag allows me to build successfully. Not sure why this flag was originally added.