### PR TITLE
add ARMCI-MPI package

### DIFF
--- a/var/spack/repos/builtin/packages/armci-mpi/package.py
+++ b/var/spack/repos/builtin/packages/armci-mpi/package.py
@@ -57,11 +57,7 @@ class ArmciMpi(AutotoolsPackage):
         # FIXME: If not needed delete this function
         args = ["--enable-g"]
 
-        shared = int(self.spec.variants["shared"].value)
-        if shared:
-            args.extend([
-                "--enable-shared",
-            ])
+        args.extend(self.enable_or_disable("shared"))
 
         progress = int(self.spec.variants["progress"].value)
         if progress:

--- a/var/spack/repos/builtin/packages/armci-mpi/package.py
+++ b/var/spack/repos/builtin/packages/armci-mpi/package.py
@@ -59,10 +59,6 @@ class ArmciMpi(AutotoolsPackage):
 
         args.extend(self.enable_or_disable("shared"))
 
-        progress = int(self.spec.variants["progress"].value)
-        if progress:
-            args.extend([
-                "--with-progress",
-            ])
+        args.extend(self.with_or_without("progress"))
 
         return args

--- a/var/spack/repos/builtin/packages/armci-mpi/package.py
+++ b/var/spack/repos/builtin/packages/armci-mpi/package.py
@@ -25,7 +25,7 @@ from spack.package import *
 
 class ArmciMpi(AutotoolsPackage):
     """ARMCI-MPI is an implementation of the ARMCI library used by Global Arrays.
-       MPI-3 one-sided communication is used to implement ARMCI.
+    MPI-3 one-sided communication is used to implement ARMCI.
     """
 
     homepage = "https://github.com/pmodels/armci-mpi"
@@ -35,8 +35,12 @@ class ArmciMpi(AutotoolsPackage):
 
     license("BSD-3-Clause", checked_by="jeffhammond")
 
-    version("0.4", sha256="bcc3bb189b23bf653dcc69bc469eb86eae5ebc5ad94ab5f83e52ddbdbbebf1b1")
-    version("0.3.1-beta", sha256="f3eaa8f365fb55123ecd9ced401086b0732e37e4df592b27916d71a67ab34fe9")
+    version(
+        "0.4", sha256="bcc3bb189b23bf653dcc69bc469eb86eae5ebc5ad94ab5f83e52ddbdbbebf1b1"
+    )
+    version(
+        "0.3.1-beta", sha256="f3eaa8f365fb55123ecd9ced401086b0732e37e4df592b27916d71a67ab34fe9"
+    )
 
     variant("shared", default=True, description="Builds a shared version of the library")
     variant("progress", default=False, description="Enable asynchronous progress")
@@ -49,16 +53,10 @@ class ArmciMpi(AutotoolsPackage):
     depends_on("mpi")
 
     def autoreconf(self, spec, prefix):
-        # FIXME: Modify the autoreconf method as necessary
         autoreconf("--install", "--verbose", "--force")
 
     def configure_args(self):
-        # FIXME: Add arguments other than --prefix
-        # FIXME: If not needed delete this function
         args = ["--enable-g"]
-
         args.extend(self.enable_or_disable("shared"))
-
         args.extend(self.with_or_without("progress"))
-
         return args

--- a/var/spack/repos/builtin/packages/armci-mpi/package.py
+++ b/var/spack/repos/builtin/packages/armci-mpi/package.py
@@ -5,6 +5,7 @@
 
 from spack.package import *
 
