### PR TITLE
aocl-utils: source sha has changed

### DIFF
--- a/var/spack/repos/builtin/packages/aocl-utils/package.py
+++ b/var/spack/repos/builtin/packages/aocl-utils/package.py
@@ -42,7 +42,7 @@ class AoclUtils(CMakePackage):
         sha256="1294cdf275de44d3a22fea6fc4cd5bf66260d0a19abb2e488b898aaf632486bd",
         preferred=True,
     )
-    version("4.1", sha256="a2f271f5eef07da366dae421af3c89286ebb6239047a31a46451758d4a06bc85")
+    version("4.1", sha256="660746e7770dd195059ec25e124759b126ee9f060f43302d13354560ca76c02c")
 
     variant("doc", default=False, description="enable documentation")
     variant("tests", default=False, description="enable testing")

--- a/var/spack/repos/builtin/packages/aocl-utils/package.py
+++ b/var/spack/repos/builtin/packages/aocl-utils/package.py
@@ -39,7 +39,7 @@ class AoclUtils(CMakePackage):
 
     version(
         "4.2",
-        sha256="48ce7fae592f5c73a1c3d2c18752f43c939451ed5d3f7a154551f738af440d77",
+        sha256="1294cdf275de44d3a22fea6fc4cd5bf66260d0a19abb2e488b898aaf632486bd",
         preferred=True,
     )
     version("4.1", sha256="a2f271f5eef07da366dae421af3c89286ebb6239047a31a46451758d4a06bc85")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Seems like the checksum of the 4.2 source packages has changed.