### PR TITLE
vecgeom: fix checksum for 1.2.6, add 1.2.7

### DIFF
--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -21,7 +21,8 @@ class Vecgeom(CMakePackage, CudaPackage):
     maintainers("drbenmorgan", "sethrj")
 
     version("master", branch="master")
-    version("1.2.6", sha256="e5162cf8adb67859dc4a111a81d1390d995895293e6ef1acf5f9d9834fd6d40e")
+    version("1.2.7", sha256="d264c69b78bf431b9542be1f1af087517eac629da03cf2da62eb1e433fe06021")
+    version("1.2.6", sha256="337f8846491930f3d8bfa4b45a1589d46e5d1d87f2d38c8f7006645c3aa90df8")
     version("1.2.5", sha256="d79ea05125e4d03c5605e5ea232994c500841d207b4543ac3d84758adddc15a9")
     version(
         "1.2.4",


### PR DESCRIPTION
Similar to #41530 , not sure what went wrong for 1.2.6. 
I am getting otherwise:

```
18:40:24  ==> Installing vecgeom-1.2.6-biugz6useiw3eg4ftkm2netzj356t4dr [237/495]
18:40:24  ==> No binary for vecgeom-1.2.6-biugz6useiw3eg4ftkm2netzj356t4dr found: installing from source
18:40:27  ==> Fetching https://gitlab.cern.ch/VecGeom/VecGeom/-/archive/v1.2.6/VecGeom-v1.2.6.tar.gz
18:40:28  ==> Error: ChecksumError: sha256 checksum failed for /tmp/sftnight/spack-stage/spack-stage-vecgeom-1.2.6-biugz6useiw3eg4ftkm2netzj356t4dr/VecGeom-v1.2.6.tar.gz
18:40:28      Expected e5162cf8adb67859dc4a111a81d1390d995895293e6ef1acf5f9d9834fd6d40e but got 337f8846491930f3d8bfa4b45a1589d46e5d1d87f2d38c8f7006645c3aa90df8. File size = 2503259 bytes. Contents = b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\xec;\xebz\xdb\xb6...\xc8?\xf2\x8f\xfc#\xff\x17}\xf8\xc7\xed\x00Ha\x01'
```

using `spack checksum` and tweaking the URLs, or
```
wget https://gitlab.cern.ch/VecGeom/VecGeom/-/archive/v1.2.7/VecGeom-v1.2.7.tar.gz
wget https://gitlab.cern.ch/VecGeom/VecGeom/-/archive/v1.2.6/VecGeom-v1.2.6.tar.gz
sha256sum *.tar.gz
```

