### PR TITLE
py-torchdata: update checksum

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchdata/package.py
+++ b/var/spack/repos/builtin/packages/py-torchdata/package.py
@@ -18,7 +18,7 @@ class PyTorchdata(PythonPackage):
     license("BSD-3-Clause")
 
     version("main", branch="main")
-    version("0.7.1", sha256="1b6589336776ccba19fd3bf435588416105d372f6b85d58a9f2b008286f483bf")
+    version("0.7.1", sha256="ef9bbdcee759b53c3c9d99e76eb0a66da33d36bfb7f859a25a9b5e737a51fa23")
     version("0.7.0", sha256="0b444719c3abc67201ed0fea92ea9c4100e7f36551ba0d19a09446cc11154eb3")
     version("0.6.1", sha256="c596db251c5e6550db3f00e4308ee7112585cca4d6a1c82a433478fd86693257")
     version("0.6.0", sha256="048dea12ee96c0ea1525097959fee811d7b38c2ed05f44a90f35f8961895fb5b")


### PR DESCRIPTION
torchdata 0.7.1 was released on [16 Nov](https://github.com/pytorch/data/releases/tag/v0.7.1) and added to Spack [the same day](https://github.com/spack/spack/pull/41105). However, two new commits were added and the tag was moved [18 hrs ago](https://github.com/pytorch/data/commits/v0.7.1/). This resulted in a new tarball with a different checksum, breaking our CI. The two new commits only affect torchdata CI and should not affect the installed package. If I had to guess, this was in response to [this article](https://johnstawinski.com/2024/01/11/playing-with-fire-how-we-executed-a-critical-supply-chain-attack-on-pytorch/), but it could just be a mistake. In general, moving tags is frowned upon because it invalidates checksums and risks security vulnerabilities. I confirmed that no other PyTorch packages or versions are affected by this.

@huydhn @trws @haampie 