### PR TITLE
xz: add comment to avoid 5.6 pending CVE resolution

### DIFF
--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -28,6 +28,8 @@ class Xz(MSBuildPackage, AutotoolsPackage, SourceforgePackage):
 
     license("GPL-2.0-or-later AND Public-Domain AND LGPL-2.1-or-later", checked_by="tgamblin")
 
+    # NOTE: don't add XZ 5.6 until this compromise is resolved:
+    # https://www.openwall.com/lists/oss-security/2024/03/29/4
     version("5.4.6", sha256="913851b274e8e1d31781ec949f1c23e8dbcf0ecf6e73a2436dc21769dd3e6f49")
     version("5.4.5", sha256="8ccf5fff868c006f29522e386fb4c6a1b66463fbca65a4cfc3c4bd596e895e79")
     version("5.4.1", sha256="dd172acb53867a68012f94c17389401b2f274a1aa5ae8f84cbfb8b7e383ea8d3")


### PR DESCRIPTION
XZ is compromised; add a note for maintainers to avoid updating until we have a release without the CVE.

See:
* https://www.openwall.com/lists/oss-security/2024/03/29/4

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
