### PR TITLE
intel-oneapi-compilers 2024.0.1: added new version to packages

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
@@ -36,7 +36,7 @@ class IntelOneapiCompilersClassic(Package):
         "2021.8.0": "2023.0.0",
         "2021.9.0": "2023.1.0",
         "2021.10.0": "2023.2.0",
-        "2021.11.0": "2024.0.0",
+        "2021.11.0": "2024.0.1",
     }.items():
         # prefer 2021.10.0 because it is the last one that has a C compiler
         version(ver, preferred=(ver == "2021.10.0"))

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -10,6 +10,17 @@ versions = [
     {
         "version": "2024.0.0",
         "cpp": {
+            "url": "https://registrationcenter-download.intel.com/akdlm//IRC_NAS/c68c8f0a-47f5-4f26-8e8e-fa2627271279/l_dpcpp-cpp-compiler_p_2024.0.1.29_offline.sh",
+            "sha256": "22497c46bfb916c82677489775c113141510423799b7eca35f35dffeb2a14104",
+        },
+        "ftn": {
+            "url": "https://registrationcenter-download.intel.com/akdlm//IRC_NAS/4eedf77e-e097-40de-b62d-5fb70efecb59/l_fortran-compiler_p_2024.0.1.31_offline.sh",
+            "sha256": "9d49ecc1862c60eb0627bfdd80d63a47118095af0ff5adeeda10ec36aaffc82c",
+        },
+    },
+    {
+        "version": "2024.0.0",
+        "cpp": {
             "url": "https://registrationcenter-download.intel.com/akdlm//IRC_NAS/5c8e686a-16a7-4866-b585-9cf09e97ef36/l_dpcpp-cpp-compiler_p_2024.0.0.49524_offline.sh",
             "sha256": "d10bad2009c98c631fbb834aae62012548daeefc806265ea567316cd9180a684",
         },

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -8,7 +8,7 @@ from spack.package import *
 
 versions = [
     {
-        "version": "2024.0.0",
+        "version": "2024.0.1",
         "cpp": {
             "url": "https://registrationcenter-download.intel.com/akdlm//IRC_NAS/c68c8f0a-47f5-4f26-8e8e-fa2627271279/l_dpcpp-cpp-compiler_p_2024.0.1.29_offline.sh",
             "sha256": "22497c46bfb916c82677489775c113141510423799b7eca35f35dffeb2a14104",


### PR DESCRIPTION
@rscohn2 