### PR TITLE
suite-sparse: Add version 7.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -155,7 +155,6 @@ class SuiteSparse(Package):
         for symbol in symbols:
             args.append("CFLAGS+=-D{0}={1}{2}".format(symbol, symbol, suffix))
 
-
     def install(self, spec, prefix):
         # The build system of SuiteSparse is quite old-fashioned.
         # It's basically a plain Makefile which include an header
@@ -237,10 +236,10 @@ class SuiteSparse(Package):
                 "CMAKE_OPTIONS=-DCMAKE_INSTALL_PREFIX=%s" % prefix
                 + " -DCMAKE_LIBRARY_PATH=%s" % prefix.lib
                 + " -DBLA_VENDOR=OpenBLAS"
-                + " -DBLAS_INCLUDE_DIRS=%s" % (spec["blas"].prefix.include)      # for versions 7.4.0 and later
-                + " -DLAPACK_INCLUDE_DIRS=%s" % (spec["lapack"].prefix.include)  # for versions 7.4.0 and later
-                + " -DBLAS_LIBRARIES=%s" % (spec["blas"].prefix.include)         # for versions 7.3.1 and before
-                + " -DLAPACK_LIBRARIES=%s" % (spec["lapack"].prefix.include)     # for versions 7.3.1 and before
+                + " -DBLAS_INCLUDE_DIRS=%s" % (spec["blas"].prefix.include)      # for >= v7.4.0
+                + " -DLAPACK_INCLUDE_DIRS=%s" % (spec["lapack"].prefix.include)  # for >= v7.4.0
+                + " -DBLAS_LIBRARIES=%s" % (spec["blas"].prefix.include)         # for <= v7.3.1
+                + " -DLAPACK_LIBRARIES=%s" % (spec["lapack"].prefix.include)     # for <= v7.3.1
             ]
 
         if spec.satisfies("%gcc platform=darwin"):
@@ -274,7 +273,7 @@ class SuiteSparse(Package):
 
         # Finally make and install
         make("-C", "SuiteSparse_config", *make_args)
-        #make("-C", "SuiteSparse_config", "config", *make_args)
+#       make("-C", "SuiteSparse_config", "config", *make_args)
         for target in targets:
             make("-C", target, "library", *make_args)
             make("-C", target, "install", *make_args)

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -17,6 +17,12 @@ class SuiteSparse(Package):
 
     license("Apache-2.0")
 
+#    version("7.6.1", sha256="ab1992802723b09aca3cbb0f4dc9b2415a781b9ad984ed934c7d8a0dcc31bc42")
+#    version("7.5.1", sha256="dccfb5f75aa83fe2edb4eb2462fc984a086c82bad8433f63c31048d84b565d74")
+#    version("7.4.0", sha256="f9a5cc2316a967198463198f7bf10fb8c4332de6189b0e405419a7092bc921b7")
+# these fail with hundreds of libcholmod.so.5.2.0: undefined reference to xxxx when builing
+# the various cholmod_yyy_demo's or creating the static archive
+    version("7.3.1", sha256="b512484396a80750acf3082adc1807ba0aabb103c2e09be5691f46f14d0a9718")
     version("5.13.0", sha256="59c6ca2959623f0c69226cf9afb9a018d12a37fab3a8869db5f6d7f83b6b147d")
     version("5.12.0", sha256="5fb0064a3398111976f30c5908a8c0b40df44c6dd8f0cc4bfa7b9e45d8c647de")
     version("5.11.0", sha256="fdd957ed06019465f7de73ce931afaf5d40e96e14ae57d91f60868b8c123c4c8")
@@ -65,6 +71,7 @@ class SuiteSparse(Package):
     depends_on("gmp", when="@5.8.0:")
     depends_on("m4", type="build", when="@5.0.0:")
     depends_on("cmake", when="+graphblas @5.2.0:", type="build")
+    depends_on("cmake@3.22:", when="@7.3.1:", type="build")
     depends_on("metis@5.1.0", when="@4.5.1:")
 
     with when("+tbb"):
@@ -148,6 +155,7 @@ class SuiteSparse(Package):
         for symbol in symbols:
             args.append("CFLAGS+=-D{0}={1}{2}".format(symbol, symbol, suffix))
 
+
     def install(self, spec, prefix):
         # The build system of SuiteSparse is quite old-fashioned.
         # It's basically a plain Makefile which include an header
@@ -228,6 +236,11 @@ class SuiteSparse(Package):
             make_args += [
                 "CMAKE_OPTIONS=-DCMAKE_INSTALL_PREFIX=%s" % prefix
                 + " -DCMAKE_LIBRARY_PATH=%s" % prefix.lib
+                + " -DBLA_VENDOR=OpenBLAS"
+                + " -DBLAS_INCLUDE_DIRS=%s" % (spec["blas"].prefix.include)      # for versions 7.4.0 and later
+                + " -DLAPACK_INCLUDE_DIRS=%s" % (spec["lapack"].prefix.include)  # for versions 7.4.0 and later
+                + " -DBLAS_LIBRARIES=%s" % (spec["blas"].prefix.include)         # for versions 7.3.1 and before
+                + " -DLAPACK_LIBRARIES=%s" % (spec["lapack"].prefix.include)     # for versions 7.3.1 and before
             ]
 
         if spec.satisfies("%gcc platform=darwin"):
