### PR TITLE
dorado: switching to source build

### DIFF
--- a/var/spack/repos/builtin/packages/dorado/cmake-htslib.patch
+++ b/var/spack/repos/builtin/packages/dorado/cmake-htslib.patch
@@ -1,0 +1,111 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 64d6091e..323412a4 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -316,10 +316,6 @@ target_link_libraries(dorado_lib
+         minimap2
+ )
+ 
+-if(NOT WIN32)
+-    add_dependencies(dorado_lib htslib_project)
+-endif()
+-
+ if(NOT DORADO_DISABLE_DORADO)
+     if(NOT WIN32)
+         # Set up RPATHs so we can find dependencies
+diff --git a/cmake/Htslib.cmake b/cmake/Htslib.cmake
+index caabc1a3..c72fe534 100644
+--- a/cmake/Htslib.cmake
++++ b/cmake/Htslib.cmake
+@@ -1,68 +1,4 @@
+-if(NOT TARGET htslib) # lazy include guard
+-    if(WIN32)
+-        message(STATUS "Fetching htslib")
+-        download_and_extract(https://cdn.oxfordnanoportal.com/software/analysis/htslib-win.tar.gz htslib-win)
+-        set(HTSLIB_DIR ${DORADO_3RD_PARTY_DOWNLOAD}/htslib-win CACHE STRING
+-                    "Path to htslib repo")
+-        add_library(htslib SHARED IMPORTED)
+-        set_target_properties(htslib PROPERTIES 
+-            "IMPORTED_IMPLIB" ${HTSLIB_DIR}/hts-3.lib
+-            "IMPORTED_LOCATION" ${HTSLIB_DIR}/hts-3.dll
+-            "INTERFACE_INCLUDE_DIRECTORIES" ${HTSLIB_DIR})
+-        target_link_directories(htslib INTERFACE ${HTSLIB_DIR})
+-    else()
+-        message(STATUS "Setting up htslib build")
+-        set(HTSLIB_DIR ${DORADO_3RD_PARTY_SOURCE}/htslib CACHE STRING "Path to htslib repo")
+-        set(htslib_PREFIX ${CMAKE_BINARY_DIR}/3rdparty/htslib)
++include_directories(${HTSLIB_PREFIX}/include)
+ 
+-        find_program(MAKE_COMMAND make REQUIRED)
+-        find_program(AUTOCONF_COMMAND autoconf REQUIRED)
+-        find_program(AUTOHEADER_COMMAND autoheader REQUIRED)
+-        execute_process(COMMAND bash -c "${AUTOCONF_COMMAND} -V | sed 's/.* //; q'"
+-            OUTPUT_VARIABLE AUTOCONF_VERS)
+-        if (AUTOCONF_VERS VERSION_GREATER_EQUAL 2.70 AND NOT CMAKE_GENERATOR STREQUAL "Xcode")
+-            set(AUTOCONF_COMMAND autoreconf --install)
+-        endif()
+-
+-        # The Htslib build apparently requires BUILD_IN_SOURCE=1, which is a problem when
+-        # switching between build targets because htscodecs object files aren't regenerated.
+-        # To avoid this, copy the source tree to a build-specific directory and do the build there.
+-        set(HTSLIB_BUILD ${CMAKE_BINARY_DIR}/htslib_build)
+-        file(COPY ${HTSLIB_DIR} DESTINATION ${HTSLIB_BUILD})
+-
+-        if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
+-            # We need cross-compilation mode for iOS builds.  Otherwise we end up trying to link a MacOS library
+-            # into an iOS target.
+-            set(CONFIGURE_FLAGS --host=aarch64-apple-darwin "CFLAGS=-isysroot ${CMAKE_OSX_SYSROOT}" "CC=${CMAKE_C_COMPILER}" "LDFLAGS=-isysroot ${CMAKE_OSX_SYSROOT}")
+-            # By default the dylib install name will be some local path that won't work on the device.
+-            set(INSTALL_NAME ${CMAKE_INSTALL_NAME_TOOL} -id "@executable_path/Frameworks/libhts.3.dylib" ${htslib_PREFIX}/lib/libhts.3.dylib)
+-        endif()
+-
+-        include(ExternalProject)
+-        ExternalProject_Add(htslib_project
+-                PREFIX ${HTSLIB_BUILD}
+-                SOURCE_DIR ${HTSLIB_BUILD}/htslib
+-                BUILD_IN_SOURCE 1
+-                CONFIGURE_COMMAND ${AUTOHEADER_COMMAND}
+-                COMMAND ${AUTOCONF_COMMAND}
+-                COMMAND ./configure --disable-bz2 --disable-lzma --disable-libcurl --disable-s3 --disable-gcs ${CONFIGURE_FLAGS}
+-                BUILD_COMMAND ${MAKE_COMMAND} install prefix=${htslib_PREFIX}
+-                COMMAND ${INSTALL_NAME}
+-                INSTALL_COMMAND ""
+-                BUILD_BYPRODUCTS ${htslib_PREFIX}/lib/libhts.a
+-                LOG_CONFIGURE 0
+-                LOG_BUILD 0
+-                LOG_TEST 0
+-                LOG_INSTALL 0
+-                )
+-
+-        add_library(htslib STATIC IMPORTED)
+-        # Need to ensure this directory exists before we can add it to INTERFACE_INCLUDE_DIRECTORIES
+-        file(MAKE_DIRECTORY ${htslib_PREFIX}/include)
+-        set_target_properties(htslib 
+-            PROPERTIES 
+-                "IMPORTED_LOCATION" ${htslib_PREFIX}/lib/libhts.a
+-                "INTERFACE_INCLUDE_DIRECTORIES" ${htslib_PREFIX}/include)
+-        message(STATUS "Done Building htslib")
+-    endif()
+-endif()
++add_library(htslib SHARED IMPORTED)
++set_target_properties(htslib PROPERTIES IMPORTED_LOCATION ${HTSLIB_PREFIX}/lib/libhts.so)
+diff --git a/dorado/utils/CMakeLists.txt b/dorado/utils/CMakeLists.txt
+index 9bbf7067..e78feabe 100644
+--- a/dorado/utils/CMakeLists.txt
++++ b/dorado/utils/CMakeLists.txt
+@@ -117,13 +117,9 @@ if(APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
+     target_link_libraries(dorado_utils PUBLIC ${IOKIT})
+ endif()
+ 
+-if(NOT WIN32)
+-    add_dependencies(dorado_utils htslib_project)
+-endif()
+-
+ # GCC 8 ICEs trying to compile this file with ASAN+optimisations enabled, so knock down the optimisation to try and help it out.
+ if (ECM_ENABLE_SANITIZERS AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0))
+     set_source_files_properties(duplex_utils.cpp PROPERTIES COMPILE_OPTIONS "-O0")
+ endif()
+ 
+-enable_warnings_as_errors(dorado_utils)
+\ No newline at end of file
++enable_warnings_as_errors(dorado_utils)

--- a/var/spack/repos/builtin/packages/dorado/package.py
+++ b/var/spack/repos/builtin/packages/dorado/package.py
@@ -5,6 +5,7 @@
 
 from spack.package import *
 
+
 class Dorado(CMakePackage, CudaPackage):
     """Dorado is a high-performance, easy-to-use, open source basecaller
     for Oxford Nanopore reads."""

--- a/var/spack/repos/builtin/packages/dorado/package.py
+++ b/var/spack/repos/builtin/packages/dorado/package.py
@@ -5,19 +5,37 @@
 
 from spack.package import *
 
-
-class Dorado(Package):
-    """
-    Dorado is a high-performance, easy-to-use, open source basecaller for Oxford Nanopore reads.
-    """
+class Dorado(CMakePackage, CudaPackage):
+    """Dorado is a high-performance, easy-to-use, open source basecaller
+    for Oxford Nanopore reads."""
 
     homepage = "https://github.com/nanoporetech/dorado"
-    url = "https://cdn.oxfordnanoportal.com/software/analysis/dorado-0.5.1-linux-x64.tar.gz"
+    git = "https://github.com/nanoporetech/dorado.git"
+    url = "https://github.com/nanoporetech/dorado/archive/refs/tags/v0.5.1.tar.gz"
 
-    version("0.5.1", sha256="7d95f4d47e0024db8ca275a5c591ebcaf2e17bfbff714fa824b212fb58a98802")
+    maintainers("snehring")
 
-    def install(self, spec, prefix):
-        mkdirp(prefix.bin)
-        install("bin/dorado", prefix.bin)
-        mkdirp(prefix.lib)
-        install_tree("lib/.", prefix.lib)
+    version("0.5.1", commit="a7fb3e3d4afa7a11cb52422e7eecb1a2cdb7860f", submodules=True)
+
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("git", type="build")
+    depends_on("curl", type="build")
+    depends_on("cuda")
+    depends_on("hdf5@1.17:+hl+cxx+szip")
+    depends_on("htslib@1.15.1")
+    depends_on("openssl")
+    depends_on("zstd")
+    depends_on("libdeflate")
+    depends_on("zlib-api")
+
+    patch("cmake-htslib.patch")
+
+    def setup_build_environment(self, env):
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["libdeflate"].prefix.lib64)
+        env.prepend_path("LIBRARY_PATH", self.spec["libdeflate"].prefix.lib64)
+
+    def cmake_args(self):
+        htslib_prefix = self.spec["htslib"].prefix
+        args = [f"-DHTSLIB_PREFIX={htslib_prefix}", f"-DDORADO_INSTALL_PATH={self.prefix}"]
+        return args


### PR DESCRIPTION
I was working on this off and on for a while and someone beat me to adding a binary version.

This vendors several libraries, the bundled htslib I could not for the life of me get to compile. So I cut away at the build system a bit to make it use an htslib from spack.

This has been tested, and is supposedly faster than the binary version that one of our group was using in a container.