### PR TITLE
pyAMReX: No CCache

### DIFF
--- a/var/spack/repos/builtin/packages/py-amrex/package.py
+++ b/var/spack/repos/builtin/packages/py-amrex/package.py
@@ -87,7 +87,7 @@ class PyAmrex(PythonPackage, CudaPackage, ROCmPackage):
 
         # disable superbuilds: use external dependencies
         env.set("AMREX_INTERNAL", "OFF")
-        env.set("PYAMREX_CCACHE", "ON")
+        env.set("PYAMREX_CCACHE", "OFF")
         env.set("PYAMREX_IPO", "ON")
         env.set("PYBIND11_INTERNAL", "OFF")
 


### PR DESCRIPTION
This interferes with Spack compiler wrappers.

Background: https://github.com/ECP-WarpX/WarpX/pull/4637

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
