### PR TITLE
e4s ci: switch to neoverse_v2 target

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -207,6 +207,10 @@ default:
   extends: [ ".generate-base" ]
   tags: ["spack", "public", "medium", "aarch64", "graviton3"]
 
+.generate-neoverse-v2:
+  extends: [ ".generate-base" ]
+  tags: ["spack", "public", "medium", "neoverse_v2"]
+
 .generate-deprecated:
   extends: [ ".base-job" ]
   stage: generate
@@ -340,27 +344,27 @@ e4s-build:
       job: e4s-generate
 
 ########################################
-# E4S aarch64 pipeline
+# E4S Neoverse V2
 ########################################
-.e4s-aarch64:
-  extends: [ ".linux_aarch64" ]
+.e4s-neoverse-v2:
+  extends: [ ".linux_neoverse_v2" ]
   variables:
-    SPACK_CI_STACK_NAME: e4s-aarch64
+    SPACK_CI_STACK_NAME: e4s-neoverse-v2
 
-e4s-aarch64-generate:
-  extends: [ ".e4s-aarch64", ".generate-aarch64" ]
+e4s-neoverse-v2-generate:
+  extends: [ ".e4s-neoverse-v2", ".generate-neoverse-v2" ]
   image: ecpe4s/ubuntu22.04-runner-arm64-gcc-11.4:2024.01.01
 
-e4s-aarch64-build:
-  extends: [ ".e4s-aarch64", ".build" ]
+e4s-neoverse-v2-build:
+  extends: [ ".e4s-neoverse-v2", ".build" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: e4s-aarch64-generate
+        job: e4s-neoverse-v2-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: e4s-aarch64-generate
+      job: e4s-neoverse-v2-generate
 
 ########################################
 # E4S Neoverse V1 pipeline

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/neoverse_v2/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/neoverse_v2/ci.yaml
@@ -1,0 +1,7 @@
+ci:
+  pipeline-gen:
+  - any-job:
+      variables:
+        SPACK_TARGET_ARCH: neoverse_v2
+  - build-job:
+      tags: ["neoverse_v2"]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse-v2/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse-v2/spack.yaml
@@ -7,7 +7,7 @@ spack:
 
   packages:
     all:
-      require: '%gcc@11.4.0 target=aarch64'
+      require: '%gcc@11.4.0 target=neoverse_v2'
       providers:
         blas: [openblas]
         mpi: [mpich]
@@ -332,4 +332,4 @@ spack:
         image: "ecpe4s/ubuntu22.04-runner-arm64-gcc-11.4:2024.01.01"
 
   cdash:
-    build-group: E4S ARM AARCH64
+    build-group: E4S ARM Neoverse V2


### PR DESCRIPTION
E4S target `neoverse_v2` on new Grace Grace and Grace Hopper nodes at UO