### PR TITLE
Add missing import to a few packages

### DIFF
--- a/var/spack/repos/builtin/packages/fpocket/package.py
+++ b/var/spack/repos/builtin/packages/fpocket/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+from spack.build_systems import makefile
 from spack.package import *
 
 
@@ -21,7 +22,7 @@ class Fpocket(MakefilePackage):
     depends_on("qhull")
 
 
-class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
+class MakefileBuilder(makefile.MakefileBuilder):
     def setup_build_environment(self, env):
         if self.pkg.compiler.name == "gcc":
             env.set("CXX", "g++")

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -6,6 +6,7 @@
 import os
 import socket
 
+import spack.platforms.cray
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 
+import spack.builder
+from spack.build_systems import autotools, nmake
 from spack.package import *
 
 
@@ -205,7 +207,7 @@ class BaseBuilder(metaclass=spack.builder.PhaseCallbacksMeta):
                 python("-c", "import libxml2")
 
 
-class AutotoolsBuilder(BaseBuilder, spack.build_systems.autotools.AutotoolsBuilder):
+class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
     def configure_args(self):
         spec = self.spec
 
@@ -231,7 +233,7 @@ class AutotoolsBuilder(BaseBuilder, spack.build_systems.autotools.AutotoolsBuild
         return args
 
 
-class NMakeBuilder(BaseBuilder, spack.build_systems.nmake.NMakeBuilder):
+class NMakeBuilder(BaseBuilder, nmake.NMakeBuilder):
     phases = ("configure", "build", "install")
 
     @property

--- a/var/spack/repos/builtin/packages/smee-client/package.py
+++ b/var/spack/repos/builtin/packages/smee-client/package.py
@@ -5,7 +5,6 @@
 
 
 from spack.package import *
-from spack.util.executable import ProcessError
 
 
 class SmeeClient(Package):
@@ -35,7 +34,7 @@ class SmeeClient(Package):
         # Allow tsc to fail with typing "errors" which don't affect results
         output = npm("run", "build", output=str, error=str, fail_on_error=False)
         if npm.returncode not in (0, 2):
-            raise ProcessError(output)
+            raise InstallError(output)
 
     def install(self, spec, prefix):
         npm = which("npm", required=True)


### PR DESCRIPTION
Modifications:
- [x] Import `spack.builder` and `spack.build_systems` explicitly when needed
- [x] Do not use internal exceptions `spack.util.executable.ProcessError` when `InstallError` is available for recipes