### PR TITLE
fenicsx: deprecate older versions

### DIFF
--- a/var/spack/repos/builtin/packages/fenics-basix/package.py
+++ b/var/spack/repos/builtin/packages/fenics-basix/package.py
@@ -19,8 +19,16 @@ class FenicsBasix(CMakePackage):
     version("main", branch="main")
     version("0.7.0", sha256="9bee81b396ee452eec8d9735f278cb44cb6994c6bc30aec8ed9bb4b12d83fa7f")
     version("0.6.0", sha256="687ae53153c98facac4080dcdc7081701db1dcea8c5e7ae3feb72aec17f83304")
-    version("0.5.1", sha256="69133476ac35f0bd0deccb480676030378c341d7dfb2adaca22cd16b7e1dc1cb", deprecated=True)
-    version("0.4.2", sha256="a54f5e442b7cbf3dbb6319c682f9161272557bd7f42e2b8b8ccef88bc1b7a22f", deprecated=True)
+    version(
+        "0.5.1",
+        sha256="69133476ac35f0bd0deccb480676030378c341d7dfb2adaca22cd16b7e1dc1cb",
+        deprecated=True,
+    )
+    version(
+        "0.4.2",
+        sha256="a54f5e442b7cbf3dbb6319c682f9161272557bd7f42e2b8b8ccef88bc1b7a22f",
+        deprecated=True,
+    )
 
     depends_on("cmake@3.19:", type="build")
     depends_on("blas")

--- a/var/spack/repos/builtin/packages/fenics-basix/package.py
+++ b/var/spack/repos/builtin/packages/fenics-basix/package.py
@@ -46,6 +46,4 @@ class FenicsBasix(CMakePackage):
         msg="fenics-basix requires Clang-10 or newer for C++20 support",
     )
 
-    @property
-    def root_cmakelists_dir(self):
-        return "cpp"
+    root_cmakelists_dir = "cpp"

--- a/var/spack/repos/builtin/packages/fenics-basix/package.py
+++ b/var/spack/repos/builtin/packages/fenics-basix/package.py
@@ -19,23 +19,8 @@ class FenicsBasix(CMakePackage):
     version("main", branch="main")
     version("0.7.0", sha256="9bee81b396ee452eec8d9735f278cb44cb6994c6bc30aec8ed9bb4b12d83fa7f")
     version("0.6.0", sha256="687ae53153c98facac4080dcdc7081701db1dcea8c5e7ae3feb72aec17f83304")
-    version("0.5.1", sha256="69133476ac35f0bd0deccb480676030378c341d7dfb2adaca22cd16b7e1dc1cb")
-    version("0.4.2", sha256="a54f5e442b7cbf3dbb6319c682f9161272557bd7f42e2b8b8ccef88bc1b7a22f")
-    version(
-        "0.3.0",
-        sha256="9b148fd2a5485c94011fc6ca977ebdef0e51782a62b3654fc044f35b60e2bd07",
-        deprecated=True,
-    )
-    version(
-        "0.2.0",
-        sha256="e1ec537737adb283717060221635092474e3f2b5b5ba79dfac74aa496bec2fcb",
-        deprecated=True,
-    )
-    version(
-        "0.1.0",
-        sha256="2ab41fe6ad4f6c42f01b17a6e7c39debb4e0ae61c334d1caebee78b741bca4e7",
-        deprecated=True,
-    )
+    version("0.5.1", sha256="69133476ac35f0bd0deccb480676030378c341d7dfb2adaca22cd16b7e1dc1cb", deprecated=True)
+    version("0.4.2", sha256="a54f5e442b7cbf3dbb6319c682f9161272557bd7f42e2b8b8ccef88bc1b7a22f", deprecated=True)
 
     depends_on("cmake@3.19:", type="build")
     depends_on("blas")
@@ -43,7 +28,6 @@ class FenicsBasix(CMakePackage):
 
     depends_on("xtensor@0.23.10:", when="@:0.4")
     depends_on("xtl@0.7.2:", when="@:0.4")
