### PR TITLE
gromacs: Add nvshmem dependencies for cufftmp variant

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/cufftmp-cmake-add-nvshmem.patch
+++ b/var/spack/repos/builtin/packages/gromacs/cufftmp-cmake-add-nvshmem.patch
@@ -1,0 +1,62 @@
+diff -uNr a/cmake/FindcuFFTMp.cmake b/cmake/FindcuFFTMp.cmake
+--- a/cmake/FindcuFFTMp.cmake	2023-12-14 07:31:29.905756661 +0000
++++ b/cmake/FindcuFFTMp.cmake	2023-12-14 09:45:29.270603244 +0000
+@@ -34,8 +34,10 @@
+ # - Find cuFFTMp, NVIDIA's FFT library for multi-GPU multi-node
+ #
+ # This script does define cache variables
+-#   CUFFTMP_INCLUDE_DIR    - Location of cuFFTMP's include directory.
+-#   CUFFTMP_LIBRARY        - Location of cuFFTMP's libraries
++#   cuFFTMp_INCLUDE_DIR     - Location of cuFFTMP's include directory.
++#   cuFFTMp_LIBRARY         - cuFFTMP library
++#   cuFFTMp_NVSHMEM_LIBRARY - nvshmem library to use with cuFFTMP
++#   cuFFTMp_NVSHMEM_HOST_LIBRARY nvshmem_host library to use with cuFFTMP
+ #
+ # If your cuFFTMp installation is not in a standard installation
+ # directory, you may provide a hint to where it may be found. Simply
+@@ -73,6 +75,33 @@
+     ${PC_cuFFTMp_LIBRARY_DIRS}
+     )
+
++# cufftmp depends on a particular NVSHEM
++#
++# TODO: If nvhpc is used cuFFTMp_NVSHMEM_ROOT_DIR could be derived from
++# cuFFTMp_ROOT_DIR and the CUDA version used.
++#
++find_path(cuFFTMp_NVSHMEM_ROOT_DIR
++    NAMES
++    include/nvshmem.h
++    HINTS
++    ${cuFFTMp_NVSHMEM_ROOT}
++    DOC "cuFFTMp-compatible NVSHMEM root directory.")
++
++find_library(cuFFTMp_NVSHMEM_LIBRARY
++    NAMES nvshmem
++    HINTS
++    ${cuFFTMp_NVSHMEM_ROOT_DIR}/lib64
++    ${cuFFTMp_NVSHMEM_ROOT_DIR}/lib
++)
++
++# nvshmem seem to depend on nvshmem_host
++find_library(cuFFTMp_NVSHMEM_HOST_LIBRARY
++    NAMES nvshmem_host
++    HINTS
++    ${cuFFTMp_NVSHMEM_ROOT_DIR}/lib64
++    ${cuFFTMp_NVSHMEM_ROOT_DIR}/lib
++)
++
+ # handle the QUIETLY and REQUIRED arguments and set cuFFTMp_FOUND to TRUE if
+ # all listed variables are TRUE
+ include(FindPackageHandleStandardArgs)
+diff -uNr a/src/gromacs/CMakeLists.txt b/src/gromacs/CMakeLists.txt
+--- a/src/gromacs/CMakeLists.txt	2023-12-14 07:31:29.846750717 +0000
++++ b/src/gromacs/CMakeLists.txt	2023-12-14 08:29:03.422645290 +0000
+@@ -185,6 +185,8 @@
+     #we cannot link with both cufftmp and cufft
+     if(GMX_USE_cuFFTMp)
+         target_link_libraries(libgromacs PRIVATE ${cuFFTMp_LIBRARY})
++	target_link_libraries(libgromacs PRIVATE ${cuFFTMp_NVSHMEM_LIBRARY})
++	target_link_libraries(libgromacs PRIVATE ${cuFFTMp_NVSHMEM_HOST_LIBRARY})
+     else()
+         target_link_libraries(libgromacs PRIVATE ${CUDA_CUFFT_LIBRARIES})
+     endif()

