### PR TITLE
nlohmann-json-schema-validator: added version 2.2.0 and 2.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/nlohmann-json-schema-validator/package.py
+++ b/var/spack/repos/builtin/packages/nlohmann-json-schema-validator/package.py
@@ -16,6 +16,8 @@ class NlohmannJsonSchemaValidator(CMakePackage):
     license("MIT")
 
     version("master", branch="master")
+    version("2.3.0", sha256="2c00b50023c7d557cdaa71c0777f5bcff996c4efd7a539e58beaa4219fa2a5e1")
+    version("2.2.0", sha256="03897867bd757ecac1db7545babf0c6c128859655b496582a9cea4809c2260aa")
     version("2.1.0", sha256="83f61d8112f485e0d3f1e72d51610ba3924b179926a8376aef3c038770faf202")
     version("2.0.0", sha256="ca8e4ca5a88c49ea52b5f5c2a08a293dbf02b2fc66cb8c09d4cce5810ee98b57")
     version("1.0.0", sha256="4bdcbf6ce98eda993d8a928dbe97a03f46643395cb872af875a908156596cc4b")

--- a/var/spack/repos/builtin/packages/nlohmann-json-schema-validator/package.py
+++ b/var/spack/repos/builtin/packages/nlohmann-json-schema-validator/package.py
@@ -15,7 +15,7 @@ class NlohmannJsonSchemaValidator(CMakePackage):
 
     license("MIT")
 
-    version("master", branch="master")
+    version("main", branch="main")
     version("2.3.0", sha256="2c00b50023c7d557cdaa71c0777f5bcff996c4efd7a539e58beaa4219fa2a5e1")
     version("2.2.0", sha256="03897867bd757ecac1db7545babf0c6c128859655b496582a9cea4809c2260aa")
     version("2.1.0", sha256="83f61d8112f485e0d3f1e72d51610ba3924b179926a8376aef3c038770faf202")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
What the title says, and also replace "master" with "main" (the master branch still exists in the repo but is outdated).