### PR TITLE
Manual downloads: skip checksum, do not require concretization for instructions

### DIFF
--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -86,6 +86,10 @@ def checksum(parser, args):
     # Get the package we're going to generate checksums for
     pkg = spack.repo.PATH.get_pkg_class(spec.name)(spec)
 
+    # Skip manually downloaded packages
+    if pkg.manual_download:
+        tty.die(pkg.download_instr)
+
     versions = [Version(v) for v in args.versions]
 
     # Define placeholder for remote versions.

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -17,7 +17,12 @@ import spack.stage
 import spack.util.crypto
 import spack.util.web as web_util
 from spack.cmd.common import arguments
-from spack.package_base import PackageBase, deprecated_version, preferred_version
+from spack.package_base import (
+    ManualDownloadRequiredError,
+    PackageBase,
+    deprecated_version,
+    preferred_version,
+)
 from spack.util.editor import editor
 from spack.util.format import get_version_lines
 from spack.version import Version
@@ -88,7 +93,7 @@ def checksum(parser, args):
 
     # Skip manually downloaded packages
     if pkg.manual_download:
-        tty.die(pkg.download_instr)
+        raise ManualDownloadRequiredError(pkg.download_instr)
 
     versions = [Version(v) for v in args.versions]
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1412,13 +1412,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             (str):  default manual download instructions
         """
         required = (
-            "Manual download is required for {0}. ".format(self.spec.name)
-            if self.manual_download
-            else ""
+            f"Manual download is required for {self.spec.name}. " if self.manual_download else ""
         )
-        return "{0}Refer to {1} for download instructions.".format(
-            required, self.spec.package.homepage
-        )
+        return f"{required}Refer to {self.homepage} for download instructions."
 
     def do_fetch(self, mirror_only=False):
         """

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2559,3 +2559,7 @@ class DependencyConflictError(spack.error.SpackError):
 
     def __init__(self, conflict):
         super().__init__("%s conflicts with another file in the flattened directory." % (conflict))
+
+
+class ManualDownloadRequiredError(InvalidPackageOpError):
+    """Raised when attempting an invalid operation on a package that requires a manual download."""

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -272,3 +272,12 @@ def test_checksum_verification_fails(install_mockery, capsys):
     assert out.count("Correct") == 0
     assert "No previous checksum" in out
     assert "Invalid checksum" in out
+
+
+def test_checksum_manual_download_fails(mock_packages, monkeypatch):
+    """Confirm that checksumming a manually downloadable package fails."""
+    pkg_cls = spack.repo.PATH.get_pkg_class("zlib")
+    versions = [str(v) for v in pkg_cls.versions]
+    monkeypatch.setattr(spack.package_base.PackageBase, "manual_download", True)
+    with pytest.raises(spack.main.SpackCommandError):
+        spack_checksum("zlib", *versions)


### PR DESCRIPTION
It would be clearer for `spack checksum` to report download instructions for manually downloaded packages than error out with `Could not find any remote versions`.

Also, `spack checksum` should be allowed to print the download instructions that are part of the package itself without the spec being concretized.

This PR therefore:
- skips attempts to checksum packages with `manual_download` set to `True`;
- allows the download instructions to be returned/printed whether the package is concretized or not;
- changes default download instructions to use f-strings.

