### PR TITLE
Fix spack compiler wrappers in ESMF's esmf.mk on Cray when using cc, CC, ftn

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -136,6 +136,14 @@ class Esmf(MakefilePackage):
     # https://github.com/spack/spack/issues/35957
     patch("esmf_cpp_info.patch")
 
+    # This is strictly required on Cray systems that use
+    # the Cray compiler wrappers, where we need to swap
+    # out the spack compiler wrappers in esmf.mk with the
+    # Cray wrappers. It doesn't hurt/have any effect on
+    # other systems where the logic in setup_build_environment
+    # below sets the compilers to the MPI wrappers.
+    filter_compiler_wrappers("esmf.mk", relative_root="lib")
+
     # Make script from mvapich2.patch executable
     @when("@:7.0")
     @run_before("build")


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/41487. Thanks to @haampie pointing me in the right direction.

I tested this on the Navy Narwhal HPC.