### PR TITLE
VTk: stabalize spack package consumers

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+import glob
 import os
 
 from spack.package import *
@@ -98,7 +99,7 @@ class Vtk(CMakePackage):
     patch("vtkm-findmpi-downstream.patch", when="@9.0.0")
 
     # use internal FindHDF5
-    patch("internal_findHDF5.patch", when="@:8")
+    patch("internal_findHDF5.patch", when="@:8 ^cmake@:3.22")
 
     # Fix IOADIOS2 module to work with kits
     # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8653
@@ -117,6 +118,10 @@ class Vtk(CMakePackage):
     depends_on("gl@3.2:", when="+opengl2")
     depends_on("gl@1.2:", when="~opengl2")
 
+    depends_on("xz")
+    patch("vtk_find_liblzma.patch", when="@:9.0")
+    patch("vtk_movie_link_ogg.patch")
+    patch("vtk_use_sqlite_name_vtk_expects.patch")
     with when("~osmesa"):
         depends_on("glx", when="platform=linux")
         depends_on("glx", when="platform=cray")
@@ -161,7 +166,7 @@ class Vtk(CMakePackage):
     depends_on("eigen", when="@8.2.0:")
     depends_on("double-conversion", when="@8.2.0:")
     depends_on("sqlite", when="@8.2.0:")
-    depends_on("pugixml", when="@8.2.0:")
+    depends_on("pugixml", when="@8.3.0:")
     depends_on("libogg")
     depends_on("libtheora")
     depends_on("utf8cpp", when="@9:")
@@ -472,7 +477,19 @@ class Vtk(CMakePackage):
                     "-DCMAKE_CXX_FLAGS={0}".format(compile_flags),
                 ]
             )
-
-        cmake_args.append(self.define_from_variant("VTK_BUILD_EXAMPLES", "examples"))
+        if spec.satisfies("@:8"):
+            vtk_example_arg = "BUILD_EXAMPLES"
+        else:
+            vtk_example_arg = "VTK_BUILD_EXAMPLES"
+        cmake_args.append(self.define_from_variant(f"{vtk_example_arg}", "examples"))
 
         return cmake_args
+
+    @when("+examples")
+    def install(self, spec, prefix):
+        super().install(spec, prefix)
+        with working_dir(self.build_directory):
+            examples = glob.glob("bin\\*.exe")
+            for example in examples:
+                install(example, prefix.bin)
+

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -492,4 +492,3 @@ class Vtk(CMakePackage):
             examples = glob.glob("bin\\*.exe")
             for example in examples:
                 install(example, prefix.bin)
-

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -98,8 +98,9 @@ class Vtk(CMakePackage):
     # Broken downstream FindMPI
     patch("vtkm-findmpi-downstream.patch", when="@9.0.0")
 
-    # use internal FindHDF5
-    patch("internal_findHDF5.patch", when="@:8 ^cmake@:3.22")
+    for plat in ["linux", "darwin", "freebsd", "cray"]:
+        # use internal FindHDF5
+        patch("internal_findHDF5.patch", when=f"@:8 platform={plat}")
 
     # Fix IOADIOS2 module to work with kits
     # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8653

--- a/var/spack/repos/builtin/packages/vtk/vtk_find_liblzma.patch
+++ b/var/spack/repos/builtin/packages/vtk/vtk_find_liblzma.patch
@@ -1,0 +1,11 @@
+diff --git a/CMake/FindLZMA.cmake b/CMake/FindLZMA.cmake
+index 213ab18df1..c9e693800b 100644
+--- a/CMake/FindLZMA.cmake
++++ b/CMake/FindLZMA.cmake
+@@ -1,5 +1,5 @@
+ 
+-find_library(LZMA_LIBRARIES NAMES lzma)
++find_library(LZMA_LIBRARIES NAMES lzma liblzma)
+ find_path(LZMA_INCLUDE_DIRS NAMES lzma.h)
+ 
+ include(FindPackageHandleStandardArgs)

--- a/var/spack/repos/builtin/packages/vtk/vtk_movie_link_ogg.patch
+++ b/var/spack/repos/builtin/packages/vtk/vtk_movie_link_ogg.patch
@@ -1,0 +1,12 @@
+diff --git a/IO/Movie/module.cmake b/IO/Movie/module.cmake
+index 4275171403..dd1efc3dd9 100644
+--- a/IO/Movie/module.cmake
++++ b/IO/Movie/module.cmake
+@@ -1,6 +1,6 @@
+ if(NOT CMAKE_C_COMPILER_ID STREQUAL "XL")
+   if(NOT ${CMAKE_CROSSCOMPILING})
+-    set(vtkIOMovie_vtkoggtheora vtktheora)
++    set(vtkIOMovie_vtkoggtheora vtkogg vtktheora)
+   endif()
+ endif()
+ vtk_module(vtkIOMovie

--- a/var/spack/repos/builtin/packages/vtk/vtk_use_sqlite_name_vtk_expects.patch
+++ b/var/spack/repos/builtin/packages/vtk/vtk_use_sqlite_name_vtk_expects.patch
@@ -1,0 +1,26 @@
+diff --git a/CMake/FindSQLite3.cmake b/CMake/FindSQLite3.cmake
+index 7933ba7cc3..43f467e524 100644
+--- a/CMake/FindSQLite3.cmake
++++ b/CMake/FindSQLite3.cmake
+@@ -1,6 +1,6 @@
+-find_path(SQLite3_INCLUDE_DIR NAMES sqlite3.h)
++find_path(SQLite3_INCLUDE_DIRS NAMES sqlite3.h)
+ 
+-get_filename_component(POSSIBLE_SQLite_ROOT "${SQLite3_INCLUDE_DIR}" DIRECTORY)
++get_filename_component(POSSIBLE_SQLite_ROOT "${SQLite3_INCLUDE_DIRS}" DIRECTORY)
+ 
+ find_library(SQLite3_LIBRARY
+   NAMES sqlite3
+@@ -14,9 +14,9 @@ add_library(sqlite3::sqlite3 UNKNOWN IMPORTED)
+ set_target_properties(sqlite3::sqlite3
+   PROPERTIES
+     IMPORTED_LOCATION ${SQLite3_LIBRARY}
+-    INTERFACE_INCLUDE_DIRECTORIES ${SQLite3_INCLUDE_DIR})
++    INTERFACE_INCLUDE_DIRECTORIES ${SQLite3_INCLUDE_DIRS})
+ 
+ include(FindPackageHandleStandardArgs)
+-find_package_handle_standard_args(SQLite3 DEFAULT_MSG SQLite3_LIBRARY SQLite3_INCLUDE_DIR)
++find_package_handle_standard_args(SQLite3 DEFAULT_MSG SQLite3_LIBRARY SQLite3_INCLUDE_DIRS)
+ 
+-mark_as_advanced(SQLite3_INCLUDE_DIR SQLite3_LIBRARY)
++mark_as_advanced(SQLite3_INCLUDE_DIRS SQLite3_LIBRARY)


### PR DESCRIPTION
VTK struggles to consume some Spack derived packages on Windows Patch VTK to allow a smoother integration

Add install for examples as they are not part of the install interface