### PR TITLE
vtk: add patch for missing includes

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -59,13 +59,18 @@ class Vtk(CMakePackage):
     variant("examples", default=False, description="Enable building & installing the VTK examples")
 
     patch("gcc.patch", when="@6.1.0")
-    # patch to fix some missing stl includes
-    # which lead to build errors on newer compilers
 
+    # patches to fix some missing stl includes
+    # which lead to build errors on newer compilers
     patch(
         "https://gitlab.kitware.com/vtk/vtk/-/commit/e066c3f4fbbfe7470c6207db0fc3f3952db633c.diff",
         when="@9:9.0",
         sha256="0546696bd02f3a99fccb9b7c49533377bf8179df16d901cefe5abf251173716d",
+    )
+    patch(
+        "https://gitlab.kitware.com/vtk/vtk/-/commit/1233ceec268d5366c66f5e79786ec784042b591.diff",
+        when="@9.1:9.2",
+        sha256="38380bd20443d94d8ce9f339b9b2fbdea03400aa9d6dbb7e3ef138a65f11c080",
     )
 
     # Patch for paraview 5.10: +hdf5 ^hdf5@1.13.2:


### PR DESCRIPTION
The goal of the PR is to backport the patch corresponding to the following upstream commit : https://gitlab.kitware.com/vtk/vtk/-/commit/1233ceec268d5366c66f5e79786ec784042b591b

The fix is meant for all vtk versions from 9.1 to 9.2.

The PR is meant to allow tobuild VTK with newer compiler such as gcc 13 that require the <cstdint> header to be present to use its contents, whereas earlier versions were more lenient.

The issue was originnaly created by the following commit : https://gitlab.kitware.com/vtk/vtk/-/commit/e20e9c6fcb49a869c34ae2554e223f36b6a77380?merge_request_iid=7516 
