### PR TITLE
Don't delete "spack develop" build artifacts after install

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2311,9 +2311,15 @@ class BuildProcessInstaller:
         """Main entry point from ``build_process`` to kick off install in child."""
 
         stage = self.pkg.stage
-        stage.keep = self.keep_stage
+        is_develop = self.pkg.spec.is_develop
 
-        if self.restage:
+        # Note: user commands do not have an explicit choice to disable
+        # keeping stages (i.e., we have a --keep-stage option, but not
+        # a --destroy-stage option), so we can override a default choice
+        # to destroy
+        stage.keep = self.keep_stage or is_develop
+
+        if self.restage and (not is_develop):
             stage.destroy()
 
         with stage:

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2282,7 +2282,7 @@ class BuildProcessInstaller:
         # to destroy
         self.keep_stage = is_develop or install_args.get("keep_stage", False)
         # whether to restage
-        self.restage = (not is_develop) or install_args.get("restage", False)
+        self.restage = (not is_develop) and install_args.get("restage", False)
 
         # whether to skip the patch phase
         self.skip_patch = install_args.get("skip_patch", False)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1410,7 +1410,7 @@ class Spec:
 
     @property
     def is_develop(self):
-        return bool(self.spec.variants.get("dev_path", False))
+        return bool(self.variants.get("dev_path", False))
 
     def clear_dependencies(self):
         """Trim the dependencies of this spec."""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1408,6 +1408,10 @@ class Spec:
     def external(self):
         return bool(self.external_path) or bool(self.external_modules)
 
+    @property
+    def is_develop(self):
+        return bool(self.spec.variants.get("dev_path", False))
+
     def clear_dependencies(self):
         """Trim the dependencies of this spec."""
         self._dependencies.clear()

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1410,6 +1410,9 @@ class Spec:
 
     @property
     def is_develop(self):
+        """Return whether the Spec represents a user-developed package
+        in a Spack ``Environment`` (i.e. using `spack develop`).
+        """
         return bool(self.variants.get("dev_path", False))
 
     def clear_dependencies(self):

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -927,6 +927,10 @@ class DevelopStage(LockableStagingDir):
             shutil.rmtree(self.path)
         except FileNotFoundError:
             pass
+        try:
+            os.remove(self.reference_link)
+        except FileNotFoundError:
+            pass
         self.created = False
 
     def restage(self):

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -20,10 +20,12 @@ dev_build = SpackCommand("dev-build")
 install = SpackCommand("install")
 env = SpackCommand("env")
 
-pytestmark = pytest.mark.not_on_windows("does not run on windows")
+pytestmark = [
+    pytest.mark.not_on_windows("does not run on windows"),
+    pytest.mark.disable_clean_stage_check,
+]
 
 
-@pytest.mark.disable_clean_stage_check
 def test_dev_build_basics(tmpdir, install_mockery):
     spec = spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmpdir}").concretized()
 
@@ -42,7 +44,6 @@ def test_dev_build_basics(tmpdir, install_mockery):
     assert os.path.exists(str(tmpdir))
 
 
-@pytest.mark.disable_clean_stage_check
 def test_dev_build_before(tmpdir, install_mockery):
     spec = spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmpdir}").concretized()
 
@@ -59,7 +60,6 @@ def test_dev_build_before(tmpdir, install_mockery):
     assert not os.path.exists(spec.prefix)
 
 
-@pytest.mark.disable_clean_stage_check
 def test_dev_build_until(tmpdir, install_mockery):
     spec = spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmpdir}").concretized()
 
@@ -77,7 +77,6 @@ def test_dev_build_until(tmpdir, install_mockery):
     assert not spack.store.STORE.db.query(spec, installed=True)
 
 
-@pytest.mark.disable_clean_stage_check
 def test_dev_build_until_last_phase(tmpdir, install_mockery):
     # Test that we ignore the last_phase argument if it is already last
     spec = spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmpdir}").concretized()
@@ -97,7 +96,6 @@ def test_dev_build_until_last_phase(tmpdir, install_mockery):
     assert os.path.exists(str(tmpdir))
 
 
-@pytest.mark.disable_clean_stage_check
 def test_dev_build_before_until(tmpdir, install_mockery, capsys):
     spec = spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmpdir}").concretized()
 
