### PR TITLE
commands: better install status help formatting

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -384,10 +384,11 @@ def install_status():
         "--install-status",
         action="store_true",
         default=True,
-        help="show install status of packages\n\npackages can be: "
-        "installed [+], missing and needed by an installed package [-], "
-        "installed in an upstream instance [^], "
-        "or not installed (no annotation)",
+        help=(
+            "show install status of packages\n"
+            "[+] installed       [^] installed in an upstream\n"
+            " -  not installed   [-] missing dep of installed package\n"
+        ),
     )
 
 


### PR DESCRIPTION
Before (hard to read, doesn't fit on small terminals): :
```console
  -I, --install-status  show install status of packages

                        packages can be: installed [+], missing and needed by an installed package [-], installed in an upstream instance [^], or not installed (no annotation)
```

After (fits in 80 columns):

```console
  -I, --install-status  show install status of packages
                        [+] installed       [^] installed in an upstream
                         -  not installed   [-] missing dep of installed package
```