### PR TITLE
py-nglview: add new package and dependency (py-versioneer-518)

### DIFF
--- a/var/spack/repos/builtin/packages/py-nglview/package.py
+++ b/var/spack/repos/builtin/packages/py-nglview/package.py
@@ -21,5 +21,5 @@ class PyNglview(PythonPackage):
     depends_on("py-numpy", type=("build", "run"))
 
     depends_on("py-setuptools@40.8.0:", type="build")
-    depends_on("py-jupyter-packaging@0.7.9:0.7", type="build")
+    depends_on("py-jupyter-packaging@0.7.9:0.7", type=("build", "run"))
     depends_on("py-versioneer-518", type="build")

--- a/var/spack/repos/builtin/packages/py-nglview/package.py
+++ b/var/spack/repos/builtin/packages/py-nglview/package.py
@@ -16,10 +16,10 @@ class PyNglview(PythonPackage):
 
     version("3.0.8", sha256="f9e468cd813dac319cbeca6ae20ae099008ff3a06399f5d23d75582dde28623a")
 
-    depends_on("py-ipywidgets@7:", type="run")
-    depends_on("py-jupyterlab-widgets", type="run")
+    depends_on("py-ipywidgets@7:", type=("build", "run"))
+    depends_on("py-jupyterlab-widgets", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
 
     depends_on("py-setuptools@40.8.0:", type="build")
-    depends_on("py-jupyter-packaging@0.7.9:0.7", type=("build", "run"))
+    depends_on("py-jupyter-packaging@0.7.9:0.7", type="build")
     depends_on("py-versioneer-518", type="build")

--- a/var/spack/repos/builtin/packages/py-nglview/package.py
+++ b/var/spack/repos/builtin/packages/py-nglview/package.py
@@ -10,16 +10,17 @@ class PyNglview(PythonPackage):
     """Jupyter widget to interactively view molecular structures and trajectories."""
 
     homepage = "http://nglviewer.org"
-    pypi = "nglview/nglview-3.1.1.tar.gz"
+    pypi = "nglview/nglview-3.0.8.tar.gz"
 
-    version("3.1.1", sha256="71c61a69c2d459ee93b40698fa54ad9cc793003d3dbbbb520e9a61975813c1cd")
+    maintainers("w8jcik")
 
-    depends_on("py-ipywidgets@8:", type="run")
+    version("3.0.8", sha256="f9e468cd813dac319cbeca6ae20ae099008ff3a06399f5d23d75582dde28623a")
+
+    depends_on("py-ipywidgets@7:", type="run")
     depends_on("py-jupyterlab-widgets", type="run")
     depends_on("py-numpy", type="run")
-    depends_on("py-notebook@7:", type="run")
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools@40.8.0:", type="build")
-    depends_on("py-jupyter-packaging@0.7:", type="build")
+    depends_on("py-jupyter-packaging@0.7", type="build")
     depends_on("py-versioneer", type="build")

--- a/var/spack/repos/builtin/packages/py-nglview/package.py
+++ b/var/spack/repos/builtin/packages/py-nglview/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyNglview(PythonPackage):
+    """Jupyter widget to interactively view molecular structures and trajectories."""
+
+    homepage = "http://nglviewer.org"
+    pypi = "nglview/nglview-3.1.1.tar.gz"
+
+    version("3.1.1", sha256="71c61a69c2d459ee93b40698fa54ad9cc793003d3dbbbb520e9a61975813c1cd")
+
+    depends_on("py-ipywidgets@8:", type="run")
+    depends_on("py-jupyterlab-widgets", type="run")
+    depends_on("py-numpy", type="run")
+    depends_on("py-notebook@7:", type="run")
+
+    depends_on("python@3.6:", type=("build", "run"))
+    depends_on("py-setuptools@40.8.0:", type="build")
+    depends_on("py-jupyter-packaging@0.7:", type="build")
+    depends_on("py-versioneer", type="build")

--- a/var/spack/repos/builtin/packages/py-nglview/package.py
+++ b/var/spack/repos/builtin/packages/py-nglview/package.py
@@ -18,9 +18,8 @@ class PyNglview(PythonPackage):
 
     depends_on("py-ipywidgets@7:", type="run")
     depends_on("py-jupyterlab-widgets", type="run")
-    depends_on("py-numpy", type="run")
+    depends_on("py-numpy", type=("build", "run"))
 
-    depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools@40.8.0:", type="build")
     depends_on("py-jupyter-packaging@0.7.9:0.7", type="build")
     depends_on("py-versioneer-518", type="build")

--- a/var/spack/repos/builtin/packages/py-nglview/package.py
+++ b/var/spack/repos/builtin/packages/py-nglview/package.py
@@ -22,5 +22,5 @@ class PyNglview(PythonPackage):
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools@40.8.0:", type="build")
-    depends_on("py-jupyter-packaging@0.7", type="build")
+    depends_on("py-jupyter-packaging@0.7.9:0.7", type="build")
     depends_on("py-versioneer-518", type="build")

--- a/var/spack/repos/builtin/packages/py-nglview/package.py
+++ b/var/spack/repos/builtin/packages/py-nglview/package.py
@@ -23,4 +23,4 @@ class PyNglview(PythonPackage):
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools@40.8.0:", type="build")
     depends_on("py-jupyter-packaging@0.7", type="build")
-    depends_on("py-versioneer", type="build")
+    depends_on("py-versioneer-518", type="build")

--- a/var/spack/repos/builtin/packages/py-versioneer-518/package.py
+++ b/var/spack/repos/builtin/packages/py-versioneer-518/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyVersioneer518(PythonPackage):
+    """Versioneer is a tool to automatically update version strings by
+    asking your version-control system about the current tree."""
+
+    homepage = "https://github.com/python-versioneer/versioneer-518"
+    pypi = "versioneer-518/versioneer-518-0.19.tar.gz"
+    git = "https://github.com/python-versioneer/versioneer-518.git"
+
+    version("518-0.19", sha256="a287608997415f45401849d1227a42bb41b80a6e4a7da5776666f85ce6faec41")
+
+    depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-versioneer-518/package.py
+++ b/var/spack/repos/builtin/packages/py-versioneer-518/package.py
@@ -14,6 +14,6 @@ class PyVersioneer518(PythonPackage):
     pypi = "versioneer-518/versioneer-518-0.19.tar.gz"
     git = "https://github.com/python-versioneer/versioneer-518.git"
 
-    version("518-0.19", sha256="a287608997415f45401849d1227a42bb41b80a6e4a7da5776666f85ce6faec41")
+    version("0.19", sha256="a287608997415f45401849d1227a42bb41b80a6e4a7da5776666f85ce6faec41")
 
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
Jupyter widget to interactively view molecular structures and trajectories.

Tested by installing with `spack install py-nglview` and importing in a Jupyter notebook

```
import nglview

nglview.show_structure_file("1lys.pdb")
```