### PR TITLE
bootstrap: relax dependencies

### DIFF
--- a/lib/spack/spack/bootstrap/__init__.py
+++ b/lib/spack/spack/bootstrap/__init__.py
@@ -5,7 +5,13 @@
 """Function and classes needed to bootstrap Spack itself."""
 
 from .config import ensure_bootstrap_configuration, is_bootstrapping, store_path
-from .core import all_core_root_specs, ensure_core_dependencies, ensure_patchelf_in_path_or_raise
+from .core import (
+    all_core_root_specs,
+    ensure_clingo_importable_or_raise,
+    ensure_core_dependencies,
+    ensure_gpg_in_path_or_raise,
+    ensure_patchelf_in_path_or_raise,
+)
 from .environment import BootstrapEnvironment, ensure_environment_dependencies
 from .status import status_message
 
@@ -13,6 +19,8 @@ __all__ = [
     "is_bootstrapping",
     "ensure_bootstrap_configuration",
     "ensure_core_dependencies",
+    "ensure_gpg_in_path_or_raise",
+    "ensure_clingo_importable_or_raise",
     "ensure_patchelf_in_path_or_raise",
     "all_core_root_specs",
     "ensure_environment_dependencies",

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1415,7 +1415,7 @@ class Environment:
         # Ensure we don't try to bootstrap clingo in parallel
         if spack.config.get("config:concretizer", "clingo") == "clingo":
             with spack.bootstrap.ensure_bootstrap_configuration():
-                spack.bootstrap.ensure_core_dependencies()
+                spack.bootstrap.ensure_clingo_importable_or_raise()
 
         # Ensure all the indexes have been built or updated, since
         # otherwise the processes in the pool may timeout on waiting

--- a/lib/spack/spack/solver/core.py
+++ b/lib/spack/spack/solver/core.py
@@ -195,7 +195,7 @@ def _bootstrap_clingo() -> ModuleType:
     import spack.bootstrap
 
     with spack.bootstrap.ensure_bootstrap_configuration():
-        spack.bootstrap.ensure_core_dependencies()
+        spack.bootstrap.ensure_clingo_importable_or_raise()
         clingo_mod = importlib.import_module("clingo")
 
     return clingo_mod

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -60,7 +60,7 @@ def init(gnupghome=None, force=False):
 
     # Set the executable objects for "gpg" and "gpgconf"
     with spack.bootstrap.ensure_bootstrap_configuration():
-        spack.bootstrap.ensure_core_dependencies()
+        spack.bootstrap.ensure_gpg_in_path_or_raise()
         GPG, GPGCONF = _gpg(), _gpgconf()
 
     GPG.add_default_env("GNUPGHOME", GNUPGHOME)


### PR DESCRIPTION
currently bootstrapping from source fails because clingo requires gnupg
requires clingo.

This PR stops eager bootstrapping. We don't need `patchelf` nor `gnupg`
generally. They're bootstrapped when needed.
