### PR TITLE
ImageMagick: fewer dependencies on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/imagemagick/package.py
+++ b/var/spack/repos/builtin/packages/imagemagick/package.py
@@ -38,8 +38,8 @@ class Imagemagick(AutotoolsPackage):
     depends_on("ghostscript-fonts", when="+ghostscript")
 
     # TODO: are these actually required?
-    depends_on("libsm")
-    depends_on("libtool")
+    depends_on("libsm", when="platform=linux")
+    depends_on("libtool", when="platform=linux")
 
     def configure_args(self):
         args = []


### PR DESCRIPTION
The libsm dependency was added by @jrood-nrel in #17577, while the libtool link dependency was added by @glennpj in #20969. Please comment on this PR if you can.

When I build ImageMagick 7.1.1 on macOS, it does not link to either of these libraries, and installation precedes smoothly with the system libuuid and libtool. Both of these libraries are tricky on macOS, as it provides its own Apple versions of each that aren't necessarily compatible with the GNU versions.

Reason for change: I'm trying to build bazel, but it fails when using Spack-installed libtool, which is only in my PATH because my environment includes ImageMagick.