### PR TITLE
Update py-werkzeug version dependency for py-graphene-tornado@2.6.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-graphene-tornado/package.py
+++ b/var/spack/repos/builtin/packages/py-graphene-tornado/package.py
@@ -21,5 +21,8 @@ class PyGrapheneTornado(PythonPackage):
     depends_on("py-graphene@2.1:2", type=("build", "run"))
     depends_on("py-jinja2@2.10.1:", type=("build", "run"))
     depends_on("py-tornado@5.1.0:", type=("build", "run"))
+    # py-werkzeug version requirements differ between setup.py (0.12.2)
+    # and requirements.txt (0.15.3); the latter seems to be correct,
+    # see also https://github.com/spack/spack/pull/41426
     depends_on("py-werkzeug@0.15.3", type=("build", "run"))
     depends_on("py-pytest", type=("build"))

--- a/var/spack/repos/builtin/packages/py-graphene-tornado/package.py
+++ b/var/spack/repos/builtin/packages/py-graphene-tornado/package.py
@@ -21,5 +21,5 @@ class PyGrapheneTornado(PythonPackage):
     depends_on("py-graphene@2.1:2", type=("build", "run"))
     depends_on("py-jinja2@2.10.1:", type=("build", "run"))
     depends_on("py-tornado@5.1.0:", type=("build", "run"))
-    depends_on("py-werkzeug@0.12.2", type=("build", "run"))
+    depends_on("py-werkzeug@0.15.3", type=("build", "run"))
     depends_on("py-pytest", type=("build"))


### PR DESCRIPTION
I was looking into the dependencies for `py-graphene-tornado` because I simply couldn't get something that dependent on `py-graphene-tornado` (currently only version 2.6.1 coded up) to build with Python newer than 3.9.

The py-werkzeug dependency in the package had `0.12.2` as version, but according to https://github.com/graphql-python/graphene-tornado/blob/v2.6.1/requirements.txt it should be `0.15.3`. I made this change and was able to build the dependent package I was after (`py-cylc-uiserver`) fine.

I was able to launch the `jupyter-cylc` dashboard fine with the so-built packages. I didn't test the cylc flow server itself, but given that the `py-cylc-flow` package is already happy with newer Python versions (it doesn't use `py-werkzeug`), I guess it's ok?