### PR TITLE
add ILP64 option for BLIS

### DIFF
--- a/var/spack/repos/builtin/packages/blis/package.py
+++ b/var/spack/repos/builtin/packages/blis/package.py
@@ -26,6 +26,7 @@ class BlisBase(MakefilePackage):
         multi=False,
     )
 
+    variant("ilp64", default=False, description="Force 64-bit Fortran native integers")
     variant("blas", default=True, description="BLAS compatibility")
     variant("cblas", default=True, description="CBLAS compatibility")
     variant(
@@ -51,6 +52,11 @@ class BlisBase(MakefilePackage):
     def configure_args(self):
         spec = self.spec
         config_args = ["--enable-threading={0}".format(spec.variants["threads"].value)]
+
+        if "+ilp64" in spec:
+            config_args.append("--blas-int-size=64")
+        else:
+            config_args.append("--blas-int-size=32")
 
         if "+cblas" in spec:
             config_args.append("--enable-cblas")

--- a/var/spack/repos/builtin/packages/blis/package.py
+++ b/var/spack/repos/builtin/packages/blis/package.py
@@ -16,6 +16,8 @@ class BlisBase(MakefilePackage):
     of the library in the 'amdblis' package.
     """
 
+    maintainers("jeffhammond")
+
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
 
     variant(


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Add +ilp64 option like OpenBLAS.

Resolves https://github.com/spack/spack/issues/43867 (the important part).