### PR TITLE
Allow snapshots of Spack environments

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -51,6 +51,7 @@ subcommands = [
     "update",
     "revert",
     "depfile",
+    "snapshot",
 ]
 
 
@@ -722,6 +723,17 @@ def env_depfile(args):
             f.write(makefile)
     else:
         sys.stdout.write(makefile)
+
+
+def env_snapshot_setup_parser(subparser):
+    """saves, loads or lists snapshots of the active environment"""
+
+
+def env_snapshot(args):
+    spack.cmd.require_active_env(cmd_name="env snapshot")
+    active_env = ev.active_environment()
+    prompter = ev.SnapshotPrompter(active_env, stream=sys.stdout)
+    prompter.prompt()
 
 
 #: Dictionary mapping subcommand names and aliases to functions

--- a/lib/spack/spack/environment/__init__.py
+++ b/lib/spack/spack/environment/__init__.py
@@ -369,6 +369,7 @@ from .environment import (
     spack_env_view_var,
     update_yaml,
 )
+from .snapshot import SnapshotLoader, SnapshotPrompter, SnapshotSaver, snapshot_from_dir
 
 __all__ = [
     "TOP_LEVEL_KEY",
@@ -399,6 +400,10 @@ __all__ = [
     "no_active_environment",
     "read",
     "root",
+    "SnapshotLoader",
+    "SnapshotPrompter",
+    "SnapshotSaver",
+    "snapshot_from_dir",
     "spack_env_var",
     "spack_env_view_var",
     "update_yaml",

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -84,7 +84,7 @@ lockfile_name = "spack.lock"
 
 
 #: Name of the directory where environments store repos, logs, views
-env_subdir_name = ".spack-env"
+ENV_SUBDIR_NAME = ".spack-env"
 
 
 def env_root_path():
@@ -987,15 +987,19 @@ class Environment:
     @property
     def env_subdir_path(self):
         """Path to directory where the env stores repos, logs, views."""
-        return os.path.join(self.path, env_subdir_name)
+        return os.path.join(self.path, ENV_SUBDIR_NAME)
 
     @property
     def repos_path(self):
-        return os.path.join(self.path, env_subdir_name, "repos")
+        return os.path.join(self.path, ENV_SUBDIR_NAME, "repos")
 
     @property
     def log_path(self):
-        return os.path.join(self.path, env_subdir_name, "logs")
+        return os.path.join(self.path, ENV_SUBDIR_NAME, "logs")
+
+    @property
+    def snapshots_path(self):
+        return os.path.join(self.path, ENV_SUBDIR_NAME, "snapshots")
 
     @property
     def config_stage_dir(self):

--- a/lib/spack/spack/environment/snapshot.py
+++ b/lib/spack/spack/environment/snapshot.py
@@ -1,0 +1,165 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Manage snapshots of environments"""
+import datetime
+import io
+import os.path
+import pathlib
+import shutil
+from typing import List, NamedTuple
+
+from llnl.util.tty import colify, color
+
+from .environment import Environment, SpackEnvironmentError, lockfile_name, manifest_name
+
+
+class Snapshot(NamedTuple):
+    time: datetime.datetime
+    spack_yaml: pathlib.Path
+    spack_lock: pathlib.Path
+
+
+class SnapshotSaver:
+    """Saves a snapshot of a Spack environment"""
+
+    def __init__(self, env: Environment) -> None:
+        self.environment = env
+
+    def save(self, snapshot_dir: pathlib.Path) -> Snapshot:
+        if not os.path.exists(self.environment.lock_path):
+            raise SpackEnvironmentError(
+                f"cannot take a snapshot of the environment in '{self.environment.path}', "
+                f"because it has no lock file."
+            )
+
+        snapshot_time = datetime.datetime.now(tz=datetime.timezone.utc)
+        root_dir = snapshot_dir / str(snapshot_time.timestamp())
+        # TODO: Ensure the root specs in the lockfile are in sync with the manifest
+        snapshot = Snapshot(
+            time=snapshot_time,
+            spack_yaml=root_dir / manifest_name,
+            spack_lock=root_dir / lockfile_name,
+        )
+        root_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            shutil.copy(self.environment.manifest_path, snapshot.spack_yaml)
+            shutil.copy(self.environment.lock_path, snapshot.spack_lock)
+        except OSError as e:
+            shutil.rmtree(root_dir)
+            msg = f"cannot take a snapshot of the environment: {e}"
+            raise SpackEnvironmentError(msg) from e
+
+        return snapshot
+
+
+class SnapshotLoader:
+    """Loads a snapshot of a Spack environment"""
+
+    def __init__(self, snapshot: Snapshot):
+        self.snapshot = snapshot
+
+    def load(self, environment_dir: pathlib.Path) -> Environment:
+        try:
+            shutil.copy(self.snapshot.spack_yaml, environment_dir / manifest_name)
+            shutil.copy(self.snapshot.spack_lock, environment_dir / lockfile_name)
+        except OSError as e:
+            msg = f"cannot restore the environment in {environment_dir}: {str(e)}"
+            raise RuntimeError(msg) from e
+
+        env = Environment(manifest_dir=environment_dir)
+        env.regenerate_views()
+        return env
+
+
+class SnapshotPrompter:
+    def __init__(self, env: Environment, stream: io.IOBase) -> None:
+        self.environment = env
+        self.snapshots: List[Snapshot] = []
+        self._update_snapshots()
+        self.stream = stream
+
+    def _update_snapshots(self):
+        self.snapshots = [
+            snapshot_from_dir(x)
+            for x in pathlib.Path(self.environment.snapshots_path).iterdir()
+            if x.is_dir()
+        ]
+        self.snapshots.sort(key=lambda x: x.time)
+
+    def prompt(self) -> None:
+        while True:
+            self.show_available_snapshots()
+            command = self.ask_user()
+            if command == "q":
+                break
+            elif command == "s":
+                snapshot = SnapshotSaver(self.environment).save(
+                    snapshot_dir=pathlib.Path(self.environment.snapshots_path)
+                )
+                self.stream.write(f"\nSnapshot taken at {snapshot.time}\n\n")
+                self._update_snapshots()
+
+            elif command == "d":
+                self.ask_what_to_delete()
+
+            elif command == "r":
+                self.ask_what_to_restore()
+
+            else:
+                self.stream.write(f"\nInvalid command: {command}\n\n")
+
+    def show_available_snapshots(self):
+        header = "Available snapshots:\n\n" if self.snapshots else "No snapshots available.\n\n"
+        self.stream.write(header)
+        for ii, snapshot in enumerate(self.snapshots):
+            self.stream.write(f"{ii}.    Date: {str(snapshot.time)}\n")
+        self.stream.write("\n")
+
+    def ask_user(self):
+        self.stream.write(color.colorize("Enter the @*{action} to take:\n"))
+        commands = ("@*b{[s]ave}", "@*b{[r]estore}", "@*b{[d]elete}", "@*b{[q]}uit")
+        colify.colify(list(map(color.colorize, commands)), indent=4)
+        try:
+            command = input(color.colorize("@*g{action>} ")).strip().lower()
+        except EOFError:
+            print()
+            command = "q"
+        return command
+
+    def ask_what_to_restore(self):
+        self.stream.write(color.colorize("Enter the @*{number} of the snapshot to restore:\n"))
+        try:
+            idx = input(color.colorize("@*g{number>} ")).strip().lower()
+            idx = int(idx)
+        except EOFError:
+            return
+
+        if idx >= len(self.snapshots):
+            return
+
+        SnapshotLoader(self.snapshots[idx]).load(pathlib.Path(self.environment.path))
+        self.stream.write(f"\nRestored environment from {self.snapshots[idx].time}\n\n")
+
+    def ask_what_to_delete(self):
+        self.stream.write(color.colorize("Enter the @*{number} of the snapshot to delete:\n"))
+        try:
+            idx = input(color.colorize("@*g{number>} ")).strip().lower()
+            idx = int(idx)
+        except EOFError:
+            return
+
+        if idx >= len(self.snapshots):
+            return
+
+        shutil.rmtree(self.snapshots[idx].spack_yaml.parent)
+        self._update_snapshots()
+
+
+def snapshot_from_dir(snapshot_dir: pathlib.Path) -> Snapshot:
+    """Returns a snapshot object, given the directory where the data is stored"""
+    time = datetime.datetime.fromtimestamp(float(snapshot_dir.name), tz=datetime.timezone.utc)
+    return Snapshot(
+        time=time, spack_yaml=snapshot_dir / manifest_name, spack_lock=snapshot_dir / lockfile_name
+    )

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1023,7 +1023,7 @@ _spack_env() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="activate deactivate create remove rm list ls status st loads view update revert depfile"
+        SPACK_COMPREPLY="activate deactivate create remove rm list ls status st loads view update revert depfile snapshot"
     fi
 }
 
@@ -1121,6 +1121,10 @@ _spack_env_depfile() {
     else
         _all_packages
     fi
+}
+
+_spack_env_snapshot() {
+    SPACK_COMPREPLY="-h --help"
 }
 
 _spack_extensions() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1463,6 +1463,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a view -d 'manag
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a update -d 'update environments to the latest format'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a revert -d 'restore environments to their state before update'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a depfile -d 'generate a depfile from the concrete environment specs'
+complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a snapshot -d 'saves, loads or lists snapshots of the active environment'
 complete -c spack -n '__fish_spack_using_command env' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command env' -s h -l help -d 'show this help message and exit'
 
@@ -1611,6 +1612,11 @@ complete -c spack -n '__fish_spack_using_command env depfile' -s o -l output -r 
 complete -c spack -n '__fish_spack_using_command env depfile' -s o -l output -r -d 'write the depfile to FILE rather than to stdout'
 complete -c spack -n '__fish_spack_using_command env depfile' -s G -l generator -r -f -a make
 complete -c spack -n '__fish_spack_using_command env depfile' -s G -l generator -r -d 'specify the depfile type'
+
+# spack env snapshot
+set -g __fish_spack_optspecs_spack_env_snapshot h/help
+complete -c spack -n '__fish_spack_using_command env snapshot' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command env snapshot' -s h -l help -d 'show this help message and exit'
 
 # spack extensions
 set -g __fish_spack_optspecs_spack_extensions h/help l/long L/very-long d/deps p/paths s/show=


### PR DESCRIPTION
This adds an interactive subcommand:
```console
$ spack env snapshot
```
that allows to save, delete or restore snapshots of environments.

Currently, a snapshot is simply defined as a `spack.yaml` / `spack.lock` pair, but can be extended later with more metadata.

Modifications:
- [x] Add an interactive sub-command to manage snapshots of environments
- [ ] Improve displaying the content of each snapshot (for easier selection by the user)
- [ ] Add unit-tests and docs

<details>
<summary>Sample screenshot </summary>

![Screenshot from 2023-12-29 21-28-57](https://github.com/spack/spack/assets/4199709/b79c0ac3-be4c-462b-9fe9-265706ba50c0)

</details>