### PR TITLE
edm4hep: Add 0.10.5 version and deprecate broken 0.10.4

### DIFF
--- a/var/spack/repos/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/builtin/packages/edm4hep/package.py
@@ -21,7 +21,12 @@ class Edm4hep(CMakePackage):
     license("Apache-2.0")
 
     version("main", branch="main")
-    version("0.10.4", sha256="76d51947525bc8a27b62f567033255da2e632d42d07a32ff578887948d56bd6f")
+    version("0.10.5", sha256="003c8e0c8e1d1844592d43d41384f4320586fbfa51d4d728ae0870b9c4f78d81")
+    version(
+        "0.10.4",
+        sha256="76d51947525bc8a27b62f567033255da2e632d42d07a32ff578887948d56bd6f",
+        deprecated=True,
+    )
     version("0.10.3", sha256="0ba5e4e90376f750f9531831909160e3d7b9c2d1f020d7556f0d3977b7eaafcc")
     version("0.10.2", sha256="c22c5c2f0fd1d09da9b734c1fa7ee546675fd2b047406db6ab8266e7657486d2")
     version("0.10.1", sha256="28a3bd4df899309b14ec0d441f8b6ed0065206a08a0018113bb490e9d008caed")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Add EDM4hep version v00-10-05 with a fix for a backwards incompatible change in v00-10-04. Deprecating the latter for that reason.