### PR TITLE
iq-tree: adding version 2.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/iq-tree/package.py
+++ b/var/spack/repos/builtin/packages/iq-tree/package.py
@@ -17,6 +17,9 @@ class IqTree(CMakePackage):
     license("GPL-2.0-or-later")
 
     version(
+        "2.3.1", tag="v2.3.1", commit="2914a2f7aac0a1a3c4fadde42c83e5dee315186d", submodules=True
+    )
+    version(
         "2.2.2.7",
         tag="v2.2.2.7",
         commit="bd3468c7af6572ea29002dfdba377804f8f56c26",


### PR DESCRIPTION
Seems like a straightforward version update.

We should probably pick either this package or the iqtree2 package (my vote is for this one (iq-tree) now that I've noticed it) to be _the_ iqtree package for spack. It's kind of confusing to have duplicates.
