### PR TITLE
VASP package pointing to the correct fftw directory level 

### DIFF
--- a/var/spack/repos/builtin/packages/vasp/package.py
+++ b/var/spack/repos/builtin/packages/vasp/package.py
@@ -248,7 +248,11 @@ class Vasp(MakefilePackage):
         if "^amdfftw" in spec:
             spack_env.set("AMDFFTW_ROOT", spec["fftw-api"].prefix)
         else:
-            spack_env.set("FFTW", spec["fftw-api"].libs.ld_flags)
+            if "@5.4.4" in spec:
+                spack_env.set("FFTW", spec["fftw-api"].prefix)
+            else:
+                spack_env.set("FFTW", spec["fftw-api"].libs.ld_flags)
+
         spack_env.set("MPI_INC", spec["mpi"].prefix.include)
 
         if "%nvhpc" in spec:


### PR DESCRIPTION
fftw-api prefix rather than libs is what needs to be set in the Spack env, because the makefile adds libs and include internally.
I can only check 5.4.4 because thats what I have access to, hence the if statement. 
If you look at old spack releases this was always how it was done for VASP 5.4.4 earlier as well.

With how its setup right now I get the below error repeatedly, because we are adding the lib folder rather than the prefix, in my understanding. I was able to build 5.4.4 with the proposed modifications.

```
gcc -E -P -C -w asa.F >asa.f90 -DMPI -DMPI_BLOCK=8000 -Duse_collective -DCACHE_SIZE=4000 -Davoidalloc -Duse_bse_te -Dtbdyn -Duse_shmem -DHOST=\"LinuxGNU\" -DscaLAPACK -Dsol_compat -DNGZhalf
mpif90 -ffree-form -ffree-line-length-none -w -fallow-argument-mismatch -O2 -I-L/work/kavalurav/userapps/opensource-24/milan-24/linux-rocky8-zen3/gcc-11.2.0/fftw-3.3.10-uxa7vo5pdehbjaodkk2z6e3zam7cfl7z/lib -lfftw3/include -c asa.f90
f951: Warning: Nonexistent include directory '-L/work/kavalurav/userapps/opensource-24/milan-24/linux-rocky8-zen3/gcc-11.2.0/fftw-3.3.10-uxa7vo5pdehbjaodkk2z6e3zam7cfl7z/lib' [-Wmissing-include-dirs]

```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
