### PR TITLE
improvements for dlib;highway;libjxl

### DIFF
--- a/var/spack/repos/builtin/packages/dlib/package.py
+++ b/var/spack/repos/builtin/packages/dlib/package.py
@@ -70,7 +70,7 @@ class Dlib(CMakePackage, CudaPackage):
             self.define_from_variant("DLIB_WEBP_SUPPORT", "webp"),
             self.define_from_variant("DLIB_USE_CUDA", "cuda"),
         ]
-        self.spec.satisfies("+cuda"):
+        if spec.satisfies("+cuda"):
             args.append(
                 self.define(
                     "DLIB_USE_CUDA_COMPUTE_CAPABILITIES", self.spec.variants["cuda_arch"].value

--- a/var/spack/repos/builtin/packages/dlib/package.py
+++ b/var/spack/repos/builtin/packages/dlib/package.py
@@ -70,7 +70,7 @@ class Dlib(CMakePackage, CudaPackage):
             self.define_from_variant("DLIB_WEBP_SUPPORT", "webp"),
             self.define_from_variant("DLIB_USE_CUDA", "cuda"),
         ]
-        if "+cuda" in self.spec:
+        self.spec.satisfies("+cuda"):
             args.append(
                 self.define(
                     "DLIB_USE_CUDA_COMPUTE_CAPABILITIES", self.spec.variants["cuda_arch"].value

--- a/var/spack/repos/builtin/packages/dlib/package.py
+++ b/var/spack/repos/builtin/packages/dlib/package.py
@@ -5,7 +5,7 @@
 from spack.package import *
 
 
-class Dlib(CMakePackage):
+class Dlib(CMakePackage, CudaPackage):
     """toolkit containing machine learning algorithms and tools
     for creating complex software in C++ to solve real world problems"""
 
@@ -24,20 +24,57 @@ class Dlib(CMakePackage):
     version("19.20", sha256="fc3f0986350e8e53aceadf95a71d2f413f1eedc469abda99a462cb528741d411")
     version("19.19", sha256="7af455bb422d3ae5ef369c51ee64e98fa68c39435b0fa23be2e5d593a3d45b87")
 
+    variant("ffmpeg", default=False, description="build ffmpeg image support")
+    variant("gif", default=False, description="build gif image support")
+    variant("gui", default=False, description="build dlib graphical support")
+    variant("jpeg", default=False, description="build jpeg image support")
+    variant("jxl", default=False, description="build jxl image support")
+    variant("png", default=False, description="build png image support")
     variant("shared", default=True, description="build the shared libraries")
+    variant("sqlite", default=False, description="build sqlite3 support")
+    variant("webp", default=False, description="build webp image support")
+    variant("blas", default=True, description="build blas image support")
+    variant("lapack", default=True, description="build lapack image support")
 
     depends_on("zlib-api")
-    depends_on("libpng")
-    depends_on("libjpeg")
-    depends_on("blas")
-    depends_on("lapack")
-    depends_on("libsm")
-    depends_on("libx11")
+    depends_on("ffmpeg", when="+ffmpeg")
+    depends_on("libjxl@0.10.2:", when="+jxl")
+    depends_on("giflib", when="+gif")
+    depends_on("libpng", when="+png")
+    depends_on("libwebp", when="+webp")
+    depends_on("libjpeg", when="+jpeg")
+    depends_on("sqlite", when="+sqlite")
+    depends_on("blas", when="+blas")
+    depends_on("lapack", when="+lapack")
+    depends_on("libsm", when="+gui")
+    depends_on("libx11", when="+gui")
+    depends_on("cuda@7.5:", when="+cuda")
+    depends_on("cudnn", when="+cuda")
+    # depends on the deprecated FindCUDA module dependency as of 19.24.4
+    # when cuda is enabled
+    depends_on("cmake@:3.26", when="+cuda")
 
     def cmake_args(self):
         spec = self.spec
-        args = []
-        if spec.satisfies("+shared"):
-            args.append(self.define("BUILD_SHARED_LIBS", "ON"))
+        args = [
+            self.define_from_variant("DLIB_USE_BLAS", "blas"),
+            self.define_from_variant("DLIB_USE_LAPACK", "lapack"),
+            self.define_from_variant("DLIB_USE_FFMPEG", "ffmpeg"),
+            self.define_from_variant("DLIB_GIF_SUPPORT", "gif"),
+            self.define("DLIB_NO_GUI_SUPPORT", spec.satisfies("~gui")),
+            self.define_from_variant("DLIB_JPEG_SUPPORT", "jpeg"),
+            self.define_from_variant("DLIB_JXL_SUPPORT", "jxl"),
+            self.define_from_variant("DLIB_PNG_SUPPORT", "png"),
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("DLIB_LINK_WITH_SQLITE3", "sqlite"),
+            self.define_from_variant("DLIB_WEBP_SUPPORT", "webp"),
+            self.define_from_variant("DLIB_USE_CUDA", "cuda"),
+        ]
+        if "+cuda" in self.spec:
+            args.append(
+                self.define(
+                    "DLIB_USE_CUDA_COMPUTE_CAPABILITIES", self.spec.variants["cuda_arch"].value
+                )
+            )
 
         return args

--- a/var/spack/repos/builtin/packages/highway/package.py
+++ b/var/spack/repos/builtin/packages/highway/package.py
@@ -28,7 +28,10 @@ class Highway(CMakePackage):
     depends_on("googletest", type="test")
 
     def cmake_args(self):
-        args = []
+        args = [
+            self.define("HWY_ENABLE_TESTS", self.run_tests),
+            self.define("BUILD_TESTING", self.run_tests),
+        ]
         if self.run_tests:
             args.append(self.define("HWY_SYSTEM_GTEST", True))
         return args

--- a/var/spack/repos/builtin/packages/libjxl/package.py
+++ b/var/spack/repos/builtin/packages/libjxl/package.py
@@ -17,6 +17,9 @@ class Libjxl(CMakePackage):
 
     version("main", branch="main", submodules=True)
     version(
+        "0.10.2", tag="v0.10.2", commit="e1489592a770b989303b0edc5cc1dc447bbe0515", submodules=True
+    )
+    version(
         "0.7.0", tag="v0.7.0", commit="f95da131cf7c7ccd4da256356fde2fec1fa23bb5", submodules=True
     )
     version(
@@ -40,6 +43,7 @@ class Libjxl(CMakePackage):
         args = [
             self.define("JPEGXL_FORCE_SYSTEM_BROTLI", True),
             self.define("JPEGXL_FORCE_SYSTEM_HWY", True),
+            self.define("BUILD_TESTING", self.run_tests),
         ]
 
         if self.run_tests:


### PR DESCRIPTION
Add many variants to dlib to allow more minimal dependencies, enable features not enabled by default, and fix build errors on some systems.

For highway, disable building tests by default to vastly improve install times.

For libjxl, add new version required by dlib, and disable the building of tests by default to improve install times.
