### PR TITLE
tcoffee: updating to @13.46.0.919e8c6b

### DIFF
--- a/var/spack/repos/builtin/packages/amap/amap.patch
+++ b/var/spack/repos/builtin/packages/amap/amap.patch
@@ -1,0 +1,42 @@
+diff -ruN amap_raw/align/Amap.cc amap_new/align/Amap.cc
+--- amap_raw/align/Amap.cc	2008-02-13 15:36:30.000000000 +0100
++++ amap_new/align/Amap.cc	2019-04-17 23:32:47.000000000 +0200
+@@ -23,6 +23,8 @@
+ #include <cstdlib>
+ #include <cerrno>
+ #include <iomanip>
++#include <cstring>  //BUG strcmp
++#include <climits>
+ 
+ string parametersInputFilename = "";
+ string parametersOutputFilename = "no training";
+--- amap_raw/align/ProbabilisticModel.h
++++ amap_new/align/ProbabilisticModel.h
+@@ -16,6 +16,7 @@
+ #include "ScoreType.h"
+ #include "SparseMatrix.h"
+ #include "MultiSequence.h"
++#include <cstring>
+ 
+ using namespace std;
+ 
+--- amap_raw/align/SafeVector.h
++++ amap_new/align/SafeVector.h
+@@ -10,6 +10,7 @@
+ 
+ #include <cassert>
+ #include <vector>
++#include <cstddef>
+ 
+ /////////////////////////////////////////////////////////////////
+ // SafeVector
+--- amap_raw/align/MultiSequenceDag.h	1970-01-01 01:00:00.000000000 +0100
++++ amap_new/align/MultiSequenceDag.h.new	2024-02-07 20:20:03.086278987 +0000
+@@ -15,6 +15,7 @@
+ #include <iostream>
+ #include "MultiSequence.h"
+ #include "SparseMatrix.h"
++#include <limits>
+ 
+ using namespace std;
+ typedef map<int,int> MII;

--- a/var/spack/repos/builtin/packages/amap/package.py
+++ b/var/spack/repos/builtin/packages/amap/package.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Amap(MakefilePackage):
+    """AMAP is a multiple sequence alignment program based on sequence annealing. This
+    approach consists of building up the multiple alignment one match at a time, thereby
+    circumventing many of the problems of progressive alignment"""
+
+    homepage = "https://github.com/mes5k/amap-align"
+    git = "https://github.com/mes5k/amap-align.git"
+
+    version("2.2", commit="600fc29fb9d0e8a6abf797c173c7a416ab99c541")
+
+    build_directory = "align"
+
+    # update includes to bring inline with modern C++
+    # (combines relevant patches from the `amap` and `probcons` bioconda recipes)
+    patch("amap.patch")
+
+    def edit(self, spec, prefix):
+        with working_dir(self.build_directory):
+            filter_file("CXX = .*", f"CXX = {spack_cxx}", "Makefile")
+
+    def edit(self, spec, prefix):
+        with working_dir(self.build_directory):
+            make()
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        with working_dir(self.build_directory):
+            install("amap", prefix.bin)

--- a/var/spack/repos/builtin/packages/amap/package.py
+++ b/var/spack/repos/builtin/packages/amap/package.py
@@ -26,7 +26,7 @@ class Amap(MakefilePackage):
         with working_dir(self.build_directory):
             filter_file("CXX = .*", f"CXX = {spack_cxx}", "Makefile")
 
-    def edit(self, spec, prefix):
+    def build(self, spec, prefix):
         with working_dir(self.build_directory):
             make()
 

--- a/var/spack/repos/builtin/packages/consan/package.py
+++ b/var/spack/repos/builtin/packages/consan/package.py
@@ -1,0 +1,44 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Consan(MakefilePackage):
+    """Pairwise RNA structural alignment, both unconstrained and constrained on alignment
+    pins"""
+
+    homepage = "http://eddylab.org/software/consan/"
+    url = "http://eddylab.org/software/consan/consan-1.2.tar.gz"
+
+    license("GPL-2.0-only", checked_by="A-N-Other")
+
+    version("1.2", sha256="c9bc9878927a2eaef54aee91be9edd6cf2d01819cba6b6165978cea08c308b24")
+
+    def edit(self, spec, prefix):
+        # multiple individual Makefiles to edit
+        filter_file("^CC\s+=.*", f"CC = {spack_cc}", join_path("src", "Makefile"))
+        filter_file("^CC\s+=.*", f"CC = {spack_cc}", join_path("src", "squid", "Makefile"))
+        filter_file("^CC\s+=.*", f"CC = {spack_cc}", join_path("src", "utilities", "Makefile"))
+        filter_file("^CC\s+=.*", f"CC = {spack_cc}", join_path("src", "boot", "Makefile"))
+        filter_file("^CC\s+=.*", f"CC = {spack_cc}", join_path("src", "conus-1.1", "Makefile"))
+
+    def flag_handler(self, name, flags):
+        # need to set -fcommon to prevent complaints about multiple definitions
+        if name == "cflags":
+            comp_spec = self.spec.compiler
+            if any(comp_spec.satisfies(c) for c in ["gcc@10:", "clang@11:", "cce@11:", "aocc@3:", "oneapi"]):
+                flags.append("-fcommon")
+        return flags, None, None
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        for f in ("scompare", "sfold", "strain_ml"):
+            install(join_path("src", f), prefix.bin)
+        install(join_path("src", "boot", "bstats"), prefix.bin)
+        for f in ("comppair", "pModel"):
+            install(join_path("src", "utilities", f), prefix.bin)
+        for f in ("conus_train", "conus_compare"):
+            install(join_path("src", "conus-1.1", f), prefix.bin)

--- a/var/spack/repos/builtin/packages/consan/package.py
+++ b/var/spack/repos/builtin/packages/consan/package.py
@@ -19,17 +19,20 @@ class Consan(MakefilePackage):
 
     def edit(self, spec, prefix):
         # multiple individual Makefiles to edit
-        filter_file("^CC\s+=.*", f"CC = {spack_cc}", join_path("src", "Makefile"))
-        filter_file("^CC\s+=.*", f"CC = {spack_cc}", join_path("src", "squid", "Makefile"))
-        filter_file("^CC\s+=.*", f"CC = {spack_cc}", join_path("src", "utilities", "Makefile"))
-        filter_file("^CC\s+=.*", f"CC = {spack_cc}", join_path("src", "boot", "Makefile"))
-        filter_file("^CC\s+=.*", f"CC = {spack_cc}", join_path("src", "conus-1.1", "Makefile"))
+        filter_file(r"^CC\s+=.*", f"CC = {spack_cc}", join_path("src", "Makefile"))
+        filter_file(r"^CC\s+=.*", f"CC = {spack_cc}", join_path("src", "squid", "Makefile"))
+        filter_file(r"^CC\s+=.*", f"CC = {spack_cc}", join_path("src", "utilities", "Makefile"))
+        filter_file(r"^CC\s+=.*", f"CC = {spack_cc}", join_path("src", "boot", "Makefile"))
+        filter_file(r"^CC\s+=.*", f"CC = {spack_cc}", join_path("src", "conus-1.1", "Makefile"))
 
     def flag_handler(self, name, flags):
         # need to set -fcommon to prevent complaints about multiple definitions
         if name == "cflags":
             comp_spec = self.spec.compiler
-            if any(comp_spec.satisfies(c) for c in ["gcc@10:", "clang@11:", "cce@11:", "aocc@3:", "oneapi"]):
+            if any(
+                comp_spec.satisfies(c)
+                for c in ["gcc@10:", "clang@11:", "cce@11:", "aocc@3:", "oneapi"]
+            ):
                 flags.append("-fcommon")
         return flags, None, None
 

--- a/var/spack/repos/builtin/packages/dca/package.py
+++ b/var/spack/repos/builtin/packages/dca/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Dca(MakefilePackage):
+    """Divide-and-Conquer Multiple Sequence Alignment ( DCA) is a program for producing
+    fast, high quality simultaneous multiple sequence alignments of amino acid, RNA, or
+    DNA sequences"""
+
+    homepage = "https://bibiserv.cebitec.uni-bielefeld.de/dca"
+    url = "https://bibiserv.cebitec.uni-bielefeld.de/applications/dca/resources/downloads/dca-1.1-src.tar.gz"
+
+    version("1.1", sha256="b90ab90e18503a62b03ceab96747d9150f03600ef4ad547a5bb5a15030a250db")
+
+    depends_on("msa@2.1", type="run")
+
+    def edit(self, spec, prefix):
+        filter_file("CC = .*", f"CC = {spack_cc}", "Makefile")
+
+    def edit(self, spec, prefix):
+        make()
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install(join_path("bin", "dca"), prefix.bin)
+        install_tree("cost", prefix.cost)
+
+    def setup_run_environment(self, env):
+        env.set("DCA_COST_DIR", self.prefix.cost)

--- a/var/spack/repos/builtin/packages/dca/package.py
+++ b/var/spack/repos/builtin/packages/dca/package.py
@@ -21,7 +21,7 @@ class Dca(MakefilePackage):
     def edit(self, spec, prefix):
         filter_file("CC = .*", f"CC = {spack_cc}", "Makefile")
 
