### PR TITLE
gitlab ci: Remove protected publish job

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-stages: [ "generate", "build", "publish" ]
+stages: [ "generate", "build" ]
 
 variables:
   SPACK_DISABLE_LOCAL_CONFIG: "1"
@@ -258,36 +258,6 @@ default:
 .build:
   extends: [ ".base-job" ]
   stage: build
-
-protected-publish:
-  # Copy binaries from stack-specific mirrors to a root mirror
-  stage: publish
-  only:
-  - /^develop$/
-  - /^releases\/v.*/
-  - /^v.*/
-  - /^develop-[\d]{4}-[\d]{2}-[\d]{2}$/
-  image: "ghcr.io/spack/python-aws-bash:0.0.1"
-  tags: ["spack", "public", "medium", "aws", "x86_64"]
-  retry:
-    max: 2
-    when: ["runner_system_failure", "stuck_or_timeout_failure"]
-  variables:
-    SPACK_COPY_BUILDCACHE: "${PROTECTED_MIRROR_PUSH_DOMAIN}/${CI_COMMIT_REF_NAME}"
-    SPACK_PIPELINE_TYPE: "spack_protected_branch"
-    KUBERNETES_CPU_REQUEST: 4000m
-    KUBERNETES_MEMORY_REQUEST: 16G
-  script:
-    - . "./share/spack/setup-env.sh"
-    - spack --version
-    - export COPY_SPECS_DIR=${CI_PROJECT_DIR}/jobs_scratch_dir/specs_to_copy
-    - spack buildcache sync --manifest-glob "${COPY_SPECS_DIR}/*.json"
-    - curl -fLsS https://spack.github.io/keys/spack-public-binary-key.pub -o /tmp/spack-public-binary-key.pub
-    - aws s3 cp /tmp/spack-public-binary-key.pub "${SPACK_COPY_BUILDCACHE}/build_cache/_pgp/spack-public-binary-key.pub"
-    - spack buildcache update-index --keys "${SPACK_COPY_BUILDCACHE}"
-  id_tokens:
-    GITLAB_OIDC_TOKEN:
-      aud: "protected_binary_mirror"
 
 ########################################
 # TEMPLATE FOR ADDING ANOTHER PIPELINE


### PR DESCRIPTION
Remove the `protected-publish` job from gitlab pipelines, in favor of an [alternate](https://github.com/spack/spack-infrastructure/pull/848) approach.

The `protected-publish` job copies rebuilt packages of changed specs from stack-specific mirrors to the top-level mirror, and then it recomputes the binary index at the top level.  This has a couple of problems:

* We don't run `protected-publish` unless all child pipelines pass, to avoid the risk of contaminating the top-level mirror with improperly signed binaries.  Each time that job is skipped, it results in holes/gaps in the top-level mirror.
* Depending on the number of binary packages at the top-level, recomputing the index can take multiple hours.  

This PR replaces the current approach with an idempotent job that can be triggered by gitlab webhooks and/or run as a cron.  This will do a better job of keeping the top-level mirror up-to-date, and it will remove a long-running job from protected pipelines, effectively increasing the number of commits on spack `develop` that get tested in gitlab.