### PR TITLE
pkg-config: support apple-clang@15:

### DIFF
--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -62,7 +62,7 @@ class PkgConfig(AutotoolsPackage):
             # the cycle by using the internal glib.
             config_args.append("--with-internal-glib")
 
-        for strict_compiler in ("%oneapi", "%cce", "%apple-clang@15:", "clang@15:"):
+        for strict_compiler in ("%oneapi", "%cce", "%apple-clang@15:", "%clang@15:"):
             if spec.satisfies(strict_compiler):
                 config_args.append("CFLAGS=-Wno-error=int-conversion")
                 break

--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -65,5 +65,6 @@ class PkgConfig(AutotoolsPackage):
         for strict_compiler in ("%oneapi", "%cce", "%apple-clang@15:", "clang@15:"):
             if spec.satisfies(strict_compiler):
                 config_args.append("CFLAGS=-Wno-error=int-conversion")
+                break
 
         return config_args

--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -53,17 +53,17 @@ class PkgConfig(AutotoolsPackage):
         env.append_path("ACLOCAL_PATH", self.prefix.share.aclocal)
 
     def configure_args(self):
+        spec = self.spec
         config_args = ["--enable-shared"]
 
-        if "+internal_glib" in self.spec:
+        if spec.satisfies("+internal_glib"):
             # There's a bootstrapping problem here;
             # glib uses pkg-config as well, so break
             # the cycle by using the internal glib.
             config_args.append("--with-internal-glib")
 
-        c_name = self.spec.compiler.name
-        if "oneapi" in c_name or "cce" in c_name:
-            # Don't treat int-conversion warning as error with oneapi and cce.
-            config_args.append("CFLAGS=-Wno-error=int-conversion")
+        for strict_compiler in ("%oneapi", "%cce", "%apple-clang@15:"):
+            if spec.satisfies(strict_compiler):
+                config_args.append("CFLAGS=-Wno-error=int-conversion")
 
         return config_args

--- a/var/spack/repos/builtin/packages/pkg-config/package.py
+++ b/var/spack/repos/builtin/packages/pkg-config/package.py
@@ -62,7 +62,7 @@ class PkgConfig(AutotoolsPackage):
             # the cycle by using the internal glib.
             config_args.append("--with-internal-glib")
 
-        for strict_compiler in ("%oneapi", "%cce", "%apple-clang@15:"):
+        for strict_compiler in ("%oneapi", "%cce", "%apple-clang@15:", "clang@15:"):
             if spec.satisfies(strict_compiler):
                 config_args.append("CFLAGS=-Wno-error=int-conversion")
 


### PR DESCRIPTION
Starting with `apple-clang@15:` int conversions are now treated as errors instead of warnings which breaks pkg-config support on MacOS Sonoma.