### PR TITLE
Add XCDF package

### DIFF
--- a/var/spack/repos/builtin/packages/xcdf/package.py
+++ b/var/spack/repos/builtin/packages/xcdf/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Xcdf(CMakePackage):
+    """Binary data format designed to store data fields with user-specified accuracy."""
+
+    homepage = "https://github.com/jimbraun/XCDF"
+    url = "https://github.com/jimbraun/XCDF/archive/refs/tags/v3.00.03.tar.gz"
+
+    license("BSD-2-Clause")
+
+    version("3.00.03", sha256="4e445a2fea947ba14505d08177c8d5b55856f8411f28de1fe4d4c00f6824b711")
+
+    patch("remove_python_support.patch")

--- a/var/spack/repos/builtin/packages/xcdf/remove_python_support.patch
+++ b/var/spack/repos/builtin/packages/xcdf/remove_python_support.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3270f47..e5648d2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -45,7 +45,6 @@ SET (XCDF_PATCH_VERSION  1 CACHE STRING "Patch number")
+ # ------------------------------------------------------------------------------
+ SET (CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+ INCLUDE (Utility)
+-INCLUDE (Python)
+ 
+ INCLUDE_DIRECTORIES (${CMAKE_SOURCE_DIR}/include)
+ INCLUDE_DIRECTORIES (${CMAKE_SOURCE_DIR}/include/utility)


### PR DESCRIPTION
This PR adds the XCDF package which is needed by the [HAWC](https://hawc-observatory.org/) and [SWGO](https://www.swgo.org/) software frameworks.

I found no way of supporting the Python 2 bindings provided in the latest XCDF release; looking at the current main branch it seems like Python 3 support is currently under development though, so a future release may include Python bindings.

Many thanks for taking a look!