### PR TITLE
py-hist: add v2.6.2 thru v2.8.0 (switch to hatchling)

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -106,8 +106,10 @@ spack:
   #- professor
   - py-awkward
   - py-boost-histogram
+  - py-dask-awkward +io
+  - py-dask-histogram
   - py-hepunits
-  - py-hist
+  - py-hist +dask +fit +plot
   - py-histbook
   - py-histoprint
   - py-iminuit

--- a/var/spack/repos/spack_repo/builtin/packages/py_dask_awkward/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_dask_awkward/package.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack_repo.builtin.build_systems.python import PythonPackage
+
 from spack.package import *
 
 
@@ -24,8 +25,8 @@ class PyDaskAwkward(PythonPackage):
     depends_on("python@3.8:", type=("build", "run"))
     depends_on("python@3.9:", type=("build", "run"), when="@2025.3.0:")
 
-    depends_on("py-hatchlingi@1.8.0:", type="build")
-    depends_on("hatch-vcs", type="build")
+    depends_on("py-hatchling@1.8.0:", type="build")
+    depends_on("py-hatch-vcs", type="build")
 
     depends_on("py-awkward@2.5.1:", type=("build", "run"))
     depends_on("py-dask@2023.04:2025.3", type=("build", "run"))

--- a/var/spack/repos/spack_repo/builtin/packages/py_dask_awkward/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_dask_awkward/package.py
@@ -1,0 +1,35 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+from spack.package import *
+
+
+class PyDaskAwkward(PythonPackage):
+    """Connecting awkward-array and Dask."""
+
+    homepage = "https://github.com/dask-contrib/dask-awkward"
+    pypi = "dask_awkward/dask_awkward-2025.5.0.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("BSD-3-Clause", checked_by="wdconinc")
+
+    version("2025.5.0", sha256="2e6e71562055b9b7eadaab5e66b23a78d23274487ebf38669bfd82e7346f3659")
+    version("2024.12.2", sha256="13c5ef32c5489e9e32e9f9163eb13e045f722ed6ed0f17ce1e07f892fc77a547")
+
+    variant("io", default=False, description="Add support for IO")
+
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("python@3.9:", type=("build", "run"), when="@2025.3.0:")
+
+    depends_on("py-hatchlingi@1.8.0:", type="build")
+    depends_on("hatch-vcs", type="build")
+
+    depends_on("py-awkward@2.5.1:", type=("build", "run"))
+    depends_on("py-dask@2023.04:2025.3", type=("build", "run"))
+    depends_on("py-cachetools", type=("build", "run"))
+    depends_on("py-typing-extensions@4.8.0:", type=("build", "run"))
+
+    depends_on("py-pyarrow", type=("build", "run"), when="+io")

--- a/var/spack/repos/spack_repo/builtin/packages/py_dask_histogram/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_dask_histogram/package.py
@@ -17,11 +17,17 @@ class PyDaskHistogram(PythonPackage):
 
     license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("2025.2.0", sha256="ad59f787add2e280ccff409f36b8495d0a782689e6c9797b1d19fd95e3fde067")
+    version("2024.12.1", sha256="cbb8c660c64eaed5c92d1987e9bad5287487548315befb00140caf90201b1641")
     version("2024.9.1", sha256="a3e778b606db4affcc4fc8b6d34f5d99e165ea1691da57f40659032cd79f03e8")
     version("2024.3.0", sha256="834d4d25f5e2c417f5e792fafaa55484c20c9f3812d175125de7ac34f994ef7b")
+
+    depends_on("python@3.8:", type=("build", "run"))
+    depends_on("python@3.9:", type=("build", "run"), when="@2025.2.0:")
 
     depends_on("py-hatchling@1.8:", type="build")
     depends_on("py-hatch-vcs", type="build")
 
     depends_on("py-boost-histogram@1.3.2:", type=("build", "run"))
     depends_on("py-dask@2021.03.0:", type=("build", "run"))
+    depends_on("py-dask-awkward@2025:", type=("build", "run"), when="@2025.2.0:")

--- a/var/spack/repos/spack_repo/builtin/packages/py_dask_histogram/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_dask_histogram/package.py
@@ -1,0 +1,26 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyDaskHistogram(PythonPackage):
+    """Histograms with task scheduling."""
+
+    homepage = "https://github.com/dask-contrib/dask-histogram"
+    pypi = "dask_histogram/dask_histogram-2024.3.0.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("BSD-3-Clause", checked_by="wdconinc")
+
+    version("2024.3.0", sha256="834d4d25f5e2c417f5e792fafaa55484c20c9f3812d175125de7ac34f994ef7b")
+
+    depends_on("py-hatchling@1.8.0:", type="build")
+    depends_on("py-hatch-vcs", type="build")
+
+    depends_on("py-boost-histogram@1.3.2:", type=("build", "run"))
+    depends_on("py-dask@2021.03.0:", type=("build", "run"))

