### PR TITLE
fix pyright for package files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ ignore_missing_imports = true
 useLibraryCodeForTypes = true
 reportMissingImports = true
 reportWildcardImportFromLibrary = false
-include = ['lib/spack']
+include = ['lib/spack', 'var/spack/repos']
 ignore = ['lib/spack/external']
 extraPaths = ['lib/spack', 'lib/spack/external']
 


### PR DESCRIPTION
The pyright LSP (used by default in vscode's microsoft python LSP for example) was misconfigured so that it did not work in spack package files.  This fixes that for everything except injected module variables.

Would love to make the module injected stuff more painful to add as package outputs and less painful to use (they all show up as undefined).  Maybe force any such thing to be listed as a lazy functor in the `spack.package` file so at least they show up?

From #10804 