### PR TITLE
icedtea: Change jdk dependency to java

### DIFF
--- a/var/spack/repos/builtin/packages/icedtea/package.py
+++ b/var/spack/repos/builtin/packages/icedtea/package.py
@@ -37,7 +37,7 @@ class Icedtea(AutotoolsPackage):
     depends_on("pkgconfig", type="build")
     depends_on("gmake", type="build")
     depends_on("cups")
-    depends_on("jdk", type="build")
+    depends_on("java", type="build")
     # X11 deps required for building even when headless
     depends_on("libx11", when="~X", type="build")
     depends_on("xproto", when="~X", type="build")


### PR DESCRIPTION
Allows `icedtea` to use any package that provides `java`, such as `openjdk`.