### PR TITLE
perl-config-tiny: New package

### DIFF
--- a/var/spack/repos/builtin/packages/perl-config-tiny/package.py
+++ b/var/spack/repos/builtin/packages/perl-config-tiny/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright 2023 EMBL-European Bioinformatics Institute
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlConfigTiny(PerlPackage):
+    """Read/Write .ini style files with as little code as possible"""
+
+    homepage = "https://metacpan.org/pod/Config::Tiny"
+    url = "https://cpan.metacpan.org/authors/id/R/RS/RSAVAGE/Config-Tiny-2.30.tgz"
+
+    maintainers("EbiArnie")
+
+    version("2.30", sha256="b2f7345619b3b8e636dd39ea010731c9dc2bfb8f022bcbd86ae6ad17866e110d")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Config::Tiny; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
Adds Config::Tiny.
No dependencies outside of base Perl