### PR TITLE
bugfix: make `test_requires_directive` work on more platforms

### DIFF
--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -856,6 +856,8 @@ def test_skip_requirement_when_default_requirement_condition_cannot_be_met(
 
 def test_requires_directive(concretize_scope, mock_packages):
     compilers_yaml = pathlib.Path(concretize_scope) / "compilers.yaml"
+
+    # NOTE: target is omitted here so that the test works on aarch64, as well.
     compilers_yaml.write_text(
         """
 compilers::
@@ -867,7 +869,6 @@ compilers::
       f77: null
       fc: null
     operating_system: debian6
-    target: x86_64
     modules: []
 """
     )


### PR DESCRIPTION
Literal compiler config in `test_requires_directive` specifically lists `target: x86_64`, but it doesn't need to, and the unnecessary target makes the test fail on non-`x86_64` machines.

- [x] Remove target from config yaml in `test_requires_directive`