### PR TITLE
perl testing: refactor stand-alone testing into base class

### DIFF
--- a/lib/spack/docs/build_systems/perlpackage.rst
+++ b/lib/spack/docs/build_systems/perlpackage.rst
@@ -173,6 +173,72 @@ arguments to ``Makefile.PL`` or ``Build.PL`` by overriding
        ]
 
 
+^^^^^^^
+Testing
+^^^^^^^
+
+``PerlPackage`` provides a simple stand-alone test of the successfully
+installed package to confirm that installed perl module(s) can be used.
+These tests can be performed any time after the installation using
+``spack -v test run``. (For more information on the command, see 
+:ref:`cmd-spack-test-run`.)
+
+The base class automatically detects perl modules based on the presence
+of ``*.pm`` files under the package's library directory. For example,
+the files under ``perl-bignum``'s perl library are:
+
+.. code-block:: console
+
+   $ find . -name "*.pm"
+   ./bigfloat.pm
+   ./bigrat.pm
+   ./Math/BigFloat/Trace.pm
+   ./Math/BigInt/Trace.pm
+   ./Math/BigRat/Trace.pm
+   ./bigint.pm
+   ./bignum.pm
+
+
+which results in the package having the ``use_modules`` property containing:
+
+.. code-block:: python
+
+   use_modules = [
+       "bigfloat",
+       "bigrat",
+       "Math::BigFloat::Trace",
+       "Math::BigInt::Trace",
+       "Math::BigRat::Trace",
+       "bigint",
+       "bignum",
+   ]
+
+.. note::
+
+   This list can often be used to catch missing dependencies.
+
+If the list is somehow wrong, you can provide the names of the modules
+yourself by overriding ``use_modules`` like so:
+
+ .. code-block:: python
+
+    use_modules = ["bigfloat", "bigrat", "bigint", "bignum"]
+
+If you only want a subset of the automatically detected modules to be
+tested, you could instead define the ``skip_modules`` property on the
+package. So, instead of overriding ``use_modules`` as shown above, you
+could define the following:
+
+ .. code-block:: python
+
+    skip_modules = [
+        "Math::BigFloat::Trace",
+        "Math::BigInt::Trace",
+        "Math::BigRat::Trace",
+    ]
+
+for the same use tests.
+
 ^^^^^^^^^^^^^^^^^^^^^
 Alternatives to Spack
 ^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -45,11 +45,7 @@ class PerlPackage(spack.package_base.PackageBase):
 
         perl = self.spec["perl"].command
         for module in self.use_modules:
-            with test_part(
-                self,
-                f"test_use-{module}",
-                purpose=f"checking use of {module}",
-            ):
+            with test_part(self, f"test_use-{module}", purpose=f"checking use of {module}"):
                 options = ["-we", f'use strict; use {module}; print("OK\n")']
                 out = perl(*options, output=str.split, error=str.split)
                 assert "OK" in out

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -34,7 +34,7 @@ class PerlPackage(spack.package_base.PackageBase):
     @lang.classproperty
     def use_modules(cls) -> Iterable[str]:
         """The list of installed perl modules."""
-        if cls.homepage is not None and "metacpan.org" in cls.homepage:
+        if cls.homepage is not None and "metacpan.org/pod" in cls.homepage:
             return [os.path.basename(cls.homepage)]
         return []
 

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -6,8 +6,8 @@ import inspect
 import os
 from typing import Iterable
 
-from llnl.util.lang import memoized
 from llnl.util.filesystem import filter_file, find
