### PR TITLE
mapl: add conflicts for intel 2021.7

### DIFF
--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -224,6 +224,10 @@ class Mapl(CMakePackage):
         values=("Debug", "Release", "Aggressive"),
     )
 
+    # https://github.com/JCSDA/spack-stack/issues/769
+    conflicts("+pflogger", when="@:2.40.3 %intel@2021.7:")
+    conflicts("+extdata2g", when="@:2.40.3 %intel@2021.7:")
+
     depends_on("cmake@3.17:", type="build")
     depends_on("mpi")
     depends_on("hdf5")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

@climbfuji and the JCSDA spack-stack folks found an issue with older MAPL tags and Intel (see https://github.com/JCSDA/spack-stack/issues/769). This PR adds in their `conflicts` from their fork to mainline so all get the benefit.