### PR TITLE
CI: Disable downloading artifacts from upstream jobs

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1253,6 +1253,7 @@ def generate_gitlab_ci_yaml(
                 op=lambda cmd: cmd.replace("mirror_prefix", temp_storage_url_prefix),
             )
 
+            cleanup_job["dependencies"] = []
             output_object["cleanup"] = cleanup_job
 
         if (
@@ -1276,6 +1277,7 @@ def generate_gitlab_ci_yaml(
                 if buildcache_destination
                 else remote_mirror_override or remote_mirror_url
             )
+            signing_job["dependencies"] = []
 
             output_object["sign-pkgs"] = signing_job
 
@@ -1296,6 +1298,7 @@ def generate_gitlab_ci_yaml(
             final_job["when"] = "always"
             final_job["retry"] = service_job_retries
             final_job["interruptible"] = True
+            final_job["dependencies"] = []
 
             output_object["rebuild-index"] = final_job
 


### PR DESCRIPTION
Un-revert the non-broken parts of the CI fix