### PR TITLE
ucx: add explicit dependency to hsa-rocr-dev

### DIFF
--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -137,6 +137,7 @@ class Ucx(AutotoolsPackage, CudaPackage):
     depends_on("rdma-core", when="+verbs")
     depends_on("xpmem", when="+xpmem")
     depends_on("hip", when="+rocm")
+    depends_on("hsa-rocr-dev", when="+rocm")
 
     conflicts("+gdrcopy", when="~cuda", msg="gdrcopy currently requires cuda support")
     conflicts("+rocm", when="+gdrcopy", msg="gdrcopy > 2.0 does not support rocm")


### PR DESCRIPTION
Fixes an issue that occurs when `hip` is provided as an external. `hsa-rocr-dev` would not be part of the dependency tree in that case, which causes a `KeyError` in `spec['hsa-rocr-dev']` during configure.