### PR TITLE
Update GFE packages

### DIFF
--- a/var/spack/repos/builtin/packages/fargparse/package.py
+++ b/var/spack/repos/builtin/packages/fargparse/package.py
@@ -20,6 +20,7 @@ class Fargparse(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.7.0", sha256="9889e7eca9c020b742787fba2be0ba16edcc3fcf52929261ccb7d09996a35f89")
     version("1.6.0", sha256="055a0af44f50c302f8f20a8bcf3d26c5bbeacf5222cdbaa5b19da4cff56eb9c0")
     version("1.5.0", sha256="1c16ead5f1bacb9c2f33aab99a0889c68c1a1ece754ddc3fd340f10a0d5da2f7")
     version("1.4.2", sha256="2cd3f14845235407c6a4171ab4602499dade045e3f9b7dc75190f4a315ac8b44")
@@ -32,6 +33,13 @@ class Fargparse(CMakePackage):
     depends_on("gftl-shared")
     depends_on("gftl")
     depends_on("cmake@3.12:", type="build")
+
+    # fargparse only works with the Fujitsu compiler from 1.7.0 onwards
+    conflicts(
+        "%fj",
+        when="@:1.6.0",
+        msg="fargparse only works with the Fujitsu compiler from 1.7.0 onwards",
+    )
 
     variant(
         "build_type",

--- a/var/spack/repos/builtin/packages/gftl-shared/package.py
+++ b/var/spack/repos/builtin/packages/gftl-shared/package.py
@@ -25,6 +25,7 @@ class GftlShared(CMakePackage):
 
     version("main", branch="main")
 
+    version("1.8.0", sha256="3450161508c573ea053b2a23cdbf2a1d6fd6fdb78c162d31fc0019da0f8dd03c")
     version("1.7.0", sha256="8ba567133fcee6b93bc71f61b3bb2053b4b07c6d78f6ad98a04dfc40aa478de7")
     version("1.6.1", sha256="0e3e1e0c7e0c3f1576e296b3b199dcae4bbaad055fc8fe929c34e52d4b07b02c")
     version("1.6.0", sha256="90245b83aea9854bc5b9fbd553a68cf73ab12f6ed5a14753a9c84092047e8cb0")
@@ -43,6 +44,13 @@ class GftlShared(CMakePackage):
     depends_on("m4", type=("build", "run"))
     depends_on("cmake@3.12:", type="build")
     depends_on("gftl")
+
+    # gftl-shared only works with the Fujitsu compiler from 1.8.0 onwards
+    conflicts(
+        "%fj",
+        when="@:1.7.0",
+        msg="gftl-shared only works with the Fujitsu compiler from 1.8.0 onwards",
+    )
 
     variant(
         "build_type",

--- a/var/spack/repos/builtin/packages/gftl/package.py
+++ b/var/spack/repos/builtin/packages/gftl/package.py
@@ -39,6 +39,7 @@ class Gftl(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.12.0", sha256="b50e17cb2109372819b3ee676e6e61fd3a517dc4c1ea293937c8a83f03b0cbd6")
     version("1.11.0", sha256="b28935bc077749823b1505ad8c1208360a5ba7e961d7593c17a33b11455a32a4")
     version("1.10.0", sha256="d6086e8cba2497bacdae66d301f7cdacaed9138a0055f33f8ca1b778a0cf0dc5")
     version("1.9.0", sha256="4c7cb8b1313d87eaa5cc9aae242301085aa3b12688d0fddf54061503e95e4cc0")
@@ -56,6 +57,11 @@ class Gftl(CMakePackage):
 
     depends_on("cmake@3.12:", type="build")
     depends_on("m4", type="build")
+
+    # gftl only works with the Fujitsu compiler from 1.12 onwards
+    conflicts(
+        "%fj", when="@:1.11.0", msg="gftl only works with the Fujitsu compiler from 1.12 onwards"
+    )
 
     variant(
         "build_type",

--- a/var/spack/repos/builtin/packages/pflogger/package.py
+++ b/var/spack/repos/builtin/packages/pflogger/package.py
@@ -22,6 +22,7 @@ class Pflogger(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.13.0", sha256="d46b61162496e227d2982bcdfe9b2c8af6a5734d0fbad9305b1a1547abeac06e")
     version("1.12.0", sha256="ff29b0ce4baf50675edb69c3c7493be5410839b5f81e3ce5405f04925503fb0d")
     version("1.11.0", sha256="bf197b6f223a75c7d3eee23888cdde204b5aea053c308852a3f8f677784b8899")
     version("1.10.0", sha256="8e25564699c0adcbe9a23fded6637668ce659480b39420be5a4c8181cd44ad53")
@@ -59,6 +60,13 @@ class Pflogger(CMakePackage):
 
     # Using pFlogger with MPICH 4 is only supported from version 1.11
     conflicts("^mpich@4:", when="@:1.10")
+
+    # pflogger only works with the Fujitsu compiler from 1.13.0 onwards
+    conflicts(
+        "%fj",
+        when="@:1.12",
+        msg="pFlogger only works with the Fujitsu compiler from version 1.13.0 onwards",
+    )
 
     depends_on("cmake@3.12:", type="build")
 

--- a/var/spack/repos/builtin/packages/pflogger/package.py
+++ b/var/spack/repos/builtin/packages/pflogger/package.py
@@ -22,6 +22,7 @@ class Pflogger(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.13.1", sha256="d2246d1bf3e5186045ae84c52656168856f693f743700f473cf3d1c99eecae02")
     version("1.13.0", sha256="d46b61162496e227d2982bcdfe9b2c8af6a5734d0fbad9305b1a1547abeac06e")
     version("1.12.0", sha256="ff29b0ce4baf50675edb69c3c7493be5410839b5f81e3ce5405f04925503fb0d")
     version("1.11.0", sha256="bf197b6f223a75c7d3eee23888cdde204b5aea053c308852a3f8f677784b8899")

--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -19,6 +19,7 @@ class Pfunit(CMakePackage):
 
     maintainers("mathomp4", "tclune")
 
+    version("4.9.0", sha256="caea019f623d4e02dd3e8442cee88e6087b4c431a2628e9ec2de55b527b51ab6")
     version("4.8.0", sha256="b5c66ab949fd23bee5c3b4d93069254f7ea40decb8d21f622fd6aa45ee68ef10")
     version("4.7.4", sha256="ac850e33ea99c283f503f75293bf238b4b601885d7adba333066e6185dad5c04")
     version("4.7.3", sha256="247239298b55e847417b7830183d7fc62cca93dc92c8ec7c0067784b7ce34544")
@@ -124,6 +125,11 @@ class Pfunit(CMakePackage):
     )
 
     conflicts("%gcc@:8.3.9", when="@4.0.0:", msg="pFUnit requires GCC 8.4.0 or newer")
+
+    # pfunit only works with the Fujitsu compiler from 4.9.0 onwards
+    conflicts(
+        "%fj", when="@:4.8.0", msg="pfunit only works with the Fujitsu compiler from 4.9.0 onwards"
+    )
 
     patch("mpi-test.patch", when="+use_comm_world")
 

--- a/var/spack/repos/builtin/packages/yafyaml/package.py
+++ b/var/spack/repos/builtin/packages/yafyaml/package.py
@@ -30,6 +30,7 @@ class Yafyaml(CMakePackage):
 
     version("main", branch="main")
 
+    version("1.3.0", sha256="a3882210b2620485471e3337d995edc1e653b49d9caaa902a43293826a61a635")
     version("1.2.0", sha256="912a4248bbf2e2e84cf3e36f2ae8483bee6b32d2eaa4406dd2100ad660c9bfc6")
     version("1.1.0", sha256="f0be81afe643adc2452055e5485f09cdb509a8fdd5a4ec5547b0c31dd22b4830")
     version("1.0.7", sha256="54f5c87e86c12e872e615fbc9540610ae38053f844f1e75d1e753724fea85c64")
@@ -51,6 +52,13 @@ class Yafyaml(CMakePackage):
     depends_on("gftl-shared")
     depends_on("gftl")
     depends_on("cmake@3.12:", type="build")
+
+    # yafyaml only works with the Fujitsu compiler from 1.3.0 onwards
+    conflicts(
+        "%fj",
+        when="@:1.2.0",
+        msg="yaFyaml only works with the Fujitsu compiler from 1.3.0 onwards",
+    )
 
     variant(
         "build_type",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR updates the GFE packages:

* gftl
* gftl-shared
* fargparse
* pfunit
* yafyaml
* fargparse

One of the main drivers was support for the Fujitsu compiler by @wkensuke (see https://github.com/Goddard-Fortran-Ecosystem/gFTL-shared/issues/71). I tried to protect the packages so that Fujitsu only would use the latest versions, but please let me know.