### PR TITLE
openexr: Add custom libs property

### DIFF
--- a/var/spack/repos/builtin/packages/openexr/package.py
+++ b/var/spack/repos/builtin/packages/openexr/package.py
@@ -85,6 +85,11 @@ class Openexr(CMakePackage, AutotoolsPackage):
     with when("build_system=cmake"):
         depends_on("cmake@3.12:", type="build")
 
+    @property
+    def libs(self):
+        # Override because libs have different case than Spack package name
+        name = "libOpenEXR*"
+        return find_libraries(name, root=self.prefix, shared=True, recursive=True)
 
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/openexr/package.py
+++ b/var/spack/repos/builtin/packages/openexr/package.py
@@ -96,6 +96,7 @@ class Openexr(CMakePackage, AutotoolsPackage):
                 break
         return liblist
 
+
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
         args = [self.define("BUILD_TESTING", self.pkg.run_tests)]

--- a/var/spack/repos/builtin/packages/openexr/package.py
+++ b/var/spack/repos/builtin/packages/openexr/package.py
@@ -89,7 +89,12 @@ class Openexr(CMakePackage, AutotoolsPackage):
     def libs(self):
         # Override because libs have different case than Spack package name
         name = "libOpenEXR*"
-        return find_libraries(name, root=self.prefix, shared=True, recursive=True)
+        # We expect libraries to be in either lib64 or lib directory
+        for root in (self.prefix.lib64, self.prefix.lib):
+            liblist = find_libraries(name, root=root, shared=True, recursive=False)
+            if liblist:
+                break
+        return liblist
 
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):


### PR DESCRIPTION
Libraries for openexr are named libOpenEXR*.so, etc., so the default libs handler in spec does not find them.

Add a custom libs property to address this.

Partial fix for #42273