### PR TITLE
preCICE: add v3.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -87,6 +87,7 @@ class Precice(CMakePackage):
     depends_on("eigen@3.2:")
     depends_on("eigen@:3.3.7", type="build", when="@:1.5")  # bug in prettyprint
     depends_on("libxml2")
+    depends_on("libxml2@:2.11.99", type="build", when="@:2.5.0")
     depends_on("mpi", when="+mpi")
     depends_on("petsc@3.6:", when="+petsc")
     depends_on("petsc@3.12:", when="+petsc@2.1.0:")

--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -23,6 +23,7 @@ class Precice(CMakePackage):
     license("LGPL-3.0-or-later")
 
     version("develop", branch="develop")
+    version("3.0.0", sha256="efe6cf505d9305af89c6da1fdba246199a75a1c63a6a22103773ed95341879ba")
     version("2.5.1", sha256="a5a37d3430eac395e885eb9cbbed9d0980a15e96c3e44763a3769fa7301e3b3a")
     version("2.5.0", sha256="76ec6ee0d1a66f6f3d3d2d11f03cfc5aa7ef4d9e5deb9b7a4b4455ec7f796c00")
     version("2.4.0", sha256="762e603fbcaa96c4fb0b378b7cb6789d09da0cf6193325603e5eeb13e4c7601c")


### PR DESCRIPTION
This PR adds version 3.0.0 of the xSDK member preCICE.

It also proactively adds a version conflict with libxml2 2.12+, which was fixed in preCICE version 2.5.1.
The libxml2 package currently doesn't contain versions past 2.10.3 @AlexanderRichert-NOAA.
