### PR TITLE
spack find: add options for local/upstream only

### DIFF
--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -144,7 +144,7 @@ def setup_parser(subparser):
         "--install-tree",
         action="store",
         default="all",
-        help="Install trees to query. 'all' (default), 'local', 'upstream', or upstream name"
+        help="Install trees to query. 'all' (default), 'local', 'upstream', or upstream name",
     )
 
     subparser.add_argument("--start-date", help="earliest date of installation [YYYY-MM-DD]")

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -141,10 +141,10 @@ def setup_parser(subparser):
         "--only-deprecated", action="store_true", help="show only deprecated packages"
     )
     subparser.add_argument(
-        "--local", action="store_true", help="Only show packages from the local database"
-    )
-    subparser.add_argument(
-        "--upstream", action="store_true", help="Only show packages from upstreams"
+        "--install-tree",
+        action="store",
+        default="all",
+        help="Install trees to query. 'all' (default), 'local', 'upstream', or upstream name"
     )
 
     subparser.add_argument("--start-date", help="earliest date of installation [YYYY-MM-DD]")
@@ -176,8 +176,7 @@ def query_arguments(args):
         "installed": installed,
         "known": known,
         "explicit": explicit,
-        "local": not args.upstream,
-        "upstream": not args.local,
+        "install_tree": args.install_tree,
     }
 
     # Time window of installation

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -178,6 +178,7 @@ def query_arguments(args):
     upstreams = spack.config.get("upstreams", {})
     if install_tree in upstreams.keys():
         install_tree = upstreams[install_tree]["install_tree"]
+    q_args["install_tree"] = install_tree
 
     # Time window of installation
     for attribute in ("start_date", "end_date"):

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -172,11 +172,7 @@ def query_arguments(args):
     if args.implicit:
         explicit = False
 
-    q_args = {
-        "installed": installed,
-        "known": known,
-        "explicit": explicit,
-    }
+    q_args = {"installed": installed, "known": known, "explicit": explicit}
 
     install_tree = args.install_tree
     upstreams = spack.config.get("upstreams", {})

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -144,7 +144,7 @@ def setup_parser(subparser):
         "--install-tree",
         action="store",
         default="all",
-        help="Install trees to query. 'all' (default), 'local', 'upstream', or upstream name",
+        help="Install trees to query: 'all' (default), 'local', 'upstream', upstream name or path",
     )
 
     subparser.add_argument("--start-date", help="earliest date of installation [YYYY-MM-DD]")
@@ -176,8 +176,12 @@ def query_arguments(args):
         "installed": installed,
         "known": known,
         "explicit": explicit,
-        "install_tree": args.install_tree,
     }
+
+    install_tree = args.install_tree
+    upstreams = spack.config.get("upstreams", {})
+    if install_tree in upstreams.keys():
+        install_tree = upstreams[install_tree]["install_tree"]
 
     # Time window of installation
     for attribute in ("start_date", "end_date"):

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -140,6 +140,12 @@ def setup_parser(subparser):
     subparser.add_argument(
         "--only-deprecated", action="store_true", help="show only deprecated packages"
     )
+    subparser.add_argument(
+        "--local", action="store_true", help="Only show packages from the local database"
+    )
+    subparser.add_argument(
+        "--upstream", action="store_true", help="Only show packages from upstreams"
+    )
 
     subparser.add_argument("--start-date", help="earliest date of installation [YYYY-MM-DD]")
     subparser.add_argument("--end-date", help="latest date of installation [YYYY-MM-DD]")
@@ -166,7 +172,13 @@ def query_arguments(args):
     if args.implicit:
         explicit = False
 
-    q_args = {"installed": installed, "known": known, "explicit": explicit}
+    q_args = {
+        "installed": installed,
+        "known": known,
+        "explicit": explicit,
+        "local": not args.upstream,
+        "upstream": not args.local,
+    }
 
     # Time window of installation
     for attribute in ("start_date", "end_date"):

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1624,7 +1624,7 @@ class Database:
         """Query the Spack database including all upstream databases.
 
         Additional Arguments:
-            install_tree (str): query 'all' (default), 'local', 'upstream', or named upstream
+            install_tree (str): query 'all' (default), 'local', 'upstream', or upstream path
         """
         install_tree = kwargs.pop("install_tree", "all")
         valid_trees = ["all", "upstream", "local", self.root] + [u.root for u in self.upstream_dbs]

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -90,6 +90,7 @@ def test_query_arguments():
     q_args = query_arguments(args)
     assert q_args["explicit"] is False
 
