### PR TITLE
Enable MacOS, Sonoma (OS version 14.x) building of FMS and MAPL

### DIFF
--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -104,8 +104,4 @@ class Fms(CMakePackage):
             self.define_from_variant("USE_DEPRECATED_IO", "deprecated_io"),
         ]
 
-        args.append(self.define("CMAKE_C_COMPILER", self.spec["mpi"].mpicc))
-        args.append(self.define("CMAKE_CXX_COMPILER", self.spec["mpi"].mpicxx))
-        args.append(self.define("CMAKE_Fortran_COMPILER", self.spec["mpi"].mpifc))
-
         return args

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -246,6 +246,9 @@ class Mapl(CMakePackage):
     depends_on("py-numpy", when="+f2py")
     depends_on("perl")
 
+    # when using apple-clang version 15.x or newer, need to use the llvm-openmp library
+    depends_on("llvm-openmp", when="%apple-clang@15:", type=("build", "run"))
+
     def cmake_args(self):
         args = [
             self.define_from_variant("BUILD_WITH_FLAP", "flap"),
@@ -254,9 +257,6 @@ class Mapl(CMakePackage):
             self.define_from_variant("BUILD_SHARED_MAPL", "shared"),
             self.define_from_variant("USE_EXTDATA2G", "extdata2g"),
             self.define_from_variant("USE_F2PY", "f2py"),
-            "-DCMAKE_C_COMPILER=%s" % self.spec["mpi"].mpicc,
-            "-DCMAKE_CXX_COMPILER=%s" % self.spec["mpi"].mpicxx,
-            "-DCMAKE_Fortran_COMPILER=%s" % self.spec["mpi"].mpifc,
         ]
 
         if self.spec.satisfies("@2.22.0:"):


### PR DESCRIPTION
This PR updates the package.py scripts for the FMS and MAPL packages. These changes enabled the building of FMS and MAPL on the MacOS, Sonoma (14) with the Xcode 15.1 (apple clang 15.0.0) tools.

The primary update is to remove the usage of the MPI wrappers to build FMS and MAPL. Since these two packages use CMake, the wrappers should not be necessary. However, I realize that there were likely reasons for using the wrappers so this solution may not be viable.

I think if we can get by without the MPI wrappers, great! But I'm fine with keeping the MPI wrappers and open to other solutions. In this case, perhaps a conditional (based on MacOS for example) removal of the wrappers would be workable?

Partially addresses jcsda/spack-stack/pull/1083. Still need to get these changes merged into the JCSDA spack fork to complete the resolution of this issue.