### PR TITLE
arrow: Add minimum orc version when +orc

### DIFF
--- a/var/spack/repos/builtin/packages/arrow/package.py
+++ b/var/spack/repos/builtin/packages/arrow/package.py
@@ -50,7 +50,7 @@ class Arrow(CMakePackage, CudaPackage):
     depends_on("ninja", type="build")
     depends_on("openssl", when="+gandiva @6.0.0:")
     depends_on("openssl", when="@4.0.0:")
-    depends_on("orc", when="+orc")
+    depends_on("orc@1.6.11:", when="+orc")
     depends_on("protobuf", when="+gandiva")
     depends_on("py-numpy", when="+python")
     depends_on("python", when="+python")


### PR DESCRIPTION
arrow+orc needs getSoftwareVersion from orc, which was added in orc@1.6.11 This places a minimum on orc version required for arrow +orc

This should be a partial fix to #43221

Requires  PR #43222

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
