### PR TITLE
libhugetlbfs: add native_only variant

### DIFF
--- a/var/spack/repos/builtin/packages/libhugetlbfs/package.py
+++ b/var/spack/repos/builtin/packages/libhugetlbfs/package.py
@@ -6,16 +6,26 @@
 from spack.package import *
 
 
-class Libhugetlbfs(MakefilePackage):
+class Libhugetlbfs(AutotoolsPackage):
     """libhugetlbfs is a library which provides easy access
     to huge pages of memory."""
 
     homepage = "https://github.com/libhugetlbfs/libhugetlbfs"
-    url = "https://github.com/libhugetlbfs/libhugetlbfs/releases/download/2.22/libhugetlbfs-2.22.tar.gz"
+    url = "https://github.com/libhugetlbfs/libhugetlbfs/releases/download/2.24/libhugetlbfs-2.24.tar.gz"
 
     license("LGPL-2.1-or-later")
 
-    version("2.22", sha256="94dca9ea2c527cd77bf28904094fe4708865a85122d416bfccc8f4b73b9a6785")
+    version("2.24", sha256="d501dfa91c8ead1106967a3d3829f2ba738c3fac0a65cb358ed2ab3870ddc5ef")
 
-    def install(self, spec, prefix):
-        make("install", "PREFIX=%s" % prefix)
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
+    build_targets = ["-e", "libs", "tools"]
+    install_targets = ["-e", "install"]
+    parallel = False
+
+    def setup_build_environment(self, env):
+        env.set("BUILDTYPE", "NATIVEONLY")
+        env.set("PREFIX", self.prefix)
+        env.set("V", "1")


### PR DESCRIPTION
Updated information:
- 2.22 (released in 2019) does not build on current Linux systems like Ubuntu 22.04 because glibc-2.34 removed `__morecore`.
- This has been addressed in the current release 2.24 (released in March)
  - https://github.com/libhugetlbfs/libhugetlbfs/blob/master/NEWS
- NEWS indicates not breaking or API changes in 2.24

Because of this and as the package has not been maintained since it was submitted to `spack` in 2020, nearly 4 years ago, update from the no longer generally usable 2.22 to the current 2.24.

----
Initial findings:

The package did not build in its current state. The following changes were necessary:
- Remove the `build` stage and build during install stage as the Makefile expects to find the install prefix when `make` is called.
- Add variant `native_only` which prevents building 32-bit on 64-bit systems and vice versa. We cannot expect headers for a different architecture to be available.
- `mkdir prefix.lib` so that at least one [these](https://github.com/libhugetlbfs/libhugetlbfs/blob/e6499ff92b4a7dcffbd131d1f5d24933e48c3f20/Makefile#L176) PATHs is not empty.
- Do not build the tools target by default. the tools target uses `$CC -B` to direct the compiler to a special linker. The potential `RPATH` inside `$CC` (e.g. when the compiler is installed through spack) overwrites this option.
- Disable parallel make as it will run into a race condition.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
