### PR TITLE
MSVC: Broken ifx needs new $TMP

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1068,16 +1068,6 @@ def working_dir(dirname: str, *, create: bool = False):
         os.chdir(orig_dir)
 
 
-@system_path_filter
-def safe_make_new_dir(path):
-    while True:
-        try:
-            os.mkdir(path)
-            break
-        except FileExistsError:
-            pass
-
-
 class CouldNotRestoreDirectoryBackup(RuntimeError):
     def __init__(self, inner_exception, outer_exception):
         self.inner_exception = inner_exception

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1077,6 +1077,7 @@ def safe_make_new_dir(path):
         except FileExistsError:
             pass
 
+
 class CouldNotRestoreDirectoryBackup(RuntimeError):
     def __init__(self, inner_exception, outer_exception):
         self.inner_exception = inner_exception

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1068,6 +1068,15 @@ def working_dir(dirname: str, *, create: bool = False):
         os.chdir(orig_dir)
 
 
+@system_path_filter
+def safe_make_new_dir(path):
+    while True:
+        try:
+            os.mkdir(path)
+            break
+        except FileExistsError:
+            pass
+
 class CouldNotRestoreDirectoryBackup(RuntimeError):
     def __init__(self, inner_exception, outer_exception):
         self.inner_exception = inner_exception

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 from typing import Dict, List, Set
 
+import llnl.util.filesystem as fs
+
 import spack.compiler
 import spack.operating_systems.windows_os
 import spack.platforms
@@ -17,8 +19,6 @@ import spack.util.executable
 from spack.compiler import Compiler
 from spack.error import SpackError
 from spack.version import Version, VersionRange
-
-import llnl.util.filesystem as fs
 
 avail_fc_version: Set[str] = set()
 fc_path: Dict[str, str] = dict()
@@ -298,7 +298,9 @@ class Msvc(Compiler):
         # certain versions of ifx (2021.3.0:2023.1.0) do not play well with env:TMP
         # that has a "." character in the path
         # Work around by pointing tmp to the stage for the duration of the build
-        if self.fc and Version(self.fc_version(self.fc)).satisfies(VersionRange("2021.3.0", "2023.1.0")):
+        if self.fc and Version(self.fc_version(self.fc)).satisfies(
+            VersionRange("2021.3.0", "2023.1.0")
+        ):
             new_tmp = pathlib.Path(pkg.stage.path) / "MSVCTMP"
             fs.safe_make_new_dir(new_tmp)
             env.set("TMP", str(new_tmp))

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -4,14 +4,11 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import pathlib
 import re
 import subprocess
 import sys
 import tempfile
 from typing import Dict, List, Set
-
-import llnl.util.filesystem as fs
 
 import spack.compiler
 import spack.operating_systems.windows_os

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -299,8 +299,8 @@ class Msvc(Compiler):
         # that has a "." character in the path
         # Work around by pointing tmp to the stage for the duration of the build
         if self.fc and Version(self.fc_version(self.fc)).satisfies(VersionRange("2021.3.0", "2023.1.0")):
-            new_tmp = pathlib.Path(pkg.stage.path) / "tmp"
-            fs.mkdirp(str(new_tmp))
+            new_tmp = pathlib.Path(pkg.stage.path) / "MSVCTMP"
+            fs.safe_make_new_dir(new_tmp)
             env.set("TMP", str(new_tmp))
 
         env.set("CC", self.cc)

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -8,6 +8,7 @@ import pathlib
 import re
 import subprocess
 import sys
+import tempfile
 from typing import Dict, List, Set
 
 import llnl.util.filesystem as fs
@@ -301,9 +302,8 @@ class Msvc(Compiler):
         if self.fc and Version(self.fc_version(self.fc)).satisfies(
             VersionRange("2021.3.0", "2023.1.0")
         ):
-            new_tmp = pathlib.Path(pkg.stage.path) / "MSVCTMP"
-            fs.safe_make_new_dir(new_tmp)
-            env.set("TMP", str(new_tmp))
+            new_tmp = tempfile.mkdtemp(dir=pkg.stage.path)
+            env.set("TMP", new_tmp)
 
         env.set("CC", self.cc)
         env.set("CXX", self.cxx)


### PR DESCRIPTION
Certain versions of ifx (the majority of those available) have an issue where they are not compatible with TMP directories with dot chars This precludes their use with CMake.
Remap TMP to point to the stage directory rather than whatever the TMP default is