### PR TITLE
ecp-data-vis-sdk: remove self-referential dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -187,7 +187,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     )
     # TODO: When Ascent is updated to use VTK-m >= 1.8 move examples to
     # the main spec.
-    depends_on("vtk-m+examples", when="+vtkm ^vtk-m@1.8:")
+    conflicts("^vtk-m~examples", when="+vtkm ^vtk-m@1.8:")
     depends_on("vtk-m+openmp", when="~rocm+vtkm")
     depends_on("vtk-m~openmp", when="+rocm+vtkm")
 


### PR DESCRIPTION
This shouldn't be an issue, but express this limitation with a conflict.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
