### PR TITLE
Resolve unzip build failure with %oneapi 

### DIFF
--- a/var/spack/repos/builtin/packages/unzip/package.py
+++ b/var/spack/repos/builtin/packages/unzip/package.py
@@ -16,7 +16,7 @@ class Unzip(MakefilePackage):
 
     version("6.0", sha256="036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37")
 
-    # clang and oneapi need this patch, likely others. 
+    # clang and oneapi need this patch, likely others
     # There is no problem with it on gcc, so make it a catch all
     patch("configure-cflags.patch")
 

--- a/var/spack/repos/builtin/packages/unzip/package.py
+++ b/var/spack/repos/builtin/packages/unzip/package.py
@@ -16,20 +16,20 @@ class Unzip(MakefilePackage):
 
     version("6.0", sha256="036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37")
 
-    patch("configure-cflags.patch", when="%clang@16:")
+    # clang and oneapi need this patch, likely others. There is no problem with it on gcc, so make it a catch all
+    patch("configure-cflags.patch")
 
     # The Cray cc wrapper doesn't handle the '-s' flag (strip) cleanly.
     @when("platform=cray")
     def patch(self):
-        filter_file(r"^LFLAGS2=.*", "LFLAGS2=", join_path("unix", "configure"))
-
+       filter_file(r"^LFLAGS2=.*", "LFLAGS2=", join_path("unix", "configure"))
+    
     def get_make_args(self):
         make_args = ["-f", join_path("unix", "Makefile")]
 
         cflags = []
-        if self.spec.satisfies("%clang@16:"):
-            cflags.append("-Wno-error=implicit-function-declaration")
-            cflags.append("-Wno-error=implicit-int")
+        cflags.append("-Wno-error=implicit-function-declaration")
+        cflags.append("-Wno-error=implicit-int")
         cflags.append("-DLARGE_FILE_SUPPORT")
 
         make_args.append('LOC="{}"'.format(" ".join(cflags)))

--- a/var/spack/repos/builtin/packages/unzip/package.py
+++ b/var/spack/repos/builtin/packages/unzip/package.py
@@ -16,7 +16,8 @@ class Unzip(MakefilePackage):
 
     version("6.0", sha256="036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37")
 
-    # clang and oneapi need this patch, likely others. There is no problem with it on gcc, so make it a catch all
+    # clang and oneapi need this patch, likely others. 
+    # There is no problem with it on gcc, so make it a catch all
     patch("configure-cflags.patch")
 
     # The Cray cc wrapper doesn't handle the '-s' flag (strip) cleanly.

--- a/var/spack/repos/builtin/packages/unzip/package.py
+++ b/var/spack/repos/builtin/packages/unzip/package.py
@@ -22,8 +22,8 @@ class Unzip(MakefilePackage):
     # The Cray cc wrapper doesn't handle the '-s' flag (strip) cleanly.
     @when("platform=cray")
     def patch(self):
-       filter_file(r"^LFLAGS2=.*", "LFLAGS2=", join_path("unix", "configure"))
-    
+        filter_file(r"^LFLAGS2=.*", "LFLAGS2=", join_path("unix", "configure"))
+
     def get_make_args(self):
         make_args = ["-f", join_path("unix", "Makefile")]
 


### PR DESCRIPTION
Apply `CFLAGS` patch to all compilers.  This resolves the build error of `unzip` with `%oneapi` as per spack/spack/issues/40864. I note the commit message has a copy-paste error, and this is 40864 /not/ 42007.