### PR TITLE
perl-sereal and deps: new packages

### DIFF
--- a/var/spack/repos/builtin/packages/perl-sereal-decoder/package.py
+++ b/var/spack/repos/builtin/packages/perl-sereal-decoder/package.py
@@ -1,0 +1,44 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlSerealDecoder(PerlPackage):
+    """Fast, compact, powerful binary deserialization"""
+
+    homepage = "https://metacpan.org/pod/Sereal::Decoder"
+    url = "https://cpan.metacpan.org/authors/id/Y/YV/YVES/Sereal-Decoder-5.004.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("5.004", sha256="68ef0314d87d1a6e60bb0f66fcf43eb2cacdeb1754432f5e25e784e39d3e6784")
+
+    depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-devel-checklib@1.16:", type=("build"))
+    depends_on("perl-test-deep", type=("build", "link", "test"))
+    depends_on("perl-test-differences", type=("build", "link", "test"))
+    depends_on("perl-test-longstring", type=("build", "link", "test"))
+    depends_on("perl-test-warn", type=("build", "link", "test"))
+    depends_on("zstd", type=("build", "link", "run", "test"))
+
+    def setup_build_environment(self, env):
+        # These are not currently available in Spack
+        env.set("SEREAL_USE_BUNDLED_CSNAPPY", "1")
+        env.set("SEREAL_USE_BUNDLED_MINIZ", "1")
+        env.set("USE_UNALIGNED", "1")
+        env.set("USE_UNALIGNED", "1")
+        env.set("NO_ASM", "0")
+        env.set("ZSTD_DISABLE_ASM", "0")
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Sereal::Decoder; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-sereal-encoder/package.py
+++ b/var/spack/repos/builtin/packages/perl-sereal-encoder/package.py
@@ -1,0 +1,45 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlSerealEncoder(PerlPackage):
+    """Fast, compact, powerful binary serialization"""
+
+    homepage = "https://metacpan.org/pod/Sereal::Encoder"
+    url = "https://cpan.metacpan.org/authors/id/Y/YV/YVES/Sereal-Encoder-5.004.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("5.004", sha256="5e5a86ccd32dae34ed80932ecbe5c68e29752b5de0e9b0a793ab7eb2ca55cb1b")
+
+    depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-devel-checklib@1.16:", type=("build"))
+    depends_on("perl-sereal-decoder@5.004:", type=("build", "link", "run", "test"))
+    depends_on("perl-test-deep", type=("build", "link", "test"))
+    depends_on("perl-test-differences", type=("build", "link", "test"))
+    depends_on("perl-test-longstring", type=("build", "link", "test"))
+    depends_on("perl-test-warn", type=("build", "link", "test"))
+    depends_on("zstd", type=("build", "link", "run", "test"))
+
+    def setup_build_environment(self, env):
+        # These are not currently available in Spack
+        env.set("SEREAL_USE_BUNDLED_CSNAPPY", "1")
+        env.set("SEREAL_USE_BUNDLED_MINIZ", "1")
+        env.set("USE_UNALIGNED", "1")
+        env.set("USE_UNALIGNED", "1")
+        env.set("NO_ASM", "0")
+        env.set("ZSTD_DISABLE_ASM", "0")
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Sereal::Encoder; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-sereal/package.py
+++ b/var/spack/repos/builtin/packages/perl-sereal/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlSereal(PerlPackage):
+    """Fast, compact, powerful binary (de-)serialization"""
+
+    homepage = "https://metacpan.org/pod/Sereal"
+    url = "https://cpan.metacpan.org/authors/id/Y/YV/YVES/Sereal-5.004.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("5.004", sha256="9c25bb7ae4bd736d24b1ad1d93d77395b0c65ca8741e266bfc0cbe542261d76f")
+
+    depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-sereal-decoder@5.004:", type=("build", "run", "test"))
+    depends_on("perl-sereal-encoder@5.004:", type=("build", "run", "test"))
+    depends_on("perl-test-deep", type=("build", "test"))
+    depends_on("perl-test-differences", type=("build", "test"))
+    depends_on("perl-test-longstring", type=("build", "test"))
+    depends_on("perl-test-warn", type=("build", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Sereal; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
This adds Sereal and its missing dependencies:
- Sereal::Encoder
- Sereal::Decoder

Build-time tests depend on my pending changes to Test::Warn to pass ( PR #42901 ).
The package itself will work, it's just the test suite that's failing.
With that, installation with build-time tests works fine.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
