### PR TITLE
glew: remove a few unused options

### DIFF
--- a/var/spack/repos/builtin/packages/glew/package.py
+++ b/var/spack/repos/builtin/packages/glew/package.py
@@ -57,15 +57,12 @@ class Glew(CMakePackage):
             self.define("BUILD_UTILS", True),
             self.define("GLEW_REGAL", False),
             self.define("GLEW_EGL", "gl=egl" in spec),
-            self.define("OpenGL_GL_PREFERENCE", "LEGACY"),
             self.define("OPENGL_INCLUDE_DIR", spec["gl"].headers.directories[0]),
             self.define("OPENGL_gl_LIBRARY", spec["gl"].libs[0]),
             self.define("OPENGL_opengl_LIBRARY", "IGNORE"),
             self.define("OPENGL_glx_LIBRARY", "IGNORE"),
             self.define("OPENGL_glu_LIBRARY", "IGNORE"),
             self.define("GLEW_OSMESA", "gl=osmesa" in spec),
-            self.define("GLEW_X11", "gl=glx" in spec),
-            self.define("CMAKE_DISABLE_FIND_PACKAGE_X11", "gl=glx" not in spec),
         ]
         if "gl=egl" in spec:
             args.append(


### PR DESCRIPTION
When running cmake I get the following:

```
  Manually-specified variables were not used by the project:

    CMAKE_DISABLE_FIND_PACKAGE_X11
    GLEW_X11
    OpenGL_GL_PREFERENCE
```

and I checked and couldn't find those for the versions that are listed in the recipe.