### PR TITLE
ci: update upload-artifact to v4 (in build-containers)

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -87,7 +87,7 @@ jobs:
           fi
 
       - name: Upload Dockerfile
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
         with:
           name: dockerfiles
           path: dockerfiles

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Upload Dockerfile
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
         with:
-          name: dockerfiles
+          name: dockerfiles_${{ matrix.dockerfile[0] }}
           path: dockerfiles
 
       - name: Set up QEMU
@@ -120,3 +120,14 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+
+jobs:
+  merge-dockerfiles:
+    runs-on: ubuntu-latest
+    needs: deploy-images
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@65462800fd760344b1a7b4382951275a0abb4808
+        with:
+          name: dockerfiles
+          pattern: dockerfiles_*

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -130,3 +130,4 @@ jobs:
         with:
           name: dockerfiles
           pattern: dockerfiles_*
+          delete-merged: true

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -121,7 +121,6 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
 
-jobs:
   merge-dockerfiles:
     runs-on: ubuntu-latest
     needs: deploy-images


### PR DESCRIPTION
This PR updates the upload-artifacts action to v4, supporting nodejs 20 (rather than nodejs 16) and removing the warnings in e.g. https://github.com/spack/spack/actions/runs/8835451720?pr=43847 (#43847).

Commit https://github.com/actions/upload-artifact/commit/65462800fd760344b1a7b4382951275a0abb4808 is https://github.com/actions/upload-artifact/releases/tag/v4.3.3.

upload-artifact v4 changed quite a bit compared to v3, see [migration docs](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md), so this requires a [merge](https://github.com/actions/upload-artifact/blob/main/merge/README.md) job too now.

See also https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions for deprecation notice for v3 (yes, November 30, 2024 is still some time away...).

Closes:
- https://github.com/spack/spack/pull/43784
- https://github.com/spack/spack/pull/42509