### PR TITLE
py-pythran: `@:0.12.1` is incompatible with `python@3.11:`

### DIFF
--- a/var/spack/repos/builtin/packages/py-pythran/package.py
+++ b/var/spack/repos/builtin/packages/py-pythran/package.py
@@ -68,7 +68,7 @@ class PyPythran(PythonPackage):
     # https://github.com/serge-sans-paille/pythran/issues/1937
     conflicts("%apple-clang@13:", when="@:0.10")
     # https://github.com/serge-sans-paille/pythran/issues/2101
-    conflicts("python@3.11:", when="@:0.12.1")
+    conflicts("^python@3.11:", when="@:0.12.1")
 
     @property
     def headers(self):

--- a/var/spack/repos/builtin/packages/py-pythran/package.py
+++ b/var/spack/repos/builtin/packages/py-pythran/package.py
@@ -67,6 +67,8 @@ class PyPythran(PythonPackage):
 
     # https://github.com/serge-sans-paille/pythran/issues/1937
     conflicts("%apple-clang@13:", when="@:0.10")
+    # https://github.com/serge-sans-paille/pythran/issues/2101
+    conflicts("python@3.11:", when="@:0.12.1")
 
     @property
     def headers(self):


### PR DESCRIPTION
Ref: https://github.com/serge-sans-paille/pythran/issues/2101 and https://github.com/scipy/scipy/issues/18390.

Fix #42940.