### PR TITLE
ccache: Add 4.9.1

### DIFF
--- a/var/spack/repos/builtin/packages/ccache/package.py
+++ b/var/spack/repos/builtin/packages/ccache/package.py
@@ -23,6 +23,8 @@ class Ccache(CMakePackage):
 
     license("GPL-3.0-or-later")
 
+    version("4.9.1", sha256="12834ecaaaf2db069dda1d1d991f91c19e3274cc04a471af5b64195def17e90f")
+    version("4.8.3", sha256="d59dd569ad2bbc826c0bc335c8ebd73e78ed0f2f40ba6b30069347e63585d9ef")
     version("4.8.2", sha256="75eef15b8b9da48db9c91e1d0ff58b3645fc70c0e4ca2ef1b6825a12f21f217d")
     version("4.8.1", sha256="869903c1891beb8bee87f1ec94d8a0dad18c2add4072c456acbc85cdfc23ca63")
     version("4.8", sha256="ac4b01748fd59cfe07e070c34432b91bdd0fd8640e1e653a80b01d6a523186b0")
@@ -74,7 +76,7 @@ class Ccache(CMakePackage):
     conflicts("%clang@:7", when="@4.7:")
     conflicts("%clang@:4", when="@4.4:")
 
-    patch("fix-gcc-12.patch", when="%gcc@12")
+    patch("fix-gcc-12.patch", when="@4.8:4.8.2 %gcc@12")
 
     def cmake_args(self):
         return [


### PR DESCRIPTION
Add latest ccache version 4.9.1.

Also add older version 4.8.3, where the [gcc 12 fix was backported](https://ccache.dev/releasenotes.html#_build_improvements_2).

Only apply gcc 12 fix patch to ccache `4.8:` because it fails to apply to `4.7`.

~Also, gcc 12 bug will be [fixed in gcc 12.4](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109241).~
