### PR TITLE
ci: pass codecov token as env variable

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -48,3 +48,4 @@ jobs:
       with:
         flags: unittests,audits
         token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -95,6 +95,7 @@ jobs:
       with:
         flags: unittests,linux,${{ matrix.concretizer }}
         token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true
   # Test shell integration
   shell:
     runs-on: ubuntu-latest
@@ -127,6 +128,7 @@ jobs:
       with:
         flags: shelltests,linux
         token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true
 
   # Test RHEL8 UBI with platform Python. This job is run
   # only on PRs modifying core Spack
@@ -187,6 +189,7 @@ jobs:
       with:
         flags: unittests,linux,clingo
         token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true
   # Run unit tests on MacOS
   macos:
     runs-on: ${{ matrix.os }}
@@ -224,3 +227,4 @@ jobs:
       with:
         flags: unittests,macos
         token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true

--- a/.github/workflows/windows_python.yml
+++ b/.github/workflows/windows_python.yml
@@ -37,6 +37,7 @@ jobs:
       with:
         flags: unittests,windows
         token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true
   unit-tests-cmd:
     runs-on: windows-latest
     steps:
@@ -62,6 +63,7 @@ jobs:
       with:
         flags: unittests,windows
         token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true
   build-abseil:
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
For some reason passing `with:token: ${{ secrets.CODECOV_TOKEN }}` hasn't worked.
