### PR TITLE
ngspice: new version 42

### DIFF
--- a/var/spack/repos/builtin/packages/ngspice/package.py
+++ b/var/spack/repos/builtin/packages/ngspice/package.py
@@ -12,6 +12,8 @@ class Ngspice(AutotoolsPackage):
 
     homepage = "http://ngspice.sourceforge.net/"
     url = "https://sourceforge.net/projects/ngspice/files/ngspice-33.tar.gz"
+    list_url = "https://sourceforge.net/projects/ngspice/files/ng-spice-rework"
+    list_depth = 1
     git = "git://git.code.sf.net/p/ngspice/ngspice"
 
     maintainers("aweits", "cessenat")
@@ -20,6 +22,7 @@ class Ngspice(AutotoolsPackage):
 
     # Master version by default adds the experimental adms feature
     version("master", branch="master")
+    version("42", sha256="737fe3846ab2333a250dfadf1ed6ebe1860af1d8a5ff5e7803c772cc4256e50a")
     version("41", sha256="1ce219395d2f50c33eb223a1403f8318b168f1e6d1015a7db9dbf439408de8c4")
     version("40", sha256="e303ca7bc0f594e2d6aa84f68785423e6bf0c8dad009bb20be4d5742588e890d")
     version("39", sha256="bf94e811eaad8aaf05821d036a9eb5f8a65d21d30e1cab12701885e09618d771")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
New version https://sourceforge.net/projects/ngspice/files/ng-spice-rework/42/ReleaseNotes.txt/download

> Ngspice-42, Dec 27th, 2023
> ============
> - New features:
>     + New optional matrix solver KLU (select by 'option klu')
>     + improve error messages (more verbose, user centric)
>     + Add variable wr_onspace to allow printing the vector name with
>       one space delimiter
>     + Re-write of the code model PWM generator
>     + Linked list modtab has been enhanced by a hash table
>       modtabhash
>     + Add a code model function cm_cexit(const int exitcode).
>     + PSP103 model pspnqs103va is now standard
>     + Add Isotel d_process xspice digital model (enable C models).
>     + OSDI interface allows small signal noise simulation in Verilog-A
>       compact models compiled by current OpenVAF.
>     + Add series resistance 1e-4 Ohms to diode model, if RS is not given
>     + Generate seed numbers from a microseconds clock, not a seconds clock
>     + Add functions ngSpice_LockRealloc and ngSpice_UnlockRealloc
>     + Add new code model function cm_irreversible().
>     + Add XSPICE code model d_cosim, a generic adaptor for digital cosimulation.
>     + Script 'vlnggen' may be used with Verilator and d_cosim to create
>       XSPICE code models controlled by HDL code.
>     + New interpreter commands strstr, strslice, fopen, fread and fclose.
>     + Recognise *ng_script_with_params
>     + Add a predefined variable 'skywaterpdk' to speed up circuit
>       loading and parsing.
>     + Add scripts for running the paranoia tests in parallel on Linux with valgri\
> nd.
