### PR TITLE
libc: from current python process

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -12,7 +12,6 @@ import shlex
 import shutil
 import sys
 import tempfile
-from subprocess import PIPE, run
 from typing import List, Optional, Sequence
 
 import llnl.path
@@ -24,6 +23,7 @@ import spack.compilers
 import spack.error
 import spack.spec
 import spack.util.executable
+import spack.util.libc
 import spack.util.module_cmd
 import spack.version
 from spack.util.environment import filter_system_paths
@@ -195,98 +195,6 @@ def _parse_dynamic_linker(output: str):
                 return args[idx + 1]
             elif arg.startswith("--dynamic-linker=") or arg.startswith("-dynamic-linker="):
                 return arg.split("=", 1)[1]
-
-
-def _libc_from_ldd(ldd: str) -> Optional["spack.spec.Spec"]:
-    try:
-        result = run([ldd, "--version"], stdout=PIPE, stderr=PIPE, check=False)
-        stdout = result.stdout.decode("utf-8")
-    except Exception:
-        return None
-
-    if not re.search("gnu|glibc", stdout, re.IGNORECASE):
-        return None
-
-    version_str = re.match(r".+\(.+\) (.+)", stdout)
-    if not version_str:
-        return None
-    try:
-        return spack.spec.Spec(f"glibc@={version_str.group(1)}")
-    except Exception:
-        return None
-
-
-def _libc_from_dynamic_linker(dynamic_linker: str) -> Optional["spack.spec.Spec"]:
-    if not os.path.exists(dynamic_linker):
-        return None
-
-    # The dynamic linker is usually installed in the same /lib(64)?/ld-*.so path across all
-    # distros. The rest of libc is elsewhere, e.g. /usr. Typically the dynamic linker is then
-    # a symlink into /usr/lib, which we use to for determining the actual install prefix of
-    # libc.
-    realpath = os.path.realpath(dynamic_linker)
-
-    prefix = os.path.dirname(realpath)
-    # Remove the multiarch suffix if it exists
-    if os.path.basename(prefix) not in ("lib", "lib64"):
-        prefix = os.path.dirname(prefix)
-
-    # Non-standard install layout -- just bail.
-    if os.path.basename(prefix) not in ("lib", "lib64"):
-        return None
-
-    prefix = os.path.dirname(prefix)
-
-    # Now try to figure out if glibc or musl, which is the only ones we support.
-    # In recent glibc we can simply execute the dynamic loader. In musl that's always the case.
-    try:
-        result = run([dynamic_linker, "--version"], stdout=PIPE, stderr=PIPE, check=False)
-        stdout = result.stdout.decode("utf-8")
-        stderr = result.stderr.decode("utf-8")
-    except Exception:
-        return None
-
-    # musl prints to stderr
-    if stderr.startswith("musl libc"):
-        version_str = re.search(r"^Version (.+)$", stderr, re.MULTILINE)
-        if not version_str:
-            return None
-        try:
-            spec = spack.spec.Spec(f"musl@={version_str.group(1)}")
-            spec.external_path = prefix
-            return spec
-        except Exception:
-            return None
-    elif re.search("gnu|glibc", stdout, re.IGNORECASE):
-        # output is like "ld.so (...) stable release version 2.33." write a regex for it
-        match = re.search(r"version (\d+\.\d+(?:\.\d+)?)", stdout)
-        if not match:
-            return None
-        try:
-            version = match.group(1)
-            spec = spack.spec.Spec(f"glibc@={version}")
-            spec.external_path = prefix
-            return spec
-        except Exception:
-            return None
-    else:
-        # Could not get the version by running the dynamic linker directly. Instead locate `ldd`
-        # relative to the dynamic linker.
-        ldd = os.path.join(prefix, "bin", "ldd")
-        if not os.path.exists(ldd):
-            # If `/lib64/ld.so` was not a symlink to `/usr/lib/ld.so` we can try to use /usr as
-            # prefix. This is the case on ubuntu 18.04 where /lib != /usr/lib.
-            if prefix != "/":
-                return None
-            prefix = "/usr"
-            ldd = os.path.join(prefix, "bin", "ldd")
-            if not os.path.exists(ldd):
-                return None
-        maybe_spec = _libc_from_ldd(ldd)
-        if not maybe_spec:
-            return None
-        maybe_spec.external_path = prefix
-        return maybe_spec
 
 
 def in_system_subdirectory(path):
@@ -536,7 +444,9 @@ class Compiler:
         all_required_libs = list(self.required_libs) + Compiler._all_compiler_rpath_libraries
         return list(paths_containing_libs(link_dirs, all_required_libs))
 
+    @property
     def default_libc(self) -> Optional["spack.spec.Spec"]:
+        """Determine libc targeted by the compiler from link line"""
         output = self.compiler_verbose_output
 
         if not output:
