### PR TITLE
[WIP] gromacs/hipsycl: build with ROCm

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -519,7 +519,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
                     [
                         "-DGMX_GPU:STRING=SYCL",
                         "-DGMX_SYCL_HIPSYCL=ON",
-                        f"-DHIPSYCL_TARGETS='hip:{arch_str}'",
+                        f"-DHIPSYCL_TARGETS=hip:{arch_str}",
                     ]
                 )
             elif "+sycl" in self.spec:

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -515,10 +515,13 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             elif "+rocm" in self.spec:
                 archs = self.spec.variants["amdgpu_target"].value
                 arch_str = ",".join(archs)
-                options.extend([
-                    "-DGMX_GPU:STRING=SYCL",
-                    "-DGMX_SYCL_HIPSYCL=ON",
-                    f"-DHIPSYCL_TARGETS='hip:{arch_str}'"])
+                options.extend(
+                    [
+                        "-DGMX_GPU:STRING=SYCL",
+                        "-DGMX_SYCL_HIPSYCL=ON",
+                        f"-DHIPSYCL_TARGETS='hip:{arch_str}'",
+                    ]
+                )
             elif "+sycl" in self.spec:
                 options.append("-DGMX_GPU:STRING=SYCL")
             else:

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -10,7 +10,7 @@ import llnl.util.filesystem as fs
 from spack.package import *
 
 
