### PR TITLE
osg-ca-certs: new version osg 1.119 and igtf 1.128

### DIFF
--- a/var/spack/repos/builtin/packages/osg-ca-certs/package.py
+++ b/var/spack/repos/builtin/packages/osg-ca-certs/package.py
@@ -24,7 +24,7 @@ class OsgCaCerts(Package):
             "osg_version": "1.119",
             "igtf_version": "1.128",
             "osg_sha256": "d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed",
-            "igtf_sha256": "1385e2206b4088cbad94264e2c252ad431f075f88a427cdee4ed523df95b9ab7 ",
+            "igtf_sha256": "1385e2206b4088cbad94264e2c252ad431f075f88a427cdee4ed523df95b9ab7",
         }
         {
             "osg_version": "1.110",

--- a/var/spack/repos/builtin/packages/osg-ca-certs/package.py
+++ b/var/spack/repos/builtin/packages/osg-ca-certs/package.py
@@ -21,6 +21,12 @@ class OsgCaCerts(Package):
 
     releases = [
         {
+            "osg_version": "1.119",
+            "igtf_version": "1.128",
+            "osg_sha256": "d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed",
+            "igtf_sha256": "1385e2206b4088cbad94264e2c252ad431f075f88a427cdee4ed523df95b9ab7 ",
+        }
+        {
             "osg_version": "1.110",
             "igtf_version": "1.119",
             "osg_sha256": "025969d415bf27c1609699caf63d0d79540a01df500187195f2bd973fe69e00d",

--- a/var/spack/repos/builtin/packages/osg-ca-certs/package.py
+++ b/var/spack/repos/builtin/packages/osg-ca-certs/package.py
@@ -25,7 +25,7 @@ class OsgCaCerts(Package):
             "igtf_version": "1.128",
             "osg_sha256": "d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed",
             "igtf_sha256": "1385e2206b4088cbad94264e2c252ad431f075f88a427cdee4ed523df95b9ab7",
-        }
+        },
         {
             "osg_version": "1.110",
             "igtf_version": "1.119",

--- a/var/spack/repos/builtin/packages/osg-ca-certs/package.py
+++ b/var/spack/repos/builtin/packages/osg-ca-certs/package.py
@@ -24,16 +24,13 @@ class OsgCaCerts(Package):
             "igtf_version": "1.128",
             "osg_commit": "1f7abbe392e339aae28625a4016bc98d58ad7cab",
             "igtf_sha256": "1385e2206b4088cbad94264e2c252ad431f075f88a427cdee4ed523df95b9ab7",
-        },
+        }
     ]
 
     for release in releases:
         _version = "{0}.igtf.{1}".format(release["osg_version"], release["igtf_version"])
 
-        version(
-            _version,
-            commit=release["osg_commit"],
-        )
+        version(_version, commit=release["osg_commit"])
 
         resource(
             name="igtf-{igtf_version}".format(igtf_version=release["igtf_version"]),

--- a/var/spack/repos/builtin/packages/osg-ca-certs/package.py
+++ b/var/spack/repos/builtin/packages/osg-ca-certs/package.py
@@ -11,9 +11,8 @@ class OsgCaCerts(Package):
     in the OpenSSL 1.0.* format."""
 
     homepage = "http://repo.opensciencegrid.org/cadist"
-    url = "https://github.com/opensciencegrid/osg-certificates/archive/v1.109.igtf.1.117/osg-certificates-1.109.igtf.1.117.tar.gz"
+    git = "https://github.com/opensciencegrid/osg-certificates.git"
 
-    _osg_base_url = "https://github.com/opensciencegrid/osg-certificates/archive/v{osg_version}.igtf.{igtf_version}/osg-certificates-{osg_version}.igtf.{igtf_version}.tar.gz"
     _igtf_base_url = "https://dist.eugridpma.info/distribution/igtf/{igtf_version}/igtf-policy-installation-bundle-{igtf_version}.tar.gz"
     _letsencrypt_base_url = "https://github.com/opensciencegrid/letsencrypt-certificates/archive/v{letsencrypt_version}/letsencrypt-certificates.tar.gz"
 
@@ -23,20 +22,8 @@ class OsgCaCerts(Package):
         {
             "osg_version": "1.119",
             "igtf_version": "1.128",
-            "osg_sha256": "d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed",
+            "osg_commit": "1f7abbe392e339aae28625a4016bc98d58ad7cab",
             "igtf_sha256": "1385e2206b4088cbad94264e2c252ad431f075f88a427cdee4ed523df95b9ab7",
-        },
-        {
-            "osg_version": "1.110",
-            "igtf_version": "1.119",
-            "osg_sha256": "025969d415bf27c1609699caf63d0d79540a01df500187195f2bd973fe69e00d",
-            "igtf_sha256": "cc4db07a86fc27f0e0dfd15c797d1a0da7b5620f4b611dbb686543712b2f335a",
-        },
-        {
-            "osg_version": "1.109",
-            "igtf_version": "1.117",
-            "osg_sha256": "41e12c05aedb4df729bf326318cc29b9b79eb097564fd68c6af2e1448ec74f75",
-            "igtf_sha256": "130d4d95cd65d01d2db250ee24c539341e3adc899b7eff1beafef1ba4674807d",
         },
     ]
 
@@ -45,10 +32,7 @@ class OsgCaCerts(Package):
 
         version(
             _version,
-            url=_osg_base_url.format(
-                osg_version=release["osg_version"], igtf_version=release["igtf_version"]
-            ),
-            sha256=release["osg_sha256"],
+            commit=release["osg_commit"],
         )
 
         resource(


### PR DESCRIPTION
Older versions removed since removed from upstream. Because of that, switching to commits on github for newer versions.