@@ -547,7 +457,7 @@ class Compiler:
         if not dynamic_linker:
             return None
 
-        return _libc_from_dynamic_linker(dynamic_linker)
+        return spack.util.libc.libc_from_dynamic_linker(dynamic_linker)
 
     @property
     def required_libs(self):

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -332,7 +332,7 @@ def all_compilers_config(
     *,
     scope: Optional[str] = None,
     init_config: bool = True,
-) -> List["spack.compiler.Compiler"]:
+) -> List[dict]:
     """Return a set of specs for all the compiler versions currently
     available to build with.  These are instances of CompilerSpec.
     """
@@ -517,7 +517,9 @@ def all_compilers(scope=None, init_config=True):
     )
 
 
-def all_compilers_from(configuration, scope=None, init_config=True):
+def all_compilers_from(
+    configuration, scope=None, init_config=True
+) -> List[spack.compiler.Compiler]:
     compilers = []
     for items in all_compilers_config(
         configuration=configuration, scope=scope, init_config=init_config

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -332,7 +332,7 @@ def all_compilers_config(
     *,
     scope: Optional[str] = None,
     init_config: bool = True,
-) -> List[dict]:
+) -> List["spack.compiler.Compiler"]:
     """Return a set of specs for all the compiler versions currently
     available to build with.  These are instances of CompilerSpec.
     """
@@ -517,9 +517,7 @@ def all_compilers(scope=None, init_config=True):
     )
 
 
