### PR TITLE
cppzmq: new version 4.10.0

### DIFF
--- a/var/spack/repos/builtin/packages/cppzmq/package.py
+++ b/var/spack/repos/builtin/packages/cppzmq/package.py
@@ -18,6 +18,7 @@ class Cppzmq(CMakePackage):
     license("MIT")
 
     version("master", branch="master")
+    version("4.10.0", sha256="c81c81bba8a7644c84932225f018b5088743a22999c6d82a2b5f5cd1e6942b74")
     version("4.9.0", sha256="3fdf5b100206953f674c94d40599bdb3ea255244dcc42fab0d75855ee3645581")
     version("4.8.1", sha256="7a23639a45f3a0049e11a188e29aaedd10b2f4845f0000cf3e22d6774ebde0af")
     version("4.7.1", sha256="9853e0437d834cbed5d3c223bf1d755cadee70e7c964c6e42c4c6783dee5d02c")


### PR DESCRIPTION
This PR adds a new version of cppzmq, [release notes](https://github.com/zeromq/cppzmq/releases/tag/v4.10.0), [diff](https://github.com/zeromq/cppzmq/compare/v4.9.0...v4.10.0). No build system changes.

```
==> Installed packages
-- linux-ubuntu24.04-skylake / gcc@13.2.0 -----------------------
ptjlvdd cppzmq@4.10.0~drafts~ipo build_system=cmake build_type=Release generator=make
==> 1 installed package
```