### PR TITLE
remove a few redundant calls to setup_run_environment

### DIFF
--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -77,7 +77,6 @@ class CrayMpich(Package):
             env.set("MPIF90", spack_fc)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
         env.set("MPICH_CC", spack_cc)
         env.set("MPICH_CXX", spack_cxx)
         env.set("MPICH_F77", spack_f77)

--- a/var/spack/repos/builtin/packages/cray-mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/cray-mvapich2/package.py
@@ -33,8 +33,6 @@ class CrayMvapich2(Package):
         env.set("MPIF90", spack_fc)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
-
         env.set("MPICH_CC", spack_cc)
         env.set("MPICH_CXX", spack_cxx)
         env.set("MPICH_F77", spack_f77)

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -381,12 +381,6 @@ class Cudnn(Package):
         if "target=ppc64le: platform=linux" in self.spec:
             env.set("cuDNN_ROOT", os.path.join(self.prefix, "targets", "ppc64le-linux"))
 
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
-
-    def setup_dependent_run_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
-
     def install(self, spec, prefix):
         install_tree(".", prefix)
 

--- a/var/spack/repos/builtin/packages/dmd/package.py
+++ b/var/spack/repos/builtin/packages/dmd/package.py
@@ -47,9 +47,6 @@ class Dmd(MakefilePackage):
         env.prepend_path("LIBRARY_PATH", self.prefix.linux.lib64)
         env.prepend_path("LD_LIBRARY_PATH", self.prefix.linux.lib64)
 
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
-
     def edit(self, spec, prefix):
         # Move contents to dmd/
         mkdir = which("mkdir")

--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -41,9 +41,6 @@ class FujitsuMpi(Package):
         self.spec.mpif77 = self.prefix.bin.mpifrt
         self.spec.mpifc = self.prefix.bin.mpifrt
 
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
-
     def setup_run_environment(self, env):
         # Because MPI are both compilers and runtimes, we set up the compilers
         # as part of run environment

--- a/var/spack/repos/builtin/packages/genie/package.py
+++ b/var/spack/repos/builtin/packages/genie/package.py
@@ -88,11 +88,9 @@ class Genie(Package):
 
     def setup_build_environment(self, env):
         env.set("GENIE", self.stage.source_path)
-        return super().setup_build_environment(env)
 
     def setup_run_environment(self, env):
         env.set("GENIE", self.prefix)
-        return super().setup_run_environment(env)
 
     def install(self, spec, prefix):
         configure = Executable("./configure")

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -457,8 +457,6 @@ supported, and netmod is ignored if device is ch3:sock.""",
             env.set("MPIF90", join_path(self.prefix.bin, "mpif90"))
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
-
         env.set("MPICH_CC", spack_cc)
         env.set("MPICH_CXX", spack_cxx)
         env.set("MPICH_F77", spack_f77)

--- a/var/spack/repos/builtin/packages/mpitrampoline/package.py
+++ b/var/spack/repos/builtin/packages/mpitrampoline/package.py
@@ -90,7 +90,6 @@ class Mpitrampoline(CMakePackage):
         env.set("MPIF90", join_path(self.prefix.bin, "mpifc"))
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
         # Use the Spack compiler wrappers under MPI
         env.set("MPITRAMPOLINE_CC", spack_cc)
         env.set("MPITRAMPOLINE_CXX", spack_cxx)

--- a/var/spack/repos/builtin/packages/mpt/package.py
+++ b/var/spack/repos/builtin/packages/mpt/package.py
@@ -35,8 +35,6 @@ class Mpt(BundlePackage):
         return find_libraries(libraries, root=self.prefix, shared=True, recursive=True)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
-
         # use the Spack compiler wrappers under MPI
         env.set("MPICC_CC", spack_cc)
         env.set("MPICXX_CXX", spack_cxx)

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -300,7 +300,6 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
 
 class BaseBuilder(metaclass=spack.builder.PhaseCallbacksMeta):
     def setup_dependent_build_environment(self, env, dependent_spec):
-        self.pkg.setup_run_environment(env)
         # Some packages, e.g. ncview, refuse to build if the compiler path returned by nc-config
         # differs from the path to the compiler that the package should be built with. Therefore,
         # we have to shadow nc-config from self.prefix.bin, which references the real compiler,

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -820,8 +820,6 @@ class Openmpi(AutotoolsPackage, CudaPackage):
         env.set("MPIF90", join_path(self.prefix.bin, "mpif90"))
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
-
         # Use the spack compiler wrappers under MPI
         env.set("OMPI_CC", spack_cc)
         env.set("OMPI_CXX", spack_cxx)

--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -116,14 +116,8 @@ class Proj(CMakePackage, AutotoolsPackage):
         # * https://rasterio.readthedocs.io/en/latest/faq.html
         env.set("PROJ_LIB", self.prefix.share.proj)
 
-    def setup_dependent_run_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
-
 
 class BaseBuilder(metaclass=spack.builder.PhaseCallbacksMeta):
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        self.pkg.setup_run_environment(env)
-
     def setup_build_environment(self, env):
         env.set("PROJ_LIB", join_path(self.pkg.stage.source_path, "nad"))
 

--- a/var/spack/repos/builtin/packages/serialbox/package.py
+++ b/var/spack/repos/builtin/packages/serialbox/package.py
@@ -158,9 +158,6 @@ class Serialbox(CMakePackage):
         # enable the Python interface in a non-standard directory:
         env.prepend_path("PYTHONPATH", self.prefix.python)
 
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
-
     def setup_dependent_package(self, module, dependent_spec):
         # Simplify the location of the preprocessor by dependent packages:
         self.spec.pp_ser = join_path(self.prefix.python.pp_ser, "pp_ser.py")

--- a/var/spack/repos/builtin/packages/texlive/package.py
+++ b/var/spack/repos/builtin/packages/texlive/package.py
@@ -184,9 +184,6 @@ class Texlive(AutotoolsPackage):
     def setup_run_environment(self, env):
         env.prepend_path("PATH", join_path(self.prefix.bin, self.tex_arch()))
 
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
-
     @when("@live")
     def autoreconf(self, spec, prefix):
         touch("configure")


### PR DESCRIPTION
Closes #42700

Any package `X` used as `depends_on("x", type="build")` will have
`X.setup_run_environment(env)` called, because it has to be able to
"run" in the build environment.

So there is no point in calling `setup_run_environment` from
`setup_dependent_build_environment`.

Also it's redundant to call `setup_run_environment` in
`setup_dependent_run_environment`, cause (a) the latter is called _for
every parent edge_ instead of once per node, and (b) it's only called
after `setup_run_environment` is called anyways. Better to call
`setup_run_environment` once and only once.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
