### PR TITLE
re2: add v2023-06-01 -> main

### DIFF
--- a/var/spack/repos/builtin/packages/re2/package.py
+++ b/var/spack/repos/builtin/packages/re2/package.py
@@ -6,15 +6,31 @@
 from spack.package import *
 
 
-class Re2(CMakePackage):
+class Re2(MakefilePackage, CMakePackage):
     """RE2 is a fast, safe, thread-friendly alternative to backtracking
     regular expression engines like those used in PCRE, Perl, and Python."""
 
+    # The makefile build is preferred, but cmake and bazel are also supported:
+    # https://github.com/google/re2/wiki/Install
+    build_system(conditional("cmake", when="@:2021-06-01"), "makefile", default="makefile")
+
     homepage = "https://github.com/google/re2"
-    url = "https://github.com/google/re2/archive/2020-08-01.tar.gz"
+    url = "https://github.com/google/re2/releases/download/2023-11-01/re2-2023-11-01.tar.gz"
+    git = "https://github.com/google/re2.git"
+    list_url = "https://github.com/google/re2/releases"
+
+    maintainers("cosmicexplorer")
 
     license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("main", branch="main")
+
+    version(
+        "2024-02-01", sha256="cd191a311b84fcf37310e5cd876845b4bf5aee76fdd755008eef3b6478ce07bb"
+    )
+    version(
+        "2023-11-01", sha256="4e6593ac3c71de1c0f322735bc8b0492a72f66ffccfad76e259fa21c41d27d8a"
+    )
     version(
         "2024-07-02", sha256="eb2df807c781601c14a260a507a5bb4509be1ee626024cb45acbd57cb9d4032b"
     )
@@ -38,6 +54,9 @@ class Re2(CMakePackage):
     )
     version(
         "2023-09-01", sha256="5bb6875ae1cd1e9fedde98018c346db7260655f86fdb8837e3075103acd3649b"
+    )
+    version(
+        "2023-06-01", sha256="8b4a8175da7205df2ad02e405a950a02eaa3e3e0840947cd598e92dca453199b"
     )
     version(
         "2021-06-01", sha256="26155e050b10b5969e986dab35654247a3b1b295e0532880b5a9c13c0a700ceb"
@@ -68,7 +87,11 @@ class Re2(CMakePackage):
     depends_on("benchmark ~performance_counters", type="test")
 
     # shared libs must have position-independent code
-    conflicts("+shared ~pic")
+    conflicts("+shared ~pic", msg="shared libs must have PIC code!")
+    conflicts(
+        "+pic ~shared build_system=makefile",
+        msg="the makefile build does not support static libs with PIC code!",
+    )
 
     def cmake_args(self):
         args = [
@@ -83,3 +106,19 @@ class Re2(CMakePackage):
         if abseil:
             args.append(self.define("CMAKE_CXX_STANDARD", abseil[0].variants["cxxstd"].value))
         return args
+
+    @when("build_system=makefile")
+    def patch(self):
+        filter_file("prefix=/usr/local", "prefix={}".format(self.prefix), "Makefile", string=True)
+
+    @property
+    def build_targets(self):
+        if "+shared" in self.spec:
+            return ["shared"]
+        return ["static"]
+
+    @property
+    def install_targets(self):
+        if "+shared" in self.spec:
+            return ["shared-install"]
+        return ["static-install"]


### PR DESCRIPTION
I found re2's Makefile build to be more reliable than cmake for integrating into cargo for the purposes of `spack-rs` and #41960, so I've added it as a build system and made it the default (as recommended in their [install guide](https://github.com/google/re2/wiki/Install)). I've also added several new versions and listed myself as a maintainer for this spack package.