### PR TITLE
setup-env.sh: if exe contains qemu, use /proc/$$/comm instead

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -232,6 +232,10 @@ _spack_determine_shell() {
         # If procfs is present this seems a more reliable
         # way to detect the current shell
         _sp_exe=$(readlink /proc/$$/exe)
+        # Qemu emulation has _sp_exe point to the emulator
+        if [ "${_sp_exe##*qemu*}" != "${_sp_exe}" ]; then
+            _sp_exe=$(cat /proc/$$/comm)
+        fi
         # Shell may contain number, like zsh5 instead of zsh
         basename ${_sp_exe} | tr -d '0123456789'
     elif [ -n "${BASH:-}" ]; then


### PR DESCRIPTION
fixes #41639

In #41639 we identified that the shell is determined incorrectly when under qemu emulation. This handles the case of qemu in the exe, by using the procfs comm field instead in only those cases.