### PR TITLE
re2: use the same standard that was used for abseil-cpp

### DIFF
--- a/var/spack/repos/builtin/packages/re2/package.py
+++ b/var/spack/repos/builtin/packages/re2/package.py
@@ -40,5 +40,6 @@ class Re2(CMakePackage):
         args = [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
+            f"-DCMAKE_CXX_STANDARD={self.spec['abseil-cpp'].variants['cxxstd'].value}",
         ]
         return args


### PR DESCRIPTION
Otherwise abseil-cpp can use something from std that isn't yet in current standard being used for re2. For example:

``` 
  >> 48     /m2-sonoma-apple-clang15.0.0-opt/abseil-cpp/20230802.1-r47ix3/include/absl/utility/utility.h:164:12: In file included
            from error: no member named 'in_place_t' in namespace 'std'
     49     using std::in_place_t;
```
in this case `abseil-cpp` was built with C++20 and re2 is being built with C++14. `std::in_place_t` was introduced in C++17