### PR TITLE
cray: return false more readily in detection logic (#43150)

### DIFF
--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -160,10 +160,15 @@ class Cray(Platform):
         system, as the Cray compiler wrappers and other components of the Cray
         programming environment are irrelevant without module support.
         """
-        craype_type, craype_version = cls.craype_type_and_version()
-        if craype_type == "EX" and craype_version >= spack.version.Version("21.10"):
+        if "opt/cray" not in os.environ.get("MODULEPATH", ""):
             return False
-        return "opt/cray" in os.environ.get("MODULEPATH", "")
+
+        craype_type, craype_version = cls.craype_type_and_version()
+        if craype_type == "XC":
+            return True
+        if craype_type == "EX" and craype_version < spack.version.Version("21.10"):
+            return True
+        return False
 
     def _default_target_from_env(self):
         """Set and return the default CrayPE target loaded in a clean login


### PR DESCRIPTION
Often in containers, the files we use to detect whether a cray system supports new features are not available.

Given that the cray containers only support the newer versions, and that these versions have been around for a while at this point and few sites don't support them, this PR changes the logic for detecting cray systems so that:
1. Don't even consider whether something is the `cray` platform if `opt/cray` is not in `MODULEPATH`
2. Only use the `cray` platform if we can read files in /opt/cray/pe and positively detect an older version
3. Otherwise, assume we're *not* on a cray (includes newer Cray PE's, which we treat as Linux)