### PR TITLE
libxcb, xcb-proto: new variant `use_spack_interpreter`

### DIFF
--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
+
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -58,7 +58,7 @@ class Libxcb(AutotoolsPackage, XorgPackage):
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
 
-    when("+use_spack_interpreter")
+    @when("+use_spack_interpreter")
     def setup_build_environment(self, env):
         env.set("PYTHON", sys.executable)
 

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -33,7 +33,11 @@ class Libxcb(AutotoolsPackage, XorgPackage):
         deprecated=True,
     )
 
-    variant("use_spack_interpreter", default=False, description="Use the interpreter running spack to configure")
+    variant(
+        "use_spack_interpreter",
+        default=False,
+        description="Use the interpreter running spack to configure",
+    )
 
     depends_on("c", type="build")  # generated
 

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -63,8 +63,8 @@ class Libxcb(AutotoolsPackage, XorgPackage):
 
         # use spack interpreter to avoid dependency cycles
         if self.spec.satisfies("+use_spack_interpreter"):
-            config_args.append(f"--with-python_prefix={sys.prefix}")
-            config_args.append(f"--with-python_exec_prefix={sys.exec_prefix}")
+            config_args.append(f"--with-python_prefix={self.prefix}")
+            config_args.append(f"--with-python_exec_prefix={self.prefix}")
 
         # -Werror flags are not properly interpreted by the NVIDIA compiler
         if self.spec.satisfies("%nvhpc@:20.11"):

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -54,6 +54,10 @@ class Libxcb(AutotoolsPackage, XorgPackage):
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
 
+    when("+use_spack_interpreter")
+    def setup_build_environment(self, env):
+        env.set("PYTHON", sys.executable)
+
     def configure_args(self):
         config_args = []
 

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -50,6 +50,10 @@ class XcbProto(AutotoolsPackage, XorgPackage):
     patch("xcb-proto-1.12-schema-1.patch", when="@1.12")
 
     when("+use_spack_interpreter")
+    def setup_build_environment(self, env):
+        env.set("PYTHON", sys.executable)
+
+    when("+use_spack_interpreter")
     def configure_args(self):
         return [
             f"--with-python_prefix={sys.prefix}",

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -56,6 +56,6 @@ class XcbProto(AutotoolsPackage, XorgPackage):
     when("+use_spack_interpreter")
     def configure_args(self):
         return [
-            f"--with-python_prefix={sys.prefix}",
-            f"--with-python_exec_prefix={sys.exec_prefix}",
+            f"--with-python_prefix={self.prefix}",
+            f"--with-python_exec_prefix={self.prefix}",
         ]

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
+
 from spack.package import *
 
 
@@ -41,6 +43,15 @@ class XcbProto(AutotoolsPackage, XorgPackage):
         deprecated=True,
     )
 
-    extends("python")
+    variant("use_spack_interpreter", default=False, description="Use the interpreter running spack to configure")
+
+    depends_on("python", type="build", when="~use_spack_interpreter")
 
     patch("xcb-proto-1.12-schema-1.patch", when="@1.12")
+
+    when("+use_spack_interpreter")
+    def configure_args(self):
+        return [
+            f"--with-python_prefix={sys.prefix}",
+            f"--with-python_exec_prefix={sys.exec_prefix}",
+        ]

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -43,7 +43,11 @@ class XcbProto(AutotoolsPackage, XorgPackage):
         deprecated=True,
     )
 
-    variant("use_spack_interpreter", default=False, description="Use the interpreter running spack to configure")
+    variant(
+        "use_spack_interpreter",
+        default=False,
+        description="Use the interpreter running spack to configure",
+    )
 
     depends_on("python", type="build", when="~use_spack_interpreter")
 
@@ -53,9 +57,6 @@ class XcbProto(AutotoolsPackage, XorgPackage):
     def setup_build_environment(self, env):
         env.set("PYTHON", sys.executable)
 
-    when("+use_spack_interpreter")
+    @when("+use_spack_interpreter")
     def configure_args(self):
-        return [
-            f"--with-python_prefix={self.prefix}",
-            f"--with-python_exec_prefix={self.prefix}",
-        ]
+        return [f"--with-python_prefix={self.prefix}", f"--with-python_exec_prefix={self.prefix}"]

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -53,7 +53,7 @@ class XcbProto(AutotoolsPackage, XorgPackage):
 
     patch("xcb-proto-1.12-schema-1.patch", when="@1.12")
 
-    when("+use_spack_interpreter")
+    @when("+use_spack_interpreter")
     def setup_build_environment(self, env):
         env.set("PYTHON", sys.executable)
 


### PR DESCRIPTION
This adds the variant `use_spack_interpreter` (as in #41801) to break a cyclic dependency in trying to concretize `python +tkinter` (see e.g. #41146 and some others). The default is to use a true python dependency in libxcb, xcb-proto, but the variant allows to fall back to the python interpreter that spack uses (which could be a system interpreter). This should only be activated when the cyclic dependency is encountered.

Tests: this allows the following environment to concretize and install correctly:
```yaml
spack:
  specs:
  - python+tkinter
  view: true
  concretizer:
    unify: true
```
resulting in:
```console
cnb4zvy libxcb@1.16+use_spack_interpreter build_system=autotools
2hsl7vq python@3.11.6+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix+tkinter+uuid+zlib build_system=generic patches=b0615b2,ebdca64,f2fd060
boh6q4e xcb-proto@1.16.0+use_spack_interpreter build_system=autotools
```
Then, `python -m tkinter` pops up a `Tcl/Tk` window. 

### Question to reviewers with more python knowledge
This causes `xcb-proto` to install the `xcbgen` python package into `{self.prefix}/local/lib/python3.11/dist-package`, with the extra `local` (well, it does that only sometimes; as far as I can tell, a stage or develop dir under `/home` doesn't get `local` added). `libxcb` still finds it fine but it's not a standard location...