### PR TITLE
Fix csh patch() for ncl

### DIFF
--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -132,6 +132,7 @@ class Ncl(Package):
 
     sanity_check_is_file = ["bin/ncl"]
 
+    @run_before("install")
     def patch(self):
         # Make configure scripts use Spack's tcsh
         files = ["Configure"] + glob.glob("config/*")


### PR DESCRIPTION
This PR adds `@run_before("install")` for the patch() function in the ncl recipe. Without this, on a system without /bin/csh, the build fails because the replacement doesn't get applied, so the Configure and config/* scripts can't run.