### PR TITLE
Use multiprocessing.pool.ThreadPool instead of Pool in buildcache

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -327,7 +327,7 @@ def _progress(i: int, total: int):
 
 
 def _make_pool():
-    return multiprocessing.pool.Pool(determine_number_of_jobs(parallel=True))
+    return multiprocessing.pool.ThreadPool(determine_number_of_jobs(parallel=True))
 
 
 def push_fn(args):


### PR DESCRIPTION
Closes https://github.com/spack/spack/issues/41833

This is an implicit workaround for https://github.com/python/cpython/blob/d1c711e757213b38cff177ba4b4d8ae201da1d21/Lib/multiprocessing/pool.py#L177, where the default `Pool` wraps exceptions and `ThreadPool` doesn't.  Their wrappers are lossy and switching to `starmap_async` with a custom error handler didn't help either, since by that time the Spack exception had already been lost.

Now the exception is as if `Pool.starmap` wasn't even used:
```
==> Using cached archive: /home/eric/data/spack/var/spack/cache/blobs/sha256/3b5502ea27da7ef85c9f60bd6355ffacedd856d2760b1e8cd0f8a42500b1eaaf
==> 5 specs need to be pushed to ghcr.io/berquist/spack-gha-buildcache-example
==> Error: HTTP Error 401: Failed to login to https://ghcr.io/v2/berquist/spack-gha-buildcache-example/blobs/uploads/: Unauthorized
```