### PR TITLE
SLURM/MPICH fixes

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/mpich33_slurm_hostlist.patch
+++ b/var/spack/repos/builtin/packages/mpich/mpich33_slurm_hostlist.patch
@@ -1,0 +1,22 @@
+From 28f617c8565ea862e140b9fa20ad309b3300f4f5 Mon Sep 17 00:00:00 2001
+From: Richard Berger <rberger@lanl.gov>
+Date: Mon, 22 Jan 2024 16:11:20 -0700
+Subject: [PATCH] hydra: slurm hostlist_t should be used as pointer
+
+---
+ src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c b/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
+index f6639806c..cadbf4a87 100644
+--- a/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
++++ b/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
+@@ -26,7 +26,7 @@ static struct HYD_node *global_node_list = NULL;
+ #if defined(HAVE_LIBSLURM)
+ static HYD_status list_to_nodes(char *str)
+ {
+-    hostlist_t hostlist;
++    hostlist_t *hostlist;
+     char *host;
+     int k = 0;
+     HYD_status status = HYD_SUCCESS;

--- a/var/spack/repos/builtin/packages/mpich/mpich40_slurm_hostlist.patch
+++ b/var/spack/repos/builtin/packages/mpich/mpich40_slurm_hostlist.patch
@@ -1,0 +1,22 @@
+From 15c0b2449136ffbdbdc6049a4a9553cf8c045e2c Mon Sep 17 00:00:00 2001
+From: Richard Berger <rberger@lanl.gov>
+Date: Mon, 22 Jan 2024 16:07:16 -0700
+Subject: [PATCH] hydra: slurm hostlist_t should be used as pointer
+
+---
+ src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c b/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
+index 869d38b7a..953e8aa2d 100644
+--- a/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
++++ b/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
+@@ -25,7 +25,7 @@ static struct HYD_node *global_node_list = NULL;
+ #if defined(HAVE_SLURM)
+ static HYD_status list_to_nodes(char *str)
+ {
+-    hostlist_t hostlist;
++    hostlist_t *hostlist;
+     char *host;
+     int k = 0;
+     HYD_status status = HYD_SUCCESS;

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -189,20 +189,20 @@ supported, and netmod is ignored if device is ch3:sock.""",
     # See https://github.com/pmodels/mpich/issues/6806
     # and https://github.com/pmodels/mpich/pull/6820
     patch(
-      "https://github.com/pmodels/mpich/commit/7a28682a805acfe84a4ea7b41cea079696407398.patch?full_index=1",
-      sha256="8cc80a8ffc3f1c907b1d8176129a0c1d01794a95adbed5b5357f50c13f6560e4",
-      when="@4.1:4.1.2 +slurm ^slurm@23-11-1-1:",
+        "https://github.com/pmodels/mpich/commit/7a28682a805acfe84a4ea7b41cea079696407398.patch?full_index=1",
+        sha256="8cc80a8ffc3f1c907b1d8176129a0c1d01794a95adbed5b5357f50c13f6560e4",
+        when="@4.1:4.1.2 +slurm ^slurm@23-11-1-1:",
     )
     # backports of fix down to v3.3
     patch(
-      "mpich40_slurm_hostlist.patch",
-      sha256="39aa1353305b7b03bc5c645c87d5299bd5d2ff676750898ba925f6cb9b716bdb",
-      when="@4.0 +slurm ^slurm@23-11-1-1:",
+        "mpich40_slurm_hostlist.patch",
+        sha256="39aa1353305b7b03bc5c645c87d5299bd5d2ff676750898ba925f6cb9b716bdb",
+        when="@4.0 +slurm ^slurm@23-11-1-1:",
     )
     patch(
-      "mpich33_slurm_hostlist.patch",
-      sha256="d6ec26adcf2d08d0739be44ab65b928a7a88e9ff1375138a0593678eedd420ab",
-      when="@3.3:3.4 +slurm ^slurm@23-11-1-1:",
+        "mpich33_slurm_hostlist.patch",
+        sha256="d6ec26adcf2d08d0739be44ab65b928a7a88e9ff1375138a0593678eedd420ab",
+        when="@3.3:3.4 +slurm ^slurm@23-11-1-1:",
     )
 
     # Fix reduce operations for unsigned integers

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -185,6 +185,26 @@ supported, and netmod is ignored if device is ch3:sock.""",
         when="@=3.3",
     )
 
+    # Fix SLURM hostlist_t usage
+    # See https://github.com/pmodels/mpich/issues/6806
+    # and https://github.com/pmodels/mpich/pull/6820
+    patch(
+      "https://github.com/pmodels/mpich/commit/7a28682a805acfe84a4ea7b41cea079696407398.patch?full_index=1",
+      sha256="8cc80a8ffc3f1c907b1d8176129a0c1d01794a95adbed5b5357f50c13f6560e4",
+      when="@4.1:4.1.2 +slurm ^slurm@23-11-1-1:",
+    )
+    # backports of fix down to v3.3
+    patch(
+      "mpich40_slurm_hostlist.patch",
+      sha256="39aa1353305b7b03bc5c645c87d5299bd5d2ff676750898ba925f6cb9b716bdb",
+      when="@4.0 +slurm ^slurm@23-11-1-1:",
+    )
+    patch(
+      "mpich33_slurm_hostlist.patch",
+      sha256="d6ec26adcf2d08d0739be44ab65b928a7a88e9ff1375138a0593678eedd420ab",
+      when="@3.3:3.4 +slurm ^slurm@23-11-1-1:",
+    )
+
     # Fix reduce operations for unsigned integers
     # See https://github.com/pmodels/mpich/issues/6083
     patch(

--- a/var/spack/repos/builtin/packages/slurm/package.py
+++ b/var/spack/repos/builtin/packages/slurm/package.py
@@ -28,6 +28,11 @@ class Slurm(AutotoolsPackage):
 
     license("GPL-2.0-or-later")
 
+    version("23-11-1-1", sha256="31506df24c6d24e0ea0329cac1395ab9b645bbde1518f5c469f7711df5e22c11")
+    version("23-11-0-1", sha256="3780773a80b73ea2edb4353318b4220188f4eda92c31ab3a2bdd3a4fdec76be9")
+    version("23-02-7-1", sha256="3f60ad5b5a492312d1febb9f9167caa3aee7f8438bb032590a993f5a65c5e4db")
+    version("23-02-6-1", sha256="ed44d4e591c0f91874d535cb8c9ea67dd2a38bfa4e96fa6c71687293f6a1d3bb")
+    version("23-02-5-1", sha256="4fee743a34514d8fe487080048256f5ee032374ed5f42d0eae342110dcd59edf")
     version("23-02-4-1", sha256="7290143a71ce2797d0df3423f08396fd5c0ae4504749ff372d6860b2d6a3a1b0")
     version("23-02-3-1", sha256="c41747e4484011cf376d6d4bc73b6c4696cdc0f7db4f64174f111bb9f53fb603")
     version("23-02-2-1", sha256="71edcf187a7d68176cca06143adf98e8f332d42cdf000cb534b03b13834ad537")


### PR DESCRIPTION
Newer Slurm versions have changed `hostlist_t`, which causes compilation errors with MPICH versions prior to the upcoming v4.2.0. This PR addresses this down to MPICH v3.3 and adds some missing Slurm versions.