### PR TITLE
rocm conflicts with compilers that do not support rocm

### DIFF
--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -139,11 +139,6 @@ class CachedCMakeBuilder(CMakeBuilder):
             "endif()\n",
         ]
 
-        # We defined hipcc as top-level compiler for packages when +rocm.
-        # This avoid problems coming from rocm flags being applied to another compiler.
-        if "+rocm" in spec:
-            entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
-
         flags = spec.compiler_flags
 
         # use global spack compiler flags

--- a/lib/spack/spack/build_systems/rocm.py
+++ b/lib/spack/spack/build_systems/rocm.py
@@ -145,7 +145,7 @@ class ROCmPackage(PackageBase):
     depends_on("hip +rocm", when="+rocm")
 
     # need amd gpu type for rocm builds
-    compilers_supporting_rocm = ("cce", "rocmcc")
+    compilers_supporting_rocm = ("cce", "rocmcc", "clang", "aocc")
     conflicts("amdgpu_target=none", when="+rocm")
     # If this variable shadows a property, it overrides it
     for cmp_name in spack.compilers.supported_compilers():

--- a/lib/spack/spack/build_systems/rocm.py
+++ b/lib/spack/spack/build_systems/rocm.py
@@ -145,7 +145,11 @@ class ROCmPackage(PackageBase):
     depends_on("hip +rocm", when="+rocm")
 
     # need amd gpu type for rocm builds
+    compilers_supporting_rocm = ("cce", "rocmcc")
     conflicts("amdgpu_target=none", when="+rocm")
+    for compiler in spack.compilers.supported_compilers():
+        if compiler not in compilers_supporting_rocm:
+            conflicts(f"%{compiler}", when="+rocm")
 
     # https://github.com/ROCm-Developer-Tools/HIP/blob/master/bin/hipcc
     # It seems that hip-clang does not (yet?) accept this flag, in which case

--- a/lib/spack/spack/build_systems/rocm.py
+++ b/lib/spack/spack/build_systems/rocm.py
@@ -147,9 +147,10 @@ class ROCmPackage(PackageBase):
     # need amd gpu type for rocm builds
     compilers_supporting_rocm = ("cce", "rocmcc")
     conflicts("amdgpu_target=none", when="+rocm")
-    for compiler in spack.compilers.supported_compilers():
-        if compiler not in compilers_supporting_rocm:
-            conflicts(f"%{compiler}", when="+rocm")
+    # If this variable shadows a property, it overrides it
+    for cmp_name in spack.compilers.supported_compilers():
+        if cmp_name not in compilers_supporting_rocm:
+            conflicts(f"%{cmp_name}", when="+rocm")
 
     # https://github.com/ROCm-Developer-Tools/HIP/blob/master/bin/hipcc
     # It seems that hip-clang does not (yet?) accept this flag, in which case

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -18,23 +18,23 @@
 { attr("virtual_node", node(0..X-1, Package)) } :- max_dupes(Package, X), virtual(Package).
 
 % Integrity constraints on DAG nodes
