### PR TITLE
ginkgo@1.7.0 %oneapi: patch sycl w changes from ginkgo pr #1524

### DIFF
--- a/var/spack/repos/builtin/packages/ginkgo/ginkgo-sycl-pr1524.patch
+++ b/var/spack/repos/builtin/packages/ginkgo/ginkgo-sycl-pr1524.patch
@@ -1,0 +1,13 @@
+diff -ruN spack-src/dpcpp/components/cooperative_groups.dp.hpp spack-src-patched/dpcpp/components/cooperative_groups.dp.hpp
+--- spack-src/dpcpp/components/cooperative_groups.dp.hpp	2024-01-18 17:25:05.336926061 +0000
++++ spack-src-patched/dpcpp/components/cooperative_groups.dp.hpp	2024-01-18 17:26:50.649595478 +0000
+@@ -240,7 +240,8 @@
+     {
+         // todo: change it when OneAPI update the mask related api
+         return sycl::reduce_over_group(
+-            *this, (predicate != 0) ? mask_type(1) << data_.rank : mask_type(0),
++            static_cast<sycl::sub_group>(*this),
++            (predicate != 0) ? mask_type(1) << data_.rank : mask_type(0),
+             sycl::plus<mask_type>());
+     }
+ 

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -99,7 +99,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     )
 
     # https://github.com/ginkgo-project/ginkgo/pull/1524
-    patch("ginkgo-sycl-pr1524.patch", when="@1.7.0 +sycl")
+    patch("ginkgo-sycl-pr1524.patch", when="@1.7.0 +sycl %oneapi@2024:")
 
     # Skip smoke tests if compatible hardware isn't found
     patch("1.4.0_skip_invalid_smoke_tests.patch", when="@1.4.0")

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -98,6 +98,9 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
         "+sycl", when="@:1.4.0", msg="For SYCL support, please use Ginkgo version 1.4.0 and newer."
     )
 
+    # https://github.com/ginkgo-project/ginkgo/pull/1524
+    patch("ginkgo-sycl-pr1524.patch", when="@1.7.0 +sycl")
+
     # Skip smoke tests if compatible hardware isn't found
     patch("1.4.0_skip_invalid_smoke_tests.patch", when="@1.4.0")
 


### PR DESCRIPTION
Patch `ginkgo@1.7.0 +sycl %oneapi@2024:` using changes from upstream https://github.com/ginkgo-project/ginkgo/commit/7c566bb69c233261cc461cd51edd440710871bc9

Fixes https://github.com/spack/spack/pull/42146#issuecomment-1898876093