### PR TITLE
perl-chi and deps: new packages 

### DIFF
--- a/var/spack/repos/builtin/packages/perl-cache-cache/package.py
+++ b/var/spack/repos/builtin/packages/perl-cache-cache/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlCacheCache(PerlPackage):
+    """Extends Cache::SizeAwareMemoryCache"""
+
+    homepage = "https://metacpan.org/pod/Cache::Cache"
+    url = "https://cpan.metacpan.org/authors/id/R/RJ/RJBS/Cache-Cache-1.08.tar.gz"
+
+    maintainers("EbiArnie")
+
+    version("1.08", sha256="d2c7fd5dba5dd010b7d8923516890bb6ccf6b5f188ccb69f35cb0fd6c031d1e8")
+
+    depends_on("perl-digest-sha1@2.02:", type=("build", "run", "test"))
+    depends_on("perl-error@0.15:", type=("build", "run", "test"))
+    depends_on("perl-ipc-sharelite@0.09:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Cache::Cache; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-cache-cache/package.py
+++ b/var/spack/repos/builtin/packages/perl-cache-cache/package.py
@@ -14,6 +14,8 @@ class PerlCacheCache(PerlPackage):
 
     maintainers("EbiArnie")
 
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
     version("1.08", sha256="d2c7fd5dba5dd010b7d8923516890bb6ccf6b5f188ccb69f35cb0fd6c031d1e8")
 
     depends_on("perl-digest-sha1@2.02:", type=("build", "run", "test"))

--- a/var/spack/repos/builtin/packages/perl-chi/package.py
+++ b/var/spack/repos/builtin/packages/perl-chi/package.py
@@ -1,0 +1,51 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlChi(PerlPackage):
+    """Unified cache handling interface"""
+
+    homepage = "https://metacpan.org/pod/CHI"
+    url = "https://cpan.metacpan.org/authors/id/A/AS/ASB/CHI-0.61.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.61", sha256="583545c9e5312bb4193ab16de9f55ff8f4b4a7ded128cee8dd2cb021d4678b5b")
+
+    depends_on("perl-cache-cache", type=("build", "test"))
+    depends_on("perl-carp-assert@0.20:", type=("build", "run", "test"))
+    depends_on("perl-class-load", type=("build", "run", "test"))
+    depends_on("perl-data-uuid", type=("build", "run", "test"))
+    depends_on("perl-digest-jhash", type=("build", "run", "test"))
+    depends_on("perl-hash-moreutils", type=("build", "run", "test"))
+    depends_on("perl-json-maybexs@1.003003:", type=("build", "run", "test"))
+    depends_on("perl-list-moreutils@0.13:", type=("build", "run", "test"))
+    depends_on("perl-log-any@0.08:", type=("build", "run", "test"))
+    depends_on("perl-module-mask", type=("build", "test"))
+    depends_on("perl-moo@1.003:", type=("build", "run", "test"))
+    depends_on("perl-moox-types-mooselike@0.23:", type=("build", "run", "test"))
+    depends_on("perl-moox-types-mooselike-numeric", type=("build", "run", "test"))
+    depends_on("perl-string-rewriteprefix", type=("build", "run", "test"))
+    depends_on("perl-task-weaken", type=("build", "run", "test"))
+    depends_on("perl-test-class", type=("build", "test"))
+    depends_on("perl-test-deep", type=("build", "test"))
+    depends_on("perl-test-exception", type=("build", "test"))
+    depends_on("perl-test-warn", type=("build", "test"))
+    depends_on("perl-time-duration@1.06:", type=("build", "run", "test"))
+    depends_on("perl-time-duration-parse@0.03:", type=("build", "run", "test"))
+    depends_on("perl-timedate", type=("build", "test"))
+    depends_on("perl-try-tiny@0.05:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use CHI; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-data-uuid/package.py
+++ b/var/spack/repos/builtin/packages/perl-data-uuid/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlDataUuid(PerlPackage):
+    """Globally/Universally Unique Identifiers (GUIDs/UUIDs)"""
+
+    homepage = "https://metacpan.org/pod/Data::UUID"
+    url = "https://cpan.metacpan.org/authors/id/R/RJ/RJBS/Data-UUID-1.226.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("BSD")
+
+    version("1.226", sha256="093d57ffa0d411a94bafafae495697db26f5c9d0277198fe3f7cf2be22996453")
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Data::UUID; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-digest-jhash/package.py
+++ b/var/spack/repos/builtin/packages/perl-digest-jhash/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlDigestJhash(PerlPackage):
+    """Perl extension for 32 bit Jenkins Hashing Algorithm"""
+
+    homepage = "https://metacpan.org/pod/Digest::JHash"
+    url = "https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF/Digest-JHash-0.10.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-2.0")
+
+    version("0.10", sha256="c746cf0a861a004090263cd54d7728d0c7595a0cf90cbbfd8409b396ee3b0063")
+
+    depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Digest::JHash; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-digest-sha1/package.py
+++ b/var/spack/repos/builtin/packages/perl-digest-sha1/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlDigestSha1(PerlPackage):
+    """Perl interface to the SHA-1 algorithm"""
+
+    homepage = "https://metacpan.org/pod/Digest::SHA1"
+    url = "https://cpan.metacpan.org/authors/id/G/GA/GAAS/Digest-SHA1-2.13.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("2.13", sha256="68c1dac2187421f0eb7abf71452a06f190181b8fc4b28ededf5b90296fb943cc")
+
+    depends_on("perl@5.4.0:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Digest::SHA1; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-hash-moreutils/package.py
+++ b/var/spack/repos/builtin/packages/perl-hash-moreutils/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlHashMoreutils(PerlPackage):
+    """Provide the stuff missing in Hash::Util"""
+
+    homepage = "https://metacpan.org/pod/Hash::MoreUtils"
+    url = "https://cpan.metacpan.org/authors/id/R/RE/REHSACK/Hash-MoreUtils-0.06.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.06", sha256="db9a8fb867d50753c380889a5e54075651b5e08c9b3b721cb7220c0883547de8")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Hash::MoreUtils; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-ipc-sharelite/package.py
+++ b/var/spack/repos/builtin/packages/perl-ipc-sharelite/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlIpcSharelite(PerlPackage):
+    """Lightweight interface to shared memory"""
+
+    homepage = "https://metacpan.org/pod/IPC::ShareLite"
+    url = "https://cpan.metacpan.org/authors/id/A/AN/ANDYA/IPC-ShareLite-0.17.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.17", sha256="14d406b91da96d6521d0d1a82d22a306274765226b86b0a56e7ffddcf96ae7bf")
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use IPC::ShareLite; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-module-mask/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-mask/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlModuleMask(PerlPackage):
+    """Pretend certain modules are not installed"""
+
+    homepage = "https://metacpan.org/pod/Module::Mask"
+    url = "https://cpan.metacpan.org/authors/id/M/MA/MATTLAW/Module-Mask-0.06.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.06", sha256="2d73f81ff21c9fa28102791e546ff257164b3025f7832544c8223fb87c1e7e77")
+
+    depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-module-util@1.00:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Module::Mask; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-module-util/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-util/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlModuleUtil(PerlPackage):
+    """Module name tools and transformations"""
+
+    homepage = "https://metacpan.org/pod/Module::Util"
+    url = "https://cpan.metacpan.org/authors/id/M/MA/MATTLAW/Module-Util-1.09.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.09", sha256="6cfbcb6a45064446ec8aa0ee1a7dddc420b54469303344187aef84d2c7f3e2c6")
+
+    depends_on("perl@5.5.3:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Module::Util; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-moox-types-mooselike-numeric/package.py
+++ b/var/spack/repos/builtin/packages/perl-moox-types-mooselike-numeric/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlMooxTypesMooselikeNumeric(PerlPackage):
+    """Moo types for numbers"""
+
+    homepage = "https://metacpan.org/pod/MooX::Types::MooseLike::Numeric"
+    url = (
+        "https://cpan.metacpan.org/authors/id/M/MA/MATEU/MooX-Types-MooseLike-Numeric-1.03.tar.gz"
+    )
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.03", sha256="16adeb617b963d010179922c2e4e8762df77c75232e17320b459868c4970c44b")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-moo@1.004002:", type=("build", "link"))
+    depends_on("perl-moox-types-mooselike@0.23:", type=("build", "run", "test"))
+    depends_on("perl-test-fatal@0.003:", type=("build", "link"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use MooX::Types::MooseLike::Numeric; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-class/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-class/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTestClass(PerlPackage):
+    """Easily create test classes in an xUnit/JUnit style"""
+
+    homepage = "https://metacpan.org/pod/Test::Class"
+    url = "https://cpan.metacpan.org/authors/id/S/SZ/SZABGAB/Test-Class-0.52.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.52", sha256="40c1b1d388f0a8674769c27529f0cc3634ca0fd9d8f72b196c0531611934bc82")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-module-runtime", type=("build", "run", "test"))
+    depends_on("perl-mro-compat@0.11:", type=("build", "run", "test"))
+    depends_on("perl-test-exception@0.25:", type=("build", "test"))
+    depends_on("perl-try-tiny", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Test::Class; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-time-duration-parse/package.py
+++ b/var/spack/repos/builtin/packages/perl-time-duration-parse/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTimeDurationParse(PerlPackage):
+    """Parse string that represents time duration"""
+
+    homepage = "https://metacpan.org/pod/Time::Duration::Parse"
+    url = "https://cpan.metacpan.org/authors/id/N/NE/NEILB/Time-Duration-Parse-0.16.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.16", sha256="1084a6463ee2790f99215bd76b135ca45afe2bfa6998fa6fd5470b69e1babc12")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-time-duration", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Time::Duration::Parse; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-time-duration/package.py
+++ b/var/spack/repos/builtin/packages/perl-time-duration/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTimeDuration(PerlPackage):
+    """Rounded or exact English expression of durations"""
+
+    homepage = "https://metacpan.org/pod/Time::Duration"
+    url = "https://cpan.metacpan.org/authors/id/N/NE/NEILB/Time-Duration-1.21.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.21", sha256="fe340eba8765f9263694674e5dff14833443e19865e5ff427bbd79b7b5f8a9b8")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Time::Duration; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
Adds CHI and its deps:
- Module::Mask
- Data::UUID
- Time::Duration
- Hash::MoreUtils
- Cache::Cache
- Time::Duration::Parse
- Digest::JHash
- Test::Class
- MooX::Types::MooseLike::Numeric
- Module::Util
- Digest::SHA1
- IPC::ShareLite        
