### PR TITLE
unit tests: disable ones failing on win32

### DIFF
--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -251,6 +251,7 @@ def test_overriding_prefix(mock_executable, mutable_config, monkeypatch):
     assert gcc.external_path == os.path.sep + os.path.join("opt", "gcc", "bin")
 
 
+@pytest.mark.not_on_windows("Fails spuriously on Windows")
 def test_new_entries_are_reported_correctly(mock_executable, mutable_config, monkeypatch):
     # Prepare an environment to detect a fake gcc
     gcc_exe = mock_executable("gcc", output="echo 4.2.1")

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -141,6 +141,7 @@ def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch, wo
     assert s.package.spec.installed
 
 
+@pytest.mark.not_on_windows("Fails spuriously on Windows")
 @pytest.mark.disable_clean_stage_check
 def test_failing_overwrite_install_should_keep_previous_installation(
     mock_fetch, install_mockery, working_env


### PR DESCRIPTION
Fails often, so skip and let the windows folks figure it out.
