### PR TITLE
perl-readonly-xs: new package

### DIFF
--- a/var/spack/repos/builtin/packages/perl-readonly-xs/package.py
+++ b/var/spack/repos/builtin/packages/perl-readonly-xs/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlReadonlyXs(PerlPackage):
+    """Companion module for Readonly.pm, to speed up read-only scalar variables."""
+
+    homepage = "https://metacpan.org/pod/Readonly::XS"
+    url = "https://cpan.metacpan.org/authors/id/R/RO/ROODE/Readonly-XS-1.05.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.05", sha256="8ae5c4e85299e5c8bddd1b196f2eea38f00709e0dc0cb60454dc9114ae3fff0d")
+
+    depends_on("perl-readonly@1.02:", type=("build", "run", "test"))
+
+    def test_use(self):
+        # This module can not be "use"d.
+        pass


### PR DESCRIPTION
This adds Readonly::XS. Since this module can not be used by itself, the Spack package comes with a test override. This anticipates that the perl builder will one day have a generic standalone module usage test.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
