### PR TITLE
spack graph: slight change in behavior

### DIFF
--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -18,7 +18,14 @@ level = "long"
 
 def setup_parser(subparser):
     setup_parser.parser = subparser
+    subparser.epilog = """
+Outside of an environment, the command concretizes specs and graphs them, unless the
+--installed option is given. In that case specs are matched from the current DB.
 
+If an environment is active, specs are matched from the currently available concrete specs
+in the lockfile.
+
+"""
     method = subparser.add_mutually_exclusive_group()
     method.add_argument(
         "-a", "--ascii", action="store_true", help="draw graph as ascii to stdout (default)"
@@ -41,36 +48,46 @@ def setup_parser(subparser):
     )
 
     subparser.add_argument(
-        "-i",
-        "--installed",
-        action="store_true",
-        help="graph installed specs, or specs in the active env (implies --dot)",
+        "-i", "--installed", action="store_true", help="graph specs from the DB"
     )
 
     arguments.add_common_arguments(subparser, ["deptype", "specs"])
 
 
 def graph(parser, args):
-    if args.installed and args.specs:
-        tty.die("cannot specify specs with --installed")
+    env = ev.active_environment()
+    if args.installed and env:
+        tty.die("cannot use --installed with an active environment")
+
+    if args.installed and args.ascii:
+        tty.die("cannot use --installed with --ascii")
+
+    if env and args.ascii:
+        tty.die("cannot use --ascii with an active environment")
 
     if args.color and not args.dot:
         tty.die("the --color option can be used only with --dot")
 
     if args.installed:
         args.dot = True
-        env = ev.active_environment()
-        if env:
-            specs = env.concrete_roots()
-        else:
+        if not args.specs:
             specs = spack.store.STORE.db.query()
+        else:
+            result = []
+            for item in args.specs:
+                result.extend(spack.store.STORE.db.query(item))
+            specs = list(set(result))
+    elif env:
+        args.dot = True
+        specs = env.concrete_roots()
+        if args.specs:
+            specs = [x for x in specs if any(x.satisfies(req) for req in args.specs)]
 
     else:
         specs = spack.cmd.parse_specs(args.specs, concretize=not args.static)
 
     if not specs:
-        setup_parser.parser.print_help()
-        return 1
+        tty.die("no spec matching the query")
 
     if args.static:
         args.dot = True

--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -59,17 +59,10 @@ def graph(parser, args):
     if args.installed and env:
         tty.die("cannot use --installed with an active environment")
 
-    if args.installed and args.ascii:
-        tty.die("cannot use --installed with --ascii")
-
-    if env and args.ascii:
-        tty.die("cannot use --ascii with an active environment")
-
     if args.color and not args.dot:
         tty.die("the --color option can be used only with --dot")
 
     if args.installed:
-        args.dot = True
         if not args.specs:
             specs = spack.store.STORE.db.query()
         else:
@@ -78,10 +71,9 @@ def graph(parser, args):
                 result.extend(spack.store.STORE.db.query(item))
             specs = list(set(result))
     elif env:
-        args.dot = True
         specs = env.concrete_roots()
         if args.specs:
-            specs = [x for x in specs if any(x.satisfies(req) for req in args.specs)]
+            specs = env.all_matching_specs(*args.specs)
 
     else:
         specs = spack.cmd.parse_specs(args.specs, concretize=not args.static)
@@ -90,7 +82,6 @@ def graph(parser, args):
         tty.die("no spec matching the query")
 
     if args.static:
-        args.dot = True
         static_graph_dot(specs, depflag=args.deptype)
         return
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1876,7 +1876,7 @@ complete -c spack -n '__fish_spack_using_command graph' -s s -l static -d 'graph
 complete -c spack -n '__fish_spack_using_command graph' -s c -l color -f -a color
 complete -c spack -n '__fish_spack_using_command graph' -s c -l color -d 'use different colors for different dependency types'
 complete -c spack -n '__fish_spack_using_command graph' -s i -l installed -f -a installed
-complete -c spack -n '__fish_spack_using_command graph' -s i -l installed -d 'graph installed specs, or specs in the active env (implies --dot)'
+complete -c spack -n '__fish_spack_using_command graph' -s i -l installed -d 'graph specs from the DB'
 complete -c spack -n '__fish_spack_using_command graph' -l deptype -r -f -a deptype
 complete -c spack -n '__fish_spack_using_command graph' -l deptype -r -d 'comma-separated list of deptypes to traverse (default=build,link,run,test)'
 


### PR DESCRIPTION
Currently the `spack graph` command behaves in "unexpected" ways, when environments are involved:
1. An active environment is disregarded, when specs are given
2. The full active environment is shown with `--installed` (even if the specs are just concretized and not yet installed)

On top of that, `--installed` doesn't allow filtering the result via `args.specs`. 

### Modifications

This PR changes the behavior so that:
1. `spack graph` is environment aware by default
2. `--installed` can be used only outside of an environment
3. `args.specs` act as filters both when using an environment and when using `--installed`

<details>

<summary>Examples</summary>

To concretize a spec and print a graph in dot format:
```console
$ spack -E graph -d hdf5
...
```
To print the whole concrete environment from `spack.lock`:
```console
$ spack -e . graph -d
...
```
To print a few selected roots from `spack.lock`:
```console
$ spack -e . graph -d hdf5
...
```
To print the whole database:
```console
$ spack -E graph -i
```
To filter a few specs from the current DB:
```console
$ spack -E graph -i hdf5 cp2k
```

</details>