### PR TITLE
protobuf: update hash for patch needed when="@3.4:3.21"

### DIFF
--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -112,7 +112,7 @@ class Protobuf(CMakePackage):
     patch(
         "https://github.com/protocolbuffers/protobuf/commit/3039f932aaf212bcf2f14a3f2fd00dbfb881e46b.patch?full_index=1",
         when="@3.4:3.21",
-        sha256="ae8639a308294bed85d3f6ebb7e005ee4fde6b2884d41cb75543191c9c5c98ef",
+        sha256="a779238fb7957514d4fb393410111419a964771e826ec2a8f09c21aa1efbb4d1",
     )
 
     patch("msvc-abseil-target-namespace.patch", when="@3.22 %msvc")

--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -110,7 +110,7 @@ class Protobuf(CMakePackage):
 
     # fix build on Centos 8, see also https://github.com/protocolbuffers/protobuf/issues/5144
     patch(
-        "https://github.com/protocolbuffers/protobuf/pull/11032/commits/3039f932aaf212bcf2f14a3f2fd00dbfb881e46b.patch?full_index=1",
+        "https://github.com/protocolbuffers/protobuf/commit/3039f932aaf212bcf2f14a3f2fd00dbfb881e46b.patch?full_index=1",
         when="@3.4:3.21",
         sha256="ae8639a308294bed85d3f6ebb7e005ee4fde6b2884d41cb75543191c9c5c98ef",
     )

--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -112,7 +112,7 @@ class Protobuf(CMakePackage):
     patch(
         "https://github.com/protocolbuffers/protobuf/pull/11032/commits/3039f932aaf212bcf2f14a3f2fd00dbfb881e46b.patch?full_index=1",
         when="@3.4:3.21",
-        sha256="cefc4bf4aadf9ca33a336b2aa6d0d82006b6563e85122ae8cfb70345f85321dd",
+        sha256="ae8639a308294bed85d3f6ebb7e005ee4fde6b2884d41cb75543191c9c5c98ef",
     )
 
     patch("msvc-abseil-target-namespace.patch", when="@3.22 %msvc")


### PR DESCRIPTION
Doing a download of the patch 'manually' via, e.g.

* `wget https://github.com/protocolbuffers/protobuf/pull/11032/commits/3039f932aaf212bcf2f14a3f2fd00dbfb881e46b.patch?full_index=1`

gets a different hash than what Spack currently expects:

```
$ sha256sum 3039f932aaf212bcf2f14a3f2fd00dbfb881e46b.patch\?full_index\=1
ae8639a308294bed85d3f6ebb7e005ee4fde6b2884d41cb75543191c9c5c98ef 3039f932aaf212bcf2f14a3f2fd00dbfb881e46b.patch?full_index=1
```

This old(er) version of Protobuf is pulled in by, _e.g._, py-torch (which seems to need older versions).
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
