### PR TITLE
gnuplot: fix undefined ref to symbol libiconv_open

### DIFF
--- a/var/spack/repos/builtin/packages/gnuplot/package.py
+++ b/var/spack/repos/builtin/packages/gnuplot/package.py
@@ -162,7 +162,7 @@ class Gnuplot(AutotoolsPackage):
         # TODO: --with-aquaterm  depends_on('aquaterm')
         options.append("--without-aquaterm")
 
-        if spec.satisfies("%gcc@11:"):
+        if spec.satisfies("%gcc@8:"):
             os.environ["LDFLAGS"] = "-Wl,--copy-dt-needed-entries"
 
         return options


### PR DESCRIPTION
This fixes #39720.