### PR TITLE
[bigdft] Enable building dynamic libraries

### DIFF
--- a/var/spack/repos/builtin/packages/bigdft-atlab/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-atlab/package.py
@@ -21,7 +21,9 @@ class BigdftAtlab(AutotoolsPackage):
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("openbabel", default=False, description="Enable detection of openbabel compilation")
-    variant("shared", default=True, description="Build shared libraries")  # Not default in bigdft, but is typically the default expectation
+    variant(
+        "shared", default=True, description="Build shared libraries"
+    )  # Not default in bigdft, but is typically the default expectation
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")

--- a/var/spack/repos/builtin/packages/bigdft-atlab/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-atlab/package.py
@@ -21,6 +21,7 @@ class BigdftAtlab(AutotoolsPackage):
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("openbabel", default=False, description="Enable detection of openbabel compilation")
+    variant("shared", default=True, description="Build shared libraries")  # Not default in bigdft, but is typically the default expectation
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
@@ -39,20 +40,31 @@ class BigdftAtlab(AutotoolsPackage):
         prefix = self.prefix
 
         fcflags = []
+        cflags = []
+        cxxflags = []
+
         if "+openmp" in spec:
             fcflags.append(self.compiler.openmp_flag)
 
+        if "+shared" in spec:
+            fcflags.append("-fPIC")
+            cflags.append("-fPIC")
+            cxxflags.append("-fPIC")
         if self.spec.satisfies("%gcc@10:"):
             fcflags.append("-fallow-argument-mismatch")
 
         args = [
             "FCFLAGS=%s" % " ".join(fcflags),
+            "CFLAGS=%s" % " ".join(cflags),
+            "CXXFLAGS=%s" % " ".join(cxxflags),
             "--with-futile-libs=%s" % spec["bigdft-futile"].libs.ld_flags,
             "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags + "/futile",
             "--with-moduledir=%s" % prefix.include,
             "--prefix=%s" % prefix,
             "--without-etsf-io",
         ]
+        if "+shared" in spec:
+            args.append("--enable-dynamic-libraries")
 
         if "+mpi" in spec:
             args.append("CC=%s" % spec["mpi"].mpicc)

--- a/var/spack/repos/builtin/packages/bigdft-atlab/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-atlab/package.py
@@ -48,7 +48,7 @@ class BigdftAtlab(AutotoolsPackage):
         if "+openmp" in spec:
             fcflags.append(self.compiler.openmp_flag)
 
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             fcflags.append("-fPIC")
             cflags.append("-fPIC")
             cxxflags.append("-fPIC")
@@ -65,7 +65,7 @@ class BigdftAtlab(AutotoolsPackage):
             "--prefix=%s" % prefix,
             "--without-etsf-io",
         ]
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             args.append("--enable-dynamic-libraries")
 
         if "+mpi" in spec:

--- a/var/spack/repos/builtin/packages/bigdft-chess/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-chess/package.py
@@ -23,7 +23,9 @@ class BigdftChess(AutotoolsPackage, CudaPackage):
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("scalapack", default=True, description="Enable SCALAPACK support")
     variant("ntpoly", default=False, description="Option to use NTPoly")
-    variant("shared", default=True, description="Build shared libraries")  # Not default in bigdft, but is typically the default expectation
+    variant(
+        "shared", default=True, description="Build shared libraries"
+    )  # Not default in bigdft, but is typically the default expectation
     # variant('minpack', default=False,  description='Give the link-line for MINPACK')
 
     depends_on("autoconf", type="build")

--- a/var/spack/repos/builtin/packages/bigdft-chess/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-chess/package.py
@@ -76,7 +76,7 @@ class BigdftChess(AutotoolsPackage, CudaPackage):
             "--prefix=%s" % prefix,
             "--without-etsf-io",
         ]
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             args.append("--enable-dynamic-libraries")
 
         if "+mpi" in spec:

--- a/var/spack/repos/builtin/packages/bigdft-chess/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-chess/package.py
@@ -23,6 +23,7 @@ class BigdftChess(AutotoolsPackage, CudaPackage):
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("scalapack", default=True, description="Enable SCALAPACK support")
     variant("ntpoly", default=False, description="Option to use NTPoly")
+    variant("shared", default=True, description="Build shared libraries")  # Not default in bigdft, but is typically the default expectation
     # variant('minpack', default=False,  description='Give the link-line for MINPACK')
 
     depends_on("autoconf", type="build")
