### PR TITLE
Kokkos Kernels: adding missing TPLs and pre-conditions

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos-kernels/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/package.py
@@ -147,8 +147,6 @@ class KokkosKernels(CMakePackage, CudaPackage):
         "rocblas": (False, "rocblas", "ROCBLAS", "@3.6.00:", "Link to AMD BLAS library"),
         "rocsparse": (False, "rocsparse", "ROCSPARSE", "@3.6.00:", "Link to AMD sparse library"),
     }
-        # "cusolver": (False, "cuda", None, "@4.3.00:", "Link to CUDA solver library"),
-        # "rocsolver": (False, "rocsolver", "ROCSOLVER", "@4.3.00:", "Link to AMD solver library"),
 
     for tpl in tpls:
         deflt_bool, spackname, rootname, condition, descr = tpls[tpl]

--- a/var/spack/repos/builtin/packages/kokkos-kernels/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/package.py
@@ -135,7 +135,7 @@ class KokkosKernels(CMakePackage, CudaPackage):
         variant(eti, default=deflt, description=eti, values=vals, multi=True)
 
     tpls = {
-        # variant name   #deflt   #spack name   #root var name #docstring
+        # variant name   #deflt   #spack name  #root var name  #supporting versions  #docstring
         "blas": (False, "blas", "BLAS", "@3.0.00:", "Link to system BLAS"),
         "lapack": (False, "lapack", "LAPACK", "@3.0.00:", "Link to system LAPACK"),
         "mkl": (False, "mkl", "MKL", "@3.0.00:", "Link to system MKL"),
@@ -150,7 +150,7 @@ class KokkosKernels(CMakePackage, CudaPackage):
 
     for tpl in tpls:
         deflt_bool, spackname, rootname, condition, descr = tpls[tpl]
-        variant(tpl, default=deflt_bool, when="%s" % condition, description=descr)
+        variant(tpl, default=deflt_bool, when=f'{condition}', description=descr)
         depends_on(spackname, when="+%s" % tpl)
 
     variant("shared", default=True, description="Build shared libraries")

--- a/var/spack/repos/builtin/packages/kokkos-kernels/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/package.py
@@ -136,19 +136,23 @@ class KokkosKernels(CMakePackage, CudaPackage):
 
     tpls = {
         # variant name   #deflt   #spack name   #root var name #docstring
-        "blas": (False, "blas", "BLAS", "Link to system BLAS"),
-        "lapack": (False, "lapack", "LAPACK", "Link to system LAPACK"),
-        "mkl": (False, "mkl", "MKL", "Link to system MKL"),
-        "cublas": (False, "cuda", None, "Link to CUDA BLAS library"),
-        "cusparse": (False, "cuda", None, "Link to CUDA sparse library"),
-        "superlu": (False, "superlu", "SUPERLU", "Link to SuperLU library"),
-        "cblas": (False, "cblas", "CBLAS", "Link to CBLAS library"),
-        "lapacke": (False, "clapack", "LAPACKE", "Link to LAPACKE library"),
+        "blas": (False, "blas", "BLAS", "@3.0.00:", "Link to system BLAS"),
+        "lapack": (False, "lapack", "LAPACK", "@3.0.00:", "Link to system LAPACK"),
+        "mkl": (False, "mkl", "MKL", "@3.0.00:", "Link to system MKL"),
+        "cublas": (False, "cuda", None, "@3.0.00:", "Link to CUDA BLAS library"),
+        "cusparse": (False, "cuda", None, "@3.0.00:", "Link to CUDA sparse library"),
+        "superlu": (False, "superlu", "SUPERLU", "@3.1.00:", "Link to SuperLU library"),
+        "cblas": (False, "cblas", "CBLAS", "@3.1.00:", "Link to CBLAS library"),
+        "lapacke": (False, "clapack", "LAPACKE", "@3.1.00:", "Link to LAPACKE library"),
+        "rocblas": (False, "rocblas", "ROCBLAS", "@3.6.00:", "Link to AMD BLAS library"),
+        "rocsparse": (False, "rocsparse", "ROCSPARSE", "@3.6.00:", "Link to AMD sparse library"),
     }
+        # "cusolver": (False, "cuda", None, "@4.3.00:", "Link to CUDA solver library"),
+        # "rocsolver": (False, "rocsolver", "ROCSOLVER", "@4.3.00:", "Link to AMD solver library"),
 
     for tpl in tpls:
-        deflt_bool, spackname, rootname, descr = tpls[tpl]
-        variant(tpl, default=deflt_bool, description=descr)
+        deflt_bool, spackname, rootname, condition, descr = tpls[tpl]
+        variant(tpl, default=deflt_bool, when="%s" % condition, description=descr)
         depends_on(spackname, when="+%s" % tpl)
 
     variant("shared", default=True, description="Build shared libraries")

--- a/var/spack/repos/builtin/packages/kokkos-kernels/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/package.py
@@ -150,7 +150,7 @@ class KokkosKernels(CMakePackage, CudaPackage):
 
     for tpl in tpls:
         deflt_bool, spackname, rootname, condition, descr = tpls[tpl]
-        variant(tpl, default=deflt_bool, when=f'{condition}', description=descr)
+        variant(tpl, default=deflt_bool, when=f"{condition}", description=descr)
         depends_on(spackname, when="+%s" % tpl)
 
     variant("shared", default=True, description="Build shared libraries")

--- a/var/spack/repos/builtin/packages/kokkos-kernels/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/package.py
@@ -176,7 +176,7 @@ class KokkosKernels(CMakePackage, CudaPackage):
         for tpl in self.tpls:
             on_flag = "+%s" % tpl
             off_flag = "~%s" % tpl
-            dflt, spackname, rootname, descr = self.tpls[tpl]
+            dflt, spackname, rootname, condition, descr = self.tpls[tpl]
             if on_flag in self.spec:
                 options.append("-DKokkosKernels_ENABLE_TPL_%s=ON" % tpl.upper())
                 if rootname:


### PR DESCRIPTION
Adding variants and dependencies for rocBLAS and rocSPARSE. Also adding a "when=" close to the TPL variants that prevents enabling the TPLs in versions of the library when it was not yet available.
