### PR TITLE
Revert "krb5: add perl as a build dependency"

### DIFF
--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -36,7 +36,6 @@ class Krb5(AutotoolsPackage):
     depends_on("openssl@:1", when="@:1.19")
     depends_on("openssl")
     depends_on("gettext")
-    depends_on("perl", type="build")
     depends_on("findutils", type="build")
     depends_on("pkgconfig", type="build", when="^openssl~shared")
 


### PR DESCRIPTION
Reverts spack/spack#42114

Pipelines started failing after this PR was merged. Checking if reverting fixes any of the :fire: currently on `develop`