### PR TITLE
apptainer: adding version 1.3.1 and dependency updates

### DIFF
--- a/var/spack/repos/builtin/packages/apptainer/package.py
+++ b/var/spack/repos/builtin/packages/apptainer/package.py
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+from glob import glob
+from os.path import basename
+
 from spack.package import *
 from spack.pkg.builtin.singularityce import SingularityBase
 
@@ -33,6 +36,7 @@ class Apptainer(SingularityBase):
     )
 
     version("main", branch="main")
+    version("1.3.1", sha256="6956c689c4a8f148789c5c34b33c15ad8f3460b4cee3f48022119fd872eacee9")
     version("1.2.5", sha256="606b67ef97683e1420401718687d258b1034fdf2edae72eeacd0828dffbfc2c2")
     version("1.1.9", sha256="c615777539154288542cf393d3fd44c04ccb3260bc6330dc324d4e4ebe902bfa")
     version("1.1.7", sha256="e6d3956a26c3965703402e17f153ba07f59bf710068806462b314d2d04e825e7")
@@ -42,8 +46,15 @@ class Apptainer(SingularityBase):
     version("1.1.3", sha256="c7bf7f4d5955e1868739627928238d02f94ca9fd0caf110b0243d65548427899")
     version("1.0.2", sha256="2d7a9d0a76d5574459d249c3415e21423980d9154ce85e8c34b0600782a7dfd3")
 
+    depends_on("e2fsprogs@1.47:+fuse2fs", type="run")
     depends_on("go@1.17.5:", when="@1.1.0:")
+    depends_on("go@1.19:", when="@1.2:")
+    depends_on("go@1.20:", when="@1.3:")
+    depends_on("gocryptfs@2.4:", type="run", when="@1.3:")
     depends_on("squashfuse", type="run")
+    depends_on("squashfuse@0.5.1:", type="run", when="@1.3:")
+    depends_on("fuse-overlayfs", type="run")
+    depends_on("fuse-overlayfs@1.13:", type="run", when="@1.3:")
 
     singularity_org = "apptainer"
     singularity_name = "apptainer"
@@ -65,3 +76,19 @@ class Apptainer(SingularityBase):
         # Certain go modules this build pulls in cannot be built with anything
         # other than -O0. Best to just discard any injected flags.
         return (None, flags, None)
+
+    # They started vendoring the fuse bits and assume they'll be in the
+    # libexec/apptainer prefix as a result. When singularity is run with
+    # suid it doesn't search the user's $PATH for security reasons.
+    # Since we don't use the vendored deps and instead install them in
+    # their own prefixes they are not found by default.
+    # This is likely only relevant for 1.3:, but it should be fine everywhere
+    @run_after("install")
+    def fix_binary_path(self):
+        for i in [
+            s for s in ["e2fsprogs", "gocryptfs", "squashfuse", "fuse-overlayfs"] if s in self.spec
+        ]:
+            for binary in glob(join_path(self.spec[i].prefix.bin, "*")):
+                symlink(
+                    binary, join_path(self.spec.prefix.libexec.apptainer.bin, basename(binary))
+                )

--- a/var/spack/repos/builtin/packages/e2fsprogs/package.py
+++ b/var/spack/repos/builtin/packages/e2fsprogs/package.py
@@ -15,14 +15,38 @@ class E2fsprogs(AutotoolsPackage):
 
     license("GPL-2.0-or-later AND LGPL-2.0-or-later AND BSD-3-Clause AND MIT")
 
+    version("1.47.1", sha256="db95ff1cb6ef741c9aa8875d9f3f52a34168360febba765b6377b80bada09a8c")
+    version("1.47.0", sha256="74c8ea97c73294edc6c11dc5e7fbb4324f86c28efd66ad0ba50be4eec8a48be2")
     version("1.45.6", sha256="d785164a2977cd88758cb0cac5c29add3fe491562a60040cfb193abcd0f9609b")
     version("1.45.5", sha256="0fd76e55c1196c1d97a2c01f2e84f463b8e99484541b43ff4197f5a695159fd3")
 
+    variant("fuse2fs", default=False, description="Build fuse2fs")
+
     depends_on("texinfo", type="build")
