### PR TITLE
Fix Catch2 patch to the appropriate version

### DIFF
--- a/var/spack/repos/builtin/packages/catch2/package.py
+++ b/var/spack/repos/builtin/packages/catch2/package.py
@@ -122,6 +122,7 @@ class Catch2(CMakePackage):
     )
     variant("shared", when="@3:", default=False, description="Build shared library")
 
+    @when("@3:")
     def patch(self):
         filter_file(
             r"#include \<catch2",


### PR DESCRIPTION
PR #41199 broke catch2 builds for versions older than 3. This PR fixes the patch version to v3 and above.