### PR TITLE
Fix filter_compiler_wrapper where compiler is None

### DIFF
--- a/lib/spack/spack/mixins.py
+++ b/lib/spack/spack/mixins.py
@@ -93,7 +93,7 @@ def filter_compiler_wrappers(*files, **kwargs):
         replacements = []
 
         for idx, (env_var, compiler_path) in enumerate(compiler_vars):
-            if env_var in os.environ and not compiler_path is None:
+            if env_var in os.environ and compiler_path is not None:
                 # filter spack wrapper and links to spack wrapper in case
                 # build system runs realpath
                 wrapper = os.environ[env_var]

--- a/lib/spack/spack/mixins.py
+++ b/lib/spack/spack/mixins.py
@@ -93,7 +93,7 @@ def filter_compiler_wrappers(*files, **kwargs):
         replacements = []
 
         for idx, (env_var, compiler_path) in enumerate(compiler_vars):
-            if env_var in os.environ:
+            if env_var in os.environ and not compiler_path is None:
                 # filter spack wrapper and links to spack wrapper in case
                 # build system runs realpath
                 wrapper = os.environ[env_var]


### PR DESCRIPTION
Fix `filter_compiler_wrapper` for cases where the compiler returned is `None`, this happens on some installed gcc systems that do not have fortran built into them as standard, e.g. gcc@11.4.0 on ubuntu 22.04

fixes #41427