### PR TITLE
Add more granular bootstrap spec for Win

### DIFF
--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -224,7 +224,6 @@ def _root_spec(spec_str: str) -> str:
         spec_str += " %gcc"
     elif platform == "freebsd":
         spec_str += " %clang"
-    # Note: this may be too restrictive for freebsd
     spec_str += f" platform={platform}"
     target = archspec.cpu.host().family
     spec_str += f" target={target}"

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -213,10 +213,12 @@ def _root_spec(spec_str: str) -> str:
     Args:
         spec_str: spec to be bootstrapped. Must be without compiler and target.
     """
-    # Add a compiler requirement to the root spec.
+    # Add a compiler and platform requirement to the root spec.
     platform = str(spack.platforms.host())
     if platform == "darwin":
         spec_str += " %apple-clang"
+    elif platform == "windows":
+        spec_str += " %msvc platform=windows"
     elif platform == "linux":
         spec_str += " %gcc"
     elif platform == "freebsd":

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -215,15 +215,17 @@ def _root_spec(spec_str: str) -> str:
     """
     # Add a compiler and platform requirement to the root spec.
     platform = str(spack.platforms.host())
+
     if platform == "darwin":
         spec_str += " %apple-clang"
     elif platform == "windows":
-        spec_str += " %msvc platform=windows"
+        spec_str += " %msvc"
     elif platform == "linux":
         spec_str += " %gcc"
     elif platform == "freebsd":
         spec_str += " %clang"
-
+    # Note: this may be too restrictive for freebsd
+    spec_str += f" platform={platform}"
     target = archspec.cpu.host().family
     spec_str += f" target={target}"
 


### PR DESCRIPTION
Windows bootstrap is getting cache hits from Darwin build caches. Make the spec Windows specific when bootstrapping on that platform.