### PR TITLE
Update OpenSubdiv spec

### DIFF
--- a/var/spack/repos/builtin/packages/opensubdiv/package.py
+++ b/var/spack/repos/builtin/packages/opensubdiv/package.py
@@ -21,6 +21,8 @@ class Opensubdiv(CMakePackage, CudaPackage):
     license("Apache-2.0")
 
     version("develop", branch="dev")
+    version("3.5.1", sha256="42c7c89ffa552f37e9742d1ecfa4bd1d6a2892e01b68fc156775d104154d3d43")
+    version("3.5.0", sha256="8f5044f453b94162755131f77c08069004f25306fd6dc2192b6d49889efb8095")
     version("3.4.3", sha256="7b22eb27d636ab0c1e03722c7a5a5bd4f11664ee65c9b48f341a6d0ce7f36745")
     version("3.4.0", sha256="d932b292f83371c7518960b2135c7a5b931efb43cdd8720e0b27268a698973e4")
 

--- a/var/spack/repos/builtin/packages/opensubdiv/package.py
+++ b/var/spack/repos/builtin/packages/opensubdiv/package.py
@@ -39,6 +39,7 @@ class Opensubdiv(CMakePackage, CudaPackage):
     depends_on("glfw@3.0.0:")
     depends_on("intel-tbb@4.0:", when="+tbb")
     depends_on("libxrandr")
+    depends_on("libxxf86vm")
     depends_on("libxcursor")
     depends_on("libxinerama")
     depends_on("llvm-openmp", when="+openmp")


### PR DESCRIPTION
This updates OpenSubdiv's package.yaml file to include versions 3.5.0 and 3.5.1, and adds a dependency on `libxxf86vm` to fix a cmake error where it can't find `xf86vm`.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
