### PR TITLE
Update ELPA 2023.11.001-patched checksum.

### DIFF
--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -26,7 +26,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     version(
         "2023.11.001-patched",
-        sha256="9903f94a6fcb43e59d9e04f511c3da98fb4040c2728039932d15cac1a788a7f7",
+        sha256="62ee109afc06539507f459c08b958dc4db65b757dbd77f927678c77f7687415e",
         url="https://elpa.mpcdf.mpg.de/software/tarball-archive/Releases/2023.11.001/elpa-2023.11.001-patched.tar.gz",
     )
     version(


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Just updating the checksum that suddently changed. See https://github.com/spack/spack/pull/42539#issuecomment-1942884805

If the checksum changes again, we should probably just remove this version until the next release of ELPA.