### PR TITLE
Change Spack user-agent to "Spack"

### DIFF
--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -87,7 +87,7 @@ def _urlopen():
 urlopen = lang.Singleton(_urlopen)
 
 #: User-Agent used in Request objects
-SPACK_USER_AGENT = "Spackbot/{0}".format(spack.spack_version)
+SPACK_USER_AGENT = "Spack/{0}".format(spack.spack_version)
 
 
 # Also, HTMLParseError is deprecated and never raised.


### PR DESCRIPTION
This is prompted by the issue described here: https://github.com/spack/spack/issues/43032

    Edit by @haampie: to be specific, hoobly dot com serves ads instead of files when "bot" is in the user agent:

    ```
    curl -A 'SpackBot' -LfsS 'https://gnu.mirrors.hoobly.com/autoconf/autoconf-2.72.tar.gz' # broken
    curl -A 'Spack' -LfsS 'https://gnu.mirrors.hoobly.com/autoconf/autoconf-2.72.tar.gz' # works
    ```
    
    It does however not block bots in /robots.txt from accessing those files

In my opinion, the user-agent "Spackbot" is inappropriate and in this case is causing a problem when a source code mirror is treating clients with "bot" in the name differently than other clients.  I would argue that spack is not a "bot" and that "Spack" is a more appropriate user-agent for the spack client. 

This change will remove "bot" from the user-agent string.