### PR TITLE
autoconf: fix typo in m4 dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -52,8 +52,8 @@ class Autoconf(AutotoolsPackage, GNUMirrorPackage):
 
     # Note: m4 is not a pure build-time dependency of autoconf. m4 is
     # needed when autoconf runs, not only when autoconf is built.
-    depends_on("m4@1.4.8:", type=("build", "run"), when="@1.72:")
-    depends_on("m4@1.4.6:", type=("build", "run"), when="@:1.71")
+    depends_on("m4@1.4.8:", type=("build", "run"), when="@2.72:")
+    depends_on("m4@1.4.6:", type=("build", "run"), when="@:2.71")
     depends_on("perl", type=("build", "run"))
 
     build_directory = "spack-build"


### PR DESCRIPTION
m4 1.4.8 is actually required starting with autoconf 2.72 according to the NEWS file.