### PR TITLE
fujitsu-fftw: add new version and fix some package.py processing

### DIFF
--- a/var/spack/repos/builtin/packages/fujitsu-fftw/fujitsu-fftw111.patch
+++ b/var/spack/repos/builtin/packages/fujitsu-fftw/fujitsu-fftw111.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac_org b/configure.ac
+index 69c4569..9a87e89 100644
+--- a/configure.ac_org
++++ b/configure.ac
+@@ -735,7 +735,7 @@ if test "$enable_linkfortran"x = "yes"x; then
+         case "${host_cpu}" in
+              aarch64)
+                 case "${CC}" in
+-                     fcc*)
++                     *fcc*)
+                      archive_expsym_cmds="$archive_expsym_cmds --linkfortran"
+                      archive_cmds="$archive_cmds --linkfortran"
+ 		     FORT_SUFFIX=_fortran

--- a/var/spack/repos/builtin/packages/fujitsu-fftw/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-fftw/package.py
@@ -33,12 +33,16 @@ class FujitsuFftw(FftwBase):
     homepage = "https://github.com/fujitsu/fftw3"
     url = "https://github.com/fujitsu/fftw3/archive/sve-v1.0.0.tar.gz"
 
+    version("1.1.1", sha256="d5ac7354e8d1a4ac221de51dc5a4336a3a4ad9a31091b34b675cc556057186e1")
     version("1.1.0", sha256="47b01a20846802041a9533a115f816b973cc9b15b3e827a2f0caffaae34a6c9d")
     version("1.0.0", sha256="b5931e352355d8d1ffeb215922f4b96de11b8585c423fceeaffbf3d5436f6f2f")
 
     variant("shared", default=True, description="Builds a shared version of the library")
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("debug", default=False, description="Builds a debug version of the library")
+    variant(
+        "fortranwrap", default=False, when="@1.1.1:", description="Builds a fortran wrap library"
+    )
 
     depends_on("texinfo")
 
@@ -65,7 +69,7 @@ class FujitsuFftw(FftwBase):
         """Configure function"""
         # Base options
         options = [
-            "CFLAGS=-Ofast",
+            "CFLAGS=-Ofast -ffj-no-fast-matmul",
             "FFLAGS=-Kfast",
             "--enable-sve",
             "--enable-armv8-cntvct-el0",
@@ -105,9 +109,25 @@ class FujitsuFftw(FftwBase):
             "quad": ["--enable-quad-precision"],
         }
 
+        enable_linkfortran = [""]
+        if "+fortranwrap" in spec:
+            enable_linkfortran.append("--enable-linkfortran")
+
         # Different precisions must be configured and compiled one at a time
         configure = Executable("../configure")
         for precision in self.selected_precisions:
             opts = (enable_precision[precision] or []) + options[:]
-            with working_dir(precision, create=True):
-                configure(*opts)
+            for num, option in enumerate(enable_linkfortran):
+                opts.append(option)
+                with working_dir(precision + str(num), create=True):
+                    configure(*opts)
+
+    def for_each_precision_make(self, *targets):
+        create_fortranlib = 1
+        if "+fortranwrap" in self.spec:
+            create_fortranlib += 1
+
+        for precision in self.selected_precisions:
+            for num in range(create_fortranlib):
+                with working_dir(precision + str(num)):
+                    make(*targets)

--- a/var/spack/repos/builtin/packages/fujitsu-fftw/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-fftw/package.py
@@ -56,6 +56,9 @@ class FujitsuFftw(FftwBase):
     )
     requires("%fj")
 
+    # In spack, an absolute path to the compiler is specified in CC.
+    patch("fujitsu-fftw111.patch", when="@1.1.1 %fj")
+
     def autoreconf(self, spec, prefix):
         if spec.target != "a64fx":
             target_check(spec)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Fixed the following:
- Add version 1.1.1
- Set the new configure option to variant(fortranwrap, default=False)
   - This option creates a library that avoids FJ compiler-specific specifications
- Change build option (-ffj-no-fast-matmul)
- Create a patch to support spack settings