### PR TITLE
py-ruff: add version 0.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-ruff/package.py
+++ b/var/spack/repos/builtin/packages/py-ruff/package.py
@@ -15,8 +15,13 @@ class PyRuff(PythonPackage):
 
     license("MIT")
 
+    version("0.3.0", sha256="0886184ba2618d815067cf43e005388967b67ab9c80df52b32ec1152ab49f53a")
     version("0.1.6", sha256="1b09f29b16c6ead5ea6b097ef2764b42372aebe363722f1605ecbcd2b9207184")
-    version("0.0.276", sha256="d456c86eb6ce9225507f24fcc7bf72fa031bb7cc750023310e62889bf4ad4b6a")
+    version(
+        "0.0.276",
+        sha256="d456c86eb6ce9225507f24fcc7bf72fa031bb7cc750023310e62889bf4ad4b6a",
+        deprecated=True,
+    )
 
     depends_on("py-maturin@1", type="build")
 


### PR DESCRIPTION
I had some issues installing the previous version (maybe some incompatibilities with the latest version of rust?) and version 0.3.0 installs fine.