### PR TITLE
libxkbcommon: add v1.7.0, v1.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/libxkbcommon/package.py
+++ b/var/spack/repos/builtin/packages/libxkbcommon/package.py
@@ -22,6 +22,8 @@ class Libxkbcommon(MesonPackage, AutotoolsPackage):
 
     license("MIT")
 
+    version("1.7.0", sha256="65782f0a10a4b455af9c6baab7040e2f537520caa2ec2092805cdfd36863b247")
+    version("1.6.0", sha256="0edc14eccdd391514458bc5f5a4b99863ed2d651e4dd761a90abf4f46ef99c2b")
     version("1.5.0", sha256="560f11c4bbbca10f495f3ef7d3a6aa4ca62b4f8fb0b52e7d459d18a26e46e017")
     version("1.4.1", sha256="943c07a1e2198026d8102b17270a1f406e4d3d6bbc4ae105b9e1b82d7d136b39")
     version("1.4.0", sha256="106cec5263f9100a7e79b5f7220f889bc78e7d7ffc55d2b6fdb1efefb8024031")
@@ -46,6 +48,7 @@ class Libxkbcommon(MesonPackage, AutotoolsPackage):
     depends_on("meson@0.41:", type="build", when="@0.9:")
     depends_on("meson@0.49:", type="build", when="@1.0:")
     depends_on("meson@0.51:", type="build", when="@1.5:")
+    depends_on("meson@0.52:", type="build", when="@1.6:")
     depends_on("pkgconfig@0.9.0:", type="build")
     depends_on("bison", type="build")
     depends_on("util-macros")
@@ -59,11 +62,16 @@ class Libxkbcommon(MesonPackage, AutotoolsPackage):
 
 class MesonBuilder(spack.build_systems.meson.MesonBuilder):
     def meson_args(self):
-        return [
+        args = [
             "-Dxkb-config-root={0}".format(self.spec["xkbdata"].prefix),
             "-Denable-docs=false",
             "-Denable-wayland=" + str(self.spec.satisfies("+wayland")),
         ]
+
+        if self.spec.satisfies("@1.6:"):
+            args.append("-Denable-bash-completion=false")
+
+        return args
 
 
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):


### PR DESCRIPTION
This adds two new versions of libxkbcommon.

Version 1.6.0 [introduced bash completions](https://github.com/xkbcommon/libxkbcommon/commit/1c1542d64f37c67bf29c3de1e06735fd79cc50ea) which pick up the system-wide completion scripts directory. For this reason, I've elected to disable bash completions.

```
==> In environment libxkbcommon
==> 3 root specs
[+] qnkguq6 libxkbcommon@1.5.0  [+] ttz6g4h libxkbcommon@1.6.0  [+] apjhy5i libxkbcommon@1.7.0

==> Installed packages
-- linux-ubuntu24.04-skylake / gcc@13.2.0 -----------------------
qnkguq6 libxkbcommon@1.5.0~strip~wayland build_system=meson buildtype=release default_library=shared  apjhy5i libxkbcommon@1.7.0~strip+wayland build_system=meson buildtype=release default_library=shared
ttz6g4h libxkbcommon@1.6.0~strip~wayland build_system=meson buildtype=release default_library=shared
==> 3 installed packages
```