### PR TITLE
containers: update gpg key in almalinux_8.dockerfile

### DIFF
--- a/share/spack/templates/container/almalinux_8.dockerfile
+++ b/share/spack/templates/container/almalinux_8.dockerfile
@@ -1,6 +1,9 @@
 {% extends "container/bootstrap-base.dockerfile" %}
 {% block install_os_packages %}
-RUN dnf update -y \
+# import new gpg key due to key change on January 12, 2024
+# https://almalinux.org/blog/2023-12-20-almalinux-8-key-update/
+RUN rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux
+ && dnf update -y \
  && dnf install -y \
         bzip2 \
         curl \

--- a/share/spack/templates/container/almalinux_8.dockerfile
+++ b/share/spack/templates/container/almalinux_8.dockerfile
@@ -2,7 +2,7 @@
 {% block install_os_packages %}
 # import new gpg key due to key change on January 12, 2024
 # https://almalinux.org/blog/2023-12-20-almalinux-8-key-update/
-RUN rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux
+RUN rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux \
  && dnf update -y \
  && dnf install -y \
         bzip2 \


### PR DESCRIPTION
AlmaLinux8 uses an updated gpg key as of January 12, 2024, see https://almalinux.org/blog/2023-12-20-almalinux-8-key-update/. This is causing scheduled container builds to fail in CI, see https://github.com/spack/spack/actions/runs/7578298346/job/20640679687.

This PR explicitly imports the required gpg key using the fast track solution suggested by AlmaLinux.

I assume that at some point quay.io will update their container at quay.io/almalinux/almalinux:8, but right now it is still missing this key.