### PR TITLE
elf: relocate PT_INTERP

### DIFF
--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -542,7 +542,7 @@ def verify_patchelf(patchelf: "spack.util.executable.Executable") -> bool:
     return version >= spack.version.Version("0.13.1")
 
 
-def ensure_patchelf_in_path_or_raise() -> None:
+def ensure_patchelf_in_path_or_raise() -> spack.util.executable.Executable:
     """Ensure patchelf is in the PATH or raise."""
     # The old concretizer is not smart and we're doing its job: if the latest patchelf
     # does not concretize because the compiler doesn't support C++17, we try to

--- a/lib/spack/spack/hooks/drop_redundant_rpaths.py
+++ b/lib/spack/spack/hooks/drop_redundant_rpaths.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-from typing import IO, Optional, Tuple
+from typing import BinaryIO, Optional, Tuple
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import BaseDirectoryVisitor, visit_directory_tree
@@ -18,7 +18,7 @@ def should_keep(path: bytes) -> bool:
     return path.startswith(b"$") or (os.path.isabs(path) and os.path.lexists(path))
 
 
-def _drop_redundant_rpaths(f: IO) -> Optional[Tuple[bytes, bytes]]:
+def _drop_redundant_rpaths(f: BinaryIO) -> Optional[Tuple[bytes, bytes]]:
     """Drop redundant entries from rpath.
 
     Args:

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -7,6 +7,7 @@ import itertools
 import os
 import re
 from collections import OrderedDict
+from typing import List, Optional
 
 import macholib.mach_o
 import macholib.MachO
@@ -47,7 +48,7 @@ class InstallRootStringError(spack.error.SpackError):
 
 
 @memoized
-def _patchelf():
+def _patchelf() -> Optional[executable.Executable]:
     """Return the full path to the patchelf binary, if available, else None."""
     import spack.bootstrap
 
@@ -55,9 +56,7 @@ def _patchelf():
         return None
 
     with spack.bootstrap.ensure_bootstrap_configuration():
-        patchelf = spack.bootstrap.ensure_patchelf_in_path_or_raise()
-
-    return patchelf.path
+        return spack.bootstrap.ensure_patchelf_in_path_or_raise()
 
 
 def _elf_rpaths_for(path):
@@ -340,42 +339,34 @@ def macholib_get_paths(cur_path):
     return (rpaths, deps, ident)
 
 
-def _set_elf_rpaths(target, rpaths):
-    """Replace the original RPATH of the target with the paths passed
-    as arguments.
+def _set_elf_rpaths_and_interpreter(
+    target: str, rpaths: List[str], interpreter: Optional[str] = None
+) -> Optional[str]:
+    """Replace the original RPATH of the target with the paths passed as arguments.
 
     Args:
         target: target executable. Must be an ELF object.
         rpaths: paths to be set in the RPATH
+        interpreter: optionally set the interpreter
 
     Returns:
-        A string concatenating the stdout and stderr of the call
-        to ``patchelf`` if it was invoked
+        A string concatenating the stdout and stderr of the call to ``patchelf`` if it was invoked
     """
     # Join the paths using ':' as a separator
     rpaths_str = ":".join(rpaths)
 
-    patchelf, output = executable.Executable(_patchelf()), None
     try:
+        # TODO: error handling is not great here?
         # TODO: revisit the use of --force-rpath as it might be conditional
         # TODO: if we want to support setting RUNPATH from binary packages
-        patchelf_args = ["--force-rpath", "--set-rpath", rpaths_str, target]
-        output = patchelf(*patchelf_args, output=str, error=str)
+        args = ["--force-rpath", "--set-rpath", rpaths_str]
+        if interpreter:
+            args.extend(["--set-interpreter", interpreter])
+        args.append(target)
+        return _patchelf()(*args, output=str, error=str)
     except executable.ProcessError as e:
-        msg = "patchelf --force-rpath --set-rpath {0} failed with error {1}"
-        tty.warn(msg.format(target, e))
-    return output
-
-
-def _set_elf_interpreter(target: str, interpreter: str):
-    """Similar to _set_elf_rpaths, but for the interpreter."""
-    patchelf, output = executable.Executable(_patchelf()), None
-    try:
-        patchelf_args = ["--set-interpreter", interpreter, target]
-        output = patchelf(*patchelf_args, output=str, error=str)
-    except executable.ProcessError as e:
-        tty.warn(f"patchelf --set-interpreter {target} failed with: {e}")
-    return output
+        tty.warn(str(e))
+        return None
 
 
 def needs_binary_relocation(m_type, m_subtype):
