### PR TITLE
Migrate netcdf-cxx4 to use CMake and stop linking against system libnetcdf

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -29,8 +29,8 @@ class NetcdfCxx4(CMakePackage):
     depends_on("netcdf-c")
     depends_on("hdf5")
 
-    # if we link against an mpi-aware hdf5 then this needs to also be mpi aware
-    depends_on("mpi", when="^hdf5+mpi")
+    # if we link against an mpi-aware hdf5 then this needs to also be mpi aware for tests
+    depends_on("mpi", when="+tests ^hdf5+mpi")
     depends_on("doxygen", when="+doc", type="build")
 
     filter_compiler_wrappers("ncxx4-config", relative_root="bin")

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -24,10 +24,10 @@ class NetcdfCxx4(CMakePackage):
     variant("shared", default=True, description="Enable shared library")
     variant("pic", default=True, description="Produce position-independent code (for shared libs)")
     variant("doc", default=False, description="Enable doxygen docs")
-    variant("tests", default=False, description="Enable CTest-based tests, dashboards.")  
+    variant("tests", default=False, description="Enable CTest-based tests, dashboards.")
 
     depends_on("netcdf-c")
-    depends_on('hdf5') 
+    depends_on('hdf5')
 
     # if we link against an mpi-aware hdf5 then this needs to also be mpi aware
     depends_on('mpi', when='^hdf5+mpi')

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -5,6 +5,7 @@
 
 from spack.package import *
 
+
 class NetcdfCxx4(CMakePackage):
     """NetCDF (network Common Data Form) is a set of software libraries and
     machine-independent data formats that support the creation, access, and
@@ -28,8 +29,8 @@ class NetcdfCxx4(CMakePackage):
     depends_on("netcdf-c")
     depends_on('hdf5') 
 
-    # if we link against an mpi-aware hdf5 then this needs to also be mpi aware 
-    depends_on('mpi', when='^hdf5+mpi')  
+    # if we link against an mpi-aware hdf5 then this needs to also be mpi aware
+    depends_on('mpi', when='^hdf5+mpi')
     depends_on("doxygen", when="+doc", type="build")
 
     filter_compiler_wrappers("ncxx4-config", relative_root="bin")
@@ -61,11 +62,10 @@ class NetcdfCxx4(CMakePackage):
         filter_file(
                r"HDF5_C_LIBRARY_hdf5",
                "HDF5_C_LIBRARIES",
-               join_path(self.stage.source_path,'cxx4', "CMakeLists.txt"))
+               join_path(self.stage.source_path, 'cxx4', "CMakeLists.txt"))
 
     def cmake_args(self):
-
-        args = [ 
+        args = [
                     self.define_from_variant('BUILD_SHARED_LIBS', "shared"),
                     self.define_from_variant('ENABLE_DOXYGEN', "doc"),
                     self.define_from_variant('NCXX_ENABLE_TESTS', "tests"),

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -26,6 +26,10 @@ class NetcdfCxx4(CMakePackage):
     variant("doc", default=False, description="Enable doxygen docs")
     variant("tests", default=False, description="Enable CTest-based tests, dashboards.")
 
+    # If another cmake-built netcdf-c exists outside of spack  e.g., homebrew's libnetcdf,
+    # then cmake will choose that external netcdf-c.
+    # This approach ensures the config.cmake exists, and thus ensures the spack version is
+    #  found before the system's
     depends_on("netcdf-c build_system=cmake")
     depends_on("hdf5")
 

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -3,10 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack.package import *
-
 
 class NetcdfCxx4(CMakePackage):
     """NetCDF (network Common Data Form) is a set of software libraries and
@@ -26,11 +23,13 @@ class NetcdfCxx4(CMakePackage):
     variant("shared", default=True, description="Enable shared library")
     variant("pic", default=True, description="Produce position-independent code (for shared libs)")
     variant("doc", default=False, description="Enable doxygen docs")
-    variant("tests", default=False, description="Enable CTest-based tests, dashboards.")  # This looks to have unidata specific config
+    variant("tests", default=False, description="Enable CTest-based tests, dashboards.")  
 
     depends_on("netcdf-c")
-    depends_on('hdf5') # the cmake code path of netcdf-cxx4 has an explicit check on hdf5 so this needs to be a depend now
-    depends_on('mpi',when='^hdf5+mpi')  # if we link against an mpi-aware hdf5 then this needs to also be mpi aware 
+    depends_on('hdf5') 
+
+    # if we link against an mpi-aware hdf5 then this needs to also be mpi aware 
+    depends_on('mpi', when='^hdf5+mpi')  
     depends_on("doxygen", when="+doc", type="build")
 
     filter_compiler_wrappers("ncxx4-config", relative_root="bin")
