### PR TITLE
Buildcache/ensure symlinks proper prefix

### DIFF
--- a/lib/spack/llnl/path.py
+++ b/lib/spack/llnl/path.py
@@ -104,4 +104,4 @@ def sanitize_win_longpath(path: str) -> str:
     """Strip Windows extended path prefix from strings
     Returns sanitized string.
     no-op if extended path prefix is not present"""
-    return path.strip("\\\\?\\")
+    return path.lstrip("\\\\?\\")

--- a/lib/spack/llnl/path.py
+++ b/lib/spack/llnl/path.py
@@ -98,3 +98,10 @@ def system_path_filter(_func=None, arg_slice: Optional[slice] = None):
     if _func:
         return holder_func(_func)
     return holder_func
+
+
+def sanitize_win_longpath(path: str) -> str:
+    """Strip Windows extended path prefix from strings
+    Returns sanitized string.
+    no-op if extended path prefix is not present"""
+    return path.strip("\\\\?\\")

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2429,9 +2429,10 @@ class WindowsSimulatedRPath:
         """
         for pth in dest:
             if os.path.isfile(pth):
-                self._additional_library_dependents.add(pathlib.Path(pth).parent)
+                new_pth = pathlib.Path(pth).parent
             else:
-                self._additional_library_dependents.add(pathlib.Path(pth))
+                new_pth = pathlib.Path(pth)
+            self._additional_library_dependents.add(new_pth)
 
     @property
     def rpaths(self):

--- a/lib/spack/llnl/util/symlink.py
+++ b/lib/spack/llnl/util/symlink.py
@@ -119,13 +119,6 @@ def islink(path: str) -> bool:
     return any([os.path.islink(path), _windows_is_junction(path), _windows_is_hardlink(path)])
 
 
-def readlink(path: str, *, dir_fd=None) -> bool:
-    """Override os.readlink to sanitize Windows long path prefixes read from link
-    Otherwise identical to os.readlink
-    """
-    return sanitize_win_longpath(os.readlink(path, dir_fd=dir_fd))
-
-
 def _windows_is_hardlink(path: str) -> bool:
     """Determines if a path is a windows hard link. This is accomplished
     by looking at the number of links using os.stat. A non-hard-linked file
@@ -254,9 +247,9 @@ def _windows_create_junction(source: str, link: str):
     out, err = proc.communicate()
     tty.debug(out.decode())
     if proc.returncode != 0:
-        err = err.decode()
-        tty.error(err)
-        raise SymlinkError("Make junction command returned a non-zero return code.", err)
+        err_str = err.decode()
+        tty.error(err_str)
+        raise SymlinkError("Make junction command returned a non-zero return code.", err_str)
 
 
 def _windows_create_hard_link(path: str, link: str):
@@ -276,14 +269,14 @@ def _windows_create_hard_link(path: str, link: str):
         CreateHardLink(link, path)
 
 
-def readlink(path: str):
+def readlink(path: str, *, dir_fd=None):
     """Spack utility to override of os.readlink method to work cross platform"""
     if _windows_is_hardlink(path):
         return _windows_read_hard_link(path)
     elif _windows_is_junction(path):
         return _windows_read_junction(path)
     else:
-        return os.readlink(path)
+        return sanitize_win_longpath(os.readlink(path, dir_fd=dir_fd))
 
 
 def _windows_read_hard_link(link: str) -> str:

--- a/lib/spack/llnl/util/symlink.py
+++ b/lib/spack/llnl/util/symlink.py
@@ -11,7 +11,7 @@ import tempfile
 
 from llnl.util import lang, tty
 
-from ..path import system_path_filter
+from ..path import sanitize_win_longpath, system_path_filter
 
 if sys.platform == "win32":
     from win32file import CreateHardLink
