### PR TITLE
bdsim: Use the same C++ standard as in ROOT, add a patch

### DIFF
--- a/var/spack/repos/builtin/packages/bdsim/c++-standard.patch
+++ b/var/spack/repos/builtin/packages/bdsim/c++-standard.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4750d9a..7b10b57 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,7 +5,7 @@ if (CMAKE_VERSION VERSION_LESS 3.9.0)
+   cmake_policy(SET CMP0042 OLD)
+ endif()
+ 
+-set(CMAKE_CXX_STANDARD 11)
++set(CMAKE_CXX_STANDARD 11 CACHE STRING "")
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ 
+ include(GenerateExportHeader)

--- a/var/spack/repos/builtin/packages/bdsim/package.py
+++ b/var/spack/repos/builtin/packages/bdsim/package.py
@@ -39,5 +39,5 @@ class Bdsim(CMakePackage):
 
     def cmake_args(self):
         args = []
-        args.append("-DCMAKE_CXX_STANDARD=%s" % self.spec["root"].variants["cxxstd"].value)
+        args.append(f"-DCMAKE_CXX_STANDARD={self.spec['root'].variants['cxxstd'].value}")
         return args

--- a/var/spack/repos/builtin/packages/bdsim/package.py
+++ b/var/spack/repos/builtin/packages/bdsim/package.py
@@ -22,7 +22,9 @@ class Bdsim(CMakePackage):
 
     license("GPL-3.0-or-later")
 
-    version("develop", branch="develop")
+    version("master", branch="master")
+    version("1.7.6", sha256="92f53aa0a9fbd3cafd218f9e58ae4d1e7115733e641191c1658243fefb436600")
+    version("1.7.0", sha256="713ce3c9d94f340ca774ce1803e0c4f992b904dbc28ce4129713abe883e98683")
     version("1.6.0", sha256="e3241d2d097cb4e22249e315c1474da9b3657b9c6893232d9f9e543a5323f717")
 
     depends_on("cmake")
@@ -32,3 +34,10 @@ class Bdsim(CMakePackage):
     depends_on("clhep")
     depends_on("flex")
     depends_on("bison")
+
+    patch("c++-standard.patch", when="@:1.7.6")
+
+    def cmake_args(self):
+        args = []
+        args.append("-DCMAKE_CXX_STANDARD=%s" % self.spec["root"].variants["cxxstd"].value)
+        return args


### PR DESCRIPTION
The patch fixes compilation with other standards by caching the `CMAKE_CXX_STANDARD`. Without caching it, the `-DCMAKE_CXX_STANDARD` variable is ignored and when not passed at all (like previously) the default standard for a given compiler is used. Built successfully with C++20 with ROOT with C++20