### PR TITLE
libuv: Update compiler requirements

### DIFF
--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -44,6 +44,14 @@ class Libuv(AutotoolsPackage):
     depends_on("libtool", type="build", when="@:1.43.0")
     depends_on("m4", type="build", when="@:1.43.0")
 
+    conflicts(
+        "%gcc@:4.8",
+        when="@1.45:",
+        msg="libuv version 1.45 and above require <stdatomic.h>. "
+        "See: https://github.com/libuv/libuv/blob/v1.45.0/ChangeLog#L11"
+        "and https://gcc.gnu.org/gcc-4.9/changes.html",
+    )
+
     # Tries to build an Objective-C file with GCC's C frontend
     # https://github.com/libuv/libuv/issues/2805
     conflicts(


### PR DESCRIPTION
libuv version 1.45 and later require support for <stdatomic.h> that was added in GCC 4.9
