### PR TITLE
Enforce consistency of `gl` providers

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
@@ -79,7 +79,7 @@ spack:
     - openfoam
     - osu-micro-benchmarks
     - parallel
-    - paraview
+    # - paraview
     - picard
     - quantum-espresso
     - raja

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml
@@ -85,7 +85,7 @@ spack:
     - openfoam
     - osu-micro-benchmarks
     - parallel
-    - paraview
+    # - paraview
     - picard
     - quantum-espresso
 # Build broken for gcc@7.3.1 x86_64_v4 (error: '_mm512_loadu_epi32' was not declared in this scope)

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -25,14 +25,14 @@ spack:
   - paraview_specs:
     - matrix:
       - - paraview +raytracing
-      - - +qt~osmesa # GUI Support w/ GLX Rendering
-        - ~qt~osmesa # GLX Rendering
-        - ~qt+osmesa # OSMesa Rendering
+      - - +qt ^[virtuals=gl] glx # GUI Support w/ GLX Rendering
+        - ~qt ^[virtuals=gl] glx # GLX Rendering
+        - ^[virtuals=gl] osmesa # OSMesa Rendering
   - visit_specs:
     - matrix:
-      - - visit
-      - - ~gui~osmesa # GLX Rendering
-        - ~gui+osmesa # OSMesa Rendering
+      - - visit~gui
+      - - ^[virtuals=gl] glx # GLX Rendering
+        - ^[virtuals=gl] osmesa # OSMesa Rendering
         # VisIt GUI does not work with Qt 5.14.2
         # - +gui~osmesa # GUI Support w/ GLX Rendering
   - sdk_base_spec:

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -34,7 +34,7 @@ spack:
       - - ^[virtuals=gl] glx # GLX Rendering
         - ^[virtuals=gl] osmesa # OSMesa Rendering
         # VisIt GUI does not work with Qt 5.14.2
-        # - +gui~osmesa # GUI Support w/ GLX Rendering
+        # - +gui ^[virtuals=gl] glx # GUI Support w/ GLX Rendering
   - sdk_base_spec:
     - matrix:
       - - ecp-data-vis-sdk +ascent +adios2 +cinema +darshan +faodel +hdf5 +pnetcdf

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-rhel/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-rhel/spack.yaml
@@ -50,7 +50,7 @@ spack:
       variants: +termlib
     paraview:
       # Don't build GUI support or GLX rendering for HPC/container deployments
-      require: "@5.11 ~qt+osmesa"
+      require: "@5.11 ~qt ^[virtuals=gl] osmesa"
     python:
       version: [3.8.13]
     trilinos:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-sles/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-sles/spack.yaml
@@ -43,7 +43,7 @@ spack:
       variants: +termlib
     paraview:
       # Don't build GUI support or GLX rendering for HPC/container deployments
-      require: "@5.11 ~qt+osmesa"
+      require: "@5.11 ~qt ^[virtuals=gl] osmesa"
     python:
       version: [3.8.13]
     trilinos:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
@@ -168,7 +168,6 @@ spack:
   - hdf5
   - libcatalyst
   - parallel-netcdf
-  - paraview
   - py-cinemasci
   - sz
   - unifyfs

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -21,7 +21,7 @@ spack:
       variants: threads=openmp
     paraview:
       # Don't build GUI support or GLX rendering for HPC/container deployments
-      require: "@5.11 ~qt+osmesa"
+      require: "@5.11 ~qt ^[virtuals=gl] osmesa"
 
     # ROCm 5.4.3
     comgr:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -52,7 +52,7 @@ spack:
       version: [11.8.0]
     paraview:
       # Don't build GUI support or GLX rendering for HPC/container deployments
-      require: "@5.11 ~qt+osmesa"
+      require: "@5.11 ~qt ^[virtuals=gl] osmesa"
 
   specs:
   # CPU

--- a/share/spack/gitlab/cloud_pipelines/stacks/gpu-tests/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/gpu-tests/spack.yaml
@@ -31,7 +31,7 @@ spack:
       variants: threads=openmp
     paraview:
       # Don't build GUI support or GLX rendering for HPC/container deployments
