### PR TITLE
Adding aqlprofile dependency for the opencl tests

### DIFF
--- a/var/spack/repos/builtin/packages/rocm-opencl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-opencl/package.py
@@ -121,6 +121,9 @@ class RocmOpencl(CMakePackage):
         depends_on(f"comgr@{ver}", type="build", when=f"@{ver}")
         depends_on(f"hsa-rocr-dev@{ver}", type="link", when=f"@{ver}")
 
+    for ver in ["6.0.0", "6.0.2"]:
+        depends_on(f"aqlprofile@{ver}", type="link", when=f"@{ver}")
+
     for ver in ["5.5.0", "5.5.1", "5.6.0", "5.6.1", "5.7.0", "5.7.1", "6.0.0", "6.0.2"]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
 


### PR DESCRIPTION
OCLPerfCounters test depends on aqlprofile.
Updating rocm-opencl recipe with aqlprofile dependency.