### PR TITLE
py-editables: add v0.4, v0.5 (switch to flit-core)

### DIFF
--- a/var/spack/repos/builtin/packages/py-editables/package.py
+++ b/var/spack/repos/builtin/packages/py-editables/package.py
@@ -12,7 +12,10 @@ class PyEditables(PythonPackage):
     homepage = "https://github.com/pfmoore/editables"
     pypi = "editables/editables-0.3.tar.gz"
 
+    version("0.5", sha256="309627d9b5c4adc0e668d8c6fa7bac1ba7c8c5d415c2d27f60f081f8e80d1de2")
+    version("0.4", sha256="dc322c42e7ccaf19600874035a4573898d88aadd07e177c239298135b75da772")
     version("0.3", sha256="167524e377358ed1f1374e61c268f0d7a4bf7dbd046c656f7b410cde16161b1a")
 
     depends_on("python@3.7:", type=("build", "run"))
-    depends_on("py-setuptools@42:", type="build")
+    depends_on("py-setuptools@42:", type="build", when="@:0.3")
+    depends_on("py-flit-core@3.3:", type="build", when="@0.4:")


### PR DESCRIPTION
This adds v0.4 and v0.5 of py-editables. It switches to `py-flit-core` as build system.

Test build:
```
==> Installing py-editables-0.5-togceux5rmlsgx46xwj32zmqrwmcg4z7 [121/158]
==> No binary for py-editables-0.5-togceux5rmlsgx46xwj32zmqrwmcg4z7 found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/e/editables/editables-0.5.tar.gz
==> No patches needed for py-editables
==> py-editables: Executing phase: 'install'
==> py-editables: Successfully installed py-editables-0.5-togceux5rmlsgx46xwj32zmqrwmcg4z7
  Stage: 1.99s.  Install: 1.06s.  Post-install: 0.07s.  Total: 3.33s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/py-editables-0.5-togceux5rmlsgx46xwj32zmqrwmcg4z7
```