### PR TITLE
adios2: add v2.10.0-rc1 release

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -26,13 +26,11 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version(
-        "2.10.0-rc1", sha256="8b72142bd5aabfb80c7963f524df11b8721c09ef20caea6df5fb00c31a7747c0"
-    )
-    version(
-        "2.9.2",
-        sha256="78309297c82a95ee38ed3224c98b93d330128c753a43893f63bbe969320e4979",
+        "2.10.0",
+        sha256="e5984de488bda546553dd2f46f047e539333891e63b9fe73944782ba6c2d95e4",
         preferred=True,
     )
+    version("2.9.2", sha256="78309297c82a95ee38ed3224c98b93d330128c753a43893f63bbe969320e4979")
     version("2.9.1", sha256="ddfa32c14494250ee8a48ef1c97a1bf6442c15484bbbd4669228a0f90242f4f9")
     version("2.9.0", sha256="69f98ef58c818bb5410133e1891ac192653b0ec96eb9468590140f2552b6e5d1")
     version("2.8.3", sha256="4906ab1899721c41dd918dddb039ba2848a1fb0cf84f3a563a1179b9d6ee0d9f")
@@ -225,7 +223,7 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
 
     # cmake: find threads package first
     # https://github.com/ornladios/ADIOS2/pull/3893
-    patch("2.9.2-cmake-find-threads-package-first.patch", when="@2.9.2:")
+    patch("2.9.2-cmake-find-threads-package-first.patch", when="@2.9")
 
     @when("%fj")
     def patch(self):


### PR DESCRIPTION
:tada: :tada: :tada: 


Finally! ADIOS2 v2.10.0 release is out.

This bring exiting new features and bugfixes. Find the release notes at:
https://github.com/ornladios/ADIOS2/releases/tag/v2.10.0

Let me know if we need to change anything else in the package

ViB

:tada: :tada: :tada: