### PR TITLE
glibc: detect from "Free Software Foundation" not "gnu"

### DIFF
--- a/lib/spack/spack/util/libc.py
+++ b/lib/spack/spack/util/libc.py
@@ -22,7 +22,7 @@ def _libc_from_ldd(ldd: str) -> Optional["spack.spec.Spec"]:
     except Exception:
         return None
 
-    if not re.search(r"\b(?:gnu|glibc|arm)\b", stdout, re.IGNORECASE):
+    if not re.search(r"\bFree Software Foundation\b", stdout):
         return None
 
     version_str = re.match(r".+\(.+\) (.+)", stdout)
@@ -75,7 +75,7 @@ def libc_from_dynamic_linker(dynamic_linker: str) -> Optional["spack.spec.Spec"]
             return spec
         except Exception:
             return None
-    elif re.search(r"\b(?:gnu|glibc|arm)\b", stdout, re.IGNORECASE):
+    elif re.search(r"\bFree Software Foundation\b", stdout):
         # output is like "ld.so (...) stable release version 2.33."
         match = re.search(r"version (\d+\.\d+(?:\.\d+)?)", stdout)
         if not match:


### PR DESCRIPTION
Closes #44145

`ld.so --version` and `ldd --version` do not always contain `gnu` but seem to
consistently mention the free software foundation, so let's use that for
detection.
