### PR TITLE
llvm: bring back setup_run_environment

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -766,6 +766,14 @@ class Llvm(CMakePackage, CudaPackage):
                     os.symlink(bin, sym)
             env.prepend_path("PATH", self.stage.path)
 
+    def setup_run_environment(self, env):
+        if "+clang" in self.spec:
+            env.set("CC", join_path(self.spec.prefix.bin, "clang"))
+            env.set("CXX", join_path(self.spec.prefix.bin, "clang++"))
+        if "+flang" in self.spec:
+            env.set("FC", join_path(self.spec.prefix.bin, "flang"))
+            env.set("F77", join_path(self.spec.prefix.bin, "flang"))
+
     root_cmakelists_dir = "llvm"
 
     def cmake_args(self):


### PR DESCRIPTION
This was removed in #35737 because at that point `x%gcc ^llvm` would override
CC/CXX from the build environment, and replace gcc with llvm's compiler.

That problem was fixed more generally in #40916, but the changes to llvm were not restored

