### PR TITLE
flecsi+legion: add cr versions FleCSI depended on in past releases

### DIFF
--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -21,7 +21,7 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
 
     tags = ["e4s"]
 
-    version("develop", branch="develop")
+    version("develop", branch="develop", deprecated=True)
     version("2.2.1", tag="v2.2.1", commit="84b5b232aebab40610f57387778db80f6c8c84c5")
     version("2.2.0", tag="v2.2.0", commit="dd531ac16c5df124d76e385c6ebe9b9589c2d3ad")
     version("2.1.0", tag="v2.1.0", commit="533df139c267e2a93c268dfe68f9aec55de11cf0")

--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -22,9 +22,7 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     tags = ["e4s"]
 
     version("develop", branch="develop")
-    version(
-        "2.2.1", tag="v2.2.1", commit="84b5b232aebab40610f57387778db80f6c8c84c5", preferred=True
-    )
+    version("2.2.1", tag="v2.2.1", commit="84b5b232aebab40610f57387778db80f6c8c84c5")
     version("2.2.0", tag="v2.2.0", commit="dd531ac16c5df124d76e385c6ebe9b9589c2d3ad")
     version("2.1.0", tag="v2.1.0", commit="533df139c267e2a93c268dfe68f9aec55de11cf0")
     version("2.0.0", tag="v2.0.0", commit="5ceebadf75d1c98999ea9e9446926722d061ec22")
@@ -93,7 +91,7 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("legion+shared", when="backend=legion @:1")
     depends_on("legion+hdf5", when="backend=legion +hdf5 @:1")
     depends_on("legion build_type=Debug", when="backend=legion +debug_backend")
-    depends_on("legion@master", when="backend=legion @:1")
+    depends_on("legion@cr-20191217", when="backend=legion @:1")
     depends_on("hpx@1.4.1 cxxstd=17 malloc=system max_cpu_count=128", when="backend=hpx @:1")
     depends_on("hpx build_type=Debug", when="backend=hpx +debug_backend")
     depends_on("googletest@1.8.1+gmock", when="@:1")
@@ -113,7 +111,8 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("kokkos +cuda +cuda_constexpr +cuda_lambda", when="+kokkos +cuda @2.0:")
     depends_on("kokkos +rocm", when="+kokkos +rocm @2.0:")
     depends_on("kokkos +openmp", when="+kokkos +openmp @2.0:")
-    depends_on("legion@master", when="backend=legion @2.0:2.2.1")
+    depends_on("legion@cr-20210122", when="backend=legion @2.0:2.2.1")
+    depends_on("legion@cr-20230307", when="backend=legion @2.2.0:2.2.1")
     depends_on("legion@24.03.0:", when="backend=legion @2.2.2:")
     depends_on("legion+shared", when="backend=legion +shared @2.0:")
     depends_on("legion+hdf5", when="backend=legion +hdf5 @2.0:")

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -45,6 +45,11 @@ class Legion(CMakePackage, ROCmPackage):
     version("stable", branch="stable")
     version("master", branch="master")
 
+    # Old control replication commits used by FleCSI releases, prior to 24.03.0
+    version("cr-20230307", commit="435183796d7c8b6ac1035a6f7af480ded750f67d", deprecated=True)
+    version("cr-20210122", commit="181e63ad4187fbd9a96761ab3a52d93e157ede20", deprecated=True)
+    version("cr-20191217", commit="572576b312509e666f2d72fafdbe9d968b1a6ac3", deprecated=True)
+
     depends_on("cmake@3.16:", type="build")
     # TODO: Need to spec version of MPI v3 for use of the low-level MPI transport
     # layer. At present the MPI layer is still experimental and we discourge its


### PR DESCRIPTION
Following the discussion in https://github.com/spack/spack/pull/43410, this is another attempt at adding the necessary unreleased versions of Legion for building FleCSI releases. @elliottslaughter I tried doing this without touching the Legion spackage, but it seems the Spack devs would prefer this.