### PR TITLE
mpfr: new version 4.2.1

### DIFF
--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -13,8 +13,11 @@ class Mpfr(AutotoolsPackage, GNUMirrorPackage):
     homepage = "https://www.mpfr.org/"
     gnu_mirror_path = "mpfr/mpfr-4.0.2.tar.bz2"
 
+    maintainers("cessenat")
+
     license("LGPL-3.0-or-later")
 
+    version("4.2.1", sha256="b9df93635b20e4089c29623b19420c4ac848a1b29df1cfd59f26cab0d2666aa0")
     version("4.2.0", sha256="691db39178e36fc460c046591e4b0f2a52c8f2b3ee6d750cc2eab25f1eaa999d")
     version("4.1.1", sha256="85fdf11614cc08e3545386d6b9c8c9035e3db1e506211a45f4e108117fe3c951")
     version("4.1.0", sha256="feced2d430dd5a97805fa289fed3fc8ff2b094c02d05287fd6133e7f1f0ec926")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
From https://www.mpfr.org/mpfr-current/#download

> Changes from version 4.2.0 to version 4.2.1
> Bug fixes (see the fixed bugs on the MPFR 4.2.0 page and/or the ChangeLog file).
> https://www.mpfr.org/mpfr-4.2.0/#fixed
> Improved MPFR manual.
> Configure tests: replaced the test of the link with GMP, in order to avoid the use of a function without a prototype (Autoconf issue), as this is obsolescent in ISO C. The new test should be more robust.
