### PR TITLE
Update cmake dep for tau

### DIFF
--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -114,6 +114,7 @@ class Tau(Package):
     )
 
     depends_on("cmake@3.14:", type="build", when="%clang")
+    depends_on("cmake@3.14:", type="build", when="%aocc")
     depends_on("zlib-api", type="link")
     depends_on("pdt", when="+pdt")  # Required for TAU instrumentation
     depends_on("scorep", when="+scorep")


### PR DESCRIPTION
This PR adds cmake as a dependency for tau%aocc (build fails if cmake not in $PATH).