### PR TITLE
perl-test-mockobject and deps: new packages

### DIFF
--- a/var/spack/repos/builtin/packages/perl-test-mockobject/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-mockobject/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTestMockobject(PerlPackage):
+    """Perl extension for emulating troublesome interfaces"""
+
+    homepage = "https://metacpan.org/pod/Test::MockObject"
+    url = "https://cpan.metacpan.org/authors/id/C/CH/CHROMATIC/Test-MockObject-1.20200122.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version(
+        "1.20200122", sha256="2b7f80da87f5a6fe0360d9ee521051053017442c3a26e85db68dfac9f8307623"
+    )
+
+    depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-test-exception@0.31:", type=("build", "test"))
+    depends_on("perl-test-warn@0.23:", type=("build", "test"))
+    depends_on("perl-universal-can@1.20110617:", type=("build", "run", "test"))
+    depends_on("perl-universal-isa@1.20110614:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Test::MockObject; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-universal-can/package.py
+++ b/var/spack/repos/builtin/packages/perl-universal-can/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlUniversalCan(PerlPackage):
+    """Work around buggy code calling UNIVERSAL::can() as a function"""
+
+    homepage = "https://metacpan.org/pod/UNIVERSAL::can"
+    url = "https://cpan.metacpan.org/authors/id/C/CH/CHROMATIC/UNIVERSAL-can-1.20140328.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version(
+        "1.20140328", sha256="522da9f274786fe2cba99bc77cc1c81d2161947903d7fad10bd62dfb7f11990f"
+    )
+
+    depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use UNIVERSAL::can; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-universal-isa/package.py
+++ b/var/spack/repos/builtin/packages/perl-universal-isa/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlUniversalIsa(PerlPackage):
+    """Attempt to recover from people calling UNIVERSAL::isa as a function"""
+
+    homepage = "https://metacpan.org/pod/UNIVERSAL::isa"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/UNIVERSAL-isa-1.20171012.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version(
+        "1.20171012", sha256="d16956036cb01c819dec7d294f6ef891be0bb64876989601354b293164da7f2b"
+    )
+
+    depends_on("perl@5.6.2:", type=("build", "link", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use UNIVERSAL::isa; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
Adds Test::MockObject and its dependencies.
Installed OK with build-time tests. Added dependencies:
- UNIVERSAL::can
- UNIVERSAL::isa

These modules are not the same as the UNIVERSAL core module.
They exist as a workaround to test (or use) other Perl modules that are not well-behaved.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
