### PR TITLE
intel-oneapi-mkl: change logic for gfortran compatibility

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -5,6 +5,8 @@
 
 from os.path import dirname, isdir
 
+from llnl.util import tty
+
 from spack.package import *
 
 
@@ -208,8 +210,11 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         # cmake for the library list and they have to be consistent.
         # https://github.com/spack/spack/pull/43673 for discussion
         if self.spec.satisfies("+gfortran"):
+            depends_on("fortran", type="build")
             libs.append(self._xlp64_lib("libmkl_gf"))
         else:
+            if self.spec.satisfies("^[virtuals=fortran-rt] gcc-runtime"):
+                tty.warn("Use intel-oneapi-mkl +gfortran for GNU Fortran support")
             libs.append(self._xlp64_lib("libmkl_intel"))
 
         if self.spec.satisfies("threads=tbb"):

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -111,6 +111,8 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         expand=False,
     )
 
+    variant("gfortran", default=False, description="Compatibility with Gnu Fortran")
+
     variant("shared", default=True, description="Builds shared library")
     variant("ilp64", default=False, description="Build with ILP64 support")
     variant(
@@ -200,10 +202,15 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         if self.spec.satisfies("+cluster"):
             libs.extend([self._xlp64_lib("libmkl_scalapack"), "libmkl_cdft_core"])
 
-        if self.spec.satisfies("%oneapi") or self.spec.satisfies("%intel"):
-            libs.append(self._xlp64_lib("libmkl_intel"))
-        else:
+        # Explicit variant for compatibility with gfortran, otherwise
+        # support intel fortran. Be aware that some dependencies may
+        # be using this logic and other dependencies might be using
+        # cmake for the library list and they have to be consistent.
+        # https://github.com/spack/spack/pull/43673 for discussion
+        if self.spec.satisfies("+gfortran"):
             libs.append(self._xlp64_lib("libmkl_gf"))
+        else:
+            libs.append(self._xlp64_lib("libmkl_intel"))
 
         if self.spec.satisfies("threads=tbb"):
             libs.append("libmkl_tbb_thread")

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -5,8 +5,6 @@
 
 from os.path import dirname, isdir
 
-from llnl.util import tty
-
 from spack.package import *
 
 
@@ -213,8 +211,6 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
             depends_on("fortran", type="build")
             libs.append(self._xlp64_lib("libmkl_gf"))
         else:
-            if self.spec.satisfies("^[virtuals=fortran-rt] gcc-runtime"):
-                tty.warn("Use intel-oneapi-mkl +gfortran for GNU Fortran support")
             libs.append(self._xlp64_lib("libmkl_intel"))
 
         if self.spec.satisfies("threads=tbb"):

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -111,7 +111,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         expand=False,
     )
 
-    variant("gfortran", default=False, description="Compatibility with Gnu Fortran")
+    variant("gfortran", default=False, description="Compatibility with GNU Fortran")
 
     variant("shared", default=True, description="Builds shared library")
     variant("ilp64", default=False, description="Build with ILP64 support")


### PR DESCRIPTION
Use a variant to request gfortran compatibility instead of toolchain.
See discussion in https://github.com/spack/spack/pull/43673

@RMeli: Can you test your example. I testing: `spack install dla-future ^intel-oneapi-mkl`