### PR TITLE
serialbox: fix PYTHONPATH

### DIFF
--- a/var/spack/repos/builtin/packages/serialbox/package.py
+++ b/var/spack/repos/builtin/packages/serialbox/package.py
@@ -156,7 +156,7 @@ class Serialbox(CMakePackage):
         env.prepend_path("PATH", self.prefix.python.pp_ser)
         # Allow for running the preprocessor as a Python module, as well as
         # enable the Python interface in a non-standard directory:
-        env.prepend_path("PYTHONPATH", self.prefix.python)
+        env.prepend_path("PYTHONPATH", self.prefix.python.pp_ser)
 
     def setup_dependent_package(self, module, dependent_spec):
         # Simplify the location of the preprocessor by dependent packages:


### PR DESCRIPTION
This fixes the `setup_run_environment` method of `serialbox`, which currently extends `PYTHONPATH` with the path to a wrong directory.