### PR TITLE
glew: add ld flags when compiling on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/glew/package.py
+++ b/var/spack/repos/builtin/packages/glew/package.py
@@ -77,5 +77,6 @@ class Glew(CMakePackage):
         return args
 
     if sys.platform == "darwin":
+
         def setup_build_environment(self, env):
             env.prepend_path("LDFLAGS", "-framework OpenGL")

--- a/var/spack/repos/builtin/packages/glew/package.py
+++ b/var/spack/repos/builtin/packages/glew/package.py
@@ -75,3 +75,7 @@ class Glew(CMakePackage):
             args.append(self.define("OPENGL_egl_LIBRARY", "IGNORE"))
 
         return args
+
+    if sys.platform == "darwin":
+        def setup_build_environment(self, env):
+            env.prepend_path("LDFLAGS", "-framework OpenGL")

--- a/var/spack/repos/builtin/packages/glew/package.py
+++ b/var/spack/repos/builtin/packages/glew/package.py
@@ -76,7 +76,7 @@ class Glew(CMakePackage):
 
         return args
 
-    if sys.platform == "darwin":
-
-        def setup_build_environment(self, env):
-            env.prepend_path("LDFLAGS", "-framework OpenGL")
+    def flag_handler(self, name, flags):
+        if name == "ldflags" and self.spec.satisfies("platform=darwin ^apple-gl"):
+            flags.append("-framework OpenGL")
+        return (flags, None, None)


### PR DESCRIPTION
When compiling on macOS I get the following:

```
  >> 107    Undefined symbols for architecture arm64:
     108      "_CGLChoosePixelFormat", referenced from:
     109          _main in visualinfo.c.o
     110          _CreateContext in visualinfo.c.o
     111      "_CGLCreateContext", referenced from:
     112          _main in visualinfo.c.o
     113          _CreateContext in visualinfo.c.o

     ...

     126          _main in visualinfo.c.o
     127          _main in visualinfo.c.o
     128          _main in visualinfo.c.o
     129          _CreateContext in visualinfo.c.o
     130          _DestroyContext in visualinfo.c.o
     131    ld: symbol(s) not found for architecture arm64
```

Following the suggestion in https://stackoverflow.com/questions/19480099/compiling-macos-application-with-cgl#comment28894036_19480099, this change fixes it for me. I'm compiling with `gl=other` so I'm not completely sure if when using different variants with macOS this change is needed or not.