### PR TITLE
Do not detect a compiler without a C compiler

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -970,7 +970,10 @@ def make_compiler_list(
     compilers = []
     for compiler_id, _, compiler in flat_compilers:
         make_compilers = getattr(compiler_id.os, "make_compilers", _default_make_compilers)
-        compilers.extend(make_compilers(compiler_id, compiler))
+        candidates = make_compilers(compiler_id, compiler)
+        # Discard candidates without a C compiler
+        candidates = [x for x in candidates if x.cc is not None]
+        compilers.extend(candidates)
 
     return compilers
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -967,7 +967,7 @@ def make_compiler_list(
         make_mixed_toolchain(flat_compilers)
 
     # Finally, create the compiler list
-    compilers = []
+    compilers: List["spack.compiler.Compiler"] = []
     for compiler_id, _, compiler in flat_compilers:
         make_compilers = getattr(compiler_id.os, "make_compilers", _default_make_compilers)
         candidates = make_compilers(compiler_id, compiler)

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -971,9 +971,7 @@ def make_compiler_list(
     for compiler_id, _, compiler in flat_compilers:
         make_compilers = getattr(compiler_id.os, "make_compilers", _default_make_compilers)
         candidates = make_compilers(compiler_id, compiler)
-        # Discard candidates without a C compiler
-        candidates = [x for x in candidates if x.cc is not None]
-        compilers.extend(candidates)
+        compilers.extend(x for x in candidates if x.cc is not None)
 
     return compilers
 

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -894,3 +894,52 @@ def test_compiler_executable_verification_success(tmpdir):
     # Test that null entries don't fail
     compiler.cc = None
     compiler.verify_executables()
+
+
+@pytest.mark.parametrize(
+    "detected_versions,expected_length",
+    [
+        # If we detect a C compiler we expect the result to be valid
+        (
+            [
+                spack.compilers.DetectVersionArgs(
+                    id=spack.compilers.CompilerID(
+                        os="ubuntu20.04", compiler_name="clang", version="12.0.0"
+                    ),
+                    variation=spack.compilers.NameVariation(prefix="", suffix="-12"),
+                    language="cc",
+                    path="/usr/bin/clang-12",
+                ),
+                spack.compilers.DetectVersionArgs(
+                    id=spack.compilers.CompilerID(
+                        os="ubuntu20.04", compiler_name="clang", version="12.0.0"
+                    ),
+                    variation=spack.compilers.NameVariation(prefix="", suffix="-12"),
+                    language="cxx",
+                    path="/usr/bin/clang++-12",
+                ),
+            ],
+            1,
+        ),
+        # If we detect only a C++ compiler we expect the result to be discarded
+        (
+            [
+                spack.compilers.DetectVersionArgs(
+                    id=spack.compilers.CompilerID(
+                        os="ubuntu20.04", compiler_name="clang", version="12.0.0"
+                    ),
+                    variation=spack.compilers.NameVariation(prefix="", suffix="-12"),
+                    language="cxx",
+                    path="/usr/bin/clang++-12",
+                )
+            ],
+            0,
+        ),
+    ],
+)
+def test_detection_requires_c_compiler(detected_versions, expected_length):
+    """Tests that compilers automatically added to the configuration have
+    at least a C compiler.
+    """
+    result = spack.compilers.make_compiler_list(detected_versions)
+    assert len(result) == expected_length


### PR DESCRIPTION
When running `spack compiler find` only compilers with a cc executable will be considered.

This PR is motivated by the recent deprecation by Intel of their C and C++ classic compilers, in recent OneAPI releases. Classic Fortran compilers will be deprecated later in 2024, and this currently leads Spack to detect:
```yaml
- compiler:
    spec: intel@=2021.12.0
    paths:
      cc: null
      cxx: null
      f77: /opt/intel/oneapi/2024.1/bin/ifort
      fc: /opt/intel/oneapi/2024.1/bin/ifort
    flags: {}
    operating_system: ubuntu20.04
    target: x86_64
    modules: []
    environment: {}
    extra_rpaths: []
```
Obviously the `%intel` compiler is mostly unusable.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
