### PR TITLE
perl-net-server-ss-prefork and deps: new packages

### DIFF
--- a/var/spack/repos/builtin/packages/perl-http-server-simple/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-server-simple/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlHttpServerSimple(PerlPackage):
+    """Lightweight HTTP server"""
+
+    homepage = "https://metacpan.org/pod/HTTP::Server::Simple"
+    url = "https://cpan.metacpan.org/authors/id/B/BP/BPS/HTTP-Server-Simple-0.52.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.52", sha256="d8939fa4f12bd6b8c043537fd0bf96b055ac3686b9cdd9fa773dca6ae679cb4c")
+
+    depends_on("perl-cgi", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use HTTP::Server::Simple; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-net-server-ss-prefork/package.py
+++ b/var/spack/repos/builtin/packages/perl-net-server-ss-prefork/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlNetServerSsPrefork(PerlPackage):
+    """A hot-deployable variant of Net::Server::PreFork"""
+
+    homepage = "https://metacpan.org/pod/Net::Server::SS::PreFork"
+    url = "https://cpan.metacpan.org/authors/id/K/KA/KAZUHO/Net-Server-SS-PreFork-0.05.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.05", sha256="6d22b3a84eb3e01fb238f566bdb3014847d30e0d51ec1e86a0b6e043e367968b")
+
+    depends_on("perl-http-server-simple", type=("build", "link"))
+    depends_on("perl-libwww-perl", type=("build", "link"))
+    depends_on("perl-net-server", type=("build", "run", "test"))
+    depends_on("perl-server-starter@0.02:", type=("build", "run", "test"))
+    depends_on("perl-test-tcp@0.06:", type=("build", "link"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Net::Server::SS::PreFork; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-net-server/package.py
+++ b/var/spack/repos/builtin/packages/perl-net-server/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlNetServer(PerlPackage):
+    """Extensible Perl internet server"""
+
+    homepage = "https://metacpan.org/pod/Net::Server"
+    url = "https://cpan.metacpan.org/authors/id/R/RH/RHANDOM/Net-Server-2.014.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("2.014", sha256="3406b9ca5a662a0075eed47fb78de1316b601c94f62a0ee34a5544db9baa3720")
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Net::Server; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-server-starter/package.py
+++ b/var/spack/repos/builtin/packages/perl-server-starter/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlServerStarter(PerlPackage):
+    """A superdaemon for hot-deploying server programs"""
+
+    homepage = "https://metacpan.org/pod/Server::Starter"
+    url = "https://cpan.metacpan.org/authors/id/K/KA/KAZUHO/Server-Starter-0.35.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.35", sha256="676dc0d6cff4648538332c63c32fb88ad09ed868213ea9e62e3f19fad41b9c40")
+
+    depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-test-requires", type=("build", "test"))
+    depends_on("perl-test-sharedfork", type=("build", "test"))
+    depends_on("perl-test-tcp@2.08:", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Server::Starter; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
Adds Net::Server::SS::PreFork and its dependencies. Installed OK with build-time tests. Added dependencies:
- Server::Starter
- Net::Server
- HTTP::Server::Simple

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
