### PR TITLE
Update Intel download URLs

### DIFF
--- a/var/spack/repos/builtin/packages/intel-daal/package.py
+++ b/var/spack/repos/builtin/packages/intel-daal/package.py
@@ -20,121 +20,121 @@ class IntelDaal(IntelPackage):
     version(
         "2020.2.254",
         sha256="08528bc150dad312ff2ae88ce12d6078ed8ba2f378f4bf3daf0fbbb9657dce1e",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16822/l_daal_2020.2.254.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16822/l_daal_2020.2.254.tgz",
         deprecated=True,
     )
     version(
         "2020.1.217",
         sha256="3f84dea0ce1038ac1b9c25b3e2c02e9fac440fa36cc8adfce69edfc06fe0edda",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16536/l_daal_2020.1.217.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16536/l_daal_2020.1.217.tgz",
         deprecated=True,
     )
     version(
         "2020.0.166",
         sha256="695166c9ab32ac5d3006d6d35162db3c98734210507144e315ed7c3b7dbca9c1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16234/l_daal_2020.0.166.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16234/l_daal_2020.0.166.tgz",
         deprecated=True,
     )
     version(
         "2019.5.281",
         sha256="e92aaedbe35c9daf1c9483260cb2363da8a85fa1aa5566eb38cf4b1f410bc368",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15818/l_daal_2019.5.281.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15818/l_daal_2019.5.281.tgz",
         deprecated=True,
     )
     version(
         "2019.4.243",
         sha256="c74486a555ca5636c2ac1b060d5424726c022468f3ee0898bb46e333cda6f7b8",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15552/l_daal_2019.4.243.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15552/l_daal_2019.4.243.tgz",
         deprecated=True,
     )
     version(
         "2019.3.199",
         sha256="1f7d9cdecc1091b03f1ee6303fc7566179d1e3f1813a98ef7a6239f7d456b8ef",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15277/l_daal_2019.3.199.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15277/l_daal_2019.3.199.tgz",
         deprecated=True,
     )
     version(
         "2019.2.187",
         sha256="2982886347e9376e892a5c4e22fa1d4b7b843e1ae988a107dd2d0a639f257765",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15097/l_daal_2019.2.187.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15097/l_daal_2019.2.187.tgz",
         deprecated=True,
     )
     version(
         "2019.1.144",
         sha256="1672afac568c93e185283cf7e044d511381092ebc95d7204c4dccb83cc493197",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14869/l_daal_2019.1.144.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/14869/l_daal_2019.1.144.tgz",
         deprecated=True,
     )
     version(
         "2019.0.117",
         sha256="85ac8e983bc9b9cc635e87cb4ec775ffd3695e44275d20fdaf53c19ed280d69f",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13577/l_daal_2019.0.117.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13577/l_daal_2019.0.117.tgz",
         deprecated=True,
     )
     version(
         "2018.3.222",
         sha256="378fec529a36508dd97529037e1164ff98e0e062a9a47ede99ccf9e91493d1e2",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13007/l_daal_2018.3.222.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13007/l_daal_2018.3.222.tgz",
         deprecated=True,
     )
     version(
         "2018.2.199",
         sha256="cee30299b3ffaea515f5a9609f4df0f644579c8a1ba2b61747b390f6caf85b14",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12727/l_daal_2018.2.199.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12727/l_daal_2018.2.199.tgz",
         deprecated=True,
     )
     version(
         "2018.1.163",
         sha256="ac96b5a6c137cda18817d9b3505975863f8f53347225ebb6ccdaaf4bdb8dc349",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12414/l_daal_2018.1.163.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12414/l_daal_2018.1.163.tgz",
         deprecated=True,
     )
     version(
         "2018.0.128",
         sha256="d13a7cd1b6779971f2ba46797447de9409c98a4d2f0eb0dc9622d9d63ac8990f",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12072/l_daal_2018.0.128.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12072/l_daal_2018.0.128.tgz",
         deprecated=True,
     )
     version(
         "2017.4.239",
         sha256="cc4b608f59f3b2fafee16389102a763d27c46f6d136a6cfa89847418a8ea7460",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12148/l_daal_2017.4.239.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12148/l_daal_2017.4.239.tgz",
         deprecated=True,
     )
     version(
         "2017.3.196",
         sha256="cfa863f342dd1c5fe8f1c7b6fd69589140370fc92742a19d82c8594e4e1e46ce",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11546/l_daal_2017.3.196.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11546/l_daal_2017.3.196.tgz",
         deprecated=True,
     )
     version(
         "2017.2.174",
         sha256="5ee838b08d4cda7fc3e006e1deeed41671cbd7cfd11b64ec3b762c94dfc2b660",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11308/l_daal_2017.2.174.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11308/l_daal_2017.2.174.tgz",
         deprecated=True,
     )
     version(
         "2017.1.132",
         sha256="6281105d3947fc2860e67401ea0218198cc4753fd2d4b513528a89143248e4f3",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/10983/l_daal_2017.1.132.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/10983/l_daal_2017.1.132.tgz",
         deprecated=True,
     )
     version(
         "2017.0.098",
         sha256="a7064425653b4f5f0fe51e25358d267d8ae023179eece61e08da891b67d79fe5",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9664/l_daal_2017.0.098.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9664/l_daal_2017.0.098.tgz",
         deprecated=True,
     )
     version(
         "2016.3.210",
         sha256="367eaef21ea0143c11ae3fd56cd2a05315768c059e14caa15894bcf96853687c",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9099/l_daal_2016.3.210.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9099/l_daal_2016.3.210.tgz",
         deprecated=True,
     )
     version(
         "2016.2.181",
         sha256="afdb65768957784d28ac537b4933a86eb4193c68a636157caed17b29ccdbfacb",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8687/l_daal_2016.2.181.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/8687/l_daal_2016.2.181.tgz",
         deprecated=True,
     )
 

