### PR TITLE
libcatalyst: add missing python dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/libcatalyst/package.py
+++ b/var/spack/repos/builtin/packages/libcatalyst/package.py
@@ -32,6 +32,8 @@ class Libcatalyst(CMakePackage):
     depends_on("mpi", when="+mpi")
     depends_on("conduit", when="+conduit")
     depends_on("cmake@3.26:", type="build")
+    depends_on("python@3:", when="+python")
+    depends_on("py-numpy", when="+python")
 
     def cmake_args(self):
         """Populate cmake arguments for libcatalyst."""

--- a/var/spack/repos/builtin/packages/libcatalyst/package.py
+++ b/var/spack/repos/builtin/packages/libcatalyst/package.py
@@ -33,7 +33,7 @@ class Libcatalyst(CMakePackage):
     depends_on("conduit", when="+conduit")
     depends_on("cmake@3.26:", type="build")
     depends_on("python@3:", when="+python")
-    depends_on("py-numpy", when="+python")
+    depends_on("py-numpy", when="+python", type=("build", "link", "run"))
 
     def cmake_args(self):
         """Populate cmake arguments for libcatalyst."""


### PR DESCRIPTION
According to [source code](https://gitlab.kitware.com/paraview/catalyst/-/blob/master/CMakeLists.txt#L16-18), `libcatalyst+python` should depend on `python` (at least version 3) and `py-numpy` when built with `CATALYST_WRAP_PYTHON=ON`.

Not sure about link type. If there are no information about linking type, I would leave it like this for now.
