### PR TITLE
scorep: add conflict for ROCm6

### DIFF
--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -144,7 +144,9 @@ class Scorep(AutotoolsPackage):
     # does not work on macOS
     # https://github.com/spack/spack/issues/1609
     conflicts("platform=darwin")
-
+    # Score-P first has support for ROCm 6.x as of v8.4
+    conflicts("hip@6.0:", when="@1.0:8.3+hip")
+    
     def find_libpath(self, libname, root):
         libs = find_libraries(libname, root, shared=True, recursive=True)
         if len(libs.directories) == 0:

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -146,7 +146,7 @@ class Scorep(AutotoolsPackage):
     conflicts("platform=darwin")
     # Score-P first has support for ROCm 6.x as of v8.4
     conflicts("hip@6.0:", when="@1.0:8.3+hip")
-    
+
     def find_libpath(self, libname, root):
         libs = find_libraries(libname, root, shared=True, recursive=True)
         if len(libs.directories) == 0:


### PR DESCRIPTION
ROCm 6.x is first supported as of Score-P 8.4, thus `scorep+hip` should exclude `hip@6.0+` for 8.3 and earlier.

For reviewers: should we be changing to a `^rocm` dependency rather than `^hip`?

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
