### PR TITLE
Fix concretization when installing missing compilers

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2519,12 +2519,18 @@ class SpackSolverSetup:
             if not compiler.available:
                 continue
 
-            if using_libc_compatibility() and compiler.compiler_obj.default_libc:
+            current_libc = compiler.compiler_obj.default_libc
+            # If this is a compiler yet to be built (config:install_missing_compilers:true)
+            # infer libc from the Python process
+            if not current_libc and compiler.compiler_obj.cc is None:
+                current_libc = spack.util.libc.libc_from_current_python_process()
+
+            if using_libc_compatibility() and current_libc:
                 recorder("*").depends_on(
                     "libc", when=f"%{compiler.spec}", type="link", description="Add libc"
                 )
                 recorder("*").depends_on(
-                    str(compiler.compiler_obj.default_libc),
+                    str(current_libc),
                     when=f"%{compiler.spec}",
                     type="link",
                     description="Add libc",

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2439,6 +2439,7 @@ class TestConcretize:
                 return None
             return Spec("glibc@=2.28")
 
+        monkeypatch.setattr(spack.concretize.Concretizer, "check_for_compiler_existence", False)
         monkeypatch.setattr(spack.compiler.Compiler, "default_libc", property(_default_libc))
         monkeypatch.setattr(
             spack.util.libc, "libc_from_current_python_process", lambda: Spec("glibc@=2.28")

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -24,6 +24,7 @@ import spack.hash_types as ht
 import spack.platforms
 import spack.repo
 import spack.solver.asp
+import spack.util.libc
 import spack.variant as vt
 from spack.concretize import find_spec
 from spack.spec import CompilerSpec, Spec
@@ -2426,6 +2427,25 @@ class TestConcretize:
         spack.config.set("packages", external_conf)
         s = Spec("mpich").concretized()
         assert s.external
+
+    @pytest.mark.regression("43875")
+    def test_concretize_missing_compiler(self, mutable_config, monkeypatch):
+        """Tests that Spack can concretize a spec with a missing compiler when the
+        option is active.
+        """
+
+        def _default_libc(self):
+            if self.cc is None:
+                return None
+            return Spec("glibc@=2.28")
+
+        monkeypatch.setattr(spack.compiler.Compiler, "default_libc", property(_default_libc))
+        monkeypatch.setattr(
+            spack.util.libc, "libc_from_current_python_process", lambda: Spec("glibc@=2.28")
+        )
+        mutable_config.set("config:install_missing_compilers", True)
+        s = Spec("a %gcc@=13.2.0").concretized()
+        assert s.satisfies("%gcc@13.2.0")
 
 
 @pytest.fixture()


### PR DESCRIPTION
Restore the previous behavior when config:install_missing_compilers is True. The libc of the missing compiler is inferred from the Python process.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
