### PR TITLE
Bugfix: fix sticky variants in externals

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1864,14 +1864,11 @@ class SpackSolverSetup:
                 msg = "%s available as external when satisfying %s" % (spec.name, spec)
 
                 def external_imposition(input_spec, requirements):
-                    return requirements + [fn.attr("external_conditions_hold", input_spec.name, local_idx)]
+                    return requirements + [
+                        fn.attr("external_conditions_hold", input_spec.name, local_idx)
+                    ]
 
-                self.condition(
-                    spec,
-                    spec,
-                    msg=msg,
-                    transform_imposed=external_imposition,
-                )
+                self.condition(spec, spec, msg=msg, transform_imposed=external_imposition)
                 self.possible_versions[spec.name].add(spec.version)
                 self.gen.newline()
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1863,12 +1863,12 @@ class SpackSolverSetup:
             for local_idx, spec in enumerate(external_specs):
                 msg = "%s available as external when satisfying %s" % (spec.name, spec)
 
-                def external_imposition(input_spec, _):
-                    return [fn.attr("external_conditions_hold", input_spec.name, local_idx)]
+                def external_imposition(input_spec, requirements):
+                    return requirements + [fn.attr("external_conditions_hold", input_spec.name, local_idx)]
 
                 self.condition(
                     spec,
-                    spack.spec.Spec(spec.name),
+                    spec,
                     msg=msg,
                     transform_imposed=external_imposition,
                 )

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1524,17 +1524,17 @@ class TestConcretize:
 
     @pytest.mark.regression("42172")
     @pytest.mark.only_clingo("Original concretizer cannot use sticky variants")
-    @pytest.mark.parametrize("spec,allow_gcc", [
-        ("sticky-variant@1.0+allow-gcc", True),
-        ("sticky-variant@1.0~allow-gcc", False),
-        ("sticky-variant@1.0", False),
-    ])
+    @pytest.mark.parametrize(
+        "spec,allow_gcc",
+        [
+            ("sticky-variant@1.0+allow-gcc", True),
+            ("sticky-variant@1.0~allow-gcc", False),
+            ("sticky-variant@1.0", False),
+        ],
+    )
     def test_sticky_variant_in_external(self, spec, allow_gcc):
         # setup external for sticky-variant+allow-gcc
-        config = {
-            "externals": [{"spec": spec, "prefix": "/fake/path"}],
-            "buildable": False,
-        }
+        config = {"externals": [{"spec": spec, "prefix": "/fake/path"}], "buildable": False}
         spack.config.set("packages:sticky-variant", config)
 
         maybe = llnl.util.lang.nullcontext if allow_gcc else pytest.raises

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1522,6 +1522,21 @@ class TestConcretize:
         s = Spec("sticky-variant %clang").concretized()
         assert s.satisfies("%clang") and s.satisfies("~allow-gcc")
 
+    @pytest.mark.only_clingo("Original concretizer cannot use sticky variants")
+    def test_sticky_variant_in_external(self):
+        # setup external for sticky-variant+allow-gcc
+        config = {
+            "externals": [{
+                "spec": "sticky-variant@1.0+allow-gcc",
+                "prefix": "/fake/path",
+            }],
+            "buildable": False
+        }
+        spack.config.set("packages:sticky-variant", config)
+
+        s = Spec("sticky-variant%gcc").concretized()
+        assert s.satisfies("%gcc") and s.satisfies("+allow-gcc") and s.external
+
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_do_not_invent_new_concrete_versions_unless_necessary(self):
         # ensure we select a known satisfying version rather than creating

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1522,17 +1522,29 @@ class TestConcretize:
         s = Spec("sticky-variant %clang").concretized()
         assert s.satisfies("%clang") and s.satisfies("~allow-gcc")
 
+    @pytest.mark.regression("42172")
     @pytest.mark.only_clingo("Original concretizer cannot use sticky variants")
-    def test_sticky_variant_in_external(self):
+    @pytest.mark.parametrize("spec,allow_gcc", [
+        ("sticky-variant@1.0+allow-gcc", True),
+        ("sticky-variant@1.0~allow-gcc", False),
+        ("sticky-variant@1.0", False),
+    ])
+    def test_sticky_variant_in_external(self, spec, allow_gcc):
         # setup external for sticky-variant+allow-gcc
         config = {
-            "externals": [{"spec": "sticky-variant@1.0+allow-gcc", "prefix": "/fake/path"}],
+            "externals": [{"spec": spec, "prefix": "/fake/path"}],
             "buildable": False,
         }
         spack.config.set("packages:sticky-variant", config)
 
-        s = Spec("sticky-variant%gcc").concretized()
-        assert s.satisfies("%gcc") and s.satisfies("+allow-gcc") and s.external
+        maybe = llnl.util.lang.nullcontext if allow_gcc else pytest.raises
+        with maybe(spack.error.SpackError):
+            s = Spec("sticky-variant-dependent%gcc").concretized()
+
+        if allow_gcc:
+            assert s.satisfies("%gcc")
+            assert s["sticky-variant"].satisfies("+allow-gcc")
+            assert s["sticky-variant"].external
 
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_do_not_invent_new_concrete_versions_unless_necessary(self):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1526,11 +1526,8 @@ class TestConcretize:
     def test_sticky_variant_in_external(self):
         # setup external for sticky-variant+allow-gcc
         config = {
-            "externals": [{
-                "spec": "sticky-variant@1.0+allow-gcc",
-                "prefix": "/fake/path",
-            }],
-            "buildable": False
+            "externals": [{"spec": "sticky-variant@1.0+allow-gcc", "prefix": "/fake/path"}],
+            "buildable": False,
         }
         spack.config.set("packages:sticky-variant", config)
 

--- a/var/spack/repos/builtin.mock/packages/sticky-variant-dependent/package.py
+++ b/var/spack/repos/builtin.mock/packages/sticky-variant-dependent/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class StickyVariantDependent(AutotoolsPackage):
+    """Package with a sticky variant and a conflict"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/a-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    depends_on("sticky-variant")
+    conflicts("%gcc", when="^sticky-variant~allow-gcc")


### PR DESCRIPTION
Fixes #42172

Currently, the concretizer does not preserve information about which variants were set explicitly on externals, which leads to concretization failures when an external specifies a sticky variant. This PR fixes the generation of facts for externals to preserve that information.

Includes regression test.