### PR TITLE
pika-algorithms: Add upper bound for pika version

### DIFF
--- a/var/spack/repos/builtin/packages/pika-algorithms/package.py
+++ b/var/spack/repos/builtin/packages/pika-algorithms/package.py
@@ -51,6 +51,7 @@ class PikaAlgorithms(CMakePackage):
     depends_on("pika@0.11:0.12", when="@0.1.1")
     depends_on("pika@0.11:0.15", when="@0.1.2")
     depends_on("pika@0.11:0.16", when="@0.1.3")
+    depends_on("pika@0.11:0.20", when="@0.1.4")
 
     for cxxstd in cxxstds:
         depends_on("boost cxxstd={0}".format(map_cxxstd(cxxstd)), when="cxxstd={0}".format(cxxstd))

--- a/var/spack/repos/builtin/packages/pika-algorithms/package.py
+++ b/var/spack/repos/builtin/packages/pika-algorithms/package.py
@@ -46,12 +46,11 @@ class PikaAlgorithms(CMakePackage):
     # Other dependencies
     depends_on("boost@1.71:")
     depends_on("fmt@9:")
-    depends_on("pika@0.11:")
-    depends_on("pika@0.11", when="@0.1.0")
-    depends_on("pika@0.11:0.12", when="@0.1.1")
-    depends_on("pika@0.11:0.15", when="@0.1.2")
-    depends_on("pika@0.11:0.16", when="@0.1.3")
-    depends_on("pika@0.11:0.20", when="@0.1.4")
+    depends_on("pika@0.11:0.20")
+    depends_on("pika@:0.11", when="@0.1.0")
+    depends_on("pika@:0.12", when="@0.1.1")
+    depends_on("pika@:0.15", when="@0.1.2")
+    depends_on("pika@:0.16", when="@0.1.3")
 
     for cxxstd in cxxstds:
         depends_on("boost cxxstd={0}".format(map_cxxstd(cxxstd)), when="cxxstd={0}".format(cxxstd))


### PR DESCRIPTION
pika-algorithms is going to be archived and no longer works with the latest version of pika (0.21.0).