### PR TITLE
tbl2asn: adding runtime dep libidn

### DIFF
--- a/var/spack/repos/builtin/packages/tbl2asn/package.py
+++ b/var/spack/repos/builtin/packages/tbl2asn/package.py
@@ -22,6 +22,8 @@ class Tbl2asn(Package):
         deprecated=True,
     )
 
+    depends_on("libidn@1.34", type="run")
+
     def url_for_version(self, ver):
         return "https://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/linux64.tbl2asn.gz"
 


### PR DESCRIPTION
This binary distribution requires libidn with so.11, which 1.34 is the latest provider of. 

Depends on #42170