### PR TITLE
ML CI: remove MXNet

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -71,7 +71,6 @@ ci:
 
     - match:
       - dealii
-      - mxnet
       - rocblas
       build-job:
         tags: [ "spack", "huge" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-darwin-aarch64-mps/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-darwin-aarch64-mps/spack.yaml
@@ -34,9 +34,6 @@ spack:
   - py-keras-preprocessing
   - py-keras2onnx
 
-  # MXNet not supported on darwin aarch64 yet
-  # - mxnet
-
   # PyTorch
   - py-botorch
   - py-efficientnet-pytorch

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cpu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cpu/spack.yaml
@@ -28,9 +28,6 @@ spack:
     - py-keras-preprocessing
     - py-keras2onnx
 
-    # MXNet
-    - mxnet
-
     # PyTorch
     - py-botorch
     - py-efficientnet-pytorch

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-cuda/spack.yaml
@@ -32,9 +32,6 @@ spack:
     - py-keras-preprocessing
     - py-keras2onnx
 
-    # MXNet
-    - mxnet
-
     # PyTorch
     - py-botorch
     - py-efficientnet-pytorch

--- a/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/ml-linux-x86_64-rocm/spack.yaml
@@ -34,9 +34,6 @@ spack:
     - py-keras-preprocessing
     - py-keras2onnx
 
-    # MXNet
-    - mxnet
-
     # PyTorch
     - py-botorch
     - py-efficientnet-pytorch

--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -14,8 +14,6 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
     list_url = "https://mxnet.apache.org/get_started/download"
     git = "https://github.com/apache/mxnet.git"
 
-    maintainers("adamjstewart")
-
     license("Apache-2.0")
 
     version("master", branch="master", submodules=True)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
MXNet development has halted and the GitHub repo is now read-only: https://github.com/apache/mxnet/issues/21206

MXNet doesn't build on macOS and I'm also having trouble building it in the new Linux aarch64 pipeline. I think it's time to retire MXNet from our ML pipelines.