### PR TITLE
Add `mpas-model` and `mpich` to pcluster neoverse stack

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
@@ -4,8 +4,8 @@ spack:
   definitions:
   - apps:
     - gromacs
-    # - mpas-model: Spack currently forces REAL(8) when using GCC. This conflicts with `precision=single`
-    # Fix proposed in https://github.com/spack/spack/pull/43547
+    - mpas-model
+    - mpich
     - openfoam
     # - quantum-espresso : %gcc@12.3.0 on neoverse_v1 fails.
     # Root cause: internal compiler error: in compute_live_loop_exits, at tree-ssa-loop-manip.cc:247


### PR DESCRIPTION
Should build now since https://github.com/spack/spack/pull/43547 has been merged.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
