### PR TITLE
orca: recipe rework

### DIFF
--- a/var/spack/repos/builtin/packages/orca/package.py
+++ b/var/spack/repos/builtin/packages/orca/package.py
@@ -18,64 +18,36 @@ class Orca(Package):
     set up a mirror, see https://spack.readthedocs.io/en/latest/mirrors.html"""
 
     homepage = "https://cec.mpg.de"
-    url = "file://{0}/orca_4_0_1_2_linux_x86-64_openmpi202.tar.zst".format(os.getcwd())
     maintainers("snehring")
     manual_download = True
 
     license("LGPL-2.1-or-later")
 
-    version(
-        "5.0.3",
-        sha256="b8b9076d1711150a6d6cb3eb30b18e2782fa847c5a86d8404b9339faef105043",
-        url="file://{0}/orca_5_0_3_linux_x86-64_shared_openmpi411.tar.xz".format(os.getcwd()),
-    )
-    version(
-        "4.2.1",
-        sha256="9bbb3bfdca8220b417ee898b27b2885508d8c82799adfa63dde9e72eab49a6b2",
-        expand=False,
-    )
-    version(
-        "4.2.0",
-        sha256="55a5ca5aaad03396ac5ada2f14b61ffa735fdc2d98355e272465e07a6749d399",
-        expand=False,
-    )
-    version(
-        "4.0.1.2",
-        sha256="cea442aa99ec0d7ffde65014932196b62343f7a6191b4bfc438bfb38c03942f7",
-        expand=False,
-    )
+    version("5.0.3", sha256="b8b9076d1711150a6d6cb3eb30b18e2782fa847c5a86d8404b9339faef105043")
+    version("4.2.1", sha256="a84b6d2706f0ddb2f3750951864502a5c49d081836b00164448b1d81c577f51a")
+    version("4.2.0", sha256="01096466e41a5232e5a18af7400e48c02a6e489f0d5d668a90cdd2746e8e22e2")
 
-    depends_on("zstd", when="@:4.2.1", type="build")
     depends_on("libevent", type="run")
     depends_on("libpciaccess", type="run")
 
     # Map Orca version with the required OpenMPI version
-    openmpi_versions = {"4.0.1.2": "2.0.2", "4.2.0": "3.1.4", "4.2.1": "3.1.4", "5.0.3": "4.1.2"}
+    # OpenMPI@4.1.1 has issues in pmix environments, hence 4.1.2 here
+    openmpi_versions = {"4.2.0": "3.1.4", "4.2.1": "3.1.4", "5.0.3": "4.1.2"}
     for orca_version, openmpi_version in openmpi_versions.items():
         depends_on(
             "openmpi@{0}".format(openmpi_version), type="run", when="@{0}".format(orca_version)
         )
 
     def url_for_version(self, version):
-        out = "file://{0}/orca_{1}_linux_x86-64_openmpi{2}.tar.zst"
-        return out.format(os.getcwd(), version.underscored, self.openmpi_versions[version.string])
+        openmpi_version = self.openmpi_versions[str(version.dotted)].replace(".", "")
+        if openmpi_version == "412":
+            openmpi_version = "411"
+        return f"file://{os.getcwd()}/orca_{version.underscored}_linux_x86-64_shared_openmpi{openmpi_version}.tar.xz"
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
 
-        if self.spec.satisfies("@:4.2.1"):
-            vername = os.path.basename(self.stage.archive_file).split(".")[0]
-
-            zstd = which("zstd")
-            zstd("-d", self.stage.archive_file, "-o", vername + ".tar")
-
-            tar = which("tar")
-            tar("-xvf", vername + ".tar")
-
-            # there are READMEs in there but they don't hurt anyone
-            install_tree(vername, prefix.bin)
-        else:
-            install_tree(".", prefix.bin)
+        install_tree(".", prefix.bin)
 
         # Check "mpirun" usability when building against OpenMPI
         # with Slurm scheduler and add a "mpirun" wrapper that


### PR DESCRIPTION
The current iteration of the orca recipe uses the zstd archives of the releases, which has caused confusion in the past. Let's just switch to xz universally and shrink it down a bit.
