### PR TITLE
load extensions through pythons entry-points machinery

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -222,7 +222,7 @@ adding the following to ``my_package``'s ``pyproject.toml`` will make ``my_packa
 .. code-block:: toml
 
    [project.entry_points:"spack.config"]
-   my_package = "my_package.get_config_path"
+   my_package = "my_package:get_config_path"
 
 The function ``my_package.get_extension_path`` in ``my_package/__init__.py`` might look like
 

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -221,7 +221,7 @@ adding the following to ``my_package``'s ``pyproject.toml`` will make ``my_packa
 
 .. code-block:: toml
 
-   [project.entry_points:"spack.config"]
+   [project.entry_points."spack.config"]
    my_package = "my_package:get_config_path"
 
 The function ``my_package.get_extension_path`` in ``my_package/__init__.py`` might look like

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -213,7 +213,7 @@ Spack can be made aware of configuration scopes that are installed as part of a 
 .. code-block:: console
 
   my-package/
-  ├── lib
+  ├── src
   │   ├── my_package
   │   │   ├── __init__.py
   │   │   └── spack/

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -224,7 +224,7 @@ adding the following to ``my_package``'s ``pyproject.toml`` will make ``my_packa
    [project.entry_points:"spack.config"]
    my_package = "my_package.get_config_path"
 
-The function ``my_package.get_extension_path`` in ``scripting/__init__.py`` might look like
+The function ``my_package.get_extension_path`` in ``my_package/__init__.py`` might look like
 
 .. code-block:: python
 

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -224,7 +224,7 @@ adding the following to ``my_package``'s ``pyproject.toml`` will make ``my_packa
    [project.entry_points:"spack.config"]
    my_package = "my_package.get_config_path"
 
-The function ``scripting.get_extension_path`` in ``scripting/__init__.py`` might look like
+The function ``my_package.get_extension_path`` in ``scripting/__init__.py`` might look like
 
 .. code-block:: python
 

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -73,9 +73,12 @@ are six configuration scopes. From lowest to highest:
    Spack instance per project) or for site-wide settings on a multi-user
    machine (e.g., for a common Spack instance).
 
+#. **plugin**: Read from a Python project's entry points. Settings here affect
+   all instances of Spack running with the same Python installation.  This scope takes higher precedence than site, system, and default scopes.
+
 #. **user**: Stored in the home directory: ``~/.spack/``. These settings
    affect all instances of Spack and take higher precedence than site,
-   system, or defaults scopes.
+   system, plugin, or defaults scopes.
 
 #. **custom**: Stored in a custom directory specified by ``--config-scope``.
    If multiple scopes are listed on the command line, they are ordered
@@ -195,6 +198,42 @@ with MPICH. You can create different configuration scopes for use with
            providers:
                mpi: [mpich]
 
+
+.. _plugin-scopes:
+
+^^^^^^^^^^^^^
+Plugin scopes
+^^^^^^^^^^^^^
+
+Spack can be made aware of configuration scopes that are installed as part of a python package.  To do so, register a function that returns the scope's path to the ``"spack.config"`` entry point.  Consider the Python package ``my_package`` that includes Spack configurations:
+
+.. code-block:: console
+
+  my-package/
+  ├── lib
+  │   ├── my_package
+  │   │   ├── __init__.py
+  │   │   └── spack/
+  │   │   │   └── config.yaml
+  └── pyproject.toml
+
+adding the following to ``my_package``'s ``pyproject.toml`` will make ``my_package``'s ``spack/`` configurations visible to Spack when ``my_package`` is installed:
+
+.. code-block:: toml
+
+   [project.entry_points:"spack.config"]
+   my_package = "my_package.get_config_path"
+
+The function ``scripting.get_extension_path`` in ``scripting/__init__.py`` might look like
+
+.. code-block:: python
+
+   import importlib.resources
+
+   def get_config_path():
+       dirname = importlib.resources.files("my_package").joinpath("spack")
+       if dirname.exists():
+           return str(dirname)
 
 .. _platform-scopes:
 

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -205,6 +205,9 @@ with MPICH. You can create different configuration scopes for use with
 Plugin scopes
 ^^^^^^^^^^^^^
 
+.. note::
+   Python version >= 3.8 is required to enable plugin configuration.
+
 Spack can be made aware of configuration scopes that are installed as part of a python package.  To do so, register a function that returns the scope's path to the ``"spack.config"`` entry point.  Consider the Python package ``my_package`` that includes Spack configurations:
 
 .. code-block:: console

--- a/lib/spack/docs/extensions.rst
+++ b/lib/spack/docs/extensions.rst
@@ -111,3 +111,36 @@ The corresponding unit tests can be run giving the appropriate options to ``spac
 
    (5 durations < 0.005s hidden.  Use -vv to show these durations.)
    =========================================== 5 passed in 5.06s ============================================
