### PR TITLE
dd4hep: depends_on root +root7 in some cases

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -100,7 +100,6 @@ class Dd4hep(CMakePackage):
         depends_on("root @:6.27", when="@:1.23")
         conflicts("^root ~webgui", when="^root@6.28:")
         # For DD4hep >= 1.24, DDEve_Interface needs ROOT::ROOTGeomViewer only if ROOT >= 6.27
-        # but to avoid self-referential conflicts we simply require ROOT >= 6.27
         requires("^root +root7 +webgui", when="@1.24: ^root @6.27:")
     depends_on("root @6.08: +gdml +math +python +x +opengl", when="+utilityapps")
 

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -94,12 +94,14 @@ class Dd4hep(CMakePackage):
     depends_on("boost +iostreams", when="+ddg4")
     depends_on("boost +system +filesystem", when="%gcc@:7")
     depends_on("root @6.08: +gdml +math +python")
-    depends_on("root +root7", when="@1.26: ^root@6.12.2:")  # DDCoreGraphics needs ROOT::ROOTHistDraw
+    depends_on("root @6.12.2: +root7", when="@1.26:")  # DDCoreGraphics needs ROOT::ROOTHistDraw
     with when("+ddeve"):
         depends_on("root @6.08: +x +opengl")
         depends_on("root @:6.27", when="@:1.23")
-        depends_on("root +root7", when="@1.24: ^root@6.27:")  # DDEve_Interface needs ROOT::ROOTGeomViewer
         conflicts("^root ~webgui", when="^root@6.28:")
+        # For DD4hep >= 1.24, DDEve_Interface needs ROOT::ROOTGeomViewer if ROOT >= 6.27
+        conflicts("^root ~root7", when="@1.24: ^root@6.27:")
+        conflicts("^root ~webgui", when="@1.24: ^root@6.27:")
     depends_on("root @6.08: +gdml +math +python +x +opengl", when="+utilityapps")
 
     extends("python")

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -101,7 +101,7 @@ class Dd4hep(CMakePackage):
         conflicts("^root ~webgui", when="^root@6.28:")
         # For DD4hep >= 1.24, DDEve_Interface needs ROOT::ROOTGeomViewer only if ROOT >= 6.27
         # but to avoid self-referential conflicts we simply require ROOT >= 6.27
-        depends_on("root @6.27: +root7 +webgui", when="@1.24:")
+        requires("^root +root7 +webgui", when="@1.24: ^root @6.27:")
     depends_on("root @6.08: +gdml +math +python +x +opengl", when="+utilityapps")
 
     extends("python")

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -94,9 +94,11 @@ class Dd4hep(CMakePackage):
     depends_on("boost +iostreams", when="+ddg4")
     depends_on("boost +system +filesystem", when="%gcc@:7")
     depends_on("root @6.08: +gdml +math +python")
+    depends_on("root +root7", when="@1.26: ^root@6.12.2:")  # DDCoreGraphics needs ROOT::ROOTHistDraw
     with when("+ddeve"):
         depends_on("root @6.08: +x +opengl")
         depends_on("root @:6.27", when="@:1.23")
+        depends_on("root +root7", when="@1.24: ^root@6.27:")  # DDEve_Interface needs ROOT::ROOTGeomViewer
         conflicts("^root ~webgui", when="^root@6.28:")
     depends_on("root @6.08: +gdml +math +python +x +opengl", when="+utilityapps")
 

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -99,9 +99,9 @@ class Dd4hep(CMakePackage):
         depends_on("root @6.08: +x +opengl")
         depends_on("root @:6.27", when="@:1.23")
         conflicts("^root ~webgui", when="^root@6.28:")
-        # For DD4hep >= 1.24, DDEve_Interface needs ROOT::ROOTGeomViewer if ROOT >= 6.27
-        conflicts("^root ~root7", when="@1.24: ^root@6.27:")
-        conflicts("^root ~webgui", when="@1.24: ^root@6.27:")
+        # For DD4hep >= 1.24, DDEve_Interface needs ROOT::ROOTGeomViewer only if ROOT >= 6.27
+        # but to avoid self-referential conflicts we simply require ROOT >= 6.27
+        depends_on("root @6.27: +root7 +webgui", when="@1.24:")
     depends_on("root @6.08: +gdml +math +python +x +opengl", when="+utilityapps")
 
     extends("python")


### PR DESCRIPTION
DD4hep depends on ROOT, and in some cases for some recent versions, it needs the variant `+root7` where it does not currently get it.
- DDCoreGraphics needs ROOT::ROOTHistDraw for `dd4hep@1.26:` due to https://github.com/AIDASoft/DD4hep/commit/0f68497aba442fa47021aebf8691eb0dbfd94df3, and that target was introduced in ROOT in v6-12-02 with https://github.com/root-project/root/commit/dd844aa1b7bf031be7464ba6df2ff2c4ac6e0b59
  - hence: `depends_on("root @6.12.2: +root7", when="@1.26:")`
- DDEve_Interface needs ROOT::ROOTGeomViewer for `dd4hep@1.24:` if `^root@6.27:` due to https://github.com/AIDASoft/DD4hep/commit/96207d5c5c330aa57ae66b67a252e702e09fa0bd, and that target was introduced in ROOT in v6-27-02 with https://github.com/root-project/root/commit/bbcc486e8a9c8a4194c73a345b39c3ea96aff8a5 (see also https://github.com/AIDASoft/DD4hep/issues/1197). This now also requires `+webgui` per https://github.com/root-project/root/blob/0b052384a9afc14a3b399286669048b8f6ad7db4/geom/CMakeLists.txt#L25-L27.
  - ~~hence: `conflicts("^root ~root7", when="@1.24: ^root@6.27:")` and `conflicts("^root ~webgui", when="@1.24: ^root@6.27:")` (one conflict would still allow `+root7 ~webgui`)~~
  - ~~this got me a case of :exploding_head:~~
  - ~~instead of using conflicts, this applies `depends_on("root @6.27: +root7 +webgui", when="@1.24:")` (technically too strict, since e.g. `root@6.26 ~root7 ~webgui` also works with `dd4hep@1.24:`)~~
  - instead of using too strict depends, this now uses `requires("^root +root7 +webgui", when="@1.24: ^root @6.27:")`