### PR TITLE
xyce: break blis circularity in depends_on

### DIFF
--- a/var/spack/repos/builtin/packages/xyce/package.py
+++ b/var/spack/repos/builtin/packages/xyce/package.py
@@ -138,8 +138,8 @@ class Xyce(CMakePackage):
 
         depends_on("armpl-gcc~shared", when="^armpl-gcc")
         depends_on("atlas~shared", when="^atlas")
-        depends_on("blis libs=static", when="^blis+cblas")
-        depends_on("blis libs=static", when="^blis+blas")
+        depends_on("blis libs=static", when="^[virtuals=blas] blis+cblas")
+        depends_on("blis libs=static", when="^[virtuals=blas] blis+blas")
         depends_on("clblast~shared", when="^clblast+netlib")
         depends_on("intel-mkl~shared", when="^intel-mkl")
         depends_on("intel-oneapi-mkl~shared", when="^intel-oneapi-mkl")


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/42296

Thanks to @alalazo for explaining this:
The way this is specified prior to this PR, the depends_on makes the choice for concretizer to use blis because of circular reference. Adding `virtuals=` breaks the cycle because we require `blis` to be a provider for `blas` which keeps it in competition with other providers.

CC @TBird2001 