### PR TITLE
gaudi: add py-yaml dependency

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -83,6 +83,7 @@ class Gaudi(CMakePackage):
     depends_on("python", type=("build", "run"))
     depends_on("py-networkx", type=("build", "run"))
     depends_on("py-six", type=("build", "run"))
+    depends_on("py-pyyaml", type=("build", "run", "test"))
     depends_on("range-v3")
     depends_on("root +python +root7 +ssl +tbb +threads")
     depends_on("zlib-api")


### PR DESCRIPTION
Needed to parse job options in yaml format (https://gitlab.cern.ch/gaudi/Gaudi/-/blob/master/GaudiKernel/python/GaudiKernel/ProcessJobOptions.py#L528). In principle this is optional, but it's needed for the test  35 - GaudiKernel.pytest.nose.test_Configurables (Failed). Seems like there's no harm done in adding this as a full dependency.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
