### PR TITLE
gobject-introspection: fine-grained glib dependency versions. add 1.79.1

### DIFF
--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -28,6 +28,7 @@ class Glib(MesonPackage, AutotoolsPackage):
 
     license("LGPL-2.1-or-later")
 
+    version("2.79.1", sha256="b3764dd6e29b664085921dd4dd6ba2430fc19760ab6857ecfa3ebd4e8c1d114c")
     version("2.78.3", sha256="609801dd373796e515972bf95fc0b2daa44545481ee2f465c4f204d224b2bc21")
     version("2.78.0", sha256="44eaab8b720877ce303c5540b657b126f12dc94972d9880b52959f43fb537b30")
     version("2.76.6", sha256="1136ae6987dcbb64e0be3197a80190520f7acab81e2bfb937dc85c11c8aa9f04")

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -28,7 +28,6 @@ class Glib(MesonPackage, AutotoolsPackage):
 
     license("LGPL-2.1-or-later")
 
-    version("2.79.1", sha256="b3764dd6e29b664085921dd4dd6ba2430fc19760ab6857ecfa3ebd4e8c1d114c")
     version("2.78.3", sha256="609801dd373796e515972bf95fc0b2daa44545481ee2f465c4f204d224b2bc21")
     version("2.78.0", sha256="44eaab8b720877ce303c5540b657b126f12dc94972d9880b52959f43fb537b30")
     version("2.76.6", sha256="1136ae6987dcbb64e0be3197a80190520f7acab81e2bfb937dc85c11c8aa9f04")

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -20,7 +20,7 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
 
     license("LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT")
 
-    version("1.79.1", sha256="f80ea33ee05ca48fb997952bb46131cfbdd3751f7f5da068888739cbeb2d5443")
+    version("1.78.1", sha256="bd7babd99af7258e76819e45ba4a6bc399608fe762d83fde3cac033c50841bb4")
     version("1.76.1", sha256="196178bf64345501dcdc4d8469b36aa6fe80489354efe71cb7cb8ab82a3738bf")
     version("1.72.1", sha256="012e313186e3186cf0fde6decb57d970adf90e6b1fac5612fe69cbb5ba99543a")
     version("1.72.0", sha256="02fe8e590861d88f83060dd39cda5ccaa60b2da1d21d0f95499301b186beaabc")
@@ -42,14 +42,12 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     depends_on("sed", when="platform=darwin", type="build")
 
     depends_on("cairo+gobject")
-    depends_on("glib@2.49.2:", when="@1.49.2:")
-    # version 1.48.0 build fails with glib 2.49.4
-    depends_on("glib@2.48.1", when="@1.48.0")
-    depends_on("glib@2.49.2:", when="@1.49.2:")
-    depends_on("glib@2.56:", when="@1.56")
-    depends_on("glib@2.72:", when="@1.72")
+    depends_on("glib@2.78:", when="@1.78")
     depends_on("glib@2.76:", when="@1.76")
-    depends_on("glib@2.79:", when="@1.79")
+    depends_on("glib@2.72:", when="@1.72")
+    depends_on("glib@2.56:", when="@1.56")
+    depends_on("glib@2.49.2:", when="@1.49.2:")
+    depends_on("glib@2.48.1", when="@1.48.0")
 
     depends_on("libffi")
     # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/283

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -20,6 +20,7 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
 
     license("LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT")
 
+    version("1.79.1", sha256="f80ea33ee05ca48fb997952bb46131cfbdd3751f7f5da068888739cbeb2d5443")
     version("1.76.1", sha256="196178bf64345501dcdc4d8469b36aa6fe80489354efe71cb7cb8ab82a3738bf")
     version("1.72.1", sha256="012e313186e3186cf0fde6decb57d970adf90e6b1fac5612fe69cbb5ba99543a")
     version("1.72.0", sha256="02fe8e590861d88f83060dd39cda5ccaa60b2da1d21d0f95499301b186beaabc")
@@ -44,6 +45,12 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     depends_on("glib@2.49.2:", when="@1.49.2:")
     # version 1.48.0 build fails with glib 2.49.4
     depends_on("glib@2.48.1", when="@1.48.0")
+    depends_on("glib@2.49.2:", when="@1.49.2:")
+    depends_on("glib@2.56:", when="@1.56")
+    depends_on("glib@2.72:", when="@1.72")
+    depends_on("glib@2.76:", when="@1.76")
+    depends_on("glib@2.79:", when="@1.79")
+
     depends_on("libffi")
     # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/283
     depends_on("libffi@:3.3", when="@:1.72")  # libffi 3.4 caused seg faults


### PR DESCRIPTION
gobject-introspection's glib dependency seems to require matching minor versions: https://gitlab.gnome.org/GNOME/gobject-introspection/-/blob/main/meson.build?ref_type=heads#L131-138

I don't know a good way to programatically do this so I explicitly added fine-grained glib dependencies.

I also updated both glib and gobject-introspection to their most recent release versions, 2.79.1 and 1.79.1, respectively.