### PR TITLE
allow `+` in module file names

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -171,7 +171,7 @@ def polite_path(components: Iterable[str]):
 @memoized
 def _polite_antipattern():
     # A regex of all the characters we don't want in a filename
-    return re.compile(r"[^A-Za-z0-9_.-+]")
+    return re.compile(r"[^A-Za-z0-9_+.-]")
 
 
 def polite_filename(filename: str) -> str:

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -171,7 +171,7 @@ def polite_path(components: Iterable[str]):
 @memoized
 def _polite_antipattern():
     # A regex of all the characters we don't want in a filename
-    return re.compile(r"[^A-Za-z0-9_.-]")
+    return re.compile(r"[^A-Za-z0-9_.-+]")
 
 
 def polite_filename(filename: str) -> str:


### PR DESCRIPTION
As a result of https://github.com/spack/spack/pull/39398, module files now convert the `+` character to `_`. This PR adds the `+` character to the list of approved characters in a "polite filename".

Example of the problem:
```
modules:
  default:
    lmod:
      projections:
        ^zlib: '{name}/{version}+zlib{^zlib.version}'
```

The module file for `pigz^zlib` is named `pigz/2.7_zlib1.3-uqeze72.lua`. In version 0.20 of spack, it was named `pigz/2.7+zlib1.3-uqeze72.lua`. 

For sites that use `LMOD_EXACT_MATCH` and require users to exactly specify the name of the modules they are loading, changes like this to the names of modules can be disruptive. I want to update spack for my site to take advantage of the new features, but I don't want to break all my users' scripts and force them to adjust this character in their module names.