--- a/var/spack/repos/builtin/packages/intel-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-ipp/package.py
@@ -20,110 +20,110 @@ class IntelIpp(IntelPackage):
     version(
         "2020.2.254",
         sha256="18266ad1eec9b5b17e76da24f1aa9a9147300e5bd345e6bdad58d7187392fa77",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16846/l_ipp_2020.2.254.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16846/l_ipp_2020.2.254.tgz",
         deprecated=True,
     )
     version(
         "2020.1.217",
         sha256="0bf8ac7e635e7e602cf201063a1a7dea3779b093104563fdb15e6b7ecf2f00a7",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16534/l_ipp_2020.1.217.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16534/l_ipp_2020.1.217.tgz",
         deprecated=True,
     )
     version(
         "2020.0.166",
         sha256="6844007892ba524e828f245355cee44e8149f4c233abbbea16f7bb55a7d6ecff",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16233/l_ipp_2020.0.166.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16233/l_ipp_2020.0.166.tgz",
         deprecated=True,
     )
     version(
         "2019.5.281",
         sha256="61d1e1da1a4a50f1cf02a3ed44e87eed05e94d58b64ef1e67a3bdec363bee713",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15817/l_ipp_2019.5.281.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15817/l_ipp_2019.5.281.tgz",
         deprecated=True,
     )
     version(
         "2019.4.243",
         sha256="d4f4232323e66b010d8440c75189aeb6a3249966e05035242b21982238a7a7f2",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15541/l_ipp_2019.4.243.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15541/l_ipp_2019.4.243.tgz",
         deprecated=True,
     )
     version(
         "2019.3.199",
         sha256="02545383206c1ae4dd66bfa6a38e2e14480ba11932eeed632df8ab798aa15ccd",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15276/l_ipp_2019.3.199.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15276/l_ipp_2019.3.199.tgz",
         deprecated=True,
     )
     version(
         "2019.2.187",
         sha256="280e9081278a0db3892fe82474c1201ec780a6f7c8d1f896494867f4b3bd8421",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15096/l_ipp_2019.2.187.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15096/l_ipp_2019.2.187.tgz",
         deprecated=True,
     )
     version(
         "2019.1.144",
         sha256="1eb7cd0fba74615aeafa4e314c645414497eb73f1705200c524fe78f00620db3",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14887/l_ipp_2019.1.144.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/14887/l_ipp_2019.1.144.tgz",
         deprecated=True,
     )
     version(
         "2019.0.117",
         sha256="d552ba49fba58f0e94da2048176f21c5dfd490dca7c5ce666dfc2d18db7fd551",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13576/l_ipp_2019.0.117.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13576/l_ipp_2019.0.117.tgz",
         deprecated=True,
     )
     version(
         "2018.4.274",
         sha256="bdc6082c65410c98ccf6daf239e0a6625d15ec5e0ddc1c0563aad42b6ba9063c",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13726/l_ipp_2018.4.274.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13726/l_ipp_2018.4.274.tgz",
         deprecated=True,
     )
     version(
         "2018.3.222",
         sha256="bb783c5e6220e240f19136ae598cd1c1d647496495139ce680de58d3d5496934",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13006/l_ipp_2018.3.222.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13006/l_ipp_2018.3.222.tgz",
         deprecated=True,
     )
     version(
         "2018.2.199",
         sha256="55cb5c910b2c1e2bd798163fb5019b992b1259a0692e328bb9054778cf01562b",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12726/l_ipp_2018.2.199.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12726/l_ipp_2018.2.199.tgz",
         deprecated=True,
     )
     version(
         "2018.0.128",
         sha256="da568ceec1b7acbcc8f666b73d4092788b037b1b03c0436974b82155056ed166",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12071/l_ipp_2018.0.128.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12071/l_ipp_2018.0.128.tgz",
         deprecated=True,
     )
     version(
         "2017.3.196",
         sha256="50d49a1000a88a8a58bd610466e90ae28d07a70993a78cbbf85d44d27c4232b6",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11545/l_ipp_2017.3.196.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11545/l_ipp_2017.3.196.tgz",
         deprecated=True,
     )
     version(
         "2017.2.174",
         sha256="92f866c9dce8503d7e04223ec35f281cfeb0b81cf94208c3becb11aacfda7b99",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11307/l_ipp_2017.2.174.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11307/l_ipp_2017.2.174.tgz",
         deprecated=True,
     )
     version(
         "2017.1.132",
         sha256="2908bdeab3057d4ebcaa0b8ff5b00eb47425d35961a96f14780be68554d95376",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11031/l_ipp_2017.1.132.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11031/l_ipp_2017.1.132.tgz",
         deprecated=True,
     )
     version(
         "2017.0.098",
         sha256="7633d16e2578be64533892336c8a15c905139147b0f74eaf9f281358ad7cdcba",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9663/l_ipp_2017.0.098.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9663/l_ipp_2017.0.098.tgz",
         deprecated=True,
     )
     # built from parallel_studio_xe_2016.3.067
     version(
         "9.0.3.210",
         sha256="8ce7bf17f4a0bbf8c441063de26be7f6e0f6179789e23f24eaa8b712632b3cdd",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9067/l_ipp_9.0.3.210.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9067/l_ipp_9.0.3.210.tgz",
         deprecated=True,
     )
 

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -22,141 +22,141 @@ class IntelMkl(IntelPackage):
     version(
         "2020.4.304",
         sha256="2314d46536974dbd08f2a4e4f9e9a155dc7e79e2798c74e7ddfaad00a5917ea5",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16917/l_mkl_2020.4.304.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16917/l_mkl_2020.4.304.tgz",
         deprecated=True,
     )
     version(
         "2020.3.279",
         sha256="2b8e434ecc9462491130ba25a053927fd1a2eca05e12acb5936b08c486857a04",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16903/l_mkl_2020.3.279.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16903/l_mkl_2020.3.279.tgz",
         deprecated=True,
     )
     version(
         "2020.2.254",
         sha256="ed00a267af362a6c14212bd259ab1673d64337e077263033edeef8ac72c10223",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16849/l_mkl_2020.2.254.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16849/l_mkl_2020.2.254.tgz",
         deprecated=True,
     )
     version(
         "2020.1.217",
         sha256="082a4be30bf4f6998e4d6e3da815a77560a5e66a68e254d161ab96f07086066d",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16533/l_mkl_2020.1.217.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16533/l_mkl_2020.1.217.tgz",
         deprecated=True,
     )
     version(
         "2020.0.166",
         sha256="f6d92deb3ff10b11ba3df26b2c62bb4f0f7ae43e21905a91d553e58f0f5a8ae0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16232/l_mkl_2020.0.166.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16232/l_mkl_2020.0.166.tgz",
         deprecated=True,
     )
     version(
         "2019.5.281",
         sha256="9995ea4469b05360d509c9705e9309dc983c0a10edc2ae3a5384bc837326737e",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15816/l_mkl_2019.5.281.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15816/l_mkl_2019.5.281.tgz",
         deprecated=True,
     )
     version(
         "2019.4.243",
         sha256="fcac7b0369665d93f0c4dd98afe2816aeba5410e2b760655fe55fc477f8f33d0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15540/l_mkl_2019.4.243.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15540/l_mkl_2019.4.243.tgz",
         deprecated=True,
     )
     version(
         "2019.3.199",
         sha256="06de2b54f4812e7c39a118536259c942029fe1d6d8918ad9df558a83c4162b8f",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15275/l_mkl_2019.3.199.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15275/l_mkl_2019.3.199.tgz",
         deprecated=True,
     )
     version(
         "2019.2.187",
         sha256="2bf004e6b5adb4f956993d6c20ea6ce289bb630314dd501db7f2dd5b9978ed1d",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15095/l_mkl_2019.2.187.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15095/l_mkl_2019.2.187.tgz",
         deprecated=True,
     )
     version(
         "2019.1.144",
         sha256="5205a460a9c685f7a442868367389b2d0c25e1455346bc6a37c5b8ff90a20fbb",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14895/l_mkl_2019.1.144.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/14895/l_mkl_2019.1.144.tgz",
         deprecated=True,
     )
     version(
         "2019.0.117",
         sha256="4e1fe2c705cfc47050064c0d6c4dee1a8c6740ac1c4f64dde9c7511c4989c7ad",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13575/l_mkl_2019.0.117.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13575/l_mkl_2019.0.117.tgz",
         deprecated=True,
     )
     version(
         "2018.4.274",
         sha256="18eb3cde3e6a61a88f25afff25df762a560013f650aaf363f7d3d516a0d04881",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13725/l_mkl_2018.4.274.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13725/l_mkl_2018.4.274.tgz",
         deprecated=True,
     )
     version(
         "2018.3.222",
         sha256="108d59c0927e58ce8c314db6c2b48ee331c3798f7102725f425d6884eb6ed241",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13005/l_mkl_2018.3.222.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13005/l_mkl_2018.3.222.tgz",
         deprecated=True,
     )
     version(
         "2018.2.199",
         sha256="e28d12173bef9e615b0ded2f95f59a42b3e9ad0afa713a79f8801da2bfb31936",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12725/l_mkl_2018.2.199.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12725/l_mkl_2018.2.199.tgz",
         deprecated=True,
     )
     version(
         "2018.1.163",
         sha256="f6dc263fc6f3c350979740a13de1b1e8745d9ba0d0f067ece503483b9189c2ca",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12414/l_mkl_2018.1.163.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12414/l_mkl_2018.1.163.tgz",
         deprecated=True,
     )
     version(
         "2018.0.128",
         sha256="c368baa40ca88057292512534d7fad59fa24aef06da038ea0248e7cd1e280cec",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12070/l_mkl_2018.0.128.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12070/l_mkl_2018.0.128.tgz",
         deprecated=True,
     )
     version(
         "2017.4.239",
         sha256="dcac591ed1e95bd72357fd778edba215a7eab9c6993236373231cc16c200c92a",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12147/l_mkl_2017.4.239.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12147/l_mkl_2017.4.239.tgz",
         deprecated=True,
     )
     version(
         "2017.3.196",
         sha256="fd7295870fa164d6138c9818304f25f2bb263c814a6c6539c9fe4e104055f1ca",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11544/l_mkl_2017.3.196.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11544/l_mkl_2017.3.196.tgz",
         deprecated=True,
     )
     version(
         "2017.2.174",
         sha256="0b8a3fd6bc254c3c3d9d51acf047468c7f32bf0baff22aa1e064d16d9fea389f",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11306/l_mkl_2017.2.174.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11306/l_mkl_2017.2.174.tgz",
         deprecated=True,
     )
     version(
         "2017.1.132",
         sha256="8c6bbeac99326d59ef3afdc2a95308c317067efdaae50240d2f4a61f37622e69",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11024/l_mkl_2017.1.132.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11024/l_mkl_2017.1.132.tgz",
         deprecated=True,
     )
     version(
         "2017.0.098",
         sha256="f2233e8e011f461d9c15a853edf7ed0ae8849aa665a1ec765c1ff196fd70c4d9",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9662/l_mkl_2017.0.098.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9662/l_mkl_2017.0.098.tgz",
         deprecated=True,
     )
     # built from parallel_studio_xe_2016.3.x
     version(
         "11.3.3.210",
         sha256="ff858f0951fd698e9fb30147ea25a8a810c57f0126c8457b3b0cdf625ea43372",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9068/l_mkl_11.3.3.210.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9068/l_mkl_11.3.3.210.tgz",
         deprecated=True,
     )
     # built from parallel_studio_xe_2016.2.062
     version(
         "11.3.2.181",
         sha256="bac04a07a1fe2ae4996a67d1439ee90c54f31305e8663d1ccfce043bed84fc27",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8711/l_mkl_11.3.2.181.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/8711/l_mkl_11.3.2.181.tgz",
         deprecated=True,
     )
 

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -17,128 +17,128 @@ class IntelMpi(IntelPackage):
     version(
         "2019.10.317",
         sha256="28e1b615e63d2170a99feedc75e3b0c5a7e1a07dcdaf0a4181831b07817a5346",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/17534/l_mpi_2019.10.317.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/17534/l_mpi_2019.10.317.tgz",
         deprecated=True,
     )
     version(
         "2019.9.304",
         sha256="618a5dc2de54306645e6428c5eb7d267b54b11b5a83dfbcad7d0f9e0d90bb2e7",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/17263/l_mpi_2019.9.304.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/17263/l_mpi_2019.9.304.tgz",
         deprecated=True,
     )
     version(
         "2019.8.254",
         sha256="fa163b4b79bd1b7509980c3e7ad81b354fc281a92f9cf2469bf4d323899567c0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16814/l_mpi_2019.8.254.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16814/l_mpi_2019.8.254.tgz",
         deprecated=True,
     )
     version(
         "2019.7.217",
         sha256="90383b0023f84ac003a55d8bb29dbcf0c639f43a25a2d8d8698a16e770ac9c07",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16546/l_mpi_2019.7.217.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16546/l_mpi_2019.7.217.tgz",
         deprecated=True,
     )
     version(
         "2019.6.166",
         sha256="119be69f1117c93a9e5e9b8b4643918e55d2a55a78ad9567f77d16cdaf18cd6e",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16120/l_mpi_2019.6.166.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16120/l_mpi_2019.6.166.tgz",
         deprecated=True,
     )
     version(
         "2019.5.281",
         sha256="9c59da051f1325b221e5bc4d8b689152e85d019f143069fa39e17989306811f4",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15838/l_mpi_2019.5.281.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15838/l_mpi_2019.5.281.tgz",
         deprecated=True,
     )
     version(
         "2019.4.243",
         sha256="233a8660b92ecffd89fedd09f408da6ee140f97338c293146c9c080a154c5fcd",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15553/l_mpi_2019.4.243.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15553/l_mpi_2019.4.243.tgz",
         deprecated=True,
     )
     version(
         "2019.3.199",
         sha256="5304346c863f64de797250eeb14f51c5cfc8212ff20813b124f20e7666286990",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15260/l_mpi_2019.3.199.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15260/l_mpi_2019.3.199.tgz",
         deprecated=True,
     )
     version(
         "2019.2.187",
         sha256="6a3305933b5ef9e3f7de969e394c91620f3fa4bb815a4f439577739d04778b20",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15040/l_mpi_2019.2.187.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15040/l_mpi_2019.2.187.tgz",
         deprecated=True,
     )
     version(
         "2019.1.144",
         sha256="dac86a5db6b86503313742b17535856a432955604f7103cb4549a9bfc256c3cd",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14879/l_mpi_2019.1.144.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/14879/l_mpi_2019.1.144.tgz",
         deprecated=True,
     )
     version(
         "2019.0.117",
         sha256="dfb403f49c1af61b337aa952b71289c7548c3a79c32c57865eab0ea0f0e1bc08",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13584/l_mpi_2019.0.117.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13584/l_mpi_2019.0.117.tgz",
         deprecated=True,
     )
     version(
         "2018.4.274",
         sha256="a1114b3eb4149c2f108964b83cad02150d619e50032059d119ac4ffc9d5dd8e0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13741/l_mpi_2018.4.274.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13741/l_mpi_2018.4.274.tgz",
         deprecated=True,
     )
     version(
         "2018.3.222",
         sha256="5021d14b344fc794e89f146e4d53d70184d7048610895d7a6a1e8ac0cf258999",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13112/l_mpi_2018.3.222.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13112/l_mpi_2018.3.222.tgz",
         deprecated=True,
     )
     version(
         "2018.2.199",
         sha256="0927f1bff90d10974433ba2892e3fd38e6fee5232ab056a9f9decf565e814460",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12748/l_mpi_2018.2.199.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12748/l_mpi_2018.2.199.tgz",
         deprecated=True,
     )
     version(
         "2018.1.163",
         sha256="130b11571c3f71af00a722fa8641db5a1552ac343d770a8304216d8f5d00e75c",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12414/l_mpi_2018.1.163.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12414/l_mpi_2018.1.163.tgz",
         deprecated=True,
     )
     version(
         "2018.0.128",
         sha256="debaf2cf80df06db9633dfab6aa82213b84a665a55ee2b0178403906b5090209",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12120/l_mpi_2018.0.128.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12120/l_mpi_2018.0.128.tgz",
         deprecated=True,
     )
     version(
         "2017.4.239",
         sha256="5a1048d284dce8bc75b45789471c83c94b3c59f8f159cab43d783fc44302510b",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12209/l_mpi_2017.4.239.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12209/l_mpi_2017.4.239.tgz",
         deprecated=True,
     )
     version(
         "2017.3.196",
         sha256="dad9efbc5bbd3fd27cce7e1e2507ad77f342d5ecc929747ae141c890e7fb87f0",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11595/l_mpi_2017.3.196.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11595/l_mpi_2017.3.196.tgz",
         deprecated=True,
     )
     version(
         "2017.2.174",
         sha256="106a4b362c13ddc6978715e50f5f81c58c1a4c70cd2d20a99e94947b7e733b88",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11334/l_mpi_2017.2.174.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11334/l_mpi_2017.2.174.tgz",
         deprecated=True,
     )
     version(
         "2017.1.132",
         sha256="8d30a63674fe05f17b0a908a9f7d54403018bfed2de03c208380b171ab99be82",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11014/l_mpi_2017.1.132.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11014/l_mpi_2017.1.132.tgz",
         deprecated=True,
     )
     # built from parallel_studio_xe_2016.3.068
     version(
         "5.1.3.223",
         sha256="544f4173b09609beba711fa3ba35567397ff3b8390e4f870a3307f819117dd9b",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9278/l_mpi_p_5.1.3.223.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9278/l_mpi_p_5.1.3.223.tgz",
         deprecated=True,
     )
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
@@ -50,37 +50,37 @@ class IntelOneapiAdvisor(IntelOneApiLibraryPackageWithSdk):
     )
     version(
         "2023.0.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19094/l_oneapi_advisor_p_2023.0.0.25338_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19094/l_oneapi_advisor_p_2023.0.0.25338_offline.sh",
         sha256="5d8ef163f70ee3dc42b13642f321d974f49915d55914ba1ca9177ed29b100b9d",
         expand=False,
     )
     version(
         "2022.3.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18985/l_oneapi_advisor_p_2022.3.1.15323_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18985/l_oneapi_advisor_p_2022.3.1.15323_offline.sh",
         sha256="f05b58c2f13972b3ac979e4796bcc12a234b1e077400b5d00fc5df46cd228899",
         expand=False,
     )
     version(
         "2022.3.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18872/l_oneapi_advisor_p_2022.3.0.8704_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18872/l_oneapi_advisor_p_2022.3.0.8704_offline.sh",
         sha256="ae1e542e6030b04f70f3b9831b5e92def97ce4692c974da44e7e9d802f25dfa7",
         expand=False,
     )
     version(
         "2022.1.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18730/l_oneapi_advisor_p_2022.1.0.171_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18730/l_oneapi_advisor_p_2022.1.0.171_offline.sh",
         sha256="b627dbfefa779b44e7ab40dfa37614e56caa6e245feaed402d51826e6a7cb73b",
         expand=False,
     )
     version(
         "2022.0.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18369/l_oneapi_advisor_p_2022.0.0.92_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18369/l_oneapi_advisor_p_2022.0.0.92_offline.sh",
         sha256="f1c4317c2222c56fb2e292513f7eec7ec27eb1049d3600cb975bc08ed1477993",
         expand=False,
     )
     version(
         "2021.4.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18220/l_oneapi_advisor_p_2021.4.0.389_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18220/l_oneapi_advisor_p_2021.4.0.389_offline.sh",
         sha256="dd948f7312629d9975e12a57664f736b8e011de948771b4c05ad444438532be8",
         expand=False,
     )

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -59,61 +59,61 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
     )
     version(
         "2021.8.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19135/l_oneapi_ccl_p_2021.8.0.25371_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19135/l_oneapi_ccl_p_2021.8.0.25371_offline.sh",
         sha256="c660405fcc29bddd5bf9371b8e586c597664fb1ae59eb17cb02685cc662db82c",
         expand=False,
     )
     version(
         "2021.7.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19029/l_oneapi_ccl_p_2021.7.1.16948_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19029/l_oneapi_ccl_p_2021.7.1.16948_offline.sh",
         sha256="daab05a0779db343b600253df8fea93ab0ed20bd630d89883dd651b6b540b1b2",
         expand=False,
     )
     version(
         "2021.7.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18891/l_oneapi_ccl_p_2021.7.0.8733_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18891/l_oneapi_ccl_p_2021.7.0.8733_offline.sh",
         sha256="a0e64db03868081fe075afce8abf4cb94236effc6c52e5049118cfb2ef81a6c7",
         expand=False,
     )
     version(
         "2021.6.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18697/l_oneapi_ccl_p_2021.6.0.568.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18697/l_oneapi_ccl_p_2021.6.0.568.sh",
         sha256="e3c50c9cbeb350e8f28488b2e8fee54156116548db8010bb2c2443048715d3ea",
         expand=False,
     )
     version(
         "2021.5.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18472/l_oneapi_ccl_p_2021.5.1.494_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18472/l_oneapi_ccl_p_2021.5.1.494_offline.sh",
         sha256="237f45d3c43447460e36eb7d68ae3bf611aa282015e57c7fe06c2004d368a68e",
         expand=False,
     )
     version(
         "2021.5.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18371/l_oneapi_ccl_p_2021.5.0.478_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18371/l_oneapi_ccl_p_2021.5.0.478_offline.sh",
         sha256="47584ad0269fd13bcfbc2cd0bb029bdcc02b723070abcb3d5e57f9586f4e74f8",
         expand=False,
     )
     version(
         "2021.4.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18188/l_oneapi_ccl_p_2021.4.0.433_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18188/l_oneapi_ccl_p_2021.4.0.433_offline.sh",
         sha256="004031629d97ef99267d8ea962b666dc4be1560d7d32bd510f97bc81d9251ef6",
         expand=False,
     )
     version(
         "2021.3.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17920/l_oneapi_ccl_p_2021.3.0.343_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17920/l_oneapi_ccl_p_2021.3.0.343_offline.sh",
         sha256="0bb63e2077215cc161973b2e5029919c55e84aea7620ee9a848f6c2cc1245e3f",
         expand=False,
     )
     version(
         "2021.2.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17731/l_oneapi_ccl_p_2021.2.0.269_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17731/l_oneapi_ccl_p_2021.2.0.269_offline.sh",
         sha256="18b7875030243295b75471e235e91e5f7b4fc15caf18c07d941a6d47fba378d7",
         expand=False,
     )
     version(
         "2021.1.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17391/l_oneapi_ccl_p_2021.1.1.54_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17391/l_oneapi_ccl_p_2021.1.1.54_offline.sh",
         sha256="de732df57a03763a286106c8b885fd60e83d17906936a8897a384b874e773f49",
         expand=False,
     )

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -100,110 +100,110 @@ versions = [
     {
         "version": "2023.0.0",
         "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/19123/l_dpcpp-cpp-compiler_p_2023.0.0.25393_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19123/l_dpcpp-cpp-compiler_p_2023.0.0.25393_offline.sh",
             "sha256": "473eb019282c2735d65c6058f6890e60b79a5698ae18d2c1e4489fed8dd18a02",
         },
         "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/19105/l_fortran-compiler_p_2023.0.0.25394_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19105/l_fortran-compiler_p_2023.0.0.25394_offline.sh",
             "sha256": "fd7525bf90646c8e43721e138f29c9c6f99e96dfe5648c13633f30ec64ac8b1b",
         },
     },
     {
         "version": "2022.2.1",
         "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/19049/l_dpcpp-cpp-compiler_p_2022.2.1.16991_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19049/l_dpcpp-cpp-compiler_p_2022.2.1.16991_offline.sh",
             "sha256": "3f0f02f9812a0cdf01922d2df9348910c6a4cb4f9dfe50fc7477a59bbb1f7173",
         },
         "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/18998/l_fortran-compiler_p_2022.2.1.16992_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18998/l_fortran-compiler_p_2022.2.1.16992_offline.sh",
             "sha256": "64f1d1efbcdc3ac2182bec18313ca23f800d94f69758db83a1394490d9d4b042",
         },
     },
     {
         "version": "2022.2.0",
         "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/18849/l_dpcpp-cpp-compiler_p_2022.2.0.8772_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18849/l_dpcpp-cpp-compiler_p_2022.2.0.8772_offline.sh",
             "sha256": "8ca97f7ea8abf7876df6e10ce2789ea8cbc310c100ad7bf0b5ffccc4f3c7f2c9",
         },
         "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/18909/l_fortran-compiler_p_2022.2.0.8773_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18909/l_fortran-compiler_p_2022.2.0.8773_offline.sh",
             "sha256": "4054e4bf5146d55638d21612396a19ea623d22cbb8ac63c0a7150773541e0311",
         },
     },
     {
         "version": "2022.1.0",
         "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/18717/l_dpcpp-cpp-compiler_p_2022.1.0.137_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18717/l_dpcpp-cpp-compiler_p_2022.1.0.137_offline.sh",
             "sha256": "1027819581ba820470f351abfc2b2658ff2684ed8da9ed0e722a45774a2541d6",
         },
         "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/18703/l_fortran-compiler_p_2022.1.0.134_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18703/l_fortran-compiler_p_2022.1.0.134_offline.sh",
             "sha256": "583082abe54a657eb933ea4ba3e988eef892985316be13f3e23e18a3c9515020",
         },
     },
     {
         "version": "2022.0.2",
         "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/18478/l_dpcpp-cpp-compiler_p_2022.0.2.84_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18478/l_dpcpp-cpp-compiler_p_2022.0.2.84_offline.sh",
             "sha256": "ade5bbd203e7226ca096d7bf758dce07857252ec54e83908cac3849e6897b8f3",
         },
         "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/18481/l_fortran-compiler_p_2022.0.2.83_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18481/l_fortran-compiler_p_2022.0.2.83_offline.sh",
             "sha256": "78532b4118fc3d7afd44e679fc8e7aed1e84efec0d892908d9368e0c7c6b190c",
         },
     },
     {
         "version": "2022.0.1",
         "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/18435/l_dpcpp-cpp-compiler_p_2022.0.1.71_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18435/l_dpcpp-cpp-compiler_p_2022.0.1.71_offline.sh",
             "sha256": "c7cddc64c3040eece2dcaf48926ba197bb27e5a46588b1d7b3beddcdc379926a",
         },
         "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/18436/l_fortran-compiler_p_2022.0.1.70_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18436/l_fortran-compiler_p_2022.0.1.70_offline.sh",
             "sha256": "2cb28a04f93554bfeffd6cad8bd0e7082735f33d73430655dea86df8933f50d1",
         },
     },
     {
         "version": "2021.4.0",
         "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/18209/l_dpcpp-cpp-compiler_p_2021.4.0.3201_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18209/l_dpcpp-cpp-compiler_p_2021.4.0.3201_offline.sh",
             "sha256": "9206bff1c2fdeb1ca0d5f79def90dcf3e6c7d5711b9b5adecd96a2ba06503828",
         },
         "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/18210/l_fortran-compiler_p_2021.4.0.3224_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18210/l_fortran-compiler_p_2021.4.0.3224_offline.sh",
             "sha256": "de2fcf40e296c2e882e1ddf2c45bb8d25aecfbeff2f75fcd7494068d621eb7e0",
         },
     },
     {
         "version": "2021.3.0",
         "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/17928/l_dpcpp-cpp-compiler_p_2021.3.0.3168_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17928/l_dpcpp-cpp-compiler_p_2021.3.0.3168_offline.sh",
             "sha256": "f848d81b7cabc76c2841c9757abb2290921efd7b82491d830605f5785600e7a1",
         },
         "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/17959/l_fortran-compiler_p_2021.3.0.3168_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17959/l_fortran-compiler_p_2021.3.0.3168_offline.sh",
             "sha256": "c4553f7e707be8e8e196f625e4e7fbc8eff5474f64ab85fc7146b5ed53ebc87c",
         },
     },
     {
         "version": "2021.2.0",
         "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/17749/l_dpcpp-cpp-compiler_p_2021.2.0.118_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17749/l_dpcpp-cpp-compiler_p_2021.2.0.118_offline.sh",
             "sha256": "5d01cbff1a574c3775510cd97ffddd27fdf56d06a6b0c89a826fb23da4336d59",
         },
         "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/17756/l_fortran-compiler_p_2021.2.0.136_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17756/l_fortran-compiler_p_2021.2.0.136_offline.sh",
             "sha256": "a62e04a80f6d2f05e67cd5acb03fa58857ee22c6bd581ec0651c0ccd5bdec5a1",
         },
     },
     {
         "version": "2021.1.2",
         "cpp": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/17513/l_dpcpp-cpp-compiler_p_2021.1.2.63_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17513/l_dpcpp-cpp-compiler_p_2021.1.2.63_offline.sh",
             "sha256": "68d6cb638091990e578e358131c859f3bbbbfbf975c581fd0b4b4d36476d6f0a",
         },
         "ftn": {
-            "url": "https://registrationcenter-download.intel.com/akdlm/irc_nas/17508/l_fortran-compiler_p_2021.1.2.62_offline.sh",
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17508/l_fortran-compiler_p_2021.1.2.62_offline.sh",
             "sha256": "29345145268d08a59fa7eb6e58c7522768466dd98f6d9754540d1a0803596829",
         },
     },

