### PR TITLE
mvapich: add v3.0

### DIFF
--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -17,7 +17,7 @@ class Mvapich(AutotoolsPackage):
     platforms (x86 (Intel and AMD), ARM and OpenPOWER)"""
 
     homepage = "https://mvapich.cse.ohio-state.edu/userguide/userguide_spack/"
-    url = "https://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich-3.0b.tar.gz"
+    url = "https://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich-3.0.tar.gz"
     list_url = "https://mvapich.cse.ohio-state.edu/downloads/"
 
     maintainers("natshineman", "harisubramoni", "MatthewLieber")
@@ -27,7 +27,7 @@ class Mvapich(AutotoolsPackage):
     license("Unlicense")
 
     # Prefer the latest stable release
-    version("3.0b", sha256="52d8a742e16eef69e944754fea7ebf8ba4ac572dac67dbda528443d9f32547cc")
+    version("3.0", sha256="ee076c4e672d18d6bf8dd2250e4a91fa96aac1db2c788e4572b5513d86936efb")
 
     provides("mpi")
     provides("mpi@:3.1")


### PR DESCRIPTION
MVAPICH 3.0 has gone into a GA release.  We have updated the sha for the new release and have removed the info for the beta release as everyone should move over to the GA.
