### PR TITLE
apple-clang: inject llvm-openmp dependency

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -68,6 +68,9 @@ TransformFunction = Callable[["spack.spec.Spec", List[AspFunction]], List[AspFun
 #: Enable the addition of a runtime node
 WITH_RUNTIME = sys.platform != "win32"
 
+#: Package placeholder for global rules
+PACKAGE_PLACEHOLDER = "XXX"
+
 #: Data class that contain configuration on what a
 #: clingo solve should output.
 #:
@@ -1731,7 +1734,7 @@ class SpackSolverSetup:
                     continue
 
                 # validate variant value only if spec not concrete
-                if not spec.concrete:
+                if not spec.concrete and spec.name != PACKAGE_PLACEHOLDER:
                     reserved_names = spack.directives.reserved_names
                     if not spec.virtual and vname not in reserved_names:
                         pkg_cls = self.pkg_class(spec.name)
@@ -2913,16 +2916,15 @@ class RuntimePropertyRecorder:
         if dependency_spec.versions != vn.any_version:
             self._setup.version_constraints.add((dependency_spec.name, dependency_spec.versions))
 
-        placeholder = "XXX"
         node_variable = "node(ID, Package)"
-        when_spec.name = placeholder
+        when_spec.name = PACKAGE_PLACEHOLDER
 
         body_clauses = self._setup.spec_clauses(when_spec, body=True)
         body_str = (
             f"  {f',{os.linesep}  '.join(str(x) for x in body_clauses)},\n"
             f"  not external({node_variable}),\n"
             f"  not runtime(Package)"
-        ).replace(f'"{placeholder}"', f"{node_variable}")
+        ).replace(f'"{PACKAGE_PLACEHOLDER}"', f"{node_variable}")
         if languages:
             body_str += ",\n"
             for language in languages:

--- a/var/spack/repos/builtin/packages/apcomp/package.py
+++ b/var/spack/repos/builtin/packages/apcomp/package.py
@@ -50,7 +50,6 @@ class Apcomp(Package):
 
     depends_on("cmake@3.9:", type="build")
     depends_on("mpi", when="+mpi")
-    depends_on("llvm-openmp", when="+openmp %apple-clang")
 
     root_cmakelists_dir = "src"
 

--- a/var/spack/repos/builtin/packages/apple-clang/package.py
+++ b/var/spack/repos/builtin/packages/apple-clang/package.py
@@ -74,3 +74,23 @@ class AppleClang(BundlePackage):
         msg = "apple-clang is expected to be an external spec"
         assert self.spec.concrete and self.spec.external, msg
         return self.spec.extra_attributes["compilers"].get("cxx", None)
+
+    @classmethod
+    def runtime_constraints(cls, *, spec, pkg):
+        """Callback function to inject runtime-related rules into the solver.
+
+        Rule-injection is obtained through method calls of the ``pkg`` argument.
+
+        Documentation for this function is temporary. When the API will be in its final state,
+        we'll document the behavior at https://spack.readthedocs.io/en/latest/
+
+        Args:
+            compiler: compiler object (node attribute) currently considered
+            pkg: object used to forward information to the solver
+        """
+        pkg("*").depends_on(
+            "llvm-openmp",
+            when="+openmp %apple-clang ",
+            type="link",
+            description="If any package uses %apple-clang +openmp, it depends on llvm-openmp",
+        )

--- a/var/spack/repos/builtin/packages/blaspp/package.py
+++ b/var/spack/repos/builtin/packages/blaspp/package.py
@@ -55,7 +55,6 @@ class Blaspp(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("cmake@3.15.0:", type="build")
     depends_on("blas")
-    depends_on("llvm-openmp", when="%apple-clang +openmp")
     depends_on("rocblas", when="+rocm")
     depends_on("intel-oneapi-mkl", when="+sycl")
     depends_on("intel-oneapi-mkl threads=openmp", when="+sycl")

--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -71,7 +71,6 @@ class Eckit(CMakePackage):
     depends_on("ecbuild@3.7:", when="@1.21:", type="build")
 
     depends_on("mpi", when="+mpi")
-    depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
 
     depends_on("yacc", type="build", when="+admin")
     depends_on("flex", type="build", when="+admin")

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -55,7 +55,6 @@ class EcmwfAtlas(CMakePackage):
     )
 
     variant("openmp", default=True, description="Use OpenMP")
-    depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
     variant("shared", default=True, description="Build shared libraries")
     variant("trans", default=False, description="Enable trans")
     depends_on("ectrans@1.1.0:", when="@0.31.0: +trans")

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -43,7 +43,6 @@ class Fckit(CMakePackage):
     depends_on("eckit@1.24: +mpi", when="@0.11: +eckit")
 
     variant("openmp", default=True, description="Use OpenMP?")
-    depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
     variant("shared", default=True, description="Build shared libraries")
     variant("fismahigh", default=False, description="Apply patching for FISMA-high compliance")
     variant(

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -27,7 +27,6 @@ class FftwBase(AutotoolsPackage):
     variant("mpi", default=True, description="Activate MPI support")
 
     depends_on("mpi", when="+mpi")
-    depends_on("llvm-openmp", when="%apple-clang +openmp")
 
     # https://github.com/FFTW/fftw3/commit/902d0982522cdf6f0acd60f01f59203824e8e6f3
     conflicts("%gcc@8.0:8", when="@3.3.7")

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -128,8 +128,6 @@ class Hydrogen(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("hipcub +rocm", when="+rocm +cub")
     depends_on("half", when="+half")
 
-    depends_on("llvm-openmp", when="%apple-clang +openmp")
-
     # Fixes https://github.com/spack/spack/issues/42286
     # https://github.com/LLNL/Elemental/pull/177
     patch("cmake-intel-mpi-escape-quotes-pr177.patch", when="@1.5.3")

--- a/var/spack/repos/builtin/packages/llvm-openmp/package.py
+++ b/var/spack/repos/builtin/packages/llvm-openmp/package.py
@@ -24,6 +24,8 @@ class LlvmOpenmp(CMakePackage):
     homepage = "https://openmp.llvm.org/"
     url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/openmp-14.0.6.src.tar.xz"
 
+    tags = ["runtime"]
+
     license("Apache-2.0")
 
     version("18.1.0", sha256="ef1cef885d463e4becf5e132a9175a540c6f4487334c0e86274a374ce7d0a092")

--- a/var/spack/repos/builtin/packages/mgard/package.py
+++ b/var/spack/repos/builtin/packages/mgard/package.py
@@ -56,8 +56,6 @@ class Mgard(CMakePackage, CudaPackage):
     depends_on("cmake@3.19:", type="build")
     depends_on("nvcomp@2.2.0:", when="@2022-11-18:+cuda")
     depends_on("nvcomp@2.0.2", when="@:2021-11-12+cuda")
-    with when("+openmp"):
-        depends_on("llvm-openmp", when="%apple-clang")
 
     conflicts("cuda_arch=none", when="+cuda")
     conflicts(

--- a/var/spack/repos/builtin/packages/opensubdiv/package.py
+++ b/var/spack/repos/builtin/packages/opensubdiv/package.py
@@ -42,7 +42,6 @@ class Opensubdiv(CMakePackage, CudaPackage):
     depends_on("libxxf86vm")
     depends_on("libxcursor")
     depends_on("libxinerama")
-    depends_on("llvm-openmp", when="+openmp")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/py-dgl/package.py
+++ b/var/spack/repos/builtin/packages/py-dgl/package.py
@@ -45,7 +45,6 @@ class PyDgl(CMakePackage, PythonExtension, CudaPackage):
     )
 
     depends_on("cmake@3.5:", type="build")
-    depends_on("llvm-openmp", when="%apple-clang +openmp")
 
     # Python dependencies
     # See python/setup.py

--- a/var/spack/repos/builtin/packages/py-networkit/package.py
+++ b/var/spack/repos/builtin/packages/py-networkit/package.py
@@ -39,7 +39,6 @@ class PyNetworkit(PythonPackage):
     depends_on("libnetworkit@7.1", type=("build", "link"), when="@7.1")
     depends_on("libnetworkit@7.0", type=("build", "link"), when="@7.0")
     depends_on("libnetworkit@6.1", type=("build", "link"), when="@6.1")
-    depends_on("llvm-openmp", when="%apple-clang")
     depends_on("ninja", type="build")
     depends_on("py-cython", type="build")
     depends_on("py-numpy", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
@@ -81,9 +81,6 @@ class PyPennylaneLightningKokkos(CMakePackage, PythonExtension, CudaPackage, ROC
     depends_on("py-pennylane@0.32:", type=("build", "run"), when="@0.32:")
     depends_on("py-pennylane-lightning~kokkos", type=("build", "run"), when="@:0.31")
 
-    # variant defined dependencies
-    depends_on("llvm-openmp", when="+openmp %apple-clang")
-
     # Test deps
     depends_on("py-pytest", type="test")
     depends_on("py-pytest-mock", type="test")

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
@@ -49,7 +49,6 @@ class PyPennylaneLightning(CMakePackage, PythonExtension):
     depends_on("blas", when="+blas")
     depends_on("kokkos@:4.0.01", when="@:0.31+kokkos")
     depends_on("kokkos-kernels@:4.0.01", when="@:0.31+kokkos")
-    depends_on("llvm-openmp", when="+openmp %apple-clang")
 
     depends_on("python@3.8:", type=("build", "run"), when="@:0.31")
     depends_on("python@3.9:", type=("build", "run"), when="@0.32:")

--- a/var/spack/repos/builtin/packages/py-scikit-learn/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-learn/package.py
@@ -81,7 +81,6 @@ class PyScikitLearn(PythonPackage):
     depends_on("py-joblib@1:", when="@1.1:", type=("build", "run"))
     depends_on("py-joblib@0.11:", type=("build", "run"))
     depends_on("py-threadpoolctl@2.0.0:", when="@0.23:", type=("build", "run"))
-    depends_on("llvm-openmp", when="%apple-clang +openmp")
 
     # Test dependencies
     depends_on("py-matplotlib@3.3.4:", type="test")

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -217,7 +217,6 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     depends_on("magma+rocm", when="+magma+rocm")
     depends_on("nccl", when="+nccl+cuda")
     depends_on("numactl", when="+numa")
-    depends_on("llvm-openmp", when="%apple-clang +openmp")
     depends_on("valgrind", when="+valgrind")
     with when("+rocm"):
         depends_on("hsa-rocr-dev")

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -150,8 +150,6 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("cmake@3.23:", when="@2022.10:+rocm", type="build")
     depends_on("cmake@3.14:", when="@2022.03.0:", type="build")
 
-    depends_on("llvm-openmp", when="+openmp %apple-clang")
-
     depends_on("rocprim", when="+rocm")
     with when("+rocm @0.12.0:"):
         depends_on("camp+rocm")

--- a/var/spack/repos/builtin/packages/sw4/package.py
+++ b/var/spack/repos/builtin/packages/sw4/package.py
@@ -36,7 +36,6 @@ class Sw4(MakefilePackage):
     depends_on("h5z-zfp@develop", when="+zfp")
     depends_on("python")
     depends_on("py-h5py")
-    depends_on("llvm-openmp", when="%apple-clang +openmp")
 
     def edit(self, spec, prefix):
         os.environ["CXX"] = spec["mpi"].mpicxx

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -92,7 +92,6 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cuda@10.1.0:", when="+cuda_native")
     depends_on("tbb", when="+tbb")
     depends_on("mpi", when="+mpi")
-    depends_on("llvm-openmp", when="+openmp %apple-clang")
 
     # VTK-m uses the default Kokkos backend
     depends_on("kokkos", when="+kokkos")

--- a/var/spack/repos/builtin/packages/xgboost/package.py
+++ b/var/spack/repos/builtin/packages/xgboost/package.py
@@ -46,7 +46,6 @@ class Xgboost(CMakePackage, CudaPackage):
     # https://github.com/dmlc/xgboost/pull/7379
     depends_on("cuda@10:11.4", when="@:1.5.0+cuda")
     depends_on("nccl", when="+nccl")
-    depends_on("llvm-openmp", when="%apple-clang +openmp")
     depends_on("hwloc", when="%clang")
 
     # https://github.com/dmlc/xgboost/issues/6972


### PR DESCRIPTION
This PR moves the responsibility to inject a dependency on llvm-openmp to the compiler package.

Injecting is based on a convention: each package compiled with `%apple-clang` that activates `+openmp` gets a dependency on `llvm-openmp`
