### PR TITLE
Fujitsu packages: require `%fj`

### DIFF
--- a/var/spack/repos/builtin/packages/fujitsu-fftw/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-fftw/package.py
@@ -50,16 +50,7 @@ class FujitsuFftw(FftwBase):
         when="%fj",
         msg="ARM-SVE vector instructions only works in single or double precision",
     )
-    conflicts("%arm")
-    conflicts("%cce")
-    conflicts("%apple-clang")
-    conflicts("%clang")
-    conflicts("%gcc")
-    conflicts("%intel")
-    conflicts("%nag")
-    conflicts("%pgi")
-    conflicts("%xl")
-    conflicts("%xl_r")
+    requires("%fj")
 
     def autoreconf(self, spec, prefix):
         if spec.target != "a64fx":

--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -13,18 +13,8 @@ class FujitsuMpi(Package):
 
     homepage = "https://www.fujitsu.com/us/"
 
-    conflicts("%arm")
-    conflicts("%cce")
-    conflicts("%apple-clang")
-    conflicts("%clang")
-    conflicts("%gcc")
-    conflicts("%intel")
-    conflicts("%nag")
-    conflicts("%pgi")
-    conflicts("%xl")
-    conflicts("%xl_r")
-
     provides("mpi@3.1:")
+    requires("%fj")
 
     def install(self, spec, prefix):
         raise InstallError("Fujitsu MPI is not installable; it is vendor supplied")

--- a/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py
@@ -18,20 +18,11 @@ class FujitsuSsl2(Package):
 
     variant("parallel", default=True, description="Build with thread-parallel versions")
 
-    conflicts("%arm")
-    conflicts("%cce")
-    conflicts("%apple-clang")
-    conflicts("%clang")
-    conflicts("%gcc")
-    conflicts("%intel")
-    conflicts("%nag")
-    conflicts("%pgi")
-    conflicts("%xl")
-    conflicts("%xl_r")
-
     provides("blas")
     provides("lapack")
     provides("scalapack")
+
+    requires("%fj")
 
     def install(self, spec, prefix):
         raise InstallError(


### PR DESCRIPTION
These packages were written before the "requires" directive, and so they are conflicting with all compilers but Fujitsu to express they _require_ `%fj`