### PR TITLE
pexsi: fix to build with fujitsu-ssl2

### DIFF
--- a/var/spack/repos/builtin/packages/pexsi/fujitsu-add-link-flags.patch
+++ b/var/spack/repos/builtin/packages/pexsi/fujitsu-add-link-flags.patch
@@ -1,0 +1,11 @@
+diff -Nur spack-src.org/fortran/CMakeLists.txt spack-src/fortran/CMakeLists.txt
+--- spack-src.org/fortran/CMakeLists.txt	2023-06-06 17:55:44.000000000 +0900
++++ spack-src/fortran/CMakeLists.txt	2023-06-06 15:50:05.000000000 +0900
+@@ -47,6 +47,7 @@
+ 
+ endmacro()
+ 
++set (CMAKE_EXE_LINKER_FLAGS "--linkfortran")
+ 
+ add_pexsi_f_example_exe( f_driver_ksdft                 )
+ add_pexsi_f_example_exe( f_driver_pselinv_real          )

--- a/var/spack/repos/builtin/packages/pexsi/package.py
+++ b/var/spack/repos/builtin/packages/pexsi/package.py
@@ -38,6 +38,8 @@ class Pexsi(MakefilePackage, CMakePackage):
     version("0.10.2", sha256="8714c71b76542e096211b537a9cb1ffb2c28f53eea4f5a92f94cc1ca1e7b499f")
     version("0.9.0", sha256="e5efe0c129013392cdac3234e37f1f4fea641c139b1fbea47618b4b839d05029")
 
+    patch("fujitsu-add-link-flags.patch", when="%fj")
+
     depends_on("parmetis")
     depends_on("superlu-dist@5.1.2:5.3", when="@0.10.2:0")
     depends_on("superlu-dist@:6.1.0", when="@1")  # Upper limit from CP2K toolchain
@@ -123,4 +125,8 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             self.define_from_variant("PEXSI_ENABLE_FORTRAN", "fortran"),
             self.define_from_variant("PEXSI_ENABLE_OPENMP ", "openmp"),
         ]
+
+        if self.spec.satisfies("%fj"):
+            args.append(self.define("BLAS_LIBRARIES", self.spec["blas"].libs.link_flags))
+
         return args


### PR DESCRIPTION
This PR allows the pexsi to be built using the Fujitsu Compiler.