### PR TITLE
For ecflow@5.11.4, apply ctsapi_cassert.path for all compilers

### DIFF
--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -69,7 +69,8 @@ class Ecflow(CMakePackage):
     depends_on("cmake@3.16:", type="build")
 
     # https://github.com/JCSDA/spack-stack/issues/1001
-    patch("ctsapi_cassert.patch", when="@5.11.4 %intel@2021")
+    # https://github.com/JCSDA/spack-stack/issues/1009
+    patch("ctsapi_cassert.patch", when="@5.11.4")
 
     @when("@:4.13.0")
     def patch(self):


### PR DESCRIPTION
## Description

It turns out that the bug fix that was merged previously for `ecflow@5.11.4` for the Intel classic compilers only (https://github.com/spack/spack/pull/42622) is also needed for other compilers. I tested this with clang and gcc.
