### PR TITLE
ReSolve: Add version 0.99.1

### DIFF
--- a/var/spack/repos/builtin/packages/resolve/package.py
+++ b/var/spack/repos/builtin/packages/resolve/package.py
@@ -15,7 +15,7 @@ class Resolve(CMakePackage, CudaPackage, ROCmPackage):
 
     maintainers("cameronrutherford", "pelesh", "ryandanehy", "kswirydo")
 
-    # version("1.0.0", submodules=False, branch="develop")
+    version("0.99.1", submodules=False, tag="v0.99.1", commit="e10dd417e836f47b3dc7c8b123a81bfbb654ee82")
     version("develop", submodules=False, branch="develop")
 
     variant("klu", default=True, description="Use KLU, AMD and COLAMD Libraries from SuiteSparse")

--- a/var/spack/repos/builtin/packages/resolve/package.py
+++ b/var/spack/repos/builtin/packages/resolve/package.py
@@ -15,7 +15,12 @@ class Resolve(CMakePackage, CudaPackage, ROCmPackage):
 
     maintainers("cameronrutherford", "pelesh", "ryandanehy", "kswirydo")
 
-    version("0.99.1", submodules=False, tag="v0.99.1", commit="e10dd417e836f47b3dc7c8b123a81bfbb654ee82")
+    version(
+        "0.99.1",
+        submodules=False,
+        tag="v0.99.1",
+        commit="e10dd417e836f47b3dc7c8b123a81bfbb654ee82",
+    )
     version("develop", submodules=False, branch="develop")
 
     variant("klu", default=True, description="Use KLU, AMD and COLAMD Libraries from SuiteSparse")


### PR DESCRIPTION
Modifies ReSolve package to add newly released version 0.99.1

@balay, this is the version we would like to have reviewed for xSDK compliance.
 