### PR TITLE
Skip 'icc.patch' for py-gevent@23.7.0+

### DIFF
--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -39,7 +39,7 @@ class PyGevent(PythonPackage):
     conflicts("^py-cython@3:", when="@:20.5.0")
 
     # Deprecated compiler options. upstream PR: https://github.com/gevent/gevent/pull/1896
-    patch("icc.patch", when="%intel")
+    patch("icc.patch", when="@:21.12.0 %intel")
 
     @run_before("install")
     def recythonize(self):


### PR DESCRIPTION
## Description

Fixes https://github.com/spack/spack/issues/41567 (see issue for a description of the problem).

With this change, I was able to build `py-gevent@23.7.0` with `intel@2021.4.0`.