@@ -41,20 +40,14 @@ class NetcdfCxx4(CMakePackage):
         if name == "cxxflags" and "+pic" in self.spec:
             flags.append(self.compiler.cxx_pic_flag)
 
-        # Note that cflags and cxxflags should be added by the compiler wrapper
-        # and not on the command line to avoid overriding the default
-        # compilation flags set by the configure script:
         return flags, None, None
-
 
     @property
     def libs(self):
         libraries = ["libnetcdf_c++4"]
-
         shared = "+shared" in spec
 
         return find_libraries(libraries, root=self.prefix, shared=shared, recursive=True)
-
 
     def patch(self):
         # An incorrect value is queried post find_package(HDF5)
@@ -63,24 +56,22 @@ class NetcdfCxx4(CMakePackage):
         filter_file(
                r"HDF5_C_LIBRARY_hdf5",
                "HDF5_C_LIBRARIES",
-               join_path(self.stage.source_path,"CMakeLists.txt"))
+               join_path(self.stage.source_path, "CMakeLists.txt"))
 
         filter_file(
                r"HDF5_C_LIBRARY_hdf5",
                "HDF5_C_LIBRARIES",
-               join_path(self.stage.source_path,'cxx4',"CMakeLists.txt"))
-
+               join_path(self.stage.source_path,'cxx4', "CMakeLists.txt"))
 
     def cmake_args(self):
 
         args = [ 
                     self.define_from_variant('BUILD_SHARED_LIBS', "shared"),
-                    self.define_from_variant('ENABLE_DOXYGEN', "doc"), 
+                    self.define_from_variant('ENABLE_DOXYGEN', "doc"),
                     self.define_from_variant('NCXX_ENABLE_TESTS', "tests"),
             ]
 
         return args
-
 
     def check(self):
         with working_dir(self.build_directory):

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -78,10 +78,11 @@ class NetcdfCxx4(CMakePackage):
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("ENABLE_DOXYGEN", "doc"),
             self.define_from_variant("NCXX_ENABLE_TESTS", "tests"),
+
         ]
 
         return args
 
     def check(self):
         with working_dir(self.build_directory):
-            make("check", parallel=False)
+            make("test", parallel=False)

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -48,7 +48,14 @@ class NetcdfCxx4(CMakePackage):
         libraries = ["libnetcdf_c++4"]
         shared = "+shared" in spec
 
-        return find_libraries(libraries, root=self.prefix, shared=shared, recursive=True)
+        libs = find_libraries(libraries, root=self.prefix, shared=shared, recursive=True)
+        if libs:
+            return libs
+
+        msg = "Unable to recursively locate {0} {1} libraries in {2}"
+        raise spack.error.NoLibrariesError(
+            msg.format("shared" if shared else "static", self.spec.name, self.spec.prefix)
+        )
 
     def patch(self):
         # An incorrect value is queried post find_package(HDF5)

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -27,10 +27,10 @@ class NetcdfCxx4(CMakePackage):
     variant("tests", default=False, description="Enable CTest-based tests, dashboards.")
 
     depends_on("netcdf-c")
-    depends_on('hdf5')
+    depends_on("hdf5")
 
     # if we link against an mpi-aware hdf5 then this needs to also be mpi aware
-    depends_on('mpi', when='^hdf5+mpi')
+    depends_on("mpi", when="^hdf5+mpi")
     depends_on("doxygen", when="+doc", type="build")
 
     filter_compiler_wrappers("ncxx4-config", relative_root="bin")
@@ -55,21 +55,23 @@ class NetcdfCxx4(CMakePackage):
         # This looks to be resolved in master, but not any of the tag releases
         # https://github.com/Unidata/netcdf-cxx4/issues/88
         filter_file(
-               r"HDF5_C_LIBRARY_hdf5",
-               "HDF5_C_LIBRARIES",
-               join_path(self.stage.source_path, "CMakeLists.txt"))
+            r"HDF5_C_LIBRARY_hdf5",
+            "HDF5_C_LIBRARIES",
+            join_path(self.stage.source_path, "CMakeLists.txt"),
+        )
 
         filter_file(
-               r"HDF5_C_LIBRARY_hdf5",
-               "HDF5_C_LIBRARIES",
-               join_path(self.stage.source_path, 'cxx4', "CMakeLists.txt"))
+            r"HDF5_C_LIBRARY_hdf5",
+            "HDF5_C_LIBRARIES",
+            join_path(self.stage.source_path, "cxx4", "CMakeLists.txt"),
+        )
 
     def cmake_args(self):
         args = [
-                    self.define_from_variant('BUILD_SHARED_LIBS', "shared"),
-                    self.define_from_variant('ENABLE_DOXYGEN', "doc"),
-                    self.define_from_variant('NCXX_ENABLE_TESTS', "tests"),
-            ]
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("ENABLE_DOXYGEN", "doc"),
+            self.define_from_variant("NCXX_ENABLE_TESTS", "tests"),
+        ]
 
         return args
 

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -8,7 +8,7 @@ import os
 from spack.package import *
 
 
