### PR TITLE
motif: patch to ensure main function (fixes #29594)

### DIFF
--- a/var/spack/repos/builtin/packages/motif/add_wmluiltok_option_main.patch
+++ b/var/spack/repos/builtin/packages/motif/add_wmluiltok_option_main.patch
@@ -1,0 +1,8 @@
+diff -Naur motif-2.3.8/tools/wml/wmluiltok.l motif-2.3.8_patched/tools/wml/wmluiltok.l
+--- motif-2.3.8/tools/wml/wmluiltok.l   2024-01-18 17:19:43.997764906 -0600
++++ motif-2.3.8_patched/tools/wml/wmluiltok.l   2024-01-18 17:19:13.998702374 -0600
+@@ -1,3 +1,4 @@
++%option main
+ %{
+ /*
+  * Motif

--- a/var/spack/repos/builtin/packages/motif/package.py
+++ b/var/spack/repos/builtin/packages/motif/package.py
@@ -39,6 +39,8 @@ class Motif(AutotoolsPackage):
     depends_on("pkgconfig", type="build")
 
     patch("add_xbitmaps_dependency.patch")
+    # ensure tools/wml/wmluiltok.c has a main function
+    patch("add_wmluiltok_option_main.patch")
 
     def patch(self):
         # fix linking the simple_app demo program


### PR DESCRIPTION
This fixes #29594, by ensuring that lex generates a main function in the `wmluiltok.c`.

It is not clear to me why this started producing errors now, possibly due to a change in default behavior of flex (but the last real change there was May 2021). It is also possible that this hasn't worked for a long time but that motif has too few users for this to have become apparent...

Inside `docker --rm -it spack/ubuntu-jammy: develop`, before this patch `spack install motif` fails with the error message in #29594:
```
     2833    /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/11/../../../x86_64-linu
             x-gnu/Scrt1.o: in function `_start':
  >> 2834    (.text+0x1b): undefined reference to `main'
  >> 2835    collect2: error: ld returned 1 exit status
  >> 2836    make[2]: *** [Makefile:505: wmluiltok] Error 1
```
After this PR, the same command in the same container succeeds:
```
==> Installing motif-2.3.8-flyoryu3vlhyzy4qpms7czdfeee3yw7e [61/61]
==> No binary for motif-2.3.8-flyoryu3vlhyzy4qpms7czdfeee3yw7e found: installing from source
==> Using cached archive: /opt/spack/var/spack/cache/_source-cache/archive/85/859b723666eeac7df018209d66045c9853b50b4218cecadb794e2359619ebce7.tar.gz
==> Applied patch /opt/spack/var/spack/repos/builtin/packages/motif/add_xbitmaps_dependency.patch
==> Applied patch /opt/spack/var/spack/repos/builtin/packages/motif/add_wmluiltok_option_main.patch
==> Ran patch() for motif
==> motif: Executing phase: 'autoreconf'
==> motif: Executing phase: 'configure'
==> motif: Executing phase: 'build'
==> motif: Executing phase: 'install'
==> motif: Successfully installed motif-2.3.8-flyoryu3vlhyzy4qpms7czdfeee3yw7e
  Stage: 0.18s.  Autoreconf: 5.91s.  Configure: 11.55s.  Build: 1m 5.35s.  Install: 3.71s.  Post-install: 0.41s.  Total: 1m 27.37s
[+] /opt/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-11.4.0/motif-2.3.8-flyoryu3vlhyzy4qpms7czdfeee3yw7e
```
