### PR TITLE
bison: remove unnecessary deps, add variant for colored output

### DIFF
--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -50,15 +50,15 @@ class Bison(AutotoolsPackage, GNUMirrorPackage):
     version("3.0.4", sha256="b67fd2daae7a64b5ba862c66c07c1addb9e6b1b05c5f2049392cfd8a2172952e")
     version("2.7", sha256="19bbe7374fd602f7a6654c131c21a15aebdc06cc89493e8ff250cb7f9ed0a831")
 
+    variant("color", default=False, description="Enable experimental colored output", when="@3.4:")
+
     # https://lists.gnu.org/archive/html/bug-bison/2019-08/msg00008.html
     patch("parallel.patch", when="@3.4.2")
 
     provides("yacc")
 
-    depends_on("gettext", when="@3.4:")
-    depends_on("diffutils", type="build")
-    depends_on("m4", type=("build", "run"))
-    depends_on("perl", type="build")
+    depends_on("gettext", when="+color")
+    depends_on("m4@1.4.6:", type=("build", "run"))
 
     patch("pgi.patch", when="@3.0.4")
     # The NVIDIA compilers do not currently support some GNU builtins.


### PR DESCRIPTION
Investigating bison I'm unsure why `perl` and `diffutils` are listed as dependencies. I could not find reference to them in the upstream documentation outside of suggested developer tooling. Debian packages bison with a single build & run dependency on `m4`. I've converted the dependency on gettext to an optional variant as it is still listed as experimental. 