### PR TITLE
Trilinos: add threadsafe variant

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -103,8 +103,8 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     variant("wrapper", default=False, description="Use nvcc-wrapper for CUDA build")
 
     # Makes the Teuchos Memory Management classes (Teuchos::RCP, Teuchos::Ptr, Teuchos::Array,
-    # Teuchos::ArrayView, and Teuchos::ArrayRCP) thread-safe. Requires at least the OMP kokkos backend
-    # to be enabled. Without, this seemingly does nothing
+    # Teuchos::ArrayView, and Teuchos::ArrayRCP) thread-safe. Requires at least the OMP kokkos
+    # backend to be enabled. Without, this seemingly does nothing
     variant(
         "threadsafe", default=False, when="+openmp", description="Enable threadsafe in Teuchos"
     )

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -102,10 +102,12 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     variant("uvm", default=False, when="@13.2: +cuda", description="Turn on UVM for CUDA build")
     variant("wrapper", default=False, description="Use nvcc-wrapper for CUDA build")
 
-    # Makes the Teuchos Memory Management classes (Teuchos::RCP, Teuchos::Ptr, Teuchos::Array, 
+    # Makes the Teuchos Memory Management classes (Teuchos::RCP, Teuchos::Ptr, Teuchos::Array,
     # Teuchos::ArrayView, and Teuchos::ArrayRCP) thread-safe. Requires at least the OMP kokkos backend
     # to be enabled. Without, this seemingly does nothing
-    variant("threadsafe", default=False, when="+openmp", description="Enable threadsafe in Teuchos")
+    variant(
+        "threadsafe", default=False, when="+openmp", description="Enable threadsafe in Teuchos"
+    )
 
     # TPLs (alphabet order)
     variant("adios2", default=False, description="Enable ADIOS2")
@@ -624,11 +626,9 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
                 define_trilinos_enable(
                     "EXPLICIT_INSTANTIATION", "explicit_template_instantiation"
                 ),
-                define_from_variant("Trilinos_ENABLE_THREAD_SAFE", "threadsafe")
+                define_from_variant("Trilinos_ENABLE_THREAD_SAFE", "threadsafe"),
             ]
         )
-
-            
 
         if spec.version >= Version("15"):
             options.append(define_trilinos_enable("PyTrilinos2", "python"))

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -102,6 +102,11 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     variant("uvm", default=False, when="@13.2: +cuda", description="Turn on UVM for CUDA build")
     variant("wrapper", default=False, description="Use nvcc-wrapper for CUDA build")
 
+    # Makes the Teuchos Memory Management classes (Teuchos::RCP, Teuchos::Ptr, Teuchos::Array, 
+    # Teuchos::ArrayView, and Teuchos::ArrayRCP) thread-safe. Requires at least the OMP kokkos backend
+    # to be enabled. Without, this seemingly does nothing
+    variant("threadsafe", default=False, when="+openmp", description="Enable threadsafe in Teuchos")
+
     # TPLs (alphabet order)
     variant("adios2", default=False, description="Enable ADIOS2")
     variant("boost", default=False, description="Compile with Boost")
@@ -619,8 +624,11 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
                 define_trilinos_enable(
                     "EXPLICIT_INSTANTIATION", "explicit_template_instantiation"
                 ),
+                define_from_variant("Trilinos_ENABLE_THREAD_SAFE", "threadsafe")
             ]
         )
+
+            
 
         if spec.version >= Version("15"):
             options.append(define_trilinos_enable("PyTrilinos2", "python"))


### PR DESCRIPTION
Fixes #43454 by exposing the variant `+threadsafe`