### PR TITLE
(py-)onnx: new version 1.14.{0,1}, 1.15.0

### DIFF
--- a/var/spack/repos/builtin/packages/onnx/package.py
+++ b/var/spack/repos/builtin/packages/onnx/package.py
@@ -20,6 +20,9 @@ class Onnx(CMakePackage):
     license("Apache-2.0")
 
     version("master", branch="master")
+    version("1.15.0", sha256="c757132e018dd0dd171499ef74fca88b74c5430a20781ec53da19eb7f937ef68")
+    version("1.14.1", sha256="e296f8867951fa6e71417a18f2e550a730550f8829bd35e947b4df5e3e777aa1")
+    version("1.14.0", sha256="1b02ad523f79d83f9678c749d5a3f63f0bcd0934550d5e0d7b895f9a29320003")
     version(
         "1.13.1", sha256="090d3e10ec662a98a2a72f1bf053f793efc645824f0d4b779e0ce47468a0890e"
     )  # py-torch@2:
@@ -62,7 +65,7 @@ class Onnx(CMakePackage):
     depends_on("protobuf")
 
     def patch(self):
-        if self.spec.satisfies("@1.13 ^protobuf@3.22:"):
+        if self.spec.satisfies("@1.13:1.14 ^protobuf@3.22:"):
             filter_file("CMAKE_CXX_STANDARD 11", "CMAKE_CXX_STANDARD 14", "CMakeLists.txt")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/py-onnx/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx/package.py
@@ -38,7 +38,7 @@ class PyOnnx(PythonPackage):
     depends_on("py-pybind11@2.2:", type=("build", "link"))
 
     # requirements.txt
-    depends_on("py-setuptools@61:", type="build")
+    depends_on("py-setuptools@64:", type="build")
     depends_on("py-setuptools", type="build")
     depends_on("py-protobuf@3.20.2:", type=("build", "run"), when="@1.15:")
     depends_on("py-protobuf@3.20.2:3", type=("build", "run"), when="@1.13")

--- a/var/spack/repos/builtin/packages/py-onnx/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx/package.py
@@ -35,7 +35,7 @@ class PyOnnx(PythonPackage):
 
     # CMakeLists.txt
     depends_on("cmake@3.1:", type="build")
-    depends_on("py-pybind11@2.2:", type=("build", "run"))
+    depends_on("py-pybind11@2.2:", type=("build", "link"))
 
     # requirements.txt
     depends_on("py-setuptools@61:", type="build")

--- a/var/spack/repos/builtin/packages/py-onnx/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx/package.py
@@ -22,6 +22,8 @@ class PyOnnx(PythonPackage):
     license("Apache-2.0")
 
     version("1.15.0", sha256="b18461a7d38f286618ca2a6e78062a2a9c634ce498e631e708a8041b00094825")
+    version("1.14.1", sha256="70903afe163643bd71195c78cedcc3f4fa05a2af651fd950ef3acbb15175b2d1")
+    version("1.14.0", sha256="43b85087c6b919de66872a043c7f4899fe6f840e11ffca7e662b2ce9e4cc2927")
     version("1.13.1", sha256="0bdcc25c2c1ce4a8750e4ffbd93ae945442e7fac6e51176f38e366b74a97dfd9")
     version("1.13.0", sha256="410b39950367857f97b65093681fe2495a2e23d63777a8aceaf96c56a16d166e")
     version("1.12.0", sha256="13b3e77d27523b9dbf4f30dfc9c959455859d5e34e921c44f712d69b8369eff9")
@@ -33,6 +35,7 @@ class PyOnnx(PythonPackage):
 
     # CMakeLists.txt
     depends_on("cmake@3.1:", type="build")
+    depends_on("py-pybind11@2.2:", type=("build", "run"))
 
     # requirements.txt
     depends_on("py-setuptools@61:", type="build")
@@ -54,8 +57,8 @@ class PyOnnx(PythonPackage):
 
     # Historical dependencies
     depends_on("py-six", type=("build", "run"), when="@:1.8.1")
-    depends_on("py-typing-extensions@3.6.2.1:", type=("build", "run"), when="@:1.13")
-    depends_on("py-pytest-runner", type="build", when="@:1.13")
+    depends_on("py-typing-extensions@3.6.2.1:", type=("build", "run"), when="@:1.14")
+    depends_on("py-pytest-runner", type="build", when="@:1.14")
 
     # 'python_out' does not recognize dllexport_decl.
     patch("remove_dllexport_decl.patch", when="@:1.6.0")


### PR DESCRIPTION
Notes on `onnx`:
- The C++ standard was changed to C++14 in 1.15, so no more filter_file is needed. (The C++ standard has since changed to C++17 in master.)

Notes on `py-onnx`:
- `py-pybind11` was an unlisted requirement in CMakeLists.txt since 1.3 or so (before earliest spack package), but was picked up as vendored third_party.
- `py-setuptools` is listed as >= 61, but does not work until >= 64 due to attribute editable_mode used in setup.py.