### PR TITLE
ci: use "strong preference" idiom for compilers

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-rhel/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-rhel/spack.yaml
@@ -10,7 +10,8 @@ spack:
 
   packages:
     all:
-      require: '%cce'
+      require:
+      - one_of: ["%cce", "@:"]  # cce as a strong preference; not all packages support it
       compiler: [cce]
       providers:
         blas: [cray-libsci]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-rhel/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-rhel/spack.yaml
@@ -11,7 +11,7 @@ spack:
   packages:
     all:
       require:
-      - one_of: ["%cce", "@:"]  # cce as a strong preference; not all packages support it
+      - any_of: ["%cce", "@:"]  # cce as a strong preference; not all packages support it
       compiler: [cce]
       providers:
         blas: [cray-libsci]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -8,7 +8,7 @@ spack:
   packages:
     all:
       require:
-      - one_of: ["%oneapi", "@:"]  # oneapi as a strong preference; not all packages support it
+      - any_of: ["%oneapi", "@:"]  # oneapi as a strong preference; not all packages support it
       - "target=x86_64_v3"
       providers:
         blas: [openblas]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -7,7 +7,9 @@ spack:
 
   packages:
     all:
-      require: '%oneapi target=x86_64_v3'
+      require:
+      - one_of: ["%oneapi", "@:"]  # oneapi as a strong preference; not all packages support it
+      - "target=x86_64_v3"
       providers:
         blas: [openblas]
         mpi: [mpich]


### PR DESCRIPTION
This way we don't have to duplicate compiler conflicts / requirements from package.py in config
