### PR TITLE
Target.optimization_flags converts non-numeric versions to numeric

### DIFF
--- a/lib/spack/spack/target.py
+++ b/lib/spack/spack/target.py
@@ -155,4 +155,5 @@ class Target:
                 # log this and just return compiler.version instead
                 tty.debug(str(e))
 
+        compiler_version = compiler_version.dotted.force_numeric
         return self.microarchitecture.optimization_flags(compiler.name, str(compiler_version))

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -270,7 +270,7 @@ class StandardVersion(ConcreteVersion):
         # null separators except the final one have to be converted to avoid concatenating ints
         # default to '.' as most common delimiter for versions
         separators = tuple(
-            '.' if s == "" and i != len(self.separators) - 1 else s
+            "." if s == "" and i != len(self.separators) - 1 else s
             for i, s in enumerate(self.separators)
         )
         return type(self)(None, numeric, separators)

--- a/lib/spack/spack/version/version_types.py
+++ b/lib/spack/spack/version/version_types.py
@@ -193,12 +193,15 @@ class StandardVersion(ConcreteVersion):
         message = "{cls.__name__} indices must be integers"
         raise TypeError(message.format(cls=cls))
 
+    def _stringify(self):
+        string = ""
+        for index in range(len(self.version)):
+            string += str(self.version[index])
+            string += str(self.separators[index])
+        return string
+
     def __str__(self):
-        return (
-            self.string
-            if isinstance(self.string, str)
-            else ".".join((str(c) for c in self.version))
-        )
+        return self.string or self._stringify()
 
     def __repr__(self) -> str:
         # Print indirect repr through Version(...)
@@ -256,6 +259,21 @@ class StandardVersion(ConcreteVersion):
         return any(
             isinstance(p, VersionStrComponent) and isinstance(p.data, int) for p in self.version
         )
+
+    @property
+    def force_numeric(self):
+        """Replaces all non-numeric components of the version with 0
+
+        This can be used to pass Spack versions to libraries that have stricter version schema.
+        """
+        numeric = tuple(0 if isinstance(v, VersionStrComponent) else v for v in self.version)
+        # null separators except the final one have to be converted to avoid concatenating ints
+        # default to '.' as most common delimiter for versions
+        separators = tuple(
+            '.' if s == "" and i != len(self.separators) - 1 else s
+            for i, s in enumerate(self.separators)
+        )
+        return type(self)(None, numeric, separators)
 
     @property
     def dotted(self):


### PR DESCRIPTION
Archspec requires versions to be dot-separated integers. Spack allows more version freedom.

`spack.target.Target.optimization_flags()` passes a version to Archspec. We already call the compiler directly to get a more accurate version number in this method, but there are still corner cases in which a non-numeric spack version is passed to archspec.

This PR ensures the version is converted to be numeric-only and dotted immediately before passing it to archspec.

@white238  
