### PR TITLE
Add support for clang with OpenMP and other minor changes to oneapi build system

### DIFF
--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -206,6 +206,8 @@ class IntelOneApiLibraryPackage(IntelOneApiPackage):
             libname = "libiomp5"
         elif self.spec.satisfies("%gcc"):
             libname = "libgomp"
+        elif self.spec.satisfies("%clang"):
+            libname = "libomp"
         else:
             raise_lib_error("MKL OMP requires one of %gcc, %oneapi,or %intel")
 

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -209,7 +209,9 @@ class IntelOneApiLibraryPackage(IntelOneApiPackage):
         elif self.spec.satisfies("%clang"):
             libname = "libomp"
         else:
-            raise_lib_error("MKL OMP requires one of %gcc, %oneapi,or %intel")
+            raise_lib_error(
+                "MKL with OpenMP threading requires one of %clang, %gcc, %oneapi, or %intel"
+            )
 
         # query the compiler for the library path
         with self.compiler.compiler_environment():
@@ -231,7 +233,7 @@ class IntelOneApiLibraryPackage(IntelOneApiPackage):
             raise_lib_error(f"Cannot locate OpenMP library: {omp_lib_path}")
 
         omp_libs = LibraryList(omp_lib_path)
-        tty.info(f"mkl requires openmp library: {omp_libs}")
+        tty.info(f"MKL requires OpenMP library: {omp_libs}")
         return omp_libs
 
     # find_headers uses heuristics to determine the include directory

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -22,13 +22,6 @@ from spack.util.executable import Executable
 from .generic import Package
 
 
-def raise_lib_error(*args):
-    """Bails out with an error message. Shows args after the first as one per
-    line, tab-indented, useful for long paths to line up and stand out.
-    """
-    raise InstallError("\n\t".join(str(i) for i in args))
-
-
 class IntelOneApiPackage(Package):
     """Base class for Intel oneAPI packages."""
 
@@ -209,7 +202,7 @@ class IntelOneApiLibraryPackage(IntelOneApiPackage):
         elif self.spec.satisfies("%clang"):
             libname = "libomp"
         else:
-            raise_lib_error(
+            raise InstallError(
                 "OneAPI package with OpenMP threading requires one of %clang, %gcc, %oneapi, or %intel"
             )
 
@@ -230,7 +223,7 @@ class IntelOneApiLibraryPackage(IntelOneApiPackage):
 
         # if the compiler cannot find the file, it returns the input path
         if not os.path.exists(omp_lib_path):
-            raise_lib_error(f"Cannot locate OpenMP library: {omp_lib_path}")
+            raise InstallError(f"Cannot locate OpenMP library: {omp_lib_path}")
 
         omp_libs = LibraryList(omp_lib_path)
         tty.info(f"OneAPI package requires OpenMP library: {omp_libs}")

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -203,7 +203,8 @@ class IntelOneApiLibraryPackage(IntelOneApiPackage):
             libname = "libomp"
         else:
             raise InstallError(
-                "OneAPI package with OpenMP threading requires one of %clang, %gcc, %oneapi, or %intel"
+                "OneAPI package with OpenMP threading requires one of %clang, %gcc, %oneapi, "
+                "or %intel"
             )
 
         # query the compiler for the library path

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -223,7 +223,7 @@ class IntelOneApiLibraryPackage(IntelOneApiPackage):
 
         # if the compiler cannot find the file, it returns the input path
         if not os.path.exists(omp_lib_path):
-            raise InstallError(f"Cannot locate OpenMP library: {omp_lib_path}")
+            raise InstallError(f"OneAPI package cannot locate OpenMP library: {omp_lib_path}")
 
         omp_libs = LibraryList(omp_lib_path)
         tty.info(f"OneAPI package requires OpenMP library: {omp_libs}")

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -210,7 +210,7 @@ class IntelOneApiLibraryPackage(IntelOneApiPackage):
             libname = "libomp"
         else:
             raise_lib_error(
-                "MKL with OpenMP threading requires one of %clang, %gcc, %oneapi, or %intel"
+                "OneAPI package with OpenMP threading requires one of %clang, %gcc, %oneapi, or %intel"
             )
 
         # query the compiler for the library path

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -233,7 +233,7 @@ class IntelOneApiLibraryPackage(IntelOneApiPackage):
             raise_lib_error(f"Cannot locate OpenMP library: {omp_lib_path}")
 
         omp_libs = LibraryList(omp_lib_path)
-        tty.info(f"MKL requires OpenMP library: {omp_libs}")
+        tty.info(f"OneAPI package requires OpenMP library: {omp_libs}")
         return omp_libs
 
     # find_headers uses heuristics to determine the include directory

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -125,6 +125,16 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         multi=False,
     )
 
+    requires(
+        "%clang",
+        "%gcc",
+        "%intel",
+        "%oneapi",
+        policy="one_of",
+        when="threads=openmp",
+        msg="MKL with OpenMP threading requires GCC, clang, or Intel compilers",
+    )
+
     depends_on("tbb")
     # cluster libraries need mpi
     depends_on("mpi", when="+cluster")


### PR DESCRIPTION
Follow-up from #42653.

- Adds a `requires` for compilers to the `intel-oneapi-mkl` package to error out earlier during concretization rather than building. The downside of this is that the oneapi package definition also has a check for supported compilers and these could become out of sync, but I think the usability benefit is worth it.
- Adds a fallback option to look for libomp with clang (which doesn't report the path of `libomp.so` in newer versions).
- Minor error/logging message changes.