### PR TITLE
AMG2023: removing the cmake fork version

### DIFF
--- a/var/spack/repos/builtin/packages/amg2023/package.py
+++ b/var/spack/repos/builtin/packages/amg2023/package.py
@@ -18,7 +18,6 @@ class Amg2023(CMakePackage, CudaPackage, ROCmPackage):
     git = "https://github.com/LLNL/AMG2023.git"
 
     version("develop", branch="main")
-    version("cmake-build", git="https://github.com/dyokelson/AMG2023.git", branch="cmake")
 
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=False, description="Enable OpenMP support")


### PR DESCRIPTION
The AMG2023 spack recipe no longer needs to point to a fork for the cmake build version as that pull request has been merged with develop. I removed that line and now the only version is develop.