### PR TITLE
fastjet: Adding thread safety variant

### DIFF
--- a/var/spack/repos/builtin/packages/fastjet/package.py
+++ b/var/spack/repos/builtin/packages/fastjet/package.py
@@ -62,13 +62,12 @@ class Fastjet(AutotoolsPackage):
     variant("shared", default=True, description="Builds a shared version of the library")
     variant("auto-ptr", default=False, description="Use auto_ptr")
     variant(
-        "limited-thread-safety",
-        default=True,
+        "thread-safety",
+        default="limited",
+        values=("none", "limited", "full"),
+        multi=False,
         when="@3.4.0:",
-        description="Enables limited thread safety",
-    )
-    variant(
-        "thread-safety", default=False, when="@3.4.0:", description="Enables full thread safety"
+        description="Enables thread safety",
     )
     variant("atlas", default=False, description="Patch to make random generator thread_local")
 
@@ -84,7 +83,9 @@ class Fastjet(AutotoolsPackage):
         extra_args = ["--enable-allplugins"]
         extra_args += self.enable_or_disable("shared")
         extra_args += self.enable_or_disable("auto-ptr")
-        extra_args += self.enable_or_disable("limited-thread-safety")
-        extra_args += self.enable_or_disable("thread-safety")
+        if self.spec.variants["thread-safety"].value == "limited":
+            extra_args += ["--enable-limited-thread-safety"]
+        if self.spec.variants["thread-safety"].value == "full":
+            extra_args += ["--enable-thread-safety"]
 
         return extra_args

--- a/var/spack/repos/builtin/packages/fastjet/package.py
+++ b/var/spack/repos/builtin/packages/fastjet/package.py
@@ -61,7 +61,8 @@ class Fastjet(AutotoolsPackage):
 
     variant("shared", default=True, description="Builds a shared version of the library")
     variant("auto-ptr", default=False, description="Use auto_ptr")
-    variant("limited-thread-safety", default=True, description="Enables limited thread safety")
+    variant("limited-thread-safety", default=True, when="@3.4.0:", description="Enables limited thread safety")
+    variant("thread-safety", default=False, when="@3.4.0:", description="Enables full thread safety")
     variant("atlas", default=False, description="Patch to make random generator thread_local")
 
     patch("atlas.patch", when="@:3.3 +atlas", level=0)
@@ -77,5 +78,6 @@ class Fastjet(AutotoolsPackage):
         extra_args += self.enable_or_disable("shared")
         extra_args += self.enable_or_disable("auto-ptr")
         extra_args += self.enable_or_disable("limited-thread-safety")
+        extra_args += self.enable_or_disable("thread-safety")
 
         return extra_args

--- a/var/spack/repos/builtin/packages/fastjet/package.py
+++ b/var/spack/repos/builtin/packages/fastjet/package.py
@@ -61,8 +61,15 @@ class Fastjet(AutotoolsPackage):
 
     variant("shared", default=True, description="Builds a shared version of the library")
     variant("auto-ptr", default=False, description="Use auto_ptr")
-    variant("limited-thread-safety", default=True, when="@3.4.0:", description="Enables limited thread safety")
-    variant("thread-safety", default=False, when="@3.4.0:", description="Enables full thread safety")
+    variant(
+        "limited-thread-safety",
+        default=True,
+        when="@3.4.0:",
+        description="Enables limited thread safety",
+    )
+    variant(
+        "thread-safety", default=False, when="@3.4.0:", description="Enables full thread safety"
+    )
     variant("atlas", default=False, description="Patch to make random generator thread_local")
 
     patch("atlas.patch", when="@:3.3 +atlas", level=0)

--- a/var/spack/repos/builtin/packages/fastjet/package.py
+++ b/var/spack/repos/builtin/packages/fastjet/package.py
@@ -61,6 +61,7 @@ class Fastjet(AutotoolsPackage):
 
     variant("shared", default=True, description="Builds a shared version of the library")
     variant("auto-ptr", default=False, description="Use auto_ptr")
+    variant("limited-thread-safety", default=True, description="Enables limited thread safety")
     variant("atlas", default=False, description="Patch to make random generator thread_local")
 
     patch("atlas.patch", when="@:3.3 +atlas", level=0)
@@ -75,5 +76,6 @@ class Fastjet(AutotoolsPackage):
         extra_args = ["--enable-allplugins"]
         extra_args += self.enable_or_disable("shared")
         extra_args += self.enable_or_disable("auto-ptr")
+        extra_args += self.enable_or_disable("limited-thread-safety")
 
         return extra_args


### PR DESCRIPTION
Adds variant to by default enable limited thread safety. Limited thread safety should not hinder performance. See http://fastjet.fr/repo/fastjet-doc-3.4.2.pdf