### PR TITLE
perl-rose-db-object and deps: New packages

### DIFF
--- a/var/spack/repos/builtin/packages/perl-datetime/package.py
+++ b/var/spack/repos/builtin/packages/perl-datetime/package.py
@@ -10,14 +10,18 @@ class PerlDatetime(PerlPackage):
     """DateTime - A date and time object for Perl"""
 
     homepage = "https://metacpan.org/pod/DateTime"
-    url = "https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/DateTime-1.63.tar.gz"
-
-    license("Artistic-2.0")
+    url = "https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/DateTime-1.65.tar.gz"
 
     maintainers("EbiArnie")
 
+    license("Artistic-2.0")
+
     version("1.65", sha256="0bfda7ff0253fb3d88cf4bdb5a14afb8cea24d147975d5bdf3c88b40e7ab140e")
-    version("1.63", sha256="1b11e49ec6e184ae2a10eccd05eda9534f32458fc644c12ab710c29a3a816f6f")
+    version(
+        "1.63",
+        sha256="1b11e49ec6e184ae2a10eccd05eda9534f32458fc644c12ab710c29a3a816f6f",
+        deprecated=True,
+    )
 
     depends_on("perl@5.8.4:", type=("build", "link", "run", "test"))
     depends_on("perl-cpan-meta-check@0.011:", type=("build", "test"))

--- a/var/spack/repos/builtin/packages/perl-rose-db-object/package.py
+++ b/var/spack/repos/builtin/packages/perl-rose-db-object/package.py
@@ -1,0 +1,38 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlRoseDbObject(PerlPackage):
+    """Extensible, high performance object-relational mapper (ORM)."""
+
+    homepage = "https://metacpan.org/pod/Rose::DB::Object"
+    url = "https://cpan.metacpan.org/authors/id/J/JS/JSIRACUSA/Rose-DB-Object-0.820.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.820", sha256="a0077609250966636f1411bcce2493cf1e1166ba935071738eb4b713104da83b")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-bit-vector", type=("build", "run", "test"))
+    depends_on("perl-clone@0.29:", type=("build", "run", "test"))
+    depends_on("perl-datetime", type=("build", "run", "test"))
+    depends_on("perl-dbi@1.40:", type=("build", "run", "test"))
+    depends_on("perl-list-moreutils", type=("build", "run", "test"))
+    depends_on("perl-rose-datetime", type=("build", "run", "test"))
+    depends_on("perl-rose-db@0.782:", type=("build", "run", "test"))
+    depends_on("perl-rose-object@0.854:", type=("build", "run", "test"))
+    depends_on("perl-time-clock@1.00:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Rose::DB::Object; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-rose-db/package.py
+++ b/var/spack/repos/builtin/packages/perl-rose-db/package.py
@@ -1,0 +1,40 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlRoseDb(PerlPackage):
+    """A DBI wrapper and abstraction layer."""
+
+    homepage = "https://metacpan.org/pod/Rose::DB"
+    url = "https://cpan.metacpan.org/authors/id/J/JS/JSIRACUSA/Rose-DB-0.785.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.785", sha256="7849307d748d9672b42ef3cd78f83d44dec034cdc94f4d4251d2761e27c67a3c")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-bit-vector", type=("build", "run", "test"))
+    depends_on("perl-clone-pp", type=("build", "run", "test"))
+    depends_on("perl-datetime", type=("build", "run", "test"))
+    depends_on("perl-datetime-format-mysql", type=("build", "run", "test"))
+    depends_on("perl-datetime-format-oracle", type=("build", "run", "test"))
+    depends_on("perl-datetime-format-pg@0.11:", type=("build", "run", "test"))
+    depends_on("perl-dbi", type=("build", "run", "test"))
+    depends_on("perl-rose-datetime", type=("build", "run", "test"))
+    depends_on("perl-rose-object@0.854:", type=("build", "run", "test"))
+    depends_on("perl-sql-reservedwords", type=("build", "run", "test"))
+    depends_on("perl-time-clock", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Rose::DB; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
- Modifies DateTime to allow for build-time tests and updates to latest version
- Adds Rose::DateTime
- Adds Rose::DB
- Adds Rose::DB::Object