### PR TITLE
qpdf: new package

### DIFF
--- a/var/spack/repos/builtin/packages/qpdf/package.py
+++ b/var/spack/repos/builtin/packages/qpdf/package.py
@@ -1,0 +1,45 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class Qpdf(CMakePackage):
+    """
+    QPDF is a command-line tool and C++ library that performs
+    content-preserving transformations on PDF files.
+    """
+
+    homepage = "https://qpdf.sourceforge.io/"
+    url = "https://github.com/qpdf/qpdf/releases/download/v11.9.0/qpdf-11.9.0.tar.gz"
+
+    maintainers("taliaferro")
+
+    license("Apache-2.0", checked_by="taliaferro")
+
+    version("11.9.0", sha256="9f5d6335bb7292cc24a7194d281fc77be2bbf86873e8807b85aeccfbff66082f")
+
+    variant(
+        "crypto",
+        values=["openssl", "gnutls", "native", "implicit"],
+        default="implicit",
+        multi=False,
+        description="Provider of cryptographic functions.",
+    )
+
+    depends_on("zlib-api")
+    depends_on("jpeg")
+    depends_on("openssl", when="crypto=openssl")
+    depends_on("gnutls", when="crypto=gnutls")
+
+    def cmake_args(self):
+
+        if self.spec.satisfies("crypto=implicit"):
+            return []
+
+        else:
+            crypto_type = self.spec.variants["crypto"].value.upper()
+            return ["USE_IMPLICIT_CRYPTO=0", f"REQUIRE_CRYPTO_{crypto_type}=1"]

--- a/var/spack/repos/builtin/packages/qpdf/package.py
+++ b/var/spack/repos/builtin/packages/qpdf/package.py
@@ -37,9 +37,9 @@ class Qpdf(CMakePackage):
 
     def cmake_args(self):
 
-        if self.spec.satisfies("crypto=implicit"):
-            return []
-
-        else:
+        args = []
+        if not self.spec.satisfies("crypto=implicit"):
             crypto_type = self.spec.variants["crypto"].value.upper()
-            return ["USE_IMPLICIT_CRYPTO=0", f"REQUIRE_CRYPTO_{crypto_type}=1"]
+            args.append("USE_IMPLICIT_CRYPTO=0")
+            args.append(f"REQUIRE_CRYPTO_{crypto_type}=1")
+        return args

--- a/var/spack/repos/builtin/packages/qpdf/package.py
+++ b/var/spack/repos/builtin/packages/qpdf/package.py
@@ -36,10 +36,10 @@ class Qpdf(CMakePackage):
     depends_on("gnutls", when="crypto=gnutls")
 
     def cmake_args(self):
-
         args = []
         if not self.spec.satisfies("crypto=implicit"):
             crypto_type = self.spec.variants["crypto"].value.upper()
             args.append("USE_IMPLICIT_CRYPTO=0")
             args.append(f"REQUIRE_CRYPTO_{crypto_type}=1")
+
         return args


### PR DESCRIPTION
Added the package `qpdf` which provides a library and CLI tool to combine, linearize, transform and encrypt PDF documents. It has variants for different cryptography providers (see "[build-time crypto providers](https://qpdf.readthedocs.io/en/latest/installation.html#build-time-crypto-selection)" in the manual for details.)