### PR TITLE
whizard: Make it possible to build from sources checked out from VC

### DIFF
--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
@@ -120,6 +122,14 @@ class Whizard(AutotoolsPackage):
         env.set("CXX", self.compiler.cxx)
         env.set("FC", self.compiler.fc)
         env.set("F77", self.compiler.fc)
+
+    @run_before("autoreconf")
+    def prepare_whizard(self):
+        # As described in the manual (SVN Repository version)
+        # https://whizard.hepforge.org/manual/manual003.html#sec%3Aprerequisites
+        if not os.path.exists("configure.ac"):
+            shell = which("sh")
+            shell("build_master.sh")
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

If whizard is checked out from version control the `build_master.sh` script needs to run to generate the `configure.ac` inputs for `autoreconf`.