### PR TITLE
evtgen: add version 02.02.01

### DIFF
--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -17,6 +17,7 @@ class Evtgen(CMakePackage):
 
     maintainers("vvolkl")
 
+    version("02.02.01", sha256="1fcae56c6b27b89c4a2f4b224d27980607442185f5570e961f6334a3543c6e77")
     version("02.02.00", sha256="0c626e51cb17e799ad0ffd0beea5cb94d7ac8a5f8777b746aa1944dd26071ecf")
     version("02.00.00", sha256="02372308e1261b8369d10538a3aa65fe60728ab343fcb64b224dac7313deb719")
     # switched to cmake in 02.00.00
@@ -36,6 +37,7 @@ class Evtgen(CMakePackage):
 
     depends_on("hepmc", when="~hepmc3")
     depends_on("hepmc3", when="+hepmc3")
+    depends_on("pythia8@:8.309", when="@:02.02.00 +pythia8")
     depends_on("pythia8", when="+pythia8")
     depends_on("tauola~hepmc3", when="+tauola~hepmc3")
     depends_on("photos~hepmc3", when="+photos~hepmc3")


### PR DESCRIPTION
Based on commits on the git repository, this version should build with pythia 8.310. On AlmaLinux 9 it builds fine.

 The current latest version fails to build with pythia 8.310.