### PR TITLE
gmsh: fix `setup_run_environment`

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -49,6 +49,7 @@ __all__ = [
     "copy_mode",
     "filter_file",
     "find",
+    "find_first",
     "find_headers",
     "find_all_headers",
     "find_libraries",

--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -20,6 +20,8 @@ class Gmsh(CMakePackage):
     url = "https://gmsh.info/src/gmsh-4.4.1-source.tgz"
     git = "https://gitlab.onelab.info/gmsh/gmsh.git"
 
+    maintainers("tristan0x")
+
     license("GPL-2.0-or-later")
 
     version("master", branch="master")

--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -185,4 +185,5 @@ class Gmsh(CMakePackage):
         return options
 
     def setup_run_environment(self, env):
-        env.prepend_path("PYTHONPATH", self.prefix.lib)
+        sitedir = ancestor(find_first(self.prefix, "gmsh.py"))
+        env.prepend_path("PYTHONPATH", sitedir)


### PR DESCRIPTION
Fix the path prepended to PYTHONPATH since the /lib directory does not always exist. I experience `lib` and `lib64` on different Linux systems with the 4.12.2 and `lib` on MacOS.
