### PR TITLE
[Score-P] Make local with-or-without not use "yes"

### DIFF
--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -153,6 +153,9 @@ class Scorep(AutotoolsPackage):
             return None
         return libs.directories[0]
 
+    def with_or_without(self, arg):
+        return super.with_or_without(arg).remove_suffix("=yes")
+
     def configure_args(self):
         spec = self.spec
 


### PR DESCRIPTION
Score-P does not accept "--with-foo=yes", but only "--with-foo" or "--with-foo=some-valid-specific-choice-or-path". This keeps Spack from generating config flags that will cause Score-P to barf.


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
