### PR TITLE
possvm: new package @1.2

### DIFF
--- a/var/spack/repos/builtin/packages/possvm/package.py
+++ b/var/spack/repos/builtin/packages/possvm/package.py
@@ -42,6 +42,6 @@ class Possvm(Package):
         sed = Executable("sed")
         targets = ("possvm.py", join_path("scripts", "possvm_reconstruction.py"))
         for script in targets:
-            sed("-i", f'1 i\#! {self.spec["python"].command.path}\n', script)
+            sed("-i", rf'1 i\#! {self.spec["python"].command.path}\n', script)
             os.chmod(script, 0o755)
             install(script, prefix.bin)

--- a/var/spack/repos/builtin/packages/possvm/package.py
+++ b/var/spack/repos/builtin/packages/possvm/package.py
@@ -22,7 +22,7 @@ class Possvm(Package):
     license("GPL-3.0-only", checked_by="A-N-Other")
 
     # version number is taken from -v/--version argparse info in possvm.py
-    version("1.2", commit="8e97f27806095b9368836e7630188f9b8d473b55")
+    version("1.2", commit="3158757423edafc29aa29bf3ae0cc63a93a56df9")
 
     depends_on("python@3.10:", type="run")
 

--- a/var/spack/repos/builtin/packages/possvm/package.py
+++ b/var/spack/repos/builtin/packages/possvm/package.py
@@ -1,0 +1,47 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack.package import *
+
+
+class Possvm(Package):
+    """Possvm (Phylogenetic Ortholog Sorting with Species oVerlap and MCL)
+    is a python tool to analyse pre-computed gene trees and identify pairs
+    and clusters of orthologous genes. It takes advantage of the species
+    overlap algorithm implemented in the ETE toolkit to parse the phylogeny
+    and identify orthologous gene pairs, and MCL clustering for orthogroup
+    identification."""
+
+    homepage = "https://github.com/xgrau/possvm-orthology"
+    git = "https://github.com/xgrau/possvm-orthology.git"
+
+    license("GPL-3.0-only", checked_by="A-N-Other")
+
+    # version number is taken from -v/--version argparse info in possvm.py
+    version("1.2", commit="8e97f27806095b9368836e7630188f9b8d473b55")
+
+    depends_on("python@3.10:", type="run")
+
+    # dependencies from GitHub README.md
+    depends_on("py-ete3@3.1.2", type="run")
+    depends_on("py-markov-clustering@0.0.6.dev0", type="run")
+    depends_on("py-matplotlib@3.7.1", type="run")
+    depends_on("py-networkx@3.0", type="run")
+    depends_on("py-scipy@1.10.0", type="run")
+    depends_on("py-numpy@1.23.5", type="run")
+    depends_on("py-pandas@1.5.3", type="run")
+
+    def install(self, spec, prefix):
+        # This package has no setup.py ...
+        # Add shebangs, ensure +x, and move the scripts to prefix.bin
+        mkdirp(prefix.bin)
+        sed = Executable("sed")
+        targets = ("possvm.py", join_path("scripts", "possvm_reconstruction.py"))
+        for script in targets:
+            sed("-i", f'1 i\#! {self.spec["python"].command.path}\n', script)
+            os.chmod(script, 0o755)
+            install(script, prefix.bin)

--- a/var/spack/repos/builtin/packages/py-markov-clustering/package.py
+++ b/var/spack/repos/builtin/packages/py-markov-clustering/package.py
@@ -18,10 +18,14 @@ class PyMarkovClustering(PythonPackage):
         "0.0.6.dev0", sha256="8f72eee0ee5d9bfbab1b28bbfa95eaa020b2bba64b528ce45030b8b4300ecf33"
     )
 
+    variant("graphing", default=False, description="Include graphing capabilities")
+
+    depends_on("python@3", type=("build", "run"))
     depends_on("py-setuptools", type="build")
 
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-scipy@0.19.0:", type=("build", "run"))
     depends_on("py-scikit-learn", type=("build", "run"))
-    depends_on("py-networkx", type=("build", "run"))
-    depends_on("py-matplotlib", type=("build", "run"))
+
+    depends_on("py-networkx", type=("build", "run"), when="+graphing")
+    depends_on("py-matplotlib", type=("build", "run"), when="+graphing")

