### PR TITLE
Allow more control over which specs are reused

### DIFF
--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -34,8 +34,22 @@ In case a finer control over which specs are reused is needed, then the value of
 an object, with the following keys:
 
 1. ``strategy``: takes the same values as above (``true``, ``false``, and ``dependencies``)
-2. ``include``: list of specs. If present, reusable specs must match at least one of the constraint in the list
-3. ``from``: selects the sources from which reused specs are taken
+2. ``from``: list of sources from which reused specs are taken
+
+Each source in ``from`` is itself an object:
+
+.. list-table:: Attributes for a source or reusable specs
+   :header-rows: 1
+
+   * - Attribute name
+     - Description
+   * - type (mandatory, string)
+     - Can be ``local`` or ``mirror``
+   * - include (optional, list of specs)
+     - If present, reusable specs must match at least one of the constraint in the list
+   * - exclude (optional, list of specs)
+     - If present, reusable specs must not match any of the constraint in the list. It's
+       disregarded if ``include`` is present.
 
 For instance, the following configuration:
 
@@ -44,14 +58,35 @@ For instance, the following configuration:
    concretizer:
      reuse:
        strategy: true
-       include:
-       - "%gcc"
-       - "%clang"
        from:
        - type: local
+         include:
+         - "%gcc"
+         - "%clang"
 
 tells the concretizer to reuse all specs compiled with either ``gcc`` or ``clang``, that are installed
 in the local store. Any spec from remote buildcaches is disregarded.
+
+To reduce the boilerplate in configuration files, default values for the ``include`` and
+``exclude`` options can be pushed up one level:
+
+.. code-block:: yaml
+
+   concretizer:
+     reuse:
+       strategy: true
+       include:
+       - "%gcc"
+       from:
+       - type: local
+       - type: mirror
+       - type: local
+         include:
+         - "foo %oneapi"
+
+In the example above we reuse all specs compiled with ``gcc`` from the local store
+and remote mirrors, and we also reuse ``foo %oneapi``. Note that the last source of
+specs override the default ``include`` attribute.
 
 For one-off concretizations, the are command line arguments for each of the simple "single value"
 configurations. This means a user can:

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -21,23 +21,52 @@ is the following:
 Reuse already installed packages
 --------------------------------
 
-The ``reuse`` attribute controls whether Spack will prefer to use installed packages (``true``), or
-whether it will do a "fresh" installation and prefer the latest settings from
-``package.py`` files and ``packages.yaml`` (``false``).
-You can use:
+The ``reuse`` attribute controls how aggressively Spack reuses binary packages during concretization. The
+attribute can either be a single value, or an object for more complex configurations.
+
+In the former case ("single value") it allows Spack to:
+
+1. Reuse installed packages and buildcaches for all the specs to be concretized, when ``true``
+2. Reuse installed packages and buildcaches only for the dependencies of the root specs, when ``dependencies``
+3. Disregard reusing installed packages and buildcaches, when ``false``
+
+In case a finer control over which specs are reused is needed, then the value of this attribute can be
+an object, with the following keys:
+
+1. ``strategy``: takes the same values as above (``true``, ``false``, and ``dependencies``)
+2. ``include``: list of specs. If present, reusable specs must match at least one of the constraint in the list
+3. ``from``: selects the sources from which reused specs are taken
+
+For instance, the following configuration:
+
+.. code-block:: yaml
+
+   concretizer:
+     reuse:
+       strategy: true
+       include:
+       - "%gcc"
+       - "%clang"
+       from:
+       - type: local
+
+tells the concretizer to reuse all specs compiled with either ``gcc`` or ``clang``, that are installed
+in the local store. Any spec from remote buildcaches is disregarded.
+
+For one-off concretizations, the are command line arguments for each of the simple "single value"
+configurations. This means a user can:
 
 .. code-block:: console
 
    % spack install --reuse <spec>
 
-to enable reuse for a single installation, and you can use:
+to enable reuse for a single installation, or:
 
 .. code-block:: console
 
    spack install --fresh <spec>
 
 to do a fresh install if ``reuse`` is enabled by default.
-``reuse: dependencies`` is the default.
 
 .. seealso::
 

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -44,7 +44,7 @@ Each source in ``from`` is itself an object:
    * - Attribute name
      - Description
    * - type (mandatory, string)
-     - Can be ``local``, ``mirror``, or ``external``
+     - Can be ``local``, ``buildcache``, or ``external``
    * - include (optional, list of specs)
      - If present, reusable specs must match at least one of the constraint in the list
    * - exclude (optional, list of specs)
