### PR TITLE
libtheora: Remove unneeded autoreconf section

### DIFF
--- a/var/spack/repos/builtin/packages/libtheora/package.py
+++ b/var/spack/repos/builtin/packages/libtheora/package.py
@@ -70,17 +70,12 @@ class Libtheora(AutotoolsPackage, MSBuildPackage):
 
 
 class AutotoolsBuilder(AutotoolsBuilder):
+
     def configure_args(self):
         args = []
         args += self.enable_or_disable("doc")
         args += ["LIBS=-lm"]
         return args
-
-    def autoreconf(self, pkg, spec, prefix):
-        sh = which("sh")
-        # arguments are passed on to configure, let it just print its version
-        # and exit, so that configure can run in the configure build phase
-        sh("./autogen.sh", "-V")
 
 
 class MSBuildBuilder(MSBuildBuilder):

--- a/var/spack/repos/builtin/packages/libtheora/package.py
+++ b/var/spack/repos/builtin/packages/libtheora/package.py
@@ -70,7 +70,6 @@ class Libtheora(AutotoolsPackage, MSBuildPackage):
 
 
 class AutotoolsBuilder(AutotoolsBuilder):
-
     def configure_args(self):
         args = []
         args += self.enable_or_disable("doc")


### PR DESCRIPTION
The custom `autoreconf` section was causing a libtool mismatch error as shown in spack/spack/issues/43498

```
  309    libtool: Version mismatch error.  This is libtool 2.4.7, but the
     310    libtool: definition of this LT_INIT comes from libtool 2.4.6.
     311    libtool: You should recreate aclocal.m4 with macros from libtool 2.4.7
     312    libtool: and run autoconf again.
```

It is not clear to me what this section is supposed to be doing. The tarball from xiph.org already contains a configure script (this is the tarball used in this package). The github repo does not and requires an autoreconf step. Ref: https://github.com/xiph/theora/issues/16

Keeping this step adds complexity.  `autoreconf` isn't supposed to run `./configure`, however, `configure` is automatically run post `autoreconf`. This causes an error about an already configured package. Passing "-V" to configure is noted to stop configure doing anything post-autoreconf step, and should resolve that. However, it then results in a libtool version conflict -- perhaps because the wrong toolchain is used when calling through the shell script?

```
$ which libtool
/usr/bin/libtool
$ libtool --version
libtool (GNU libtool) 2.4.6
```

Regardless, as a configure is already provided, this is not needed.