### PR TITLE
clingo: add version 5.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -29,6 +29,7 @@ class Clingo(CMakePackage):
 
     version("master", branch="master", submodules=True)
     version("spack", commit="2a025667090d71b2c9dce60fe924feb6bde8f667", submodules=True)
+    version("5.7.0", sha256="ed5401bda54315184697fd69ff0f15389c62779e812058a5f296ba587ed9c10b")
     version("5.6.2", sha256="81eb7b14977ac57c97c905bd570f30be2859eabc7fe534da3cdc65eaca44f5be")
     version("5.5.2", sha256="a2a0a590485e26dce18860ac002576232d70accc5bfcb11c0c22e66beb23baa6")
     version("5.5.1", sha256="b9cf2ba2001f8241b8b1d369b6f353e628582e2a00f13566e51c03c4dd61f67e")


### PR DESCRIPTION
5.7.0 was just released. It includes a number of changes requested and/or upstreamed by Spack developers, e.g.:

* API for accessing optimization priorities: https://github.com/potassco/clingo/pull/406
* Hash optimization: https://github.com/potassco/clingo/pull/441
* Contributing Guide: https://github.com/potassco/clingo/pull/465
* Hiding more ELF symbols:
  * https://github.com/potassco/clingo/pull/447
  * https://github.com/potassco/clingo/pull/449