--- a/var/spack/repos/builtin/packages/py-markov-clustering/package.py
+++ b/var/spack/repos/builtin/packages/py-markov-clustering/package.py
@@ -27,5 +27,5 @@ class PyMarkovClustering(PythonPackage):
     depends_on("py-scipy@0.19.0:", type=("build", "run"))
     depends_on("py-scikit-learn", type=("build", "run"))
 
-    depends_on("py-networkx", type=("build", "run"), when="+graphing")
-    depends_on("py-matplotlib", type=("build", "run"), when="+graphing")
+    depends_on("py-networkx", type=("build", "run"), when="+drawing")
+    depends_on("py-matplotlib", type=("build", "run"), when="+drawing")

--- a/var/spack/repos/builtin/packages/py-markov-clustering/package.py
+++ b/var/spack/repos/builtin/packages/py-markov-clustering/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyMarkovClustering(PythonPackage):
+    """Implementation of the Markov clustering (MCL) algorithm in python"""
+
+    homepage = "https://github.com/GuyAllard/markov_clustering"
+    pypi = "markov_clustering/markov_clustering-0.0.6.dev0.tar.gz"
+
+    license("MIT", checked_by="A-N-Other")
+
+    version("0.0.6.dev0", sha256="8f72eee0ee5d9bfbab1b28bbfa95eaa020b2bba64b528ce45030b8b4300ecf33")
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-scipy@0.19.0:", type=("build", "run"))
+    depends_on("py-scikit-learn", type=("build", "run"))
+    depends_on("py-networkx", type=("build", "run"))
+    depends_on("py-matplotlib", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-markov-clustering/package.py
+++ b/var/spack/repos/builtin/packages/py-markov-clustering/package.py
@@ -14,7 +14,9 @@ class PyMarkovClustering(PythonPackage):
 
     license("MIT", checked_by="A-N-Other")
 
-    version("0.0.6.dev0", sha256="8f72eee0ee5d9bfbab1b28bbfa95eaa020b2bba64b528ce45030b8b4300ecf33")
+    version(
+        "0.0.6.dev0", sha256="8f72eee0ee5d9bfbab1b28bbfa95eaa020b2bba64b528ce45030b8b4300ecf33"
+    )
 
     depends_on("py-setuptools", type="build")
 

--- a/var/spack/repos/builtin/packages/py-markov-clustering/package.py
+++ b/var/spack/repos/builtin/packages/py-markov-clustering/package.py
@@ -18,7 +18,7 @@ class PyMarkovClustering(PythonPackage):
         "0.0.6.dev0", sha256="8f72eee0ee5d9bfbab1b28bbfa95eaa020b2bba64b528ce45030b8b4300ecf33"
     )
 
-    variant("graphing", default=False, description="Include graphing capabilities")
+    variant("drawing", default=False, description="Include graphing capabilities")
 
     depends_on("python@3", type=("build", "run"))
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-networkx/package.py
+++ b/var/spack/repos/builtin/packages/py-networkx/package.py
@@ -17,6 +17,7 @@ class PyNetworkx(PythonPackage):
     license("BSD-3-Clause")
 
     version("3.1", sha256="de346335408f84de0eada6ff9fafafff9bcda11f0a0dfaa931133debb146ab61")
+    version("3.0", sha256="9a9992345353618ae98339c2b63d8201c381c2944f38a2ab49cb45a4c667e412")
     version("2.8.6", sha256="bd2b7730300860cbd2dafe8e5af89ff5c9a65c3975b352799d87a6238b4301a6")
     version("2.7.1", sha256="d1194ba753e5eed07cdecd1d23c5cd7a3c772099bd8dbd2fea366788cf4de7ba")
     version("2.6.3", sha256="c0946ed31d71f1b732b5aaa6da5a0388a345019af232ce2f49c766e2d6795c51")


### PR DESCRIPTION
- Adding the new `possvm` package (CLI python app, so no `^py-`) from GitHub. No `setup.py`, so a bit kludgy.
- Adding the `py-markov-clustering` dependency.
- Requires a specific version of `py-networkx` (apparently), so have added the checksum for `@3.0`.

Installed and tested on `linux-rocky8-icelake`.