### PR TITLE
qt-base: depends_on cmake@3.21: when ~shared or platform=darwin

### DIFF
--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -130,6 +130,8 @@ class QtBase(QtPackage):
     variant("widgets", default=True, when="+gui", description="Build with widgets.")
 
     # Dependencies, then variant- and version-specific dependencies
+    depends_on("cmake@3.21:", type="build", when="~shared")
+    depends_on("cmake@3.21:", type="build", when="platform=darwin")
     depends_on("double-conversion")
     depends_on("icu4c")
     depends_on("libxml2")


### PR DESCRIPTION
This PR adds a stricter dependency on cmake@3.21: when building either static or on darwin. See https://github.com/qt/qtbase/blob/dev/.cmake.conf.