### PR TITLE
Don't do user socket check on Windows

### DIFF
--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -7,6 +7,7 @@ import errno
 import functools
 import os
 import re
+import sys
 
 import spack.error
 import spack.paths
@@ -372,6 +373,9 @@ def _socket_dir(gpgconf):
     # If there is no suitable gpgconf, don't even bother trying to
     # pre-create a user run dir.
     if not gpgconf:
+        return None
+
+    if sys.platform == "win32":
         return None
 
     result = None


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Windows does not support  `os.getuid` or have the `/var/...` socket for gpg. Don't do this on windows.

CC: @johnwparent @scheibelp 