### PR TITLE
perl-test-perl-critic: new package

### DIFF
--- a/var/spack/repos/builtin/packages/perl-test-perl-critic/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-perl-critic/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTestPerlCritic(PerlPackage):
+    """Use Perl::Critic in test programs."""
+
+    homepage = "https://metacpan.org/pod/Test::Perl::Critic"
+    url = "https://cpan.metacpan.org/authors/id/P/PE/PETDANCE/Test-Perl-Critic-1.04.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-1.0-Perl OR GPL-1.0-or-later")
+
+    version("1.04", sha256="28f806b5412c7908b56cf1673084b8b44ce1cb54c9417d784d91428e1a04096e")
+
+    depends_on("perl-mce@1.827:", type=("build", "run", "test"))
+    depends_on("perl-perl-critic@1.105:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Test::Perl::Critic; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
Adds Test::Perl::Critic

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
