### PR TITLE
pythia8: new version 8.310

### DIFF
--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -22,6 +22,7 @@ class Pythia8(AutotoolsPackage):
 
     license("GPL-2.0-only")
 
+    version("8.310", sha256="90c811abe7a3d2ffdbf9b4aeab51cf6e0a5a8befb4e3efa806f3d5b9c311e227")
     version("8.309", sha256="5bdafd9f2c4a1c47fd8a4e82fb9f0d8fcfba4de1003b8e14be4e0347436d6c33")
     version("8.308", sha256="c2e8c8d38136d85fc0bc9c9fad4c2db679b0819b7d2b6fc9a47f80f99538b4e3")
     version("8.307", sha256="e5b14d44aa5943332e32dd5dda9a18fdd1a0085c7198e28d840e04167fa6013d")


### PR DESCRIPTION
No release notes available, but diff: https://gitlab.com/Pythia8/releases/-/compare/pythia8309...pythia8310?from_project_id=12340057&straight=false. Builds fine locally.