+from llnl.util.lang import memoized
 
 import spack.builder
 import spack.package_base

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -221,6 +221,7 @@ def test_test_list_all(mock_packages):
         [
             "fail-test-audit",
             "mpich",
+            "perl-extension",
             "printing-package",
             "py-extension1",
             "py-extension2",

--- a/var/spack/repos/builtin/packages/perl-algorithm-c3/package.py
+++ b/var/spack/repos/builtin/packages/perl-algorithm-c3/package.py
@@ -19,11 +19,3 @@ class PerlAlgorithmC3(PerlPackage):
     version("0.11", sha256="aaf48467765deea6e48054bc7d43e46e4d40cbcda16552c629d37be098289309")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Algorithm::C3; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-alien-build-plugin-download-gitlab/package.py
+++ b/var/spack/repos/builtin/packages/perl-alien-build-plugin-download-gitlab/package.py
@@ -21,11 +21,3 @@ class PerlAlienBuildPluginDownloadGitlab(PerlPackage):
     depends_on("perl-path-tiny", type=("build", "run", "test"))
     depends_on("perl-test2-suite", type=("build", "test"))
     depends_on("perl-uri", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Alien::Build::Plugin::Download::GitLab; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-any-uri-escape/package.py
+++ b/var/spack/repos/builtin/packages/perl-any-uri-escape/package.py
@@ -17,11 +17,3 @@ class PerlAnyUriEscape(PerlPackage):
     version("0.01", sha256="e3813cec9f108fa5c0be66e08c1986bfba4d242151b0f9f4ec5e0c5e17108c4c")
 
     depends_on("perl-uri", type=("run"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Any::URI::Escape; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-apache-logformat-compiler/package.py
+++ b/var/spack/repos/builtin/packages/perl-apache-logformat-compiler/package.py
@@ -28,11 +28,3 @@ class PerlApacheLogformatCompiler(PerlPackage):
     depends_on("perl-test-requires", type=("build", "test"))
     depends_on("perl-try-tiny@0.12:", type=("build", "test"))
     depends_on("perl-uri", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Apache::LogFormat::Compiler; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-b-cow/package.py
+++ b/var/spack/repos/builtin/packages/perl-b-cow/package.py
@@ -19,11 +19,3 @@ class PerlBCow(PerlPackage):
     version("0.007", sha256="1290daf227e8b09889a31cf182e29106f1cf9f1a4e9bf7752f9de92ed1158b44")
 
     depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use B::COW; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-b-hooks-endofscope/package.py
+++ b/var/spack/repos/builtin/packages/perl-b-hooks-endofscope/package.py
@@ -22,11 +22,3 @@ class PerlBHooksEndofscope(PerlPackage):
     depends_on("perl@5.6.1:", type=("build", "link", "run", "test"))
     depends_on("perl-module-implementation@0.05:", type=("build", "run", "test"))
     depends_on("perl-sub-exporter-progressive@0.001006:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use B::Hooks::EndOfScope; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-b-keywords/package.py
+++ b/var/spack/repos/builtin/packages/perl-b-keywords/package.py
@@ -15,11 +15,3 @@ class PerlBKeywords(PerlPackage):
     maintainers("EbiArnie")
 
     version("1.26", sha256="2daa155d2f267fb0dedd87f8a4c4fb5663879fc106517b1ee258353ef87aed34")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use B::Keywords; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-bignum/package.py
+++ b/var/spack/repos/builtin/packages/perl-bignum/package.py
@@ -18,3 +18,5 @@ class PerlBignum(PerlPackage):
     depends_on("perl-math-bigrat", type=("build", "run"))
     depends_on("perl-math-bigint", type=("build", "run"))
     depends_on("perl-extutils-makemaker", type=("build"))
+
+    use_modules = ["Math::BigFloat", "Math::BigInt", "Math::BigRat"]

--- a/var/spack/repos/builtin/packages/perl-bignum/package.py
+++ b/var/spack/repos/builtin/packages/perl-bignum/package.py
@@ -18,5 +18,3 @@ class PerlBignum(PerlPackage):
     depends_on("perl-math-bigrat", type=("build", "run"))
     depends_on("perl-math-bigint", type=("build", "run"))
     depends_on("perl-extutils-makemaker", type=("build"))
-
-    use_modules = ["Math::BigFloat", "Math::BigInt", "Math::BigRat"]

--- a/var/spack/repos/builtin/packages/perl-bio-asn1-entrezgene/package.py
+++ b/var/spack/repos/builtin/packages/perl-bio-asn1-entrezgene/package.py
@@ -21,11 +21,3 @@ class PerlBioAsn1Entrezgene(PerlPackage):
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-bio-cluster", type=("build", "run", "test"))
     depends_on("perl-bioperl", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Bio::ASN1::EntrezGene; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-bio-cluster/package.py
+++ b/var/spack/repos/builtin/packages/perl-bio-cluster/package.py
@@ -22,11 +22,3 @@ class PerlBioCluster(PerlPackage):
     depends_on("perl-bio-variation", type=("build", "run", "test"))
     depends_on("perl-bioperl", type=("build", "run", "test"))
     depends_on("perl-xml-sax", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Bio::Cluster; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-bio-eutilities/package.py
+++ b/var/spack/repos/builtin/packages/perl-bio-eutilities/package.py
@@ -26,11 +26,3 @@ class PerlBioEutilities(PerlPackage):
     depends_on("perl-text-csv", type=("build", "run", "test"))
     depends_on("perl-uri", type=("build", "run", "test"))
     depends_on("perl-xml-simple", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Bio::DB::EUtilities; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-bio-variation/package.py
+++ b/var/spack/repos/builtin/packages/perl-bio-variation/package.py
@@ -23,11 +23,3 @@ class PerlBioVariation(PerlPackage):
     depends_on("perl-io-string", type=("build", "run", "test"))
     depends_on("perl-xml-twig", type=("build", "run", "test"))
     depends_on("perl-xml-writer@0.4:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Bio::Variation; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-bsd-resource/package.py
+++ b/var/spack/repos/builtin/packages/perl-bsd-resource/package.py
@@ -15,11 +15,3 @@ class PerlBsdResource(PerlPackage):
     maintainers("EbiArnie")
 
     version("1.2911", sha256="9d1cfba063cc18f72427a22451f7908836b7331ac8785dbe07553c5b043a0c3d")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use BSD::Resource; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-cache-cache/package.py
+++ b/var/spack/repos/builtin/packages/perl-cache-cache/package.py
@@ -21,11 +21,3 @@ class PerlCacheCache(PerlPackage):
     depends_on("perl-digest-sha1@2.02:", type=("build", "run", "test"))
     depends_on("perl-error@0.15:", type=("build", "run", "test"))
     depends_on("perl-ipc-sharelite@0.09:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Cache::Cache; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-cache-memcached/package.py
+++ b/var/spack/repos/builtin/packages/perl-cache-memcached/package.py
@@ -17,11 +17,3 @@ class PerlCacheMemcached(PerlPackage):
     version("1.30", sha256="31b3c51ec0eaaf03002e2cc8e3d7d5cbe61919cfdada61c008eb9853acac42a9")
 
     depends_on("perl-string-crc32", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Cache::Memcached; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-canary-stability/package.py
+++ b/var/spack/repos/builtin/packages/perl-canary-stability/package.py
@@ -15,11 +15,3 @@ class PerlCanaryStability(PerlPackage):
     maintainers("EbiArnie")
 
     version("2013", sha256="a5c91c62cf95fcb868f60eab5c832908f6905221013fea2bce3ff57046d7b6ea")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Canary::Stability; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-catalyst-action-renderview/package.py
+++ b/var/spack/repos/builtin/packages/perl-catalyst-action-renderview/package.py
@@ -24,11 +24,3 @@ class PerlCatalystActionRenderview(PerlPackage):
     depends_on("perl-data-visitor@0.24:", type=("build", "run", "test"))
     depends_on("perl-http-request-ascgi", type=("build", "link"))
     depends_on("perl-mro-compat", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Catalyst::Action::RenderView; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-catalyst-action-rest/package.py
+++ b/var/spack/repos/builtin/packages/perl-catalyst-action-rest/package.py
@@ -29,11 +29,3 @@ class PerlCatalystActionRest(PerlPackage):
     depends_on("perl-params-validate@0.76:", type=("build", "run", "test"))
     depends_on("perl-test-requires", type=("build", "test"))
     depends_on("perl-uri-find", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Catalyst::Action::REST; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-catalyst-component-instancepercontext/package.py
+++ b/var/spack/repos/builtin/packages/perl-catalyst-component-instancepercontext/package.py
@@ -20,11 +20,3 @@ class PerlCatalystComponentInstancepercontext(PerlPackage):
 
     depends_on("perl-catalyst-runtime", type=("build", "run", "test"))
     depends_on("perl-moose", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Catalyst::Component::InstancePerContext; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-catalyst-devel/package.py
+++ b/var/spack/repos/builtin/packages/perl-catalyst-devel/package.py
@@ -36,11 +36,3 @@ class PerlCatalystDevel(PerlPackage):
     depends_on("perl-template-toolkit", type=("build", "run", "test"))
     depends_on("perl-test-fatal@0.003:", type=("build", "test"))
     depends_on("perl-yaml-tiny", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Catalyst::Devel; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-catalyst-plugin-cache/package.py
+++ b/var/spack/repos/builtin/packages/perl-catalyst-plugin-cache/package.py
@@ -24,11 +24,3 @@ class PerlCatalystPluginCache(PerlPackage):
     depends_on("perl-test-deep", type=("build", "link"))
     depends_on("perl-test-exception", type=("build", "link"))
     depends_on("perl-class-accessor", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Catalyst::Plugin::Cache; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-catalyst-plugin-configloader/package.py
+++ b/var/spack/repos/builtin/packages/perl-catalyst-plugin-configloader/package.py
@@ -24,11 +24,3 @@ class PerlCatalystPluginConfigloader(PerlPackage):
     depends_on("perl-config-any@0.20:", type=("build", "run", "test"))
     depends_on("perl-data-visitor@0.24:", type=("build", "run", "test"))
     depends_on("perl-mro-compat@0.09:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Catalyst::Plugin::ConfigLoader; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-catalyst-plugin-static-simple/package.py
+++ b/var/spack/repos/builtin/packages/perl-catalyst-plugin-static-simple/package.py
@@ -22,11 +22,3 @@ class PerlCatalystPluginStaticSimple(PerlPackage):
     depends_on("perl-mime-types@2.03:", type=("build", "run", "test"))
     depends_on("perl-moose", type=("build", "run", "test"))
     depends_on("perl-namespace-autoclean", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Catalyst::Plugin::Static::Simple; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-catalyst-runtime/package.py
+++ b/var/spack/repos/builtin/packages/perl-catalyst-runtime/package.py
@@ -60,11 +60,3 @@ class PerlCatalystRuntime(PerlPackage):
     depends_on("perl-try-tiny@0.17:", type=("build", "run", "test"))
     depends_on("perl-uri@1.65:", type=("build", "run", "test"))
     depends_on("perl-uri-ws@0.03:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Catalyst::Test; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-catalyst-view-json/package.py
+++ b/var/spack/repos/builtin/packages/perl-catalyst-view-json/package.py
@@ -21,11 +21,3 @@ class PerlCatalystViewJson(PerlPackage):
     depends_on("perl-catalyst-runtime", type=("build", "run", "test"))
     depends_on("perl-json-maybexs@1.003000:", type=("build", "run", "test"))
     depends_on("perl-mro-compat", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Catalyst::View::JSON; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-cgi-simple/package.py
+++ b/var/spack/repos/builtin/packages/perl-cgi-simple/package.py
@@ -20,11 +20,3 @@ class PerlCgiSimple(PerlPackage):
 
     depends_on("perl-test-exception", type=("build", "test"))
     depends_on("perl-test-nowarnings", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use CGI::Simple; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-cgi-struct/package.py
+++ b/var/spack/repos/builtin/packages/perl-cgi-struct/package.py
@@ -19,11 +19,3 @@ class PerlCgiStruct(PerlPackage):
     version("1.21", sha256="d13d8da7fdcd6d906054e4760fc28a718aec91bd3cf067a58927fb7cb1c09d6c")
 
     depends_on("perl-test-deep", type=("build", "link"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use CGI::Struct; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-chart-gnuplot/package.py
+++ b/var/spack/repos/builtin/packages/perl-chart-gnuplot/package.py
@@ -17,11 +17,3 @@ class PerlChartGnuplot(PerlPackage):
     license("Artistic-1.0-Perl OR GPL-1.0-or-later")
 
     version("0.23", sha256="dcb46c0f93436464bdc3403469c828c6c33e954123a2adf4092fbb30bb244b6c")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Chart::Gnuplot; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-chi-driver-memcached/package.py
+++ b/var/spack/repos/builtin/packages/perl-chi-driver-memcached/package.py
@@ -21,11 +21,3 @@ class PerlChiDriverMemcached(PerlPackage):
     depends_on("perl-chi@0.33:", type=("build", "run", "test"))
     depends_on("perl-moose@0.66:", type=("build", "run", "test"))
     depends_on("perl-test-class", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use CHI::Driver::Memcached; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-chi/package.py
+++ b/var/spack/repos/builtin/packages/perl-chi/package.py
@@ -41,11 +41,3 @@ class PerlChi(PerlPackage):
     depends_on("perl-time-duration-parse@0.03:", type=("build", "run", "test"))
     depends_on("perl-timedate", type=("build", "run", "test"))
     depends_on("perl-try-tiny@0.05:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use CHI; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-class-accessor-grouped/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-accessor-grouped/package.py
@@ -21,11 +21,3 @@ class PerlClassAccessorGrouped(PerlPackage):
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-module-runtime@0.012:", type=("build", "run", "test"))
     depends_on("perl-test-exception@0.31:", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Class::Accessor::Grouped; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-class-accessor-lvalue/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-accessor-lvalue/package.py
@@ -20,11 +20,3 @@ class PerlClassAccessorLvalue(PerlPackage):
 
     depends_on("perl-class-accessor", type=("build", "run", "test"))
     depends_on("perl-want", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Class::Accessor::Lvalue; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-class-accessor/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-accessor/package.py
@@ -15,11 +15,3 @@ class PerlClassAccessor(PerlPackage):
     maintainers("EbiArnie")
 
     version("0.51", sha256="bf12a3e5de5a2c6e8a447b364f4f5a050bf74624c56e315022ae7992ff2f411c")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Class::Accessor; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-class-c3-adopt-next/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-c3-adopt-next/package.py
@@ -22,11 +22,3 @@ class PerlClassC3AdoptNext(PerlPackage):
     depends_on("perl-module-build-tiny@0.039:", type=("build"))
     depends_on("perl-mro-compat", type=("build", "run", "test"))
     depends_on("perl-test-exception@0.27:", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Class::C3::Adopt::NEXT; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-class-c3-componentised/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-c3-componentised/package.py
@@ -23,11 +23,3 @@ class PerlClassC3Componentised(PerlPackage):
     depends_on("perl-class-inspector@1.32:", type=("build", "run", "test"))
     depends_on("perl-mro-compat@0.09:", type=("build", "run", "test"))
     depends_on("perl-test-exception@0.31:", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Class::C3::Componentised; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-class-c3/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-c3/package.py
@@ -20,11 +20,3 @@ class PerlClassC3(PerlPackage):
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-algorithm-c3@0.07:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Class::C3; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-class-singleton/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-singleton/package.py
@@ -19,11 +19,3 @@ class PerlClassSingleton(PerlPackage):
     version("1.6", sha256="27ba13f0d9512929166bbd8c9ef95d90d630fc80f0c9a1b7458891055e9282a4")
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Class::Singleton; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-clone-pp/package.py
+++ b/var/spack/repos/builtin/packages/perl-clone-pp/package.py
@@ -19,11 +19,3 @@ class PerlClonePp(PerlPackage):
     version("1.08", sha256="57203094a5d8574b6a00951e8f2399b666f4e74f9511d9c9fb5b453d5d11f578")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Clone::PP; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-common-sense/package.py
+++ b/var/spack/repos/builtin/packages/perl-common-sense/package.py
@@ -17,11 +17,3 @@ class PerlCommonSense(PerlPackage):
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
     version("3.75", sha256="a86a1c4ca4f3006d7479064425a09fa5b6689e57261fcb994fe67d061cba0e7e")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use common::sense; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-compress-lzo/package.py
+++ b/var/spack/repos/builtin/packages/perl-compress-lzo/package.py
@@ -19,11 +19,3 @@ class PerlCompressLzo(PerlPackage):
     depends_on("perl@5.4.0:", type=("build", "link", "run", "test"))
     depends_on("perl-devel-checklib@0.9:", type=("build"))
     depends_on("lzo", type=("build", "link", "run"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Compress::LZO; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-config-any/package.py
+++ b/var/spack/repos/builtin/packages/perl-config-any/package.py
@@ -19,11 +19,3 @@ class PerlConfigAny(PerlPackage):
     version("0.33", sha256="c0668eb5f2cd355bf20557f04dc18a25474b7a0bcfa79562e3165d9a3c789333")
 
     depends_on("perl-module-pluggable", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Config::Any; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-config-inifiles/package.py
+++ b/var/spack/repos/builtin/packages/perl-config-inifiles/package.py
@@ -20,11 +20,3 @@ class PerlConfigInifiles(PerlPackage):
 
     depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
     depends_on("perl-io-stringy", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Config::IniFiles; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-config-tiny/package.py
+++ b/var/spack/repos/builtin/packages/perl-config-tiny/package.py
@@ -19,11 +19,3 @@ class PerlConfigTiny(PerlPackage):
     version("2.30", sha256="b2f7345619b3b8e636dd39ea010731c9dc2bfb8f022bcbd86ae6ad17866e110d")
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Config::Tiny; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-context-preserve/package.py
+++ b/var/spack/repos/builtin/packages/perl-context-preserve/package.py
@@ -21,11 +21,3 @@ class PerlContextPreserve(PerlPackage):
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-test-exception", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Context::Preserve; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-convert-nls-date-format/package.py
+++ b/var/spack/repos/builtin/packages/perl-convert-nls-date-format/package.py
@@ -18,11 +18,3 @@ class PerlConvertNlsDateFormat(PerlPackage):
 
     depends_on("perl@5.6.1:", type=("build", "link", "run", "test"))
     depends_on("perl-module-build-tiny@0.035:", type=("build"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Convert::NLS_DATE_FORMAT; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-cookie-baker/package.py
+++ b/var/spack/repos/builtin/packages/perl-cookie-baker/package.py
@@ -22,11 +22,3 @@ class PerlCookieBaker(PerlPackage):
     depends_on("perl-module-build-tiny@0.035:", type=("build"))
     depends_on("perl-test-time", type=("build", "test"))
     depends_on("perl-uri", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Cookie::Baker; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-cpanel-json-xs/package.py
+++ b/var/spack/repos/builtin/packages/perl-cpanel-json-xs/package.py
@@ -17,11 +17,3 @@ class PerlCpanelJsonXs(PerlPackage):
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
     version("4.37", sha256="c241615a0e17ff745aaa86bbf466a6e29cd240515e65f06a7a05017b619e6d4b")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Cpanel::JSON::XS; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-css-minifier-xs/package.py
+++ b/var/spack/repos/builtin/packages/perl-css-minifier-xs/package.py
@@ -20,11 +20,3 @@ class PerlCssMinifierXs(PerlPackage):
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
     depends_on("perl-test-diaginc@0.002:", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use CSS::Minifier::XS; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-data-dump/package.py
+++ b/var/spack/repos/builtin/packages/perl-data-dump/package.py
@@ -19,11 +19,3 @@ class PerlDataDump(PerlPackage):
     version("1.25", sha256="a4aa6e0ddbf39d5ad49bddfe0f89d9da864e3bc00f627125d1bc580472f53fbd")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Data::Dump; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-data-dumper-concise/package.py
+++ b/var/spack/repos/builtin/packages/perl-data-dumper-concise/package.py
@@ -19,11 +19,3 @@ class PerlDataDumperConcise(PerlPackage):
     version("2.023", sha256="a6c22f113caf31137590def1b7028a7e718eface3228272d0672c25e035d5853")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Data::Dumper::Concise; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-data-predicate/package.py
+++ b/var/spack/repos/builtin/packages/perl-data-predicate/package.py
@@ -18,11 +18,3 @@ class PerlDataPredicate(PerlPackage):
 
     depends_on("perl-test-exception", type=("build", "test"))
     depends_on("perl-readonly", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Data::Predicate; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-data-uuid/package.py
+++ b/var/spack/repos/builtin/packages/perl-data-uuid/package.py
@@ -17,11 +17,3 @@ class PerlDataUuid(PerlPackage):
     license("BSD")
 
     version("1.226", sha256="093d57ffa0d411a94bafafae495697db26f5c9d0277198fe3f7cf2be22996453")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Data::UUID; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-data-visitor/package.py
+++ b/var/spack/repos/builtin/packages/perl-data-visitor/package.py
@@ -23,11 +23,3 @@ class PerlDataVisitor(PerlPackage):
     depends_on("perl-namespace-clean@0.19:", type=("build", "run", "test"))
     depends_on("perl-test-needs", type=("build", "test"))
     depends_on("perl-tie-toobject@0.01:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Data::Visitor; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-date-exception/package.py
+++ b/var/spack/repos/builtin/packages/perl-date-exception/package.py
@@ -22,11 +22,3 @@ class PerlDateException(PerlPackage):
     depends_on("perl-moo@2.000000:", type=("build", "run", "test"))
     depends_on("perl-namespace-autoclean@0.28:", type=("build", "run", "test"))
     depends_on("perl-throwable@0.200011:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Date::Exception; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-date-utils/package.py
+++ b/var/spack/repos/builtin/packages/perl-date-utils/package.py
@@ -23,11 +23,3 @@ class PerlDateUtils(PerlPackage):
     depends_on("perl-moo", type=("build", "run", "test"))
     depends_on("perl-namespace-autoclean@0.28:", type=("build", "run", "test"))
     depends_on("perl-term-ansicolor-markup@0.06:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Date::Utils; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-datetime-format-builder/package.py
+++ b/var/spack/repos/builtin/packages/perl-datetime-format-builder/package.py
@@ -21,11 +21,3 @@ class PerlDatetimeFormatBuilder(PerlPackage):
     depends_on("perl-datetime@1.00:", type=("build", "run", "test"))
     depends_on("perl-datetime-format-strptime@1.04:", type=("build", "run", "test"))
     depends_on("perl-params-validate@0.72:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use DateTime::Format::Builder; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-datetime-format-iso8601/package.py
+++ b/var/spack/repos/builtin/packages/perl-datetime-format-iso8601/package.py
@@ -24,11 +24,3 @@ class PerlDatetimeFormatIso8601(PerlPackage):
     depends_on("perl-params-validationcompiler@0.26:", type=("build", "run", "test"))
     depends_on("perl-specio@0.18:", type=("build", "run", "test"))
     depends_on("perl-test2-suite", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use DateTime::Format::ISO8601; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-datetime-format-mysql/package.py
+++ b/var/spack/repos/builtin/packages/perl-datetime-format-mysql/package.py
@@ -20,11 +20,3 @@ class PerlDatetimeFormatMysql(PerlPackage):
 
     depends_on("perl-datetime", type=("build", "run", "test"))
     depends_on("perl-datetime-format-builder@0.6:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use DateTime::Format::MySQL; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-datetime-format-oracle/package.py
+++ b/var/spack/repos/builtin/packages/perl-datetime-format-oracle/package.py
@@ -21,11 +21,3 @@ class PerlDatetimeFormatOracle(PerlPackage):
     depends_on("perl-convert-nls-date-format@0.03:", type=("build", "run", "test"))
     depends_on("perl-datetime", type=("build", "run", "test"))
     depends_on("perl-datetime-format-builder", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use DateTime::Format::Oracle; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-datetime-format-pg/package.py
+++ b/var/spack/repos/builtin/packages/perl-datetime-format-pg/package.py
@@ -22,11 +22,3 @@ class PerlDatetimeFormatPg(PerlPackage):
     depends_on("perl-datetime-format-builder@0.72:", type=("build", "run", "test"))
     depends_on("perl-datetime-timezone@0.05:", type=("build", "run", "test"))
     depends_on("perl-module-build-tiny@0.035:", type=("build"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use DateTime::Format::Pg; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-datetime-format-strptime/package.py
+++ b/var/spack/repos/builtin/packages/perl-datetime-format-strptime/package.py
@@ -26,11 +26,3 @@ class PerlDatetimeFormatStrptime(PerlPackage):
     depends_on("perl-test-fatal", type=("build", "test"))
     depends_on("perl-test-warnings", type=("build", "test"))
     depends_on("perl-try-tiny", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use DateTime::Format::Strptime; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-datetime-locale/package.py
+++ b/var/spack/repos/builtin/packages/perl-datetime-locale/package.py
@@ -31,11 +31,3 @@ class PerlDatetimeLocale(PerlPackage):
     depends_on("perl-test-file-sharedir", type=("build", "test"))
     depends_on("perl-test2-plugin-nowarnings", type=("build", "test"))
     depends_on("perl-test2-suite", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use DateTime::Locale; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-datetime-timezone/package.py
+++ b/var/spack/repos/builtin/packages/perl-datetime-timezone/package.py
@@ -27,11 +27,3 @@ class PerlDatetimeTimezone(PerlPackage):
     depends_on("perl-test-fatal", type=("build", "test"))
     depends_on("perl-test-requires", type=("build", "test"))
     depends_on("perl-try-tiny", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use DateTime::TimeZone; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-datetime/package.py
+++ b/var/spack/repos/builtin/packages/perl-datetime/package.py
@@ -35,11 +35,3 @@ class PerlDatetime(PerlPackage):
     depends_on("perl-test-warnings@0.005:", type=("build", "test"))
     depends_on("perl-test-without-module", type=("build", "test"))
     depends_on("perl-try-tiny", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use DateTime; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-dbd-oracle/package.py
+++ b/var/spack/repos/builtin/packages/perl-dbd-oracle/package.py
@@ -23,11 +23,3 @@ class PerlDbdOracle(PerlPackage):
 
     def setup_build_environment(self, env):
         env.set("ORACLE_HOME", self.spec["oracle-instant-client"].prefix)
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use DBD::Oracle; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-dbix-class/package.py
+++ b/var/spack/repos/builtin/packages/perl-dbix-class/package.py
@@ -42,11 +42,3 @@ class PerlDbixClass(PerlPackage):
     depends_on("perl-test-exception@0.31:", type=("build", "link"))
     depends_on("perl-test-warn@0.21:", type=("build", "link"))
     depends_on("perl-try-tiny@0.07:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use DBIx::Class; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-devel-stacktrace-ashtml/package.py
+++ b/var/spack/repos/builtin/packages/perl-devel-stacktrace-ashtml/package.py
@@ -19,11 +19,3 @@ class PerlDevelStacktraceAshtml(PerlPackage):
     version("0.15", sha256="6283dbe2197e2f20009cc4b449997742169cdd951bfc44cbc6e62c2a962d3147")
 
     depends_on("perl-devel-stacktrace", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Devel::StackTrace::AsHTML; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-digest-jhash/package.py
+++ b/var/spack/repos/builtin/packages/perl-digest-jhash/package.py
@@ -19,11 +19,3 @@ class PerlDigestJhash(PerlPackage):
     version("0.10", sha256="c746cf0a861a004090263cd54d7728d0c7595a0cf90cbbfd8409b396ee3b0063")
 
     depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Digest::JHash; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-digest-sha1/package.py
+++ b/var/spack/repos/builtin/packages/perl-digest-sha1/package.py
@@ -19,11 +19,3 @@ class PerlDigestSha1(PerlPackage):
     version("2.13", sha256="68c1dac2187421f0eb7abf71452a06f190181b8fc4b28ededf5b90296fb943cc")
 
     depends_on("perl@5.4.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Digest::SHA1; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-email-abstract/package.py
+++ b/var/spack/repos/builtin/packages/perl-email-abstract/package.py
@@ -22,11 +22,3 @@ class PerlEmailAbstract(PerlPackage):
     depends_on("perl-email-simple@1.998:", type=("build", "run", "test"))
     depends_on("perl-module-pluggable@1.5:", type=("build", "run", "test"))
     depends_on("perl-mro-compat", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Email::Abstract; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-email-address-xs/package.py
+++ b/var/spack/repos/builtin/packages/perl-email-address-xs/package.py
@@ -17,11 +17,3 @@ class PerlEmailAddressXs(PerlPackage):
     version("1.05", sha256="1510b7f10d67201037cd50d22c9d6b26eeca55ededa4cdb46bbca27e59a4ea16")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Email::Address::XS; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-email-date-format/package.py
+++ b/var/spack/repos/builtin/packages/perl-email-date-format/package.py
@@ -19,11 +19,3 @@ class PerlEmailDateFormat(PerlPackage):
     version("1.008", sha256="432b7c83ff88749af128003f5257c573aec1a463418db90ed22843cbbc258b4f")
 
     depends_on("perl@5.12.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Email::Date::Format; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-email-messageid/package.py
+++ b/var/spack/repos/builtin/packages/perl-email-messageid/package.py
@@ -17,11 +17,3 @@ class PerlEmailMessageid(PerlPackage):
     version("1.408", sha256="1f3d5b4ff0b1c7b39e9ac7c318fb37adcd0bac9556036546494d14f06dc5643c")
 
     depends_on("perl@5.12.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Email::MessageID; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-email-mime-contenttype/package.py
+++ b/var/spack/repos/builtin/packages/perl-email-mime-contenttype/package.py
@@ -20,11 +20,3 @@ class PerlEmailMimeContenttype(PerlPackage):
 
     depends_on("perl@5.12.0:", type=("build", "link", "run", "test"))
     depends_on("perl-text-unidecode", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Email::MIME::ContentType; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-email-mime-encodings/package.py
+++ b/var/spack/repos/builtin/packages/perl-email-mime-encodings/package.py
@@ -17,11 +17,3 @@ class PerlEmailMimeEncodings(PerlPackage):
     version("1.317", sha256="4a9a41671a9d1504c4da241be419a9503fa3486262526edb81eca9e2ebea0baf")
 
     depends_on("perl@5.12.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Email::MIME::Encodings; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-email-mime/package.py
+++ b/var/spack/repos/builtin/packages/perl-email-mime/package.py
@@ -26,11 +26,3 @@ class PerlEmailMime(PerlPackage):
     depends_on("perl-email-simple@2.212:", type=("build", "run", "test"))
     depends_on("perl-mime-types@1.13:", type=("build", "run", "test"))
     depends_on("perl-module-runtime", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Email::MIME; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-email-sender/package.py
+++ b/var/spack/repos/builtin/packages/perl-email-sender/package.py
@@ -29,11 +29,3 @@ class PerlEmailSender(PerlPackage):
     depends_on("perl-sub-exporter", type=("build", "run", "test"))
     depends_on("perl-throwable", type=("build", "run", "test"))
     depends_on("perl-try-tiny", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Email::Sender; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-email-simple/package.py
+++ b/var/spack/repos/builtin/packages/perl-email-simple/package.py
@@ -18,11 +18,3 @@ class PerlEmailSimple(PerlPackage):
 
     depends_on("perl@5.12.0:", type=("build", "link", "run", "test"))
     depends_on("perl-email-date-format", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Email::Simple; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-email-stuffer/package.py
+++ b/var/spack/repos/builtin/packages/perl-email-stuffer/package.py
@@ -25,11 +25,3 @@ class PerlEmailStuffer(PerlPackage):
     depends_on("perl-moo", type=("build", "test"))
     depends_on("perl-params-util@1.05:", type=("build", "run", "test"))
     depends_on("perl-test-fatal", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Email::Stuffer; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-exporter-auto/package.py
+++ b/var/spack/repos/builtin/packages/perl-exporter-auto/package.py
@@ -21,11 +21,3 @@ class PerlExporterAuto(PerlPackage):
     depends_on("perl@5.8.5:", type=("build", "link", "run", "test"))
     depends_on("perl-b-hooks-endofscope", type=("build", "run", "test"))
     depends_on("perl-sub-identify", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Exporter::Auto; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-file-changenotify/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-changenotify/package.py
@@ -26,11 +26,3 @@ class PerlFileChangenotify(PerlPackage):
     depends_on("perl-test-without-module", type=("build", "test"))
     depends_on("perl-test2-suite", type=("build", "test"))
     depends_on("perl-type-tiny", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use File::ChangeNotify; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-file-sharedir/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-sharedir/package.py
@@ -20,11 +20,3 @@ class PerlFileSharedir(PerlPackage):
 
     depends_on("perl-class-inspector@1.12:", type=("build", "run", "test"))
     depends_on("perl-file-sharedir-install@0.13:", type=("build", "link"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use File::ShareDir; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-filesys-notify-simple/package.py
+++ b/var/spack/repos/builtin/packages/perl-filesys-notify-simple/package.py
@@ -20,11 +20,3 @@ class PerlFilesysNotifySimple(PerlPackage):
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
     depends_on("perl-test-sharedfork", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Filesys::Notify::Simple; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-getopt-long-descriptive/package.py
+++ b/var/spack/repos/builtin/packages/perl-getopt-long-descriptive/package.py
@@ -21,11 +21,3 @@ class PerlGetoptLongDescriptive(PerlPackage):
     depends_on("perl@5.12.0:", type=("build", "link", "run", "test"))
     depends_on("perl-params-validate@0.97:", type=("build", "run", "test"))
     depends_on("perl-sub-exporter@0.972:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Getopt::Long::Descriptive; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-graphviz/package.py
+++ b/var/spack/repos/builtin/packages/perl-graphviz/package.py
@@ -24,11 +24,3 @@ class PerlGraphviz(PerlPackage):
     depends_on("perl-parse-recdescent@1.965001:", type=("build", "run", "test"))
     depends_on("perl-xml-twig@3.52:", type=("build", "run", "test"))
     depends_on("perl-xml-xpath@1.13:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use GraphViz; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-gzip-faster/package.py
+++ b/var/spack/repos/builtin/packages/perl-gzip-faster/package.py
@@ -19,11 +19,3 @@ class PerlGzipFaster(PerlPackage):
     version("0.21", sha256="c65f41ca108e7e53ec34c30dbb1b5d614bf4b8100673646cf301d0caf82c7aa5")
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Gzip::Faster; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-hash-moreutils/package.py
+++ b/var/spack/repos/builtin/packages/perl-hash-moreutils/package.py
@@ -19,11 +19,3 @@ class PerlHashMoreutils(PerlPackage):
     version("0.06", sha256="db9a8fb867d50753c380889a5e54075651b5e08c9b3b721cb7220c0883547de8")
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Hash::MoreUtils; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-hash-multivalue/package.py
+++ b/var/spack/repos/builtin/packages/perl-hash-multivalue/package.py
@@ -19,11 +19,3 @@ class PerlHashMultivalue(PerlPackage):
     version("0.16", sha256="66181df7aa68e2786faf6895c88b18b95c800a8e4e6fb4c07fd176410a3c73f4")
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Hash::MultiValue; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-heap/package.py
+++ b/var/spack/repos/builtin/packages/perl-heap/package.py
@@ -17,11 +17,3 @@ class PerlHeap(PerlPackage):
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
     version("0.80", sha256="ccda29f3c93176ad0fdfff4dd6f5e4ac90b370cba4b028386b7343bf64139bde")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Heap; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-hook-lexwrap/package.py
+++ b/var/spack/repos/builtin/packages/perl-hook-lexwrap/package.py
@@ -19,11 +19,3 @@ class PerlHookLexwrap(PerlPackage):
     version("0.26", sha256="b60bdc5f98f94f9294b06adef82b1d996da192d5f183f9f434b610fd1137ec2d")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Hook::LexWrap; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-html-template/package.py
+++ b/var/spack/repos/builtin/packages/perl-html-template/package.py
@@ -20,11 +20,3 @@ class PerlHtmlTemplate(PerlPackage):
 
     depends_on("perl-cgi", type=("build", "run", "test"))
     depends_on("perl-test-pod", type=("build", "link"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use HTML::Template; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-http-body/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-body/package.py
@@ -20,11 +20,3 @@ class PerlHttpBody(PerlPackage):
 
     depends_on("perl-http-message", type=("build", "link", "run", "test"))
     depends_on("perl-test-deep", type=("build", "link"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use HTTP::Body; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-http-cookiejar/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-cookiejar/package.py
@@ -23,11 +23,3 @@ class PerlHttpCookiejar(PerlPackage):
     depends_on("perl-test-deep", type=("test"))
     depends_on("perl-test-requires", type=("test"))
     depends_on("perl-uri", type=("test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use HTTP::CookieJar; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-http-entity-parser/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-entity-parser/package.py
@@ -26,11 +26,3 @@ class PerlHttpEntityParser(PerlPackage):
     depends_on("perl-module-build-tiny@0.035:", type=("build"))
     depends_on("perl-stream-buffered", type=("build", "run", "test"))
     depends_on("perl-www-form-urlencoded@0.23:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use HTTP::Entity::Parser; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-http-headers-fast/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-headers-fast/package.py
@@ -22,11 +22,3 @@ class PerlHttpHeadersFast(PerlPackage):
     depends_on("perl-http-date", type=("build", "run", "test"))
     depends_on("perl-module-build-tiny@0.035:", type=("build"))
     depends_on("perl-test-requires", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use HTTP::Headers::Fast; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-http-multipartparser/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-multipartparser/package.py
@@ -20,11 +20,3 @@ class PerlHttpMultipartparser(PerlPackage):
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
     depends_on("perl-test-deep", type=("build", "link"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use HTTP::MultiPartParser; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-http-parser-xs/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-parser-xs/package.py
@@ -17,11 +17,3 @@ class PerlHttpParserXs(PerlPackage):
     license("Artistic-1.0-Perl OR GPL-1.0-or-later")
 
     version("0.17", sha256="794e6833e326b10d24369f9cdbfc1667105ef6591e8f41e561a3d41a7027a809")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use HTTP::Parser::XS; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-http-request-ascgi/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-request-ascgi/package.py
@@ -21,11 +21,3 @@ class PerlHttpRequestAscgi(PerlPackage):
     depends_on("perl-class-accessor", type=("build", "run", "test"))
     depends_on("perl-http-message", type=("build", "run", "test"))
     depends_on("perl-uri", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use HTTP::Request::AsCGI; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-http-server-simple/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-server-simple/package.py
@@ -19,11 +19,3 @@ class PerlHttpServerSimple(PerlPackage):
     version("0.52", sha256="d8939fa4f12bd6b8c043537fd0bf96b055ac3686b9cdd9fa773dca6ae679cb4c")
 
     depends_on("perl-cgi", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use HTTP::Server::Simple; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-import-into/package.py
+++ b/var/spack/repos/builtin/packages/perl-import-into/package.py
@@ -20,11 +20,3 @@ class PerlImportInto(PerlPackage):
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-module-runtime", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Import::Into; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-ipc-run3/package.py
+++ b/var/spack/repos/builtin/packages/perl-ipc-run3/package.py
@@ -15,11 +15,3 @@ class PerlIpcRun3(PerlPackage):
     maintainers("EbiArnie")
 
     version("0.048", sha256="3d81c3cc1b5cff69cca9361e2c6e38df0352251ae7b41e2ff3febc850e463565")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use IPC::Run3; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-ipc-sharelite/package.py
+++ b/var/spack/repos/builtin/packages/perl-ipc-sharelite/package.py
@@ -17,11 +17,3 @@ class PerlIpcSharelite(PerlPackage):
     license("Artistic-1.0-Perl OR GPL-1.0-or-later")
 
     version("0.17", sha256="14d406b91da96d6521d0d1a82d22a306274765226b86b0a56e7ffddcf96ae7bf")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use IPC::ShareLite; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-ipc-system-simple/package.py
+++ b/var/spack/repos/builtin/packages/perl-ipc-system-simple/package.py
@@ -19,11 +19,3 @@ class PerlIpcSystemSimple(PerlPackage):
     version("1.30", sha256="22e6f5222b505ee513058fdca35ab7a1eab80539b98e5ca4a923a70a8ae9ba9e")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use IPC::System::Simple; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-javascript-minifier-xs/package.py
+++ b/var/spack/repos/builtin/packages/perl-javascript-minifier-xs/package.py
@@ -20,11 +20,3 @@ class PerlJavascriptMinifierXs(PerlPackage):
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
     depends_on("perl-test-diaginc@0.002:", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use JavaScript::Minifier::XS; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-json-any/package.py
+++ b/var/spack/repos/builtin/packages/perl-json-any/package.py
@@ -23,11 +23,3 @@ class PerlJsonAny(PerlPackage):
     depends_on("perl-test-needs", type=("build", "test"))
     depends_on("perl-test-warnings@0.009:", type=("build", "test"))
     depends_on("perl-test-without-module", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use JSON::Any; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-json-maybexs/package.py
+++ b/var/spack/repos/builtin/packages/perl-json-maybexs/package.py
@@ -19,11 +19,3 @@ class PerlJsonMaybexs(PerlPackage):
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-cpanel-json-xs@2.3310:", type=("build", "run", "test"))
     depends_on("perl-test-needs@0.002006:", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use JSON::MaybeXS; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-json-xs/package.py
+++ b/var/spack/repos/builtin/packages/perl-json-xs/package.py
@@ -22,11 +22,3 @@ class PerlJsonXs(PerlPackage):
 
     def setup_build_environment(self, env):
         env.set("PERL_CANARY_STABILITY_NOPROMPT", "1")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use JSON::XS; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-kyotocabinet/package.py
+++ b/var/spack/repos/builtin/packages/perl-kyotocabinet/package.py
@@ -22,11 +22,3 @@ class PerlKyotocabinet(PerlPackage):
     depends_on("zlib-api", type=("build", "link", "run", "test"))
     depends_on("lzo", type=("build", "link", "run", "test"))
     depends_on("xz", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use KyotoCabinet; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-lingua-en-inflect/package.py
+++ b/var/spack/repos/builtin/packages/perl-lingua-en-inflect/package.py
@@ -15,11 +15,3 @@ class PerlLinguaEnInflect(PerlPackage):
     maintainers("EbiArnie")
 
     version("1.905", sha256="05c29ec3482e572313a60da2181b0b30c5db7cf01f8ae7616ad67e1b66263296")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Lingua::EN::Inflect; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-list-compare/package.py
+++ b/var/spack/repos/builtin/packages/perl-list-compare/package.py
@@ -19,11 +19,3 @@ class PerlListCompare(PerlPackage):
     version("0.55", sha256="cc719479836579d52b02bc328ed80a98f679df043a99b5710ab2c191669eb837")
 
     depends_on("perl-capture-tiny", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use List::Compare; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-list-someutils/package.py
+++ b/var/spack/repos/builtin/packages/perl-list-someutils/package.py
@@ -21,11 +21,3 @@ class PerlListSomeutils(PerlPackage):
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-module-implementation@0.04:", type=("build", "run", "test"))
     depends_on("perl-test-leaktrace", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use List::SomeUtils; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-log-any-adapter-callback/package.py
+++ b/var/spack/repos/builtin/packages/perl-log-any-adapter-callback/package.py
@@ -22,11 +22,3 @@ class PerlLogAnyAdapterCallback(PerlPackage):
     version("0.102", sha256="7c01883265bdab65344257c1b1d1e69fbe300e7693dddeebb98f9f67310e07cd")
 
     depends_on("perl-log-any", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Log::Any::Adapter::Callback; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-log-any/package.py
+++ b/var/spack/repos/builtin/packages/perl-log-any/package.py
@@ -17,11 +17,3 @@ class PerlLogAny(PerlPackage):
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
     version("1.717", sha256="56649da0f3900230c9e3d29252cb0a74806fb2ddebd22805acd7368959a65bca")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Log::Any; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-log-dispatch-filerotate/package.py
+++ b/var/spack/repos/builtin/packages/perl-log-dispatch-filerotate/package.py
@@ -24,11 +24,3 @@ class PerlLogDispatchFilerotate(PerlPackage):
     depends_on("perl-sub-uplevel", type=("build", "run", "test"))
     depends_on("perl-path-tiny@0.018:", type=("build", "test"))
     depends_on("perl-test-warn", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Log::Dispatch::FileRotate; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-log-dispatch/package.py
+++ b/var/spack/repos/builtin/packages/perl-log-dispatch/package.py
@@ -29,11 +29,3 @@ class PerlLogDispatch(PerlPackage):
     depends_on("perl-test-fatal", type=("build", "test"))
     depends_on("perl-test-needs", type=("build", "test"))
     depends_on("perl-try-tiny", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Log::Dispatch; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-metacpan-client/package.py
+++ b/var/spack/repos/builtin/packages/perl-metacpan-client/package.py
@@ -30,11 +30,3 @@ class PerlMetacpanClient(PerlPackage):
     depends_on("perl-test-needs@0.002005:", type=("build", "test"))
     depends_on("perl-type-tiny", type=("build", "run", "test"))
     depends_on("perl-uri", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use MetaCPAN::Client; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-mime-types/package.py
+++ b/var/spack/repos/builtin/packages/perl-mime-types/package.py
@@ -17,11 +17,3 @@ class PerlMimeTypes(PerlPackage):
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
     version("2.24", sha256="629e361f22b220be50c2da7354e23c0451757709a03c25a22f3160edb94cb65f")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use MIME::Types; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-mock-config/package.py
+++ b/var/spack/repos/builtin/packages/perl-mock-config/package.py
@@ -17,11 +17,3 @@ class PerlMockConfig(PerlPackage):
     version("0.03", sha256="a5b8345757ca4f2b9335f5be14e93ebbb502865233a755bf53bc7156deec001b")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Mock::Config; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-module-find/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-find/package.py
@@ -19,11 +19,3 @@ class PerlModuleFind(PerlPackage):
     version("0.16", sha256="4bcaaa376915014728d4f533a98c5b59d665051cd3cdbafc960e5a66fd131092")
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Module::Find; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-module-install/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-install/package.py
@@ -12,6 +12,8 @@ class PerlModuleInstall(PerlPackage):
     homepage = "https://metacpan.org/pod/Module::Install"
     url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Module-Install-1.19.tar.gz"
 
+    skip_modules = ["Module::Install"]  # requires prepend "inc::"
+
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
     version("1.21", sha256="fbf91007f30565f3920e106055fd0d4287981d5e7dad8b35323ce4b733f15a7b")

--- a/var/spack/repos/builtin/packages/perl-module-mask/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-mask/package.py
@@ -20,11 +20,3 @@ class PerlModuleMask(PerlPackage):
 
     depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
     depends_on("perl-module-util@1.00:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Module::Mask; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-module-pluggable/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-pluggable/package.py
@@ -19,11 +19,3 @@ class PerlModulePluggable(PerlPackage):
     version("5.2", sha256="b3f2ad45e4fd10b3fb90d912d78d8b795ab295480db56dc64e86b9fa75c5a6df")
 
     depends_on("perl@5.5.30:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Module::Pluggable; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-module-util/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-util/package.py
@@ -19,11 +19,3 @@ class PerlModuleUtil(PerlPackage):
     version("1.09", sha256="6cfbcb6a45064446ec8aa0ee1a7dddc420b54469303344187aef84d2c7f3e2c6")
 
     depends_on("perl@5.5.3:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Module::Util; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-mojolicious/package.py
+++ b/var/spack/repos/builtin/packages/perl-mojolicious/package.py
@@ -19,11 +19,3 @@ class PerlMojolicious(PerlPackage):
     version("9.35", sha256="6a4a446ee07fca7c6db72f5d817540d6833009cb8de7cce4c6fb24a15ee7d46b")
 
     depends_on("perl@5.16.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Mojolicious; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-moosex-emulate-class-accessor-fast/package.py
+++ b/var/spack/repos/builtin/packages/perl-moosex-emulate-class-accessor-fast/package.py
@@ -21,11 +21,3 @@ class PerlMoosexEmulateClassAccessorFast(PerlPackage):
     depends_on("perl-moose@0.84:", type=("build", "run", "test"))
     depends_on("perl-namespace-clean", type=("build", "run", "test"))
     depends_on("perl-test-exception", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use MooseX::Emulate::Class::Accessor::Fast; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-moosex-getopt/package.py
+++ b/var/spack/repos/builtin/packages/perl-moosex-getopt/package.py
@@ -32,11 +32,3 @@ class PerlMoosexGetopt(PerlPackage):
     depends_on("perl-test-trap", type=("build", "test"))
     depends_on("perl-test-warnings@0.009:", type=("build", "test"))
     depends_on("perl-try-tiny", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use MooseX::Getopt; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-moosex-methodattributes/package.py
+++ b/var/spack/repos/builtin/packages/perl-moosex-methodattributes/package.py
@@ -24,11 +24,3 @@ class PerlMoosexMethodattributes(PerlPackage):
     depends_on("perl-namespace-autoclean@0.08:", type=("build", "run", "test"))
     depends_on("perl-test-fatal", type=("build", "test"))
     depends_on("perl-test-needs", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use MooseX::MethodAttributes; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-moosex-role-parameterized/package.py
+++ b/var/spack/repos/builtin/packages/perl-moosex-role-parameterized/package.py
@@ -27,11 +27,3 @@ class PerlMoosexRoleParameterized(PerlPackage):
     depends_on("perl-namespace-clean@0.19:", type=("build", "run", "test"))
     depends_on("perl-test-fatal", type=("build", "test"))
     depends_on("perl-test-needs", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use MooseX::Role::Parameterized; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-moox-types-mooselike-numeric/package.py
+++ b/var/spack/repos/builtin/packages/perl-moox-types-mooselike-numeric/package.py
@@ -24,11 +24,3 @@ class PerlMooxTypesMooselikeNumeric(PerlPackage):
     depends_on("perl-moo@1.004002:", type=("build", "link"))
     depends_on("perl-moox-types-mooselike@0.23:", type=("build", "run", "test"))
     depends_on("perl-test-fatal@0.003:", type=("build", "link"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use MooX::Types::MooseLike::Numeric; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-moox-types-mooselike/package.py
+++ b/var/spack/repos/builtin/packages/perl-moox-types-mooselike/package.py
@@ -19,11 +19,3 @@ class PerlMooxTypesMooselike(PerlPackage):
     depends_on("perl-module-runtime@0.014:", type=("build", "run", "test"))
     depends_on("perl-moo@1.004002:", type=("build", "test"))
     depends_on("perl-test-fatal@0.003:", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use MooX::Types::MooseLike; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-namespace-autoclean/package.py
+++ b/var/spack/repos/builtin/packages/perl-namespace-autoclean/package.py
@@ -23,11 +23,3 @@ class PerlNamespaceAutoclean(PerlPackage):
     depends_on("perl-namespace-clean@0.20:", type=("build", "run", "test"))
     depends_on("perl-sub-identify", type=("build", "run", "test"))
     depends_on("perl-test-needs", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use namespace::autoclean; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-namespace-clean/package.py
+++ b/var/spack/repos/builtin/packages/perl-namespace-clean/package.py
@@ -21,11 +21,3 @@ class PerlNamespaceClean(PerlPackage):
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
     depends_on("perl-b-hooks-endofscope@0.12:", type=("build", "run", "test"))
     depends_on("perl-package-stash@0.23:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use namespace::clean; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-net-cidr-lite/package.py
+++ b/var/spack/repos/builtin/packages/perl-net-cidr-lite/package.py
@@ -17,11 +17,3 @@ class PerlNetCidrLite(PerlPackage):
     license("Artistic-1.0-Perl OR GPL-1.0-or-later")
 
     version("0.22", sha256="4317d8cb341a617b9e0888da43c09cdffffcb0c9edf7b8c9928d742a563b8517")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Net::CIDR::Lite; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-net-ip/package.py
+++ b/var/spack/repos/builtin/packages/perl-net-ip/package.py
@@ -15,11 +15,3 @@ class PerlNetIp(PerlPackage):
     maintainers("EbiArnie")
 
     version("1.26", sha256="040f16f3066647d761b724a3b70754d28cbd1e6fe5ea01c63ed1cd857117d639")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Net::IP; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-net-server-ss-prefork/package.py
+++ b/var/spack/repos/builtin/packages/perl-net-server-ss-prefork/package.py
@@ -23,11 +23,3 @@ class PerlNetServerSsPrefork(PerlPackage):
     depends_on("perl-net-server", type=("build", "run", "test"))
     depends_on("perl-server-starter@0.02:", type=("build", "run", "test"))
     depends_on("perl-test-tcp@0.06:", type=("build", "link"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Net::Server::SS::PreFork; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-net-server/package.py
+++ b/var/spack/repos/builtin/packages/perl-net-server/package.py
@@ -17,11 +17,3 @@ class PerlNetServer(PerlPackage):
     license("Artistic-1.0-Perl OR GPL-1.0-or-later")
 
     version("2.014", sha256="3406b9ca5a662a0075eed47fb78de1316b601c94f62a0ee34a5544db9baa3720")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Net::Server; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-package-variant/package.py
+++ b/var/spack/repos/builtin/packages/perl-package-variant/package.py
@@ -23,11 +23,3 @@ class PerlPackageVariant(PerlPackage):
     depends_on("perl-module-runtime@0.013:", type=("build", "run", "test"))
     depends_on("perl-strictures@2.000000:", type=("build", "run", "test"))
     depends_on("perl-test-fatal", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Package::Variant; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-params-validationcompiler/package.py
+++ b/var/spack/repos/builtin/packages/perl-params-validationcompiler/package.py
@@ -25,11 +25,3 @@ class PerlParamsValidationcompiler(PerlPackage):
     depends_on("perl-test-without-module", type=("build", "test"))
     depends_on("perl-test2-plugin-nowarnings", type=("build", "test"))
     depends_on("perl-test2-suite", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Params::ValidationCompiler; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-path-class/package.py
+++ b/var/spack/repos/builtin/packages/perl-path-class/package.py
@@ -17,11 +17,3 @@ class PerlPathClass(PerlPackage):
     license("Artistic-1.0-Perl OR GPL-1.0-or-later")
 
     version("0.37", sha256="654781948602386f2cb2e4473a739f17dc6953d92aabc2498a4ca2561bc248ce")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Path::Class; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-perl-critic-moose/package.py
+++ b/var/spack/repos/builtin/packages/perl-perl-critic-moose/package.py
@@ -22,11 +22,3 @@ class PerlPerlCriticMoose(PerlPackage):
     depends_on("perl-namespace-autoclean", type=("build", "run", "test"))
     depends_on("perl-perl-critic", type=("build", "run", "test"))
     depends_on("perl-readonly", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Perl::Critic::Moose; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-perl-critic/package.py
+++ b/var/spack/repos/builtin/packages/perl-perl-critic/package.py
@@ -34,11 +34,3 @@ class PerlPerlCritic(PerlPackage):
     depends_on("perl-ppix-utils", type=("build", "run", "test"))
     depends_on("perl-readonly@2:", type=("build", "run", "test"))
     depends_on("perl-string-format@1.18:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Perl::Critic; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-perl-tidy/package.py
+++ b/var/spack/repos/builtin/packages/perl-perl-tidy/package.py
@@ -19,11 +19,3 @@ class PerlPerlTidy(PerlPackage):
     version("20240202", sha256="9451adde47c2713652d39b150fb3eeb3ccc702add46913e989125184cd7ec57d")
 
     depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Perl::Tidy; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-plack-middleware-assets/package.py
+++ b/var/spack/repos/builtin/packages/perl-plack-middleware-assets/package.py
@@ -22,11 +22,3 @@ class PerlPlackMiddlewareAssets(PerlPackage):
     depends_on("perl-http-date", type=("build", "run", "test"))
     depends_on("perl-javascript-minifier-xs", type=("build", "run", "test"))
     depends_on("perl-plack", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Plack::Middleware::Assets; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-plack-middleware-crossorigin/package.py
+++ b/var/spack/repos/builtin/packages/perl-plack-middleware-crossorigin/package.py
@@ -22,11 +22,3 @@ class PerlPlackMiddlewareCrossorigin(PerlPackage):
 
     depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
     depends_on("perl-plack", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Plack::Middleware::CrossOrigin; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-plack-middleware-deflater/package.py
+++ b/var/spack/repos/builtin/packages/perl-plack-middleware-deflater/package.py
@@ -23,11 +23,3 @@ class PerlPlackMiddlewareDeflater(PerlPackage):
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
     depends_on("perl-plack", type=("build", "run", "test"))
     depends_on("perl-test-requires", type=("build", "link"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Plack::Middleware::Deflater; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-plack-middleware-fixmissingbodyinredirect/package.py
+++ b/var/spack/repos/builtin/packages/perl-plack-middleware-fixmissingbodyinredirect/package.py
@@ -21,14 +21,3 @@ class PerlPlackMiddlewareFixmissingbodyinredirect(PerlPackage):
     depends_on("perl-html-parser", type=("build", "run", "test"))
     depends_on("perl-http-message", type=("build", "test"))
     depends_on("perl-plack", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = [
-            "-we",
-            'use strict; use Plack::Middleware::FixMissingBodyInRedirect; print("OK\n")',
-        ]
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-plack-middleware-methodoverride/package.py
+++ b/var/spack/repos/builtin/packages/perl-plack-middleware-methodoverride/package.py
@@ -21,11 +21,3 @@ class PerlPlackMiddlewareMethodoverride(PerlPackage):
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
     depends_on("perl-plack", type=("build", "run", "test"))
     depends_on("perl-uri", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Plack::Middleware::MethodOverride; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-plack-middleware-removeredundantbody/package.py
+++ b/var/spack/repos/builtin/packages/perl-plack-middleware-removeredundantbody/package.py
@@ -20,11 +20,3 @@ class PerlPlackMiddlewareRemoveredundantbody(PerlPackage):
 
     depends_on("perl-http-message", type=("build", "test"))
     depends_on("perl-plack", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Plack::Middleware::RemoveRedundantBody; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-plack-middleware-reverseproxy/package.py
+++ b/var/spack/repos/builtin/packages/perl-plack-middleware-reverseproxy/package.py
@@ -20,11 +20,3 @@ class PerlPlackMiddlewareReverseproxy(PerlPackage):
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
     depends_on("perl-plack@0.9988:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Plack::Middleware::ReverseProxy; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-plack-test-externalserver/package.py
+++ b/var/spack/repos/builtin/packages/perl-plack-test-externalserver/package.py
@@ -24,11 +24,3 @@ class PerlPlackTestExternalserver(PerlPackage):
     depends_on("perl-plack", type=("build", "test"))
     depends_on("perl-test-tcp", type=("build", "test"))
     depends_on("perl-uri", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Plack::Test::ExternalServer; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-plack/package.py
+++ b/var/spack/repos/builtin/packages/perl-plack/package.py
@@ -36,11 +36,3 @@ class PerlPlack(PerlPackage):
     depends_on("perl-try-tiny", type=("build", "run", "test"))
     depends_on("perl-uri@1.59:", type=("build", "run", "test"))
     depends_on("perl-www-form-urlencoded@0.23:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Plack; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-pod-coverage/package.py
+++ b/var/spack/repos/builtin/packages/perl-pod-coverage/package.py
@@ -18,11 +18,3 @@ class PerlPodCoverage(PerlPackage):
 
     depends_on("perl-devel-symdump@2.01:", type=("build", "run", "test"))
     depends_on("perl-pod-parser@1.13:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Pod::Coverage; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-pod-parser/package.py
+++ b/var/spack/repos/builtin/packages/perl-pod-parser/package.py
@@ -15,11 +15,3 @@ class PerlPodParser(PerlPackage):
     maintainers("EbiArnie")
 
     version("1.67", sha256="5deccbf55d750ce65588cd211c1a03fa1ef3aaa15d1ac2b8d85383a42c1427ea")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Pod::Parser; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-pod-spell/package.py
+++ b/var/spack/repos/builtin/packages/perl-pod-spell/package.py
@@ -23,11 +23,3 @@ class PerlPodSpell(PerlPackage):
     depends_on("perl-file-sharedir", type=("build", "run", "test"))
     depends_on("perl-file-sharedir-install@0.06:", type=("build"))
     depends_on("perl-lingua-en-inflect", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Pod::Spell; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-posix-strftime-compiler/package.py
+++ b/var/spack/repos/builtin/packages/perl-posix-strftime-compiler/package.py
@@ -20,11 +20,3 @@ class PerlPosixStrftimeCompiler(PerlPackage):
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
     depends_on("perl-module-build-tiny@0.035:", type=("build"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use POSIX::strftime::Compiler; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-ppi/package.py
+++ b/var/spack/repos/builtin/packages/perl-ppi/package.py
@@ -26,11 +26,3 @@ class PerlPpi(PerlPackage):
     depends_on("perl-test-nowarnings", type=("build", "test"))
     depends_on("perl-test-object@0.07:", type=("build", "test"))
     depends_on("perl-test-subcalls@1.07:", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use PPI; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-ppix-quotelike/package.py
+++ b/var/spack/repos/builtin/packages/perl-ppix-quotelike/package.py
@@ -21,11 +21,3 @@ class PerlPpixQuotelike(PerlPackage):
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-ppi", type=("build", "run", "test"))
     depends_on("perl-readonly", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use PPIx::QuoteLike; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-ppix-regexp/package.py
+++ b/var/spack/repos/builtin/packages/perl-ppix-regexp/package.py
@@ -21,11 +21,3 @@ class PerlPpixRegexp(PerlPackage):
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-ppi", type=("build", "run", "test"))
     depends_on("perl-task-weaken", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use PPIx::Regexp; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-ppix-utils/package.py
+++ b/var/spack/repos/builtin/packages/perl-ppix-utils/package.py
@@ -21,11 +21,3 @@ class PerlPpixUtils(PerlPackage):
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-b-keywords@1.09:", type=("build", "run", "test"))
     depends_on("perl-ppi@1.250:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use PPIx::Utils; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-proc-daemon/package.py
+++ b/var/spack/repos/builtin/packages/perl-proc-daemon/package.py
@@ -17,11 +17,3 @@ class PerlProcDaemon(PerlPackage):
     version("0.23", sha256="34c0b85b7948b431cbabc97cee580835e515ccf43badbd8339eb109474089b69")
 
     depends_on("perl-proc-processtable", type=("build", "link"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Proc::Daemon; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-proc-processtable/package.py
+++ b/var/spack/repos/builtin/packages/perl-proc-processtable/package.py
@@ -19,11 +19,3 @@ class PerlProcProcesstable(PerlPackage):
     version("0.636", sha256="944224ffb00fc1ef35069633770a0afda8623b5c7532d1e4ab48a9df394890fd")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Proc::ProcessTable; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-readonly-xs/package.py
+++ b/var/spack/repos/builtin/packages/perl-readonly-xs/package.py
@@ -19,7 +19,3 @@ class PerlReadonlyXs(PerlPackage):
     version("1.05", sha256="8ae5c4e85299e5c8bddd1b196f2eea38f00709e0dc0cb60454dc9114ae3fff0d")
 
     depends_on("perl-readonly@1.02:", type=("build", "run", "test"))
-
-    def test_use(self):
-        # This module can not be "use"d.
-        pass

--- a/var/spack/repos/builtin/packages/perl-ref-util/package.py
+++ b/var/spack/repos/builtin/packages/perl-ref-util/package.py
@@ -19,11 +19,3 @@ class PerlRefUtil(PerlPackage):
     version("0.204", sha256="415fa73dbacf44f3d5d79c14888cc994562720ab468e6f71f91cd1f769f105e1")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Ref::Util; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-rose-datetime/package.py
+++ b/var/spack/repos/builtin/packages/perl-rose-datetime/package.py
@@ -18,11 +18,3 @@ class PerlRoseDatetime(PerlPackage):
 
     depends_on("perl-datetime", type=("build", "run", "test"))
     depends_on("perl-rose-object@0.82:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Rose::DateTime; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-rose-db-object/package.py
+++ b/var/spack/repos/builtin/packages/perl-rose-db-object/package.py
@@ -28,11 +28,3 @@ class PerlRoseDbObject(PerlPackage):
     depends_on("perl-rose-db@0.782:", type=("build", "run", "test"))
     depends_on("perl-rose-object@0.854:", type=("build", "run", "test"))
     depends_on("perl-time-clock@1.00:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Rose::DB::Object; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-rose-db/package.py
+++ b/var/spack/repos/builtin/packages/perl-rose-db/package.py
@@ -30,11 +30,3 @@ class PerlRoseDb(PerlPackage):
     depends_on("perl-rose-object@0.854:", type=("build", "run", "test"))
     depends_on("perl-sql-reservedwords", type=("build", "run", "test"))
     depends_on("perl-time-clock", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Rose::DB; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-rose-object/package.py
+++ b/var/spack/repos/builtin/packages/perl-rose-object/package.py
@@ -17,11 +17,3 @@ class PerlRoseObject(PerlPackage):
     version("0.860", sha256="f3ff294097b1a4b02a4bae6dc3544ded744a08972e831c1d2741083403197f47")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Rose::Object; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-safe-isa/package.py
+++ b/var/spack/repos/builtin/packages/perl-safe-isa/package.py
@@ -19,11 +19,3 @@ class PerlSafeIsa(PerlPackage):
     version("1.000010", sha256="87f4148aa0ff1d5e652723322eab7dafa3801c967d6f91ac9147a3c467b8a66a")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Safe::Isa; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-scope-guard/package.py
+++ b/var/spack/repos/builtin/packages/perl-scope-guard/package.py
@@ -17,11 +17,3 @@ class PerlScopeGuard(PerlPackage):
     version("0.21", sha256="8c9b1bea5c56448e2c3fadc65d05be9e4690a3823a80f39d2f10fdd8f777d278")
 
     depends_on("perl@5.6.1:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Scope::Guard; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-search-elasticsearch/package.py
+++ b/var/spack/repos/builtin/packages/perl-search-elasticsearch/package.py
@@ -38,11 +38,3 @@ class PerlSearchElasticsearch(PerlPackage):
     depends_on("perl-test-sharedfork", type=("build", "test"))
     depends_on("perl-try-tiny", type=("build", "run", "test"))
     depends_on("perl-uri", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Search::Elasticsearch; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-sereal-decoder/package.py
+++ b/var/spack/repos/builtin/packages/perl-sereal-decoder/package.py
@@ -34,11 +34,3 @@ class PerlSerealDecoder(PerlPackage):
         env.set("USE_UNALIGNED", "1")
         env.set("NO_ASM", "0")
         env.set("ZSTD_DISABLE_ASM", "0")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Sereal::Decoder; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-sereal-encoder/package.py
+++ b/var/spack/repos/builtin/packages/perl-sereal-encoder/package.py
@@ -35,11 +35,3 @@ class PerlSerealEncoder(PerlPackage):
         env.set("USE_UNALIGNED", "1")
         env.set("NO_ASM", "0")
         env.set("ZSTD_DISABLE_ASM", "0")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Sereal::Encoder; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-sereal/package.py
+++ b/var/spack/repos/builtin/packages/perl-sereal/package.py
@@ -25,11 +25,3 @@ class PerlSereal(PerlPackage):
     depends_on("perl-test-differences", type=("build", "test"))
     depends_on("perl-test-longstring", type=("build", "test"))
     depends_on("perl-test-warn", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Sereal; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-server-starter/package.py
+++ b/var/spack/repos/builtin/packages/perl-server-starter/package.py
@@ -22,11 +22,3 @@ class PerlServerStarter(PerlPackage):
     depends_on("perl-test-requires", type=("build", "test"))
     depends_on("perl-test-sharedfork", type=("build", "test"))
     depends_on("perl-test-tcp@2.08:", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Server::Starter; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-set-object/package.py
+++ b/var/spack/repos/builtin/packages/perl-set-object/package.py
@@ -15,11 +15,3 @@ class PerlSetObject(PerlPackage):
     maintainers("EbiArnie")
 
     version("1.42", sha256="d18c5a8a233eabbd0206cf3da5b00fcdd7b37febf12a93dcc3d1c026e6fdec45")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Set::Object; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-specio/package.py
+++ b/var/spack/repos/builtin/packages/perl-specio/package.py
@@ -28,11 +28,3 @@ class PerlSpecio(PerlPackage):
     depends_on("perl-test-fatal", type=("build", "run", "test"))
     depends_on("perl-test-needs", type=("build", "test"))
     depends_on("perl-try-tiny", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Specio; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-spiffy/package.py
+++ b/var/spack/repos/builtin/packages/perl-spiffy/package.py
@@ -19,11 +19,3 @@ class PerlSpiffy(PerlPackage):
     version("0.46", sha256="8f58620a8420255c49b6c43c5ff5802bd25e4f09240c51e5bf2b022833d41da3")
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Spiffy; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-sql-abstract-classic/package.py
+++ b/var/spack/repos/builtin/packages/perl-sql-abstract-classic/package.py
@@ -24,11 +24,3 @@ class PerlSqlAbstractClassic(PerlPackage):
     depends_on("perl-test-deep@0.101:", type=("build", "link"))
     depends_on("perl-test-exception@0.31:", type=("build", "link"))
     depends_on("perl-test-warn", type=("build", "link"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use SQL::Abstract::Classic; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-sql-abstract/package.py
+++ b/var/spack/repos/builtin/packages/perl-sql-abstract/package.py
@@ -27,11 +27,3 @@ class PerlSqlAbstract(PerlPackage):
     depends_on("perl-test-deep@0.101:", type=("build", "run", "test"))
     depends_on("perl-test-exception@0.31:", type=("build", "test"))
     depends_on("perl-test-warn", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use SQL::Abstract; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-sql-reservedwords/package.py
+++ b/var/spack/repos/builtin/packages/perl-sql-reservedwords/package.py
@@ -17,11 +17,3 @@ class PerlSqlReservedwords(PerlPackage):
     version("0.8", sha256="09f4aecf1bd8efdd3f9b39f16a240c4e9ceb61eb295b88145c96eb9d58504a2a")
 
     depends_on("perl-sub-exporter", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use SQL::ReservedWords; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-sql-translator/package.py
+++ b/var/spack/repos/builtin/packages/perl-sql-translator/package.py
@@ -33,11 +33,3 @@ class PerlSqlTranslator(PerlPackage):
     depends_on("perl-try-tiny@0.04:", type=("build", "run", "test"))
     depends_on("perl-xml-writer@0.500:", type=("build", "test"))
     depends_on("perl-yaml@0.66:", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use SQL::Translator; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-starman/package.py
+++ b/var/spack/repos/builtin/packages/perl-starman/package.py
@@ -29,11 +29,3 @@ class PerlStarman(PerlPackage):
     depends_on("perl-plack@0.9971:", type=("build", "run", "test"))
     depends_on("perl-test-requires", type=("build", "test"))
     depends_on("perl-test-tcp@2.00:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Starman; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-stream-buffered/package.py
+++ b/var/spack/repos/builtin/packages/perl-stream-buffered/package.py
@@ -19,11 +19,3 @@ class PerlStreamBuffered(PerlPackage):
     version("0.03", sha256="9b2d4390b5de6b0cf4558e4ad04317a73c5e13dd19af29149c4e47c37fb2423b")
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Stream::Buffered; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-strictures/package.py
+++ b/var/spack/repos/builtin/packages/perl-strictures/package.py
@@ -19,11 +19,3 @@ class PerlStrictures(PerlPackage):
     version("2.000006", sha256="09d57974a6d1b2380c802870fed471108f51170da81458e2751859f2714f8d57")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use strictures; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-string-approx/package.py
+++ b/var/spack/repos/builtin/packages/perl-string-approx/package.py
@@ -15,11 +15,3 @@ class PerlStringApprox(PerlPackage):
     maintainers("EbiArnie")
 
     version("3.28", sha256="43201e762d8699cb0ac2c0764a5454bdc2306c0771014d6c8fba821480631342")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use String::Approx; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-string-crc32/package.py
+++ b/var/spack/repos/builtin/packages/perl-string-crc32/package.py
@@ -17,11 +17,3 @@ class PerlStringCrc32(PerlPackage):
     license("CC0-1.0 OR SSLeay")
 
     version("2.100", sha256="9706093b2d068b6715d35b4c58f51558e37960083202129fbb00a57e19a74713")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use String::CRC32; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-string-format/package.py
+++ b/var/spack/repos/builtin/packages/perl-string-format/package.py
@@ -15,11 +15,3 @@ class PerlStringFormat(PerlPackage):
     maintainers("EbiArnie")
 
     version("1.18", sha256="9e417a8f8d9ea623beea2d13a47c0d5a696fc8602c0509b826cd45f97b76e778")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use String::Format; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-string-numeric/package.py
+++ b/var/spack/repos/builtin/packages/perl-string-numeric/package.py
@@ -20,11 +20,3 @@ class PerlStringNumeric(PerlPackage):
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-test-exception", type=("build", "link"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use String::Numeric; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-string-rewriteprefix/package.py
+++ b/var/spack/repos/builtin/packages/perl-string-rewriteprefix/package.py
@@ -20,11 +20,3 @@ class PerlStringRewriteprefix(PerlPackage):
 
     depends_on("perl@5.12.0:", type=("build", "link", "run", "test"))
     depends_on("perl-sub-exporter@0.972:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use String::RewritePrefix; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-term-ansicolor-markup/package.py
+++ b/var/spack/repos/builtin/packages/perl-term-ansicolor-markup/package.py
@@ -23,11 +23,3 @@ class PerlTermAnsicolorMarkup(PerlPackage):
     depends_on("perl-html-parser", type=("build", "run", "test"))
     depends_on("perl-test-exception", type=("build", "link"))
     depends_on("perl-module-install", type=("build", "link"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Term::ANSIColor::Markup; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-term-table/package.py
+++ b/var/spack/repos/builtin/packages/perl-term-table/package.py
@@ -19,11 +19,3 @@ class PerlTermTable(PerlPackage):
     version("0.018", sha256="9159b9131ee6b3f3956b74f45422985553574babbfaeba60be5c17bc114ac011")
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Term::Table; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-base/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-base/package.py
@@ -22,11 +22,3 @@ class PerlTestBase(PerlPackage):
     depends_on("perl-algorithm-diff@1.15:", type=("build", "test"))
     depends_on("perl-spiffy@0.40:", type=("run", "test"))
     depends_on("perl-text-diff@0.35:", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::Base; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-class/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-class/package.py
@@ -23,11 +23,3 @@ class PerlTestClass(PerlPackage):
     depends_on("perl-mro-compat@0.11:", type=("build", "run", "test"))
     depends_on("perl-test-exception@0.25:", type=("build", "test"))
     depends_on("perl-try-tiny", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::Class; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-diaginc/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-diaginc/package.py
@@ -20,11 +20,3 @@ class PerlTestDiaginc(PerlPackage):
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-capture-tiny@0.21:", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::DiagINC; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-file-contents/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-file-contents/package.py
@@ -20,11 +20,3 @@ class PerlTestFileContents(PerlPackage):
 
     depends_on("perl@5.8.3:", type=("build", "link", "run", "test"))
     depends_on("perl-text-diff@0.35:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::File::Contents; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-file-sharedir/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-file-sharedir/package.py
@@ -25,11 +25,3 @@ class PerlTestFileSharedir(PerlPackage):
     depends_on("perl-path-tiny@0.018:", type=("build", "run", "test"))
     depends_on("perl-scope-guard", type=("build", "run", "test"))
     depends_on("perl-test-fatal", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::File::ShareDir; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-json/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-json/package.py
@@ -20,11 +20,3 @@ class PerlTestJson(PerlPackage):
 
     depends_on("perl-json-any@1.2:", type=("build", "run", "test"))
     depends_on("perl-test-differences@0.47:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::JSON; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-longstring/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-longstring/package.py
@@ -17,11 +17,3 @@ class PerlTestLongstring(PerlPackage):
     license("Artistic-1.0-Perl OR GPL-1.0-or-later")
 
     version("0.17", sha256="abc4349eaf04d1bec1e464166a3018591ea846d8f3c5c9c8af4ac4905d3e974f")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::LongString; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-mockobject/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-mockobject/package.py
@@ -25,11 +25,3 @@ class PerlTestMockobject(PerlPackage):
     depends_on("perl-test-warn@0.23:", type=("build", "test"))
     depends_on("perl-universal-can@1.20110617:", type=("build", "run", "test"))
     depends_on("perl-universal-isa@1.20110614:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::MockObject; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-mocktime/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-mocktime/package.py
@@ -17,11 +17,3 @@ class PerlTestMocktime(PerlPackage):
     license("Artistic-1.0-Perl OR GPL-1.0-or-later")
 
     version("0.17", sha256="3363e118b2606f1d6abc956f22b0d09109772b7086155fb5c9c7f983350602f9")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::MockTime; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-object/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-object/package.py
@@ -19,11 +19,3 @@ class PerlTestObject(PerlPackage):
     version("0.08", sha256="65278964147837313f4108e55b59676e8a364d6edf01b3dc198aee894ab1d0bb")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::Object; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-output/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-output/package.py
@@ -11,8 +11,6 @@ class PerlTestOutput(PerlPackage):
 
     homepage = "https://github.com/briandfoy/test-output"
     url = "https://github.com/briandfoy/test-output/archive/release-1.033.tar.gz"
-    use_modules = ["Test::Output"]
-
     license("Artistic-2.0")
 
     version("1.033", sha256="35f0a4ef2449fc78886b4c99e1c1d23f432c2fae98538a4489439eb17223bfc2")

--- a/var/spack/repos/builtin/packages/perl-test-output/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-output/package.py
@@ -11,6 +11,7 @@ class PerlTestOutput(PerlPackage):
 
     homepage = "https://github.com/briandfoy/test-output"
     url = "https://github.com/briandfoy/test-output/archive/release-1.033.tar.gz"
+    use_modules = ["Test::Output"]
 
     license("Artistic-2.0")
 

--- a/var/spack/repos/builtin/packages/perl-test-perl-critic/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-perl-critic/package.py
@@ -20,11 +20,3 @@ class PerlTestPerlCritic(PerlPackage):
 
     depends_on("perl-mce@1.827:", type=("build", "run", "test"))
     depends_on("perl-perl-critic@1.105:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::Perl::Critic; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-pod-coverage/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-pod-coverage/package.py
@@ -20,11 +20,3 @@ class PerlTestPodCoverage(PerlPackage):
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-pod-coverage", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::Pod::Coverage; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-pod/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-pod/package.py
@@ -19,11 +19,3 @@ class PerlTestPod(PerlPackage):
     version("1.52", sha256="60a8dbcc60168bf1daa5cc2350236df9343e9878f4ab9830970a5dde6fe8e5fc")
 
     depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::Pod; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-sharedfork/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-sharedfork/package.py
@@ -20,11 +20,3 @@ class PerlTestSharedfork(PerlPackage):
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
     depends_on("perl-test-requires", type=("test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::SharedFork; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-subcalls/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-subcalls/package.py
@@ -20,11 +20,3 @@ class PerlTestSubcalls(PerlPackage):
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-hook-lexwrap@0.20:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::SubCalls; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-tcp/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-tcp/package.py
@@ -20,11 +20,3 @@ class PerlTestTcp(PerlPackage):
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
     depends_on("perl-test-sharedfork@0.29:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::TCP; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-time-hires/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-time-hires/package.py
@@ -21,11 +21,3 @@ class PerlTestTimeHires(PerlPackage):
     depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
     depends_on("perl-module-build-tiny@0.034:", type=("build"))
     depends_on("perl-test-time@0.07:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::Time::HiRes; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-time/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-time/package.py
@@ -17,11 +17,3 @@ class PerlTestTime(PerlPackage):
     license("Artistic-1.0-Perl OR GPL-1.0-or-later")
 
     version("0.092", sha256="30d90f54ce840893c7ba2cac2a4d1eecd4c9cdf805910c595e3ae89dfd644738")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::Time; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-trap/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-trap/package.py
@@ -25,11 +25,3 @@ class PerlTestTrap(PerlPackage):
         return (
             f"https://cpan.metacpan.org/authors/id/E/EB/EBHANSSEN/Test-Trap-{str(version)}.tar.gz"
         )
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::Trap; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-warn/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-warn/package.py
@@ -26,11 +26,3 @@ class PerlTestWarn(PerlPackage):
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-sub-uplevel@0.12:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::Warn; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-xml-simple/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-xml-simple/package.py
@@ -24,11 +24,3 @@ class PerlTestXmlSimple(PerlPackage):
     # The test suite from upstream is failing, so we just skip the tests
     def check(self):
         pass
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::XML::Simple; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-xml/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-xml/package.py
@@ -21,11 +21,3 @@ class PerlTestXml(PerlPackage):
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-xml-parser@2.34:", type=("build", "run", "test"))
     depends_on("perl-xml-semanticdiff@0.95:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::XML; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-xpath/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-xpath/package.py
@@ -20,11 +20,3 @@ class PerlTestXpath(PerlPackage):
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-xml-libxml@1.70:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::XPath; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test-yaml/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-yaml/package.py
@@ -19,11 +19,3 @@ class PerlTestYaml(PerlPackage):
     version("1.07", sha256="1f300d034f46298cb92960912cc04bac33fb27f05b8852d8f051e110b9cd995f")
 
     depends_on("perl-test-base@0.89:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test::YAML; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test2-plugin-nowarnings/package.py
+++ b/var/spack/repos/builtin/packages/perl-test2-plugin-nowarnings/package.py
@@ -20,11 +20,3 @@ class PerlTest2PluginNowarnings(PerlPackage):
 
     depends_on("perl-ipc-run3", type=("build", "test"))
     depends_on("perl-test2-suite", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test2::Plugin::NoWarnings; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-test2-suite/package.py
+++ b/var/spack/repos/builtin/packages/perl-test2-suite/package.py
@@ -20,11 +20,3 @@ class PerlTest2Suite(PerlPackage):
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
     depends_on("perl-term-table@0.013:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Test2::Suite; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-text-csv-xs/package.py
+++ b/var/spack/repos/builtin/packages/perl-text-csv-xs/package.py
@@ -19,11 +19,3 @@ class PerlTextCsvXs(PerlPackage):
     version("1.53", sha256="ba3231610fc755a69e14eb4a3c6d8cce46cc4fd32853777a6c9ce485a8878b42")
 
     depends_on("perl@5.6.1:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Text::CSV_XS; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-throwable/package.py
+++ b/var/spack/repos/builtin/packages/perl-throwable/package.py
@@ -22,11 +22,3 @@ class PerlThrowable(PerlPackage):
     depends_on("perl-module-runtime@0.002:", type=("run"))
     depends_on("perl-moo@1.000001:", type=("run"))
     depends_on("perl-sub-quote", type=("run"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Throwable; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-tie-ixhash/package.py
+++ b/var/spack/repos/builtin/packages/perl-tie-ixhash/package.py
@@ -19,11 +19,3 @@ class PerlTieIxhash(PerlPackage):
     version("1.23", sha256="fabb0b8c97e67c9b34b6cc18ed66f6c5e01c55b257dcf007555e0b027d4caf56")
 
     depends_on("perl@5.5.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Tie::IxHash; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-tie-toobject/package.py
+++ b/var/spack/repos/builtin/packages/perl-tie-toobject/package.py
@@ -15,11 +15,3 @@ class PerlTieToobject(PerlPackage):
     maintainers("EbiArnie")
 
     version("0.03", sha256="a31a0d4430fe14f59622f31db7f25b2275dad2ec52f1040beb030d3e83ad3af4")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Tie::ToObject; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-time-clock/package.py
+++ b/var/spack/repos/builtin/packages/perl-time-clock/package.py
@@ -17,11 +17,3 @@ class PerlTimeClock(PerlPackage):
     version("1.03", sha256="35e8a8bbfcdb35d86dd4852a9cd32cfb455a9b42e22669186e920c8aca017aef")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Time::Clock; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-time-duration-parse/package.py
+++ b/var/spack/repos/builtin/packages/perl-time-duration-parse/package.py
@@ -20,11 +20,3 @@ class PerlTimeDurationParse(PerlPackage):
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-time-duration", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Time::Duration::Parse; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-time-duration/package.py
+++ b/var/spack/repos/builtin/packages/perl-time-duration/package.py
@@ -19,11 +19,3 @@ class PerlTimeDuration(PerlPackage):
     version("1.21", sha256="fe340eba8765f9263694674e5dff14833443e19865e5ff427bbd79b7b5f8a9b8")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Time::Duration; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-tree-simple-visitorfactory/package.py
+++ b/var/spack/repos/builtin/packages/perl-tree-simple-visitorfactory/package.py
@@ -20,11 +20,3 @@ class PerlTreeSimpleVisitorfactory(PerlPackage):
 
     depends_on("perl-test-exception@0.15:", type=("build", "test"))
     depends_on("perl-tree-simple@1.12:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Tree::Simple::VisitorFactory; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-tree-simple/package.py
+++ b/var/spack/repos/builtin/packages/perl-tree-simple/package.py
@@ -19,11 +19,3 @@ class PerlTreeSimple(PerlPackage):
     version("1.34", sha256="b7e9799bd222bb94cff993f7d765980cbea1b6cd2aaa5ecbead635abdf47d29c")
 
     depends_on("perl-test-exception@0.15:", type=("build", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Tree::Simple; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-type-tiny/package.py
+++ b/var/spack/repos/builtin/packages/perl-type-tiny/package.py
@@ -20,11 +20,3 @@ class PerlTypeTiny(PerlPackage):
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
     depends_on("perl-exporter-tiny@1.006000:", type=("run"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Type::Tiny; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-types-serialiser/package.py
+++ b/var/spack/repos/builtin/packages/perl-types-serialiser/package.py
@@ -17,11 +17,3 @@ class PerlTypesSerialiser(PerlPackage):
     version("1.01", sha256="f8c7173b0914d0e3d957282077b366f0c8c70256715eaef3298ff32b92388a80")
 
     depends_on("perl-common-sense", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use Types::Serialiser; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-universal-can/package.py
+++ b/var/spack/repos/builtin/packages/perl-universal-can/package.py
@@ -21,11 +21,3 @@ class PerlUniversalCan(PerlPackage):
     )
 
     depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use UNIVERSAL::can; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-universal-isa/package.py
+++ b/var/spack/repos/builtin/packages/perl-universal-isa/package.py
@@ -21,11 +21,3 @@ class PerlUniversalIsa(PerlPackage):
     )
 
     depends_on("perl@5.6.2:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use UNIVERSAL::isa; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-uri-find/package.py
+++ b/var/spack/repos/builtin/packages/perl-uri-find/package.py
@@ -20,11 +20,3 @@ class PerlUriFind(PerlPackage):
 
     depends_on("perl@5.8.8:", type=("build", "link", "run", "test"))
     depends_on("perl-uri@1.60:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use URI::Find; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-uri-ws/package.py
+++ b/var/spack/repos/builtin/packages/perl-uri-ws/package.py
@@ -20,11 +20,3 @@ class PerlUriWs(PerlPackage):
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
     depends_on("perl-uri", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use URI::ws; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-uri/package.py
+++ b/var/spack/repos/builtin/packages/perl-uri/package.py
@@ -12,6 +12,8 @@ class PerlUri(PerlPackage):
     homepage = "https://metacpan.org/pod/URI"
     url = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/URI-1.72.tar.gz"
 
+    skip_modules = ["URI::urn::isbn"]  # required missing Business::ISBN
+
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
     version("5.08", sha256="7e2c6fe3b1d5947da334fa558a96e748aaa619213b85bcdce5b5347d4d26c46e")

--- a/var/spack/repos/builtin/packages/perl-www-form-urlencoded/package.py
+++ b/var/spack/repos/builtin/packages/perl-www-form-urlencoded/package.py
@@ -19,11 +19,3 @@ class PerlWwwFormUrlencoded(PerlPackage):
     version("0.26", sha256="c0480b5f1f15b71163ec327b8e7842298f0cb3ace97e63d7034af1e94a2d90f4")
 
     depends_on("perl@5.8.1:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use WWW::Form::UrlEncoded; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-www-robotrules/package.py
+++ b/var/spack/repos/builtin/packages/perl-www-robotrules/package.py
@@ -15,3 +15,5 @@ class PerlWwwRobotrules(PerlPackage):
     version("6.02", sha256="46b502e7a288d559429891eeb5d979461dd3ecc6a5c491ead85d165b6e03a51e")
 
     depends_on("perl-uri", type=("build", "run"))
+
+    use_modules = ["WWW::RobotRules"]

--- a/var/spack/repos/builtin/packages/perl-www-robotrules/package.py
+++ b/var/spack/repos/builtin/packages/perl-www-robotrules/package.py
@@ -15,5 +15,3 @@ class PerlWwwRobotrules(PerlPackage):
     version("6.02", sha256="46b502e7a288d559429891eeb5d979461dd3ecc6a5c491ead85d165b6e03a51e")
 
     depends_on("perl-uri", type=("build", "run"))
-
-    use_modules = ["WWW::RobotRules"]

--- a/var/spack/repos/builtin/packages/perl-xml-hash-xs/package.py
+++ b/var/spack/repos/builtin/packages/perl-xml-hash-xs/package.py
@@ -17,11 +17,3 @@ class PerlXmlHashXs(PerlPackage):
     license("Artistic-1.0-Perl OR GPL-1.0-or-later")
 
     version("0.56", sha256="be4c60ded94c5ebe53a81ef74928dfbec9613986d2a6056dd253665c6ae9802f")
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use XML::Hash::XS; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-xml-semanticdiff/package.py
+++ b/var/spack/repos/builtin/packages/perl-xml-semanticdiff/package.py
@@ -20,11 +20,3 @@ class PerlXmlSemanticdiff(PerlPackage):
 
     depends_on("perl@5.8.0:", type=("build", "link", "run", "test"))
     depends_on("perl-xml-parser", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use XML::SemanticDiff; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-xml-xpath/package.py
+++ b/var/spack/repos/builtin/packages/perl-xml-xpath/package.py
@@ -21,11 +21,3 @@ class PerlXmlXpath(PerlPackage):
     depends_on("perl@5.10.1:", type=("build", "link", "run", "test"))
     depends_on("perl-path-tiny@0.076:", type=("build", "link"))
     depends_on("perl-xml-parser@2.23:", type=("build", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use XML::XPath; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out

--- a/var/spack/repos/builtin/packages/perl-yaml-syck/package.py
+++ b/var/spack/repos/builtin/packages/perl-yaml-syck/package.py
@@ -19,11 +19,3 @@ class PerlYamlSyck(PerlPackage):
     version("1.34", sha256="cc9156ccaebda798ebfe2f31b619e806577f860ed1704262f17ffad3c6e34159")
 
     depends_on("perl@5.6.0:", type=("build", "link", "run", "test"))
-
-    def test_use(self):
-        """Test 'use module'"""
-        options = ["-we", 'use strict; use YAML::Syck; print("OK\n")']
-
-        perl = self.spec["perl"].command
-        out = perl(*options, output=str.split, error=str.split)
-        assert "OK" in out


### PR DESCRIPTION
This PR moves the `test_use` stand-alone test method from individual classes to the base `PerlPackage` class so the implementation does not have to be repeated for each class. It also automatically determines which perl modules are installed in the package's library thereby ensuring every perl package has a minimal set of stand-alone tests.  (Note: These tests can facilitate identifying missing dependencies.)

The automated identification of installed perl modules and modules to skip are similar to the approach taken for `PythonPackage` resulting in the addition of two properties to `PerlPackage`:

- `use_modules`: initialized to all modules detected under the package's library;
- `skip_modules`: can be overridden on a package basis to identify those that should not be tested (e.g., the module now calls "die <message>" when used).

Refer to the `PerlPackage` documentation for more information on these properties and how they are used.

TODO:
- [x] Add documentation to https://spack.readthedocs.io/en/latest/build_systems/perlpackage.html