### PR TITLE
Fix CMake generator documentation

### DIFF
--- a/lib/spack/docs/build_systems/cmakepackage.rst
+++ b/lib/spack/docs/build_systems/cmakepackage.rst
@@ -250,7 +250,7 @@ generator is Ninja. To switch to the Ninja generator, simply add:
 
 .. code-block:: python
 
-   generator = "Ninja"
+   generator("ninja")
 
 
 ``CMakePackage`` defaults to "Unix Makefiles". If you switch to the


### PR DESCRIPTION
The method for changing the CMake generator that is proposed by the [docs](https://spack.readthedocs.io/en/latest/build_systems/cmakepackage.html#generators) (setting `generator = "Ninja"`) has no effect. Looking at existing packages, it seems like it should be `generator("ninja")` instead.