### PR TITLE
Update crtm-fix and crtm (from JCSDA fork)

### DIFF
--- a/var/spack/repos/builtin/packages/crtm-fix/package.py
+++ b/var/spack/repos/builtin/packages/crtm-fix/package.py
@@ -18,6 +18,9 @@ class CrtmFix(Package):
         "BenjaminTJohnson", "edwardhartnett", "AlexanderRichert-NOAA", "Hang-Lei-NOAA", "climbfuji"
     )
 
+    version(
+        "2.4.0.1_emc", sha256="6e4005b780435c8e280d6bfa23808d8f12609dfd72f77717d046d4795cac0457"
+    )
     version("2.4.0_emc", sha256="d0f1b2ae2905457f4c3731746892aaa8f6b84ee0691f6228dfbe48917df1e85e")
     version("2.3.0_emc", sha256="1452af2d1d11d57ef3c57b6b861646541e7042a9b0f3c230f9a82854d7e90924")
 
@@ -28,8 +31,11 @@ class CrtmFix(Package):
     conflicts("+big_endian", when="+little_endian", msg="big_endian and little_endian conflict")
 
     def url_for_version(self, version):
-        url = "ftp://ftp.ssec.wisc.edu/pub/s4/CRTM/fix_REL-{}.tgz"
-        return url.format(version)
+        if version == Version("2.4.0.1_emc"):
+            url = "ftp://ftp.ssec.wisc.edu/pub/s4/CRTM/fix_REL-2.4.0_emc_07112023.tgz"
+        else:
+            url = f"ftp://ftp.ssec.wisc.edu/pub/s4/CRTM/fix_REL-{version}.tgz"
+        return url
 
     def install(self, spec, prefix):
         spec = self.spec
@@ -52,23 +58,27 @@ class CrtmFix(Package):
         # Little_Endian amsua_metop-c_v2.SpcCoeff.bin is what it's supposed to be.
         # Remove the incorrect file, and install it as noACC,, then install
         # correct file under new name.
