### PR TITLE
trilinos: replace pytrilinos2 variant with python

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -402,7 +402,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         depends_on(kokkos_spec, when="@14.4.0 +kokkos {0}".format(arch_str))
 
     depends_on("adios2", when="+adios2")
-    depends_on("binder@1.3:", when="+python", type="build")
+    depends_on("binder@1.3:", when="@15: +python", type="build")
     depends_on("blas")
     depends_on("boost+graph+math+exception+stacktrace", when="+boost")
     # Need to revisit the requirement of STK
@@ -422,15 +422,14 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("matio", when="+exodus")
     depends_on("metis", when="+zoltan")
     depends_on("mpi", when="+mpi")
-    depends_on("mpi", when="+python")
+    depends_on("mpi", when="@15: +python")
     depends_on("netcdf-c", when="+exodus")
     depends_on("parallel-netcdf", when="+exodus+mpi")
     depends_on("parmetis", when="+mpi +zoltan")
     depends_on("parmetis", when="+scorec")
-    depends_on("py-mpi4py", when="+mpi+python", type=("build", "run"))
     depends_on("py-mpi4py", when="+python", type=("build", "run"))
     depends_on("py-numpy", when="+python", type=("build", "run"))
-    depends_on("py-pybind11", when="+python", type=("build", "link"))
+    depends_on("py-pybind11", when="@15: +python", type=("build", "link"))
     depends_on("python", when="+python")
     depends_on("python", when="@13.2: +ifpack +hypre", type="build")
     depends_on("python", when="@13.2: +ifpack2 +hypre", type="build")
@@ -440,7 +439,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("suite-sparse", when="+suite-sparse")
     depends_on("superlu-dist", when="+superlu-dist")
     depends_on("superlu@4.3 +pic", when="+superlu")
-    depends_on("swig", when="+python")
+    depends_on("swig", when="@:14 +python")
     depends_on("zlib-api", when="+zoltan")
 
     # Trilinos' Tribits config system is limited which makes it very tricky to
@@ -752,7 +751,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
                 ]
             )
 
-        if "+python" in spec:
+        if "@15: +python" in spec:
             binder = spec["binder"].prefix.bin.binder
             clang_include_dirs = spec["binder"].clang_include_dirs
             libclang_include_dir = spec["binder"].libclang_include_dir

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -138,8 +138,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     variant("nox", default=False, description="Compile with NOX")
     variant("panzer", default=False, description="Compile with Panzer")
     variant("piro", default=False, description="Compile with Piro")
-    variant("pytrilinos2", default=False, when="@develop", description="Compile with PyTrilinos2")
-    extends("python", when="+pytrilinos2")
     variant("phalanx", default=False, description="Compile with Phalanx")
     variant("rol", default=False, description="Compile with ROL")
     variant("rythmos", default=False, description="Compile with Rythmos")
@@ -404,8 +402,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         depends_on(kokkos_spec, when="@14.4.0 +kokkos {0}".format(arch_str))
 
     depends_on("adios2", when="+adios2")
-    depends_on("binder@1.3:", when="@15: +python", type="build")
-    depends_on("binder@1.3:", when="+pytrilinos2", type="build")
+    depends_on("binder@1.3:", when="+python", type="build")
     depends_on("blas")
     depends_on("boost+graph+math+exception+stacktrace", when="+boost")
     # Need to revisit the requirement of STK
@@ -425,21 +422,16 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("matio", when="+exodus")
     depends_on("metis", when="+zoltan")
     depends_on("mpi", when="+mpi")
-    depends_on("mpi", when="@15: +python")
-    depends_on("mpi", when="+pytrilinos2")
+    depends_on("mpi", when="+python")
     depends_on("netcdf-c", when="+exodus")
     depends_on("parallel-netcdf", when="+exodus+mpi")
     depends_on("parmetis", when="+mpi +zoltan")
     depends_on("parmetis", when="+scorec")
     depends_on("py-mpi4py", when="+mpi+python", type=("build", "run"))
-    depends_on("py-mpi4py", when="+pytrilinos2", type=("build", "run"))
+    depends_on("py-mpi4py", when="+python", type=("build", "run"))
     depends_on("py-numpy", when="+python", type=("build", "run"))
-    depends_on("py-numpy", when="+pytrilinos2", type=("build", "run"))
-    depends_on("py-pybind11", when="@15: +python", type=("build", "link"))
-    depends_on("py-pybind11", when="+pytrilinos2", type=("build", "link"))
+    depends_on("py-pybind11", when="+python", type=("build", "link"))
     depends_on("python", when="+python")
-    # note that +python is a variant but pytrilinos2 still requires python itself
-    depends_on("python", when="+pytrilinos2")
     depends_on("python", when="@13.2: +ifpack +hypre", type="build")
     depends_on("python", when="@13.2: +ifpack2 +hypre", type="build")
     depends_on("scalapack", when="+mumps")
@@ -448,7 +440,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("suite-sparse", when="+suite-sparse")
     depends_on("superlu-dist", when="+superlu-dist")
     depends_on("superlu@4.3 +pic", when="+superlu")
