### PR TITLE
Windows: Update MSVC + oneAPI detection and integration

### DIFF
--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -189,7 +189,7 @@ class Msvc(Compiler):
         # for a fortran compiler
         if paths[2]:
             # If this found, it sets all the vars
-            oneapi_root = os.path.join(self.cc, "../../..")
+            oneapi_root = os.path.join(self.fc, "../../..")
             oneapi_root_setvars = os.path.join(oneapi_root, "setvars.bat")
             oneapi_version_setvars = os.path.join(
                 oneapi_root, "compiler", str(self.ifx_version), "env", "vars.bat"

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -111,12 +111,9 @@ def get_valid_fortran_pth():
     """Assign maximum available fortran compiler version"""
     # TODO (johnwparent): validate compatibility w/ try compiler
     # functionality when added
-    valid_fortran_path = None
-    if FC_PATH.get(""):
-        sort_fn = lambda fc_ver: Version(fc_ver)
-        sort_fc_ver = sorted(list(FC_PATH.keys()), key=sort_fn)
-        valid_fortran_path = FC_PATH[sort_fc_ver[-1]]
-    return valid_fortran_path
+    sort_fn = lambda fc_ver: Version(fc_ver)
+    sort_fc_ver = sorted(list(FC_PATH.keys()), key=sort_fn)
+    return FC_PATH[sort_fc_ver[-1]] if sort_fc_ver else None
 
 
 class Msvc(Compiler):

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -325,8 +325,6 @@ class Msvc(Compiler):
 
     @classmethod
     def fc_version(cls, fc):
-        # We're using intel for the Fortran compilers, which exist if
-        # ONEAPI_ROOT is a meaningful variable
         if not sys.platform == "win32":
             return "unknown"
         fc_ver = cls.default_version(fc)

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -213,7 +213,8 @@ class Msvc(Compiler):
             oneapi_root_setvars = os.path.join(oneapi_root, "setvars.bat")
             # some oneAPI versions return a version more precise than their
             # install paths
-            version_from_path = re.search(r"([1-9][0-9]*\.[0-9]*(?:\.[0-9])*)", self.fc).group(1)
+            version_from_path_grp = re.search(r"([1-9][0-9]*\.[0-9]*(?:\.[0-9])*)", self.fc)
+            version_from_path = "latest" if not version_from_path_grp else version_from_path_grp.group(1)
             oneapi_version_setvars = os.path.join(
                 oneapi_root, "compiler", version_from_path, "env", "vars.bat"
             )

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -321,15 +321,14 @@ class Msvc(Compiler):
         fc_ver = cls.default_version(fc)
         avail_fc_version.add(fc_ver)
         fc_path[fc_ver] = fc
-        if os.getenv("ONEAPI_ROOT"):
-            try:
-                sps = spack.operating_systems.windows_os.WindowsOs().compiler_search_paths
-            except AttributeError:
-                raise SpackError("Windows compiler search paths not established")
-            clp = spack.util.executable.which_string("cl", path=sps)
+        ver = fc_ver
+        try:
+            sps = spack.operating_systems.windows_os.WindowsOs().compiler_search_paths
+        except AttributeError:
+            raise SpackError("Windows compiler search paths not established")
+        clp = spack.util.executable.which_string("cl", path=sps)
+        if clp:
             ver = cls.default_version(clp)
-        else:
-            ver = fc_ver
         return ver
 
     @classmethod

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -8,7 +8,7 @@ import re
 import subprocess
 import sys
 import tempfile
-from typing import Dict, List, Set
+from typing import Dict, List
 
 import archspec.cpu
 

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -191,6 +191,7 @@ class Msvc(Compiler):
         # paths[2] refers to the fc path and is a generic check
         # for a fortran compiler
         if paths[2]:
+
             def get_oneapi_root(pth: str):
                 """From within a prefix known to be a oneAPI path
                 determine the oneAPI root path from arbitrary point
@@ -200,10 +201,11 @@ class Msvc(Compiler):
                     pth: path prefixed within oneAPI root
                 """
                 if not pth or not os.path.basename(pth):
-                    return ''
+                    return ""
                 if os.path.basename(pth) == "oneAPI":
                     return pth
                 return get_oneapi_root(os.path.dirname(pth))
+
             # If this found, it sets all the vars
             oneapi_root = get_oneapi_root(self.fc)
             if not oneapi_root:

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -214,7 +214,9 @@ class Msvc(Compiler):
             # some oneAPI versions return a version more precise than their
             # install paths
             version_from_path_grp = re.search(r"([1-9][0-9]*\.[0-9]*(?:\.[0-9])*)", self.fc)
-            version_from_path = "latest" if not version_from_path_grp else version_from_path_grp.group(1)
+            version_from_path = (
+                "latest" if not version_from_path_grp else version_from_path_grp.group(1)
+            )
             oneapi_version_setvars = os.path.join(
                 oneapi_root, "compiler", version_from_path, "env", "vars.bat"
             )

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -209,8 +209,11 @@ class Msvc(Compiler):
             if not oneapi_root:
                 raise RuntimeError(f"Non oneAPI Fortran compiler {self.fc} assigned to MSVC")
             oneapi_root_setvars = os.path.join(oneapi_root, "setvars.bat")
+            # some oneAPI versions return a version more precise than their
+            # install paths
+            version_from_path = re.search(r"([1-9][0-9]*\.[0-9]*(?:\.[0-9])*)", self.fc).group(1)
             oneapi_version_setvars = os.path.join(
-                oneapi_root, "compiler", str(self.ifx_version), "env", "vars.bat"
+                oneapi_root, "compiler", version_from_path, "env", "vars.bat"
             )
             # order matters here, the specific version env must be invoked first,
             # otherwise it will be ignored if the root setvars sets up the oneapi

--- a/lib/spack/spack/operating_systems/windows_os.py
+++ b/lib/spack/spack/operating_systems/windows_os.py
@@ -74,17 +74,27 @@ class WindowsOs(OperatingSystem):
         return [os.path.join(path, "VC", "Tools", "MSVC") for path in self.vs_install_paths]
 
     @property
+    def oneapi_root(self):
+        oneapi_root = ""
+        root = os.environ.get("ONEAPI_ROOT", "") or \
+        os.path.join(os.environ.get("ProgramFiles(x86)", ""), "Intel", "oneAPI")
+        if os.path.exists(root):
+            oneapi_root = root
+        return oneapi_root
+
+
+
+
+
+    @property
     def compiler_search_paths(self):
         # First Strategy: Find MSVC directories using vswhere
         _compiler_search_paths = []
         for p in self.msvc_paths:
             _compiler_search_paths.extend(glob.glob(os.path.join(p, "*", "bin", "Hostx64", "x64")))
-        if os.getenv("ONEAPI_ROOT"):
-            _compiler_search_paths.extend(
-                glob.glob(
-                    os.path.join(str(os.getenv("ONEAPI_ROOT")), "compiler", "*", "windows", "bin")
-                )
-            )
+        oneapi_root = self.oneapi_root
+        if oneapi_root:
+            _compiler_search_paths.extend(glob.glob(os.path.join("compiler", "**", "bin"), recursive=True))
 
         # Second strategy: Find MSVC via the registry
         def try_query_registry(retry=False):

--- a/lib/spack/spack/operating_systems/windows_os.py
+++ b/lib/spack/spack/operating_systems/windows_os.py
@@ -76,15 +76,12 @@ class WindowsOs(OperatingSystem):
     @property
     def oneapi_root(self):
         oneapi_root = ""
-        root = os.environ.get("ONEAPI_ROOT", "") or \
-        os.path.join(os.environ.get("ProgramFiles(x86)", ""), "Intel", "oneAPI")
+        root = os.environ.get("ONEAPI_ROOT", "") or os.path.join(
+            os.environ.get("ProgramFiles(x86)", ""), "Intel", "oneAPI"
+        )
         if os.path.exists(root):
             oneapi_root = root
         return oneapi_root
-
-
-
-
 
     @property
     def compiler_search_paths(self):
@@ -94,7 +91,9 @@ class WindowsOs(OperatingSystem):
             _compiler_search_paths.extend(glob.glob(os.path.join(p, "*", "bin", "Hostx64", "x64")))
         oneapi_root = self.oneapi_root
         if oneapi_root:
-            _compiler_search_paths.extend(glob.glob(os.path.join("compiler", "**", "bin"), recursive=True))
+            _compiler_search_paths.extend(
+                glob.glob(os.path.join("compiler", "**", "bin"), recursive=True)
+            )
 
         # Second strategy: Find MSVC via the registry
         def try_query_registry(retry=False):

--- a/lib/spack/spack/operating_systems/windows_os.py
+++ b/lib/spack/spack/operating_systems/windows_os.py
@@ -92,7 +92,7 @@ class WindowsOs(OperatingSystem):
         oneapi_root = self.oneapi_root
         if oneapi_root:
             _compiler_search_paths.extend(
-                glob.glob(os.path.join("compiler", "**", "bin"), recursive=True)
+                glob.glob(os.path.join(oneapi_root, "compiler", "**", "bin"), recursive=True)
             )
 
         # Second strategy: Find MSVC via the registry

--- a/lib/spack/spack/operating_systems/windows_os.py
+++ b/lib/spack/spack/operating_systems/windows_os.py
@@ -75,13 +75,11 @@ class WindowsOs(OperatingSystem):
 
     @property
     def oneapi_root(self):
-        oneapi_root = ""
         root = os.environ.get("ONEAPI_ROOT", "") or os.path.join(
             os.environ.get("ProgramFiles(x86)", ""), "Intel", "oneAPI"
         )
         if os.path.exists(root):
-            oneapi_root = root
-        return oneapi_root
+            return root
 
     @property
     def compiler_search_paths(self):


### PR DESCRIPTION
More recent versions of oneAPI are installed in a tree incompatible with current detection heuristics.
`ONEAPI_ROOT` move away from reliance on this environment variable for oneAPI detection and to determine MSVC + oneAPI integration
Refactor oneAPI detection to ensure all detected versions of MSVC receive available versions of oneAPI.
Previous approach to assigning oneAPI versions was badly out of date, fragile, and when considering MSVC integration, redundant. This should be improved when the work in https://github.com/spack/spack/pull/43458 lands.

