### PR TITLE
VTK: vtk@9 support for Windows

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -123,6 +123,8 @@ class Vtk(CMakePackage):
     patch("vtk_find_liblzma.patch", when="@8.2")
     patch("vtk_movie_link_ogg.patch", when="@8.2")
     patch("vtk_use_sqlite_name_vtk_expects.patch", when="@8.2")
+    patch("vtk_proj_include_no_strict.patch", when="@9: platform=windows")
+    patch("vtk_alias_hdf5.patch", when="@9: platform=windows")
     with when("~osmesa"):
         depends_on("glx", when="platform=linux")
         depends_on("glx", when="platform=cray")

--- a/var/spack/repos/builtin/packages/vtk/vtk_alias_hdf5.patch
+++ b/var/spack/repos/builtin/packages/vtk/vtk_alias_hdf5.patch
@@ -1,0 +1,14 @@
+diff --git a/CMake/patches/99/FindHDF5.cmake b/CMake/patches/99/FindHDF5.cmake
+index b54877d519..adf5d84430 100644
+--- a/CMake/patches/99/FindHDF5.cmake
++++ b/CMake/patches/99/FindHDF5.cmake
+@@ -1150,6 +1150,9 @@ if (HDF5_FOUND)
+       endif ()
+     endif ()
+   endforeach ()
++  if(NOT TARGET "hdf5")
++    add_library(hdf5 ALIAS hdf5::hdf5)
++  endif()
+   unset(hdf5_lang)
+ 
+   if (HDF5_DIFF_EXECUTABLE AND NOT TARGET hdf5::h5diff)

--- a/var/spack/repos/builtin/packages/vtk/vtk_proj_include_no_strict.patch
+++ b/var/spack/repos/builtin/packages/vtk/vtk_proj_include_no_strict.patch
@@ -1,0 +1,26 @@
+diff --git a/ThirdParty/libproj/vtk_libproj.h.in b/ThirdParty/libproj/vtk_libproj.h.in
+index 00cd3599e3..3ce90dd198 100644
+--- a/ThirdParty/libproj/vtk_libproj.h.in
++++ b/ThirdParty/libproj/vtk_libproj.h.in
+@@ -26,6 +26,10 @@
+ #endif
+ 
+ #if VTK_MODULE_USE_EXTERNAL_vtklibproj
++# ifdef STRICT
++#  define _OLD_STRICT STRICT
++#  undef STRICT
++# endif
+ # if VTK_LibPROJ_MAJOR_VERSION >= 5
+ #  include <proj.h>
+ #  include <proj/io.hpp>
+@@ -35,6 +39,10 @@
+ #  include <projects.h>
+ # endif
+ # include <geodesic.h>
++# ifdef _OLD_STRICT
++#  define STRICT _OLD_STRICT
++#  undef _OLD_STRICT
++# endif
+ #else
+ # include <vtklibproj/src/proj.h>
+ # include <vtklibproj/src/geodesic.h>


### PR DESCRIPTION
* Adds a patch preventing the VTK definition of the MSVC STRICT keyword from effecting preprocessor pass over Proj headers

* Adds a patch aliasing `hdf5` target with `IMPORTED` alias target to avoid persistence of `hdf5` target, allowing subsequent invocations of `find_package(HDF5...` from VTK dependencies

Requires: https://github.com/spack/spack/pull/42749 https://github.com/spack/spack/pull/42750 https://github.com/spack/spack/pull/42692


