### PR TITLE
Only reuse externals when configured

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3210,11 +3210,10 @@ class Solver:
             # Specs from the local Database
             with spack.store.STORE.db.read_transaction():
                 reusable_specs.extend(
-                    [
-                        s
-                        for s in spack.store.STORE.db.query(installed=True)
-                        if _is_reusable(s, packages)
-                    ]
+                    record.spec
+                    for record in spack.store.STORE.db._data.values()
+                    if record.installed
+                    and (record.origin == "external-db" or _is_reusable(record.spec, packages))
                 )
 
             # Specs from buildcaches

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3154,7 +3154,12 @@ def _is_reusable(spec: spack.spec.Spec, packages) -> bool:
     if not spec.external:
         return True
 
-    for name in {spec.name, *(p.name for p in spec.package.provided)}:
+    try:
+        provided = [p.name for p in spec.package.provided]
+    except spack.repo.RepoError:
+        provided = []
+
+    for name in {spec.name, *provided}:
         for entry in packages.get(name, {}).get("externals", []):
             if (
                 spec.satisfies(entry["spec"])

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2434,7 +2434,8 @@ def test_reusable_externals_match(mock_packages, tmpdir):
     spec.external_path = tmpdir.strpath
     spec.external_modules = ["mpich/4.1"]
     spec._mark_concrete()
-    assert spack.solver.asp._is_reusable_external(
+    assert spack.solver.asp._is_reusable(
+        spec,
         {
             "mpich": {
                 "externals": [
@@ -2442,7 +2443,6 @@ def test_reusable_externals_match(mock_packages, tmpdir):
                 ]
             }
         },
-        spec,
     )
 
 
@@ -2451,7 +2451,8 @@ def test_reusable_externals_match_virtual(mock_packages, tmpdir):
     spec.external_path = tmpdir.strpath
     spec.external_modules = ["mpich/4.1"]
     spec._mark_concrete()
-    assert spack.solver.asp._is_reusable_external(
+    assert spack.solver.asp._is_reusable(
+        spec,
         {
             "mpi": {
                 "externals": [
@@ -2459,7 +2460,6 @@ def test_reusable_externals_match_virtual(mock_packages, tmpdir):
                 ]
             }
         },
-        spec,
     )
 
 
@@ -2468,7 +2468,8 @@ def test_reusable_externals_different_prefix(mock_packages, tmpdir):
     spec.external_path = "/other/path"
     spec.external_modules = ["mpich/4.1"]
     spec._mark_concrete()
-    assert not spack.solver.asp._is_reusable_external(
+    assert not spack.solver.asp._is_reusable(
+        spec,
         {
             "mpich": {
                 "externals": [
@@ -2476,7 +2477,6 @@ def test_reusable_externals_different_prefix(mock_packages, tmpdir):
                 ]
             }
         },
-        spec,
     )
 
 
@@ -2486,7 +2486,8 @@ def test_reusable_externals_different_modules(mock_packages, tmpdir, modules):
     spec.external_path = tmpdir.strpath
     spec.external_modules = modules
     spec._mark_concrete()
-    assert not spack.solver.asp._is_reusable_external(
+    assert not spack.solver.asp._is_reusable(
+        spec,
         {
             "mpich": {
                 "externals": [
@@ -2494,7 +2495,6 @@ def test_reusable_externals_different_modules(mock_packages, tmpdir, modules):
                 ]
             }
         },
-        spec,
     )
 
 
@@ -2502,6 +2502,6 @@ def test_reusable_externals_different_spec(mock_packages, tmpdir):
     spec = Spec("mpich@4.1%gcc@13.1.0~debug build_system=generic arch=linux-ubuntu23.04-zen2")
     spec.external_path = tmpdir.strpath
     spec._mark_concrete()
-    assert not spack.solver.asp._is_reusable_external(
-        {"mpich": {"externals": [{"spec": "mpich@4.1 +debug", "prefix": tmpdir.strpath}]}}, spec
+    assert not spack.solver.asp._is_reusable(
+        spec, {"mpich": {"externals": [{"spec": "mpich@4.1 +debug", "prefix": tmpdir.strpath}]}}
     )

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2445,6 +2445,7 @@ def test_reusable_externals_match(mock_packages, tmpdir):
                 ]
             }
         },
+        local=False,
     )
 
 
@@ -2462,6 +2463,7 @@ def test_reusable_externals_match_virtual(mock_packages, tmpdir):
                 ]
             }
         },
+        local=False,
     )
 
 
@@ -2479,6 +2481,7 @@ def test_reusable_externals_different_prefix(mock_packages, tmpdir):
                 ]
             }
         },
+        local=False,
     )
 
 
@@ -2497,6 +2500,7 @@ def test_reusable_externals_different_modules(mock_packages, tmpdir, modules):
                 ]
             }
         },
