### PR TITLE
fix(adios2): fix missing stdind include in 2.7

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/2.7-fix-missing-cstdint-include.patch
+++ b/var/spack/repos/builtin/packages/adios2/2.7-fix-missing-cstdint-include.patch
@@ -1,0 +1,24 @@
+From abbe0f81d78403a62444b1a76222b9a226fd17c6 Mon Sep 17 00:00:00 2001
+From: Vicente Adolfo Bolea Sanchez <vicente.bolea@kitware.com>
+Date: Mon, 22 Apr 2024 20:52:49 -0700
+Subject: [PATCH] fix py11bind stdint dep
+
+---
+ thirdparty/pybind11/pybind11/include/pybind11/pybind11.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/thirdparty/pybind11/pybind11/include/pybind11/pybind11.h b/thirdparty/pybind11/pybind11/include/pybind11/pybind11.h
+index fa98f7c18..6992c3d55 100644
+--- a/thirdparty/pybind11/pybind11/include/pybind11/pybind11.h
++++ b/thirdparty/pybind11/pybind11/include/pybind11/pybind11.h
+@@ -47,6 +47,7 @@
+ #include "detail/class.h"
+ #include "detail/init.h"
+ 
++#include <cstdint>
+ #include <memory>
+ #include <vector>
+ #include <string>
+-- 
+2.35.3
+

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -209,6 +209,9 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     # See https://github.com/ornladios/ADIOS2/pull/2714
     patch("2.6-fix-gcc10-symbols.patch", when="@2.6.0")
 
+    # add missing include <cstdint>
+    patch("2.7-fix-missing-cstdint-include.patch", when="@2.7")
+
     # Add missing include <memory>
     # https://github.com/ornladios/adios2/pull/2710
     patch(


### PR DESCRIPTION
Fixes: https://github.com/spack/spack/issues/43495