### PR TITLE
Permit shared-library for libbacktrace

### DIFF
--- a/var/spack/repos/builtin/packages/libbacktrace/package.py
+++ b/var/spack/repos/builtin/packages/libbacktrace/package.py
@@ -17,7 +17,14 @@ class Libbacktrace(AutotoolsPackage):
     version("master", branch="master")
     version("2020-02-19", commit="ca0de0517f3be44fedf5a2c01cfaf6437d4cae68")
 
+    variant("shared", default=False, description="Additionally build shared library")
+
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
+
+    def configure_args(self):
+        args = []
+        args.extend(self.enable_or_disable("shared"))
+        return args


### PR DESCRIPTION
Just adding a variant and adjusting the corresponding configure args.