### PR TITLE
python: don't run mkdirp in `setup_dependent_package`

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -856,6 +856,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         filter_file("build:opt --host_copt=-march=native", "", ".tf_configure.bazelrc")
 
     def build(self, spec, prefix):
+        mkdirp(python_platlib)
         tmp_path = env["TEST_TMPDIR"]
 
         # https://docs.bazel.build/versions/master/command-line-reference.html

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -856,6 +856,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
         filter_file("build:opt --host_copt=-march=native", "", ".tf_configure.bazelrc")
 
     def build(self, spec, prefix):
+        # Bazel needs the directory to exist on install
         mkdirp(python_platlib)
         tmp_path = env["TEST_TMPDIR"]
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1260,11 +1260,6 @@ print(json.dumps(config))
         module.python_platlib = join_path(dependent_spec.prefix, self.platlib)
         module.python_purelib = join_path(dependent_spec.prefix, self.purelib)
 
-        # Make the site packages directory for extensions
-        if dependent_spec.package.is_extension:
-            mkdirp(module.python_platlib)
-            mkdirp(module.python_purelib)
-
     def add_files_to_view(self, view, merge_map, skip_if_exists=True):
         bin_dir = self.spec.prefix.bin if sys.platform != "win32" else self.spec.prefix
         for src, dst in merge_map.items():


### PR DESCRIPTION
Extracted from #40773

`setup_dependent_package` is not a build phase, it should just set
globals for a package.

It's called during setup of runtime environment of packages, and there
have been reports of it actually failing on Slack.