### PR TITLE
perl-catalyst-component-instancepercontext: new package

### DIFF
--- a/var/spack/repos/builtin/packages/perl-catalyst-component-instancepercontext/package.py
+++ b/var/spack/repos/builtin/packages/perl-catalyst-component-instancepercontext/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlCatalystComponentInstancepercontext(PerlPackage):
+    """Moose role to create only one instance of component per context"""
+
+    homepage = "https://metacpan.org/pod/Catalyst::Component::InstancePerContext"
+    url = "https://cpan.metacpan.org/authors/id/G/GR/GRODITI/Catalyst-Component-InstancePerContext-0.001001.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.001001", sha256="7f63f930e1e613f15955c9e6d73873675c50c0a3bc2a61a034733361ed26d271")
+
+    depends_on("perl-catalyst-runtime", type=("build", "run", "test"))
+    depends_on("perl-moose", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Catalyst::Component::InstancePerContext; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
Adds Catalyst::Component::InstancePerContext

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
