### PR TITLE
Propagate os compatibility to arch specs

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -916,6 +916,7 @@ def list_fn(args):
 
     if not args.allarch:
         arch = spack.spec.Spec.default_arch()
+        breakpoint()
         specs = [s for s in specs if s.intersects(arch)]
 
     if args.specs:

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -916,7 +916,6 @@ def list_fn(args):
 
     if not args.allarch:
         arch = spack.spec.Spec.default_arch()
-        breakpoint()
         specs = [s for s in specs if s.intersects(arch)]
 
     if args.specs:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -403,14 +403,17 @@ class ArchSpec:
         Args:
             other: spec to be satisfied
         """
+        breakpoint()
         other = self._autospec(other)
 
         # Check platform and os
-        for attribute in ("platform", "os"):
-            other_attribute = getattr(other, attribute)
-            self_attribute = getattr(self, attribute)
-            if other_attribute and self_attribute != other_attribute:
-                return False
+        other_attribute = other.platform
+        self_attribute = self.platform 
+        if other_attribute and self_attribute != other_attribute:
+            return False
+
+        if not self._os_satisfies(other, strict=False):
+            return False
 
         return self._target_satisfies(other, strict=True)
 
@@ -426,14 +429,30 @@ class ArchSpec:
         """
         other = self._autospec(other)
 
+        breakpoint()
         # Check platform and os
-        for attribute in ("platform", "os"):
-            other_attribute = getattr(other, attribute)
-            self_attribute = getattr(self, attribute)
-            if other_attribute and self_attribute and self_attribute != other_attribute:
-                return False
+        other_attribute = other.platform
+        self_attribute = self.platform
+        if other_attribute and self_attribute and self_attribute != other_attribute:
+            return False
+
+        if not self._os_satisfies(other, strict=False):
+            return False
 
         return self._target_satisfies(other, strict=False)
+
+    def _os_satisfies(self, other: "ArchSpec", strict: bool) -> bool:
+        breakpoint()
+        if bool(self.os) and bool(other.os):
+            if strict and self.os != other.os:
+                return False
+            else:
+                # can this os be used by the other os
+                compatible_os = spack.config.get("concretizer:os_compatible", {})
+                reuse_list = compatible_os.get(other.os, [])
+                return self.os in reuse_list
+        else:
+            return False
 
     def _target_satisfies(self, other: "ArchSpec", strict: bool) -> bool:
         if strict is True:
@@ -3711,6 +3730,7 @@ class Spec:
             other: spec to be checked for compatibility
             deps: if True check compatibility of dependency nodes too, if False only check root
         """
+        breakpoint()
         other = self._autospec(other)
 
         if other.concrete and self.concrete:
@@ -3831,6 +3851,7 @@ class Spec:
             other: spec to be satisfied
             deps: if True descend to dependencies, otherwise only check root node
         """
+        breakpoint()
         other = self._autospec(other)
 
         if other.concrete:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -403,7 +403,6 @@ class ArchSpec:
         Args:
             other: spec to be satisfied
         """
-        breakpoint()
         other = self._autospec(other)
 
         # Check platform and os
@@ -429,7 +428,6 @@ class ArchSpec:
         """
         other = self._autospec(other)
 
-        breakpoint()
         # Check platform and os
         other_attribute = other.platform
         self_attribute = self.platform
@@ -442,7 +440,6 @@ class ArchSpec:
         return self._target_satisfies(other, strict=False)
 
     def _os_satisfies(self, other: "ArchSpec", strict: bool) -> bool:
-        breakpoint()
         if bool(self.os) and bool(other.os):
             if strict and self.os != other.os:
                 return False
@@ -3730,7 +3727,6 @@ class Spec:
             other: spec to be checked for compatibility
             deps: if True check compatibility of dependency nodes too, if False only check root
         """
-        breakpoint()
         other = self._autospec(other)
 
         if other.concrete and self.concrete:
@@ -3851,7 +3847,6 @@ class Spec:
             other: spec to be satisfied
             deps: if True descend to dependencies, otherwise only check root node
         """
-        breakpoint()
         other = self._autospec(other)
 
         if other.concrete:


### PR DESCRIPTION
Currently binary caches seem to be ignorant of compatible OS's.  This draft PR is an attempt to fix that.
Testing my `darwin-sonoma-m1` trying to pull from the `darwin-ventura-aarch64` cache.  This make the reusable os when adding the config `spack config add concretizer:os_compatible:sonoma:[ventura]` but is failing on the target check for satisfying.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
