### PR TITLE
add missing endtime property to CDash (fixes 38825 unit tests)

### DIFF
--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -93,6 +93,7 @@ class CDash(Reporter):
         self.osrelease = platform.release()
         self.target = spack.platforms.host().target("default_target")
         self.starttime = int(time.time())
+        self.endtime = self.starttime
         self.buildstamp = (
             configuration.buildstamp
             if configuration.buildstamp


### PR DESCRIPTION
Alternative to #41497 plus a fix PR is to just add the fix to #38825 with this PR.

This PR adds the `endtime` property back to `CDash` so should resolve unit test failures reported for #38825.  Manually tested the relevant test.