### PR TITLE
add arm libc to compiler detection

### DIFF
--- a/lib/spack/spack/util/libc.py
+++ b/lib/spack/spack/util/libc.py
@@ -22,7 +22,7 @@ def _libc_from_ldd(ldd: str) -> Optional["spack.spec.Spec"]:
     except Exception:
         return None
 
-    if not re.search("gnu|glibc", stdout, re.IGNORECASE):
+    if not re.search("gnu|glibc|arm", stdout, re.IGNORECASE):
         return None
 
     version_str = re.match(r".+\(.+\) (.+)", stdout)
@@ -75,7 +75,7 @@ def libc_from_dynamic_linker(dynamic_linker: str) -> Optional["spack.spec.Spec"]
             return spec
         except Exception:
             return None
-    elif re.search("gnu|glibc", stdout, re.IGNORECASE):
+    elif re.search("gnu|glibc|arm", stdout, re.IGNORECASE):
         # output is like "ld.so (...) stable release version 2.33." write a regex for it
         match = re.search(r"version (\d+\.\d+(?:\.\d+)?)", stdout)
         if not match:

--- a/lib/spack/spack/util/libc.py
+++ b/lib/spack/spack/util/libc.py
@@ -75,7 +75,7 @@ def libc_from_dynamic_linker(dynamic_linker: str) -> Optional["spack.spec.Spec"]
             return spec
         except Exception:
             return None
-    elif re.search("\b(?:gnu|glibc|arm)\b", stdout, re.IGNORECASE):
+    elif re.search(r"\b(?:gnu|glibc|arm)\b", stdout, re.IGNORECASE):
         # output is like "ld.so (...) stable release version 2.33." write a regex for it
         match = re.search(r"version (\d+\.\d+(?:\.\d+)?)", stdout)
         if not match:

--- a/lib/spack/spack/util/libc.py
+++ b/lib/spack/spack/util/libc.py
@@ -76,7 +76,7 @@ def libc_from_dynamic_linker(dynamic_linker: str) -> Optional["spack.spec.Spec"]
         except Exception:
             return None
     elif re.search(r"\b(?:gnu|glibc|arm)\b", stdout, re.IGNORECASE):
-        # output is like "ld.so (...) stable release version 2.33." write a regex for it
+        # output is like "ld.so (...) stable release version 2.33."
         match = re.search(r"version (\d+\.\d+(?:\.\d+)?)", stdout)
         if not match:
             return None

--- a/lib/spack/spack/util/libc.py
+++ b/lib/spack/spack/util/libc.py
@@ -22,7 +22,7 @@ def _libc_from_ldd(ldd: str) -> Optional["spack.spec.Spec"]:
     except Exception:
         return None
 
-    if not re.search("gnu|glibc|arm", stdout, re.IGNORECASE):
+    if not re.search(r"\b(?:gnu|glibc|arm)\b", stdout, re.IGNORECASE):
         return None
 
     version_str = re.match(r".+\(.+\) (.+)", stdout)
@@ -75,7 +75,7 @@ def libc_from_dynamic_linker(dynamic_linker: str) -> Optional["spack.spec.Spec"]
             return spec
         except Exception:
             return None
-    elif re.search("gnu|glibc|arm", stdout, re.IGNORECASE):
+    elif re.search("\b(?:gnu|glibc|arm)\b", stdout, re.IGNORECASE):
         # output is like "ld.so (...) stable release version 2.33." write a regex for it
         match = re.search(r"version (\d+\.\d+(?:\.\d+)?)", stdout)
         if not match:


### PR DESCRIPTION
[Arm GNU Toolchain](https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain) shows different version line:
`ld.so (Arm) stable release version 2.37.`
vs typical:
`ld.so (GNU libc) stable release version 2.28.`