### PR TITLE
[%intel] deprecation message

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -354,7 +354,7 @@ def set_compiler_environment_variables(pkg, env):
             raise RuntimeError(message)
         else:
             tty.warn(message)
-        
+
     # Set SPACK compiler rpath flags so that our wrapper knows what to use
     env.set("SPACK_CC_RPATH_ARG", compiler.cc_rpath_arg)
     env.set("SPACK_CXX_RPATH_ARG", compiler.cxx_rpath_arg)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -348,6 +348,13 @@ def set_compiler_environment_variables(pkg, env):
     else:
         env.set("FC", os.path.join(link_dir, "fc"))
 
+    if hasattr(compiler, "deprecated") and not spack.config.get("config:deprecated"):
+        error, message = compiler.deprecated
+        if error:
+            raise RuntimeError(message)
+        else:
+            tty.warn(message)
+        
     # Set SPACK compiler rpath flags so that our wrapper knows what to use
     env.set("SPACK_CC_RPATH_ARG", compiler.cc_rpath_arg)
     env.set("SPACK_CXX_RPATH_ARG", compiler.cxx_rpath_arg)

--- a/lib/spack/spack/compilers/dpcpp.py
+++ b/lib/spack/spack/compilers/dpcpp.py
@@ -22,6 +22,11 @@ class Dpcpp(spack.compilers.oneapi.Oneapi):
     See also: https://www.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top/compiler-setup/using-the-command-line/invoking-the-compiler.html
     """
 
+    @property
+    def deprecated(self):
+        # change to True for error
+        return False, "The %dpcpp toolchain has been deprecated, use %oneapi with -fsycl."
+
     # Subclasses use possible names of C++ compiler
     cxx_names = ["dpcpp"]
 

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -6,8 +6,6 @@
 import os
 import sys
 
-import llnl.util.tty as tty
-
 from spack.compiler import Compiler, UnsupportedCompilerFlag
 from spack.version import Version
 

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -6,6 +6,8 @@
 import os
 import sys
 
+import llnl.util.tty as tty
+
 from spack.compiler import Compiler, UnsupportedCompilerFlag
 from spack.version import Version
 
@@ -49,6 +51,40 @@ class Intel(Compiler):
         return "-v"
 
     required_libs = ["libirc", "libifcore", "libifcoremt", "libirng"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Intel deprecated icc/icpc/ifort in 2022. The compilers emit
+        # a deprecation warning, but it will be in a log file and
+        # difficult to notice. This code adds a spack warning to make
+        # it more visible. Making it an error in January 2025 would
+        # give people one year to change to %oneapi.
+        #
+        # The warning is triggered by having an intel toolchain in
+        # your compilers.yaml, even if you do not use it.
+
+        # To make it work like package deprecation (error unless
+        # --deprecated is passed), then check the value of
+        # spack.config.get("config:deprecated", False)
+        #
+        # spack install
+        #
+        # accepts the --deprecated argument and sets the spack
+        # config. You will need to add support for the --deprecated
+        # option to some commands:
+        #
+        # spack compiler find
+        # spack spec
+        #
+        # I think the error behavior should only happen if you use the
+        # compiler, not just includes it in your compilers.yaml. That
+        # requires passing info to the wrapper.
+        message = (
+            "The %intel toolchain has been deprecated."
+            "Remove %intel from your compilers.yaml and use %oneapi instead."
+        )
+        tty.warn(message)
 
     @property
     def debug_flags(self):

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -52,39 +52,10 @@ class Intel(Compiler):
 
     required_libs = ["libirc", "libifcore", "libifcoremt", "libirng"]
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Intel deprecated icc/icpc/ifort in 2022. The compilers emit
-        # a deprecation warning, but it will be in a log file and
-        # difficult to notice. This code adds a spack warning to make
-        # it more visible. Making it an error in January 2025 would
-        # give people one year to change to %oneapi.
-        #
-        # The warning is triggered by having an intel toolchain in
-        # your compilers.yaml, even if you do not use it.
-
-        # To make it work like package deprecation (error unless
-        # --deprecated is passed), then check the value of
-        # spack.config.get("config:deprecated", False)
-        #
-        # spack install
-        #
-        # accepts the --deprecated argument and sets the spack
-        # config. You will need to add support for the --deprecated
-        # option to some commands:
-        #
-        # spack compiler find
-        # spack spec
-        #
-        # I think the error behavior should only happen if you use the
-        # compiler, not just includes it in your compilers.yaml. That
-        # requires passing info to the wrapper.
-        message = (
-            "The %intel toolchain has been deprecated."
-            "Remove %intel from your compilers.yaml and use %oneapi instead."
-        )
-        tty.warn(message)
+    @property
+    def deprecated(self):
+        # change to True for error
+        return False, "The %intel toolchain has been deprecated, use %oneapi instead."
 
     @property
     def debug_flags(self):


### PR DESCRIPTION
Add a method to deprecate a toolchain and use it to deprecate %intel and %dpcpp. You can choose between a warning and an error. Using the `--deprecated` option disables the warning/error. The check is at the point the build environment is set up so it is emitted once for  each package that is built with a deprecated toolchain.

Edit: The comment below describes an earlier implementation that was abandoned.
See the description below in the comments. After seeing how it works, I am no longer sure spack should do anything. It might be annoying to see the warning if you are not using the `%intel` compiler. Having the compiler wrapper emit a warning is unnecessary because the compiler already emits a warning.

```
rscohn1@gkdse-fcp-19:spack$ spack install patchelf
==> Warning: The %intel toolchain has been deprecated. Remove %intel from your compilers.yaml and use %oneapi instead.
^[]0;Spack: Processing gmake [1/2]^G[+] /usr (external gmake-4.3-5r2svr4ltlqsp3ue4utnbipfmeigph6s)
^[]0;Spack: Processing patchelf [2/2]^G^[]0;Spack: Acquiring lock for patchelf [2/2]^G==> Waiting for patchelf-0.17.2-p6q7rn4hwm62ua\dx5tobh4ot7kqkinfy
```