### PR TITLE
OpenFOAM: Add MPFR search paths required for LLVM builds @2306:

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -689,11 +689,13 @@ class Openfoam(Package):
             "CGAL": [
                 ("BOOST_ARCH_PATH", spec["boost"].prefix),
                 ("CGAL_ARCH_PATH", spec["cgal"].prefix),
+                ("MPFR_ARCH_PATH", spec["mpfr"].prefix),
                 (
                     "LD_LIBRARY_PATH",
                     foam_add_lib(
                         pkglib(spec["boost"], "${BOOST_ARCH_PATH}"),
                         pkglib(spec["cgal"], "${CGAL_ARCH_PATH}"),
+                        pkglib(spec["mpfr"], "${MPFR_ARCH_PATH}"),
                     ),
                 ),
             ],


### PR DESCRIPTION
Builds with LLVM-based compilers need to be additionally instructed to link against mfpr following changes in OpenFOAM 2306+.

This issue is also raised upstream at https://develop.openfoam.com/Development/openfoam/-/issues/3101 for long-term fix.