### PR TITLE
[intel-oneapi-mkl] provide omp lib for threads=openmp

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -241,6 +241,8 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         except spack.error.NoLibrariesError:
             pass
 
+        if self.spec.satisfies("threads=openmp"):
+            resolved_libs += self.openmp_libs()
         return resolved_libs
 
     def _xlp64_lib(self, lib):


### PR DESCRIPTION
Provide omp library when using `intel-oneapi-mkl threads=openmp`

Code is based on implementation from intel.py. The openmp depends on the compiler so make the compiler for the intel-oneapi-mkl install match the openmp you want to use for the application.

Hoping to resolve the issues in #42310 #42368
