### PR TITLE
`set_package_py_globals`: only set pure build related globals on the root in build context

### DIFF
--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -149,7 +149,7 @@ class MesonBuilder(BaseBuilder):
         else:
             default_library = "shared"
 
-        args = [
+        return [
             "-Dprefix={0}".format(pkg.prefix),
             # If we do not specify libdir explicitly, Meson chooses something
             # like lib/x86_64-linux-gnu, which causes problems when trying to
@@ -162,8 +162,6 @@ class MesonBuilder(BaseBuilder):
             # Do not automatically download and install dependencies
             "-Dwrap_mode=nodownload",
         ]
-
-        return args
 
     @property
     def build_dirname(self):

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -457,10 +457,10 @@ def test_parallel_false_is_not_propagating(default_mock_concretization):
     # b (parallel =True)
     s = default_mock_concretization("a foobar=bar")
 
-    spack.build_environment.set_package_py_globals(s.package)
+    spack.build_environment.set_package_py_globals(s.package, context=Context.BUILD)
     assert s["a"].package.module.make_jobs == 1
 
-    spack.build_environment.set_package_py_globals(s["b"].package)
+    spack.build_environment.set_package_py_globals(s["b"].package, context=Context.BUILD)
     assert s["b"].package.module.make_jobs == spack.build_environment.determine_number_of_jobs(
         parallel=s["b"].package.parallel
     )
@@ -685,3 +685,33 @@ def test_clear_compiler_related_runtime_variables_of_build_deps(default_mock_con
     assert "FC" not in result
     assert "F77" not in result
     assert result["ANOTHER_VAR"] == "this-should-be-present"
+
+
+@pytest.mark.parametrize("context", [Context.BUILD, Context.RUN])
+def test_build_system_globals_only_set_on_root_during_build(default_mock_concretization, context):
+    """Test whether when setting up a build environment, the build related globals are set only
+    in the top level spec.
+
+    TODO: Since module instances are globals themselves, and Spack defines properties on them, they
+    persist across tests. In principle this is not terrible, cause the variables are mostly static.
+    But obviously it can lead to very hard to find bugs... We should get rid of those globals and
+    define them instead as a property on the package instance.
+    """
+    root = spack.spec.Spec("mpileaks").concretized()
+    build_variables = ("std_cmake_args", "std_meson_args", "std_pip_args")
+
+    # See todo above, we clear out any properties that may have been set by the previous test.
+    # Commenting this loop will make the test fail. I'm leaving it here as a reminder that those
+    # globals were always a bad idea, and we should pass them to the package instance.
+    for spec in root.traverse():
+        for variable in build_variables:
+            spec.package.module.__dict__.pop(variable, None)
+
+    spack.build_environment.SetupContext(root, context=context).set_all_package_py_globals()
+
+    # Excpect the globals to be set at the root in a build context only.
+    should_be_set = lambda depth: context == Context.BUILD and depth == 0
+
+    for depth, spec in root.traverse(depth=True, root=True):
+        for variable in build_variables:
+            assert hasattr(spec.package.module, variable) == should_be_set(depth)


### PR DESCRIPTION
Previously we called `std_args(pkg)` also on direct build deps, leading to
issues as seen in #42201 where a direct build dependency itself had a build
dependency on Python. Calling `std_args` would then attempt to search
Python's bin dir for an executable. But that Python was not installed, so the
build errors. This could happen either when installing dependencies from a
build cache, or after `spack gc`.

This PR ensures that we only call `std_args(pkg)` on the root in a build
context. All other variables are always set, also in Context.RUN, even if
they're arguably build type globals... but they're mostly static, cheap and
people sometimes use them in setup_run_environment as per comments in
`build_environment.py`.

Further this PR shows that Spack's globals are terribly stateful: they leave
traces on the package modules across tests and installs. The test points this
out and leaves a few lines that when commented expose the problem, so that we
can deal with it in the future.


