### PR TITLE
root: add dependent package required for build time tests

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -352,6 +352,8 @@ class Root(CMakePackage):
     depends_on("xrootd", when="+xrootd")
     depends_on("xrootd@:4", when="@:6.22.03 +xrootd")
 
+    depends_on("googletest", when="@6.28.00:", type="test")
+
     # ###################### Conflicts ######################
 
     # I was unable to build root with any Intel compiler


### PR DESCRIPTION
Fix #42720.
Add the following dependencies needed for build time tests:
- googletest

This package seems to be required for root version 6.28 or higher as far as I have tried.
