### PR TITLE
llnl/util/symlink.py: stub temp directory in Win32 symlink check

### DIFF
--- a/lib/spack/llnl/util/symlink.py
+++ b/lib/spack/llnl/util/symlink.py
@@ -189,6 +189,7 @@ def _windows_can_symlink() -> bool:
     import llnl.util.filesystem as fs
 
     fs.touchp(fpath)
+    fs.mkdirp(dpath)
 
     try:
         os.symlink(dpath, dlink)


### PR DESCRIPTION
On my system and a few tested system, the lack of an existing `dlink` directory on symlink cleanup raises an error and crashes Spack. Stubbing the temp directory solves the issue.
