### PR TITLE
cuda: Add 12.4.1

### DIFF
--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -137,11 +137,14 @@ class CudaPackage(PackageBase):
         conflicts("%gcc@11.2:", when="+cuda ^cuda@:11.5")
         conflicts("%gcc@12:", when="+cuda ^cuda@:11.8")
         conflicts("%gcc@13:", when="+cuda ^cuda@:12.3")
+        conflicts("%gcc@14:", when="+cuda ^cuda@:12.4")
         conflicts("%clang@12:", when="+cuda ^cuda@:11.4.0")
         conflicts("%clang@13:", when="+cuda ^cuda@:11.5")
         conflicts("%clang@14:", when="+cuda ^cuda@:11.7")
         conflicts("%clang@15:", when="+cuda ^cuda@:12.0")
-        conflicts("%clang@16:", when="+cuda ^cuda@:12.3")
+        conflicts("%clang@16:", when="+cuda ^cuda@:12.1")
+        conflicts("%clang@17:", when="+cuda ^cuda@:12.3")
+        conflicts("%clang@18:", when="+cuda ^cuda@:12.4")
 
         # https://gist.github.com/ax3l/9489132#gistcomment-3860114
         conflicts("%gcc@10", when="+cuda ^cuda@:11.4.0")

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -25,6 +25,20 @@ from spack.package import *
 
 preferred_ver = "11.8.0"
 _versions = {
+    "12.4.1": {
+        "Linux-aarch64": (
+            "b0fbc77effa225498974625b6b08b3f6eff4a37e379f5b60f1d3827b215ad19b",
+            "https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_550.54.15_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "367d2299b3a4588ab487a6d27276ca5d9ead6e394904f18bccb9e12433b9c4fb",
+            "https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_550.54.15_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "677f44da10dd81396cb53a32c4e26eccdc24912063cb2e3beb3bbcb1658ef451",
+            "https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_550.54.15_linux_ppc64le.run",
+        ),
+    },
     "12.4.0": {
         "Linux-aarch64": (
             "b12bfe6c36d32ecf009a6efb0024325c5fc389fca1143f5f377ae2555936e803",

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -101,7 +101,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     )
 
     # Probably fixed in NVIDIA/cccl#1528 which hopefully comes with the next CUDA release
-    conflicts("^cuda@12.4.0", when="+cuda", msg="CCCL 2.3 bug causes build failure.")
+    conflicts("^cuda@12.4", when="+cuda", msg="CCCL 2.3 bug causes build failure.")
 
     # https://github.com/ginkgo-project/ginkgo/pull/1524
     patch("ginkgo-sycl-pr1524.patch", when="@1.7.0 +sycl %oneapi@2024:")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
`cuda` package:
- Add newest patch version

CUDA build system:
- Add gcc/clang conflicts for `cuda@12.4` which were missed in #42748
- Fix/relax existing clang conflict which was too strict from #41304

`ginkgo` package:
- Change conflict introduced in #42748 from `cuda@12.4.0` to `cuda@12.4` as the necessary fix wasn't included in `cuda@12.4.1`. (Ginkgo is also preparing a workaround in https://github.com/ginkgo-project/ginkgo/pull/1569, but it isn't merged/released at the time of writing)