### PR TITLE
hdf5: Make +subfiling variant depend on +mpi

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -88,7 +88,9 @@ class Hdf5(CMakePackage):
     variant("hl", default=False, description="Enable the high-level library")
     variant("cxx", default=False, description="Enable C++ support")
     variant("map", when="@1.14:", default=False, description="Enable MAP API support")
-    variant("subfiling", when="@1.14:", default=False, description="Enable Subfiling VFD support")
+    variant(
+        "subfiling", when="@1.14: +mpi", default=False, description="Enable Subfiling VFD support"
+    )
     variant("fortran", default=False, description="Enable Fortran support")
     variant("java", when="@1.10:", default=False, description="Enable Java support")
     variant("threadsafe", default=False, description="Enable thread-safe capabilities")


### PR DESCRIPTION
Based on CMakeLists.txt, the subfiling VFD requires a parallel HDF5 build. So make +subfiling variant depend on +mpi

Should resolve #42323