### PR TITLE
siesta-relmax3: Added siesta-relmax3 package

### DIFF
--- a/var/spack/repos/builtin/packages/siesta-relmax3/fix_linkerror.patch
+++ b/var/spack/repos/builtin/packages/siesta-relmax3/fix_linkerror.patch
@@ -23,15 +23,6 @@
    logical        , intent(in)    :: restore
 --- a/Src/Makefile	2023-11-16 23:15:53.000000000 +0900
 +++ b/Src/Makefile	2023-11-17 13:41:30.000000000 +0900
-@@ -195,7 +195,7 @@ OBJS =  automatic_cell.o atom_options.o
- 	m_initwf.o wavefunctions.o \
- 	m_evolve.o cranknic_evolk.o cranknic_evolg.o sankey_change_basis.o m_iotddft.o \
- 	m_matdiag.o m_matswinvers.o iotdxv.o  m_inversemm.o runinfo_m.o cli_m.o \
--        hamann.o
-+        hamann.o 
- 
- OBJS += kpoint_t.o kpoint_scf.o kpoint_dos.o kpoint_pdos.o kpoint_ldos.o
- 
 @@ -301,6 +301,8 @@ OBJS += contract_coefio.o
  # DFT-D3
  OBJS += grimme_dispersion_m.o
@@ -41,25 +32,3 @@
  # Special dependency that sfmakedepend cannot grasp for now
  m_pexsi.o m_pexsi_driver.o m_pexsi_dos.o m_pexsi_local_dos.o: f_ppexsi_interface.o
  
---- a/Src/m_ts_voltage.F90	2023-11-16 23:15:48.000000000 +0900
-+++ b/Src/m_ts_voltage.F90	2023-11-17 13:41:30.000000000 +0900
-@@ -484,7 +484,7 @@ contains
- 
-     use parallel, only : IONode
- 
--    use netcdf_ncdf
-+    use netcdf_ncdf, ncdf_parallel => parallel
-     use dictionary
- 
-     character(len=*), intent(in) :: fname
---- a/Src/siesta_init.F	2023-11-16 23:15:54.000000000 +0900
-+++ b/Src/siesta_init.F	2023-11-17 13:41:30.000000000 +0900
-@@ -89,7 +89,7 @@
- #endif
- 
- #ifdef NCDF_4
--      use netcdf_ncdf
-+      use netcdf_ncdf, ncdf_parallel => parallel
- #endif
- 
-       use reinit_m, only: reinit, parse_command_line

--- a/var/spack/repos/builtin/packages/siesta-relmax3/fj_fix_use_netcdf_parallel.patch
+++ b/var/spack/repos/builtin/packages/siesta-relmax3/fj_fix_use_netcdf_parallel.patch
@@ -1,0 +1,22 @@
+--- a/Src/m_ts_voltage.F90	2023-11-16 23:15:48.000000000 +0900
++++ b/Src/m_ts_voltage.F90	2023-11-17 13:41:30.000000000 +0900
+@@ -484,7 +484,7 @@ contains
+ 
+     use parallel, only : IONode
+ 
+-    use netcdf_ncdf
++    use netcdf_ncdf, ncdf_parallel => parallel
+     use dictionary
+ 
+     character(len=*), intent(in) :: fname
+--- a/Src/siesta_init.F	2023-11-16 23:15:54.000000000 +0900
++++ b/Src/siesta_init.F	2023-11-17 13:41:30.000000000 +0900
+@@ -89,7 +89,7 @@
+ #endif
+ 
+ #ifdef NCDF_4
+-      use netcdf_ncdf
++      use netcdf_ncdf, ncdf_parallel => parallel
+ #endif
+ 
+       use reinit_m, only: reinit, parse_command_line

