### PR TITLE
fontconfig: depends_on gperf when `@2.11.1:`

### DIFF
--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -26,7 +26,7 @@ class Fontconfig(AutotoolsPackage):
     # freetype2 21.0.15+ provided by freetype 2.8.1+
     depends_on("freetype@2.8.1:", when="@2.13:")
     depends_on("freetype")
-    depends_on("gperf", type="build", when="@2.12.2:")
+    depends_on("gperf", type="build", when="@2.11.1:")
     depends_on("libxml2@2.6:")
     depends_on("pkgconfig@0.9:", type="build")
     depends_on("font-util")


### PR DESCRIPTION
Although #4551 indicates that the build dependency on `gperf` started with 2.12.2, it actually started earlier with 2.11.1, see the tags which include the relevant commit at https://gitlab.freedesktop.org/fontconfig/fontconfig/-/commit/59fd9960bbb58fd6257adb13ec0f918882149332

This PR changes the version from which gperf is required from `@2.12.2:` to `@2.11.1:`.

There's some discussion in the comments of #4551 on where this exactly starts (not just commit, but when it takes effect), and it is definitely before 2.12.2, since I get:
```
#30 2412.5      272    /bin/bash /tmp/root/spack-stage/spack-stage-fontconfig-2.12.1-4kupe
#30 2412.5             e2pw5sml7fdz4cbohcgkeuo7ylc/spack-src/missing gperf -m 100 fcobjsha
#30 2412.5             sh.gperf > fcobjshash.h.tmp && \
#30 2412.5      273    mv -f fcobjshash.h.tmp fcobjshash.h || ( rm -f fcobjshash.h.tmp && 
#30 2412.5             false )
#30 2412.5      274    /tmp/root/spack-stage/spack-stage-fontconfig-2.12.1-4kupee2pw5sml7f
#30 2412.5             dz4cbohcgkeuo7ylc/spack-src/missing: line 81: gperf: command not fo
#30 2412.5             und
#30 2412.5   >> 275    WARNING: 'gperf' is missing on your system.
```
That failing line in the `src/Makefile.am` is there since https://gitlab.freedesktop.org/fontconfig/fontconfig/-/commit/da0946721af3ab2dff3cd903065336b93592d067, which is in tag 2.11.0 (which is earlier than the oldest tag in spack). Hence, I think `@2.11.1:` is a good starting point.