### PR TITLE
[WIP: CodeCov patch diff hit failure] CI: add source directory for logs CI: add source directory for logs

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -187,7 +187,8 @@ class AutotoolsBuilder(BaseBuilder):
     @property
     def archive_files(self):
         """Files to archive for packages based on autotools"""
-        files = [os.path.join(self.build_directory, "config.log")]
+        staging_prefixes = (self.build_directory, self.pkg.stage.source_path)
+        files = [os.path.join(prefix, "config.log") for prefix in staging_prefixes]
         if not self.install_libtool_archives:
             files.append(self._removed_la_files_log)
         return files

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -187,8 +187,11 @@ class AutotoolsBuilder(BaseBuilder):
     @property
     def archive_files(self):
         """Files to archive for packages based on autotools"""
+        archives = ("config.log", "config.guess", "configure")
         staging_prefixes = (self.build_directory, self.pkg.stage.source_path)
-        files = [os.path.join(prefix, "config.log") for prefix in staging_prefixes]
+        files = [
+            os.path.join(prefix, archive) for archive in archives for prefix in staging_prefixes
+        ]
         if not self.install_libtool_archives:
             files.append(self._removed_la_files_log)
         return files

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -110,7 +110,8 @@ class MesonBuilder(BaseBuilder):
     @property
     def archive_files(self):
         """Files to archive for packages based on Meson"""
-        return [os.path.join(self.build_directory, "meson-logs", "meson-log.txt")]
+        staging_prefixes = (self.build_directory, self.pkg.stage.source_path)
+        return [os.path.join(prefix, "meson-logs", "meson-log.txt") for prefix in staging_prefixes]
 
     @property
     def root_mesonlists_dir(self):


### PR DESCRIPTION
Meson and Autotools dump configuration files to the source directory.

ref. https://github.com/spack/spack/pull/42213#issuecomment-2040009344

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
