### PR TITLE
get cupy compiling with latest cuda

### DIFF
--- a/var/spack/repos/builtin/packages/cutensor/package.py
+++ b/var/spack/repos/builtin/packages/cutensor/package.py
@@ -13,6 +13,10 @@ _versions = {
         "Linux-x86_64": "4fdebe94f0ba3933a422cff3dd05a0ef7a18552ca274dd12564056993f55471d",
         "Linux-ppc64le": "ad736acc94e88673b04a3156d7d3a408937cac32d083acdfbd8435582cbe15db",
         "Linux-aarch64": "5b9ac479b1dadaf40464ff3076e45f2ec92581c07df1258a155b5bcd142f6090",
+    },
+    "2.0.1.2": {
+        "Linux-x86_64": "ededa12ca622baad706ea0a500a358ea51146535466afabd96e558265dc586a2",
+        "Linux-ppc64le": "7176083a4dad44cb0176771be6efb3775748ad30a39292bf7b4584510f1dd811",
     }
 }
 

--- a/var/spack/repos/builtin/packages/cutensor/package.py
+++ b/var/spack/repos/builtin/packages/cutensor/package.py
@@ -17,7 +17,7 @@ _versions = {
     "2.0.1.2": {
         "Linux-x86_64": "ededa12ca622baad706ea0a500a358ea51146535466afabd96e558265dc586a2",
         "Linux-ppc64le": "7176083a4dad44cb0176771be6efb3775748ad30a39292bf7b4584510f1dd811",
-    }
+    },
 }
 
 

--- a/var/spack/repos/builtin/packages/py-cupy/package.py
+++ b/var/spack/repos/builtin/packages/py-cupy/package.py
@@ -36,10 +36,10 @@ class PyCupy(PythonPackage, CudaPackage, ROCmPackage):
     depends_on("py-fastrlock@0.5:", type=("build", "run"))
     depends_on("py-numpy@1.20:1.25", when="@:11", type=("build", "run"))
     depends_on("py-numpy@1.20:1.26", when="@12:", type=("build", "run"))
-    depends_on("py-numpy@1.22:1.29", when="@13:", type=("build", "run"))
+    depends_on("py-numpy@1.22:1.28", when="@13:", type=("build", "run"))
 
     depends_on("py-scipy@1.6:1.12", when="@:12+all", type=("build", "run"))
-    depends_on("py-scipy@1.7:1.14", when="@13:+all", type=("build", "run"))
+    depends_on("py-scipy@1.7:1.13", when="@13:+all", type=("build", "run"))
     depends_on("py-cython@0.29.22:2", when="+all", type=("build", "run"))
     depends_on("py-optuna@2:", when="+all", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/py-cupy/package.py
+++ b/var/spack/repos/builtin/packages/py-cupy/package.py
@@ -18,6 +18,7 @@ class PyCupy(PythonPackage, CudaPackage, ROCmPackage):
     homepage = "https://cupy.dev/"
     pypi = "cupy/cupy-8.0.0.tar.gz"
 
+    version("13.1.0", sha256="5caf62288481a27713384523623045380ff42e618be4245f478238ed1786f32d")
     version("12.1.0", sha256="f6d31989cdb2d96581da12822e28b102f29e254427195c2017eac327869b7320")
     version("12.0.0", sha256="61ddbbef73d50d606bd5087570645f3c91ec9176c2566784c1d486d6a3404545")
     version("11.6.0", sha256="53dbb840072bb32d4bfbaa6bfa072365a30c98b1fcd1f43e48969071ad98f1a7")
@@ -42,13 +43,15 @@ class PyCupy(PythonPackage, CudaPackage, ROCmPackage):
 
     # Based on https://github.com/cupy/cupy/releases
     depends_on("cuda@:11.9", when="@:11 +cuda")
-    depends_on("cuda@:12.1", when="@12: +cuda")
+    depends_on("cuda@:12.1", when="@12:12.1.0 +cuda")
+    depends_on("cuda@:12.4", when="@13: +cuda")
 
     for a in CudaPackage.cuda_arch_values:
         depends_on("nccl +cuda cuda_arch={0}".format(a), when="+cuda cuda_arch={0}".format(a))
 
     depends_on("cudnn", when="+cuda")
-    depends_on("cutensor", when="+cuda")
+    depends_on("cutensor", when="@:12.1.0 +cuda")
+    depends_on("cutensor@2.0.1.2", when="@13.1: +cuda")
 
     for _arch in ROCmPackage.amdgpu_targets:
         arch_str = "amdgpu_target={0}".format(_arch)

--- a/var/spack/repos/builtin/packages/py-cupy/package.py
+++ b/var/spack/repos/builtin/packages/py-cupy/package.py
@@ -36,8 +36,10 @@ class PyCupy(PythonPackage, CudaPackage, ROCmPackage):
     depends_on("py-fastrlock@0.5:", type=("build", "run"))
     depends_on("py-numpy@1.20:1.25", when="@:11", type=("build", "run"))
     depends_on("py-numpy@1.20:1.26", when="@12:", type=("build", "run"))
+    depends_on("py-numpy@1.22:1.29", when="@13:", type=("build", "run"))
 
-    depends_on("py-scipy@1.6:1.12", when="+all", type=("build", "run"))
+    depends_on("py-scipy@1.6:1.12", when="@:12+all", type=("build", "run"))
+    depends_on("py-scipy@1.7:1.14", when="@13:+all", type=("build", "run"))
     depends_on("py-cython@0.29.22:2", when="+all", type=("build", "run"))
     depends_on("py-optuna@2:", when="+all", type=("build", "run"))
 


### PR DESCRIPTION
py-cupy@13 requires cutensor@2 to build.  py-cupy@13 is needed for cuda@12.4 support.  The link from Nvidia  https://developer.download.nvidia.com/compute/cutensor/redist/redistrib_2.0.1.json doesn't mention an aarch64 version so I've omitted it.