### PR TITLE
Improve the error message when an unknown compiler is requested

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -823,11 +823,12 @@ class PyclingoDriver:
             print("Statistics:")
             pprint.pprint(self.control.statistics)
 
-        if result.unsolved_specs and setup.concretize_everything:
+        if result.satisfiable and result.unsolved_specs and setup.concretize_everything:
             unsolved_str = Result.format_unsolved(result.unsolved_specs)
             raise InternalConcretizerError(
                 "Internal Spack error: the solver completed but produced specs"
-                f" that do not satisfy the request.\n\t{unsolved_str}"
+                " that do not satisfy the request. Please report a bug at "
+                f"https://github.com/spack/spack/issues\n\t{unsolved_str}"
             )
 
         return result, timer, self.control.statistics

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1172,11 +1172,13 @@ attr("node_compiler_version_satisfies", PackageNode, Compiler, Constraint)
 
 % If the compiler version was set from the command line,
 % respect it verbatim
-:- attr("node_compiler_version_set", PackageNode, Compiler, Version),
-   not attr("node_compiler_version", PackageNode, Compiler, Version).
+error(100, "Cannot set the required compiler: {2}%{0}@{1}", Compiler, Version, Package)
+  :- attr("node_compiler_version_set", node(X, Package), Compiler, Version),
+     not attr("node_compiler_version", node(X, Package), Compiler, Version).
 
-:- attr("node_compiler_set", PackageNode, Compiler),
-   not attr("node_compiler_version", PackageNode, Compiler, _).
+error(100, "Cannot set the required compiler: {1}%{0}", Compiler, Package)
+  :- attr("node_compiler_set", node(X, Package), Compiler),
+     not attr("node_compiler_version", node(X, Package), Compiler, _).
 
 % Cannot select a compiler if it is not supported on the OS
 % Compilers that are explicitly marked as allowed

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2115,6 +2115,7 @@ class TestConcretize:
             solver.driver.solve(setup, specs, reuse=[])
 
     @pytest.mark.regression("43141")
+    @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_clear_error_when_unknown_compiler_requested(self, mock_packages, config):
         """Tests that the solver can report a case where the compiler cannot be set"""
         with pytest.raises(

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2114,6 +2114,14 @@ class TestConcretize:
         ):
             solver.driver.solve(setup, specs, reuse=[])
 
+    @pytest.mark.regression("43141")
+    def test_clear_error_when_unknown_compiler_requested(self, mock_packages, config):
+        """Tests that the solver can report a case where the compiler cannot be set"""
+        with pytest.raises(
+            spack.error.UnsatisfiableSpecError, match="Cannot set the required compiler: a%foo"
+        ):
+            Spec("a %foo").concretized()
+
     @pytest.mark.regression("36339")
     def test_compiler_match_constraints_when_selected(self):
         """Test that, when multiple compilers with the same name are in the configuration


### PR DESCRIPTION
fixes #43141

**Before**:
```console
$ spack spec zlib-ng %nvhpc
==> Error: Internal Spack error: the solver completed but produced specs that do not satisfy the request.
	Unsatisfied input specs:
	Input spec: zlib-ng%nvhpc
	(No candidate specs from solver)
```

**After**:
```console
$ spack spec zlib-ng %nvhpc
==> Error: concretization failed for the following reasons:

   1. Cannot set the required compiler: zlib-ng%nvhpc

```