-    depends_on("xtensor-blas@0.19.1:", when="@:0.3")
 
     conflicts(
         "%gcc@:9.10", when="@0.5.0:", msg="fenics-basix requires GCC-10 or newer for C++20 support"
@@ -56,6 +40,4 @@ class FenicsBasix(CMakePackage):
 
     @property
     def root_cmakelists_dir(self):
-        if self.spec.satisfies("@0.4.0:"):
-            return "cpp"
-        return self.stage.source_path
+        return "cpp"

--- a/var/spack/repos/builtin/packages/fenics-dolfinx/package.py
+++ b/var/spack/repos/builtin/packages/fenics-dolfinx/package.py
@@ -19,9 +19,9 @@ class FenicsDolfinx(CMakePackage):
     version("main", branch="main")
     version("0.7.2", sha256="7d9ce1338ce66580593b376327f23ac464a4ce89ef63c105efc1a38e5eae5c0b")
     version("0.6.0", sha256="eb8ac2bb2f032b0d393977993e1ab6b4101a84d54023a67206e3eac1a8d79b80")
-    version("0.5.1", sha256="a570e3f6ed8e7c570e7e61d0e6fd44fa9dad2c5f8f1f48a6dc9ad22bacfbc973")
-    version("0.5.0", sha256="503c70c01a44d1ffe48e052ca987693a49f8d201877652cabbe2a44eb3b7c040")
-    version("0.4.1", sha256="68dcf29a26c750fcea5e02d8d58411e3b054313c3bf6fcbc1d0f08dd2851117f")
+    version("0.5.1", sha256="a570e3f6ed8e7c570e7e61d0e6fd44fa9dad2c5f8f1f48a6dc9ad22bacfbc973", deprecated=True)
+    version("0.5.0", sha256="503c70c01a44d1ffe48e052ca987693a49f8d201877652cabbe2a44eb3b7c040", deprecated=True)
+    version("0.4.1", sha256="68dcf29a26c750fcea5e02d8d58411e3b054313c3bf6fcbc1d0f08dd2851117f", deprecated=True)
 
     conflicts(
         "%gcc@:9.10",

--- a/var/spack/repos/builtin/packages/fenics-dolfinx/package.py
+++ b/var/spack/repos/builtin/packages/fenics-dolfinx/package.py
@@ -19,9 +19,21 @@ class FenicsDolfinx(CMakePackage):
     version("main", branch="main")
     version("0.7.2", sha256="7d9ce1338ce66580593b376327f23ac464a4ce89ef63c105efc1a38e5eae5c0b")
     version("0.6.0", sha256="eb8ac2bb2f032b0d393977993e1ab6b4101a84d54023a67206e3eac1a8d79b80")
-    version("0.5.1", sha256="a570e3f6ed8e7c570e7e61d0e6fd44fa9dad2c5f8f1f48a6dc9ad22bacfbc973", deprecated=True)
-    version("0.5.0", sha256="503c70c01a44d1ffe48e052ca987693a49f8d201877652cabbe2a44eb3b7c040", deprecated=True)
-    version("0.4.1", sha256="68dcf29a26c750fcea5e02d8d58411e3b054313c3bf6fcbc1d0f08dd2851117f", deprecated=True)
+    version(
+        "0.5.1",
+        sha256="a570e3f6ed8e7c570e7e61d0e6fd44fa9dad2c5f8f1f48a6dc9ad22bacfbc973",
+        deprecated=True,
+    )
+    version(
+        "0.5.0",
+        sha256="503c70c01a44d1ffe48e052ca987693a49f8d201877652cabbe2a44eb3b7c040",
+        deprecated=True,
+    )
+    version(
+        "0.4.1",
+        sha256="68dcf29a26c750fcea5e02d8d58411e3b054313c3bf6fcbc1d0f08dd2851117f",
+        deprecated=True,
+    )
 
     conflicts(
         "%gcc@:9.10",

--- a/var/spack/repos/builtin/packages/fenics-ufcx/package.py
+++ b/var/spack/repos/builtin/packages/fenics-ufcx/package.py
@@ -22,11 +22,20 @@ class FenicsUfcx(CMakePackage):
     version("0.7.0", sha256="7f3c3ca91d63ce7831d37799cc19d0551bdcd275bdfa4c099711679533dd1c71")
     version("0.6.0", sha256="076fad61d406afffd41019ae1abf6da3f76406c035c772abad2156127667980e")
     version(
-        "0.5.0.post0", sha256="039908c9998b51ba53e5deb3a97016062c262f0a4285218644304f7d3cd35882",
-        deprecated=True
+        "0.5.0.post0",
+        sha256="039908c9998b51ba53e5deb3a97016062c262f0a4285218644304f7d3cd35882",
+        deprecated=True,
     )
-    version("0.5.0", sha256="3413409e5885e41e220f99e0f95cc817e94c4931143d1f700c6e0c5e1bfad1f6", deprecated=True)
-    version("0.4.2", sha256="3be6eef064d6ef907245db5b6cc15d4e603762e68b76e53e099935ca91ef1ee4", deprecated=True)
+    version(
+        "0.5.0",
+        sha256="3413409e5885e41e220f99e0f95cc817e94c4931143d1f700c6e0c5e1bfad1f6",
+        deprecated=True,
+    )
+    version(
+        "0.4.2",
+        sha256="3be6eef064d6ef907245db5b6cc15d4e603762e68b76e53e099935ca91ef1ee4",
+        deprecated=True,
+    )
 
     depends_on("cmake@3.19:", type="build")
 

--- a/var/spack/repos/builtin/packages/fenics-ufcx/package.py
+++ b/var/spack/repos/builtin/packages/fenics-ufcx/package.py
@@ -22,10 +22,11 @@ class FenicsUfcx(CMakePackage):
     version("0.7.0", sha256="7f3c3ca91d63ce7831d37799cc19d0551bdcd275bdfa4c099711679533dd1c71")
     version("0.6.0", sha256="076fad61d406afffd41019ae1abf6da3f76406c035c772abad2156127667980e")
     version(
-        "0.5.0.post0", sha256="039908c9998b51ba53e5deb3a97016062c262f0a4285218644304f7d3cd35882"
+        "0.5.0.post0", sha256="039908c9998b51ba53e5deb3a97016062c262f0a4285218644304f7d3cd35882",
+        deprecated=True
     )
-    version("0.5.0", sha256="3413409e5885e41e220f99e0f95cc817e94c4931143d1f700c6e0c5e1bfad1f6")
-    version("0.4.2", sha256="3be6eef064d6ef907245db5b6cc15d4e603762e68b76e53e099935ca91ef1ee4")
+    version("0.5.0", sha256="3413409e5885e41e220f99e0f95cc817e94c4931143d1f700c6e0c5e1bfad1f6", deprecated=True)
+    version("0.4.2", sha256="3be6eef064d6ef907245db5b6cc15d4e603762e68b76e53e099935ca91ef1ee4", deprecated=True)
 
     depends_on("cmake@3.19:", type="build")
 

--- a/var/spack/repos/builtin/packages/py-fenics-basix/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-basix/package.py
@@ -19,8 +19,16 @@ class PyFenicsBasix(PythonPackage):
     version("main", branch="main")
     version("0.7.0", sha256="9bee81b396ee452eec8d9735f278cb44cb6994c6bc30aec8ed9bb4b12d83fa7f")
     version("0.6.0", sha256="687ae53153c98facac4080dcdc7081701db1dcea8c5e7ae3feb72aec17f83304")
-    version("0.5.1", sha256="69133476ac35f0bd0deccb480676030378c341d7dfb2adaca22cd16b7e1dc1cb", deprecated=True)
-    version("0.4.2", sha256="a54f5e442b7cbf3dbb6319c682f9161272557bd7f42e2b8b8ccef88bc1b7a22f", deprecated=True)
+    version(
+        "0.5.1",
+        sha256="69133476ac35f0bd0deccb480676030378c341d7dfb2adaca22cd16b7e1dc1cb",
+        deprecated=True,
+    )
+    version(
+        "0.4.2",
+        sha256="a54f5e442b7cbf3dbb6319c682f9161272557bd7f42e2b8b8ccef88bc1b7a22f",
+        deprecated=True,
+    )
 
     depends_on("fenics-basix@main", type=("build", "run"), when="@main")
     depends_on("fenics-basix@0.7.0", type=("build", "run"), when="@0.7.0")

--- a/var/spack/repos/builtin/packages/py-fenics-basix/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-basix/package.py
@@ -19,8 +19,8 @@ class PyFenicsBasix(PythonPackage):
     version("main", branch="main")
     version("0.7.0", sha256="9bee81b396ee452eec8d9735f278cb44cb6994c6bc30aec8ed9bb4b12d83fa7f")
     version("0.6.0", sha256="687ae53153c98facac4080dcdc7081701db1dcea8c5e7ae3feb72aec17f83304")
-    version("0.5.1", sha256="69133476ac35f0bd0deccb480676030378c341d7dfb2adaca22cd16b7e1dc1cb")
-    version("0.4.2", sha256="a54f5e442b7cbf3dbb6319c682f9161272557bd7f42e2b8b8ccef88bc1b7a22f")
+    version("0.5.1", sha256="69133476ac35f0bd0deccb480676030378c341d7dfb2adaca22cd16b7e1dc1cb", deprecated=True)
+    version("0.4.2", sha256="a54f5e442b7cbf3dbb6319c682f9161272557bd7f42e2b8b8ccef88bc1b7a22f", deprecated=True)
 
     depends_on("fenics-basix@main", type=("build", "run"), when="@main")
     depends_on("fenics-basix@0.7.0", type=("build", "run"), when="@0.7.0")

--- a/var/spack/repos/builtin/packages/py-fenics-dolfinx/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-dolfinx/package.py
@@ -20,9 +20,9 @@ class PyFenicsDolfinx(PythonPackage):
     version("main", branch="main")
     version("0.7.2", sha256="7d9ce1338ce66580593b376327f23ac464a4ce89ef63c105efc1a38e5eae5c0b")
     version("0.6.0", sha256="eb8ac2bb2f032b0d393977993e1ab6b4101a84d54023a67206e3eac1a8d79b80")
-    version("0.5.1", sha256="a570e3f6ed8e7c570e7e61d0e6fd44fa9dad2c5f8f1f48a6dc9ad22bacfbc973")
-    version("0.5.0", sha256="503c70c01a44d1ffe48e052ca987693a49f8d201877652cabbe2a44eb3b7c040")
-    version("0.4.1", sha256="68dcf29a26c750fcea5e02d8d58411e3b054313c3bf6fcbc1d0f08dd2851117f")
+    version("0.5.1", sha256="a570e3f6ed8e7c570e7e61d0e6fd44fa9dad2c5f8f1f48a6dc9ad22bacfbc973", deprecated=True)
+    version("0.5.0", sha256="503c70c01a44d1ffe48e052ca987693a49f8d201877652cabbe2a44eb3b7c040", deprecated=True)
+    version("0.4.1", sha256="68dcf29a26c750fcea5e02d8d58411e3b054313c3bf6fcbc1d0f08dd2851117f", deprecated=True)
 
     depends_on("cmake@3.19:", type="build")
     depends_on("hdf5", type="build")

--- a/var/spack/repos/builtin/packages/py-fenics-dolfinx/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-dolfinx/package.py
@@ -20,9 +20,21 @@ class PyFenicsDolfinx(PythonPackage):
     version("main", branch="main")
     version("0.7.2", sha256="7d9ce1338ce66580593b376327f23ac464a4ce89ef63c105efc1a38e5eae5c0b")
     version("0.6.0", sha256="eb8ac2bb2f032b0d393977993e1ab6b4101a84d54023a67206e3eac1a8d79b80")
-    version("0.5.1", sha256="a570e3f6ed8e7c570e7e61d0e6fd44fa9dad2c5f8f1f48a6dc9ad22bacfbc973", deprecated=True)
-    version("0.5.0", sha256="503c70c01a44d1ffe48e052ca987693a49f8d201877652cabbe2a44eb3b7c040", deprecated=True)
-    version("0.4.1", sha256="68dcf29a26c750fcea5e02d8d58411e3b054313c3bf6fcbc1d0f08dd2851117f", deprecated=True)
+    version(
+        "0.5.1",
+        sha256="a570e3f6ed8e7c570e7e61d0e6fd44fa9dad2c5f8f1f48a6dc9ad22bacfbc973",
+        deprecated=True,
+    )
+    version(
+        "0.5.0",
+        sha256="503c70c01a44d1ffe48e052ca987693a49f8d201877652cabbe2a44eb3b7c040",
+        deprecated=True,
+    )
+    version(
+        "0.4.1",
+        sha256="68dcf29a26c750fcea5e02d8d58411e3b054313c3bf6fcbc1d0f08dd2851117f",
+        deprecated=True,
+    )
 
     depends_on("cmake@3.19:", type="build")
     depends_on("hdf5", type="build")

--- a/var/spack/repos/builtin/packages/py-fenics-ffcx/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-ffcx/package.py
@@ -20,9 +20,15 @@ class PyFenicsFfcx(PythonPackage):
     version("0.7.0", sha256="7f3c3ca91d63ce7831d37799cc19d0551bdcd275bdfa4c099711679533dd1c71")
     version("0.6.0", sha256="076fad61d406afffd41019ae1abf6da3f76406c035c772abad2156127667980e")
     version(
-        "0.5.0.post0", sha256="039908c9998b51ba53e5deb3a97016062c262f0a4285218644304f7d3cd35882", deprecated=True
+        "0.5.0.post0",
+        sha256="039908c9998b51ba53e5deb3a97016062c262f0a4285218644304f7d3cd35882",
+        deprecated=True,
     )
-    version("0.4.2", sha256="3be6eef064d6ef907245db5b6cc15d4e603762e68b76e53e099935ca91ef1ee4", deprecated=True)
+    version(
+        "0.4.2",
+        sha256="3be6eef064d6ef907245db5b6cc15d4e603762e68b76e53e099935ca91ef1ee4",
+        deprecated=True,
+    )
 
     depends_on("python@3.8:", when="@0.7:", type=("build", "run"))
     depends_on("py-setuptools@62:", when="@0.7:", type="build")

--- a/var/spack/repos/builtin/packages/py-fenics-ffcx/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-ffcx/package.py
@@ -20,9 +20,9 @@ class PyFenicsFfcx(PythonPackage):
     version("0.7.0", sha256="7f3c3ca91d63ce7831d37799cc19d0551bdcd275bdfa4c099711679533dd1c71")
     version("0.6.0", sha256="076fad61d406afffd41019ae1abf6da3f76406c035c772abad2156127667980e")
     version(
-        "0.5.0.post0", sha256="039908c9998b51ba53e5deb3a97016062c262f0a4285218644304f7d3cd35882"
+        "0.5.0.post0", sha256="039908c9998b51ba53e5deb3a97016062c262f0a4285218644304f7d3cd35882", deprecated=True
     )
-    version("0.4.2", sha256="3be6eef064d6ef907245db5b6cc15d4e603762e68b76e53e099935ca91ef1ee4")
+    version("0.4.2", sha256="3be6eef064d6ef907245db5b6cc15d4e603762e68b76e53e099935ca91ef1ee4", deprecated=True)
 
     depends_on("python@3.8:", when="@0.7:", type=("build", "run"))
     depends_on("py-setuptools@62:", when="@0.7:", type="build")


### PR DESCRIPTION
Deprecate older beta versions of FEniCSx packages. This will allow simplification of package files in the future.
