### PR TITLE
CrayPE: Update linux_distro.py to report sles with service pack ("sp"…

### DIFF
--- a/lib/spack/spack/operating_systems/linux_distro.py
+++ b/lib/spack/spack/operating_systems/linux_distro.py
@@ -53,6 +53,8 @@ class LinuxDistro(OperatingSystem):
 
         if "ubuntu" in distname:
             version = ".".join(version[0:2])
+        elif "sles" in distname:
+            version = "sp".join(version[0:2])
         # openSUSE Tumbleweed is a rolling release which can change
         # more than once in a week, so set version to tumbleweed$GLIBVERS
         elif "opensuse-tumbleweed" in distname or "opensusetumbleweed" in distname:


### PR DESCRIPTION
This affects SLES only.
`spack arch` will now report sles with service pack ("sp") version. This will allow for better compatibility with the CPE descriptive manifest when sles is the OS.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
