### PR TITLE
ROOT: fix macos build for 6.30

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -124,6 +124,12 @@ class Root(CMakePackage):
         # Resolve circular dependency, _cf_
         # https://sft.its.cern.ch/jira/browse/ROOT-8226.
         patch("root6-60606-mathmore.patch", when="@6.06.06")
+        # Fix macOS build when cocoa is disabled:
+        patch(
+            "https://github.com/root-project/root/pull/14387.patch?full_index=1",
+            sha256="559495f7bdd6b7674d3b1019da9b76e8b374f6dca3dbe72fb1320b0be2b00e53",
+            when="@6.30:6.30.3 ~aqua",
+        )
 
     # ###################### Variants ##########################
     # See README.md for specific notes about what ROOT configuration


### PR DESCRIPTION
This applies https://github.com/root-project/root/pull/14387 to the latest ROOT to fix a link error on macOS. I successfully installed `root@6.30.02~aqua~arrow~cuda~cudnn~davix~dcache~emacs~examples~fftw~fits~fortran+gdml+gminimal~graphviz+gsl~http~ipo+math+minuit~mlp~mysql~opengl~oracle~postgres~pythia6~pythia8+python~r+roofit~root7+rpath~shadow~spectrum~sqlite~ssl~tbb+threads~tmva~tmva-cpu~tmva-gpu~tmva-pymva~tmva-sofie+unuran~vc+vdt~veccore~x+xml~xrootd build_system=cmake build_type=Release cxxstd=17 generator=make patches=22af347,559495f darwin-sonoma-m2 / apple-clang@15.0.0`