### PR TITLE
py-torch: set env OpenBLAS_HOME

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -579,6 +579,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         elif self.spec["blas"].name == "openblas":
             env.set("BLAS", "OpenBLAS")
             env.set("WITH_BLAS", "open")
+            env.set("OpenBLAS_HOME", self.spec["openblas"].prefix)
         elif self.spec["blas"].name == "veclibfort":
             env.set("BLAS", "vecLib")
             env.set("WITH_BLAS", "veclib")

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -567,9 +567,11 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         if self.spec["blas"].name == "atlas":
             env.set("BLAS", "ATLAS")
             env.set("WITH_BLAS", "atlas")
+            env.set("Atlas_ROOT_DIR", self.spec["atlas"].prefix)
         elif self.spec["blas"].name in ["blis", "amdblis"]:
             env.set("BLAS", "BLIS")
             env.set("WITH_BLAS", "blis")
+            env.set("BLIS_HOME", self.spec["blas"].prefix)
         elif self.spec["blas"].name == "eigen":
             env.set("BLAS", "Eigen")
         elif self.spec["lapack"].name in ["libflame", "amdlibflame"]:

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -419,6 +419,13 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         when="@2.0.0:2.0.1",
     )
 
+    # Use correct OpenBLAS include path under prefix
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/110063.patch?full_index=1",
+        sha256="23fb4009f7337051fc5303927ff977186a5af960245e7212895406477d8b2f66",
+        when="@:2.2",
+    )
+
     @when("@1.5.0:")
     def patch(self):
         # https://github.com/pytorch/pytorch/issues/52208
@@ -427,13 +434,6 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
             "torch_global_deps PROPERTIES LINKER_LANGUAGE CXX",
             "caffe2/CMakeLists.txt",
         )
-
-    # Use correct OpenBLAS include path under prefix
-    patch(
-        "https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/110063.patch?full_index=1",
-        sha256="23fb4009f7337051fc5303927ff977186a5af960245e7212895406477d8b2f66",
-        when="@:2.2",
-    )
 
     def setup_build_environment(self, env):
         """Set environment variables used to control the build.

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -428,6 +428,13 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
             "caffe2/CMakeLists.txt",
         )
 
+    # Use correct OpenBLAS include path under prefix
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/110063.patch?full_index=1",
+        sha256="23fb4009f7337051fc5303927ff977186a5af960245e7212895406477d8b2f66",
+        when="@:2.2",
+    )
+
     def setup_build_environment(self, env):
         """Set environment variables used to control the build.
 

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -423,7 +423,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     patch(
         "https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/110063.patch?full_index=1",
         sha256="23fb4009f7337051fc5303927ff977186a5af960245e7212895406477d8b2f66",
-        when="@:2.2",
+        when="@:2.1",
     )
 
     @when("@1.5.0:")


### PR DESCRIPTION
Because [`FindOpenBLAS.cmake`](https://github.com/pytorch/pytorch/blob/main/cmake/Modules/FindOpenBLAS.cmake) uses a hardcoded list of search paths for includes and libraries, we have to pass the `OpenBLAS_HOME` environment variable.

Editorial note: `OpenBLAS_HOME` works for include and lib, but `OpenBLAS` only works for lib. It's cmake, so maybe `OpenBLAS_DIR` or `OpenBLAS_ROOT` would have been a sensible choice. Hardcoded `/usr/local` entries make this work in some cases when an environment view already exists there, but not if you build `py-torch` in a new environment that only gets put in a view at `/usr/local` at the end of the build... It also works if the system has `openblas` installed and then it is not possible to override with a spack version.

Likely also affected: `atlas`, `blis`, `flexiblas`.  (note: `flexiblas` supported by recent [PyTorch v1.11](https://github.com/pytorch/pytorch/commit/cee4e8f35d5329da45d0beb4fef16d6736e66f03) but not yet in spack)