### PR TITLE
NetCDF-C: Skip problematic post install on Windows

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -358,6 +358,8 @@ class CMakeBuilder(BaseBuilder, cmake.CMakeBuilder):
         due to incorrectly using hdf5 target names
         https://github.com/spack/spack/pull/42878
         """
+        if sys.platform == "win32":
+            return
 
         pkgconfig_file = find(self.prefix, "netcdf.pc", recursive=True)
         cmakeconfig_file = find(self.prefix, "netCDFTargets.cmake", recursive=True)


### PR DESCRIPTION
#42878 adds a post install filter of the netCDFConfig.cmake file.
This replaces a valid CMake target on Windows with an invalid one.
Do not do this.

Stopgap fix to: #43038; real solution should have a more robust consideration of the HDF5-netCDF CMake interface.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
