### PR TITLE
py-versioneer-518: add a workaround for invalid download URL

### DIFF
--- a/var/spack/repos/builtin/packages/py-versioneer-518/package.py
+++ b/var/spack/repos/builtin/packages/py-versioneer-518/package.py
@@ -14,6 +14,10 @@ class PyVersioneer518(PythonPackage):
     pypi = "versioneer-518/versioneer-518-0.19.tar.gz"
     git = "https://github.com/python-versioneer/versioneer-518.git"
 
+    # A workaround for invalid URL, most likely due to presence of 518 in the name.
+    def url_for_version(self, version):
+        return super().url_for_version(f"518-{version}")
+
     version("0.19", sha256="a287608997415f45401849d1227a42bb41b80a6e4a7da5776666f85ce6faec41")
 
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
Without this, package doesn't install, because `518` is stripped from the download URL.

There seems to be some bug either in `PythonPackage` or somewhere higher in the core of Spack, related to numbers in names. I could only come up with a workaround.

Some other workaround would be to specify `version("518-0.19", ...`. With this, package would install, but as an invalid version `518-0.19`.

This package is used by `py-nglview`.