### PR TITLE
geant4: extend patch for 10.6 to 10.0+

### DIFF
--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -162,7 +162,7 @@ class Geant4(CMakePackage):
     patch("CLHEP-10.03.03.patch", level=1, when="@10.3")
     # Build failure on clang 15, ubuntu 22: see Geant4 problem report #2444
     # fixed by ascii-V10-07-03
-    patch("geant4-10.6.patch", level=1, when="@10.5:10.6")
+    patch("geant4-10.6.patch", level=1, when="@10.0:10.6")
     # These patches can be applied independent of the cxxstd value?
     patch("cxx17.patch", when="@10.3 cxxstd=17")
     patch("cxx17_geant4_10_0.patch", level=1, when="@10.4.0 cxxstd=17")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Extends the work of https://github.com/spack/spack/pull/43212. I was able to build geant4.10.04 successfully with gcc12. The file modified by this patch remained unmodified between v10.0-10.7, so the patch should be safe for all these versions.