### PR TITLE
msmpi tries to access dependent package hdf5 spack_cc

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1002,16 +1002,17 @@ class SetupContext:
     def set_all_package_py_globals(self):
         """Set the globals in modules of package.py files."""
         for dspec, flag in chain(self.external, self.nonexternal):
-            pkg = dspec.package
-
             if self.should_set_package_py_globals & flag:
+                pkg = dspec.package
                 if self.context == Context.BUILD and self.needs_build_context & flag:
                     set_package_py_globals(pkg, context=Context.BUILD)
                 else:
                     # This includes runtime dependencies, also runtime deps of direct build deps.
                     set_package_py_globals(pkg, context=Context.RUN)
 
+        for dspec, flag in chain(self.external, self.nonexternal):
             for spec in dspec.dependents():
+                pkg = dspec.package
                 # Note: some specs have dependents that are unreachable from the root, so avoid
                 # setting globals for those.
                 if id(spec) not in self.nodes_in_subdag:

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1002,8 +1002,8 @@ class SetupContext:
     def set_all_package_py_globals(self):
         """Set the globals in modules of package.py files."""
         for dspec, flag in chain(self.external, self.nonexternal):
+            pkg = dspec.package
             if self.should_set_package_py_globals & flag:
-                pkg = dspec.package
                 if self.context == Context.BUILD and self.needs_build_context & flag:
                     set_package_py_globals(pkg, context=Context.BUILD)
                 else:
@@ -1015,8 +1015,8 @@ class SetupContext:
         # any package setup. This guarantees package setup methods have
         # access to expected module level definitions such as "spack_cc"
         for dspec, flag in chain(self.external, self.nonexternal):
+            pkg = dspec.package
             for spec in dspec.dependents():
-                pkg = dspec.package
                 # Note: some specs have dependents that are unreachable from the root, so avoid
                 # setting globals for those.
                 if id(spec) not in self.nodes_in_subdag:

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1010,6 +1010,10 @@ class SetupContext:
                     # This includes runtime dependencies, also runtime deps of direct build deps.
                     set_package_py_globals(pkg, context=Context.RUN)
 