@@ -78,13 +78,13 @@ To reduce the boilerplate in configuration files, default values for the ``inclu
        - "%gcc"
        from:
        - type: local
-       - type: mirror
+       - type: buildcache
        - type: local
          include:
          - "foo %oneapi"
 
 In the example above we reuse all specs compiled with ``gcc`` from the local store
-and remote mirrors, and we also reuse ``foo %oneapi``. Note that the last source of
+and remote buildcaches, and we also reuse ``foo %oneapi``. Note that the last source of
 specs override the default ``include`` attribute.
 
 For one-off concretizations, the are command line arguments for each of the simple "single value"

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -33,7 +33,7 @@ In the former case ("single value") it allows Spack to:
 In case a finer control over which specs are reused is needed, then the value of this attribute can be
 an object, with the following keys:
 
-1. ``strategy``: takes the same values as above (``true``, ``false``, and ``dependencies``)
+1. ``roots``: if ``true`` root specs are reused, if ``false`` only dependencies of root specs are reused
 2. ``from``: list of sources from which reused specs are taken
 
 Each source in ``from`` is itself an object:
@@ -56,7 +56,7 @@ For instance, the following configuration:
 
    concretizer:
      reuse:
-       strategy: true
+       roots: true
        from:
        - type: local
          include:
@@ -73,7 +73,7 @@ To reduce the boilerplate in configuration files, default values for the ``inclu
 
    concretizer:
      reuse:
-       strategy: true
+       roots: true
        include:
        - "%gcc"
        from:

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -44,12 +44,11 @@ Each source in ``from`` is itself an object:
    * - Attribute name
      - Description
    * - type (mandatory, string)
-     - Can be ``local`` or ``mirror``
+     - Can be ``local``, ``mirror``, or ``external``
    * - include (optional, list of specs)
      - If present, reusable specs must match at least one of the constraint in the list
    * - exclude (optional, list of specs)
