### PR TITLE
More updates for GitLab CI memory requests

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -8,6 +8,16 @@ ci:
   - match_behavior: first
     submapping:
     - match:
+      - py-torch
+      build-job:
+        tags: [ "spack", "huge" ]
+        variables:
+          CI_JOB_SIZE: huge
+          SPACK_BUILD_JOBS: "12"
+          KUBERNETES_CPU_REQUEST: 12000m
+          KUBERNETES_MEMORY_REQUEST: 46G
+
+    - match:
       - rust
       build-job:
         tags: [ "spack", "huge" ]
@@ -19,6 +29,7 @@ ci:
 
     - match:
       - py-tensorflow
+      - py-torchaudio
       build-job:
         tags: [ "spack", "huge" ]
         variables:
@@ -50,7 +61,6 @@ ci:
 
     - match:
       - llvm
-      - py-torch
       build-job:
         tags: [ "spack", "huge" ]
         variables:
@@ -62,7 +72,6 @@ ci:
     - match:
       - dealii
       - mxnet
-      - py-torchaudio
       - rocblas
       build-job:
         tags: [ "spack", "huge" ]

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -88,11 +88,9 @@ ci:
 
     - match:
       - ascent
-      - atk
       - axom
       - cistem
       - cmake
-      - ctffind
       - cuda
       - dray
       - dyninst
@@ -134,7 +132,6 @@ ci:
       - vtk-m
       - warpx
       - wrf
-      - wxwidgets
       build-job:
         tags: [ "spack", "large" ]
         variables:
@@ -336,7 +333,6 @@ ci:
       - tar
       - tcl
       - texinfo
-      - tut
       - unzip
       - util-linux-uuid
       - util-macros

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -175,8 +175,8 @@ ci:
         tags: [ "spack", "medium" ]
         variables:
           CI_JOB_SIZE: "medium"
-          SPACK_BUILD_JOBS: "4"
-          KUBERNETES_CPU_REQUEST: "4000m"
+          SPACK_BUILD_JOBS: "8"
+          KUBERNETES_CPU_REQUEST: "8000m"
           KUBERNETES_MEMORY_REQUEST: "6G"
 
     - match:
@@ -187,9 +187,19 @@ ci:
         tags: [ "spack", "medium" ]
         variables:
           CI_JOB_SIZE: "medium"
-          SPACK_BUILD_JOBS: "4"
-          KUBERNETES_CPU_REQUEST: "4000m"
+          SPACK_BUILD_JOBS: "8"
+          KUBERNETES_CPU_REQUEST: "8000m"
           KUBERNETES_MEMORY_REQUEST: "5G"
+
+    - match:
+      - parallelio
+      build-job:
+        tags: [ "spack", "medium" ]
+        variables:
+          CI_JOB_SIZE: "medium"
+          SPACK_BUILD_JOBS: "8"
+          KUBERNETES_CPU_REQUEST: "8000m"
+          KUBERNETES_MEMORY_REQUEST: "3G"
 
     - match:
       - adios2
@@ -238,7 +248,6 @@ ci:
       - openpmd-api
       - pagmo2
       - papyrus
-      - parallelio
       - parsec
       - petsc
       - pumi
@@ -280,8 +289,8 @@ ci:
         tags: [ "spack", "medium" ]
         variables:
           CI_JOB_SIZE: "medium"
-          SPACK_BUILD_JOBS: "2"
-          KUBERNETES_CPU_REQUEST: "2000m"
+          SPACK_BUILD_JOBS: "8"
+          KUBERNETES_CPU_REQUEST: "8000m"
           KUBERNETES_MEMORY_REQUEST: "3G"
 
     - match:
@@ -303,9 +312,18 @@ ci:
           KUBERNETES_MEMORY_REQUEST: "2G"
 
     - match:
+      - kokkos-nvcc-wrapper
+      build-job:
+        tags: [ "spack", "medium" ]
+        variables:
+          CI_JOB_SIZE: "medium"
+          SPACK_BUILD_JOBS: "8"
+          KUBERNETES_CPU_REQUEST: "8000m"
+          KUBERNETES_MEMORY_REQUEST: "1G"
+
+    - match:
       - ffmpeg
       - gperftools
-      - kokkos-nvcc-wrapper
       - samrai
       build-job:
         tags: [ "spack", "medium" ]

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -99,48 +99,30 @@ ci:
       - ascent
       - axom
       - cistem
-      - cmake
       - cuda
       - dray
-      - dyninst
       - ecp-data-vis-sdk
       - gcc
       - ginkgo
       - hdf5
-      - hipblas
-      - hpx
       - kokkos-kernels
-      - kokkos-nvcc-wrapper
-      - lbann
-      - magma
-      - mesa
       - mfem
       - mpich
       - netlib-lapack
-      - oce
       - openblas
       - openfoam
       - openturns
-      - parallelio
-      - plumed
-      - precice
-      - qt
       - raja
       - relion
-      - rocfft
       - rocsolver
       - rocsparse
-      - slate
       - strumpack
       - sundials
       - trilinos
-      - umpire
       - visit
       - vtk
       - vtk-h
       - vtk-m
-      - warpx
-      - wrf
       build-job:
         tags: [ "spack", "large" ]
         variables:
@@ -150,14 +132,72 @@ ci:
           KUBERNETES_MEMORY_REQUEST: 12G
 
     - match:
