### PR TITLE
Fix callbacks accumulation when using mixins with builders

### DIFF
--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -164,3 +164,20 @@ def test_install_time_test_callback(tmpdir, config, mock_packages, mock_stage):
     with open(s.package.tester.test_log_file, "r") as f:
         results = f.read().replace("\n", " ")
         assert "PyTestCallback test" in results
+
+
+@pytest.mark.regression("43097")
+@pytest.mark.usefixtures("builder_test_repository", "config")
+def test_mixins_with_builders(working_env):
+    """Tests that run_after and run_before callbacks are accumulated correctly,
+    when mixins are used with builders.
+    """
+    s = spack.spec.Spec("builder-and-mixins").concretized()
+    builder = spack.builder.create(s.package)
+
+    # Check that callbacks added by the mixin are in the list
+    assert any(fn.__name__ == "before_install" for _, fn in builder.run_before_callbacks)
+    assert any(fn.__name__ == "after_install" for _, fn in builder.run_after_callbacks)
+
+    # Check that callback from the GenericBuilder are in the list too
+    assert any(fn.__name__ == "sanity_check_prefix" for _, fn in builder.run_after_callbacks)

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -144,12 +144,9 @@ def test_list_repos():
         os.path.join(spack.paths.repos_path, "builder.test"),
     ):
         total_pkgs = len(list().strip().split())
-
         mock_pkgs = len(list("-r", "builtin.mock").strip().split())
         builder_pkgs = len(list("-r", "builder.test").strip().split())
-
-        assert builder_pkgs == 8
-        assert total_pkgs > mock_pkgs > builder_pkgs
-
         both_repos = len(list("-r", "builtin.mock", "-r", "builder.test").strip().split())
+
+        assert total_pkgs > mock_pkgs > builder_pkgs
         assert both_repos == total_pkgs

--- a/var/spack/repos/builder.test/packages/builder-and-mixins/package.py
+++ b/var/spack/repos/builder.test/packages/builder-and-mixins/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import spack.builder
+from spack.build_systems import generic
+from spack.package import *
+
+
+class BuilderAndMixins(Package):
+    """This package defines a mixin for its builder"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/a-1.0.tar.gz"
+
+    version("2.0", md5="abcdef0123456789abcdef0123456789")
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+
+class BuilderMixin(metaclass=spack.builder.PhaseCallbacksMeta):
+    @run_before("install")
+    def before_install(self):
+        pass
+
+    @run_after("install")
+    def after_install(self):
+        pass
+
+
+class GenericBuilder(BuilderMixin, generic.GenericBuilder):
+    def install(self, pkg, spec, prefix):
+        pass


### PR DESCRIPTION
fixes #43097

Before this PR the behavior of mixins used together with builders was to mask completely the callbacks defined from the class coming later in the MRO.

Here we fix the behavior by accumulating all callbacks, and de-duplicating them later.

A unit-test is added to prevent regression.
