### PR TITLE
perl-perl-critic-moose and deps: new packages

### DIFF
--- a/var/spack/repos/builtin/packages/perl-b-keywords/package.py
+++ b/var/spack/repos/builtin/packages/perl-b-keywords/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlBKeywords(PerlPackage):
+    """Lists of reserved barewords and symbol names"""
+
+    homepage = "https://metacpan.org/pod/B::Keywords"
+    url = "https://cpan.metacpan.org/authors/id/R/RU/RURBAN/B-Keywords-1.26.tar.gz"
+
+    maintainers("EbiArnie")
+
+    version("1.26", sha256="2daa155d2f267fb0dedd87f8a4c4fb5663879fc106517b1ee258353ef87aed34")
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use B::Keywords; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-hook-lexwrap/package.py
+++ b/var/spack/repos/builtin/packages/perl-hook-lexwrap/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlHookLexwrap(PerlPackage):
+    """Lexically scoped subroutine wrappers"""
+
+    homepage = "https://metacpan.org/pod/Hook::LexWrap"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Hook-LexWrap-0.26.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.26", sha256="b60bdc5f98f94f9294b06adef82b1d996da192d5f183f9f434b610fd1137ec2d")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Hook::LexWrap; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-lingua-en-inflect/package.py
+++ b/var/spack/repos/builtin/packages/perl-lingua-en-inflect/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlLinguaEnInflect(PerlPackage):
+    """Convert singular to plural. Select "a" or "an"."""
+
+    homepage = "https://metacpan.org/pod/Lingua::EN::Inflect"
+    url = "https://cpan.metacpan.org/authors/id/D/DC/DCONWAY/Lingua-EN-Inflect-1.905.tar.gz"
+
+    maintainers("EbiArnie")
+
+    version("1.905", sha256="05c29ec3482e572313a60da2181b0b30c5db7cf01f8ae7616ad67e1b66263296")
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Lingua::EN::Inflect; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-list-someutils/package.py
+++ b/var/spack/repos/builtin/packages/perl-list-someutils/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlListSomeutils(PerlPackage):
+    """Provide the stuff missing in List::Util"""
+
+    homepage = "https://metacpan.org/pod/List::SomeUtils"
+    url = "https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/List-SomeUtils-0.59.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.59", sha256="fab30372e4c67bf5a46062da38d1d0c8756279feada866eb439fa29571a2dc7b")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-module-implementation@0.04:", type=("build", "run", "test"))
+    depends_on("perl-test-leaktrace", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use List::SomeUtils; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-perl-critic-moose/package.py
+++ b/var/spack/repos/builtin/packages/perl-perl-critic-moose/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPerlCriticMoose(PerlPackage):
+    """Policies for Perl::Critic concerned with using Moose"""
+
+    homepage = "https://metacpan.org/pod/Perl::Critic::Moose"
+    url = "https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/Perl-Critic-Moose-1.05.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.05", sha256="52eb8e22c42643f17fe297a21714017efdb9e2986c24e3337e030f3650f92201")
+
+    depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-namespace-autoclean", type=("build", "run", "test"))
+    depends_on("perl-perl-critic", type=("build", "run", "test"))
+    depends_on("perl-readonly", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Perl::Critic::Moose; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-perl-critic/package.py
+++ b/var/spack/repos/builtin/packages/perl-perl-critic/package.py
@@ -1,0 +1,44 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPerlCritic(PerlPackage):
+    """Critique Perl source code for best-practices."""
+
+    homepage = "https://metacpan.org/pod/Perl::Critic"
+    url = "https://cpan.metacpan.org/authors/id/P/PE/PETDANCE/Perl-Critic-1.152.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.152", sha256="e5bfaf67f61a2a6a0ed343f0403b19f515b4890eed6272abaab707749c5e5e1e")
+
+    depends_on("perl@5.10.1:", type=("build", "link", "run", "test"))
+    depends_on("perl-b-keywords@1.23:", type=("build", "run", "test"))
+    depends_on("perl-config-tiny@2:", type=("build", "run", "test"))
+    depends_on("perl-exception-class@1.23:", type=("build", "run", "test"))
+    depends_on("perl-file-which", type=("build", "run", "test"))
+    depends_on("perl-list-someutils@0.55:", type=("build", "run", "test"))
+    depends_on("perl-module-pluggable@3.1:", type=("build", "run", "test"))
+    depends_on("perl-perl-tidy", type=("build", "run", "test"))
+    depends_on("perl-pod-parser", type=("build", "run", "test"))
+    depends_on("perl-pod-spell@1:", type=("build", "run", "test"))
+    depends_on("perl-ppi@1.277:", type=("build", "run", "test"))
+    depends_on("perl-ppix-quotelike", type=("build", "run", "test"))
+    depends_on("perl-ppix-regexp@0.027:", type=("build", "run", "test"))
+    depends_on("perl-ppix-utils", type=("build", "run", "test"))
+    depends_on("perl-readonly@2:", type=("build", "run", "test"))
+    depends_on("perl-string-format@1.18:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Perl::Critic; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-perl-tidy/package.py
+++ b/var/spack/repos/builtin/packages/perl-perl-tidy/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPerlTidy(PerlPackage):
+    """Indent and reformat perl scripts"""
+
+    homepage = "https://metacpan.org/pod/Perl::Tidy"
+    url = "https://cpan.metacpan.org/authors/id/S/SH/SHANCOCK/Perl-Tidy-20240202.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("GPL-2.0-only")
+
+    version("20240202", sha256="9451adde47c2713652d39b150fb3eeb3ccc702add46913e989125184cd7ec57d")
+
+    depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Perl::Tidy; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-pod-parser/package.py
+++ b/var/spack/repos/builtin/packages/perl-pod-parser/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPodParser(PerlPackage):
+    """Modules for parsing/translating POD format documents"""
+
+    homepage = "https://metacpan.org/pod/Pod::Parser"
+    url = "https://cpan.metacpan.org/authors/id/M/MA/MAREKR/Pod-Parser-1.67.tar.gz"
+
+    maintainers("EbiArnie")
+
+    version("1.67", sha256="5deccbf55d750ce65588cd211c1a03fa1ef3aaa15d1ac2b8d85383a42c1427ea")
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Pod::Parser; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-pod-spell/package.py
+++ b/var/spack/repos/builtin/packages/perl-pod-spell/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPodSpell(PerlPackage):
+    """A formatter for spellchecking Pod"""
+
+    homepage = "https://metacpan.org/pod/Pod::Spell"
+    url = "https://cpan.metacpan.org/authors/id/H/HA/HAARG/Pod-Spell-1.26.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-2.0")
+
+    version("1.26", sha256="2f05bfc9cfb04b96fcbfa2c8544d1e6ae908596d3696c46e0e26556b750afbbf")
+
+    depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-class-tiny", type=("build", "run", "test"))
+    depends_on("perl-file-sharedir", type=("build", "run", "test"))
+    depends_on("perl-file-sharedir-install@0.06:", type=("build"))
+    depends_on("perl-lingua-en-inflect", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Pod::Spell; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-ppi/package.py
+++ b/var/spack/repos/builtin/packages/perl-ppi/package.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPpi(PerlPackage):
+    """Parse, Analyze and Manipulate Perl (without perl)"""
+
+    homepage = "https://metacpan.org/pod/PPI"
+    url = "https://cpan.metacpan.org/authors/id/M/MI/MITHALDU/PPI-1.277.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.277", sha256="87c79f83b6876e206051965d5019d2507c551f819a86750080ec7ec43b2e0af8")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-class-inspector@1.22:", type=("build", "test"))
+    depends_on("perl-clone@0.30:", type=("build", "run", "test"))
+    depends_on("perl-params-util@1.00:", type=("build", "run", "test"))
+    depends_on("perl-task-weaken", type=("build", "run", "test"))
+    depends_on("perl-test-nowarnings", type=("build", "test"))
+    depends_on("perl-test-object@0.07:", type=("build", "test"))
+    depends_on("perl-test-subcalls@1.07:", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use PPI; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-ppix-quotelike/package.py
+++ b/var/spack/repos/builtin/packages/perl-ppix-quotelike/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPpixQuotelike(PerlPackage):
+    """Parse Perl string literals and string-literal-like things."""
+
+    homepage = "https://metacpan.org/pod/PPIx::QuoteLike"
+    url = "https://cpan.metacpan.org/authors/id/W/WY/WYANT/PPIx-QuoteLike-0.023.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.023", sha256="3576a3149d2c53e07e9737b7892be5cfb84a499a6ef1df090b713b0544234d21")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-ppi", type=("build", "run", "test"))
+    depends_on("perl-readonly", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use PPIx::QuoteLike; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-ppix-regexp/package.py
+++ b/var/spack/repos/builtin/packages/perl-ppix-regexp/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPpixRegexp(PerlPackage):
+    """Parse regular expressions"""
+
+    homepage = "https://metacpan.org/pod/PPIx::Regexp"
+    url = "https://cpan.metacpan.org/authors/id/W/WY/WYANT/PPIx-Regexp-0.088.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.088", sha256="885433f9b102fad4fd36b21c7320bb036036111caf998131bf416f7cd5ee9764")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-ppi", type=("build", "run", "test"))
+    depends_on("perl-task-weaken", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use PPIx::Regexp; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-ppix-utils/package.py
+++ b/var/spack/repos/builtin/packages/perl-ppix-utils/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPpixUtils(PerlPackage):
+    """Utility functions for PPI"""
+
+    homepage = "https://metacpan.org/pod/PPIx::Utils"
+    url = "https://cpan.metacpan.org/authors/id/D/DB/DBOOK/PPIx-Utils-0.003.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.003", sha256="2a9bccfc8ead03be01b67248fe8e152522040f798286fa4ef4432b7f2efdba11")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-b-keywords@1.09:", type=("build", "run", "test"))
+    depends_on("perl-ppi@1.250:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use PPIx::Utils; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-string-format/package.py
+++ b/var/spack/repos/builtin/packages/perl-string-format/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlStringFormat(PerlPackage):
+    """Sprintf-like string formatting capabilities with arbitrary format definitions"""
+
+    homepage = "https://metacpan.org/pod/String::Format"
+    url = "https://cpan.metacpan.org/authors/id/S/SR/SREZIC/String-Format-1.18.tar.gz"
+
+    maintainers("EbiArnie")
+
+    version("1.18", sha256="9e417a8f8d9ea623beea2d13a47c0d5a696fc8602c0509b826cd45f97b76e778")
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use String::Format; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-object/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-object/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTestObject(PerlPackage):
+    """Thoroughly testing objects via registered handlers"""
+
+    homepage = "https://metacpan.org/pod/Test::Object"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Test-Object-0.08.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.08", sha256="65278964147837313f4108e55b59676e8a364d6edf01b3dc198aee894ab1d0bb")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Test::Object; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-subcalls/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-subcalls/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTestSubcalls(PerlPackage):
+    """Track the number of times subs are called"""
+
+    homepage = "https://metacpan.org/pod/Test::SubCalls"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Test-SubCalls-1.10.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.10", sha256="cbc1e9b35a05e71febc13e5ef547a31c8249899bb6011dbdc9d9ff366ddab6c2")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-hook-lexwrap@0.20:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Test::SubCalls; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
Adds Perl::Critic::Moose and its dependencies.
Installed OK with build-time tests. Added dependencies:
- Perl::Critic
- Pod::Parser
- Perl::Tidy
- PPI
- PPIx::QuoteLike
- List::SomeUtils
- PPIx::Regexp
- B::Keywords
- PPIx::Utils
- String::Format
- Pod::Spell
- Test::SubCalls
- Test::Object
- Lingua::EN::Inflect
- Hook::LexWrap

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
