### PR TITLE
pixman: avoid assembler macros error with Fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/pixman/package.py
+++ b/var/spack/repos/builtin/packages/pixman/package.py
@@ -74,4 +74,8 @@ class Pixman(AutotoolsPackage):
             if self.spec.target.family == "aarch64":
                 args.append("--disable-arm-a64-neon")
 
+        # The Fujitsu compiler does not support assembler macros.
+        if self.spec.satisfies("%fj"):
+            args.append("--disable-arm-a64-neon")
+
         return args


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Make the configure option specify `--disable-arm-a64-neon` because assembler macros are not supported by the Fujitsu compiler.