### PR TITLE
2023.9.0 update for UPC++ and GASNet-EX

### DIFF
--- a/var/spack/repos/builtin/packages/gasnet/package.py
+++ b/var/spack/repos/builtin/packages/gasnet/package.py
@@ -37,15 +37,36 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
     version("main", branch="stable")
     version("master", branch="master")
 
+    version("2023.9.0", sha256="2d9f15a794e10683579ce494cd458b0dd97e2d3327c4d17e1fea79bd95576ce6")
     version("2023.3.0", sha256="e1fa783d38a503cf2efa7662be591ca5c2bb98d19ac72a9bc6da457329a9a14f")
     version("2022.9.2", sha256="2352d52f395a9aa14cc57d82957d9f1ebd928d0a0021fd26c5f1382a06cd6f1d")
     version("2022.9.0", sha256="6873ff4ad8ebee49da4378f2d78095a6ccc31333d6ae4cd739b9f772af11f936")
     version("2022.3.0", sha256="91b59aa84c0680c807e00d3d1d8fa7c33c1aed50b86d1616f93e499620a9ba09")
-    version("2021.9.0", sha256="1b6ff6cdad5ecf76b92032ef9507e8a0876c9fc3ee0ab008de847c1fad0359ee")
-    version("2021.3.0", sha256="8a40fb3fa8bacc3922cd4d45217816fcb60100357ab97fb622a245567ea31747")
-    version("2020.10.0", sha256="ed17baf7fce90499b539857ee37b3eea961aa475cffbde77e4c607a34ece06a0")
-    version("2020.3.0", sha256="019eb2d2284856e6fabe6c8c0061c874f10e95fa0265245f227fd3497f1bb274")
-    version("2019.9.0", sha256="117f5fdb16e53d0fa8a47a1e28cccab1d8020ed4f6e50163d985dc90226aaa2c")
+    version(
+        "2021.9.0",
+        deprecated=True,
+        sha256="1b6ff6cdad5ecf76b92032ef9507e8a0876c9fc3ee0ab008de847c1fad0359ee",
+    )
+    version(
+        "2021.3.0",
+        deprecated=True,
+        sha256="8a40fb3fa8bacc3922cd4d45217816fcb60100357ab97fb622a245567ea31747",
+    )
+    version(
+        "2020.10.0",
+        deprecated=True,
+        sha256="ed17baf7fce90499b539857ee37b3eea961aa475cffbde77e4c607a34ece06a0",
+    )
+    version(
+        "2020.3.0",
+        deprecated=True,
+        sha256="019eb2d2284856e6fabe6c8c0061c874f10e95fa0265245f227fd3497f1bb274",
+    )
+    version(
+        "2019.9.0",
+        deprecated=True,
+        sha256="117f5fdb16e53d0fa8a47a1e28cccab1d8020ed4f6e50163d985dc90226aaa2c",
+    )
     # Do NOT add older versions here.
     # GASNet-EX releases over 2 years old are not supported.
 
@@ -70,12 +91,30 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
         default=False,
         description="Enables support for the CUDA memory kind in some conduits.\n"
         + "NOTE: Requires CUDA Driver library be present on the build system",
+        when="@2020.11:",
+    )
+    conflicts(
+        "+cuda",
+        when="@:2020.10",
+        msg="GASNet version 2020.11.0 or newer required for CUDA support",
     )
 
     variant(
         "rocm",
         default=False,
         description="Enables support for the ROCm/HIP memory kind in some conduits",
+        when="@2021.9:",
+    )
+    conflicts(
+        "+rocm", when="@:2021.8", msg="GASNet version 2021.9.0 or newer required for ROCm support"
+    )
+
+    variant(
+        "level_zero",
+        default=False,
+        description="Enables *experimental* support for the Level Zero "
+        + "memory kind on Intel GPUs in some conduits",
+        when="@2023.9.0:",
     )
 
     depends_on("mpi", when="conduits=mpi")
@@ -84,6 +123,8 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
     depends_on("automake@1.16:", type="build", when="@master:")
 
     conflicts("^hip@:4.4.0", when="+rocm")
+
+    depends_on("oneapi-level-zero@1.8.0:", when="+level_zero")
 
     def install(self, spec, prefix):
         if spec.satisfies("@master:"):
