### PR TITLE
intel-oneapi-compilers and intel-oneapi-ccl: added new version to packages

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -35,13 +35,13 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
     )
     version(
         "2021.11.1",
-        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/07958f2f-8d95-422d-8c18-a4c7352b005c/l_oneapi_ccl_p_2021.11.1.9_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/07958f2f-8d95-422d-8c18-a4c7352b005c/l_oneapi_ccl_p_2021.11.1.9_offline.sh",
         sha256="35817d40f57c0d35b9bacf3935cedc1c82fc8d809513d82580561f63f31cac17",
         expand=False,
     )
     version(
         "2021.11.0",
-        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/9e63eba5-2b3d-4032-ad22-21f02e35b518/l_oneapi_ccl_p_2021.11.0.49161_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/9e63eba5-2b3d-4032-ad22-21f02e35b518/l_oneapi_ccl_p_2021.11.0.49161_offline.sh",
         sha256="35fde9862d620c211064addfd3c15c4fc33bcaac6fe050163eb59a006fb9d476",
         expand=False,
     )

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -28,6 +28,12 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
     depends_on("intel-oneapi-mpi")
 
     version(
+        "2021.11.2",
+        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/7a2bbe23-9cf2-47a3-945f-fc160b9d868a/l_oneapi_ccl_p_2021.11.2.7_offline.sh",
+        sha256="095be44ae21348ead46008844667a30da92a0afac305f722777c345394e50a14",
+        expand=False,
+    )
+    version(
         "2021.11.1",
         url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/07958f2f-8d95-422d-8c18-a4c7352b005c/l_oneapi_ccl_p_2021.11.1.9_offline.sh",
         sha256="35817d40f57c0d35b9bacf3935cedc1c82fc8d809513d82580561f63f31cac17",

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -29,7 +29,7 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
 
     version(
         "2021.11.2",
-        url="https://registrationcenter-download.intel.com/akdlm//IRC_NAS/7a2bbe23-9cf2-47a3-945f-fc160b9d868a/l_oneapi_ccl_p_2021.11.2.7_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/7a2bbe23-9cf2-47a3-945f-fc160b9d868a/l_oneapi_ccl_p_2021.11.2.7_offline.sh",
         sha256="095be44ae21348ead46008844667a30da92a0afac305f722777c345394e50a14",
         expand=False,
     )

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -37,6 +37,10 @@ versions = [
             "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/d85fbeee-44ec-480a-ba2f-13831bac75f7/l_dpcpp-cpp-compiler_p_2023.2.3.12_offline.sh",
             "sha256": "b80119a3e54306b85198e907589b00b11c072f107ac39c1686a1996f76466b26",
         },
+        "ftn": {
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/0ceccee5-353c-4fd2-a0cc-0aecb7492f87/l_fortran-compiler_p_2023.2.3.13_offline.sh",
+            "sha256": "ef8d95b7165d42da8576bf89a100bd21be7253d0aec039ff76c9213fa2aa9c62",
+        },
     },
     {
         "version": "2023.2.1",


### PR DESCRIPTION
@rscohn2 

Added freshly released fortran compiler 2023.2.3
Added freshly released oneapi-ccl 2024.0.2

Fixed link slashes in intel-oneapi-ccl