### PR TITLE
geant4-data: fix versions for 11.2

### DIFF
--- a/var/spack/repos/builtin/packages/g4emlow/package.py
+++ b/var/spack/repos/builtin/packages/g4emlow/package.py
@@ -18,7 +18,7 @@ class G4emlow(Package):
     maintainers("drbenmorgan")
 
     # Only versions relevant to Geant4 releases built by spack are added
-    version("8.5", sha256="c97be73fece5fb4f73c43e11c146b43f651c6991edd0edf8619c9452f8ab1236")
+    version("8.5", sha256="66baca49ac5d45e2ac10c125b4fb266225e511803e66981909ce9cd3e9bcef73")
     version("8.4", sha256="d87de4d2a364cb0a1e1846560525ffc3f735ccdeea8bc426d61775179aebbe8e")
     version("8.2", sha256="3d7768264ff5a53bcb96087604bbe11c60b7fea90aaac8f7d1252183e1a8e427")
     version("8.0", sha256="d919a8e5838688257b9248a613910eb2a7633059e030c8b50c0a2c2ad9fd2b3b")

--- a/var/spack/repos/builtin/packages/g4emlow/package.py
+++ b/var/spack/repos/builtin/packages/g4emlow/package.py
@@ -18,6 +18,7 @@ class G4emlow(Package):
     maintainers("drbenmorgan")
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version("8.5", sha256="c97be73fece5fb4f73c43e11c146b43f651c6991edd0edf8619c9452f8ab1236")
     version("8.4", sha256="d87de4d2a364cb0a1e1846560525ffc3f735ccdeea8bc426d61775179aebbe8e")
     version("8.2", sha256="3d7768264ff5a53bcb96087604bbe11c60b7fea90aaac8f7d1252183e1a8e427")
     version("8.0", sha256="d919a8e5838688257b9248a613910eb2a7633059e030c8b50c0a2c2ad9fd2b3b")

--- a/var/spack/repos/builtin/packages/g4incl/package.py
+++ b/var/spack/repos/builtin/packages/g4incl/package.py
@@ -19,6 +19,7 @@ class G4incl(Package):
     maintainers("drbenmorgan")
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version("1.2", sha256="f880b16073ee0a92d7494f3276a6d52d4de1d3677a0d4c7c58700396ed0e1a7e")
     version("1.1", sha256="5d82e71db5f5a1b659937506576be58db7de7753ec5913128141ae7fce673b44")
     version("1.0", sha256="716161821ae9f3d0565fbf3c2cf34f4e02e3e519eb419a82236eef22c2c4367d")
 

--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -45,7 +45,7 @@ class Geant4Data(BundlePackage):
     _datasets = {
         "11.2.0:11.2": [
             "g4ndl@4.7",
-            "g4emlow@8.4",
+            "g4emlow@8.5",
             "g4photonevaporation@5.7",
             "g4radioactivedecay@5.6",
             "g4particlexs@4.0",
@@ -53,7 +53,7 @@ class Geant4Data(BundlePackage):
             "g4realsurface@2.2",
             "g4saiddata@2.0",
             "g4abla@3.3",
-            "g4incl@1.1",
+            "g4incl@1.2",
             "g4ensdfstate@2.3",
         ],
         "11.1.0:11.1": [


### PR DESCRIPTION
The Geant4@11.2 DATASET cmake variables are looking for G4EMLOW 8.5 (not 8.4) and G4INCL 1.2 (not 1.1). @wdconinc is it possible that you set those earlier data versions using a pre-release of Geant4 11.2?