### PR TITLE
snakemake: add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-toposort/package.py
+++ b/var/spack/repos/builtin/packages/py-toposort/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/py-toposort/package.py
+++ b/var/spack/repos/builtin/packages/py-toposort/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -9,13 +9,20 @@ from spack.package import *
 class PyToposort(PythonPackage):
     """Implements a topological sort algorithm."""
 
-    pypi = "toposort/toposort-1.6.tar.gz"
+    pypi = "toposort/toposort-1.10.tar.gz"
 
     maintainers("marcusboden")
 
     license("Apache-2.0")
 
+    version("1.10", sha256="bfbb479c53d0a696ea7402601f4e693c97b0367837c8898bc6471adfca37a6bd")
+    version("1.9", sha256="f41a34490d44934b533a7bdaff979ee8a47203fd2d8a746db83f2d5ab12458b9")
+    version("1.8", sha256="b1e89996c43daaf0e03805d33df22333c99c9d36715b188dea0e551ce2f1cd81")
+    version("1.7", sha256="ddc2182c42912a440511bd7ff5d3e6a1cabc3accbc674a3258c8c41cbfbb2125")
     version("1.6", sha256="a7428f56ef844f5055bb9e9e44b343983773ae6dce0fe5b101e08e27ffbd50ac")
 
-    depends_on("python@2.7:2.8,3.3:", type=("build", "run"))
+    depends_on("python@3.8:", type=("build", "run"), when="@1.8:")
+    depends_on("python@2.7:2.8,3.3:", type=("build", "run"), when="@:1.8")
+
+    depends_on("py-setuptools@42:", type="build", when="@1.7:")
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/snakemake/package.py
+++ b/var/spack/repos/builtin/packages/snakemake/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/snakemake/package.py
+++ b/var/spack/repos/builtin/packages/snakemake/package.py
@@ -34,69 +34,59 @@ class Snakemake(PythonPackage):
     version("6.13.1", sha256="22f57dcd8b1ca8a30aaa45c5d2c0f56d381d4731abd0988f24f9de46b7d9827c")
     version("6.12.3", sha256="af86af9a540da3dceb05dad1040f1d3d733e6a695f8b3f8c30f8cf3bc6570a88")
 
-    # See https://github.com/snakemake/snakemake/blob/v7.30.2/setup.cfg#L34
-    depends_on("python@3.9:", type=("build", "run"), when="@7.30.2:7.31.1")
-    # See https://github.com/snakemake/snakemake/releases/tag/v7.31.1
-    depends_on("python@3.7:", type=("build", "run"), when="@7.31.1:7")
-    # See https://github.com/snakemake/snakemake/blob/v8.0.0/setup.cfg#L34
     depends_on("python@3.11:", type=("build", "run"), when="@8:")
+    depends_on("python@3.7:", type=("build", "run"), when="@7.31.1:7")
+    depends_on("python@3.9:", type=("build", "run"), when="@7.30.2:7.31.1")
 
-    depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-setuptools@42:", type=("build", "run"), when="@7:")
-
-    # See https://github.com/snakemake/snakemake/pull/2065
+    depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-tomli", type=("build"), when="@7.20.0: ^python@:3.10")
-    # See https://github.com/snakemake/snakemake/blob/v7.20.0/setup.cfg#L44
-    depends_on("py-humanfriendly", type=("build", "run"), when="@7.20.0:")
-    # See https://github.com/snakemake/snakemake/blob/v7.18.2/setup.py#L56
-    depends_on("py-wrapt", type=("build", "run"))
-    depends_on("py-requests", type=("build", "run"))
-    depends_on("py-throttler", type=("build", "run"), when="@7:")
-    depends_on("py-pyyaml", type=("build", "run"))
-    depends_on("py-configargparse", type=("build", "run"))
+    
     depends_on("py-appdirs", type=("build", "run"))
+    depends_on("py-configargparse", type=("build", "run"))
+    depends_on("py-connectionpool@0.0.3:", type=("build", "run"))
     depends_on("py-datrie", type=("build", "run"))
