### PR TITLE
zstd: 1.5.6 does not build on Windows

### DIFF
--- a/var/spack/repos/builtin/packages/zstd/package.py
+++ b/var/spack/repos/builtin/packages/zstd/package.py
@@ -66,6 +66,8 @@ class Zstd(CMakePackage, MakefilePackage):
     # (last tested: nvhpc@22.3)
     conflicts("+programs %nvhpc")
 
+    conflicts("platform=windows", when="@1.5.6")
+
     build_system("cmake", "makefile", default="makefile")
 
 


### PR DESCRIPTION
Conflict until a fix has been merged upstream

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
