### PR TITLE
matio: add v1.5.26

### DIFF
--- a/var/spack/repos/builtin/packages/matio/package.py
+++ b/var/spack/repos/builtin/packages/matio/package.py
@@ -15,6 +15,7 @@ class Matio(AutotoolsPackage):
 
     license("BSD-2-Clause")
 
+    version("1.5.26", sha256="8b47c29f58e468dba7a5555371c6a72ad4c6aa8b15f459b2b0b65a303c063933")
     version("1.5.17", sha256="5e455527d370ab297c4abe5a2ab4d599c93ac7c1a0c85d841cc5c22f8221c400")
     version("1.5.16", sha256="47ba3d5d269d5709b8d9a7385c88c8b5fb5ff875ef781a1ced4892b5b03c4f44")
     version("1.5.15", sha256="21bf4587bb7f0231dbb4fcc88728468f1764c06211d5a0415cd622036f09b1cf")


### PR DESCRIPTION
To match SIERRA's latest matio version we need to add matio 1.5.26 to spack's packages. This comes from SIERRA's update from matio 1.5.9 to 1.5.26 on 01/03/2024.

@psakievich could you take a look at this please and see if it is acceptable?