### PR TITLE
Add g2@3.4.9

### DIFF
--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -20,6 +20,7 @@ class G2(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
     version("develop", branch="develop")
+    version("3.4.9", sha256="6edc33091f6bd2acb191182831499c226a1c3992c3acc104d6363528b12dfbae")
     version("3.4.8", sha256="071a6f799c4c4fdfd5d0478152a0cbb9d668d12d71c78d5bda71845fc5580a7f")
     version("3.4.7", sha256="d6530611e3a515122f11ed4aeede7641f6f8932ef9ee0d4828786572767304dc")
     version("3.4.6", sha256="c4b03946365ce0bacf1e10e8412a5debd72d8671d1696aa4fb3f3adb119175fe")


### PR DESCRIPTION
This PR adds g2@3.4.9. No changes to CMake build options (at least, none that need to be reflected in Spack).