@@ -135,7 +133,6 @@ def mock_module_noop(*args):
     pass
 
 
-@pytest.mark.disable_clean_stage_check
 def test_dev_build_drop_in(tmpdir, mock_packages, monkeypatch, install_mockery, working_env):
     monkeypatch.setattr(os, "execvp", print_spack_cc)
     monkeypatch.setattr(spack.build_environment, "module", mock_module_noop)
@@ -145,7 +142,6 @@ def test_dev_build_drop_in(tmpdir, mock_packages, monkeypatch, install_mockery, 
         assert "lib/spack/env" in output
 
 
-@pytest.mark.disable_clean_stage_check
 def test_dev_build_fails_already_installed(tmpdir, install_mockery):
     spec = spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % tmpdir)
     spec.concretize()
@@ -186,7 +182,6 @@ def test_dev_build_fails_no_version(mock_packages):
     assert "dev-build spec must have a single, concrete version" in output
 
 
-@pytest.mark.disable_clean_stage_check
 def test_dev_build_env(tmpdir, install_mockery, mutable_mock_env_path):
     """Test Spack does dev builds for packages in develop section of env."""
     # setup dev-build-test-install package for dev build
@@ -223,7 +218,6 @@ spack:
         assert f.read() == spec.package.replacement_string
 
 
-@pytest.mark.disable_clean_stage_check
 def test_dev_build_env_with_vars(tmpdir, install_mockery, mutable_mock_env_path, monkeypatch):
     """Test Spack does dev builds for packages in develop section of env (path with variables)."""
     # setup dev-build-test-install package for dev build
@@ -296,7 +290,6 @@ spack:
                 install()
 
 
-@pytest.mark.disable_clean_stage_check
 def test_dev_build_multiple(tmpdir, install_mockery, mutable_mock_env_path, mock_fetch):
     """Test spack install with multiple developer builds
 
@@ -360,7 +353,6 @@ spack:
             assert f.read() == spec.package.replacement_string
 
 
-@pytest.mark.disable_clean_stage_check
 def test_dev_build_env_dependency(tmpdir, install_mockery, mock_fetch, mutable_mock_env_path):
     """
     Test non-root specs in an environment are properly marked for dev builds.
@@ -410,7 +402,6 @@ spack:
     assert spec.satisfies("^dev_path=*")
 
 
