### PR TITLE
bugfix: add arg to `write_line_break()` in `spack_yaml`

### DIFF
--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -296,8 +296,8 @@ class LineAnnotationEmitter(emitter.Emitter):
         if marked(self.event.value):
             self.saved = self.event.value
 
-    def write_line_break(self):
-        super().write_line_break()
+    def write_line_break(self, data=None):
+        super().write_line_break(data)
         if self.saved is None:
             _ANNOTATIONS.append(colorize("@K{---}"))
             return


### PR DESCRIPTION
`ruamel`'s `Emitter.write_line_break()` method takes an extra argument that we forgot to implement in our custom emitter. That argument is used on windows, and we need this for CI to work on windows.