-     - If present, reusable specs must not match any of the constraint in the list. It's
-       disregarded if ``include`` is present.
+     - If present, reusable specs must not match any of the constraint in the list.
 
 For instance, the following configuration:
 

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -9,6 +9,8 @@
 """
 from typing import Any, Dict
 
+LIST_OF_SPECS = {"type": "array", "items": {"type": "string"}}
+
 properties: Dict[str, Any] = {
     "concretizer": {
         "type": "object",
@@ -27,13 +29,16 @@ properties: Dict[str, Any] = {
                                     {"type": "string", "enum": ["dependencies"]},
                                 ]
                             },
-                            "include": {"type": "array", "items": {"type": "string"}},
+                            "include": LIST_OF_SPECS,
+                            "exclude": LIST_OF_SPECS,
                             "from": {
                                 "type": "array",
                                 "items": {
                                     "type": "object",
                                     "properties": {
-                                        "type": {"type": "string", "enum": ["local", "mirror"]}
+                                        "type": {"type": "string", "enum": ["local", "mirror"]},
+                                        "include": LIST_OF_SPECS,
+                                        "exclude": LIST_OF_SPECS,
                                     },
                                 },
                             },

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -15,7 +15,22 @@ properties: Dict[str, Any] = {
         "additionalProperties": False,
         "properties": {
             "reuse": {
-                "oneOf": [{"type": "boolean"}, {"type": "string", "enum": ["dependencies"]}]
+                "oneOf": [
+                    {"type": "boolean"},
+                    {"type": "string", "enum": ["dependencies"]},
+                    {
+                        "type": "object",
+                        "properties": {
+                            "strategy": {
+                                "oneOf": [
+                                    {"type": "boolean"},
+                                    {"type": "string", "enum": ["dependencies"]},
+                                ]
+                            },
+                            "include": {"type": "string"},
+                        },
+                    },
+                ]
             },
             "enable_node_namespace": {"type": "boolean"},
             "targets": {

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -23,12 +23,7 @@ properties: Dict[str, Any] = {
                     {
                         "type": "object",
                         "properties": {
-                            "strategy": {
-                                "oneOf": [
-                                    {"type": "boolean"},
-                                    {"type": "string", "enum": ["dependencies"]},
-                                ]
-                            },
+                            "roots": {"type": "boolean"},
                             "include": LIST_OF_SPECS,
                             "exclude": LIST_OF_SPECS,
                             "from": {

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -27,7 +27,7 @@ properties: Dict[str, Any] = {
                                     {"type": "string", "enum": ["dependencies"]},
                                 ]
                             },
-                            "include": {"type": "string"},
+                            "include": {"type": "array", "items": {"type": "string"}},
                         },
                     },
                 ]

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -33,7 +33,7 @@ properties: Dict[str, Any] = {
                                     "properties": {
                                         "type": {
                                             "type": "string",
-                                            "enum": ["local", "mirror", "external"],
+                                            "enum": ["local", "buildcache", "external"],
                                         },
                                         "include": LIST_OF_SPECS,
                                         "exclude": LIST_OF_SPECS,

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -28,6 +28,15 @@ properties: Dict[str, Any] = {
                                 ]
                             },
                             "include": {"type": "array", "items": {"type": "string"}},
+                            "from": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {"type": "string", "enum": ["local", "mirror"]}
+                                    },
+                                },
+                            },
                         },
                     },
                 ]

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -36,7 +36,10 @@ properties: Dict[str, Any] = {
                                 "items": {
                                     "type": "object",
                                     "properties": {
-                                        "type": {"type": "string", "enum": ["local", "mirror"]},
+                                        "type": {
+                                            "type": "string",
+                                            "enum": ["local", "mirror", "external"],
+                                        },
                                         "include": LIST_OF_SPECS,
                                         "exclude": LIST_OF_SPECS,
                                     },

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3583,6 +3583,9 @@ class Solver:
         # These properties are settable via spack configuration, and overridable
         # by setting them directly as properties.
         self.reuse = spack.config.get("concretizer:reuse", True)
+        self.reuse_filters = []
+        if isinstance(self.reuse, typing.Mapping):
+            self.reuse, self.reuse_filters = self.reuse["strategy"], self.reuse["include"]
 
     @staticmethod
     def _check_input_and_extract_concrete_specs(specs):
@@ -3625,6 +3628,11 @@ class Solver:
         if self.reuse == "dependencies":
             reusable_specs = [
                 spec for spec in reusable_specs if not any(root in spec for root in specs)
+            ]
+
+        if self.reuse_filters:
+            reusable_specs = [
+                x for x in reusable_specs if any(x.satisfies(c) for c in self.reuse_filters)
             ]
 
         return reusable_specs

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3644,7 +3644,7 @@ class SpecFilter:
     @staticmethod
     def from_store(configuration, include, exclude) -> "SpecFilter":
         """Constructs a filter that takes the specs from the current store."""
-        packages = configuration.get("packages")
+        packages = _external_config_with_implicit_externals(configuration)
         is_reusable = functools.partial(_is_reusable, packages=packages, local=True)
         factory = functools.partial(_specs_from_store, configuration=configuration)
         return SpecFilter(factory=factory, is_usable=is_reusable, include=include, exclude=exclude)
@@ -3652,7 +3652,7 @@ class SpecFilter:
     @staticmethod
     def from_buildcache(configuration, include, exclude) -> "SpecFilter":
         """Constructs a filter that takes the specs from the configured buildcaches."""
-        packages = configuration.get("packages")
+        packages = _external_config_with_implicit_externals(configuration)
         is_reusable = functools.partial(_is_reusable, packages=packages, local=False)
         return SpecFilter(
             factory=_specs_from_mirror, is_usable=is_reusable, include=include, exclude=exclude

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3567,7 +3567,7 @@ def _has_runtime_dependencies(spec: spack.spec.Spec) -> bool:
 class ReusableSpecsSelector:
     """Selects specs that can be reused during concretization."""
 
-    def __init__(self, configuration):
+    def __init__(self, configuration: spack.config.Configuration) -> None:
         self.configuration = configuration
         self.store = spack.store.create(configuration)
 
@@ -3577,9 +3577,8 @@ class ReusableSpecsSelector:
         self.mirrors_enabled = True
         if isinstance(self.reuse, typing.Mapping):
             reuse_yaml = self.reuse
-            self.reuse, self.reuse_filters = reuse_yaml.get("strategy", True), reuse_yaml.get(
-                "include", []
-            )
+            self.reuse = reuse_yaml.get("strategy", True)
+            self.reuse_filters = reuse_yaml.get("include", [])
             self.local_store_enabled = any(
                 x["type"] == "local" for x in reuse_yaml.get("from", [{"type": "local"}])
             )
@@ -3587,13 +3586,13 @@ class ReusableSpecsSelector:
                 x["type"] == "mirror" for x in reuse_yaml.get("from", [{"type": "mirror"}])
             )
 
-    def is_selected(self, spec):
+    def is_selected(self, spec: spack.spec.Spec) -> bool:
         if not self.reuse_filters:
             return True
 
         return any(spec.satisfies(c) for c in self.reuse_filters)
 
-    def selected_from_local_store(self):
+    def selected_from_local_store(self) -> List[spack.spec.Spec]:
         if not self.local_store_enabled:
             return []
 
@@ -3605,7 +3604,7 @@ class ReusableSpecsSelector:
                 if _is_reusable(s, packages, local=True) and self.is_selected(s)
             ]
 
-    def selected_from_mirrors(self):
+    def selected_from_mirrors(self) -> List[spack.spec.Spec]:
         if not self.mirrors_enabled:
             return []
 
@@ -3622,7 +3621,7 @@ class ReusableSpecsSelector:
             # TODO: source cache (or any mirror really) doesn't have binaries.
             return []
 
-    def reusable_specs(self, specs):
+    def reusable_specs(self, specs: List[spack.spec.Spec]) -> List[spack.spec.Spec]:
         if self.reuse is False:
             return []
 
@@ -3640,12 +3639,6 @@ class Solver:
 
     It manages solver configuration and preferences in one place. It sets up the solve
     and passes the setup method to the driver, as well.
-
-    Properties of interest:
-
-      ``reuse (bool)``
-        Whether to try to reuse existing installs/binaries
-
     """
 
     def __init__(self):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1650,7 +1650,6 @@ class SpackSolverSetup:
             if pkg_name not in spack.repo.PATH:
                 continue
 
