### PR TITLE
C-Blosc2: Fuzzer Tests

### DIFF
--- a/var/spack/repos/builtin/packages/c-blosc2/package.py
+++ b/var/spack/repos/builtin/packages/c-blosc2/package.py
@@ -69,6 +69,7 @@ class CBlosc2(CMakePackage):
             self.define("BUILD_TESTS", self.run_tests),
             self.define("BUILD_BENCHMARKS", self.run_tests),
             self.define("BUILD_EXAMPLES", self.run_tests),
+            self.define("BUILD_FUZZERS", self.run_tests),
         ]
 
         return args


### PR DESCRIPTION
The fuzzer tests are a bit flaky and have linker issues on clang. We generally only should build them in testing.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