--- a/var/spack/repos/builtin/packages/gromacs/cufftmp-cmake-add-nvshmem.patch
+++ b/var/spack/repos/builtin/packages/gromacs/cufftmp-cmake-add-nvshmem.patch
@@ -1,7 +1,29 @@
+diff -uNr a/api/nblib/samples/CMakeLists.txt b/api/nblib/samples/CMakeLists.txt
+--- a/api/nblib/samples/CMakeLists.txt	2023-10-19 08:40:00.000000000 +0000
++++ b/api/nblib/samples/CMakeLists.txt	2023-12-18 09:41:22.050209780 +0000
+@@ -39,12 +39,16 @@
+ set(argon "argon-forces-integration")
+ add_executable(${argon} argon-forces-integration.cpp)
+ 
+-target_link_libraries(${argon} PRIVATE nblib)
++target_link_libraries(${argon} PRIVATE
++		      nblib
++		      ${GMX_EXE_LINKER_FLAGS})
+ 
+ set(methane "methane-water-integration")
+ add_executable(${methane} methane-water-integration.cpp)
+ 
+-target_link_libraries(${methane} PRIVATE nblib)
++target_link_libraries(${methane} PRIVATE
++		      nblib
++		      ${GMX_EXE_LINKER_FLAGS})
+ 
+ if(BUILD_TESTING)
+     add_test(NAME NbLibSamplesTestArgon COMMAND ${argon})
 diff -uNr a/cmake/FindcuFFTMp.cmake b/cmake/FindcuFFTMp.cmake
---- a/cmake/FindcuFFTMp.cmake	2023-12-14 07:31:29.905756661 +0000
-+++ b/cmake/FindcuFFTMp.cmake	2023-12-14 09:45:29.270603244 +0000
-@@ -34,8 +34,10 @@
+--- a/cmake/FindcuFFTMp.cmake	2023-10-19 08:40:00.000000000 +0000
++++ b/cmake/FindcuFFTMp.cmake	2023-12-15 17:12:53.849274758 +0000
+@@ -34,8 +34,11 @@
  # - Find cuFFTMp, NVIDIA's FFT library for multi-GPU multi-node
  #
  # This script does define cache variables
@@ -11,13 +33,14 @@ diff -uNr a/cmake/FindcuFFTMp.cmake b/cmake/FindcuFFTMp.cmake
 +#   cuFFTMp_LIBRARY         - cuFFTMP library
 +#   cuFFTMp_NVSHMEM_LIBRARY - nvshmem library to use with cuFFTMP
 +#   cuFFTMp_NVSHMEM_HOST_LIBRARY nvshmem_host library to use with cuFFTMP
++#   cuFFTMp_NVIDIA_ML_LIBRARY nvidia_ml library to use with cuFFTMP
  #
  # If your cuFFTMp installation is not in a standard installation
  # directory, you may provide a hint to where it may be found. Simply
-@@ -73,6 +75,33 @@
+@@ -73,6 +76,44 @@
      ${PC_cuFFTMp_LIBRARY_DIRS}
      )
-
+ 
 +# cufftmp depends on a particular NVSHEM
 +#
 +# TODO: If nvhpc is used cuFFTMp_NVSHMEM_ROOT_DIR could be derived from
@@ -37,7 +60,7 @@ diff -uNr a/cmake/FindcuFFTMp.cmake b/cmake/FindcuFFTMp.cmake
 +    ${cuFFTMp_NVSHMEM_ROOT_DIR}/lib
 +)
 +
-+# nvshmem seem to depend on nvshmem_host
++# nvshmem seems to depend on nvshmem_host
 +find_library(cuFFTMp_NVSHMEM_HOST_LIBRARY
 +    NAMES nvshmem_host
 +    HINTS
@@ -45,18 +68,30 @@ diff -uNr a/cmake/FindcuFFTMp.cmake b/cmake/FindcuFFTMp.cmake
 +    ${cuFFTMp_NVSHMEM_ROOT_DIR}/lib
 +)
 +
