### PR TITLE
ASP-based solver: fix issue with conditional requirements and trigger conditions

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -698,6 +698,14 @@ requirement_group_satisfied(node(ID, Package), X) :-
   activate_requirement(node(ID, Package), X),
   requirement_group(Package, X).
 
+% Do not impose requirements, if the conditional requirement is not active
+do_not_impose(EffectID, node(ID, Package)) :-
+  trigger_condition_holds(TriggerID, node(ID, Package)),
+  pkg_fact(Package, condition_trigger(ConditionID, TriggerID)),
+  pkg_fact(Package, condition_effect(ConditionID, EffectID)),
+  requirement_group_member(ConditionID , Package, RequirementID),
+  not activate_requirement(node(ID, Package), RequirementID).
+
 % When we have a required provider, we need to ensure that the provider/2 facts respect
 % the requirement. This is particularly important for packages that could provide multiple
 % virtuals independently

--- a/var/spack/repos/builtin.mock/packages/dependency-mv/package.py
+++ b/var/spack/repos/builtin.mock/packages/dependency-mv/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class DependencyMv(Package):
+    """Package providing a virtual dependency and with a multivalued variant."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/foo-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    variant("cuda", default=False, description="Build with CUDA")
+    variant(
+        "cuda_arch",
+        values=any_combination_of("10", "11"),
+        description="Build shared libs, static libs or both",
+        when="+cuda",
+    )

--- a/var/spack/repos/builtin.mock/packages/dependency-mv/package.py
+++ b/var/spack/repos/builtin.mock/packages/dependency-mv/package.py
@@ -15,9 +15,4 @@ class DependencyMv(Package):
     version("1.0", md5="0123456789abcdef0123456789abcdef")
 
     variant("cuda", default=False, description="Build with CUDA")
-    variant(
-        "cuda_arch",
-        values=any_combination_of("10", "11"),
-        description="Build shared libs, static libs or both",
-        when="+cuda",
-    )
+    variant("cuda_arch", values=any_combination_of("10", "11"), when="+cuda")

--- a/var/spack/repos/builtin.mock/packages/forward-multi-value/package.py
+++ b/var/spack/repos/builtin.mock/packages/forward-multi-value/package.py
@@ -15,16 +15,9 @@ class ForwardMultiValue(Package):
     version("1.0", md5="0123456789abcdef0123456789abcdef")
 
     variant("cuda", default=False, description="Build with CUDA")
-    variant(
-        "cuda_arch",
-        values=any_combination_of("10", "11"),
-        description="Build shared libs, static libs or both",
-        when="+cuda",
-    )
+    variant("cuda_arch", values=any_combination_of("10", "11"), when="+cuda")
 
     depends_on("dependency-mv")
 
-    for _val in ("10", "11"):
-        requires(
-            f"^dependency-mv cuda_arch={_val}", when=f"+cuda cuda_arch={_val} ^dependency-mv+cuda"
-        )
+    requires("^dependency-mv cuda_arch=10", when="+cuda cuda_arch=10 ^dependency-mv+cuda")
+    requires("^dependency-mv cuda_arch=11", when="+cuda cuda_arch=11 ^dependency-mv+cuda")

--- a/var/spack/repos/builtin.mock/packages/forward-multi-value/package.py
+++ b/var/spack/repos/builtin.mock/packages/forward-multi-value/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class ForwardMultiValue(Package):
+    """A package that forwards the value of a multi-valued variant to a dependency"""
+
+    homepage = "http://www.llnl.gov"
+    url = "http://www.llnl.gov/mpileaks-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    variant("cuda", default=False, description="Build with CUDA")
+    variant(
+        "cuda_arch",
+        values=any_combination_of("10", "11"),
+        description="Build shared libs, static libs or both",
+        when="+cuda",
+    )
+
+    depends_on("dependency-mv")
+
+    for _val in ("10", "11"):
+        requires(
+            f"^dependency-mv cuda_arch={_val}", when=f"+cuda cuda_arch={_val} ^dependency-mv+cuda"
+        )


### PR DESCRIPTION
This PR fixes a bug noticed in #42487 

The lack of a rule to avoid enforcing requirements on multi-valued variants, when the condition activating the environment was not met, resulted in multiple optimal solution. The fix is to prevent imposing a requirement if the `when=` rule activating it is not met.

