### PR TITLE
CMakePackage pass python hints automatically

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -86,7 +86,11 @@ class CMakePackage(spack.package_base.PackageBase):
     #: Legacy buildsystem attribute used to deserialize and install old specs
     legacy_buildsystem = "cmake"
 
-    #: Enable injecting FindPython{,3} hints
+    #: When this package depends on Python and ``find_python_hints`` is set to True, pass the
+    #: defines {Python3,Python,PYTHON}_EXECUTABLE explicitly, so that CMake locates the right
+    #: Python in its builtin FindPython3, FindPython, and FindPythonInterp modules. Spack does
+    #: CMake's job because CMake's modules by default only search for Python versions known at the
+    #: time of release.
     find_python_hints = True
 
     build_system("cmake")
@@ -291,12 +295,13 @@ class CMakeBuilder(BaseBuilder):
                 [define("CMAKE_FIND_FRAMEWORK", "LAST"), define("CMAKE_FIND_APPBUNDLE", "LAST")]
             )
 
-        if getattr(pkg, "find_python_hints", False) and "python" in pkg.dependency_names():
+        if getattr(pkg, "find_python_hints", False) and pkg.spec.dependencies("python"):
+            python_executable = pkg.spec["python"].command.path
             args.extend(
                 [
-                    define("PYTHON_EXECUTABLE", pkg.spec["python"].command.path),
-                    define("Python_EXECUTABLE", pkg.spec["python"].command.path),
-                    define("Python3_EXECUTABLE", pkg.spec["python"].command.path),
+                    define("PYTHON_EXECUTABLE", python_executable),
+                    define("Python_EXECUTABLE", python_executable),
+                    define("Python3_EXECUTABLE", python_executable),
                 ]
             )
 

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -86,6 +86,9 @@ class CMakePackage(spack.package_base.PackageBase):
     #: Legacy buildsystem attribute used to deserialize and install old specs
     legacy_buildsystem = "cmake"
 
+    #: Enable injecting FindPython{,3} hints
+    find_python_hints = True
+
     build_system("cmake")
 
     with when("build_system=cmake"):
@@ -286,6 +289,15 @@ class CMakeBuilder(BaseBuilder):
         if platform.mac_ver()[0]:
             args.extend(
                 [define("CMAKE_FIND_FRAMEWORK", "LAST"), define("CMAKE_FIND_APPBUNDLE", "LAST")]
+            )
+
+        if getattr(pkg, "find_python_hints", False) and "python" in pkg.dependency_names():
+            args.extend(
+                [
+                    define("PYTHON_EXECUTABLE", pkg.spec["python"].command.path),
+                    define("Python_EXECUTABLE", pkg.spec["python"].command.path),
+                    define("Python3_EXECUTABLE", pkg.spec["python"].command.path),
+                ]
             )
 
         # Set up CMake rpath

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -295,15 +295,17 @@ class CMakeBuilder(BaseBuilder):
                 [define("CMAKE_FIND_FRAMEWORK", "LAST"), define("CMAKE_FIND_APPBUNDLE", "LAST")]
             )
 
-        if getattr(pkg, "find_python_hints", False) and pkg.spec.dependencies("python"):
-            python_executable = pkg.spec["python"].command.path
-            args.extend(
-                [
-                    define("PYTHON_EXECUTABLE", python_executable),
-                    define("Python_EXECUTABLE", python_executable),
-                    define("Python3_EXECUTABLE", python_executable),
-                ]
-            )
+        if getattr(pkg, "find_python_hints", False):
+            python = pkg.spec.dependencies("python")
+            if len(python) == 1:
+                python_executable = python[0].package.command.path
+                args.extend(
+                    [
+                        define("PYTHON_EXECUTABLE", python_executable),
+                        define("Python_EXECUTABLE", python_executable),
+                        define("Python3_EXECUTABLE", python_executable),
+                    ]
+                )
 
         # Set up CMake rpath
         args.extend(

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -15,6 +15,7 @@ import llnl.util.filesystem as fs
 
 import spack.build_environment
 import spack.builder
+import spack.deptypes as dt
 import spack.package_base
 from spack.directives import build_system, conflicts, depends_on, variant
 from spack.multimethod import when
@@ -296,7 +297,7 @@ class CMakeBuilder(BaseBuilder):
             )
 
         if getattr(pkg, "find_python_hints", False):