-:- attr("root", PackageNode), not attr("node", PackageNode).
-:- attr("version", PackageNode, _), not attr("node", PackageNode), not attr("virtual_node", PackageNode).
-:- attr("node_version_satisfies", PackageNode, _), not attr("node", PackageNode), not attr("virtual_node", PackageNode).
-:- attr("hash", PackageNode, _), not attr("node", PackageNode).
-:- attr("node_platform", PackageNode, _), not attr("node", PackageNode).
-:- attr("node_os", PackageNode, _), not attr("node", PackageNode).
-:- attr("node_target", PackageNode, _), not attr("node", PackageNode).
-:- attr("node_compiler_version", PackageNode, _, _), not attr("node", PackageNode).
-:- attr("variant_value", PackageNode, _, _), not attr("node", PackageNode).
-:- attr("node_flag_compiler_default", PackageNode), not attr("node", PackageNode).
-:- attr("node_flag", PackageNode, _, _), not attr("node", PackageNode).
-:- attr("no_flags", PackageNode, _), not attr("node", PackageNode).
-:- attr("external_spec_selected", PackageNode, _), not attr("node", PackageNode).
-:- attr("depends_on", ParentNode, _, _), not attr("node", ParentNode).
-:- attr("depends_on", _, ChildNode, _), not attr("node", ChildNode).
-:- attr("node_flag_source", ParentNode, _, _), not attr("node", ParentNode).
-:- attr("node_flag_source", _, _, ChildNode), not attr("node", ChildNode).
+:- attr("root", PackageNode), not attr("node", PackageNode), internal_error("root without node").
+:- attr("version", PackageNode, _), not attr("node", PackageNode), not attr("virtual_node", PackageNode), internal_error("version without node").
+:- attr("node_version_satisfies", PackageNode, _), not attr("node", PackageNode), not attr("virtual_node", PackageNode), internal_error("version satisfies without node").
+:- attr("hash", PackageNode, _), not attr("node", PackageNode), internal_error("hash without node").
+:- attr("node_platform", PackageNode, _), not attr("node", PackageNode), internal_error("platform without node").
+:- attr("node_os", PackageNode, _), not attr("node", PackageNode), internal_error("os without node").
+:- attr("node_target", PackageNode, _), not attr("node", PackageNode), internal_error("target without node").
+:- attr("node_compiler_version", PackageNode, _, _), not attr("node", PackageNode), internal_error("compiler without node").
+:- attr("variant_value", PackageNode, _, _), not attr("node", PackageNode), internal_error("variant without node").
+:- attr("node_flag_compiler_default", PackageNode), not attr("node", PackageNode), internal_error("compiler flag default without node").
+:- attr("node_flag", PackageNode, _, _), not attr("node", PackageNode), internal_error("compiler flag without node").
+:- attr("no_flags", PackageNode, _), not attr("node", PackageNode), internal_error("empty compiler flag without node").
+:- attr("external_spec_selected", PackageNode, _), not attr("node", PackageNode), internal_error("external spec without node").
+:- attr("depends_on", ParentNode, _, _), not attr("node", ParentNode), internal_error("depends on without node for parent").
+- attr("depends_on", _, ChildNode, _), not attr("node", ChildNode), internal_error("depends on without node for child").
+:- attr("node_flag_source", ParentNode, _, _), not attr("node", ParentNode), internal_error("node flag source without flag node").
+:- attr("node_flag_source", _, _, ChildNode), not attr("node", ChildNode), internal_error("node flag source without source node").
 :- attr("virtual_node", VirtualNode), not provider(_, VirtualNode), internal_error("virtual node with no provider").
 :- provider(_, VirtualNode), not attr("virtual_node", VirtualNode), internal_error("provider with no virtual node").
 :- provider(PackageNode, _), not attr("node", PackageNode), internal_error("provider with no real node").

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -32,7 +32,7 @@
 :- attr("no_flags", PackageNode, _), not attr("node", PackageNode), internal_error("empty compiler flag without node").
 :- attr("external_spec_selected", PackageNode, _), not attr("node", PackageNode), internal_error("external spec without node").
 :- attr("depends_on", ParentNode, _, _), not attr("node", ParentNode), internal_error("depends on without node for parent").
-- attr("depends_on", _, ChildNode, _), not attr("node", ChildNode), internal_error("depends on without node for child").
+:- attr("depends_on", _, ChildNode, _), not attr("node", ChildNode), internal_error("depends on without node for child").
 :- attr("node_flag_source", ParentNode, _, _), not attr("node", ParentNode), internal_error("node flag source without flag node").
 :- attr("node_flag_source", _, _, ChildNode), not attr("node", ChildNode), internal_error("node flag source without source node").
 :- attr("virtual_node", VirtualNode), not provider(_, VirtualNode), internal_error("virtual node with no provider").

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -143,9 +143,12 @@ spack:
       - spec: llvm-amdgpu@5.7.1
         prefix: /opt/rocm-5.7.1/llvm
         extra_attributes:
