### PR TITLE
Fix spack bootstrap without setup-env

### DIFF
--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -87,7 +87,8 @@ class BootstrapEnvironment(spack.environment.Environment):
 
     def update_installations(self) -> None:
         """Update the installations of this environment."""
-        with tty.SuppressOutput(msg_enabled=False, warn_enabled=False):
+        log_enabled = tty.is_debug() or tty.is_verbose()
+        with tty.SuppressOutput(msg_enabled=log_enabled, warn_enabled=log_enabled):
             specs = self.concretize()
         if specs:
             colorized_specs = [
@@ -96,8 +97,9 @@ class BootstrapEnvironment(spack.environment.Environment):
             ]
             tty.msg(f"[BOOTSTRAPPING] Installing dependencies ({', '.join(colorized_specs)})")
             self.write(regenerate=False)
-            self.install_all()
-            self.write(regenerate=True)
+            with tty.SuppressOutput(msg_enabled=log_enabled, warn_enabled=log_enabled):
+                self.install_all()
+                self.write(regenerate=True)
 
     def update_syspath_and_environ(self) -> None:
         """Update ``sys.path`` and the PATH, PYTHONPATH environment variables to point to

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -16,7 +16,6 @@ import archspec.cpu
 from llnl.util import tty
 
 import spack.environment
-import spack.paths
 import spack.tengine
 import spack.util.cpus
 import spack.util.executable

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -16,6 +16,7 @@ import archspec.cpu
 from llnl.util import tty
 
 import spack.environment
+import spack.paths
 import spack.tengine
 import spack.util.cpus
 import spack.util.executable
@@ -133,6 +134,8 @@ class BootstrapEnvironment(spack.environment.Environment):
         kwargs = {}
         if not tty.is_debug():
             kwargs = {"output": os.devnull, "error": os.devnull}
+        # Make sure spack is in PATH for Makefile
+        kwargs["extra_env"] = {"PATH": spack.paths.bin_path + ":" + os.environ["PATH"]}
         make(
             "-C",
             str(self.environment_root()),

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -135,12 +135,13 @@ class BootstrapEnvironment(spack.environment.Environment):
         if not tty.is_debug():
             kwargs = {"output": os.devnull, "error": os.devnull}
         # Make sure spack is in PATH for Makefile
-        kwargs["extra_env"] = {"PATH": spack.paths.bin_path + ":" + os.environ["PATH"]}
+        extra_env = {"PATH": spack.paths.bin_path + ":" + os.environ["PATH"]}
         make(
             "-C",
             str(self.environment_root()),
             "-j",
             str(spack.util.cpus.determine_number_of_jobs(parallel=True)),
+            extra_env=extra_env,
             **kwargs,
         )
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2008,7 +2008,9 @@ class PackageInstaller:
 
         # Only enable the terminal status line when we're in a tty without debug info
         # enabled, so that the output does not get cluttered.
-        term_status = TermStatusLine(enabled=sys.stdout.isatty() and tty.msg_enabled() and not tty.is_debug())
+        term_status = TermStatusLine(
+            enabled=sys.stdout.isatty() and tty.msg_enabled() and not tty.is_debug()
+        )
 
         while self.build_pq:
             task = self._pop_task()

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -357,7 +357,8 @@ def _print_installed_pkg(message: str) -> None:
     Args:
         message (str): message to be output
     """
-    print(colorize("@*g{[+]} ") + spack.util.path.debug_padded_filter(message))
+    if tty.msg_enabled():
+        print(colorize("@*g{[+]} ") + spack.util.path.debug_padded_filter(message))
 
 
 def print_install_test_log(pkg: "spack.package_base.PackageBase") -> None:
@@ -2007,7 +2008,7 @@ class PackageInstaller:
 
         # Only enable the terminal status line when we're in a tty without debug info
         # enabled, so that the output does not get cluttered.
-        term_status = TermStatusLine(enabled=sys.stdout.isatty() and not tty.is_debug())
+        term_status = TermStatusLine(enabled=sys.stdout.isatty() and tty.msg_enabled() and not tty.is_debug())
 
         while self.build_pq:
             task = self._pop_task()

--- a/share/spack/templates/bootstrap/spack.yaml
+++ b/share/spack/templates/bootstrap/spack.yaml
@@ -17,6 +17,8 @@ spack:
       root: {{ store_path }}
       padded_length: 0
 
+    install_status: false
+
   packages:
     python:
       buildable: false


### PR DESCRIPTION
Allow spack bootstrap to work without having spack in your `PATH` (without `source share/spack/setup-env.sh`). And also without `gmake`.

Removed depfile-generated `Makefile` install mechanism, see https://github.com/spack/spack/pull/41458#issuecomment-1843431707.

Since #34029, spack bootstrapp can fail if spack isn't in your `PATH`:

```sh
$ ./bin/spack bootstrap now --dev
==> [BOOTSTRAPPING] Installing dependencies (py-isort@5, py-mypy@0.900:, py-black@:23.1.0, py-flake8@3.8.2:, py-pytest@6.2.4:)
==> Error: Command exited with status 2:
'/usr/bin/make' '-C' '/home/me/.spack/bootstrap/environments/python3.10-x86_64-7d8fd' '-j' '16'
```

This is because the generated `Makefile` tries to run `spack`.

I thought of adding an absolute spack path in the generated `Makefile`, but I think having a relocatable `Makefile` can be useful.
