### PR TITLE
python: allow executables with minor versions

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -332,7 +332,7 @@ class Python(Package):
     # An in-source build with --enable-optimizations fails for python@3.X
     build_directory = "spack-build"
 
-    executables = [r"^python\d?$"]
+    executables = [r"^python(\d+(\.\d+)?)?$"]
 
     @classmethod
     def determine_version(cls, exe):


### PR DESCRIPTION
I am on a machine that has multiple minor Python versions in `PATH`, so this new regex will match on `python3.11`, etc. Hopefully this was the right approach to fix this, I don't know enough about the internals to know if this will break something

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
