### PR TITLE
Concretize `when_possible`: add failure detection and explicit message

### DIFF
--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -91,7 +91,6 @@ def setup_parser(subparser):
 
 
 def _process_result(result, show, required_format, kwargs):
-    result.raise_if_unsat()
     opt, _, _ = min(result.answers)
     if ("opt" in show) and (not required_format):
         tty.msg("Best of %d considered solutions." % result.nmodels)

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -749,7 +749,6 @@ def _concretize_specs_together_new(*abstract_specs, **kwargs):
     result = solver.solve(
         abstract_specs, tests=kwargs.get("tests", False), allow_deprecated=allow_deprecated
     )
-    result.raise_if_unsat()
     return [s.copy() for s in result.specs]
 
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3536,8 +3536,16 @@ class Solver:
                 break
 
             # This means we cannot progress with solving the input
-            if not result.satisfiable or not result.specs:
-                break
+            result.raise_if_unsat()
+
+            if not result.specs:
+                # This is also a problem: no specs were solved for, which
+                # means we would be in a loop if we tried again
+                unsolved_str = Result.format_unsolved(result.unsolved_specs)
+                raise InternalConcretizerError(
+                    "Internal Spack error: a subset of input specs could not"
+                    f" be solved for.\n\t{unsolved_str}"
+                )
 
             input_specs = list(x for (x, y) in result.unsolved_specs)
             for spec in result.specs:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -763,7 +763,6 @@ class PyclingoDriver:
         timer.stop("ground")
 
         # With a grounded program, we can run the solve.
-        result = Result(specs)
         models = []  # stable models if things go well
         cores = []  # unsatisfiable cores if they do not
 
@@ -784,6 +783,7 @@ class PyclingoDriver:
         timer.stop("solve")
 
         # once done, construct the solve result
+        result = Result(specs)
         result.satisfiable = solve_result.satisfiable
 
         if result.satisfiable:
@@ -823,6 +823,8 @@ class PyclingoDriver:
         if output.stats:
             print("Statistics:")
             pprint.pprint(self.control.statistics)
+
+        result.raise_if_unsat()
 
         if result.satisfiable and result.unsolved_specs and setup.concretize_everything:
             unsolved_str = Result.format_unsolved(result.unsolved_specs)
@@ -3534,9 +3536,6 @@ class Solver:
             # If we don't have unsolved specs we are done
             if not result.unsolved_specs:
                 break
-
-            # This means we cannot progress with solving the input
-            result.raise_if_unsat()
 
             if not result.specs:
                 # This is also a problem: no specs were solved for, which

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2968,7 +2968,6 @@ class Spec:
         allow_deprecated = spack.config.get("config:deprecated", False)
         solver = spack.solver.asp.Solver()
         result = solver.solve([self], tests=tests, allow_deprecated=allow_deprecated)
-        result.raise_if_unsat()
 
         # take the best answer
         opt, i, answer = min(result.answers)

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1794,6 +1794,22 @@ class TestConcretize:
                 counter += 1
         assert counter == occurances, concrete_specs
 
+    @pytest.mark.only_clingo("Original concretizer cannot concretize in rounds")
+    def test_solve_in_rounds_all_unsolved(self, monkeypatch, mock_packages, config):
+        specs = [Spec(x) for x in ["libdwarf%gcc", "libdwarf%clang"]]
+        solver = spack.solver.asp.Solver()
+        solver.reuse = False
+
+        simulate_unsolved_property = list((x, None) for x in specs)
+        monkeypatch.setattr(spack.solver.asp.Result, "unsolved_specs", simulate_unsolved_property)
+        monkeypatch.setattr(spack.solver.asp.Result, "specs", list())
+
+        with pytest.raises(
+            spack.solver.asp.InternalConcretizerError,
+            match="a subset of input specs could not be solved for",
+        ):
+            list(solver.solve_in_rounds(specs))
+
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_coconcretize_reuse_and_virtuals(self):
         reusable_specs = []


### PR DESCRIPTION
Add logic to solve_in_rounds to explicitly fail when solve loop cannot make progress (was returning silently before)

https://github.com/spack/spack/pull/42655 did this for other solve invocations (e.g. `unify: true`) but skipped this logic because it was assumed it would already fail for analogous cases; that was an oversight on my part (as shown in #42608).

This should resolve https://github.com/spack/spack/issues/42608 (or at least, the part where the concretization failure is not detected, it might be we want to improve the error message too).
