### PR TITLE
autodiff: add v1.0.2 -> v1.1.2

### DIFF
--- a/var/spack/repos/builtin/packages/autodiff/package.py
+++ b/var/spack/repos/builtin/packages/autodiff/package.py
@@ -16,7 +16,7 @@ class Autodiff(CMakePackage, CudaPackage):
 
     maintainers("wdconinc")
 
-    license("MIT")
+    license("MIT", checked_by="wdconinc")
 
     version("1.1.2", sha256="86f68aabdae1eed214bfbf0ddaa182c78ea1bb99e4df404efb7b94d30e06b744")
     version("1.1.1", sha256="05aa2a432c83db079efeca1c407166a3f3d190645bd3202da3b6357fb30fc9e1")

--- a/var/spack/repos/builtin/packages/autodiff/package.py
+++ b/var/spack/repos/builtin/packages/autodiff/package.py
@@ -36,7 +36,7 @@ class Autodiff(CMakePackage, CudaPackage):
     version("0.6.4", sha256="cfe0bb7c0de10979caff9d9bfdad7e6267faea2b8d875027397486b47a7edd75")
     version("0.5.13", sha256="a73dc571bcaad6b44f74865fed51af375f5a877db44321b5568d94a4358b77a1")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     variant("python", default=False, description="Enable the compilation of the python bindings.")
     variant("examples", default=False, description="Enable the compilation of the example files.")

--- a/var/spack/repos/builtin/packages/autodiff/package.py
+++ b/var/spack/repos/builtin/packages/autodiff/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Autodiff(CMakePackage):
+class Autodiff(CMakePackage, CudaPackage):
     """autodiff is automatic differentiation made easier for C++."""
 
     homepage = "https://autodiff.github.io"
@@ -18,6 +18,10 @@ class Autodiff(CMakePackage):
 
     license("MIT")
 
+    version("1.1.1", sha256="05aa2a432c83db079efeca1c407166a3f3d190645bd3202da3b6357fb30fc9e1")
+    version("1.1.0", sha256="a5489bb546c460af52de8ead447439b3c97429184df28b4d142ce7dcfd62b82c")
+    version("1.0.3", sha256="21b57ce60864857913cacb856c3973ae10f7539b6bb00bcc04f85b2f00db0ce2")
+    version("1.0.2", sha256="a3289aed937a39a817f76e6befa0d071a3e70a5b0b125ec62d1acf1d389e2197")
     version("1.0.1", sha256="63f2c8aaf940fbb1d1e7098b1d6c08794da0194eec3faf773f3123dc7233838c")
     version("1.0.0", sha256="112c6f5740071786b3f212c96896abc2089a74bca16b57bb46ebf4cec79dca43")
     version("0.6.12", sha256="3e9d667b81bba8e43bbe240a0321e25f4be248d1761097718664445306882dcc")
@@ -43,6 +47,8 @@ class Autodiff(CMakePackage):
     depends_on("py-pybind11", type=("build", "run"))
     depends_on("catch2", type="test")
     depends_on("catch2@3:", when="@0.6.12:", type="test")
+
+    conflicts("+cuda", when="@:1.0", msg="CUDA support was added in 1.1.0")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/autodiff/package.py
+++ b/var/spack/repos/builtin/packages/autodiff/package.py
@@ -18,6 +18,7 @@ class Autodiff(CMakePackage, CudaPackage):
 
     license("MIT")
 
+    version("1.1.2", sha256="86f68aabdae1eed214bfbf0ddaa182c78ea1bb99e4df404efb7b94d30e06b744")
     version("1.1.1", sha256="05aa2a432c83db079efeca1c407166a3f3d190645bd3202da3b6357fb30fc9e1")
     version("1.1.0", sha256="a5489bb546c460af52de8ead447439b3c97429184df28b4d142ce7dcfd62b82c")
     version("1.0.3", sha256="21b57ce60864857913cacb856c3973ae10f7539b6bb00bcc04f85b2f00db0ce2")


### PR DESCRIPTION
This PR adds a few new versions of autodiff, per https://github.com/autodiff/autodiff/releases.

No build system or major changes in [1.0.2](https://github.com/autodiff/autodiff/compare/v1.0.1...v1.0.2), and [1.0.3](https://github.com/autodiff/autodiff/compare/v1.0.2...v1.0.3). 

Version [1.1.0](https://github.com/autodiff/autodiff/compare/v1.0.3...v1.1.0) adds CUDA support (https://github.com/autodiff/autodiff/pull/309).