### PR TITLE
dealii@9.5 +cgal requires ^cgal@5:

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -177,6 +177,7 @@ class Dealii(CMakePackage, CudaPackage):
     depends_on("arpack-ng+mpi", when="+arpack+mpi")
     depends_on("assimp", when="@9.0:+assimp")
     depends_on("cgal", when="@9.4:+cgal")
+    depends_on("cgal@5:", when="@9.5:+cgal")
     depends_on("doxygen+graphviz", when="+doc")
     depends_on("graphviz", when="+doc")
     depends_on("ginkgo", when="@9.1:+ginkgo")


### PR DESCRIPTION
Fix cgal version constraint for `dealii +cgal`

Do you know more about the requirement here? What do you think @jppelteret @luca-heltai?

Without this PR, trying to build for instance `dealii@9.5.1 +cgal ^cgal@4.13` yields this error:
```
1 error found in build log:
     712    -- Boost libraries:
     713    -- CGAL wrappers require CGAL version 5 and above.
     714    -- Processing CGAL variables and targets
     715    --   CGAL_INCLUDE_DIRS: *** Required variable "CGAL_INCLUDE_DIRS" set to NOTFOUND ***
     716    -- Unable to process CGAL
     717    -- DEAL_II_WITH_CGAL has unmet external dependencies.
  >> 718    CMake Error at cmake/macros/macro_configure_feature.cmake:112 (message):
     719
     720
     721      Could not find the cgal library!
     722
     723      Please ensure that a suitable cgal library is installed on your computer.
     724
```