### PR TITLE
xrootd: add a dependency on pkgconfig when building with +davix

### DIFF
--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -112,6 +112,7 @@ class Xrootd(CMakePackage):
     conflicts("^cmake@:3.0", when="@5.0.0")
     conflicts("^cmake@:3.15.99", when="@5.5.4:5.5")
     depends_on("davix", when="+davix")
+    depends_on("pkgconfig", type="build", when="+davix")
     depends_on("libxml2", when="+http")
     depends_on("uuid", when="@4.11.0:")
     depends_on("openssl@:1", when="@:5.4")


### PR DESCRIPTION
The following error happens when building with `+davix` and pkgconfig is not found:

```
CMake Error at cmake/XRootDSummary.cmake:46 (message):
  Could not enable feature: XRDCLHTTP
Call Stack (most recent call first):
  CMakeLists.txt:52 (include)


-- Configuring incomplete, errors occurred!
```

This happens because FindDavix.cmake uses pkgconfig: https://github.com/xrootd/xrootd/blob/master/cmake/FindDavix.cmake#L44


This PR seems to fix the issue; I was able to build with `+davix` with this change.