### PR TITLE
py-torchvision: enable png/jpeg by default

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchvision/package.py
+++ b/var/spack/repos/builtin/packages/py-torchvision/package.py
@@ -47,8 +47,8 @@ class PyTorchvision(PythonPackage):
     version("0.5.0", sha256="eb9afc93df3d174d975ee0914057a9522f5272310b4d56c150b955c287a4d74d")
 
     desc = "Enable support for native encoding/decoding of {} formats in torchvision.io"
-    variant("png", default=False, description=desc.format("PNG"))
-    variant("jpeg", default=False, description=desc.format("JPEG"))
+    variant("png", default=True, description=desc.format("PNG"))
+    variant("jpeg", default=True, description=desc.format("JPEG"))
     variant("nvjpeg", default=False, description=desc.format("JPEG"))
     variant("ffmpeg", default=False, description=desc.format("FFMPEG"))
     variant("video_codec", default=False, description=desc.format("video_codec"))


### PR DESCRIPTION
Closes #41883

@yichiac