### PR TITLE
New subcommand `spack config scopes [-hips]`

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -243,7 +243,7 @@ def config_list(args):
     print(" ".join(list(spack.config.SECTION_SCHEMAS)))
 
 
-def _config_scope_info_string(args, scope: List[spack.config.ConfigScope]):
+def _config_scope_info_string(args, scope):
     if args.show_paths and hasattr(scope, "path"):
         section_path = scope.get_section_filename(args.section) if args.section else None
         path = section_path if section_path and os.path.exists(section_path) else f"{scope.path}/"

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -70,6 +70,7 @@ def setup_parser(subparser):
 
     list_scopes_parser = sp.add_parser("list-scopes", help="list defined scopes")
     list_scopes_parser.add_argument(
+        "-f",
         "--file",
         action="store_true",
         default=False,

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -90,7 +90,8 @@ def setup_parser(subparser):
     )
     scopes_parser.add_argument(
         "section",
-        help="tailor scope path information to the specified section\noptions: %(choices)s",
+        help="tailor scope path information to the specified section (implies -s|--show-paths)"
+        "\noptions: %(choices)s",
         metavar="section",
         nargs="?",
         choices=spack.config.SECTION_SCHEMAS,
@@ -244,7 +245,7 @@ def config_list(args):
 
 
 def _config_scope_info_string(args, scope):
-    if args.show_paths and hasattr(scope, "path"):
+    if (args.section or args.show_paths) and hasattr(scope, "path"):
         section_path = scope.get_section_filename(args.section) if args.section else None
         path = (
             section_path
@@ -258,9 +259,6 @@ def _config_scope_info_string(args, scope):
 
 def config_scopes(args):
     """List configured scopes in descending order of precedence."""
-
-    if args.section and not args.show_paths:
-        tty.warn(f"[section] ({args.section}) ignored without -s|--show-paths")
 
     scopes = (
         spack.config.scopes().reversed_values()

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -68,6 +68,18 @@ def setup_parser(subparser):
 
     sp.add_parser("list", help="list configuration sections")
 
+    list_scopes_parser = sp.add_parser("list-scopes", help="list defined scopes")
+    stype = list_scopes_parser.add_mutually_exclusive_group(required=False)
+    stype.add_argument(
+        "--file",
+        action="store_true",
+        default=False,
+        help="list only writable scopes with an associated file",
+    )
+    stype.add_argument(
+        "--non-platform", action="store_true", default=False, help="list only non-platform scopes"
+    )
+
     add_parser = sp.add_parser("add", help="add configuration parameters")
     add_parser.add_argument(
         "path",
@@ -213,6 +225,19 @@ def config_list(args):
     Used primarily for shell tab completion scripts.
     """
     print(" ".join(list(spack.config.SECTION_SCHEMAS)))
+
+
+def config_list_scopes(args):
+    scopes = (
+        spack.config.writable_scopes()
+        if args.file
+        else (
+            (s for s in spack.config.scopes().reversed_values() if not s.is_platform_dependent)
+            if args.non_platform
+            else spack.config.scopes().reversed_values()
+        )
+    )
+    print(" ".join([s.name for s in scopes]))
 
 
 def config_add(args):
@@ -580,6 +605,7 @@ def config(parser, args):
         "blame": config_blame,
         "edit": config_edit,
         "list": config_list,
+        "list-scopes": config_list_scopes,
         "add": config_add,
         "rm": config_remove,
         "remove": config_remove,

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -68,18 +68,18 @@ def setup_parser(subparser):
 
     sp.add_parser("list", help="list configuration sections")
 
-    list_scopes_parser = sp.add_parser("list-scopes", help="list defined scopes")
-    list_scopes_parser.add_argument(
+    scopes_parser = sp.add_parser("scopes", help="list defined scopes")
+    scopes_parser.add_argument(
         "-f",
         "--file",
         action="store_true",
         default=False,
         help="list only writable scopes with an associated file",
     )
-    list_scopes_parser.add_argument(
+    scopes_parser.add_argument(
         "--non-platform", action="store_true", default=False, help="list only non-platform scopes"
     )
-    list_scopes_parser.add_argument(
+    scopes_parser.add_argument(
         "--included",
         action="store_true",
         default=False,
@@ -233,7 +233,7 @@ def config_list(args):
     print(" ".join(list(spack.config.SECTION_SCHEMAS)))
 
 
-def config_list_scopes(args):
+def config_scopes(args):
     if args.included and (args.file or args.non_platform):
         tty.warn("`--included' overrides `--file' and `--non-platform'")
     scopes = (
@@ -613,7 +613,7 @@ def config(parser, args):
         "blame": config_blame,
         "edit": config_edit,
         "list": config_list,
-        "list-scopes": config_list_scopes,
+        "scopes": config_scopes,
         "add": config_add,
         "rm": config_remove,
         "remove": config_remove,

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -79,6 +79,12 @@ def setup_parser(subparser):
     list_scopes_parser.add_argument(
         "--non-platform", action="store_true", default=False, help="list only non-platform scopes"
     )
+    list_scopes_parser.add_argument(
+        "--included",
+        action="store_true",
+        default=False,
+        help="list only included scopes (overrides --file and --non-platform)",
+    )
 
     add_parser = sp.add_parser("add", help="add configuration parameters")
     add_parser.add_argument(
@@ -228,10 +234,16 @@ def config_list(args):
 
 
 def config_list_scopes(args):
+    if args.included and (args.file or args.non_platform):
+        tty.warn("`--included' overrides `--file' and `--non-platform'")
     scopes = (
-        spack.config.writable_scopes() if args.file else spack.config.scopes().reversed_values()
+        spack.config.scopes().reversed_values()
+        if (args.included or not args.file)
+        else spack.config.writable_scopes()
     )
-    if args.non_platform:
+    if args.included:
+        scopes = (i for s in scopes for i in s.included_scopes)
+    elif args.non_platform:
         scopes = (s for s in scopes if not s.is_platform_dependent)
     print(" ".join([s.name for s in scopes]))
 

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -69,14 +69,13 @@ def setup_parser(subparser):
     sp.add_parser("list", help="list configuration sections")
 
     list_scopes_parser = sp.add_parser("list-scopes", help="list defined scopes")
-    stype = list_scopes_parser.add_mutually_exclusive_group(required=False)
-    stype.add_argument(
+    list_scopes_parser.add_argument(
         "--file",
         action="store_true",
         default=False,
         help="list only writable scopes with an associated file",
     )
-    stype.add_argument(
+    list_scopes_parser.add_argument(
         "--non-platform", action="store_true", default=False, help="list only non-platform scopes"
     )
 
@@ -229,14 +228,10 @@ def config_list(args):
 
 def config_list_scopes(args):
     scopes = (
-        spack.config.writable_scopes()
-        if args.file
-        else (
-            (s for s in spack.config.scopes().reversed_values() if not s.is_platform_dependent)
-            if args.non_platform
-            else spack.config.scopes().reversed_values()
-        )
+        spack.config.writable_scopes() if args.file else spack.config.scopes().reversed_values()
     )
+    if args.non_platform:
+        scopes = (s for s in scopes if not s.is_platform_dependent)
     print(" ".join([s.name for s in scopes]))
 
 

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -68,16 +68,32 @@ def setup_parser(subparser):
 
     sp.add_parser("list", help="list configuration sections")
 
-    scopes_parser = sp.add_parser("scopes", help="list defined scopes")
+    scopes_parser = sp.add_parser(
+        "scopes", help="list defined scopes in descending order of precedence"
+    )
+    scopes_parser.add_argument(
+        "-i", "--included", action="store_true", default=False, help="list only included scopes"
+    )
     scopes_parser.add_argument(
         "-p",
-        "--path",
+        "--path-scopes",
         action="store_true",
         default=False,
         help="list only writable scopes with an associated path",
     )
     scopes_parser.add_argument(
-        "--included", action="store_true", default=False, help="list only included scopes"
+        "-s",
+        "--show-paths",
+        action="store_true",
+        default=False,
+        help="show associated paths for appropriate scopes",
+    )
+    scopes_parser.add_argument(
+        "section",
+        help="tailor scope path information to the specified section\noptions: %(choices)s",
+        metavar="section",
+        nargs="?",
+        choices=spack.config.SECTION_SCHEMAS,
     )
 
     add_parser = sp.add_parser("add", help="add configuration parameters")
@@ -227,17 +243,29 @@ def config_list(args):
     print(" ".join(list(spack.config.SECTION_SCHEMAS)))
 
 
+def _config_scope_info_string(args, scope: List[spack.config.ConfigScope]):
+    if args.show_paths and hasattr(scope, "path"):
+        section_path = scope.get_section_filename(args.section) if args.section else None
+        path = section_path if section_path and os.path.exists(section_path) else f"{scope.path}/"
+        return f"{scope.name} ({path})"
+    else:
+        return scope.name
+
+
 def config_scopes(args):
+    """List configured scopes in descending order of precedence."""
+
+    if args.section and not args.show_paths:
+        tty.warning(f"[section] ({args.section}) ignored without --show-path")
+
     scopes = (
         spack.config.scopes().reversed_values()
-        if (args.included or not args.path)
+        if (args.included or not args.path_scopes)
         else spack.config.writable_scopes()
     )
     if args.included:
         scopes = (i for s in scopes for i in s.included_scopes)
-    info = (
-        f"{s.name} ({s.path})" if s.name.startswith("include:") else f"{s.name}" for s in scopes
-    )
+    info = (_config_scope_info_string(args, s) for s in scopes)
 
     print(" ".join(info))
 

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -70,17 +70,14 @@ def setup_parser(subparser):
 
     scopes_parser = sp.add_parser("scopes", help="list defined scopes")
     scopes_parser.add_argument(
-        "-f",
-        "--file",
+        "-p",
+        "--path",
         action="store_true",
         default=False,
-        help="list only writable scopes with an associated file",
+        help="list only writable scopes with an associated path",
     )
     scopes_parser.add_argument(
-        "--included",
-        action="store_true",
-        default=False,
-        help="list only included scopes (overrides --file)",
+        "--included", action="store_true", default=False, help="list only included scopes"
     )
 
     add_parser = sp.add_parser("add", help="add configuration parameters")
@@ -231,16 +228,18 @@ def config_list(args):
 
 
 def config_scopes(args):
-    if args.included and args.file:
-        tty.warn("`--included' overrides `--file'")
     scopes = (
         spack.config.scopes().reversed_values()
-        if (args.included or not args.file)
+        if (args.included or not args.path)
         else spack.config.writable_scopes()
     )
     if args.included:
         scopes = (i for s in scopes for i in s.included_scopes)
-    print(" ".join([s.name for s in scopes]))
+    info = (
+        f"{s.name} ({s.path})" if s.name.startswith("include:") else f"{s.name}" for s in scopes
+    )
+
+    print(" ".join(info))
 
 
 def config_add(args):

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -246,7 +246,11 @@ def config_list(args):
 def _config_scope_info_string(args, scope):
     if args.show_paths and hasattr(scope, "path"):
         section_path = scope.get_section_filename(args.section) if args.section else None
-        path = section_path if section_path and os.path.exists(section_path) else f"{scope.path}/"
+        path = (
+            section_path
+            if section_path and os.path.exists(section_path)
+            else f"{scope.path}{os.sep}"
+        )
         return f"{scope.name} ({path})"
     else:
         return scope.name
@@ -256,7 +260,7 @@ def config_scopes(args):
     """List configured scopes in descending order of precedence."""
 
     if args.section and not args.show_paths:
-        tty.warning(f"[section] ({args.section}) ignored without --show-path")
+        tty.warn(f"[section] ({args.section}) ignored without -s|--show-paths")
 
     scopes = (
         spack.config.scopes().reversed_values()

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -77,13 +77,10 @@ def setup_parser(subparser):
         help="list only writable scopes with an associated file",
     )
     scopes_parser.add_argument(
-        "--non-platform", action="store_true", default=False, help="list only non-platform scopes"
-    )
-    scopes_parser.add_argument(
         "--included",
         action="store_true",
         default=False,
-        help="list only included scopes (overrides --file and --non-platform)",
+        help="list only included scopes (overrides --file)",
     )
 
     add_parser = sp.add_parser("add", help="add configuration parameters")
@@ -234,8 +231,8 @@ def config_list(args):
 
 
 def config_scopes(args):
-    if args.included and (args.file or args.non_platform):
-        tty.warn("`--included' overrides `--file' and `--non-platform'")
+    if args.included and args.file:
+        tty.warn("`--included' overrides `--file'")
     scopes = (
         spack.config.scopes().reversed_values()
         if (args.included or not args.file)
@@ -243,8 +240,6 @@ def config_scopes(args):
     )
     if args.included:
         scopes = (i for s in scopes for i in s.included_scopes)
-    elif args.non_platform:
-        scopes = (s for s in scopes if not s.is_platform_dependent)
     print(" ".join([s.name for s in scopes]))
 
 

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -40,27 +40,27 @@ def config_yaml_v015(mutable_config):
     return functools.partial(_create_config, data=old_data, section="config")
 
 
-def test_config_list_scopes():
-    output = config("list-scopes")
+def test_config_scopes():
+    output = config("scopes")
     assert "command_line" in output
     assert "_builtin" in output
 
 
-def test_config_list_scopes_file():
-    output = config("list-scopes", "--file")
+def test_config_scopes_file():
+    output = config("scopes", "--file")
     assert "site" in output
     assert "_builtin" not in output
 
 
-def test_config_list_scopes_non_platform():
-    output = config("list-scopes", "--non-platform")
+def test_config_scopes_non_platform():
+    output = config("scopes", "--non-platform")
     assert "site" in output
 
 
-def test_config_list_scopes_file_non_platform():
+def test_config_scopes_file_non_platform():
     if "SPACK_DISABLE_LOCAL_CONFIG" in os.environ:
         del os.environ["SPACK_DISABLE_LOCAL_CONFIG"]
-    output = config("list-scopes", "--non-platform", "--file")
+    output = config("scopes", "--non-platform", "--file")
     assert "site" in output
     assert "_builtin" not in output
 

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -59,7 +59,7 @@ def test_config_scopes_include(with_path_scopes):
     if with_path_scopes:
         scopes_cmd.append("--path-scopes")
     output = config(*scopes_cmd)
-    assert all(":" in x for x in output.split())
+    assert not output or all(":" in x for x in output.split())
 
 
 scope_path_re = r"\(([^\)]+)\)"
@@ -70,7 +70,7 @@ def test_config_scopes_path_section():
     assert "_builtin" not in output
     assert "site" not in output
     paths = (x[1] for x in (re.fullmatch(scope_path_re, s) for s in output.split()) if x)
-    assert all("/" in x for x in paths)
+    assert all(os.sep in x for x in paths)
 
 
 def test_get_config_scope(mock_low_high_config):

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -52,19 +52,6 @@ def test_config_scopes_file():
     assert "_builtin" not in output
 
 
-def test_config_scopes_non_platform():
-    output = config("scopes", "--non-platform")
-    assert "site" in output
-
-
-def test_config_scopes_file_non_platform():
-    if "SPACK_DISABLE_LOCAL_CONFIG" in os.environ:
-        del os.environ["SPACK_DISABLE_LOCAL_CONFIG"]
-    output = config("scopes", "--non-platform", "--file")
-    assert "site" in output
-    assert "_builtin" not in output
-
-
 def test_get_config_scope(mock_low_high_config):
     assert config("get", "compilers").strip() == "compilers: {}"
 

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import functools
 import os
+import re
 
 import pytest
 
@@ -42,32 +43,34 @@ def config_yaml_v015(mutable_config):
 
 def test_config_scopes():
     output = config("scopes")
-    assert "command_line" in output
-    assert "_builtin" in output
+    assert "command_line" in output.split()
+    assert "_builtin" in output.split()
 
 
-def test_config_scopes_path():
-    output = config("scopes", "--path")
-    assert "site" in output
-    assert "_builtin" not in output
+def test_config_scopes_path_scopes():
+    output = config("scopes", "--path-scopes")
+    assert "site" in output.split()
+    assert "_builtin" not in output.split()
 
 
-def test_config_scopes_include():
-    output = config("scopes", "--include")
-    assert "site" in output
-    assert "_builtin" not in output
+@pytest.mark.parametrize("with_path_scopes", [False, True])
+def test_config_scopes_include(with_path_scopes):
+    scopes_cmd = ["scopes", "--included"]
+    if with_path_scopes:
+        scopes_cmd.append("--path-scopes")
+    output = config(*scopes_cmd)
+    assert all(":" in x for x in output.split())
 
 
-def test_config_scopes_include_path():
-    output = config("scopes", "--include", "--path")
-    assert "site" in output
-    assert "_builtin" not in output
+scope_path_re = r"\(([^\)]+)\)"
 
 
 def test_config_scopes_path_section():
-    output = config("scopes", "--include", "--path", "config")
-    assert "site" in output
+    output = config("scopes", "--included", "--show-paths", "modules")
     assert "_builtin" not in output
+    assert "site" not in output
+    paths = (x[1] for x in (re.fullmatch(scope_path_re, s) for s in output.split()) if x)
+    assert all("/" in x for x in paths)
 
 
 def test_get_config_scope(mock_low_high_config):

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -46,8 +46,26 @@ def test_config_scopes():
     assert "_builtin" in output
 
 
-def test_config_scopes_file():
-    output = config("scopes", "--file")
+def test_config_scopes_path():
+    output = config("scopes", "--path")
+    assert "site" in output
+    assert "_builtin" not in output
+
+
+def test_config_scopes_include():
+    output = config("scopes", "--include")
+    assert "site" in output
+    assert "_builtin" not in output
+
+
+def test_config_scopes_include_path():
+    output = config("scopes", "--include", "--path")
+    assert "site" in output
+    assert "_builtin" not in output
+
+
+def test_config_scopes_path_section():
+    output = config("scopes", "--include", "--path", "config")
     assert "site" in output
     assert "_builtin" not in output
 

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -53,14 +53,8 @@ def test_config_list_scopes_file():
 
 
 def test_config_list_scopes_non_platform():
-    os.environ["SPACK_DISABLE_LOCAL_CONFIG"] = "true"
     output = config("list-scopes", "--non-platform")
     assert "site" in output
-    assert "user" not in output
-    del os.environ["SPACK_DISABLE_LOCAL_CONFIG"]
-    output = config("list-scopes", "--non-platform")
-    assert "site" in output
-    assert "user" in output
 
 
 def test_config_list_scopes_file_non_platform():

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -69,7 +69,8 @@ def test_config_list_scopes_non_platform():
 
 
 def test_config_list_scopes_file_non_platform():
-    del os.environ["SPACK_DISABLE_LOCAL_CONFIG"]
+    if "SPACK_DISABLE_LOCAL_CONFIG" in os.environ:
+        del os.environ["SPACK_DISABLE_LOCAL_CONFIG"]
     output = config("list-scopes", "--non-platform", "--file")
     assert "site" in output
     assert "_builtin" not in output

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -68,6 +68,14 @@ def test_config_list_scopes_non_platform():
     assert f"site/{spack.platforms.host()}" not in output
 
 
+def test_config_list_scopes_file_non_platform():
+    del os.environ["SPACK_DISABLE_LOCAL_CONFIG"]
+    output = config("list-scopes", "--non-platform", "--file")
+    assert "site" in output
+    assert "_builtin" not in output
+    assert f"site/{spack.platforms.host()}" not in output
+
+
 def test_get_config_scope(mock_low_high_config):
     assert config("get", "compilers").strip() == "compilers: {}"
 

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -13,7 +13,6 @@ import spack.config
 import spack.database
 import spack.environment as ev
 import spack.main
-import spack.platforms
 import spack.schema.config
 import spack.store
 import spack.util.spack_yaml as syaml
@@ -45,13 +44,13 @@ def test_config_list_scopes():
     output = config("list-scopes")
     assert "command_line" in output
     assert "_builtin" in output
-    assert f"site/{spack.platforms.host()}" in output
+    assert "site/test" in output  # Test platform
 
 
 def test_config_list_scopes_file():
     output = config("list-scopes", "--file")
     assert "site" in output
-    assert f"site/{spack.platforms.host()}" in output
+    assert "site/test" in output  # Test platform
     assert "_builtin" not in output
 
 
@@ -60,12 +59,12 @@ def test_config_list_scopes_non_platform():
     output = config("list-scopes", "--non-platform")
     assert "site" in output
     assert "user" not in output
-    assert f"site/{spack.platforms.host()}" not in output
+    assert "site/test" not in output  # Test platform
     del os.environ["SPACK_DISABLE_LOCAL_CONFIG"]
     output = config("list-scopes", "--non-platform")
     assert "site" in output
     assert "user" in output
-    assert f"site/{spack.platforms.host()}" not in output
+    assert "site/test" not in output  # Test platform
 
 
 def test_config_list_scopes_file_non_platform():
@@ -74,7 +73,7 @@ def test_config_list_scopes_file_non_platform():
     output = config("list-scopes", "--non-platform", "--file")
     assert "site" in output
     assert "_builtin" not in output
-    assert f"site/{spack.platforms.host()}" not in output
+    assert "site/test" not in output  # Test platform
 
 
 def test_get_config_scope(mock_low_high_config):

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -40,6 +40,24 @@ def config_yaml_v015(mutable_config):
     return functools.partial(_create_config, data=old_data, section="config")
 
 
+def test_config_list_scopes():
+    output = config("list-scopes")
+    assert "command_line" in output
+    assert "_builtin" in output
+
+
+def test_config_list_scopes_file():
+    output = config("list-scopes", "--file")
+    assert "site" in output
+    assert "_builtin" not in output
+
+
+def test_config_list_scopes_non_platform():
+    output = config("list-scopes", "--non-platform")
+    assert "site" in output
+    assert "user" in output
+
+
 def test_get_config_scope(mock_low_high_config):
     assert config("get", "compilers").strip() == "compilers: {}"
 

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -13,6 +13,7 @@ import spack.config
 import spack.database
 import spack.environment as ev
 import spack.main
+import spack.platforms
 import spack.schema.config
 import spack.store
 import spack.util.spack_yaml as syaml
@@ -44,11 +45,13 @@ def test_config_list_scopes():
     output = config("list-scopes")
     assert "command_line" in output
     assert "_builtin" in output
+    assert f"site/{spack.platforms.host()}" in output
 
 
 def test_config_list_scopes_file():
     output = config("list-scopes", "--file")
     assert "site" in output
+    assert f"site/{spack.platforms.host()}" in output
     assert "_builtin" not in output
 
 
@@ -57,10 +60,12 @@ def test_config_list_scopes_non_platform():
     output = config("list-scopes", "--non-platform")
     assert "site" in output
     assert "user" not in output
+    assert f"site/{spack.platforms.host()}" not in output
     del os.environ["SPACK_DISABLE_LOCAL_CONFIG"]
     output = config("list-scopes", "--non-platform")
     assert "site" in output
     assert "user" in output
+    assert f"site/{spack.platforms.host()}" not in output
 
 
 def test_get_config_scope(mock_low_high_config):

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -53,6 +53,11 @@ def test_config_list_scopes_file():
 
 
 def test_config_list_scopes_non_platform():
+    os.environ["SPACK_DISABLE_LOCAL_CONFIG"] = "true"
+    output = config("list-scopes", "--non-platform")
+    assert "site" in output
+    assert "user" not in output
+    del os.environ["SPACK_DISABLE_LOCAL_CONFIG"]
     output = config("list-scopes", "--non-platform")
     assert "site" in output
     assert "user" in output

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -44,13 +44,11 @@ def test_config_list_scopes():
     output = config("list-scopes")
     assert "command_line" in output
     assert "_builtin" in output
-    assert "site/test" in output  # Test platform
 
 
 def test_config_list_scopes_file():
     output = config("list-scopes", "--file")
     assert "site" in output
-    assert "site/test" in output  # Test platform
     assert "_builtin" not in output
 
 
@@ -59,12 +57,10 @@ def test_config_list_scopes_non_platform():
     output = config("list-scopes", "--non-platform")
     assert "site" in output
     assert "user" not in output
-    assert "site/test" not in output  # Test platform
     del os.environ["SPACK_DISABLE_LOCAL_CONFIG"]
     output = config("list-scopes", "--non-platform")
     assert "site" in output
     assert "user" in output
-    assert "site/test" not in output  # Test platform
 
 
 def test_config_list_scopes_file_non_platform():
@@ -73,7 +69,6 @@ def test_config_list_scopes_file_non_platform():
     output = config("list-scopes", "--non-platform", "--file")
     assert "site" in output
     assert "_builtin" not in output
-    assert "site/test" not in output  # Test platform
 
 
 def test_get_config_scope(mock_low_high_config):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -868,7 +868,7 @@ _spack_config_list() {
 }
 
 _spack_config_list_scopes() {
-    SPACK_COMPREPLY="-h --help --file --non-platform"
+    SPACK_COMPREPLY="-h --help -f --file --non-platform"
 }
 
 _spack_config_add() {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -868,7 +868,12 @@ _spack_config_list() {
 }
 
 _spack_config_scopes() {
-    SPACK_COMPREPLY="-h --help -f --file --included"
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -i --included -p --path-scopes -s --show-paths"
+    else
+        _config_sections
+    fi
 }
 
 _spack_config_add() {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -868,7 +868,7 @@ _spack_config_list() {
 }
 
 _spack_config_list_scopes() {
-    SPACK_COMPREPLY="-h --help -f --file --non-platform"
+    SPACK_COMPREPLY="-h --help -f --file --non-platform --included"
 }
 
 _spack_config_add() {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -832,7 +832,7 @@ _spack_config() {
     then
         SPACK_COMPREPLY="-h --help --scope"
     else
-        SPACK_COMPREPLY="get blame edit list add change prefer-upstream remove rm update revert"
+        SPACK_COMPREPLY="get blame edit list list-scopes add change prefer-upstream remove rm update revert"
     fi
 }
 
@@ -865,6 +865,10 @@ _spack_config_edit() {
 
 _spack_config_list() {
     SPACK_COMPREPLY="-h --help"
+}
+
+_spack_config_list_scopes() {
+    SPACK_COMPREPLY="-h --help --file --non-platform"
 }
 
 _spack_config_add() {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -832,7 +832,7 @@ _spack_config() {
     then
         SPACK_COMPREPLY="-h --help --scope"
     else
-        SPACK_COMPREPLY="get blame edit list list-scopes add change prefer-upstream remove rm update revert"
+        SPACK_COMPREPLY="get blame edit list scopes add change prefer-upstream remove rm update revert"
     fi
 }
 
@@ -867,7 +867,7 @@ _spack_config_list() {
     SPACK_COMPREPLY="-h --help"
 }
 
-_spack_config_list_scopes() {
+_spack_config_scopes() {
     SPACK_COMPREPLY="-h --help -f --file --non-platform --included"
 }
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -868,7 +868,7 @@ _spack_config_list() {
 }
 
 _spack_config_scopes() {
-    SPACK_COMPREPLY="-h --help -f --file --non-platform --included"
+    SPACK_COMPREPLY="-h --help -f --file --included"
 }
 
 _spack_config_add() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1236,15 +1236,13 @@ complete -c spack -n '__fish_spack_using_command config list' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command config list' -s h -l help -d 'show this help message and exit'
 
 # spack config scopes
-set -g __fish_spack_optspecs_spack_config_scopes h/help f/file non-platform included
+set -g __fish_spack_optspecs_spack_config_scopes h/help f/file included
 complete -c spack -n '__fish_spack_using_command config scopes' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config scopes' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command config scopes' -s f -l file -f -a file
 complete -c spack -n '__fish_spack_using_command config scopes' -s f -l file -d 'list only writable scopes with an associated file'
-complete -c spack -n '__fish_spack_using_command config scopes' -l non-platform -f -a non_platform
-complete -c spack -n '__fish_spack_using_command config scopes' -l non-platform -d 'list only non-platform scopes'
 complete -c spack -n '__fish_spack_using_command config scopes' -l included -f -a included
-complete -c spack -n '__fish_spack_using_command config scopes' -l included -d 'list only included scopes (overrides --file and --non-platform)'
+complete -c spack -n '__fish_spack_using_command config scopes' -l included -d 'list only included scopes (overrides --file)'
 
 # spack config add
 set -g __fish_spack_optspecs_spack_config_add h/help f/file=

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1236,11 +1236,11 @@ complete -c spack -n '__fish_spack_using_command config list' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command config list' -s h -l help -d 'show this help message and exit'
 
 # spack config list-scopes
-set -g __fish_spack_optspecs_spack_config_list_scopes h/help file non-platform
+set -g __fish_spack_optspecs_spack_config_list_scopes h/help f/file non-platform
 complete -c spack -n '__fish_spack_using_command config list-scopes' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config list-scopes' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command config list-scopes' -l file -f -a file
-complete -c spack -n '__fish_spack_using_command config list-scopes' -l file -d 'list only writable scopes with an associated file'
+complete -c spack -n '__fish_spack_using_command config list-scopes' -s f -l file -f -a file
+complete -c spack -n '__fish_spack_using_command config list-scopes' -s f -l file -d 'list only writable scopes with an associated file'
 complete -c spack -n '__fish_spack_using_command config list-scopes' -l non-platform -f -a non_platform
 complete -c spack -n '__fish_spack_using_command config list-scopes' -l non-platform -d 'list only non-platform scopes'
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1197,6 +1197,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a get -d 'pri
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a blame -d 'print configuration annotated with source file:line'
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a edit -d 'edit configuration file'
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a list -d 'list configuration sections'
+complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a list-scopes -d 'list defined scopes'
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a add -d 'add configuration parameters'
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a change -d 'swap variants etc. on specs in config'
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a prefer-upstream -d 'set package preferences from upstream'
@@ -1233,6 +1234,15 @@ complete -c spack -n '__fish_spack_using_command config edit' -l print-file -d '
 set -g __fish_spack_optspecs_spack_config_list h/help
 complete -c spack -n '__fish_spack_using_command config list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config list' -s h -l help -d 'show this help message and exit'
+
+# spack config list-scopes
+set -g __fish_spack_optspecs_spack_config_list_scopes h/help file non-platform
+complete -c spack -n '__fish_spack_using_command config list-scopes' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command config list-scopes' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command config list-scopes' -l file -f -a file
+complete -c spack -n '__fish_spack_using_command config list-scopes' -l file -d 'list only writable scopes with an associated file'
+complete -c spack -n '__fish_spack_using_command config list-scopes' -l non-platform -f -a non_platform
+complete -c spack -n '__fish_spack_using_command config list-scopes' -l non-platform -d 'list only non-platform scopes'
 
 # spack config add
 set -g __fish_spack_optspecs_spack_config_add h/help f/file=

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1197,7 +1197,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a get -d 'pri
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a blame -d 'print configuration annotated with source file:line'
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a edit -d 'edit configuration file'
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a list -d 'list configuration sections'
-complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a scopes -d 'list defined scopes'
+complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a scopes -d 'list defined scopes in descending order of precedence'
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a add -d 'add configuration parameters'
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a change -d 'swap variants etc. on specs in config'
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a prefer-upstream -d 'set package preferences from upstream'
@@ -1236,13 +1236,16 @@ complete -c spack -n '__fish_spack_using_command config list' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command config list' -s h -l help -d 'show this help message and exit'
 
 # spack config scopes
-set -g __fish_spack_optspecs_spack_config_scopes h/help f/file included
+set -g __fish_spack_optspecs_spack_config_scopes h/help i/included p/path-scopes s/show-paths
+complete -c spack -n '__fish_spack_using_command_pos 0 config scopes' -f -a 'bootstrap cdash ci compilers concretizer config definitions develop env_vars include mirrors modules packages repos upstreams view'
 complete -c spack -n '__fish_spack_using_command config scopes' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config scopes' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command config scopes' -s f -l file -f -a file
-complete -c spack -n '__fish_spack_using_command config scopes' -s f -l file -d 'list only writable scopes with an associated file'
-complete -c spack -n '__fish_spack_using_command config scopes' -l included -f -a included
-complete -c spack -n '__fish_spack_using_command config scopes' -l included -d 'list only included scopes (overrides --file)'
+complete -c spack -n '__fish_spack_using_command config scopes' -s i -l included -f -a included
+complete -c spack -n '__fish_spack_using_command config scopes' -s i -l included -d 'list only included scopes'
+complete -c spack -n '__fish_spack_using_command config scopes' -s p -l path-scopes -f -a path_scopes
+complete -c spack -n '__fish_spack_using_command config scopes' -s p -l path-scopes -d 'list only writable scopes with an associated path'
+complete -c spack -n '__fish_spack_using_command config scopes' -s s -l show-paths -f -a show_paths
+complete -c spack -n '__fish_spack_using_command config scopes' -s s -l show-paths -d 'show associated paths for appropriate scopes'
 
 # spack config add
 set -g __fish_spack_optspecs_spack_config_add h/help f/file=

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1236,13 +1236,15 @@ complete -c spack -n '__fish_spack_using_command config list' -s h -l help -f -a
 complete -c spack -n '__fish_spack_using_command config list' -s h -l help -d 'show this help message and exit'
 
 # spack config list-scopes
-set -g __fish_spack_optspecs_spack_config_list_scopes h/help f/file non-platform
+set -g __fish_spack_optspecs_spack_config_list_scopes h/help f/file non-platform included
 complete -c spack -n '__fish_spack_using_command config list-scopes' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config list-scopes' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command config list-scopes' -s f -l file -f -a file
 complete -c spack -n '__fish_spack_using_command config list-scopes' -s f -l file -d 'list only writable scopes with an associated file'
 complete -c spack -n '__fish_spack_using_command config list-scopes' -l non-platform -f -a non_platform
 complete -c spack -n '__fish_spack_using_command config list-scopes' -l non-platform -d 'list only non-platform scopes'
+complete -c spack -n '__fish_spack_using_command config list-scopes' -l included -f -a included
+complete -c spack -n '__fish_spack_using_command config list-scopes' -l included -d 'list only included scopes (overrides --file and --non-platform)'
 
 # spack config add
 set -g __fish_spack_optspecs_spack_config_add h/help f/file=

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1197,7 +1197,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a get -d 'pri
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a blame -d 'print configuration annotated with source file:line'
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a edit -d 'edit configuration file'
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a list -d 'list configuration sections'
-complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a list-scopes -d 'list defined scopes'
+complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a scopes -d 'list defined scopes'
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a add -d 'add configuration parameters'
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a change -d 'swap variants etc. on specs in config'
 complete -c spack -n '__fish_spack_using_command_pos 0 config' -f -a prefer-upstream -d 'set package preferences from upstream'
@@ -1235,16 +1235,16 @@ set -g __fish_spack_optspecs_spack_config_list h/help
 complete -c spack -n '__fish_spack_using_command config list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command config list' -s h -l help -d 'show this help message and exit'
 
-# spack config list-scopes
-set -g __fish_spack_optspecs_spack_config_list_scopes h/help f/file non-platform included
-complete -c spack -n '__fish_spack_using_command config list-scopes' -s h -l help -f -a help
-complete -c spack -n '__fish_spack_using_command config list-scopes' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command config list-scopes' -s f -l file -f -a file
-complete -c spack -n '__fish_spack_using_command config list-scopes' -s f -l file -d 'list only writable scopes with an associated file'
-complete -c spack -n '__fish_spack_using_command config list-scopes' -l non-platform -f -a non_platform
-complete -c spack -n '__fish_spack_using_command config list-scopes' -l non-platform -d 'list only non-platform scopes'
-complete -c spack -n '__fish_spack_using_command config list-scopes' -l included -f -a included
-complete -c spack -n '__fish_spack_using_command config list-scopes' -l included -d 'list only included scopes (overrides --file and --non-platform)'
+# spack config scopes
+set -g __fish_spack_optspecs_spack_config_scopes h/help f/file non-platform included
+complete -c spack -n '__fish_spack_using_command config scopes' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command config scopes' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command config scopes' -s f -l file -f -a file
+complete -c spack -n '__fish_spack_using_command config scopes' -s f -l file -d 'list only writable scopes with an associated file'
+complete -c spack -n '__fish_spack_using_command config scopes' -l non-platform -f -a non_platform
+complete -c spack -n '__fish_spack_using_command config scopes' -l non-platform -d 'list only non-platform scopes'
+complete -c spack -n '__fish_spack_using_command config scopes' -l included -f -a included
+complete -c spack -n '__fish_spack_using_command config scopes' -l included -d 'list only included scopes (overrides --file and --non-platform)'
 
 # spack config add
 set -g __fish_spack_optspecs_spack_config_add h/help f/file=


### PR DESCRIPTION
List the scopes available in the current environment in descending priority order.

* With `-p|--path-scopes`, list only writable, file-based scopes (ignoring `command_line` and `_builtin`).
* With `-i|--included`, list only included scopes (specified in `include.yaml` or an environment `include:` clause).
* With `-s|--show-paths`, annotate scopes with their directory or file (with non-option argument `section`) locations when appropriate.
* Automatically takes account of `SPACK_DISABLE_LOCAL_CONFIG=true`

Useful for understanding the best scope in which to put a particular specific configuration item, or for debugging "missing" config.

### Examples

* MacOS:
  ```console
  $ spack arch
  darwin-sequoia-m1
  $ spack config scopes
  command_line user site system defaults defaults:darwin defaults:base _builtin
  ```

* Linux:
  ```console
  $ spack arch
  linux-almalinux9-cascadelake
  $ spack config scopes
  command_line user site system defaults defaults:linux defaults:base _builtin
  $ SPACK_DISABLE_LOCAL_CONFIG=1 spack config scopes
  command_line site defaults defaults:linux defaults:base _builtin
  $ SPACK_DISABLE_LOCAL_CONFIG=1 spack config --scope=site scopes --path-scopes
  site defaults defaults:linux defaults:base
  $ SPACK_DISABLE_LOCAL_CONFIG=1 spack config --scope=site scopes --included
  defaults:linux defaults:base
  $ SPACK_DISABLE_LOCAL_CONFIG=1 spack config --scope=site scopes --included --show-paths
  defaults:linux (/home/greenc/work/cet-is/sources/Spack/spack/run/etc/spack/defaults/linux/) defaults:base (/home/greenc/work/cet-is/sources/Spack/spack/run/etc/spack/defaults/base/)
  $ SPACK_DISABLE_LOCAL_CONFIG=1 spack config --scope=site scopes modules
  command_line site (/home/greenc/work/cet-is/sources/Spack/spack/run/etc/spack/) defaults (/home/greenc/work/cet-is/sources/Spack/spack/run/etc/spack/defaults/modules.yaml) defaults:linux (/home/greenc/work/cetis/sources/Spack/spack/run/etc/spack/defaults/linux/modules.yaml) defaults:base (/home/greenc/work/cet-is/sources/Spack/spack/run/etc/spack/defaults/base/) builtin
  ```