### PR TITLE
r: Add version 4.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -16,12 +16,13 @@ class R(AutotoolsPackage):
     Please consult the R project homepage for further information."""
 
     homepage = "https://www.r-project.org"
-    url = "https://cloud.r-project.org/src/base/R-3/R-3.4.3.tar.gz"
+    url = "https://cloud.r-project.org/src/base/R-4/R-4.4.0.tar.gz"
 
     extendable = True
 
     license("GPL-2.0-or-later")
 
+    version("4.4.0", sha256="ace4125f9b976d2c53bcc5fca30c75e30d4edc401584859cbadb080e72b5f030")
     version("4.3.2", sha256="b3f5760ac2eee8026a3f0eefcb25b47723d978038eee8e844762094c860c452a")
     version("4.3.1", sha256="8dd0bf24f1023c6f618c3b317383d291b4a494f40d73b983ac22ffea99e4ba99")
     version("4.3.0", sha256="45dcc48b6cf27d361020f77fde1a39209e997b81402b3663ca1c010056a6a609")


### PR DESCRIPTION
This adds the checksum for v4.4.0 to the R package.

Version 4.4.0 is supposed to address CVE-2024-27322 (arbitrary code execution during deserialization of .rds and .rdx files).  More details available at:
* https://support.posit.co/hc/en-us/articles/23170092899607-CVE-2024-27322-R-bitrary-Code-Execution
* https://kb.cert.org/vuls/id/238194

I also bumped the `url` so that `spack checksum` can work with recent versions.  (Should it be reported as a Spack bug that `spack checksum` doesn't appear to make use of the `url_for_version` method?)

This updated R package was tested on a Centos7 box.

cc: @hartzell 