### PR TITLE
wayland: +doc requires graphviz +expat for HTML tables

### DIFF
--- a/var/spack/repos/builtin/packages/wayland/package.py
+++ b/var/spack/repos/builtin/packages/wayland/package.py
@@ -59,7 +59,7 @@ class Wayland(MesonPackage, AutotoolsPackage):
         depends_on("doxygen", type="build")
         depends_on("xmlto", type="build")
         depends_on("libxslt", type="build")
-        depends_on("graphviz+libgd", type="build")
+        depends_on("graphviz+expat+libgd", type="build")
 
     @when("build_system=autotools")
     def configure_args(self):


### PR DESCRIPTION
Since forever (https://gitlab.freedesktop.org/wayland/wayland/-/commit/042e7eadd8e852ef466592f0f0be0dab84736187), `wayland +doc` has required `graphviz` with support for HTML labels, which requires `graphviz +expat`.

This PR updates the dependency in wayland to require `graphviz +expat`.