### PR TITLE
cellpose: new package @2.2.3

### DIFF
--- a/var/spack/repos/builtin/packages/cellpose/package.py
+++ b/var/spack/repos/builtin/packages/cellpose/package.py
@@ -1,0 +1,51 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Cellpose(PythonPackage):
+    """A generalist algorithm for cell and nucleus segmentation that can be optimized for
+    your own data"""
+
+    homepage = "https://cellpose.readthedocs.io/"
+    pypi = "cellpose/cellpose-2.2.3.tar.gz"
+
+    license("BSD-3-Clause", checked_by="A-N-Other")
+
+    version("2.2.3", sha256="7ff63cb60a154ce3c0a17ff05ed27d2aaaa1a24a4c7a8160c0a4c15443366618")
+
+    variant("cuda", default=True, description="Require py-torch built with CUDA support")
+    variant("gui", default=False, description="Build the GUI")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools-scm", type="build")
+    depends_on("py-pytest-runner", type="build")
+
+    depends_on("py-numpy@1.20.0:", type=("build", "run"))
+    depends_on("py-scipy", type=("build", "run"))
+    depends_on("py-natsort", type=("build", "run"))
+    depends_on("py-tifffile", type=("build", "run"))
+    depends_on("py-tqdm", type=("build", "run"))
+    depends_on("py-numba@0.53.0:", type=("build", "run"))
+    depends_on("py-llvmlite", type=("build", "run"))
+    depends_on("py-numpy@1.20.0:", type=("build", "run"))
+    depends_on("py-fastremap", type=("build", "run"))
+    depends_on("py-imagecodecs", type=("build", "run"))
+    depends_on("py-roifile", type=("build", "run"))
+
+    # provides `cv2` in place of opencv-python-headless specified in setup.py
+    # +ximgproc is required from the contrib modules
+    depends_on("opencv +python3+ximgproc", type=("build", "run"))
+
+    depends_on("py-torch@1.6: +cuda", type=("build", "run"), when="+cuda")
+    depends_on("py-torch@1.6:", type=("build", "run"), when="~cuda")
+
+    depends_on("py-pyqtgraph@0.11.0:", type=("build", "run"), when="+gui")
+    depends_on("py-pyqt5", type=("build", "run"), when="+gui")
+    depends_on("py-pyqt5-sip", type=("build", "run"), when="+gui")
+    depends_on("py-qtpy", type=("build", "run"), when="+gui")
+    depends_on("py-superqt", type=("build", "run"), when="+gui")
+    depends_on("py-google-cloud-storage", type=("build", "run"), when="+gui")

--- a/var/spack/repos/builtin/packages/cellpose/package.py
+++ b/var/spack/repos/builtin/packages/cellpose/package.py
@@ -30,19 +30,17 @@ class Cellpose(PythonPackage):
     depends_on("py-tqdm", type=("build", "run"))
     depends_on("py-numba@0.53.0:", type=("build", "run"))
     depends_on("py-llvmlite", type=("build", "run"))
-    depends_on("py-numpy@1.20.0:", type=("build", "run"))
+    depends_on("py-torch@1.6:", type=("build", "run"))
+    # `copencv` provides `cv2` in place of opencv-python-headless specified in setup.py
+    # +ximgproc is required from the contrib modules
+    depends_on("opencv +python3+ximgproc", type=("build", "run"))
     depends_on("py-fastremap", type=("build", "run"))
     depends_on("py-imagecodecs", type=("build", "run"))
     depends_on("py-roifile", type=("build", "run"))
-    depends_on("py-torch@1.6:", type=("build", "run"))
-
-    # provides `cv2` in place of opencv-python-headless specified in setup.py
-    # +ximgproc is required from the contrib modules
-    depends_on("opencv +python3+ximgproc", type=("build", "run"))
 
     depends_on("py-pyqtgraph@0.11.0:", type=("build", "run"), when="+gui")
-    depends_on("py-pyqt5", type=("build", "run"), when="+gui")
-    depends_on("py-pyqt5-sip", type=("build", "run"), when="+gui")
+    depends_on("py-pyqt6", type=("build", "run"), when="+gui")
+    depends_on("py-pyqt6-sip", type=("build", "run"), when="+gui")
     depends_on("py-qtpy", type=("build", "run"), when="+gui")
     depends_on("py-superqt", type=("build", "run"), when="+gui")
     depends_on("py-google-cloud-storage", type=("build", "run"), when="+gui")

--- a/var/spack/repos/builtin/packages/cellpose/package.py
+++ b/var/spack/repos/builtin/packages/cellpose/package.py
@@ -17,7 +17,6 @@ class Cellpose(PythonPackage):
 
     version("2.2.3", sha256="7ff63cb60a154ce3c0a17ff05ed27d2aaaa1a24a4c7a8160c0a4c15443366618")
 
-    variant("cuda", default=True, description="Require py-torch built with CUDA support")
     variant("gui", default=False, description="Build the GUI")
 
     depends_on("py-setuptools", type="build")