@@ -73,6 +74,8 @@ class BigdftChess(AutotoolsPackage, CudaPackage):
             "--prefix=%s" % prefix,
             "--without-etsf-io",
         ]
+        if "+shared" in spec:
+            args.append("--enable-dynamic-libraries")
 
         if "+mpi" in spec:
             args.append("CC=%s" % spec["mpi"].mpicc)

--- a/var/spack/repos/builtin/packages/bigdft-core/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-core/package.py
@@ -90,7 +90,7 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
             "--prefix=%s" % prefix,
             "--without-etsf-io",
         ]
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             args.append("--enable-dynamic-libraries")
 
         if "+mpi" in spec:

--- a/var/spack/repos/builtin/packages/bigdft-core/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-core/package.py
@@ -23,6 +23,7 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("scalapack", default=True, description="Enable SCALAPACK support")
     variant("openbabel", default=False, description="Enable detection of openbabel compilation")
+    variant("shared", default=True, description="Build shared libraries")  # Not default in bigdft, but is typically the default expectation
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
@@ -87,6 +88,8 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
             "--prefix=%s" % prefix,
             "--without-etsf-io",
         ]
+        if "+shared" in spec:
+            args.append("--enable-dynamic-libraries")
 
         if "+mpi" in spec:
             args.append("CC=%s" % spec["mpi"].mpicc)

--- a/var/spack/repos/builtin/packages/bigdft-core/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-core/package.py
@@ -23,7 +23,9 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("scalapack", default=True, description="Enable SCALAPACK support")
     variant("openbabel", default=False, description="Enable detection of openbabel compilation")
-    variant("shared", default=True, description="Build shared libraries")  # Not default in bigdft, but is typically the default expectation
+    variant(
+        "shared", default=True, description="Build shared libraries"
+    )  # Not default in bigdft, but is typically the default expectation
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")

--- a/var/spack/repos/builtin/packages/bigdft-futile/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-futile/package.py
@@ -24,6 +24,7 @@ class BigdftFutile(AutotoolsPackage, CudaPackage):
 
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
+    variant("shared", default=True, description="Build shared libraries")  # Not default in bigdft, but is typically the default expectation
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
@@ -59,6 +60,8 @@ class BigdftFutile(AutotoolsPackage, CudaPackage):
             "--with-pyyaml-path=%s" % pyyaml,
             "--prefix=%s" % prefix,
         ]
+        if "+shared" in spec:
+            args.append("--enable-dynamic-libraries")
 
         if "+openmp" in spec:
             args.append("--with-openmp")

--- a/var/spack/repos/builtin/packages/bigdft-futile/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-futile/package.py
@@ -62,7 +62,7 @@ class BigdftFutile(AutotoolsPackage, CudaPackage):
             "--with-pyyaml-path=%s" % pyyaml,
             "--prefix=%s" % prefix,
         ]
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             args.append("--enable-dynamic-libraries")
 
         if "+openmp" in spec:

--- a/var/spack/repos/builtin/packages/bigdft-futile/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-futile/package.py
@@ -24,7 +24,9 @@ class BigdftFutile(AutotoolsPackage, CudaPackage):
 
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
-    variant("shared", default=True, description="Build shared libraries")  # Not default in bigdft, but is typically the default expectation
+    variant(
+        "shared", default=True, description="Build shared libraries"
+    )  # Not default in bigdft, but is typically the default expectation
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")

--- a/var/spack/repos/builtin/packages/bigdft-libabinit/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-libabinit/package.py
@@ -26,7 +26,9 @@ class BigdftLibabinit(AutotoolsPackage):
     depends_on("libtool", type="build")
 
     variant("mpi", default=True, description="Enable MPI support")
-    variant("shared", default=True, description="Build shared libraries")  # Not default in bigdft, but is typically the default expectation
+    variant(
+        "shared", default=True, description="Build shared libraries"
+    )  # Not default in bigdft, but is typically the default expectation
 
     depends_on("python@3.0:", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/bigdft-libabinit/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-libabinit/package.py
@@ -59,7 +59,7 @@ class BigdftLibabinit(AutotoolsPackage):
             "--with-moduledir=%s" % prefix.include,
             "--prefix=%s" % prefix,
         ]
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             args.append("--enable-dynamic-libraries")
 
         if "+mpi" in spec:

