### PR TITLE
py-matplotlib: qualify when to do a post install

### DIFF
--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -330,7 +330,7 @@ class PyMatplotlib(PythonPackage):
                 if self.spec.satisfies("%clang") or self.spec.satisfies("%oneapi"):
                     config.write("enable_lto = False\n")
 
-    @run_after("install")
+    @run_after("install",when="@3.6:")
     def copy_reference_images(self):
         # https://matplotlib.org/devdocs/devel/testing.html#obtain-the-reference-images
         install_tree(

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -330,17 +330,24 @@ class PyMatplotlib(PythonPackage):
                 if self.spec.satisfies("%clang") or self.spec.satisfies("%oneapi"):
                     config.write("enable_lto = False\n")
 
-    @run_after("install",when="@3.6:")
+    @run_after("install")
+    @on_package_attributes(run_tests=True)
     def copy_reference_images(self):
         # https://matplotlib.org/devdocs/devel/testing.html#obtain-the-reference-images
         install_tree(
             join_path("lib", "matplotlib", "tests", "baseline_images"),
             join_path(python_platlib, "matplotlib", "tests", "baseline_images"),
         )
-        for toolkit in ["axes_grid1", "axisartist", "mplot3d"]:
+        if self.spec.satisfies("@3.7:"):
+            for toolkit in ["axes_grid1", "axisartist", "mplot3d"]:
+                install_tree(
+                    join_path("lib", "mpl_toolkits", toolkit, "tests", "baseline_images"),
+                    join_path(python_platlib, "mpl_toolkits", toolkit, "tests", "baseline_images"),
+                )
+        else:
             install_tree(
-                join_path("lib", "mpl_toolkits", toolkit, "tests", "baseline_images"),
-                join_path(python_platlib, "mpl_toolkits", toolkit, "tests", "baseline_images"),
+                join_path("lib", "mpl_toolkits", "tests", "baseline_images"),
+                join_path(python_platlib, "mpl_toolkits", "tests", "baseline_images"),
             )
 
     @run_after("install")
@@ -348,5 +355,8 @@ class PyMatplotlib(PythonPackage):
     def install_test(self):
         # https://matplotlib.org/devdocs/devel/testing.html#run-the-tests
         python("-m", "pytest", "--pyargs", "matplotlib.tests")
-        for toolkit in ["axes_grid1", "axisartist", "mplot3d"]:
-            python("-m", "pytest", "--pyargs", f"mpl_toolkits.{toolkit}.tests")
+        if self.spec.satisfies("@3.7:"):
+            for toolkit in ["axes_grid1", "axisartist", "mplot3d"]:
+                python("-m", "pytest", "--pyargs", f"mpl_toolkits.{toolkit}.tests")
+        else:
+            python("-m", "pytest", "--pyargs", "mpl_toolkits.tests")


### PR DESCRIPTION
Older versions of py-matplotlib don't seem to have some of the files that the post install step is trying to install. Looks like the files first appeared in 3.6.0 and later.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
