### PR TITLE
scipy: register conflict with too-recent openblas

### DIFF
--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -50,7 +50,7 @@ class PyScipy(PythonPackage):
     version("1.3.2", sha256="a03939b431994289f39373c57bbe452974a7da724ae7f9620a1beee575434da4")
 
     # Based on wheel availability on PyPI
-    depends_on("python@3.9:3.11", when="@1.11:", type=("build", "link", "run"))
+    depends_on("python@3.9:3.12", when="@1.11:", type=("build", "link", "run"))
     depends_on("python@3.8:3.11", when="@1.9.2:1.10", type=("build", "link", "run"))
     depends_on("python@3.8:3.10", when="@1.8:1.9.1", type=("build", "link", "run"))
     depends_on("python@:3.10", when="@1.7.2:1.7", type=("build", "link", "run"))
@@ -90,8 +90,7 @@ class PyScipy(PythonPackage):
     depends_on("py-setuptools@:59", when="@1.8", type="build")
     depends_on("py-setuptools@:57", when="@1.7", type="build")
     depends_on("py-setuptools@:51.0.0", when="@1.6", type="build")
-    depends_on("py-numpy@1.22.4:2", when="@1.12:", type=("build", "link", "run"))
-    depends_on("py-numpy@1.21.6:1.27", when="@1.11", type=("build", "link", "run"))
+    depends_on("py-numpy@1.21.6:1.27", when="@1.11:", type=("build", "link", "run"))
     depends_on("py-numpy@1.19.5:1.26", when="@1.10", type=("build", "link", "run"))
     depends_on("py-numpy@1.18.5:1.25", when="@1.9", type=("build", "link", "run"))
     depends_on("py-numpy@1.17.3:1.24", when="@1.8", type=("build", "link", "run"))
@@ -121,7 +120,7 @@ class PyScipy(PythonPackage):
     )
 
     # https://github.com/scipy/scipy/issues/19831
-    conflicts("openblas@0.3.26:", when="@:1.12")
+    conflicts("^openblas@0.3.26:", when="@:1.12")
 
     # https://github.com/scipy/scipy/issues/19352
     conflicts("^py-cython@3.0.3")

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -10,7 +10,7 @@ class PyScipy(PythonPackage):
     """Fundamental algorithms for scientific computing in Python."""
 
     homepage = "https://www.scipy.org/"
-    pypi = "scipy/scipy-1.10.1.tar.gz"
+    pypi = "scipy/scipy-1.12.0.tar.gz"
     git = "https://github.com/scipy/scipy.git"
 
     maintainers("adamjstewart", "rgommers")
@@ -18,6 +18,7 @@ class PyScipy(PythonPackage):
     license("BSD-3-Clause")
 
     version("main", branch="main")
+    version("1.12.0", sha256="4bf5abab8a36d20193c698b0f1fc282c1d083c94723902c447e5d2f1780936a3")
     version("1.11.4", sha256="90a2b78e7f5733b9de748f589f09225013685f9b218275257f8a8168ededaeaa")
     version("1.11.3", sha256="bba4d955f54edd61899776bad459bf7326e14b9fa1c552181f0479cc60a568cd")
     version("1.11.2", sha256="b29318a5e39bd200ca4381d80b065cdf3076c7d7281c5e36569e99273867f61d")
@@ -50,7 +51,8 @@ class PyScipy(PythonPackage):
     version("1.3.2", sha256="a03939b431994289f39373c57bbe452974a7da724ae7f9620a1beee575434da4")
 
     # Based on wheel availability on PyPI
-    depends_on("python@3.9:3.12", when="@1.11:", type=("build", "link", "run"))
+    depends_on("python@3.9:3.12", when="@1.12:", type=("build", "link", "run"))
+    depends_on("python@3.9:3.11", when="@1.11", type=("build", "link", "run"))
     depends_on("python@3.8:3.11", when="@1.9.2:1.10", type=("build", "link", "run"))
     depends_on("python@3.8:3.10", when="@1.8:1.9.1", type=("build", "link", "run"))
     depends_on("python@:3.10", when="@1.7.2:1.7", type=("build", "link", "run"))
