### PR TITLE
Update metkit package.py with git url

### DIFF
--- a/var/spack/repos/builtin/packages/metkit/package.py
+++ b/var/spack/repos/builtin/packages/metkit/package.py
@@ -11,6 +11,7 @@ class Metkit(CMakePackage):
     implementing the MARS language and associated processing and semantics."""
 
     homepage = "https://github.com/ecmwf/metkit"
+    git = "https://github.com/ecmwf/metkit.git"
     url = "https://github.com/ecmwf/metkit/archive/refs/tags/1.7.0.tar.gz"
 
     maintainers("skosukhin", "victoria-cherkas", "dominichofer")


### PR DESCRIPTION
Enables installation of git references eg commit/branches/tags not in the package version list, see: https://spack.readthedocs.io/en/latest/basic_usage.html#git-versions 