### PR TITLE
New version for openCARP packages, v14.0

### DIFF
--- a/var/spack/repos/builtin/packages/meshtool/package.py
+++ b/var/spack/repos/builtin/packages/meshtool/package.py
@@ -16,6 +16,7 @@ class Meshtool(MakefilePackage):
 
     version("master", branch="master", preferred=True)
     # Version to use with openCARP releases
+    version("oc14.0", commit="867431d")
     version("oc13.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc12.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc11.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -46,6 +46,7 @@ class Opencarp(CMakePackage):
     version(
         "7.0", commit="78da91952738b45760bcbc34610814a83c8c6299", submodules=False, no_cache=True
     )
+    version("14.0", commit="a92e564a", submodules=False, no_cache=True, preferred=True)
     version("master", branch="master", submodules=False, no_cache=True)
 
     variant("carputils", default=False, description="Installs the carputils framework")
@@ -66,7 +67,7 @@ class Opencarp(CMakePackage):
     depends_on("py-carputils", when="+carputils", type=("build", "run"))
     depends_on("meshtool", when="+meshtool", type=("build", "run"))
     # Use specific versions of carputils and meshtool for releases
-    for ver in ["13.0", "12.0", "11.0", "10.0", "9.0", "8.2", "7.0", "8.1"]:
+    for ver in ["14.0", "13.0", "12.0", "11.0", "10.0", "9.0", "8.2", "7.0", "8.1"]:
         depends_on("py-carputils@oc" + ver, when="@" + ver + " +carputils")
         depends_on("meshtool@oc" + ver, when="@" + ver + " +meshtool")
 

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -17,6 +17,7 @@ class PyCarputils(PythonPackage):
 
     version("master", branch="master")
     # Version to use with openCARP releases
+    version("oc14.0", commit="50e2580b3f75711388eb55982a9b43871c3201f3")
     version("oc13.0", commit="216c3802c2ac2d14c739164dcd57f2e59aa2ede3")
     version("oc12.0", commit="4d7a1f0c604a2ad232e70cf9aa3a8daff5ffb195")
     version("oc11.0", commit="a02f9b846c6e852b7315b20e925d55c355f239b8")


### PR DESCRIPTION
Add a new version for the packages of the openCARP ecosystem, opencarp, meshtool and py-carputils.