@@ -255,11 +268,13 @@ class SuiteSparse(Package):
         targets.extend(["SPQR"])
         if spec.satisfies("+graphblas"):
             targets.append("GraphBLAS")
-        if spec.satisfies("@5.8.0:"):
-            targets.append("SLIP_LU")
+#        if spec.satisfies("@5.8.0:"):
+#            targets.append("SLIP_LU")
+#        fails with  make: *** SLIP_LU: No such file or directory.  Stop.
 
         # Finally make and install
-        make("-C", "SuiteSparse_config", "config", *make_args)
+        make("-C", "SuiteSparse_config", *make_args)
+        #make("-C", "SuiteSparse_config", "config", *make_args)
         for target in targets:
             make("-C", target, "library", *make_args)
             make("-C", target, "install", *make_args)

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -17,11 +17,11 @@ class SuiteSparse(Package):
 
     license("Apache-2.0")
 
-#    version("7.6.1", sha256="ab1992802723b09aca3cbb0f4dc9b2415a781b9ad984ed934c7d8a0dcc31bc42")
-#    version("7.5.1", sha256="dccfb5f75aa83fe2edb4eb2462fc984a086c82bad8433f63c31048d84b565d74")
-#    version("7.4.0", sha256="f9a5cc2316a967198463198f7bf10fb8c4332de6189b0e405419a7092bc921b7")
-# these fail with hundreds of libcholmod.so.5.2.0: undefined reference to xxxx when builing
-# the various cholmod_yyy_demo's or creating the static archive
+    #    version("7.6.1", sha256="ab1992802723b09aca3cbb0f4dc9b2415a781b9ad984ed934c7d8a0dcc31bc42")
+    #    version("7.5.1", sha256="dccfb5f75aa83fe2edb4eb2462fc984a086c82bad8433f63c31048d84b565d74")
+    #    version("7.4.0", sha256="f9a5cc2316a967198463198f7bf10fb8c4332de6189b0e405419a7092bc921b7")
+    # these fail with hundreds of libcholmod.so.5.2.0: undefined reference to xxxx when builing
+    # the various cholmod_yyy_demo's or creating the static archive
     version("7.3.1", sha256="b512484396a80750acf3082adc1807ba0aabb103c2e09be5691f46f14d0a9718")
     version("5.13.0", sha256="59c6ca2959623f0c69226cf9afb9a018d12a37fab3a8869db5f6d7f83b6b147d")
     version("5.12.0", sha256="5fb0064a3398111976f30c5908a8c0b40df44c6dd8f0cc4bfa7b9e45d8c647de")
@@ -236,10 +236,10 @@ class SuiteSparse(Package):
                 "CMAKE_OPTIONS=-DCMAKE_INSTALL_PREFIX=%s" % prefix
                 + " -DCMAKE_LIBRARY_PATH=%s" % prefix.lib
                 + " -DBLA_VENDOR=OpenBLAS"
-                + " -DBLAS_INCLUDE_DIRS=%s" % (spec["blas"].prefix.include)      # for >= v7.4.0
+                + " -DBLAS_INCLUDE_DIRS=%s" % (spec["blas"].prefix.include)  # for >= v7.4.0
                 + " -DLAPACK_INCLUDE_DIRS=%s" % (spec["lapack"].prefix.include)  # for >= v7.4.0
-                + " -DBLAS_LIBRARIES=%s" % (spec["blas"].prefix.include)         # for <= v7.3.1
-                + " -DLAPACK_LIBRARIES=%s" % (spec["lapack"].prefix.include)     # for <= v7.3.1
+                + " -DBLAS_LIBRARIES=%s" % (spec["blas"].prefix.include)  # for <= v7.3.1
+                + " -DLAPACK_LIBRARIES=%s" % (spec["lapack"].prefix.include)  # for <= v7.3.1
             ]
 
         if spec.satisfies("%gcc platform=darwin"):
@@ -267,13 +267,13 @@ class SuiteSparse(Package):
         targets.extend(["SPQR"])
         if spec.satisfies("+graphblas"):
             targets.append("GraphBLAS")
-#        if spec.satisfies("@5.8.0:"):
-#            targets.append("SLIP_LU")
-#        fails with  make: *** SLIP_LU: No such file or directory.  Stop.
+        #        if spec.satisfies("@5.8.0:"):
+        #            targets.append("SLIP_LU")
+        #        fails with  make: *** SLIP_LU: No such file or directory.  Stop.
 
         # Finally make and install
         make("-C", "SuiteSparse_config", *make_args)
-#       make("-C", "SuiteSparse_config", "config", *make_args)
+        #       make("-C", "SuiteSparse_config", "config", *make_args)
         for target in targets:
             make("-C", target, "library", *make_args)
             make("-C", target, "install", *make_args)


### PR DESCRIPTION
@DrTimothyAldenDavis @becker33 (sorry for the false start on the other repo, sigh)

After lots of banging my head on the keyboard I was able to get this version of SuiteSparse to compile in spack. It's not the latest and it's a bit hacky, but still much better than before, and this is the best I can do given my limited understanding of SuiteSparse, its build system and spack.

If either of you have time to improve it, I'd be delighted, but otherwise this should be an improvement compared to current unmaintained state of the affairs.
