### PR TITLE
py-numba: add `tbb` variant

### DIFF
--- a/var/spack/repos/builtin/packages/py-numba/package.py
+++ b/var/spack/repos/builtin/packages/py-numba/package.py
@@ -56,7 +56,7 @@ class PyNumba(PythonPackage):
     depends_on("py-importlib-metadata", when="@0.56:^python@:3.8", type=("build", "run"))
 
     depends_on("tbb", when="+tbb")
-
+    conflicts("~tbb", when="@:0.50")  # No way to disable TBB
     # Version 6.0.0 of llvm had a hidden symbol which breaks numba at runtime.
     # See https://reviews.llvm.org/D44140
     conflicts("^llvm@6.0.0")

--- a/var/spack/repos/builtin/packages/py-numba/package.py
+++ b/var/spack/repos/builtin/packages/py-numba/package.py
@@ -62,6 +62,5 @@ class PyNumba(PythonPackage):
     conflicts("^llvm@6.0.0")
 
     def setup_build_environment(self, env):
-        # No way to disable TBB before v0.51.
-        if "+tbb" not in self.spec and self.spec.satisfies("@0.51:"):
+        if self.spec.satisfies("~tbb"):
             env.set("NUMBA_DISABLE_TBB", "yes")

--- a/var/spack/repos/builtin/packages/py-numba/package.py
+++ b/var/spack/repos/builtin/packages/py-numba/package.py
@@ -28,6 +28,8 @@ class PyNumba(PythonPackage):
     version("0.50.1", sha256="89e81b51b880f9b18c82b7095beaccc6856fcf84ba29c4f0ced42e4e5748a3a7")
     version("0.48.0", sha256="9d21bc77e67006b5723052840c88cc59248e079a907cc68f1a1a264e1eaba017")
 
+    variant("tbb", default=False, description="Build with Intel Threading Building Blocks")
+
     depends_on("python@3.8:3.11", when="@0.57:", type=("build", "run"))
     depends_on("python@3.7:3.10", when="@0.55:0.56", type=("build", "run"))
     depends_on("python@3.7:3.9", when="@0.54", type=("build", "run"))
@@ -53,6 +55,14 @@ class PyNumba(PythonPackage):
     depends_on("py-llvmlite@0.31", when="@0.48", type=("build", "run"))
     depends_on("py-importlib-metadata", when="@0.56:^python@:3.8", type=("build", "run"))
 
+    with when("+tbb"):
+        depends_on("tbb")
+
     # Version 6.0.0 of llvm had a hidden symbol which breaks numba at runtime.
     # See https://reviews.llvm.org/D44140
     conflicts("^llvm@6.0.0")
+
+    def setup_build_environment(self, env):
+        # No way to disable TBB before v0.51.
+        if "+tbb" not in self.spec and self.spec.satisfies("@0.51:"):
+            env.set("NUMBA_DISABLE_TBB", "yes")

--- a/var/spack/repos/builtin/packages/py-numba/package.py
+++ b/var/spack/repos/builtin/packages/py-numba/package.py
@@ -55,8 +55,7 @@ class PyNumba(PythonPackage):
     depends_on("py-llvmlite@0.31", when="@0.48", type=("build", "run"))
     depends_on("py-importlib-metadata", when="@0.56:^python@:3.8", type=("build", "run"))
 
-    with when("+tbb"):
-        depends_on("tbb")
+    depends_on("tbb", when="+tbb")
 
     # Version 6.0.0 of llvm had a hidden symbol which breaks numba at runtime.
     # See https://reviews.llvm.org/D44140


### PR DESCRIPTION
Numba tries to automatically use TBB if available in the system: https://github.com/numba/numba/blob/b88209445d62d63eb2f91cdaa44c3eae0d8b35dc/setup.py#L266-L276 but then compilation fails because the compiler can't find it:
```
  numba/np/ufunc/tbbpool.cpp:15:10: fatal error: tbb/version.h: No such file or directory
     15 | #include <tbb/version.h>
        |          ^~~~~~~~~~~~~~~
  compilation terminated.
```
I suspect there may be some version incompatibilities here, but on first instance the problem is that Numba has a dependency on `tbb` which is not identified by Spack and that should be addressed.

CC: @haampie who spotted the implicit TBB dependency.