### PR TITLE
cairo: 'new' versions 1.18.0, 1.18.2 (now also MesonPackage)

### DIFF
--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -32,10 +32,7 @@ class Cairo(MesonPackage, AutotoolsPackage):
         sha256="6b70d4655e2a47a22b101c666f4b29ba746eda4aa8a0f7255b32b2e9408801df",
         url="https://cairographics.org/snapshots/cairo-1.17.2.tar.xz",
     )  # Snapshot
-    version(
-        "1.16.0",
-        sha256="5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331",
-    )
+    version("1.16.0", sha256="5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331")
     version("1.14.12", sha256="8c90f00c500b2299c0a323dd9beead2a00353752b2092ead558139bd67f7bf16")
     version("1.14.8", sha256="d1f2d98ae9a4111564f6de4e013d639cf77155baf2556582295a0f00a9bc5e20")
     version("1.14.0", sha256="2cf5f81432e77ea4359af9dcd0f4faf37d015934501391c311bfd2d19a0134b7")
@@ -101,7 +98,9 @@ class MesonBuilder(spack.build_systems.meson.MesonBuilder):
             args.extend(["-Dxlib=disabled", "-Dxcb=disabled"])
 
         args.append("-Dzlib=" + ("enabled" if "+pdf" in self.spec else "disabled"))
-        args.append("-Dpng=" + ("enabled" if ("+png" in self.spec or "+svg" in self.spec) else "disabled"))
+        args.append(
+            "-Dpng=" + ("enabled" if ("+png" in self.spec or "+svg" in self.spec) else "disabled")
+        )
         args.append("-Dfreetype=" + ("enabled" if "+ft" in self.spec else "disabled"))
         args.append("-Dfontconfig=" + ("enabled" if "+fc" in self.spec else "disabled"))
         args.append("-Ddefault_library=" + ("shared" if "+shared" in self.spec else "static"))

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -74,6 +74,7 @@ class Cairo(MesonPackage, AutotoolsPackage):
     depends_on("python", when="+X", type="build")
     depends_on("libpng", when="+png")
     depends_on("glib")
+    depends_on("pixman@0.40.0:", when="@1.18.2:")
     depends_on("pixman@0.36.0:", when="@1.17.2:")
     depends_on("pixman")
     depends_on("freetype build_system=autotools", when="+ft")

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -22,6 +22,7 @@ class Cairo(MesonPackage, AutotoolsPackage):
         default="meson",
     )
 
+    version("1.18.2", sha256="a62b9bb42425e844cc3d6ddde043ff39dbabedd1542eba57a2eb79f85889d45a")
     version("1.18.0", sha256="243a0736b978a33dee29f9cca7521733b78a65b5418206fef7bd1c3d4cf10b64")
     # 1.17.8: https://gitlab.freedesktop.org/cairo/cairo/-/issues/646 (we enable tee by default)
     version(

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.autotools
+import spack.build_systems.meson
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -83,6 +83,10 @@ class Cairo(MesonPackage, AutotoolsPackage):
     depends_on("fontconfig@2.10.91:", when="+fc")  # Require newer version of fontconfig.
     depends_on("which", type="build")
     depends_on("zlib", when="+pdf")
+    # lzo is not strictly required, but cannot be disabled and may be pulled in accidentally
+    # https://github.com/mesonbuild/meson/issues/8224
+    # https://github.com/microsoft/vcpkg/pull/38313
+    depends_on("lzo", when="@1.18: build_system=meson")
 
     conflicts("+png", when="platform=darwin")
     conflicts("+svg", when="platform=darwin")

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -15,6 +15,7 @@ class Cairo(MesonPackage, AutotoolsPackage):
 
     license("LGPL-2.1-or-later OR MPL-1.1", checked_by="tgamblin")
 
+    # Cairo has meson.build @1.17.4:, but we only support @1.17.8: here
     build_system(
         conditional("autotools", when="@:1.17.6"),
         conditional("meson", when="@1.17.8:"),
@@ -22,16 +23,22 @@ class Cairo(MesonPackage, AutotoolsPackage):
     )
 
     version("1.18.0", sha256="243a0736b978a33dee29f9cca7521733b78a65b5418206fef7bd1c3d4cf10b64")
+    # 1.17.8: https://gitlab.freedesktop.org/cairo/cairo/-/issues/646 (we enable tee by default)
+    version(
+        "1.17.6",
+        sha256="4eebc4c2bad0402bc3f501db184417094657d111fb6c06f076a82ea191fe1faf",
+        url="https://cairographics.org/snapshots/cairo-1.17.6.tar.xz",
+    )
     version(
         "1.17.4",
         sha256="74b24c1ed436bbe87499179a3b27c43f4143b8676d8ad237a6fa787401959705",
         url="https://cairographics.org/snapshots/cairo-1.17.4.tar.xz",
-    )  # Snapshot
+    )
     version(
         "1.17.2",
         sha256="6b70d4655e2a47a22b101c666f4b29ba746eda4aa8a0f7255b32b2e9408801df",
         url="https://cairographics.org/snapshots/cairo-1.17.2.tar.xz",
-    )  # Snapshot
+    )
     version("1.16.0", sha256="5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331")
     version("1.14.12", sha256="8c90f00c500b2299c0a323dd9beead2a00353752b2092ead558139bd67f7bf16")
     version("1.14.8", sha256="d1f2d98ae9a4111564f6de4e013d639cf77155baf2556582295a0f00a9bc5e20")
