### PR TITLE
compiler.py: detect libc

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -485,7 +485,7 @@ class Compiler:
                 self._real_version = self.version
         return self._real_version
 
-    def implicit_rpaths(self):
+    def implicit_rpaths(self) -> List[str]:
         if self.enable_implicit_rpaths is False:
             return []
 
@@ -544,7 +544,7 @@ class Compiler:
             shutil.rmtree(tmpdir, ignore_errors=True)
 
     @property
-    def verbose_flag(self):
+    def verbose_flag(self) -> Optional[str]:
         """
         This property should be overridden in the compiler subclass if a
         verbose flag is available.

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -201,7 +201,7 @@ def _parse_dynamic_linker(output: str):
                 return arg.split("=", 1)[1]
 
 
-def _libc_from_ldd(ldd: str) -> Optional[spack.spec.Spec]:
+def _libc_from_ldd(ldd: str) -> Optional["spack.spec.Spec"]:
     try:
         result = run([ldd, "--version"], stdout=PIPE, stderr=PIPE, check=False)
         stdout = result.stdout.decode("utf-8")
@@ -220,7 +220,7 @@ def _libc_from_ldd(ldd: str) -> Optional[spack.spec.Spec]:
         return None
 
 
-def _libc_from_dynamic_linker(dynamic_linker: str) -> Optional[spack.spec.Spec]:
+def _libc_from_dynamic_linker(dynamic_linker: str) -> Optional["spack.spec.Spec"]:
     if not os.path.exists(dynamic_linker):
         return None
 
@@ -499,7 +499,7 @@ class Compiler:
         all_required_libs = list(self.required_libs) + Compiler._all_compiler_rpath_libraries
         return list(paths_containing_libs(link_dirs, all_required_libs))
 
-    def default_libc(self) -> Optional[spack.spec.Spec]:
+    def default_libc(self) -> Optional["spack.spec.Spec"]:
         output = self._compile_c_source_verbose()
 
         if not output:

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -8,9 +8,11 @@ import itertools
 import os
 import platform
 import re
+import shlex
 import shutil
 import sys
 import tempfile
+from subprocess import PIPE, run
 from typing import List, Optional, Sequence
 
 import llnl.path
@@ -182,6 +184,106 @@ def _parse_non_system_link_dirs(string: str) -> List[str]:
     # a system directory as a subdirectory
     link_dirs = filter_system_paths(link_dirs)
     return list(p for p in link_dirs if not in_system_subdirectory(p))
+
+
+def _parse_dynamic_linker(output: str):
+    """Parse -dynamic-linker /path/to/ld.so from compiler output"""
+    for line in reversed(output.splitlines()):
+        if "-dynamic-linker" not in line:
+            continue
+        args = shlex.split(line)
+
+        for idx in reversed(range(1, len(args))):
+            arg = args[idx]
+            if arg == "-dynamic-linker" or args == "--dynamic-linker":
+                return args[idx + 1]
+            elif arg.startswith("--dynamic-linker=") or arg.startswith("-dynamic-linker="):
+                return arg.split("=", 1)[1]
+
+
+def _libc_from_ldd(ldd: str) -> Optional[spack.spec.Spec]:
+    try:
+        result = run([ldd, "--version"], stdout=PIPE, stderr=PIPE, check=False)
+        stdout = result.stdout.decode("utf-8")
+    except Exception:
+        return None
+
+    if not re.search("gnu|glibc", stdout, re.IGNORECASE):
+        return None
+
+    version_str = re.match(r".+\(.+\) (.+)", stdout)
+    if not version_str:
+        return None
+    try:
+        return spack.spec.Spec(f"glibc@={version_str.group(1)}")
+    except Exception:
+        return None
+
+
+def _libc_from_dynamic_linker(dynamic_linker: str) -> Optional[spack.spec.Spec]:
+    if not os.path.exists(dynamic_linker):
+        return None
+
+    # The dynamic linker is usually installed in the same /lib(64)?/ld-*.so path across all
+    # distros. The rest of libc is elsewhere, e.g. /usr. Typically the dynamic linker is then
+    # a symlink into /usr/lib, which we use to for determining the actual install prefix of
+    # libc.
+    realpath = os.path.realpath(dynamic_linker)
+
+    prefix = os.path.dirname(realpath)
+    # Remove the multiarch suffix if it exists
+    if os.path.basename(prefix) not in ("lib", "lib64"):
+        prefix = os.path.dirname(prefix)
+
+    # Non-standard install layout -- just bail.
+    if os.path.basename(prefix) not in ("lib", "lib64"):
+        return None
+
+    prefix = os.path.dirname(prefix)
+
+    # Now try to figure out if glibc or musl, which is the only ones we support.
+    # In recent glibc we can simply execute the dynamic loader. In musl that's always the case.
+    try:
+        result = run([dynamic_linker, "--version"], stdout=PIPE, stderr=PIPE, check=False)
+        stdout = result.stdout.decode("utf-8")
+        stderr = result.stderr.decode("utf-8")
+    except Exception:
+        return None
+
+    # musl prints to stderr
+    if stderr.startswith("musl libc"):
+        version_str = re.search(r"^Version (.+)$", stderr, re.MULTILINE)
+        if not version_str:
+            return None
+        try:
+            spec = spack.spec.Spec(f"musl@={version_str.group(1)}")
+            spec.external_path = prefix
+            return spec
+        except Exception:
+            return None
+    elif re.search("gnu|glibc", stdout, re.IGNORECASE):
+        # output is like "ld.so (...) stable release version 2.33." write a regex for it
+        match = re.search(r"version (\d+\.\d+(?:\.\d+)?)", stdout)
+        if not match:
+            return None
+        try:
+            version = match.group(1)
+            spec = spack.spec.Spec(f"glibc@={version}")
+            spec.external_path = prefix
+            return spec
+        except Exception:
+            return None
+    else:
+        # Could not get the version by running the dynamic linker directly. Instead locate `ldd`
+        # relative to the dynamic linker.
+        ldd = os.path.join(prefix, "bin", "ldd")
+        if not os.path.exists(ldd):
+            return None
+        maybe_spec = _libc_from_ldd(ldd)
+        if not maybe_spec:
+            return None
+        maybe_spec.external_path = prefix
+        return maybe_spec
 
 
 def in_system_subdirectory(path):
@@ -387,12 +489,25 @@ class Compiler:
         if self.enable_implicit_rpaths is False:
             return []
 
-        # Put CXX first since it has the most linking issues
-        # And because it has flags that affect linking
-        link_dirs = self._get_compiler_link_paths()
+        output = self._compile_c_source_verbose()
+
+        if not output:
+            return []
+
+        link_dirs = _parse_non_system_link_dirs(output)
 
         all_required_libs = list(self.required_libs) + Compiler._all_compiler_rpath_libraries
         return list(paths_containing_libs(link_dirs, all_required_libs))
+
+    def default_libc(self) -> Optional[spack.spec.Spec]:
+        output = self._compile_c_source_verbose()
+
+        if not output:
+            return None
+
+        dynamic_linker = _parse_dynamic_linker(output)
+
+        return _libc_from_dynamic_linker(dynamic_linker)
 
     @property
     def required_libs(self):
@@ -402,17 +517,10 @@ class Compiler:
         # By default every compiler returns the empty list
         return []
 
-    def _get_compiler_link_paths(self):
+    def _compile_c_source_verbose(self) -> Optional[str]:
         cc = self.cc if self.cc else self.cxx
         if not cc or not self.verbose_flag:
-            # Cannot determine implicit link paths without a compiler / verbose flag
-            return []
-
-        # What flag types apply to first_compiler, in what order
-        if cc == self.cc:
-            flags = ["cflags", "cppflags", "ldflags"]
-        else:
-            flags = ["cxxflags", "cppflags", "ldflags"]
+            return None
 
         try:
             tmpdir = tempfile.mkdtemp(prefix="spack-implicit-link-info")
@@ -424,15 +532,14 @@ class Compiler:
                     "int main(int argc, char* argv[]) { (void)argc; (void)argv; return 0; }\n"
                 )
             cc_exe = spack.util.executable.Executable(cc)
-            for flag_type in flags:
+            for flag_type in ["cflags" if cc == self.cc else "cxxflags", "cppflags", "ldflags"]:
                 cc_exe.add_default_arg(*self.flags.get(flag_type, []))
 
             with self.compiler_environment():
-                output = cc_exe(self.verbose_flag, fin, "-o", fout, output=str, error=str)
-            return _parse_non_system_link_dirs(output)
+                return cc_exe(self.verbose_flag, fin, "-o", fout, output=str, error=str)
         except spack.util.executable.ProcessError as pe:
             tty.debug("ProcessError: Command exited with non-zero status: " + pe.long_message)
-            return []
+            return None
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
 

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -64,7 +64,7 @@ class Nag(spack.compiler.Compiler):
         #
         # This way, we at least enable the implicit rpath detection, which is
         # based on compilation of a C file (see method
-        # spack.compiler._get_compiler_link_paths): in the case of a mixed
+        # spack.compiler._compile_c_source_verbose): in the case of a mixed
         # NAG/GCC toolchain, the flag will be passed to g++ (e.g.
         # 'g++ -Wl,-v ./main.c'), otherwise, the flag will be passed to nagfor
         # (e.g. 'nagfor -Wl,-v ./main.c' - note that nagfor recognizes '.c'

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -156,6 +156,7 @@ class MockCompiler(Compiler):
     required_libs = ["libgfortran"]
 
 
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_implicit_rpaths(dirs_with_libfiles):
     lib_to_dirs, all_dirs = dirs_with_libfiles
     compiler = MockCompiler()

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -14,6 +14,7 @@ import spack.compiler
 import spack.compilers
 import spack.spec
 import spack.util.environment
+import spack.util.module_cmd
 from spack.compiler import Compiler
 from spack.util.executable import Executable, ProcessError
 
@@ -138,14 +139,6 @@ class MockCompiler(Compiler):
             environment={},
         )
 
-    def _get_compiler_link_paths(self):
-        # Mock os.path.isdir so the link paths don't have to exist
-        old_isdir = os.path.isdir
-        os.path.isdir = lambda x: True
-        ret = super()._get_compiler_link_paths()
-        os.path.isdir = old_isdir
-        return ret
-
     @property
     def name(self):
         return "mockcompiler"
@@ -163,34 +156,24 @@ class MockCompiler(Compiler):
     required_libs = ["libgfortran"]
 
 
-def test_implicit_rpaths(dirs_with_libfiles, monkeypatch):
+def test_implicit_rpaths(dirs_with_libfiles):
     lib_to_dirs, all_dirs = dirs_with_libfiles
-
-    def try_all_dirs(*args):
-        return all_dirs
-
-    monkeypatch.setattr(MockCompiler, "_get_compiler_link_paths", try_all_dirs)
-
-    expected_rpaths = set(lib_to_dirs["libstdc++"] + lib_to_dirs["libgfortran"])
-
     compiler = MockCompiler()
+    compiler._compile_c_source_verbose = lambda *args: "ld " + " ".join(f"-L{d}" for d in all_dirs)
     retrieved_rpaths = compiler.implicit_rpaths()
-    assert set(retrieved_rpaths) == expected_rpaths
+    assert set(retrieved_rpaths) == set(lib_to_dirs["libstdc++"] + lib_to_dirs["libgfortran"])
 
 
-no_flag_dirs = ["/path/to/first/lib", "/path/to/second/lib64"]
-no_flag_output = "ld -L%s -L%s" % tuple(no_flag_dirs)
-
-flag_dirs = ["/path/to/first/with/flag/lib", "/path/to/second/lib64"]
-flag_output = "ld -L%s -L%s" % tuple(flag_dirs)
+without_flag_output = "ld -L/path/to/first/lib -L/path/to/second/lib64"
+with_flag_output = "ld -L/path/to/first/with/flag/lib -L/path/to/second/lib64"
 
 
 def call_compiler(exe, *args, **kwargs):
     # This method can replace Executable.__call__ to emulate a compiler that
     # changes libraries depending on a flag.
     if "--correct-flag" in exe.exe:
-        return flag_output
-    return no_flag_output
+        return with_flag_output
+    return without_flag_output
 
 
 @pytest.mark.not_on_windows("Not supported on Windows (yet)")
@@ -204,8 +187,8 @@ def call_compiler(exe, *args, **kwargs):
         ("cc", "cppflags"),
     ],
 )
-@pytest.mark.enable_compiler_link_paths
-def test_get_compiler_link_paths(monkeypatch, exe, flagname):
+@pytest.mark.enable_compiler_execution
+def test_compile_c_source_verbose_adds_flags(monkeypatch, exe, flagname):
     # create fake compiler that emits mock verbose output
     compiler = MockCompiler()
     monkeypatch.setattr(Executable, "__call__", call_compiler)
@@ -222,40 +205,38 @@ def test_get_compiler_link_paths(monkeypatch, exe, flagname):
         assert False
 
     # Test without flags
-    assert compiler._get_compiler_link_paths() == no_flag_dirs
+    assert compiler._compile_c_source_verbose() == without_flag_output
 
     if flagname:
         # set flags and test
         compiler.flags = {flagname: ["--correct-flag"]}
-        assert compiler._get_compiler_link_paths() == flag_dirs
+        assert compiler._compile_c_source_verbose() == with_flag_output
 
 
-def test_get_compiler_link_paths_no_path():
+@pytest.mark.enable_compiler_execution
+def test_compile_c_source_verbose_no_path():
     compiler = MockCompiler()
     compiler.cc = None
     compiler.cxx = None
-    compiler.f77 = None
-    compiler.fc = None
-    assert compiler._get_compiler_link_paths() == []
+    assert compiler._compile_c_source_verbose() is None
 
 
-def test_get_compiler_link_paths_no_verbose_flag():
+@pytest.mark.enable_compiler_execution
+def test_compile_c_source_verbose_no_verbose_flag():
     compiler = MockCompiler()
     compiler._verbose_flag = None
-    assert compiler._get_compiler_link_paths() == []
+    assert compiler._compile_c_source_verbose() is None
 
 
 @pytest.mark.not_on_windows("Not supported on Windows (yet)")
-@pytest.mark.enable_compiler_link_paths
-def test_get_compiler_link_paths_load_env(working_env, monkeypatch, tmpdir):
+@pytest.mark.enable_compiler_execution
+def test_compile_c_source_verbose_load_env(working_env, monkeypatch, tmpdir):
     gcc = str(tmpdir.join("gcc"))
     with open(gcc, "w") as f:
         f.write(
-            """#!/bin/sh
+            f"""#!/bin/sh
 if [ "$ENV_SET" = "1" ] && [ "$MODULE_LOADED" = "1" ]; then
-  echo '"""
-            + no_flag_output
-            + """'
+  printf '{without_flag_output}'
 fi
 """
         )
