### PR TITLE
Update fdb package.py with libs

### DIFF
--- a/var/spack/repos/builtin/packages/fdb/package.py
+++ b/var/spack/repos/builtin/packages/fdb/package.py
@@ -68,10 +68,7 @@ class Fdb(CMakePackage):
 
     @property
     def libs(self):
-        return find_libraries("libfdb5",
-                              root=self.prefix,
-                              shared=True,
-                              recursive=True)
+        return find_libraries("libfdb5", root=self.prefix, shared=True, recursive=True)
 
     def cmake_args(self):
         enable_build_tools = "+tools" in self.spec

--- a/var/spack/repos/builtin/packages/fdb/package.py
+++ b/var/spack/repos/builtin/packages/fdb/package.py
@@ -66,6 +66,13 @@ class Fdb(CMakePackage):
         when="@5.7.1:5.7.10+tools",
     )
 
+    @property
+    def libs(self):
+        return find_libraries("libfdb5",
+                              root=self.prefix,
+                              shared=True,
+                              recursive=True)
+
     def cmake_args(self):
         enable_build_tools = "+tools" in self.spec
 


### PR DESCRIPTION
When FDB is a dependency of another package, `find_libraries` is unable to find `libfdb.so` because it is called `libfdb5.so`. This PR would prevent the follwing error when building such packages that depend on FDB.

`Error: NoLibrariesError: Unable to recursively locate fdb libraries in /opt/spack/linux-sles15-zen3/gcc-11.3.0/fdb-5.11.17-fhzbzrh54f3b4qrnzclhqc235ced4x5x`