### PR TITLE
`umpire`: Depend on `camp~rocm` when umpire itself has `~rocm`

### DIFF
--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -195,6 +195,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("camp@main", when="@develop")
     depends_on("camp+openmp", when="+openmp")
     depends_on("camp~cuda", when="~cuda")
+    depends_on("camp~rocm", when="~rocm")
 
     with when("@5.0.0:"):
         with when("+cuda"):


### PR DESCRIPTION
This mirrors the behaviour with cuda. Without this I get
```
1 error found in build log:
     72    -- CMAKE_EXE_LINKER_FLAGS flags are:
     73    -- Setting C standard to 99
     74    -- Checking for std::filesystem
     75    -- std::filesystem NOT found, using POSIX
     76    -- Host Shared Memory Disabled
     77    -- Configuring done
  >> 78    CMake Error at /projappl/project_465000105/simbergm/spack-install-tree-tmp/23.03/0.19.2/camp-2022.10.1-g2afdx6/lib/cmake/camp/bltTargets.cmake:74 (set_target_properties):
     79      The link interface of target "blt::blt_hip_runtime" contains:
     80
     81        hip::amdhip64
     82
     83      but the target was not found.  Possible reasons include:
     84
```
if I happen to have a `camp+rocm` installed, even if I ask for `umpire~rocm`.