### PR TITLE
remove redundant write lock post env install w/o view

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -420,10 +420,9 @@ def install_with_active_env(env: ev.Environment, args, install_kwargs, reporter_
         with reporter_factory(specs_to_install):
             env.install_specs(specs_to_install, **install_kwargs)
     finally:
-        # TODO: this is doing way too much to trigger
-        # views and modules to be generated.
-        with env.write_transaction():
-            env.write(regenerate=True)
+        if env.views:
+            with env.write_transaction():
+                env.write(regenerate=True)
 
 
 def concrete_specs_from_cli(args, install_kwargs):


### PR DESCRIPTION
`spack env depfile` is very slow when there's lots of parallelism for lots of
small packages (or already installed ones).

The reason is Spack likes to generate views at the end of `spack install /x`,
which is done in sync through an env write lock.

However, when using `spack env depfile` you typically have no views enabled
since it doesn't make sense to generate a view after each install.

So, this PR only conditionally acquires a write lock on the env if the env has
views.

Before this PR `spack install /x` for already installed `/x` would take
anywhere between 5 - 60 seconds, now it's much faster.
