### PR TITLE
geopm-service: New package and deprecate geopm

### DIFF
--- a/var/spack/repos/builtin/packages/geopm-service/0001-Support-NVML-via-CUDA-installation.patch
+++ b/var/spack/repos/builtin/packages/geopm-service/0001-Support-NVML-via-CUDA-installation.patch
@@ -1,0 +1,28 @@
+From cea9ceba3996e58af24c614c91a3d8721f0d8406 Mon Sep 17 00:00:00 2001
+From: Brad Geltz <brad.geltz@intel.com>
+Date: Thu, 14 Dec 2023 16:35:02 -0800
+Subject: [PATCH] Support NVML via CUDA installation
+
+Signed-off-by: Brad Geltz <brad.geltz@intel.com>
+---
+ configure.ac | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/service/configure.ac b/service/configure.ac
+index f9eb56d50..e8b523006 100644
+--- a/service/configure.ac
++++ b/service/configure.ac
+@@ -264,8 +264,8 @@ AC_ARG_WITH([nvml], [AS_HELP_STRING([--with-nvml=PATH],
+             [specify directory for installed nvml package.])])
+ if test "x$with_nvml" != x; then
+   AM_CPPFLAGS="$AM_CPPFLAGS -I$with_nvml/include"
+-  LD_LIBRARY_PATH="$with_nvml/lib64:$with_nvml/lib:$LD_LIBRARY_PATH"
+-  AM_LDFLAGS="$AM_LDFLAGS -L$with_nvml/lib -L$with_nvml/lib64"
++  LD_LIBRARY_PATH="$with_nvml/lib64:$with_nvml/lib:$with_nvml/lib/stubs:$LD_LIBRARY_PATH"
++  AM_LDFLAGS="$AM_LDFLAGS -L$with_nvml/lib -L$with_nvml/lib64 -L$with_nvml/lib/stubs"
+ fi
+
+ AC_ARG_WITH([dcgm], [AS_HELP_STRING([--with-dcgm=PATH],
+--
+2.26.2
+

--- a/var/spack/repos/builtin/packages/geopm-service/package.py
+++ b/var/spack/repos/builtin/packages/geopm-service/package.py
@@ -1,0 +1,148 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack.package import *
+
+
+class GeopmService(AutotoolsPackage):
+    """The Global Extensible Open Power Manager (GEOPM) is a framework for
+    exploring power and energy optimizations targeting heterogeneous platforms.
+    The GEOPM package provides many built-in features. A simple use case is
+    reading hardware counters and setting hardware controls with platform
+    independent syntax using a command line tool on a particular compute node.
+    An advanced use case is dynamically coordinating hardware settings across
+    all compute nodes used by a distributed application is response to the
+    application's behavior and requests from the resource manager.
+
+    Note: GEOPM interfaces with hardware using Model Specific Registers (MSRs).
+    For proper usage make sure MSRs are made available via the msr or
+    msr-safe kernel modules by your administrator."""
+
+    homepage = "https://geopm.github.io"
+    git = "https://github.com/geopm/geopm.git"
+    url = "https://github.com/geopm/geopm/tarball/v3.0.1"
+
+    maintainers("bgeltz", "cmcantalupo")
+    license("BSD-3-Clause")
+    tags = ["e4s"]
+
+    version("develop", branch="dev", get_full_repo=True)
+    version("3.0.1", sha256="32ba1948de58815ee055470dcdea64593d1113a6cad70ce00ab0286c127f8234")
+
+    variant("debug", default=False, description="Enable debug")
+    variant("docs", default=True, description="Create man pages with Sphinx")
+    variant(
+        "systemd",
+        default=False,
+        description="Enable use of systemd (systemd development libraries required)",
+    )
+    variant("liburing", default=True, description="Enables the use of liburing for batch I/O")
+    variant(
+        "libcap", default=True, description="Enables the use of libcap to do capabilities checks"
+    )
+    variant("gnu-ld", default=False, description="Assume C compiler uses gnu-ld")
+
+    variant("levelzero", default=False, description="Enables the use of oneAPI Level Zero loader")
+    variant("nvml", default=False, description="Enable NVML support")
+
+    variant(
+        "rawmsr",
+        default=True,
+        description="Enable direct use of standard msr device driver",
+        when="@develop",
+    )
+
+    conflicts("+nvml", when="+levelzero", msg="LevelZero and NVML support are mutually exclusive")
+
+    conflicts("%gcc@:7.2", msg="Requires C++17 support")
+    conflicts("%clang@:4", msg="Requires C++17 support")
+
+    conflicts("platform=darwin", msg="Darwin is not supported")
+    conflicts("platform=windows", msg="Windows is not supported")
+
+    conflicts("target=aarch64:", msg="Only available on x86_64")
+    conflicts("target=ppc64:", msg="Only available on x86_64")
+    conflicts("target=ppc64le:", msg="Only available on x86_64")
+
+    patch("0001-Support-NVML-via-CUDA-installation.patch", when="+nvml")
+
+    # Autotools dependencies
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("file")
+
+    # Docs dependencies
+    depends_on("doxygen", type="build", when="+docs")
+    depends_on("py-docstring-parser@0.13.0:", type="build", when="+docs")
+    depends_on("py-sphinx@4.5:", type="build", when="+docs")
+    depends_on("py-sphinx-rtd-theme@1:", type="build", when="+docs")
+    depends_on("py-sphinxemoji@0.2.0:", type="build", when="+docs")
+    depends_on("py-sphinx-tabs@3.3.1:", type="build", when="+docs")
+    depends_on("py-pygments@2.13.0:", type="build", when="+docs")
+
+    # Other Python dependencies - from service/setup.py
+    depends_on("py-dasbus@1.6.0:", type=("build", "run"))
+    depends_on("py-cffi@1.14.5:", type="run")
+    depends_on("py-psutil@5.8.0:", type="run")
+    depends_on("py-jsonschema@3.2.0:", type="run")
+    depends_on("py-pyyaml@6.0:", type="run")
+    depends_on("py-setuptools@53.0.0:", type="build")
+
+    # Other dependencies
+    depends_on("bash-completion")
+    depends_on("unzip")
+    depends_on("libcap", when="+libcap")
+    depends_on("liburing", when="+liburing")
+    depends_on("oneapi-level-zero", when="+levelzero")
+    depends_on("cuda", when="+nvml")
+
+    extends("python")
+
+    configure_directory = "service"
+
+    def autoreconf(self, spec, prefix):
+        bash = which("bash")
+        with working_dir("service"):
+            if not spec.version.isdevelop():
+                # Required to workaround missing VERSION files
+                # from GitHub generated source tarballs
+                with open("VERSION_OVERRIDE", "w") as fd:
+                    fd.write(f"{spec.version}")
+            bash("./autogen.sh")
+
+    def configure_args(self):
+        args = [
+            "--with-bash-completion-dir="
+            + join_path(self.spec.prefix, "share", "bash-completion", "completions")
+        ]
+
+        args += self.enable_or_disable("debug")
+        args += self.enable_or_disable("docs")
+        args += self.enable_or_disable("systemd")
+        args += self.enable_or_disable("liburing")
+        args += self.with_or_without("liburing", activation_value="prefix")
+        args += self.enable_or_disable("libcap")
+        args += self.with_or_without("gnu-ld")
+
+        args += self.enable_or_disable("levelzero")
+        args += self.enable_or_disable("nvml")
+        if "+nvml" in self.spec:
+            args += [
+                "--with-nvml=" + join_path(self.spec["cuda"].prefix, "targets", "x86_64-linux")
+            ]
+
+        args += self.enable_or_disable("rawmsr")
+        return args
+
+    def setup_run_environment(self, env):
+        # Required to ensure geopmdpy can load
+        # libgeopmd.so.2 via CFFI
+        if os.path.isdir(self.prefix.lib64):
+            lib_dir = self.prefix.lib64
+        else:
+            lib_dir = self.prefix.lib
+        env.prepend_path("LD_LIBRARY_PATH", lib_dir)

--- a/var/spack/repos/builtin/packages/geopm/package.py
+++ b/var/spack/repos/builtin/packages/geopm/package.py
@@ -25,16 +25,48 @@ class Geopm(AutotoolsPackage):
     license("BSD-3-Clause")
 
     # Add additional proper versions and checksums here. "spack checksum geopm"
-    version("develop", branch="dev")
-    version("master", branch="master")
-    version("1.1.0", sha256="5f9a4df37ef0d64c53d64829d46736803c9fe614afd8d2c70fe7a5ebea09f88e")
-    version("1.0.0", sha256="24fe72265a7e44d62bdfe49467c49f0b7a649131ddda402d763c00a49765e1cb")
-    version("0.6.1", sha256="0ca42853f90885bf213df190c3462b8675c143cc843aee0d8b8a0e30802b55a9")
-    version("0.6.0", sha256="95ccf256c2b7cb35838978152479569d154347c3065af1639ed17be1399182d3")
-    version("0.5.1", sha256="db247af55f7000b6e4628af099956349b68a637500b9d4fe8d8fb13687124d53")
-    version("0.5.0", sha256="cdc123ea68b6d918dcc578a39a7a38275a5d711104364eb889abed15029f4060")
-    version("0.4.0", sha256="7d165f5a5fe0f19ca586bd81a4631202effb542e9d762cc9cc86ad6ef7afcad9")
-    version("0.3.0", sha256="73b45d36e7d2431d308038fc8c50a521a1d214c5ce105a17fba440f28509d907")
+    version("develop", branch="dev", deprecated=True)
+    version("master", branch="master", deprecated=True)
+    version(
+        "1.1.0",
+        sha256="5f9a4df37ef0d64c53d64829d46736803c9fe614afd8d2c70fe7a5ebea09f88e",
+        deprecated=True,
+    )
+    version(
+        "1.0.0",
+        sha256="24fe72265a7e44d62bdfe49467c49f0b7a649131ddda402d763c00a49765e1cb",
+        deprecated=True,
+    )
+    version(
+        "0.6.1",
+        sha256="0ca42853f90885bf213df190c3462b8675c143cc843aee0d8b8a0e30802b55a9",
+        deprecated=True,
+    )
+    version(
+        "0.6.0",
+        sha256="95ccf256c2b7cb35838978152479569d154347c3065af1639ed17be1399182d3",
+        deprecated=True,
+    )
+    version(
+        "0.5.1",
+        sha256="db247af55f7000b6e4628af099956349b68a637500b9d4fe8d8fb13687124d53",
+        deprecated=True,
+    )
+    version(
+        "0.5.0",
+        sha256="cdc123ea68b6d918dcc578a39a7a38275a5d711104364eb889abed15029f4060",
+        deprecated=True,
+    )
+    version(
+        "0.4.0",
+        sha256="7d165f5a5fe0f19ca586bd81a4631202effb542e9d762cc9cc86ad6ef7afcad9",
+        deprecated=True,
+    )
+    version(
+        "0.3.0",
+        sha256="73b45d36e7d2431d308038fc8c50a521a1d214c5ce105a17fba440f28509d907",
+        deprecated=True,
+    )
 
     # Variants reflecting most ./configure --help options
     variant("debug", default=False, description="Enable debug.")

--- a/var/spack/repos/builtin/packages/py-dasbus/package.py
+++ b/var/spack/repos/builtin/packages/py-dasbus/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyDasbus(PythonPackage):
+    """Dasbus is a DBus library written in Python 3, based on GLib and inspired by pydbus."""
+
+    homepage = "https://dasbus.readthedocs.io/en/latest/"
+    pypi = "dasbus/dasbus-1.7.tar.gz"
+    license("LGPL-2.1-or-later")
+
+    version("1.7", sha256="a8850d841adfe8ee5f7bb9f82cf449ab9b4950dc0633897071718e0d0036b6f6")
+
+    depends_on("python@3.6:3", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-pygobject", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pygobject/package.py
+++ b/var/spack/repos/builtin/packages/py-pygobject/package.py
@@ -10,23 +10,44 @@ class PyPygobject(PythonPackage):
     """bindings for the GLib, and GObject,
     to be used in Python."""
 
-    homepage = "https://pypi.python.org/pypi/pygobject"
+    homepage = "https://pygobject.readthedocs.io/en/latest/"
 
     license("LGPL-2.1-or-later")
 
-    version("3.38.0", sha256="0372d1bb9122fc19f500a249b1f38c2bb67485000f5887497b4b205b3e7084d5")
-    version("3.28.3", sha256="3dd3e21015d06e00482ea665fc1733b77e754a6ab656a5db5d7f7bfaf31ad0b0")
-    version("2.28.6", sha256="fb8a1d4f665130a125011659bd347c7339c944232163dbb9a34fd0686577adb8")
+    version("3.46.0", sha256="426008b2dad548c9af1c7b03b59df0440fde5c33f38fb5406b103a43d653cafc")
+    version(
+        "3.38.0",
+        sha256="0372d1bb9122fc19f500a249b1f38c2bb67485000f5887497b4b205b3e7084d5",
+        deprecated=True,
+    )
+    version(
+        "3.28.3",
+        sha256="3dd3e21015d06e00482ea665fc1733b77e754a6ab656a5db5d7f7bfaf31ad0b0",
+        deprecated=True,
+    )
+    version(
+        "2.28.6",
+        sha256="fb8a1d4f665130a125011659bd347c7339c944232163dbb9a34fd0686577adb8",
+        deprecated=True,
+    )
 
     extends("python")
 
     depends_on("py-setuptools", type="build")
     depends_on("pkgconfig", type="build")
-    depends_on("libffi")
-    depends_on("glib")
-    depends_on("py-pycairo", type=("build", "run"))
-    depends_on("gobject-introspection")
     depends_on("gtkplus")
+
+    # meson.build
+    depends_on("python@3.8:3", type=("build", "run"), when="@3.46.0")
+    depends_on("glib@2.64.0:", when="@3.46.0")
+    depends_on("gobject-introspection@1.64.0:", when="@3.46.0")
+    depends_on("py-pycairo@1.16:1", type=("build", "run"), when="@3.46.0")
+    depends_on("libffi@3.0.0:", when="@3.46.0")
+
+    depends_on("glib", when="@:3.46.0")
+    depends_on("gobject-introspection", when="@:3.46.0")
+    depends_on("py-pycairo", type=("build", "run"), when="@:3.46.0")
+    depends_on("libffi", when="@:3.46.0")
 
     # pygobject links directly using the compiler, not spack's wrapper.
     # This causes it to fail to add the appropriate rpaths. This patch modifies

--- a/var/spack/repos/builtin/packages/py-sphinx-tabs/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-tabs/package.py
@@ -17,10 +17,17 @@ class PySphinxTabs(PythonPackage):
 
     license("MIT")
 
+    version("3.4.4", sha256="f1b72c4f23d1ba9cdcaf880fd883524bc70689f561b9785719b8b3c3c5ed0aca")
+    version("3.4.1", sha256="d2a09f9e8316e400d57503f6df1c78005fdde220e5af589cc79d493159e1b832")
+    version("3.3.1", sha256="d10dd7fb2700329b8e5948ab9f8e3ef54fff30f79d2e42cfd1b0089ae26e8c5e")
     version("3.2.0", sha256="33137914ed9b276e6a686d7a337310ee77b1dae316fdcbce60476913a152e0a4")
 
     depends_on("python@3.6:3", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-sphinx@2:4", type=("build", "run"))
+    depends_on("py-sphinx", type=("build", "run"), when="@3.4.1:")
+    depends_on("py-sphinx@2:4", type=("build", "run"), when="@:3.3.1")
     depends_on("py-pygments", type=("build", "run"))
-    depends_on("py-docutils@0.16", type=("build", "run"))
+
+    depends_on("py-docutils@0.16", when="@3.2.0", type=("build", "run"))
+    depends_on("py-docutils@0.17", when="@3.3.1", type=("build", "run"))
+    depends_on("py-docutils@0.18", when="@3.4.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-sphinxemoji/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxemoji/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySphinxemoji(PythonPackage):
+    """An extension to use emoji codes in your Sphinx documentation!"""
+
+    homepage = "https://sphinxemojicodes.readthedocs.io"
+    pypi = "sphinxemoji/sphinxemoji-0.2.0.tar.gz"
+    license("BSD-3-Clause")
+
+    version("0.2.0", sha256="27861d1dd7c6570f5e63020dac9a687263f7481f6d5d6409eb31ecebcc804e4c")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-sphinx@1.8:", type=("build", "run"))


### PR DESCRIPTION
- Add geopm-service and its dependencies: py-sphinx-emoji and py-dasbus.
- Deprecate old geopm package as it is no longer supported.
- GEOPM is now distributed as 2 packages: geopm-service and geopm-runtime.
- geopm-runtime will be dependent on geopm-service (in particular libgeopmd.so.2).  A PR for geopm-runtime is forthcoming.
- Relates to #26003.
- Relates to #38795.
- Relates to #38798.