### PR TITLE
Fix Lua providers

### DIFF
--- a/lib/spack/spack/build_systems/lua.py
+++ b/lib/spack/spack/build_systems/lua.py
@@ -29,15 +29,12 @@ class LuaPackage(spack.package_base.PackageBase):
 
     with when("build_system=lua"):
         depends_on("lua-lang")
-        extends("lua", when="^lua")
-        with when("^lua-luajit"):
-            extends("lua-luajit")
-            depends_on("luajit")
-            depends_on("lua-luajit+lualinks")
-        with when("^lua-luajit-openresty"):
-            extends("lua-luajit-openresty")
-            depends_on("luajit")
-            depends_on("lua-luajit-openresty+lualinks")
+        with when("^[virtuals=lua-lang] lua"):
+            extends("lua")
+        with when("^[virtuals=lua-lang] lua-luajit"):
+            extends("lua-luajit+lualinks")
+        with when("^[virtuals=lua-lang] lua-luajit-openresty"):
+            extends("lua-luajit-openresty+lualinks")
 
     @property
     def lua(self):


### PR DESCRIPTION
Close #41407 

I don't know much about Lua. Form what I can tell reading spack doc, Lua has multiple providers, `lua-lang` and `luajit`, and the latter is a subset of the former.

Investigating #41407 problem, I realised that in the DAG both `lua` and `lua-jit-openresty` were picked up. But to me it sounds like there should be just one "interpreter" in the DAG, similarly to what happens for Python.

This seems confirmed also by how `provides` are defined. Indeed, `lua-luajit-openresty` either provides both `lua-lang` and `luajit` together or none.

https://github.com/spack/spack/blob/d983ac35fe6ead23400269db3f445b9141e88302/var/spack/repos/builtin/packages/lua-luajit-openresty/package.py#L33

I still have some doubts about this, and I will investigate further and I'll report here.