### PR TITLE
darshan-runtime,darshan-util,py-darshan: add darshan-3.4.5 packages

### DIFF
--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -16,7 +16,7 @@ class DarshanRuntime(AutotoolsPackage):
     systems where you intend to instrument MPI applications."""
 
     homepage = "https://www.mcs.anl.gov/research/projects/darshan/"
-    url = "https://ftp.mcs.anl.gov/pub/darshan/releases/darshan-3.1.0.tar.gz"
+    url = "https://web.cels.anl.gov/projects/darshan/releases/darshan-3.4.0.tar.gz"
     git = "https://github.com/darshan-hpc/darshan.git"
 
     maintainers("shanedsnyder", "carns")
@@ -25,6 +25,7 @@ class DarshanRuntime(AutotoolsPackage):
     test_requires_compiler = True
 
     version("main", branch="main", submodules=True)
+    version("3.4.5", sha256="1c017ac635fab5ee0e87a6b52c5c7273962813569495cb1dd3b7cfa6e19f6ed0")
     version("3.4.4", sha256="d9c9df5aca94dc5ca3d56fd763bec2f74771d35126d61cb897373d2166ccd867")
     version("3.4.3", sha256="dca5f9f9b0ead55a8724b218071ecbb5c4f2ef6027eaade3a6477256930ccc2c")
     version("3.4.2", sha256="b095c3b7c059a8eba4beb03ec092b60708780a3cae3fc830424f6f9ada811c6b")

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -13,7 +13,7 @@ class DarshanUtil(AutotoolsPackage):
     log files produced by Darshan (runtime)."""
 
     homepage = "https://www.mcs.anl.gov/research/projects/darshan/"
-    url = "https://ftp.mcs.anl.gov/pub/darshan/releases/darshan-3.1.0.tar.gz"
+    url = "https://web.cels.anl.gov/projects/darshan/releases/darshan-3.4.0.tar.gz"
     git = "https://github.com/darshan-hpc/darshan.git"
 
     maintainers("shanedsnyder", "carns")
@@ -21,6 +21,7 @@ class DarshanUtil(AutotoolsPackage):
     tags = ["e4s"]
 
     version("main", branch="main", submodules="True")
+    version("3.4.5", sha256="1c017ac635fab5ee0e87a6b52c5c7273962813569495cb1dd3b7cfa6e19f6ed0")
     version("3.4.4", sha256="d9c9df5aca94dc5ca3d56fd763bec2f74771d35126d61cb897373d2166ccd867")
     version("3.4.3", sha256="dca5f9f9b0ead55a8724b218071ecbb5c4f2ef6027eaade3a6477256930ccc2c")
     version("3.4.2", sha256="b095c3b7c059a8eba4beb03ec092b60708780a3cae3fc830424f6f9ada811c6b")

--- a/var/spack/repos/builtin/packages/py-darshan/package.py
+++ b/var/spack/repos/builtin/packages/py-darshan/package.py
@@ -38,6 +38,7 @@ class PyDarshan(PythonPackage):
     depends_on("py-pytest", type="test")
     depends_on("py-packaging", type="test")
     depends_on("py-lxml", type="test")
+    depends_on("py-importlib-resources", when="^python@:3.8", type="test")
 
     # py-darshan depends on specific darshan-util versions corresponding
     # to the first 3 parts of the py-darshan version string

--- a/var/spack/repos/builtin/packages/py-darshan/package.py
+++ b/var/spack/repos/builtin/packages/py-darshan/package.py
@@ -36,6 +36,8 @@ class PyDarshan(PythonPackage):
     depends_on("py-mako", type=("build", "run"))
     depends_on("py-humanize", when="@3.4.3.0:", type=("build", "run"))
     depends_on("py-pytest", type="test")
+    depends_on("py-packaging", type="test")
+    depends_on("py-lxml", type="test")
 
     # py-darshan depends on specific darshan-util versions corresponding
     # to the first 3 parts of the py-darshan version string

--- a/var/spack/repos/builtin/packages/py-darshan/package.py
+++ b/var/spack/repos/builtin/packages/py-darshan/package.py
@@ -22,7 +22,8 @@ class PyDarshan(PythonPackage):
     version("3.4.0.1", sha256="0142fc7c0b12a9e5c22358aa26cca7083d28af42aeea7dfcc5698c56b6aee6b7")
 
     depends_on("python@3.7:", type=("build", "run"))
-    depends_on("py-setuptools@:63", type="build")
+    depends_on("py-setuptools@:63", when="@:3.4.4", type="build")
+    depends_on("py-setuptools@64:", when="@3.4.5:", type="build")
     depends_on("py-pytest-runner", type="build")
     depends_on("py-cffi", type=("build", "run"))
     # NOTE: SciPy is an indirect dependency needed for interpolate usage in pandas

--- a/var/spack/repos/builtin/packages/py-darshan/package.py
+++ b/var/spack/repos/builtin/packages/py-darshan/package.py
@@ -14,6 +14,7 @@ class PyDarshan(PythonPackage):
 
     maintainers("jeanbez", "shanedsnyder")
 
+    version("3.4.5.0", sha256="1419e246b2383d3e71da14942d6579a86fb298bf6dbbc3f507accefa614c6e50")
     version("3.4.4.0", sha256="2d218a1b2a450934698a78148c6603e453c246ec852679432bf217981668e56b")
     version("3.4.3.0", sha256="e0708fc5445f2d491ebd381a253cd67534cef13b963f1d749dd605a10f5c0f8f")
     version("3.4.2.0", sha256="eb00eb758c96899c0d523b71eb00caa3b967509c27fd504c579ac8c9b521845c")


### PR DESCRIPTION
This PR updates Darshan Spack packages (darshan-runtime, darshan-util, py-darshan) for the Darshan 3.4.5 release.

Note that the location of Darshan release tarballs has also been updated.