### PR TITLE
qb3: Add custom libs property

### DIFF
--- a/var/spack/repos/builtin/packages/qb3/package.py
+++ b/var/spack/repos/builtin/packages/qb3/package.py
@@ -24,14 +24,8 @@ class Qb3(CMakePackage):
         # Override because libs have different case than Spack package name
         name = "libQB3*"
         # We expect libraries to be in either lib64 or lib directory
-        # Try lib64 first
-        root = self.prefix.lib64
-        liblist = find_libraries(name, root=root, shared=True, recursive=False)
-        if liblist:
-            # Found libs in lib64, so return those
-            return liblist
-        else:
-            # Did not find libs in lib64, so try lib w/out 64 suffix
-            root = self.prefix.lib
+        for root in (self.prefix.lib64, self.prefix.lib):
             liblist = find_libraries(name, root=root, shared=True, recursive=False)
-            return liblist
+            if liblist:
+                break
+        return liblist

--- a/var/spack/repos/builtin/packages/qb3/package.py
+++ b/var/spack/repos/builtin/packages/qb3/package.py
@@ -18,3 +18,9 @@ class Qb3(CMakePackage):
 
     depends_on("cmake@3.5:", type="build")
     depends_on("libicd")
+
+    @property
+    def libs(self):
+        # Override because libs have different case than Spack package name
+        name = "libQB3*"
+        return find_libraries(name, root=self.prefix, shared=True, recursive=True)

--- a/var/spack/repos/builtin/packages/qb3/package.py
+++ b/var/spack/repos/builtin/packages/qb3/package.py
@@ -23,4 +23,15 @@ class Qb3(CMakePackage):
     def libs(self):
         # Override because libs have different case than Spack package name
         name = "libQB3*"
-        return find_libraries(name, root=self.prefix, shared=True, recursive=True)
+        # We expect libraries to be in either lib64 or lib directory
+        # Try lib64 first
+        root = self.prefix.lib64
+        liblist = find_libraries(name, root=root, shared=True, recursive=False)
+        if liblist:
+            # Found libs in lib64, so return those
+            return liblist
+        else:
+            # Did not find libs in lib64, so try lib w/out 64 suffix
+            root = self.prefix.lib
+            liblist = find_libraries(name, root=root, shared=True, recursive=False)
+            return liblist


### PR DESCRIPTION
Libraries for openexr are named libQB3*.so, etc., so the default libs handler in spec does not find them.

Add a custom libs property to address this.

Partial fix for #42273