### PR TITLE
`spack gc`: add options for environments and build dependencies

### DIFF
--- a/lib/spack/spack/cmd/common/confirmation.py
+++ b/lib/spack/spack/cmd/common/confirmation.py
@@ -21,10 +21,11 @@ def confirm_action(specs: List[spack.spec.Spec], participle: str, noun: str):
         participle: action expressed as a participle, e.g. "uninstalled"
         noun: action expressed as a noun, e.g. "uninstallation"
     """
-    tty.msg(f"The following {len(specs)} packages will be {participle}:\n")
     spack.cmd.display_specs(specs, **display_args)
-    print("")
-    answer = tty.get_yes_or_no("Do you want to proceed?", default=False)
+    print()
+    answer = tty.get_yes_or_no(
+        f"{len(specs)} packages will be {participle}. Do you want to proceed?", default=False
+    )
     if not answer:
         tty.msg(f"Aborting {noun}")
         sys.exit(0)

--- a/lib/spack/spack/cmd/gc.py
+++ b/lib/spack/spack/cmd/gc.py
@@ -17,31 +17,76 @@ level = "short"
 
 
 def setup_parser(subparser):
+    subparser.add_argument(
+        "-E",
+        "--except-any-environment",
+        action="store_true",
+        help="remove everything unless needed by an environment",
+    )
+    subparser.add_argument(
+        "-e",
+        "--except-environment",
+        metavar="ENV",
+        action="append",
+        default=[],
+        help="remove everything unless needed by specified environment\n"
+        "you can list multiple environments, or specify directory\n"
+        "environments by path.",
+    )
+    subparser.add_argument(
+        "-b",
+        "--keep-build-dependencies",
+        action="store_true",
+        help="do not remove installed build-only dependencies of roots\n"
+        "(default is to keep only link & run dependencies)",
+    )
     spack.cmd.common.arguments.add_common_arguments(subparser, ["yes_to_all"])
 
 
 def gc(parser, args):
-    specs = spack.store.STORE.db.unused_specs
+    deptypes = ("link", "run")
+    if args.keep_build_dependencies:
+        deptypes += ("build",)
 
-    # Restrict garbage collection to the active environment
-    # speculating over roots that are yet to be installed
-    env = ev.active_environment()
-    if env:
-        msg = 'Restricting the garbage collection to the "{0}" environment'
-        tty.msg(msg.format(env.name))
-        env.concretize()
-        roots = [s for s in env.roots()]
-        all_hashes = set([s.dag_hash() for r in roots for s in r.traverse()])
-        lr_hashes = set([s.dag_hash() for r in roots for s in r.traverse(deptype=("link", "run"))])
-        maybe_to_be_removed = all_hashes - lr_hashes
-        specs = [s for s in specs if s.dag_hash() in maybe_to_be_removed]
+    active_env = ev.active_environment()
 
+    # if we're using -E or -e, make a list of environments whose roots we should consider.
+    all_environments = []
+
+    # -E will garbage collect anything not needed by any env, including the current one
+    if args.except_any_environment:
+        all_environments += list(ev.all_environments())
+        if active_env:
+            all_environments.append(active_env)
+
+    # -e says "also preserve things needed by this particular env"
+    for env_name_or_dir in args.except_environment:
+        all_environments.append(ev.read(env_name_or_dir))
+
+    # add root hashes from all considered environments to list of roots
+    root_hashes = set()
+    for env in all_environments:
+        root_hashes |= set(env.concretized_order)
+
+    # if the user didn't specify they wanted to gc everything BUT particular envs,
+    # do normal garbage collection.
+    if not root_hashes:
+        # only gc the current environment (note: `spack -e ENV gc -b` likely does nothing)
+        if active_env:
+            tty.msg(f"Restricting garbage collection to environment '{env.name}'")
+            root_hashes = set(spack.store.STORE.db.all_hashes())  # keep everything
+            root_hashes -= set(active_env.all_hashes())  # except this env
+            root_hashes |= set(active_env.concretized_order)  # but keep its roots
+        else:
+            # consider all explicit specs roots (this is the default for db.unused_specs())
+            root_hashes = None
+
+    specs = spack.store.STORE.db.unused_specs(root_hashes=root_hashes, deptypes=deptypes)
     if not specs:
-        msg = "There are no unused specs. Spack's store is clean."
-        tty.msg(msg)
+        tty.msg("There are no unused specs. Spack's store is clean.")
         return
 
     if not args.yes_to_all:
-        spack.cmd.common.confirmation.confirm_action(specs, "uninstalled", "uninstallation")
+        spack.cmd.common.confirmation.confirm_action(specs, "uninstalled", "uninstall")
 
     spack.cmd.uninstall.do_uninstall(specs, force=False)

--- a/lib/spack/spack/cmd/gc.py
+++ b/lib/spack/spack/cmd/gc.py
@@ -62,7 +62,13 @@ def gc(parser, args):
 
     # -e says "also preserve things needed by this particular env"
     for env_name_or_dir in args.except_environment:
-        all_environments.append(ev.read(env_name_or_dir))
+        if ev.exists(env_name_or_dir):
+            env = ev.read(env_name_or_dir)
+        elif ev.is_env_dir(env_name_or_dir):
+            env = ev.Environment(env_name_or_dir)
+        else:
+            tty.die(f"No such environment: '{env_name_or_dir}'")
+        all_environments.append(env)
 
     # add root hashes from all considered environments to list of roots
     root_hashes = set()

--- a/lib/spack/spack/cmd/gc.py
+++ b/lib/spack/spack/cmd/gc.py
@@ -8,6 +8,7 @@ import llnl.util.tty as tty
 import spack.cmd.common.arguments
 import spack.cmd.common.confirmation
 import spack.cmd.uninstall
+import spack.deptypes as dt
 import spack.environment as ev
 import spack.store
 
@@ -44,9 +45,9 @@ def setup_parser(subparser):
 
 
 def gc(parser, args):
-    deptypes = ("link", "run")
+    deptype = dt.LINK | dt.RUN
     if args.keep_build_dependencies:
-        deptypes += ("build",)
+        deptype |= dt.BUILD
 
     active_env = ev.active_environment()
 
@@ -81,7 +82,7 @@ def gc(parser, args):
             # consider all explicit specs roots (this is the default for db.unused_specs())
             root_hashes = None
 
-    specs = spack.store.STORE.db.unused_specs(root_hashes=root_hashes, deptypes=deptypes)
+    specs = spack.store.STORE.db.unused_specs(root_hashes=root_hashes, deptype=deptype)
     if not specs:
         tty.msg("There are no unused specs. Spack's store is clean.")
         return

--- a/lib/spack/spack/cmd/gc.py
+++ b/lib/spack/spack/cmd/gc.py
@@ -73,7 +73,7 @@ def gc(parser, args):
     if not root_hashes:
         # only gc the current environment (note: `spack -e ENV gc -b` likely does nothing)
         if active_env:
-            tty.msg(f"Restricting garbage collection to environment '{env.name}'")
+            tty.msg(f"Restricting garbage collection to environment '{active_env.name}'")
             root_hashes = set(spack.store.STORE.db.all_hashes())  # keep everything
             root_hashes -= set(active_env.all_hashes())  # except this env
             root_hashes |= set(active_env.concretized_order)  # but keep its roots

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -277,7 +277,7 @@ def uninstall_specs(args, specs):
         return
 
     if not args.yes_to_all:
-        confirmation.confirm_action(uninstall_list, "uninstalled", "uninstallation")
+        confirmation.confirm_action(uninstall_list, "uninstalled", "uninstall")
 
     # Uninstall everything on the list
     do_uninstall(uninstall_list, args.force)

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1665,7 +1665,7 @@ class Database:
     def unused_specs(
         self,
         root_hashes: Optional[Container[str]] = None,
-        deptypes: Tuple[str, ...] = ("link", "run"),
+        deptypes: Optional[Tuple[str, ...]] = None,
     ) -> "List[spack.spec.Spec]":
         """Return all specs that are currently installed but not needed by root specs.
 
