### PR TITLE
perl-test-pod-coverage and deps: new packages

### DIFF
--- a/var/spack/repos/builtin/packages/perl-pod-coverage/package.py
+++ b/var/spack/repos/builtin/packages/perl-pod-coverage/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlPodCoverage(PerlPackage):
+    """Checks if the documentation of a module is comprehensive"""
+
+    homepage = "https://metacpan.org/pod/Pod::Coverage"
+    url = "https://cpan.metacpan.org/authors/id/R/RC/RCLAMP/Pod-Coverage-0.23.tar.gz"
+
+    maintainers("EbiArnie")
+
+    version("0.23", sha256="30b7a0b0c942f44a7552c0d34e9b1f2e0ba0b67955c61e3b1589ec369074b107")
+
+    depends_on("perl-devel-symdump@2.01:", type=("build", "run", "test"))
+    depends_on("perl-pod-parser@1.13:", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Pod::Coverage; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-pod-coverage/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-pod-coverage/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PerlTestPodCoverage(PerlPackage):
+    """Check for pod coverage in your distribution"""
+
+    homepage = "https://metacpan.org/pod/Test::Pod::Coverage"
+    url = "https://cpan.metacpan.org/authors/id/N/NE/NEILB/Test-Pod-Coverage-1.10.tar.gz"
+
+    maintainers("EbiArnie")
+
+    license("Artistic-2.0")
+
+    version("1.10", sha256="48c9cca9f7d99eee741176445b431adf09c029e1aa57c4703c9f46f7601d40d4")
+
+    depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
+    depends_on("perl-pod-coverage", type=("build", "run", "test"))
+
+    def test_use(self):
+        """Test 'use module'"""
+        options = ["-we", 'use strict; use Test::Pod::Coverage; print("OK\n")']
+
+        perl = self.spec["perl"].command
+        out = perl(*options, output=str.split, error=str.split)
+        assert "OK" in out


### PR DESCRIPTION
Adds Test::Pod::Coverage and its dependencies.
Installed OK with build-time tests. Added dependencies:
- Pod::Coverage

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
