### PR TITLE
nopayloadclient: new package

### DIFF
--- a/var/spack/repos/builtin/packages/nopayloadclient/package.py
+++ b/var/spack/repos/builtin/packages/nopayloadclient/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Nopayloadclient(CMakePackage):
+    """NoPayloadClient is the client-side library meant to communicate with NoPayloadDB."""
+
+    homepage = "https://github.com/BNLNPPS/nopayloadclient"
+    url = "https://github.com/BNLNPPS/nopayloadclient/archive/refs/tags/v0.0.3.tar.gz"
+    git = "https://github.com/BNLNPPS/nopayloadclient.git"
+
+    maintainers("wdconinc")
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("main", branch="main")
+    version("0.0.3", sha256="9481981d0cfbe1727f08ae3d1129c142a952d5e67ddb9ad88224356040af2225")
+
+    depends_on("curl")
+    depends_on("nlohmann-json", type="build")
+
+    def cmake_args(self):
+        return [
+            self.define("BUILD_TESTING", self.run_tests),
+            self.define("INCLUDE_DIR_NLOHMANN_JSON", self.spec["nlohmann-json"].prefix.include),
+        ]


### PR DESCRIPTION
This PR adds `nopayloadclient`, a client-side library meant to communicate with NoPayloadDB, an artifact database used by HEP experiments.

`nopayloadclient` bundles nlohmann-json, but we specify that the spack version should be used.

Test builds:
- `main`
```
==> Installing nopayloadclient-main-odd7h4gvyicj7zjebgofkge3r4hidnt6 [11/12]
==> No binary for nopayloadclient-main-odd7h4gvyicj7zjebgofkge3r4hidnt6 found: installing from source
==> No patches needed for nopayloadclient
==> nopayloadclient: Executing phase: 'cmake'
==> nopayloadclient: Executing phase: 'build'
==> nopayloadclient: Executing phase: 'install'
==> nopayloadclient: Successfully installed nopayloadclient-main-odd7h4gvyicj7zjebgofkge3r4hidnt6
  Stage: 0.82s.  Cmake: 5.10s.  Build: 5.35s.  Install: 0.06s.  Post-install: 0.03s.  Total: 11.42s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/nopayloadclient-main-odd7h4gvyicj7zjebgofkge3r4hidnt6
```
- `0.0.3`
```
==> Installing nopayloadclient-0.0.3-toqfionk5ztaaq5mrfhokeroqgltmzsg [11/11]
==> No binary for nopayloadclient-0.0.3-toqfionk5ztaaq5mrfhokeroqgltmzsg found: installing from source
==> Fetching https://github.com/BNLNPPS/nopayloadclient/archive/refs/tags/v0.0.3.tar.gz
==> No patches needed for nopayloadclient
==> nopayloadclient: Executing phase: 'cmake'
==> nopayloadclient: Executing phase: 'build'
==> nopayloadclient: Executing phase: 'install'
==> nopayloadclient: Successfully installed nopayloadclient-0.0.3-toqfionk5ztaaq5mrfhokeroqgltmzsg
  Stage: 1.15s.  Cmake: 5.05s.  Build: 17.52s.  Install: 0.07s.  Post-install: 0.05s.  Total: 23.90s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/nopayloadclient-0.0.3-toqfionk5ztaaq5mrfhokeroqgltmzsg
```