### PR TITLE
gnupg: make discoverable as external

### DIFF
--- a/var/spack/repos/builtin/packages/gnupg/package.py
+++ b/var/spack/repos/builtin/packages/gnupg/package.py
@@ -15,8 +15,6 @@ class Gnupg(AutotoolsPackage):
     homepage = "https://gnupg.org/index.html"
     url = "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.3.4.tar.bz2"
 
-    executables = ["^gpg$", "^gpg-agent$"]
-
     maintainers("alalazo")
 
     license("GPL-3.0-or-later")
@@ -139,6 +137,8 @@ class Gnupg(AutotoolsPackage):
 
     # Getting some linking error.
     conflicts("%gcc@10:", when="@:1")
+
+    executables = ["^gpg$", "^gpg-agent$"]
 
     @classmethod
     def determine_version(cls, exe):

--- a/var/spack/repos/builtin/packages/gnupg/package.py
+++ b/var/spack/repos/builtin/packages/gnupg/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 from spack.package import *
 from spack.util.environment import is_system_path
 
@@ -12,6 +14,8 @@ class Gnupg(AutotoolsPackage):
 
     homepage = "https://gnupg.org/index.html"
     url = "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.3.4.tar.bz2"
+
+    executables = ["^gpg$", "^gpg-agent$"]
 
     maintainers("alalazo")
 
@@ -135,6 +139,12 @@ class Gnupg(AutotoolsPackage):
 
     # Getting some linking error.
     conflicts("%gcc@10:", when="@:1")
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("--version", output=str, error=str)
+        match = re.search(r"gpg \(GnuPG\) (\S+)", output)
+        return match.group(1) if match else None
 
     @run_after("install")
     def add_gpg2_symlink(self):


### PR DESCRIPTION
Allow `gnupg` to be discovered as an external.