### PR TITLE
flecsi: remove ^legion network=gasnet restriction

### DIFF
--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -78,7 +78,6 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("metis@5.1.0:")
     depends_on("parmetis@4.0.3:")
     depends_on("boost@1.70.0: cxxstd=17 +program_options +stacktrace")
-    depends_on("legion network=gasnet", when="backend=legion")
 
     # FleCSI@1.x
     depends_on("cmake@3.12:", when="@:1")


### PR DESCRIPTION
This allows using `^legion network=ucx` with FleCSI.