### PR TITLE
`seacas`: protect against known mixed-toolchain problem

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -235,7 +235,7 @@ class Seacas(CMakePackage):
     # it triggers a bug in apple-clang w.r.t how symbols are mangled
     # https://github.com/spack/spack/issues/44330
     conflicts(
-        "fmt@9%gcc",
+        "^fmt@9%gcc",
         msg="""Cannot mix gcc/apple-clang toolchains
               for this library combination.
               See https://github.com/spack/spack/issues/44330""",

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -231,6 +231,14 @@ class Seacas(CMakePackage):
     depends_on("fmt@9.1.0", when="@2022-10-14:2023-05-30")
     depends_on("fmt@8.1.0:9", when="@2022-03-04:2022-05-16")
 
+    # if fmt@9.1.0%gcc is mixed with an %apple-clang seacas build
+    # it triggers a bug in apple-clang w.r.t how symbols are mangled
+    # https://github.com/spack/spack/issues/44330
+    conflicts("fmt@9%gcc", msg="""Cannot mix gcc/apple-clang toolchains 
+              for this library combination. 
+              See https://github.com/spack/spack/issues/44330""",              
+              when="%apple-clang")
+
     depends_on("catch2@3:", when="@2024-03-11:+tests")
 
     depends_on("matio", when="+matio")

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -236,8 +236,8 @@ class Seacas(CMakePackage):
     # https://github.com/spack/spack/issues/44330
     conflicts(
         "fmt@9%gcc",
-        msg="""Cannot mix gcc/apple-clang toolchains 
-              for this library combination. 
+        msg="""Cannot mix gcc/apple-clang toolchains
+              for this library combination.
               See https://github.com/spack/spack/issues/44330""",
         when="%apple-clang",
     )

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -234,10 +234,13 @@ class Seacas(CMakePackage):
     # if fmt@9.1.0%gcc is mixed with an %apple-clang seacas build
     # it triggers a bug in apple-clang w.r.t how symbols are mangled
     # https://github.com/spack/spack/issues/44330
-    conflicts("fmt@9%gcc", msg="""Cannot mix gcc/apple-clang toolchains 
+    conflicts(
+        "fmt@9%gcc",
+        msg="""Cannot mix gcc/apple-clang toolchains 
               for this library combination. 
-              See https://github.com/spack/spack/issues/44330""",              
-              when="%apple-clang")
+              See https://github.com/spack/spack/issues/44330""",
+        when="%apple-clang",
+    )
 
     depends_on("catch2@3:", when="@2024-03-11:+tests")
 


### PR DESCRIPTION
Fixes  #44330

When `fmt%gcc` is mixed with `seacas@2022-10-14%apple-clang`, `fmt@9` is used which triggers an apple-clang compiler bug in symbol mangling.

@gsjaardema
