### PR TITLE
pv: Add version 1.8.5.

### DIFF
--- a/var/spack/repos/builtin/packages/pv/package.py
+++ b/var/spack/repos/builtin/packages/pv/package.py
@@ -12,9 +12,11 @@ class Pv(AutotoolsPackage):
     """
 
     homepage = "https://www.ivarch.com/programs/pv.shtml"
-    url = "https://www.ivarch.com/programs/sources/pv-1.6.6.tar.bz2"
+    url = "https://www.ivarch.com/programs/sources/pv-1.6.6.tar.gz"
 
-    license("Artistic-2.0")
+    license("GPL-3.0-or-later", when="@1.8.0:", checked_by="RemiLacroix-IDRIS")
+    license("Artistic-2.0", when="@:1.7.24", checked_by="RemiLacroix-IDRIS")
 
-    version("1.6.20", sha256="e831951eff0718fba9b1ef286128773b9d0e723e1fbfae88d5a3188814fdc603")
-    version("1.6.6", sha256="608ef935f7a377e1439c181c4fc188d247da10d51a19ef79bcdee5043b0973f1")
+    version("1.8.5", sha256="d22948d06be06a5be37336318de540a2215be10ab0163f8cd23a20149647b780")
+    version("1.6.20", sha256="b5f1ee79a370c5287e092b6e8f1084f026521fe0aecf25c44b9460b870319a9e")
+    version("1.6.6", sha256="94defb4183ae07c44219ba298d43c4991d6e203c29f74393d72ecad3b090508a")


### PR DESCRIPTION
Switch to "tar.gz" source packages as the "tar.bz2" archives are not available for newer versions.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
