### PR TITLE
flux-sched: set the version if the ver file is missing

### DIFF
--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -187,7 +187,7 @@ class FluxSched(CMakePackage, AutotoolsPackage):
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
         if not os.path.exists(os.path.join(self.stage.source_path, "flux-sched.ver")):
-            return [f"-DFLUX_SCHED_VER={self.spec.version}"]
+            return [self.define("FLUX_SCHED_VER", self.spec.version)]
         return []
 
 

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -186,6 +186,8 @@ class FluxSched(CMakePackage, AutotoolsPackage):
 
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
+        if not os.path.exists(os.path.join(self.stage.source_path, "flux-sched.ver")):
+            return [f"-DFLUX_SCHED_VER={self.spec.version}"]
         return []
 
 

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -187,6 +187,7 @@ class FluxSched(CMakePackage, AutotoolsPackage):
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
         ver_in_src = os.path.exists(os.path.join(self.stage.source_path, "flux-sched.ver"))
+        # flux-sched before v0.33 does not correctly set the version even when the file is present.
         if self.spec.satisfies("@:0.33") or not ver_in_src:
             return [self.define("FLUX_SCHED_VER", self.spec.version)]
         return []

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -186,7 +186,8 @@ class FluxSched(CMakePackage, AutotoolsPackage):
 
 class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
-        if not os.path.exists(os.path.join(self.stage.source_path, "flux-sched.ver")):
+        ver_in_src = os.path.exists(os.path.join(self.stage.source_path, "flux-sched.ver"))
+        if self.spec.satisfies("@:0.33") or not ver_in_src:
             return [self.define("FLUX_SCHED_VER", self.spec.version)]
         return []
 


### PR DESCRIPTION
problem: flux-sched needs a version, it normally gets this from a release tarball or from git tags, but if using a source archive or a git clone without tags the version is missing

solution: set the version through cmake based on the version spack sees when the version file is missing