--- a/var/spack/repos/builtin/packages/siesta-relmax3/fj_mod.patch
+++ b/var/spack/repos/builtin/packages/siesta-relmax3/fj_mod.patch
@@ -1,0 +1,65 @@
+--- a/Config/mk-build/build.mk	2023-11-16 23:15:44.000000000 +0900
++++ b/Config/mk-build/build.mk	2023-11-16 23:18:41.000000000 +0900
+@@ -187,7 +187,7 @@ ifeq ($(WITH_OMM_SPARSE_BUNDLE),1)
+      endif
+      DBCSR     = $(DBCSR_ROOT)
+      DBCSRINC  = -I$(DBCSR)/include
+-     DBCSRLIB  = -L$(DBCSR)/lib -ldbcsr
++     DBCSRLIB  = -L$(DBCSR)/lib64 -ldbcsr
+      FPPFLAGS += -DHAVE_DBCSR
+ 
+      LIBS += $(DBCSRLIB)
+--- a/Src/contract_siesta_forces.F90	2023-11-16 23:15:50.000000000 +0900
++++ b/Src/contract_siesta_forces.F90	2023-11-17 13:41:30.000000000 +0900
+@@ -153,7 +153,8 @@ subroutine xc_functional_switch( restore
+   !! Exchanges the current functional during coefficient optimizations
+   !! if using VDW.
+   use alloc, only : re_alloc, de_alloc
+-  use xcmod, only : getXC, setXC
++!  use xcmod, only : getXC, setXC
++  use gridXC,  only : getXC=>gridxc_getXC, setXC=>gridxc_setXC
+ 
+   implicit none
+   logical        , intent(in)    :: restore
+--- a/Src/Makefile	2023-11-16 23:15:53.000000000 +0900
++++ b/Src/Makefile	2023-11-17 13:41:30.000000000 +0900
+@@ -195,7 +195,7 @@ OBJS =  automatic_cell.o atom_options.o
+ 	m_initwf.o wavefunctions.o \
+ 	m_evolve.o cranknic_evolk.o cranknic_evolg.o sankey_change_basis.o m_iotddft.o \
+ 	m_matdiag.o m_matswinvers.o iotdxv.o  m_inversemm.o runinfo_m.o cli_m.o \
+-        hamann.o
++        hamann.o 
+ 
+ OBJS += kpoint_t.o kpoint_scf.o kpoint_dos.o kpoint_pdos.o kpoint_ldos.o
+ 
+@@ -301,6 +301,8 @@ OBJS += contract_coefio.o
+ # DFT-D3
+ OBJS += grimme_dispersion_m.o
+ 
++OBJS += cellsubs.o
++
+ # Special dependency that sfmakedepend cannot grasp for now
+ m_pexsi.o m_pexsi_driver.o m_pexsi_dos.o m_pexsi_local_dos.o: f_ppexsi_interface.o
+ 
+--- a/Src/m_ts_voltage.F90	2023-11-16 23:15:48.000000000 +0900
++++ b/Src/m_ts_voltage.F90	2023-11-17 13:41:30.000000000 +0900
+@@ -484,7 +484,7 @@ contains
+ 
+     use parallel, only : IONode
+ 
+-    use netcdf_ncdf
++    use netcdf_ncdf, ncdf_parallel => parallel
+     use dictionary
+ 
+     character(len=*), intent(in) :: fname
+--- a/Src/siesta_init.F	2023-11-16 23:15:54.000000000 +0900
++++ b/Src/siesta_init.F	2023-11-17 13:41:30.000000000 +0900
+@@ -89,7 +89,7 @@
+ #endif
+ 
+ #ifdef NCDF_4
+-      use netcdf_ncdf
++      use netcdf_ncdf, ncdf_parallel => parallel
+ #endif
+ 
+       use reinit_m, only: reinit, parse_command_line

--- a/var/spack/repos/builtin/packages/siesta-relmax3/package.py
+++ b/var/spack/repos/builtin/packages/siesta-relmax3/package.py
@@ -1,0 +1,97 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+import os
+import shutil
+
+from spack.package import *
+
+
+class SiestaRelmax3(MakefilePackage):
+    """The MaX3 branch of the SIESTA program is a special branch 
+    that contains all the features currently implemented within 
+    the MaX Center of Excellence EU H2020 project. 
+    This branch is intended for HPC users who want to try 
+    the new optimizations and enhancements, and provide feedback on them.
+    """
+
+    homepage = "https://departments.icmab.es/leem/siesta/"
+    git = "https://gitlab.com/siesta-project/siesta"
+
+    version(
+        "rel-MaX-3",
+        sha256="353c73ca8701eeaebca0dfc0790778ffb2095386ea079f3567f7b3ca35aaa8ee",
+        url="https://gitlab.com/siesta-project/siesta/-/archive/rel-MaX-3/siesta-rel-MaX-3.tar.gz",
+    )
+
+    patch("fj_mod.patch")
+
+    depends_on("mpi")
+    depends_on("blas")
+    depends_on("lapack")
+    depends_on("scalapack")
+    depends_on("netcdf-c")
+    depends_on("netcdf-fortran")
+
+    depends_on("hdf5")
+    depends_on("elsi@2.6.2")
+    depends_on("xmlf90")
+    depends_on("libpsml")
+    depends_on("libxc")
+    depends_on("libgridxc@1.1.0+mpi")
+    depends_on("flook")
+    depends_on("fftw")
+    # use dbcsr and omm-bundle specified in ExtLibs directory
+    depends_on("dbcsr@46cd0928465ee6bf21d82e5aac0a1970dcb54501")
+    depends_on("omm-bundle@0f863b217889486df299099fed14abb8e7910d56")
+
+    def flag_handler(self, name, flags):
+        if "%gcc@10:" in self.spec and name == "fflags":
+            flags.append("-fallow-argument-mismatch")
+        return flags, None, None
+
+    def edit(self, spec, prefix):
+        sh = which("sh")
+        with working_dir("Obj", create=True):
+            sh("../Src/obj_setup.sh")
+            
+            # setup arch.make(compilers and flags)
+            shutil.copy("../Config/mk-build/sample-arch-makes/gcc-modules.mk", "./arch.make")
+            arch_make = FileFilter("./arch.make")
+            arch_make.filter("FC_PARALLEL=.*", "FC_PARALLEL={0}".format(spec["mpi"].mpifc))
+            arch_make.filter("FC_SERIAL=.*", "FC_SERIAL={0}".format(spack_fc))
+            if spec.satisfies("%fj"):
+                arch_make.filter("FFLAGS=.*", "FFLAGS= -Kfast --Nlst -Cpp -X08")
+                arch_make.filter("FFLAGS_DEBUG=.*", "FFLAGS_DEBUG= -g -O0 -fPIC -Nlst -Cpp -X08")
+                arch_make.filter("RANLIB=echo", "RANLIB=echo\nLDFLAGS= -Kparallel -Kopenmp")
+            
+            # setup build.mk
+            build_mk = FileFilter("./build.mk")
+            build_mk.filter("#XMLF90_ROOT=.*", "XMLF90_ROOT={0}".format(spec["xmlf90"].prefix))
+            build_mk.filter("#PSML_ROOT=.*", "PSML_ROOT={0}".format(spec["libpsml"].prefix))
+            build_mk.filter("#GRIDXC_ROOT=.*", "GRIDXC_ROOT={0}".format(spec["libgridxc"].prefix))
+            build_mk.filter("#ELPA_ROOT=.*", "ELPA_ROOT={0}".format(spec["elsi"].prefix))
+            build_mk.filter("#ELPA_INCLUDE_DIRECTORY=.*", "ELPA_INCLUDE_DIRECTORY={0}".format(spec["elsi"].prefix.include))
+            build_mk.filter("#FLOOK_ROOT=.*", "FLOOK_ROOT={0}".format(spec["flook"].prefix))
+            build_mk.filter("#DBCSR_ROOT=.*", "DBCSR_ROOT={0}".format(spec["dbcsr"].prefix))
+            build_mk.filter("#OMM_SPARSE_BUNDLE_ROOT=.*", "OMM_SPARSE_BUNDLE_ROOT={0}".format(spec["omm-bundle"].prefix))
+            build_mk.filter("#NETCDF_ROOT=.*", "NETCDF_ROOT={0}".format(spec["netcdf-c"].prefix))
+            build_mk.filter("#NETCDF_LIBS=.*","NETCDF_LIBS= -L{0} -L{1} -L{2} -lnetcdff -lnetcdf  -lhdf5_hl -lhdf5"
+             .format(spec["netcdf-c"].prefix.lib,spec["netcdf-fortran"].prefix.lib,spec["hdf5"].prefix.lib))
+            build_mk.filter("#NETCDF_INCFLAGS=.*", "NETCDF_INCFLAGS=-I{0} -I{1}"
+             .format(spec["netcdf-c"].prefix.include,spec["netcdf-fortran"].prefix.include))
+            build_mk.filter("#SCALAPACK_LIBS=.*", "SCALAPACK_LIBS={0}".format(spec["scalapack"].libs))
+            build_mk.filter("#LAPACK_LIBS=.*", "LAPACK_LIBS={0} {1}".format(spec["lapack"].libs,spec["blas"].libs))
+
+    def build(self, spec, prefix):
+        with working_dir("Obj"):
+            make()
+
+    def install(self, spec, prefix):
+        mkdir(prefix.bin)
+        with working_dir("Obj"):
+            install("siesta", prefix.bin)
+

--- a/var/spack/repos/builtin/packages/siesta-relmax3/package.py
+++ b/var/spack/repos/builtin/packages/siesta-relmax3/package.py
@@ -27,7 +27,11 @@ class SiestaRelmax3(MakefilePackage):
         url="https://gitlab.com/siesta-project/siesta/-/archive/rel-MaX-3/siesta-rel-MaX-3.tar.gz",
     )
 
