### PR TITLE
Add macos-14 as a runner (Apple M1)

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -186,9 +186,10 @@ jobs:
         flags: unittests,linux,clingo
   # Run unit tests on MacOS
   macos:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [macos-latest, macos-14]
         python-version: ["3.11"]
     steps:
     - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # @v2

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -284,9 +284,7 @@ def test_relocate_text_bin_raise_if_new_prefix_is_longer(tmpdir):
 
 
 @pytest.mark.requires_executables("install_name_tool", "file", "cc")
-@pytest.mark.skipif(
-    str(archspec.cpu.host().family) != "x86_64", reason="failing on Apple M1/M2"
-)
+@pytest.mark.skipif(str(archspec.cpu.host().family) != "x86_64", reason="failing on Apple M1/M2")
 def test_fixup_macos_rpaths(make_dylib, make_object_file):
     # For each of these tests except for the "correct" case, the first fixup
     # should make changes, and the second fixup should be a null-op.

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -9,6 +9,8 @@ import shutil
 
 import pytest
 
+import archspec.cpu
+
 import spack.concretize
 import spack.paths
 import spack.platforms
@@ -282,6 +284,9 @@ def test_relocate_text_bin_raise_if_new_prefix_is_longer(tmpdir):
 
 
 @pytest.mark.requires_executables("install_name_tool", "file", "cc")
+@pytest.mark.skipif(
+    str(archspec.cpu.host().family) != "x86_64", reason="failing on Apple M1/M2"
+)
 def test_fixup_macos_rpaths(make_dylib, make_object_file):
     # For each of these tests except for the "correct" case, the first fixup
     # should make changes, and the second fixup should be a null-op.


### PR DESCRIPTION
Requires #43363

This should allow us to run test Apple M1 in CI.