### PR TITLE
xerces-c: new version 3.2.5

### DIFF
--- a/var/spack/repos/builtin/packages/xerces-c/package.py
+++ b/var/spack/repos/builtin/packages/xerces-c/package.py
@@ -20,6 +20,7 @@ class XercesC(AutotoolsPackage):
 
     license("Apache-2.0")
 
+    version("3.2.5", sha256="1db4028c9b7f1f778efbf4a9462d65e13f9938f2c22f9e9994e12c49ba97e252")
     version("3.2.4", sha256="74aa626fc71e729ee227602870dd29a5a01cd8c9c1c7330837a51da2eb5722cc")
     version("3.2.3", sha256="45c2329e684405f2b8854ecbddfb8d5b055cdf0fe4d35736cc352c504989bbb6")
     version("3.2.2", sha256="1f2a4d1dbd0086ce0f52b718ac0fa4af3dc1ce7a7ff73a581a05fbe78a82bce0")


### PR DESCRIPTION
This PR adds a new version of xerces-c, 3.2.5. No build system changes, https://github.com/apache/xerces-c/compare/v3.2.4...v3.2.5, but fixes [CVE-2018-1311](https://github.com/advisories/GHSA-7rpp-hwhj-9hv8).

Test build:
```
==> Installed packages
-- linux-ubuntu24.04-skylake / gcc@13.2.0 -----------------------
4xuf64u xerces-c@3.2.5 build_system=autotools cxxstd=20 netaccessor=curl transcoder=gnuiconv
==> 1 installed package
```