@@ -1677,6 +1677,7 @@ class Database:
             deptypes: if a spec is reachable from a root via these dependency types, it is
                 considered needed. By default only link and run dependency types are considered.
         """
+        deptypes = ("link", "run") if deptypes is None else deptypes
 
         def root(key, record):
             """Whether a DB record is a root for garbage collection."""

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1661,7 +1661,8 @@ class Database:
 
     def all_hashes(self):
         """Return dag hash of every spec in the database."""
-        return list(self._data.keys())
+        with self.read_transaction():
+            return list(self._data.keys())
 
     def unused_specs(
         self,

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1665,7 +1665,7 @@ class Database:
     def unused_specs(
         self,
         root_hashes: Optional[Container[str]] = None,
-        deptypes: Optional[Tuple[str, ...]] = None,
+        deptype: Union[dt.DepFlag, dt.DepTypes] = dt.LINK | dt.RUN,
     ) -> "List[spack.spec.Spec]":
         """Return all specs that are currently installed but not needed by root specs.
 
@@ -1674,10 +1674,9 @@ class Database:
 
         Arguments:
             root_hashes: optional list of roots to consider when evaluating needed installations.
-            deptypes: if a spec is reachable from a root via these dependency types, it is
+            deptype: if a spec is reachable from a root via these dependency types, it is
                 considered needed. By default only link and run dependency types are considered.
         """
-        deptypes = ("link", "run") if deptypes is None else deptypes
 
         def root(key, record):
             """Whether a DB record is a root for garbage collection."""
@@ -1692,7 +1691,7 @@ class Database:
                     continue
 
                 # recycle `visited` across calls to avoid redundantly traversing
-                for spec in record.spec.traverse(visited=visited, deptype=deptypes):
+                for spec in record.spec.traverse(visited=visited, deptype=deptype):
                     needed.add(spec.dag_hash())
 
             return [

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -793,7 +793,7 @@ class Environment:
         #: User specs from the last concretization
         self.concretized_user_specs: List[Spec] = []
         #: Roots associated with the last concretization, in order
-        self.concretized_order: List[Spec] = []
+        self.concretized_order: List[str] = []
         #: Concretized specs by hash
         self.specs_by_hash: Dict[str, Spec] = {}
         #: Repository for this environment (memoized)

--- a/lib/spack/spack/test/cmd/gc.py
+++ b/lib/spack/spack/test/cmd/gc.py
@@ -127,3 +127,12 @@ def test_gc_except_specific_environments(config, mutable_database, mutable_mock_
     assert "Restricting garbage collection" not in output
     assert "Successfully uninstalled zmpi" in output
     assert "zmpi" not in find()
+
+
+@pytest.mark.db
+def test_gc_except_specific_dir_env(
+    config, mutable_database, mutable_mock_env_path, capsys, tmpdir
+):
+    output = gc("-ye", tmpdir.strpath, fail_on_error=False)
+    assert "No such environment" in output
+    gc.returncode == 1

--- a/lib/spack/spack/test/cmd/gc.py
+++ b/lib/spack/spack/test/cmd/gc.py
@@ -19,33 +19,29 @@ pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 @pytest.mark.db
-def test_gc_without_build_dependency(config, mutable_database, capsys):
-    with capsys.disabled():
-        output = gc("-yb")
+def test_gc_without_build_dependency(config, mutable_database):
+    output = gc("-yb")
     assert "There are no unused specs." in output
 
-    with capsys.disabled():
-        output = gc("-y")
+    output = gc("-y")
     assert "There are no unused specs." in output
 
 
 @pytest.mark.db
-def test_gc_with_build_dependency(config, mutable_database, capsys):
+def test_gc_with_build_dependency(config, mutable_database):
     s = spack.spec.Spec("simple-inheritance")
     s.concretize()
     s.package.do_install(fake=True, explicit=True)
 
-    with capsys.disabled():
-        output = gc("-yb")
+    output = gc("-yb")
     assert "There are no unused specs." in output
 
-    with capsys.disabled():
-        output = gc("-y")
+    output = gc("-y")
     assert "Successfully uninstalled cmake" in output
 
 
 @pytest.mark.db
-def test_gc_with_environment(config, mutable_database, mutable_mock_env_path, capsys):
+def test_gc_with_environment(config, mutable_database, mutable_mock_env_path):
     s = spack.spec.Spec("simple-inheritance")
     s.concretize()
     s.package.do_install(fake=True, explicit=True)
@@ -54,17 +50,14 @@ def test_gc_with_environment(config, mutable_database, mutable_mock_env_path, ca
     with e:
         add("cmake")
         install()
-        with capsys.disabled():
-            assert "cmake" in find()
-            output = gc("-y")
+        assert "cmake" in find()
+        output = gc("-y")
     assert "Restricting garbage collection" in output
     assert "There are no unused specs" in output
 
 
 @pytest.mark.db
-def test_gc_with_build_dependency_in_environment(
-    config, mutable_database, mutable_mock_env_path, capsys
-):
+def test_gc_with_build_dependency_in_environment(config, mutable_database, mutable_mock_env_path):
     s = spack.spec.Spec("simple-inheritance")
     s.concretize()
     s.package.do_install(fake=True, explicit=True)
@@ -73,22 +66,20 @@ def test_gc_with_build_dependency_in_environment(
     with e:
         add("simple-inheritance")
         install()
-        with capsys.disabled():
-            assert "simple-inheritance" in find()
-            output = gc("-yb")
+        assert "simple-inheritance" in find()
+        output = gc("-yb")
     assert "Restricting garbage collection" in output
     assert "There are no unused specs" in output
 
     with e:
-        with capsys.disabled():
-            assert "simple-inheritance" in find()
-            output = gc("-y")
+        assert "simple-inheritance" in find()
+        output = gc("-y")
     assert "Restricting garbage collection" in output
     assert "Successfully uninstalled cmake" in output
 
 
 @pytest.mark.db
-def test_gc_except_any_environments(config, mutable_database, mutable_mock_env_path, capsys):
+def test_gc_except_any_environments(config, mutable_database, mutable_mock_env_path):
     s = spack.spec.Spec("simple-inheritance")
     s.concretize()
     s.package.do_install(fake=True, explicit=True)
@@ -99,8 +90,7 @@ def test_gc_except_any_environments(config, mutable_database, mutable_mock_env_p
     with e:
         add("simple-inheritance")
         install()
-        with capsys.disabled():
-            assert "simple-inheritance" in find()
+        assert "simple-inheritance" in find()
 
     output = gc("-yE")
     assert "Restricting garbage collection" not in output
@@ -114,7 +104,7 @@ def test_gc_except_any_environments(config, mutable_database, mutable_mock_env_p
 
 
 @pytest.mark.db
-def test_gc_except_specific_environments(config, mutable_database, mutable_mock_env_path, capsys):
+def test_gc_except_specific_environments(config, mutable_database, mutable_mock_env_path):
     s = spack.spec.Spec("simple-inheritance")
     s.concretize()
     s.package.do_install(fake=True, explicit=True)
@@ -125,8 +115,7 @@ def test_gc_except_specific_environments(config, mutable_database, mutable_mock_
     with e:
         add("simple-inheritance")
         install()
-        with capsys.disabled():
-            assert "simple-inheritance" in find()
+        assert "simple-inheritance" in find()
 
     output = gc("-ye", "test_gc")
     assert "Restricting garbage collection" not in output
@@ -135,18 +124,14 @@ def test_gc_except_specific_environments(config, mutable_database, mutable_mock_
 
 
 @pytest.mark.db
-def test_gc_except_nonexisting_dir_env(
-    config, mutable_database, mutable_mock_env_path, capsys, tmpdir
-):
+def test_gc_except_nonexisting_dir_env(config, mutable_database, mutable_mock_env_path, tmpdir):
     output = gc("-ye", tmpdir.strpath, fail_on_error=False)
     assert "No such environment" in output
     gc.returncode == 1
 
 
 @pytest.mark.db
-def test_gc_except_specific_dir_env(
-    config, mutable_database, mutable_mock_env_path, capsys, tmpdir
-):
+def test_gc_except_specific_dir_env(config, mutable_database, mutable_mock_env_path, tmpdir):
     s = spack.spec.Spec("simple-inheritance")
     s.concretize()
     s.package.do_install(fake=True, explicit=True)
@@ -157,8 +142,7 @@ def test_gc_except_specific_dir_env(
     with e:
         add("simple-inheritance")
         install()
-        with capsys.disabled():
-            assert "simple-inheritance" in find()
+        assert "simple-inheritance" in find()
 
     output = gc("-ye", tmpdir.strpath)
     assert "Restricting garbage collection" not in output

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -801,13 +801,13 @@ def mock_low_high_config(tmpdir):
 def _populate(mock_db):
     r"""Populate a mock database with packages.
 
