### PR TITLE
xyce: Disable CMake test

### DIFF
--- a/var/spack/repos/builtin/packages/xyce/454-oneapi-xyce.patch
+++ b/var/spack/repos/builtin/packages/xyce/454-oneapi-xyce.patch
@@ -1,0 +1,13 @@
+diff --git a/src/LinearAlgebraServicesPKG/ksparse/alloc.c b/src/LinearAlgebraServicesPKG/ksparse/alloc.c
+index 320878d7817273269e8805acaa9f6f7a252443f1..af40b7e800e5e8b573a69608aae49c324f2a0253 100644
+--- a/src/LinearAlgebraServicesPKG/ksparse/alloc.c
++++ b/src/LinearAlgebraServicesPKG/ksparse/alloc.c
+@@ -53,6 +53,7 @@ Copyright 1990 Regents of the University of California.  All rights reserved.
+  */
+
+ void bye_bye(i)
++    int i;
+ {
+     printf ("inv = %d\n",1/i);
+ }
+

--- a/var/spack/repos/builtin/packages/xyce/package.py
+++ b/var/spack/repos/builtin/packages/xyce/package.py
@@ -143,17 +143,17 @@ class Xyce(CMakePackage):
         when="@7.4:7.6 +pymi",
     )
 
-     # fix oneapi issue
+    # fix oneapi issue
     patch(
         "454-oneapi-xyce.patch",
         sha256="8b81cabbb2eee3e98852f350463d0eff6a277bbb435095f4bd6d8f08cf1a4057",
-        when="%oneapi"
+        when="%oneapi",
     )
 
     # fix cmake not passing tests issue
     patch(
         "xyceCmake.patch",
-        sha256="4d47cd1f10607205e64910ac124c6dd329f1ecbf861416e9da24a1736f2149ff"
+        sha256="4d47cd1f10607205e64910ac124c6dd329f1ecbf861416e9da24a1736f2149ff",
     )
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/xyce/package.py
+++ b/var/spack/repos/builtin/packages/xyce/package.py
@@ -143,11 +143,10 @@ class Xyce(CMakePackage):
         when="@7.4:7.6 +pymi",
     )
 
-    # fix oneapi issue
+    # fix cmake not passing tests issue
     patch(
-        "454-oneapi-xyce.patch",
-        sha256="76a3ff987e43d1657f24d55cfd864b487876a72a9a7c8a37c3151a9b586a21c1",
-        when="%oneapi",
+        "xyceCmake.patch",
+        sha256="4d47cd1f10607205e64910ac124c6dd329f1ecbf861416e9da24a1736f2149ff"
     )
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/xyce/package.py
+++ b/var/spack/repos/builtin/packages/xyce/package.py
@@ -143,6 +143,13 @@ class Xyce(CMakePackage):
         when="@7.4:7.6 +pymi",
     )
 
+     # fix oneapi issue
+    patch(
+        "454-oneapi-xyce.patch",
+        sha256="8b81cabbb2eee3e98852f350463d0eff6a277bbb435095f4bd6d8f08cf1a4057",
+        when="%oneapi"
+    )
+
     # fix cmake not passing tests issue
     patch(
         "xyceCmake.patch",

--- a/var/spack/repos/builtin/packages/xyce/xyceCmake.patch
+++ b/var/spack/repos/builtin/packages/xyce/xyceCmake.patch
@@ -1,16 +1,3 @@
-diff --git a/src/LinearAlgebraServicesPKG/ksparse/alloc.c b/src/LinearAlgebraServicesPKG/ksparse/alloc.c
-index 320878d7817273269e8805acaa9f6f7a252443f1..af40b7e800e5e8b573a69608aae49c324f2a0253 100644
---- a/src/LinearAlgebraServicesPKG/ksparse/alloc.c
-+++ b/src/LinearAlgebraServicesPKG/ksparse/alloc.c
-@@ -53,6 +53,7 @@ Copyright 1990 Regents of the University of California.  All rights reserved.
-  */
- 
- void bye_bye(i)
-+    int i;
- {
-     printf ("inv = %d\n",1/i);
- }
-
 diff --git a/cmake/tps.cmake b/cmake/tps.cmake
 index 3732758f6..b3f00bb7a 100644
 --- a/cmake/tps.cmake


### PR DESCRIPTION
This splits the previous oneapi patch into 2,
One is implemented always, which removes a call to check_include_file_cxx that causes some builds of xyce to fail.
The other patch fixes a type issue for when xyce is compiled with oneapi, as described in pr https://github.com/spack/spack/pull/39429.
@eugeneswalker  



