### PR TITLE
Add py-flash-attn@2.4.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-flash-attn/package.py
+++ b/var/spack/repos/builtin/packages/py-flash-attn/package.py
@@ -19,6 +19,7 @@ class PyFlashAttn(PythonPackage):
 
     version("2.5.5", sha256="751cee17711d006fe7341cdd78584af86a6239afcfe43b9ed11c84db93126267")
     version("2.5.4", sha256="d83bb427b517b07e9db655f6e5166eb2607dccf4d6ca3229e3a3528c206b0175")
+    version("2.4.2", sha256="eb822a8c4219b610e9d734cbc8cd9ee4547f27433815a2b90dc1462766feefc1")
 
     depends_on("py-setuptools", type="build")
 
@@ -27,6 +28,9 @@ class PyFlashAttn(PythonPackage):
         depends_on("py-ninja")
         depends_on("py-einops")
         depends_on("py-packaging")
+
+    with default_args(type=("build", "link", "run")):
+        depends_on("py-pybind11")
 
     depends_on("py-psutil", type="build")
 


### PR DESCRIPTION
NVIDIA/TransformerEngine requires flash attention <= 2.4.2.
Fix compilation error, missing pybind dependency.