+
+---------------------------------------
+Registering Extensions via Entry Points
+---------------------------------------
+
+Spack can be made aware of extensions that are installed as part of a python package.  To do so, register a function that returns the extension path, or paths, to the ``"spack.extensions"`` entry point.  Consider the Python package ``my_package`` that includes a Spack extension:
+
+.. code-block:: console
+
+  my-package/
+  ├── lib
+  │   ├── my_package
+  │   │   └── __init__.py
+  │   └── spack-scripting/  # the spack extensions
+  └── pyproject.toml
+
+adding the following to ``my_package``'s ``pyproject.toml`` will make the ``spack-scripting`` extension visible to Spack when ``my_package`` is installed:
+
+.. code-block:: toml
+
+   [project.entry_points:"spack.extenions"]
+   my_package = "my_package.get_extension_path"
+
+The function ``scripting.get_extension_path`` in ``scripting/__init__.py`` might look like
+
+.. code-block:: python
+
+   import importlib.resources
+
+   def get_extension_path():
+       dirname = importlib.resources.files("my_package").joinpath("spack-scripting")
+       if dirname.exists():
+           return str(dirname)

--- a/lib/spack/docs/extensions.rst
+++ b/lib/spack/docs/extensions.rst
@@ -124,7 +124,7 @@ Spack can be made aware of extensions that are installed as part of a python pac
 .. code-block:: console
 
   my-package/
-  ├── lib
+  ├── src
   │   ├── my_package
   │   │   └── __init__.py
   │   └── spack-scripting/  # the spack extensions

--- a/lib/spack/docs/extensions.rst
+++ b/lib/spack/docs/extensions.rst
@@ -131,7 +131,7 @@ adding the following to ``my_package``'s ``pyproject.toml`` will make the ``spac
 
 .. code-block:: toml
 
-   [project.entry_points:"spack.extenions"]
+   [project.entry_points."spack.extenions"]
    my_package = "my_package:get_extension_path"
 
 The function ``my_package.get_extension_path`` in ``my_package/__init__.py`` might look like

--- a/lib/spack/docs/extensions.rst
+++ b/lib/spack/docs/extensions.rst
@@ -134,7 +134,7 @@ adding the following to ``my_package``'s ``pyproject.toml`` will make the ``spac
    [project.entry_points:"spack.extenions"]
    my_package = "my_package.get_extension_path"
 
-The function ``scripting.get_extension_path`` in ``scripting/__init__.py`` might look like
+The function ``my_package.get_extension_path`` in ``scripting/__init__.py`` might look like
 
 .. code-block:: python
 

--- a/lib/spack/docs/extensions.rst
+++ b/lib/spack/docs/extensions.rst
@@ -116,6 +116,9 @@ The corresponding unit tests can be run giving the appropriate options to ``spac
 Registering Extensions via Entry Points
 ---------------------------------------
 
+.. note::
+   Python version >= 3.8 is required to register extensions via entry points.
+
 Spack can be made aware of extensions that are installed as part of a python package.  To do so, register a function that returns the extension path, or paths, to the ``"spack.extensions"`` entry point.  Consider the Python package ``my_package`` that includes a Spack extension:
 
 .. code-block:: console

--- a/lib/spack/docs/extensions.rst
+++ b/lib/spack/docs/extensions.rst
@@ -134,7 +134,7 @@ adding the following to ``my_package``'s ``pyproject.toml`` will make the ``spac
    [project.entry_points:"spack.extenions"]
    my_package = "my_package.get_extension_path"
 
-The function ``my_package.get_extension_path`` in ``scripting/__init__.py`` might look like
+The function ``my_package.get_extension_path`` in ``my_package/__init__.py`` might look like
 
 .. code-block:: python
 

--- a/lib/spack/docs/extensions.rst
+++ b/lib/spack/docs/extensions.rst
@@ -132,7 +132,7 @@ adding the following to ``my_package``'s ``pyproject.toml`` will make the ``spac
 .. code-block:: toml
 
    [project.entry_points:"spack.extenions"]
-   my_package = "my_package.get_extension_path"
+   my_package = "my_package:get_extension_path"
 
 The function ``my_package.get_extension_path`` in ``my_package/__init__.py`` might look like
 

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -14,7 +14,7 @@ import sys
 import traceback
 import warnings
 from datetime import datetime, timedelta
-from typing import Any, Callable, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Iterable, List, Tuple
 
 # Ignore emacs backups when listing modules
 ignore_modules = [r"^\.#", "~$"]

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -847,7 +847,11 @@ class Singleton:
 def get_entry_points(*, group: str):
     """Wrapper for ``importlib.metadata.entry_points``
 
-    :return: EntryPoints for all installed packages.
+    Adapted from https://github.com/HypothesisWorks/hypothesis/blob/0a90ed6edf56319149956c7321d4110078a5c228/hypothesis-python/src/hypothesis/entry_points.py
+
+    Returns:
+        EntryPoints for all installed packages.
+
     """
 
     try:

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -859,7 +859,7 @@ def get_entry_points(*, group: str):
 
     try:
         try:
