### PR TITLE
py-tesorter: requires setuptools

### DIFF
--- a/var/spack/repos/builtin/packages/py-tesorter/package.py
+++ b/var/spack/repos/builtin/packages/py-tesorter/package.py
@@ -24,6 +24,8 @@ class PyTesorter(PythonPackage):
 
     version("1.4.6", sha256="c6952c98fa78d0084742fd6c7d2d1204d36db103c3cbeb19e52093cd9d311523")
 
+    depends_on("py-setuptools", type="build")
+
     depends_on("py-biopython", type=("build", "run"))
     depends_on("py-xopen", type=("build", "run"))
 


### PR DESCRIPTION
Not sure how this built back in June, but this does need setuptools.