@@ -117,6 +117,13 @@ def islink(path: str) -> bool:
          bool - whether the path is any kind link or not.
     """
     return any([os.path.islink(path), _windows_is_junction(path), _windows_is_hardlink(path)])
+
+
+def readlink(path: str, *, dir_fd=None) -> bool:
+    """Override os.readlink to sanitize Windows long path prefixes read from link
+    Otherwise identical to os.readlink
+    """
+    return sanitize_win_longpath(os.readlink(path, dir_fd=dir_fd))
 
 
 def _windows_is_hardlink(path: str) -> bool:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -703,7 +703,6 @@ def hashes_to_prefixes(spec):
 
 def get_buildinfo_dict(spec):
     """Create metadata for a tarball"""
-    import pdb; pdb.set_trace()
     manifest = get_buildfile_manifest(spec)
 
     return {
@@ -1641,10 +1640,9 @@ def relocate_package(spec):
 
     # this logic is fundamentally wrong
     # if in hdf5 we have bin/zlib.dll where zlib.dll points to
-    # <install-prefix>/zlib-hash/bin/zlib.dll
-    # the old dep prefix <orig-install-hash>/bin/zlib.dll will now point
+    # <host-install-prefix>/zlib-hash/bin/zlib.dll
+    # the old dep prefix <host-install-hash>/bin/zlib.dll will now point
     # to the hdf5 install hash (new_dep_prefix) which is wrong
-    import pdb; pdb.set_trace()
     for dag_hash, new_dep_prefix in hashes_to_prefixes(spec).items():
         if dag_hash in hash_to_old_prefix:
             old_dep_prefix = hash_to_old_prefix[dag_hash]
@@ -1815,7 +1813,7 @@ def _tar_strip_component(tar: tarfile.TarFile, prefix: str):
                     # the absolute path exists on the target system
                     source = m.name
                     target = m.linkname
-                    raise ValueError(
+                    tty.warn(
                         f'Symbolic link from "{source}" to "{target}" cannot be relocated'
                     )
             elif m.type == tarfile.LNKTYPE:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -29,6 +29,7 @@ import llnl.util.filesystem as fsys
 import llnl.util.lang
 import llnl.util.tty as tty
 from llnl.util.filesystem import BaseDirectoryVisitor, mkdirp, visit_directory_tree
+from llnl.util.symlink import readlink
 
 import spack.caches
 import spack.cmd
@@ -658,7 +659,7 @@ def get_buildfile_manifest(spec):
     #   2. paths are used as strings.
     for rel_path in visitor.symlinks:
         abs_path = os.path.join(root, rel_path)
-        link = spack.util.path.sanitize_win_longpath(os.readlink(abs_path))
+        link = readlink(abs_path)
         if os.path.isabs(link) and link.startswith(spack.store.STORE.layout.root):
             data["link_to_relocate"].append(rel_path)
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1637,12 +1637,6 @@ def relocate_package(spec):
     # First match specific prefix paths. Possibly the *local* install prefix
     # of some dependency is in an upstream, so we cannot assume the original
     # spack store root can be mapped uniformly to the new spack store root.
-
-    # this logic is fundamentally wrong
-    # if in hdf5 we have bin/zlib.dll where zlib.dll points to
-    # <host-install-prefix>/zlib-hash/bin/zlib.dll
-    # the old dep prefix <host-install-hash>/bin/zlib.dll will now point
-    # to the hdf5 install hash (new_dep_prefix) which is wrong
     for dag_hash, new_dep_prefix in hashes_to_prefixes(spec).items():
         if dag_hash in hash_to_old_prefix:
             old_dep_prefix = hash_to_old_prefix[dag_hash]
@@ -1805,17 +1799,7 @@ def _tar_strip_component(tar: tarfile.TarFile, prefix: str):
         m.name = m.name[result.end() :]
         if m.linkname:
             if m.type == tarfile.SYMTYPE:
-                result = regex.match(m.linkname)
-                is_abs = os.path.isabs(m.linkname)
-                if result or is_abs:
-                    # absolute path outside of the install prefix
-                    # this cannot be extracted because we have no garuntee
-                    # the absolute path exists on the target system
-                    source = m.name
-                    target = m.linkname
-                    tty.warn(
-                        f'Symbolic link from "{source}" to "{target}" cannot be relocated'
-                    )
+                m.
             elif m.type == tarfile.LNKTYPE:
                 result = regex.match(m.linkname)
                 if result:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1801,7 +1801,7 @@ def _tar_strip_component(tar: tarfile.TarFile, prefix: str):
             if m.type == tarfile.SYMTYPE:
                 result = regex.match(m.linkname)
                 is_abs = os.path.isabs(m.linkname)
-                if not result and is_abs:
+                if result or is_abs:
                     # absolute path outside of the install prefix
                     # this cannot be extracted because we have no garuntee
                     # the absolute path exists on the target system
@@ -1810,14 +1810,6 @@ def _tar_strip_component(tar: tarfile.TarFile, prefix: str):
                     raise ValueError(
                         f'Symbolic link from "{source}" to "{target}" cannot be relocated'
                     )
-                elif result:
-                    # backwards compat for previously created spackballs that
-                    # have absolute paths inside the prefix
-
-                    # absolute path inside of the install prefix
-                    # not viable to extract in its current state
-                    # instead set link name to equivalent relative link
-                    m.linkname = os.path.relpath(m.linkname, os.path.basename(m.name))
             elif m.type == tarfile.LNKTYPE:
                 result = regex.match(m.linkname)
                 if result:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2022,6 +2022,7 @@ def install_root_node(spec, unsigned=False, force=False, sha256=None):
     with spack.util.path.filter_padding():
         tty.msg('Installing "{0}" from a buildcache'.format(spec.format()))
         extract_tarball(spec, download_result, force)
+        spec.package.windows_establish_runtime_linkage()
         spack.hooks.post_install(spec, False)
         spack.store.STORE.db.add(spec, spack.store.STORE.layout)
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -658,7 +658,7 @@ def get_buildfile_manifest(spec):
     #   2. paths are used as strings.
     for rel_path in visitor.symlinks:
         abs_path = os.path.join(root, rel_path)
-        link = os.readlink(abs_path)
+        link = spack.util.path.sanitize_win_longpath(os.readlink(abs_path))
         if os.path.isabs(link) and link.startswith(spack.store.STORE.layout.root):
             data["link_to_relocate"].append(rel_path)
 
@@ -703,6 +703,7 @@ def hashes_to_prefixes(spec):
 
 def get_buildinfo_dict(spec):
     """Create metadata for a tarball"""
+    import pdb; pdb.set_trace()
     manifest = get_buildfile_manifest(spec)
 
     return {
@@ -1637,6 +1638,13 @@ def relocate_package(spec):
     # First match specific prefix paths. Possibly the *local* install prefix
     # of some dependency is in an upstream, so we cannot assume the original
     # spack store root can be mapped uniformly to the new spack store root.
+
+    # this logic is fundamentally wrong
+    # if in hdf5 we have bin/zlib.dll where zlib.dll points to
+    # <install-prefix>/zlib-hash/bin/zlib.dll
+    # the old dep prefix <orig-install-hash>/bin/zlib.dll will now point
+    # to the hdf5 install hash (new_dep_prefix) which is wrong
+    import pdb; pdb.set_trace()
     for dag_hash, new_dep_prefix in hashes_to_prefixes(spec).items():
         if dag_hash in hash_to_old_prefix:
             old_dep_prefix = hash_to_old_prefix[dag_hash]

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1798,12 +1798,9 @@ def _tar_strip_component(tar: tarfile.TarFile, prefix: str):
             continue
         m.name = m.name[result.end() :]
         if m.linkname:
-            if m.type == tarfile.SYMTYPE:
-                m.
-            elif m.type == tarfile.LNKTYPE:
-                result = regex.match(m.linkname)
-                if result:
-                    m.linkname = m.linkname[result.end() :]
+            result = regex.match(m.linkname)
+            if result:
+                m.linkname = m.linkname[result.end() :]
         yield m
 
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -488,6 +488,7 @@ def _process_binary_cache_tarball(
 
     with timer.measure("install"), spack.util.path.filter_padding():
         binary_distribution.extract_tarball(pkg.spec, download_result, force=False, timer=timer)
+        pkg.windows_establish_runtime_linkage()
 
         if hasattr(pkg, "_post_buildcache_install_hook"):
             pkg._post_buildcache_install_hook()

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -16,7 +16,7 @@ import llnl.util.filesystem as fs
 import llnl.util.lang
 import llnl.util.tty as tty
 from llnl.util.lang import memoized
-from llnl.util.symlink import symlink
+from llnl.util.symlink import readlink, symlink
 
 import spack.paths
 import spack.platforms
@@ -614,7 +614,7 @@ def relocate_links(links, prefix_to_prefix):
     """Relocate links to a new install prefix."""
     regex = re.compile("|".join(re.escape(p) for p in prefix_to_prefix.keys()))
     for link in links:
-        old_target = spack.util.path.sanitize_win_longpath(os.readlink(link))
+        old_target = readlink(link)
         match = regex.match(old_target)
 
         # No match.

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -25,6 +25,7 @@ import spack.spec
 import spack.store
 import spack.util.elf as elf
 import spack.util.executable as executable
+import spack.util.path
 
 from .relocate_text import BinaryFilePrefixReplacer, TextFilePrefixReplacer
 
@@ -613,7 +614,7 @@ def relocate_links(links, prefix_to_prefix):
     """Relocate links to a new install prefix."""
     regex = re.compile("|".join(re.escape(p) for p in prefix_to_prefix.keys()))
     for link in links:
-        old_target = os.readlink(link)
+        old_target = spack.util.path.sanitize_win_longpath(os.readlink(link))
         match = regex.match(old_target)
 
         # No match.

--- a/lib/spack/spack/util/archive.py
+++ b/lib/spack/spack/util/archive.py
@@ -196,39 +196,15 @@ def reproducible_tarfile_from_prefix(
             file_info = tarfile.TarInfo(path_to_name(entry.path))
 
             if entry.is_symlink():
-                def add_entry_to_tarfile(safe_link_path):
-                    """encapsulate logic around adding symlinks to a tarball"""
-                    file_info.linkname = safe_link_path
-                    # According to POSIX: "the value of the file mode bits returned in the
-                    # st_mode field of the stat structure is unspecified." So we set it to
-                    # something sensible without lstat'ing the link.
-                    file_info.mode = 0o755
-                    file_info.type = tarfile.SYMTYPE
-                    tar.addfile(file_info)
-
-                # Absolute links need to be made relative
-                #  - if links point inside the prefix
-                #    compute relative link as normal
-                #  - if link points outside the prefix
-                #    include as is, let relocation handle it
-
                 # strip off long path reg prefix on Windows
                 link_dest = sanitize_win_longpath(os.readlink(entry.path))
-                # if os.path.isabs(link_dest):
-                #     full_path = os.path.realpath(link_dest)
-                #     reg = re.compile(re.escape(prefix))
-                #     res = reg.match(full_path)
-                #     if res:
-                #         # need to compute relative path
-                #         add_entry_to_tarfile(
-                #             os.path.relpath(full_path, os.path.dirname(entry.path))
-                #         )
-                #     else:
-                #         add_entry_to_tarfile(full_path)
-                # # Relative links should stay relative
-                # # always leave as is
-                # else:
-                add_entry_to_tarfile(link_dest)
+                file_info.linkname = link_dest
+                # According to POSIX: "the value of the file mode bits returned in the
+                # st_mode field of the stat structure is unspecified." So we set it to
+                # something sensible without lstat'ing the link.
+                file_info.mode = 0o755
+                file_info.type = tarfile.SYMTYPE
+                tar.addfile(file_info)
 
             elif entry.is_file(follow_symlinks=False):
                 # entry.stat has zero (st_ino, st_dev, st_nlink) on Windows: use lstat.

--- a/lib/spack/spack/util/archive.py
+++ b/lib/spack/spack/util/archive.py
@@ -7,6 +7,7 @@ import hashlib
 import io
 import os
 import pathlib
+import re
 import tarfile
 from contextlib import closing, contextmanager
 from gzip import GzipFile
@@ -193,13 +194,43 @@ def reproducible_tarfile_from_prefix(
             file_info = tarfile.TarInfo(path_to_name(entry.path))
 
             if entry.is_symlink():
-                file_info.type = tarfile.SYMTYPE
-                file_info.linkname = os.readlink(entry.path)
-                # According to POSIX: "the value of the file mode bits returned in the
-                # st_mode field of the stat structure is unspecified." So we set it to
-                # something sensible without lstat'ing the link.
-                file_info.mode = 0o755
-                tar.addfile(file_info)
+                def add_entry_to_tarfile(safe_link_path):
+                    """encapsulate logic around adding symlinks to a tarball"""
+                    file_info.linkname = safe_link_path
+                    # According to POSIX: "the value of the file mode bits returned in the
+                    # st_mode field of the stat structure is unspecified." So we set it to
+                    # something sensible without lstat'ing the link.
+                    file_info.mode = 0o755
+                    tar.addfile(file_info)
+                    file_info.type = tarfile.SYMTYPE
+
+                # Absolute links need to be made relative
+                #  - if links point inside the prefix
+                #    compute relative link as normal
+                #  - if link points outside the prefix
+                #    we should not include them
+                # strip off long path reg prefix on Windows
+                link_dest = os.readlink(entry.path).strip("\\\\?\\")
+                if os.path.isabs(link_dest):
+                    full_path = os.path.realpath(link_dest)
+                    reg = re.compile(re.escape(prefix))
+                    res = reg.match(full_path)
+                    if res:
+                        # need to compute relative path
+                        add_entry_to_tarfile(
+                            os.path.relpath(full_path, os.path.dirname(entry.path))
+                        )
+                # Relative links should stay relative
+                #  - if links point inside the prefix
+                #    leave them
+                #  - if they point outside the prefix
+                #    don't include them in the first place
+                #    as we can't reason about
+                else:
+                    potential_path = os.path.join(prefix, link_dest)
+                    candidate_rel_path = os.path.relpath(os.path.realpath(potential_path), prefix)
+                    if not candidate_rel_path.startswith(".."):
+                        add_entry_to_tarfile(candidate_rel_path)
 
             elif entry.is_file(follow_symlinks=False):
                 # entry.stat has zero (st_ino, st_dev, st_nlink) on Windows: use lstat.

--- a/lib/spack/spack/util/archive.py
+++ b/lib/spack/spack/util/archive.py
@@ -14,6 +14,7 @@ from typing import Callable, Dict, Tuple
 
 from llnl.util.symlink import readlink
 
+
 class ChecksumWriter(io.BufferedIOBase):
     """Checksum writer computes a checksum while writing to a file."""
 

--- a/lib/spack/spack/util/archive.py
+++ b/lib/spack/spack/util/archive.py
@@ -7,7 +7,6 @@ import hashlib
 import io
 import os
 import pathlib
-import re
 import tarfile
 from contextlib import closing, contextmanager
 from gzip import GzipFile

--- a/lib/spack/spack/util/archive.py
+++ b/lib/spack/spack/util/archive.py
@@ -201,8 +201,8 @@ def reproducible_tarfile_from_prefix(
                     # st_mode field of the stat structure is unspecified." So we set it to
                     # something sensible without lstat'ing the link.
                     file_info.mode = 0o755
-                    tar.addfile(file_info)
                     file_info.type = tarfile.SYMTYPE
+                    tar.addfile(file_info)
 
                 # Absolute links need to be made relative
                 #  - if links point inside the prefix

--- a/lib/spack/spack/util/archive.py
+++ b/lib/spack/spack/util/archive.py
@@ -12,8 +12,7 @@ from contextlib import closing, contextmanager
 from gzip import GzipFile
 from typing import Callable, Dict, Tuple
 
-from spack.util.path import sanitize_win_longpath
-
+from llnl.util.symlink import readlink
 
 class ChecksumWriter(io.BufferedIOBase):
     """Checksum writer computes a checksum while writing to a file."""
@@ -196,7 +195,7 @@ def reproducible_tarfile_from_prefix(
 
             if entry.is_symlink():
                 # strip off long path reg prefix on Windows
-                link_dest = sanitize_win_longpath(os.readlink(entry.path))
+                link_dest = readlink(entry.path)
                 file_info.linkname = link_dest
                 # According to POSIX: "the value of the file mode bits returned in the
                 # st_mode field of the stat structure is unspecified." So we set it to

--- a/lib/spack/spack/util/archive.py
+++ b/lib/spack/spack/util/archive.py
@@ -196,7 +196,6 @@ def reproducible_tarfile_from_prefix(
             file_info = tarfile.TarInfo(path_to_name(entry.path))
 
             if entry.is_symlink():
-
                 def add_entry_to_tarfile(safe_link_path):
                     """encapsulate logic around adding symlinks to a tarball"""
                     file_info.linkname = safe_link_path
@@ -215,21 +214,21 @@ def reproducible_tarfile_from_prefix(
 
                 # strip off long path reg prefix on Windows
                 link_dest = sanitize_win_longpath(os.readlink(entry.path))
-                if os.path.isabs(link_dest):
-                    full_path = os.path.realpath(link_dest)
-                    reg = re.compile(re.escape(prefix))
-                    res = reg.match(full_path)
-                    if res:
-                        # need to compute relative path
-                        add_entry_to_tarfile(
-                            os.path.relpath(full_path, os.path.dirname(entry.path))
-                        )
-                    else:
-                        add_entry_to_tarfile(full_path)
-                # Relative links should stay relative
-                # always leave as is
-                else:
-                    add_entry_to_tarfile(link_dest)
+                # if os.path.isabs(link_dest):
+                #     full_path = os.path.realpath(link_dest)
+                #     reg = re.compile(re.escape(prefix))
+                #     res = reg.match(full_path)
+                #     if res:
+                #         # need to compute relative path
+                #         add_entry_to_tarfile(
+                #             os.path.relpath(full_path, os.path.dirname(entry.path))
+                #         )
+                #     else:
+                #         add_entry_to_tarfile(full_path)
+                # # Relative links should stay relative
+                # # always leave as is
+                # else:
+                add_entry_to_tarfile(link_dest)
 
             elif entry.is_file(follow_symlinks=False):
                 # entry.stat has zero (st_ino, st_dev, st_nlink) on Windows: use lstat.

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -101,6 +101,13 @@ def win_exe_ext():
     return r"(?:\.bat|\.exe)"
 
 
+def sanitize_win_longpath(path: str) -> str:
+    """Strip Windows extended path prefix from strings
+    Returns santized string.
+    no-op if extended path prefix is not present"""
+    return path.strip("\\\\?\\")
+
+
 def sanitize_filename(filename: str) -> str:
     """
     Replaces unsupported characters (for the host) in a filename with underscores.

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -103,7 +103,7 @@ def win_exe_ext():
 
 def sanitize_win_longpath(path: str) -> str:
     """Strip Windows extended path prefix from strings
-    Returns santized string.
+    Returns sanitized string.
     no-op if extended path prefix is not present"""
     return path.strip("\\\\?\\")
 

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -101,13 +101,6 @@ def win_exe_ext():
     return r"(?:\.bat|\.exe)"
 
 
-def sanitize_win_longpath(path: str) -> str:
-    """Strip Windows extended path prefix from strings
-    Returns sanitized string.
-    no-op if extended path prefix is not present"""
-    return path.strip("\\\\?\\")
-
-
 def sanitize_filename(filename: str) -> str:
     """
     Replaces unsupported characters (for the host) in a filename with underscores.


### PR DESCRIPTION
Adds handling to archiving and extracting Spackballs when adding to and installing from, the buildcache.

Ensures symlinks read by Spack have the longpath prefix (`\\?\`) stripped from them
Ensures Windows RPath symlinks are recreated as expected.

NOTE: If you read this PR prior to 4/29, it's not at all the same set of changes, please re-review if you are interested in reviewing/commenting.
