### PR TITLE
gitlab: release branch pipelines rebuild what changed

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -78,22 +78,12 @@ default:
       when: never
     - if: $SPACK_CI_ENABLE_STACKS =~ /.+/ && $SPACK_CI_STACK_NAME !~ $SPACK_CI_ENABLE_STACKS
       when: never
-    - if: $CI_COMMIT_REF_NAME == "develop"
-      # Pipelines on develop only rebuild what is missing from the mirror
+    - if: $CI_COMMIT_REF_NAME == "develop" || $CI_COMMIT_REF_NAME =~ /^releases\/v.*/
+      # Pipelines on develop/release branches only rebuild what is missing from the mirror
       when: always
       variables:
         SPACK_PIPELINE_TYPE: "spack_protected_branch"
         SPACK_COPY_BUILDCACHE: "${PROTECTED_MIRROR_PUSH_DOMAIN}/${CI_COMMIT_REF_NAME}"
-        SPACK_REQUIRE_SIGNING: "True"
-        OIDC_TOKEN_AUDIENCE: "protected_binary_mirror"
-    - if: $CI_COMMIT_REF_NAME =~ /^releases\/v.*/
-      # Pipelines on release branches always rebuild everything
-      when: always
-      variables:
-        SPACK_PIPELINE_TYPE: "spack_protected_branch"
-        SPACK_COPY_BUILDCACHE: "${PROTECTED_MIRROR_PUSH_DOMAIN}/${CI_COMMIT_REF_NAME}"
-        SPACK_PRUNE_UNTOUCHED: "False"
-        SPACK_PRUNE_UP_TO_DATE: "False"
         SPACK_REQUIRE_SIGNING: "True"
         OIDC_TOKEN_AUDIENCE: "protected_binary_mirror"
     - if: $CI_COMMIT_TAG =~ /^develop-[\d]{4}-[\d]{2}-[\d]{2}$/ || $CI_COMMIT_TAG =~ /^v.*/


### PR DESCRIPTION
Change release _branch_ pipeline behavior so that by default we only rebuild the things that changed (which is what we do for pipelines on `develop`).

So the first pipeline on a new release branch will rebuild everything since nothing exists in the new release branch mirror yet.  Subsequent pipelines should only rebuild what changed.  We will soon provide a mechanism to trigger full rebuilds of everything on release branches on demand, but until we have that, we can trigger these manually.  That can already be accomplished in gitlab using the "Run Pipeline" button, and then supplying the branch and two environment variables.  Like this:

![rebuild_everything_release](https://github.com/spack/spack/assets/6527504/f5fa802c-da70-4bd6-8739-1d6a28e7a3da)

