### PR TITLE
hepmc3: fix from_variant -> self.define

### DIFF
--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -63,8 +63,8 @@ class Hepmc3(CMakePackage):
             py_ver = spec["python"].version.up_to(2)
             args.extend(
                 [
-                    from_variant("HEPMC3_PYTHON_VERSIONS", str(py_ver)),
-                    from_variant("HEPMC3_Python_SITEARCH" + py_ver.joined, python_platlib),
+                    self.define("HEPMC3_PYTHON_VERSIONS", str(py_ver)),
+                    self.define("HEPMC3_Python_SITEARCH" + py_ver.joined, python_platlib),
                 ]
             )
 

--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -64,7 +64,7 @@ class Hepmc3(CMakePackage):
             args.extend(
                 [
                     self.define("HEPMC3_PYTHON_VERSIONS", str(py_ver)),
-                    self.define("HEPMC3_Python_SITEARCH" + py_ver.joined, python_platlib),
+                    self.define("HEPMC3_Python_SITEARCH" + str(py_ver.joined), python_platlib),
                 ]
             )
 


### PR DESCRIPTION
Something happened in https://github.com/spack/spack/pull/38841 and what probably should have been `self.define` was mistakenly added as `from_variant`. This fixes the following KeyError for `+python`:
```
#41 1591.9 ==> Installing hepmc3-3.2.6-qg6pssvkeeimedqmsddeotulaei6s7mb [1/1]
#41 1591.9 ==> No binary for hepmc3-3.2.6-qg6pssvkeeimedqmsddeotulaei6s7mb found: installing from source
#41 1591.9 ==> Using cached archive: /var/cache/spack/_source-cache/archive/24/248f3b5b36dd773844cbe73d51f60891458334b986b259754c59dbf4bbf1d525.tar.gz
#41 1591.9 ==> No patches needed for hepmc3
#41 1591.9 ==> hepmc3: Executing phase: 'cmake'
#41 1591.9 ==> Error: KeyError: '"3.11" is not a variant of "hepmc3"'
#41 1591.9 
#41 1591.9 /opt/spack/lib/spack/spack/build_systems/cmake.py:426, in define_from_variant:
#41 1591.9         423            variant = cmake_var.lower()
#41 1591.9         424
#41 1591.9         425        if variant not in self.pkg.variants:
#41 1591.9   >>    426            raise KeyError('"{0}" is not a variant of "{1}"'.format(variant, self.pkg.name))
#41 1591.9         427
#41 1591.9         428        if variant not in self.pkg.spec.variants:
#41 1591.9         429            return ""
#41 1591.9
```