### PR TITLE
Move in vs. satisfies to a note and mention special cases of in

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4379,10 +4379,17 @@ implementation was selected for this build:
    elif "mvapich" in spec:
        configure_args.append("--with-mvapich")
 
-It's also a bit more concise than satisfies.  The difference between
-the two functions is that ``satisfies()`` tests whether spec
-constraints overlap at all, while ``in`` tests whether a spec or any
-of its dependencies satisfy the provided spec.
+It's also a bit more concise than satisfies.
+
+.. note::
+
+   The ``satisfies()`` method tests whether spec constraints overlap at all,
+   while ``in`` tests whether a spec or any of its dependencies satisfy the
+   provided spec.
+
+   If the provided spec is anonymous (e.g., ":1.2:", "+shared") or has the
+   same name as the spec being checked, then ``in`` works the same as
+   ``satisfies()``; however, use of ``satisfies()`` is more intuitive.
 
 ^^^^^^^^^^^^^^^^^^^^^^^
 Architecture specifiers

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4383,9 +4383,8 @@ It's also a bit more concise than satisfies.
 
 .. note::
 
-   The ``satisfies()`` method tests whether spec constraints intersect, while
-   ``in`` tests whether a spec or any of its dependencies satisfy the provided
-   spec.
+   The ``satisfies()`` method tests whether this spec has, at least, all the constraints of the argument spec,
+   while ``in`` tests whether a spec or any of its dependencies satisfy the provided spec.
 
    If the provided spec is anonymous (e.g., ":1.2:", "+shared") or has the
    same name as the spec being checked, then ``in`` works the same as

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4383,9 +4383,9 @@ It's also a bit more concise than satisfies.
 
 .. note::
 
-   The ``satisfies()`` method tests whether spec constraints overlap at all,
-   while ``in`` tests whether a spec or any of its dependencies satisfy the
-   provided spec.
+   The ``satisfies()`` method tests whether spec constraints intersect, while
+   ``in`` tests whether a spec or any of its dependencies satisfy the provided
+   spec.
 
    If the provided spec is anonymous (e.g., ":1.2:", "+shared") or has the
    same name as the spec being checked, then ``in`` works the same as


### PR DESCRIPTION
We've been recommending use of  `in` versus `satisfies` for a spec for clarity and this section of the docs has been referenced in feedback for multiple PRs.  

This PR moves the explanation of the differences to a note *and* adds the special cases for the `in` method for transparency.