### PR TITLE
geant4: new version 11.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/g4abla/package.py
+++ b/var/spack/repos/builtin/packages/g4abla/package.py
@@ -18,6 +18,7 @@ class G4abla(Package):
     maintainers("drbenmorgan")
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version("3.3", sha256="1e041b3252ee9cef886d624f753e693303aa32d7e5ef3bba87b34f36d92ea2b1")
     version("3.1", sha256="7698b052b58bf1b9886beacdbd6af607adc1e099fc730ab6b21cf7f090c027ed")
     version("3.0", sha256="99fd4dcc9b4949778f14ed8364088e45fa4ff3148b3ea36f9f3103241d277014")
 

--- a/var/spack/repos/builtin/packages/g4emlow/package.py
+++ b/var/spack/repos/builtin/packages/g4emlow/package.py
@@ -18,6 +18,7 @@ class G4emlow(Package):
     maintainers("drbenmorgan")
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version("8.4", sha256="d87de4d2a364cb0a1e1846560525ffc3f735ccdeea8bc426d61775179aebbe8e")
     version("8.2", sha256="3d7768264ff5a53bcb96087604bbe11c60b7fea90aaac8f7d1252183e1a8e427")
     version("8.0", sha256="d919a8e5838688257b9248a613910eb2a7633059e030c8b50c0a2c2ad9fd2b3b")
     version("7.13", sha256="374896b649be776c6c10fea80abe6cf32f9136df0b6ab7c7236d571d49fb8c69")

--- a/var/spack/repos/builtin/packages/g4incl/package.py
+++ b/var/spack/repos/builtin/packages/g4incl/package.py
@@ -19,6 +19,7 @@ class G4incl(Package):
     maintainers("drbenmorgan")
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version("1.1", sha256="5d82e71db5f5a1b659937506576be58db7de7753ec5913128141ae7fce673b44")
     version("1.0", sha256="716161821ae9f3d0565fbf3c2cf34f4e02e3e519eb419a82236eef22c2c4367d")
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -18,6 +18,7 @@ class Geant4Data(BundlePackage):
 
     tags = ["hep"]
 
+    version("11.2.0")
     version("11.1.0")
     version("11.0.0")
     version("10.7.4")
@@ -42,6 +43,19 @@ class Geant4Data(BundlePackage):
     # they generally don't change on the patch level
     # Can move to declaring on a dataset basis if needed
     _datasets = {
+        "11.2.0:11.2": [
+            "g4ndl@4.7",
+            "g4emlow@8.4",
+            "g4photonevaporation@5.7",
+            "g4radioactivedecay@5.6",
+            "g4particlexs@4.0",
+            "g4pii@1.3",
+            "g4realsurface@2.2",
+            "g4saiddata@2.0",
+            "g4abla@3.3",
+            "g4incl@1.1",
+            "g4ensdfstate@2.3",
+        ],
         "11.1.0:11.1": [
             "g4ndl@4.7",
             "g4emlow@8.2",

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -89,8 +89,9 @@ class Geant4(CMakePackage):
         "10.7.2",
         "10.7.3",
         "10.7.4",
-        "11.0.0:11.0",
-        "11.1:",
+        "11.0",
+        "11.1",
+        "11.2:",
     ]:
         depends_on("geant4-data@" + _vers, type="run", when="@" + _vers)
 

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -148,7 +148,9 @@ class Geant4(CMakePackage):
     depends_on("libx11", when="+x11")
     depends_on("libxmu", when="+x11")
     depends_on("motif", when="+motif")
-    depends_on("qt@5: +opengl", when="+qt")
+    with when("+qt"):
+        depends_on("qt@5: +opengl")
+        depends_on("qt@5.9:", when="@11.2:")
 
     # As released, 10.0.4 has inconsistently capitalised filenames
     # in the cmake files; this patch also enables cxxstd 14

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -22,6 +22,7 @@ class Geant4(CMakePackage):
 
     maintainers("drbenmorgan")
 
+    version("11.2.0", sha256="9ff544739b243a24dac8f29a4e7aab4274fc0124fd4e1c4972018213dc6991ee")
     version("11.1.3", sha256="5d9a05d4ccf8b975649eab1d615fc1b8dce5937e01ab9e795bffd04149240db6")
     version("11.1.2", sha256="e9df8ad18c445d9213f028fd9537e174d6badb59d94bab4eeae32f665beb89af")
     version("11.1.1", sha256="c5878634da9ba6765ce35a469b2893044f4a6598aa948733da8436cdbfeef7d2")

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -114,7 +114,8 @@ class Geant4(CMakePackage):
 
     # Vecgeom specific versions for each Geant4 version
     with when("+vecgeom"):
-        depends_on("vecgeom@1.2.0:", when="@11.1:")
+        depends_on("vecgeom@1.2.6:", when="@11.2:")
+        depends_on("vecgeom@1.2.0:", when="@11.1")
         depends_on("vecgeom@1.1.18:1.1", when="@11.0.0:11.0")
         depends_on("vecgeom@1.1.8:1.1", when="@10.7.0:10.7")
         depends_on("vecgeom@1.1.5", when="@10.6.0:10.6")

--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -21,6 +21,7 @@ class Vecgeom(CMakePackage, CudaPackage):
     maintainers("drbenmorgan", "sethrj")
 
     version("master", branch="master")
+    version("1.2.6", sha256="e5162cf8adb67859dc4a111a81d1390d995895293e6ef1acf5f9d9834fd6d40e")
     version("1.2.5", sha256="d79ea05125e4d03c5605e5ea232994c500841d207b4543ac3d84758adddc15a9")
     version(
         "1.2.4",


### PR DESCRIPTION
New geant4 version 11.2.0, [release notes](https://geant4.web.cern.ch/download/release-notes/notes-v11.2.0.html), relevant here:
- New data versions for three data sets (g4able, g4emlow, g4incl)
- VecGeom 1.2.6 required
- Qt 5.9 required

Qt6 is now supported, but that support is not added with this PR (haven't gotten it to work yet in spack despite trying for a few weeks on the beta, mainly due to qmake virtual resolution issues).