### PR TITLE
Quantum-Espresso: Add clock spec to display program time in seconds

### DIFF
--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -104,6 +104,9 @@ class QuantumEspresso(CMakePackage, Package):
     with when("+nvtx~cuda"):
         depends_on("cuda")
 
+    # CLOCK variant to display program time in seconds
+    variant("clock", default=False, description="Display program time in seconds")
+
     # Apply upstream patches by default. Variant useful for 3rd party
     # patches which are incompatible with upstream patches
     desc = "Apply recommended upstream patches. May need to be set "
@@ -426,6 +429,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             self.define_from_variant("QE_ENABLE_LIBXC", "libxc"),
             self.define_from_variant("QE_ENABLE_CUDA", "cuda"),
             self.define_from_variant("QE_ENABLE_PROFILE_NVTX", "nvtx"),
+            self.define_from_variant("QE_CLOCK_SECONDS", "clock"),
             self.define_from_variant("QE_ENABLE_MPI_GPU_AWARE", "mpigpu"),
         ]
 


### PR DESCRIPTION
The spec +clock maps the cmake option for program time in second.
The default is false as in the default of cmake.
This opton simplifies parsing the walltime from the logfile with regex patterns.