@@ -90,7 +92,8 @@ class PyScipy(PythonPackage):
     depends_on("py-setuptools@:59", when="@1.8", type="build")
     depends_on("py-setuptools@:57", when="@1.7", type="build")
     depends_on("py-setuptools@:51.0.0", when="@1.6", type="build")
-    depends_on("py-numpy@1.21.6:1.27", when="@1.11:", type=("build", "link", "run"))
+    depends_on("py-numpy@1.22.4:2", when="@1.12:", type=("build", "link", "run"))
+    depends_on("py-numpy@1.21.6:1.27", when="@1.11", type=("build", "link", "run"))
     depends_on("py-numpy@1.19.5:1.26", when="@1.10", type=("build", "link", "run"))
     depends_on("py-numpy@1.18.5:1.25", when="@1.9", type=("build", "link", "run"))
     depends_on("py-numpy@1.17.3:1.24", when="@1.8", type=("build", "link", "run"))
@@ -118,6 +121,9 @@ class PyScipy(PythonPackage):
         msg="SciPy requires at least vc142 (default with Visual Studio 2019) "
         "when building with MSVC",
     )
+
+    # https://github.com/scipy/scipy/issues/19831
+    conflicts("openblas@0.3.26:", when="@:1.12")
 
     # https://github.com/scipy/scipy/issues/19352
     conflicts("^py-cython@3.0.3")

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -10,7 +10,7 @@ class PyScipy(PythonPackage):
     """Fundamental algorithms for scientific computing in Python."""
 
     homepage = "https://www.scipy.org/"
-    pypi = "scipy/scipy-1.12.0.tar.gz"
+    pypi = "scipy/scipy-1.10.1.tar.gz"
     git = "https://github.com/scipy/scipy.git"
 
     maintainers("adamjstewart", "rgommers")
@@ -18,7 +18,6 @@ class PyScipy(PythonPackage):
     license("BSD-3-Clause")
 
     version("main", branch="main")
-    version("1.12.0", sha256="4bf5abab8a36d20193c698b0f1fc282c1d083c94723902c447e5d2f1780936a3")
     version("1.11.4", sha256="90a2b78e7f5733b9de748f589f09225013685f9b218275257f8a8168ededaeaa")
     version("1.11.3", sha256="bba4d955f54edd61899776bad459bf7326e14b9fa1c552181f0479cc60a568cd")
     version("1.11.2", sha256="b29318a5e39bd200ca4381d80b065cdf3076c7d7281c5e36569e99273867f61d")
@@ -51,8 +50,7 @@ class PyScipy(PythonPackage):
     version("1.3.2", sha256="a03939b431994289f39373c57bbe452974a7da724ae7f9620a1beee575434da4")
 
     # Based on wheel availability on PyPI
-    depends_on("python@3.9:3.12", when="@1.12:", type=("build", "link", "run"))
-    depends_on("python@3.9:3.11", when="@1.11", type=("build", "link", "run"))
+    depends_on("python@3.9:3.11", when="@1.11:", type=("build", "link", "run"))
     depends_on("python@3.8:3.11", when="@1.9.2:1.10", type=("build", "link", "run"))
     depends_on("python@3.8:3.10", when="@1.8:1.9.1", type=("build", "link", "run"))
     depends_on("python@:3.10", when="@1.7.2:1.7", type=("build", "link", "run"))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

(on another note, a dependency bound on ~~numpy~~ EDIT: PYTHON was made more strict after looking at the dependency matrix on scipy's own online documentation)

**assumtions made by this patch:**:
- version ranges (like @2.1:2.2) are inclusive (I'm mostly sure of this, but I'ld rather not submit a broken patch if this is wrong)

checks:
- [X] spack unit-test -> no worse than before (4670 passed, 125 skipped, 11 xfailed, 18 xpassed, 40 warnings)
- [X] spack style -> OK
- [X] spec correctly constructed for most recent scipy
- [ ] scipy tests (I am not sure how to run them correctly on a pre-installed scipy. `spack test run py-scipy` seems to only return errors linked to not having cupy and torch installed)