-            # self.gen.h2("External package: {0}".format(pkg_name))
             # Check if the external package is buildable. If it is
             # not then "external(<pkg>)" is a fact, unless we can
             # reuse an already installed spec.
@@ -3651,7 +3650,7 @@ class SpecFilter:
         return SpecFilter(factory=factory, is_usable=is_reusable, include=include, exclude=exclude)
 
     @staticmethod
-    def from_mirror(configuration, include, exclude) -> "SpecFilter":
+    def from_buildcache(configuration, include, exclude) -> "SpecFilter":
         """Constructs a filter that takes the specs from the configured buildcaches."""
         packages = configuration.get("packages")
         is_reusable = functools.partial(_is_reusable, packages=packages, local=False)
@@ -3702,7 +3701,7 @@ class ReusableSpecsSelector:
                     SpecFilter.from_store(
                         configuration=self.configuration, include=[], exclude=[]
                     ),
-                    SpecFilter.from_mirror(
+                    SpecFilter.from_buildcache(
                         configuration=self.configuration, include=[], exclude=[]
                     ),
                 ]
@@ -3715,7 +3714,7 @@ class ReusableSpecsSelector:
                 self.reuse_strategy = ReuseStrategy.DEPENDENCIES
             default_include = reuse_yaml.get("include", [])
             default_exclude = reuse_yaml.get("exclude", [])
-            default_sources = [{"type": "local"}, {"type": "mirror"}]
+            default_sources = [{"type": "local"}, {"type": "buildcache"}]
             for source in reuse_yaml.get("from", default_sources):
                 include = source.get("include", default_include)
                 exclude = source.get("exclude", default_exclude)
@@ -3723,9 +3722,9 @@ class ReusableSpecsSelector:
                     self.reuse_sources.append(
                         SpecFilter.from_store(self.configuration, include=include, exclude=exclude)
                     )
