### PR TITLE
pythia8: add a cxxstd variant

### DIFF
--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -58,6 +58,14 @@ class Pythia8(AutotoolsPackage):
         deprecated=True,
     )
 
+    cxxstds = ("11", "17", "20", "23")
+    variant(
+        "cxxstd",
+        default="11",
+        values=cxxstds,
+        description="Use the specified C++ standard when building",
+    )
+
     variant("shared", default=True, description="Build shared library")
     variant("gzip", default=False, description="Build with gzip support, for reading lhe.gz files")
     variant(
@@ -119,6 +127,10 @@ class Pythia8(AutotoolsPackage):
     conflicts("+hdf5", when="~mpich", msg="MPICH is required for reading HDF5 files")
 
     filter_compiler_wrappers("Makefile.inc", relative_root="share/Pythia8/examples")
+
+    @run_before("configure")
+    def setup_cxxstd(self):
+        filter_file("-std=c++[0-9][0-9]", f"-std=c++{self.spec.variants['cxxstd'].value}", "configure")
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -130,7 +130,9 @@ class Pythia8(AutotoolsPackage):
 
     @run_before("configure")
     def setup_cxxstd(self):
-        filter_file("-std=c++[0-9][0-9]", f"-std=c++{self.spec.variants['cxxstd'].value}", "configure")
+        filter_file(
+            "-std=c++[0-9][0-9]", f"-std=c++{self.spec.variants['cxxstd'].value}", "configure"
+        )
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -58,11 +58,11 @@ class Pythia8(AutotoolsPackage):
         deprecated=True,
     )
 
-    cxxstds = ("11", "17", "20", "23")
     variant(
         "cxxstd",
         default="11",
-        values=cxxstds,
+        values=("11", "17", "20", "23"),
+        multi=False,
         description="Use the specified C++ standard when building",
     )
 
@@ -131,7 +131,7 @@ class Pythia8(AutotoolsPackage):
     @run_before("configure")
     def setup_cxxstd(self):
         filter_file(
-            "-std=c++[0-9][0-9]", f"-std=c++{self.spec.variants['cxxstd'].value}", "configure"
+            "-std=c\+\+[0-9][0-9]", f"-std=c++{self.spec.variants['cxxstd'].value}", "configure"
         )
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -131,7 +131,7 @@ class Pythia8(AutotoolsPackage):
     @run_before("configure")
     def setup_cxxstd(self):
         filter_file(
-            "-std=c\+\+[0-9][0-9]", f"-std=c++{self.spec.variants['cxxstd'].value}", "configure"
+            r"-std=c\+\+[0-9][0-9]", f"-std=c++{self.spec.variants['cxxstd'].value}", "configure"
         )
 
     def configure_args(self):


### PR DESCRIPTION
I've found that whizard (that depends on pythia8) uses `pythia-config --cxxflags` to decide which flags to use and currently there is no way to change the C++ standard in pythia8. Pythia takes C++ arguments through `--cxx-common` and some arguments are hardcoded in the configure script, so the configure script is filtered to preserve the arguments:
https://gitlab.com/Pythia8/releases/-/blob/001b35e1f9ba95cb9dc5e212635a4fdadc614b21/configure#L329
```
    CXX_COMMON="${ENABLE_DEBUG}-std=c++11 -pedantic -W -Wall -Wshadow -fPIC"
```