### PR TITLE
spack bootstrap --dev: EOL Python versions no longer supported

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -132,11 +132,14 @@ jobs:
     runs-on: ubuntu-latest
     container: registry.access.redhat.com/ubi8/ubi
     steps:
-    - name: Install dependencies
+    - name: Install System packages
       run: |
           dnf install -y \
               bzip2 curl file gcc-c++ gcc gcc-gfortran git gnupg2 gzip \
               make patch tcl unzip which xz
+    - name: Install Python packages
+      run: |
+          pip install --upgrade pytest
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # @v2
     - name: Setup repo and non-root user
       run: |

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -150,7 +150,7 @@ jobs:
       shell: runuser -u spack-test -- bash {0}
       run: |
           source share/spack/setup-env.sh
-          spack -d bootstrap now --dev
+          spack -d bootstrap now
           spack unit-test -k 'not cvs and not svn and not hg' -x --verbose
   # Test for the clingo based solver (using clingo-cffi)
   clingo-cffi:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -126,35 +126,6 @@ jobs:
       with:
         flags: shelltests,linux
 
-  # Test RHEL8 UBI with platform Python. This job is run
-  # only on PRs modifying core Spack
-  rhel8-platform-python:
-    runs-on: ubuntu-latest
-    container: registry.access.redhat.com/ubi8/ubi
-    steps:
-    - name: Install System packages
-      run: |
-          dnf install -y \
-              bzip2 curl file gcc-c++ gcc gcc-gfortran git gnupg2 gzip \
-              make patch tcl unzip which xz
-    - name: Install Python packages
-      run: |
-          pip install --upgrade pytest
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # @v2
-    - name: Setup repo and non-root user
-      run: |
-          git --version
-          git config --global --add safe.directory /__w/spack/spack
-          git fetch --unshallow
-          . .github/workflows/setup_git.sh
-          useradd spack-test
-          chown -R spack-test .
-    - name: Run unit tests
-      shell: runuser -u spack-test -- bash {0}
-      run: |
-          source share/spack/setup-env.sh
-          spack -d bootstrap now
-          spack unit-test -k 'not cvs and not svn and not hg' -x --verbose
   # Test for the clingo based solver (using clingo-cffi)
   clingo-cffi:
     runs-on: ubuntu-latest

--- a/.github/workflows/valid-style.yml
+++ b/.github/workflows/valid-style.yml
@@ -59,30 +59,3 @@ jobs:
     with:
       with_coverage: ${{ inputs.with_coverage }}
       python_version: '3.11'
-  # Check that spack can bootstrap the development environment on Python 3.6 - RHEL8
-  bootstrap-dev-rhel8:
-    runs-on: ubuntu-latest
-    container: registry.access.redhat.com/ubi8/ubi
-    steps:
-      - name: Install dependencies
-        run: |
-          dnf install -y \
-              bzip2 curl file gcc-c++ gcc gcc-gfortran git gnupg2 gzip \
-              make patch tcl unzip which xz
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # @v2
-      - name: Setup repo and non-root user
-        run: |
-          git --version
-          git config --global --add safe.directory /__w/spack/spack
-          git fetch --unshallow
-          . .github/workflows/setup_git.sh
-          useradd spack-test
-          chown -R spack-test .
-      - name: Bootstrap Spack development environment
-        shell: runuser -u spack-test -- bash {0}
-        run: |
-          source share/spack/setup-env.sh
-          spack debug report
-          spack -d bootstrap now --dev
-          spack style -t black
-          spack unit-test -V

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -444,6 +444,14 @@ def _now(args):
     with spack.bootstrap.ensure_bootstrap_configuration():
         spack.bootstrap.ensure_core_dependencies()
         if args.dev:
+            if sys.version_info < (3, 8):
+                llnl.util.tty.warn(
+                    "Spack does not support installing Python libraries with EOL versions of "
+                    "Python: https://devguide.python.org/versions/. If the install fails, try "
+                    "running Spack with a newer version of Python, or use pip to install the "
+                    "development dependencies, or use `@spackbot fix style` on your GitHub PR "
+                    "instead of `spack style` on the command line."
+                )
             spack.bootstrap.ensure_environment_dependencies()
 
 


### PR DESCRIPTION
As discussed in https://github.com/spack/spack/pull/41031#issuecomment-1852697475, we decided to no longer support `spack bootstrap --dev` for EOL Python versions. Users have many alternative options:

* Run `spack style` with a newer version of Python
* Use pip to install development dependencies
* Use `@spackbot fix style` on their PR instead

Note that bootstrapping clingo/gpg with EOL Python versions is still supported and expected to work.