### PR TITLE
Add maintainers to fdb, eckit, ecbuild, metkit, eccodes

### DIFF
--- a/var/spack/repos/builtin/packages/ecbuild/package.py
+++ b/var/spack/repos/builtin/packages/ecbuild/package.py
@@ -13,7 +13,7 @@ class Ecbuild(CMakePackage):
     homepage = "https://github.com/ecmwf/ecbuild"
     url = "https://github.com/ecmwf/ecbuild/archive/refs/tags/3.6.1.tar.gz"
 
-    maintainers("skosukhin", "climbfuji")
+    maintainers("skosukhin", "climbfuji", "victoria-cherkas", "dominichofer")
 
     version("3.7.2", sha256="7a2d192cef1e53dc5431a688b2e316251b017d25808190faed485903594a3fb9")
     version("3.6.5", sha256="98bff3d3c269f973f4bfbe29b4de834cd1d43f15b1c8d1941ee2bfe15e3d4f7f")

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -45,7 +45,7 @@ class Eccodes(CMakePackage):
     git = "https://github.com/ecmwf/eccodes.git"
     list_url = "https://confluence.ecmwf.int/display/ECC/Releases"
 
-    maintainers("skosukhin")
+    maintainers("skosukhin", "victoria-cherkas", "dominichofer")
 
     version("develop", branch="develop")
     version("2.32.0", sha256="b57e8eeb0eba0c05d66fda5527c4ffa84b5ab35c46bcbc9a2227142973ccb8e6")

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -45,7 +45,7 @@ class Eccodes(CMakePackage):
     git = "https://github.com/ecmwf/eccodes.git"
     list_url = "https://confluence.ecmwf.int/display/ECC/Releases"
 
-    maintainers("skosukhin", "victoria-cherkas", "dominichofer")
+    maintainers("skosukhin", "victoria-cherkas", "dominichofer", "climbfuji")
 
     version("develop", branch="develop")
     version("2.32.0", sha256="b57e8eeb0eba0c05d66fda5527c4ffa84b5ab35c46bcbc9a2227142973ccb8e6")

--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -16,7 +16,7 @@ class Eckit(CMakePackage):
     git = "https://github.com/ecmwf/eckit.git"
     url = "https://github.com/ecmwf/eckit/archive/refs/tags/1.16.0.tar.gz"
 
-    maintainers("skosukhin", "climbfuji")
+    maintainers("skosukhin", "climbfuji", "victoria-cherkas", "dominichofer")
 
     version("1.24.4", sha256="b6129eb4f7b8532aa6905033e4cf7d09aadc8547c225780fea3db196e34e4671")
     version("1.23.1", sha256="cd3c4b7a3a2de0f4a59f00f7bab3178dd59c0e27900d48eaeb357975e8ce2f15")

--- a/var/spack/repos/builtin/packages/fdb/package.py
+++ b/var/spack/repos/builtin/packages/fdb/package.py
@@ -14,7 +14,7 @@ class Fdb(CMakePackage):
     url = "https://github.com/ecmwf/fdb/archive/refs/tags/5.7.8.tar.gz"
     git = "https://github.com/ecmwf/fdb.git"
 
-    maintainers("skosukhin")
+    maintainers("skosukhin", "victoria-cherkas", "dominichofer")
 
     version("master", branch="master")
     version("5.11.23", sha256="09b1d93f2b71d70c7b69472dfbd45a7da0257211f5505b5fcaf55bfc28ca6c65")

--- a/var/spack/repos/builtin/packages/metkit/package.py
+++ b/var/spack/repos/builtin/packages/metkit/package.py
@@ -13,7 +13,7 @@ class Metkit(CMakePackage):
     homepage = "https://github.com/ecmwf/metkit"
     url = "https://github.com/ecmwf/metkit/archive/refs/tags/1.7.0.tar.gz"
 
-    maintainers("skosukhin")
+    maintainers("skosukhin", "victoria-cherkas", "dominichofer")
 
     version("1.10.17", sha256="1c525891d77ed28cd4c87b065ba4d1aea24d0905452c18d885ccbd567bbfc9b1")
     version("1.10.2", sha256="a038050962aecffda27b755c40b0a6ed0db04a2c22cad3d8c93e6109c8ab4b34")


### PR DESCRIPTION
This PR adds maintainers @victoria-cherkas and @dominichofer to the following packages: 
- fdb
- eckit
- ecbuild
- metkit
- eccodes

We depend heavily on these packages and their latest releases, and we would add/review new releases and updates when required.