### PR TITLE
Allow packages to depend on `my.version`, `variant=my.value`, etc.

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -13,7 +13,7 @@ import pprint
 import re
 import types
 import warnings
-from typing import Callable, Dict, List, NamedTuple, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Sequence, Set, Tuple, Union
 
 import archspec.cpu
 
@@ -338,12 +338,36 @@ class AspFunctionBuilder:
 
 fn = AspFunctionBuilder()
 
-TransformFunction = Callable[[spack.spec.Spec, List[AspFunction]], List[AspFunction]]
+TransformFunction = Callable[
+    [spack.spec.Spec, spack.spec.Spec, List[AspFunction]], List[AspFunction]
+]
 
 
-def remove_node(spec: spack.spec.Spec, facts: List[AspFunction]) -> List[AspFunction]:
+def transform(
+    required: spack.spec.Spec,
+    imposed: spack.spec.Spec,
+    clauses: List[AspFunction],
+    transformations: Optional[List[TransformFunction]],
+) -> List[AspFunction]:
+    """Apply a list of TransformFunctions in order."""
+    if transformations is None:
+        return clauses
+
+    for func in transformations:
+        clauses = func(required, imposed, clauses)
+    return clauses
+
+
+def cond_key(spec, transforms):
+    """Key generator for caching triggers and effects"""
+    return (str(spec), None) if transforms is None else (str(spec), tuple(transforms))
+
+
+def remove_node(
+    required: spack.spec.Spec, imposed: spack.spec.Spec, functions: List[AspFunction]
+) -> List[AspFunction]:
     """Transformation that removes all "node" and "virtual_node" from the input list of facts."""
-    return list(filter(lambda x: x.args[0] not in ("node", "virtual_node"), facts))
+    return [func for func in functions if func.args[0] not in ("node", "virtual_node")]
 
 
 def _create_counter(specs, tests):
@@ -1501,14 +1525,26 @@ class SpackSolverSetup:
 
             self.gen.newline()
 
