### PR TITLE
pcre: ensure consistency between autotools and cmake builds

### DIFF
--- a/var/spack/repos/builtin/packages/pcre/package.py
+++ b/var/spack/repos/builtin/packages/pcre/package.py
@@ -43,7 +43,11 @@ class Pcre(AutotoolsPackage, CMakePackage):
     variant("shared", default=True, description="Build shared libraries")
     variant("static", default=True, description="Build static libraries")
     conflicts("-shared -static", msg="Must build one of shared and static")
-    conflicts("+shared +static", when="build_system=cmake", msg="CMake can only build either shared or static")
+    conflicts(
+        "+shared +static",
+        when="build_system=cmake",
+        msg="CMake can only build either shared or static",
+    )
 
     variant("pic", default=True, description="Enable position-independent code (PIC)")
     requires("+pic", when="+shared build_system=autotools")

--- a/var/spack/repos/builtin/packages/pcre/package.py
+++ b/var/spack/repos/builtin/packages/pcre/package.py
@@ -68,15 +68,15 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):
         args = []
 
-        self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
-        self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
+        args.extend(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+        args.extend(self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"))
 
-        args.define_from_variant("PCRE_SUPPORT_JIT", "jit")
+        args.extend(self.define_from_variant("PCRE_SUPPORT_JIT", "jit"))
 
-        args.define_from_variant("PCRE_BUILD_PCRE16", "multibyte")
-        args.define_from_variant("PCRE_BUILD_PCRE32", "multibyte")
+        args.extend(self.define_from_variant("PCRE_BUILD_PCRE16", "multibyte"))
+        args.extend(self.define_from_variant("PCRE_BUILD_PCRE32", "multibyte"))
 
-        args.define_from_variant("PCRE_SUPPORT_UTF", "utf")
-        args.define_from_variant("PCRE_SUPPORT_UNICODE_PROPERTIES", "utf")
+        args.extend(self.define_from_variant("PCRE_SUPPORT_UTF", "utf"))
+        args.extend(self.define_from_variant("PCRE_SUPPORT_UNICODE_PROPERTIES", "utf"))
 
         return args

--- a/var/spack/repos/builtin/packages/pcre/package.py
+++ b/var/spack/repos/builtin/packages/pcre/package.py
@@ -49,7 +49,7 @@ class Pcre(AutotoolsPackage, CMakePackage):
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
     def configure_args(self):
         args = []
-        
+
         args.extend(self.enable_or_disable("shared"))
         args.extend(self.with_or_without("pic"))
 

--- a/var/spack/repos/builtin/packages/pcre/package.py
+++ b/var/spack/repos/builtin/packages/pcre/package.py
@@ -41,8 +41,11 @@ class Pcre(AutotoolsPackage, CMakePackage):
     )
 
     variant("shared", default=True, description="Build shared libraries")
-    variant("pic", default=True, description="Enable position-independent code (PIC)")
+    variant("static", default=True, description="Build static libraries")
+    conflicts("-shared -static", msg="Must build one of shared and static")
+    conflicts("+shared +static", when="build_system=cmake", msg="CMake can only build either shared or static")
 
+    variant("pic", default=True, description="Enable position-independent code (PIC)")
     requires("+pic", when="+shared build_system=autotools")
 
 
@@ -51,6 +54,7 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
         args = []
 
         args.extend(self.enable_or_disable("shared"))
+        args.extend(self.enable_or_disable("static"))
         args.extend(self.with_or_without("pic"))
 
         args.extend(self.enable_or_disable("jit"))
@@ -68,15 +72,16 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):
         args = []
 
