### PR TITLE
NMake/MSBuild: Robust handling for paths with spaces

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1240,6 +1240,43 @@ def get_single_file(directory):
     return fnames[0]
 
 
+@system_path_filter
+def compute_sfn(path: os.PathLike):
+    """8.3 Filenames (SFN or short filename) is a file
+    naming convention used prior to Win95 that Windows
+    still (and will continue to) support. This convention
+    caps filenames at 8 characters, and most importantly
+    does not allow for spaces in addition to other specifications.
+    The scheme is generally the same as a normal Windows
+    file scheme, but all spaces are removed and the filename
+    is capped at 6 characters. The remaining characters are
+    replaced with ~N where N is the number file in a directory
+    that a given file represents i.e. Program Files and Program Files (x86)
+    would be PROGRA~1 and PROGRA~2 respectively.
+    Further, all file/directory names are all caps (although modern Windows
+    is case insensitive in practice).
+    Conversion is accomplished by fileapi.h GetShortPathNameW
+
+    Returns paths in 8.3 Filename form
+
+    Note: this method is a no-op on Linux
+
+    Args:
+        path: Path to be transformed into SFN (8.3 filename) format
+    """
+    # This should not be run-able on linux/macos
+    if sys.platform != "win32":
+        return path
+    path = str(path)
+    import ctypes
+    k32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    # stub Windows types TCHAR[LENGTH]
+    TCHAR_arr = ctypes.c_wchar * len(path)
+    ret_str = TCHAR_arr()
+    k32.GetShortPathNameW(path, ret_str, len(path))
+    return ret_str.value
+
+
 @contextmanager
 def temp_cwd():
     tmp_dir = tempfile.mkdtemp()

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1241,8 +1241,11 @@ def get_single_file(directory):
 
 
 @system_path_filter
-def compute_sfn(path: os.PathLike):
-    """8.3 Filenames (SFN or short filename) is a file
+def windows_sfn(path: os.PathLike):
+    """Returns 8.3 Filename (SFN) representation of
+    path
+
+    8.3 Filenames (SFN or short filename) is a file
     naming convention used prior to Win95 that Windows
     still (and will continue to) support. This convention
     caps filenames at 8 characters, and most importantly

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1269,6 +1269,7 @@ def compute_sfn(path: os.PathLike):
         return path
     path = str(path)
     import ctypes
+
     k32 = ctypes.WinDLL("kernel32", use_last_error=True)
     # stub Windows types TCHAR[LENGTH]
     TCHAR_arr = ctypes.c_wchar * len(path)

--- a/lib/spack/spack/build_systems/msbuild.py
+++ b/lib/spack/spack/build_systems/msbuild.py
@@ -69,7 +69,7 @@ class MSBuildBuilder(BaseBuilder):
     @property
     def build_directory(self):
         """Return the directory containing the MSBuild solution or vcxproj."""
-        return self.pkg.stage.source_path
+        return fs.compute_sfn(self.pkg.stage.source_path)
 
     @property
     def toolchain_version(self):

--- a/lib/spack/spack/build_systems/msbuild.py
+++ b/lib/spack/spack/build_systems/msbuild.py
@@ -69,7 +69,7 @@ class MSBuildBuilder(BaseBuilder):
     @property
     def build_directory(self):
         """Return the directory containing the MSBuild solution or vcxproj."""
-        return fs.compute_sfn(self.pkg.stage.source_path)
+        return fs.windows_sfn(self.pkg.stage.source_path)
 
     @property
     def toolchain_version(self):

--- a/lib/spack/spack/build_systems/nmake.py
+++ b/lib/spack/spack/build_systems/nmake.py
@@ -77,7 +77,7 @@ class NMakeBuilder(BaseBuilder):
     @property
     def build_directory(self):
         """Return the directory containing the makefile."""
-        return self.pkg.stage.source_path if not self.makefile_root else self.makefile_root
+        return fs.compute_sfn(self.pkg.stage.source_path) if not self.makefile_root else fs.compute_sfn(self.makefile_root)
 
     @property
     def std_nmake_args(self):

--- a/lib/spack/spack/build_systems/nmake.py
+++ b/lib/spack/spack/build_systems/nmake.py
@@ -77,7 +77,11 @@ class NMakeBuilder(BaseBuilder):
     @property
     def build_directory(self):
         """Return the directory containing the makefile."""
