### PR TITLE
acts: new version 33.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -423,6 +423,7 @@ class Acts(CMakePackage, CudaPackage):
             cmake_variant("FATRAS_GEANT4", "fatras_geant4"),
             example_cmake_variant("GEANT4", "geant4"),
             plugin_cmake_variant("GEANT4", "geant4"),
+            plugin_cmake_variant("GEOMODEL", "geomodel"),
             example_cmake_variant("HEPMC3", "hepmc3"),
             plugin_cmake_variant("IDENTIFICATION", "identification"),
             cmake_variant(integration_tests_label, "integration_tests"),

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -42,6 +42,11 @@ class Acts(CMakePackage, CudaPackage):
     # Supported Acts versions
     version("main", branch="main")
     version("master", branch="main", deprecated=True)  # For compatibility
+    version("33.1.0", commit="00591a593a648430820e980b031301d25c18f1c7", submodules=True)
+    version("33.0.0", commit="f6ed9013e76120137ae456583a04b554d88d9452", submodules=True)
+    version("32.1.0", commit="5333c67b49b4bfcd45558090e4ba37b4f86b82db", submodules=True)
+    version("32.0.2", commit="3d23e16a2d0ba68ce5a596ced16883f90de1fae4", submodules=True)
+    version("32.0.1", commit="6317634ec16eb40e52ca85445a014e378c9a4829", submodules=True)
     version("32.0.0", commit="9385e36691bb2687437c39ad02ddb2ac21acccdc", submodules=True)
     version("31.2.0", commit="1d2e90f534ff2c9bf1c40914980b426f4b5d3096", submodules=True)
     version("31.1.0", commit="95c3ceef79a7b68fcfc7fd558c3134d0c7529dac", submodules=True)
@@ -208,7 +213,7 @@ class Acts(CMakePackage, CudaPackage):
         "autodiff",
         default=False,
         description="Build the auto-differentiation plugin",
-        when="@1.2:",
+        when="@1.2:32",
     )
     variant("dd4hep", default=False, description="Build the DD4hep plugin", when="+tgeo")
     variant(
@@ -226,6 +231,7 @@ class Acts(CMakePackage, CudaPackage):
         when="@0.16:",
     )
     variant("fatras_geant4", default=False, description="Build Geant4 Fatras package")
+    variant("geomodel", default=False, description="Build GeoModel plugin", when="@33:")
     variant("identification", default=False, description="Build the Identification plugin")
     variant("json", default=False, description="Build the Json plugin")
     variant("legacy", default=False, description="Build the Legacy package")
