### PR TITLE
nvpl-blas and nvpl-lapack: new packages for NVidia performance libraries

### DIFF
--- a/var/spack/repos/builtin/packages/nvpl-blas/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-blas/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/nvpl-blas/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-blas/package.py
@@ -26,7 +26,42 @@ class NvplBlas(Package):
 
     provides("blas")
 
-    # TODO add compiler requirements
+    variant("ilp64", default=False, description="Force 64-bit Fortran native integers")
+    variant(
+        "threads",
+        default="none",
+        description="Multithreading support",
+        values=("openmp", "none"),
+        multi=False,
+    )
+
+    conflicts("%gcc@:7")
+    conflicts("%clang@:13")
+
+    conflicts("threads=openmp", when="%clang")
+
+    @property
+    def blas_headers(self):
+        return find_all_headers(self.spec.prefix.include)
+
+    @property
+    def blas_libs(self):
+        spec = self.spec
+
+        if "+ilp64" in spec:
+          int_type = "ilp64"
+        else:
+          int_type = "lp64"
+
+        if spec.satisfies("threads=openmp"):
+          threading_type="gomp"
+        else:
+          # threads=none
+          threading_type = "seq"
+
+        name = ["libnvpl_blas_core", f"libnvpl_blas_{int_type}_{threading_type}"]
+
+        return find_libraries(name, spec.prefix.lib, shared=True, recursive=True)
 
     def install(self, spec, prefix):
         install_tree(".", prefix)

--- a/var/spack/repos/builtin/packages/nvpl-blas/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-blas/package.py
@@ -20,8 +20,6 @@ class NvplBlas(Package):
 
     maintainers("albestro", "rasolca")
 
-    # FIXME: Add the SPDX identifier of the project's license below.
-    # See https://spdx.org/licenses/ for a list.
     license("UNKNOWN")
 
     version("0.1.0", sha256="4ccc894593cbcbfaa1a4f3c54505982691971667acf191c9ab0f4252a37c8063")

--- a/var/spack/repos/builtin/packages/nvpl-blas/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-blas/package.py
@@ -35,6 +35,8 @@ class NvplBlas(Package):
         multi=False,
     )
 
+    requires("target=armv8.2a:", msg="Any CPU with Arm-v8.2a+ microarch")
+
     conflicts("%gcc@:7")
     conflicts("%clang@:13")
 

--- a/var/spack/repos/builtin/packages/nvpl-blas/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-blas/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class NvplBlas(Package):
+    """
+    NVPL BLAS (NVIDIA Performance Libraries BLAS) is part of NVIDIA Performance Libraries
+    that provides standard Fortran 77 BLAS APIs as well as C (CBLAS).
+    """
+
+    homepage = "https://docs.nvidia.com/nvpl/_static/blas/index.html"
+    url = ("https://developer.download.nvidia.com/compute/nvpl/redist"
+           "/nvpl_blas/linux-sbsa/nvpl_blas-linux-sbsa-0.1.0-archive.tar.xz")
+
+    maintainers("albestro", "rasolca")
+
+    # FIXME: Add the SPDX identifier of the project's license below.
+    # See https://spdx.org/licenses/ for a list.
+    license("UNKNOWN")
+
+    version("0.1.0", sha256="4ccc894593cbcbfaa1a4f3c54505982691971667acf191c9ab0f4252a37c8063")
+
+    provides("blas")
+
+    # TODO add compiler requirements
+
+    def install(self, spec, prefix):
+        install_tree(".", prefix)

