### PR TITLE
Bump spglib version v2.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/spglib/package.py
+++ b/var/spack/repos/builtin/packages/spglib/package.py
@@ -20,6 +20,7 @@ class Spglib(CMakePackage):
 
     license("BSD-3-Clause")
 
+    version("2.3.0", sha256="c05eb869018efe2efe5dcb2654cda19c5dd4c07434874205fa542f7766f7548e")
     version("2.2.0", sha256="ac929e20ec9d4621411e2cdec59b1442e02506c1e546005bbe2c7f781e9bd49a")
     version("2.1.0", sha256="31bca273a1bc54e1cff4058eebe7c0a35d5f9b489579e84667d8e005c73dcc13")
     version("2.0.2", sha256="10e44a35099a0a5d0fc6ee0cdb39d472c23cb98b1f5167c0e2b08f6069f3db1e")


### PR DESCRIPTION
If my reading is correct, the default `CMakePackage` does not call `ctest`. If that's the case this should be fixed since there are a lot more tests that I don't think are captured on the makefiles.

But even more so, are package tests not run in the CI?