### PR TITLE
py-pyshp: add v2.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyshp/package.py
+++ b/var/spack/repos/builtin/packages/py-pyshp/package.py
@@ -15,6 +15,7 @@ class PyPyshp(PythonPackage):
 
     license("MIT")
 
+    version("2.3.1", sha256="4caec82fd8dd096feba8217858068bacb2a3b5950f43c048c6dc32a3489d5af1")
     version("2.1.0", sha256="e65c7f24d372b97d0920b864bbeb78322bb37b83f2606e2a2212631d5d51e5c0")
     version("1.2.12", sha256="8dcd65e0aa2aa2951527ddb7339ea6e69023543d8a20a73fc51e2829b9ed6179")
 


### PR DESCRIPTION
PyShp - add version 2.3.1: [release notes](https://github.com/GeospatialPython/pyshp/releases/tag/2.3.1)