### PR TITLE
opensta: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/opensta/package.py
+++ b/var/spack/repos/builtin/packages/opensta/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/opensta/package.py
+++ b/var/spack/repos/builtin/packages/opensta/package.py
@@ -1,0 +1,49 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack.package import *
+
+
+class Opensta(CMakePackage):
+    """
+    OpenSTA is a gate level static timing verifier. As a stand-alone executable
+    it can be used to verify the timing of a design using standard file formats.
+
+    * Verilog netlist
+    * Liberty library
+    * SDC timing constraints
+    * SDF delay annotation
+    * SPEF parasitics
+
+    """
+
+    homepage = "https://github.com/parallaxsw/OpenSTA"
+    git = "https://github.com/parallaxsw/OpenSTA.git"
+
+    maintainers("davekeeshan")
+
+    version("master", branch="master")
+
+    variant("zlib", default=True, description="build with zlib support")
+    variant("cudd", default=True, description="build with cudd support")
+
+    depends_on("tcl@8.6.11", type="build")
+    depends_on("flex", type="build")
+    depends_on("swig", type="build")
+    depends_on("llvm")
+    depends_on("zlib", type="build", when="+zlib")
+    depends_on("cudd", type="build", when="+cudd")
+
+    def cmake_args(self):
+        args = []
+        if self.spec.satisfies("+zlib"):
+            args.append(f"-DZLIB_ROOT={self.spec['zlib'].prefix}")
+        if self.spec.satisfies("+cudd"):
+            args.append("-DUSE_CUDD=ON ")
+            args.append(f"-DCUDD_DIR={self.spec['cudd'].prefix}")
+
+        return args


### PR DESCRIPTION
Add opensta, it allows 2 variants, `zlib` and `cudd`, but they are both enabled by default. There are no release versions or tags, so we build straight from the master branch on github.

_OpenSTA is a gate level static timing verifier._