### PR TITLE
bison: add missing diffutils build dep

### DIFF
--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -59,6 +59,7 @@ class Bison(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on("gettext", when="+color")
     depends_on("m4@1.4.6:", type=("build", "run"))
+    depends_on("diffutils", type="build")
 
     patch("pgi.patch", when="@3.0.4")
     # The NVIDIA compilers do not currently support some GNU builtins.


### PR DESCRIPTION
Closes #44207

Supersedes #44245 and #44208

Issue is that `move-if-change` requires `cmp` from diffutils.
