### PR TITLE
try getting shebang limits with fallback to hardcoded 127 characters

### DIFF
--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -26,6 +26,18 @@ if sys.platform == "darwin":
     system_shebang_limit = 511
 else:
     system_shebang_limit = 127
+    try:
+        # searching for line '#define BINPRM_BUF_SIZE 256' in /usr/include/linux/binfmts.h
+        # the nbr-1 is the sbang limit on the linux platform
+        sbang_limit_re = re.compile("#define BINPRM_BUF_SIZE ([0-9]+)")
+        with open("/usr/include/linux/binfmts.h", "r", encoding="utf-8") as f:
+            for line in f:
+                m = sbang_limit_re.match(line)
+                if m:
+                    system_shebang_limit = int(m.group(1)) - 1
+    except Exception:
+        # ignore any error a sane default is set already
+        pass
 
 #: Groupdb does not exist on Windows, prevent imports
 #: on supported systems


### PR DESCRIPTION
This PR tries to get the shebang limits onlinux platforms. It could fail getting this number for numerous reasons (e.g. linux-headers not installed, the define looks different). But any failure would result in the current behaviour of having 127 characters as hardcoded value.
If it finds the correct value, it will use it.
This would fix :  #43289