### PR TITLE
Remove deprecated `--spec-file` arg from tests

### DIFF
--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1210,7 +1210,7 @@ spack:
             dl_dir = working_dir.join("download_dir")
             if not os.path.exists(dl_dir.strpath):
                 os.makedirs(dl_dir.strpath)
-            buildcache_cmd("download", "--spec-file", json_path, "--path", dl_dir.strpath)
+            buildcache_cmd("download", "--spec", json_path, "--path", dl_dir.strpath)
             dl_dir_list = os.listdir(dl_dir.strpath)
 
             assert len(dl_dir_list) == 2


### PR DESCRIPTION
The `spack ci` tests were using the deprecated `--spec-file` argument, which should be replaced with `--spec`.