### PR TITLE
Honor `cmake_prefix_paths` property if available

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1234,6 +1234,9 @@ class SetupContext:
             if os.path.isdir(bin_dir):
                 env.prepend_path("PATH", bin_dir)
 
+        for cp_dir in spack.build_systems.cmake.get_cmake_prefix_path(dep.package):
+            env.prepend_path("CMAKE_PREFIX_PATH", cp_dir)
+
 
 def _setup_pkg_and_run(
     serialized_pkg: "spack.subprocess_context.PackageInstallContext",

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1235,7 +1235,8 @@ class SetupContext:
                 env.prepend_path("PATH", bin_dir)
 
         for cp_dir in spack.build_systems.cmake.get_cmake_prefix_path(dep.package):
-            env.prepend_path("CMAKE_PREFIX_PATH", cp_dir)
+            env.append_path("CMAKE_PREFIX_PATH", cp_dir)
+        env.prune_duplicate_paths("CMAKE_PREFIX_PATH")
 
 
 def _setup_pkg_and_run(

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -52,7 +52,8 @@ def test_load_recursive(install_mockery, mock_fetch, mock_archive, mock_packages
         mpileaks_spec = spack.concretize.concretize_one("mpileaks")
 
         # Ensure our reference variable is clean.
-        os.environ["CMAKE_PREFIX_PATH"] = "/hello" + os.pathsep + "/world"
+        hello_world_paths = [os.path.normpath(p) for p in ("/hello", "/world")]
+        os.environ["CMAKE_PREFIX_PATH"] = os.pathsep.join(hello_world_paths)
 
         shell_out = load(shell, "mpileaks")
 
@@ -69,7 +70,7 @@ def test_load_recursive(install_mockery, mock_fetch, mock_archive, mock_packages
         paths_shell = extract_value(shell_out, "CMAKE_PREFIX_PATH")
 
         # We should've prepended new paths, and keep old ones.
-        assert paths_shell[-2:] == ["/hello", "/world"]
+        assert paths_shell[-2:] == hello_world_paths
 
         # All but the last two paths are added by spack load; lookup what packages they're from.
         pkgs = [prefix_to_pkg(p) for p in paths_shell[:-2]]


### PR DESCRIPTION
Issue #38265 describes a bug where the `CMAKE_PREFIX_PATH` is not updated at runtime according to the property `cmake_prefix_paths` as defined in the package.  This commit addresses that issue.