### PR TITLE
View creation: use env specs if none are provided

### DIFF
--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -219,7 +219,7 @@ def view(parser, args):
         env = ev.active_environment()
         if len(specs) == 0:
             if not env:
-                tty.die("Created views require specs unless you are in an environment")
+                tty.die("View creation requires specs unless you are in an environment")
             specs = env.concrete_roots()
         else:
             specs = [spack.cmd.disambiguate_spec(s, env) for s in specs]

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -41,6 +41,7 @@ import spack.environment as ev
 import spack.schema.projections
 import spack.store
 from spack.config import validate
+from spack.error import SpackError
 from spack.filesystem_view import YamlFilesystemView, view_func_parser
 from spack.util import spack_yaml as s_yaml
 
@@ -159,16 +160,16 @@ def setup_parser(sp):
             grp.add_argument("specs", **so)
             grp.add_argument("-a", "--all", action="store_true", help="act on all specs in view")
 
-        elif cmd == "statlink":
+        elif cmd in ("statlink", "symlink", "hardlink", "copy"):
+            # view-creation commands do not need to mention specs
+            # if an environment is active. status commands default
+            # to inspecting all specs in the view if none are provided
             so = specs_opts.copy()
             so["nargs"] = "*"
             act.add_argument("specs", **so)
 
         else:
-            # without all option, spec is required
-            so = specs_opts.copy()
-            so["nargs"] = "+"
-            act.add_argument("specs", **so)
+            raise SpackError(f"Unexpected command: {cmd}")
 
     for cmd in ["symlink", "hardlink", "copy"]:
         act = file_system_view_actions[cmd]
@@ -216,7 +217,12 @@ def view(parser, args):
     elif args.action in actions_link:
         # only link commands need to disambiguate specs
         env = ev.active_environment()
-        specs = [spack.cmd.disambiguate_spec(s, env) for s in specs]
+        if len(specs) == 0:
+            if not env:
+                tty.die("Created views require specs unless you are in an environment")
+            specs = env.concrete_roots()
+        else:
+            specs = [spack.cmd.disambiguate_spec(s, env) for s in specs]
 
     elif args.action in actions_status:
         # no specs implies all

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -65,7 +65,7 @@ def test_view_projections(
     viewpath = str(tmpdir.mkdir("view_{0}".format(cmd)))
     view_projection = {"projections": {"all": "{name}-{version}"}}
     projection_file = create_projection_file(tmpdir, view_projection)
-    view(cmd, viewpath, "--projection-file={0}".format(projection_file), "libdwarf")
+    view(cmd, "--projection-file={0}".format(projection_file), viewpath, "libdwarf")
 
     package_prefix = os.path.join(viewpath, "libdwarf-20130207/libdwarf")
     assert os.path.exists(package_prefix)
@@ -87,7 +87,7 @@ def test_view_multiple_projections(
     )
 
     projection_file = create_projection_file(tmpdir, view_projection)
-    view("add", viewpath, "--projection-file={0}".format(projection_file), "libdwarf", "extendee")
+    view("add", "--projection-file={0}".format(projection_file), viewpath, "libdwarf", "extendee")
 
     libdwarf_prefix = os.path.join(viewpath, "libdwarf-20130207/libdwarf")
     extendee_prefix = os.path.join(viewpath, "extendee-gcc/bin")
@@ -107,7 +107,7 @@ def test_view_multiple_projections_all_first(
     )
 
     projection_file = create_projection_file(tmpdir, view_projection)
-    view("add", viewpath, "--projection-file={0}".format(projection_file), "libdwarf", "extendee")
+    view("add", "--projection-file={0}".format(projection_file), viewpath, "libdwarf", "extendee")
 
     libdwarf_prefix = os.path.join(viewpath, "libdwarf-20130207/libdwarf")
     extendee_prefix = os.path.join(viewpath, "extendee-gcc/bin")

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -169,7 +169,7 @@ def test_view_extension_conflict_ignored(
     install("extension1@2.0")
     viewpath = str(tmpdir.mkdir("view"))
     view("symlink", viewpath, "extension1@1.0")
-    view("symlink", viewpath, "-i", "extension1@2.0")
+    view("symlink", "-i", viewpath, "extension1@2.0")
     with open(os.path.join(viewpath, "bin", "extension1"), "r") as fin:
         assert fin.read() == "1.0"
 


### PR DESCRIPTION
Allow creating views without designating which specs to use if you are inside an env. With this PR you can do:

`spack view symlink <dir>`

if there is an active env (in this case, all concretized specs from the active env are put in the view).

Before this PR, it was allowed to put options after `path` and before the `spec`, e.g.

`spack view symlink test-view-dir --projection-file test-projection.yaml tar`

With this PR, options must appear before all args:

`spack view symlink --projection-file test-projection.yaml test-view-dir tar`