### PR TITLE
Update/add packages in the Nextflow ecosystem

### DIFF
--- a/var/spack/repos/builtin/packages/nextflow/package.py
+++ b/var/spack/repos/builtin/packages/nextflow/package.py
@@ -15,6 +15,11 @@ class Nextflow(Package):
     maintainers("dialvarezs", "marcodelapierre")
 
     version(
+        "23.10.1",
+        sha256="9abc54f1ffb2b834a8135d44300404552d1e27719659cbb635199898677b660a",
+        expand=False,
+    )
+    version(
         "23.10.0",
         sha256="4b7fba61ecc6d53a6850390bb435455a54ae4d0c3108199f88b16b49e555afdd",
         expand=False,

--- a/var/spack/repos/builtin/packages/nf-seqerakit/package.py
+++ b/var/spack/repos/builtin/packages/nf-seqerakit/package.py
@@ -23,4 +23,4 @@ class NfSeqerakit(PythonPackage):
     depends_on("python@3.8:3", type=("build", "run"))
     depends_on("py-setuptools", type="build")
 
-    depends_on("py-pyyaml@6.0.0:", type=("build", "run"))
+    depends_on("py-pyyaml@6:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/nf-seqerakit/package.py
+++ b/var/spack/repos/builtin/packages/nf-seqerakit/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class NfSeqerakit(PythonPackage):
+    """A Python wrapper for the Seqera Platform CLI (formerly Tower CLI)."""
+
+    homepage = "https://github.com/seqeralabs/seqera-kit"
+    pypi = "seqerakit/seqerakit-0.4.5.tar.gz"
+    maintainers("marcodelapierre")
+
+    license("Apache-2.0")
+
+    version("0.4.5", sha256="792bd4fa53de4b3959929413d1ad8f39e20587971c9c5451419da1ff68cf3f49")
+
+    depends_on("nf-tower-cli", type="run")
+
+    depends_on("python@3.8:3", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-pyyaml@6.0.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/nf-tower-cli/package.py
+++ b/var/spack/repos/builtin/packages/nf-tower-cli/package.py
@@ -20,6 +20,18 @@ class NfTowerCli(Package):
     if platform.machine() == "x86_64":
         if platform.system() == "Darwin":
             version(
+                "0.9.2",
+                sha256="e96c036401c21b4c9b0379a4099192161d94f7567ea16313e7147d6f75828394",
+                url="https://github.com/seqeralabs/tower-cli/releases/download/v0.9.2/tw-osx-x86_64",
+                expand=False,
+            )
+            version(
+                "0.8.0",
+                sha256="c32f9ad48a1a49f1aa62a496b253f24423ae361c1309740f22c429de7e9cc75a",
+                url="https://github.com/seqeralabs/tower-cli/releases/download/v0.8.0/tw-osx-x86_64",
+                expand=False,
+            )
+            version(
                 "0.7.2",
                 sha256="b72093af9c8d61e0150eb9d56cedb67afc982d2432221ae0819aaa0c8826ff2b",
                 url="https://github.com/seqeralabs/tower-cli/releases/download/v0.7.2/tw-0.7.2-osx-x86_64",
@@ -51,6 +63,18 @@ class NfTowerCli(Package):
             )
         elif platform.system() == "Linux":
             version(
+                "0.9.2",
+                sha256="1b96696219d922aaa1a5e09f4a018b34c38806c134234b7f9bde19c92f04ab64",
+                url="https://github.com/seqeralabs/tower-cli/releases/download/v0.9.2/tw-linux-x86_64",
+                expand=False,
+            )
+            version(
+                "0.8.0",
+                sha256="c0d08bbf3059296e4819d33c6ff9282cfdd4d97087213c2d9aa0b5943ced60f4",
+                url="https://github.com/seqeralabs/tower-cli/releases/download/v0.8.0/tw-linux-x86_64",
+                expand=False,
+            )
+            version(
                 "0.7.2",
                 sha256="a66d1655d2f3d83db160a890e6b3f20f4573978aa9e8ea5d6e505958a2980e72",
                 url="https://github.com/seqeralabs/tower-cli/releases/download/v0.7.2/tw-0.7.2-linux-x86_64",
@@ -78,6 +102,14 @@ class NfTowerCli(Package):
                 "0.6.2",
                 sha256="02c6d141416b046b6e8b6f9723331fe0e39d37faa3561c47c152df4d33b37e50",
                 url="https://github.com/seqeralabs/tower-cli/releases/download/v0.6.2/tw-0.6.2-linux-x86_64",
+                expand=False,
+            )
+    elif platform.machine() == "aarch64":
+        if platform.system() == "Darwin":
+            version(
+                "0.9.2",
+                sha256="31ffa200aea3e70533222cab08a212080b889d933ac7ee2b8ece22c51d3e8c1a",
+                url="https://github.com/seqeralabs/tower-cli/releases/download/v0.9.2/tw-osx-arm64",
                 expand=False,
             )
 

--- a/var/spack/repos/builtin/packages/nf-wave-cli/package.py
+++ b/var/spack/repos/builtin/packages/nf-wave-cli/package.py
@@ -9,8 +9,7 @@ from spack.package import *
 
 
 class NfWaveCli(Package):
-    """Command line tool for Wave containers provisioning service.
-    """
+    """Command line tool for Wave containers provisioning service."""
 
     homepage = "https://github.com/seqeralabs/wave-cli"
     maintainers("marcodelapierre")

--- a/var/spack/repos/builtin/packages/nf-wave-cli/package.py
+++ b/var/spack/repos/builtin/packages/nf-wave-cli/package.py
@@ -1,0 +1,63 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import platform
+
+from spack.package import *
+
+
+class NfWaveCli(Package):
+    """Command line tool for Wave containers provisioning service.
+    """
+
+    homepage = "https://github.com/seqeralabs/wave-cli"
+    maintainers("marcodelapierre")
+
+    if platform.machine() == "x86_64":
+        if platform.system() == "Darwin":
+            version(
+                "1.2.0",
+                sha256="97152d86d6ffed9e97b4eea1dc369525bdbc9bb19f0fefca79a10cbcbb82c549",
+                url="https://github.com/seqeralabs/wave-cli/releases/download/v1.2.0/wave-1.2.0-macos-x86_64",
+                expand=False,
+            )
+            version(
+                "1.1.3",
+                sha256="8f57cfafaefe34a9aadb460e3ddfe911bdcf7a93296e7a00d29983c065366a2f",
+                url="https://github.com/seqeralabs/wave-cli/releases/download/v1.1.3/wave-1.1.3-macos-x86_64",
+                expand=False,
+            )
+        elif platform.system() == "Linux":
+            version(
+                "1.2.0",
+                sha256="12c572ec3384ddc07a623dcff5262398e0f7d50306b9f2bd35f779c7264a1c38",
+                url="https://github.com/seqeralabs/wave-cli/releases/download/v1.2.0/wave-1.2.0-linux-x86_64",
+                expand=False,
+            )
+            version(
+                "1.1.3",
+                sha256="953935159a5581e3a078528792651c12212302a609dffafe5a007d36f75049c0",
+                url="https://github.com/seqeralabs/wave-cli/releases/download/v1.1.3/wave-1.1.3-linux-x86_64",
+                expand=False,
+            )
+    elif platform.machine() == "aarch64":
+        if platform.system() == "Darwin":
+            version(
+                "1.2.0",
+                sha256="813867e931d19f2452a1b8eee52dc976e08f4146001beed755b12ef44de29050",
+                url="https://github.com/seqeralabs/wave-cli/releases/download/v1.2.0/wave-1.2.0-macos-arm64",
+                expand=False,
+            )
+            version(
+                "1.1.3",
+                sha256="1ffdf6ff9d49d14ba38f563a57412e9a408e25c273ae9b11575243a032d101ed",
+                url="https://github.com/seqeralabs/wave-cli/releases/download/v1.1.3/wave-1.1.3-macos-arm64",
+                expand=False,
+            )
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install(self.stage.archive_file, join_path(prefix.bin, "wave"))
+        set_executable(join_path(prefix.bin, "wave"))


### PR DESCRIPTION
This PR adds recipes for 2 new tools in the Nextflow ecosystem:
- [Wave CLI](https://github.com/seqeralabs/wave-cli)
- [Seqera-Kit](https://github.com/seqeralabs/seqera-kit)

It also adds recent versions for the packages Nextflow and Tower CLI.