### PR TITLE
 `spack env track` command

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -483,7 +483,7 @@ def env_track(args):
     tty.msg(f"Tracking environment in {src_path}")
     tty.msg(
         "You can now activate this environment with the following command:\n\n"
-        "        spack env activate {name}\n"
+        f"        spack env activate {name}\n"
     )
 
 
@@ -509,7 +509,7 @@ def env_untrack(args):
 
         # fail if the user tries to untrack a managed environment
         if not islink(env_path):
-            tty.die(
+            raise ev.SpackEnvironmentError(
                 f"{env_name} is not a tracked env. "
                 "To remove it completely run,"
                 "\n\n"
@@ -596,9 +596,8 @@ def env_remove(args):
         if env.active:
             tty.die(f"Environment {name} can't be removed while activated.")
         # Get path to check if environment is a tracked / symlinked environment
-        env_path = ev.environment_dir_from_name(env)
-        if islink(path):
-            os.unlink(path)
+        if islink(env.path):
+            os.unlink(env.path)
             tty.msg(f"Successfully untracked environment '{name}'")
         else:
             env.destroy()

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -562,11 +562,13 @@ def env_remove(args):
     for env_name in unknown_envs:
         tty.error(f"Environment {env_name} does not exist")
 
-    for env_name in known_envs:
+    for env_name in all_envs:
         try:
             env = ev.read(env_name)
             valid_envs.append(env)
-            remove_envs.append(env)
+
+            if env_name in known_envs:
+                remove_envs.append(env)
         except (spack.config.ConfigFormatError, ev.SpackEnvironmentConfigError):
             bad_envs.append(env_name)
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -473,7 +473,7 @@ def env_track(args):
         dst_path = ev.environment_dir_from_name(name, exists_ok=False)
     except ev.SpackEnvironmentError:
         tty.die(
-            f"An environment named {name} already exists. Set a name with,"
+            f"An environment named {name} already exists. Set a name with:"
             "\n\n"
             f"        spack env track --name NAME {src_path}\n"
         )
@@ -514,7 +514,7 @@ def env_untrack(args):
         if not islink(env_path):
             tty.die(
                 f"{env_name} is not a tracked env. "
-                "To remove it completely run,"
+                "To remove it completely run:"
                 "\n\n"
                 f"        spack env rm {env_name}\n"
             )

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -15,7 +15,7 @@ from typing import List, Optional
 import llnl.string as string
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
-from llnl.util.symlink import SymlinkError, symlink, islink
+from llnl.util.symlink import islink, symlink
 from llnl.util.tty.colify import colify
 from llnl.util.tty.color import cescape, colorize
 
@@ -462,7 +462,7 @@ def env_track_setup_parser(subparser):
 def env_track(args):
     src_path = os.path.abspath(args.dir)
     if not ev.is_env_dir(src_path):
-        tty.die(f"Cannot track environment. Path doesn't contain an environment")
+        tty.die("Cannot track environment. Path doesn't contain an environment")
 
     if args.name:
         name = args.name

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -494,10 +494,7 @@ def env_untrack_setup_parser(subparser):
     """track an environment from a directory in Spack"""
     subparser.add_argument("env", nargs="+", help="tracked environment name")
     subparser.add_argument(
-        "-f",
-        "--force",
-        action="store_true",
-        help="force unlink even when environment is active",
+        "-f", "--force", action="store_true", help="force unlink even when environment is active"
     )
     arguments.add_common_arguments(subparser, ["yes_to_all"])
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -532,7 +532,7 @@ def get_valid_envs(env_names: Set[str]) -> Set[ev.Environment]:
 
 def _env_untrack_or_remove(
     env_names: List[str], remove: bool = False, force: bool = False, yes_to_all: bool = False
-) -> List[str]:
+):
     all_env_names = set(ev.all_environment_names())
     known_env_names = set(env_names).intersection(all_env_names)
     unknown_env_names = set(env_names) - known_env_names
@@ -568,7 +568,7 @@ def _env_untrack_or_remove(
 
     if not (yes_to_all or force) and (envs_to_remove or bad_env_names_to_remove):
         environments = string.plural(len(env_names_to_remove), "environment", show_n=False)
-        envs = string.comma_and(env_names_to_remove)
+        envs = string.comma_and(list(env_names_to_remove))
         answer = tty.get_yes_or_no(
             f"Really {'remove' if remove else 'untrack'} {environments} {envs}?", default=False
         )

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -42,7 +42,6 @@ subcommands = [
     "activate",
     "deactivate",
     "create",
-    "add",
     ["remove", "rm"],
     ["rename", "mv"],
     ["list", "ls"],
@@ -52,6 +51,7 @@ subcommands = [
     "update",
     "revert",
     "depfile",
+    "track",
 ]
 
 
@@ -449,19 +449,19 @@ def env_deactivate(args):
 
 
 #
-# env add
+# env track
 #
-def env_add_setup_parser(subparser):
-    """add an existing environment from a directory"""
+def env_track_setup_parser(subparser):
+    """track an environment from a directory in Spack"""
     subparser.add_argument("-n", "--name", help="custom environment name")
     subparser.add_argument("dir", help="path to environment")
     arguments.add_common_arguments(subparser, ["yes_to_all"])
 
 
-def env_add(args):
+def env_track(args):
     src_path = os.path.abspath(args.dir)
     if not ev.is_env_dir(src_path):
-        msg = f"cannot add environment {src_path} doesn't contain an environment"
+        msg = f"cannot track environment {src_path} doesn't contain an environment"
         raise ev.SpackEnvironmentError(msg)
 
     if args.name:
@@ -474,10 +474,10 @@ def env_add(args):
     try:
         symlink(src_path, dst_path)
     except SymlinkError as exc:
-        msg = f"cannot add the environment {src_path} unable to create symlink"
+        msg = f"cannot track the environment {src_path} unable to create symlink"
         raise ev.SpackEnvironmentError(msg) from exc
 
-    tty.msg(f"Linked environment in {src_path}")
+    tty.msg(f"Tracking environment in {src_path}")
     tty.msg("You can activate this environment with:")
     tty.msg(f"    spack env activate {name}")
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -477,7 +477,7 @@ def env_track(args):
         msg = f"cannot track the environment {src_path} unable to create symlink"
         raise ev.SpackEnvironmentError(msg) from exc
 
-    tty.msg(f"Tracking environment in {src_path}")
+    tty.msg(f"Tracking environment in {src_path} as {name}")
     tty.msg("You can activate this environment with:")
     tty.msg(f"    spack env activate {name}")
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -460,6 +460,10 @@ def env_add_setup_parser(subparser):
 
 def env_add(args):
     src_path = os.path.abspath(args.dir)
+    if not os.path.exists(src_path):
+        msg = f"cannot add the environment {src_path} does not exist"
+        raise ev.SpackEnvironmentError(msg)
+
     name = os.path.basename(src_path)
     if args.name:
         name = args.name
@@ -469,7 +473,7 @@ def env_add(args):
     try:
         symlink(src_path, dst_path)
     except SymlinkError as exc:
-        msg = f"cannot add the environment {src_path} does not exist"
+        msg = f"cannot add the environment {src_path} unable to create symlink"
         raise ev.SpackEnvironmentError(msg) from exc
 
     tty.msg(f"Linked environment in {src_path}")

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -460,13 +460,14 @@ def env_add_setup_parser(subparser):
 
 def env_add(args):
     src_path = os.path.abspath(args.dir)
-    if not os.path.exists(src_path):
-        msg = f"cannot add the environment {src_path} does not exist"
+    if not ev.is_env_dir(src_path):
+        msg = f"cannot add environment {src_path} doesn't contain an environment"
         raise ev.SpackEnvironmentError(msg)
 
-    name = os.path.basename(src_path)
     if args.name:
         name = args.name
+    else:
+        name = os.path.basename(src_path)
 
     dst_path = ev.environment_dir_from_name(name, exists_ok=False)
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -15,9 +15,9 @@ from typing import List, Optional
 import llnl.string as string
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
+from llnl.util.symlink import SymlinkError, symlink
 from llnl.util.tty.colify import colify
-from llnl.util.tty.color import cescape, colorize
-from llnl.util.symlink import symlink, SymlinkError
+from llnl.util.tty.color import colorize
 
 import spack.cmd
 import spack.cmd.common

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -17,7 +17,7 @@ import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 from llnl.util.symlink import SymlinkError, symlink
 from llnl.util.tty.colify import colify
-from llnl.util.tty.color import colorize
+from llnl.util.tty.color import cescape, colorize
 
 import spack.cmd
 import spack.cmd.common
@@ -449,99 +449,6 @@ def env_deactivate(args):
 
 
 #
-<<<<<<< HEAD
-=======
-# env create
-#
-def env_create_setup_parser(subparser):
-    """create a new environment"""
-    subparser.add_argument("create_env", metavar="env", help="name of environment to create")
-    subparser.add_argument(
-        "-d", "--dir", action="store_true", help="create an environment in a specific directory"
-    )
-    subparser.add_argument(
-        "--keep-relative",
-        action="store_true",
-        help="copy relative develop paths verbatim into the new environment"
-        " when initializing from envfile",
-    )
-    view_opts = subparser.add_mutually_exclusive_group()
-    view_opts.add_argument(
-        "--without-view", action="store_true", help="do not maintain a view for this environment"
-    )
-    view_opts.add_argument(
-        "--with-view",
-        help="specify that this environment should maintain a view at the"
-        " specified path (by default the view is maintained in the"
-        " environment directory)",
-    )
-    subparser.add_argument(
-        "envfile",
-        nargs="?",
-        default=None,
-        help="either a lockfile (must end with '.json' or '.lock') or a manifest file",
-    )
-
-
-def env_create(args):
-    if args.with_view:
-        # Expand relative paths provided on the command line to the current working directory
-        # This way we interpret `spack env create --with-view ./view --dir ./env` as
-        # a view in $PWD/view, not $PWD/env/view. This is different from specifying a relative
-        # path in the manifest, which is resolved relative to the manifest file's location.
-        with_view = os.path.abspath(args.with_view)
-    elif args.without_view:
-        with_view = False
-    else:
-        # Note that 'None' means unspecified, in which case the Environment
-        # object could choose to enable a view by default. False means that
-        # the environment should not include a view.
-        with_view = None
-
-    env = _env_create(
-        args.create_env,
-        init_file=args.envfile,
-        dir=args.dir,
-        with_view=with_view,
-        keep_relative=args.keep_relative,
-    )
-
-    # Generate views, only really useful for environments created from spack.lock files.
-    env.regenerate_views()
-
-
-def _env_create(name_or_path, *, init_file=None, dir=False, with_view=None, keep_relative=False):
-    """Create a new environment, with an optional yaml description.
-
-    Arguments:
-        name_or_path (str): name of the environment to create, or path to it
-        init_file (str or file): optional initialization file -- can be
-            a JSON lockfile (*.lock, *.json) or YAML manifest file
-        dir (bool): if True, create an environment in a directory instead
-            of a named environment
-        keep_relative (bool): if True, develop paths are copied verbatim into
-            the new environment file, otherwise they may be made absolute if the
-            new environment is in a different location
-    """
-    if not dir:
-        env = ev.create(
-            name_or_path, init_file=init_file, with_view=with_view, keep_relative=keep_relative
-        )
-        tty.msg("Created environment '%s' in %s" % (name_or_path, env.path))
-        tty.msg("You can activate this environment with:")
-        tty.msg("  spack env activate %s" % (name_or_path))
-        return env
-
-    env = ev.create_in_dir(
-        name_or_path, init_file=init_file, with_view=with_view, keep_relative=keep_relative
-    )
-    tty.msg("Created environment in %s" % env.path)
-    tty.msg("You can activate this environment with:")
-    tty.msg("  spack env activate %s" % env.path)
-    return env
-
-
-#
 # env add
 #
 def env_add_setup_parser(subparser):
@@ -571,7 +478,6 @@ def env_add(args):
 
 
 #
->>>>>>> 441d900d28 (Add spack env add command)
 # env remove
 #
 def env_remove_setup_parser(subparser):

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -467,7 +467,7 @@ def env_add(args):
     dst_path = ev.environment_dir_from_name(name, exists_ok=False)
 
     try:
-        symlink(src_path, dst_path, allow_broken_symlinks=False)
+        symlink(src_path, dst_path)
     except SymlinkError as exc:
         msg = f"cannot add the environment {src_path} does not exist"
         raise ev.SpackEnvironmentError(msg) from exc

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -654,7 +654,7 @@ class ViewDescriptor:
 
     @property
     def _current_root(self):
-        if not os.path.islink(self.root):
+        if not islink(self.root):
             return None
 
         root = readlink(self.root)
@@ -1247,10 +1247,7 @@ class Environment:
 
     def destroy(self):
         """Remove this environment from Spack entirely."""
-        if islink(self.path):
-            os.unlink(self.path)
-        else:
-            shutil.rmtree(self.path)
+        shutil.rmtree(self.path)
 
     def update_stale_references(self, from_list=None):
         """Iterate over spec lists updating references."""

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1247,7 +1247,10 @@ class Environment:
 
     def destroy(self):
         """Remove this environment from Spack entirely."""
-        shutil.rmtree(self.path)
+        if os.path.islink(self.path):
+            os.unlink(self.path)
+        else:
+            shutil.rmtree(self.path)
 
     def update_stale_references(self, from_list=None):
         """Iterate over spec lists updating references."""

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -22,7 +22,7 @@ import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 import llnl.util.tty.color as clr
 from llnl.util.link_tree import ConflictingSpecsError
-from llnl.util.symlink import readlink, symlink
+from llnl.util.symlink import islink, readlink, symlink
 
 import spack
 import spack.caches
@@ -1247,7 +1247,7 @@ class Environment:
 
     def destroy(self):
         """Remove this environment from Spack entirely."""
-        if os.path.islink(self.path):
+        if islink(self.path):
             os.unlink(self.path)
         else:
             shutil.rmtree(self.path)

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -117,7 +117,7 @@ def check_viewdir_removal(viewdir):
 
 
 def test_env_track_nonexistant_path_fails():
-    with pytest.raises(ev.SpackEnvironmentError, match=r"doesn't contain an environment"):
+    with pytest.raises(BaseException, match=r"doesn't contain an environment"):
         env("track", "path/does/not/exist")
 
 
@@ -4149,7 +4149,7 @@ all: post-install
 include include.mk
 
 example/post-install/%: example/install/%
-	$(info post-install: $(HASH)) # noqa: W191,E101
+        $(info post-install: $(HASH)) # noqa: W191,E101
 
 post-install: $(addprefix example/post-install/,$(example/SPACK_PACKAGE_IDS))
 """

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -116,16 +116,22 @@ def check_viewdir_removal(viewdir):
     ) == ["projections.yaml"]
 
 
-def test_env_track_nonexistant_path_fails():
-    with pytest.raises(BaseException, match=r"doesn't contain an environment"):
+def test_env_track_nonexistant_path_fails(capfd):
+    with pytest.raises(spack.main.SpackCommandError):
         env("track", "path/does/not/exist")
 
+    out, _ = capfd.readouterr()
+    assert "doesn't contain an environment" in out
 
-def test_env_track_existing_env_fails():
+
+def test_env_track_existing_env_fails(capfd):
     env("create", "track_test")
 
-    with pytest.raises(ev.SpackEnvironmentError, match=r"environment already exists"):
+    with pytest.raises(spack.main.SpackCommandError):
         env("track", "--name", "track_test", ev.environment_dir_from_name("track_test"))
+
+    out, _ = capfd.readouterr()
+    assert "environment named track_test already exists" in out
 
 
 def test_env_track_valid(tmp_path):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -4155,7 +4155,7 @@ all: post-install
 include include.mk
 
 example/post-install/%: example/install/%
-        $(info post-install: $(HASH)) # noqa: W191,E101
+	$(info post-install: $(HASH)) # noqa: W191,E101
 
 post-install: $(addprefix example/post-install/,$(example/SPACK_PACKAGE_IDS))
 """

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -155,7 +155,7 @@ def test_env_untrack_valid(tmp_path):
 
         # test tracking an environment in known store
         env("track", "--name", "test_untrack", ".")
-        env("untrack", "test_untrack")
+        env("untrack", "--yes-to-all", "test_untrack")
 
         # check that environment was sucessfully untracked
         out = env("ls")
@@ -168,7 +168,7 @@ def test_env_untrack_invalid_name():
 
     out = env("untrack", env_name)
 
-    assert f"Environment {env_name} does not exist" in out
+    assert f"Environment '{env_name}' does not exist" in out
 
 
 def test_env_untrack_when_active(tmp_path, capfd):
@@ -184,11 +184,11 @@ def test_env_untrack_when_active(tmp_path, capfd):
         active_env = ev.read(env_name)
         with active_env:
             with pytest.raises(spack.main.SpackCommandError):
-                env("untrack", env_name)
+                env("untrack", "--yes-to-all", env_name)
 
         # check that environment could not be untracked while active
         out, _ = capfd.readouterr()
-        assert f"{env_name} can't be untracked while activated" in out
+        assert f"'{env_name}' can't be untracked while activated" in out
 
         env("untrack", "-f", env_name)
         out = env("ls")
@@ -206,7 +206,7 @@ def test_env_untrack_managed(tmp_path, capfd):
 
     # check that environment could not be untracked while active
     out, _ = capfd.readouterr()
-    assert f"{env_name} is not a tracked env" in out
+    assert f"'{env_name}' is not a tracked env" in out
 
 
 def test_add():
@@ -770,7 +770,7 @@ def test_force_remove_included_env():
     rm_output = env("remove", "-f", "-y", "test")
     list_output = env("list")
 
-    assert '"test" is being used by environment "combined_env"' in rm_output
+    assert "'test' is used by environment 'combined_env'" in rm_output
     assert "test" not in list_output
 
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -152,7 +152,7 @@ def test_change_multiple_matches():
 
 
 def test_env_add_nonexistant_path_fails():
-    with pytest.raises(ev.SpackEnvironmentError, match=r"does not exist"):
+    with pytest.raises(ev.SpackEnvironmentError, match=r"doesn't contain an environment"):
         env("add", "path/does/not/exist")
 
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -150,15 +150,18 @@ def test_change_multiple_matches():
     assert all(x.intersects("%gcc") for x in e.user_specs if x.name == "mpileaks")
     assert any(x.intersects("%clang") for x in e.user_specs if x.name == "libelf")
 
+
 def test_env_add_nonexistant_path_fails():
     with pytest.raises(ev.SpackEnvironmentError, match=r"does not exist"):
         env("add", "path/does/not/exist")
+
 
 def test_env_add_existing_env_fails():
     env("create", "test")
 
     with pytest.raises(ev.SpackEnvironmentError, match=r"environment already exists"):
         env("add", "--name", "test", ev.environment_dir_from_name("test"))
+
 
 def test_env_pkg_add_virtual():
     env("create", "test")

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -163,6 +163,20 @@ def test_env_add_existing_env_fails():
         env("add", "--name", "add_test", ev.environment_dir_from_name("add_test"))
 
 
+def test_env_add_valid(tmp_path):
+    with fs.working_dir(str(tmp_path)):
+        # create an independent environment
+        env("create", "-d", ".")
+
+        # test adding environment into known store
+        env("add", "--name", "test1", ".")
+
+        # test removing environment to ensure independent isn't deleted
+        env("rm", "-y", "test1")
+
+        assert os.path.isfile("spack.yaml")
+
+
 def test_env_add_virtual():
     env("create", "test")
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -150,8 +150,17 @@ def test_change_multiple_matches():
     assert all(x.intersects("%gcc") for x in e.user_specs if x.name == "mpileaks")
     assert any(x.intersects("%clang") for x in e.user_specs if x.name == "libelf")
 
+def test_env_add_nonexistant_path_fails():
+    with pytest.raises(ev.SpackEnvironmentError, match=r"does not exist"):
+        env("add", "path/does/not/exist")
 
-def test_env_add_virtual():
+def test_env_add_existing_env_fails():
+    env("create", "test")
+
+    with pytest.raises(ev.SpackEnvironmentError, match=r"environment already exists"):
+        env("add", "--name", "test", ev.environment_dir_from_name("test"))
+
+def test_env_pkg_add_virtual():
     env("create", "test")
 
     e = ev.read("test")
@@ -164,7 +173,7 @@ def test_env_add_virtual():
     assert spec.intersects("mpi")
 
 
-def test_env_add_nonexistant_fails():
+def test_env_pkg_add_nonexistant_fails():
     env("create", "test")
 
     e = ev.read("test")
@@ -4123,7 +4132,7 @@ all: post-install
 include include.mk
 
 example/post-install/%: example/install/%
-	$(info post-install: $(HASH)) # noqa: W191,E101
+    $(info post-install: $(HASH)) # noqa: W191,E101
 
 post-install: $(addprefix example/post-install/,$(example/SPACK_PACKAGE_IDS))
 """

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -157,13 +157,13 @@ def test_env_add_nonexistant_path_fails():
 
 
 def test_env_add_existing_env_fails():
-    env("create", "test")
+    env("create", "add_test")
 
     with pytest.raises(ev.SpackEnvironmentError, match=r"environment already exists"):
-        env("add", "--name", "test", ev.environment_dir_from_name("test"))
+        env("add", "--name", "add_test", ev.environment_dir_from_name("add_test"))
 
 
-def test_env_pkg_add_virtual():
+def test_env_add_virtual():
     env("create", "test")
 
     e = ev.read("test")
@@ -176,7 +176,7 @@ def test_env_pkg_add_virtual():
     assert spec.intersects("mpi")
 
 
-def test_env_pkg_add_nonexistant_fails():
+def test_env_add_nonexistant_fails():
     env("create", "test")
 
     e = ev.read("test")
@@ -4135,7 +4135,7 @@ all: post-install
 include include.mk
 
 example/post-install/%: example/install/%
-    $(info post-install: $(HASH)) # noqa: W191,E101
+	$(info post-install: $(HASH)) # noqa: W191,E101
 
 post-install: $(addprefix example/post-install/,$(example/SPACK_PACKAGE_IDS))
 """

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1153,7 +1153,7 @@ _spack_env_track() {
 _spack_env_untrack() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -y --yes-to-all"
+        SPACK_COMPREPLY="-h --help -f --force -y --yes-to-all"
     else
         _environments
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1023,7 +1023,7 @@ _spack_env() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="activate deactivate create remove rm rename mv list ls status st loads view update revert depfile track"
+        SPACK_COMPREPLY="activate deactivate create remove rm rename mv list ls status st loads view update revert depfile track untrack"
     fi
 }
 
@@ -1147,6 +1147,15 @@ _spack_env_track() {
         SPACK_COMPREPLY="-h --help -n --name -y --yes-to-all"
     else
         SPACK_COMPREPLY=""
+    fi
+}
+
+_spack_env_untrack() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -y --yes-to-all"
+    else
+        _environments
     fi
 }
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1023,7 +1023,7 @@ _spack_env() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="activate deactivate create add remove rm rename mv list ls status st loads view update revert depfile"
+        SPACK_COMPREPLY="activate deactivate create remove rm rename mv list ls status st loads view update revert depfile track"
     fi
 }
 
@@ -1046,15 +1046,6 @@ _spack_env_create() {
         SPACK_COMPREPLY="-h --help -d --dir --keep-relative --without-view --with-view --include-concrete"
     else
         _environments
-    fi
-}
-
-_spack_env_add() {
-    if $list_options
-    then
-        SPACK_COMPREPLY="-h --help -n --name -y --yes-to-all"
-    else
-        SPACK_COMPREPLY=""
     fi
 }
 
@@ -1147,6 +1138,15 @@ _spack_env_depfile() {
         SPACK_COMPREPLY="-h --help --make-prefix --make-target-prefix --make-disable-jobserver --use-buildcache -o --output -G --generator"
     else
         _all_packages
+    fi
+}
+
+_spack_env_track() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -n --name -y --yes-to-all"
+    else
+        SPACK_COMPREPLY=""
     fi
 }
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1023,7 +1023,7 @@ _spack_env() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="activate deactivate create remove rm rename mv list ls status st loads view update revert depfile"
+        SPACK_COMPREPLY="activate deactivate create add remove rm rename mv list ls status st loads view update revert depfile"
     fi
 }
 
