### PR TITLE
clfft: workaround compiler error

### DIFF
--- a/var/spack/repos/builtin/packages/clfft/package.py
+++ b/var/spack/repos/builtin/packages/clfft/package.py
@@ -35,6 +35,12 @@ class Clfft(CMakePackage):
 
     root_cmakelists_dir = "src"
 
+    def flag_handler(self, name, flags):
+        if name == "cxxflags":
+            # https://github.com/clMathLibraries/clFFT/issues/237
+            flags.append("-fpermissive")
+        return (flags, None, None)
+
     def cmake_args(self):
         args = [
             self.define_from_variant("BUILD_CLIENT", "client"),


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This is a workaround for a compiler error caused by clFFT:
https://github.com/clMathLibraries/clFFT/issues/237