### PR TITLE
openjdk: Use correct homepage

### DIFF
--- a/var/spack/repos/builtin/packages/openjdk/package.py
+++ b/var/spack/repos/builtin/packages/openjdk/package.py
@@ -334,7 +334,7 @@ _versions = {
 class Openjdk(Package):
     """The free and opensource java implementation"""
 
-    homepage = "https://jdk.java.net"
+    homepage = "https://openjdk.org/"
     preferred_prefix = "11."
 
     preferred_defined = False


### PR DESCRIPTION
https://jdk.java.net/ is for the Oracle JDK, not openjdk!