### PR TITLE
Use relative target in symlinks to modified files in view

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -180,7 +180,7 @@ class PythonExtension(spack.package_base.PackageBase):
             except (OSError, KeyError):
                 target = None
             if target:
-                os.symlink(target, dst)
+                os.symlink(os.path.relpath(target, os.path.dirname(dst)), dst)
             else:
                 view.link(src, dst, spec=self.spec)
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1306,7 +1306,7 @@ print(json.dumps(config))
             except (OSError, KeyError):
                 target = None
             if target:
-                os.symlink(target, dst)
+                os.symlink(os.path.relpath(target, os.path.dirname(dst)), dst)
             else:
                 view.link(src, dst, spec=self.spec)
 


### PR DESCRIPTION
Previously when an executable or script got modified in python or any of its extensions, symlinks like

```
python -> python3.11
```

pointing to those files would be rewritten as

```
python -> /absolute/path/to/view/._view/abcdefabcdefabcdef/bin/python3.11
```

This commit makes the symlinks relative so that `ls -al view/bin` looks more sensible.

