### PR TITLE
"spack diff": add ignore option for dependencies

### DIFF
--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -100,13 +100,6 @@ def compare_specs(a, b, to_string=False, color=None, ignore_packages=None):
         if func.name == "attr"
     )
 
-    if ignore_packages:
-        # If we are ignoring differences in dependencies, we probably want
-        # to also ignore differences in hashes (since any difference in a
-        # dep will transitively propagate to all parent hashes)
-        a_facts = set(x for x in a_facts if x.name not in ["hash"])
-        b_facts = set(x for x in b_facts if x.name not in ["hash"])
-
     # We want to present them to the user as simple key: values
     intersect = sorted(a_facts.intersection(b_facts))
     spec1_not_spec2 = sorted(a_facts.difference(b_facts))

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -44,6 +44,11 @@ def setup_parser(subparser):
         action="append",
         help="select the attributes to show (defaults to all)",
     )
+    subparser.add_argument(
+        "--ignore",
+        action="append",
+        help="omit diffs related to these dependencies",
+    )
 
 
 def shift(asp_function):
@@ -54,7 +59,7 @@ def shift(asp_function):
     return asp.AspFunction(first, rest)
 
 
-def compare_specs(a, b, to_string=False, color=None):
+def compare_specs(a, b, to_string=False, color=None, ignore_packages=None):
     """
     Generate a comparison, including diffs (for each side) and an intersection.
 
@@ -72,6 +77,14 @@ def compare_specs(a, b, to_string=False, color=None):
     """
     if color is None:
         color = get_color_when()
+
+    a = a.copy()
+    b = b.copy()
+
+    if ignore_packages:
+        for pkg_name in ignore_packages:
+            a.trim(pkg_name)
+            b.trim(pkg_name)
 
     # Prepare a solver setup to parse differences
     setup = asp.SpackSolverSetup()
@@ -209,7 +222,7 @@ def diff(parser, args):
 
     # Calculate the comparison (c)
     color = False if args.dump_json else get_color_when()
-    c = compare_specs(specs[0], specs[1], to_string=True, color=color)
+    c = compare_specs(specs[0], specs[1], to_string=True, color=color, ignore_packages=args.ignore)
 
     # Default to all attributes
     attributes = args.attribute or ["all"]

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -100,6 +100,9 @@ def compare_specs(a, b, to_string=False, color=None, ignore_packages=None):
         if func.name == "attr"
     )
 
+    if ignore_packages:
+        import pdb; pdb.set_trace()
+
     # We want to present them to the user as simple key: values
     intersect = sorted(a_facts.intersection(b_facts))
     spec1_not_spec2 = sorted(a_facts.difference(b_facts))

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -45,9 +45,7 @@ def setup_parser(subparser):
         help="select the attributes to show (defaults to all)",
     )
     subparser.add_argument(
-        "--ignore",
-        action="append",
-        help="omit diffs related to these dependencies",
+        "--ignore", action="append", help="omit diffs related to these dependencies"
     )
 
 

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -100,6 +100,13 @@ def compare_specs(a, b, to_string=False, color=None, ignore_packages=None):
         if func.name == "attr"
     )
 
+    if ignore_packages:
+        # If we are ignoring differences in dependencies, we probably want
+        # to also ignore differences in hashes (since any difference in a
+        # dep will transitively propagate to all parent hashes)
+        a_facts = set(x for x in a_facts if not x.name in ["hash"])
+        b_facts = set(x for x in b_facts if not x.name in ["hash"])
+
     # We want to present them to the user as simple key: values
     intersect = sorted(a_facts.intersection(b_facts))
     spec1_not_spec2 = sorted(a_facts.difference(b_facts))

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -100,9 +100,6 @@ def compare_specs(a, b, to_string=False, color=None, ignore_packages=None):
         if func.name == "attr"
     )
 
-    if ignore_packages:
-        import pdb; pdb.set_trace()
-
     # We want to present them to the user as simple key: values
     intersect = sorted(a_facts.intersection(b_facts))
     spec1_not_spec2 = sorted(a_facts.difference(b_facts))

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -104,8 +104,8 @@ def compare_specs(a, b, to_string=False, color=None, ignore_packages=None):
         # If we are ignoring differences in dependencies, we probably want
         # to also ignore differences in hashes (since any difference in a
         # dep will transitively propagate to all parent hashes)