-    depends_on("py-jsonschema", type=("build", "run"))
     depends_on("py-docutils", type=("build", "run"))
     depends_on("py-gitpython", type=("build", "run"))
-    depends_on("py-psutil", type=("build", "run"))
+    depends_on("py-humanfriendly", type=("build", "run"), when="@7.20.0:")
+    depends_on("py-jinja2@3", type=("build", "run"), when="@7:")
+    depends_on("py-jsonschema", type=("build", "run"))
     depends_on("py-nbformat", type=("build", "run"))
-    # See https://github.com/snakemake/snakemake/blob/v7.24.0/setup.cfg#L57
-    depends_on("py-toposort@1.10:", type=("build", "run"), when="@7.24.0:")
-    depends_on("py-toposort", type=("build", "run"), when="@:7.23")
-    depends_on("py-connectionpool@0.0.3:", type=("build", "run"))
+    depends_on("py-packaging", type=("build", "run"), when="@7.29.0:")
+    depends_on("py-psutil", type=("build", "run"))
     depends_on("py-pulp@2:", type=("build", "run"))
+    depends_on("py-pyyaml", type=("build", "run"))
+    depends_on("py-requests", type=("build", "run"))
+    depends_on("py-reretry", type=("build", "run"), when="@7:")
     depends_on("py-smart-open@3:", type=("build", "run"))
-    depends_on("py-filelock", type=("build", "run"), when="@:6")
     depends_on("py-stopit", type=("build", "run"))
     depends_on("py-tabulate", type=("build", "run"))
-    depends_on("py-ratelimiter", type=("build", "run"), when="@:6")
-    # See https://github.com/snakemake/snakemake/blob/v7.28.1/setup.cfg#L59
+    depends_on("py-throttler", type=("build", "run"), when="@7:")
+    depends_on("py-toposort@1.10:", type=("build", "run"), when="@7.24.0:")
+    depends_on("py-toposort", type=("build", "run"), when="@:7.23")
+    depends_on("py-wrapt", type=("build", "run"))
     depends_on("py-yte@1.5.1:1", type=("build", "run"), when="@7.28.1:")
     depends_on("py-yte@1", type=("build", "run"), when="@7:7.28.0")
-    depends_on("py-jinja2@3", type=("build", "run"), when="@7:")
-    depends_on("py-reretry", type=("build", "run"), when="@7:")
-    # See https://github.com/snakemake/snakemake/blob/v7.28.0/setup.cfg#L60
-    depends_on("py-msrest", type=("build", "run"), when="@7.28.0")
-    # See https://github.com/snakemake/snakemake/blob/v7.29.0/setup.cfg#L48
-    depends_on("py-packaging", type=("build", "run"), when="@7.29.0:")
 
     variant("reports", default=False, description="Generate self-contained HTML reports")
+
     with when("+reports"):
-        depends_on("py-jinja2", type=("build", "run"), when="@:7.19.1")
         depends_on("py-pygments", type=("build", "run"))
-        # https://github.com/snakemake/snakemake/pull/1470
+        # Historical dependencies
+        depends_on("py-jinja2", type=("build", "run"), when="@:7.19.1")
         depends_on("py-networkx", type=("build", "run"), when="@:7.1.1")
         depends_on("py-pygraphviz", type=("build", "run"), when="@:7.1.1")
 
     variant("google-cloud", default=False, description="Enable Google Cloud execution")
+
     with when("+google-cloud"):
-        depends_on("py-oauth2client", type=("build", "run"))
-        depends_on("py-google-crc32c", type=("build", "run"))
         depends_on("py-google-api-python-client", type=("build", "run"))
         depends_on("py-google-cloud-storage", type=("build", "run"))
+        depends_on("py-google-crc32c", type=("build", "run"))
+        depends_on("py-oauth2client", type=("build", "run"))
 
     variant("azure", default=False, description="Enable Azure execution", when="@7.28.0:")