-            python = pkg.spec.dependencies("python")
+            python = pkg.spec.dependencies("python", dt.BUILD | dt.LINK)
             if len(python) == 1:
                 python_executable = python[0].package.command.path
                 args.extend(

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -458,10 +458,6 @@ class Acts(CMakePackage, CudaPackage):
             if cuda_arch != "none":
                 args.append(f"-DCUDA_FLAGS=-arch=sm_{cuda_arch[0]}")
 
-        if "+python" in spec:
-            python = spec["python"].command.path
-            args.append(f"-DPython_EXECUTABLE={python}")
-
         args.append(self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"))
 
         return args

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -292,10 +292,6 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
         if "%fj" in spec:
             args.extend(["-DCMAKE_Fortran_SUBMODULE_EXT=.smod", "-DCMAKE_Fortran_SUBMODULE_SEP=."])
 
-        if "+python" in spec or self.run_tests:
-            args.append(f"-DPYTHON_EXECUTABLE:FILEPATH={spec['python'].command.path}")
-            args.append(f"-DPython_EXECUTABLE:FILEPATH={spec['python'].command.path}")
-
         # hip support
         if "+cuda" in spec:
             args.append(self.builder.define_cuda_architectures(self))

--- a/var/spack/repos/builtin/packages/bohrium/package.py
+++ b/var/spack/repos/builtin/packages/bohrium/package.py
@@ -119,8 +119,6 @@ class Bohrium(CMakePackage, CudaPackage):
         # different hosts.
 
         args = [
-            # Choose a particular python version
-            "-DPYTHON_EXECUTABLE:FILEPATH=" + spec["python"].command.path,
             #
             # Hard-disable Jupyter, since this would override a config
             # file in the user's home directory in some cases during

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -129,7 +129,6 @@ class Caliper(CMakePackage, CudaPackage, ROCmPackage):
         spec = self.spec
 
         args = [
-            ("-DPYTHON_EXECUTABLE=%s" % spec["python"].command.path),
             "-DBUILD_TESTING=Off",
             "-DBUILD_DOCS=Off",
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -92,22 +92,6 @@ class Clingo(CMakePackage):
             )
 
     @property
-    def cmake_python_hints(self):
-        """Return standard CMake defines to ensure that the
-        current spec is the one found by CMake find_package(Python, ...)
-        """
-        python = self.spec["python"]
-        return [
-            self.define("Python_EXECUTABLE", python.command.path),
-            self.define("Python_INCLUDE_DIR", python.headers.directories[0]),
-            self.define("Python_LIBRARIES", python.libs[0]),
-            # XCode command line tools on macOS has no python-config executable, and
-            # CMake assumes you have python 2 if it does not find a python-config,
-            # so we set the version explicitly so that it's passed to FindPython.
-            self.define("CLINGO_PYTHON_VERSION", python.version.up_to(2)),
-        ]
-
-    @property
     def cmake_py_shared(self):
         return self.define("CLINGO_BUILD_PY_SHARED", "ON")
 
@@ -127,8 +111,6 @@ class Clingo(CMakePackage):
                 "-DPYCLINGO_USE_INSTALL_PREFIX=ON",
                 self.cmake_py_shared,
             ]
-            if self.spec["cmake"].satisfies("@3.16.0:"):
-                args += self.cmake_python_hints
         else:
             args += ["-DCLINGO_BUILD_WITH_PYTHON=OFF"]
 

--- a/var/spack/repos/builtin/packages/cvise/package.py
+++ b/var/spack/repos/builtin/packages/cvise/package.py
@@ -33,6 +33,3 @@ class Cvise(CMakePackage):
 
     depends_on("py-pytest", when="+pytest", type=("build", "run"))
     depends_on("colordiff", when="+colordiff", type=("build", "run"))
-
-    def cmake_args(self):
-        return ["-DPYTHON_EXECUTABLE=" + self.spec["python"].command.path]

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -232,7 +232,6 @@ class Dd4hep(CMakePackage):
             "-DBUILD_TESTING={0}".format(self.run_tests),
             "-DBOOST_ROOT={0}".format(spec["boost"].prefix),
             "-DBoost_NO_BOOST_CMAKE=ON",
-            "-DPYTHON_EXECUTABLE={0}".format(spec["python"].command.path),
         ]
         subpackages = []
         if spec.satisfies("+ddg4"):

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -540,12 +540,10 @@ class Dealii(CMakePackage, CudaPackage):
         if spec.satisfies("@8.5.0:"):
             options.append(self.define_from_variant("DEAL_II_COMPONENT_PYTHON_BINDINGS", "python"))
             if "+python" in spec:
-                python_exe = spec["python"].command.path
                 python_library = spec["python"].libs[0]
                 python_include = spec["python"].headers.directories[0]
                 options.extend(
                     [
-                        self.define("PYTHON_EXECUTABLE", python_exe),
                         self.define("PYTHON_INCLUDE_DIR", python_include),
                         self.define("PYTHON_LIBRARY", python_library),
                     ]

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -539,15 +539,6 @@ class Dealii(CMakePackage, CudaPackage):
         # Python bindings
         if spec.satisfies("@8.5.0:"):
             options.append(self.define_from_variant("DEAL_II_COMPONENT_PYTHON_BINDINGS", "python"))
-            if "+python" in spec:
-                python_library = spec["python"].libs[0]
-                python_include = spec["python"].headers.directories[0]
-                options.extend(
-                    [
-                        self.define("PYTHON_INCLUDE_DIR", python_include),
-                        self.define("PYTHON_LIBRARY", python_library),
-                    ]
-                )
 
         # Simplex support (no longer experimental)
         if spec.satisfies("@9.3.0:9.4.0"):

--- a/var/spack/repos/builtin/packages/doxygen/package.py
+++ b/var/spack/repos/builtin/packages/doxygen/package.py
@@ -124,12 +124,3 @@ class Doxygen(CMakePackage):
             join_path("cmake", "FindIconv.cmake"),
             string=True,
         )
-
-    def cmake_args(self):
-        args = [
-            # Doxygen's build system uses CMake's deprecated `FindPythonInterp`,
-            # which can get confused by other `python` executables in the PATH.
-            # See issue: https://github.com/spack/spack/issues/28215
-            self.define("PYTHON_EXECUTABLE", self.spec["python"].command.path)
-        ]
-        return args

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -351,9 +351,6 @@ class Eccodes(CMakePackage):
             # Prevent overriding by environment variables AEC_DIR and AEC_PATH:
             args.append(self.define("AEC_DIR", self.spec["libaec"].prefix))
 
-        if "+memfs" in self.spec:
-            args.append(self.define("PYTHON_EXECUTABLE", python.path))
-
         return args
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -91,7 +91,6 @@ class Ecflow(CMakePackage):
             self.define_from_variant("ENABLE_SSL", "ssl"),
             # https://jira.ecmwf.int/browse/SUP-2641#comment-208943
             self.define_from_variant("ENABLE_STATIC_BOOST_LIBS", "static_boost"),
-            self.define("Python3_EXECUTABLE", spec["python"].package.command),
             self.define("BOOST_ROOT", spec["boost"].prefix),
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
         ]

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -73,7 +73,6 @@ class EcmwfAtlas(CMakePackage):
             self.define_from_variant("ENABLE_TRANS", "trans"),
             self.define_from_variant("ENABLE_EIGEN", "eigen"),
             self.define_from_variant("ENABLE_FFTW", "fftw"),
-            "-DPYTHON_EXECUTABLE:FILEPATH=" + self.spec["python"].command.path,
         ]
         if "~shared" in self.spec:
             args.append("-DBUILD_SHARED_LIBS=OFF")

--- a/var/spack/repos/builtin/packages/faiss/package.py
+++ b/var/spack/repos/builtin/packages/faiss/package.py
@@ -96,9 +96,6 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             self.define_from_variant("BUILD_TESTING", "tests"),
             self.define("FAISS_OPT_LEVEL", "generic"),
         ]
-        if "+python" in spec:
-            pyexe = spec["python"].command.path
-            args.append(self.define("Python_EXECUTABLE", pyexe))
 
         if "+cuda" in spec:
             key = "CMAKE_CUDA_ARCHITECTURES"

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -62,7 +62,6 @@ class Fckit(CMakePackage):
         args = [
             self.define_from_variant("ENABLE_ECKIT", "eckit"),
             self.define_from_variant("ENABLE_OMP", "openmp"),
-            "-DPYTHON_EXECUTABLE:FILEPATH=" + self.spec["python"].command.path,
             "-DFYPP_NO_LINE_NUMBERING=ON",
         ]
 

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -123,8 +123,4 @@ class Flann(CMakePackage):
         use_mpi = "ON" if "+mpi" in spec else "OFF"
         args.append("-DUSE_MPI:BOOL={0}".format(use_mpi))
 
-        # Configure the proper python executable
-        if "+python" in spec:
-            args.append("-DPYTHON_EXECUTABLE={0}".format(spec["python"].command.path))
-
         return args

--- a/var/spack/repos/builtin/packages/gnina/package.py
+++ b/var/spack/repos/builtin/packages/gnina/package.py
@@ -70,10 +70,7 @@ class Gnina(CMakePackage, CudaPackage):
     depends_on("cudnn", when="+cudnn")
 
     def cmake_args(self):
-        args = [
-            "-DBLAS=Open",  # Use OpenBLAS instead of Atlas' BLAS
-            f"-DPYTHON_EXECUTABLE={self.spec['python'].command.path}",
-        ]
+        args = ["-DBLAS=Open"]  # Use OpenBLAS instead of Atlas' BLAS
 
         if "+gninavis" in self.spec:
             args.append(f"-DRDKIT_INCLUDE_DIR={self.spec['rdkit'].prefix.include.rdkit}")

--- a/var/spack/repos/builtin/packages/gnuradio/package.py
+++ b/var/spack/repos/builtin/packages/gnuradio/package.py
@@ -61,10 +61,7 @@ class Gnuradio(CMakePackage):
     extends("python")
 
     def cmake_args(self):
-        args = []
-        args.append("-DPYTHON_EXECUTABLE={0}".format(self.spec["python"].command.path))
-        args.append("-DENABLE_INTERNAL_VOLK=OFF")
-        return args
+        return ["-DENABLE_INTERNAL_VOLK=OFF"]
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.prepend_path("XDG_DATA_DIRS", self.prefix.share)

--- a/var/spack/repos/builtin/packages/halide/package.py
+++ b/var/spack/repos/builtin/packages/halide/package.py
@@ -108,7 +108,6 @@ class Halide(CMakePackage, PythonExtension):
 
         if "+python" in spec:
             args += [
-                self.define("Python3_EXECUTABLE", spec["python"].command.path),
                 self.define("PYBIND11_USE_FETCHCONTENT", False),
                 self.define("Halide_INSTALL_PYTHONDIR", python_platlib),
             ]

--- a/var/spack/repos/builtin/packages/henson/package.py
+++ b/var/spack/repos/builtin/packages/henson/package.py
@@ -32,13 +32,8 @@ class Henson(CMakePackage):
     conflicts("^openmpi", when="+mpi-wrappers")
 
     def cmake_args(self):
