### PR TITLE
legion: do not set HIP_PATH env variable

### DIFF
--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -186,6 +186,9 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
             if "+rocm" in self.spec:
                 options.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
                 options.append(self.define("CMAKE_C_COMPILER", self.spec["hip"].hipcc))
+                if "backend=legion" in self.spec:
+                    # CMake pulled in via find_package(Legion) won't work without this
+                    options.append(self.define("HIP_PATH", "{0}/hip".format(spec["hip"].prefix)))
             elif "+kokkos" in self.spec:
                 options.append(self.define("CMAKE_CXX_COMPILER", self.spec["kokkos"].kokkos_cxx))
         else:

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -268,11 +268,6 @@ class Legion(CMakePackage, ROCmPackage):
         description="Maximum number of nodes supported by Legion.",
     )
 
-    def setup_build_environment(self, build_env):
-        spec = self.spec
-        if "+rocm" in spec:
-            build_env.set("HIP_PATH", "{0}/hip".format(spec["hip"].prefix))
-
     def cmake_args(self):
         spec = self.spec
         cmake_cxx_flags = []
@@ -344,6 +339,7 @@ class Legion(CMakePackage, ROCmPackage):
             options.append(from_variant("Legion_HIP_TARGET", "hip_target"))
             options.append(from_variant("Legion_HIP_ARCH", "amdgpu_target"))
             options.append(from_variant("Legion_HIJACK_HIP", "hip_hijack"))
+            options.append(self.define("HIP_PATH", "{0}/hip".format(spec["hip"].prefix)))
 
         if "+fortran" in spec:
             # default is off.


### PR DESCRIPTION
Outcome of the COE hackathon at LLNL. Newer ROCm (like 5.7.1) don't like `HIP_PATH` environment variable to be set. However, given that Legion's CMake requires is for finding the legacy `FindHIP.cmake`, make use of the fact that the existing CMake logic allows you to also define it as `HIP_PATH` CMake cache variable without causing havoc during the actual build.