### PR TITLE
py-shacl: new version, update dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-poetry-core/package.py
+++ b/var/spack/repos/builtin/packages/py-poetry-core/package.py
@@ -14,6 +14,7 @@ class PyPoetryCore(PythonPackage):
 
     license("MIT")
 
+    version("1.8.1", sha256="67a76c671da2a70e55047cddda83566035b701f7e463b32a2abfeac6e2a16376")
     version("1.7.0", sha256="8f679b83bd9c820082637beca1204124d5d2a786e4818da47ec8acefd0353b74")
     version("1.6.1", sha256="0f9b0de39665f36d6594657e7d57b6f463cc10f30c28e6d1c3b9ff54c26c9ac3")
     version("1.2.0", sha256="ceccec95487e46c63a41761fbac5211b809bca22658e25a049f4c7da96269f71")

--- a/var/spack/repos/builtin/packages/py-prettytable/package.py
+++ b/var/spack/repos/builtin/packages/py-prettytable/package.py
@@ -15,13 +15,16 @@ class PyPrettytable(PythonPackage):
     homepage = "https://github.com/jazzband/prettytable"
     pypi = "prettytable/prettytable-0.7.2.tar.gz"
 
+    version("3.7.0", sha256="ef8334ee40b7ec721651fc4d37ecc7bb2ef55fde5098d994438f0dfdaa385c0c")
     version("3.4.1", sha256="7d7dd84d0b206f2daac4471a72f299d6907f34516064feb2838e333a4e2567bd")
     version("3.2.0", sha256="ae7d96c64100543dc61662b40a28f3b03c0f94a503ed121c6fca2782c5816f81")
     version("2.4.0", sha256="18e56447f636b447096977d468849c1e2d3cfa0af8e7b5acfcf83a64790c0aca")
     version("2.2.1", sha256="6d465005573a5c058d4ca343449a5b28c21252b86afcdfa168cdc6a440f0b24c")
     version("0.7.2", sha256="2d5460dc9db74a32bcc8f9f67de68b2c4f4d2f01fa3bd518764c69156d9cacd9")
 
-    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools", type="build", when="@:3.4")
+    depends_on("py-hatchling", type="build", when="@3.7:")
+    depends_on("py-hatch-vcs", type="build", when="@3.7:")
     depends_on("py-wcwidth", type=("build", "run"), when="@2.4.0:")
     depends_on("py-importlib-metadata", type=("build", "run"), when="@2: ^python@:3.7")
-    depends_on("py-setuptools-scm", type="build", when="@2.4.0:")
+    depends_on("py-setuptools-scm", type="build", when="@2.4.0:3.4")

--- a/var/spack/repos/builtin/packages/py-pyshacl/package.py
+++ b/var/spack/repos/builtin/packages/py-pyshacl/package.py
@@ -18,7 +18,9 @@ class PyPyshacl(PythonPackage):
     version("0.17.2", sha256="46f31c7a7f7298aa5b483d92dbc850ff79a144d26f1f41e83267ed84b4d6ae23")
 
     depends_on("py-poetry-core@1.1:1", type="build")
+    depends_on("py-poetry-core@1.8.1:1", when="@0.25.0:", type="build")
     depends_on("python@3.7:3", type=("build", "run"))
