### PR TITLE
rust: add conflict for older GCC

### DIFF
--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -81,6 +81,9 @@ class Rust(Package):
     depends_on("rust-bootstrap@1.73:1.74", type="build", when="@1.74")
     depends_on("rust-bootstrap@1.74:1.75", type="build", when="@1.75")
 
+    # src/llvm-project/llvm/cmake/modules/CheckCompilerVersion.cmake
+    conflicts("%gcc@:7.3", when="@1.73:", msg="Host GCC version must be at least 7.4")
+
     extendable = True
     executables = ["^rustc$", "^cargo$"]
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Extracted from #39666