### PR TITLE
perl-test-file-sharedir: New package, update deps

### DIFF
--- a/var/spack/repos/builtin/packages/perl-file-sharedir/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-sharedir/package.py
@@ -12,6 +12,17 @@ class PerlFileSharedir(PerlPackage):
     homepage = "https://metacpan.org/pod/File::ShareDir"
     url = "https://cpan.metacpan.org/authors/id/R/RE/REHSACK/File-ShareDir-1.118.tar.gz"
 
+    maintainers("EbiArnie")
+
     version("1.118", sha256="3bb2a20ba35df958dc0a4f2306fc05d903d8b8c4de3c8beefce17739d281c958")
 
-    # depends_on("perl-module-build", type="build")
+    depends_on("perl-class-inspector@1.12:", type=("build", "run", "test"))
+    depends_on("perl-file-sharedir-install@0.13:", type=("build", "link"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use File::ShareDir; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-file-sharedir/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-file-sharedir/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright 2023 EMBL-European Bioinformatics Institute
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTestFileSharedir(PerlPackage):
+    """Create a Fake ShareDir for your modules for testing."""
+
+    homepage = "https://metacpan.org/pod/Test::File::ShareDir"
+    url = "https://cpan.metacpan.org/authors/id/K/KE/KENTNL/Test-File-ShareDir-1.001002.tar.gz"
+
+    maintainers("EbiArnie")
+
+    version("1.001002", sha256="b33647cbb4b2f2fcfbde4f8bb4383d0ac95c2f89c4c5770eb691f1643a337aad")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-class-tiny", type=("build", "run", "test"))
+    depends_on("perl-file-copy-recursive", type=("build", "run", "test"))
+    depends_on("perl-file-sharedir@1.00:", type=("build", "run", "test"))
+    depends_on("perl-path-tiny@0.018:", type=("build", "run", "test"))
+    depends_on("perl-scope-guard", type=("build", "run", "test"))
+    depends_on("perl-test-fatal", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Test::File::ShareDir; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
Adds perl-test-file-sharedir, updates perl-file-sharedir to allow for build-time tests