### PR TITLE
visit: add missing header includes needed for GUI build

### DIFF
--- a/var/spack/repos/builtin/packages/visit/0001-fix-missing-header-includes-for-QSurfaceFormat.patch
+++ b/var/spack/repos/builtin/packages/visit/0001-fix-missing-header-includes-for-QSurfaceFormat.patch
@@ -1,0 +1,76 @@
+From a9f33beccc72e113d95e97b9461e39e87e356d97 Mon Sep 17 00:00:00 2001
+From: Ben Wibking <ben@wibking.com>
+Date: Sun, 10 Dec 2023 16:42:49 -0500
+Subject: [PATCH] fix missing header includes for QSurfaceFormat
+
+---
+ src/tools/examples/avtexamples/qtviswinExample.C   | 1 +
+ src/tools/examples/avtexamples/qtvtkExample.C      | 1 +
+ src/tools/examples/avtexamples/qvtkopenglExample.C | 1 +
+ src/tools/examples/mcurvit/main.C                  | 1 +
+ src/viewer/main/viewer.C                           | 1 +
+ 5 files changed, 5 insertions(+)
+
+diff --git a/src/tools/examples/avtexamples/qtviswinExample.C b/src/tools/examples/avtexamples/qtviswinExample.C
+index 27c54fcd18..1b8d651c1d 100644
+--- a/src/tools/examples/avtexamples/qtviswinExample.C
++++ b/src/tools/examples/avtexamples/qtviswinExample.C
+@@ -5,6 +5,7 @@
+ #include <QtVisWindow.h>
+ 
+ #include <QApplication>
++#include <QSurfaceFormat>
+ 
+ #include <visit-config.h> // For LIB_VERSION_LE
+ #if LIB_VERSION_LE(VTK, 8,1,0)
+diff --git a/src/tools/examples/avtexamples/qtvtkExample.C b/src/tools/examples/avtexamples/qtvtkExample.C
+index 478e9842a9..41e19ff305 100644
+--- a/src/tools/examples/avtexamples/qtvtkExample.C
++++ b/src/tools/examples/avtexamples/qtvtkExample.C
+@@ -5,6 +5,7 @@
+ #include <GUIWindow2.h>
+ 
+ #include <QApplication>
++#include <QSurfaceFormat>
+ 
+ #include <visit-config.h> // For LIB_VERSION_LE
+ #if LIB_VERSION_LE(VTK,8,1,0)
+diff --git a/src/tools/examples/avtexamples/qvtkopenglExample.C b/src/tools/examples/avtexamples/qvtkopenglExample.C
+index f25cad6ed2..180c760fca 100644
+--- a/src/tools/examples/avtexamples/qvtkopenglExample.C
++++ b/src/tools/examples/avtexamples/qvtkopenglExample.C
+@@ -5,6 +5,7 @@
+ #include <GUIWindow.h>
+ 
+ #include <QApplication>
++#include <QSurfaceFormat>
+ 
+ #include <visit-config.h> // For LIB_VERSION_LE
+ #if LIB_VERSION_LE(VTK, 8,1,0)
+diff --git a/src/tools/examples/mcurvit/main.C b/src/tools/examples/mcurvit/main.C
+index bc5a54ed73..e877cc0099 100644
+--- a/src/tools/examples/mcurvit/main.C
++++ b/src/tools/examples/mcurvit/main.C
+@@ -4,6 +4,7 @@
+ 
+ #include <QApplication>
+ #include <QDir>
++#include <QSurfaceFormat>
+ 
+ #include <visit-config.h> // For LIB_VERSION_LE
+ #if LIB_VERSION_LE(VTK, 8,1,0)
+diff --git a/src/viewer/main/viewer.C b/src/viewer/main/viewer.C
+index ea7e1f3768..7b0b209f46 100644
+--- a/src/viewer/main/viewer.C
++++ b/src/viewer/main/viewer.C
+@@ -12,6 +12,7 @@
+ 
+ #include <qapplication.h>
+ #include <QStringList>
++#include <QSurfaceFormat>
+ 
+ #include <VisItViewer.h>
+ #include <AppearanceAttributes.h>
+-- 
+2.43.0
+

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -96,7 +96,7 @@ class Visit(CMakePackage):
     patch("cmake-findjpeg.patch", when="@3.1.0:3.2.2")
     patch("cmake-findjpeg-3.3.patch", when="@3.3.0")
     patch("0001-fix-missing-header-includes-for-QSurfaceFormat.patch", when="+gui")
