### PR TITLE
xcdf: add newly released v3.01 with Python 3 support

### DIFF
--- a/var/spack/repos/builtin/packages/xcdf/package.py
+++ b/var/spack/repos/builtin/packages/xcdf/package.py
@@ -14,6 +14,13 @@ class Xcdf(CMakePackage):
 
     license("BSD-2-Clause")
 
+    version("3.01", sha256="39fe816f40d6af18e16e71ffcf958258fdac4959ac894a60d1b863efaa57754e")
     version("3.00.03", sha256="4e445a2fea947ba14505d08177c8d5b55856f8411f28de1fe4d4c00f6824b711")
 
-    patch("remove_python_support.patch")
+    patch("remove_python_support.patch", when="@3.00.03")
+
+    depends_on("python@3.7:", when="@3.01:")
+    depends_on("py-pybind11", when="@3.01:", type="build")
+
+    def setup_run_environment(self, env):
+        env.prepend_path("PYTHONPATH", self.prefix.lib)


### PR DESCRIPTION
This PR adds XCDF v3.01, which includes Python 3 bindings.