### PR TITLE
dla-future: Add patch for compilation with newer ROCm versions

### DIFF
--- a/var/spack/repos/builtin/packages/dla-future/hip_complex_operator_overloads.patch
+++ b/var/spack/repos/builtin/packages/dla-future/hip_complex_operator_overloads.patch
@@ -1,0 +1,23 @@
+diff --git a/src/lapack/gpu/add.cu b/src/lapack/gpu/add.cu
+index a55110c2..5d839540 100644
+--- a/src/lapack/gpu/add.cu
++++ b/src/lapack/gpu/add.cu
+@@ -32,6 +32,18 @@ __device__ inline void addAlpha(const T& alpha, const T& a, T& b) {
+   b = b + alpha * a;
+ }
+
++template <>
++__device__ inline void addAlpha<hipFloatComplex>(const hipFloatComplex& alpha, const hipFloatComplex& a,
++                                                 hipFloatComplex& b) {
++  b = b + hipCmulf(alpha, a);
++}
++
++template <>
++__device__ inline void addAlpha<hipDoubleComplex>(const hipDoubleComplex& alpha,
++                                                  const hipDoubleComplex& a, hipDoubleComplex& b) {
++  b = b + hipCmul(alpha, a);
++}
++
+ template <class T>
+ __device__ inline void sum(const T& /*alpha*/, const T& a, T& b) {
+   b = b + a;

--- a/var/spack/repos/builtin/packages/dla-future/package.py
+++ b/var/spack/repos/builtin/packages/dla-future/package.py
@@ -128,6 +128,8 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
         sha256="7f382c872d89f22da1ad499e85ffe9881cc7404c8465e42877a210a09382e2ea",
         when="@:0.3 %gcc@13:",
     )
+    # https://github.com/spack/spack/issues/41511
+    patch("hip_complex_operator_overloads.patch", when="+rocm")
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
Fixes #41511. Applies the patch proposed by @yizeyi18 in https://github.com/spack/spack/issues/41511#issuecomment-1853747920. This is needed for newer versions of HIP (presumably 5.7 onwards), but I'm applying it for any version since it doesn't hurt for other versions. I'm not setting an upper bound on the DLA-Future version since it's not yet fixed upstream. https://github.com/eth-cscs/DLA-Future/pull/1083 is intended to become the long term solution, but until that is cleaned up we can at least get things compiling with this patch.

@yizeyi18 would you mind testing this in your setup?