### PR TITLE
Support environment variable expansion inside module projections

### DIFF
--- a/lib/spack/spack/projections.py
+++ b/lib/spack/spack/projections.py
@@ -13,7 +13,7 @@ def get_projection(projections, spec):
     all_projection = None
     for spec_like, projection in projections.items():
         if spec.satisfies(spec_like):
-            return spack.util.path.substitute_config_variables(projection)
+            return spack.util.path.canonicalize_path(projection)
         elif spec_like == "all":
-            all_projection = spack.util.path.substitute_config_variables(projection)
+            all_projection = spack.util.path.canonicalize_path(projection)
     return all_projection

--- a/lib/spack/spack/projections.py
+++ b/lib/spack/spack/projections.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.util.path
 
 def get_projection(projections, spec):
     """
@@ -11,7 +12,7 @@ def get_projection(projections, spec):
     all_projection = None
     for spec_like, projection in projections.items():
         if spec.satisfies(spec_like):
-            return projection
+            return spack.util.path.substitute_config_variables(projection)
         elif spec_like == "all":
-            all_projection = projection
+            all_projection = spack.util.path.substitute_config_variables(projection)
     return all_projection

--- a/lib/spack/spack/projections.py
+++ b/lib/spack/spack/projections.py
@@ -13,7 +13,7 @@ def get_projection(projections, spec):
     all_projection = None
     for spec_like, projection in projections.items():
         if spec.satisfies(spec_like):
-            return spack.util.path.canonicalize_path(projection)
+            return spack.util.path.substitute_path_variables(projection)
         elif spec_like == "all":
-            all_projection = spack.util.path.canonicalize_path(projection)
+            all_projection = spack.util.path.substitute_path_variables(projection)
     return all_projection

--- a/lib/spack/spack/projections.py
+++ b/lib/spack/spack/projections.py
@@ -5,6 +5,7 @@
 
 import spack.util.path
 
+
 def get_projection(projections, spec):
     """
     Get the projection for a spec from a projections dict.


### PR DESCRIPTION
Allow spack config variables to appear in view and module projections. So we can do things like:

``` yaml
module:
  tcl:
    projections:
       all: "{name}/$date/$user/{hash:4}"
```

We could also do the more general `canonicalize_path` to include environment variable injection.

That would be my preference, but I went more conservative for this PR.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
