### PR TITLE
hepmc3: new v3.2.7

### DIFF
--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -20,6 +20,7 @@ class Hepmc3(CMakePackage):
 
     license("LGPL-3.0-or-later")
 
+    version("3.2.7", sha256="587faa6556cc54ccd89ad35421461b4761d7809bc17a2e72f5034daea142232b")
     version("3.2.6", sha256="248f3b5b36dd773844cbe73d51f60891458334b986b259754c59dbf4bbf1d525")
     version("3.2.5", sha256="cd0f75c80f75549c59cc2a829ece7601c77de97cb2a5ab75790cac8e1d585032")
     version("3.2.4", sha256="e088fccfd1a6c2f8e1089f457101bee1e5c7a9777e9d51c6419c8a288a49e1bb")


### PR DESCRIPTION
Bugfix only, https://gitlab.cern.ch/hepmc/HepMC3/-/compare/3.2.6...3.2.7?from_project_id=6751&straight=false.