+        local=False,
     )
 
 
@@ -2505,5 +2509,7 @@ def test_reusable_externals_different_spec(mock_packages, tmpdir):
     spec.external_path = tmpdir.strpath
     spec._mark_concrete()
     assert not spack.solver.asp._is_reusable(
-        spec, {"mpich": {"externals": [{"spec": "mpich@4.1 +debug", "prefix": tmpdir.strpath}]}}
+        spec,
+        {"mpich": {"externals": [{"spec": "mpich@4.1 +debug", "prefix": tmpdir.strpath}]}},
+        local=False,
     )

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1817,12 +1817,14 @@ class TestConcretize:
 
     @pytest.mark.regression("31484")
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")
-    def test_installed_externals_are_reused(self, mutable_database, repo_with_changing_recipe):
+    def test_installed_externals_are_reused(
+        self, mutable_database, repo_with_changing_recipe, tmp_path
+    ):
         """Test that external specs that are in the DB can be reused."""
         external_conf = {
             "changing": {
                 "buildable": False,
-                "externals": [{"spec": "changing@1.0", "prefix": "/usr"}],
+                "externals": [{"spec": "changing@1.0", "prefix": str(tmp_path)}],
             }
         }
         spack.config.set("packages", external_conf)
@@ -1847,12 +1849,12 @@ class TestConcretize:
 
     @pytest.mark.regression("31484")
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")
-    def test_user_can_select_externals_with_require(self, mutable_database):
+    def test_user_can_select_externals_with_require(self, mutable_database, tmp_path):
         """Test that users have means to select an external even in presence of reusable specs."""
         external_conf = {
             "mpi": {"buildable": False},
             "multi-provider-mpi": {
-                "externals": [{"spec": "multi-provider-mpi@2.0.0", "prefix": "/usr"}]
+                "externals": [{"spec": "multi-provider-mpi@2.0.0", "prefix": str(tmp_path)}]
             },
         }
         spack.config.set("packages", external_conf)

--- a/lib/spack/spack/test/cray_manifest.py
+++ b/lib/spack/spack/test/cray_manifest.py
@@ -19,6 +19,7 @@ import spack.cmd
 import spack.compilers
 import spack.config
 import spack.cray_manifest as cray_manifest
+import spack.solver.asp
 import spack.spec
 import spack.store
 from spack.cray_manifest import compiler_from_entry, entries_to_specs
@@ -488,3 +489,23 @@ def test_find_external_nonempty_default_manifest_dir(
     spack.cmd.external._collect_and_consume_cray_manifest_files(ignore_default_dir=False)
     specs = spack.store.STORE.db.query("hwloc")
     assert any(x.dag_hash() == "hwlocfakehashaaa" for x in specs)
+
+
+def test_reusable_externals_cray_manifest(
+    tmpdir, mutable_config, mock_packages, temporary_store, manifest_content
+):
+    """The concretizer should be able to reuse specs imported from a manifest without a
+    externals config entry in packages.yaml"""
+    with tmpdir.as_cwd():
+        with open("external-db.json", "w") as f:
+            json.dump(manifest_content, f)
+        cray_manifest.read(path="external-db.json", apply_updates=True)
+
+        # Get any imported spec
+        spec = temporary_store.db.query_local()[0]
+
+        # Reusable if imported locally
+        assert spack.solver.asp._is_reusable(spec, packages={}, local=True)
+
+        # If cray manifest entries end up in a build cache somehow, they are not reusable
+        assert not spack.solver.asp._is_reusable(spec, packages={}, local=False)


### PR DESCRIPTION
Closes #40843

Followup to #35975
 
Users often learn the hard way that removing or modifying an external in
packages.yaml is not enough to avoid the original external from getting
picked up in concretization. To users it feels like their config changes have
no effect, or they think that Spack somehow caches their old config.

I don't think it's reasonable to expect users to understand that their old
config ended up as an "installed" spec in the database, and follows the
usual reuse rules of installed specs. This jargon makes barely any sense,
since users don't think of externals being "installed in the database" at all,
their externals are "installed on the system", and the only way they interact
with them is by registering them in config -- externals getting "installed"
is really just an implementation detail. Asking users to `spack uninstall`
their old external by hash also raises eyebrows.

It can be quite a time waster for users, in particular the case reported in
#40843, where the only change to config was fixing a typo in the module
list for the external. Barely any user would understand that config is copied
into the database, and it's never really exposed to the user. That means
that accidental reuse of the old external with the typo is a really fun and
time consuming debugging activity (in particular since it may not cause
and error on module load, and on cray systems module load related
problems are notoriously hard to troubleshoot)

Since this such a footgun, and gets reported almost every week on Slack,
I think it would be clean and consistent to apply the same reuse condition we
already apply to build caches also to the local database: reuse externals
that are configured in packages.yaml.
