### PR TITLE
google benchmark: Add variant with libpfm4

### DIFF
--- a/var/spack/repos/builtin/packages/benchmark/package.py
+++ b/var/spack/repos/builtin/packages/benchmark/package.py
@@ -44,14 +44,24 @@ class Benchmark(CMakePackage):
         description="The build type to build",
         values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel", "Coverage"),
     )
+    variant(
+        "performance_counters",
+        default=True,
+        when="@1.5.4:",
+        description="Enable performance counters provided by libpfm",
+    )
 
     depends_on("cmake@2.8.11:", type="build", when="@:1.1.0")
     depends_on("cmake@2.8.12:", type="build", when="@1.2.0:1.4")
     depends_on("cmake@3.5.1:", type="build", when="@1.5.0:")
+    depends_on("libpfm4", type=("build", "link"), when="+performance_counters")
 
     def cmake_args(self):
         # No need for testing for the install
-        args = ["-DBENCHMARK_ENABLE_TESTING=OFF"]
+        args = [
+            self.define("BENCHMARK_ENABLE_TESTING", False),
+            self.define_from_variant("BENCHMARK_ENABLE_LIBPFM", "performance_counters"),
+        ]
         return args
 
     def patch(self):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This add a `performance_counters` variant that adds [support for collecting performance counter data](https://google.github.io/benchmark/perf_counters.html).

example usage: https://abseil.io/fast/53