### PR TITLE
slate: fix smoke test dependency

### DIFF
--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -165,7 +165,7 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
         test_dir = join_path(self.test_suite.current_test_cache_dir, "examples", "build")
         with working_dir(test_dir, create=True):
             cmake_bin = join_path(self.spec["cmake"].prefix.bin, "cmake")
-            deps = "blaspp lapackpp mpi"
+            deps = "slate blaspp lapackpp mpi"
             if self.spec.satisfies("+rocm"):
                 deps += " rocblas hip llvm-amdgpu comgr hsa-rocr-dev rocsolver"
             prefixes = ";".join([self.spec[x].prefix for x in deps.split()])


### PR DESCRIPTION
Adding itself to the list of package dependencies for the purposes of running the smoke tests.  It was failing because slate was not being added to the CMAKE_PREFIX_PATH.