### PR TITLE
sfcgal: Add new versions and restrict versions of cgal dependency

### DIFF
--- a/var/spack/repos/builtin/packages/sfcgal/package.py
+++ b/var/spack/repos/builtin/packages/sfcgal/package.py
@@ -15,16 +15,37 @@ class Sfcgal(CMakePackage):
     """
 
     homepage = "http://www.sfcgal.org/"
-    url = "https://github.com/Oslandia/SFCGAL/archive/v1.3.8.tar.gz"
+    url = "https://gitlab.com/sfcgal/SFCGAL/-/archive/v1.5.1/SFCGAL-v1.5.1.tar.gz"
+    # URL for versions up to 1.3.8
+    old_github_urlbase = "https://github.com/Oslandia/SFCGAL/archive/v{0}.tar.gz"
 
     license("LGPL-2.0-or-later")
 
-    version("1.3.8", sha256="5154bfc67a5e99d95cb653d70d2b9d9293d3deb3c8f18b938a33d68fec488a6d")
-    version("1.3.7", sha256="30ea1af26cb2f572c628aae08dd1953d80a69d15e1cac225390904d91fce031b")
+    version("1.5.1", sha256="ea5d1662fada7de715ad564dc810c3059024ed81ae393f5352489f706fdfa3b1")
+    version("1.4.1", sha256="1800c8a26241588f11cddcf433049e9b9aea902e923414d2ecef33a3295626c3")
+    version(
+        "1.3.8",
+        sha256="5154bfc67a5e99d95cb653d70d2b9d9293d3deb3c8f18b938a33d68fec488a6d",
+        url=old_github_urlbase.format("1.3.8"),
+    )
+    version(
+        "1.3.7",
+        sha256="30ea1af26cb2f572c628aae08dd1953d80a69d15e1cac225390904d91fce031b",
+        url=old_github_urlbase.format("1.3.7"),
+    )
 
     depends_on("cmake@2.8.6:", type="build")
     # Ref: https://oslandia.github.io/SFCGAL/installation.html, but starts to work @4.7:
-    depends_on("cgal@4.7: +core")
+    # Ref: https://gitlab.com/sfcgal/SFCGAL/-/blob/v1.5.1/NEWS?ref_type=tags
+    # and looking at CMakeLists.txt find_package(CGAL) declaration
+    # for different versions (around line 70)
+    # @1.3.8:1.3.10 (from comments) cgal@4.3 is minimal, @4.13 recommended, @5 supported?
+    depends_on("cgal +core")
+    depends_on("cgal@4.7:4", when="@1.3.8")
+    depends_on("cgal@4.7:5.1", when="@1.3.9")
+    depends_on("cgal@4.7:5.2", when="@1.3.10")
+    depends_on("cgal@5.3", when="@1.4")
+    depends_on("cgal@5.6", when="@1.5")
     depends_on(
         "boost@1.54.0:+chrono+filesystem+program_options+serialization+system+test+thread+timer"
     )


### PR DESCRIPTION
Added new versions @1.5.1 and @1.4.1 (sfcgal moved from github to gitlab)

Placed restrictions on what versions of cgal are supported for different cfcgal versions.  These restrictions are based on what was found in the version history at https://gitlab.com/sfcgal/SFCGAL/-/blob/v1.5.1/NEWS?ref_type=tags as well as the CMakeLists.txt for different versions.

@1.4 and @1.5 seem to require a specific version of cgal based on CMakeLists.txt

Earlier versions (@1.3.8:1.3.10) claim to support cgal@4.3: (but Spack recipe claims did not work until @4.7, so sticking with that as minimum).  CMakeList.txt suggests they support cgal@5 as well, but version history suggests otherwise. (I had issues building sfcgal@1.3.8 ^cgal@5.4 which looked like sfcgal did not support changes in cgal).

This might at least parially fix #41712