### PR TITLE
Spec.satisfies: fix a bug with concrete spec from JSON

### DIFF
--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2448,6 +2448,20 @@ class TestConcretize:
         s = Spec("a %gcc@=13.2.0").concretized()
         assert s.satisfies("%gcc@13.2.0")
 
+    @pytest.mark.regression("43267")
+    def test_spec_with_build_dep_from_json(self, tmp_path):
+        """Tests that we can correctly concretize a spec, when we express its dependency as a
+        concrete spec to be read from JSON.
+
+        The bug was triggered by missing virtuals on edges that were trimmed from pure build
+        dependencies.
+        """
+        build_dep = Spec("dttop").concretized()
+        json_file = tmp_path / "build.json"
+        json_file.write_text(build_dep.to_json())
+        s = Spec(f"dtuse ^{str(json_file)}").concretized()
+        assert s["dttop"].dag_hash() == build_dep.dag_hash()
+
 
 @pytest.fixture()
 def duplicates_test_repository():

--- a/var/spack/repos/builtin.mock/packages/dtbuild1/package.py
+++ b/var/spack/repos/builtin.mock/packages/dtbuild1/package.py
@@ -16,6 +16,6 @@ class Dtbuild1(Package):
     version("1.0", md5="0123456789abcdef0123456789abcdef")
     version("0.5", md5="fedcba9876543210fedcba9876543210")
 
-    depends_on("dtbuild2", type="build")
+    depends_on("vdtbuild2", type="build")
     depends_on("dtlink2")
     depends_on("dtrun2", type="run")

--- a/var/spack/repos/builtin.mock/packages/dtbuild2/package.py
+++ b/var/spack/repos/builtin.mock/packages/dtbuild2/package.py
@@ -13,3 +13,5 @@ class Dtbuild2(Package):
     url = "http://www.example.com/dtbuild2-1.0.tar.gz"
 
     version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    provides("vdtbuild2")


### PR DESCRIPTION
fixes #43267

Fix a bug triggered by missing a virtual on some transitive edge, in a subdag of a pure build dependency.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
