### PR TITLE
PackageStillNeededError: add pkg that needs spec to exception msg

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2555,7 +2555,7 @@ class PackageStillNeededError(InstallError):
     """Raised when package is still needed by another on uninstall."""
 
     def __init__(self, spec, dependents):
-        super().__init__("Cannot uninstall %s" % spec)
+        super().__init__("Cannot uninstall %s, needed by %s" % (spec, dependents))
         self.spec = spec
         self.dependents = dependents
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2555,7 +2555,11 @@ class PackageStillNeededError(InstallError):
     """Raised when package is still needed by another on uninstall."""
 
     def __init__(self, spec, dependents):
-        super().__init__("Cannot uninstall %s, needed by %s" % (spec, dependents))
+        spec_fmt = spack.spec.DEFAULT_FORMAT + " /{hash:7}"
+        dep_fmt = "{name}{@versions} /{hash:7}"
+        super().__init__(
+            f"Cannot uninstall {spec.format(spec_fmt)}, needed by {[dep.format(dep_fmt) for dep in dependents]}"
+        )
         self.spec = spec
         self.dependents = dependents
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2558,7 +2558,8 @@ class PackageStillNeededError(InstallError):
         spec_fmt = spack.spec.DEFAULT_FORMAT + " /{hash:7}"
         dep_fmt = "{name}{@versions} /{hash:7}"
         super().__init__(
-            f"Cannot uninstall {spec.format(spec_fmt)}, needed by {[dep.format(dep_fmt) for dep in dependents]}"
+            f"Cannot uninstall {spec.format(spec_fmt)}, "
+            f"needed by {[dep.format(dep_fmt) for dep in dependents]}"
         )
         self.spec = spec
         self.dependents = dependents


### PR DESCRIPTION
This PR adds the package that needs a package that is requested to be uninstalled when an exception occurs.

Previously, this just printed:
```
PackageStillNeededError: Cannot uninstall py-exceptiongroup@=1.1.1%gcc@=12.2.0 ...
```
and now this prints:
```
PackageStillNeededError: Cannot uninstall py-exceptiongroup@=1.1.1%gcc@=12.2.0 ..., needed by {py-scikit-build-core@=0.2.0%gcc@=12.2.0+pyproject ..., ...}
```