### PR TITLE
docs: Fix method signature in autoreconf example

### DIFF
--- a/lib/spack/docs/build_systems/autotoolspackage.rst
+++ b/lib/spack/docs/build_systems/autotoolspackage.rst
@@ -144,7 +144,7 @@ example, the ``bash`` shell is used to run the ``autogen.sh`` script.
 
 .. code-block:: python
 
-   def autoreconf(self, spec, prefix):
+   def autoreconf(self, pkg, spec, prefix):
        which("bash")("autogen.sh")
 
 """""""""""""""""""""""""""""""""""""""

--- a/lib/spack/docs/build_systems/autotoolspackage.rst
+++ b/lib/spack/docs/build_systems/autotoolspackage.rst
@@ -144,8 +144,17 @@ example, the ``bash`` shell is used to run the ``autogen.sh`` script.
 
 .. code-block:: python
 
-   def autoreconf(self, pkg, spec, prefix):
+   def autoreconf(self, spec, prefix):
        which("bash")("autogen.sh")
+
+If the ``package.py`` has build instructions in a separate
+:ref:`builder class <multiple_build_systems>`, the signature for a phase changes slightly:
+
+.. code-block:: python
+
+   class AutotoolsBuilder(AutotoolsBuilder):
+      def autoreconf(self, pkg, spec, prefix):
+         which("bash")("autogen.sh")
 
 """""""""""""""""""""""""""""""""""""""
 patching configure or Makefile.in files


### PR DESCRIPTION
This fixes the method signature in the autoools/autoreconf example to match the method sigature [that is expected](https://spack.readthedocs.io/en/latest/spack.build_systems.html#spack.build_systems.autotools.AutotoolsBuilder.autoreconf).