### PR TITLE
btop: Add cmake version restriction

### DIFF
--- a/var/spack/repos/builtin/packages/btop/package.py
+++ b/var/spack/repos/builtin/packages/btop/package.py
@@ -25,7 +25,7 @@ class Btop(MakefilePackage, CMakePackage):
 
     variant("gpu", default=False, description="Enable GPU support", when="build_system=cmake")
 
-    depends_on("cmake@3.24:", when="@1.3.0: build_system=cmake")
+    depends_on("cmake@3.24:", type="build", when="@1.3.0: build_system=cmake")
 
     # Fix linking GPU support, by adding an explicit "target_link_libraries" to ${CMAKE_DL_LIBS}
     patch("link-dl.patch", when="+gpu")

--- a/var/spack/repos/builtin/packages/btop/package.py
+++ b/var/spack/repos/builtin/packages/btop/package.py
@@ -25,7 +25,7 @@ class Btop(MakefilePackage, CMakePackage):
 
     variant("gpu", default=False, description="Enable GPU support", when="build_system=cmake")
 
-    depends_on("cmake@3.24:", when="@1.3.0 build_system=cmake")
+    depends_on("cmake@3.24:", when="@1.3.0: build_system=cmake")
 
     # Fix linking GPU support, by adding an explicit "target_link_libraries" to ${CMAKE_DL_LIBS}
     patch("link-dl.patch", when="+gpu")

--- a/var/spack/repos/builtin/packages/btop/package.py
+++ b/var/spack/repos/builtin/packages/btop/package.py
@@ -25,6 +25,8 @@ class Btop(MakefilePackage, CMakePackage):
 
     variant("gpu", default=False, description="Enable GPU support", when="build_system=cmake")
 
+    depends_on("cmake@3.24:", when="@1.3.0 build_system=cmake")
+
     # Fix linking GPU support, by adding an explicit "target_link_libraries" to ${CMAKE_DL_LIBS}
     patch("link-dl.patch", when="+gpu")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
btop have its cmake_minium_required in CMakeLists.txt, this PR implements this restriction in spack. 
@spackbot fix style