### PR TITLE
Windows: Non config changes to support Gitlab CI

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -215,6 +215,15 @@ def _win_rename(src, dst):
 
 
 @system_path_filter
+def msdos_escape_parens(path):
+    """MS-DOS interprets parens as grouping parameters even in a quoted string"""
+    if sys.platform == "win32":
+        return path.replace("(", "^(").replace(")", "^)")
+    else:
+        return path
+
+
+@system_path_filter
 def rename(src, dst):
     # On Windows, os.rename will fail if the destination file already exists
     # os.replace is the same as os.rename on POSIX and is MoveFileExW w/

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -191,8 +191,9 @@ def getuid():
     if sys.platform == "win32":
         import ctypes
 
+        # If not admin, use the string name of the login as a unique ID
         if ctypes.windll.shell32.IsUserAnAdmin() == 0:
-            return 1
+            return os.getlogin()
         return 0
     else:
         return os.getuid()

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -187,7 +187,12 @@ def polite_filename(filename: str) -> str:
     return _polite_antipattern().sub("_", filename)
 
 
-def getuid():
+def getuid() -> Union[str, int]:
+    """Returns os getuid on non Windows
+    On Windows returns 0 for admin users, login string otherwise
+    This is in line with behavior from get_owner_uid which
+    always returns the login string on Windows
+    """
     if sys.platform == "win32":
         import ctypes
 
@@ -220,7 +225,7 @@ def msdos_escape_parens(path):
     if sys.platform == "win32":
         return path.replace("(", "^(").replace(")", "^)")
     else:
-        return cmd
+        return path
 
 
 @system_path_filter
@@ -563,7 +568,13 @@ def exploding_archive_handler(tarball_container, stage):
 
 
 @system_path_filter(arg_slice=slice(1))
-def get_owner_uid(path, err_msg=None):
+def get_owner_uid(path, err_msg=None) -> Union[str, int]:
+    """Returns owner UID of path destination
+    On non Windows this is the value of st_uid
+    On Windows this is the login string associated with the
+     owning user.
+
+    """
     if not os.path.exists(path):
         mkdirp(path, mode=stat.S_IRWXU)
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -220,7 +220,7 @@ def msdos_escape_parens(path):
     if sys.platform == "win32":
         return path.replace("(", "^(").replace(")", "^)")
     else:
-        return path
+        return cmd
 
 
 @system_path_filter

--- a/lib/spack/spack/build_systems/nmake.py
+++ b/lib/spack/spack/build_systems/nmake.py
@@ -145,7 +145,7 @@ class NMakeBuilder(BaseBuilder):
         opts += self.nmake_install_args()
         if self.makefile_name:
             opts.append("/F{}".format(self.makefile_name))
