### PR TITLE
Remove Fedora 37 and 38, Ubuntu 18 from CI in v0.22

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -50,8 +50,6 @@ jobs:
                      [almalinux9, 'linux/amd64,linux/arm64,linux/ppc64le', 'almalinux:9'],
                      [rockylinux8, 'linux/amd64,linux/arm64', 'rockylinux:8'],
                      [rockylinux9, 'linux/amd64,linux/arm64', 'rockylinux:9'],
-                     [fedora37, 'linux/amd64,linux/arm64,linux/ppc64le', 'fedora:37'],
-                     [fedora38, 'linux/amd64,linux/arm64,linux/ppc64le', 'fedora:38'],
                      [fedora39, 'linux/amd64,linux/arm64,linux/ppc64le', 'fedora:39'],
                      [fedora40, 'linux/amd64,linux/arm64,linux/ppc64le', 'fedora:40']]
     name: Build ${{ matrix.dockerfile[0] }}

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -194,9 +194,6 @@ The OS that are currently supported are summarized in the table below:
    * - Operating System
      - Base Image
      - Spack Image
-   * - Ubuntu 18.04
-     - ``ubuntu:18.04``
-     - ``spack/ubuntu-bionic``
    * - Ubuntu 20.04
      - ``ubuntu:20.04``
      - ``spack/ubuntu-focal``
@@ -230,12 +227,6 @@ The OS that are currently supported are summarized in the table below:
    * - Rocky Linux 9
      - ``rockylinux:9``
      - ``spack/rockylinux9``
-   * - Fedora Linux 37
-     - ``fedora:37``
-     - ``spack/fedora37``
-   * - Fedora Linux 38
-     - ``fedora:38``
-     - ``spack/fedora38``
    * - Fedora Linux 39
      - ``fedora:39``
      - ``spack/fedora39``

--- a/lib/spack/spack/container/images.json
+++ b/lib/spack/spack/container/images.json
@@ -34,28 +34,6 @@
         "image": "docker.io/fedora:39"
       }
     },
-    "fedora:38": {
-      "bootstrap": {
-        "template": "container/fedora.dockerfile",
-        "image": "docker.io/fedora:38"
-      },
-      "os_package_manager": "dnf",
-      "build": "spack/fedora38",
-      "final": {
-        "image": "docker.io/fedora:38"
-      }
-    },
-    "fedora:37": {
-      "bootstrap": {
-        "template": "container/fedora.dockerfile",
-        "image": "docker.io/fedora:37"
-      },
-      "os_package_manager": "dnf",
-      "build": "spack/fedora37",
-      "final": {
-        "image": "docker.io/fedora:37"
-      }
-    },
     "rockylinux:9": {
       "bootstrap": {
         "template": "container/rockylinux_9.dockerfile",
@@ -158,13 +136,6 @@
       },
       "build": "spack/ubuntu-focal",
       "os_package_manager": "apt"
-    },
-    "ubuntu:18.04": {
-      "bootstrap": {
-        "template": "container/ubuntu_1804.dockerfile"
-      },
-      "os_package_manager": "apt",
-      "build": "spack/ubuntu-bionic"
     }
   },
   "os_package_managers": {

--- a/lib/spack/spack/test/container/cli.py
+++ b/lib/spack/spack/test/container/cli.py
@@ -17,7 +17,7 @@ def test_command(default_config, container_config_dir, capsys):
     with capsys.disabled():
         with fs.working_dir(container_config_dir):
             output = containerize()
-    assert "FROM spack/ubuntu-bionic" in output
+    assert "FROM spack/ubuntu-jammy" in output
 
 
 def test_listing_possible_os():

--- a/lib/spack/spack/test/container/conftest.py
+++ b/lib/spack/spack/test/container/conftest.py
@@ -14,7 +14,7 @@ def minimal_configuration():
             "specs": ["gromacs", "mpich", "fftw precision=float"],
             "container": {
                 "format": "docker",
-                "images": {"os": "ubuntu:18.04", "spack": "develop"},
+                "images": {"os": "ubuntu:22.04", "spack": "develop"},
             },
         }
     }

--- a/lib/spack/spack/test/container/docker.py
+++ b/lib/spack/spack/test/container/docker.py
@@ -21,11 +21,11 @@ def test_build_and_run_images(minimal_configuration):
 
     # Test the output of run property
     run = writer.run
-    assert run.image == "ubuntu:18.04"
+    assert run.image == "ubuntu:22.04"
 
     # Test the output of the build property
     build = writer.build
-    assert build.image == "spack/ubuntu-bionic:develop"
+    assert build.image == "spack/ubuntu-jammy:develop"
 
 
 def test_packages(minimal_configuration):

--- a/lib/spack/spack/test/container/images.py
+++ b/lib/spack/spack/test/container/images.py
@@ -12,8 +12,8 @@ import spack.container
 @pytest.mark.parametrize(
     "image,spack_version,expected",
     [
-        ("ubuntu:18.04", "develop", ("spack/ubuntu-bionic", "develop")),
-        ("ubuntu:18.04", "0.14.0", ("spack/ubuntu-bionic", "0.14.0")),
+        ("ubuntu:22.04", "develop", ("spack/ubuntu-jammy", "develop")),
+        ("ubuntu:22.04", "0.14.0", ("spack/ubuntu-jammy", "0.14.0")),
     ],
 )
 def test_build_info(image, spack_version, expected):
@@ -21,7 +21,7 @@ def test_build_info(image, spack_version, expected):
     assert output == expected
 
 
-@pytest.mark.parametrize("image", ["ubuntu:18.04"])
+@pytest.mark.parametrize("image", ["ubuntu:22.04"])
 def test_package_info(image):
     pkg_manager = spack.container.images.os_package_manager_for(image)
     update, install, clean = spack.container.images.commands_for(pkg_manager)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