--- a/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
@@ -46,61 +46,61 @@ class IntelOneapiDal(IntelOneApiLibraryPackage):
     )
     version(
         "2023.0.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19122/l_daal_oneapi_p_2023.0.0.25395_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19122/l_daal_oneapi_p_2023.0.0.25395_offline.sh",
         sha256="83d0ca7501c882bf7e1f250e7310dafa6b6fd404858298ce9cde7546654d43bc",
         expand=False,
     )
     version(
         "2021.7.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19032/l_daal_oneapi_p_2021.7.1.16996_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19032/l_daal_oneapi_p_2021.7.1.16996_offline.sh",
         sha256="2328927480b0ba5d380028f981717b63ee323f8a1616a491a160a0a0b239e285",
         expand=False,
     )
     version(
         "2021.7.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18895/l_daal_oneapi_p_2021.7.0.8746_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18895/l_daal_oneapi_p_2021.7.0.8746_offline.sh",
         sha256="c18e68df120c2b1db17877cfcbb1b5c93a47b2f4756a3444c663d0f03be4eee3",
         expand=False,
     )
     version(
         "2021.6.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18698/l_daal_oneapi_p_2021.6.0.915_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18698/l_daal_oneapi_p_2021.6.0.915_offline.sh",
         sha256="bc9a430f372a5f9603c19ec25207c83ffd9d59fe517599c734d465e32afc9790",
         expand=False,
     )
     version(
         "2021.5.3",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18480/l_daal_oneapi_p_2021.5.3.832_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18480/l_daal_oneapi_p_2021.5.3.832_offline.sh",
         sha256="6d3503cf7be2908bbb7bd18e67b8f2e96ad9aec53d4813c9be620adaa2db390f",
         expand=False,
     )
     version(
         "2021.5.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18432/l_daal_oneapi_p_2021.5.1.803_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18432/l_daal_oneapi_p_2021.5.1.803_offline.sh",
         sha256="bba7bee3caef14fbb54ad40615222e5da429496455edf7375f11fd84a72c87ba",
         expand=False,
     )
     version(
         "2021.4.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18218/l_daal_oneapi_p_2021.4.0.729_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18218/l_daal_oneapi_p_2021.4.0.729_offline.sh",
         sha256="61da9d2a40c75edadff65d052fd84ef3db1da5d94f86ad3956979e6988549dda",
         expand=False,
     )
     version(
         "2021.3.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17905/l_daal_oneapi_p_2021.3.0.557_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17905/l_daal_oneapi_p_2021.3.0.557_offline.sh",
         sha256="4c2e77a3a2fa5f8a09b7d68760dfca6c07f3949010836cd6da34075463467995",
         expand=False,
     )
     version(
         "2021.2.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17747/l_daal_oneapi_p_2021.2.0.358_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17747/l_daal_oneapi_p_2021.2.0.358_offline.sh",
         sha256="cbf4e64dbd21c10179f2d1d7e8b8b0f12eeffe6921602df33276cd0ebd1f8e34",
         expand=False,
     )
     version(
         "2021.1.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17443/l_daal_oneapi_p_2021.1.1.79_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17443/l_daal_oneapi_p_2021.1.1.79_offline.sh",
         sha256="6e0e24bba462e80f0fba5a46e95cf0cca6cf17948a7753f8e396ddedd637544e",
         expand=False,
     )

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -46,61 +46,61 @@ class IntelOneapiDnn(IntelOneApiLibraryPackage):
     )
     version(
         "2023.0.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19137/l_onednn_p_2023.0.0.25399_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19137/l_onednn_p_2023.0.0.25399_offline.sh",
         sha256="f974901132bf55ba11ce782747ba9443f38d67827bce3994775eeb86ed018869",
         expand=False,
     )
     version(
         "2022.2.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19035/l_onednn_p_2022.2.1.16994_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19035/l_onednn_p_2022.2.1.16994_offline.sh",
         sha256="2102964a36a5b58b529385706e6829456ee5225111c33dfce6326fff5175aace",
         expand=False,
     )
     version(
         "2022.2.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18933/l_onednn_p_2022.2.0.8750_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18933/l_onednn_p_2022.2.0.8750_offline.sh",
         sha256="920833cd1f05f2fdafb942c96946c3925eb734d4458d52f22f2cc755133cb9e0",
         expand=False,
     )
     version(
         "2022.1.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18725/l_onednn_p_2022.1.0.132_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18725/l_onednn_p_2022.1.0.132_offline.sh",
         sha256="0b9a7efe8dd0f0b5132b353a8ee99226f75bae4bab188a453817263a0684cc93",
         expand=False,
     )
     version(
         "2022.0.2",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18476/l_onednn_p_2022.0.2.43_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18476/l_onednn_p_2022.0.2.43_offline.sh",
         sha256="a2a953542b4f632b51a2527d84bd76c3140a41c8085420da4237e2877c27c280",
         expand=False,
     )
     version(
         "2022.0.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18441/l_onednn_p_2022.0.1.26_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18441/l_onednn_p_2022.0.1.26_offline.sh",
         sha256="8339806300d83d2629952e6e2f2758b52f517c072a20b7b7fc5642cf1e2a5410",
         expand=False,
     )
     version(
         "2021.4.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18221/l_onednn_p_2021.4.0.467_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18221/l_onednn_p_2021.4.0.467_offline.sh",
         sha256="30cc601467f6a94b3d7e14f4639faf0b12fdf6d98df148b07acdb4dfdfb971db",
         expand=False,
     )
     version(
         "2021.3.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17923/l_onednn_p_2021.3.0.344_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17923/l_onednn_p_2021.3.0.344_offline.sh",
         sha256="1521f6cbffcf9ce0c7b5dfcf1a2546a4a0c8d8abc99f3011709039aaa9e0859a",
         expand=False,
     )
     version(
         "2021.2.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17751/l_onednn_p_2021.2.0.228_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17751/l_onednn_p_2021.2.0.228_offline.sh",
         sha256="62121a3355298211a124ff4e71c42fc172bf1061019be6c6120830a1a502aa88",
         expand=False,
     )
     version(
         "2021.1.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17385/l_onednn_p_2021.1.1.55_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17385/l_onednn_p_2021.1.1.55_offline.sh",
         sha256="24002c57bb8931a74057a471a5859d275516c331fd8420bee4cae90989e77dc3",
         expand=False,
     )

