### PR TITLE
add get_arch to sqlite autotools builder

### DIFF
--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -207,10 +207,6 @@ class Sqlite(AutotoolsPackage, NMakePackage):
     def libs(self):
         return find_libraries("libsqlite3", root=self.prefix.lib)
 
-    def get_arch(self):
-        host_platform = spack.platforms.host()
-        return str(host_platform.target("default_target"))
-
     def test_example(self):
         """check example table dump"""
 
@@ -259,6 +255,10 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
             args.append("CPPFLAGS=-DSQLITE_ENABLE_COLUMN_METADATA=1")
 
         return args
+
+    def get_arch(self):
+        host_platform = spack.platforms.host()
+        return str(host_platform.target("default_target"))
 
     @run_after("install")
     def build_libsqlitefunctions(self):


### PR DESCRIPTION
Problem: the refactor of sqlite to add the autotools builder needed to move get_arch to that class.
Solution: put it there.

I tested the build locally (on ubuntu 20.04) and at least it works here. The original failure can be seen in:

https://github.com/flux-framework/spack/actions/runs/7295482304/job/19881923847

This will close #41823 