### PR TITLE
`netcdf-cxx4`: fix syntax error

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -50,7 +50,7 @@ class NetcdfCxx4(CMakePackage):
     @property
     def libs(self):
         libraries = ["libnetcdf_c++4"]
-        shared = "+shared" in spec
+        shared = "+shared" in self.spec
 
         libs = find_libraries(libraries, root=self.prefix, shared=shared, recursive=True)
         if libs:


### PR DESCRIPTION
This fixes a syntax error that was accidentally introduced during the code review of spack/spack/pull/42766 