### PR TITLE
intel-oneapi-compiler: Fix generation of config files

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -304,7 +304,7 @@ class IntelOneapiCompilers(IntelOneApiPackage):
             # Tolerate missing compilers.
             # Initially, we installed icx/ifx/icc/ifort into a single prefix.
             # Starting in 2024, there is no icc. 2023.2.3 does not have an ifx.
-            if os.path.exists(compiler):
+            if os.path.exists(path.join(compiler)):
                 p = path.join(compiler + ".cfg")
                 with open(p, "w") as f:
                     f.write(" ".join(flags))


### PR DESCRIPTION
Commit 330a9a7c9ac82e91f18a6cbcd9c067eeaa26d617 aimed at preventing generation of .cfg files when a given compiler does not exist in the particular release. However the check does not contain the full paths so it always fails resulting in empty .cfg files. This commit fixes it.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
