### PR TITLE
Allow awscli-v2 to be installed without examples/ dir

### DIFF
--- a/var/spack/repos/builtin/packages/awscli-v2/package.py
+++ b/var/spack/repos/builtin/packages/awscli-v2/package.py
@@ -35,8 +35,5 @@ class AwscliV2(PythonPackage):
     @run_after("install")
     @when("~examples")
     def post_install(self):
-        pyver = self.spec["python"].version.up_to(2)
-        examples_dir = join_path(
-            self.spec.prefix.lib, f"python{pyver}/site-packages/awscli/examples/"
-        )
+        examples_dir = join_path(python_purelib, "awscli", "examples")
         remove_directory_contents(examples_dir)

--- a/var/spack/repos/builtin/packages/awscli-v2/package.py
+++ b/var/spack/repos/builtin/packages/awscli-v2/package.py
@@ -29,3 +29,12 @@ class AwscliV2(PythonPackage):
     depends_on("py-python-dateutil@2.1:2", type=("build", "run"))
     depends_on("py-jmespath@0.7.1:1.0", type=("build", "run"))
     depends_on("py-urllib3@1.25.4:1.26", type=("build", "run"))
+
+    variant("examples", default=True, description="Install code examples")
+
+    @run_after("install")
+    @when("~examples")
+    def post_install(self):
+        pyver = self.spec["python"].version.up_to(2)
+        examples_dir = join_path(self.spec.prefix.lib, f"python{pyver}/site-packages/awscli/examples/")
+        remove_directory_contents(examples_dir)

--- a/var/spack/repos/builtin/packages/awscli-v2/package.py
+++ b/var/spack/repos/builtin/packages/awscli-v2/package.py
@@ -36,5 +36,7 @@ class AwscliV2(PythonPackage):
     @when("~examples")
     def post_install(self):
         pyver = self.spec["python"].version.up_to(2)
-        examples_dir = join_path(self.spec.prefix.lib, f"python{pyver}/site-packages/awscli/examples/")
+        examples_dir = join_path(
+            self.spec.prefix.lib, f"python{pyver}/site-packages/awscli/examples/"
+        )
         remove_directory_contents(examples_dir)


### PR DESCRIPTION
This PR adds a variant to awscli-v2 that uninstalls the examples/ directory, which contains 5-6k files that probably many users don't need (though the default is the current behavior, i.e., retaining it). Unfortunately I can't find a clean way to do this through installer options.