### PR TITLE
perl-catalyst-action-renderview and deps: new packages

### DIFF
--- a/var/spack/repos/builtin/packages/perl-catalyst-action-renderview/package.py
+++ b/var/spack/repos/builtin/packages/perl-catalyst-action-renderview/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlCatalystActionRenderview(PerlPackage):
+    """Sensible default end action."""
+
+    homepage = "https://metacpan.org/pod/Catalyst::Action::RenderView"
+    url = (
+        "https://cpan.metacpan.org/authors/id/B/BO/BOBTFISH/Catalyst-Action-RenderView-0.16.tar.gz"
+    )
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.16", sha256="8565203950a057d43ecd64e9593715d565c2fbd8b02c91f43c53b2111acd3948")
+
+    depends_on("perl-catalyst-runtime@5.80030:", type=("build", "run", "test"))
+    depends_on("perl-data-visitor@0.24:", type=("build", "run", "test"))
+    depends_on("perl-http-request-ascgi", type=("build", "link"))
+    depends_on("perl-mro-compat", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Catalyst::Action::RenderView; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-data-visitor/package.py
+++ b/var/spack/repos/builtin/packages/perl-data-visitor/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlDataVisitor(PerlPackage):
+    """Visitor style traversal of Perl data structures"""
+
+    homepage = "https://metacpan.org/pod/Data::Visitor"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Data-Visitor-0.32.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.32", sha256="b194290f257cc6275a039374111554c666a1650e4c01ad799c1e0a277f47917d")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-moose@0.89:", type=("build", "run", "test"))
+    depends_on("perl-namespace-clean@0.19:", type=("build", "run", "test"))
+    depends_on("perl-test-needs", type=("build", "test"))
+    depends_on("perl-tie-toobject@0.01:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Data::Visitor; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-http-request-ascgi/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-request-ascgi/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlHttpRequestAscgi(PerlPackage):
+    """Set up a CGI environment from an HTTP::Request"""
+
+    homepage = "https://metacpan.org/pod/HTTP::Request::AsCGI"
+    url = "https://cpan.metacpan.org/authors/id/F/FL/FLORA/HTTP-Request-AsCGI-1.2.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.2", sha256="945bfb07c6d1af52773fb7845ba62e3a74111b35cbd2d5e43ef8319e55acbcea")
+
+    depends_on("perl-class-accessor", type=("build", "run", "test"))
+    depends_on("perl-http-message", type=("build", "run", "test"))
+    depends_on("perl-uri", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use HTTP::Request::AsCGI; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-tie-toobject/package.py
+++ b/var/spack/repos/builtin/packages/perl-tie-toobject/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTieToobject(PerlPackage):
+    """Tie to an existing object."""
+
+    homepage = "https://metacpan.org/pod/Tie::ToObject"
+    url = "https://cpan.metacpan.org/authors/id/N/NU/NUFFIN/Tie-ToObject-0.03.tar.gz"
+
+    maintainers("EbiArnie")
+
+    version("0.03", sha256="a31a0d4430fe14f59622f31db7f25b2275dad2ec52f1040beb030d3e83ad3af4")
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Tie::ToObject; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
Adds Catalyst::Action::RenderView and its dependencies. Installed OK with build-time tests. Added dependencies:
- Data::Visitor
- HTTP::Request::AsCGI
- Tie::ToObject
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
