### PR TITLE
Fix for tirpc variable in libdap4

### DIFF
--- a/var/spack/repos/builtin/packages/libdap4/package.py
+++ b/var/spack/repos/builtin/packages/libdap4/package.py
@@ -41,7 +41,7 @@ class Libdap4(AutotoolsPackage):
         # during configure tests. This can cause a failure with libtirpc if the following variable
         # is not set.
         if self.spec.satisfies("^libtirpc"):
-            env.set("TIRPC_LIBS", self.spec["rpc"].libs)
+            env.set("TIRPC_LIBS", self.spec["rpc"].libs.link_flags)
 
     def configure_args(self):
         # libxml2 exports ./include/libxml2/ instead of ./include/, which we


### PR DESCRIPTION
This PR fixes a bug that was introduced during revision of the original PR in https://github.com/spack/spack/pull/40019. The script expects the library name flag (`-l`), not the library path flag (`-L`). Apologies for the oversight and extra work.