### PR TITLE
add rpp tests and modify mivisionx's opencv dependency

### DIFF
--- a/var/spack/repos/builtin/packages/mivisionx/package.py
+++ b/var/spack/repos/builtin/packages/mivisionx/package.py
@@ -287,7 +287,7 @@ class Mivisionx(CMakePackage):
     depends_on(
         "opencv@4.5:"
         "+calib3d+features2d+highgui+imgcodecs+imgproc"
-        "+video+videoio+flann+photo+objdetect",
+        "+video+videoio+flann+photo+objdetect+png+jpeg",
         type="build",
         when="@5.3:",
     )

--- a/var/spack/repos/builtin/packages/rpp/0003-changes-to-rpp-unit-tests.patch
+++ b/var/spack/repos/builtin/packages/rpp/0003-changes-to-rpp-unit-tests.patch
@@ -1,3 +1,10 @@
+From: Afzal Patel <afzal.patel@amd.com>
+Date: Tue Jan  9 09:57:48 PST 2024
+Subject: [PATCH] changes-to-rpp-unit-tests
+Description: This patch makes changes to the CMakeLists.txt for the rpp unit tests.
+             It adds the directory which contains half.hpp and also modifies the method
+             the libjpegturbo library is linked.
+---
 diff git a/utilities/test_suite/HIP/CMakeLists.txt b/utilities/test_suite/HIP/CMakeLists.txt
 index 8f32a66..456999e 100644
 --- a/utilities/test_suite/HIP/CMakeLists.txt

--- a/var/spack/repos/builtin/packages/rpp/0003-changes-to-rpp-unit-tests.patch
+++ b/var/spack/repos/builtin/packages/rpp/0003-changes-to-rpp-unit-tests.patch
@@ -1,0 +1,55 @@
+diff git a/utilities/test_suite/HIP/CMakeLists.txt b/utilities/test_suite/HIP/CMakeLists.txt
+index 8f32a66..456999e 100644
+--- a/utilities/test_suite/HIP/CMakeLists.txt
++++ b/utilities/test_suite/HIP/CMakeLists.txt
+@@ -55,7 +55,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+ if(TurboJpeg_FOUND)
+     message("-- ${Green}${PROJECT_NAME} set to build with rpp and TurboJpeg${ColourReset}")
+     include_directories(${TurboJpeg_INCLUDE_DIRS})
+-    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${TurboJpeg_LIBRARIES_DIR})
++    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${TurboJpeg_LIBRARIES})
+ else()
+     message("-- ${Yellow}Error: TurboJpeg must be installed to install ${PROJECT_NAME} successfully!${ColourReset}")
+ endif()
+@@ -72,7 +72,7 @@ if (hip_FOUND AND OpenCV_FOUND)
+
+     add_executable(Tensor_hip Tensor_hip.cpp)
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGPU_SUPPORT=1 -DRPP_BACKEND_HIP=1 -std=gnu++14")
+-    target_link_libraries(Tensor_hip ${OpenCV_LIBS} -lturbojpeg -lrpp ${hip_LIBRARIES} pthread ${LINK_LIBRARY_LIST} hip::device)
++    target_link_libraries(Tensor_hip ${OpenCV_LIBS} -lrpp ${hip_LIBRARIES} pthread ${LINK_LIBRARY_LIST} hip::device)
+ else()
+     message("-- ${Yellow}Error: OpenCV and hip must be installed to install ${PROJECT_NAME} successfully!${ColourReset}")
+-endif()
+\ No newline at end of file
++endif()
+diff --git a/utilities/test_suite/HOST/CMakeLists.txt b/utilities/test_suite/HOST/CMakeLists.txt
+index bad0d60..5a8fd5c 100644
+--- a/utilities/test_suite/HOST/CMakeLists.txt
++++ b/utilities/test_suite/HOST/CMakeLists.txt
+@@ -50,10 +50,13 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} -ggdb -O0")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+ set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} OpenMP::OpenMP_CXX)
+
++find_path(HALF_INCLUDE_DIR half.hpp)
++include_directories(${HALF_INCLUDE_DIR})
++
+ if(TurboJpeg_FOUND)
+     message("-- ${Green}${PROJECT_NAME} set to build with rpp and TurboJpeg${ColourReset}")
+     include_directories(${TurboJpeg_INCLUDE_DIRS})
+-    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${TurboJpeg_LIBRARIES_DIR})
++    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${TurboJpeg_LIBRARIES})
+ else()
+     message("-- ${Yellow}Error: TurboJpeg must be installed to install ${PROJECT_NAME} successfully!${ColourReset}")
+ endif()
+@@ -67,8 +70,8 @@ if (OpenCV_FOUND)
+     add_executable(Tensor_host Tensor_host.cpp)
+
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++14")
+-    target_link_libraries(Tensor_host ${OpenCV_LIBS} -lturbojpeg -lrpp pthread ${LINK_LIBRARY_LIST})
++    target_link_libraries(Tensor_host ${OpenCV_LIBS} -lrpp pthread ${LINK_LIBRARY_LIST})
+
+ else()
+     message("-- ${Yellow}Error: OpenCV must be installed to install ${PROJECT_NAME} successfully!${ColourReset}")
+-endif()
+\ No newline at end of file
++endif()

