### PR TITLE
[intel-mkl,intel-ipp,intel-daal]: deprecate packages

### DIFF
--- a/var/spack/repos/builtin/packages/intel-daal/package.py
+++ b/var/spack/repos/builtin/packages/intel-daal/package.py
@@ -21,101 +21,121 @@ class IntelDaal(IntelPackage):
         "2020.2.254",
         sha256="08528bc150dad312ff2ae88ce12d6078ed8ba2f378f4bf3daf0fbbb9657dce1e",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16822/l_daal_2020.2.254.tgz",
+        deprecated=True,
     )
     version(
         "2020.1.217",
         sha256="3f84dea0ce1038ac1b9c25b3e2c02e9fac440fa36cc8adfce69edfc06fe0edda",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16536/l_daal_2020.1.217.tgz",
+        deprecated=True,
     )
     version(
         "2020.0.166",
         sha256="695166c9ab32ac5d3006d6d35162db3c98734210507144e315ed7c3b7dbca9c1",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16234/l_daal_2020.0.166.tgz",
+        deprecated=True,
     )
     version(
         "2019.5.281",
         sha256="e92aaedbe35c9daf1c9483260cb2363da8a85fa1aa5566eb38cf4b1f410bc368",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15818/l_daal_2019.5.281.tgz",
+        deprecated=True,
     )
     version(
         "2019.4.243",
         sha256="c74486a555ca5636c2ac1b060d5424726c022468f3ee0898bb46e333cda6f7b8",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15552/l_daal_2019.4.243.tgz",
+        deprecated=True,
     )
     version(
         "2019.3.199",
         sha256="1f7d9cdecc1091b03f1ee6303fc7566179d1e3f1813a98ef7a6239f7d456b8ef",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15277/l_daal_2019.3.199.tgz",
+        deprecated=True,
     )
     version(
         "2019.2.187",
         sha256="2982886347e9376e892a5c4e22fa1d4b7b843e1ae988a107dd2d0a639f257765",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15097/l_daal_2019.2.187.tgz",
+        deprecated=True,
     )
     version(
         "2019.1.144",
         sha256="1672afac568c93e185283cf7e044d511381092ebc95d7204c4dccb83cc493197",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14869/l_daal_2019.1.144.tgz",
+        deprecated=True,
     )
     version(
         "2019.0.117",
         sha256="85ac8e983bc9b9cc635e87cb4ec775ffd3695e44275d20fdaf53c19ed280d69f",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13577/l_daal_2019.0.117.tgz",
+        deprecated=True,
     )
     version(
         "2018.3.222",
         sha256="378fec529a36508dd97529037e1164ff98e0e062a9a47ede99ccf9e91493d1e2",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13007/l_daal_2018.3.222.tgz",
+        deprecated=True,
     )
     version(
         "2018.2.199",
         sha256="cee30299b3ffaea515f5a9609f4df0f644579c8a1ba2b61747b390f6caf85b14",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12727/l_daal_2018.2.199.tgz",
+        deprecated=True,
     )
     version(
         "2018.1.163",
         sha256="ac96b5a6c137cda18817d9b3505975863f8f53347225ebb6ccdaaf4bdb8dc349",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12414/l_daal_2018.1.163.tgz",
+        deprecated=True,
     )
     version(
         "2018.0.128",
         sha256="d13a7cd1b6779971f2ba46797447de9409c98a4d2f0eb0dc9622d9d63ac8990f",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12072/l_daal_2018.0.128.tgz",
+        deprecated=True,
     )
     version(
         "2017.4.239",
         sha256="cc4b608f59f3b2fafee16389102a763d27c46f6d136a6cfa89847418a8ea7460",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12148/l_daal_2017.4.239.tgz",
+        deprecated=True,
     )
     version(
         "2017.3.196",
         sha256="cfa863f342dd1c5fe8f1c7b6fd69589140370fc92742a19d82c8594e4e1e46ce",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11546/l_daal_2017.3.196.tgz",
+        deprecated=True,
     )
     version(
         "2017.2.174",
         sha256="5ee838b08d4cda7fc3e006e1deeed41671cbd7cfd11b64ec3b762c94dfc2b660",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11308/l_daal_2017.2.174.tgz",
+        deprecated=True,
     )
     version(
         "2017.1.132",
         sha256="6281105d3947fc2860e67401ea0218198cc4753fd2d4b513528a89143248e4f3",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/10983/l_daal_2017.1.132.tgz",
+        deprecated=True,
     )
     version(
         "2017.0.098",
         sha256="a7064425653b4f5f0fe51e25358d267d8ae023179eece61e08da891b67d79fe5",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9664/l_daal_2017.0.098.tgz",
+        deprecated=True,
     )
     version(
         "2016.3.210",
         sha256="367eaef21ea0143c11ae3fd56cd2a05315768c059e14caa15894bcf96853687c",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9099/l_daal_2016.3.210.tgz",
+        deprecated=True,
     )
     version(
         "2016.2.181",
         sha256="afdb65768957784d28ac537b4933a86eb4193c68a636157caed17b29ccdbfacb",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8687/l_daal_2016.2.181.tgz",
+        deprecated=True,
     )
 
     provides("daal")

