### PR TITLE
[embree] rely on spack to provide location of tbb

### DIFF
--- a/var/spack/repos/builtin/packages/embree/package.py
+++ b/var/spack/repos/builtin/packages/embree/package.py
@@ -59,7 +59,6 @@ class Embree(CMakePackage):
             "-DEMBREE_TUTORIALS=OFF",
             "-DEMBREE_IGNORE_CMAKE_CXX_FLAGS=ON",
             self.define_from_variant("EMBREE_ISPC_SUPPORT", "ispc"),
-            self.define("EMBREE_TBB_ROOT", spec["tbb"].prefix),
         ]
 
         if spec.satisfies("target=x86_64:") or spec.satisfies("target=x86:"):


### PR DESCRIPTION
Addresses https://github.com/spack/spack/issues/42154

Rely on spack to set the cmake paths to find tbb. I verified this works for `intel-tbb`, `intel-oneapi-tbb@2021.10.0` and `intel-oneapi-tbb@2021.11.0`. It builds and finds the requested tbb.

Setting the `TBB_ROOT` is difficult because it is `.prefix` for `intel-tbb` and `.prefix.tbb.latest` for `intel-oneapi-tbb`