### PR TITLE
astyle: new version 4.1.11 and build using cmake

### DIFF
--- a/var/spack/repos/builtin/packages/astyle/package.py
+++ b/var/spack/repos/builtin/packages/astyle/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.build_systems.cmake import CMakeBuilder
-from spack.build_systems.makefile import MakefileBuilder
+from spack.build_systems import makefile
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/astyle/package.py
+++ b/var/spack/repos/builtin/packages/astyle/package.py
@@ -46,12 +46,6 @@ class Astyle(CMakePackage, MakefilePackage):
         return url
 
 
-class CMakeBuilder(CMakeBuilder):
-    def cmake_args(self):
-        args = []
-        return args
-
-
 class MakefileBuilder(MakefileBuilder):
     @property
     def build_directory(self):

--- a/var/spack/repos/builtin/packages/astyle/package.py
+++ b/var/spack/repos/builtin/packages/astyle/package.py
@@ -46,7 +46,7 @@ class Astyle(CMakePackage, MakefilePackage):
         return url
 
 
-class MakefileBuilder(MakefileBuilder):
+class MakefileBuilder(makefile.MakefileBuilder):
     @property
     def build_directory(self):
         return join_path(self.stage.source_path, "build", self.pkg.compiler.name)

--- a/var/spack/repos/builtin/packages/astyle/package.py
+++ b/var/spack/repos/builtin/packages/astyle/package.py
@@ -47,12 +47,13 @@ class Astyle(CMakePackage, MakefilePackage):
             url = "{0}/astyle%20{1}/astyle_{2}_linux.tar.gz"
         return url.format(root, version.up_to(2), version)
 
+
 class CMakeBuilder(CMakeBuilder):
 
     def cmake_args(self):
-        spec = self.spec
         args = []
         return args
+
 
 class MakefileBuilder(MakefileBuilder):
 

--- a/var/spack/repos/builtin/packages/astyle/package.py
+++ b/var/spack/repos/builtin/packages/astyle/package.py
@@ -3,34 +3,64 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.cmake import CMakeBuilder
+from spack.build_systems.makefile import MakefileBuilder
 from spack.package import *
 
 
-class Astyle(MakefilePackage):
+class Astyle(CMakePackage, MakefilePackage):
     """A Free, Fast, and Small Automatic Formatter for C, C++, C++/CLI,
     Objective-C, C#, and Java Source Code.
     """
 
     homepage = "http://astyle.sourceforge.net/"
-    url = "https://sourceforge.net/projects/astyle/files/astyle/astyle%203.0.1/astyle_3.0.1_linux.tar.gz"
-    # Gentoo alternative
-    # url = "https://distfiles.gentoo.org/distfiles/astyle_3.0.1_linux.tar.gz"
+    url = "https://sourceforge.net/projects/astyle/files/astyle/astyle%204.1.11/astyle-4.1.11.tar.bz2"
+    list_url = "https://sourceforge.net/projects/astyle/files/astyle"
+    list_depth = 1
+
+    maintainers("cessenat")
 
     license("MIT")
 
+    version("3.4.11", sha256="15b22bc6cbc038ccd8cef3804efec02f35c6f2538b75c93bc7f76e4de98aba92")
+    version("3.3.1", sha256="246979db8ba82948d2925f823293321617e4a51dcac8719b370b670782e9c57d")
+    version("3.2.1", sha256="191576fbd1f4abe55a25769c176da78294ec590f96f27037a4746bda0f84fe60")
     version("3.1", sha256="cbcc4cf996294534bb56f025d6f199ebfde81aa4c271ccbd5ee1c1a3192745d7")
     version("3.0.1", sha256="6c3ab029e0e4a75e2e603d449014374aa8269218fdd03a4aaa46ab743b1912fd")
     version("2.06", sha256="3b7212210dc139e8f648e004b758c0be1b3ceb1694b22a879202d2b833db7c7e")
     version("2.05.1", sha256="fbdfc6f1966a972d19a215927266c76d4183eee235ed1e2bd7ec551c2a270eac")
     version("2.04", sha256="70b37f4853c418d1e2632612967eebf1bdb93dfbe558c51d7d013c9b4e116b60")
 
