### PR TITLE
libogg does not build a shared libary with cmake

### DIFF
--- a/var/spack/repos/builtin/packages/libogg/package.py
+++ b/var/spack/repos/builtin/packages/libogg/package.py
@@ -5,8 +5,8 @@
 
 import os
 
-from spack.build_systems.generic import GenericBuilder
 from spack.build_systems import cmake
+from spack.build_systems.generic import GenericBuilder
 from spack.package import *
 
 
@@ -24,7 +24,12 @@ class Libogg(CMakePackage, AutotoolsPackage, Package):
     version("1.3.2", sha256="e19ee34711d7af328cb26287f4137e70630e7261b17cbe3cd41011d73a654692")
 
     variant("shared", default=True, description="Build shared library", when="build_system=cmake")
-    variant("pic", default=True, description="Produce position-independent code (for shared libs)", when="build_system=cmake")
+    variant(
+        "pic",
+        default=True,
+        description="Produce position-independent code (for shared libs)",
+        when="build_system=cmake",
+    )
 
     # Backport a patch that fixes an unsigned typedef problem on macOS:
     # https://github.com/xiph/ogg/pull/64
@@ -42,7 +47,6 @@ class Libogg(CMakePackage, AutotoolsPackage, Package):
 
 
 class CMakeBuilder(cmake.CMakeBuilder):
-
     def cmake_args(self):
         base_cmake_args = [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),

--- a/var/spack/repos/builtin/packages/libogg/package.py
+++ b/var/spack/repos/builtin/packages/libogg/package.py
@@ -30,6 +30,8 @@ class Libogg(CMakePackage, AutotoolsPackage, Package):
         when="build_system=cmake",
     )
 
+    requires("+pic", when="+shared")
+
     # Backport a patch that fixes an unsigned typedef problem on macOS:
     # https://github.com/xiph/ogg/pull/64
     patch(

--- a/var/spack/repos/builtin/packages/libogg/package.py
+++ b/var/spack/repos/builtin/packages/libogg/package.py
@@ -5,8 +5,7 @@
 
 import os
 
-from spack.build_systems import cmake
-from spack.build_systems.generic import GenericBuilder
+from spack.build_systems import cmake, generic
 from spack.package import *
 
 
@@ -56,7 +55,7 @@ class CMakeBuilder(cmake.CMakeBuilder):
         return base_cmake_args
 
 
-class GenericBuilder(GenericBuilder):
+class GenericBuilder(generic.GenericBuilder):
     phases = ["build", "install"]
 
     def is_64bit(self):

--- a/var/spack/repos/builtin/packages/libogg/package.py
+++ b/var/spack/repos/builtin/packages/libogg/package.py
@@ -6,6 +6,7 @@
 import os
 
 from spack.build_systems.generic import GenericBuilder
+from spack.build_systems import cmake
 from spack.package import *
 
 
@@ -22,6 +23,9 @@ class Libogg(CMakePackage, AutotoolsPackage, Package):
     version("1.3.4", sha256="fe5670640bd49e828d64d2879c31cb4dde9758681bb664f9bdbf159a01b0c76e")
     version("1.3.2", sha256="e19ee34711d7af328cb26287f4137e70630e7261b17cbe3cd41011d73a654692")
 
+    variant("shared", default=True, description="Build shared library", when="build_system=cmake")
+    variant("pic", default=True, description="Produce position-independent code (for shared libs)", when="build_system=cmake")
+
     # Backport a patch that fixes an unsigned typedef problem on macOS:
     # https://github.com/xiph/ogg/pull/64
     patch(
@@ -35,6 +39,17 @@ class Libogg(CMakePackage, AutotoolsPackage, Package):
         "autotools",
         default="autotools",
     )
+
+
+class CMakeBuilder(cmake.CMakeBuilder):
+
+    def cmake_args(self):
+        base_cmake_args = [
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
+        ]
+
+        return base_cmake_args
 
 
 class GenericBuilder(GenericBuilder):


### PR DESCRIPTION
By default, the cmake `libogg` build does not build a shared library. This breaks other builds that require a shared object, such as `libtheora`. This resolves that.