-class Gromacs(CMakePackage, CudaPackage):
+class Gromacs(CMakePackage, CudaPackage, ROCmPackage):
     """GROMACS is a molecular dynamics package primarily designed for simulations
     of proteins, lipids and nucleic acids. It was originally developed in
     the Biophysical Chemistry department of University of Groningen, and is now
@@ -512,6 +512,13 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
                 options.append("-DGMX_GPU:STRING=CUDA")
             elif "+opencl" in self.spec:
                 options.append("-DGMX_GPU:STRING=OpenCL")
+            elif "+rocm" in self.spec:
+                archs = self.spec.variants["amdgpu_target"].value
+                arch_str = ",".join(archs)
+                options.extend([
+                    "-DGMX_GPU:STRING=SYCL",
+                    "-DGMX_SYCL_HIPSYCL=ON",
+                    f"-DHIPSYCL_TARGETS='hip:{arch_str}'"])
             elif "+sycl" in self.spec:
                 options.append("-DGMX_GPU:STRING=SYCL")
             else:

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -285,6 +285,8 @@ class Gromacs(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("nvhpc", when="+cufftmp")
     depends_on("heffte", when="+heffte")
 
+    conflicts("^hipsycl~rocm", when="+rocm")
+
     requires(
         "%intel",
         "%oneapi",

--- a/var/spack/repos/builtin/packages/hipsycl/package.py
+++ b/var/spack/repos/builtin/packages/hipsycl/package.py
@@ -24,7 +24,12 @@ class Hipsycl(CMakePackage, ROCmPackage):
     provides("sycl")
 
     version("stable", branch="stable", submodules=True)
-    version("23.10.0", commit="3952b468c9da89edad9dff953cdcab0a3c3bf78c", submodules=True, get_full_repo=True)
+    version(
+        "23.10.0",
+        commit="3952b468c9da89edad9dff953cdcab0a3c3bf78c",
+        submodules=True,
+        get_full_repo=True,
+    )
     version("0.9.4", commit="99d9e24d462b35e815e0e59c1b611936c70464ae", submodules=True)
     version("0.9.3", commit="51507bad524c33afe8b124804091b10fa25618dc", submodules=True)
     version("0.9.2", commit="49fd02499841ae884c61c738610e58c27ab51fdb", submodules=True)
@@ -157,7 +162,9 @@ class Hipsycl(CMakePackage, ROCmPackage):
                     "found: {0}".format(so_paths)
                 )
             rpaths.add(path.dirname(so_paths[0]))
-            config["default-cuda-link-line"] += " " + " ".join("-rpath {0}".format(p) for p in rpaths)
+            config["default-cuda-link-line"] += " " + " ".join(
+                "-rpath {0}".format(p) for p in rpaths
+            )
         # Replace the installed config file
         with open(config_file_path, "w") as f:
             json.dump(config, f, indent=2)

--- a/var/spack/repos/builtin/packages/hipsycl/package.py
+++ b/var/spack/repos/builtin/packages/hipsycl/package.py
@@ -11,7 +11,7 @@ from llnl.util import filesystem
 from spack.package import *
 
 
-class Hipsycl(CMakePackage):
+class Hipsycl(CMakePackage, ROCmPackage):
     """hipSYCL is an implementation of the SYCL standard programming model
     over NVIDIA CUDA/AMD HIP"""
 
@@ -24,6 +24,7 @@ class Hipsycl(CMakePackage):
     provides("sycl")
 
     version("stable", branch="stable", submodules=True)
+    version("23.10.0", commit="3952b468c9da89edad9dff953cdcab0a3c3bf78c", submodules=True, get_full_repo=True)
     version("0.9.4", commit="99d9e24d462b35e815e0e59c1b611936c70464ae", submodules=True)
     version("0.9.3", commit="51507bad524c33afe8b124804091b10fa25618dc", submodules=True)
     version("0.9.2", commit="49fd02499841ae884c61c738610e58c27ab51fdb", submodules=True)
@@ -37,13 +38,13 @@ class Hipsycl(CMakePackage):
     depends_on("boost +filesystem", when="@:0.8")
     depends_on("boost@1.67.0:1.69.0 +filesystem +fiber +context cxxstd=17", when="@0.9.1:")
     depends_on("python@3:")
-    depends_on("llvm@8: +clang", when="~cuda")
-    depends_on("llvm@9: +clang", when="+cuda")
+    depends_on("libllvm@8: +clang", when="~cuda")
+    depends_on("libllvm@9: +clang", when="+cuda")
     # hipSYCL 0.8.0 supported only LLVM 8-10:
     # (https://github.com/AdaptiveCpp/AdaptiveCpp/blob/v0.8.0/CMakeLists.txt#L29-L37)
-    depends_on("llvm@8:10", when="@0.8.0")
+    depends_on("libllvm@8:10", when="@0.8.0")
     # https://github.com/OpenSYCL/OpenSYCL/pull/918 was introduced after 0.9.4
-    conflicts("^llvm@16:", when="@:0.9.4")
+    conflicts("^libllvm@16:", when="@:0.9.4")
     # LLVM PTX backend requires cuda7:10.1 (https://tinyurl.com/v82k5qq)
     depends_on("cuda@9:10.1", when="@0.8.1: +cuda ^llvm@9")
     depends_on("cuda@9:", when="@0.8.1: +cuda ^llvm@10:")
@@ -73,15 +74,17 @@ class Hipsycl(CMakePackage):
         args = [
             "-DWITH_CPU_BACKEND:Bool=TRUE",
             # TODO: no ROCm stuff available in spack yet
-            "-DWITH_ROCM_BACKEND:Bool=FALSE",
+            "-DWITH_ROCM_BACKEND:Bool={0}".format("TRUE" if "+rocm" in spec else "FALSE"),
             "-DWITH_CUDA_BACKEND:Bool={0}".format("TRUE" if "+cuda" in spec else "FALSE"),
             # prevent hipSYCL's cmake to look for other LLVM installations
             # if the specified one isn't compatible
             "-DDISABLE_LLVM_VERSION_CHECK:Bool=TRUE",
         ]
+        if "+rocm" in spec:
+            args += [f"-DHIP_CXX_COMPILER={self.compiler.cxx}"]
         # LLVM directory containing all installed CMake files
         # (e.g.: configs consumed by client projects)
-        llvm_cmake_dirs = filesystem.find(spec["llvm"].prefix, "LLVMExports.cmake")
+        llvm_cmake_dirs = filesystem.find(spec["libllvm"].prefix, "LLVMExports.cmake")
         if len(llvm_cmake_dirs) != 1:
             raise InstallError(
                 "concretized llvm dependency must provide "
@@ -91,7 +94,7 @@ class Hipsycl(CMakePackage):
         args.append("-DLLVM_DIR:String={0}".format(path.dirname(llvm_cmake_dirs[0])))
         # clang internal headers directory
         llvm_clang_include_dirs = filesystem.find(
-            spec["llvm"].prefix, "__clang_cuda_runtime_wrapper.h"
+            spec["libllvm"].prefix, "__clang_cuda_runtime_wrapper.h"
         )
         if len(llvm_clang_include_dirs) != 1:
             raise InstallError(
@@ -103,7 +106,7 @@ class Hipsycl(CMakePackage):
             "-DCLANG_INCLUDE_PATH:String={0}".format(path.dirname(llvm_clang_include_dirs[0]))
         )
         # target clang++ executable
-        llvm_clang_bin = path.join(spec["llvm"].prefix.bin, "clang++")
+        llvm_clang_bin = path.join(spec["libllvm"].prefix.bin, "clang++")
         if not filesystem.is_exe(llvm_clang_bin):
             raise InstallError(
                 "concretized llvm dependency must provide a "
@@ -129,31 +132,32 @@ class Hipsycl(CMakePackage):
             config = json.load(f)
         # 1. Fix compiler: use the real one in place of the Spack wrapper
         config["default-cpu-cxx"] = self.compiler.cxx
-        # 2. Fix stdlib: we need to make sure cuda-enabled binaries find
-        #    the libc++.so and libc++abi.so dyn linked to the sycl
-        #    ptx backend
-        rpaths = set()
-        so_paths = filesystem.find_libraries(
-            "libc++", self.spec["llvm"].prefix, shared=True, recursive=True
-        )
-        if len(so_paths) != 1:
-            raise InstallError(
-                "concretized llvm dependency must provide a "
-                "unique directory containing libc++.so, "
-                "found: {0}".format(so_paths)
+        if "+cuda" in self.spec:
+            # 2. Fix stdlib: we need to make sure cuda-enabled binaries find
+            #    the libc++.so and libc++abi.so dyn linked to the sycl
+            #    ptx backend
+            rpaths = set()
+            so_paths = filesystem.find_libraries(
+                "libc++", self.spec["libllvm"].prefix, shared=True, recursive=True
             )
-        rpaths.add(path.dirname(so_paths[0]))
-        so_paths = filesystem.find_libraries(
-            "libc++abi", self.spec["llvm"].prefix, shared=True, recursive=True
-        )
-        if len(so_paths) != 1:
-            raise InstallError(
-                "concretized llvm dependency must provide a "
-                "unique directory containing libc++abi, "
-                "found: {0}".format(so_paths)
+            if len(so_paths) != 1:
+                raise InstallError(
+                    "concretized llvm dependency must provide a "
+                    "unique directory containing libc++.so, "
+                    "found: {0}".format(so_paths)
+                )
+            rpaths.add(path.dirname(so_paths[0]))
+            so_paths = filesystem.find_libraries(
+                "libc++abi", self.spec["libllvm"].prefix, shared=True, recursive=True
             )
-        rpaths.add(path.dirname(so_paths[0]))
-        config["default-cuda-link-line"] += " " + " ".join("-rpath {0}".format(p) for p in rpaths)
+            if len(so_paths) != 1:
+                raise InstallError(
+                    "concretized llvm dependency must provide a "
+                    "unique directory containing libc++abi, "
+                    "found: {0}".format(so_paths)
+                )
+            rpaths.add(path.dirname(so_paths[0]))
+            config["default-cuda-link-line"] += " " + " ".join("-rpath {0}".format(p) for p in rpaths)
         # Replace the installed config file
         with open(config_file_path, "w") as f:
             json.dump(config, f, indent=2)

--- a/var/spack/repos/builtin/packages/hipsycl/package.py
+++ b/var/spack/repos/builtin/packages/hipsycl/package.py
@@ -78,13 +78,13 @@ class Hipsycl(CMakePackage, ROCmPackage):
         spec = self.spec
         args = [
             "-DWITH_CPU_BACKEND:Bool=TRUE",
-            # TODO: no ROCm stuff available in spack yet
             "-DWITH_ROCM_BACKEND:Bool={0}".format("TRUE" if "+rocm" in spec else "FALSE"),
             "-DWITH_CUDA_BACKEND:Bool={0}".format("TRUE" if "+cuda" in spec else "FALSE"),
             # prevent hipSYCL's cmake to look for other LLVM installations
             # if the specified one isn't compatible
             "-DDISABLE_LLVM_VERSION_CHECK:Bool=TRUE",
         ]
+        args += [f"-DACPP_VERSION_SUFFIX=spack-{self.version}"]
         if "+rocm" in spec:
             args += [f"-DHIP_CXX_COMPILER={self.compiler.cxx}"]
         # LLVM directory containing all installed CMake files

--- a/var/spack/repos/builtin/packages/hipsycl/package.py
+++ b/var/spack/repos/builtin/packages/hipsycl/package.py
@@ -43,8 +43,9 @@ class Hipsycl(CMakePackage, ROCmPackage):
     depends_on("boost +filesystem", when="@:0.8")
     depends_on("boost@1.67.0:1.69.0 +filesystem +fiber +context cxxstd=17", when="@0.9.1:")
     depends_on("python@3:")
-    depends_on("libllvm@8: +clang", when="~cuda")
-    depends_on("libllvm@9: +clang", when="+cuda")
+    depends_on("libllvm@8:", when="~cuda")
+    depends_on("libllvm@9:", when="+cuda")
+    depends_on("llvm+clang", when="^llvm")
     # hipSYCL 0.8.0 supported only LLVM 8-10:
     # (https://github.com/AdaptiveCpp/AdaptiveCpp/blob/v0.8.0/CMakeLists.txt#L29-L37)
     depends_on("libllvm@8:10", when="@0.8.0")


### PR DESCRIPTION
Using https://spack.readthedocs.io/en/latest/gpu_configuration.html#using-an-external-rocm-installation, build `hipsycl` and `gromacs` with a new `+rocm` option enabled. Changes include:

* `hipsycl` was expecting to use `llvm` specifically, vs. the `libllvm` virtual (which `llvm-amdgpu` also provides)
* `hipsycl`: conditionally perform a search for `libc++.so`, since the resulting usage is only required for `+cuda`

There are a number of issues that require some attention:

* The `-DHIPSYCL` args in CMake are deprecated:
    ```
    find_package(hipSYCL) is deprecated.  Use find_package(AdaptiveCpp)
    instead.  For this, you may have to set
    -DAdaptiveCpp_DIR=/install/prefix/lib/cmake/AdaptiveCpp.  Additionally,
    replace -DHIPSYCL_* cmake arguments with -DACPP_*
    ```
  * UPDATE: I tried specifying e.g. `-DACPP_TARGETS` instead of `-DHIPSYCL_TARGETS` and the `gromacs` build failed. I'm wondering if `gromacs` CMake needs updating to use these new option names
* Right now `gromacs` has `+sycl` and `+rocm`, which may be redundant and/or allow for nonsensical combinations
  * I could set CMake args based on `hipsycl+rocm` and omit a `+rocm` variant for `gromacs`
    * This makes ROCm-handling for gromacs inconsistent with other libs though
  * I could forbid `~sycl+rocm` (`+sycl~rocm` would make sense though)
* (EDIT: this is fixed thanks to a suggestion from Andrey) ~`hipsycl` runs git commands as part of its build, which fails if Spack uses a cached instance of a git commit (using `get_full_repo` on the version does not help). For now, a repeated installation attempt of `hipsycl` requires running `spack clean -d` beforehand.~

Side notes

* The Spack `hipsycl` package renamed their project, and https://github.com/illuhad/hipSYCL redirects to https://github.com/AdaptiveCpp/AdaptiveCpp (in case anyone finds the warnings about "ACPP" to be confusing)
* I tried removing `sycl` from `gromacs` but GROMACS appears to explicitly require finding `hipsycl` in its CMake files