### PR TITLE
libcatalyst: add fortran & python variants

### DIFF
--- a/var/spack/repos/builtin/packages/libcatalyst/package.py
+++ b/var/spack/repos/builtin/packages/libcatalyst/package.py
@@ -28,7 +28,7 @@ class Libcatalyst(CMakePackage):
     variant("conduit", default=False, description="Use external Conduit for Catalyst")
     variant("fortran", default=False, description="Enable Fortran wrapping")
     variant("python", default=False, description="Enable Python wrapping")
-    
+
     depends_on("mpi", when="+mpi")
     depends_on("conduit", when="+conduit")
     depends_on("cmake@3.26:", type="build")

--- a/var/spack/repos/builtin/packages/libcatalyst/package.py
+++ b/var/spack/repos/builtin/packages/libcatalyst/package.py
@@ -26,7 +26,9 @@ class Libcatalyst(CMakePackage):
 
     variant("mpi", default=False, description="Enable MPI support")
     variant("conduit", default=False, description="Use external Conduit for Catalyst")
-
+    variant("fortran", default=False, description="Enable Fortran wrapping")
+    variant("python", default=False, description="Enable Python wrapping")
+    
     depends_on("mpi", when="+mpi")
     depends_on("conduit", when="+conduit")
     depends_on("cmake@3.26:", type="build")
@@ -37,6 +39,8 @@ class Libcatalyst(CMakePackage):
             "-DCATALYST_BUILD_TESTING=OFF",
             self.define_from_variant("CATALYST_USE_MPI", "mpi"),
             self.define_from_variant("CATALYST_WITH_EXTERNAL_CONDUIT", "conduit"),
+            self.define_from_variant("CATALYST_WRAP_FORTRAN", "fortran"),
+            self.define_from_variant("CATALYST_WRAP_PYTHON", "python"),
         ]
 
         return args


### PR DESCRIPTION
Adding two variants 'fortran' and 'python' to enable language wrappings

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
