### PR TITLE
Update scine-qcmaquis

### DIFF
--- a/var/spack/repos/builtin/packages/scine-qcmaquis/cmake_molcas_interface.patch
+++ b/var/spack/repos/builtin/packages/scine-qcmaquis/cmake_molcas_interface.patch
@@ -1,0 +1,19 @@
+diff --git a/dmrg/lib/interfaces/openmolcas/CMakeLists.txt b/dmrg/lib/interfaces/openmolcas/CMakeLists.txt
+index 46e569074..83fda1ca6 100644
+--- a/dmrg/lib/interfaces/openmolcas/CMakeLists.txt
++++ b/dmrg/lib/interfaces/openmolcas/CMakeLists.txt
+@@ -24,7 +24,13 @@ add_library(qcmaquis-hdf5-interface ${HDF5_INTERFACE_SOURCES})
+ 
+ target_link_libraries(qcmaquis-hdf5-interface ${HDF5_LIBRARIES})
+ 
+-set_target_properties(qcmaquis-driver PROPERTIES COMPILE_FLAGS "-cpp")
++if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
++  target_compile_options(qcmaquis-driver PRIVATE "-cpp")
++elseif ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel")
++  target_compile_options(qcmaquis-driver PRIVATE "-fpp")
++elseif ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Clang")
++  target_compile_options(qcmaquis-driver PRIVATE "-x f95")
++endif()
+ 
+ if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU"
+        AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER 10.0)

--- a/var/spack/repos/builtin/packages/scine-qcmaquis/package.py
+++ b/var/spack/repos/builtin/packages/scine-qcmaquis/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
@@ -15,14 +17,9 @@ class ScineQcmaquis(CMakePackage):
     maintainers("adam-grofe")
 
     version("master", branch="master")
+    version("3.1.4", branch="release-3.1.4")
     version("3.1.3", branch="release-3.1.3")
-    version("3.1.2", branch="release-3.1.2", preferred=True)
-    variant(
-        "blas",
-        values=("openblas", "mkl"),
-        default="openblas",
-        description="Which blas library to use.",
-    )
+    version("3.1.2", branch="release-3.1.2")
     variant(
         "symmetries",
         default="SU2U1PG,TwoU1PG",
@@ -30,9 +27,10 @@ class ScineQcmaquis(CMakePackage):
         values=("U1", "TwoU1", "TwoU1PG", "NU1", "Z2", "SU2U1", "SU2U1PG", "U1DG", "NONE"),
         multi=True,
     )
+    variant("openmolcas", default=False, description="Build the OpenMOLCAS Fortran interface.")
     variant(
         "build_tests",
-        default=True,
+        default=False,
         description="Whether to build unit tests using gtest and gmock",
     )
 
@@ -40,17 +38,42 @@ class ScineQcmaquis(CMakePackage):
 
     depends_on("hdf5~mpi")
     depends_on("lapack")
-    depends_on("openblas+ilp64 threads=openmp", when="blas=openblas")
-    depends_on("intel-oneapi-mkl", when="blas=mkl")
+
+    depends_on("blas")
+    for _pkg in ["openblas"] + list(INTEL_MATH_LIBRARIES):
+        with when(f"^[virtuals=blas] {_pkg}"):
+            depends_on(f"{_pkg}+ilp64 threads=openmp")
+
     depends_on("gsl")
-    depends_on("boost+program_options+filesystem+system+thread+serialization+chrono")
+    depends_on("boost+program_options+filesystem+system+thread+serialization+chrono @1.56:")
     depends_on("googletest+gmock", when="+build_tests")
+
+    depends_on("globalarrays", when="+openmolcas")
+
+    patch("cmake_molcas_interface.patch")
 
     def cmake_args(self):
         args = [
             self.define_from_variant("BUILD_SYMMETRIES", "symmetries"),
+            self.define_from_variant("BUILD_OPENMOLCAS_INTERFACE", "openmolcas"),
             self.define_from_variant("QCMAQUIS_TESTS", "build_tests"),
+            self.define("LAPACK_64_BIT", True),
         ]
+        if "+openmolcas" in self.spec:
+            globalarrays_libdir = self.spec["globalarrays"].prefix.lib
+            args.extend(
+                [
+                    self.define("BUILD_OPENMOLCAS_MPI", True),
+                    self.define("GA_INCLUDE_DIR", self.spec["globalarrays"].prefix.include),
+                    self.define(
+                        "GA_LIBRARIES",
+                        [
+                            os.path.join(globalarrays_libdir, "libga.so"),
+                            os.path.join(globalarrays_libdir, "libarmci.so"),
+                        ],
+                    ),
+                ]
+            )
         return args
 
     def patch(self):


### PR DESCRIPTION
Version 3.1.4 and 3.1.2 of `scine-qcmaquis` are added.
The option to build the OpenMolcas interface is added, and some dependencies are clarified.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
