### PR TITLE
Retiring as PythonPackage maintainer

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -56,8 +56,6 @@ def _flatten_dict(dictionary: Mapping[str, object]) -> Iterable[str]:
 
 
 class PythonExtension(spack.package_base.PackageBase):
-    maintainers("adamjstewart")
-
     @property
     def import_modules(self) -> Iterable[str]:
         """Names of modules that the Python package provides.

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -27,7 +27,7 @@ import spack.multimethod
 import spack.package_base
 import spack.spec
 import spack.store
-from spack.directives import build_system, depends_on, extends, maintainers
+from spack.directives import build_system, depends_on, extends
 from spack.error import NoHeadersError, NoLibrariesError
 from spack.install_test import test_part
 from spack.spec import Spec

--- a/lib/spack/spack/test/cmd/maintainers.py
+++ b/lib/spack/spack/test/cmd/maintainers.py
@@ -12,12 +12,7 @@ import spack.repo
 
 maintainers = spack.main.SpackCommand("maintainers")
 
-MAINTAINED_PACKAGES = [
-    "maintainers-1",
-    "maintainers-2",
-    "maintainers-3",
-    "py-extension1",
-]
+MAINTAINED_PACKAGES = ["maintainers-1", "maintainers-2", "maintainers-3", "py-extension1"]
 
 
 def split(output):

--- a/lib/spack/spack/test/cmd/maintainers.py
+++ b/lib/spack/spack/test/cmd/maintainers.py
@@ -17,7 +17,6 @@ MAINTAINED_PACKAGES = [
     "maintainers-2",
     "maintainers-3",
     "py-extension1",
-    "py-extension2",
 ]
 
 
@@ -53,11 +52,8 @@ def test_all(mock_packages, capfd):
         "user2,",
         "user3",
         "py-extension1:",
-        "adamjstewart,",
         "user1,",
         "user2",
-        "py-extension2:",
-        "adamjstewart",
     ]
 
     with capfd.disabled():
@@ -69,9 +65,6 @@ def test_all_by_user(mock_packages, capfd):
     with capfd.disabled():
         out = split(maintainers("--all", "--by-user"))
     assert out == [
-        "adamjstewart:",
-        "py-extension1,",
-        "py-extension2",
         "user0:",
         "maintainers-3",
         "user1:",

--- a/lib/spack/spack/test/data/unparse/py-torch.txt
+++ b/lib/spack/spack/test/data/unparse/py-torch.txt
@@ -24,8 +24,6 @@ class PyTorch(PythonPackage, CudaPackage):
     homepage = "https://pytorch.org/"
     git = "https://github.com/pytorch/pytorch.git"
 
-    maintainers("adamjstewart")
-
     # Exact set of modules is version- and variant-specific, just attempt to import the
     # core libraries to ensure that the package was successfully installed.
     import_modules = ["torch", "torch.autograd", "torch.nn", "torch.utils"]

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -79,7 +79,7 @@ def test_error_on_anonymous_dependency(config, mock_packages):
     [
         ("maintainers-1", ["user1", "user2"]),
         # Extends PythonPackage
-        ("py-extension1", ["adamjstewart", "user1", "user2"]),
+        ("py-extension1", ["user1", "user2"]),
         # Extends maintainers-1
         ("maintainers-3", ["user0", "user1", "user2", "user3"]),
     ],

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -33,7 +33,7 @@ class Python(Package):
     list_depth = 1
     tags = ["windows", "build-tools"]
 
-    maintainers("adamjstewart", "skosukhin", "scheibelp")
+    maintainers("skosukhin", "scheibelp")
 
     phases = ["configure", "build", "install"]
 


### PR DESCRIPTION
I have served as the maintainer for every single Python library in Spack for over 3 years now (#21125). Unfortunately, it's time to step down.

## Q&A

### Why now?

* Too much work: the number of Python packages in Spack has nearly doubled in the last 3 years, from 1.3k to 2.5k, and is too much for a single (sane) person to maintain
* Not enough time: I would like to spend more time on my postdoc and [my other baby](https://github.com/microsoft/torchgeo)

### Can we still ask you to review PRs or solve issues?

Yes! Please ping me for the following:

1. Any machine learning package
2. Any geospatial package
3. Any package on which I am explicitly listed as a maintainer
4. Any time there is a question/confusion regarding the proper way to package any Python library

Please refrain from pinging me for the following:

5. Any simple Python package update or new package that does not fall under the previous categories

### So should we just merge everything blindly?

I would prefer that someone at least _attempts_ to review Python PRs before merging. 99% of Python packages carefully list their dependencies; all you have to do is make sure that list matches the package. https://spack.readthedocs.io/en/latest/build_systems/pythonpackage.html contains instructions for where to find these. I would be more than happy to teach others how to review Python PRs if anyone has any interest in this.

### Will you ever come back?

Maybe. @haampie and others are doing some great work on automating the 99% of packages that do not require manual attention to correct known issues or document non-Python dependencies. I have high hopes that a future in which most builtin Python/R/Perl packages will be removed from Spack entirely and built on-the-fly. If this happens, depending on where I'm at in my career, I may be willing to reprise my role. 

Let me know if you have any other questions!