### PR TITLE
unison: update to 2.53.3

### DIFF
--- a/var/spack/repos/builtin/packages/unison/package.py
+++ b/var/spack/repos/builtin/packages/unison/package.py
@@ -21,6 +21,16 @@ class Unison(MakefilePackage):
     license("GPL-3.0-or-later")
 
     version("2.53.3", sha256="aaea04fc5bc76dcfe8627683c9659ee4c194d4f992cc8aaa15bbb2820fc8de46")
+    version(
+        "2.51.2",
+        sha256="a2efcbeab651be6df69cc9b253011a07955ecb91fb407a219719451197849d5e",
+        deprecated=True,
+    )
+    version(
+        "2.48.15v4",
+        sha256="f8c7e982634bbe1ed6510fe5b36b6c5c55c06caefddafdd9edc08812305fdeec",
+        deprecated=True,
+    )
 
     depends_on("ocaml@4.10.0:~force-safe-string", type=("build", "link"))
 

--- a/var/spack/repos/builtin/packages/unison/package.py
+++ b/var/spack/repos/builtin/packages/unison/package.py
@@ -40,6 +40,8 @@ class Unison(MakefilePackage):
 
     parallel = False
 
+    build_targets = ["UISTYLE=text", "DEBUGGING=false", "THREADS=true"]
+
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         install("src/unison", prefix.bin)

--- a/var/spack/repos/builtin/packages/unison/package.py
+++ b/var/spack/repos/builtin/packages/unison/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Unison(Package):
+class Unison(MakefilePackage):
     """Unison is a file-synchronization tool for OSX, Unix, and
     Windows. It allows two replicas of a collection of files and
     directories to be stored on different hosts (or different disks
@@ -20,19 +20,12 @@ class Unison(Package):
 
     license("GPL-3.0-or-later")
 
-    version("2.51.2", sha256="a2efcbeab651be6df69cc9b253011a07955ecb91fb407a219719451197849d5e")
-    version("2.48.15v4", sha256="f8c7e982634bbe1ed6510fe5b36b6c5c55c06caefddafdd9edc08812305fdeec")
+    version("2.53.3", sha256="aaea04fc5bc76dcfe8627683c9659ee4c194d4f992cc8aaa15bbb2820fc8de46")
 
-    depends_on("ocaml@4.10.0:~force-safe-string", type="build")
-
-    patch("large.patch", level=0)
-    patch("4.08-compatibility.patch", when="^ocaml@4.08:")
+    depends_on("ocaml@4.10.0:~force-safe-string", type=("build", "link"))
 
     parallel = False
 
     def install(self, spec, prefix):
-        make("UISTYLE=text DEBUGGING=false THREADS=true")
-
         mkdirp(prefix.bin)
         install("src/unison", prefix.bin)
-        set_executable(join_path(prefix.bin, "unison"))

--- a/var/spack/repos/builtin/packages/unison/package.py
+++ b/var/spack/repos/builtin/packages/unison/package.py
@@ -34,6 +34,10 @@ class Unison(MakefilePackage):
 
     depends_on("ocaml@4.10.0:~force-safe-string", type=("build", "link"))
 
+    with when("@:2.51.2"):
+        patch("large.patch", level=0)
+        patch("4.08-compatibility.patch", when="^ocaml@4.08:")
+
     parallel = False
 
     def install(self, spec, prefix):


### PR DESCRIPTION
- Updates unison to 2.53.3
- Removes old versions - they did not build for me with OCaml 4.13.1 that is currently in Spack. Also, the changes from the previous versions seem to be quite significant.
- Used MakefilePackage and simplified package.py