### PR TITLE
asp.py: allow no name & delay lookup to setup

### DIFF
--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -179,7 +179,7 @@ def test_force_uninstall_and_reinstall_by_hash(mutable_database):
     assert len(mpi_specs) == 3
 
     # Now, REINSTALL the spec and make sure everything still holds
-    install("--fake", "/%s" % dag_hash[:7])
+    install("--fake", f"/{dag_hash[:7]}")
 
     validate_callpath_spec(True)
 


### PR DESCRIPTION
This commit allows omiting a package name in environments

```
spack:
  specs:
  - /hash
  - zlig-ng
  concretizer:
    unify: true
```

and makes it such that abstract input specs do not expand the abstract
hash to a concrete spec in various places in the solver, which avoids
expensive operations (e.g. satisfies / hashing for dict on a large and no
longer entirely abstract spec)

Todo:

- [ ] Downside is that the generic implementation has an O(nm) loop to
  match input and output specs, which should really be avoided if the
  solver can just say what input spec an output belongs to.
- [ ] There is an early exit in `Spec`'s concretize function which now
  does not early exit because the abstract hash is kept abstract.

