### PR TITLE
Revert "cc: work around -v split between ld and ccld"

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -283,19 +283,10 @@ esac
 if [ -z "$mode" ] || [ "$mode" = ld ]; then
     for arg in "$@"; do
         case $arg in
-            -V|--version|-dumpversion)
+            -v|-V|--version|-dumpversion)
                 mode=vcheck
                 break
                 ;;
-            -v)
-                # NOTE(trws): -v is verbose on gcc, not version, this is an ld-mode flag only
-                # -V is invalid on gcc but may be valid on some other compiler so leaving that in
-                case "$mode" in
-                    ld)
-                        mode=vcheck
-                        break
-                        ;;
-                esac
         esac
     done
 fi

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -244,10 +244,10 @@ def test_no_wrapper_environment():
 def test_vcheck_mode(wrapper_environment):
     assert dump_mode(cc, ["-I/include", "--version"]) == "vcheck"
     assert dump_mode(cc, ["-I/include", "-V"]) == "vcheck"
+    assert dump_mode(cc, ["-I/include", "-v"]) == "vcheck"
     assert dump_mode(cc, ["-I/include", "-dumpversion"]) == "vcheck"
     assert dump_mode(cc, ["-I/include", "--version", "-c"]) == "vcheck"
     assert dump_mode(cc, ["-I/include", "-V", "-o", "output"]) == "vcheck"
-    assert dump_mode(ld, ["-I/include", "-v"]) == "vcheck"
 
 
 def test_cpp_mode(wrapper_environment):


### PR DESCRIPTION
Reverts spack/spack#42111

Causes issues, since `g++ -v` exits with error, and is used in various places (even if erroneously...)

```
$ spack build-env /2qoktqo -- env SPACK_TEST_COMMAND=dump-args gcc -v
ccache
/usr/bin/gcc
-march=znver2
-mtune=znver2
-Wl,--disable-new-dtags
-Wl,-rpath,/home/harmen/spack/opt/spack/linux-ubuntu23.10-zen2/gcc-13.2.0/zlib-ng-2.1.4-2qoktqohv4xnpobdflwjrh6vuahf7x2a/lib
-Wl,-rpath,/home/harmen/spack/opt/spack/linux-ubuntu23.10-zen2/gcc-13.2.0/zlib-ng-2.1.4-2qoktqohv4xnpobdflwjrh6vuahf7x2a/lib64
-v
```

The issue is that adding `-Wl,-rpath,*` flags causes the compiler / linker to be invoked, which fails cause there is no code.