### PR TITLE
Correct VTK - NetCDFC - HDF5 interface

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -359,7 +359,7 @@ class CMakeBuilder(BaseBuilder, cmake.CMakeBuilder):
     @run_after("install")
     def patch_hdf5_pkgconfigcmake(self):
         """
-        Incorrect hdf5 library names are put in the package config and config.cmake files
+        Incorrect hdf5 library names are put in the package config files
         due to incorrectly using hdf5 target names
         https://github.com/spack/spack/pull/42878
         """

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -370,7 +370,7 @@ class CMakeBuilder(BaseBuilder, cmake.CMakeBuilder):
         ncconfig_file = find(self.prefix, "nc-config", recursive=True)
         settingsconfig_file = find(self.prefix, "libnetcdf.settings", recursive=True)
 
-        files = pkgconfig_file + cmakeconfig_file + ncconfig_file + settingsconfig_file
+        files = pkgconfig_file + ncconfig_file + settingsconfig_file
         config = "shared" if self.spec.satisfies("+shared") else "static"
         filter_file(f"hdf5-{config}", "hdf5", *files, ignore_absent=True)
         filter_file(f"hdf5_hl-{config}", "hdf5_hl", *files, ignore_absent=True)

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -66,7 +66,7 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
         # no upstream PR (or set of PRs) covering all changes in this path.
         # When #2595 lands, this patch should be updated to include only
         # the changes not incorporated into that PR
-        patch("netcdfc_correct_and_export_link_interface.patch", when="platform=windows")
+        patch("netcdfc_correct_and_export_link_interface.patch")
 
     # Some of the patches touch configure.ac and, therefore, require forcing the autoreconf stage:
     _force_autoreconf_when = []

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -367,7 +367,6 @@ class CMakeBuilder(BaseBuilder, cmake.CMakeBuilder):
             return
 
         pkgconfig_file = find(self.prefix, "netcdf.pc", recursive=True)
-        cmakeconfig_file = find(self.prefix, "netCDFTargets.cmake", recursive=True)
         ncconfig_file = find(self.prefix, "nc-config", recursive=True)
         settingsconfig_file = find(self.prefix, "libnetcdf.settings", recursive=True)
 

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -135,7 +135,7 @@ class Vtk(CMakePackage):
     # allow proj to be detected via a CMake produced export config file
     # failing that, falls back on standard library detection
     # required for VTK to build against modern proj/more robustly
-    patch("vtk_findproj_config.patch")
+    patch("vtk_findproj_config.patch", when="@9:")
     # adds a fake target alias'ing the hdf5 target to prevent
     # checks for that target from falling on VTK's empty stub target
     # Required to consume netcdf and hdf5 both built

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -20,7 +20,6 @@ class Vtk(CMakePackage):
     url = "https://www.vtk.org/files/release/9.0/VTK-9.0.0.tar.gz"
     list_url = "https://www.vtk.org/download/"
 
-
     maintainers("chuckatkins", "danlipsa", "johnwparent")
 
     license("BSD-3-Clause")

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -20,7 +20,8 @@ class Vtk(CMakePackage):
     url = "https://www.vtk.org/files/release/9.0/VTK-9.0.0.tar.gz"
     list_url = "https://www.vtk.org/download/"
 
-    maintainers("danlipsa", "vicentebolea")
+
+    maintainers("chuckatkins", "danlipsa", "johnwparent")
 
     license("BSD-3-Clause")
 
@@ -131,6 +132,14 @@ class Vtk(CMakePackage):
     patch("vtk_movie_link_ogg.patch", when="@8.2")
     patch("vtk_use_sqlite_name_vtk_expects.patch", when="@8.2")
     patch("vtk_proj_include_no_strict.patch", when="@9: platform=windows")
+    # allow proj to be detected via a CMake produced export config file
+    # failing that, falls back on standard library detection
+    # required for VTK to build against modern proj/more robustly
+    patch("vtk_findproj_config.patch")
+    # adds a fake target alias'ing the hdf5 target to prevent
+    # checks for that target from falling on VTK's empty stub target
+    # Required to consume netcdf and hdf5 both built
+    # with CMake from VTK
     # a patch with the same name is also applied to paraview
     # the two patches are the same but for the path to the files they patch
     patch("vtk_alias_hdf5.patch", when="@9:")

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -133,8 +133,8 @@ class Vtk(CMakePackage):
     patch("vtk_proj_include_no_strict.patch", when="@9: platform=windows")
     # a patch with the same name is also applied to paraview
     # the two patches are the same but for the path to the files they patch
-    patch("vtk_alias_hdf5.patch", when="@9: platform=windows")
-    patch("vtk_findproj_config.patch", when="platform=windows")
+    patch("vtk_alias_hdf5.patch", when="@9:")
+    patch("vtk_findproj_config.patch")
     depends_on("libxt", when="^[virtuals=gl] glx platform=linux")
 
     # VTK will need Qt5OpenGL, and qt needs '-opengl' for that

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -142,7 +142,6 @@ class Vtk(CMakePackage):
     # a patch with the same name is also applied to paraview
     # the two patches are the same but for the path to the files they patch
     patch("vtk_alias_hdf5.patch", when="@9:")
-    patch("vtk_findproj_config.patch")
     depends_on("libxt", when="^[virtuals=gl] glx platform=linux")
 
     # VTK will need Qt5OpenGL, and qt needs '-opengl' for that


### PR DESCRIPTION
After some testing (Thanks to @Chrismarsh ) some patches from VTK dealing with external CMake based HDF5 detection that are currently applied only to Windows need to be applied to all platforms.
Additionally the changes in https://github.com/spack/spack/pull/42878 add filtering to the NetCDF export interface generated by CMake. This is incorrectly applied to the CMake config as well. This removes that step.