### PR TITLE
rocksdb: fix build error when LUA_PATH and LUA_CPATH are set

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -217,6 +217,9 @@ def clean_environment():
     env.unset("R_HOME")
     env.unset("R_ENVIRON")
 
+    env.unset("LUA_PATH")
+    env.unset("LUA_CPATH")
+
     # Affects GNU make, can e.g. indirectly inhibit enabling parallel build
     # env.unset('MAKEFLAGS')
 

--- a/var/spack/repos/builtin/packages/rocksdb/package.py
+++ b/var/spack/repos/builtin/packages/rocksdb/package.py
@@ -60,6 +60,10 @@ class Rocksdb(MakefilePackage):
     def patch(self):
         filter_file("-march=native", "", join_path("build_tools", "build_detect_platform"))
 
+    def setup_build_environment(self, env):
+        env.unset("LUA_PATH")
+        env.unset("LUA_CPATH")
+
     def install(self, spec, prefix):
         cflags = []
         ldflags = []

--- a/var/spack/repos/builtin/packages/rocksdb/package.py
+++ b/var/spack/repos/builtin/packages/rocksdb/package.py
@@ -60,10 +60,6 @@ class Rocksdb(MakefilePackage):
     def patch(self):
         filter_file("-march=native", "", join_path("build_tools", "build_detect_platform"))
 
-    def setup_build_environment(self, env):
-        env.unset("LUA_PATH")
-        env.unset("LUA_CPATH")
-
     def install(self, spec, prefix):
         cflags = []
         ldflags = []


### PR DESCRIPTION
This PR fixes https://github.com/spack/spack/issues/28884.

For some reason RocksDB's Makefile uses LUA_PATH and LUA_CPATH even though RocksDB doesn't use Lua, and it fails because it finds "?" in these paths. This PR corrects this by unsetting these variables in `setup_build_environment`.