### PR TITLE
Basic check for winsdk before concretizing

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -1572,12 +1572,15 @@ Microsoft Visual Studio
 """""""""""""""""""""""
 
 Microsoft Visual Studio provides the only Windows C/C++ compiler that is currently supported by Spack.
+Spack additionally requires that the Windows SDK (including WGL) to be installed as part of your
+visual studio installation as it is required to build many packages from source.
 
 We require several specific components to be included in the Visual Studio installation.
 One is the C/C++ toolset, which can be selected as "Desktop development with C++" or "C++ build tools,"
 depending on installation type (Professional, Build Tools, etc.)  The other required component is
 "C++ CMake tools for Windows," which can be selected from among the optional packages.
 This provides CMake and Ninja for use during Spack configuration.
+
 
 If you already have Visual Studio installed, you can make sure these components are installed by
 rerunning the installer.  Next to your installation, select "Modify" and look at the

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -579,8 +579,6 @@ def ensure_core_dependencies() -> None:
         ensure_patchelf_in_path_or_raise()
     if not IS_WINDOWS:
         ensure_gpg_in_path_or_raise()
-    else:
-        ensure_winsdk_external_or_raise()
     ensure_clingo_importable_or_raise()
 
 

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -538,12 +538,49 @@ def ensure_patchelf_in_path_or_raise() -> spack.util.executable.Executable:
         )
 
 
+def ensure_winsdk_external_or_raise() -> None:
+    """Ensure the Windows SDK + WGL are available on system
+    If both of these package are found, the Spack user or bootstrap
+    configuration (depending on where Spack is running)
+    will be updated to include all versions and variants detected.
+    If either the WDK or WSDK are not found, this method will raise
+    a RuntimeError.
+
+    **NOTE:** This modifies the Spack config in the current scope,
+    either user or environment depending on the calling context.
+    This is different from all other current bootstrap dependency
+    checks.
+    """
+    if set(["win-sdk", "wgl"]).issubset(spack.config.get("packages").keys()):
+        return
+    externals = spack.detection.by_path(["win-sdk", "wgl"])
+    if not set(["win-sdk", "wgl"]) == externals.keys():
+        missing_packages_lst = []
+        if "wgl" not in externals:
+            missing_packages_lst.append("wgl")
+        if "win-sdk" not in externals:
+            missing_packages_lst.append("win-sdk")
+        missing_packages = " & ".join(missing_packages_lst)
+        raise RuntimeError(
+            f"Unable to find the {missing_packages}, please install these packages\
+via the Visual Studio installer\
+before proceeding with Spack or provide the path to a non standard install via\
+'spack external find --path'"
+        )
+    # wgl/sdk are not required for bootstrapping Spack, but
+    # are required for building anything non trivial
+    # add to user config so they can be used by subsequent Spack ops
+    spack.detection.update_configuration(externals, buildable=False)
+
+
 def ensure_core_dependencies() -> None:
     """Ensure the presence of all the core dependencies."""
     if sys.platform.lower() == "linux":
         ensure_patchelf_in_path_or_raise()
     if not IS_WINDOWS:
         ensure_gpg_in_path_or_raise()
+    else:
+        ensure_winsdk_external_or_raise()
     ensure_clingo_importable_or_raise()
 
 

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -562,9 +562,9 @@ def ensure_winsdk_external_or_raise() -> None:
             missing_packages_lst.append("win-sdk")
         missing_packages = " & ".join(missing_packages_lst)
         raise RuntimeError(
-            f"Unable to find the {missing_packages}, please install these packages\
-via the Visual Studio installer\
-before proceeding with Spack or provide the path to a non standard install via\
+            f"Unable to find the {missing_packages}, please install these packages \
+via the Visual Studio installer \
+before proceeding with Spack or provide the path to a non standard install with \
 'spack external find --path'"
         )
     # wgl/sdk are not required for bootstrapping Spack, but

--- a/lib/spack/spack/cmd/unit_test.py
+++ b/lib/spack/spack/cmd/unit_test.py
@@ -214,8 +214,6 @@ def unit_test(parser, args, unknown_args):
 
     # Ensure clingo is available before switching to the
     # mock configuration used by unit tests
-    # Note: skip on windows here because for the moment,
-    # clingo is wholly unsupported from bootstrap
     with spack.bootstrap.ensure_bootstrap_configuration():
         spack.bootstrap.ensure_core_dependencies()
         if pytest is None:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -25,6 +25,7 @@ import llnl.util.tty as tty
 
 import spack
 import spack.binary_distribution
+import spack.bootstrap
 import spack.cmd
 import spack.compilers
 import spack.config
@@ -813,6 +814,12 @@ class PyclingoDriver:
 
         # Initialize the control object for the solver
         self.control = control or default_clingo_control()
+
+        # ensure core deps are present on Windows
+        # needs to modify active config scope, so cannot be run within
+        # bootstrap config scope
+        if sys.platform == "win32":
+            spack.bootstrap.core.ensure_winsdk_external_or_raise()
 
         timer.start("setup")
         asp_problem = setup.setup(specs, reuse=reuse, allow_deprecated=allow_deprecated)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -818,7 +818,7 @@ class PyclingoDriver:
         # needs to modify active config scope, so cannot be run within
         # bootstrap config scope
         if sys.platform == "win32":
-            tty.info("Ensuring basic dependencies {win-sdk, wgl} available")
+            tty.debug("Ensuring basic dependencies {win-sdk, wgl} available")
             spack.bootstrap.core.ensure_winsdk_external_or_raise()
 
         timer.start("setup")

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -808,6 +808,8 @@ class PyclingoDriver:
             A tuple of the solve result, the timer for the different phases of the
             solve, and the internal statistics from clingo.
         """