++pkg_check_modules(PC_nvidia_ml QUIET nvidia-ml)
++
++# nvshmem_host seems to depend on nvidia-ml
++string(TOLOWER ${CMAKE_SYSTEM_NAME} cuFFTMp_SYSTEM_NAME_LOWER)
++find_library(cuFFTMp_NVIDIA_ML_LIBRARY
++    NAMES nvidia-ml
++    HINTS
++    PC_nvidia_ml_LIBRARY_DIRS
++    ${CUDA_TOOLKIT_ROOT_DIR}/targets/${CMAKE_SYSTEM_PROCESSOR}-${cuFFTMp_SYSTEM_NAME_LOWER}/lib/stubs
++)
++
  # handle the QUIETLY and REQUIRED arguments and set cuFFTMp_FOUND to TRUE if
  # all listed variables are TRUE
  include(FindPackageHandleStandardArgs)
 diff -uNr a/src/gromacs/CMakeLists.txt b/src/gromacs/CMakeLists.txt
---- a/src/gromacs/CMakeLists.txt	2023-12-14 07:31:29.846750717 +0000
-+++ b/src/gromacs/CMakeLists.txt	2023-12-14 08:29:03.422645290 +0000
-@@ -185,6 +185,8 @@
+--- a/src/gromacs/CMakeLists.txt	2023-10-19 08:40:00.000000000 +0000
++++ b/src/gromacs/CMakeLists.txt	2023-12-15 23:47:00.182314220 +0000
+@@ -185,6 +185,9 @@
      #we cannot link with both cufftmp and cufft
      if(GMX_USE_cuFFTMp)
          target_link_libraries(libgromacs PRIVATE ${cuFFTMp_LIBRARY})
 +	target_link_libraries(libgromacs PRIVATE ${cuFFTMp_NVSHMEM_LIBRARY})
 +	target_link_libraries(libgromacs PRIVATE ${cuFFTMp_NVSHMEM_HOST_LIBRARY})
++	target_link_libraries(libgromacs PRIVATE ${cuFFTMp_NVIDIA_ML_LIBRARY})
      else()
          target_link_libraries(libgromacs PRIVATE ${CUDA_CUFFT_LIBRARIES})
      endif()

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -551,9 +551,9 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             # This currently requires the NVIDIA device drivers to be installed on the build
             # machine to fulfill nvshmem_host's dependency on nvidia-ml.
             options.append(
-                f'-DcuFFTMp_NVSHMEM_ROOT={self.spec["nvhpc"].prefix}/Linux_{self.spec.target.family}'
-                + f'/{self.spec["nvhpc"].version}/comm_libs/{self.spec["cuda"].version.up_to(2)}'
-                + f"/nvshmem_cufftmp_compat"
+                f'-DcuFFTMp_NVSHMEM_ROOT={self.spec["nvhpc"].prefix}/'
+                + f'Linux_{self.spec.target.family}/{self.spec["nvhpc"].version}'
+                + f'/comm_libs/{self.spec["cuda"].version.up_to(2)}/nvshmem_cufftmp_compat'
             )
 
         if "+heffte" in self.spec:

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -1,4 +1,4 @@
-e# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -555,6 +555,14 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
                 + f'Linux_{self.spec.target.family}/{self.spec["nvhpc"].version}'
                 + f'/comm_libs/{self.spec["cuda"].version.up_to(2)}/nvshmem_cufftmp_compat'
             )
