### PR TITLE
modules: Truncate configure options comment in tcl modules to 8192 ch…

### DIFF
--- a/share/spack/templates/modules/modulefile.tcl
+++ b/share/spack/templates/modules/modulefile.tcl
@@ -4,7 +4,7 @@
 ## {{ spec.short_spec }}
 ##
 {% if configure_options %}
-## Configure options: {{ configure_options | truncate(8192 - 23, True, "...", 0) }}
+## Configure options: {{ configure_options | wordwrap(8192 - 23, True, "\n##                    ", 0) }}
 ##
 {% endif %}
 

--- a/share/spack/templates/modules/modulefile.tcl
+++ b/share/spack/templates/modules/modulefile.tcl
@@ -4,7 +4,7 @@
 ## {{ spec.short_spec }}
 ##
 {% if configure_options %}
-## Configure options: {{ configure_options }}
+## Configure options: {{ configure_options | truncate(8192 - 23, True, "...", 0) }}
 ##
 {% endif %}
 


### PR DESCRIPTION
…aracter line length.

Since apparently beyond 8192 characters tcl starts treating it as a new line and errors out for invalid commands.