### PR TITLE
ADIOS2: Campaign Variant

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -82,6 +82,7 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
         when="+shared",
         description="Enable the DataMan engine for WAN transports",
     )
+    variant("campaign", default=False, when="@2.10:", description="Enable campaign management")
     variant("dataspaces", default=False, when="@2.5:", description="Enable support for DATASPACES")
     variant("ssc", default=True, when="@:2.7", description="Enable the SSC staging engine")
     variant("hdf5", default=False, description="Enable the HDF5 engine")
@@ -173,6 +174,8 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("hdf5~mpi", when="+hdf5~mpi")
     depends_on("hdf5+mpi", when="+hdf5+mpi")
 
+    depends_on("sqlite@3", when="+campaign")
+
     depends_on("libpressio", when="+libpressio")
     depends_on("c-blosc", when="+blosc")
     depends_on("c-blosc2", when="+blosc2")
@@ -251,6 +254,7 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
             from_variant("ADIOS2_USE_Blosc", "blosc"),
             from_variant("ADIOS2_USE_Blosc2", "blosc2"),
             from_variant("ADIOS2_USE_BZip2", "bzip2"),
+            from_variant("ADIOS2_USE_Campaign", "campaign"),
             from_variant("ADIOS2_USE_DataMan", "dataman"),
             from_variant("ADIOS2_USE_DataSpaces", "dataspaces"),
             from_variant("ADIOS2_USE_Fortran", "fortran"),


### PR DESCRIPTION
With v2.10+, ADIOS added a campaign manager. This is auto-enabled if SQLite3 is found.

Add explicit control for it now and disables it by default, to avoid picking up system dependencies or bloating by default the ADIOS2 dependencies. Also, not yet fully mature to be used by default: https://github.com/ornladios/ADIOS2/issues/4148

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
