### PR TITLE
CI: Add OIDC capability for deprecated CI

### DIFF
--- a/lib/spack/spack/schema/gitlab_ci.py
+++ b/lib/spack/spack/schema/gitlab_ci.py
@@ -35,7 +35,7 @@ runner_attributes_schema_items = {
 
 runner_selector_schema = {
     "type": "object",
-    "additionalProperties": False,
+    "additionalProperties": True,
     "required": ["tags"],
     "properties": runner_attributes_schema_items,
 }

--- a/share/spack/gitlab/cloud_pipelines/stacks/deprecated/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/deprecated/spack.yaml
@@ -62,6 +62,9 @@ spack:
     - match:
       - '@:'
       runner-attributes:
+        id_tokens:
+          GITLAB_OIDC_TOKEN:
+            aud: "${OIDC_TOKEN_AUDIENCE}"
         tags: [spack, public, small, x86_64]
         variables:
           CI_JOB_SIZE: small
@@ -69,6 +72,9 @@ spack:
           KUBERNETES_CPU_REQUEST: 500m
           KUBERNETES_MEMORY_REQUEST: 500M
     signing-job-attributes:
+      id_tokens:
+        GITLAB_OIDC_TOKEN:
+          aud: "${OIDC_TOKEN_AUDIENCE}"
       image: {name: 'ghcr.io/spack/notary:latest', entrypoint: ['']}
       tags: [aws]
       script:
@@ -80,6 +86,9 @@ spack:
         --recursive --exclude "*" --include "*.pub"
 
     service-job-attributes:
+      id_tokens:
+        GITLAB_OIDC_TOKEN:
+          aud: "${OIDC_TOKEN_AUDIENCE}"
       image: ghcr.io/spack/tutorial-ubuntu-18.04:v2021-11-02
       before_script:
       - . "./share/spack/setup-env.sh"


### PR DESCRIPTION
This "breaks" the deprecated schema by allowing unknown attributes to the attributes section of the job types. The breaking change here is that deprecated stacks will no longer ignore attributes that are unknown but rather assume the new CI schema behavior of injecting them into the generated CI configuration. This change is required to secure authentication in Spack CI.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
