### PR TITLE
Rework modulerc generation mechanism to hide implicits

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -35,7 +35,7 @@ import inspect
 import os.path
 import re
 import string
-from typing import List, Optional
+from typing import Optional
 
 import llnl.util.filesystem
 import llnl.util.tty as tty
@@ -843,8 +843,8 @@ class BaseContext(tengine.Context):
 
 class BaseModuleFileWriter:
     default_template: str
-    hide_cmd_format: str
-    modulerc_header: List[str]
+    modulerc_template: str
+    hide_cmd_regexp: str
 
     def __init__(
         self, spec: spack.spec.Spec, module_set_name: str, explicit: Optional[bool] = None
@@ -872,25 +872,25 @@ class BaseModuleFileWriter:
             name = type(self).__name__
             raise DefaultTemplateNotDefined(msg.format(name))
 
+        # Check if a modulerc template has been defined,
+        # throw if not found
+        try:
+            self.modulerc_template
+        except AttributeError:
+            msg = "'{0}' object has no attribute 'modulerc_template'\n"
+            msg += "Did you forget to define it in the class?"
+            name = type(self).__name__
+            raise ModulercTemplateNotDefined(msg.format(name))
+
         # Check if format for module hide command has been defined,
         # throw if not found
         try:
-            self.hide_cmd_format
+            self.hide_cmd_regexp
         except AttributeError:
-            msg = "'{0}' object has no attribute 'hide_cmd_format'\n"
+            msg = "'{0}' object has no attribute 'hide_cmd_regexp'\n"
             msg += "Did you forget to define it in the class?"
             name = type(self).__name__
-            raise HideCmdFormatNotDefined(msg.format(name))
-
-        # Check if modulerc header content has been defined,
-        # throw if not found
-        try:
-            self.modulerc_header
-        except AttributeError:
-            msg = "'{0}' object has no attribute 'modulerc_header'\n"
-            msg += "Did you forget to define it in the class?"
-            name = type(self).__name__
-            raise ModulercHeaderNotDefined(msg.format(name))
+            raise HideCmdRegexpNotDefined(msg.format(name))
 
     def _get_template(self):
         """Gets the template that will be rendered for this spec."""
@@ -1008,50 +1008,58 @@ class BaseModuleFileWriter:
                 removed from modulerc.
         """
         modulerc_path = self.layout.modulerc
-        hide_module_cmd = self.hide_cmd_format % self.layout.use_name
         hidden = self.conf.hidden and not remove
         modulerc_exists = os.path.exists(modulerc_path)
         updated = False
 
         if modulerc_exists:
-            # retrieve modulerc content
+            # get already hidden modules from modulerc content
             with open(modulerc_path) as f:
-                content = f.readlines()
-                content = "".join(content).split("\n")
-                # remove last empty item if any
-                if len(content[-1]) == 0:
-                    del content[-1]
-            already_hidden = hide_module_cmd in content
+                hidden_modules = re.findall(self.hide_cmd_regexp, f.read())
+            already_hidden = self.layout.use_name in hidden_modules
 
-            # remove hide command if module not hidden
+            # remove not hidden anymore module
             if already_hidden and not hidden:
-                content.remove(hide_module_cmd)
+                hidden_modules.remove(self.layout.use_name)
                 updated = True
-
-            # add hide command if module is hidden
+            # add hidden module
             elif not already_hidden and hidden:
-                if len(content) == 0:
-                    content = self.modulerc_header.copy()
-                content.append(hide_module_cmd)
+                hidden_modules.append(self.layout.use_name)
                 updated = True
         else:
-            content = self.modulerc_header.copy()
+            hidden_modules = []
             if hidden:
-                content.append(hide_module_cmd)
+                hidden_modules.append(self.layout.use_name)
                 updated = True
 
         # no modulerc file change if no content update
         if updated:
-            is_empty = content == self.modulerc_header or len(content) == 0
             # remove existing modulerc if empty
-            if modulerc_exists and is_empty:
+            if modulerc_exists and len(hidden_modules) == 0:
                 os.remove(modulerc_path)
             # create or update modulerc
-            elif content != self.modulerc_header:
-                # ensure file ends with a newline character
-                content.append("")
+            elif len(hidden_modules) > 0:
+                import jinja2
+
+                try:
+                    env = tengine.make_environment()
+                    template = env.get_template(self.modulerc_template)
+                except jinja2.TemplateNotFound:
+                    # If the template was not found raise an exception with a little
+                    # more information
+                    msg = "template '{0}' was not found for '{1}'"
+                    name = type(self).__name__
+                    msg = msg.format(self.modulerc_template, name)
+                    raise ModulesTemplateNotFoundError(msg)
+
+                context = self.context.to_dict()
+                context.update({"hidden_modules": hidden_modules})
+
+                # Render the template
+                text = template.render(context)
+                # Write it to file
                 with open(modulerc_path, "w") as f:
-                    f.write("\n".join(content))
+                    f.write(text)
 
     def remove(self):
         """Deletes the module file."""
@@ -1104,14 +1112,14 @@ class DefaultTemplateNotDefined(AttributeError, ModulesError):
     """
 
 
-class HideCmdFormatNotDefined(AttributeError, ModulesError):
-    """Raised if the attribute 'hide_cmd_format' has not been specified
+class ModulercTemplateNotDefined(AttributeError, ModulesError):
+    """Raised if the attribute 'modulerc_template' has not been specified
     in the derived classes.
     """
 
 
-class ModulercHeaderNotDefined(AttributeError, ModulesError):
-    """Raised if the attribute 'modulerc_header' has not been specified
+class HideCmdRegexpNotDefined(AttributeError, ModulesError):
+    """Raised if the attribute 'hide_cmd_regexp' has not been specified
     in the derived classes.
     """
 

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -476,10 +476,9 @@ class LmodModulefileWriter(BaseModuleFileWriter):
     """Writer class for lmod module files."""
 
     default_template = "modules/modulefile.lua"
+    modulerc_template = "modules/modulerc.lua"
 
-    modulerc_header = []
-
-    hide_cmd_format = 'hide_version("%s")'
+    hide_cmd_regexp = r'hide_version\("(.*?)"\)'
 
 
 class CoreCompilersNotFoundError(spack.error.SpackError, KeyError):

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -79,7 +79,6 @@ class TclModulefileWriter(BaseModuleFileWriter):
     """Writer class for tcl module files."""
 
     default_template = "modules/modulefile.tcl"
+    modulerc_template = "modules/modulerc.tcl"
 
-    modulerc_header = ["#%Module4.7"]
-
-    hide_cmd_format = "module-hide --soft --hidden-loaded %s"
+    hide_cmd_regexp = r"module-hide --soft --hidden-loaded (\S*)"

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -503,6 +503,8 @@ class TestTcl:
             content = [line.strip() for line in f.readlines()]
         hide_implicit_mpileaks = f"module-hide --soft --hidden-loaded {writer.layout.use_name}"
         assert len([x for x in content if hide_implicit_mpileaks == x]) == 1
+        lmod_hide_implicit_mpileaks = f"hide-version {writer.layout.use_name}"
+        assert len([x for x in content if lmod_hide_implicit_mpileaks == x]) == 1
 
         # The direct dependencies are all implicit, and they should have depends-on with fixed
         # 7 character hash, even though the config is set to hash_length = 0.
@@ -519,7 +521,9 @@ class TestTcl:
         with open(writer.layout.modulerc) as f:
             content = [line.strip() for line in f.readlines()]
         assert hide_implicit_mpileaks in content  # old, implicit mpileaks is still hidden
+        assert lmod_hide_implicit_mpileaks in content  # old, implicit mpileaks is still hidden
         assert f"module-hide --soft --hidden-loaded {writer.layout.use_name}" not in content
+        assert f"hide-version {writer.layout.use_name}" not in content
 
         # after removing both the implicit and explicit module, the modulerc file would be empty
         # and should be removed.
@@ -552,9 +556,15 @@ class TestTcl:
         hide_cmd = f"module-hide --soft --hidden-loaded {writer.layout.use_name}"
         hide_cmd_alt1 = f"module-hide --soft --hidden-loaded {writer_alt1.layout.use_name}"
         hide_cmd_alt2 = f"module-hide --soft --hidden-loaded {writer_alt2.layout.use_name}"
+        lmod_hide_cmd = f"hide-version {writer.layout.use_name}"
+        lmod_hide_cmd_alt1 = f"hide-version {writer_alt1.layout.use_name}"
+        lmod_hide_cmd_alt2 = f"hide-version {writer_alt2.layout.use_name}"
         assert len([x for x in content if hide_cmd == x]) == 1
         assert len([x for x in content if hide_cmd_alt1 == x]) == 1
         assert len([x for x in content if hide_cmd_alt2 == x]) == 1
+        assert len([x for x in content if lmod_hide_cmd == x]) == 1
+        assert len([x for x in content if lmod_hide_cmd_alt1 == x]) == 1
+        assert len([x for x in content if lmod_hide_cmd_alt2 == x]) == 1
 
         # one version is removed
         writer_alt1.remove()
@@ -564,3 +574,6 @@ class TestTcl:
         assert len([x for x in content if hide_cmd == x]) == 1
         assert len([x for x in content if hide_cmd_alt1 == x]) == 0
         assert len([x for x in content if hide_cmd_alt2 == x]) == 1
+        assert len([x for x in content if lmod_hide_cmd == x]) == 1
+        assert len([x for x in content if lmod_hide_cmd_alt1 == x]) == 0
+        assert len([x for x in content if lmod_hide_cmd_alt2 == x]) == 1

--- a/share/spack/templates/modules/modulerc.lua
+++ b/share/spack/templates/modules/modulerc.lua
@@ -1,0 +1,11 @@
+-- -*- lua -*-
+-- Module rc created by spack (https://github.com/spack/spack) on {{ timestamp }}
+--
+
+{% block hidden %}
+{% if hidden_modules|length > 0 %}
+{% for module in hidden_modules %}
+hide_version("{{ module }}")
+{% endfor %}
+{% endif %}
+{% endblock %}

--- a/share/spack/templates/modules/modulerc.tcl
+++ b/share/spack/templates/modules/modulerc.tcl
@@ -1,0 +1,17 @@
+#%Module
+## Module rc created by spack (https://github.com/spack/spack) on {{ timestamp }}
+##
+
+{% block hidden %}
+{% if hidden_modules|length > 0 %}
+if {[info exists ModuleTool] && $ModuleTool eq {Modules} && [versioncmp $ModuleToolVersion 4.7] >= 0} {
+{% for module in hidden_modules %}
+    module-hide --soft --hidden-loaded {{ module }}
+{% endfor %}
+} elseif {[info exists ::env(LMOD_VERSION_MAJOR)]} {
+{% for module in hidden_modules %}
+    hide-version {{ module }}
+{% endfor %}
+}
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
Tcl modulercs that are generated to hide implicit modules requires Modules >= 4.7 in a way that produces error when loading these implicit modules with a prior Modules version.

In addition, these Tcl modulercs are not compatible with Lmod module tool (as Lmod hides modules with `hide-version` command in Tcl modules rather `module-hide`).

To overcome these two limitations a reworked modulerc generation mechanism is proposed here. A Tcl `if` branch is used to check a compatible Modules version is used (rather specifying version requirement in modulerc file header). Another branch of this condition statement is used to define module hide commands for Lmod.

Modulerc generation mechanism is changed to rely on templates like done for modulefile generation. Templates are more convenient to generate the content, especially for tcl modulercs that now contain an `if` statement.

New mechanism can be used over modulerc files generated with previous mechanism. It can correcly read previous-kind of modulerc files and generate from these information new-kind of modulerc.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
