### PR TITLE
Add aocc support to qt

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -282,6 +282,7 @@ class Qt(Package):
         "intel": ("icc",),
         "apple-clang": ("clang-libc++", "clang"),
         "clang": ("clang-libc++", "clang"),
+        "aocc": ("clang-libc++", "clang"),
         "fj": ("clang",),
         "gcc": ("g++",),
     }


### PR DESCRIPTION
This PR adds aocc to the compiler mapping in the qt recipe. It successfully build with qt@5.15.12 %aocc@4.1.0.