### PR TITLE
dakota: make python dependency optional

### DIFF
--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -43,6 +43,12 @@ class Dakota(CMakePackage):
     license("LGPL-2.1-or-later")
 
     version(
+        "6.19.0",
+        tag="v6.19.0",
+        commit="603f448b916a8f629d258922e26e7e40dcaaf8ce",
+        submodules=submodules,
+    )
+    version(
         "6.18",
         tag="v6.18.0",
         commit="f6cb33b517bb304795e1e14d3673fe289df2ec9b",
@@ -81,7 +87,7 @@ class Dakota(CMakePackage):
 
         args = [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
-            self.define_from_variant("DAKOTA_PYTHON", "python")
+            self.define_from_variant("DAKOTA_PYTHON", "python"),
         ]
 
         if "+mpi" in spec:

--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -54,6 +54,7 @@ class Dakota(CMakePackage):
 
     variant("shared", default=True, description="Enables the build of shared libraries")
     variant("mpi", default=True, description="Activates MPI support")
+    variant("python", default=True, description="Add Python dependency for dakota.interfacing API")
 
     # Generic 'lapack' provider won't work, dakota searches for
     # 'LAPACKConfig.cmake' or 'lapack-config.cmake' on the path
@@ -62,7 +63,7 @@ class Dakota(CMakePackage):
     depends_on("blas")
     depends_on("mpi", when="+mpi")
 
-    depends_on("python")
+    depends_on("python", when="+python")
     depends_on("perl-data-dumper", type="build", when="@6.12:")
     depends_on("boost@:1.68.0", when="@:6.12")
     depends_on("boost@1.69.0:", when="@6.18:")
@@ -79,6 +80,9 @@ class Dakota(CMakePackage):
         spec = self.spec
 
         args = [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]
+
+        if self.spec.satisfies("~python"):
+            args.append(self.define("DAKOTA_PYTHON", False))
 
         if "+mpi" in spec:
             args.extend(

--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -79,10 +79,10 @@ class Dakota(CMakePackage):
     def cmake_args(self):
         spec = self.spec
 
-        args = [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]
-
-        if self.spec.satisfies("~python"):
-            args.append(self.define("DAKOTA_PYTHON", False))
+        args = [
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("DAKOTA_PYTHON", "python")
+        ]
 
         if "+mpi" in spec:
             args.extend(


### PR DESCRIPTION
This PR makes Python an optional dependency for Dakota and adds v6.19. Tested on personal machine, the cmake logic successfully disables the Python component.