-          compilers:
-            c: /opt/rocm-5.7.1/llvm/bin/clang++
-            cxx: /opt/rocm-5.7.1/llvm/bin/clang++
+          # These will change to new cleaner format soon
+          paths:
+            cc: /opt/rocm-5.7.1/bin/amdclang
+            cxx: /opt/rocm-5.7.1/bin/amdclang++
+            fc: /opt/rocm-5.7.1/bin/amdflang
+            f77: /opt/rocm-5.7.1/bin/amdflang
     hsakmt-roct:
       buildable: false
       externals:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -7,7 +7,10 @@ spack:
 
   packages:
     all:
-      require: '%gcc target=x86_64_v3'
+      require:
+      - one_of:
+        - '%gcc target=x86_64_v3'
+        - '+rocm %rocmcc target=x86_64_v3'
       providers:
         blas: [openblas]
       variants: +mpi
@@ -259,7 +262,7 @@ spack:
   - chai +rocm amdgpu_target=gfx90a
   # - cp2k +mpi +rocm amdgpu_target=gfx90a # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
   - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx90a
-  - exago +mpi +python +raja +hiop +rocm amdgpu_target=gfx90a ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target=gfx90a  
+  - exago +mpi +python +raja +hiop +rocm amdgpu_target=gfx90a ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target=gfx90a
   - gasnet +rocm amdgpu_target=gfx90a
   - ginkgo +rocm amdgpu_target=gfx90a
   - heffte +rocm amdgpu_target=gfx90a

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -11,6 +11,8 @@ spack:
       - one_of:
         - '%gcc target=x86_64_v3'
         - '+rocm %rocmcc target=x86_64_v3'
+      - spec: '+rocm'
+        when: 'rocm=*'
       providers:
         blas: [openblas]
       variants: +mpi

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -8,11 +8,11 @@ spack:
   packages:
     all:
       require:
-#      - one_of:
-#        - '%gcc target=x86_64_v3'
-      - '%rocmcc target=x86_64_v3'
-#      - spec: '+rocm'
-#        when: 'rocm=*'
+      - one_of:
+        - '%gcc target=x86_64_v3'
+        - '%rocmcc target=x86_64_v3'
+      - spec: '+rocm'
+        when: 'rocm=*'
       providers:
         blas: [openblas]
       variants: +mpi
@@ -227,7 +227,7 @@ spack:
   - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target==gfx908
   - exago +mpi +python +raja +hiop +rocm amdgpu_target==gfx908 ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target==gfx908
   - gasnet +rocm amdgpu_target==gfx908
-  - ginkgo +rocm amdgpu_target==gfx908
+#  - ginkgo +rocm amdgpu_target==gfx908
   - heffte +rocm amdgpu_target==gfx908
   - hpx +rocm amdgpu_target==gfx908
   - hypre +rocm amdgpu_target==gfx908

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -261,7 +261,7 @@ spack:
   - matrix:
     - [$per_arch_specs]
     - [++rocm]
-    - [amdgpu_target==gfx908, amgdpu_target==gfx90a]
+    - [amdgpu_target==gfx908, amdgpu_target==gfx90a]
 
   ci:
     pipeline-gen:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -183,7 +183,12 @@ spack:
     rocrand:
       buildable: false
       externals:
-      - spec: rocrand@5.7.1
+      - spec: rocrand@5.7.1 amdgpu_target=gfx908,gfx90a
+        prefix: /opt/rocm-5.7.1
+    hiprand:
+      buildable: false
+      externals:
+      - spec: hiprand@5.7.1 amdgpu_target=gfx908,gfx90a
         prefix: /opt/rocm-5.7.1
     hipsolver:
       buildable: false

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -8,11 +8,11 @@ spack:
   packages:
     all:
       require:
