### PR TITLE
openCARP: Add v15.0 packages

### DIFF
--- a/var/spack/repos/builtin/packages/meshtool/package.py
+++ b/var/spack/repos/builtin/packages/meshtool/package.py
@@ -16,6 +16,7 @@ class Meshtool(MakefilePackage):
 
     version("master", branch="master", preferred=True)
     # Version to use with openCARP releases
+    version("oc15.0", commit="867431d")
     version("oc13.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc12.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc11.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")

--- a/var/spack/repos/builtin/packages/meshtool/package.py
+++ b/var/spack/repos/builtin/packages/meshtool/package.py
@@ -16,7 +16,9 @@ class Meshtool(MakefilePackage):
 
     version("master", branch="master", preferred=True)
     # Version to use with openCARP releases
-    version("oc15.0", commit="867431d")
+    # It is possible that different openCARP releases rely on the same
+    # meshtool version
+    version("oc15.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc13.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc12.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc11.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -23,7 +23,7 @@ class Opencarp(CMakePackage):
         commit="2271a3cccd7137f1e28c043c10adbd80480f1462",
         submodules=False,
         no_cache=True,
-        preferred=True
+        preferred=True,
     )
     version(
         "13.0", commit="e1e0deca7eddcfd210835f54430361c85a97a5a4", submodules=False, no_cache=True

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -19,11 +19,14 @@ class Opencarp(CMakePackage):
     maintainers("MarieHouillon")
 
     version(
-        "13.0",
-        commit="e1e0deca7eddcfd210835f54430361c85a97a5a4",
+        "15.0",
+        commit="2271a3cccd7137f1e28c043c10adbd80480f1462",
         submodules=False,
         no_cache=True,
-        preferred=True,
+        preferred=True
+    )
+    version(
+        "13.0", commit="e1e0deca7eddcfd210835f54430361c85a97a5a4", submodules=False, no_cache=True
     )
     version(
         "12.0", commit="a34c11af3e8c2afd6e123e586a446c6993e0b039", submodules=False, no_cache=True
@@ -46,7 +49,6 @@ class Opencarp(CMakePackage):
     version(
         "7.0", commit="78da91952738b45760bcbc34610814a83c8c6299", submodules=False, no_cache=True
     )
-    version("15.0", commit="2271a3cc", submodules=False, no_cache=True, preferred=True)
     version("master", branch="master", submodules=False, no_cache=True)
 
     variant("carputils", default=False, description="Installs the carputils framework")
@@ -67,7 +69,7 @@ class Opencarp(CMakePackage):
     depends_on("py-carputils", when="+carputils", type=("build", "run"))
     depends_on("meshtool", when="+meshtool", type=("build", "run"))
     # Use specific versions of carputils and meshtool for releases
-    for ver in ["15.0", "13.0", "12.0", "11.0", "10.0", "9.0", "8.2", "7.0", "8.1"]:
+    for ver in ["15.0", "13.0", "12.0", "11.0", "10.0", "9.0", "8.2", "8.1", "7.0"]:
         depends_on("py-carputils@oc" + ver, when="@" + ver + " +carputils")
         depends_on("meshtool@oc" + ver, when="@" + ver + " +meshtool")
 

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -46,6 +46,7 @@ class Opencarp(CMakePackage):
     version(
         "7.0", commit="78da91952738b45760bcbc34610814a83c8c6299", submodules=False, no_cache=True
     )
+    version("15.0", commit="2271a3cc", submodules=False, no_cache=True, preferred=True)
     version("master", branch="master", submodules=False, no_cache=True)
 
     variant("carputils", default=False, description="Installs the carputils framework")
@@ -66,7 +67,7 @@ class Opencarp(CMakePackage):
     depends_on("py-carputils", when="+carputils", type=("build", "run"))
     depends_on("meshtool", when="+meshtool", type=("build", "run"))
     # Use specific versions of carputils and meshtool for releases
-    for ver in ["13.0", "12.0", "11.0", "10.0", "9.0", "8.2", "7.0", "8.1"]:
+    for ver in ["15.0", "13.0", "12.0", "11.0", "10.0", "9.0", "8.2", "7.0", "8.1"]:
         depends_on("py-carputils@oc" + ver, when="@" + ver + " +carputils")
         depends_on("meshtool@oc" + ver, when="@" + ver + " +meshtool")
 

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -19,6 +19,7 @@ class PyCarputils(PythonPackage):
 
     version("master", branch="master")
     # Version to use with openCARP releases
+    version("oc15.0", commit="50e2580b3f75711388eb55982a9b43871c3201f3")
     version("oc13.0", commit="216c3802c2ac2d14c739164dcd57f2e59aa2ede3")
     version("oc12.0", commit="4d7a1f0c604a2ad232e70cf9aa3a8daff5ffb195")
     version("oc11.0", commit="a02f9b846c6e852b7315b20e925d55c355f239b8")

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -37,7 +37,7 @@ class PyCarputils(PythonPackage):
     depends_on("py-scipy@1.5.0:", type=("build", "run"))
     depends_on("py-matplotlib@3.0.0:", type=("build", "run"))
     depends_on("py-pandas", type=("build", "run"))
-    depends_on("py-tables@3.6.1:", type=("build", "run"))
+    depends_on("py-tables@3.8.0:", type=("build", "run"))
     depends_on("py-six@1.12.0:", type=("build", "run"))
     depends_on("py-pydoe@0.3.8", type=("build", "run"))
     depends_on("py-ruamel-yaml@0.17.4:", type=("build", "run"))


### PR DESCRIPTION
Add a new version for the packages of the openCARP ecosystem, opencarp, meshtool and py-carputils.