### PR TITLE
fix iconv from libc

### DIFF
--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -6,7 +6,6 @@
 import re
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Bash(AutotoolsPackage, GNUMirrorPackage):
@@ -187,10 +186,10 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
             "--enable-readline",
             "--with-installed-readline",
         ]
-        if spec["iconv"].name == "libc":
+        if spec["iconv"].name == "libiconv":
+            args.append(f"--with-libiconv-prefix={spec['iconv'].prefix}")
+        else:
             args.append("--without-libiconv-prefix")
-        elif not is_system_path(spec["iconv"].prefix):
-            args.append("--with-libiconv-prefix={0}".format(spec["iconv"].prefix))
         return args
 
     def check(self):

--- a/var/spack/repos/builtin/packages/doxygen/package.py
+++ b/var/spack/repos/builtin/packages/doxygen/package.py
@@ -112,7 +112,7 @@ class Doxygen(CMakePackage):
     conflicts("%gcc@7.0:7.9", when="@1.9:")
 
     def patch(self):
-        if self.spec["iconv"].name == "libc":
+        if self.spec["iconv"].name != "libiconv":
             return
         # On Linux systems, iconv is provided by libc. Since CMake finds the
         # symbol in libc, it does not look for libiconv, which leads to linker

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -128,10 +128,10 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
             args.append("--with-zstd=%s" % spec["zstd"].prefix)
 
         if spec.satisfies("@0.183:"):
-            if spec["iconv"].name == "libc":
+            if spec["iconv"].name == "libiconv":
+                args.append(f"--with-libiconv-prefix={spec['iconv'].prefix}")
+            else:
                 args.append("--without-libiconv-prefix")
-            elif not is_system_path(spec["iconv"].prefix):
-                args.append("--with-libiconv-prefix=" + format(spec["iconv"].prefix))
 
         if "+nls" in spec:
             # Prior to 0.183, only msgfmt is used from gettext.

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -9,7 +9,7 @@ import sys
 from spack.build_systems.autotools import AutotoolsBuilder
 from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
-from spack.util.environment import filter_system_paths, is_system_path
+from spack.util.environment import filter_system_paths
 
 
 class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
@@ -718,10 +718,10 @@ class AutotoolsBuilder(AutotoolsBuilder):
             self.with_or_without("php"),
         ]
         if "+iconv" in self.spec:
-            if self.spec["iconv"].name == "libc":
+            if self.spec["iconv"].name == "libiconv":
+                args.append(f"--with-libiconv-prefix={self.spec['iconv'].prefix}")
+            else:
                 args.append("--without-libiconv-prefix")
-            elif not is_system_path(self.spec["iconv"].prefix):
-                args.append("--with-libiconv-prefix=" + self.spec["iconv"].prefix)
 
         # Renamed or modified flags
         if self.spec.satisfies("@3:"):
@@ -755,7 +755,7 @@ class AutotoolsBuilder(AutotoolsBuilder):
 
         if "+hdf4" in self.spec:
             hdf4 = self.spec["hdf"]
-            if "+external-xdr" in hdf4 and hdf4["rpc"].name != "libc":
+            if "+external-xdr" in hdf4 and hdf4["rpc"].name == "libtirpc":
                 args.append("LIBS=" + hdf4["rpc"].libs.link_flags)
 
         # Remove empty strings

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -6,7 +6,6 @@
 import re
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Gettext(AutotoolsPackage, GNUMirrorPackage):
@@ -114,10 +113,10 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
 
         config_args.extend(self.enable_or_disable("shared"))
 
-        if self.spec["iconv"].name == "libc":
+        if self.spec["iconv"].name == "libiconv":
+            config_args.append(f"--with-libiconv-prefix={self.spec['iconv'].prefix}")
+        else:
             config_args.append("--without-libiconv-prefix")
-        elif not is_system_path(self.spec["iconv"].prefix):
-            config_args.append("--with-libiconv-prefix=" + self.spec["iconv"].prefix)
 
         if "+curses" in spec:
             config_args.append("--with-ncurses-prefix={0}".format(spec["ncurses"].prefix))

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -278,12 +278,8 @@ class Git(AutotoolsPackage):
             "--with-zlib={0}".format(spec["zlib-api"].prefix),
         ]
 
