### PR TITLE
suite-sparse: improve setting of the `libs` property

### DIFF
--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -311,5 +311,8 @@ class SuiteSparse(Package):
         return find_libraries(
             # Libraries may be installed under both `lib/` and `lib64/`,
             # don't force searching under `lib/` only.
-            ["lib" + c for c in comps], root=self.prefix, shared=True, recursive=True
+            ["lib" + c for c in comps],
+            root=self.prefix,
+            shared=True,
+            recursive=True,
         )

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -309,5 +309,7 @@ class SuiteSparse(Package):
         query_parameters = self.spec.last_query.extra_parameters
         comps = all_comps if not query_parameters else query_parameters
         return find_libraries(
-            ["lib" + c for c in comps], root=self.prefix.lib, shared=True, recursive=False
+            # Libraries may be installed under both `lib/` and `lib64/`,
+            # don't force searching under `lib/` only.
+            ["lib" + c for c in comps], root=self.prefix, shared=True, recursive=True
         )


### PR DESCRIPTION
The current definition searches for libraries only under `lib/`, but they may also be under `lib64/`.  This resolves for me a build issue of `julia` on MareNostrum 5.  CC: @mofeing.