--- a/var/spack/repos/spack_repo/builtin/packages/py_dask_histogram/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_dask_histogram/package.py
@@ -17,6 +17,7 @@ class PyDaskHistogram(PythonPackage):
 
     license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("2024.9.1", sha256="a3e778b606db4affcc4fc8b6d34f5d99e165ea1691da57f40659032cd79f03e8")
     version("2024.3.0", sha256="834d4d25f5e2c417f5e792fafaa55484c20c9f3812d175125de7ac34f994ef7b")
 
     depends_on("py-hatchling@1.8.0:", type="build")

--- a/var/spack/repos/spack_repo/builtin/packages/py_dask_histogram/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_dask_histogram/package.py
@@ -20,7 +20,7 @@ class PyDaskHistogram(PythonPackage):
     version("2024.9.1", sha256="a3e778b606db4affcc4fc8b6d34f5d99e165ea1691da57f40659032cd79f03e8")
     version("2024.3.0", sha256="834d4d25f5e2c417f5e792fafaa55484c20c9f3812d175125de7ac34f994ef7b")
 
-    depends_on("py-hatchling@1.8.0:", type="build")
+    depends_on("py-hatchling@1.8:", type="build")
     depends_on("py-hatch-vcs", type="build")
 
     depends_on("py-boost-histogram@1.3.2:", type=("build", "run"))

--- a/var/spack/repos/spack_repo/builtin/packages/py_hist/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_hist/package.py
@@ -30,6 +30,7 @@ class PyHist(PythonPackage):
     variant("fit", default=False, description="Add support for fitting histograms", when="@2.7.1:")
 
     depends_on("python@3.7:", type=("build", "run"))
+    depends_on("python@3.8:", type=("build", "run"), when="@2.8.0:")
     with when("@:2.6.1"):
         depends_on("py-setuptools@45:", type="build")
         depends_on("py-setuptools-scm@3.4:+toml", type="build")

--- a/var/spack/repos/spack_repo/builtin/packages/py_hist/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_hist/package.py
@@ -43,9 +43,9 @@ class PyHist(PythonPackage):
     depends_on("py-boost-histogram@1.3.1:1.4", when="@2.7.2:", type=("build", "run"))
     depends_on("py-boost-histogram@1.3.1:1.5", when="@2.8.0:", type=("build", "run"))
     depends_on("py-histoprint@2.2.0:", type=("build", "run"))
-    depends_on("py-numpy@1.14.5:", type=("build", "run"), when="@:2.7.1")
-    depends_on("py-numpy@1.14.5:", type=("build", "run"), when="@2.7.2: ^python@:3.11")
-    depends_on("py-numpy@1.26:", type=("build", "run"), when="@2.7.2: ^python@3.12:")
+    depends_on("py-numpy@1.14.5:", type=("build", "run"), when="@:2.7.1,2.7.3:")
+    depends_on("py-numpy@1.14.5:", type=("build", "run"), when="@2.7.2 ^python@:3.11")
+    depends_on("py-numpy@1.26:", type=("build", "run"), when="@2.7.2 ^python@3.12:")
     depends_on("py-typing-extensions@3.7:", when="@:2.6 ^python@:3.7", type=("build", "run"))
     depends_on("py-typing-extensions@4:", when="@2.7: ^python@:3.11", type=("build", "run"))
 

