### PR TITLE
glib: replace url links with local files for patches

### DIFF
--- a/var/spack/repos/builtin/packages/glib/gsubprocess-2.78-patch.diff
+++ b/var/spack/repos/builtin/packages/glib/gsubprocess-2.78-patch.diff
@@ -1,0 +1,14 @@
+diff --git a/gio/tests/gsubprocess.c b/gio/tests/gsubprocess.c
+index 45fdf93b2f5b3b1354439518a7807d300ada2d15..1a0d6df3480e69eea7d2beb61ad3ec4103f849e3 100644
+--- a/gio/tests/gsubprocess.c
++++ b/gio/tests/gsubprocess.c
+@@ -2006,7 +2006,9 @@ trace_children (pid_t main_child)
+   g_assert_no_errno (waitpid (main_child, &wstatus, 0));
+   g_assert_no_errno (ptrace (PTRACE_SETOPTIONS, main_child, NULL,
+                              (PTRACE_O_TRACEFORK |
++#ifdef PTRACE_O_EXITKILL
+                               PTRACE_O_EXITKILL |
++#endif
+                               PTRACE_O_TRACEVFORK |
+                               PTRACE_O_TRACECLONE |
+                               PTRACE_O_TRACEEXEC)));

--- a/var/spack/repos/builtin/packages/glib/meson-build-2.76-patch.diff
+++ b/var/spack/repos/builtin/packages/glib/meson-build-2.76-patch.diff
@@ -1,0 +1,13 @@
+diff --git a/gio/tests/meson.build b/gio/tests/meson.build
+index b4a64926e9ce18e21d370e2accaf7834063bddad..2631b1285395322aaace42dae32cabe3aa16389b 100644
+--- a/gio/tests/meson.build
++++ b/gio/tests/meson.build
+@@ -929,7 +929,7 @@ if not meson.is_cross_build()
+       input : test_gresource_binary,
+       output : 'test_resources.o',
+       command : cc.cmd_array() + ['-Wl,-z,noexecstack', '-r', '-Wl,-b,binary',
+-                                  '@INPUT@', '-o','@OUTPUT@'])
++                                  '-nostdlib', '@INPUT@', '-o','@OUTPUT@'])
+ 
+     # Rename symbol to match the one in the C file
+     if cc.get_id() == 'gcc' and host_system == 'windows'

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -161,24 +161,14 @@ class Glib(MesonPackage, AutotoolsPackage):
     patch("old-kernels.patch", when="@2.56.0:2.56.1 os=centos6")
     patch("old-kernels.patch", when="@2.56.0:2.56.1 os=scientific6")
     # fix multiple definition error in gio tests for 2.76.1
-    patch(
-        "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3368.diff",
-        sha256="fa31180b55a832cbb75cc640bb115b7b092a26d7bcf0f48768de55576f0a38d3",
-        when="@2.76.1",
-    )
-
+    patch("meson-build-2.76-patch.diff", when="@2.76.1")
     # glib prefers the libc version of gettext, which breaks the build if the
     # external version is also found.
     patch("meson-gettext.patch", when="@2.58:2.64")
     patch("meson-gettext-2.66.patch", when="@2.66:2.68,2.72")
     patch("meson-gettext-2.70.patch", when="@2.70")
-
     # Don't use PTRACE_O_EXITKILL if it's not defined
-    patch(
-        "https://gitlab.gnome.org/GNOME/glib/-/commit/bda87264372c006c94e21ffb8ff9c50ecb3e14bd.diff",
-        sha256="2c25d7b3bf581b3ec992d7af997fa6c769174d49b9350e0320c33f5e048cba99",
-        when="@2.78.0",
-    )
+    patch("gsubprocess-2.78-patch.diff", when="@2.78.0")
 
     def url_for_version(self, version):
         """Handle glib's version-based custom URLs."""


### PR DESCRIPTION
Spack FetchError: glib fails to build at LANL because Spack tries and fails to fetch some patches from gitlab.gnome.org due to proxy issues. Placing these patches in the package directory seems to solves this problem (tested on pop_os for v2.76.1 and v2.78.0 and sles15 for v2.78.0).