### PR TITLE
dealii +cuda: conflicts with ^cuda@12:

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -289,6 +289,9 @@ class Dealii(CMakePackage, CudaPackage):
         when="@:9.4 +ginkgo ^ginkgo@1.5.0:",
     )
 
+    # deal.II's own CUDA backend does not support CUDA version 12.0 or newer.
+    conflicts("+cuda ^cuda@12:")
+
     # Check for sufficiently modern versions
     conflicts("cxxstd=11", when="@9.3:")
 


### PR DESCRIPTION
Trying to install `dealii +cuda ^cuda@12:` gives this error:
```
...
CMake Error at cmake/configure/configure_40_cuda.cmake:74 (message): deal.II's own CUDA backend does not support CUDA version 12.0 or newer.
...
```

@jppelteret @luca-heltai 