### PR TITLE
simmetrix-simmodsuite: support RHEL8, fix module paths

### DIFF
--- a/var/spack/repos/builtin/packages/simmetrix-simmodsuite/package.py
+++ b/var/spack/repos/builtin/packages/simmetrix-simmodsuite/package.py
@@ -542,8 +542,9 @@ class SimmetrixSimmodsuite(Package):
     variant("paralleladapt", default=False, description="enable parallel adaptation")
 
     depends_on("mpi")
+    depends_on("libtirpc", type="link")
 
-    oslib = "x64_rhel7_gcc48"
+    oslib = "x64_rhel8_gcc83"
 
     for release in RELEASES:
         # define the version using the mscore tarball
@@ -571,12 +572,12 @@ class SimmetrixSimmodsuite(Package):
             simmetrix_resource(_name, url, sha256, condition)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        archlib = join_path(prefix.lib, self.oslib)
+        archlib = join_path(self.prefix.lib, self.oslib)
         env.append_path("CMAKE_PREFIX_PATH", archlib)
         simmetrix_setkernelcmakeprefixpath(self.spec, archlib, env)
 
     def setup_run_environment(self, env):
-        archlib = join_path(prefix.lib, self.oslib)
+        archlib = join_path(self.prefix.lib, self.oslib)
         env.append_path("CMAKE_PREFIX_PATH", archlib)
         simmetrix_setkernelcmakeprefixpath(self.spec, archlib, env)
 


### PR DESCRIPTION
This PR updates the simmetrix-simmodsuite package to use RHEL8 and fixes incorrect paths being written into tcl/lua module files.