+            # The stub directories included in the Cuda Toolkit are
+            # internally versioned but not linked/name after their
+            # SONAME version. When compiling an executable the linker
+            # wants to load the versioned libraries and will fail for
+            # libnvidia.so.<VER> unless we relax this
+            # requirment. Unfortunately this relaxes this for all
+            # libraries.
+            options.append("-DGMX_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined")
 
         if "+heffte" in self.spec:
             options.append("-DGMX_USE_HEFFTE=on")

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+e# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -547,17 +547,13 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
                 f'-DcuFFTMp_ROOT={self.spec["nvhpc"].prefix}/Linux_{self.spec.target.family}'
                 + f'/{self.spec["nvhpc"].version}/math_libs'
             )
-            options.append(
-                f'-DcuFFTMp_ROOT={self.spec["nvhpc"].prefix}/Linux_{self.spec.target.family}'
-                + f'/{self.spec["nvhpc"].version}/math_libs'
-            )
             # Add option to include cufft-mp's nvhshmem dependency.
             # This currently requires the NVIDIA device drivers to be installed on the build
             # machine to fulfill nvshmem_host's dependency on nvidia-ml.
             options.append(
                 f'-DcuFFTMp_NVSHMEM_ROOT={self.spec["nvhpc"].prefix}/Linux_{self.spec.target.family}'
                 + f'/{self.spec["nvhpc"].version}/comm_libs/{self.spec["cuda"].version.up_to(2)}'
-                + f'/nvshmem_cufftmp_compat'
+                + f"/nvshmem_cufftmp_compat"
             )
 
         if "+heffte" in self.spec:

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -544,20 +544,20 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         if "+cufftmp" in self.spec:
             options.append("-DGMX_USE_CUFFTMP=ON")
             options.append(
-                f'-DcuFFTMp_ROOT={self.spec["nvhpc"].prefix}/Linux_{self.spec.target.family}' +
-                f'/{self.spec["nvhpc"].version}/math_libs'
+                f'-DcuFFTMp_ROOT={self.spec["nvhpc"].prefix}/Linux_{self.spec.target.family}'
+                + f'/{self.spec["nvhpc"].version}/math_libs'
             )
             options.append(
-                f'-DcuFFTMp_ROOT={self.spec["nvhpc"].prefix}/Linux_{self.spec.target.family}' +
-                f'/{self.spec["nvhpc"].version}/math_libs'
+                f'-DcuFFTMp_ROOT={self.spec["nvhpc"].prefix}/Linux_{self.spec.target.family}'
+                + f'/{self.spec["nvhpc"].version}/math_libs'
             )
             # Add option to include cufft-mp's nvhshmem dependency.
             # This currently requires the NVIDIA device drivers to be installed on the build
             # machine to fulfill nvshmem_host's dependency on nvidia-ml.
             options.append(
-                f'-DcuFFTMp_NVSHMEM_ROOT={self.spec["nvhpc"].prefix}/Linux_{self.spec.target.family}' +
-                f'/{self.spec["nvhpc"].version}/comm_libs/{self.spec["cuda"].version.up_to(2)}' +
-                f'/nvshmem_cufftmp_compat'
+                f'-DcuFFTMp_NVSHMEM_ROOT={self.spec["nvhpc"].prefix}/Linux_{self.spec.target.family}'
+                + f'/{self.spec["nvhpc"].version}/comm_libs/{self.spec["cuda"].version.up_to(2)}'
+                + f'/nvshmem_cufftmp_compat'
             )
 
         if "+heffte" in self.spec:


### PR DESCRIPTION
Workaround for the issue mentioned on
https://manual.gromacs.org/current/install-guide/index.html#using-cufftmp

This PR is using a different solution than proposed in the link in order to get the rpath set to the nvshmem libraries.

Note that nvshmem_host requires nvidia-ml and I've only tested this patch with nvidia-ml available on the build machine via installation of the NVIDIA drivers. I'll try to follow up with a PR that uses  stubs/libnvidia-ml.so in the cuda package instead to avoid this external build-time dependency.

(Testing has been limited to cuda 11.8.0 and 12.2.1 and nvhpc 23.9)