-    patch("fj_mod.patch")
+    # Fix dbscr and libgridxc link error and add missing object files
+    patch("fix_linkerror.patch")
+
+    # Fix ncdf_parallel link error when using Fujitsu compiler
+    patch("fj_fix_use_netcdf_parallel.patch", when="%fj")
 
     depends_on("mpi")
     depends_on("blas")

--- a/var/spack/repos/builtin/packages/siesta-relmax3/package.py
+++ b/var/spack/repos/builtin/packages/siesta-relmax3/package.py
@@ -4,17 +4,16 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-import os
 import shutil
 
 from spack.package import *
 
 
 class SiestaRelmax3(MakefilePackage):
-    """The MaX3 branch of the SIESTA program is a special branch 
-    that contains all the features currently implemented within 
-    the MaX Center of Excellence EU H2020 project. 
-    This branch is intended for HPC users who want to try 
+    """The MaX3 branch of the SIESTA program is a special branch
+    that contains all the features currently implemented within
+    the MaX Center of Excellence EU H2020 project.
+    This branch is intended for HPC users who want to try
     the new optimizations and enhancements, and provide feedback on them.
     """
 
@@ -61,7 +60,7 @@ class SiestaRelmax3(MakefilePackage):
         sh = which("sh")
         with working_dir("Obj", create=True):
             sh("../Src/obj_setup.sh")
-            
+
             # setup arch.make(compilers and flags)
             shutil.copy("../Config/mk-build/sample-arch-makes/gcc-modules.mk", "./arch.make")
             arch_make = FileFilter("./arch.make")
@@ -71,24 +70,45 @@ class SiestaRelmax3(MakefilePackage):
                 arch_make.filter("FFLAGS=.*", "FFLAGS= -Kfast --Nlst -Cpp -X08")
                 arch_make.filter("FFLAGS_DEBUG=.*", "FFLAGS_DEBUG= -g -O0 -fPIC -Nlst -Cpp -X08")
                 arch_make.filter("RANLIB=echo", "RANLIB=echo\nLDFLAGS= -Kparallel -Kopenmp")
-            
+
             # setup build.mk
             build_mk = FileFilter("./build.mk")
             build_mk.filter("#XMLF90_ROOT=.*", "XMLF90_ROOT={0}".format(spec["xmlf90"].prefix))
             build_mk.filter("#PSML_ROOT=.*", "PSML_ROOT={0}".format(spec["libpsml"].prefix))
             build_mk.filter("#GRIDXC_ROOT=.*", "GRIDXC_ROOT={0}".format(spec["libgridxc"].prefix))
             build_mk.filter("#ELPA_ROOT=.*", "ELPA_ROOT={0}".format(spec["elsi"].prefix))
-            build_mk.filter("#ELPA_INCLUDE_DIRECTORY=.*", "ELPA_INCLUDE_DIRECTORY={0}".format(spec["elsi"].prefix.include))
+            build_mk.filter(
+                "#ELPA_INCLUDE_DIRECTORY=.*",
+                "ELPA_INCLUDE_DIRECTORY={0}".format(spec["elsi"].prefix.include),
+            )
             build_mk.filter("#FLOOK_ROOT=.*", "FLOOK_ROOT={0}".format(spec["flook"].prefix))
             build_mk.filter("#DBCSR_ROOT=.*", "DBCSR_ROOT={0}".format(spec["dbcsr"].prefix))
-            build_mk.filter("#OMM_SPARSE_BUNDLE_ROOT=.*", "OMM_SPARSE_BUNDLE_ROOT={0}".format(spec["omm-bundle"].prefix))
+            build_mk.filter(
+                "#OMM_SPARSE_BUNDLE_ROOT=.*",
+                "OMM_SPARSE_BUNDLE_ROOT={0}".format(spec["omm-bundle"].prefix),
+            )
             build_mk.filter("#NETCDF_ROOT=.*", "NETCDF_ROOT={0}".format(spec["netcdf-c"].prefix))
-            build_mk.filter("#NETCDF_LIBS=.*","NETCDF_LIBS= -L{0} -L{1} -L{2} -lnetcdff -lnetcdf  -lhdf5_hl -lhdf5"
-             .format(spec["netcdf-c"].prefix.lib,spec["netcdf-fortran"].prefix.lib,spec["hdf5"].prefix.lib))
-            build_mk.filter("#NETCDF_INCFLAGS=.*", "NETCDF_INCFLAGS=-I{0} -I{1}"
-             .format(spec["netcdf-c"].prefix.include,spec["netcdf-fortran"].prefix.include))
-            build_mk.filter("#SCALAPACK_LIBS=.*", "SCALAPACK_LIBS={0}".format(spec["scalapack"].libs))
-            build_mk.filter("#LAPACK_LIBS=.*", "LAPACK_LIBS={0} {1}".format(spec["lapack"].libs,spec["blas"].libs))
+            build_mk.filter(
+                "#NETCDF_LIBS=.*",
+                "NETCDF_LIBS= -L{0} -L{1} -L{2} -lnetcdff -lnetcdf  -lhdf5_hl -lhdf5".format(
+                    spec["netcdf-c"].prefix.lib,
+                    spec["netcdf-fortran"].prefix.lib,
+                    spec["hdf5"].prefix.lib,
+                ),
+            )
+            build_mk.filter(
+                "#NETCDF_INCFLAGS=.*",
+                "NETCDF_INCFLAGS=-I{0} -I{1}".format(
+                    spec["netcdf-c"].prefix.include, spec["netcdf-fortran"].prefix.include
+                ),
+            )
+            build_mk.filter(
+                "#SCALAPACK_LIBS=.*", "SCALAPACK_LIBS={0}".format(spec["scalapack"].libs)
+            )
+            build_mk.filter(
+                "#LAPACK_LIBS=.*",
+                "LAPACK_LIBS={0} {1}".format(spec["lapack"].libs, spec["blas"].libs),
+            )
 
     def build(self, spec, prefix):
         with working_dir("Obj"):
@@ -98,4 +118,3 @@ class SiestaRelmax3(MakefilePackage):
         mkdir(prefix.bin)
         with working_dir("Obj"):
             install("siesta", prefix.bin)
-


### PR DESCRIPTION
We added siesta relmax3 branch as a separate package because the dependent libraries and build procedure are very different from the mainstream.