### PR TITLE
Fix packages inheriting GROMACS, add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.pkg.builtin.gromacs import Gromacs
+from spack.pkg.builtin.gromacs import Gromacs, CMakeBuilder as GromacsCMakeBuilder
 
 
 class GromacsChainCoordinate(Gromacs):
@@ -14,11 +14,17 @@ class GromacsChainCoordinate(Gromacs):
     """
 
     homepage = "https://gitlab.com/cbjh/gromacs-chain-coordinate/-/blob/main/README.md"
-    url = "https://gitlab.com/cbjh/gromacs-chain-coordinate/-/archive/release-2021.chaincoord-0.2/gromacs-chain-coordinate-release-2021.chaincoord-0.2.tar.bz2"
+    url = "https://gitlab.com/cbjh/gromacs-chain-coordinate/-/archive/release-2021.chaincoord-0.3/gromacs-chain-coordinate-release-2021.chaincoord-0.3.tar.bz2"
     git = "https://gitlab.com/cbjh/gromacs-chain-coordinate.git"
     maintainers("w8jcik")
 
     version("main", branch="main")
+
+    version(
+        "2021.5-0.3",
+        sha256="64ec5f385445ae43dfec8c27198034c0ba641863ab856c8c29798a4c83016baa",
+        url="https://gitlab.com/cbjh/gromacs-chain-coordinate/-/archive/release-2021.chaincoord-0.3/gromacs-chain-coordinate-release-2021.chaincoord-0.3.tar.bz2",
+    )
 
     version(
         "2021.5-0.2",
@@ -56,3 +62,7 @@ class GromacsChainCoordinate(Gromacs):
                 self._if_make_target_execute("check")
             elif self.generator == "Ninja":
                 self._if_ninja_target_execute("check")
+
+
+class CMakeBuilder(GromacsCMakeBuilder):
+    pass

--- a/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.pkg.builtin.gromacs import Gromacs, CMakeBuilder as GromacsCMakeBuilder
+from spack.pkg.builtin.gromacs import CMakeBuilder as GromacsCMakeBuilder
+from spack.pkg.builtin.gromacs import Gromacs
 
 
 class GromacsChainCoordinate(Gromacs):

--- a/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.pkg.builtin.gromacs import Gromacs, CMakeBuilder as GromacsCMakeBuilder
+from spack.pkg.builtin.gromacs import CMakeBuilder as GromacsCMakeBuilder
+from spack.pkg.builtin.gromacs import Gromacs
 
 
 class GromacsSwaxs(Gromacs):

--- a/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
@@ -4,16 +4,22 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.pkg.builtin.gromacs import Gromacs
+from spack.pkg.builtin.gromacs import Gromacs, CMakeBuilder as GromacsCMakeBuilder
 
 
 class GromacsSwaxs(Gromacs):
     """Modified Gromacs for small-angle scattering calculations (SAXS/WAXS/SANS)"""
 
     homepage = "https://biophys.uni-saarland.de/swaxs.html"
-    url = "https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2019.swaxs-0.1/gromacs-swaxs-release-2019.swaxs-0.1.tar.bz2"
+    url = "https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2021.swaxs-0.5/gromacs-swaxs-release-2021.swaxs-0.5.tar.bz2"
     git = "https://gitlab.com/cbjh/gromacs-swaxs.git"
     maintainers("w8jcik")
+
+    version(
+        "2021.5-0.5",
+        sha256="7207f107dc6c4009a04a533e18545666d4f58c172b2b24d04442bb1a0f43ff44",
+        url="https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2021.swaxs-0.5/gromacs-swaxs-release-2021.swaxs-0.5.tar.bz2",
+    )
 
     version(
         "2021.5-0.4",
@@ -151,3 +157,7 @@ class GromacsSwaxs(Gromacs):
         super().__init__(spec)
 
         self.remove_parent_versions()
+
+
+class CMakeBuilder(GromacsCMakeBuilder):
+    pass


### PR DESCRIPTION
Without the change package variants are ignored when installing `gromacs-swaxs` or `gromacs-chain-coordinate`.

For example GPU-support is silently disabled.