### PR TITLE
khmer: new package @2.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/khmer/package.py
+++ b/var/spack/repos/builtin/packages/khmer/package.py
@@ -21,6 +21,7 @@ class Khmer(PythonPackage):
     conflicts("^python@3.12:")
 
     depends_on("py-setuptools@18:", type="build")
+    depends_on("pytest-runner@2", type="build")
     depends_on("py-screed@1:", type=("build", "run"))
     # abandoned `bz2file` dependency dropped in favour of the patch below
 
@@ -28,3 +29,4 @@ class Khmer(PythonPackage):
 
     def patch(self):
         filter_file("bz2file", "bz2", join_path("khmer", "kfile.py"))
+        filter_file("'bz2file', ", "", "setup.py")

--- a/var/spack/repos/builtin/packages/khmer/package.py
+++ b/var/spack/repos/builtin/packages/khmer/package.py
@@ -20,7 +20,7 @@ class Khmer(PythonPackage):
     # https://github.com/dib-lab/khmer/pull/1922 ...
     conflicts("^python@3.12:")
 
-    depends_on("py-setuptools@18:", type="build")
+    depends_on("py-setuptools@3.4.1:", type="build")
     depends_on("py-pytest-runner@2", type="build")
     depends_on("py-screed@1:", type=("build", "run"))
     # abandoned `bz2file` dependency dropped in favour of the patch below

--- a/var/spack/repos/builtin/packages/khmer/package.py
+++ b/var/spack/repos/builtin/packages/khmer/package.py
@@ -18,15 +18,13 @@ class Khmer(PythonPackage):
     version("2.1.1", sha256="a709606910bb8679bd8525e9d2bf6d1421996272e343b54cc18090feb2fdbe24")
 
     # https://github.com/dib-lab/khmer/pull/1922 ...
-    conflicts("python@3.12:")
+    conflicts("^python@3.12:")
 
     depends_on("py-setuptools@18:", type="build")
     depends_on("py-screed@1:", type=("build", "run"))
-    # abandoned `bz2file` dependency dropped in favour of the edits below
+    # abandoned `bz2file` dependency dropped in favour of the patch below
 
     depends_on("openmpi")
 
-    @run_before("install")
-    def patcher(self):
-        patchf = FileFilter(join_path("khmer", "kfile.py"))
-        patchf.filter("bz2file", "bz2")
+    def patch(self):
+        filter_file("bz2file", "bz2", join_path("khmer", "kfile.py"))

--- a/var/spack/repos/builtin/packages/khmer/package.py
+++ b/var/spack/repos/builtin/packages/khmer/package.py
@@ -21,7 +21,7 @@ class Khmer(PythonPackage):
     conflicts("^python@3.12:")
 
     depends_on("py-setuptools@18:", type="build")
-    depends_on("pytest-runner@2", type="build")
+    depends_on("py-pytest-runner@2", type="build")
     depends_on("py-screed@1:", type=("build", "run"))
     # abandoned `bz2file` dependency dropped in favour of the patch below
 

--- a/var/spack/repos/builtin/packages/khmer/package.py
+++ b/var/spack/repos/builtin/packages/khmer/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Khmer(PythonPackage):
+    """khmer is a software library and toolkit for k-mer based analysis and transformation
+    of nucleotide sequence data"""
+
+    homepage = "https://khmer.readthedocs.io/en/latest/"
+    pypi = "khmer/khmer-2.1.1.tar.gz"
+
+    license("BSD-3-Clause", checked_by="A-N-Other")
+
+    version("2.1.1", sha256="a709606910bb8679bd8525e9d2bf6d1421996272e343b54cc18090feb2fdbe24")
+
+    # https://github.com/dib-lab/khmer/pull/1922 ...
+    conflicts("python@3.12:")
+
+    depends_on("py-setuptools@18:", type="build")
+    depends_on("py-screed@1:", type=("build", "run"))
+    # abandoned `bz2file` dependency dropped in favour of the edits below
+
+    depends_on("openmpi")
+
+    @run_before("install")
+    def patcher(self):
+        patchf = FileFilter(join_path("khmer", "kfile.py"))
+        patchf.filter("bz2file", "bz2")


### PR DESCRIPTION
Adding `khmer` (program not a library, so no `^py-`).

Has a very old dependency (`bz2file`) that was aimed at backporting bits of the `bz2` stdlib. That's abandoned, so I didn't really want to add it in here - simpler just to just patch `bz2file` to `bz2`.