### PR TITLE
slate: Adding comgr as dependency

### DIFF
--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -91,6 +91,7 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("lapackpp@master", when="@master")
     depends_on("scalapack", type="test")
     depends_on("hipify-clang", when="@:2021.05.02 +rocm ^hip@5:")
+    depends_on("comgr", when="+rocm")
 
     requires("%oneapi", when="+sycl", msg="slate+sycl must be compiled with %oneapi")
 
@@ -165,6 +166,8 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
         test_dir = join_path(self.test_suite.current_test_cache_dir, "examples", "build")
         with working_dir(test_dir, create=True):
             cmake_bin = join_path(self.spec["cmake"].prefix.bin, "cmake")
+            # This package must directly depend on all packages listed here.
+            # Otherwise, it will not work when some packages are external to spack. 
             deps = "slate blaspp lapackpp mpi"
             if self.spec.satisfies("+rocm"):
                 deps += " rocblas hip llvm-amdgpu comgr hsa-rocr-dev rocsolver"

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -92,6 +92,8 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("scalapack", type="test")
     depends_on("hipify-clang", when="@:2021.05.02 +rocm ^hip@5:")
     depends_on("comgr", when="+rocm")
+    depends_on("rocblas", when="+rocm")
+    depends_on("rocsolver", when="+rocm")
 
     requires("%oneapi", when="+sycl", msg="slate+sycl must be compiled with %oneapi")
 
@@ -167,10 +169,10 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
         with working_dir(test_dir, create=True):
             cmake_bin = join_path(self.spec["cmake"].prefix.bin, "cmake")
             # This package must directly depend on all packages listed here.
-            # Otherwise, it will not work when some packages are external to spack. 
+            # Otherwise, it will not work when some packages are external to spack.
             deps = "slate blaspp lapackpp mpi"
             if self.spec.satisfies("+rocm"):
-                deps += " rocblas hip llvm-amdgpu comgr hsa-rocr-dev rocsolver"
+                deps += " rocblas hip llvm-amdgpu comgr hsa-rocr-dev rocsolver "
             prefixes = ";".join([self.spec[x].prefix for x in deps.split()])
             self.run_test(cmake_bin, ["-DCMAKE_PREFIX_PATH=" + prefixes, ".."])
             make()


### PR DESCRIPTION
The Smoke tests require comgr, rocblas, and rocsolver.  So, these must be a direct dependency of slate.  Otherwise, the smoke tests won't work if some AMD packages are external dependencies.