### PR TITLE
latex2html: new version 2024 and 2023.2

### DIFF
--- a/var/spack/repos/builtin/packages/latex2html/package.py
+++ b/var/spack/repos/builtin/packages/latex2html/package.py
@@ -13,7 +13,7 @@ class Latex2html(AutotoolsPackage):
     """LaTeX2HTML is a utility that converts LaTeX documents to web pages in HTML."""
 
     homepage = "https://www.latex2html.org/"
-    url = "https://github.com/latex2html/latex2html/archive/refs/tags/v2021.tar.gz"
+    url = "https://github.com/latex2html/latex2html/archive/refs/tags/v2024.tar.gz"
     git = "https://github.com/latex2html/latex2html.git"
 
     maintainers("cessenat")
@@ -21,6 +21,8 @@ class Latex2html(AutotoolsPackage):
     license("GPL-2.0-only")
 
     version("master", branch="master")
+    version("2024", sha256="554a51f83431683521b9e47a19edf07c90960feb040048a08ad8301bdca2c6fa")
+    version("2023.2", sha256="2a3f50621a71c9c0c425fb6709ae69bb2cf4df4bfe72ac661c2ea302e5aba185")
     version("2022.2", sha256="b1d5bba7bab7d0369d1241f2d8294137a52b7cb7df11239bfa15ec0a2546c093")
     version("2021", sha256="872fe7a53f91ababaafc964847639e3644f2b9fab3282ea059788e4e18cbba47")
     version("2017", sha256="28a5d4b8f14b1f95928da281b6332559bcd83349ba439b2fa43655b2e21c83ab")
@@ -37,6 +39,9 @@ class Latex2html(AutotoolsPackage):
     depends_on("netpbm", type=("build", "run"))
     # Provides pdftocairo
     depends_on("poppler+glib", type=("build", "run"), when="+svg")
+
+    def url_for_version(self, version):
+        return f"https://github.com/latex2html/latex2html/archive/refs/tags/v{version}.tar.gz"
 
     # A copy of texlive function as long as it does not provide the
     # bin env to dependent package:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
I did not find the release notes related to
https://github.com/latex2html/latex2html/commit/ad3dea6e3b9ea8aabd28cf301d71b5b2dc3d4af3