@@ -250,7 +256,7 @@ class Acts(CMakePackage, CudaPackage):
 
     # Variants that only affect Acts examples for now
     variant(
-        "binaries", default=False, description="Build the examples binaries", when="@23: +examples"
+        "binaries", default=False, description="Build the examples binaries", when="@23:32 +examples"
     )
     variant(
         "edm4hep",
@@ -301,6 +307,7 @@ class Acts(CMakePackage, CudaPackage):
         depends_on("actsvg@0.4.33:", when="@25:27")
         depends_on("actsvg@0.4.35:", when="@28:")
         depends_on("actsvg@0.4.39:", when="@32:")
+        depends_on("actsvg@0.4.40:", when="@32.1:")
     depends_on("autodiff @0.6:", when="@17: +autodiff")
     depends_on("autodiff @0.5.11:0.5.99", when="@1.2:16 +autodiff")
     depends_on("boost @1.62:1.69 +program_options +test", when="@:0.10.3")

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -256,7 +256,10 @@ class Acts(CMakePackage, CudaPackage):
 
     # Variants that only affect Acts examples for now
     variant(
-        "binaries", default=False, description="Build the examples binaries", when="@23:32 +examples"
+        "binaries",
+        default=False,
+        description="Build the examples binaries",
+        when="@23:32 +examples",
     )
     variant(
         "edm4hep",

--- a/var/spack/repos/builtin/packages/actsvg/package.py
+++ b/var/spack/repos/builtin/packages/actsvg/package.py
@@ -20,6 +20,8 @@ class Actsvg(CMakePackage):
 
     license("MPL-2.0")
 
+    version("0.4.41", sha256="c675795e74efcf42c3015d6efc8d7a1848b677f1d4efe6dcaa4fb490b46268ff")
+    version("0.4.40", sha256="e24f51e70cff57c74d3b5f51c08f6ea1f409ef85ef7b4bad4a29520ecda032a6")
     version("0.4.39", sha256="2d9605ecf8c9975d600cafb6d076969d77c634fa92844bd9586c38066da31739")
     version("0.4.35", sha256="693a4cc0e702842072a478c913895ed3596350ffdfa87f5d296ddd6ea36b61c6")
     version("0.4.33", sha256="25c93b8382bdb1864b4d8de64b146fe8ea86eec84048d594c375700d2fff1d1d")

--- a/var/spack/repos/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/builtin/packages/geomodel/package.py
@@ -54,9 +54,10 @@ class Geomodel(CMakePackage):
     depends_on("geant4", when="+fullsimlight")
     depends_on("hepmc3", when="+hepmc3")
     depends_on("pythia8", when="+pythia")
-    depends_on("hdf5", when="+visualization")
-    depends_on("qt-base +gui +opengl +sql +widgets", when="+visualization")
-    depends_on("opengl", when="+visualization")
+    with when("+visualization"):
+        depends_on("hdf5")
+        depends_on("qt-base +gui +opengl +sql +widgets")
+        depends_on("opengl")
 
     def cmake_args(self):
         def cmake_variant(cmake_label, spack_variant):

--- a/var/spack/repos/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/builtin/packages/geomodel/package.py
@@ -20,14 +20,26 @@ class Geomodel(CMakePackage):
 
     version("4.6.0", sha256="d827dc79a5555fd7b09d1b670fc6f01f91476d0edf98ccd644c624f18fb729ca")
 
-    variant("visualization", default=False, description="Enable the build of GeoModelVisualization")
+    variant(
+        "visualization", default=False, description="Enable the build of GeoModelVisualization"
+    )
     variant("geomodelg4", default=False, description="Enable the build of GeoModelG4")
     variant("fullsimlight", default=False, description="Enable the build of FullSimLight")
     variant("fsl", default=False, description="Enable the build of FSL and FullSimLight")
     variant("examples", default=False, description="Enable the build of GeoModelExamples")
     variant("tools", default=False, description="Enable the build of GeoModelTools")
-    variant("hepmc3", default=False, description="Build GeoModel tools with support for the HepMC3 exchange format", when="+fullsimlight")
-    variant("pythia", default=False, description="Build GeoModel tools with support for the Pythia event generator", when="+fullsimlight")
+    variant(
+        "hepmc3",
+        default=False,
+        description="Build GeoModel tools with support for the HepMC3 exchange format",
+        when="+fullsimlight",
+    )
+    variant(
+        "pythia",
+        default=False,
+        description="Build GeoModel tools with support for the Pythia event generator",
+        when="+fullsimlight",
+    )
 
     conflicts("+fullsimlight", when="+fsl", msg="FSL triggers the build of the FullSimLight")
 

--- a/var/spack/repos/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/builtin/packages/geomodel/package.py
@@ -1,0 +1,62 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Geomodel(CMakePackage):
+    """GeoModel is a user-friendly C++ Toolkit and Suite for
+    HEP Detector Description with minimal dependencies."""
+
+    homepage = "https://gitlab.cern.ch/GeoModelDev/GeoModel"
+    url = "https://gitlab.cern.ch/GeoModelDev/GeoModel/-/archive/4.6.0/GeoModel-4.6.0.tar.bz2"
+    git = "https://gitlab.cern.ch/GeoModelDev/GeoModel"
+
+    maintainers("wdconinc")
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("4.6.0", sha256="d827dc79a5555fd7b09d1b670fc6f01f91476d0edf98ccd644c624f18fb729ca")
+
+    variant("visualization", default=False, description="Enable the build of GeoModelVisualization")
+    variant("geomodelg4", default=False, description="Enable the build of GeoModelG4")
+    variant("fullsimlight", default=False, description="Enable the build of FullSimLight")
+    variant("fsl", default=False, description="Enable the build of FSL and FullSimLight")
+    variant("examples", default=False, description="Enable the build of GeoModelExamples")
+    variant("tools", default=False, description="Enable the build of GeoModelTools")
+    variant("hepmc3", default=False, description="Build GeoModel tools with support for the HepMC3 exchange format", when="+fullsimlight")
+    variant("pythia", default=False, description="Build GeoModel tools with support for the Pythia event generator", when="+fullsimlight")
+
+    conflicts("+fullsimlight", when="+fsl", msg="FSL triggers the build of the FullSimLight")
+
+    depends_on("cmake@3.16:", type="build")
+
+    depends_on("eigen@3.2.9:")
+    depends_on("nlohmann-json@3.6.1:")
+    depends_on("sqlite@3.7.17:")
+    depends_on("xerces-c@3.2.3:")
+
+    depends_on("geant4", when="+geomodelg4")
+    depends_on("geant4", when="+fullsimlight")
+    depends_on("hepmc3", when="+hepmc3")
+    depends_on("pythia8", when="+pythia")
+    depends_on("hdf5", when="+visualization")
+    depends_on("qt-base +gui +opengl +sql +widgets", when="+visualization")
+    depends_on("opengl", when="+visualization")
+
+    def cmake_args(self):
+        def cmake_variant(cmake_label, spack_variant):
+            enabled = spec.satisfies("+" + spack_variant)
+            return f"-DGEOMODEL_BUILD_{cmake_label}={enabled}"
+
+        args = [
+            cmake_variant("VISUALIZATION", "visualization"),
+            cmake_variant("GEOMODELG4", "geomodelg4"),
+            cmake_variant("FULLSIMLIGHT", "fullsimlight"),
+            cmake_variant("FSL", "fsl"),
+            cmake_variant("EXAMPLES", "examples"),
+            cmake_variant("TOOLS", "tools"),
+        ]
+        return args


### PR DESCRIPTION
This PR adds new versions of Acts through 33.1.0:
- RIP `autodiff`
- RIP `binaries`
- welcome `geomodel`

