### PR TITLE
paraview: fix paraview@5.12.0-RC1+adios2 build

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -309,7 +309,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
 
     # Fix VTK to remove deprecated ADIOS2 functions
     # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10113
-    patch("adios2-remove-deprecated-functions.patch", when="@5.10: ^adios2@2.9:")
+    patch("adios2-remove-deprecated-functions.patch", when="@5.10:5.11 ^adios2@2.9:")
 
     patch("exodusII-netcdf4.9.0.patch", when="@:5.10.2")
 


### PR DESCRIPTION
Paraview carries a patch for `adios2` that is no longer needed for v5.12.0-RC1. This changes the spec so it is only applied for versions 5.10-5.11. This enables `paraview@5.12.0-RC1` to build successfully with `+adios2`.

Builds and runs successfully on Linux with:
```
spack install paraview@5.12.0-RC1+qt+openpmd+adios2 ^llvm~gold
```