### PR TITLE
lammps: Explicitly specify path to python exe to CMake when +python

### DIFF
--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -863,6 +863,9 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
         if "+rocm" in spec:
             args.append(self.define("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
+        if "+python" in spec:
+            args.append(self.define("Python_EXECUTABLE", self.spec["python"].prefix.bin.python))
+
         return args
 
     def setup_build_environment(self, env):


### PR DESCRIPTION
When +python variant is selected, explicitly tell CMake which python binary to use.

This should fix issue #43197 wherein cmake was finding system installed python binaries instead of spack installed versions.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
