### PR TITLE
performance: avoid `jinja2` import at startup unless needed

### DIFF
--- a/lib/spack/spack/detection/test.py
+++ b/lib/spack/spack/detection/test.py
@@ -9,8 +9,6 @@ import pathlib
 import tempfile
 from typing import Any, Deque, Dict, Generator, List, NamedTuple, Tuple
 
-import jinja2
-
 from llnl.util import filesystem
 
 import spack.repo
@@ -85,6 +83,8 @@ class Runner:
             self.tmpdir.cleanup()
 
     def _create_executable_scripts(self, mock_executables: MockExecutables) -> List[pathlib.Path]:
+        import jinja2
+
         relative_paths = mock_executables.executables
         script = mock_executables.script
         script_template = jinja2.Template("#!/bin/bash\n{{ script }}\n")


### PR DESCRIPTION
`jinja2` can be a costly import, and right now it happens at startup every time we run Spack. This slows down `spack --print-shell-vars` a bit, which is needed by `setup-env.*sh`.

- [x] move `jinja2` import into function

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
