### PR TITLE
berkeleygw: update FCPP flags for gcc

### DIFF
--- a/var/spack/repos/builtin/packages/berkeleygw/package.py
+++ b/var/spack/repos/builtin/packages/berkeleygw/package.py
@@ -234,7 +234,7 @@ class Berkeleygw(MakefilePackage):
             buildopts.append("MOD_OPT=-J ")
             # std c11 prevents problems with linebreaks and fortran comments
             # containing // (which is interpreted as C++ style comment)
-            buildopts.append("FCPP=cpp -C -nostdinc -std=c11")
+            buildopts.append("FCPP=%s -C -nostdinc -std=c11" % join_path(self.compiler.prefix, "bin", "cpp"))
             if "+mpi" in spec:
                 buildopts.append("F90free=%s %s" % (spec["mpi"].mpifc, f90_flags))
                 buildopts.append("C_COMP=%s %s" % (spec["mpi"].mpicc, c_flags))

--- a/var/spack/repos/builtin/packages/berkeleygw/package.py
+++ b/var/spack/repos/builtin/packages/berkeleygw/package.py
@@ -232,7 +232,7 @@ class Berkeleygw(MakefilePackage):
                 f90_flags += " -fallow-argument-mismatch"
             buildopts.append("COMPFLAG=-DGNU")
             buildopts.append("MOD_OPT=-J ")
-            buildopts.append("FCPP=cpp -P -ansi -nostdinc -C -E -std=c11")
+            buildopts.append("FCPP=cpp -P -nostdinc -C -E -std=c11")
             if "+mpi" in spec:
                 buildopts.append("F90free=%s %s" % (spec["mpi"].mpifc, f90_flags))
                 buildopts.append("C_COMP=%s %s" % (spec["mpi"].mpicc, c_flags))

--- a/var/spack/repos/builtin/packages/berkeleygw/package.py
+++ b/var/spack/repos/builtin/packages/berkeleygw/package.py
@@ -232,7 +232,9 @@ class Berkeleygw(MakefilePackage):
                 f90_flags += " -fallow-argument-mismatch"
             buildopts.append("COMPFLAG=-DGNU")
             buildopts.append("MOD_OPT=-J ")
-            buildopts.append("FCPP=cpp -P -nostdinc -C -E -std=c11")
+            # std c11 prevents problems with linebreaks and fortran comments
+            # containing // (which is interpreted as C++ style comment)
+            buildopts.append("FCPP=cpp -C -nostdinc -std=c11")
             if "+mpi" in spec:
                 buildopts.append("F90free=%s %s" % (spec["mpi"].mpifc, f90_flags))
                 buildopts.append("C_COMP=%s %s" % (spec["mpi"].mpicc, c_flags))

--- a/var/spack/repos/builtin/packages/berkeleygw/package.py
+++ b/var/spack/repos/builtin/packages/berkeleygw/package.py
@@ -234,7 +234,9 @@ class Berkeleygw(MakefilePackage):
             buildopts.append("MOD_OPT=-J ")
             # std c11 prevents problems with linebreaks and fortran comments
             # containing // (which is interpreted as C++ style comment)
-            buildopts.append("FCPP=%s -C -nostdinc -std=c11" % join_path(self.compiler.prefix, "bin", "cpp"))
+            buildopts.append(
+                "FCPP=%s -C -nostdinc -std=c11" % join_path(self.compiler.prefix, "bin", "cpp")
+            )
             if "+mpi" in spec:
                 buildopts.append("F90free=%s %s" % (spec["mpi"].mpifc, f90_flags))
                 buildopts.append("C_COMP=%s %s" % (spec["mpi"].mpicc, c_flags))

--- a/var/spack/repos/builtin/packages/berkeleygw/package.py
+++ b/var/spack/repos/builtin/packages/berkeleygw/package.py
@@ -232,7 +232,7 @@ class Berkeleygw(MakefilePackage):
                 f90_flags += " -fallow-argument-mismatch"
             buildopts.append("COMPFLAG=-DGNU")
             buildopts.append("MOD_OPT=-J ")
-            buildopts.append("FCPP=cpp -C -nostdinc")
+            buildopts.append("FCPP=cpp -P -ansi -nostdinc -C -E -std=c11")
             if "+mpi" in spec:
                 buildopts.append("F90free=%s %s" % (spec["mpi"].mpifc, f90_flags))
                 buildopts.append("C_COMP=%s %s" % (spec["mpi"].mpicc, c_flags))


### PR DESCRIPTION
Compilation with the old flags fails on PowerPC (power8le) due to syntax errors in the output from the preprocessor. Compilation with the extended set of flags works both on PowerPC and x86_64.

The additional std c11 is necessary to prevent
- problems with line breaks (sometimes a word was moved to the beginning of the next line and became part of the type)
- problems with fortran comments that contain // in the text, e.g. a link (// is understood as C++ style comment disallowed in old versions of C)

~~The correct set of flags was suggested from the berkeleygw developers: https://groups.google.com/a/berkeleygw.org/g/help/c/ewi3RZgOyeE/m/jSIoe45PAgAJ (The suggestions contains several flags that show no effect, these have been removed)~~

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
