### PR TITLE
compadre: bumped up version of kokkos-kernels

### DIFF
--- a/var/spack/repos/builtin/packages/compadre/package.py
+++ b/var/spack/repos/builtin/packages/compadre/package.py
@@ -25,7 +25,7 @@ class Compadre(CMakePackage):
     version("1.4.1", sha256="2e1e7d8e30953f76b6dc3a4c86ec8103d4b29447194cb5d5abb74b8e4099bdd9")
     version("1.3.0", sha256="f711a840fd921e84660451ded408023ec3bcfc98fd0a7dc4a299bfae6ab489c2")
 
-    depends_on("kokkos-kernels@3.3.01:3.6")
+    depends_on("kokkos-kernels@3.3.01:4")
     depends_on("cmake@3.13:", type="build")
 
     variant("mpi", default=False, description="Enable MPI support")


### PR DESCRIPTION
Newer versions of kokkos and kokkos-kernels are out. Bumped the version to allow using them with compadre.
