### PR TITLE
e4s ci: add exawind

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -229,6 +229,7 @@ spack:
   - caliper +rocm amdgpu_target=gfx908
   - chai +rocm amdgpu_target=gfx908
   - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx908
+  - exawind ~cuda +rocm amdgpu_target=gfx908
   - fftx +rocm amdgpu_target=gfx908
   - gasnet +rocm amdgpu_target=gfx908
   - ginkgo +rocm amdgpu_target=gfx908
@@ -275,6 +276,7 @@ spack:
   - caliper +rocm amdgpu_target=gfx90a
   - chai +rocm amdgpu_target=gfx90a
   - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx90a
+  - exawind ~cuda +rocm amdgpu_target=gfx90a
   - fftx +rocm amdgpu_target=gfx90a
   - gasnet +rocm amdgpu_target=gfx90a
   - ginkgo +rocm amdgpu_target=gfx90a

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -98,6 +98,7 @@ spack:
   - dyninst
   - e4s-cl
   - ecp-data-vis-sdk ~cuda ~rocm +adios2 +ascent +cinema +darshan +faodel +hdf5 +paraview +pnetcdf +sz +unifyfs +veloc +visit +vtkm +zfp # 
+  - exawind ~cuda ~rocm
   - exaworks
   - fftx
   - flecsi
@@ -258,6 +259,7 @@ spack:
   - dealii +cuda cuda_arch=80
   - ecp-data-vis-sdk ~rocm +adios2 ~ascent +hdf5 +vtkm +zfp ~paraview +cuda cuda_arch=80 # +paraview: FAILED: VTK/ThirdParty/vtkm/vtkvtkm/vtk-m/vtkm/filter/flow/CMakeFiles/vtkm_filter_flow.dir/StreamSurface.cxx.o
   - exago +mpi +python +raja +hiop ~rocm +cuda cuda_arch=80 ~ipopt ^hiop@1.0.0 ~sparse +mpi +raja ~rocm +cuda cuda_arch=80
+  - exawind ~rocm +cuda cuda_arch=80
   - fftx +cuda cuda_arch=80
   - flecsi +cuda cuda_arch=80
   - ginkgo +cuda cuda_arch=80
@@ -303,6 +305,7 @@ spack:
   - cabana +cuda cuda_arch=90 ^kokkos +wrapper +cuda_lambda +cuda cuda_arch=90
   - caliper +cuda cuda_arch=90
   - chai +cuda cuda_arch=90 ^umpire ~shared
+  - exawind ~rocm +cuda cuda_arch=90
   - chapel +cuda cuda_arch=90
   - cusz +cuda cuda_arch=90
   - ecp-data-vis-sdk ~rocm +adios2 ~ascent +hdf5 +vtkm +zfp ~paraview +cuda cuda_arch=90 # +paraview: issue with cuda@12; +ascent: # ascent: https://github.com/spack/spack/issues/38045; +paraview: VTK/ThirdParty/vtkm/vtkvtkm/vtk-m/vtkm/exec/cuda/internal/ExecutionPolicy.h(121): error: namespace "thrust" has no member "sort"
@@ -357,6 +360,7 @@ spack:
   - caliper +rocm amdgpu_target=gfx90a
   - chai +rocm amdgpu_target=gfx90a
   - ecp-data-vis-sdk ~paraview +vtkm +rocm amdgpu_target=gfx90a # +paraview: CMake Error at VTK/ThirdParty/vtkm/vtkvtkm/vtk-m/CMakeLists.txt:272 (find_package): Could not find a package configuration file provided by "rocthrust" with any of the following names: rocthrustConfig.cmake rocthrust-config.cmake
+  - exawind ~cuda +rocm amdgpu_target=gfx90a
   - gasnet +rocm amdgpu_target=gfx90a
   - ginkgo +rocm amdgpu_target=gfx90a
   - heffte +rocm amdgpu_target=gfx90a

--- a/var/spack/repos/builtin/packages/py-netcdf4/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf4/package.py
@@ -49,6 +49,7 @@ class PyNetcdf4(PythonPackage):
     depends_on("netcdf-c+mpi", when="+mpi")
     depends_on("hdf5@1.8.0:+hl~mpi", when="~mpi")
     depends_on("hdf5@1.8.0:+hl+mpi", when="+mpi")
+    depends_on("mpi", when="+mpi")
 
     # The installation script tries to find hdf5 using pkg-config. However, the
     # version of hdf5 installed with Spack does not have pkg-config files.


### PR DESCRIPTION
E4S CI: add ExaWind packages

@psakievich can you advise on which non-default variants we should turn on for CPU, CUDA, and ROCm builds?
