### PR TITLE
Check extensions for exact matches

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1284,7 +1284,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         # If the extendee is in the spec's deps already, return that.
         for dep in self.spec.traverse(deptype=("link", "run")):
-            if dep.name in self.extendees:
+            if dep.name in self.extendees and dep not in deps:
                 deps.append(dep)
 
         if deps:


### PR DESCRIPTION
I ran into an issue when I have an upstream and a binary cache with an identical installation of python (DAG hash match). It led to two entries in the extendee_spec list.

This PR ensures that extendees are not identical before extending.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
