### PR TITLE
add boost components to dakota deps

### DIFF
--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -70,6 +70,7 @@ class Dakota(CMakePackage):
     depends_on(
         "boost@1.69.0: +filesystem +program_options +regex +serialization +system", when="@6.18:"
     )
+    depends_on("boost +filesystem +program_options +regex +serialization +system")
 
     # TODO: replace this with an explicit list of components of Boost,
     # for instance depends_on('boost +filesystem')

--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -64,12 +64,8 @@ class Dakota(CMakePackage):
 
     depends_on("python")
     depends_on("perl-data-dumper", type="build", when="@6.12:")
-    depends_on(
-        "boost@:1.68.0 +filesystem +program_options +regex +serialization +system", when="@:6.12"
-    )
-    depends_on(
-        "boost@1.69.0: +filesystem +program_options +regex +serialization +system", when="@6.18:"
-    )
+    depends_on("boost@:1.68.0", when="@:6.12")
+    depends_on("boost@1.69.0:", when="@6.18:")
     depends_on("boost +filesystem +program_options +regex +serialization +system")
 
     # TODO: replace this with an explicit list of components of Boost,

--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -64,8 +64,12 @@ class Dakota(CMakePackage):
 
     depends_on("python")
     depends_on("perl-data-dumper", type="build", when="@6.12:")
-    depends_on("boost@:1.68.0 +filesystem +program_options +regex +serialization +system", when="@:6.12")
-    depends_on("boost@1.69.0: +filesystem +program_options +regex +serialization +system", when="@6.18:")
+    depends_on(
+        "boost@:1.68.0 +filesystem +program_options +regex +serialization +system", when="@:6.12"
+    )
+    depends_on(
+        "boost@1.69.0: +filesystem +program_options +regex +serialization +system", when="@6.18:"
+    )
 
     # TODO: replace this with an explicit list of components of Boost,
     # for instance depends_on('boost +filesystem')

--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -64,8 +64,8 @@ class Dakota(CMakePackage):
 
     depends_on("python")
     depends_on("perl-data-dumper", type="build", when="@6.12:")
-    depends_on("boost@:1.68.0", when="@:6.12")
-    depends_on("boost@1.69.0:", when="@6.18:")
+    depends_on("boost@:1.68.0 +filesystem +program_options +regex +serialization +system", when="@:6.12")
+    depends_on("boost@1.69.0: +filesystem +program_options +regex +serialization +system", when="@6.18:")
 
     # TODO: replace this with an explicit list of components of Boost,
     # for instance depends_on('boost +filesystem')


### PR DESCRIPTION
This PR explicitly adds the required components to dakota's boost dependency, namely, ` +filesystem +program_options +regex +serialization +system`, which are spelled out in dakota's cmake configuration going back to the oldest version available through spack (6.3).