### PR TITLE
ncurses: fix 5.9 and 6.0 on modern compilers

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/0001-Fix-errors-in-type-conversion.patch
+++ b/var/spack/repos/builtin/packages/ncurses/0001-Fix-errors-in-type-conversion.patch
@@ -1,0 +1,153 @@
+From 6e12cb73e23e8e9488c6db1c4710bb4b3d2b48c3 Mon Sep 17 00:00:00 2001
+From: Adam Jiang <jiang.adam@gmail.com>
+Date: Fri, 1 Aug 2014 19:58:40 +0900
+Subject: [PATCH 1/2] Fix errors in type conversion
+
+Basically, converting to 'void*' is not a good idea. However, if that
+conversion is unavoidable, it should be done in a proper way. 'const_cast'
+itself could not convert type 'T*' to 'void *', this patch adds
+'reintepret_cast' to do it correctly.
+
+At the same time, function that returns on 'const' member like 'void*' should
+not be declared as 'const'.
+---
+ c++/cursesf.h | 12 +++++++-----
+ c++/cursesm.h | 10 +++++-----
+ c++/cursesp.h |  9 +++++----
+ 3 files changed, 17 insertions(+), 14 deletions(-)
+
+diff --git a/c++/cursesf.h b/c++/cursesf.h
+index 70a30c3..23b3022 100644
+--- a/c++/cursesf.h
++++ b/c++/cursesf.h
+@@ -673,7 +673,8 @@ protected:
+ 		   const T* p_UserData = STATIC_CAST(T*)(0))
+     : NCursesForm(nlines,ncols,begin_y,begin_x) {
+       if (form)
+-	set_user (const_cast<void *>(p_UserData));
++	set_user (const_cast<void *>(reinterpret_cast<const void*>
++				     (p_UserData)));
+   }
+ 
+ public:
+@@ -683,7 +684,7 @@ public:
+ 		   bool autoDelete_Fields=FALSE)
+     : NCursesForm (Fields, with_frame, autoDelete_Fields) {
+       if (form)
+-	set_user (const_cast<void *>(p_UserData));
++	set_user (const_cast<void *>(reinterpret_cast<const void*>(p_UserData)));
+   };
+ 
+   NCursesUserForm (NCursesFormField Fields[],
+@@ -697,19 +698,20 @@ public:
+     : NCursesForm (Fields, nlines, ncols, begin_y, begin_x,
+ 		   with_frame, autoDelete_Fields) {
+       if (form)
+-	set_user (const_cast<void *>(p_UserData));
++	set_user (const_cast<void *>(reinterpret_cast<const void*>
++				     (p_UserData)));
+   };
+ 
+   virtual ~NCursesUserForm() {
+   };
+ 
+-  inline T* UserData (void) const {
++  inline T* UserData (void) {
+     return reinterpret_cast<T*>(get_user ());
+   };
+ 
+   inline virtual void setUserData (const T* p_UserData) {
+     if (form)
+-      set_user (const_cast<void *>(p_UserData));
++      set_user (const_cast<void *>(reinterpret_cast<const void*>(p_UserData)));
+   }
+ 
+ };
+diff --git a/c++/cursesm.h b/c++/cursesm.h
+index d9c2273..545ed49 100644
+--- a/c++/cursesm.h
++++ b/c++/cursesm.h
+@@ -631,7 +631,7 @@ protected:
+ 		   const T* p_UserData = STATIC_CAST(T*)(0))
+     : NCursesMenu(nlines,ncols,begin_y,begin_x) {
+       if (menu)
+-	set_user (const_cast<void *>(p_UserData));
++	set_user (const_cast<void *>(reinterpret_cast<const void*>(p_UserData)));
+   }
+ 
+ public:
+@@ -641,7 +641,7 @@ public:
+ 		   bool autoDelete_Items=FALSE)
+     : NCursesMenu (Items, with_frame, autoDelete_Items) {
+       if (menu)
+-	set_user (const_cast<void *>(p_UserData));
++	set_user (const_cast<void *>(reinterpret_cast<const void*>(p_UserData)));
+   };
+ 
+   NCursesUserMenu (NCursesMenuItem Items[],
+@@ -653,19 +653,19 @@ public:
+ 		   bool with_frame=FALSE)
+     : NCursesMenu (Items, nlines, ncols, begin_y, begin_x, with_frame) {
+       if (menu)
+-	set_user (const_cast<void *>(p_UserData));
++	set_user (const_cast<void *>(reinterpret_cast<const void*>(p_UserData)));
+   };
+ 
+   virtual ~NCursesUserMenu() {
+   };
+ 
+-  inline T* UserData (void) const {
++  inline T* UserData (void) {
+     return reinterpret_cast<T*>(get_user ());
+   };
+ 
+   inline virtual void setUserData (const T* p_UserData) {
+     if (menu)
+-      set_user (const_cast<void *>(p_UserData));
++      set_user (const_cast<void *>(reinterpret_cast<const void*>(p_UserData)));
+   }
+ };
+ 
+diff --git a/c++/cursesp.h b/c++/cursesp.h
+index 9b63d6d..661e4a9 100644
+--- a/c++/cursesp.h
++++ b/c++/cursesp.h
+@@ -236,7 +236,8 @@ public:
+     : NCursesPanel (nlines, ncols, begin_y, begin_x)
+   {
+       if (p)
+-	set_user (const_cast<void *>(p_UserData));
++	set_user (const_cast<void *>(reinterpret_cast<const void*>
++				     (p_UserData)));
+   };
+   // This creates an user panel of the requested size with associated
+   // user data pointed to by p_UserData.
+@@ -244,14 +245,14 @@ public:
+   NCursesUserPanel(const T* p_UserData = STATIC_CAST(T*)(0)) : NCursesPanel()
+   {
+     if (p)
+-      set_user(const_cast<void *>(p_UserData));
++      set_user(const_cast<void *>(reinterpret_cast<const void*>(p_UserData)));
+   };
+   // This creates an user panel associated with the ::stdscr and user data
+   // pointed to by p_UserData.
+ 
+   virtual ~NCursesUserPanel() {};
+ 
+-  T* UserData (void) const
++  T* UserData (void)
+   {
+     return reinterpret_cast<T*>(get_user ());
+   };
+@@ -260,7 +261,7 @@ public:
+   virtual void setUserData (const T* p_UserData)
+   {
+     if (p)
+-      set_user (const_cast<void *>(p_UserData));
++      set_user (const_cast<void *>(reinterpret_cast<const void*>(p_UserData)));
+   }
+   // Associate the user panel with the user data pointed to by p_UserData.
+ };
+-- 
+1.8.5.2 (Apple Git-48)
+

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -51,7 +51,7 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on("pkgconfig", type="build")
 
