### PR TITLE
samtools: add v1.19

### DIFF
--- a/var/spack/repos/builtin/packages/bcftools/package.py
+++ b/var/spack/repos/builtin/packages/bcftools/package.py
@@ -13,9 +13,14 @@ class Bcftools(AutotoolsPackage):
     commands work transparently with both VCFs and BCFs, both
     uncompressed and BGZF-compressed."""
 
+    maintainers("jbeal-work")
+
     homepage = "https://samtools.github.io/bcftools/"
     url = "https://github.com/samtools/bcftools/releases/download/1.3.1/bcftools-1.3.1.tar.bz2"
 
+    version("1.19", sha256="782b5f1bc690415192231e82213b3493b047f45e630dc8ef6f154d6126ab3e68")
+    version("1.18", sha256="d9b9d36293e4cc62ab7473aa2539389d4e1de79b1a927d483f6e91f3c3ceac7e")
+    version("1.17", sha256="01f75d8e701d85b2c759172412009cc04f29b61616ace2fa75116123de4596cc")
     version("1.16", sha256="293010736b076cf684d2873928924fcc3d2c231a091084c2ac23a8045c7df982")
     version("1.15.1", sha256="f21f9564873eb27ccf22d13b91a64acb8fbbfe4f9e4c37933a54b9a95857f2d7")
     version("1.14", sha256="b7ef88ae89fcb55658c5bea2e8cb8e756b055e13860036d6be13756782aa19cb")
@@ -48,6 +53,9 @@ class Bcftools(AutotoolsPackage):
     depends_on("perl", when="@1.8:~perl-filters", type="run")
     depends_on("perl", when="@1.8:+perl-filters", type=("build", "run"))
 
+    depends_on("htslib@1.19", when="@1.19")
+    depends_on("htslib@1.18", when="@1.18")
+    depends_on("htslib@1.17", when="@1.17")
     depends_on("htslib@1.16", when="@1.16")
     depends_on("htslib@1.15", when="@1.15")
     depends_on("htslib@1.14", when="@1.14")

--- a/var/spack/repos/builtin/packages/htslib/package.py
+++ b/var/spack/repos/builtin/packages/htslib/package.py
@@ -14,6 +14,7 @@ class Htslib(AutotoolsPackage):
     homepage = "https://github.com/samtools/htslib"
     url = "https://github.com/samtools/htslib/releases/download/1.13/htslib-1.13.tar.bz2"
 
+    version("1.19", sha256="8751c40c4fa7d1f23a6864c5b20a73744f8be68239535ae7729c5f7d394d0736")
     version("1.18", sha256="f1ab53a593a2320a1bfadf4ef915dae784006c5b5c922c8a8174d7530a9af18f")
     version("1.17", sha256="763779288c40f07646ec7ad98b96c378c739171d162ad98398868783b721839f")
     version("1.16", sha256="606b7c7aff73734cf033ecd156f40529fa5792f54524952a28938ca0890d7924")

--- a/var/spack/repos/builtin/packages/samtools/package.py
+++ b/var/spack/repos/builtin/packages/samtools/package.py
@@ -16,6 +16,7 @@ class Samtools(Package):
     homepage = "https://www.htslib.org"
     url = "https://github.com/samtools/samtools/releases/download/1.13/samtools-1.13.tar.bz2"
 
+    version("1.19", sha256="fa6b3b18e20851b6f3cb55afaf3205d02fcb79dae3b849fcf52e8fc10ff08b83")
     version("1.18", sha256="d686ffa621023ba61822a2a50b70e85d0b18e79371de5adb07828519d3fc06e1")
     version("1.17", sha256="3adf390b628219fd6408f14602a4c4aa90e63e18b395dad722ab519438a2a729")
     version("1.16.1", sha256="2fa0a25f78594cf23d07c9d32d5060a14f1c5ee14d7b0af7a8a71abc9fdf1d07")
@@ -46,6 +47,7 @@ class Samtools(Package):
     depends_on("python", type="run")
 
     # htslib became standalone @1.3.1, must use corresponding version
+    depends_on("htslib@1.19", when="@1.19")
     depends_on("htslib@1.18", when="@1.18")
     depends_on("htslib@1.17", when="@1.17")
     depends_on("htslib@1.16", when="@1.16.1")


### PR DESCRIPTION
A new version of samtools was released yesterday. 

Brought bcftools up to date with the other packages.