### PR TITLE
gcc: use -rpath {rpath_dir} not -rpath={rpath dir}

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -973,7 +973,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
 
             # rpath
             if rpath_dir:
-                f.write(f"*link_libgcc:\n+ -rpath={rpath_dir}\n\n")
+                f.write(f"*link_libgcc:\n+ -rpath {rpath_dir}\n\n")
 
             # programs search path
             if self.spec.satisfies("+binutils"):


### PR DESCRIPTION
to make macOS's linker happy.
