### PR TITLE
amdblis+amdlibflame: Adding 'logging' and 'tracing' variants to enable AOCL DTL trace and logging capabilities

### DIFF
--- a/var/spack/repos/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/builtin/packages/amdblis/package.py
@@ -55,6 +55,9 @@ class Amdblis(BlisBase):
     variant("aocl_gemm", default=False, when="@4.1:", description="aocl_gemm support")
     variant("suphandling", default=True, description="Small Unpacked Kernel handling")
 
+    variant("logging", default=False, description="Enable AOCL DTL Logging")
+    variant("tracing", default=False, description="Enable AOCL DTL Tracing")
+
     def configure_args(self):
         spec = self.spec
         args = super().configure_args()
@@ -94,6 +97,20 @@ class Amdblis(BlisBase):
 
         if spec.satisfies("@3.1:"):
             args.append("--disable-aocl-dynamic")
+
+        if spec.satisfies("+logging"):
+            filter_file(
+                "#define AOCL_DTL_LOG_ENABLE         0",
+                "#define AOCL_DTL_LOG_ENABLE         1",
+                f"{self.stage.source_path}/aocl_dtl/aocldtlcf.h",
+            )
+
+        if spec.satisfies("+tracing"):
+            filter_file(
+                "#define AOCL_DTL_TRACE_ENABLE       0",
+                "#define AOCL_DTL_TRACE_ENABLE       1",
+                f"{self.stage.source_path}/aocl_dtl/aocldtlcf.h",
+            )
 
         return args
 

--- a/var/spack/repos/builtin/packages/amdlibflame/package.py
+++ b/var/spack/repos/builtin/packages/amdlibflame/package.py
@@ -79,6 +79,9 @@ class Amdlibflame(CMakePackage, LibflameBase):
         description="Use hardware vectorization support",
     )
 
+    variant("logging", default="False", description="Enable AOCL DTL Logging")
+    variant("tracing", default="False", description="Enable AOCL DTL Tracing")
+
     # Build system
     build_system(
         conditional("cmake", when="@4.2:"), conditional("autotools", when="@:4.1"), default="cmake"
@@ -214,6 +217,20 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
             args.append("CFLAGS=-I{0}".format(spec["aocl-utils"].prefix.include))
             aocl_utils_lib_path = spec["aocl-utils"].libs
             args.append("LIBAOCLUTILS_LIBRARY_PATH={0}".format(aocl_utils_lib_path))
+
+        if spec.satisfies("+tracing"):
+            filter_file(
+                "#define AOCL_DTL_TRACE_ENABLE       0",
+                "#define AOCL_DTL_TRACE_ENABLE       1",
+                f"{self.stage.source_path}/aocl_dtl/aocldtlcf.h",
+            )
+
+        if spec.satisfies("+logging"):
+            filter_file(
+                "#define AOCL_DTL_LOG_ENABLE         0",
+                "#define AOCL_DTL_LOG_ENABLE         1",
+                f"{self.stage.source_path}/aocl_dtl/aocldtlcf.h",
+            )
 
         return args
 


### PR DESCRIPTION
Adding 'logging' and 'tracing' variants to enable AOCL DTL trace and logging capabilities

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
