### PR TITLE
ci: bump ghcr.io/spack/linux-ubuntu22.04-x86_64_v2 tag

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -707,7 +707,7 @@ tutorial-build:
 
 ml-linux-x86_64-cpu-generate:
   extends: [ ".generate-x86_64", .ml-linux-x86_64-cpu, ".tags-x86_64_v4" ]
-  image: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:v2023-07-01
+  image: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:v2024-01-29
 
 ml-linux-x86_64-cpu-build:
   extends: [ ".build", ".ml-linux-x86_64-cpu" ]
@@ -730,7 +730,7 @@ ml-linux-x86_64-cpu-build:
 
 ml-linux-x86_64-cuda-generate:
   extends: [ ".generate-x86_64", .ml-linux-x86_64-cuda, ".tags-x86_64_v4" ]
-  image: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:v2023-07-01
+  image: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:v2024-01-29
 
 ml-linux-x86_64-cuda-build:
   extends: [ ".build", ".ml-linux-x86_64-cuda"  ]
@@ -753,7 +753,7 @@ ml-linux-x86_64-cuda-build:
 
 ml-linux-x86_64-rocm-generate:
   extends: [ ".generate-x86_64", .ml-linux-x86_64-rocm, ".tags-x86_64_v4" ]
-  image: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:v2023-07-01
+  image: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:v2024-01-29
 
 ml-linux-x86_64-rocm-build:
   extends: [ ".build", ".ml-linux-x86_64-rocm" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cpu/spack.yaml
@@ -82,7 +82,7 @@ spack:
     pipeline-gen:
     - build-job:
         image:
-          name: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:v2023-07-01
+          name: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:v2024-01-29
           entrypoint: ['']
 
   cdash:

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
@@ -85,7 +85,7 @@ spack:
     pipeline-gen:
     - build-job:
         image:
-          name: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:v2023-07-01
+          name: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:v2024-01-29
           entrypoint: ['']
 
   cdash:

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
@@ -88,7 +88,7 @@ spack:
     pipeline-gen:
     - build-job:
         image:
-          name: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:v2023-07-01
+          name: ghcr.io/spack/linux-ubuntu22.04-x86_64_v2:v2024-01-29
           entrypoint: ['']
 
   cdash:


### PR DESCRIPTION
This adds an image that contains a `/usr/bin/python3` symlink as a workaround
for https://github.com/tensorflow/tensorflow/issues/62497.


Sad to pollute the build environment unnecessarily, but it doesn't look like
that tensorflow / bazel issue is getting solved any time soon.

