### PR TITLE
cvise: Add 2.10.0 and conflicts

### DIFF
--- a/var/spack/repos/builtin/packages/cvise/package.py
+++ b/var/spack/repos/builtin/packages/cvise/package.py
@@ -17,6 +17,7 @@ class Cvise(CMakePackage):
     license("NCSA")
 
     version("master", branch="master")
+    version("2.10.0", tag="v2.10.0", commit="c8606497e354ddab273745cf823823bdd3e86bd8")
     version("2.7.0", tag="v2.7.0", commit="d9e4a50514d9931b2a1293755a7e96e0f9520032")
 
     variant("pytest", default=False, description="Add py-pytest as dependency")

--- a/var/spack/repos/builtin/packages/cvise/package.py
+++ b/var/spack/repos/builtin/packages/cvise/package.py
@@ -34,3 +34,8 @@ class Cvise(CMakePackage):
 
     depends_on("py-pytest", when="+pytest", type=("build", "run"))
     depends_on("colordiff", when="+colordiff", type=("build", "run"))
+
+    # C-Vise doesn't directly depend on ncurses, but LLVM does. However, LLVM
+    # doesn't provide correctly export terminfo CMake targets that it depends on
+    # and C-Vise fails during configuration with ncurses +termlib.
+    depends_on("ncurses ~termlib", when="^llvm +lldb")

--- a/var/spack/repos/builtin/packages/cvise/package.py
+++ b/var/spack/repos/builtin/packages/cvise/package.py
@@ -23,7 +23,8 @@ class Cvise(CMakePackage):
     variant("pytest", default=False, description="Add py-pytest as dependency")
     variant("colordiff", default=False, description="Add colordiff support")
 
-    depends_on("cmake", type="build")
+    depends_on("cmake@2.8.12:", type="build")
+    depends_on("cmake@3.14:", when="@2.9:", type="build")
     depends_on("flex", type=("build", "run"))
     depends_on("llvm@9.0.0:", type=("build", "run"))
     depends_on("python@3.6:", type=("build", "run"))


### PR DESCRIPTION
Adds the latest available version 2.10. I haven't added intermediate versions since I haven't tested them. This also adds a conflict with `ncurses +termlib` as it seems like LLVM ends up depending on a terminfo CMake target, but when configuring cvise the terminfo CMake target is not found. Instead of trying to patch it I've opted to simply add a conflict. A build with `ncurses ~termlib` builds for me.