### PR TITLE
containers: switch to quay.io/almalinuxorg images

### DIFF
--- a/lib/spack/spack/container/images.json
+++ b/lib/spack/spack/container/images.json
@@ -71,7 +71,7 @@
     "almalinux:9": {
       "bootstrap": {
         "template": "container/almalinux_9.dockerfile",
-        "image": "quay.io/almalinux/almalinux:9"
+        "image": "quay.io/almalinuxorg/almalinux:9"
       },
       "os_package_manager": "dnf_epel",
       "build": "spack/almalinux9",
@@ -79,13 +79,13 @@
         "develop": "latest"
       },
       "final": {
-        "image": "quay.io/almalinux/almalinux:9"
+        "image": "quay.io/almalinuxorg/almalinux:9"
       }
     },
     "almalinux:8": {
       "bootstrap": {
         "template": "container/almalinux_8.dockerfile",
-        "image": "quay.io/almalinux/almalinux:8"
+        "image": "quay.io/almalinuxorg/almalinux:8"
       },
       "os_package_manager": "dnf_epel",
       "build": "spack/almalinux8",
@@ -93,7 +93,7 @@
         "develop": "latest"
       },
       "final": {
-        "image": "quay.io/almalinux/almalinux:8"
+        "image": "quay.io/almalinuxorg/almalinux:8"
       }
     },
     "centos:stream": {


### PR DESCRIPTION
As pointed out by @blue42u in (closed) https://github.com/spack/spack/pull/42187, it is better to change to the official almalinux containers. This PR does that by modifying the `images.json`.

The container images [recommended](https://almalinux.org/get-almalinux/#Container_Images) by almalinux *link* to https://quay.io/almalinuxorg/almalinux but the link *text* still has quay.io/almalinux/almalinux. The difference is clear from the listings:
- https://quay.io/repository/almalinux/almalinux?tab=tags&tag=latest (older versions only, don't use)
![image](https://github.com/spack/spack/assets/4656391/96d12eda-6164-41d5-a598-874ecf81e6c8)
- https://quay.io/repository/almalinuxorg/almalinux?tab=tags&tag=latest (newer versions, should use)
![image](https://github.com/spack/spack/assets/4656391/5a34516e-fefc-4c39-8c9f-6e17bb61d661)