-    patch("patch_gcc_5.txt", when="@6.0%gcc@5.0:")
+    patch("0001-Fix-errors-in-type-conversion.patch", when="@:5")
     patch("sed_pgi.patch", when="@:6.0")
     patch("nvhpc_fix_preprocessor_flag.patch", when="@6.0:6.2%nvhpc")
 
@@ -103,6 +103,16 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
             flags.append(self.compiler.cc_pic_flag)
         elif name == "cxxflags":
             flags.append(self.compiler.cxx_pic_flag)
+
+        # ncurses@:6.0 fails in definition of macro 'mouse_trafo' without -P
+        if self.spec.satisfies("@:6.0 %gcc@5.0:"):
+            if name == "cppflags":
+                flags.append("-P")
+
+        # ncurses@:6.0 uses dynamic exception specifications not allowed in c++17
+        if self.spec.satisfies("@:5"):
+            if name == "cxxflags":
+                flags.append(self.compiler.cxx14_flag)
 
         return (flags, None, None)
 

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -51,6 +51,8 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on("pkgconfig", type="build")
 
+    # avoid disallowed const_cast from T* to void* and use reinterpret_cast
+    # Ref: https://lists.gnu.org/archive/html/bug-ncurses/2014-08/msg00008.html
     patch("0001-Fix-errors-in-type-conversion.patch", when="@:5")
     patch("sed_pgi.patch", when="@:6.0")
     patch("nvhpc_fix_preprocessor_flag.patch", when="@6.0:6.2%nvhpc")


### PR DESCRIPTION
This fixes #41981, and now allows installation of ncurses 5.9 and 6.0 with gcc-13.

## cppflags -P for 5.9 too
Version 6.0 had already a patch to the Makefile to add `-P` to the cppflags to avoid a first error. This patch did not apply cleanly to 5.9, so instead of adding a patch this PR turns this into a flag_handler modification for both 5.9 and 6.0, with the same gcc@5: constraint as was already present for 6.0.

## c++14 for 5.9 and 6.0
Both versions 5.9 and 6.0 use [dynamic exception specifications](https://en.cppreference.com/w/cpp/language/except_spec) not allowed in c++17 (and deprecated since c++11). This PR modifies the flag_handler to pins the c++ standard to c++14 for both 5.9 and 6.0.

## const type conversion patch for 5.9
In addition to the above, and only for 5.9, a patch is needed that fixes some const-correctness issues in 5.9. No online repository with direct link is available, but the patch content and filename was kept the same as the [upstream mailing list report](https://lists.gnu.org/archive/html/bug-ncurses/2014-08/msg00008.html).