### PR TITLE
Bugfix: `spack config change` handle string requirements

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -304,6 +304,10 @@ def _config_change_requires_scope(path, spec, scope, match_spec=None):
                 item["any_of"] = [override_cfg_spec(x) for x in item["any_of"]]
             elif "spec" in item:
                 item["spec"] = override_cfg_spec(item["spec"])
+            elif isinstance(item, str):
+                item = override_cfg_spec(item)
+            else:
+                raise ValueError(f"Unexpected requirement: ({type(item)}) {str(item)}")
             new_require.append(item)
 
     spack.config.set(path, new_require, scope=scope)

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -922,9 +922,21 @@ spack:
         # a spec string that requires enclosing in quotes as
         # part of the config path
         config("change", 'packages:libelf:require:"@0.8.12:"')
-        test_spec = spack.spec.Spec("libelf@0.8.12").concretized()
+        spack.spec.Spec("libelf@0.8.12").concretized()
         # No need for assert, if there wasn't a failure, we
         # changed the requirement successfully.
+
+        # Use change to add a requirement for a package that
+        # has no requirements defined
+        config("change", "packages:fftw:require:+mpi")
+        test_spec = spack.spec.Spec("fftw").concretized()
+        assert test_spec.satisfies("+mpi")
+        config("change", "packages:fftw:require:~mpi")
+        test_spec = spack.spec.Spec("fftw").concretized()
+        assert test_spec.satisfies("~mpi")
+        config("change", "packages:fftw:require:@1.0")
+        test_spec = spack.spec.Spec("fftw").concretized()
+        assert test_spec.satisfies("@1.0~mpi")
 
         # Use "--match-spec" to change one spec in a "one_of"
         # list


### PR DESCRIPTION
For a requirement like

```
packages:
  foo:
    require:
    - "+debug"
```

(not `one_of:`, `any_of:`, or `spec:`)

`spack config change` would ignore the string. This was particularly evident if toggling a variant for a previously unmentioned package:

```
$ spack config change packages:foo:require:+debug
$ spack config change packages:foo:require:~debug
```

This fixes that and adds a test for it.