### PR TITLE
FleCSI updates

### DIFF
--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -29,7 +29,11 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     version("2.1.0", tag="v2.1.0", commit="533df139c267e2a93c268dfe68f9aec55de11cf0")
     version("2.0.0", tag="v2.0.0", commit="5ceebadf75d1c98999ea9e9446926722d061ec22")
     version(
-        "1.4.1", tag="v1.4.1", commit="ab974c3164056e6c406917c8ca771ffd43c5a031", submodules=True
+        "1.4.1",
+        tag="v1.4.1",
+        commit="ab974c3164056e6c406917c8ca771ffd43c5a031",
+        submodules=True,
+        deprecated=True,
     )
 
     variant(

--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -173,9 +173,7 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
                 self.define_from_variant("CALIPER_DETAIL", "caliper_detail"),
                 self.define_from_variant("ENABLE_FLOG", "flog"),
                 self.define_from_variant("ENABLE_GRAPHVIZ", "graphviz"),
-                self.define(
-                    "ENABLE_HDF5", "+hdf5" in spec and spec.variants["backend"].value != "hpx"
-                ),
+                self.define_from_variant("ENABLE_HDF5", "hdf5"),
                 self.define_from_variant("ENABLE_KOKKOS", "kokkos"),
                 self.define_from_variant("ENABLE_OPENMP", "openmp"),
                 self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
@@ -208,9 +206,7 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
                 self.define_from_variant("ENABLE_FLECSTAN", "flecstan"),
                 self.define("ENABLE_MPI", spec.variants["backend"].value != "serial"),
                 self.define("ENABLE_UNIT_TESTS", self.run_tests or "+unit_tests" in spec),
-                self.define(
-                    "ENABLE_HDF5", "+hdf5" in spec and spec.variants["backend"].value != "hpx"
-                ),
+                self.define_from_variant("ENABLE_HDF5", "hdf5"),
             ]
 
             if "+external_cinch" in spec:


### PR DESCRIPTION
- deprecate 1.4
- simplify `hdf5` variant logic, since there is an explicit conflict for `backend=hpx`