### PR TITLE
mgard: disable C++11 warning also for apple-clang@15

### DIFF
--- a/var/spack/repos/builtin/packages/mgard/package.py
+++ b/var/spack/repos/builtin/packages/mgard/package.py
@@ -69,6 +69,8 @@ class Mgard(CMakePackage, CudaPackage):
         if name == "cxxflags":
             if self.spec.satisfies("@2020-10-01 %oneapi@2023:"):
                 flags.append("-Wno-error=c++11-narrowing")
+            if self.spec.satisfies("@2020-10-01 %apple-clang@15:"):
+                flags.append("-Wno-error=c++11-narrowing")
         return (flags, None, None)
 
     def cmake_args(self):


### PR DESCRIPTION
otherwise, multiple instances of this warning come up and error out with @2020-10-01:
error: non-constant-expression cannot be narrowed from type 'int' to 'unsigned long' in initializer list [-Wc++11-narrowing]
