### PR TITLE
perl-graphviz and deps: new packages

### DIFF
--- a/var/spack/repos/builtin/packages/perl-graphviz/package.py
+++ b/var/spack/repos/builtin/packages/perl-graphviz/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlGraphviz(PerlPackage):
+    """Interface to AT&T's GraphViz. Deprecated. See GraphViz2"""
+
+    homepage = "https://metacpan.org/pod/GraphViz"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETJ/GraphViz-2.26.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("2.26", sha256="9a5d2520b3262bf30475272dd764a445f8e7f931bef88be0e3d3bff445da7328")
+
+    depends_on("perl-file-which@1.09:", type=("build", "run", "test"))
+    depends_on("perl-ipc-run@0.6:", type=("build", "run", "test"))
+    depends_on("perl-libwww-perl", type=("build", "run", "test"))
+    depends_on("perl-parse-recdescent@1.965001:", type=("build", "run", "test"))
+    depends_on("perl-xml-twig@3.52:", type=("build", "run", "test"))
+    depends_on("perl-xml-xpath@1.13:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use GraphViz; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-xml-xpath/package.py
+++ b/var/spack/repos/builtin/packages/perl-xml-xpath/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlXmlXpath(PerlPackage):
+    """Parse and evaluate XPath statements."""
+
+    homepage = "https://metacpan.org/pod/XML::XPath"
+    url = "https://cpan.metacpan.org/authors/id/M/MA/MANWAR/XML-XPath-1.48.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-2.0")
+
+    version("1.48", sha256="7bc75be36b239e5b2e700a9570d2b53b43093d467f2abe6a743f9ff9093790cd")
+
+    depends_on("perl@5.10.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-path-tiny@0.076:", type=("build", "link"))
+    depends_on("perl-xml-parser@2.23:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use XML::XPath; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
Adds GraphViz and its dependencies.
Installed OK with build-time tests. Added dependencies:
- XML::XPath

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
