### PR TITLE
abseil-cpp: new version 20240116.2

### DIFF
--- a/var/spack/repos/builtin/packages/abseil-cpp/package.py
+++ b/var/spack/repos/builtin/packages/abseil-cpp/package.py
@@ -18,6 +18,9 @@ class AbseilCpp(CMakePackage):
     license("Apache-2.0")
 
     version(
+        "20240116.2", sha256="733726b8c3a6d39a4120d7e45ea8b41a434cdacde401cba500f14236c49b39dc"
+    )
+    version(
         "20240116.1", sha256="3c743204df78366ad2eaf236d6631d83f6bc928d1705dd0000b872e53b73dc6a"
     )
     version(


### PR DESCRIPTION
This PR adds the new abseil-cpp version 20240116.2, release notes at https://github.com/abseil/abseil-cpp/releases/tag/20240116.2 but changes wrt 20240116.1 are at https://github.com/abseil/abseil-cpp/pull/1650.

Test build:
```
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/abseil-cpp-20240116.2-x3cyvj6hys4oshtcap45awaqb5lqlrd6
```