### PR TITLE
foldseek: new package @8-ef4e960

### DIFF
--- a/var/spack/repos/builtin/packages/foldseek/package.py
+++ b/var/spack/repos/builtin/packages/foldseek/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Foldseek(CMakePackage):
+    """Foldseek enables fast and sensitive comparisons of large protein structure sets"""
+
+    homepage = "https://foldseek.com/"
+    url = "https://github.com/steineggerlab/foldseek/archive/refs/tags/8-ef4e960.tar.gz"
+
+    license("GPL-3.0-only", checked_by="A-N-Other")
+
+    version("8-ef4e960", sha256="c74d02c4924d20275cc567783b56fff10e76ed67f3d642f53c283f67c4180a1e")
+    version("7-04e0ec8", sha256="009d722d600248a680b9e1e9dcb3bf799f8be8de41e80a598b7f39a5ced54191")
+
+    depends_on("zlib-api")
+    depends_on("bzip2")
+    depends_on("openmpi")
+    depends_on("rust", type="build")


### PR DESCRIPTION
Adding `foldseek@8-ef4e960`. Install tested with `linux-rocky8-icelake`. Dependencies determined from the bioconda yaml file.