### PR TITLE
opencascade: new versions 7.5.3p5, 7.7.2, 7.8.0

### DIFF
--- a/var/spack/repos/builtin/packages/opencascade/package.py
+++ b/var/spack/repos/builtin/packages/opencascade/package.py
@@ -24,6 +24,16 @@ class Opencascade(CMakePackage):
     license("LGPL-2.1-only")
 
     version(
+        "7.8.0",
+        extension="tar.gz",
+        sha256="b9c8f0a9d523ac1a606697f95fc39d8acf1140d3728561b8010a604431b4e9cf",
+    )
+    version(
+        "7.7.2",
+        extension="tar.gz",
+        sha256="2fb23c8d67a7b72061b4f7a6875861e17d412d524527b2a96151ead1d9cfa2c1",
+    )
+    version(
         "7.7.1",
         extension="tar.gz",
         sha256="f413d30a8a06d6164e94860a652cbc96ea58fe262df36ce4eaa92a9e3561fd12",
@@ -42,6 +52,11 @@ class Opencascade(CMakePackage):
         "7.6.0",
         extension="tar.gz",
         sha256="e7f989d52348c3b3acb7eb4ee001bb5c2eed5250cdcceaa6ae97edc294f2cabd",
+    )
+    version(
+        "7.5.3p5",
+        extension="tar.gz",
+        sha256="29a4b4293f725bea2f32de5641b127452fc836a30e207d0daa5a0d1b746226b8",
     )
     version(
         "7.5.3p4",


### PR DESCRIPTION
New patch 7.5.3p5, new bugfix 7.7.2, new minor 7.8.0.

Only possible impact on spack is the potential addition of a variant to select the memory manager in 7.8.0, see [diff](https://github.com/Open-Cascade-SAS/OCCT/compare/V7_7_2...V7_8_0). Not adding a variant at this time.

Test build of 7.7.2 (first lines not in scroll-back buffer anymore):
```
==> opencascade: Executing phase: 'cmake'
==> opencascade: Executing phase: 'build'
==> opencascade: Executing phase: 'install'
==> opencascade: Successfully installed opencascade-7.7.2-hwrj4hgcgunwi63sves5nekxlkjkcu47
  Stage: 1.23s.  Cmake: 8.97s.  Build: 35m 33.95s.  Install: 12.99s.  Post-install: 1.50s.  Total: 35m 58.80s
[+] /opt/software/linux-ubuntu23.10-skylake/gcc-13.2.0/opencascade-7.7.2-hwrj4hgcgunwi63sves5nekxlkjkcu47
```

Test build of 7.8.0:
```
==> Installing opencascade-7.8.0-m74t6la4abmjz5c6jpbkk65ip23zjhn7 [394/429]
==> No binary for opencascade-7.8.0-m74t6la4abmjz5c6jpbkk65ip23zjhn7 found: installing from source
==> Fetching https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/tags/V7_8_0;sf=tgz
==> No patches needed for opencascade
==> opencascade: Executing phase: 'cmake'
==> opencascade: Executing phase: 'build'
==> opencascade: Executing phase: 'install'
==> opencascade: Successfully installed opencascade-7.8.0-m74t6la4abmjz5c6jpbkk65ip23zjhn7
  Stage: 24.15s.  Cmake: 7.96s.  Build: 35m 17.81s.  Install: 11.63s.  Post-install: 1.37s.  Total: 36m 3.08s
[+] /opt/software/linux-ubuntu23.10-skylake/gcc-13.2.0/opencascade-7.8.0-m74t6la4abmjz5c6jpbkk65ip23zjhn7
```

Test build of 7.5.3p5 not attempted since [only very minimal changes](https://github.com/Open-Cascade-SAS/OCCT/compare/V7_5_3p4...V7_5_3p5).