### PR TITLE
(py-)onnx: new version 1.16.0

### DIFF
--- a/var/spack/repos/builtin/packages/onnx/package.py
+++ b/var/spack/repos/builtin/packages/onnx/package.py
@@ -20,6 +20,7 @@ class Onnx(CMakePackage):
     license("Apache-2.0")
 
     version("master", branch="master")
+    version("1.16.0", sha256="0ce153e26ce2c00afca01c331a447d86fbf21b166b640551fe04258b4acfc6a4")
     version("1.15.0", sha256="c757132e018dd0dd171499ef74fca88b74c5430a20781ec53da19eb7f937ef68")
     version("1.14.1", sha256="e296f8867951fa6e71417a18f2e550a730550f8829bd35e947b4df5e3e777aa1")
     version("1.14.0", sha256="1b02ad523f79d83f9678c749d5a3f63f0bcd0934550d5e0d7b895f9a29320003")

--- a/var/spack/repos/builtin/packages/py-onnx/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx/package.py
@@ -21,6 +21,7 @@ class PyOnnx(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.16.0", sha256="237c6987c6c59d9f44b6136f5819af79574f8d96a760a1fa843bede11f3822f7")
     version("1.15.0", sha256="b18461a7d38f286618ca2a6e78062a2a9c634ce498e631e708a8041b00094825")
     version("1.14.1", sha256="70903afe163643bd71195c78cedcc3f4fa05a2af651fd950ef3acbb15175b2d1")
     version("1.14.0", sha256="43b85087c6b919de66872a043c7f4899fe6f840e11ffca7e662b2ce9e4cc2927")
@@ -54,6 +55,7 @@ class PyOnnx(PythonPackage):
     depends_on("py-protobuf+cpp", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-numpy@1.16.6:", type=("build", "run"), when="@1.8.1:1.13")
+    depends_on("py-numpy@1.20:", type=("build", "run"), when="@1.16.0:")
 
     # Historical dependencies
     depends_on("py-six", type=("build", "run"), when="@:1.8.1")

--- a/var/spack/repos/builtin/packages/py-onnxruntime/package.py
+++ b/var/spack/repos/builtin/packages/py-onnxruntime/package.py
@@ -55,6 +55,7 @@ class PyOnnxruntime(CMakePackage, PythonExtension):
     depends_on("protobuf@:3.19", when="@:1.11")
     depends_on("py-cerberus", type=("build", "run"))
     depends_on("py-onnx", type=("build", "run"))
+    depends_on("py-onnx@:1.15.0", type=("build", "run"), when="@:1.17.1")
     depends_on("zlib-api")
     depends_on("libpng")
     depends_on("cuda", when="+cuda")


### PR DESCRIPTION
This PR adds a new version of onnx and py-onnx. This version is not compatible with the most recent py-onnxruntime, so the dependency there is made explicit.

Test builds:
```
zcdkzrj onnx@1.16.0~ipo build_system=cmake build_type=Release generator=ninja
xwzvfjx py-onnx@1.16.0 build_system=python_pip
```