### PR TITLE
py-ipyvuetify: new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-ipyvuetify/package.py
+++ b/var/spack/repos/builtin/packages/py-ipyvuetify/package.py
@@ -23,7 +23,6 @@ class PyIpyvuetify(PythonPackage):
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools@40.8.0:", type="build")
-    depends_on("py-wheel", type="build")
 
     depends_on("py-ipyvue@1.7:1", type=("build", "run"))
     depends_on("py-jupyter-packaging@0.7.9:0.7", type="build")

--- a/var/spack/repos/builtin/packages/py-ipyvuetify/package.py
+++ b/var/spack/repos/builtin/packages/py-ipyvuetify/package.py
@@ -25,7 +25,7 @@ class PyIpyvuetify(PythonPackage):
     depends_on("py-setuptools@40.8.0:", type="build")
     depends_on("py-wheel", type="build")
 
-    depends_on("py-ipyvue@1.7:2", type=("build", "run"))
+    depends_on("py-ipyvue@1.7:1", type=("build", "run"))
     depends_on("py-jupyter-packaging@0.7.9:0.7", type="build")
     depends_on("py-jupyterlab@3", type="build")
     depends_on("py-pynpm", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-ipyvuetify/package.py
+++ b/var/spack/repos/builtin/packages/py-ipyvuetify/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyIpyvuetify(PythonPackage):
+    """
+    Jupyter widgets based on vuetify UI components which implement Google's
+    Material Design Spec with the Vue.js framework.
+    """
+
+    homepage = "https://github.com/widgetti/ipyvuetify/tree/master"
+    pypi = "ipyvuetify/ipyvuetify-1.9.0.tar.gz"
+
+    license("MIT")
+
+    maintainers("jeremyfix")
+
+    version("1.9.0", sha256="9c537e218299de32194b1da949d6b96bffe6c00f36bb6035409f2485feb881e7")
+
+    depends_on("python@3.6:", type=("build", "run"))
+    depends_on("py-setuptools@40.8.0:", type="build")
+    depends_on("py-wheel", type="build")
+
+    depends_on("py-ipyvue@1.7:2", type=("build", "run"))
+    depends_on("py-jupyter-packaging@0.7.10:", type=("build", "run"))
+    depends_on("py-jupyterlab@3.0.1:", type=("build", "run"))
+    depends_on("py-pynpm", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-ipyvuetify/package.py
+++ b/var/spack/repos/builtin/packages/py-ipyvuetify/package.py
@@ -26,6 +26,6 @@ class PyIpyvuetify(PythonPackage):
     depends_on("py-wheel", type="build")
 
     depends_on("py-ipyvue@1.7:2", type=("build", "run"))
-    depends_on("py-jupyter-packaging@0.7.10:", type=("build", "run"))
+    depends_on("py-jupyter-packaging@0.7.9:0.7", type="build")
     depends_on("py-jupyterlab@3.0.1:", type=("build", "run"))
     depends_on("py-pynpm", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-ipyvuetify/package.py
+++ b/var/spack/repos/builtin/packages/py-ipyvuetify/package.py
@@ -27,5 +27,5 @@ class PyIpyvuetify(PythonPackage):
 
     depends_on("py-ipyvue@1.7:2", type=("build", "run"))
     depends_on("py-jupyter-packaging@0.7.9:0.7", type="build")
-    depends_on("py-jupyterlab@3.0.1:", type=("build", "run"))
+    depends_on("py-jupyterlab@3", type="build")
     depends_on("py-pynpm", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-ipyvuetify/package.py
+++ b/var/spack/repos/builtin/packages/py-ipyvuetify/package.py
@@ -24,7 +24,7 @@ class PyIpyvuetify(PythonPackage):
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools@40.8.0:", type="build")
 
-    depends_on("py-ipyvue@1.7:1", type=("build", "run"))
     depends_on("py-jupyter-packaging@0.7.9:0.7", type="build")
     depends_on("py-jupyterlab@3", type="build")
-    depends_on("py-pynpm", type=("build", "run"))
+    depends_on("py-pynpm", type="build")
+    depends_on("py-ipyvue@1.7:1", type=("build", "run"))


### PR DESCRIPTION
This is a resubmission of #42790 . Since I messed up the git history on that branch, I prefered closing the first PR and making a new cleaner PR. 

This PR still keeps the fix of the issues indicated by @adamjstewart 

I copy here the comment I did before closing the first PR : 

For the versions @adamjstewart  , I'm not sure how to specify a version exclusion such as :  "jupyter_packaging~=0.7.9", "jupyterlab~=3.0". Hence, I specified it as 

```
depends_on("py-jupyter-packaging@0.7.10:", type=("build", "run"))
depends_on("py-jupyterlab@3.0.1:", type=("build", "run"))
```
