### PR TITLE
Remove optimization criterion on OS mismatches

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1011,16 +1011,6 @@ node_os_weight(PackageNode, Weight)
     attr("node_os", PackageNode, OS),
     os(OS, Weight).
 
-% match semantics for OS's
-node_os_match(PackageNode, DependencyNode) :-
-   depends_on(PackageNode, DependencyNode),
-   attr("node_os", PackageNode, OS),
-   attr("node_os", DependencyNode, OS).
-
-node_os_mismatch(PackageNode, DependencyNode) :-
-   depends_on(PackageNode, DependencyNode),
-   not node_os_match(PackageNode, DependencyNode).
-
 % every OS is compatible with itself. We can use `os_compatible` to declare
 os_compatible(OS, OS) :- os(OS).
 
@@ -1506,16 +1496,6 @@ opt_criterion(39, "compiler mismatches that are not from CLI").
 #minimize{
     1@39+Priority,PackageNode,DependencyNode
     : compiler_mismatch_required(PackageNode, DependencyNode),
-      build_priority(PackageNode, Priority)
-}.
-
-% Try to minimize the number of compiler mismatches in the DAG.
-opt_criterion(35, "OS mismatches").
-#minimize{ 0@235: #true }.
-#minimize{ 0@35: #true }.
-#minimize{
-    1@35+Priority,PackageNode,DependencyNode
-    : node_os_mismatch(PackageNode, DependencyNode),
       build_priority(PackageNode, Priority)
 }.
 


### PR DESCRIPTION
The optimization on OS mismatches is redundant, since:
1. In most cases we have a single OS on the host
2. The OS that can be used on the host are determined by the `os_compatible` facts
3. We already weight each OS in another optimization criteria

This was introduced in 2c142f9dd4cf29220f6b2840f4d448c5c9d936f1 which was part of #25310 It seems the criterion on OS mismatches was introduced to be symmetric with target mismatches, but we can likely avoid that.