### PR TITLE
Fix Broken Link to Spack.io on Intel OneAPI Package Page

### DIFF
--- a/lib/spack/docs/build_systems/inteloneapipackage.rst
+++ b/lib/spack/docs/build_systems/inteloneapipackage.rst
@@ -25,7 +25,7 @@ use Spack to build packages with the tools.
 The Spack Python class ``IntelOneapiPackage`` is a base class that is
 used by ``IntelOneapiCompilers``, ``IntelOneapiMkl``,
 ``IntelOneapiTbb`` and other classes to implement the oneAPI
-packages. Search for ``oneAPI`` at `<packages.spack.io>`_ for the full
+packages. Search for ``oneAPI`` at `packages.spack.io <https://packages.spack.io>`_ for the full
 list of available oneAPI packages, or use::
 
   spack list -d oneAPI


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This pull request addresses a broken link found on the [IntelOneApiPackage](https://spack.readthedocs.io/en/latest/build_systems/inteloneapipackage.html) documentation page. The existing link, intended to direct users to the Spack.io package listings, is currently not functioning as expected.