### PR TITLE
py-cmake: only run test suite when run_tests

### DIFF
--- a/var/spack/repos/builtin/packages/py-cmake/package.py
+++ b/var/spack/repos/builtin/packages/py-cmake/package.py
@@ -53,3 +53,16 @@ class PyCmake(PythonPackage):
 
     def install_options(self, spec, prefix):
         return ["-DBUILD_CMAKE_FROM_SOURCE=ON", "-DCMakeProject_SOURCE_DIR=cmake-src"]
+
+    def setup_build_environment(self, env):
+        if self.run_tests:
+            env.set(
+                "SKBUILD_CONFIGURE_OPTIONS",
+                # BootstrapTest is already exlcude upstream,
+                # The rest are (non-understood) known failures, disabled to get test suite working
+                # todo: investigate test failures / check if still needed in newer versions
+                "-DRUN_CMAKE_TEST=ON -DRUN_CMAKE_TEST_EXCLUDE=BootstrapTest|CompileWarningAsError"
+                "|GET_RUNTIME_DEPENDENCIES",
+            )
+        else:
+            env.set("SKBUILD_CONFIGURE_OPTIONS", "-DRUN_CMAKE_TEST=OFF")


### PR DESCRIPTION
As the cmake build is triggered by scikit build, the usual spack option for enabling tests had no effect and the heavy test suite ran all the time. Used https://github.com/scikit-build/cmake-python-distributions/issues/172#issuecomment-890322263 for the implementation how to pass options to the actual cmake build.

I also excluded some tests that failed for me on alma9 (gcc 11.4.1), so the rest of the test suite can be run.
