### PR TITLE
py-torch-nvidia-apex: @3.11: Add config_settings(PEP517), add missing py-packaging

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch-nvidia-apex/package.py
+++ b/var/spack/repos/builtin/packages/py-torch-nvidia-apex/package.py
@@ -21,6 +21,7 @@ class PyTorchNvidiaApex(PythonPackage, CudaPackage):
 
     depends_on("python@3:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
+    depends_on("py-packaging", type="build")
     depends_on("py-torch@0.4:", type=("build", "run"))
     depends_on("cuda@9:", when="+cuda")
     depends_on("py-pybind11", type=("build", "link", "run"))
@@ -43,6 +44,7 @@ class PyTorchNvidiaApex(PythonPackage, CudaPackage):
         else:
             env.unset("CUDA_HOME")
 
+    @when("^python@:3.10")
     def global_options(self, spec, prefix):
         args = []
         if spec.satisfies("^py-torch@1.0:"):
@@ -50,3 +52,11 @@ class PyTorchNvidiaApex(PythonPackage, CudaPackage):
             if "+cuda" in spec:
                 args.append("--cuda_ext")
         return args
+
+    @when("^python@3.11:")
+    def config_settings(self, spec, prefix):
+        return {
+            "builddir": "build",
+            "compile-args": f"-j{make_jobs}",
+            "--global-option": "--cpp_ext --cuda_ext",
+        }


### PR DESCRIPTION
The installation of the package is failing with python 3.11 which uses pep 517. The global options specified are ignored in that case.