-    
+
     # Fix pthread and librt link errors
     patch("visit32-missing-link-libs.patch", when="@3.2")
 

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -95,7 +95,8 @@ class Visit(CMakePackage):
     patch("cmake-findvtkh-3.3.patch", when="@3.3.0:3.3.2+vtkm")
     patch("cmake-findjpeg.patch", when="@3.1.0:3.2.2")
     patch("cmake-findjpeg-3.3.patch", when="@3.3.0")
-
+    patch("0001-fix-missing-header-includes-for-QSurfaceFormat.patch", when="+gui")
+    
     # Fix pthread and librt link errors
     patch("visit32-missing-link-libs.patch", when="@3.2")
 

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -95,7 +95,7 @@ class Visit(CMakePackage):
     patch("cmake-findvtkh-3.3.patch", when="@3.3.0:3.3.2+vtkm")
     patch("cmake-findjpeg.patch", when="@3.1.0:3.2.2")
     patch("cmake-findjpeg-3.3.patch", when="@3.3.0")
-    patch("0001-fix-missing-header-includes-for-QSurfaceFormat.patch", when="+gui")
+    patch("0001-fix-missing-header-includes-for-QSurfaceFormat.patch", when="@3.3.3+gui")
 
     # Fix pthread and librt link errors
     patch("visit32-missing-link-libs.patch", when="@3.2")

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -95,7 +95,7 @@ class Visit(CMakePackage):
     patch("cmake-findvtkh-3.3.patch", when="@3.3.0:3.3.2+vtkm")
     patch("cmake-findjpeg.patch", when="@3.1.0:3.2.2")
     patch("cmake-findjpeg-3.3.patch", when="@3.3.0")
-    # add missing QT header includes for the QSurfaceFormat class
+    # add missing QT header includes for the QSurfaceFormat class (needed to fix "incomplete type" compiler errors)
     patch("0001-fix-missing-header-includes-for-QSurfaceFormat.patch", when="@3.3.3+gui")
 
     # Fix pthread and librt link errors

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -95,7 +95,8 @@ class Visit(CMakePackage):
     patch("cmake-findvtkh-3.3.patch", when="@3.3.0:3.3.2+vtkm")
     patch("cmake-findjpeg.patch", when="@3.1.0:3.2.2")
     patch("cmake-findjpeg-3.3.patch", when="@3.3.0")
-    # add missing QT header includes for the QSurfaceFormat class (needed to fix "incomplete type" compiler errors)
+    # add missing QT header includes for the QSurfaceFormat class
+    # (needed to fix "incomplete type" compiler errors)
     patch("0001-fix-missing-header-includes-for-QSurfaceFormat.patch", when="@3.3.3+gui")
 
     # Fix pthread and librt link errors

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -95,6 +95,7 @@ class Visit(CMakePackage):
     patch("cmake-findvtkh-3.3.patch", when="@3.3.0:3.3.2+vtkm")
     patch("cmake-findjpeg.patch", when="@3.1.0:3.2.2")
     patch("cmake-findjpeg-3.3.patch", when="@3.3.0")
+    # add missing QT header includes for the QSurfaceFormat class
     patch("0001-fix-missing-header-includes-for-QSurfaceFormat.patch", when="@3.3.3+gui")
 
     # Fix pthread and librt link errors


### PR DESCRIPTION
This adds missing header includes for QSurfaceFormat that are needed to successfully build VisIt with `+gui`.

I have tested this builds and runs successfully on a Linux ARM64 laptop with:
`spack install visit@3.3.3~mfem~conduit%gcc@11.4.0 ^llvm~gold`

This also works:
`spack install visit@3.3.3~mfem~conduit%gcc@13.2.1 ^llvm~gold ^qt%gcc@11.4.0`.
(For some reason, qt does not build with any newer gcc.)

Fixes https://github.com/spack/spack/issues/40731.