-                elif source["type"] == "mirror":
+                elif source["type"] == "buildcache":
                     self.reuse_sources.append(
-                        SpecFilter.from_mirror(
+                        SpecFilter.from_buildcache(
                             self.configuration, include=include, exclude=exclude
                         )
                     )

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2869,7 +2869,7 @@ def test_filtering_reused_specs(
 @pytest.mark.usefixtures("database", "mock_store")
 @pytest.mark.parametrize(
     "reuse_yaml,expected_length",
-    [({"from": [{"type": "local"}]}, 17), ({"from": [{"type": "mirror"}]}, 0)],
+    [({"from": [{"type": "local"}]}, 17), ({"from": [{"type": "buildcache"}]}, 0)],
 )
 @pytest.mark.not_on_windows("Expected length is different on Windows")
 def test_selecting_reused_sources(reuse_yaml, expected_length, mutable_config, monkeypatch):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2831,14 +2831,14 @@ def test_concretization_version_order():
     [
         (
             ["mpileaks"],
-            {"strategy": True, "include": ["^mpich"]},
+            {"roots": True, "include": ["^mpich"]},
             ["^mpich"],
             ["^mpich2", "^zmpi"],
             2,
         ),
         (
             ["mpileaks"],
-            {"strategy": True, "include": ["externaltest"]},
+            {"roots": True, "include": ["externaltest"]},
             ["externaltest"],
             ["^mpich", "^mpich2", "^zmpi"],
             1,

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2848,9 +2848,11 @@ def test_concretization_version_order():
 @pytest.mark.usefixtures("database", "mock_store")
 @pytest.mark.not_on_windows("Expected length is different on Windows")
 def test_filtering_reused_specs(
-    roots, reuse_yaml, expected, not_expected, expected_length, mutable_config
+    roots, reuse_yaml, expected, not_expected, expected_length, mutable_config, monkeypatch
 ):
     """Tests that we can select which specs are to be reused, using constraints as filters"""
+    # Assume all specs have a runtime dependency
+    monkeypatch.setattr(spack.solver.asp, "_has_runtime_dependencies", lambda x: True)
     mutable_config.set("concretizer:reuse", reuse_yaml)
     selector = spack.solver.asp.ReusableSpecsSelector(mutable_config)
     specs = selector.reusable_specs(roots)
@@ -2870,8 +2872,10 @@ def test_filtering_reused_specs(
     [({"from": [{"type": "local"}]}, 17), ({"from": [{"type": "mirror"}]}, 0)],
 )
 @pytest.mark.not_on_windows("Expected length is different on Windows")
-def test_selecting_reused_sources(reuse_yaml, expected_length, mutable_config):
+def test_selecting_reused_sources(reuse_yaml, expected_length, mutable_config, monkeypatch):
     """Tests that we can turn on/off sources of reusable specs"""
+    # Assume all specs have a runtime dependency
+    monkeypatch.setattr(spack.solver.asp, "_has_runtime_dependencies", lambda x: True)
     mutable_config.set("concretizer:reuse", reuse_yaml)
     selector = spack.solver.asp.ReusableSpecsSelector(mutable_config)
     specs = selector.reusable_specs(["mpileaks"])

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2846,6 +2846,7 @@ def test_concretization_version_order():
     ],
 )
 @pytest.mark.usefixtures("database", "mock_store")
+@pytest.mark.not_on_windows("Expected length is different on Windows")
 def test_filtering_reused_specs(
     roots, reuse_yaml, expected, not_expected, expected_length, mutable_config
 ):
@@ -2868,10 +2869,10 @@ def test_filtering_reused_specs(
     "reuse_yaml,expected_length",
     [({"from": [{"type": "local"}]}, 17), ({"from": [{"type": "mirror"}]}, 0)],
 )
+@pytest.mark.not_on_windows("Expected length is different on Windows")
 def test_selecting_reused_sources(reuse_yaml, expected_length, mutable_config):
     """Tests that we can turn on/off sources of reusable specs"""
     mutable_config.set("concretizer:reuse", reuse_yaml)
     selector = spack.solver.asp.ReusableSpecsSelector(mutable_config)
     specs = selector.reusable_specs(["mpileaks"])
-
     assert len(specs) == expected_length


### PR DESCRIPTION
fixes #42813
fixes #32888

This PR gives users finer control over which specs are reused during concretization.

The value of the `concretizer:reuse` config option now can take an object with the following properties:
- `roots`: true if reusing roots, false if reusing just dependencies
- `exclude`: list of constraints used to select reusable specs 
- `include`: list of constraints used to select reusable specs 
- `from`: allows to select the sources of reused specs

### Examples

#### Reuse only specs compiled with GCC
```yaml
concretizer:
  reuse:
    roots: true
    include:
    - "%gcc"
```

#### `openmpi` must be used from externals, and it must be the only external used
```yaml
concretizer:
  reuse:
    roots: true
    from:
    - type: local
      exclude:
      - "openmpi"
    - type: buildcache
      exclude:
      - "openmpi"
    - type: external
      include:
      - "openmpi"
```


### Extensions in future PRs

Since the items in the `from:` list are object, they can be extended easily. As an example we might allow something like:
```yaml
concretizer:
  reuse:
    from:
    - type: buildcache
      name: e4s
```
to select specs only from a specific buildcache. Or select specs based on installation dates etc.