### PR TITLE
caliper: allow newer papi to be used

### DIFF
--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -98,7 +98,7 @@ class Caliper(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("adiak@0.1:0", when="@2.2: +adiak")
 
     depends_on("papi@5.3:5", when="@:2.2 +papi")
-    depends_on("papi@5.3:6", when="@2.3: +papi")
+    depends_on("papi@5.3:", when="@2.3: +papi")
 
     depends_on("libpfm4@4.8:4", when="+libpfm")
 


### PR DESCRIPTION
I've been seeing problems with newer compilers building old versions of papi. At the same time, caliper is restricting itself to version 6 of papi, which seems to be an arbitrary limit set 4 years ago. Building papi 7.1.0 and compiling caliper with it and the newer compilers just works. So unless there is a good reason for the limitation, I would suggest to remove it.