### PR TITLE
Upstream: uninstalled packages from upstreams

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -746,12 +746,13 @@ class Database:
     def query_by_spec_hash(
         self, hash_key: str, data: Optional[Dict[str, InstallRecord]] = None
     ) -> Tuple[bool, Optional[InstallRecord]]:
-        """Get a spec for hash, and whether it's installed upstream.
+        """Get an InstallRecord for a hash, and also indicate whether
+        the record is from an upstream DB.
 
         Return:
             (tuple): (bool, optional InstallRecord): bool tells us whether
-                the spec is installed upstream. Its InstallRecord is also
-                returned if it's installed at all; otherwise None.
+                the record is from an upstream DB. Its InstallRecord is
+                also returned; otherwise None.
         """
         if data and hash_key in data:
             return False, data[hash_key]

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1775,6 +1775,8 @@ class Spec:
         if not self.concrete:
             return False
 
+        #upstream, record = spack.store.STORE.db.query_by_spec_hash(self.dag_hash())
+        #return upstream and record.installed
         upstream, _ = spack.store.STORE.db.query_by_spec_hash(self.dag_hash())
         return upstream
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1775,10 +1775,8 @@ class Spec:
         if not self.concrete:
             return False
 
-        #upstream, record = spack.store.STORE.db.query_by_spec_hash(self.dag_hash())
-        #return upstream and record.installed
-        upstream, _ = spack.store.STORE.db.query_by_spec_hash(self.dag_hash())
-        return upstream
+        upstream, record = spack.store.STORE.db.query_by_spec_hash(self.dag_hash())
+        return upstream and record.installed
 
     def traverse(self, **kwargs):
         """Shorthand for :meth:`~spack.traverse.traverse_nodes`"""

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -328,6 +328,8 @@ def test_uninstalled_upstream(install_upstream, mock_fetch):
             record.installed = False
 
     with spack.store.use_store(store_root):
+        # Re-read the Database so in-memory state reflects updated
+        # upstream
         assert not dependency.installed_upstream
 
         dependent.package.do_install()

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -314,26 +314,25 @@ def test_installed_upstream(install_upstream, mock_fetch):
 
 def test_uninstalled_upstream(install_upstream, mock_fetch):
     """A dependency has a record in an upstream DB, but it is not
-       actually installed in that upstream.
+    actually installed in that upstream.
     """
     store_root, _, upstream_db = install_upstream("dependency-install")
     with spack.store.use_store(store_root):
-        dependency = spack.spec.Spec("dependency-install").concretized()
         dependent = spack.spec.Spec("dependent-install").concretized()
 
-        new_dependency = dependent["dependency-install"]
-        assert new_dependency.installed_upstream
+        dependency = dependent["dependency-install"]
+        assert dependency.installed_upstream
 
         with upstream_db.write_transaction():
-            _, record = upstream_db.query_by_spec_hash(new_dependency.dag_hash())
+            _, record = upstream_db.query_by_spec_hash(dependency.dag_hash())
             record.installed = False
 
     with spack.store.use_store(store_root):
-        assert not new_dependency.installed_upstream
+        assert not dependency.installed_upstream
 
         dependent.package.do_install()
 
-        assert os.path.exists(new_dependency.prefix)
+        assert os.path.exists(dependency.prefix)
 
 
 @pytest.mark.disable_clean_stage_check

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -328,6 +328,7 @@ def test_uninstalled_upstream(install_upstream, mock_fetch):
             _, record = upstream_db.query_by_spec_hash(new_dependency.dag_hash())
             record.installed = False
 
+    with spack.store.use_store(store_root):
         assert not new_dependency.installed_upstream
 
         dependent.package.do_install()


### PR DESCRIPTION
Generally when using an upstream, packages should not be uninstalled from it.

However, it is possible that a user might uninstall a package from a Spack instance before ever using it as an upstream, and in some of those cases it may occur that the associated DB retains a record of the Spec (although marked as uninstalled); in this case when used as an upstream, it was possible for `Spec.installed_upstream` to incorrectly report that a given Spec was installed in an upstream instance (since it took the presence of the record as an indication that the Spec was installed vs. looking at `InstallRecord.installed`); the result was that Spack would not install the Spec in a local instance.

This addresses that issue and adds a test.

Note that with these changes, for a series of upstreams X, Y, Z... if a spec like `zlib...` is present as a record in Y and not installed in Y, and also present as a record in Z and installed in Z, Spack will pick the first upstream that has any record, and will choose to install locally (since `zlib ...` is in fact not installed in Y).