### PR TITLE
container: don't map develop to latest

### DIFF
--- a/lib/spack/spack/container/images.json
+++ b/lib/spack/spack/container/images.json
@@ -19,7 +19,6 @@
       },
       "os_package_manager": "dnf",
       "build": "spack/fedora38",
-      "build_tags": {},
       "final": {
         "image": "docker.io/fedora:38"
       }
@@ -31,7 +30,6 @@
       },
       "os_package_manager": "dnf",
       "build": "spack/fedora37",
-      "build_tags": {},
       "final": {
         "image": "docker.io/fedora:37"
       }
@@ -43,7 +41,6 @@
       },
       "os_package_manager": "dnf_epel",
       "build": "spack/rockylinux9",
-      "build_tags": {},
       "final": {
         "image": "docker.io/rockylinux:9"
       }
@@ -55,7 +52,6 @@
       },
       "os_package_manager": "dnf_epel",
       "build": "spack/rockylinux8",
-      "build_tags": {},
       "final": {
         "image": "docker.io/rockylinux:8"
       }
@@ -67,7 +63,6 @@
       },
       "os_package_manager": "dnf_epel",
       "build": "spack/almalinux9",
-      "build_tags": {},
       "final": {
         "image": "quay.io/almalinuxorg/almalinux:9"
       }
@@ -79,7 +74,6 @@
       },
       "os_package_manager": "dnf_epel",
       "build": "spack/almalinux8",
-      "build_tags": {},
       "final": {
         "image": "quay.io/almalinuxorg/almalinux:8"
       }
@@ -91,7 +85,6 @@
       },
       "os_package_manager": "dnf_epel",
       "build": "spack/centos-stream",
-      "build_tags": {},
       "final": {
         "image": "quay.io/centos/centos:stream"
       }
@@ -101,8 +94,7 @@
         "template": "container/centos_7.dockerfile"
       },
       "os_package_manager": "yum",
-      "build": "spack/centos7",
-      "build_tags": {}
+      "build": "spack/centos7"
     },
     "opensuse/leap:15": {
       "bootstrap": {
@@ -110,7 +102,6 @@
       },
       "os_package_manager": "zypper",
       "build": "spack/leap15",
-      "build_tags": {},
       "final": {
         "image": "opensuse/leap:latest"
       }
@@ -130,15 +121,13 @@
         "template": "container/ubuntu_2204.dockerfile"
       },
       "os_package_manager": "apt",
-      "build": "spack/ubuntu-jammy",
-      "build_tags": {}
+      "build": "spack/ubuntu-jammy"
     },
     "ubuntu:20.04": {
       "bootstrap": {
         "template": "container/ubuntu_2004.dockerfile"
       },
       "build": "spack/ubuntu-focal",
-      "build_tags": {},
       "os_package_manager": "apt"
     },
     "ubuntu:18.04": {
@@ -146,8 +135,7 @@
         "template": "container/ubuntu_1804.dockerfile"
       },
       "os_package_manager": "apt",
-      "build": "spack/ubuntu-bionic",
-      "build_tags": {}
+      "build": "spack/ubuntu-bionic"
     }
   },
   "os_package_managers": {

--- a/lib/spack/spack/container/images.json
+++ b/lib/spack/spack/container/images.json
@@ -19,9 +19,7 @@
       },
       "os_package_manager": "dnf",
       "build": "spack/fedora38",
-      "build_tags": {
-        "develop": "latest"
-      },
+      "build_tags": {},
       "final": {
         "image": "docker.io/fedora:38"
       }
@@ -33,9 +31,7 @@
       },
       "os_package_manager": "dnf",
       "build": "spack/fedora37",
-      "build_tags": {
-        "develop": "latest"
-      },
+      "build_tags": {},
       "final": {
         "image": "docker.io/fedora:37"
       }
@@ -47,9 +43,7 @@
       },
       "os_package_manager": "dnf_epel",
       "build": "spack/rockylinux9",
-      "build_tags": {
-        "develop": "latest"
-      },
+      "build_tags": {},
       "final": {
         "image": "docker.io/rockylinux:9"
       }
@@ -61,9 +55,7 @@
       },
       "os_package_manager": "dnf_epel",
       "build": "spack/rockylinux8",
-      "build_tags": {
-        "develop": "latest"
-      },
+      "build_tags": {},
       "final": {
         "image": "docker.io/rockylinux:8"
       }
