### PR TITLE
py-scikit-learn: add v1.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-pandas/package.py
+++ b/var/spack/repos/builtin/packages/py-pandas/package.py
@@ -17,9 +17,8 @@ class PyPandas(PythonPackage):
 
     skip_modules = ["pandas.tests", "pandas.plotting._matplotlib", "pandas.core._numba.kernels"]
 
-    maintainers("adamjstewart")
-
     license("Apache-2.0")
+    maintainers("adamjstewart", "rgommers")
 
     version("2.2.2", sha256="9e79019aba43cb4fda9e4d983f8e88ca0373adbb697ae9c6c43093218de28b54")
     version("2.2.1", sha256="0ab90f87093c13f3e8fa45b48ba9f39181046e8f3317d3aadb2fffbb1b978572")

--- a/var/spack/repos/builtin/packages/py-scikit-learn-extra/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-learn-extra/package.py
@@ -27,4 +27,5 @@ class PyScikitLearnExtra(PythonPackage):
     depends_on("py-cython@0.28.5:", type="build")
     depends_on("py-numpy@1.13.3:", type=("build", "run"))
     depends_on("py-scipy@0.19.1:", type=("build", "run"))
-    depends_on("py-scikit-learn@0.23:", type=("build", "run"))
+    # For upperbound see https://github.com/scikit-learn-contrib/scikit-learn-extra/issues/171
+    depends_on("py-scikit-learn@0.23:1.2", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-scikit-learn/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-learn/package.py
@@ -15,7 +15,7 @@ class PyScikitLearn(PythonPackage):
     git = "https://github.com/scikit-learn/scikit-learn.git"
 
     license("BSD-3-Clause")
-    maintainers("adamjstewart")
+    maintainers("adamjstewart", "rgommers")
 
     version("main", branch="main")
     version("master", branch="main", deprecated=True)

--- a/var/spack/repos/builtin/packages/py-scikit-learn/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-learn/package.py
@@ -11,14 +11,15 @@ class PyScikitLearn(PythonPackage):
     """A set of python modules for machine learning and data mining."""
 
     homepage = "https://scikit-learn.org/"
-    pypi = "scikit-learn/scikit-learn-0.24.0.tar.gz"
+    pypi = "scikit-learn/scikit_learn-1.5.0.tar.gz"
     git = "https://github.com/scikit-learn/scikit-learn.git"
 
+    license("BSD-3-Clause")
     maintainers("adamjstewart")
 
-    license("BSD-3-Clause")
-
-    version("master", branch="master")
+    version("main", branch="main")
+    version("master", branch="main", deprecated=True)
+    version("1.5.0", sha256="789e3db01c750ed6d496fa2db7d50637857b451e57bcae863bff707c1247bef7")
     version("1.4.2", sha256="daa1c471d95bad080c6e44b4946c9390a4842adc3082572c20e4f8884e39e959")
     version("1.4.0", sha256="d4373c984eba20e393216edd51a3e3eede56cbe93d4247516d205643c3b93121")
     version("1.3.2", sha256="a2f54c76accc15a34bfb9066e6c7a56c1e7235dda5762b990792330b52ccfb05")
@@ -46,8 +47,6 @@ class PyScikitLearn(PythonPackage):
     version("0.22.1", sha256="51ee25330fc244107588545c70e2f3570cfc4017cff09eed69d6e1d82a212b7d")
     version("0.22", sha256="314abf60c073c48a1e95feaae9f3ca47a2139bd77cebb5b877c23a45c9e03012")
 
-    variant("openmp", default=True, description="Build with OpenMP support")
-
     # Based on PyPI wheel availability
     with default_args(type=("build", "link", "run")):
         depends_on("python@3.9:3.12", when="@1.4:")
@@ -58,17 +57,15 @@ class PyScikitLearn(PythonPackage):
         depends_on("python@:3.9", when="@0.24:1.0.1")
         depends_on("python@:3.8", when="@0.22:0.23")
 
-    # pyproject.toml
     with default_args(type="build"):
-        depends_on("py-setuptools")
-        depends_on("py-setuptools@:59", when="@:1.2.1")
+        depends_on("py-meson-python@0.15:", when="@1.5:")
+        depends_on("py-cython@3.0.10:", when="@1.5:")
         depends_on("py-cython@3.0.8:", when="@1.4.2:")
         depends_on("py-cython@0.29.33:", when="@1.4.0:1.4.1")
         depends_on("py-cython@0.29.33:2", when="@1.3")
         depends_on("py-cython@0.29.24:2", when="@1.0.2:1.2")
         depends_on("py-cython@0.28.5:2", when="@0.21:1.0.1")
 
-    # sklearn/_min_dependencies.py
     with default_args(type=("build", "link", "run")):
         depends_on("py-numpy@1.19.5:", when="@1.4.2:")
         depends_on("py-numpy@1.19.5:1", when="@1.4.0:1.4.1")
@@ -76,6 +73,7 @@ class PyScikitLearn(PythonPackage):
         depends_on("py-numpy@1.14.6:1", when="@1.0")
         depends_on("py-numpy@1.13.3:1", when="@0.23:0.24")
         depends_on("py-numpy@1.11.0:1", when="@0.21:0.22")
+
     with default_args(type=("build", "run")):
         depends_on("py-scipy@1.6:", when="@1.4:")
         depends_on("py-scipy@1.5:", when="@1.3:")
@@ -87,44 +85,31 @@ class PyScikitLearn(PythonPackage):
         depends_on("py-joblib@1.1.1:", when="@1.2:")
         depends_on("py-joblib@1:", when="@1.1:")
         depends_on("py-joblib@0.11:")
-        depends_on("py-threadpoolctl@2.0.0:", when="@0.23:")
-    depends_on("llvm-openmp", when="%apple-clang +openmp")
+        depends_on("py-threadpoolctl@3.1:", when="@1.5:")
+        depends_on("py-threadpoolctl@2.0:", when="@0.23:")
 
-    # Test dependencies
-    with default_args(type="test"):
-        depends_on("py-matplotlib@3.3.4:")
-        depends_on("py-scikit-image@0.17.2:")
-        depends_on("py-pandas@1.1.5:")
-        depends_on("py-pytest@7.1.2:")
-        depends_on("py-pyamg@4:")
-        depends_on("py-polars@0.19.12:", when="@1.4:")
-        depends_on("py-pyarrow@12:", when="@1.4:")
-        depends_on("py-pooch@1.6:", when="@1.2:")
+    depends_on("llvm-openmp", when="%apple-clang")
 
-    # Release tarballs are already cythonized. If you wanted to build a release
-    # version without OpenMP support, you would need to delete all .c files
-    # that include omp.h, as well as PKG-INFO.
-    # See https://github.com/scikit-learn/scikit-learn/issues/14332
-    conflicts("~openmp", when="@:999", msg="Only master supports ~openmp")
+    # Historical dependencies
+    with default_args(type="build"):
+        depends_on("py-setuptools", when="@:1.4")
+        depends_on("py-setuptools@:59", when="@:1.2.1")
+
+    def url_for_version(self, version):
+        url = "https://files.pythonhosted.org/packages/source/s/scikit-learn/{}-{}.tar.gz"
+        if version >= Version("1.5"):
+            name = "scikit_learn"
+        else:
+            name = "scikit-learn"
+        return url.format(name, version)
 
     def setup_build_environment(self, env):
-        # enable parallel builds of the sklearn backend
+        # Enable parallel builds of the sklearn backend
         env.append_flags("SKLEARN_BUILD_PARALLEL", str(make_jobs))
 
-        # https://scikit-learn.org/stable/developers/advanced_installation.html#building-from-source
-        if self.spec.satisfies("~openmp"):
-            env.set("SKLEARN_NO_OPENMP", "True")
-        # https://scikit-learn.org/stable/developers/advanced_installation.html#mac-osx
-        elif self.spec.satisfies("@0.21: %apple-clang +openmp"):
+        # https://scikit-learn.org/stable/developers/advanced_installation.html#macos
+        if self.spec.satisfies("%apple-clang"):
             env.append_flags("CPPFLAGS", self.compiler.openmp_flag)
             env.append_flags("CFLAGS", self.spec["llvm-openmp"].headers.include_flags)
             env.append_flags("CXXFLAGS", self.spec["llvm-openmp"].headers.include_flags)
             env.append_flags("LDFLAGS", self.spec["llvm-openmp"].libs.ld_flags)
-
-    @run_after("install")
-    @on_package_attributes(run_tests=True)
-    def install_test(self):
-        # https://scikit-learn.org/stable/developers/advanced_installation.html#testing
-        with working_dir("spack-test", create=True):
-            pytest = which("pytest")
-            pytest(join_path(self.prefix, python_purelib, "sklearn"))


### PR DESCRIPTION
Sklearn has also ported to meson! Not as much of a build speedup though:

### Before

```
  Stage: 2.26s.  Install: 56.53s.  Post-install: 0.34s.  
 59.25s
```

### After

```
  Stage: 2.29s.  Install: 47.79s.  Post-install: 0.35s.  Total: 50.55s
```

https://scikit-learn.org/stable/whats_new/v1.5.html