### PR TITLE
qctool: add new package with version 2.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/qctool/package.py
+++ b/var/spack/repos/builtin/packages/qctool/package.py
@@ -23,4 +23,6 @@ class Qctool(WafPackage):
         url="https://enkre.net/cgi-bin/code/qctool/tarball/86639c1ad4/qctool-86639c1ad4.tar.gz",
     )
 
+    # Required external libraries as detailed in Prerequisites:
+    # https://enkre.net/cgi-bin/code/qctool/wiki?name=Compiling+QCTOOL
     depends_on("zlib")

--- a/var/spack/repos/builtin/packages/qctool/package.py
+++ b/var/spack/repos/builtin/packages/qctool/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Qctool(WafPackage):
+    """QCTOOL is a command-line utility program for manipulation and quality
+    control of gwas datasets and other genome-wide data. This repository contains
+    the source code for QCTOOL and a number of other command-line programs that
+    manipulate gwas datasets and other genomic data, such as: Inthinnerator,
+    HPTEST, and LDBIRD."""
+
+    homepage = "https://www.chg.ox.ac.uk/~gav/qctool_v2/index.html"
+
+    license("BSL-1.0")
+
+    version(
+        "2.2.0",
+        sha256="7ba47998a2559193483cebe3710ce14d4e5d55d2e123840b4d1614b88459a9fc",
+        url="https://enkre.net/cgi-bin/code/qctool/tarball/86639c1ad4/qctool-86639c1ad4.tar.gz",
+    )
+
+    depends_on("zlib")


### PR DESCRIPTION
qctool - 2.2.0: [release notes](https://enkre.net/cgi-bin/code/qctool/info/86639c1ad4e7cba1)
