### PR TITLE
cosma/costa default shared library

### DIFF
--- a/var/spack/repos/builtin/packages/cosma/package.py
+++ b/var/spack/repos/builtin/packages/cosma/package.py
@@ -41,7 +41,7 @@ class Cosma(CMakePackage):
     variant("cuda", default=False, description="Build with cuBLAS support")
     variant("rocm", default=False, description="Build with rocBLAS support")
     variant("scalapack", default=False, description="Build with ScaLAPACK API")
-    variant("shared", default=False, description="Build the shared library version")
+    variant("shared", default=True, description="Build the shared library version")
     variant("tests", default=False, description="Build tests")
     variant("apps", default=False, description="Build miniapp")
     variant("profiling", default=False, description="Enable profiling")

--- a/var/spack/repos/builtin/packages/costa/package.py
+++ b/var/spack/repos/builtin/packages/costa/package.py
@@ -29,7 +29,7 @@ class Costa(CMakePackage):
     version("2.0", sha256="de250197f31f7d23226c6956a687c3ff46fb0ff6c621a932428236c3f7925fe4")
 
     variant("scalapack", default=False, description="Build with ScaLAPACK API")
-    variant("shared", default=False, description="Build shared libraries")
+    variant("shared", default=True, description="Build shared libraries")
     variant("profiling", default=False, description="Enable profiling")
     variant("tests", default=False, description="Enable tests")
     variant("apps", default=False, description="Enable miniapp")

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -183,7 +183,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("eigen@3.4.0:", when="@7.3.2: +tests")
 
-    depends_on("costa+shared", when="@7.3.2:")
+    depends_on("costa", when="@7.3.2:")
 
     with when("@7.5: +memory_pool"):
         depends_on("umpire~cuda~rocm", when="~cuda~rocm")


### PR DESCRIPTION
Set default shared for cosma/costa. Remove shared in sirius `depends_on(costa+shared)`.