+        # avoid circular import
+        import spack.bootstrap
         output = output or DEFAULT_OUTPUT_CONFIGURATION
         timer = spack.util.timer.Timer()
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -810,6 +810,7 @@ class PyclingoDriver:
         """
         # avoid circular import
         import spack.bootstrap
+
         output = output or DEFAULT_OUTPUT_CONFIGURATION
         timer = spack.util.timer.Timer()
 
@@ -1405,7 +1406,6 @@ class SpackSolverSetup:
             raise ValueError(f"Must provide a name for anonymous condition: '{required_spec}'")
 
         with spec_with_name(required_spec, name):
-
             # Check if we can emit the requirements before updating the condition ID counter.
             # In this way, if a condition can't be emitted but the exception is handled in the
             # caller, we won't emit partial facts.

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -818,6 +818,7 @@ class PyclingoDriver:
         # needs to modify active config scope, so cannot be run within
         # bootstrap config scope
         if sys.platform == "win32":
+            tty.info("Ensuring basic dependencies {win-sdk, wgl} available")
             spack.bootstrap.core.ensure_winsdk_external_or_raise()
 
         timer.start("setup")

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -25,7 +25,6 @@ import llnl.util.tty as tty
 
 import spack
 import spack.binary_distribution
-import spack.bootstrap
 import spack.cmd
 import spack.compilers
 import spack.config

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -773,7 +773,9 @@ def monkeypatch_session():
 @pytest.fixture(scope="session", autouse=True)
 def mock_wsdk_externals(monkeypatch_session):
     """Skip check for required external packages on Windows during testing"""
-    monkeypatch_session.setattr(spack.bootstrap.core, "ensure_winsdk_external_or_raise", _return_none)
+    monkeypatch_session.setattr(
+        spack.bootstrap.core, "ensure_winsdk_external_or_raise", _return_none
+    )
 
 
 @pytest.fixture(scope="function")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -763,28 +763,10 @@ def mutable_empty_config(tmpdir_factory, configuration_dir):
         yield cfg
 
 
-@pytest.fixture(scope="session", autouse=True)
-def mock_wsdk_externals(mock_configuration_scopes):
-    with spack.config.use_configuration(*mock_configuration_scopes) as config:
-        mock_pkgs = spack.util.spack_yaml.syaml_dict()
-
-        def make_external_entry(name):
-            external_pkg_items = spack.util.spack_yaml.syaml_dict(
-                [
-                    ("spec", f"{name}@10.0.20348 plat=x64"),
-                    ("prefix", "C:/Program Files (x86)/Windows Kits/10"),
-                ]
-            )
-            external_pkg = spack.util.spack_yaml.syaml_dict()
-            external_pkg["externals"] = [external_pkg_items]
-            external_pkg["buildable"] = False
-            mock_pkgs[name] = external_pkg
-
-        make_external_entry("win-sdk")
-        make_external_entry("wgl")
-        pkgs_cfg = config.get("packages")
-        pkgs_cfg = spack.config.merge_yaml(pkgs_cfg, mock_pkgs)
-        config.set("packages", pkgs_cfg)
+@pytest.fixture(scope="function", autouse=True)
+def mock_wsdk_externals(monkeypatch):
+    """Skip check for required external packages on Windows during testing"""
+    monkeypatch.setattr(spack.bootstrap.core, "ensure_winsdk_external_or_raise", _return_none)
 
 
 @pytest.fixture(scope="function")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -763,6 +763,30 @@ def mutable_empty_config(tmpdir_factory, configuration_dir):
         yield cfg
 
 
+@pytest.fixture(scope="session", autouse=True)
+def mock_wsdk_externals(mock_configuration_scopes):
+    with spack.config.use_configuration(*mock_configuration_scopes) as config:
+        mock_pkgs = spack.util.spack_yaml.syaml_dict()
+
+        def make_external_entry(name):
+            external_pkg_items = spack.util.spack_yaml.syaml_dict(
+                [
+                    ("spec", f"{name}@10.0.20348 plat=x64"),
+                    ("prefix", "C:/Program Files (x86)/Windows Kits/10"),
+                ]
+            )
+            external_pkg = spack.util.spack_yaml.syaml_dict()
+            external_pkg["externals"] = [external_pkg_items]
+            external_pkg["buildable"] = False
+            mock_pkgs[name] = external_pkg
+
+        make_external_entry("win-sdk")
+        make_external_entry("wgl")
+        pkgs_cfg = config.get("packages")
+        pkgs_cfg = spack.config.merge_yaml(pkgs_cfg, mock_pkgs)
+        config.set("packages", pkgs_cfg)
+
+
 @pytest.fixture(scope="function")
 def concretize_scope(mutable_config, tmpdir):
     """Adds a scope for concretization preferences"""

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -763,7 +763,10 @@ def mutable_empty_config(tmpdir_factory, configuration_dir):
         yield cfg
 
 
-# From https://github.com/pytest-dev/pytest/issues/363
+# From  https://github.com/pytest-dev/pytest/issues/363#issuecomment-1335631998
+# Current suggested implementation from issue compatible with pytest >= 6.2
+# this may be subject to change as new versions of Pytest are released
+# and update the suggested solution
 @pytest.fixture(scope="session")
 def monkeypatch_session():
     with pytest.MonkeyPatch.context() as monkeypatch:
@@ -772,7 +775,11 @@ def monkeypatch_session():
 
 @pytest.fixture(scope="session", autouse=True)
 def mock_wsdk_externals(monkeypatch_session):
-    """Skip check for required external packages on Windows during testing"""
+    """Skip check for required external packages on Windows during testing
+    Note: In general this should cover this behavior for all tests,
+    however any session scoped fixture involving concretization should
+    include this fixture
+    """
     monkeypatch_session.setattr(
         spack.bootstrap.core, "ensure_winsdk_external_or_raise", _return_none
     )


### PR DESCRIPTION
Adds a pre-concretization check in asp.py for the Windows SDK and WGL (Windows GL) packages as non-buildable externals.
Previously this was incorporated into `ensure_core_depenendencies` in the bootstrap module, but that scoped the config modifications to the bootstrap scope, which made the changes fundamentally useless for general purpose use, so we transitioned to a pre concretization call to ensure these packages are always available pre concretization.

The goal is to achieve parity with most unix-like systems where we have a consistent understanding of the system (potentially hardware accelerated) GL location and can reasonably rely on that heuristic to bake the external into packages.yaml. 
Adds documentation to the startup guide denoting that the SDK is a hard requirement for Spack now.
Adds error handling if WGL and WSDK cannot be detected on system.

Adds pytest fixture mocking the check for WGL and WSDK as if they were present
> Note: This fixture requires the `session` scope in order to avoid a race where certain fixtures are invoked first without the mocked WSDK check. Typical pytest `monkeypatch` fixtures are `function` scope, which is incompatible with session scoped fixtures. This required the introduction of a session scoped `monkeypatch` fixture named `monkeypatch_session`.