### PR TITLE
mysql: fix issue when using old core API call

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3128,9 +3128,7 @@ class Spec:
 
         except spack.error.UnsatisfiableSpecError as e:
             # Here, the DAG contains two instances of the same package
-            # with inconsistent constraints.  Users cannot produce
-            # inconsistent specs like this on the command line: the
-            # parser doesn't allow it. Spack must be broken!
+            # with inconsistent constraints.
             raise InconsistentSpecError("Invalid Spec DAG: %s" % e.message) from e
 
     def index(self, deptype="all"):

--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -191,5 +191,5 @@ class Mysql(CMakePackage):
             if int(cxxstd) > 14:
                 env.append_flags("CXXFLAGS", "-Wno-error=register")
 
-        if "python" in self.spec.flat_dependencies() and self.spec.satisfies("@:7"):
+        if "python" in self.spec and self.spec.satisfies("@:7"):
             self._fix_dtrace_shebang(env)


### PR DESCRIPTION
MySQL was performing a core API call to `Spec.flat_dependencies` when setting up the build environment. This function is an implementation detail of the old concretizer, where multiple nodes from the same package are not allowed.

This PR uses a more idiomatic way to check if `python` is in the DAG. For reference, see #11356 to check why the call was introduced.