### PR TITLE
cp2k: fix for fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/fj_2023.1.patch
+++ b/var/spack/repos/builtin/packages/cp2k/fj_2023.1.patch
@@ -1,0 +1,32 @@
+diff -Nur cp2k-2023.1.org/src/fm/cp_fm_elpa.F cp2k-2023.1.OK/src/fm/cp_fm_elpa.F
+--- cp2k-2023.1.org/src/fm/cp_fm_elpa.F	2023-07-20 17:03:27.000000000 +0900
++++ cp2k-2023.1/src/fm/cp_fm_elpa.F	2023-09-20 09:00:41.000000000 +0900
+@@ -189,7 +189,9 @@
+ ! **************************************************************************************************
+    SUBROUTINE finalize_elpa_library()
+ #if defined(__ELPA)
+-      CALL elpa_uninit()
++      USE ISO_C_BINDING, ONLY: C_INT
++      INTEGER(KIND=C_INT)                 :: error_elpa
++      CALL elpa_uninit(error_elpa)
+ #else
+       CPABORT("Finalization of ELPA library requested but not enabled during build")
+ #endif
+@@ -324,6 +326,8 @@
+ ! **************************************************************************************************
+    SUBROUTINE cp_fm_diag_elpa_base(matrix, eigenvectors, eigenvalues, rdinfo)
+ 
++      USE ISO_C_BINDING, ONLY: C_INT
++      INTEGER(KIND=C_INT)                 :: error_elpa
+       TYPE(cp_fm_type), INTENT(IN)                       :: matrix, eigenvectors
+       REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: eigenvalues
+       TYPE(cp_fm_redistribute_info), INTENT(IN)          :: rdinfo
+@@ -473,7 +477,7 @@
+       ! the full eigenvalues vector is needed
+       ALLOCATE (eval(n))
+ 
+-      elpa_obj => elpa_allocate()
++      elpa_obj => elpa_allocate(error_elpa)
+ 
+       CALL elpa_obj%set("na", n, success)
+       CPASSERT(success == elpa_ok)

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -176,7 +176,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("pkgconfig", type="build")
         # please set variants: smm=blas by configuring packages.yaml or install
         # cp2k with option smm=blas on aarch64
-        conflicts("libxsmm@:1.7", when="target=aarch64", msg="libxsmm is not available on arm")
+        conflicts("libxsmm@:1.17", when="target=aarch64", msg="old libxsmm is not available on arm")
 
     with when("+libint"):
         depends_on("pkgconfig", type="build", when="@7.0:")
@@ -346,6 +346,8 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     # after NDEBUG support was dropped in https://github.com/cp2k/cp2k/pull/3172
     # The patch applies https://github.com/cp2k/cp2k/pull/3251 to version 2024.1
     patch("cmake-relwithdebinfo-2024.1.patch", when="@2024.1 build_system=cmake")
+    # Fix to build with Fujitsu compiler
+    patch("fj_2023.1.patch", when="@2023.1 %fj")
 
     # Patch for an undefined constant due to incompatible changes in ELPA
     @when("@9.1:2022.2 +elpa")

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -176,7 +176,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("pkgconfig", type="build")
         # please set variants: smm=blas by configuring packages.yaml or install
         # cp2k with option smm=blas on aarch64
-        conflicts("target=aarch64:", msg="libxsmm is not available on arm")
+        conflicts("libxsmm@:1.7", when="target=aarch64", msg="libxsmm is not available on arm")
 
     with when("+libint"):
         depends_on("pkgconfig", type="build", when="@7.0:")
@@ -208,7 +208,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     with when("+cosma"):
         depends_on("cosma+scalapack")
         depends_on("cosma@2.5.1:", when="@9:")
-        depends_on("cosma@2.6.3:", when="@2023.2:")
+        depends_on("cosma@2.6.3:", when="@2023.1:")
         depends_on("cosma+cuda", when="+cuda")
         depends_on("cosma+rocm", when="+rocm")
 
@@ -243,7 +243,8 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     # like ELPA, SCALAPACK are independent and Spack will ensure that
     # a consistent/compatible combination is pulled into the dependency graph.
     with when("+sirius"):
