### PR TITLE
zstd: patch broken 1.5.6 release for Windows

### DIFF
--- a/var/spack/repos/builtin/packages/zstd/package.py
+++ b/var/spack/repos/builtin/packages/zstd/package.py
@@ -65,7 +65,7 @@ class Zstd(CMakePackage, MakefilePackage):
     # +programs builds vendored xxhash, which uses unsupported builtins
     # (last tested: nvhpc@22.3)
     conflicts("+programs %nvhpc")
-
+    patch("https://github.com/facebook/zstd/pull/4009.patch", sha256="f24a0b522e17b4ce6f824e332872b56e43ddca0c1364040bdc7c079a3fc52c94", when="@1.5.6 platform=windows")
     build_system("cmake", "makefile", default="makefile")
 
 

--- a/var/spack/repos/builtin/packages/zstd/package.py
+++ b/var/spack/repos/builtin/packages/zstd/package.py
@@ -65,7 +65,11 @@ class Zstd(CMakePackage, MakefilePackage):
     # +programs builds vendored xxhash, which uses unsupported builtins
     # (last tested: nvhpc@22.3)
     conflicts("+programs %nvhpc")
-    patch("https://github.com/facebook/zstd/pull/4009.patch", sha256="f24a0b522e17b4ce6f824e332872b56e43ddca0c1364040bdc7c079a3fc52c94", when="@1.5.6 platform=windows")
+    patch(
+        "https://github.com/facebook/zstd/pull/4009.patch",
+        sha256="f24a0b522e17b4ce6f824e332872b56e43ddca0c1364040bdc7c079a3fc52c94",
+        when="@1.5.6 platform=windows",
+    )
     build_system("cmake", "makefile", default="makefile")
 
 


### PR DESCRIPTION
zstd 1.5.6 has issues building on Windows without the changes from https://github.com/facebook/zstd/pull/4009

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Tested on Windows 11 with VS22.