### PR TITLE
Update GitLab memory requests

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -8,11 +8,61 @@ ci:
   - match_behavior: first
     submapping:
     - match:
-      - llvm
-      - llvm-amdgpu
-      - paraview
+      - rust
+      build-job:
+        tags: [ "spack", "huge" ]
+        variables:
+          CI_JOB_SIZE: huge
+          SPACK_BUILD_JOBS: "12"
+          KUBERNETES_CPU_REQUEST: 12000m
+          KUBERNETES_MEMORY_REQUEST: 35G
+
+    - match:
       - py-tensorflow
+      build-job:
+        tags: [ "spack", "huge" ]
+        variables:
+          CI_JOB_SIZE: huge
+          SPACK_BUILD_JOBS: "12"
+          KUBERNETES_CPU_REQUEST: 12000m
+          KUBERNETES_MEMORY_REQUEST: 32G
+
+    - match:
+      - py-jaxlib
+      build-job:
+        tags: [ "spack", "huge" ]
+        variables:
+          CI_JOB_SIZE: huge
+          SPACK_BUILD_JOBS: "12"
+          KUBERNETES_CPU_REQUEST: 12000m
+          KUBERNETES_MEMORY_REQUEST: 29G
+
+    - match:
+      - nvhpc
+      - paraview
+      build-job:
+        tags: [ "spack", "huge" ]
+        variables:
+          CI_JOB_SIZE: huge
+          SPACK_BUILD_JOBS: "12"
+          KUBERNETES_CPU_REQUEST: 12000m
+          KUBERNETES_MEMORY_REQUEST: 24G
+
+    - match:
+      - llvm
       - py-torch
+      build-job:
+        tags: [ "spack", "huge" ]
+        variables:
+          CI_JOB_SIZE: huge
+          SPACK_BUILD_JOBS: "12"
+          KUBERNETES_CPU_REQUEST: 12000m
+          KUBERNETES_MEMORY_REQUEST: 21G
+
+    - match:
+      - dealii
+      - mxnet
+      - py-torchaudio
       - rocblas
       build-job:
         tags: [ "spack", "huge" ]
@@ -20,7 +70,21 @@ ci:
           CI_JOB_SIZE: huge
           SPACK_BUILD_JOBS: "12"
           KUBERNETES_CPU_REQUEST: 12000m
-          KUBERNETES_MEMORY_REQUEST: 42G
+          KUBERNETES_MEMORY_REQUEST: 19G
+
+    - match:
+      - ecp-data-vis-sdk
+      - intel-tbb
+      - llvm-amdgpu
+      - salmon
+      - trilinos
+      build-job:
+        tags: [ "spack", "large" ]
+        variables:
+          CI_JOB_SIZE: large
+          SPACK_BUILD_JOBS: "8"
+          KUBERNETES_CPU_REQUEST: 8000m
+          KUBERNETES_MEMORY_REQUEST: 15G
 
     - match:
       - ascent
@@ -30,7 +94,6 @@ ci:
       - cmake
       - ctffind
       - cuda
-      - dealii
       - dray
       - dyninst
       - ecp-data-vis-sdk
@@ -47,7 +110,6 @@ ci:
       - mfem
       - mpich
       - netlib-lapack
-      - nvhpc
       - oce
       - openblas
       - openfoam
@@ -61,7 +123,6 @@ ci:
       - rocfft
       - rocsolver
       - rocsparse
-      - rust
       - slate
       - strumpack
       - sundials

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -58,11 +58,8 @@ ci:
       - parallelio
       - plumed
       - precice
-      #- py-tensorflow
-      #- qt
       - raja
       - relion
-      #- rocblas
       - rocfft
       - rocsolver
       - rocsparse
@@ -72,7 +69,6 @@ ci:
       - sundials
       - trilinos
       - umpire
-      #- visit
       - vtk
       - vtk-h
       - vtk-m

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -10,7 +10,6 @@ ci:
     - match:
       - llvm
       - llvm-amdgpu
-      - pango
       - paraview
       - py-tensorflow
       - py-torch

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -8,16 +8,13 @@ ci:
   - match_behavior: first
     submapping:
     - match:
-      - hipblas
       - llvm
       - llvm-amdgpu
       - pango
       - paraview
       - py-tensorflow
       - py-torch
-      - qt
       - rocblas
-      - visit
       build-job:
         tags: [ "spack", "huge" ]
         variables:
@@ -41,6 +38,7 @@ ci:
       - gcc
       - ginkgo
       - hdf5
+      - hipblas
       - hpx
       - kokkos-kernels
       - kokkos-nvcc-wrapper
@@ -58,6 +56,7 @@ ci:
       - parallelio
       - plumed
       - precice
+      - qt
       - raja
       - relion
       - rocfft
@@ -69,6 +68,7 @@ ci:
       - sundials
       - trilinos
       - umpire
+      - visit
       - vtk
       - vtk-h
       - vtk-m


### PR DESCRIPTION
We've recently started gathering memory usage data from our GitLab CI jobs. Use this information to update the resources we are requesting for the various packages we build in CI.

Here's a relevant subset of data that I used to make these decisions. This data was captured for GitLab CI jobs that ran between January 19, 2024, 12:01 PM and January 29, 2024, 12:39 PM (EST).

For those with metabase access, you can view and rerun this query here:
https://metabase.spack.io/question/32-max-memory-per-package

| Package Name  | Max Memory (in GB) |
| ------------- | ------------- |
| rust | 34.40 |
| py-tensorflow | 31.79 |
| py-jaxlib | 28.55 |
| nvhpc | 23.51 |
| paraview | 23.15 |
| llvm | 20.14 |
| py-torch | 18.97 |
| py-torchaudio | 18.16 |
| dealii | 18.04 |
| mxnet | 16.92 |
| rocblas | 16.75 |
| llvm-amdgpu | 14.43 |
| salmon | 14.29 |
| intel-tbb | 14.29 |
| ecp-data-vis-sdk | 14.04 |
| trilinos | 13.48 |
| openfoam | 12.41 |
| xyce | 11.89 |
| openturns | 11.77 |
| cuda | 11.72 |
| py-jupyterhub | 11.68 |
| py-cinemasci | 11.37 |
| py-torchvision | 11.10 |
| gptune | 10.76 |
| embree | 10.38 |
| ginkgo | 10.29 |
| xgboost | 10.00 |