--- a/var/spack/repos/builtin/packages/intel-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-ipp/package.py
@@ -21,92 +21,110 @@ class IntelIpp(IntelPackage):
         "2020.2.254",
         sha256="18266ad1eec9b5b17e76da24f1aa9a9147300e5bd345e6bdad58d7187392fa77",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16846/l_ipp_2020.2.254.tgz",
+        deprecated=True,
     )
     version(
         "2020.1.217",
         sha256="0bf8ac7e635e7e602cf201063a1a7dea3779b093104563fdb15e6b7ecf2f00a7",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16534/l_ipp_2020.1.217.tgz",
+        deprecated=True,
     )
     version(
         "2020.0.166",
         sha256="6844007892ba524e828f245355cee44e8149f4c233abbbea16f7bb55a7d6ecff",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16233/l_ipp_2020.0.166.tgz",
+        deprecated=True,
     )
     version(
         "2019.5.281",
         sha256="61d1e1da1a4a50f1cf02a3ed44e87eed05e94d58b64ef1e67a3bdec363bee713",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15817/l_ipp_2019.5.281.tgz",
+        deprecated=True,
     )
     version(
         "2019.4.243",
         sha256="d4f4232323e66b010d8440c75189aeb6a3249966e05035242b21982238a7a7f2",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15541/l_ipp_2019.4.243.tgz",
+        deprecated=True,
     )
     version(
         "2019.3.199",
         sha256="02545383206c1ae4dd66bfa6a38e2e14480ba11932eeed632df8ab798aa15ccd",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15276/l_ipp_2019.3.199.tgz",
+        deprecated=True,
     )
     version(
         "2019.2.187",
         sha256="280e9081278a0db3892fe82474c1201ec780a6f7c8d1f896494867f4b3bd8421",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15096/l_ipp_2019.2.187.tgz",
+        deprecated=True,
     )
     version(
         "2019.1.144",
         sha256="1eb7cd0fba74615aeafa4e314c645414497eb73f1705200c524fe78f00620db3",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14887/l_ipp_2019.1.144.tgz",
+        deprecated=True,
     )
     version(
         "2019.0.117",
         sha256="d552ba49fba58f0e94da2048176f21c5dfd490dca7c5ce666dfc2d18db7fd551",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13576/l_ipp_2019.0.117.tgz",
+        deprecated=True,
     )
     version(
         "2018.4.274",
         sha256="bdc6082c65410c98ccf6daf239e0a6625d15ec5e0ddc1c0563aad42b6ba9063c",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13726/l_ipp_2018.4.274.tgz",
+        deprecated=True,
     )
     version(
         "2018.3.222",
         sha256="bb783c5e6220e240f19136ae598cd1c1d647496495139ce680de58d3d5496934",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13006/l_ipp_2018.3.222.tgz",
+        deprecated=True,
     )
     version(
         "2018.2.199",
         sha256="55cb5c910b2c1e2bd798163fb5019b992b1259a0692e328bb9054778cf01562b",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12726/l_ipp_2018.2.199.tgz",
+        deprecated=True,
     )
     version(
         "2018.0.128",
         sha256="da568ceec1b7acbcc8f666b73d4092788b037b1b03c0436974b82155056ed166",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12071/l_ipp_2018.0.128.tgz",
+        deprecated=True,
     )
     version(
         "2017.3.196",
         sha256="50d49a1000a88a8a58bd610466e90ae28d07a70993a78cbbf85d44d27c4232b6",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11545/l_ipp_2017.3.196.tgz",
+        deprecated=True,
     )
     version(
         "2017.2.174",
         sha256="92f866c9dce8503d7e04223ec35f281cfeb0b81cf94208c3becb11aacfda7b99",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11307/l_ipp_2017.2.174.tgz",
+        deprecated=True,
     )
     version(
         "2017.1.132",
         sha256="2908bdeab3057d4ebcaa0b8ff5b00eb47425d35961a96f14780be68554d95376",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11031/l_ipp_2017.1.132.tgz",
+        deprecated=True,
     )
     version(
         "2017.0.098",
         sha256="7633d16e2578be64533892336c8a15c905139147b0f74eaf9f281358ad7cdcba",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9663/l_ipp_2017.0.098.tgz",
+        deprecated=True,
     )
     # built from parallel_studio_xe_2016.3.067
     version(
         "9.0.3.210",
         sha256="8ce7bf17f4a0bbf8c441063de26be7f6e0f6179789e23f24eaa8b712632b3cdd",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9067/l_ipp_9.0.3.210.tgz",
+        deprecated=True,
     )
 
     provides("ipp")

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -23,118 +23,141 @@ class IntelMkl(IntelPackage):
         "2020.4.304",
         sha256="2314d46536974dbd08f2a4e4f9e9a155dc7e79e2798c74e7ddfaad00a5917ea5",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16917/l_mkl_2020.4.304.tgz",