-        if "+big_endian" in spec and spec.version == Version("2.4.0_emc"):
-            remove_path = join_path(
-                os.getcwd(), "fix", "SpcCoeff", "Big_Endian", "amsua_metop-c.SpcCoeff.bin"
+        if "+big_endian" in spec and (
+            spec.version in [Version("2.4.0_emc"), Version("2.4.0.1_emc")]
+        ):
+            amc_sc_path = join_path("SpcCoeff", "Big_Endian", "amsua_metop-c.SpcCoeff.bin")
+            amc_sc_v2_path = join_path(
+                "SpcCoeff", "Little_Endian", "amsua_metop-c_v2.SpcCoeff.bin"
             )
+            # In 2.4.0_emc, the path is prefixed by 'fix/'
+            if spec.version == Version("2.4.0_emc"):
+                amc_sc_path = join_path("fix", amc_sc_path)
+                amc_sc_v2_path = join_path("fix", amc_sc_v2_path)
+
+            remove_path = join_path(os.getcwd(), amc_sc_path)
+
             fix_files.remove(remove_path)
 
             # This file is incorrect, install it as a different name.
-            install(
-                join_path("fix", "SpcCoeff", "Big_Endian", "amsua_metop-c.SpcCoeff.bin"),
-                join_path(self.prefix.fix, "amsua_metop-c.SpcCoeff.noACC.bin"),
-            )
+            install(amc_sc_path, join_path(self.prefix.fix, "amsua_metop-c.SpcCoeff.noACC.bin"))
 
             # This "Little_Endian" file is actually the correct one.
-            install(
-                join_path("fix", "SpcCoeff", "Little_Endian", "amsua_metop-c_v2.SpcCoeff.bin"),
-                join_path(self.prefix.fix, "amsua_metop-c.SpcCoeff.bin"),
-            )
+            install(amc_sc_v2_path, join_path(self.prefix.fix, "amsua_metop-c.SpcCoeff.bin"))
 
         for f in fix_files:
             install(f, self.prefix.fix)

--- a/var/spack/repos/builtin/packages/crtm/package.py
+++ b/var/spack/repos/builtin/packages/crtm/package.py
@@ -28,48 +28,64 @@ class Crtm(CMakePackage):
     variant(
         "fix", default=False, description='Download CRTM coeffecient or "fix" files (several GBs).'
     )
-    depends_on("cmake@3.15:")
+
+    depends_on("cmake@3.15:", type="build")
     depends_on("git-lfs")
     depends_on("netcdf-fortran", when="@2.4.0:")
     depends_on("netcdf-fortran", when="@v2.3-jedi.4")
     depends_on("netcdf-fortran", when="@v2.4-jedi.1")
     depends_on("netcdf-fortran", when="@v2.4-jedi.2")
     depends_on("netcdf-fortran", when="@v2.4.1-jedi")
+    depends_on("netcdf-fortran", when="@v3")
 
     depends_on("crtm-fix@2.3.0_emc", when="@2.3.0 +fix")
-    depends_on("crtm-fix@2.4.0_emc", when="@2.4.0 +fix")
+    depends_on("crtm-fix@2.4.0_emc", when="@=2.4.0 +fix")
+    depends_on("crtm-fix@2.4.0.1_emc", when="@2.4.0.1 +fix")
 
     depends_on("ecbuild", type=("build"), when="@v2.3-jedi.4")
     depends_on("ecbuild", type=("build"), when="@v2.4-jedi.1")
     depends_on("ecbuild", type=("build"), when="@v2.4-jedi.2")
     depends_on("ecbuild", type=("build"), when="@v2.4.1-jedi")
-
-    # ecbuild release v2.4.0 is broken
-    # add ecbuild dependency for next release with fix
-    # depends_on("ecbuild", when="@2.4.0:", type=("build"))
+    depends_on("ecbuild", type=("build"), when="@v3.0")
+    depends_on("ecbuild", type=("build"), when="@v3.1.0-skylabv7")
 
     license("CC0-1.0")
 
     version(
+        "v3.1.0-skylabv8",
+        sha256="a475c8a444072aef1e8c2babba3d12f13ab0fb6c7ecab88edad57130839e29ff",
+    )
+    version(
+        "v3.1.0-skylabv7",
+        sha256="3ac45c49562ab41c3baf443ce382e3a6bcb7226831b54146d9f73995be165ec7",
+    )
+    version(
+        "v3.0.0-skylabv6",
+        sha256="780fbc4e0f3b0414fbade4b595832bb35d9c5d3e7c3b25ad128ca94f71bea2b8",
+    )
+    version(
+        "v3.0.0-skylabv5",
+        sha256="4fa5dd2d65b4d4ff77d50992e8e0c02a59584b35599f424085fccdc2174d7bd2",
+    )
+    version(
         "v2.4.1-jedi", sha256="fd8bf4db4f2a3b420b4186de84483ba2a36660519dffcb1e0ff14bfe8c6f6a14"
     )
+    version("v2.4-jedi.2", commit="62831cbb6c1ffcbb219eeec60e1b1c422526f597")
+    version("v2.4-jedi.1", commit="82223419fdb479d76c2f2109c2b704e1d9618f22")
     version("2.4.0.1", tag="v2.4.0_emc.3", commit="7ecad4866c400d7d0db1413348ee225cfa99ff36")
     # REL-2.4.0_emc (v2.4.0 ecbuild does not work)
     version("2.4.0", commit="5ddd0d6b0138284764065feda73b5adf599082a2")
     # Uses the tip of REL-2.3.0_emc branch
     version("2.3.0", commit="99760e693ce3b90a3b3b0e97d80972b4dfb61196")
-    # JEDI applications so far use these versions
-    # Branch release/crtm_jedi
-    version("v2.3-jedi.4", commit="bfede42adc6149213f28f58bf4e02fa8f7cb0198")
-    # Branch release/crtm_jedi_v2.4.0
-    version("v2.4-jedi.1", commit="82223419fdb479d76c2f2109c2b704e1d9618f22")
-    version("v2.4-jedi.2", commit="62831cbb6c1ffcbb219eeec60e1b1c422526f597")
 
     def url_for_version(self, version):
         if self.spec.satisfies("@v3") or version >= Version("3.0.0"):
-            return "https://github.com/JCSDA/crtmv3/archive/refs/tags/{}.tar.gz".format(version)
+            return f"https://github.com/JCSDA/crtmv3/archive/refs/tags/{version}.tar.gz"
         else:
-            return "https://github.com/JCSDA/crtm/archive/refs/tags/{}.tar.gz".format(version)
+            return f"https://github.com/JCSDA/crtm/archive/refs/tags/{version}.tar.gz"
+
+    # https://github.com/JCSDA/spack-stack/issues/1088
+    patch("v3.1.0-skylabv8.installprefix.patch", when="@v3.1.0-skylabv8")
 
     @when("@2.4.0.1")
     def patch(self):

--- a/var/spack/repos/builtin/packages/crtm/v3.1.0-skylabv8.installprefix.patch
+++ b/var/spack/repos/builtin/packages/crtm/v3.1.0-skylabv8.installprefix.patch
@@ -1,0 +1,14 @@
+--- a/CMakeLists.txt	2024-04-22 08:25:42.000000000 -0600
++++ b/CMakeLists.txt	2024-04-22 08:25:54.000000000 -0600
+@@ -6,8 +6,9 @@
+ 
+ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+ set(CMAKE_DIRECTORY_LABELS ${PROJECT_NAME})
+-set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR} CACHE PATH "default install path" FORCE)
+-message("CMAKE_INSTALL_PREFIX set to ${CMAKE_INSTALL_PREFIX}")
++# https://github.com/JCSDA/spack-stack/issues/1088
++#set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR} CACHE PATH "default install path" FORCE)
++#message("CMAKE_INSTALL_PREFIX set to ${CMAKE_INSTALL_PREFIX}")
+ 
+ ## Configuration options
+ include(${PROJECT_NAME}_compiler_flags)


### PR DESCRIPTION
This PR updates the `crtm-fix` and `crtm` packages from the JCSDA fork (which is the organization leading the development of CRTM). These updated packages are identical to what we have in https://github.com/jcsda/spack. They've been tested in CI (Linux, macOS) and on several HPCs.