-      require: "@5.11 ~qt+osmesa"
+      require: "@5.11 ~qt ^[virtuals=gl] osmesa"
     trilinos:
       require: +amesos +amesos2 +anasazi +aztec +boost +epetra +epetraext
         +ifpack +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu

--- a/var/spack/repos/builtin/packages/mesa-demos/package.py
+++ b/var/spack/repos/builtin/packages/mesa-demos/package.py
@@ -2,8 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import sys
-
 from spack.package import *
 
 
@@ -20,18 +18,6 @@ class MesaDemos(AutotoolsPackage):
     version("8.2.0", sha256="5a9f71b815d968d0c3b77edfcc3782d0211f8520b00da9e554ccfed80c8889f6")
     version("8.1.0", sha256="cc5826105355830208c90047fc38c5b09fa3ab0045366e7e859104935b00b76d")
 
-    variant(
-        "gl",
-        default="glx" if sys.platform.startswith("linux") else "osmesa",
-        values=("glx", "osmesa", "other"),
-        multi=False,
-        description="The OpenGL provider to use",
-    )
-    conflicts("^osmesa", when="gl=glx")
-    conflicts("^osmesa", when="gl=other")
-    conflicts("^glx", when="gl=osmesa")
-    conflicts("^glx", when="gl=other")
-
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
@@ -39,10 +25,8 @@ class MesaDemos(AutotoolsPackage):
     depends_on("pkgconfig", type="build")
 
     depends_on("gl")
-    depends_on("osmesa", when="gl=osmesa")
-    depends_on("glx", when="gl=glx")
-    depends_on("libx11", when="gl=glx")
-    depends_on("libxext", when="gl=glx")
+    depends_on("libx11", when="^[virtuals=gl] glx")
+    depends_on("libxext", when="^[virtuals=gl] glx")
 
     depends_on("glu")
     depends_on("glew@1.5.4:")
@@ -64,11 +48,11 @@ class MesaDemos(AutotoolsPackage):
             "--disable-rbug",
             "--without-glut",
         ]
-        if "gl=glx" in spec:
+        if spec.satisfies("^[virtuals=gl] glx"):
             args.append("--enable-x11")
         else:
             args.append("--disable-x11")
-        if "gl=osmesa" in spec:
+        if spec.satisfies("^[virtuals=gl] osmesa"):
             args.append("--enable-osmesa")
         else:
             args.append("--disable-osmesa")

--- a/var/spack/repos/builtin/packages/mesa-glu/package.py
+++ b/var/spack/repos/builtin/packages/mesa-glu/package.py
@@ -2,9 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-import sys
-
 from spack.package import *
 
 
@@ -18,22 +15,7 @@ class MesaGlu(AutotoolsPackage):
     version("9.0.1", sha256="f6f484cfcd51e489afe88031afdea1e173aa652697e4c19ddbcb8260579a10f7")
     version("9.0.0", sha256="4387476a1933f36fec1531178ea204057bbeb04cc2d8396c9ea32720a1f7e264")
 
-    variant(
-        "gl",
-        default="glx" if sys.platform.startswith("linux") else "other",
-        values=("glx", "osmesa", "other"),
-        multi=False,
-        description="The OpenGL provider to use",
-    )
-    conflicts("^osmesa", when="gl=glx")
-    conflicts("^osmesa", when="gl=other")
-    conflicts("^glx", when="gl=osmesa")
-    conflicts("^glx", when="gl=other")
-
     depends_on("gl@3:")
-    depends_on("osmesa", when="gl=osmesa")
-    depends_on("glx", when="gl=glx")
-
     provides("glu@1.3")
 
     # When using -std=c++17, using register long will throw an error. This
@@ -43,7 +25,7 @@ class MesaGlu(AutotoolsPackage):
     def configure_args(self):
         args = ["--disable-libglvnd"]
 
