### PR TITLE
Seacas: Updates the patch hash 

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -189,7 +189,7 @@ class Seacas(CMakePackage):
     # See https://github.com/sandialabs/seacas/issues/438
     patch(
         "https://github.com/sandialabs/seacas/commit/29a9ebeccb5a656b4b334fa6af904689da9ffddc.diff?full_index=1",
-        sha256="aedb1fe0af81686f9ed6d511d9b2a3bd52e574eb0ed6363d3f4851280cacde2c",
+        sha256="d088208511fb0a087e2bf70ae70676e59bfefe8d8f5b24bd53b829566f5147d2",
         when="@:2023-10-24",
     )
 


### PR DESCRIPTION
Updates the Seacas patch hash fixing #42916

I have confirmed the new hash is correct on linux and also double checked it on windows 

```
PS > wget https://github.com/sandialabs/seacas/commit/29a9ebeccb5a656b4b334fa6af904689da9ffddc.diff?full_index=1  -Outfile out.diff      
PS > get-filehash out.diff

Algorithm       Hash                                                                   Path
---------       ----                                                                   ----
SHA256          D088208511FB0A087E2BF70AE70676E59BFEFE8D8F5B24BD53B829566F5147D2       C:\Users\MarshC\Desktop\out.diff

```

/cc @johnwparent @scheibelp 