### PR TITLE
directives: ensure all specs are parsed at import time

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -536,7 +536,7 @@ def conflicts(conflict_spec, when=None, msg=None):
             return
 
         # Save in a list the conflicts and the associated custom messages
-        when_spec_list = pkg.conflicts.setdefault(conflict_spec, [])
+        when_spec_list = pkg.conflicts.setdefault(spack.spec.Spec(conflict_spec), [])
         msg_with_name = f"{pkg.name}: {msg}" if msg is not None else msg
         when_spec_list.append((when_spec, msg_with_name))
 
@@ -966,7 +966,9 @@ def requires(*requirement_specs, policy="one_of", when=None, msg=None):
             return
 
         # Save in a list the requirements and the associated custom messages
-        when_spec_list = pkg.requirements.setdefault(tuple(requirement_specs), [])
+        when_spec_list = pkg.requirements.setdefault(
+            tuple(spack.spec.Spec(r) for r in requirement_specs), []
+        )
         msg_with_name = f"{pkg.name}: {msg}" if msg is not None else msg
         when_spec_list.append((when_spec, policy, msg_with_name))
 

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -46,7 +46,7 @@ def test_constraints_from_context(mock_packages):
     assert spack.spec.Spec("@1.0") in pkg_cls.dependencies["b"]
 
     assert pkg_cls.conflicts
-    assert (spack.spec.Spec("+foo@1.0"), None) in pkg_cls.conflicts["%gcc"]
+    assert (spack.spec.Spec("+foo@1.0"), None) in pkg_cls.conflicts[spack.spec.Spec("%gcc")]
 
 
 @pytest.mark.regression("26656")


### PR DESCRIPTION
Some metadata in packages are left as unparsed strings, which avoids any advance checking we might want to do to ensure that everything in our packages is a valid spec.

- [x] make sure all string metadata is parsed via the Spec constructor
- [x] store specs in dictionaries instead of strings

This adds about 6% overhead to importing all packages, so I'm not sure we want it, but it was useful for ensuring that all packages still had valid specs when we changed spec parsing.