### PR TITLE
New package Model Coupling Toolkit (MCT)

### DIFF
--- a/var/spack/repos/builtin/packages/mct/package.py
+++ b/var/spack/repos/builtin/packages/mct/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Mct(AutotoolsPackage):
+    """Model Coupling Toolkit (MCT): toolkit to support the construction
+    of highly portable and extensible high-performance couplers for
+    distributed memory parallel coupled models."""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://github.com/MCSclimate/MCT"
+    url = "https://github.com/MCSclimate/MCT/archive/refs/tags/MCT_2.11.0.tar.gz"
+
+    maintainers("climbfuji")
+
+    # This is a custom license that doesn't match any of the ones listed
+    # in https://spdx.org/licenses/, but similar to Creative Commons?
+    license("https://github.com/MCSclimate/MCT/blob/master/LICENSE")
+
+    version("2.11.0", sha256="1b2a30bcba0081226ff1f1f5152e82afa3a2bb911215883965e669f776dcb365")
+    version("2.10.0", sha256="42f32e3ab8bba31d16a1c6c9533f717a9d950e42c9b03b864b3436335d4e1b71")
+
+    variant("mpi", default=True, description="Enable MPI support")
+
+    depends_on("mpi", when="+mpi")
+
+    def configure_args(self):
+        args = []
+        if self.spec.satisfies("~mpi"):
+            args.append("--enable-mpiserial")
+        return args

--- a/var/spack/repos/builtin/packages/mct/package.py
+++ b/var/spack/repos/builtin/packages/mct/package.py
@@ -11,7 +11,6 @@ class Mct(AutotoolsPackage):
     of highly portable and extensible high-performance couplers for
     distributed memory parallel coupled models."""
 
-    # FIXME: Add a proper url for your package's homepage here.
     homepage = "https://github.com/MCSclimate/MCT"
     url = "https://github.com/MCSclimate/MCT/archive/refs/tags/MCT_2.11.0.tar.gz"
 

--- a/var/spack/repos/builtin/packages/mct/package.py
+++ b/var/spack/repos/builtin/packages/mct/package.py
@@ -24,12 +24,4 @@ class Mct(AutotoolsPackage):
     version("2.11.0", sha256="1b2a30bcba0081226ff1f1f5152e82afa3a2bb911215883965e669f776dcb365")
     version("2.10.0", sha256="42f32e3ab8bba31d16a1c6c9533f717a9d950e42c9b03b864b3436335d4e1b71")
 
-    variant("mpi", default=True, description="Enable MPI support")
-
-    depends_on("mpi", when="+mpi")
-
-    def configure_args(self):
-        args = []
-        if self.spec.satisfies("~mpi"):
-            args.append("--enable-mpiserial")
-        return args
+    depends_on("mpi")


### PR DESCRIPTION
Adding a new package called MCT (Model Coupling Toolkit), developed by Argonne National Laboratory.

Built successfully on macOS using `apple-clang@13.1.6` and `openmpi@4.1.6`.

According to https://github.com/MCSclimate/MCT/blob/master/README, the package should support a non-mpi build, but I had issues with that (need to add more compiler flags, then errors during the install phase (nothing to install) etc.). We don't need that variant, and most other people exploring/using MCT for coupled models use MPI as well, therefore not coding this up.