### PR TITLE
sfcgal: Add custom libs property

### DIFF
--- a/var/spack/repos/builtin/packages/sfcgal/package.py
+++ b/var/spack/repos/builtin/packages/sfcgal/package.py
@@ -40,3 +40,10 @@ class Sfcgal(CMakePackage):
         # https://github.com/Oslandia/SFCGAL/releases/tag/v1.3.0
         # Also, see https://github.com/Oslandia/SFCGAL-viewer
         return [self.define("BUILD_SHARED_LIBS", True), self.define("SFCGAL_BUILD_VIEWER", False)]
+
+    @property
+    def libs(self):
+        # Override because libs have different case than Spack package name
+        name = "libSFCGAL*"
+        return find_libraries(name, root=self.prefix, shared=True, recursive=True)
+~ 

--- a/var/spack/repos/builtin/packages/sfcgal/package.py
+++ b/var/spack/repos/builtin/packages/sfcgal/package.py
@@ -45,5 +45,10 @@ class Sfcgal(CMakePackage):
     def libs(self):
         # Override because libs have different case than Spack package name
         name = "libSFCGAL*"
-        return find_libraries(name, root=self.prefix, shared=True, recursive=True)
+        # We expect libraries to be in either lib64 or lib directory
+        for root in (self.prefix.lib64, self.prefix.lib):
+            liblist = find_libraries(name, root=root, shared=True, recursive=False)
+            if liblist:
+                break
+        return liblist
 ~ 

--- a/var/spack/repos/builtin/packages/sfcgal/package.py
+++ b/var/spack/repos/builtin/packages/sfcgal/package.py
@@ -51,4 +51,3 @@ class Sfcgal(CMakePackage):
             if liblist:
                 break
         return liblist
-~ 


### PR DESCRIPTION
Libraries for openexr are named libSFCGAL*.so, etc., so the default libs handler in spec does not find them.

Add a custom libs property to address this.

Partial fix for #42273