-      - one_of:
-        - '%gcc target=x86_64_v3'
-        - '+rocm %rocmcc target=x86_64_v3'
-      - spec: '+rocm'
-        when: 'rocm=*'
+#      - one_of:
+#        - '%gcc target=x86_64_v3'
+      - '%rocmcc target=x86_64_v3'
+#      - spec: '+rocm'
+#        when: 'rocm=*'
       providers:
         blas: [openblas]
       variants: +mpi

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -211,94 +211,57 @@ spack:
       - spec: rocprofiler-dev@5.7.1
         prefix: /opt/rocm-5.7.1
 
+  definitions:
+  - per_arch_specs:
+    - adios2 +kokkos
+    - amrex
+    - arborx
+    - cabana
+    - caliper
+    - chai
+    # - cp2k +mpi  # cptk: Error KeyError: 'No spec with name rocm in ... "-L{}".format(spec["rocm"].libs.directories[0])
+    - ecp-data-vis-sdk +paraview +vtkm
+    - exago +mpi +python +raja +hiop ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop ~sparse +mpi +raja
+    - gasnet
+    - ginkgo
+    - heffte
+    - hpx
+    - hypre
+    - kokkos
+    - legion
+    - magma ~cuda
+    - mfem
+    - petsc
+    - raja ~openmp
+    # - slate  # slate: hip/device_gescale_row_col.hip.cc:58:49: error: use of overloaded operator '*' is ambiguous (with operand types 'HIP_vector_type<double, 2>' and 'const HIP_vector_type<double, 2>')
+    - slepc
+    - strumpack ~slate
+    - sundials
+    - superlu-dist
+    - tasmanian ~openmp
+    - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack ~ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu ~stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
+    - umpire
+    - upcxx
+    # INCLUDED IN ECP DAV ROCM
+    # - hdf5
+    # - hdf5-vol-async
+    # - hdf5-vol-cache
+    # - hdf5-vol-log
+    # - libcatalyst
+    - paraview
+    # vtk-m ~openmp  # vtk-m: https://github.com/spack/spack/issues/40268
+    # --
+    # - lbann ~cuda  # aluminum: https://github.com/spack/spack/issues/38807
+    # - papi  # papi: https://github.com/spack/spack/issues/27898
+
   specs:
   # ROCM NOARCH
