### PR TITLE
ELPA: Fix paths for patched versions

### DIFF
--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -98,7 +98,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         # upstream sometimes adds tarball suffixes not part of the internal version
         elpa_version = str(self.spec.version)
-        for vsuffix in ("_bugfix",):
+        for vsuffix in ("_bugfix", "-patched"):
             if elpa_version.endswith(vsuffix):  # implementation of py3.9 removesuffix
                 elpa_version = elpa_version[: -len(vsuffix)]
 


### PR DESCRIPTION
This should resolve #42788 without the need to remove the offending version.   It's not ideal as we are just adding to the list of arbitrary patch version suffixes but it's probably the least invasive fix.