### PR TITLE
libtool: add build dep on findutils

### DIFF
--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -34,6 +34,12 @@ class Libtool(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on("m4@1.4.6:", type="build")
 
+    # the following are places in which libtool depends on findutils
+    # https://github.com/autotools-mirror/libtool/blob/v2.4.7/build-aux/ltmain.in#L3296
+    # https://github.com/autotools-mirror/libtool/blob/v2.4.6/build-aux/ltmain.in#L3278
+    # https://github.com/autotools-mirror/libtool/blob/v2.4.2/libltdl/config/ltmain.m4sh#L3028
+    depends_on("findutils", type="run")
+
     with when("@2.4.2"):
         depends_on("autoconf", type="build")
         depends_on("automake", type="build")


### PR DESCRIPTION
There is some discussion on if we need to explicitly state when there is a dependency on `find`, considering many systems have it installed by default (e.g. POSIX systems), but neither a POSIX environment nor `find` are listed [requirements of Spack](https://spack.readthedocs.io/en/latest/getting_started.html#system-prerequisites). If not listed here, it should probably go there.

Also see https://github.com/spack/spack/pull/39902