### PR TITLE
jwt-cpp: new version 0.7.0, scitokens-cpp: new versions to 1.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/jwt-cpp/package.py
+++ b/var/spack/repos/builtin/packages/jwt-cpp/package.py
@@ -16,6 +16,7 @@ class JwtCpp(CMakePackage):
 
     license("MIT")
 
+    version("0.7.0", sha256="b9eb270e3ba8221e4b2bc38723c9a1cb4fa6c241a42908b9a334daff31137406")
     version("0.6.0", sha256="0227bd6e0356b211341075c7997c837f0b388c01379bd256aa525566a5553f03")
     version("0.5.2", sha256="d3188f9611597eb1bb285169879e1d87202bf10a08e4e7734c9f2097bfd4a850")
     version("0.5.1", sha256="d8f5ffb361824630b3b6f4aad26c730c915081071040c232ac57947d6177ef4f")
@@ -37,6 +38,7 @@ class JwtCpp(CMakePackage):
     depends_on("openssl@1.0.2:", when="@0.5.0:0.5.99 ssl=openssl")
     depends_on("openssl@1.0.1:", when="@0.6.0: ssl=openssl")
     depends_on("libressl@3:", when="@0.5.0: ssl=libressl")
+    depends_on("nlohmann-json", when="@0.7.0:")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/scitokens-cpp/package.py
+++ b/var/spack/repos/builtin/packages/scitokens-cpp/package.py
@@ -44,7 +44,9 @@ class ScitokensCpp(CMakePackage):
     depends_on("pkgconfig", type="build")
     depends_on("uuid", type="build")
 
+    # Some jwt-cpp releases introduce breaking API changes
     conflicts("^jwt-cpp@0.5:", when="@:0.7")
+    conflicts("^jwt-cpp@0.7:", when="@:1.1")
 
     # https://github.com/scitokens/scitokens-cpp/issues/72
     @when("@0.7.0 ^openssl@3:")

--- a/var/spack/repos/builtin/packages/scitokens-cpp/package.py
+++ b/var/spack/repos/builtin/packages/scitokens-cpp/package.py
@@ -17,6 +17,9 @@ class ScitokensCpp(CMakePackage):
 
     license("Apache-2.0")
 
+    version("1.1.1", sha256="a9091b888fc778282caf2a6808c86f685d2411557673152d58fe53932a6c7212")
+    version("1.1.0", sha256="9c4afd6638e94855ede52ecfc3d4f05082f2bdf151a9ab8dafcc2bb7cd4d9039")
+    version("1.0.2", sha256="cdc1e80e0cba9ca0e16de2efa10ec5e38765792bf5107024bfb66ddad5a16a85")
     version("1.0.1", sha256="d4660521fa17189e7a7858747d066052dd8ea8f430ce7649911c157d4423c412")
     version("1.0.0", sha256="88376c5cd065aac8d92445184a02ccf5186dc4890ccd7518e88be436978675c0")
     version("0.7.3", sha256="7d3c438596588cd74cf1af8255c55f44ca86a34293b81415ee24b33de64f886a")


### PR DESCRIPTION
This PR adds jwt-cpp-0.7.0, which removes the bundled nlohmann-json and now requires it as a dependency (https://github.com/Thalhammer/jwt-cpp/compare/v0.6.0...v0.7.0 for diff). If nlohmann-json is not found, then 3.11.2 is used through FetchContent, but no version is required in the find_package so I am not adding one here).

This PR adds scitokens-cpp versions up to 1.1.1, with no build system changes required (https://github.com/scitokens/scitokens-cpp/compare/v1.0.1...v1.1.1 for diff). Due to API changes, scitokens-cpp@1.1.1 doesn't yet work with jwt-cpp@0.7.0.

Build tests:
```
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/jwt-cpp-0.7.0-yahngwim7t3nqiad5l4brxf4qocmsccr
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/scitokens-cpp-1.1.1-qrlqtgjyzuhjmm44ekeiibhkkedhdoat
```