-        return fs.compute_sfn(self.pkg.stage.source_path) if not self.makefile_root else fs.compute_sfn(self.makefile_root)
+        return (
+            fs.compute_sfn(self.pkg.stage.source_path)
+            if not self.makefile_root
+            else fs.compute_sfn(self.makefile_root)
+        )
 
     @property
     def std_nmake_args(self):

--- a/lib/spack/spack/build_systems/nmake.py
+++ b/lib/spack/spack/build_systems/nmake.py
@@ -78,9 +78,9 @@ class NMakeBuilder(BaseBuilder):
     def build_directory(self):
         """Return the directory containing the makefile."""
         return (
-            fs.compute_sfn(self.pkg.stage.source_path)
+            fs.windows_sfn(self.pkg.stage.source_path)
             if not self.makefile_root
-            else fs.compute_sfn(self.makefile_root)
+            else fs.windows_sfn(self.makefile_root)
         )
 
     @property

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -471,7 +471,8 @@ class NMakeBuilder(NMakeBuilder):
         # The trailing path seperator is REQUIRED for cURL to install
         # otherwise cURLs build system will interpret the path as a file
         # and the install will fail with ambiguous errors
-        args.append("WITH_PREFIX=%s" % self.prefix + "\\")
+        inst_prefix = self.prefix + "\\"
+        args.append(f"WITH_PREFIX={compute_sfn(inst_prefix)}")
         return args
 
     def install(self, pkg, spec, prefix):

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -7,6 +7,7 @@ import glob
 import os
 import re
 import sys
+from llnl.util.filesystem import compute_sfn
 
 from spack.build_systems.autotools import AutotoolsBuilder
 from spack.build_systems.nmake import NMakeBuilder
@@ -485,6 +486,7 @@ class NMakeBuilder(NMakeBuilder):
         env["CC"] = ""
         env["CXX"] = ""
         winbuild_dir = os.path.join(self.stage.source_path, "winbuild")
+        winbuild_dir = compute_sfn(winbuild_dir)
         with working_dir(winbuild_dir):
             nmake("/f", "Makefile.vc", *self.nmake_args(), ignore_quotes=True)
         with working_dir(os.path.join(self.stage.source_path, "builds")):

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -7,6 +7,7 @@ import glob
 import os
 import re
 import sys
+
 from llnl.util.filesystem import compute_sfn
 
 from spack.build_systems.autotools import AutotoolsBuilder

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -8,7 +8,7 @@ import os
 import re
 import sys
 
-from llnl.util.filesystem import compute_sfn
+from llnl.util.filesystem import windows_sfn
 
 from spack.build_systems.autotools import AutotoolsBuilder
 from spack.build_systems.nmake import NMakeBuilder
@@ -473,7 +473,7 @@ class NMakeBuilder(NMakeBuilder):
         # otherwise cURLs build system will interpret the path as a file
         # and the install will fail with ambiguous errors
         inst_prefix = self.prefix + "\\"
-        args.append(f"WITH_PREFIX={compute_sfn(inst_prefix)}")
+        args.append(f"WITH_PREFIX={windows_sfn(inst_prefix)}")
         return args
 
     def install(self, pkg, spec, prefix):
@@ -488,7 +488,7 @@ class NMakeBuilder(NMakeBuilder):
         env["CC"] = ""
         env["CXX"] = ""
         winbuild_dir = os.path.join(self.stage.source_path, "winbuild")
-        winbuild_dir = compute_sfn(winbuild_dir)
+        winbuild_dir = windows_sfn(winbuild_dir)
         with working_dir(winbuild_dir):
             nmake("/f", "Makefile.vc", *self.nmake_args(), ignore_quotes=True)
         with working_dir(os.path.join(self.stage.source_path, "builds")):

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -288,7 +288,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             args.append("CCTYPE=%s" % self.compiler.short_msvc_version)
         else:
             raise RuntimeError("Perl unsupported for non MSVC compilers on Windows")
