### PR TITLE
py-cutadapt: updating to @4.7

### DIFF
--- a/var/spack/repos/builtin/packages/py-cutadapt/package.py
+++ b/var/spack/repos/builtin/packages/py-cutadapt/package.py
@@ -17,6 +17,7 @@ class PyCutadapt(PythonPackage):
 
     license("MIT")
 
+    version("4.7", sha256="8738a35b363eaf615665a4e7d1b4beb385cd93fb7ffdcf82cd4ab6457acc879b")
     version("4.4", sha256="4554157c673022e1c433fcd6e3b803008fef60c8e71c01215e4aa04b0f09fe83")
     version("4.3", sha256="319de860f975977e080ea42d9d255322060693ca39b7be51187831311702fe29")
     version("4.2", sha256="ab0ac450baecc1576cc5ccbc06eab2685be9ee7676763938237d954a644237f1")
@@ -27,12 +28,14 @@ class PyCutadapt(PythonPackage):
     version("1.13", sha256="aa9f2c1f33dc081fe94f42b1250e4382b8fb42cabbf6e70a76ff079f211d5fc0")
 
     # version 4 deps
-    depends_on("py-setuptools@63:", type=("build", "run"), when="@4.2:")
-    depends_on("py-setuptools@43:", type=("build", "run"), when="@:4.1")
+    depends_on("python@3.8:", type=("build", "run"), when="@4.7:")
+    depends_on("python@3.7:", type=("build", "run"), when="@4.1:4.6")
+    depends_on("py-setuptools@63:", type="build", when="@4.2:")
+    depends_on("py-setuptools@43:", type="build", when="@:4.1")
     depends_on("py-setuptools-scm@6.2:+toml", type="build", when="@2.0:")
-    depends_on("python@3.7:", type=("build", "run"), when="@4.1:")
     depends_on("py-cython@0.29.20:", type="build")
-    depends_on("py-dnaio@0.10:", type=("build", "run"), when="@4.3:")
+    depends_on("py-dnaio@1.2.0:", type=("build", "run"), when="@4.7:")
+    depends_on("py-dnaio@0.10:", type=("build", "run"), when="@4.3:4.6")
     depends_on("py-dnaio@0.9.1:", type=("build", "run"), when="@4.2")
     depends_on("py-dnaio@0.7.1:", type=("build", "run"), when="@4.1")
     depends_on("py-xopen@1.6:", type=("build", "run"), when="@4.2:")

--- a/var/spack/repos/builtin/packages/py-dnaio/package.py
+++ b/var/spack/repos/builtin/packages/py-dnaio/package.py
@@ -15,17 +15,18 @@ class PyDnaio(PythonPackage):
 
     license("MIT")
 
+    version("1.2.0", sha256="d0528c23516fe4e947970bdef33c423f0a30ab3b083bd4f6f049fd66d8cef803")
     version("0.10.0", sha256="de51a50948f00b864297d74eddb588fbee5ac229855754e77564d18b24619d18")
     version("0.9.1", sha256="a1a14181995b27197b7e2b8897994a3107c649b9fc2dfe263caff3c455b0d0c4")
     version("0.4.2", sha256="fa55a45bfd5d9272409b714158fb3a7de5dceac1034a0af84502c7f503ee84f8")
     version("0.3", sha256="47e4449affad0981978fe986684fc0d9c39736f05a157f6cf80e54dae0a92638")
 
-    depends_on("py-setuptools@52:", type=("build", "run"))
-    depends_on("py-setuptools-scm@6.2:", when="@0.4:", type="build")
-    # 0.9.1 deps
     depends_on("python@3.7:", type=("build", "run"), when="@0.9.1:")
+    # build deps
+    depends_on("py-setuptools@52:", type="build")
+    depends_on("py-setuptools-scm@6.2:", type="build", when="@0.4:")
     depends_on("py-cython@0.29.20:", type="build", when="@0.9.1:")
+    # run deps
     depends_on("py-xopen@1.4.0:", type=("build", "run"), when="@0.9.1:")
-    # older deps
+    depends_on("py-xopen@0.8.2:", type=("build", "run"), when="@0.4:")
     depends_on("py-xopen", type=("build", "run"))
-    depends_on("py-xopen@0.8.2:", when="@0.4:", type=("build", "run"))


### PR DESCRIPTION
Updating `py-cutadapt` and a required dependency. Tested and working on `linux-rocky8-icelake`.