### PR TITLE
GDAL: The CMake built binaries don't have a fixed install_name

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -591,7 +591,7 @@ class CMakeBuilder(CMakeBuilder):
         args = [arg for arg in args if arg]
 
         return args
-    
+
     @run_after("install")
     @when("platform=darwin")
     def darwin_install_name(self):

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -591,6 +591,12 @@ class CMakeBuilder(CMakeBuilder):
         args = [arg for arg in args if arg]
 
         return args
+    
+    @run_after("install")
+    @when("platform=darwin")
+    def darwin_install_name(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        fix_darwin_install_name(self.prefix.lib)
 
 
 class AutotoolsBuilder(AutotoolsBuilder):


### PR DESCRIPTION
On macos, the cmake-built gdal shared objects have an `install_name` like:
```
$ otool -D libgdal.34.3.8.4.dylib
libgdal.34.3.8.4.dylib:
@rpath/libgdal.34.dylib
```
instead of an absolute path.

This fix exists for the` gdal@:3.6` autotools builds, but is missing for the cmake builds. This rectifies that.