### PR TITLE
py-ordered-set: add v4.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-ordered-set/package.py
+++ b/var/spack/repos/builtin/packages/py-ordered-set/package.py
@@ -16,7 +16,10 @@ class PyOrderedSet(PythonPackage):
 
     license("MIT")
 
+    version("4.1.0", sha256="694a8e44c87657c59292ede72891eb91d34131f6531463aab3009191c77364a8")
     version("4.0.2", sha256="ba93b2df055bca202116ec44b9bead3df33ea63a7d5827ff8e16738b97f33a95")
 
     depends_on("python@3.5:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
+    depends_on("python@3.7:", type=("build", "run"), when="@4.1:")
+    depends_on("py-setuptools", type="build", when="@:4.0")
+    depends_on("py-flit-core@3.2:3", type="build", when="@4.1:")


### PR DESCRIPTION
New version of ordered-set, 4.1.0, which is the first version with flit-core as build system. Diffs to pyproject.toml at https://github.com/rspeer/ordered-set/compare/release/4.0.2...release/4.1.0#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711.

```
==> Installing py-ordered-set-4.1.0-43mdaybduxuqvhzovt5ynlm64xtdrmyk [27/27]
==> No binary for py-ordered-set-4.1.0-43mdaybduxuqvhzovt5ynlm64xtdrmyk found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/69/694a8e44c87657c59292ede72891eb91d34131f6531463aab3009191c77364a8.tar.gz
==> No patches needed for py-ordered-set
==> py-ordered-set: Executing phase: 'install'
==> py-ordered-set: Successfully installed py-ordered-set-4.1.0-43mdaybduxuqvhzovt5ynlm64xtdrmyk
  Stage: 0.01s.  Install: 1.22s.  Post-install: 0.08s.  Total: 1.53s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/py-ordered-set-4.1.0-43mdaybduxuqvhzovt5ynlm64xtdrmyk
```