### PR TITLE
spdlog: new version 1.13.0

### DIFF
--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -14,6 +14,7 @@ class Spdlog(CMakePackage):
 
     license("MIT")
 
+    version("1.13.0", sha256="534f2ee1a4dcbeb22249856edfb2be76a1cf4f708a20b0ac2ed090ee24cfdbc9")
     version("1.12.0", sha256="4dccf2d10f410c1e2feaff89966bfc49a1abb29ef6f08246335b110e001e09a9")
     version("1.11.0", sha256="ca5cae8d6cac15dae0ec63b21d6ad3530070650f68076f3a4a862ca293a858bb")
     version("1.10.0", sha256="697f91700237dbae2326b90469be32b876b2b44888302afbc7aceb68bcfe8224")
@@ -52,6 +53,7 @@ class Spdlog(CMakePackage):
 
     depends_on("cmake@3.2:", when="@:1.7.0", type="build")
     depends_on("cmake@3.10:", when="@1.8.0:", type="build")
+    depends_on("cmake@3.11:", when="@1.13.0:", type="build")
 
     depends_on("fmt@5.3:")
     depends_on("fmt@7:", when="@1.7:")


### PR DESCRIPTION
This PR adds spdlog 1.13.0. No major build system changes, apart from small upgrade to cmake requirement.
