### PR TITLE
mgard: fix OpenMP on AppleClang

### DIFF
--- a/var/spack/repos/builtin/packages/mgard/package.py
+++ b/var/spack/repos/builtin/packages/mgard/package.py
@@ -55,6 +55,9 @@ class Mgard(CMakePackage, CudaPackage):
     depends_on("cmake@3.19:", type="build")
     depends_on("nvcomp@2.2.0:", when="@2022-11-18:+cuda")
     depends_on("nvcomp@2.0.2", when="@:2021-11-12+cuda")
+    with when("+openmp"):
+        depends_on("llvm-openmp", when="%apple-clang")
+
     conflicts("cuda_arch=none", when="+cuda")
     conflicts(
         "~cuda", when="@2021-11-12", msg="without cuda MGARD@2021-11-12 has undefined symbols"


### PR DESCRIPTION
macOS AppleClang does not provide OpenMP by default with XCode. Use LLVM's OpenMP to fix compile errors of mgard with OpenMP (default).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
