### PR TITLE
Add syntactic sugar for "strong preferences" and "conflicts"

### DIFF
--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -487,6 +487,42 @@ present. For instance with a configuration like:
 
 you will use ``mvapich2~cuda %gcc`` as an ``mpi`` provider.
 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Conflicts and strong preferences
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The semantic of requirements allows for expressing both "strong preferences" and "conflicts"
+from configuration files. The syntax for doing so, though, may not be immediately clear. For
+instance, if we want to prevent any package to use ``%clang``, we can set:
+
+.. code-block:: yaml
+
+   packages:
+     all:
+       require:
+       - one_of: ['%clang', '@:']
+
+Since only one of the requirements must hold, and ``@:`` is always true, the rule above is
+equivalent to a conflict. For "strong preferences" we need to substitute the ``one_of`` policy
+with ``any_of``.
+
+Since the syntax above obfuscates the meaning of the rules added by a user, there is some
+syntactic sugar that can be used in configuration:
+
+.. code-block:: yaml
+
+   packages:
+     all:
+       prefer:
+       - '%clang'
+       conflict:
+       - '+shared'
+
+The ``prefer`` and ``conflict`` sections can be used whenever a ``require`` section is allowed,
+and they translate internally to the more complex syntax based on requirements. They always
+accept a list of spec constraints.
+
+
 .. _package-preferences:
 
 -------------------

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -493,7 +493,7 @@ Conflicts and strong preferences
 
 The semantic of requirements allows for expressing both "strong preferences" and "conflicts"
 from configuration files. The syntax for doing so, though, may not be immediately clear. For
-instance, if we want to prevent any package to use ``%clang``, we can set:
+instance, if we want to prevent any package from using ``%clang``, we can set:
 
 .. code-block:: yaml
 

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -491,23 +491,8 @@ you will use ``mvapich2~cuda %gcc`` as an ``mpi`` provider.
 Conflicts and strong preferences
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The semantic of requirements allows for expressing both "strong preferences" and "conflicts"
-from configuration files. The syntax for doing so, though, may not be immediately clear. For
-instance, if we want to prevent any package from using ``%clang``, we can set:
-
-.. code-block:: yaml
-
-   packages:
-     all:
-       require:
-       - one_of: ['%clang', '@:']
-
-Since only one of the requirements must hold, and ``@:`` is always true, the rule above is
-equivalent to a conflict. For "strong preferences" we need to substitute the ``one_of`` policy
-with ``any_of``.
-
-Since the syntax above obfuscates the meaning of the rules added by a user, there is some
-syntactic sugar that can be used in configuration:
+If the semantic of requirements is too strong, or too verbose to exclude a single configuration
+from a set, you can also express "strong preferences" and "conflicts" from configuration files:
 
 .. code-block:: yaml
 
@@ -518,9 +503,38 @@ syntactic sugar that can be used in configuration:
        conflict:
        - '+shared'
 
-The ``prefer`` and ``conflict`` sections can be used whenever a ``require`` section is allowed,
-and they translate internally to the more complex syntax based on requirements. They always
-accept a list of spec constraints.
+The ``prefer`` and ``conflict`` sections can be used whenever a ``require`` section is allowed.
+The argument is always a list of constraints, and each constraint can be either a simple string,
+or a more complex object:
+
+.. code-block:: yaml
+
+   packages:
+     all:
+       conflict:
+       - spec: '%clang'
+         when: 'target=x86_64_v3'
+         message: 'reason why clang cannot be used'
+
+The ``spec`` attribute is mandatory, while both ``when`` and ``message`` are optional.
+
+.. note::
+
+   Requirements allow for expressing both "strong preferences" and "conflicts".
+   The syntax for doing so, though, may not be immediately clear. For
+   instance, if we want to prevent any package from using ``%clang``, we can set:
+
+   .. code-block:: yaml
+
+      packages:
+        all:
+          require:
+          - one_of: ['%clang', '@:']
+
+   Since only one of the requirements must hold, and ``@:`` is always true, the rule above is
+   equivalent to a conflict. For "strong preferences" we need to substitute the ``one_of`` policy
+   with ``any_of``.
+
 
 
 .. _package-preferences:

--- a/lib/spack/docs/packages_yaml.rst
+++ b/lib/spack/docs/packages_yaml.rst
@@ -491,8 +491,8 @@ you will use ``mvapich2~cuda %gcc`` as an ``mpi`` provider.
 Conflicts and strong preferences
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If the semantic of requirements is too strong, or too verbose to exclude a single configuration
-from a set, you can also express "strong preferences" and "conflicts" from configuration files:
+If the semantic of requirements is too strong, you can also express "strong preferences" and "conflicts"
+from configuration files:
 
 .. code-block:: yaml
 

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -54,6 +54,8 @@ requirements = {
     ]
 }
 
