### PR TITLE
Update versions of GFE packages

### DIFF
--- a/var/spack/repos/builtin/packages/fargparse/package.py
+++ b/var/spack/repos/builtin/packages/fargparse/package.py
@@ -20,6 +20,7 @@ class Fargparse(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.6.0", sha256="055a0af44f50c302f8f20a8bcf3d26c5bbeacf5222cdbaa5b19da4cff56eb9c0")
     version("1.5.0", sha256="1c16ead5f1bacb9c2f33aab99a0889c68c1a1ece754ddc3fd340f10a0d5da2f7")
     version("1.4.2", sha256="2cd3f14845235407c6a4171ab4602499dade045e3f9b7dc75190f4a315ac8b44")
     version("1.4.1", sha256="8f9b92a80f05b0a8ab2dd5cd309ad165041c7fcdd589b96bf75c7dd889b9b584")

--- a/var/spack/repos/builtin/packages/gftl-shared/package.py
+++ b/var/spack/repos/builtin/packages/gftl-shared/package.py
@@ -23,6 +23,7 @@ class GftlShared(CMakePackage):
 
     version("main", branch="main")
 
+    version("1.7.0", sha256="8ba567133fcee6b93bc71f61b3bb2053b4b07c6d78f6ad98a04dfc40aa478de7")
     version("1.6.1", sha256="0e3e1e0c7e0c3f1576e296b3b199dcae4bbaad055fc8fe929c34e52d4b07b02c")
     version("1.6.0", sha256="90245b83aea9854bc5b9fbd553a68cf73ab12f6ed5a14753a9c84092047e8cb0")
     version("1.5.1", sha256="353d07cc22678d1a79b19dbf53d8ba54b889e424a15e315cc4f035b72eedb83a")

--- a/var/spack/repos/builtin/packages/gftl/package.py
+++ b/var/spack/repos/builtin/packages/gftl/package.py
@@ -39,6 +39,7 @@ class Gftl(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.11.0", sha256="b28935bc077749823b1505ad8c1208360a5ba7e961d7593c17a33b11455a32a4")
     version("1.10.0", sha256="d6086e8cba2497bacdae66d301f7cdacaed9138a0055f33f8ca1b778a0cf0dc5")
     version("1.9.0", sha256="4c7cb8b1313d87eaa5cc9aae242301085aa3b12688d0fddf54061503e95e4cc0")
     version("1.8.3", sha256="5864c6a427105c1194cbc0dcbe0dad2c3d14d42b2717f0a5e1626e0d56bba8a6")

--- a/var/spack/repos/builtin/packages/pflogger/package.py
+++ b/var/spack/repos/builtin/packages/pflogger/package.py
@@ -20,6 +20,7 @@ class Pflogger(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.11.0", sha256="bf197b6f223a75c7d3eee23888cdde204b5aea053c308852a3f8f677784b8899")
     version("1.10.0", sha256="8e25564699c0adcbe9a23fded6637668ce659480b39420be5a4c8181cd44ad53")
     version("1.9.5", sha256="baa3ebb83962f1b6c8c5b0413fe9d02411d3e379c76b8c190112e158c10ac0ac")
     version("1.9.3", sha256="f300fab515a25b728889ef6c2ab64aa90e7f94c98fd8190dd11a9b1ebd38117a")

--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -19,6 +19,7 @@ class Pfunit(CMakePackage):
 
     maintainers("mathomp4", "tclune")
 
+    version("4.8.0", sha256="b5c66ab949fd23bee5c3b4d93069254f7ea40decb8d21f622fd6aa45ee68ef10")
     version("4.7.4", sha256="ac850e33ea99c283f503f75293bf238b4b601885d7adba333066e6185dad5c04")
     version("4.7.3", sha256="247239298b55e847417b7830183d7fc62cca93dc92c8ec7c0067784b7ce34544")
     version("4.7.2", sha256="3142a1e56b7d127fdc9589cf6deff8505174129834a6a268d0ce7e296f51ab02")

--- a/var/spack/repos/builtin/packages/yafyaml/package.py
+++ b/var/spack/repos/builtin/packages/yafyaml/package.py
@@ -28,6 +28,7 @@ class Yafyaml(CMakePackage):
 
     version("main", branch="main")
 
+    version("1.2.0", sha256="912a4248bbf2e2e84cf3e36f2ae8483bee6b32d2eaa4406dd2100ad660c9bfc6")
     version("1.1.0", sha256="f0be81afe643adc2452055e5485f09cdb509a8fdd5a4ec5547b0c31dd22b4830")
     version("1.0.7", sha256="54f5c87e86c12e872e615fbc9540610ae38053f844f1e75d1e753724fea85c64")
     version("1.0.6", sha256="8075e1349d900985f5b5a81159561568720f21c5f011c43557c46f5bbedd0661")


### PR DESCRIPTION
This PR updates the various [GFE](https://github.com/Goddard-Fortran-Ecosystem/GFE) packages to include the new versions in [GFE v1.12.0](https://github.com/Goddard-Fortran-Ecosystem/GFE/releases/tag/v1.12.0):

| Package     | Version    |
| :------     | :------    |
| gFTL        | v1.11.0    |
| gFTL-shared | v1.7.0     |
| fArgParse   | v1.6.0     |
| pFUnit      | v4.8.0     |
| yaFyaml     | v1.2.0     |
| pFlogger    | v1.11.0    |

If you prefer six separate PRs, just let me know.