### PR TITLE
asp.py: remove "CLI" reference

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2697,7 +2697,7 @@ class SpackSolverSetup:
             # Special condition triggered by "literal_solved"
             self.gen.fact(fn.literal(trigger_id))
             self.gen.fact(fn.pkg_fact(spec.name, fn.condition_trigger(condition_id, trigger_id)))
-            self.gen.fact(fn.condition_reason(condition_id, f"{spec} requested from CLI"))
+            self.gen.fact(fn.condition_reason(condition_id, f"{spec} requested explicitly"))
 
             imposed_spec_key = str(spec), None
             cache = self._effect_cache[spec.name]

--- a/lib/spack/spack/test/concretize_errors.py
+++ b/lib/spack/spack/test/concretize_errors.py
@@ -16,8 +16,8 @@ pytestmark = [
 version_error_messages = [
     "Cannot satisfy 'fftw@:1.0' and 'fftw@1.1:",
     "        required because quantum-espresso depends on fftw@:1.0",
-    "          required because quantum-espresso ^fftw@1.1: requested from CLI",
-    "        required because quantum-espresso ^fftw@1.1: requested from CLI",
+    "          required because quantum-espresso ^fftw@1.1: requested explicitly",
+    "        required because quantum-espresso ^fftw@1.1: requested explicitly",
 ]
 
 external_error_messages = [
@@ -30,15 +30,15 @@ external_error_messages = [
         " which was not satisfied"
     ),
     "        'quantum-espresso+veritas' required",
-    "        required because quantum-espresso+veritas requested from CLI",
+    "        required because quantum-espresso+veritas requested explicitly",
 ]
 
 variant_error_messages = [
     "'fftw' required multiple values for single-valued variant 'mpi'",
     "    Requested '~mpi' and '+mpi'",
     "        required because quantum-espresso depends on fftw+mpi when +invino",
-    "          required because quantum-espresso+invino ^fftw~mpi requested from CLI",
-    "        required because quantum-espresso+invino ^fftw~mpi requested from CLI",
+    "          required because quantum-espresso+invino ^fftw~mpi requested explicitly",
+    "        required because quantum-espresso+invino ^fftw~mpi requested explicitly",
 ]
 
 external_config = {


### PR DESCRIPTION
Can also be an environment root, or programatically
`Spec("x").concretized()`.
