### PR TITLE
CachedCMakePackage: remove hardcoded hipcc

### DIFF
--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -139,11 +139,6 @@ class CachedCMakeBuilder(CMakeBuilder):
             "endif()\n",
         ]
 
-        # We defined hipcc as top-level compiler for packages when +rocm.
-        # This avoid problems coming from rocm flags being applied to another compiler.
-        if "+rocm" in spec:
-            entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
-
         flags = spec.compiler_flags
 
         # use global spack compiler flags


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This was in multiple packages in a place that had no impact due to cache variables being immutable in CMake. It got moved into a common location but higher in the generated CMake initial cache.

This should not be hardcoded due to wanting to use `crayCC`, `amdclang++`, or `hipcc` as your ROCM compiler.