### PR TITLE
ginkgo@1.7 +sycl %oneapi 2024.1: icpx 2024.1 no longer accepts sycl::ext::intel::ctz

### DIFF
--- a/var/spack/repos/builtin/packages/ginkgo/ginkgo-dpcpp-intrinsincs-oneapi-2024.1.patch
+++ b/var/spack/repos/builtin/packages/ginkgo/ginkgo-dpcpp-intrinsincs-oneapi-2024.1.patch
@@ -1,0 +1,19 @@
+diff -ruN spack-src/dpcpp/components/intrinsics.dp.hpp spack-src-patched/dpcpp/components/intrinsics.dp.hpp
+--- spack-src/dpcpp/components/intrinsics.dp.hpp	2024-04-03 18:53:42.724032846 +0000
++++ spack-src-patched/dpcpp/components/intrinsics.dp.hpp	2024-04-03 18:55:01.744543032 +0000
+@@ -67,13 +67,13 @@
+  */
+ __dpct_inline__ int ffs(uint32 mask)
+ {
+-    return (mask == 0) ? 0 : (sycl::ext::intel::ctz(mask) + 1);
++    return (mask == 0) ? 0 : (sycl::ctz(mask) + 1);
+ }
+ 
+ /** @copydoc ffs */
+ __dpct_inline__ int ffs(uint64 mask)
+ {
+-    return (mask == 0) ? 0 : (sycl::ext::intel::ctz(mask) + 1);
++    return (mask == 0) ? 0 : (sycl::ctz(mask) + 1);
+ }
+ 
+ 

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -106,6 +106,9 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     # https://github.com/ginkgo-project/ginkgo/pull/1524
     patch("ginkgo-sycl-pr1524.patch", when="@1.7.0 +sycl %oneapi@2024:")
 
+    # https://github.com/ginkgo-project/ginkgo/pull/1585
+    patch("ginkgo-dpcpp-intrinsincs-oneapi-2024.1.patch", when="@1.7.0 +sycl %oneapi@2024.1:")
+
     # Skip smoke tests if compatible hardware isn't found
     patch("1.4.0_skip_invalid_smoke_tests.patch", when="@1.4.0")
 


### PR DESCRIPTION
Patch `ginkgo@1.7 +sycl %oneapi@2024.1:` using changes submitted upstream:
* https://github.com/ginkgo-project/ginkgo/pull/1585

Without this PR, trying to build `ginkgo@1.7 +sycl %oneapi@2024.1:` yields the following error:
* https://gitlab.spack.io/spack/spack/-/jobs/10602728
```
...
     419    In file included from /tmp/root/spack-stage/spack-stage-ginkgo-1.7.
            0-iztrreyutfqitl3qq7aa65gjgdkimmjc/spack-src/dpcpp/base/batch_multi
            _vector_kernels.dp.cpp:56:
  >> 420    /tmp/root/spack-stage/spack-stage-ginkgo-1.7.0-iztrreyutfqitl3qq7aa
            65gjgdkimmjc/spack-src/dpcpp/components/intrinsics.dp.hpp:70:31: er
            ror: no member named 'ctz' in namespace 'sycl::ext::intel'; did you
             mean 'sycl::ctz'?
     421       70 |     return (mask == 0) ? 0 : (sycl::ext::intel::ctz(mask) +
             1);
     422          |                               ^~~~~~~~~~~~~~~~~~~~~
     423          |     
```

With this PR:
```
...
==> Installing ginkgo-1.7.0-4uuvpuqzbcb67h4jcrqwjxbzgkufq5ae [22/22]
==> No binary for ginkgo-1.7.0-4uuvpuqzbcb67h4jcrqwjxbzgkufq5ae found: installing from source
==> Using cached archive: /spack/var/spack/cache/_source-cache/git//ginkgo-project/ginkgo.git/49242ff89af1e695d7794f6d50ed9933024b66fe.tar.gz
==> Warning: Fetching from mirror without a checksum!
  This package is normally checked out from a version control system, but it has been archived on a spack mirror.  This means we cannot know a checksum for the tarball in advance. Be sure that your connection to this mirror is secure!
==> Applied patch /spack/var/spack/repos/builtin/packages/ginkgo/ginkgo-sycl-pr1524.patch
==> Applied patch /spack/var/spack/repos/builtin/packages/ginkgo/ginkgo-dpcpp-intrinsincs-oneapi-2024.1.patch
==> ginkgo: Executing phase: 'cmake'
==> ginkgo: Executing phase: 'build'
==> ginkgo: Executing phase: 'install'
==> ginkgo: Successfully installed ginkgo-1.7.0-4uuvpuqzbcb67h4jcrqwjxbzgkufq5ae
```