### PR TITLE
Trim external dependencies on gcc-runtime

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2927,6 +2927,7 @@ class RuntimePropertyRecorder:
         body_clauses = self._setup.spec_clauses(when_spec, body=True)
         body_str = (
             f"  {f',{os.linesep}  '.join(str(x) for x in body_clauses)},\n"
+            f"  not external({node_variable}),\n"
             f"  not runtime(Package)"
         ).replace(f'"{placeholder}"', f"{node_variable}")
         head_clauses = self._setup.spec_clauses(dependency_spec, body=False)

--- a/lib/spack/spack/test/concretize_compiler_runtimes.py
+++ b/lib/spack/spack/test/concretize_compiler_runtimes.py
@@ -13,7 +13,10 @@ import spack.solver.asp
 import spack.spec
 from spack.version import Version
 
-pytestmark = [pytest.mark.only_clingo("Original concretizer does not support compiler runtimes")]
+pytestmark = [
+    pytest.mark.only_clingo("Original concretizer does not support compiler runtimes"),
+    pytest.mark.usefixtures("enable_runtimes"),
+]
 
 
 @pytest.fixture
@@ -31,7 +34,7 @@ def enable_runtimes():
     spack.solver.asp.WITH_RUNTIME = original
 
 
-def test_correct_gcc_runtime_is_injected_as_dependency(runtime_repo, enable_runtimes):
+def test_correct_gcc_runtime_is_injected_as_dependency(runtime_repo):
     s = spack.spec.Spec("a%gcc@10.2.1 ^b%gcc@4.5.0").concretized()
     a, b = s["a"], s["b"]
 
@@ -43,10 +46,10 @@ def test_correct_gcc_runtime_is_injected_as_dependency(runtime_repo, enable_runt
 
 
 @pytest.mark.regression("41972")
-def test_external_nodes_do_not_have_runtimes(runtime_repo, enable_runtimes, mutable_config):
+def test_external_nodes_do_not_have_runtimes(runtime_repo, mutable_config, tmp_path):
     """Tests that external nodes don't have runtime dependencies."""
 
-    packages_yaml = {"b": {"externals": [{"spec": "b@1.0", "prefix": "/usr"}]}}
+    packages_yaml = {"b": {"externals": [{"spec": "b@1.0", "prefix": f"{str(tmp_path)}"}]}}
     spack.config.set("packages", packages_yaml)
 
     s = spack.spec.Spec("a%gcc@10.2.1").concretized()

--- a/lib/spack/spack/test/concretize_compiler_runtimes.py
+++ b/lib/spack/spack/test/concretize_compiler_runtimes.py
@@ -40,3 +40,20 @@ def test_correct_gcc_runtime_is_injected_as_dependency(runtime_repo, enable_runt
 
     # And the gcc-runtime version should be that of the newest gcc used in the dag.
     assert a["gcc-runtime"].version == Version("10.2.1")
+
+
+@pytest.mark.regression("41972")
+def test_external_nodes_do_not_have_runtimes(runtime_repo, enable_runtimes, mutable_config):
+    """Tests that external nodes don't have runtime dependencies."""
+
+    packages_yaml = {"b": {"externals": [{"spec": "b@1.0", "prefix": "/usr"}]}}
+    spack.config.set("packages", packages_yaml)
+
+    s = spack.spec.Spec("a%gcc@10.2.1").concretized()
+
+    a, b = s["a"], s["b"]
+
+    # Since b is an external, it doesn't depend on gcc-runtime
+    assert a.dependencies("gcc-runtime")
+    assert a.dependencies("b")
+    assert not b.dependencies("gcc-runtime")


### PR DESCRIPTION
fixes #41972

This modifies the rule attaching gcc-runtime to packages, to exclude external nodes.