-def all_compilers_from(
-    configuration, scope=None, init_config=True
-) -> List[spack.compiler.Compiler]:
+def all_compilers_from(configuration, scope=None, init_config=True):
     compilers = []
     for items in all_compilers_config(
         configuration=configuration, scope=scope, init_config=init_config

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2349,7 +2349,7 @@ class SpackSolverSetup:
         node_counter = _create_counter(specs, tests=self.tests)
         self.possible_virtuals = node_counter.possible_virtuals()
         self.pkgs = node_counter.possible_dependencies()
-        self.libcs = sorted(all_libcs())
+        self.libcs = sorted(all_libcs())  # type: ignore[type-var]
 
         # Fail if we already know an unreachable node is requested
         for spec in specs:

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1082,6 +1082,9 @@ error(100, "{0} compiler '{2}@{3}' incompatible with 'target={1}'", Package, Tar
      compiler_version(CompilerID, Version),
      build(node(X, Package)).
 
+#defined compiler_supports_target/2.
+#defined compiler_available/1.
+
 % if a target is set explicitly, respect it
 attr("node_target", PackageNode, Target)
  :- attr("node", PackageNode), attr("node_target_set", PackageNode, Target).

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -83,7 +83,7 @@ def binary_compatibility(monkeypatch, request):
         return
 
     monkeypatch.setattr(spack.solver.asp, "using_libc_compatibility", lambda: True)
-    monkeypatch.setattr(spack.compiler.Compiler, "default_libc", lambda x: Spec("glibc@=2.28"))
+    monkeypatch.setattr(spack.compiler.Compiler, "default_libc", Spec("glibc@=2.28"))
 
 
 @pytest.fixture(

--- a/lib/spack/spack/util/elf.py
+++ b/lib/spack/spack/util/elf.py
@@ -641,6 +641,20 @@ def substitute_rpath_and_pt_interp_in_place_or_raise(
         return False
 
 
+def pt_interp(path: str) -> Optional[str]:
+    """Retrieve the interpreter of an executable at `path`."""
+    try:
+        with open(path, "rb") as f:
+            elf = parse_elf(f, interpreter=True)
+    except (OSError, ElfParsingError):
+        return None
+
+    if not elf.has_pt_interp:
+        return None
+
+    return elf.pt_interp_str.decode("utf-8")
+
+
 class ElfCStringUpdatesFailed(Exception):
     def __init__(
         self, rpath: Optional[UpdateCStringAction], pt_interp: Optional[UpdateCStringAction]

--- a/lib/spack/spack/util/libc.py
+++ b/lib/spack/spack/util/libc.py
@@ -13,7 +13,7 @@ import spack.spec
 import spack.util.elf
 
 
-def _libc_from_ldd(ldd: str) -> Optional[spack.spec.Spec]:
+def _libc_from_ldd(ldd: str) -> Optional["spack.spec.Spec"]:
     try:
         result = run([ldd, "--version"], stdout=PIPE, stderr=PIPE, check=False)
         stdout = result.stdout.decode("utf-8")
@@ -32,7 +32,7 @@ def _libc_from_ldd(ldd: str) -> Optional[spack.spec.Spec]:
         return None
 
 
-def libc_from_dynamic_linker(dynamic_linker: str) -> Optional[spack.spec.Spec]:
+def libc_from_dynamic_linker(dynamic_linker: str) -> Optional["spack.spec.Spec"]:
     if not os.path.exists(dynamic_linker):
         return None
 
@@ -105,7 +105,7 @@ def libc_from_dynamic_linker(dynamic_linker: str) -> Optional[spack.spec.Spec]:
         return maybe_spec
 
 
-def libc_from_current_python_process() -> Optional[spack.spec.Spec]:
+def libc_from_current_python_process() -> Optional["spack.spec.Spec"]:
     if not sys.executable:
         return None
 

--- a/lib/spack/spack/util/libc.py
+++ b/lib/spack/spack/util/libc.py
@@ -1,0 +1,117 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+import re
+import sys
+from subprocess import PIPE, run
+from typing import Optional
+
+import spack.spec
+import spack.util.elf
+
+
+def _libc_from_ldd(ldd: str) -> Optional[spack.spec.Spec]:
+    try:
+        result = run([ldd, "--version"], stdout=PIPE, stderr=PIPE, check=False)
+        stdout = result.stdout.decode("utf-8")
+    except Exception:
+        return None
+
+    if not re.search("gnu|glibc", stdout, re.IGNORECASE):
+        return None
+
+    version_str = re.match(r".+\(.+\) (.+)", stdout)
+    if not version_str:
+        return None
+    try:
+        return spack.spec.Spec(f"glibc@={version_str.group(1)}")
+    except Exception:
+        return None
+
+
+def libc_from_dynamic_linker(dynamic_linker: str) -> Optional[spack.spec.Spec]:
+    if not os.path.exists(dynamic_linker):
+        return None
+
+    # The dynamic linker is usually installed in the same /lib(64)?/ld-*.so path across all
+    # distros. The rest of libc is elsewhere, e.g. /usr. Typically the dynamic linker is then
+    # a symlink into /usr/lib, which we use to for determining the actual install prefix of
+    # libc.
+    realpath = os.path.realpath(dynamic_linker)
+
+    prefix = os.path.dirname(realpath)
+    # Remove the multiarch suffix if it exists
+    if os.path.basename(prefix) not in ("lib", "lib64"):
+        prefix = os.path.dirname(prefix)
+
+    # Non-standard install layout -- just bail.
+    if os.path.basename(prefix) not in ("lib", "lib64"):
+        return None
+
+    prefix = os.path.dirname(prefix)
+
+    # Now try to figure out if glibc or musl, which is the only ones we support.
+    # In recent glibc we can simply execute the dynamic loader. In musl that's always the case.
+    try:
+        result = run([dynamic_linker, "--version"], stdout=PIPE, stderr=PIPE, check=False)
+        stdout = result.stdout.decode("utf-8")
+        stderr = result.stderr.decode("utf-8")
+    except Exception:
+        return None
+
+    # musl prints to stderr
+    if stderr.startswith("musl libc"):
+        version_str = re.search(r"^Version (.+)$", stderr, re.MULTILINE)
+        if not version_str:
+            return None
+        try:
+            spec = spack.spec.Spec(f"musl@={version_str.group(1)}")
+            spec.external_path = prefix
+            return spec
+        except Exception:
+            return None
+    elif re.search("gnu|glibc", stdout, re.IGNORECASE):
+        # output is like "ld.so (...) stable release version 2.33." write a regex for it
+        match = re.search(r"version (\d+\.\d+(?:\.\d+)?)", stdout)
+        if not match:
+            return None
+        try:
+            version = match.group(1)
+            spec = spack.spec.Spec(f"glibc@={version}")
+            spec.external_path = prefix
+            return spec
+        except Exception:
+            return None
+    else:
+        # Could not get the version by running the dynamic linker directly. Instead locate `ldd`
+        # relative to the dynamic linker.
+        ldd = os.path.join(prefix, "bin", "ldd")
+        if not os.path.exists(ldd):
+            # If `/lib64/ld.so` was not a symlink to `/usr/lib/ld.so` we can try to use /usr as
+            # prefix. This is the case on ubuntu 18.04 where /lib != /usr/lib.
+            if prefix != "/":
+                return None
+            prefix = "/usr"
+            ldd = os.path.join(prefix, "bin", "ldd")
+            if not os.path.exists(ldd):
+                return None
+        maybe_spec = _libc_from_ldd(ldd)
+        if not maybe_spec:
+            return None
+        maybe_spec.external_path = prefix
+        return maybe_spec
+
+
+def libc_from_current_python_process() -> Optional[spack.spec.Spec]:
+    if not sys.executable:
+        return None
+
+    dynamic_linker = spack.util.elf.pt_interp(sys.executable)
+
+    if not dynamic_linker:
+        return None
+
+    return libc_from_dynamic_linker(dynamic_linker)


### PR DESCRIPTION
If there's no compiler we currently don't have any external libc for the solver.

This commit adds a fallback on libc from the current Python process, which works if it is dynamically linked.
