### PR TITLE
Add applications to aws-pcluster-* stacks

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/scripts/pcluster/setup-pcluster.sh
+++ b/share/spack/gitlab/cloud_pipelines/scripts/pcluster/setup-pcluster.sh
@@ -23,10 +23,9 @@ set_pcluster_defaults() {
 
 setup_spack() {
     spack compiler add --scope site
-    spack external find --scope site
-    # Remove all autotools/buildtools packages. These versions need to be managed by spack or it will
+    # Do not add  autotools/buildtools packages. These versions need to be managed by spack or it will
     # eventually end up in a version mismatch (e.g. when compiling gmp).
-    spack tags build-tools | xargs -I {} spack config --scope site rm packages:{}
+    spack external find --scope site --tag core-packages
 }
 
 patch_compilers_yaml() {

--- a/share/spack/gitlab/cloud_pipelines/scripts/pcluster/setup-pcluster.sh
+++ b/share/spack/gitlab/cloud_pipelines/scripts/pcluster/setup-pcluster.sh
@@ -99,7 +99,7 @@ install_compilers() {
     # The compilers needs to be in the same install tree as the rest of the software such that the path
     # relocation works correctly. This holds the danger that this part will fail when the current spack gets
     # incompatible with the one in $spack_intel_compiler_commit. Therefore, we make intel installations optional
-    # in package.yaml files.
+    # in package.yaml files and add a fallback `%gcc` version for each application.
     if [ "x86_64" == "$(arch)" ]; then
         (
             CURRENT_SPACK_ROOT=${SPACK_ROOT}

--- a/share/spack/gitlab/cloud_pipelines/scripts/pcluster/setup-pcluster.sh
+++ b/share/spack/gitlab/cloud_pipelines/scripts/pcluster/setup-pcluster.sh
@@ -10,7 +10,7 @@ set -e
 # The best solution would be to have the compilers hash (or packages contents) be part of the
 # individual packages hashes. I don't see this at the moment.
 # Set to the latest tag including a recent oneapi compiler.
-spack_intel_compiler_commit="develop-2024-03-10"
+spack_intel_compiler_commit="develop-2023-08-06"
 
 set_pcluster_defaults() {
     # Set versions of pre-installed software in packages.yaml
@@ -108,6 +108,8 @@ install_compilers() {
             # this leads to libstdc++.so errors during linking (e.g. slepc).
             git clone --depth=1 -b ${spack_intel_compiler_commit} https://github.com/spack/spack.git \
                 && cd spack \
+                && curl -sL https://github.com/spack/spack/pull/40557.patch | patch -p1 \
+                && curl -sL https://github.com/spack/spack/pull/40561.patch | patch -p1 \
                 && cp "${CURRENT_SPACK_ROOT}/etc/spack/config.yaml" etc/spack/ \
                 && cp "${CURRENT_SPACK_ROOT}/etc/spack/compilers.yaml" etc/spack/ \
                 && cp "${CURRENT_SPACK_ROOT}/etc/spack/packages.yaml" etc/spack/ \

--- a/share/spack/gitlab/cloud_pipelines/scripts/pcluster/setup-pcluster.sh
+++ b/share/spack/gitlab/cloud_pipelines/scripts/pcluster/setup-pcluster.sh
@@ -10,7 +10,7 @@ set -e
 # The best solution would be to have the compilers hash (or packages contents) be part of the
 # individual packages hashes. I don't see this at the moment.
 # Set to the latest tag including a recent oneapi compiler.
-spack_intel_compiler_commit="develop-2023-08-06"
+spack_intel_compiler_commit="develop-2024-03-10"
 
 set_pcluster_defaults() {
     # Set versions of pre-installed software in packages.yaml
@@ -108,8 +108,6 @@ install_compilers() {
             # this leads to libstdc++.so errors during linking (e.g. slepc).
             git clone --depth=1 -b ${spack_intel_compiler_commit} https://github.com/spack/spack.git \
                 && cd spack \
-                && curl -sL https://github.com/spack/spack/pull/40557.patch | patch -p1 \
-                && curl -sL https://github.com/spack/spack/pull/40561.patch | patch -p1 \
                 && cp "${CURRENT_SPACK_ROOT}/etc/spack/config.yaml" etc/spack/ \
                 && cp "${CURRENT_SPACK_ROOT}/etc/spack/compilers.yaml" etc/spack/ \
                 && cp "${CURRENT_SPACK_ROOT}/etc/spack/packages.yaml" etc/spack/ \

--- a/share/spack/gitlab/cloud_pipelines/scripts/pcluster/setup-pcluster.sh
+++ b/share/spack/gitlab/cloud_pipelines/scripts/pcluster/setup-pcluster.sh
@@ -10,6 +10,7 @@ set -e
 # The best solution would be to have the compilers hash (or packages contents) be part of the
 # individual packages hashes. I don't see this at the moment.
 # Set to the latest tag including a recent oneapi compiler.
+# NOTE: If we update this spack version in the future make sure the compiler version also updates.
 spack_intel_compiler_commit="develop-2023-08-06"
 
 set_pcluster_defaults() {

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/packages.yaml
@@ -19,7 +19,10 @@ packages:
   llvm:
     variants: ~lldb
   mpas-model:
-    require: "precision=single make_target=llvm %arm ^parallelio+pnetcdf"
+    require:
+      - one_of:
+          - "precision=single make_target=llvm %arm ^parallelio+pnetcdf"
+          - "precision=single %gcc ^parallelio+pnetcdf"
   mpich:
     require: "mpich pmi=pmi2 device=ch4 netmod=ofi +slurm"
   nvhpc:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
@@ -2,13 +2,18 @@ spack:
   view: false
 
   definitions:
-  - optimized_configs:
-    - gromacs target=neoverse_v1
-    - gromacs target=neoverse_n1
+  - apps:
+    - gromacs
+    - openfoam
+
+  - targets:
+      - 'target=neoverse_v1'
+      - 'target=neoverse_n1'
 
   specs:
-  - $optimized_configs
-
+  - matrix:
+      - [$apps]
+      - [$targets]
   ci:
     pipeline-gen:
     - build-job:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
@@ -4,7 +4,10 @@ spack:
   definitions:
   - apps:
     - gromacs
+    - mpas-model
     - openfoam
+    - quantum-espresso
+    - wrf
 
   - targets:
       - 'target=neoverse_v1'

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
@@ -4,9 +4,11 @@ spack:
   definitions:
   - apps:
     - gromacs
-    - mpas-model
+    # - mpas-model: Spack currently forces REAL(8) when using GCC. This conflicts with `precision=single`
+    # Fix proposed in https://github.com/spack/spack/pull/43547
     - openfoam
-    - quantum-espresso
+    # - quantum-espresso : %gcc@12.3.0 on neoverse_v1 fails.
+    # Root cause: internal compiler error: in compute_live_loop_exits, at tree-ssa-loop-manip.cc:247
     - wrf
 
   - targets:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
@@ -6,6 +6,12 @@ packages:
           - "cflags=-std=c18 target=x86_64_v4"
           - "cflags=-std=c18 target=x86_64_v3"
           - "%gcc"
+  gettext:
+    require:
+      - one_of:
+          - '%intel cflags="-std=c18"'
+          - '%gcc'
+        message: "gettext uses single valued `static_assert` which is only available in `icc` as part of later C standard."
   gromacs:
     require:
       - one_of:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
@@ -14,8 +14,6 @@ packages:
         when: "%intel"
         message: "gettext uses single valued `static_assert` which is only available in `icc` as part of later C standard."
   gromacs:
-    prefer:
-      - "%intel"
     require:
       - one_of:
           - "+intel_provided_gcc ^intel-oneapi-mkl target=x86_64_v4"
@@ -28,8 +26,6 @@ packages:
   intel-oneapi-mpi:
     variants: +external-libfabric generic-names=True
   lammps:
-    prefer:
-      - "%intel"
     require:
       - one_of:
           - "lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package +intel ^intel-oneapi-mkl target=x86_64_v4"
@@ -54,8 +50,6 @@ packages:
           - "cflags=-std=c18 target=x86_64_v3"
         when: "%intel"
   mpas-model:
-    prefer:
-      - "%intel"
     require:
       - one_of:
           - "precision=single ^parallelio+pnetcdf target=x86_64_v4"
@@ -78,8 +72,6 @@ packages:
           - "openmpi @4: target=x86_64_v4"
           - "openmpi @4: target=x86_64_v3"
   palace:
-    prefer:
-      - "%oneapi"
     require:
       - one_of:
           - "palace ^fmt@9.1.0 target=x86_64_v4"
@@ -94,8 +86,6 @@ packages:
           - "pmix@3: target=x86_64_v4"
           - "pmix@3: target=x86_64_v3"
   quantum-espresso:
-    prefer:
-      - "%intel"
     require:
       - one_of:
           - "quantum-espresso@6.6 ^intel-oneapi-mkl+cluster target=x86_64_v4"
@@ -107,8 +97,6 @@ packages:
       - prefix: /opt/slurm/
         spec: slurm@${SLURM_VERSION} +pmix
   wrf:
-    prefer:
-      - "%intel"
     require:
       - one_of:
           - "wrf@4 build_type=dm+sm target=x86_64_v4"

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
@@ -5,20 +5,22 @@ packages:
       - one_of:
           - "cflags=-std=c18 target=x86_64_v4"
           - "cflags=-std=c18 target=x86_64_v3"
-          - "%gcc"
+        when: "%intel"
   gettext:
     require:
       - one_of:
           - "cflags=-std=c18 target=x86_64_v4"
-          - "cflags=-std=c18 target=x86_64_v4"
-          - "%gcc"
+          - "cflags=-std=c18 target=x86_64_v3"
+        when: "%intel"
         message: "gettext uses single valued `static_assert` which is only available in `icc` as part of later C standard."
   gromacs:
+    prefer:
+      - "%intel"
     require:
       - one_of:
-          - "+intel_provided_gcc %intel ^intel-oneapi-mkl target=x86_64_v4"
-          - "+intel_provided_gcc %intel ^intel-oneapi-mkl target=x86_64_v3"
-          - "%gcc"
+          - "+intel_provided_gcc ^intel-oneapi-mkl target=x86_64_v4"
+          - "+intel_provided_gcc ^intel-oneapi-mkl target=x86_64_v3"
+        when: "%intel"
   intel-mpi:
     variants: +external-libfabric
   intel-oneapi-compilers:
@@ -26,17 +28,19 @@ packages:
   intel-oneapi-mpi:
     variants: +external-libfabric generic-names=True
   lammps:
+    prefer:
+      - "%intel"
     require:
       - one_of:
-          - "lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package +intel %intel ^intel-oneapi-mkl target=x86_64_v4"
-          - "lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package %intel ^intel-oneapi-mkl target=x86_64_v3"
-          - "%gcc"
+          - "lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package +intel ^intel-oneapi-mkl target=x86_64_v4"
+          - "lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package ^intel-oneapi-mkl target=x86_64_v3"
+        when: "%intel"
   libidn2:
     require:
       - one_of:
           - "cflags=-std=c18 target=x86_64_v4"
           - "cflags=-std=c18 target=x86_64_v3"
-          - '%gcc'
+        when: "%intel"
   libfabric:
     buildable: true
     externals:
@@ -48,13 +52,15 @@ packages:
       - one_of:
           - "cflags=-std=c18 target=x86_64_v4"
           - "cflags=-std=c18 target=x86_64_v3"
-          - "%gcc"
+        when: "%intel"
   mpas-model:
+    prefer:
+      - "%intel"
     require:
       - one_of:
-          - "precision=single %intel ^parallelio+pnetcdf target=x86_64_v4"
-          - "precision=single %intel ^parallelio+pnetcdf target=x86_64_v3"
-          - "%gcc"
+          - "precision=single ^parallelio+pnetcdf target=x86_64_v4"
+          - "precision=single ^parallelio+pnetcdf target=x86_64_v3"
+        when: "%intel"
   mpich:
     require:
       - one_of:
@@ -72,36 +78,46 @@ packages:
           - "openmpi @4: target=x86_64_v4"
           - "openmpi @4: target=x86_64_v3"
   palace:
+    prefer:
+      - "%oneapi"
     require:
       - one_of:
-          - "palace %oneapi ^fmt@9.1.0 target=x86_64_v4"
-          - "palace %oneapi ^fmt@9.1.0 target=x86_64_v3"
-          - "%gcc ^fmt@9.1.0"
+          - "palace ^fmt@9.1.0 target=x86_64_v4"
+          - "palace ^fmt@9.1.0 target=x86_64_v3"
+        when: "%oneapi"
+      - one_of:
+          - "palace ^fmt@9.1.0"
+        when: "%gcc"
   pmix:
     require:
       - one_of:
           - "pmix@3: target=x86_64_v4"
           - "pmix@3: target=x86_64_v3"
   quantum-espresso:
+    prefer:
+      - "%intel"
     require:
       - one_of:
-          - "quantum-espresso@6.6 %intel ^intel-oneapi-mkl+cluster target=x86_64_v4"
-          - "quantum-espresso@6.6 %intel ^intel-oneapi-mkl+cluster target=x86_64_v3"
-          - "%gcc"
+          - "quantum-espresso@6.6 ^intel-oneapi-mkl+cluster target=x86_64_v4"
+          - "quantum-espresso@6.6 ^intel-oneapi-mkl+cluster target=x86_64_v3"
+        when: "%intel"
   slurm:
     buildable: false
     externals:
       - prefix: /opt/slurm/
         spec: slurm@${SLURM_VERSION} +pmix
   wrf:
+    prefer:
+      - "%intel"
     require:
       - one_of:
-          - "wrf@4 build_type=dm+sm %intel target=x86_64_v4"
-          - "wrf@4 build_type=dm+sm %intel target=x86_64_v3"
-          - "wrf@4.2.2 +netcdf_classic fflags=\"-fp-model fast=2 -no-heap-arrays -no-prec-div -no-prec-sqrt -fno-common\" build_type=dm+sm %intel  target=x86_64_v3"
-          - "%gcc"
+          - "wrf@4 build_type=dm+sm target=x86_64_v4"
+          - "wrf@4 build_type=dm+sm target=x86_64_v3"
+          - "wrf@4.2.2 +netcdf_classic fflags=\"-fp-model fast=2 -no-heap-arrays -no-prec-div -no-prec-sqrt -fno-common\" build_type=dm+sm target=x86_64_v3"
+        when: "%intel"
+
   all:
-    compiler: [intel, gcc]
+    compiler: [intel, oneapi, gcc]
     permissions:
       read: world
       write: user

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
@@ -7,11 +7,8 @@ packages:
           - "cflags=-std=c18 target=x86_64_v3"
         when: "%intel"
   gettext:
-    require:
-      - one_of:
-          - "%gcc"
-          - "%oneapi"
-          - "%intel cflags=-std=c18"
+    # Newer gettext cannot build with gcc@12 and old AL2 glibc headers
+    require: '@0.19.8.1'
   gromacs:
     require:
       - one_of:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
@@ -9,10 +9,9 @@ packages:
   gettext:
     require:
       - one_of:
-          - "cflags=-std=c18 target=x86_64_v4"
-          - "cflags=-std=c18 target=x86_64_v3"
-        when: "%intel"
-        message: "gettext uses single valued `static_assert` which is only available in `icc` as part of later C standard."
+          - "%gcc"
+          - "%oneapi"
+          - "%intel cflags=-std=c18"
   gromacs:
     require:
       - one_of:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
@@ -9,8 +9,8 @@ packages:
   gettext:
     require:
       - one_of:
-          - '%intel cflags="-std=c18"'
-          - '%gcc'
+          - "%intel cflags=-std=c18"
+          - "%gcc"
         message: "gettext uses single valued `static_assert` which is only available in `icc` as part of later C standard."
   gromacs:
     require:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
@@ -9,7 +9,8 @@ packages:
   gettext:
     require:
       - one_of:
-          - "%intel cflags=-std=c18"
+          - "cflags=-std=c18 target=x86_64_v4"
+          - "cflags=-std=c18 target=x86_64_v4"
           - "%gcc"
         message: "gettext uses single valued `static_assert` which is only available in `icc` as part of later C standard."
   gromacs:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
@@ -8,7 +8,7 @@ packages:
         when: "%intel"
   gettext:
     # Newer gettext cannot build with gcc@12 and old AL2 glibc headers
-    require: '@0.19.8.1'
+    require: '@:0.20'
   gromacs:
     require:
       - one_of:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
@@ -8,7 +8,11 @@ packages:
         when: "%intel"
   gettext:
     # Newer gettext cannot build with gcc@12 and old AL2 glibc headers
-    require: '@:0.20'
+    # Older gettext versions do not build correctly with oneapi.
+    require:
+      - one_of:
+          - '@:0.20'
+          - '%oneapi'
   gromacs:
     require:
       - one_of:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
@@ -5,11 +5,13 @@ spack:
   - apps:
     - gromacs
     - lammps
-    - mpas-model
+    # - mpas-model: Spack currently forces REAL(8) when using GCC. This conflicts with `precision=single`
     - openfoam
     - palace
-    - quantum-espresso
+    # - quantum-espresso : %gcc@12.3.0 on neoverse_v1 fails.
+    # Root cause: internal compiler error: in compute_live_loop_exits, at tree-ssa-loop-manip.cc:247
     # - wrf : While building hdf5 cmake errors out with Detecting Fortran/C Interface: Failed to compile
+    # Root cause: ifort cannot deal with arbitrarily long file names.
 
   - targets:
       - 'target=x86_64_v4'

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
@@ -2,14 +2,23 @@ spack:
   view: false
 
   definitions:
+  - apps:
+    - gromacs
+    - lammps
+    - mpas-model
+    - openfoam
+    - palace
+    - quantum-espresso
+    - wrf
 
-  - optimized_configs:
-    - palace target=x86_64_v4
-    - palace target=x86_64_v3
+  - targets:
+      - 'target=x86_64_v4'
+      - 'target=x86_64_v3'
 
   specs:
-  - $optimized_configs
-
+  - matrix:
+      - [$apps]
+      - [$targets]
   ci:
     pipeline-gen:
     - build-job:
@@ -28,5 +37,6 @@ spack:
           # Do not distribute Intel & ARM binaries
           - - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep intel-oneapi | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
             - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep armpl | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+
   cdash:
     build-group: AWS Packages

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
@@ -9,7 +9,7 @@ spack:
     - openfoam
     - palace
     - quantum-espresso
-    - wrf
+    # - wrf : While building hdf5 cmake errors out with Detecting Fortran/C Interface: Failed to compile
 
   - targets:
       - 'target=x86_64_v4'

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
@@ -5,11 +5,10 @@ spack:
   - apps:
     - gromacs
     - lammps
-    # - mpas-model: Spack currently forces REAL(8) when using GCC. This conflicts with `precision=single`
+    - mpas-model
     - openfoam
     - palace
-    # - quantum-espresso : %gcc@12.3.0 on neoverse_v1 fails.
-    # Root cause: internal compiler error: in compute_live_loop_exits, at tree-ssa-loop-manip.cc:247
+    - quantum-espresso
     # - wrf : While building hdf5 cmake errors out with Detecting Fortran/C Interface: Failed to compile
     # Root cause: ifort cannot deal with arbitrarily long file names.
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
@@ -3,12 +3,12 @@ spack:
 
   definitions:
   - apps:
-    - gromacs
-    - lammps
-    - mpas-model
-    - openfoam
-    - palace
-    - quantum-espresso
+    - gromacs %intel
+    - lammps %intel
+    - mpas-model %intel
+    - openfoam %gcc
+    - palace %oneapi
+    - quantum-espresso %intel
     # - wrf : While building hdf5 cmake errors out with Detecting Fortran/C Interface: Failed to compile
     # Root cause: ifort cannot deal with arbitrarily long file names.
 


### PR DESCRIPTION
This PR adds building gromacs, openfoam, wrf, mpas-model, quantum-espresso, palace & lammps with intel, gcc and oneapi compilers in the aws-pcluster-* build cache stacks.

(This is a rebase of https://github.com/spack/spack/pull/43536 onto develop after my push/pull hickup on that PR.)