### PR TITLE
cp2k: add a separate MakefileBuilder

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -379,7 +379,10 @@ class MakefileBuilder(makefile.MakefileBuilder):
         }
 
         dflags = ["-DNDEBUG"] if spec.satisfies("@:2023.2") else []
-        cppflags = ["-D__FFTW3", "-I{0}".format(fftw_header_dir)]
+        if spec["fftw-api"].name in ("intel-mkl", "intel-parallel-studio", "intel-oneapi-mkl"):
+            cppflags = ["-D__FFTW3_MKL", "-I{0}".format(fftw_header_dir)]
+        else:
+            cppflags = ["-D__FFTW3", "-I{0}".format(fftw_header_dir)]
 
         # CP2K requires MPI 3 starting at version 2023.1
         # and __MPI_VERSION is not supported anymore.
@@ -498,7 +501,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
             # while intel-mkl has a mpi variant and adds the scalapack
             # libs to its libs, intel-oneapi-mkl does not.
             if spec["scalapack"].name == "intel-oneapi-mkl":
-                mpi_impl = "openmpi" if spec["mpi"] == "openmpi" else "intelmpi"
+                mpi_impl = "openmpi" if spec["mpi"].name in ["openmpi", "hpcx-mpi"] else "intelmpi"
                 scalapack = [
                     join_path(
                         spec["intel-oneapi-mkl"].libs.directories[0], "libmkl_scalapack_lp64.so"

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -272,6 +272,8 @@ class Gromacs(CMakePackage, CudaPackage):
     depends_on("cmake@3.16.3:3", type="build", when="@2022:")
     depends_on("cmake@3.18.4:3", type="build", when="@main")
     depends_on("cmake@3.16.0:3", type="build", when="%fj")
+    depends_on("pkgconfig", type="build")
+
     depends_on("cuda", when="+cuda")
     depends_on("sycl", when="+sycl")
     depends_on("lapack")


### PR DESCRIPTION
follow up from #42009

Modifications:
- [x] Extracted a separate `MakefileBuilder`
- [x] Removed deprecated versions, cleaned-up the recipe
- [x] Factored together the `GPU_MAP` dictionary, which is now used by both builders