### PR TITLE
CI: Add ability to enable and disable stacks

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -84,6 +84,10 @@ default:
     PUSH_BUILDCACHE_DEPRECATED: "${PROTECTED_MIRROR_PUSH_DOMAIN}/${CI_COMMIT_REF_NAME}/${SPACK_CI_STACK_NAME}"
 
   rules:
+    - if: $SPACK_CI_DISABLE_STACKS =~ /.+/ && $SPACK_CI_STACK_NAME =~ $SPACK_CI_DISABLE_STACKS
+      when: never
+    - if: $SPACK_CI_ENABLE_STACKS =~ /.+/ && $SPACK_CI_STACK_NAME !~ $SPACK_CI_ENABLE_STACKS
+      when: never
     - if: $CI_COMMIT_REF_NAME == "develop"
       # Pipelines on develop only rebuild what is missing from the mirror
       when: always


### PR DESCRIPTION
It is useful to enable/disable stacks in order to handle turning specific stacks on/off based on runner availability, stack stability, testing requirements, etc.

The disabled stack list takes precedence over the enable stack list. The assumption is that stacks that are disabled are so due to some functionality missing or broken for that stack.

The enable stack list implicitly disables all stacks not listed in the enable list.

Test Enable and Disable:
* SPACK_CI_ENABLE_STACKS: `/^(build_systems|e4s)$/`
* SPACK_CI_DISABLE_STACKS: `/^(e4s.*)$/`
* URL: https://gitlab.staging.spack.io/spack/spack/-/pipelines/706

Test Enable and Disable:
* SPACK_CI_DISABLE_STACKS: `/^(e4s.*)$/`
* URL: https://gitlab.staging.spack.io/spack/spack/-/pipelines/707