### PR TITLE
hydrogen@1.5.3: cmake patch with ESCAPE_QUOTES

### DIFF
--- a/var/spack/repos/builtin/packages/hydrogen/cmake-intel-mpi-escape-quotes-pr177.patch
+++ b/var/spack/repos/builtin/packages/hydrogen/cmake-intel-mpi-escape-quotes-pr177.patch
@@ -1,0 +1,12 @@
+diff -ruN spack-src/CMakeLists.txt spack-src-patched/CMakeLists.txt
+--- spack-src/CMakeLists.txt	2023-11-07 21:54:14.000000000 +0000
++++ spack-src-patched/CMakeLists.txt	2024-01-26 19:32:52.140539356 +0000
+@@ -515,7 +515,7 @@
+ # docs (which has the advantage that preprocessing will take
+ # "{,hydrogen_}config.h" into consideration).
+ configure_file("${PROJECT_SOURCE_DIR}/cmake/configure_files/config.h.in"
+-  "${PROJECT_BINARY_DIR}/include/El/config.h")
++  "${PROJECT_BINARY_DIR}/include/El/config.h" ESCAPE_QUOTES)
+ configure_file("${PROJECT_SOURCE_DIR}/cmake/configure_files/hydrogen_config.h.in"
+   "${PROJECT_BINARY_DIR}/include/El/hydrogen_config.h")
+ configure_file("${PROJECT_SOURCE_DIR}/doxy/Doxyfile.in"

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -130,6 +130,10 @@ class Hydrogen(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("llvm-openmp", when="%apple-clang +openmp")
 
+    # Fixes https://github.com/spack/spack/issues/42286
+    # https://github.com/LLNL/Elemental/pull/177
+    patch("cmake-intel-mpi-escape-quotes-pr177.patch", when="@1.5.3")
+
     @property
     def libs(self):
         shared = True if "+shared" in self.spec else False


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/42286 by patching changes from:
* https://github.com/LLNL/Elemental/pull/177

Credit to @rscohn2 for this.

```
==> Installing hydrogen-1.5.3-llw47g7bs5gxepdp5guaqhe4hveljxig [16/16]
==> No binary for hydrogen-1.5.3-llw47g7bs5gxepdp5guaqhe4hveljxig found: installing from source
==> Using cached archive: /spack/var/spack/cache/_source-cache/archive/fa/faefbe738bd364d0e26ce9ad079a11c93a18c6f075719a365fd4fa5f1f7a989a.tar.gz
==> Applied patch /spack/var/spack/repos/builtin/packages/hydrogen/cmake-intel-mpi-escape-quotes-pr177.patch
==> hydrogen: Executing phase: 'initconfig'
==> hydrogen: Executing phase: 'cmake'
==> hydrogen: Executing phase: 'build'
==> hydrogen: Executing phase: 'install'
==> hydrogen: Successfully installed hydrogen-1.5.3-llw47g7bs5gxepdp5guaqhe4hveljxig
  Stage: 0.17s.  Initconfig: 0.07s.  Cmake: 10.95s.  Build: 53.01s.  Install: 0.77s.  Post-install: 0.21s.  Total: 1m 5.42s
[+] /spack/opt/spack/linux-ubuntu22.04-x86_64/oneapi-2024.0.2/hydrogen-1.5.3-llw47g7bs5gxepdp5guaqhe4hveljxig
``` 