### PR TITLE
mpfr: missing dependency for version 4.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -38,7 +38,7 @@ class Mpfr(AutotoolsPackage, GNUMirrorPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("autoconf-archive", when="@4.0.1:", type="build")
+    depends_on("autoconf-archive", when="@4.0.0:", type="build")
     depends_on("texinfo", when="@4.1.0:", type="build")
 
     variant(

--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -38,7 +38,7 @@ class Mpfr(AutotoolsPackage, GNUMirrorPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("autoconf-archive", when="@4.0.2:", type="build")
+    depends_on("autoconf-archive", when="@4.0.1:", type="build")
     depends_on("texinfo", when="@4.1.0:", type="build")
 
     variant(


### PR DESCRIPTION
mpfr 4.0.1 (like 4.0.2) needs autoconf-archive where it takes the AX_PTHREAD macro from

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