+      - hpx
+      - slate
+      - warpx
+      build-job:
+        tags: [ "spack", "large" ]
+        variables:
+          CI_JOB_SIZE: "large"
+          SPACK_BUILD_JOBS: "8"
+          KUBERNETES_CPU_REQUEST: "8000m"
+          KUBERNETES_MEMORY_REQUEST: "9G"
+
+    - match:
+      - hipblas
+      - rocfft
+      - umpire
+      build-job:
+        tags: [ "spack", "large" ]
+        variables:
+          CI_JOB_SIZE: "large"
+          SPACK_BUILD_JOBS: "8"
+          KUBERNETES_CPU_REQUEST: "8000m"
+          KUBERNETES_MEMORY_REQUEST: "8G"
+
+    - match:
+      - lbann
+      - magma
+      - mesa
+      - qt
+      build-job:
+        tags: [ "spack", "large" ]
+        variables:
+          CI_JOB_SIZE: "large"
+          SPACK_BUILD_JOBS: "8"
+          KUBERNETES_CPU_REQUEST: "8000m"
+          KUBERNETES_MEMORY_REQUEST: "7G"
+
+    - match:
+      - dyninst
+      - precice
+      build-job:
+        tags: [ "spack", "medium" ]
+        variables:
+          CI_JOB_SIZE: "medium"
+          SPACK_BUILD_JOBS: "4"
+          KUBERNETES_CPU_REQUEST: "4000m"
+          KUBERNETES_MEMORY_REQUEST: "6G"
+
+    - match:
+      - cmake
+      - plumed
+      - wrf
+      build-job:
+        tags: [ "spack", "medium" ]
+        variables:
+          CI_JOB_SIZE: "medium"
+          SPACK_BUILD_JOBS: "4"
+          KUBERNETES_CPU_REQUEST: "4000m"
+          KUBERNETES_MEMORY_REQUEST: "5G"
+
+    - match:
       - adios2
       - amrex
       - archer
       - ascent
       - autoconf-archive
       - axom
-      - binutils
-      - blaspp
       - blt
       - boost
       - butterflypack
@@ -168,15 +208,10 @@ ci:
       - conduit
       - curl
       - datatransferkit
-      - double-conversion
       - dray
-      - eigen
       - faodel
-      - ffmpeg
-      - fftw
       - fortrilinos
       - gettext
-      - gperftools
       - gptune
       - hdf5
       - heffte
@@ -188,7 +223,6 @@ ci:
       - lammps
       - lapackpp
       - legion
-      - libtool
       - libxml2
       - libzmq
       - llvm-openmp-ompt
@@ -196,7 +230,6 @@ ci:
       - mfem
       - mpich
       - mvapich2
-      - nasm
       - netlib-scalapack
       - omega-h
       - openblas
@@ -205,9 +238,8 @@ ci:
       - openpmd-api
       - pagmo2
       - papyrus
+      - parallelio
       - parsec
-      - pdt
-      - pegtl
       - petsc
       - pumi
       - py-beniget
@@ -221,7 +253,6 @@ ci:
       - py-warlock
       - py-warpx
       - raja
-      - samrai
       - slepc
       - slurm
       - sqlite
@@ -242,6 +273,47 @@ ci:
           SPACK_BUILD_JOBS: "2"
           KUBERNETES_CPU_REQUEST: "2000m"
           KUBERNETES_MEMORY_REQUEST: "4G"
+
+    - match:
+      - oce
+      build-job:
+        tags: [ "spack", "medium" ]
+        variables:
+          CI_JOB_SIZE: "medium"
+          SPACK_BUILD_JOBS: "2"
+          KUBERNETES_CPU_REQUEST: "2000m"
+          KUBERNETES_MEMORY_REQUEST: "3G"
+
+    - match:
+      - binutils
+      - blaspp
+      - double-conversion
+      - eigen
+      - fftw
+      - libtool
+      - nasm
+      - pegtl
+      - pdt
+      build-job:
+        tags: [ "spack", "medium" ]
+        variables:
+          CI_JOB_SIZE: "medium"
+          SPACK_BUILD_JOBS: "2"
+          KUBERNETES_CPU_REQUEST: "2000m"
+          KUBERNETES_MEMORY_REQUEST: "2G"
+
+    - match:
+      - ffmpeg
+      - gperftools
+      - kokkos-nvcc-wrapper
+      - samrai
+      build-job:
+        tags: [ "spack", "medium" ]
+        variables:
+          CI_JOB_SIZE: "medium"
+          SPACK_BUILD_JOBS: "2"
+          KUBERNETES_CPU_REQUEST: "2000m"
+          KUBERNETES_MEMORY_REQUEST: "1G"
 
     - match:
       - alsa-lib

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -15,7 +15,7 @@ ci:
           CI_JOB_SIZE: huge
           SPACK_BUILD_JOBS: "12"
           KUBERNETES_CPU_REQUEST: 12000m
-          KUBERNETES_MEMORY_REQUEST: 46G
+          KUBERNETES_MEMORY_REQUEST: 48G
 
     - match:
       - rust


### PR DESCRIPTION
Continues the work started in #42351

As before, these decisions were made based on the following metabase question:
https://metabase.spack.io/question/32-max-memory-per-package

For those without metabase access, a CSV of this data is attached:
[max_memory_per_package.csv](https://github.com/spack/spack/files/14127349/max_memory_per_package.csv)

This data was gathered between January 19, 2024, 12:01 PM and February 1, 2024, 10:15 AM (EST).
