### PR TITLE
visit: set minimum silo version to 4.11

### DIFF
--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -153,9 +153,8 @@ class Visit(CMakePackage):
 
     # VisIt uses Silo's 'ghost zone' data structures, which are only available
     # in v4.10+ releases: https://wci.llnl.gov/simulation/computer-codes/silo/releases/release-notes-4.10
-    depends_on("silo@4.10: +shared", when="+silo")
-    # When Conduit is enabled, there are build failures unless Silo v4.11+ is used
-    depends_on("silo@4.11:", when="+conduit")
+    # Silo versions < 4.11 do not build successfully with Spack
+    depends_on("silo@4.11: +shared", when="+silo")
     depends_on("silo+hdf5", when="+silo+hdf5")
     depends_on("silo~hdf5", when="+silo~hdf5")
     depends_on("silo+mpi", when="+silo+mpi")

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -154,6 +154,8 @@ class Visit(CMakePackage):
     # VisIt uses Silo's 'ghost zone' data structures, which are only available
     # in v4.10+ releases: https://wci.llnl.gov/simulation/computer-codes/silo/releases/release-notes-4.10
     depends_on("silo@4.10: +shared", when="+silo")
+    # When Conduit is enabled, there are build failures unless Silo v4.11+ is used
+    depends_on("silo@4.11:", when="+conduit")
     depends_on("silo+hdf5", when="+silo+hdf5")
     depends_on("silo~hdf5", when="+silo~hdf5")
     depends_on("silo+mpi", when="+silo+mpi")


### PR DESCRIPTION
This sets the minimum Silo version to 4.11, since Silo versions < 4.11 are broken.

The underlying problem is that the Spack package for Silo versions < 4.11 are broken and do not build. This should probably be fixed by removing those from the Silo package.