### PR TITLE
octopus: disable gdlib by default

### DIFF
--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -292,6 +292,12 @@ class Octopus(AutotoolsPackage, CudaPackage):
             args.append(f"{cxxflags} {gcc10_extra}")
             args.append(f"{cflags} {gcc10_extra}")
 
+        # Disable flags
+        #
+        # disable gdlib explicitly to avoid
+        # autotools picking gdlib up from the system
+        args.append("--disable-gdlib")
+
         return args
 
     @run_after("install")


### PR DESCRIPTION
Octopus m4 for gdlib is greedy and picks up gdlib from the system if present.
This causes two kinds of problems:

- The system gdlib could be sometimes picked up during the configure stage and can cause build errors:
(see for eg https://github.com/spack/spack/pull/38010#issuecomment-1577684446)
- Before octopus 14, gdlib-related tests failed due to a bug in the test suite (see https://gitlab.com/octopus-code/octopus/-/merge_requests/2198). This meant that tests failed even though gdlib was not explicitly asked for.

Since gdlib is set to be deprecated by the octopus team (cgal replacing its use case), and it reduces the build issues, we could consider disabling gdlib entirely.