### PR TITLE
apex: Set `APEX_WITH_KOKKOS` CMake option in apex package

### DIFF
--- a/var/spack/repos/builtin/packages/apex/package.py
+++ b/var/spack/repos/builtin/packages/apex/package.py
@@ -154,6 +154,7 @@ class Apex(CMakePackage):
         args.append(self.define_from_variant(prefix + "_LM_SENSORS", "lmsensors"))
         args.append(self.define_from_variant(prefix + "_TCMALLOC", "gperftools"))
         args.append(self.define_from_variant(prefix + "_JEMALLOC", "jemalloc"))
+        args.append(self.define_from_variant(prefix + "_KOKKOS", "kokkos"))
         args.append(self.define_from_variant(test_prefix + "BUILD_TESTS", "tests"))
         args.append(self.define_from_variant(test_prefix + "BUILD_EXAMPLES", "examples"))
 

--- a/var/spack/repos/builtin/packages/apex/package.py
+++ b/var/spack/repos/builtin/packages/apex/package.py
@@ -125,6 +125,11 @@ class Apex(CMakePackage):
     # https://github.com/UO-OACISS/apex/pull/177#issuecomment-1726322959
     conflicts("+openmp", when="%gcc")
 
+    # Up to 2.6.3 Kokkos support is always enabled. In 2.6.4 and 2.6.5 there is
+    # a CMake option to disable Kokkos support but it doesn't work:
+    # https://github.com/UO-OACISS/apex/issues/180.
+    conflicts("~kokkos", when="@:2.6.5")
+
     # Patches
 
     # This patch ensures that the missing dependency_tree.hpp header is


### PR DESCRIPTION
I noticed that 2.6.4 and 2.6.5 of apex has a CMake option but the option isn't set in the spack package.

I've also tentatively addeed a conflict with 2.6.4 and 2.6.5 due to https://github.com/UO-OACISS/apex/issues/180. @khuck do you think we could patch up those releases to avoid adding the conflict?

Finally, in 2.6.3 and earlier there is no `APEX_WITH_KOKKOS` CMake option. @khuck should the `kokkos` variant be conditional on the version, or should the spack package simply skip setting `APEX_WITH_KOKKOS` for the older versions? It's not clear to me exactly what sort of kokkos support there is in earlier versions (I see mentions of kokkos quite far back in the repo, so presumably there is some sort of support also in older versions).