### PR TITLE
Update prod-util recipe

### DIFF
--- a/var/spack/repos/builtin/packages/prod-util/package.py
+++ b/var/spack/repos/builtin/packages/prod-util/package.py
@@ -24,9 +24,9 @@ class ProdUtil(CMakePackage):
     version(
         "1.2.2",
         sha256="c51b903ea5a046cb9b545b5c04fd28647c58b4ab6182e61710f0287846350ef8",
-        deprecated=True
+        deprecated=True,
     )
- 
+
     depends_on("w3nco", when="@1")
     depends_on("w3emc", when="@2:")
 

--- a/var/spack/repos/builtin/packages/prod-util/package.py
+++ b/var/spack/repos/builtin/packages/prod-util/package.py
@@ -14,9 +14,22 @@ class ProdUtil(CMakePackage):
 
     homepage = "https://github.com/NOAA-EMC/NCEPLIBS-prod_util"
     url = "https://github.com/NOAA-EMC/NCEPLIBS-prod_util/archive/refs/tags/v1.2.2.tar.gz"
+    git = "https://github.com/NOAA-EMC/NCEPLIBS-prod_util"
 
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
-    version("1.2.2", sha256="c51b903ea5a046cb9b545b5c04fd28647c58b4ab6182e61710f0287846350ef8")
+    version("develop", branch="develop")
+    version("2.1.1", sha256="2f7507fa378a44f42b971f60de8152387c311bfa9c5c05a274c87b43a143aacd")
+    version("2.1.0", sha256="fa7df4a82dae269ffb347b9007376fb0d9979c17c4974814ea82204b12d70ea5")
+    version(
+        "1.2.2",
+        sha256="c51b903ea5a046cb9b545b5c04fd28647c58b4ab6182e61710f0287846350ef8",
+        deprecated=True
+    )
+ 
+    depends_on("w3nco", when="@1")
+    depends_on("w3emc", when="@2:")
 
-    depends_on("w3nco")
+    def check(self):
+        with working_dir(self.builder.build_directory):
+            make("test")


### PR DESCRIPTION
This PR adds the latest versions of prod-util, removes an old one, and updates the dependency from w3nco to w3emc.