### PR TITLE
OpenMPI: Limit `orterunprefix` variant to pre-5.x versions

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -526,6 +526,7 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     variant(
         "orterunprefix",
         default=False,
+        when="@:4",
         description="Prefix Open MPI to PATH and LD_LIBRARY_PATH on local and remote hosts",
     )
     # Adding support to build a debug version of OpenMPI that activates


### PR DESCRIPTION
OpenMPI 5.x switches to `--enable-prte-prefix-by-default` instead, which is enabled by default at configure time.