### PR TITLE
opencl-c-headers: Install with CMake

### DIFF
--- a/var/spack/repos/builtin/packages/opencl-c-headers/package.py
+++ b/var/spack/repos/builtin/packages/opencl-c-headers/package.py
@@ -9,7 +9,7 @@ import sys
 from spack.package import *
 
 
-class OpenclCHeaders(Package):
+class OpenclCHeaders(CMakePackage):
     """OpenCL (Open Computing Language) C header files"""
 
     homepage = "https://www.khronos.org/registry/OpenCL/"
@@ -55,8 +55,6 @@ class OpenclCHeaders(Package):
         "2020.03.13", sha256="664bbe587e5a0a00aac267f645b7c413586e7bc56dca9ff3b00037050d06f476"
     )
 
-    def install(self, spec, prefix):
-        install_tree("CL", prefix.include.CL)
-        if sys.platform == "darwin":
-            ln = which("ln")
-            ln("-s", prefix.include.CL, prefix.include.OpenCL)
+    def cmake_args(self):
+        # Disable testing the headers. They definitely work.
+        return ["-DBUILD_TESTING=OFF"]

--- a/var/spack/repos/builtin/packages/opencl-c-headers/package.py
+++ b/var/spack/repos/builtin/packages/opencl-c-headers/package.py
@@ -19,6 +19,24 @@ class OpenclCHeaders(Package):
     license("Apache-2.0")
 
     version(
+        "2023.12.14", sha256="407d5e109a70ec1b6cd3380ce357c21e3d3651a91caae6d0d8e1719c69a1791d"
+    )
+    version(
+        "2023.04.17", sha256="0ce992f4167f958f68a37918dec6325be18f848dee29a4521c633aae3304915d"
+    )
+    version(
+        "2023.02.06", sha256="464d1b04a5e185739065b2d86e4cebf02c154c416d63e6067a5060d7c053c79a"
+    )
+    version(
+        "2022.09.30", sha256="0ae857ecb28af95a420c800b21ed2d0f437503e104f841ab8db249df5f4fbe5c"
+    )
+    version(
+        "2022.09.23", sha256="dfaded8acf44473e47e7829373c6bb5fba148dc36a38ccd6ef7b6c1ebb78ae68"
+    )
+    version(
+        "2022.05.18", sha256="88a1177853b279eaf574e2aafad26a84be1a6f615ab1b00c20d5af2ace95c42e"
+    )
+    version(
         "2022.01.04", sha256="6e716e2b13fc8d363b40a165ca75021b102f9328e2b38f8054d7db5884de29c9"
     )
     version(

--- a/var/spack/repos/builtin/packages/opencl-c-headers/package.py
+++ b/var/spack/repos/builtin/packages/opencl-c-headers/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-import sys
-
 from spack.package import *
 
 


### PR DESCRIPTION
The [upstream repository](https://github.com/KhronosGroup/OpenCL-Headers) includes a CMake installation mechanism that produces extra files intended for packages:

- Since `@2020.12.18`, this installs [config files for CMake](https://github.com/KhronosGroup/OpenCL-Headers/commit/006fc6797e3a76f16dac3fe31b8baaf2191bd542) (e.g. `find_package(OpenCLHeaders)`), and
- Since `@2023.02.06`, this installs [files for `pkg-config`](https://github.com/KhronosGroup/OpenCL-Headers/commit/a86f4e7d8ec90c2a78d97729282ce7efff6982f4) (e.g. `pkg-config --cflags opencl-headers`).

For full compatibility with downstream build systems, the `opencl-c-headers` package should include these files on suitable versions. This PR rewrites the recipe to install with CMake, which in turn generates and installs these files.

Also, new versions added.