--- a/var/spack/repos/builtin/packages/intel-oneapi-dpct/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dpct/package.py
@@ -39,25 +39,25 @@ class IntelOneapiDpct(IntelOneApiPackage):
     )
     version(
         "2023.0.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19100/l_dpcpp-ct_p_2023.0.0.25483_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19100/l_dpcpp-ct_p_2023.0.0.25483_offline.sh",
         sha256="81f392d16a10cbdb8e9d053f18566304a78e1be624280ad43ddbc0dfd767fc7f",
         expand=False,
     )
     version(
         "2022.2.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18991/l_dpcpp-ct_p_2022.2.1.14994_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18991/l_dpcpp-ct_p_2022.2.1.14994_offline.sh",
         sha256="ea2fbe36de70eb3c78c97133f81e0b2a2fbcfc9525e77125a183d7af446ef3e6",
         expand=False,
     )
     version(
         "2022.2.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18908/l_dpcpp-ct_p_2022.2.0.8701_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18908/l_dpcpp-ct_p_2022.2.0.8701_offline.sh",
         sha256="ca79b89ba4b97accb868578a1b7ba0e38dc5e4457d45c6c2552ba33d71b52128",
         expand=False,
     )
     version(
         "2022.1.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18746/l_dpcpp-ct_p_2022.1.0.172_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18746/l_dpcpp-ct_p_2022.1.0.172_offline.sh",
         sha256="ec42f4df3f9daf1af587b14b8b6644c773a0b270e03dd22ac9e2f49131e3e40c",
         expand=False,
     )

--- a/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
@@ -42,43 +42,43 @@ class IntelOneapiDpl(IntelOneApiLibraryPackage):
     )
     version(
         "2022.0.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19133/l_oneDPL_p_2022.0.0.25335_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19133/l_oneDPL_p_2022.0.0.25335_offline.sh",
         sha256="61fcdfe854393f90c43c01bff81bf917c1784bc1c128afdb0c8be2795455d3d2",
         expand=False,
     )
     version(
         "2021.7.2",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19046/l_oneDPL_p_2021.7.2.15007_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19046/l_oneDPL_p_2021.7.2.15007_offline.sh",
         sha256="84d60a6b1978ff45d2c416f18ca7df542eaa8c0b18dc3abf4bb0824a91b4fc44",
         expand=False,
     )
     version(
         "2021.7.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18846/l_oneDPL_p_2021.7.1.8713_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18846/l_oneDPL_p_2021.7.1.8713_offline.sh",
         sha256="275c935427e3ad0eb995034b05ff2ffd13c55ee58069c3702aa383f68a1e5485",
         expand=False,
     )
     version(
         "2021.7.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18752/l_oneDPL_p_2021.7.0.631_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18752/l_oneDPL_p_2021.7.0.631_offline.sh",
         sha256="1e2d735d5eccfe8058e18f96d733eda8de5b7a07d613447b7d483fd3f9cec600",
         expand=False,
     )
     version(
         "2021.6.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18372/l_oneDPL_p_2021.6.0.501_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18372/l_oneDPL_p_2021.6.0.501_offline.sh",
         sha256="0225f133a6c38b36d08635986870284a958e5286c55ca4b56a4058bd736f8f4f",
         expand=False,
     )
     version(
         "2021.5.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18189/l_oneDPL_p_2021.5.0.445_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18189/l_oneDPL_p_2021.5.0.445_offline.sh",
         sha256="7d4adf300a18f779c3ab517070c61dba10e3952287d5aef37c38f739e9041a68",
         expand=False,
     )
     version(
         "2021.4.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17889/l_oneDPL_p_2021.4.0.337_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17889/l_oneDPL_p_2021.4.0.337_offline.sh",
         sha256="540ef0d308c4b0f13ea10168a90edd42a56dc0883024f6f1a678b94c10b5c170",
         expand=False,
     )

--- a/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
@@ -44,43 +44,43 @@ class IntelOneapiInspector(IntelOneApiLibraryPackageWithSdk):
     )
     version(
         "2023.0.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19125/l_inspector_oneapi_p_2023.0.0.25340_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19125/l_inspector_oneapi_p_2023.0.0.25340_offline.sh",
         sha256="adae2f06443c62a1a7be6aff2ad9c78672ec70f67b83dd660e68faafd7911dd4",
         expand=False,
     )
     version(
         "2022.3.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19005/l_inspector_oneapi_p_2022.3.1.15318_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19005/l_inspector_oneapi_p_2022.3.1.15318_offline.sh",
         sha256="62aa2abf6928c0f4fc60ccfb69375297f823c183aea2519d7344e09c9734c1f8",
         expand=False,
     )
     version(
         "2022.3.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18924/l_inspector_oneapi_p_2022.3.0.8706_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18924/l_inspector_oneapi_p_2022.3.0.8706_offline.sh",
         sha256="c239b93769afae0ef5f7d3b8584d739bf4a839051bd428f1e6be3e8ca5d4aefa",
         expand=False,
     )
     version(
         "2022.1.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18712/l_inspector_oneapi_p_2022.1.0.123_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18712/l_inspector_oneapi_p_2022.1.0.123_offline.sh",
         sha256="8551180aa30be3abea11308fb11ea9a296f0e056ab07d9254585448a0b23333e",
         expand=False,
     )
     version(
         "2022.0.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18363/l_inspector_oneapi_p_2022.0.0.56_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18363/l_inspector_oneapi_p_2022.0.0.56_offline.sh",
         sha256="79a0eb2ae3f1de1e3456076685680c468702922469c3fda3e074718fb0bea741",
         expand=False,
     )
     version(
         "2021.4.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18239/l_inspector_oneapi_p_2021.4.0.266_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18239/l_inspector_oneapi_p_2021.4.0.266_offline.sh",
         sha256="c8210cbcd0e07cc75e773249a5e4a02cf34894ec80a213939f3a20e6c5705274",
         expand=False,
     )
     version(
         "2021.3.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17946/l_inspector_oneapi_p_2021.3.0.217_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17946/l_inspector_oneapi_p_2021.3.0.217_offline.sh",
         sha256="1371ca74be2a6d4b069cdb3f8f2d6109abbc3261a81f437f0fe5412a7b659b43",
         expand=False,
     )

--- a/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
@@ -47,61 +47,61 @@ class IntelOneapiIpp(IntelOneApiLibraryPackage):
     )
     version(
         "2021.7.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19126/l_ipp_oneapi_p_2021.7.0.25396_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19126/l_ipp_oneapi_p_2021.7.0.25396_offline.sh",
         sha256="98b40cb6cea2198480400579330a5de85fd58d441b323246dfd2b960990fec26",
         expand=False,
     )
     version(
         "2021.6.2",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19007/l_ipp_oneapi_p_2021.6.2.16995_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19007/l_ipp_oneapi_p_2021.6.2.16995_offline.sh",
         sha256="23ae49afa9f13c2bed0c8a32e447e1c6b3528685cebdd32e4aa2a9736827cc4e",
         expand=False,
     )
     version(
         "2021.6.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18925/l_ipp_oneapi_p_2021.6.1.8749_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18925/l_ipp_oneapi_p_2021.6.1.8749_offline.sh",
         sha256="3f8705bf57c07b71d822295bfad49b531a38b6c3a4ca1119e4c52236cb664f57",
         expand=False,
     )
     version(
         "2021.6.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18748/l_ipp_oneapi_p_2021.6.0.626_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18748/l_ipp_oneapi_p_2021.6.0.626_offline.sh",
         sha256="cf09b5229dd38d75671fa1ab1af47e4d5f9f16dc7c9c22a4313a221a184774aa",
         expand=False,
     )
     version(
         "2021.5.2",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18474/l_ipp_oneapi_p_2021.5.2.544_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18474/l_ipp_oneapi_p_2021.5.2.544_offline.sh",
         sha256="ba48d91ab1447d0ae3d3a5448e3f08e460393258b60630c743be88281e51608e",
         expand=False,
     )
     version(
         "2021.5.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18440/l_ipp_oneapi_p_2021.5.1.522_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18440/l_ipp_oneapi_p_2021.5.1.522_offline.sh",
         sha256="be99f9b0b2cc815e017188681ab997f3ace94e3010738fa6f702f2416dac0de4",
         expand=False,
     )
     version(
         "2021.4.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18219/l_ipp_oneapi_p_2021.4.0.459_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18219/l_ipp_oneapi_p_2021.4.0.459_offline.sh",
         sha256="1a7a8fe5502ae61c10f5c432b7662c6fa542e5832a40494eb1c3a2d8e27c9f3e",
         expand=False,
     )
     version(
         "2021.3.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17958/l_ipp_oneapi_p_2021.3.0.333_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17958/l_ipp_oneapi_p_2021.3.0.333_offline.sh",
         sha256="67e75c80813ec9a30d5fda5860f76122ae66fa2128a48c8461f5e6b100b38bbb",
         expand=False,
     )
     version(
         "2021.2.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17758/l_ipp_oneapi_p_2021.2.0.233_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17758/l_ipp_oneapi_p_2021.2.0.233_offline.sh",
         sha256="ccdfc81f77203822d80151b40ce9e8fd82bb2de85a9b132ceed12d24d3f3ff52",
         expand=False,
     )
     version(
         "2021.1.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17436/l_ipp_oneapi_p_2021.1.1.47_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17436/l_ipp_oneapi_p_2021.1.1.47_offline.sh",
         sha256="2656a3a7f1f9f1438cbdf98fd472a213c452754ef9476dd65190a7d46618ba86",
         expand=False,
     )

