### PR TITLE
Python-venv: use correct python name for which call on Windows

### DIFF
--- a/var/spack/repos/builtin/packages/python-venv/package.py
+++ b/var/spack/repos/builtin/packages/python-venv/package.py
@@ -54,7 +54,8 @@ class PythonVenv(Package):
     @property
     def command(self):
         """Returns a python Executable instance"""
-        return which("python3", path=self.bindir)
+        python_name = "python" if self.spec.satisfies("platform=windows") else "python3"
+        return which(python_name, path=self.bindir)
 
     def _get_path(self, name) -> str:
         return self.command(


### PR DESCRIPTION
https://github.com/spack/spack/pull/40773 introduces the `python-venv` package.

`python-venv`'s `command` method uses the wrong python name to search for the python executable on the Windows platform. The name is always just `python`. 

Currently, bootstrapping, and every other build operation involving Python's venv are broken on normal Windows installations.

CI did not catch this as the GH runners have the MSYS/Cygwin Python's available which are named with nix conventions so the original PR was able to function.