### PR TITLE
Windows: automatic GL detection during bootstrap

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -1579,6 +1579,12 @@ depending on installation type (Professional, Build Tools, etc.)  The other requ
 "C++ CMake tools for Windows," which can be selected from among the optional packages.
 This provides CMake and Ninja for use during Spack configuration.
 
+.. Important::
+
+   Spack requires that the Windows SDK (including WGL) to be installed as part of your
+   visual studio installation
+
+
 If you already have Visual Studio installed, you can make sure these components are installed by
 rerunning the installer.  Next to your installation, select "Modify" and look at the
 "Installation details" pane on the right.

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -1572,17 +1572,14 @@ Microsoft Visual Studio
 """""""""""""""""""""""
 
 Microsoft Visual Studio provides the only Windows C/C++ compiler that is currently supported by Spack.
+Spack additionally requires that the Windows SDK (including WGL) to be installed as part of your
+visual studio installation as it is required to build many packages from source.
 
 We require several specific components to be included in the Visual Studio installation.
 One is the C/C++ toolset, which can be selected as "Desktop development with C++" or "C++ build tools,"
 depending on installation type (Professional, Build Tools, etc.)  The other required component is
 "C++ CMake tools for Windows," which can be selected from among the optional packages.
 This provides CMake and Ninja for use during Spack configuration.
-
-.. Important::
-
-   Spack requires that the Windows SDK (including WGL) to be installed as part of your
-   visual studio installation
 
 
 If you already have Visual Studio installed, you can make sure these components are installed by

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -568,7 +568,9 @@ def ensure_winsdk_or_raise() -> None:
     a RuntimeError.
 
     **NOTE:** This modifies the Spack config in the current scope,
-    either user or environment depending on the calling context
+    either user or environment depending on the calling context.
+    This is different from all other current bootstrap dependency
+    checks.
     """
     externals = spack.detection.by_path(["win-sdk", "wgl"])
     if not set(["win-sdk", "wgl"]) == externals.keys():

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -559,6 +559,21 @@ def ensure_patchelf_in_path_or_raise() -> spack.util.executable.Executable:
         )
 
 
+def ensure_winsdk_or_raise() -> None:
+    """Ensure the Windows SDK + WGL are available on system"""
+    externals = spack.detection.by_path(["win-sdk", "wgl"])
+    if not externals:
+        raise RuntimeError(
+            "Unable to find the Windows SDK, please install via the Visual Studio installer\
+before proceeding with Spack or provide the path to a non standard install via\
+'spack external find --path'"
+        )
+    # wgl/sdk are not required for bootstrapping Spack, but
+    # are required for building anything non trivial
+    # add to user config so they can be used by subsequent Spack ops
+    spack.detection.update_configuration(externals, scope="user", buildable=False)
+
+
 def ensure_core_dependencies() -> None:
     """Ensure the presence of all the core dependencies."""
     if sys.platform.lower() == "linux":

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -561,8 +561,14 @@ def ensure_patchelf_in_path_or_raise() -> spack.util.executable.Executable:
 
 def ensure_winsdk_or_raise() -> None:
     """Ensure the Windows SDK + WGL are available on system
-    If found, the Spack configuration is updated to include
-    all versions/variants detected in the packages section
+    If both of these package are found, the Spack user or bootstrap
+    configuration (depending on where Spack is running)
+    will be updated to include all versions and variants detected.
+    If either the WDK or WSDK are not found, this method will raise
+    a RuntimeError.
+
+    **NOTE:** This modifies the Spack config in the current scope,
+    either user or environment depending on the calling context
     """
     externals = spack.detection.by_path(["win-sdk", "wgl"])
     if not set(["win-sdk", "wgl"]) == externals.keys():

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -601,7 +601,7 @@ def ensure_core_dependencies() -> None:
     if not IS_WINDOWS:
         ensure_gpg_in_path_or_raise()
     else:
-        ensure_winsdk_or_raise()
+        ensure_winsdk_external_or_raise()
     ensure_clingo_importable_or_raise()
 
 

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -573,7 +573,8 @@ def ensure_winsdk_or_raise() -> None:
             missing_packages_lst.append("win-sdk")
         missing_packages = " & ".join(missing_packages_lst)
         raise RuntimeError(
-            f"Unable to find the {missing_packages}, please install via the Visual Studio installer\
+            f"Unable to find the {missing_packages}, please install these packages\
+via the Visual Studio installer\
 before proceeding with Spack or provide the path to a non standard install via\
 'spack external find --path'"
         )

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -559,7 +559,7 @@ def ensure_patchelf_in_path_or_raise() -> spack.util.executable.Executable:
         )
 
 
-def ensure_winsdk_or_raise() -> None:
+def ensure_winsdk_external_or_raise() -> None:
     """Ensure the Windows SDK + WGL are available on system
     If both of these package are found, the Spack user or bootstrap
     configuration (depending on where Spack is running)
@@ -572,6 +572,8 @@ def ensure_winsdk_or_raise() -> None:
     This is different from all other current bootstrap dependency
     checks.
     """
+    if set(["win-sdk", "wgl"]).issubset(spack.config.get("packages").keys()):
+        return
     externals = spack.detection.by_path(["win-sdk", "wgl"])
     if not set(["win-sdk", "wgl"]) == externals.keys():
         missing_packages_lst = []


### PR DESCRIPTION
Require users of Spack on Windows installed the Windows SDK alongside VS (this is one extra box to click) which will guarantee we have WGL available during Spack runs (bundled as part of the sdk).
Detect WGL as part of the bootstrapping run, and if not found, do not allow Spack to complete the bootstrap. If not found, inform users to install as part of the Windows SDK.
This brings Windows up to parity with other platforms, where detecting a GL provider is done automatically, or GL providers can be built natively.