-        args = [
+        return [
             self.define_from_variant("python", "python"),
             self.define_from_variant("mpi-wrappers", "mpi-wrappers"),
             self.define_from_variant("use_boost", "boost"),
         ]
-
-        if self.spec.satisfies("+python"):
-            args += [self.define("PYTHON_EXECUTABLE", self.spec["python"].command.path)]
-
-        return args

--- a/var/spack/repos/builtin/packages/hoomd-blue/package.py
+++ b/var/spack/repos/builtin/packages/hoomd-blue/package.py
@@ -65,10 +65,7 @@ class HoomdBlue(CMakePackage):
     def cmake_args(self):
         spec = self.spec
 
-        cmake_args = [
-            "-DPYTHON_EXECUTABLE={0}".format(spec["python"].command.path),
-            "-DCMAKE_INSTALL_PREFIX={0}".format(python_platlib),
-        ]
+        cmake_args = ["-DCMAKE_INSTALL_PREFIX={0}".format(python_platlib)]
 
         # MPI support
         if "+mpi" in spec:

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -860,9 +860,6 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
         if "+rocm" in spec:
             args.append(self.define("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
-        if "+python" in spec:
-            args.append(self.define("Python_EXECUTABLE", spec["python"].command.path))
-
         return args
 
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/libmolgrid/package.py
+++ b/var/spack/repos/builtin/packages/libmolgrid/package.py
@@ -35,9 +35,4 @@ class Libmolgrid(CMakePackage):
         ob_incl = os.path.join(self.spec["openbabel"].prefix.include, "openbabel3")
         ob_libs = self.spec["openbabel"].libs.joined(";")
 
-        args = [
-            "-DOPENBABEL3_INCLUDE_DIR=" + ob_incl,
-            "-DOPENBABEL3_LIBRARIES=" + ob_libs,
-            f"-DPYTHON_EXECUTABLE={self.spec['python'].command.path}",
-        ]
-        return args
+        return ["-DOPENBABEL3_INCLUDE_DIR=" + ob_incl, "-DOPENBABEL3_LIBRARIES=" + ob_libs]

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -278,7 +278,6 @@ class Libpressio(CMakePackage, CudaPackage):
         if "+python" in self.spec:
             args.append("-DLIBPRESSIO_PYTHON_SITELIB={0}".format(python_platlib))
             args.append("-DBUILD_PYTHON_WRAPPER=ON")
-            args.append("-DPython3_EXECUTABLE={0}".format(self.spec["python"].command))
             if "+mpi" in self.spec:
                 args.append("-DLIBPRESSIO_HAS_MPI4PY=ON")
         if "+hdf5" in self.spec:

--- a/var/spack/repos/builtin/packages/llvm-doe/package.py
+++ b/var/spack/repos/builtin/packages/llvm-doe/package.py
@@ -405,13 +405,11 @@ class LlvmDoe(CMakePackage, CudaPackage):
         define = self.define
         from_variant = self.define_from_variant
 
-        python = spec["python"]
         cmake_args = [
             define("LLVM_REQUIRES_RTTI", True),
             define("LLVM_ENABLE_RTTI", True),
             define("LLVM_ENABLE_EH", True),
             define("CLANG_DEFAULT_OPENMP_RUNTIME", "libomp"),
-            define("PYTHON_EXECUTABLE", python.command.path),
             define("LIBOMP_USE_HWLOC", True),
             define("LIBOMP_HWLOC_INSTALL_DIR", spec["hwloc"].prefix),
         ]
@@ -419,11 +417,6 @@ class LlvmDoe(CMakePackage, CudaPackage):
         version_suffix = spec.variants["version_suffix"].value
         if version_suffix != "none":
             cmake_args.append(define("LLVM_VERSION_SUFFIX", version_suffix))
-
-        if python.version >= Version("3"):
-            cmake_args.append(define("Python3_EXECUTABLE", python.command.path))
-        else:
-            cmake_args.append(define("Python2_EXECUTABLE", python.command.path))
 
         projects = []
         runtimes = []

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -781,13 +781,11 @@ class Llvm(CMakePackage, CudaPackage):
         define = self.define
         from_variant = self.define_from_variant
 
-        python = spec["python"]
         cmake_args = [
             define("LLVM_REQUIRES_RTTI", True),
             define("LLVM_ENABLE_RTTI", True),
             define("LLVM_ENABLE_LIBXML2", False),
             define("CLANG_DEFAULT_OPENMP_RUNTIME", "libomp"),
-            define("PYTHON_EXECUTABLE", python.command.path),
             define("LIBOMP_USE_HWLOC", True),
             define("LIBOMP_HWLOC_INSTALL_DIR", spec["hwloc"].prefix),
             from_variant("LLVM_ENABLE_ZSTD", "zstd"),
@@ -810,11 +808,6 @@ class Llvm(CMakePackage, CudaPackage):
         shlib_symbol_version = spec.variants.get("shlib_symbol_version", None)
         if shlib_symbol_version is not None and shlib_symbol_version.value != "none":
             cmake_args.append(define("LLVM_SHLIB_SYMBOL_VERSION", shlib_symbol_version.value))
-
-        if python.version >= Version("3"):
-            cmake_args.append(define("Python3_EXECUTABLE", python.command.path))
-        else:
-            cmake_args.append(define("Python2_EXECUTABLE", python.command.path))
 
         projects = []
         runtimes = []

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -86,9 +86,6 @@ class Neuron(CMakePackage):
         if "~mpi" in spec and "+coreneuron" in spec:
             args.append("-DCORENRN_ENABLE_MPI=OFF")
 
-        if "+python" in spec:
-            args.append("-DPYTHON_EXECUTABLE:FILEPATH=" + spec["python"].command.path)
-
         if spec.variants["build_type"].value == "Debug":
             args.append("-DCMAKE_C_FLAGS=-g -O0")
             args.append("-DCMAKE_CXX_FLAGS=-g -O0")

--- a/var/spack/repos/builtin/packages/nlopt/package.py
+++ b/var/spack/repos/builtin/packages/nlopt/package.py
@@ -53,16 +53,12 @@ class Nlopt(CMakePackage):
         # Specify on command line to alter defaults:
         # eg: spack install nlopt@master +guile -octave +cxx
 
-        # Spack should locate python by default - but to point to a build
-        if "+python" in spec:
-            args.append("-DPYTHON_EXECUTABLE=%s" % spec["python"].command.path)
-
         # On is default
-        if "-shared" in spec:
+        if "~shared" in spec:
             args.append("-DBUILD_SHARED_LIBS:Bool=OFF")
 
         # On is default
-        if "-octave" in spec:
+        if "~octave" in spec:
             args.append("-DNLOPT_OCTAVE:Bool=OFF")
 
         if "+cxx" in spec:

--- a/var/spack/repos/builtin/packages/odgi/package.py
+++ b/var/spack/repos/builtin/packages/odgi/package.py
@@ -41,8 +41,4 @@ class Odgi(CMakePackage):
     # >>> Dependencies list ends here
 
     def cmake_args(self):
-        args = [
-            "-DCMAKE_CXX_STANDARD_REQUIRED:BOOL=ON",
-            "-DPYTHON_EXECUTABLE:FILEPATH={0}".format(self.spec["python"].command),
-        ]
-        return args
+        return ["-DCMAKE_CXX_STANDARD_REQUIRED:BOOL=ON"]

--- a/var/spack/repos/builtin/packages/omnitrace/package.py
+++ b/var/spack/repos/builtin/packages/omnitrace/package.py
@@ -126,11 +126,6 @@ class Omnitrace(CMakePackage):
             tau_root = spec["tau"].prefix
             args.append(self.define("TAU_ROOT_DIR", tau_root))
 
-        if "+python" in spec:
-            pyexe = spec["python"].command.path
-            args.append(self.define("PYTHON_EXECUTABLE", pyexe))
-            args.append(self.define("Python3_EXECUTABLE", pyexe))
-
         if "+mpi" in spec:
             args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
             args.append(self.define("MPI_CXX_COMPILER", spec["mpi"].mpicxx))

--- a/var/spack/repos/builtin/packages/open3d/package.py
+++ b/var/spack/repos/builtin/packages/open3d/package.py
@@ -70,7 +70,7 @@ class Open3d(CMakePackage, CudaPackage):
         )
 
     def cmake_args(self):
-        args = [
+        return [
             self.define("BUILD_UNIT_TESTS", self.run_tests),
             self.define_from_variant("BUILD_PYTHON_MODULE", "python"),
             self.define_from_variant("BUILD_CUDA_MODULE", "cuda"),
@@ -94,11 +94,6 @@ class Open3d(CMakePackage, CudaPackage):
             # self.define('USE_SYSTEM_TINYGLTF', True),
             # self.define('USE_SYSTEM_TINYOBJLOADER', True),
         ]
-
-        if "+python" in self.spec:
-            args.append(self.define("PYTHON_EXECUTABLE", self.spec["python"].command.path))
-
-        return args
 
     def check(self):
         with working_dir(self.build_directory):

--- a/var/spack/repos/builtin/packages/openbabel/package.py
+++ b/var/spack/repos/builtin/packages/openbabel/package.py
@@ -63,13 +63,7 @@ class Openbabel(CMakePackage):
         args = []
 
         if "+python" in spec:
-            args.extend(
-                [
-                    "-DPYTHON_BINDINGS=ON",
-                    "-DPYTHON_EXECUTABLE={0}".format(spec["python"].command.path),
-                    "-DRUN_SWIG=ON",
-                ]
-            )
+            args.extend(["-DPYTHON_BINDINGS=ON", "-DRUN_SWIG=ON"])
         else:
             args.append("-DPYTHON_BINDINGS=OFF")
 

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -1026,14 +1026,12 @@ class Opencv(CMakePackage, CudaPackage):
             )
 
         # Python
-        python_exe = spec["python"].command.path
         python_lib = spec["python"].libs[0]
         python_include_dir = spec["python"].headers.directories[0]
 
         if "+python3" in spec:
             args.extend(
                 [
-                    self.define("PYTHON3_EXECUTABLE", python_exe),
                     self.define("PYTHON3_LIBRARY", python_lib),
                     self.define("PYTHON3_INCLUDE_DIR", python_include_dir),
                     self.define("PYTHON2_EXECUTABLE", ""),

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -15,6 +15,7 @@ class Opencv(CMakePackage, CudaPackage):
     homepage = "https://opencv.org/"
     url = "https://github.com/opencv/opencv/archive/4.5.0.tar.gz"
     git = "https://github.com/opencv/opencv.git"
+    find_python_hints = False  # opencv uses custom OpenCVDetectPython.cmake
 
     maintainers("bvanessen", "adamjstewart")
 
@@ -1026,12 +1027,14 @@ class Opencv(CMakePackage, CudaPackage):
             )
 
         # Python
+        python_exe = spec["python"].command.path
         python_lib = spec["python"].libs[0]
         python_include_dir = spec["python"].headers.directories[0]
 
         if "+python3" in spec:
             args.extend(
                 [
+                    self.define("PYTHON3_EXECUTABLE", python_exe),
                     self.define("PYTHON3_LIBRARY", python_lib),
                     self.define("PYTHON3_INCLUDE_DIR", python_include_dir),
                     self.define("PYTHON2_EXECUTABLE", ""),

--- a/var/spack/repos/builtin/packages/openmolcas/package.py
+++ b/var/spack/repos/builtin/packages/openmolcas/package.py
@@ -44,11 +44,7 @@ class Openmolcas(CMakePackage):
             env.append_path("PATH", self.prefix)
 
     def cmake_args(self):
-        args = [
-            "-DLINALG=OpenBLAS",
-            "-DOPENBLASROOT=%s" % self.spec["openblas"].prefix,
-            "-DPYTHON_EXECUTABLE=%s" % self.spec["python"].command.path,
-        ]
+        args = ["-DLINALG=OpenBLAS", "-DOPENBLASROOT=%s" % self.spec["openblas"].prefix]
         if "+mpi" in self.spec:
             mpi_args = [
                 "-DMPI=ON",

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -123,13 +123,7 @@ class OpenpmdApi(CMakePackage):
 
         # switch internally shipped third-party libraries for spack
         if spec.satisfies("+python"):
-            py_exe_define = (
-                "Python_EXECUTABLE" if spec.version >= Version("0.13.0") else "PYTHON_EXECUTABLE"
-            )
-            args += [
-                self.define(py_exe_define, self.spec["python"].command.path),
-                self.define("openPMD_USE_INTERNAL_PYBIND11", False),
-            ]
+            args.append(self.define("openPMD_USE_INTERNAL_PYBIND11", False))
 
         args.append(self.define("openPMD_USE_INTERNAL_JSON", False))
         if spec.satisfies("@:0.14"):  # pre C++17 releases

--- a/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
@@ -236,24 +236,19 @@ class OpenspeedshopUtils(CMakePackage):
         # Appends to cmake_options the options that will enable
         # the appropriate base level options to the openspeedshop
         # cmake build.
-        python_library = spec["python"].libs[0]
-        python_include = spec["python"].headers.directories[0]
-
-        base_options = []
-
-        base_options.append("-DBINUTILS_DIR=%s" % spec["binutils"].prefix)
-        base_options.append("-DLIBELF_DIR=%s" % spec["elfutils"].prefix)
-        base_options.append("-DLIBDWARF_DIR=%s" % spec["libdwarf"].prefix)
-        base_options.append("-DPYTHON_INCLUDE_DIR=%s" % python_include)
-        base_options.append("-DPYTHON_LIBRARY=%s" % python_library)
-        base_options.append("-DBoost_NO_SYSTEM_PATHS=TRUE")
-        base_options.append("-DBoost_NO_BOOST_CMAKE=TRUE")
-        base_options.append("-DBOOST_ROOT=%s" % spec["boost"].prefix)
-        base_options.append("-DBoost_DIR=%s" % spec["boost"].prefix)
-        base_options.append("-DBOOST_LIBRARYDIR=%s" % spec["boost"].prefix.lib)
-        base_options.append("-DDYNINST_DIR=%s" % spec["dyninst"].prefix)
-
-        cmake_options.extend(base_options)
+        cmake_options.extend(
+            [
+                self.define("BINUTILS_DIR", spec["binutils"].prefix),
+                self.define("LIBELF_DIR", spec["elfutils"].prefix),
+                self.define("LIBDWARF_DIR", spec["libdwarf"].prefix),
+                self.define("Boost_NO_SYSTEM_PATHS", True),
+                self.define("Boost_NO_BOOST_CMAKE", True),
+                self.define("BOOST_ROOT", spec["boost"].prefix),
+                self.define("Boost_DIR", spec["boost"].prefix),
+                self.define("BOOST_LIBRARYDIR", spec["boost"].prefix.lib),
+                self.define("DYNINST_DIR", spec["dyninst"].prefix),
+            ]
+        )
 
     def set_mpi_cmake_options(self, spec, cmake_options):
         # Appends to cmake_options the options that will enable

--- a/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
@@ -236,7 +236,6 @@ class OpenspeedshopUtils(CMakePackage):
         # Appends to cmake_options the options that will enable
         # the appropriate base level options to the openspeedshop
         # cmake build.
-        python_exe = spec["python"].command.path
         python_library = spec["python"].libs[0]
         python_include = spec["python"].headers.directories[0]
 
@@ -245,7 +244,6 @@ class OpenspeedshopUtils(CMakePackage):
         base_options.append("-DBINUTILS_DIR=%s" % spec["binutils"].prefix)
         base_options.append("-DLIBELF_DIR=%s" % spec["elfutils"].prefix)
         base_options.append("-DLIBDWARF_DIR=%s" % spec["libdwarf"].prefix)
-        base_options.append("-DPYTHON_EXECUTABLE=%s" % python_exe)
         base_options.append("-DPYTHON_INCLUDE_DIR=%s" % python_include)
         base_options.append("-DPYTHON_LIBRARY=%s" % python_library)
         base_options.append("-DBoost_NO_SYSTEM_PATHS=TRUE")

--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -254,7 +254,6 @@ class Openspeedshop(CMakePackage):
         # Appends to cmake_options the options that will enable
         # the appropriate base level options to the openspeedshop
         # cmake build.
-        python_exe = spec["python"].command.path
         python_library = spec["python"].libs[0]
         python_include = spec["python"].headers.directories[0]
         true_value = "TRUE"
@@ -264,7 +263,6 @@ class Openspeedshop(CMakePackage):
         base_options.append("-DBINUTILS_DIR=%s" % spec["binutils"].prefix)
         base_options.append("-DLIBELF_DIR=%s" % spec["elfutils"].prefix)
         base_options.append("-DLIBDWARF_DIR=%s" % spec["libdwarf"].prefix)
-        base_options.append("-DPYTHON_EXECUTABLE=%s" % python_exe)
         base_options.append("-DPYTHON_INCLUDE_DIR=%s" % python_include)
         base_options.append("-DPYTHON_LIBRARY=%s" % python_library)
         base_options.append("-DBoost_NO_SYSTEM_PATHS=%s" % true_value)

--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -254,25 +254,19 @@ class Openspeedshop(CMakePackage):
         # Appends to cmake_options the options that will enable
         # the appropriate base level options to the openspeedshop
         # cmake build.
-        python_library = spec["python"].libs[0]
-        python_include = spec["python"].headers.directories[0]
-        true_value = "TRUE"
-
-        base_options = []
-
-        base_options.append("-DBINUTILS_DIR=%s" % spec["binutils"].prefix)
-        base_options.append("-DLIBELF_DIR=%s" % spec["elfutils"].prefix)
-        base_options.append("-DLIBDWARF_DIR=%s" % spec["libdwarf"].prefix)
-        base_options.append("-DPYTHON_INCLUDE_DIR=%s" % python_include)
-        base_options.append("-DPYTHON_LIBRARY=%s" % python_library)
-        base_options.append("-DBoost_NO_SYSTEM_PATHS=%s" % true_value)
-        base_options.append("-DBoost_NO_BOOST_CMAKE=%s" % true_value)
-        base_options.append("-DBOOST_ROOT=%s" % spec["boost"].prefix)
-        base_options.append("-DBoost_DIR=%s" % spec["boost"].prefix)
-        base_options.append("-DBOOST_LIBRARYDIR=%s" % spec["boost"].prefix.lib)
-        base_options.append("-DDYNINST_DIR=%s" % spec["dyninst"].prefix)
-
-        cmake_options.extend(base_options)
+        cmake_options.extend(
+            [
+                self.define("BINUTILS_DIR", spec["binutils"].prefix),
+                self.define("LIBELF_DIR", spec["elfutils"].prefix),
+                self.define("LIBDWARF_DIR", spec["libdwarf"].prefix),
+                self.define("Boost_NO_SYSTEM_PATHS", True),
+                self.define("Boost_NO_BOOST_CMAKE", True),
+                self.define("BOOST_ROOT", spec["boost"].prefix),
+                self.define("Boost_DIR", spec["boost"].prefix),
+                self.define("BOOST_LIBRARYDIR", spec["boost"].prefix.lib),
+                self.define("DYNINST_DIR", spec["dyninst"].prefix),
+            ]
+        )
 
     def set_mpi_cmake_options(self, spec, cmake_options):
         # Appends to cmake_options the options that will enable

--- a/var/spack/repos/builtin/packages/openturns/package.py
+++ b/var/spack/repos/builtin/packages/openturns/package.py
@@ -59,10 +59,8 @@ class Openturns(CMakePackage):
         if "+python" in spec:
             args.extend(
                 [
-                    # By default picks up the system python not the Spack build
-                    "-DPYTHON_EXECUTABLE={0}".format(spec["python"].command.path),
                     # By default installs to the python prefix
-                    "-DPYTHON_SITE_PACKAGES={0}".format(python_platlib),
+                    "-DPYTHON_SITE_PACKAGES={0}".format(python_platlib)
                 ]
             )
 

--- a/var/spack/repos/builtin/packages/openwsman/package.py
+++ b/var/spack/repos/builtin/packages/openwsman/package.py
@@ -55,7 +55,6 @@ class Openwsman(CMakePackage):
                 arg.extend([define("BUILD_PYTHON", False), define("BUILD_PYTHON3", True)])
             else:
                 arg.extend([define("BUILD_PYTHON", True), define("BUILD_PYTHON3", False)])
-            arg.append(define("PYTHON_EXECUTABLE", spec["python"].command.path))
         else:
             arg.extend([define("BUILD_PYTHON", False), define("BUILD_PYTHON3", False)])
         return arg

--- a/var/spack/repos/builtin/packages/pagmo/package.py
+++ b/var/spack/repos/builtin/packages/pagmo/package.py
@@ -99,10 +99,8 @@ class Pagmo(CMakePackage):
         if "+python" in spec:
             args.extend(
                 [
-                    # By default picks up the system python not the Spack build
-                    "-DPYTHON_EXECUTABLE={0}".format(spec["python"].command.path),
                     # By default installs to the python prefix not the pagmo prefix
-                    "-DPYTHON_MODULES_DIR={0}".format(python_platlib),
+                    "-DPYTHON_MODULES_DIR={0}".format(python_platlib)
                 ]
             )
 

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -537,7 +537,6 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
             cmake_args.extend(
                 [
                     "-DPARAVIEW_%s_PYTHON:BOOL=ON" % py_use_opt,
-                    "-DPYTHON_EXECUTABLE:FILEPATH=%s" % spec["python"].command.path,
                     "-D%s_PYTHON_VERSION:STRING=%d" % (py_ver_opt, py_ver_val),
                 ]
             )

--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -152,7 +152,6 @@ class Pfunit(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         args = [
-            self.define("Python_EXECUTABLE", spec["python"].command),
             self.define("BUILD_SHARED_LIBS", False),
             self.define("CMAKE_Fortran_MODULE_DIRECTORY", spec.prefix.include),
             self.define_from_variant("ENABLE_BUILD_DOXYGEN", "docs"),

--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -172,7 +172,8 @@ class Precice(CMakePackage):
             cmake_args.extend(["-DPETSC_DIR=%s" % spec["petsc"].prefix, "-DPETSC_ARCH=."])
 
         # Python
-        if "+python" in spec:
+        if "@:2.3 +python" in spec:
+            # 2.4.0 and higher use find_package(Python3).
             python_library = spec["python"].libs[0]
             python_include = spec["python"].headers.directories[0]
             numpy_include = join_path(

--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -84,10 +84,7 @@ class PyPybind11(CMakePackage, PythonExtension):
 
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):
-        return [
-            self.define("PYTHON_EXECUTABLE:FILEPATH", self.spec["python"].command.path),
-            self.define("PYBIND11_TEST", self.pkg.run_tests),
-        ]
+        return [self.define("PYBIND11_TEST", self.pkg.run_tests)]
 
     def install(self, pkg, spec, prefix):
         super().install(pkg, spec, prefix)

--- a/var/spack/repos/builtin/packages/py-pykokkos-base/package.py
+++ b/var/spack/repos/builtin/packages/py-pykokkos-base/package.py
@@ -44,13 +44,9 @@ class PyPykokkosBase(CMakePackage, PythonExtension):
     depends_on("python@3:", type=("build", "run"))
 
     def cmake_args(self):
-        spec = self.spec
-
         args = [
             self.define("ENABLE_INTERNAL_KOKKOS", False),
             self.define("ENABLE_INTERNAL_PYBIND11", False),
-            self.define("PYTHON_EXECUTABLE", spec["python"].command.path),
-            self.define("Python3_EXECUTABLE", spec["python"].command.path),
             self.define_from_variant("ENABLE_VIEW_RANKS", "view_ranks"),
         ]
 

--- a/var/spack/repos/builtin/packages/py-tfdlpack/package.py
+++ b/var/spack/repos/builtin/packages/py-tfdlpack/package.py
@@ -33,14 +33,7 @@ class PyTfdlpack(CMakePackage, PythonExtension):
     depends_on("py-tensorflow", type=("build", "run"))
 
     def cmake_args(self):
-        args = ["-DPYTHON_EXECUTABLE=" + self.spec["python"].command.path]
-
-        if "+cuda" in self.spec:
-            args.append("-DUSE_CUDA=ON")
-        else:
-            args.append("-DUSE_CUDA=OFF")
-
-        return args
+        return [self.define_from_variant("USE_CUDA", "cuda")]
 
     def install(self, spec, prefix):
         with working_dir("python"):

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -391,7 +391,6 @@ class Qmcpack(CMakePackage, CudaPackage):
         else:
             args.append("-DBUILD_PPCONVERT=0")
 
-        args.append(self.define("Python3_EXECUTABLE", self.spec["python"].command.path))
         return args
 
     # QMCPACK needs custom install method for the following reason:

--- a/var/spack/repos/builtin/packages/rdma-core/package.py
+++ b/var/spack/repos/builtin/packages/rdma-core/package.py
@@ -107,11 +107,4 @@ class RdmaCore(CMakePackage):
         if self.spec.satisfies("~man_pages"):
             cmake_args.append("-DNO_MAN_PAGES=1")
 
-        if self.spec.satisfies("@:39.0"):
-            cmake_args.extend(
-                [
-                    self.define("PYTHON_LIBRARY", self.spec["python"].libs[0]),
-                    self.define("PYTHON_INCLUDE_DIR", self.spec["python"].headers.directories[0]),
-                ]
-            )
         return cmake_args

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -505,7 +505,6 @@ class Root(CMakePackage):
         return " ".join(v)
 
     def cmake_args(self):
-        spec = self.spec
         define = self.define
         define_from_variant = self.define_from_variant
         options = []
@@ -688,9 +687,6 @@ class Root(CMakePackage):
             ftgl_prefix = self.spec["ftgl"].prefix
             options.append(define("FTGL_ROOT_DIR", ftgl_prefix))
             options.append(define("FTGL_INCLUDE_DIR", ftgl_prefix.include))
-        if "+python" in self.spec:
-            # See https://github.com/spack/spack/pull/11579
-            options.append(define("PYTHON_EXECUTABLE", spec["python"].command.path))
 
         return options
 

--- a/var/spack/repos/builtin/packages/scine-database/package.py
+++ b/var/spack/repos/builtin/packages/scine-database/package.py
@@ -51,11 +51,8 @@ class ScineDatabase(CMakePackage):
         )
 
     def cmake_args(self):
-        args = [
+        return [
             self.define("SCINE_BUILD_TESTS", self.run_tests),
             self.define("SCINE_BUILD_PYTHON_BINDINGS", "+python" in self.spec),
             self.define("SCINE_MARCH", ""),
         ]
-        if "+python" in self.spec:
-            args.append(self.define("PYTHON_EXECUTABLE", self.spec["python"].command.path))
-        return args

--- a/var/spack/repos/builtin/packages/scine-molassembler/package.py
+++ b/var/spack/repos/builtin/packages/scine-molassembler/package.py
@@ -84,7 +84,7 @@ class ScineMolassembler(CMakePackage):
         )
 
     def cmake_args(self):
-        args = [
+        return [
             self.define("BUILD_SHARED_LIBS", True),
             self.define("SCINE_BUILD_TESTS", self.run_tests),
             self.define("SCINE_BUILD_PYTHON_BINDINGS", "+python" in self.spec),
@@ -95,6 +95,3 @@ class ScineMolassembler(CMakePackage):
             self.define("BOOST_NO_SYSTEM_PATHS", True),
             self.define("Boost_NO_BOOST_CMAKE", True),
         ]
-        if "+python" in self.spec:
-            args.append(self.define("PYTHON_EXECUTABLE", self.spec["python"].command.path))
-        return args

--- a/var/spack/repos/builtin/packages/scine-readuct/package.py
+++ b/var/spack/repos/builtin/packages/scine-readuct/package.py
@@ -54,7 +54,7 @@ class ScineReaduct(CMakePackage):
         )
 
     def cmake_args(self):
-        args = [
+        return [
             self.define("SCINE_BUILD_TESTS", self.run_tests),
             self.define("SCINE_BUILD_PYTHON_BINDINGS", "+python" in self.spec),
             self.define("SCINE_MARCH", ""),
@@ -64,6 +64,3 @@ class ScineReaduct(CMakePackage):
             self.define("BOOST_NO_SYSTEM_PATHS", True),
             self.define("Boost_NO_BOOST_CMAKE", True),
         ]
-        if "+python" in self.spec:
-            args.append(self.define("PYTHON_EXECUTABLE", self.spec["python"].command.path))
-        return args

--- a/var/spack/repos/builtin/packages/scine-serenity/package.py
+++ b/var/spack/repos/builtin/packages/scine-serenity/package.py
@@ -57,7 +57,7 @@ class ScineSerenity(CMakePackage):
         )
 
     def cmake_args(self):
-        args = [
+        return [
             self.define("SCINE_BUILD_TESTS", self.run_tests),
             self.define_from_variant("SCINE_BUILD_PYTHON_BINDINGS", "python"),
             self.define("SCINE_MARCH", ""),
@@ -69,6 +69,3 @@ class ScineSerenity(CMakePackage):
             self.define("BOOST_NO_SYSTEM_PATHS", True),
             self.define("Boost_NO_BOOST_CMAKE", True),
         ]
-        if "+python" in self.spec:
-            args.append(self.define("PYTHON_EXECUTABLE", self.spec["python"].command.path))
-        return args

--- a/var/spack/repos/builtin/packages/scine-sparrow/package.py
+++ b/var/spack/repos/builtin/packages/scine-sparrow/package.py
@@ -76,7 +76,7 @@ class ScineSparrow(CMakePackage):
         )
 
     def cmake_args(self):
-        args = [
+        return [
             self.define("SCINE_BUILD_TESTS", self.run_tests),
             self.define("SCINE_BUILD_PYTHON_BINDINGS", "+python" in self.spec),
             self.define("SCINE_MARCH", ""),
@@ -86,9 +86,6 @@ class ScineSparrow(CMakePackage):
             self.define("BOOST_NO_SYSTEM_PATHS", True),
             self.define("Boost_NO_BOOST_CMAKE", True),
         ]
-        if "+python" in self.spec:
-            args.append(self.define("PYTHON_EXECUTABLE", self.spec["python"].command.path))
-        return args
 
     # Adapted from ddd in MacPorts: cmake will build the executable
     # "sparrow" right next to the copy of the source directory "Sparrow".

--- a/var/spack/repos/builtin/packages/scine-utilities/package.py
+++ b/var/spack/repos/builtin/packages/scine-utilities/package.py
@@ -67,7 +67,7 @@ class ScineUtilities(CMakePackage):
         )
 
     def cmake_args(self):
-        args = [
+        return [
             self.define("SCINE_BUILD_TESTS", self.run_tests),
             self.define_from_variant("SCINE_BUILD_PYTHON_BINDINGS", "python"),
             self.define("SCINE_MARCH", ""),
@@ -77,7 +77,3 @@ class ScineUtilities(CMakePackage):
             self.define("BOOST_NO_SYSTEM_PATHS", True),
             self.define("Boost_NO_BOOST_CMAKE", True),
         ]
-        if "+python" in self.spec:
-            args.append(self.define("PYTHON_EXECUTABLE", self.spec["python"].command.path))
-
-        return args

--- a/var/spack/repos/builtin/packages/scine-xtb/package.py
+++ b/var/spack/repos/builtin/packages/scine-xtb/package.py
@@ -52,7 +52,7 @@ class ScineXtb(CMakePackage):
         os.rename("_dev", "dev")
 
     def cmake_args(self):
-        args = [
+        return [
             self.define("SCINE_BUILD_TESTS", self.run_tests),
             self.define("SCINE_BUILD_PYTHON_BINDINGS", "+python" in self.spec),
             self.define("SCINE_MARCH", ""),
@@ -62,6 +62,3 @@ class ScineXtb(CMakePackage):
             self.define("BOOST_NO_SYSTEM_PATHS", True),
             self.define("Boost_NO_BOOST_CMAKE", True),
         ]
-        if "+python" in self.spec:
-            args.append(self.define("PYTHON_EXECUTABLE", self.spec["python"].command.path))
-        return args

--- a/var/spack/repos/builtin/packages/sensei/package.py
+++ b/var/spack/repos/builtin/packages/sensei/package.py
@@ -116,27 +116,30 @@ class Sensei(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
+        prefix = ""
+        if spec.satisfies("@5:"):
+            prefix = "SENSEI_"
 
         # -Ox flags are set by default in CMake based on the build type
         args = [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define("SENSEI_USE_EXTERNAL_pugixml", True),
-            self.define("ENABLE_SENSEI", True),
+            self.define(f"{prefix}ENABLE_SENSEI", True),
             self.define("MPI_C_COMPILER", spec["mpi"].mpicc),
             self.define("MPI_CXX_COMPILER", spec["mpi"].mpicxx),
             # Don"t rely on MPI found in cray environment for cray systems.
             # On non-cray systems this should be a no-op
-            self.define("ENABLE_CRAY_MPICH", False),
-            self.define_from_variant("ENABLE_ASCENT", "ascent"),
-            self.define_from_variant("ENABLE_VTKM", "vtkm"),
-            self.define_from_variant("ENABLE_CATALYST", "catalyst"),
-            self.define_from_variant("ENABLE_LIBSIM", "libsim"),
-            self.define_from_variant("ENABLE_VTK_IO", "vtkio"),
-            self.define_from_variant("ENABLE_PYTHON", "python"),
-            self.define_from_variant("ENABLE_ADIOS2", "adios2"),
-            self.define_from_variant("ENABLE_HDF5", "hdf5"),
-            self.define_from_variant("ENABLE_PARALLEL3D", "miniapps"),
-            self.define_from_variant("ENABLE_OSCILLATORS", "miniapps"),
+            self.define(f"{prefix}ENABLE_CRAY_MPICH", False),
+            self.define_from_variant(f"{prefix}ENABLE_ASCENT", "ascent"),
+            self.define_from_variant(f"{prefix}ENABLE_VTKM", "vtkm"),
+            self.define_from_variant(f"{prefix}ENABLE_CATALYST", "catalyst"),
+            self.define_from_variant(f"{prefix}ENABLE_LIBSIM", "libsim"),
+            self.define_from_variant(f"{prefix}ENABLE_VTK_IO", "vtkio"),
+            self.define_from_variant(f"{prefix}ENABLE_PYTHON", "python"),
+            self.define_from_variant(f"{prefix}ENABLE_ADIOS2", "adios2"),
+            self.define_from_variant(f"{prefix}ENABLE_HDF5", "hdf5"),
+            self.define_from_variant(f"{prefix}ENABLE_PARALLEL3D", "miniapps"),
+            self.define_from_variant(f"{prefix}ENABLE_OSCILLATORS", "miniapps"),
         ]
 
         if "+adios2" in spec:
@@ -153,6 +156,6 @@ class Sensei(CMakePackage):
         if "+python" in spec:
             if spec.satisfies("@3:"):
                 args.append(self.define("SENSEI_PYTHON_VERSION", 3))
-            args.append(self.define_from_variant("ENABLE_CATALYST_PYTHON", "catalyst"))
+            args.append(self.define_from_variant(f"{prefix}ENABLE_CATALYST_PYTHON", "catalyst"))
 
         return args

--- a/var/spack/repos/builtin/packages/sensei/package.py
+++ b/var/spack/repos/builtin/packages/sensei/package.py
@@ -151,9 +151,6 @@ class Sensei(CMakePackage):
             args.append("-DVISIT_DIR:PATH={0}/current/linux-x86_64".format(spec["visit"].prefix))
 
         if "+python" in spec:
-            args.append(self.define("PYTHON_EXECUTABLE", spec["python"].command.path))
-            args.append(self.define("Python_EXECUTABLE", spec["python"].command.path))
-            args.append(self.define("Python3_EXECUTABLE", spec["python"].command.path))
             if spec.satisfies("@3:"):
                 args.append(self.define("SENSEI_PYTHON_VERSION", 3))
             args.append(self.define_from_variant("ENABLE_CATALYST_PYTHON", "catalyst"))

--- a/var/spack/repos/builtin/packages/serenity/package.py
+++ b/var/spack/repos/builtin/packages/serenity/package.py
@@ -115,7 +115,7 @@ class Serenity(CMakePackage):
         )
 
     def cmake_args(self):
-        args = [
+        return [
             self.define("SERENITY_BUILD_TESTS", self.run_tests),
             self.define_from_variant("SERENITY_BUILD_PYTHON_BINDINGS", "python"),
             self.define("SERENITY_MARCH", ""),
@@ -137,6 +137,3 @@ class Serenity(CMakePackage):
             self.define("BOOST_NO_SYSTEM_PATHS", True),
             self.define("Boost_NO_BOOST_CMAKE", True),
         ]
-        if "+python" in self.spec:
-            args.append(self.define("PYTHON_EXECUTABLE", self.spec["python"].command.path))
-        return args

--- a/var/spack/repos/builtin/packages/sollve/package.py
+++ b/var/spack/repos/builtin/packages/sollve/package.py
@@ -259,7 +259,6 @@ class Sollve(CMakePackage):
             "-DLLVM_ENABLE_RTTI:BOOL=ON",
             "-DLLVM_ENABLE_EH:BOOL=ON",
             "-DCLANG_DEFAULT_OPENMP_RUNTIME:STRING=libomp",
-            "-DPYTHON_EXECUTABLE:PATH={0}".format(spec["python"].command.path),
         ]
 
         # TODO: Instead of unconditionally disabling CUDA, add a "cuda" variant

--- a/var/spack/repos/builtin/packages/spectre/package.py
+++ b/var/spack/repos/builtin/packages/spectre/package.py
@@ -307,7 +307,6 @@ class Spectre(CMakePackage):
         args = [
             self.define("CHARM_ROOT", self.spec["charmpp"].prefix),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
-            self.define("Python_EXECUTABLE", self.spec["python"].command.path),
             self.define_from_variant("BUILD_PYTHON_BINDINGS", "python"),
             self.define("BUILD_TESTING", self.run_tests),
             self.define_from_variant("BUILD_DOCS", "doc"),

--- a/var/spack/repos/builtin/packages/steps/package.py
+++ b/var/spack/repos/builtin/packages/steps/package.py
@@ -85,7 +85,6 @@ class Steps(CMakePackage):
     def cmake_args(self):
         args = [
             self.define("BLAS_LIBRARIES", self.spec["blas"].libs.joined(";")),
-            self.define("PYTHON_EXECUTABLE", self.spec["python"].command),
             self.define("STEPS_INSTALL_PYTHON_DEPS", False),
             self.define_from_variant("BUILD_STOCHASTIC_TESTS", "stochtests"),
             self.define_from_variant("BUILD_TESTING", "codechecks"),

--- a/var/spack/repos/builtin/packages/tasmanian/package.py
+++ b/var/spack/repos/builtin/packages/tasmanian/package.py
@@ -114,11 +114,6 @@ class Tasmanian(CMakePackage, CudaPackage, ROCmPackage):
             args.append("-DBLAS_LIBRARIES={0}".format(spec["blas"].libs.joined(";")))
             args.append("-DLAPACK_LIBRARIES={0}".format(spec["lapack"].libs.joined(";")))
 
-        if spec.satisfies("+python"):
-            args.append(
-                "-DPYTHON_EXECUTABLE:FILEPATH={0}".format(self.spec["python"].command.path)
-            )
-
         return args
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/templight/package.py
+++ b/var/spack/repos/builtin/packages/templight/package.py
@@ -128,7 +128,6 @@ class Templight(CMakePackage):
         cmake_args = [
             "-DLLVM_REQUIRES_RTTI:BOOL=ON",
             "-DCLANG_DEFAULT_OPENMP_RUNTIME:STRING=libomp",
-            "-DPYTHON_EXECUTABLE:PATH={0}".format(spec["python"].command.path),
             "-DLLVM_EXTERNAL_POLLY_BUILD:Bool=OFF",
             "-DLLVM_TOOL_POLLY_BUILD:Bool=OFF",
             "-DLLVM_POLLY_BUILD:Bool=OFF",

--- a/var/spack/repos/builtin/packages/tfel/package.py
+++ b/var/spack/repos/builtin/packages/tfel/package.py
@@ -180,6 +180,8 @@ class Tfel(CMakePackage):
             args.append("-Denable-python-bindings=OFF")
 
         if ("+python" in self.spec) or ("+python_bindings" in self.spec):
+            # Note: calls find_package(PythonLibs) before find_package(PythonInterp), so these
+            # variables are required.
             python = self.spec["python"]
             args.append("-DPYTHON_LIBRARY={0}".format(python.libs[0]))
             args.append("-DPYTHON_INCLUDE_DIR={0}".format(python.headers.directories[0]))

--- a/var/spack/repos/builtin/packages/timemory/package.py
+++ b/var/spack/repos/builtin/packages/timemory/package.py
@@ -322,11 +322,6 @@ class Timemory(CMakePackage, PythonExtension):
             self.define_from_variant("TIMEMORY_USE_ALLINEA_MAP", "allinea_map"),
         ]
 
-        if "+python" in spec:
-            pyexe = spec["python"].command.path
-            args.append(self.define("PYTHON_EXECUTABLE=", pyexe))
-            args.append(self.define("Python3_EXECUTABLE", pyexe))
-
         if "+mpi" in spec:
             args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
             args.append(self.define("MPI_CXX_COMPILER", spec["mpi"].mpicxx))

--- a/var/spack/repos/builtin/packages/tiramisu/package.py
+++ b/var/spack/repos/builtin/packages/tiramisu/package.py
@@ -57,10 +57,7 @@ class Tiramisu(CMakePackage, CudaPackage, PythonExtension):
             self.define("USE_FLEXNLP", False),
         ]
         if "+python" in spec:
-            args += [
-                self.define("Tiramisu_INSTALL_PYTHONDIR", python_platlib),
-                self.define("Python3_EXECUTABLE", spec["python"].command.path),
-            ]
+            args += [self.define("Tiramisu_INSTALL_PYTHONDIR", python_platlib)]
         return args
 
     @property

--- a/var/spack/repos/builtin/packages/vdt/package.py
+++ b/var/spack/repos/builtin/packages/vdt/package.py
@@ -46,10 +46,7 @@ class Vdt(CMakePackage):
         elif spec.satisfies("target=ppc64le:"):
             disable_features.add("fma")
 
-        args = [
-            self.define_from_variant("PRELOAD"),
-            self.define("PYTHON_EXECUTABLE", spec["python"].command),
-        ]
+        args = [self.define_from_variant("PRELOAD")]
         for f in ["sse", "avx", "avx2", "fma", "neon"]:
             args.append(
                 self.define(f.upper(), f not in disable_features and f in self.spec.target)

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -310,8 +310,6 @@ class Vtk(CMakePackage):
         # Enable/Disable wrappers for Python.
         if "+python" in spec:
             cmake_args.append("-DVTK_WRAP_PYTHON=ON")
-            if spec.satisfies("@:8"):
-                cmake_args.append("-DPYTHON_EXECUTABLE={0}".format(spec["python"].command.path))
             if "+mpi" in spec and spec.satisfies("@:8"):
                 cmake_args.append("-DVTK_USE_SYSTEM_MPI4PY:BOOL=ON")
             if spec.satisfies("@9.0.0: ^python@3:"):

--- a/var/spack/repos/builtin/packages/xcfun/package.py
+++ b/var/spack/repos/builtin/packages/xcfun/package.py
@@ -36,7 +36,6 @@ class Xcfun(CMakePackage):
             "-DPYMOD_INSTALL_LIBDIR=/python{0}/site-packages".format(spec["python"].version[:-1]),
             "-DXCFUN_MAX_ORDER=8",
             "-DXCFUN_PYTHON_INTERFACE=ON",
-            "-DPYTHON_EXECUTABLE={0}".format(spec["python"].command),
             "-DENABLE_TESTALL=OFF",
         ]
         return args

--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -203,12 +203,7 @@ class Xrootd(CMakePackage):
         ]
         # see https://github.com/spack/spack/pull/11581
         if "+python" in self.spec:
-            options.extend(
-                [
-                    define("PYTHON_EXECUTABLE", spec["python"].command.path),
-                    define("XRD_PYTHON_REQ_VERSION", spec["python"].version.up_to(2)),
-                ]
-            )
+            options.append(define("XRD_PYTHON_REQ_VERSION", spec["python"].version.up_to(2)))
 
         if "+scitokens-cpp" in self.spec:
             options.append("-DSCITOKENS_CPP_DIR=%s" % spec["scitokens-cpp"].prefix)

--- a/var/spack/repos/builtin/packages/xtensor-python/package.py
+++ b/var/spack/repos/builtin/packages/xtensor-python/package.py
@@ -33,11 +33,3 @@ class XtensorPython(CMakePackage):
     depends_on("python", type=("build", "link", "run"))
 
     extends("python")
-
-    def cmake_args(self):
-        spec = self.spec
-
-        python_exe = spec["python"].command.path
-
-        args = ["-DPYTHON_EXECUTABLE={0}".format(python_exe)]
-        return args


### PR DESCRIPTION
Pass python hints automatically to cmake packages to help `FindPython` find new versions of python. Can be disabled by setting the `find_python_hints=False` in the package.

CC: @haampie @johnwparent 