### PR TITLE
Apply patch to allow vtk to compile with %gcc 13 and 14. Fixes #44331

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -214,7 +214,7 @@ class Vtk(CMakePackage):
     patch(
         "https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9996.diff",
         sha256="dab51ffd0d62b00c089c1245e6b105f740106b53893305c87193d4ba03a948e0",
-        when="@9.1:9.2 %gcc@13:"
+        when="@9.1:9.2 %gcc@13:",
     )
 
     @when("@9.2:")

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -211,12 +211,11 @@ class Vtk(CMakePackage):
 
     # vtk@9 does not compile with gcc 13 or 14
     # https://gitlab.kitware.com/vtk/vtk/-/issues/18782
-    if self.spec.statisfies("%gcc@13") or self.spec.statisfies("%gcc@14"):
-        patch(
-            "https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9996.patch",
-            sha256="48755539f47c51ed1efdc028da17aae580f816cd29f97f9adc479f90228fe3e4",
-            when="@9"
-        )
+    patch(
+        "https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9996.patch",
+        sha256="48755539f47c51ed1efdc028da17aae580f816cd29f97f9adc479f90228fe3e4",
+        when="@9 %gcc@14"
+    )
 
     @when("@9.2:")
     def patch(self):

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -212,9 +212,9 @@ class Vtk(CMakePackage):
     # vtk@9 does not compile with gcc 13 or 14
     # https://gitlab.kitware.com/vtk/vtk/-/issues/18782
     patch(
-        "https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9996.patch",
-        sha256="48755539f47c51ed1efdc028da17aae580f816cd29f97f9adc479f90228fe3e4",
-        when="@9 %gcc@13:14"
+        "https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9996.diff",
+        sha256="dab51ffd0d62b00c089c1245e6b105f740106b53893305c87193d4ba03a948e0",
+        when="@9.1:9.2 %gcc@13:"
     )
 
     @when("@9.2:")

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -214,7 +214,7 @@ class Vtk(CMakePackage):
     patch(
         "https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9996.patch",
         sha256="48755539f47c51ed1efdc028da17aae580f816cd29f97f9adc479f90228fe3e4",
-        when="@9 %gcc@14"
+        when="@9 %gcc@13:14"
     )
 
     @when("@9.2:")

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -209,6 +209,15 @@ class Vtk(CMakePackage):
         when="@9.1",
     )
 
+    # vtk@9 does not compile with gcc 13 or 14
+    # https://gitlab.kitware.com/vtk/vtk/-/issues/18782
+    if self.spec.statisfies("%gcc@13") or self.spec.statisfies("%gcc@14"):
+        patch(
+            "https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9996.patch",
+            sha256="48755539f47c51ed1efdc028da17aae580f816cd29f97f9adc479f90228fe3e4",
+            when="@9"
+        )
+
     @when("@9.2:")
     def patch(self):
         # provide definition for Ioss::Init::Initializer::Initializer(),


### PR DESCRIPTION
fixes #44331

vtk@9.2 doesn't compile with gcc%13 or 14. This is a known issue.
https://gitlab.kitware.com/vtk/vtk/-/issues/18782

the patch was back ported in
https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9996

and this applies that patch.