### PR TITLE
gxsview: compiles against system qt and vtk on rhel8

### DIFF
--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 from spack.package import *
 
 
@@ -51,11 +52,23 @@ class Gxsview(QMakePackage):
         vtk_suffix = self.spec["vtk"].version.up_to(2)
         vtk_lib_dir = self.spec["vtk"].prefix.lib
         vtk_include_dir = join_path(self.spec["vtk"].prefix.include, "vtk-{0}".format(vtk_suffix))
-        args = [
+        args = []
+        if not os.path.exists(vtk_include_dir):
+            vtk_include_dir = join_path(self.spec["vtk"].prefix.include, "vtk")
+            args.append("VTK_NO_VER_SUFFIX=ON")
+        args.extend([
             "VTK_LIB_DIR={0}".format(vtk_lib_dir),
             "VTK_INC_DIR={0}".format(vtk_include_dir),
             "VTK_MAJOR_VER={0}".format(str(vtk_suffix)),
-        ]
+        ])
+        # Below to avoid undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
+        if self.spec.satisfies("%gcc@8.0:8.9") or self.spec.satisfies("%fj"):
+            if "^vtk@9:" in spec:
+                fic="vtk9.pri"
+            else:
+                fic="vtk8.pri"
+            with open(fic, "a") as fh:
+                fh.write("-lstdc++fs\n")
         return args
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -66,7 +66,7 @@ class Gxsview(QMakePackage):
         )
         # Below to avoid undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
         if self.spec.satisfies("%gcc@8.0:8.9") or self.spec.satisfies("%fj"):
-            if "^vtk@9:" in spec:
+            if "^vtk@9:" in self.spec:
                 fic = "vtk9.pri"
             else:
                 fic = "vtk8.pri"

--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -64,9 +64,9 @@ class Gxsview(QMakePackage):
         # Below to avoid undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
         if self.spec.satisfies("%gcc@8.0:8.9") or self.spec.satisfies("%fj"):
             if "^vtk@9:" in spec:
-                fic="vtk9.pri"
+                fic = "vtk9.pri"
             else:
-                fic="vtk8.pri"
+                fic = "vtk8.pri"
             with open(fic, "a") as fh:
                 fh.write("-lstdc++fs\n")
         return args

--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -57,11 +57,13 @@ class Gxsview(QMakePackage):
         if not os.path.exists(vtk_include_dir):
             vtk_include_dir = join_path(self.spec["vtk"].prefix.include, "vtk")
             args.append("VTK_NO_VER_SUFFIX=ON")
-        args.extend([
-            "VTK_LIB_DIR={0}".format(vtk_lib_dir),
-            "VTK_INC_DIR={0}".format(vtk_include_dir),
-            "VTK_MAJOR_VER={0}".format(str(vtk_suffix)),
-        ])
+        args.extend(
+            [
+                "VTK_LIB_DIR={0}".format(vtk_lib_dir),
+                "VTK_INC_DIR={0}".format(vtk_include_dir),
+                "VTK_MAJOR_VER={0}".format(str(vtk_suffix)),
+            ]
+        )
         # Below to avoid undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
         if self.spec.satisfies("%gcc@8.0:8.9") or self.spec.satisfies("%fj"):
             if "^vtk@9:" in spec:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Adds code to make gxsview compile with RedHat8 and system qt and system vtk, as well as gcc 8.5