### PR TITLE
vtk: limit to using proj@:7

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -173,7 +173,7 @@ class Vtk(CMakePackage):
     depends_on("gl2ps", when="@8.1:")
     depends_on("gl2ps@1.4.1:", when="@9:")
     depends_on("proj@4", when="@8.2.0")
-    depends_on("proj@4:", when="@9:")
+    depends_on("proj@4:7", when="@9:")
     depends_on("cgns@4.1.1:+mpi", when="@9.1: +mpi")
     depends_on("cgns@4.1.1:~mpi", when="@9.1: ~mpi")
     with when("@9.1:"):


### PR DESCRIPTION
This PR limits vtk to using up to version 7 of proj, as it needs proj_api.h, which was removed in proj@8.0.0.