### PR TITLE
gitlab ci: tutorial: add `julia` and `vim`

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -180,7 +180,6 @@ ci:
 
     - match:
       - cmake
-      - openblas
       - plumed
       - wrf
       build-job:
@@ -242,7 +241,6 @@ ci:
       - mvapich2
       - netlib-scalapack
       - omega-h
-      - openblas
       - openjpeg
       - openmpi
       - openpmd-api
@@ -395,7 +393,6 @@ ci:
       - ncurses
       - ninja
       - numactl
-      - openblas
       - openjdk
       - openssh
       - openssl

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -180,6 +180,7 @@ ci:
 
     - match:
       - cmake
+      - openblas
       - plumed
       - wrf
       build-job:

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -23,7 +23,7 @@ spack:
         - lmod@8.7.18
         - environment-modules
         - macsio@1.1+scr ^scr@2.0.0~fortran ^silo~fortran ^hdf5~fortran
-        - julia@1.9 ^llvm ~clang ~gold ~lldb ~lua ~polly compiler-rt=none libcxx=none libunwind=none targets=x86
+        - julia@1.9 ^llvm ~clang ~gold ~lldb ~lua ~polly compiler-rt=none libcxx=none libunwind=none targets=x86 ^openblas threads=openmp
       - ['%gcc@11']
   - gcc_old_packages:
     - zlib-ng%gcc@10

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -23,7 +23,7 @@ spack:
         - lmod@8.7.18
         - environment-modules
         - macsio@1.1+scr ^scr@2.0.0~fortran ^silo~fortran ^hdf5~fortran
-        - julia@1.10 ^llvm ~clang ~gold ~lld ~lldb ~lua ~polly compiler-rt=none libcxx=none libunwind=none targets=amdgpu,bpf,nvptx,webassembly
+        - julia@1.9 ^llvm ~clang ~gold ~lldb ~lua ~polly compiler-rt=none libcxx=none libunwind=none targets=x86
       - ['%gcc@11']
   - gcc_old_packages:
     - zlib-ng%gcc@10

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -23,7 +23,7 @@ spack:
         - lmod@8.7.18
         - environment-modules
         - macsio@1.1+scr ^scr@2.0.0~fortran ^silo~fortran ^hdf5~fortran
-        - julia@1.10 ^llvm ~clang ~gold ~lld ~lldb ~lua ~polly compiler-rt=none libcxx=none libunwind=none
+        - julia@1.10 ^llvm ~clang ~gold ~lld ~lldb ~lua ~polly compiler-rt=none libcxx=none libunwind=none targets=amdgpu,bpf,nvptx,webassembly
       - ['%gcc@11']
   - gcc_old_packages:
     - zlib-ng%gcc@10

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -24,6 +24,7 @@ spack:
         - environment-modules
         - macsio@1.1+scr ^scr@2.0.0~fortran ^silo~fortran ^hdf5~fortran
         - julia@1.9 ^llvm ~clang ~gold ~lldb ~lua ~polly compiler-rt=none libcxx=none libunwind=none targets=x86 ^openblas threads=openmp
+        - vim
       - ['%gcc@11']
   - gcc_old_packages:
     - zlib-ng%gcc@10

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -23,7 +23,7 @@ spack:
         - lmod@8.7.18
         - environment-modules
         - macsio@1.1+scr ^scr@2.0.0~fortran ^silo~fortran ^hdf5~fortran
-        - julia@1.10
+        - julia@1.10 ^llvm ~clang ~gold ~lld ~lldb ~lua ~polly compiler-rt=none libcxx=none libunwind=none
       - ['%gcc@11']
   - gcc_old_packages:
     - zlib-ng%gcc@10

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -23,6 +23,7 @@ spack:
         - lmod@8.7.18
         - environment-modules
         - macsio@1.1+scr ^scr@2.0.0~fortran ^silo~fortran ^hdf5~fortran
+        - julia@1.10
       - ['%gcc@11']
   - gcc_old_packages:
     - zlib-ng%gcc@10


### PR DESCRIPTION
For showcasing generated container images.

Also fixes an issue in CI where `openblas` is mapped to a small runner.