### PR TITLE
nettle: remove openssl dep

### DIFF
--- a/var/spack/repos/builtin/packages/nettle/package.py
+++ b/var/spack/repos/builtin/packages/nettle/package.py
@@ -26,7 +26,11 @@ class Nettle(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on("gmp")
     depends_on("m4", type="build")
-    depends_on("openssl")
+
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            flags.append(self.compiler.c99_flag)
+        return (flags, None, None)
 
     def configure_args(self):
-        return ["CFLAGS={0}".format(self.compiler.c99_flag)]
+        return ["--disable-openssl"]


### PR DESCRIPTION
Closes #43768

The configure script unconditionally looks for openssl headers, but
`--disable-openssl` undefines `WITH_OPENSSL` which is ifdef'd for the entire
file in 

https://github.com/gnutls/nettle/blob/775d6adb77a885616ef3a9fcbc4c087cad129f3d/examples/nettle-openssl.c#L41

so should be good like this.
