### PR TITLE
gnupg: add v2.4.5, remove deprecated versions

### DIFF
--- a/var/spack/repos/builtin/packages/gnupg/package.py
+++ b/var/spack/repos/builtin/packages/gnupg/package.py
@@ -19,6 +19,7 @@ class Gnupg(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
+    version("2.4.5", sha256="f68f7d75d06cb1635c336d34d844af97436c3f64ea14bcb7c869782f96f44277")
     version("2.4.4", sha256="67ebe016ca90fa7688ce67a387ebd82c6261e95897db7b23df24ff335be85bc6")
     version("2.4.3", sha256="a271ae6d732f6f4d80c258ad9ee88dd9c94c8fdc33c3e45328c4d7c126bd219d")
     version("2.4.2", sha256="97eb47df8ae5a3ff744f868005a090da5ab45cb48ee9836dbf5ee739a4e5cf49")
@@ -28,88 +29,7 @@ class Gnupg(AutotoolsPackage):
     version("2.3.7", sha256="ee163a5fb9ec99ffc1b18e65faef8d086800c5713d15a672ab57d3799da83669")
     version("2.2.40", sha256="1164b29a75e8ab93ea15033300149e1872a7ef6bdda3d7c78229a735f8204c28")
 
-    # Deprecated over CVE-2022-34903
-    version(
-        "2.3.4",
-        sha256="f3468ecafb1d7f9ad7b51fd1db7aebf17ceb89d2efa8a05cf2f39b4d405402ae",
-        deprecated=True,
-    )
-    version(
-        "2.3.3",
-        sha256="5789b86da6a1a6752efb38598f16a77af51170a8494039c3842b085032e8e937",
-        deprecated=True,
-    )
-    version(
-        "2.3.2",
-        sha256="e1d953e0e296072fca284215103ef168885eaac596c4660c5039a36a83e3041b",
-        deprecated=True,
-    )
-    version(
-        "2.3.1",
-        sha256="c498db346a9b9a4b399e514c8f56dfc0a888ce8f327f10376ff984452cd154ec",
-        deprecated=True,
-    )
-    version(
-        "2.2.27",
-        sha256="34e60009014ea16402069136e0a5f63d9b65f90096244975db5cea74b3d02399",
-        deprecated=True,
-    )
-    version(
-        "2.2.25",
-        sha256="c55307b247af4b6f44d2916a25ffd1fb64ce2e509c3c3d028dbe7fbf309dc30a",
-        deprecated=True,
-    )
-    version(
-        "2.2.24",
-        sha256="9090b400faae34f08469d78000cfec1cee5b9c553ce11347cc96ef16eab98c46",
-        deprecated=True,
-    )
-    version(
-        "2.2.23",
-        sha256="10b55e49d78b3e49f1edb58d7541ecbdad92ddaeeb885b6f486ed23d1cd1da5c",
-        deprecated=True,
-    )
-    version(
-        "2.2.22",
-        sha256="7c1370565e1910b9d8c4e0fb57b9de34aa062ec7bb91abad5803d791f38d855b",
-        deprecated=True,
-    )
-    version(
-        "2.2.21",
-        sha256="61e83278fb5fa7336658a8b73ab26f379d41275bb1c7c6e694dd9f9a6e8e76ec",
-        deprecated=True,
-    )
-    version(
-        "2.2.20",
-        sha256="04a7c9d48b74c399168ee8270e548588ddbe52218c337703d7f06373d326ca30",
-        deprecated=True,
-    )
-    version(
-        "2.2.19",
-        sha256="242554c0e06f3a83c420b052f750b65ead711cc3fddddb5e7274fcdbb4e9dec0",
-        deprecated=True,
-    )
-    version(
-        "2.2.17",
-        sha256="afa262868e39b651a2db4c071fba90415154243e83a830ca00516f9a807fd514",
-        deprecated=True,
-    )
-    version(
-        "2.2.15",
-        sha256="cb8ce298d7b36558ffc48aec961b14c830ff1783eef7a623411188b5e0f5d454",
-        deprecated=True,
-    )
-    version(
-        "2.2.3",
-        sha256="cbd37105d139f7aa74f92b6f65d136658682094b0e308666b820ae4b984084b4",
-        deprecated=True,
-    )
-    version(
-        "2.1.21",
-        sha256="7aead8a8ba75b69866f583b6c747d91414d523bfdfbe9a8e0fe026b16ba427dd",
-        deprecated=True,
-    )
-
+    # Versions up to 2.2.27, and 2.3.6 deprecated over CVE-2022-34903
     version(
         "1.4.23",
         sha256="c9462f17e651b6507848c08c430c791287cd75491f8b5a8b50c6ed46b12678ba",
@@ -125,7 +45,6 @@ class Gnupg(AutotoolsPackage):
     depends_on("libgcrypt@1.9.1:", when="@2.3:")
 
     depends_on("libksba@1.3.4:", when="@2.0.0:")
-    depends_on("libassuan@2.4:", when="@2.0.0:2.2.3")
     depends_on("libassuan@2.5:", when="@2.2.15:")
     depends_on("pinentry", type="run", when="@2:")
     depends_on("iconv", when="@2:")
@@ -157,7 +76,7 @@ class Gnupg(AutotoolsPackage):
             "--disable-bzip2",
             "--disable-ldap",
             "--disable-regex",
-            "--with-zlib=" + self.spec["zlib-api"].prefix,
+            f"--with-zlib={self.spec['zlib-api'].prefix}",
             "--without-tar",
             "--without-readline",
         ]
@@ -168,18 +87,18 @@ class Gnupg(AutotoolsPackage):
                     "--disable-sqlite",
                     "--disable-ntbtls",
                     "--disable-gnutls",
-                    "--with-pinentry-pgm=" + self.spec["pinentry"].command.path,
-                    "--with-libgpg-error-prefix=" + self.spec["libgpg-error"].prefix,
-                    "--with-libgcrypt-prefix=" + self.spec["libgcrypt"].prefix,
-                    "--with-libassuan-prefix=" + self.spec["libassuan"].prefix,
-                    "--with-ksba-prefix=" + self.spec["libksba"].prefix,
-                    "--with-npth-prefix=" + self.spec["npth"].prefix,
+                    f"--with-pinentry-pgm={self.spec['pinentry'].command.path}",
+                    f"--with-libgpg-error-prefix={self.spec['libgpg-error'].prefix}",
+                    f"--with-libgcrypt-prefix={self.spec['libgcrypt'].prefix}",
+                    f"--with-libassuan-prefix={self.spec['libassuan'].prefix}",
+                    f"--with-ksba-prefix={self.spec['libksba'].prefix}",
+                    f"--with-npth-prefix={self.spec['npth'].prefix}",
                 ]
             )
             if self.spec["iconv"].name == "libc":
                 args.append("--without-libiconv-prefix")
             elif not is_system_path(self.spec["iconv"].prefix):
