### PR TITLE
protobuf: apply centos 8 patch only to @3.4:

### DIFF
--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -111,7 +111,7 @@ class Protobuf(CMakePackage):
     # fix build on Centos 8, see also https://github.com/protocolbuffers/protobuf/issues/5144
     patch(
         "https://github.com/protocolbuffers/protobuf/pull/11032/commits/3039f932aaf212bcf2f14a3f2fd00dbfb881e46b.patch?full_index=1",
-        when="@:3.21",
+        when="@3.4:3.21",
         sha256="cefc4bf4aadf9ca33a336b2aa6d0d82006b6563e85122ae8cfb70345f85321dd",
     )
 


### PR DESCRIPTION
does not apply cleanly to older versions

