### PR TITLE
Bump for new version of bedtools2 

### DIFF
--- a/var/spack/repos/builtin/packages/bedtools2/package.py
+++ b/var/spack/repos/builtin/packages/bedtools2/package.py
@@ -17,6 +17,7 @@ class Bedtools2(Package):
 
     license("MIT")
 
+    version("2.31.1", sha256="fc7e660c2279b1e008b80aca0165a4a157daf4994d08a533ee925d73ce732b97")
     version("2.31.0", sha256="183cf9a96aabc50ef4bd557a53fd01557a123c05a0dc87651371878f357439ec")
     version("2.30.0", sha256="c575861ec746322961cd15d8c0b532bb2a19333f1cf167bbff73230a7d67302f")
     version("2.29.2", sha256="bc2f36b5d4fc9890c69f607d54da873032628462e88c545dd633d2c787a544a5")

--- a/var/spack/repos/builtin/packages/bedtools2/package.py
+++ b/var/spack/repos/builtin/packages/bedtools2/package.py
@@ -17,7 +17,7 @@ class Bedtools2(Package):
 
     license("MIT")
 
-    version("2.31.1", sha256="fc7e660c2279b1e008b80aca0165a4a157daf4994d08a533ee925d73ce732b97")
+    version("2.31.1", sha256="79a1ba318d309f4e74bfa74258b73ef578dccb1045e270998d7fe9da9f43a50e")
     version("2.31.0", sha256="183cf9a96aabc50ef4bd557a53fd01557a123c05a0dc87651371878f357439ec")
     version("2.30.0", sha256="c575861ec746322961cd15d8c0b532bb2a19333f1cf167bbff73230a7d67302f")
     version("2.29.2", sha256="bc2f36b5d4fc9890c69f607d54da873032628462e88c545dd633d2c787a544a5")

--- a/var/spack/repos/builtin/packages/bedtools2/package.py
+++ b/var/spack/repos/builtin/packages/bedtools2/package.py
@@ -32,7 +32,7 @@ class Bedtools2(Package):
     depends_on("xz", when="@2.29:")
     depends_on("python", type="build")
 
-    patch("bedtools-gcc13.patch", level=1, when="@2.27:%gcc@13:")
+    patch("bedtools-gcc13.patch", level=1, when="@2.27:2.31.0%gcc@13:")
 
     def install(self, spec, prefix):
         make("prefix=%s" % prefix, "install")


### PR DESCRIPTION
https://github.com/arq5x/bedtools2/releases/tag/v2.31.1