### PR TITLE
asp.py: log error instead of throwing when unsatisfied after solve

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -826,7 +826,7 @@ class PyclingoDriver:
         if result.satisfiable and result.unsolved_specs and setup.concretize_everything:
             tty.error(
                 "resolved spec does not satisfy input spec, which may be caused by a bug in the "
-                " solver. Please open an issue at https://github.com/spack/spack/issues\n\t"
+                "solver. Please open an issue at https://github.com/spack/spack/issues\n\t"
                 f"{Result.format_unsolved(result.unsolved_specs)}"
             )
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -824,11 +824,10 @@ class PyclingoDriver:
             pprint.pprint(self.control.statistics)
 
         if result.satisfiable and result.unsolved_specs and setup.concretize_everything:
-            unsolved_str = Result.format_unsolved(result.unsolved_specs)
-            raise InternalConcretizerError(
-                "Internal Spack error: the solver completed but produced specs"
-                " that do not satisfy the request. Please report a bug at "
-                f"https://github.com/spack/spack/issues\n\t{unsolved_str}"
+            tty.error(
+                "resolved spec does not satisfy input spec, which may be caused by a bug in the "
+                " solver. Please open an issue at https://github.com/spack/spack/issues\n\t"
+                f"{Result.format_unsolved(result.unsolved_specs)}"
             )
 
         return result, timer, self.control.statistics

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2096,10 +2096,8 @@ class TestConcretize:
         assert result.specs
 
     @pytest.mark.regression("38664")
-    def test_unsolved_specs_raises_error(self, monkeypatch, mock_packages, config):
-        """Check that the solver raises an exception when input specs are not
-        satisfied.
-        """
+    def test_unsolved_specs_logs_error(self, monkeypatch, mock_packages, config, capfd):
+        """Check that the solver logs an error when input specs are not satisfied."""
         specs = [Spec("zlib")]
         solver = spack.solver.asp.Solver()
         setup = spack.solver.asp.SpackSolverSetup()
@@ -2108,11 +2106,9 @@ class TestConcretize:
 
         monkeypatch.setattr(spack.solver.asp.Result, "unsolved_specs", simulate_unsolved_property)
 
-        with pytest.raises(
-            spack.solver.asp.InternalConcretizerError,
-            match="the solver completed but produced specs",
-        ):
-            solver.driver.solve(setup, specs, reuse=[])
+        solver.driver.solve(setup, specs, reuse=[])
+
+        assert "resolved spec does not satisfy input spec" in capfd.readouterr().err
 
     @pytest.mark.regression("43141")
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")


### PR DESCRIPTION
Spack tests `output.satisfies(input)` to uncover solver bugs.

But the test itself has a few issues. One of them #43267, but
if I believe there are also certain bugs in `satisfies` w.r.t. multi-valued
variants, flags, virtuals, and partially concrete specs. 

Instead of throwing an exception, log an error, so users can ignore the
message when it's a false positive. That gives us a bit of time to resolve
the false positives as they are uncovered.