### PR TITLE
spack load: remove --only argument

### DIFF
--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -5,8 +5,6 @@
 
 import sys
 
-import llnl.util.tty as tty
-
 import spack.cmd
 import spack.cmd.find
 import spack.environment as ev
@@ -71,16 +69,6 @@ def setup_parser(subparser):
     )
 
     subparser.add_argument(
-        "--only",
-        default="package,dependencies",
-        dest="things_to_load",
-        choices=["package", "dependencies"],
-        help="select whether to load the package and its dependencies\n\n"
-        "the default is to load the package and all dependencies. alternatively, "
-        "one can decide to load only the package or only the dependencies",
-    )
-
-    subparser.add_argument(
         "--list",
         action="store_true",
         default=False,
@@ -109,11 +97,6 @@ def load(parser, args):
             "spack load", f"    eval `spack load {{sh_arg}} {specs_str}`"
         )
         return 1
-
-    if args.things_to_load != "package,dependencies":
-        tty.warn(
-            "The `--only` flag in spack load is deprecated and will be removed in Spack v0.22"
-        )
 
     with spack.store.STORE.db.read_transaction():
         env_mod = uenv.environment_modifications_for_specs(*specs)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1338,7 +1338,7 @@ _spack_list() {
 _spack_load() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --sh --csh --fish --bat --pwsh --first --only --list"
+        SPACK_COMPREPLY="-h --help --sh --csh --fish --bat --pwsh --first --list"
     else
         _installed_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2067,7 +2067,7 @@ complete -c spack -n '__fish_spack_using_command list' -l update -r -f -a update
 complete -c spack -n '__fish_spack_using_command list' -l update -r -d 'write output to the specified file, if any package is newer'
 
 # spack load
-set -g __fish_spack_optspecs_spack_load h/help sh csh fish bat pwsh first only= list
+set -g __fish_spack_optspecs_spack_load h/help sh csh fish bat pwsh first list
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 load' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command load' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command load' -s h -l help -d 'show this help message and exit'
@@ -2083,8 +2083,6 @@ complete -c spack -n '__fish_spack_using_command load' -l pwsh -f -a shell
 complete -c spack -n '__fish_spack_using_command load' -l pwsh -d 'print pwsh commands to load the package'
 complete -c spack -n '__fish_spack_using_command load' -l first -f -a load_first
 complete -c spack -n '__fish_spack_using_command load' -l first -d 'load the first match if multiple packages match the spec'
-complete -c spack -n '__fish_spack_using_command load' -l only -r -f -a 'package dependencies'
-complete -c spack -n '__fish_spack_using_command load' -l only -r -d 'select whether to load the package and its dependencies'
 complete -c spack -n '__fish_spack_using_command load' -l list -f -a list
 complete -c spack -n '__fish_spack_using_command load' -l list -d 'show loaded packages: same as `spack find --loaded`'
 


### PR DESCRIPTION
The argument was deprecated in v0.21 and slated for removal in v0.22.