### PR TITLE
papi: only patch flag issue for 7.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -85,7 +85,7 @@ class Papi(AutotoolsPackage, ROCmPackage):
         when="@5.4.0:5.6%gcc@8:",
     )
     # 7.1.0 erroneously adds -ffree-form for all fortran compilers
-    patch("sysdetect-free-form-fix.patch", when="@7.1.0:")
+    patch("sysdetect-free-form-fix.patch", when="@7.1.0")
     patch("crayftn-fixes.patch", when="@6.0.0:%cce@9:")
     patch("intel-oneapi-compiler-fixes.patch", when="@6.0.0:%oneapi")
     patch("intel-cray-freeform.patch", when="@7.0.1")


### PR DESCRIPTION
PAPI CI checks a `spack install` of `papi@master`, and the open range here breaks their CI with the fix because the patch is no longer needed (see #26784, #27625 for why it's difficult to avoid this).

The patch issue is going to be fixed in PAPI upstream with whatever release is after `7.1.0`, so we can restrict the patch to `7.1.0` and avoid this issue.