### PR TITLE
Revert #43701 (scorep)

### DIFF
--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -153,9 +153,6 @@ class Scorep(AutotoolsPackage):
             return None
         return libs.directories[0]
 
-    def with_or_without(self, arg):
-        return super.with_or_without(arg).remove_suffix("=yes")
-
     def configure_args(self):
         spec = self.spec
 


### PR DESCRIPTION
PR #43701 is broken, preventing scorep from being installed. As explained in #43700 the issue is internal to scorep and can not be fixed in the package, at least by the method being attempted here.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
