### PR TITLE
py-astropy: add v6.1 and new py-astropy-iers-data dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-astropy-iers-data/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy-iers-data/package.py
@@ -16,7 +16,7 @@ class PyAstropyIersData(PythonPackage):
     git = "https://github.com/astropy/astropy-iers-data.git"
 
     maintainers("aweaver1fandm")
-    
+
     version("main", branch="main", preferred=True)
 
     depends_on("python@3.8:")

--- a/var/spack/repos/builtin/packages/py-astropy-iers-data/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy-iers-data/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyAstropyIersData(PythonPackage):
+    """IERS Earth rotation and leap second table
+
+       Note: This package is not meant for standalone purposes
+       but is needed by AstroPy"""
+
+    homepage = "https://github.com/astropy/astropy-iers-data"
+    git = "https://github.com/astropy/astropy-iers-data.git"
+
+    maintainers("aweaver1fandm")
+    
+    version("main", branch="main", preferred=True)
+
+    depends_on("python@3.8:")
+    depends_on("py-setuptools", type="build")
+    depends_on("py-wheel", type="build")

--- a/var/spack/repos/builtin/packages/py-astropy-iers-data/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy-iers-data/package.py
@@ -10,15 +10,15 @@ class PyAstropyIersData(PythonPackage):
     """IERS Earth rotation and leap second table
 
     Note: This package is not meant for standalone purposes
-    but is needed by AstroPy"""
+    but is needed by AstroPy."""
 
     homepage = "https://github.com/astropy/astropy-iers-data"
-    git = "https://github.com/astropy/astropy-iers-data.git"
+    pypi = "astropy-iers-data/astropy_iers_data-0.2024.4.29.0.28.48.tar.gz"
 
-    maintainers("aweaver1fandm")
-
-    version("main", branch="main", preferred=True)
+    version("0.2024.5.20.0.29.40", sha256="7fff3d3404ae8560533ac0e685db7acc02c4d8984faa4ac3d607096879fba2d1")
+    version("0.2024.4.29.0.28.48", sha256="a2d5acf97e731f1d4a0eab1c8e4c7f454ddc166af06797b141202dd901bd1dfc")
 
     depends_on("python@3.8:")
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools-scm", type="build")
     depends_on("py-wheel", type="build")

--- a/var/spack/repos/builtin/packages/py-astropy-iers-data/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy-iers-data/package.py
@@ -9,8 +9,8 @@ from spack.package import *
 class PyAstropyIersData(PythonPackage):
     """IERS Earth rotation and leap second table
 
-       Note: This package is not meant for standalone purposes
-       but is needed by AstroPy"""
+    Note: This package is not meant for standalone purposes
+    but is needed by AstroPy"""
 
     homepage = "https://github.com/astropy/astropy-iers-data"
     git = "https://github.com/astropy/astropy-iers-data.git"

--- a/var/spack/repos/builtin/packages/py-astropy-iers-data/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy-iers-data/package.py
@@ -15,8 +15,14 @@ class PyAstropyIersData(PythonPackage):
     homepage = "https://github.com/astropy/astropy-iers-data"
     pypi = "astropy-iers-data/astropy_iers_data-0.2024.4.29.0.28.48.tar.gz"
 
-    version("0.2024.5.20.0.29.40", sha256="7fff3d3404ae8560533ac0e685db7acc02c4d8984faa4ac3d607096879fba2d1")
-    version("0.2024.4.29.0.28.48", sha256="a2d5acf97e731f1d4a0eab1c8e4c7f454ddc166af06797b141202dd901bd1dfc")
+    version(
+        "0.2024.5.20.0.29.40",
+        sha256="7fff3d3404ae8560533ac0e685db7acc02c4d8984faa4ac3d607096879fba2d1",
+    )
+    version(
+        "0.2024.4.29.0.28.48",
+        sha256="a2d5acf97e731f1d4a0eab1c8e4c7f454ddc166af06797b141202dd901bd1dfc",
+    )
 
     depends_on("python@3.8:")
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy/package.py
@@ -19,7 +19,7 @@ class PyAstropy(PythonPackage):
 
     license("BSD-3-Clause")
 