--- a/var/spack/repos/builtin/packages/rpp/package.py
+++ b/var/spack/repos/builtin/packages/rpp/package.py
@@ -48,7 +48,7 @@ class Rpp(CMakePackage):
     variant(
         "add_tests",
         default=False,
-        description="add utilities folder which contains rpp unit tests"
+        description="add utilities folder which contains rpp unit tests",
     )
 
     patch("0001-include-half-openmp-through-spack-package.patch")

--- a/var/spack/repos/builtin/packages/rpp/package.py
+++ b/var/spack/repos/builtin/packages/rpp/package.py
@@ -53,6 +53,9 @@ class Rpp(CMakePackage):
 
     patch("0001-include-half-openmp-through-spack-package.patch")
     patch("0002-declare-handle-in-header.patch")
+
+    """patch adds half include directory and modifies how the libjpegturbo
+    library is linked for the rpp unit test"""
     patch("0003-changes-to-rpp-unit-tests.patch", when="+add_tests")
 
     def patch(self):

--- a/var/spack/repos/builtin/packages/rpp/package.py
+++ b/var/spack/repos/builtin/packages/rpp/package.py
@@ -45,7 +45,11 @@ class Rpp(CMakePackage):
     variant("opencl", default=False, description="Use OPENCL as the backend")
     variant("hip", default=True, description="Use HIP as backend")
     variant("cpu", default=False, description="Use CPU as backend")
-    variant("add_tests", default=False, description="add utilities folder")
+    variant(
+        "add_tests",
+        default=False,
+        description="add utilities folder which contains rpp unit tests"
+    )
 
     patch("0001-include-half-openmp-through-spack-package.patch")
     patch("0002-declare-handle-in-header.patch")

--- a/var/spack/repos/builtin/packages/rpp/package.py
+++ b/var/spack/repos/builtin/packages/rpp/package.py
@@ -54,8 +54,8 @@ class Rpp(CMakePackage):
     patch("0001-include-half-openmp-through-spack-package.patch")
     patch("0002-declare-handle-in-header.patch")
 
-    """patch adds half include directory and modifies how the libjpegturbo
-    library is linked for the rpp unit test"""
+    # adds half.hpp include directory and modifies how the libjpegturbo
+    # library is linked for the rpp unit test
     patch("0003-changes-to-rpp-unit-tests.patch", when="+add_tests")
 
     def patch(self):

--- a/var/spack/repos/builtin/packages/rpp/package.py
+++ b/var/spack/repos/builtin/packages/rpp/package.py
@@ -107,10 +107,10 @@ class Rpp(CMakePackage):
         "opencv@4.5:"
         "+calib3d+features2d+highgui+imgcodecs+imgproc"
         "+video+videoio+flann+photo+objdetect",
-        type=("build", "run"),
+        type=("build", "link"),
         when="@1.0:",
     )
