### PR TITLE
Update Xyce and Trilinos recipes

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -812,6 +812,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             ("HDF5", "hdf5", "hdf5"),
             ("HYPRE", "hypre", "hypre"),
             ("MUMPS", "mumps", "mumps"),
+            ("AMD", "suite-sparse", "suite-sparse"),
             ("UMFPACK", "suite-sparse", "suite-sparse"),
             ("SuperLU", "superlu", "superlu"),
             ("SuperLUDist", "superlu-dist", "superlu-dist"),

--- a/var/spack/repos/builtin/packages/xyce/package.py
+++ b/var/spack/repos/builtin/packages/xyce/package.py
@@ -10,13 +10,18 @@ from spack.package import *
 
 class Xyce(CMakePackage):
     """Xyce (rhymes with 'spice') is an open source, SPICE-compatible,
-    high-performance analog circuit simulator, capable of solving extremely
-    large circuit problems by supporting large-scale parallel computing
-    platforms.
-    Xyce also supports serial execution on all common desktop platforms,
-    and small-scale parallel runs on Unix-like systems. In addition to analog
-    electronic simulation, Xyce has also been used to investigate more general
-    network systems, such as neural networks and power grids.
+    high-performance analog circuit simulator, Xyce supports the standard
+    analysis capabilities found in other SPICE-like codes, such as DC,
+    transient, AC, and small-signal noise analyses; it also has less common
+    capabilities, such as harmonic balance, sensitivity analysis, and
+    uncertainty propagation techniques. Xyce supplies industry-standard compact
+    models and can support custom models via its Verilog-A model compiler.
+    Foundry process-development kits (PDKs) in other SPICE syntax can be used
+    via the XDM netlist translator, which is included as part of the Xyce
+    package. In addition to supporting use on all common desktop platforms
+    (Mac, Windows, Linux), Xyce can also be compiled to run in a large-scale
+    parallel mode to provide scalable, numerically accurate analog simulation
+    of circuits containing millions of devices, or more.
     """
 
     homepage = "https://xyce.sandia.gov"
@@ -27,18 +32,39 @@ class Xyce(CMakePackage):
     license("GPL-3.0-or-later")
 
     version("master", branch="master")
+    version("7.8.0", sha256="f763b7d5ad6defd25d2c7e5cc95155958cd12510a5e22a179daab459b21fa713")
     version("7.7.0", sha256="1b95450e1905c3af3c16b42c41d5ef1f8ab0e640f48086d0cb4d52961a90a175")
-    version("7.6.0", sha256="fc25557e2edc82adbe0436a15fca2929a2f9ab08ddf91f1a47aab5e8b27ec88c")
-    version("7.5.0", sha256="854d7d5e19e0ee2138d1f20f10f8f27f2bebb94ec81c157040955cff7250dacd")
-    version("7.4.0", sha256="2d6bc1b7377834b2e0bf50131e96728c5be83dbb3548e765bb48911067c87c91")
-    version("7.3.0", sha256="43869a70967f573ff6f00451db3f4642684834bdad1fd3926380e3789016b446")
-    version("7.2.0", sha256="cf49705278ecda46373784bb24925cb97f9017b6adff49e4416de146bdd6a4b5")
+    version(
+        "7.6.0",
+        sha256="fc25557e2edc82adbe0436a15fca2929a2f9ab08ddf91f1a47aab5e8b27ec88c",
+        deprecated=True,
+    )
+    version(
+        "7.5.0",
+        sha256="854d7d5e19e0ee2138d1f20f10f8f27f2bebb94ec81c157040955cff7250dacd",
+        deprecated=True,
+    )
+    version(
+        "7.4.0",
+        sha256="2d6bc1b7377834b2e0bf50131e96728c5be83dbb3548e765bb48911067c87c91",
+        deprecated=True,
+    )
+    version(
+        "7.3.0",
+        sha256="43869a70967f573ff6f00451db3f4642684834bdad1fd3926380e3789016b446",
+        deprecated=True,
+    )
+    version(
+        "7.2.0",
+        sha256="cf49705278ecda46373784bb24925cb97f9017b6adff49e4416de146bdd6a4b5",
+        deprecated=True,
+    )
 
-    depends_on("cmake@3.13:", type="build")
+    depends_on("cmake@3.22:", type="build")
     depends_on("flex")
     depends_on("bison")
 
