### PR TITLE
py-tables, py-carputils: python ecosystem dependency fixes

### DIFF
--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -30,7 +30,7 @@ class PyCarputils(PythonPackage):
 
     # cusettings:11: DeprecationWarning:
     # The distutils package is deprecated and slated for removal in Python 3.12.
-    conflicts("python@3.10:", when="@:oc13.0")
+    conflicts("python@3.12:", when="@:oc13.0")
 
     depends_on("py-numpy@1.14.5:", type=("build", "run"))
     depends_on("py-setuptools@41.6.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -30,7 +30,6 @@ class PyCarputils(PythonPackage):
 
     # cusettings:11: DeprecationWarning:
     # The distutils package is deprecated and slated for removal in Python 3.12.
-    conflicts("python@3.10:", when="@master")
     conflicts("python@3.10:", when="@:oc13.0")
 
     depends_on("py-numpy@1.14.5:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -28,6 +28,11 @@ class PyCarputils(PythonPackage):
 
     depends_on("git", type=("build", "run"))
 
+    # cusettings:11: DeprecationWarning:
+    # The distutils package is deprecated and slated for removal in Python 3.12.
+    conflicts("python@3.10:", when="@master")
+    conflicts("python@3.10:", when="@:oc13.0")
+
     depends_on("py-numpy@1.14.5:", type=("build", "run"))
     depends_on("py-setuptools@41.6.0:", type=("build", "run"))
     depends_on("py-python-dateutil@2.8.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-tables/package.py
+++ b/var/spack/repos/builtin/packages/py-tables/package.py
@@ -41,9 +41,9 @@ class PyTables(PythonPackage):
     # python 3.11 is supported only from version 3.8 onwards.
     # python 3.12 is supported only from version 3.9.1 onwards.
     # See https://github.com/PyTables/PyTables/releases/tag/v3.8.0
-    depends_on("python@3.6:3.10", when="@:3.7", type=("build", "run"))
-    depends_on("python@3.8:3.11", when="@3.8:3.9.0", type=("build", "run"))
     depends_on("python@3.8:", when="@3.9.1:", type=("build", "run"))
+    depends_on("python@3.8:3.11", when="@3.8:3.9.0", type=("build", "run"))
+    depends_on("python@3.6:3.10", when="@:3.7", type=("build", "run"))
 
     # requirements.txt
     depends_on("py-numpy@1.19:", when="@3.8:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-tables/package.py
+++ b/var/spack/repos/builtin/packages/py-tables/package.py
@@ -38,7 +38,12 @@ class PyTables(PythonPackage):
     depends_on("py-cython@0.21:", type="build")
 
     # setup.py
-    depends_on("python@3.8:", when="@3.8:", type=("build", "run"))
+    # python 3.11 is supported only from version 3.8 onwards.
+    # python 3.12 is supported only from version 3.9.1 onwards.
+    # See https://github.com/PyTables/PyTables/releases/tag/v3.8.0
+    depends_on("python@3.6:3.10", when="@:3.7", type=("build", "run"))
+    depends_on("python@3.8:3.11", when="@3.8:3.9.0", type=("build", "run"))
+    depends_on("python@3.8:", when="@3.9.1:", type=("build", "run"))
 
     # requirements.txt
     depends_on("py-numpy@1.19:", when="@3.8:", type=("build", "run"))


### PR DESCRIPTION
This PR fixes python a few python ecosystem problems identified in #41370.

The py-tables package's python requirements are too open currently, the developers explicitly state in their release notes that they drop support for older pythons and add newer versions only for set versions, namely:
+ version 3.8 drops support for python 3.6 and 3.7
+ version 3.8 adds support for python 3.11
+ version 3.9.1 has working support for python 3.12.

py-carputils also relies on a deprecated feature, which is removed is python 3.12