### PR TITLE
string not String

### DIFF
--- a/var/spack/repos/builtin/packages/itensor/package.py
+++ b/var/spack/repos/builtin/packages/itensor/package.py
@@ -80,10 +80,10 @@ class Itensor(MakefilePackage):
                 vinc += " -fpermissive"
             vinc += " -DHAVE_LAPACK_CONFIG_H"
             vinc += " -DLAPACK_COMPLEX_STRUCTURE"
-            filter_file("#PLATFORM=lapack", vinc, mf, String=True)
+            filter_file("#PLATFORM=lapack", vinc, mf, string=True)
         elif ltype == "intel-mkl":
             vpla = "PLATFORM=mkl"
-            filter_file("#PLATFORM=lapack", vinc, mf, String=True)
+            filter_file("#PLATFORM=lapack", vinc, mf, string=True)
 
         filter_file(r"^PLATFORM.+", vpla, mf)
         filter_file(r"^BLAS_LAPACK_LIBFLAGS.+", vlib, mf)

--- a/var/spack/repos/builtin/packages/skilion-onedrive/package.py
+++ b/var/spack/repos/builtin/packages/skilion-onedrive/package.py
@@ -28,7 +28,7 @@ class SkilionOnedrive(MakefilePackage):
         makefile.filter("$(shell git describe --tags)", "{0}".format(spec.version), string=True)
         # Patch sqlite.d https://github.com/skilion/onedrive/issues/392
         sqlited = FileFilter("src/sqlite.d")
-        sqlited.filter("std.c.stdlib", "core.stdc.stdlib", String=True)
+        sqlited.filter("std.c.stdlib", "core.stdc.stdlib", string=True)
 
     def build(self, spec, prefix):
         make("onedrive", "DESTDIR={0}".format(prefix), "PREFIX=/")


### PR DESCRIPTION
The signature of filter_file is

```
def filter_file(
    regex: str,
    repl: Union[str, Callable[[Match], str]],
    *filenames: str,
    string: bool = False,
    backup: bool = False,
    ignore_absent: bool = False,
    start_at: Optional[str] = None,
    stop_at: Optional[str] = None,
)
```

String should be string. Credit to Adam Stewart.