### PR TITLE
bigdft: use -fPIC when building shared library

### DIFF
--- a/var/spack/repos/builtin/packages/bigdft-core/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-core/package.py
@@ -59,9 +59,16 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
         python_version = spec["python"].version.up_to(2)
         pyyaml = join_path(spec["py-pyyaml"].prefix.lib, f"python{python_version}")
 
-        openmp_flag = []
+        fcflags = []
+        cflags = []
+        cxxflags = []
         if "+openmp" in spec:
-            openmp_flag.append(self.compiler.openmp_flag)
+            fcflags.append(self.compiler.openmp_flag)
+
+        if spec.satisfies("+shared"):
+            fcflags.append("-fPIC")
+            cflags.append("-fPIC")
+            cxxflags.append("-fPIC")
 
         linalg = []
         if "+scalapack" in spec:
@@ -70,7 +77,9 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
         linalg.append(spec["blas"].libs.ld_flags)
 
         args = [
-            f"FCFLAGS={' '.join(openmp_flag)}",
+            f"FCFLAGS={' '.join(fcflags)}",
+            f"CFLAGS={' '.join(cflags)}",
+            f"CXXFLAGS={' '.join(cxxflags)}",
             f"--with-ext-linalg={' '.join(linalg)}",
             f"--with-pyyaml-path={pyyaml}",
             f"--with-futile-libs={spec['bigdft-futile'].libs.ld_flags}",

--- a/var/spack/repos/builtin/packages/bigdft-core/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-core/package.py
@@ -37,6 +37,7 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
     depends_on("lapack")
     depends_on("py-pyyaml")
     depends_on("libgain")
+    depends_on("libgain+shared", when="+shared")
     depends_on("mpi", when="+mpi")
     depends_on("scalapack", when="+scalapack")
     depends_on("openbabel", when="+openbabel")

--- a/var/spack/repos/builtin/packages/bigdft-spred/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-spred/package.py
@@ -52,9 +52,17 @@ class BigdftSpred(AutotoolsPackage):
         python_version = spec["python"].version.up_to(2)
         pyyaml = join_path(spec["py-pyyaml"].prefix.lib, f"python{python_version}")
 
-        openmp_flag = []
+        fcflags = []
+        cflags = []
+        cxxflags = []
+
         if "+openmp" in spec:
-            openmp_flag.append(self.compiler.openmp_flag)
+            fcflags.append(self.compiler.openmp_flag)
+
+        if spec.satisfies("+shared"):
+            fcflags.append("-fPIC")
+            cflags.append("-fPIC")
+            cxxflags.append("-fPIC")
 
         linalg = []
         if "+scalapack" in spec:
@@ -63,7 +71,9 @@ class BigdftSpred(AutotoolsPackage):
         linalg.append(spec["blas"].libs.ld_flags)
 
         args = [
-            f"FCFLAGS={' '.join(openmp_flag)}",
+            f"FCFLAGS={' '.join(fcflags)}",
+            f"CFLAGS={' '.join(cflags)}",
+            f"CXXFLAGS={' '.join(cxxflags)}",
             f"--with-ext-linalg={' '.join(linalg)}",
             f"--with-pyyaml-path={pyyaml}",
             f"--with-futile-libs={spec['bigdft-futile'].libs.ld_flags}",

--- a/var/spack/repos/builtin/packages/libgain/package.py
+++ b/var/spack/repos/builtin/packages/libgain/package.py
@@ -21,6 +21,9 @@ class Libgain(AutotoolsPackage):
         sha256="3e02637433272f5edfee74ea47abf93ab7e3f1ce717664d22329468a5bd45c3a",
         url="https://gitlab.com/l_sim/bigdft-suite/-/raw/1.9.1/GaIn-1.0.tar.gz",
     )
+    variant(
+        "shared", default=True, description="Build shared libraries"
+    )  # Not default in bigdft, but is typically the default expectation
 
     def configure_args(self):
         fcflags = []

--- a/var/spack/repos/builtin/packages/libgain/package.py
+++ b/var/spack/repos/builtin/packages/libgain/package.py
@@ -22,6 +22,23 @@ class Libgain(AutotoolsPackage):
         url="https://gitlab.com/l_sim/bigdft-suite/-/raw/1.9.1/GaIn-1.0.tar.gz",
     )
 
+    def configure_args(self):
+        fcflags = []
+        cflags = []
+        cxxflags = []
+
+        if self.spec.satisfies("+shared"):
+            fcflags.append("-fPIC")
+            cflags.append("-fPIC")
+            cxxflags.append("-fPIC")
+
+        args = [
+            f"FCFLAGS={' '.join(fcflags)}",
+            f"CFLAGS={' '.join(cflags)}",
+            f"CXXFLAGS={' '.join(cxxflags)}",
+        ]
+        return args
+
     @property
     def libs(self):
         shared = "+shared" in self.spec


### PR DESCRIPTION
The default behavior of bigdft-suite was updated to build as a shared library in https://github.com/spack/spack/pull/41562 . 
This however broke bigdft-spred as bigdft-suite doesn't compile with `-fPIC` by default and hence we need to add those compiler flags manually when building the shared library variant. I am not sure if this is something to be reported as a "bug" in the upstream package ( ie. build system design should be intelligent to do this on its own but their package doesn't). Im at the moment trying to fix that issue by manually adding the right flags when a shared library is built. 

The MR is in a draft state as it is still not compiling without errors and I need some time to solve that.