### PR TITLE
libquo: Update default version from 1.3.1 to 1.4.

### DIFF
--- a/var/spack/repos/builtin/packages/libquo/package.py
+++ b/var/spack/repos/builtin/packages/libquo/package.py
@@ -12,7 +12,7 @@ class Libquo(AutotoolsPackage):
     single- and multi-threaded libraries."""
 
     homepage = "https://github.com/lanl/libquo"
-    url = "https://lanl.github.io/libquo/dists/libquo-1.3.1.tar.gz"
+    url = "https://lanl.github.io/libquo/dists/libquo-1.4.tar.gz"
     git = "https://github.com/lanl/libquo.git"
 
     maintainers("samuelkgutierrez")
@@ -22,6 +22,7 @@ class Libquo(AutotoolsPackage):
     license("BSD-3-Clause")
 
     version("master", branch="master")
+    version("1.4", sha256="82395148cdef43c37ef018672307316951e55fc6feffce5ab9b412cfafedffcb")
     version("1.3.1", sha256="407f7c61cc80aa934cf6086f3516a31dee3b803047713c297102452c3d7d6ed1")
     version("1.3", sha256="61b0beff15eae4be94b5d3cbcbf7bf757659604465709ed01827cbba45efcf90")
     version("1.2.9", sha256="0a64bea8f52f9eecd89e4ab82fde1c5bd271f3866c612da0ce7f38049409429b")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
