### PR TITLE
globalarrays: add missing dependencies for armci=ofi/openib

### DIFF
--- a/var/spack/repos/builtin/packages/globalarrays/package.py
+++ b/var/spack/repos/builtin/packages/globalarrays/package.py
@@ -47,6 +47,9 @@ class Globalarrays(AutotoolsPackage):
     depends_on("blas")
     depends_on("lapack")
 
+    depends_on("libfabric", when="armci=ofi")
+    depends_on("rdma-core", when="armci=openib")
+
     depends_on("scalapack", when="+scalapack")
 
     # See release https://github.com/GlobalArrays/ga/releases/tag/v5.7.1


### PR DESCRIPTION
`armci=openib` uses IB verbs and `armci=ofi` uses libfabric, both of which are missing as dependencies atm.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