+    depends_on("python@3.8.1:3", when="@0.25.0:", type=("build", "run"))
     depends_on("py-rdflib@6.0.0:6", when="@0.17.2", type=("build", "run"))
     depends_on("py-rdflib@6.2.0:6", when="@0.20.0", type=("build", "run"))
     depends_on("py-rdflib@6.3.2:7", when="@0.25.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pyshacl/package.py
+++ b/var/spack/repos/builtin/packages/py-pyshacl/package.py
@@ -25,7 +25,7 @@ class PyPyshacl(PythonPackage):
     depends_on("py-rdflib@6.2.0:6", when="@0.20.0", type=("build", "run"))
     depends_on("py-rdflib@6.3.2:7", when="@0.25.0:", type=("build", "run"))
     depends_on("py-html5lib@1.1:1", when="@0.20.0:", type=("build", "run"))
-    depends_on("py-importlib-metadata@6:", when="@0.25.0: ^python@:3.11", type=("build", "run"))
+    depends_on("py-importlib-metadata@7:", when="@0.25.0: ^python@:3.11", type=("build", "run"))
     depends_on("py-owlrl@5.2.3:6", when="@0.17.2", type=("build", "run"))
     depends_on("py-owlrl@6.0.2:6", when="@0.20.0:", type=("build", "run"))
     depends_on("py-packaging@21.3:", when="@0.20.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pyshacl/package.py
+++ b/var/spack/repos/builtin/packages/py-pyshacl/package.py
@@ -13,18 +13,23 @@ class PyPyshacl(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.25.0", sha256="91e87ed04ccb29aa47abfcf8a3e172d35a8831fce23a011cfbf35534ce4c940b")
     version("0.20.0", sha256="47f014c52cc69167b902c89b3940dd400f7f5d2169a62f97f837f3419b4a737d")
     version("0.17.2", sha256="46f31c7a7f7298aa5b483d92dbc850ff79a144d26f1f41e83267ed84b4d6ae23")
 
     depends_on("py-poetry-core@1.1:1", type="build")
     depends_on("python@3.7:3", type=("build", "run"))
     depends_on("py-rdflib@6.0.0:6", when="@0.17.2", type=("build", "run"))
-    depends_on("py-rdflib@6.2.0:6", when="@0.20.0:", type=("build", "run"))
+    depends_on("py-rdflib@6.2.0:6", when="@0.20.0", type=("build", "run"))
+    depends_on("py-rdflib@6.3.2:7", when="@0.25.0:", type=("build", "run"))
     depends_on("py-html5lib@1.1:1", when="@0.20.0:", type=("build", "run"))
+    depends_on("py-importlib-metadata@6:", when="@0.25.0: ^python@:3.11", type=("build", "run"))
     depends_on("py-owlrl@5.2.3:6", when="@0.17.2", type=("build", "run"))
     depends_on("py-owlrl@6.0.2:6", when="@0.20.0:", type=("build", "run"))
     depends_on("py-packaging@21.3:", when="@0.20.0:", type=("build", "run"))
-    depends_on("py-prettytable@2.2.1:2", type=("build", "run"))
+    depends_on("py-prettytable@2.2.1:2", when="@:0.20", type=("build", "run"))
+    depends_on("py-prettytable@3.5.0:", when="@0.25.0: ^python@:3.11", type=("build", "run"))
+    depends_on("py-prettytable@3.7.0:", when="@0.25.0: ^python@3.12:", type=("build", "run"))
 
     def patch(self):
         if self.spec.satisfies("@0.17.2"):

--- a/var/spack/repos/builtin/packages/py-rdflib/package.py
+++ b/var/spack/repos/builtin/packages/py-rdflib/package.py
@@ -23,6 +23,7 @@ class PyRdflib(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("7.0.0", sha256="9995eb8569428059b8c1affd26b25eac510d64f5043d9ce8c84e0d0036e995ae")
     version("6.3.2", sha256="72af591ff704f4caacea7ecc0c5a9056b8553e0489dd4f35a9bc52dbd41522e0")
     version("6.2.0", sha256="62dc3c86d1712db0f55785baf8047f63731fa59b2682be03219cb89262065942")
     version("6.0.2", sha256="6136ae056001474ee2aff5fc5b956e62a11c3a9c66bb0f3d9c0aaa5fbb56854e")

--- a/var/spack/repos/builtin/packages/py-rdflib/package.py
+++ b/var/spack/repos/builtin/packages/py-rdflib/package.py
@@ -30,6 +30,7 @@ class PyRdflib(PythonPackage):
     version("5.0.0", sha256="78149dd49d385efec3b3adfbd61c87afaf1281c30d3fcaf1b323b34f603fb155")
 
     depends_on("python@3.7:3", when="@6.3:", type=("build", "run"))
+    depends_on("python@3.8.1:3", when="@7:", type=("build", "run"))
     depends_on("py-poetry-core@1.4:", when="@6.3:", type="build")
 
     depends_on("py-isodate@0.6", when="@6.3:", type=("build", "run"))


### PR DESCRIPTION
Also updates the dependencies py-prettytable and py-rdflib.