### PR TITLE
Add an audit to prevent virtual packages with variants specified

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -757,6 +757,15 @@ def _issues_in_depends_on_directive(pkgs, error_cls):
                     ]
                     errors.append(error_cls(summary=summary, details=details))
 
+                for s in (dependency_spec, when):
+                    if s.virtual and s.variants:
+                        summary = f"{pkg_name}: virtual dependency cannot have variants"
+                        details = [
+                            f"remove variants from '{str(s)}' in depends_on directive",
+                            f"in {filename}",
+                        ]
+                        errors.append(error_cls(summary=summary, details=details))
+
             # No need to analyze virtual packages
             if spack.repo.PATH.is_virtual(dependency_name):
                 continue

--- a/var/spack/repos/builtin/packages/arrayfire/package.py
+++ b/var/spack/repos/builtin/packages/arrayfire/package.py
@@ -35,7 +35,10 @@ class Arrayfire(CMakePackage, CudaPackage):
     depends_on("blas")
     depends_on("cuda@7.5:", when="+cuda")
     depends_on("cudnn", when="+cuda")
-    depends_on("opencl +icd", when="+opencl")
+
+    depends_on("opencl", when="+opencl")
+    depends_on("pocl+icd", when="^[virtuals=opencl] pocl")
+
     # TODO add more opencl backends:
     # currently only Cuda backend is enabled
     # https://github.com/arrayfire/arrayfire/wiki/Build-Instructions-for-Linux#opencl-backend-dependencies

--- a/var/spack/repos/builtin/packages/beatnik/package.py
+++ b/var/spack/repos/builtin/packages/beatnik/package.py
@@ -25,8 +25,16 @@ class Beatnik(CMakePackage, CudaPackage, ROCmPackage):
 
     # Dependencies for all Beatnik versions
     depends_on("mpi")
-    depends_on("mpi +cuda", when="+cuda")
-    depends_on("mpi +rocm", when="+rocm")
+    with when("+cuda"):
+        depends_on("mpich +cuda", when="^[virtuals=mpi] mpich")
+        depends_on("mvapich +cuda", when="^[virtuals=mpi] mvapich")
+        depends_on("mvapich2 +cuda", when="^[virtuals=mpi] mvapich2")
+        depends_on("mvapich2-gdr +cuda", when="^[virtuals=mpi] mvapich2-gdr")
+        depends_on("openmpi +cuda", when="^[virtuals=mpi] openmpi")
+
+    with when("+rocm"):
+        depends_on("mpich +rocm", when="^[virtuals=mpi] mpich")
+        depends_on("mvapich2-gdr +rocm", when="^[virtuals=mpi] mvapich2-gdr")
 
     # Kokkos dependencies
     depends_on("kokkos @4:")

--- a/var/spack/repos/builtin/packages/berkeleygw/package.py
+++ b/var/spack/repos/builtin/packages/berkeleygw/package.py
@@ -54,8 +54,34 @@ class Berkeleygw(MakefilePackage):
     depends_on("hdf5+fortran+hl+mpi", when="+hdf5+mpi")
     depends_on("elpa+openmp", when="+elpa+openmp")
     depends_on("elpa~openmp", when="+elpa~openmp")
-    depends_on("fftw-api@3+openmp", when="+openmp")
-    depends_on("fftw-api@3~openmp", when="~openmp")
+
+    depends_on("fftw-api@3")
+    with when("+openmp"):
+        depends_on("acfl threads=openmp", when="^[virtuals=fftw-api] acfl")
+        depends_on("amdfftw+openmp", when="^[virtuals=fftw-api] amdfftw")
+        depends_on("armpl-gcc threads=openmp", when="^[virtuals=fftw-api] armpl-gcc")
+        depends_on("cray-fftw+openmp", when="^[virtuals=fftw-api] cray-fftw")
+        depends_on("fftw+openmp", when="^[virtuals=fftw-api] fftw")
+        depends_on("fujitsu-fftw+openmp", when="^[virtuals=fftw-api] fujitsu-fftw")
+        depends_on("intel-mkl threads=openmp", when="^[virtuals=fftw-api] intel-mkl")
+        depends_on("intel-oneapi-mkl threads=openmp", when="^[virtuals=fftw-api] intel-oneapi-mkl")
+        depends_on(
+            "intel-parallel-studio threads=openmp",
+            when="^[virtuals=fftw-api] intel-parallel-studio",
+        )
+
+    with when("~openmp"):
+        depends_on("acfl threads=none", when="^[virtuals=fftw-api] acfl")
+        depends_on("amdfftw~openmp", when="^[virtuals=fftw-api] amdfftw")
+        depends_on("armpl-gcc threads=none", when="^[virtuals=fftw-api] armpl-gcc")
+        depends_on("cray-fftw~openmp", when="^[virtuals=fftw-api] cray-fftw")
+        depends_on("fftw~openmp", when="^[virtuals=fftw-api] fftw")
+        depends_on("fujitsu-fftw~openmp", when="^[virtuals=fftw-api] fujitsu-fftw")
+        depends_on("intel-mkl threads=none", when="^[virtuals=fftw-api] intel-mkl")
+        depends_on("intel-oneapi-mkl threads=none", when="^[virtuals=fftw-api] intel-oneapi-mkl")
+        depends_on(
+            "intel-parallel-studio threads=none", when="^[virtuals=fftw-api] intel-parallel-studio"
+        )
 
     # in order to run the installed python scripts
     depends_on("python", type=("build", "run"), when="+python")

