### PR TITLE
Fix issues in packages with the new release of archspec

### DIFF
--- a/var/spack/repos/builtin/packages/arbor/package.py
+++ b/var/spack/repos/builtin/packages/arbor/package.py
@@ -120,9 +120,7 @@ class Arbor(CMakePackage, CudaPackage):
 
         # query spack for the architecture-specific compiler flags set by its wrapper
         args.append("-DARB_ARCH=none")
-        opt_flags = self.spec.target.optimization_flags(
-            self.spec.compiler.name, self.spec.compiler.version
-        )
+        opt_flags = self.spec.architecture.target.optimization_flags(self.spec.compiler)
         args.append("-DARB_CXX_FLAGS_TARGET=" + opt_flags)
 
         return args

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -683,10 +683,10 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         """Get the right (but pessimistic) architecture specific flags supported by
         both host gcc and to-be-built gcc. For example: gcc@7 %gcc@12 target=znver3
         should pick -march=znver1, since that's what gcc@7 supports."""
-        archs = [spec.target] + spec.target.ancestors
-        for arch in archs:
+        microarchitectures = [spec.target] + spec.target.ancestors
+        for uarch in microarchitectures:
             try:
-                return arch.optimization_flags("gcc", spec.version)
+                return uarch.optimization_flags("gcc", str(spec.version))
             except UnsupportedMicroarchitecture:
                 pass
         # no arch specific flags in common, unlikely to happen.

--- a/var/spack/repos/builtin/packages/hpcc/package.py
+++ b/var/spack/repos/builtin/packages/hpcc/package.py
@@ -159,7 +159,7 @@ class Hpcc(MakefilePackage):
         if spec.satisfies("%intel"):
             # with intel-parallel-studio+mpi the '-march' arguments
             # are not passed to icc
-            arch_opt = spec.target.optimization_flags(spec.compiler.name, spec.compiler.version)
+            arch_opt = spec.architecture.target.optimization_flags(spec.compiler)
             self.config["@CCFLAGS@"] = "-O3 -restrict -ansi-alias -ip {0}".format(arch_opt)
             self.config["@CCNOOPT@"] = "-restrict"
         self._write_make_arch(spec, prefix)

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -5,8 +5,6 @@
 import datetime as dt
 import os
 
-import archspec
-
 from spack.package import *
 
 
@@ -822,9 +820,7 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
             args.append(self.define("CMAKE_CXX_FLAGS_RELWITHDEBINFO", cxx_flags))
 
         # Overwrite generic cpu tune option
-        cmake_tune_flags = archspec.cpu.TARGETS[spec.target.name].optimization_flags(
-            spec.compiler.name, spec.compiler.version
-        )
+        cmake_tune_flags = spec.architecture.target.optimization_flags(spec.compiler)
         args.append(self.define("CMAKE_TUNE_FLAGS", cmake_tune_flags))
 
         args.append(self.define_from_variant("LAMMPS_SIZES", "lammps_sizes"))

--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -134,7 +134,7 @@ class Namd(MakefilePackage, CudaPackage):
                 # this options are take from the default provided
                 # configuration files
                 # https://github.com/UIUC-PPL/charm/pull/2778
-                archopt = spec.target.optimization_flags(spec.compiler.name, spec.compiler.version)
+                archopt = spec.architecture.target.optimization_flags(spec.compiler)
 
                 if self.spec.satisfies("^charmpp@:6.10.1"):
                     optims_opts = {

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -605,10 +605,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
 
         # Please specify optimization flags to use during compilation when
         # bazel option '--config=opt' is specified
-        env.set(
-            "CC_OPT_FLAGS",
-            spec.target.optimization_flags(spec.compiler.name, spec.compiler.version),
-        )
+        env.set("CC_OPT_FLAGS", spec.architecture.target.optimization_flags(spec.compiler))
 
         # Would you like to interactively configure ./WORKSPACE for
         # Android builds?


### PR DESCRIPTION
A few packages were passing a `StandardVersion` to an argument expecting a string.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
