### PR TITLE
nwchem: add libxc/elpa support

### DIFF
--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -32,7 +32,9 @@ class Nwchem(Package):
     variant("mpipr", default=False, description="Enables ARMCI with progress rank")
     variant("fftw3", default=False, description="Link against the FFTW library")
     variant("libxc", default=False, description="Support additional functionals via libxc")
-    variant("elpa", default=False, description="Enable optimised diagonalisation routines from ELPA")
+    variant(
+        "elpa", default=False, description="Enable optimised diagonalisation routines from ELPA"
+    )
     variant("xtb", default=False, description="xtb supporting")
 
     # This patch is for the modification of the build system (e.g. compiler flags) and
@@ -127,11 +129,13 @@ class Nwchem(Package):
             args.extend(["FFTW3_INCLUDE={0}".format(spec["fftw-api"].prefix.include)])
 
         if "+libxc" in spec:
-            args.extend(["LIBXC_LIB=%s"%spec["libxc"].libs.ld_flags])
-            args.extend(["LIBXC_INCLUDE=%s"%spec["libxc"].prefix.include])
+            args.extend(["LIBXC_LIB=%s" % spec["libxc"].libs.ld_flags])
+            args.extend(["LIBXC_INCLUDE=%s" % spec["libxc"].prefix.include])
 
         if "+elpa" in spec:
-            args.extend(["ELPA=%s"%spec["elpa"].libs.ld_flags+" -I"+spec["elpa"].prefix.include])
+            args.extend(
+                ["ELPA=%s" % spec["elpa"].libs.ld_flags + " -I" + spec["elpa"].prefix.include]
+            )
             if use_32_bit_lin_alg:
                 args.extend(["ELPA_SIZE=4"])
             else:

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -56,7 +56,7 @@ class Nwchem(Package):
     depends_on("lapack")
     depends_on("mpi")
     depends_on("scalapack")
-    depends_on("fftw-api", when="+fftw3")
+    depends_on("fftw-api@3", when="+fftw3")
     depends_on("libxc", when="+libxc")
     depends_on("elpa", when="+elpa")
     depends_on("python@3:3.9", type=("build", "link", "run"), when="@:7.0.2")

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -132,10 +132,8 @@ class Nwchem(Package):
             args.extend([f"LIBXC_INCLUDE={0}".format(spec["libxc"].prefix.include)])
 
         if spec.satisfies("+elpa"):
-            elpa=spec["elpa"]
-            args.extend(
-                [f"ELPA={elpa.libs.ld_flags} -I{elpa.prefix.include}"]
-            )
+            elpa = spec["elpa"]
+            args.extend([f"ELPA={elpa.libs.ld_flags} -I{elpa.prefix.include}"])
             if use_32_bit_lin_alg:
                 args.extend(["ELPA_SIZE=4"])
             else:

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -78,7 +78,7 @@ class Nwchem(Package):
                 f"FC={os.path.basename(spack_fc)}",
                 "USE_MPI=y",
                 "USE_MPIF=y",
-                f"PYTHONVERSION={spec["python"].version.up_to(2)}",
+                "PYTHONVERSION={}".format(spec["python"].version.up_to(2)),
                 f"BLASOPT={(lapack + blas).ld_flags}",
                 f"LAPACK_LIB={lapack.ld_flags}",
                 f"SCALAPACK_LIB={scalapack.ld_flags}",

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -125,15 +125,16 @@ class Nwchem(Package):
         if spec.satisfies("+fftw3"):
             args.extend(["USE_FFTW3=y"])
             args.extend([f"LIBFFTW3={fftw.ld_flags}"])
-            args.extend([f"FFTW3_INCLUDE={spec["fftw-api"].prefix.include}"])
+            args.extend(["FFTW3_INCLUDE={0}".format(spec["fftw-api"].prefix.include)])
 
         if spec.satisfies("+libxc"):
-            args.extend([f"LIBXC_LIB={spec["libxc"].libs.ld_flags}"])
-            args.extend([f"LIBXC_INCLUDE={spec["libxc"].prefix.include}"])
+            args.extend([f"LIBXC_LIB={0}".format(spec["libxc"].libs.ld_flags)])
+            args.extend([f"LIBXC_INCLUDE={0}".format(spec["libxc"].prefix.include)])
 
         if spec.satisfies("+elpa"):
+            elpa=spec["elpa"]
             args.extend(
-                [f"ELPA={spec["elpa"].libs.ld_flags} -I{spec["elpa"].prefix.include}"]
+                [f"ELPA={elpa.libs.ld_flags} -I{elpa.prefix.include}"]
             )
             if use_32_bit_lin_alg:
                 args.extend(["ELPA_SIZE=4"])


### PR DESCRIPTION
NWChem announced elpa and libxc support in version 7.0; this PR adds support of using elpa and libxc in nwchem building by spack.
Also added an experimental linear algebra integer size detecting, instead of defaulting 32-bit integer now.