### PR TITLE
ELPA: Linking fixes for BLAS and OpenMP

### DIFF
--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -180,8 +180,9 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
         ldflags = [spec["blas"].libs.search_flags, spec["lapack"].libs.search_flags]
         libs = [spec["lapack"].libs.link_flags, spec["blas"].libs.link_flags]
 
-        # if using mkl with openmp support, link with openmp
-        if self.spec.satisfies("^intel-oneapi-mkl threads=openmp"):
+        # If using blas with openmp support, link with openmp
+        # Needed for Spack-provided OneAPI MKL and for many externals
+        if self.spec["blas"].satisfies("threads=openmp"):
             ldflags.append(self.compiler.openmp_flag)
 
         options += [f'LDFLAGS={" ".join(ldflags)}', f'LIBS={" ".join(libs)}']

--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -184,7 +184,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
         if self.spec.satisfies("^intel-oneapi-mkl threads=openmp"):
             ldflags.append(self.compiler.openmp_flag)
 
-        options += [f'LDFLAGS={" ".join(ldflags)}', f'LIBS={" ".join(ldflags)}']
+        options += [f'LDFLAGS={" ".join(ldflags)}', f'LIBS={" ".join(libs)}']
 
         if "+mpi" in self.spec:
             options += [

--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -176,16 +176,15 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         options += self.enable_or_disable("openmp")
 
+        # Additional linker search paths and link libs
+        ldflags = [spec["blas"].libs.search_flags, spec["lapack"].libs.search_flags]
+        libs = [spec["lapack"].libs.link_flags, spec["blas"].libs.link_flags]
+
         # if using mkl with openmp support, link with openmp
-        mkl_openmp_flag = (
-            self.compiler.openmp_flag
-            if self.spec.satisfies("^intel-oneapi-mkl threads=openmp")
-            else ""
-        )
-        options += [
-            "LDFLAGS={0} {1}".format(mkl_openmp_flag, spec["lapack"].libs.search_flags),
-            "LIBS={0} {1}".format(spec["lapack"].libs.link_flags, spec["blas"].libs.link_flags),
-        ]
+        if self.spec.satisfies("^intel-oneapi-mkl threads=openmp"):
+            ldflags.append(self.compiler.openmp_flag)
+
+        options += [f'LDFLAGS={" ".join(ldflags)}', f'LIBS={" ".join(ldflags)}']
 
         if "+mpi" in self.spec:
             options += [


### PR DESCRIPTION
* Support the case where BLAS and LAPACK libs are located in different directories.
* Support non-OneAPI cases where OpenMP lib is needed (A missing OpenMP link requirement can also show up when using externally provided BLAS/LAPACK)
