### PR TITLE
Paraview: update FindFreetype patch

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -305,7 +305,8 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     patch("vtk-xdmf2-hdf51.13.2.patch", when="@5.10:5.11.0")
 
     # Fix VTK to work with external freetype using CONFIG mode for find_package
-    patch("FindFreetype.cmake.patch", when="@5.10.1:")
+    # patch("FindFreetype.cmake.patch", when="@5.10.1:")
+    patch("vtk_find_freetype_alias_import.patch", when="@5.10.1:")
 
     # Fix VTK to remove deprecated ADIOS2 functions
     # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10113

--- a/var/spack/repos/builtin/packages/paraview/vtk_find_freetype_alias_import.patch
+++ b/var/spack/repos/builtin/packages/paraview/vtk_find_freetype_alias_import.patch
@@ -1,0 +1,23 @@
+Submodule VTK contains modified content
+diff --git a/VTK/CMake/FindFreetype.cmake b/VTK/CMake/FindFreetype.cmake
+index b4532735c2..0e4259778a 100644
+--- a/VTK/CMake/FindFreetype.cmake
++++ b/VTK/CMake/FindFreetype.cmake
+@@ -63,6 +63,17 @@ directory of a Freetype installation.
+ # I'm going to attempt to cut out the middleman and hope
+ # everything still works.
+ 
++find_package(freetype CONFIG) # foward `QUIET`, version, and components here, but not `REQUIRED`
++if (freetype_FOUND)
++  if (NOT TARGET Freetype::Freetype)
++    add_library(Freetype::Freetype ALIAS freetype)
++  endif ()
++  set(FREETYPE_INCLUDE_DIRS "${freetype_interface_include_directories}")
++  set(FREETYPE_LIBRARIES "${freetype_interface_link_libraries}")
++  set(Freetype_FOUND 1) # might need to also forward the version found
++  return ()
++endif ()
++
+ set(FREETYPE_FIND_ARGS
+   HINTS
+     ENV FREETYPE_DIR


### PR DESCRIPTION
Paraview's FindFreetype patch did not correctly handle the definition of an imported shared release target. 

Approach changed to aliasing the target generated by Freetype's CMake to use expected namespace rather than redefining target by hand.

Fixes build error on Windows where CMake config and generate pass, but the build fails with `Freetype::Freetype-Notfound` as a target with no build rule, due to the implib location of the target interface not being specified.