### PR TITLE
Allow compilers to be configured in packages.yaml

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -250,9 +250,10 @@ Compiler configuration
 
 Spack has the ability to build packages with multiple compilers and
 compiler versions. Compilers can be made available to Spack by
-specifying them manually in ``compilers.yaml``, or automatically by
-running ``spack compiler find``, but for convenience Spack will
-automatically detect compilers the first time it needs them.
+specifying them manually in ``compilers.yaml`` or ``packages.yaml``,
+or automatically by running ``spack compiler find``, but for
+convenience Spack will automatically detect compilers the first time
+it needs them.
 
 .. _cmd-spack-compilers:
 
@@ -457,6 +458,48 @@ specification. The operations available to modify the environment are ``set``, `
          prepend_path: # Similar for append|remove_path
            LD_LIBRARY_PATH: /ld/paths/added/by/setvars/sh
 
+.. note::
+
+   Spack is in the process of moving compilers from a separate
+   attribute to be handled like all other packages. As part of this
+   process, the ``compilers.yaml`` section will eventually be replaced
+   by configuration in the ``packages.yaml`` section. This new
+   configuration is now available, although it is not yet the default
+   behavior.
+
+Compilers can also be configured as external packages in the
+``packages.yaml`` config file. Any external package for a compiler
+(e.g. ``gcc`` or ``llvm``) will be treated as a configured compiler
+assuming the paths to the compiler executables are determinable from
+the prefix.
+
+If the paths to the compiler executable are not determinable from the
+prefix, you can add them to the ``extra_attributes`` field. Similarly,
+all other fields from the compilers config can be added to the
+``extra_attributes`` field for an external representing a compiler.
+
+.. code-block:: yaml
+
+   packages:
+     gcc:
+       external:
+       - spec: gcc@12.2.0 arch=linux-rhel8-skylake
+         prefix: /usr
+         extra_attributes:
+           environment:
+             set:
+               GCC_ROOT: /usr
+       external:
+       - spec: llvm+clang@15.0.0 arch=linux-rhel8-skylake
+         prefix: /usr
+         extra_attributes:
+           paths:
+             cc: /usr/bin/clang-with-suffix
+             cxx: /usr/bin/clang++-with-extra-info
+             fc: /usr/bin/gfortran
+             f77: /usr/bin/gfortran
+           extra_rpaths:
+           - /usr/lib/llvm/
 
 ^^^^^^^^^^^^^^^^^^^^^^^
 Build Your Own Compiler

--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -147,7 +147,7 @@ def _add_compilers_if_missing() -> None:
             mixed_toolchain=sys.platform == "darwin"
         )
         if new_compilers:
-            spack.compilers.add_compilers_to_config(new_compilers, init_config=False)
+            spack.compilers.add_compilers_to_config(new_compilers)
 
 
 @contextlib.contextmanager

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -103,7 +103,7 @@ def compiler_find(args):
         paths, scope=None, mixed_toolchain=args.mixed_toolchain
     )
     if new_compilers:
-        spack.compilers.add_compilers_to_config(new_compilers, scope=args.scope, init_config=False)
+        spack.compilers.add_compilers_to_config(new_compilers, scope=args.scope)
         n = len(new_compilers)
         s = "s" if n > 1 else ""
 

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -334,6 +334,40 @@ class Compiler:
         # used for version checks for API, e.g. C++11 flag
         self._real_version = None
 
+    def __eq__(self, other):
+        return (
+            self.cc == other.cc
+            and self.cxx == other.cxx
+            and self.fc == other.fc
+            and self.f77 == other.f77
+            and self.spec == other.spec
+            and self.operating_system == other.operating_system
+            and self.target == other.target
+            and self.flags == other.flags
+            and self.modules == other.modules
+            and self.environment == other.environment
+            and self.extra_rpaths == other.extra_rpaths
+            and self.enable_implicit_rpaths == other.enable_implicit_rpaths
+        )
+
+    def __hash__(self):
+        return hash(
+            (
+                self.cc,
+                self.cxx,
+                self.fc,
+                self.f77,
+                self.spec,
+                self.operating_system,
+                self.target,
+                str(self.flags),
+                str(self.modules),
+                str(self.environment),
+                str(self.extra_rpaths),
+                self.enable_implicit_rpaths,
+            )
+        )
+
     def verify_executables(self):
         """Raise an error if any of the compiler executables is not valid.
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -233,6 +233,9 @@ def compiler_config_files():
         compiler_config = config.get("compilers", scope=name)
         if compiler_config:
             config_files.append(config.get_config_filename(name, "compilers"))
+        compiler_config_from_packages = get_compiler_config_from_packages(scope=name)
+        if compiler_config_from_packages:
+            config_files.append(config.get_config_filename(name, "packages"))
     return config_files
 
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -134,8 +134,7 @@ def get_compiler_config_from_packages(scope=None):
         return packages
 
     for name, entry in config.items():
-        if (name not in supported_compilers() and
-            name not in package_name_to_compiler_name.keys()):
+        if name not in supported_compilers() and name not in package_name_to_compiler_name.keys():
             continue
         packages.extend(_compiler_config_from_package_config(entry))
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -167,24 +167,18 @@ def _compiler_config_from_external(config):
     compiler_class = class_for_compiler_name(compiler_spec.name)
     paths = extra_attributes.get("paths", {})
     compiler_langs = ["cc", "cxx", "fc", "f77"]
-    for compiler in compiler_langs:
-        if paths.setdefault(compiler, None):
+    for lang in compiler_langs:
+        if paths.setdefault(lang, None):
             continue
 
         if not prefix:
             continue
 
-        bindir = prefix
-        if os.path.basename(prefix) != "bin":
-            bindir = os.path.join(prefix, "bin")
-
         # Check for files that satisfy the naming scheme for this compiler
-        for file, regexp in itertools.product(
-            os.listdir(bindir), compiler_class.search_regexps(compiler)
-        ):
-            match = regexp.match(file)
-            if match:
-                paths[compiler] = os.path.join(bindir, file)
+        bindir = os.path.join(prefix, "bin")
+        for f, regex in itertools.product(os.listdir(bindir), compiler_class.search_regexps(lang)):
+            if regex.match(f):
+                paths[lang] = os.path.join(bindir, f)
 
     if all(v is None for v in paths.values()):
         return None
@@ -209,7 +203,7 @@ def _compiler_config_from_external(config):
             "spec": str(compiler_spec),
             "paths": paths,
             "flags": extra_attributes.get("flags", {}),
-            "operating_system": operating_system,
+            "operating_system": str(operating_system),
             "target": str(target.family),
             "modules": config.get("modules", []),
             "environment": extra_attributes.get("environment", {}),

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -156,10 +156,10 @@ def _compiler_config_from_package_config(config):
 
 
 def _compiler_config_from_external(config):
-    spec = spack.spec.Spec(config["spec"])
+    spec = spack.spec.parse_with_version_concrete(config["spec"])
     # use str(spec.versions) to allow `@x.y.z` instead of `@=x.y.z`
     compiler_spec = spack.spec.CompilerSpec(
-        package_name_to_compiler_name.get(spec.name, spec.name), str(spec.versions)
+        package_name_to_compiler_name.get(spec.name, spec.name), spec.version
     )
 
     extra_attributes = config.get("extra_attributes", {})

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -236,8 +236,6 @@ def remove_compiler_from_config(compiler_spec, scope=None):
         compiler_spec: compiler to be removed
         scope: configuration scope to modify
     """
-
-    # TODO GBB: remove if it comes from packages.yaml as well
     candidate_scopes = [scope]
     if scope is None:
         candidate_scopes = spack.config.CONFIG.scopes.keys()
@@ -246,6 +244,9 @@ def remove_compiler_from_config(compiler_spec, scope=None):
     for current_scope in candidate_scopes:
         removal_happened |= _remove_compiler_from_scope(compiler_spec, scope=current_scope)
 
+    msg = "`spack compiler remove` will not remove compilers defined in packages.yaml"
+    msg += "\nTo remove these compilers, either edit the config or use `spack external remove`"
+    tty.debug(msg)
     return removal_happened
 
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -176,6 +176,8 @@ def remove_compiler_from_config(compiler_spec, scope=None):
         compiler_spec: compiler to be removed
         scope: configuration scope to modify
     """
+
+    # TODO GBB: remove if it comes from packages.yaml as well
     candidate_scopes = [scope]
     if scope is None:
         candidate_scopes = spack.config.CONFIG.scopes.keys()
@@ -221,6 +223,7 @@ def all_compilers_config(scope=None, init_config=True):
     """Return a set of specs for all the compiler versions currently
     available to build with.  These are instances of CompilerSpec.
     """
+    # TODO GBB: return compiler specs from packages.yaml
     return get_compiler_config(scope, init_config)
 
 
@@ -388,7 +391,8 @@ def find_specs_by_arch(compiler_spec, arch_spec, scope=None, init_config=True):
 
 
 def all_compilers(scope=None, init_config=True):
-    config = get_compiler_config(scope, init_config=init_config)
+    # TODO GBB: get compilers from packages.yaml as well
+    config = all_compilers_config(scope, init_config=init_config)
     compilers = list()
     for items in config:
         items = items["compiler"]
@@ -403,10 +407,7 @@ def compilers_for_spec(
     """This gets all compilers that satisfy the supplied CompilerSpec.
     Returns an empty list if none are found.
     """
-    if use_cache:
-        config = all_compilers_config(scope, init_config)
-    else:
-        config = get_compiler_config(scope, init_config)
+    config = all_compilers_config(scope, init_config)
 
     matches = set(find(compiler_spec, scope, init_config))
     compilers = []
@@ -582,9 +583,7 @@ def get_compiler_duplicates(compiler_spec, arch_spec):
 
     scope_to_compilers = {}
     for scope in config.scopes:
-        compilers = compilers_for_spec(
-            compiler_spec, arch_spec=arch_spec, scope=scope, use_cache=False
-        )
+        compilers = compilers_for_spec(compiler_spec, arch_spec=arch_spec, scope=scope)
         if compilers:
             scope_to_compilers[scope] = compilers
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -208,7 +208,7 @@ def _compiler_config_from_external(config):
             "modules": config.get("modules", []),
             "environment": extra_attributes.get("environment", {}),
             "extra_rpaths": extra_attributes.get("extra_rpaths", []),
-            "implicit_rpaths": extra_attributes.get("implicit_rpaths", True),
+            "implicit_rpaths": extra_attributes.get("implicit_rpaths", None),
         }
     }
     return compiler_entry
@@ -315,7 +315,9 @@ def all_compilers_config(scope=None, init_config=True):
     """
     from_compilers_yaml = get_compiler_config(scope, init_config)
     from_packages_yaml = get_compiler_config_from_packages(scope)
-    return from_compilers_yaml + from_packages_yaml
+    result = from_compilers_yaml + from_packages_yaml
+    key = lambda c: _compiler_from_config_entry(c["compiler"])
+    return list(llnl.util.lang.dedupe(result, key=key))
 
 
 def all_compiler_specs(scope=None, init_config=True):

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -157,8 +157,9 @@ def _compiler_config_from_package_config(config):
 
 def _compiler_config_from_external(config):
     spec = spack.spec.Spec(config["spec"])
+    # use str(spec.versions) to allow `@x.y.z` instead of `@=x.y.z`
     compiler_spec = spack.spec.CompilerSpec(
-        package_name_to_compiler_name.get(spec.name, spec.name), spec.version
+        package_name_to_compiler_name.get(spec.name, spec.name), str(spec.versions)
     )
 
     extra_attributes = config.get("extra_attributes", {})

--- a/lib/spack/spack/cray_manifest.py
+++ b/lib/spack/spack/cray_manifest.py
@@ -227,7 +227,7 @@ def read(path, apply_updates):
     if apply_updates and compilers:
         for compiler in compilers:
             try:
-                spack.compilers.add_compilers_to_config([compiler], init_config=False)
+                spack.compilers.add_compilers_to_config([compiler])
             except Exception:
                 warnings.warn(
                     f"Could not add compiler {str(compiler.spec)}: "

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1554,7 +1554,7 @@ class Environment:
 
         # Ensure we have compilers in compilers.yaml to avoid that
         # processes try to write the config file in parallel
-        _ = spack.compilers.get_compiler_config()
+        _ = spack.compilers.get_compiler_config(init_config=True)
 
         # Early return if there is nothing to do
         if len(args) == 0:

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -292,3 +292,41 @@ def test_compilers_shows_packages_yaml(no_compilers_yaml, working_env, compilers
 """
 
     assert out == expected
+
+
+def test_compilers_shows_packages_yaml_minimal(no_compilers_yaml, working_env, compilers_dir):
+    """Spack should see a single compiler defined from packages.yaml"""
+    gcc_entry = {
+        "externals": [{
+            "spec": "gcc@=7.7.7",
+            "prefix": str(compilers_dir),
+            "modules": ["gcc/7.7.7", "foobar"],
+            "extra_attributes": {
+                "flags": {
+                    "fflags": "-ffree-form"
+                }
+            }
+        }]
+    }
+
+    packages = spack.config.get("packages")
+    packages["gcc"] = gcc_entry
+    spack.config.set("packages", packages)
+
+    out = compiler("list")
+    assert out.count("gcc@7.7.7") == 1
+
+    out = compiler("info", "gcc@7.7.7")
+    expected = f"""gcc@7.7.7:
+	paths:
+		cc = {compilers_dir}/gcc-8
+		cxx = {compilers_dir}/g++-8
+		f77 = {compilers_dir}/gfortran-8
+		fc = {compilers_dir}/gfortran-8
+	flags:
+		fflags = ['-ffree-form']
+	modules  = ['gcc/7.7.7', 'foobar']
+	operating system  = debian6
+"""
+
+    assert out == expected

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -280,15 +280,15 @@ def test_compilers_shows_packages_yaml(no_compilers_yaml, working_env, compilers
 
     out = compiler("info", "gcc@7.7.7")
     expected = """gcc@7.7.7:
-	paths:
-		cc = /path/to/fake/gcc
-		cxx = /path/to/fake/g++
-		f77 = /path/to/fake/gfortran
-		fc = /path/to/fake/gfortran
-	flags:
-		fflags = ['-ffree-form']
-	modules  = ['gcc/7.7.7', 'foobar']
-	operating system  = foobar
+\tpaths:
+\t\tcc = /path/to/fake/gcc
+\t\tcxx = /path/to/fake/g++
+\t\tf77 = /path/to/fake/gfortran
+\t\tfc = /path/to/fake/gfortran
+\tflags:
+\t\tfflags = ['-ffree-form']
+\tmodules  = ['gcc/7.7.7', 'foobar']
+\toperating system  = foobar
 """
 
     assert out == expected
@@ -316,15 +316,15 @@ def test_compilers_shows_packages_yaml_minimal(no_compilers_yaml, working_env, c
 
     out = compiler("info", "gcc@7.7.7")
     expected = f"""gcc@7.7.7:
-	paths:
-		cc = {compilers_dir}/gcc-8
-		cxx = {compilers_dir}/g++-8
-		f77 = {compilers_dir}/gfortran-8
-		fc = {compilers_dir}/gfortran-8
-	flags:
-		fflags = ['-ffree-form']
-	modules  = ['gcc/7.7.7', 'foobar']
-	operating system  = debian6
+\tpaths:
+\t\tcc = {compilers_dir}/gcc-8
+\t\tcxx = {compilers_dir}/g++-8
+\t\tf77 = {compilers_dir}/gfortran-8
+\t\tfc = {compilers_dir}/gfortran-8
+\tflags:
+\t\tfflags = ['-ffree-form']
+\tmodules  = ['gcc/7.7.7', 'foobar']
+\toperating system  = debian6
 """
 
     assert out == expected

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -314,13 +314,15 @@ def test_compilers_shows_packages_yaml_minimal(no_compilers_yaml, working_env, c
     out = compiler("list")
     assert out.count("gcc@7.7.7") == 1
 
+    suffix = ".bat" if sys.platform == "win32" else ""
+
     out = compiler("info", "gcc@7.7.7")
     expected = f"""gcc@7.7.7:
 \tpaths:
-\t\tcc = {compilers_dir}/gcc-8
-\t\tcxx = {compilers_dir}/g++-8
-\t\tf77 = {compilers_dir}/gfortran-8
-\t\tfc = {compilers_dir}/gfortran-8
+\t\tcc = {compilers_dir}/gcc-8{suffix}
+\t\tcxx = {compilers_dir}/g++-8{suffix}
+\t\tf77 = {compilers_dir}/gfortran-8{suffix}
+\t\tfc = {compilers_dir}/gfortran-8{suffix}
 \tflags:
 \t\tfflags = ['-ffree-form']
 \tmodules  = ['gcc/7.7.7', 'foobar']

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -252,22 +252,22 @@ def test_compiler_list_empty(no_compilers_yaml, working_env, compilers_dir):
 def test_compilers_shows_packages_yaml(no_compilers_yaml, working_env, compilers_dir):
     """Spack should see a single compiler defined from packages.yaml"""
     gcc_entry = {
-        "externals": [{
-            "spec": "gcc@=7.7.7 os=foobar target=x86_64",
-            "prefix": "/path/to/fake",
-            "modules": ["gcc/7.7.7", "foobar"],
-            "extra_attributes": {
-                "paths": {
-                    "cc": "/path/to/fake/gcc",
-                    "cxx": "/path/to/fake/g++",
-                    "fc": "/path/to/fake/gfortran",
-                    "f77": "/path/to/fake/gfortran",
+        "externals": [
+            {
+                "spec": "gcc@=7.7.7 os=foobar target=x86_64",
+                "prefix": "/path/to/fake",
+                "modules": ["gcc/7.7.7", "foobar"],
+                "extra_attributes": {
+                    "paths": {
+                        "cc": "/path/to/fake/gcc",
+                        "cxx": "/path/to/fake/g++",
+                        "fc": "/path/to/fake/gfortran",
+                        "f77": "/path/to/fake/gfortran",
+                    },
+                    "flags": {"fflags": "-ffree-form"},
                 },
-                "flags": {
-                    "fflags": "-ffree-form"
-                }
             }
-        }]
+        ]
     }
 
     packages = spack.config.get("packages")
@@ -297,16 +297,14 @@ def test_compilers_shows_packages_yaml(no_compilers_yaml, working_env, compilers
 def test_compilers_shows_packages_yaml_minimal(no_compilers_yaml, working_env, compilers_dir):
     """Spack should see a single compiler defined from packages.yaml"""
     gcc_entry = {
-        "externals": [{
-            "spec": "gcc@=7.7.7",
-            "prefix": str(compilers_dir),
-            "modules": ["gcc/7.7.7", "foobar"],
-            "extra_attributes": {
-                "flags": {
-                    "fflags": "-ffree-form"
-                }
+        "externals": [
+            {
+                "spec": "gcc@=7.7.7",
+                "prefix": str(compilers_dir),
+                "modules": ["gcc/7.7.7", "foobar"],
+                "extra_attributes": {"flags": {"fflags": "-ffree-form"}},
             }
-        }]
+        ]
     }
 
     packages = spack.config.get("packages")

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -300,7 +300,7 @@ def test_compilers_shows_packages_yaml_minimal(no_compilers_yaml, working_env, c
     gcc_entry = {
         "externals": [
             {
-                "spec": "gcc@=7.7.7",
+                "spec": "gcc@7.7.7",
                 "prefix": str(compilers_dir),
                 "modules": ["gcc/7.7.7", "foobar"],
                 "extra_attributes": {"flags": {"fflags": "-ffree-form"}},

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 import shutil
+import sys
 
 import pytest
 

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -320,10 +320,10 @@ def test_compilers_shows_packages_yaml_minimal(no_compilers_yaml, working_env, c
     out = compiler("info", "gcc@7.7.7")
     expected = f"""gcc@7.7.7:
 \tpaths:
-\t\tcc = {compilers_dir}/gcc-8{suffix}
-\t\tcxx = {compilers_dir}/g++-8{suffix}
-\t\tf77 = {compilers_dir}/gfortran-8{suffix}
-\t\tfc = {compilers_dir}/gfortran-8{suffix}
+\t\tcc = {compilers_dir}{os.sep}gcc-8{suffix}
+\t\tcxx = {compilers_dir}{os.sep}g++-8{suffix}
+\t\tf77 = {compilers_dir}{os.sep}gfortran-8{suffix}
+\t\tfc = {compilers_dir}{os.sep}gfortran-8{suffix}
 \tflags:
 \t\tfflags = ['-ffree-form']
 \tmodules  = ['gcc/7.7.7', 'foobar']

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -247,3 +247,48 @@ def test_compiler_list_empty(no_compilers_yaml, working_env, compilers_dir):
     out = compiler("list")
     assert not out
     assert compiler.returncode == 0
+
+
+def test_compilers_shows_packages_yaml(no_compilers_yaml, working_env, compilers_dir):
+    """Spack should see a single compiler defined from packages.yaml"""
+    gcc_entry = {
+        "externals": [{
+            "spec": "gcc@=7.7.7 os=foobar target=x86_64",
+            "prefix": "/path/to/fake",
+            "modules": ["gcc/7.7.7", "foobar"],
+            "extra_attributes": {
+                "paths": {
+                    "cc": "/path/to/fake/gcc",
+                    "cxx": "/path/to/fake/g++",
+                    "fc": "/path/to/fake/gfortran",
+                    "f77": "/path/to/fake/gfortran",
+                },
+                "flags": {
+                    "fflags": "-ffree-form"
+                }
+            }
+        }]
+    }
+
+    packages = spack.config.get("packages")
+    packages["gcc"] = gcc_entry
+    spack.config.set("packages", packages)
+
+    out = compiler("list")
+    assert out.count("gcc foobar-x86_64") == 1
+    assert out.count("gcc@7.7.7") == 1
+
+    out = compiler("info", "gcc@7.7.7")
+    expected = """gcc@7.7.7:
+	paths:
+		cc = /path/to/fake/gcc
+		cxx = /path/to/fake/g++
+		f77 = /path/to/fake/gfortran
+		fc = /path/to/fake/gfortran
+	flags:
+		fflags = ['-ffree-form']
+	modules  = ['gcc/7.7.7', 'foobar']
+	operating system  = foobar
+"""
+
+    assert out == expected


### PR DESCRIPTION
Todo:
- [x] Code
- [x] Tests
- [x] Docs

Allow externals with sufficient information to be considered as a compiler. This is work towards compilers as dependencies.