### PR TITLE
Fix wrong call to a function

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -376,8 +376,7 @@ class PythonPackage(PythonExtension):
         platlib = self.prefix.join(self.spec["python"].package.platlib).join(name)
         purelib = self.prefix.join(self.spec["python"].package.purelib).join(name)
 
-        find_all_headers = functools.partial(fs.find_all_headers, recursive=True)
-        headers_list = map(find_all_headers, [include, platlib, purelib])
+        headers_list = map(fs.find_all_headers, [include, platlib, purelib])
         headers = functools.reduce(operator.add, headers_list)
 
         if headers:


### PR DESCRIPTION
refers https://github.com/spack/spack/pull/42602#issuecomment-1960521903

The `find_all_headers` function is defined in:

https://github.com/spack/spack/blob/a2908fb9f7c2e2273e2e970b2893349967d14362/lib/spack/llnl/util/filesystem.py#L2123
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
