### PR TITLE
flexiblas: explicitly set SYSCONFDIR

### DIFF
--- a/var/spack/repos/builtin/packages/flexiblas/package.py
+++ b/var/spack/repos/builtin/packages/flexiblas/package.py
@@ -22,3 +22,6 @@ class Flexiblas(CMakePackage):
     # virtual dependency
     provides("blas")
     provides("lapack")
+
+    def cmake_args(self):
+        return [self.define("SYSCONFDIR", self.prefix.etc)]


### PR DESCRIPTION
As of CMake 3.4, [GNUInstallDirs](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html#special-cases) treats `SYSCONFDIR` differently for a prefix that starts with `/opt`, then "the SYSCONFDIR value etc becomes /etc/opt/...." In the case of flexiblas, that results in failing attempts to write files to a system directory.

Since [flexiblas version 1](https://github.com/mpimd-csc/flexiblas/commit/0f2d2c76594ed27c9315f3736ff7d2727223620a#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR16), we can override SYSCONFDIR with our own defines.