### PR TITLE
Update g2tmpl recipe

### DIFF
--- a/var/spack/repos/builtin/packages/g2tmpl/package.py
+++ b/var/spack/repos/builtin/packages/g2tmpl/package.py
@@ -18,6 +18,20 @@ class G2tmpl(CMakePackage):
     maintainers("edwardhartnett", "AlexanderRichert-NOAA", "Hang-Lei-NOAA")
 
     version("develop", branch="develop")
+    version("1.11.0", sha256="00fde3b37c6b4d1f0eaf60f230159298ffcb47349a076c3bd6afa20c7ed791a9")
     version("1.10.2", sha256="4063361369f3691f75288c801fa9d1a2414908b7d6c07bbf69d4165802e2a7fc")
     version("1.10.1", sha256="0be425e5128fabb89915a92261aa75c27a46a3e115e00c686fc311321e5d1e2a")
     version("1.10.0", sha256="dcc0e40b8952f91d518c59df7af64e099131c17d85d910075bfa474c8822649d")
+
+    variant("shared", default=False, description="Build shared library")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define("BUILD_TESTING", self.run_tests),
+        ]
+        return args
+
+    def check(self):
+        with working_dir(self.builder.build_directory):
+            make("test")


### PR DESCRIPTION
This PR updates the g2tmpl recipe:
 - Adds g2tmpl@1.11.0
 - Adds a `shared` variant
 - Adds build testing support