### PR TITLE
perl-json-xs and deps: new packages

### DIFF
--- a/var/spack/repos/builtin/packages/perl-canary-stability/package.py
+++ b/var/spack/repos/builtin/packages/perl-canary-stability/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlCanaryStability(PerlPackage):
+    """Canary to check perl compatibility for schmorp's modules"""
+
+    homepage = "https://metacpan.org/pod/Canary::Stability"
+    url = "https://cpan.metacpan.org/authors/id/M/ML/MLEHMANN/Canary-Stability-2013.tar.gz"
+
+    maintainers("EbiArnie")
+
+    version("2013", sha256="a5c91c62cf95fcb868f60eab5c832908f6905221013fea2bce3ff57046d7b6ea")
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Canary::Stability; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-json-xs/package.py
+++ b/var/spack/repos/builtin/packages/perl-json-xs/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlJsonXs(PerlPackage):
+    """JSON serialising/deserialising, done correctly and fast"""
+
+    homepage = "https://metacpan.org/pod/JSON::XS"
+    url = "https://cpan.metacpan.org/authors/id/M/ML/MLEHMANN/JSON-XS-4.03.tar.gz"
+
+    maintainers("EbiArnie")
+
+    version("4.03", sha256="515536f45f2fa1a7e88c8824533758d0121d267ab9cb453a1b5887c8a56b9068")
+
+    depends_on("perl-canary-stability", type=("build"))
+    depends_on("perl-common-sense", type=("build", "run", "test"))
+    depends_on("perl-types-serialiser", type=("build", "run", "test"))
+
+    def setup_build_environment(self, env):
+        env.set("PERL_CANARY_STABILITY_NOPROMPT", "1")
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use JSON::XS; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-types-serialiser/package.py
+++ b/var/spack/repos/builtin/packages/perl-types-serialiser/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTypesSerialiser(PerlPackage):
+    """Simple data types for common serialisation formats"""
+
+    homepage = "https://metacpan.org/pod/Types::Serialiser"
+    url = "https://cpan.metacpan.org/authors/id/M/ML/MLEHMANN/Types-Serialiser-1.01.tar.gz"
+
+    maintainers("EbiArnie")
+
+    version("1.01", sha256="f8c7173b0914d0e3d957282077b366f0c8c70256715eaef3298ff32b92388a80")
+
+    depends_on("perl-common-sense", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Types::Serialiser; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
Adds JSON::XS and its deps:
- Canary::Stability
- Types::Serialiser

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
