### PR TITLE
`proj@7`: Fix patch being applied that causes an error

### DIFF
--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -92,7 +92,7 @@ class Proj(CMakePackage, AutotoolsPackage):
         # CMake 3.19 refactored the FindTiff module interface, update older proj's
         # to be compatible with this "new" interface
         # patch replaces the TIFF_LIBRARY variable (no longer used) with TIFF_LIBRARIES
-        patch("proj-8.1-cmake-3.29-new-tiff-interface.patch", when="+tiff @7:9.1.0 ^cmake@3.19:")
+        patch("proj-8.1-cmake-3.29-new-tiff-interface.patch", when="+tiff @8:9.1.0 ^cmake@3.19:")
         patch("proj.cmakelists.5.0.patch", when="@5.0")
         patch("proj.cmakelists.5.1.patch", when="@5.1:5.2")
         conflicts("cmake@3.19:", when="@:7")


### PR DESCRIPTION
The patch `proj-8.1-cmake-3.29-new-tiff-interface.patch` conflicts with `proj@7`:
```
==> Applied patch https://github.com/OSGeo/PROJ/commit/3f38a67a354a3a1e5cca97793b9a43860c380d95.patch?full_index=1
1 out of 1 hunk FAILED -- saving rejects to file src/lib_proj.cmake.rej
==> Patch /fs/homeu2/eccc/crd/ords/ccrp/chm003/spack/var/spack/repos/builtin/packages/proj/proj-8.1-cmake-3.29-new-tiff-interface.patch failed.
==> Error: ProcessError: Command exited with status 1:
    '/usr/bin/patch' '-s' '-p' '1' '-i' '/fs/homeu2/eccc/crd/ords/ccrp/chm003/spack/var/spack/repos/builtin/packages/proj/proj-8.1-cmake-3.29-new-t
```
`proj@9` seems to tolerate this patch when testing, so I have not touched that range. 

@adamjstewart 

