### PR TITLE
libevent: remove autotools build deps again

### DIFF
--- a/var/spack/repos/builtin/packages/libevent/package.py
+++ b/var/spack/repos/builtin/packages/libevent/package.py
@@ -43,10 +43,6 @@ class Libevent(AutotoolsPackage):
     depends_on("openssl@:1.0", when="@:2.0+openssl")
     depends_on("openssl", when="+openssl")
 
-    depends_on("autoconf", type="build")
-    depends_on("automake", type="build")
-    depends_on("libtool", type="build")
-
     def url_for_version(self, version):
         if version >= Version("2.0.22"):
             url = "https://github.com/libevent/libevent/releases/download/release-{0}-stable/libevent-{0}-stable.tar.gz"
@@ -59,9 +55,6 @@ class Libevent(AutotoolsPackage):
     def libs(self):
         libs = find_libraries("libevent", root=self.prefix, shared=True, recursive=True)
         return LibraryList(libs)
-
-    def autoreconf(self, spec, prefix):
-        autoreconf("--force", "--install", "--symlink")
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
The deps were added in #40945 to make it work on macOS 11, because the
old configure scripts only detect macOS 10. Apparently the bundled
autogen.sh script caused issues, later fixed in #41057. However, also
with that fix, things are incorrect, cause people now report:

```
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.7
libtool: and run autoconf again.
```

I did not check what that error is about exactly, but it looks like
Spack's `def autoreconf` step does way less than the `autogen.sh`
script provided in the tarball.

HOWEVER, all this is unnecessary, because the underlying issue was
already fixed long ago, it's just that it regressed at some point. With
#41205 it's back in place, and therefore we can get rid of those
redundant build deps.

