### PR TITLE
Adjust message severity of irreversible environment adjustments

### DIFF
--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -642,8 +642,8 @@ class EnvironmentModifications:
             elif isinstance(envmod, AppendFlagsEnv):
                 rev.remove_flags(envmod.name, envmod.value)
             else:
-                tty.warn(
-                    f"Skipping reversal of unreversable operation {type(envmod)} {envmod.name}"
+                tty.debug(
+                    f"Skipping reversal of irreversible operation {type(envmod)} {envmod.name}"
                 )
 
         return rev


### PR DESCRIPTION
This PR switches the message severity of irreversible operations from `tty.warn` to `tty.debug`.  In many of Fermilab's recipes, we use `env.deprioritize_system_paths(...)` and `env.prune_duplicate_paths(...)`, both of which are irreversible adjustments.  Whenever we unload a package that invokes these methods, we receive the warning that they cannot be reversed.  We would never expect them to be, and we don't see it as alarming.

There is some precedent for using a debug (not warning) message when the environment cannot necessarily be recovered ([see the code here](https://github.com/spack/spack/blob/eb2ddf6fa21b774c20791eed80676795b8034d07/lib/spack/spack/util/environment.py#L631,L647)).  Specifically:

```python
if isinstance(envmod, SetEnv):
    tty.debug("Reversing `Set` environment operation may lose the original value")
    rev.unset(envmod.name)
```
and
```python
elif isinstance(envmod, SetPath):
    tty.debug("Reversing `SetPath` environment operation may lose the original value")
    rev.unset(envmod.name)
```

I argue that the same applies for the other cases.  If you like, I can separate out the two cases we particularly care about and leave the others as a warning message.  This particular change, however, would make Fermilab users' Spack experiences less "noisy".