### PR TITLE
hpctoolkit: Update develop and add 2024.01.stable

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -172,7 +172,7 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
     depends_on("opencl-c-headers", when="+opencl")
 
     depends_on("intel-xed+pic", when="target=x86_64:")
-    depends_on("memkind", type=("build", "run"), when="@2021.05.01:")
+    depends_on("memkind", type=("build", "run"), when="@2021.05.01:2023.08")
     depends_on("papi", when="+papi")
     depends_on("libpfm4", when="~papi")
     depends_on("mpi", when="+cray")
@@ -285,7 +285,7 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
         if spec.satisfies("@:2022.03"):
             args.append("--with-mbedtls=%s" % spec["mbedtls"].prefix)
 
-        if spec.satisfies("@2021.05.01:"):
+        if spec.satisfies("@2021.05.01:2023.08"):
             args.append("--with-memkind=%s" % spec["memkind"].prefix)
 
         if spec.satisfies("+papi"):
@@ -395,8 +395,6 @@ class MesonBuilder(spack.build_systems.meson.MesonBuilder):
 
         if spec.target.family == "x86_64":
             cfg["properties"]["prefix_xed"] = f"'''{spec['intel-xed'].prefix}'''"
-
-        cfg["properties"]["prefix_memkind"] = f"'''{spec['memkind'].prefix}'''"
 
         if spec.satisfies("+papi"):
             cfg["properties"]["prefix_papi"] = f"'''{spec['papi'].prefix}'''"

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -374,9 +374,15 @@ class MesonBuilder(spack.build_systems.meson.MesonBuilder):
             "-Drocm=" + ("enabled" if "+rocm" in spec else "disabled"),
             "-Dlevel0=" + ("enabled" if "+level_zero" in spec else "disabled"),
             "-Dgtpin=" + ("enabled" if "+gtpin" in spec else "disabled"),
+            f"--native-file={self.gen_prefix_file()}",
         ]
 
-        # We use a native file to provide paths to all the dependencies.
+        return args
+
+    def gen_prefix_file(self):
+        """Generate a native file specifying install prefixes for dependencies"""
+        spec = self.spec
+
         cfg = configparser.ConfigParser()
         cfg["properties"] = {}
         cfg["binaries"] = {}
@@ -434,4 +440,4 @@ class MesonBuilder(spack.build_systems.meson.MesonBuilder):
         with os.fdopen(native_fd, "w") as native_f:
             cfg.write(native_f)
 
-        return ["--native-file", native_path] + args
+        return native_path


### PR DESCRIPTION
Updates:
- `memkind` is no longer a dependency since the `2023.08.x` release series.
- Added the `@2024.01.stable` rolling version, for the upcoming `2024.01.x` release series.
- The extra native file containing install prefixes is no longer required to build `@develop`, instead we use `pkgconf` and `cmake` (new dependencies for `@develop`).

`@2024.01` is the last version that supports building from Autotools, and the first version that supports building with Meson.