### PR TITLE
keepassxc: new version 2.7.7

### DIFF
--- a/var/spack/repos/builtin/packages/keepassxc/package.py
+++ b/var/spack/repos/builtin/packages/keepassxc/package.py
@@ -18,6 +18,7 @@ class Keepassxc(CMakePackage):
     license("GPL-2.0-only OR GPL-3.0-only")
 
     version("master", branch="master")
+    version("2.7.7", sha256="58fc45ae98e4b3ffb052103014f5b97a41fefd17102c7f56073934dd3a82ee67")
     version("2.7.6", sha256="a58074509fa8e90f152c6247f73e75e126303081f55eedb4ea0cbb6fa980d670")
     version("2.7.1", sha256="6001ba626c35c316dbda6de35736f012a2264f95139fcb4a094b8eb49b15d3e7")
     version("2.7.0", sha256="83be76890904cd6703343fa097d68bcfdd99bb525cf518fa62a7df9293026aa7")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
New release 2.7.7 that delivers the official implementation of Passkeys
https://keepassxc.org/blog/