### PR TITLE
llvm: disable libomptarget AMDGPU plugin

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -841,6 +841,12 @@ class Llvm(CMakePackage, CudaPackage):
 
         cmake_args.append(from_variant("LIBOMPTARGET_ENABLE_DEBUG", "libomptarget_debug"))
 
+        if spec.satisfies("@14:"):
+            # The hsa-rocr-dev package may be pulled in through hwloc, which can lead to cmake
+            # finding libhsa and enabling the AMDGPU plugin. Since we don't support this yet,
+            # disable explicitly. See commit a05a0c3c2f8eefc80d84b7a87a23a4452d4a3087.
+            cmake_args.append(define("LIBOMPTARGET_BUILD_AMDGPU_PLUGIN", False))
+
         if "+lldb" in spec:
             projects.append("lldb")
             cmake_args.extend(


### PR DESCRIPTION
This should fix failing CI on develop, as `llvm ^hwloc+rocm` pulls in
`hsa-rocr-dev` which makes llvm's cmake detect libhsa and enable libomptarget's
AMDGPU plugin, which fails because they include `hsa.h` instead of `hsa/hsa.h`
in LLVM 14.

In any case it should be disabled as long as we don't have support, instead of
automatically enabled when detected.

