### PR TITLE
adios2: depend in kokkos without a dev

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -120,6 +120,7 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cuda", when="+cuda ~kokkos")
 
     # Kokkos support
+    depends_on("kokkos@3.7:", when="+kokkos ~cuda ~rocm ~sycl")
     depends_on("kokkos@3.7: +cuda +wrapper", when="+kokkos +cuda")
     depends_on("kokkos@3.7: +rocm", when="+kokkos +rocm")
     depends_on("kokkos@3.7: +sycl", when="+kokkos +sycl")

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -120,10 +120,11 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cuda", when="+cuda ~kokkos")
 
     # Kokkos support
-    depends_on("kokkos@3.7:", when="+kokkos ~cuda ~rocm ~sycl")
-    depends_on("kokkos@3.7: +cuda +wrapper", when="+kokkos +cuda")
-    depends_on("kokkos@3.7: +rocm", when="+kokkos +rocm")
-    depends_on("kokkos@3.7: +sycl", when="+kokkos +sycl")
+    with when("+kokkos"):
+        depends_on("kokkos@3.7:")
+        depends_on("kokkos +cuda +wrapper", when="+cuda")
+        depends_on("kokkos +rocm", when="+rocm")
+        depends_on("kokkos +sycl", when="+sycl")
 
     # Propagate CUDA target to kokkos for +cuda
     for cuda_arch in CudaPackage.cuda_arch_values:


### PR DESCRIPTION
Before we only depend on Kokkos when we also set the variants: `+cuda|+rocm|+sycl` and `+kokkos`. Here we depend on Kokkos when using the kokkos variant, independently of the device variant.