### PR TITLE
llvm-openmp: make llvm-openmp work consistently

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-openmp/package.py
+++ b/var/spack/repos/builtin/packages/llvm-openmp/package.py
@@ -4,8 +4,18 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+from os.path import isdir
 
 from spack.package import *
+
+
+def resource_for_ver(ver, sha256):
+    resource(
+        name="cmake",
+        url=f"https://github.com/llvm/llvm-project/releases/download/llvmorg-{ver}/cmake-{ver}.src.tar.xz",
+        sha256=sha256,
+        when=f"@{ver}",
+    )
 
 
 class LlvmOpenmp(CMakePackage):
@@ -17,30 +27,29 @@ class LlvmOpenmp(CMakePackage):
 
     license("Apache-2.0")
 
+    version("18.1.0", sha256="ef1cef885d463e4becf5e132a9175a540c6f4487334c0e86274a374ce7d0a092")
+    resource_for_ver(
+        "18.1.0", sha256="d367bf77a3707805168b0a7a7657c8571207fcae29c5890312642ee42b76c967"
+    )
+    version("17.0.6", sha256="74334cbb4dc8b73a768448a7561d5a3540404940b2267b1fb9813a6464b320de")
+    resource_for_ver(
+        "17.0.6", sha256="807f069c54dc20cb47b21c1f6acafdd9c649f3ae015609040d6182cab01140f4"
+    )
     version("16.0.0", sha256="e30f69c6533157ec4399193ac6b158807610815accfbed98695d72074e4bedd0")
+    resource_for_ver(
+        "16.0.0", sha256="04e62ab7d0168688d9102680adf8eabe7b04275f333fe20eef8ab5a3a8ea9fcc"
+    )
     version("14.0.6", sha256="4f731ff202add030d9d68d4c6daabd91d3aeed9812e6a5b4968815cfdff0eb1f")
     version("12.0.1", sha256="60fe79440eaa9ebf583a6ea7f81501310388c02754dbe7dc210776014d06b091")
     version("9.0.0", sha256="9979eb1133066376cc0be29d1682bc0b0e7fb541075b391061679111ae4d3b5b")
     version("8.0.0", sha256="f7b1705d2f16c4fc23d6531f67d2dd6fb78a077dd346b02fed64f4b8df65c9d5")
 
-    variant(
-        "multicompat",
-        default=False,
-        description="Support gomp and the Intel openMP runtime library.",
-    )
+    variant("multicompat", default=True, description="Support the GNU OpenMP runtime interface.")
 
     depends_on("cmake@3.13.4:", when="@12:", type="build")
     depends_on("cmake@2.8:", type="build")
     depends_on("py-lit", type="test")
     depends_on("py-filecheck", type="test")
-    # depends_on("llvm-utils", type="test")  # for "not"
-
-    resource(
-        name="cmake",
-        url="https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.0/cmake-16.0.0.src.tar.xz",
-        sha256="04e62ab7d0168688d9102680adf8eabe7b04275f333fe20eef8ab5a3a8ea9fcc",
-        when="@16.0.0",
-    )
 
     @property
     def root_cmakelists_dir(self):
@@ -59,14 +68,12 @@ class LlvmOpenmp(CMakePackage):
 
     @when("@16:")
     def patch(self):
-        src = os.path.join(self.stage.source_path, f"cmake-{self.version}.src")
-        dst = os.path.join(self.stage.path, "cmake")
-        os.rename(src, dst)
+        cmake_mod_dir = os.path.join(self.stage.source_path, f"cmake-{self.version}.src")
+        if os.path.isdir(cmake_mod_dir):
+            os.rename(cmake_mod_dir, os.path.join(self.stage.path, "cmake"))
 
     def cmake_args(self):
-        # Disable LIBOMP_INSTALL_ALIASES, otherwise the library is installed as
-        # libgomp alias which can conflict with GCC's libgomp.
-        cmake_args = ["-DLIBOMP_INSTALL_ALIASES=OFF"]
+        cmake_args = []
         # Add optional support for both Intel and gcc compilers
         if self.spec.satisfies("+multicompat"):
             cmake_args.append("-DKMP_GOMP_COMPAT=1")

--- a/var/spack/repos/builtin/packages/llvm-openmp/package.py
+++ b/var/spack/repos/builtin/packages/llvm-openmp/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-from os.path import isdir
 
 from spack.package import *
 


### PR DESCRIPTION
This is part of trying to make llvm-openmp behave more consistently with other llvm builds we have and make it more composable with software built with other compilers.  I am not currently adding it here, but the behavior in `py-scikit-learn` that injects include and library flags for libomp are required for this to work, at least on sonoma, so most packages that use this remain broken both here and develop until something happens to add that.

1. add current versions of the 17 and 18 releases
2. stop making it nearly impossible to compose this correctly with code built with gcc
3. build for compatiblity by default like we do in every other llvm package