-        if not self.spec["iconv"].name == "libc":
-            configure_args.append(
-                "--with-iconv={0}".format(
-                    "yes" if is_system_path(spec["iconv"].prefix) else spec["iconv"].prefix
-                )
-            )
+        if self.spec["iconv"].name == "libiconv":
+            configure_args.append(f"--with-iconv={self.spec['iconv'].prefix}")
 
         if "+perl" in self.spec:
             configure_args.append("--with-perl={0}".format(spec["perl"].command.path))

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -339,9 +339,9 @@ class AutotoolsBuilder(BaseBuilder, spack.build_systems.autotools.AutotoolsBuild
                 "--with-python={0}".format(os.path.basename(self.spec["python"].command.path))
             )
         if self.spec["iconv"].name == "libiconv":
-            args.append("--with-libiconv=maybe")
-        else:
             args.append("--with-libiconv=gnu")
+        else:
+            args.append("--with-libiconv=maybe")
         if self.spec.satisfies("@2.56:"):
             for value in ("dtrace", "systemtap"):
                 if ("tracing=" + value) in self.spec:

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -317,13 +317,13 @@ class MesonBuilder(BaseBuilder, spack.build_systems.meson.MesonBuilder):
         if self.spec.satisfies("@:2.72"):
             args.append("-Dgettext=external")
         if self.spec.satisfies("@:2.74"):
-            if self.spec["iconv"].name == "libc":
-                args.append("-Diconv=libc")
-            else:
+            if self.spec["iconv"].name == "libiconv":
                 if self.spec.satisfies("@2.61.0:"):
                     args.append("-Diconv=external")
                 else:
                     args.append("-Diconv=gnu")
+            else:
+                args.append("-Diconv=libc")
         return args
 
 
@@ -338,7 +338,7 @@ class AutotoolsBuilder(BaseBuilder, spack.build_systems.autotools.AutotoolsBuild
             args.append(
                 "--with-python={0}".format(os.path.basename(self.spec["python"].command.path))
             )
-        if self.spec["iconv"].name == "libc":
+        if self.spec["iconv"].name == "libiconv":
             args.append("--with-libiconv=maybe")
         else:
             args.append("--with-libiconv=gnu")

--- a/var/spack/repos/builtin/packages/glibc/package.py
+++ b/var/spack/repos/builtin/packages/glibc/package.py
@@ -207,3 +207,7 @@ class Glibc(AutotoolsPackage, GNUMirrorPackage):
     @property
     def libs(self):
         return LibraryList([])
+
+    @property
+    def headers(self):
+        return HeaderList([])

--- a/var/spack/repos/builtin/packages/gnupg/package.py
+++ b/var/spack/repos/builtin/packages/gnupg/package.py
@@ -6,7 +6,6 @@
 import re
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Gnupg(AutotoolsPackage):
@@ -95,10 +94,10 @@ class Gnupg(AutotoolsPackage):
                     f"--with-npth-prefix={self.spec['npth'].prefix}",
                 ]
             )
-            if self.spec["iconv"].name == "libc":
-                args.append("--without-libiconv-prefix")
-            elif not is_system_path(self.spec["iconv"].prefix):
+            if self.spec["iconv"].name == "libiconv":
                 args.append(f"--with-libiconv-prefix={self.spec['iconv'].prefix}")
