### PR TITLE
e4s ci: add py-torch, py-tensorflow: cpu and assorted gpu builds

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse-v2/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse-v2/spack.yaml
@@ -353,9 +353,9 @@ spack:
   - py-torch ~rocm +cuda cuda_arch=80
   - py-torch ~rocm +cuda cuda_arch=90
   - py-tensorflow ~rocm ~cuda
-  - py-tensorflow ~rocm +cuda cuda_arch=75
-  - py-tensorflow ~rocm +cuda cuda_arch=80
-  - py-tensorflow ~rocm +cuda cuda_arch=90
+  # - py-tensorflow ~rocm +cuda cuda_arch=75 # py-tensorflow: /usr/lib/gcc/aarch64-linux-gnu/11/include/arm_neon.h(1270): error:identifier "__builtin_aarch64_raddhnv2di" is undefined
+  # - py-tensorflow ~rocm +cuda cuda_arch=80 # py-tensorflow: /usr/lib/gcc/aarch64-linux-gnu/11/include/arm_neon.h(1270): error:identifier "__builtin_aarch64_raddhnv2di" is undefined
+  # - py-tensorflow ~rocm +cuda cuda_arch=90 # py-tensorflow: /usr/lib/gcc/aarch64-linux-gnu/11/include/arm_neon.h(1270): error:identifier "__builtin_aarch64_raddhnv2di" is undefined
 
 
   ci:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse-v2/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse-v2/spack.yaml
@@ -348,6 +348,16 @@ spack:
   # - tasmanian +cuda cuda_arch=90  # tasmanian: conflicts with cuda@12
   # - upcxx +cuda cuda_arch=90      # upcxx: needs NVIDIA driver
 
+  - py-torch ~rocm ~cuda 
+  - py-torch ~rocm +cuda cuda_arch=75
+  - py-torch ~rocm +cuda cuda_arch=80
+  - py-torch ~rocm +cuda cuda_arch=90
+  - py-tensorflow ~rocm ~cuda
+  - py-tensorflow ~rocm +cuda cuda_arch=75
+  - py-tensorflow ~rocm +cuda cuda_arch=80
+  - py-tensorflow ~rocm +cuda cuda_arch=90
+
+
   ci:
     pipeline-gen:
     - build-job:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse_v1/spack.yaml
@@ -346,6 +346,15 @@ spack:
   # - tasmanian +cuda cuda_arch=90  # tasmanian: conflicts with cuda@12
   # - upcxx +cuda cuda_arch=90      # upcxx: needs NVIDIA driver
 
+  - py-torch ~rocm ~cuda 
+  - py-torch ~rocm +cuda cuda_arch=75
+  - py-torch ~rocm +cuda cuda_arch=80
+  - py-torch ~rocm +cuda cuda_arch=90
+  - py-tensorflow ~rocm ~cuda
+  - py-tensorflow ~rocm +cuda cuda_arch=75
+  - py-tensorflow ~rocm +cuda cuda_arch=80
+  - py-tensorflow ~rocm +cuda cuda_arch=90
+
   ci:
     pipeline-gen:
     - build-job:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse_v1/spack.yaml
@@ -351,9 +351,9 @@ spack:
   - py-torch ~rocm +cuda cuda_arch=80
   - py-torch ~rocm +cuda cuda_arch=90
   - py-tensorflow ~rocm ~cuda
-  - py-tensorflow ~rocm +cuda cuda_arch=75
-  - py-tensorflow ~rocm +cuda cuda_arch=80
-  - py-tensorflow ~rocm +cuda cuda_arch=90
+  # - py-tensorflow ~rocm +cuda cuda_arch=75 # py-tensorflow: /usr/lib/gcc/aarch64-linux-gnu/11/include/arm_neon.h(1270): error:identifier "__builtin_aarch64_raddhnv2di" is undefined
+  # - py-tensorflow ~rocm +cuda cuda_arch=80 # py-tensorflow: /usr/lib/gcc/aarch64-linux-gnu/11/include/arm_neon.h(1270): error:identifier "__builtin_aarch64_raddhnv2di" is undefined
+  # - py-tensorflow ~rocm +cuda cuda_arch=90 # py-tensorflow: /usr/lib/gcc/aarch64-linux-gnu/11/include/arm_neon.h(1270): error:identifier "__builtin_aarch64_raddhnv2di" is undefined
 
   ci:
     pipeline-gen:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
@@ -258,10 +258,10 @@ spack:
   # - trilinos +cuda cuda_arch=70           # trilinos: https://github.com/trilinos/Trilinos/issues/11630
   # - upcxx +cuda cuda_arch=70              # upcxx: needs NVIDIA driver
 
