### PR TITLE
geant4/geant4-data: add v10.0.4

### DIFF
--- a/var/spack/repos/builtin/packages/clhep/package.py
+++ b/var/spack/repos/builtin/packages/clhep/package.py
@@ -51,6 +51,7 @@ class Clhep(CMakePackage):
     version("2.2.0.8", sha256="f735e236b1f023ba7399269733b2e84eaed4de615081555b1ab3af25a1e92112")
     version("2.2.0.5", sha256="92e8b5d32ae96154edd27d0c641ba048ad33cb69dd4f1cfb72fc578770a34818")
     version("2.2.0.4", sha256="9bf7fcd9892313c8d1436bc4a4a285a016c4f8e81e1fc65bdf6783207ae57550")
+    version("2.1.2.3", sha256="4353231be09c134507092161cd3ced27a065ca0ebb31ee0256e60a8163c47c3b")
 
     variant(
         "cxxstd",

--- a/var/spack/repos/builtin/packages/g4emlow/package.py
+++ b/var/spack/repos/builtin/packages/g4emlow/package.py
@@ -26,6 +26,7 @@ class G4emlow(Package):
     version("7.7", sha256="16dec6adda6477a97424d749688d73e9bd7d0b84d0137a67cf341f1960984663")
     version("7.3", sha256="583aa7f34f67b09db7d566f904c54b21e95a9ac05b60e2bfb794efb569dba14e")
     version("6.50", sha256="c97be73fece5fb4f73c43e11c146b43f651c6991edd0edf8619c9452f8ab1236")
+    version("6.35", sha256="1564045a0acad344c8d432cd48c2c3bb2e051a81ab3099a84e0f56ba0fe82cec")
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))

--- a/var/spack/repos/builtin/packages/g4ensdfstate/package.py
+++ b/var/spack/repos/builtin/packages/g4ensdfstate/package.py
@@ -21,6 +21,7 @@ class G4ensdfstate(Package):
     version("2.3", sha256="9444c5e0820791abd3ccaace105b0e47790fadce286e11149834e79c4a8e9203")
     version("2.2", sha256="dd7e27ef62070734a4a709601f5b3bada6641b111eb7069344e4f99a01d6e0a6")
     version("2.1", sha256="933e7f99b1c70f24694d12d517dfca36d82f4e95b084c15d86756ace2a2790d9")
+    version("1.0", sha256="4562e7476aa2df7204a1a77263e9d2331e9ffcdb591d11814dcc2d6b605021dd")
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))

--- a/var/spack/repos/builtin/packages/g4ndl/package.py
+++ b/var/spack/repos/builtin/packages/g4ndl/package.py
@@ -20,6 +20,7 @@ class G4ndl(Package):
     version("4.7", sha256="7e7d3d2621102dc614f753ad928730a290d19660eed96304a9d24b453d670309")
     version("4.6", sha256="9d287cf2ae0fb887a2adce801ee74fb9be21b0d166dab49bcbee9408a5145408")
     version("4.5", sha256="cba928a520a788f2bc8229c7ef57f83d0934bb0c6a18c31ef05ef4865edcdf8e")
+    version("4.4", sha256="e9fe8800566a83ccaf9b5229a1fa1d2cd24530bbd2e9fcb96eb6b5b117233071")
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))

--- a/var/spack/repos/builtin/packages/g4photonevaporation/package.py
+++ b/var/spack/repos/builtin/packages/g4photonevaporation/package.py
@@ -23,6 +23,7 @@ class G4photonevaporation(Package):
     version("5.3", sha256="d47ababc8cbe548065ef644e9bd88266869e75e2f9e577ebc36bc55bf7a92ec8")
     version("5.2", sha256="83607f8d36827b2a7fca19c9c336caffbebf61a359d0ef7cee44a8bcf3fc2d1f")
     version("4.3.2", sha256="d4641a6fe1c645ab2a7ecee09c34e5ea584fb10d63d2838248bfc487d34207c7")
+    version("3.0", sha256="c76a843672eca21110e97a274a6b5cd9a58b66f35235301c8e1b162926e0e7cb")
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))

