### PR TITLE
Truncate `spack concretize` output in environments

### DIFF
--- a/lib/spack/spack/environment/__init__.py
+++ b/lib/spack/spack/environment/__init__.py
@@ -528,5 +528,6 @@ __all__ = [
     "root",
     "spack_env_var",
     "spack_env_view_var",
+    "unique_roots",
     "update_yaml",
 ]

--- a/lib/spack/spack/environment/__init__.py
+++ b/lib/spack/spack/environment/__init__.py
@@ -493,6 +493,7 @@ from .environment import (
     root,
     spack_env_var,
     spack_env_view_var,
+    unique_roots,
     update_yaml,
 )
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2478,7 +2478,7 @@ def unique_roots(concretized_specs):
     unique = list()
 
     for i, root in enumerate(concretized_roots):
-        others = concretized_roots[:i] + concretized_roots[i+1:]
+        others = concretized_roots[:i] + concretized_roots[i + 1 :]
         if not any(root in x for x in others):
             unique.append(concretized_specs[i])
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2467,6 +2467,24 @@ def _equiv_dict(first, second):
     return same_values and same_keys_with_same_overrides
 
 
+def unique_roots(concretized_specs):
+    """For a list of user/concretized spec pairs, return the list of
+    entries filtering out any that appear as a dependency of any of
+    the others.
+    """
+    concretized_specs = list(concretized_specs)
+    concretized_roots = list(y for x, y in concretized_specs)
+
+    unique = list()
+
+    for i, root in enumerate(concretized_roots):
+        others = concretized_roots[:i] + concretized_roots[i+1:]
+        if not any(root in x for x in others):
+            unique.append(concretized_specs[i])
+
+    return unique
+
+
 def display_specs(concretized_specs):
     """Displays the list of specs returned by `Environment.concretize()`.
 
@@ -2484,7 +2502,7 @@ def display_specs(concretized_specs):
             hashes=True,
         )
 
-    for user_spec, concrete_spec in concretized_specs:
+    for user_spec, concrete_spec in unique_roots(concretized_specs):
         tty.msg("Concretized {0}".format(user_spec))
         sys.stdout.write(_tree_to_display(concrete_spec))
         print("")

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -848,7 +848,8 @@ def test_root_version_weights_for_old_versions(mutable_mock_env_path, mock_packa
 def test_unique_roots(mutable_mock_env_path, mock_packages):
     mutable_mock_env_path.mkdir()
     spack_yaml = mutable_mock_env_path / ev.manifest_name
-    spack_yaml.write_text("""\
+    spack_yaml.write_text(
+        """\
 spack:
   specs:
   - mpileaks

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -843,3 +843,25 @@ def test_root_version_weights_for_old_versions(mutable_mock_env_path, mock_packa
 
     assert bowtie.satisfies("@=1.3.0")
     assert gcc.satisfies("@=1.0")
+
+
+def test_unique_roots(mutable_mock_env_path, mock_packages):
+    mutable_mock_env_path.mkdir()
+    spack_yaml = mutable_mock_env_path / ev.manifest_name
+    spack_yaml.write_text("""\
+spack:
+  specs:
+  - mpileaks
+  - callpath
+  - dependent-install
+  - dependency-install
+  concretizer:
+    unify: true
+"""
+    )
+    e = ev.Environment(mutable_mock_env_path)
+    with e:
+        e.concretize()
+
+    filtered = ev.unique_roots(e.concretized_specs())
+    assert len(filtered) == 2


### PR DESCRIPTION
If you have an environment speclist like:

```
spack:
  specs:
  - x
  - y
  - z
```

where `x -> y -> z`, `spack concretize ...` will print each of x, y, z completely. This PR reduces duplication by omitting a printout of any root spec that is a dependency of another root spec.

This does not eliminate all forms of duplication, e.g. if `x->z` and `y->z`, but `! x->y`, then `z` would be printed for each of `x`, `y`.