### PR TITLE
argobots: update to v1.2

### DIFF
--- a/var/spack/repos/builtin/packages/argobots/package.py
+++ b/var/spack/repos/builtin/packages/argobots/package.py
@@ -18,7 +18,7 @@ class Argobots(AutotoolsPackage):
     homepage = "https://www.argobots.org/"
     url = "https://github.com/pmodels/argobots/releases/download/v1.2/argobots-1.2.tar.gz"
     git = "https://github.com/pmodels/argobots.git"
-    maintainers("shintaro-iwasaki")
+    maintainers("yfguo")
 
     tags = ["e4s"]
 

--- a/var/spack/repos/builtin/packages/argobots/package.py
+++ b/var/spack/repos/builtin/packages/argobots/package.py
@@ -16,13 +16,14 @@ class Argobots(AutotoolsPackage):
     execution model and a memory model."""
 
     homepage = "https://www.argobots.org/"
-    url = "https://github.com/pmodels/argobots/releases/download/v1.0b1/argobots-1.0b1.tar.gz"
+    url = "https://github.com/pmodels/argobots/releases/download/v1.2/argobots-1.2.tar.gz"
     git = "https://github.com/pmodels/argobots.git"
     maintainers("shintaro-iwasaki")
 
     tags = ["e4s"]
 
     version("main", branch="main")
+    version("1.2", sha256="1c056429d9c0a27c041d4734f6318b801fc2ec671854e42c35251c4c7d0d43e1")
     version("1.1", sha256="f0f971196fc8354881681c2282a2f2adb6d48ff5e84cf820ca657daad1549005")
     version("1.0.1", sha256="fa05a02d7f8f74d845647636609219ee02f6adf628ebcbf40393f829987d9036")
     version("1.0", sha256="36a0815f7bf99900a9c9c1eef61ef9b3b76aa2cfc4594a304f6c8c3296da8def")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Upgrading to latest Argobots release and making v1.2 the default.