-@pytest.mark.disable_clean_stage_check
 @pytest.mark.parametrize("test_spec", ["dev-build-test-install", "dependent-of-dev-build"])
 def test_dev_build_rebuild_on_source_changes(
     test_spec, tmpdir, install_mockery, mutable_mock_env_path, mock_fetch

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -23,6 +23,7 @@ env = SpackCommand("env")
 pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
+@pytest.mark.disable_clean_stage_check
 def test_dev_build_basics(tmpdir, install_mockery):
     spec = spack.spec.Spec(f"dev-build-test-install@0.0.0 dev_path={tmpdir}").concretized()
 
@@ -144,6 +145,7 @@ def test_dev_build_drop_in(tmpdir, mock_packages, monkeypatch, install_mockery, 
         assert "lib/spack/env" in output
 
 
+@pytest.mark.disable_clean_stage_check
 def test_dev_build_fails_already_installed(tmpdir, install_mockery):
     spec = spack.spec.Spec("dev-build-test-install@0.0.0 dev_path=%s" % tmpdir)
     spec.concretize()
@@ -184,6 +186,7 @@ def test_dev_build_fails_no_version(mock_packages):
     assert "dev-build spec must have a single, concrete version" in output
 
 
+@pytest.mark.disable_clean_stage_check
 def test_dev_build_env(tmpdir, install_mockery, mutable_mock_env_path):
     """Test Spack does dev builds for packages in develop section of env."""
     # setup dev-build-test-install package for dev build
@@ -220,6 +223,7 @@ spack:
         assert f.read() == spec.package.replacement_string
 
 
+@pytest.mark.disable_clean_stage_check
 def test_dev_build_env_with_vars(tmpdir, install_mockery, mutable_mock_env_path, monkeypatch):
     """Test Spack does dev builds for packages in develop section of env (path with variables)."""
     # setup dev-build-test-install package for dev build
@@ -292,6 +296,7 @@ spack:
                 install()
 
 
+@pytest.mark.disable_clean_stage_check
 def test_dev_build_multiple(tmpdir, install_mockery, mutable_mock_env_path, mock_fetch):
     """Test spack install with multiple developer builds
 
@@ -355,6 +360,7 @@ spack:
             assert f.read() == spec.package.replacement_string
 
 
+@pytest.mark.disable_clean_stage_check
 def test_dev_build_env_dependency(tmpdir, install_mockery, mock_fetch, mutable_mock_env_path):
     """
     Test non-root specs in an environment are properly marked for dev builds.
@@ -404,6 +410,7 @@ spack:
     assert spec.satisfies("^dev_path=*")
 
 
+@pytest.mark.disable_clean_stage_check
 @pytest.mark.parametrize("test_spec", ["dev-build-test-install", "dependent-of-dev-build"])
 def test_dev_build_rebuild_on_source_changes(
     test_spec, tmpdir, install_mockery, mutable_mock_env_path, mock_fetch

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3053,7 +3053,7 @@ spack:
 
     with ev.read("test") as e:
         concretize()
-        mpileaks_spec, = e.all_matching_specs("mpileaks")
+        (mpileaks_spec,) = e.all_matching_specs("mpileaks")
         assert not os.path.exists(mpileaks_spec.package.stage.path)
         install()
         assert os.path.exists(mpileaks_spec.package.stage.path)

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3040,6 +3040,25 @@ spack:
                     assert spec.prefix in contents
 
 
+def test_install_develop_keep_stage(
+    environment_from_manifest, install_mockery, mock_fetch, monkeypatch
+):
+    environment_from_manifest(
+        """
+spack:
+  specs:
+  - mpileaks
+"""
+    )
+
+    with ev.read("test") as e:
+        concretize()
+        mpileaks_spec, = e.all_matching_specs("mpileaks")
+        assert not os.path.exists(mpileaks_spec.package.stage.path)
+        install()
+        assert os.path.exists(mpileaks_spec.package.stage.path)
+
+
 @pytest.mark.regression("24148")
 def test_virtual_spec_concretize_together(tmpdir):
     # An environment should permit to concretize "mpi"

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3055,6 +3055,8 @@ spack:
 """
     )
 
+    monkeypatch.setattr(spack.stage.DevelopStage, "destroy", _always_fail)
+
     with ev.read("test") as e:
         libelf_dev_path = tmpdir.ensure("libelf-test-dev-path", dir=True)
         develop(f"--path={libelf_dev_path}", "libelf@0.8.13")
@@ -3066,6 +3068,11 @@ spack:
         install()
         assert os.path.exists(libelf_spec.package.stage.path)
         assert not os.path.exists(mpileaks_spec.package.stage.path)
+
+
+# Helper method for test_install_develop_keep_stage
+def _always_fail(cls, *args, **kwargs):
+    raise Exception("Restage or destruction of dev stage detected during install")
 
 
 @pytest.mark.regression("24148")

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -909,18 +909,20 @@ class TestDevelopStage:
         """
         devtree, srcdir = develop_path
         stage = DevelopStage("test-stage", srcdir, reference_link="link-to-stage")
+        assert not os.path.exists(stage.reference_link)
         stage.create()
+        assert os.path.exists(stage.reference_link)
         srctree1 = _create_tree_from_dir_recursive(stage.source_path)
         assert os.path.samefile(srctree1["link-to-stage"], stage.path)
         del srctree1["link-to-stage"]
         assert srctree1 == devtree
 
         stage.destroy()
+        assert not os.path.exists(stage.reference_link)
         # Make sure destroying the stage doesn't change anything
         # about the path
         assert not os.path.exists(stage.path)
         srctree2 = _create_tree_from_dir_recursive(srcdir)
-        del srctree2["link-to-stage"]  # Note the symlink persists but is broken
         assert srctree2 == devtree
 
 


### PR DESCRIPTION
Fixes #43393.

After #41373, where we stopped considering the source directory to be the stage for develop builds, we resumed *deleting* the stage even after a successful build.

We don't want this for develop builds because developers need to iterate; we should keep the artifacts unless they explicitly run `spack clean`.  

Now:
- [x] Build artifacts for develop packages are not removed after a successful install
- [x] They are also not removed before an install starts, i.e. develop packages always reuse prior artifacts, if available.
- [x] They can be deleted in any other context, e.g. by running  `spack clean --stage`