@@ -275,7 +256,7 @@ fi
     compiler.environment = {"set": {"ENV_SET": "1"}}
     compiler.modules = ["turn_on"]
 
-    assert compiler._get_compiler_link_paths() == no_flag_dirs
+    assert compiler._compile_c_source_verbose() == without_flag_output
 
 
 # Get the desired flag from the specified compiler spec.

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -33,6 +33,7 @@ from llnl.util.filesystem import copy_tree, mkdirp, remove_linked_tree, touchp, 
 import spack.binary_distribution
 import spack.caches
 import spack.cmd.buildcache
+import spack.compiler
 import spack.compilers
 import spack.config
 import spack.database
@@ -267,10 +268,6 @@ def clean_test_environment():
     ev.deactivate()
 
 
-def _verify_executables_noop(*args):
-    return None
-
-
 def _host():
     """Mock archspec host so there is no inconsistency on the Windows platform
     This function cannot be local as it needs to be pickleable"""
@@ -296,9 +293,7 @@ def mock_compiler_executable_verification(request, monkeypatch):
 
     If a test is marked in that way this is a no-op."""
     if "enable_compiler_verification" not in request.keywords:
-        monkeypatch.setattr(
-            spack.compiler.Compiler, "verify_executables", _verify_executables_noop
-        )
+        monkeypatch.setattr(spack.compiler.Compiler, "verify_executables", _return_none)
 
 
 # Hooks to add command line options or set other custom behaviors.
@@ -929,26 +924,16 @@ def dirs_with_libfiles(tmpdir_factory):
     yield lib_to_dirs, all_dirs
 
 
-def _compiler_link_paths_noop(*args):
-    return []
+def _return_none(*args):
+    return None
 
 
 @pytest.fixture(scope="function", autouse=True)
 def disable_compiler_execution(monkeypatch, request):
-    """
-    This fixture can be disabled for tests of the compiler link path
-    functionality by::
-
-        @pytest.mark.enable_compiler_link_paths
-
-    If a test is marked in that way this is a no-op."""
-    if "enable_compiler_link_paths" not in request.keywords:
-        # Compiler.determine_implicit_rpaths actually runs the compiler. So
-        # replace that function with a noop that simulates finding no implicit
-        # RPATHs
-        monkeypatch.setattr(
-            spack.compiler.Compiler, "_get_compiler_link_paths", _compiler_link_paths_noop
-        )
+    """Disable compiler execution to determine implicit link paths and libc flavor and version.
+    To re-enable use `@pytest.mark.enable_compiler_execution`"""
+    if "enable_compiler_execution" not in request.keywords:
+        monkeypatch.setattr(spack.compiler.Compiler, "_compile_c_source_verbose", _return_none)
 
 
 @pytest.fixture(scope="function")

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,7 +12,7 @@ markers =
   requires_executables: tests that requires certain executables in PATH to run
   nomockstage: use a stage area specifically created for this test, instead of relying on a common mock stage
   enable_compiler_verification: enable compiler verification within unit tests
-  enable_compiler_link_paths: verifies compiler link paths within unit tests
+  enable_compiler_execution: enable compiler execution to detect link paths and libc
   disable_clean_stage_check: avoid failing tests if there are leftover files in the stage area
   only_clingo: mark unit tests that run only with clingo
   only_original: mark unit tests that are specific to the original concretizer


### PR DESCRIPTION
Some logic to detect what libc the C / CXX compilers use by default,
based on `-dynamic-linker`.

The function `compiler.default_libc()` returns a `Spec` of the form
`glibc@=x.y` or `musl@=x.y` with the `external_path` property set.

The idea is this can be injected as an automatic dependency on Linux.