### PR TITLE
fix package permissions docs link for gaussian packages

### DIFF
--- a/var/spack/repos/builtin/packages/gaussian-src/package.py
+++ b/var/spack/repos/builtin/packages/gaussian-src/package.py
@@ -129,7 +129,7 @@ read through it and then execute it:
 If you have to give others access, please customize the group membership of the package
 files as documented here:
 
-    https://spack.readthedocs.io/en/latest/build_settings.html#package-permissions""".format(
+    https://spack.readthedocs.io/en/latest/packages_yaml.html#package-permissions""".format(
                 perm_script_path
             )
         )

--- a/var/spack/repos/builtin/packages/gaussian-view/package.py
+++ b/var/spack/repos/builtin/packages/gaussian-view/package.py
@@ -102,7 +102,7 @@ read through it and then execute it:
 If you have to give others access, please customize the group membership of the package
 files as documented here:
 
-    https://spack.readthedocs.io/en/latest/build_settings.html#package-permissions""".format(
+    https://spack.readthedocs.io/en/latest/packages_yaml.html#package-permissions""".format(
                 perm_script_path
             )
         )


### PR DESCRIPTION
Package permissions guide instructions have moved to new packages yaml page: https://spack.readthedocs.io/en/latest/packages_yaml.html#package-permissions
