### PR TITLE
containers: add ubuntu 24.04

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -45,6 +45,7 @@ jobs:
                      [leap15, 'linux/amd64,linux/arm64,linux/ppc64le', 'opensuse/leap:15'],
                      [ubuntu-focal, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:20.04'],
                      [ubuntu-jammy, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:22.04'],
+                     [ubuntu-noble, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:24.04'],
                      [almalinux8, 'linux/amd64,linux/arm64,linux/ppc64le', 'almalinux:8'],
                      [almalinux9, 'linux/amd64,linux/arm64,linux/ppc64le', 'almalinux:9'],
                      [rockylinux8, 'linux/amd64,linux/arm64', 'rockylinux:8'],

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -203,6 +203,9 @@ The OS that are currently supported are summarized in the table below:
    * - Ubuntu 22.04
      - ``ubuntu:22.04``
      - ``spack/ubuntu-jammy``
+   * - Ubuntu 24.04
+     - ``ubuntu:24.04``
+     - ``spack/ubuntu-noble``
    * - CentOS 7
      - ``centos:7``
      - ``spack/centos7``

--- a/lib/spack/spack/container/images.json
+++ b/lib/spack/spack/container/images.json
@@ -116,6 +116,13 @@
       },
       "os_package_manager": "apt"
     },
+    "ubuntu:24.04": {
+      "bootstrap": {
+        "template": "container/ubuntu_2404.dockerfile"
+      },
+      "os_package_manager": "apt",
+      "build": "spack/ubuntu-noble"
+    },
     "ubuntu:22.04": {
       "bootstrap": {
         "template": "container/ubuntu_2204.dockerfile"

--- a/share/spack/templates/container/ubuntu_2404.dockerfile
+++ b/share/spack/templates/container/ubuntu_2404.dockerfile
@@ -1,0 +1,1 @@
+ubuntu_2004.dockerfile

--- a/share/spack/templates/container/ubuntu_2404.dockerfile
+++ b/share/spack/templates/container/ubuntu_2404.dockerfile
@@ -1,1 +1,33 @@
-ubuntu_2004.dockerfile
+{% extends "container/bootstrap-base.dockerfile" %}
+{% block env_vars %}
+{{ super() }}
+ENV DEBIAN_FRONTEND=noninteractive   \
+    LANGUAGE=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
+{% endblock %}
+{% block install_os_packages %}
+RUN apt-get -yqq update \
+ && apt-get -yqq upgrade \
+ && apt-get -yqq install --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        file \
+        g++ \
+        gcc \
+        gfortran \
+        git \
+        gnupg2 \
+        iproute2 \
+        locales \
+        make \
+        mercurial \
+        subversion \
+        python3 \
+        python3-boto3 \
+        unzip \
+        zstd \
+ && locale-gen en_US.UTF-8 \
+ && rm -rf /var/lib/apt/lists/*
+{% endblock %}


### PR DESCRIPTION
This PR adds containers for the new ubuntu 24.04 LTS release. Similar to #43847 for Fedora.

Ubuntu 24.04 disables system installs with pip, so this switches the install of boto3 to a system package with apt-get install python3-boto3.

This is not rolled out to older ubuntu versions since boto3 in 22.04 and older depends transitively on several more graphics libraries. Only as of 24.04 are the dependencies of python3-boto3 more limited.