### PR TITLE
Fix installation issue #27709: curl does not configure/build with Intel compilers spa

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -345,6 +345,12 @@ class Curl(NMakePackage, AutotoolsPackage):
     def command(self):
         return Executable(self.prefix.bin.join("curl-config"))
 
+    def flag_handler(self, name, flags):
+        build_system_flags = []
+        if name == "cflags" and self.spec.compiler.name in ["intel", "oneapi"]:
+            build_system_flags = ["-we147"]
+        return flags, None, build_system_flags
+
 
 class AutotoolsBuilder(AutotoolsBuilder):
     def configure_args(self):
@@ -385,10 +391,6 @@ class AutotoolsBuilder(AutotoolsBuilder):
         args += self.with_or_without("libssh2", activation_value="prefix")
         args += self.with_or_without("libssh", activation_value="prefix")
         args += self.enable_or_disable("ldap")
-
-        # https://github.com/spack/spack/issues/27709
-        if self.spec.compiler.name in ["intel", "oneapi"]:
-            args.append("CFLAGS=-we147")
 
         return args
 

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -386,6 +386,10 @@ class AutotoolsBuilder(AutotoolsBuilder):
         args += self.with_or_without("libssh", activation_value="prefix")
         args += self.enable_or_disable("ldap")
 
+        # https://github.com/spack/spack/issues/27709
+        if self.spec.compiler.name in ["intel", "oneapi"]:
+            args.append("CFLAGS=-we147")
+
         return args
 
     def with_or_without_gnutls(self, activated):


### PR DESCRIPTION
## Description

See https://github.com/spack/spack/issues/27709 for a long and detailed discussion of the problem and when it triggers. I just ran into this on a Navy HPC system and needed to fix it.

I first tried to use the `flag_handler` logic, but somehow that got ignored by `configure`. Therefore the suggested patch for the curl package.

Fixes https://github.com/spack/spack/issues/27709

@markyoder FYI