### PR TITLE
mpich: Rename pmi variant to pmi1

### DIFF
--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -179,7 +179,7 @@ class FluxCore(AutotoolsPackage):
     depends_on("libtool", type="build", when="@master")
 
     # Testing Dependencies
-    depends_on("mpich pmi=pmi", type="test")
+    depends_on("mpich pmi=pmi1", type="test")
     depends_on("valgrind", type="test")
     depends_on("jq", type="test")
 

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -61,9 +61,9 @@ class Mpich(AutotoolsPackage, CudaPackage, ROCmPackage):
     variant("wrapperrpath", default=True, description="Enable wrapper rpath")
     variant(
         "pmi",
-        default="pmi",
+        default="pmi1",
         description="""PMI interface.""",
-        values=("pmi", "pmi2", "pmix", "cray"),
+        values=("pmi1", "pmi2", "pmix", "cray"),
         multi=False,
     )
     variant(
@@ -389,7 +389,7 @@ supported, and netmod is ignored if device is ch3:sock.""",
                 variants.append("+argobots")
 
             if re.search(r"--with-pmi=simple", output):
-                variants.append("pmi=pmi")
+                variants.append("pmi=pmi1")
             elif re.search(r"--with-pmi=pmi2/simple", output):
                 variants.append("pmi=pmi2")
             elif re.search(r"--with-pmix", output):
@@ -554,7 +554,7 @@ supported, and netmod is ignored if device is ch3:sock.""",
         else:
             config_args.append("--with-slurm=no")
 
-        if "pmi=pmi" in spec:
+        if "pmi=pmi1" in spec:
             config_args.append("--with-pmi=simple")
         elif "pmi=pmi2" in spec:
             config_args.append("--with-pmi=pmi2/simple")


### PR DESCRIPTION
MPICH supports 3 PMI client interfaces - PMI1, PMI2, and PMIx. pmi=pmi as a variant is poorly named, so make it more explicit.

This is the second split from https://github.com/spack/spack/pull/42885.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
