### PR TITLE
Fix installation of static libraries for python on Windows

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -548,7 +548,7 @@ class Python(Package):
         static_libraries = glob.glob("%s\\*.lib" % build_root)
         os.makedirs(prefix.libs, exist_ok=True)
         for lib in static_libraries:
-            copy(lib, os.path.join(prefix.libs, os.path.basename(lib)))
+            copy(lib, prefix.libs)
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -545,9 +545,10 @@ class Python(Package):
                 copy(lib, prefix)
             else:
                 copy(lib, prefix.DLLs)
-        static_libraries = glob.glob("%s\\*.lib")
+        static_libraries = glob.glob("%s\\*.lib" % build_root)
+        os.makedirs(prefix.libs, exist_ok=True)
         for lib in static_libraries:
-            copy(lib, prefix.libs)
+            copy(lib, os.path.join(prefix.libs, os.path.basename(lib)))
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
The line in the `win_installer` method that handles copying of .lib files was not working, and thus packages that depend on the static libraries, like `py-cython`, were unable to install.