### PR TITLE
setup performance improvements

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -911,6 +911,9 @@ class FlagMap(lang.HashableMap):
             yield flags
 
     def __str__(self):
+        if not self:
+            return ""
+
         sorted_items = sorted((k, v) for k, v in self.items() if v)
 
         result = ""
@@ -4563,6 +4566,8 @@ class Spec:
         return str(path_ctor(*output_path_components))
 
     def __str__(self):
+        if not self._dependencies:
+            return self.format()
         root_str = [self.format()]
         sorted_dependencies = sorted(
             self.traverse(root=False), key=lambda x: (x.name, x.abstract_hash)


### PR DESCRIPTION
- do less work in `__str__` in the trivial case, which is very common
- do not copy a full spec to set a single property -- mutate temporarily instead

Together with #43712 I'm getting `spack solve --fresh hdf5` setup time going from 5.5s to 4.0s (or -27%)

