### PR TITLE
py-torch-spline-conv: add v1.2.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch-geometric/package.py
+++ b/var/spack/repos/builtin/packages/py-torch-geometric/package.py
@@ -52,8 +52,7 @@ class PyTorchGeometric(PythonPackage):
     # Optional dependencies
     depends_on("py-torch-cluster+cuda", when="+cuda", type=("build", "run"))
     depends_on("py-torch-cluster~cuda", when="~cuda", type=("build", "run"))
-    depends_on("py-torch-spline-conv+cuda", when="+cuda", type=("build", "run"))
-    depends_on("py-torch-spline-conv~cuda", when="~cuda", type=("build", "run"))
+    depends_on("py-torch-spline-conv", type=("build", "run"))
 
     # Undocumented dependencies
     depends_on("py-torch", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-torch-spline-conv/package.py
+++ b/var/spack/repos/builtin/packages/py-torch-spline-conv/package.py
@@ -22,6 +22,7 @@ class PyTorchSplineConv(PythonPackage):
         deprecated=True,
     )
 
+    depends_on("python", type=("build", "link", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-torch", type=("build", "link", "run"))
 

--- a/var/spack/repos/builtin/packages/py-torch-spline-conv/package.py
+++ b/var/spack/repos/builtin/packages/py-torch-spline-conv/package.py
@@ -11,23 +11,37 @@ class PyTorchSplineConv(PythonPackage):
     convolution operator of SplineCNN."""
 
     homepage = "https://github.com/rusty1s/pytorch_spline_conv"
-    url = "https://github.com/rusty1s/pytorch_spline_conv/archive/1.2.0.tar.gz"
+    pypi = "torch-spline-conv/torch_spline_conv-1.2.2.tar.gz"
 
     license("MIT")
 
-    version("1.2.0", sha256="ab8da41357c8a4785662366655bb6dc5e84fd0e938008194955409aefe535009")
+    version("1.2.2", sha256="ed45a81da29f774665dbdd4709d7e534cdf16d2e7006dbd06957f35bd09661b2")
+    version(
+        "1.2.0",
+        sha256="b7a1788004f6c6143d47040f2dd7d8a579a0c69a0cb0b5d7537416bf37c082a5",
+        deprecated=True,
+    )
 
-    variant("cuda", default=False, description="Enable CUDA support")
-
-    depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-pytest-runner", type="build")
-    depends_on("py-torch+cuda", when="+cuda")
-    depends_on("py-torch~cuda", when="~cuda")
+    depends_on("py-torch", type=("build", "link", "run"))
+
+    # Historical dependencies
+    depends_on("py-pytest-runner", type="build", when="@:1.2.1")
 
     def setup_build_environment(self, env):
-        if "+cuda" in self.spec:
-            env.set("FORCE_CUDA", "1")
-            env.set("CUDA_HOME", self.spec["cuda"].prefix)
+        if self.spec.satisfies("@1.2.1:"):
+            if "+cuda" in self.spec["py-torch"]:
+                env.set("FORCE_CUDA", 1)
+                env.set("FORCE_ONLY_CUDA", 0)
+                env.set("FORCE_ONLY_CPU", 0)
+            else:
+                env.set("FORCE_CUDA", 0)
+                env.set("FORCE_ONLY_CUDA", 0)
+                env.set("FORCE_ONLY_CPU", 1)
         else:
-            env.set("FORCE_CUDA", "0")
+            if "+cuda" in self.spec["py-torch"]:
+                env.set("FORCE_CUDA", 1)
+                env.set("FORCE_CPU", 0)
+            else:
+                env.set("FORCE_CUDA", 0)
+                env.set("FORCE_CPU", 1)


### PR DESCRIPTION
1.2.0 is failing in CI on aarch64, trying a newer version: https://gitlab.spack.io/spack/spack/-/jobs/11025715