### PR TITLE
leveldb: turning benchmark and tests off

### DIFF
--- a/var/spack/repos/builtin/packages/leveldb/package.py
+++ b/var/spack/repos/builtin/packages/leveldb/package.py
@@ -70,10 +70,11 @@ class Leveldb(CMakePackage):
         else:
             args.append("-DBUILD_SHARED_LIBS=OFF")
 
-        # The tarball is missing the benchmark and test submodules
-        if self.spec.satisfies("@1.23:"):
-            args.append("-DLEVELDB_BUILD_BENCHMARKS=OFF")
-            args.append("-DLEVELDB_BUILD_TESTS=OFF")
+        # 0.23 tarball is missing the benchmark and test submodules
+        # and for older versions, some compilers fail to compile the
+        # benchmarks
+        args.append("-DLEVELDB_BUILD_BENCHMARKS=OFF")
+        args.append("-DLEVELDB_BUILD_TESTS=OFF")
 
         return args
 

--- a/var/spack/repos/builtin/packages/leveldb/package.py
+++ b/var/spack/repos/builtin/packages/leveldb/package.py
@@ -70,7 +70,7 @@ class Leveldb(CMakePackage):
         else:
             args.append("-DBUILD_SHARED_LIBS=OFF")
 
-        # 0.23 tarball is missing the benchmark and test submodules
+        # 1.23 tarball is missing the benchmark and test submodules
         # and for older versions, some compilers fail to compile the
         # benchmarks
         args.append("-DLEVELDB_BUILD_BENCHMARKS=OFF")


### PR DESCRIPTION
The benchmark in LevelDB 1.22 fails to build with gcc 12 (and probably more recent ones and other compilers).
The package had already disabled building the benchmarks and tests for leveldb 1.23 (because their sources were missing in the archive), this PR simply disables them for all the versions.