### PR TITLE
pythia8: patch latest 8.311 for upstream bug

### DIFF
--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -135,7 +135,7 @@ class Pythia8(AutotoolsPackage):
         )
 
     # Fix for https://gitlab.com/Pythia8/releases/-/issues/428
-    @when("@:8.311") 
+    @when("@:8.311")
     def patch(self):
         filter_file("\|;n'", "|'", "configure")
 

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -23,7 +23,11 @@ class Pythia8(AutotoolsPackage):
     license("GPL-2.0-only")
 
     version("8.311", sha256="2782d5e429c1543c67375afe547fd4c4ca0720309deb008f7db78626dc7d1464")
-    version("8.310", sha256="90c811abe7a3d2ffdbf9b4aeab51cf6e0a5a8befb4e3efa806f3d5b9c311e227", preferred=True)
+    version(
+        "8.310",
+        sha256="90c811abe7a3d2ffdbf9b4aeab51cf6e0a5a8befb4e3efa806f3d5b9c311e227",
+        preferred=True,
+    )
     version("8.309", sha256="5bdafd9f2c4a1c47fd8a4e82fb9f0d8fcfba4de1003b8e14be4e0347436d6c33")
     version("8.308", sha256="c2e8c8d38136d85fc0bc9c9fad4c2db679b0819b7d2b6fc9a47f80f99538b4e3")
     version("8.307", sha256="e5b14d44aa5943332e32dd5dda9a18fdd1a0085c7198e28d840e04167fa6013d")

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -23,7 +23,7 @@ class Pythia8(AutotoolsPackage):
     license("GPL-2.0-only")
 
     version("8.311", sha256="2782d5e429c1543c67375afe547fd4c4ca0720309deb008f7db78626dc7d1464")
-    version("8.310", sha256="90c811abe7a3d2ffdbf9b4aeab51cf6e0a5a8befb4e3efa806f3d5b9c311e227", preferred=True)
+    version("8.310", sha256="90c811abe7a3d2ffdbf9b4aeab51cf6e0a5a8befb4e3efa806f3d5b9c311e227")
     version("8.309", sha256="5bdafd9f2c4a1c47fd8a4e82fb9f0d8fcfba4de1003b8e14be4e0347436d6c33")
     version("8.308", sha256="c2e8c8d38136d85fc0bc9c9fad4c2db679b0819b7d2b6fc9a47f80f99538b4e3")
     version("8.307", sha256="e5b14d44aa5943332e32dd5dda9a18fdd1a0085c7198e28d840e04167fa6013d")

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -137,7 +137,7 @@ class Pythia8(AutotoolsPackage):
     # Fix for https://gitlab.com/Pythia8/releases/-/issues/428
     @when("@:8.311")
     def patch(self):
-        filter_file(r"\|;n'", "|'", "configure")
+        filter_file(r"[/]examples[/]Makefile[.]inc\|;n' \\", "/examples/Makefile.inc|' \\", "configure")
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -134,7 +134,7 @@ class Pythia8(AutotoolsPackage):
             r"-std=c\+\+[0-9][0-9]", f"-std=c++{self.spec.variants['cxxstd'].value}", "configure"
         )
 
-    @when("@:8.311") 
+    @when("@:8.311")
     def patch(self):
         filter_file("\|;n'", "|'", "configure")
 

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -134,7 +134,8 @@ class Pythia8(AutotoolsPackage):
             r"-std=c\+\+[0-9][0-9]", f"-std=c++{self.spec.variants['cxxstd'].value}", "configure"
         )
 
-    @when("@:8.311")
+    # Fix for https://gitlab.com/Pythia8/releases/-/issues/428
+    @when("@:8.311") 
     def patch(self):
         filter_file("\|;n'", "|'", "configure")
 

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -23,11 +23,7 @@ class Pythia8(AutotoolsPackage):
     license("GPL-2.0-only")
 
     version("8.311", sha256="2782d5e429c1543c67375afe547fd4c4ca0720309deb008f7db78626dc7d1464")
-    version(
-        "8.310",
-        sha256="90c811abe7a3d2ffdbf9b4aeab51cf6e0a5a8befb4e3efa806f3d5b9c311e227",
-        preferred=True,
-    )
+    version("8.310", sha256="90c811abe7a3d2ffdbf9b4aeab51cf6e0a5a8befb4e3efa806f3d5b9c311e227", preferred=True)
     version("8.309", sha256="5bdafd9f2c4a1c47fd8a4e82fb9f0d8fcfba4de1003b8e14be4e0347436d6c33")
     version("8.308", sha256="c2e8c8d38136d85fc0bc9c9fad4c2db679b0819b7d2b6fc9a47f80f99538b4e3")
     version("8.307", sha256="e5b14d44aa5943332e32dd5dda9a18fdd1a0085c7198e28d840e04167fa6013d")

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -137,7 +137,9 @@ class Pythia8(AutotoolsPackage):
     # Fix for https://gitlab.com/Pythia8/releases/-/issues/428
     @when("@:8.311")
     def patch(self):
-        filter_file(r"[/]examples[/]Makefile[.]inc\|;n' \\", "/examples/Makefile.inc|' \\", "configure")
+        filter_file(
+            r"[/]examples[/]Makefile[.]inc\|;n' \\", "/examples/Makefile.inc|' \\", "configure"
+        )
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -138,6 +138,10 @@ class Pythia8(AutotoolsPackage):
             r"-std=c\+\+[0-9][0-9]", f"-std=c++{self.spec.variants['cxxstd'].value}", "configure"
         )
 
+    @when("@:8.311") 
+    def patch(self):
+        filter_file("\|;n'", "|'", "configure")
+
     def configure_args(self):
         args = []
 

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -137,7 +137,7 @@ class Pythia8(AutotoolsPackage):
     # Fix for https://gitlab.com/Pythia8/releases/-/issues/428
     @when("@:8.311")
     def patch(self):
-        filter_file("\|;n'", "|'", "configure")
+        filter_file(r"\|;n'", "|'", "configure")
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -23,7 +23,7 @@ class Pythia8(AutotoolsPackage):
     license("GPL-2.0-only")
 
     version("8.311", sha256="2782d5e429c1543c67375afe547fd4c4ca0720309deb008f7db78626dc7d1464")
-    version("8.310", sha256="90c811abe7a3d2ffdbf9b4aeab51cf6e0a5a8befb4e3efa806f3d5b9c311e227")
+    version("8.310", sha256="90c811abe7a3d2ffdbf9b4aeab51cf6e0a5a8befb4e3efa806f3d5b9c311e227", preferred=True)
     version("8.309", sha256="5bdafd9f2c4a1c47fd8a4e82fb9f0d8fcfba4de1003b8e14be4e0347436d6c33")
     version("8.308", sha256="c2e8c8d38136d85fc0bc9c9fad4c2db679b0819b7d2b6fc9a47f80f99538b4e3")
     version("8.307", sha256="e5b14d44aa5943332e32dd5dda9a18fdd1a0085c7198e28d840e04167fa6013d")


### PR DESCRIPTION
Something is not right with pythia8-8.311, and it took some more extensive usage testing to figure it out. In contrast to 8.310, the line `CFG_FILE=examples/Makefile.inc` in `pythia8-config` is not replaced by the configure script, resulting in `pythia8-config --cxxflags` failing with `Error: cannot find valid configuration for Pythia 8`. Initial investigation of this issue does not point to anything specific. Because https://gitlab.com/Pythia8/releases/ is only updated with releases, it is hard to run a bisect for when this started.

This PR fixes all versions for a sed `n` that limited replacement to even lines only.