### PR TITLE
Revert: c3b131e

### DIFF
--- a/lib/spack/spack/hooks/windows_runtime_linkage.py
+++ b/lib/spack/spack/hooks/windows_runtime_linkage.py
@@ -1,8 +1,0 @@
-# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
-#
-# SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-
-def post_install(spec, explicit=None):
-    spec.package.windows_establish_runtime_linkage()

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1699,6 +1699,10 @@ class PackageInstaller:
             spack.package_base.PackageBase._verbose = spack.build_environment.start_build_process(
                 pkg, build_process, install_args
             )
+            # Currently this is how RPATH-like behavior is achieved on Windows, after install
+            # establish runtime linkage via Windows Runtime link object
+            # Note: this is a no-op on non Windows platforms
+            pkg.windows_establish_runtime_linkage()
             # Note: PARENT of the build process adds the new package to
             # the database, so that we don't need to re-read from file.
             spack.store.STORE.db.add(pkg.spec, spack.store.STORE.layout, explicit=explicit)


### PR DESCRIPTION
Fixes #44163
Reopens #42445

https://github.com/spack/spack/pull/40773/commits/c3b131e44cabbc54f96a45bdeda596433f63e2ab

Windows change made out of context that breaks develop should be reverted.

> Note: Not entirely clear on the surface _why_ this change breaks linking on Windows, this is a stop gap until we can make the change suggested in https://github.com/spack/spack/issues/42445 without breaking anything.