### PR TITLE
netcdfc: consider static build in pkgconf filtering

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -367,9 +367,9 @@ class CMakeBuilder(BaseBuilder, cmake.CMakeBuilder):
         settingsconfig_file = find(self.prefix, "libnetcdf.settings", recursive=True)
 
         files = pkgconfig_file + cmakeconfig_file + ncconfig_file + settingsconfig_file
-
-        filter_file("hdf5-shared", "hdf5", *files, ignore_absent=True)
-        filter_file("hdf5_hl-shared", "hdf5_hl", *files, ignore_absent=True)
+        config = "shared" if self.spec.satisfies("+shared") else "static"
+        filter_file(f"hdf5-{config}", "hdf5", *files, ignore_absent=True)
+        filter_file(f"hdf5_hl-{config}", "hdf5_hl", *files, ignore_absent=True)
 
 
 class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):


### PR DESCRIPTION
https://github.com/spack/spack/pull/42878 added post install pkgconf filtering of libraries improperly named for their CMake targets for the case where netcdf-c is built as a shared library.
This PR adds the case considering the static netcdf-c.