-class NetcdfCxx4(AutotoolsPackage):
+class NetcdfCxx4(CMakePackage):
     """NetCDF (network Common Data Form) is a set of software libraries and
     machine-independent data formats that support the creation, access, and
     sharing of array-oriented scientific data. This is the C++ distribution."""
@@ -26,9 +26,11 @@ class NetcdfCxx4(AutotoolsPackage):
     variant("shared", default=True, description="Enable shared library")
     variant("pic", default=True, description="Produce position-independent code (for shared libs)")
     variant("doc", default=False, description="Enable doxygen docs")
+    variant("tests", default=False, description="Enable CTest-based tests, dashboards.")  # This looks to have unidata specific config
 
     depends_on("netcdf-c")
-
+    depends_on('hdf5') # the cmake code path of netcdf-cxx4 has an explicit check on hdf5 so this needs to be a depend now
+    depends_on('mpi',when='^hdf5+mpi')  # if we link against an mpi-aware hdf5 then this needs to also be mpi aware 
     depends_on("doxygen", when="+doc", type="build")
 
     filter_compiler_wrappers("ncxx4-config", relative_root="bin")
@@ -53,92 +55,37 @@ class NetcdfCxx4(AutotoolsPackage):
     def libs(self):
         libraries = ["libnetcdf_c++4"]
 
-        query_parameters = self.spec.last_query.extra_parameters
-
-        if "shared" in query_parameters:
-            shared = True
-        elif "static" in query_parameters:
-            shared = False
-        else:
-            shared = "+shared" in self.spec
-
-        libs = find_libraries(libraries, root=self.prefix, shared=shared, recursive=True)
+        libs = find_libraries(libraries, root=self.prefix, shared=self.shared, recursive=True)
 
         if libs:
             return libs
 
         msg = "Unable to recursively locate {0} {1} libraries in {2}"
         raise spack.error.NoLibrariesError(
-            msg.format("shared" if shared else "static", self.spec.name, self.spec.prefix)
+            msg.format("shared" if self.shared else "static", self.spec.name, self.spec.prefix)
         )
 
-    @when("@4.3.1:+shared")
-    @on_package_attributes(run_tests=True)
+
     def patch(self):
-        # We enable the filter tests only when the tests are requested by the
-        # user. This, however, has a side effect: an extra file 'libh5bzip2.so'
-        # gets installed (note that the file has .so extension even on darwin).
-        # It's unclear whether that is intended but given the description of the
-        # configure option --disable-filter-testing (Do not run filter test and
-        # example; requires shared libraries and netCDF-4), we currently assume
-        # that the file is not really meant for the installation. To make all
-        # installations consistent and independent of whether the shared
-        # libraries or the tests are requested, we prevent installation of
-        # 'libh5bzip2.so':
+        # An incorrect value is queried post find_package(HDF5)
+        # This looks to be resolved in master, but not any of the tag releases
+        # https://github.com/Unidata/netcdf-cxx4/issues/88
         filter_file(
-            r"(^\s*)lib(_LTLIBRARIES\s*)(=\s*libh5bzip2\.la\s*$)",
-            r"\1noinst\2+\3",
-            join_path(self.stage.source_path, "plugins", "Makefile.in"),
-        )
+               r"HDF5_C_LIBRARY_hdf5",
+               "HDF5_C_LIBRARIES",
+               join_path(self.stage.source_path,"CMakeLists.txt"))
 
-    def configure_args(self):
-        config_args = self.enable_or_disable("shared")
 
-        if "+doc" in self.spec:
-            config_args.append("--enable-doxygen")
-        else:
-            config_args.append("--disable-doxygen")
+    def cmake_args(self):
 
-        if self.spec.satisfies("@4.3.1:"):
-            if self.run_tests and "+shared" in self.spec:
-                config_args.append("--enable-filter-testing")
-                if self.spec.satisfies("^hdf5+mpi"):
-                    # The package itself does not need the MPI libraries but
-                    # includes <hdf5.h> in the filter test C code, which
-                    # requires <mpi.h> when HDF5 is built with the MPI support.
-                    # Using the MPI wrapper introduces overlinking to MPI
-                    # libraries and we would prefer not to use it but it is the
-                    # only reliable way to provide the compiler with the correct
-                    # path to <mpi.h>. For example, <mpi.h> of a MacPorts-built
-                    # MPICH might reside in /opt/local/include/mpich-gcc10,
-                    # which Spack does not know about and cannot inject with its
-                    # compiler wrapper.
-                    config_args.append("CC={0}".format(self.spec["mpi"].mpicc))
-            else:
-                config_args.append("--disable-filter-testing")
+        args = [ 
+                    self.define('BUILD_SHARED_LIBS', self.shared),
+                    self.define('ENABLE_DOXYGEN', self.doc), 
+                    self.define('NCXX_ENABLE_TESTS', self.tests),
+            ]
 
