### PR TITLE
perl-catalyst-runtime and deps: new packages

### DIFF
--- a/var/spack/repos/builtin/packages/perl-apache-logformat-compiler/package.py
+++ b/var/spack/repos/builtin/packages/perl-apache-logformat-compiler/package.py
@@ -1,0 +1,38 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlApacheLogformatCompiler(PerlPackage):
+    """Compile a log format string to perl-code"""
+
+    homepage = "https://metacpan.org/pod/Apache::LogFormat::Compiler"
+    url = (
+        "https://cpan.metacpan.org/authors/id/K/KA/KAZEBURO/Apache-LogFormat-Compiler-0.36.tar.gz"
+    )
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.36", sha256="94509503ee74ea820183d070c11630ee5bc0fd8c12cb74fae953ed62e4a1ac17")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-http-message", type=("build", "test"))
+    depends_on("perl-module-build-tiny@0.035:", type=("build"))
+    depends_on("perl-posix-strftime-compiler@0.30:", type=("build", "run", "test"))
+    depends_on("perl-test-mocktime", type=("build", "test"))
+    depends_on("perl-test-requires", type=("build", "test"))
+    depends_on("perl-try-tiny@0.12:", type=("build", "test"))
+    depends_on("perl-uri", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Apache::LogFormat::Compiler; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-catalyst-runtime/package.py
+++ b/var/spack/repos/builtin/packages/perl-catalyst-runtime/package.py
@@ -1,0 +1,70 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlCatalystRuntime(PerlPackage):
+    """The Catalyst Framework Runtime"""
+
+    homepage = "https://metacpan.org/pod/Catalyst::Test"
+    url = "https://cpan.metacpan.org/authors/id/J/JJ/JJNAPIORK/Catalyst-Runtime-5.90131.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("5.90131", sha256="9d641efacf0f9935e6ecb98f5a3b476c961b1f819bd2f8f23a647d1d867e1849")
+
+    depends_on("perl@5.8.3:", type=("build", "link", "run", "test"))
+    depends_on("perl-cgi-simple", type=("build", "run", "test"))
+    depends_on("perl-cgi-struct", type=("build", "run", "test"))
+    depends_on("perl-class-c3-adopt-next@0.07:", type=("build", "run", "test"))
+    depends_on("perl-class-load@0.12:", type=("build", "run", "test"))
+    depends_on("perl-data-dump", type=("build", "run", "test"))
+    depends_on("perl-data-optlist", type=("build", "run", "test"))
+    depends_on("perl-hash-multivalue", type=("build", "run", "test"))
+    depends_on("perl-html-parser", type=("build", "run", "test"))
+    depends_on("perl-http-body@1.22:", type=("build", "run", "test"))
+    depends_on("perl-http-message", type=("build", "run", "test"))
+    depends_on("perl-json-maybexs@1.000000:", type=("build", "run", "test"))
+    depends_on("perl-libwww-perl@5.837:", type=("build", "run", "test"))
+    depends_on("perl-module-pluggable@4.7:", type=("build", "run", "test"))
+    depends_on("perl-moose@2.1400:", type=("build", "run", "test"))
+    depends_on("perl-moosex-emulate-class-accessor-fast@0.00903:", type=("build", "run", "test"))
+    depends_on("perl-moosex-getopt@0.48:", type=("build", "run", "test"))
+    depends_on("perl-moosex-methodattributes", type=("build", "run", "test"))
+    depends_on("perl-mro-compat", type=("build", "run", "test"))
+    depends_on("perl-namespace-clean@0.23:", type=("build", "run", "test"))
+    depends_on("perl-path-class@0.09:", type=("build", "run", "test"))
+    depends_on("perl-perlio-utf8-strict", type=("build", "run", "test"))
+    depends_on("perl-plack@0.9991:", type=("build", "run", "test"))
+    depends_on(
+        "perl-plack-middleware-fixmissingbodyinredirect@0.09:", type=("build", "run", "test")
+    )
+    depends_on("perl-plack-middleware-methodoverride@0.12:", type=("build", "run", "test"))
+    depends_on("perl-plack-middleware-removeredundantbody@0.03:", type=("build", "run", "test"))
+    depends_on("perl-plack-middleware-reverseproxy@0.04:", type=("build", "run", "test"))
+    depends_on("perl-plack-test-externalserver", type=("build", "run", "test"))
+    depends_on("perl-safe-isa", type=("build", "run", "test"))
+    depends_on("perl-stream-buffered", type=("build", "run", "test"))
+    depends_on("perl-string-rewriteprefix@0.004:", type=("build", "run", "test"))
+    depends_on("perl-sub-exporter", type=("build", "run", "test"))
+    depends_on("perl-task-weaken", type=("build", "run", "test"))
+    depends_on("perl-test-fatal", type=("build", "test"))
+    depends_on("perl-text-simpletable@0.03:", type=("build", "run", "test"))
+    depends_on("perl-tree-simple@1.15:", type=("build", "run", "test"))
+    depends_on("perl-tree-simple-visitorfactory", type=("build", "run", "test"))
+    depends_on("perl-try-tiny@0.17:", type=("build", "run", "test"))
+    depends_on("perl-uri@1.65:", type=("build", "run", "test"))
+    depends_on("perl-uri-ws@0.03:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Catalyst::Test; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-cgi-simple/package.py
+++ b/var/spack/repos/builtin/packages/perl-cgi-simple/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlCgiSimple(PerlPackage):
+    """A Simple totally OO CGI interface that is CGI.pm compliant"""
+
+    homepage = "https://metacpan.org/pod/CGI::Simple"
+    url = "https://cpan.metacpan.org/authors/id/M/MA/MANWAR/CGI-Simple-1.281.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.281", sha256="4d58103fdfa5c8e1ed076b15d5cafb7001b2886cb3396f00564a881eb324e5a7")
+
+    depends_on("perl-test-exception", type=("build", "test"))
+    depends_on("perl-test-nowarnings", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use CGI::Simple; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-cgi-struct/package.py
+++ b/var/spack/repos/builtin/packages/perl-cgi-struct/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlCgiStruct(PerlPackage):
+    """Build structures from CGI data"""
+
+    homepage = "https://metacpan.org/pod/CGI::Struct"
+    url = "https://cpan.metacpan.org/authors/id/F/FU/FULLERMD/CGI-Struct-1.21.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("BSD")
+
+    version("1.21", sha256="d13d8da7fdcd6d906054e4760fc28a718aec91bd3cf067a58927fb7cb1c09d6c")
+
+    depends_on("perl-test-deep", type=("build", "link"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use CGI::Struct; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-class-c3-adopt-next/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-c3-adopt-next/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlClassC3AdoptNext(PerlPackage):
+    """Make NEXT suck less"""
+
+    homepage = "https://metacpan.org/pod/Class::C3::Adopt::NEXT"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Class-C3-Adopt-NEXT-0.14.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.14", sha256="85676225aadb76e8666a6abe2e0659d40eb4581ad6385b170eea4e1d6bf34bf7")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-module-build-tiny@0.039:", type=("build"))
+    depends_on("perl-mro-compat", type=("build", "run", "test"))
+    depends_on("perl-test-exception@0.27:", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Class::C3::Adopt::NEXT; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-cookie-baker/package.py
+++ b/var/spack/repos/builtin/packages/perl-cookie-baker/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlCookieBaker(PerlPackage):
+    """Cookie string generator / parser"""
+
+    homepage = "https://metacpan.org/pod/Cookie::Baker"
+    url = "https://cpan.metacpan.org/authors/id/K/KA/KAZEBURO/Cookie-Baker-0.12.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.12", sha256="9b04df5d47dcd45ac4299626a10ec990fb40c94ee5a6300c3a88bdfb3575ec29")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-module-build-tiny@0.035:", type=("build"))
+    depends_on("perl-test-time", type=("build", "test"))
+    depends_on("perl-uri", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Cookie::Baker; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-data-dump/package.py
+++ b/var/spack/repos/builtin/packages/perl-data-dump/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlDataDump(PerlPackage):
+    """Pretty printing of data structures"""
+
+    homepage = "https://metacpan.org/pod/Data::Dump"
+    url = "https://cpan.metacpan.org/authors/id/G/GA/GARU/Data-Dump-1.25.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.25", sha256="a4aa6e0ddbf39d5ad49bddfe0f89d9da864e3bc00f627125d1bc580472f53fbd")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Data::Dump; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-devel-stacktrace-ashtml/package.py
+++ b/var/spack/repos/builtin/packages/perl-devel-stacktrace-ashtml/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlDevelStacktraceAshtml(PerlPackage):
+    """Displays stack trace in HTML"""
+
+    homepage = "https://metacpan.org/pod/Devel::StackTrace::AsHTML"
+    url = "https://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA/Devel-StackTrace-AsHTML-0.15.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.15", sha256="6283dbe2197e2f20009cc4b449997742169cdd951bfc44cbc6e62c2a962d3147")
+
+    depends_on("perl-devel-stacktrace", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Devel::StackTrace::AsHTML; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-filesys-notify-simple/package.py
+++ b/var/spack/repos/builtin/packages/perl-filesys-notify-simple/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlFilesysNotifySimple(PerlPackage):
+    """Simple and dumb file system watcher"""
+
+    homepage = "https://metacpan.org/pod/Filesys::Notify::Simple"
+    url = "https://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA/Filesys-Notify-Simple-0.14.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.14", sha256="1fda712d4ba5e1868159ed35f6f8efbfae9d435d6376f5606d533bcb080555a4")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-test-sharedfork", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Filesys::Notify::Simple; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-getopt-long-descriptive/package.py
+++ b/var/spack/repos/builtin/packages/perl-getopt-long-descriptive/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlGetoptLongDescriptive(PerlPackage):
+    """Getopt::Long, but simpler and more powerful"""
+
+    homepage = "https://metacpan.org/pod/Getopt::Long::Descriptive"
+    url = "https://cpan.metacpan.org/authors/id/H/HD/HDP/Getopt-Long-Descriptive-0.088.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.088", sha256="5008d3694280087e03280208637916ba968013c54bee863a3c3e1185368f9e65")
+
+    depends_on("perl@5.12.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-params-validate@0.97:", type=("build", "run", "test"))
+    depends_on("perl-sub-exporter@0.972:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Getopt::Long::Descriptive; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-hash-multivalue/package.py
+++ b/var/spack/repos/builtin/packages/perl-hash-multivalue/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlHashMultivalue(PerlPackage):
+    """Store multiple values per key"""
+
+    homepage = "https://metacpan.org/pod/Hash::MultiValue"
+    url = "https://cpan.metacpan.org/authors/id/A/AR/ARISTOTLE/Hash-MultiValue-0.16.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.16", sha256="66181df7aa68e2786faf6895c88b18b95c800a8e4e6fb4c07fd176410a3c73f4")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Hash::MultiValue; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-http-body/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-body/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlHttpBody(PerlPackage):
+    """HTTP Body Parser"""
+
+    homepage = "https://metacpan.org/pod/HTTP::Body"
+    url = "https://cpan.metacpan.org/authors/id/G/GE/GETTY/HTTP-Body-1.22.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.22", sha256="fc0d2c585b3bd1532d92609965d589e0c87cd380e7cca42fb9ad0a1311227297")
+
+    depends_on("perl-http-message", type=("build", "link", "run", "test"))
+    depends_on("perl-test-deep", type=("build", "link"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use HTTP::Body; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-http-entity-parser/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-entity-parser/package.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlHttpEntityParser(PerlPackage):
+    """PSGI compliant HTTP Entity Parser"""
+
+    homepage = "https://metacpan.org/pod/HTTP::Entity::Parser"
+    url = "https://cpan.metacpan.org/authors/id/K/KA/KAZEBURO/HTTP-Entity-Parser-0.25.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.25", sha256="3a8cd0d8cba3d17cd8c04ee82d7341dfaa247dbdd94a49eb94b53f69e483ec3a")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-hash-multivalue", type=("build", "run", "test"))
+    depends_on("perl-http-message@6:", type=("build", "test"))
+    depends_on("perl-http-multipartparser", type=("build", "run", "test"))
+    depends_on("perl-json-maybexs@1.003007:", type=("build", "run", "test"))
+    depends_on("perl-module-build-tiny@0.035:", type=("build"))
+    depends_on("perl-stream-buffered", type=("build", "run", "test"))
+    depends_on("perl-www-form-urlencoded@0.23:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use HTTP::Entity::Parser; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-http-headers-fast/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-headers-fast/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlHttpHeadersFast(PerlPackage):
+    """Faster implementation of HTTP::Headers"""
+
+    homepage = "https://metacpan.org/pod/HTTP::Headers::Fast"
+    url = "https://cpan.metacpan.org/authors/id/T/TO/TOKUHIROM/HTTP-Headers-Fast-0.22.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.22", sha256="cc431db68496dd884db4bc0c0b7112c1f4a4f1dc68c4f5a3caa757a1e7481b48")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-http-date", type=("build", "run", "test"))
+    depends_on("perl-module-build-tiny@0.035:", type=("build"))
+    depends_on("perl-test-requires", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use HTTP::Headers::Fast; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-http-multipartparser/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-multipartparser/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlHttpMultipartparser(PerlPackage):
+    """HTTP MultiPart Parser"""
+
+    homepage = "https://metacpan.org/pod/HTTP::MultiPartParser"
+    url = "https://cpan.metacpan.org/authors/id/C/CH/CHANSEN/HTTP-MultiPartParser-0.02.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.02", sha256="5eddda159f54d16f868e032440ac2b024e55aac48931871b62627f1a16d00b12")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-test-deep", type=("build", "link"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use HTTP::MultiPartParser; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-moosex-emulate-class-accessor-fast/package.py
+++ b/var/spack/repos/builtin/packages/perl-moosex-emulate-class-accessor-fast/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlMoosexEmulateClassAccessorFast(PerlPackage):
+    """Emulate Class::Accessor::Fast behavior using Moose attributes"""
+
+    homepage = "https://metacpan.org/pod/MooseX::Emulate::Class::Accessor::Fast"
+    url = "https://cpan.metacpan.org/authors/id/H/HA/HAARG/MooseX-Emulate-Class-Accessor-Fast-0.009032.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.009032", sha256="82eeb7ef1f0d25418ae406ea26912b241428d4b2ab9510d5e9deb3f72c187994")
+
+    depends_on("perl-moose@0.84:", type=("build", "run", "test"))
+    depends_on("perl-namespace-clean", type=("build", "run", "test"))
+    depends_on("perl-test-exception", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use MooseX::Emulate::Class::Accessor::Fast; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-moosex-getopt/package.py
+++ b/var/spack/repos/builtin/packages/perl-moosex-getopt/package.py
@@ -1,0 +1,42 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlMoosexGetopt(PerlPackage):
+    """A Moose role for processing command line options"""
+
+    homepage = "https://metacpan.org/pod/MooseX::Getopt"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/MooseX-Getopt-0.76.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.76", sha256="ff8731bd2b1df83347dfb6afe9ca15c04d2ecd8b288e5793d095eaf956b6b028")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-getopt-long-descriptive@0.088:", type=("build", "run", "test"))
+    depends_on("perl-module-build-tiny@0.034:", type=("build"))
+    depends_on("perl-module-runtime", type=("build", "test"))
+    depends_on("perl-moose", type=("build", "run", "test"))
+    depends_on("perl-moosex-role-parameterized@1.01:", type=("build", "run", "test"))
+    depends_on("perl-namespace-autoclean", type=("build", "run", "test"))
+    depends_on("perl-path-tiny@0.009:", type=("build", "test"))
+    depends_on("perl-test-deep", type=("build", "test"))
+    depends_on("perl-test-fatal@0.003:", type=("build", "test"))
+    depends_on("perl-test-needs", type=("build", "test"))
+    depends_on("perl-test-trap", type=("build", "test"))
+    depends_on("perl-test-warnings@0.009:", type=("build", "test"))
+    depends_on("perl-try-tiny", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use MooseX::Getopt; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-moosex-methodattributes/package.py
+++ b/var/spack/repos/builtin/packages/perl-moosex-methodattributes/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlMoosexMethodattributes(PerlPackage):
+    """Code attribute introspection"""
+
+    homepage = "https://metacpan.org/pod/MooseX::MethodAttributes"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/MooseX-MethodAttributes-0.32.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.32", sha256="cb33886574b7d2dd39c42c0dcdc707acdb0aec7dbbde9a21c0422660368c197b")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-moose", type=("build", "run", "test"))
+    depends_on("perl-moosex-role-parameterized", type=("build", "test"))
+    depends_on("perl-namespace-autoclean@0.08:", type=("build", "run", "test"))
+    depends_on("perl-test-fatal", type=("build", "test"))
+    depends_on("perl-test-needs", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use MooseX::MethodAttributes; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-moosex-role-parameterized/package.py
+++ b/var/spack/repos/builtin/packages/perl-moosex-role-parameterized/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlMoosexRoleParameterized(PerlPackage):
+    """Moose roles with composition parameters"""
+
+    homepage = "https://metacpan.org/pod/MooseX::Role::Parameterized"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/MooseX-Role-Parameterized-1.11.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.11", sha256="1cfe766c5d7f0ecab57f733dcca430a2a2acd6b995757141b940ade3692bec9e")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-cpan-meta-check@0.011:", type=("build", "test"))
+    depends_on("perl-module-build-tiny@0.034:", type=("build"))
+    depends_on("perl-module-runtime", type=("build", "run", "test"))
+    depends_on("perl-moose@2.0300:", type=("build", "run", "test"))
+    depends_on("perl-namespace-autoclean", type=("build", "run", "test"))
+    depends_on("perl-namespace-clean@0.19:", type=("build", "run", "test"))
+    depends_on("perl-test-fatal", type=("build", "test"))
+    depends_on("perl-test-needs", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use MooseX::Role::Parameterized; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-path-class/package.py
+++ b/var/spack/repos/builtin/packages/perl-path-class/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPathClass(PerlPackage):
+    """Cross-platform path specification manipulation"""
+
+    homepage = "https://metacpan.org/pod/Path::Class"
+    url = "https://cpan.metacpan.org/authors/id/K/KW/KWILLIAMS/Path-Class-0.37.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.37", sha256="654781948602386f2cb2e4473a739f17dc6953d92aabc2498a4ca2561bc248ce")
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Path::Class; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-plack-middleware-fixmissingbodyinredirect/package.py
+++ b/var/spack/repos/builtin/packages/perl-plack-middleware-fixmissingbodyinredirect/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPlackMiddlewareFixmissingbodyinredirect(PerlPackage):
+    """Plack::Middleware which sets body for redirect response, if it's not already set"""
+
+    homepage = "https://metacpan.org/pod/Plack::Middleware::FixMissingBodyInRedirect"
+    url = "https://cpan.metacpan.org/authors/id/S/SW/SWEETKID/Plack-Middleware-FixMissingBodyInRedirect-0.12.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.12", sha256="6c22d069f5a57ac206d4659b28b8869bb9270640bb955efddd451dcc58cdb391")
+
+    depends_on("perl-html-parser", type=("build", "run", "test"))
+    depends_on("perl-http-message", type=("build", "test"))
+    depends_on("perl-plack", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = [
+            "-we",
+            'use strict; use Plack::Middleware::FixMissingBodyInRedirect; print("OK\n")',
+        ]
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-plack-middleware-methodoverride/package.py
+++ b/var/spack/repos/builtin/packages/perl-plack-middleware-methodoverride/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPlackMiddlewareMethodoverride(PerlPackage):
+    """Override REST methods to Plack apps via POST"""
+
+    homepage = "https://metacpan.org/pod/Plack::Middleware::MethodOverride"
+    url = "https://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA/Plack-Middleware-MethodOverride-0.20.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.20", sha256="dbfb5a2efb48bfeb01cb3ae1e1c677e155dc7bfe210c7e7f221bae3cb6aab5f1")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-plack", type=("build", "run", "test"))
+    depends_on("perl-uri", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Plack::Middleware::MethodOverride; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-plack-middleware-removeredundantbody/package.py
+++ b/var/spack/repos/builtin/packages/perl-plack-middleware-removeredundantbody/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPlackMiddlewareRemoveredundantbody(PerlPackage):
+    """Plack::Middleware which removes body for HTTP response if it's not required"""
+
+    homepage = "https://metacpan.org/pod/Plack::Middleware::RemoveRedundantBody"
+    url = "https://cpan.metacpan.org/authors/id/S/SW/SWEETKID/Plack-Middleware-RemoveRedundantBody-0.09.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.09", sha256="80d45f93d6b7290b0bd8b3cedd84a37fc501456cc3dec02ec7aad81c0018087e")
+
+    depends_on("perl-http-message", type=("build", "test"))
+    depends_on("perl-plack", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Plack::Middleware::RemoveRedundantBody; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-plack-middleware-reverseproxy/package.py
+++ b/var/spack/repos/builtin/packages/perl-plack-middleware-reverseproxy/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPlackMiddlewareReverseproxy(PerlPackage):
+    """Supports app to run as a reverse proxy backend"""
+
+    homepage = "https://metacpan.org/pod/Plack::Middleware::ReverseProxy"
+    url = "https://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA/Plack-Middleware-ReverseProxy-0.16.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.16", sha256="874931d37d07667ba0d0f37903b94511071f4191feb73fa45765da2b8c15a128")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-plack@0.9988:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Plack::Middleware::ReverseProxy; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-plack-test-externalserver/package.py
+++ b/var/spack/repos/builtin/packages/perl-plack-test-externalserver/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPlackTestExternalserver(PerlPackage):
+    """Run HTTP tests on external live servers"""
+
+    homepage = "https://metacpan.org/pod/Plack::Test::ExternalServer"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Plack-Test-ExternalServer-0.02.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.02", sha256="5baf5c57fe0c06412deec9c5abe7952ab8a04f8c47b4bbd8e9e9982268903ed0")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-http-message", type=("build", "test"))
+    depends_on("perl-libwww-perl", type=("build", "run", "test"))
+    depends_on("perl-plack", type=("build", "test"))
+    depends_on("perl-test-tcp", type=("build", "test"))
+    depends_on("perl-uri", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Plack::Test::ExternalServer; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-plack/package.py
+++ b/var/spack/repos/builtin/packages/perl-plack/package.py
@@ -1,0 +1,46 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPlack(PerlPackage):
+    """Perl Superglue for Web frameworks and Web Servers (PSGI toolkit)"""
+
+    homepage = "https://metacpan.org/pod/Plack"
+    url = "https://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA/Plack-1.0051.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.0051", sha256="bebde91c42298ed6ec8e6c82b21433a1b49aa39412c247f3905b80f955acf77b")
+
+    depends_on("perl@5.12.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-apache-logformat-compiler@0.33:", type=("build", "run", "test"))
+    depends_on("perl-cookie-baker@0.07:", type=("build", "run", "test"))
+    depends_on("perl-devel-stacktrace@1.23:", type=("build", "run", "test"))
+    depends_on("perl-devel-stacktrace-ashtml@0.11:", type=("build", "run", "test"))
+    depends_on("perl-file-sharedir@1.00:", type=("build", "run", "test"))
+    depends_on("perl-file-sharedir-install@0.06:", type=("build"))
+    depends_on("perl-filesys-notify-simple", type=("build", "run", "test"))
+    depends_on("perl-hash-multivalue@0.05:", type=("build", "run", "test"))
+    depends_on("perl-http-entity-parser@0.25:", type=("build", "run", "test"))
+    depends_on("perl-http-headers-fast@0.18:", type=("build", "run", "test"))
+    depends_on("perl-http-message@5.814:", type=("build", "run", "test"))
+    depends_on("perl-stream-buffered@0.02:", type=("build", "run", "test"))
+    depends_on("perl-test-requires", type=("build", "test"))
+    depends_on("perl-test-tcp@2.15:", type=("build", "run", "test"))
+    depends_on("perl-try-tiny", type=("build", "run", "test"))
+    depends_on("perl-uri@1.59:", type=("build", "run", "test"))
+    depends_on("perl-www-form-urlencoded@0.23:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Plack; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-posix-strftime-compiler/package.py
+++ b/var/spack/repos/builtin/packages/perl-posix-strftime-compiler/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPosixStrftimeCompiler(PerlPackage):
+    """GNU C library compatible strftime for loggers and servers"""
+
+    homepage = "https://metacpan.org/pod/POSIX::strftime::Compiler"
+    url = "https://cpan.metacpan.org/authors/id/K/KA/KAZEBURO/POSIX-strftime-Compiler-0.46.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.46", sha256="bf88873248ef88cc5e68ed074493496be684ec334e11273d4654306dd9dae485")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-module-build-tiny@0.035:", type=("build"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use POSIX::strftime::Compiler; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-stream-buffered/package.py
+++ b/var/spack/repos/builtin/packages/perl-stream-buffered/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlStreamBuffered(PerlPackage):
+    """Temporary buffer to save bytes"""
+
+    homepage = "https://metacpan.org/pod/Stream::Buffered"
+    url = "https://cpan.metacpan.org/authors/id/D/DO/DOY/Stream-Buffered-0.03.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.03", sha256="9b2d4390b5de6b0cf4558e4ad04317a73c5e13dd19af29149c4e47c37fb2423b")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Stream::Buffered; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-string-rewriteprefix/package.py
+++ b/var/spack/repos/builtin/packages/perl-string-rewriteprefix/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlStringRewriteprefix(PerlPackage):
+    """Rewrite strings based on a set of known prefixes"""
+
+    homepage = "https://metacpan.org/pod/String::RewritePrefix"
+    url = "https://cpan.metacpan.org/authors/id/R/RJ/RJBS/String-RewritePrefix-0.009.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.009", sha256="44918bec96a54af8ca37ca897e436709ec284a07b28516ef3cce4666869646d5")
+
+    depends_on("perl@5.12.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-sub-exporter@0.972:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use String::RewritePrefix; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-mocktime/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-mocktime/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTestMocktime(PerlPackage):
+    """Replaces actual time with simulated time"""
+
+    homepage = "https://metacpan.org/pod/Test::MockTime"
+    url = "https://cpan.metacpan.org/authors/id/D/DD/DDICK/Test-MockTime-0.17.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.17", sha256="3363e118b2606f1d6abc956f22b0d09109772b7086155fb5c9c7f983350602f9")
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Test::MockTime; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-tcp/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-tcp/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTestTcp(PerlPackage):
+    """Testing TCP program"""
+
+    homepage = "https://metacpan.org/pod/Test::TCP"
+    url = "https://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA/Test-TCP-2.22.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("2.22", sha256="3e53c3c06d6d0980a2bfeb915602b714e682ee211ae88c11748cf2cc714e7b57")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-test-sharedfork@0.29:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Test::TCP; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-time/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-time/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTestTime(PerlPackage):
+    """Overrides the time() and sleep() core functions for testing"""
+
+    homepage = "https://metacpan.org/pod/Test::Time"
+    url = "https://cpan.metacpan.org/authors/id/A/AN/ANATOFUZ/Test-Time-0.092.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.092", sha256="30d90f54ce840893c7ba2cac2a4d1eecd4c9cdf805910c595e3ae89dfd644738")
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Test::Time; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-trap/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-trap/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTestTrap(PerlPackage):
+    """Trap exit codes, exceptions, output, etc."""
+
+    homepage = "https://metacpan.org/pod/Test::Trap"
+    url = "https://cpan.metacpan.org/authors/id/E/EB/EBHANSSEN/Test-Trap-v0.3.5.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("v0.3.5", sha256="54f99016562b5b1d72110100f1f2be437178cdf84376f495ffd0376f1d7ecb9a")
+
+    depends_on("perl@5.6.2:", type=("build", "link", "run", "test"))
+    depends_on("perl-data-dump", type=("build", "run", "test"))
+
+    def url_for_version(self, version):
+        return f"https://cpan.metacpan.org/authors/id/E/EB/EBHANSSEN/Test-Trap-{str(version)}.tar.gz"
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Test::Trap; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-trap/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-trap/package.py
@@ -22,7 +22,9 @@ class PerlTestTrap(PerlPackage):
     depends_on("perl-data-dump", type=("build", "run", "test"))
 
     def url_for_version(self, version):
