### PR TITLE
hpctoolkit: restrict one patch to :2022

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -234,6 +234,7 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
 
     # Fix a bug where make would mistakenly overwrite hpcrun-fmt.h.
     # https://gitlab.com/hpctoolkit/hpctoolkit/-/merge_requests/751
+    @when("@:2022")
     def patch(self):
         with working_dir(join_path("src", "lib", "prof-lean")):
             if os.access("hpcrun-fmt.txt", os.F_OK):


### PR DESCRIPTION
Restrict the hpcrun-fmt.txt patch to :2022.  It's fixed in the code after that, and in recent develop, some code paths have moved causing this patch to fail.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
