### PR TITLE
compiler.py: fix early return

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -26,7 +26,7 @@ import spack.util.executable
 import spack.util.libc
 import spack.util.module_cmd
 import spack.version
-from spack.util.environment import EnvironmentModifications, filter_system_paths
+from spack.util.environment import filter_system_paths
 
 __all__ = ["Compiler"]
 

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -707,8 +707,6 @@ class Compiler:
             env.apply_modifications()
 
             yield
-        except BaseException:
-            raise
         finally:
             # Restore environment regardless of whether inner code succeeded
             os.environ.clear()

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -20,12 +20,13 @@ from llnl.util.filesystem import path_contains_subdirectory, paths_containing_li
 
 import spack.compilers
 import spack.error
+import spack.schema.environment
 import spack.spec
 import spack.util.executable
 import spack.util.libc
 import spack.util.module_cmd
 import spack.version
-from spack.util.environment import filter_system_paths
+from spack.util.environment import EnvironmentModifications, filter_system_paths
 
 __all__ = ["Compiler"]
 
@@ -683,8 +684,8 @@ class Compiler:
 
     @contextlib.contextmanager
     def compiler_environment(self):
-        # yield immediately if no modules
-        if not self.modules:
+        # Avoid modifying os.environ if possible.
+        if not self.modules and not self.environment:
             yield
             return
 
@@ -701,7 +702,7 @@ class Compiler:
                 spack.util.module_cmd.load_module(module)
 
             # apply other compiler environment changes
-            env = spack.util.environment.EnvironmentModifications()
+            env = EnvironmentModifications()
             env.extend(spack.schema.environment.parse(self.environment))
             env.apply_modifications()
 

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -702,9 +702,7 @@ class Compiler:
                 spack.util.module_cmd.load_module(module)
 
             # apply other compiler environment changes
-            env = EnvironmentModifications()
-            env.extend(spack.schema.environment.parse(self.environment))
-            env.apply_modifications()
+            spack.schema.environment.parse(self.environment).apply_modifications()
 
             yield
         finally:

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -943,3 +943,17 @@ def test_detection_requires_c_compiler(detected_versions, expected_length):
     """
     result = spack.compilers.make_compiler_list(detected_versions)
     assert len(result) == expected_length
+
+
+def test_compiler_environment(working_env):
+    """Test whether environment modifications from compilers are applied in compiler_environment"""
+    os.environ.pop("TEST", None)
+    compiler = Compiler(
+        "gcc@=13.2.0",
+        operating_system="ubuntu20.04",
+        target="x86_64",
+        paths=["/test/bin/gcc", "/test/bin/g++"],
+        environment={"set": {"TEST": "yes"}},
+    )
+    with compiler.compiler_environment():
+        assert os.environ["TEST"] == "yes"


### PR DESCRIPTION
Closes #43895. The early return was there because replacing `os.environ` entirely has lead to issues (iirc when other code modifies `os.environb`, but don't remember details). However, the early return's condition was wrong.