### PR TITLE
n2p2: add --no-print-directory flag to calls to "make"

### DIFF
--- a/var/spack/repos/builtin/packages/n2p2/package.py
+++ b/var/spack/repos/builtin/packages/n2p2/package.py
@@ -71,11 +71,13 @@ class N2p2(MakefilePackage):
 
     def build(self, spec, prefix):
         with working_dir("src"):
-            make()
-            make("lammps-nnp")
-            make("pynnp")
+            # Add --no-print-directory flag to avoid issues when variables set
+            # to value of shell function with cd cmd used as target (see #43192)
+            make("--no-print-directory")
+            make("--no-print-directory", "lammps-nnp")
+            make("--no-print-directory", "pynnp")
             if "+doc" in self.spec:
-                make("doc")
+                make("--no-print-directory", "doc")
 
     def install(self, spec, prefix):
         install_tree("bin", prefix.bin)


### PR DESCRIPTION
This should fix issue #43192

Basically, had issue where a make variable was set to the output of a shell function which included cd commands, and then the value of that variable used as a makefile target.

The cd commands in the shell function caused assorted informational messages (e.g. "Entering directory ...") which got included in the return of the shell function, corrupting the value of the variable. The presence of colons in the corrupted value caused make to issue "multiple target" erros.

This fix adds --no-print-directory flags to the calls to the make function in the package's build method, which resolves the issue above.

It is admittedly a crude fix, and will remove *all* informational messages re directory changes, thereby potentially making it more difficult to diagnose/debug future issues building this package. However, I do not see a way for to turn off these messages in a more surgical manner.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
