### PR TITLE
kokkos: disable CUDA_MALLOC_ASYNC on cray-mpich

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -355,6 +355,13 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         if self.spec.satisfies("%oneapi") or self.spec.satisfies("%intel"):
             options.append(self.define("CMAKE_CXX_FLAGS", "-fp-model=precise"))
 
+        # Kokkos 4.2.00+ changed the default to Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=on
+        # which breaks GPU-aware with Cray-MPICH
+        # See https://github.com/kokkos/kokkos/pull/6402
+        # TODO: disable this once Cray-MPICH is fixed
+        if self.spec.satisfies("@4.2.00:") and self.spec["mpi"].name == "cray-mpich":
+            options.append(self.define("Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC", False))
+
         # Remove duplicate options
         return lang.dedupe(options)
 

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -359,7 +359,11 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         # which breaks GPU-aware with Cray-MPICH
         # See https://github.com/kokkos/kokkos/pull/6402
         # TODO: disable this once Cray-MPICH is fixed
-        if self.spec.satisfies("@4.2.00:") and self.spec["mpi"].name == "cray-mpich":
+        if (
+            self.spec.satisfies("@4.2.00:")
+            and "mpi" in self.spec
+            and self.spec["mpi"].name == "cray-mpich"
+        ):
             options.append(self.define("Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC", False))
 
         # Remove duplicate options


### PR DESCRIPTION
Running GPU-aware codes like LAMMPS with Kokkos 4.2+ on Cray systems stopped working.

I was considering if this should be a variant, but since we're hoping that MPI implementations eventually should catch up and fix this, this seemed like the cleaner solution for now.