### PR TITLE
[obsolete by using @=main] Rename LIBXSMM main build to develop to avoid conflict with `main-2023-11`

### DIFF
--- a/var/spack/repos/builtin/packages/libxsmm/package.py
+++ b/var/spack/repos/builtin/packages/libxsmm/package.py
@@ -22,11 +22,12 @@ class Libxsmm(MakefilePackage):
 
     license("BSD-3-Clause")
 
+    version("develop", branch="main")
+
     # 2.0 release is planned for Jan / Feb 2024. This commit from main is added
     # as a stable version that supports other targets than x86. Remove this
     # after 2.0 release.
     version("main-2023-11", commit="0d9be905527ba575c14ca5d3b4c9673916c868b2")
-    version("main", branch="main")
 
     version("1.17", sha256="8b642127880e92e8a75400125307724635ecdf4020ca4481e5efe7640451bb92")
     version("1.16.3", sha256="e491ccadebc5cdcd1fc08b5b4509a0aba4e2c096f53d7880062a66b82a0baf84")


### PR DESCRIPTION
As is, `spack install libxsmm@main` installs `main-2023-11` since it is interpreted as a newer version. I'm not sure how to force installation of `main`.

This PR resolves this by renaming the `main` build to `develop`. Another way to go about this would be to use `preferred=True` on the `main` version, but I'm worried this will break other packages which assume v1.17 is the default preferred version for installation. I think LIBXSMM is planning a v2.0 release in the next few months which should hopefully resolve all of these issues, but in the mean time it would be nice to be able to build `main` with Spack.