### PR TITLE
GDAL: fix MDB build on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -491,6 +491,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
     def patch(self):
         if "+java platform=darwin" in self.spec:
             filter_file("linux", "darwin", "swig/java/java.opt", string=True)
+            filter_file("-lazy-ljvm", "-ljvm", "configure", string=True)
 
 
 class CMakeBuilder(CMakeBuilder):


### PR DESCRIPTION
Tried building GDAL 3.4 with Java/MDB support and hit the following error with the latest Xcode:
```
ld: library 'azy-ljvm' not found
```
When building GDAL 3.4 with Java support on macOS, configure injects `-lazy-ljvm` into the build. However, this flag doesn't seem to work for the latest version of Xcode. GDAL 3.5 and newer don't use this flag, so I'm not sure if it was removed for some reason. MDB support was removed entirely in GDAL 3.5, so I can't use a newer version.

Confirmed that the build works, MDB shows up in `ogrinfo --formats`.

@rouault may know why/when this flag was removed or what purpose it was supposed to serve, but this is for an ancient version of GDAL and a build system/driver that is no longer supported, so I'm obviously not expecting bug fixes.

P.S. I don't actually need this driver, this is more of a reproducibility exercise 😄 