--- a/var/spack/repos/spack_repo/builtin/packages/py_hist/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_hist/package.py
@@ -15,6 +15,8 @@ class PyHist(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2.8.0", sha256="0a3e602dd1d2721bd7f2229f456709dde323f6f74952f13ba4e5986c3275f77b")
+    version("2.7.3", sha256="f9f9b56809b190bb546698789cc0d7d040934fc5141d2763c6e49d65e81dbc0b")
     version("2.7.2", sha256="26b1ab810d8b10222db5d161d4acaf64aaa04fe6baaed2966d41c1dac5601d06")
     version("2.7.1", sha256="ffbe314c2bd03c342b9f168dce715ad8f36281eb23172a00970882a9344fe988")
     version("2.7.0", sha256="0ce40fd898ded8ef23d97c77cf1da9caf47b3caaef5fde190055d4d679a2d7a4")

--- a/var/spack/repos/spack_repo/builtin/packages/py_hist/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_hist/package.py
@@ -15,21 +15,45 @@ class PyHist(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2.7.2", sha256="26b1ab810d8b10222db5d161d4acaf64aaa04fe6baaed2966d41c1dac5601d06")
+    version("2.7.1", sha256="ffbe314c2bd03c342b9f168dce715ad8f36281eb23172a00970882a9344fe988")
+    version("2.7.0", sha256="0ce40fd898ded8ef23d97c77cf1da9caf47b3caaef5fde190055d4d679a2d7a4")
+    version("2.6.3", sha256="dede097733d50b273af9f67386e6dcccaab77e900ae702e1a9408a856e217ce9")
+    version("2.6.2", sha256="55bb6366728ee48cb3fe48f20f92f0dbc560837a95961c39651699bb63af720a")
     version("2.6.1", sha256="ee9034795fd2feefed923461aaccaf76f87c1f8d5414b1e704faa293ceb4fc27")
     version("2.5.2", sha256="0bafb8b956cc041f1b26e8f5663fb8d3b8f7673f56336facb84d8cfdc30ae2cf")
 
     variant("plot", default=False, description="Add support for drawing histograms")
+    variant("dask", default=False, description="Add support for dask histograms", when="@2.6.3:")
+    variant("fit", default=False, description="Add support for fitting histograms", when="@2.7.1:")
 
     depends_on("python@3.7:", type=("build", "run"))
-    depends_on("py-setuptools@45:", type="build")
-    depends_on("py-setuptools-scm@3.4:+toml", type="build")
+    with when("@:2.6.1"):
+        depends_on("py-setuptools@45:", type="build")
+        depends_on("py-setuptools-scm@3.4:+toml", type="build")
+    with when("@2.6.2:"):
+        depends_on("py-hatchling", type="build")
+        depends_on("py-hatch-vcs", type="build")
+
     depends_on("py-boost-histogram@1.2.0:1.2", when="@2.5.2", type=("build", "run"))
-    depends_on("py-boost-histogram@1.3.1:1.3", when="@2.6.1", type=("build", "run"))
+    depends_on("py-boost-histogram@1.3.1:1.3", when="@2.6.1:2.7.1", type=("build", "run"))
+    depends_on("py-boost-histogram@1.3.1:1.4", when="@2.7.2:", type=("build", "run"))
     depends_on("py-histoprint@2.2.0:", type=("build", "run"))
     depends_on("py-numpy@1.14.5:", type=("build", "run"))
-    depends_on("py-typing-extensions@3.7:", when="^python@:3.7", type=("build", "run"))
+    depends_on("py-typing-extensions@3.7:", when="@:2.6 ^python@:3.7", type=("build", "run"))
+    depends_on("py-typing-extensions@4:", when="@2.7: ^python@:3.11", type=("build", "run"))
 
-    depends_on("py-matplotlib@3.0:", when="+plot", type=("build", "run"))
-    depends_on("py-scipy@1.4:", when="+plot", type=("build", "run"))
-    depends_on("py-iminuit@2:", when="+plot", type=("build", "run"))
-    depends_on("py-mplhep@0.2.16:", when="+plot", type=("build", "run"))
+    with when("+plot"):
+        depends_on("py-matplotlib@3.0:", type=("build", "run"))
+        depends_on("py-mplhep@0.2.16:", type=("build", "run"))
+        with when("@:2.7.0"):
+            depends_on("py-scipy@1.4:", type=("build", "run"))
+            depends_on("py-iminuit@2:", type=("build", "run"))
+
+    with when("+dask"):
+        depends_on("py-dask@2022: +dataframe", type=("build", "run"), when="^python@3.8:")
+        depends_on("py-dask-histogram@2023.1:", type=("build", "run"), when="^python@3.8:")
+
+    with when("+fit"):
+        depends_on("py-scipy@1.4:", type=("build", "run"))
+        depends_on("py-iminuit@2:", type=("build", "run"))

--- a/var/spack/repos/spack_repo/builtin/packages/py_hist/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_hist/package.py
@@ -13,8 +13,11 @@ class PyHist(PythonPackage):
     homepage = "https://github.com/scikit-hep/hist"
     pypi = "hist/hist-2.5.2.tar.gz"
 
+    maintainers("wdconinc")
+
     license("BSD-3-Clause")
 
+    version("2.8.1", sha256="7da7c900e2ef6d425793da1a9adac424ebc013a8eabf29b24301f70898218d9d")
     version("2.8.0", sha256="0a3e602dd1d2721bd7f2229f456709dde323f6f74952f13ba4e5986c3275f77b")
     version("2.7.3", sha256="f9f9b56809b190bb546698789cc0d7d040934fc5141d2763c6e49d65e81dbc0b")
     version("2.7.2", sha256="26b1ab810d8b10222db5d161d4acaf64aaa04fe6baaed2966d41c1dac5601d06")
@@ -59,7 +62,7 @@ class PyHist(PythonPackage):
             depends_on("py-iminuit@2:", type=("build", "run"), when="@2.6.2:2.6.3 ^python@:3.10")
 
     with when("+dask"):
-        depends_on("py-dask@2022: +dataframe", type=("build", "run"), when="^python@3.8:")
+        depends_on("py-dask@2022:2024 +dataframe", type=("build", "run"), when="^python@3.8:")
         depends_on("py-dask-histogram@2023.1:", type=("build", "run"), when="^python@3.8:")
 
     with when("+fit"):

--- a/var/spack/repos/spack_repo/builtin/packages/py_hist/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_hist/package.py
@@ -39,7 +39,9 @@ class PyHist(PythonPackage):
     depends_on("py-boost-histogram@1.3.1:1.3", when="@2.6.1:2.7.1", type=("build", "run"))
     depends_on("py-boost-histogram@1.3.1:1.4", when="@2.7.2:", type=("build", "run"))
     depends_on("py-histoprint@2.2.0:", type=("build", "run"))
-    depends_on("py-numpy@1.14.5:", type=("build", "run"))
+    depends_on("py-numpy@1.14.5:", type=("build", "run"), when="@:2.7.1")
+    depends_on("py-numpy@1.14.5:", type=("build", "run"), when="@2.7.2: ^python@:3.11")
+    depends_on("py-numpy@1.26:", type=("build", "run"), when="@2.7.2: ^python@3.12:")
     depends_on("py-typing-extensions@3.7:", when="@:2.6 ^python@:3.7", type=("build", "run"))
     depends_on("py-typing-extensions@4:", when="@2.7: ^python@:3.11", type=("build", "run"))
 

--- a/var/spack/repos/spack_repo/builtin/packages/py_hist/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_hist/package.py
@@ -41,6 +41,7 @@ class PyHist(PythonPackage):
     depends_on("py-boost-histogram@1.2.0:1.2", when="@2.5.2", type=("build", "run"))
     depends_on("py-boost-histogram@1.3.1:1.3", when="@2.6.1:2.7.1", type=("build", "run"))
     depends_on("py-boost-histogram@1.3.1:1.4", when="@2.7.2:", type=("build", "run"))
+    depends_on("py-boost-histogram@1.3.1:1.5", when="@2.8.0:", type=("build", "run"))
     depends_on("py-histoprint@2.2.0:", type=("build", "run"))
     depends_on("py-numpy@1.14.5:", type=("build", "run"), when="@:2.7.1")
     depends_on("py-numpy@1.14.5:", type=("build", "run"), when="@2.7.2: ^python@:3.11")

--- a/var/spack/repos/spack_repo/builtin/packages/py_hist/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/py_hist/package.py
@@ -47,8 +47,10 @@ class PyHist(PythonPackage):
         depends_on("py-matplotlib@3.0:", type=("build", "run"))
         depends_on("py-mplhep@0.2.16:", type=("build", "run"))
         with when("@:2.7.0"):
-            depends_on("py-scipy@1.4:", type=("build", "run"))
-            depends_on("py-iminuit@2:", type=("build", "run"))
+            depends_on("py-scipy@1.4:", type=("build", "run"), when="@:2.6.1,2.7.0")
+            depends_on("py-iminuit@2:", type=("build", "run"), when="@:2.6.1,2.7.0")
+            depends_on("py-scipy@1.4:", type=("build", "run"), when="@2.6.2:2.6.3 ^python@:3.10")
+            depends_on("py-iminuit@2:", type=("build", "run"), when="@2.6.2:2.6.3 ^python@:3.10")
 
     with when("+dask"):
         depends_on("py-dask@2022: +dataframe", type=("build", "run"), when="^python@3.8:")


### PR DESCRIPTION
This PR adds v2.6.2-3, 2.7.0-3, 2.8.0 of py-hist. It also adds the new package py-dask-histogram as a dependency.