### PR TITLE
Relax conflict in pika with cxxstd >= 20 and cuda <= 11

### DIFF
--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -96,7 +96,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("cxxstd=23", when="^cmake@:3.20.2")
     # CUDA version <= 11 does not support C++20 and newer
     for cxxstd in filter(lambda x: x != "17", cxxstds):
-        conflicts(f"cxxstd={cxxstd}", when="^cuda@:11")
+        requires("%nvhpc", when=f"cxxstd={cxxstd} ^cuda@:11")
 
     # Other dependencies
     depends_on("boost@1.71:")

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -94,7 +94,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("%clang@:8", when="@0.2:")
     conflicts("+stdexec", when="cxxstd=17")
     conflicts("cxxstd=23", when="^cmake@:3.20.2")
-    # CUDA version <= 11 does not support C++20 and newer
+    # nvcc version <= 11 does not support C++20 and newer
     for cxxstd in filter(lambda x: x != "17", cxxstds):
         requires("%nvhpc", when=f"cxxstd={cxxstd} ^cuda@:11")
 


### PR DESCRIPTION
The conflict is concerning nvcc and cxxstd={20,23}, when using nvhpc we use nvc++ which supports C++20 even with cuda <= 11. pika uses nvc++ for device compilation when it's set as the compiler, for all other compilers we use nvcc.