### PR TITLE
[mpas-model] Only add options for double precision when requested

### DIFF
--- a/var/spack/repos/builtin/packages/mpas-model/package.py
+++ b/var/spack/repos/builtin/packages/mpas-model/package.py
@@ -104,15 +104,9 @@ class MpasModel(MakefilePackage):
         fflags = [self.compiler.openmp_flag]
         cppflags = ["-D_MPI"]
         if satisfies("%gcc"):
-            fflags.extend(
-                [
-                    "-ffree-line-length-none",
-                    "-fconvert=big-endian",
-                    "-ffree-form",
-                    "-fdefault-real-8",
-                    "-fdefault-double-8",
-                ]
-            )
+            fflags.extend(["-ffree-line-length-none", "-fconvert=big-endian", "-ffree-form"])
+            if satisfies("precision=double"):
+                fflags.extend(["-fdefault-real-8", "-fdefault-double-8"])
             cppflags.append("-DUNDERSCORE")
         elif satisfies("%fj"):
             fflags.extend(["-Free", "-Fwide", "-CcdRR8"])


### PR DESCRIPTION
As in the original makefile "FFLAGS_PROMOTION = -fdefault-real-8 -fdefault-double-8" is only used when `precision=double`. This is the default for the Spack package, so no change if `precision` is left unset.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
