### PR TITLE
Fix windows kit base path and reference to windows registry key

### DIFF
--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -309,10 +309,12 @@ class WindowsKitExternalPaths:
         return glob.glob(kit_base)
 
     @staticmethod
-    def find_windows_kit_bin_paths(kit_base: Optional[str] = None) -> List[str]:
+    def find_windows_kit_bin_paths(kit_base: Optional[str, list] = None) -> List[str]:
         """Returns Windows kit bin directory per version"""
         kit_base = WindowsKitExternalPaths.find_windows_kit_roots() if not kit_base else kit_base
         assert kit_base, "Unexpectedly empty value for Windows kit base path"
+        if isinstance(kit_base, str):
+            kit_base = kit_base.split(';')
         kit_paths = []
         for kit in kit_base:
             kit_bin = os.path.join(kit, "bin")
@@ -320,10 +322,12 @@ class WindowsKitExternalPaths:
         return kit_paths
 
     @staticmethod
-    def find_windows_kit_lib_paths(kit_base: Optional[str] = None) -> List[str]:
+    def find_windows_kit_lib_paths(kit_base: Optional[str, list] = None) -> List[str]:
         """Returns Windows kit lib directory per version"""
         kit_base = WindowsKitExternalPaths.find_windows_kit_roots() if not kit_base else kit_base
         assert kit_base, "Unexpectedly empty value for Windows kit base path"
+        if isinstance(kit_base, str):
+            kit_base = kit_base.split(';')
         kit_paths = []
         for kit in kit_base:
             kit_lib = os.path.join(kit, "Lib")

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -309,12 +309,14 @@ class WindowsKitExternalPaths:
         return glob.glob(kit_base)
 
     @staticmethod
-    def find_windows_kit_bin_paths(kit_base: Optional[str, list] = None) -> List[str]:
+    def find_windows_kit_bin_paths(
+        kit_base: Union[Optional[str], Optional[list]] = None
+    ) -> List[str]:
         """Returns Windows kit bin directory per version"""
         kit_base = WindowsKitExternalPaths.find_windows_kit_roots() if not kit_base else kit_base
         assert kit_base, "Unexpectedly empty value for Windows kit base path"
         if isinstance(kit_base, str):
-            kit_base = kit_base.split(';')
+            kit_base = kit_base.split(";")
         kit_paths = []
         for kit in kit_base:
             kit_bin = os.path.join(kit, "bin")
@@ -322,12 +324,14 @@ class WindowsKitExternalPaths:
         return kit_paths
 
     @staticmethod
-    def find_windows_kit_lib_paths(kit_base: Optional[str, list] = None) -> List[str]:
+    def find_windows_kit_lib_paths(
+        kit_base: Union[Optional[str], Optional[list]] = None
+    ) -> List[str]:
         """Returns Windows kit lib directory per version"""
         kit_base = WindowsKitExternalPaths.find_windows_kit_roots() if not kit_base else kit_base
         assert kit_base, "Unexpectedly empty value for Windows kit base path"
         if isinstance(kit_base, str):
-            kit_base = kit_base.split(';')
+            kit_base = kit_base.split(";")
         kit_paths = []
         for kit in kit_base:
             kit_lib = os.path.join(kit, "Lib")

--- a/var/spack/repos/builtin/packages/win-wdk/package.py
+++ b/var/spack/repos/builtin/packages/win-wdk/package.py
@@ -133,7 +133,7 @@ class WinWdk(Package):
             except ProcessError as pe:
                 reg = winreg.WindowsRegistryView(
                     "SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots",
-                    root_key=spack.util.windows_registry.HKEY_LOCAL_MACHINE,
+                    root_key=spack.util.windows_registry.HKEY.HKEY_LOCAL_MACHINE,
                 )
                 if not reg:
                     # No Kits are available, failure was genuine


### PR DESCRIPTION
This PR fixes 2 bugs:

1. It ensures that `kit_base` is a list in 2 methods. This was causing the `win-wdk` external find command to fail silently because it was looping through a string charcter-by-character instead of looping through a list of path strings.
2. Fixes a reference to a windows registry key in the `win-wdk` package.py which was incorrect. 