### PR TITLE
pflogger: Add v1.12

### DIFF
--- a/var/spack/repos/builtin/packages/pflogger/package.py
+++ b/var/spack/repos/builtin/packages/pflogger/package.py
@@ -22,6 +22,7 @@ class Pflogger(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.12.0", sha256="ff29b0ce4baf50675edb69c3c7493be5410839b5f81e3ce5405f04925503fb0d")
     version("1.11.0", sha256="bf197b6f223a75c7d3eee23888cdde204b5aea053c308852a3f8f677784b8899")
     version("1.10.0", sha256="8e25564699c0adcbe9a23fded6637668ce659480b39420be5a4c8181cd44ad53")
     version("1.9.5", sha256="baa3ebb83962f1b6c8c5b0413fe9d02411d3e379c76b8c190112e158c10ac0ac")
@@ -39,7 +40,7 @@ class Pflogger(CMakePackage):
         values=("Debug", "Release"),
     )
 
-    variant("mpi", default=False, description="Enable MPI")
+    variant("mpi", default=True, description="Enable MPI")
 
     # pFlogger needs careful versioning to build
     depends_on("gftl@:1.5", when="@:1.6")
@@ -55,6 +56,9 @@ class Pflogger(CMakePackage):
     depends_on("yafyaml@1.0.4:", when="@1.9:")
 
     depends_on("mpi", when="+mpi")
+    
+    # Using pFlogger with MPICH 4 is only supported from version 1.11
+    conflicts("^mpich@4:", when="@:1.10")
 
     depends_on("cmake@3.12:", type="build")
 
@@ -64,5 +68,11 @@ class Pflogger(CMakePackage):
 
         if spec.satisfies("+mpi"):
             args.extend(["-DCMAKE_Fortran_COMPILER=%s" % spec["mpi"].mpifc])
+
+        # From version 1.12 on, there is an `ENABLE_MPI` option that
+        # defaults to `ON`. If we don't want MPI, we need to set it to
+        # `OFF`
+        if spec.satisfies("~mpi"):
+            args.append("-DENABLE_MPI=OFF")
 
         return args

--- a/var/spack/repos/builtin/packages/pflogger/package.py
+++ b/var/spack/repos/builtin/packages/pflogger/package.py
@@ -40,7 +40,7 @@ class Pflogger(CMakePackage):
         values=("Debug", "Release"),
     )
 
-    variant("mpi", default=True, description="Enable MPI")
+    variant("mpi", default=False, description="Enable MPI")
 
     # pFlogger needs careful versioning to build
     depends_on("gftl@:1.5", when="@:1.6")

--- a/var/spack/repos/builtin/packages/pflogger/package.py
+++ b/var/spack/repos/builtin/packages/pflogger/package.py
@@ -56,7 +56,7 @@ class Pflogger(CMakePackage):
     depends_on("yafyaml@1.0.4:", when="@1.9:")
 
     depends_on("mpi", when="+mpi")
-    
+
     # Using pFlogger with MPICH 4 is only supported from version 1.11
     conflicts("^mpich@4:", when="@:1.10")
 

--- a/var/spack/repos/builtin/packages/pflogger/package.py
+++ b/var/spack/repos/builtin/packages/pflogger/package.py
@@ -72,7 +72,7 @@ class Pflogger(CMakePackage):
         # From version 1.12 on, there is an `ENABLE_MPI` option that
         # defaults to `ON`. If we don't want MPI, we need to set it to
         # `OFF`
-        if spec.satisfies("~mpi"):
+        if spec.satisfies("@1.12: ~mpi"):
             args.append("-DENABLE_MPI=OFF")
 
         return args


### PR DESCRIPTION
This PR adds a new version, v1.12.0, for pFlogger. 

It also changes a few things. 

First, it was found by @climbfuji and others that, by default, pFlogger was enabling MPI support if it could just find it even if you told it *not* to enable it. (CMake is good at finding MPI in your paths via `find_package(MPI)`. So in v1.12 a new CMake option, `ENABLE_MPI` was added defaulting to `ON`. If `~mpi` is asked for with v1.12+, we now set `-DENABLE_MPI=OFF`

Second, MPICH 4 support is only possible from v1.11 on, so we add a conflict.