### PR TITLE
openblas: fix macOS build when using XCode 15 or newer

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -93,6 +93,9 @@ class Openblas(CMakePackage, MakefilePackage):
     provides("lapack@3.9.1:", when="@0.3.15:")
     provides("lapack@3.7.0", when="@0.2.20")
 
+    # https://github.com/OpenMathLib/OpenBLAS/pull/4328
+    patch("xcode15-fortran.patch", when="%apple-clang@15:")
+    
     # https://github.com/xianyi/OpenBLAS/pull/2519/files
     patch("ifort-msvc.patch", when="%msvc")
 

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -94,7 +94,7 @@ class Openblas(CMakePackage, MakefilePackage):
     provides("lapack@3.7.0", when="@0.2.20")
 
     # https://github.com/OpenMathLib/OpenBLAS/pull/4328
-    patch("xcode15-fortran.patch", when="%apple-clang@15:")
+    patch("xcode15-fortran.patch", when="@0.3.25 %apple-clang@15:")
 
     # https://github.com/xianyi/OpenBLAS/pull/2519/files
     patch("ifort-msvc.patch", when="%msvc")

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -95,7 +95,7 @@ class Openblas(CMakePackage, MakefilePackage):
 
     # https://github.com/OpenMathLib/OpenBLAS/pull/4328
     patch("xcode15-fortran.patch", when="%apple-clang@15:")
-    
+
     # https://github.com/xianyi/OpenBLAS/pull/2519/files
     patch("ifort-msvc.patch", when="%msvc")
 

--- a/var/spack/repos/builtin/packages/openblas/xcode15-fortran.patch
+++ b/var/spack/repos/builtin/packages/openblas/xcode15-fortran.patch
@@ -1,0 +1,22 @@
+From 47b03fd4b4ce7bc51d5b56397e52e6da3c5f3f36 Mon Sep 17 00:00:00 2001
+From: Martin Kroeker <martin@ruby.chemie.uni-freiburg.de>
+Date: Sat, 18 Nov 2023 23:45:02 +0100
+Subject: [PATCH] Copy XCode15-specific workaround to Fortran flags to fix
+ build of tests
+
+---
+ Makefile.system | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Makefile.system b/Makefile.system
+index 1b84195e45..ff06e503cb 100644
+--- a/Makefile.system
++++ b/Makefile.system
+@@ -407,6 +407,7 @@ XCVER = $(shell pkgutil --pkg-info=com.apple.pkg.CLTools_Executables |awk '/vers
+ endif
+ ifeq (x$(XCVER), x 15)
+ CCOMMON_OPT += -Wl,-ld_classic
++FCOMMON_OPT += -Wl,-ld_classic
+ endif
+ endif
+ 


### PR DESCRIPTION
This fixes Openblas when built with XCode 15 (macOS Sonoma), which switched to a new linker. This patch forces the build to use the old macOS linker.

This applies this patch from the Openblas development branch to earlier versions: https://github.com/OpenMathLib/OpenBLAS/pull/4328