-    Here is what the mock DB looks like:
+    Here is what the mock DB looks like (explicit roots at top):
 
-    o  mpileaks     o  mpileaks'    o  mpileaks''
-    |\              |\              |\
-    | o  callpath   | o  callpath'  | o  callpath''
-    |/|             |/|             |/|
-    o |  mpich      o |  mpich2     o |  zmpi
+    o  mpileaks     o  mpileaks'    o  mpileaks''     o externaltest     o trivial-smoke-test
+    |\              |\              |\                |
+    | o  callpath   | o  callpath'  | o  callpath''   o externaltool
+    |/|             |/|             |/|               |
+    o |  mpich      o |  mpich2     o |  zmpi         o externalvirtual
       |               |             o |  fake
       |               |               |
       |               |______________/

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -1039,6 +1039,16 @@ def test_check_parents(spec_str, parent_name, expected_nparents, database):
     assert len(edges) == expected_nparents
 
 
+def test_db_all_hashes(database):
+    # ensure we get the right number of hashes without a read transaction
+    hashes = database.all_hashes()
+    assert len(hashes) == 17
+
+    # and make sure the hashes match
+    with database.read_transaction():
+        assert set(s.dag_hash() for s in database.query()) == set(hashes)
+
+
 def test_consistency_of_dependents_upon_remove(mutable_database):
     # Check the initial state
     s = mutable_database.query_one("dyninst")

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1177,7 +1177,7 @@ _spack_find() {
 }
 
 _spack_gc() {
-    SPACK_COMPREPLY="-h --help -y --yes-to-all"
+    SPACK_COMPREPLY="-h --help -E --except-any-environment -e --except-environment -b --keep-build-dependencies -y --yes-to-all"
 }
 
 _spack_gpg() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1747,9 +1747,15 @@ complete -c spack -n '__fish_spack_using_command find' -l end-date -r -f -a end_
 complete -c spack -n '__fish_spack_using_command find' -l end-date -r -d 'latest date of installation [YYYY-MM-DD]'
 
 # spack gc
