### PR TITLE
Fix typo preventing correct stage computation in pipelines

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -205,7 +205,7 @@ def _extract_dag(specs: List[spack.spec.Spec]) -> Tuple[PlainNodes, PlainEdges]:
     nodes: PlainNodes = {}
     edges: PlainEdges = defaultdict(set)
 
-    for edge in traverse.traverse_edges(specs):
+    for edge in traverse.traverse_edges(specs, cover="edges"):
         if (edge.parent and edge.parent.external) or edge.spec.external:
             continue
         child_id = _spec_ci_label(edge.spec)


### PR DESCRIPTION
Introduced in #43759 

closes #43760

We want to visit all the edges once (the default is to visit all nodes once).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
