### PR TITLE
Fix Axom: index out of range when configuring axom~mpi on toss_4

### DIFF
--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -415,20 +415,20 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(cmake_cache_option("ENABLE_MPI", True))
             if spec["mpi"].name == "spectrum-mpi":
                 entries.append(cmake_cache_string("BLT_MPI_COMMAND_APPEND", "mpibind"))
+
+            # Replace /usr/bin/srun path with srun flux wrapper path on TOSS 4
+            # TODO: Remove this logic by adding `using_flux` case in
+            #  spack/lib/spack/spack/build_systems/cached_cmake.py:196 and remove hard-coded
+            #  path to srun in same file.
+            if "toss_4" in self._get_sys_type(spec):
+                srun_wrapper = which_string("srun")
+                mpi_exec_index = [
+                    index for index, entry in enumerate(entries) if "MPIEXEC_EXECUTABLE" in entry
+                ]
+                del entries[mpi_exec_index[0]]
+                entries.append(cmake_cache_path("MPIEXEC_EXECUTABLE", srun_wrapper))
         else:
             entries.append(cmake_cache_option("ENABLE_MPI", False))
-
-        # Replace /usr/bin/srun path with srun flux wrapper path on TOSS 4
-        # TODO: Remove this logic by adding `using_flux` case in
-        #  spack/lib/spack/spack/build_systems/cached_cmake.py:196 and remove hard-coded
-        #  path to srun in same file.
-        if "toss_4" in self._get_sys_type(spec):
-            srun_wrapper = which_string("srun")
-            mpi_exec_index = [
-                index for index, entry in enumerate(entries) if "MPIEXEC_EXECUTABLE" in entry
-            ]
-            del entries[mpi_exec_index[0]]
-            entries.append(cmake_cache_path("MPIEXEC_EXECUTABLE", srun_wrapper))
 
         return entries
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

@white238 I found this one by "luck" trying to build axom on ruby without MPI while tracking another issue.

This fix assumes we don’t care about enforcing the slurm wrapper when we don’t build with MPI, which sounds reasonable to me.