### PR TITLE
libfabric: Add version 1.20.1

### DIFF
--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -24,6 +24,7 @@ class Libfabric(AutotoolsPackage):
     license("GPL-2.0-or-later")
 
     version("main", branch="main")
+    version("1.20.1", sha256="fd88d65c3139865d42a6eded24e121aadabd6373239cef42b76f28630d6eed76")
     version("1.20.0", sha256="7fbbaeb0e15c7c4553c0ac5f54e4ef7aecaff8a669d4ba96fa04b0fc780b9ddc")
     version("1.19.0", sha256="f14c764be9103e80c46223bde66e530e5954cb28b3835b57c8e728479603ef9e")
     version("1.18.2", sha256="64d7837853ca84d2a413fdd96534b6a81e6e777cc13866e28cf86cd0ccf1b93e")


### PR DESCRIPTION
Latest 1.20.1 version from https://github.com/ofiwg/libfabric/releases via `spack checksum`