### PR TITLE
costa: add missing dependency

### DIFF
--- a/var/spack/repos/builtin/packages/costa/package.py
+++ b/var/spack/repos/builtin/packages/costa/package.py
@@ -37,6 +37,7 @@ class Costa(CMakePackage):
     depends_on("mpi@3:")
     depends_on("scalapack", when="+scalapack")
     depends_on("cxxopts", when="+apps")
+    depends_on("cxxopts", when="+tests")
     depends_on("semiprof", when="+profiling")
 
     def url_for_version(self, version):


### PR DESCRIPTION
`costa+tests` depends on `cxxopts`.