### PR TITLE
DTK: specify MPI compilers so that the wrong ones from /usr/bin are not picked up

### DIFF
--- a/var/spack/repos/builtin/packages/datatransferkit/package.py
+++ b/var/spack/repos/builtin/packages/datatransferkit/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import pathlib
-
 from spack.package import *
 
 
@@ -62,7 +60,7 @@ class Datatransferkit(CMakePackage):
             "-DCMAKE_C_COMPILER=" + spec["mpi"].mpicc,
             "-DCMAKE_CXX_COMPILER=" + spec["mpi"].mpicxx,
             "-DCMAKE_Fortran_COMPILER=" + spec["mpi"].mpifc,
-            "-DMPI_BASE_DIR=" + str(pathlib.PurePosixPath(spec["mpi"].prefix)),
+            "-DMPI_BASE_DIR=" + spec["mpi"].prefix,
         ]
 
         if "+openmp" in spec:

--- a/var/spack/repos/builtin/packages/datatransferkit/package.py
+++ b/var/spack/repos/builtin/packages/datatransferkit/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import pathlib
+
 from spack.package import *
 
 
@@ -58,10 +59,10 @@ class Datatransferkit(CMakePackage):
             "-DDataTransferKit_ENABLE_EXAMPLES=OFF",
             "-DCMAKE_CXX_EXTENSIONS=OFF",
             "-DCMAKE_CXX_STANDARD=14",
-            "-DCMAKE_C_COMPILER="+spec["mpi"].mpicc,
-            "-DCMAKE_CXX_COMPILER="+spec["mpi"].mpicxx,
-            "-DCMAKE_Fortran_COMPILER="+spec["mpi"].mpifc,
-            "-DMPI_BASE_DIR="+str(pathlib.PurePosixPath(spec["mpi"].prefix)),
+            "-DCMAKE_C_COMPILER=" + spec["mpi"].mpicc,
+            "-DCMAKE_CXX_COMPILER=" + spec["mpi"].mpicxx,
+            "-DCMAKE_Fortran_COMPILER=" + spec["mpi"].mpifc,
+            "-DMPI_BASE_DIR=" + str(pathlib.PurePosixPath(spec["mpi"].prefix)),
         ]
 
         if "+openmp" in spec:

--- a/var/spack/repos/builtin/packages/datatransferkit/package.py
+++ b/var/spack/repos/builtin/packages/datatransferkit/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import pathlib
 from spack.package import *
 
 
@@ -35,6 +36,7 @@ class Datatransferkit(CMakePackage):
     variant("serial", default=True, description="enable Serial backend (default)")
     variant("shared", default=True, description="enable the build of shared lib")
 
+    depends_on("mpi")
     depends_on("arborx@1.0:", when="+external-arborx")
     depends_on("boost")
     depends_on("cmake", type="build")
@@ -56,6 +58,10 @@ class Datatransferkit(CMakePackage):
             "-DDataTransferKit_ENABLE_EXAMPLES=OFF",
             "-DCMAKE_CXX_EXTENSIONS=OFF",
             "-DCMAKE_CXX_STANDARD=14",
+            "-DCMAKE_C_COMPILER="+spec["mpi"].mpicc,
+            "-DCMAKE_CXX_COMPILER="+spec["mpi"].mpicxx,
+            "-DCMAKE_Fortran_COMPILER="+spec["mpi"].mpifc,
+            "-DMPI_BASE_DIR="+str(pathlib.PurePosixPath(spec["mpi"].prefix)),
         ]
 
         if "+openmp" in spec:


### PR DESCRIPTION
ref: https://github.com/xsdk-project/xsdk-issues/issues/253