+        deprecated=True,
     )
     version(
         "2020.3.279",
         sha256="2b8e434ecc9462491130ba25a053927fd1a2eca05e12acb5936b08c486857a04",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16903/l_mkl_2020.3.279.tgz",
+        deprecated=True,
     )
     version(
         "2020.2.254",
         sha256="ed00a267af362a6c14212bd259ab1673d64337e077263033edeef8ac72c10223",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16849/l_mkl_2020.2.254.tgz",
+        deprecated=True,
     )
     version(
         "2020.1.217",
         sha256="082a4be30bf4f6998e4d6e3da815a77560a5e66a68e254d161ab96f07086066d",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16533/l_mkl_2020.1.217.tgz",
+        deprecated=True,
     )
     version(
         "2020.0.166",
         sha256="f6d92deb3ff10b11ba3df26b2c62bb4f0f7ae43e21905a91d553e58f0f5a8ae0",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16232/l_mkl_2020.0.166.tgz",
+        deprecated=True,
     )
     version(
         "2019.5.281",
         sha256="9995ea4469b05360d509c9705e9309dc983c0a10edc2ae3a5384bc837326737e",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15816/l_mkl_2019.5.281.tgz",
+        deprecated=True,
     )
     version(
         "2019.4.243",
         sha256="fcac7b0369665d93f0c4dd98afe2816aeba5410e2b760655fe55fc477f8f33d0",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15540/l_mkl_2019.4.243.tgz",
+        deprecated=True,
     )
     version(
         "2019.3.199",
         sha256="06de2b54f4812e7c39a118536259c942029fe1d6d8918ad9df558a83c4162b8f",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15275/l_mkl_2019.3.199.tgz",
+        deprecated=True,
     )
     version(
         "2019.2.187",
         sha256="2bf004e6b5adb4f956993d6c20ea6ce289bb630314dd501db7f2dd5b9978ed1d",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15095/l_mkl_2019.2.187.tgz",
+        deprecated=True,
     )
     version(
         "2019.1.144",
         sha256="5205a460a9c685f7a442868367389b2d0c25e1455346bc6a37c5b8ff90a20fbb",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14895/l_mkl_2019.1.144.tgz",
+        deprecated=True,
     )
     version(
         "2019.0.117",
         sha256="4e1fe2c705cfc47050064c0d6c4dee1a8c6740ac1c4f64dde9c7511c4989c7ad",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13575/l_mkl_2019.0.117.tgz",
+        deprecated=True,
     )
     version(
         "2018.4.274",
         sha256="18eb3cde3e6a61a88f25afff25df762a560013f650aaf363f7d3d516a0d04881",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13725/l_mkl_2018.4.274.tgz",
+        deprecated=True,
     )
     version(
         "2018.3.222",
         sha256="108d59c0927e58ce8c314db6c2b48ee331c3798f7102725f425d6884eb6ed241",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13005/l_mkl_2018.3.222.tgz",
+        deprecated=True,
     )
     version(
         "2018.2.199",
         sha256="e28d12173bef9e615b0ded2f95f59a42b3e9ad0afa713a79f8801da2bfb31936",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12725/l_mkl_2018.2.199.tgz",
+        deprecated=True,
     )
     version(
         "2018.1.163",
         sha256="f6dc263fc6f3c350979740a13de1b1e8745d9ba0d0f067ece503483b9189c2ca",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12414/l_mkl_2018.1.163.tgz",
+        deprecated=True,
     )
     version(
         "2018.0.128",
         sha256="c368baa40ca88057292512534d7fad59fa24aef06da038ea0248e7cd1e280cec",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12070/l_mkl_2018.0.128.tgz",
+        deprecated=True,
     )
     version(
         "2017.4.239",
         sha256="dcac591ed1e95bd72357fd778edba215a7eab9c6993236373231cc16c200c92a",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12147/l_mkl_2017.4.239.tgz",
+        deprecated=True,
     )
     version(
         "2017.3.196",
         sha256="fd7295870fa164d6138c9818304f25f2bb263c814a6c6539c9fe4e104055f1ca",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11544/l_mkl_2017.3.196.tgz",
+        deprecated=True,
     )
     version(
         "2017.2.174",
         sha256="0b8a3fd6bc254c3c3d9d51acf047468c7f32bf0baff22aa1e064d16d9fea389f",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11306/l_mkl_2017.2.174.tgz",
+        deprecated=True,
     )
     version(
         "2017.1.132",
         sha256="8c6bbeac99326d59ef3afdc2a95308c317067efdaae50240d2f4a61f37622e69",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11024/l_mkl_2017.1.132.tgz",
+        deprecated=True,
     )
     version(
         "2017.0.098",
         sha256="f2233e8e011f461d9c15a853edf7ed0ae8849aa665a1ec765c1ff196fd70c4d9",
         url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9662/l_mkl_2017.0.098.tgz",
+        deprecated=True,
     )
     # built from parallel_studio_xe_2016.3.x
     version(
         "11.3.3.210",
         sha256="ff858f0951fd698e9fb30147ea25a8a810c57f0126c8457b3b0cdf625ea43372",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9068/l_mkl_11.3.3.210.tgz",
+        deprecated=True,
     )
     # built from parallel_studio_xe_2016.2.062
     version(
         "11.3.2.181",
         sha256="bac04a07a1fe2ae4996a67d1439ee90c54f31305e8663d1ccfce043bed84fc27",
         url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8711/l_mkl_11.3.2.181.tgz",
+        deprecated=True,
     )
 
     depends_on("cpio", type="build")


### PR DESCRIPTION
The deprecated packages have not been updated since 2020. New releases are in intel-oneapi-mkl, intel-oneapi-ipp, intel-oneapi-dal