### PR TITLE
Enhance binutils logic for scorep recipe

### DIFF
--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -201,7 +201,8 @@ class Scorep(AutotoolsPackage):
             config_args.append("--with-mpi=openmpi")
 
         if spec.satisfies("^binutils"):
-            config_args.append("--with-libbfd=%s" % spec["binutils"].prefix)
+            config_args.append("--with-libbfd-lib=%s" % spec["binutils"].prefix.lib)
+            config_args.append("--with-libbfd-include=%s" % spec["binutils"].prefix.include)
 
         config_args.extend(
             [


### PR DESCRIPTION
This PR updates the scorep recipe to use the separate `--with-libbfd-lib` and `--with-libbfd-include` options when pointing to binutils. Based on my testing, this appears to be more robust than using the `--with-libbfd`, which was creating a failure in the configure step based on the most recent versions of scorep and binutils.
