### PR TITLE
hh-suite: apply patch to fix compilation with GCC 13

### DIFF
--- a/var/spack/repos/builtin/packages/hh-suite/package.py
+++ b/var/spack/repos/builtin/packages/hh-suite/package.py
@@ -26,6 +26,12 @@ class HhSuite(CMakePackage):
     depends_on("cmake@2.8.12:", type="build")
     depends_on("mpi", when="+mpi")
 
+    # https://github.com/soedinglab/hh-suite/pull/357
+    patch(
+        "https://github.com/soedinglab/hh-suite/commit/cec47cba5dcd580e668b1ee507c9282fbdc8e7d7.patch?full_index=1",
+        sha256="dad4ee82e506a42c243fa315f542a0e91e379851dffc368e17c9584b2ee71d89",
+    )
+
     def build_args(self, spec, prefix):
         args = []
         if "+mpi" in self.spec:


### PR DESCRIPTION
This fixes errors like
```
     294    In file included from /build_stage/spack-stage-hh-suite-3.3.0-4kkv3zqhcadpubeo63l73xq3shr7gjmh/spack-src/src/a3m_compress.cpp:8:
  >> 295    /build_stage/spack-stage-hh-suite-3.3.0-4kkv3zqhcadpubeo63l73xq3shr7gjmh/spack-src/src/a3m_compress.h:37:37: error: 'uint16_t' has not been declared
     296       37 |   void writeU16(std::ostream& file, uint16_t);
     297          |                                     ^~~~~~~~
  >> 298    /build_stage/spack-stage-hh-suite-3.3.0-4kkv3zqhcadpubeo63l73xq3shr7gjmh/spack-src/src/a3m_compress.h:38:28: error: 'uint16_t' has not been declared
     299       38 |   void readU16(char** ptr, uint16_t &result);
     300          |                            ^~~~~~~~
  >> 301    /build_stage/spack-stage-hh-suite-3.3.0-4kkv3zqhcadpubeo63l73xq3shr7gjmh/spack-src/src/a3m_compress.h:40:37: error: 'uint32_t' has not been declared
     302       40 |   void writeU32(std::ostream& file, uint32_t);
     303          |                                     ^~~~~~~~
  >> 304    /build_stage/spack-stage-hh-suite-3.3.0-4kkv3zqhcadpubeo63l73xq3shr7gjmh/spack-src/src/a3m_compress.h:41:27: error: 'uint32_t' has not been declared
     305       41 |   void readU32(char**ptr, uint32_t &result);
     306          |                           ^~~~~~~~
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
