### PR TITLE
NWChem: add v7.2.2

### DIFF
--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -18,6 +18,11 @@ class Nwchem(Package):
     tags = ["ecp", "ecp-apps"]
 
     version(
+        "7.2.2",
+        sha256="6b68e9c12eec38c09d92472bdd1ff130b93c1b5e1f65e4702aa7ee36c80e4af7",
+        url="https://github.com/nwchemgit/nwchem/releases/download/v7.2.2-release/nwchem-7.2.2-release.revision-74936fb9-srconly.2023-11-03.tar.bz2",
+    )
+    version(
         "7.2.0",
         sha256="28ea70947e77886337c84e6fae3bdf88f25f0acfdeaf95e722615779c19f7a7e",
         url="https://github.com/nwchemgit/nwchem/releases/download/v7.2.0-release/nwchem-7.2.0-release.revision-d0d141fd-srconly.2023-03-10.tar.bz2",


### PR DESCRIPTION
Latest via `spack checksum`, with minor tweaking to shorten version string to just its numerical release/match prior versions.

