### PR TITLE
googletest: change the URL

### DIFF
--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -10,7 +10,7 @@ class Googletest(CMakePackage):
     """Google test framework for C++.  Also called gtest."""
 
     homepage = "https://github.com/google/googletest"
-    url = "https://github.com/google/googletest/archive/release-1.10.0.tar.gz"
+    url = "https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz"
     git = "https://github.com/google/googletest"
 
     maintainers("sethrj")
@@ -85,11 +85,11 @@ class Googletest(CMakePackage):
         while versions up to, and including, 1.8.0 are available only from
         `archive/release-<version>.tar.gz`
         """
-        if version.satisfies("@:1.8.0"):
+        if version <= Version("1.8.0"):
             return f"{self.git}/archive/release-{version}.tar.gz"
 
         tagname = f"release-{version}"
-        if version.satisfies("@1.13:"):
+        if version >= Version("1.13"):
             tagname = f"v{version}"
 
         return f"{self.git}/archive/refs/tags/{tagname}.tar.gz"


### PR DESCRIPTION
The old URL doesn't work for v1.13 and 1.14, the new one does and the hashes are correct.