### PR TITLE
add later versions of packages 

### DIFF
--- a/var/spack/repos/builtin/packages/py-deepdiff/package.py
+++ b/var/spack/repos/builtin/packages/py-deepdiff/package.py
@@ -14,6 +14,7 @@ class PyDeepdiff(PythonPackage):
 
     license("MIT")
 
+    version("6.7.1", sha256="b367e6fa6caac1c9f500adc79ada1b5b1242c50d5f716a1a4362030197847d30")
     version("6.3.0", sha256="6a3bf1e7228ac5c71ca2ec43505ca0a743ff54ec77aa08d7db22de6bc7b2b644")
     version("5.6.0", sha256="e3f1c3a375c7ea5ca69dba6f7920f9368658318ff1d8a496293c79481f48e649")
 

--- a/var/spack/repos/builtin/packages/py-mysql-connector-python/package.py
+++ b/var/spack/repos/builtin/packages/py-mysql-connector-python/package.py
@@ -18,6 +18,7 @@ class PyMysqlConnectorPython(PythonPackage):
 
     license("Artistic-1.0-Perl")
 
+    version("8.3.0", sha256="968323a49d8100c5660a5f4d1f07a27982de07e6fe6cec21bcd55cfcacc9501e")
     version("8.0.13", sha256="d4c0834c583cdb90c0aeae90b1917d58355a4bf9b0266c16fd58874a5607f9d4")
 
     depends_on("py-setuptools", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-nbconvert/package.py
+++ b/var/spack/repos/builtin/packages/py-nbconvert/package.py
@@ -15,6 +15,7 @@ class PyNbconvert(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("7.16.0", sha256="813e6553796362489ae572e39ba1bff978536192fb518e10826b0e8cadf03ec8")
     version("7.14.1", sha256="20cba10e0448dc76b3bebfe1adf923663e3b98338daf77b97b42511ef5a88618")
     version("7.4.0", sha256="51b6c77b507b177b73f6729dba15676e42c4e92bcb00edc8cc982ee72e7d89d7")
     version("7.0.0", sha256="fd1e361da30e30e4c5a5ae89f7cae95ca2a4d4407389672473312249a7ba0060")

--- a/var/spack/repos/builtin/packages/py-pyqt5-sip/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5-sip/package.py
@@ -14,6 +14,7 @@ class PyPyqt5Sip(PythonPackage):
 
     license("GPL-2.0-only")
 
+    version("12.12.2", sha256="10d9bfa9f59f0fd1cad81be187479316ffc95684f573efea94512cb4257d2b17")
     version("12.12.1", sha256="8fdc6e0148abd12d977a1d3828e7b79aae958e83c6cb5adae614916d888a6b10")
     version("12.9.0", sha256="d3e4489d7c2b0ece9d203ae66e573939f7f60d4d29e089c9f11daa17cfeaae32")
 

--- a/var/spack/repos/builtin/packages/py-pyqt5/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5/package.py
@@ -17,6 +17,7 @@ class PyPyqt5(SIPPackage):
 
     license("GPL-3.0-only")
 
+    version("5.15.10", sha256="dc41e8401a90dc3e2b692b411bd5492ab559ae27a27424eed4bd3915564ec4c0")
     version("5.15.9", sha256="dc41e8401a90dc3e2b692b411bd5492ab559ae27a27424eed4bd3915564ec4c0")
 
     # pyproject.toml

--- a/var/spack/repos/builtin/packages/py-scikit-image/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-image/package.py
@@ -21,6 +21,7 @@ class PyScikitImage(PythonPackage):
         "skimage.future.graph",
     ]
 
+    version("0.21.0", sha256="b33e823c54e6f11873ea390ee49ef832b82b9f70752c8759efd09d5a4e3d87f0")
     version("0.20.0", sha256="2cd784fce18bd31d71ade62c6221440199ead03acf7544086261ee032264cf61")
     version("0.19.3", sha256="24b5367de1762da6ee126dd8f30cc4e7efda474e0d7d70685433f0e3aa2ec450")
     version("0.18.3", sha256="ecae99f93f4c5e9b1bf34959f4dc596c41f2f6b2fc407d9d9ddf85aebd3137ca")

--- a/var/spack/repos/builtin/packages/py-sqlalchemy/package.py
+++ b/var/spack/repos/builtin/packages/py-sqlalchemy/package.py
@@ -15,6 +15,7 @@ class PySqlalchemy(PythonPackage):
 
     license("MIT")
 
+    version("2.0.27", sha256="86a6ed69a71fe6b88bf9331594fa390a2adda4a49b5c06f98e47bf0d392534f8")
     version("2.0.19", sha256="77a14fa20264af73ddcdb1e2b9c5a829b8cc6b8304d0f093271980e36c200a3f")
     version("1.4.49", sha256="06ff25cbae30c396c4b7737464f2a7fc37a67b7da409993b182b024cec80aed9")
     version("1.4.45", sha256="fd69850860093a3f69fefe0ab56d041edfdfe18510b53d9a2eaecba2f15fa795")

--- a/var/spack/repos/builtin/packages/py-tabulate/package.py
+++ b/var/spack/repos/builtin/packages/py-tabulate/package.py
@@ -14,6 +14,7 @@ class PyTabulate(PythonPackage):
 
     license("MIT")
 
+    version("0.9.0", sha256="0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c")
     version("0.8.9", sha256="eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7")
     version("0.8.7", sha256="db2723a20d04bcda8522165c73eea7c300eda74e0ce852d9022e0159d7895007")
     version("0.8.6", sha256="5470cc6687a091c7042cee89b2946d9235fe9f6d49c193a4ae2ac7bf386737c8")

--- a/var/spack/repos/builtin/packages/py-texttable/package.py
+++ b/var/spack/repos/builtin/packages/py-texttable/package.py
@@ -15,6 +15,7 @@ class PyTexttable(PythonPackage):
 
     license("MIT")
 
+    version("1.7.0", sha256="2d2068fb55115807d3ac77a4ca68fa48803e84ebb0ee2340f858107a36522638")
     version("1.6.7", sha256="290348fb67f7746931bcdfd55ac7584ecd4e5b0846ab164333f0794b121760f2")
     version("1.6.6", sha256="e106b1204b788663283784fd6e5dfc23f1574b84e518e5d286c1a1e66dabd42c")
     version("1.6.5", sha256="fc3f763a89796ae03789a02343bd4e8fed9735935123b1bfb9537a5935852315")

--- a/var/spack/repos/builtin/packages/py-typing-extensions/package.py
+++ b/var/spack/repos/builtin/packages/py-typing-extensions/package.py
@@ -17,6 +17,7 @@ class PyTypingExtensions(PythonPackage):
 
     license("0BSD")
 
+    version("4.9.0", sha256="23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783")
     version("4.8.0", sha256="df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef")
     version("4.6.3", sha256="d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5")
     version("4.5.0", sha256="5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb")


### PR DESCRIPTION
add later versions of packages for of py-deepdiff py-mysql-connector-python py-nbconvert py-pyqt5-sip py-pyqt5 py-scikit-image py-sqlalchemy py-tabulate py-texttable py-typing-extensions

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
