### PR TITLE
dbcsr: Adopt out-of-source build and fix Fujitsu compiler build error

### DIFF
--- a/var/spack/repos/builtin/packages/dbcsr/fjfrt_mod.patch
+++ b/var/spack/repos/builtin/packages/dbcsr/fjfrt_mod.patch
@@ -1,0 +1,14 @@
+--- a/examples/CMakeLists.txt	2023-11-02 12:15:04.000000000 +0900
++++ b/examples/CMakeLists.txt	2023-11-02 13:19:11.000000000 +0900
+@@ -17,6 +17,11 @@ foreach (dbcsr_program_src ${DBCSR_PROGR
+   # actually Fortran and needs to be told explicitly:
+   set_target_properties(${dbcsr_program_name} PROPERTIES LINKER_LANGUAGE
+                                                          Fortran)
++  if (CMAKE_Fortran_COMPILER_ID STREQUAL "Fujitsu")
++    if (OpenMP_FOUND)
++       target_link_libraries(${dbcsr_program_name} OpenMP::OpenMP_Fortran)
++    endif ()
++  endif ()
+ endforeach ()
+ 
+ # Compile C++ examples

--- a/var/spack/repos/builtin/packages/dbcsr/package.py
+++ b/var/spack/repos/builtin/packages/dbcsr/package.py
@@ -117,8 +117,6 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
     generator("ninja")
     depends_on("ninja@1.10:", type="build")
 
-    build_directory = "spack-build"
-
     patch("fjfrt_mod.patch", when="%fj")
 
     def cmake_args(self):
@@ -134,7 +132,6 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
             "-DUSE_SMM=%s" % ("libxsmm" if "smm=libxsmm" in spec else "blas"),
             self.define_from_variant("USE_MPI", "mpi"),
             self.define_from_variant("USE_OPENMP", "openmp"),
-            "-DWITH_C_API=false",
             "-DBLAS_FOUND=true",
             "-DBLAS_LIBRARIES=%s" % (spec["blas"].libs.joined(";")),
             "-DLAPACK_FOUND=true",
@@ -195,7 +192,7 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
     @run_after("install")
     def install_modfiles(self):
         if self.spec.satisfies("%fj"):
-            for mod in glob.iglob(self.build_directory + "/src/*.mod"):
+            for mod in glob.iglob(join_path(self.build_directory, "src", "*.mod")):
                 install(mod, self.prefix.include)
 
     def flag_handler(self, name, flags):

--- a/var/spack/repos/builtin/packages/dbcsr/package.py
+++ b/var/spack/repos/builtin/packages/dbcsr/package.py
@@ -116,9 +116,9 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
 
     generator("ninja")
     depends_on("ninja@1.10:", type="build")
-    
-    build_directory = 'spack-build'
-    
+
+    build_directory = "spack-build"
+
     patch("fjfrt_mod.patch", when="%fj")
 
     def cmake_args(self):
@@ -142,15 +142,14 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("WITH_EXAMPLES", "examples"),
         ]
-    
+
         # C API needs MPI
         with_c_api = self.define_from_variant("WITH_C_API", "mpi")
-        # skip building C API since fujitsu compiler do not support 
+        # skip building C API since fujitsu compiler do not support
         # calling Fortran subroutines with optional arguments in bind(C)
         if self.spec.satisfies("%fj"):
             with_c_api = "-DWITH_C_API=false"
         args += [with_c_api]
-     
 
         # Switch necessary as a result of a bug.
         if "@2.1:2.2" in spec:
@@ -196,7 +195,7 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
     @run_after("install")
     def install_modfiles(self):
         if self.spec.satisfies("%fj"):
-            for mod in glob.iglob(self.build_directory+"/src/*.mod"):
+            for mod in glob.iglob(self.build_directory + "/src/*.mod"):
                 install(mod, self.prefix.include)
 
     def flag_handler(self, name, flags):

--- a/var/spack/repos/builtin/packages/dbcsr/package.py
+++ b/var/spack/repos/builtin/packages/dbcsr/package.py
@@ -121,6 +121,7 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
     generator("ninja")
     depends_on("ninja@1.10:", type="build")
 
+    # Add '-Kopenmp' option for Fujitsu compiler to avoid errors
     patch("fjfrt_mod.patch", when="%fj")
 
     def cmake_args(self):


### PR DESCRIPTION
This PR allows the dbcsr to be built using the Fujitsu Compiler.