### PR TITLE
LLVM: avoid Fujitsu compiler build fail in llvm17-18

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/llvm17-18-thread.patch
+++ b/var/spack/repos/builtin/packages/llvm/llvm17-18-thread.patch
@@ -1,0 +1,22 @@
+diff --git a/openmp/libomptarget/cmake/Modules/LibomptargetGetDependencies.cmake b/openmp/libomptarget/cmake/Modules/LibomptargetGetDependencies.cmake
+index 1f2a50667c4f..d3ff232f6bd3 100644
+--- a/openmp/libomptarget/cmake/Modules/LibomptargetGetDependencies.cmake
++++ b/openmp/libomptarget/cmake/Modules/LibomptargetGetDependencies.cmake
+@@ -280,4 +280,5 @@ if (NOT LIBOMPTARGET_CUDA_TOOLKIT_ROOT_DIR_PRESET AND
+   endif()
+ endif()
+ 
+-set(OPENMP_PTHREAD_LIB ${LLVM_PTHREAD_LIB})
++find_package(Threads REQUIRED)
++set(OPENMP_PTHREAD_LIB Threads::Threads)
+diff --git a/openmp/libomptarget/src/CMakeLists.txt b/openmp/libomptarget/src/CMakeLists.txt
+index 071ec61889a2..b782c3b07e6f 100644
+--- a/openmp/libomptarget/src/CMakeLists.txt.orig	2024-03-26 14:30:52.000000000 +0900
++++ b/openmp/libomptarget/src/CMakeLists.txt	2024-03-26 14:34:02.000000000 +0900
+@@ -41,5 +41,6 @@
+ 
+ if (LIBOMP_HAVE_VERSION_SCRIPT_FLAG)
+   target_link_libraries(omptarget PRIVATE
++    ${OPENMP_PTHREAD_LIB}
+     "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports")
+ endif()

--- a/var/spack/repos/builtin/packages/llvm/llvm17-fujitsu.patch
+++ b/var/spack/repos/builtin/packages/llvm/llvm17-fujitsu.patch
@@ -11,3 +11,18 @@ index aeef3e5..2f14ff3 100644
  // __FILE_NAME__ is a Clang-specific extension that functions similar to
  // __FILE__ but only renders the last path component (the filename) instead of
  // an invocation dependent full path to that file.
+
+diff --git runtimes/CMakeLists.txt_org runtimes/CMakeLists.txt
+--- a/runtimes/CMakeLists.txt_org
++++ b/runtimes/CMakeLists.txt
+@@ -6,2 +6,2 @@
+ include(${LLVM_COMMON_CMAKE_UTILS}/Modules/CMakePolicy.cmake
+   NO_POLICY_SCOPE)
+
++string(REPLACE "-Nclang" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
++string(REPLACE "-Nnofjprof" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
++string(REPLACE "-Nfjprof" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
++
+ project(Runtimes C CXX ASM)
+
+ list(INSERT CMAKE_MODULE_PATH 0

--- a/var/spack/repos/builtin/packages/llvm/llvm17-fujitsu.patch
+++ b/var/spack/repos/builtin/packages/llvm/llvm17-fujitsu.patch
@@ -1,0 +1,13 @@
+diff --git a/lldb/include/lldb/Utility/LLDBAssert.h_org b/lldb/include/lldb/Utility/LLDBAssert.h
+index aeef3e5..2f14ff3 100644
+--- a/lldb/include/lldb/Utility/LLDBAssert.h_org
++++ b/lldb/include/lldb/Utility/LLDBAssert.h
+@@ -14,7 +14,7 @@
+ #ifndef NDEBUG
+ #define lldbassert(x) assert(x)
+ #else
+-#if defined(__clang__)
++#if defined(__clang__) && !defined(__CLANG_FUJITSU)
+ // __FILE_NAME__ is a Clang-specific extension that functions similar to
+ // __FILE__ but only renders the last path component (the filename) instead of
+ // an invocation dependent full path to that file.

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -538,6 +538,10 @@ class Llvm(CMakePackage, CudaPackage):
     # avoid build failed with Fujitsu compiler
     patch("llvm13-fujitsu.patch", when="@13 %fj")
 
+    # avoid build failed with Fujitsu compiler since llvm17
+    patch("llvm17-fujitsu.patch", when="@17: %fj")
+    patch("llvm17-18-thread.patch", when="@17:18 %fj")
+
     # patch for missing hwloc.h include for libompd
     # see https://reviews.llvm.org/D123888
     patch(

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -990,16 +990,6 @@ class Llvm(CMakePackage, CudaPackage):
 
         return cmake_args
 
-    @run_after("cmake")
-    def change_makefile(self):
-        # Avoid Fujitsu compiler Clang Mode options when building LLVM
-        if self.spec.satisfies("%fj"):
-            filter_file(
-                r"-DCMAKE_C_COMPILER=",
-                "-DCMAKE_CXX_FLAGS= -DCMAKE_C_COMPILER=",
-                join_path(self.build_directory, "build.ninja"),
-            )
-
     @run_after("install")
     def post_install(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -986,6 +986,16 @@ class Llvm(CMakePackage, CudaPackage):
 
         return cmake_args
 
+    @run_after("cmake")
+    def change_makefile(self):
+        # Avoid Fujitsu compiler Clang Mode options when building LLVM
+        if self.spec.satisfies("%fj"):
+            filter_file(
+                r"-DCMAKE_C_COMPILER=",
+                "-DCMAKE_CXX_FLAGS= -DCMAKE_C_COMPILER=",
+                join_path(self.build_directory, "build.ninja"),
+            )
+
     @run_after("install")
     def post_install(self):
         spec = self.spec


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This PR fixes the following two issues.
- Avoid Fujitsu compiler Clang Mode options being specified when building LLVM.
- Patch to work around the problem of error at build time with Fujitsu compiler.