### PR TITLE
Inhibit CMake packages to pollute user home folder with CMake User Package Registry

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -318,15 +318,28 @@ class CMakeBuilder(BaseBuilder):
                 [define("CMAKE_FIND_FRAMEWORK", "LAST"), define("CMAKE_FIND_APPBUNDLE", "LAST")]
             )
 
-        _maybe_set_python_hints(pkg, args)
-
         # Disable CMake User Package Registry
+        # Do not populate CMake User Package Registry
         if pkg.spec.satisfies("^cmake@3.15:"):
             # see https://cmake.org/cmake/help/latest/policy/CMP0090.html
             args.append(define("CMAKE_POLICY_DEFAULT_CMP0090", "NEW"))
         elif pkg.spec.satisfies("^cmake@3.1:3.14"):
             # see https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_NO_PACKAGE_REGISTRY.html
             args.append(define("CMAKE_EXPORT_NO_PACKAGE_REGISTRY", True))
+
+        # Do not use CMake User/System Package Registry
+        # https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#disabling-the-package-registry
+        if pkg.spec.satisfies("^cmake@3.16:"):
+            args.append(define("CMAKE_FIND_USE_PACKAGE_REGISTRY", False))
+        elif pkg.spec.satisfies("^cmake@3.1:3.15"):
+            args.extend(
+                [
+                    define("CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY", False),
+                    define("CMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY", False),
+                ]
+            )
+
+        _maybe_set_python_hints(pkg, args)
 
         # Set up CMake rpath
         args.extend(

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -320,6 +320,14 @@ class CMakeBuilder(BaseBuilder):
 
         _maybe_set_python_hints(pkg, args)
 
+        # Disable CMake User Package Registry
+        if pkg.spec.satisfies("^cmake@3.15:"):
+            # see https://cmake.org/cmake/help/latest/policy/CMP0090.html
+            args.append(define("CMAKE_POLICY_DEFAULT_CMP0090", "NEW"));
+        elif pkg.spec.satisfies("^cmake@3.1:3.14"):
+            # see https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_NO_PACKAGE_REGISTRY.html
+            args.append(define("CMAKE_EXPORT_NO_PACKAGE_REGISTRY", True));
+
         # Set up CMake rpath
         args.extend(
             [

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -323,10 +323,10 @@ class CMakeBuilder(BaseBuilder):
         # Disable CMake User Package Registry
         if pkg.spec.satisfies("^cmake@3.15:"):
             # see https://cmake.org/cmake/help/latest/policy/CMP0090.html
-            args.append(define("CMAKE_POLICY_DEFAULT_CMP0090", "NEW"));
+            args.append(define("CMAKE_POLICY_DEFAULT_CMP0090", "NEW"))
         elif pkg.spec.satisfies("^cmake@3.1:3.14"):
             # see https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_NO_PACKAGE_REGISTRY.html
-            args.append(define("CMAKE_EXPORT_NO_PACKAGE_REGISTRY", True));
+            args.append(define("CMAKE_EXPORT_NO_PACKAGE_REGISTRY", True))
 
         # Set up CMake rpath
         args.extend(

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -17,7 +17,6 @@ import spack.build_environment
 import spack.builder
 import spack.deptypes as dt
 import spack.package_base
-import spack.spec
 from spack.directives import build_system, conflicts, depends_on, variant
 from spack.multimethod import when
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1501,7 +1501,9 @@ class Spec:
         result = f"{deptypes_str} {virtuals_str}".strip()
         return f"[{result}]"
 
-    def dependencies(self, name=None, deptype: Union[dt.DepTypes, dt.DepFlag] = dt.ALL):
+    def dependencies(
+        self, name=None, deptype: Union[dt.DepTypes, dt.DepFlag] = dt.ALL
+    ) -> List["Spec"]:
         """Return a list of direct dependencies (nodes in the DAG).
 
         Args:
@@ -1512,7 +1514,9 @@ class Spec:
             deptype = dt.canonicalize(deptype)
         return [d.spec for d in self.edges_to_dependencies(name, depflag=deptype)]
 
-    def dependents(self, name=None, deptype: Union[dt.DepTypes, dt.DepFlag] = dt.ALL):
+    def dependents(
+        self, name=None, deptype: Union[dt.DepTypes, dt.DepFlag] = dt.ALL
+    ) -> List["Spec"]:
         """Return a list of direct dependents (nodes in the DAG).
 
         Args:

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -29,6 +29,7 @@ class Cmake(Package):
     license("BSD-3-Clause")
 
     version("master", branch="master")
+    version("3.28.1", sha256="15e94f83e647f7d620a140a7a5da76349fc47a1bfed66d0f5cdee8e7344079ad")
     version("3.27.9", sha256="609a9b98572a6a5ea477f912cffb973109ed4d0a6a6b3f9e2353d2cdc048708e")
     version("3.27.8", sha256="fece24563f697870fbb982ea8bf17482c9d5f855d8c9bf0b82463d76c9e8d0cc")
     version("3.27.7", sha256="08f71a106036bf051f692760ef9558c0577c42ac39e96ba097e7662bd4158d8e")

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -29,7 +29,6 @@ class Cmake(Package):
     license("BSD-3-Clause")
 
     version("master", branch="master")
-    version("3.28.1", sha256="15e94f83e647f7d620a140a7a5da76349fc47a1bfed66d0f5cdee8e7344079ad")
     version("3.27.9", sha256="609a9b98572a6a5ea477f912cffb973109ed4d0a6a6b3f9e2353d2cdc048708e")
     version("3.27.8", sha256="fece24563f697870fbb982ea8bf17482c9d5f855d8c9bf0b82463d76c9e8d0cc")
     version("3.27.7", sha256="08f71a106036bf051f692760ef9558c0577c42ac39e96ba097e7662bd4158d8e")


### PR DESCRIPTION
This PR aims at avoiding CMake-based packages to pollute home folder with `~/.cmake/packages`, aka CMake User Package Registry. It's not a big deal, but I think it is something that spack does not want to happen.

Reading the doc it is possible to say what to do for `cmake@3.1` up to now (and hopefully it will remain like this, considering there is a CMake policy for that now).

AFAIK for `cmake@:3.0`, i.e. before `CMAKE_EXPORT_NO_PACKAGE_REGISTRY` got introduced, there was no way of disabling it. We might opt for just a warning in that case. Open to suggestions.

### Context
CMake has a command `export(PACKAGE <package_name>)` that adds the package to the package registry in the user home folder. For what concerns spack, this is not useful (if not remotely and potentially harmful IMHO), and pollutes the user home folder.

### When it happens?
This happens for all packages that:
- uses CMake as build system
- uses the `export(PACKAGE)` directive
- still have a `cmake_minimum_required` directive requiring an old version (so even with new versions of CMake).

Not many package might have the overlap of all these conditions, but for instance

`eigen` uses `export(PACKAGE)` [here](https://gitlab.com/libeigen/eigen/-/blob/3.4/CMakeLists.txt?ref_type=heads#L675)
- `cmake_minimum_required(VERSION 3.5.0)` on [3.4.0](https://gitlab.com/libeigen/eigen/-/blob/3.4/CMakeLists.txt?ref_type=heads#L2)
- `cmake_minimum_required(VERSION 3.10)` on [master](https://gitlab.com/libeigen/eigen/-/blob/master/CMakeLists.txt?ref_type=heads#L2)

which are both below 3.15, so cmake by default will add the package to the registry.

### References
In the code I commented with some useful references that I report here too for documenting the PR.

- https://cmake.org/cmake/help/latest/policy/CMP0090.html
- https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_NO_PACKAGE_REGISTRY.html