### PR TITLE
python wheels: do not "expand"

### DIFF
--- a/lib/spack/llnl/url.py
+++ b/lib/spack/llnl/url.py
@@ -12,7 +12,7 @@ from urllib.parse import urlsplit, urlunsplit
 # Archive extensions allowed in Spack
 PREFIX_EXTENSIONS = ("tar", "TAR")
 EXTENSIONS = ("gz", "bz2", "xz", "Z")
-NO_TAR_EXTENSIONS = ("zip", "tgz", "tbz2", "tbz", "txz")
+NO_TAR_EXTENSIONS = ("zip", "tgz", "tbz2", "tbz", "txz", "whl")
 
 # Add PREFIX_EXTENSIONS and EXTENSIONS last so that .tar.gz is matched *before* .tar or .gz
 ALLOWED_ARCHIVE_TYPES = (
@@ -403,7 +403,7 @@ def expand_contracted_extension_in_path(
 def compression_ext_from_compressed_archive(extension: str) -> Optional[str]:
     """Returns compression extension for a compressed archive"""
     extension = expand_contracted_extension(extension)
-    for ext in [*EXTENSIONS]:
+    for ext in EXTENSIONS:
         if ext in extension:
             return ext
     return None

--- a/lib/spack/spack/test/llnl/url.py
+++ b/lib/spack/spack/test/llnl/url.py
@@ -148,6 +148,8 @@ def test_strip_compression_extension(archive_and_expected):
         assert stripped == "Foo.zip"
         stripped = llnl.url.strip_compression_extension(archive, "zip")
         assert stripped == "Foo"
+    elif extension == "whl":
+        assert stripped == "Foo.whl"
     elif (
         extension.lower() == "tar"
         or extension in llnl.url.CONTRACTION_MAP

--- a/lib/spack/spack/test/util/compression.py
+++ b/lib/spack/spack/test/util/compression.py
@@ -29,7 +29,9 @@ ext_archive = {}
 ]
 # Spack does not use Python native handling for tarballs or zip
 # Don't test tarballs or zip in native test
-native_archive_list = [key for key in ext_archive.keys() if "tar" not in key and "zip" not in key]
+native_archive_list = [
+    key for key in ext_archive.keys() if "tar" not in key and "zip" not in key and "whl" not in key
+]
 
 
 @pytest.fixture

--- a/lib/spack/spack/test/util/compression.py
+++ b/lib/spack/spack/test/util/compression.py
@@ -73,7 +73,9 @@ def test_native_unpacking(tmpdir_factory, archive_file_and_extension):
 
 @pytest.mark.not_on_windows("Only Python unpacking available on Windows")
 @pytest.mark.parametrize(
-    "archive_file_and_extension", [(ext, True) for ext in ext_archive.keys()], indirect=True
+    "archive_file_and_extension",
+    [(ext, True) for ext in ext_archive.keys() if "whl" not in ext],
+    indirect=True,
 )
 def test_system_unpacking(tmpdir_factory, archive_file_and_extension, compr_support_check):
     # actually run test

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -9,7 +9,7 @@ import io
 import os
 import shutil
 import sys
-from typing import BinaryIO, Callable, Dict, List, Optional
+from typing import Any, BinaryIO, Callable, Dict, List, Optional
 
 import llnl.url
 from llnl.util import tty
@@ -157,8 +157,8 @@ def _system_gunzip(archive_file: str) -> str:
     return destination_abspath
 
 
-def _do_nothing(archive_file: str) -> str:
-    pass
+def _do_nothing(archive_file: str) -> None:
+    return None
 
 
 def _unzip(archive_file: str) -> str:
@@ -287,7 +287,7 @@ def decompressor_for(path: str, extension: Optional[str] = None):
         return decompressor_for_nix(extension)
 
 
-def decompressor_for_nix(extension: str) -> Callable[[str], str]:
+def decompressor_for_nix(extension: str) -> Callable[[str], Any]:
     """Returns a function pointer to appropriate decompression algorithm based on extension type
     and unix specific considerations i.e. a reasonable expectation system utils like gzip, bzip2,
     and xz are available
@@ -295,7 +295,7 @@ def decompressor_for_nix(extension: str) -> Callable[[str], str]:
     Args:
         extension: path of the archive file requiring decompression
     """
-    extension_to_decompressor: Dict[str, Callable[[str], str]] = {
+    extension_to_decompressor: Dict[str, Callable[[str], Any]] = {
         "zip": _unzip,
         "gz": _gunzip,
         "bz2": _bunzip2,
@@ -307,7 +307,7 @@ def decompressor_for_nix(extension: str) -> Callable[[str], str]:
     return extension_to_decompressor.get(extension, _system_untar)
 
 
-def _determine_py_decomp_archive_strategy(extension: str) -> Optional[Callable[[str], str]]:
+def _determine_py_decomp_archive_strategy(extension: str) -> Optional[Callable[[str], Any]]:
     """Returns appropriate python based decompression strategy
     based on extension type"""
     extension_to_decompressor: Dict[str, Callable[[str], str]] = {
@@ -318,7 +318,7 @@ def _determine_py_decomp_archive_strategy(extension: str) -> Optional[Callable[[
     return extension_to_decompressor.get(extension, None)
 
 
-def decompressor_for_win(extension: str) -> Callable[[str], str]:
+def decompressor_for_win(extension: str) -> Callable[[str], Any]:
     """Returns a function pointer to appropriate decompression
     algorithm based on extension type and Windows specific considerations
 
@@ -328,7 +328,7 @@ def decompressor_for_win(extension: str) -> Callable[[str], str]:
     and files as Python does not provide support for the UNIX compress algorithm
     """
     extension = llnl.url.expand_contracted_extension(extension)
-    extension_to_decompressor: Dict[str, Callable[[str], str]] = {
+    extension_to_decompressor: Dict[str, Callable[[str], Any]] = {
         # Windows native tar can handle .zip extensions, use standard unzip method
         "zip": _unzip,
         # if extension is standard tarball, invoke Windows native tar

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -157,6 +157,10 @@ def _system_gunzip(archive_file: str) -> str:
     return destination_abspath
 
 
+def _do_nothing(archive_file: str) -> str:
+    pass
+
+
 def _unzip(archive_file: str) -> str:
     """Returns path to extracted zip archive. Extract Zipfile, searching for unzip system
     executable. If unavailable, search for 'tar' executable on system and use instead.
@@ -297,6 +301,7 @@ def decompressor_for_nix(extension: str) -> Callable[[str], str]:
         "bz2": _bunzip2,
         "Z": _system_unZ,  # no builtin support for .Z files
         "xz": _lzma_decomp,
+        "whl": _do_nothing,
     }
 
     return extension_to_decompressor.get(extension, _system_untar)
@@ -333,6 +338,7 @@ def decompressor_for_win(extension: str) -> Callable[[str], str]:
         # detected
         "Z": _system_unZ,
         "xz": _lzma_decomp,
+        "whl": _do_nothing,
     }
 
     decompressor = extension_to_decompressor.get(extension)

--- a/var/spack/repos/builtin/packages/py-azureml-automl-core/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-automl-core/package.py
@@ -14,11 +14,7 @@ class PyAzuremlAutomlCore(PythonPackage):
     homepage = "https://docs.microsoft.com/en-us/azure/machine-learning/service/"
     url = "https://pypi.io/packages/py3/a/azureml_automl_core/azureml_automl_core-1.11.0-py3-none-any.whl"
 
-    version(
-        "1.23.0",
-        sha256="1fa4a900856b15e1ec9a6bb949946ed0c873a5a54da3db592f03dbb46a117ceb",
-        expand=False,
-    )
+    version("1.23.0", sha256="1fa4a900856b15e1ec9a6bb949946ed0c873a5a54da3db592f03dbb46a117ceb")
 
     depends_on("python@3.5:3", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/py-azureml-core/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-core/package.py
@@ -17,21 +17,9 @@ class PyAzuremlCore(PythonPackage):
     homepage = "https://docs.microsoft.com/en-us/azure/machine-learning/service/"
     url = "https://pypi.io/packages/py3/a/azureml_core/azureml_core-1.11.0-py3-none-any.whl"
 
-    version(
-        "1.23.0",
-        sha256="0965d0741e39cdb95cff5880dbf1a55fdd87cd9fc316884f965668e6cc36e628",
-        expand=False,
-    )
-    version(
-        "1.11.0",
-        sha256="df8a01b04bb156852480de0bdd78434ed84f386e1891752bdf887faeaa2ca417",
-        expand=False,
-    )
-    version(
-        "1.8.0",
-        sha256="a0f2b0977f18fb7dcb88c314594a4a85c636a36be3d582be1cae25655fea6105",
-        expand=False,
-    )
+    version("1.23.0", sha256="0965d0741e39cdb95cff5880dbf1a55fdd87cd9fc316884f965668e6cc36e628")
+    version("1.11.0", sha256="df8a01b04bb156852480de0bdd78434ed84f386e1891752bdf887faeaa2ca417")
+    version("1.8.0", sha256="a0f2b0977f18fb7dcb88c314594a4a85c636a36be3d582be1cae25655fea6105")
 
     depends_on("python@3.5:3.8", type=("build", "run"))
     depends_on("py-pytz", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-azureml-dataprep-native/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-dataprep-native/package.py
@@ -17,13 +17,11 @@ class PyAzuremlDataprepNative(PythonPackage):
         version(
             "30.0.0-py3.9",
             sha256="eaf3fcd9f965e87b03fe89d7c6fe6abce53483a79afc963e4981061f4c250e85",
-            expand=False,
             url="https://pypi.io/packages/cp39/a/azureml_dataprep_native/azureml_dataprep_native-30.0.0-cp39-cp39-macosx_10_9_x86_64.whl",
         )
         version(
             "30.0.0-py3.8",
             sha256="6772b638f9d03a041b17ce4343061f5d543019200904b9d361b2b2629c3595a7",
-            expand=False,
             preferred=True,
             url="https://pypi.io/packages/cp38/a/azureml_dataprep_native/azureml_dataprep_native-30.0.0-cp38-cp38-macosx_10_9_x86_64.whl",
         )
@@ -31,13 +29,11 @@ class PyAzuremlDataprepNative(PythonPackage):
         version(
             "30.0.0-py3.9",
             sha256="b8673136948f682c84d047feacbfee436df053cba4f386f31c4c3a245a4e3646",
-            expand=False,
             url="https://pypi.io/packages/cp39/a/azureml_dataprep_native/azureml_dataprep_native-30.0.0-cp39-cp39-manylinux1_x86_64.whl",
         )
         version(
             "30.0.0-py3.8",
             sha256="d07cf20f22b14c98576e135bbad9bb8aaa3108941d2beaadf050b4238bc93a18",
-            expand=False,
             preferred=True,
             url="https://pypi.io/packages/cp38/a/azureml_dataprep_native/azureml_dataprep_native-30.0.0-cp38-cp38-manylinux1_x86_64.whl",
         )

--- a/var/spack/repos/builtin/packages/py-azureml-dataprep-rslex/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-dataprep-rslex/package.py
@@ -20,13 +20,11 @@ class PyAzuremlDataprepRslex(PythonPackage):
         version(
             "1.9.0-py3.9",
             sha256="9bdaa31d129dac19ee20d5a3aad1726397e90d8d741b4f6de4554040800fefe8",
-            expand=False,
             url="https://pypi.io/packages/cp39/a/azureml_dataprep_rslex/azureml_dataprep_rslex-1.9.0-cp39-cp39-macosx_10_9_x86_64.whl",
         )
         version(
             "1.9.0-py3.8",
             sha256="9b2e741ac1c53d3f7e6061d264feccf157d97e404c772933a176e6021014484e",
-            expand=False,
             preferred=True,
             url="https://pypi.io/packages/cp38/a/azureml_dataprep_rslex/azureml_dataprep_rslex-1.9.0-cp38-cp38-macosx_10_9_x86_64.whl",
         )
@@ -34,26 +32,22 @@ class PyAzuremlDataprepRslex(PythonPackage):
         version(
             "1.8.0-py3.9",
             sha256="677c25a7e23ec7f91d25aa596f382f7f3b6d60fbc3258bead2b2a6aa42f3a16d",
-            expand=False,
             url="https://pypi.io/packages/cp39/a/azureml_dataprep_rslex/azureml_dataprep_rslex-1.8.0-cp39-cp39-macosx_10_9_x86_64.whl",
         )
         version(
             "1.8.0-py3.8",
             sha256="d7f2dec06296544b1707f5b01c6a4eaad744b4abfe9e8e89830b561c84d95a7a",
-            expand=False,
             url="https://pypi.io/packages/cp38/a/azureml_dataprep_rslex/azureml_dataprep_rslex-1.8.0-cp38-cp38-macosx_10_9_x86_64.whl",
         )
     elif sys.platform.startswith("linux"):
         version(
             "1.9.0-py3.9",
             sha256="79d52bb427e3ca781a645c4f11f7a8e5e2c8f61e61bfc162b4062d8e47bcf3d6",
-            expand=False,
             url="https://pypi.io/packages/cp39/a/azureml_dataprep_rslex/azureml_dataprep_rslex-1.9.0-cp39-cp39-manylinux1_x86_64.whl",
         )
         version(
             "1.9.0-py3.8",
             sha256="a52461103b45867dd919bab593bb6f2426c9b5f5a435081e82a3c57c54c3add6",
-            expand=False,
             preferred=True,
             url="https://pypi.io/packages/cp38/a/azureml_dataprep_rslex/azureml_dataprep_rslex-1.9.0-cp38-cp38-manylinux1_x86_64.whl",
         )
@@ -61,13 +55,11 @@ class PyAzuremlDataprepRslex(PythonPackage):
         version(
             "1.8.0-py3.9",
             sha256="e251a077669703ca117b157b225fbc20832169f913476cf79c01a5c6f8ff7a50",
-            expand=False,
             url="https://pypi.io/packages/cp39/a/azureml_dataprep_rslex/azureml_dataprep_rslex-1.8.0-cp39-cp39-manylinux1_x86_64.whl",
         )
         version(
             "1.8.0-py3.8",
             sha256="2ebfa164f0933a5cec383cd27ba10d33861a73237ef481ada5a9a822bb55514a",
-            expand=False,
             url="https://pypi.io/packages/cp38/a/azureml_dataprep_rslex/azureml_dataprep_rslex-1.8.0-cp38-cp38-manylinux1_x86_64.whl",
         )
 

--- a/var/spack/repos/builtin/packages/py-azureml-dataprep/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-dataprep/package.py
@@ -13,16 +13,8 @@ class PyAzuremlDataprep(PythonPackage):
     homepage = "https://docs.microsoft.com/en-us/python/api/overview/azure/ml/?view=azure-ml-py"
     url = "https://pypi.io/packages/py3/a/azureml_dataprep/azureml_dataprep-2.0.2-py3-none-any.whl"
 
-    version(
-        "2.11.0",
-        sha256="755c0d7cfe228705aee7adc97813fb6d7d6ecb048b66f47c1fd5897f2709c3a2",
-        expand=False,
-    )
-    version(
-        "2.10.1",
-        sha256="a36f807112ff1e64d21265b8e7f40154c93e3bead539e2a74c9d74200fd77c86",
-        expand=False,
-    )
+    version("2.11.0", sha256="755c0d7cfe228705aee7adc97813fb6d7d6ecb048b66f47c1fd5897f2709c3a2")
+    version("2.10.1", sha256="a36f807112ff1e64d21265b8e7f40154c93e3bead539e2a74c9d74200fd77c86")
 
     variant("fuse", default=False, description="Build with FUSE support")
 

--- a/var/spack/repos/builtin/packages/py-azureml-dataset-runtime/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-dataset-runtime/package.py
@@ -14,11 +14,7 @@ class PyAzuremlDatasetRuntime(PythonPackage):
     homepage = "https://docs.microsoft.com/en-us/azure/machine-learning/service/"
     url = "https://pypi.io/packages/py3/a/azureml-dataset-runtime/azureml_dataset_runtime-1.11.0.post1-py3-none-any.whl"
 
-    version(
-        "1.23.0",
-        sha256="96ca73d03ffedc0dd336d9383d2e17cf74548a89fc7ca4c201c599817c97bbc6",
-        expand=False,
-    )
+    version("1.23.0", sha256="96ca73d03ffedc0dd336d9383d2e17cf74548a89fc7ca4c201c599817c97bbc6")
 
     variant("fuse", default=False, description="Build with FUSE support")
 

--- a/var/spack/repos/builtin/packages/py-azureml-pipeline-core/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-pipeline-core/package.py
@@ -13,21 +13,9 @@ class PyAzuremlPipelineCore(PythonPackage):
     homepage = "https://docs.microsoft.com/en-us/azure/machine-learning/service/"
     url = "https://pypi.io/packages/py3/a/azureml_pipeline_core/azureml_pipeline_core-1.11.0-py3-none-any.whl"
 
-    version(
-        "1.23.0",
-        sha256="347e3e41559879611d53eeff5c05dd133db6fa537edcf2b9f70d91aad461df02",
-        expand=False,
-    )
-    version(
-        "1.11.0",
-        sha256="98012195e3bba12bf42ac69179549038b3563b39e3dadab4f1d06407a00ad8b3",
-        expand=False,
-    )
-    version(
-        "1.8.0",
-        sha256="24e1c57a57e75f9d74ea6f45fa4e93c1ee3114c8ed9029d538f9cc8e4f8945b2",
-        expand=False,
-    )
+    version("1.23.0", sha256="347e3e41559879611d53eeff5c05dd133db6fa537edcf2b9f70d91aad461df02")
+    version("1.11.0", sha256="98012195e3bba12bf42ac69179549038b3563b39e3dadab4f1d06407a00ad8b3")
+    version("1.8.0", sha256="24e1c57a57e75f9d74ea6f45fa4e93c1ee3114c8ed9029d538f9cc8e4f8945b2")
 
     depends_on("python@3.5:3", type=("build", "run"))
     depends_on("py-azureml-core@1.23.0:1.23", when="@1.23.0", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-azureml-pipeline-steps/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-pipeline-steps/package.py
@@ -13,11 +13,7 @@ class PyAzuremlPipelineSteps(PythonPackage):
     homepage = "https://docs.microsoft.com/en-us/azure/machine-learning/service/"
     url = "https://pypi.io/packages/py3/a/azureml_pipeline_steps/azureml_pipeline_steps-1.11.0-py3-none-any.whl"
 
-    version(
-        "1.23.0",
-        sha256="72154c2f75624a1e7500b8e2239ae1354eeedf66d2cabb11e213b7eb80aedddb",
-        expand=False,
-    )
+    version("1.23.0", sha256="72154c2f75624a1e7500b8e2239ae1354eeedf66d2cabb11e213b7eb80aedddb")
 
     depends_on("python@3:", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/py-azureml-pipeline/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-pipeline/package.py
@@ -16,11 +16,7 @@ class PyAzuremlPipeline(PythonPackage):
         "https://pypi.io/packages/py3/a/azureml_pipeline/azureml_pipeline-1.11.0-py3-none-any.whl"
     )
 
-    version(
-        "1.23.0",
-        sha256="ed0fae96771840d3ffd63d63df1b1eed2f50c3b8dbe7b672a4f1ba6e66d0a392",
-        expand=False,
-    )
+    version("1.23.0", sha256="ed0fae96771840d3ffd63d63df1b1eed2f50c3b8dbe7b672a4f1ba6e66d0a392")
 
     depends_on("python@3:", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/py-azureml-sdk/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-sdk/package.py
@@ -15,11 +15,7 @@ class PyAzuremlSdk(PythonPackage):
 
     maintainers("adamjstewart")
 
-    version(
-        "1.23.0",
-        sha256="b9520f426831acb99fafa1ecd154b6bfd4f73fbf71e918d819f9db4a75438ab9",
-        expand=False,
-    )
+    version("1.23.0", sha256="b9520f426831acb99fafa1ecd154b6bfd4f73fbf71e918d819f9db4a75438ab9")
 
     # https://github.com/Azure/MachineLearningNotebooks/issues/1285
     depends_on("python@3.5:3.8", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-azureml-telemetry/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-telemetry/package.py
@@ -14,21 +14,9 @@ class PyAzuremlTelemetry(PythonPackage):
     homepage = "https://docs.microsoft.com/en-us/azure/machine-learning/service/"
     url = "https://pypi.io/packages/py3/a/azureml_telemetry/azureml_telemetry-1.11.0-py3-none-any.whl"
 
-    version(
-        "1.23.0",
-        sha256="68f9aac77e468db80e60f75d0843536082e2884ab251b6d3054dd623bd9c9e0d",
-        expand=False,
-    )
-    version(
-        "1.11.0",
-        sha256="0d46c4a7bb8c0b188f1503504a6029384bc2237d82a131e7d1e9e89c3491b1fc",
-        expand=False,
-    )
-    version(
-        "1.8.0",
-        sha256="de657efe9773bea0de76c432cbab34501ac28606fe1b380d6883562ebda3d804",
-        expand=False,
-    )
+    version("1.23.0", sha256="68f9aac77e468db80e60f75d0843536082e2884ab251b6d3054dd623bd9c9e0d")
+    version("1.11.0", sha256="0d46c4a7bb8c0b188f1503504a6029384bc2237d82a131e7d1e9e89c3491b1fc")
+    version("1.8.0", sha256="de657efe9773bea0de76c432cbab34501ac28606fe1b380d6883562ebda3d804")
 
     depends_on("python@3.5:3", type=("build", "run"))
     depends_on("py-applicationinsights", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-azureml-train-automl-client/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-train-automl-client/package.py
@@ -15,11 +15,7 @@ class PyAzuremlTrainAutomlClient(PythonPackage):
     homepage = "https://docs.microsoft.com/en-us/azure/machine-learning/service/"
     url = "https://pypi.io/packages/py3/a/azureml_train_automl_client/azureml_train_automl_client-1.11.0-py3-none-any.whl"
 
-    version(
-        "1.23.0",
-        sha256="ac5f1ce9b04b4e61e2e28e0fa8d2d8e47937a546f624d1cd3aa6bc4f9110ecbe",
-        expand=False,
-    )
+    version("1.23.0", sha256="ac5f1ce9b04b4e61e2e28e0fa8d2d8e47937a546f624d1cd3aa6bc4f9110ecbe")
 
     depends_on("python@3.5:3", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/py-azureml-train-core/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-train-core/package.py
@@ -14,21 +14,9 @@ class PyAzuremlTrainCore(PythonPackage):
     homepage = "https://docs.microsoft.com/en-us/azure/machine-learning/service/"
     url = "https://pypi.io/packages/py3/a/azureml_train_core/azureml_train_core-1.11.0-py3-none-any.whl"
 
-    version(
-        "1.23.0",
-        sha256="5c384ea0bea3ecd8bf2a1832dda906fd183cf2a03ad3372cb824ce8fa417979e",
-        expand=False,
-    )
-    version(
-        "1.11.0",
-        sha256="1b5fd813d21e75cd522d3a078eba779333980a309bcff6fc72b74ddc8e7a26f1",
-        expand=False,
-    )
-    version(
-        "1.8.0",
-        sha256="5a8d90a08d4477527049d793feb40d07dc32fafc0e4e57b4f0729d3c50b408a2",
-        expand=False,
-    )
+    version("1.23.0", sha256="5c384ea0bea3ecd8bf2a1832dda906fd183cf2a03ad3372cb824ce8fa417979e")
+    version("1.11.0", sha256="1b5fd813d21e75cd522d3a078eba779333980a309bcff6fc72b74ddc8e7a26f1")
+    version("1.8.0", sha256="5a8d90a08d4477527049d793feb40d07dc32fafc0e4e57b4f0729d3c50b408a2")
 
     depends_on("python@3.5:3", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/py-azureml-train-restclients-hyperdrive/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-train-restclients-hyperdrive/package.py
@@ -14,21 +14,9 @@ class PyAzuremlTrainRestclientsHyperdrive(PythonPackage):
     homepage = "https://docs.microsoft.com/en-us/azure/machine-learning/service/"
     url = "https://pypi.io/packages/py3/a/azureml_train_restclients_hyperdrive/azureml_train_restclients_hyperdrive-1.11.0-py3-none-any.whl"
 
-    version(
-        "1.23.0",
-        sha256="8ecee0cdb92a4a431b778ebcc7f9fe7c5bf63ea4cae9caa687980bc34ae3a42c",
-        expand=False,
-    )
-    version(
-        "1.11.0",
-        sha256="8bc6f9676a9f75e6ee06d201c418ea904c24e854f26cf799b08c259c3ac92d13",
-        expand=False,
-    )
-    version(
-        "1.8.0",
-        sha256="1633c7eb0fd96714f54f72072ccf1c5ee1ef0a8ba52680793f20d27e0fd43c87",
-        expand=False,
-    )
+    version("1.23.0", sha256="8ecee0cdb92a4a431b778ebcc7f9fe7c5bf63ea4cae9caa687980bc34ae3a42c")
+    version("1.11.0", sha256="8bc6f9676a9f75e6ee06d201c418ea904c24e854f26cf799b08c259c3ac92d13")
+    version("1.8.0", sha256="1633c7eb0fd96714f54f72072ccf1c5ee1ef0a8ba52680793f20d27e0fd43c87")
 
     depends_on("python@3.5:3", type=("build", "run"))
     depends_on("py-requests@2.19.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-azureml-train/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-train/package.py
@@ -15,21 +15,9 @@ class PyAzuremlTrain(PythonPackage):
     homepage = "https://docs.microsoft.com/en-us/azure/machine-learning/service/"
     url = "https://pypi.io/packages/py3/a/azureml_train/azureml_train-1.11.0-py3-none-any.whl"
 
-    version(
-        "1.23.0",
-        sha256="e16cb8673d9c9c70966c37c7362ceed3514e9797b0816c0aa449730da3b9c857",
-        expand=False,
-    )
-    version(
-        "1.11.0",
-        sha256="7800a3067979972b976c81082dc509e23c04405129cc1fdef0f9cd7895bcafc7",
-        expand=False,
-    )
-    version(
-        "1.8.0",
-        sha256="124e5b7d8d64bac61db022f305bd31c25e57fdcb4be93eefd4244a04a13deab3",
-        expand=False,
-    )
+    version("1.23.0", sha256="e16cb8673d9c9c70966c37c7362ceed3514e9797b0816c0aa449730da3b9c857")
+    version("1.11.0", sha256="7800a3067979972b976c81082dc509e23c04405129cc1fdef0f9cd7895bcafc7")
+    version("1.8.0", sha256="124e5b7d8d64bac61db022f305bd31c25e57fdcb4be93eefd4244a04a13deab3")
 
     depends_on("python@3.5:3", type=("build", "run"))
     depends_on("py-azureml-train-core@1.23.0:1.23", when="@1.23.0", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-climate/package.py
+++ b/var/spack/repos/builtin/packages/py-climate/package.py
@@ -14,10 +14,6 @@ class PyClimate(PythonPackage):
 
     license("Apache-2.0")
 
-    version(
-        "0.1.0",
-        sha256="01026c764b34d8204b8f527a730ef667fa5827fca765993ff1ed3e9dab2c11ae",
-        expand=False,
-    )
+    version("0.1.0", sha256="01026c764b34d8204b8f527a730ef667fa5827fca765993ff1ed3e9dab2c11ae")
 
     depends_on("python@3.7:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-dotnetcore2/package.py
+++ b/var/spack/repos/builtin/packages/py-dotnetcore2/package.py
@@ -17,14 +17,12 @@ class PyDotnetcore2(PythonPackage):
         version(
             "2.1.14",
             sha256="68182f4b704db401b2012c10ed8a19561f8d487063632f8731c2e58960ca9242",
-            expand=False,
             url="https://pypi.io/packages/py3/d/dotnetcore2/dotnetcore2-2.1.14-py3-none-macosx_10_9_x86_64.whl",
         )
     elif sys.platform.startswith("linux"):
         version(
             "2.1.14",
             sha256="d8d83ac30c22a0e48a9a881e117d98da17f95c4098cb9500a35e323b8e4ab737",
-            expand=False,
             url="https://pypi.io/packages/py3/d/dotnetcore2/dotnetcore2-2.1.14-py3-none-manylinux1_x86_64.whl",
         )
 

--- a/var/spack/repos/builtin/packages/py-igor2/package.py
+++ b/var/spack/repos/builtin/packages/py-igor2/package.py
@@ -15,11 +15,7 @@ class PyIgor2(PythonPackage):
 
     license("LGPL-3.0-or-later")
 
-    version(
-        "0.5.3",
-        sha256="bb7b54a5926ec640e0e9176f46e0dd88ad956fec2d17ba3b0a7687eba82cefee",
-        expand=False,
-    )
+    version("0.5.3", sha256="bb7b54a5926ec640e0e9176f46e0dd88ad956fec2d17ba3b0a7687eba82cefee")
 
     depends_on("python@3.8:3", type=("build", "run"))
     depends_on("py-numpy@1.25.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-installer/package.py
+++ b/var/spack/repos/builtin/packages/py-installer/package.py
@@ -17,16 +17,8 @@ class PyInstaller(Package, PythonExtension):
     )
     list_url = "https://pypi.org/simple/installer/"
 
-    version(
-        "0.7.0",
-        sha256="05d1933f0a5ba7d8d6296bb6d5018e7c94fa473ceb10cf198a92ccea19c27b53",
-        expand=False,
-    )
-    version(
-        "0.6.0",
-        sha256="ae7c62d1d6158b5c096419102ad0d01fdccebf857e784cee57f94165635fe038",
-        expand=False,
-    )
+    version("0.7.0", sha256="05d1933f0a5ba7d8d6296bb6d5018e7c94fa473ceb10cf198a92ccea19c27b53")
+    version("0.6.0", sha256="ae7c62d1d6158b5c096419102ad0d01fdccebf857e784cee57f94165635fe038")
 
     extends("python")
 

--- a/var/spack/repos/builtin/packages/py-intel-openmp/package.py
+++ b/var/spack/repos/builtin/packages/py-intel-openmp/package.py
@@ -23,7 +23,6 @@ class PyIntelOpenmp(PythonPackage):
             "2021.1.2",
             url="https://pypi.io/packages/py2.py3/i/intel-openmp/intel_openmp-2021.1.2-py2.py3-none-manylinux1_x86_64.whl",
             sha256="8796797ecae99f39b27065e4a7f1f435e2ca08afba654ca57a77a2717f864dca",
-            expand=False,
         )
 
     if sys.platform.startswith("darwin"):
@@ -31,5 +30,4 @@ class PyIntelOpenmp(PythonPackage):
             "2021.1.2",
             url="https://pypi.io/packages/py2.py3/i/intel-openmp/intel_openmp-2021.1.2-py2.py3-none-macosx_10_15_x86_64.whl",
             sha256="2af893738b4b06cb0183746f2992169111031340b59c84a0fd4dec1ed66b80f2",
-            expand=False,
         )

--- a/var/spack/repos/builtin/packages/py-itk/package.py
+++ b/var/spack/repos/builtin/packages/py-itk/package.py
@@ -21,7 +21,6 @@ class PyItk(PythonPackage):
             "5.1.1-cp38",
             url="https://pypi.io/packages/cp35/i/itk/itk-5.1.1-cp38-cp38-macosx_10_9_x86_64.whl",
             sha256="94b09ab9dd59ceaecc456ede2b719a44b8f0d54d92409eede372c6004395ae7b",
-            expand=False,
         )
 
         # version 5.1.2
@@ -29,13 +28,11 @@ class PyItk(PythonPackage):
             "5.1.2-cp38",
             url="https://pypi.io/packages/cp38/i/itk/itk-5.1.2-cp38-cp38-macosx_10_9_x86_64.whl",
             sha256="e8dec75b4452bd2ee65beb4901b245fc3a2a2ccc46dfa008ae0b5b757718d458",
-            expand=False,
         )
         version(
             "5.1.2-cp39",
             url="https://pypi.io/packages/cp39/i/itk/itk-5.1.2-cp39-cp39-macosx_10_9_x86_64.whl",
             sha256="e8dec75b4452bd2ee65beb4901b245fc3a2a2ccc46dfa008ae0b5b757718d458",
-            expand=False,
         )
 
         # version 5.3.0
@@ -43,25 +40,21 @@ class PyItk(PythonPackage):
             "5.3.0-cp38",
             url="https://pypi.io/packages/cp38/i/itk/itk-5.3.0-cp38-cp38-macosx_10_9_x86_64.whl",
             sha256="1fbcde6f6612b13d2934722707fd7194b1d5900a655efa191dfc130bbb94df09",
-            expand=False,
         )
         version(
             "5.3.0-cp39",
             url="https://pypi.io/packages/cp39/i/itk/itk-5.3.0-cp39-cp39-macosx_10_9_x86_64.whl",
             sha256="155581581929dfe834af6c6233a8c83e2ca2b1f52d6c7b2c81f04dc249aab1a5",
-            expand=False,
         )
         version(
             "5.3.0-cp310",
             url="https://pypi.io/packages/cp310/i/itk/itk-5.3.0-cp310-cp310-macosx_10_9_x86_64.whl",
             sha256="f92ec860173c82eb458764b4b5b771783b690c3aa3a01d15c6f3d008fc2bb493",
-            expand=False,
         )
         version(
             "5.3.0-cp311",
             url="https://pypi.io/packages/cp311/i/itk/itk-5.3.0-cp311-cp311-macosx_10_9_x86_64.whl",
             sha256="9dcfd9721ff6022e91eb98dc4004d437de2912dfd50d707d1ee72b89c334a3d4",
-            expand=False,
         )
     elif sys.platform.startswith("linux"):
         # version 5.1.1
@@ -69,7 +62,6 @@ class PyItk(PythonPackage):
             "5.1.1-cp38",
             url="https://pypi.io/packages/cp38/i/itk/itk-5.1.1-cp38-cp38-manylinux1_x86_64.whl",
             sha256="14cd6c3a25f0d69f45eda74b006eceeaf8e2b2fcbe7c343e49683edf97e0fb14",
-            expand=False,
         )
 
         # version 5.1.2
@@ -77,13 +69,11 @@ class PyItk(PythonPackage):
             "5.1.2-cp38",
             url="https://pypi.io/packages/cp38/i/itk/itk-5.1.2-cp38-cp38-manylinux1_x86_64.whl",
             sha256="fe9225ac353116f4000c0a3440bf151200beb4a65deec5b2e626edda5b498f16",
-            expand=False,
         )
         version(
             "5.1.2-cp39",
             url="https://pypi.io/packages/cp39/i/itk/itk-5.1.2-cp39-cp39-manylinux1_x86_64.whl",
             sha256="5781b74410b7189a825c89d370411595e5e3d5dbb480201907f751f26698df83",
-            expand=False,
         )
 
         # version 5.3.0
@@ -91,25 +81,21 @@ class PyItk(PythonPackage):
             "5.3.0-cp38",
             url="https://pypi.io/packages/cp38/i/itk/itk-5.3.0-cp38-cp38-manylinux_2_28_x86_64.whl",
             sha256="d83dc2b0f5d673226ef6eacac012d1da6dd36c6126f2b3cffc7ed62231c29bf2",
-            expand=False,
         )
         version(
             "5.3.0-cp39",
             url="https://pypi.io/packages/cp39/i/itk/itk-5.3.0-cp39-cp39-manylinux_2_28_x86_64.whl",
             sha256="bcc4449f2df35224cbc26472475d2afeb8a92886a81db950b2305f911bc2a38c",
-            expand=False,
         )
         version(
             "5.3.0-cp310",
             url="https://pypi.io/packages/cp310/i/itk/itk-5.3.0-cp310-cp310-manylinux_2_28_x86_64.whl",
             sha256="272708ee5ed5d09a519b2e98ac9c130f3146630257506ea440c83501c16f9580",
-            expand=False,
         )
         version(
             "5.3.0-cp311",
             url="https://pypi.io/packages/cp311/i/itk/itk-5.3.0-cp311-cp311-manylinux_2_28_x86_64.whl",
             sha256="ba8361a8ed1c5462e690ee893f624c0babb7a1072a15609c26790eea717e3f77",
-            expand=False,
         )
 
     depends_on("python@3.8.0:3.8", when="@5.1.1-cp38,5.1.2-cp38,5.3.0-cp38", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-jupyterlab-pygments/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyterlab-pygments/package.py
@@ -18,21 +18,9 @@ class PyJupyterlabPygments(PythonPackage):
     # -> py-jupyter-server -> py-nbconvert
     # Reported here: https://github.com/jupyterlab/jupyterlab_pygments/issues/23
 
-    version(
-        "0.2.2",
-        sha256="2405800db07c9f770863bcf8049a529c3dd4d3e28536638bd7c1c01d2748309f",
-        expand=False,
-    )
-    version(
-        "0.1.2",
-        sha256="abfb880fd1561987efaefcb2d2ac75145d2a5d0139b1876d5be806e32f630008",
-        expand=False,
-    )
-    version(
-        "0.1.1",
-        sha256="c9535e5999f29bff90bd0fa423717dcaf247b71fad505d66b17d3217e9021fc5",
-        expand=False,
-    )
+    version("0.2.2", sha256="2405800db07c9f770863bcf8049a529c3dd4d3e28536638bd7c1c01d2748309f")
+    version("0.1.2", sha256="abfb880fd1561987efaefcb2d2ac75145d2a5d0139b1876d5be806e32f630008")
+    version("0.1.1", sha256="c9535e5999f29bff90bd0fa423717dcaf247b71fad505d66b17d3217e9021fc5")
 
     depends_on("python@3.7:", when="@0.2.2:", type=("build", "run"))
     depends_on("py-pygments@2.4.1:2", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-jupyterlab-widgets/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyterlab-widgets/package.py
@@ -16,21 +16,9 @@ class PyJupyterlabWidgets(PythonPackage):
 
     license("BSD-3-Clause")
 
-    version(
-        "3.0.3",
-        sha256="6aa1bc0045470d54d76b9c0b7609a8f8f0087573bae25700a370c11f82cb38c8",
-        expand=False,
-    )
-    version(
-        "1.1.0",
-        sha256="c2a9bd3789f120f64d73268c066ed3b000c56bc1dda217be5cdc43e7b4ebad3f",
-        expand=False,
-    )
-    version(
-        "1.0.2",
-        sha256="f5d9efface8ec62941173ba1cffb2edd0ecddc801c11ae2931e30b50492eb8f7",
-        expand=False,
-    )
+    version("3.0.3", sha256="6aa1bc0045470d54d76b9c0b7609a8f8f0087573bae25700a370c11f82cb38c8")
+    version("1.1.0", sha256="c2a9bd3789f120f64d73268c066ed3b000c56bc1dda217be5cdc43e7b4ebad3f")
+    version("1.0.2", sha256="f5d9efface8ec62941173ba1cffb2edd0ecddc801c11ae2931e30b50492eb8f7")
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("python@3.7:", when="@3.0.3:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-lightning-api-access/package.py
+++ b/var/spack/repos/builtin/packages/py-lightning-api-access/package.py
@@ -15,8 +15,4 @@ class PyLightningApiAccess(PythonPackage):
     url = "https://files.pythonhosted.org/packages/py3/l/lightning-api-access/lightning_api_access-0.0.5-py3-none-any.whl"
     list_url = "https://pypi.org/simple/lightning-api-access/"
 
-    version(
-        "0.0.5",
-        sha256="08657fee636377534332df92e0bee893d46cb877f9642cba09ce560aed95fd40",
-        expand=False,
-    )
+    version("0.0.5", sha256="08657fee636377534332df92e0bee893d46cb877f9642cba09ce560aed95fd40")

--- a/var/spack/repos/builtin/packages/py-nvidia-dali/package.py
+++ b/var/spack/repos/builtin/packages/py-nvidia-dali/package.py
@@ -26,148 +26,124 @@ class PyNvidiaDali(PythonPackage):
         version(
             "1.27.0-cuda120",
             sha256="d8def4361bd9f888ddac3e2316b9eb89ee216f280c0973be12b8e1061d1ff108",
-            expand=False,
             preferred=True,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda120/nvidia_dali_cuda120-1.27.0-8625314-py3-none-manylinux2014_x86_64.whl",
         )
         version(
             "1.27.0-cuda110",
             sha256="9edf5097787cb1bbbbabc291d814bf367c5f5a986cffa101205fe31c86418a66",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda110/nvidia_dali_cuda110-1.27.0-8625303-py3-none-manylinux2014_x86_64.whl",
         )
         version(
             "1.26.0-cuda120",
             sha256="784dbad4e4e1399b4d2f51bfa1a01e3e23f6fb37e8f327cf136df9c1b5fb8470",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda120/nvidia_dali_cuda120-1.26.0-8269288-py3-none-manylinux2014_x86_64.whl",
         )
         version(
             "1.26.0-cuda110",
             sha256="545b56c104def627d6c2ead747875eaadba2e12610850b4480f718dc3e8a9177",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda110/nvidia_dali_cuda110-1.26.0-8269290-py3-none-manylinux2014_x86_64.whl",
         )
         version(
             "1.25.0-cuda120",
             sha256="72591f0db9fe6dd82035b2b6cc41aed478e48656ba99e81344a9cb59123710aa",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda120/nvidia_dali_cuda120-1.25.0-7922358-py3-none-manylinux2014_x86_64.whl",
         )
         version(
             "1.25.0-cuda110",
             sha256="9901cfa0f67674e5d2b77dbd90d3506b42390d12fc5996593fd395c0370ea46f",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda110/nvidia_dali_cuda110-1.25.0-7922357-py3-none-manylinux2014_x86_64.whl",
         )
         version(
             "1.24.0-cuda120",
             sha256="f280fba3e917a0c47e705fa488c6d53e5c50629b3664fe6cf95d0913213f3b13",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda120/nvidia_dali_cuda120-1.24.0-7582307-py3-none-manylinux2014_x86_64.whl",
         )
         version(
             "1.24.0-cuda110",
             sha256="5988317a5f17fdefa9254bebb6f8dc344c2b0bd958badf6688172e537d324d60",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda110/nvidia_dali_cuda110-1.24.0-7582302-py3-none-manylinux2014_x86_64.whl",
         )
         version(
             "1.23.0-cuda120",
             sha256="d10a14074df6cdd38adb1181785372ab8ace677323fdf62d2bc07e28a8469ef0",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda120/nvidia_dali_cuda120-1.23.0-7355174-py3-none-manylinux2014_x86_64.whl",
         )
         version(
             "1.23.0-cuda110",
             sha256="ede8245d3f7df181abdc5c5109a79be1ba9b6d888ca9f693f62db2c95efad267",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda110/nvidia_dali_cuda110-1.23.0-7355173-py3-none-manylinux2014_x86_64.whl",
         )
         version(
             "1.22.0-cuda120",
             sha256="6cbd9e3139d4c203f61f960f5ad1fc4b461621a60b7fa7ef0ba6d77c780b35f4",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda120/nvidia_dali_cuda120-1.22.0-6971317-py3-none-manylinux2014_x86_64.whl",
         )
         version(
             "1.22.0-cuda110",
             sha256="8c3ccc7eddc1f63d3f858448c5c384ab129273e0c140e091aca2a98d48c5a80c",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda110/nvidia_dali_cuda110-1.22.0-6988993-py3-none-manylinux2014_x86_64.whl",
         )
     elif "linux" in system and arch == "aarch64":
         version(
             "1.27.0-cuda120",
             sha256="57700656c4dd411497d3f8c690d409c71d6a8e9c2cc5e70499098dd0a01fd56b",
-            expand=False,
             preferred=True,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda120/nvidia_dali_cuda120-1.27.0-8625314-py3-none-manylinux2014_aarch64.whl",
         )
         version(
             "1.27.0-cuda110",
             sha256="8c28429f979c3fcb45f40f08efdae4b6ed3f4743634d41722a6c94d18c4cd995",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda110/nvidia_dali_cuda110-1.27.0-8625303-py3-none-manylinux2014_aarch64.whl",
         )
         version(
             "1.26.0-cuda120",
             sha256="9672969cab3d1a009b9e2bf3b139aec06af46f67a45a128098f8279736848079",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda120/nvidia_dali_cuda120-1.26.0-8269288-py3-none-manylinux2014_aarch64.whl",
         )
         version(
             "1.26.0-cuda110",
             sha256="e90fcb896cc0ee22a0fa5476a8fde8227412683796367334636c3f844e208975",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda110/nvidia_dali_cuda110-1.26.0-8269290-py3-none-manylinux2014_aarch64.whl",
         )
         version(
             "1.25.0-cuda120",
             sha256="f497ce8bf0df83e5c72b393a621d910bc712c6cdc4bbba6db50cf1cbc47d881b",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda120/nvidia_dali_cuda120-1.25.0-7922358-py3-none-manylinux2014_aarch64.whl",
         )
         version(
             "1.25.0-cuda110",
             sha256="2eb94223ac980658606af6a56720ce963f4fd877c1291d08517f82ce435b4155",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda110/nvidia_dali_cuda110-1.25.0-7922357-py3-none-manylinux2014_aarch64.whl",
         )
         version(
             "1.24.0-cuda120",
             sha256="2a7fab1d94b23edde1cee5b93918aca6b86417e3ffb4544adcb9961c73375014",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda120/nvidia_dali_cuda120-1.24.0-7582307-py3-none-manylinux2014_aarch64.whl",
         )
         version(
             "1.24.0-cuda110",
             sha256="84711689dacc787dfd90bfc66da7ce4b1884a006b763109e9ecf0b07aefacbc2",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda110/nvidia_dali_cuda110-1.24.0-7582302-py3-none-manylinux2014_aarch64.whl",
         )
         version(
             "1.23.0-cuda120",
             sha256="911d16b40c95b8cc700d3c96b40d3144953e7ffbb191ec22a75990c76cf638c3",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda120/nvidia_dali_cuda120-1.23.0-7355174-py3-none-manylinux2014_aarch64.whl",
         )
         version(
             "1.23.0-cuda110",
             sha256="ca58f2990825d18736c872f48d3f5e5dbda8de136ab6339f1f9f6984d7b3dffe",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda110/nvidia_dali_cuda110-1.23.0-7355173-py3-none-manylinux2014_aarch64.whl",
         )
         version(
             "1.22.0-cuda120",
             sha256="5e496eebeba3bc1cddd18e081c8c45121283478931cbe9b64912d2394d0942ca",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda120/nvidia_dali_cuda120-1.22.0-6971317-py3-none-manylinux2014_aarch64.whl",
         )
         version(
             "1.22.0-cuda110",
             sha256="0da47629fec01abf418fda0eeb393998820e40f6fae6b4c7d3e625aa4cdba6bd",
-            expand=False,
             url="https://developer.download.nvidia.com/compute/redist/nvidia-dali-cuda110/nvidia_dali_cuda110-1.22.0-6988993-py3-none-manylinux2014_aarch64.whl",
         )
 

--- a/var/spack/repos/builtin/packages/py-opencensus-context/package.py
+++ b/var/spack/repos/builtin/packages/py-opencensus-context/package.py
@@ -15,8 +15,4 @@ class PyOpencensusContext(PythonPackage):
 
     license("Apache-2.0")
 
-    version(
-        "0.1.1",
-        sha256="1a3fdf6bec537031efcc93d51b04f1edee5201f8c9a0c85681d63308b76f5702",
-        expand=False,
-    )
+    version("0.1.1", sha256="1a3fdf6bec537031efcc93d51b04f1edee5201f8c9a0c85681d63308b76f5702")

--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -24,71 +24,19 @@ class PyPip(Package, PythonExtension):
 
     license("MIT")
 
-    version(
-        "23.1.2",
-        sha256="3ef6ac33239e4027d9a5598a381b9d30880a1477e50039db2eac6e8a8f6d1b18",
-        expand=False,
-    )
-    version(
-        "23.0",
-        sha256="b5f88adff801f5ef052bcdef3daa31b55eb67b0fccd6d0106c206fa248e0463c",
-        expand=False,
-    )
-    version(
-        "22.2.2",
-        sha256="b61a374b5bc40a6e982426aede40c9b5a08ff20e640f5b56977f4f91fed1e39a",
-        expand=False,
-    )
-    version(
-        "22.1.2",
-        sha256="a3edacb89022ef5258bf61852728bf866632a394da837ca49eb4303635835f17",
-        expand=False,
-    )
-    version(
-        "21.3.1",
-        sha256="deaf32dcd9ab821e359cd8330786bcd077604b5c5730c0b096eda46f95c24a2d",
-        expand=False,
-    )
-    version(
-        "21.1.2",
-        sha256="f8ea1baa693b61c8ad1c1d8715e59ab2b93cd3c4769bacab84afcc4279e7a70e",
-        expand=False,
-    )
-    version(
-        "20.2",
-        sha256="d75f1fc98262dabf74656245c509213a5d0f52137e40e8f8ed5cc256ddd02923",
-        expand=False,
-    )
-    version(
-        "19.3",
-        sha256="e100a7eccf085f0720b4478d3bb838e1c179b1e128ec01c0403f84e86e0e2dfb",
-        expand=False,
-    )
-    version(
-        "19.1.1",
-        sha256="993134f0475471b91452ca029d4390dc8f298ac63a712814f101cd1b6db46676",
-        expand=False,
-    )
-    version(
-        "19.0.3",
-        sha256="bd812612bbd8ba84159d9ddc0266b7fbce712fc9bc98c82dee5750546ec8ec64",
-        expand=False,
-    )
-    version(
-        "18.1",
-        sha256="7909d0a0932e88ea53a7014dfd14522ffef91a464daaaf5c573343852ef98550",
-        expand=False,
-    )
-    version(
-        "10.0.1",
-        sha256="717cdffb2833be8409433a93746744b59505f42146e8d37de6c62b430e25d6d7",
-        expand=False,
-    )
-    version(
-        "9.0.1",
-        sha256="690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0",
-        expand=False,
-    )
+    version("23.1.2", sha256="3ef6ac33239e4027d9a5598a381b9d30880a1477e50039db2eac6e8a8f6d1b18")
+    version("23.0", sha256="b5f88adff801f5ef052bcdef3daa31b55eb67b0fccd6d0106c206fa248e0463c")
+    version("22.2.2", sha256="b61a374b5bc40a6e982426aede40c9b5a08ff20e640f5b56977f4f91fed1e39a")
+    version("22.1.2", sha256="a3edacb89022ef5258bf61852728bf866632a394da837ca49eb4303635835f17")
+    version("21.3.1", sha256="deaf32dcd9ab821e359cd8330786bcd077604b5c5730c0b096eda46f95c24a2d")
+    version("21.1.2", sha256="f8ea1baa693b61c8ad1c1d8715e59ab2b93cd3c4769bacab84afcc4279e7a70e")
+    version("20.2", sha256="d75f1fc98262dabf74656245c509213a5d0f52137e40e8f8ed5cc256ddd02923")
+    version("19.3", sha256="e100a7eccf085f0720b4478d3bb838e1c179b1e128ec01c0403f84e86e0e2dfb")
+    version("19.1.1", sha256="993134f0475471b91452ca029d4390dc8f298ac63a712814f101cd1b6db46676")
+    version("19.0.3", sha256="bd812612bbd8ba84159d9ddc0266b7fbce712fc9bc98c82dee5750546ec8ec64")
+    version("18.1", sha256="7909d0a0932e88ea53a7014dfd14522ffef91a464daaaf5c573343852ef98550")
+    version("10.0.1", sha256="717cdffb2833be8409433a93746744b59505f42146e8d37de6c62b430e25d6d7")
+    version("9.0.1", sha256="690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0")
 
     extends("python")
     depends_on("python@3.7:", when="@22:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -19,201 +19,45 @@ class PySetuptools(Package, PythonExtension):
     # Requires railroad
     skip_modules = ["setuptools._vendor", "pkg_resources._vendor"]
 
-    version(
-        "69.2.0",
-        sha256="c21c49fb1042386df081cb5d86759792ab89efca84cf114889191cd09aacc80c",
-        expand=False,
-    )
-    version(
-        "69.1.1",
-        sha256="02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56",
-        expand=False,
-    )
-    version(
-        "69.0.3",
-        sha256="385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05",
-        expand=False,
-    )
-    version(
-        "68.2.2",
-        sha256="b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a",
-        expand=False,
-    )
-    version(
-        "68.0.0",
-        sha256="11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f",
-        expand=False,
-    )
-    version(
-        "67.6.0",
-        sha256="b78aaa36f6b90a074c1fa651168723acbf45d14cb1196b6f02c0fd07f17623b2",
-        expand=False,
-    )
-    version(
-        "65.5.0",
-        sha256="f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356",
-        expand=False,
-    )
-    version(
-        "65.0.0",
-        sha256="fe9a97f68b064a6ddd4bacfb0b4b93a4c65a556d97ce906255540439d0c35cef",
-        expand=False,
-    )
-    version(
-        "64.0.0",
-        sha256="63f463b90ff5e0a1422010100268fd688e15c44ae0798659013c8412963e15e4",
-        expand=False,
-    )
-    version(
-        "63.4.3",
-        sha256="7f61f7e82647f77d4118eeaf43d64cbcd4d87e38af9611694d4866eb070cd10d",
-        expand=False,
-    )
-    version(
-        "63.0.0",
-        sha256="045aec56a3eee5c82373a70e02db8b6da9a10f7faf61ff89a14ab66c738ed370",
-        expand=False,
-    )
-    version(
-        "62.6.0",
-        sha256="c1848f654aea2e3526d17fc3ce6aeaa5e7e24e66e645b5be2171f3f6b4e5a178",
-        expand=False,
-    )
-    version(
-        "62.4.0",
-        sha256="5a844ad6e190dccc67d6d7411d119c5152ce01f7c76be4d8a1eaa314501bba77",
-        expand=False,
-    )
-    version(
-        "62.3.2",
-        sha256="68e45d17c9281ba25dc0104eadd2647172b3472d9e01f911efa57965e8d51a36",
-        expand=False,
-    )
-    version(
-        "59.4.0",
-        sha256="feb5ff19b354cde9efd2344ef6d5e79880ce4be643037641b49508bbb850d060",
-        expand=False,
-    )
-    version(
-        "58.2.0",
-        sha256="2551203ae6955b9876741a26ab3e767bb3242dafe86a32a749ea0d78b6792f11",
-        expand=False,
-    )
-    version(
-        "57.4.0",
-        sha256="a49230977aa6cfb9d933614d2f7b79036e9945c4cdd7583163f4e920b83418d6",
-        expand=False,
-    )
-    version(
-        "57.1.0",
-        sha256="ddae4c1b9220daf1e32ba9d4e3714df6019c5b583755559be84ff8199f7e1fe3",
-        expand=False,
-    )
-    version(
-        "51.0.0",
-        sha256="8c177936215945c9a37ef809ada0fab365191952f7a123618432bbfac353c529",
-        expand=False,
-    )
-    version(
-        "50.3.2",
-        sha256="2c242a0856fbad7efbe560df4a7add9324f340cf48df43651e9604924466794a",
-        expand=False,
-    )
-    version(
-        "50.1.0",
-        sha256="4537c77e6e7dc170081f8547564551d4ff4e4999717434e1257600bbd3a23296",
-        expand=False,
-    )
-    version(
-        "49.6.0",
-        sha256="4dd5bb0a0a0cff77b46ca5dd3a84857ee48c83e8223886b556613c724994073f",
-        expand=False,
-    )
-    version(
-        "49.2.0",
-        sha256="272c7f48f5cddc5af5901f4265274c421c7eede5c8bc454ac2903d3f8fc365e9",
-        expand=False,
-    )
-    version(
-        "46.1.3",
-        sha256="4fe404eec2738c20ab5841fa2d791902d2a645f32318a7850ef26f8d7215a8ee",
-        expand=False,
-    )
-    version(
-        "44.1.1",
-        sha256="27a714c09253134e60a6fa68130f78c7037e5562c4f21f8f318f2ae900d152d5",
-        expand=False,
-    )
-    version(
-        "44.1.0",
-        sha256="992728077ca19db6598072414fb83e0a284aca1253aaf2e24bb1e55ee6db1a30",
-        expand=False,
-    )
-    version(
-        "43.0.0",
-        sha256="a67faa51519ef28cd8261aff0e221b6e4c370f8fb8bada8aa3e7ad8945199963",
-        expand=False,
-    )
-    version(
-        "41.4.0",
-        sha256="8d01f7ee4191d9fdcd9cc5796f75199deccb25b154eba82d44d6a042cf873670",
-        expand=False,
-    )
-    version(
-        "41.3.0",
-        sha256="e9832acd9be6f3174f4c34b40e7d913a146727920cbef6465c1c1bd2d21a4ec4",
-        expand=False,
-    )
-    version(
-        "41.0.1",
-        sha256="c7769ce668c7a333d84e17fe8b524b1c45e7ee9f7908ad0a73e1eda7e6a5aebf",
-        expand=False,
-    )
-    version(
-        "41.0.0",
-        sha256="e67486071cd5cdeba783bd0b64f5f30784ff855b35071c8670551fd7fc52d4a1",
-        expand=False,
-    )
-    version(
-        "40.8.0",
-        sha256="e8496c0079f3ac30052ffe69b679bd876c5265686127a3159cfa415669b7f9ab",
-        expand=False,
-    )
-    version(
-        "40.4.3",
-        sha256="ce4137d58b444bac11a31d4e0c1805c69d89e8ed4e91fde1999674ecc2f6f9ff",
-        expand=False,
-    )
-    version(
-        "40.2.0",
-        sha256="ea3796a48a207b46ea36a9d26de4d0cc87c953a683a7b314ea65d666930ea8e6",
-        expand=False,
-    )
-    version(
-        "39.2.0",
-        sha256="8fca9275c89964f13da985c3656cb00ba029d7f3916b37990927ffdf264e7926",
-        expand=False,
-    )
-    version(
-        "39.0.1",
-        sha256="8010754433e3211b9cdbbf784b50f30e80bf40fc6b05eb5f865fab83300599b8",
-        expand=False,
-    )
-    version(
-        "25.2.0",
-        sha256="2845247c359bb91097ccf8f6be8a69edfa44847f3d2d5def39aa43c3d7f615ca",
-        expand=False,
-    )
-    version(
-        "20.7.0",
-        sha256="8917a52aa3a389893221b173a89dae0471022d32bff3ebc31a1072988aa8039d",
-        expand=False,
-    )
-    version(
-        "20.6.7",
-        sha256="9982ee4d279a2541dc1a7efee994ff9c535cfc05315e121e09df7f93da48c442",
-        expand=False,
-    )
+    version("69.2.0", sha256="c21c49fb1042386df081cb5d86759792ab89efca84cf114889191cd09aacc80c")
+    version("69.1.1", sha256="02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56")
+    version("69.0.3", sha256="385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05")
+    version("68.2.2", sha256="b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a")
+    version("68.0.0", sha256="11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f")
+    version("67.6.0", sha256="b78aaa36f6b90a074c1fa651168723acbf45d14cb1196b6f02c0fd07f17623b2")
+    version("65.5.0", sha256="f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356")
+    version("65.0.0", sha256="fe9a97f68b064a6ddd4bacfb0b4b93a4c65a556d97ce906255540439d0c35cef")
+    version("64.0.0", sha256="63f463b90ff5e0a1422010100268fd688e15c44ae0798659013c8412963e15e4")
+    version("63.4.3", sha256="7f61f7e82647f77d4118eeaf43d64cbcd4d87e38af9611694d4866eb070cd10d")
+    version("63.0.0", sha256="045aec56a3eee5c82373a70e02db8b6da9a10f7faf61ff89a14ab66c738ed370")
+    version("62.6.0", sha256="c1848f654aea2e3526d17fc3ce6aeaa5e7e24e66e645b5be2171f3f6b4e5a178")
+    version("62.4.0", sha256="5a844ad6e190dccc67d6d7411d119c5152ce01f7c76be4d8a1eaa314501bba77")
+    version("62.3.2", sha256="68e45d17c9281ba25dc0104eadd2647172b3472d9e01f911efa57965e8d51a36")
+    version("59.4.0", sha256="feb5ff19b354cde9efd2344ef6d5e79880ce4be643037641b49508bbb850d060")
+    version("58.2.0", sha256="2551203ae6955b9876741a26ab3e767bb3242dafe86a32a749ea0d78b6792f11")
+    version("57.4.0", sha256="a49230977aa6cfb9d933614d2f7b79036e9945c4cdd7583163f4e920b83418d6")
+    version("57.1.0", sha256="ddae4c1b9220daf1e32ba9d4e3714df6019c5b583755559be84ff8199f7e1fe3")
+    version("51.0.0", sha256="8c177936215945c9a37ef809ada0fab365191952f7a123618432bbfac353c529")
+    version("50.3.2", sha256="2c242a0856fbad7efbe560df4a7add9324f340cf48df43651e9604924466794a")
+    version("50.1.0", sha256="4537c77e6e7dc170081f8547564551d4ff4e4999717434e1257600bbd3a23296")
+    version("49.6.0", sha256="4dd5bb0a0a0cff77b46ca5dd3a84857ee48c83e8223886b556613c724994073f")
+    version("49.2.0", sha256="272c7f48f5cddc5af5901f4265274c421c7eede5c8bc454ac2903d3f8fc365e9")
+    version("46.1.3", sha256="4fe404eec2738c20ab5841fa2d791902d2a645f32318a7850ef26f8d7215a8ee")
+    version("44.1.1", sha256="27a714c09253134e60a6fa68130f78c7037e5562c4f21f8f318f2ae900d152d5")
+    version("44.1.0", sha256="992728077ca19db6598072414fb83e0a284aca1253aaf2e24bb1e55ee6db1a30")
+    version("43.0.0", sha256="a67faa51519ef28cd8261aff0e221b6e4c370f8fb8bada8aa3e7ad8945199963")
+    version("41.4.0", sha256="8d01f7ee4191d9fdcd9cc5796f75199deccb25b154eba82d44d6a042cf873670")
+    version("41.3.0", sha256="e9832acd9be6f3174f4c34b40e7d913a146727920cbef6465c1c1bd2d21a4ec4")
+    version("41.0.1", sha256="c7769ce668c7a333d84e17fe8b524b1c45e7ee9f7908ad0a73e1eda7e6a5aebf")
+    version("41.0.0", sha256="e67486071cd5cdeba783bd0b64f5f30784ff855b35071c8670551fd7fc52d4a1")
+    version("40.8.0", sha256="e8496c0079f3ac30052ffe69b679bd876c5265686127a3159cfa415669b7f9ab")
+    version("40.4.3", sha256="ce4137d58b444bac11a31d4e0c1805c69d89e8ed4e91fde1999674ecc2f6f9ff")
+    version("40.2.0", sha256="ea3796a48a207b46ea36a9d26de4d0cc87c953a683a7b314ea65d666930ea8e6")
+    version("39.2.0", sha256="8fca9275c89964f13da985c3656cb00ba029d7f3916b37990927ffdf264e7926")
+    version("39.0.1", sha256="8010754433e3211b9cdbbf784b50f30e80bf40fc6b05eb5f865fab83300599b8")
+    version("25.2.0", sha256="2845247c359bb91097ccf8f6be8a69edfa44847f3d2d5def39aa43c3d7f615ca")
+    version("20.7.0", sha256="8917a52aa3a389893221b173a89dae0471022d32bff3ebc31a1072988aa8039d")
+    version("20.6.7", sha256="9982ee4d279a2541dc1a7efee994ff9c535cfc05315e121e09df7f93da48c442")
 
     extends("python")
 

--- a/var/spack/repos/builtin/packages/py-shiboken2/package.py
+++ b/var/spack/repos/builtin/packages/py-shiboken2/package.py
@@ -18,14 +18,12 @@ class PyShiboken2(PythonPackage):
             "5.15.2",
             url="https://files.pythonhosted.org/packages/cp35.cp36.cp37.cp38.cp39/s/shiboken2/shiboken2-5.15.2-5.15.2-cp35.cp36.cp37.cp38.cp39-abi3-manylinux1_x86_64.whl",
             sha256="4aee1b91e339578f9831e824ce2a1ec3ba3a463f41fda8946b4547c7eb3cba86",
-            expand=False,
         )
     elif sys.platform == "darwin":
         version(
             "5.15.2",
             url="https://files.pythonhosted.org/packages/cp35.cp36.cp37.cp38.cp39/s/shiboken2/shiboken2-5.15.2-5.15.2-cp35.cp36.cp37.cp38.cp39-abi3-macosx_10_13_intel.whl",
             sha256="edc12a4df2b5be7ca1e762ab94e331ba9e2fbfe3932c20378d8aa3f73f90e0af",
-            expand=False,
         )
 
     depends_on("python@3.5:3.9", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-tensorboard-plugin-wit/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorboard-plugin-wit/package.py
@@ -25,21 +25,9 @@ class PyTensorboardPluginWit(PythonPackage):
 
     license("Apache-2.0")
 
-    version(
-        "1.8.1",
-        sha256="ff26bdd583d155aa951ee3b152b3d0cffae8005dc697f72b44a8e8c2a77a8cbe",
-        expand=False,
-    )
-    version(
-        "1.8.0",
-        sha256="2a80d1c551d741e99b2f197bb915d8a133e24adb8da1732b840041860f91183a",
-        expand=False,
-    )
-    version(
-        "1.7.0",
-        sha256="ee775f04821185c90d9a0e9c56970ee43d7c41403beb6629385b39517129685b",
-        expand=False,
-    )
+    version("1.8.1", sha256="ff26bdd583d155aa951ee3b152b3d0cffae8005dc697f72b44a8e8c2a77a8cbe")
+    version("1.8.0", sha256="2a80d1c551d741e99b2f197bb915d8a133e24adb8da1732b840041860f91183a")
+    version("1.7.0", sha256="ee775f04821185c90d9a0e9c56970ee43d7c41403beb6629385b39517129685b")
 
     depends_on("py-setuptools@36.2.0:", type="build")
     depends_on("python@3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-tensorboard/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorboard/package.py
@@ -21,146 +21,34 @@ class PyTensorboard(PythonPackage):
 
     license("Apache-2.0")
 
-    version(
-        "2.16.2",
-        sha256="9f2b4e7dad86667615c0e5cd072f1ea8403fc032a299f0072d6f74855775cc45",
-        expand=False,
-    )
-    version(
-        "2.16.1",
-        sha256="928b62567911a8eeb2ebeb7482a9e4599b35f6713a6f2c56655259c18a139569",
-        expand=False,
-    )
-    version(
-        "2.16.0",
-        sha256="263b909a2009cb3a79daa6abe64c1785cc317c25a54e4db2fecb6429ffc54c58",
-        expand=False,
-    )
-    version(
-        "2.15.2",
-        sha256="a6f6443728064d962caea6d34653e220e34ef8df764cb06a8212c17e1a8f0622",
-        expand=False,
-    )
-    version(
-        "2.15.1",
-        sha256="c46c1d1cf13a458c429868a78b2531d8ff5f682058d69ec0840b0bc7a38f1c0f",
-        expand=False,
-    )
-    version(
-        "2.15.0",
-        sha256="c05b4d02a3a9fd4bd6c25265087d52b49b790a871ddf98f4fb32fe97cbbc7ad0",
-        expand=False,
-    )
-    version(
-        "2.14.1",
-        sha256="3db108fb58f023b6439880e177743c5f1e703e9eeb5fb7d597871f949f85fd58",
-        expand=False,
-    )
-    version(
-        "2.14.0",
-        sha256="3667f9745d99280836ad673022362c840f60ed8fefd5a3e30bf071f5a8fd0017",
-        expand=False,
-    )
-    version(
-        "2.13.0",
-        sha256="ab69961ebddbddc83f5fa2ff9233572bdad5b883778c35e4fe94bf1798bd8481",
-        expand=False,
-    )
-    version(
-        "2.12.3",
-        sha256="b4a69366784bc347e02fbe7d847e01896a649ca52f8948a11005e205dcf724fb",
-        expand=False,
-    )
-    version(
-        "2.12.2",
-        sha256="811ab0d27a139445836db9fd4f974424602c3dce12379364d379bcba7c783a68",
-        expand=False,
-    )
-    version(
-        "2.12.1",
-        sha256="58f1c2a25b4829b9c48d2b1ec951dedc9325dcd1ea4b0f601d241d2887d0ed65",
-        expand=False,
-    )
-    version(
-        "2.12.0",
-        sha256="3cbdc32448d7a28dc1bf0b1754760c08b8e0e2e37c451027ebd5ff4896613012",
-        expand=False,
-    )
-    version(
-        "2.11.2",
-        sha256="cbaa2210c375f3af1509f8571360a19ccc3ded1d9641533414874b5deca47e89",
-        expand=False,
-    )
-    version(
-        "2.11.1",
-        sha256="0c7529f3f43691e8cc2ece8e564c2e103c51ade317c6af626d415239b5088018",
-        expand=False,
-    )
-    version(
-        "2.11.0",
-        sha256="a0e592ee87962e17af3f0dce7faae3fbbd239030159e9e625cce810b7e35c53d",
-        expand=False,
-    )
-    version(
-        "2.10.1",
-        sha256="fb9222c1750e2fa35ef170d998a1e229f626eeced3004494a8849c88c15d8c1c",
-        expand=False,
-    )
-    version(
-        "2.10.0",
-        sha256="76c91a5e8959cd2208cc32cb17a0cb002badabb66a06ac2af02a7810f49a59e3",
-        expand=False,
-    )
-    version(
-        "2.9.1",
-        sha256="baa727f791776f9e5841d347127720ceed4bbd59c36b40604b95fb2ae6029276",
-        expand=False,
-    )
-    version(
-        "2.9.0",
-        sha256="bd78211076dca5efa27260afacfaa96cd05c7db12a6c09cc76a1d6b2987ca621",
-        expand=False,
-    )
-    version(
-        "2.8.0",
-        sha256="65a338e4424e9079f2604923bdbe301792adce2ace1be68da6b3ddf005170def",
-        expand=False,
-    )
-    version(
-        "2.7.0",
-        sha256="239f78a4a8dff200ce585a030c787773a8c1184d5c159252f5f85bac4e3c3b38",
-        expand=False,
-    )
-    version(
-        "2.6.0",
-        sha256="f7dac4cdfb52d14c9e3f74585ce2aaf8e6203620a864e51faf84988b09f7bbdb",
-        expand=False,
-    )
-    version(
-        "2.5.0",
-        sha256="e167460085b6528956b33bab1c970c989cdce47a6616273880733f5e7bde452e",
-        expand=False,
-    )
-    version(
-        "2.4.1",
-        sha256="7b8c53c396069b618f6f276ec94fc45d17e3282d668979216e5d30be472115e4",
-        expand=False,
-    )
-    version(
-        "2.4.0",
-        sha256="cde0c663a85609441cb4d624e7255fd8e2b6b1d679645095aac8a234a2812738",
-        expand=False,
-    )
-    version(
-        "2.3.0",
-        sha256="d34609ed83ff01dd5b49ef81031cfc9c166bba0dabd60197024f14df5e8eae5e",
-        expand=False,
-    )
-    version(
-        "2.2.0",
-        sha256="bb6bbc75ad2d8511ba6cbd49e4417276979f49866e11841e83da8298727dbaed",
-        expand=False,
-    )
+    version("2.16.2", sha256="9f2b4e7dad86667615c0e5cd072f1ea8403fc032a299f0072d6f74855775cc45")
+    version("2.16.1", sha256="928b62567911a8eeb2ebeb7482a9e4599b35f6713a6f2c56655259c18a139569")
+    version("2.16.0", sha256="263b909a2009cb3a79daa6abe64c1785cc317c25a54e4db2fecb6429ffc54c58")
+    version("2.15.2", sha256="a6f6443728064d962caea6d34653e220e34ef8df764cb06a8212c17e1a8f0622")
+    version("2.15.1", sha256="c46c1d1cf13a458c429868a78b2531d8ff5f682058d69ec0840b0bc7a38f1c0f")
+    version("2.15.0", sha256="c05b4d02a3a9fd4bd6c25265087d52b49b790a871ddf98f4fb32fe97cbbc7ad0")
+    version("2.14.1", sha256="3db108fb58f023b6439880e177743c5f1e703e9eeb5fb7d597871f949f85fd58")
+    version("2.14.0", sha256="3667f9745d99280836ad673022362c840f60ed8fefd5a3e30bf071f5a8fd0017")
+    version("2.13.0", sha256="ab69961ebddbddc83f5fa2ff9233572bdad5b883778c35e4fe94bf1798bd8481")
+    version("2.12.3", sha256="b4a69366784bc347e02fbe7d847e01896a649ca52f8948a11005e205dcf724fb")
+    version("2.12.2", sha256="811ab0d27a139445836db9fd4f974424602c3dce12379364d379bcba7c783a68")
+    version("2.12.1", sha256="58f1c2a25b4829b9c48d2b1ec951dedc9325dcd1ea4b0f601d241d2887d0ed65")
+    version("2.12.0", sha256="3cbdc32448d7a28dc1bf0b1754760c08b8e0e2e37c451027ebd5ff4896613012")
+    version("2.11.2", sha256="cbaa2210c375f3af1509f8571360a19ccc3ded1d9641533414874b5deca47e89")
+    version("2.11.1", sha256="0c7529f3f43691e8cc2ece8e564c2e103c51ade317c6af626d415239b5088018")
+    version("2.11.0", sha256="a0e592ee87962e17af3f0dce7faae3fbbd239030159e9e625cce810b7e35c53d")
+    version("2.10.1", sha256="fb9222c1750e2fa35ef170d998a1e229f626eeced3004494a8849c88c15d8c1c")
+    version("2.10.0", sha256="76c91a5e8959cd2208cc32cb17a0cb002badabb66a06ac2af02a7810f49a59e3")
+    version("2.9.1", sha256="baa727f791776f9e5841d347127720ceed4bbd59c36b40604b95fb2ae6029276")
+    version("2.9.0", sha256="bd78211076dca5efa27260afacfaa96cd05c7db12a6c09cc76a1d6b2987ca621")
+    version("2.8.0", sha256="65a338e4424e9079f2604923bdbe301792adce2ace1be68da6b3ddf005170def")
+    version("2.7.0", sha256="239f78a4a8dff200ce585a030c787773a8c1184d5c159252f5f85bac4e3c3b38")
+    version("2.6.0", sha256="f7dac4cdfb52d14c9e3f74585ce2aaf8e6203620a864e51faf84988b09f7bbdb")
+    version("2.5.0", sha256="e167460085b6528956b33bab1c970c989cdce47a6616273880733f5e7bde452e")
+    version("2.4.1", sha256="7b8c53c396069b618f6f276ec94fc45d17e3282d668979216e5d30be472115e4")
+    version("2.4.0", sha256="cde0c663a85609441cb4d624e7255fd8e2b6b1d679645095aac8a234a2812738")
+    version("2.3.0", sha256="d34609ed83ff01dd5b49ef81031cfc9c166bba0dabd60197024f14df5e8eae5e")
+    version("2.2.0", sha256="bb6bbc75ad2d8511ba6cbd49e4417276979f49866e11841e83da8298727dbaed")
 
     depends_on("python@3.9:", type=("build", "run"), when="@2.14:")
     depends_on("python@3.8:", type=("build", "run"), when="@2.12:")

--- a/var/spack/repos/builtin/packages/py-thop/package.py
+++ b/var/spack/repos/builtin/packages/py-thop/package.py
@@ -18,7 +18,6 @@ class PyThop(PythonPackage):
     version(
         "0.1.1.post2209072238",
         sha256="01473c225231927d2ad718351f78ebf7cffe6af3bed464c4f1ba1ef0f7cdda27",
-        expand=False,
     )
 
     depends_on("py-torch", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-tuswsgi/package.py
+++ b/var/spack/repos/builtin/packages/py-tuswsgi/package.py
@@ -15,11 +15,7 @@ class PyTuswsgi(PythonPackage):
 
     license("MIT")
 
-    version(
-        "0.5.4",
-        sha256="f681a386254a161a97301a67c01ee7da77419c007d9bc43dbd48d5a987491a5e",
-        expand=False,
-    )
+    version("0.5.4", sha256="f681a386254a161a97301a67c01ee7da77419c007d9bc43dbd48d5a987491a5e")
 
     depends_on("python@3.6:", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/py-wheel/package.py
+++ b/var/spack/repos/builtin/packages/py-wheel/package.py
@@ -13,66 +13,18 @@ class PyWheel(Package, PythonExtension):
     url = "https://files.pythonhosted.org/packages/py3/w/wheel/wheel-0.41.2-py3-none-any.whl"
     list_url = "https://pypi.org/simple/wheel/"
 
-    version(
-        "0.41.2",
-        sha256="75909db2664838d015e3d9139004ee16711748a52c8f336b52882266540215d8",
-        expand=False,
-    )
-    version(
-        "0.37.1",
-        sha256="4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a",
-        expand=False,
-    )
-    version(
-        "0.37.0",
-        sha256="21014b2bd93c6d0034b6ba5d35e4eb284340e09d63c59aef6fc14b0f346146fd",
-        expand=False,
-    )
-    version(
-        "0.36.2",
-        sha256="78b5b185f0e5763c26ca1e324373aadd49182ca90e825f7853f4b2509215dc0e",
-        expand=False,
-    )
-    version(
-        "0.35.1",
-        sha256="497add53525d16c173c2c1c733b8f655510e909ea78cc0e29d374243544b77a2",
-        expand=False,
-    )
-    version(
-        "0.34.2",
-        sha256="df277cb51e61359aba502208d680f90c0493adec6f0e848af94948778aed386e",
-        expand=False,
-    )
-    version(
-        "0.33.6",
-        sha256="f4da1763d3becf2e2cd92a14a7c920f0f00eca30fdde9ea992c836685b9faf28",
-        expand=False,
-    )
-    version(
-        "0.33.4",
-        sha256="5e79117472686ac0c4aef5bad5172ea73a1c2d1646b808c35926bd26bdfb0c08",
-        expand=False,
-    )
-    version(
-        "0.33.1",
-        sha256="8eb4a788b3aec8abf5ff68d4165441bc57420c9f64ca5f471f58c3969fe08668",
-        expand=False,
-    )
-    version(
-        "0.32.3",
-        sha256="1e53cdb3f808d5ccd0df57f964263752aa74ea7359526d3da6c02114ec1e1d44",
-        expand=False,
-    )
-    version(
-        "0.29.0",
-        sha256="ea8033fc9905804e652f75474d33410a07404c1a78dd3c949a66863bd1050ebd",
-        expand=False,
-    )
-    version(
-        "0.26.0",
-        sha256="c92ed3a2dd87c54a9e20024fb0a206fe591c352c745fff21e8f8c6cdac2086ea",
-        expand=False,
-    )
+    version("0.41.2", sha256="75909db2664838d015e3d9139004ee16711748a52c8f336b52882266540215d8")
+    version("0.37.1", sha256="4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a")
+    version("0.37.0", sha256="21014b2bd93c6d0034b6ba5d35e4eb284340e09d63c59aef6fc14b0f346146fd")
+    version("0.36.2", sha256="78b5b185f0e5763c26ca1e324373aadd49182ca90e825f7853f4b2509215dc0e")
+    version("0.35.1", sha256="497add53525d16c173c2c1c733b8f655510e909ea78cc0e29d374243544b77a2")
+    version("0.34.2", sha256="df277cb51e61359aba502208d680f90c0493adec6f0e848af94948778aed386e")
+    version("0.33.6", sha256="f4da1763d3becf2e2cd92a14a7c920f0f00eca30fdde9ea992c836685b9faf28")
+    version("0.33.4", sha256="5e79117472686ac0c4aef5bad5172ea73a1c2d1646b808c35926bd26bdfb0c08")
+    version("0.33.1", sha256="8eb4a788b3aec8abf5ff68d4165441bc57420c9f64ca5f471f58c3969fe08668")
+    version("0.32.3", sha256="1e53cdb3f808d5ccd0df57f964263752aa74ea7359526d3da6c02114ec1e1d44")
+    version("0.29.0", sha256="ea8033fc9905804e652f75474d33410a07404c1a78dd3c949a66863bd1050ebd")
+    version("0.26.0", sha256="c92ed3a2dd87c54a9e20024fb0a206fe591c352c745fff21e8f8c6cdac2086ea")
 
     extends("python")
     depends_on("python +ctypes", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-x21/package.py
+++ b/var/spack/repos/builtin/packages/py-x21/package.py
@@ -30,33 +30,27 @@ class PyX21(PythonPackage):
         version(
             "0.2.6-py3.8",
             sha256="bbbfdb6b56562ecc81f0dc39e009713157011fbb50d47353eb25f633acf77204",
-            expand=False,
         )
         version(
             "0.2.6-py3.9",
             sha256="d7b4f06a71ac27d05ae774752b3ca396134916427f371b5995b07f0f43205043",
-            expand=False,
         )
         version(
             "0.2.6-py3.10",
             sha256="2cbda690757f1fc80edfe48fcb13f168068f1784f0cb8c300a0d8051714d0452",
-            expand=False,
         )
     elif sys.platform.startswith("linux"):
         version(
             "0.2.6-py3.8",
             sha256="64275052bcda784395bc613f750b8b5a6b1ddbfa4e7a590cb8e209543f0ca0c4",
-            expand=False,
         )
         version(
             "0.2.6-py3.9",
             sha256="e20b29650fcbf0be116ac93511033bf10debc76261b7350e018ff91b92ff950d",
-            expand=False,
         )
         version(
             "0.2.6-py3.10",
             sha256="7c5c58ff6dc81caac6815578f78cf545e719beb0bf4017f77120d38025d2bc7d",
-            expand=False,
         )
 
     depends_on("python@3.8.0:3.8", type=("build", "run"), when="@0.2.6-py3.8")


### PR DESCRIPTION
Implement a no-op decompressor for "whl" to make `expand=False` redundant.

Should be future-proof in the sense that we can identify the mime type of these
file as zip, and discriminate between wheel vs any other zip file by looking for a
`*.dist-info/WHEEL` file. For now it's file extension based though.

