### PR TITLE
Add genf90 resource for cprnc to allow offline builds

### DIFF
--- a/var/spack/repos/builtin/packages/cprnc/package.py
+++ b/var/spack/repos/builtin/packages/cprnc/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
@@ -22,3 +24,19 @@ class Cprnc(CMakePackage):
 
     depends_on("netcdf-fortran")
     depends_on("cmake@3:", type="build")
+
+    resource(
+        name="genf90",
+        git="https://github.com/PARALLELIO/genf90",
+        tag="genf90_200608",
+        destination="genf90-resource",
+    )
+
+    def cmake_args(self):
+        args = [
+            self.define(
+                "GENF90_PATH", os.path.join(self.stage.source_path, "genf90-resource/genf90")
+            )
+        ]
+
+        return args

--- a/var/spack/repos/builtin/packages/cprnc/package.py
+++ b/var/spack/repos/builtin/packages/cprnc/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack.package import *
 
 
@@ -35,7 +33,7 @@ class Cprnc(CMakePackage):
     def cmake_args(self):
         args = [
             self.define(
-                "GENF90_PATH", os.path.join(self.stage.source_path, "genf90-resource/genf90")
+                "GENF90_PATH", join_path(self.stage.source_path, "genf90-resource/genf90")
             )
         ]
 

--- a/var/spack/repos/builtin/packages/cprnc/package.py
+++ b/var/spack/repos/builtin/packages/cprnc/package.py
@@ -32,9 +32,7 @@ class Cprnc(CMakePackage):
 
     def cmake_args(self):
         args = [
-            self.define(
-                "GENF90_PATH", join_path(self.stage.source_path, "genf90-resource/genf90")
-            )
+            self.define("GENF90_PATH", join_path(self.stage.source_path, "genf90-resource/genf90"))
         ]
 
         return args


### PR DESCRIPTION
This PR adds a resource to provide the genf90 script for the cprnc recipe in order to allow non-internet connected builds. Tested with and without internet connection on personal machine.