### PR TITLE
[intel-oneap-*] no redist

### DIFF
--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -15,6 +15,7 @@ from llnl.util.link_tree import LinkTree
 
 from spack.build_environment import dso_suffix
 from spack.directives import conflicts, license, variant
+from spack.package import redistribute
 from spack.package_base import InstallError
 from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable
@@ -30,7 +31,7 @@ class IntelOneApiPackage(Package):
 
     # oneAPI license does not allow mirroring outside of the
     # organization (e.g. University/Company).
-    redistribute_source = False
+    redistribute(source=False, binary=False)
 
     for c in [
         "target=ppc64:",

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -14,8 +14,7 @@ from llnl.util.filesystem import HeaderList, LibraryList, find_libraries, join_p
 from llnl.util.link_tree import LinkTree
 
 from spack.build_environment import dso_suffix
-from spack.directives import conflicts, license, variant
-from spack.package import redistribute
+from spack.directives import conflicts, license, redistribute, variant
 from spack.package_base import InstallError
 from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable

--- a/var/spack/repos/builtin/packages/intel-oneapi-runtime/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-runtime/package.py
@@ -19,6 +19,12 @@ class IntelOneapiRuntime(Package):
 
     maintainers("rscohn2")
 
+    # The libraries are redistributable according to intel
+    # license. Need to investigate if the way it is redistributed
+    # meets the conditions of the license. Until then, disable
+    # distribution
+    redistribute(source=False, binary=False)
+
     tags = ["runtime"]
 
     requires("%oneapi")

--- a/var/spack/repos/builtin/packages/intel-oneapi-runtime/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-runtime/package.py
@@ -10,20 +10,15 @@ from spack.package import *
 from spack.pkg.builtin.gcc_runtime import get_elf_libraries
 
 
+@IntelOneApiPackage.update_description
 class IntelOneapiRuntime(Package):
-    """Package for OneAPI compiler runtime libraries"""
+    """Package for OneAPI compiler runtime libraries redistributables."""
 
     homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi.html"
     has_code = False
     license("https://intel.ly/393CijO")
 
     maintainers("rscohn2")
-
-    # The libraries are redistributable according to intel
-    # license. Need to investigate if the way it is redistributed
-    # meets the conditions of the license. Until then, disable
-    # distribution
-    redistribute(source=False, binary=False)
 
     tags = ["runtime"]
 


### PR DESCRIPTION
Disable redistribution for all intel oneapi packages.
