### PR TITLE
Remove unnecessary leading or trailing path seps in env mods

### DIFF
--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -818,7 +818,7 @@ class EnvironmentModifications:
         for variable_name in new_variables:
             sep = return_separator_if_any(after[variable_name])
             if sep:
-                env.prepend_path(variable_name, after[variable_name], separator=sep)
+                env.prepend_path(variable_name, after[variable_name].strip(sep), separator=sep)
             elif "PATH" in variable_name:
                 env.prepend_path(variable_name, after[variable_name])
             else:


### PR DESCRIPTION
The environment modification code, as currently constructed, can produce prepend_path arguments in **Lmod** modules like this:

```
prepend_path("LIBRARY_PATH",".../spack/opt/spack/intel-oneapi-mkl/2024.0.0/oneapi/2024.0.2/hc5p/mkl/2024.0/lib:")
```

Thus far, I've only seen this happen with **intel-oneapi-mkl**, but I'm sure it can happen with other packages.

It results in an empty path, at least when using **Lmod** modules, which causes problems for the Lmod cache. I've documented [this issue](https://github.com/TACC/Lmod/issues/701) more in the Lmod repo.

That said, I don't see any reason why we would want to leave a dangling separator in the specified paths, so this PR strips any leading or trailing separator before adding the string to the environment mods.