### PR TITLE
dd4hep: remove self-referential dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -162,8 +162,8 @@ class Dd4hep(CMakePackage):
     depends_on("root @6.08: +gdml +math +python")
     with when("+ddeve"):
         depends_on("root @6.08: +x +opengl")
-        depends_on("root +webgui", when="^root@6.28:")
         depends_on("root @:6.27", when="@:1.23")
+        conflicts("^root ~webgui", when="^root@6.28:")
     depends_on("root @6.08: +gdml +math +python +x +opengl", when="+utilityapps")
 
     extends("python")


### PR DESCRIPTION
This shouldn't be an issue, but express the self-reference with a conflict.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
