### PR TITLE
Bump version on `develop` to v0.23dev0

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-__version__ = "0.22.0.dev0"
+__version__ = "0.23.0.dev0"
 spack_version = __version__
 
 


### PR DESCRIPTION
We're releasing v0.22, so update develop to v0.23dev0.