### PR TITLE
gc tests: replace `find()` with DB query

### DIFF
--- a/lib/spack/spack/test/cmd/gc.py
+++ b/lib/spack/spack/test/cmd/gc.py
@@ -13,7 +13,6 @@ import spack.spec
 gc = spack.main.SpackCommand("gc")
 add = spack.main.SpackCommand("add")
 install = spack.main.SpackCommand("install")
-find = spack.main.SpackCommand("find")
 
 pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
@@ -50,7 +49,7 @@ def test_gc_with_environment(config, mutable_database, mutable_mock_env_path):
     with e:
         add("cmake")
         install()
-        assert "cmake" in find()
+        assert mutable_database.query_local("cmake")
         output = gc("-y")
     assert "Restricting garbage collection" in output
     assert "There are no unused specs" in output
@@ -66,13 +65,13 @@ def test_gc_with_build_dependency_in_environment(config, mutable_database, mutab
     with e:
         add("simple-inheritance")
         install()
-        assert "simple-inheritance" in find()
+        assert mutable_database.query_local("simple-inheritance")
         output = gc("-yb")
     assert "Restricting garbage collection" in output
     assert "There are no unused specs" in output
 
     with e:
-        assert "simple-inheritance" in find()
+        assert mutable_database.query_local("simple-inheritance")
         output = gc("-y")
     assert "Restricting garbage collection" in output
     assert "Successfully uninstalled cmake" in output
@@ -84,23 +83,23 @@ def test_gc_except_any_environments(config, mutable_database, mutable_mock_env_p
     s.concretize()
     s.package.do_install(fake=True, explicit=True)
 
-    assert "zmpi" in find()
+    assert mutable_database.query_local("zmpi")
 
     e = ev.create("test_gc")
     with e:
         add("simple-inheritance")
         install()
-        assert "simple-inheritance" in find()
+        assert mutable_database.query_local("simple-inheritance")
 
     output = gc("-yE")
     assert "Restricting garbage collection" not in output
     assert "Successfully uninstalled zmpi" in output
-    assert "zmpi" not in find()
+    assert not mutable_database.query_local("zmpi")
 
     with e:
         output = gc("-yE")
     assert "Restricting garbage collection" not in output
-    assert "There are no unused specs" not in find()
+    assert "There are no unused specs" not in output
 
 
 @pytest.mark.db
@@ -109,18 +108,18 @@ def test_gc_except_specific_environments(config, mutable_database, mutable_mock_
     s.concretize()
     s.package.do_install(fake=True, explicit=True)
 
-    assert "zmpi" in find()
+    assert mutable_database.query_local("zmpi")
 
     e = ev.create("test_gc")
     with e:
         add("simple-inheritance")
         install()
-        assert "simple-inheritance" in find()
+        assert mutable_database.query_local("simple-inheritance")
 
     output = gc("-ye", "test_gc")
     assert "Restricting garbage collection" not in output
     assert "Successfully uninstalled zmpi" in output
-    assert "zmpi" not in find()
+    assert not mutable_database.query_local("zmpi")
 
 
 @pytest.mark.db
@@ -136,15 +135,15 @@ def test_gc_except_specific_dir_env(config, mutable_database, mutable_mock_env_p
     s.concretize()
     s.package.do_install(fake=True, explicit=True)
 
-    assert "zmpi" in find()
+    assert mutable_database.query_local("zmpi")
 
     e = ev.create_in_dir(tmpdir.strpath)
     with e:
         add("simple-inheritance")
         install()
-        assert "simple-inheritance" in find()
+        assert mutable_database.query_local("simple-inheritance")
 
     output = gc("-ye", tmpdir.strpath)
     assert "Restricting garbage collection" not in output
     assert "Successfully uninstalled zmpi" in output
-    assert "zmpi" not in find()
+    assert not mutable_database.query_local("zmpi")


### PR DESCRIPTION
Per https://github.com/spack/spack/pull/41731#discussion_r1434827924, This cleans up the tests for `spack gc` by replacing

```python
assert <string> in find()
```

with the more precise

```python
assert mutable_database.query_local(<string>)
```