### PR TITLE
adios2: fix build failure in v2.7.1

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/2.7.1-fix-broken-endian-reverse-compile.patch
+++ b/var/spack/repos/builtin/packages/adios2/2.7.1-fix-broken-endian-reverse-compile.patch
@@ -1,0 +1,23 @@
+From 5aed0d5c3ecb7afbd56a786243b2bc8811e0fbdd Mon Sep 17 00:00:00 2001
+From: Axel Huebl <axel.huebl@plasma.ninja>
+Date: Fri, 14 May 2021 18:22:19 -0700
+Subject: [PATCH] Fix Broken Endinage Reverse Compile
+
+Add right type in comparison.
+---
+ source/adios2/helper/adiosMemory.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/source/adios2/helper/adiosMemory.cpp b/source/adios2/helper/adiosMemory.cpp
+index c3a4246a91..3bf8c89adc 100644
+--- a/source/adios2/helper/adiosMemory.cpp
++++ b/source/adios2/helper/adiosMemory.cpp
+@@ -29,7 +29,7 @@ void CopyPayloadStride(const char *src, const size_t payloadStride, char *dest,
+ #ifdef ADIOS2_HAVE_ENDIAN_REVERSE
+     if (endianReverse)
+     {
+-        if (destType == "")
++        if (destType == DataType::None)
+         {
+         }
+ #define declare_type(T)                                                        \

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -212,6 +212,10 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
         sha256="8221073d1b2f8944395a88a5d60a15c7370646b62f5fc6309867bbb6a8c2096c",
     )
 
+    # Fix mismatched datatypes in comparison
+    # See https://github.com/ornladios/ADIOS2/pull/2701
+    patch("2.7.1-fix-broken-endian-reverse-compile.patch", when="@2.7.1")
+
     # cmake: find threads package first
     # https://github.com/ornladios/ADIOS2/pull/3893
     patch("2.9.2-cmake-find-threads-package-first.patch", when="@2.9.2:")


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/23643.

This version is needed for VisIt.