### PR TITLE
mpich: Update PMI configure options

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -61,9 +61,9 @@ class Mpich(AutotoolsPackage, CudaPackage, ROCmPackage):
     variant("wrapperrpath", default=True, description="Enable wrapper rpath")
     variant(
         "pmi",
-        default="pmi",
+        default="default",
         description="""PMI interface.""",
-        values=("pmi", "pmi2", "pmix", "cray"),
+        values=("default", "pmi", "pmi2", "pmix", "cray"),
         multi=False,
     )
     variant(
@@ -388,9 +388,15 @@ supported, and netmod is ignored if device is ch3:sock.""",
             if re.search(r"--with-thread-package=argobots", output):
                 variants.append("+argobots")
 
-            if re.search(r"--with-pmi=simple", output):
+            if re.search(r"--with-pmi=default", output):
+                variants.append("pmi=default")
+            elif re.search(r"--with-pmi=simple", output):
                 variants.append("pmi=pmi")
             elif re.search(r"--with-pmi=pmi2/simple", output):
+                variants.append("pmi=pmi2")
+            elif re.search(r"--with-pmi=pmi", output):
+                variants.append("pmi=pmi")
+            elif re.search(r"--with-pmi=pmi2", output):
                 variants.append("pmi=pmi2")
             elif re.search(r"--with-pmix", output):
                 variants.append("pmi=pmix")
@@ -554,14 +560,32 @@ supported, and netmod is ignored if device is ch3:sock.""",
         else:
             config_args.append("--with-slurm=no")
 
-        if "pmi=pmi" in spec:
-            config_args.append("--with-pmi=simple")
-        elif "pmi=pmi2" in spec:
-            config_args.append("--with-pmi=pmi2/simple")
-        elif "pmi=pmix" in spec:
-            config_args.append("--with-pmix={0}".format(spec["pmix"].prefix))
-        elif "pmi=cray" in spec:
-            config_args.append("--with-pmi=cray")
+        # PMI options changed in 4.2.0
+        if spec.satisfies("@4.2:"):
+            # default (no option) is to build both PMIv1 and PMI2 client interfaces
+            if "pmi=pmi" in spec:
+                # make PMI1 the default client interface
+                config_args.append("--with-pmi=pmi")
+            elif "pmi=pmi2" in spec:
+                # make PMI2 the default client interface
+                config_args.append("--with-pmi=pmi2")
+            elif "pmi=pmix" in spec:
+                # use the PMIx client interface with an external PMIx library
+                config_args.append("--with-pmi=pmix")
+                config_args.append(f"--with-pmix={spec['pmix'].prefix}")
+            elif "pmi=cray" in spec:
+                # use PMI2 interface of the Cray PMI library
+                config_args.append("--with-pmi=pmi2")
+                config_args.append(f"--with-pmi2={spec['cray-pmi'].prefix}")
+        else:
+            if "pmi=pmi" in spec:
+                config_args.append("--with-pmi=simple")
+            elif "pmi=pmi2" in spec:
+                config_args.append("--with-pmi=pmi2/simple")
+            elif "pmi=pmix" in spec:
+                config_args.append(f"--with-pmix={spec['pmix'].prefix}")
+            elif "pmi=cray" in spec:
+                config_args.append("--with-pmi=cray")
 
         if "+cuda" in spec:
             config_args.append("--with-cuda={0}".format(spec["cuda"].prefix))


### PR DESCRIPTION
Add a "default" option that passes no option to configure. Existing options changed in the MPICH 4.2.0 release, so update the package to reflect those changes. This is necessary to be able to add new MPICH releases to Spack.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
