### PR TITLE
Docs: try using nosearch to deprioritize api docs in search

### DIFF
--- a/lib/spack/docs/Makefile
+++ b/lib/spack/docs/Makefile
@@ -59,6 +59,7 @@ upload:
 apidoc:
 	sphinx-apidoc -f -T -o . ../spack
 	sphinx-apidoc -f -T -o . ../llnl
+        ./nosearch-api-docs  # set :nosearch: at top of each file
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"

--- a/lib/spack/docs/nosearch-api-docs
+++ b/lib/spack/docs/nosearch-api-docs
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Set :nosearch: at top of each api doc file
+for filename in {spack,llnl}.*.rst; do
+    $(echo ":nosearch:"; cat $filename) > $filename
+done


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

We have had requests to separate the API and user docs to improve the usefulness of search on the readthedocs site. This PR uses the `:nosearch:` metadata tag to avoid doing full text search on the files associated with the API docs.

@white238 