### PR TITLE
visit-ffp and visit-unv: sets the licence SPDX

### DIFF
--- a/var/spack/repos/builtin/packages/visit-ffp/package.py
+++ b/var/spack/repos/builtin/packages/visit-ffp/package.py
@@ -21,6 +21,8 @@ class VisitFfp(CMakePackage):
 
     maintainers("cyrush", "cessenat")
 
+    license("BSD-3-Clause")
+
     # Here we provide a local file that contains only the plugin in a flat directory
     version("local", url="file://{0}/visit-ffp.tgz".format(os.getcwd()))
     # Below we copy the VisIt paths, ffp first shipment is with VisIt 3

--- a/var/spack/repos/builtin/packages/visit-unv/package.py
+++ b/var/spack/repos/builtin/packages/visit-unv/package.py
@@ -19,6 +19,8 @@ class VisitUnv(CMakePackage):
 
     maintainers("cyrush", "cessenat")
 
+    license("BSD-3-Clause")
+
     # Here we provide a local file that contains only the plugin in a flat directory
     version("local", url="file://{0}/visit-unv.tgz".format(os.getcwd()))
     # Below we copy the VisIt paths:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
From https://github.com/visit-dav/visit/blob/develop/LICENSE
the ffp and unv plugins for VisIt follow the BSD 3-Clause "New" or "Revised" License.