### PR TITLE
UCX:  Add patch to set HIP_PLATFORM_AMD

### DIFF
--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -160,6 +160,11 @@ class Ucx(AutotoolsPackage, CudaPackage):
                 "-L$with_rocm/hip/lib -L$with_rocm/lib", "$ROCM_LDFLAGS", "configure", string=True
             )
 
+            if self.spec.satisfies("^hip@6:"):
+                filter_file(
+                    "HIP_PLATFORM_HCC", "HIP_PLATFORM_AMD", "configure", string=True
+                )
+
     @when("@1.9-dev")
     def autoreconf(self, spec, prefix):
         Executable("./autogen.sh")()

--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -161,9 +161,7 @@ class Ucx(AutotoolsPackage, CudaPackage):
             )
 
             if self.spec.satisfies("^hip@6:"):
-                filter_file(
-                    "HIP_PLATFORM_HCC", "HIP_PLATFORM_AMD", "configure", string=True
-                )
+                filter_file("HIP_PLATFORM_HCC", "HIP_PLATFORM_AMD", "configure", string=True)
 
     @when("@1.9-dev")
     def autoreconf(self, spec, prefix):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

HIP header files require HIP_PLATFORM_AMD to be set for hip 6.0 on AMD gpus.