### PR TITLE
rust-bootstrap: install without docs

### DIFF
--- a/var/spack/repos/builtin/packages/rust-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/rust-bootstrap/package.py
@@ -109,6 +109,8 @@ class RustBootstrap(Package):
         if os in rust_releases[release] and target in rust_releases[release][os]:
             version(release, sha256=rust_releases[release][os][target])
 
+    variant("docs", default=True, description="Build docs")
+
     def url_for_version(self, version):
         # Allow maintainers to checksum multiple architectures via
         # `spack checksum rust-bootstrap@1.70.0-darwin-aarch64`.
@@ -126,4 +128,7 @@ class RustBootstrap(Package):
 
     def install(self, spec, prefix):
         install_script = Executable("./install.sh")
-        install_script(f"--prefix={prefix}")
+        install_args = [f"--prefix={prefix}"]
+        if self.spec.satisfies("~docs"):
+            install_args.append("--without=rust-docs")
+        install_script(" ".join(install_args))

--- a/var/spack/repos/builtin/packages/rust-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/rust-bootstrap/package.py
@@ -109,8 +109,6 @@ class RustBootstrap(Package):
         if os in rust_releases[release] and target in rust_releases[release][os]:
             version(release, sha256=rust_releases[release][os][target])
 
-    variant("docs", default=True, description="Build docs")
-
     def url_for_version(self, version):
         # Allow maintainers to checksum multiple architectures via
         # `spack checksum rust-bootstrap@1.70.0-darwin-aarch64`.
@@ -128,7 +126,5 @@ class RustBootstrap(Package):
 
     def install(self, spec, prefix):
         install_script = Executable("./install.sh")
-        install_args = [f"--prefix={prefix}"]
-        if self.spec.satisfies("~docs"):
-            install_args.append("--without=rust-docs")
+        install_args = [f"--prefix={prefix}", "--without=rust-docs"]
         install_script(" ".join(install_args))


### PR DESCRIPTION
This PR adds a `docs` variant to rust-bootstrap in order to make the installer's `--without=rust-docs` option available. This will allow us to save about 35k files in our installations, which is not inconsequential for our file number quotas. Default value reflects default (current) behavior.