### PR TITLE
Add documentation on checked_by license parameter

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -6978,7 +6978,7 @@ Many of the licenses that are currently in the spack repositories have been
 automatically determined. While this is great for bulk adding license
 information and is most likely correct, there are sometimes edge cases that
 require manual intervention. To determine which licenses are validated and
-which are not, there is the `checked_by` paramter in the license directive:
+which are not, there is the `checked_by` parameter in the license directive:
 
 .. code-block:: python
 

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -6973,3 +6973,18 @@ you probably care most about are:
 You may also care about `license exceptions
 <https://spdx.org/licenses/exceptions-index.html>`_ that use the ``WITH`` operator,
 e.g. ``Apache-2.0 WITH LLVM-exception``.
+
+Many of the licenses that are currently in the spack repositories have been
+automatically determined. While this is great for bulk adding license
+information and is most likely correct, there are sometimes edge cases that
+require manual intervention. To determine which licenses are validated and
+which are not, there is the `checked_by` paramter in the license directive:
+
+.. code-block:: python
+
+   license("<license>", when="<when>", checked_by="<github username>")
+
+When you have validated a github license, either when doing so explicitly or
+as part of packaging a new package, please set the `checked_by` parameter
+to your Github username to signal that the license has been manually
+verified.

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -64,8 +64,9 @@ class {class_name}({base_class_name}):
     # maintainers("github_user1", "github_user2")
 
     # FIXME: Add the SPDX identifier of the project's license below.
-    # See https://spdx.org/licenses/ for a list.
-    license("UNKNOWN")
+    # See https://spdx.org/licenses/ for a list. Upon manually verifying
+    # the license, set checked_by to your Github username.
+    license("UNKNOWN", checked_by="github_user1")
 
 {versions}
 

--- a/lib/spack/spack/test/cmd/create.py
+++ b/lib/spack/spack/test/cmd/create.py
@@ -27,7 +27,11 @@ create = SpackCommand("create")
             [r"TestNamedPackage(Package)", r"def install(self"],
         ),
         (["file://example.tar.gz"], "example", [r"Example(Package)", r"def install(self"]),
-        (["-n", "test-license"], "test-license", [r'license("UNKNOWN", checked_by="github_user1")']),
+        (
+            ["-n", "test-license"],
+            "test-license",
+            [r'license("UNKNOWN", checked_by="github_user1")'],
+        ),
         # Template-specific cases
         (
             ["-t", "autoreconf", "/test-autoreconf"],

--- a/lib/spack/spack/test/cmd/create.py
+++ b/lib/spack/spack/test/cmd/create.py
@@ -27,7 +27,7 @@ create = SpackCommand("create")
             [r"TestNamedPackage(Package)", r"def install(self"],
         ),
         (["file://example.tar.gz"], "example", [r"Example(Package)", r"def install(self"]),
-        (["-n", "test-license"], "test-license", [r'license("UNKNOWN")']),
+        (["-n", "test-license"], "test-license", [r'license("UNKNOWN", checked_by="github_user1")']),
         # Template-specific cases
         (
             ["-t", "autoreconf", "/test-autoreconf"],


### PR DESCRIPTION
This patch adds documentation on the checked_by license direcitve parameter that was added in #40755 but was not documented at that time.