### PR TITLE
Legion: add Rust-based profiler to install

### DIFF
--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -25,6 +25,8 @@ class Legion(CMakePackage, ROCmPackage):
     homepage = "https://legion.stanford.edu/"
     git = "https://github.com/StanfordLegion/legion.git"
 
+    license("Apache-2.0")
+
     maintainers("pmccormick", "streichler", "elliottslaughter")
     tags = ["e4s"]
     version("24.03.0", tag="legion-24.03.0", commit="c61071541218747e35767317f6f89b83f374f264")


### PR DESCRIPTION
This adds a `prof` variant which when enabled installs the Rust-based Legion prof.

@elliottslaughter let me know what you think.