### PR TITLE
intel-oneapi-mkl: add missing compiler libraries for thread=openmp

### DIFF
--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -9,7 +9,7 @@ import platform
 import shutil
 from os.path import basename, isdir
 
-from llnl.util.filesystem import HeaderList, find_libraries, join_path, mkdirp
+from llnl.util.filesystem import HeaderList, LibraryList, find_libraries, join_path, mkdirp
 from llnl.util.link_tree import LinkTree
 
 from spack.directives import conflicts, variant
@@ -194,6 +194,45 @@ class IntelOneApiLibraryPackage(IntelOneApiPackage):
     def libs(self):
         # for v2_layout all libraries are in the top level, v1 sometimes put them in intel64
         return find_libraries("*", root=self.component_prefix.lib, recursive=not self.v2_layout)
+
+    @property
+    def openmp_libs(self):
+        """Supply LibraryList for linking OpenMP"""
+
+        if "%intel" in self.spec:
+            # NB: Hunting down explicit library files may be the Spack way of
+            # doing things, but be aware that "{icc|ifort} --help openmp"
+            # steers us towards options instead: -qopenmp-link={dynamic,static}
+
+            omp_libnames = ["libiomp5"]
+            omp_libs = find_libraries(
+                omp_libnames,
+                root=self.component_lib_dir("compiler"),
+                shared=("+shared" in self.spec),
+            )
+            # Note about search root here: For MKL, the directory
+            # "$MKLROOT/../compiler" will be present even for an MKL-only
+            # product installation (as opposed to one being ghosted via
+            # packages.yaml), specificially to provide the 'iomp5' libs.
+
+        elif "%gcc" in self.spec:
+            with self.compiler.compiler_environment():
+                omp_lib_path = Executable(self.compiler.cc)(
+                    "--print-file-name", "libgomp.%s" % dso_suffix, output=str
+                )
+            omp_libs = LibraryList(omp_lib_path.strip())
+
+        elif "%clang" in self.spec:
+            with self.compiler.compiler_environment():
+                omp_lib_path = Executable(self.compiler.cc)(
+                    "--print-file-name", "libomp.%s" % dso_suffix, output=str
+                )
+            omp_libs = LibraryList(omp_lib_path.strip())
+
+        if len(omp_libs) < 1:
+            raise_lib_error("Cannot locate OpenMP libraries:", omp_libnames)
+
+        return omp_libs
 
 
 class IntelOneApiLibraryPackageWithSdk(IntelOneApiPackage):

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -178,7 +178,12 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
                 libs.append("libmkl_intel_thread")
             else:
                 libs.append("libmkl_gnu_thread")
-            threading_libs += self.openmp_libs
+
+            # this is slightly different than what link-line advisor suggests.
+            # here it uses what the compiler suggests to use to enable openmp,
+            # instead of being explicit about in which path openmp libraries
+            # are located (e.g. intel libiomp5, gcc libgomp, clang libomp).
+            threading_libs += [self.compiler.openmp_flag]
         else:
             libs.append("libmkl_sequential")
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -165,7 +165,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
 
     def _find_mkl_libs(self, shared):
         libs = []
-        resolved_libs = []
+        threading_libs = []
 
         if self.spec.satisfies("+cluster"):
             libs.extend([self._xlp64_lib("libmkl_scalapack"), "libmkl_cdft_core"])
@@ -178,7 +178,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
                 libs.append("libmkl_intel_thread")
             else:
                 libs.append("libmkl_gnu_thread")
-            resolved_libs = self.openmp_libs
+            threading_libs += self.openmp_libs
         else:
             libs.append("libmkl_sequential")
 
@@ -214,7 +214,10 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         )
         lib_path = lib_path if isdir(lib_path) else dirname(lib_path)
 
-        resolved_libs += find_libraries(libs, lib_path, shared=shared)
+        # resolved_libs is populated as follows
+        # MKL-related + MPI-related + threading-related
+        resolved_libs = find_libraries(libs, lib_path, shared=shared)
+
         # Add MPI libraries for cluster support. If MPI is not in the
         # spec, then MKL is externally installed and application must
         # link with MPI libaries. If MPI is in spec, but there are no
@@ -225,6 +228,9 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
                 resolved_libs = resolved_libs + self.spec["mpi"].libs
         except spack.error.NoLibrariesError:
             pass
+
+        resolved_libs += threading_libs
+
         return resolved_libs
 
     def _xlp64_lib(self, lib):

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -165,6 +165,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
 
     def _find_mkl_libs(self, shared):
         libs = []
+        resolved_libs = []
 
         if self.spec.satisfies("+cluster"):
             libs.extend([self._xlp64_lib("libmkl_scalapack"), "libmkl_cdft_core"])
@@ -177,6 +178,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
                 libs.append("libmkl_intel_thread")
             else:
                 libs.append("libmkl_gnu_thread")
+            resolved_libs = self.openmp_libs
         else:
             libs.append("libmkl_sequential")
 
@@ -212,7 +214,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         )
         lib_path = lib_path if isdir(lib_path) else dirname(lib_path)
 
-        resolved_libs = find_libraries(libs, lib_path, shared=shared)
+        resolved_libs += find_libraries(libs, lib_path, shared=shared)
         # Add MPI libraries for cluster support. If MPI is not in the
         # spec, then MKL is externally installed and application must
         # link with MPI libaries. If MPI is in spec, but there are no


### PR DESCRIPTION
This is somehow a follow up of #37637, where MKL libraries related to threading were added, but some compiler-related libraries suggested by the link-line advisor were still missing.

This PR adds the missing threading-related compiler libraries to fix OpenMP support for both GNU and Intel compilers.

Changelog:
- ~main logic has been copy-pasted from old MKL~ rely on compiler to enable OpenMP as a follow up of #38719 (slightly different than what link-line advisor suggests).
- important detail: the `intel-oneapi-mkl` package logic has been slightly adapted in order to end up having the correct linking order, i.e. "{MKL} {MPI} {compiler} {system}".