### PR TITLE
motioncor2: updating to @1.6.4

### DIFF
--- a/var/spack/repos/builtin/packages/motioncor2/package.py
+++ b/var/spack/repos/builtin/packages/motioncor2/package.py
@@ -20,6 +20,7 @@ class Motioncor2(Package):
     homepage = "http://msg.ucsf.edu/em/software"
     manual_download = True
 
+    version("1.6.4", sha256="28bb3e6477abf34fe41a78bcb9da9d77d08e2e89ecd41240fab085a308e6c498")
     version("1.4.7", sha256="8c33969b10916835b55f14f3c370f67ebe5c4b2a9df9ec487c5251710f038e6b")
 
     # None of the below are available for download
@@ -41,18 +42,27 @@ class Motioncor2(Package):
         deprecated=True,
     )
 
+    depends_on("cuda@10.2,11.1:11.8,12.1", type="run")
+    depends_on("libtiff", type="run")
+
     def url_for_version(self, version):
         return "file://{0}/MotionCor2_{1}.zip".format(os.getcwd(), version)
 
-    depends_on("cuda@10.2,11.1:11.5", type="run")
-    depends_on("libtiff", type="run")
+    def setup_run_environment(self, env):
+        # As this is downloaded precompiled, we can't set library paths when building and
+        # have to manually specify the location of the CUDA libs (requires libcufft.so)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["cuda"].prefix.lib64)
 
     def install(self, spec, prefix):
         cuda_version = spec["cuda"].version.up_to(2).joined
 
         mkdirp(prefix.bin)
-        with working_dir("MotionCor2_{0}".format(spec.version)):
-            install(
-                "MotionCor2_{0}_Cuda{1}_*".format(spec.version, cuda_version),
-                join_path(prefix.bin, "MotionCor2"),
-            )
+        install(
+            "MotionCor2_{0}_Cuda{1}_*".format(spec.version, cuda_version),
+            join_path(prefix.bin, "MotionCor2"),
+        )
+        #with working_dir("MotionCor2_{0}".format(spec.version)):
+        #    install(
+        #        "MotionCor2_{0}_Cuda{1}_*".format(spec.version, cuda_version),
+        #        join_path(prefix.bin, "MotionCor2"),
+        #    )

--- a/var/spack/repos/builtin/packages/motioncor2/package.py
+++ b/var/spack/repos/builtin/packages/motioncor2/package.py
@@ -61,8 +61,3 @@ class Motioncor2(Package):
             "MotionCor2_{0}_Cuda{1}_*".format(spec.version, cuda_version),
             join_path(prefix.bin, "MotionCor2"),
         )
-        #with working_dir("MotionCor2_{0}".format(spec.version)):
-        #    install(
-        #        "MotionCor2_{0}_Cuda{1}_*".format(spec.version, cuda_version),
-        #        join_path(prefix.bin, "MotionCor2"),
-        #    )

--- a/var/spack/repos/builtin/packages/motioncor2/package.py
+++ b/var/spack/repos/builtin/packages/motioncor2/package.py
@@ -63,7 +63,5 @@ class Motioncor2(Package):
     def ensure_rpaths(self):
         patchelf = which("patchelf")
         patchelf(
-           "--set-rpath",
-           self.spec["cuda"].prefix.lib64,
-           join_path(self.prefix.bin, "MotionCor2"),
+           "--set-rpath", self.spec["cuda"].prefix.lib64, join_path(self.prefix.bin, "MotionCor2")
         )

--- a/var/spack/repos/builtin/packages/motioncor2/package.py
+++ b/var/spack/repos/builtin/packages/motioncor2/package.py
@@ -63,5 +63,5 @@ class Motioncor2(Package):
     def ensure_rpaths(self):
         patchelf = which("patchelf")
         patchelf(
-           "--set-rpath", self.spec["cuda"].prefix.lib64, join_path(self.prefix.bin, "MotionCor2")
+            "--set-rpath", self.spec["cuda"].prefix.lib64, join_path(self.prefix.bin, "MotionCor2")
         )


### PR DESCRIPTION
Updating to `motioncor2@1.6.4`. Testing the install on our `linux-rocky8-icelake` system, this was complaining about not being able to locate `libcufft.so` from `cuda`. As this is downloaded as a precompiled binary, I've fixed this by manually specifying the addition to the `LD_LIBRARY_PATH` in the `package.py`.