### PR TITLE
update mpi-serial version

### DIFF
--- a/var/spack/repos/builtin/packages/mpi-serial/package.py
+++ b/var/spack/repos/builtin/packages/mpi-serial/package.py
@@ -17,6 +17,7 @@ class MpiSerial(AutotoolsPackage):
     # notify when the package is updated.
     maintainers("jedwards4b")
 
+    version("2.5.0", sha256="2faf459ea1f37020662067e7ab6c76b926501c4b94e8fdf77591c0040ba1f006")
     version("2.3.0", sha256="cc55e6bf0ae5e1d93aafa31ba91bfc13e896642a511c3101695ea05eccf97988")
 
     variant(

--- a/var/spack/repos/builtin/packages/mpi-serial/package.py
+++ b/var/spack/repos/builtin/packages/mpi-serial/package.py
@@ -36,6 +36,10 @@ class MpiSerial(AutotoolsPackage):
 
     provides("mpi")
 
+    depends_on("autoconf", type="build", when="@2.5.0")
+    depends_on("automake", type="build", when="@2.5.0")
+    depends_on("libtool",  type="build", when="@2.5.0")
+    
     def flag_handler(self, name, flags):
         spec = self.spec
         config_flags = []

--- a/var/spack/repos/builtin/packages/mpi-serial/package.py
+++ b/var/spack/repos/builtin/packages/mpi-serial/package.py
@@ -11,8 +11,8 @@ from spack.package import *
 class MpiSerial(AutotoolsPackage):
     """A single processor implementation of the mpi library."""
 
-    homepage = "https://github.com/MCSclimate/mpi-serial"
-    url = "https://github.com/MCSclimate/mpi-serial/archive/refs/tags/MPIserial_2.3.0.tar.gz"
+    homepage = "https://github.com/ESMCI/mpi-serial"
+    url = "https://github.com/ESMCI/mpi-serial/archive/refs/tags/MPIserial_2.3.0.tar.gz"
 
     # notify when the package is updated.
     maintainers("jedwards4b")

--- a/var/spack/repos/builtin/packages/mpi-serial/package.py
+++ b/var/spack/repos/builtin/packages/mpi-serial/package.py
@@ -38,8 +38,8 @@ class MpiSerial(AutotoolsPackage):
 
     depends_on("autoconf", type="build", when="@2.5.0")
     depends_on("automake", type="build", when="@2.5.0")
-    depends_on("libtool",  type="build", when="@2.5.0")
-    
+    depends_on("libtool", type="build", when="@2.5.0")
+
     def flag_handler(self, name, flags):
         spec = self.spec
         config_flags = []


### PR DESCRIPTION
Add a new tag for mpi-serial.  The github URL was also changed, but the old URL works as well.