+
 class ArmciMpi(AutotoolsPackage):
     """ARMCI-MPI is an implementation of the ARMCI library used by Global Arrays.
     MPI-3 one-sided communication is used to implement ARMCI.

--- a/var/spack/repos/builtin/packages/armci-mpi/package.py
+++ b/var/spack/repos/builtin/packages/armci-mpi/package.py
@@ -1,0 +1,54 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install armci-mpi
+#
+# You can edit this file again by typing:
+#
+#     spack edit armci-mpi
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack.package import *
+
+
+class ArmciMpi(AutotoolsPackage):
+    """FIXME: Put a proper description of your package here."""
+
+    homepage = "https://github.com/pmodels/armci-mpi"
+    url = "https://github.com/pmodels/armci-mpi/archive/refs/tags/v0.4.tar.gz"
+
+    maintainers("jeffhammond")
+
+    license("BSD-3-Clause", checked_by="jeffhammond")
+
+    version("0.4", sha256="bcc3bb189b23bf653dcc69bc469eb86eae5ebc5ad94ab5f83e52ddbdbbebf1b1")
+    version("0.3.1-beta", sha256="f3eaa8f365fb55123ecd9ced401086b0732e37e4df592b27916d71a67ab34fe9")
+
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
+
+    depends_on("mpi")
+
+    def autoreconf(self, spec, prefix):
+        # FIXME: Modify the autoreconf method as necessary
+        autoreconf("--install", "--verbose", "--force")
+
+    def configure_args(self):
+        # FIXME: Add arguments other than --prefix
+        # FIXME: If not needed delete this function
+        args = []
+        return args

--- a/var/spack/repos/builtin/packages/armci-mpi/package.py
+++ b/var/spack/repos/builtin/packages/armci-mpi/package.py
@@ -24,7 +24,9 @@ from spack.package import *
 
 
 class ArmciMpi(AutotoolsPackage):
-    """FIXME: Put a proper description of your package here."""
+    """ARMCI-MPI is an implementation of the ARMCI library used by Global Arrays.
+       MPI-3 one-sided communication is used to implement ARMCI.
+    """
 
     homepage = "https://github.com/pmodels/armci-mpi"
     url = "https://github.com/pmodels/armci-mpi/archive/refs/tags/v0.4.tar.gz"
@@ -35,6 +37,9 @@ class ArmciMpi(AutotoolsPackage):
 
     version("0.4", sha256="bcc3bb189b23bf653dcc69bc469eb86eae5ebc5ad94ab5f83e52ddbdbbebf1b1")
     version("0.3.1-beta", sha256="f3eaa8f365fb55123ecd9ced401086b0732e37e4df592b27916d71a67ab34fe9")
+
+    variant("shared", default=True, description="Builds a shared version of the library")
+    variant("progress", default=False, description="Enable asynchronous progress")
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
@@ -50,5 +55,18 @@ class ArmciMpi(AutotoolsPackage):
     def configure_args(self):
         # FIXME: Add arguments other than --prefix
         # FIXME: If not needed delete this function
-        args = []
+        args = ["--enable-g"]
+
+        shared = int(self.spec.variants["shared"].value)
+        if shared:
+            args.extend([
+                "--enable-shared",
+            ])
+
+        progress = int(self.spec.variants["progress"].value)
+        if progress:
+            args.extend([
+                "--with-progress",
+            ])
+
         return args

--- a/var/spack/repos/builtin/packages/armci-mpi/package.py
+++ b/var/spack/repos/builtin/packages/armci-mpi/package.py
@@ -3,25 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install armci-mpi
-#
-# You can edit this file again by typing:
-#
-#     spack edit armci-mpi
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack.package import *
-
 
 class ArmciMpi(AutotoolsPackage):
     """ARMCI-MPI is an implementation of the ARMCI library used by Global Arrays.
@@ -35,9 +17,7 @@ class ArmciMpi(AutotoolsPackage):
 
     license("BSD-3-Clause", checked_by="jeffhammond")
 
-    version(
-        "0.4", sha256="bcc3bb189b23bf653dcc69bc469eb86eae5ebc5ad94ab5f83e52ddbdbbebf1b1"
-    )
+    version("0.4", sha256="bcc3bb189b23bf653dcc69bc469eb86eae5ebc5ad94ab5f83e52ddbdbbebf1b1")
     version(
         "0.3.1-beta", sha256="f3eaa8f365fb55123ecd9ced401086b0732e37e4df592b27916d71a67ab34fe9"
     )


### PR DESCRIPTION
This is my first time.  I followed https://spack-tutorial.readthedocs.io/en/latest/tutorial_packaging.html to add ARMCI-MPI.

I made a [fresh release](https://github.com/pmodels/armci-mpi/releases) of ARMCI-MPI for this.

The current deficiencies include:
- There is no detection of problematic MPI implementations.  Frankly, there are so many of them it's impossible to maintain a list.  Fortunately, ARMCI-MPI directly detects some of these in the source code and, furthermore, there are runtime options that work around known issues with RMA+datatypes and `MPI_Win_allocate`.

I intend to use this in https://github.com/spack/spack/issues/43812 although it is independently useful, which is why it's a Debian package.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

