### PR TITLE
spack gc: do not show uninstalled but needed specs

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1687,7 +1687,11 @@ class Database:
         with self.read_transaction():
             roots = [rec.spec for key, rec in self._data.items() if root(key, rec)]
             needed = set(id(spec) for spec in tr.traverse_nodes(roots, deptype=deptype))
-            return [rec.spec for rec in self._data.values() if id(rec.spec) not in needed]
+            return [
+                rec.spec
+                for rec in self._data.values()
+                if id(rec.spec) not in needed and rec.installed
+            ]
 
     def update_explicit(self, spec, explicit):
         """

--- a/lib/spack/spack/test/cmd/gc.py
+++ b/lib/spack/spack/test/cmd/gc.py
@@ -19,11 +19,8 @@ pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 @pytest.mark.db
 def test_gc_without_build_dependency(config, mutable_database):
-    output = gc("-yb")
-    assert "There are no unused specs." in output
-
-    output = gc("-y")
-    assert "There are no unused specs." in output
+    assert "There are no unused specs." in gc("-yb")
+    assert "There are no unused specs." in gc("-y")
 
 
 @pytest.mark.db
@@ -32,11 +29,9 @@ def test_gc_with_build_dependency(config, mutable_database):
     s.concretize()
     s.package.do_install(fake=True, explicit=True)
 
-    output = gc("-yb")
-    assert "There are no unused specs." in output
-
-    output = gc("-y")
-    assert "Successfully uninstalled cmake" in output
+    assert "There are no unused specs." in gc("-yb")
+    assert "Successfully uninstalled cmake" in gc("-y")
+    assert "There are no unused specs." in gc("-y")
 
 
 @pytest.mark.db
@@ -72,9 +67,12 @@ def test_gc_with_build_dependency_in_environment(config, mutable_database, mutab
 
     with e:
         assert mutable_database.query_local("simple-inheritance")
-        output = gc("-y")
-    assert "Restricting garbage collection" in output
-    assert "Successfully uninstalled cmake" in output
+        fst = gc("-y")
+        assert "Restricting garbage collection" in fst
+        assert "Successfully uninstalled cmake" in fst
+        snd = gc("-y")
+        assert "Restricting garbage collection" in snd
+        assert "There are no unused specs" in snd
 
 
 @pytest.mark.db

--- a/lib/spack/spack/test/cmd/gc.py
+++ b/lib/spack/spack/test/cmd/gc.py
@@ -6,9 +6,11 @@
 
 import pytest
 
+import spack.deptypes as dt
 import spack.environment as ev
 import spack.main
 import spack.spec
+import spack.traverse
 
 gc = spack.main.SpackCommand("gc")
 add = spack.main.SpackCommand("add")
@@ -77,27 +79,29 @@ def test_gc_with_build_dependency_in_environment(config, mutable_database, mutab
 
 @pytest.mark.db
 def test_gc_except_any_environments(config, mutable_database, mutable_mock_env_path):
-    s = spack.spec.Spec("simple-inheritance")
-    s.concretize()
-    s.package.do_install(fake=True, explicit=True)
-
+    """Tests whether the garbage collector can remove all specs except those still needed in some
+    environment (needed in the sense of roots + link/run deps)."""
     assert mutable_database.query_local("zmpi")
 
     e = ev.create("test_gc")
-    with e:
-        add("simple-inheritance")
-        install()
-        assert mutable_database.query_local("simple-inheritance")
+    e.add("simple-inheritance")
+    e.concretize()
+    e.install_all(fake=True)
+    e.write()
+
+    assert mutable_database.query_local("simple-inheritance")
+    assert not e.all_matching_specs(spack.spec.Spec("zmpi"))
 
     output = gc("-yE")
     assert "Restricting garbage collection" not in output
     assert "Successfully uninstalled zmpi" in output
     assert not mutable_database.query_local("zmpi")
 
-    with e:
-        output = gc("-yE")
-    assert "Restricting garbage collection" not in output
-    assert "There are no unused specs" not in output
+    # All runtime specs in this env should still be installed.
+    assert all(
+        s.installed
+        for s in spack.traverse.traverse_nodes(e.concrete_roots(), deptype=dt.LINK | dt.RUN)
+    )
 
 
 @pytest.mark.db


### PR DESCRIPTION
Closes #42335

Repeated `spack gc` keeps showing specs removed from disk, but listed as missing in the db.

This commit fixes that and tests that second `spack gc` invocation does nothing.


