### PR TITLE
mirror: clean up stage when retrying

### DIFF
--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -221,6 +221,7 @@ def create_mirror_from_package_object(
                 pkg_stage.cache_mirror(mirror_cache, mirror_stats)
             break
         except Exception as e:
+            pkg_obj.stage.destroy()
             if num_retries + 1 == max_retries:
                 if spack.config.get("config:debug"):
                     traceback.print_exc()


### PR DESCRIPTION
If we do not clean up the stage, retries might use a corrupted stage:
1. Cloning a Git repository succeeds
2. Disk space runs out while copying the repository to the stage
3. Since the stage exists, a retry will simply reuse it without noticing that it is missing files due to the previous error