### PR TITLE
gcc: use -idirafter for libc headers

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -1174,7 +1174,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
             os.path.exists(os.path.join(header_dir, h))
             for h in libc.package_class.representative_headers
         ):
-            relocation_args.append(f"-isystem {header_dir}")
+            relocation_args.append(f"-idirafter {header_dir}")
         else:
             tty.warn(
                 f"Cannot relocate {specs_file} include directories, "


### PR DESCRIPTION
GCC C++ headers like cstdlib use `#include_next <stdlib.h>` to wrap libc
headers. We're using `-isystem` for libc, which puts those headers too
early in the search path. `-idirafter` fixes this so `include_next`
works.
