### PR TITLE
glibc: provides iconv

### DIFF
--- a/etc/spack/defaults/cray/packages.yaml
+++ b/etc/spack/defaults/cray/packages.yaml
@@ -1,0 +1,19 @@
+# -------------------------------------------------------------------------
+# This file controls default concretization preferences for Spack.
+#
+# Settings here are versioned with Spack and are intended to provide
+# sensible defaults out of the box. Spack maintainers should edit this
+# file to keep it current.
+#
+# Users can override these settings by editing the following files.
+#
+# Per-spack-instance settings (overrides defaults):
+#   $SPACK_ROOT/etc/spack/packages.yaml
+#
+# Per-user settings (overrides default and site settings):
+#   ~/.spack/packages.yaml
+# -------------------------------------------------------------------------
+packages:
+  all:
+    providers:
+      iconv: [glibc, musl, libiconv]

--- a/etc/spack/defaults/linux/packages.yaml
+++ b/etc/spack/defaults/linux/packages.yaml
@@ -1,0 +1,19 @@
+# -------------------------------------------------------------------------
+# This file controls default concretization preferences for Spack.
+#
+# Settings here are versioned with Spack and are intended to provide
+# sensible defaults out of the box. Spack maintainers should edit this
+# file to keep it current.
+#
+# Users can override these settings by editing the following files.
+#
+# Per-spack-instance settings (overrides defaults):
+#   $SPACK_ROOT/etc/spack/packages.yaml
+#
+# Per-user settings (overrides default and site settings):
+#   ~/.spack/packages.yaml
+# -------------------------------------------------------------------------
+packages:
+  all:
+    providers:
+      iconv: [glibc, musl, libiconv]

--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -30,7 +30,7 @@ packages:
       glu: [mesa-glu, openglu]
       golang: [go, gcc]
       go-or-gccgo-bootstrap: [go-bootstrap, gcc]
-      iconv: [glibc, musl, libiconv]
+      iconv: [libiconv]
       ipp: [intel-oneapi-ipp]
       java: [openjdk, jdk, ibm-java]
       jpeg: [libjpeg-turbo, libjpeg]

--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -30,7 +30,7 @@ packages:
       glu: [mesa-glu, openglu]
       golang: [go, gcc]
       go-or-gccgo-bootstrap: [go-bootstrap, gcc]
-      iconv: [glibc, libiconv]
+      iconv: [glibc, musl, libiconv]
       ipp: [intel-oneapi-ipp]
       java: [openjdk, jdk, ibm-java]
       jpeg: [libjpeg-turbo, libjpeg]

--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -30,7 +30,7 @@ packages:
       glu: [mesa-glu, openglu]
       golang: [go, gcc]
       go-or-gccgo-bootstrap: [go-bootstrap, gcc]
-      iconv: [libiconv]
+      iconv: [glibc, libiconv]
       ipp: [intel-oneapi-ipp]
       java: [openjdk, jdk, ibm-java]
       jpeg: [libjpeg-turbo, libjpeg]

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -29,6 +29,7 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
     license("LGPL-2.1-or-later")
 
     provides("libc")
+    provides("iconv")
 
     version("master", branch="master")
     version("2.39", sha256="97f84f3b7588cd54093a6f6389b0c1a81e70d99708d74963a2e3eab7c7dc942d")

--- a/var/spack/repos/builtin/packages/musl/package.py
+++ b/var/spack/repos/builtin/packages/musl/package.py
@@ -34,6 +34,7 @@ class Musl(MakefilePackage):
     representative_headers = ["iso646.h"]
 
     provides("libc")
+    provides("iconv")
 
     version("1.2.4", sha256="7a35eae33d5372a7c0da1188de798726f68825513b7ae3ebe97aaaa52114f039")
     version("1.2.3", sha256="7d5b0b6062521e4627e099e4c9dc8248d32a30285e959b7eecaa780cf8cfd4a4")


### PR DESCRIPTION
Closes #43874 

`iconv` is a bit of weird virtual because the only shared API between
`glibc` and `libiconv` is:

```
iconv
iconv_open
iconv_close
```

whereas `libiconv` has further symbols [iconvctl](https://www.gnu.org/software/libiconv/documentation/libiconv-1.17/iconvctl.3.html), [iconv_open_into](https://www.gnu.org/software/libiconv/documentation/libiconv-1.17/iconv_open_into.3.html), and an `iconv` executable and `libcharset.so`. Packages that need those will have to do `depends_on("[virtuals=iconv] libiconv")`.
