### PR TITLE
update an everywhere-but-windows check to include freebsd

### DIFF
--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -51,7 +51,7 @@ class Tcl(AutotoolsPackage, NMakePackage, SourceforgePackage, TclMixin):
     depends_on("zlib-api")
 
     # No compiler wrappers on Windows
-    for plat in ["linux", "darwin", "cray"]:
+    for plat in ["linux", "darwin", "cray", "freebsd"]:
         filter_compiler_wrappers("tclConfig.sh", relative_root="lib", when=f"platform={plat}")
 
     build_system("autotools", "nmake")


### PR DESCRIPTION
When reviewing https://github.com/spack/spack/pull/41759, I overlooked that we now have a `freebsd` platform

Until https://github.com/spack/spack/pull/41453 merges, update the loop that iterates over "everything-except-Windows" to include FreeBSD.