@@ -1046,6 +1046,15 @@ _spack_env_create() {
         SPACK_COMPREPLY="-h --help -d --dir --keep-relative --without-view --with-view --include-concrete"
     else
         _environments
+    fi
+}
+
+_spack_env_add() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -n --name -y --yes-to-all"
+    else
+        SPACK_COMPREPLY=""
     fi
 }
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1682,10 +1682,12 @@ complete -c spack -n '__fish_spack_using_command env track' -s y -l yes-to-all -
 complete -c spack -n '__fish_spack_using_command env track' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 
 # spack env untrack
-set -g __fish_spack_optspecs_spack_env_untrack h/help y/yes-to-all
+set -g __fish_spack_optspecs_spack_env_untrack h/help f/force y/yes-to-all
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 env untrack' -f -a '(__fish_spack_environments)'
 complete -c spack -n '__fish_spack_using_command env untrack' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command env untrack' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command env untrack' -s f -l force -f -a force
+complete -c spack -n '__fish_spack_using_command env untrack' -s f -l force -d 'force unlink even when environment is active'
 complete -c spack -n '__fish_spack_using_command env untrack' -s y -l yes-to-all -f -a yes_to_all
 complete -c spack -n '__fish_spack_using_command env untrack' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1475,7 +1475,6 @@ set -g __fish_spack_optspecs_spack_env h/help
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a activate -d 'set the active environment'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a deactivate -d 'deactivate the active environment'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a create -d 'create a new environment'
-complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a add -d 'add an existing environment from a directory'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a remove -d 'remove managed environment(s)'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a rm -d 'remove managed environment(s)'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a rename -d 'rename an existing environment'
@@ -1489,6 +1488,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a view -d 'manag
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a update -d 'update the environment manifest to the latest schema format'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a revert -d 'restore the environment manifest to its previous format'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a depfile -d 'generate a depfile to exploit parallel builds across specs'
+complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a track -d 'track an environment from a directory in Spack'
 complete -c spack -n '__fish_spack_using_command env' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command env' -s h -l help -d 'show this help message and exit'
 
