### PR TITLE
libpthread-stubs: new version 0.5

### DIFF
--- a/var/spack/repos/builtin/packages/libpthread-stubs/package.py
+++ b/var/spack/repos/builtin/packages/libpthread-stubs/package.py
@@ -15,6 +15,7 @@ class LibpthreadStubs(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("0.5", sha256="593196cc746173d1e25cb54a93a87fd749952df68699aab7e02c085530e87747")
     version(
         "0.4",
         sha256="50d5686b79019ccea08bcbd7b02fe5a40634abcfd4146b6e75c6420cc170e9d9",


### PR DESCRIPTION
This PR adds a new libpthread-stubs version 0.5. No build system or dependency changes. First release after move from xcb to centralized freedesktop.org.