### PR TITLE
bugfix: external detection for compilers with os but not target

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -220,8 +220,9 @@ def _compiler_config_from_external(config):
         operating_system = host_platform.operating_system("default_os")
         target = host_platform.target("default_target").microarchitecture
     else:
-        target = spec.architecture.target
-        if not target:
+        if spec.architecture.target:
+            target = spec.architecture.target.microarchitecture
+        else:
             host_platform = spack.platforms.host()
             target = host_platform.target("default_target").microarchitecture
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -220,11 +220,10 @@ def _compiler_config_from_external(config):
         operating_system = host_platform.operating_system("default_os")
         target = host_platform.target("default_target").microarchitecture
     else:
-        if spec.architecture.target:
-            target = spec.architecture.target.microarchitecture
-        else:
-            host_platform = spack.platforms.host()
-            target = host_platform.target("default_target").microarchitecture
+        target = spec.architecture.target
+        if not target:
+            target = spack.platforms.host().target("default_target")
+        target = target.microarchitecture
 
         operating_system = spec.os
         if not operating_system:

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -220,7 +220,7 @@ def _compiler_config_from_external(config):
         operating_system = host_platform.operating_system("default_os")
         target = host_platform.target("default_target").microarchitecture
     else:
-        target = spec.target
+        target = spec.architecture.target
         if not target:
             host_platform = spack.platforms.host()
             target = host_platform.target("default_target").microarchitecture


### PR DESCRIPTION
avoid calling `spec.target` when None.

When an external compiler package has an `os` set but no `target` set, Spack currently falls into a codepath that calls `spec.target` (which itself calls `spec.architecture.target.Microarchitecture`) when `spec.architecture.target` is None, throwing an error.

e.g.

```
packages:
  gcc:
    externals:
    - spec: gcc@12.3.1 os=rhel7
      prefix: /usr
```
