### PR TITLE
mpich: Fix +vci variant for newer releases

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -615,7 +615,6 @@ supported, and netmod is ignored if device is ch3:sock.""",
 
         if "+vci" in spec:
             config_args.append("--enable-thread-cs=per-vci")
-            config_args.append("--with-ch4-max-vcis=default")
 
         if "datatype-engine=yaksa" in spec:
             config_args.append("--with-datatype-engine=yaksa")


### PR DESCRIPTION
--with-ch4-max-vcis=default is no longer accepted by MPICH configure since the 4.1 release. Just omit the option from the +vci variant, since configure will select the default value in its absence.

See https://github.com/pmodels/mpich/issues/6896
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