-        a_facts = set(x for x in a_facts if not x.name in ["hash"])
-        b_facts = set(x for x in b_facts if not x.name in ["hash"])
+        a_facts = set(x for x in a_facts if x.name not in ["hash"])
+        b_facts = set(x for x in b_facts if x.name not in ["hash"])
 
     # We want to present them to the user as simple key: values
     intersect = sorted(a_facts.intersection(b_facts))

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4732,16 +4732,11 @@ class Spec:
         from this tree. This can also remove other dependencies if
         they are only present because of `dep_name`.
         """
-        dep_spec = Spec(dep_name)
-        remove = [dep_spec]
-        if dep_spec.virtual:
-            remove = list(spack.repo.PATH.providers_for(dep_name))
-        # Create a list to avoid modification during traversal
         for spec in list(self.traverse()):
             new_dependencies = _EdgeMap()  # A new _EdgeMap
             for pkg_name, edge_list in spec._dependencies.items():
-                if not any(Spec(pkg_name).satisfies(x) for x in remove):
-                    for edge in edge_list:
+                for edge in edge_list:
+                    if (dep_name not in edge.virtuals) and (not dep_name == edge.spec.name):
                         new_dependencies.add(edge)
             spec._dependencies = new_dependencies
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4729,7 +4729,8 @@ class Spec:
     def trim(self, dep_name):
         """
         Remove any package that is or provides `dep_name` transitively
-        from this tree.
+        from this tree. This can also remove other dependencies if
+        they are only present because of `dep_name`.
         """
         dep_spec = Spec(dep_name)
         remove = [dep_spec]

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3960,9 +3960,10 @@ class Spec:
         # Create a list to avoid modification during traversal
         for spec in list(self.traverse()):
             new_dependencies = _EdgeMap()  # A new _EdgeMap
-            for key, value in new_dependencies.items():
-                if not any(Spec(key).satisfies(x) for x in remove):
-                    new_dependencies[key] = value
+            for pkg_name, edge_list in spec._dependencies.items():
+                if not any(Spec(pkg_name).satisfies(x) for x in remove):
+                    for edge in edge_list:
+                        new_dependencies.add(edge)
             spec._dependencies = new_dependencies
 
     @property  # type: ignore[misc] # decorated prop not supported in mypy

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3959,7 +3959,7 @@ class Spec:
             remove = list(spack.repo.PATH.providers_for(dep_name))
         # Create a list to avoid modification during traversal
         for spec in list(self.traverse()):
-            new_dependencies = _EdgeMap() # A new _EdgeMap
+            new_dependencies = _EdgeMap()  # A new _EdgeMap
             for key, value in new_dependencies.items():
                 if not any(Spec(key).satisfies(x) for x in remove):
                     new_dependencies[key] = value

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3951,6 +3951,20 @@ class Spec:
         """Return list of any virtual deps in this spec."""
         return [spec for spec in self.traverse() if spec.virtual]
 
+    # should require concrete
+    def trim(self, dep_name):
+        dep_spec = Spec(dep_name)
+        remove = [dep_spec]
+        if dep_spec.virtual:
+            remove = list(spack.repo.PATH.providers_for(dep_name))
+        # Create a list to avoid modification during traversal
+        for spec in list(self.traverse()):
+            new_dependencies = _EdgeMap() # A new _EdgeMap
+            for key, value in new_dependencies.items():
+                if not any(Spec(key).satisfies(x) for x in remove):
+                    new_dependencies[key] = value
+            spec._dependencies = new_dependencies
+
     @property  # type: ignore[misc] # decorated prop not supported in mypy
     def patches(self):
         """Return patch objects for any patch sha256 sums on this Spec.

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -137,10 +137,10 @@ def test_diff_ignore(test_repo):
 
     assert find(c1["a_not_b"], "package_hash", ["p4"])
 
