### PR TITLE
Update survey performance tool mpi dependency and add 1.0.8.1 update branch

### DIFF
--- a/var/spack/repos/builtin/packages/survey/package.py
+++ b/var/spack/repos/builtin/packages/survey/package.py
@@ -34,6 +34,7 @@ class Survey(CMakePackage):
 
     version("master", branch="master")
     version("1.0.9", branch="1.0.9")
+    version("1.0.8.1", branch="1.0.8.1")
     version("1.0.8", tag="1.0.8")
     version("1.0.7", tag="1.0.7")
     version("1.0.6", tag="1.0.6")
@@ -69,7 +70,7 @@ class Survey(CMakePackage):
     depends_on("llvm-openmp@12.0.1", type=("build", "link"), when="@1.0.3:")
 
     # MPI Installation
-    depends_on("mpi", when="+mpi")
+    depends_on("mpi", type="build", when="+mpi")
 
     depends_on("python@3:", type=("build", "run"))
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
Update survey performance tool mpi dependency so we do not load the build mpi version at module load time. Add 1.0.8.1 update branch.