### PR TITLE
CI: Disable downloading artifacts from upstream jobs

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1253,6 +1253,7 @@ def generate_gitlab_ci_yaml(
                 op=lambda cmd: cmd.replace("mirror_prefix", temp_storage_url_prefix),
             )
 
+            cleanup_job["dependencies"] = []
             output_object["cleanup"] = cleanup_job
 
         if (
@@ -1276,6 +1277,7 @@ def generate_gitlab_ci_yaml(
                 if buildcache_destination
                 else remote_mirror_override or remote_mirror_url
             )
+            signing_job["dependencies"] = []
 
             output_object["sign-pkgs"] = signing_job
 
@@ -1296,6 +1298,7 @@ def generate_gitlab_ci_yaml(
             final_job["when"] = "always"
             final_job["retry"] = service_job_retries
             final_job["interruptible"] = True
+            final_job["dependencies"] = []
 
             output_object["rebuild-index"] = final_job
 

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -73,6 +73,7 @@ default:
 # Job templates
 ########################################
 .base-job:
+  when: manual
   variables:
     PIPELINE_MIRROR_TEMPLATE: "single-src-protected-mirrors.yaml.in"
     # TODO: We can remove this when we drop the "deprecated" stack


### PR DESCRIPTION
Setting dependencies to an empty array disables downloading artifacts. Spack CI does not use artifacts between jobs other than those already specifying `needs:artifacts:*` in the parent pipeline.

Ref. https://docs.gitlab.com/ee/ci/yaml/#dependencies