### PR TITLE
py-nibabel: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-nibabel/package.py
+++ b/var/spack/repos/builtin/packages/py-nibabel/package.py
@@ -13,8 +13,11 @@ class PyNibabel(PythonPackage):
     pypi = "nibabel/nibabel-3.2.1.tar.gz"
     git = "https://github.com/nipy/nibabel"
 
-    license("PDDL-1.0")
+    maintainers("ChristopherChristofi")
 
+    license("MIT")
+
+    version("5.2.1", sha256="b6c80b2e728e4bc2b65f1142d9b8d2287a9102a8bf8477e115ef0d8334559975")
     version("5.1.0", sha256="ce73ca5e957209e7219a223cb71f77235c9df2acf4d3f27f861ba38e9481ac53")
     version("4.0.2", sha256="45c49b5349351b45f6c045a91aa02b4f0d367686ff3284632ef95ac65b930786")
     version("3.2.2", sha256="b0dcc174b30405ce9e8fec1eab3cbbb20f5c5e4920976c08b22e050b7c124f94")
@@ -26,12 +29,14 @@ class PyNibabel(PythonPackage):
     depends_on("py-hatchling", when="@5:", type="build")
     depends_on("py-hatch-vcs", when="@5:", type="build")
 
+    depends_on("py-numpy@1.20:", when="@5.2.1:", type=("build", "run"))
     depends_on("py-numpy@1.19:", when="@5:", type=("build", "run"))
     depends_on("py-numpy@1.17:", when="@4:", type=("build", "run"))
     depends_on("py-numpy@1.14:", when="@3.2:", type=("build", "run"))
     depends_on("py-numpy@1.8:", type=("build", "run"))
     depends_on("py-packaging@17:", when="@4:", type=("build", "run"))
     depends_on("py-packaging@14.3:", when="@3.1:", type=("build", "run"))
+    depends_on("py-importlib-resources@1.3:", when="@5.2.1: ^python@:3.9", type=("build", "run"))
     depends_on("py-importlib-resources@1.3:", when="@5.1: ^python@:3.8", type=("build", "run"))
 
     depends_on("py-pytest", type="test")

--- a/var/spack/repos/builtin/packages/py-nibabel/package.py
+++ b/var/spack/repos/builtin/packages/py-nibabel/package.py
@@ -15,7 +15,8 @@ class PyNibabel(PythonPackage):
 
     maintainers("ChristopherChristofi")
 
-    license("MIT")
+    # As detailed: https://nipy.org/nibabel/legal.html
+    license("MIT AND BSD-3-Clause AND PSF-2.0 AND PDDL-1.0")
 
     version("5.2.1", sha256="b6c80b2e728e4bc2b65f1142d9b8d2287a9102a8bf8477e115ef0d8334559975")
     version("5.1.0", sha256="ce73ca5e957209e7219a223cb71f77235c9df2acf4d3f27f861ba38e9481ac53")


### PR DESCRIPTION
PyNibabel - 5.2.1: [release notes](https://github.com/nipy/nibabel/releases/tag/5.2.1)