+
 @pytest.mark.db
 @pytest.mark.usefixtures("database", "mock_display")
 def test_tag1(parser, specs):

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -77,7 +77,7 @@ def test_query_arguments():
     assert q_args["explicit"] is any
     assert "start_date" in q_args
     assert "end_date" not in q_args
-    assert q_args["local"] == "all"
+    assert q_args["install_tree"] == "all"
     assert q_args["upstream"] is True
 
     # Check that explicit works correctly

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -65,7 +65,6 @@ def test_query_arguments():
         start_date="2018-02-23",
         end_date=None,
         install_tree="all",
-        upstream=None,
     )
 
     q_args = query_arguments(args)
@@ -78,7 +77,6 @@ def test_query_arguments():
     assert "start_date" in q_args
     assert "end_date" not in q_args
     assert q_args["install_tree"] == "all"
-    assert q_args["upstream"] is True
 
     # Check that explicit works correctly
     args.explicit = True

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -64,7 +64,7 @@ def test_query_arguments():
         implicit=False,
         start_date="2018-02-23",
         end_date=None,
-        local=None,
+        install_tree="all",
         upstream=None,
     )
 
@@ -77,7 +77,7 @@ def test_query_arguments():
     assert q_args["explicit"] is any
     assert "start_date" in q_args
     assert "end_date" not in q_args
-    assert q_args["local"] is True
+    assert q_args["local"] == "all"
     assert q_args["upstream"] is True
 
     # Check that explicit works correctly
@@ -89,18 +89,6 @@ def test_query_arguments():
     args.implicit = True
     q_args = query_arguments(args)
     assert q_args["explicit"] is False
-
-    # Check that local/upstream work correctly
-    args.local = True
-    q_args = query_arguments(args)
-    assert q_args["upstream"] is False
-
-    args.upstream = True
-    args.local = False
-    q_args = query_arguments(args)
-    assert q_args["local"] is False
-    assert q_args["upstream"] is True
-
 
 @pytest.mark.db
 @pytest.mark.usefixtures("database", "mock_display")

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -64,6 +64,8 @@ def test_query_arguments():
         implicit=False,
         start_date="2018-02-23",
         end_date=None,
+        local=None,
+        upstream=None,
     )
 
     q_args = query_arguments(args)
@@ -75,6 +77,8 @@ def test_query_arguments():
     assert q_args["explicit"] is any
     assert "start_date" in q_args
     assert "end_date" not in q_args
+    assert q_args["local"] is True
+    assert q_args["upstream"] is True
 
     # Check that explicit works correctly
     args.explicit = True
@@ -85,6 +89,17 @@ def test_query_arguments():
     args.implicit = True
     q_args = query_arguments(args)
     assert q_args["explicit"] is False
+
+    # Check that local/upstream work correctly
+    args.local = True
+    q_args = query_arguments(args)
+    assert q_args["upstream"] is False
+
+    args.upstream = True
+    args.local = False
+    q_args = query_arguments(args)
+    assert q_args["local"] is False
+    assert q_args["upstream"] is True
 
 
 @pytest.mark.db

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -80,13 +80,9 @@ def test_spec_installed_upstream(
     upstream_and_downstream_db, mock_custom_repository, config, monkeypatch
 ):
     """Test whether Spec.installed_upstream() works."""
-    (
-        upstream_write_db,
-        upstream_db,
-        upstream_layout,
-        downstream_db,
-        downstream_layout,
-    ) = upstream_and_downstream_db
+    upstream_write_db, upstream_db, upstream_layout, downstream_db, downstream_layout = (
+        upstream_and_downstream_db
+    )
 
     # a known installed spec should say that it's installed
     with spack.repo.use_repositories(mock_custom_repository):