-        return config_args
+        return args
 
-    @run_after("configure")
-    def rename_version(self):
-        # See https://github.com/Unidata/netcdf-cxx4/issues/109
-        # The issue is fixed upstream:
-        #   https://github.com/Unidata/netcdf-cxx4/commit/e7cc5bab02cf089dc79616456a0a951fee979fe9
-        # We do not apply the upstream patch because we want to avoid running
-        # autoreconf and introduce additional dependencies. We do not generate a
-        # patch for the configure script because the patched string contains the
-        # version and we would need a patch file for each supported version of
-        # the library. We do not implement the patching with filter_file in the
-        # patch method because writing a robust regexp seems to be more
-        # difficult that simply renaming the file if exists. It also looks like
-        # we can simply remove the file since it is not used anywhere.
-        if not self.spec.satisfies("@:4.3.1 platform=darwin"):
-            return
-
-        with working_dir(self.build_directory):
-            fname = "VERSION"
-            if os.path.exists(fname):
-                os.rename(fname, "{0}.txt".format(fname))
 
     def check(self):
         with working_dir(self.build_directory):

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -73,7 +73,6 @@ class NetcdfCxx4(CMakePackage):
             join_path(self.stage.source_path, "cxx4", "CMakeLists.txt"),
         )
 
-
     def cmake_args(self):
         args = [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -26,7 +26,7 @@ class NetcdfCxx4(CMakePackage):
     variant("doc", default=False, description="Enable doxygen docs")
     variant("tests", default=False, description="Enable CTest-based tests, dashboards.")
 
-    depends_on("netcdf-c")
+    depends_on("netcdf-c build_system=cmake")
     depends_on("hdf5")
 
     # if we link against an mpi-aware hdf5 then this needs to also be mpi aware for tests
@@ -73,12 +73,12 @@ class NetcdfCxx4(CMakePackage):
             join_path(self.stage.source_path, "cxx4", "CMakeLists.txt"),
         )
 
+
     def cmake_args(self):
         args = [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("ENABLE_DOXYGEN", "doc"),
             self.define_from_variant("NCXX_ENABLE_TESTS", "tests"),
-
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -55,14 +55,14 @@ class NetcdfCxx4(CMakePackage):
     def libs(self):
         libraries = ["libnetcdf_c++4"]
 
-        libs = find_libraries(libraries, root=self.prefix, shared=self.shared, recursive=True)
+        libs = find_libraries(libraries, root=self.prefix, shared=True if "+debug" in spec else False, recursive=True)
 
         if libs:
             return libs
 
         msg = "Unable to recursively locate {0} {1} libraries in {2}"
         raise spack.error.NoLibrariesError(
-            msg.format("shared" if self.shared else "static", self.spec.name, self.spec.prefix)
+            msg.format("+shared" if self.spec else "static", self.spec.name, self.spec.prefix)
         )
 
 
@@ -79,9 +79,9 @@ class NetcdfCxx4(CMakePackage):
     def cmake_args(self):
 
         args = [ 
-                    self.define('BUILD_SHARED_LIBS', self.shared),
-                    self.define('ENABLE_DOXYGEN', self.doc), 
-                    self.define('NCXX_ENABLE_TESTS', self.tests),
+                    self.define_from_variant('BUILD_SHARED_LIBS', "shared"),
+                    self.define_from_variant('ENABLE_DOXYGEN', "doc"), 
+                    self.define_from_variant('NCXX_ENABLE_TESTS', "tests"),
             ]
 
         return args


### PR DESCRIPTION
This PR fixes issue #42735 

The underlying issue is that some of the assumptions made in netcdf-cxx4 package.py result in system libnetcdf being linked to.

This PR migrates to using CMake to better control how dependencies are found, explicitly depends upon netcdf and hdf5 as netcdf-cxx4 uses symbols from both, and cleans up the logic to be more composable and consistent in how MPI etc are used.

Specifically:
- `hdf5` is searched from in the netcdf-cxx4 CMakeLists.txt, so hdf5 has been added as an explicit dependency
- The logic around `^hdf5+mpi` has been cleaned up and now the spack MPI compiler wrapper is used.  The CC flag mutation for including MPI is not composable and should be done using external package definitions for MPI.
- The patch removing `libh5bzip2` is removed as this library is (seemingly) not installed via cmake
- VERSION is not written out by cmake so this patch is removed
- An option to enable tests was added, but this looks to have a lot of internal unidata config, so I am not sure how useful it is.


