### PR TITLE
Add handling of custom ssl certs in urllib ops

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -104,7 +104,7 @@ config:
   # This is where custom certs for proxy/firewall are stored.
   # It can be a path or environment variable. To match ssl env configuration
   # the default is the environment variable SSL_CERT_FILE
-  custom_certs: $SSL_CERT_FILE
+  ssl_certs: $SSL_CERT_FILE
 
 
   # Suppress gpg warnings from binary package verification

--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -101,6 +101,12 @@ config:
   verify_ssl: true
 
 
+  # This is where custom certs for proxy/firewall are stored.
+  # It can be a path or environment variable. To match ssl env configuration
+  # the default is the environment variable SSL_CERT_FILE
+  custom_certs: $SSL_CERT_FILE
+
+
   # Suppress gpg warnings from binary package verification
   # Only suppresses warnings, gpg failure will still fail the install
   # Potential rationale to set True: users have already explicitly trusted the

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -146,7 +146,7 @@ tools like ``curl`` will use their ``--insecure`` options.  Disabling
 this can expose you to attacks.  Use at your own risk.
 
 --------------------
-``custom_certs``
+``ssl_certs``
 --------------------
 
 Path to custom certificats for SSL verification. The value can be a 

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -154,6 +154,12 @@ filesytem path, or an environment variable that expands to a file path.
 The default value is set to the environment variable ``SSL_CERT_FILE``
 to use the same syntax used by many other applications that automatically
 detect custom certificates.
+When ``url_fetch_method:curl`` the ``config:ssl_certs`` should resolve to
+a single file.  Spack will then set the environment variable ``CURL_CA_BUNDLE``
+in the subprocess calling ``curl``.
+If ``url_fetch_method:urllib`` then files and directories are supported i.e. 
+``config:ssl_certs:$SSL_CERT_FILE`` or ``config:ssl_certs:$SSL_CERT_DIR``
+will work.
 
 --------------------
 ``checksum``

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -146,6 +146,16 @@ tools like ``curl`` will use their ``--insecure`` options.  Disabling
 this can expose you to attacks.  Use at your own risk.
 
 --------------------
+``custom_certs``
+--------------------
+
+Path to custom certificats for SSL verification. The value can be a 
+filesytem path, or an environment variable that expands to a file path.
+The default value is set to the environment variable ``SSL_CERT_FILE``
+to use the same syntax used by many other applications that automatically
+detect custom certificates.
+
+--------------------
 ``checksum``
 --------------------
 

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -27,7 +27,7 @@ import spack.util.git
 from spack.error import SpackError
 from spack.util.crypto import checksum
 from spack.util.log_parse import parse_log_events
-from spack.util.web import ssl_cert_handler
+from spack.util.web import urllib_ssl_cert_handler
 
 from .base import Reporter
 from .extract import extract_test_parts
@@ -428,7 +428,7 @@ class CDash(Reporter):
         # Compute md5 checksum for the contents of this file.
         md5sum = checksum(hashlib.md5, filename, block_size=8192)
 
