### PR TITLE
Remove `import distro` outside of internals

### DIFF
--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -552,11 +552,11 @@ With either interpreter you can run a single command:
 
 .. code-block:: console
 
-   $ spack python -c 'import distro; distro.linux_distribution()'
-   ('Ubuntu', '18.04', 'Bionic Beaver')
+   $ spack python -c 'from spack.spec import Spec; Spec("python").concretized()'
+   ...
 
-   $ spack python -i ipython -c 'import distro; distro.linux_distribution()'
-   Out[1]: ('Ubuntu', '18.04', 'Bionic Beaver')
+   $ spack python -i ipython -c 'from spack.spec import Spec; Spec("python").concretized()'
+   Out[1]: ...
 
 or a file:
 

--- a/var/spack/repos/builtin/packages/hip-tensor/package.py
+++ b/var/spack/repos/builtin/packages/hip-tensor/package.py
@@ -31,4 +31,4 @@ class HipTensor(CMakePackage, ROCmPackage):
     def setup_build_environment(self, env):
         env.set("CXX", self.spec["hip"].hipcc)
         if self.spec.satisfies("+asan"):
-            self.asan_on(env, self.spec["llvm-amdgpu"].prefix)
+            self.asan_on(env)

--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -117,7 +117,7 @@ class Hipblas(CMakePackage, CudaPackage, ROCmPackage):
 
     def setup_build_environment(self, env):
         if self.spec.satisfies("+asan"):
-            self.asan_on(env, self.spec["llvm-amdgpu"].prefix)
+            self.asan_on(env)
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/hipcub/package.py
+++ b/var/spack/repos/builtin/packages/hipcub/package.py
@@ -89,7 +89,7 @@ class Hipcub(CMakePackage, CudaPackage, ROCmPackage):
         if self.spec.satisfies("+rocm"):
             env.set("CXX", self.spec["hip"].hipcc)
         if self.spec.satisfies("+asan"):
-            self.asan_on(env, self.spec["llvm-amdgpu"].prefix)
+            self.asan_on(env)
 
     def cmake_args(self):
         args = [self.define("BUILD_TEST", self.run_tests)]

--- a/var/spack/repos/builtin/packages/hipfft/package.py
+++ b/var/spack/repos/builtin/packages/hipfft/package.py
@@ -94,7 +94,7 @@ class Hipfft(CMakePackage, CudaPackage, ROCmPackage):
 
     def setup_build_environment(self, env):
         if self.spec.satisfies("+asan"):
-            self.asan_on(env, self.spec["llvm-amdgpu"].prefix)
+            self.asan_on(env)
 
     def cmake_args(self):
         args = [self.define("BUILD_CLIENTS_SAMPLES", "OFF")]

--- a/var/spack/repos/builtin/packages/hiprand/package.py
+++ b/var/spack/repos/builtin/packages/hiprand/package.py
@@ -108,7 +108,7 @@ class Hiprand(CMakePackage, CudaPackage, ROCmPackage):
     def setup_build_environment(self, env):
         env.set("CXX", self.spec["hip"].hipcc)
         if self.spec.satisfies("+asan"):
-            self.asan_on(env, self.spec["llvm-amdgpu"].prefix)
+            self.asan_on(env)
 
     @classmethod
     def determine_version(cls, lib):

--- a/var/spack/repos/builtin/packages/hipsolver/package.py
+++ b/var/spack/repos/builtin/packages/hipsolver/package.py
@@ -127,7 +127,7 @@ class Hipsolver(CMakePackage, CudaPackage, ROCmPackage):
 
     def setup_build_environment(self, env):
         if self.spec.satisfies("+asan"):
-            self.asan_on(env, self.spec["llvm-amdgpu"].prefix)
+            self.asan_on(env)
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/hipsparse/package.py
+++ b/var/spack/repos/builtin/packages/hipsparse/package.py
@@ -103,7 +103,7 @@ class Hipsparse(CMakePackage, CudaPackage, ROCmPackage):
 
     def setup_build_environment(self, env):
         if self.spec.satisfies("+asan"):
-            self.asan_on(env, self.spec["llvm-amdgpu"].prefix)
+            self.asan_on(env)
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/roctracer-dev/package.py
+++ b/var/spack/repos/builtin/packages/roctracer-dev/package.py
@@ -105,7 +105,7 @@ class RoctracerDev(CMakePackage, ROCmPackage):
 
     def setup_build_environment(self, env):
         if self.spec.satisfies("+asan"):
-            self.asan_on(env, self.spec["llvm-amdgpu"].prefix)
+            self.asan_on(env)
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
the rocm packages should obviously not use `import distro`.
