### PR TITLE
nf-tower-cli: fix typo in conditional

### DIFF
--- a/var/spack/repos/builtin/packages/nf-tower-cli/package.py
+++ b/var/spack/repos/builtin/packages/nf-tower-cli/package.py
@@ -104,7 +104,7 @@ class NfTowerCli(Package):
                 url="https://github.com/seqeralabs/tower-cli/releases/download/v0.6.2/tw-0.6.2-linux-x86_64",
                 expand=False,
             )
-    elif platform.machine() == "aarch64":
+    elif platform.machine() == "arm64":
         if platform.system() == "Darwin":
             version(
                 "0.9.2",

--- a/var/spack/repos/builtin/packages/nf-wave-cli/package.py
+++ b/var/spack/repos/builtin/packages/nf-wave-cli/package.py
@@ -41,7 +41,7 @@ class NfWaveCli(Package):
                 url="https://github.com/seqeralabs/wave-cli/releases/download/v1.1.3/wave-1.1.3-linux-x86_64",
                 expand=False,
             )
-    elif platform.machine() == "aarch64":
+    elif platform.machine() == "arm64":
         if platform.system() == "Darwin":
             version(
                 "1.2.0",


### PR DESCRIPTION
The default runner changed on GitHub for macOS, and that revealed a bug in a package when running audits

See https://github.com/spack/spack/actions/runs/8813066774/job/24190021926?pr=43805
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
