### PR TITLE
x264: Tag a newer commit.

### DIFF
--- a/var/spack/repos/builtin/packages/x264/package.py
+++ b/var/spack/repos/builtin/packages/x264/package.py
@@ -13,6 +13,7 @@ class X264(AutotoolsPackage):
 
     license("GPL-2.0-or-later")
 
+    version("20240314", commit="585e01997f0c7e6d72c8ca466406d955c07de912")
     version("20210613", commit="5db6aa6cab1b146e07b60cc1736a01f21da01154")
 
     depends_on("nasm")


### PR DESCRIPTION
x264 does not publish releases so tag a newer commit in Spack in order to be able to use an up-to-date version.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
