### PR TITLE
sbang: skip hook on Windows

### DIFF
--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -229,6 +229,8 @@ def post_install(spec, explicit=None):
     $spack_prefix/bin/sbang instead of something longer than the
     shebang limit.
     """
+    if sys.platform == "win32":
+        return
     if spec.external:
         tty.debug("SKIP: shebang filtering [external package]")
         return


### PR DESCRIPTION
Sbang's don't exist on Native Windows, and the hook is causing errors due to the file comparison + behavior of `os.rename` on Windows.
Skip the hook on Windows.