--- a/var/spack/repos/builtin/packages/nvpl-blas/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-blas/package.py
@@ -13,8 +13,10 @@ class NvplBlas(Package):
     """
 
     homepage = "https://docs.nvidia.com/nvpl/_static/blas/index.html"
-    url = ("https://developer.download.nvidia.com/compute/nvpl/redist"
-           "/nvpl_blas/linux-sbsa/nvpl_blas-linux-sbsa-0.1.0-archive.tar.xz")
+    url = (
+        "https://developer.download.nvidia.com/compute/nvpl/redist"
+        "/nvpl_blas/linux-sbsa/nvpl_blas-linux-sbsa-0.1.0-archive.tar.xz"
+    )
 
     maintainers("albestro", "rasolca")
 
@@ -49,15 +51,15 @@ class NvplBlas(Package):
         spec = self.spec
 
         if "+ilp64" in spec:
-          int_type = "ilp64"
+            int_type = "ilp64"
         else:
-          int_type = "lp64"
+            int_type = "lp64"
 
         if spec.satisfies("threads=openmp"):
-          threading_type="gomp"
+            threading_type = "gomp"
         else:
-          # threads=none
-          threading_type = "seq"
+            # threads=none
+            threading_type = "seq"
 
         name = ["libnvpl_blas_core", f"libnvpl_blas_{int_type}_{threading_type}"]
 

--- a/var/spack/repos/builtin/packages/nvpl-lapack/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-lapack/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/nvpl-lapack/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-lapack/package.py
@@ -35,6 +35,8 @@ class NvplLapack(Package):
         multi=False,
     )
 
+    requires("target=armv8.2a:", msg="Any CPU with Arm-v8.2a+ microarch")
+
     conflicts("%gcc@:7")
     conflicts("%clang@:13")
 

--- a/var/spack/repos/builtin/packages/nvpl-lapack/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-lapack/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class NvplLapack(Package):
+    """
+    NVPL LAPACK (NVIDIA Performance Libraries LAPACK) is part of NVIDIA Performance Libraries
+    that provides standard Fortran 90 LAPACK APIs.
+    """
+
+    homepage = "https://docs.nvidia.com/nvpl/_static/lapack/index.html"
+    url = ("https://developer.download.nvidia.com/compute/nvpl/redist"
+           "/nvpl_lapack/linux-sbsa/nvpl_lapack-linux-sbsa-0.2.0.1-archive.tar.xz")
+
+    maintainers("albestro", "rasolca")
+
+    # FIXME: Add the SPDX identifier of the project's license below.
+    # See https://spdx.org/licenses/ for a list.
+    license("UNKNOWN")
+
+    version("0.1.0", sha256="7054f775b18916ee662c94ad7682ace53debbe8ee36fa926000fe412961edb0b")
+
+    provides("lapack")
+
+    # TODO add compiler requirements
+
+    def install(self, spec, prefix):
+        install_tree(".", prefix)

--- a/var/spack/repos/builtin/packages/nvpl-lapack/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-lapack/package.py
@@ -13,8 +13,10 @@ class NvplLapack(Package):
     """
 
     homepage = "https://docs.nvidia.com/nvpl/_static/lapack/index.html"
-    url = ("https://developer.download.nvidia.com/compute/nvpl/redist"
-           "/nvpl_lapack/linux-sbsa/nvpl_lapack-linux-sbsa-0.2.0.1-archive.tar.xz")
+    url = (
+        "https://developer.download.nvidia.com/compute/nvpl/redist"
+        "/nvpl_lapack/linux-sbsa/nvpl_lapack-linux-sbsa-0.2.0.1-archive.tar.xz"
+    )
 
     maintainers("albestro", "rasolca")
 
@@ -49,15 +51,15 @@ class NvplLapack(Package):
         spec = self.spec
 
         if "+ilp64" in spec:
-          int_type = "ilp64"
+            int_type = "ilp64"
         else:
-          int_type = "lp64"
+            int_type = "lp64"
 
         if spec.satisfies("threads=openmp"):
-          threading_type="gomp"
+            threading_type = "gomp"
         else:
-          # threads=none
-          threading_type = "seq"
+            # threads=none
+            threading_type = "seq"
 
         name = ["libnvpl_lapack_core", f"libnvpl_lapack_{int_type}_{threading_type}"]
 

--- a/var/spack/repos/builtin/packages/nvpl-lapack/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-lapack/package.py
@@ -20,8 +20,6 @@ class NvplLapack(Package):
 
     maintainers("albestro", "rasolca")
 
-    # FIXME: Add the SPDX identifier of the project's license below.
-    # See https://spdx.org/licenses/ for a list.
     license("UNKNOWN")
 
     version("0.1.0", sha256="7054f775b18916ee662c94ad7682ace53debbe8ee36fa926000fe412961edb0b")


### PR DESCRIPTION
These are just basic prototypes for starting using these packages in spack.

We added us as maintainers, but we will be happy to hand-off these to NVidia Performance Libraries maintainers.

Before merging, there are two main missing points:
- how to define supported architectures (https://docs.nvidia.com/nvpl/#system-support): from a quick check it seems that we have to define them by negation (even if it does not sound really maintainable as soon as a new arch is added)
- how to correctly indicate the license (https://docs.nvidia.com/nvpl/_static/license.htm)