### PR TITLE
NWChem ARMCI-MPI variant and optional TCE builds

### DIFF
--- a/var/spack/repos/builtin/packages/armcimpi/package.py
+++ b/var/spack/repos/builtin/packages/armcimpi/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class ArmciMpi(AutotoolsPackage):
+class Armcimpi(AutotoolsPackage):
     """ARMCI-MPI is an implementation of the ARMCI library used by Global Arrays.
     MPI-3 one-sided communication is used to implement ARMCI.
     """

--- a/var/spack/repos/builtin/packages/armcimpi/package.py
+++ b/var/spack/repos/builtin/packages/armcimpi/package.py
@@ -18,8 +18,6 @@ class Armcimpi(AutotoolsPackage):
 
     license("BSD-3-Clause", checked_by="jeffhammond")
 
-    version("master", branch="master")
-
     version("0.4", sha256="bcc3bb189b23bf653dcc69bc469eb86eae5ebc5ad94ab5f83e52ddbdbbebf1b1")
     version(
         "0.3.1-beta", sha256="f3eaa8f365fb55123ecd9ced401086b0732e37e4df592b27916d71a67ab34fe9"
@@ -48,4 +46,3 @@ class Armcimpi(AutotoolsPackage):
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.set("ARMCIMPI_DIR", self.prefix)
-

--- a/var/spack/repos/builtin/packages/armcimpi/package.py
+++ b/var/spack/repos/builtin/packages/armcimpi/package.py
@@ -18,6 +18,8 @@ class Armcimpi(AutotoolsPackage):
 
     license("BSD-3-Clause", checked_by="jeffhammond")
 
+    version("master", branch="master")
+
     version("0.4", sha256="bcc3bb189b23bf653dcc69bc469eb86eae5ebc5ad94ab5f83e52ddbdbbebf1b1")
     version(
         "0.3.1-beta", sha256="f3eaa8f365fb55123ecd9ced401086b0732e37e4df592b27916d71a67ab34fe9"

--- a/var/spack/repos/builtin/packages/armcimpi/package.py
+++ b/var/spack/repos/builtin/packages/armcimpi/package.py
@@ -28,6 +28,8 @@ class Armcimpi(AutotoolsPackage):
     variant("shared", default=True, description="Builds a shared version of the library")
     variant("progress", default=False, description="Enable asynchronous progress")
 
+    provides("armci")
+
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
@@ -43,3 +45,7 @@ class Armcimpi(AutotoolsPackage):
         args.extend(self.enable_or_disable("shared"))
         args.extend(self.with_or_without("progress"))
         return args
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set("ARMCIMPI_DIR", self.prefix)
+

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -64,6 +64,7 @@ class Nwchem(Package):
     depends_on("blas")
     depends_on("lapack")
     depends_on("mpi")
+    depends_on("armci", when="+armcimpi")
     depends_on("scalapack")
     depends_on("fftw-api@3", when="+fftw3")
     depends_on("libxc", when="+libxc")
@@ -136,12 +137,9 @@ class Nwchem(Package):
         if spec.satisfies("+mpipr"):
             args.extend(["ARMCI_NETWORK=MPI-PR"])
         elif spec.satisfies("+armcimpi"):
-            # this does not work, sadly
-            # armcimpi = spec["armcimpi"]
-            # args.extend([f"EXTERNAL_ARMCI_PATH={armcimpi.prefix}"])
-            # this works
-            args.extend(["EXTERNAL_ARMCI_PATH=${ARMCIMPI_DIR}"])
+            armcimpi = spec["armci"]
             args.extend(["ARMCI_NETWORK=ARMCI"])
+            args.extend([f"EXTERNAL_ARMCI_PATH={armcimpi.prefix}"])
 
         if spec.satisfies("+fftw3"):
             args.extend(["USE_FFTW3=y"])

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -134,8 +134,12 @@ class Nwchem(Package):
         if spec.satisfies("+mpipr"):
             args.extend(["ARMCI_NETWORK=MPI-PR"])
         elif spec.satisfies("+armcimpi"):
+            # this does not work, sadly
+            #armcimpi = spec["armcimpi"]
+            #args.extend([f"EXTERNAL_ARMCI_PATH={armcimpi.prefix}"])
+            # this works
+            args.extend(["EXTERNAL_ARMCI_PATH=${ARMCIMPI_DIR}"])
             args.extend(["ARMCI_NETWORK=ARMCI"])
-            args.extend([f"EXTERNAL_ARMCI_PATH={armcimpi.prefix}"])
 
         if spec.satisfies("+fftw3"):
             args.extend(["USE_FFTW3=y"])

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -137,8 +137,8 @@ class Nwchem(Package):
             args.extend(["ARMCI_NETWORK=MPI-PR"])
         elif spec.satisfies("+armcimpi"):
             # this does not work, sadly
-            #armcimpi = spec["armcimpi"]
-            #args.extend([f"EXTERNAL_ARMCI_PATH={armcimpi.prefix}"])
+            # armcimpi = spec["armcimpi"]
+            # args.extend([f"EXTERNAL_ARMCI_PATH={armcimpi.prefix}"])
             # this works
             args.extend(["EXTERNAL_ARMCI_PATH=${ARMCIMPI_DIR}"])
             args.extend(["ARMCI_NETWORK=ARMCI"])

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -36,8 +36,12 @@ class Nwchem(Package):
     )
 
     variant("openmp", default=False, description="Enables OpenMP support")
-    variant("mpipr", default=False, description="Enables ARMCI with progress rank")
-    variant("armcimpi", default=False, description="Enables ARMCI-MPI")
+    variant(
+        "armci",
+        values=("mpi-ts", "mpi-pr", "armcimpi", "mpi3", "openib", "ofi"),
+        default="mpi-ts",
+        description="ARMCI runtime",
+    )
     variant("extratce", default=False, description="Enables rarely-used TCE features")
     variant("fftw3", default=False, description="Link against the FFTW library")
     variant("libxc", default=False, description="Support additional functionals via libxc")
@@ -64,7 +68,7 @@ class Nwchem(Package):
     depends_on("blas")
     depends_on("lapack")
     depends_on("mpi")
-    depends_on("armci", when="+armcimpi")
+    depends_on("armcimpi", when="armci=armcimpi")
     depends_on("scalapack")
     depends_on("fftw-api@3", when="+fftw3")
     depends_on("libxc", when="+libxc")
@@ -134,12 +138,20 @@ class Nwchem(Package):
         if spec.satisfies("+openmp"):
             args.extend(["USE_OPENMP=y"])
 
-        if spec.satisfies("+mpipr"):
-            args.extend(["ARMCI_NETWORK=MPI-PR"])
-        elif spec.satisfies("+armcimpi"):
+        if self.spec.variants["armci"].value == "armcimpi":
             armcimpi = spec["armci"]
             args.extend(["ARMCI_NETWORK=ARMCI"])
             args.extend([f"EXTERNAL_ARMCI_PATH={armcimpi.prefix}"])
+        elif self.spec.variants["armci"].value == "mpi-pr":
+            args.extend(["ARMCI_NETWORK=MPI-PR"])
+        elif self.spec.variants["armci"].value == "mpi-ts":
+            args.extend(["ARMCI_NETWORK=MPI-TS"])
+        elif self.spec.variants["armci"].value == "mpi3":
+            args.extend(["ARMCI_NETWORK=MPI3"])
+        elif self.spec.variants["armci"].value == "openib":
+            args.extend(["ARMCI_NETWORK=OPENIB"])
+        elif self.spec.variants["armci"].value == "ofi":
+            args.extend(["ARMCI_NETWORK=OFI"])
 
         if spec.satisfies("+fftw3"):
             args.extend(["USE_FFTW3=y"])

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -17,6 +17,8 @@ class Nwchem(Package):
 
     tags = ["ecp", "ecp-apps"]
 
+    maintainers("jeffhammond")
+
     version(
         "7.2.2",
         sha256="6b68e9c12eec38c09d92472bdd1ff130b93c1b5e1f65e4702aa7ee36c80e4af7",

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -42,7 +42,7 @@ class Nwchem(Package):
         default="mpi-ts",
         description="ARMCI runtime",
     )
-    variant("extratce", default=False, description="Enables rarely-used TCE features")
+    variant("extratce", default=False, description="Enables rarely-used TCE features (CCSDTQ, CCSDTLR, EACCSD, IPCCSD, MRCC)")
     variant("fftw3", default=False, description="Link against the FFTW library")
     variant("libxc", default=False, description="Support additional functionals via libxc")
     variant(

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -73,6 +73,8 @@ class Nwchem(Package):
     depends_on("lapack")
     depends_on("mpi")
     depends_on("armcimpi", when="armci=armcimpi")
+    depends_on("libfabric", when="armci=ofi")
+    depends_on("rdma-core", when="armci=openib")
     depends_on("scalapack")
     depends_on("fftw-api@3", when="+fftw3")
     depends_on("libxc", when="+libxc")

--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -42,7 +42,11 @@ class Nwchem(Package):
         default="mpi-ts",
         description="ARMCI runtime",
     )
-    variant("extratce", default=False, description="Enables rarely-used TCE features (CCSDTQ, CCSDTLR, EACCSD, IPCCSD, MRCC)")
+    variant(
+        "extratce",
+        default=False,
+        description="Enables rarely-used TCE features (CCSDTQ, CCSDTLR, EACCSD, IPCCSD, MRCC)",
+    )
     variant("fftw3", default=False, description="Link against the FFTW library")
     variant("libxc", default=False, description="Support additional functionals via libxc")
     variant(


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This is ready for review.

This adds two new features:
1. ARMCI-MPI can be used by Global Arrays, with `+armcimpi`.
2. Rarely-used TCE features are not compiled by default.  They can be added with `+extratce`.

The motivation for 1 is stability.  ARMCI-MPI performs better than MPI-TS (most of the time) and is easier to use than MPI-PR.  It also integrates nicely with MPI profiling and debugging tools.

The motivation for 2 is compilation time.  The extra TCE stuff more than doubles the compilation time.  The default here is consistent with manual builds of NWChem as well.

I'll note that `+extratce` includes a nontrivial portion of my PhD dissertation projects, so my choice to disable it by default is carefully considered.

I am working on GPU-related options now but that will go into a separate PR.