### PR TITLE
eccodes: drop redundant build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -113,7 +113,6 @@ class Eccodes(CMakePackage):
     depends_on("cmake@3.12:", when="@2.19:", type="build")
 
     depends_on("ecbuild", type="build", when="@develop")
-    depends_on("ecbuild@3.7:", type="build", when="@2.25:")
 
     conflicts("+openmp", when="+pthreads", msg="Cannot enable both POSIX threads and OMP")
 


### PR DESCRIPTION
The release tarballs of `eccodes` contain all required `CMake` scripts, therefore `ecbuild` should not be needed for non-develop versions. I did not notice that when I was reviewing #40770.