### PR TITLE
Revert "acfl: truncate version version number"

### DIFF
--- a/var/spack/repos/builtin/packages/acfl/package.py
+++ b/var/spack/repos/builtin/packages/acfl/package.py
@@ -184,13 +184,12 @@ def get_os(ver):
 
 def get_armpl_version_to_3(spec):
     """Return version string with 3 numbers"""
-    version = spec.version.up_to(3)
-    version_len = len(version)
+    version_len = len(spec.version)
     assert version_len == 2 or version_len == 3
     if version_len == 2:
-        return version.string + ".0"
+        return spec.version.string + ".0"
     elif version_len == 3:
-        return version.string
+        return spec.version.string
 
 
 def get_armpl_prefix(spec):


### PR DESCRIPTION
Reverts spack/spack#41354 because it is currently breaking installation for any version with a leading zero in its minor version.