--- a/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
@@ -48,61 +48,61 @@ class IntelOneapiIppcp(IntelOneApiLibraryPackage):
     )
     version(
         "2021.6.3",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19108/l_ippcp_oneapi_p_2021.6.3.25343_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19108/l_ippcp_oneapi_p_2021.6.3.25343_offline.sh",
         sha256="82e7f577a73af8c168a28029019f85136617ac762438e77d21647a70dec74baf",
         expand=False,
     )
     version(
         "2021.6.2",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18999/l_ippcp_oneapi_p_2021.6.2.15006_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18999/l_ippcp_oneapi_p_2021.6.2.15006_offline.sh",
         sha256="3c285c12da98a4d16e9a5ba237c8c51780475af54b1d1162185480ac891f16ee",
         expand=False,
     )
     version(
         "2021.6.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18923/l_ippcp_oneapi_p_2021.6.1.8714_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18923/l_ippcp_oneapi_p_2021.6.1.8714_offline.sh",
         sha256="a83c2e74f78ea00aae877259df38baab31e78bc04c0a387a1de36fff712eb225",
         expand=False,
     )
     version(
         "2021.6.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18709/l_ippcp_oneapi_p_2021.6.0.536_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18709/l_ippcp_oneapi_p_2021.6.0.536_offline.sh",
         sha256="dac90862b408a6418f3782a5c4bf940939b1307ff4841ecfc6a29322976a2d43",
         expand=False,
     )
     version(
         "2021.5.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18470/l_ippcp_oneapi_p_2021.5.1.462_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18470/l_ippcp_oneapi_p_2021.5.1.462_offline.sh",
         sha256="7ec058abbc1cdfd240320228d6426c65e5a855fd3a27e11fbd1ad2523f64812a",
         expand=False,
     )
     version(
         "2021.5.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18364/l_ippcp_oneapi_p_2021.5.0.445_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18364/l_ippcp_oneapi_p_2021.5.0.445_offline.sh",
         sha256="e71aee288cc970b9c9fe21f7d5c300dbc2a4ea0687c7028f200d6b87e6c895a1",
         expand=False,
     )
     version(
         "2021.4.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18187/l_ippcp_oneapi_p_2021.4.0.401_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18187/l_ippcp_oneapi_p_2021.4.0.401_offline.sh",
         sha256="2ca2320f733ee75b4a27865185a1b0730879fe2c47596e570b1bd50d0b8ac608",
         expand=False,
     )
     version(
         "2021.3.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17886/l_ippcp_oneapi_p_2021.3.0.315_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17886/l_ippcp_oneapi_p_2021.3.0.315_offline.sh",
         sha256="0214d132d8e64b02e9cc63182e2099fb9caebf8c240fb1629ae898c2e1f72fb9",
         expand=False,
     )
     version(
         "2021.2.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17684/l_ippcp_oneapi_p_2021.2.0.231_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17684/l_ippcp_oneapi_p_2021.2.0.231_offline.sh",
         sha256="64cd5924b42f924b6a8128a8bf8e686f5dc52b98f586ffac6c2e2f1585e3aba9",
         expand=False,
     )
     version(
         "2021.1.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17415/l_ippcp_oneapi_p_2021.1.1.54_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17415/l_ippcp_oneapi_p_2021.1.1.54_offline.sh",
         sha256="c0967afae22c7a223ec42542bcc702121064cd3d8f680eff36169c94f964a936",
         expand=False,
     )

--- a/var/spack/repos/builtin/packages/intel-oneapi-itac/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-itac/package.py
@@ -41,25 +41,25 @@ class IntelOneapiItac(IntelOneApiPackage):
     )
     version(
         "2021.8.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19129/l_itac_oneapi_p_2021.8.0.25341_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19129/l_itac_oneapi_p_2021.8.0.25341_offline.sh",
         sha256="9e943e07cbe7bcb2c6ec181cea5a2fd2241555bed695050f5069467fe7140c37",
         expand=False,
     )
     version(
         "2021.7.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19024/l_itac_oneapi_p_2021.7.1.15324_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19024/l_itac_oneapi_p_2021.7.1.15324_offline.sh",
         sha256="fb26689efdb7369e211b5cf05f3e30d491a2787f24fef174b23241b997cc442f",
         expand=False,
     )
     version(
         "2021.7.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18886/l_itac_oneapi_p_2021.7.0.8707_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18886/l_itac_oneapi_p_2021.7.0.8707_offline.sh",
         sha256="719faeccfb1478f28110b72b1558187590a6f44cce067158f407ab335a7395bd",
         expand=False,
     )
     version(
         "2021.6.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18694/l_itac_oneapi_p_2021.6.0.434_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18694/l_itac_oneapi_p_2021.6.0.434_offline.sh",
         sha256="1ecc2735da960041b051e377cadb9f6ab2f44e8aa44d0f642529a56a3cbba436",
         expand=False,
     )

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -45,61 +45,61 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
     )
     version(
         "2023.0.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19138/l_onemkl_p_2023.0.0.25398_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19138/l_onemkl_p_2023.0.0.25398_offline.sh",
         sha256="0d61188e91a57bdb575782eb47a05ae99ea8eebefee6b2dfe20c6708e16e9927",
         expand=False,
     )
     version(
         "2022.2.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19038/l_onemkl_p_2022.2.1.16993_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19038/l_onemkl_p_2022.2.1.16993_offline.sh",
         sha256="eedd4b795720de776b1fc5f542ae0fac37ec235cdb567f7c2ee3182e73e3e59d",
         expand=False,
     )
     version(
         "2022.2.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18898/l_onemkl_p_2022.2.0.8748_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18898/l_onemkl_p_2022.2.0.8748_offline.sh",
         sha256="07d7caedd4b9f025c6fd439a0d2c2f279b18ecbbb63cadb864f6c63c1ed942db",
         expand=False,
     )
     version(
         "2022.1.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18721/l_onemkl_p_2022.1.0.223_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18721/l_onemkl_p_2022.1.0.223_offline.sh",
         sha256="4b325a3c4c56e52f4ce6c8fbb55d7684adc16425000afc860464c0f29ea4563e",
         expand=False,
     )
     version(
         "2022.0.2",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18483/l_onemkl_p_2022.0.2.136_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18483/l_onemkl_p_2022.0.2.136_offline.sh",
         sha256="134b748825a474acc862bb4a7fada99741a15b7627cfaa6ba0fb05ec0b902b5e",
         expand=False,
     )
     version(
         "2022.0.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18444/l_onemkl_p_2022.0.1.117_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18444/l_onemkl_p_2022.0.1.117_offline.sh",
         sha256="22afafbe2f3762eca052ac21ec40b845ff2f3646077295c88c2f37f80a0cc160",
         expand=False,
     )
     version(
         "2021.4.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18222/l_onemkl_p_2021.4.0.640_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18222/l_onemkl_p_2021.4.0.640_offline.sh",
         sha256="9ad546f05a421b4f439e8557fd0f2d83d5e299b0d9bd84bdd86be6feba0c3915",
         expand=False,
     )
     version(
         "2021.3.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17901/l_onemkl_p_2021.3.0.520_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17901/l_onemkl_p_2021.3.0.520_offline.sh",
         sha256="a06e1cdbfd8becc63440b473b153659885f25a6e3c4dcb2907ad9cd0c3ad59ce",
         expand=False,
     )
     version(
         "2021.2.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17757/l_onemkl_p_2021.2.0.296_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17757/l_onemkl_p_2021.2.0.296_offline.sh",
         sha256="816e9df26ff331d6c0751b86ed5f7d243f9f172e76f14e83b32bf4d1d619dbae",
         expand=False,
     )
     version(
         "2021.1.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17402/l_onemkl_p_2021.1.1.52_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17402/l_onemkl_p_2021.1.1.52_offline.sh",
         sha256="818b6bd9a6c116f4578cda3151da0612ec9c3ce8b2c8a64730d625ce5b13cc0c",
         expand=False,
     )

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -41,61 +41,61 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
     )
     version(
         "2021.8.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19131/l_mpi_oneapi_p_2021.8.0.25329_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19131/l_mpi_oneapi_p_2021.8.0.25329_offline.sh",
         sha256="0fcb1171fc42fd4b2d863ae474c0b0f656b0fa1fdc1df435aa851ccd6d1eaaf7",
         expand=False,
     )
     version(
         "2021.7.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19010/l_mpi_oneapi_p_2021.7.1.16815_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19010/l_mpi_oneapi_p_2021.7.1.16815_offline.sh",
         sha256="90e7804f2367d457cd4cbf7aa29f1c5676287aa9b34f93e7c9a19e4b8583fff7",
         expand=False,
     )
     version(
         "2021.7.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18926/l_mpi_oneapi_p_2021.7.0.8711_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18926/l_mpi_oneapi_p_2021.7.0.8711_offline.sh",
         sha256="4eb1e1487b67b98857bc9b7b37bcac4998e0aa6d1b892b2c87b003bf84fb38e9",
         expand=False,
     )
     version(
         "2021.6.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18714/l_mpi_oneapi_p_2021.6.0.602_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18714/l_mpi_oneapi_p_2021.6.0.602_offline.sh",
         sha256="e85db63788c434d43c1378e5e2bf7927a75d11aee8e6b78ee0d933da920977a6",
         expand=False,
     )
     version(
         "2021.5.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18471/l_mpi_oneapi_p_2021.5.1.515_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18471/l_mpi_oneapi_p_2021.5.1.515_offline.sh",
         sha256="b992573959e39752e503e691564a0d876b099547c38b322d5775c5b06ec07a7f",
         expand=False,
     )
     version(
         "2021.5.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18370/l_mpi_oneapi_p_2021.5.0.495_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18370/l_mpi_oneapi_p_2021.5.0.495_offline.sh",
         sha256="3aae53fe77f7c6aac7a32b299c25d6ca9a00ba4e2d512a26edd90811e59e7471",
         expand=False,
     )
     version(
         "2021.4.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18186/l_mpi_oneapi_p_2021.4.0.441_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18186/l_mpi_oneapi_p_2021.4.0.441_offline.sh",
         sha256="cc4b7072c61d0bd02b1c431b22d2ea3b84b967b59d2e587e77a9e7b2c24f2a29",
         expand=False,
     )
     version(
         "2021.3.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17947/l_mpi_oneapi_p_2021.3.0.294_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17947/l_mpi_oneapi_p_2021.3.0.294_offline.sh",
         sha256="04c48f864ee4c723b1b4ca62f2bea8c04d5d7e3de19171fd62b17868bc79bc36",
         expand=False,
     )
     version(
         "2021.2.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17729/l_mpi_oneapi_p_2021.2.0.215_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17729/l_mpi_oneapi_p_2021.2.0.215_offline.sh",
         sha256="d0d4cdd11edaff2e7285e38f537defccff38e37a3067c02f4af43a3629ad4aa3",
         expand=False,
     )
     version(
         "2021.1.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17397/l_mpi_oneapi_p_2021.1.1.76_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17397/l_mpi_oneapi_p_2021.1.1.76_offline.sh",
         sha256="8b7693a156c6fc6269637bef586a8fd3ea6610cac2aae4e7f48c1fbb601625fe",
         expand=False,
     )

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -42,61 +42,61 @@ class IntelOneapiTbb(IntelOneApiLibraryPackage):
     )
     version(
         "2021.8.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19143/l_tbb_oneapi_p_2021.8.0.25334_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19143/l_tbb_oneapi_p_2021.8.0.25334_offline.sh",
         sha256="41074fcf6a33e41f9e8007609100e40c27f4e36b709b964835eff823e655486b",
         expand=False,
     )
     version(
         "2021.7.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19041/l_tbb_oneapi_p_2021.7.1.15005_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19041/l_tbb_oneapi_p_2021.7.1.15005_offline.sh",
         sha256="f13a8e740d69347b5985c1be496a3259a86d64ec94933b3d26100dbc2f059fd4",
         expand=False,
     )
     version(
         "2021.7.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18901/l_tbb_oneapi_p_2021.7.0.8712_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18901/l_tbb_oneapi_p_2021.7.0.8712_offline.sh",
         sha256="879bd2004b8e93bc12c53c43eab44cd843433e3da7a976baa8bf07a1069a87c5",
         expand=False,
     )
     version(
         "2021.6.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18728/l_tbb_oneapi_p_2021.6.0.835_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18728/l_tbb_oneapi_p_2021.6.0.835_offline.sh",
         sha256="e9ede40a3d7745de6d711d43818f820c8486ab544a45610a71118fbca20698e5",
         expand=False,
     )
     version(
         "2021.5.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18473/l_tbb_oneapi_p_2021.5.1.738_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18473/l_tbb_oneapi_p_2021.5.1.738_offline.sh",
         sha256="c154749f1f370e4cde11a0a7c80452d479e2dfa53ff2b1b97003d9c0d99c91e3",
         expand=False,
     )
     version(
         "2021.5.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18380/l_tbb_oneapi_p_2021.5.0.707_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18380/l_tbb_oneapi_p_2021.5.0.707_offline.sh",
         sha256="6ff7890a74a43ae02e0fa2d9c5533fce70a49dff8e73278b546a0995367fec5e",
         expand=False,
     )
     version(
         "2021.4.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18194/l_tbb_oneapi_p_2021.4.0.643_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18194/l_tbb_oneapi_p_2021.4.0.643_offline.sh",
         sha256="33332012ff8ffe7987b1a20bea794d76f7d8050ccff04fa6e1990974c336ee24",
         expand=False,
     )
     version(
         "2021.3.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17952/l_tbb_oneapi_p_2021.3.0.511_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17952/l_tbb_oneapi_p_2021.3.0.511_offline.sh",
         sha256="b83f5e018e3d262e42e9c96881845bbc09c3f036c265e65023422ca8e8637633",
         expand=False,
     )
     version(
         "2021.2.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17759/l_tbb_oneapi_p_2021.2.0.357_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17759/l_tbb_oneapi_p_2021.2.0.357_offline.sh",
         sha256="c1c3623c5bef547b30eac009e7a444611bf714c758d7472c114e9be9d5700eba",
         expand=False,
     )
     version(
         "2021.1.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17378/l_tbb_oneapi_p_2021.1.1.119_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17378/l_tbb_oneapi_p_2021.1.1.119_offline.sh",
         sha256="535290e3910a9d906a730b24af212afa231523cf13a668d480bade5f2a01b53b",
         expand=False,
     )

