### PR TITLE
qt-base: fix xcb plugin not being built

### DIFF
--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -153,6 +153,13 @@ class QtBase(QtPackage):
             depends_on("libxkbcommon")
             depends_on("libxcb@1.13:")  # requires xinput
             depends_on("libxrender")
+            depends_on("libx11")
+            depends_on("xcb-util")
+            depends_on("xcb-util-cursor")
+            depends_on("xcb-util-image")
+            depends_on("xcb-util-keysyms")
+            depends_on("xcb-util-renderutil")
+            depends_on("xcb-util-wm")
 
     with when("+network"):
         depends_on("openssl")


### PR DESCRIPTION
Qt requires quite a few X11/xcb dependencies to be able to compile the xcb platform plugin. See https://doc.qt.io/qt-6/linux-requirements.html