### PR TITLE
fmt: Add patch to allow compilation with clang in CUDA mode

### DIFF
--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -84,6 +84,13 @@ class Fmt(CMakePackage):
         when="@9.0.0:9.1.0",
     )
 
+    # Fix compilation with clang in CUDA mode: https://github.com/fmtlib/fmt/issues/3740
+    patch(
+        "https://github.com/fmtlib/fmt/commit/89860eb9013a345608c8144b1aad5f12b0682d7e.patch?full_index=1",
+        sha256="6ef12fe60a2b3625139c6d29c748dafd81b51e2a0690c1fa37604ed5b15615e0",
+        when="@10.0.0:10.1.1",
+    )
+
     def cmake_args(self):
         spec = self.spec
         args = []


### PR DESCRIPTION
Backports https://github.com/fmtlib/fmt/pull/3751 to allow compilation of some fmt headers with clang in CUDA mode. The PR has been merged upstream so restricting the upper bound for the patch to the latest release of fmt (the issue starts with fmt 10.0.0).