### PR TITLE
curl: new version 8.7.1

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -32,6 +32,7 @@ class Curl(NMakePackage, AutotoolsPackage):
 
     license("curl")
 
+    version("8.7.1", sha256="05bbd2b698e9cfbab477c33aa5e99b4975501835a41b7ca6ca71de03d8849e76")
     version("8.6.0", sha256="b4785f2d8877fa92c0e45d7155cf8cc6750dbda961f4b1a45bcbec990cf2fa9b")
     version("8.4.0", sha256="e5250581a9c032b1b6ed3cf2f9c114c811fc41881069e9892d115cc73f9e88c6")
 


### PR DESCRIPTION
This PR adds the new version 8.7.1 of curl (same as 8.7.0 which was missing a file in the tarballs).

Peering over `configure.ac` in the diff, https://github.com/curl/curl/compare/curl-8_6_0...curl-8_7_1, the following changes apply, and for most I don't see any reason they require changes in the package.py. Due to the central nature of curl in spack, I'm going to be exhaustive, though (and have no way of testing with nmake on windows).
- minor changes:
  - some reorg of `libpsl` handling, which we always disable with `--without-libpsl`,
  - `--with-zsh-functions-dir=default` now means no, but is unused by us,
  - `--with-fish-functions-dir-default` now means no, but is unused by us.

There is also a new option `--enable-docs`, which defaults to yes, but also requires perl to be installed which we don't have in direct dependencies; perl is searched for in system directories so this ends up enablig building docs with system /usr/bin/perl... And explicitly disabling with `--disable-docs` also fails to build...

Well, I'm going to keep this marked as draft until I have a chance to look into it further.