-set -g __fish_spack_optspecs_spack_gc h/help y/yes-to-all
+set -g __fish_spack_optspecs_spack_gc h/help E/except-any-environment e/except-environment= b/keep-build-dependencies y/yes-to-all
 complete -c spack -n '__fish_spack_using_command gc' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command gc' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command gc' -s E -l except-any-environment -f -a except_any_environment
+complete -c spack -n '__fish_spack_using_command gc' -s E -l except-any-environment -d 'remove everything unless needed by an environment'
+complete -c spack -n '__fish_spack_using_command gc' -s e -l except-environment -r -f -a except_environment
+complete -c spack -n '__fish_spack_using_command gc' -s e -l except-environment -r -d 'remove everything unless needed by specified environment'
+complete -c spack -n '__fish_spack_using_command gc' -s b -l keep-build-dependencies -f -a keep_build_dependencies
+complete -c spack -n '__fish_spack_using_command gc' -s b -l keep-build-dependencies -d 'do not remove installed build-only dependencies of roots'
 complete -c spack -n '__fish_spack_using_command gc' -s y -l yes-to-all -f -a yes_to_all
 complete -c spack -n '__fish_spack_using_command gc' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 


### PR DESCRIPTION
Closes #14695.

This adds a few options to `spack gc`.

One to give you a little more control over dependencies:

* `-b` / `--keep-build-dependencies`: By default, `spack gc` considers build dependencies to be "no longer needed" once their dependents are installed. With this option, we'll keep build dependencies of needed installations as well.

And two more to make working with environments easier:

* `-E` / `--except-any-environment`: Garbage collect anything NOT needed by an environment. `spack gc -E` and `spack gc -bE` are now easy ways to get rid of everytihng not used by some environment.

* `-e` / `--except-environment` `ENV`: Instead of considering all environments, garbage collect everything not needed by a *specific* environment. Note that you can use this with `-E` to add directory environments to the list of considered envs, e.g.:

      spack gc -E -e /path/to/direnv1 -e /path/to/direnv2 #...

- [x] rework `unused_specs()` method on DB to add options for roots and deptypes
- [x] add `all_hashes()` method on DB
- [x] rework `spack gc` command to add 3 more options
- [x] tests