### PR TITLE
Updated support for Python version for awscli-v2

### DIFF
--- a/var/spack/repos/builtin/packages/awscli-v2/package.py
+++ b/var/spack/repos/builtin/packages/awscli-v2/package.py
@@ -16,7 +16,7 @@ class AwscliV2(PythonPackage):
 
     version("2.13.22", sha256="dd731a2ba5973f3219f24c8b332a223a29d959493c8a8e93746d65877d02afc1")
 
-    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("python@3.8:3.11", type=("build", "run"))
     depends_on("py-flit-core@3.7.1:3.8.0", type=("build"))
     depends_on("py-colorama@0.2.5:0.4.6", type=("build", "run"))
     depends_on("py-docutils@0.10:0.19", type=("build", "run"))


### PR DESCRIPTION
Removed support for python 3.12.0. awscli 2.13.22 does not appear to build with this version and it's not mentioned in https://github.com/aws/aws-cli/tree/v2. Note, earlier releases of awscli-v2 not tested.