### PR TITLE
PythonPackage: check purelib for libs/headers

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -361,8 +361,8 @@ class PythonPackage(PythonExtension):
         if headers:
             return headers
 
-        msg = "Unable to locate {} headers in {} or {}"
-        raise NoHeadersError(msg.format(self.spec.name, include, platlib))
+        msg = "Unable to locate {} headers in {}, {}, or {}"
+        raise NoHeadersError(msg.format(self.spec.name, include, platlib, purelib))
 
     @property
     def libs(self) -> LibraryList:
@@ -382,8 +382,8 @@ class PythonPackage(PythonExtension):
         if libs:
             return libs
 
-        msg = "Unable to recursively locate {} libraries in {}"
-        raise NoLibrariesError(msg.format(self.spec.name, root))
+        msg = "Unable to recursively locate {} libraries in {} or {}"
+        raise NoLibrariesError(msg.format(self.spec.name, platlib, purelib))
 
 
 @spack.builder.builder("python_pip")

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -356,7 +356,7 @@ class PythonPackage(PythonExtension):
 
         find_all_headers = functools.partial(fs.find_all_headers, recursive=True)
         headers_list = map(find_all_headers, [include, platlib, purelib])
-        headers = functools.reduce(headers_list, operator.add)
+        headers = functools.reduce(operator.add, headers_list)
 
         if headers:
             return headers
@@ -377,7 +377,7 @@ class PythonPackage(PythonExtension):
 
         find_all_libraries = functools.partial(fs.find_all_libraries, recursive=True)
         libs_list = map(find_all_libraries, [platlib, purelib])
-        libs = functools.reduce(libs_list, operator.add)
+        libs = functools.reduce(operator.add, libs_list)
 
         if libs:
             return libs


### PR DESCRIPTION
Fixes #42441, where the libs/headers somehow ended up in purelib instead of platlib.

Let me know if the functional programming stuff is hard to read. I can replace it with for-loops if needed.

@srinathv 