### PR TITLE
macos platform-specific virtuals not correctly prioritized

### DIFF
--- a/var/spack/repos/builtin/packages/libuuid/package.py
+++ b/var/spack/repos/builtin/packages/libuuid/package.py
@@ -20,7 +20,7 @@ class Libuuid(AutotoolsPackage, SourceforgePackage):
 
     depends_on("c", type="build")  # generated
 
-    if sys.platform not in ["darwin", "windows"]:
+    if sys.platform not in ["darwin", "windows"]: #only provide on *nix-like
         provides("uuid")
 
     conflicts("%gcc@14:")

--- a/var/spack/repos/builtin/packages/libuuid/package.py
+++ b/var/spack/repos/builtin/packages/libuuid/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-
+import sys
 
 class Libuuid(AutotoolsPackage, SourceforgePackage):
     """Portable uuid C library"""
@@ -20,6 +20,7 @@ class Libuuid(AutotoolsPackage, SourceforgePackage):
 
     depends_on("c", type="build")  # generated
 
-    provides("uuid")
+    if sys.platform not in ["darwin", "windows"]:
+        provides("uuid")
 
     conflicts("%gcc@14:")

--- a/var/spack/repos/builtin/packages/libuuid/package.py
+++ b/var/spack/repos/builtin/packages/libuuid/package.py
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import *
 import sys
+from spack.package import *
+
 
 class Libuuid(AutotoolsPackage, SourceforgePackage):
     """Portable uuid C library"""

--- a/var/spack/repos/builtin/packages/libuuid/package.py
+++ b/var/spack/repos/builtin/packages/libuuid/package.py
@@ -22,7 +22,7 @@ class Libuuid(AutotoolsPackage, SourceforgePackage):
 
     depends_on("c", type="build")  # generated
 
-    if sys.platform not in ["darwin", "windows"]:
+    if sys.platform not in ["darwin", "win32"]:
         provides("uuid")
 
     conflicts("%gcc@14:")

--- a/var/spack/repos/builtin/packages/libuuid/package.py
+++ b/var/spack/repos/builtin/packages/libuuid/package.py
@@ -20,7 +20,7 @@ class Libuuid(AutotoolsPackage, SourceforgePackage):
 
     depends_on("c", type="build")  # generated
 
-    if sys.platform not in ["darwin", "windows"]: #only provide on *nix-like
+    if sys.platform not in ["darwin", "windows"]:
         provides("uuid")
 
     conflicts("%gcc@14:")

