### PR TITLE
[TAU Package] Updates for rocm

### DIFF
--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -140,6 +140,8 @@ class Tau(Package):
     depends_on("roctracer-dev", when="+roctracer")
     depends_on("hsa-rocr-dev", when="+rocm")
     depends_on("rocm-smi-lib", when="@2.32.1: +rocm")
+    depends_on("rocm-core", when="@2.34: +rocm")
+    depends_on("hip", when="@2.34: +roctracer")
     depends_on("java", type="run")  # for paraprof
     depends_on("oneapi-level-zero", when="+level_zero")
     depends_on("dyninst@12.3.0:", when="+dyninst")
@@ -154,6 +156,17 @@ class Tau(Package):
     conflicts("+dyninst", when="@:2.32.1")
     conflicts("+disable-no-pie", when="@:2.33.2")
     patch("unwind.patch", when="@2.29.0")
+
+    conflicts("+rocprofiler", when="+roctracer", msg="Use either rocprofiler or roctracer")
+    requires("+rocm", when="+rocprofiler", msg="Rocprofiler requires ROCm")
+    requires("+rocm", when="+roctracer", msg="Roctracer requires ROCm")
+
+    requires(
+        "+rocprofiler", "+roctracer",
+        policy="one_of",
+        when="+rocm",
+        msg="When using ROCm, you need to select either +rocprofiler or +roctracer"
+    )
 
     filter_compiler_wrappers("Makefile", relative_root="include")
     filter_compiler_wrappers("Makefile.tau*", relative_root="lib")
@@ -316,12 +329,16 @@ class Tau(Package):
             options.append("-rocm=%s" % spec["hsa-rocr-dev"].prefix)
             if spec.satisfies("@2.32.1"):
                 options.append("-rocmsmi=%s" % spec["rocm-smi-lib"].prefix)
+            if spec.satisfies("@2.34:"):
+                options.append("-rocm-core=%s" % spec["rocm-core"].prefix)
 
         if "+rocprofiler" in spec:
             options.append("-rocprofiler=%s" % spec["rocprofiler-dev"].prefix)
 
         if "+roctracer" in spec:
             options.append("-roctracer=%s" % spec["roctracer-dev"].prefix)
+            if spec.satisfies("@2.34:"):
+                options.append("-hip=%s" % spec["hip"].prefix)
 
         if "+adios2" in spec:
             options.append("-adios=%s" % spec["adios2"].prefix)
@@ -546,6 +563,8 @@ class Tau(Package):
         )
 
     def test(self):
+        #Temporarily disable tests, will update them with the new test method.
+        return
         test_dir = self.test_suite.current_test_cache_dir
         # Run mm test program pulled from the build
         if "+ompt" in self.spec:

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -162,10 +162,11 @@ class Tau(Package):
     requires("+rocm", when="+roctracer", msg="Roctracer requires ROCm")
 
     requires(
-        "+rocprofiler", "+roctracer",
+        "+rocprofiler",
+        "+roctracer",
         policy="one_of",
         when="+rocm",
-        msg="When using ROCm, you need to select either +rocprofiler or +roctracer"
+        msg="When using ROCm, you need to select either +rocprofiler or +roctracer",
     )
 
     filter_compiler_wrappers("Makefile", relative_root="include")
@@ -563,7 +564,7 @@ class Tau(Package):
         )
 
     def test(self):
-        #Temporarily disable tests, will update them with the new test method.
+        # Temporarily disable tests, will update them with the new test method.
         return
         test_dir = self.test_suite.current_test_cache_dir
         # Run mm test program pulled from the build


### PR DESCRIPTION
Updated for rocm@6
Added conflict between rocprofiler and roctracer.
Request either +rocprofiler or +roctracer when +rocm. In this case, it automatically builds for one, instead of displaying the message.  Request +rocm when using either +rocprofiler or +roctracer. In this case, it automatically builds with +rocm, instead of displaying the message.

Disabled the tests. Will update them with the new test method.


@spackbot fix style
@spackbot help