### PR TITLE
Fix lib/include paths with oneapi

### DIFF
--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -307,8 +307,8 @@ class Tau(Package):
                 env["F77"] = spec["mpi"].mpif77
                 env["FC"] = spec["mpi"].mpifc
             if spec["mpi"].name == "intel-oneapi-mpi":
-                options.append("-mpiinc=%s" % spec["mpi"].package.component_prefix)
-                options.append("-mpilib=%s" % spec["mpi"].package.component_prefix)
+                options.append("-mpiinc=%s/include" % spec["mpi"].package.component_prefix)
+                options.append("-mpilib=%s/lib" % spec["mpi"].package.component_prefix)
             else:
                 options.append("-mpiinc=%s" % spec["mpi"].prefix.include)
                 options.append("-mpilib=%s" % spec["mpi"].prefix.lib)


### PR DESCRIPTION
Is there a better way to handle this? Do we need to check for lib vs lib64?
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