+            else:
+                args.append("--without-libiconv-prefix")
 
         if self.spec.satisfies("@:1"):
             args.extend(

--- a/var/spack/repos/builtin/packages/groff/package.py
+++ b/var/spack/repos/builtin/packages/groff/package.py
@@ -6,7 +6,6 @@
 import re
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Groff(AutotoolsPackage, GNUMirrorPackage):
@@ -80,10 +79,10 @@ class Groff(AutotoolsPackage, GNUMirrorPackage):
         args.extend(self.with_or_without("x"))
         if "@1.22.4:" in self.spec:
             args.extend(self.with_or_without("uchardet"))
-        if self.spec["iconv"].name == "libc":
+        if self.spec["iconv"].name == "libiconv":
+            args.append(f"--with-libiconv-prefix={self.spec['iconv'].prefix}")
+        else:
             args.append("--without-libiconv-prefix")
-        elif not is_system_path(self.spec["iconv"].prefix):
-            args.append("--with-libiconv-prefix={0}".format(self.spec["iconv"].prefix))
         return args
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/hdf-eos2/package.py
+++ b/var/spack/repos/builtin/packages/hdf-eos2/package.py
@@ -130,8 +130,8 @@ class HdfEos2(AutotoolsPackage):
         # Add flags to LDFLAGS for any dependencies that need it
         extra_ldflags = []
         # hdf might have link dependency on rpc, if so need to add flags
-        if "rpc" in self.spec:
-            tmp = self.spec["rpc"].libs.ld_flags
+        if self.spec.satisfies("^libtirpc"):
+            tmp = self.spec["libtirpc"].libs.ld_flags
             extra_ldflags.append(tmp)
         # Set LDFLAGS
         env.set("LDFLAGS", " ".join(extra_ldflags))

--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -132,7 +132,7 @@ class Hdf(AutotoolsPackage):
             libs += self.spec["zlib:transitive"].libs
             if "+szip" in self.spec:
                 libs += self.spec["szip:transitive"].libs
-            if "+external-xdr" in self.spec and self.spec["rpc"].name != "libc":
+            if "+external-xdr" in self.spec and self.spec["rpc"].name == "libtirpc":
                 libs += self.spec["rpc:transitive"].libs
 
         return libs
@@ -178,7 +178,7 @@ class Hdf(AutotoolsPackage):
 
         if "~external-xdr" in self.spec:
             config_args.append("--enable-hdf4-xdr")
-        elif self.spec["rpc"].name != "libc":
+        elif self.spec["rpc"].name == "libtirpc":
             # We should not specify '--disable-hdf4-xdr' due to a bug in the
             # configure script.
             config_args.append("LIBS=%s" % self.spec["rpc"].libs.link_flags)

--- a/var/spack/repos/builtin/packages/lftp/package.py
+++ b/var/spack/repos/builtin/packages/lftp/package.py
@@ -37,10 +37,10 @@ class Lftp(AutotoolsPackage):
             "--with-zlib={0}".format(self.spec["zlib-api"].prefix),
             "--disable-dependency-tracking",
         ]
-        if self.spec["iconv"].name == "libc":
-            args.append("--without-libiconv-prefix")
+        if self.spec["iconv"].name == "libiconv":
+            args.append(f"--with-libiconv-prefix={self.spec['iconv'].prefix}")
         elif not is_system_path(self.spec["iconv"].prefix):
-            args.append("--with-libiconv-prefix={0}".format(self.spec["iconv"].prefix))
+            args.append("--without-libiconv-prefix")
         if "intl" not in self.spec["gettext"].libs.names:
             args.append("--without-libintl-prefix")
         elif not is_system_path(self.spec["gettext"].prefix):

--- a/var/spack/repos/builtin/packages/libarchive/package.py
+++ b/var/spack/repos/builtin/packages/libarchive/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Libarchive(AutotoolsPackage):
@@ -132,10 +131,10 @@ class Libarchive(AutotoolsPackage):
         args += self.enable_or_disable("programs")
 
         if "+iconv" in spec:
-            if spec["iconv"].name == "libc":
+            if spec["iconv"].name == "libiconv":
+                args.append(f"--with-libiconv-prefix={spec['iconv'].prefix}")
+            else:
                 args.append("--without-libiconv-prefix")
-            elif not is_system_path(spec["iconv"].prefix):
-                args.append("--with-libiconv-prefix={p}".format(p=spec["iconv"].prefix))
         else:
             args.append("--without-iconv")
 

--- a/var/spack/repos/builtin/packages/mono/package.py
+++ b/var/spack/repos/builtin/packages/mono/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Mono(AutotoolsPackage):
@@ -77,8 +76,8 @@ class Mono(AutotoolsPackage):
 
     def configure_args(self):
         args = []
-        if self.spec["iconv"].name == "libc":
+        if self.spec["iconv"].name == "libiconv":
+            args.append(f"--with-libiconv-prefix={self.spec['iconv'].prefix}")
+        else:
             args.append("--without-libiconv-prefix")
-        elif not is_system_path(self.spec["iconv"].prefix):
-            args.append("--with-libiconv-prefix={p}".format(p=self.spec["iconv"].prefix))
         return args