+    depends_on("cmake@3.8.0:", type="build", when="@3.2.0:")
+
+    build_system(conditional("cmake", when="@3.2.0:"), "makefile", default="cmake")
+
     parallel = False
+
+    conflicts("%oneapi", when="@:3.1.99")
+
+    def url_for_version(self, version):
+        root = self.url.rsplit("/", 2)[0]
+        if version >= Version('3.2.0'):
+            url = "{0}/astyle%20{1}/astyle-{2}.tar.bz2"
+        else:
+            url = "{0}/astyle%20{1}/astyle_{2}_linux.tar.gz"
+        return url.format(root, version.up_to(2), version)
+
+class CMakeBuilder(CMakeBuilder):
+
+    def cmake_args(self):
+        spec = self.spec
+        args = []
+        return args
+
+class MakefileBuilder(MakefileBuilder):
 
     @property
     def build_directory(self):
-        return join_path(self.stage.source_path, "build", self.compiler.name)
+        return join_path(self.stage.source_path, "build", self.pkg.compiler.name)
 
-    def edit(self, spec, prefix):
+    def edit(self, pkg, spec, prefix):
         makefile = join_path(self.build_directory, "Makefile")
         filter_file(r"^CXX\s*=.*", f"CXX={spack_cxx}", makefile)
         # If the group is not a user account, the installation will fail,

--- a/var/spack/repos/builtin/packages/astyle/package.py
+++ b/var/spack/repos/builtin/packages/astyle/package.py
@@ -41,11 +41,10 @@ class Astyle(CMakePackage, MakefilePackage):
 
     def url_for_version(self, version):
         root = self.url.rsplit("/", 2)[0]
-        if version >= Version("3.2.0"):
-            url = "{0}/astyle%20{1}/astyle-{2}.tar.bz2"
-        else:
-            url = "{0}/astyle%20{1}/astyle_{2}_linux.tar.gz"
-        return url.format(root, version.up_to(2), version)
+        url = f"{root}/astyle%20{version.up_to(2)}/astyle-{version}.tar.bz2"
+        if version < Version("3.2.0"):
+            url = f"{root}/astyle%20{version.up_to(2)}/astyle_{version}_linux.tar.gz"
+        return url
 
 
 class CMakeBuilder(CMakeBuilder):

--- a/var/spack/repos/builtin/packages/astyle/package.py
+++ b/var/spack/repos/builtin/packages/astyle/package.py
@@ -41,7 +41,7 @@ class Astyle(CMakePackage, MakefilePackage):
 
     def url_for_version(self, version):
         root = self.url.rsplit("/", 2)[0]
-        if version >= Version('3.2.0'):
+        if version >= Version("3.2.0"):
             url = "{0}/astyle%20{1}/astyle-{2}.tar.bz2"
         else:
             url = "{0}/astyle%20{1}/astyle_{2}_linux.tar.gz"
@@ -49,14 +49,12 @@ class Astyle(CMakePackage, MakefilePackage):
 
 
 class CMakeBuilder(CMakeBuilder):
-
     def cmake_args(self):
         args = []
         return args
 
 
 class MakefileBuilder(MakefileBuilder):
-
     @property
     def build_directory(self):
         return join_path(self.stage.source_path, "build", self.pkg.compiler.name)


### PR DESCRIPTION
This is a major modification of the "astyle" package which shifted from makefile to cmake at 3.2.1
Compatibility with makefile versions is ensured.

Some interrogations I have, related to the package or more general to spack, I don't know:
- Despite it is a cmake package, and depends_on("cmake") is set, it may not work without setting ^cmake.
- As well "spack versions" does not benefit from url_for_version.

I would be pleased to have a review from @alalazo 