-        opts.append(self.define("PREFIX", prefix))
+        opts.append(self.define("PREFIX", fs.windows_sfn(prefix)))
         with fs.working_dir(self.build_directory):
             inspect.getmodule(self.pkg).nmake(
                 *opts, *self.install_targets, ignore_quotes=self.ignore_quotes

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -2175,14 +2175,10 @@ class CDashHandler:
 
     def args(self):
         return [
-            "--cdash-upload-url",
-            f'"{self.upload_url}"',
-            "--cdash-build",
-            f'"{self.build_name}"',
-            "--cdash-site",
-            f'"{self.site}"',
-            "--cdash-buildstamp",
-            f'"{self.build_stamp}"',
+            f'--cdash-upload-url="{self.upload_url}"',
+            f'--cdash-build="{self.build_name}"',
+            f'--cdash-site="{self.site}"',
+            f'--cdash-buildstamp="{self.build_stamp}"',
         ]
 
     @property  # type: ignore

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -2176,13 +2176,13 @@ class CDashHandler:
     def args(self):
         return [
             "--cdash-upload-url",
-            self.upload_url,
+            f'"{self.upload_url}"',
             "--cdash-build",
-            self.build_name,
+            f'"{self.build_name}"',
             "--cdash-site",
-            self.site,
+            f'"{self.site}"',
             "--cdash-buildstamp",
-            self.build_stamp,
+            f'"{self.build_stamp}"',
         ]
 
     @property  # type: ignore

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -2175,10 +2175,14 @@ class CDashHandler:
 
     def args(self):
         return [
-            f'--cdash-upload-url="{self.upload_url}"',
-            f'--cdash-build="{self.build_name}"',
-            f'--cdash-site="{self.site}"',
-            f'--cdash-buildstamp="{self.build_stamp}"',
+            "--cdash-upload-url",
+            f'"{self.upload_url}"',
+            "--cdash-build",
+            f'"{self.build_name}"',
+            "--cdash-site",
+            f'"{self.site}"',
+            "--cdash-buildstamp",
+            f'"{self.build_stamp}"',
         ]
 
     @property  # type: ignore

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1478,6 +1478,12 @@ def copy_test_logs_to_artifacts(test_stage, job_test_dir):
     copy_files_to_artifacts(os.path.join(test_stage, "*", "*.txt"), job_test_dir)
 
 
+def win_quote(quote_str: str) -> str:
+    if IS_WINDOWS:
+        quote_str = f'"{quote_str}"'
+    return quote_str
+
+
 def download_and_extract_artifacts(url, work_dir):
     """Look for gitlab artifacts.zip at the given url, and attempt to download
         and extract the contents into the given work_dir
@@ -1942,9 +1948,9 @@ def process_command(name, commands, repro_dir, run=True, exit_on_failure=True):
         # but we need to handle EXEs (git, etc) ourselves
         catch_exe_failure = (
             """
-if ($LASTEXITCODE -ne 0){
-    throw "Command {} has failed"
-}
+if ($LASTEXITCODE -ne 0){{
+    throw 'Command {} has failed'
+}}
 """
             if IS_WINDOWS
             else ""
@@ -2176,13 +2182,13 @@ class CDashHandler:
     def args(self):
         return [
             "--cdash-upload-url",
-            f'"{self.upload_url}"',
+            win_quote(self.upload_url),
             "--cdash-build",
-            f'"{self.build_name}"',
+            win_quote(self.build_name),
             "--cdash-site",
-            f'"{self.site}"',
+            win_quote(self.site),
             "--cdash-buildstamp",
-            f'"{self.build_stamp}"',
+            win_quote(self.build_stamp),
         ]
 
     @property  # type: ignore

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -41,7 +41,7 @@ def deindent(desc):
 
 
 def encode_path(path: str) -> str:
-    return path.encode("unicode-escape".decode())
+    return path.encode("unicode-escape").decode()
 
 
 def setup_parser(subparser):

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -568,13 +568,13 @@ def ci_rebuild(args):
     if not verify_binaries:
         install_args.append("--no-check-signature")
 
-    slash_hash = "/{}".format(job_spec.dag_hash())
+    slash_hash = '"/{}"'.format(job_spec.dag_hash())
 
     # Arguments when installing the root from sources
     root_install_args = install_args + [
         "--keep-stage",
         "--only=package",
-        "--use-buildcache=package:never,dependencies:only",
+        '--use-buildcache="package:never,dependencies:only"',
     ]
     if cdash_handler:
         # Add additional arguments to `spack install` for CDash reporting.

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -569,7 +569,7 @@ def ci_rebuild(args):
     if not verify_binaries:
         install_args.append("--no-check-signature")
 
-    slash_hash = spack_ci.win_quote(job_spec.dag_hash())
+    slash_hash = spack_ci.win_quote("/" + job_spec.dag_hash())
 
     # Arguments when installing the root from sources
     deps_install_args = install_args + ["--only=dependencies"]

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -561,7 +561,7 @@ def ci_rebuild(args):
     if not config["verify_ssl"]:
         spack_cmd.append("-k")
 
-    install_args = []
+    install_args = ['--use-buildcache="package:never,dependencies:only"']
 
     can_verify = spack_ci.can_verify_binaries()
     verify_binaries = can_verify and spack_is_pr_pipeline is False
@@ -571,11 +571,8 @@ def ci_rebuild(args):
     slash_hash = '"/{}"'.format(job_spec.dag_hash())
 
     # Arguments when installing the root from sources
-    root_install_args = install_args + [
-        "--keep-stage",
-        "--only=package",
-        '--use-buildcache="package:never,dependencies:only"',
-    ]
+    deps_install_args = install_args + ["--only=dependencies"]
+    root_install_args = install_args + ["--keep-stage", "--only=package"]
     if cdash_handler:
         # Add additional arguments to `spack install` for CDash reporting.
         root_install_args.extend(cdash_handler.args())
@@ -584,6 +581,7 @@ def ci_rebuild(args):
     commands = [
         # apparently there's a race when spack bootstraps? do it up front once
         [SPACK_COMMAND, "-e", encode_path(env.path), "bootstrap", "now"],
+        spack_cmd + ["install"] + deps_install_args,
         spack_cmd + ["install"] + root_install_args,
     ]
     import pdb; pdb.set_trace()

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -570,9 +570,6 @@ def ci_rebuild(args):
 
     slash_hash = "/{}".format(job_spec.dag_hash())
 
-    # Arguments when installing dependencies from cache
-    deps_install_args = install_args
-
     # Arguments when installing the root from sources
     root_install_args = install_args + [
         "--keep-stage",
@@ -583,9 +580,6 @@ def ci_rebuild(args):
         # Add additional arguments to `spack install` for CDash reporting.
         root_install_args.extend(cdash_handler.args())
     root_install_args.append(slash_hash)
-
-    # ["x", "y"] -> "'x' 'y'"
-    args_to_string = lambda args: " ".join("'{}'".format(arg) for arg in args)
 
     commands = [
         # apparently there's a race when spack bootstraps? do it up front once

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -40,6 +40,10 @@ def deindent(desc):
     return desc.replace("    ", "")
 
 
+def encode_path(path: str) -> str:
+    return path.encode("unicode-escape".decode())
+
+
 def setup_parser(subparser):
     setup_parser.parser = subparser
     subparsers = subparser.add_subparsers(help="CI sub-commands")
@@ -585,7 +589,7 @@ def ci_rebuild(args):
 
     commands = [
         # apparently there's a race when spack bootstraps? do it up front once
-        [SPACK_COMMAND, "-e", env.path, "bootstrap", "now"],
+        [SPACK_COMMAND, "-e", encode_path(env.path), "bootstrap", "now"],
         spack_cmd + ["install"] + root_install_args,
     ]
 

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -576,6 +576,7 @@ def ci_rebuild(args):
     if cdash_handler:
         # Add additional arguments to `spack install` for CDash reporting.
         root_install_args.extend(cdash_handler.args())
+    deps_install_args.append(slash_hash)
     root_install_args.append(slash_hash)
 
     commands = [

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -586,37 +586,6 @@ def ci_rebuild(args):
     commands = [
         # apparently there's a race when spack bootstraps? do it up front once
         [SPACK_COMMAND, "-e", env.path, "bootstrap", "now"],
-        [
-            SPACK_COMMAND,
-            "-e",
-            env.path,
-            "env",
-            "depfile",
-            "-o",
-            "Makefile",
-            "--use-buildcache=package:never,dependencies:only",
-            slash_hash,  # limit to spec we're building
-        ],
-        [
-            # --output-sync requires GNU make 4.x.
-            # Old make errors when you pass it a flag it doesn't recognize,
-            # but it doesn't error or warn when you set unrecognized flags in
-            # this variable.
-            "export",
-            "GNUMAKEFLAGS=--output-sync=recurse",
-        ],
-        [
-            MAKE_COMMAND,
-            "SPACK={}".format(args_to_string(spack_cmd)),
-            "SPACK_COLOR=always",
-            "SPACK_INSTALL_FLAGS={}".format(args_to_string(deps_install_args)),
-            "-j$(nproc)",
-            "install-deps/{}".format(
-                spack.environment.depfile.MakefileSpec(job_spec).safe_format(
-                    "{name}-{version}-{hash}"
-                )
-            ),
-        ],
         spack_cmd + ["install"] + root_install_args,
     ]
 

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -580,7 +580,6 @@ def ci_rebuild(args):
     deps_install_args.append(slash_hash)
     root_install_args.append(slash_hash)
 
-
     commands = [
         # apparently there's a race when spack bootstraps? do it up front once
         [SPACK_COMMAND, "-e", unicode_escape(env.path), "bootstrap", "now"],

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -585,7 +585,6 @@ def ci_rebuild(args):
         spack_cmd + ["install"] + deps_install_args,
         spack_cmd + ["install"] + root_install_args,
     ]
-    import pdb; pdb.set_trace()
     tty.debug("Installing {0} from source".format(job_spec.name))
     install_exit_code = spack_ci.process_command("install", commands, repro_dir)
 

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -586,7 +586,7 @@ def ci_rebuild(args):
         [SPACK_COMMAND, "-e", encode_path(env.path), "bootstrap", "now"],
         spack_cmd + ["install"] + root_install_args,
     ]
-
+    import pdb; pdb.set_trace()
     tty.debug("Installing {0} from source".format(job_spec.name))
     install_exit_code = spack_ci.process_command("install", commands, repro_dir)
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2734,7 +2734,7 @@ class EnvironmentManifestFile(collections.abc.Mapping):
             if spack.util.url.validate_scheme(config_path):
                 include_url = urllib.parse.urlparse(config_path)
                 # Transform file:// URLs to direct includes.
-                if include_url.scheme in ("file"):
+                if include_url.scheme == "file":
                     config_path = urllib.request.url2pathname(include_url.path)
 
                 # Any other URL should be fetched.

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2729,7 +2729,7 @@ class EnvironmentManifestFile(collections.abc.Mapping):
             # allow paths to contain spack config/environment variables, etc.
             config_path = substitute_path_variables(config_path)
 
-            # If scheme is not valid, config_path is not a known url
+            # If scheme is not valid, config_path is not a url
             # of a type Spack is generally aware
             if spack.util.url.validate_scheme(config_path):
                 include_url = urllib.parse.urlparse(config_path)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2731,8 +2731,8 @@ class EnvironmentManifestFile(collections.abc.Mapping):
 
             include_url = urllib.parse.urlparse(config_path)
 
-            # Transform file:// or C:// URLs to direct includes.
-            if include_url.scheme in ("file", "c"):
+            # Transform file:// URLs to direct includes.
+            if include_url.scheme in ("file"):
                 config_path = urllib.request.url2pathname(include_url.path)
 
             # Any other URL should be fetched.

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2731,8 +2731,8 @@ class EnvironmentManifestFile(collections.abc.Mapping):
 
             include_url = urllib.parse.urlparse(config_path)
 
-            # Transform file:// URLs to direct includes.
-            if include_url.scheme == "file":
+            # Transform file:// or C:// URLs to direct includes.
+            if include_url.scheme in ("file", "c"):
                 config_path = urllib.request.url2pathname(include_url.path)
 
             # Any other URL should be fetched.

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2729,53 +2729,55 @@ class EnvironmentManifestFile(collections.abc.Mapping):
             # allow paths to contain spack config/environment variables, etc.
             config_path = substitute_path_variables(config_path)
 
-            include_url = urllib.parse.urlparse(config_path)
+            # If scheme is not valid, config_path is not a known url
+            # of a type Spack is generally aware
+            if spack.util.url.validate_scheme(config_path):
+                include_url = urllib.parse.urlparse(config_path)
+                # Transform file:// URLs to direct includes.
+                if include_url.scheme in ("file"):
+                    config_path = urllib.request.url2pathname(include_url.path)
 
-            # Transform file:// URLs to direct includes.
-            if include_url.scheme in ("file"):
-                config_path = urllib.request.url2pathname(include_url.path)
-
-            # Any other URL should be fetched.
-            elif include_url.scheme in ("http", "https", "ftp"):
-                # Stage any remote configuration file(s)
-                staged_configs = (
-                    os.listdir(self.config_stage_dir)
-                    if os.path.exists(self.config_stage_dir)
-                    else []
-                )
-                remote_path = urllib.request.url2pathname(include_url.path)
-                basename = os.path.basename(remote_path)
-                if basename in staged_configs:
-                    # Do NOT re-stage configuration files over existing
-                    # ones with the same name since there is a risk of
-                    # losing changes (e.g., from 'spack config update').
-                    tty.warn(
-                        "Will not re-stage configuration from {0} to avoid "
-                        "losing changes to the already staged file of the "
-                        "same name.".format(remote_path)
+                # Any other URL should be fetched.
+                elif include_url.scheme in ("http", "https", "ftp"):
+                    # Stage any remote configuration file(s)
+                    staged_configs = (
+                        os.listdir(self.config_stage_dir)
+                        if os.path.exists(self.config_stage_dir)
+                        else []
                     )
-
-                    # Recognize the configuration stage directory
-                    # is flattened to ensure a single copy of each
-                    # configuration file.
-                    config_path = self.config_stage_dir
-                    if basename.endswith(".yaml"):
-                        config_path = os.path.join(config_path, basename)
-                else:
-                    staged_path = spack.config.fetch_remote_configs(
-                        config_path, str(self.config_stage_dir), skip_existing=True
-                    )
-                    if not staged_path:
-                        raise SpackEnvironmentError(
-                            "Unable to fetch remote configuration {0}".format(config_path)
+                    remote_path = urllib.request.url2pathname(include_url.path)
+                    basename = os.path.basename(remote_path)
+                    if basename in staged_configs:
+                        # Do NOT re-stage configuration files over existing
+                        # ones with the same name since there is a risk of
+                        # losing changes (e.g., from 'spack config update').
+                        tty.warn(
+                            "Will not re-stage configuration from {0} to avoid "
+                            "losing changes to the already staged file of the "
+                            "same name.".format(remote_path)
                         )
-                    config_path = staged_path
 
-            elif include_url.scheme:
-                raise ValueError(
-                    f"Unsupported URL scheme ({include_url.scheme}) for "
-                    f"environment include: {config_path}"
-                )
+                        # Recognize the configuration stage directory
+                        # is flattened to ensure a single copy of each
+                        # configuration file.
+                        config_path = self.config_stage_dir
+                        if basename.endswith(".yaml"):
+                            config_path = os.path.join(config_path, basename)
+                    else:
+                        staged_path = spack.config.fetch_remote_configs(
+                            config_path, str(self.config_stage_dir), skip_existing=True
+                        )
+                        if not staged_path:
+                            raise SpackEnvironmentError(
+                                "Unable to fetch remote configuration {0}".format(config_path)
+                            )
+                        config_path = staged_path
+
+                elif include_url.scheme:
+                    raise ValueError(
+                        f"Unsupported URL scheme ({include_url.scheme}) for "
+                        f"environment include: {config_path}"
+                    )
 
             # treat relative paths as relative to the environment
             if not os.path.isabs(config_path):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2728,11 +2728,11 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         for i, config_path in enumerate(reversed(includes)):
             # allow paths to contain spack config/environment variables, etc.
             config_path = substitute_path_variables(config_path)
+            include_url = urllib.parse.urlparse(config_path)
 
             # If scheme is not valid, config_path is not a url
             # of a type Spack is generally aware
-            if spack.util.url.validate_scheme(config_path):
-                include_url = urllib.parse.urlparse(config_path)
+            if spack.util.url.validate_scheme(include_url.scheme):
                 # Transform file:// URLs to direct includes.
                 if include_url.scheme == "file":
                     config_path = urllib.request.url2pathname(include_url.path)

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -760,7 +760,6 @@ def test_ci_rebuild_mock_success(
     rebuild_env = create_rebuild_env(tmpdir, pkg_name, broken_tests)
 
     monkeypatch.setattr(spack.cmd.ci, "SPACK_COMMAND", "echo")
-    monkeypatch.setattr(spack.cmd.ci, "MAKE_COMMAND", "echo")
 
     with rebuild_env.env_dir.as_cwd():
         activate_rebuild_env(tmpdir, pkg_name, rebuild_env)
@@ -843,7 +842,6 @@ def test_ci_rebuild(
         ci_cmd("rebuild", "--tests", fail_on_error=False)
 
     monkeypatch.setattr(spack.cmd.ci, "SPACK_COMMAND", "notcommand")
-    monkeypatch.setattr(spack.cmd.ci, "MAKE_COMMAND", "notcommand")
     monkeypatch.setattr(spack.cmd.ci, "INSTALL_FAIL_CODE", 127)
 
     with rebuild_env.env_dir.as_cwd():

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -8,6 +8,7 @@ import functools
 import os
 import re
 
+import llnl.util.filesystem
 import spack.error
 import spack.paths
 import spack.util.executable
@@ -385,7 +386,7 @@ def _socket_dir(gpgconf):
                 os.mkdir(var_run_user)
                 os.chmod(var_run_user, 0o777)
 
-            user_dir = os.path.join(var_run_user, str(os.getuid()))
+            user_dir = os.path.join(var_run_user, str(llnl.util.filesystem.getuid()))
 
             if not os.path.exists(user_dir):
                 os.mkdir(user_dir)

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -9,6 +9,7 @@ import os
 import re
 
 import llnl.util.filesystem
+
 import spack.error
 import spack.paths
 import spack.util.executable

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -88,6 +88,8 @@ def is_path_instead_of_url(path_or_url):
         if "bad path" in str(e).lower():
             # possibly a valid url
             is_path = False
+        else:
+            raise
     return is_path
 
 

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -76,21 +76,7 @@ def is_path_instead_of_url(path_or_url):
     """Historically some config files and spack commands used paths
     where urls should be used. This utility can be used to validate
     and promote paths to urls."""
-    # directly parsing the scheme requires us to know all valid schemes
-    # and to string parse a potential windows drive prefix
-    # instead try to interpret path_or_url as a path
-    # if urllib is unable to interpret the string as a path, assume its
-    # a url
-    is_path = True
-    try:
-        urllib.request.pathname2url(path_or_url)
-    except OSError as e:
-        if "bad path" in str(e).lower():
-            # possibly a valid url
-            is_path = False
-        else:
-            raise
-    return is_path
+    return not validate_scheme(urllib.parse.urlparse(path_or_url).scheme)
 
 
 def format(parsed_url):

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -83,7 +83,7 @@ def is_path_instead_of_url(path_or_url):
         return not scheme
 
     # On Windows, we may have drive letters.
-    return "A" <= scheme <= "Z"
+    return "A" <= scheme.capitalize() <= "Z"
 
 
 def format(parsed_url):

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -8,6 +8,8 @@ import spack.builder
 from spack.build_systems import autotools, nmake
 from spack.package import *
 
+import llnl.util.filesystem as fs
+
 
 class Libxml2(AutotoolsPackage, NMakePackage):
     """Libxml2 is the XML C parser and toolkit developed for the Gnome
@@ -244,19 +246,19 @@ class NMakeBuilder(BaseBuilder, nmake.NMakeBuilder):
 
     @property
     def build_directory(self):
-        return os.path.join(self.stage.source_path, "win32")
+        return fs.windows_sfn(os.path.join(self.stage.source_path, "win32"))
 
     def configure(self, pkg, spec, prefix):
         with working_dir(self.build_directory):
             opts = [
-                "prefix=%s" % prefix,
+                "prefix=%s" % fs.windows_sfn(prefix),
                 "compiler=msvc",
                 "iconv=no",
                 "zlib=yes",
                 "lzma=yes",
-                "lib=%s" % ";".join((spec["zlib-api"].prefix.lib, spec["xz"].prefix.lib)),
+                "lib=%s" % ";".join((fs.windows_sfn(spec["zlib-api"].prefix.lib), fs.windows_sfn(spec["xz"].prefix.lib))),
                 "include=%s"
-                % ";".join((spec["zlib-api"].prefix.include, spec["xz"].prefix.include)),
+                % ";".join((fs.windows_sfn(spec["zlib-api"].prefix.include), fs.windows_sfn(spec["xz"].prefix.include))),
             ]
             if "+python" in spec:
                 opts.append("python=yes")

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -4,11 +4,11 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 
+import llnl.util.filesystem as fs
+
 import spack.builder
 from spack.build_systems import autotools, nmake
 from spack.package import *
-
-import llnl.util.filesystem as fs
 
 
 class Libxml2(AutotoolsPackage, NMakePackage):
@@ -256,9 +256,20 @@ class NMakeBuilder(BaseBuilder, nmake.NMakeBuilder):
                 "iconv=no",
                 "zlib=yes",
                 "lzma=yes",
-                "lib=%s" % ";".join((fs.windows_sfn(spec["zlib-api"].prefix.lib), fs.windows_sfn(spec["xz"].prefix.lib))),
+                "lib=%s"
+                % ";".join(
+                    (
+                        fs.windows_sfn(spec["zlib-api"].prefix.lib),
+                        fs.windows_sfn(spec["xz"].prefix.lib),
+                    )
+                ),
                 "include=%s"
-                % ";".join((fs.windows_sfn(spec["zlib-api"].prefix.include), fs.windows_sfn(spec["xz"].prefix.include))),
+                % ";".join(
+                    (
+                        fs.windows_sfn(spec["zlib-api"].prefix.include),
+                        fs.windows_sfn(spec["xz"].prefix.include),
+                    )
+                ),
             ]
             if "+python" in spec:
                 opts.append("python=yes")

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -837,7 +837,6 @@ class Python(Package):
             else:
                 path = os.path.join(self.prefix, "python{0}.exe".format(ver))
             if os.path.exists(path):
-                path = f"""\"{path}\""""
                 return Executable(path)
 
         else:

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -837,6 +837,7 @@ class Python(Package):
             else:
                 path = os.path.join(self.prefix, "python{0}.exe".format(ver))
             if os.path.exists(path):
+                path = f"""\"{path}\""""
                 return Executable(path)
 
         else:


### PR DESCRIPTION
Adds non-config changes required to run Spack's Gitlab CI workflow with Windows runners. 

Adds generally improved support for escaping Windows escape characters
Adds improved handling of Windows paths and quoting in commands executed by CI
Adds general improvements to the cmd/ci module to support Windows paths and escaping.
Refactors Spack's gpg module to use the filesystem module's `getuid`.
Misc SFN changes not covered by the original SFN PR.