### PR TITLE
perl-fth: new version 0.529

### DIFF
--- a/var/spack/repos/builtin/packages/perl-fth/package.py
+++ b/var/spack/repos/builtin/packages/perl-fth/package.py
@@ -23,10 +23,11 @@ class PerlFth(Package):
     """
 
     homepage = "https://sourceforge.net/projects/ftagshtml/"
-    url = "https://downloads.sourceforge.net/project/ftagshtml/ftagshtml-0.524.tgz"
+    url = "https://downloads.sourceforge.net/project/ftagshtml/ftagshtml-0.529.tgz"
 
     maintainers("cessenat")
 
+    version("0.529", sha256="3cc2030372cf88dad257bd0cfbe662873a454d55035c54a76090e0da860074c4")
     version("0.527", sha256="df98e9e2f4dbef863b09a22ed92681dff028a6f345ba530bc3afd8221efe633c")
     version("0.526", sha256="ada1c7306111d59d64572fe8a9b038026fd0daebaff630924997ef2dc22d87a8")
     version("0.525", sha256="378116febeb20f4b0c1e298de90305e8494335949d853c7e390d1b6386c1326a")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Version 0.529 corrects a not seen call in reuse mode when there was a space between the call and the parenthesis.
More robust javatex.pl for files indexes, compilation dependencies builder initmak makes included dep files accept error.
Mkversion finds the local git version.