### PR TITLE
dotnet-core-sdk: Fix environment setup

### DIFF
--- a/var/spack/repos/builtin/packages/dotnet-core-sdk/package.py
+++ b/var/spack/repos/builtin/packages/dotnet-core-sdk/package.py
@@ -86,9 +86,9 @@ class DotnetCoreSdk(Package):
 
     variant("telemetry", default=False, description="allow collection of telemetry data")
 
-    def setup_build_environment(self, env):
-        if "-telemetry" in self.spec:
-            env.set("DOTNET_CLI_TELEMETRY_OPTOUT", 1)
+    def setup_run_environment(self, env):
+        if "~telemetry" in self.spec:
+            env.set("DOTNET_CLI_TELEMETRY_OPTOUT", "1")
 
     def install(self, spec, prefix):
         mkdirp("bin")


### PR DESCRIPTION
The "DOTNET_CLI_TELEMETRY_OPTOUT" environment variable should be defined when using the product, not when installing it (the installation phase is just extract the files anyway).

Also use `~` instead of `-` to check for the variant and fix the second argument for `env.set`  which should also be a string.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
