### PR TITLE
Environments: add global config scope test for definitions

### DIFF
--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -823,7 +823,7 @@ def test_env_defs_as_globals(mutable_mock_env_path, mock_packages):
 
     spack_yaml = env_path / ev.manifest_name
     spack_yaml.write_text(
-        f"""spack:
+        """spack:
   definitions:
   - core_specs: [libdwarf, libelf]
   - my_packages: [zlib]


### PR DESCRIPTION
This PR adds a unit test comparing the old (pre-#33960) way of accessing environment definitions (only through the manifest) to the new way (through global configuration and only *after* the environment is activated).