### PR TITLE
perl-dbix-class and deps: new packages

### DIFF
--- a/var/spack/repos/builtin/packages/perl-algorithm-c3/package.py
+++ b/var/spack/repos/builtin/packages/perl-algorithm-c3/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlAlgorithmC3(PerlPackage):
+    """A module for merging hierarchies using the C3 algorithm"""
+
+    homepage = "https://metacpan.org/pod/Algorithm::C3"
+    url = "https://cpan.metacpan.org/authors/id/H/HA/HAARG/Algorithm-C3-0.11.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.11", sha256="aaf48467765deea6e48054bc7d43e46e4d40cbcda16552c629d37be098289309")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Algorithm::C3; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-class-accessor-grouped/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-accessor-grouped/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlClassAccessorGrouped(PerlPackage):
+    """Lets you build groups of accessors"""
+
+    homepage = "https://metacpan.org/pod/Class::Accessor::Grouped"
+    url = "https://cpan.metacpan.org/authors/id/H/HA/HAARG/Class-Accessor-Grouped-0.10014.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.10014", sha256="35d5b03efc09f67f3a3155c9624126c3e162c8e3ca98ff826db358533a44c4bb")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-module-runtime@0.012:", type=("build", "run", "test"))
+    depends_on("perl-test-exception@0.31:", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Class::Accessor::Grouped; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-class-c3-componentised/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-c3-componentised/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlClassC3Componentised(PerlPackage):
+    """Load mix-ins or components to your C3-based class"""
+
+    homepage = "https://metacpan.org/pod/Class::C3::Componentised"
+    url = "https://cpan.metacpan.org/authors/id/H/HA/HAARG/Class-C3-Componentised-1.001002.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.001002", sha256="3051b146dc1efeaea1a9a2e9e6b1773080995b898ab583f155658d5fc80b9693")
+
+    depends_on("perl@5.6.2:", type=("build", "link", "run", "test"))
+    depends_on("perl-class-c3@0.20:", type=("build", "run", "test"))
+    depends_on("perl-class-inspector@1.32:", type=("build", "run", "test"))
+    depends_on("perl-mro-compat@0.09:", type=("build", "run", "test"))
+    depends_on("perl-test-exception@0.31:", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Class::C3::Componentised; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-class-c3/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-c3/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlClassC3(PerlPackage):
+    """A pragma to use the C3 method resolution order algorithm"""
+
+    homepage = "https://metacpan.org/pod/Class::C3"
+    url = "https://cpan.metacpan.org/authors/id/H/HA/HAARG/Class-C3-0.35.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.35", sha256="84053cf1a68fcc8c12056c2f120adf04f7f68e3be34f4408e95d026fee67e33e")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-algorithm-c3@0.07:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Class::C3; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-config-any/package.py
+++ b/var/spack/repos/builtin/packages/perl-config-any/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlConfigAny(PerlPackage):
+    """Load configuration from different file formats, transparently"""
+
+    homepage = "https://metacpan.org/pod/Config::Any"
+    url = "https://cpan.metacpan.org/authors/id/H/HA/HAARG/Config-Any-0.33.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.33", sha256="c0668eb5f2cd355bf20557f04dc18a25474b7a0bcfa79562e3165d9a3c789333")
+
+    depends_on("perl-module-pluggable", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Config::Any; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-context-preserve/package.py
+++ b/var/spack/repos/builtin/packages/perl-context-preserve/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlContextPreserve(PerlPackage):
+    """Run code after a subroutine call, preserving the context the subroutine
+    would have seen if it were the last statement in the caller"""
+
+    homepage = "https://metacpan.org/pod/Context::Preserve"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Context-Preserve-0.03.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.03", sha256="09914a4c2c7bdb99cab680c183cbf492ec98d6e23fbcc487fcc4ae10567dfd1f")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-test-exception", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Context::Preserve; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-data-dumper-concise/package.py
+++ b/var/spack/repos/builtin/packages/perl-data-dumper-concise/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlDataDumperConcise(PerlPackage):
+    """Less indentation and newlines plus sub deparsing"""
+
+    homepage = "https://metacpan.org/pod/Data::Dumper::Concise"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Data-Dumper-Concise-2.023.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("2.023", sha256="a6c22f113caf31137590def1b7028a7e718eface3228272d0672c25e035d5853")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Data::Dumper::Concise; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-dbix-class/package.py
+++ b/var/spack/repos/builtin/packages/perl-dbix-class/package.py
@@ -1,0 +1,52 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlDbixClass(PerlPackage):
+    """Extensible and flexible object <-> relational mapper."""
+
+    homepage = "https://metacpan.org/pod/DBIx::Class"
+    url = "https://cpan.metacpan.org/authors/id/R/RI/RIBASUSHI/DBIx-Class-0.082843.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.082843", sha256="341e0b6ecb29d8c49174a6c09d7c6dbf38729ba4015ee7fd70360a4ffee1f251")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-class-accessor-grouped@0.10012:", type=("build", "run", "test"))
+    depends_on("perl-class-c3-componentised@1.0009:", type=("build", "run", "test"))
+    depends_on("perl-class-inspector@1.24:", type=("build", "run", "test"))
+    depends_on("perl-config-any@0.20:", type=("build", "run", "test"))
+    depends_on("perl-context-preserve@0.01:", type=("build", "run", "test"))
+    depends_on("perl-data-dumper-concise@2.020:", type=("build", "run", "test"))
+    depends_on("perl-dbd-sqlite@1.29:", type=("build", "link"))
+    depends_on("perl-dbi@1.57:", type=("build", "run", "test"))
+    depends_on("perl-devel-globaldestruction@0.09:", type=("build", "run", "test"))
+    depends_on("perl-hash-merge@0.12:", type=("build", "run", "test"))
+    depends_on("perl-module-find@0.07:", type=("build", "run", "test"))
+    depends_on("perl-moo@2.000:", type=("build", "run", "test"))
+    depends_on("perl-mro-compat@0.12:", type=("build", "run", "test"))
+    depends_on("perl-namespace-clean@0.24:", type=("build", "run", "test"))
+    depends_on("perl-package-stash@0.28:", type=("build", "link"))
+    depends_on("perl-path-class@0.18:", type=("build", "run", "test"))
+    depends_on("perl-scope-guard@0.03:", type=("build", "run", "test"))
+    depends_on("perl-sql-abstract-classic@1.91:", type=("build", "run", "test"))
+    depends_on("perl-sub-name@0.04:", type=("build", "run", "test"))
+    depends_on("perl-test-deep@0.101:", type=("build", "link"))
+    depends_on("perl-test-exception@0.31:", type=("build", "link"))
+    depends_on("perl-test-warn@0.21:", type=("build", "link"))
+    depends_on("perl-try-tiny@0.07:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use DBIx::Class; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-module-find/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-find/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlModuleFind(PerlPackage):
+    """Find and use installed modules in a (sub)category"""
+
+    homepage = "https://metacpan.org/pod/Module::Find"
+    url = "https://cpan.metacpan.org/authors/id/C/CR/CRENZ/Module-Find-0.16.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.16", sha256="4bcaaa376915014728d4f533a98c5b59d665051cd3cdbafc960e5a66fd131092")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Module::Find; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-sql-abstract-classic/package.py
+++ b/var/spack/repos/builtin/packages/perl-sql-abstract-classic/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlSqlAbstractClassic(PerlPackage):
+    """Generate SQL from Perl data structures"""
+
+    homepage = "https://metacpan.org/pod/SQL::Abstract::Classic"
+    url = "https://cpan.metacpan.org/authors/id/R/RI/RIBASUSHI/SQL-Abstract-Classic-1.91.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.91", sha256="4e3d1dfd095b2123268586bb06b86929ea571388d4e941acccbdcda1e108ef28")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-mro-compat@0.12:", type=("build", "run", "test"))
+    depends_on("perl-sql-abstract@1.79:", type=("build", "run", "test"))
+    depends_on("perl-test-deep@0.101:", type=("build", "link"))
+    depends_on("perl-test-exception@0.31:", type=("build", "link"))
+    depends_on("perl-test-warn", type=("build", "link"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use SQL::Abstract::Classic; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-sql-abstract/package.py
+++ b/var/spack/repos/builtin/packages/perl-sql-abstract/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlSqlAbstract(PerlPackage):
+    """Generate SQL from Perl data structures"""
+
+    homepage = "https://metacpan.org/pod/SQL::Abstract"
+    url = "https://cpan.metacpan.org/authors/id/M/MS/MSTROUT/SQL-Abstract-2.000001.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("2.000001", sha256="35a642662c349420d44be6e0ef7d8765ea743eb12ad14399aa3a232bb94e6e9a")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-data-dumper-concise", type=("build", "test"))
+    depends_on("perl-hash-merge@0.12:", type=("build", "run", "test"))
+    depends_on("perl-moo@2.000001:", type=("build", "run", "test"))
+    depends_on("perl-mro-compat@0.12:", type=("build", "run", "test"))
+    depends_on("perl-sub-quote@2.000001:", type=("build", "run", "test"))
+    depends_on("perl-test-deep@0.101:", type=("build", "run", "test"))
+    depends_on("perl-test-exception@0.31:", type=("build", "test"))
+    depends_on("perl-test-warn", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use SQL::Abstract; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
Adds DBIx::Class and its dependencies.
Installed OK with build-time tests. Added dependencies:
- Class::C3::Componentised
- Data::Dumper::Concise
- Config::Any
- Context::Preserve
- Class::Accessor::Grouped
- Module::Find
- SQL::Abstract::Classic
- Class::C3
- SQL::Abstract
- Algorithm::C3

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