-        return f"https://cpan.metacpan.org/authors/id/E/EB/EBHANSSEN/Test-Trap-{str(version)}.tar.gz"
+        return (
+            f"https://cpan.metacpan.org/authors/id/E/EB/EBHANSSEN/Test-Trap-{str(version)}.tar.gz"
+        )
 
     def test_use(self):
         """Test 'use module'"""

--- a/var/spack/repos/builtin/packages/perl-tree-simple-visitorfactory/package.py
+++ b/var/spack/repos/builtin/packages/perl-tree-simple-visitorfactory/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTreeSimpleVisitorfactory(PerlPackage):
+    """A factory object for dispensing Visitor objects"""
+
+    homepage = "https://metacpan.org/pod/Tree::Simple::VisitorFactory"
+    url = "https://cpan.metacpan.org/authors/id/R/RS/RSAVAGE/Tree-Simple-VisitorFactory-0.16.tgz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.16", sha256="9cf538faa12c54ffb4a91439945e488f1856f62b89ac5072a922119e01880da6")
+
+    depends_on("perl-test-exception@0.15:", type=("build", "test"))
+    depends_on("perl-tree-simple@1.12:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Tree::Simple::VisitorFactory; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-tree-simple/package.py
+++ b/var/spack/repos/builtin/packages/perl-tree-simple/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTreeSimple(PerlPackage):
+    """A simple tree object"""
+
+    homepage = "https://metacpan.org/pod/Tree::Simple"
+    url = "https://cpan.metacpan.org/authors/id/R/RS/RSAVAGE/Tree-Simple-1.34.tgz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.34", sha256="b7e9799bd222bb94cff993f7d765980cbea1b6cd2aaa5ecbead635abdf47d29c")
+
+    depends_on("perl-test-exception@0.15:", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Tree::Simple; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-uri-ws/package.py
+++ b/var/spack/repos/builtin/packages/perl-uri-ws/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlUriWs(PerlPackage):
+    """WebSocket support for URI package"""
+
+    homepage = "https://metacpan.org/pod/URI::ws"
+    url = "https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/URI-ws-0.03.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.03", sha256="6e6b0e4172acb6a53c222639c000608c2dd61d50848647482ac8600d50e541ef")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-uri", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use URI::ws; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-www-form-urlencoded/package.py
+++ b/var/spack/repos/builtin/packages/perl-www-form-urlencoded/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlWwwFormUrlencoded(PerlPackage):
+    """Parser and builder for application/x-www-form-urlencoded"""
+
+    homepage = "https://metacpan.org/pod/WWW::Form::UrlEncoded"
+    url = "https://cpan.metacpan.org/authors/id/K/KA/KAZEBURO/WWW-Form-UrlEncoded-0.26.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.26", sha256="c0480b5f1f15b71163ec327b8e7842298f0cb3ace97e63d7034af1e94a2d90f4")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use WWW::Form::UrlEncoded; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
This adds Perl Catalyst::Runtime and its missing dependencies.

Build-time tests ran successfully.

Adds:
- perl-catalyst-runtime
- perl-apache-logformat-compiler
- perl-cgi-simple
- perl-cgi-struct
- perl-class-c3-adopt-next
- perl-cookie-baker
- perl-data-dump
- perl-devel-stacktrace-ashtml
- perl-filesys-notify-simple
- perl-getopt-long-descriptive
- perl-hash-multivalue
- perl-http-body
- perl-http-entity-parser
- perl-http-headers-fast
- perl-http-multipartparser
- perl-moosex-emulate-class-accessor-fast
- perl-moosex-getopt
- perl-moosex-methodattributes
- perl-moosex-role-parameterized
- perl-path-class
- perl-plack
- perl-plack-middleware-fixmissingbodyinredirect
- perl-plack-middleware-methodoverride
- perl-plack-middleware-removeredundantbody
- perl-plack-middleware-reverseproxy
- perl-plack-test-externalserver
- perl-posix-strftime-compiler
- perl-stream-buffered
- perl-string-rewriteprefix
- perl-test-mocktime
- perl-test-tcp
- perl-test-time
- perl-test-trap
- perl-tree-simple
- perl-tree-simple-visitorfactory
- perl-uri-ws
- perl-www-form-urlencoded

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