-  - py-torch ~rocm ~cuda 
-  - py-torch ~rocm +cuda cuda_arch=70
-  - py-tensorflow ~rocm ~cuda
-  - py-tensorflow ~rocm +cuda cuda_arch=70
+  # - py-torch ~rocm ~cuda                  # py-torch: error
+  # - py-torch ~rocm +cuda cuda_arch=70     # py-torch: error
+  # - py-tensorflow ~rocm ~cuda             # py-tensorboard-data-server: https://github.com/spack/spack/issues/42669
+  # - py-tensorflow ~rocm +cuda cuda_arch=70 # py-tensorboard-data-server: https://github.com/spack/spack/issues/42669
 
   ci:
     pipeline-gen:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
@@ -258,6 +258,11 @@ spack:
   # - trilinos +cuda cuda_arch=70           # trilinos: https://github.com/trilinos/Trilinos/issues/11630
   # - upcxx +cuda cuda_arch=70              # upcxx: needs NVIDIA driver
 
+  - py-torch ~rocm ~cuda 
+  - py-torch ~rocm +cuda cuda_arch=70
+  - py-tensorflow ~rocm ~cuda
+  - py-tensorflow ~rocm +cuda cuda_arch=70
+
   ci:
     pipeline-gen:
     - build-job:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -324,10 +324,10 @@ spack:
   # - lbann ~cuda +rocm amdgpu_target=gfx90a    # aluminum: https://github.com/spack/spack/issues/38807
   # - papi +rocm amdgpu_target=gfx90a           # papi: https://github.com/spack/spack/issues/27898
 
-  - py-torch ~cuda +rocm amdgpu_target=gfx908
-  - py-torch ~cuda +rocm amdgpu_target=gfx90a
-  - py-tensorflow ~cuda +rocm amdgpu_target=gfx908
-  - py-tensorflow ~cuda +rocm amdgpu_target=gfx90a
+  # - py-torch ~cuda +rocm amdgpu_target=gfx908 # py-torch: /usr/bin/ld: cannot find -lgloo_hip
+  # - py-torch ~cuda +rocm amdgpu_target=gfx90a # py-torch: /usr/bin/ld: cannot find -lgloo_hip
+  # - py-tensorflow ~cuda +rocm amdgpu_target=gfx908 # py-tensorflow@2.7.4-rocm-enhanced: Error in fail: ROCm Configuration Error: Invalid AMDGPU target:
+  # - py-tensorflow ~cuda +rocm amdgpu_target=gfx90a # py-tensorflow@2.7.4-rocm-enhanced: Error in fail: ROCm Configuration Error: Invalid AMDGPU target:
 
   ci:
     pipeline-gen:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -324,6 +324,11 @@ spack:
   # - lbann ~cuda +rocm amdgpu_target=gfx90a    # aluminum: https://github.com/spack/spack/issues/38807
   # - papi +rocm amdgpu_target=gfx90a           # papi: https://github.com/spack/spack/issues/27898
 
+  - py-torch ~cuda +rocm amdgpu_target=gfx908
+  - py-torch ~cuda +rocm amdgpu_target=gfx90a
+  - py-tensorflow ~cuda +rocm amdgpu_target=gfx908
+  - py-tensorflow ~cuda +rocm amdgpu_target=gfx90a
+
   ci:
     pipeline-gen:
     - build-job:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -397,6 +397,19 @@ spack:
   # - lbann ~cuda +rocm amdgpu_target=gfx90a    # aluminum: https://github.com/spack/spack/issues/38807
   # - papi +rocm amdgpu_target=gfx90a           # papi: https://github.com/spack/spack/issues/27898
 
+  - py-torch ~rocm ~cuda 
+  - py-torch ~rocm +cuda cuda_arch=75
+  - py-torch ~rocm +cuda cuda_arch=80
+  - py-torch ~rocm +cuda cuda_arch=90
+  - py-torch ~cuda +rocm amdgpu_target=gfx908
+  - py-torch ~cuda +rocm amdgpu_target=gfx90a
+  - py-tensorflow ~rocm ~cuda
+  - py-tensorflow ~rocm +cuda cuda_arch=75
+  - py-tensorflow ~rocm +cuda cuda_arch=80
+  - py-tensorflow ~rocm +cuda cuda_arch=90
+  - py-tensorflow ~cuda +rocm amdgpu_target=gfx908
+  - py-tensorflow ~cuda +rocm amdgpu_target=gfx90a
+
   ci:
     pipeline-gen:
     - build-job:


### PR DESCRIPTION
Adding various `py-torch` and `py-tensorflow` builds to E4S stacks.