-        if "gl=osmesa" in self.spec:
+        if self.spec.satisfies("^[virtuals=gl] osmesa"):
             args.append("--enable-osmesa")
         else:
             args.append("--disable-osmesa")

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -111,12 +111,13 @@ class Mesa(MesonPackage):
         depends_on("libllvm@:12", when="@:21")
         depends_on("libllvm@:17", when="@:23")
 
-    depends_on("libx11", when="+glx")
-    depends_on("libxcb", when="+glx")
-    depends_on("libxext", when="+glx")
-    depends_on("libxt", when="+glx")
-    depends_on("xrandr", when="+glx")
-    depends_on("glproto@1.4.14:", when="+glx")
+    with when("+glx"):
+        depends_on("libx11")
+        depends_on("libxcb")
+        depends_on("libxext")
+        depends_on("libxt")
+        depends_on("xrandr")
+        depends_on("glproto@1.4.14:")
 
     # version specific issue
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96130

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -62,6 +62,7 @@ class Mesa(MesonPackage):
     depends_on("unwind")
     depends_on("expat")
     depends_on("zlib-api")
+    depends_on("libxml2")
 
     # Internal options
     variant("llvm", default=True, description="Enable LLVM.")

--- a/var/spack/repos/builtin/packages/of-catalyst/package.py
+++ b/var/spack/repos/builtin/packages/of-catalyst/package.py
@@ -32,7 +32,11 @@ class OfCatalyst(CMakePackage):
 
     depends_on("openfoam@1806", when="@1806", type=("build", "link", "run"))
     depends_on("openfoam@develop", when="@develop", type=("build", "link", "run"))
-    depends_on("paraview@5.5:+osmesa~qt", when="+full")
+
+    with when("+full"):
+        depends_on("paraview@5.5: ~qt")
+        depends_on("gl")
+        requires("^[virtuals=gl] osmesa")
 
     root_cmakelists_dir = "src/catalyst"
 

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -187,8 +187,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("gl@3.2:", when="+opengl2")
     depends_on("gl@1.2:", when="~opengl2")
-    depends_on("glew", when="~egl")
-    depends_on("glew gl=egl", when="+egl")
+    depends_on("glew")
 
     depends_on("osmesa", when="+osmesa")
     for p in ["linux", "cray"]:

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -66,8 +66,6 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     variant("python", default=False, description="Enable Python support", when="@5.6:")
     variant("fortran", default=False, description="Enable Fortran support")
     variant("mpi", default=True, description="Enable MPI support")
-    variant("osmesa", default=False, description="Enable OSMesa support")
-    variant("egl", default=False, description="Enable EGL in the OpenGL library being used")
     variant("qt", default=False, description="Enable Qt (gui) support")
     variant("opengl2", default=True, description="Enable OpenGL2 backend")
     variant("examples", default=False, description="Build examples")
@@ -189,13 +187,10 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("gl@1.2:", when="~opengl2")
     depends_on("glew")
 
-    depends_on("osmesa", when="+osmesa")
     for p in ["linux", "cray"]:
-        depends_on("glx", when="~egl ~osmesa platform={}".format(p))
-        depends_on("libxt", when="~egl ~osmesa platform={}".format(p))
-    conflicts("+qt", when="+osmesa")
-    conflicts("+qt", when="+egl")
-    conflicts("+egl", when="+osmesa")
+        depends_on("libxt", when=f"platform={p} ^[virtuals=gl] glx")
+
+    requires("^[virtuals=gl] glx", when="+qt", msg="Qt support requires GLX")
 
     depends_on("ospray@2.1:2", when="+raytracing")
     depends_on("openimagedenoise", when="+raytracing")
@@ -375,7 +370,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
                 if self.spec["hdf5"].satisfies("@1.12:"):
                     flags.append("-DH5_USE_110_API")
 
-        return (flags, None, None)
+        return flags, None, None
 
     def setup_run_environment(self, env):
         # paraview 5.5 and later
@@ -423,19 +418,17 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
 
         def variant_bool(feature, on="ON", off="OFF"):
             """Ternary for spec variant to ON/OFF string"""