@@ -75,9 +67,7 @@
       },
       "os_package_manager": "dnf_epel",
       "build": "spack/almalinux9",
-      "build_tags": {
-        "develop": "latest"
-      },
+      "build_tags": {},
       "final": {
         "image": "quay.io/almalinuxorg/almalinux:9"
       }
@@ -89,9 +79,7 @@
       },
       "os_package_manager": "dnf_epel",
       "build": "spack/almalinux8",
-      "build_tags": {
-        "develop": "latest"
-      },
+      "build_tags": {},
       "final": {
         "image": "quay.io/almalinuxorg/almalinux:8"
       }
@@ -103,11 +91,9 @@
       },
       "os_package_manager": "dnf_epel",
       "build": "spack/centos-stream",
+      "build_tags": {},
       "final": {
         "image": "quay.io/centos/centos:stream"
-      },
-      "build_tags": {
-        "develop": "latest"
       }
     },
     "centos:7": {
@@ -116,9 +102,7 @@
       },
       "os_package_manager": "yum",
       "build": "spack/centos7",
-      "build_tags": {
-        "develop": "latest"
-      }
+      "build_tags": {}
     },
     "opensuse/leap:15": {
       "bootstrap": {
@@ -126,9 +110,7 @@
       },
       "os_package_manager": "zypper",
       "build": "spack/leap15",
-      "build_tags": {
-        "develop": "latest"
-      },
+      "build_tags": {},
       "final": {
         "image": "opensuse/leap:latest"
       }
@@ -149,18 +131,14 @@
       },
       "os_package_manager": "apt",
       "build": "spack/ubuntu-jammy",
-      "build_tags": {
-        "develop": "latest"
-      }
+      "build_tags": {}
     },
     "ubuntu:20.04": {
       "bootstrap": {
         "template": "container/ubuntu_2004.dockerfile"
       },
       "build": "spack/ubuntu-focal",
-      "build_tags": {
-        "develop": "latest"
-      },
+      "build_tags": {},
       "os_package_manager": "apt"
     },
     "ubuntu:18.04": {
@@ -169,9 +147,7 @@
       },
       "os_package_manager": "apt",
       "build": "spack/ubuntu-bionic",
-      "build_tags": {
-        "develop": "latest"
-      }
+      "build_tags": {}
     }
   },
   "os_package_managers": {

--- a/lib/spack/spack/container/images.py
+++ b/lib/spack/spack/container/images.py
@@ -50,9 +50,6 @@ def build_info(image, spack_version):
     if not build_image:
         return None, None
 
-    # Translate version from git to docker if necessary
-    build_tag = image_data["build_tags"].get(spack_version, spack_version)
-
     return build_image, build_tag
 
 

--- a/lib/spack/spack/container/images.py
+++ b/lib/spack/spack/container/images.py
@@ -50,7 +50,7 @@ def build_info(image, spack_version):
     if not build_image:
         return None, None
 
-    return build_image, build_tag
+    return build_image, spack_version
 
 
 def os_package_manager_for(image):

--- a/lib/spack/spack/test/container/docker.py
+++ b/lib/spack/spack/test/container/docker.py
@@ -25,7 +25,7 @@ def test_build_and_run_images(minimal_configuration):
 
     # Test the output of the build property
     build = writer.build
-    assert build.image == "spack/ubuntu-bionic:latest"
+    assert build.image == "spack/ubuntu-bionic:develop"
 
 
 def test_packages(minimal_configuration):

--- a/lib/spack/spack/test/container/images.py
+++ b/lib/spack/spack/test/container/images.py
@@ -12,7 +12,7 @@ import spack.container
 @pytest.mark.parametrize(
     "image,spack_version,expected",
     [
-        ("ubuntu:18.04", "develop", ("spack/ubuntu-bionic", "latest")),
+        ("ubuntu:18.04", "develop", ("spack/ubuntu-bionic", "develop")),
         ("ubuntu:18.04", "0.14.0", ("spack/ubuntu-bionic", "0.14.0")),
     ],
 )


### PR DESCRIPTION
As discussed in https://spackpm.slack.com/archives/C016VGW665P/p1709311731659219, `spack containerize` with `spack:container:images:spack:develop` produces a Dockerfile that starts with `FROM spack/ubuntu-jammy:latest as builder`, where `latest` is currently `0.21.1`. This PR removes the mapping from `develop` to `latest`.

I kept the mapping empty, and kept the `build_tags` code in `lib/spack/spack/container/images.py` for possible future mapping purposes.