### PR TITLE
Allow custom code blocks in modulefiles, defined in `modules.yaml`

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -557,6 +557,10 @@ class BaseConfiguration:
         """
         return self.conf.get("verbose")
 
+    @property
+    def custom_code_block(self):
+        return self.conf.get("custom_code_block")
+
 
 class BaseFileLayout:
     """Provides information on the layout of module files. Needs to be
@@ -826,6 +830,10 @@ class BaseContext(tengine.Context):
     def verbose(self):
         """Verbosity level."""
         return self.conf.verbose
+
+    @tengine.context_property
+    def custom_code_block(self):
+        return self.conf.custom_code_block
 
 
 class BaseModuleFileWriter:

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -58,6 +58,7 @@ module_file_configuration = {
             "patternProperties": {r"\w[\w-]*": {"type": "string"}},  # key
         },
         "environment": spack.schema.environment.definition,
+        "custom_code_block": {"type": "string", "default": ""}
     },
 }
 

--- a/share/spack/templates/modules/modulefile.lua
+++ b/share/spack/templates/modules/modulefile.lua
@@ -98,4 +98,6 @@ append_path("MANPATH", "", ":")
 
 {% block footer %}
 {# In case the module needs to be extended with custom Lua code #}
+{# `custom_code_block` can be defined in `modules.yaml` #}
+{{ custom_code_block }}
 {% endblock %}

--- a/share/spack/templates/modules/modulefile.tcl
+++ b/share/spack/templates/modules/modulefile.tcl
@@ -86,4 +86,6 @@ append-path MANPATH {{ '{' }}{{ '}' }}
 
 {% block footer %}
 {# In case the module needs to be extended with custom Tcl code #}
+{# `custom_code_block` can be defined in `modules.yaml` #}
+{{ custom_code_block }}
 {% endblock %}


### PR DESCRIPTION
In the modulefile templates, there is a `footer` section for custom logic. But lines added here are added to every modulefile for every spec. You can implement spec-specific logic by doing an if statement using `spec.name`.

On my system, we have a modified version default modulefile template, living in a separate directory. When we update to a newer version of spack, we will miss out on updates to this template. This creates maintenance: go back, compare our modified template to the default template of that version, and make the same edits to the new default template. If we could instead add code blocks using `modules.yaml` rather than making a hard copy, this eliminates the maintenance.

Example:
```yml
modules:
  default:
    lmod:
      cuda:
        custom_code_block: |
          if (mode() == "load") then
              if (posix.stat("/dev/nvidiactl") == nil) then
                  LmodWarning("this is not a GPU node!")
              end
          end
```