+        # Looping over the set of packages a second time
+        # ensures all globals are loaded into the module space prior to
+        # any package setup. This guarantees package setup methods have
+        # access to expected module level definitions such as "spack_cc"
         for dspec, flag in chain(self.external, self.nonexternal):
             for spec in dspec.dependents():
                 pkg = dspec.package

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -513,8 +513,8 @@ def test_setting_dtags_based_on_config(config_setting, expected_flag, config, mo
         assert dtags_to_add.value == expected_flag
 
 
-def test_module_globals_available_at_setup(monkeypatch):
-    def setup_dependent_package(self, module, dependent_spec):
+def test_module_globals_available_at_setup(monkeypatch, mutable_config, mock_packages):
+    def setup_dependent_package(module, dependent_spec):
         # Make sure set_package_py_globals was already called on
         # dependents
         # ninja is always set by the setup context and is not None
@@ -523,12 +523,8 @@ def test_module_globals_available_at_setup(monkeypatch):
         assert dependent_module.ninja is not None
         dependent_spec.package.test_attr = True
 
-    ext_config = {"externals": [{"spec": "externaltool@1.0", "prefix": "/fake/path"}]}
-    spack.config.set("packages:externaltool", ext_config)
-    externaltool = spack.spec.Spec("externaltool").concretized()
-    monkeypatch.setattr(
-        externaltool["externalprereq"].package, "setup_dependent_package", setup_dependent_package
-    )
+    externaltool = spack.spec.Spec("externaltest").concretized()
+    monkeypatch.setattr(externaltool["externaltool"].package, "setup_dependent_package", setup_dependent_package)
     spack.build_environment.setup_package(externaltool.package, False)
     assert externaltool.package.test_attr
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -519,6 +519,7 @@ def test_module_globals_available_at_setup_dependent_time(
     """Spack built package externaltest depends on an external package
     externaltool. Externaltool's setup_dependent_package needs to be able to
     access globals on the dependent"""
+
     def setup_dependent_package(module, dependent_spec):
         # Make sure set_package_py_globals was already called on
         # dependents

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -513,6 +513,31 @@ def test_setting_dtags_based_on_config(config_setting, expected_flag, config, mo
         assert dtags_to_add.value == expected_flag
 
 
+def test_module_globals_available_at_setup(monkeypatch):
+    def setup_dependent_package(self, module, dependent_spec):
+        # Make sure set_package_py_globals was already called on
+        # dependents
+        # ninja is always set by the setup context and is not None
+        dependent_module = dependent_spec.package.module
+        assert hasattr(dependent_module, "ninja")
+        assert dependent_module.ninja is not None
+        dependent_spec.package.test_attr = True
+
+    ext_config = {
+        "externals": [
+            {
+                "spec": "externaltool@1.0",
+                "prefix": "/fake/path",
+            }
+        ]
+    }
+    spack.config.set("packages:externaltool", ext_config)
+    externaltool = spack.spec.Spec("externaltool").concretized()
+    monkeypatch.setattr(externaltool["externalprereq"].package, "setup_dependent_package", setup_dependent_package)
+    spack.build_environment.setup_package(externaltool.package, False)
+    assert externaltool.package.test_attr
+
+
 def test_build_jobs_sequential_is_sequential():
     assert (
         determine_number_of_jobs(

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -513,9 +513,12 @@ def test_setting_dtags_based_on_config(config_setting, expected_flag, config, mo
         assert dtags_to_add.value == expected_flag
 
 
-def test_module_globals_available_at_setup(
+def test_module_globals_available_at_setup_dependent_time(
     monkeypatch, mutable_config, mock_packages, working_env
 ):
+    """Spack built package externaltest depends on an external package
+    externaltool. Externaltool's setup_dependent_package needs to be able to
+    access globals on the dependent"""
     def setup_dependent_package(module, dependent_spec):
         # Make sure set_package_py_globals was already called on
         # dependents

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -523,17 +523,12 @@ def test_module_globals_available_at_setup(monkeypatch):
         assert dependent_module.ninja is not None
         dependent_spec.package.test_attr = True
 
-    ext_config = {
-        "externals": [
-            {
-                "spec": "externaltool@1.0",
-                "prefix": "/fake/path",
-            }
-        ]
-    }
+    ext_config = {"externals": [{"spec": "externaltool@1.0", "prefix": "/fake/path"}]}
     spack.config.set("packages:externaltool", ext_config)
     externaltool = spack.spec.Spec("externaltool").concretized()
-    monkeypatch.setattr(externaltool["externalprereq"].package, "setup_dependent_package", setup_dependent_package)
+    monkeypatch.setattr(
+        externaltool["externalprereq"].package, "setup_dependent_package", setup_dependent_package
+    )
     spack.build_environment.setup_package(externaltool.package, False)
     assert externaltool.package.test_attr
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -513,7 +513,7 @@ def test_setting_dtags_based_on_config(config_setting, expected_flag, config, mo
         assert dtags_to_add.value == expected_flag
 
 
-def test_module_globals_available_at_setup(monkeypatch, mutable_config, mock_packages):
+def test_module_globals_available_at_setup(monkeypatch, mutable_config, mock_packages, working_env):
     def setup_dependent_package(module, dependent_spec):
         # Make sure set_package_py_globals was already called on
         # dependents

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -524,7 +524,9 @@ def test_module_globals_available_at_setup(monkeypatch, mutable_config, mock_pac
         dependent_spec.package.test_attr = True
 
     externaltool = spack.spec.Spec("externaltest").concretized()
-    monkeypatch.setattr(externaltool["externaltool"].package, "setup_dependent_package", setup_dependent_package)
+    monkeypatch.setattr(
+        externaltool["externaltool"].package, "setup_dependent_package", setup_dependent_package
+    )
     spack.build_environment.setup_package(externaltool.package, False)
     assert externaltool.package.test_attr
 

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -513,7 +513,9 @@ def test_setting_dtags_based_on_config(config_setting, expected_flag, config, mo
         assert dtags_to_add.value == expected_flag
 
 
-def test_module_globals_available_at_setup(monkeypatch, mutable_config, mock_packages, working_env):
+def test_module_globals_available_at_setup(
+    monkeypatch, mutable_config, mock_packages, working_env
+):
     def setup_dependent_package(module, dependent_spec):
         # Make sure set_package_py_globals was already called on
         # dependents

--- a/var/spack/repos/builtin.mock/packages/externaltool/package.py
+++ b/var/spack/repos/builtin.mock/packages/externaltool/package.py
@@ -15,9 +15,3 @@ class Externaltool(Package):
     version("0.8.1", md5="1234567890abcdef1234567890abcdef")
 
     depends_on("externalprereq")
-
-    def setup_dependent_package(self, module, dependent_spec):
-        # Make sure set_package_py_globals was already called on
-        # dependents (so dependant_module.spack_cc is set)
-        dependent_module = dependent_spec.package.module
-        assert dependent_module.spack_cc is not None

--- a/var/spack/repos/builtin.mock/packages/externaltool/package.py
+++ b/var/spack/repos/builtin.mock/packages/externaltool/package.py
@@ -15,3 +15,9 @@ class Externaltool(Package):
     version("0.8.1", md5="1234567890abcdef1234567890abcdef")
 
     depends_on("externalprereq")
+
+    def setup_dependent_package(self, module, dependent_spec):
+        # Make sure set_package_py_globals was already called on
+        # dependents (so dependant_module.spack_cc is set)
+        dependent_module = dependent_spec.package.module
+        assert dependent_module.spack_cc is not None


### PR DESCRIPTION
The full error:
```
==> Installing hdf5-1.14.3-ohtopgtkb3nmwyxxgqdpwjvvnttospev [24/35] ==> No binary for hdf5-1.14.3-ohtopgtkb3nmwyxxgqdpwjvvnttospev found: installing from source ==> Error: AttributeError: module 'spack.pkg.builtin.hdf5' has no attribute 'spack_cc'

The 'hdf5' package cannot find an attribute while trying to build from sources. This might be due to a change in Spack's package format to support multiple build-systems for a single package. You can fix this by updating the build recipe, and you can also report the issue as a bug. More information at https://spack.readthedocs.io/en/latest/packaging_guide.html#installation-procedure

C:\Users\dan.lipsa\projects\spack\var\spack\repos\builtin\packages\msmpi\package.py:48, in setup_dependent_package:
         45        # be manually supplied to compiler by consuming package
         46        # Note: This is not typical of MPI installations
         47        dependent_module = dependent_spec.package.module
  >>     48        self.spec.mpicc = dependent_module.spack_cc
         49        self.spec.mpicxx = dependent_module.spack_cxx
         50        self.spec.mpifc = dependent_module.spack_fc
         51        self.spec.mpif77 = dependent_module.spack_f77
```

Changes to msmpi by 1fe8e63481 caused this error.



<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
