### PR TITLE
Spack External Find: Dependencies

### DIFF
--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -53,6 +53,9 @@ def setup_parser(subparser):
     find_parser.add_argument(
         "--all", action="store_true", help="search for all packages that Spack knows about"
     )
+    find_parser.add_argument(
+        "--debug-find", action="store_true", help="write all candidate paths seached for externals to stdout"
+    )
     arguments.add_common_arguments(find_parser, ["tags", "jobs"])
     find_parser.add_argument("packages", nargs=argparse.REMAINDER)
     find_parser.epilog = (
@@ -134,7 +137,7 @@ def external_find(args):
         names=args.packages, tags=args.tags, exclude=args.exclude
     )
     detected_packages = spack.detection.by_path(
-        candidate_packages, path_hints=args.path, max_workers=args.jobs
+        candidate_packages, path_hints=args.path, max_workers=args.jobs, debug_find=args.debug_find
     )
 
     new_entries = spack.detection.update_configuration(

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -212,17 +212,15 @@ class Finder:
         self._report_search = debug_find
         super(Finder, self).__init__()
 
-
     def _log_status(self, pkg_name, candidates, results):
-        pkg_name = pkg_name.split(".")[1]
-        llnl.util.tty.info(f"Spack considered the following paths for external package {pkg_name}:")
+        name = pkg_name.split(".")[1]
+        llnl.util.tty.info(f"Spack considered the following paths for external package {name}:")
         [llnl.util.tty.info(f"\t{x}") for x in candidates]
         llnl.util.tty.info("\n")
         if results:
-            llnl.util.info(f"Spack found package at location(s):")
-            [llnl.util.tty.info("\t{x}" for x in results)]
+            llnl.util.tty.info(f"Spack found package {name} at location(s):")
+            [llnl.util.tty.info(f"{'spec: ':>8}{str(x.spec):34}{'prefix: '}{x.prefix}") for x in results]
             llnl.util.tty.info("\n")
-
 
     def default_path_hints(self) -> List[str]:
         return []
@@ -438,7 +436,6 @@ def by_path(
         llnl.util.tty.info("\tSupplied path hints:")
         if path_hints:
             [llnl.util.tty.info(f"\t\t{x}") for x in path_hints]
-        llnl.util.tty.info("\n")
 
     result = collections.defaultdict(list)
     with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor:


### PR DESCRIPTION
Spack's external find allows users to provide Spack with system packages as resolution for dependencies in DAGs that require such packages. However, currently the interface for this is a very direct expression of "attempt to find this package on system", whereas Spack's user interface is typically oriented around the user based expression of a top level spec to install, and Spack handles the details. This PR extends this UX philosophy to the external find command, allowing users to provide a spec to `spack external find`, for which Spack will attempt to detect each of the spec's dependencies on the system.