### PR TITLE
Fix Nettle for OpenSSL 1.0 versions

### DIFF
--- a/var/spack/repos/builtin/packages/nettle/openssl_1.0_compatibity.patch
+++ b/var/spack/repos/builtin/packages/nettle/openssl_1.0_compatibity.patch
@@ -1,0 +1,16 @@
+--- nettle-3.9.1.orig/examples/nettle-openssl.c	2023-06-01 20:40:36.000000000 +0200
++++ nettle-3.9.1/examples/nettle-openssl.c	2024-03-08 16:18:49.643424081 +0100
+@@ -40,6 +40,12 @@
+ 
+ #if WITH_OPENSSL
+ 
++/* OpenSSL 1.0 compatibility; see https://wiki.openssl.org/index.php/EVP_Message_Digests */
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#  define EVP_MD_CTX_new   EVP_MD_CTX_create
++#  define EVP_MD_CTX_free  EVP_MD_CTX_destroy
++#endif
++
+ /* No ancient ssleay compatibility */
+ #define NCOMPAT
+ #define OPENSSL_DISABLE_OLD_DES_SUPPORT
+

--- a/var/spack/repos/builtin/packages/nettle/package.py
+++ b/var/spack/repos/builtin/packages/nettle/package.py
@@ -28,5 +28,8 @@ class Nettle(AutotoolsPackage, GNUMirrorPackage):
     depends_on("m4", type="build")
     depends_on("openssl")
 
+    # Nettle 3.7 started using OpenSSL EVP routines in examples/nettle-openssl.c
+    patch("openssl_1.0_compatibility.patch", when="@3.7:")
+
     def configure_args(self):
         return ["CFLAGS={0}".format(self.compiler.c99_flag)]


### PR DESCRIPTION
OpenSSL is only used in a single example file, `examples/nettle-openssl.c`. The change that causes the error was introduced in Nettle commit [d55fc19](https://git.lysator.liu.se/nettle/nettle/-/commit/d55fc19dfcb6b6766fbe05292d0c62f380bec439). The fix used here is [described in the OpenSSL wiki](https://wiki.openssl.org/index.php/EVP_Message_Digests).