@@ -1554,16 +1554,6 @@ complete -c spack -n '__fish_spack_using_command env create' -l with-view -r -f 
 complete -c spack -n '__fish_spack_using_command env create' -l with-view -r -d 'maintain view at WITH_VIEW (vs. environment'"'"'s directory)'
 complete -c spack -n '__fish_spack_using_command env create' -l include-concrete -r -f -a include_concrete
 complete -c spack -n '__fish_spack_using_command env create' -l include-concrete -r -d 'copy concrete specs from INCLUDE_CONCRETE'"'"'s environment'
-
-# spack env add
-set -g __fish_spack_optspecs_spack_env_add h/help n/name= y/yes-to-all
-complete -c spack -n '__fish_spack_using_command_pos 0 env add' -f -a '(__fish_spack_environments)'
-complete -c spack -n '__fish_spack_using_command env add' -s h -l help -f -a help
-complete -c spack -n '__fish_spack_using_command env add' -s h -l help -d 'show this help message and exit'
-complete -c spack -n '__fish_spack_using_command env add' -s n -l name -r -f -a name
-complete -c spack -n '__fish_spack_using_command env add' -s n -l name -r -d 'custom environment name'
-complete -c spack -n '__fish_spack_using_command env add' -s y -l yes-to-all -f -a yes_to_all
-complete -c spack -n '__fish_spack_using_command env add' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 
 # spack env remove
 set -g __fish_spack_optspecs_spack_env_remove h/help y/yes-to-all f/force
