### PR TITLE
Add separate command to add all specs in env to a view

### DIFF
--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -193,7 +193,6 @@ def setup_parser(sp):
 def view(parser, args):
     "Produce a view of a set of packages."
 
-    specs = spack.cmd.parse_specs(args.specs)
     path = args.path[0]
 
     if args.action in actions_link and args.projection_file:
@@ -206,7 +205,7 @@ def view(parser, args):
         ordered_projections = {}
 
     # What method are we using for this view
-    if args.action in actions_link:
+    if args.action in actions_link_specs:
         link_fn = view_func_parser(args.action)
     else:
         link_fn = view_func_parser("symlink")

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -224,27 +224,29 @@ def view(parser, args):
         if len(specs) == 0:
             tty.warn("Found no specs in %s" % path)
 
-    elif args.action in actions_link_specs:
-        # only link commands need to disambiguate specs
-        env = ev.active_environment()
-        specs = [spack.cmd.disambiguate_spec(s, env) for s in specs]
-
     elif args.action == "env-symlink":
         env = ev.active_environment()
         if not env:
             tty.die("View creation requires specs unless you are in an environment")
         specs = env.concrete_roots()
 
-    elif args.action in actions_status:
-        # no specs implies all
-        if len(specs) == 0:
-            specs = view.get_all_specs()
-        else:
-            specs = disambiguate_in_view(specs, view)
-
     else:
-        # status and remove can map a partial spec to packages in view
-        specs = disambiguate_in_view(specs, view)
+        specs = spack.cmd.parse_specs(args.specs)
+        if args.action in actions_link_specs:
+            # only link commands need to disambiguate specs
+            env = ev.active_environment()
+            specs = [spack.cmd.disambiguate_spec(s, env) for s in specs]
+
+        elif args.action in actions_status:
+            # no specs implies all
+            if len(specs) == 0:
+                specs = view.get_all_specs()
+            else:
+                specs = disambiguate_in_view(specs, view)
+
+        else:
+            # status and remove can map a partial spec to packages in view
+            specs = disambiguate_in_view(specs, view)
 
     with_dependencies = args.dependencies.lower() in ["true", "yes"]
 

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -114,8 +114,7 @@ def setup_parser(sp):
             help="add package files to a filesystem view via symbolic links",
         ),
         "env-symlink": ssp.add_parser(
-            "env-symlink",
-            help="add all packages in an environment to a view",
+            "env-symlink", help="add all packages in an environment to a view"
         ),
         "hardlink": ssp.add_parser(
             "hardlink",


### PR DESCRIPTION
`spack view env-symlink`, e.g.

`spack view env-symlink --projection-file test-projection.yaml test-view-dir`

This command expects an active environment, and puts all specs in the env into the specified view path.

Like https://github.com/spack/spack/pull/42928, but backport-able.