### PR TITLE
py-smote-variants: Added package py-smote-variants

### DIFF
--- a/var/spack/repos/builtin/packages/py-metric-learn/package.py
+++ b/var/spack/repos/builtin/packages/py-metric-learn/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyMetricLearn(PythonPackage):
+    """metric-learn contains efficient Python implementations of several
+    popular supervised and weakly-supervised metric learning algorithms. As
+    part of scikit-learn-contrib, the API of metric-learn is compatible with
+    scikit-learn, the leading library for machine learning in Python. This
+    allows to use all the scikit-learn routines (for pipelining, model
+    selection, etc) with metric learning algorithms through a unified
+    interface."""
+
+    homepage = "https://github.com/scikit-learn-contrib/metric-learn"
+    pypi = "metric-learn/metric-learn-0.7.0.tar.gz"
+
+    version("0.7.0", sha256="2b35246a1098d74163b16cc7779e0abfcbf9036050f4caa258e4fee55eb299cc")
+
+    depends_on("py-numpy@1.11.0:", type=("build", "run"))
+    depends_on("py-scipy@0.17.0:", type=("build", "run"))
+    depends_on("py-scikit-learn@0.21.3:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-metric-learn/package.py
+++ b/var/spack/repos/builtin/packages/py-metric-learn/package.py
@@ -20,6 +20,7 @@ class PyMetricLearn(PythonPackage):
 
     version("0.7.0", sha256="2b35246a1098d74163b16cc7779e0abfcbf9036050f4caa258e4fee55eb299cc")
 
+    depends_on("py-setuptools", type="build")
     depends_on("py-numpy@1.11.0:", type=("build", "run"))
     depends_on("py-scipy@0.17.0:", type=("build", "run"))
     depends_on("py-scikit-learn@0.21.3:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-minisom/package.py
+++ b/var/spack/repos/builtin/packages/py-minisom/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyMinisom(PythonPackage):
+    """MiniSom is a minimalistic and Numpy based implementation of the Self
+    Organizing Maps (SOM). SOM is a type of Artificial Neural Network able to
+    convert complex, nonlinear statistical relationships between
+    high-dimensional data items into simple geometric relationships on a
+    low-dimensional display. Minisom is designed to allow researchers to easily
+    build on top of it and to give students the ability to quickly grasp its
+    details.
+
+    The project initially aimed for a minimalistic implementation of the
+    Self-Organizing Map (SOM) algorithm, focusing on simplicity in features,
+    dependencies, and code style. Although it has expanded in terms of
+    features, it remains minimalistic by relying only on the numpy library and
+    emphasizing vectorization in coding style."""
+
+    homepage = "https://github.com/JustGlowing/minisom"
+    pypi = "MiniSom/MiniSom-2.3.1.tar.gz"
+
+    version("2.3.1", sha256="c0f1411616d7614fbd440a811975c12c7dfc091baea33efb49f5f4eabad7b966")
+
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-setuptools", type=("build"))

--- a/var/spack/repos/builtin/packages/py-smote-variants/package.py
+++ b/var/spack/repos/builtin/packages/py-smote-variants/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySmoteVariants(PythonPackage):
+    """Variants of the synthetic minority oversampling technique (SMOTE) for
+    imbalanced learning"""
+
+    homepage = "https://github.com/analyticalmindsltd/smote_variants"
+    pypi = "smote_variants/smote_variants-0.7.3.tar.gz"
+
+    version("0.7.3", sha256="69497c764f101a76e8a3d4a9c80176704375c7aa5e26914f19222b59fb03b890")
+
+    depends_on("py-wheel@0.33.4:", type=("build"))
+
+    depends_on("py-setuptools@41.0.1:", type=("build"))
+
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-scipy", type=("build", "run"))
+    depends_on("py-scikit-learn", type=("build", "run"))
+    depends_on("py-joblib", type=("build", "run"))
+    depends_on("py-minisom", type=("build", "run"))
+    depends_on("py-tensorflow", type=("build", "run"))
+    depends_on("py-keras", type=("build", "run"))
+    depends_on("py-pandas", type=("build", "run"))
+    depends_on("mkl")
+    depends_on("py-metric-learn", type=("build", "run"))
+    depends_on("py-seaborn", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-smote-variants/package.py
+++ b/var/spack/repos/builtin/packages/py-smote-variants/package.py
@@ -15,9 +15,11 @@ class PySmoteVariants(PythonPackage):
 
     version("0.7.3", sha256="69497c764f101a76e8a3d4a9c80176704375c7aa5e26914f19222b59fb03b890")
 
-    depends_on("py-wheel@0.33.4:", type=("build"))
+    depends_on("python@3.5:", type=("build", "run"))
 
-    depends_on("py-setuptools@41.0.1:", type=("build"))
+    depends_on("py-wheel@0.33.4:", type="build")
+    depends_on("py-setuptools@41.0.1:", type="build")
+    depends_on("py-pytest-runner", type="build")
 
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-scipy", type=("build", "run"))
@@ -30,3 +32,4 @@ class PySmoteVariants(PythonPackage):
     depends_on("mkl")
     depends_on("py-metric-learn", type=("build", "run"))
     depends_on("py-seaborn", type=("build", "run"))
+    # Not including statistics, because is only needed for python 2 

--- a/var/spack/repos/builtin/packages/py-smote-variants/package.py
+++ b/var/spack/repos/builtin/packages/py-smote-variants/package.py
@@ -32,4 +32,4 @@ class PySmoteVariants(PythonPackage):
     depends_on("mkl")
     depends_on("py-metric-learn", type=("build", "run"))
     depends_on("py-seaborn", type=("build", "run"))
-    # Not including statistics, because is only needed for python 2 
+    # Not including statistics, because is only needed for python 2


### PR DESCRIPTION
Also added py-minisom and py-metric-learn as dependencies

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
