### PR TITLE
Curl: update win32 support

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -288,6 +288,11 @@ class Curl(NMakePackage, AutotoolsPackage):
             # curl queries pkgconfig for openssl compilation flags
             depends_on("pkgconfig", type="build")
 
+    with when("platform=windows"):
+        # Curl should be built either static or shared on Windows to avoid
+        # collisions between import library and static library
+        variant("shared", default=True, description="Build shared curl")
+
     conflicts("platform=cray", when="tls=secure_transport", msg="Only supported on macOS")
     conflicts("platform=linux", when="tls=secure_transport", msg="Only supported on macOS")
 
@@ -353,6 +358,13 @@ class Curl(NMakePackage, AutotoolsPackage):
         if name == "cflags" and self.spec.compiler.name in ["intel", "oneapi"]:
             build_system_flags = ["-we147"]
         return flags, None, build_system_flags
+
+
+class BuildEnvironment:
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        if "~shared" in self.spec:
+            env.append_flags("CFLAGS", "-DCURL_STATICLIB")
+            env.append_flags("CXXFLAGS", "-DCURL_STATICLIB")
 
 
 class AutotoolsBuilder(AutotoolsBuilder):
@@ -441,12 +453,12 @@ class AutotoolsBuilder(AutotoolsBuilder):
                 return "--without-darwinssl"
 
 
-class NMakeBuilder(NMakeBuilder):
+class NMakeBuilder(BuildEnvironment, NMakeBuilder):
     phases = ["install"]
 
     def nmake_args(self):
         args = []
-        mode = "dll" if "libs=dll" in self.spec else "static"
+        mode = "dll" if "+shared" in self.spec else "static"
         args.append("mode=%s" % mode)
         args.append("WITH_ZLIB=%s" % mode)
         args.append("ZLIB_PATH=%s" % self.spec["zlib-api"].prefix)

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -502,3 +502,12 @@ class NMakeBuilder(BuildEnvironment, NMakeBuilder):
         with working_dir(os.path.join(self.stage.source_path, "builds")):
             install_dir = glob.glob("libcurl-**")[0]
             install_tree(install_dir, self.prefix)
+        if "~shared" in spec:
+            # curl is named libcurl_a when static on Windows
+            # Consumers look for just libcurl
+            # make a symlink to make consumers happy
+            libcurl_a = os.path.join(prefix.lib, "libcurl_a.lib")
+            libcurl = os.path.join(self.prefix.lib, "libcurl.lib")
+            # safeguard against future curl releases that do this for us
+            if os.path.exists(libcurl_a) and not os.path.exists(libcurl):
+                symlink(libcurl_a, libcurl)


### PR DESCRIPTION
Properly specify Curl builder interface for `static` vs `shared` curl with NMake system to ensure all built curls export expected symbols.

Symlinks curl library build artifact to more idiomatic name for `FindCurl.cmake` implementations and other NMake consumers.