### PR TITLE
Open MPI: adjust pmix dependency for 5.0.x

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -587,7 +587,7 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     with when("~internal-pmix"):
         depends_on("pmix@1", when="@2")
         depends_on("pmix@3.2:", when="@4:")
-        depends_on("pmix@4.2:", when="@5:")
+        depends_on("pmix@4.2.4:", when="@5:")
 
         # pmix@4.2.3 contains a breaking change, compat fixed in openmpi@4.1.6
         # See https://www.mail-archive.com/announce@lists.open-mpi.org//msg00158.html


### PR DESCRIPTION
for various reasons had to advance dependency of 5.0.2 to at least pmix 4.2.4.  5.0.1 and 5.0.0 can also build with 4.2.4 pmix or newer.

related to #42651

