### PR TITLE
spack buildcache check: use same interface as push

### DIFF
--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -618,7 +618,12 @@ _spack_buildcache_preview() {
 }
 
 _spack_buildcache_check() {
-    SPACK_COMPREPLY="-h --help -m --mirror-url -o --output-file --scope -s --spec --spec-file"
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -m --mirror-url -o --output-file --scope -s --spec --spec-file"
+    else
+        _all_packages
+    fi
 }
 
 _spack_buildcache_download() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -797,6 +797,7 @@ complete -c spack -n '__fish_spack_using_command buildcache preview' -s h -l hel
 
 # spack buildcache check
 set -g __fish_spack_optspecs_spack_buildcache_check h/help m/mirror-url= o/output-file= scope= s/spec= spec-file=
+complete -c spack -n '__fish_spack_using_command_pos_remainder 0 buildcache check' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command buildcache check' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache check' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command buildcache check' -s m -l mirror-url -r -f -a mirror_url


### PR DESCRIPTION
This ensures that `spack buildcache push` and `spack buildcache check` can be
used the same way.

`spack buildcache check` without args is for checking the currently active env.

It deprecates the `spack buildcache check --spec` in favor of positional
arguments.

