### PR TITLE
CDash: Spack dumps stage errors to configure phase

### DIFF
--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -157,7 +157,9 @@ class CDash(Reporter):
         # dump the report in the configure line so teams can see what the issue is
         if len(phases_encountered) == 1 and package["exception"]:
             phases_encountered.append("configure")
-            report_data["configure"]["loglines"].append(xml.sax.saxutils.escape(package["exception"]))
+            report_data["configure"]["loglines"].append(
+                xml.sax.saxutils.escape(package["exception"])
+            )
 
         # Move the build phase to the front of the list if it occurred.
         # This supports older versions of CDash that expect this phase

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -153,6 +153,12 @@ class CDash(Reporter):
             elif cdash_phase:
                 report_data[cdash_phase]["loglines"].append(xml.sax.saxutils.escape(line))
 
+        # something went wrong in staging b/c we have an exception and only "update" was encounterd
+        # dump the report in the configure line so teams can see what the issue is
+        if len(phases_encountered) == 1 and package["exception"]:
+            phases_encountered.append("configure")
+            report_data["configure"]["loglines"].append(xml.sax.saxutils.escape(package["exception"]))
+
         # Move the build phase to the front of the list if it occurred.
         # This supports older versions of CDash that expect this phase
         # to be reported before all others.

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -153,13 +153,24 @@ class CDash(Reporter):
             elif cdash_phase:
                 report_data[cdash_phase]["loglines"].append(xml.sax.saxutils.escape(line))
 
-        # something went wrong in staging b/c we have an exception and only "update" was encounterd
+        # something went wrong pre-cdash "configure" phase b/c we have an exception and only
+        # "update" was encounterd.
         # dump the report in the configure line so teams can see what the issue is
         if len(phases_encountered) == 1 and package["exception"]:
-            phases_encountered.append("configure")
-            report_data["configure"]["loglines"].append(
-                xml.sax.saxutils.escape(package["exception"])
+            # TODO this mapping is not ideal since these are pre-configure errors
+            # we need to determine if a more appropriate cdash phase can be utilized
+            # for now we will add a message to the log explaining this
+            cdash_phase = "configure"
+            phases_encountered.append(cdash_phase)
+
+            log_message = (
+                "Pre-configure errors occured in Spack's process that terminated the "
+                "build process prematurely.\nSpack output::\n{0}".format(
+                    xml.sax.saxutils.escape(package["exception"])
+                )
             )
+
+            report_data[cdash_phase]["loglines"].append(log_message)
 
         # Move the build phase to the front of the list if it occurred.
         # This supports older versions of CDash that expect this phase


### PR DESCRIPTION
Allow users to see on Cdash why a stage error, such as a failed patch, occurred.