### PR TITLE
regtools: new package @1.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/regtools/package.py
+++ b/var/spack/repos/builtin/packages/regtools/package.py
@@ -19,5 +19,4 @@ class Regtools(CMakePackage):
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        with working_dir(self.build_directory):
-            install("regtools", prefix.bin)
+        install(join_path(self.build_directory, "regtools"), prefix.bin)

--- a/var/spack/repos/builtin/packages/regtools/package.py
+++ b/var/spack/repos/builtin/packages/regtools/package.py
@@ -17,8 +17,6 @@ class Regtools(CMakePackage):
 
     version("1.0.0", sha256="ed2b9db6b71b943924002653caee18511a22ed7cc3c88f428e7e9e0c2e4f431b")
 
-    depends_on("cmake@2.8.12:", type="build")
-
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         with working_dir(self.build_directory):

--- a/var/spack/repos/builtin/packages/regtools/package.py
+++ b/var/spack/repos/builtin/packages/regtools/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Regtools(CMakePackage):
+    """Tools that integrate DNA-seq and RNA-seq data to help interpret mutations in a regulatory
+    and splicing context"""
+
+    homepage = "https://regtools.readthedocs.org/"
+    url = "https://github.com/griffithlab/regtools/archive/refs/tags/1.0.0.tar.gz"
+
+    license("MIT", checked_by="A-N-Other")
+
+    version("1.0.0", sha256="ed2b9db6b71b943924002653caee18511a22ed7cc3c88f428e7e9e0c2e4f431b")
+
+    depends_on("cmake@2.8.12:", type="build")
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        with working_dir(self.build_directory):
+            install("regtools", prefix.bin)


### PR DESCRIPTION
Adding `regtools`.

No `install` routine but otherwise a straightforward `cmake` install. Tested and working on `linux-rocky8-icelake`.