-    variant("mpi", default=True, description="Enable MPI support")
+    variant("mpi", default=False, description="Enable MPI support")
     depends_on("mpi", when="+mpi")
 
     variant("plugin", default=False, description="Enable plug-in support for Xyce")
@@ -58,8 +84,8 @@ class Xyce(CMakePackage):
     variant("cxxstd", default="11", description="C++ standard", values=cxxstd_choices, multi=False)
 
     variant("pymi", default=False, description="Enable Python Model Interpreter for Xyce")
-    # Downstream dynamic library symbols from pip installed numpy and other
-    # pip installed python packages can cause conflicts. This is most often
+    # Downstream dynamic library symbols from pip-installed numpy and other
+    # pip-installed python packages can cause conflicts. This is most often
     # seen with blas symbols from numpy, and building blas static resolves
     # this issue.
     variant(
@@ -76,16 +102,20 @@ class Xyce(CMakePackage):
 
     depends_on(
         "trilinos"
-        "+amesos+amesos2+anasazi+aztec+basker+belos+complex+epetra+epetraext"
-        "+explicit_template_instantiation+fortran+ifpack+kokkos+nox"
-        "+sacado+suite-sparse+trilinoscouplings+stokhos+epetraextbtf"
-        "+epetraextexperimental+epetraextgraphreorderings"
+        "+amesos+amesos2+aztec+basker+belos+complex+epetra+epetraext"
+        "+epetraextbtf+epetraextexperimental+epetraextgraphreorderings"
+        "+ifpack+nox+sacado+stokhos+suite-sparse+trilinoscouplings"
     )
     depends_on("trilinos+isorropia+zoltan", when="+mpi")
 
-    # tested versions of Trilinos for everything up to 7.4.0
-    depends_on("trilinos@12.12.1:13.4", when="@:7.5")
-    depends_on("trilinos@13.5.0:develop", when="@7.6.0:master")
+    # Currently supported versions of Xyce
+    depends_on("trilinos@15.0.0:develop", when="@7.8.0:")
+    depends_on("trilinos+rol", when="@7.7.0:")
+
+    # tested versions of Trilinos against older versions of Xyce
+    depends_on("trilinos@13.5.0:14.4", when="@7.6.0:7.7.0")
+    depends_on("trilinos@12.12.1:13.4", when="@7.5")
+    depends_on("trilinos@12.12.1", when="@:7.4")
     depends_on("trilinos gotype=all cxxstd=11", when="^trilinos@:12.15")
     # pymi requires Kokkos/KokkosKernels >= 3.3, Trilinos 13.2 onward
     depends_on("trilinos@13.2.0:", when="+pymi")
@@ -97,7 +127,7 @@ class Xyce(CMakePackage):
 
     # The default settings for various Trilinos variants would require the
     # installation of many more packages than are needed for Xyce.
-    depends_on("trilinos~float~ifpack2~ml~muelu~zoltan2")
+    depends_on("trilinos~anasazi~float~ifpack2~ml~muelu~zoltan2")
 
     # Issue #1712 forces explicitly enumerating blas packages to propagate variants
     with when("+pymi_static_tpls"):
@@ -152,7 +182,12 @@ class Xyce(CMakePackage):
         when="@:7.7",
     )
 
-    # fix cmake trilinos test issue
+    # Xyce CMake relies on Kokkos to report if OpenMP was used.  However, the
+    # OpenMP requirement does not always propogate via the Spack packages, for
+    # various esoteric reasons.  Therefore, when Xyce checks to see if it can
+    # compile against Trilinos, the check might erroneously fail.  Since Spack
+    # should be handling everything properly, we simply disable the Trilinos
+    # compile test.  See the Xyce internal issue 454 for more information.
     patch(
         "454-cmake-xyce.patch",
         sha256="4d47cd1f10607205e64910ac124c6dd329f1ecbf861416e9da24a1736f2149ff",


### PR DESCRIPTION
These commits update the Xyce and Trilinos recipes. The Trilinos recipe assumed certain features required by Xyce would be enabled by default. I made those features visible in the Trilinos recipe. On the Xyce side, I made several adjustments to better reflect the Trilinos requirements and other features. In addition, I added the 7.8 release. See the commit messages for more details.