### PR TITLE
nvhpc: Do not use `-Wno-error` with `nvhpc`

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -931,8 +931,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
         Valid return values are:
         * ``"all"``: keep all ``-Werror`` flags.
         * ``"specific"``: keep only ``-Werror=specific-warning`` flags.
-        * ``"none"``: filter out all ``-Werror*`` flags (this is the default).
-        * ``None``: respect the user's configuration.
+        * ``"none"``: filter out all ``-Werror*`` flags.
+        * ``None``: respect the user's configuration (``"none"`` by default).
         """
         if self.spec.satisfies("%nvhpc@:23.3") or self.spec.satisfies("%pgi"):
             # Filtering works by replacing -Werror with -Wno-error, but older nvhpc and

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -617,10 +617,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
     #: By default do not run tests within package's install()
     run_tests = False
 
-    #: Keep -Werror flags, matches config:flags:keep_werror to override config
-    # NOTE: should be type Optional[Literal['all', 'specific', 'none']] in 3.8+
-    keep_werror: Optional[str] = None
-
     #: Most packages are NOT extendable. Set to True if you want extensions.
     extendable = False
 
@@ -925,6 +921,32 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
         return os.path.join(
             self.global_license_dir, self.name, os.path.basename(self.license_files[0])
         )
+
+    # NOTE: return type should be Optional[Literal['all', 'specific', 'none']] in
+    # Python 3.8+, but we still support 3.6.
+    @property
+    def keep_werror(self) -> Optional[str]:
+        """Keep ``-Werror`` flags, matches ``config:flags:keep_werror`` to override config.
+
+        Valid return values are:
+        * ``"all"``: keep all ``-Werror`` flags.
+        * ``"specific"``: keep only ``-Werror=specific-warning`` flags.
+        * ``"none"``: filter out all ``-Werror*`` flags (this is the default).
+        * ``None``: respect the user's configuration.
+        """
+        if self.spec.satisfies("%nvhpc@:23.3") or self.spec.satisfies("%pgi"):
+            # Filtering works by replacing -Werror with -Wno-error, but older nvhpc and
+            # PGI do not understand -Wno-error, so we disable filtering.
+            return "all"
+
+        elif self.spec.satisfies("%nvhpc@23.4:"):
+            # newer nvhpc supports -Wno-error but can't disable specific warnings with
+            # -Wno-error=warning. Skip -Werror=warning, but still filter -Werror.
+            return "specific"
+
+        else:
+            # use -Werror disablement by default for other compilers
+            return None
 
     @property
     def version(self):

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -828,14 +828,14 @@ def test_keep_and_replace(wrapper_environment):
         ),
         (
             "config:flags:keep_werror:specific",
-            ["-Werror", "-Werror=specific", "-bah"],
-            ["-Werror=specific", "-bah"],
+            ["-Werror", "-Werror=specific", "-Werror-specific2", "-bah"],
+            ["-Wno-error", "-Werror=specific", "-Werror-specific2", "-bah"],
             ["-Werror"],
         ),
         (
             "config:flags:keep_werror:none",
             ["-Werror", "-Werror=specific", "-bah"],
-            ["-bah", "-Wno-error", "-Wno-error=specific"],
+            ["-Wno-error", "-Wno-error=specific", "-bah"],
             ["-Werror", "-Werror=specific"],
         ),
         # check non-standard -Werror opts like -Werror-implicit-function-declaration
@@ -848,13 +848,13 @@ def test_keep_and_replace(wrapper_environment):
         (
             "config:flags:keep_werror:specific",
             ["-Werror", "-Werror-implicit-function-declaration", "-bah"],
-            ["-Werror-implicit-function-declaration", "-bah", "-Wno-error"],
+            ["-Wno-error", "-Werror-implicit-function-declaration", "-bah"],
             ["-Werror"],
         ),
         (
             "config:flags:keep_werror:none",
             ["-Werror", "-Werror-implicit-function-declaration", "-bah"],
-            ["-bah", "-Wno-error=implicit-function-declaration"],
+            ["-Wno-error", "-bah", "-Wno-error=implicit-function-declaration"],
             ["-Werror", "-Werror-implicit-function-declaration"],
         ),
     ],


### PR DESCRIPTION
Closes #36961.
Closes #35235.

In #30882, we made Spack ignore `-Werror` calls so that it could more easily build projects that inject `-Werror` into their builds. We did this by translating them to `-Wno-error` in the compiler wrapper. However, some compilers (like `nvhpc`) do not support `-Wno-error`. We need to exclude them from this feature until they do.

- [x] make a property on `PackageBase` for `keep_werror` that knows not to use it for `nvhpc`.