-        args.extend(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
-        args.extend(self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"))
+        args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+        args.append(self.define_from_variant("BUILD_STATIC_LIBS", "static"))
+        args.append(self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"))
 
-        args.extend(self.define_from_variant("PCRE_SUPPORT_JIT", "jit"))
+        args.append(self.define_from_variant("PCRE_SUPPORT_JIT", "jit"))
 
-        args.extend(self.define_from_variant("PCRE_BUILD_PCRE16", "multibyte"))
-        args.extend(self.define_from_variant("PCRE_BUILD_PCRE32", "multibyte"))
+        args.append(self.define_from_variant("PCRE_BUILD_PCRE16", "multibyte"))
+        args.append(self.define_from_variant("PCRE_BUILD_PCRE32", "multibyte"))
 
-        args.extend(self.define_from_variant("PCRE_SUPPORT_UTF", "utf"))
-        args.extend(self.define_from_variant("PCRE_SUPPORT_UNICODE_PROPERTIES", "utf"))
+        args.append(self.define_from_variant("PCRE_SUPPORT_UTF", "utf"))
+        args.append(self.define_from_variant("PCRE_SUPPORT_UNICODE_PROPERTIES", "utf"))
 
         return args


### PR DESCRIPTION
This PR adds two new variants: `pic` and `shared`. This is to address the discrepancy between the autotools and cmake builds due to differing default settings. While adding these two new variants, the logic of the other variants was rewritten to ensure that `--without` and `VARIABLE:BOOL=OFF` are also passed.

Here are the defaults without variants enabled: left = autotools, right = cmake
```
pcre-8.45 configuration summary:                                      -- PCRE-8.45 configuration summary:
                                                                      -- 
    Install prefix .................. : /usr/local                    --   Install prefix .................. : /usr/local
    C preprocessor .................. :                               --   C compiler ...................... : /usr/bin/cc
    C compiler ...................... : gcc                           --   C++ compiler .................... : /usr/bin/c++
    C++ preprocessor ................ : g++ -E                        --   C compiler flags ................ : 
    C++ compiler .................... : g++                           --   C++ compiler flags .............. : 
    Linker .......................... : /usr/bin/ld -m elf_x86_64     -- 
    C preprocessor flags ............ :                               
    C compiler flags ................ : -g -O2 -fvisibility=hidden    
    C++ compiler flags .............. : -O2 -fvisibility=hidden       
                                        -fvisibility-inlines-hidden   
    Linker flags .................... :                               
    Extra libraries ................. :                               
                                                                      
    Build 8 bit pcre library ........ : yes                           --   Build 8 bit PCRE library ........ : ON
    Build 16 bit pcre library ....... : no                            --   Build 16 bit PCRE library ....... : OFF
    Build 32 bit pcre library ....... : no                            --   Build 32 bit PCRE library ....... : OFF
    Build C++ library ............... : yes                           --   Build C++ library ............... : ON
    Enable JIT compiling support .... : no                            --   Enable JIT compiling support .... : OFF
    Enable UTF-8/16/32 support ...... : no                            --   Enable UTF support .............. : OFF
    Unicode properties .............. : no                            --   Unicode properties .............. : OFF
    Newline char/sequence ........... : lf                            --   Newline char/sequence ........... : LF
    \R matches only ANYCRLF ......... : no                            --   \R matches only ANYCRLF ......... : OFF
    EBCDIC coding ................... : no                            --   EBCDIC coding ................... : OFF
    EBCDIC code for NL .............. : n/a                           --   EBCDIC coding with NL=0x25 ...... : OFF
    Rebuild char tables ............. : no                            --   Rebuild char tables ............. : OFF
    Use stack recursion ............. : yes                           --   No stack recursion .............. : OFF
    POSIX mem threshold ............. : 10                            --   POSIX mem threshold ............. : 10
    Internal link size .............. : 2                             --   Internal link size .............. : 2
    Nested parentheses limit ........ : 250                           --   Parentheses nest limit .......... : 250
    Match limit ..................... : 10000000                      --   Match limit ..................... : 10000000
    Match limit recursion ........... : MATCH_LIMIT                   --   Match limit recursion ........... : MATCH_LIMIT
    Build shared libs ............... : yes                           --   Build shared libs ............... : OFF
    Build static libs ............... : yes                           --   Build static libs ............... : ON
                                                                      --   Build pcregrep .................. : ON
    Use JIT in pcregrep ............. : no                            --   Enable JIT in pcregrep .......... : ON
    Buffer size for pcregrep ........ : 20480                         --   Buffer size for pcregrep ........ : 20480
                                                                      --   Build tests (implies pcretest  .. : ON
                                                                      --                and pcregrep)
    Link pcregrep with libz ......... : no                            --   Link pcregrep with libz ......... : ON
    Link pcregrep with libbz2 ....... : no                            --   Link pcregrep with libbz2 ....... : ON
    Link pcretest with libedit ...... : no                            --   Link pcretest with libeditline .. : OFF
    Link pcretest with libreadline .. : no                            --   Link pcretest with libreadline .. : ON
    Valgrind support ................ : no                            --   Support Valgrind .................: OFF
    Code coverage ................... : no                            --   Support coverage .................: 
```
Differences:
- Autotools builds shared and static; cmake only builds static.
- Not shown here is that the autotools build defaults to `-fPIC`, while the cmake build doesn't.
- Autotools defaults to JIT off, while cmake defaults to JIT on.