### PR TITLE
apple-clang: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/apple-clang/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/apple-clang/detection_test.yaml
@@ -1,0 +1,35 @@
+paths:
+  # Apple Clang on MacBook Pro (Catalina)
+  - layout:
+      - executables:
+          - "bin/clang"
+          - "bin/clang++"
+        script: |
+          echo "Apple clang version 11.0.0 (clang-1100.0.33.8)"
+          echo "Target: x86_64-apple-darwin19.5.0"
+          echo "Thread model: posix"
+          echo "InstalledDir: /Library/Developer/CommandLineTools/usr/bin"
+    results:
+      - spec: 'apple-clang@11.0.0'
+  # Apple Clang on Apple M1 (Ventura)
+  - layout:
+      - executables:
+          - "bin/clang"
+          - "bin/clang++"
+        script: |
+          echo "Apple clang version 15.0.0 (clang-1500.0.40.1)"
+          echo "Target: arm64-apple-darwin22.6.0"
+          echo "Thread model: posix"
+          echo "InstalledDir: /Library/Developer/CommandLineTools/usr/bin"
+    results:
+      - spec: 'apple-clang@15.0.0'
+  # Test that missing a compiler prevents the package from being detected
+  - layout:
+      - executables:
+          - "bin/clang"
+        script: |
+          echo "Apple clang version 11.0.0 (clang-1100.0.33.8)"
+          echo "Target: x86_64-apple-darwin19.5.0"
+          echo "Thread model: posix"
+          echo "InstalledDir: /Library/Developer/CommandLineTools/usr/bin"
+    results: [ ]

--- a/var/spack/repos/builtin/packages/apple-clang/package.py
+++ b/var/spack/repos/builtin/packages/apple-clang/package.py
@@ -1,0 +1,77 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import re
+
+from spack.package import *
+
+
+class AppleClang(BundlePackage):
+    """Apple's Clang compiler"""
+
+    homepage = "https://developer.apple.com/videos/developer-tools/compiler-and-llvm"
+    has_code = False
+
+    executables = ["^clang$", r"^clang\+\+$", "^ld.lld$", "^lldb$"]
+
+    @classmethod
+    def determine_version(cls, exe):
+        version_regex = re.compile(
+            # Apple's LLVM compiler has its own versions, which are
+            # different from vanilla LLVM
+            r"^Apple (?:LLVM|clang) version ([^ )]+)",
+            # Multi-line, since 'Apple clang' may not be on the first line
+            # in particular, when run as gcc, it seems to output
+            # "Configured with: --prefix=..." as the first line
+            re.M,
+        )
+        try:
+            compiler = Executable(exe)
+            output = compiler("--version", output=str, error=str)
+            match = version_regex.search(output)
+            if match:
+                return match.group(match.lastindex)
+        except Exception:
+            pass
+
+        return None
+
+    @classmethod
+    def determine_variants(cls, exes, version_str):
+        compilers = {}
+        for exe in exes:
+            if "clang++" in exe:
+                compilers["cxx"] = exe
+            elif "clang" in exe:
+                compilers["c"] = exe
+            elif "ld.lld" in exe:
+                compilers["ld"] = exe
+            elif "lldb" in exe:
+                compilers["lldb"] = exe
+
+        return "", {"compilers": compilers}
+
+    @classmethod
+    def validate_detected_spec(cls, spec, extra_attributes):
+        # For GCC 'compilers' is a mandatory attribute
+        msg = 'the extra attribute "compilers" must be set for ' 'the detected spec "{0}"'.format(
+            spec
+        )
+        assert "compilers" in extra_attributes, msg
+        compilers = extra_attributes["compilers"]
+        for key in ("c", "cxx"):
+            msg = "{0} compiler not found for {1}"
+            assert key in compilers, msg.format(key, spec)
+
+    @property
+    def cc(self):
+        msg = "apple-clang is expected to be an external spec"
+        assert self.spec.concrete and self.spec.external, msg
+        return self.spec.extra_attributes["compilers"].get("c", None)
+
+    @property
+    def cxx(self):
+        msg = "apple-clang is expected to be an external spec"
+        assert self.spec.concrete and self.spec.external, msg
+        return self.spec.extra_attributes["compilers"].get("cxx", None)

--- a/var/spack/repos/builtin/packages/apple-clang/package.py
+++ b/var/spack/repos/builtin/packages/apple-clang/package.py
@@ -56,15 +56,12 @@ class AppleClang(BundlePackage):
 
     @classmethod
     def validate_detected_spec(cls, spec, extra_attributes):
-        # For GCC 'compilers' is a mandatory attribute
-        msg = 'the extra attribute "compilers" must be set for ' 'the detected spec "{0}"'.format(
-            spec
-        )
+        msg = f'the extra attribute "compilers" must be set for the detected spec "{spec}"'
         assert "compilers" in extra_attributes, msg
         compilers = extra_attributes["compilers"]
         for key in ("c", "cxx"):
-            msg = "{0} compiler not found for {1}"
-            assert key in compilers, msg.format(key, spec)
+            msg = f"{key} compiler not found for {spec}"
+            assert key in compilers, msg
 
     @property
     def cc(self):

--- a/var/spack/repos/builtin/packages/apple-clang/package.py
+++ b/var/spack/repos/builtin/packages/apple-clang/package.py
@@ -13,6 +13,8 @@ class AppleClang(BundlePackage):
     homepage = "https://developer.apple.com/videos/developer-tools/compiler-and-llvm"
     has_code = False
 
+    maintainers("alalazo")
+
     executables = ["^clang$", r"^clang\+\+$", "^ld.lld$", "^lldb$"]
 
     @classmethod


### PR DESCRIPTION
refers #40250

This package is only meant to detect `apple-clang` as an external package, in preparation for turning compilers into dependencies.