### PR TITLE
perl-graph: fix default version ordering to latest releases

### DIFF
--- a/var/spack/repos/builtin/packages/perl-graph/package.py
+++ b/var/spack/repos/builtin/packages/perl-graph/package.py
@@ -14,7 +14,7 @@ class PerlGraph(PerlPackage):
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("0.9704", sha256="325e8eb07be2d09a909e450c13d3a42dcb2a2e96cc3ac780fe4572a0d80b2a25", preferred=True)
     version("0.20105", sha256="d72d6512e5a637a64b879a7b74cf3822278b4917e1a0317d340523a6a3936b67")
-    version("0.9704", sha256="325e8eb07be2d09a909e450c13d3a42dcb2a2e96cc3ac780fe4572a0d80b2a25")
 
     depends_on("perl@5.6.0:")

--- a/var/spack/repos/builtin/packages/perl-graph/package.py
+++ b/var/spack/repos/builtin/packages/perl-graph/package.py
@@ -14,7 +14,11 @@ class PerlGraph(PerlPackage):
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
-    version("0.9704", sha256="325e8eb07be2d09a909e450c13d3a42dcb2a2e96cc3ac780fe4572a0d80b2a25", preferred=True)
+    version(
+        "0.9704",
+        sha256="325e8eb07be2d09a909e450c13d3a42dcb2a2e96cc3ac780fe4572a0d80b2a25",
+        preferred=True,
+    )
     version("0.20105", sha256="d72d6512e5a637a64b879a7b74cf3822278b4917e1a0317d340523a6a3936b67")
 
     depends_on("perl@5.6.0:")


### PR DESCRIPTION
Version `0.20105` was released in 2004, whereas version `0.9704` was released in 2015.

Spack continues to default to `0.20105` even though it is a much older version of perl-graph.

This behaviour occurs when called by spack commands, such as: `checksum`, `spec`, and when included as a `depends_on`.