### PR TITLE
Codespaces support for rapid PR evaluation 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,4 @@
 {
-  "image": "ghcr.io/spack/ubuntu-jammy:develop"
+  "image": "ghcr.io/spack/ubuntu-jammy:develop",
+  "postCreateCommand": "./.devcontainer/postCreateCommand.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "ghcr.io/spack/ubuntu-jammy:develop"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
 {
-  "image": "ghcr.io/spack/ubuntu-jammy:develop",
+  "image": "ghcr.io/spack/ubuntu20.04-runner-amd64-gcc-11.4:2023.08.01",
   "postCreateCommand": "./.devcontainer/postCreateCommand.sh"
 }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -11,6 +11,7 @@ EOF
 # Ensure generic targets for maximum matching with buildcaches
 spack config add --scope site "packages:all:require:[target=x86_64_v3]"
 spack config add --scope site "concretizer:targets:granularity:generic"
+spack compiler find --scope site
 
 # Setup buildcaches
 spack mirror add --scope site develop-root https://binaries.spack.io/develop/root

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Load spack environment at terminal startup
+cat <<EOF >> /root/.bashrc
+. /workspaces/spack/share/spack/setup-env.sh
+EOF
+
+# Load spack environment in this script
+. /workspaces/spack/share/spack/setup-env.sh
+
+# Ensure generic targets for maximum matching with buildcaches
+spack config add --scope site "packages:all:require:[target=x86_64_v3]"
+spack config add --scope site "concretizer:targets:granularity:generic"
+
+# Setup buildcaches
+spack mirror add --scope site develop-root https://binaries.spack.io/develop/root
+spack buildcache keys --install --trust

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -9,8 +9,8 @@ EOF
 . /workspaces/spack/share/spack/setup-env.sh
 
 # Ensure generic targets for maximum matching with buildcaches
-spack config add --scope site "packages:all:require:[target=x86_64_v3]"
-spack config add --scope site "concretizer:targets:granularity:generic"
+spack config --scope site add "packages:all:require:[target=x86_64_v3]"
+spack config --scope site add "concretizer:targets:granularity:generic"
 spack compiler find --scope site
 
 # Setup buildcaches

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -11,8 +11,10 @@ EOF
 # Ensure generic targets for maximum matching with buildcaches
 spack config --scope site add "packages:all:require:[target=x86_64_v3]"
 spack config --scope site add "concretizer:targets:granularity:generic"
+
+# Find compiler and install gcc-runtime
 spack compiler find --scope site
 
 # Setup buildcaches
-spack mirror add --scope site develop-root https://binaries.spack.io/develop/root
+spack mirror add --scope site develop https://binaries.spack.io/develop
 spack buildcache keys --install --trust


### PR DESCRIPTION
This PR adds some support for codespaces, mainly to facilitate evaluating and reviewing PRs in the browser.

This sets up the codespaces environment with the most common cloud_pipelines architecture as basis image, and sets it up such that buildcache hits are most likely to succeed. It also loads the spack environment for the branch in question.

Caveats:
- I don't know if x86_64_v3 is really the minimum we can expect on codespaces, but I've always ended up on zen2 nodes in my tests.

TODO:
- wish I could also add the gitlab CI buildcaches for the PR in question...