--- a/var/spack/repos/builtin/packages/libuuid/package.py
+++ b/var/spack/repos/builtin/packages/libuuid/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import sys
+
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/ossp-uuid/package.py
+++ b/var/spack/repos/builtin/packages/ossp-uuid/package.py
@@ -24,7 +24,7 @@ class OsspUuid(AutotoolsPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    if sys.platform not in ["darwin", "windows"]:
+    if sys.platform not in ["darwin", "win32"]:
         provides("uuid")
 
     @property

--- a/var/spack/repos/builtin/packages/ossp-uuid/package.py
+++ b/var/spack/repos/builtin/packages/ossp-uuid/package.py
@@ -22,7 +22,7 @@ class OsspUuid(AutotoolsPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    if sys.platform not in ["darwin", "windows"]:
+    if sys.platform not in ["darwin", "windows"]: #only provide on *nix-like
         provides("uuid")
 
     @property

--- a/var/spack/repos/builtin/packages/ossp-uuid/package.py
+++ b/var/spack/repos/builtin/packages/ossp-uuid/package.py
@@ -24,6 +24,8 @@ class OsspUuid(AutotoolsPackage):
 
     provides("uuid")
 
+    conflicts("platform=darwin")
+
     @property
     def libs(self):
         return find_libraries("libuuid", self.prefix, recursive=True)

--- a/var/spack/repos/builtin/packages/ossp-uuid/package.py
+++ b/var/spack/repos/builtin/packages/ossp-uuid/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-
+import sys
 
 class OsspUuid(AutotoolsPackage):
     """OSSP uuid is a ISO-C:1999 application programming interface (API) and
@@ -22,9 +22,8 @@ class OsspUuid(AutotoolsPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    provides("uuid")
-
-    conflicts("platform=darwin")
+    if sys.platform not in ["darwin", "windows"]:
+        provides("uuid")
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/ossp-uuid/package.py
+++ b/var/spack/repos/builtin/packages/ossp-uuid/package.py
@@ -22,7 +22,7 @@ class OsspUuid(AutotoolsPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    if sys.platform not in ["darwin", "windows"]: #only provide on *nix-like
+    if sys.platform not in ["darwin", "windows"]:
         provides("uuid")
 
     @property

--- a/var/spack/repos/builtin/packages/ossp-uuid/package.py
+++ b/var/spack/repos/builtin/packages/ossp-uuid/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import sys
+
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/ossp-uuid/package.py
+++ b/var/spack/repos/builtin/packages/ossp-uuid/package.py
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import *
 import sys
+from spack.package import *
+
 
 class OsspUuid(AutotoolsPackage):
     """OSSP uuid is a ISO-C:1999 application programming interface (API) and

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -300,7 +300,7 @@ class Python(Package):
 
         # macos sdk already defines and uses uuid.h. 
         #  However it uses uuid types that are not defined in libuuid
-        if sys.platform != "darwin"
+        if sys.platform != "darwin":
             depends_on("uuid", when="+uuid")
 
         depends_on("tix", when="+tix")

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -298,7 +298,7 @@ class Python(Package):
         depends_on("tcl@8.5.12:", when="@3.11: +tkinter")
         depends_on("tcl", when="+tkinter")
 
-        # macos sdk already defines and uses uuid.h. 
+        # macos sdk already defines and uses uuid.h
         #  However it uses uuid types that are not defined in libuuid
         if sys.platform != "darwin":
             depends_on("uuid", when="+uuid")

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -298,10 +298,7 @@ class Python(Package):
         depends_on("tcl@8.5.12:", when="@3.11: +tkinter")
         depends_on("tcl", when="+tkinter")
 
-        # macos sdk already defines and uses uuid.h
-        #  However it uses uuid types that are not defined in libuuid
-        if sys.platform != "darwin":
-            depends_on("uuid", when="+uuid")
+        depends_on("uuid", when="+uuid")
 
         depends_on("tix", when="+tix")
         depends_on("libxcrypt", when="+crypt")

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -297,9 +297,7 @@ class Python(Package):
         depends_on("tk", when="+tkinter")
         depends_on("tcl@8.5.12:", when="@3.11: +tkinter")
         depends_on("tcl", when="+tkinter")
-
         depends_on("uuid", when="+uuid")
-
         depends_on("tix", when="+tix")
         depends_on("libxcrypt", when="+crypt")
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -297,7 +297,12 @@ class Python(Package):
         depends_on("tk", when="+tkinter")
         depends_on("tcl@8.5.12:", when="@3.11: +tkinter")
         depends_on("tcl", when="+tkinter")
-        depends_on("uuid", when="+uuid")
+
+        # macos sdk already defines and uses uuid.h. 
+        #  However it uses uuid types that are not defined in libuuid
+        if sys.platform != "darwin"
+            depends_on("uuid", when="+uuid")
+
         depends_on("tix", when="+tix")
         depends_on("libxcrypt", when="+crypt")
 

--- a/var/spack/repos/builtin/packages/util-linux-uuid/package.py
+++ b/var/spack/repos/builtin/packages/util-linux-uuid/package.py
@@ -31,7 +31,7 @@ class UtilLinuxUuid(AutotoolsPackage):
 
     depends_on("pkgconfig", type="build")
 
-    if sys.platform not in ["darwin", "windows"]:
+    if sys.platform not in ["darwin", "win32"]:
         provides("uuid")
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/util-linux-uuid/package.py
+++ b/var/spack/repos/builtin/packages/util-linux-uuid/package.py
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import *
 import sys
+from spack.package import *
 
 
 class UtilLinuxUuid(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/util-linux-uuid/package.py
+++ b/var/spack/repos/builtin/packages/util-linux-uuid/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
+import sys
 
 
 class UtilLinuxUuid(AutotoolsPackage):
@@ -29,7 +30,8 @@ class UtilLinuxUuid(AutotoolsPackage):
 
     depends_on("pkgconfig", type="build")
 
-    provides("uuid", when="platform=linux")
+    if sys.platform not in ["darwin", "windows"]:
+        provides("uuid")
 
     def url_for_version(self, version):
         url = "https://www.kernel.org/pub/linux/utils/util-linux/v{0}/util-linux-{1}.tar.gz"

--- a/var/spack/repos/builtin/packages/util-linux-uuid/package.py
+++ b/var/spack/repos/builtin/packages/util-linux-uuid/package.py
@@ -29,9 +29,7 @@ class UtilLinuxUuid(AutotoolsPackage):
 
     depends_on("pkgconfig", type="build")
 
-    provides("uuid")
-
-    conflicts("platform=darwin")
+    provides("uuid", when="platform=linux")
 
     def url_for_version(self, version):
         url = "https://www.kernel.org/pub/linux/utils/util-linux/v{0}/util-linux-{1}.tar.gz"

--- a/var/spack/repos/builtin/packages/util-linux-uuid/package.py
+++ b/var/spack/repos/builtin/packages/util-linux-uuid/package.py
@@ -30,7 +30,7 @@ class UtilLinuxUuid(AutotoolsPackage):
 
     depends_on("pkgconfig", type="build")
 
-    if sys.platform not in ["darwin", "windows"]: #only provide on *nix-like
+    if sys.platform not in ["darwin", "windows"]:
         provides("uuid")
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/util-linux-uuid/package.py
+++ b/var/spack/repos/builtin/packages/util-linux-uuid/package.py
@@ -30,7 +30,7 @@ class UtilLinuxUuid(AutotoolsPackage):
 
     depends_on("pkgconfig", type="build")
 
-    if sys.platform not in ["darwin", "windows"]:
+    if sys.platform not in ["darwin", "windows"]: #only provide on *nix-like
         provides("uuid")
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/util-linux-uuid/package.py
+++ b/var/spack/repos/builtin/packages/util-linux-uuid/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import sys
+
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/util-linux-uuid/package.py
+++ b/var/spack/repos/builtin/packages/util-linux-uuid/package.py
@@ -31,6 +31,8 @@ class UtilLinuxUuid(AutotoolsPackage):
 
     provides("uuid")
 
+    conflicts("platform=darwin")
+
     def url_for_version(self, version):
         url = "https://www.kernel.org/pub/linux/utils/util-linux/v{0}/util-linux-{1}.tar.gz"
         return url.format(version.up_to(2), version)


### PR DESCRIPTION
Macos already defines a uuid.h at `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/uuid/uuid.h` that defines this type
```
#ifndef _UUID_STRING_T
#define _UUID_STRING_T
typedef __darwin_uuid_string_t  uuid_string_t;
#endif /* _UUID_STRING_T */
```
This type is not included with `libuuid` / `linux-utl` libraries. Python packages that use core SDK features, like `py-matplotlib` that uses `CarbonCore.framework` have compilation errors that looks like:

```
/Users/cmarsh/Documents/science/code/spack/lib/spack/env/clang/clang -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/Users/cmarsh/Documents/science/code/spack/opt/spack/darwin-sonoma-m1/apple-clang-15.0.0/python-3.11.7-iu63c3hdeosb2vpkjzvkt5zhlfozs2yv/include/python3.11 -c src/_macosx.m -o build/temp.macosx-14.0-arm64-cpython-311/matplotlib.backends._macosx/src/_macosx.o -Werror -fvisibility=hidden -flto
  In file included from src/_macosx.m:2:
  In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Cocoa.framework/Headers/Cocoa.h:12:
  In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:93:
  In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLError.h:15:
  In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreServices.framework/Headers/CoreServices.h:23:
  In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/AE.framework/Headers/AE.h:20:
  In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/CarbonCore.h:208:
  In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/HFSVolumes.h:25:
  /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/hfs/hfs_format.h:802:2: error: unknown type name 'uuid_string_t'; did you mean 'io_string_t'?
          uuid_string_t   ext_jnl_uuid;
          ^
  /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/device/device_types.h:89:33: note: 'io_string_t' declared here
  typedef char                    io_string_t[512];
                                  ^
  In file included from src/_macosx.m:2:
  In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Cocoa.framework/Headers/Cocoa.h:12:
  In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:93:
  In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLError.h:15:
  In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreServices.framework/Headers/CoreServices.h:23:
  In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/AE.framework/Headers/AE.h:20:
  In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/CarbonCore.h:208:
  In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/HFSVolumes.h:25:
  /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/hfs/hfs_format.h:804:20: error: use of undeclared identifier 'uuid_string_t'
          char            reserved[JIB_RESERVED_SIZE];
                                   ^
  /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/hfs/hfs_format.h:795:61: note: expanded from macro 'JIB_RESERVED_SIZE'
  #define JIB_RESERVED_SIZE  ((32*sizeof(u_int32_t)) - sizeof(uuid_string_t) - 48)
                                                              ^
```

I chose to remove the `uuid` reference for darwin as the `apple-libuuid` package (which seems a natural fit) doesn't have any uuid refernce in it

```
spack info apple-libuuid
BundlePackage:   apple-libuuid

Description:
    Placeholder package for Apple's analogue to non-GNU libuuid

Homepage: https://opensource.apple.com/tarballs/Libsystem/
```

```
❯ cd Libsystem-Libsystem-1336.80.1
❯ ag uuid
❯ find . -name uuid
```
However I can ammend if this really is the better option

