### PR TITLE
perl-sql-translator and deps: New packages

### DIFF
--- a/var/spack/repos/builtin/packages/perl-import-into/package.py
+++ b/var/spack/repos/builtin/packages/perl-import-into/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlImportInto(PerlPackage):
+    """Import packages into other packages"""
+
+    homepage = "https://metacpan.org/pod/Import::Into"
+    url = "https://cpan.metacpan.org/authors/id/H/HA/HAARG/Import-Into-1.002005.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.002005", sha256="bd9e77a3fb662b40b43b18d3280cd352edf9fad8d94283e518181cc1ce9f0567")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-module-runtime", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Import::Into; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-package-variant/package.py
+++ b/var/spack/repos/builtin/packages/perl-package-variant/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPackageVariant(PerlPackage):
+    """Parameterizable packages"""
+
+    homepage = "https://metacpan.org/pod/Package::Variant"
+    url = "https://cpan.metacpan.org/authors/id/M/MS/MSTROUT/Package-Variant-1.003002.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.003002", sha256="b2ed849d2f4cdd66467512daa3f143266d6df810c5fae9175b252c57bc1536dc")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-import-into@1.000000:", type=("build", "run", "test"))
+    depends_on("perl-module-runtime@0.013:", type=("build", "run", "test"))
+    depends_on("perl-strictures@2.000000:", type=("build", "run", "test"))
+    depends_on("perl-test-fatal", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Package::Variant; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-sql-translator/package.py
+++ b/var/spack/repos/builtin/packages/perl-sql-translator/package.py
@@ -1,0 +1,43 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlSqlTranslator(PerlPackage):
+    """SQL DDL transformations and more"""
+
+    homepage = "https://metacpan.org/pod/SQL::Translator"
+    url = "https://cpan.metacpan.org/authors/id/V/VE/VEESH/SQL-Translator-1.65.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.65", sha256="606750db6a4ebf2693aa9bc8444c998c169b76bc308f3d314ead5eac17bede4a")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-carp-clan", type=("build", "run", "test"))
+    depends_on("perl-dbi@1.54:", type=("build", "run", "test"))
+    depends_on("perl-file-sharedir@1.0:", type=("build", "run", "test"))
+    depends_on("perl-file-sharedir-install", type=("build"))
+    depends_on("perl-json-maybexs@1.003003:", type=("build", "test"))
+    depends_on("perl-moo@1.000003:", type=("build", "run", "test"))
+    depends_on("perl-package-variant@1.001001:", type=("build", "run", "test"))
+    depends_on("perl-parse-recdescent@1.967009:", type=("build", "run", "test"))
+    depends_on("perl-sub-quote", type=("build", "run", "test"))
+    depends_on("perl-test-differences", type=("build", "test"))
+    depends_on("perl-test-exception@0.42:", type=("build", "test"))
+    depends_on("perl-try-tiny@0.04:", type=("build", "run", "test"))
+    depends_on("perl-xml-writer@0.500:", type=("build", "test"))
+    depends_on("perl-yaml@0.66:", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use SQL::Translator; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-strictures/package.py
+++ b/var/spack/repos/builtin/packages/perl-strictures/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlStrictures(PerlPackage):
+    """Turn on strict and make most warnings fatal"""
+
+    homepage = "https://metacpan.org/pod/strictures"
+    url = "https://cpan.metacpan.org/authors/id/H/HA/HAARG/strictures-2.000006.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("2.000006", sha256="09d57974a6d1b2380c802870fed471108f51170da81458e2751859f2714f8d57")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use strictures; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
- Adds perl-sql-translator and its missing deps:
- Adds perl-import-into
- Adds perl-package-variant
- Adds perl-strictures

Built with build-time tests and comes with a simple run-time test.