### PR TITLE
namd: disable parallel build

### DIFF
--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -57,6 +57,9 @@ class Namd(MakefilePackage, CudaPackage):
     variant("avxtiles", when="target=x86_64_v4:", default=False, description="Enable avxtiles")
     variant("single_node_gpu", default=False, description="Single node GPU")
 
+    # Disable parallel build
+    parallel = False
+
     # init_tcl_pointers() declaration and implementation are inconsistent
     # "src/colvarproxy_namd.C", line 482: error: inherited member is not
     # allowed

--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -57,9 +57,6 @@ class Namd(MakefilePackage, CudaPackage):
     variant("avxtiles", when="target=x86_64_v4:", default=False, description="Enable avxtiles")
     variant("single_node_gpu", default=False, description="Single node GPU")
 
-    # Disable parallel build
-    parallel = False
-
     # init_tcl_pointers() declaration and implementation are inconsistent
     # "src/colvarproxy_namd.C", line 482: error: inherited member is not
     # allowed
@@ -291,6 +288,13 @@ class Namd(MakefilePackage, CudaPackage):
                 "CHARM = $(CHARMBASE)",
                 join_path(self.build_directory, "Make.config"),
             )
+
+    @when("@3.0b3")
+    def build(self, spec, prefix):
+        # Disable parallel build
+        # https://github.com/spack/spack/pull/43215
+        with working_dir(self.build_directory):
+            make(parallel=False)
 
     def install(self, spec, prefix):
         with working_dir(self.build_directory):


### PR DESCRIPTION
When building `namd@3` in parallel with `^charmpp backend=ofi`, I encountered the following error:
```
     76    In file included from src/common.C:21:
  >> 77    src/Node.h:31:10: fatal error: Node.decl.h: No such file or directory
     78       31 | #include "Node.decl.h"
     79          |          ^~~~~~~~~~~~~
     80    compilation terminated.
  >> 81    make[2]: *** [Make.depends:551: obj/common.o] Error 1
     82    make[2]: *** Waiting for unfinished jobs....
     83    cpp -E -P -DNAMD_CUDA -DBONDED_CUDA src/NamdCentLB.ci > inc/NamdCentLB.ci
     84    /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/charmpp-7.0.0-6x3j7itrjegtag2r3eowe7i2hypiot5a/bin/charmc inc/NamdCentLB.ci
     85    rm -f inc/NamdCentLB.ci
     86    mv NamdCentLB.def.h inc
     87    mv NamdCentLB.decl.h inc
```

It seems that `Node.decl.h` is not generated before it is needed. Building with `-j1` did work, therefore this PR disable parallel build.