### PR TITLE
Add new maintainers to fenics-ufcx

### DIFF
--- a/var/spack/repos/builtin/packages/fenics-ufcx/package.py
+++ b/var/spack/repos/builtin/packages/fenics-ufcx/package.py
@@ -14,7 +14,7 @@ class FenicsUfcx(CMakePackage):
     homepage = "https://github.com/FEniCS/ffcx"
     git = "https://github.com/FEniCS/ffcx.git"
     url = "https://github.com/FEniCS/ffcx/archive/v0.4.2.tar.gz"
-    maintainers("ma595", "jhale")
+    maintainers("ma595", "jhale", "garth-wells", "chrisrichardson")
 
     license("LGPL-3.0-or-later")
 


### PR DESCRIPTION
Add Chris Richardson and Garth Wells to maintainers.

Both are FEniCS Project Steering Council members.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