-  - hpctoolkit +rocm
-  - tau +mpi +rocm +syscall  # tau: has issue with `spack env depfile` build
-
-  # ROCM 908
-  - adios2 +kokkos +rocm amdgpu_target==gfx908
-  - amrex +rocm amdgpu_target==gfx908
-  - arborx +rocm amdgpu_target==gfx908
-  - cabana +rocm amdgpu_target==gfx908
-  - caliper +rocm amdgpu_target==gfx908
-  - chai +rocm amdgpu_target==gfx908
-  # - cp2k +mpi +rocm amdgpu_target==gfx908 # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
-  - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target==gfx908
-  - exago +mpi +python +raja +hiop +rocm amdgpu_target==gfx908 ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target==gfx908
-  - gasnet +rocm amdgpu_target==gfx908
-#  - ginkgo +rocm amdgpu_target==gfx908
-  - heffte +rocm amdgpu_target==gfx908
-  - hpx +rocm amdgpu_target==gfx908
-  - hypre +rocm amdgpu_target==gfx908
-  - kokkos +rocm amdgpu_target==gfx908
-  - legion +rocm amdgpu_target==gfx908
-  - magma ~cuda +rocm amdgpu_target==gfx908
-  - mfem +rocm amdgpu_target==gfx908
-  - petsc +rocm amdgpu_target==gfx908
-  - raja ~openmp +rocm amdgpu_target==gfx908
-  # - slate +rocm amdgpu_target==gfx908          # slate: hip/device_gescale_row_col.hip.cc:58:49: error: use of overloaded operator '*' is ambiguous (with operand types 'HIP_vector_type<double, 2>' and 'const HIP_vector_type<double, 2>')
-  - slepc +rocm amdgpu_target==gfx908 ^petsc +rocm amdgpu_target==gfx908
-  - strumpack ~slate +rocm amdgpu_target==gfx908
-  - sundials +rocm amdgpu_target==gfx908
-  - superlu-dist +rocm amdgpu_target==gfx908
-  - tasmanian ~openmp +rocm amdgpu_target==gfx908
-  - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack ~ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu ~stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long +rocm amdgpu_target==gfx908
-  - umpire +rocm amdgpu_target==gfx908
-  - upcxx +rocm amdgpu_target==gfx908
-  # INCLUDED IN ECP DAV ROCM
-  # - hdf5
-  # - hdf5-vol-async
-  # - hdf5-vol-cache
-  # - hdf5-vol-log
-  # - libcatalyst
-  - paraview +rocm amdgpu_target==gfx908
-  # - vtk-m ~openmp +rocm amdgpu_target==gfx908  # vtk-m: https://github.com/spack/spack/issues/40268
-  # --
-  # - lbann ~cuda +rocm amdgpu_target==gfx908    # aluminum: https://github.com/spack/spack/issues/38807
-  # - papi +rocm amdgpu_target==gfx908           # papi: https://github.com/spack/spack/issues/27898
-
-  # ROCM 90a
-  - adios2 +kokkos +rocm amdgpu_target==gfx90a
-  - amrex +rocm amdgpu_target==gfx90a
-  - arborx +rocm amdgpu_target==gfx90a
-  - cabana +rocm amdgpu_target==gfx90a
-  - caliper +rocm amdgpu_target==gfx90a
-  - chai +rocm amdgpu_target==gfx90a
-  # - cp2k +mpi +rocm amdgpu_target==gfx90a # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
-  - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target==gfx90a
-  - exago +mpi +python +raja +hiop +rocm amdgpu_target==gfx90a ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target==gfx90a
-  - gasnet +rocm amdgpu_target==gfx90a
-  - ginkgo +rocm amdgpu_target==gfx90a
-  - heffte +rocm amdgpu_target==gfx90a
-  - hpx +rocm amdgpu_target==gfx90a
-  - hypre +rocm amdgpu_target==gfx90a
-  - kokkos +rocm amdgpu_target==gfx90a
-  - legion +rocm amdgpu_target==gfx90a
-  - magma ~cuda +rocm amdgpu_target==gfx90a
-  - mfem +rocm amdgpu_target==gfx90a
-  - petsc +rocm amdgpu_target==gfx90a
-  - raja ~openmp +rocm amdgpu_target==gfx90a
-  # - slate +rocm amdgpu_target==gfx90a          # slate: hip/device_gescale_row_col.hip.cc:58:49: error: use of overloaded operator '*' is ambiguous (with operand types 'HIP_vector_type<double, 2>' and 'const HIP_vector_type<double, 2>')
-  - slepc +rocm amdgpu_target==gfx90a ^petsc +rocm amdgpu_target==gfx90a
-  - strumpack ~slate +rocm amdgpu_target==gfx90a
-  - sundials +rocm amdgpu_target==gfx90a
-  - superlu-dist +rocm amdgpu_target==gfx90a
-  - tasmanian ~openmp +rocm amdgpu_target==gfx90a
-  - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack ~ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu ~stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long +rocm amdgpu_target==gfx90a
-  - umpire +rocm amdgpu_target==gfx90a
-  - upcxx +rocm amdgpu_target==gfx90a
-  # INCLUDED IN ECP DAV ROCM
-  # - hdf5
-  # - hdf5-vol-async
-  # - hdf5-vol-cache
-  # - hdf5-vol-log
-  # - libcatalyst
-  - paraview +rocm amdgpu_target==gfx90a
-  # - vtk-m ~openmp +rocm amdgpu_target==gfx90a  # vtk-m: https://github.com/spack/spack/issues/40268
-  # --
-  # - lbann ~cuda +rocm amdgpu_target==gfx90a    # aluminum: https://github.com/spack/spack/issues/38807
-  # - papi +rocm amdgpu_target==gfx90a           # papi: https://github.com/spack/spack/issues/27898
+  - hpctoolkit ++rocm
+  - tau +mpi ++rocm +syscall  # tau: has issue with `spack env depfile` build
+  - matrix:
+    - [$per_arch_specs]
+    - [++rocm]
+    - [amdgpu_target==gfx908, amgdpu_target==gfx90a]
 
   ci:
     pipeline-gen:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -217,88 +217,88 @@ spack:
   - tau +mpi +rocm +syscall  # tau: has issue with `spack env depfile` build
 
   # ROCM 908
