### PR TITLE
MET fixes for 11.1 and HDF4 support

### DIFF
--- a/var/spack/repos/builtin/packages/met/package.py
+++ b/var/spack/repos/builtin/packages/met/package.py
@@ -106,7 +106,7 @@ class Met(AutotoolsPackage):
             ldflags.append(nc_config("--libs", "--static", output=str).strip())
             libs.append(nc_config("--libs", "--static", output=str).strip())
 
-        zlib = spec["zlib"]
+        zlib = spec["zlib-api"]
         cppflags.append("-D__64BIT__")
         ldflags.append("-L" + zlib.prefix.lib)
         libs.append("-lz")

--- a/var/spack/repos/builtin/packages/met/package.py
+++ b/var/spack/repos/builtin/packages/met/package.py
@@ -128,6 +128,7 @@ class Met(AutotoolsPackage):
         if "+python" in spec:
             python = spec["python"]
             env.set("MET_PYTHON", python.command.path)
+            env.set("MET_PYTHON_BIN_EXE", python.command.path)
             env.set("MET_PYTHON_CC", "-I" + python.headers.directories[0])
             py_ld = [python.libs.ld_flags]
             if spec["python"].satisfies("~shared"):
@@ -142,6 +143,11 @@ class Met(AutotoolsPackage):
             hdfeos = spec["hdf-eos2"]
             env.set("MET_HDF5", hdf.prefix)
             env.set("MET_HDFEOS", hdfeos.prefix)
+
+            if "+szip" in hdf:
+                libs.append(" ".join(hdf["szip"].libs))
+            if "+external-xdr" in hdf:
+                libs.append(" ".join(hdf["rpc"].libs))
 
         if "+graphics" in spec:
             cairo = spec["cairo"]


### PR DESCRIPTION
This PR makes two changes to the MET package recipe:

1. Defines `MET_PYTHON_BIN_EXE`, which is required for Python bindings at least in 11.1.0. You will get a configure error if you do not set this but specify `+python`. (see [here](https://met.readthedocs.io/en/latest/Users_Guide/appendixF.html) for docs)
2. Like many packages, this MET recipe fails if you need HDF4 and HDF4 was built with either `+szip` or `+external-xdr`, as you end up with missing library references. I've taken the approach used in the **netcdf-c** package and adapted it for use in this recipe.