### PR TITLE
Update trans/ectrans variant and configure tesselation variant for ecmwf-atlas

### DIFF
--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -57,13 +57,14 @@ class EcmwfAtlas(CMakePackage):
     variant("openmp", default=True, description="Use OpenMP")
     depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
     variant("shared", default=True, description="Build shared libraries")
-
     variant("trans", default=False, description="Enable trans")
     depends_on("ectrans@1.1.0:", when="@0.31.0: +trans")
     variant("eigen", default=True, description="Enable eigen")
     depends_on("eigen", when="+eigen")
     variant("fftw", default=True, description="Enable fftw")
     depends_on("fftw-api", when="+fftw")
+    variant("tesselation", default=False, description="Enable tesselation", when="@0.35.0:")
+    depends_on("qhull", when="+tesselation")
 
     variant("fismahigh", default=False, description="Apply patching for FISMA-high compliance")
 
@@ -71,10 +72,14 @@ class EcmwfAtlas(CMakePackage):
         args = [
             self.define_from_variant("ENABLE_OMP", "openmp"),
             self.define_from_variant("ENABLE_FCKIT", "fckit"),
-            self.define_from_variant("ENABLE_TRANS", "trans"),
             self.define_from_variant("ENABLE_EIGEN", "eigen"),
             self.define_from_variant("ENABLE_FFTW", "fftw"),
         ]
+        if self.spec.satisfies("@0.31:0.34"):
+            args.append(self.define_from_variant("ENABLE_TRANS", "trans"))
+        if self.spec.satisfies("@0.35:"):
+            args.append(self.define_from_variant("ENABLE_ECTRANS", "trans"))
+            args.append(self.define_from_variant("ENABLE_TESSELATION", "tesselation"))
         if "~shared" in self.spec:
             args.append("-DBUILD_SHARED_LIBS=OFF")
         return args


### PR DESCRIPTION
## Description

1. Update the `trans`/`ectrans` variant for `ecmwf-atlas` - the name of the option changed recently
2. Configure the `tesselation` variant for the package.

This version of the `ecmwf-atlas` package matches what is used in spack-stack at JCSDA/NOAA/NCAR/NAVY/NASA/EPIC.