### PR TITLE
Opencarp: Initial Ginkgo backend integration

### DIFF
--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -24,7 +24,9 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
 
     version("develop", branch="develop")
     version("master", branch="master")
-    version("1.7.0", commit="49242ff89af1e695d7794f6d50ed9933024b66fe")  # v1.7.0
+    version("1.7.0", commit="49242ff89af1e695d7794f6d50ed9933024b66fe", preferred=True)  # v1.7.0
+    # v1.7.0 with (unmerged) resource manager feature for openCARP
+    version("1.7.0.opencarp_experimental", branch="openCARP_experimental")
     version("1.6.0", commit="1f1ed46e724334626f016f105213c047e16bc1ae")  # v1.6.0
     version("1.5.0", commit="234594c92b58e2384dfb43c2d08e7f43e2b58e7a")  # v1.5.0
     version(
@@ -160,6 +162,10 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
 
         if self.run_tests:
             args.append("-DGINKGO_USE_EXTERNAL_GTEST=ON")
+
+        if self.spec.satisfies("@1.7.0.opencarp_experimental"):
+            args.append("-DGINKGO_BUILD_CONFIG_PARSER=ON")
+            args.append("-DGINKGO_BUILD_EXTENSIONS=ON")
 
         if "+cuda" in spec:
             archs = spec.variants["cuda_arch"].value

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -28,7 +28,8 @@ class Opencarp(CMakePackage):
     version(
         "13.0.ginkgo_integration",
         branch="ginkdo_distributed_backend",
-        submodules=False, no_cache=True
+        submodules=False,
+        no_cache=True,
     )
     version(
         "12.0", commit="a34c11af3e8c2afd6e123e586a446c6993e0b039", submodules=False, no_cache=True
@@ -55,7 +56,12 @@ class Opencarp(CMakePackage):
 
     variant("carputils", default=False, description="Installs the carputils framework")
     variant("meshtool", default=False, description="Installs the meshtool software")
-    variant("ginkgo", default=False, description="Enable the Ginkgo as linear algebra backend", when="@13.0.ginkgo_integration")
+    variant(
+        "ginkgo",
+        default=False,
+        description="Enable the Ginkgo as linear algebra backend",
+        when="@13.0.ginkgo_integration",
+    )
 
     # Patch removing problematic steps in CMake process
     patch("opencarp7.patch", when="@7.0")
@@ -77,17 +83,13 @@ class Opencarp(CMakePackage):
         depends_on("py-carputils@oc" + ver, when="@" + ver + " +carputils")
         depends_on("meshtool@oc" + ver, when="@" + ver + " +meshtool")
 
-
     # The ginkgo integration relies on carputils features only in master,
-    #or in release >oc14.0
+    # or in release >oc14.0
     depends_on("py-carputils@master", when="@13.0.ginkgo_integration+carputils")
     depends_on("meshtool@oc13.0", when="@13.0.ginkgo_integration+meshtool")
 
     def cmake_args(self):
-        args = [
-            self.define("DLOPEN", True),
-            self.define("SPACK_BUILD", True)
-        ]
+        args = [self.define("DLOPEN", True), self.define("SPACK_BUILD", True)]
         if "+ginkgo" in self.spec:
             args.append("-DENABLE_GINKGO=ON")
         return args

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -85,8 +85,8 @@ class Opencarp(CMakePackage):
 
     # The ginkgo integration relies on carputils features only in master,
     # or in release >oc14.0
-    depends_on("py-carputils@master", when="@13.0.ginkgo_integration+carputils")
-    depends_on("meshtool@oc13.0", when="@13.0.ginkgo_integration+meshtool")
+    depends_on("py-carputils@oc13.0.ginkgo", when="@13.0.ginkgo_integration+carputils+ginkgo")
+    depends_on("meshtool@oc13.0", when="@13.0.ginkgo_integration+meshtool+ginkgo")
 
     def cmake_args(self):
         args = [self.define("DLOPEN", True), self.define("SPACK_BUILD", True)]

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -30,7 +30,6 @@ class PyCarputils(PythonPackage):
 
     # cusettings:11: DeprecationWarning:
     # The distutils package is deprecated and slated for removal in Python 3.12.
-    conflicts("python@3.10:", when="@master")
     conflicts("python@3.10:", when="@:oc13.0")
 
     depends_on("py-numpy@1.14.5:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -28,6 +28,11 @@ class PyCarputils(PythonPackage):
 
     depends_on("git", type=("build", "run"))
 
+    # cusettings:11: DeprecationWarning:
+    # The distutils package is deprecated and slated for removal in Python 3.12.
+    conflicts("python@3.10:", when="@master")
+    conflicts("python@3.10:", when="@:oc13.0")
+
     depends_on("py-numpy@1.14.5:", type=("build", "run"))
     depends_on("py-setuptools@41.6.0:", type=("build", "run"))
     depends_on("py-python-dateutil@2.8.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -17,7 +17,8 @@ class PyCarputils(PythonPackage):
 
     version("master", branch="master")
     # Version to use with openCARP releases
-    version("oc13.0", commit="216c3802c2ac2d14c739164dcd57f2e59aa2ede3")
+    version("oc13.0.ginkgo", commit="88ea4ff29aa6ba7899c945c8daba856caacc4a87")
+    version("oc13.0", commit="216c3802c2ac2d14c739164dcd57f2e59aa2ede3", preferred=True)
     version("oc12.0", commit="4d7a1f0c604a2ad232e70cf9aa3a8daff5ffb195")
     version("oc11.0", commit="a02f9b846c6e852b7315b20e925d55c355f239b8")
     version("oc10.0", commit="a02f9b846c6e852b7315b20e925d55c355f239b8")

--- a/var/spack/repos/builtin/packages/py-tables/package.py
+++ b/var/spack/repos/builtin/packages/py-tables/package.py
@@ -38,7 +38,12 @@ class PyTables(PythonPackage):
     depends_on("py-cython@0.21:", type="build")
 
     # setup.py
-    depends_on("python@3.8:", when="@3.8:", type=("build", "run"))
+    # python 3.11 is supported only from version 3.8 onwards.
+    # python 3.12 is supported only from version 3.9.1 onwards.
+    # See https://github.com/PyTables/PyTables/releases/tag/v3.8.0
+    depends_on("python@3.6:3.10", when="@:3.7", type=("build", "run"))
+    depends_on("python@3.8:3.11", when="@3.8:3.9.0", type=("build", "run"))
+    depends_on("python@3.8:", when="@3.9.1:", type=("build", "run"))
 
     # requirements.txt
     depends_on("py-numpy@1.19:", when="@3.8:", type=("build", "run"))


### PR DESCRIPTION
Ginkgo is available as a numerical backend to OpenCARP. This does the spack integration.

Currently, this PR relies on experimental features within Ginkgo, hence special versions are added on both sides. Ginkgo 1.8.0 will have the necessary features to enable native integration without custom branch usage.