### PR TITLE
spack help --spec: add @= notation

### DIFF
--- a/lib/spack/spack/cmd/help.py
+++ b/lib/spack/spack/cmd/help.py
@@ -30,6 +30,7 @@ spec expression syntax:
       @c{@min:max}                      version range (inclusive)
       @c{@min:}                         version <min> or higher
       @c{@:max}                         up to version <max> (inclusive)
+      @c{@=version}                     exact version
 
     compilers:
       @g{%compiler}                     build with <compiler>


### PR DESCRIPTION
Not sure if anyone else remembers that this exists, but it's extremely helpful (both the help output and the notation).

Wasn't exactly sure how to explain the difference between `@version` and `@=version` without writing a whole paragraph...