### PR TITLE
extensions: remove unused `extendee_args()` method

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -568,7 +568,7 @@ def depends_on(spec, when=None, type=dt.DEFAULT_TYPES, patches=None):
 
 
 @directive(("extendees", "dependencies"))
-def extends(spec, type=("build", "run"), **kwargs):
+def extends(spec, when=None, type=("build", "run"), patches=None):
     """Same as depends_on, but also adds this package to the extendee list.
 
     keyword arguments can be passed to extends() so that extension
@@ -578,14 +578,15 @@ def extends(spec, type=("build", "run"), **kwargs):
     """
 
     def _execute_extends(pkg):
-        when = kwargs.get("when")
         when_spec = make_when_spec(when)
         if not when_spec:
             return
 
-        _depends_on(pkg, spec, when=when, type=type)
+        _depends_on(pkg, spec, when=when, type=type, patches=patches)
         spec_obj = spack.spec.Spec(spec)
-        pkg.extendees[spec_obj.name] = (spec_obj, kwargs)
+
+        # TODO: the values of the extendees dictionary are not used. Remove in next refactor.
+        pkg.extendees[spec_obj.name] = (spec_obj, None)
 
     return _execute_extends
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1260,20 +1260,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         else:
             # If it's not concrete, then return the spec from the
             # extends() directive since that is all we know so far.
-            spec_str, kwargs = next(iter(self.extendees.items()))
+            spec_str = next(iter(self.extendees))
             return spack.spec.Spec(spec_str)
-
-    @property
-    def extendee_args(self):
-        """
-        Spec of the extendee of this package, or None if it is not an extension
-        """
-        if not self.extendees:
-            return None
-
-        # TODO: allow multiple extendees.
-        name = next(iter(self.extendees))
-        return self.extendees[name][1]
 
     @property
     def is_extension(self):

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -268,12 +268,6 @@ def test_package_fetcher_fails():
         pkg.fetcher
 
 
-def test_package_no_extendees():
-    s = spack.spec.Spec("a")
-    pkg = BaseTestPackage(s)
-    assert pkg.extendee_args is None
-
-
 def test_package_test_no_compilers(mock_packages, monkeypatch, capfd):
     def compilers(compiler, arch_spec):
         return None


### PR DESCRIPTION
This method is vestigial; the only arg we ever used was `ignore=`, and that was eliminated in #29317 and #35588.

The values of the `extendees` dictionary are completely unused now -- added a note for the next refactor.