### PR TITLE
Add missing build system/custom phases to the CDash map

### DIFF
--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -32,13 +32,26 @@ from .base import Reporter
 from .extract import extract_test_parts
 
 # Mapping Spack phases to the corresponding CTest/CDash phase.
+# TODO: Some of the phases being lumped into configure in the CDash tables
+# TODO:   really belong in a separate column, such as "Setup".
+# TODO: Would also be nice to have `stage` as a separate phase that could
+# TODO:   be lumped into that new column instead of configure, for example.
 MAP_PHASES_TO_CDASH = {
-    "autoreconf": "configure",
-    "cmake": "configure",
-    "configure": "configure",
-    "edit": "configure",
+    "autoreconf": "configure",  # AutotoolsBuilder
+    "bootstrap": "configure",  # CMakeBuilder
     "build": "build",
+    "build_processes": "build",  # Openloops
+    "cmake": "configure",  # CMakeBuilder
+    "configure": "configure",
+    "edit": "configure",  # MakefileBuilder
+    "generate_luarocks_config": "configure",  # LuaBuilder
+    "hostconfig": "configure",  # Lvarray
+    "initconfig": "configure",  # CachedCMakeBuilder
     "install": "build",
+    "meson": "configure",  # MesonBuilder
+    "preprocess": "configure",  # LuaBuilder
+    "qmake": "configure",  # QMakeBuilder
+    "unpack": "configure",  # LuaBuilder
 }
 
 # Initialize data structures common to each phase's report.


### PR DESCRIPTION
@psakievich @becker33 

A number of build systems and packages have special phases that are not currently recognized for reporting to the current CDash tables (see https://cdash.spack.io/index.php?project=Spack%20Testing).

This PR adds those phases to the map with initial associations to the current set of CDash columns for builds (i.e., `Configure`, `Build`).  Since the list is growing, it also alphabetizes the phases (keys) to make it easier to visually locate missing entries.

The reporter is extracting "Executing phase:" lines from the log to determine the name of the current phase that is used as the key into the CDash map to determine which column in the CDash table to put any output.