### PR TITLE
Remove caching in generated Dockerfiles

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -118,7 +118,5 @@ jobs:
           context: dockerfiles/${{ matrix.dockerfile[0] }}
           platforms: ${{ matrix.dockerfile[1] }}
           push: ${{ github.event_name != 'pull_request' }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/generate_spack_yaml_containerize.sh
+++ b/.github/workflows/generate_spack_yaml_containerize.sh
@@ -6,5 +6,4 @@
 &&   echo "    images:" \
 &&   echo "      os: \"${SPACK_YAML_OS}\"" \
 &&   echo "      spack:" \
-&&   echo "        resolve_sha: True" \
 &&   echo "        ref: ${GITHUB_REF}") > spack.yaml

--- a/.github/workflows/generate_spack_yaml_containerize.sh
+++ b/.github/workflows/generate_spack_yaml_containerize.sh
@@ -6,4 +6,5 @@
 &&   echo "    images:" \
 &&   echo "      os: \"${SPACK_YAML_OS}\"" \
 &&   echo "      spack:" \
+&&   echo "        resolve_sha: True" \
 &&   echo "        ref: ${GITHUB_REF}") > spack.yaml


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

The cache type we are using doesn't work as expected with multiple images built in the same repository. Since we just build containers once a day, remove caching for now. 
