### PR TITLE
hpcg: adding clang compiler checks which behaves exactly like aocc

### DIFF
--- a/var/spack/repos/builtin/packages/hpcg/package.py
+++ b/var/spack/repos/builtin/packages/hpcg/package.py
@@ -48,6 +48,11 @@ class Hpcg(AutotoolsPackage):
         sha256="722c13837b287e979442f8372274aa5910a290aa39f1ed1ff646116be08dcae9",
         when="%intel",
     )
+    patch(
+        "https://github.com/hpcg-benchmark/hpcg/commit/e9e0b7e6cae23e1f30dd983c2ce2d3bd34d56f75.patch?full_index=1",
+        sha256="722c13837b287e979442f8372274aa5910a290aa39f1ed1ff646116be08dcae9",
+        when="%clang",
+    )
 
     depends_on("mpi@1.1:")
 
@@ -62,6 +67,7 @@ class Hpcg(AutotoolsPackage):
             and not spec.satisfies("%arm")
             and not spec.satisfies("%intel")
             and not spec.satisfies("%oneapi")
+            and not spec.satisfies("%clang")
         ):
             CXXFLAGS += " -ftree-vectorizer-verbose=0 "
         if spec.satisfies("%cce"):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