-    def edit(self, spec, prefix):
+    def build(self, spec, prefix):
         make()
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/dialign-tx/dialign-tx.patch
+++ b/var/spack/repos/builtin/packages/dialign-tx/dialign-tx.patch
@@ -1,0 +1,182 @@
+--- a/source/parameters.c
++++ b/source/parameters.c
+@@ -26,6 +26,8 @@
+ 
+ extern char *optarg;
+ extern int optind, opterr, optopt;
++
++struct parameters* para;
+ /****************************
+ * PROTEIN DEFAULT VALUES!   *
+ ****************************/
+--- a/source/parameters.h
++++ b/source/parameters.h
+@@ -138,7 +138,7 @@
+     /*              global variable                 */
+     /*                                              */
+     /************************************************/
+-struct parameters* para;
++extern struct parameters* para;
+ 
+ 
+ 
+--- a/source/museq.c
++++ b/source/museq.c
+@@ -38,6 +38,7 @@
+ //extern void calc_weight(struct diag* dg, struct scr_matrix* smatrix, 
+ //		 struct prob_dist *pdist);
+ //extern struct diag_col *create_diag_col(int seq_amount);
++extern void free_diag(struct diag* dg);
+ extern void free_diag_col(struct diag_col* dcol);
+ extern struct diag_col *find_all_diags(struct scr_matrix *smatrix, 
+ 				struct prob_dist *pdist, 
+@@ -52,6 +53,7 @@
+ 
+ // alig.c
+ extern struct alignment* create_empty_alignment(struct seq_col *scol);
++extern void free_alignment(struct alignment *algn);
+ //extern char adapt_diag(struct alignment *algn, struct scr_matrix *smatrix, struct diag* dg);
+ extern int  simple_aligner(struct seq_col *scol, struct diag_col *dcol, 
+ 			    struct scr_matrix* smatrix, 
+--- a/source/alig.c
++++ b/source/alig.c
+@@ -10,9 +10,9 @@
+ 
+ extern void error(char *message);
+ extern void merror(char *msg1, char *msg2);
+-extern inline void calc_weight(struct diag* dg, struct scr_matrix* smatrix, 
++extern void calc_weight(struct diag* dg, struct scr_matrix* smatrix, 
+ 			struct prob_dist *pdist);
+-extern inline void calc_ov_weight(struct diag* dg, struct diag_col *dcol, struct scr_matrix* smatrix, 
++extern void calc_ov_weight(struct diag* dg, struct diag_col *dcol, struct scr_matrix* smatrix, 
+ 		    struct prob_dist *pdist);
+ //extern struct seq_part* create_seq_part(int num, struct seq* aSeq, unsigned int startpos);
+ extern struct diag* create_diag(struct seq_part* part1, struct seq_part* part2, 
+@@ -520,7 +520,7 @@ struct alignment* copy_alignment( struct alignment *o_algn, struct alignment *al
+  * datastructure (i.e. frontiers). The given diag must be consistent
+  * to the given alignment !
+  */
+-inline char align_diag(struct alignment *algn, struct scr_matrix *smatrix, struct diag* dg) {
++char align_diag(struct alignment *algn, struct scr_matrix *smatrix, struct diag* dg) {
+ 
+   char alignedSomething = 0;
+   int i,j,k;
+--- a/source/assemble.c
++++ b/source/assemble.c
+@@ -10,9 +10,9 @@
+ 
+ extern void error(char *message);
+ extern void merror(char *msg1, char *msg2);
+-extern inline void calc_weight(struct diag* dg, struct scr_matrix* smatrix, 
++extern void calc_weight(struct diag* dg, struct scr_matrix* smatrix, 
+ 			struct prob_dist *pdist);
+-extern inline void calc_ov_weight(struct diag* dg, struct diag_col *dcol, struct scr_matrix* smatrix, 
++extern void calc_ov_weight(struct diag* dg, struct diag_col *dcol, struct scr_matrix* smatrix, 
+ 		    struct prob_dist *pdist);
+ //extern struct seq_part* create_seq_part(int num, struct seq* aSeq, unsigned int startpos);
+ extern long double** create_tmp_pdist(struct prob_dist *pdist);
+@@ -22,7 +22,7 @@ extern struct diag* create_diag(int n1, struct seq* sq1, unsigned int sp1,
+                          int n2, struct seq* sq2, unsigned int sp2,
+                          int dlength);
+ extern void free_diag(struct diag* dg);
+-extern inline struct simple_diag_col* find_diags_guided(struct scr_matrix *smatrix,  
++extern struct simple_diag_col* find_diags_guided(struct scr_matrix *smatrix,  
+ 							struct prob_dist *pdist, 
+ 							struct gt_node* n1,  
+ 							struct gt_node* n2, 
+@@ -34,10 +34,10 @@ extern inline struct simple_diag_col* find_diags_guided(struct scr_matrix *smatr
+ 
+ extern struct alignment* create_empty_alignment(struct seq_col *scol);
+ extern void free_alignment(struct alignment *algn);
+-extern inline struct algn_pos *find_eqc(struct algn_pos **ap, int seqnum, int pos);
++extern struct algn_pos *find_eqc(struct algn_pos **ap, int seqnum, int pos);
+ extern struct alignment* copy_alignment( struct alignment *o_algn, struct alignment *algn, char doDgc);
+ //extern char adapt_diag(struct alignment *algn, struct scr_matrix *smatrix, struct diag* dg);
+-extern inline char align_diag(struct alignment *algn, struct scr_matrix *smatrix, struct diag* dg);
++extern char align_diag(struct alignment *algn, struct scr_matrix *smatrix, struct diag* dg);
+ //extern inline struct diag_cont* enter_sorted(struct diag_cont* backlog_diags, struct diag_cont *cand);
+ //extern inline char fit_fpos_diag(struct alignment *algn, struct diag* dg);
+ 
+@@ -57,7 +57,7 @@ extern inline char align_diag(struct alignment *algn, struct scr_matrix *smatrix
+ /**
+  * enters the candidate in a sorted way to the list and returns pointer to the first element
+  */
+-inline struct diag_cont* enter_sorted(struct diag_cont* backlog_diags, struct diag_cont *cand) {
++struct diag_cont* enter_sorted(struct diag_cont* backlog_diags, struct diag_cont *cand) {
+   if(backlog_diags==NULL) {
+     cand->next=NULL;
+     return cand;
+@@ -92,7 +92,7 @@ inline struct diag_cont* enter_sorted(struct diag_cont* backlog_diags, struct di
+ /**
+  * returns whether the given first position of the diag fits intho the given alignment
+  */
+-inline char fit_fpos_diag(struct alignment *algn, struct diag* dg) {
++char fit_fpos_diag(struct alignment *algn, struct diag* dg) {
+   unsigned int s1 = dg->seq_p1.num;
+   unsigned int s2 = dg->seq_p2.num;
+ 
+@@ -574,7 +574,7 @@ char simple_aligner(struct seq_col *scol, struct diag_col *dcol,
+  * returns a value <0 if there is an non-conflicting overlap
+  * returns 0 in all other non-conflicting cases
+  */
+-inline char confl_diag(struct alignment *algn, char *layer, struct diag *dg1, struct diag *dg2) {
++char confl_diag(struct alignment *algn, char *layer, struct diag *dg1, struct diag *dg2) {
+   //  if(dg1->multi_dg || dg2->multi_dg) error(" confl_diag(): cannot accept multi dgs!");
+   int s1_1 = dg1->seq_p1.num;
+   int s1_2 = dg1->seq_p2.num;
+--- a/source/diag.c
++++ b/source/diag.c
+@@ -183,7 +183,7 @@ void fill_tmp_pdist(struct prob_dist *pdist, long double **tmp_dist, int slen1,
+  * omitScore = 0:  normal 
+  * omitScore = 1:  no score calculation 
+  */ 
+-inline void real_calc_weight(struct diag* dg, struct scr_matrix* smatrix,  
++void real_calc_weight(struct diag* dg, struct scr_matrix* smatrix,  
+ 		 struct prob_dist *pdist, char omitScore, long double **tmp_dist, struct alignment *algn ) { 
+    
+   if(dg->multi_dg) {
+@@ -302,7 +302,7 @@ inline void real_calc_weight(struct diag* dg, struct scr_matrix* smatrix,
+   } 
+ } 
+  
+-inline void calc_weight(struct diag* dg, struct scr_matrix* smatrix,  
++void calc_weight(struct diag* dg, struct scr_matrix* smatrix,  
+ 		 struct prob_dist *pdist) { 
+   real_calc_weight(dg, smatrix, pdist, 0,NULL,NULL); 
+ } 
+@@ -312,7 +312,7 @@ inline void calc_weight(struct diag* dg, struct scr_matrix* smatrix,
+ /** 
+  * calculates the overlap weight for the given diag 
+  */ 
+-inline void calc_ov_weight(struct diag* dg, struct diag_col *dcol, struct scr_matrix* smatrix,  
++void calc_ov_weight(struct diag* dg, struct diag_col *dcol, struct scr_matrix* smatrix,  
+ 		    struct prob_dist *pdist) { 
+   int sn1 = dg->seq_p1.num; 
+   int sn2 = dg->seq_p2.num; 
+@@ -444,7 +444,7 @@ void free_diag_col(struct diag_col* dcol) {
+  * The pointer returned (and the ones included in the struct)  
+  * has to be deallocted explicitely from memory. 
+  */ 
+-inline struct simple_diag_col* find_diags_guided(struct scr_matrix *smatrix,  
++struct simple_diag_col* find_diags_guided(struct scr_matrix *smatrix,  
+ 				struct prob_dist *pdist, struct gt_node* n1,  
+ 				struct gt_node* n2, struct alignment *algn, 
+ 				double thres_weight,
+@@ -958,7 +958,7 @@ inline struct simple_diag_col* find_diags_guided(struct scr_matrix *smatrix,
+  * The pointer returned (and the ones included in the struct)  
+  * has to be deallocted explicitely from memory. 
+  */ 
+-inline struct simple_diag_col* find_diags_dialign(struct scr_matrix *smatrix,  
++struct simple_diag_col* find_diags_dialign(struct scr_matrix *smatrix,  
+ 				struct prob_dist *pdist, struct seq* seq1,  
+ 				struct seq* seq2, struct alignment *algn, 
+ 				 long double **tmp_dist, int round) { 
+@@ -1262,7 +1262,7 @@ inline struct simple_diag_col* find_diags_dialign(struct scr_matrix *smatrix,
+  * The pointer returned (and the ones included in the struct)  
+  * has to be deallocted explicitely from memory. 
+  */ 
+-inline struct simple_diag_col* find_diags_dyn(struct scr_matrix *smatrix,  
++struct simple_diag_col* find_diags_dyn(struct scr_matrix *smatrix,  
+ 				struct prob_dist *pdist, struct seq* seq1,  
+ 				struct seq* seq2, struct alignment *algn, 
+ 				 long double **tmp_dist) { 

--- a/var/spack/repos/builtin/packages/dialign-tx/package.py
+++ b/var/spack/repos/builtin/packages/dialign-tx/package.py
@@ -19,19 +19,18 @@ class DialignTx(MakefilePackage):
 
     build_directory = "source"
 
-    conflicts("%gcc@6:")
+    # patches assembled from gentoo builds
+    # https://ftp.dimensiondata.com/mirror/gentoo-portage/sci-biology/dialign-tx/files/
+    patch("dialign-tx.patch")
 
     def edit(self, spec, prefix):
         with working_dir(self.build_directory):
             makefile = FileFilter("Makefile")
-            makefile.filter(" -march=i686 ", " ")
-            makefile.filter("CC=gcc", "CC=%s" % spack_cc)
-            if spec.target.family == "aarch64":
-                makefile.filter("-mfpmath=sse -msse  -mmmx", " ")
+            makefile.filter("^CC=.*", "")
+            makefile.filter("^CPPFLAGS=.*", "")
+            makefile.filter(r"$\(CC\)", "$(CC) $(LDFLAGS)")
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         with working_dir(self.build_directory):
             install("dialign-tx", prefix.bin)
-            # t-coffee recognizes as dialign-t
-            install("dialign-tx", join_path(prefix.bin, "dialign-t"))

--- a/var/spack/repos/builtin/packages/famsa/famsa.patch
+++ b/var/spack/repos/builtin/packages/famsa/famsa.patch
@@ -1,0 +1,13 @@
+diff --git a/makefile b/makefile
+index 99fd138..cad0eae 100644
+--- a/makefile
++++ b/makefile
+@@ -50,7 +50,7 @@ $(info *** Detecting g++ version 11 ***)
+ 		DEFINE_FLAGS = -DOLD_ATOMIC_FLAG
+ 	else
+ 		CPP_STD=c++20
+-		DEFINE_FLAGS = 
++		DEFINE_FLAGS = -DUSE_NATIVE_BARRIERS
+ 	endif
+ else
+ $(info *** Detecting g++ version 12 or higher ***)

--- a/var/spack/repos/builtin/packages/famsa/package.py
+++ b/var/spack/repos/builtin/packages/famsa/package.py
@@ -16,6 +16,9 @@ class Famsa(MakefilePackage):
 
     version("2.2.2", sha256="9e1d96b80ff0010852dcab24f8691bf2deb7415838c001f0362ec72fd0ac2d44")
 
+    # patching to correct barrier implementation
+    patch("famsa.patch")
+
     def build(self, spec, prefix):
         if spec.satisfies("target=m1:"):
             arch = "m1"

--- a/var/spack/repos/builtin/packages/famsa/package.py
+++ b/var/spack/repos/builtin/packages/famsa/package.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Famsa(MakefilePackage):
+    """Progressive algorithm for large-scale multiple sequence alignments"""
+
+    homepage = "https://github.com/refresh-bio/FAMSA"
+    url = "https://github.com/refresh-bio/FAMSA/archive/refs/tags/v2.2.2.tar.gz"
+
+    license("GPL-3.0-only", checked_by="A-N-Other")
+
+    version("2.2.2", sha256="9e1d96b80ff0010852dcab24f8691bf2deb7415838c001f0362ec72fd0ac2d44")
+
+    def build(self, spec, prefix):
+        if spec.satisfies("target=m1:"):
+            arch = "m1"
+        elif spec.satisfies("target=aarch64:"):
+            arch = "arm8"
+        elif "avx2" in spec.target:
+            arch = "avx2"
+        elif "avx" in spec.target:
+            arch = "avx"
+        elif "sse4" in spec.target:
+            arch = "sse4"
+        else:
+            arch = "none"
+        make(f"PLATFORM={arch}")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install("famsa", prefix.bin)

--- a/var/spack/repos/builtin/packages/fsa/package.py
+++ b/var/spack/repos/builtin/packages/fsa/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Fsa(AutotoolsPackage):
+    """FSA is a probabilistic multiple sequence alignment algorithm which uses
+    a distance-based approach to aligning homologous protein, RNA or DNA sequences"""
+
+    homepage = "https://fsa.sourceforge.net/"
+    url = "https://sourceforge.net/projects/fsa/files/fsa-1.15.9.tar.gz/download"
+
+    license("GPL-2.0-only", checked_by="A-N-Other")
+
+    version("1.15.9", sha256="6ee6e238e168ccba0d51648ba64d518cdf68fa875061e0d954edfb2500b50b30")
+
+    depends_on("mummer", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/gor/package.py
+++ b/var/spack/repos/builtin/packages/gor/package.py
@@ -10,7 +10,9 @@ class Gor(MakefilePackage):
     """The GOR (Garnier–Osguthorpe–Robson) method is an information theory-based method
     for the prediction of secondary structures in proteins"""
 
-    homepage = "https://npsa-prabi.ibcp.fr/cgi-bin/npsa_automat.pl?page=/NPSAHLP/npsahlp_secpredgor4.html"
+    homepage = (
+        "https://npsa-prabi.ibcp.fr/cgi-bin/npsa_automat.pl?page=/NPSAHLP/npsahlp_secpredgor4.html"
+    )
     # This mirror is the only extant download of GOR that I can find
     url = "https://s3.eu-central-1.amazonaws.com/tcoffee-packages/mirrors/source/GOR_IV.tar.gz"
 

--- a/var/spack/repos/builtin/packages/gor/package.py
+++ b/var/spack/repos/builtin/packages/gor/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Gor(MakefilePackage):
+    """The GOR (Garnier–Osguthorpe–Robson) method is an information theory-based method
+    for the prediction of secondary structures in proteins"""
+
+    homepage = "https://npsa-prabi.ibcp.fr/cgi-bin/npsa_automat.pl?page=/NPSAHLP/npsahlp_secpredgor4.html"
+    # This mirror is the only extant download of GOR that I can find
+    url = "https://s3.eu-central-1.amazonaws.com/tcoffee-packages/mirrors/source/GOR_IV.tar.gz"
+
+    version("4", sha256="3c2707195e39bc682d8fb9d7d1ee39d07a43588209fff54487ff2a2d0bf2f18e")
+
+    build_directory = "SOURCE"
+
+    def edit(self, spec, prefix):
+        with working_dir(self.build_directory):
+            filter_file("cc", spack_cc, "Makefile")
+
+    def build(self, spec, prefix):
+        with working_dir(self.build_directory):
+            make("gor")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        with working_dir(self.build_directory):
+            install("gorIV", prefix.bin)

--- a/var/spack/repos/builtin/packages/gor/package.py
+++ b/var/spack/repos/builtin/packages/gor/package.py
@@ -13,7 +13,8 @@ class Gor(MakefilePackage):
     homepage = (
         "https://npsa-prabi.ibcp.fr/cgi-bin/npsa_automat.pl?page=/NPSAHLP/npsahlp_secpredgor4.html"
     )
-    # This mirror is the only extant download of GOR that I can find
+    # This mirror is the only extant download of GOR that I can find, as per
+    #   https://github.com/cbcrg/tcoffee/blob/master/lib/data_headers/tclinkdb.txt
     url = "https://s3.eu-central-1.amazonaws.com/tcoffee-packages/mirrors/source/GOR_IV.tar.gz"
 
     version("4", sha256="3c2707195e39bc682d8fb9d7d1ee39d07a43588209fff54487ff2a2d0bf2f18e")

--- a/var/spack/repos/builtin/packages/gor/package.py
+++ b/var/spack/repos/builtin/packages/gor/package.py
@@ -21,6 +21,7 @@ class Gor(MakefilePackage):
     def edit(self, spec, prefix):
         with working_dir(self.build_directory):
             filter_file("cc", spack_cc, "Makefile")
+            filter_file("DATABASE", prefix.DATABASE, "gor.c")
 
     def build(self, spec, prefix):
         with working_dir(self.build_directory):
@@ -30,3 +31,4 @@ class Gor(MakefilePackage):
         mkdirp(prefix.bin)
         with working_dir(self.build_directory):
             install("gorIV", prefix.bin)
+        install_tree("DATABASE", prefix.DATABASE)

--- a/var/spack/repos/builtin/packages/msa/package.py
+++ b/var/spack/repos/builtin/packages/msa/package.py
@@ -15,7 +15,7 @@ class Msa(MakefilePackage):
     version(
         "2.1",
         sha256="b162b206bb6f47971cb6f1b6b7093eac19d96f45ed1d6268bf57fe983ce61976",
-        url="https://ftp.ncbi.nih.gov/pub/msa/msa.tar.Z"
+        url="https://ftp.ncbi.nih.gov/pub/msa/msa.tar.Z",
     )
 
     def edit(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/msa/package.py
+++ b/var/spack/repos/builtin/packages/msa/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Msa(MakefilePackage):
+    """MSA is a program to perform multiple sequence alignment under the sum-of-pairs criterion"""
+
+    homepage = "https://www.ncbi.nlm.nih.gov/research/staff/schaffer/msa/"
+    url = "https://ftp.ncbi.nih.gov/pub/msa/msa.tar.Z"
+
+    version(
+        "2.1",
+        sha256="b162b206bb6f47971cb6f1b6b7093eac19d96f45ed1d6268bf57fe983ce61976",
+        url="https://ftp.ncbi.nih.gov/pub/msa/msa.tar.Z"
+    )
+
+    def edit(self, spec, prefix):
+        filter_file("CC = .*", f"CC = {spack_cc}", "makefile")
+
+    def build(self, spec, prefix):
+        make("msa")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install("msa", prefix.bin)

--- a/var/spack/repos/builtin/packages/msaprobs/package.py
+++ b/var/spack/repos/builtin/packages/msaprobs/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Msaprobs(MakefilePackage):
+    """MSAProbs is a well-established state-of-the-art multiple sequence alignment algorithm
+    for protein sequences"""
+
+    homepage = "https://msaprobs.sourceforge.net/homepage.htm#latest"
+    url = "https://downloads.sourceforge.net/project/msaprobs/MSAProbs-0.9.7.tar.gz"
+
+    license("GPL-3.0-only", checked_by="A-N-Other")
+
+    version("0.9.7", sha256="a14c59d714a5020c091ba9dd64d57d4d4aa5e39fefec06ba2f3d29e9ab38dad0")
+
+    depends_on("openmpi")
+
+    build_directory = "MSAProbs"
+
+    def edit(self, spec, prefix):
+        with working_dir(self.build_directory):
+            filter_file("CXX = .*", f"CXX = {spack_cxx}", "Makefile")
+
+    def build(self, spec, prefix):
+        with working_dir(self.build_directory):
+            make("all")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        with working_dir(self.build_directory):
+            install("msaprobs", prefix.bin)

--- a/var/spack/repos/builtin/packages/msaprobs/package.py
+++ b/var/spack/repos/builtin/packages/msaprobs/package.py
@@ -17,7 +17,7 @@ class Msaprobs(MakefilePackage):
 
     version("0.9.7", sha256="a14c59d714a5020c091ba9dd64d57d4d4aa5e39fefec06ba2f3d29e9ab38dad0")
 
-    depends_on("openmpi")
+    depends_on("mpi")
 
     build_directory = "MSAProbs"
 

--- a/var/spack/repos/builtin/packages/mustang/package.py
+++ b/var/spack/repos/builtin/packages/mustang/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack.package import *
+
+
+class Mustang(MakefilePackage):
+    """Mustang is a program that implements an algorithm for structural
+    alignment of multiple protein structures. Given a set of PDB files, the
+    program uses the spatial information in the Calpha atoms of the set to
+    produce a sequence alignment"""
+
+    homepage = "https://lcb.infotech.monash.edu/mustang/"
+    url = "https://lcb.infotech.monash.edu/mustang/mustang_v3.2.4.tgz"
+
+    license_url = "https://lcb.infotech.monash.edu/mustang/"
+
+    version("3.2.4", sha256="c05e91c955f491a1fddc404a36ef963b057fd725bcc6d22ef6df1c23b26ce237")
+
+    def edit(self, spec, prefix):
+        filter_file("CCP = .*", f"CCP = {spack_cxx}", "Makefile")
+
+    def build(self, spec, prefix):
+        make("all")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        binary = f"mustang-{self.version}"
+        install(join_path("bin", binary), prefix.bin)
+        os.symlink(join_path(prefix.bin, binary), prefix.bin.mustang)

--- a/var/spack/repos/builtin/packages/perl-task-weaken/package.py
+++ b/var/spack/repos/builtin/packages/perl-task-weaken/package.py
@@ -15,3 +15,5 @@ class PerlTaskWeaken(PerlPackage):
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
     version("1.04", sha256="67e271c55900fe7889584f911daa946e177bb60c8af44c32f4584b87766af3c4")
+
+    depends_on("perl-module-install", type="build")

--- a/var/spack/repos/builtin/packages/probcons/package.py
+++ b/var/spack/repos/builtin/packages/probcons/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Probcons(MakefilePackage):
+    """PROBCONS is a novel tool for generating multiple alignments of protein sequences using
+    a combination of probabilistic modeling and consistency-based alignment techniques"""
+
+    homepage = "http://probcons.stanford.edu/about.html"
+    url = "http://probcons.stanford.edu/probcons_v1_12.tar.gz"
+
+    version("1.12", sha256="ecf3f9ab9ad47e14787c76d1c64aeea5533d4038c4be0236c00cdd79104cf383")
+
+    # update includes to bring inline with modern C++
+    # (from patch file in the bioconda recipe)
+    patch("probcons.patch")
+
+    def url_for_version(self, version):
+        return f"http://probcons.stanford.edu/probcons_v{version.underscored}.tar.gz"
+
+    def edit(self, spec, prefix):
+        makefile = FileFilter("Makefile")
+        makefile.filter("CXX = .*", f"CXX = {spack_cxx}")
+
+    def build(self, spec, prefix):
+        make("probcons", "compare")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install("probcons", prefix.bin)
+        install("compare", prefix.bin)

--- a/var/spack/repos/builtin/packages/probcons/package.py
+++ b/var/spack/repos/builtin/packages/probcons/package.py
@@ -23,13 +23,12 @@ class Probcons(MakefilePackage):
         return f"http://probcons.stanford.edu/probcons_v{version.underscored}.tar.gz"
 
     def edit(self, spec, prefix):
-        makefile = FileFilter("Makefile")
-        makefile.filter("CXX = .*", f"CXX = {spack_cxx}")
+        filter_file("CXX = .*", f"CXX = {spack_cxx}", "Makefile")
 
     def build(self, spec, prefix):
-        make("probcons", "compare")
+        make("probcons", "compare", "project")
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        install("probcons", prefix.bin)
-        install("compare", prefix.bin)
+        for f in ("probcons", "compare", "project"):
+            install(f, prefix.bin)

--- a/var/spack/repos/builtin/packages/probcons/probcons.patch
+++ b/var/spack/repos/builtin/packages/probcons/probcons.patch
@@ -1,0 +1,72 @@
+diff --git a/CompareToRef.cc b/CompareToRef.cc
+index 142fa4c..a564b5d 100644
+--- a/CompareToRef.cc
++++ b/CompareToRef.cc
+@@ -18,6 +18,7 @@
+ #include <cstdlib>
+ #include <cerrno>
+ #include <iomanip>
++#include <cstring>
+ 
+ const char CORE_BLOCK = 'h';
+ typedef pair<int,int> PII;
+diff --git a/FixRef.cc b/FixRef.cc
+index 7060c79..3544126 100644
+--- a/FixRef.cc
++++ b/FixRef.cc
+@@ -19,6 +19,7 @@
+ #include <cstdlib>
+ #include <cerrno>
+ #include <iomanip>
++#include <cstring>
+ 
+ string matrixFilename = "";
+ string parametersInputFilename = "";
+diff --git a/Main.cc b/Main.cc
+index 399b1a2..de1ad34 100644
+--- a/Main.cc
++++ b/Main.cc
+@@ -23,6 +23,7 @@
+ #include <cstdlib>
+ #include <cerrno>
+ #include <iomanip>
++#include <cstring>
+ 
+ string parametersInputFilename = "";
+ string parametersOutputFilename = "no training";
+diff --git a/ProbabilisticModel.h b/ProbabilisticModel.h
+index 3c72b4f..a1cee7b 100644
+--- a/ProbabilisticModel.h
++++ b/ProbabilisticModel.h
+@@ -16,6 +16,7 @@
+ #include "ScoreType.h"
+ #include "SparseMatrix.h"
+ #include "MultiSequence.h"
++#include <cstring>
+ 
+ using namespace std;
+ 
+diff --git a/ProjectPairwise.cc b/ProjectPairwise.cc
+index 4696ba1..469fbaf 100644
+--- a/ProjectPairwise.cc
++++ b/ProjectPairwise.cc
+@@ -18,6 +18,7 @@
+ #include <cstdlib>
+ #include <cerrno>
+ #include <iomanip>
++#include <cstring>
+ 
+ bool compressGaps = true;
+ 
+diff --git a/SafeVector.h b/SafeVector.h
+index abf4b64..103e894 100644
+--- a/SafeVector.h
++++ b/SafeVector.h
+@@ -10,6 +10,7 @@
+ 
+ #include <cassert>
+ #include <vector>
++#include <cstddef>
+ 
+ /////////////////////////////////////////////////////////////////
+ // SafeVector

--- a/var/spack/repos/builtin/packages/probconsrna/package.py
+++ b/var/spack/repos/builtin/packages/probconsrna/package.py
@@ -6,20 +6,27 @@
 from spack.package import *
 
 
-class Probconsrna(Package):
-    """Experimental version of PROBCONS with parameters estimated via
-    unsupervised training on BRAliBASE"""
+class Probconsrna(MakefilePackage):
+    """Experimental version of PROBCONS with parameters estimated via unsupervised training
+    on BRAliBASE"""
 
     homepage = "http://probcons.stanford.edu/"
     url = "http://probcons.stanford.edu/probconsRNA.tar.gz"
 
-    version("2005-6-7", sha256="7fe4494bd423db1d5f33f5ece2c70f9f66a0d9112e28d3eaa7dfdfe7fa66eba8")
+    version("1.10", sha256="7fe4494bd423db1d5f33f5ece2c70f9f66a0d9112e28d3eaa7dfdfe7fa66eba8")
 
-    def install(self, build, prefix):
+    # update includes to bring inline with modern C++
+    # (from patch file in the bioconda recipe)
+    patch("probconsrna.patch")
+
+    def edit(self, spec, prefix):
+        filter_file("CXX = .*", f"CXX = {spack_cxx}", "Makefile")
+
+    def build(self, spec, prefix):
+        make("probcons", "compare", "project")
+
+    def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        install("compare", prefix.bin)
-        install("makegnuplot", prefix.bin)
-        install("probcons", prefix.bin)
-        # needed for tcoffee
         install("probcons", prefix.bin.probconsRNA)
+        install("compare", prefix.bin)
         install("project", prefix.bin)

--- a/var/spack/repos/builtin/packages/probconsrna/probconsrna.patch
+++ b/var/spack/repos/builtin/packages/probconsrna/probconsrna.patch
@@ -1,0 +1,61 @@
+--- a/CompareToRef.cc
++++ b/CompareToRef.cc
+@@ -18,6 +18,7 @@
+ #include <cstdlib>
+ #include <cerrno>
+ #include <iomanip>
++#include <cstring>
+ 
+ const char CORE_BLOCK = 'h';
+ typedef pair<int,int> PII;
+--- a/FixRef.cc
++++ b/FixRef.cc
+@@ -19,6 +19,7 @@
+ #include <cstdlib>
+ #include <cerrno>
+ #include <iomanip>
++#include <cstring>
+ 
+ string matrixFilename = "";
+ string parametersInputFilename = "";
+--- a/Main.cc
++++ b/Main.cc
+@@ -21,6 +21,8 @@
+ #include <cstdio>
+ #include <cstdlib>
+ #include <cerrno>
++#include <cstring>
++#include <climits>
+ #include <iomanip>
+ 
+ string parametersInputFilename = "";
+--- a/ProbabilisticModel.h
++++ b/ProbabilisticModel.h
+@@ -16,6 +16,7 @@
+ #include "ScoreType.h"
+ #include "SparseMatrix.h"
+ #include "MultiSequence.h"
++#include <cstring>
+ 
+ using namespace std;
+ 
+--- a/ProjectPairwise.cc
++++ b/ProjectPairwise.cc
+@@ -18,6 +18,7 @@
+ #include <cstdlib>
+ #include <cerrno>
+ #include <iomanip>
++#include <cstring>
+ 
+ bool compressGaps = true;
+ 
+--- a/SafeVector.h
++++ b/SafeVector.h
+@@ -10,6 +10,7 @@
+ 
+ #include <cassert>
+ #include <vector>
++#include <cstddef>
+ 
+ /////////////////////////////////////////////////////////////////
+ // SafeVector

--- a/var/spack/repos/builtin/packages/proda/package.py
+++ b/var/spack/repos/builtin/packages/proda/package.py
@@ -1,0 +1,38 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Proda(MakefilePackage):
+    """ProDA is public domain software for multiple alignment of protein sequences with
+    repeated and shuffled elements"""
+
+    homepage = "http://proda.stanford.edu/"
+    url = "http://proda.stanford.edu/proda_1_0.tar.gz"
+
+    version("1.0", sha256="439a93bf35e1a29ac1d5dde51e61f2cb174618596afaaaaa27d33a8ea1868a08")
+
+    # update includes to bring inline with modern C++
+    # (relevant patches taken from the bioconda recipe)
+    patch("proda.patch")
+
+    def url_for_version(self, version):
+        return f"http://proda.stanford.edu/proda_{version.underscored}.tar.gz"
+
+    def edit(self, spec, prefix):
+        makefile = FileFilter("Makefile")
+        makefile.filter("CXX = .*", f"CXX = {spack_cxx}")
+        makefile.filter(
+            "CXXFLAGS = .*",
+            "CXXFLAGS = -O3 -W -Wall -pedantic -DNDEBUG $(OTHERFLAGS) -funroll-loops",
+        )
+
+    def build(self, spec, prefix):
+        make("proda")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install("proda", prefix.bin)

--- a/var/spack/repos/builtin/packages/proda/proda.patch
+++ b/var/spack/repos/builtin/packages/proda/proda.patch
@@ -1,0 +1,92 @@
+diff -ruN proda_raw/AlignedFragment.cc proda/AlignedFragment.cc
+--- proda_raw/AlignedFragment.cc	2005-10-10 06:16:49.000000000 +0200
++++ proda/AlignedFragment.cc	2019-04-26 18:52:31.075383078 +0200
+@@ -2,10 +2,14 @@
+ //
+ //////////////////////////////////////////////////////////////////////
+ 
++#include<stdio.h>
++#include<cstdio>
++#include<cstring>
+ #include "AlignedFragment.h"
+ #include "Assert.h"
+ #include "Utilities.h"
+ 
++
+ //////////////////////////////////////////////////////////////////////
+ // Construction/Destruction
+ //////////////////////////////////////////////////////////////////////
+diff -ruN proda_raw/AlignedFragment.h proda/AlignedFragment.h
+--- proda_raw/AlignedFragment.h	2005-10-08 11:31:05.000000000 +0200
++++ proda/AlignedFragment.h	2019-04-26 18:52:56.432383249 +0200
+@@ -7,8 +7,12 @@
+ #ifndef ALIGNFRAGMENT_H
+ #define ALIGNFRAGMENT_H
+ 
++#include<stdio.h>
++#include<cstdio>
++#include<cstring>
+ #include <vector>
+ 
++
+ class Fragment;
+ class AlignedFragment;
+ 
+diff -ruN proda_raw/Block.cc proda/Block.cc
+--- proda_raw/Block.cc	2005-10-08 12:33:14.000000000 +0200
++++ proda/Block.cc	2019-04-26 16:13:30.872944305 +0200
+@@ -8,7 +8,7 @@
+ #include "MultiSequence.h"
+ #include "Utilities.h"
+ #include "Types.h"
+-
++#include <stdlib.h>
+ extern int MINLENGTH;
+ //////////////////////////////////////////////////////////////////////
+ // Construction/Destruction
+diff -ruN proda_raw/Main.cc proda/Main.cc
+--- proda_raw/Main.cc	2006-02-02 14:23:41.000000000 +0100
++++ proda/Main.cc	2019-04-29 10:30:02.990515178 +0200
+@@ -21,7 +21,8 @@
+ #include "Consistency.h"
+ #include "PairAligner.h"
+ #include "Types.h"
+-
++#include <climits>
++#include <cerrno>
+ bool verbose = true;
+ int MINLENGTH = 30; // shortest local alignment
+ bool enableViterbi = true;
+@@ -116,7 +117,7 @@
+   char *endPtr;
+   long int retVal;
+ 
+-  int errno = 0;
++  extern int errno;
+   retVal = strtol (data, &endPtr, 0);
+   if (retVal == 0 && (errno != 0 || data == endPtr)) return false;
+   if (errno != 0 && (retVal == LONG_MAX || retVal == LONG_MIN)) return false;
+diff -ruN proda_raw/PairAligner.cc proda/PairAligner.cc
+--- proda_raw/PairAligner.cc	2005-10-08 12:33:45.000000000 +0200
++++ proda/PairAligner.cc	2019-04-26 16:16:00.842824480 +0200
+@@ -7,7 +7,8 @@
+ #include "PairAligner.h"
+ #include "Utilities.h"
+ #include "LocalAlign.h"
+-
++#include <cstring>
++#include <stdlib.h>
+ extern bool verbose;
+ extern int MINLENGTH;
+ extern bool enableViterbi;
+diff -ruN proda_raw/ProbModel.cc proda/ProbModel.cc
+--- proda_raw/ProbModel.cc	2005-10-08 12:14:20.000000000 +0200
++++ proda/ProbModel.cc	2019-04-26 16:16:48.056543721 +0200
+@@ -6,6 +6,7 @@
+ #include <ctype.h>
+ #include "ProbModel.h"
+ #include "Utilities.h"
++#include <cstring>
+ 
+ int EMISSIONS[NUM_STATES][2] = { 
+   {1, 0},

--- a/var/spack/repos/builtin/packages/sap/package.py
+++ b/var/spack/repos/builtin/packages/sap/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Sap(AutotoolsPackage):
+    """SAP: pairwise structure alignment using double-dynamic programming"""
+
+    homepage = "https://github.com/mathbio-nimr-mrc-ac-uk/SAP"
+    url = "https://github.com/mathbio-nimr-mrc-ac-uk/SAP/archive/refs/tags/v.1.1.3.tar.gz"
+
+    license("GPL-3.0-only", checked_by="A-N-Other")
+
+    version("1.1.3", sha256="1ee5025f8a900cd9d9c490f7038b98d80a619e3015f2dc97b869ea3033c459e0")
+
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")

--- a/var/spack/repos/builtin/packages/sepp/package.py
+++ b/var/spack/repos/builtin/packages/sepp/package.py
@@ -31,6 +31,7 @@ class Sepp(Package):
     phases = ["edit", "install"]
 
     def edit(self, spec, prefix):
+       # will need editing next update, as it's fixed upstream but not in this version
         if spec.satisfies("^python@3.10:"):
             filter_file(
                 "from collections import Mapping",

--- a/var/spack/repos/builtin/packages/sepp/package.py
+++ b/var/spack/repos/builtin/packages/sepp/package.py
@@ -31,7 +31,7 @@ class Sepp(Package):
     phases = ["edit", "install"]
 
     def edit(self, spec, prefix):
-       # will need editing next update, as it's fixed upstream but not in this version
+        # will need editing next update, as it's fixed upstream but not in this version
         if spec.satisfies("^python@3.10:"):
             filter_file(
                 "from collections import Mapping",

--- a/var/spack/repos/builtin/packages/sepp/package.py
+++ b/var/spack/repos/builtin/packages/sepp/package.py
@@ -28,6 +28,16 @@ class Sepp(Package):
 
     extends("python")
 
+    phases = ["edit", "install"]
+
+    def edit(self, spec, prefix):
+        if spec.satisfies("^python@3.10:"):
+            filter_file(
+                "from collections import Mapping",
+                "from collections.abc import Mapping",
+                join_path("sepp", "alignment.py"),
+            )
+
     def install(self, spec, prefix):
         dirs = ["sepp", "tools"]
         for d in dirs:

--- a/var/spack/repos/builtin/packages/strike/package.py
+++ b/var/spack/repos/builtin/packages/strike/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Strike(MakefilePackage):
+    """STRIKE (Single sTRucture Induced Evaluation) is a program to evaluate protein multiple
+    sequence alignments using a single protein structure"""
+
+    homepage = "https://tcoffee.org/Projects/strike/index.html"
+    url = "https://s3.eu-central-1.amazonaws.com/tcoffee-packages/strike/download/strike_v1.2.tar.bz2"
+
+    version("1.2", sha256="4e0974c57a18b10faff635f60d2d4c5e253a67e43e525aec98545f45884e7295")
+
+    def edit(self, spec, prefix):
+        makefile = FileFilter("Makefile")
+        makefile.filter("CC = .*", f"CC = {spack_cc}")
+
+    def build(self, spec, prefix):
+        make()
+
+    def install(self, spec, prefix):
+        install_tree("bin", prefix.bin)

--- a/var/spack/repos/builtin/packages/tcoffee/package.py
+++ b/var/spack/repos/builtin/packages/tcoffee/package.py
@@ -116,6 +116,8 @@ class Tcoffee(MakefilePackage):
 
     build_directory = "t_coffee/src"
 
+    parallel = False
+
     @property
     def sys_max_pid(self):
         if self.spec.satisfies("platform=darwin"):

--- a/var/spack/repos/builtin/packages/tcoffee/package.py
+++ b/var/spack/repos/builtin/packages/tcoffee/package.py
@@ -7,26 +7,76 @@ from spack.package import *
 
 
 class Tcoffee(MakefilePackage):
-    """T-Coffee is a multiple sequence alignment program."""
+    """T-Coffee is a collection of tools for computing, evaluating and manipulating
+    multiple alignments of DNA, RNA, protein sequences and structures"""
 
-    homepage = "http://www.tcoffee.org/"
+    homepage = "https://tcoffee.org/Projects/tcoffee/index.html"
     git = "https://github.com/cbcrg/tcoffee.git"
+    url = "https://s3.eu-central-1.amazonaws.com/tcoffee-packages/Archives/T-COFFEE_distribution_Version_13.46.0.919e8c6b.tar.gz"
 
-    version("2017-08-17", commit="f389b558e91d0f82e7db934d9a79ce285f853a71")
+    license("GPL-2.0-only", checked_by="A-N-Other")
 
-    depends_on("perl", type=("build", "run"))
-    depends_on("blast-plus")
-    depends_on("dialign-tx")
-    depends_on("viennarna")
-    depends_on("clustalw")
-    depends_on("tmalign")
-    depends_on("muscle")
-    depends_on("mafft")
-    depends_on("pcma")
-    depends_on("poamsa")
-    depends_on("probconsrna")
+    version(
+        "13.46.0.919e8c6b",
+        sha256="31fd0ca0734974c93cb68bef6e394f463a4589c3315fd28cf2bd41b8a167db22")
+    version(
+        "11.0",
+        commit="f389b558e91d0f82e7db934d9a79ce285f853a71",
+        deprecated=True,
+    )
 
-    build_directory = "compile"
+    depends_on("perl", type="run")
+    depends_on("perl-soap-lite", type="run")
+    depends_on("perl-xml-simple", type="run")
+
+    # Dependencies taken from ./install script
+    # TODO: lots of missing dependencies!
+    # TODO: make variants for these as per the ./install script
+
+    # depends_on("clustalo", type="run")
+    # depends_on("strike", type="run")
+    # depends_on("clustalw2", type="run")
+    depends_on("clustalw", type="run")
+    # depends_on("dialign-t", type="run")
+    depends_on("dialign-tx", type="run")
+    depends_on("poamsa", type="run")
+    depends_on("probconsrna", type="run")
+    # depends_on("msaprobs", type="run")
+    # depends_on("upp", type="run")
+    # depends_on("famsa", type="run")
+    depends_on("mafft", type="run")
+    # depends_on("msa", type="run")
+    # depends_on("dca", type="run")
+    depends_on("muscle", type="run")
+    depends_on("pcma", type="run")
+    # depends_on("kalign", type="run")
+    # depends_on("amap", type="run")
+    # depends_on("proda", type="run")
+    # depends_on("prank", type="run")
+    # depends_on("sap", type="run")
+    depends_on("tmalign", type="run")
+    # depends_on("mustang", type="run")
+    # depends_on("fugue", type="run")
+    # depends_on("dali-lite", type="run")
+    # depends_on("sfold", type="run")
+    depends_on("viennarna", type="run")
+    # depends_on("retree", type="run")
+    # depends_on("hmmtop", type="run")
+    # depends_on("goriv", type="run")
+    depends_on("blast-legacy", type="run")
+    # depends_on("x3dna", type="run")
+    # depends_on("fsa", type="run")
+
+    @property
+    def build_directory(self):
+        if spec.satisfies("@13:"):
+            return "t_coffee_source"
+        else:
+            return"compile"
+
+    def edit(self, spec, prefix):
+        with working_dir(self.build_directory):
+            filter_file("CC=g++", f"CC={spack_cxx}", "makefile")
 
     def build(self, spec, prefix):
         with working_dir(self.build_directory):

--- a/var/spack/repos/builtin/packages/tcoffee/package.py
+++ b/var/spack/repos/builtin/packages/tcoffee/package.py
@@ -43,7 +43,6 @@ class Tcoffee(MakefilePackage):
     # - `x3dna`, `hmmtop`, and `fugue` are distributed manually / under manual license
     #   agreement. These have been removed here to allow simpler install of the package.
     #   - `saracoffee` variant is a stub due to dependency on `x3dna`.
-    #   - `psicoffee` variant is a stub due to dependency on `hmmtop`.
     # - `lsqman` and `align_pdb` are extremely old. I can't find extant / reputable sources
     #   for these programs.
     # - `dialign-t` has disappeared in favour of its successor `dialign-tx`. I can't find an
@@ -59,11 +58,15 @@ class Tcoffee(MakefilePackage):
     variant("expresso", default=False, description="Very accurate structure-based MSA")
     variant("3dcoffee", default=False, description="Multiple structure alignments")
     variant("rcoffee", default=False, description="RNA MSA")
-    variant("saracoffee", default=False, description="Structure-based multiple RNA alignment")
+    # variant("saracoffee", default=False, description="Structure-based multiple RNA alignment")
     variant("trmsd", default=False, description="RMSD-based structural clustering of proteins")
     variant(
         "seq_reformat", default=False, description="Clean, reformat, and compare MSAs and trees"
     )
+
+    # ensure ~all is explicit when +variants are declared
+    for v in ("mcoffee", "psicoffee", "expresso", "3dcoffee", "rcoffee", "trmsd", "seq_reformat"):
+        conflicts(f"+{v}", when="+all")
 
     with when("+all") or when("+mcoffee"):
         depends_on("clustalw", type="run")  # this is clustalw2
@@ -102,10 +105,6 @@ class Tcoffee(MakefilePackage):
         depends_on("probconsrna", type="run")
         depends_on("consan", type="run")
         depends_on("viennarna", type="run")
-
-    with when("+all") or when("+saracoffee"):
-        # depends_on("x3dna", type="run")
-        pass
 
     with when("+all") or when("+trmsd"):
         depends_on("phylip", type="run")

--- a/var/spack/repos/builtin/packages/tcoffee/package.py
+++ b/var/spack/repos/builtin/packages/tcoffee/package.py
@@ -24,11 +24,7 @@ class Tcoffee(MakefilePackage):
     license("GPL-2.0-only", checked_by="A-N-Other")
 
     version("13.46.0.919e8c6b", tag="Version_13.46.0.919e8c6b")
-    version(
-        "11.0",
-        commit="f389b558e91d0f82e7db934d9a79ce285f853a71",
-        deprecated=True,
-    )
+    version("11.0", commit="f389b558e91d0f82e7db934d9a79ce285f853a71", deprecated=True)
 
     depends_on("perl", type=("build", "link", "run"))
     depends_on("perl-xml-simple", type="run")
@@ -67,10 +63,12 @@ class Tcoffee(MakefilePackage):
     variant("rcoffee", default=False, description="RNA MSA")
     variant("saracoffee", default=False, description="Structure-based multiple RNA alignment")
     variant("trmsd", default=False, description="RMSD-based structural clustering of proteins")
-    variant("seq_reformat", default=False, description="Clean, reformat, and compare MSAs and trees")
+    variant(
+        "seq_reformat", default=False, description="Clean, reformat, and compare MSAs and trees"
+    )
 
     with when("+all") or when("+mcoffee"):
-        depends_on("clustalw", type="run") # this is clustalw2
+        depends_on("clustalw", type="run")  # this is clustalw2
         depends_on("dialign-tx", type="run")
         depends_on("poamsa", type="run")
         depends_on("probcons", type="run")
@@ -100,7 +98,7 @@ class Tcoffee(MakefilePackage):
         pass
 
     with when("+all") or when("+rcoffee"):
-        depends_on("clustalw", type="run") # this is clustalw2
+        depends_on("clustalw", type="run")  # this is clustalw2
         depends_on("famsa", type="run")
         depends_on("muscle", type="run")
         depends_on("probconsrna", type="run")
@@ -128,17 +126,15 @@ class Tcoffee(MakefilePackage):
             with open("/proc/sys/kernel/pid_max") as f:
                 return f.read().strip()
         except:
-            return 4194304 # 64-bit default
+            return 4194304  # 64-bit default
 
     def edit(self, spec, prefix):
-        filter_file(
-            "CC =.*",
-            f"CC = {spack_cxx}",
-            join_path(self.build_directory, "makefile"))
+        filter_file("CC =.*", f"CC = {spack_cxx}", join_path(self.build_directory, "makefile"))
         filter_file(
             "#define MAX_N_PID.*",
             f"#define MAX_N_PID {self.sys_max_pid}",
-            join_path("lib", "coffee_defines.h"))
+            join_path("lib", "coffee_defines.h"),
+        )
 
     def build(self, spec, prefix):
         with working_dir(self.build_directory):

--- a/var/spack/repos/builtin/packages/tcoffee/package.py
+++ b/var/spack/repos/builtin/packages/tcoffee/package.py
@@ -1,9 +1,7 @@
-# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-from datetime import date
-import os
 
 from spack.package import *
 
@@ -125,7 +123,7 @@ class Tcoffee(MakefilePackage):
         try:
             with open("/proc/sys/kernel/pid_max") as f:
                 return f.read().strip()
-        except:
+        except (FileNotFoundError, IOError) as e:
             return 4194304  # 64-bit default
 
     def edit(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/tcoffee/package.py
+++ b/var/spack/repos/builtin/packages/tcoffee/package.py
@@ -1,7 +1,8 @@
-# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
 
 from spack.package import *
 
@@ -26,69 +27,106 @@ class Tcoffee(MakefilePackage):
     )
 
     depends_on("perl", type="run")
-    depends_on("perl-soap-lite", type="run")
     depends_on("perl-xml-simple", type="run")
 
-    variant("t_coffee", default=True, description="Regular MSA")
-    variant("rcoffee", default=False, description="RNA MSA")
+    # t_coffee / common dependencies
+    depends_on("strike", type="run")
+    depends_on("gor", type="run")
+    depends_on("blast-plus", type="run")
+    depends_on("mafft", type="run")
+    depends_on("clustal-omega", type="run")
+
+    #
+    # Variants and their required dependencies are taken from the ./install script (L1642-)
+    #
+    # Notes:
+    # - `x3dna`, `hmmtop`, and `fugue` are distributed manually / under manual license
+    #   agreement. These have been removed to allow simpler install of the package.
+    # - `saracoffee` variant is disabled for now due to dependency on `x3dna`.
+    # - `dialign-tx` doesn't compile properly and is remaining as an optional dependency
+    # - `lsqman` and `align_pdb` are extremely old. I can't find a extant source of these
+    #   programs and/or can't persuade them to compile.
+    #
+
+    variant("mcoffee", default=False, description="Meta-alignment with multiple MSA programs")
     variant("psicoffee", default=False, description="Homology extended MSA")
     variant("expresso", default=False, description="Very accurate structure-based MSA")
     variant("3dcoffee", default=False, description="Multiple structure alignments")
-    variant("mcoffee", default=False, description="Meta-alignment with multiple MSA programs")
+    variant("rcoffee", default=False, description="RNA MSA")
+    # variant("saracoffee", default=False, description="Structure-based multiple RNA alignment")
+    variant("trmsd", default=False, description="RMSD-based structural clustering of related proteins")
 
-    # Dependencies taken from ./install script
-    # TODO: lots of missing dependencies!
-    # TODO: context managers as below to specify these per variant
+    with when("+mcoffee"):
+        depends_on("clustalw", type="run") # this is clustalw2
+        depends_on("dialign", type="run") # this is dialign-t
+        # depends_on("dialign-tx", type="run")
+        depends_on("poamsa", type="run")
+        depends_on("probcons", type="run")
+        depends_on("probconsrna", type="run")
+        depends_on("msaprobs", type="run")
+        depends_on("famsa", type="run")
+        depends_on("msa", type="run")
+        depends_on("dca", type="run")
+        depends_on("muscle", type="run")
+        depends_on("pcma", type="run")
+        depends_on("kalign", type="run")
+        depends_on("amap", type="run")
+        depends_on("proda", type="run")
+        depends_on("prank", type="run")
+        depends_on("fsa", type="run")
 
-    # with when("@3: +trilinos"):
-    #    depends_on("trilinos@12.6:")
+    with when("+expresso") or when("+3dcoffee"):
+        depends_on("sap", type="run")
+        depends_on("tmalign", type="run")
+        depends_on("mustang", type="run")
+        # depends_on("lsqman", type="run")
+        # depends_on("pdb_align", type="run")
+        # depends_on("fugue", type="run")
 
+    with when("+psicoffee"):
+        # depends_on("hmmtop", type="run")
+        pass
 
+    with when("+rcoffee"):
+        depends_on("clustalw", type="run") # this is clustalw2
+        depends_on("famsa", type="run")
+        depends_on("muscle", type="run")
+        depends_on("probconsrna", type="run")
+        depends_on("consan", type="run")
+        depends_on("viennarna", type="run")
 
-    # depends_on("clustalo", type="run")
-    # depends_on("strike", type="run")
-    # depends_on("clustalw2", type="run")
-    depends_on("clustalw", type="run")
-    # depends_on("dialign-t", type="run")
-    depends_on("dialign-tx", type="run")
-    depends_on("poamsa", type="run")
-    depends_on("probconsrna", type="run")
-    # depends_on("msaprobs", type="run")
-    # depends_on("upp", type="run")
-    # depends_on("famsa", type="run")
-    depends_on("mafft", type="run")
-    # depends_on("msa", type="run")
-    # depends_on("dca", type="run")
-    depends_on("muscle", type="run")
-    depends_on("pcma", type="run")
-    # depends_on("kalign", type="run")
-    # depends_on("amap", type="run")
-    # depends_on("proda", type="run")
-    # depends_on("prank", type="run")
-    # depends_on("sap", type="run")
-    depends_on("tmalign", type="run")
-    # depends_on("mustang", type="run")
-    # depends_on("fugue", type="run")
-    # depends_on("dali-lite", type="run")
-    # depends_on("sfold", type="run")
-    depends_on("viennarna", type="run")
-    # depends_on("retree", type="run")
-    # depends_on("hmmtop", type="run")
-    # depends_on("goriv", type="run")
-    depends_on("blast-legacy", type="run")
-    # depends_on("x3dna", type="run")
-    # depends_on("fsa", type="run")
+    # with when("+saracoffee"):
+    #     depends_on("x3dna", type="run")
+
+    with when("+trmsd"):
+        depends_on("phylip", type="run")
 
     @property
     def build_directory(self):
-        if spec.satisfies("@13:"):
+        if self.spec.satisfies("@13:"):
             return "t_coffee_source"
         else:
-            return"compile"
+            return "compile"
+
+    @property
+    def sys_max_pid(self):
+        if self.spec.satisfies("platform=darwin"):
+            return 99998
+        try:
+            with open("/proc/sys/kernel/pid_max") as f:
+                return f.read().strip()
+        except:
+            return 4194304 # 64-bit default
 
     def edit(self, spec, prefix):
         with working_dir(self.build_directory):
-            filter_file("CC=g++", f"CC={spack_cxx}", "makefile")
+            filter_file("CC=.*", f"CC={spack_cxx}", "makefile")
+            filter_file("#define MAX_N_PID.*", f"#define MAX_N_PID {self.sys_max_pid}", "coffee_defines.h")
+
+    def flag_handler(self, name, flags):
+        if name == "cxxflags":
+            flags.append("-std=c++11")
+        return flags, None, None
 
     def build(self, spec, prefix):
         with working_dir(self.build_directory):
@@ -98,3 +136,7 @@ class Tcoffee(MakefilePackage):
         mkdirp(prefix.bin)
         with working_dir(self.build_directory):
             install("t_coffee", prefix.bin)
+        install_tree("mcoffee", prefix.mcoffee)
+
+    def setup_run_environment(self, env):
+        env.set("MCOFFEE_4_TCOFFEE", self.prefix.mcoffee)

--- a/var/spack/repos/builtin/packages/tcoffee/package.py
+++ b/var/spack/repos/builtin/packages/tcoffee/package.py
@@ -123,7 +123,7 @@ class Tcoffee(MakefilePackage):
         try:
             with open("/proc/sys/kernel/pid_max") as f:
                 return f.read().strip()
-        except (FileNotFoundError, IOError) as e:
+        except (FileNotFoundError, IOError):
             return 4194304  # 64-bit default
 
     def edit(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/tcoffee/package.py
+++ b/var/spack/repos/builtin/packages/tcoffee/package.py
@@ -29,9 +29,21 @@ class Tcoffee(MakefilePackage):
     depends_on("perl-soap-lite", type="run")
     depends_on("perl-xml-simple", type="run")
 
+    variant("t_coffee", default=True, description="Regular MSA")
+    variant("rcoffee", default=False, description="RNA MSA")
+    variant("psicoffee", default=False, description="Homology extended MSA")
+    variant("expresso", default=False, description="Very accurate structure-based MSA")
+    variant("3dcoffee", default=False, description="Multiple structure alignments")
+    variant("mcoffee", default=False, description="Meta-alignment with multiple MSA programs")
+
     # Dependencies taken from ./install script
     # TODO: lots of missing dependencies!
-    # TODO: make variants for these as per the ./install script
+    # TODO: context managers as below to specify these per variant
+
+    # with when("@3: +trilinos"):
+    #    depends_on("trilinos@12.6:")
+
+
 
     # depends_on("clustalo", type="run")
     # depends_on("strike", type="run")

--- a/var/spack/repos/builtin/packages/tcoffee/package.py
+++ b/var/spack/repos/builtin/packages/tcoffee/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from datetime import date
 import os
 
 from spack.package import *
@@ -12,22 +13,26 @@ class Tcoffee(MakefilePackage):
     multiple alignments of DNA, RNA, protein sequences and structures"""
 
     homepage = "https://tcoffee.org/Projects/tcoffee/index.html"
+
+    # tcoffee is officially distributed through
+    #   https://tcoffee.org/Projects/tcoffee/index.html
+    # however these source bundles do not build properly with spack - error-free completion
+    # but the binary segfaults. These bundles are generated from a CI pipeline running on
+    # the top-level GitHub source, which does build properly, so we use that...
     git = "https://github.com/cbcrg/tcoffee.git"
-    url = "https://s3.eu-central-1.amazonaws.com/tcoffee-packages/Archives/T-COFFEE_distribution_Version_13.46.0.919e8c6b.tar.gz"
 
     license("GPL-2.0-only", checked_by="A-N-Other")
 
-    version(
-        "13.46.0.919e8c6b",
-        sha256="31fd0ca0734974c93cb68bef6e394f463a4589c3315fd28cf2bd41b8a167db22")
+    version("13.46.0.919e8c6b", tag="Version_13.46.0.919e8c6b")
     version(
         "11.0",
         commit="f389b558e91d0f82e7db934d9a79ce285f853a71",
         deprecated=True,
     )
 
-    depends_on("perl", type="run")
+    depends_on("perl", type=("build", "link", "run"))
     depends_on("perl-xml-simple", type="run")
+    depends_on("perl-soap-lite", type="run")
 
     # t_coffee / common dependencies
     depends_on("strike", type="run")
@@ -36,30 +41,37 @@ class Tcoffee(MakefilePackage):
     depends_on("mafft", type="run")
     depends_on("clustal-omega", type="run")
 
+    # Variants and their required dependencies are formed by parsing the program:mode pairs
+    # within the ./lib/data_headers/tclinkdb.txt file.
     #
-    # Variants and their required dependencies are taken from the ./install script (L1642-)
-    #
-    # Notes:
+    # Notes on listed dependencies:
+    # * All dependencies are technically optional. They extend the core functionality.
     # - `x3dna`, `hmmtop`, and `fugue` are distributed manually / under manual license
-    #   agreement. These have been removed to allow simpler install of the package.
-    # - `saracoffee` variant is disabled for now due to dependency on `x3dna`.
-    # - `dialign-tx` doesn't compile properly and is remaining as an optional dependency
-    # - `lsqman` and `align_pdb` are extremely old. I can't find a extant source of these
-    #   programs and/or can't persuade them to compile.
-    #
+    #   agreement. These have been removed here to allow simpler install of the package.
+    #   - `saracoffee` variant is a stub due to dependency on `x3dna`.
+    #   - `psicoffee` variant is a stub due to dependency on `hmmtop`.
+    # - `lsqman` and `align_pdb` are extremely old. I can't find extant / reputable sources
+    #   for these programs.
+    # - `dialign-t` has disappeared in favour of its successor `dialign-tx`. I can't find an
+    #   extant download for this version.
+    # - `muscle4` was never released properly and is dropped here. This was an experimental
+    #   version between `3` and `muscle5`.
+    # - The version of `upp` expected by tcoffee is obsolete and the dependency is dropped
+    #   here. UPP2 is now distributed with `sepp` but has a different interface.
 
+    variant("all", default=True, description="Enable all functionality", sticky=True)
     variant("mcoffee", default=False, description="Meta-alignment with multiple MSA programs")
     variant("psicoffee", default=False, description="Homology extended MSA")
     variant("expresso", default=False, description="Very accurate structure-based MSA")
     variant("3dcoffee", default=False, description="Multiple structure alignments")
     variant("rcoffee", default=False, description="RNA MSA")
-    # variant("saracoffee", default=False, description="Structure-based multiple RNA alignment")
-    variant("trmsd", default=False, description="RMSD-based structural clustering of related proteins")
+    variant("saracoffee", default=False, description="Structure-based multiple RNA alignment")
+    variant("trmsd", default=False, description="RMSD-based structural clustering of proteins")
+    variant("seq_reformat", default=False, description="Clean, reformat, and compare MSAs and trees")
 
-    with when("+mcoffee"):
+    with when("+all") or when("+mcoffee"):
         depends_on("clustalw", type="run") # this is clustalw2
-        depends_on("dialign", type="run") # this is dialign-t
-        # depends_on("dialign-tx", type="run")
+        depends_on("dialign-tx", type="run")
         depends_on("poamsa", type="run")
         depends_on("probcons", type="run")
         depends_on("probconsrna", type="run")
@@ -75,7 +87,7 @@ class Tcoffee(MakefilePackage):
         depends_on("prank", type="run")
         depends_on("fsa", type="run")
 
-    with when("+expresso") or when("+3dcoffee"):
+    with when("+all") or when("+expresso") or when("+3dcoffee"):
         depends_on("sap", type="run")
         depends_on("tmalign", type="run")
         depends_on("mustang", type="run")
@@ -83,11 +95,11 @@ class Tcoffee(MakefilePackage):
         # depends_on("pdb_align", type="run")
         # depends_on("fugue", type="run")
 
-    with when("+psicoffee"):
+    with when("+all") or when("+psicoffee"):
         # depends_on("hmmtop", type="run")
         pass
 
-    with when("+rcoffee"):
+    with when("+all") or when("+rcoffee"):
         depends_on("clustalw", type="run") # this is clustalw2
         depends_on("famsa", type="run")
         depends_on("muscle", type="run")
@@ -95,18 +107,18 @@ class Tcoffee(MakefilePackage):
         depends_on("consan", type="run")
         depends_on("viennarna", type="run")
 
-    # with when("+saracoffee"):
-    #     depends_on("x3dna", type="run")
+    with when("+all") or when("+saracoffee"):
+        # depends_on("x3dna", type="run")
+        pass
 
-    with when("+trmsd"):
+    with when("+all") or when("+trmsd"):
         depends_on("phylip", type="run")
 
-    @property
-    def build_directory(self):
-        if self.spec.satisfies("@13:"):
-            return "t_coffee_source"
-        else:
-            return "compile"
+    with when("+all") or when("+seq_reformat"):
+        depends_on("phylip", type="run")
+        depends_on("viennarna", type="run")
+
+    build_directory = "t_coffee/src"
 
     @property
     def sys_max_pid(self):
@@ -119,14 +131,14 @@ class Tcoffee(MakefilePackage):
             return 4194304 # 64-bit default
 
     def edit(self, spec, prefix):
-        with working_dir(self.build_directory):
-            filter_file("CC=.*", f"CC={spack_cxx}", "makefile")
-            filter_file("#define MAX_N_PID.*", f"#define MAX_N_PID {self.sys_max_pid}", "coffee_defines.h")
-
-    def flag_handler(self, name, flags):
-        if name == "cxxflags":
-            flags.append("-std=c++11")
-        return flags, None, None
+        filter_file(
+            "CC =.*",
+            f"CC = {spack_cxx}",
+            join_path(self.build_directory, "makefile"))
+        filter_file(
+            "#define MAX_N_PID.*",
+            f"#define MAX_N_PID {self.sys_max_pid}",
+            join_path("lib", "coffee_defines.h"))
 
     def build(self, spec, prefix):
         with working_dir(self.build_directory):
@@ -134,9 +146,8 @@ class Tcoffee(MakefilePackage):
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        with working_dir(self.build_directory):
-            install("t_coffee", prefix.bin)
-        install_tree("mcoffee", prefix.mcoffee)
+        install(join_path(self.build_directory, "t_coffee"), prefix.bin)
+        install_tree(join_path("lib", "mcoffee"), prefix.mcoffee)
 
     def setup_run_environment(self, env):
         env.set("MCOFFEE_4_TCOFFEE", self.prefix.mcoffee)


### PR DESCRIPTION
This is a bit of a mammoth update to `tcoffee`...

Though they're technically optional, as they extend the core functionality, the previous version was missing the majority of the dependencies that would be installed normally (as per `bioconda` etc or via `tcoffee`'s own `./install` script). I've added 13 new packages here that bring this as far forwards as practical and have done a complete rewrite of the `package.py` to add in the different variants and their individual dependency trees and to adjust the build for modern systems. I've corrected build issues with a few other packages along the way.

I've deprecated the previous version as it's extremely old but have also given it it's correct version number (from https://github.com/cbcrg/tcoffee/blob/f389b558e91d0f82e7db934d9a79ce285f853a71/lib/version_number.version).

Tested and working on `linux-rocky8-icelake`. This will be a somewhat experimental PR as until the testing pipeline runs, I've no idea how all these new dependencies will react on `arm` arch systems and/or `darwin` platforms. Some of them are extremely (!) old.

// EDIT // Remarkably, all the builds passed first time 🤯 