### PR TITLE
charmpp: add archs including Cray shasta with ARM

### DIFF
--- a/var/spack/repos/builtin/packages/charmpp/ofi-crayshasta-arm.patch
+++ b/var/spack/repos/builtin/packages/charmpp/ofi-crayshasta-arm.patch
@@ -1,0 +1,13 @@
+diff --git a/src/arch/ofi-crayshasta/conv-mach.h b/src/arch/ofi-crayshasta/conv-mach.h
+index 61d295df3..9e15fd2a9 100644
+--- a/src/arch/ofi-crayshasta/conv-mach.h
++++ b/src/arch/ofi-crayshasta/conv-mach.h
+@@ -74,7 +74,7 @@
+ #define CMK_LBDB_ON					   1
+ 
+ #define CMK_64BIT                      1
+-#define CMK_AMD64                      1
++#define CMK_ARM                        1
+ 
+ /* Other possible definitions:
+ 

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -198,31 +198,37 @@ class Charmpp(Package):
             ("cnl", "x86_64", "gni"): "gni-crayxc",
             ("cnl", "x86_64", "mpi"): "mpi-crayxc",
         }
-        
+
         if self.spec.satisfies("@6.10:"):
-            versions.update({
-                ("linux", "x86_64", "ucx"): "ucx-linux-x86_64", 
-                ("linux", "aarch64", "ucx"): "ucx-linux-arm8",
-            })
+            versions.update(
+                {
+                    ("linux", "x86_64", "ucx"): "ucx-linux-x86_64",
+                    ("linux", "aarch64", "ucx"): "ucx-linux-arm8",
+                }
+            )
 
         # Some versions were renamed/removed in 6.11
         if self.spec.version < Version("6.11.0"):
-            versions.update({
-                ("linux", "i386", "mpi"): "mpi-linux", 
-                ("linux", "i386", "multicore"): "multicore-linux", 
-                ("linux", "i386", "netlrts"): "netlrts-linux", 
-                ("linux", "i386", "uth"): "uth-linux", 
-                ("linux", "arm", "multicore"): "multicore-arm7",
-                ("linux", "aarch64", "multicore"): "multicore-arm8",
-            })
+            versions.update(
+                {
+                    ("linux", "i386", "mpi"): "mpi-linux",
+                    ("linux", "i386", "multicore"): "multicore-linux",
+                    ("linux", "i386", "netlrts"): "netlrts-linux",
+                    ("linux", "i386", "uth"): "uth-linux",
+                    ("linux", "arm", "multicore"): "multicore-arm7",
+                    ("linux", "aarch64", "multicore"): "multicore-arm8",
+                }
+            )
         else:
-            versions.update({
-                ("linux", "i386", "mpi"): "mpi-linux-i386", 
-                ("linux", "i386", "multicore"): "multicore-linux-i386", 
-                ("linux", "i386", "netlrts"): "netlrts-linux-i386",
-                ("linux", "arm", "multicore"): "multicore-linux-arm7",
-                ("linux", "aarch64", "multicore"): "multicore-linux-arm8",
-            })
+            versions.update(
+                {
+                    ("linux", "i386", "mpi"): "mpi-linux-i386",
+                    ("linux", "i386", "multicore"): "multicore-linux-i386",
+                    ("linux", "i386", "netlrts"): "netlrts-linux-i386",
+                    ("linux", "arm", "multicore"): "multicore-linux-arm7",
+                    ("linux", "aarch64", "multicore"): "multicore-linux-arm8",
+                }
+            )
 
         if self.spec.satisfies("@7:"):
             versions.update(
@@ -233,10 +239,12 @@ class Charmpp(Package):
             )
 
             if self.spec.satisfies("backend=ofi pmi=cray-pmi"):
-                versions.update({
-                    ("linux", "x86_64", "ofi"): "ofi-crayshasta", 
-                    ("linux", "aarch64", "ofi"): "ofi-crayshasta",
-                })
+                versions.update(
+                    {
+                        ("linux", "x86_64", "ofi"): "ofi-crayshasta",
+                        ("linux", "aarch64", "ofi"): "ofi-crayshasta",
+                    }
+                )
 
         if (plat, mach, comm) not in versions:
             raise InstallError(

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -59,7 +59,7 @@ class Charmpp(Package):
     patch("strictpass.patch", when="@:6.8.2")
 
     # Support Cray Shasta with ARM
-    patch("ofi-crayshasta-arm.patch", when="backend=ofi ^cray-mpich")
+    patch("ofi-crayshasta-arm.patch", when="backend=ofi pmi=cray-pmi target=aarch64:")
 
     # Build targets
     # "target" is reserved, so we have to use something else.
@@ -89,7 +89,7 @@ class Charmpp(Package):
     variant(
         "pmi",
         default="none",
-        values=("none", "simplepmi", "slurmpmi", "slurmpmi2", "pmix"),
+        values=("none", "simplepmi", "slurmpmi", "slurmpmi2", "pmix", "cray-pmi"),
         description="The ucx/ofi/gni backends need PMI to run!",
     )
 
@@ -127,6 +127,7 @@ class Charmpp(Package):
     depends_on("mpi", when="pmi=simplepmi")
     depends_on("mpi", when="pmi=slurmpmi")
     depends_on("mpi", when="pmi=slurmpmi2")
+    depends_on("cray-mpich", when="pmi=cray-pmi")
 
     # Git versions of Charm++ require automake and autoconf
     depends_on("automake", when="@develop")
@@ -199,7 +200,10 @@ class Charmpp(Package):
         }
         
         if self.spec.satisfies("@6.10:"):
-            versions.update({("linux", "x86_64", "ucx"): "ucx-linux-x86_64", ("linux", "aarch64", "ucx"): "ucx-linux-arm8"})
+            versions.update({
+                ("linux", "x86_64", "ucx"): "ucx-linux-x86_64", 
+                ("linux", "aarch64", "ucx"): "ucx-linux-arm8",
+            })
 
         # Some versions were renamed/removed in 6.11
         if self.spec.version < Version("6.11.0"):
@@ -228,7 +232,7 @@ class Charmpp(Package):
                 }
             )
 
-            if "^cray-mpich" in self.spec:
+            if self.spec.satisfies("backend=ofi pmi=cray-pmi"):
                 versions.update({
                     ("linux", "x86_64", "ofi"): "ofi-crayshasta", 
                     ("linux", "aarch64", "ofi"): "ofi-crayshasta",

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -58,6 +58,9 @@ class Charmpp(Package):
     # Ignore compiler warnings while configuring
     patch("strictpass.patch", when="@:6.8.2")
 
+    # Support Cray Shasta with ARM
+    patch("ofi-crayshasta-arm.patch", when="backend=ofi ^cray-mpich")
+
     # Build targets
     # "target" is reserved, so we have to use something else.
     variant(
@@ -112,6 +115,7 @@ class Charmpp(Package):
     depends_on("cuda", when="+cuda")
 
     depends_on("ucx", when="backend=ucx")
+    depends_on("libfabric", when="backend=ofi")
     depends_on("slurm@:17-11-9-2", when="pmi=slurmpmi")
     depends_on("slurm@17-11-9-2:", when="pmi=slurmpmi2")
 
@@ -180,7 +184,6 @@ class Charmpp(Package):
             ("linux", "x86_64", "netlrts"): "netlrts-linux-x86_64",
             ("linux", "x86_64", "verbs"): "verbs-linux-x86_64",
             ("linux", "x86_64", "ofi"): "ofi-linux-x86_64",
-            ("linux", "x86_64", "ucx"): "ucx-linux-x86_64",
             ("linux", "ppc", "mpi"): "mpi-linux-ppc",
             ("linux", "ppc", "multicore"): "multicore-linux-ppc",
             ("linux", "ppc", "netlrts"): "netlrts-linux-ppc",
@@ -194,29 +197,42 @@ class Charmpp(Package):
             ("cnl", "x86_64", "gni"): "gni-crayxc",
             ("cnl", "x86_64", "mpi"): "mpi-crayxc",
         }
+        
+        if self.spec.satisfies("@6.10:"):
+            versions.update({("linux", "x86_64", "ucx"): "ucx-linux-x86_64", ("linux", "aarch64", "ucx"): "ucx-linux-arm8"})
 
         # Some versions were renamed/removed in 6.11
         if self.spec.version < Version("6.11.0"):
-            versions.update({("linux", "i386", "mpi"): "mpi-linux"})
-            versions.update({("linux", "i386", "multicore"): "multicore-linux"})
-            versions.update({("linux", "i386", "netlrts"): "netlrts-linux"})
-            versions.update({("linux", "i386", "uth"): "uth-linux"})
-            versions.update(
-                {
-                    ("linux", "arm", "multicore"): "multicore-arm7",
-                    ("linux", "aarch64", "multicore"): "multicore-arm8",
-                }
-            )
+            versions.update({
+                ("linux", "i386", "mpi"): "mpi-linux", 
+                ("linux", "i386", "multicore"): "multicore-linux", 
+                ("linux", "i386", "netlrts"): "netlrts-linux", 
+                ("linux", "i386", "uth"): "uth-linux", 
+                ("linux", "arm", "multicore"): "multicore-arm7",
+                ("linux", "aarch64", "multicore"): "multicore-arm8",
+            })
         else:
-            versions.update({("linux", "i386", "mpi"): "mpi-linux-i386"})
-            versions.update({("linux", "i386", "multicore"): "multicore-linux-i386"})
-            versions.update({("linux", "i386", "netlrts"): "netlrts-linux-i386"})
+            versions.update({
+                ("linux", "i386", "mpi"): "mpi-linux-i386", 
+                ("linux", "i386", "multicore"): "multicore-linux-i386", 
+                ("linux", "i386", "netlrts"): "netlrts-linux-i386",
+                ("linux", "arm", "multicore"): "multicore-linux-arm7",
+                ("linux", "aarch64", "multicore"): "multicore-linux-arm8",
+            })
+
+        if self.spec.satisfies("@7:"):
             versions.update(
                 {
-                    ("linux", "arm", "multicore"): "multicore-linux-arm7",
-                    ("linux", "aarch64", "multicore"): "multicore-linux-arm8",
+                    ("linux", "arm", "mpi"): "mpi-linux-arm7",
+                    ("linux", "aarch64", "mpi"): "mpi-linux-arm8",
                 }
             )
+
+            if "^cray-mpich" in self.spec:
+                versions.update({
+                    ("linux", "x86_64", "ofi"): "ofi-crayshasta", 
+                    ("linux", "aarch64", "ofi"): "ofi-crayshasta",
+                })
 
         if (plat, mach, comm) not in versions:
             raise InstallError(

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -414,4 +414,4 @@ class Charmpp(Package):
         self.spec.mpicxx = self.prefix.bin.ampicxx
         self.spec.mpifc = self.prefix.bin.ampif90
         self.spec.mpif77 = self.prefix.bin.ampif77
-        self.spec.charmarch = self.charmarch
+        self.spec.charmarch = self.charmarch + "-smp" if self.spec.satisfies("+smp") else ""


### PR DESCRIPTION
* Add patch to build `arch/ofi-crayshasta` on ARM
* Add `cray-pmi` as PMI provider
* Add `cray-mpich` dependency when PMI provider is `cray-pmi` (similar to `openmpi` when provider is `pmix`)
* Add explicit dependency on `libfabric` when `backend=ofi`
* Added a bunch of versions
* Added `-smp` suffix when `+smp`, for NAMD 