### PR TITLE
fastjet: new multi-valued variant `plugins`

### DIFF
--- a/var/spack/repos/builtin/packages/rivet/package.py
+++ b/var/spack/repos/builtin/packages/rivet/package.py
@@ -54,7 +54,7 @@ class Rivet(AutotoolsPackage):
 
     depends_on("hepmc", when="hepmc=2")
     depends_on("hepmc3", when="hepmc=3")
-    depends_on("fastjet")
+    depends_on("fastjet plugins=cxx")
     depends_on("fastjet@3.4.0:", when="@3.1.7:")
     depends_on("fjcontrib")
     depends_on("python", type=("build", "run"))


### PR DESCRIPTION
Enabling all fastjet plugins (as is the default) installs the pxcone plugin which requires a fortran compiler. For certain software stacks this adds a requirement for a fortran compiler, solely due to this (unused) fastjet plugin.

This PR adds more flexibility for which plugins are included, with two meta-values: `all` and `cxx`. Default is identical as before, but now allows e.g. `fastjet plugins=cxx` and `fastjet plugins=atlastcone,cmsiterativecone`.
