### PR TITLE
repo.py: pass package name not fully qualified package name

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -490,7 +490,7 @@ class TagIndexer(Indexer):
         self.index = spack.tag.TagIndex.from_json(stream, self.repository)
 
     def update(self, pkg_fullname):
-        self.index.update_package(pkg_fullname)
+        self.index.update_package(pkg_fullname.split(".")[-1])
 
     def write(self, stream):
         self.index.to_json(stream)


### PR DESCRIPTION
A branch `pkg_name in pkg_list` was always false due to included namespace.

That causes `~/.spack/cache/tags/*-index.json` to grow with package names
any time a `package.py` file is touched.

This should fix CI failures somehow only on seen on macOS (probably due to test
ordering).