-  - adios2 +kokkos +rocm amdgpu_target=gfx908
-  - amrex +rocm amdgpu_target=gfx908
-  - arborx +rocm amdgpu_target=gfx908
-  - cabana +rocm amdgpu_target=gfx908
-  - caliper +rocm amdgpu_target=gfx908
-  - chai +rocm amdgpu_target=gfx908
-  # - cp2k +mpi +rocm amdgpu_target=gfx908 # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
-  - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx908
-  - exago +mpi +python +raja +hiop +rocm amdgpu_target=gfx908 ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target=gfx908
-  - gasnet +rocm amdgpu_target=gfx908
-  - ginkgo +rocm amdgpu_target=gfx908
-  - heffte +rocm amdgpu_target=gfx908
-  - hpx +rocm amdgpu_target=gfx908
-  - hypre +rocm amdgpu_target=gfx908
-  - kokkos +rocm amdgpu_target=gfx908
-  - legion +rocm amdgpu_target=gfx908
-  - magma ~cuda +rocm amdgpu_target=gfx908
-  - mfem +rocm amdgpu_target=gfx908
-  - petsc +rocm amdgpu_target=gfx908
-  - raja ~openmp +rocm amdgpu_target=gfx908
-  # - slate +rocm amdgpu_target=gfx908          # slate: hip/device_gescale_row_col.hip.cc:58:49: error: use of overloaded operator '*' is ambiguous (with operand types 'HIP_vector_type<double, 2>' and 'const HIP_vector_type<double, 2>')
-  - slepc +rocm amdgpu_target=gfx908 ^petsc +rocm amdgpu_target=gfx908
-  - strumpack ~slate +rocm amdgpu_target=gfx908
-  - sundials +rocm amdgpu_target=gfx908
-  - superlu-dist +rocm amdgpu_target=gfx908
-  - tasmanian ~openmp +rocm amdgpu_target=gfx908
-  - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack ~ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu ~stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long +rocm amdgpu_target=gfx908
-  - umpire +rocm amdgpu_target=gfx908
-  - upcxx +rocm amdgpu_target=gfx908
+  - adios2 +kokkos +rocm amdgpu_target==gfx908
+  - amrex +rocm amdgpu_target==gfx908
+  - arborx +rocm amdgpu_target==gfx908
+  - cabana +rocm amdgpu_target==gfx908
+  - caliper +rocm amdgpu_target==gfx908
+  - chai +rocm amdgpu_target==gfx908
+  # - cp2k +mpi +rocm amdgpu_target==gfx908 # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
+  - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target==gfx908
+  - exago +mpi +python +raja +hiop +rocm amdgpu_target==gfx908 ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target==gfx908
+  - gasnet +rocm amdgpu_target==gfx908
+  - ginkgo +rocm amdgpu_target==gfx908
+  - heffte +rocm amdgpu_target==gfx908
+  - hpx +rocm amdgpu_target==gfx908
+  - hypre +rocm amdgpu_target==gfx908
+  - kokkos +rocm amdgpu_target==gfx908
+  - legion +rocm amdgpu_target==gfx908
+  - magma ~cuda +rocm amdgpu_target==gfx908
+  - mfem +rocm amdgpu_target==gfx908
+  - petsc +rocm amdgpu_target==gfx908
+  - raja ~openmp +rocm amdgpu_target==gfx908
+  # - slate +rocm amdgpu_target==gfx908          # slate: hip/device_gescale_row_col.hip.cc:58:49: error: use of overloaded operator '*' is ambiguous (with operand types 'HIP_vector_type<double, 2>' and 'const HIP_vector_type<double, 2>')
+  - slepc +rocm amdgpu_target==gfx908 ^petsc +rocm amdgpu_target==gfx908
+  - strumpack ~slate +rocm amdgpu_target==gfx908
+  - sundials +rocm amdgpu_target==gfx908
+  - superlu-dist +rocm amdgpu_target==gfx908
+  - tasmanian ~openmp +rocm amdgpu_target==gfx908
+  - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack ~ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu ~stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long +rocm amdgpu_target==gfx908
+  - umpire +rocm amdgpu_target==gfx908
+  - upcxx +rocm amdgpu_target==gfx908
   # INCLUDED IN ECP DAV ROCM
   # - hdf5
   # - hdf5-vol-async
   # - hdf5-vol-cache
   # - hdf5-vol-log
   # - libcatalyst
