### PR TITLE
cmake: Enable CMAKE_EXPORT_COMPILE_COMMANDS

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -95,6 +95,10 @@ def _conditional_cmake_defaults(pkg: spack.package_base.PackageBase, args: List[
         args.append(CMakeBuilder.define("CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY", False))
         args.append(CMakeBuilder.define("CMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY", False))
 
+    # CMAKE_EXPORT_COMPILE_COMMANDS only exists for CMake >= 3.5
+    if cmake.satisfies("@3.5:"):
+        args.append(CMakeBuilder.define("CMAKE_EXPORT_COMPILE_COMMANDS", True))
+
 
 def generator(*names: str, default: Optional[str] = None):
     """The build system generator to use.
@@ -340,7 +344,6 @@ class CMakeBuilder(BaseBuilder):
             generator,
             define("CMAKE_INSTALL_PREFIX", pathlib.Path(pkg.prefix).as_posix()),
             define("CMAKE_BUILD_TYPE", build_type),
-            define("CMAKE_EXPORT_COMPILE_COMMANDS", True),
         ]
 
         if primary_generator == "Unix Makefiles":

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -58,6 +58,20 @@ def _maybe_set_python_hints(pkg: spack.package_base.PackageBase, args: List[str]
     )
 
 
+def _supports_compilation_databases(pkg: spack.package_base.PackageBase) -> bool:
+    """Check if this package (and CMake) can support compilation databases."""
+
+    # CMAKE_EXPORT_COMPILE_COMMANDS only exists for CMake >= 3.5
+    if not pkg.spec.satisfies("^cmake@3.5:"):
+        return False
+
+    # CMAKE_EXPORT_COMPILE_COMMANDS is only implemented for Makefile and Ninja generators
+    if not (pkg.spec.satisfies("generator=make") or pkg.spec.satisfies("generator=ninja")):
+        return False
+
+    return True
+
+
 def _conditional_cmake_defaults(pkg: spack.package_base.PackageBase, args: List[str]) -> None:
     """Set a few default defines for CMake, depending on its version."""
     cmakes = pkg.spec.dependencies("cmake", dt.BUILD)
@@ -95,8 +109,8 @@ def _conditional_cmake_defaults(pkg: spack.package_base.PackageBase, args: List[
         args.append(CMakeBuilder.define("CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY", False))
         args.append(CMakeBuilder.define("CMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY", False))
 
-    # CMAKE_EXPORT_COMPILE_COMMANDS only exists for CMake >= 3.5
-    if cmake.satisfies("@3.5:"):
+    # Export a compilation database if supported.
+    if _supports_compilation_databases(pkg):
         args.append(CMakeBuilder.define("CMAKE_EXPORT_COMPILE_COMMANDS", True))
 
 
@@ -288,10 +302,10 @@ class CMakeBuilder(BaseBuilder):
     @property
     def archive_files(self):
         """Files to archive for packages based on CMake"""
-        return [
-            os.path.join(self.build_directory, "CMakeCache.txt"),
-            os.path.join(self.build_directory, "compile_commands.json"),
-        ]
+        files = [os.path.join(self.build_directory, "CMakeCache.txt")]
+        if _supports_compilation_databases(self):
+            files.append(os.path.join(self.build_directory, "compile_commands.json"))
+        return files
 
     @property
     def root_cmakelists_dir(self):

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -284,7 +284,10 @@ class CMakeBuilder(BaseBuilder):
     @property
     def archive_files(self):
         """Files to archive for packages based on CMake"""
-        return [os.path.join(self.build_directory, "CMakeCache.txt")]
+        return [
+            os.path.join(self.build_directory, "CMakeCache.txt"),
+            os.path.join(self.build_directory, "compile_commands.json"),
+        ]
 
     @property
     def root_cmakelists_dir(self):
@@ -337,6 +340,7 @@ class CMakeBuilder(BaseBuilder):
             generator,
             define("CMAKE_INSTALL_PREFIX", pathlib.Path(pkg.prefix).as_posix()),
             define("CMAKE_BUILD_TYPE", build_type),
+            define("CMAKE_EXPORT_COMPILE_COMMANDS", True),
         ]
 
         if primary_generator == "Unix Makefiles":


### PR DESCRIPTION
Enabling this option causes CMake to generate a compile_commands.json file containing a compilation database that can be used to drive third-party tools.