### PR TITLE
`spack list`: add `--namesapce` / `--repo` option

### DIFF
--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -41,6 +41,16 @@ def setup_parser(subparser):
         help="optional case-insensitive glob patterns to filter results",
     )
     subparser.add_argument(
+        "-r",
+        "--repo",
+        "-N",
+        "--namespace",
+        dest="repos",
+        action="append",
+        default=[],
+        help="only list packages from the specified repo/namespace",
+    )
+    subparser.add_argument(
         "-d",
         "--search-description",
         action="store_true",
@@ -307,7 +317,11 @@ def list(parser, args):
     formatter = formatters[args.format]
 
     # Retrieve the names of all the packages
-    pkgs = set(spack.repo.all_package_names(args.virtuals))
+    repos = [spack.repo.PATH]
+    if args.repos:
+        repos = [spack.repo.PATH.get_repo(name) for name in args.repos]
+    pkgs = set().union(*[set(repo.all_package_names(args.virtuals)) for repo in repos])
+
     # Filter the set appropriately
     sorted_packages = filter_by_name(pkgs, args)
 

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os.path
 import sys
 from textwrap import dedent
 
@@ -134,3 +135,21 @@ def test_list_count(mock_packages):
     assert int(output.strip()) == len(
         [name for name in spack.repo.all_package_names() if "py-" in name]
     )
+
+
+# def test_list_repos(mock_packages, builder_test_repository):
+def test_list_repos():
+    with spack.repo.use_repositories(
+        os.path.join(spack.paths.repos_path, "builtin.mock"),
+        os.path.join(spack.paths.repos_path, "builder.test"),
+    ):
+        total_pkgs = len(list().strip().split())
+
+        mock_pkgs = len(list("-r", "builtin.mock").strip().split())
+        builder_pkgs = len(list("-r", "builder.test").strip().split())
+
+        assert builder_pkgs == 8
+        assert total_pkgs > mock_pkgs > builder_pkgs
+
+        both_repos = len(list("-r", "builtin.mock", "-r", "builder.test").strip().split())
+        assert both_repos == total_pkgs

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1320,7 +1320,7 @@ _spack_license_update_copyright_year() {
 _spack_list() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -d --search-description --format -v --virtuals -t --tag --count --update"
+        SPACK_COMPREPLY="-h --help -r --repo -N --namespace -d --search-description --format -v --virtuals -t --tag --count --update"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2017,10 +2017,12 @@ complete -c spack -n '__fish_spack_using_command license update-copyright-year' 
 complete -c spack -n '__fish_spack_using_command license update-copyright-year' -s h -l help -d 'show this help message and exit'
 
 # spack list
-set -g __fish_spack_optspecs_spack_list h/help d/search-description format= v/virtuals t/tag= count update=
+set -g __fish_spack_optspecs_spack_list h/help r/repo= d/search-description format= v/virtuals t/tag= count update=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 list' -f -a '(__fish_spack_packages)'
 complete -c spack -n '__fish_spack_using_command list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command list' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command list' -s r -l repo -s N -l namespace -r -f -a repos
+complete -c spack -n '__fish_spack_using_command list' -s r -l repo -s N -l namespace -r -d 'only list packages from the specified repo/namespace'
 complete -c spack -n '__fish_spack_using_command list' -s d -l search-description -f -a search_description
 complete -c spack -n '__fish_spack_using_command list' -s d -l search-description -d 'filtering will also search the description for a match'
 complete -c spack -n '__fish_spack_using_command list' -l format -r -f -a 'name_only version_json html'


### PR DESCRIPTION
This adds options to `spack list` that allow you to list only packages from specific repositories/namespaces, e.g.:

```console
spack list -r builtin
```

only lists packages from the `builtin` repo, while:

```console
spack list -r myrepo -r myrepo2
```

would list packages from `myrepo` and `myrepo2`, but not from `builtin`. Note that you can use the same argument multiple times.

You can use either `-r` / `--repo` or `-N` / `--namespace`. `-N` is there to match the corresponding option on `spack find`.

- [x] add `-r` / `--repo` / `-N` / `--namespace` argument
- [x] add test