### PR TITLE
libxsmm: add v1.17-cp2k

### DIFF
--- a/var/spack/repos/builtin/packages/libxsmm/package.py
+++ b/var/spack/repos/builtin/packages/libxsmm/package.py
@@ -27,7 +27,7 @@ class Libxsmm(MakefilePackage):
     # after 2.0 release.
     version("main-2023-11", commit="0d9be905527ba575c14ca5d3b4c9673916c868b2")
     version("main", branch="main")
-
+    version("1.17-cp2k", commit="6f883620f58afdeebab28039fc9cf580e76a5ec6")
     version("1.17", sha256="8b642127880e92e8a75400125307724635ecdf4020ca4481e5efe7640451bb92")
     version("1.16.3", sha256="e491ccadebc5cdcd1fc08b5b4509a0aba4e2c096f53d7880062a66b82a0baf84")
     version("1.16.2", sha256="bdc7554b56b9e0a380fc9c7b4f4394b41be863344858bc633bc9c25835c4c64e")
@@ -113,8 +113,11 @@ class Libxsmm(MakefilePackage):
             "CXX={0}".format(spack_cxx),
             "FC={0}".format(spack_fc),
             "PREFIX=%s" % prefix,
-            "SYM=1",
         ]
+        if spec.target.family == "aarch64":
+            make_args += ["PLATFORM=1"]
+        else:
+            make_args += ["SYM=1"]
 
         # JIT (AVX and later) makes MNK, M, N, or K spec. superfluous
         # make_args += ['MNK=1 4 5 6 8 9 13 16 17 22 23 24 26 32']


### PR DESCRIPTION
This PR adds support for the aarch64 environment.

In addition, I have added a version of libxsmm that corresponds to the specific commit id required by the application cp2k. The added version is as follows:

```
version("1.17-cp2k", commit="6f883620f58afdeebab28039fc9cf580e76a5ec6")
```

However, I am not entirely confident if this is the best way to handle this situation. I would appreciate it if you could review my changes and provide feedback. If there is a better way to address this issue, I would be grateful if you could guide me.