### PR TITLE
bison: add missing build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -59,6 +59,7 @@ class Bison(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on("gettext", when="+color")
     depends_on("m4@1.4.6:", type=("build", "run"))
+    depends_on("texinfo", type="build")
 
     patch("pgi.patch", when="@3.0.4")
     # The NVIDIA compilers do not currently support some GNU builtins.


### PR DESCRIPTION
Building on an "empty" rocky8 image, `spack install bison` fails because it's missing the `texinfo` dependency.
```
/tmp/root/spack-stage/spack-stage-bison-3.8.2-46ttmnqkblgfi4vpdckagxhibiywho5p/spack-src/build-aux/missing: line 81: makeinfo: command not found
WARNING: 'makeinfo' is missing on your system.
         You should only need it if you modified a '.texi' file, or
         any other file indirectly affecting the aspect of the manual.
         You might want to install the Texinfo package:
         <https://www.gnu.org/software/texinfo/>
         The spurious makeinfo call might also be the consequence of
         using a buggy 'make' (AIX, DU, IRIX), in which case you might
         want to install GNU make:
         <https://www.gnu.org/software/make/>
make[2]: *** [Makefile:9582: /tmp/root/spack-stage/spack-stage-bison-3.8.2-46ttmnqkblgfi4vpdckagxhibiywho5p/spack-src/doc/bison.info] Error 127
make[2]: Leaving directory '/tmp/root/spack-stage/spack-stage-bison-3.8.2-46ttmnqkblgfi4vpdckagxhibiywho5p/spack-src/spack-build'
make[1]: *** [Makefile:10377: all-recursive] Error 1
make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-bison-3.8.2-46ttmnqkblgfi4vpdckagxhibiywho5p/spack-src/spack-build
```