### PR TITLE
intel-oneapi-mkl: Add correct PKG_CONFIG_PATH entry for older versions.

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -158,7 +158,10 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         # Only if environment modifications are desired (default is +envmods)
         if self.spec.satisfies("+envmods"):
             env.set("MKLROOT", self.component_prefix)
+            # 2023.1.0 has the pkgconfig files in lib/pkgconfig, 2021.3.0 has them in
+            # tools/pkgconfig, just including both in PKG_CONFIG_PATH
             env.append_path("PKG_CONFIG_PATH", self.component_prefix.lib.pkgconfig)
+            env.append_path("PKG_CONFIG_PATH", self.component_prefix.tools.pkgconfig)
 
     def _find_mkl_libs(self, shared):
         libs = []


### PR DESCRIPTION
At least 2021.3.0 puts the .pc files in tools/pkgconfig, not lib/pkgconfig.