### PR TITLE
paraview: update cuda_arch management

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -176,8 +176,8 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     # Starting from cmake@3.18, CUDA architecture managament can be delegated to CMake.
     # Hence, it is possible to rely on it instead of relying on custom logic updates from VTK-m for
     # newer architectures (wrt mapping).
-    for cuda_arch in filter(lambda x: x > 86, map(int, CudaPackage.cuda_arch_values)):
-        conflicts("cmake@:3.17", when=f"cuda_arch={cuda_arch}")
+    for _arch in [arch for arch in CudaPackage.cuda_arch_values if int(arch) > 86]:
+        conflicts("cmake@:3.17", when=f"cuda_arch={_arch}")
 
     # We only support one single Architecture
     for _arch, _other_arch in itertools.permutations(CudaPackage.cuda_arch_values, 2):

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -171,7 +171,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
 
     # VTK-m and transitively ParaView does not support Tesla Arch
     for _arch in range(10, 14):
-        conflicts("cuda_arch=%d" % _arch, when="+cuda", msg="ParaView requires cuda_arch >= 20")
+        conflicts(f"cuda_arch={_arch}", when="+cuda", msg="ParaView requires cuda_arch >= 20")
 
     # Starting from cmake@3.18, CUDA architecture managament can be delegated to CMake.
     # Hence, it is possible to rely on it instead of relying on custom logic updates from VTK-m for

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -145,6 +145,40 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
         msg="Use paraview@5.9.0 with %xl_r. Earlier versions are not able to build with xl.",
     )
 
+    # CUDA ARCH
+
+    # This is (more or less) the mapping hard-coded in VTK-m logic
+    # see https://gitlab.kitware.com/vtk/vtk-m/-/blob/v2.1.0/CMake/VTKmDeviceAdapters.cmake?ref_type=tags#L221-247
+    supported_cuda_archs = {
+        "20": "fermi",
+        "21": "fermi",
+        "30": "kepler",
+        "32": "kepler",
+        "35": "kepler",
+        "37": "kepler",
+        "50": "maxwel",
+        "52": "maxwel",
+        "53": "maxwel",
+        "60": "pascal",
+        "61": "pascal",
+        "62": "pascal",
+        "70": "volta",
+        "72": "volta",
+        "75": "turing",
+        "80": "ampere",
+        "86": "ampere",
+    }
+
+    # VTK-m and transitively ParaView does not support Tesla Arch
+    for _arch in range(10, 14):
+        conflicts("cuda_arch=%d" % _arch, when="+cuda", msg="ParaView requires cuda_arch >= 20")
+
+    # Starting from cmake@3.18, CUDA architecture managament can be delegated to CMake.
+    # Hence, it is possible to rely on it instead of relying on custom logic updates from VTK-m for
+    # newer architectures (wrt mapping).
+    for cuda_arch in filter(lambda x: x > 86, map(int, CudaPackage.cuda_arch_values)):
+        conflicts("cmake@:3.17", when=f"cuda_arch={cuda_arch}")
+
     # We only support one single Architecture
     for _arch, _other_arch in itertools.permutations(CudaPackage.cuda_arch_values, 2):
         conflicts(
@@ -152,9 +186,6 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
             when="cuda_arch={0}".format(_other_arch),
             msg="Paraview only accepts one architecture value",
         )
-
-    for _arch in range(10, 14):
-        conflicts("cuda_arch=%d" % _arch, when="+cuda", msg="ParaView requires cuda_arch >= 20")
 
     depends_on("cmake@3.3:", type="build")
     depends_on("cmake@3.21:", type="build", when="+rocm")
@@ -583,38 +614,25 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
 
         # VTK-m expects cuda_arch to be the arch name vs. the arch version.
         if spec.satisfies("+cuda"):
-            supported_cuda_archs = {
-                # VTK-m and transitively ParaView does not support Tesla Arch
-                "20": "fermi",
-                "21": "fermi",
-                "30": "kepler",
-                "32": "kepler",
-                "35": "kepler",
-                "37": "kepler",
-                "50": "maxwel",
-                "52": "maxwel",
-                "53": "maxwel",
-                "60": "pascal",
-                "61": "pascal",
-                "62": "pascal",
-                "70": "volta",
-                "72": "volta",
-                "75": "turing",
-                "80": "ampere",
-                "86": "ampere",
-            }
+            if spec["cmake"].satisfies("@3.18:"):
+                cmake_args.append(
+                    self.define(
+                        "CMAKE_CUDA_ARCHITECTURES", ";".join(spec.variants["cuda_arch"].value)
+                    )
+                )
+            else:
+                # ParaView/VTK-m only accepts one arch, default to first element
+                requested_arch = spec.variants["cuda_arch"].value[0]
 
-            cuda_arch_value = "native"
-            requested_arch = spec.variants["cuda_arch"].value
+                if requested_arch == "none":
+                    cuda_arch_value = "native"
+                else:
+                    try:
+                        cuda_arch_value = supported_cuda_archs[requested_arch]
+                    except KeyError:
+                        raise InstallError("Incompatible cuda_arch=" + requested_arch)
 
-            # ParaView/VTK-m only accepts one arch, default to first element
-            if requested_arch[0] != "none":
-                try:
-                    cuda_arch_value = supported_cuda_archs[requested_arch[0]]
-                except KeyError:
-                    raise InstallError("Incompatible cuda_arch=" + requested_arch[0])
-
-            cmake_args.append(self.define("VTKm_CUDA_Architecture", cuda_arch_value))
+                cmake_args.append(self.define("VTKm_CUDA_Architecture", cuda_arch_value))
 
         if "darwin" in spec.architecture:
             cmake_args.extend(


### PR DESCRIPTION
As also stated in [VTK-m CMake](https://gitlab.kitware.com/vtk/vtk-m/-/blob/v2.1.0/CMake/VTKmDeviceAdapters.cmake?ref_type=tags#L131-132), prefer the CMake management for `cuda_arch` with `CMAKE_CUDA_ARCHITECTURES` (for CMake 3.18+).

Since the custom VTK-m logic would require updates for newer architectures not yet mapped (both on CMake and spack package sides), it sounded reasonable adding `cmake@3.18` as minimum requirement for newer architectures (see snippet below), where "new architectures" mean the ones not yet mapped in the CMake and in the spack package (not sure if they are going to be updated, not sure what are the plans).

https://github.com/spack/spack/blob/c1ad45e907ac30414bf47cced3e7a85c6214bd64/var/spack/repos/builtin/packages/paraview/package.py#L176-L180


Moreover, it might be worth highlighting that CMake should support also multiple CUDA architectures, but I don't know if there is any other limit related to Paraview (or one of its dependencies).

https://github.com/spack/spack/blob/c1ad45e907ac30414bf47cced3e7a85c6214bd64/var/spack/repos/builtin/packages/paraview/package.py#L182-L188

Looking forward to your comments.