### PR TITLE
package/qgis & gdal: fix_zstd_support

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -368,7 +368,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     # depends_on('tiledb', when='+tiledb')
     depends_on("libwebp", when="+webp")
     depends_on("xerces-c@3.1:", when="+xercesc")
-    depends_on("zstd", when="+zstd") # TODO only true if internal libtiff is used?
+    depends_on("zstd", when="+zstd")  # TODO only true if internal libtiff is used?
 
     # Language bindings
     # FIXME: Allow packages to extend multiple packages

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -264,6 +264,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     depends_on("zlib-api")
     depends_on("libtiff@4:", when="@3:")
     depends_on("libtiff@3.6.0:")  # 3.9.0+ needed to pass testsuite
+    depends_on("libtiff+zstd", when="+zstd")
     depends_on("libgeotiff@1.5:", when="@3:")
     depends_on("libgeotiff@1.2.1:1.5", when="@2.4.1:2")
     depends_on("libgeotiff@1.2.1:1.4", when="@:2.4.0")
@@ -367,7 +368,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     # depends_on('tiledb', when='+tiledb')
     depends_on("libwebp", when="+webp")
     depends_on("xerces-c@3.1:", when="+xercesc")
-    depends_on("zstd", when="+zstd")
+    depends_on("zstd", when="+zstd") # TODO only true if internal libtiff is used?
 
     # Language bindings
     # FIXME: Allow packages to extend multiple packages

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -368,7 +368,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     # depends_on('tiledb', when='+tiledb')
     depends_on("libwebp", when="+webp")
     depends_on("xerces-c@3.1:", when="+xercesc")
-    depends_on("zstd", when="+zstd")  # TODO only true if internal libtiff is used?
+    depends_on("zstd", when="+zstd")
 
     # Language bindings
     # FIXME: Allow packages to extend multiple packages

--- a/var/spack/repos/builtin/packages/qgis/package.py
+++ b/var/spack/repos/builtin/packages/qgis/package.py
@@ -111,6 +111,7 @@ class Qgis(CMakePackage):
     depends_on("expat@1.95:")
     depends_on("gdal@2.1.0: +python", type=("build", "link", "run"))
     depends_on("gdal@3.2.0: +python", type=("build", "link", "run"), when="@3.28:")
+    depends_on("gdal+zstd", when="+zstd")
     depends_on("geos@3.4.0:")
     depends_on("libspatialindex")
     depends_on("libspatialite@4.2.0:")

--- a/var/spack/repos/builtin/packages/qgis/package.py
+++ b/var/spack/repos/builtin/packages/qgis/package.py
@@ -110,8 +110,9 @@ class Qgis(CMakePackage):
     depends_on("exiv2")
     depends_on("expat@1.95:")
     depends_on("gdal@2.1.0: +python", type=("build", "link", "run"))
+    # Since qgis requires zstd as of 3.22
+    depends_on("gdal@3.2.0: +python +zstd", type=("build", "link", "run"), when="@3.22:")
     depends_on("gdal@3.2.0: +python", type=("build", "link", "run"), when="@3.28:")
-    depends_on("gdal+zstd", when="+zstd")
     depends_on("geos@3.4.0:")
     depends_on("libspatialindex")
     depends_on("libspatialite@4.2.0:")

--- a/var/spack/repos/builtin/packages/qgis/package.py
+++ b/var/spack/repos/builtin/packages/qgis/package.py
@@ -110,8 +110,8 @@ class Qgis(CMakePackage):
     depends_on("exiv2")
     depends_on("expat@1.95:")
     depends_on("gdal@2.1.0: +python", type=("build", "link", "run"))
-    # Since qgis requires zstd as of 3.22
-    depends_on("gdal@3.2.0: +python +zstd", type=("build", "link", "run"), when="@3.22:")
+    # Since qgis requires zstd as of 3.22, it's implicit that it should require gdal+zstd
+    depends_on("gdal+zstd", when="@3.22")
     depends_on("gdal@3.2.0: +python", type=("build", "link", "run"), when="@3.28:")
     depends_on("geos@3.4.0:")
     depends_on("libspatialindex")

--- a/var/spack/repos/builtin/packages/qgis/package.py
+++ b/var/spack/repos/builtin/packages/qgis/package.py
@@ -111,8 +111,8 @@ class Qgis(CMakePackage):
     depends_on("expat@1.95:")
     depends_on("gdal@2.1.0: +python", type=("build", "link", "run"))
     # Since qgis requires zstd as of 3.22, it's implicit that it should require gdal+zstd
-    depends_on("gdal+zstd", when="@3.22")
-    depends_on("gdal@3.2.0: +python", type=("build", "link", "run"), when="@3.28:")
+    depends_on("gdal@3: +python +zstd", type=("build", "link", "run"), when="@3.22:")
+    depends_on("gdal@3.2.0: +python +zstd", type=("build", "link", "run"), when="@3.28:")
     depends_on("geos@3.4.0:")
     depends_on("libspatialindex")
     depends_on("libspatialite@4.2.0:")


### PR DESCRIPTION
ran into an issue with qgis in opening compressed cog geotiffs.
gdal+zstd didn't fix the issue
qgis already requires zstd as of 3.22
'gdal ^libtiff+zstd' is the way to go.
from gdal docs:
> ZSTD is available since GDAL 2.3 when using internal libtiff and if GDAL built against libzstd >=1.0, or if built against external libtiff with zstd support.

Since, we're building gdal with extrnal libtiff, it should depend on `libtiff+zstd` Accordingly, zstd dependency in gdal can be removed since it's only useful if internal libtiff is used.
