### PR TITLE
py-cig-pythia: add missing py-setuptools dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-cig-pythia/package.py
+++ b/var/spack/repos/builtin/packages/py-cig-pythia/package.py
@@ -30,6 +30,7 @@ class PyCigPythia(AutotoolsPackage, PythonExtension):
     depends_on("mpi", when="+mpi")
     depends_on("python@3.8:")
     depends_on("py-pip")
+    depends_on("py-setuptools")
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
