### PR TITLE
Everywhere but windows

### DIFF
--- a/lib/spack/spack/multimethod.py
+++ b/lib/spack/spack/multimethod.py
@@ -279,6 +279,25 @@ def default_args(**kwargs):
     spack.directives.DirectiveMeta.pop_default_args()
 
 
+every_plat_but_windows = ["cray", "darwin", "freebsd", "linux"]
+
+
+def everywhere_but_windows(directive, *args, **kwargs):
+    """Abstraction around making directives non Windows
+    Invokes directive with arguments given every platform
+    scope but Windows
+
+    Args:
+        directive (function): function pointer for the
+            directive to be invoked
+        args (list): positional arguments given to directive
+        kwargs (dict): keyword args for directive
+    """
+    for plat in every_plat_but_windows:
+        with when(f"platform={plat}"):
+            directive(*args, **kwargs)
+
+
 class MultiMethodError(spack.error.SpackError):
     """Superclass for multimethod dispatch errors"""
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -90,7 +90,7 @@ from spack.installer import (
     UpstreamPackageError,
 )
 from spack.mixins import filter_compiler_wrappers
-from spack.multimethod import default_args, when
+from spack.multimethod import default_args, everywhere_but_windows, when
 from spack.package_base import (
     DependencyConflictError,
     build_system_flags,

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -98,7 +98,7 @@ class Vtk(CMakePackage):
     patch("vtkm-findmpi-downstream.patch", when="@9.0.0")
 
     # use internal FindHDF5
-    patch("internal_findHDF5.patch", when="@:8")
+    everywhere_but_windows(patch, "internal_findHDF5.patch", when="@:8")
 
     # Fix IOADIOS2 module to work with kits
     # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8653


### PR DESCRIPTION
Add `everywhere_but_windows` check as a convenience wrapper abstracting the logic:
```python
for plat in ["linux", "freebsd", "cray", "darwin"]:
  some_directive(..., when=f"platform={plat}
```
to
```python
everywhere_but_windows(some_directive, ...)
```
that has been implemented over and over again in multiple packages w/ Windows support.
Expressing this sentiment in such a distributed fashion means any updates to the list of platforms will necessitate changes in numerous locations, not just one.
Further, expressing this sentiment in this manner reduces the fairly verbose and unwieldy for loop into something similar to all other directives

TODO: Maybe make this a true directive? 