### PR TITLE
Warn users of the future removal of platform=cray

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -571,6 +571,13 @@ def setup_main_options(args):
     # Assign a custom function to show warnings
     warnings.showwarning = send_warning_to_tty
 
+    if spack.platforms.host().name == "cray":
+        msg = (
+            "The Cray platform, i.e. 'platform=cray', will be removed in Spack v0.23. "
+            "All Cray machines will be then detected as 'platform=linux'."
+        )
+        warnings.warn(msg)
+
     # Set up environment based on args.
     tty.set_verbose(args.verbose)
     tty.set_debug(args.debug)

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -571,13 +571,6 @@ def setup_main_options(args):
     # Assign a custom function to show warnings
     warnings.showwarning = send_warning_to_tty
 
-    if spack.platforms.host().name == "cray":
-        msg = (
-            "The Cray platform, i.e. 'platform=cray', will be removed in Spack v0.23. "
-            "All Cray machines will be then detected as 'platform=linux'."
-        )
-        warnings.warn(msg)
-
     # Set up environment based on args.
     tty.set_verbose(args.verbose)
     tty.set_debug(args.debug)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3763,6 +3763,12 @@ class Solver:
     def __init__(self):
         self.driver = PyclingoDriver()
         self.selector = ReusableSpecsSelector(configuration=spack.config.CONFIG)
+        if spack.platforms.host().name != "cray":
+            msg = (
+                "The Cray platform, i.e. 'platform=cray', will be removed in Spack v0.23. "
+                "All Cray machines will be then detected as 'platform=linux'."
+            )
+            warnings.warn(msg)
 
     @staticmethod
     def _check_input_and_extract_concrete_specs(specs):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3763,7 +3763,7 @@ class Solver:
     def __init__(self):
         self.driver = PyclingoDriver()
         self.selector = ReusableSpecsSelector(configuration=spack.config.CONFIG)
-        if spack.platforms.host().name != "cray":
+        if spack.platforms.host().name == "cray":
             msg = (
                 "The Cray platform, i.e. 'platform=cray', will be removed in Spack v0.23. "
                 "All Cray machines will be then detected as 'platform=linux'."


### PR DESCRIPTION
In Spack, `platform=cray` denotes Cray machines using modules from the Cray PE. These platforms are outdated, and new Cray machines are supported by:
```console
$ spack external read-cray-manifest
```
and will be detected as `platform=linux`.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