-  - paraview +rocm amdgpu_target=gfx908
-  # - vtk-m ~openmp +rocm amdgpu_target=gfx908  # vtk-m: https://github.com/spack/spack/issues/40268
+  - paraview +rocm amdgpu_target==gfx908
+  # - vtk-m ~openmp +rocm amdgpu_target==gfx908  # vtk-m: https://github.com/spack/spack/issues/40268
   # --
-  # - lbann ~cuda +rocm amdgpu_target=gfx908    # aluminum: https://github.com/spack/spack/issues/38807
-  # - papi +rocm amdgpu_target=gfx908           # papi: https://github.com/spack/spack/issues/27898
+  # - lbann ~cuda +rocm amdgpu_target==gfx908    # aluminum: https://github.com/spack/spack/issues/38807
+  # - papi +rocm amdgpu_target==gfx908           # papi: https://github.com/spack/spack/issues/27898
 
   # ROCM 90a
-  - adios2 +kokkos +rocm amdgpu_target=gfx90a
-  - amrex +rocm amdgpu_target=gfx90a
-  - arborx +rocm amdgpu_target=gfx90a
-  - cabana +rocm amdgpu_target=gfx90a
-  - caliper +rocm amdgpu_target=gfx90a
-  - chai +rocm amdgpu_target=gfx90a
-  # - cp2k +mpi +rocm amdgpu_target=gfx90a # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
-  - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx90a
-  - exago +mpi +python +raja +hiop +rocm amdgpu_target=gfx90a ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target=gfx90a
-  - gasnet +rocm amdgpu_target=gfx90a
-  - ginkgo +rocm amdgpu_target=gfx90a
-  - heffte +rocm amdgpu_target=gfx90a
-  - hpx +rocm amdgpu_target=gfx90a
-  - hypre +rocm amdgpu_target=gfx90a
-  - kokkos +rocm amdgpu_target=gfx90a
-  - legion +rocm amdgpu_target=gfx90a
-  - magma ~cuda +rocm amdgpu_target=gfx90a
-  - mfem +rocm amdgpu_target=gfx90a
-  - petsc +rocm amdgpu_target=gfx90a
-  - raja ~openmp +rocm amdgpu_target=gfx90a
-  # - slate +rocm amdgpu_target=gfx90a          # slate: hip/device_gescale_row_col.hip.cc:58:49: error: use of overloaded operator '*' is ambiguous (with operand types 'HIP_vector_type<double, 2>' and 'const HIP_vector_type<double, 2>')
-  - slepc +rocm amdgpu_target=gfx90a ^petsc +rocm amdgpu_target=gfx90a
-  - strumpack ~slate +rocm amdgpu_target=gfx90a
-  - sundials +rocm amdgpu_target=gfx90a
-  - superlu-dist +rocm amdgpu_target=gfx90a
-  - tasmanian ~openmp +rocm amdgpu_target=gfx90a
-  - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack ~ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu ~stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long +rocm amdgpu_target=gfx90a
-  - umpire +rocm amdgpu_target=gfx90a
-  - upcxx +rocm amdgpu_target=gfx90a
+  - adios2 +kokkos +rocm amdgpu_target==gfx90a
+  - amrex +rocm amdgpu_target==gfx90a
+  - arborx +rocm amdgpu_target==gfx90a
+  - cabana +rocm amdgpu_target==gfx90a
+  - caliper +rocm amdgpu_target==gfx90a
+  - chai +rocm amdgpu_target==gfx90a
+  # - cp2k +mpi +rocm amdgpu_target==gfx90a # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
+  - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target==gfx90a
+  - exago +mpi +python +raja +hiop +rocm amdgpu_target==gfx90a ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target==gfx90a
+  - gasnet +rocm amdgpu_target==gfx90a
+  - ginkgo +rocm amdgpu_target==gfx90a
+  - heffte +rocm amdgpu_target==gfx90a
+  - hpx +rocm amdgpu_target==gfx90a
+  - hypre +rocm amdgpu_target==gfx90a
+  - kokkos +rocm amdgpu_target==gfx90a
+  - legion +rocm amdgpu_target==gfx90a
+  - magma ~cuda +rocm amdgpu_target==gfx90a
+  - mfem +rocm amdgpu_target==gfx90a
+  - petsc +rocm amdgpu_target==gfx90a
+  - raja ~openmp +rocm amdgpu_target==gfx90a
+  # - slate +rocm amdgpu_target==gfx90a          # slate: hip/device_gescale_row_col.hip.cc:58:49: error: use of overloaded operator '*' is ambiguous (with operand types 'HIP_vector_type<double, 2>' and 'const HIP_vector_type<double, 2>')
+  - slepc +rocm amdgpu_target==gfx90a ^petsc +rocm amdgpu_target==gfx90a
+  - strumpack ~slate +rocm amdgpu_target==gfx90a
+  - sundials +rocm amdgpu_target==gfx90a
+  - superlu-dist +rocm amdgpu_target==gfx90a
+  - tasmanian ~openmp +rocm amdgpu_target==gfx90a
+  - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack ~ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu ~stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long +rocm amdgpu_target==gfx90a
+  - umpire +rocm amdgpu_target==gfx90a
+  - upcxx +rocm amdgpu_target==gfx90a
   # INCLUDED IN ECP DAV ROCM
   # - hdf5
   # - hdf5-vol-async
   # - hdf5-vol-cache
   # - hdf5-vol-log
   # - libcatalyst
