### PR TITLE
Update recipe for Palace v0.12.0

### DIFF
--- a/var/spack/repos/builtin/packages/palace/package.py
+++ b/var/spack/repos/builtin/packages/palace/package.py
@@ -17,16 +17,12 @@ class Palace(CMakePackage):
     maintainers("sebastiangrimberg")
 
     version("develop", branch="main")
+    version("0.12.0", tag="v0.12.0", commit="8c192071206466638d5818048ee712e1fada386f")
     version("0.11.2", tag="v0.11.2", commit="6c3aa5f84a934a6ddd58022b2945a1bdb5fa329d")
 
-    variant("shared", default=True, description="Enables the build of shared libraries")
+    variant("shared", default=True, description="Build shared libraries")
     variant("int64", default=False, description="Use 64 bit integers")
-    variant("openmp", default=False, description="Use OpenMP")
-    variant(
-        "gslib",
-        default=True,
-        description="Build with GSLIB library for high-order field interpolation",
-    )
+    variant("openmp", default=False, description="Use OpenMP for shared-memory parallelism")
     variant(
         "superlu-dist", default=True, description="Build with SuperLU_DIST sparse direct solver"
     )
@@ -34,9 +30,16 @@ class Palace(CMakePackage):
     variant("mumps", default=False, description="Build with MUMPS sparse direct solver")
     variant("slepc", default=True, description="Build with SLEPc eigenvalue solver")
     variant("arpack", default=False, description="Build with ARPACK eigenvalue solver")
+    variant("libxsmm", default=True, description="Build with LIBXSMM backend for libCEED")
+    variant("magma", default=True, description="Build with MAGMA backend for libCEED")
+    variant(
+        "gslib",
+        default=True,
+        description="Build with GSLIB library for high-order field interpolation",
+    )
 
     # Dependencies
-    depends_on("cmake@3.13:", type="build")
+    depends_on("cmake@3.21:", type="build")
     depends_on("pkgconfig", type="build")
     depends_on("mpi")
     depends_on("zlib-api")
@@ -81,7 +84,8 @@ class Palace(CMakePackage):
         depends_on("mumps~openmp", when="~openmp")
 
     with when("+slepc"):
-        depends_on("slepc ^petsc+mpi+double+complex")
+        depends_on("slepc")
+        depends_on("petsc+mpi+double+complex")
         depends_on("petsc+shared", when="+shared")
         depends_on("petsc~shared", when="~shared")
         depends_on("petsc+int64", when="+int64")
@@ -94,8 +98,19 @@ class Palace(CMakePackage):
         depends_on("arpack-ng+shared", when="+shared")
         depends_on("arpack-ng~shared", when="~shared")
 
-    # Palace always builds its own internal MFEM, GSLIB
+    with when("+libxsmm"):
+        depends_on("libxsmm@main")
+        depends_on("libxsmm+shared", when="+shared")
+        depends_on("libxsmm~shared", when="~shared")
+
+    with when("+magma"):
+        depends_on("magma")
+        depends_on("magma+shared", when="+shared")
+        depends_on("magma~shared", when="~shared")
+
+    # Palace always builds its own internal MFEM, libCEED, and GSLIB
     conflicts("mfem")
+    conflicts("libceed")
     conflicts("gslib")
 
     # More dependency variant conflicts
@@ -108,12 +123,14 @@ class Palace(CMakePackage):
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("PALACE_WITH_64BIT_INT", "int64"),
             self.define_from_variant("PALACE_WITH_OPENMP", "openmp"),
-            self.define_from_variant("PALACE_WITH_GSLIB", "gslib"),
             self.define_from_variant("PALACE_WITH_SUPERLU", "superlu-dist"),
             self.define_from_variant("PALACE_WITH_STRUMPACK", "strumpack"),
             self.define_from_variant("PALACE_WITH_MUMPS", "mumps"),
             self.define_from_variant("PALACE_WITH_SLEPC", "slepc"),
             self.define_from_variant("PALACE_WITH_ARPACK", "arpack"),
+            self.define_from_variant("PALACE_WITH_LIBXSMM", "libxsmm"),
+            self.define_from_variant("PALACE_WITH_MAGMA", "magma"),
+            self.define_from_variant("PALACE_WITH_GSLIB", "gslib"),
             self.define("PALACE_BUILD_EXTERNAL_DEPS", False),
         ]
 
@@ -132,6 +149,12 @@ class Palace(CMakePackage):
             args += [self.define("STRUMPACK_REQUIRED_PACKAGES", "LAPACK;BLAS;MPI;MPI_Fortran")]
         if "+mumps" in self.spec:
             args += [self.define("MUMPS_REQUIRED_PACKAGES", "LAPACK;BLAS;MPI;MPI_Fortran")]
+
+        # Allow internal libCEED build to find LIBXSMM, MAGMA
+        if "+libxsmm" in self.spec:
+            args += [self.define("LIBXSMM_DIR", self.spec["libxsmm"].prefix)]
+        if "+magma" in self.spec:
+            args += [self.define("MAGMA_DIR", self.spec["magma"].prefix)]
 
         return args
 


### PR DESCRIPTION
Update Spack build recipe for Palace v0.12.0, released in Dec. 2023.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
