### PR TITLE
py-cloudpickle: add v2.2.1, v3.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-cloudpickle/package.py
+++ b/var/spack/repos/builtin/packages/py-cloudpickle/package.py
@@ -14,6 +14,8 @@ class PyCloudpickle(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.0.0", sha256="996d9a482c6fb4f33c1a35335cf8afd065d2a56e973270364840712d9131a882")
+    version("2.2.1", sha256="d89684b8de9e34a2a43b3460fbca07d09d6e25ce858df4d5a44240403b6178f5")
     version("2.2.0", sha256="3f4219469c55453cfe4737e564b67c2a149109dabf7f242478948b895f61106f")
     version("1.6.0", sha256="9bc994f9e9447593bd0a45371f0e7ac7333710fcf64a4eb9834bf149f4ef2f32")
     version("1.2.1", sha256="603244e0f552b72a267d47a7d9b347b27a3430f58a0536037a290e7e0e212ecf")
@@ -22,4 +24,6 @@ class PyCloudpickle(PythonPackage):
 
     depends_on("python@3.5:", type=("build", "run"), when="@1.6.0:")
     depends_on("python@3.6:", type=("build", "run"), when="@2.2.0:")
-    depends_on("py-setuptools", type="build")
+    depends_on("python@3.8:", type=("build", "run"), when="@3:")
+    depends_on("py-setuptools", type="build", when="@:2")
+    depends_on("py-flit-core", type="build", when="@3:")


### PR DESCRIPTION
This PR adds the version 3.0.0 of cloudpickle which is the first version to use flit-core as build system, and also the last bugfix 2.2.1 in the 2 series.

Test build:
```console
==> Installing py-cloudpickle-3.0.0-ueyb7747turchrl5epuim2imwmtnli2x [27/27]
==> No binary for py-cloudpickle-3.0.0-ueyb7747turchrl5epuim2imwmtnli2x found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/99/996d9a482c6fb4f33c1a35335cf8afd065d2a56e973270364840712d9131a882.tar.gz
==> No patches needed for py-cloudpickle
==> py-cloudpickle: Executing phase: 'install'
==> py-cloudpickle: Successfully installed py-cloudpickle-3.0.0-ueyb7747turchrl5epuim2imwmtnli2x
  Stage: 0.00s.  Install: 0.75s.  Post-install: 0.05s.  Total: 0.91s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/py-cloudpickle-3.0.0-ueyb7747turchrl5epuim2imwmtnli2x
```