### PR TITLE
pythia8: Add a gzip variant and filter some compiler wrapper paths

### DIFF
--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -58,6 +58,7 @@ class Pythia8(AutotoolsPackage):
     )
 
     variant("shared", default=True, description="Build shared library")
+    variant("gzip", default=False, description="Build with gzip support, for reading lhe.gz files")
     variant(
         "hepmc", default=True, description="Export PYTHIA events to the HEPMC format, version 2"
     )
@@ -83,6 +84,7 @@ class Pythia8(AutotoolsPackage):
     variant("mpich", default=False, description="Multi-threading support via MPICH")
     variant("hdf5", default=False, description="Support the use of HDF5 format")
 
+    depends_on("gzip", when="+gzip")
     depends_on("rsync", type="build")
     depends_on("hepmc", when="+hepmc")
     depends_on("hepmc3", when="+hepmc3")
@@ -115,6 +117,8 @@ class Pythia8(AutotoolsPackage):
     conflicts("+hdf5", when="@:8.304", msg="HDF5 support was added in 8.304")
     conflicts("+hdf5", when="~mpich", msg="MPICH is required for reading HDF5 files")
 
+    filter_compiler_wrappers("Makefile.inc", relative_root="share/Pythia8/examples")
+
     def configure_args(self):
         args = []
 
@@ -135,15 +139,11 @@ class Pythia8(AutotoolsPackage):
 
         if "+madgraph5amc" in self.spec:
             args.append("--with-mg5mes=" + self.spec["madgraph5amc"].prefix)
-        else:
-            args.append("--without-mg5mes")
 
         args += self.with_or_without("hepmc3", activation_value="prefix")
 
         if "+fastjet" in self.spec:
             args.append("--with-fastjet3=" + self.spec["fastjet"].prefix)
-        else:
-            args.append("--without-fastjet3")
 
         args += self.with_or_without("evtgen", activation_value="prefix")
         args += self.with_or_without("root", activation_value="prefix")
@@ -158,6 +158,8 @@ class Pythia8(AutotoolsPackage):
 
         if self.spec.satisfies("+hdf5"):
             args.append("--with-highfive=" + self.spec["highfive"].prefix)
+
+        args += self.with_or_without("gzip", activation_value="prefix")
 
         return args
 

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -84,7 +84,7 @@ class Pythia8(AutotoolsPackage):
     variant("mpich", default=False, description="Multi-threading support via MPICH")
     variant("hdf5", default=False, description="Support the use of HDF5 format")
 
-    depends_on("gzip", when="+gzip")
+    depends_on("zlib-api", when="+gzip")
     depends_on("rsync", type="build")
     depends_on("hepmc", when="+hepmc")
     depends_on("hepmc3", when="+hepmc3")
@@ -159,7 +159,9 @@ class Pythia8(AutotoolsPackage):
         if self.spec.satisfies("+hdf5"):
             args.append("--with-highfive=" + self.spec["highfive"].prefix)
 
-        args += self.with_or_without("gzip", activation_value="prefix")
+        args += self.with_or_without(
+            "gzip", activation_value=lambda x: self.spec["zlib-api"].prefix
+        )
 
         return args
 


### PR DESCRIPTION
Building with `--with-gzip` is needed for being able to read, for example, `lhe.gz` files. Pythia8 will build a bunch of new files so I thought a new variant was OK.

The file `Makefile.inc` is used downstream, so if used after an installation (for example, when installing the pythia interface in madgraph) it points to the compiler wrappers so it won't work.

Most of the `--without-` are not needed, from configuring pythia:

```
WARNING: Ignoring invalid option "--without-mg5mes".
WARNING: Ignoring invalid option "--without-hepmc3".
WARNING: Ignoring invalid option "--without-fastjet3".
WARNING: Ignoring invalid option "--without-evtgen".
WARNING: Ignoring invalid option "--without-root".
WARNING: Ignoring invalid option "--without-rivet".
WARNING: Ignoring invalid option "--without-python".
WARNING: Ignoring invalid option "--without-openmp".
WARNING: Ignoring invalid option "--without-mpich".
WARNING: Ignoring invalid option "--without-hdf5".
```

but the ones coming from `self.with_or_without` can't be easily removed. In any case it doesn't hurt to have them, so it's fine keeping them.

The build with `+gzip` went fine, and also reading `lhe.gz` files.