### PR TITLE
Add `tests-sos` package + Variants to `sos` package

### DIFF
--- a/var/spack/repos/builtin/packages/sos/package.py
+++ b/var/spack/repos/builtin/packages/sos/package.py
@@ -24,14 +24,39 @@ class Sos(AutotoolsPackage):
 
     variant("xpmem", default=False, description="Enable xpmem for transport")
     variant("ofi", default=True, description="Enable ofi for transport")
-    variant("manual-progress", default=False, description="Enable intermittent progress calls in transport layer")
-    variant("ofi-manual-progress", default=False, when="+ofi", description="Use FI_MANUAL_PROGRESS for data progress control mode")
+    variant(
+        "manual-progress",
+        default=False,
+        description="Enable intermittent progress calls in transport layer",
+    )
+    variant(
+        "ofi-manual-progress",
+        default=False,
+        when="+ofi",
+        description="Use FI_MANUAL_PROGRESS for data progress control mode",
+    )
     variant("shr-atomics", default=False, description="Enable shared memory atomic operations")
-    variant("av-map", default=False, description="Enable av-map instead of av-table in the OFI transport")
-    variant("completion-polling", default=False, description="Enable polling in quiet, fence, and local completion operations")
-    variant("thread-completion", default=False, description="Support SHMEM_THREAD_MULTIPLE in OFI transport using FI_THREAD_COMPLETION")
+    variant(
+        "av-map",
+        default=False,
+        description="Enable av-map instead of av-table in the OFI transport",
+    )
+    variant(
+        "completion-polling",
+        default=False,
+        description="Enable polling in quiet, fence, and local completion operations",
+    )
+    variant(
+        "thread-completion",
+        default=False,
+        description="Support SHMEM_THREAD_MULTIPLE in OFI transport using FI_THREAD_COMPLETION",
+    )
     variant("error-checking", default=False, description="Enable error checking for SHMEM calls")
-    variant("lengthy-tests", default=False, description="Execute long running tests as part of 'make check'")
+    variant(
+        "lengthy-tests",
+        default=False,
+        description="Execute long running tests as part of 'make check'",
+    )
     variant("rpath", default=True, description="Use rpath in compiler wrappers ")
     variant("hard-polling", default=False, description="Enable hard polling of wait calls")
 
@@ -39,7 +64,7 @@ class Sos(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("hydra", type=("build","run"), when="+ofi")
+    depends_on("hydra", type=("build", "run"), when="+ofi")
 
     depends_on("libfabric", type="link", when="+ofi")
     depends_on("xpmem", type="link", when="+xpmem")

--- a/var/spack/repos/builtin/packages/sos/package.py
+++ b/var/spack/repos/builtin/packages/sos/package.py
@@ -24,12 +24,22 @@ class Sos(AutotoolsPackage):
 
     variant("xpmem", default=False, description="Enable xpmem for transport")
     variant("ofi", default=True, description="Enable ofi for transport")
+    variant("manual-progress", default=False, description="Enable intermittent progress calls in transport layer")
+    variant("ofi-manual-progress", default=False, when="+ofi", description="Use FI_MANUAL_PROGRESS for data progress control mode")
     variant("shr-atomics", default=False, description="Enable shared memory atomic operations")
+    variant("av-map", default=False, description="Enable av-map instead of av-table in the OFI transport")
+    variant("completion-polling", default=False, description="Enable polling in quiet, fence, and local completion operations")
+    variant("thread-completion", default=False, description="Support SHMEM_THREAD_MULTIPLE in OFI transport using FI_THREAD_COMPLETION")
+    variant("error-checking", default=False, description="Enable error checking for SHMEM calls")
+    variant("lengthy-tests", default=False, description="Execute long running tests as part of 'make check'")
+    variant("rpath", default=True, description="Use rpath in compiler wrappers ")
+    variant("hard-polling", default=False, description="Enable hard polling of wait calls")
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
+    depends_on("hydra", type=("build","run"), when="+ofi")
 
     depends_on("libfabric", type="link", when="+ofi")
     depends_on("xpmem", type="link", when="+xpmem")
@@ -39,8 +49,6 @@ class Sos(AutotoolsPackage):
     filter_compiler_wrappers("oshcc", "oshc++", "oshcc", "oshfort", relative_root="bin")
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_compiler_environment(env)
-
         # Enable the osh wrappers to use spack wrappers when inside spack
         # with env variables
         env.set("SHMEM_CC", spack_cc)
@@ -57,5 +65,14 @@ class Sos(AutotoolsPackage):
         args.extend(self.with_or_without("ofi"))
         # This option is not compatiable with remote atomics
         args.extend(self.enable_or_disable("shr-atomics"))
+        args.extend(self.enable_or_disable("av-map"))
+        args.extend(self.enable_or_disable("completion-polling"))
+        args.extend(self.enable_or_disable("thread-completion"))
+        args.extend(self.enable_or_disable("error-checking"))
+        args.extend(self.enable_or_disable("lengthy-tests"))
+        args.extend(self.enable_or_disable("rpath"))
+        args.extend(self.enable_or_disable("manual-progress"))
+        args.extend(self.enable_or_disable("ofi-manual-progress"))
+        args.extend(self.enable_or_disable("hard-polling"))
         args.append("--enable-pmi-simple")
         return args

--- a/var/spack/repos/builtin/packages/tests-sos/package.py
+++ b/var/spack/repos/builtin/packages/tests-sos/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class TestsSos(AutotoolsPackage):
+    """Sandia OpenSHMEM unit tests and performance testing suite."""
+
+    homepage = "https://github.com/openshmem-org/tests-sos"
+    url = "https://github.com/openshmem-org/tests-sos/archive/refs/tags/v1.5.2.tar.gz"
+
+    maintainers("jack-morrison")
+
+    version("1.5.2", sha256="3a063963ef779419aadc6b21ff2f1e4dcdd3e95fa8ed23545434e56757f3187f")
+
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
+    depends_on("sos", type=("build", "run"))
+
+    def autoreconf(self, spec, prefix):
+        bash = which("bash")
+        bash("./autogen.sh")
+
+    def setup_build_environment(self, env):
+        env.set("CC", "oshcc")
+        env.set("CXX", "oshc++")
+        env.set("FC", "oshfort")


### PR DESCRIPTION
The primary goal of this PR is to introduce the `tests-sos` package, which was recently moved into its own [openshmem-org/tests-sos](https://github.com/openshmem-org/tests-sos) repo from [Sandia-OpenSHMEM/SOS](https://github.com/Sandia-OpenSHMEM/SOS).

To support the new package, I've included some updates to the `sos` package that serves as a dependency. This includes removing a failing call to `self.setup_compiler_environment(env)`, likely not noticed because no other packages depend on `sos` (until `tests-sos` via this PR). Also added some of the configure variants for `sos` and a new dependency on `hydra` to provide the requisite process management at runtime.

[cc @tmh97]