### PR TITLE
lzo: ensure #include <lzo/lzo1x.h> works with pkgconf cflags `-I${includedir}/lzo`

### DIFF
--- a/var/spack/repos/builtin/packages/lzo/package.py
+++ b/var/spack/repos/builtin/packages/lzo/package.py
@@ -34,7 +34,7 @@ class Lzo(AutotoolsPackage):
         args += self.enable_or_disable("libs")
         return args
 
-    @run_after('install')
+    @run_after("install")
     def postinstall(self):
         # ensure e.g. #include <lzo/lzo1x.h> works with Cflags: -I${includedir}/lzo in pkgconf
         # by creating symlink ${includedir}/lzo/lzo -> ${includedir}/lzo

--- a/var/spack/repos/builtin/packages/lzo/package.py
+++ b/var/spack/repos/builtin/packages/lzo/package.py
@@ -33,3 +33,10 @@ class Lzo(AutotoolsPackage):
         args = ["--disable-dependency-tracking"]
         args += self.enable_or_disable("libs")
         return args
+
+    @run_after('install')
+    def postinstall(self):
+        # ensure e.g. #include <lzo/lzo1x.h> works with Cflags: -I${includedir}/lzo in pkgconf
+        # by creating symlink ${includedir}/lzo/lzo -> ${includedir}/lzo
+        with working_dir(self.prefix.include.lzo):
+            symlink(".", "lzo")


### PR DESCRIPTION
Downstream packages from lzo, e.g. squashfuse, [use](https://github.com/vasi/squashfuse/blob/94f998c58d2bb6dff00173f33140a0354adce324/decompress.c#L133) `#include <lzo/lzo1x.h>`, while the `lzo2.pc` file contains `Cflags: -I${includedir}/lzo` (no direct link available). These two are not compatible since it leads to a search for `lzo/lzo1x.h` under `<prefix>/include/lzo/` where it does not exist.

Squashfuse doesn't use pkgconf (it uses a custom m4 macro that returns [cppflags](https://github.com/vasi/squashfuse/blob/94f998c58d2bb6dff00173f33140a0354adce324/m4/squashfuse_decompress.m4#L42) ending at include/), but packages using pkgconf will run into problems. An example of a package that picks up lzo through pkgconf is cairo, after transition from autotools to meson, in particular when using environments that pull in lzo (since it is not a direct dependency of cairo, but pkgconfig picks up lzo2.pc through the shared view `<prefix>/lib/pkgconfig`).

This PR adds the recursive link `<prefix>/include/lzo/lzo` -> `<prefix>/include/lzo` to ensure that includes will resolve correctly when meson uses pkgconfig to set cflags.

With this PR we get
```console
$ ls -al $(spack location -i lzo)/include/lzo
total 216
drwxr-sr-x 2 wdconinc wdconinc   4096 May 12 19:15 .
drwxr-sr-x 3 wdconinc wdconinc   4096 May 12 19:15 ..
lrwxrwxrwx 1 wdconinc wdconinc      1 May 12 19:15 lzo -> .
-rw-r--r-- 1 wdconinc wdconinc   2638 May 12 19:15 lzo1a.h
-rw-r--r-- 1 wdconinc wdconinc   5387 May 12 19:15 lzo1b.h
-rw-r--r-- 1 wdconinc wdconinc   5384 May 12 19:15 lzo1c.h
-rw-r--r-- 1 wdconinc wdconinc   3073 May 12 19:15 lzo1f.h
-rw-r--r-- 1 wdconinc wdconinc   2634 May 12 19:15 lzo1.h
-rw-r--r-- 1 wdconinc wdconinc   5873 May 12 19:15 lzo1x.h
-rw-r--r-- 1 wdconinc wdconinc   4641 May 12 19:15 lzo1y.h
-rw-r--r-- 1 wdconinc wdconinc   3771 May 12 19:15 lzo1z.h
-rw-r--r-- 1 wdconinc wdconinc   2525 May 12 19:15 lzo2a.h
-rw-r--r-- 1 wdconinc wdconinc   5566 May 12 19:15 lzo_asm.h
-rw-r--r-- 1 wdconinc wdconinc  16006 May 12 19:15 lzoconf.h
-rw-r--r-- 1 wdconinc wdconinc 127289 May 12 19:15 lzodefs.h
-rw-r--r-- 1 wdconinc wdconinc   1823 May 12 19:15 lzoutil.h
```