### PR TITLE
Clingo: Remove msvc constraint

### DIFF
--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -213,9 +213,6 @@ def _root_spec(spec_str: str) -> str:
     platform = str(spack.platforms.host())
     if platform == "darwin":
         spec_str += " %apple-clang"
-    elif platform == "windows":
-        # TODO (johnwparent): Remove version constraint when clingo patch is up
-        spec_str += " %msvc@:19.37"
     elif platform == "linux":
         spec_str += " %gcc"
     elif platform == "freebsd":

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -75,7 +75,7 @@ class Clingo(CMakePackage):
     patch("python38.patch", when="@5.3:5.4.0")
     patch("size-t.patch", when="%msvc")
     patch("vs2022.patch", when="%msvc@19.30:")
-    patch("clingo_msc_1938_native_handle.patch", when="%msvc@19.38:")
+    patch("clingo_msc_1938_native_handle.patch", when="@:5.7.0 %msvc@19.38:")
 
     # TODO: Simplify this after Spack 0.21 release. The old concretizer has problems with
     # py-setuptools ^python@3.6, so we only apply the distutils -> setuptools patch for Python 3.12


### PR DESCRIPTION
Patch allowing Clingo to build with VS22 has landed both in Spack and Clingo upstream, update Spack's bootstrap constraints to handle this.

Additionally, properly scope the patch application in the clingo package to handle upstream patch.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