-    version("6.1", sha256="6c3b915f10b1576190730ddce45f6245f9927dda3de6e3f692db45779708950f")
+    version("6.1.0", sha256="6c3b915f10b1576190730ddce45f6245f9927dda3de6e3f692db45779708950f")
     version("5.1", sha256="1db1b2c7eddfc773ca66fa33bd07b25d5b9c3b5eee2b934e0ca277fa5b1b7b7e")
     version(
         "4.0.1.post1", sha256="5c304a6c1845ca426e7bc319412b0363fccb4928cb4ba59298acd1918eec44b5"
@@ -32,7 +32,7 @@ class PyAstropy(PythonPackage):
     variant("all", default=False, when="@3.2:", description="Enable all functionality")
 
     # Required dependencies
-    depends_on("python@3.10:", when="@6.1:", type=("build", "run"))
+    depends_on("python@3.10:", when="@6.1.0:", type=("build", "run"))
     depends_on("python@3.8:", when="@5.1:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-cython@0.29.13:", type="build")
@@ -54,6 +54,7 @@ class PyAstropy(PythonPackage):
     depends_on("py-packaging@19.0:", when="@5.1:", type=("build", "run"))
     depends_on("py-pyyaml@3.13:", when="@5.1:", type=("build", "run"))
     depends_on("py-pyerfa@2.0:", when="@5.1:", type=("build", "run"))
+    depends_on("py-pyerfa@2.0.1.1:", when="@6.1.0:", type=("build", "run"))
     depends_on("py-setuptools-scm@6.2:", when="@5.1:", type="build")
     depends_on("py-extension-helpers", when="@5.1:", type="build")
     depends_on("pkgconfig", type="build")

--- a/var/spack/repos/builtin/packages/py-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy/package.py
@@ -19,10 +19,9 @@ class PyAstropy(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("6.1", sha256="6c3b915f10b1576190730ddce45f6245f9927dda3de6e3f692db45779708950f")
     version("5.1", sha256="1db1b2c7eddfc773ca66fa33bd07b25d5b9c3b5eee2b934e0ca277fa5b1b7b7e")
-    version(
-        "4.0.1.post1", sha256="5c304a6c1845ca426e7bc319412b0363fccb4928cb4ba59298acd1918eec44b5"
-    )
+    version("4.0.1.post1", sha256="5c304a6c1845ca426e7bc319412b0363fccb4928cb4ba59298acd1918eec44b5")
     version("3.2.1", sha256="706c0457789c78285e5464a5a336f5f0b058d646d60f4e5f5ba1f7d5bf424b28")
     version("2.0.14", sha256="618807068609a4d8aeb403a07624e9984f566adc0dc0f5d6b477c3658f31aeb6")
     version("1.1.2", sha256="6f0d84cd7dfb304bb437dda666406a1d42208c16204043bc920308ff8ffdfad1")
@@ -31,12 +30,18 @@ class PyAstropy(PythonPackage):
     variant("all", default=False, when="@3.2:", description="Enable all functionality")
 
     # Required dependencies
+    depends_on("python@3.10:", when="@6.1:", type=("build", "run"))
     depends_on("python@3.8:", when="@5.1:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-cython@0.29.13:", type="build")
+    depends_on("py-cython@0.29.30", when="@5.1:6.0", type="build")
+    depends_on("py-cython@3.0.0", when="@6.1.0:", type="build")
+
     # in newer pip versions --install-option does not exist
     depends_on("py-pip@:23.0", type="build")
 
+    depends_on("py-astropy-iers-data", when="@6:", type=("build", "run"))
+    depends_on("py-numpy@1.23:", when="@6.1:", type=("build", "run"))
     depends_on("py-numpy@1.18:", when="@5.1:", type=("build", "run"))
     depends_on("py-numpy@1.16:", when="@4.0:", type=("build", "run"))
     depends_on("py-numpy@1.13:", when="@3.1:", type=("build", "run"))
@@ -48,7 +53,6 @@ class PyAstropy(PythonPackage):
     depends_on("py-pyyaml@3.13:", when="@5.1:", type=("build", "run"))
     depends_on("py-pyerfa@2.0:", when="@5.1:", type=("build", "run"))
     depends_on("py-setuptools-scm@6.2:", when="@5.1:", type="build")
-    depends_on("py-cython@0.29.30", when="@5.1:", type="build")
     depends_on("py-extension-helpers", when="@5.1:", type="build")
     depends_on("pkgconfig", type="build")
 
@@ -60,8 +64,10 @@ class PyAstropy(PythonPackage):
 
     # Optional dependencies
     with when("+all"):
+        depends_on("py-scipy@1.8:", when="@6:", type=("build", "run"))
         depends_on("py-scipy@1.3:", when="@5:", type=("build", "run"))
         depends_on("py-scipy@0.18:", type=("build", "run"))
+        depends_on("py-matplotlib@3.3:", when="@6:", type=("build", "run"))
         depends_on("py-matplotlib@3.1:", when="@5:", type=("build", "run"))
         depends_on("py-matplotlib@2.1:", when="@4:", type=("build", "run"))
         depends_on("py-matplotlib@2.0:", type=("build", "run"))
@@ -85,6 +91,8 @@ class PyAstropy(PythonPackage):
         depends_on("py-ipython", type=("build", "run"))
         depends_on("py-pytest@7:", when="@5.0.2:", type=("build", "run"))
         depends_on("py-pytest", type=("build", "run"))
+        depends_on("py-fsspec+http@2023.4:", when="@6.1:", type=("build", "run"))
+        depends_on("py-s3fs@2023.4:", when="@6.1:", type=("build", "run"))
         depends_on("py-typing-extensions@3.10.0.1:", when="@5.0.2:", type=("build", "run"))
 
         # Historical optional dependencies

--- a/var/spack/repos/builtin/packages/py-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy/package.py
@@ -21,7 +21,9 @@ class PyAstropy(PythonPackage):
 
     version("6.1", sha256="6c3b915f10b1576190730ddce45f6245f9927dda3de6e3f692db45779708950f")
     version("5.1", sha256="1db1b2c7eddfc773ca66fa33bd07b25d5b9c3b5eee2b934e0ca277fa5b1b7b7e")
-    version("4.0.1.post1", sha256="5c304a6c1845ca426e7bc319412b0363fccb4928cb4ba59298acd1918eec44b5")
+    version(
+        "4.0.1.post1", sha256="5c304a6c1845ca426e7bc319412b0363fccb4928cb4ba59298acd1918eec44b5"
+    )
     version("3.2.1", sha256="706c0457789c78285e5464a5a336f5f0b058d646d60f4e5f5ba1f7d5bf424b28")
     version("2.0.14", sha256="618807068609a4d8aeb403a07624e9984f566adc0dc0f5d6b477c3658f31aeb6")
     version("1.1.2", sha256="6f0d84cd7dfb304bb437dda666406a1d42208c16204043bc920308ff8ffdfad1")

--- a/var/spack/repos/builtin/packages/py-pyerfa/package.py
+++ b/var/spack/repos/builtin/packages/py-pyerfa/package.py
@@ -22,12 +22,16 @@ class PyPyerfa(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2.0.1.1", sha256="dbac74ef8d3d3b0f22ef0ad3bbbdb30b2a9e10570b1fa5a98be34c7be36c9a6b")
     version("2.0.0.1", sha256="2fd4637ffe2c1e6ede7482c13f583ba7c73119d78bef90175448ce506a0ede30")
 
     # From setup.cfg
     depends_on("python@3.7:", type=("build", "run"))
+    depends_on("py-numpy@1.25:2", when="@2.0.1.1", type=("build", "run"))
     depends_on("py-numpy@1.17:", type=("build", "run"))
+    depends_on("py-setuptools-scm@6.2:", when="@2.0.1.1", type="build")
     depends_on("py-setuptools-scm@3.4:+toml", type="build")
+
     # From pyproject.toml
     depends_on("py-setuptools@42:", type="build")
     depends_on("py-packaging", type="build")


### PR DESCRIPTION
Added build info for version 6.1 in py-astropy.  Requires a new additional package, astropy-iers-data which has been included as py-astropy-iers-data to match with spack's general naming conventions.

Below is the output of the spack install showing successful build fro version 6.1 and the new py-astropy-iers-data package

[+] /usr (external glibc-2.28-oj2wjfl2ao5inhfz4qehw6hlck2hizvp)
[+] /opt/apps/spack/gcc-runtime-8.5.0-5k6kvi5
[+] /opt/apps/spack/bzip2-1.0.8-t65bq3t
[+] /opt/apps/spack/libmd-1.0.4-zbdiprt
[+] /opt/apps/spack/libiconv-1.17-jskazis
[+] /opt/apps/spack/util-linux-uuid-2.38.1-w3kgjq3
[+] /opt/apps/spack/libxcrypt-4.4.35-zigqpjo
[+] /opt/apps/spack/xz-5.4.6-axoznvt
[+] /opt/apps/spack/zlib-ng-2.1.6-ccn5qny
[+] /opt/apps/spack/libyaml-0.2.5-fxathvq
[+] /opt/apps/spack/ncurses-6.4-xbvwv2w
[+] /opt/apps/spack/zstd-1.5.6-nyk6gt6
[+] /opt/apps/spack/pcre2-10.42-fu62kky
[+] /opt/apps/spack/libunistring-1.2-whrov3e
[+] /opt/apps/spack/nghttp2-1.57.0-u72gxms
[+] /opt/apps/spack/openblas-0.3.26-pfyk2vi
[+] /opt/apps/spack/berkeley-db-18.1.40-jftva2u
[+] /opt/apps/spack/wcslib-7.3-zvcqq7o
[+] /opt/apps/spack/libffi-3.4.6-ibucrfe
[+] /opt/apps/spack/erfa-2.0.0-4qkta2n
[+] /opt/apps/spack/pkgconf-1.9.5-ckjdqjm
[+] /opt/apps/spack/libbsd-0.12.1-njt5grs
[+] /opt/apps/spack/openssl-3.2.1-4lqdgni
[+] /opt/apps/spack/pigz-2.8-rx263bp
[+] /opt/apps/spack/readline-8.2-2ys6ede
[+] /opt/apps/spack/libidn2-2.3.7-vnie4rz
[+] /opt/apps/spack/libedit-3.1-20230828-676jwbd
[+] /opt/apps/spack/libxml2-2.10.3-37klvxv
[+] /opt/apps/spack/expat-2.6.2-7kfe3hb
[+] /opt/apps/spack/curl-8.6.0-gpzsr3p
[+] /opt/apps/spack/tar-1.34-wjzs4wj
[+] /opt/apps/spack/gdbm-1.23-cylmqwx
[+] /opt/apps/spack/sqlite-3.43.2-axuxulg
[+] /opt/apps/spack/cfitsio-3.49-mmy3dbr
[+] /opt/apps/spack/gettext-0.22.4-zjsp346
[+] /opt/apps/spack/perl-5.38.0-gzljgek
[+] /opt/apps/spack/python-3.10.13-fz7fymx
[+] /opt/apps/spack/krb5-1.20.1-tqiapsx
[+] /opt/apps/spack/py-pyyaml-6.0-rju7jls
[+] /opt/apps/spack/py-tomli-2.0.1-eanxpu2
[+] /opt/apps/spack/py-numpy-1.26.4-t5acjcv
[+] /opt/apps/spack/python-venv-1.0-2cz5c3s
[+] /opt/apps/spack/py-pip-23.0-lxkcvby
[+] /opt/apps/spack/openssh-9.7p1-jxrkzso
[+] /opt/apps/spack/py-pyerfa-2.0.0.1-kyfazhs
[+] /opt/apps/spack/py-packaging-23.1-wkeyuk6
[+] /opt/apps/spack/py-typing-extensions-4.8.0-ujwbb6g
[+] /opt/apps/spack/py-setuptools-69.2.0-3do76jw
[+] /opt/apps/spack/py-wheel-0.41.2-brm3k3h
[+] /opt/apps/spack/git-2.45.1-tuc5jnb
[+] /opt/apps/spack/py-cython-3.0.0-zx62ssd
==> Installing py-astropy-iers-data-main-ukchsfzhfcyz6e6fxar6mtykqiavporj [52/55]
==> No binary for py-astropy-iers-data-main-ukchsfzhfcyz6e6fxar6mtykqiavporj found: installing from source
==> No patches needed for py-astropy-iers-data
==> py-astropy-iers-data: Executing phase: 'install'
==> py-astropy-iers-data: Successfully installed py-astropy-iers-data-main-ukchsfzhfcyz6e6fxar6mtykqiavporj
  Stage: 1.74s.  Install: 0.93s.  Post-install: 0.52s.  Total: 3.36s
[+] /opt/apps/spack/py-astropy-iers-data-main-ukchsfz
[+] /opt/apps/spack/py-extension-helpers-0.1-a5hmr6j
[+] /opt/apps/spack/py-setuptools-scm-8.0.4-qdhxchg
==> Installing py-astropy-6.1.0-f4pffru3kmyion2kq6muomgrfs5y4gdo [55/55]
==> No binary for py-astropy-6.1.0-f4pffru3kmyion2kq6muomgrfs5y4gdo found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/a/astropy/astropy-6.1.0.tar.gz
==> Ran patch() for py-astropy
==> py-astropy: Executing phase: 'install'
==> Warning: Module file /opt/modulefiles/spack/Core/py-astropy/6.1.0.lua exists and will not be overwritten
==> py-astropy: Successfully installed py-astropy-6.1.0-f4pffru3kmyion2kq6muomgrfs5y4gdo
  Stage: 1.29s.  Install: 1m 5.77s.  Post-install: 0.60s.  Total: 1m 7.94s
