### PR TITLE
rust: add v1.75.0 & v1.74.0, merge related variants into `+dev`, add rust-analyzer

### DIFF
--- a/lib/spack/spack/build_systems/cargo.py
+++ b/lib/spack/spack/build_systems/cargo.py
@@ -25,7 +25,7 @@ class CargoPackage(spack.package_base.PackageBase):
     build_system("cargo")
 
     with when("build_system=cargo"):
-        depends_on("rust", type="build")
+        depends_on("rust+cargo", type="build")
 
 
 @spack.builder.builder("cargo")

--- a/lib/spack/spack/build_systems/cargo.py
+++ b/lib/spack/spack/build_systems/cargo.py
@@ -25,7 +25,7 @@ class CargoPackage(spack.package_base.PackageBase):
     build_system("cargo")
 
     with when("build_system=cargo"):
-        depends_on("rust+cargo", type="build")
+        depends_on("rust", type="build")
 
 
 @spack.builder.builder("cargo")

--- a/share/spack/gitlab/cloud_pipelines/stacks/developer-tools/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/developer-tools/spack.yaml
@@ -22,7 +22,7 @@ spack:
       - node-js # for editor plugins etc., pyright language server
       - npm
       - go # to build fzf, gh, hub
-      - rust+analysis # fd, ripgrep, hyperfine, exa, rust-analyzer
+      - rust+dev # fd, ripgrep, hyperfine, exa, rust-analyzer
       - binutils+ld+gold+plugins # support linking with built gcc
       # styling and lints
       - astyle

--- a/var/spack/repos/builtin/packages/py-tensorboard-data-server/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorboard-data-server/package.py
@@ -20,7 +20,7 @@ class PyTensorboardDataServer(PythonPackage):
     version("0.6.1", commit="6acf0be88b5727e546dd64a8b9b12d790601d561")
 
     depends_on("py-setuptools", type="build")