--- a/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
@@ -33,43 +33,43 @@ class IntelOneapiVpl(IntelOneApiLibraryPackage):
     )
     version(
         "2023.0.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19134/l_oneVPL_p_2023.0.0.25332_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19134/l_oneVPL_p_2023.0.0.25332_offline.sh",
         sha256="69e42fc7f412271c92395412a693bd158ef6df1472b3e0e783a63fddfc44c5af",
         expand=False,
     )
     version(
         "2022.2.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18903/l_oneVPL_p_2022.2.0.8703_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18903/l_oneVPL_p_2022.2.0.8703_offline.sh",
         sha256="cb8af222d194ebb4b1dafe12e0b70cbbdee204f9fcfe9eafb46b287ee33b3797",
         expand=False,
     )
     version(
         "2022.1.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18750/l_oneVPL_p_2022.1.0.154_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18750/l_oneVPL_p_2022.1.0.154_offline.sh",
         sha256="486cca918c9772a43f62da77e07cdf54dabb92ecebf494eb8c89c4492ab43447",
         expand=False,
     )
     version(
         "2022.0.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18375/l_oneVPL_p_2022.0.0.58_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18375/l_oneVPL_p_2022.0.0.58_offline.sh",
         sha256="600b8566e1aa523b97291bed6b08f69a04bc7c4c75c035942a64a38f45a1a7f0",
         expand=False,
     )
     version(
         "2021.6.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18190/l_oneVPL_p_2021.6.0.458_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18190/l_oneVPL_p_2021.6.0.458_offline.sh",
         sha256="40c50008be3f03d17cc8c0c34324593c1d419ee4c45af5543aa5a2d5fb11071f",
         expand=False,
     )
     version(
         "2021.2.2",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17733/l_oneVPL_p_2021.2.2.212_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17733/l_oneVPL_p_2021.2.2.212_offline.sh",
         sha256="21106ba5cde22f3e31fd55280fbccf263508fa054030f12d5dff4a5379ef3bb7",
         expand=False,
     )
     version(
         "2021.1.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/17418/l_oneVPL_p_2021.1.1.66_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/17418/l_oneVPL_p_2021.1.1.66_offline.sh",
         sha256="0fec42545b30b7bb2e4e33deb12ab27a02900f5703153d9601673a8ce43082ed",
         expand=False,
     )

--- a/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
@@ -51,43 +51,43 @@ class IntelOneapiVtune(IntelOneApiLibraryPackageWithSdk):
     )
     version(
         "2023.0.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19136/l_oneapi_vtune_p_2023.0.0.25339_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19136/l_oneapi_vtune_p_2023.0.0.25339_offline.sh",
         sha256="77fb356b501177d7bd5c936729ba4c1ada45935dc45a8ecd2f1164c276feb1ea",
         expand=False,
     )
     version(
         "2022.4.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/19027/l_oneapi_vtune_p_2022.4.1.16919_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19027/l_oneapi_vtune_p_2022.4.1.16919_offline.sh",
         sha256="eb4b4da61eea52c08fc139dbf4630e2c52cbcfaea8f1376c545c0863839366d1",
         expand=False,
     )
     version(
         "2022.4.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18888/l_oneapi_vtune_p_2022.4.0.8705_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18888/l_oneapi_vtune_p_2022.4.0.8705_offline.sh",
         sha256="8c5a144ed61ef9addaa41abe7fbfceeedb6a8fe1c5392e3e265aada1f545b0fe",
         expand=False,
     )
     version(
         "2022.3.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18656/l_oneapi_vtune_p_2022.3.0.195_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18656/l_oneapi_vtune_p_2022.3.0.195_offline.sh",
         sha256="7921fce7fcc3b82575be22d9c36beec961ba2a9fb5262ba16a04090bcbd2e1a6",
         expand=False,
     )
     version(
         "2022.0.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18406/l_oneapi_vtune_p_2022.0.0.94_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18406/l_oneapi_vtune_p_2022.0.0.94_offline.sh",
         sha256="aa4d575c22e7be0c950b87d67d9e371f470f682906864c4f9b68e530ecd22bd7",
         expand=False,
     )
     version(
         "2021.7.1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18086/l_oneapi_vtune_p_2021.7.1.492_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18086/l_oneapi_vtune_p_2021.7.1.492_offline.sh",
         sha256="4cf17078ae6e09f26f70bd9d0b726af234cc30c342ae4a8fda69941b40139b26",
         expand=False,
     )
     version(
         "2021.6.0",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/18012/l_oneapi_vtune_p_2021.6.0.411_offline.sh",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18012/l_oneapi_vtune_p_2021.6.0.411_offline.sh",
         sha256="6b1df7da713337aa665bcc6ff23e4a006695b5bfaf71dffd305cbadca2e5560c",
         expand=False,
     )

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -31,186 +31,186 @@ class IntelParallelStudio(IntelPackage):
     version(
         "cluster.2020.4",
         sha256="f36e49da97b6ce24d2d464d73d7ff49d71cff20e1698c20e607919819602a9f5",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/17113/parallel_studio_xe_2020_update4_cluster_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/17113/parallel_studio_xe_2020_update4_cluster_edition.tgz",
         deprecated=True,
     )
     version(
         "cluster.2020.2",
         sha256="4795c44374e8988b91da20ac8f13022d7d773461def4a26ca210a8694f69f133",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16744/parallel_studio_xe_2020_update2_cluster_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16744/parallel_studio_xe_2020_update2_cluster_edition.tgz",
         deprecated=True,
     )
     version(
         "cluster.2020.1",
         sha256="fd11d8de72b2bd60474f8bce7b463e4cbb2255969b9eaf24f689575aa2a2abab",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16526/parallel_studio_xe_2020_update1_cluster_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16526/parallel_studio_xe_2020_update1_cluster_edition.tgz",
         deprecated=True,
     )
     version(
         "cluster.2020.0",
         sha256="573b1d20707d68ce85b70934cfad15b5ad9cc14124a261c17ddd7717ba842c64",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16225/parallel_studio_xe_2020_cluster_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16225/parallel_studio_xe_2020_cluster_edition.tgz",
         deprecated=True,
     )
     #
     version(
         "cluster.2019.5",
         sha256="c03421de616bd4e640ed25ce4103ec9c5c85768a940a5cb5bd1e97b45be33904",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15809/parallel_studio_xe_2019_update5_cluster_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15809/parallel_studio_xe_2019_update5_cluster_edition.tgz",
         deprecated=True,
     )
     version(
         "cluster.2019.4",
         sha256="32aee12de3b5ca14caf7578313c06b205795c67620f4a9606ea45696ee3b3d9e",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15533/parallel_studio_xe_2019_update4_cluster_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15533/parallel_studio_xe_2019_update4_cluster_edition.tgz",
         deprecated=True,
     )
     version(
         "cluster.2019.3",
         sha256="b5b022366d6d1a98dbb63b60221c62bc951c9819653ad6f5142192e89f78cf63",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15268/parallel_studio_xe_2019_update3_cluster_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15268/parallel_studio_xe_2019_update3_cluster_edition.tgz",
         deprecated=True,
     )
     version(
         "cluster.2019.2",
         sha256="8c526bdd95d1da454e5cada00f7a2353089b86d0c9df2088ca7f842fe3ff4cae",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15088/parallel_studio_xe_2019_update2_cluster_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15088/parallel_studio_xe_2019_update2_cluster_edition.tgz",
         deprecated=True,
     )
     version(
         "cluster.2019.1",
         sha256="3a1eb39f15615f7a2688426b9835e5e841e0c030f21dcfc899fe23e09bd2c645",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14850/parallel_studio_xe_2019_update1_cluster_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/14850/parallel_studio_xe_2019_update1_cluster_edition.tgz",
         deprecated=True,
     )
     version(
         "cluster.2019.0",
         sha256="1096dd4139bdd4b3abbda69a17d1e229a606759f793f5b0ba0d39623928ee4a1",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13589/parallel_studio_xe_2019_cluster_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13589/parallel_studio_xe_2019_cluster_edition.tgz",
         deprecated=True,
     )
     #
     version(
         "cluster.2018.4",
         sha256="210a5904a860e11b861720e68416f91fd47a459e4500976853291fa8b0478566",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13717/parallel_studio_xe_2018_update4_cluster_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13717/parallel_studio_xe_2018_update4_cluster_edition.tgz",
         deprecated=True,
     )
     version(
         "cluster.2018.3",
         sha256="23c64b88cea5056eaeef7b4ae0f4c6a86485c97f5e41d6c8419cb00aa4929287",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12998/parallel_studio_xe_2018_update3_cluster_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12998/parallel_studio_xe_2018_update3_cluster_edition.tgz",
         deprecated=True,
     )
     version(
         "cluster.2018.2",
         sha256="550bc4758f7dd70e75830d329947532ad8b7cbb85225b8ec6db7e78a3f1d6d84",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12717/parallel_studio_xe_2018_update2_cluster_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12717/parallel_studio_xe_2018_update2_cluster_edition.tgz",
         deprecated=True,
     )
     version(
         "cluster.2018.1",
         sha256="f7a94e83248d2641eb7ae2c1abf681067203a5b4372619e039861b468744774c",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12374/parallel_studio_xe_2018_update1_cluster_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12374/parallel_studio_xe_2018_update1_cluster_edition.tgz",
         deprecated=True,
     )
     version(
         "cluster.2018.0",
         sha256="526e5e71c420dc9b557b0bae2a81abb33eedb9b6a28ac94996ccbcf71cf53774",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12058/parallel_studio_xe_2018_cluster_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12058/parallel_studio_xe_2018_cluster_edition.tgz",
         deprecated=True,
     )
     #
     version(
         "cluster.2017.7",
         sha256="133c3aa99841a4fe48149938a90f971467452a82f033be10cd9464ba810f6360",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12856/parallel_studio_xe_2017_update7.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12856/parallel_studio_xe_2017_update7.tgz",
         deprecated=True,
     )
     version(
         "cluster.2017.6",
         sha256="d771b00d3658934c424f294170125dc58ae9b03639aa898a2f115d7a7482dd3a",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12534/parallel_studio_xe_2017_update6.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12534/parallel_studio_xe_2017_update6.tgz",
         deprecated=True,
     )
     version(
         "cluster.2017.5",
         sha256="36e496d1d1d7d7168cc3ba8f5bca9b52022339f30b62a87ed064b77a5cbccc09",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12138/parallel_studio_xe_2017_update5.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12138/parallel_studio_xe_2017_update5.tgz",
         deprecated=True,
     )
     version(
         "cluster.2017.4",
         sha256="27d34625adfc635d767c136b5417a372f322fabe6701b651d858a8fe06d07f2d",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11537/parallel_studio_xe_2017_update4.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11537/parallel_studio_xe_2017_update4.tgz",
         deprecated=True,
     )
     version(
         "cluster.2017.3",
         sha256="856950c0493de3e8b4150e18f8821675c1cf75c2eea5ff0804f59eb301414bbe",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11460/parallel_studio_xe_2017_update3.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11460/parallel_studio_xe_2017_update3.tgz",
         deprecated=True,
     )
     version(
         "cluster.2017.2",
         sha256="83a655f0c2969409758488d70d6719fb5ea81a84b6da3feb641ce67bb240bc8a",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11298/parallel_studio_xe_2017_update2.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11298/parallel_studio_xe_2017_update2.tgz",
         deprecated=True,
     )
     version(
         "cluster.2017.1",
         sha256="c808be744c98f7471c61258144859e8e8fc92771934281a16135803e941fd9b0",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/10973/parallel_studio_xe_2017_update1.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/10973/parallel_studio_xe_2017_update1.tgz",
         deprecated=True,
     )
     version(
         "cluster.2017.0",
         sha256="f380a56a25cf17941eb691a640035e79f92516346500e0df80fbdd46c5c1b301",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9651/parallel_studio_xe_2017.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9651/parallel_studio_xe_2017.tgz",
         deprecated=True,
     )
     #
     version(
         "cluster.2016.4",
         sha256="ea43c150ed6f9967bc781fe4253169a0447c69bac4fe2c563016a1ad2875ae23",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9781/parallel_studio_xe_2016_update4.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9781/parallel_studio_xe_2016_update4.tgz",
         deprecated=True,
     )
     version(
         "cluster.2016.3",
         sha256="aa7c6f1a6603fae07c2b01409c12de0811aa5947eaa71dfb1fe9898076c2773e",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9061/parallel_studio_xe_2016_update3.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9061/parallel_studio_xe_2016_update3.tgz",
         deprecated=True,
     )
     version(
         "cluster.2016.2",
         sha256="280bf39c75d7f52f206759ca4d8b6334ab92d5970957b90f5aa286bb0aa8d65e",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8676/parallel_studio_xe_2016_update2.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/8676/parallel_studio_xe_2016_update2.tgz",
         deprecated=True,
     )
     version(
         "cluster.2016.1",
         sha256="f5a3ab9fb581e19bf1bd966f7d40a11905e002a2bfae1c4a2140544288ca3e48",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8365/parallel_studio_xe_2016_update1.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/8365/parallel_studio_xe_2016_update1.tgz",
         deprecated=True,
     )
     version(
         "cluster.2016.0",
         sha256="fd4c32352fd78fc919601bedac5658ad5ac48efbc5700d9a8d42ed7d53bd8bb7",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/7997/parallel_studio_xe_2016.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/7997/parallel_studio_xe_2016.tgz",
         deprecated=True,
     )
     #
     version(
         "cluster.2015.6",
         sha256="e604ed2bb45d227b151dd2898f3edd93526d58d1db1cb9d6b6f614907864f392",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8469/parallel_studio_xe_2015_update6.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/8469/parallel_studio_xe_2015_update6.tgz",
         deprecated=True,
     )
     version(
         "cluster.2015.1",
         sha256="84fdf48d1de20e1d580ba5d419a5bc1c55d217a4f5dc1807190ecffe0229a62b",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/4992/parallel_studio_xe_2015_update1.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/4992/parallel_studio_xe_2015_update1.tgz",
         deprecated=True,
     )
 
