### PR TITLE
perl-cache-memcached and deps: new packages

### DIFF
--- a/var/spack/repos/builtin/packages/perl-cache-memcached/package.py
+++ b/var/spack/repos/builtin/packages/perl-cache-memcached/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlCacheMemcached(PerlPackage):
+    """Client library for memcached (memory cache daemon)"""
+
+    homepage = "https://metacpan.org/pod/Cache::Memcached"
+    url = "https://cpan.metacpan.org/authors/id/D/DO/DORMANDO/Cache-Memcached-1.30.tar.gz"
+
+    maintainers("EbiArnie")
+
+    version("1.30", sha256="31b3c51ec0eaaf03002e2cc8e3d7d5cbe61919cfdada61c008eb9853acac42a9")
+
+    depends_on("perl-string-crc32", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Cache::Memcached; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-string-crc32/package.py
+++ b/var/spack/repos/builtin/packages/perl-string-crc32/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlStringCrc32(PerlPackage):
+    """Perl interface for cyclic redundancy check generation"""
+
+    homepage = "https://metacpan.org/pod/String::CRC32"
+    url = "https://cpan.metacpan.org/authors/id/L/LE/LEEJO/String-CRC32-2.100.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("CC0-1.0 OR SSLeay")
+
+    version("2.100", sha256="9706093b2d068b6715d35b4c58f51558e37960083202129fbb00a57e19a74713")
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use String::CRC32; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
Adds Cache::Memcached and its dependencies.
Installed OK with build-time tests. Added dependencies:
- String::CRC32

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
