### PR TITLE
py-onnxruntime: add a dependency on git for when an old version is available

### DIFF
--- a/var/spack/repos/builtin/packages/py-onnxruntime/package.py
+++ b/var/spack/repos/builtin/packages/py-onnxruntime/package.py
@@ -52,6 +52,8 @@ class PyOnnxruntime(CMakePackage, PythonExtension):
     depends_on("cudnn", when="+cuda")
     depends_on("iconv", type=("build", "link", "run"))
     depends_on("re2+shared")
+    # For old systems with and old version of git
+    depends_on("git")
 
     extends("python")
     # Adopted from CMS experiment's fork of onnxruntime


### PR DESCRIPTION
For example on CentOS 7, the system git will fail to correctly fetch the source because of git submodules. Apparently git submodules were introduced in 1.5.3 and on CentOS 7 I have 1.8.X so it should work but it seems it doesn't; with this change it didn't fail at fetching.