### PR TITLE
libdrm: new version 2.4.120

### DIFF
--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -18,6 +18,11 @@ class Libdrm(Package):
 
     license("MIT")
 
+    version("2.4.120", sha256="3bf55363f76c7250946441ab51d3a6cc0ae518055c0ff017324ab76cdefb327a")
+    version("2.4.119", sha256="0a49f12f09b5b6e68eaaaff3f02ca7cff9aa926939b212d343161d3e8ac56291")
+    version("2.4.118", sha256="a777bd85f2b5fc9c57f886c82058300578317cafdbc77d0a769d7e9a9567ab88")
+    version("2.4.117", sha256="a2888d69e3eb1c8a77adc08a75a60fbae01f0d208d26f034d1a12e362361242b")
+    version("2.4.116", sha256="46c53f40735ea3d26d614297f155f6131a510624a24274f654f6469ca905339a")
     version("2.4.115", sha256="554cfbfe0542bddb391b4e3e05bfbbfc3e282b955bd56218d21c0616481f65eb")
     version("2.4.114", sha256="3049cf843a47d12e5eeefbc3be3496d782fa09f42346bf0b7defe3d1e598d026")
     version("2.4.113", sha256="7fd7eb2967f63beb4606f22d50e277d993480d05ef75dd88a9bd8e677323e5e1")
@@ -42,7 +47,8 @@ class Libdrm(Package):
 
     # 2.4.90 is the first version to use meson, spack defaults to meson since
     # 2.4.101.
-    depends_on("meson", type="build", when="@2.4.101:")
+    depends_on("meson@0.53:", type="build", when="@2.4.101:")
+    depends_on("meson@0.59:", type="build", when="@2.4.117:")
 
     # >= 2.4.104 uses reStructuredText for man pages.
     with when("@2.4.104: +docs"):


### PR DESCRIPTION
This PR adds new versions of libdrm through 2.4.120. It adds an explicit minimum meson version, and updates this requirement as of 2.4.117. There are no other build system changes.

Test build:
```
==> Installing libdrm-2.4.120-itqfo7hkkzqb5bimu3h47ev6a62wry4i [29/29]
==> No binary for libdrm-2.4.120-itqfo7hkkzqb5bimu3h47ev6a62wry4i found: installing from source
==> Fetching https://dri.freedesktop.org/libdrm/libdrm-2.4.120.tar.xz
==> No patches needed for libdrm
==> libdrm: Executing phase: 'install'
==> libdrm: Successfully installed libdrm-2.4.120-itqfo7hkkzqb5bimu3h47ev6a62wry4i
  Stage: 0.91s.  Install: 14.18s.  Post-install: 0.09s.  Total: 15.35s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/libdrm-2.4.120-itqfo7hkkzqb5bimu3h47ev6a62wry4i
```