### PR TITLE
Paraview: Do not use PYTHON3_EXECUTABLE

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -537,7 +537,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
             cmake_args.extend(
                 [
                     "-DPARAVIEW_%s_PYTHON:BOOL=ON" % py_use_opt,
-                    "-DPYTHON_EXECUTABLE:FILEPATH=%s" % spec["python"].command.path,
+                    "-DPython3_EXECUTABLE:FILEPATH=%s" % spec["python"].command.path,
                     "-D%s_PYTHON_VERSION:STRING=%d" % (py_ver_opt, py_ver_val),
                 ]
             )


### PR DESCRIPTION
According to the following Discourse discussion: https://discourse.paraview.org/t/python-executable-cmake-variable/13634 PYTHON3_EXECUTABLE should be replaced in favor of Python3_EXECUTABLE.