@@ -80,7 +87,7 @@ class Cairo(MesonPackage, AutotoolsPackage):
 
     # patch from https://gitlab.freedesktop.org/cairo/cairo/issues/346
     patch("fontconfig.patch", when="@1.16.0:1.17.2")
-    # Don't regenerate docs to avoid a dependency on gtk-doc
+    # Patch autogen.sh to not regenerate docs to avoid a dependency on gtk-doc
     patch("disable-gtk-docs.patch", when="build_system=autotools ^autoconf@2.70:")
 
     def check(self):

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -90,6 +90,7 @@ class Cairo(MesonPackage, AutotoolsPackage):
         """The checks are only for the cairo devs: They write others shouldn't bother"""
         pass
 
+
 class MesonBuilder(spack.build_systems.meson.MesonBuilder):
     def meson_args(self):
         args = ["-Dtee=enabled"]
@@ -99,12 +100,12 @@ class MesonBuilder(spack.build_systems.meson.MesonBuilder):
         else:
             args.extend(["-Dxlib=disabled", "-Dxcb=disabled"])
 
-        args.append("-Dzlib=" + ("enabled" if "pdf" in self.spec else "disabled"))
-        args.append("-Dpng=" + ("enabled" if ("png" in self.spec or "svg" in self.spec) else "disabled"))
-        args.append("-Dfreetype=" + ("enabled" if "ft" in self.spec else "disabled"))
-        args.append("-Dfontconfig=" + ("enabled" if "fc" in self.spec else "disabled"))
-        args.append("-Ddefault_library=" + ("shared" if "shared" in self.spec else "static"))
-        args.append("-Db_staticpic=" + ("true" if "pic" in self.spec else "false"))
+        args.append("-Dzlib=" + ("enabled" if "+pdf" in self.spec else "disabled"))
+        args.append("-Dpng=" + ("enabled" if ("+png" in self.spec or "+svg" in self.spec) else "disabled"))
+        args.append("-Dfreetype=" + ("enabled" if "+ft" in self.spec else "disabled"))
+        args.append("-Dfontconfig=" + ("enabled" if "+fc" in self.spec else "disabled"))
+        args.append("-Ddefault_library=" + ("shared" if "+shared" in self.spec else "static"))
+        args.append("-Db_staticpic=" + ("true" if "+pic" in self.spec else "false"))
 
         return args
 

--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -76,6 +76,9 @@ class Cairo(MesonPackage, AutotoolsPackage):
     depends_on("pixman@0.36.0:", when="@1.17.2:")
     depends_on("pixman")
     depends_on("freetype build_system=autotools", when="+ft")
+    # Require freetype with FT_Color
+    # https://gitlab.freedesktop.org/cairo/cairo/-/issues/792
+    depends_on("freetype@2.10:", when="@1.18.0: +ft")
     depends_on("pkgconfig", type="build")
     depends_on("fontconfig@2.10.91:", when="+fc")  # Require newer version of fontconfig.
     depends_on("which", type="build")


### PR DESCRIPTION
This PR 'adds' cairo version 1.18.0. This is in quotes since the version was there already; it just wasn't buildable. With version 1.18.0 (actually 1.17.6) the build system was switched to meson and no more autotools stuff is inside cairo for 1.18.0. Because 1.16.0 was set as preferred, this was likely not noticed.

Not all options can be trivially translated from autotools to meson. Several are counter-intuitive (like `+pdf` is achieved by ensuring that zlib is installed... and `+svg` and `+png` are identical now... and `+svg` leads to a circular dependency anyway). Main changes:
- `--disable-trace` doesn't have an equivalent,
- freetype LDFLAGS and LIBS is not appended as it was for configure_args.

This builds with meson now, and with identical features in `include/cairo/cairo-features.h`, from 1.17.4 to 1.18.0 with `+X+fc+ft+gobject+pdf+png~svg`.