### PR TITLE
cc: work around -v split between ld and ccld

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -283,10 +283,19 @@ esac
 if [ -z "$mode" ] || [ "$mode" = ld ]; then
     for arg in "$@"; do
         case $arg in
-            -v|-V|--version|-dumpversion)
+            -V|--version|-dumpversion)
                 mode=vcheck
                 break
                 ;;
+            -v)
+                # NOTE(trws): -v is verbose on gcc, not version, this is an ld-mode flag only
+                # -V is invalid on gcc but may be valid on some other compiler so leaving that in
+                case "$mode" in
+                    ld)
+                        mode=vcheck
+                        break
+                        ;;
+                esac
         esac
     done
 fi

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -244,10 +244,10 @@ def test_no_wrapper_environment():
 def test_vcheck_mode(wrapper_environment):
     assert dump_mode(cc, ["-I/include", "--version"]) == "vcheck"
     assert dump_mode(cc, ["-I/include", "-V"]) == "vcheck"
-    assert dump_mode(cc, ["-I/include", "-v"]) == "vcheck"
     assert dump_mode(cc, ["-I/include", "-dumpversion"]) == "vcheck"
     assert dump_mode(cc, ["-I/include", "--version", "-c"]) == "vcheck"
     assert dump_mode(cc, ["-I/include", "-V", "-o", "output"]) == "vcheck"
+    assert dump_mode(ld, ["-I/include", "-v"]) == "vcheck"
 
 
 def test_cpp_mode(wrapper_environment):


### PR DESCRIPTION
When the cc wrapper gets a `-v` argument, it currently assumes it's a version check when `mode` is either `ld` or unset.  That seems right, but it checks the value of mode before `ccld` is detected.  This moves the code down so that `-v` on gcc in ccld mode gives us the gcc verbose behavior with wrapper args passed rather than adding no wrapper args.

From #42082 