-  - paraview +rocm amdgpu_target=gfx90a
-  # - vtk-m ~openmp +rocm amdgpu_target=gfx90a  # vtk-m: https://github.com/spack/spack/issues/40268
+  - paraview +rocm amdgpu_target==gfx90a
+  # - vtk-m ~openmp +rocm amdgpu_target==gfx90a  # vtk-m: https://github.com/spack/spack/issues/40268
   # --
-  # - lbann ~cuda +rocm amdgpu_target=gfx90a    # aluminum: https://github.com/spack/spack/issues/38807
-  # - papi +rocm amdgpu_target=gfx90a           # papi: https://github.com/spack/spack/issues/27898
+  # - lbann ~cuda +rocm amdgpu_target==gfx90a    # aluminum: https://github.com/spack/spack/issues/38807
+  # - papi +rocm amdgpu_target==gfx90a           # papi: https://github.com/spack/spack/issues/27898
 
   ci:
     pipeline-gen:

--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -224,7 +224,7 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
         "+rocm", when="@:20.11", msg="AMReX HIP support needs AMReX newer than version 20.11"
     )
     conflicts(
-        "%rocm@4.2.0:4.2",
+        "%rocmcc@4.2.0:4.2",
         when="+rocm",
         msg="AMReX does not support rocm-4.2 due to a compiler bug",
     )


### PR DESCRIPTION
In #41375 we introduced a bug that rocm packages using `CachedCMakePackage` cannot build with non-hipcc compiler executables. Reading the discussion there and in discussions with @white238, it seems that the line causing the bug was added to address the problem that most compilers do not support the hip language.

In this PR, we introduce a conflict between the `+rocm` variant in `RocmPackage` and each of the compilers that does not support the hip language. That allows us to remove the line causing the problems without reintroducing the bug that it fixed.

@adrienbernede does this address the concerns you had with mixing compilers in #41375 sufficiently?
