### PR TITLE
update: flux-core add uuid

### DIFF
--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -160,8 +160,7 @@ class FluxCore(AutotoolsPackage):
     depends_on("pkgconfig")
     depends_on("lz4")
     depends_on("sqlite")
-    
-    # Before this version, czmq brings it in 
+    # Before this version, czmq brings it in
     depends_on("uuid", when="@0.55.0:")
     depends_on("asciidoc", type="build", when="+docs")
     depends_on("py-docutils", type="build", when="@0.32.0: +docs")

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -160,7 +160,9 @@ class FluxCore(AutotoolsPackage):
     depends_on("pkgconfig")
     depends_on("lz4")
     depends_on("sqlite")
-
+    
+    # Before this version, czmq brings it in 
+    depends_on("uuid", when="@0.55.0:")
     depends_on("asciidoc", type="build", when="+docs")
     depends_on("py-docutils", type="build", when="@0.32.0: +docs")
 


### PR DESCRIPTION
This update to flux-core will add uuid, which previously was added via a dependency (czmq) and overall is not a great approach as it's a core dependency to flux-core. :apple: 