### PR TITLE
acts: new version 32.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -42,6 +42,7 @@ class Acts(CMakePackage, CudaPackage):
     # Supported Acts versions
     version("main", branch="main")
     version("master", branch="main", deprecated=True)  # For compatibility
+    version("32.0.0", commit="9385e36691bb2687437c39ad02ddb2ac21acccdc", submodules=True)
     version("31.2.0", commit="1d2e90f534ff2c9bf1c40914980b426f4b5d3096", submodules=True)
     version("31.1.0", commit="95c3ceef79a7b68fcfc7fd558c3134d0c7529dac", submodules=True)
     version("31.0.0", commit="2cf3fe0254d2bf9434899fdcfbe316366a970956", submodules=True)
@@ -228,7 +229,7 @@ class Acts(CMakePackage, CudaPackage):
     variant("identification", default=False, description="Build the Identification plugin")
     variant("json", default=False, description="Build the Json plugin")
     variant("legacy", default=False, description="Build the Legacy package")
-    variant("mlpack", default=False, description="Build MLpack plugin", when="@25:")
+    variant("mlpack", default=False, description="Build MLpack plugin", when="@25:31")
     variant("onnx", default=False, description="Build ONNX plugin")
     variant("odd", default=False, description="Build the Open Data Detector", when="@19.1:")
     variant("podio", default=False, description="Build Podio plugin", when="@30.3:")
@@ -292,12 +293,14 @@ class Acts(CMakePackage, CudaPackage):
 
     # Build dependencies
     depends_on("acts-dd4hep", when="@19 +dd4hep")
-    depends_on("actsvg@0.4.20:", when="@20.1: +svg")
-    depends_on("actsvg@0.4.28:", when="@23.2: +svg")
-    depends_on("actsvg@0.4.29:", when="@23.4: +svg")
-    depends_on("actsvg@0.4.30:", when="@23.5: +svg")
-    depends_on("actsvg@0.4.33:", when="@25:27 +svg")
-    depends_on("actsvg@0.4.35:", when="@28: +svg")
+    with when("+svg"):
+        depends_on("actsvg@0.4.20:", when="@20.1:")
+        depends_on("actsvg@0.4.28:", when="@23.2:")
+        depends_on("actsvg@0.4.29:", when="@23.4:")
+        depends_on("actsvg@0.4.30:", when="@23.5:")
+        depends_on("actsvg@0.4.33:", when="@25:27")
+        depends_on("actsvg@0.4.35:", when="@28:")
+        depends_on("actsvg@0.4.39:", when="@32:")
     depends_on("autodiff @0.6:", when="@17: +autodiff")
     depends_on("autodiff @0.5.11:0.5.99", when="@1.2:16 +autodiff")
     depends_on("boost @1.62:1.69 +program_options +test", when="@:0.10.3")

--- a/var/spack/repos/builtin/packages/actsvg/package.py
+++ b/var/spack/repos/builtin/packages/actsvg/package.py
@@ -31,7 +31,9 @@ class Actsvg(CMakePackage):
 
     variant("examples", default=False, description="Build the example applications")
     variant("meta", default=True, description="Build the meta level interface")
-    variant("web", default=True, when="@0.4.36:", description="Build the webpage builder interface")
+    variant(
+        "web", default=True, when="@0.4.36:", description="Build the webpage builder interface"
+    )
 
     depends_on("boost +program_options", type="test")
     depends_on("boost +program_options", when="+examples")

--- a/var/spack/repos/builtin/packages/actsvg/package.py
+++ b/var/spack/repos/builtin/packages/actsvg/package.py
@@ -20,6 +20,7 @@ class Actsvg(CMakePackage):
 
     license("MPL-2.0")
 
+    version("0.4.39", sha256="2d9605ecf8c9975d600cafb6d076969d77c634fa92844bd9586c38066da31739")
     version("0.4.35", sha256="693a4cc0e702842072a478c913895ed3596350ffdfa87f5d296ddd6ea36b61c6")
     version("0.4.33", sha256="25c93b8382bdb1864b4d8de64b146fe8ea86eec84048d594c375700d2fff1d1d")
     version("0.4.30", sha256="f7ffea39b3132914fcbb0fac6ab7395bef295cd6078dfd1c2509fd2d9aab0acb")
@@ -30,6 +31,7 @@ class Actsvg(CMakePackage):
 
     variant("examples", default=False, description="Build the example applications")
     variant("meta", default=True, description="Build the meta level interface")
+    variant("web", default=True, when="@0.4.36:", description="Build the webpage builder interface")
 
     depends_on("boost +program_options", type="test")
     depends_on("boost +program_options", when="+examples")
@@ -39,6 +41,7 @@ class Actsvg(CMakePackage):
         args = [
             self.define_from_variant("ACTSVG_BUILD_EXAMPLES", "examples"),
             self.define_from_variant("ACTSVG_BUILD_META", "meta"),
+            self.define_from_variant("ACTSVG_BUILD_WEB", "web"),
             self.define("ACTSVG_BUILD_TESTING", self.run_tests),
         ]
         return args


### PR DESCRIPTION
No major build system changes, see [diff](https://github.com/acts-project/acts/compare/v31.2.0...v32.0.0). Summary of changes:
- updated actsvg version requirement
- MLpack dependency removed as of 32.0.0 (https://github.com/acts-project/acts/pull/2863)