--- a/var/spack/repos/builtin/packages/clblast/package.py
+++ b/var/spack/repos/builtin/packages/clblast/package.py
@@ -33,7 +33,8 @@ class Clblast(CMakePackage):
     version("1.0.1", sha256="6c9415a1394c554debce85c47349ecaaebdc9d5baa187d3ecb84be00ae9c70f0")
     version("1.0.0", sha256="230a55a868bdd21425867cbd0dcb7ec046aa5ca522fb5694e42740b5b16d0f59")
 
-    depends_on("opencl +icd")
+    depends_on("opencl")
+    depends_on("pocl+icd", when="^[virtuals=opencl] pocl")
 
     variant("shared", description="Build a shared libraries", default=True)
     variant("tuners", description="Enable compilation of the tuners", default=False)

--- a/var/spack/repos/builtin/packages/elk/package.py
+++ b/var/spack/repos/builtin/packages/elk/package.py
@@ -68,7 +68,12 @@ class Elk(MakefilePackage):
     depends_on("lapack", when="linalg=generic")
 
     depends_on("mkl", when="linalg=mkl")
-    depends_on("mkl threads=openmp", when="linalg=mkl +openmp")
+    with when("linalg=mkl +openmp"):
+        depends_on("intel-mkl threads=openmp", when="^[virtuals=mkl] intel-mkl")
+        depends_on("intel-oneapi-mkl threads=openmp", when="^[virtuals=mkl] intel-oneapi-mkl")
+        depends_on(
+            "intel-parallel-studio threads=openmp", when="^[virtuals=mkl] intel-parallel-studio"
+        )
 
     depends_on("openblas", when="linalg=openblas")
     depends_on("openblas threads=openmp", when="linalg=openblas +openmp")

--- a/var/spack/repos/builtin/packages/hpcc/package.py
+++ b/var/spack/repos/builtin/packages/hpcc/package.py
@@ -51,7 +51,7 @@ class Hpcc(MakefilePackage):
     depends_on("gmake", type="build")
     depends_on("mpi@1.1:")
     depends_on("blas")
-    depends_on("fftw-api@2+mpi", when="fft=fftw2")
+    depends_on("fftw@2+mpi", when="fft=fftw2")
     depends_on("mkl", when="fft=mkl")
 
     arch = "{0}-{1}".format(platform.system(), platform.processor())

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -141,7 +141,9 @@ class Hpctoolkit(AutotoolsPackage):
     depends_on("xerces-c transcoder=iconv")
     depends_on("xz+pic libs=static", type="link")
     depends_on("yaml-cpp@0.7.0: +shared", when="@2022.10:")
-    depends_on("zlib-api+shared")
+
+    depends_on("zlib-api")
+    depends_on("zlib+shared", when="^[virtuals=zlib-api] zlib")
 
     depends_on("cuda", when="+cuda")
     depends_on("oneapi-level-zero", when="+level_zero")

--- a/var/spack/repos/builtin/packages/ngspice/package.py
+++ b/var/spack/repos/builtin/packages/ngspice/package.py
@@ -55,8 +55,34 @@ class Ngspice(AutotoolsPackage):
     variant("fft", default=True, description="Use external fftw lib")
     variant("osdi", default=False, description="Use osdi/OpenVAF")
 
