### PR TITLE
spack buildcache push: default to --update-index

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -1132,7 +1132,7 @@ index once every package is pushed. Note how this target uses the generated
    example/push/%: example/install/%
    	@mkdir -p $(dir $@)
    	$(info About to push $(SPEC) to a buildcache)
-   	$(SPACK) -e . buildcache push --allow-root --only=package $(BUILDCACHE_DIR) /$(HASH)
+   	$(SPACK) -e . buildcache push --no-update-index --only=package $(BUILDCACHE_DIR) /$(HASH)
    	@touch $@
 
    push: $(addprefix example/push/,$(example/SPACK_PACKAGE_IDS))

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -96,13 +96,22 @@ def setup_parser(subparser: argparse.ArgumentParser):
     push.add_argument(
         "mirror", type=arguments.mirror_name_or_url, help="mirror name, path, or URL"
     )
-    push.add_argument(
+    push_update_index = push.add_mutually_exclusive_group(required=False)
+    push_update_index.add_argument(
         "--update-index",
         "--rebuild-index",
         action="store_true",
-        default=False,
-        help="regenerate buildcache index after building package(s)",
+        dest="update_index",
+        help="regenerate buildcache index after pushing (default)",
     )
+    push_update_index.add_argument(
+        "--no-update-index",
+        "--no-rebuild-index",
+        action="store_false",
+        dest="update_index",
+        help="do not regenerate buildcache index after pushing packages",
+    )
+    push_update_index.set_defaults(update_index=True)
     push.add_argument(
         "--spec-file", default=None, help="create buildcache entry for spec from json or yaml file"
     )

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -348,10 +348,10 @@ def test_push_and_install_with_mirror_marked_unsigned_does_not_require_extra_fla
     # Push
     if signed:
         # Need to pass "--unsigned" to override the mirror's default
-        args = ["push", "--update-index", "--unsigned", "my-mirror", f"/{spec.dag_hash()}"]
+        args = ["push", "--unsigned", "my-mirror", f"/{spec.dag_hash()}"]
     else:
         # No need to pass "--unsigned" if the mirror is unsigned
-        args = ["push", "--update-index", "my-mirror", f"/{spec.dag_hash()}"]
+        args = ["push", "my-mirror", f"/{spec.dag_hash()}"]
 
     buildcache(*args)
 

--- a/lib/spack/spack/test/oci/integration_test.py
+++ b/lib/spack/spack/test/oci/integration_test.py
@@ -35,7 +35,7 @@ def test_buildcache_push_command(mutable_database, disable_parallel_buildcache_p
         mirror("add", "oci-test", "oci://example.com/image")
 
         # Push the package(s) to the OCI registry
-        buildcache("push", "--update-index", "oci-test", "mpileaks^mpich")
+        buildcache("push", "oci-test", "mpileaks^mpich")
 
         # Remove mpileaks from the database
         matches = mutable_database.query_local("mpileaks^mpich")

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -571,7 +571,7 @@ _spack_buildcache() {
 _spack_buildcache_push() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -f --force --allow-root -a --unsigned -u --signed --key -k --update-index --rebuild-index --spec-file --only --fail-fast --base-image -j --jobs"
+        SPACK_COMPREPLY="-h --help -f --force --allow-root -a --unsigned -u --signed --key -k --update-index --rebuild-index --no-update-index --no-rebuild-index --spec-file --only --fail-fast --base-image -j --jobs"
     else
         _mirrors
     fi
@@ -580,7 +580,7 @@ _spack_buildcache_push() {
 _spack_buildcache_create() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -f --force --allow-root -a --unsigned -u --signed --key -k --update-index --rebuild-index --spec-file --only --fail-fast --base-image -j --jobs"
+        SPACK_COMPREPLY="-h --help -f --force --allow-root -a --unsigned -u --signed --key -k --update-index --rebuild-index --no-update-index --no-rebuild-index --spec-file --only --fail-fast --base-image -j --jobs"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -697,7 +697,7 @@ complete -c spack -n '__fish_spack_using_command buildcache' -s h -l help -f -a 
 complete -c spack -n '__fish_spack_using_command buildcache' -s h -l help -d 'show this help message and exit'
 
 # spack buildcache push
-set -g __fish_spack_optspecs_spack_buildcache_push h/help f/force a/allow-root u/unsigned signed k/key= update-index spec-file= only= fail-fast base-image= j/jobs=
+set -g __fish_spack_optspecs_spack_buildcache_push h/help f/force a/allow-root u/unsigned signed k/key= update-index no-update-index spec-file= only= fail-fast base-image= j/jobs=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 1 buildcache push' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command buildcache push' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache push' -s h -l help -d 'show this help message and exit'
@@ -712,7 +712,9 @@ complete -c spack -n '__fish_spack_using_command buildcache push' -l signed -d '
 complete -c spack -n '__fish_spack_using_command buildcache push' -l key -s k -r -f -a key
 complete -c spack -n '__fish_spack_using_command buildcache push' -l key -s k -r -d 'key for signing'
 complete -c spack -n '__fish_spack_using_command buildcache push' -l update-index -l rebuild-index -f -a update_index
-complete -c spack -n '__fish_spack_using_command buildcache push' -l update-index -l rebuild-index -d 'regenerate buildcache index after building package(s)'
+complete -c spack -n '__fish_spack_using_command buildcache push' -l update-index -l rebuild-index -d 'regenerate buildcache index after pushing (default)'
+complete -c spack -n '__fish_spack_using_command buildcache push' -l no-update-index -l no-rebuild-index -f -a update_index
+complete -c spack -n '__fish_spack_using_command buildcache push' -l no-update-index -l no-rebuild-index -d 'do not regenerate buildcache index after pushing packages'
 complete -c spack -n '__fish_spack_using_command buildcache push' -l spec-file -r -f -a spec_file
 complete -c spack -n '__fish_spack_using_command buildcache push' -l spec-file -r -d 'create buildcache entry for spec from json or yaml file'
 complete -c spack -n '__fish_spack_using_command buildcache push' -l only -r -f -a 'package dependencies'
@@ -725,7 +727,7 @@ complete -c spack -n '__fish_spack_using_command buildcache push' -s j -l jobs -
 complete -c spack -n '__fish_spack_using_command buildcache push' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
 
 # spack buildcache create
-set -g __fish_spack_optspecs_spack_buildcache_create h/help f/force a/allow-root u/unsigned signed k/key= update-index spec-file= only= fail-fast base-image= j/jobs=
+set -g __fish_spack_optspecs_spack_buildcache_create h/help f/force a/allow-root u/unsigned signed k/key= update-index no-update-index spec-file= only= fail-fast base-image= j/jobs=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 1 buildcache create' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command buildcache create' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command buildcache create' -s h -l help -d 'show this help message and exit'
@@ -740,7 +742,9 @@ complete -c spack -n '__fish_spack_using_command buildcache create' -l signed -d
 complete -c spack -n '__fish_spack_using_command buildcache create' -l key -s k -r -f -a key
 complete -c spack -n '__fish_spack_using_command buildcache create' -l key -s k -r -d 'key for signing'
 complete -c spack -n '__fish_spack_using_command buildcache create' -l update-index -l rebuild-index -f -a update_index
-complete -c spack -n '__fish_spack_using_command buildcache create' -l update-index -l rebuild-index -d 'regenerate buildcache index after building package(s)'
+complete -c spack -n '__fish_spack_using_command buildcache create' -l update-index -l rebuild-index -d 'regenerate buildcache index after pushing (default)'
+complete -c spack -n '__fish_spack_using_command buildcache create' -l no-update-index -l no-rebuild-index -f -a update_index
+complete -c spack -n '__fish_spack_using_command buildcache create' -l no-update-index -l no-rebuild-index -d 'do not regenerate buildcache index after pushing packages'
 complete -c spack -n '__fish_spack_using_command buildcache create' -l spec-file -r -f -a spec_file
 complete -c spack -n '__fish_spack_using_command buildcache create' -l spec-file -r -d 'create buildcache entry for spec from json or yaml file'
 complete -c spack -n '__fish_spack_using_command buildcache create' -l only -r -f -a 'package dependencies'


### PR DESCRIPTION
The following works:

```
spack install x # from sources
spack buildcache push <mirror> x

spack uninstall x
spack install [--cache-only] x  # from build cache
```

which makes one think this always works.

The problem is it only works by accident since spack concretizes x to the same
spec, and it may stop doing so whenever the package repo is updated.

To make it work reliably, you gotta do

```
spack buildcache push --update-index <mirror> x
# or spack buildcache update-index <mirror>
```

which may be hard to figure out for users, so this PR changes the defaults,
meaning that users have to opt out of rebuilding the index:

```
spack buildcache push --no-update-index <mirror> x
```