@@ -1679,6 +1669,16 @@ complete -c spack -n '__fish_spack_using_command env depfile' -s o -l output -r 
 complete -c spack -n '__fish_spack_using_command env depfile' -s o -l output -r -d 'write the depfile to FILE rather than to stdout'
 complete -c spack -n '__fish_spack_using_command env depfile' -s G -l generator -r -f -a make
 complete -c spack -n '__fish_spack_using_command env depfile' -s G -l generator -r -d 'specify the depfile type (only supports `make`)'
+
+# spack env track
+set -g __fish_spack_optspecs_spack_env_track h/help n/name= y/yes-to-all
+complete -c spack -n '__fish_spack_using_command_pos 0 env track' -f -a '(__fish_spack_environments)'
+complete -c spack -n '__fish_spack_using_command env track' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command env track' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command env track' -s n -l name -r -f -a name
+complete -c spack -n '__fish_spack_using_command env track' -s n -l name -r -d 'custom environment name'
+complete -c spack -n '__fish_spack_using_command env track' -s y -l yes-to-all -f -a yes_to_all
+complete -c spack -n '__fish_spack_using_command env track' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 
 # spack extensions
 set -g __fish_spack_optspecs_spack_extensions h/help l/long L/very-long d/deps p/paths s/show=

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1489,6 +1489,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a update -d 'upd
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a revert -d 'restore the environment manifest to its previous format'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a depfile -d 'generate a depfile to exploit parallel builds across specs'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a track -d 'track an environment from a directory in Spack'
+complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a untrack -d 'track an environment from a directory in Spack'
 complete -c spack -n '__fish_spack_using_command env' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command env' -s h -l help -d 'show this help message and exit'
 
