### PR TITLE
neovim (and lua deps): use Lua providers for describing dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/lua-ffi/package.py
+++ b/var/spack/repos/builtin/packages/lua-ffi/package.py
@@ -23,4 +23,4 @@ class LuaFfi(LuaPackage):
         commit="a1cb731b08c91643b0665935eb5622b3d621211b",
     )
 
-    depends_on("lua@5.1:5.1.99")
+    depends_on("lua-lang@5.1")

--- a/var/spack/repos/builtin/packages/lua-lpeg/package.py
+++ b/var/spack/repos/builtin/packages/lua-lpeg/package.py
@@ -26,4 +26,4 @@ class LuaLpeg(LuaPackage):
         expand=False,
     )
 
-    depends_on("lua@:5.1.9", when="@:0.12.1^lua")
+    depends_on("lua-lang@:5.1.9", when="@:0.12.1 ^[virtuals=lua-lang] lua")

--- a/var/spack/repos/builtin/packages/lua-luaposix/package.py
+++ b/var/spack/repos/builtin/packages/lua-luaposix/package.py
@@ -23,4 +23,4 @@ class LuaLuaposix(LuaPackage):
     version("33.4.0", sha256="e66262f5b7fe1c32c65f17a5ef5ffb31c4d1877019b4870a5d373e2ab6526a21")
     version("33.2.1", sha256="4fb34dfea67f4cf3194cdecc6614c9aea67edc3c4093d34137669ea869c358e1")
 
-    depends_on("lua-bit32", when="^lua-lang@5.1:5.1.99")
+    depends_on("lua-bit32", when="^lua-lang@5.1")

--- a/var/spack/repos/builtin/packages/neovim/package.py
+++ b/var/spack/repos/builtin/packages/neovim/package.py
@@ -84,13 +84,12 @@ class Neovim(CMakePackage):
     )
 
     # depend on virtual, lua-luajit-openresty preferred
-    depends_on("lua-lang")
     depends_on("luajit", when="~no_luajit")
-    depends_on("lua@5.1:5.1.99", when="+no_luajit")
+    depends_on("lua-lang@5.1", when="+no_luajit")
 
     # dependencies to allow regular lua to work
-    depends_on("lua-ffi", when="^lua", type=("link", "run"))
-    depends_on("lua-bitlib", type=("link", "run"), when="^lua")
+    depends_on("lua-ffi", when="^[virtuals=lua-lang] lua", type=("link", "run"))
+    depends_on("lua-bitlib", when="^[virtuals=lua-lang] lua", type=("link", "run"))
 
     # base dependencies
     depends_on("cmake@3.0:", type="build")


### PR DESCRIPTION
This might help the concretizer in doing the right thing, lowering the risk of having more than one package that could be a provider for `lua-lang`.

- [x] #42392 