### PR TITLE
increase line length from 99 to 103

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,7 +19,7 @@
 [flake8]
 #ignore = E129,,W503,W504,F999,N801,N813,N814,F403,F405,E203
 extend-ignore = E731,E203
-max-line-length = 99
+max-line-length = 103
 
 # F4: Import
 # - F405: `name` may be undefined, or undefined from star imports: `module`

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -49,13 +49,7 @@ import spack.variant
 from spack.dependency import Dependency
 from spack.fetch_strategy import from_kwargs
 from spack.resource import Resource
-from spack.version import (
-    GitVersion,
-    Version,
-    VersionChecksumError,
-    VersionError,
-    VersionLookupError,
-)
+from spack.version import GitVersion, Version, VersionChecksumError, VersionError, VersionLookupError
 
 if TYPE_CHECKING:
     import spack.package_base
@@ -174,9 +168,7 @@ class DirectiveMeta(type):
         # Move things to be executed from module scope (where they
         # are collected first) to class scope
         if DirectiveMeta._directives_to_be_executed:
-            attr_dict["_directives_to_be_executed"].extend(
-                DirectiveMeta._directives_to_be_executed
-            )
+            attr_dict["_directives_to_be_executed"].extend(DirectiveMeta._directives_to_be_executed)
             DirectiveMeta._directives_to_be_executed = []
 
         return super(DirectiveMeta, cls).__new__(cls, name, bases, attr_dict)
@@ -873,9 +865,7 @@ def resource(**kwargs):
 
         # Check if the path is relative
         if os.path.isabs(destination):
-            message = (
-                "The destination keyword of a resource directive " "can't be an absolute path.\n"
-            )
+            message = "The destination keyword of a resource directive " "can't be an absolute path.\n"
             message += "\tdestination : '{dest}\n'".format(dest=destination)
             raise RuntimeError(message)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ features = [
 ]
 
 [tool.black]
-line-length = 99
+line-length = 103
 target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
 include = '''
     \.pyi?$
@@ -84,7 +84,7 @@ extend-exclude = '''
 skip_magic_trailing_comma = true
 
 [tool.isort]
