### PR TITLE
CP2K: Fix multiple use of spec["fftw"]

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -888,9 +888,8 @@ class MakefileBuilder(makefile.MakefileBuilder):
             content += " " + self.spec["lapack"].libs.ld_flags
             content += " " + self.spec["fftw-api"].libs.ld_flags
 
-            if (self.spec["fftw-api"].name in ["fftw", "amdfftw"]) and self.spec[
-                "fftw-api"
-            ].satisfies("+openmp"):
+            fftw = self.spec["fftw-api"]
+            if fftw.name in ["fftw", "amdfftw"] and fftw.satisfies("+openmp"):
                 content += " -lfftw3_omp"
 
             content += "\n"

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -384,7 +384,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
         }
 
         dflags = ["-DNDEBUG"] if spec.satisfies("@:2023.2") else []
-        if spec["fftw-api"].name in ("intel-mkl", "intel-parallel-studio", "intel-oneapi-mkl"):
+        if fftw.name in ("intel-mkl", "intel-parallel-studio", "intel-oneapi-mkl"):
             cppflags = ["-D__FFTW3_MKL", "-I{0}".format(fftw_header_dir)]
         else:
             cppflags = ["-D__FFTW3", "-I{0}".format(fftw_header_dir)]
@@ -888,7 +888,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
             content += " " + self.spec["lapack"].libs.ld_flags
             content += " " + self.spec["fftw-api"].libs.ld_flags
 
-            if (self.spec["fftw-api"].name == "fftw") and ("+openmp" in self.spec["fftw"]):
+            if (self.spec["fftw-api"].name in ["fftw", "amdfftw"]) and self.spec["fftw-api"].satisfies("+openmp"):
                 content += " -lfftw3_omp"
 
             content += "\n"

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -888,7 +888,9 @@ class MakefileBuilder(makefile.MakefileBuilder):
             content += " " + self.spec["lapack"].libs.ld_flags
             content += " " + self.spec["fftw-api"].libs.ld_flags
 
-            if (self.spec["fftw-api"].name in ["fftw", "amdfftw"]) and self.spec["fftw-api"].satisfies("+openmp"):
+            if (self.spec["fftw-api"].name in ["fftw", "amdfftw"]) and self.spec[
+                "fftw-api"
+            ].satisfies("+openmp"):
                 content += " -lfftw3_omp"
 
             content += "\n"


### PR DESCRIPTION
FFTW recipe internally uses a reference to `self.spec.last_query`.  In the CP2K recipe an `fftw` object is originally created with `spec["fftw:openmp"]` if OpenMP is required, but a later fixed reference to `spec["fftw"]` overwrites the 'last_query' in the spec object, so later use of fftw.libs was not returing FFTW OpenMP libs.

Also allow the post-install package config fixup to support amdfftw as well as fftw.
