### PR TITLE
Fix CCPP_SUITES setting in ufs-weather-model

### DIFF
--- a/var/spack/repos/builtin/packages/ufs-weather-model/package.py
+++ b/var/spack/repos/builtin/packages/ufs-weather-model/package.py
@@ -193,7 +193,6 @@ class UfsWeatherModel(CMakePackage):
             "32bit",
             "app",
             "ccpp_32bit",
-            "ccpp_suites",
             "cmeps_aoflux",
             "debug",
             "debug_linkmpi",


### PR DESCRIPTION
This PR fixes a bug in the ufs-weather-model recipe where CCPP_SUITES gets double defined, where the second definition is incorrect and causes the ccpp python setup to fail. Tested fix on personal machine, builds successfully.