### PR TITLE
gcc: fix run environment variables not being exported in environments

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -1016,7 +1016,9 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
                     continue
 
                 abspath = os.path.join(bin_path, filename)
-                if os.path.islink(abspath):
+
+                # Skip broken symlinks (https://github.com/spack/spack/issues/41327)
+                if not os.path.exists(abspath):
                     continue
 
                 # Set the proper environment variable


### PR DESCRIPTION
Since views use symlinks, all compiler binaries were skipped in this case. Instead, only skip them if their target does not exist.

Fixes #41327
Fixes #34791