### PR TITLE
lapackpp: new version + fix py-warpx build

### DIFF
--- a/var/spack/repos/builtin/packages/lapackpp/package.py
+++ b/var/spack/repos/builtin/packages/lapackpp/package.py
@@ -11,6 +11,7 @@ from spack.package import *
 _versions = [
     # LAPACK++,     BLAS++
     ["master", "master"],
+    ["2023.11.05", "2023.11.05"],
     ["2023.08.25", "2023.08.25"],
     ["2023.06.00", "2023.06.00"],
     ["2022.07.00", "2022.07.00"],
@@ -35,6 +36,9 @@ class Lapackpp(CMakePackage, CudaPackage, ROCmPackage):
     license("BSD-3-Clause")
 
     version("master", branch="master")
+    version(
+        "2023.11.05", sha256="9a505ef4e76504b6714cc19eb1b58939694f9ab51427a5bb915b016d615570ca"
+    )
     version(
         "2023.08.25", sha256="9effdd616a4a183a9b37c2ad33c85ddd3d6071b183e8c35e02243fbaa7333d4d"
     )


### PR DESCRIPTION
This missing package is ultimately the cause of `py-warpx` failing to build on develop, through a series of unfortunate events:

1. Current latest `lapackpp` on develop requires non-latest `blaspp`
2. `warpx` requires `lapackpp` and `blaspp` if and only if `dims=rz`
3. `warpx dims=1,2,rz,3` is the default

When concretizing `spack spec warpx`, the optimization result it:

```
  8         default values of variants not being used (roots)            0        0
  15        version badness                                              0       10
  16        default values of variants not being used (non-roots)        0        2
```

so Spack keeps `dims=1,2,rz,3` defaults, and keeps the blaspp & lapackpp deps.


However when concretizing `spack spec py-warpx`, `warpx` is no longer the
root, so the solver *drops* `dims=rz` as it does not affect criterion `#8`,
which increases `#16`, but at the same time drops the `blaspp` and `lapackpp`
dependencies, thereby reducing `#15`, which is "better":

```
  8         default values of variants not being used (roots)            0        0
  15        version badness                                              0        9
  16        default values of variants not being used (non-roots)        0        3
```

Makes me think that distinguishing between roots and non-roots is really a flaw
in Spack's optimization criteria.

I'd much rather have `spack spec x` give the same `x` as `spack spec y ^x`, provided
that `y` does not impose further constraints of `x`.

---

That's still not the whole story :) cause in principle nothing is wrong with
dropping `dims=rz`, *except* that `warpx` has a bug in its CMake scripts, since
it installs a single symlink:

```
libwarpx.1;2;3d.so -> libwarpx.[something more involved].so
```

instead of multiple

```
libwarpx.1d.so -> libwarpx.[something more involved].so
libwarpx.2d.so -> libwarpx.[something more involved].so
libwarpx.3d.so -> libwarpx.[something more involved].so
```

and apparently `dims=rz` was the only special case where

```
libwarpx.rz.so -> libwarpx.[something more involved].so
```

was created correctly. This in turn breaks detection in `py-warpx`.