### PR TITLE
hdf5: workaround build error on Apple Clang 15

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -293,9 +293,13 @@ class Hdf5(CMakePackage):
                 cmake_flags.append(self.compiler.cc_pic_flag)
             if spec.satisfies("@1.8.21 %oneapi@2023.0.0"):
                 cmake_flags.append("-Wno-error=int-conversion")
+            if spec.satisfies("%apple-clang@15:"):
+                cmake_flags.append("-Wl,-ld_classic")
         elif name == "cxxflags":
             if spec.satisfies("@:1.8.12+cxx~shared"):
                 cmake_flags.append(self.compiler.cxx_pic_flag)
+            if spec.satisfies("%apple-clang@15:"):
+                cmake_flags.append("-Wl,-ld_classic")
         elif name == "fflags":
             if spec.satisfies("%cce+fortran"):
                 # Cray compiler generates module files with uppercase names by


### PR DESCRIPTION
Closes #41360 

As seen in the issue, I've had problems building HDF5 with Apple Clang 15. Much like #40187 and https://github.com/esmf-org/esmf/issues/193, we use the `-Wl,-ld_classic` workaround.

Note I'm not sure I've ever built the C++ bits of HDF5, so maybe the workaround isn't needed there? Perhaps the HDF5 maintainers could test and see. (Or maybe macOS expert @fxcoudert could comment? I think he helped me with the ESMF issue above a while back.)

I also don't know if *every* version of HDF5 is affected or not. In testing before filing #41360 I did [try building HDF5 1.10 to 1.14 and all failed](https://github.com/JCSDA/spack/pull/372#issuecomment-1837229134). Since I don't know, the spec is based only on compiler.

And of course, if Apple fixes this issue eventually, then the `15:` would probably need adjusted.