-                args.append("--with-libiconv-prefix=" + self.spec["iconv"].prefix)
+                args.append(f"--with-libiconv-prefix={self.spec['iconv'].prefix}")
 
         if self.spec.satisfies("@:1"):
             args.extend(

--- a/var/spack/repos/builtin/packages/libassuan/package.py
+++ b/var/spack/repos/builtin/packages/libassuan/package.py
@@ -2,15 +2,11 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-
 from spack.package import *
 
 
 class Libassuan(AutotoolsPackage):
-    """Libassuan is a small library implementing the so-called Assuan
-    protocol.
-    """
+    """Libassuan is a small library implementing the so-called Assuan protocol."""
 
     homepage = "https://gnupg.org/software/libassuan/index.html"
     url = "https://gnupg.org/ftp/gcrypt/libassuan/libassuan-2.4.5.tar.bz2"
@@ -19,6 +15,7 @@ class Libassuan(AutotoolsPackage):
 
     license("LGPL-2.1-or-later")
 
+    version("2.5.7", sha256="0103081ffc27838a2e50479153ca105e873d3d65d8a9593282e9c94c7e6afb76")
     version("2.5.6", sha256="e9fd27218d5394904e4e39788f9b1742711c3e6b41689a31aa3380bd5aa4f426")
     version("2.5.5", sha256="8e8c2fcc982f9ca67dcbb1d95e2dc746b1739a4668bc20b3a3c5be632edb34e4")
     version("2.5.4", sha256="c080ee96b3bd519edd696cfcebdecf19a3952189178db9887be713ccbcb5fbf0")
@@ -32,5 +29,5 @@ class Libassuan(AutotoolsPackage):
         return [
             "--enable-static",
             "--enable-shared",
-            "--with-libgpg-error-prefix=" + self.spec["libgpg-error"].prefix,
+            f"--with-libgpg-error-prefix={self.spec['libgpg-error'].prefix}",
         ]

--- a/var/spack/repos/builtin/packages/libgcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libgcrypt/package.py
@@ -20,18 +20,29 @@ class Libgcrypt(AutotoolsPackage):
     version("1.10.2", sha256="3b9c02a004b68c256add99701de00b383accccf37177e0d6c58289664cce0c03")
     version("1.10.1", sha256="ef14ae546b0084cd84259f61a55e07a38c3b53afc0f546bffcef2f01baffe9de")
     version("1.10.0", sha256="6a00f5c05caa4c4acc120c46b63857da0d4ff61dc4b4b03933fa8d46013fae81")
+    # End of life: 2024-03-31
     version("1.9.4", sha256="ea849c83a72454e3ed4267697e8ca03390aee972ab421e7df69dfe42b65caaf7")
     version("1.9.3", sha256="97ebe4f94e2f7e35b752194ce15a0f3c66324e0ff6af26659bbfb5ff2ec328fd")
     version("1.9.2", sha256="b2c10d091513b271e47177274607b1ffba3d95b188bbfa8797f948aec9053c5a")
     version("1.9.1", sha256="c5a67a8b9b2bd370fb415ed1ee31c7172e5683076493cf4a3678a0fbdf0265d9")
+    # End of life: 2024-12-31 (LTS)
     version("1.8.9", sha256="2bda4790aa5f0895d3407cf7bf6bd7727fd992f25a45a63d92fef10767fa3769")
     version("1.8.7", sha256="03b70f028299561b7034b8966d7dd77ef16ed139c43440925fe8782561974748")
     version("1.8.6", sha256="0cba2700617b99fc33864a0c16b1fa7fdf9781d9ed3509f5d767178e5fd7b975")
     version("1.8.5", sha256="3b4a2a94cb637eff5bdebbcaf46f4d95c4f25206f459809339cdada0eb577ac3")
     version("1.8.4", sha256="f638143a0672628fde0cad745e9b14deb85dffb175709cacc1f4fe24b93f2227")
     version("1.8.1", sha256="7a2875f8b1ae0301732e878c0cca2c9664ff09ef71408f085c50e332656a78b3")
-    version("1.7.6", sha256="626aafee84af9d2ce253d2c143dc1c0902dda045780cc241f39970fc60be05bc")
-    version("1.6.2", sha256="de084492a6b38cdb27b67eaf749ceba76bf7029f63a9c0c3c1b05c88c9885c4c")
+    # End of life: 2019-06-30
+    version(
+        "1.7.6",
+        sha256="626aafee84af9d2ce253d2c143dc1c0902dda045780cc241f39970fc60be05bc",
+        deprecated=True,
+    )
+    version(
+        "1.6.2",
+        sha256="de084492a6b38cdb27b67eaf749ceba76bf7029f63a9c0c3c1b05c88c9885c4c",
+        deprecated=True,
+    )
 
     depends_on("libgpg-error@1.25:")
 


### PR DESCRIPTION
Also updates dependencies:
-  libassuan: add v2.5.7
-  libgcrypt: deprecate end of life versions
