### PR TITLE
allow spec formatting in module name suffix

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -594,7 +594,11 @@ class BaseFileLayout:
         parts = name.split("/")
         name = os.path.join(*parts)
         # Add optional suffixes based on constraints
-        path_elements = [name] + self.conf.suffixes
+        msg = "some tokens cannot be part of the module naming scheme"
+        for suffix in self.conf.suffixes:
+            _check_tokens_are_valid(suffix, msg)
+        suffixes_formatted = [self.spec.format(x) for x in self.conf.suffixes]
+        path_elements = [name] + suffixes_formatted
         return "-".join(path_elements)
 
     @property

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -597,7 +597,7 @@ class BaseFileLayout:
         msg = "some tokens cannot be part of the module naming scheme"
         for suffix in self.conf.suffixes:
             _check_tokens_are_valid(suffix, msg)
-        suffixes_formatted = [self.spec.format(x) for x in self.conf.suffixes]
+        suffixes_formatted = [self.spec.format_path(x) for x in self.conf.suffixes]
         path_elements = [name] + suffixes_formatted
         return "-".join(path_elements)
 


### PR DESCRIPTION
module projections allow spec formatting such as `^python{^python.version}`, but this is lacking in module suffixes. Added formatting to module suffixes, following `_check_tokens_are_valid`.