-    depends_on("swig", when="@:14 +python")
+    depends_on("swig", when="+python")
     depends_on("zlib-api", when="+zoltan")
 
     # Trilinos' Tribits config system is limited which makes it very tricky to
@@ -633,6 +625,11 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             ]
         )
 
+        if spec.version >= Version("15"):
+            options.append(define_trilinos_enable("PyTrilinos2", "python"))
+        else:
+            options.append(define_trilinos_enable("PyTrilinos", "python"))
+
         if "+test" in spec:
             options.append(define_trilinos_enable("TESTS", True))
             options.append(define("BUILD_TESTING", True))
@@ -683,8 +680,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
                 define_trilinos_enable("Pike", False),
                 define_trilinos_enable("Piro"),
                 define_trilinos_enable("Phalanx"),
-                define_trilinos_enable("PyTrilinos", "python"),
-                define_trilinos_enable("PyTrilinos2"),
                 define_trilinos_enable("ROL"),
                 define_trilinos_enable("Rythmos"),
                 define_trilinos_enable("Sacado"),
@@ -757,7 +752,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
                 ]
             )
 
-        if "+pytrilinos2" in spec or "@15: +python" in spec:
+        if "+python" in spec:
             binder = spec["binder"].prefix.bin.binder
             clang_include_dirs = spec["binder"].clang_include_dirs
             libclang_include_dir = spec["binder"].libclang_include_dir

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -95,7 +95,8 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         description="global ordinal type for Tpetra",
     )
     variant("openmp", default=False, description="Enable OpenMP")
-    variant("python", default=False, description="Build PyTrilinos wrappers")
+    variant("python", default=False, when="@15:", description="Build PyTrilinos2 wrappers")
+    variant("python", default=False, when="@:14", description="Build PyTrilinos wrappers")
     variant("shared", default=True, description="Enables the build of shared libraries")
     variant("uvm", default=False, when="@13.2: +cuda", description="Turn on UVM for CUDA build")
     variant("wrapper", default=False, description="Use nvcc-wrapper for CUDA build")
@@ -403,6 +404,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         depends_on(kokkos_spec, when="@14.4.0 +kokkos {0}".format(arch_str))
 
     depends_on("adios2", when="+adios2")
+    depends_on("binder@1.3:", when="@15: +python", type="build")
     depends_on("binder@1.3:", when="+pytrilinos2", type="build")
     depends_on("blas")
     depends_on("boost+graph+math+exception+stacktrace", when="+boost")
@@ -423,6 +425,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("matio", when="+exodus")
     depends_on("metis", when="+zoltan")
     depends_on("mpi", when="+mpi")
+    depends_on("mpi", when="@15: +python")
     depends_on("mpi", when="+pytrilinos2")
     depends_on("netcdf-c", when="+exodus")
     depends_on("parallel-netcdf", when="+exodus+mpi")
@@ -432,6 +435,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("py-mpi4py", when="+pytrilinos2", type=("build", "run"))
     depends_on("py-numpy", when="+python", type=("build", "run"))
     depends_on("py-numpy", when="+pytrilinos2", type=("build", "run"))
+    depends_on("py-pybind11", when="@15: +python", type=("build", "link"))
     depends_on("py-pybind11", when="+pytrilinos2", type=("build", "link"))
     depends_on("python", when="+python")
     # note that +python is a variant but pytrilinos2 still requires python itself
@@ -444,7 +448,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("suite-sparse", when="+suite-sparse")
     depends_on("superlu-dist", when="+superlu-dist")
     depends_on("superlu@4.3 +pic", when="+superlu")
-    depends_on("swig", when="+python")
+    depends_on("swig", when="@:14 +python")
     depends_on("zlib-api", when="+zoltan")
 
     # Trilinos' Tribits config system is limited which makes it very tricky to
@@ -753,7 +757,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
                 ]
             )
 
-        if "+pytrilinos2" in spec:
+        if "+pytrilinos2" in spec or "@15: +python" in spec:
             binder = spec["binder"].prefix.bin.binder
             clang_include_dirs = spec["binder"].clang_include_dirs
             libclang_include_dir = spec["binder"].libclang_include_dir

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -291,9 +291,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         conflicts("~ifpack")
         conflicts("~aztec")
 
-    # Don't disable python when building pytrilinos2
-    conflicts("~python", when="+pytrilinos2")
-
     # Known requirements from tribits dependencies
     conflicts("~thyra", when="+stratimikos")
     conflicts("+adelus", when="~kokkos")
@@ -437,6 +434,8 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("py-numpy", when="+pytrilinos2", type=("build", "run"))
     depends_on("py-pybind11", when="+pytrilinos2", type=("build", "link"))
     depends_on("python", when="+python")
+    # note that +python is a variant but pytrilinos2 still requires python itself
+    depends_on("python", when="+pytrilinos2")
     depends_on("python", when="@13.2: +ifpack +hypre", type="build")
     depends_on("python", when="@13.2: +ifpack2 +hypre", type="build")
     depends_on("scalapack", when="+mumps")


### PR DESCRIPTION
There is an ill-named variant "python" that enables the pytrilinos1 variant.  This made it through our testing but broke on our actual CI test machines.