### PR TITLE
Remove deprecated config options

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -258,40 +258,6 @@ def _search_duplicate_specs_in_externals(error_cls):
 
 
 @config_packages
-def _deprecated_preferences(error_cls):
-    """Search package preferences deprecated in v0.21 (and slated for removal in v0.23)"""
-    # TODO (v0.23): remove this audit as the attributes will not be allowed in config
-    errors = []
-    packages_yaml = spack.config.CONFIG.get_config("packages")
-
-    def make_error(attribute_name, config_data, summary):
-        s = io.StringIO()
-        s.write("Occurring in the following file:\n")
-        dict_view = syaml.syaml_dict((k, v) for k, v in config_data.items() if k == attribute_name)
-        syaml.dump_config(dict_view, stream=s, blame=True)
-        return error_cls(summary=summary, details=[s.getvalue()])
-
-    if "all" in packages_yaml and "version" in packages_yaml["all"]:
-        summary = "Using the deprecated 'version' attribute under 'packages:all'"
-        errors.append(make_error("version", packages_yaml["all"], summary))
-
-    for package_name in packages_yaml:
-        if package_name == "all":
-            continue
-
-        package_conf = packages_yaml[package_name]
-        for attribute in ("compiler", "providers", "target"):
-            if attribute not in package_conf:
-                continue
-            summary = (
-                f"Using the deprecated '{attribute}' attribute " f"under 'packages:{package_name}'"
-            )
-            errors.append(make_error(attribute, package_conf, summary))
-
-    return errors
-
-
-@config_packages
 def _avoid_mismatched_variants(error_cls):
     """Warns if variant preferences have mismatched types or names."""
     errors = []

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -109,7 +109,6 @@ properties: Dict[str, Any] = {
                     "require": requirements,
                     "prefer": prefer_and_conflict,
                     "conflict": prefer_and_conflict,
-                    "version": {},  # Here only to warn users on ignored properties
                     "target": {
                         "type": "array",
                         "default": [],
@@ -140,16 +139,6 @@ properties: Dict[str, Any] = {
                     },
                     "variants": variants,
                 },
-                "deprecatedProperties": [
-                    {
-                        "names": ["version"],
-                        "message": "setting version preferences in the 'all' section of "
-                        "packages.yaml is deprecated and will be removed in v0.23"
-                        "\n\n\tThese preferences will be ignored by Spack. You can "
-                        "set them only in package-specific sections of the same file.\n",
-                        "error": False,
-                    }
-                ],
             }
         },
         "patternProperties": {
@@ -167,14 +156,11 @@ properties: Dict[str, Any] = {
                         # version strings
                         "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                     },
-                    "target": {},  # Here only to warn users on ignored properties
-                    "compiler": {},  # Here only to warn users on ignored properties
                     "buildable": {"type": "boolean", "default": True},
                     "permissions": permissions,
                     # If 'get_full_repo' is promoted to a Package-level
                     # attribute, it could be useful to set it here
                     "package_attributes": package_attributes,
-                    "providers": {},  # Here only to warn users on ignored properties
                     "variants": variants,
                     "externals": {
                         "type": "array",
@@ -206,20 +192,6 @@ properties: Dict[str, Any] = {
                         },
                     },
                 },
-                "deprecatedProperties": [
-                    {
-                        "names": ["target", "compiler", "providers"],
-                        "message": "setting '{name}:' preferences in "
-                        "a package-specific section of packages.yaml is deprecated, and will be "
-                        "removed in v0.23.\n\n\tThis preferences will be ignored by Spack, and "
-                        "can be set only in the 'all' section of the same file. "
-                        "You can run:\n\n\t\t$ spack audit configs\n\n\tto get better "
-                        "diagnostics, including files:lines where the deprecated "
-                        "attributes are used.\n\n\tUse requirements to enforce conditions"
-                        f" on specific packages: {REQUIREMENT_URL}\n",
-                        "error": False,
-                    }
-                ],
             }
         },
     }

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -4204,9 +4204,6 @@ spack:
 {''.join(includes)}
   specs:
   - mpileaks
-  packages:
-    mpileaks:
-      compiler: [gcc]
 """
     )
 


### PR DESCRIPTION
These options have been deprecated in v0.21, and slated for removal in v0.22

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
