### PR TITLE
xmlf90: add version and fix for fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/xmlf90/fj_modmakefile.patch
+++ b/var/spack/repos/builtin/packages/xmlf90/fj_modmakefile.patch
@@ -1,0 +1,13 @@
+--- a/doc/Examples/dom/Makefile.am	2018-02-28 23:18:25.000000000 +0900
++++ b/doc/Examples/dom/Makefile.am	2023-08-03 10:32:10.000000000 +0900
+@@ -5,8 +5,8 @@
+ #
+ 
+ # Connect this directory to the main source code
+-AM_CPPFLAGS = -I../../../src/dom -I../../../src/sax -DDOM_DATA_DIR=\"$(srcdir)/\"
+-AM_FCFLAGS = -I../../../src/dom -I../../../src/sax
++AM_CPPFLAGS = -I../../../src/dom -I../../../src/sax -I../../../src/wxml -DDOM_DATA_DIR=\"$(srcdir)/\"
++AM_FCFLAGS = -I../../../src/dom -I../../../src/sax -I../../../src/wxml
+ 
+ # Example programs
+ noinst_PROGRAMS = data features pseudo pseudo_dom text

--- a/var/spack/repos/builtin/packages/xmlf90/package.py
+++ b/var/spack/repos/builtin/packages/xmlf90/package.py
@@ -10,23 +10,28 @@ from spack.package import *
 class Xmlf90(AutotoolsPackage):
     """xmlf90 is a suite of libraries to handle XML in Fortran."""
 
-    homepage = "https://launchpad.net/xmlf90"
-    url = "https://launchpad.net/xmlf90/trunk/1.5/+download/xmlf90-1.5.4.tar.gz"
+    homepage = "https://xmlf90.readthedocs.io/en/latest/"
+    git = "https://gitlab.com/siesta-project/libraries/xmlf90"
 
     license("BSD-2-Clause")
 
-    version("1.5.4", sha256="a0b1324ff224d5b5ad1127a6ad4f90979f6b127f1a517f98253eea377237bbe4")
-    version("1.5.3", sha256="a5378a5d9df4b617f51382092999eb0f20fa1a90ab49afbccfd80aa51650d27c")
-    version("1.5.2", sha256="666694db793828d1d1e9aea665f75c75ee21772693465a88b43e6370862abfa6")
+    version("1.6.3", tag="1.6.3")
+    version("1.6.2", tag="1.6.2")
+    version("1.6.1", tag="1.6.1")
+    version("1.6.0", tag="1.6.0")
+    version("1.5.6", tag="1.5.6")
+    version("1.5.5", tag="1.5.5")
+    version("1.5.4", tag="xmlf90-1.5.4")
+    version("1.5.3", tag="xmlf90-1.5.3")
+    version("1.5.2", tag="xmlf90-1.5.2")
 
     depends_on("autoconf@2.69:", type="build")
     depends_on("automake@1.14:", type="build")
     depends_on("libtool@2.4.2:", type="build")
     depends_on("m4", type="build")
-
-    def url_for_version(self, version):
-        url = "https://launchpad.net/xmlf90/trunk/{0}/+download/xmlf90-{1}.tar.gz"
-        return url.format(version.up_to(2), version)
+    
+    build_directory = "spack-build"
+    patch("fj_modmakefile.patch", when="%fj")
 
     @when("@1.5.2")
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/xmlf90/package.py
+++ b/var/spack/repos/builtin/packages/xmlf90/package.py
@@ -15,22 +15,22 @@ class Xmlf90(AutotoolsPackage):
 
     license("BSD-2-Clause")
 
-    version("1.6.3", tag="1.6.3")
-    version("1.6.2", tag="1.6.2")
-    version("1.6.1", tag="1.6.1")
-    version("1.6.0", tag="1.6.0")
-    version("1.5.6", tag="1.5.6")
-    version("1.5.5", tag="1.5.5")
-    version("1.5.4", tag="xmlf90-1.5.4")
-    version("1.5.3", tag="xmlf90-1.5.3")
-    version("1.5.2", tag="xmlf90-1.5.2")
+    version("1.6.3", tag="1.6.3", commit="963fe5d11487233d43ac59dd0c1340a7b2cc3dc5")
+    version("1.6.2", tag="1.6.2", commit="2be1d8d2253233093857e8555e50e74857d0bb51")
+    version("1.6.1", tag="1.6.1", commit="773726675fc4290334444adcc76d9af96871f25f")
+    version("1.6.0", tag="1.6.0", commit="36c64350138af1edfbbd8e0ce23b36a0ac8db617")
+    version("1.5.6", tag="1.5.6", commit="c51a18e86b0d9e7d624509e799ee823c95f69fd1")
+    version("1.5.5", tag="1.5.5", commit="166c0458750f973e2d6f86dd59738f3e3088295e")
+    version("1.5.4", tag="xmlf90-1.5.4", commit="5b21b2c63c834adaa2327e22daa0c856644b2c75")
+    version("1.5.3", tag="xmlf90-1.5.3", commit="d55a5bcf8a0d4e592a03585209435d342d8e6d0f")
+    version("1.5.2", tag="xmlf90-1.5.2", commit="b238aec8719b7c40c7b7252c5f200818a0d5004a")
 
     depends_on("autoconf@2.69:", type="build")
     depends_on("automake@1.14:", type="build")
     depends_on("libtool@2.4.2:", type="build")
     depends_on("m4", type="build")
-    
-    build_directory = "spack-build"
+
+    # Additional include directory specification required for Fujitsu compiler
     patch("fj_modmakefile.patch", when="%fj")
 
     @when("@1.5.2")


### PR DESCRIPTION
- added new versions
- changed homepage. see https://launchpad.net/xmlf90. Now, evelopment of xmlf90 has moved to the Gitlab platform.
- added a patch for fujitsu compiler