### PR TITLE
xorg-docs: add v1.7.3

### DIFF
--- a/var/spack/repos/builtin/packages/util-macros/package.py
+++ b/var/spack/repos/builtin/packages/util-macros/package.py
@@ -16,7 +16,7 @@ class UtilMacros(AutotoolsPackage, XorgPackage):
 
     # note: url_for_version can only return a single url, no mirrors
     def url_for_version(self, version):
-        if version < Version("1.20"):
+        if self.spec.satisfies("@:1.19"):
             return self.urls[0].replace("xz", "bz2")
 
     maintainers("robert-mijakovic", "wdconinc")

--- a/var/spack/repos/builtin/packages/util-macros/package.py
+++ b/var/spack/repos/builtin/packages/util-macros/package.py
@@ -11,13 +11,19 @@ class UtilMacros(AutotoolsPackage, XorgPackage):
     other Xorg modular packages, and is needed to generate new versions
     of their configure scripts with autoconf."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/util/macros/"
-    xorg_mirror_path = "util/util-macros-1.19.1.tar.bz2"
+    homepage = "https://gitlab.freedesktop.org/xorg/util/macros"
+    xorg_mirror_path = "util/util-macros-1.19.1.tar.xz"
 
-    maintainers("robert-mijakovic")
+    # note: url_for_version can only return a single url, no mirrors
+    def url_for_version(self, version):
+        if version < Version("1.20"):
+            return self.urls[0].replace("xz", "bz2")
+
+    maintainers("robert-mijakovic", "wdconinc")
 
     license("MIT")
 
+    version("1.20.1", sha256="0b308f62dce78ac0f4d9de6888234bf170f276b64ac7c96e99779bb4319bcef5")
     version("1.19.3", sha256="0f812e6e9d2786ba8f54b960ee563c0663ddbe2434bf24ff193f5feab1f31971")
     version("1.19.2", sha256="d7e43376ad220411499a79735020f9d145fdc159284867e99467e0d771f3e712")
     version("1.19.1", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")

--- a/var/spack/repos/builtin/packages/xorg-docs/package.py
+++ b/var/spack/repos/builtin/packages/xorg-docs/package.py
@@ -12,15 +12,17 @@ class XorgDocs(AutotoolsPackage, XorgPackage):
 
     The preferred documentation format for these documents is DocBook XML."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/doc/xorg-docs"
+    homepage = "https://gitlab.freedesktop.org/xorg/doc/xorg-docs"
     xorg_mirror_path = "doc/xorg-docs-1.7.1.tar.gz"
 
     maintainers("wdconinc")
 
+    version("1.7.3", sha256="30f8fc4b435cda82f21d08d81c2e2fc9046ec7e20945e32ab7b63326674cf8c5")
     version("1.7.2", sha256="0c1e018868a00cb5a5bc8622ffd87e706e119ffa0949edde00d0d0d912663677")
     version("1.7.1", sha256="360707db2ba48f6deeb53d570deca9fa98218af48ead4a726a67f63e3ef63816")
 
     depends_on("pkgconfig", type="build")
-    depends_on("util-macros", type="build")
+    depends_on("util-macros@1.8:", type="build")
+    depends_on("util-macros@1.20:", type="build", when="@1.7.3:")
     depends_on("xorg-sgml-doctools@1.8:", type="build")
     depends_on("xmlto", type="build")

--- a/var/spack/repos/builtin/packages/xorg-sgml-doctools/package.py
+++ b/var/spack/repos/builtin/packages/xorg-sgml-doctools/package.py
@@ -18,8 +18,10 @@ class XorgSgmlDoctools(AutotoolsPackage, XorgPackage):
 
     license("MIT")
 
+    version("1.12.1", sha256="8de3406f96a02bc3ab51ff47ba1612d9a11fc25d2edcaa06caa2cb2420d7bae0")
     version("1.12", sha256="985a0329e6a6dadd6ad517f8d54f8766ab4b52bb8da7b07d02ec466bec444bdb")
     version("1.11", sha256="986326d7b4dd2ad298f61d8d41fe3929ac6191c6000d6d7e47a8ffc0c34e7426")
 
     depends_on("pkgconfig", type="build")
-    depends_on("util-macros", type="build")
+    depends_on("util-macros@1.8:", type="build")
+    depends_on("util-macros@1.20:", type="build", when="@1.12.1:")


### PR DESCRIPTION
This PR updates xorg-docs and dependencies to v1.7.3.

Of note is `util-macros` which is (as other xorg packages) now distributed as xz files, not bz2 files. This can only be partially handled with `url_for_version` because that does not really allow for all mirrors. Since this is only used for older versions, the newer versions are still going to be using the mirrors. Since that's the more tricky aspect here, I'm posting the build results for `util-macros`:
```
==> Installing util-macros-1.20.1-kihw5k7kdg6t267bs4xm7ds3hq7eo726 [4/5]
==> No binary for util-macros-1.20.1-kihw5k7kdg6t267bs4xm7ds3hq7eo726 found: installing from source
==> Fetching https://www.x.org/archive/individual/util/util-macros-1.20.1.tar.xz
==> No patches needed for util-macros
==> util-macros: Executing phase: 'autoreconf'
==> util-macros: Executing phase: 'configure'
==> util-macros: Executing phase: 'build'
==> util-macros: Executing phase: 'install'
==> util-macros: Successfully installed util-macros-1.20.1-kihw5k7kdg6t267bs4xm7ds3hq7eo726
  Stage: 1.80s.  Autoreconf: 0.00s.  Configure: 1.16s.  Build: 0.00s.  Install: 0.01s.  Post-install: 0.02s.  Total: 3.08s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/util-macros-1.20.1-kihw5k7kdg6t267bs4xm7ds3hq7eo726
==> Installing util-macros-1.19.2-z7ga43evpy2yy4jz3lfdjtlvj35ncfrh [5/5]
==> No binary for util-macros-1.19.2-z7ga43evpy2yy4jz3lfdjtlvj35ncfrh found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/d7/d7e43376ad220411499a79735020f9d145fdc159284867e99467e0d771f3e712.tar.bz2
==> No patches needed for util-macros
==> util-macros: Executing phase: 'autoreconf'
==> util-macros: Executing phase: 'configure'
==> util-macros: Executing phase: 'build'
==> util-macros: Executing phase: 'install'
==> util-macros: Successfully installed util-macros-1.19.2-z7ga43evpy2yy4jz3lfdjtlvj35ncfrh
  Stage: 0.75s.  Autoreconf: 0.00s.  Configure: 1.16s.  Build: 0.00s.  Install: 0.01s.  Post-install: 0.01s.  Total: 2.02s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/util-macros-1.19.2-z7ga43evpy2yy4jz3lfdjtlvj35ncfrh
```