### PR TITLE
Patch to set PARAMETERS_MIN_ALIGNMENT to the native alignment for rocm-opencl

### DIFF
--- a/var/spack/repos/builtin/packages/rocm-opencl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-opencl/package.py
@@ -82,6 +82,21 @@ class RocmOpencl(CMakePackage):
             placement="rocclr",
             when=f"@{d_version}",
         )
+    # For avx build, the start address of values_ buffer in KernelParameters is not
+    # correct as it is computed based on 16-byte alignment.
+    patch(
+        "https://github.com/ROCm/clr/commit/c4f773db0b4ccbbeed4e3d6c0f6bff299c2aa3f0.patch?full_index=1",
+        sha256="5bb9b0e08888830ccf3a0a658529fe25f4ee62b5b8890f349bf2cc914236eb2f",
+        #working_dir="clr",
+        when="@5.7:",
+    )
+    patch(
+        "https://github.com/ROCm/clr/commit/7868876db742fb4d44483892856a66d2993add03.patch?full_index=1",
+        sha256="7668b2a710baf4cb063e6b00280fb75c4c3e0511575e8298a9c7ae5143f60b33",
+        #working_dir="clr",
+        when="@5.7:",
+    )
+
     # Patch to set package installation path for OpenCL.
     patch("0001-fix-build-error-rocm-opencl-5.1.0.patch", when="@5.1")
 

--- a/var/spack/repos/builtin/packages/rocm-opencl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-opencl/package.py
@@ -87,13 +87,11 @@ class RocmOpencl(CMakePackage):
     patch(
         "https://github.com/ROCm/clr/commit/c4f773db0b4ccbbeed4e3d6c0f6bff299c2aa3f0.patch?full_index=1",
         sha256="5bb9b0e08888830ccf3a0a658529fe25f4ee62b5b8890f349bf2cc914236eb2f",
-        #working_dir="clr",
         when="@5.7:",
     )
     patch(
         "https://github.com/ROCm/clr/commit/7868876db742fb4d44483892856a66d2993add03.patch?full_index=1",
         sha256="7668b2a710baf4cb063e6b00280fb75c4c3e0511575e8298a9c7ae5143f60b33",
-        #working_dir="clr",
         when="@5.7:",
     )
 


### PR DESCRIPTION
- Fixed the computation of the start address of KernelParameters.values_ for avx build, the start address of values_ buffer in KernelParameters is not correct as it is computed based on 16-byte alignment.
- Set PARAMETERS_MIN_ALIGNMENT to the native alignment.