### PR TITLE
Associate condition sets from cli to root node

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -127,10 +127,12 @@ trigger_node(TriggerID, Node, Node) :-
   trigger_condition_holds(TriggerID, Node),
   literal(TriggerID).
 
-% Since we trigger the existence of literal nodes from a condition, we need to construct
-% the condition_set/2 manually below
+% Since we trigger the existence of literal nodes from a condition, we need to construct the condition_set/2
 mentioned_in_literal(Root, Mentioned) :- mentioned_in_literal(TriggerID, Root, Mentioned), solve_literal(TriggerID).
-condition_set(node(min_dupe_id, Root), node(min_dupe_id, Mentioned)) :-  mentioned_in_literal(Root, Mentioned).
+condition_set(node(min_dupe_id, Root), node(min_dupe_id, Root)) :-  mentioned_in_literal(Root, Root).
+
+1 { condition_set(node(min_dupe_id, Root), node(0..Y-1, Mentioned)) : max_dupes(Mentioned, Y) } 1 :-
+  mentioned_in_literal(Root, Mentioned), Mentioned != Root.
 
 % Discriminate between "roots" that have been explicitly requested, and roots that are deduced from "virtual roots"
 explicitly_requested_root(node(min_dupe_id, Package)) :-

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -138,6 +138,20 @@ explicitly_requested_root(node(min_dupe_id, Package)) :-
   trigger_and_effect(Package, TriggerID, EffectID),
   imposed_constraint(EffectID, "root", Package).
 
+
+associated_with_root(RootNode, RootNode) :- attr("root", RootNode).
+
+associated_with_root(RootNode, ChildNode) :-
+   depends_on(ParentNode, ChildNode),
+   associated_with_root(RootNode, ParentNode).
+
+error(100, "node({0}, {1}) is not associated with root", X, Package)
+  :- attr("root", RootNode),
+     condition_set(RootNode, node(X, Package)),
+     not virtual(Package),
+     not associated_with_root(RootNode, node(X, Package)).
+
+
 #defined concretize_everything/0.
 #defined literal/1.
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -139,18 +139,18 @@ explicitly_requested_root(node(min_dupe_id, Package)) :-
   imposed_constraint(EffectID, "root", Package).
 
 
+% Keep track of which nodes are associated with which root DAG
 associated_with_root(RootNode, RootNode) :- attr("root", RootNode).
 
 associated_with_root(RootNode, ChildNode) :-
    depends_on(ParentNode, ChildNode),
    associated_with_root(RootNode, ParentNode).
 
-error(100, "node({0}, {1}) is not associated with root", X, Package)
-  :- attr("root", RootNode),
-     condition_set(RootNode, node(X, Package)),
-     not virtual(Package),
-     not associated_with_root(RootNode, node(X, Package)).
-
+% We cannot have a node in the root condition set, that is not associated with that root
+:- attr("root", RootNode),
+   condition_set(RootNode, node(X, Package)),
+   not virtual(Package),
+   not associated_with_root(RootNode, node(X, Package)).
 
 #defined concretize_everything/0.
 #defined literal/1.

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2536,6 +2536,29 @@ class TestConcretizeSeparately:
         assert len(edges) == 1
         assert edges[0].spec.satisfies("@=60")
 
+    @pytest.mark.regression("43647")
+    def test_specifying_different_versions_build_deps(self):
+        """Tests that we can concretize a spec with nodes using the same build
+        dependency pinned at different versions, when the constraint is specified
+        in the root spec.
+
+        o hdf5@1.0
+        |\
+        o | pinned-gmake@1.0
+        o | gmake@3.0
+         /
+        o gmake@4.1
+
+        """
+        hdf5_str = "hdf5@1.0 ^gmake@4.1"
+        pinned_str = "pinned-gmake@1.0 ^gmake@3.0"
+        input_specs = [Spec(hdf5_str), Spec(pinned_str)]
+        solver = spack.solver.asp.Solver()
+        result = solver.solve(input_specs)
+
+        assert any(x.satisfies(hdf5_str) for x in result.specs)
+        assert any(x.satisfies(pinned_str) for x in result.specs)
+
 
 @pytest.mark.parametrize(
     "v_str,v_opts,checksummed",


### PR DESCRIPTION
fixes #43647 

This PR prevents a `condition_set` from having nodes that are not associated with the corresponding root node through some (transitive) dependencies. 

- [x] Fix the issue with a single build spec constrained from literal
- [x]  Fix the issue with two or more build specs constrained from literal
- [x] Add unit tests