### PR TITLE
py-jupyterlab: Use the correct version dependency for jinja2

### DIFF
--- a/var/spack/repos/builtin/packages/py-jupyterlab/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyterlab/package.py
@@ -41,7 +41,7 @@ class PyJupyterlab(PythonPackage):
     depends_on("py-importlib-metadata@4.8.3:", when="@4: ^python@:3.9", type=("build", "run"))
     depends_on("py-importlib-resources@1.4:", when="@4: ^python@:3.8", type=("build", "run"))
     depends_on("py-ipykernel", when="@4:", type=("build", "run"))
-    depends_on("py-jinja2@3.0.3", when="@4:", type=("build", "run"))
+    depends_on("py-jinja2@3.0.3:", when="@4:", type=("build", "run"))
     depends_on("py-jupyter-core", when="@3:", type=("build", "run"))
     depends_on("py-jupyter-lsp@2:", when="@4:", type=("build", "run"))
     depends_on("py-jupyter-server@2.4:2", when="@4:", type=("build", "run"))


### PR DESCRIPTION
The jinja2 version should be open-ended as per the [juypterlab `pyproject.toml'](https://github.com/jupyterlab/jupyterlab/blob/1c2741f123c5a82603fb75fbc50ef3ff077a876c/pyproject.toml#L41)