+    depends_on("fuse", when="+fuse2fs")
+
+    # fuse3 support is in the yet unreleased 1.47.1
+    patch(
+        "https://github.com/tytso/e2fsprogs/commit/5598a96.patch?full_index=1",
+        sha256="72b28eb4599dbae45a01a1518ab6b8b6fc23db4f67381b49f63d3a3d45822340",
+        when="@:1.47.0 +fuse2fs",
+    )
+    patch(
+        "https://github.com/tytso/e2fsprogs/commit/1ac0061.patch?full_index=1",
+        sha256="c5fbcd4e6d7f29d083d923b33998d916e2059b8f108c8cc20e8b5c928186eef2",
+        when="@:1.47.0 +fuse2fs",
+    )
+    patch(
+        "https://github.com/tytso/e2fsprogs/commit/448a3f8.patch?full_index=1",
+        sha256="fb45c3af229b49fab19c70c00c33b9f3579a9455025aedb8049ff411b1cf3a96",
+        when="@:1.47.0 +fuse2fs",
+    )
 
     def setup_run_environment(self, env):
         env.prepend_path("PATH", self.prefix.sbin)
 
     def configure_args(self):
         # avoid installing things in /etc
-        return ["--without-udev-rules-dir", "--without-crond-dir", "--without-systemd-unit-dir"]
+        args = ["--without-udev-rules-dir", "--without-crond-dir", "--without-systemd-unit-dir"]
+        args.extend(self.enable_or_disable("fuse2fs"))
+        return args

--- a/var/spack/repos/builtin/packages/fuse-overlayfs/package.py
+++ b/var/spack/repos/builtin/packages/fuse-overlayfs/package.py
@@ -15,6 +15,7 @@ class FuseOverlayfs(AutotoolsPackage):
 
     license("GPL-2.0-or-later")
 
+    version("1.13", sha256="96d10344921d5796bcba7a38580ae14a53c4e60399bb90b238ac5a10b3bb65b2")
     version("1.10", sha256="4351eaed7cf26a5012c14c6e0fc883ef65a7b5dcc95ba129ce485904106c25a9")
     version("1.7.1", sha256="fe2c076aed7b8669e7970301a99c0b197759b611035d8199de4c0add7d2fb2b4")
     version("1.7", sha256="e4d9a794d270e237a38e7ced95af95ad15268e0584eab981ed7c7b3758b95995")
@@ -33,3 +34,4 @@ class FuseOverlayfs(AutotoolsPackage):
     depends_on("m4", type="build")
     depends_on("pkgconfig", type="build")
     depends_on("fuse")
+    depends_on("libfuse@3.2.1:", when="^[virtuals=fuse] libfuse")

--- a/var/spack/repos/builtin/packages/gocryptfs/package.py
+++ b/var/spack/repos/builtin/packages/gocryptfs/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Gocryptfs(GoPackage):
+    """Encrypted overlay filesystem written in Go"""
+
+    homepage = "https://nuetzlich.net/gocryptfs/"
+    url = (
+        "https://github.com/rfjakob/gocryptfs/releases/download/v2.4.0/gocryptfs_v2.4.0_src.tar.gz"
+    )
+
+    maintainers("snehring")
+
+    license("MIT", checked_by="snehring")
+
+    version("2.4.0", sha256="26a93456588506f4078f192b70e7816b6a4042a14b748b28a50d2b6c9b10e2ec")
+
+    depends_on("openssl")
+    depends_on("pkg-config", type="build")

--- a/var/spack/repos/builtin/packages/squashfuse/package.py
+++ b/var/spack/repos/builtin/packages/squashfuse/package.py
@@ -18,6 +18,8 @@ class Squashfuse(AutotoolsPackage):
     license("BSD-2-Clause")
 
     version("master", branch="master")
+    version("0.5.2", sha256="54e4baaa20796e86a214a1f62bab07c7c361fb7a598375576d585712691178f5")
+    version("0.5.1", sha256="4dd81ea10323078193e5435ad8481b59f3ac8539648ddc732bcaea50b13966c9")
     version("0.5.0", sha256="d7602c7a3b1d0512764547d27cb8cc99d1b21181e1c9819e76461ee96c2ab4d9")
     version("0.4.0", sha256="646e31449b7914d2404933aea88f8d5f72c5d135d7deae3370ccb394c40d114a")
     version("0.2.0", sha256="e8eea1b013b41d0a320e5a07b131bc70df14e6b3f2d3a849bdee66d100186f4f")


### PR DESCRIPTION
I thought this was going to be a simple version bump. I was wrong.

Apptainer requires newer versions of squashfuse and such now. It also restricts how these are found so we have to modify the config to add in spack installed prefixes to the search path.