### PR TITLE
Merge `virtuals=` from duplicate dependencies

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1640,15 +1640,21 @@ class Spec:
         # multiple times. Currently, we only allow identical edge types.
         orig = self._dependencies[spec.name]
         try:
-            dspec = next(dspec for dspec in orig if depflag == dspec.depflag)
-        except StopIteration:
-            current_deps = ", ".join(
-                dt.flag_to_chars(x.depflag) + " " + x.spec.short_spec for x in orig
+            dspec = next(
+                dspec for dspec in orig if depflag == dspec.depflag and virtuals == dspec.virtuals
             )
+        except StopIteration:
+            edge_attrs = []
+            required_deps = dt.flag_to_chars(depflag).strip()
+            if required_deps:
+                edge_attrs.append(f"deptypes={required_deps}")
+            if virtuals:
+                edge_attrs.append(f"virtuals={','.join(virtuals)}")
+            required_dep_str = f"^[{' '.join(edge_attrs)}] {str(spec)}"
+
             raise DuplicateDependencyError(
-                f"{self.short_spec} cannot depend on '{spec.short_spec}' multiple times.\n"
-                f"\tRequired: {dt.flag_to_chars(depflag)}\n"
-                f"\tDependency: {current_deps}"
+                f"{spec.name} is a duplicate dependency, with conflicting edge properties\n"
+                f"\t'{str(self)}' cannot depend on '{required_dep_str}'"
             )
 
         try:

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -1252,3 +1252,13 @@ def test_git_ref_spec_equivalences(mock_packages, lhs_str, rhs_str, expected):
 def test_platform_is_none_if_not_present(spec_str):
     s = SpecParser(spec_str).next_spec()
     assert s.architecture.platform is None, s
+
+
+def test_cannot_add_same_package_multiple_times_with_different_edges_properties():
+    """Tests that we don't allow specifying multiple times the same package, with different
+    edge properties.
+
+    This might change in the future, if we get an edge-based syntax to construct DAGs.
+    """
+    with pytest.raises(spack.spec.DuplicateDependencyError):
+        SpecParser("foo ^[virtuals=a] bar ^[virtuals=b] bar").next_spec()


### PR DESCRIPTION
closes #42216

Previously, for abstract specs like:
```
foo ^[virtuals=a] bar ^[virtuals=b] bar
```
the second requirement was silently discarded on concretization. Now they're merged, and the abstract spec is equivalent to:
```
foo ^[virtuals=a,b] bar
```