### PR TITLE
[oneapi]: make headers match oneapi vars.sh

### DIFF
--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -179,16 +179,23 @@ class IntelOneApiLibraryPackage(IntelOneApiPackage):
 
     """
 
+    # find_headers uses heuristics to determine the include directory
+    # that does not work for oneapi packages. Use explicit directories
+    # instead.
     def header_directories(self, dirs):
         h = HeaderList([])
         h.directories = dirs
+        # trilinos passes the directories to cmake, and cmake requires
+        # that the directory exists
+        for dir in dirs:
+            RuntimeError(f"{dir} does not exist")
         return h
 
     @property
     def headers(self):
-        return self.header_directories(
-            [self.component_prefix.include, self.component_prefix.include.join(self.component_dir)]
-        )
+        # This should match the directories added to CPATH by
+        # env/vars.sh for the component
+        return self.header_directories([self.component_prefix.include])
 
     @property
     def libs(self):

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -188,7 +188,8 @@ class IntelOneApiLibraryPackage(IntelOneApiPackage):
         # trilinos passes the directories to cmake, and cmake requires
         # that the directory exists
         for dir in dirs:
-            RuntimeError(f"{dir} does not exist")
+            if not isdir(dir):
+                raise RuntimeError(f"{dir} does not exist")
         return h
 
     @property

--- a/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
@@ -117,3 +117,14 @@ class IntelOneapiDal(IntelOneApiLibraryPackage):
     @property
     def component_dir(self):
         return "dal"
+
+    @property
+    def headers(self):
+        # This should match the directories added to CPATH by
+        # env/vars.sh for the component
+        if self.v2_layout:
+            dirs = [self.component_prefix.include, self.component_prefix.include.dal]
+        else:
+            dirs = [self.component_prefix.include]
+
+        return self.header_directories(dirs)

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -123,7 +123,14 @@ class IntelOneapiDnn(IntelOneApiLibraryPackage):
 
     @property
     def headers(self):
-        return find_headers("dnnl", self.__target().include)
+        # This should match the directories added to CPATH by
+        # env/vars.sh for the component
+        if self.v2_layout:
+            dirs = [self.component_prefix.include]
+        else:
+            dirs = [self.component_prefix.cpu_dpcpp_gpu_dpcpp.include]
+
+        return self.header_directories(dirs)
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
@@ -93,6 +93,11 @@ class IntelOneapiDpl(IntelOneApiLibraryPackage):
 
     @property
     def headers(self):
-        return self.header_directories(
-            [self.component_prefix.include, self.component_prefix.linux.include]
-        )
+        # This should match the directories added to CPATH by
+        # env/vars.sh for the component
+        if self.v2_layout:
+            dirs = [self.component_prefix.include]
+        else:
+            dirs = [self.component_prefix.linux.include]
+
+        return self.header_directories(dirs)

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -168,12 +168,6 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
         env.set("I_MPI_ROOT", self.component_prefix)
 
     @property
-    def headers(self):
-        return self.header_directories(
-            [self.component_prefix.include, self.component_prefix.include.ilp64]
-        )
-
-    @property
     def libs(self):
         libs = []
         if "+ilp64" in self.spec:


### PR DESCRIPTION
Make headers match the directories added to CPATH by oneapi vars.sh. I did this for 2023 and 2024 layouts. Before this, it sometimes added directories that do not exist and it caused problems for trilinos, which passes the directories to cmake.  I verified that trilinos gets past the cmake step for:
```
spack install trilinos ^intel-oneapi-mkl@2024
spack install trilinos ^intel-oneapi-mkl@2023.2.0
```
But I did not do full builds.

@Chrismarsh
