### PR TITLE
build_environment.py: expand SPACK_MANAGED_DIRS with realpath

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -174,18 +174,6 @@ preextend() {
     unset IFS
 }
 
-# eval this because SPACK_MANAGED_DIRS and SPACK_SYSTEM_DIRS are inputs we don't wanna loop over.
-# moving the eval inside the function would eval it every call.
-eval "\
-path_order() {
-case \"\$1\" in
-    $SPACK_MANAGED_DIRS) return 0 ;;
-    $SPACK_SYSTEM_DIRS) return 2 ;;
-    /*) return 1 ;;
-esac
-}
-"
-
 # Fail with a clear message if the input contains any bell characters.
 if eval "[ \"\${*#*${lsep}}\" != \"\$*\" ]"; then
     die "Compiler command line contains our separator ('${lsep}'). Cannot parse."
@@ -197,6 +185,18 @@ for param in $params; do
         die "Spack compiler must be run from Spack! Input '$param' is missing."
     fi
 done
+
+# eval this because SPACK_MANAGED_DIRS and SPACK_SYSTEM_DIRS are inputs we don't wanna loop over.
+# moving the eval inside the function would eval it every call.
+eval "\
+path_order() {
+case \"\$1\" in
+    $SPACK_MANAGED_DIRS) return 0 ;;
+    $SPACK_SYSTEM_DIRS) return 2 ;;
+    /*) return 1 ;;
+esac
+}
+"
 
 # Check if optional parameters are defined
 # If we aren't asking for debug flags, don't add them

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -560,7 +560,7 @@ def set_wrapper_variables(pkg, env):
     }
     spack_managed_dirs.update([os.path.realpath(p) for p in spack_managed_dirs])
 
-    env.set(SPACK_MANAGED_DIRS, "|".join(f'"{p}/"*' for p in spack_managed_dirs))
+    env.set(SPACK_MANAGED_DIRS, "|".join(f'"{p}/"*' for p in sorted(spack_managed_dirs)))
     is_spack_managed = lambda p: any(p.startswith(store) for store in spack_managed_dirs)
     link_dirs_spack, link_dirs_system = stable_partition(link_dirs, is_spack_managed)
     include_dirs_spack, include_dirs_system = stable_partition(include_dirs, is_spack_managed)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -43,7 +43,7 @@ import types
 from collections import defaultdict
 from enum import Flag, auto
 from itertools import chain
-from typing import List, Tuple
+from typing import List, Set, Tuple
 
 import llnl.util.tty as tty
 from llnl.string import plural
@@ -551,11 +551,14 @@ def set_wrapper_variables(pkg, env):
     include_dirs = list(dedupe(filter_system_paths(include_dirs)))
     rpath_dirs = list(dedupe(filter_system_paths(rpath_dirs)))
 
-    spack_managed_dirs: List[str] = [
+    # Spack managed directories include the stage, store and upstream stores. We extend this with
+    # their real paths to make it more robust (e.g. /tmp vs /private/tmp on macOS).
+    spack_managed_dirs: Set[str] = {
         spack.stage.get_stage_root(),
         spack.store.STORE.db.root,
         *(db.root for db in spack.store.STORE.db.upstream_dbs),
-    ]
+    }
+    spack_managed_dirs.update([os.path.realpath(p) for p in spack_managed_dirs])
 
     env.set(SPACK_MANAGED_DIRS, "|".join(f'"{p}/"*' for p in spack_managed_dirs))
     is_spack_managed = lambda p: any(p.startswith(store) for store in spack_managed_dirs)


### PR DESCRIPTION
Fixes an issue on Darwin where the stage root is by default in some
symlinked path. Some build systems apparently run realpath and use those
values in -I flags, so we have to take that into account when reording
flags.

