### PR TITLE
Improve clang support for boost

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -446,7 +446,7 @@ class Boost(Package):
 
     def flag_handler(self, name, flags):
         if name == "cxxflags":
-            if self.spec.satisfies("@1.79.0 %oneapi"):
+            if self.spec.satisfies("@:1.79.0") and self.spec.compiler.name in ["oneapi", "aocc", "clang"]:
                 flags.append("-Wno-error=enum-constexpr-conversion")
         return (flags, None, None)
 

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -446,7 +446,11 @@ class Boost(Package):
 
     def flag_handler(self, name, flags):
         if name == "cxxflags":
-            if self.spec.satisfies("@:1.79.0") and self.spec.compiler.name in ["oneapi", "aocc", "clang"]:
+            if self.spec.satisfies("@:1.79.0") and self.spec.compiler.name in [
+                "oneapi",
+                "aocc",
+                "clang",
+            ]:
                 flags.append("-Wno-error=enum-constexpr-conversion")
         return (flags, None, None)
 


### PR DESCRIPTION
This PR implements the `-Wno-error=enum-constexpr-conversion` fix that currently exists for oneapi for clang and aocc as well.