-            from importlib import metadata as importlib_metadata
+            from importlib import metadata as importlib_metadata  # type: ignore  # novermin
         except ImportError:
             import importlib_metadata  # type: ignore  # mypy thinks this is a redefinition
         try:
@@ -874,7 +874,7 @@ def get_entry_points(*, group: str):
         # But if we're not on Python >= 3.8 and the importlib_metadata backport
         # is not installed, we fall back to pkg_resources anyway.
         try:
-            import pkg_resources
+            import pkg_resources  # type: ignore
         except ImportError:
             warnings.warn(
                 "Under Python <= 3.7, Spack requires either the importlib_metadata "

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -849,8 +849,11 @@ def get_entry_points(*, group: str):
 
     Adapted from https://github.com/HypothesisWorks/hypothesis/blob/0a90ed6edf56319149956c7321d4110078a5c228/hypothesis-python/src/hypothesis/entry_points.py
 
+    Args:
+        group (str): the group of entry points to select
+
     Returns:
-        EntryPoints for all installed packages.
+        EntryPoints for ``group``
 
     """
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -32,7 +32,10 @@ import collections
 import contextlib
 import copy
 import functools
-import importlib.metadata
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    importlib_metadata = None
 import os
 import re
 import sys
@@ -766,10 +769,12 @@ def _add_platform_scope(
 
 
 def _add_configuration_paths_from_entry_points(configuration_paths):
+    if importlib_metadata is None:
+        return
     try:
-        entry_points = importlib.metadata.entry_points(group="spack.config")
+        entry_points = importlib_metadata.entry_points(group="spack.config")
     except TypeError:
-        entry_points = importlib.metadata.entry_points().get("spack.config")
+        entry_points = importlib_metadata.entry_points().get("spack.config")
     if not entry_points:
         return
     for entry_point in entry_points:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -785,7 +785,7 @@ def config_paths_from_entry_points() -> List[Tuple[str, str]]:
         if callable(hook):
             config_path = hook()
             if config_path and os.path.exists(config_path):
-                config_paths.append(("plugin-%s" % entry_point.name, config_path))
+                config_paths.append(("plugin-%s" % entry_point.name, str(config_path)))
     return config_paths
 
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -781,10 +781,11 @@ def config_paths_from_entry_points() -> List[Tuple[str, str]]:
     """
     config_paths: List[Tuple[str, str]] = []
     for entry_point in lang.get_entry_points(group="spack.config"):
-        get_config_path = entry_point.load()
-        config_path = get_config_path()
-        if config_path and os.path.exists(config_path):
-            config_paths.append(("plugin-%s" % entry_point.name, config_path))
+        hook = entry_point.load()
+        if callable(hook):
+            config_path = hook()
+            if config_path and os.path.exists(config_path):
+                config_paths.append(("plugin-%s" % entry_point.name, config_path))
     return config_paths
 
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -32,6 +32,7 @@ import collections
 import contextlib
 import copy
 import functools
+
 try:
     import importlib.metadata as importlib_metadata
 except ImportError:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -32,7 +32,6 @@ import collections
 import contextlib
 import copy
 import functools
-
 import os
 import re
 import sys

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -12,6 +12,7 @@ import os
 import re
 import sys
 import types
+from pathlib import Path
 from typing import List
 
 import llnl.util.lang
@@ -157,8 +158,8 @@ def extension_paths_from_entry_points() -> List[str]:
         hook = entry_point.load()
         if callable(hook):
             paths = hook() or []
-            if isinstance(paths, str):
-                extension_paths.append(paths)
+            if isinstance(paths, (Path, str)):
+                extension_paths.append(str(paths))
             else:
                 extension_paths.extend(paths)
     return extension_paths

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -8,6 +8,7 @@ for Spack's command extensions.
 import difflib
 import glob
 import importlib
+
 try:
     import importlib.metadata as importlib_metadata
 except ImportError:

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -186,8 +186,10 @@ def path_for_extension(target_name: str, *, paths: List[str]) -> str:
     Returns:
         Root directory where tests should reside or None
     """
+    print(paths)
     for path in paths:
         name = extension_name(path)
+        print(name)
         if name == target_name:
             return path
     else:

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -8,7 +8,10 @@ for Spack's command extensions.
 import difflib
 import glob
 import importlib
-import importlib.metadata
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    importlib_metadata = None
 import os
 import re
 import sys
@@ -144,10 +147,12 @@ def get_extension_paths_from_entry_points():
 
     """
     extension_paths = []
+    if importlib_metadata is None:
+        return extension_paths
     try:
-        entry_points = importlib.metadata.entry_points(group="spack.extensions")
+        entry_points = importlib_metadata.entry_points(group="spack.extensions")
     except TypeError:
-        entry_points = importlib.metadata.entry_points().get("spack.extensions")
+        entry_points = importlib_metadata.entry_points().get("spack.extensions")
     if not entry_points:
         return extension_paths
     for entry_point in entry_points:

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -8,7 +8,6 @@ for Spack's command extensions.
 import difflib
 import glob
 import importlib
-
 import os
 import re
 import sys

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -140,11 +140,17 @@ def get_extension_paths():
 
 def get_extension_paths_from_entry_points():
     """Return the list of canonicalized extension paths from a project's
-    [project.entry-points.spack]
+    [project.entry-points."spack.extensions"]
 
     """
     extension_paths = []
-    for entry_point in importlib.metadata.entry_points(group="spack.extensions"):
+    try:
+        entry_points = importlib.metadata.entry_points(group="spack.extensions")
+    except TypeError:
+        entry_points = importlib.metadata.entry_points().get("spack.extensions")
+    if not entry_points:
+        return extension_paths
+    for entry_point in entry_points:
         get_paths = entry_point.load()
         extension_paths.extend(get_paths())
     return extension_paths

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -186,10 +186,8 @@ def path_for_extension(target_name: str, *, paths: List[str]) -> str:
     Returns:
         Root directory where tests should reside or None
     """
-    print(paths)
     for path in paths:
         name = extension_name(path)
-        print(name)
         if name == target_name:
             return path
     else:

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -8,6 +8,7 @@ for Spack's command extensions.
 import difflib
 import glob
 import importlib
+import importlib.metadata
 import os
 import re
 import sys
@@ -132,8 +133,21 @@ def load_extension(name: str) -> str:
 def get_extension_paths():
     """Return the list of canonicalized extension paths from config:extensions."""
     extension_paths = spack.config.get("config:extensions") or []
+    extension_paths.extend(get_extension_paths_from_entry_points())
     paths = [spack.util.path.canonicalize_path(p) for p in extension_paths]
     return paths
+
+
+def get_extension_paths_from_entry_points():
+    """Return the list of canonicalized extension paths from a project's
+    [project.entry-points.spack]
+
+    """
+    extension_paths = []
+    for entry_point in importlib.metadata.entry_points(group="spack.extensions"):
+        get_paths = entry_point.load()
+        extension_paths.extend(get_paths())
+    return extension_paths
 
 
 def get_command_paths():

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -154,12 +154,13 @@ def extension_paths_from_entry_points() -> List[str]:
     """
     extension_paths: List[str] = []
     for entry_point in llnl.util.lang.get_entry_points(group="spack.extensions"):
-        get_paths = entry_point.load()
-        paths = get_paths() or []
-        if isinstance(paths, str):
-            extension_paths.append(paths)
-        else:
-            extension_paths.extend(paths)
+        hook = entry_point.load()
+        if callable(hook):
+            paths = hook() or []
+            if isinstance(paths, str):
+                extension_paths.append(paths)
+            else:
+                extension_paths.extend(paths)
     return extension_paths
 
 

--- a/lib/spack/spack/test/entry_points.py
+++ b/lib/spack/spack/test/entry_points.py
@@ -76,7 +76,7 @@ def test_spack_entry_points(monkeypatch, tmpdir):
             return
         monkeypatch.setattr(pkg_resources, "iter_entry_points", entry_points)
     config_paths = spack.config.config_paths_from_entry_points()
-    for (name, path) in config_paths:
+    for name, path in config_paths:
         if name == "plugin-mypackage_config":
             assert path == os.path.join(tmpdir, "spack/etc")
             break

--- a/lib/spack/spack/test/entry_points.py
+++ b/lib/spack/spack/test/entry_points.py
@@ -65,13 +65,13 @@ def test_spack_entry_points(monkeypatch, tmpdir):
     entry_points = entry_points_factory(tmpdir)
     try:
         try:
-            import importlib.metadata as importlib_metadata
+            import importlib.metadata as importlib_metadata  # type: ignore # novermin
         except ImportError:
             import importlib_metadata
         monkeypatch.setattr(importlib_metadata, "entry_points", entry_points)
     except ImportError:
         try:
-            import pkg_resources
+            import pkg_resources  # type: ignore
         except ImportError:
             return
         monkeypatch.setattr(pkg_resources, "iter_entry_points", entry_points)

--- a/lib/spack/spack/test/entry_points.py
+++ b/lib/spack/spack/test/entry_points.py
@@ -75,7 +75,16 @@ def test_spack_entry_points(monkeypatch, tmpdir):
         except ImportError:
             return
         monkeypatch.setattr(pkg_resources, "iter_entry_points", entry_points)
+    config_paths = spack.config.config_paths_from_entry_points()
+    for (name, path) in config_paths:
+        if name == "plugin-mypackage_config":
+            assert path == os.path.join(tmpdir, "spack/etc")
+            break
+    else:
+        assert 0, "mypackage_config entry_point not loaded"
     config = spack.config.create()
     assert config.get("config:install_tree:root") == "/spam/opt"
     extensions = spack.extensions.get_extension_paths()
+    assert os.path.join(tmpdir, "spack/spack-ext") in extensions
+    extensions = spack.extensions.extension_paths_from_entry_points()
     assert os.path.join(tmpdir, "spack/spack-ext") in extensions

--- a/lib/spack/spack/test/entry_points.py
+++ b/lib/spack/spack/test/entry_points.py
@@ -8,95 +8,75 @@ import sys
 
 import pytest
 
-import spack.paths
-import spack.util.spack_yaml as syaml
-from spack.util.executable import Executable
+import spack.config
+import spack.extensions
 
 
-def package_creator(tmpdir):
-    """Create a basic entry point directory structure"""
+class MockConfigEntryPoint:
+    def __init__(self, tmpdir):
+        self.dir = tmpdir
+        self.name = "mypackage_config"
 
-    root = tmpdir.ensure("myproject", dir=True)
-    with open(os.path.join(root.strpath, "pyproject.toml"), "w") as fh:
-        fh.write(
-            """\
-[project]
-name = "myproject"
-version = "1.0"
-description = "Single file project"
-requires-python = ">=3.8"
-[build-system]
-requires = ["setuptools>=64"]
-build-backend = "setuptools.build_meta"
-[project.entry-points."spack.config"]
-"myproject" = "myproject:get_spack_config_path"
-[project.entry-points."spack.extensions"]
-"myproject" = "myproject:get_spack_extension_path"
-"""
-        )
-        # The config and extension point entry points are generated on the fly
-        # for the test
-        root.ensure("src/myproject", dir=True)
-        with open(os.path.join(root.strpath, "src/myproject/__init__.py"), "w") as fh:
-            fh.write(
-                """\
-import importlib.resources
-def get_spack_config_path():
-    root = importlib.resources.files("myproject")
-    cfg = root.joinpath("spack/etc")
-    if cfg.exists():
-        return str(cfg)
-    cfg.mkdir(parents=True, exist_ok=True)
-    with open(cfg.joinpath("config.yaml"), "w") as fh:
-        fh.write("config:\\n  install_tree:\\n    root: /spam/opt\\n")
-    return str(cfg)
-def get_spack_extension_path():
-    root = importlib.resources.files("myproject")
-    ext = root.joinpath("spack/spack-ext/ext/cmd")
-    if ext.exists():
-        return str(root.joinpath("spack/spack-ext"))
-    ext.mkdir(parents=True, exist_ok=True)
-    with open(ext.joinpath("spam.py"), "w") as fh:
-        fh.write("description = 'hello world extension command'\\n")
-        fh.write("section = 'test command'\\n")
-        fh.write("level = 'long'\\n")
-        fh.write("def setup_parser(subparser):\\n    pass\\n")
-        fh.write("def spam(parser, args):\\n    print('spam for all!')\\n")
-    return str(root.joinpath("spack/spack-ext"))
-"""
-            )
-    return root
+    def load(self):
+        self.dir.ensure("spack/etc", dir=True)
+        with open(os.path.join(self.dir, "spack/etc/config.yaml"), "w") as fh:
+            fh.write("config:\n  install_tree:\n    root: /spam/opt\n")
+
+        def ep():
+            return os.path.join(self.dir, "spack/etc")
+
+        return ep
 
 
-@pytest.mark.skipif(
-    sys.version_info[:2] < (3, 8), reason="Python version 3.8 or newer required"
-)
-def test_spack_entry_points(tmpdir):
-    """Basic test of a functioning command."""
-    package_src_root = package_creator(tmpdir)
-    with tmpdir.as_cwd():
-        Executable(sys.executable)("-m", "venv", "venv")
-    venv_bin_path = os.path.join(tmpdir.strpath, "venv/bin")
-    env = dict(os.environ)
-    env["PATH"] = "%s%s%s" % (str(venv_bin_path), os.pathsep, os.environ["PATH"])
-    python = Executable(os.path.join(venv_bin_path, "python3"))
-    with package_src_root.as_cwd():
-        python("-m", "pip", "install", ".", env=env)
-        spack_script = os.path.join(spack.paths.bin_path, "spack")
-        output = python(spack_script, "config", "get", "config", output=str, env=env)
-        config = syaml.load(output)
-        assert config["config"]["install_tree"]["root"] == "/spam/opt"
-        output = python(spack_script, "spam", output=str, env=env)
-        assert "spam for all!" in output, output
+class MockExtensionsEntryPoint:
+    def __init__(self, tmpdir):
+        self.dir = tmpdir
+        self.name = "mypackage_extensions"
+
+    def load(self):
+        self.dir.ensure("spack/spack-ext/ext/cmd", dir=True)
+        with open(os.path.join(self.dir, "spack/spack-ext/ext/cmd/spam.py"), "w") as fh:
+            fh.write("description = 'hello world extension command'\n")
+            fh.write("section = 'test command'\n")
+            fh.write("level = 'long'\n")
+            fh.write("def setup_parser(subparser):\n    pass\n")
+            fh.write("def spam(parser, args):\n    print('spam for all!')\n")
+
+        def ep():
+            return os.path.join(self.dir, "spack/spack-ext")
+
+        return ep
 
 
-if __name__ == "__main__":
-    import tempfile
-    import pathlib
-    import shutil
+def entry_points_factory(tmpdir):
+    def entry_points(group=None):
+        print(f"{group=}")
+        if group == "spack.config":
+            return (MockConfigEntryPoint(tmpdir),)
+        elif group == "spack.extensions":
+            return (MockExtensionsEntryPoint(tmpdir),)
+        return ()
 
+    return entry_points
+
+
+@pytest.mark.skipif(sys.version_info[:2] < (3, 8), reason="Python>=3.8 required")
+def test_spack_entry_points(monkeypatch, tmpdir):
+    """Test config scope entry point"""
+    entry_points = entry_points_factory(tmpdir)
     try:
-        d = pathlib.Path(tempfile.mkdtemp())
-        test_spack_entry_points(d)
-    finally:
-        shutil.rmtree(str(d))
+        try:
+            import importlib.metadata as importlib_metadata
+        except ImportError:
+            import importlib_metadata
+        monkeypatch.setattr(importlib_metadata, "entry_points", entry_points)
+    except ImportError:
+        try:
+            import pkg_resources
+        except ImportError:
+            return
+        monkeypatch.setattr(pkg_resources, "iter_entry_points", entry_points)
+    config = spack.config.create()
+    assert config.get("config:install_tree:root") == "/spam/opt"
+    extensions = spack.extensions.get_extension_paths()
+    assert os.path.join(tmpdir, "spack/spack-ext") in extensions

--- a/lib/spack/spack/test/entry_points.py
+++ b/lib/spack/spack/test/entry_points.py
@@ -50,7 +50,6 @@ class MockExtensionsEntryPoint:
 
 def entry_points_factory(tmpdir):
     def entry_points(group=None):
-        print(f"{group=}")
         if group == "spack.config":
             return (MockConfigEntryPoint(tmpdir),)
         elif group == "spack.extensions":

--- a/lib/spack/spack/test/entry_points.py
+++ b/lib/spack/spack/test/entry_points.py
@@ -35,8 +35,8 @@ class MockExtensionsEntryPoint:
         self.name = "mypackage_extensions"
 
     def load(self):
-        self.dir.ensure("spack/spack-ext/ext/cmd", dir=True)
-        f = os.path.join(self.dir, "spack", "spack-ext", "ext", "cmd", "spam.py")
+        self.dir.ensure("spack/spack-myext/myext/cmd", dir=True)
+        f = os.path.join(self.dir, "spack", "spack-myext", "myext", "cmd", "spam.py")
         with open(f, "w") as fh:
             fh.write("description = 'hello world extension command'\n")
             fh.write("section = 'test command'\n")
@@ -45,7 +45,7 @@ class MockExtensionsEntryPoint:
             fh.write("def spam(parser, args):\n    print('spam for all!')\n")
 
         def ep():
-            return os.path.join(self.dir, "spack", "spack-ext")
+            return os.path.join(self.dir, "spack", "spack-myext")
 
         return ep
 
@@ -96,7 +96,7 @@ def test_spack_entry_point_config(monkeypatch, tmpdir):
 def test_spack_entry_point_extension(monkeypatch, tmpdir):
     """Test config scope entry point"""
     patch_entry_points(tmpdir, monkeypatch)
-    my_ext = os.path.join(tmpdir, "spack", "spack-ext")
+    my_ext = os.path.join(tmpdir, "spack", "spack-myext")
     extensions = spack.extensions.get_extension_paths()
     found = bool([ext for ext in extensions if os.path.samefile(ext, my_ext)])
     if not found:
@@ -105,3 +105,7 @@ def test_spack_entry_point_extension(monkeypatch, tmpdir):
     found = bool([ext for ext in extensions if os.path.samefile(ext, my_ext)])
     if not found:
         raise ValueError("Did not find extension in %s" % ", ".join(extensions))
+    root = spack.extensions.load_extension("myext")
+    assert os.path.samefile(root, my_ext)
+    module = spack.extensions.get_module("spam")
+    assert module is not None

--- a/lib/spack/spack/test/entry_points.py
+++ b/lib/spack/spack/test/entry_points.py
@@ -19,11 +19,12 @@ class MockConfigEntryPoint:
 
     def load(self):
         self.dir.ensure("spack/etc", dir=True)
-        with open(os.path.join(self.dir, "spack/etc/config.yaml"), "w") as fh:
+        f = os.path.join(self.dir, "spack", "etc", "config.yaml")
+        with open(f, "w") as fh:
             fh.write("config:\n  install_tree:\n    root: /spam/opt\n")
 
         def ep():
-            return os.path.join(self.dir, "spack/etc")
+            return os.path.join(self.dir, "spack", "etc")
 
         return ep
 
@@ -35,7 +36,8 @@ class MockExtensionsEntryPoint:
 
     def load(self):
         self.dir.ensure("spack/spack-ext/ext/cmd", dir=True)
-        with open(os.path.join(self.dir, "spack/spack-ext/ext/cmd/spam.py"), "w") as fh:
+        f = os.path.join(self.dir, "spack", "spack-ext", "ext", "cmd", "spam.py")
+        with open(f, "w") as fh:
             fh.write("description = 'hello world extension command'\n")
             fh.write("section = 'test command'\n")
             fh.write("level = 'long'\n")
@@ -43,7 +45,7 @@ class MockExtensionsEntryPoint:
             fh.write("def spam(parser, args):\n    print('spam for all!')\n")
 
         def ep():
-            return os.path.join(self.dir, "spack/spack-ext")
+            return os.path.join(self.dir, "spack", "spack-ext")
 
         return ep
 
@@ -59,9 +61,7 @@ def entry_points_factory(tmpdir):
     return entry_points
 
 
-@pytest.mark.skipif(sys.version_info[:2] < (3, 8), reason="Python>=3.8 required")
-def test_spack_entry_points(monkeypatch, tmpdir):
-    """Test config scope entry point"""
+def patch_entry_points(tmpdir, monkeypatch):
     entry_points = entry_points_factory(tmpdir)
     try:
         try:
@@ -75,16 +75,33 @@ def test_spack_entry_points(monkeypatch, tmpdir):
         except ImportError:
             return
         monkeypatch.setattr(pkg_resources, "iter_entry_points", entry_points)
-    config_paths = spack.config.config_paths_from_entry_points()
-    for name, path in config_paths:
-        if name == "plugin-mypackage_config":
-            assert path == os.path.join(tmpdir, "spack/etc")
-            break
+
+
+@pytest.mark.skipif(sys.version_info[:2] < (3, 8), reason="Python>=3.8 required")
+def test_spack_entry_point_config(monkeypatch, tmpdir):
+    """Test config scope entry point"""
+    patch_entry_points(tmpdir, monkeypatch)
+    config_paths = dict(spack.config.config_paths_from_entry_points())
+    config_path = config_paths.get("plugin-mypackage_config")
+    my_config_path = os.path.join(tmpdir, "spack", "etc")
+    if config_path is None:
+        raise ValueError("Did not find entry point config in %s" % str(config_paths))
     else:
-        assert 0, "mypackage_config entry_point not loaded"
+        assert os.path.samefile(config_path, my_config_path)
     config = spack.config.create()
-    assert config.get("config:install_tree:root") == "/spam/opt"
+    assert config.get("config:install_tree:root", scope="plugin-mypackage_config") == "/spam/opt"
+
+
+@pytest.mark.skipif(sys.version_info[:2] < (3, 8), reason="Python>=3.8 required")
+def test_spack_entry_point_extension(monkeypatch, tmpdir):
+    """Test config scope entry point"""
+    patch_entry_points(tmpdir, monkeypatch)
+    my_ext = os.path.join(tmpdir, "spack", "spack-ext")
     extensions = spack.extensions.get_extension_paths()
-    assert os.path.join(tmpdir, "spack/spack-ext") in extensions
+    found = bool([ext for ext in extensions if os.path.samefile(ext, my_ext)])
+    if not found:
+        raise ValueError("Did not find extension in %s" % ", ".join(extensions))
     extensions = spack.extensions.extension_paths_from_entry_points()
-    assert os.path.join(tmpdir, "spack/spack-ext") in extensions
+    found = bool([ext for ext in extensions if os.path.samefile(ext, my_ext)])
+    if not found:
+        raise ValueError("Did not find extension in %s" % ", ".join(extensions))

--- a/lib/spack/spack/test/entry_points.py
+++ b/lib/spack/spack/test/entry_points.py
@@ -1,0 +1,102 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+import sys
+
+import pytest
+
+import spack.paths
+import spack.util.spack_yaml as syaml
+from spack.util.executable import Executable
+
+
+def package_creator(tmpdir):
+    """Create a basic entry point directory structure"""
+
+    root = tmpdir.ensure("myproject", dir=True)
+    with open(os.path.join(root.strpath, "pyproject.toml"), "w") as fh:
+        fh.write(
+            """\
+[project]
+name = "myproject"
+version = "1.0"
+description = "Single file project"
+requires-python = ">=3.8"
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+[project.entry-points."spack.config"]
+"myproject" = "myproject:get_spack_config_path"
+[project.entry-points."spack.extensions"]
+"myproject" = "myproject:get_spack_extension_path"
+"""
+        )
+        # The config and extension point entry points are generated on the fly
+        # for the test
+        root.ensure("src/myproject", dir=True)
+        with open(os.path.join(root.strpath, "src/myproject/__init__.py"), "w") as fh:
+            fh.write(
+                """\
+import importlib.resources
+def get_spack_config_path():
+    root = importlib.resources.files("myproject")
+    cfg = root.joinpath("spack/etc")
+    if cfg.exists():
+        return str(cfg)
+    cfg.mkdir(parents=True, exist_ok=True)
+    with open(cfg.joinpath("config.yaml"), "w") as fh:
+        fh.write("config:\\n  install_tree:\\n    root: /spam/opt\\n")
+    return str(cfg)
+def get_spack_extension_path():
+    root = importlib.resources.files("myproject")
+    ext = root.joinpath("spack/spack-ext/ext/cmd")
+    if ext.exists():
+        return str(root.joinpath("spack/spack-ext"))
+    ext.mkdir(parents=True, exist_ok=True)
+    with open(ext.joinpath("spam.py"), "w") as fh:
+        fh.write("description = 'hello world extension command'\\n")
+        fh.write("section = 'test command'\\n")
+        fh.write("level = 'long'\\n")
+        fh.write("def setup_parser(subparser):\\n    pass\\n")
+        fh.write("def spam(parser, args):\\n    print('spam for all!')\\n")
+    return str(root.joinpath("spack/spack-ext"))
+"""
+            )
+    return root
+
+
+@pytest.mark.skipif(
+    sys.version_info[:2] < (3, 8), reason="Python version 3.8 or newer required"
+)
+def test_spack_entry_points(tmpdir):
+    """Basic test of a functioning command."""
+    package_src_root = package_creator(tmpdir)
+    with tmpdir.as_cwd():
+        Executable(sys.executable)("-m", "venv", "venv")
+    venv_bin_path = os.path.join(tmpdir.strpath, "venv/bin")
+    env = dict(os.environ)
+    env["PATH"] = "%s%s%s" % (str(venv_bin_path), os.pathsep, os.environ["PATH"])
+    python = Executable(os.path.join(venv_bin_path, "python3"))
+    with package_src_root.as_cwd():
+        python("-m", "pip", "install", ".", env=env)
+        spack_script = os.path.join(spack.paths.bin_path, "spack")
+        output = python(spack_script, "config", "get", "config", output=str, env=env)
+        config = syaml.load(output)
+        assert config["config"]["install_tree"]["root"] == "/spam/opt"
+        output = python(spack_script, "spam", output=str, env=env)
+        assert "spam for all!" in output, output
+
+
+if __name__ == "__main__":
+    import tempfile
+    import pathlib
+    import shutil
+
+    try:
+        d = pathlib.Path(tempfile.mkdtemp())
+        test_spack_entry_points(d)
+    finally:
+        shutil.rmtree(str(d))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,17 +154,17 @@ ignore_missing_imports = true
       'boto3',
       'botocore',
       'distro',
+      'importlib.metadata',
       'jinja2',
       'jsonschema',
       'macholib',
       'markupsafe',
       'numpy',
+      'pkg_resources',
       'pyristent',
       'pytest',
       'ruamel.yaml',
       'six',
-      'pkg_resources',
-      'importlib.metadata',
   ]
   follow_imports = 'skip'
   follow_imports_for_stubs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,8 @@ ignore_missing_imports = true
       'pytest',
       'ruamel.yaml',
       'six',
