### PR TITLE
e4s neoverse-v2 ci: use ghcr.io/spack image registry

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -353,7 +353,7 @@ e4s-build:
 
 e4s-neoverse-v2-generate:
   extends: [ ".e4s-neoverse-v2", ".generate-neoverse-v2" ]
-  image: ecpe4s/ubuntu22.04-runner-arm64-gcc-11.4:2024.01.01
+  image: ghcr.io/spack/ubuntu22.04-runner-arm64-gcc-11.4:2024.01.01
 
 e4s-neoverse-v2-build:
   extends: [ ".e4s-neoverse-v2", ".build" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse-v2/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse-v2/spack.yaml
@@ -329,7 +329,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: "ecpe4s/ubuntu22.04-runner-arm64-gcc-11.4:2024.01.01"
+        image: "ghcr.io/spack/ubuntu22.04-runner-arm64-gcc-11.4:2024.01.01"
 
   cdash:
     build-group: E4S ARM Neoverse V2


### PR DESCRIPTION
E4S Neoverse V2 CI: use `ghcr.io/spack` registry for runner images