### PR TITLE
perl-log-dispatch-filerotate and dep: new package

### DIFF
--- a/var/spack/repos/builtin/packages/perl-log-dispatch-filerotate/package.py
+++ b/var/spack/repos/builtin/packages/perl-log-dispatch-filerotate/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlLogDispatchFilerotate(PerlPackage):
+    """Log to Files that Archive/Rotate Themselves"""
+
+    homepage = "https://metacpan.org/pod/Log::Dispatch::FileRotate"
+    url = "https://cpan.metacpan.org/authors/id/M/MS/MSCHOUT/Log-Dispatch-FileRotate-1.38.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.38", sha256="b55d6cede3f0a06426488fbfa554f4561320b014c1023893ced29508e5bce4ec")
+
+    depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-date-manip", type=("build", "run", "test"))
+    depends_on("perl-log-dispatch@2.60:", type=("build", "run", "test"))
+    depends_on("perl-sub-uplevel", type=("build", "run", "test"))
+    depends_on("perl-path-tiny@0.018:", type=("build", "test"))
+    depends_on("perl-test-warn", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Log::Dispatch::FileRotate; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-log-dispatch/package.py
+++ b/var/spack/repos/builtin/packages/perl-log-dispatch/package.py
@@ -1,0 +1,39 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlLogDispatch(PerlPackage):
+    """Dispatches messages to one or more outputs"""
+
+    homepage = "https://metacpan.org/pod/Log::Dispatch"
+    url = "https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/Log-Dispatch-2.71.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-2.0")
+
+    version("2.71", sha256="9d60d9648c35ce2754731eb4deb7f05809ece1bd633b74d74795aed9ec732570")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-devel-globaldestruction", type=("build", "run", "test"))
+    depends_on("perl-dist-checkconflicts@0.02:", type=("build", "run", "test"))
+    depends_on("perl-ipc-run3", type=("build", "test"))
+    depends_on("perl-module-runtime", type=("build", "run", "test"))
+    depends_on("perl-namespace-autoclean", type=("build", "run", "test"))
+    depends_on("perl-params-validationcompiler", type=("build", "run", "test"))
+    depends_on("perl-specio@0.32:", type=("build", "run", "test"))
+    depends_on("perl-test-fatal", type=("build", "test"))
+    depends_on("perl-test-needs", type=("build", "test"))
+    depends_on("perl-try-tiny", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Log::Dispatch; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
Adds Log::Dispatch::FileRotate and its dependency:
- Log::Dispatch

Installed OK, build-time tests ran successfully.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
