### PR TITLE
gaudi: don't apply patch for 38.2

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -69,7 +69,7 @@ class Gaudi(CMakePackage):
     patch(
         "https://gitlab.cern.ch/gaudi/Gaudi/-/commit/54b727f08a685606420703098131b387d3026637.diff",
         sha256="41aa1587a3e59d49e0fa9659577073c091871c2eca1b8b237c177ab98fbacf3f",
-        when="@:38.2",
+        when="@:38.1",
     )
 
     # These dependencies are needed for a minimal Gaudi build


### PR DESCRIPTION
The patch for the list include shouldn't apply to 38.2, since it is included in that tag. See https://gitlab.cern.ch/gaudi/Gaudi/-/commit/54b727f08a685606420703098131b387d3026637.