### PR TITLE
podio: add 0.99 pre-release version and deprecate all older versions

### DIFF
--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -20,6 +20,7 @@ class Podio(CMakePackage):
     tags = ["hep", "key4hep"]
 
     version("master", branch="master")
+    version("0.99", sha256="c823918a6ec1365d316e0a753feb9d492e28903141dd124a1be06efac7c1877a")
     version("0.17.4", sha256="3ca86323c86e05e901f596a98fe84aeb2476ceed8c0b0e0b37049c23b903a9ad")
     version("0.17.3", sha256="079517eba9c43d01255ef8acd88468c3ead7bb9d8fed11792e121bb481d54dee")
     version("0.17.2", sha256="5b519335c4e1708f71ed85b3cac8ca81e544cc4572a5c37019ce9fc414c5e74d")

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -21,12 +21,36 @@ class Podio(CMakePackage):
 
     version("master", branch="master")
     version("0.99", sha256="c823918a6ec1365d316e0a753feb9d492e28903141dd124a1be06efac7c1877a")
-    version("0.17.4", sha256="3ca86323c86e05e901f596a98fe84aeb2476ceed8c0b0e0b37049c23b903a9ad")
-    version("0.17.3", sha256="079517eba9c43d01255ef8acd88468c3ead7bb9d8fed11792e121bb481d54dee")
-    version("0.17.2", sha256="5b519335c4e1708f71ed85b3cac8ca81e544cc4572a5c37019ce9fc414c5e74d")
-    version("0.17.1", sha256="97d6c5f81d50ee42bf7c01f041af2fd333c806f1bbf0a4828ca961a24cea6bb2")
-    version("0.17", sha256="0c19f69970a891459cab227ab009514f1c1ce102b70e8c4b7d204eb6a0c643c1")
-    version("0.16.7", sha256="8af7c947e2637f508b7af053412bacd9218d41a455d69addd7492f05b7a4338d")
+    version(
+        "0.17.4",
+        sha256="3ca86323c86e05e901f596a98fe84aeb2476ceed8c0b0e0b37049c23b903a9ad",
+        deprecated=True,
+    )
+    version(
+        "0.17.3",
+        sha256="079517eba9c43d01255ef8acd88468c3ead7bb9d8fed11792e121bb481d54dee",
+        deprecated=True,
+    )
+    version(
+        "0.17.2",
+        sha256="5b519335c4e1708f71ed85b3cac8ca81e544cc4572a5c37019ce9fc414c5e74d",
+        deprecated=True,
+    )
+    version(
+        "0.17.1",
+        sha256="97d6c5f81d50ee42bf7c01f041af2fd333c806f1bbf0a4828ca961a24cea6bb2",
+        deprecated=True,
+    )
+    version(
+        "0.17",
+        sha256="0c19f69970a891459cab227ab009514f1c1ce102b70e8c4b7d204eb6a0c643c1",
+        deprecated=True,
+    )
+    version(
+        "0.16.7",
+        sha256="8af7c947e2637f508b7af053412bacd9218d41a455d69addd7492f05b7a4338d",
+        deprecated=True,
+    )
     version(
         "0.16.6",
         sha256="859f7cd16bd2b833bee9c1f33eb4cdbc2a0c2b1a48a853f67c30e8a0301d16df",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Add the latest version of podio and deprecate all older versions.

Is there a convention or guideline on how to remove (extremely) old versions from spack? Should I simply remove them from the package?