### PR TITLE
swig: update symlink alias to appease cmake

### DIFF
--- a/var/spack/repos/builtin/packages/swig/package.py
+++ b/var/spack/repos/builtin/packages/swig/package.py
@@ -148,7 +148,7 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
     def create_symlink(self):
         # CMake compatibility: see https://github.com/spack/spack/pull/6240
         with working_dir(self.prefix.bin):
-            os.symlink("swig", "swig{0}".format(self.spec.version.up_to(2)))
+            os.symlink("swig", "swig{0}.0".format(self.spec.version.up_to(1)))
 
     @when(Swig.AUTOCONF_VERSIONS)
     def autoreconf(self, pkg, spec, prefix):


### PR DESCRIPTION
FindSWIG.cmake prefers explicitly `swig4.0` to `swig`, which breaks finding `swig@x.y` where `y != 0`. For example, if I have `PATH=/opt/bin:/usr/bin` and there exists `/opt/bin/swig4.1`, `/opt/bin/swig`, `/usr/bin/swig4.0`, `/usr/bin/swig`, then
```cmake
find_package(SWIG 4.1)
```
will select `/usr/bin/swig4.0` because of a hardcoded list in CMake.

The stupid solution is to alias the install of swig@4.1 to an executable named 4.0.

This *reverts* a change I made in #12185 to "fix" what I thought was an error from #6240.

See https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5306.