### PR TITLE
[Kokkos] fix deprecated code flag being ignored

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -195,6 +195,8 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "tests": [False, "Build for tests"],
     }
 
+    conflicts("~cuda_lambda", when="@4.1: +cuda ~deprecated_code")
+
     spack_micro_arch_map = {
         "thunderx2": "THUNDERX2",
         "zen": "ZEN",

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -397,7 +397,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         return smam[target.name]
 
     def append_args(self, cmake_prefix, cmake_options, spack_options):
-        variant_to_cmake_option = {"rocm": "hip"}
+        variant_to_cmake_option = {"rocm": "hip", "deprecated_code": "deprecated_code_4"}
         for variant_name in cmake_options:
             opt = variant_to_cmake_option.get(variant_name, variant_name)
             optname = f"Kokkos_{cmake_prefix}_{opt.upper()}"


### PR DESCRIPTION
Currently, the variant `+deprecated_code` generates an invalid CMake flag `KOKKOS_ENABLE_DEPRECATED_CODE`. We actually use deprecated code flags of the format `KOKKOS_ENABLE_DEPRECATED_CODE_4` (for the 4.x release series). The invalid flag is ignored, except for a warning on CMake's part.

This PR fixes the flag to set `KOKKOS_ENABLE_DEPRECATED_CODE_4`. In the future, we will need to update the mapping as we update our major releases.