### PR TITLE
gdb: add a dependency on pkgconfig

### DIFF
--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -85,6 +85,7 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
     depends_on("xz", when="+xz")
     depends_on("zlib-api")
     depends_on("zstd", when="@13.1:")
+    depends_on("pkgconfig", type="build")
     depends_on("source-highlight", when="+source-highlight")
     depends_on("ncurses", when="+tui")
     depends_on("gmp", when="@11.1:")

--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -85,7 +85,7 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
     depends_on("xz", when="+xz")
     depends_on("zlib-api")
     depends_on("zstd", when="@13.1:")
-    depends_on("pkgconfig", type="build")
+    depends_on("pkgconfig", type="build", when="@13.1:")
     depends_on("source-highlight", when="+source-highlight")
     depends_on("ncurses", when="+tui")
     depends_on("gmp", when="@11.1:")


### PR DESCRIPTION
When compiling on MacOS I get the following at configure time:

```
     2325    checking whether vasprintf is declared... yes
     2326    checking whether strnlen is declared... yes
     2327    checking whether ___lc_codepage_func is declared... no
     2328    checking for aarch64-apple-darwin23.4.0-pkg-config... no
     2329    checking for pkg-config... no
     2330    checking for libzstd >= 1.4.0... no
  >> 2331    configure: error: --with-zstd was given, but pkgconfig/libzstd.pc is not found
  >> 2332    make[1]: *** [Makefile:3010: configure-bfd] Error 1
```
adding a dependency on pkgconfig fixes this issue. On Linux it can be compiled fine without this dependency, probably because on the systems I have it's included in the system.