+    c2 = spack.cmd.diff.compare_specs(specA, specB, ignore_packages=["v1"], to_string=False)
 
-    #import pdb; pdb.set_trace()
-
-    #raise Exception()
+    assert not find(c2["a_not_b"], "package_hash", ["p4"])
+    assert find(c2["intersect"], "package_hash", ["p3"])
 
 
 def test_diff_cmd(install_mockery, mock_fetch, mock_archive, mock_packages):

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -101,14 +101,11 @@ class P4(Package):
 @pytest.fixture
 def _create_test_repo(tmpdir, mutable_config):
     """
-    p0
-    |
-
     p1____
     |     \
-    p2     v1____
-    | ____/ |    \
-    p3      p4    p5 (only i2)
+    p2     v1
+    | ____/ |
+    p3      p4
 
     i1 and i2 provide v1 (and both have the same dependencies)
 
@@ -136,12 +133,12 @@ def test_diff_ignore(test_repo):
     def find(function_list, name, args):
         return any(match(f, name, args) for f in function_list)
 
-    assert find(c1["a_not_b"], "package_hash", ["p4"])
+    assert find(c1["a_not_b"], "node_os", ["p4"])
 
     c2 = spack.cmd.diff.compare_specs(specA, specB, ignore_packages=["v1"], to_string=False)
 
-    assert not find(c2["a_not_b"], "package_hash", ["p4"])
-    assert find(c2["intersect"], "package_hash", ["p3"])
+    assert not find(c2["a_not_b"], "node_os", ["p4"])
+    assert find(c2["intersect"], "node_os", ["p3"])
 
 
 def test_diff_cmd(install_mockery, mock_fetch, mock_archive, mock_packages):

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -4,13 +4,13 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import pytest
-from spack.test.conftest import create_test_repo
 
 import spack.cmd.diff
 import spack.config
 import spack.main
 import spack.store
 import spack.util.spack_json as sjson
+from spack.test.conftest import create_test_repo
 
 install_cmd = spack.main.SpackCommand("install")
 diff_cmd = spack.main.SpackCommand("diff")
@@ -95,6 +95,7 @@ class P4(Package):
     variant("p4var", default=True)
 """,
 )
+
 
 # Note that the hash of p1 will differ depending on the variant chosen
 # we probably always want to omit that from diffs

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import pytest
+from spack.test.conftest import create_test_repo
 
 import spack.cmd.diff
 import spack.config
@@ -14,6 +15,130 @@ import spack.util.spack_json as sjson
 install_cmd = spack.main.SpackCommand("install")
 diff_cmd = spack.main.SpackCommand("diff")
 find_cmd = spack.main.SpackCommand("find")