@@ -222,186 +222,186 @@ class IntelParallelStudio(IntelPackage):
     version(
         "professional.2020.4",
         sha256="f9679a40c63575191385837f4f1bdafbcfd3736f09ac51d0761248b9ca9cc9e6",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/17114/parallel_studio_xe_2020_update4_professional_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/17114/parallel_studio_xe_2020_update4_professional_edition.tgz",
         deprecated=True,
     )
     version(
         "professional.2020.2",
         sha256="96f9bca551a43e09d9648e8cba357739a759423adb671d1aa5973b7a930370c5",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16756/parallel_studio_xe_2020_update2_professional_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16756/parallel_studio_xe_2020_update2_professional_edition.tgz",
         deprecated=True,
     )
     version(
         "professional.2020.1",
         sha256="5b547be92ecf50cb338b3038a565f5609135b27aa98a8b7964879eb2331eb29a",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16527/parallel_studio_xe_2020_update1_professional_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16527/parallel_studio_xe_2020_update1_professional_edition.tgz",
         deprecated=True,
     )
     version(
         "professional.2020.0",
         sha256="e88cad18d28da50ed9cb87b12adccf13efd91bf94731dc33290481306c6f15ac",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16226/parallel_studio_xe_2020_professional_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16226/parallel_studio_xe_2020_professional_edition.tgz",
         deprecated=True,
     )
     #
     version(
         "professional.2019.5",
         sha256="0ec638330214539361f8632e20759f385a5a78013dcc980ee93743d86d354452",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15810/parallel_studio_xe_2019_update5_professional_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15810/parallel_studio_xe_2019_update5_professional_edition.tgz",
         deprecated=True,
     )
     version(
         "professional.2019.4",
         sha256="9b2818ea5739ade100841e99ce79ef7f4049a2513beb2ce20fc94706f1ba0231",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15534/parallel_studio_xe_2019_update4_professional_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15534/parallel_studio_xe_2019_update4_professional_edition.tgz",
         deprecated=True,
     )
     version(
         "professional.2019.3",
         sha256="92a8879106d0bdf1ecf4670cd97fbcdc67d78b13bdf484f2c516a533aa7a27f9",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15269/parallel_studio_xe_2019_update3_professional_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15269/parallel_studio_xe_2019_update3_professional_edition.tgz",
         deprecated=True,
     )
     version(
         "professional.2019.2",
         sha256="cdb629d74612d135ca197f1f64e6a081e31df68cda92346a29e1223bb06e64ea",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15089/parallel_studio_xe_2019_update2_professional_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15089/parallel_studio_xe_2019_update2_professional_edition.tgz",
         deprecated=True,
     )
     version(
         "professional.2019.1",
         sha256="bc83ef5a728903359ae11a2b90ad7dae4ae61194afb28bb5bb419f6a6aea225d",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14825/parallel_studio_xe_2019_update1_professional_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/14825/parallel_studio_xe_2019_update1_professional_edition.tgz",
         deprecated=True,
     )
     version(
         "professional.2019.0",
         sha256="94b9714e353e5c4f58d38cb236e2f8911cbef31c4b42a148d60c988e926411e2",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13578/parallel_studio_xe_2019_professional_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13578/parallel_studio_xe_2019_professional_edition.tgz",
         deprecated=True,
     )
     #
     version(
         "professional.2018.4",
         sha256="54ab4320da849108602096fa7a34aa21751068467e0d1584aa8f16352b77d323",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13718/parallel_studio_xe_2018_update4_professional_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13718/parallel_studio_xe_2018_update4_professional_edition.tgz",
         deprecated=True,
     )
     version(
         "professional.2018.3",
         sha256="3d8e72ccad31f243e43b72a925ad4a6908e2955682433898640ab783decf9960",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12999/parallel_studio_xe_2018_update3_professional_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12999/parallel_studio_xe_2018_update3_professional_edition.tgz",
         deprecated=True,
     )
     version(
         "professional.2018.2",
         sha256="fc577b29fb2c687441d4faea14a6fb6da529fc78fcb778cbface59f40e128e02",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12718/parallel_studio_xe_2018_update2_professional_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12718/parallel_studio_xe_2018_update2_professional_edition.tgz",
         deprecated=True,
     )
     version(
         "professional.2018.1",
         sha256="dd3e118069d87eebb614336732323b48172c8c8a653cde673a8ef02f7358e94d",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12375/parallel_studio_xe_2018_update1_professional_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12375/parallel_studio_xe_2018_update1_professional_edition.tgz",
         deprecated=True,
     )
     version(
         "professional.2018.0",
         sha256="72308ffa088391ea65726a79d7a73738206fbb1d8ed8563e3d06eab3120fb1a0",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12062/parallel_studio_xe_2018_professional_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12062/parallel_studio_xe_2018_professional_edition.tgz",
         deprecated=True,
     )
     #
     version(
         "professional.2017.7",
         sha256="133c3aa99841a4fe48149938a90f971467452a82f033be10cd9464ba810f6360",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12856/parallel_studio_xe_2017_update7.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12856/parallel_studio_xe_2017_update7.tgz",
         deprecated=True,
     )
     version(
         "professional.2017.6",
         sha256="d771b00d3658934c424f294170125dc58ae9b03639aa898a2f115d7a7482dd3a",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12534/parallel_studio_xe_2017_update6.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12534/parallel_studio_xe_2017_update6.tgz",
         deprecated=True,
     )
     version(
         "professional.2017.5",
         sha256="36e496d1d1d7d7168cc3ba8f5bca9b52022339f30b62a87ed064b77a5cbccc09",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12138/parallel_studio_xe_2017_update5.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12138/parallel_studio_xe_2017_update5.tgz",
         deprecated=True,
     )
     version(
         "professional.2017.4",
         sha256="27d34625adfc635d767c136b5417a372f322fabe6701b651d858a8fe06d07f2d",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11537/parallel_studio_xe_2017_update4.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11537/parallel_studio_xe_2017_update4.tgz",
         deprecated=True,
     )
     version(
         "professional.2017.3",
         sha256="856950c0493de3e8b4150e18f8821675c1cf75c2eea5ff0804f59eb301414bbe",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11460/parallel_studio_xe_2017_update3.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11460/parallel_studio_xe_2017_update3.tgz",
         deprecated=True,
     )
     version(
         "professional.2017.2",
         sha256="83a655f0c2969409758488d70d6719fb5ea81a84b6da3feb641ce67bb240bc8a",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11298/parallel_studio_xe_2017_update2.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11298/parallel_studio_xe_2017_update2.tgz",
         deprecated=True,
     )
     version(
         "professional.2017.1",
         sha256="c808be744c98f7471c61258144859e8e8fc92771934281a16135803e941fd9b0",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/10973/parallel_studio_xe_2017_update1.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/10973/parallel_studio_xe_2017_update1.tgz",
         deprecated=True,
     )
     version(
         "professional.2017.0",
         sha256="f380a56a25cf17941eb691a640035e79f92516346500e0df80fbdd46c5c1b301",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9651/parallel_studio_xe_2017.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9651/parallel_studio_xe_2017.tgz",
         deprecated=True,
     )
     #
     version(
         "professional.2016.4",
         sha256="ea43c150ed6f9967bc781fe4253169a0447c69bac4fe2c563016a1ad2875ae23",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9781/parallel_studio_xe_2016_update4.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9781/parallel_studio_xe_2016_update4.tgz",
         deprecated=True,
     )
     version(
         "professional.2016.3",
         sha256="aa7c6f1a6603fae07c2b01409c12de0811aa5947eaa71dfb1fe9898076c2773e",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9061/parallel_studio_xe_2016_update3.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9061/parallel_studio_xe_2016_update3.tgz",
         deprecated=True,
     )
     version(
         "professional.2016.2",
         sha256="280bf39c75d7f52f206759ca4d8b6334ab92d5970957b90f5aa286bb0aa8d65e",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8676/parallel_studio_xe_2016_update2.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/8676/parallel_studio_xe_2016_update2.tgz",
         deprecated=True,
     )
     version(
         "professional.2016.1",
         sha256="f5a3ab9fb581e19bf1bd966f7d40a11905e002a2bfae1c4a2140544288ca3e48",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8365/parallel_studio_xe_2016_update1.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/8365/parallel_studio_xe_2016_update1.tgz",
         deprecated=True,
     )
     version(
         "professional.2016.0",
         sha256="fd4c32352fd78fc919601bedac5658ad5ac48efbc5700d9a8d42ed7d53bd8bb7",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/7997/parallel_studio_xe_2016.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/7997/parallel_studio_xe_2016.tgz",
         deprecated=True,
     )
     #
     version(
         "professional.2015.6",
         sha256="e604ed2bb45d227b151dd2898f3edd93526d58d1db1cb9d6b6f614907864f392",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8469/parallel_studio_xe_2015_update6.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/8469/parallel_studio_xe_2015_update6.tgz",
         deprecated=True,
     )
     version(
         "professional.2015.1",
         sha256="84fdf48d1de20e1d580ba5d419a5bc1c55d217a4f5dc1807190ecffe0229a62b",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/4992/parallel_studio_xe_2015_update1.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/4992/parallel_studio_xe_2015_update1.tgz",
         deprecated=True,
     )
 
