### PR TITLE
[intel-oneapi-mkl] workaround linking issue for threads=openmp

### DIFF
--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -171,8 +171,14 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         options += self.enable_or_disable("openmp")
 
+        # if using mkl with openmp support, link with openmp
+        mkl_openmp_flag = (
+            self.compiler.openmp_flag
+            if self.spec.satisfies("^intel-oneapi-mkl threads=openmp")
+            else ""
+        )
         options += [
-            "LDFLAGS={0}".format(spec["lapack"].libs.search_flags),
+            "LDFLAGS={0} {1}".format(mkl_openmp_flag, spec["lapack"].libs.search_flags),
             "LIBS={0} {1}".format(spec["lapack"].libs.link_flags, spec["blas"].libs.link_flags),
         ]
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -179,7 +179,6 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
 
     def _find_mkl_libs(self, shared):
         libs = []
-        threading_libs = []
 
         if self.spec.satisfies("+cluster"):
             libs.extend([self._xlp64_lib("libmkl_scalapack"), "libmkl_cdft_core"])
@@ -192,12 +191,6 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
                 libs.append("libmkl_intel_thread")
             else:
                 libs.append("libmkl_gnu_thread")
-
-            # this is slightly different than what link-line advisor suggests.
-            # here it uses what the compiler suggests to use to enable openmp,
-            # instead of being explicit about in which path openmp libraries
-            # are located (e.g. intel libiomp5, gcc libgomp, clang libomp).
-            threading_libs += [self.compiler.openmp_flag]
         else:
             libs.append("libmkl_sequential")
 
@@ -247,8 +240,6 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
                 resolved_libs = resolved_libs + self.spec["mpi"].libs
         except spack.error.NoLibrariesError:
             pass
-
-        resolved_libs += threading_libs
 
         return resolved_libs
 


### PR DESCRIPTION
Remove code that tried to add -fopenmp flags when using `intel-oneapi-mkl threads=openmp` It needs to be added to the flags, not the libraries.

Make elpa add the -fopenmp.

When I have some time, I will investigate if a LibraryList can add the flags so packages that use mkl need not be aware.

Addresses #42310 