@@ -35,13 +34,11 @@ class Cellpose(PythonPackage):
     depends_on("py-fastremap", type=("build", "run"))
     depends_on("py-imagecodecs", type=("build", "run"))
     depends_on("py-roifile", type=("build", "run"))
+    depends_on("py-torch@1.6:", type=("build", "run"))
 
     # provides `cv2` in place of opencv-python-headless specified in setup.py
     # +ximgproc is required from the contrib modules
     depends_on("opencv +python3+ximgproc", type=("build", "run"))
-
-    depends_on("py-torch@1.6: +cuda", type=("build", "run"), when="+cuda")
-    depends_on("py-torch@1.6:", type=("build", "run"), when="~cuda")
 
     depends_on("py-pyqtgraph@0.11.0:", type=("build", "run"), when="+gui")
     depends_on("py-pyqt5", type=("build", "run"), when="+gui")

--- a/var/spack/repos/builtin/packages/py-fastremap/package.py
+++ b/var/spack/repos/builtin/packages/py-fastremap/package.py
@@ -11,7 +11,7 @@ class PyFastremap(PythonPackage):
     Numpy arrays between C and Fortran order using an in-place transposition"""
 
     homepage = "https://github.com/seung-lab/fastremap/"
-    pypi = "fastremap/fastremap-1.2.1.tar.gz"
+    pypi = "fastremap/fastremap-1.14.1.tar.gz"
 
     license("LGPL-3.0", checked_by="A-N-Other")
 

--- a/var/spack/repos/builtin/packages/py-fastremap/package.py
+++ b/var/spack/repos/builtin/packages/py-fastremap/package.py
@@ -18,7 +18,7 @@ class PyFastremap(PythonPackage):
     version("1.14.1", sha256="067d42d6cb3b1b0789889efd1d7fae58006c82ada4a8446d40e9e838b358ee7c")
 
     depends_on("python@3.7:3", type=("build", "run"))
-    
+
     depends_on("py-setuptools", type="build")
     depends_on("py-pbr", type="build")
     depends_on("py-cython", type="build")

--- a/var/spack/repos/builtin/packages/py-fastremap/package.py
+++ b/var/spack/repos/builtin/packages/py-fastremap/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyFastremap(PythonPackage):
+    """Renumber and relabel Numpy arrays at C++ speed and physically convert rectangular
+    Numpy arrays between C and Fortran order using an in-place transposition"""
+
+    homepage = "https://github.com/seung-lab/fastremap/"
+    pypi = "fastremap/fastremap-1.2.1.tar.gz"
+
+    license("LGPL-3.0", checked_by="A-N-Other")
+
+    version("1.14.1", sha256="067d42d6cb3b1b0789889efd1d7fae58006c82ada4a8446d40e9e838b358ee7c")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-pbr", type="build")
+    depends_on("py-cython", type="build")
+
+    depends_on("py-numpy", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-fastremap/package.py
+++ b/var/spack/repos/builtin/packages/py-fastremap/package.py
@@ -17,6 +17,8 @@ class PyFastremap(PythonPackage):
 
     version("1.14.1", sha256="067d42d6cb3b1b0789889efd1d7fae58006c82ada4a8446d40e9e838b358ee7c")
 
+    depends_on("python@3.7:3", type=("build", "run"))
+    
     depends_on("py-setuptools", type="build")
     depends_on("py-pbr", type="build")
     depends_on("py-cython", type="build")

--- a/var/spack/repos/builtin/packages/py-pyqtgraph/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqtgraph/package.py
@@ -20,5 +20,5 @@ class PyPyqtgraph(PythonPackage):
     depends_on("python@3.8:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
 
-    depends_on("py-numpy@1.22:", type=("build", "run"))
+    depends_on("py-numpy@1.20:", type=("build", "run"))
     depends_on("py-pyqt5", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pyqtgraph/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqtgraph/package.py
@@ -21,4 +21,5 @@ class PyPyqtgraph(PythonPackage):
     depends_on("py-setuptools", type="build")
 
     depends_on("py-numpy@1.20:", type=("build", "run"))
-    depends_on("py-pyqt5", type=("build", "run"))
+    # This dependency listed in README.md ...
+    depends_on("py-pyqt6", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pyqtgraph/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqtgraph/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPyqtgraph(PythonPackage):
+    """PyQtGraph is a pure-python graphics and GUI library intended for use in mathematics,
+    scientific, and engineering applications"""
+
+    homepage = "http://www.pyqtgraph.org/"
+    pypi = "pyqtgraph/pyqtgraph-0.13.3.tar.gz"
+
+    license("MIT", checked_by="A-N-Other")
+
+    version("0.13.3", sha256="58108d8411c7054e0841d8b791ee85e101fc296b9b359c0e01dde38a98ff2ace")
+
+    depends_on("python@3.9:")
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-numpy@1.22:", type=("build", "run"))
+    depends_on("py-pyqt5", type=("build", "run"))
+

--- a/var/spack/repos/builtin/packages/py-pyqtgraph/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqtgraph/package.py
@@ -22,4 +22,3 @@ class PyPyqtgraph(PythonPackage):
 
     depends_on("py-numpy@1.22:", type=("build", "run"))
     depends_on("py-pyqt5", type=("build", "run"))
-

--- a/var/spack/repos/builtin/packages/py-pyqtgraph/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqtgraph/package.py
@@ -17,7 +17,7 @@ class PyPyqtgraph(PythonPackage):
 
     version("0.13.3", sha256="58108d8411c7054e0841d8b791ee85e101fc296b9b359c0e01dde38a98ff2ace")
 
-    depends_on("python@3.9:")
+    depends_on("python@3.8:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
 
     depends_on("py-numpy@1.22:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-roifile/package.py
+++ b/var/spack/repos/builtin/packages/py-roifile/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyRoifile(PythonPackage):
+    """Roifile is a Python library to read, write, create, and plot ImageJ ROIs"""
+
+    homepage = "https://www.cgohlke.com/"
+    pypi = "roifile/roifile-2024.1.10.tar.gz"
+
+    license("BSD-3-Clause", checked_by="A-N-Other")
+
+    version("2024.1.10", sha256="8bbc05a96c0a291429214cb6829426378e89931d1a7d3ad945aa2fea5765e434")
+
+    variant("all", default=True, description="Enable TIFF support")
+
+    depends_on("python@3.9:")
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-numpy", type=("build", "run"))
+
+    depends_on("py-matplotlib", type=("build", "run"), when="+all")
+    depends_on("py-tifffile", type=("build", "run"), when="+all")

--- a/var/spack/repos/builtin/packages/py-roifile/package.py
+++ b/var/spack/repos/builtin/packages/py-roifile/package.py
@@ -18,7 +18,7 @@ class PyRoifile(PythonPackage):
 
     variant("all", default=True, description="Enable TIFF support")
 
-    depends_on("python@3.9:")
+    depends_on("python@3.9:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
 
     depends_on("py-numpy", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-superqt/package.py
+++ b/var/spack/repos/builtin/packages/py-superqt/package.py
@@ -20,7 +20,7 @@ class PySuperqt(PythonPackage):
     depends_on("py-hatchling", type="build")
     depends_on("py-hatch-vcs", type="build")
 
-    depends_on("packaging", type=("build", "run"))
+    depends_on("py-packaging", type=("build", "run"))
     depends_on("py-pygments@2.4:", type=("build", "run"))
     depends_on("py-qtpy@1.1:", type=("build", "run"))
     depends_on("py-typing-extensions@3.7.4.3:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-superqt/package.py
+++ b/var/spack/repos/builtin/packages/py-superqt/package.py
@@ -16,7 +16,7 @@ class PySuperqt(PythonPackage):
 
     version("0.6.1", sha256="f1a9e0499c4bbcef34b6f895eb57cd41301b3799242cd030029238124184dade")
 
-    depends_on("python@3.8:")
+    depends_on("python@3.8:", type=("build", "run"))
     depends_on("py-hatchling", type="build")
     depends_on("py-hatch-vcs", type="build")
 

--- a/var/spack/repos/builtin/packages/py-superqt/package.py
+++ b/var/spack/repos/builtin/packages/py-superqt/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySuperqt(PythonPackage):
+    """Missing widgets and components for PyQt/PySide"""
+
+    homepage = "https://pyapp-kit.github.io/superqt/"
+    pypi = "superqt/superqt-0.6.1.tar.gz"
+
+    license("BSD-3-Clause", checked_by="A-N-Other")
+
+    version("0.6.1", sha256="f1a9e0499c4bbcef34b6f895eb57cd41301b3799242cd030029238124184dade")
+
+    depends_on("python@3.8:")
+    depends_on("py-hatchling", type="build")
+    depends_on("py-hatch-vcs", type="build")
+
+    depends_on("py-pygments@2.4:", type=("build", "run"))
+    depends_on("py-qtpy@1.1:", type=("build", "run"))
+    depends_on("py-typing-extensions@3.7.4.3:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-superqt/package.py
+++ b/var/spack/repos/builtin/packages/py-superqt/package.py
@@ -20,6 +20,9 @@ class PySuperqt(PythonPackage):
     depends_on("py-hatchling", type="build")
     depends_on("py-hatch-vcs", type="build")
 
+    depends_on("packaging", type=("build", "run"))
     depends_on("py-pygments@2.4:", type=("build", "run"))
     depends_on("py-qtpy@1.1:", type=("build", "run"))
     depends_on("py-typing-extensions@3.7.4.3:", type=("build", "run"))
+
+    conflicts("^py-typing-extensions@3.10.0.0")


### PR DESCRIPTION
Adding the `cellpose` package (Python CLI app, so I'm dropping the `py-` prefix). Adding also 4 new dependencies.

Builds and installs successfully on our `linux-rocky8-icelake` systems.