### PR TITLE
package/su2 version 8.0.0 & 8.0.1 update

### DIFF
--- a/var/spack/repos/builtin/packages/su2/package.py
+++ b/var/spack/repos/builtin/packages/su2/package.py
@@ -18,6 +18,8 @@ class Su2(MesonPackage):
 
     license("BSD-3-Clause")
 
+    version("8.0.1", commit="8ef4b1be045122b2fdb485bfb5fe4eecd1bc4246", submodules=True)
+    version("8.0.0", commit="1fe59817e984f67ff55146d90d0059e27b772891", submodules=True)
     version("7.5.1", commit="09ba9e3a9605c02d38290e34f42aa6982cb4dd05", submodules=True)
     version("7.5.0", commit="8e8ea59fe6225c8ec4e94d0e0a4b6690ea4294e5", submodules=True)
     version("7.4.0", commit="745e5d922c63c8ec6963b31808c20df2e3bfd075", submodules=True)
@@ -75,6 +77,9 @@ class Su2(MesonPackage):
     # Remove the part that fixes the meson version to 0.61.1.
     # This fix is considered meaningless and will be removed in the next version(@7.6:) of SU2.
     patch("meson_version.patch", when="@7.4.0:7.5.1")
+
+    # Remove the timestamp check of preconfigure.py for version(@8:)
+    patch("remove_preconfigure_timestamp_check.patch", when="@8.0.0:")
 
     def patch(self):
         if self.spec.satisfies("+autodiff") or self.spec.satisfies("+directdiff"):

--- a/var/spack/repos/builtin/packages/su2/remove_preconfigure_timestamp_check.patch
+++ b/var/spack/repos/builtin/packages/su2/remove_preconfigure_timestamp_check.patch
@@ -1,0 +1,13 @@
+--- a/meson.build       2022-12-20 21:08:29.000000000 +0900
++++ b/meson.build       2023-05-19 03:24:08.870966665 +0900
+@@ -6,10 +6,6 @@
+                           'c_std=c99',
+                           'cpp_std=c++11'])
+
+-fsmod = import('fs')
+-if not fsmod.exists('su2preconfig.timestamp')
+-  error('SU2 must be (pre-)configured with the extended Meson script (./meson.py) or with the ./preconfigure.py script in the SU2 root directory.')
+-endif
+
+ pymod = import('python')
+ python = pymod.find_installation()


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
The patch that appeared from 8.0 is the part where preconfigure is performed before installation in the original package, but it is a patch that removes because it is not needed in spack.