-        depends_on("sirius+fortran+shared")
+        depends_on("sirius+fortran")
+        depends_on("sirius+scalapack", when="+mpi")
         depends_on("sirius+cuda", when="+cuda")
         depends_on("sirius+rocm", when="+rocm")
         depends_on("sirius+openmp", when="+openmp")
@@ -251,6 +252,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("sirius@7.0.0:7.0", when="@8:8.2")
         depends_on("sirius@7.2", when="@8.3:8.9")
         depends_on("sirius@7.3:", when="@9.1")
+        depends_on("sirius@7.3.2", when="@2023.1")
         depends_on("sirius@7.4:7.5", when="@2023.2")
         depends_on("sirius@7.5:", when="@2024.1:")
 
@@ -381,6 +383,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
             "cce": ["-O2"],
             "xl": ["-O3"],
             "aocc": ["-O2"],
+            "fj": ["-Kfast"]
         }
 
         dflags = ["-DNDEBUG"] if spec.satisfies("@:2023.2") else []
@@ -431,6 +434,9 @@ class MakefileBuilder(makefile.MakefileBuilder):
         elif "%xl" in spec:
             fcflags += ["-qpreprocess", "-qstrict", "-q64"]
             ldflags += ["-Wl,--allow-multiple-definition"]
+        elif "%fj" in spec:
+            fcflags += ["-X08"]
+            ldflags += ["--linkfortran"]
 
         if "%gcc@10: +mpi" in spec and spec["mpi"].name in ["mpich", "cray-mpich"]:
             fcflags += [
@@ -463,7 +469,14 @@ class MakefileBuilder(makefile.MakefileBuilder):
         if "+plumed" in spec:
             dflags.extend(["-D__PLUMED2"])
             cppflags.extend(["-D__PLUMED2"])
+
             libs.extend([join_path(spec["plumed"].prefix.lib, "libplumed.{0}".format(dso_suffix))])
+
+            gsl = spec["gsl"]
+            cppflags.extend(["-D__GSL"])
+            fcflags += ["-I{0}".format(gsl.prefix.include.gsl)]
+            ldflags += [gsl.libs.search_flags]
+            libs += gsl.libs
 
         cc = spack_cc if "~mpi" in spec else spec["mpi"].mpicc
         cxx = spack_cxx if "~mpi" in spec else spec["mpi"].mpicxx
@@ -478,7 +491,10 @@ class MakefileBuilder(makefile.MakefileBuilder):
         lapack = spec["lapack"].libs
         blas = spec["blas"].libs
         ldflags.append((lapack + blas).search_flags)
-        libs.extend([str(x) for x in (fftw.libs, lapack, blas)])
+
+        libs += fftw.libs
+        libs += lapack
+        libs += blas
 
         if spec.satisfies("platform=darwin"):
             cppflags.extend(["-D__NO_STATM_ACCESS"])
@@ -487,12 +503,6 @@ class MakefileBuilder(makefile.MakefileBuilder):
             cppflags += ["-D__MKL"]
         elif spec["blas"].name == "accelerate":
             cppflags += ["-D__ACCELERATE"]
-
-        if "+cosma" in spec:
-            # add before ScaLAPACK to override the p?gemm symbols
-            cosma = spec["cosma"].libs
-            ldflags.append(cosma.search_flags)
-            libs.extend(cosma)
 
         # MPI
         if "+mpi" in spec:
@@ -520,9 +530,11 @@ class MakefileBuilder(makefile.MakefileBuilder):
                 scalapack = spec["scalapack"].libs
                 ldflags.append(scalapack.search_flags)
 
-            libs.extend(scalapack)
-            libs.extend(mpi)
-            libs.extend(pkg.compiler.stdcxx_libs)
+            libs += scalapack
+            libs += mpi
+            
+            if not "%fj" in spec:
+              libs += (self.compiler.stdcxx_libs)
 
             if "+mpi_f08" in spec:
                 cppflags.append("-D__MPI_F08")
@@ -530,7 +542,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
             if "wannier90" in spec:
                 cppflags.append("-D__WANNIER90")
                 wannier = join_path(spec["wannier90"].libs.directories[0], "libwannier.a")
-                libs.append(wannier)
+                libs += wannier
 
         if "+libint" in spec:
             cppflags += ["-D__LIBINT"]
@@ -571,7 +583,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
         if "+pexsi" in spec:
             cppflags.append("-D__LIBPEXSI")
             fcflags.append("-I" + join_path(spec["pexsi"].prefix, "fortran"))
-            libs.extend(
+            libs += (
                 [
                     join_path(spec["pexsi"].libs.directories[0], "libpexsi.a"),
                     join_path(spec["superlu-dist"].libs.directories[0], "libsuperlu_dist.a"),
@@ -591,23 +603,28 @@ class MakefileBuilder(makefile.MakefileBuilder):
 
             fcflags += ["-I{0}".format(join_path(elpa_incdir, "modules"))]
 
-            # Currently AOCC support only static libraries of ELPA
-            if "%aocc" in spec:
-                libs.append(
-                    join_path(
-                        elpa.prefix.lib, ("libelpa{elpa_suffix}.a".format(elpa_suffix=elpa_suffix))
-                    )
+            # Currently AOCC and FJ support only static libraries of ELPA
+            if "%aocc" or "%fj" in spec:
+                libs += (
+                    [
+                        join_path(
+                            elpa.prefix.lib, ("libelpa{elpa_suffix}.a".format(elpa_suffix=elpa_suffix))
+                        )
+                    ]
                 )
+
             else:
-                libs.append(
-                    join_path(
-                        elpa.libs.directories[0],
-                        (
-                            "libelpa{elpa_suffix}.{dso_suffix}".format(
-                                elpa_suffix=elpa_suffix, dso_suffix=dso_suffix
-                            )
-                        ),
-                    )
+                libs += (
+                    [
+                        join_path(
+                            elpa.libs.directories[0],
+                            (
+                                "libelpa{elpa_suffix}.{dso_suffix}".format(
+                                    elpa_suffix=elpa_suffix, dso_suffix=dso_suffix
+                                )
+                            ),
+                        )
+                    ]
                 )
 
             if spec.satisfies("@:4"):
@@ -630,7 +647,26 @@ class MakefileBuilder(makefile.MakefileBuilder):
             sirius = spec["sirius"]
             cppflags.append("-D__SIRIUS")
             fcflags += ["-I{0}".format(sirius.prefix.include.sirius)]
-            libs += list(sirius.libs)
+            ldflags += [sirius.libs.search_flags]
+            libs += sirius.libs
+
+            spfft = spec["spfft"]
+            cppflags.append("-D__SPFFT")
+            fcflags += ["-I{0}".format(spfft.prefix.include.spfft)]
+            ldflags += [spfft.libs.search_flags]
+            libs += spfft.libs
+
+            spla = spec["spla"]
+            cppflags.append("-D__SPLA")
+            fcflags += ["-I{0}".format(spla.prefix.include.spla)]
+            ldflags += [spla.libs.search_flags]
+            libs += spla.libs
+
+            hdf5 = spec["hdf5"]
+            cppflags.append("-D__HDF5")
+            fcflags += ["-I{0}".format(hdf5.prefix.include)]
+            ldflags += [hdf5.libs.search_flags]
+            libs += hdf5.libs
 
         gpuver = ""
         if spec.satisfies("+cuda"):
@@ -711,13 +747,12 @@ class MakefileBuilder(makefile.MakefileBuilder):
                     "exist. Note that it must be absolute path."
                 )
             cppflags.extend(["-D__HAS_smm_dnn", "-D__HAS_smm_vec"])
-            libs.append("-lsmm")
+            libs += LibraryList(env["LIBSMM_PATH"])
 
         elif "smm=libxsmm" in spec:
             cppflags += ["-D__LIBXSMM"]
-            cppflags += pkgconf("--cflags-only-other", "libxsmmf", output=str).split()
-            fcflags += pkgconf("--cflags-only-I", "libxsmmf", output=str).split()
-            libs += pkgconf("--libs", "libxsmmf", output=str).split()
+            fcflags += pkgconf("--cflags", "libxsmmext", output=str).split()
+            libs += pkgconf("--libs", "libxsmm", "libxsmmf", "libxsmmext", output=str).split()
 
         if "+libvori" in spec:
             cppflags += ["-D__LIBVORI"]
@@ -732,6 +767,31 @@ class MakefileBuilder(makefile.MakefileBuilder):
             ldflags += [spglib.search_flags]
             libs += spglib
 
+        if "+cosma" in spec:
+            cppflags += ["-D__COSMA"]
+            # add before ScaLAPACK to override the p?gemm symbols
+            cosma = spec["cosma"].libs
+            ldflags.append(cosma.search_flags)
+            libs += LibraryList(
+                [
+                    join_path(spec["cosma"].libs.directories[0], "libcosma_prefixed_pxgemm.a"),
+                    join_path(spec["cosma"].libs.directories[0], "libcosma_pxgemm_cpp.a"),
+                    join_path(spec["cosma"].libs.directories[0], "libcosma.a"),
+                ]
+            )
+
+        # costa linker options
+        if "+cosma" in spec or "+sirius" in spec:
+            costa = spec["costa"].libs
+            ldflags.append(costa.search_flags)
+            libs += LibraryList(
+                [
+                    join_path(spec["costa"].libs.directories[0], "libcosta_prefixed_scalapack.a"),
+                    join_path(spec["costa"].libs.directories[0], "libcosta_scalapack.a"),
+                    join_path(spec["costa"].libs.directories[0], "libcosta.a"),
+                ]
+            )
+            
         dflags.extend(cppflags)
         cflags.extend(cppflags)
         cxxflags.extend(cppflags)
@@ -747,7 +807,12 @@ class MakefileBuilder(makefile.MakefileBuilder):
                 mkf.write("include {0}\n".format(spec["plumed"].package.plumed_inc))
 
             mkf.write("\n# COMPILER, LINKER, TOOLS\n\n")
-            mkf.write(
+            if "%fj" in spec:
+                mkf.write(
+                    "FC  = {0}\n" "CC  = {1}\n" "CXX = {2}\n" "LD  = {3}\n".format(fc, cc, cxx, cxx)
+                )
+            else:
+                mkf.write(
                 "FC  = {0}\n" "CC  = {1}\n" "CXX = {2}\n" "LD  = {3}\n".format(fc, cc, cxx, fc)
             )
 
@@ -790,6 +855,12 @@ class MakefileBuilder(makefile.MakefileBuilder):
             if "%intel" in spec:
                 mkf.write(fflags("LDFLAGS_C", ldflags + ["-nofor-main"]))
 
+            if "%fj" in spec:
+                mkf.write("\n# the compiler runs out of memory when optimizing the following:\n")
+                mkf.write("mp2_eri.o: mp2_eri.F\n")
+                mkf.write("\t$(TOOLSRC)/build_utils/fypp $(FYPPFLAGS) $< $*.F90\n")
+                mkf.write("\t$(FC) -c $(FCFLAGS) -O0 -D__SHORT_FILE__=\"\\\"$(subst $(SRCDIR)/,,$<)\\\"\" -I'$(dir $<)' $(OBJEXTSINCL) $*.F90 $(FCLOGPIPE)\n")
+        
             mkf.write("# CP2K-specific flags\n\n")
             mkf.write("GPUVER = {0}\n".format(gpuver))
             mkf.write("DATA_DIR = {0}\n".format(prefix.share.data))

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -176,7 +176,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("pkgconfig", type="build")
         # please set variants: smm=blas by configuring packages.yaml or install
         # cp2k with option smm=blas on aarch64
-        conflicts("libxsmm@:1.17", when="target=aarch64", msg="old libxsmm is not available on arm")
+        conflicts("libxsmm@:1.17", when="target=aarch64:", msg="old libxsmm is not available on arm")
 
     with when("+libint"):
         depends_on("pkgconfig", type="build", when="@7.0:")


### PR DESCRIPTION
This PR enables building cp2k with the Fujitsu compiler and fixes an error that occurs when a specific variant is enabled.