### PR TITLE
rsync: add v3.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/rsync/package.py
+++ b/var/spack/repos/builtin/packages/rsync/package.py
@@ -16,6 +16,7 @@ class Rsync(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
+    version("3.3.0", sha256="7399e9a6708c32d678a72a63219e96f23be0be2336e50fd1348498d07041df90")
     version("3.2.7", sha256="4e7d9d3f6ed10878c58c5fb724a67dacf4b6aac7340b13e488fb2dc41346f2bb")
     version("3.2.6", sha256="fb3365bab27837d41feaf42e967c57bd3a47bc8f10765a3671efd6a3835454d3")
     version("3.2.5", sha256="2ac4d21635cdf791867bc377c35ca6dda7f50d919a58be45057fd51600c69aba")


### PR DESCRIPTION
This PR adds a new version of rsync, 3.3.0. Release notes at https://download.samba.org/pub/rsync/NEWS#3.3.0.