@@ -1679,6 +1680,14 @@ complete -c spack -n '__fish_spack_using_command env track' -s n -l name -r -f -
 complete -c spack -n '__fish_spack_using_command env track' -s n -l name -r -d 'custom environment name'
 complete -c spack -n '__fish_spack_using_command env track' -s y -l yes-to-all -f -a yes_to_all
 complete -c spack -n '__fish_spack_using_command env track' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
+
+# spack env untrack
+set -g __fish_spack_optspecs_spack_env_untrack h/help y/yes-to-all
+complete -c spack -n '__fish_spack_using_command_pos_remainder 0 env untrack' -f -a '(__fish_spack_environments)'
+complete -c spack -n '__fish_spack_using_command env untrack' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command env untrack' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command env untrack' -s y -l yes-to-all -f -a yes_to_all
+complete -c spack -n '__fish_spack_using_command env untrack' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 
 # spack extensions
 set -g __fish_spack_optspecs_spack_extensions h/help l/long L/very-long d/deps p/paths s/show=

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1475,6 +1475,7 @@ set -g __fish_spack_optspecs_spack_env h/help
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a activate -d 'set the active environment'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a deactivate -d 'deactivate the active environment'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a create -d 'create a new environment'
+complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a add -d 'add an existing environment from a directory'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a remove -d 'remove managed environment(s)'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a rm -d 'remove managed environment(s)'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a rename -d 'rename an existing environment'
@@ -1553,6 +1554,16 @@ complete -c spack -n '__fish_spack_using_command env create' -l with-view -r -f 
 complete -c spack -n '__fish_spack_using_command env create' -l with-view -r -d 'maintain view at WITH_VIEW (vs. environment'"'"'s directory)'
 complete -c spack -n '__fish_spack_using_command env create' -l include-concrete -r -f -a include_concrete
 complete -c spack -n '__fish_spack_using_command env create' -l include-concrete -r -d 'copy concrete specs from INCLUDE_CONCRETE'"'"'s environment'
