### PR TITLE
Octopus 14.1 : Add new version hash

### DIFF
--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -301,6 +301,11 @@ class Octopus(AutotoolsPackage, CudaPackage):
             args.append(f"{cxxflags} {gcc10_extra}")
             args.append(f"{cflags} {gcc10_extra}")
 
+        # for octopus 14.1 and above autotools is deprecated in favour of cmake
+        # inorder to continue using autotools we pass `--enable-silent-deprecation`
+        if spec.satisfies("@14.1:"):
+            args.append("--enable-silent-deprecation")
+
         # Disable flags
         #
         # disable gdlib explicitly to avoid

--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -23,6 +23,7 @@ class Octopus(AutotoolsPackage, CudaPackage):
 
     license("Apache-2.0")
 
+    version("14.1", sha256="6955f4020e69f038650a24509ff19ef35de4fd34e181539f92fa432db9b66ca7")
     version("14.0", sha256="3cf6ef571ff97cc2c226016815d2ac4aa1e00ae3fb0cc693e0aff5620b80373e")
     version("13.0", sha256="b4d0fd496c31a9c4aa4677360e631765049373131e61f396b00048235057aeb1")
     version("12.2", sha256="e919e07703696eadb4ba59352d7a2678a9191b4586cb9da538661615e765a5a2")


### PR DESCRIPTION
Octopus 14.1 was released on 2024-05-03.
This MR:
- adds the hashes for the new version
- disables the deprecation warning for autotools which otherwise would ask for user input

The next steps would be to try and get the cmake build system working in our recipe. 