### PR TITLE
Make `spack clean` env-aware

### DIFF
--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -106,7 +106,8 @@ def clean(parser, args):
 
     # Then do the cleaning falling through the cases
     if args.specs:
-        specs = list(spack.cmd.matching_spec_from_env(x) for x in args.specs)
+        specs = spack.cmd.parse_specs(args.specs, concretize=False)
+        specs = list(spack.cmd.matching_spec_from_env(x) for x in specs)
         for spec in specs:
             msg = "Cleaning build stage [{0}]"
             tty.msg(msg.format(spec.short_spec))

--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -106,7 +106,7 @@ def clean(parser, args):
 
     # Then do the cleaning falling through the cases
     if args.specs:
-        specs = spack.cmd.parse_specs(args.specs, concretize=True)
+        specs = list(spack.cmd.matching_spec_from_env(x) for x in args.specs)
         for spec in specs:
             msg = "Cleaning build stage [{0}]"
             tty.msg(msg.format(spec.short_spec))

--- a/lib/spack/spack/test/cmd/clean.py
+++ b/lib/spack/spack/test/cmd/clean.py
@@ -11,6 +11,7 @@ import llnl.util.filesystem as fs
 
 import spack.caches
 import spack.cmd.clean
+import spack.environment as ev
 import spack.main
 import spack.package_base
 import spack.stage
@@ -66,6 +67,20 @@ def test_function_calls(command_line, effects, mock_calls_for_clean):
     # number of times
     for name in ["package"] + all_effects:
         assert mock_calls_for_clean[name] == (1 if name in effects else 0)
+
+
+def test_env_aware_clean(mock_stage, install_mockery, mutable_mock_env_path, monkeypatch):
+    e = ev.create("test", with_view=False)
+    e.add("mpileaks")
+    e.concretize()
+
+    def fail(*args, **kwargs):
+        raise Exception("This should not have been called")
+
+    monkeypatch.setattr(spack.spec.Spec, "concretize", fail)
+
+    with e:
+        clean("mpileaks")
 
 
 def test_remove_python_cache(tmpdir, monkeypatch):


### PR DESCRIPTION
`spack clean <spec>` will now resolve specs based on the active environment if one is active.

If an env is active but no matching spec is found, this will fall back on fully concretizing.