@@ -409,161 +409,161 @@ class IntelParallelStudio(IntelPackage):
     version(
         "composer.2020.4",
         sha256="ac1efeff608a8c3a416e6dfe20364061e8abf62d35fbaacdffe3fc9676fc1aa3",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16759/parallel_studio_xe_2020_update2_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16759/parallel_studio_xe_2020_update2_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2020.2",
         sha256="42af16e9a91226978bb401d9f17b628bc279aa8cb104d4a38ba0808234a79bdd",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16759/parallel_studio_xe_2020_update2_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16759/parallel_studio_xe_2020_update2_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2020.1",
         sha256="26c7e7da87b8a83adfd408b2a354d872be97736abed837364c1bf10f4469b01e",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16530/parallel_studio_xe_2020_update1_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16530/parallel_studio_xe_2020_update1_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2020.0",
         sha256="9168045466139b8e280f50f0606b9930ffc720bbc60bc76f5576829ac15757ae",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16229/parallel_studio_xe_2020_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16229/parallel_studio_xe_2020_composer_edition.tgz",
         deprecated=True,
     )
     #
     version(
         "composer.2019.5",
         sha256="e8c8e4b9b46826a02c49325c370c79f896858611bf33ddb7fb204614838ad56c",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15813/parallel_studio_xe_2019_update5_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15813/parallel_studio_xe_2019_update5_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2019.4",
         sha256="1915993445323e1e78d6de73702a88fa3df2036109cde03d74ee38fef9f1abf2",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15537/parallel_studio_xe_2019_update4_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15537/parallel_studio_xe_2019_update4_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2019.3",
         sha256="15373ac6df2a84e6dd9fa0eac8b5f07ab00cdbb67f494161fd0d4df7a71aff8e",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15272/parallel_studio_xe_2019_update3_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15272/parallel_studio_xe_2019_update3_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2019.2",
         sha256="1e0f400be1f458592a8c2e7d55c1b2a4506f68f22bacbf1175af947809a4cd87",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15092/parallel_studio_xe_2019_update2_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15092/parallel_studio_xe_2019_update2_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2019.1",
         sha256="db000cb2ebf411f6e91719db68a0c68b8d3f7d38ad7f2049ea5b2f1b5f006c25",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14832/parallel_studio_xe_2019_update1_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/14832/parallel_studio_xe_2019_update1_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2019.0",
         sha256="e1a29463038b063e01f694e2817c0fcf1a8e824e24f15a26ce85f20afa3f963a",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13581/parallel_studio_xe_2019_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13581/parallel_studio_xe_2019_composer_edition.tgz",
         deprecated=True,
     )
     #
     version(
         "composer.2018.4",
         sha256="94aca8f091dff9535b02f022a37aef150b36925c8ef069335621496f8e4db267",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13722/parallel_studio_xe_2018_update4_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13722/parallel_studio_xe_2018_update4_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2018.3",
         sha256="f21f7759709a3d3e3390a8325fa89ac79b1fce8890c292e73b2ba3ec576ebd2b",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13002/parallel_studio_xe_2018_update3_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13002/parallel_studio_xe_2018_update3_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2018.2",
         sha256="02d2a9fb10d9810f85dd77700215c4348d2e4475e814e4f086eb1442462667ff",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12722/parallel_studio_xe_2018_update2_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12722/parallel_studio_xe_2018_update2_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2018.1",
         sha256="db9aa417da185a03a63330c9d76ee8e88496ae6b771584d19003a29eedc7cab5",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12381/parallel_studio_xe_2018_update1_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12381/parallel_studio_xe_2018_update1_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2018.0",
         sha256="ecad64360fdaff2548a0ea250a396faf680077c5a83c3c3ce2c55f4f4270b904",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12067/parallel_studio_xe_2018_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12067/parallel_studio_xe_2018_composer_edition.tgz",
         deprecated=True,
     )
     #
     version(
         "composer.2017.7",
         sha256="661e33b68e47bf335694d2255f5883955234e9085c8349783a5794eed2a937ad",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12860/parallel_studio_xe_2017_update7_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12860/parallel_studio_xe_2017_update7_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2017.6",
         sha256="771f50746fe130ea472394c42e25d2c7edae049ad809d2050945ef637becf65f",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12538/parallel_studio_xe_2017_update6_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12538/parallel_studio_xe_2017_update6_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2017.5",
         sha256="ede4ea9351fcf263103588ae0f130b4c2a79395529cdb698b0d6e866c4871f78",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12144/parallel_studio_xe_2017_update5_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12144/parallel_studio_xe_2017_update5_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2017.4",
         sha256="4304766f80206a27709be61641c16782fccf2b3fcf7285782cce921ddc9b10ff",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11541/parallel_studio_xe_2017_update4_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11541/parallel_studio_xe_2017_update4_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2017.3",
         sha256="3648578d7bba993ebb1da37c173979bfcfb47f26e7f4e17f257e78dea8fd96ab",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11464/parallel_studio_xe_2017_update3_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11464/parallel_studio_xe_2017_update3_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2017.2",
         sha256="abd26ab2a703e73ab93326984837818601c391782a6bce52da8b2a246798ad40",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11302/parallel_studio_xe_2017_update2_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11302/parallel_studio_xe_2017_update2_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2017.1",
         sha256="bc592abee829ba6e00a4f60961b486b80c15987ff1579d6560186407c84add6f",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/10978/parallel_studio_xe_2017_update1_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/10978/parallel_studio_xe_2017_update1_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "composer.2017.0",
         sha256="d218db66a5bb57569bea00821ac95d4647eda7422bf8a178d1586b0fb314935a",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9656/parallel_studio_xe_2017_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9656/parallel_studio_xe_2017_composer_edition.tgz",
         deprecated=True,
     )
     #
     version(
         "composer.2016.4",
         sha256="17606c52cab6f5114223a2425923c8dd69f1858f5a3bdf280e0edea49ebd430d",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9785/parallel_studio_xe_2016_composer_edition_update4.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9785/parallel_studio_xe_2016_composer_edition_update4.tgz",
         deprecated=True,
     )
     version(
         "composer.2016.3",
         sha256="fcec90ba97533e4705077e0701813b5a3bcc197b010b03e96f83191a35c26acf",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9063/parallel_studio_xe_2016_composer_edition_update3.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9063/parallel_studio_xe_2016_composer_edition_update3.tgz",
         deprecated=True,
     )
     version(
         "composer.2016.2",
         sha256="6309ef8be1abba7737d3c1e17af64ca2620672b2da57afe2c3c643235f65b4c7",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8680/parallel_studio_xe_2016_composer_edition_update2.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/8680/parallel_studio_xe_2016_composer_edition_update2.tgz",
         deprecated=True,
     )
     #
@@ -571,13 +571,13 @@ class IntelParallelStudio(IntelPackage):
     version(
         "composer.2015.6",
         sha256="b1e09833469ca76a2834cd0a5bb5fea11ec9986da85abf4c6eed42cd96ec24cb",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8432/l_compxe_2015.6.233.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/8432/l_compxe_2015.6.233.tgz",
         deprecated=True,
     )
     version(
         "composer.2015.1",
         sha256="8a438fe20103e27bfda132955616d0c886aa6cfdd86dcd9764af5d937a8799d9",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/4933/l_compxe_2015.1.133.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/4933/l_compxe_2015.1.133.tgz",
         deprecated=True,
     )
 

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -28,73 +28,73 @@ class Intel(IntelPackage):
     version(
         "20.0.4",
         sha256="ac1efeff608a8c3a416e6dfe20364061e8abf62d35fbaacdffe3fc9676fc1aa3",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/17117/parallel_studio_xe_2020_update4_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/17117/parallel_studio_xe_2020_update4_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "20.0.2",
         sha256="42af16e9a91226978bb401d9f17b628bc279aa8cb104d4a38ba0808234a79bdd",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16759/parallel_studio_xe_2020_update2_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16759/parallel_studio_xe_2020_update2_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "20.0.1",
         sha256="26c7e7da87b8a83adfd408b2a354d872be97736abed837364c1bf10f4469b01e",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16530/parallel_studio_xe_2020_update1_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16530/parallel_studio_xe_2020_update1_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "20.0.0",
         sha256="9168045466139b8e280f50f0606b9930ffc720bbc60bc76f5576829ac15757ae",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16229/parallel_studio_xe_2020_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16229/parallel_studio_xe_2020_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "19.1.2",
         sha256="42af16e9a91226978bb401d9f17b628bc279aa8cb104d4a38ba0808234a79bdd",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16759/parallel_studio_xe_2020_update2_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16759/parallel_studio_xe_2020_update2_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "19.1.1",
         sha256="26c7e7da87b8a83adfd408b2a354d872be97736abed837364c1bf10f4469b01e",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16530/parallel_studio_xe_2020_update1_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16530/parallel_studio_xe_2020_update1_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "19.1.0",
         sha256="9168045466139b8e280f50f0606b9930ffc720bbc60bc76f5576829ac15757ae",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16229/parallel_studio_xe_2020_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/16229/parallel_studio_xe_2020_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "19.0.5",
         sha256="e8c8e4b9b46826a02c49325c370c79f896858611bf33ddb7fb204614838ad56c",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15813/parallel_studio_xe_2019_update5_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15813/parallel_studio_xe_2019_update5_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "19.0.4",
         sha256="1915993445323e1e78d6de73702a88fa3df2036109cde03d74ee38fef9f1abf2",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15537/parallel_studio_xe_2019_update4_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15537/parallel_studio_xe_2019_update4_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "19.0.3",
         sha256="15373ac6df2a84e6dd9fa0eac8b5f07ab00cdbb67f494161fd0d4df7a71aff8e",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15272/parallel_studio_xe_2019_update3_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/15272/parallel_studio_xe_2019_update3_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "19.0.1",
         sha256="db000cb2ebf411f6e91719db68a0c68b8d3f7d38ad7f2049ea5b2f1b5f006c25",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/14832/parallel_studio_xe_2019_update1_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/14832/parallel_studio_xe_2019_update1_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "19.0.0",
         sha256="e1a29463038b063e01f694e2817c0fcf1a8e824e24f15a26ce85f20afa3f963a",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13581/parallel_studio_xe_2019_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13581/parallel_studio_xe_2019_composer_edition.tgz",
         deprecated=True,
     )
 
@@ -103,99 +103,99 @@ class Intel(IntelPackage):
     version(
         "18.0.5",
         sha256="94aca8f091dff9535b02f022a37aef150b36925c8ef069335621496f8e4db267",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13722/parallel_studio_xe_2018_update4_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13722/parallel_studio_xe_2018_update4_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "18.0.3",
         sha256="f21f7759709a3d3e3390a8325fa89ac79b1fce8890c292e73b2ba3ec576ebd2b",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13002/parallel_studio_xe_2018_update3_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/13002/parallel_studio_xe_2018_update3_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "18.0.2",
         sha256="02d2a9fb10d9810f85dd77700215c4348d2e4475e814e4f086eb1442462667ff",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12722/parallel_studio_xe_2018_update2_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12722/parallel_studio_xe_2018_update2_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "18.0.1",
         sha256="db9aa417da185a03a63330c9d76ee8e88496ae6b771584d19003a29eedc7cab5",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12381/parallel_studio_xe_2018_update1_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12381/parallel_studio_xe_2018_update1_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "18.0.0",
         sha256="ecad64360fdaff2548a0ea250a396faf680077c5a83c3c3ce2c55f4f4270b904",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12067/parallel_studio_xe_2018_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12067/parallel_studio_xe_2018_composer_edition.tgz",
         deprecated=True,
     )
     #
     version(
         "17.0.7",
         sha256="661e33b68e47bf335694d2255f5883955234e9085c8349783a5794eed2a937ad",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12860/parallel_studio_xe_2017_update7_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12860/parallel_studio_xe_2017_update7_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "17.0.6",
         sha256="771f50746fe130ea472394c42e25d2c7edae049ad809d2050945ef637becf65f",
-        url="https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12538/parallel_studio_xe_2017_update6_composer_edition.tgz",
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12538/parallel_studio_xe_2017_update6_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "17.0.5",
         sha256="ede4ea9351fcf263103588ae0f130b4c2a79395529cdb698b0d6e866c4871f78",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12144/parallel_studio_xe_2017_update5_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/12144/parallel_studio_xe_2017_update5_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "17.0.4",
         sha256="4304766f80206a27709be61641c16782fccf2b3fcf7285782cce921ddc9b10ff",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11541/parallel_studio_xe_2017_update4_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11541/parallel_studio_xe_2017_update4_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "17.0.3",
         sha256="3648578d7bba993ebb1da37c173979bfcfb47f26e7f4e17f257e78dea8fd96ab",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11464/parallel_studio_xe_2017_update3_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11464/parallel_studio_xe_2017_update3_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "17.0.2",
         sha256="abd26ab2a703e73ab93326984837818601c391782a6bce52da8b2a246798ad40",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/11302/parallel_studio_xe_2017_update2_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/11302/parallel_studio_xe_2017_update2_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "17.0.1",
         sha256="bc592abee829ba6e00a4f60961b486b80c15987ff1579d6560186407c84add6f",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/10978/parallel_studio_xe_2017_update1_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/10978/parallel_studio_xe_2017_update1_composer_edition.tgz",
         deprecated=True,
     )
     version(
         "17.0.0",
         sha256="d218db66a5bb57569bea00821ac95d4647eda7422bf8a178d1586b0fb314935a",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9656/parallel_studio_xe_2017_composer_edition.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9656/parallel_studio_xe_2017_composer_edition.tgz",
         deprecated=True,
     )
     #
     version(
         "16.0.4",
         sha256="17606c52cab6f5114223a2425923c8dd69f1858f5a3bdf280e0edea49ebd430d",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9785/parallel_studio_xe_2016_composer_edition_update4.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9785/parallel_studio_xe_2016_composer_edition_update4.tgz",
         deprecated=True,
     )
     version(
         "16.0.3",
         sha256="fcec90ba97533e4705077e0701813b5a3bcc197b010b03e96f83191a35c26acf",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/9063/parallel_studio_xe_2016_composer_edition_update3.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/9063/parallel_studio_xe_2016_composer_edition_update3.tgz",
         deprecated=True,
     )
     version(
         "16.0.2",
         sha256="6309ef8be1abba7737d3c1e17af64ca2620672b2da57afe2c3c643235f65b4c7",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8680/parallel_studio_xe_2016_composer_edition_update2.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/8680/parallel_studio_xe_2016_composer_edition_update2.tgz",
         deprecated=True,
     )
     #
@@ -203,13 +203,13 @@ class Intel(IntelPackage):
     version(
         "15.0.6",
         sha256="b1e09833469ca76a2834cd0a5bb5fea11ec9986da85abf4c6eed42cd96ec24cb",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/8432/l_compxe_2015.6.233.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/8432/l_compxe_2015.6.233.tgz",
         deprecated=True,
     )
     version(
         "15.0.1",
         sha256="8a438fe20103e27bfda132955616d0c886aa6cfdd86dcd9764af5d937a8799d9",
-        url="http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/4933/l_compxe_2015.1.133.tgz",
+        url="http://registrationcenter-download.intel.com/akdlm/IRC_NAS/tec/4933/l_compxe_2015.1.133.tgz",
         deprecated=True,
     )
 


### PR DESCRIPTION
There was a change in the way intel packages were hosted. Previously URL's could have irc_nas or IRC_NAS. Now IRC_NAS is required. Make the URL's all use IRC_NAS

Addresses #43262 

@prstrnn 

