### PR TITLE
abinit: fix missing comma separating arguments

### DIFF
--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -164,7 +164,7 @@ class Abinit(AutotoolsPackage):
                 options.extend(
                     [
                         f"WANNIER90_CPPFLAGS=-I{spec['wannier90'].prefix.modules}",
-                        f"WANNIER90_LIBS=-L{spec['wannier90'].prefix.lib}"
+                        f"WANNIER90_LIBS=-L{spec['wannier90'].prefix.lib}",
                         "WANNIER90_LDFLAGS=-lwannier",
                     ]
                 )


### PR DESCRIPTION
Fix a missing comma which prevented Abinit building properly.