### PR TITLE
py-ucsf-pyem: updating to commit e92cd4d

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyfftw/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfftw/package.py
@@ -24,8 +24,8 @@ class PyPyfftw(PythonPackage):
     depends_on("python@3.8:", when="@0.13.1:")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-cython@0.29.18:1", type="build", when="@0.13:")
-    depends_on("py-cython@0.29:1", type="build", when="@:0.13")
+    depends_on("py-cython@0.29.18:0", type="build", when="@0.13:")
+    depends_on("py-cython@0.29:0", type="build", when="@:0.13")
 
     depends_on("py-numpy@1.20:1", type=("build", "run"), when="@0.13.1:")
     depends_on("py-numpy@1.16:1", type=("build", "run"), when="@0.13")

--- a/var/spack/repos/builtin/packages/py-pyfftw/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfftw/package.py
@@ -15,15 +15,24 @@ class PyPyfftw(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.13.1", sha256="09155e90a0c6d0c1f2d1f3668180a7de95fb9f83fef5137a112fb05978e87320")
+    version("0.13.0", sha256="da85102405c0bd95d57eb19e99b01a0729d8406cb204c3900894b873784253da")
     version("0.12.0", sha256="60988e823ca75808a26fd79d88dbae1de3699e72a293f812aa4534f8a0a58cb0")
     version("0.11.1", sha256="05ea28dede4c3aaaf5c66f56eb0f71849d0d50f5bc0f53ca0ffa69534af14926")
     version("0.10.4", sha256="739b436b7c0aeddf99a48749380260364d2dc027cf1d5f63dafb5f50068ede1a")
 
-    depends_on("fftw")
+    depends_on("python@3.8:", when="@0.13.1:")
+
     depends_on("py-setuptools", type="build")
-    depends_on("py-cython@0.29:0", type="build")
-    depends_on("py-numpy@1.6:", type=("build", "run"), when="@:0.10.4")
-    depends_on("py-numpy@1.10:1", type=("build", "run"), when="@0.11.0:")
+    depends_on("py-cython@0.29.18:1", type="build", when="@0.13:")
+    depends_on("py-cython@0.29:1", type="build", when="@:0.13")
+
+    depends_on("py-numpy@1.20:2", type=("build", "run"), when="@0.13.1:")
+    depends_on("py-numpy@1.16:2", type=("build", "run"), when="@0.13")
+    depends_on("py-numpy@1.10:2", type=("build", "run"), when="@0.11:0.13")
+    depends_on("py-numpy@1.6:2", type=("build", "run"), when="@:0.10.4")
+
+    depends_on("fftw")
 
     def setup_build_environment(self, env):
         env.append_flags("LDFLAGS", self.spec["fftw"].libs.search_flags)

--- a/var/spack/repos/builtin/packages/py-pyfftw/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfftw/package.py
@@ -21,18 +21,18 @@ class PyPyfftw(PythonPackage):
     version("0.11.1", sha256="05ea28dede4c3aaaf5c66f56eb0f71849d0d50f5bc0f53ca0ffa69534af14926")
     version("0.10.4", sha256="739b436b7c0aeddf99a48749380260364d2dc027cf1d5f63dafb5f50068ede1a")
 
-    depends_on("python@3.8:", when="@0.13.1:")
+    depends_on("python@3.8:", type=("build", "run"), when="@0.13.1:")
 
-    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@:59.4.0", type="build")
     depends_on("py-cython@0.29.18:0", type="build", when="@0.13:")
     depends_on("py-cython@0.29:0", type="build", when="@:0.13")
 
     depends_on("py-numpy@1.20:1", type=("build", "run"), when="@0.13.1:")
-    depends_on("py-numpy@1.16:1", type=("build", "run"), when="@0.13")
-    depends_on("py-numpy@1.10:1", type=("build", "run"), when="@0.11:0.13")
+    depends_on("py-numpy@1.16:1", type=("build", "run"), when="@0.13.0")
+    depends_on("py-numpy@1.10:1", type=("build", "run"), when="@0.11:0.12")
     depends_on("py-numpy@1.6:1", type=("build", "run"), when="@:0.10.4")
 
-    depends_on("fftw")
+    depends_on("fftw@3.3:")
 
     def setup_build_environment(self, env):
         env.append_flags("LDFLAGS", self.spec["fftw"].libs.search_flags)

--- a/var/spack/repos/builtin/packages/py-pyfftw/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfftw/package.py
@@ -27,10 +27,10 @@ class PyPyfftw(PythonPackage):
     depends_on("py-cython@0.29.18:1", type="build", when="@0.13:")
     depends_on("py-cython@0.29:1", type="build", when="@:0.13")
 
-    depends_on("py-numpy@1.20:2", type=("build", "run"), when="@0.13.1:")
-    depends_on("py-numpy@1.16:2", type=("build", "run"), when="@0.13")
-    depends_on("py-numpy@1.10:2", type=("build", "run"), when="@0.11:0.13")
-    depends_on("py-numpy@1.6:2", type=("build", "run"), when="@:0.10.4")
+    depends_on("py-numpy@1.20:1", type=("build", "run"), when="@0.13.1:")
+    depends_on("py-numpy@1.16:1", type=("build", "run"), when="@0.13")
+    depends_on("py-numpy@1.10:1", type=("build", "run"), when="@0.11:0.13")
+    depends_on("py-numpy@1.6:1", type=("build", "run"), when="@:0.10.4")
 
     depends_on("fftw")
 

--- a/var/spack/repos/builtin/packages/py-ucsf-pyem/package.py
+++ b/var/spack/repos/builtin/packages/py-ucsf-pyem/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
@@ -17,7 +19,7 @@ class PyUcsfPyem(PythonPackage):
 
     license("GPL-3.0-only", checked_by="A-N-Other")
 
-    # Using commits since releases haven't been updated in since 2019
+    # Using commits as releases haven't been updated in since 2019
     version("2024-02-01", commit="e92cd4d")
     version("2021-04-07", commit="ed0527f98657d21d887357426b74e5240d477fae")
 
@@ -34,8 +36,35 @@ class PyUcsfPyem(PythonPackage):
     depends_on("py-healpy@1.11:", type=("build", "run"))
     depends_on("py-natsort@6.0:", type=("build", "run"))
 
-    # Extracts files into bin for proper useage
+    script_list = [
+        "angdist.py",
+        "cfsc.py",
+        "csparc2star.py",
+        "ctf2star.py",
+        "disparticle.py",
+        "emcalc.py",
+        "map.py",
+        "mask.py",
+        "mcstar.py",
+        "par2star.py",
+        "pose.py",
+        "projection_subtraction.py",
+        "project.py",
+        "recenter.py",
+        "reconstruct.py",
+        "sort.py",
+        "stack.py",
+        "star2bild.py",
+        "star.py",
+        "subparticles.py",
+        "subset.py",
+        "varmap.py",
+    ]
+
+    # Extracts scripts into bin for proper usage, ensures +x where not set
     @run_after("install")
-    def extraction(self):
+    def install_scripts(self):
         mkdir(self.prefix.bin)
-        install("*.py", self.prefix.bin)
+        for script in self.script_list:
+            os.chmod(script, 0o755)
+            install(script, self.prefix.bin)

--- a/var/spack/repos/builtin/packages/py-ucsf-pyem/package.py
+++ b/var/spack/repos/builtin/packages/py-ucsf-pyem/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import glob
 import os
 
 from spack.package import *
@@ -20,15 +21,17 @@ class PyUcsfPyem(PythonPackage):
     license("GPL-3.0-only", checked_by="A-N-Other")
 
     # Using commits as releases haven't been updated in since 2019
-    version("2024-02-01", commit="e92cd4d")
+    version("2024-02-01", commit="e92cd4d40087c44945bce867a359838a806bd31f")
     version("2021-04-07", commit="ed0527f98657d21d887357426b74e5240d477fae")
 
     depends_on("py-setuptools", type="build")
+
+    # Requirement versions taken from requirements.txt
+    depends_on("py-future@0.15:", type=("build", "run"))
+    depends_on("py-numba@0.41:", type=("build", "run"))
     depends_on("py-numpy@1.14:", type=("build", "run"))
     depends_on("py-scipy@1.2:", type=("build", "run"))
     depends_on("py-matplotlib@2.2:", type=("build", "run"))
-    depends_on("py-future@0.15:", type=("build", "run"))
-    depends_on("py-numba@0.41:", type=("build", "run"))
     depends_on("py-seaborn@0.9:", type=("build", "run"))
     depends_on("py-pandas@0.23.4:", type=("build", "run"))
     depends_on("py-pathos@0.2.1:", type=("build", "run"))
@@ -36,35 +39,11 @@ class PyUcsfPyem(PythonPackage):
     depends_on("py-healpy@1.11:", type=("build", "run"))
     depends_on("py-natsort@6.0:", type=("build", "run"))
 
-    script_list = [
-        "angdist.py",
-        "cfsc.py",
-        "csparc2star.py",
-        "ctf2star.py",
-        "disparticle.py",
-        "emcalc.py",
-        "map.py",
-        "mask.py",
-        "mcstar.py",
-        "par2star.py",
-        "pose.py",
-        "projection_subtraction.py",
-        "project.py",
-        "recenter.py",
-        "reconstruct.py",
-        "sort.py",
-        "stack.py",
-        "star2bild.py",
-        "star.py",
-        "subparticles.py",
-        "subset.py",
-        "varmap.py",
-    ]
-
     # Extracts scripts into bin for proper usage, ensures +x where not set
     @run_after("install")
     def install_scripts(self):
         mkdir(self.prefix.bin)
-        for script in self.script_list:
-            os.chmod(script, 0o755)
-            install(script, self.prefix.bin)
+        for script in glob.glob("*.py"):
+            if script != "setup.py":
+                os.chmod(script, 0o755)
+                install(script, self.prefix.bin)

--- a/var/spack/repos/builtin/packages/py-ucsf-pyem/package.py
+++ b/var/spack/repos/builtin/packages/py-ucsf-pyem/package.py
@@ -15,9 +15,10 @@ class PyUcsfPyem(PythonPackage):
 
     maintainers("dorton21")
 
-    license("GPL-3.0-or-later")
+    license("GPL-3.0-only", checked_by="A-N-Other")
 
-    # Using commit since releases haven't been updated in 2 years
+    # Using commits since releases haven't been updated in since 2019
+    version("2024-02-01", commit="e92cd4d")
     version("2021-04-07", commit="ed0527f98657d21d887357426b74e5240d477fae")
 
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
Updating `py-ucsf-pyem` to the latest commit in GitHub. I've also updated the way the scripts are deployed into `prefix.bin` as it was a) installing `setup.py` and b) not all of them were executable.

Separately, install of the `py-pyfftw` dependency was failing, so I've updated that to `@0.13.1` as well.