### PR TITLE
Make Ctrl-C during spack bootstrap stop the whole bootstrap process

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -1047,9 +1047,9 @@ class GroupedExceptionHandler:
         """Whether any exceptions were handled."""
         return bool(self.exceptions)
 
-    def forward(self, context: str) -> "GroupedExceptionForwarder":
+    def forward(self, context: str, base: type = BaseException) -> "GroupedExceptionForwarder":
         """Return a contextmanager which extracts tracebacks and prefixes a message."""
-        return GroupedExceptionForwarder(context, self)
+        return GroupedExceptionForwarder(context, self, base)
 
     def _receive_forwarded(self, context: str, exc: Exception, tb: List[str]):
         self.exceptions.append((context, exc, tb))
@@ -1072,15 +1072,18 @@ class GroupedExceptionForwarder:
     """A contextmanager to capture exceptions and forward them to a
     GroupedExceptionHandler."""
 
-    def __init__(self, context: str, handler: GroupedExceptionHandler):
+    def __init__(self, context: str, handler: GroupedExceptionHandler, base: type):
         self._context = context
         self._handler = handler
+        self._base = base
 
     def __enter__(self):
         return None
 
     def __exit__(self, exc_type, exc_value, tb):
         if exc_value is not None:
+            if not issubclass(exc_type, self._base):
+                return False
             self._handler._receive_forwarded(self._context, exc_value, traceback.format_tb(tb))
 
         # Suppress any exception from being re-raised:

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -386,7 +386,7 @@ def ensure_module_importable_or_raise(module: str, abstract_spec: Optional[str] 
     exception_handler = GroupedExceptionHandler()
 
     for current_config in bootstrapping_sources():
-        with exception_handler.forward(current_config["name"]):
+        with exception_handler.forward(current_config["name"], Exception):
             source_is_enabled_or_raise(current_config)
             current_bootstrapper = create_bootstrapper(current_config)
             if current_bootstrapper.try_import(module, abstract_spec):
@@ -441,7 +441,7 @@ def ensure_executables_in_path_or_raise(
     exception_handler = GroupedExceptionHandler()
 
     for current_config in bootstrapping_sources():
-        with exception_handler.forward(current_config["name"]):
+        with exception_handler.forward(current_config["name"], Exception):
             source_is_enabled_or_raise(current_config)
             current_bootstrapper = create_bootstrapper(current_config)
             if current_bootstrapper.try_search_path(executables, abstract_spec):

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -321,3 +321,18 @@ line xxx, in test_grouped_exception
     """
         ).format(__file__)
     )
+
+
+def test_grouped_exception_base_type():
+    h = llnl.util.lang.GroupedExceptionHandler()
+
+    with h.forward("catch-runtime-error", RuntimeError):
+        raise NotImplementedError()
+
+    with pytest.raises(NotImplementedError):
+        with h.forward("catch-value-error", ValueError):
+            raise NotImplementedError()
+
+    message = h.grouped_message(with_tracebacks=False)
+    assert "catch-runtime-error" in message
+    assert "catch-value-error" not in message


### PR DESCRIPTION
Before, Ctrl-C would silently cancel only the currently running bootstrap *source*, and then went on running the next bootstrap source.

Now, Ctrl-C (KeyboardInterrupt) is not silently caught while bootstrapping from a bootstrap source, and so it stops the whole bootstrap process.