### PR TITLE
strip url: fix whl suffix, remove exe

### DIFF
--- a/lib/spack/llnl/url.py
+++ b/lib/spack/llnl/url.py
@@ -357,10 +357,8 @@ def strip_version_suffixes(path_or_url: str) -> str:
         r"i[36]86",
         r"ppc64(le)?",
         r"armv?(7l|6l|64)?",
-        # PyPI
-        r"[._-]py[23].*\.whl",
-        r"[._-]cp[23].*\.whl",
-        r"[._-]win.*\.exe",
+        # PyPI wheels
+        r"-(?:py|cp)[23].*",
     ]
 
     for regex in suffix_regexes:

--- a/lib/spack/spack/test/llnl/url.py
+++ b/lib/spack/spack/test/llnl/url.py
@@ -84,14 +84,15 @@ def test_get_bad_extension():
         ("astyle_1.23_macosx", "astyle_1.23"),
         ("haxe-2.08-osx", "haxe-2.08"),
         # PyPI - wheel
-        ("entrypoints-0.2.2-py2.py3-none-any.whl", "entrypoints-0.2.2"),
+        ("wheel-1.2.3-py3-none-any", "wheel-1.2.3"),
+        ("wheel-1.2.3-py2.py3-none-any", "wheel-1.2.3"),
+        ("wheel-1.2.3-cp38-abi3-macosx_10_12_x86_64", "wheel-1.2.3"),
+        ("entrypoints-0.2.2-py2.py3-none-any", "entrypoints-0.2.2"),
         (
             "numpy-1.12.0-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel."
-            "macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl",
+            "macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64",
             "numpy-1.12.0",
         ),
-        # PyPI - exe
-        ("PyYAML-3.12.win-amd64-py3.5.exe", "PyYAML-3.12"),
         # Combinations of multiple patterns - bin, release
         ("rocketmq-all-4.5.2-bin-release", "rocketmq-all-4.5.2"),
         # Combinations of multiple patterns - all


### PR DESCRIPTION
Since `.whl` is an archive, it now gets stripped off URLs as an "extension"
(although that concept is entirely meaningless...)

So, in `strip_version_suffixes` the suffix should not try to match `.whl$`.

Further, make the regex stricter. It can only use `-` as a separator.

Also remove special casing of `.exe` suffix, we should use wheels.