### PR TITLE
py-pre-commit: add version 3.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-pre-commit/package.py
+++ b/var/spack/repos/builtin/packages/py-pre-commit/package.py
@@ -13,6 +13,7 @@ class PyPreCommit(PythonPackage):
     homepage = "https://github.com/pre-commit/pre-commit"
     pypi = "pre_commit/pre_commit-1.20.0.tar.gz"
 
+    version("3.5.0", sha256="5804465c675b659b0862f07907f96295d490822a450c4c40e747d0b1c6ebcb32")
     version("3.3.3", sha256="a2256f489cd913d575c145132ae196fe335da32d91a8294b7afe6622335dd023")
     version("2.20.0", sha256="a978dac7bc9ec0bcee55c18a277d553b0f419d259dadb4b9418ff2d00eb43959")
     version("2.17.0", sha256="c1a8040ff15ad3d648c70cc3e55b93e4d2d5b687320955505587fd79bbaed06a")


### PR DESCRIPTION
The hash should match the source distribution on https://pypi.org/project/pre-commit/.