-        args.append("INST_TOP=%s" % self.prefix.replace("/", "\\"))
+        args.append("INST_TOP=%s" % compute_sfn(self.prefix.replace("/", "\\")))
         args.append("INST_ARCH=\\$(ARCHNAME)")
         if self.spec.satisfies("~shared"):
             args.append("ALL_STATIC=%s" % "define")

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -18,6 +18,7 @@ from contextlib import contextmanager
 
 from llnl.util.lang import match_predicate
 from llnl.util.symlink import symlink
+from llnl.util.filesystem import compute_sfn
 
 from spack.operating_systems.mac_os import macos_version
 from spack.package import *
@@ -368,6 +369,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     def build_test(self):
         if sys.platform == "win32":
             win32_dir = os.path.join(self.stage.source_path, "win32")
+            win32_dir = compute_sfn(win32_dir)
             with working_dir(win32_dir):
                 nmake("test", ignore_quotes=True)
         else:
@@ -376,6 +378,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     def install(self, spec, prefix):
         if sys.platform == "win32":
             win32_dir = os.path.join(self.stage.source_path, "win32")
+            win32_dir = compute_sfn(win32_dir)
             with working_dir(win32_dir):
                 nmake("install", *self.nmake_arguments(), ignore_quotes=True)
         else:
@@ -409,6 +412,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         if sys.platform == "win32":
             maker = nmake
             cpan_dir = join_path(self.stage.source_path, cpan_dir)
+            cpan_dir = compute_sfn(cpan_dir)
         if "+cpanm" in spec:
             with working_dir(cpan_dir):
                 perl = spec["perl"].command

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -16,9 +16,9 @@ import re
 import sys
 from contextlib import contextmanager
 
+from llnl.util.filesystem import compute_sfn
 from llnl.util.lang import match_predicate
 from llnl.util.symlink import symlink
-from llnl.util.filesystem import compute_sfn
 
 from spack.operating_systems.mac_os import macos_version
 from spack.package import *

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -16,7 +16,7 @@ import re
 import sys
 from contextlib import contextmanager
 
-from llnl.util.filesystem import compute_sfn
+from llnl.util.filesystem import windows_sfn
 from llnl.util.lang import match_predicate
 from llnl.util.symlink import symlink
 
@@ -288,7 +288,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             args.append("CCTYPE=%s" % self.compiler.short_msvc_version)
         else:
             raise RuntimeError("Perl unsupported for non MSVC compilers on Windows")
-        args.append("INST_TOP=%s" % compute_sfn(self.prefix.replace("/", "\\")))
+        args.append("INST_TOP=%s" % windows_sfn(self.prefix.replace("/", "\\")))
         args.append("INST_ARCH=\\$(ARCHNAME)")
         if self.spec.satisfies("~shared"):
             args.append("ALL_STATIC=%s" % "define")
@@ -369,7 +369,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     def build_test(self):
         if sys.platform == "win32":
             win32_dir = os.path.join(self.stage.source_path, "win32")
-            win32_dir = compute_sfn(win32_dir)
+            win32_dir = windows_sfn(win32_dir)
             with working_dir(win32_dir):
                 nmake("test", ignore_quotes=True)
         else:
@@ -378,7 +378,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     def install(self, spec, prefix):
         if sys.platform == "win32":
             win32_dir = os.path.join(self.stage.source_path, "win32")
-            win32_dir = compute_sfn(win32_dir)
+            win32_dir = windows_sfn(win32_dir)
             with working_dir(win32_dir):
                 nmake("install", *self.nmake_arguments(), ignore_quotes=True)
         else:
@@ -412,7 +412,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         if sys.platform == "win32":
             maker = nmake
             cpan_dir = join_path(self.stage.source_path, cpan_dir)
-            cpan_dir = compute_sfn(cpan_dir)
+            cpan_dir = windows_sfn(cpan_dir)
         if "+cpanm" in spec:
             with working_dir(cpan_dir):
                 perl = spec["perl"].command


### PR DESCRIPTION
`nmake` and `msbuild` build systems are susceptible to paths with spaces i.e. `C:\\Users\\John Parent` (which they would see as `C:\\Users\\John`), however, they both support the `SFN` specification of paths that does not support spaces. Replacing all paths provided to these tools with the `SFN` equivalent via the win32 API ensures these build systems can handle paths with spaces.

> note: This cannot be resolved with quoting as Spack does not always have sufficient control over the mechanism the build systems are acquiring these paths with spaces.

https://en.wikipedia.org/wiki/8.3_filename