### PR TITLE
podio: +rntuple requires root +root7

### DIFF
--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -163,7 +163,7 @@ class Podio(CMakePackage):
     patch("python-tests.patch", when="@:0.14.0")
 
     depends_on("root@6.08.06: cxxstd=17", when="cxxstd=17")
-    depends_on("root@6.28.04:", when="+rntuple")
+    depends_on("root@6.28.04: +root7", when="+rntuple")
     depends_on("root@6.28:", when="@0.17:")
     for cxxstd in ("17", "20"):
         depends_on("root cxxstd={}".format(cxxstd), when="cxxstd={}".format(cxxstd))


### PR DESCRIPTION
`podio +rntuple` requires the target ROOTNTuple, defined at https://github.com/root-project/root/blob/0b052384a9afc14a3b399286669048b8f6ad7db4/tree/ntuple/CMakeLists.txt#L16, which is after an `if(NOT root7) return()` guard. This PR explicitly adds the `+root7` requirement.