### PR TITLE
[kokkos] make dpl dependence explicit

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -194,6 +194,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     for dev, (dflt, desc) in devices_variants.items():
         variant(dev, default=dflt, description=desc)
     conflicts("+cuda", when="+rocm", msg="CUDA and ROCm are not compatible in Kokkos.")
+    depends_on("intel-oneapi-dpl", when="+sycl")
 
     for opt, (dflt, desc) in options_variants.items():
         variant(opt, default=dflt, description=desc, when=("+cuda" if "cuda" in opt else None))


### PR DESCRIPTION
kokkos +sycl uses oneDPL, but does not make the dependence explicit in spack. kokkos uses cmake to find onedpl and that works ok if you do a root install of basekit. Dpl is present on the system and the cmake files are installed in /usr/local.  It will not work if you only install the compiler and/or do not install as root.

Starting with 2024, oneapi does not install cmake files in /usr/local so e4s build no longer works. If you make the dependence on oneDPL explicit, then cmake is able to find the onedpl

@eugeneswalker:  Can you see if this fixes e4s builds