### PR TITLE
exodusii: only use MPI fortran compiler if +fortran

### DIFF
--- a/var/spack/repos/builtin/packages/exodusii/package.py
+++ b/var/spack/repos/builtin/packages/exodusii/package.py
@@ -180,10 +180,11 @@ class Exodusii(CMakePackage):
                 [
                     define("CMAKE_C_COMPILER", spec["mpi"].mpicc),
                     define("CMAKE_CXX_COMPILER", spec["mpi"].mpicxx),
-                    define("CMAKE_Fortran_COMPILER", spec["mpi"].mpifc),
                     define("MPI_BASE_DIR", spec["mpi"].prefix),
                 ]
             )
+            if "+fortran" in self.spec:
+                options.append(define("CMAKE_Fortran_COMPILER", spec["mpi"].mpifc))
 
         # ##################### Dependencies ##########################
         # Always need NetCDF-C


### PR DESCRIPTION
The exodusii package was asking for a MPI Fortran compiler even for `~fortran`. `spec['mpi'].mpifc` isn't defined if e.g. with `mpich~fortran`.
