### PR TITLE
hip: don't set HIP_PATH in ROCm 5.5+

### DIFF
--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -415,7 +415,9 @@ class Hip(CMakePackage):
             env.set("HIP_DEVICE_LIB_PATH", paths["bitcode"])
 
             # Just the prefix of hip (used in hipcc)
-            env.set("HIP_PATH", paths["hip-path"])
+            # Deprecated in 5.1.0 and breaks hipcc in 5.5.1+
+            if self.spec.satisfies("@:5.4"):
+                env.set("HIP_PATH", paths["hip-path"])
 
             # Used in comgr and seems necessary when using the JIT compiler, e.g.
             # hiprtcCreateProgram:


### PR DESCRIPTION
The `HIP_PATH` environment variable will confuse `hipcc` in ROCm 5.5+ versions and should no longer be set. This closes #42691.
