### PR TITLE
VecGeom: new version 1.2.7 and fix URLs

### DIFF
--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -61,7 +61,7 @@ class Geant4(CMakePackage):
     )
 
     variant("threads", default=True, description="Build with multithreading")
-    variant("vecgeom", default=False, description="Enable vecgeom support", when="@10.3:")
+    variant("vecgeom", default=False, description="Enable vecgeom support", when="@10.4:")
     variant("opengl", default=False, description="Optional OpenGL support")
     variant("x11", default=False, description="Optional X11 support")
     variant("motif", default=False, description="Optional motif support")
@@ -121,7 +121,6 @@ class Geant4(CMakePackage):
         depends_on("vecgeom@1.1.5", when="@10.6.0:10.6")
         depends_on("vecgeom@1.1.0", when="@10.5.0:10.5")
         depends_on("vecgeom@0.5.2", when="@10.4.0:10.4")
-        depends_on("vecgeom@0.3rc", when="@10.3.0:10.3")
 
     def std_when(values):
         for v in values:

--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -147,11 +147,6 @@ class Vecgeom(CMakePackage, CudaPackage):
         commit="a7e0828c915ff936a79e672d1dd84b087a323b51",
         deprecated=True,
     )
-    version(
-        "0.3.rc",
-        sha256="a87a9ea4ab126b59ff9c79182bc0911ead3d76dd197194742e2a35ccd341299d",
-        deprecated=True,
-    )
 
     _cxxstd_values = (conditional("11", "14", when="@:1.1"), "17", conditional("20", when="@1.2:"))
     variant(

--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -21,8 +21,21 @@ class Vecgeom(CMakePackage, CudaPackage):
     maintainers("drbenmorgan", "sethrj")
 
     version("master", branch="master")
-    version("1.2.6", sha256="e5162cf8adb67859dc4a111a81d1390d995895293e6ef1acf5f9d9834fd6d40e")
-    version("1.2.5", sha256="d79ea05125e4d03c5605e5ea232994c500841d207b4543ac3d84758adddc15a9")
+    version(
+        "1.2.7",
+        url="https://gitlab.cern.ch/VecGeom/VecGeom/uploads/e4172cca4f6f731ef15e2780ecbb1645/VecGeom-v1.2.7.tar.gz",
+        sha256="d264c69b78bf431b9542be1f1af087517eac629da03cf2da62eb1e433fe06021",
+    )
+    version(
+        "1.2.6",
+        url="https://gitlab.cern.ch/VecGeom/VecGeom/uploads/0b16aed9907cea62aa5f5914bec99a90/VecGeom-v1.2.6.tar.gz",
+        sha256="337f8846491930f3d8bfa4b45a1589d46e5d1d87f2d38c8f7006645c3aa90df8",
+    )
+    version(
+        "1.2.5",
+        url="https://gitlab.cern.ch/VecGeom/VecGeom/uploads/33b93e656c5bc49d81cfcba291f5be51/VecGeom-v1.2.5.tar.gz",
+        sha256="d79ea05125e4d03c5605e5ea232994c500841d207b4543ac3d84758adddc15a9",
+    )
     version(
         "1.2.4",
         sha256="4f5d43a9cd34a5e0200c41547a438cbb1ed4439f5bb757857c5a225d708590ce",


### PR DESCRIPTION
Supersedes https://github.com/spack/spack/pull/41983 by replacing the URLs with verified artifacts that have their own hashes. Unfortunately GitLab embeds a hash of each archive in the URL so there's no `url_from_version` that will let us simplify.