### PR TITLE
traverse: w/o deptype

### DIFF
--- a/lib/spack/spack/deptypes.py
+++ b/lib/spack/spack/deptypes.py
@@ -36,6 +36,9 @@ ALL: DepFlag = BUILD | LINK | RUN | TEST
 #: Default dependency type if none is specified
 DEFAULT: DepFlag = BUILD | LINK
 
+#: A flag with no dependency types set
+NONE: DepFlag = 0
+
 #: An iterator of all flag components
 ALL_FLAGS: Tuple[DepFlag, DepFlag, DepFlag, DepFlag] = (BUILD, LINK, RUN, TEST)
 

--- a/lib/spack/spack/test/traverse.py
+++ b/lib/spack/spack/test/traverse.py
@@ -395,3 +395,16 @@ def test_traverse_edges_topo(abstract_specs_toposort):
         out_edge_indices = [i for (i, (parent, child)) in enumerate(edges) if node == parent]
         if in_edge_indices and out_edge_indices:
             assert max(in_edge_indices) < min(out_edge_indices)
+
+
+def test_traverse_nodes_no_deps(abstract_specs_dtuse):
+    """Traversing nodes without deps should be the same as deduplicating the input specs. This may
+    not look useful, but can be used to avoid a branch on the call site in which it's otherwise
+    easy to forget to deduplicate input specs."""
+    inputs = [
+        abstract_specs_dtuse["dtuse"],
+        abstract_specs_dtuse["dtlink5"],
+        abstract_specs_dtuse["dtuse"],  # <- duplicate
+    ]
+    outputs = [x for x in traverse.traverse_nodes(inputs, deptype=dt.NONE)]
+    assert outputs == [abstract_specs_dtuse["dtuse"], abstract_specs_dtuse["dtlink5"]]


### PR DESCRIPTION
Add the empty deptype `spack.deptypes.NONE`.

Test the case `traverse_nodes(deptype=spack.deptypes.NONE)` to not
traverse dependencies, only de-duplicate.

Use the construct in environment views that otherwise would branch on
whether deps are enabled or not.
