### PR TITLE
gperftools: Don't build benchmarks or tests

### DIFF
--- a/var/spack/repos/builtin/packages/gperftools/package.py
+++ b/var/spack/repos/builtin/packages/gperftools/package.py
@@ -68,6 +68,8 @@ class CMakeBuilder(cmake.CMakeBuilder):
             ),
             self.define_from_variant("GPERFTOOLS_BUILD_DEBUGALLOC", "debugalloc"),
             self.define_from_variant("gperftools_enable_libunwind", "libunwind"),
+            self.define("gperftools_build_benchmark", False),
+            self.define("BUILD_TESTING", False),
         ]
 
 


### PR DESCRIPTION
Happens to fix #44260.

@Chrismarsh 