### PR TITLE
legion: inject correct mpicc to embedded GASnet slingshot11 config

### DIFF
--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -75,6 +75,15 @@ class Legion(CMakePackage, ROCmPackage):
     # https://github.com/spack/spack/issues/37232#issuecomment-1553376552
     patch("hip-offload-arch.patch", when="@23.03.0 +rocm")
 
+    def patch(self):
+        if "network=gasnet conduit=ofi-slingshot11 ^cray-mpich+wrappers" in self.spec:
+            filter_file(
+                r"--with-mpi-cc=cc",
+                f"--with-mpi-cc={self.spec['mpi'].mpicc}",
+                "stanfordgasnet/gasnet/configs/config.ofi-slingshot11.release",
+                string=True,
+            )
+
     # HIP specific
     variant(
         "hip_hijack",


### PR DESCRIPTION
@elliottslaughter this is the `cray-mpich` patch I mentioned which is needed to compile the embedded GASnet.