### PR TITLE
perl-plack-middleware-assets and deps: new packages

### DIFF
--- a/var/spack/repos/builtin/packages/perl-css-minifier-xs/package.py
+++ b/var/spack/repos/builtin/packages/perl-css-minifier-xs/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlCssMinifierXs(PerlPackage):
+    """XS based CSS minifier"""
+
+    homepage = "https://metacpan.org/pod/CSS::Minifier::XS"
+    url = "https://cpan.metacpan.org/authors/id/G/GT/GTERMARS/CSS-Minifier-XS-0.13.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.13", sha256="c419e308cdc82af1c25d6b8d07b2ff26347a622b7a63ec20856abe8db4051f82")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-test-diaginc@0.002:", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use CSS::Minifier::XS; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-javascript-minifier-xs/package.py
+++ b/var/spack/repos/builtin/packages/perl-javascript-minifier-xs/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlJavascriptMinifierXs(PerlPackage):
+    """XS based JavaScript minifier"""
+
+    homepage = "https://metacpan.org/pod/JavaScript::Minifier::XS"
+    url = "https://cpan.metacpan.org/authors/id/G/GT/GTERMARS/JavaScript-Minifier-XS-0.15.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.15", sha256="5d9b034f58f0b6ff5b64647bd3c5a9ce05b2a70edee339fbc3173aee747cc050")
+
+    depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-test-diaginc@0.002:", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use JavaScript::Minifier::XS; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-plack-middleware-assets/package.py
+++ b/var/spack/repos/builtin/packages/perl-plack-middleware-assets/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPlackMiddlewareAssets(PerlPackage):
+    """Concatenate and minify JavaScript and CSS files"""
+
+    homepage = "https://metacpan.org/pod/Plack::Middleware::Assets"
+    url = "https://cpan.metacpan.org/authors/id/P/PE/PERLER/Plack-Middleware-Assets-1.0.0.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("BSD")
+
+    version("1.0.0", sha256="fb43c9fb7e395efcb75baeed9dc1a4546d6d7ad387761238b0568673ace0ce84")
+
+    depends_on("perl-css-minifier-xs", type=("build", "run", "test"))
+    depends_on("perl-http-date", type=("build", "run", "test"))
+    depends_on("perl-javascript-minifier-xs", type=("build", "run", "test"))
+    depends_on("perl-plack", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Plack::Middleware::Assets; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-diaginc/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-diaginc/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTestDiaginc(PerlPackage):
+    """List modules and versions loaded if tests fail"""
+
+    homepage = "https://metacpan.org/pod/Test::DiagINC"
+    url = "https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/Test-DiagINC-0.010.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Apache-2.0")
+
+    version("0.010", sha256="5bcb8d356c509e359d53d869c07efdaa8fee5d6cf99897018b9a914ceb21222e")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-capture-tiny@0.21:", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Test::DiagINC; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
This adds Plack::Middleware::Assets and its missing deps:
- CSS::Minifier::XS
- JavaScript::Minifier::XS
- Test::DiagINC

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
