### PR TITLE
autodock-gpu: build with the specified `cuda_arch`

### DIFF
--- a/var/spack/repos/builtin/packages/autodock-gpu/package.py
+++ b/var/spack/repos/builtin/packages/autodock-gpu/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class AutodockGpu(MakefilePackage):
+class AutodockGpu(MakefilePackage, CudaPackage):
     """AutoDock-GPU: AutoDock for GPUs and other accelerators.
     OpenCL and Cuda accelerated version of AutoDock 4.2.6. It
     leverages its embarrasingly parallelizable LGA by processing
@@ -30,14 +30,19 @@ class AutodockGpu(MakefilePackage):
         multi=False,
     )
     variant("overlap", default=False, description="Overlap CPU and GPU operations")
+    variant("cuda", default=True, description="Build with CUDA")
 
     depends_on("cuda")
+
+    conflicts("~cuda")  # the cuda variant is mandatory
+    conflicts("+cuda", when="cuda_arch=none")
 
     @property
     def build_targets(self):
         spec = self.spec
         return [
             "DEVICE={0}".format(spec.variants["device"].value.upper()),
+            "TARGETS={0}".format(" ".join(spec.variants["cuda_arch"].value)),
             "GPU_INCLUDE_PATH={0}".format(spec["cuda"].prefix.include),
             "GPU_LIBRARY_PATH={0}".format(spec["cuda"].libs.directories[0]),
             "OVERLAP={0}".format("ON" if "+overlap" in spec else "OFF"),


### PR DESCRIPTION
The CUDA target should be specified at build time, otherwise by default `autodock-gpu` will be built for compute capabilities 52, 60, 61, 70, which may cause an `invalid device symbol` error on unsupported cards:
```cuda
SetKernelsGpuData copy to cData failed invalid device symbol
autodock_gpu_64wi: ./cuda/kernels.cu:130: void SetKernelsGpuData(GpuData*): Assertion `0' failed.
Aborted (core dumped)
```
See also ccsb-scripps/AutoDock-GPU#172

@RemiLacroix-IDRIS