+
+# spack env add
+set -g __fish_spack_optspecs_spack_env_add h/help n/name= y/yes-to-all
+complete -c spack -n '__fish_spack_using_command_pos 0 env add' -f -a '(__fish_spack_environments)'
+complete -c spack -n '__fish_spack_using_command env add' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command env add' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command env add' -s n -l name -r -f -a name
+complete -c spack -n '__fish_spack_using_command env add' -s n -l name -r -d 'custom environment name'
+complete -c spack -n '__fish_spack_using_command env add' -s y -l yes-to-all -f -a yes_to_all
+complete -c spack -n '__fish_spack_using_command env add' -s y -l yes-to-all -d 'assume "yes" is the answer to every confirmation request'
 
 # spack env remove
 set -g __fish_spack_optspecs_spack_env_remove h/help y/yes-to-all f/force


### PR DESCRIPTION
This PR adds a sub-command to `spack env` (`track`) which allows users to add/link
anonymous environments into their installation as named environments. This allows
users to more easily track their installed packages and the environments they're
dependencies of. For example, with the addition of #41731 it's now easier to remove
all packages not required by any environments with,

```
spack gc -bE
```

#### Usage
```
spack env track /path/to/env
==> Linked environment in /path/to/env
==> You can activate this environment with:
==>     spack env activate env
```

By default `track /path/to/env` will use the last directory in the path as the name of 
the environment. However users may customize the name of the linked environment
with `-n | --name`. Shown below.
```
spack env track /path/to/env --name foo 
==> Tracking environment in /path/to/env
==> You can activate this environment with:
==>     spack env activate foo
```

When removing a linked environment, Spack will remove the link to the environment
but will keep the structure of the environment within the directory. This will allow
users to remove a linked environment from their installation without deleting it from
a shared repository.

There is a `spack env untrack` command that can be used to *only* untrack a tracked
environment -- it will fail if it is used on a managed environment.  Users can also use
`spack env remove` to untrack an environment.

This allows users to continue to share environments in git repositories  while also having
the dependencies of those environments be remembered by Spack.