### PR TITLE
Bug fix for building ESMF shared on macOS: set ESMF_TRACE_LIB_BUILD=OFF

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -398,6 +398,11 @@ class Esmf(MakefilePackage):
         if "~shared" in spec:
             env.set("ESMF_SHARED_LIB_BUILD", "OFF")
 
+        # https://github.com/JCSDA/spack-stack/issues/956
+        if "+shared" in spec:
+            if sys.platform == "darwin":
+                env.set("ESMF_TRACE_LIB_BUILD", "OFF")
+
     @run_after("install")
     def post_install(self):
         install_tree("cmake", self.prefix.cmake)


### PR DESCRIPTION
## Description

See https://github.com/JCSDA/spack-stack/issues/956 and https://github.com/spack/spack/issues/42133 for a description of the problem. Setting environment variable `ESMF_TRACE_LIB_BUILD=OFF` on macOS when building the shared ESMF library solves the problem (on my macOS locally, and in CI).