### PR TITLE
NWChem: patch on variant fftw3; fix for #41577

### DIFF
--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -50,7 +50,7 @@ class Nwchem(Package):
     # https://github.com/nwchemgit/nwchem/commit/376f86f96eb982e83f10514e9dcd994564f973b4
     # https://github.com/nwchemgit/nwchem/commit/c89fc9d1eca6689bce12564a63fdea95d962a123
     # Prior versions of NWChem, including 7.0.2, were not able to link with FFTW
-    patch("fftw_splans.patch", when="@7.2.0")
+    patch("fftw_splans.patch", when="@7.2.0 +fftw3")
 
     depends_on("blas")
     depends_on("lapack")
@@ -66,7 +66,7 @@ class Nwchem(Package):
         scalapack = spec["scalapack"].libs
         lapack = spec["lapack"].libs
         blas = spec["blas"].libs
-        fftw = spec["fftw-api:double,float"].libs
+        fftw = spec["fftw-api:double,float"].libs if self.spec.satisfies("+fftw3") else ""
         # see https://nwchemgit.github.io/Compiling-NWChem.html
         args = []
         args.extend(

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -62,6 +62,8 @@ class Nwchem(Package):
     depends_on("python@3:3.9", type=("build", "link", "run"), when="@:7.0.2")
     depends_on("python@3", type=("build", "link", "run"), when="@7.2.0:")
 
+    # Is openmp an essential for blas/fftw provider with +openmp? Not very sure yet
+
     def install(self, spec, prefix):
         scalapack = spec["scalapack"].libs
         lapack = spec["lapack"].libs

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -62,8 +62,6 @@ class Nwchem(Package):
     depends_on("python@3:3.9", type=("build", "link", "run"), when="@:7.0.2")
     depends_on("python@3", type=("build", "link", "run"), when="@7.2.0:")
 
-    # Is openmp an essential for blas/fftw provider with +openmp? Not very sure yet
-
     def install(self, spec, prefix):
         scalapack = spec["scalapack"].libs
         lapack = spec["lapack"].libs


### PR DESCRIPTION
As #41577 requested, buggy lib finding fixed. 
Actually I have no idea why there occurs a +fftw3 variant in the package. Is there any demand for installing without fftw?
Also noticed in other packages like cp2k, blas/fftw with openmp support is strictly demanded while +openmp enabled; as I know little about if any restriction on them would cause unpredictable bugs as in elpa for some compilers, only a comment left here.