### PR TITLE
fastjet: Add a cxxstd variant

### DIFF
--- a/var/spack/repos/builtin/packages/fastjet/package.py
+++ b/var/spack/repos/builtin/packages/fastjet/package.py
@@ -72,6 +72,14 @@ class Fastjet(AutotoolsPackage):
     )
     variant("atlas", default=False, description="Patch to make random generator thread_local")
 
+    cxxstds = ("11", "17", "20", "23")
+    variant(
+        "cxxstd",
+        default="11",
+        values=cxxstds,
+        description="Use the specified C++ standard when building",
+    )
+
     available_plugins = (
         conditional("atlascone", when="@2.4.0:"),
         conditional("cdfcones", when="@2.1.0:"),
@@ -126,3 +134,8 @@ class Fastjet(AutotoolsPackage):
             extra_args += ["--enable-thread-safety"]
 
         return extra_args
+
+    def flag_handler(self, name, flags):
+        if name == "cxxflags":
+            flags.append("-std=c++{0}".format(self.spec.variants["cxxstd"].value))
+        return (None, flags, None)

--- a/var/spack/repos/builtin/packages/fastjet/package.py
+++ b/var/spack/repos/builtin/packages/fastjet/package.py
@@ -137,5 +137,5 @@ class Fastjet(AutotoolsPackage):
 
     def flag_handler(self, name, flags):
         if name == "cxxflags":
-            flags.append("-std=c++{0}".format(self.spec.variants["cxxstd"].value))
+            flags.append(f"-std=c++{self.spec.variants['cxxstd'].value}")
         return (None, flags, None)

--- a/var/spack/repos/builtin/packages/fastjet/package.py
+++ b/var/spack/repos/builtin/packages/fastjet/package.py
@@ -72,11 +72,11 @@ class Fastjet(AutotoolsPackage):
     )
     variant("atlas", default=False, description="Patch to make random generator thread_local")
 
-    cxxstds = ("11", "17", "20", "23")
     variant(
         "cxxstd",
         default="11",
-        values=cxxstds,
+        values=("11", "17", "20", "23"),
+        multi=False,
         description="Use the specified C++ standard when building",
     )
 


### PR DESCRIPTION
I left 11 as the default since that seems what's being used on my machine by default. I tested building with C++20 and it went fine with GCC 11.4