--- a/var/spack/repos/builtin/packages/bigdft-libabinit/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-libabinit/package.py
@@ -26,6 +26,7 @@ class BigdftLibabinit(AutotoolsPackage):
     depends_on("libtool", type="build")
 
     variant("mpi", default=True, description="Enable MPI support")
+    variant("shared", default=True, description="Build shared libraries")  # Not default in bigdft, but is typically the default expectation
 
     depends_on("python@3.0:", type=("build", "run"))
 
@@ -56,6 +57,8 @@ class BigdftLibabinit(AutotoolsPackage):
             "--with-moduledir=%s" % prefix.include,
             "--prefix=%s" % prefix,
         ]
+        if "+shared" in spec:
+            args.append("--enable-dynamic-libraries")
 
         if "+mpi" in spec:
             args.append("CC=%s" % spec["mpi"].mpicc)

--- a/var/spack/repos/builtin/packages/bigdft-psolver/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-psolver/package.py
@@ -23,6 +23,7 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("scalapack", default=True, description="Enable SCALAPACK support")
+    variant("shared", default=True, description="Build shared libraries")  # Not default in bigdft, but is typically the default expectation
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
@@ -69,6 +70,8 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
             "--prefix=%s" % prefix,
             "--without-etsf-io",
         ]
+        if "+shared" in spec:
+            args.append("--enable-dynamic-libraries")
 
         if "+mpi" in spec:
             args.append("CC=%s" % spec["mpi"].mpicc)

--- a/var/spack/repos/builtin/packages/bigdft-psolver/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-psolver/package.py
@@ -72,7 +72,7 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
             "--prefix=%s" % prefix,
             "--without-etsf-io",
         ]
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             args.append("--enable-dynamic-libraries")
 
         if "+mpi" in spec:

--- a/var/spack/repos/builtin/packages/bigdft-psolver/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-psolver/package.py
@@ -23,7 +23,9 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("scalapack", default=True, description="Enable SCALAPACK support")
-    variant("shared", default=True, description="Build shared libraries")  # Not default in bigdft, but is typically the default expectation
+    variant(
+        "shared", default=True, description="Build shared libraries"
+    )  # Not default in bigdft, but is typically the default expectation
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")

--- a/var/spack/repos/builtin/packages/bigdft-spred/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-spred/package.py
@@ -26,7 +26,9 @@ class BigdftSpred(AutotoolsPackage):
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("scalapack", default=True, description="Enable SCALAPACK support")
-    variant("shared", default=True, description="Build shared libraries")  # Not default in bigdft, but is typically the default expectation
+    variant(
+        "shared", default=True, description="Build shared libraries"
+    )  # Not default in bigdft, but is typically the default expectation
 
     depends_on("python@3.0:", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/bigdft-spred/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-spred/package.py
@@ -75,7 +75,7 @@ class BigdftSpred(AutotoolsPackage):
             "--with-moduledir=%s" % prefix.include,
             "--prefix=%s" % prefix,
         ]
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             args.append("--enable-dynamic-libraries")
 
         if "+mpi" in spec:

--- a/var/spack/repos/builtin/packages/bigdft-spred/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-spred/package.py
@@ -26,6 +26,7 @@ class BigdftSpred(AutotoolsPackage):
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("scalapack", default=True, description="Enable SCALAPACK support")
+    variant("shared", default=True, description="Build shared libraries")  # Not default in bigdft, but is typically the default expectation
 
     depends_on("python@3.0:", type=("build", "run"))
 
@@ -72,6 +73,8 @@ class BigdftSpred(AutotoolsPackage):
             "--with-moduledir=%s" % prefix.include,
             "--prefix=%s" % prefix,
         ]
+        if "+shared" in spec:
+            args.append("--enable-dynamic-libraries")
 
         if "+mpi" in spec:
             args.append("CC=%s" % spec["mpi"].mpicc)


### PR DESCRIPTION
This PR introduces the ability to build shared libraries for various BigDFT packages. 
A new variant 'shared' is added to the package specifications, which is set to True by default. 

If this variant is enabled, the '--enable-dynamic-libraries' option is added to the package configuration arguments.


Note: The 'shared' variant is enabled by default because most packages have the default behavior of building dynamic libraries, and most spack variants with the shared variant also make it default. This decision is open to feedback.