### PR TITLE
papi: patch for cray fortran bug with `-ffree-form`

### DIFF
--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -82,6 +82,8 @@ class Papi(AutotoolsPackage, ROCmPackage):
         sha256="64c57b3ad4026255238cc495df6abfacc41de391a0af497c27d0ac819444a1f8",
         when="@5.4.0:5.6%gcc@8:",
     )
+    # 7.1.0 erroneously adds -ffree-form for all fortran compilers
+    patch("sysdetect-free-form-fix.patch", when="@7.1.0:")
     patch("crayftn-fixes.patch", when="@6.0.0:%cce@9:")
     patch("intel-oneapi-compiler-fixes.patch", when="@6.0.0:%oneapi")
     patch("intel-cray-freeform.patch", when="@7.0.1")

--- a/var/spack/repos/builtin/packages/papi/sysdetect-free-form-fix.patch
+++ b/var/spack/repos/builtin/packages/papi/sysdetect-free-form-fix.patch
@@ -1,0 +1,17 @@
+diff --git a/src/components/sysdetect/tests/Makefile b/src/components/sysdetect/tests/Makefile
+index 63ac01358..79ce57e4b 100644
+--- a/src/components/sysdetect/tests/Makefile
++++ b/src/components/sysdetect/tests/Makefile
+@@ -21,11 +21,9 @@ endif
+ intel_compilers := ifort ifx
+ cray_compilers := ftn crayftn
+ 
+-FFLAGS += -ffree-form
+-
+ ifeq ($(notdir $(F77)),gfortran)
+     FFLAGS +=-ffree-form -ffree-line-length-none
+-else ifeq ($(notdir $(F77)),flang)
++else ifeq ($(patsubst %flang,,$(notdir $(F77))),)  # compiler name ends with flang
+     FFLAGS +=-ffree-form
+ else ifneq ($(findstring $(notdir $(F77)), $(intel_compilers)),)
+     FFLAGS +=-free


### PR DESCRIPTION
PAPI 7.1.0 unconditionally adds `FFLAGS = -ffree-form` in the sysdetect tests, regardless of the compiler.

This was added in https://github.com/icl-utk-edu/papi/pull/108 to make a build with `armflang` work, but it breaks CCE (and our `develop` pipeline)

- [x] Add a patch that fixes both problems
- [x] Patch PAPI when at 7.1.0 or higher