### PR TITLE
PyTorch: disable sleef dep for now

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -192,8 +192,9 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     # depends_on("cpuinfo@2022-08-19", when="@1.13:2.0")
     # depends_on("cpuinfo@2020-12-17", when="@1.8:1.12")
     # depends_on("cpuinfo@2020-06-11", when="@1.6:1.7")
-    depends_on("sleef@3.5.1_2020-12-22", when="@1.8:")
-    depends_on("sleef@3.4.0_2019-07-30", when="@1.6:1.7")
+    # https://github.com/shibatch/sleef/issues/474
+    # depends_on("sleef@3.5.1_2020-12-22", when="@1.8:")
+    # depends_on("sleef@3.4.0_2019-07-30", when="@1.6:1.7")
     depends_on("fp16@2020-05-14", when="@1.6:")
     depends_on("pthreadpool@2021-04-13", when="@1.9:")
     depends_on("pthreadpool@2020-10-05", when="@1.8")
@@ -622,7 +623,8 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
             # env.set("USE_SYSTEM_LIBS", "ON")
             # https://github.com/pytorch/pytorch/issues/60329
             # env.set("USE_SYSTEM_CPUINFO", "ON")
-            env.set("USE_SYSTEM_SLEEF", "ON")
+            # https://github.com/shibatch/sleef/issues/474
+            # env.set("USE_SYSTEM_SLEEF", "ON")
             env.set("USE_SYSTEM_GLOO", "ON")
             env.set("USE_SYSTEM_FP16", "ON")
             env.set("USE_SYSTEM_PTHREADPOOL", "ON")


### PR DESCRIPTION
When built externally, sleef doesn't build with Apple Clang 15. When built internally, it does. No idea what magic flags PyTorch is using to build sleef, but for now I think we should let it build sleef until we figure out how to build it ourselves.

@yichiac