### PR TITLE
Gitlab pipelines: check load avg also before running script

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -137,6 +137,7 @@ default:
     - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
     - nproc || true
     - cat /proc/loadavg || true
+    - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true
     - . "./share/spack/setup-env.sh"
     - spack --version
     - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
@@ -168,6 +169,7 @@ default:
       --output-file "${CI_PROJECT_DIR}/jobs_scratch_dir/cloud-ci-pipeline.yml"
   after_script:
     - cat /proc/loadavg || true
+    - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true
   artifacts:
     paths:
       - "${CI_PROJECT_DIR}/jobs_scratch_dir"
@@ -208,6 +210,7 @@ default:
     - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
     - nproc || true
     - cat /proc/loadavg || true
+    - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true
     - . "./share/spack/setup-env.sh"
     - spack --version
     - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
@@ -219,6 +222,7 @@ default:
       --output-file "${CI_PROJECT_DIR}/jobs_scratch_dir/cloud-ci-pipeline.yml"
   after_script:
     - cat /proc/loadavg || true
+    - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true
   artifacts:
     paths:
       - "${CI_PROJECT_DIR}/jobs_scratch_dir"

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -136,6 +136,7 @@ default:
     - uname -a || true
     - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
     - nproc || true
+    - cat /proc/loadavg || true
     - . "./share/spack/setup-env.sh"
     - spack --version
     - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
@@ -206,6 +207,7 @@ default:
     - uname -a || true
     - grep -E 'vendor|model name' /proc/cpuinfo 2>/dev/null | sort -u || head -n10 /proc/cpuinfo 2>/dev/null || true
     - nproc || true
+    - cat /proc/loadavg || true
     - . "./share/spack/setup-env.sh"
     - spack --version
     - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}

--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -11,6 +11,7 @@ ci:
   pipeline-gen:
   - build-job:
       before_script-:
+      - - - cat /proc/loadavg || true
       - - spack list --count  # ensure that spack's cache is populated
       - - spack env activate --without-view ${SPACK_CONCRETE_ENV_DIR}
         - spack compiler list

--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -11,7 +11,8 @@ ci:
   pipeline-gen:
   - build-job:
       before_script-:
-      - - - cat /proc/loadavg || true
+      - - cat /proc/loadavg || true
+        - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true
       - - spack list --count  # ensure that spack's cache is populated
       - - spack env activate --without-view ${SPACK_CONCRETE_ENV_DIR}
         - spack compiler list
@@ -31,6 +32,7 @@ ci:
           ${SPACK_ARTIFACTS_ROOT}/user_data/install_times.json
       after_script:
       - - cat /proc/loadavg || true
+        - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true
       variables:
         CI_JOB_SIZE: "default"
         CI_GPG_KEY_ROOT: /mnt/key

--- a/share/spack/gitlab/cloud_pipelines/stacks/deprecated/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/deprecated/spack.yaml
@@ -35,6 +35,7 @@ spack:
     - . "./share/spack/setup-env.sh"
     - spack --version
     - spack arch
+    - cat /proc/loadavg || true
     script:
     - spack compiler find
     - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/deprecated/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/deprecated/spack.yaml
@@ -36,6 +36,7 @@ spack:
     - spack --version
     - spack arch
     - cat /proc/loadavg || true
+    - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true
     script:
     - spack compiler find
     - cd ${SPACK_CONCRETE_ENV_DIR}
@@ -55,6 +56,7 @@ spack:
       2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
     after_script:
     - cat /proc/loadavg || true
+    - cat /proc/meminfo | grep 'MemTotal\|MemFree' || true
     match_behavior: first
     mappings:
     - match:


### PR DESCRIPTION
Modifications:
- [x] Check `/proc/loadavg` also before running the script in pipelines
- [x] Check total memory and free memory too using `/proc/meminfo`