### PR TITLE
Add libxt dependency to xv

### DIFF
--- a/var/spack/repos/builtin/packages/xv/package.py
+++ b/var/spack/repos/builtin/packages/xv/package.py
@@ -27,3 +27,4 @@ class Xv(CMakePackage):
     depends_on("libpng")
     depends_on("libtiff")
     depends_on("libx11")
+    depends_on("libxt")


### PR DESCRIPTION
The xv package depends on libxt and fails without it. https://github.com/jasper-software/xv/blob/main/CMakeLists.txt:137