### PR TITLE
Add missing dependency for vcftools

### DIFF
--- a/var/spack/repos/builtin/packages/vcftools/package.py
+++ b/var/spack/repos/builtin/packages/vcftools/package.py
@@ -25,6 +25,7 @@ class Vcftools(AutotoolsPackage):
 
     depends_on("perl", type=("build", "run"))
     depends_on("zlib-api")
+    depends_on("pkg-config")
 
     # this needs to be in sync with what setup_run_environment adds to
     # PERL5LIB below

--- a/var/spack/repos/builtin/packages/vcftools/package.py
+++ b/var/spack/repos/builtin/packages/vcftools/package.py
@@ -25,7 +25,7 @@ class Vcftools(AutotoolsPackage):
 
     depends_on("perl", type=("build", "run"))
     depends_on("zlib-api")
-    depends_on("pkg-config")
+    depends_on("pkgconfig")
 
     # this needs to be in sync with what setup_run_environment adds to
     # PERL5LIB below


### PR DESCRIPTION
Without this my internal ci fails with:

```
     28    checking whether /spack/v0-21-0/lib/spack/env/gcc/gcc understands -c
            and -o together... yes
     29    checking dependency style of /spack/v0-21-0/lib/spack/env/gcc/gcc...
            gcc3
     30    checking how to run the C preprocessor... /spack/v0-21-0/lib/spack/e
           nv/gcc/gcc -E
     31    checking for perl... /usr/bin/perl
     32    checking for pkg-config... no
     33    checking for ZLIB... no
  >> 34    configure: error: in `/tmp/root/spack-stage/spack-stage-vcftools-0.1
           .16-okteqiwgxdba26lmsyacviksgqyazbnf/spack-src':
  >> 35    configure: error: The pkg-config script could not be found or is too
            old.  Make sure it
     36    is in your PATH or set the PKG_CONFIG environment variable to the fu
           ll
     37    path to pkg-config.
     38    
     39    Alternatively, you may set the environment variables ZLIB_CFLAGS
     40    and ZLIB_LIBS to avoid the need to call pkg-config.
     41    See the pkg-config man page for more details.
See build log for details:
```