### PR TITLE
Fix loading environment-modules with multiple OSs

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -792,7 +792,8 @@ def print_setup_info(*info):
     # on clusters, so skip it if not needed.
     if "modules" in info:
         generic_arch = spack.vendor.archspec.cpu.host().family
-        module_spec = "environment-modules target={0}".format(generic_arch)
+        host_os = str(spack.platforms.host().operating_system("default_os"))
+        module_spec = "environment-modules target={0} os={1}".format(generic_arch, host_os)
         specs = spack.store.STORE.db.query(module_spec)
         if specs:
             shell_set("_sp_module_prefix", specs[-1].prefix)


### PR DESCRIPTION
`print_setup_info` currently does not take into account the OS `environment-modules` has been installed for. For example, the following software stack contains versions for CentOS 8 and Rocky Linux 9:
```
$ spack find environment-modules target=x86_64
-- linux-centos8-x86_64 / gcc@12.3.0 ----------------------------
environment-modules@5.4.0

-- linux-rocky9-x86_64 / gcc@12.3.0 -----------------------------
environment-modules@5.4.0
==> 2 installed packages
```
This causes `--print-shell-vars` to select the wrong OS (`_sp_module_prefix` should point to the CentOS 8 version):
```
$ spack --print-shell-vars sh,modules
_sp_sys_type='linux-centos8-x86_64_v3'
_sp_compatible_sys_types='linux-centos8-x86_64_v3:linux-centos8-x86_64_v2:linux-centos8-x86_64'
_sp_tcl_roots='$SPACK/share/spack/modules'
_sp_lmod_roots='$SPACK/share/spack/lmod'
_sp_module_prefix='$SPACK/opt/spack/linux-rocky9-x86_64/gcc-12.3.0/environment-modules-5.4.0-twqtb7owgu77ylwici74udh6qrnu7rxj'
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
