### PR TITLE
compression.py: refactor + bug fix

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -199,6 +199,7 @@ nitpick_ignore = [
     ("py:class", "contextlib.contextmanager"),
     ("py:class", "module"),
     ("py:class", "_io.BufferedReader"),
+    ("py:class", "_io.BytesIO"),
     ("py:class", "unittest.case.TestCase"),
     ("py:class", "_frozen_importlib_external.SourceFileLoader"),
     ("py:class", "clingo.Control"),

--- a/lib/spack/spack/cmd/logs.py
+++ b/lib/spack/spack/cmd/logs.py
@@ -44,7 +44,7 @@ def _logs(cmdline_spec, concrete_spec):
         raise SpackCommandError(f"{cmdline_spec} is not installed or staged")
 
     try:
-        compression_ext = compression.extension_from_file(log_path)
+        compression_ext = compression.extension_from_magic_numbers(log_path)
         with open(log_path, "rb") as fstream:
             if compression_ext == "gz":
                 # If the log file is compressed, wrap it with a decompressor

--- a/lib/spack/spack/cmd/logs.py
+++ b/lib/spack/spack/cmd/logs.py
@@ -5,11 +5,13 @@
 
 import errno
 import gzip
+import io
 import os
 import shutil
 import sys
 
 import spack.cmd
+import spack.spec
 import spack.util.compression as compression
 from spack.cmd.common import arguments
 from spack.main import SpackCommandError
@@ -23,45 +25,36 @@ def setup_parser(subparser):
     arguments.add_common_arguments(subparser, ["spec"])
 
 
-def _dump_byte_stream_to_stdout(instream):
+def _dump_byte_stream_to_stdout(instream: io.BufferedIOBase) -> None:
+    # Reopen stdout in binary mode so we don't have to worry about encoding
     outstream = os.fdopen(sys.stdout.fileno(), "wb", closefd=False)
-
     shutil.copyfileobj(instream, outstream)
 
 
-def dump_build_log(package):
-    with open(package.log_path, "rb") as f:
-        _dump_byte_stream_to_stdout(f)
-
-
-def _logs(cmdline_spec, concrete_spec):
+def _logs(cmdline_spec: spack.spec.Spec, concrete_spec: spack.spec.Spec):
     if concrete_spec.installed:
         log_path = concrete_spec.package.install_log_path
     elif os.path.exists(concrete_spec.package.stage.path):
-        dump_build_log(concrete_spec.package)
-        return
+        # TODO: `spack logs` can currently not show the logs while a package is being built, as the
+        # combined log file is only written after the build is finished.
+        log_path = concrete_spec.package.log_path
     else:
         raise SpackCommandError(f"{cmdline_spec} is not installed or staged")
 
     try:
-        compression_ext = compression.extension_from_magic_numbers(log_path)
-        with open(log_path, "rb") as fstream:
-            if compression_ext == "gz":
-                # If the log file is compressed, wrap it with a decompressor
-                fstream = gzip.open(log_path, "rb")
-            elif compression_ext:
-                raise SpackCommandError(
-                    f"Unsupported storage format for {log_path}: {compression_ext}"
-                )
-
-            _dump_byte_stream_to_stdout(fstream)
+        stream = open(log_path, "rb")
     except OSError as e:
         if e.errno == errno.ENOENT:
             raise SpackCommandError(f"No logs are available for {cmdline_spec}") from e
-        elif e.errno == errno.EPERM:
-            raise SpackCommandError(f"Permission error accessing {log_path}") from e
-        else:
-            raise
+        raise SpackCommandError(f"Error reading logs for {cmdline_spec}: {e}") from e
+
+    with stream as f:
+        ext = compression.extension_from_magic_numbers_by_stream(f, decompress=False)
+        if ext and ext != "gz":
+            raise SpackCommandError(f"Unsupported storage format for {log_path}: {ext}")
+
+        # If the log file is gzip compressed, wrap it with a decompressor
+        _dump_byte_stream_to_stdout(gzip.GzipFile(fileobj=f) if ext == "gz" else f)
 
 
 def logs(parser, args):

--- a/lib/spack/spack/test/util/compression.py
+++ b/lib/spack/spack/test/util/compression.py
@@ -101,12 +101,13 @@ def test_unallowed_extension():
 
 
 def test_file_type_check_does_not_advance_stream(tmp_path):
-    # Create a compressed tarbal.
+    # Create a compressed tarball (without .tar.gz extension)
     path = str(tmp_path / "compressed_tarball")
 
     with tarfile.open(path, "w:gz") as tar:
         tar.addfile(tarfile.TarInfo("test.txt"), fileobj=io.BytesIO(b"test"))
 
+    # Classify the file from its magic bytes, and check that the stream is not advanced
     with open(path, "rb") as f:
         assert compression.extension_from_magic_numbers_by_stream(f, decompress=False) == "gz"
         assert f.tell() == 0

--- a/lib/spack/spack/test/util/compression.py
+++ b/lib/spack/spack/test/util/compression.py
@@ -32,15 +32,11 @@ ext_archive = {}
 native_archive_list = [key for key in ext_archive.keys() if "tar" not in key and "zip" not in key]
 
 
-def support_stub():
-    return False
-
-
 @pytest.fixture
 def compr_support_check(monkeypatch):
-    monkeypatch.setattr(compression, "is_lzma_supported", support_stub)
-    monkeypatch.setattr(compression, "is_gzip_supported", support_stub)
-    monkeypatch.setattr(compression, "is_bz2_supported", support_stub)
+    monkeypatch.setattr(compression, "LZMA_SUPPORTED", False)
+    monkeypatch.setattr(compression, "GZIP_SUPPORTED", False)
+    monkeypatch.setattr(compression, "BZ2_SUPPORTED", False)
 
 
 @pytest.fixture


### PR DESCRIPTION
Improve naming, so it's clear file "extensions" are not taken in the
`PurePath(path).suffix` sense as the original function name suggests,
but rather that the files are opened and their magic bytes are
classified.

Add type hints.

Fix a bug where `stream.read(num_bytes)` was run on the compressed
stream instead of the uncompressed stream, which can potentially break
detection of tar.bz2 files.

Ensure that when peeking into streams for magic bytes, they are reset to
their original position upon return.

Use new API in `spack logs`.