### PR TITLE
Add logging variant for netcdf-c

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -134,6 +134,7 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
     variant("fsync", default=False, description="Enable fsync support")
     variant("nczarr_zip", default=False, description="Enable NCZarr zipfile format storage")
     variant("optimize", default=True, description="Enable -O2 for a more optimized lib")
+    variant("logging", default=False, description="Enable logging")
 
     variant("szip", default=True, description="Enable Szip compression plugin")
     variant("blosc", default=True, description="Enable Blosc compression plugin")
@@ -337,6 +338,7 @@ class CMakeBuilder(BaseBuilder, cmake.CMakeBuilder):
             self.define("ENABLE_PARALLEL_TESTS", False),
             self.define_from_variant("ENABLE_FSYNC", "fsync"),
             self.define("ENABLE_LARGE_FILE_SUPPORT", True),
+            self.define_from_variant("NETCDF_ENABLE_LOGGING", "logging"),
         ]
         if "+parallel-netcdf" in self.pkg.spec:
             base_cmake_args.append(self.define("ENABLE_PNETCDF", True))
@@ -529,6 +531,8 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
         if not self.spec.satisfies("@:4.4,main"):
             # Suppress the redundant check for m4:
             config_args.append("ac_cv_prog_NC_M4=false")
+
+        config_args.extend(self.enable_or_disable("logging"))
 
         lib_search_dirs.extend(d for libs in extra_libs for d in libs.directories)
         # Remove duplicates and system prefixes:

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -434,6 +434,8 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
 
         config_args += self.enable_or_disable("fsync")
 
+        config_args.extend(self.enable_or_disable("logging"))
+
         if any(self.spec.satisfies(s) for s in ["+mpi", "+parallel-netcdf", "^hdf5+mpi~shared"]):
             config_args.append("CC={0}".format(self.spec["mpi"].mpicc))
 
@@ -531,8 +533,6 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
         if not self.spec.satisfies("@:4.4,main"):
             # Suppress the redundant check for m4:
             config_args.append("ac_cv_prog_NC_M4=false")
-
-        config_args.extend(self.enable_or_disable("logging"))
 
         lib_search_dirs.extend(d for libs in extra_libs for d in libs.directories)
         # Remove duplicates and system prefixes:

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -434,7 +434,7 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
 
         config_args += self.enable_or_disable("fsync")
 
-        config_args.extend(self.enable_or_disable("logging"))
+        config_args += self.enable_or_disable("logging")
 
         if any(self.spec.satisfies(s) for s in ["+mpi", "+parallel-netcdf", "^hdf5+mpi~shared"]):
             config_args.append("CC={0}".format(self.spec["mpi"].mpicc))


### PR DESCRIPTION
This PR adds the logging option for netcdf-c. Tested builds to ensure the configure and cmake logging settings work, but didn't test the logging itself.