### PR TITLE
ASP-based solver: improve reusing nodes with gcc-runtime

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -626,14 +626,13 @@ class ViewDescriptor:
             new: If a string, create a FilesystemView rooted at that path. Default None. This
                 should only be used to regenerate the view, and cannot be used to access specs.
         """
-        root = new if new else self._current_root
-        if not root:
+        path = new if new else self._current_root
+        if not path:
             # This can only be hit if we write a future bug
             raise SpackEnvironmentViewError(
-                "Attempting to get nonexistent view from environment. "
-                f"View root is at {self.root}"
+                f"Attempting to get nonexistent view from environment. View root is at {self.root}"
             )
-        return self._view(root)
+        return self._view(path)
 
     def _view(self, root: str) -> SimpleFilesystemView:
         """Returns a view object for a given root dir."""
@@ -678,7 +677,9 @@ class ViewDescriptor:
 
         # Filter selected, installed specs
         with spack.store.STORE.db.read_transaction():
-            return [s for s in specs if s in self and s.installed]
+            result = [s for s in specs if s in self and s.installed]
+
+        return self._exclude_duplicate_runtimes(result)
 
     def regenerate(self, concrete_roots: List[Spec]) -> None:
         specs = self.specs_for_view(concrete_roots)
@@ -764,6 +765,26 @@ class ViewDescriptor:
                 msg = "Failed to remove old view at %s\n" % old_root
                 msg += str(e)
                 tty.warn(msg)
+
+    def _exclude_duplicate_runtimes(self, nodes):
+        all_runtimes = spack.repo.PATH.packages_with_tags("runtime")
+        runtimes_by_name = {}
+        for s in nodes:
+            if s.name not in all_runtimes:
+                continue
+            runtimes_by_name.setdefault(s.name, []).append(s)
+
+        runtimes_excluded_from_view = []
+        for name, runtime_duplicates in runtimes_by_name.items():
+            if len(runtime_duplicates) == 1:
+                continue
+            runtime_duplicates.sort(key=lambda x: x.version)
+            runtimes_excluded_from_view.extend(runtime_duplicates[:-1])
+
+        if not runtimes_excluded_from_view:
+            return nodes
+
+        return [x for x in nodes if x not in runtimes_excluded_from_view]
 
 
 def _create_environment(path):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -768,23 +768,15 @@ class ViewDescriptor:
 
     def _exclude_duplicate_runtimes(self, nodes):
         all_runtimes = spack.repo.PATH.packages_with_tags("runtime")
-        runtimes_by_name = {}
+        result, runtimes_by_name = [], {}
         for s in nodes:
             if s.name not in all_runtimes:
+                result.append(s)
                 continue
-            runtimes_by_name.setdefault(s.name, []).append(s)
-
-        runtimes_excluded_from_view = []
-        for name, runtime_duplicates in runtimes_by_name.items():
-            if len(runtime_duplicates) == 1:
-                continue
-            runtime_duplicates.sort(key=lambda x: x.version)
-            runtimes_excluded_from_view.extend(runtime_duplicates[:-1])
-
-        if not runtimes_excluded_from_view:
-            return nodes
-
-        return [x for x in nodes if x not in runtimes_excluded_from_view]
+            current_runtime = runtimes_by_name.get(s.name, s)
+            runtimes_by_name[s.name] = max(current_runtime, s)
+        result.extend(runtimes_by_name.values())
+        return result
 
 
 def _create_environment(path):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -768,15 +768,13 @@ class ViewDescriptor:
 
     def _exclude_duplicate_runtimes(self, nodes):
         all_runtimes = spack.repo.PATH.packages_with_tags("runtime")
-        result, runtimes_by_name = [], {}
+        runtimes_by_name = {}
         for s in nodes:
             if s.name not in all_runtimes:
-                result.append(s)
                 continue
             current_runtime = runtimes_by_name.get(s.name, s)
-            runtimes_by_name[s.name] = max(current_runtime, s)
-        result.extend(runtimes_by_name.values())
-        return result
+            runtimes_by_name[s.name] = max(current_runtime, s, key=lambda x: x.version)
+        return [x for x in nodes if x.name not in all_runtimes or runtimes_by_name[x.name] == x]
 
 
 def _create_environment(path):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1786,6 +1786,11 @@ class SpackSolverSetup:
                 dep = dspec.spec
 
                 if spec.concrete:
+                    # GCC runtime is solved again by clingo, even on concrete specs, to give
+                    # the possibility to reuse specs built against a different runtime.
+                    if dep.name == "gcc-runtime":
+                        continue
+
                     # We know dependencies are real for concrete specs. For abstract
                     # specs they just mean the dep is somehow in the DAG.
                     for dtype in dt.ALL_FLAGS:

--- a/lib/spack/spack/test/concretize_compiler_runtimes.py
+++ b/lib/spack/spack/test/concretize_compiler_runtimes.py
@@ -60,3 +60,36 @@ def test_external_nodes_do_not_have_runtimes(runtime_repo, mutable_config, tmp_p
     assert a.dependencies("gcc-runtime")
     assert a.dependencies("b")
     assert not b.dependencies("gcc-runtime")
+
+
+@pytest.mark.parametrize(
+    "root_str,reused_str,expected,nruntime",
+    [
+        # The reused runtime is older than we need, thus we'll add a more recent one for a
+        ("a%gcc@10.2.1", "b%gcc@4.5.0", {"a": "gcc-runtime@10.2.1", "b": "gcc-runtime@4.5.0"}, 2),
+        # The root is compiled with an older compiler, thus we'll reuse the runtime from b
+        ("a%gcc@4.5.0", "b%gcc@10.2.1", {"a": "gcc-runtime@10.2.1", "b": "gcc-runtime@10.2.1"}, 1),
+    ],
+)
+def test_reusing_specs_with_gcc_runtime(root_str, reused_str, expected, nruntime, runtime_repo):
+    """Tests that we can reuse specs with a "gcc-runtime" leaf node. In particular, checks
+    that the semantic for gcc-runtimes versions accounts for reused packages too.
+    """
+    reused_spec = spack.spec.Spec(reused_str).concretized()
+    assert f"{expected['b']}" in reused_spec
+
+    setup = spack.solver.asp.SpackSolverSetup(tests=False)
+    driver = spack.solver.asp.PyclingoDriver()
+    result, _, _ = driver.solve(
+        setup, [spack.spec.Spec(f"{root_str} ^{reused_str}")], reuse=[reused_spec]
+    )
+
+    root = result.specs[0]
+
+    runtime_a = root.dependencies("gcc-runtime")[0]
+    assert runtime_a.satisfies(expected["a"])
+    runtime_b = root["b"].dependencies("gcc-runtime")[0]
+    assert runtime_b.satisfies(expected["b"])
+
+    runtimes = [x for x in root.traverse() if x.name == "gcc-runtime"]
+    assert len(runtimes) == nruntime


### PR DESCRIPTION
This PR skips emitting dependency constraints on `gcc-runtime`, for concrete specs that are considered for reuse. Instead, an appropriate version of `gcc-runtime` is recomputed considering also the concrete nodes from reused specs.

This ensures that root nodes in a DAG have always a runtime that is at a version greater or equal than their dependencies.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
