### PR TITLE
CMakeBuilder: avoid linking to system libraries

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -276,6 +276,15 @@ class CMakeBuilder(BaseBuilder):
             define("CMAKE_BUILD_TYPE", build_type),
         ]
 
+        # Avoid linking to system libraries
+        if pkg.spec.satisfies("^cmake@3.16:"):
+            args.extend(
+                [
+                    define("CMAKE_FIND_USE_CMAKE_SYSTEM_PATH", True),
+                    define("CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH", True),
+                ]
+            )
+
         # CMAKE_INTERPROCEDURAL_OPTIMIZATION only exists for CMake >= 3.9
         if pkg.spec.satisfies("^cmake@3.9:"):
             args.append(define("CMAKE_INTERPROCEDURAL_OPTIMIZATION", ipo))

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -280,8 +280,8 @@ class CMakeBuilder(BaseBuilder):
         if pkg.spec.satisfies("^cmake@3.16:"):
             args.extend(
                 [
-                    define("CMAKE_FIND_USE_CMAKE_SYSTEM_PATH", True),
-                    define("CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH", True),
+                    define("CMAKE_FIND_USE_CMAKE_SYSTEM_PATH", False),
+                    define("CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH", False),
                 ]
             )
 


### PR DESCRIPTION
Fixes #41299

Interested to see what breaks in CI. Not sure if these flags disable all of `PATH` or just system locations, we'll see.

@Chrismarsh