### PR TITLE
iqtree2: add new version 2.2.2.7 and new variant lsd2

### DIFF
--- a/var/spack/repos/builtin/packages/iqtree2/package.py
+++ b/var/spack/repos/builtin/packages/iqtree2/package.py
@@ -13,9 +13,29 @@ class Iqtree2(CMakePackage):
     homepage = "http://www.iqtree.org"
     url = "https://github.com/iqtree/iqtree2/archive/refs/tags/v2.1.2.tar.gz"
 
+    version("2.2.2.7", sha256="407a1a56d352ba9c2152a1d708cd29db872a41c252fbdc7acd8e0de0da8af008")
     version("2.2.2", sha256="2e9ce79427b140bca5f48b31fb098f394a21a7c5116bbbada1e3eabdd6efe982")
     version("2.1.2", sha256="3aaf5ac7f60d852ac8b733fb82832c049ca48b7203a6a865e99c5af359fcca5a")
+
+    resource(
+        name="lsd2-rsrc",
+        url="https://github.com/tothuhien/lsd2/archive/refs/tags/v.2.4.1.tar.gz",
+        sha256="3d0921c96edb8f30498dc8a27878a76d785516043fbede4a72eefd84b5955458",
+        destination="lsd2-rsrc",
+        when="+lsd2",
+    )
 
     depends_on("boost", type="link")
     depends_on("eigen", type="link")
     depends_on("zlib-api", type="link")
+
+    variant("lsd2", default=False, description="Build with LSD2 support")
+
+    @run_before("cmake")
+    def expand_resource(self):
+        copy_tree(join_path("lsd2-rsrc", "*"), "lsd2")
+
+    def cmake_cargs(self):
+        args = [self.define_from_variant("USE_LSD2", variant="lsd2")]
+
+        return args

--- a/var/spack/repos/builtin/packages/iqtree2/package.py
+++ b/var/spack/repos/builtin/packages/iqtree2/package.py
@@ -17,6 +17,12 @@ class Iqtree2(CMakePackage):
     version("2.2.2", sha256="2e9ce79427b140bca5f48b31fb098f394a21a7c5116bbbada1e3eabdd6efe982")
     version("2.1.2", sha256="3aaf5ac7f60d852ac8b733fb82832c049ca48b7203a6a865e99c5af359fcca5a")
 
+    variant("lsd2", default=False, description="Build with LSD2 support")
+
+    depends_on("boost", type="link")
+    depends_on("eigen", type="link")
+    depends_on("zlib-api", type="link")
+
     resource(
         name="lsd2-rsrc",
         url="https://github.com/tothuhien/lsd2/archive/refs/tags/v.2.4.1.tar.gz",
@@ -24,12 +30,6 @@ class Iqtree2(CMakePackage):
         destination="lsd2-rsrc",
         when="+lsd2",
     )
-
-    depends_on("boost", type="link")
-    depends_on("eigen", type="link")
-    depends_on("zlib-api", type="link")
-
-    variant("lsd2", default=False, description="Build with LSD2 support")
 
     @run_before("cmake")
     def expand_resource(self):


### PR DESCRIPTION
Version update and adding a variant.

I wasn't sure how to make a resource expand while ignoring the first directory level, so there's a little helper method that does it.

Ideally we wouldn't use a resource and instead would have it as a dependency, but the build process is set up to use a vendored copy vs an external dependency.