### PR TITLE
Remove bundled fmt

### DIFF
--- a/var/spack/repos/builtin/packages/bear/package.py
+++ b/var/spack/repos/builtin/packages/bear/package.py
@@ -35,7 +35,7 @@ class Bear(CMakePackage):
     depends_on("fmt@8", when="@3.0.0:")
     depends_on("grpc +shared", when="@3.0.0:")
     depends_on("nlohmann-json", when="@3.0.0:")
-    depends_on("spdlog +fmt_external", when="@3.0.0:")
+    depends_on("spdlog", when="@3.0.0:")
     depends_on("cmake@2.8:", when="@2.0.4:", type="build")
     depends_on("cmake@3.12:", when="@3.0.0:", type="build")
     depends_on("python", type="build")

--- a/var/spack/repos/builtin/packages/heyoka/package.py
+++ b/var/spack/repos/builtin/packages/heyoka/package.py
@@ -50,7 +50,7 @@ class Heyoka(CMakePackage):
     depends_on("llvm@13:17")
     depends_on("boost@1.69: +serialization")
     depends_on("fmt@9:10")
-    depends_on("spdlog +fmt_external")
+    depends_on("spdlog")
     depends_on("intel-tbb@2021.4.0:")
 
     # Optional dependencies

--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -49,25 +49,20 @@ class Spdlog(CMakePackage):
     version("0.9.0", sha256="bbbe5a855c8b309621352921d650449eb2f741d35d55ec50fb4d8122ddfb8f01")
 
     variant("shared", default=True, description="Build shared libraries (v1.4.0+)")
-    variant(
-        "fmt_external",
-        default=False,
-        description="Build using external fmt libraries instead of bundled one",
-    )
 
     depends_on("cmake@3.2:", when="@:1.7.0", type="build")
     depends_on("cmake@3.10:", when="@1.8.0:", type="build")
 
-    depends_on("fmt@5.3:", when="+fmt_external")
-    depends_on("fmt@7:", when="@1.7: +fmt_external")
-    depends_on("fmt@8:", when="@1.9: +fmt_external")
-    depends_on("fmt@9:", when="@1.11: +fmt_external")
+    depends_on("fmt@5.3:")
+    depends_on("fmt@7:", when="@1.7:")
+    depends_on("fmt@8:", when="@1.9:")
+    depends_on("fmt@9:", when="@1.11:")
 
     # spdlog@1.11.0 with fmt@10  https://github.com/gabime/spdlog/pull/2694
     patch(
         "https://github.com/gabime/spdlog/commit/0ca574ae168820da0268b3ec7607ca7b33024d05.patch?full_index=1",
         sha256="31b22a9bfa6790fdabff186c0a9b0fd588439485f05cbef5e661231d15fec49b",
-        when="@1.11.0 +fmt_external ^fmt@10:",
+        when="@1.11.0 ^fmt@10:",
     )
 
     def cmake_args(self):
@@ -77,7 +72,7 @@ class Spdlog(CMakePackage):
             args.extend(
                 [
                     self.define_from_variant("SPDLOG_BUILD_SHARED", "shared"),
-                    self.define_from_variant("SPDLOG_FMT_EXTERNAL", "fmt_external"),
+                    self.define("SPDLOG_FMT_EXTERNAL", True),
                     # tests and examples
                     self.define("SPDLOG_BUILD_TESTS", self.run_tests),
                     self.define("SPDLOG_BUILD_EXAMPLE", self.run_tests),


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This follows #34216, it removes the `fmt_external` option in spdlog and always relies on fmt provided by spack. This PR also removes `+fmt_external` in 2 other recipes that were relying on it.