### PR TITLE
libice fix for older glibc

### DIFF
--- a/var/spack/repos/builtin/packages/libice/package.py
+++ b/var/spack/repos/builtin/packages/libice/package.py
@@ -21,6 +21,10 @@ class Libice(AutotoolsPackage, XorgPackage):
     version("1.0.10", sha256="1116bc64c772fd127a0d0c0ffa2833479905e3d3d8197740b3abd5f292f22d2d")
     version("1.0.9", sha256="7812a824a66dd654c830d21982749b3b563d9c2dfe0b88b203cefc14a891edc0")
 
+    # technically libbsd is only required when glibc < 2.36 which provides arc4random_buf,
+    # but spack doesn't currently have a good way to model this so we depend on it unconditionally
+    depends_on("libbsd", when="platform=linux")
+
     depends_on("xproto")
     depends_on("xtrans")
     depends_on("pkgconfig", type="build")

--- a/var/spack/repos/builtin/packages/libice/package.py
+++ b/var/spack/repos/builtin/packages/libice/package.py
@@ -24,6 +24,7 @@ class Libice(AutotoolsPackage, XorgPackage):
     # technically libbsd is only required when glibc < 2.36 which provides arc4random_buf,
     # but spack doesn't currently have a good way to model this so we depend on it unconditionally
     depends_on("libbsd", when="platform=linux")
+    depends_on("libbsd", when="platform=cray")
 
     depends_on("xproto")
     depends_on("xtrans")


### PR DESCRIPTION
libice depends on the function `arc4random_buf(void*, size_t)` which was added to [glibc in 2.36](https://sourceware.org/bugzilla/show_bug.cgi?id=4417), since spack doesn't have a good way to depend on this version only when libice depends on an older glibc this pr adds it unconditionally.