--- a/var/spack/repos/builtin/packages/musl/package.py
+++ b/var/spack/repos/builtin/packages/musl/package.py
@@ -67,3 +67,11 @@ class Musl(MakefilePackage):
 
     def edit(self, spec, prefix):
         configure(*self.configure_args())
+
+    @property
+    def libs(self):
+        return LibraryList([])
+
+    @property
+    def headers(self):
+        return HeaderList([])

--- a/var/spack/repos/builtin/packages/ncl/package.py
+++ b/var/spack/repos/builtin/packages/ncl/package.py
@@ -236,9 +236,11 @@ class Ncl(Package):
             f.writelines(
                 [
                     "#define HdfDefines\n",
-                    "#define StdDefines -DByteSwapped\n#define ByteSwapped\n"
-                    if self.spec.satisfies("+byteswapped")
-                    else "",
+                    (
+                        "#define StdDefines -DByteSwapped\n#define ByteSwapped\n"
+                        if self.spec.satisfies("+byteswapped")
+                        else ""
+                    ),
                     "#define CppCommand '/usr/bin/env cpp -traditional'\n",
                     "#define CCompiler {0}\n".format(spack_cc),
                     "#define FCompiler {0}\n".format(spack_fc),
@@ -367,7 +369,7 @@ class Ncl(Package):
         with open(config_answers_filename, "r") as f:
             config_script(input=f)
 
-        if self.spec.satisfies("^hdf+external-xdr") and not self.spec["hdf"].satisfies("^libc"):
+        if self.spec.satisfies("^hdf+external-xdr ^libtirpc"):
             hdf4 = self.spec["hdf"]
             replace_str = hdf4["rpc"].libs.link_flags
 

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -460,7 +460,7 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
                 # introduced by the configure script:
                 if "+szip" in hdf:
                     extra_libs.append(hdf["szip"].libs)
-                if "+external-xdr" in hdf:
+                if "+external-xdr ^libtirpc" in hdf:
                     extra_libs.append(hdf["rpc"].libs)
                 extra_libs.append(hdf["zlib-api"].libs)
 

--- a/var/spack/repos/builtin/packages/procps/package.py
+++ b/var/spack/repos/builtin/packages/procps/package.py
@@ -70,9 +70,9 @@ class Procps(AutotoolsPackage):
         else:
             args.append("--disable-nls")
 
-        if spec["iconv"].name == "libc":
+        if spec["iconv"].name == "libiconv":
+            args.append(f"--with-libiconv-prefix={spec['iconv'].prefix}")
+        else:
             args.append("--without-libiconv-prefix")
-        elif not is_system_path(spec["iconv"].prefix):
-            args.append("--with-libiconv-prefix={0}".format(spec["iconv"].prefix))
 
         return args

--- a/var/spack/repos/builtin/packages/tar/package.py
+++ b/var/spack/repos/builtin/packages/tar/package.py
@@ -6,7 +6,6 @@
 import re
 
 from spack.package import *
-from spack.util.environment import is_system_path
 
 
 class Tar(AutotoolsPackage, GNUMirrorPackage):
@@ -74,10 +73,10 @@ class Tar(AutotoolsPackage, GNUMirrorPackage):
             "--with-bzip2={0}".format(spec["bzip2"].prefix.bin.bzip2),
         ]
 
-        if spec["iconv"].name == "libc":
+        if spec["iconv"].name == "libiconv":
+            args.append(f"--with-libiconv-prefix={spec['iconv'].prefix}")
+        else:
             args.append("--without-libiconv-prefix")
-        elif not is_system_path(spec["iconv"].prefix):
-            args.append("--with-libiconv-prefix={0}".format(spec["iconv"].prefix))
 
         if "^zstd" in spec:
             args.append("--with-zstd={0}".format(spec["zstd"].prefix.bin.zstd))


### PR DESCRIPTION
as well as `rpc` in some places.

Previously there was a dummy package `libc` that linux users had to manually mark external, which would provide `iconv` and `rpc`. Now there are externals for `glibc` and `musl` automating that.

Only if iconv is provided by libiconv do we need to pass its prefix to build systems, if it's from libc it's linked automatically by the compiler.

The libc packages no longer provide `rpc` since we have no detection for it. That shouldn't be a problem since it was removed relatively long ago from glibc, and optional before that.
