### PR TITLE
Bug fix for "ecflow@5.11.4 does not build with recent Intel compilers (oneAPI classic)"

### DIFF
--- a/var/spack/repos/builtin/packages/ecflow/ctsapi_cassert.patch
+++ b/var/spack/repos/builtin/packages/ecflow/ctsapi_cassert.patch
@@ -1,0 +1,10 @@
+--- a/Base/src/cts/CtsApi.hpp	2024-02-10 02:32:48.001444742 +0000
++++ b/Base/src/cts/CtsApi.hpp	2024-02-10 02:33:09.161119010 +0000
+@@ -16,6 +16,7 @@
+ //============================================================================
+ #include <string>
+ #include <vector>
++#include <cassert>
+
+ #include "CheckPt.hpp"
+ #include "NodeFwd.hpp"

--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -68,6 +68,9 @@ class Ecflow(CMakePackage):
     # Requirement to use the Python3_EXECUTABLE variable
     depends_on("cmake@3.16:", type="build")
 
+    # https://github.com/JCSDA/spack-stack/issues/1001
+    patch("ctsapi_cassert.patch", when="@5.11.4 %intel@2021")
+
     @when("@:4.13.0")
     def patch(self):
         version = str(self.spec["python"].version[:2])
@@ -76,9 +79,6 @@ class Ecflow(CMakePackage):
             rf"REQUIRED COMPONENTS python{version}",
             "Pyext/CMakeLists.txt",
         )
-
-    # https://github.com/JCSDA/spack-stack/issues/1001
-    patch("ctsapi_cassert.patch", when="@5.11.4 %intel@2021")
 
     @when("+ssl ^openssl~shared")
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -77,6 +77,9 @@ class Ecflow(CMakePackage):
             "Pyext/CMakeLists.txt",
         )
 
+    # https://github.com/JCSDA/spack-stack/issues/1001
+    patch("ctsapi_cassert.patch", when="@5.11.4 %intel@2021")
+
     @when("+ssl ^openssl~shared")
     def setup_build_environment(self, env):
         env.set("LIBS", self.spec["zlib"].libs.search_flags)


### PR DESCRIPTION
## Description

See https://github.com/JCSDA/spack-stack/issues/1001 for a description of the problem. Tested on multiple systems with `intel@2021.4.0` to `intel@2021.6.0`.