### PR TITLE
Make runtimes depend on libc only on linux

### DIFF
--- a/var/spack/repos/builtin/packages/gcc-runtime/package.py
+++ b/var/spack/repos/builtin/packages/gcc-runtime/package.py
@@ -53,7 +53,7 @@ class GccRuntime(Package):
     provides("libgfortran@4", when="%gcc@7")
     provides("libgfortran@5", when="%gcc@8:")
 
-    depends_on("libc", type="link")
+    depends_on("libc", type="link", when="platform=linux")
 
     def install(self, spec, prefix):
         if spec.platform in ["linux", "cray", "freebsd"]:

--- a/var/spack/repos/builtin/packages/gcc-runtime/package.py
+++ b/var/spack/repos/builtin/packages/gcc-runtime/package.py
@@ -54,6 +54,7 @@ class GccRuntime(Package):
     provides("libgfortran@5", when="%gcc@8:")
 
     depends_on("libc", type="link", when="platform=linux")
+    depends_on("libc", type="link", when="platform=cray")
 
     def install(self, spec, prefix):
         if spec.platform in ["linux", "cray", "freebsd"]:

--- a/var/spack/repos/builtin/packages/intel-oneapi-runtime/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-runtime/package.py
@@ -45,7 +45,7 @@ class IntelOneapiRuntime(Package):
     conflicts("platform=windows", msg="IntelOneAPI can only be installed on Linux, and FreeBSD")
     conflicts("platform=darwin", msg="IntelOneAPI can only be installed on Linux, and FreeBSD")
 
-    depends_on("libc", type="link")
+    depends_on("libc", type="link", when="platform=linux")
 
     def install(self, spec, prefix):
         libraries = get_elf_libraries(compiler=self.compiler, libraries=self.LIBRARIES)

--- a/var/spack/repos/builtin/packages/intel-oneapi-runtime/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-runtime/package.py
@@ -46,6 +46,7 @@ class IntelOneapiRuntime(Package):
     conflicts("platform=darwin", msg="IntelOneAPI can only be installed on Linux, and FreeBSD")
 
     depends_on("libc", type="link", when="platform=linux")
+    depends_on("libc", type="link", when="platform=cray")
 
     def install(self, spec, prefix):
         libraries = get_elf_libraries(compiler=self.compiler, libraries=self.LIBRARIES)


### PR DESCRIPTION
fixes #43963

At the moment we don't model `libSystem` (or whatever is the libc on macOS).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
