### PR TITLE
sirius: fix build error with Fujitsu compiler and support for both sh…

### DIFF
--- a/var/spack/repos/builtin/packages/sirius/fj.patch
+++ b/var/spack/repos/builtin/packages/sirius/fj.patch
@@ -11,15 +11,3 @@ index 54a91df..ea66ecf 100644
                                                                                  type.gaunt_coefs().gaunt_vector(lm1, lm2));
                          hmt_[ia](j2, j1) = std::conj(hmt_[ia](j1, j2));
                      }
-diff -Nur SIRIUS-7.3.2/src/k_point/k_point_set.cpp SIRIUS-7.3.2-src/src/k_point/k_point_set.cpp
---- SIRIUS-7.3.2/src/k_point/k_point_set.cpp	2022-07-05 16:19:54.000000000 +0900
-+++ SIRIUS-7.3.2-src/src/k_point/k_point_set.cpp	2023-09-22 18:28:23.000000000 +0900
-@@ -317,7 +317,7 @@
-     splindex<splindex_t::block> splb(ctx_.num_bands(), ctx_.comm_band().size(), ctx_.comm_band().rank());
- 
-     /* computes N(ef; f) = \sum_{i,k} f(ef - e_{k,i}) */
--    auto compute_ne = [&](double ef, auto&& f) {
-+    auto compute_ne = [&](double ef, std::function<double(double)> f) {
-         double ne{0};
-         for (int ikloc = 0; ikloc < spl_num_kpoints_.local_size(); ikloc++) {
-             int ik = spl_num_kpoints_[ikloc];

--- a/var/spack/repos/builtin/packages/sirius/fj.patch
+++ b/var/spack/repos/builtin/packages/sirius/fj.patch
@@ -11,3 +11,15 @@ index 54a91df..ea66ecf 100644
                                                                                  type.gaunt_coefs().gaunt_vector(lm1, lm2));
                          hmt_[ia](j2, j1) = std::conj(hmt_[ia](j1, j2));
                      }
+diff -Nur SIRIUS-7.3.2/src/k_point/k_point_set.cpp SIRIUS-7.3.2-src/src/k_point/k_point_set.cpp
+--- SIRIUS-7.3.2/src/k_point/k_point_set.cpp	2022-07-05 16:19:54.000000000 +0900
++++ SIRIUS-7.3.2-src/src/k_point/k_point_set.cpp	2023-09-22 18:28:23.000000000 +0900
+@@ -317,7 +317,7 @@
+     splindex<splindex_t::block> splb(ctx_.num_bands(), ctx_.comm_band().size(), ctx_.comm_band().rank());
+ 
+     /* computes N(ef; f) = \sum_{i,k} f(ef - e_{k,i}) */
+-    auto compute_ne = [&](double ef, auto&& f) {
++    auto compute_ne = [&](double ef, std::function<double(double)> f) {
+         double ne{0};
+         for (int ikloc = 0; ikloc < spl_num_kpoints_.local_size(); ikloc++) {
+             int ik = spl_num_kpoints_[ikloc];

--- a/var/spack/repos/builtin/packages/sirius/fj_lambda_fix.patch
+++ b/var/spack/repos/builtin/packages/sirius/fj_lambda_fix.patch
@@ -1,0 +1,12 @@
+diff -Nur SIRIUS-7.3.2/src/k_point/k_point_set.cpp SIRIUS-7.3.2-src/src/k_point/k_point_set.cpp
+--- SIRIUS-7.3.2/src/k_point/k_point_set.cpp	2022-07-05 16:19:54.000000000 +0900
++++ SIRIUS-7.3.2-src/src/k_point/k_point_set.cpp	2023-09-22 18:28:23.000000000 +0900
+@@ -317,7 +317,7 @@
+     splindex<splindex_t::block> splb(ctx_.num_bands(), ctx_.comm_band().size(), ctx_.comm_band().rank());
+ 
+     /* computes N(ef; f) = \sum_{i,k} f(ef - e_{k,i}) */
+-    auto compute_ne = [&](double ef, auto&& f) {
++    auto compute_ne = [&](double ef, std::function<double(double)> f) {
+         double ne{0};
+         for (int ikloc = 0; ikloc < spl_num_kpoints_.local_size(); ikloc++) {
+             int ik = spl_num_kpoints_[ikloc];

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -187,6 +187,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("eigen@3.4.0:", when="@7.3.2: +tests")
 
     depends_on("costa", when="@7.3.2:")
+    depends_on("costa+shared", when="@7.3.2: +shared")
 
     with when("@7.5: +memory_pool"):
         depends_on("umpire~cuda~rocm", when="~cuda~rocm")

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -197,6 +197,10 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     patch("mpi_datatypes.patch", when="@:7.2.6")
     patch("fj.patch", when="@7.3.2: %fj")
 
+    # Apply patch to fix segmentation fault caused by a bug in Fujitsu compiler
+    # when using auto parameters in C++ lambda expressions with OpenMP
+    patch("fj_lambda_fix.patch", when="@7.3.2: %fj")
+
     def cmake_args(self):
         spec = self.spec
 


### PR DESCRIPTION
This PR enables Sirius to link with Cosma as a static library and updates the patch for building with the Fujitsu Compiler.