### PR TITLE
fpocket: fix build errors

### DIFF
--- a/var/spack/repos/builtin/packages/fpocket/package.py
+++ b/var/spack/repos/builtin/packages/fpocket/package.py
@@ -18,12 +18,17 @@ class Fpocket(MakefilePackage):
 
     depends_on("netcdf-c")
     depends_on("netcdf-cxx")
+    depends_on("qhull")
 
+
+class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
     def setup_build_environment(self, env):
-        if self.compiler.name == "gcc":
+        if self.pkg.compiler.name == "gcc":
             env.set("CXX", "g++")
 
-    def edit(self, spec, prefix):
+    def edit(self, pkg, spec, prefix):
+        mkdirp(prefix.lib)
         makefile = FileFilter("makefile")
         makefile.filter("BINDIR .*", f"BINDIR = {prefix}/bin")
         makefile.filter("MANDIR .*", f"MANDIR = {prefix}/man/man8")
+        makefile.filter("LIBDIR .*", f"LIBDIR = {prefix}/lib")


### PR DESCRIPTION
Other changes resolve additional found build issues:
The qhull dependency might be missing on system so I suppose it is better to depend on the spack provided version.
The source makefile instructions do not seem to directly generate the lib directory for fpocket.