### PR TITLE
perl-datetime-format-strptime: New package

### DIFF
--- a/var/spack/repos/builtin/packages/perl-b-hooks-endofscope/package.py
+++ b/var/spack/repos/builtin/packages/perl-b-hooks-endofscope/package.py
@@ -12,7 +12,19 @@ class PerlBHooksEndofscope(PerlPackage):
     homepage = "https://metacpan.org/pod/B::Hooks::EndOfScope"
     url = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/B-Hooks-EndOfScope-0.21.tar.gz"
 
+    maintainers("EbiArnie")
+
     version("0.26", sha256="39df2f8c007a754672075f95b90797baebe97ada6d944b197a6352709cb30671")
     version("0.21", sha256="90f3580880f1d68b843c142cc86f58bead1f3e03634c63868ac9eba5eedae02c")
 
-    depends_on("perl-sub-exporter-progressive", type=("build", "run"))
+    depends_on("perl@5.6.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-module-implementation@0.05:", type=("build", "run", "test"))
+    depends_on("perl-sub-exporter-progressive@0.001006:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use B::Hooks::EndOfScope; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-class-singleton/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-singleton/package.py
@@ -12,4 +12,16 @@ class PerlClassSingleton(PerlPackage):
     homepage = "https://metacpan.org/pod/Class::Singleton"
     url = "https://cpan.metacpan.org/authors/id/S/SH/SHAY/Class-Singleton-1.6.tar.gz"
 
+    maintainers("EbiArnie")
+
     version("1.6", sha256="27ba13f0d9512929166bbd8c9ef95d90d630fc80f0c9a1b7458891055e9282a4")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Class::Singleton; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-datetime-format-strptime/package.py
+++ b/var/spack/repos/builtin/packages/perl-datetime-format-strptime/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright 2023 EMBL-European Bioinformatics Institute
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlDatetimeFormatStrptime(PerlPackage):
+    """Parse and format strp and strf time patterns"""
+
+    homepage = "https://metacpan.org/pod/DateTime::Format::Strptime"
+    url = "https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/DateTime-Format-Strptime-1.79.tar.gz"
+
+    maintainers("EbiArnie")
+
+    version("1.79", sha256="701e46802c86ed4d88695c1a6dacbbe90b3390beeb794f387e7c792300037579")
+
+    depends_on("perl-datetime@1.00:", type=("build", "run", "test"))
+    depends_on("perl-datetime-locale@1.30:", type=("build", "run", "test"))
+    depends_on("perl-datetime-timezone@2.09:", type=("build", "run", "test"))
+    depends_on("perl-params-validationcompiler", type=("build", "run", "test"))
+    depends_on("perl-specio@0.33:", type=("build", "run", "test"))
+    depends_on("perl-test-fatal", type=("build", "test"))
+    depends_on("perl-test-warnings", type=("build", "test"))
+    depends_on("perl-try-tiny", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use DateTime::Format::Strptime; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-datetime-locale/package.py
+++ b/var/spack/repos/builtin/packages/perl-datetime-locale/package.py
@@ -12,6 +12,28 @@ class PerlDatetimeLocale(PerlPackage):
     homepage = "https://metacpan.org/pod/DateTime::Locale"
     url = "https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/DateTime-Locale-1.40.tar.gz"
 
+    maintainers("EbiArnie")
+
     version("1.40", sha256="7490b4194b5d23a4e144976dedb3bdbcc6d3364b5d139cc922a86d41fdb87afb")
 
-    depends_on("perl-file-sharedir-install", type=("build", "run"))
+    depends_on("perl@5.8.4:", type=("build", "link", "run", "test"))
+    depends_on("perl-cpan-meta-check@0.011:", type=("build", "test"))
+    depends_on("perl-dist-checkconflicts@0.02:", type=("build", "run", "test"))
+    depends_on("perl-file-sharedir", type=("build", "run", "test"))
+    depends_on("perl-file-sharedir-install@0.06:", type=("build"))
+    depends_on("perl-ipc-system-simple", type=("build", "test"))
+    depends_on("perl-namespace-autoclean@0.19:", type=("build", "run", "test"))
+    depends_on("perl-params-validationcompiler@0.13:", type=("build", "run", "test"))
+    depends_on("perl-path-tiny", type=("build", "test"))
+    depends_on("perl-specio", type=("build", "run", "test"))
+    depends_on("perl-test-file-sharedir", type=("build", "test"))
+    depends_on("perl-test2-plugin-nowarnings", type=("build", "test"))
+    depends_on("perl-test2-suite", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use DateTime::Locale; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-datetime-timezone/package.py
+++ b/var/spack/repos/builtin/packages/perl-datetime-timezone/package.py
@@ -12,4 +12,24 @@ class PerlDatetimeTimezone(PerlPackage):
     homepage = "https://metacpan.org/pod/DateTime::TimeZone"
     url = "https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/DateTime-TimeZone-2.60.tar.gz"
 
+    maintainers("EbiArnie")
+
     version("2.60", sha256="f0460d379323905b579bed44e141237a337dc25dd26b6ab0c60ac2b80629323d")
+
+    depends_on("perl@5.8.4:", type=("build", "link", "run", "test"))
+    depends_on("perl-class-singleton@1.03:", type=("build", "run", "test"))
+    depends_on("perl-module-runtime", type=("build", "run", "test"))
+    depends_on("perl-namespace-autoclean", type=("build", "run", "test"))
+    depends_on("perl-params-validationcompiler@0.13:", type=("build", "run", "test"))
+    depends_on("perl-specio", type=("build", "run", "test"))
+    depends_on("perl-test-fatal", type=("build", "test"))
+    depends_on("perl-test-requires", type=("build", "test"))
+    depends_on("perl-try-tiny", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use DateTime::TimeZone; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-file-sharedir/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-sharedir/package.py
@@ -12,6 +12,17 @@ class PerlFileSharedir(PerlPackage):
     homepage = "https://metacpan.org/pod/File::ShareDir"
     url = "https://cpan.metacpan.org/authors/id/R/RE/REHSACK/File-ShareDir-1.118.tar.gz"
 
+    maintainers("EbiArnie")
+
     version("1.118", sha256="3bb2a20ba35df958dc0a4f2306fc05d903d8b8c4de3c8beefce17739d281c958")
 
-    # depends_on("perl-module-build", type="build")
+    depends_on("perl-class-inspector@1.12:", type=("build", "run", "test"))
+    depends_on("perl-file-sharedir-install@0.13:", type=("build", "link"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use File::ShareDir; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-namespace-autoclean/package.py
+++ b/var/spack/repos/builtin/packages/perl-namespace-autoclean/package.py
@@ -12,4 +12,20 @@ class PerlNamespaceAutoclean(PerlPackage):
     homepage = "https://metacpan.org/pod/namespace::autoclean"
     url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/namespace-autoclean-0.29.tar.gz"
 
+    maintainers("EbiArnie")
+
     version("0.29", sha256="45ebd8e64a54a86f88d8e01ae55212967c8aa8fed57e814085def7608ac65804")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-b-hooks-endofscope@0.12:", type=("build", "run", "test"))
+    depends_on("perl-namespace-clean@0.20:", type=("build", "run", "test"))
+    depends_on("perl-sub-identify", type=("build", "run", "test"))
+    depends_on("perl-test-needs", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use namespace::autoclean; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-namespace-clean/package.py
+++ b/var/spack/repos/builtin/packages/perl-namespace-clean/package.py
@@ -12,6 +12,18 @@ class PerlNamespaceClean(PerlPackage):
     homepage = "https://metacpan.org/pod/namespace::clean"
     url = "http://search.cpan.org/CPAN/authors/id/R/RI/RIBASUSHI/namespace-clean-0.27.tar.gz"
 
+    maintainers("EbiArnie")
+
     version("0.27", sha256="8a10a83c3e183dc78f9e7b7aa4d09b47c11fb4e7d3a33b9a12912fd22e31af9d")
 
-    depends_on("perl-b-hooks-endofscope", type=("build", "run"))
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-b-hooks-endofscope@0.12:", type=("build", "run", "test"))
+    depends_on("perl-package-stash@0.23:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use namespace::clean; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-params-validationcompiler/package.py
+++ b/var/spack/repos/builtin/packages/perl-params-validationcompiler/package.py
@@ -13,4 +13,21 @@ class PerlParamsValidationcompiler(PerlPackage):
     homepage = "https://metacpan.org/pod/Params::ValidationCompiler"
     url = "https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/Params-ValidationCompiler-0.31.tar.gz"
 
+    maintainers("EbiArnie")
+
     version("0.31", sha256="7b6497173f1b6adb29f5d51d8cf9ec36d2f1219412b4b2410e9d77a901e84a6d")
+
+    depends_on("perl-eval-closure", type=("build", "run", "test"))
+    depends_on("perl-exception-class", type=("build", "run", "test"))
+    depends_on("perl-specio@0.14:", type=("build", "test"))
+    depends_on("perl-test-without-module", type=("build", "test"))
+    depends_on("perl-test2-plugin-nowarnings", type=("build", "test"))
+    depends_on("perl-test2-suite", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Params::ValidationCompiler; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-specio/package.py
+++ b/var/spack/repos/builtin/packages/perl-specio/package.py
@@ -13,3 +13,22 @@ class PerlSpecio(PerlPackage):
     url = "http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY/Specio-0.48.tar.gz"
 
     version("0.48", sha256="0c85793580f1274ef08173079131d101f77b22accea7afa8255202f0811682b2")
+
+    depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-devel-stacktrace", type=("build", "run", "test"))
+    depends_on("perl-eval-closure", type=("build", "run", "test"))
+    depends_on("perl-module-runtime", type=("build", "run", "test"))
+    depends_on("perl-mro-compat", type=("build", "run", "test"))
+    depends_on("perl-role-tiny@1.003003:", type=("build", "run", "test"))
+    depends_on("perl-sub-quote", type=("build", "run", "test"))
+    depends_on("perl-test-fatal", type=("build", "run", "test"))
+    depends_on("perl-test-needs", type=("build", "test"))
+    depends_on("perl-try-tiny", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Specio; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-specio/package.py
+++ b/var/spack/repos/builtin/packages/perl-specio/package.py
@@ -12,6 +12,8 @@ class PerlSpecio(PerlPackage):
     homepage = "https://metacpan.org/dist/Specio"
     url = "http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY/Specio-0.48.tar.gz"
 
+    maintainers("EbiArnie")
+
     version("0.48", sha256="0c85793580f1274ef08173079131d101f77b22accea7afa8255202f0811682b2")
 
     depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))

--- a/var/spack/repos/builtin/packages/perl-test-file-sharedir/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-file-sharedir/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright 2023 EMBL-European Bioinformatics Institute
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTestFileSharedir(PerlPackage):
+    """Create a Fake ShareDir for your modules for testing."""
+
+    homepage = "https://metacpan.org/pod/Test::File::ShareDir"
+    url = "https://cpan.metacpan.org/authors/id/K/KE/KENTNL/Test-File-ShareDir-1.001002.tar.gz"
+
+    maintainers("EbiArnie")
+
+    version("1.001002", sha256="b33647cbb4b2f2fcfbde4f8bb4383d0ac95c2f89c4c5770eb691f1643a337aad")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-class-tiny", type=("build", "run", "test"))
+    depends_on("perl-file-copy-recursive", type=("build", "run", "test"))
+    depends_on("perl-file-sharedir@1.00:", type=("build", "run", "test"))
+    depends_on("perl-path-tiny@0.018:", type=("build", "run", "test"))
+    depends_on("perl-scope-guard", type=("build", "run", "test"))
+    depends_on("perl-test-fatal", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Test::File::ShareDir; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test2-plugin-nowarnings/package.py
+++ b/var/spack/repos/builtin/packages/perl-test2-plugin-nowarnings/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright 2023 EMBL-European Bioinformatics Institute
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTest2PluginNowarnings(PerlPackage):
+    """Fail if tests warn"""
+
+    homepage = "https://metacpan.org/pod/Test2::Plugin::NoWarnings"
+    url = "https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/Test2-Plugin-NoWarnings-0.09.tar.gz"
+
+    maintainers("EbiArnie")
+
+    version("0.09", sha256="be3dd800042eef362bf17d2056cf9e934dee91ccce98e4f178b8fb5772f2fb74")
+
+    depends_on("perl-ipc-run3", type=("build", "test"))
+    depends_on("perl-test2-suite", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Test2::Plugin::NoWarnings; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test2-suite/package.py
+++ b/var/spack/repos/builtin/packages/perl-test2-suite/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright 2023 EMBL-European Bioinformatics Institute
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTest2Suite(PerlPackage):
+    """Distribution with a rich set of tools built upon the Test2 framework."""
+
+    homepage = "https://metacpan.org/pod/Test2::Suite"
+    url = "https://cpan.metacpan.org/authors/id/E/EX/EXODIST/Test2-Suite-0.000159.tar.gz"
+
+    maintainers("EbiArnie")
+
+    version("0.000159", sha256="cb7453380d2a70682c450cb6ec44fecd02d1c48674a76d9799903b7f4444cc0e")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-term-table@0.013:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Test2::Suite; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
Adds package:
- perl-datetime-format-strptime

And adds these because they are test dependencies:
- perl-test-file-sharedir
- perl-test2-plugin-nowarnings
- perl-test2-suite

And modifies these to enable build time tests:
- perl-b-hooks-endofscope
- perl-class-singleton
- perl-datetime-locale
- perl-datetime-timezone
- perl-file-sharedir
- perl-namespace-autoclean
- perl-namespace-clean
- perl-params-validationcompiler
- perl-specio