-    depends_on("libjpeg-turbo", type=("build", "run"))
+    depends_on("libjpeg-turbo", type=("build", "link"))
     depends_on("rocm-openmp-extras")
     conflicts("+opencl+hip")
 

--- a/var/spack/repos/builtin/packages/rpp/package.py
+++ b/var/spack/repos/builtin/packages/rpp/package.py
@@ -45,9 +45,11 @@ class Rpp(CMakePackage):
     variant("opencl", default=False, description="Use OPENCL as the backend")
     variant("hip", default=True, description="Use HIP as backend")
     variant("cpu", default=False, description="Use CPU as backend")
+    variant("add_tests", default=False, description="add utilities folder")
 
     patch("0001-include-half-openmp-through-spack-package.patch")
     patch("0002-declare-handle-in-header.patch")
+    patch("0003-changes-to-rpp-unit-tests.patch", when="+add_tests")
 
     def patch(self):
         if self.spec.satisfies("+hip"):
@@ -59,6 +61,31 @@ class Rpp(CMakePackage):
                 "${ROCM_PATH}",
                 self.spec["rocm-opencl"].prefix,
                 "cmake/FindOpenCL.cmake",
+                string=True,
+            )
+        if self.spec.satisfies("+add_tests"):
+            filter_file(
+                "${ROCM_PATH}/include/rpp",
+                self.spec.prefix.include.rpp,
+                "utilities/test_suite/HOST/CMakeLists.txt",
+                string=True,
+            )
+            filter_file(
+                "${ROCM_PATH}/lib",
+                self.spec.prefix.lib,
+                "utilities/test_suite/HOST/CMakeLists.txt",
+                string=True,
+            )
+            filter_file(
+                "${ROCM_PATH}/include/rpp",
+                self.spec.prefix.include.rpp,
+                "utilities/test_suite/HIP/CMakeLists.txt",
+                string=True,
+            )
+            filter_file(
+                "${ROCM_PATH}/lib",
+                self.spec.prefix.lib,
+                "utilities/test_suite/HIP/CMakeLists.txt",
                 string=True,
             )
 
@@ -73,10 +100,10 @@ class Rpp(CMakePackage):
         "opencv@4.5:"
         "+calib3d+features2d+highgui+imgcodecs+imgproc"
         "+video+videoio+flann+photo+objdetect",
-        type="build",
+        type=("build", "run"),
         when="@1.0:",
     )
-    depends_on("libjpeg-turbo", type="build")
+    depends_on("libjpeg-turbo", type=("build", "run"))
     depends_on("rocm-openmp-extras")
     conflicts("+opencl+hip")
 
@@ -84,6 +111,10 @@ class Rpp(CMakePackage):
         depends_on("hip@5:")
     with when("~hip"):
         depends_on("rocm-opencl@5:")
+
+    def setup_run_environment(self, env):
+        if self.spec.satisfies("+add_tests"):
+            env.set("TURBO_JPEG_PATH", self.spec["libjpeg-turbo"].prefix)
 
     def cmake_args(self):
         spec = self.spec
@@ -102,3 +133,9 @@ class Rpp(CMakePackage):
                 )
             )
         return args
+
+    @run_after("install")
+    def add_tests(self):
+        if self.spec.satisfies("+add_tests"):
+            install_tree("utilities", self.spec.prefix.utilities)
+            install_tree("cmake", self.spec.prefix.cmake)


### PR DESCRIPTION
Adding rpp unit tests. Method to run the tests:
`spack install rpp + add_tests`
`spack load rpp`
`cd <rpp install path>/utilities/test_suite/HOST/`
`python runTests.py --case_list 0 1 2 4 13 31 34 36 37 38 84 --test_type 0 --qa_mode 1 --batch_size 3`
`cd <rpp install path>/utilities/test_suite/HIP/`
`python runTests.py --case_list 0 1 2 4 13 31 34 36 37 38 84 --test_type 0 --qa_mode 1 --batch_size 3`

Also adding build png and jpeg for opencv in mivisionx. This is required for Video Inferencing Tests and rocAL Video Unit Test

