### PR TITLE
Update metkit with additional eckit dependency constraint

### DIFF
--- a/var/spack/repos/builtin/packages/metkit/package.py
+++ b/var/spack/repos/builtin/packages/metkit/package.py
@@ -33,7 +33,7 @@ class Metkit(CMakePackage):
     depends_on("eckit@1.16:")
     depends_on("eckit@1.21:", when="@1.10:")
     depends_on("eckit@:1.21", when="@:1.10")
-    
+
     depends_on("eccodes@2.5:", when="+grib")
     depends_on("eccodes@2.27:", when="@1.10.2: +grib")
 

--- a/var/spack/repos/builtin/packages/metkit/package.py
+++ b/var/spack/repos/builtin/packages/metkit/package.py
@@ -32,7 +32,8 @@ class Metkit(CMakePackage):
 
     depends_on("eckit@1.16:")
     depends_on("eckit@1.21:", when="@1.10:")
-
+    depends_on("eckit@:1.21", when="@:1.10")
+    
     depends_on("eccodes@2.5:", when="+grib")
     depends_on("eccodes@2.27:", when="@1.10.2: +grib")
 


### PR DESCRIPTION
Adding the inverse of an existing eckit dependency constraint.
The eckit changes from version 1.21.0 are not backwards compatible, see https://github.com/ecmwf/eckit/commit/57016bdaa9e3fc29da97601408e5a6b7f6c2513f 