### PR TITLE
healpix-cxx: update to v3.82.0 and add libsharp2 dependency as independent package

### DIFF
--- a/var/spack/repos/builtin/packages/healpix-cxx/package.py
+++ b/var/spack/repos/builtin/packages/healpix-cxx/package.py
@@ -11,13 +11,24 @@ class HealpixCxx(AutotoolsPackage):
     Hierarchical Equal Area isoLatitude Pixelation of a sphere."""
 
     homepage = "https://healpix.sourceforge.io"
-    url = "https://ayera.dl.sourceforge.net/project/healpix/Healpix_3.50/healpix_cxx-3.50.0.tar.gz"
 
+    version("3.82.0", sha256="9c1b0bbbcf007359d1ef10ae3ae9a2f46c72a4eb0c2fdbb43683289002ba8552")
     version("3.50.0", sha256="6538ee160423e8a0c0f92cf2b2001e1a2afd9567d026a86ff6e2287c1580cb4c")
 
     depends_on("cfitsio")
-    depends_on("libsharp", type="build")
+    depends_on("libsharp", when="@3.50.0")
+    depends_on("libsharp2", when="@3.82.0:")
 
+    def url_for_version(self, version):
+        major, minor, patch = version
+        return f"https://sourceforge.net/projects/healpix/files/Healpix_{major}.{minor}/healpix_cxx-{major}.{minor}.{patch}.tar.gz/download"
+
+    @when("@3.82.0:")
+    def setup_build_environment(self, env):
+        env.set("SHARP_CFLAGS", "-I{0}".format(self.spec["libsharp2"].prefix.include))
+        env.set("SHARP_LIBS", "-L{0} -lsharp".format(self.spec["libsharp2"].prefix.lib))
+
+    @when("@3.50.0")
     def patch(self):
         spec = self.spec
         configure_fix = FileFilter("configure")

--- a/var/spack/repos/builtin/packages/libsharp2/package.py
+++ b/var/spack/repos/builtin/packages/libsharp2/package.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Libsharp2(AutotoolsPackage):
+    """Libsharp2 is a code library for spherical harmonic transforms (SHTs) and
+    spin-weighted spherical harmonic transforms, which evolved from the libpsht
+    library. Because the upstream repository has no tags or releases, this
+    package tracks the versions found in HEALPix releases."""
+
+    variant("openmp", default=True, description="Build with openmp support")
+    variant("mpi", default=True, description="Build with MPI support")
+    variant("pic", default=True, description="Generate position-independent code (PIC)")
+
+    homepage = "https://gitlab.mpcdf.mpg.de/mtr/libsharp"
+    git = "https://gitlab.mpcdf.mpg.de/mtr/libsharp.git"
+
+    version("3.82.0", sha256="47629f057a2daf06fca3305db1c6950edb9e61bbe2d7ed4d98ff05809da2a127")
+
+    depends_on("autoconf", type="build")
+    depends_on("mpi", when="+mpi")
+
+    configure_directory = "src/common_libraries/libsharp"
+
+    def url_for_version(self, version):
+        major, minor, patch = version
+        return f"https://sourceforge.net/projects/healpix/files/Healpix_{major}.{minor}/healpix_cxx-{major}.{minor}.{patch}.tar.gz/download"
+
+    def configure_args(self):
+        args = []
+        if "+openmp" not in self.spec:
+            args.append("--disable-openmp")
+        if "+mpi" not in self.spec:
+            args.append("--disable-mpi")
+        if "+pic" in self.spec:
+            args.append("--enable-pic")
+        return args

--- a/var/spack/repos/builtin/packages/libsharp2/package.py
+++ b/var/spack/repos/builtin/packages/libsharp2/package.py
@@ -15,6 +15,7 @@ class Libsharp2(AutotoolsPackage):
     variant("openmp", default=True, description="Build with openmp support")
     variant("mpi", default=True, description="Build with MPI support")
     variant("pic", default=True, description="Generate position-independent code (PIC)")
+    variant("fast_math", default=True, description="Enable recommended fast-math optimisations")
 
     homepage = "https://gitlab.mpcdf.mpg.de/mtr/libsharp"
     git = "https://gitlab.mpcdf.mpg.de/mtr/libsharp.git"
@@ -40,4 +41,9 @@ class Libsharp2(AutotoolsPackage):
             args.append("--disable-mpi")
         if "+pic" in self.spec:
             args.append("--enable-pic")
+        if "+fast_math" in self.spec:
+            # As per author recommendation, fast-math should only be used in the *compile* step,
+            # and *not* during the linking step. The simplest way of doing this is to
+            # (unconventionally) pass this as a pre-processor flag.
+            args.append("CPPFLAGS=-ffast-math")
         return args

--- a/var/spack/repos/builtin/packages/libsharp2/package.py
+++ b/var/spack/repos/builtin/packages/libsharp2/package.py
@@ -10,7 +10,7 @@ class Libsharp2(AutotoolsPackage):
     """Libsharp2 is a code library for spherical harmonic transforms (SHTs) and
     spin-weighted spherical harmonic transforms, which evolved from the libpsht
     library. Because the upstream repository has no tags or releases, this
-    package tracks the versions found in HEALPix releases."""
+    package tracks the versions published together with HEALPix releases."""
 
     variant("openmp", default=True, description="Build with openmp support")
     variant("mpi", default=True, description="Build with MPI support")
@@ -20,6 +20,8 @@ class Libsharp2(AutotoolsPackage):
     git = "https://gitlab.mpcdf.mpg.de/mtr/libsharp.git"
 
     version("3.82.0", sha256="47629f057a2daf06fca3305db1c6950edb9e61bbe2d7ed4d98ff05809da2a127")
+
+    conflicts("libsharp")
 
     depends_on("autoconf", type="build")
     depends_on("mpi", when="+mpi")


### PR DESCRIPTION
This PR contains an update of the healpix-cxx package to the current version 3.82.0.

It is slightly complicated by the fact that HEALPix switched from libsharp v1 to libsharp2, which does not have tags or releases on the upstream Git repository. I have communicated with the main author of libsharp2 and we agreed that it is sensible to track the version of libsharp2 that is released in the HEALPix package. He also made some recommendations regarding compile flags which I incorporated as default.

I hope combining these two packages into one PR makes sense.

Many thanks for checking in advance!