-    depends_on("fftw-api@3:~mpi~openmp", when="+fft~openmp")
-    depends_on("fftw-api@3:~mpi+openmp", when="+fft+openmp")
+    depends_on("fftw-api@3", when="+fft")
+    with when("+fft+openmp"):
+        depends_on("acfl threads=openmp", when="^[virtuals=fftw-api] acfl")
+        depends_on("amdfftw+openmp", when="^[virtuals=fftw-api] amdfftw")
+        depends_on("armpl-gcc threads=openmp", when="^[virtuals=fftw-api] armpl-gcc")
+        depends_on("cray-fftw+openmp", when="^[virtuals=fftw-api] cray-fftw")
+        depends_on("fftw+openmp", when="^[virtuals=fftw-api] fftw")
+        depends_on("fujitsu-fftw+openmp", when="^[virtuals=fftw-api] fujitsu-fftw")
+        depends_on("intel-mkl threads=openmp", when="^[virtuals=fftw-api] intel-mkl")
+        depends_on("intel-oneapi-mkl threads=openmp", when="^[virtuals=fftw-api] intel-oneapi-mkl")
+        depends_on(
+            "intel-parallel-studio threads=openmp",
+            when="^[virtuals=fftw-api] intel-parallel-studio",
+        )
+
+    with when("+fft~openmp"):
+        depends_on("acfl threads=none", when="^[virtuals=fftw-api] acfl")
+        depends_on("amdfftw~openmp", when="^[virtuals=fftw-api] amdfftw")
+        depends_on("armpl-gcc threads=none", when="^[virtuals=fftw-api] armpl-gcc")
+        depends_on("cray-fftw~openmp", when="^[virtuals=fftw-api] cray-fftw")
+        depends_on("fftw~openmp", when="^[virtuals=fftw-api] fftw")
+        depends_on("fujitsu-fftw~openmp", when="^[virtuals=fftw-api] fujitsu-fftw")
+        depends_on("intel-mkl threads=none", when="^[virtuals=fftw-api] intel-mkl")
+        depends_on("intel-oneapi-mkl threads=none", when="^[virtuals=fftw-api] intel-oneapi-mkl")
+        depends_on(
+            "intel-parallel-studio threads=none", when="^[virtuals=fftw-api] intel-parallel-studio"
+        )
+
     depends_on("readline", when="+readline build=bin")
 
     # Needed for autoreconf:

--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -96,7 +96,8 @@ class Octopus(AutotoolsPackage, CudaPackage):
     depends_on("netcdf-fortran", when="+netcdf")  # NetCDF fortran lib without mpi variant
     with when("+mpi"):  # list all the parallel dependencies
         depends_on("fftw@3:+mpi+openmp", when="@8:9")  # FFT library
-        depends_on("fftw-api@3:+mpi+openmp", when="@10:")
+        depends_on("fftw-api@3:", when="@10:")
+        depends_on("fftw+mpi+openmp", when="^[virtuals=fftw-api] fftw")
         depends_on("libvdwxc+mpi", when="+libvdwxc")
         depends_on("arpack-ng+mpi", when="+arpack")
         depends_on("elpa+mpi", when="+elpa")
@@ -105,7 +106,8 @@ class Octopus(AutotoolsPackage, CudaPackage):
 
     with when("~mpi"):  # list all the serial dependencies
         depends_on("fftw@3:+openmp~mpi", when="@8:9")  # FFT library
-        depends_on("fftw-api@3:+openmp~mpi", when="@10:")
+        depends_on("fftw-api@3:", when="@10:")
+        depends_on("fftw~mpi+openmp", when="^[virtuals=fftw-api] fftw")
         depends_on("libvdwxc~mpi", when="+libvdwxc")
         depends_on("arpack-ng~mpi", when="+arpack")
         depends_on("elpa~mpi", when="+elpa")

--- a/var/spack/repos/builtin/packages/py-torchgeo/package.py
+++ b/var/spack/repos/builtin/packages/py-torchgeo/package.py
@@ -65,7 +65,15 @@ class PyTorchgeo(PythonPackage):
     depends_on("pil@8:", when="@0.5:", type=("build", "run"))
     depends_on("pil@6.2:", type=("build", "run"))
     # JPEG, TIFF, and compressed PNG support required for file I/O in several datasets.
-    depends_on("pil+jpeg+tiff+zlib", type=("build", "run"))
+    depends_on(
+        "py-pillow +jpeg+tiff+zlib", type=("build", "run"), when="^[virtuals=pil] py-pillow"
+    )
+    depends_on(
+        "py-pillow-simd +jpeg+tiff+zlib",
+        type=("build", "run"),
+        when="^[virtuals=pil] py-pillow-simd",
+    )
+
     depends_on("py-pyproj@3:", when="@0.5:", type=("build", "run"))
     depends_on("py-pyproj@2.2:", type=("build", "run"))
     depends_on("py-rasterio@1.2:", when="@0.5:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -26,7 +26,10 @@ class Qscintilla(QMakePackage):
     variant("python", default=False, description="Build python bindings")
 
     depends_on("qmake")
-    depends_on("qmake+opengl", when="+python")
+    with when("+python"):
+        depends_on("qt+opengl", when="^[virtuals=qmake] qt")
+        depends_on("qt-base +opengl", when="^[virtuals=qmake] qt-base")
+
     depends_on("py-pyqt6", type=("build", "run"), when="+python ^qt-base")
     depends_on("py-pyqt-builder", type="build", when="+python")
     depends_on("py-pyqt5", type=("build", "run"), when="+python ^qt@5")


### PR DESCRIPTION
Currently, a virtual spec is composed of just a name and a version. When a virtual spec contains other components, such as variants, Spack won't emit warnings or errors but will silently drop them - which is unexpected by users.

This PR adds an audit to catch where we use virtual specs with variants, and fixes the directive with the tools we currently have. Some changes, like the one for `fftw-api` are definitely repetitive and should be improved later.