-line_length = 99
+line_length = 103
 profile = "black"
 sections = [
   "FUTURE",

--- a/var/spack/repos/builtin/packages/arbor/package.py
+++ b/var/spack/repos/builtin/packages/arbor/package.py
@@ -54,9 +54,7 @@ class Arbor(CMakePackage, CudaPackage):
     variant("doc", default=False, description="Build documentation.")
     variant("mpi", default=False, description="Enable MPI support")
     variant("python", default=True, description="Enable Python frontend support")
-    variant(
-        "vectorize", default=False, description="Enable vectorization of computational kernels"
-    )
+    variant("vectorize", default=False, description="Enable vectorization of computational kernels")
     variant(
         "gpu_rng",
         default=False,

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -201,14 +201,10 @@ class Cmake(Package):
     # the build.
     variant("ownlibs", default=True, description="Use CMake-provided third-party libraries")
     variant(
-        "doc",
-        default=False,
-        description="Enables the generation of html and man page documentation",
+        "doc", default=False, description="Enables the generation of html and man page documentation"
     )
     variant(
-        "ncurses",
-        default=sys.platform != "win32",
-        description="Enables the build of the ncurses gui",
+        "ncurses", default=sys.platform != "win32", description="Enables the build of the ncurses gui"
     )
 
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/21135
@@ -347,9 +343,7 @@ class Cmake(Package):
             args.append("--prefix={0}".format(self.prefix))
 
             jobs = spack.build_environment.get_effective_jobs(
-                make_jobs,
-                parallel=self.parallel,
-                supports_jobserver=self.generator.supports_jobserver,
+                make_jobs, parallel=self.parallel, supports_jobserver=self.generator.supports_jobserver
             )
             if jobs is not None:
                 args.append("--parallel={0}".format(jobs))

--- a/var/spack/repos/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/builtin/packages/dftbplus/package.py
@@ -19,9 +19,7 @@ class Dftbplus(CMakePackage, MakefilePackage):
     generator("ninja")
 
     build_system(
-        conditional("cmake", when="@20.1:"),
-        conditional("makefile", when="@:19.1"),
-        default="cmake",
+        conditional("cmake", when="@20.1:"), conditional("makefile", when="@:19.1"), default="cmake"
     )
 
     license("CC-BY-SA-4.0")
@@ -66,9 +64,7 @@ class Dftbplus(CMakePackage, MakefilePackage):
         when="+mpi",
     )
     variant(
-        "gpu",
-        default=False,
-        description="Use the MAGMA library " "for GPU accelerated computation",
+        "gpu", default=False, description="Use the MAGMA library " "for GPU accelerated computation"
     )
     variant(
         "mbd",
@@ -78,9 +74,7 @@ class Dftbplus(CMakePackage, MakefilePackage):
     )
     variant("mpi", default=False, description="Whether DFTB+ should support MPI-parallelism.")
     variant(
-        "openmp",
-        default=True,
-        description="Whether OpenMP thread parallisation should be enabled.",
+        "openmp", default=True, description="Whether OpenMP thread parallisation should be enabled."
     )
     variant(
         "plumed",
@@ -183,13 +177,9 @@ class Dftbplus(CMakePackage, MakefilePackage):
             mconfig.filter("WITH_GPU := .*", "WITH_GPU := 1")
 
         if "+mpi" in self.spec:
-            march.filter(
-                "SCALAPACKDIR = .*", "SCALAPACKDIR = {0}".format(spec["scalapack"].prefix)
-            )
+            march.filter("SCALAPACKDIR = .*", "SCALAPACKDIR = {0}".format(spec["scalapack"].prefix))
 
-            march.filter(
-                "LIB_LAPACK = -l.*", "LIB_LAPACK = {0}".format(spec["blas"].libs.ld_flags)
-            )
+            march.filter("LIB_LAPACK = -l.*", "LIB_LAPACK = {0}".format(spec["blas"].libs.ld_flags))
 
             march.filter("mpifort", "{0}".format(spec["mpi"].mpifc))
 
@@ -201,20 +191,15 @@ class Dftbplus(CMakePackage, MakefilePackage):
                 has_pexsi = "+enable_pexsi" in spec["elsi"]
 
                 mconfig.filter(
-                    "WITH_PEXSI := .*",
-                    "WITH_PEXSI := {0}".format("1" if has_pexsi is True else "0"),
+                    "WITH_PEXSI := .*", "WITH_PEXSI := {0}".format("1" if has_pexsi is True else "0")
                 )
 
-                march.filter(
-                    "ELSIINCDIR .*", "ELSIINCDIR = {0}".format(spec["elsi"].prefix.include)
-                )
+                march.filter("ELSIINCDIR .*", "ELSIINCDIR = {0}".format(spec["elsi"].prefix.include))
 
                 march.filter("ELSIDIR .*", "ELSIDIR = {0}".format(spec["elsi"].prefix))
 
         else:
-            march.filter(
-                "LIB_LAPACK += -l.*", "LIB_LAPACK += {0}".format(spec["blas"].libs.ld_flags)
-            )
+            march.filter("LIB_LAPACK += -l.*", "LIB_LAPACK += {0}".format(spec["blas"].libs.ld_flags))
 
         if "+sockets" in self.spec:
             mconfig.filter("WITH_SOCKETS := .*", "WITH_SOCKETS := 1")

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -49,8 +49,7 @@ class LlvmAmdgpu(CMakePackage):
         "rocm-device-libs",
         default=True,
         description=(
-            "Build ROCm device libs as external LLVM project instead of a "
-            "standalone spack package."
+            "Build ROCm device libs as external LLVM project instead of a " "standalone spack package."
         ),
     )
     variant(
@@ -60,9 +59,7 @@ class LlvmAmdgpu(CMakePackage):
         "components in a single shared library",
     )
     variant(
-        "link_llvm_dylib",
-        default=False,
-        description="Link LLVM tools against the LLVM shared library",
+        "link_llvm_dylib", default=False, description="Link LLVM tools against the LLVM shared library"
     )
 
     provides("libllvm@14", when="@5:5.2")

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -533,9 +533,7 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
         lib_search_dirs.extend(d for libs in extra_libs for d in libs.directories)
         # Remove duplicates and system prefixes:
         lib_search_dirs = filter_system_paths(dedupe(lib_search_dirs))
-        config_args.append(
-            "LDFLAGS={0}".format(" ".join("-L{0}".format(d) for d in lib_search_dirs))
-        )
+        config_args.append("LDFLAGS={0}".format(" ".join("-L{0}".format(d) for d in lib_search_dirs)))
 
         extra_lib_names = [n for libs in extra_libs for n in libs.names]
         # Remove duplicates in the reversed order:

--- a/var/spack/repos/builtin/packages/nlcglib/package.py
+++ b/var/spack/repos/builtin/packages/nlcglib/package.py
@@ -53,8 +53,7 @@ class Nlcglib(CMakePackage, CudaPackage, ROCmPackage):
 
     for arch in CudaPackage.cuda_arch_values:
         depends_on(
-            f"kokkos+cuda+cuda_lambda+wrapper cuda_arch={arch}",
-            when=f"%gcc +cuda cuda_arch={arch}",
+            f"kokkos+cuda+cuda_lambda+wrapper cuda_arch={arch}", when=f"%gcc +cuda cuda_arch={arch}"
         )
         depends_on(f"kokkos+cuda cuda_arch={arch}", when=f"+cuda cuda_arch={arch}")
 
@@ -100,8 +99,6 @@ class Nlcglib(CMakePackage, CudaPackage, ROCmPackage):
             options.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
             archs = ",".join(self.spec.variants["amdgpu_target"].value)
             options.append("-DHIP_HCC_FLAGS=--amdgpu-target={0}".format(archs))
-            options.append(
-                "-DCMAKE_CXX_FLAGS=--amdgpu-target={0} --offload-arch={0}".format(archs)
-            )
+            options.append("-DCMAKE_CXX_FLAGS=--amdgpu-target={0} --offload-arch={0}".format(archs))
 
         return options

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -235,7 +235,9 @@ class PySetuptools(Package, PythonExtension):
     depends_on("py-pip", type="build")
 
     def url_for_version(self, version):
-        url = "https://files.pythonhosted.org/packages/{0}/s/setuptools/setuptools-{1}-{0}-none-any.whl"
+        url = (
+            "https://files.pythonhosted.org/packages/{0}/s/setuptools/setuptools-{1}-{0}-none-any.whl"
+        )
 
         if version >= Version("45.1.0"):
             python_tag = "py3"

--- a/var/spack/repos/builtin/packages/rocm-smi-lib/package.py
+++ b/var/spack/repos/builtin/packages/rocm-smi-lib/package.py
@@ -64,9 +64,7 @@ class RocmSmiLib(CMakePackage):
     def determine_version(cls, lib):
         match = re.search(r"lib\S*\.so\.\d+\.\d+\.(\d)(\d\d)(\d\d)", lib)
         if match:
-            return "{0}.{1}.{2}".format(
-                int(match.group(1)), int(match.group(2)), int(match.group(3))
-            )
+            return "{0}.{1}.{2}".format(int(match.group(1)), int(match.group(2)), int(match.group(3)))
         return None
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/rpp/package.py
+++ b/var/spack/repos/builtin/packages/rpp/package.py
@@ -52,9 +52,7 @@ class Rpp(CMakePackage):
     variant("hip", default=True, description="Use HIP as backend")
     variant("cpu", default=False, description="Use CPU as backend")
     variant(
-        "add_tests",
-        default=False,
-        description="add utilities folder which contains rpp unit tests",
+        "add_tests", default=False, description="add utilities folder which contains rpp unit tests"
     )
 
     patch("0001-include-half-openmp-through-spack-package.patch", when="@:5.7")
@@ -72,10 +70,7 @@ class Rpp(CMakePackage):
             )
         if self.spec.satisfies("+opencl"):
             filter_file(
-                "${ROCM_PATH}",
-                self.spec["rocm-opencl"].prefix,
-                "cmake/FindOpenCL.cmake",
-                string=True,
+                "${ROCM_PATH}", self.spec["rocm-opencl"].prefix, "cmake/FindOpenCL.cmake", string=True
             )
         if self.spec.satisfies("+add_tests"):
             filter_file(
@@ -146,9 +141,7 @@ class Rpp(CMakePackage):
             args.append(self.define("BACKEND", "HIP"))
             args.append(self.define("HIP_PATH", spec["hip"].prefix))
             args.append(
-                self.define(
-                    "COMPILER_FOR_HIP", "{0}/bin/clang++".format(spec["llvm-amdgpu"].prefix)
-                )
+                self.define("COMPILER_FOR_HIP", "{0}/bin/clang++".format(spec["llvm-amdgpu"].prefix))
             )
         return args
 

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -192,11 +192,7 @@ class Scorep(AutotoolsPackage):
 
         if spec.satisfies("^intel-mpi"):
             config_args.append("--with-mpi=intel3")
-        elif (
-            spec.satisfies("^mpich")
-            or spec.satisfies("^mvapich2")
-            or spec.satisfies("^cray-mpich")
-        ):
+        elif spec.satisfies("^mpich") or spec.satisfies("^mvapich2") or spec.satisfies("^cray-mpich"):
             config_args.append("--with-mpi=mpich3")
         elif spec.satisfies("^openmpi"):
             config_args.append("--with-mpi=openmpi")

--- a/var/spack/repos/builtin/packages/sgpp/package.py
+++ b/var/spack/repos/builtin/packages/sgpp/package.py
@@ -62,9 +62,7 @@ class Sgpp(SConsPackage):
     variant("misc", default=False, description="Builds the misc module of SGpp")
     variant("combigrid", default=False, description="Builds the combigrid module of SGpp")
     variant("solver", default=True, description="Builds the solver module of SGpp")
-    variant(
-        "opencl", default=False, description="Enables support for OpenCL accelerated operations"
-    )
+    variant("opencl", default=False, description="Enables support for OpenCL accelerated operations")
     variant("mpi", default=False, description="Enables support for MPI-distributed operations")
 
     # Mandatory dependencies


### PR DESCRIPTION
The 99 line length is considered objectively correct. At least at that point in
time where it was determined.

Now that we have `with default_args(...):` it's a bit annoying that deprecating
`n` versions often results in `3n` lines of change:

```python
version("1.20.3", ...)
version("1.20.2", ...)

# With 6 character versions + sha256, this happens:

with default_args(...):
    version(
        "1.20.3", ...
    )
    version(
        "1.20.2", ...
    )

# I want this:

with default_args(...):
    version("1.20.3", ...)
    version("1.20.2", ...)
```

See for example #43261 where I'm getting a +300 -100 PR just deprecating stuff.


