### PR TITLE
Add v5.0.0 to ip

### DIFF
--- a/var/spack/repos/builtin/packages/ip/package.py
+++ b/var/spack/repos/builtin/packages/ip/package.py
@@ -18,6 +18,7 @@ class Ip(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA")
 
     version("develop", branch="develop")
+    version("5.0.0", sha256="54b2987bd4f94adc1f7595d2a384e646019c22d163bcd30840a916a6abd7df71")
     version("4.4.0", sha256="858d9201ce0bc4d16b83581ef94a4a0262f498ed1ea1b0535de2e575da7a8b8c")
     version("4.3.0", sha256="799308a868dea889d2527d96a0405af7b376869581410fe4cff681205e9212b4")
     # Note that versions 4.0-4.2 contain constants_mod module, and should not be used when
@@ -50,14 +51,20 @@ class Ip(CMakePackage):
         description="Set precision (_4/_d/_8 library versions)",
         when="@4.2:",
     )
+    variant(
+        "deprecated",
+        default=False,
+        description="Build deprecated spectral interpolation functions",
+        when="@5.0:",
+    )
 
     conflicts("+shared ~pic")
 
-    depends_on("sp")
+    depends_on("sp", when="@:4")
     depends_on("sp@:2.3.3", when="@:4.0")
-    depends_on("sp precision=4", when="precision=4")
-    depends_on("sp precision=d", when="precision=d")
-    depends_on("sp precision=8", when="precision=8")
+    depends_on("sp precision=4", when="@4.1:4 precision=4")
+    depends_on("sp precision=d", when="@4.1:4 precision=d")
+    depends_on("sp precision=8", when="@4.1:4 precision=8")
 
     def cmake_args(self):
         args = [
@@ -77,6 +84,9 @@ class Ip(CMakePackage):
 
         if self.spec.satisfies("@4.2:"):
             args.append(self.define("BUILD_8", self.spec.satisfies("precision=8")))
+
+        if self.spec.satisfies("@5:"):
+            args.append(self.define_from_variant("BUILD_DEPRECATED", "deprecated"))
 
         return args
 

--- a/var/spack/repos/builtin/packages/ip/package.py
+++ b/var/spack/repos/builtin/packages/ip/package.py
@@ -104,6 +104,7 @@ class Ip(CMakePackage):
             env.set("IP_LIB" + suffix, lib[0])
             env.set("IP_INC" + suffix, join_path(self.prefix, "include_" + suffix))
 
+    @when("@4:")
     def check(self):
         with working_dir(self.builder.build_directory):
             make("test")


### PR DESCRIPTION
This PR adds v5.0.0 to the ip recipe. As of v5 the dependency on sp goes away. Tested installing a range of versions on my personal computer, tests passed.