### PR TITLE
perl-catalyst-devel and deps: new packages

### DIFF
--- a/var/spack/repos/builtin/packages/perl-catalyst-devel/package.py
+++ b/var/spack/repos/builtin/packages/perl-catalyst-devel/package.py
@@ -1,0 +1,46 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlCatalystDevel(PerlPackage):
+    """Catalyst Development Tools"""
+
+    homepage = "https://metacpan.org/pod/Catalyst::Devel"
+    url = "https://cpan.metacpan.org/authors/id/H/HA/HAARG/Catalyst-Devel-1.42.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.42", sha256="7ec6f0b6cab5b8c097e47769fc73a4d4c015a58c41fdb40fc24df3ee77c48abd")
+
+    depends_on("perl-catalyst-action-renderview@0.10:", type=("build", "run", "test"))
+    depends_on("perl-catalyst-plugin-configloader@0.30:", type=("build", "run", "test"))
+    depends_on("perl-catalyst-plugin-static-simple@0.28:", type=("build", "run", "test"))
+    depends_on("perl-catalyst-runtime", type=("build", "run", "test"))
+    depends_on("perl-config-general@2.42:", type=("build", "run", "test"))
+    depends_on("perl-file-changenotify@0.07:", type=("build", "run", "test"))
+    depends_on("perl-file-copy-recursive", type=("build", "run", "test"))
+    depends_on("perl-file-sharedir", type=("build", "run", "test"))
+    depends_on("perl-file-sharedir-install", type=("build"))
+    depends_on("perl-module-install@1.02:", type=("build", "run", "test"))
+    depends_on("perl-moose", type=("build", "run", "test"))
+    depends_on("perl-moosex-emulate-class-accessor-fast", type=("build", "run", "test"))
+    depends_on("perl-namespace-autoclean", type=("build", "run", "test"))
+    depends_on("perl-namespace-clean", type=("build", "run", "test"))
+    depends_on("perl-path-class@0.09:", type=("build", "run", "test"))
+    depends_on("perl-template-toolkit", type=("build", "run", "test"))
+    depends_on("perl-test-fatal@0.003:", type=("build", "test"))
+    depends_on("perl-yaml-tiny", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Catalyst::Devel; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-catalyst-plugin-configloader/package.py
+++ b/var/spack/repos/builtin/packages/perl-catalyst-plugin-configloader/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlCatalystPluginConfigloader(PerlPackage):
+    """Load config files of various types"""
+
+    homepage = "https://metacpan.org/pod/Catalyst::Plugin::ConfigLoader"
+    url = (
+        "https://cpan.metacpan.org/authors/id/H/HA/HAARG/Catalyst-Plugin-ConfigLoader-0.35.tar.gz"
+    )
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.35", sha256="9e2a698a6f2d046e0dc5e57512929cd423c807d4a36ba3f29e9e5adcd71a1971")
+
+    depends_on("perl-catalyst-runtime@5.7008:", type=("build", "run", "test"))
+    depends_on("perl-config-any@0.20:", type=("build", "run", "test"))
+    depends_on("perl-data-visitor@0.24:", type=("build", "run", "test"))
+    depends_on("perl-mro-compat@0.09:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Catalyst::Plugin::ConfigLoader; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-catalyst-plugin-static-simple/package.py
+++ b/var/spack/repos/builtin/packages/perl-catalyst-plugin-static-simple/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlCatalystPluginStaticSimple(PerlPackage):
+    """Make serving static pages painless."""
+
+    homepage = "https://metacpan.org/pod/Catalyst::Plugin::Static::Simple"
+    url = "https://cpan.metacpan.org/authors/id/I/IL/ILMARI/Catalyst-Plugin-Static-Simple-0.37.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("0.37", sha256="5a4d85a3588cd4e83f1b002581412e7d71b7d57f66056e5d87a36f93d89c9e7c")
+
+    depends_on("perl-catalyst-runtime@5.80008:", type=("build", "run", "test"))
+    depends_on("perl-mime-types@2.03:", type=("build", "run", "test"))
+    depends_on("perl-moose", type=("build", "run", "test"))
+    depends_on("perl-namespace-autoclean", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Catalyst::Plugin::Static::Simple; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-file-changenotify/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-changenotify/package.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlFileChangenotify(PerlPackage):
+    """Watch for changes to files, cross-platform style"""
+
+    homepage = "https://metacpan.org/pod/File::ChangeNotify"
+    url = "https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/File-ChangeNotify-0.31.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-2.0")
+
+    version("0.31", sha256="192bdb1ce76266c6a694a8e962d039e3adeeb829b6ac1e23f5057f2b506392bd")
+
+    depends_on("perl-module-pluggable", type=("build", "run", "test"))
+    depends_on("perl-module-runtime", type=("build", "run", "test"))
+    depends_on("perl-moo@1.006:", type=("build", "run", "test"))
+    depends_on("perl-namespace-autoclean", type=("build", "run", "test"))
+    depends_on("perl-test-requires", type=("build", "test"))
+    depends_on("perl-test-without-module", type=("build", "test"))
+    depends_on("perl-test2-suite", type=("build", "test"))
+    depends_on("perl-type-tiny", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use File::ChangeNotify; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
This add Catalyst::Devel and its missing dependencies:
- Catalyst::Plugin::ConfigLoader
- Catalyst::Plugin::Static::Simple
- File::ChangeNotify

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
