### PR TITLE
py-charm4py: needs Cython<3.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-charm4py/package.py
+++ b/var/spack/repos/builtin/packages/py-charm4py/package.py
@@ -36,7 +36,7 @@ class PyCharm4py(PythonPackage):
     depends_on("py-setuptools", type="build")
     # in newer pip versions --install-option does not exist
     depends_on("py-pip@:23.0", type="build")
-    depends_on("py-cython", type="build")
+    depends_on("py-cython@:3.0.0", type="build")
     depends_on("py-cffi@1.7:", type="build")
     depends_on("py-numpy@1.10.0:", type=("build", "run"))
     depends_on("py-greenlet", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-charm4py/package.py
+++ b/var/spack/repos/builtin/packages/py-charm4py/package.py
@@ -36,7 +36,7 @@ class PyCharm4py(PythonPackage):
     depends_on("py-setuptools", type="build")
     # in newer pip versions --install-option does not exist
     depends_on("py-pip@:23.0", type="build")
-    depends_on("py-cython@:3.0.0", type="build")
+    depends_on("py-cython@:2", type="build")
     depends_on("py-cffi@1.7:", type="build")
     depends_on("py-numpy@1.10.0:", type=("build", "run"))
     depends_on("py-greenlet", type=("build", "run"))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Charm4py does not work with Cython 3.x. See this [commit](https://github.com/UIUC-PPL/charm4py/commit/3587469674d2904053b35d3c62c7e09c579ab2c1) in [UUIC-PPL/charm4py](https://github.com/UIUC-PPL/charm4py).