+
+
+_p1 = (
+    "p1",
+    """\
+class P1(Package):
+    version("1.0")
+
+    variant("p1var", default=True)
+    variant("usev1", default=True)
+
+    depends_on("p2")
+    depends_on("v1", when="+usev1")
+""",
+)
+
+
+_p2 = (
+    "p2",
+    """\
+class P2(Package):
+    version("1.0")
+
+    variant("p2var", default=True)
+
+    depends_on("p3")
+""",
+)
+
+
+_p3 = (
+    "p3",
+    """\
+class P3(Package):
+    version("1.0")
+
+    variant("p3var", default=True)
+""",
+)
+
+_i1 = (
+    "i1",
+    """\
+class I1(Package):
+    version("1.0")
+
+    provides("v1")
+
+    variant("i1var", default=True)
+
+    depends_on("p3")
+    depends_on("p4")
+""",
+)
+
+_i2 = (
+    "i2",
+    """\
+class I2(Package):
+    version("1.0")
+
+    provides("v1")
+
+    variant("i2var", default=True)
+
+    depends_on("p3")
+    depends_on("p4")
+""",
+)
+
+
+_p4 = (
+    "p4",
+    """\
+class P4(Package):
+    version("1.0")
+
+    variant("p4var", default=True)
+""",
+)
+
+
+@pytest.fixture
+def _create_test_repo(tmpdir, mutable_config):
+    """
+    p0
+    |
+
+    p1____
+    |     \
+    p2     v1____
+    | ____/ |    \
+    p3      p4    p5 (only i2)
+
+    i1 and i2 provide v1 (and both have the same dependencies)
+
+    All packages have an associated variant
+    """
+    yield create_test_repo(tmpdir, [_p1, _p2, _p3, _i1, _i2, _p4])
+
+
+@pytest.fixture
+def test_repo(_create_test_repo, monkeypatch, mock_stage):
+    with spack.repo.use_repositories(_create_test_repo) as mock_repo_path:
+        yield mock_repo_path
+
+
+def test_diff_ignore(test_repo):
+    specA = spack.spec.Spec("p1+usev1").concretized()
+    specB = spack.spec.Spec("p1~usev1").concretized()
+
+    c1 = spack.cmd.diff.compare_specs(specA, specB, to_string=False)
+
+    def match(function, name, args):
+        #if function.name == "package_hash":
+        #    import pdb; pdb.set_trace()
+        limit = len(args)
+        return function.name == name and list(args[:limit]) == list(function.args[:limit])
+
+    assert any(match(f, "package_hash", ["p4"]) for f in c1["a_not_b"])
+
+    #import pdb; pdb.set_trace()
+
+    #raise Exception()
 
 
 def test_diff_cmd(install_mockery, mock_fetch, mock_archive, mock_packages):

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -141,6 +141,18 @@ def test_diff_ignore(test_repo):
     assert not find(c2["a_not_b"], "node_os", ["p4"])
     assert find(c2["intersect"], "node_os", ["p3"])
 
+    # Check ignoring changes on multiple packages
+
+    specA = spack.spec.Spec("p1+usev1 ^p3+p3var").concretized()
+    specA = spack.spec.Spec("p1~usev1 ^p3~p3var").concretized()
+
+    c3 = spack.cmd.diff.compare_specs(specA, specB, to_string=False)
+    assert find(c3["a_not_b"], "variant_value", ["p3", "p3var"])
+
+    c4 = spack.cmd.diff.compare_specs(specA, specB, ignore_packages=["v1", "p3"], to_string=False)
+    assert not find(c4["a_not_b"], "node_os", ["p4"])
+    assert not find(c4["a_not_b"], "variant_value", ["p3"])
+
 
 def test_diff_cmd(install_mockery, mock_fetch, mock_archive, mock_packages):
     """Test that we can install two packages and diff them"""

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -129,12 +129,14 @@ def test_diff_ignore(test_repo):
     c1 = spack.cmd.diff.compare_specs(specA, specB, to_string=False)
 
     def match(function, name, args):
-        #if function.name == "package_hash":
-        #    import pdb; pdb.set_trace()
         limit = len(args)
         return function.name == name and list(args[:limit]) == list(function.args[:limit])
 
-    assert any(match(f, "package_hash", ["p4"]) for f in c1["a_not_b"])
+    def find(function_list, name, args):
+        return any(match(f, name, args) for f in function_list)
+
+    assert find(c1["a_not_b"], "package_hash", ["p4"])
+
 
     #import pdb; pdb.set_trace()
 

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -96,7 +96,8 @@ class P4(Package):
 """,
 )
 
-
+# Note that the hash of p1 will differ depending on the variant chosen
+# we probably always want to omit that from diffs
 @pytest.fixture
 def _create_test_repo(tmpdir, mutable_config):
     """

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 
 import pytest
+from spack.test.conftest import create_test_repo
 
 import spack.build_systems.generic
 import spack.config
@@ -92,30 +93,13 @@ class U(Package):
 
 
 @pytest.fixture
-def create_test_repo(tmpdir, mutable_config):
-    repo_path = str(tmpdir)
-    repo_yaml = tmpdir.join("repo.yaml")
-    with open(str(repo_yaml), "w") as f:
-        f.write(
-            """\
-repo:
-  namespace: testcfgrequirements
-"""
-        )
-
-    packages_dir = tmpdir.join("packages")
-    for pkg_name, pkg_str in [_pkgx, _pkgy, _pkgv, _pkgt, _pkgu]:
-        pkg_dir = packages_dir.ensure(pkg_name, dir=True)
-        pkg_file = pkg_dir.join("package.py")
-        with open(str(pkg_file), "w") as f:
-            f.write(pkg_str)
-
-    yield spack.repo.Repo(repo_path)
+def _create_test_repo(tmpdir, mutable_config):
+    yield create_test_repo(tmpdir, [_pkgx, _pkgy, _pkgv, _pkgt, _pkgu])
 
 
 @pytest.fixture
