### PR TITLE
PythonExtension.add_files_to_view: link non-executable/non-shebang regular files

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -169,6 +169,8 @@ class PythonExtension(spack.package_base.PackageBase):
                 fs.filter_file(
                     python_prefix, os.path.abspath(view.get_projection_for_spec(self.spec)), dst
                 )
+            else:
+                view.link(src, dst)
 
         # Finally re-target the symlinks that point to copied files.
         for src, dst in delayed_links:


### PR DESCRIPTION
Looks like a copy paste issue
