### PR TITLE
MFEM: honor examples variant

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -1116,7 +1116,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     def check_or_test(self):
         # Running 'make check' or 'make test' may fail if MFEM_MPIEXEC or
         # MFEM_MPIEXEC_NP are not set appropriately.
-        if not self.run_tests:
+        if not self.run_tests and ("+examples" in self.spec):
             # check we can build ex1 (~mpi) or ex1p (+mpi).
             make("-C", "examples", "ex1p" if ("+mpi" in self.spec) else "ex1", parallel=False)
             # make('check', parallel=False)


### PR DESCRIPTION
Found a spot where the MFEM package was building examples without checking the examples variant.

@btalamini

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
