### PR TITLE
Cmd/ci win refactor

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1924,6 +1924,7 @@ def reproduce_ci_job(url, work_dir, autostart, gpg_url, runtime):
                 f"share/spack/setup-env.{platform_script_ext}",
             ),
         ],
+        # TODO johnwparent does this work on Windows at all??
         ["spack", "gpg", "trust", mounted_gpg_path if job_image else gpg_path] if gpg_path else [],
         ["spack", "env", "activate", mounted_env_dir if job_image else repro_dir],
         [

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1924,7 +1924,6 @@ def reproduce_ci_job(url, work_dir, autostart, gpg_url, runtime):
                 f"share/spack/setup-env.{platform_script_ext}",
             ),
         ],
-        # TODO johnwparent does this work on Windows at all??
         ["spack", "gpg", "trust", mounted_gpg_path if job_image else gpg_path] if gpg_path else [],
         ["spack", "env", "activate", mounted_env_dir if job_image else repro_dir],
         [

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -31,7 +31,6 @@ section = "build"
 level = "long"
 
 SPACK_COMMAND = "spack"
-MAKE_COMMAND = "make"
 INSTALL_FAIL_CODE = 1
 FAILED_CREATE_BUILDCACHE_CODE = 100
 
@@ -551,13 +550,18 @@ def ci_rebuild(args):
     # No hash match anywhere means we need to rebuild spec
 
     # Start with spack arguments
-    spack_cmd = [SPACK_COMMAND, "--color=always", "--backtrace", "--verbose"]
+    spack_cmd = [SPACK_COMMAND,
+        "--color=always",
+        "--backtrace",
+        "--verbose",
+        "install"
+    ]
 
     config = cfg.get("config")
     if not config["verify_ssl"]:
         spack_cmd.append("-k")
 
-    install_args = []
+    install_args = ["--use-buildcache=package:never,dependencies:only"]
 
     can_verify = spack_ci.can_verify_binaries()
     verify_binaries = can_verify and spack_is_pr_pipeline is False
@@ -567,57 +571,21 @@ def ci_rebuild(args):
     slash_hash = "/{}".format(job_spec.dag_hash())
 
     # Arguments when installing dependencies from cache
-    deps_install_args = install_args
+    deps_install_args = install_args + ["--only=dependencies"]
 
     # Arguments when installing the root from sources
-    root_install_args = install_args + [
-        "--keep-stage",
-        "--only=package",
-        "--use-buildcache=package:never,dependencies:only",
-    ]
+    root_install_args = install_args + ["--keep-stage", "--only=package"]
     if cdash_handler:
         # Add additional arguments to `spack install` for CDash reporting.
         root_install_args.extend(cdash_handler.args())
-    root_install_args.append(slash_hash)
 
     # ["x", "y"] -> "'x' 'y'"
     args_to_string = lambda args: " ".join("'{}'".format(arg) for arg in args)
 
     commands = [
         # apparently there's a race when spack bootstraps? do it up front once
-        [SPACK_COMMAND, "-e", env.path, "bootstrap", "now"],
-        [
-            SPACK_COMMAND,
-            "-e",
-            env.path,
-            "env",
-            "depfile",
-            "-o",
-            "Makefile",
-            "--use-buildcache=package:never,dependencies:only",
-            slash_hash,  # limit to spec we're building
-        ],
-        [
-            # --output-sync requires GNU make 4.x.
-            # Old make errors when you pass it a flag it doesn't recognize,
-            # but it doesn't error or warn when you set unrecognized flags in
-            # this variable.
-            "export",
-            "GNUMAKEFLAGS=--output-sync=recurse",
-        ],
-        [
-            MAKE_COMMAND,
-            "SPACK={}".format(args_to_string(spack_cmd)),
-            "SPACK_COLOR=always",
-            "SPACK_INSTALL_FLAGS={}".format(args_to_string(deps_install_args)),
-            "-j$(nproc)",
-            "install-deps/{}".format(
-                spack.environment.depfile.MakefileSpec(job_spec).safe_format(
-                    "{name}-{version}-{hash}"
-                )
-            ),
-        ],
-        spack_cmd + ["install"] + root_install_args,
+        spack_cmd + deps_install_args + [slash_hash],
+        spack_cmd + root_install_args + [slash_hash]
     ]
 
     tty.debug("Installing {0} from source".format(job_spec.name))

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -574,9 +574,6 @@ def ci_rebuild(args):
         # Add additional arguments to `spack install` for CDash reporting.
         root_install_args.extend(cdash_handler.args())
 
-    # ["x", "y"] -> "'x' 'y'"
-    args_to_string = lambda args: " ".join("'{}'".format(arg) for arg in args)
-
     commands = [
         # apparently there's a race when spack bootstraps? do it up front once
         spack_cmd + deps_install_args + [slash_hash],

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -550,12 +550,7 @@ def ci_rebuild(args):
     # No hash match anywhere means we need to rebuild spec
 
     # Start with spack arguments
-    spack_cmd = [SPACK_COMMAND,
-        "--color=always",
-        "--backtrace",
-        "--verbose",
-        "install"
-    ]
+    spack_cmd = [SPACK_COMMAND, "--color=always", "--backtrace", "--verbose", "install"]
 
     config = cfg.get("config")
     if not config["verify_ssl"]:
@@ -585,7 +580,7 @@ def ci_rebuild(args):
     commands = [
         # apparently there's a race when spack bootstraps? do it up front once
         spack_cmd + deps_install_args + [slash_hash],
-        spack_cmd + root_install_args + [slash_hash]
+        spack_cmd + root_install_args + [slash_hash],
     ]
 
     tty.debug("Installing {0} from source".format(job_spec.name))


### PR DESCRIPTION
Refactor CI CMD module to produce Windows compatible commands via newly refactored `process_command`

> Note: This PR may change heavily as other areas are updated to function on Windows based on Gitlab CI progress