### PR TITLE
py-alphafold: use permanent link for openmm patch

### DIFF
--- a/var/spack/repos/builtin/packages/py-alphafold/package.py
+++ b/var/spack/repos/builtin/packages/py-alphafold/package.py
@@ -53,7 +53,7 @@ class PyAlphafold(PythonPackage, CudaPackage):
         type="run",
         patches=[
             patch(
-                "https://raw.githubusercontent.com/deepmind/alphafold/main/docker/openmm.patch",
+                "https://raw.githubusercontent.com/google-deepmind/alphafold/2819de4ddd075340b81d36bcf7932a0ff0fbe404/docker/openmm.patch",
                 sha256="a5a0ced820f3ecc56ae634c3111f80614863559b0587954a2658c8d4b2a07ae3",
                 working_dir="wrappers/python",
                 level=0,


### PR DESCRIPTION
The file doesn't exist anymore after https://github.com/google-deepmind/alphafold/commit/955737f12cc4b27398fe2369417fc2cc79815eb6, so the patch can't be downloaded.  I take no one tried to build py-alphafold with spack over the last 9 months :upside_down_face: 