### PR TITLE
spack checksum: do not add expand=False to wheels

### DIFF
--- a/lib/spack/spack/util/format.py
+++ b/lib/spack/spack/util/format.py
@@ -21,16 +21,11 @@ def get_version_lines(version_hashes_dict: dict, url_dict: Optional[dict] = None
     version_lines = []
 
     for v, h in version_hashes_dict.items():
-        expand_arg = ""
-
         # Extract the url for a version if url_dict is provided.
         url = ""
         if url_dict is not None and v in url_dict:
             url = url_dict[v]
 
-        # Add expand_arg since wheels should not be expanded during stanging
-        if url.endswith(".whl") or ".whl#" in url:
-            expand_arg = ", expand=False"
-        version_lines.append(f'    version("{v}", sha256="{h}"{expand_arg})')
+        version_lines.append(f'    version("{v}", sha256="{h}")')
 
     return "\n".join(version_lines)

--- a/lib/spack/spack/util/format.py
+++ b/lib/spack/spack/util/format.py
@@ -21,11 +21,6 @@ def get_version_lines(version_hashes_dict: dict, url_dict: Optional[dict] = None
     version_lines = []
 
     for v, h in version_hashes_dict.items():
-        # Extract the url for a version if url_dict is provided.
-        url = ""
-        if url_dict is not None and v in url_dict:
-            url = url_dict[v]
-
         version_lines.append(f'    version("{v}", sha256="{h}")')
 
     return "\n".join(version_lines)


### PR DESCRIPTION
Now that @haampie's #43317 has been merged, `spack checksum` no longer needs to add `expand=False` to all versions. Easiest way to test this is with a package like setuptools.