@@ -514,12 +505,10 @@ def new_relocate_elf_binaries(binaries, prefix_to_prefix):
         try:
             elf.substitute_rpath_and_pt_interp_in_place_or_raise(path, prefix_to_prefix)
         except elf.ElfCStringUpdatesFailed as e:
-            # Fall back to `patchelf [--set-rpath|--set-interpreter]`
-            for action in e.actions:
-                if action.type == elf.CStringType.PT_INTERP:
-                    _set_elf_interpreter(path, action.new_value.decode("utf-8"))
-                elif action.type == elf.CStringType.RPATH:
-                    _set_elf_rpaths(path, action.new_value.decode("utf-8").split(":"))
+            # Fall back to `patchelf --set-rpath ... --set-interpreter ...`
+            rpaths = e.rpath.new_value.decode("utf-8").split(":") if e.rpath else []
+            interpreter = e.pt_interp.new_value.decode("utf-8") if e.pt_interp else None
+            _set_elf_rpaths_and_interpreter(path, rpaths=rpaths, interpreter=interpreter)
 
 
 def relocate_elf_binaries(
@@ -561,10 +550,10 @@ def relocate_elf_binaries(
             new_rpaths = _make_relative(new_binary, new_root, new_norm_rpaths)
             # check to see if relative rpaths are changed before rewriting
             if sorted(new_rpaths) != sorted(orig_rpaths):
-                _set_elf_rpaths(new_binary, new_rpaths)
+                _set_elf_rpaths_and_interpreter(new_binary, new_rpaths)
         else:
             new_rpaths = _transform_rpaths(orig_rpaths, orig_root, new_prefixes)
-            _set_elf_rpaths(new_binary, new_rpaths)
+            _set_elf_rpaths_and_interpreter(new_binary, new_rpaths)
 
 
 def make_link_relative(new_links, orig_links):
@@ -611,7 +600,7 @@ def make_elf_binaries_relative(new_binaries, orig_binaries, orig_layout_root):
         orig_rpaths = _elf_rpaths_for(new_binary)
         if orig_rpaths:
             new_rpaths = _make_relative(orig_binary, orig_layout_root, orig_rpaths)
-            _set_elf_rpaths(new_binary, new_rpaths)
+            _set_elf_rpaths_and_interpreter(new_binary, new_rpaths)
 
 
 def warn_if_link_cant_be_relocated(link, target):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1851,7 +1851,7 @@ def binary_with_rpaths(prefix_tmpdir):
     paths are encoded with `$ORIGIN` prepended.
     """
 
-    def _factory(rpaths, message="Hello world!"):
+    def _factory(rpaths, message="Hello world!", dynamic_linker="/lib64/ld-linux.so.2"):
         source = prefix_tmpdir.join("main.c")
         source.write(
             """
@@ -1867,10 +1867,10 @@ def binary_with_rpaths(prefix_tmpdir):
         executable = source.dirpath("main.x")
         # Encode relative RPATHs using `$ORIGIN` as the root prefix
         rpaths = [x if os.path.isabs(x) else os.path.join("$ORIGIN", x) for x in rpaths]
-        rpath_str = ":".join(rpaths)
         opts = [
             "-Wl,--disable-new-dtags",
-            "-Wl,-rpath={0}".format(rpath_str),
+            f"-Wl,-rpath={':'.join(rpaths)}",
+            f"-Wl,--dynamic-linker,{dynamic_linker}",
             str(source),
             "-o",
             str(executable),

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -47,14 +47,6 @@ def text_in_bin(text, binary):
 
 
 @pytest.fixture()
-def mock_patchelf(tmpdir, mock_executable):
-    def _factory(output):
-        return mock_executable("patchelf", output=output)
-
-    return _factory
-
-
-@pytest.fixture()
 def make_dylib(tmpdir_factory):
     """Create a shared library with unfriendly qualities.
 

--- a/lib/spack/spack/test/util/elf.py
+++ b/lib/spack/spack/test/util/elf.py
@@ -168,31 +168,13 @@ def test_elf_get_and_replace_rpaths_and_pt_interp(binary_with_rpaths):
         elf.substitute_rpath_and_pt_interp_in_place_or_raise(
             executable, {b"/short-a": b"/very/long/prefix-a", b"/short-b": b"/very/long/prefix-b"}
         )
-    assert info.match(
-        "New rpath .*/very/long/prefix-a/x:/very/long/prefix-b/y.* is "
-        "longer than .*/short-a/x:/short-b/y.*"
-    )
-    assert info.match(
-        "New interpreter .*/very/long/prefix-b/lib/ld.so.* is longer than .*/short-b/lib/ld.so*"
-    )
 
-    # Check that there are two actions in there.
-    assert len(info.value.actions) == 2
-
-    # Extract them
-    fst, snd = info.value.actions
-
-    if fst.type == elf.CStringType.RPATH and snd.type == elf.CStringType.PT_INTERP:
-        rpath_action, pt_interp_action = fst, snd
-    elif snd.type == elf.CStringType.RPATH and fst.type == elf.CStringType.PT_INTERP:
-        rpath_action, pt_interp_action = snd, fst
-    else:
-        assert False, "Expected one action to be RPATH and the other to be PT_INTERP"
-
-    assert rpath_action.old_value == b"/short-a/x:/short-b/y"
-    assert rpath_action.new_value == b"/very/long/prefix-a/x:/very/long/prefix-b/y"
-    assert pt_interp_action.old_value == b"/short-b/lib/ld.so"
-    assert pt_interp_action.new_value == b"/very/long/prefix-b/lib/ld.so"
+    assert info.value.rpath is not None
+    assert info.value.pt_interp is not None
+    assert info.value.rpath.old_value == b"/short-a/x:/short-b/y"
+    assert info.value.rpath.new_value == b"/very/long/prefix-a/x:/very/long/prefix-b/y"
+    assert info.value.pt_interp.old_value == b"/short-b/lib/ld.so"
+    assert info.value.pt_interp.new_value == b"/very/long/prefix-b/lib/ld.so"
 
 
 @pytest.mark.requires_executables("gcc")

--- a/lib/spack/spack/test/util/elf.py
+++ b/lib/spack/spack/test/util/elf.py
@@ -166,8 +166,8 @@ def test_elf_get_and_replace_rpaths(binary_with_rpaths):
     # bytes -- it may correspond to zero-length strings for example.
     with pytest.raises(
         elf.ElfDynamicSectionUpdateFailed,
-        match="New rpath /very/long/prefix-a/x:/very/long/prefix-b/y is "
-        "longer than old rpath /short-a/x:/short-b/y",
+        match="New rpath .*/very/long/prefix-a/x:/very/long/prefix-b/y.* is "
+        "longer than old rpath .*/short-a/x:/short-b/y.*",
     ):
         elf.replace_rpath_in_place_or_raise(
             executable,

--- a/lib/spack/spack/test/util/elf.py
+++ b/lib/spack/spack/test/util/elf.py
@@ -5,7 +5,6 @@
 
 
 import io
-from collections import OrderedDict
 
 import pytest
 
@@ -137,44 +136,63 @@ def test_only_header():
 
 @pytest.mark.requires_executables("gcc")
 @skip_unless_linux
-def test_elf_get_and_replace_rpaths(binary_with_rpaths):
-    long_rpaths = ["/very/long/prefix-a/x", "/very/long/prefix-b/y"]
-    executable = str(binary_with_rpaths(rpaths=long_rpaths))
-
-    # Before
-    assert elf.get_rpaths(executable) == long_rpaths
-
-    replacements = OrderedDict(
-        [
-            (b"/very/long/prefix-a", b"/short-a"),
-            (b"/very/long/prefix-b", b"/short-b"),
-            (b"/very/long", b"/dont"),
-        ]
+def test_elf_get_and_replace_rpaths_and_pt_interp(binary_with_rpaths):
+    long_paths = ["/very/long/prefix-a/x", "/very/long/prefix-b/y"]
+    executable = str(
+        binary_with_rpaths(rpaths=long_paths, dynamic_linker="/very/long/prefix-b/lib/ld.so")
     )
 
+    # Before
+    assert elf.get_rpaths(executable) == long_paths
+
+    replacements = {
+        b"/very/long/prefix-a": b"/short-a",
+        b"/very/long/prefix-b": b"/short-b",
+        b"/very/long": b"/dont",
+    }
+
     # Replace once: should modify the file.
-    assert elf.replace_rpath_in_place_or_raise(executable, replacements)
+    assert elf.substitute_rpath_and_pt_interp_in_place_or_raise(executable, replacements)
 
     # Replace twice: nothing to be done.
-    assert not elf.replace_rpath_in_place_or_raise(executable, replacements)
+    assert not elf.substitute_rpath_and_pt_interp_in_place_or_raise(executable, replacements)
 
     # Verify the rpaths were modified correctly
     assert elf.get_rpaths(executable) == ["/short-a/x", "/short-b/y"]
+    assert elf.get_interpreter(executable) == "/short-b/lib/ld.so"
 
     # Going back to long rpaths should fail, since we've added trailing \0
     # bytes, and replacement can't assume it can write back in repeated null
     # bytes -- it may correspond to zero-length strings for example.
-    with pytest.raises(
-        elf.ElfDynamicSectionUpdateFailed,
-        match="New rpath .*/very/long/prefix-a/x:/very/long/prefix-b/y.* is "
-        "longer than old rpath .*/short-a/x:/short-b/y.*",
-    ):
-        elf.replace_rpath_in_place_or_raise(
-            executable,
-            OrderedDict(
-                [(b"/short-a", b"/very/long/prefix-a"), (b"/short-b", b"/very/long/prefix-b")]
-            ),
+    with pytest.raises(elf.ElfCStringUpdatesFailed) as info:
+        elf.substitute_rpath_and_pt_interp_in_place_or_raise(
+            executable, {b"/short-a": b"/very/long/prefix-a", b"/short-b": b"/very/long/prefix-b"}
         )
+    assert info.match(
+        "New rpath .*/very/long/prefix-a/x:/very/long/prefix-b/y.* is "
+        "longer than .*/short-a/x:/short-b/y.*"
+    )
+    assert info.match(
+        "New interpreter .*/very/long/prefix-b/lib/ld.so.* is longer than .*/short-b/lib/ld.so*"
+    )
+
+    # Check that there are two actions in there.
+    assert len(info.value.actions) == 2
+
+    # Extract them
+    fst, snd = info.value.actions
+
+    if fst.type == elf.CStringType.RPATH and snd.type == elf.CStringType.PT_INTERP:
+        rpath_action, pt_interp_action = fst, snd
+    elif snd.type == elf.CStringType.RPATH and fst.type == elf.CStringType.PT_INTERP:
+        rpath_action, pt_interp_action = snd, fst
+    else:
+        assert False, "Expected one action to be RPATH and the other to be PT_INTERP"
+
+    assert rpath_action.old_value == b"/short-a/x:/short-b/y"
+    assert rpath_action.new_value == b"/very/long/prefix-a/x:/very/long/prefix-b/y"
+    assert pt_interp_action.old_value == b"/short-b/lib/ld.so"
+    assert pt_interp_action.new_value == b"/very/long/prefix-b/lib/ld.so"
 
 
 @pytest.mark.requires_executables("gcc")


### PR DESCRIPTION
Relocation of `PT_INTERP` in ELF files already happens to work from long to short path, thanks to generic binary relocation (i.e. find and replace). This PR improves it:

1. Adds logic to grow `PT_INTERP` strings through patchelf (which is only useful if the interpreter and rpath paths are the _only_ paths in the binary that need to be relocated)
2. Makes shrinking `PT_INTERP` cleaner. Before this PR when you would use Spack-built glibc as link dep, and relocate
executables using its dynamic linker, you'd end up with

   ```
   $ file exe
   exe: ELF 64-bit LSD pie executable, ..., interpreter /////////////////////////////////////////////////path/to/glibc/lib/ld-linux.so
   ```

   With this PR you get something sensible:

   ```
   $ file exe
   exe: ELF 64-bit LSD pie executable, ..., interpreter /path/to/glibc/lib/ld-linux.so
   ```

When Spack cannot modify the interpreter or rpath strings in-place, it errors out without modifying the file, and leaves both tasks to patchelf instead.

Also add type hints to `elf.py`.

Relevant for #42082 