-def test_repo(create_test_repo, monkeypatch, mock_stage):
-    with spack.repo.use_repositories(create_test_repo) as mock_repo_path:
+def test_repo(_create_test_repo, monkeypatch, mock_stage):
+    with spack.repo.use_repositories(_create_test_repo) as mock_repo_path:
         yield mock_repo_path
 
 

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -6,7 +6,6 @@ import os
 import pathlib
 
 import pytest
-from spack.test.conftest import create_test_repo
 
 import spack.build_systems.generic
 import spack.config
@@ -17,6 +16,7 @@ import spack.util.spack_yaml as syaml
 import spack.version
 from spack.solver.asp import InternalConcretizerError, UnsatisfiableSpecError
 from spack.spec import Spec
+from spack.test.conftest import create_test_repo
 from spack.util.url import path_to_file_url
 
 pytestmark = [

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -514,7 +514,7 @@ packages:
     assert s2.satisfies("@2.5")
 
 
-def test_reuse_oneof(concretize_scope, create_test_repo, mutable_database, fake_installs):
+def test_reuse_oneof(concretize_scope, _create_test_repo, mutable_database, fake_installs):
     conf_str = """\
 packages:
   y:
@@ -522,7 +522,7 @@ packages:
     - one_of: ["@2.5", "%gcc"]
 """
 
-    with spack.repo.use_repositories(create_test_repo):
+    with spack.repo.use_repositories(_create_test_repo):
         s1 = Spec("y@2.5%gcc").concretized()
         s1.package.do_install(fake=True, explicit=True)
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1976,3 +1976,24 @@ def mock_modules_root(tmp_path, monkeypatch):
     """Sets the modules root to a temporary directory, to avoid polluting configuration scopes."""
     fn = functools.partial(_root_path, path=str(tmp_path))
     monkeypatch.setattr(spack.modules.common, "root_path", fn)
+
+
+def create_test_repo(tmpdir, pkg_name_content_tuples):
+    repo_path = str(tmpdir)
+    repo_yaml = tmpdir.join("repo.yaml")
+    with open(str(repo_yaml), "w") as f:
+        f.write(
+            """\
+repo:
+  namespace: testcfgrequirements
+"""
+        )
+
+    packages_dir = tmpdir.join("packages")
+    for pkg_name, pkg_str in pkg_name_content_tuples:
+        pkg_dir = packages_dir.ensure(pkg_name, dir=True)
+        pkg_file = pkg_dir.join("package.py")
+        with open(str(pkg_file), "w") as f:
+            f.write(pkg_str)
+
+    return spack.repo.Repo(repo_path)

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1288,6 +1288,17 @@ def test_call_dag_hash_on_old_dag_hash_spec(mock_packages, default_mock_concreti
             spec.package_hash()
 
 
+def test_spec_trim(mock_packages, config):
+    top = Spec("dt-diamond").concretized()
+    top.trim("dt-diamond-left")
+    remaining = set(x.name for x in top.traverse())
+    assert set(["dt-diamond", "dt-diamond-right", "dt-diamond-bottom"]) == remaining
+
+    top.trim("dt-diamond-right")
+    remaining = set(x.name for x in top.traverse())
+    assert set(["dt-diamond"]) == remaining
+
+
 @pytest.mark.regression("30861")
 def test_concretize_partial_old_dag_hash_spec(mock_packages, config):
     # create an "old" spec with no package hash

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -999,7 +999,7 @@ _spack_develop() {
 _spack_diff() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --json --first -a --attribute"
+        SPACK_COMPREPLY="-h --help --json --first -a --attribute --ignore"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1401,7 +1401,7 @@ complete -c spack -n '__fish_spack_using_command develop' -s f -l force -r -f -a
 complete -c spack -n '__fish_spack_using_command develop' -s f -l force -r -d 'remove any files or directories that block cloning source code'
 
 # spack diff
-set -g __fish_spack_optspecs_spack_diff h/help json first a/attribute=
+set -g __fish_spack_optspecs_spack_diff h/help json first a/attribute= ignore=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 diff' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command diff' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command diff' -s h -l help -d 'show this help message and exit'
@@ -1411,6 +1411,8 @@ complete -c spack -n '__fish_spack_using_command diff' -l first -f -a load_first
 complete -c spack -n '__fish_spack_using_command diff' -l first -d 'load the first match if multiple packages match the spec'
 complete -c spack -n '__fish_spack_using_command diff' -s a -l attribute -r -f -a attribute
 complete -c spack -n '__fish_spack_using_command diff' -s a -l attribute -r -d 'select the attributes to show (defaults to all)'
+complete -c spack -n '__fish_spack_using_command diff' -l ignore -r -f -a ignore
+complete -c spack -n '__fish_spack_using_command diff' -l ignore -r -d 'omit diffs related to these dependencies'
 
 # spack docs
 set -g __fish_spack_optspecs_spack_docs h/help


### PR DESCRIPTION
Add an `--ignore` option to `spack diff`, which can generate a diff that ignores differences that arise based on provided specs. For example, given:

```
$ spack spec --yaml dray > dray-mpi.yaml
$ spack spec --yaml dray~mpi > dray-nompi.yaml
```

compare

```
$ spack diff ./dray-mpi.yaml ./dray-nompi.yaml 
--- dray@0.1.8/zeda3rp7toj2pahu65zzympaeauauh6a
+++ dray@0.1.8/ijqs2ixgvl6bussqzsvf3r7lyqldu77p
@@ hash @@
-  apcomp 4z2tfrutjb65wz3z5nraqpuawebl7l4v
+  apcomp hkqhpb6n4ielxr6bzwra37rimoauyrrv
-  dray zeda3rp7toj2pahu65zzympaeauauh6a
+  dray ijqs2ixgvl6bussqzsvf3r7lyqldu77p
@@ variant_value @@
-  apcomp mpi True
+  apcomp mpi False
-  dray mpi True
+  dray mpi False
@@ depends_on @@
-  apcomp openmpi build
-  apcomp openmpi link
-  dray openmpi build
-  dray openmpi link
@@ virtual_on_edge @@
-  apcomp openmpi mpi
-  dray openmpi mpi
```

and

(UPDATE Dec. 18: I edited `spack diff` to include hash differences)

```
$ spack diff --ignore=mpi ./dray-mpi.yaml ./dray-nompi.yaml 
--- dray@0.1.8/zeda3rp7toj2pahu65zzympaeauauh6a
+++ dray@0.1.8/ijqs2ixgvl6bussqzsvf3r7lyqldu77p
@@ hash @@
-  apcomp 4z2tfrutjb65wz3z5nraqpuawebl7l4v
+  apcomp hkqhpb6n4ielxr6bzwra37rimoauyrrv
-  dray zeda3rp7toj2pahu65zzympaeauauh6a
+  dray ijqs2ixgvl6bussqzsvf3r7lyqldu77p
@@ variant_value @@
-  apcomp mpi True
+  apcomp mpi False
-  dray mpi True
+  dray mpi False
```

you can ignore multiple packages like `spack diff --ignore=a --ignore=b...`

Most of this diff is testing (and in particular creating a self-contained example to make the test clearer).

Note: prior to Dec. 18, this omitted hash differences when using `--ignore`, the output would have looked like:

```
spack diff --ignore=mpi ./dray-mpi.yaml ./dray-nompi.yaml 
--- dray@0.1.8/zeda3rp7toj2pahu65zzympaeauauh6a
+++ dray@0.1.8/ijqs2ixgvl6bussqzsvf3r7lyqldu77p
@@ variant_value @@
-  apcomp mpi True
+  apcomp mpi False
-  dray mpi True
+  dray mpi False
```