### PR TITLE
nvpl-lapack: fix versioning and add missing dependency

### DIFF
--- a/var/spack/repos/builtin/packages/nvpl-lapack/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-lapack/package.py
@@ -28,7 +28,7 @@ class NvplLapack(Package):
 
     variant("ilp64", default=False, description="Force 64-bit Fortran native integers")
 
-    threadings = ("openmp", "none", )
+    threadings = ("openmp", "none")
     variant(
         "threads",
         default="none",

--- a/var/spack/repos/builtin/packages/nvpl-lapack/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-lapack/package.py
@@ -27,15 +27,23 @@ class NvplLapack(Package):
     provides("lapack")
 
     variant("ilp64", default=False, description="Force 64-bit Fortran native integers")
+
+    threadings = ("openmp", "none", )
     variant(
         "threads",
         default="none",
         description="Multithreading support",
-        values=("openmp", "none"),
+        values=threadings,
         multi=False,
     )
 
     requires("target=armv8.2a:", msg="Any CPU with Arm-v8.2a+ microarch")
+
+    # propagate variants for depends_on("nvpl-blas")
+    depends_on("nvpl-blas +ilp64", when="+ilp64")
+    depends_on("nvpl-blas ~ilp64", when="~ilp64")
+    for threads in threadings:
+        depends_on(f"nvpl-blas threads={threads}", when=f"threads={threads}")
 
     conflicts("%gcc@:7")
     conflicts("%clang@:13")

--- a/var/spack/repos/builtin/packages/nvpl-lapack/package.py
+++ b/var/spack/repos/builtin/packages/nvpl-lapack/package.py
@@ -22,7 +22,7 @@ class NvplLapack(Package):
 
     license("UNKNOWN")
 
-    version("0.1.0", sha256="7054f775b18916ee662c94ad7682ace53debbe8ee36fa926000fe412961edb0b")
+    version("0.2.0", sha256="7054f775b18916ee662c94ad7682ace53debbe8ee36fa926000fe412961edb0b")
 
     provides("lapack")
 


### PR DESCRIPTION
Changelog:
- version was wrongly matched with the actual package
- add missing dependency on `nvpl-blas`

### Versioning
About versioning, in origin I wrongly added "@0.1.0" when it actually is "@0.2.0", so I fixed that. Moreover, I opted for using the ["official release"](https://docs.nvidia.com/nvpl/_static/lapack/release_notes.html#nvpl-lapack-0-2-0) `0.2.0` instead of the version extrapolated from tarball name (i.e. `@0.2.0.1`)

### Dependency on `nvpl-blas`
According to [doc](https://docs.nvidia.com/nvpl/_static/lapack/programming_model/building_and_linking.html#overview), I added the dependency together with the forced matching of variants.

> When linking an application which uses NVPL LAPACK, please note that NVPL LAPACK depends on the NVPL BLAS and both libraries have LP64/ILP64 interface layers and can either be sequential or parallel.