-    depends_on("rust+rustfmt", type="build")
+    depends_on("rust+dev", type="build")
 
     # https://github.com/tensorflow/tensorboard/issues/5713
     patch(

--- a/var/spack/repos/builtin/packages/rust-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/rust-bootstrap/package.py
@@ -30,7 +30,7 @@ class RustBootstrap(Package):
                 "x86_64": "473978b6f8ff216389f9e89315211c6b683cf95a966196e7914b46e8cf0d74f6",
                 "aarch64": "30828cd904fcfb47f1ac43627c7033c903889ea4aca538f53dcafbb3744a9a73",
                 "powerpc64le": "2599cdfea5860b4efbceb7bca69845a96ac1c96aa50cf8261151e82280b397a0",
-            }
+            },
         },
         "1.73.0": {
             "darwin": {

--- a/var/spack/repos/builtin/packages/rust-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/rust-bootstrap/package.py
@@ -21,6 +21,17 @@ class RustBootstrap(Package):
     # should update these binary releases as bootstrapping requirements are
     # modified by new releases of Rust.
     rust_releases = {
+        "1.75.0": {
+            "darwin": {
+                "x86_64": "ad066e4dec7ae5948c4e7afe68e250c336a5ab3d655570bb119b3eba9cf22851",
+                "aarch64": "878ecf81e059507dd2ab256f59629a4fb00171035d2a2f5638cb582d999373b1",
+            },
+            "linux": {
+                "x86_64": "473978b6f8ff216389f9e89315211c6b683cf95a966196e7914b46e8cf0d74f6",
+                "aarch64": "30828cd904fcfb47f1ac43627c7033c903889ea4aca538f53dcafbb3744a9a73",
+                "powerpc64le": "2599cdfea5860b4efbceb7bca69845a96ac1c96aa50cf8261151e82280b397a0",
+            }
+        },
         "1.73.0": {
             "darwin": {
                 "x86_64": "ece9646bb153d4bc0f7f1443989de0cbcd8989a7d0bf3b7fb9956e1223954f0c",

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -18,13 +18,13 @@ class Rust(Package):
 
     maintainers("alecbcs")
 
+    license("Apache-2.0 OR MIT")
+
     # When adding a version of Rust you may need to add an additional version
     # to rust-bootstrap as the minimum bootstrapping requirements increase.
     # As a general rule of thumb Rust can be built with either the previous major
     # version or the current version of the compiler as shown above.
-
-    license("Apache-2.0 OR MIT")
-
+    #
     # Pre-release versions.
     # Note: If you plan to use these versions remember to install with
     # `-n` to prevent Spack from failing due to failed checksums.
@@ -36,10 +36,16 @@ class Rust(Package):
     version("nightly")
 
     # Stable versions.
+    version("1.75.0", sha256="5b739f45bc9d341e2d1c570d65d2375591e22c2d23ef5b8a37711a0386abc088")
+    version("1.74.0", sha256="882b584bc321c5dcfe77cdaa69f277906b936255ef7808fcd5c7492925cf1049")
     version("1.73.0", sha256="96d62e6d1f2d21df7ac8acb3b9882411f9e7c7036173f7f2ede9e1f1f6b1bb3a")
     version("1.70.0", sha256="b2bfae000b7a5040e4ec4bbc50a09f21548190cb7570b0ed77358368413bd27c")
     version("1.65.0", sha256="5828bb67f677eabf8c384020582b0ce7af884e1c84389484f7f8d00dd82c0038")
     version("1.60.0", sha256="20ca826d1cf674daf8e22c4f8c4b9743af07973211c839b85839742314c838b7")
+
+    variant("dev", default=False, description="Include rust developer tools like rustfmt, clippy, and rust-analyzer.")
+    variant("docs", default=False, description="Build Rust core documentation.")
+    variant("src", default=True, description="Include standard library source files.")
 
     # Core dependencies
     depends_on("cmake@3.13.4:", type="build")
@@ -65,23 +71,8 @@ class Rust(Package):
     depends_on("rust-bootstrap@1.64:1.65", type="build", when="@1.65")
     depends_on("rust-bootstrap@1.69:1.70", type="build", when="@1.70")
     depends_on("rust-bootstrap@1.72:1.73", type="build", when="@1.73")
-
-    variant(
-        "analysis",
-        default=False,
-        description="Outputs code analysis that can be consumed by other tools",
-    )
-    variant("cargo", default=True, description="The Rust package manager.")
-    variant(
-        "clippy",
-        default=False,
-        description="A bunch of lints to catch common mistakes and improve your Rust code.",
-    )
-    variant("docs", default=False, description="Build Rust documentation.")
-    variant("rustdoc", default=True, description="Generate documentation for Rust projects.")
-    variant("rustfmt", default=False, description="Formatting tool for Rust code.")
-    variant("rust-analyzer", default=False, description="A Rust compiler front-end for IDEs")
-    variant("src", default=True, description="Include standard library source files.")
+    depends_on("rust-bootstrap@1.73:1.74", type="build", when="@1.74")
+    depends_on("rust-bootstrap@1.74:1.75", type="build", when="@1.75")
 
     extendable = True
     executables = ["^rustc$", "^cargo$"]
@@ -158,30 +149,15 @@ class Rust(Package):
         # Convert opts to '--set key=value' format.
         flags = [flag for opt in opts for flag in ("--set", opt)]
 
-        # Additional core rust tools to install.
-        tools = []
+        # Core rust tools to install.
+        tools = ["cargo"]
 
         # Add additional tools as directed by the package variants.
-        if spec.satisfies("+cargo"):
-            tools.append("cargo")
-
-        if spec.satisfies("+analysis"):
-            tools.append("analysis")
-
-        if spec.satisfies("+clippy"):
-            tools.append("clippy")
+        if spec.satisfies("+dev"):
+            tools.extend(["clippy", "rustdoc", "rustfmt", "rust-analyzer"])
 
         if spec.satisfies("+src"):
             tools.append("src")
-
-        if spec.satisfies("+rustdoc"):
-            tools.append("rustdoc")
-
-        if spec.satisfies("+rustfmt"):
-            tools.append("rustfmt")
-
-        if spec.satisfies("+rust-analyzer"):
-            tools.append("rust-analyzer")
 
         # Compile tools into flag for configure.
         flags.append(f"--tools={','.join(tools)}")

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -90,8 +90,7 @@ class Rust(Package):
         return match.group(1) if match else None
 
     def setup_dependent_package(self, module, dependent_spec):
-        if self.spec.satisfies("+cargo"):
-            module.cargo = Executable(os.path.join(self.spec.prefix.bin, "cargo"))
+        module.cargo = Executable(os.path.join(self.spec.prefix.bin, "cargo"))
 
     def setup_build_environment(self, env):
         # Manually inject the path of ar for build.

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -95,7 +95,8 @@ class Rust(Package):
         return match.group(1) if match else None
 
     def setup_dependent_package(self, module, dependent_spec):
-        module.cargo = Executable(os.path.join(self.spec.prefix.bin, "cargo"))
+        if self.spec.satisfies("+cargo"):
+            module.cargo = Executable(os.path.join(self.spec.prefix.bin, "cargo"))
 
     def setup_build_environment(self, env):
         # Manually inject the path of ar for build.

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -43,7 +43,11 @@ class Rust(Package):
     version("1.65.0", sha256="5828bb67f677eabf8c384020582b0ce7af884e1c84389484f7f8d00dd82c0038")
     version("1.60.0", sha256="20ca826d1cf674daf8e22c4f8c4b9743af07973211c839b85839742314c838b7")
 
-    variant("dev", default=False, description="Include rust developer tools like rustfmt, clippy, and rust-analyzer.")
+    variant(
+        "dev",
+        default=False,
+        description="Include rust developer tools like rustfmt, clippy, and rust-analyzer.",
+    )
     variant("docs", default=False, description="Build Rust core documentation.")
     variant("src", default=True, description="Include standard library source files.")
 

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -71,13 +71,16 @@ class Rust(Package):
         default=False,
         description="Outputs code analysis that can be consumed by other tools",
     )
+    variant("cargo", default=True, description="The Rust package manager.")
     variant(
         "clippy",
-        default=True,
+        default=False,
         description="A bunch of lints to catch common mistakes and improve your Rust code.",
     )
     variant("docs", default=False, description="Build Rust documentation.")
-    variant("rustfmt", default=True, description="Formatting tool for Rust code.")
+    variant("rustdoc", default=True, description="Generate documentation for Rust projects.")
+    variant("rustfmt", default=False, description="Formatting tool for Rust code.")
+    variant("rust-analyzer", default=False, description="A Rust compiler front-end for IDEs")
     variant("src", default=True, description="Include standard library source files.")
 
     extendable = True
@@ -154,11 +157,13 @@ class Rust(Package):
         # Convert opts to '--set key=value' format.
         flags = [flag for opt in opts for flag in ("--set", opt)]
 
-        # Include both cargo and rustdoc in minimal install to match
-        # standard download of rust.
-        tools = ["cargo", "rustdoc"]
+        # Additional core rust tools to install.
+        tools = []
 
         # Add additional tools as directed by the package variants.
+        if spec.satisfies("+cargo"):
+            tools.append("cargo")
+
         if spec.satisfies("+analysis"):
             tools.append("analysis")
 
@@ -168,8 +173,14 @@ class Rust(Package):
         if spec.satisfies("+src"):
             tools.append("src")
 
+        if spec.satisfies("+rustdoc"):
+            tools.append("rustdoc")
+
         if spec.satisfies("+rustfmt"):
             tools.append("rustfmt")
+
+        if spec.satisfies("+rust-analyzer"):
+            tools.append("rust-analyzer")
 
         # Compile tools into flag for configure.
         flags.append(f"--tools={','.join(tools)}")


### PR DESCRIPTION
- Add rust v1.75.0 and v1.74.0.
- Merge related variants into a `+dev` variant to enable developer tooling.
- Update developer-tools CI stack to reflect rust changes.
- Add `rust-analyzer` sub-package to `+dev` variant. (We'd previously had a `+analysis` variant but it turns out that that's a different tool and doesn't build the analyzer as I believe was previously thought.) 