@@ -110,13 +106,9 @@ def test_spec_installed_upstream(
 
 @pytest.mark.usefixtures("config")
 def test_installed_upstream(upstream_and_downstream_db, tmpdir):
-    (
-        upstream_write_db,
-        upstream_db,
-        upstream_layout,
-        downstream_db,
-        downstream_layout,
-    ) = upstream_and_downstream_db
+    upstream_write_db, upstream_db, upstream_layout, downstream_db, downstream_layout = (
+        upstream_and_downstream_db
+    )
 
     builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
     builder.add_package("x")
@@ -152,13 +144,9 @@ def test_installed_upstream(upstream_and_downstream_db, tmpdir):
 
 @pytest.mark.usefixtures("config")
 def test_removed_upstream_dep(upstream_and_downstream_db, tmpdir):
-    (
-        upstream_write_db,
-        upstream_db,
-        upstream_layout,
-        downstream_db,
-        downstream_layout,
-    ) = upstream_and_downstream_db
+    upstream_write_db, upstream_db, upstream_layout, downstream_db, downstream_layout = (
+        upstream_and_downstream_db
+    )
 
     builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
     builder.add_package("z")
@@ -188,13 +176,9 @@ def test_add_to_upstream_after_downstream(upstream_and_downstream_db, tmpdir):
     DB. When a package is recorded as installed in both, the results should
     refer to the downstream DB.
     """
-    (
-        upstream_write_db,
-        upstream_db,
-        upstream_layout,
-        downstream_db,
-        downstream_layout,
-    ) = upstream_and_downstream_db
+    upstream_write_db, upstream_db, upstream_layout, downstream_db, downstream_layout = (
+        upstream_and_downstream_db
+    )
 
     builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
     builder.add_package("x")

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -56,6 +56,26 @@ def upstream_and_downstream_db(tmpdir, gen_mock_layout):
     yield upstream_write_db, upstream_db, upstream_layout, downstream_db, downstream_layout
 
 
+@pytest.mark.parametrize(
+    "install_tree,result",
+    [("all", ["b", "c"]), ("upstream", ["c"]), ("local", ["b"]), ("{u}", ["c"]), ("{d}", ["b"])]
+)
+def test_query_by_install_tree(
+    install_tree, result, upstream_and_downstream_db, mock_packages, monkeypatch, config
+):
+    up_write_db, up_db, up_layout, down_db, down_layout = upstream_and_downstream_db
+
+    # Set the upstream DB to contain "c" and downstream to contain "b")
+    b = spack.spec.Spec("b").concretized()
+    c = spack.spec.Spec("c").concretized()
+    up_write_db.add(c, up_layout)
+    up_db._read()
+    down_db.add(b, down_layout)
+
+    specs = down_db.query(install_tree=install_tree.format(u=up_db.root, d=down_db.root))
+    assert [s.name for s in specs] == result
+
+
 def test_spec_installed_upstream(
     upstream_and_downstream_db, mock_custom_repository, config, monkeypatch
 ):

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -58,7 +58,7 @@ def upstream_and_downstream_db(tmpdir, gen_mock_layout):
 
 @pytest.mark.parametrize(
     "install_tree,result",
-    [("all", ["b", "c"]), ("upstream", ["c"]), ("local", ["b"]), ("{u}", ["c"]), ("{d}", ["b"])]
+    [("all", ["b", "c"]), ("upstream", ["c"]), ("local", ["b"]), ("{u}", ["c"]), ("{d}", ["b"])],
 )
 def test_query_by_install_tree(
     install_tree, result, upstream_and_downstream_db, mock_packages, monkeypatch, config
@@ -80,9 +80,13 @@ def test_spec_installed_upstream(
     upstream_and_downstream_db, mock_custom_repository, config, monkeypatch
 ):
     """Test whether Spec.installed_upstream() works."""
-    (upstream_write_db, upstream_db, upstream_layout, downstream_db, downstream_layout) = (
-        upstream_and_downstream_db
-    )
+    (
+        upstream_write_db,
+        upstream_db,
+        upstream_layout,
+        downstream_db,
+        downstream_layout,
+    ) = upstream_and_downstream_db
 
     # a known installed spec should say that it's installed
     with spack.repo.use_repositories(mock_custom_repository):
@@ -106,9 +110,13 @@ def test_spec_installed_upstream(
 
 @pytest.mark.usefixtures("config")
 def test_installed_upstream(upstream_and_downstream_db, tmpdir):
-    (upstream_write_db, upstream_db, upstream_layout, downstream_db, downstream_layout) = (
-        upstream_and_downstream_db
-    )
+    (
+        upstream_write_db,
+        upstream_db,
+        upstream_layout,
+        downstream_db,
+        downstream_layout,
+    ) = upstream_and_downstream_db
 
     builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
     builder.add_package("x")
@@ -144,9 +152,13 @@ def test_installed_upstream(upstream_and_downstream_db, tmpdir):
 
 @pytest.mark.usefixtures("config")
 def test_removed_upstream_dep(upstream_and_downstream_db, tmpdir):
-    (upstream_write_db, upstream_db, upstream_layout, downstream_db, downstream_layout) = (
-        upstream_and_downstream_db
-    )
+    (
+        upstream_write_db,
+        upstream_db,
+        upstream_layout,
+        downstream_db,
+        downstream_layout,
+    ) = upstream_and_downstream_db
 
     builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
     builder.add_package("z")
@@ -176,9 +188,13 @@ def test_add_to_upstream_after_downstream(upstream_and_downstream_db, tmpdir):
     DB. When a package is recorded as installed in both, the results should
     refer to the downstream DB.
     """
-    (upstream_write_db, upstream_db, upstream_layout, downstream_db, downstream_layout) = (
-        upstream_and_downstream_db
-    )
+    (
+        upstream_write_db,
+        upstream_db,
+        upstream_layout,
+        downstream_db,
+        downstream_layout,
+    ) = upstream_and_downstream_db
 
     builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"))
     builder.add_package("x")

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1179,7 +1179,7 @@ _spack_fetch() {
 _spack_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --format -H --hashes --json -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --deprecated --only-deprecated --local --upstream --start-date --end-date"
+        SPACK_COMPREPLY="-h --help --format -H --hashes --json -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --deprecated --only-deprecated --install-tree --start-date --end-date"
     else
         _installed_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1179,7 +1179,7 @@ _spack_fetch() {
 _spack_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --format -H --hashes --json -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --deprecated --only-deprecated --start-date --end-date"
+        SPACK_COMPREPLY="-h --help --format -H --hashes --json -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --deprecated --only-deprecated --local --upstream --start-date --end-date"
     else
         _installed_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1709,7 +1709,7 @@ complete -c spack -n '__fish_spack_using_command fetch' -s D -l dependencies -f 
 complete -c spack -n '__fish_spack_using_command fetch' -s D -l dependencies -d 'also fetch all dependencies'
 
 # spack find
-set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces c/show-concretized f/show-flags show-full-compiler x/explicit X/implicit u/unknown m/missing v/variants loaded M/only-missing deprecated only-deprecated local upstream start-date= end-date=
+set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces c/show-concretized f/show-flags show-full-compiler x/explicit X/implicit u/unknown m/missing v/variants loaded M/only-missing deprecated only-deprecated install-tree= start-date= end-date=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 find' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -d 'show this help message and exit'
@@ -1759,10 +1759,8 @@ complete -c spack -n '__fish_spack_using_command find' -l deprecated -f -a depre
 complete -c spack -n '__fish_spack_using_command find' -l deprecated -d 'show deprecated packages as well as installed specs'
 complete -c spack -n '__fish_spack_using_command find' -l only-deprecated -f -a only_deprecated
 complete -c spack -n '__fish_spack_using_command find' -l only-deprecated -d 'show only deprecated packages'
-complete -c spack -n '__fish_spack_using_command find' -l local -f -a local
-complete -c spack -n '__fish_spack_using_command find' -l local -d 'Only show packages from the local database'
-complete -c spack -n '__fish_spack_using_command find' -l upstream -f -a upstream
-complete -c spack -n '__fish_spack_using_command find' -l upstream -d 'Only show packages from upstreams'
+complete -c spack -n '__fish_spack_using_command find' -l install-tree -r -f -a install_tree
+complete -c spack -n '__fish_spack_using_command find' -l install-tree -r -d 'Install trees to query. \'all\' (default), \'local\', \'upstream\', or upstream name'
 complete -c spack -n '__fish_spack_using_command find' -l start-date -r -f -a start_date
 complete -c spack -n '__fish_spack_using_command find' -l start-date -r -d 'earliest date of installation [YYYY-MM-DD]'
 complete -c spack -n '__fish_spack_using_command find' -l end-date -r -f -a end_date

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1760,7 +1760,7 @@ complete -c spack -n '__fish_spack_using_command find' -l deprecated -d 'show de
 complete -c spack -n '__fish_spack_using_command find' -l only-deprecated -f -a only_deprecated
 complete -c spack -n '__fish_spack_using_command find' -l only-deprecated -d 'show only deprecated packages'
 complete -c spack -n '__fish_spack_using_command find' -l install-tree -r -f -a install_tree
-complete -c spack -n '__fish_spack_using_command find' -l install-tree -r -d 'Install trees to query. \'all\' (default), \'local\', \'upstream\', or upstream name'
+complete -c spack -n '__fish_spack_using_command find' -l install-tree -r -d 'Install trees to query: \'all\' (default), \'local\', \'upstream\', upstream name or path'
 complete -c spack -n '__fish_spack_using_command find' -l start-date -r -f -a start_date
 complete -c spack -n '__fish_spack_using_command find' -l start-date -r -d 'earliest date of installation [YYYY-MM-DD]'
 complete -c spack -n '__fish_spack_using_command find' -l end-date -r -f -a end_date

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1709,7 +1709,7 @@ complete -c spack -n '__fish_spack_using_command fetch' -s D -l dependencies -f 
 complete -c spack -n '__fish_spack_using_command fetch' -s D -l dependencies -d 'also fetch all dependencies'
 
 # spack find
-set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces c/show-concretized f/show-flags show-full-compiler x/explicit X/implicit u/unknown m/missing v/variants loaded M/only-missing deprecated only-deprecated start-date= end-date=
+set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces c/show-concretized f/show-flags show-full-compiler x/explicit X/implicit u/unknown m/missing v/variants loaded M/only-missing deprecated only-deprecated local upstream start-date= end-date=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 find' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -d 'show this help message and exit'
@@ -1759,6 +1759,10 @@ complete -c spack -n '__fish_spack_using_command find' -l deprecated -f -a depre
 complete -c spack -n '__fish_spack_using_command find' -l deprecated -d 'show deprecated packages as well as installed specs'
 complete -c spack -n '__fish_spack_using_command find' -l only-deprecated -f -a only_deprecated
 complete -c spack -n '__fish_spack_using_command find' -l only-deprecated -d 'show only deprecated packages'
+complete -c spack -n '__fish_spack_using_command find' -l local -f -a local
+complete -c spack -n '__fish_spack_using_command find' -l local -d 'Only show packages from the local database'
+complete -c spack -n '__fish_spack_using_command find' -l upstream -f -a upstream
+complete -c spack -n '__fish_spack_using_command find' -l upstream -d 'Only show packages from upstreams'
 complete -c spack -n '__fish_spack_using_command find' -l start-date -r -f -a start_date
 complete -c spack -n '__fish_spack_using_command find' -l start-date -r -d 'earliest date of installation [YYYY-MM-DD]'
 complete -c spack -n '__fish_spack_using_command find' -l end-date -r -f -a end_date


### PR DESCRIPTION
Users requested an option to filter between local/upstream results in `spack find` output.

```
# default behavior, same as without --install-tree argument
$ spack find --install-tree all

# show only local results
$ spack find --install-tree local  

# show results from all upstreams
$ spack find --install-tree upstream 

# show results from a particular upstream or the local install_tree
$ spack find --install-tree /path/to/install/tree/root
```