-        opener = build_opener(HTTPSHandler(context=ssl_cert_handler()))
+        opener = build_opener(HTTPSHandler(context=urllib_ssl_cert_handler()))
         with open(filename, "rb") as f:
             params_dict = {
                 "build": self.buildname,

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -14,7 +14,7 @@ import time
 import xml.sax.saxutils
 from typing import Dict, Optional
 from urllib.parse import urlencode
-from urllib.request import HTTPHandler, Request, build_opener
+from urllib.request import HTTPSHandler, Request, build_opener
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import working_dir
@@ -27,6 +27,7 @@ import spack.util.git
 from spack.error import SpackError
 from spack.util.crypto import checksum
 from spack.util.log_parse import parse_log_events
+from spack.util.web import ssl_context
 
 from .base import Reporter
 from .extract import extract_test_parts
@@ -427,7 +428,7 @@ class CDash(Reporter):
         # Compute md5 checksum for the contents of this file.
         md5sum = checksum(hashlib.md5, filename, block_size=8192)
 
-        opener = build_opener(HTTPHandler)
+        opener = build_opener(HTTPSHandler(context=ssl_context()))
         with open(filename, "rb") as f:
             params_dict = {
                 "build": self.buildname,

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -27,7 +27,7 @@ import spack.util.git
 from spack.error import SpackError
 from spack.util.crypto import checksum
 from spack.util.log_parse import parse_log_events
-from spack.util.web import ssl_context
+from spack.util.web import ssl_cert_handler
 
 from .base import Reporter
 from .extract import extract_test_parts
@@ -428,7 +428,7 @@ class CDash(Reporter):
         # Compute md5 checksum for the contents of this file.
         md5sum = checksum(hashlib.md5, filename, block_size=8192)
 
-        opener = build_opener(HTTPSHandler(context=ssl_context()))
+        opener = build_opener(HTTPSHandler(context=ssl_cert_handler()))
         with open(filename, "rb") as f:
             params_dict = {
                 "build": self.buildname,

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -72,7 +72,7 @@ properties: Dict[str, Any] = {
             "environments_root": {"type": "string"},
             "connect_timeout": {"type": "integer", "minimum": 0},
             "verify_ssl": {"type": "boolean"},
-            "custom_certs": {"type": "string"},
+            "ssl_certs": {"type": "string"},
             "suppress_gpg_warnings": {"type": "boolean"},
             "install_missing_compilers": {"type": "boolean"},
             "debug": {"type": "boolean"},

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -72,6 +72,7 @@ properties: Dict[str, Any] = {
             "environments_root": {"type": "string"},
             "connect_timeout": {"type": "integer", "minimum": 0},
             "verify_ssl": {"type": "boolean"},
+            "custom_certs": {"type": "string"},
             "suppress_gpg_warnings": {"type": "boolean"},
             "install_missing_compilers": {"type": "boolean"},
             "debug": {"type": "boolean"},

--- a/lib/spack/spack/test/data/config/config.yaml
+++ b/lib/spack/spack/test/data/config/config.yaml
@@ -10,7 +10,7 @@ config:
   source_cache: $user_cache_path/source
   misc_cache: $user_cache_path/cache
   verify_ssl: true
-  custom_certs: $SSL_CERT_FILE
+  ssl_certs: $SSL_CERT_FILE
   checksum: true
   dirty: false
   concretizer: {0}

--- a/lib/spack/spack/test/data/config/config.yaml
+++ b/lib/spack/spack/test/data/config/config.yaml
@@ -10,6 +10,7 @@ config:
   source_cache: $user_cache_path/source
   misc_cache: $user_cache_path/cache
   verify_ssl: true
+  custom_certs: $SSL_CERT_FILE
   checksum: true
   dirty: false
   concretizer: {0}

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -106,6 +106,11 @@ def append_curl_env_for_ssl_certs(curl):
                 "CURL_CA_BUNDLE".format(certs)
             )
             curl.add_default_env("CURL_CA_BUNDLE", certs)
+        elif os.path.isdir(certs):
+            tty.warn(
+                "CURL config:ssl_certs"
+                " is a directory but cURL only supports files. Default certs will be used instead."
+            )
         else:
             tty.debug(
                 "CURL config:ssl_certs "

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -60,22 +60,73 @@ class SpackHTTPDefaultErrorHandler(urllib.request.HTTPDefaultErrorHandler):
         raise DetailedHTTPError(req, code, msg, hdrs, fp)
 
 
-def ssl_cert_handler():
+dbg_msg_no_ssl_cert_config = "config:ssl_certs not in configuration. Default cert configuation and environment will be used."
+
+
+def urllib_ssl_cert_handler():
     """context for configuring ssl during urllib HTTPS operations"""
-    custom_cert_var = spack.config.get("config:custom_certs")
+    custom_cert_var = spack.config.get("config:ssl_certs")
     if custom_cert_var:
         # custom certs will be a location, so expand env variables, paths etc
         certs = spack.util.path.canonicalize_path(custom_cert_var)
         tty.debug("Looking for custom SSL certs")
         if os.path.isfile(certs):
-            tty.debug("Custom SSL certs found at {}".format(certs))
+            tty.debug("Custom SSL certs file found at {}".format(certs))
             return ssl.create_default_context(cafile=certs)
+        elif os.path.isdir(certs):
+            tty.debug("Custom SSL certs directory found at {}".format(certs))
+            return ssl.create_default_context(capath=certs)
         else:
             tty.debug("Custom SSL certs not found")
             return ssl.create_default_context()
     else:
-        tty.debug("config:custom_certs not in configuration. Default certs will be used.")
+        tty.debug(dbg_msg_no_ssl_cert_config)
         return ssl.create_default_context()
+
+
+# curl requires different strategies for custom certs at runtime depending on if certs
+# are stored as a file or a directory
+def append_curl_env_for_ssl_cert_dir(curl):
+    """
+    configure curl to use custom certs in a directory at run time
+    see: https://curl.se/docs/sslcerts.html item 4
+    """
+    custom_cert_var = spack.config.get("config:ssl_certs")
+    if custom_cert_var:
+        tty.debug("Looking for custom SSL certs")
+        # custom certs will be a location, so expand env variables, paths etc
+        certs = spack.util.path.canonicalize_path(custom_cert_var)
+        if os.path.isdir(certs):
+            tty.debug(
+                "Configuring curl to use custome certs from {} by setting CURL_CA_BUNDLE".format(
+                    certs
+                )
+            )
+            curl.add_default_env("CURL_CA_BUNDLE", certs)
+        else:
+            tty.debug(dbg_msg_no_ssl_cert_config)
+    tty.debug(dbg_msg_no_ssl_cert_config)
+
+
+def curl_runtime_flag_for_ssl_file():
+    """
+    configure curl to use custom certs from a file at run time
+    see: https://curl.se/docs/sslcerts.html item 2
+    """
+    custom_cert_var = spack.config.get("config:ssl_certs")
+    if custom_cert_var:
+        # custom certs will be a location, so expand env variables, paths etc
+        certs = spack.util.path.canonicalize_path(custom_cert_var)
+        tty.debug("Looking for custom SSL certs")
+        if os.path.isfile(certs):
+            tty.debug("Custom SSL certs file found at {}".format(certs))
+            return ["--cafile", certs]
+        else:
+            tty.debug("config:ssl_certs does not resolve to a file for curl execution")
+            return None
+    else:
+        tty.debug(dbg_msg_no_ssl_cert_config)
+        return None
 
 
 def _urlopen():
@@ -84,7 +135,9 @@ def _urlopen():
     error_handler = SpackHTTPDefaultErrorHandler()
 
     # One opener with HTTPS ssl enabled
-    with_ssl = build_opener(s3, gcs, HTTPSHandler(context=ssl_cert_handler()), error_handler)
+    with_ssl = build_opener(
+        s3, gcs, HTTPSHandler(context=urllib_ssl_cert_handler()), error_handler
+    )
 
     # One opener with HTTPS ssl disabled
     without_ssl = build_opener(
@@ -240,6 +293,7 @@ def base_curl_fetch_args(url, timeout=0):
 
         * config:connect_timeout (int): connection timeout
         * config:verify_ssl (str): Perform SSL verification
+        * config:ssl_certs (str): If this resolve to a valid file append to curl call
 
     Arguments:
         url (str): URL whose contents will be fetched
@@ -257,6 +311,10 @@ def base_curl_fetch_args(url, timeout=0):
     ]
     if not spack.config.get("config:verify_ssl"):
         curl_args.append("-k")
+
+    ssl_cert_flags = curl_runtime_flag_for_ssl_file()
+    if ssl_cert_flags:
+        curl_args.extend(ssl_cert_flags)
 
     if sys.stdout.isatty() and tty.msg_enabled():
         curl_args.append("-#")  # status bar when using a tty
@@ -306,6 +364,7 @@ def _curl(curl=None):
         except CommandNotFoundError as exc:
             tty.error(str(exc))
             raise spack.error.FetchError("Missing required curl fetch method")
+    append_curl_env_for_ssl_cert_dir(curl)
     return curl
 
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -60,7 +60,10 @@ class SpackHTTPDefaultErrorHandler(urllib.request.HTTPDefaultErrorHandler):
         raise DetailedHTTPError(req, code, msg, hdrs, fp)
 
 
-dbg_msg_no_ssl_cert_config = "config:ssl_certs not in configuration. Default cert configuation and environment will be used."
+dbg_msg_no_ssl_cert_config = (
+    "config:ssl_certs not in configuration. "
+    "Default cert configuation and environment will be used."
+)
 
 
 def urllib_ssl_cert_handler():
@@ -98,16 +101,15 @@ def append_curl_env_for_ssl_certs(curl):
         tty.debug("CURL: Looking for custom SSL certs file at {}".format(certs))
         if os.path.isfile(certs):
             tty.debug(
-                "CURL: Configuring curl to use custome certs from {} by setting CURL_CA_BUNDLE".format(
-                    certs
-                )
+                "CURL: Configuring curl to use custom"
+                " certs from {} by setting "
+                "CURL_CA_BUNDLE".format(certs)
             )
             curl.add_default_env("CURL_CA_BUNDLE", certs)
         else:
             tty.debug(
-                "CURL config:ssl_certs resolves to {}. This is not a file so default certs will be used.".format(
-                    certs
-                )
+                "CURL config:ssl_certs "
+                "resolves to {}. This is not a file so default certs will be used.".format(certs)
             )
     tty.debug(dbg_msg_no_ssl_cert_config)
     return curl

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -27,8 +27,8 @@ from llnl.util.filesystem import mkdirp, rename, working_dir
 
 import spack.config
 import spack.error
-import spack.util.url as url_util
 import spack.util.path
+import spack.util.url as url_util
 
 from .executable import CommandNotFoundError, which
 from .gcs import GCSBlob, GCSBucket, GCSHandler
@@ -59,6 +59,7 @@ class SpackHTTPDefaultErrorHandler(urllib.request.HTTPDefaultErrorHandler):
     def http_error_default(self, req, fp, code, msg, hdrs):
         raise DetailedHTTPError(req, code, msg, hdrs, fp)
 
+
 def ssl_context():
     """context for configuring ssl during urllib HTTPS operations"""
     # custom certs will be a location, so expand env variables, paths etc
@@ -68,15 +69,14 @@ def ssl_context():
     else:
         return ssl.create_default_context()
 
+
 def _urlopen():
     s3 = UrllibS3Handler()
     gcs = GCSHandler()
     error_handler = SpackHTTPDefaultErrorHandler()
 
     # One opener with HTTPS ssl enabled
-    with_ssl = build_opener(
-        s3, gcs, HTTPSHandler(context=ssl_context()), error_handler
-    )
+    with_ssl = build_opener(s3, gcs, HTTPSHandler(context=ssl_context()), error_handler)
 
     # One opener with HTTPS ssl disabled
     without_ssl = build_opener(

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -64,9 +64,12 @@ def ssl_context():
     """context for configuring ssl during urllib HTTPS operations"""
     # custom certs will be a location, so expand env variables, paths etc
     certs = spack.util.path.substitute_path_variables(spack.config.get("config:custom_certs"))
+    tty.debug("Looking for custom SSL certs")
     if os.path.isfile(certs):
+        tty.debug("Custom SSL certs found at {}".format(certs))
         return ssl.create_default_context(cafile=certs)
     else:
+        tty.debug("Custom SSL certs not found")
         return ssl.create_default_context()
 
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -67,7 +67,6 @@ def ssl_context():
     if os.path.isfile(certs):
         return ssl.create_default_context(cafile=certs)
     else:
-        tty.die("Failed to find certs")
         return ssl.create_default_context()
 
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -63,10 +63,11 @@ class SpackHTTPDefaultErrorHandler(urllib.request.HTTPDefaultErrorHandler):
 def ssl_context():
     """context for configuring ssl during urllib HTTPS operations"""
     # custom certs will be a location, so expand env variables, paths etc
-    certs = spack.util.path.canonicalize_path(spack.config.get("config:custom_certs"))
+    certs = spack.util.path.substitute_path_variables(spack.config.get("config:custom_certs"))
     if os.path.isfile(certs):
         return ssl.create_default_context(cafile=certs)
     else:
+        tty.die("Failed to find certs")
         return ssl.create_default_context()
 
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -28,6 +28,7 @@ from llnl.util.filesystem import mkdirp, rename, working_dir
 import spack.config
 import spack.error
 import spack.util.url as url_util
+import spack.util.path
 
 from .executable import CommandNotFoundError, which
 from .gcs import GCSBlob, GCSBucket, GCSHandler
@@ -58,6 +59,14 @@ class SpackHTTPDefaultErrorHandler(urllib.request.HTTPDefaultErrorHandler):
     def http_error_default(self, req, fp, code, msg, hdrs):
         raise DetailedHTTPError(req, code, msg, hdrs, fp)
 
+def ssl_context():
+    """context for configuring ssl during urllib HTTPS operations"""
+    # custom certs will be a location, so expand env variables, paths etc
+    certs = spack.util.path.canonicalize_path(spack.config.get("config:custom_certs"))
+    if os.path.isfile(certs):
+        return ssl.create_default_context(cafile=certs)
+    else:
+        return ssl.create_default_context()
 
 def _urlopen():
     s3 = UrllibS3Handler()
@@ -66,7 +75,7 @@ def _urlopen():
 
     # One opener with HTTPS ssl enabled
     with_ssl = build_opener(
-        s3, gcs, HTTPSHandler(context=ssl.create_default_context()), error_handler
+        s3, gcs, HTTPSHandler(context=ssl_context()), error_handler
     )
 
     # One opener with HTTPS ssl disabled

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -63,7 +63,7 @@ class SpackHTTPDefaultErrorHandler(urllib.request.HTTPDefaultErrorHandler):
 def ssl_context():
     """context for configuring ssl during urllib HTTPS operations"""
     # custom certs will be a location, so expand env variables, paths etc
-    certs = spack.util.path.substitute_path_variables(spack.config.get("config:custom_certs"))
+    certs = spack.util.path.canonicalize_path(spack.config.get("config:custom_certs"))
     tty.debug("Looking for custom SSL certs")
     if os.path.isfile(certs):
         tty.debug("Custom SSL certs found at {}".format(certs))


### PR DESCRIPTION
This PR allows the user to specify a path to a custom cert file (or directory) in Spack's config:

```yaml
  # This is where custom certs for proxy/firewall are stored.
  # It can be a path or environment variable. To match ssl env configuration
  # the default is the environment variable SSL_CERT_FILE
  ssl_certs: $SSL_CERT_FILE
```

`config:ssl_certs` can be a path to a file or a directory, or it can be and environment variable that resolves to one of those. When it posts to something valid, Spack will update the ssl context to include custom certs, and fetching via `urllib` and `curl` will trust the provided certs.

This should resolve many issues with fetching behind corporate firewalls.

Thanks to @btklein1 for showing me how to do this.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
