### PR TITLE
perl-test-nowarnings: New package

### DIFF
--- a/var/spack/repos/builtin/packages/perl-test-nowarnings/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-nowarnings/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright 2023 EMBL-European Bioinformatics Institute
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTestNowarnings(PerlPackage):
+    """Make sure you didn't emit any warnings while testing"""
+
+    homepage = "https://metacpan.org/pod/Test::NoWarnings"
+    url = "https://cpan.metacpan.org/authors/id/H/HA/HAARG/Test-NoWarnings-1.06.tar.gz"
+
+    version("1.06", sha256="c2dc51143b7eb63231210e27df20d2c8393772e0a333547ec8b7a205ed62f737")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))

--- a/var/spack/repos/builtin/packages/perl-test-nowarnings/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-nowarnings/package.py
@@ -13,6 +13,8 @@ class PerlTestNowarnings(PerlPackage):
     homepage = "https://metacpan.org/pod/Test::NoWarnings"
     url = "https://cpan.metacpan.org/authors/id/H/HA/HAARG/Test-NoWarnings-1.06.tar.gz"
 
+    maintainers("EbiArnie")
+
     version("1.06", sha256="c2dc51143b7eb63231210e27df20d2c8393772e0a333547ec8b7a205ed62f737")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))


### PR DESCRIPTION
Adds Perl Test::NoWarnings
Package only has dependencies that come with Perl.