### PR TITLE
mpich: Update PMI configure options

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -61,9 +61,9 @@ class Mpich(AutotoolsPackage, CudaPackage, ROCmPackage):
     variant("wrapperrpath", default=True, description="Enable wrapper rpath")
     variant(
         "pmi",
-        default="pmi",
+        default="pmi1",
         description="""PMI interface.""",
-        values=("pmi", "pmi2", "pmix", "cray"),
+        values=("pmi1", "pmi2", "pmix", "cray"),
         multi=False,
     )
     variant(
@@ -386,7 +386,7 @@ supported, and netmod is ignored if device is ch3:sock.""",
                 variants.append("+argobots")
 
             if re.search(r"--with-pmi=simple", output):
-                variants.append("pmi=pmi")
+                variants.append("pmi=pmi1")
             elif re.search(r"--with-pmi=pmi2/simple", output):
                 variants.append("pmi=pmi2")
             elif re.search(r"--with-pmix", output):
@@ -551,7 +551,7 @@ supported, and netmod is ignored if device is ch3:sock.""",
         else:
             config_args.append("--with-slurm=no")
 
-        if "pmi=pmi" in spec:
+        if "pmi=pmi1" in spec:
             config_args.append("--with-pmi=simple")
         elif "pmi=pmi2" in spec:
             config_args.append("--with-pmi=pmi2/simple")

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -568,19 +568,19 @@ supported, and netmod is ignored if device is ch3:sock.""",
                 config_args.append("--with-pmi=pmi2")
             elif "pmi=pmix" in spec:
                 # use the PMIx client interface with an external PMIx library
-                config_args.append("--with-pmi=pmix --with-pmix={0}".format(spec["pmix"].prefix))
+                config_args.append("--with-pmi=pmix")
+                config_args.append(f"--with-pmix={spec['pmix'].prefix}")
             elif "pmi=cray" in spec:
-                # use PMI2 interface with Cray PMI library
-                config_args.append(
-                    "--with-pmi=pmi2 --with-pmi2={0}".format(spec["cray-pmi"].prefix)
-                )
+                # use PMI2 interface of the Cray PMI library
+                config_args.append("--with-pmi=pmi2")
+                config_args.append(f"--with-pmi2={spec['cray-pmi'].prefix}")
         else:
             if "pmi=pmi1" in spec:
                 config_args.append("--with-pmi=simple")
             elif "pmi=pmi2" in spec:
                 config_args.append("--with-pmi=pmi2/simple")
             elif "pmi=pmix" in spec:
-                config_args.append("--with-pmix={0}".format(spec["pmix"].prefix))
+                config_args.append(f"--with-pmix={spec['pmix'].prefix}")
             elif "pmi=cray" in spec:
                 config_args.append("--with-pmi=cray")
 

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -385,7 +385,7 @@ supported, and netmod is ignored if device is ch3:sock.""",
             if re.search(r"--with-thread-package=argobots", output):
                 variants.append("+argobots")
 
-            elif re.search(r"--with-pmi=simple", output):
+            if re.search(r"--with-pmi=simple", output):
                 variants.append("pmi=pmi")
             elif re.search(r"--with-pmi=pmi2/simple", output):
                 variants.append("pmi=pmi2")
@@ -551,9 +551,7 @@ supported, and netmod is ignored if device is ch3:sock.""",
         else:
             config_args.append("--with-slurm=no")
 
-        if "pmi=off" in spec:
-            config_args.append("--with-pmi=no")
-        elif "pmi=pmi" in spec:
+        if "pmi=pmi" in spec:
             config_args.append("--with-pmi=simple")
         elif "pmi=pmi2" in spec:
             config_args.append("--with-pmi=pmi2/simple")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Add a "default" option that passes no option to configure. Existing
options changed in the MPICH 4.2.0 release, so update the package to
reflect those changes.