+    def _lookup_condition_id(self, condition, transforms, factory, cache_by_name):
+        """Look up or create a condition in a trigger/effect cache."""
+        key = cond_key(condition, transforms)
+        cache = cache_by_name[condition.name]
+
+        pair = cache.get(key)
+        if pair is None:
+            pair = cache[key] = (next(self._id_counter), factory())
+
+        id, _ = pair
+        return id
+
     def condition(
         self,
         required_spec: spack.spec.Spec,
         imposed_spec: Optional[spack.spec.Spec] = None,
         name: Optional[str] = None,
         msg: Optional[str] = None,
-        transform_required: Optional[TransformFunction] = None,
-        transform_imposed: Optional[TransformFunction] = remove_node,
+        transform_required: Optional[List[TransformFunction]] = None,
+        transform_imposed: Optional[List[TransformFunction]] = [remove_node],
     ):
         """Generate facts for a dependency or virtual provider condition.
 
@@ -1536,35 +1572,27 @@ class SpackSolverSetup:
         self.gen.fact(fn.pkg_fact(named_cond.name, fn.condition(condition_id)))
         self.gen.fact(fn.condition_reason(condition_id, msg))
 
-        cache = self._trigger_cache[named_cond.name]
-
-        named_cond_key = (str(named_cond), transform_required)
-        if named_cond_key not in cache:
-            trigger_id = next(self._id_counter)
+        def make_requirements():
             requirements = self.spec_clauses(named_cond, body=True, required_from=name)
+            return transform(named_cond, imposed_spec, requirements, transform_required)
 
-            if transform_required:
-                requirements = transform_required(named_cond, requirements)
-
-            cache[named_cond_key] = (trigger_id, requirements)
-        trigger_id, requirements = cache[named_cond_key]
+        trigger_id = self._lookup_condition_id(
+            named_cond, transform_required, make_requirements, self._trigger_cache
+        )
         self.gen.fact(fn.pkg_fact(named_cond.name, fn.condition_trigger(condition_id, trigger_id)))
 
         if not imposed_spec:
             return condition_id
 
-        cache = self._effect_cache[named_cond.name]
-        imposed_spec_key = (str(imposed_spec), transform_imposed)
-        if imposed_spec_key not in cache:
-            effect_id = next(self._id_counter)
-            requirements = self.spec_clauses(imposed_spec, body=False, required_from=name)
+        def make_impositions():
+            impositions = self.spec_clauses(imposed_spec, body=False, required_from=name)
+            return transform(named_cond, imposed_spec, impositions, transform_imposed)
 
-            if transform_imposed:
-                requirements = transform_imposed(imposed_spec, requirements)
-
-            cache[imposed_spec_key] = (effect_id, requirements)
-        effect_id, requirements = cache[imposed_spec_key]
+        effect_id = self._lookup_condition_id(
+            imposed_spec, transform_imposed, make_impositions, self._effect_cache
+        )
         self.gen.fact(fn.pkg_fact(named_cond.name, fn.condition_effect(condition_id, effect_id)))
+
         return condition_id
 
     def impose(self, condition_id, imposed_spec, node=True, name=None, body=False):
@@ -1627,14 +1655,12 @@ class SpackSolverSetup:
                 else:
                     pass
 
-                def track_dependencies(input_spec, requirements):
-                    return requirements + [fn.attr("track_dependencies", input_spec.name)]
+                def track_dependencies(required, imposed, requirements):
+                    return requirements + [fn.attr("track_dependencies", required.name)]
 
-                def dependency_holds(input_spec, requirements):
-                    return remove_node(input_spec, requirements) + [
-                        fn.attr(
-                            "dependency_holds", pkg.name, input_spec.name, dt.flag_to_string(t)
-                        )
+                def dependency_holds(required, imposed, impositions):
+                    return impositions + [
+                        fn.attr("dependency_holds", pkg.name, imposed.name, dt.flag_to_string(t))
                         for t in dt.ALL_FLAGS
                         if t & depflag
                     ]
@@ -1644,8 +1670,8 @@ class SpackSolverSetup:
                     dep.spec,
                     name=pkg.name,
                     msg=msg,
-                    transform_required=track_dependencies,
-                    transform_imposed=dependency_holds,
+                    transform_required=[track_dependencies],
+                    transform_imposed=[remove_node, dependency_holds],
                 )
 
                 self.gen.newline()
@@ -1743,15 +1769,13 @@ class SpackSolverSetup:
 
                 try:
                     # With virtual we want to emit "node" and "virtual_node" in imposed specs
-                    transform: Optional[TransformFunction] = remove_node
-                    if virtual:
-                        transform = None
+                    transform = None if virtual else [remove_node]
 
                     member_id = self.condition(
                         required_spec=when_spec,
                         imposed_spec=spec,
                         name=pkg_name,
-                        transform_imposed=transform,
+                        transform_imposed=[transform],
                         msg=f"{spec_str} is a requirement for package {pkg_name}",
                     )
                 except Exception as e:
@@ -1816,14 +1840,14 @@ class SpackSolverSetup:
             for local_idx, spec in enumerate(external_specs):
                 msg = "%s available as external when satisfying %s" % (spec.name, spec)
 
-                def external_imposition(input_spec, _):
-                    return [fn.attr("external_conditions_hold", input_spec.name, local_idx)]
+                def external_imposition(required, imposed, _):
+                    return [fn.attr("external_conditions_hold", imposed.name, local_idx)]
 
                 self.condition(
                     spec,
                     spack.spec.Spec(spec.name),
                     msg=msg,
-                    transform_imposed=external_imposition,
+                    transform_imposed=[external_imposition],
                 )
                 self.possible_versions[spec.name].add(spec.version)
                 self.gen.newline()

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -366,6 +366,11 @@ attr(Name, node(X, A1), A2)         :- impose(ID, PackageNode), imposed_constrai
 attr(Name, node(X, A1), A2, A3)     :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1, A2, A3),     imposed_nodes(ID, PackageNode, node(X, A1)), not multiple_nodes_attribute(Name).
 attr(Name, node(X, A1), A2, A3, A4) :- impose(ID, PackageNode), imposed_constraint(ID, Name, A1, A2, A3, A4), imposed_nodes(ID, PackageNode, node(X, A1)).
 
+attr(DepAttrName, DepNode, Value)
+   :- depends_on(node(X, Package), DepNode),
+      attr(PackageAttrName, node(X, Package), Value),
+      attr("sync", DepNode, DepAttrName, attr(PackageAttrName, Package)).
+
 % For node flag sources we need to look at the condition_set of the source, since it is the dependent
 % of the package on which I want to impose the constraint
 attr("node_flag_source", node(X, A1), A2, node(Y, A3))

--- a/var/spack/repos/builtin.mock/packages/version-lock-dep/package.py
+++ b/var/spack/repos/builtin.mock/packages/version-lock-dep/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class VersionLockDep(Package):
+    """version-lock-dep is depended on by version-lock with the same version"""
+
+    homepage = "http://example.com/version-lock-dep/"
+    url = "http://example.com/version-lock-dep.tar.gz"
+
+    version("3.2.1", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("3.2.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("3.1.1", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("3.1.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("3.0.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+
+    version("2.2.1", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("2.2.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("2.1.1", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("2.1.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("2.0.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+
+    version("1.2.1", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("1.2.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("1.1.1", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("1.1.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("1.0.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")

--- a/var/spack/repos/builtin.mock/packages/version-lock/package.py
+++ b/var/spack/repos/builtin.mock/packages/version-lock/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class VersionLock(Package):
+    """version-lock depends on version-lock-dep with the same version"""
+
+    homepage = "http://example.com/version-lock/"
+    url = "http://example.com/version-lock.tar.gz"
+
+    version("3.2.1", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("3.2.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("3.1.1", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("3.1.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("3.0.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+
+    version("2.2.1", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("2.2.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("2.1.1", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("2.1.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("2.0.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+
+    version("1.2.1", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("1.2.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("1.1.1", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("1.1.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+    version("1.0.0", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
+
+    depends_on("version-lock-dep@my.version")


### PR DESCRIPTION
Based on https://github.com/spack/spack/pull/37418#issuecomment-1853544290, we want to try to enable something like:

```python
depends_on("geant4-data@{my.version}", when="@10:")
```

You can think of `{my.version}` as an expression template that expands out the `depends_on()` to all possible values of some spec attribute.  `my` here is like a proxy for this package's spec, with a limited set of allowed attributes: basically the ones we know how to expand all values of.  I think this makes it intuitive to filter by the `when=` clause (to be consistent with other directives). It also enables you to, e.g., only do version matching only on certain versions (10 or higher here).

Expressions could be more complex:

```python
depends_on("geant4-data@{my.version.up_to(2)}", when="@10:")
```

And you could use this on variants as well:

```python
depends_on("hdf5 mpi={my.variants['mpi'].value}")
```

The final advantage here is that we can push logic down to the solver instead of doing a `for` loop at the package level.  *Not all versions, variant values, etc. are known at package definition time*.  They can come in from the CLI, config, externals, and other places, so only the solver really knows all the values at setup time.  Similarly, for variants with infinite legal values (e.g,. ints, strings) we only know the values at solver setup time, and we can't explode the solve to include all possible strings/ints/whatever.

@greenc-FNAL: this is a proof of concept to give you an idea of what parts of the code you'd need to touch to get something like this working.  I have some ideas for how you could propagate an actual version/variant expressions from the `depends_on()` directive, through the spec, down to the solver.  Ultimately I think those need to be evaluated in `define_version_constraints` (or a similar location for variants).  That is, they should be run at the end of setup after all values from all specs in the solve are known.

The amount of concretizer logic required here is surprisingly small. It's basically one new type of fact in the encoding:

```prolog
attr("sync", "dep_name", "node_version_satisfies", attr("version", "pkg_name"))
```

That says that you should take `Version` in any derived `attr("version", Package, Version)` and create a rule like `attr("node_version_satisfies", Dependency, Version)` to force the dependency to use the same version.  The implementation of that is just:

```prolog
attr(DepAttrName, DepNode, Value)
   :- depends_on(node(X, Package), DepNode),
      attr(PackageAttrName, node(X, Package), Value),
      attr("sync", DepNode, DepAttrName, attr(PackageAttrName, Package)).
```