### PR TITLE
charmpp: enable darwin arm build

### DIFF
--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -235,6 +235,9 @@ class Charmpp(Package):
                 {
                     ("linux", "arm", "mpi"): "mpi-linux-arm7",
                     ("linux", "aarch64", "mpi"): "mpi-linux-arm8",
+                    ("darwin", "arm", "multicore"): "multicore-darwin-arm8",
+                    ("darwin", "arm", "netlrts"): "netlrts-darwin-arm8",
+                    ("darwin", "arm", "mpi"): "mpi-darwin-arm8",
                 }
             )
 


### PR DESCRIPTION
Enables `multicore-darwin-arm8` builds of Charm++ on Apple Silicon Macs. This is a draft PR because I currently encounter this issue:

```
$ ./bin/spack install charmpp
[+] /opt/homebrew (external cmake-3.28.1-vbfjbkn5qbnaaxndqpulxjtggue7nvmo)
==> Installing charmpp-7.0.0-j65fwdjhq6kf7hak3ub4frk2n7xct4n2 [2/2]
==> No binary for charmpp-7.0.0-j65fwdjhq6kf7hak3ub4frk2n7xct4n2 found: installing from source
==> No patches needed for charmpp
==> charmpp: Executing phase: 'install'
==> Error: ProcessError: Command exited with status 2:
    './build' 'LIBS' 'multicore-darwin-arm8' 'clang' 'gfortran' '-j12' '--destination=/Users/nilsvu/spack/opt/spack/darwin-sonoma-m2/apple-clang-14.0.3/charmpp-7.0.0-j65fwdjhq6kf7hak3ub4frk2n7xct4n2' '--build-shared' '--with-production'

4 errors found in build log:
     12916    [ 92%] Performing download step (DIR copy) for 'romio'
     12917    [ 92%] No update step for 'romio'
     12918    [ 92%] No patch step for 'romio'
     12919    [ 92%] Performing configure step for 'romio'
     12920    configure: WARNING: File locks may not work with NFS.  See the Installation and
     12921    users manual for instructions on testing and if necessary fixing this
  >> 12922    configure: error: Unable to compile a simple MPI program.
     12923    Use environment variables to provide the location of MPI libraries and
     12924    include directories
  >> 12925    make[2]: *** [src/libs/ck-libs/ampi/romio-prefix/src/romio-stamp/romio-configure] Error 1
  >> 12926    make[1]: *** [src/libs/ck-libs/ampi/CMakeFiles/romio.dir/all] Error 2
  >> 12927    make: *** [all] Error 2
```

Any idea @matthiasdiener ?

This uses AppleClang 15 on macOS Sonoma. Here's the full build output: 
[spack-build-out.txt](https://github.com/spack/spack/files/15266941/spack-build-out.txt)

I swear I compiled charm on Apple Silicon with Spack before, maybe 1 year ago, and it worked. I can't figure out how though, because the `multicore-darwin-arm8` build wasn't even enabled.