### PR TITLE
gcc 12.3 ICE patch for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -487,6 +487,14 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
         when="@9.5.0:10.4.0,11.1.0:11.2.0",
     )
 
+    # patch gcc12.3.0 ICE on aarch64
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111478
+    patch(
+        "https://github.com/gcc-mirror/gcc/commit/9d033155254ac6df5f47ab32896dbf336f991589.patch?full_index=1",
+        sha256="8b76fe575ef095b48ac45e8b56544c331663f840ce4b63abdb61510bf3647597",
+        when="@12.3.0 target=aarch64:",
+    )
+
     build_directory = "spack-build"
 
     @classproperty

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -487,12 +487,18 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
         when="@9.5.0:10.4.0,11.1.0:11.2.0",
     )
 
-    # patch gcc12.3.0 ICE on aarch64
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111478
+    # patch ICE on aarch64 in tree-vect-slp, cf: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111478
+    # patch taken from releases/gcc-12 branch
     patch(
         "https://github.com/gcc-mirror/gcc/commit/9d033155254ac6df5f47ab32896dbf336f991589.patch?full_index=1",
         sha256="8b76fe575ef095b48ac45e8b56544c331663f840ce4b63abdb61510bf3647597",
         when="@12.3.0 target=aarch64:",
+    )
+    # patch taken from releases/gcc-13 branch
+    patch(
+        "https://github.com/gcc-mirror/gcc/commit/7c67939ec384425a3d7383dfb4fb39aa7e9ad20a.patch?full_index=1",
+        sha256="f0826d7a9c9808af40f3434918f24ad942f1c6a6daec73f11cf52c544cf5fc01",
+        when="@13.2.0 target=aarch64:",
     )
 
     build_directory = "spack-build"


### PR DESCRIPTION
gcc 12.3.0 suffers from an internal compiler error on aarch64 SVE, see:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111478

Am I correct that the `:` after `aarch64` causes `when="target=aarch64:`, to apply the patch also to `neoverse_v2`?

