### PR TITLE
kcov: add v42 and convert to new stand-alone test process

### DIFF
--- a/var/spack/repos/builtin/packages/kcov/package.py
+++ b/var/spack/repos/builtin/packages/kcov/package.py
@@ -12,11 +12,17 @@ class Kcov(CMakePackage):
     compilation options"""
 
     homepage = "https://simonkagstrom.github.io/kcov/index.html"
-    url = "https://github.com/SimonKagstrom/kcov/archive/38.tar.gz"
+    url = "https://github.com/SimonKagstrom/kcov/archive/refs/tags/v42.tar.gz"
 
     license("GPL-2.0-or-later")
 
-    version("38", sha256="b37af60d81a9b1e3b140f9473bdcb7975af12040feb24cc666f9bb2bb0be68b4")
+    version("42", sha256="2c47d75397af248bc387f60cdd79180763e1f88f3dd71c94bb52478f8e74a1f8")
+    version(
+        "38",
+        sha256="b37af60d81a9b1e3b140f9473bdcb7975af12040feb24cc666f9bb2bb0be68b4",
+        url="https://github.com/SimonKagstrom/kcov/archive/38.tar.gz",
+        deprecated=True,
+    )
 
     depends_on("cmake@2.8.4:", type="build")
     depends_on("zlib-api")
@@ -29,9 +35,13 @@ class Kcov(CMakePackage):
         # https://github.com/Homebrew/homebrew-core/blob/master/Formula/kcov.rb
         return ["-DSPECIFY_RPATH=ON"]
 
+    def test_kcov_help(self):
+        """run installed kcov help"""
+        kcov = Executable(self.prefix.bin.kcov)
+        # The help message exits with an exit code of 1
+        kcov("-h", ignore_errors=1)
+
     @run_after("install")
     @on_package_attributes(run_tests=True)
-    def test_install(self):
-        # The help message exits with an exit code of 1
-        kcov = Executable(self.prefix.bin.kcov)
-        kcov("-h", ignore_errors=1)
+    def check_install(self):
+        self.test_kcov_help()


### PR DESCRIPTION
Supersedes #37728 

This PR updates the check based on the new stand-alone test API, which means it renames the current post-install check method and leverages it as a stand-alone test. 

I was unable to successfully build the old version of the package so updated to the latest.  This allowed me to test the simple check during install AND as a stand-alone test.

```
$ spack -v test run kcov
==> Spack test yn2hzevrxmmx2alaybz3zqy5bq7m5rtj
==> Testing package kcov-42-sqyh5hn
==> [2024-05-21-16:47:06.068160] test: test_kcov_help: run installed kcov help
==> [2024-05-21-16:47:06.068646] '$SPACK_HOME/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/kcov-42-sqyh5hnxyws64gvzlk3svdyhmyvi2suh/bin/kcov' '-h'
Usage: kcov [OPTIONS] out-dir in-file [args...]

Where [OPTIONS] are
 -h, --help              this text
 --version               print the version of kcov
 -p, --pid=PID           trace PID instead of executing in-file,
                         in-file is optional on Linux in this case
 -l, --limits=low,high   setup limits for low/high coverage (default 25,75)

 --collect-only          Only collect coverage data (don't produce HTML/
                         Cobertura output)
 --report-only           Produce output from stored databases, don't collect
 --merge                 Merge output from multiple source dirs

 --include-path=path     comma-separated paths to include in the coverage report
 --exclude-path=path     comma-separated paths to exclude from the coverage
                         report
 --include-pattern=pat   comma-separated path patterns to include in the
                         coverage report
 --exclude-pattern=pat   comma-separated path patterns to exclude from the 
                         coverage report
 --exclude-line=pat[,...] Consider lines that match the patterns to be non-
                         code lines.
 --exclude-region=start:stop[,...] Exclude regions of code between start:stop
                         markers (e.g., within comments) as non-code lines.
 --clean                 don't accumulate data from multiple runs

 --coveralls-id=id       Travis CI job ID or secret repo_token for uploads to
                         Coveralls.io
 --strip-path=path       If not set, max common path will be stripped away.
 --uncommon-options      print uncommon options for --help

Examples:
  kcov /tmp/kcov ./frodo                        # Check coverage for ./frodo
  kcov --pid=1000 /tmp/kcov                     # Check coverage for PID 1000
  kcov --include-pattern=/src/frodo/ /tmp/kcov ./frodo # Only include files
                                                       # including /src/frodo
  kcov --collect-only /tmp/kcov ./frodo  # Collect coverage, don't report
  kcov --report-only /tmp/kcov ./frodo   # Report coverage collected above
  kcov --merge /tmp/out /tmp/dir1 /tmp/dir2     # Merge the dir1/dir2 reports
  kcov --merge /tmp/out /tmp/dir*               # same as above (wildcard)
  kcov --system-record /tmp/out-dir sysroot     # Perform full-system in-
                                                  strumentation for sysroot
  kcov --system-report  /tmp/data-dir           # Report all data from a full-
                                                  system run.
PASSED: Kcov::test_kcov_help
==> [2024-05-21-16:47:06.194491] Completed testing
==> [2024-05-21-16:47:06.194622] 
=========================== SUMMARY: kcov-42-sqyh5hn ===========================
Kcov::test_kcov_help .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
```