### PR TITLE
Use Prefix class for build_directory for CMake and a few other builders.

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -19,6 +19,7 @@ import spack.deptypes as dt
 import spack.package_base
 from spack.directives import build_system, conflicts, depends_on, variant
 from spack.multimethod import when
+from spack.util.prefix import Prefix
 
 from ._checks import BaseBuilder, execute_build_time_tests
 
@@ -526,7 +527,7 @@ class CMakeBuilder(BaseBuilder):
     @property
     def build_directory(self):
         """Full-path to the directory to use when building the package."""
-        return os.path.join(self.pkg.stage.path, self.build_dirname)
+        return Prefix(self.pkg.stage.path).join(self.build_dirname)
 
     def cmake_args(self):
         """List of all the arguments that must be passed to cmake, except:

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -12,6 +12,7 @@ import spack.builder
 import spack.package_base
 from spack.directives import build_system, conflicts, depends_on, variant
 from spack.multimethod import when
+from spack.util.prefix import Prefix
 
 from ._checks import BaseBuilder, execute_build_time_tests
 
@@ -171,7 +172,7 @@ class MesonBuilder(BaseBuilder):
     @property
     def build_directory(self):
         """Directory to use when building the package."""
-        return os.path.join(self.pkg.stage.path, self.build_dirname)
+        return Prefix(self.pkg.stage.path).join(self.build_dirname)
 
     def meson_args(self):
         """List of arguments that must be passed to meson, except:

--- a/lib/spack/spack/build_systems/racket.py
+++ b/lib/spack/spack/build_systems/racket.py
@@ -16,6 +16,7 @@ from spack.package_base import PackageBase
 from spack.util.cpus import determine_number_of_jobs
 from spack.util.environment import env_flag
 from spack.util.executable import Executable, ProcessError
+from spack.util.prefix import Prefix
 
 
 class RacketPackage(PackageBase):
@@ -73,7 +74,7 @@ class RacketBuilder(spack.builder.Builder):
         ret = os.getcwd()
         if self.subdirectory:
             ret = os.path.join(ret, self.subdirectory)
-        return ret
+        return Prefix(ret)
 
     def install(self, pkg, spec, prefix):
         """Install everything from build directory."""

--- a/lib/spack/spack/util/prefix.py
+++ b/lib/spack/spack/util/prefix.py
@@ -48,7 +48,7 @@ class Prefix(str):
         Returns:
             the newly created installation prefix
         """
-        return Prefix(os.path.join(self, name))
+        return self.join(name)
 
     def join(self, string: str) -> "Prefix":  # type: ignore[override]
         """Concatenate a string to a prefix.


### PR DESCRIPTION
The `spack.util.prefix.Prefix` class enables simple joining of path names.  Users are accustomed to using this facility for the `self.prefix` attribute in a recipe's (e.g.) `setup_run_environment(self, env)` method.  Something similar should exist for `self.build_directory`, but it does not appear to be uniformly followed.

This PR fixes that inconsistency.