### PR TITLE
Add eccodes@2.32.1 and eccodes@2.33.0

### DIFF
--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -50,6 +50,8 @@ class Eccodes(CMakePackage):
     license("Apache-2.0")
 
     version("develop", branch="develop")
+    version("2.33.0", sha256="bdcec8ce63654ec6803400c507f01220a9aa403a45fa6b5bdff7fdcc44fd7daf")
+    version("2.32.1", sha256="ad2ac1bf36577b1d35c4a771b4d174a06f522a1e5ef6c1f5e53a795fb624863e")
     version("2.32.0", sha256="b57e8eeb0eba0c05d66fda5527c4ffa84b5ab35c46bcbc9a2227142973ccb8e6")
     version("2.31.0", sha256="808ecd2c11fbf2c3f9fc7a36f8c2965b343f3151011b58a1d6e7cc2e6b3cac5d")
     version("2.25.0", sha256="8975131aac54d406e5457706fd4e6ba46a8cc9c7dd817a41f2aa64ce1193c04e")


### PR DESCRIPTION
## Description

Adding `eccodes@2.32.1` and `eccodes@2.33.0`. I briefly checked the top-level `CMakeLists.txt` of `eccodes@2.33.0` and the minimum requirements for `cmake` and `ecbuild` are still `3.12` and `3.7`, respectively. I also built both versions on macOS Monterey with `apple-clang@13.1.6`.

I saw that there is a new tag `2.33.1` on the github page, but it hasn't been released yet officially, therefore not adding it in this PR.