### PR TITLE
Fix incorrect string manipulation

### DIFF
--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -154,7 +154,7 @@ class Scorep(AutotoolsPackage):
         return libs.directories[0]
 
     def with_or_without(self, arg):
-        return super.with_or_without(arg).remove_suffix("=yes")
+        return super.with_or_without(arg).rstrip("=yes")
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -154,7 +154,7 @@ class Scorep(AutotoolsPackage):
         return libs.directories[0]
 
     def with_or_without(self, arg):
-        return super.with_or_without(arg).rstrip("=yes")
+        return super.with_or_without(arg).replace("=yes", "")
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -154,7 +154,7 @@ class Scorep(AutotoolsPackage):
         return libs.directories[0]
 
     def with_or_without(self, arg):
-        return super.with_or_without(arg).replace("=yes", "")
+        return super().with_or_without(arg).replace("=yes", "")
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
`rstrip` was of course intended, not sure how `remove_suffix` worked under any conditions.

Fixes #43716.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
