### PR TITLE
hotfix: CI: Fix timing search paths to ignore bootstrap

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/scripts/common/aggregate_package_logs.spack.py
+++ b/share/spack/gitlab/cloud_pipelines/scripts/common/aggregate_package_logs.spack.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     data = []
 
     # Look in the CWD for logs
-    local_log_path = os.path.join(os.path.getcwd(), args.log)
+    local_log_path = os.path.join(os.getcwd(), args.log)
     if os.path.exists(local_log_path):
         with open(local_log_path) as fd:
             data.append(json.load(fd))


### PR DESCRIPTION
Hot fix for previous PR that used the wrong python API for getting the current working directory!!