+      'pkg_resources',
+      'importlib.metadata',
   ]
   follow_imports = 'skip'
   follow_imports_for_stubs = true


### PR DESCRIPTION
## What is it?

This PR adds the ability to load spack extensions through `importlib.metadata.entry_points` in addition to the regular configuration variable.

## Why?

This allows one to `pip install my-extension` and have spack find it without having to provide additional configuration.

## Notes

- See initial discussion at https://spackpm.slack.com/archives/C5W7NKZJT/p1706560654393159
- Documentation and tests have not been provided, but can if this PR is deemed useful and/or of interest.

## Usage

In your package's `pyproject.toml` add the following:

```toml
[project.entry-points."spack.extensions"]
"ext-name" = "module-name:function-that-returns-list-of-extension-paths"

[project.entry-points."spack.config"]
"ext-name" = "module-name:function-that-returns-config-scope-path"
```

## Example

`pyproject.toml`

```toml
[project]
name = "baz"
description = "baz"
version = "0.1.0"
requires-python = ">=3.9"

[project.entry-points."spack.extensions"]
baz = "baz:get_spack_extension_paths"

[project.entry-points."spack.config"]
baz = "baz:get_spack_config_dir"
```

`baz/__init__.py`:

```python
import importlib.resources

def get_spack_extension_paths() -> list[str]:
    dirname = importlib.resources.files("baz").joinpath("spack-baz")
    if dirname.exists():  # type: ignore
        return [str(dirname)]
    return []

def get_spack_config_dir() -> str:
    dirname = importlib.resources.files("baz").joinpath("spack-config")
    if dirname.exists():  # type: ignore
        return str(dirname)
    return []
```
