### PR TITLE
docs: re-enable google analytics

### DIFF
--- a/lib/spack/docs/_templates/layout.html
+++ b/lib/spack/docs/_templates/layout.html
@@ -1,0 +1,12 @@
+{% extends "!layout.html" %}
+
+{%- block extrahead %} 
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-S0PQ7WV75K"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-S0PQ7WV75K');
+  </script>
+{% endblock %}


### PR DESCRIPTION
We recently switched to using the new ReadTheDocs with "addons". That includes its own analytics, which is nice, but we also want to continue using our GA4 analytics.

Adding GA4 is no longer supported by RTD, so we have to add it manually.

- [x] re-add the gtag to all pages, manually

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