--- a/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
+++ b/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
@@ -23,6 +23,7 @@ class G4radioactivedecay(Package):
     version("5.3", sha256="5c8992ac57ae56e66b064d3f5cdfe7c2fee76567520ad34a625bfb187119f8c1")
     version("5.2", sha256="99c038d89d70281316be15c3c98a66c5d0ca01ef575127b6a094063003e2af5d")
     version("5.1.1", sha256="f7a9a0cc998f0d946359f2cb18d30dff1eabb7f3c578891111fc3641833870ae")
+    version("4.0", sha256="ed2053bddee507920a29a27db4364fbef255b951597686b0410d5458e9b38cb5")
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))

--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -33,6 +33,7 @@ class Geant4Data(BundlePackage):
     version("10.4.3")
     version("10.4.0")
     version("10.3.3")
+    version("10.0.4")
 
     # Add install phase so we can create the data "view"
     phases = ["install"]
@@ -132,6 +133,18 @@ class Geant4Data(BundlePackage):
         ],
         "10.3.1:10.3": ["g4photonevaporation@4.3.2", "g4radioactivedecay@5.1.1"],
         "10.3.0": ["g4photonevaporation@4.3", "g4radioactivedecay@5.1"],
+        "10.0.4": [
+            "g4ndl@4.4",
+            "g4emlow@6.35",
+            "g4photonevaporation@3.0",
+            "g4radioactivedecay@4.0",
+            "g4neutronxs@1.4",
+            "g4pii@1.3",
+            "g4realsurface@1.0",
+            "g4saiddata@1.1",
+            "g4abla@3.0",
+            "g4ensdfstate@1.0",
+        ],
     }
 
     for _vers, _dsets in _datasets.items():

--- a/var/spack/repos/builtin/packages/geant4/geant4-10.0.4.patch
+++ b/var/spack/repos/builtin/packages/geant4/geant4-10.0.4.patch
@@ -1,0 +1,31 @@
+diff -Naur a/cmake/Modules/Geant4MakeRules_cxx.cmake b/cmake/Modules/Geant4MakeRules_cxx.cmake
+--- a/cmake/Modules/Geant4MakeRules_cxx.cmake	2016-06-10 12:04:27
++++ b/cmake/Modules/Geant4MakeRules_cxx.cmake	2023-12-04 16:49:28
+@@ -51,7 +51,7 @@
+   elseif(_gnucxx_version VERSION_LESS 4.7)
+     set(_CXXSTDS "c++98" "c++0x")
+   else()
+-    set(_CXXSTDS "c++98" "c++0x" "c++11")
++    set(_CXXSTDS "c++98" "c++0x" "c++11" "c++14")
+   endif()
+
+   set(CXXSTD_IS_AVAILABLE ${_CXXSTDS} PARENT_SCOPE)
+diff -Naur a/source/visualization/HepRep/sources.cmake b/source/visualization/HepRep/sources.cmake
+--- a/source/visualization/HepRep/sources.cmake	2016-06-10 12:04:27
++++ b/source/visualization/HepRep/sources.cmake	2023-12-04 16:12:32
+@@ -71,13 +71,13 @@
+     G4HepRepMessenger.cc
+     G4HepRepSceneHandler.cc
+     G4HepRepViewer.cc
+-    GZIPOutputStream.cc
++    gzipoutputstream.cc
+     GZIPOutputStreamBuffer.cc
+     IndentPrintWriter.cc
+     XMLHepRepFactory.cc
+     XMLHepRepWriter.cc
+     XMLWriter.cc
+-    ZipOutputStream.cc
++    zipoutputstream.cc
+     ZipOutputStreamBuffer.cc
+   GRANULAR_DEPENDENCIES
+     G4csg

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -60,7 +60,7 @@ class Geant4(CMakePackage):
     )
 
     variant("threads", default=True, description="Build with multithreading")
-    variant("vecgeom", default=False, description="Enable vecgeom support")
+    variant("vecgeom", default=False, description="Enable vecgeom support", when="@10.3:")
     variant("opengl", default=False, description="Optional OpenGL support")
     variant("x11", default=False, description="Optional X11 support")
     variant("motif", default=False, description="Optional motif support")


### PR DESCRIPTION
This PR adds a historic version (that is still used by some of our simulation frameworks) and its data dependencies.

It also introduces a new variant, builtin_clhep, that builds the CLHEP version shipped with Geant4.