-            if feature in spec:
+            if spec.satisfies(feature):
                 return on
             return off
 
-        def nvariant_bool(feature):
-            """Negated ternary for spec variant to OFF/ON string"""
-            return variant_bool(feature, on="OFF", off="ON")
-
         def use_x11():
             """Return false if osmesa or egl are requested"""
-            if "+osmesa" in spec or "+egl" in spec:
-                return "OFF"
-            if spec.satisfies("platform=windows"):
+            if (
+                spec.satisfies("^[virtuals=gl] osmesa")
+                or spec.satisfies("^[virtuals=gl] egl")
+                or spec.satisfies("platform=windows")
+            ):
                 return "OFF"
             return "ON"
 
@@ -443,7 +436,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
         includes = variant_bool("+development_files")
 
         cmake_args = [
-            "-DVTK_OPENGL_HAS_OSMESA:BOOL=%s" % variant_bool("+osmesa"),
+            "-DVTK_OPENGL_HAS_OSMESA:BOOL=%s" % variant_bool("^[virtuals=gl] osmesa"),
             "-DVTK_USE_X:BOOL=%s" % use_x11(),
             "-DPARAVIEW_INSTALL_DEVELOPMENT_FILES:BOOL=%s" % includes,
             "-DBUILD_TESTING:BOOL=OFF",
@@ -452,7 +445,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant("VISIT_BUILD_READER_Silo", "visitbridge"),
         ]
 
-        if "+egl" in spec:
+        if spec.satisfies("^[virtuals=gl] egl"):
             cmake_args.append("-DVTK_OPENGL_HAS_EGL:BOOL=ON")
 
         if spec.satisfies("@5.12:"):
@@ -529,7 +522,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
 
         # The assumed qt version changed to QT5 (as of paraview 5.2.1),
         # so explicitly specify which QT major version is actually being used
-        if "+qt" in spec:
+        if spec.satisfies("+qt"):
             cmake_args.extend(["-DPARAVIEW_QT_VERSION=%s" % spec["qt"].version[0]])
 
         if "+fortran" in spec:

--- a/var/spack/repos/builtin/packages/trilinos-catalyst-ioss-adapter/package.py
+++ b/var/spack/repos/builtin/packages/trilinos-catalyst-ioss-adapter/package.py
@@ -17,7 +17,9 @@ class TrilinosCatalystIossAdapter(CMakePackage):
 
     depends_on("bison", type="build")
     depends_on("flex", type="build")
-    depends_on("paraview+mpi+python+osmesa")
+    depends_on("paraview+mpi+python")
+    depends_on("gl")
+    requires("^[virtuals=gl] osmesa", msg="OSMesa is required for paraview")
     depends_on("py-numpy", type=("build", "run"))
     # Here we avoid paraview trying to use netcdf-c~parallel-netcdf
     # which is netcdf-c's default, even though paraview depends on 'netcdf-c'

--- a/var/spack/repos/builtin/packages/trilinos-catalyst-ioss-adapter/package.py
+++ b/var/spack/repos/builtin/packages/trilinos-catalyst-ioss-adapter/package.py
@@ -18,7 +18,7 @@ class TrilinosCatalystIossAdapter(CMakePackage):
     depends_on("bison", type="build")
     depends_on("flex", type="build")
     depends_on("paraview+mpi+python")
-    depends_on("gl")
+    depends_on("gl", type="run")
     requires("^[virtuals=gl] osmesa", msg="OSMesa is required for paraview")
     depends_on("py-numpy", type=("build", "run"))
     # Here we avoid paraview trying to use netcdf-c~parallel-netcdf


### PR DESCRIPTION
fixes #44184

Many recipes in `develop` use a wrong idiom of declaring a direct dependency on a provider. This might bring into the DAG two potential providers, when the one declared as a direct dependency is not the preferred one.

This PR reworks a few directives to avoid that problem, and simplifies the recipes in the process. Pipelines have been updated accordingly.