@@ -119,6 +160,10 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
 
             if "+rocm" in spec:
                 options.append("--enable-kind-hip")
+
+            if "+level_zero" in spec:
+                options.append("--enable-kind-ze")
+                options.append("--with-ze-home=" + spec["oneapi-level-zero"].prefix)
 
             if "conduits=mpi" in spec:
                 options.append("--enable-mpi-compat")

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -53,19 +53,41 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
     version("develop", branch="develop")
     version("master", branch="master")
 
+    version("2023.9.0", sha256="6bad2976b4bfc0263b497daa967f448159c3c2259827c8376bc96c9bf9171a83")
     version("2023.3.0", sha256="382af3c093decdb51f0533e19efb4cc7536b6617067b2dd89431e323704a1009")
     version("2022.9.0", sha256="dbf15fd9ba38bfe2491f556b55640343d6303048a117c4e84877ceddb64e4c7c")
     version("2022.3.0", sha256="72bccfc9dfab5c2351ee964232b3754957ecfdbe6b4de640e1b1387d45019496")
-    version("2021.9.0", sha256="9299e17602bcc8c05542cdc339897a9c2dba5b5c3838d6ef2df7a02250f42177")
-    version("2021.3.0", sha256="3433714cd4162ffd8aad9a727c12dbf1c207b7d6664879fc41259a4b351595b7")
+    version(
+        "2021.9.0",
+        deprecated=True,
+        sha256="9299e17602bcc8c05542cdc339897a9c2dba5b5c3838d6ef2df7a02250f42177",
+    )
+    version(
+        "2021.3.0",
+        deprecated=True,
+        sha256="3433714cd4162ffd8aad9a727c12dbf1c207b7d6664879fc41259a4b351595b7",
+    )
     version(
         "2020.11.0",
+        deprecated=True,
         sha256="f6f212760a485a9f346ca11bb4751e7095bbe748b8e5b2389ff9238e9e321317",
         url="https://bitbucket.org/berkeleylab/upcxx/downloads/upcxx-2020.11.0-memory_kinds_prototype.tar.gz",
     )
-    version("2020.10.0", sha256="623e074b512bf8cad770a04040272e1cc660d2749760398b311f9bcc9d381a37")
-    version("2020.3.2", sha256="978adc315d21089c739d5efda764b77fc9a2a7c5860f169fe5cd2ca1d840620f")
-    version("2020.3.0", sha256="01be35bef4c0cfd24e9b3d50c88866521b9cac3ad4cbb5b1fc97aea55078810f")
+    version(
+        "2020.10.0",
+        deprecated=True,
+        sha256="623e074b512bf8cad770a04040272e1cc660d2749760398b311f9bcc9d381a37",
+    )
+    version(
+        "2020.3.2",
+        deprecated=True,
+        sha256="978adc315d21089c739d5efda764b77fc9a2a7c5860f169fe5cd2ca1d840620f",
+    )
+    version(
+        "2020.3.0",
+        deprecated=True,
+        sha256="01be35bef4c0cfd24e9b3d50c88866521b9cac3ad4cbb5b1fc97aea55078810f",
+    )
     # Do NOT add older versions here.
     # UPC++ releases over 2 years old are not supported.
 
@@ -78,12 +100,18 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
         + "NOTE: Requires CUDA Driver library be present on the build system",
         when="@2019.3.0:",
     )
+    conflicts(
+        "+cuda", when="@:2019.2", msg="UPC++ version 2019.3.0 or newer required for CUDA support"
+    )
 
     variant(
         "rocm",
         default=False,
         description="Enables UPC++ support for the ROCm/HIP memory kind on AMD GPUs",
         when="@2022.3.0:",
+    )
+    conflicts(
+        "+rocm", when="@:2022.2", msg="UPC++ version 2022.3.0 or newer required for ROCm support"
     )
 
     variant(
@@ -102,8 +130,7 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
     conflicts(
         "cross=none",
         when=is_CrayXC(),
-        msg="cross=none is unacceptable on Cray XC."
-        + 'Please specify an appropriate "cross" value',
+        msg='cross=none is unacceptable on Cray XC. Please specify an appropriate "cross" value',
     )
 
     # UPC++ always relies on GASNet-EX.


### PR DESCRIPTION
Updates UPC++ and GASNet-EX to v2023.9.0