+
     with when("+azure"):
         depends_on("py-azure-storage-blob", type=("build", "run"))
         depends_on("py-azure-batch", type=("build", "run"))
@@ -104,8 +94,14 @@ class Snakemake(PythonPackage):
         depends_on("py-azure-identity", type=("build", "run"))
         depends_on("py-azure-mgmt-batch", type=("build", "run"))
 
+    # Historical dependencies
+    depends_on("py-msrest", type=("build", "run"), when="@7.28.0")
+    depends_on("py-filelock", type=("build", "run"), when="@:6")
+    depends_on("py-ratelimiter", type=("build", "run"), when="@:6")
+
     # These variants are not in PyPI/pip, but they are undocumented dependencies
     # needed to make certain parts of Snakemake work.
+
     variant("ftp", default=False, description="Enable snakemake.remote.FTP")
     depends_on("py-ftputil", when="+ftp", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/snakemake/package.py
+++ b/var/spack/repos/builtin/packages/snakemake/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -10,11 +10,20 @@ class Snakemake(PythonPackage):
     """Snakemake is an MIT-licensed workflow management system."""
 
     homepage = "https://snakemake.readthedocs.io/en/stable/"
-    pypi = "snakemake/snakemake-6.12.3.tar.gz"
+    pypi = "snakemake/snakemake-7.32.4.tar.gz"
     maintainers("marcusboden")
 
     license("MIT")
 
+    version("7.32.4", sha256="fdc3f15dd7b06fabb7da30d460e0a3b1fba08e4ea91f9c32c47a83705cdc7b6e")
+    version("7.31.1", sha256="6fadcc9a051737aa187dccf437879b3b83ddc917fff9bd7d400e056cf17a1788")
+    version("7.30.2", sha256="0cb86cf9b43b9f2f45d5685cd932595131031c7087690f64c5bc7eaec88df029")
+    version("7.29.0", sha256="c420a545924b599390efe9e2fa7a07c01d167cceac63d1d06fa6eff5e7b43be0")
+    version("7.28.3", sha256="4d0d5f9643d97154cd8925830bdb3922e4bd9cfcf7f8b619df75e4ddfdbc3f9e")
+    version("7.26.0", sha256="5e5b4750a943f73a1b62979ccac203f4bc87876559f5e44d0ce9305ac198aff0")
+    version("7.25.4", sha256="e89146fd0df196a9135dcf41c9c70841551aa4735a18da9e0402bda6746afdcc")
+    version("7.24.2", sha256="3e9bcbb9743aa2a073922e90659e9209edbea89e6d22bf7b29ea538e60983908")
+    version("7.23.1", sha256="4dc960a721d2d8eaebd9b10e56564e3742f78c65d36cd31966ed205afcc4253d")
     version("7.22.0", sha256="68d7bb4ab7555f7b58a3ba748a880024df919042cfb670da231886385de697cd")
     version("7.21.0", sha256="ebf91f4ca5c70809fcbfd2e8cbc982096cdadac1ec34138bb147b4a8c975c85b")
     version("7.20.0", sha256="f5b45191f1d419ebf28606880cb9bfac3bfa7c5949d1d2b64f551586d4212a2a")
@@ -24,6 +33,13 @@ class Snakemake(PythonPackage):
     version("6.15.1", sha256="a219601d57037f565ead9963e6bd8d04d3bdd985d172371e54197dcbdba79865")
     version("6.13.1", sha256="22f57dcd8b1ca8a30aaa45c5d2c0f56d381d4731abd0988f24f9de46b7d9827c")
     version("6.12.3", sha256="af86af9a540da3dceb05dad1040f1d3d733e6a695f8b3f8c30f8cf3bc6570a88")
+
+    # See https://github.com/snakemake/snakemake/blob/v7.30.2/setup.cfg#L34
+    depends_on("python@3.9:", type=("build", "run"), when="@7.30.2:7.31.1")
+    # See https://github.com/snakemake/snakemake/releases/tag/v7.31.1
+    depends_on("python@3.7:", type=("build", "run"), when="@7.31.1:7")
+    # See https://github.com/snakemake/snakemake/blob/v8.0.0/setup.cfg#L34
+    depends_on("python@3.11:", type=("build", "run"), when="@8:")
 
     depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-setuptools@42:", type=("build", "run"), when="@7:")
@@ -45,7 +61,9 @@ class Snakemake(PythonPackage):
     depends_on("py-gitpython", type=("build", "run"))
     depends_on("py-psutil", type=("build", "run"))
     depends_on("py-nbformat", type=("build", "run"))
-    depends_on("py-toposort", type=("build", "run"))
+    # See https://github.com/snakemake/snakemake/blob/v7.24.0/setup.cfg#L57
+    depends_on("py-toposort@1.10:", type=("build", "run"), when="@7.24.0:")
+    depends_on("py-toposort", type=("build", "run"), when="@:7.23")
     depends_on("py-connectionpool@0.0.3:", type=("build", "run"))
     depends_on("py-pulp@2:", type=("build", "run"))
     depends_on("py-smart-open@3:", type=("build", "run"))
@@ -53,9 +71,15 @@ class Snakemake(PythonPackage):
     depends_on("py-stopit", type=("build", "run"))
     depends_on("py-tabulate", type=("build", "run"))
     depends_on("py-ratelimiter", type=("build", "run"), when="@:6")
-    depends_on("py-yte@1", type=("build", "run"), when="@7:")
+    # See https://github.com/snakemake/snakemake/blob/v7.28.1/setup.cfg#L59
+    depends_on("py-yte@1.5.1:1", type=("build", "run"), when="@7.28.1:")
+    depends_on("py-yte@1", type=("build", "run"), when="@7:7.28.0")
     depends_on("py-jinja2@3", type=("build", "run"), when="@7:")
     depends_on("py-reretry", type=("build", "run"), when="@7:")
+    # See https://github.com/snakemake/snakemake/blob/v7.28.0/setup.cfg#L60
+    depends_on("py-msrest", type=("build", "run"), when="@7.28.0")
+    # See https://github.com/snakemake/snakemake/blob/v7.29.0/setup.cfg#L48
+    depends_on("py-packaging", type=("build", "run"), when="@7.29.0:")
 
     variant("reports", default=False, description="Generate self-contained HTML reports")
     with when("+reports"):
@@ -71,6 +95,14 @@ class Snakemake(PythonPackage):
         depends_on("py-google-crc32c", type=("build", "run"))
         depends_on("py-google-api-python-client", type=("build", "run"))
         depends_on("py-google-cloud-storage", type=("build", "run"))
+
+    variant("azure", default=False, description="Enable Azure execution", when="@7.28.0:")
+    with when("+azure"):
+        depends_on("py-azure-storage-blob", type=("build", "run"))
+        depends_on("py-azure-batch", type=("build", "run"))
+        depends_on("py-azure-core", type=("build", "run"))
+        depends_on("py-azure-identity", type=("build", "run"))
+        depends_on("py-azure-mgmt-batch", type=("build", "run"))
 
     # These variants are not in PyPI/pip, but they are undocumented dependencies
     # needed to make certain parts of Snakemake work.

--- a/var/spack/repos/builtin/packages/snakemake/package.py
+++ b/var/spack/repos/builtin/packages/snakemake/package.py
@@ -41,7 +41,7 @@ class Snakemake(PythonPackage):
     depends_on("py-setuptools@42:", type=("build", "run"), when="@7:")
     depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-tomli", type=("build"), when="@7.20.0: ^python@:3.10")
-    
+
     depends_on("py-appdirs", type=("build", "run"))
     depends_on("py-configargparse", type=("build", "run"))
     depends_on("py-connectionpool@0.0.3:", type=("build", "run"))


### PR DESCRIPTION
Tested that all added `py-toposort` and `snakemake` versions install successfully.

Tested latest added `snakemake@7.32.4` version in a working project.