### PR TITLE
edm4hep: Update minimum cmake version

### DIFF
--- a/var/spack/repos/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/builtin/packages/edm4hep/package.py
@@ -100,6 +100,7 @@ class Edm4hep(CMakePackage):
     )
 
     depends_on("cmake@3.3:", type="build")
+    depends_on("cmake@3.23:", type="build", when="@0.10.3:")
     depends_on("python", type="build")
 
     depends_on("root@6.08:")


### PR DESCRIPTION
EDM4hep depends on CMake >= 3.23 since https://github.com/key4hep/EDM4hep/pull/235 has been merged.