### PR TITLE
grads: fix libpng and g2c deps

### DIFF
--- a/var/spack/repos/builtin/packages/grads/package.py
+++ b/var/spack/repos/builtin/packages/grads/package.py
@@ -69,7 +69,8 @@ class Grads(AutotoolsPackage):
         
         if self.spec.satisfies("+grib2"):
             filter_file("grib2c", "g2c", "configure")
-            filter_file("G2_VERSION", "G2C_VERSION", "src/gacfg.c")
+            if self.spec.satisfies("^g2c@1.8.0:"):
+                filter_file("G2_VERSION", "G2C_VERSION", "src/gacfg.c")
 
     def setup_build_environment(self, env):
         env.set("SUPPLIBS", "/")

--- a/var/spack/repos/builtin/packages/grads/package.py
+++ b/var/spack/repos/builtin/packages/grads/package.py
@@ -63,10 +63,13 @@ class Grads(AutotoolsPackage):
             return url.format(version.up_to(2), version)
 
     # Name of grib2 C library has changed in recent versions
-    with when("+grib2"):
-
-        def patch(self):
+    def patch(self):
+        if self.spec.satisfies("@:2.2.2"):
+            filter_file("png15", "png", "configure")
+        
+        if self.spec.satisfies("+grib2"):
             filter_file("grib2c", "g2c", "configure")
+            filter_file("G2_VERSION", "G2C_VERSION", "src/gacfg.c")
 
     def setup_build_environment(self, env):
         env.set("SUPPLIBS", "/")

--- a/var/spack/repos/builtin/packages/grads/package.py
+++ b/var/spack/repos/builtin/packages/grads/package.py
@@ -66,7 +66,7 @@ class Grads(AutotoolsPackage):
     def patch(self):
         if self.spec.satisfies("@:2.2.2"):
             filter_file("png15", "png", "configure")
-        
+
         if self.spec.satisfies("+grib2"):
             filter_file("grib2c", "g2c", "configure")
             if self.spec.satisfies("^g2c@1.8.0:"):


### PR DESCRIPTION
This PR:
 - allows grads@:2.2.2 to use hdf built with the v16 libpng API; currently, `./configure` prior to v2.2.3 uses `-lpng15` specifically. It builds successfully with libpng@1.6: (v16 API; the alternative would be something like `depends_on("hdf ^libpng@1.5")`).
 - changes `G2_VERSION` to `G2C_VERSION` in src/gacfg.c. This was the only way I could get it to compile with +grib2; @vanderwb let me know if I'm missing something here, like if it's related to G2C version or something.