### PR TITLE
Packages: llvm cxx flag remove, new versions, and binutils build issue fix

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/gold-gcc4.patch
+++ b/var/spack/repos/builtin/packages/binutils/gold-gcc4.patch
@@ -1,0 +1,12 @@
+diff --git a/tmp/yizeping/spack-stage/spack-stage-binutils-2.42-lkdx5qollqoytwfulbtmqzrcso46vx2h/spack-src/gold/merge.cc b/./merge.cc
+index ca15149..a270bc0 100644
+--- a/tmp/yizeping/spack-stage/spack-stage-binutils-2.42-lkdx5qollqoytwfulbtmqzrcso46vx2h/spack-src/gold/merge.cc
++++ b/./merge.cc
+@@ -24,6 +24,7 @@
+ 
+ #include <cstdlib>
+ #include <algorithm>
++#include <uchar.h>
+ 
+ #include "merge.h"
+ #include "compressed_output.h"

--- a/var/spack/repos/builtin/packages/binutils/gold-gcc4.patch
+++ b/var/spack/repos/builtin/packages/binutils/gold-gcc4.patch
@@ -1,7 +1,7 @@
-diff --git a/tmp/yizeping/spack-stage/spack-stage-binutils-2.42-lkdx5qollqoytwfulbtmqzrcso46vx2h/spack-src/gold/merge.cc b/./merge.cc
+diff --git a/gold/merge.cc b/gold/merge.cc
 index ca15149..a270bc0 100644
---- a/tmp/yizeping/spack-stage/spack-stage-binutils-2.42-lkdx5qollqoytwfulbtmqzrcso46vx2h/spack-src/gold/merge.cc
-+++ b/./merge.cc
+--- a/gold/merge.cc
++++ b/gold/merge.cc
 @@ -24,6 +24,7 @@
  
  #include <cstdlib>

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -126,6 +126,7 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     # 2.36 is missing some dependencies, this patch allows a parallel build.
     # https://sourceware.org/bugzilla/show_bug.cgi?id=27482
     patch("parallel-build-2.36.patch", when="@2.36")
+    patch("gold-gcc4.patch", when="@2.42 %gcc@:4.8.5")
 
     # compression libs for debug symbols.
     # pkg-config is used to find zstd in gas/configure

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -24,6 +24,7 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
     license("LGPL-2.1-or-later")
 
     version("master", branch="master")
+    version("2.39", sha256="97f84f3b7588cd54093a6f6389b0c1a81e70d99708d74963a2e3eab7c7dc942d")
     version("2.38", sha256="16e51e0455e288f03380b436e41d5927c60945abd86d0c9852b84be57dd6ed5e")
     version("2.37", sha256="e3a790c2f84eed5c5d569ed6172c253c607dd3962135437da413aa39aa4fd352")
     version("2.36", sha256="02efa6ffbbaf3e10e88f16818a862608d04b0ef838c66f6025ae120530792c9c")

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -166,6 +166,8 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
 
     # See 2d7ed98add14f75041499ac189696c9bd3d757fe
     depends_on("gmake@:4.3", type="build", when="@:2.36")
+    # Since f2873d2da0ac9802e0b570e8e0b9e7e04a82bf55
+    depends_on("gmake@4.0:", type="build", when="@2.28:")
 
     # From 2.29: generates locale/C-translit.h
     # before that it's a test dependency.

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -37,6 +37,7 @@ class Llvm(CMakePackage, CudaPackage):
     license("Apache-2.0")
 
     version("main", branch="main")
+    version("18.1.2", sha256="fc5a2fd176d73ceb17f4e522f8fe96d8dde23300b8c233476d3609f55d995a7a")
     version("18.1.2", sha256="8d686d5ece6f12b09985cb382a3a530dc06bb6e7eb907f57c7f8bf2d868ebb0b")
     version("18.1.1", sha256="62439f733311869dbbaf704ce2e02141d2a07092d952fc87ef52d1d636a9b1e4")
     version("18.1.0", sha256="eb18f65a68981e94ea1a5aae4f02321b17da9e99f76bfdb983b953f4ba2d3550")

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -37,7 +37,7 @@ class Llvm(CMakePackage, CudaPackage):
     license("Apache-2.0")
 
     version("main", branch="main")
-    version("18.1.2", sha256="fc5a2fd176d73ceb17f4e522f8fe96d8dde23300b8c233476d3609f55d995a7a")
+    version("18.1.3", sha256="fc5a2fd176d73ceb17f4e522f8fe96d8dde23300b8c233476d3609f55d995a7a")
     version("18.1.2", sha256="8d686d5ece6f12b09985cb382a3a530dc06bb6e7eb907f57c7f8bf2d868ebb0b")
     version("18.1.1", sha256="62439f733311869dbbaf704ce2e02141d2a07092d952fc87ef52d1d636a9b1e4")
     version("18.1.0", sha256="eb18f65a68981e94ea1a5aae4f02321b17da9e99f76bfdb983b953f4ba2d3550")

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -753,10 +753,7 @@ class Llvm(CMakePackage, CudaPackage):
                     )
 
     def flag_handler(self, name, flags):
-        if name == "cxxflags":
-            flags.append(self.compiler.cxx11_flag)
-            return (None, flags, None)
-        elif name == "ldflags" and self.spec.satisfies("%intel"):
+        if name == "ldflags" and self.spec.satisfies("%intel"):
             flags.append("-shared-intel")
             return (None, flags, None)
         return (flags, None, None)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This pull request tries to add new versions and fix build issues, contains:
 - new version for `llvm` and `glibc`
 - remove `llvm`'s cxx11 flag as described in #42314 
 - patch gold in `binutils` when using old gcc, as old compilers do not use some c++11 header implicitly
 - depend `gmake@4.0:` for `glibc@2.28:` as requested since f2873d2da0ac9802e0b570e8e0b9e7e04a82bf55