### PR TITLE
ruamel: pass memo correctly

### DIFF
--- a/lib/spack/external/_vendoring/ruamel/yaml/comments.py
+++ b/lib/spack/external/_vendoring/ruamel/yaml/comments.py
@@ -497,7 +497,7 @@ class CommentedBase:
                   Tag.attrib, merge_attrib]:
             if hasattr(self, a):
                 if memo is not None:
-                    setattr(t, a, copy.deepcopy(getattr(self, a, memo)))
+                    setattr(t, a, copy.deepcopy(getattr(self, a), memo))
                 else:
                     setattr(t, a, getattr(self, a))
         # fmt: on

--- a/lib/spack/external/patches/ruamelyaml.patch
+++ b/lib/spack/external/patches/ruamelyaml.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/spack/external/_vendoring/ruamel/yaml/comments.py b/lib/spack/external/_vendoring/ruamel/yaml/comments.py
+index 1badeda585..892c868af3 100644
+--- a/lib/spack/external/_vendoring/ruamel/yaml/comments.py
++++ b/lib/spack/external/_vendoring/ruamel/yaml/comments.py
+@@ -497,7 +497,7 @@ def copy_attributes(self, t, memo=None):
+                   Tag.attrib, merge_attrib]:
+             if hasattr(self, a):
+                 if memo is not None:
+-                    setattr(t, a, copy.deepcopy(getattr(self, a, memo)))
++                    setattr(t, a, copy.deepcopy(getattr(self, a), memo))
+                 else:
+                     setattr(t, a, getattr(self, a))
+         # fmt: on


### PR DESCRIPTION
Fix a quadratic complexity bug in ruamel yaml.

To reproduce:

```
N=256
spack env create -d .
spack -e . add $(spack list | head -n $N)
time spack -e . find
```

runs in

| N    | before (s)  | after (s) |
|------|---------|-------|
|  256 | 1.904   | 1.491 |
|  512 | 3.479   | 1.627 |
| 1024 | 9.277   | 2.092 |
| 2048 | 32.003  | 2.712 |
| 4096 | 126.028 | 4.135 |

from 2048 -> 4096 the quadratic bits are dominating ;)

Still awfully slow, though.

