### PR TITLE
openmm: Apply patch use `FindCUDAToolkit`

### DIFF
--- a/var/spack/repos/builtin/packages/openmm/package.py
+++ b/var/spack/repos/builtin/packages/openmm/package.py
@@ -27,7 +27,7 @@ class Openmm(CMakePackage, CudaPackage):
     install_targets = ["install", "PythonInstall"]
 
     depends_on("python@2.7:", type=("build", "run"))
-    depends_on("cmake@3.17:", type="build", when="@7.6.0:")
+    depends_on("cmake@3.17:", type="build", when="@7.5.1:")
     depends_on("cmake@3.1:", type="build")
     # https://github.com/openmm/openmm/issues/3317
     depends_on("doxygen@:1.9.1", type="build", when="@:7.6.0")
@@ -38,6 +38,15 @@ class Openmm(CMakePackage, CudaPackage):
     depends_on("py-numpy", type=("build", "run"))
     depends_on("cuda", when="+cuda", type=("build", "link", "run"))
     extends("python")
+
+    # Backport <https://github.com/openmm/openmm/pull/3154> to
+    # `openmm@7.5.1+cuda`, which is the version currently required by
+    # `py-alphafold`.
+    patch(
+        "https://github.com/openmm/openmm/pull/3154.patch?full_index=1",
+        sha256="90bc01b34cf998e90220669b3ed55cd3c42000ad364234033aac631ed754e9bd",
+        when="@7.5.1+cuda",
+    )
 
     def patch(self):
         install_string = 'set(PYTHON_SETUP_COMMAND "install ' '--prefix={0}")'.format(self.prefix)


### PR DESCRIPTION
`FindCUDA` has been deprecated for a few years, but it' used by `openmm@7.5.1`, which is the version required by `py-alphafold`: https://github.com/spack/spack/blob/8b88255b43bb1ae15505d072e86083f3d691b396/var/spack/repos/builtin/packages/py-alphafold/package.py#L52 OpenMM 7.6.0 [switched to using `FindCUDAToolkit`](https://github.com/openmm/openmm/pull/3154), which fixes for example configuration of the project when building on a node without a GPU.  I verified that the patch applies cleanly and with it I was able to successfully get past the cmake stage on a node without GPU when building `openmm@7.5.1%gcc@12.2.0+cuda ^cuda@12.2.0` (then I get an internal compiler error during the actual compilation, but that's another story).