### PR TITLE
py-metomi-isodatetime: fix url parsing

### DIFF
--- a/var/spack/repos/builtin/packages/py-metomi-isodatetime/package.py
+++ b/var/spack/repos/builtin/packages/py-metomi-isodatetime/package.py
@@ -20,5 +20,4 @@ class PyMetomiIsodatetime(PythonPackage):
     depends_on("py-setuptools", type="build")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/source/m/metomi-isodatetime/metomi-isodatetime-1!{}.tar.gz"
-        return url.format(version)
+        return f"https://files.pythonhosted.org/packages/source/m/metomi-isodatetime/metomi-isodatetime-1!{version}.tar.gz"

--- a/var/spack/repos/builtin/packages/py-metomi-isodatetime/package.py
+++ b/var/spack/repos/builtin/packages/py-metomi-isodatetime/package.py
@@ -18,3 +18,7 @@ class PyMetomiIsodatetime(PythonPackage):
     version("3.0.0", sha256="2141e8aaa526ea7f7f1cb883e6c8ed83ffdab73269658d84d0624f63a6e1357e")
 
     depends_on("py-setuptools", type="build")
+
+    def url_for_version(self, version):
+        url = "https://files.pythonhosted.org/packages/source/m/metomi-isodatetime/metomi-isodatetime-1!{}.tar.gz"
+        return url.format(version)

--- a/var/spack/repos/builtin/packages/py-metomi-isodatetime/package.py
+++ b/var/spack/repos/builtin/packages/py-metomi-isodatetime/package.py
@@ -10,6 +10,7 @@ class PyMetomiIsodatetime(PythonPackage):
     """Python ISO 8601 date time parser and data model/manipulation utilities."""
 
     homepage = "https://github.com/metomi/isodatetime"
+    # NOTE: spack checksum does not yet work for epoch versions
     pypi = "metomi-isodatetime/metomi-isodatetime-1!3.0.0.tar.gz"
 
     maintainers("LydDeb")


### PR DESCRIPTION
Closes #41414

Could have modified our regexes to better support this version identifier but this is literally the only case we have in Spack as far as I know so will wait until this is more common.