### PR TITLE
perl-bio-eutilities and deps: new packages

### DIFF
--- a/var/spack/repos/builtin/packages/perl-bio-asn1-entrezgene/package.py
+++ b/var/spack/repos/builtin/packages/perl-bio-asn1-entrezgene/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlBioAsn1Entrezgene(PerlPackage):
+    """Regular expression-based Perl Parser for NCBI Entrez Gene."""
+
+    homepage = "https://metacpan.org/pod/Bio::ASN1::EntrezGene"
+    url = "https://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS/Bio-ASN1-EntrezGene-1.73.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.73", sha256="f9e778db705ce5c35ad2798e38a8490b644edfdc14253aa1b74a1f5e79fc6a4b")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-bio-cluster", type=("build", "run", "test"))
+    depends_on("perl-bioperl", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Bio::ASN1::EntrezGene; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-bio-cluster/package.py
+++ b/var/spack/repos/builtin/packages/perl-bio-cluster/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlBioCluster(PerlPackage):
+    """BioPerl cluster modules"""
+
+    homepage = "https://metacpan.org/pod/Bio::Cluster"
+    url = "https://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS/Bio-Cluster-1.7.3.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.7.3", sha256="1967fb3899b92f245b5bf6cb64ef076fc3f8427b1a96ca5f7b74d220b6191fbb")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-bio-variation", type=("build", "run", "test"))
+    depends_on("perl-bioperl", type=("build", "run", "test"))
+    depends_on("perl-xml-sax", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Bio::Cluster; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-bio-eutilities/package.py
+++ b/var/spack/repos/builtin/packages/perl-bio-eutilities/package.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlBioEutilities(PerlPackage):
+    """BioPerl low-level API for retrieving and storing data from NCBI eUtils"""
+
+    homepage = "https://metacpan.org/pod/Bio::DB::EUtilities"
+    url = "https://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS/Bio-EUtilities-1.77.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.77", sha256="4d018c8cbda73c3d71487165261a3dfc4e823f8e22747497f6a586d5ad6f737f")
+
+    depends_on("perl@5.10.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-bio-asn1-entrezgene", type=("build", "run", "test"))
+    depends_on("perl-bioperl", type=("build", "run", "test"))
+    depends_on("perl-http-message", type=("build", "run", "test"))
+    depends_on("perl-libwww-perl", type=("build", "run", "test"))
+    depends_on("perl-text-csv", type=("build", "run", "test"))
+    depends_on("perl-uri", type=("build", "run", "test"))
+    depends_on("perl-xml-simple", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Bio::DB::EUtilities; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-bio-variation/package.py
+++ b/var/spack/repos/builtin/packages/perl-bio-variation/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlBioVariation(PerlPackage):
+    """BioPerl variation-related functionality"""
+
+    homepage = "https://metacpan.org/pod/Bio::Variation"
+    url = "https://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS/Bio-Variation-1.7.5.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.7.5", sha256="4bffdd060b5e793919f700e46056eb3f0195ed4df2e60ad68b383c31e51f824f")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-bioperl", type=("build", "run", "test"))
+    depends_on("perl-io-string", type=("build", "run", "test"))
+    depends_on("perl-xml-twig", type=("build", "run", "test"))
+    depends_on("perl-xml-writer@0.4:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Bio::Variation; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
This adds Spack packages for these Perl distributons:
- Bio::DB::EUtilities and its dependencies:
- Bio::ASN1::EntrezGene
- Bio::Cluster
- Bio::Variation

The build-time and standalone tests ran successfully.