+prefer_and_conflict = {"type": "array", "items": {"type": "string"}}
+
 permissions = {
     "type": "object",
     "additionalProperties": False,
@@ -85,6 +87,8 @@ properties = {
                 "additionalProperties": False,
                 "properties": {
                     "require": requirements,
+                    "prefer": prefer_and_conflict,
+                    "conflict": prefer_and_conflict,
                     "version": {},  # Here only to warn users on ignored properties
                     "target": {
                         "type": "array",

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -153,6 +153,8 @@ properties = {
                 "additionalProperties": False,
                 "properties": {
                     "require": requirements,
+                    "prefer": prefer_and_conflict,
+                    "conflict": prefer_and_conflict,
                     "version": {
                         "type": "array",
                         "default": [],

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -54,7 +54,23 @@ requirements = {
     ]
 }
 
-prefer_and_conflict = {"type": "array", "items": {"type": "string"}}
+prefer_and_conflict = {
+    "type": "array",
+    "items": {
+        "oneOf": [
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "spec": {"type": "string"},
+                    "message": {"type": "string"},
+                    "when": {"type": "string"},
+                },
+            },
+            {"type": "string"},
+        ]
+    },
+}
 
 permissions = {
     "type": "object",
@@ -189,7 +205,6 @@ properties = {
         },
     }
 }
-
 
 #: Full schema with metadata
 schema = {

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2787,7 +2787,7 @@ class RequirementParser:
     def __init__(self, configuration):
         self.config = configuration
 
-    def rules(self, pkg: spack.package_base.PackageBase) -> List[RequirementRule]:
+    def rules(self, pkg: "spack.package_base.PackageBase") -> List[RequirementRule]:
         result = []
         result.extend(self.rules_from_package_py(pkg))
         result.extend(self.rules_from_require(pkg))
@@ -2817,11 +2817,11 @@ class RequirementParser:
             virtual_str, requirements, kind=RequirementKind.VIRTUAL
         )
 
-    def rules_from_require(self, pkg: spack.package_base.PackageBase) -> List[RequirementRule]:
+    def rules_from_require(self, pkg: "spack.package_base.PackageBase") -> List[RequirementRule]:
         kind, requirements = self._raw_yaml_data(pkg, section="require")
         return self._rules_from_requirements(pkg.name, requirements, kind=kind)
 
-    def rules_from_prefer(self, pkg: spack.package_base.PackageBase) -> List[RequirementRule]:
+    def rules_from_prefer(self, pkg: "spack.package_base.PackageBase") -> List[RequirementRule]:
         result = []
         kind, preferences = self._raw_yaml_data(pkg, section="prefer")
         for spec_str in preferences:
@@ -2861,7 +2861,7 @@ class RequirementParser:
             )
         return result
 
-    def _raw_yaml_data(self, pkg: spack.package_base.PackageBase, *, section: str):
+    def _raw_yaml_data(self, pkg: "spack.package_base.PackageBase", *, section: str):
         config = self.config.get("packages")
         data = config.get(pkg.name, {}).get(section, [])
         kind = RequirementKind.PACKAGE

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -1115,6 +1115,17 @@ def test_strong_preferences_packages_yaml(
     """,
             "multivalue-variant %clang",
         ),
+        (
+            """
+            packages:
+              multivalue-variant:
+                conflict:
+                - spec: "%clang"
+                  when: "@2"
+                  message: "cannot use clang with version 2"
+        """,
+            "multivalue-variant@=2.3 %clang",
+        ),
     ],
 )
 def test_conflict_packages_yaml(packages_yaml, spec_str, concretize_scope, mock_packages):

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-rhel/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-rhel/spack.yaml
@@ -10,8 +10,8 @@ spack:
 
   packages:
     all:
-      require:
-      - any_of: ["%cce", "@:"]  # cce as a strong preference; not all packages support it
+      prefer:
+      - "%cce"
       compiler: [cce]
       providers:
         blas: [cray-libsci]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -8,8 +8,9 @@ spack:
   packages:
     all:
       require:
-      - any_of: ["%oneapi", "@:"]  # oneapi as a strong preference; not all packages support it
       - "target=x86_64_v3"
+      prefer:
+      - "%oneapi"
       providers:
         blas: [openblas]
         mpi: [mpich]


### PR DESCRIPTION
Currently requirements allow to express "strong preferences" and "conflicts" from configuration using a convoluted syntax:
```yaml
packages:
  zlib-ng:
    require:
    # conflict on %clang
    - one_of: ["%clang", "@:"]
    # Strong preference for +shared
    - any_of: ["+shared", "@:"]
```
This PR adds syntactic sugar so that the same can be written as:
```yaml
packages:
  zlib-ng:
    conflict:
    - "%clang"
    prefer:
    - "+shared"
```
Preferences written in this way are "stronger" that the ones documented at:
- https://spack.readthedocs.io/en/latest/packages_yaml.html#package-preferences