### PR TITLE
conmon: add v2.1.12

### DIFF
--- a/var/spack/repos/builtin/packages/conmon/package.py
+++ b/var/spack/repos/builtin/packages/conmon/package.py
@@ -15,7 +15,7 @@ class Conmon(MakefilePackage):
 
     license("Apache-2.0")
 
-    version("2.1.12", sha256="842f0b5614281f7e35eec2a4e35f9f7b9834819aa58ecdad8d0ff6a84f6796a6") 
+    version("2.1.12", sha256="842f0b5614281f7e35eec2a4e35f9f7b9834819aa58ecdad8d0ff6a84f6796a6")
     version("2.1.7", sha256="7d0f9a2f7cb8a76c51990128ac837aaf0cc89950b6ef9972e94417aa9cf901fe")
     version("2.1.5", sha256="ee3179ee2b9a9107acec00eb546062cf7deb847f135a3b81503d22b0d226b3ed")
     version("2.0.30", sha256="4b0a98fbe8a63c42f60edac25c19aa6606caa7b1e4fe7846fc7f7de0b566ba25")

--- a/var/spack/repos/builtin/packages/conmon/package.py
+++ b/var/spack/repos/builtin/packages/conmon/package.py
@@ -15,6 +15,7 @@ class Conmon(MakefilePackage):
 
     license("Apache-2.0")
 
+    version("2.1.12", sha256="842f0b5614281f7e35eec2a4e35f9f7b9834819aa58ecdad8d0ff6a84f6796a6") 
     version("2.1.7", sha256="7d0f9a2f7cb8a76c51990128ac837aaf0cc89950b6ef9972e94417aa9cf901fe")
     version("2.1.5", sha256="ee3179ee2b9a9107acec00eb546062cf7deb847f135a3b81503d22b0d226b3ed")
     version("2.0.30", sha256="4b0a98fbe8a63c42f60edac25c19aa6606caa7b1e4fe7846fc7f7de0b566ba25")


### PR DESCRIPTION
This PR adds conmon v2.1.12. No relevant Makefile changes from what I can tell in https://github.com/containers/conmon/compare/v2.1.7...v2.1.12.

Test build:
```
==> Installed packages
-- linux-ubuntu24.04-skylake / gcc@13.2.0 -----------------------
kabmte2 conmon@2.1.12 build_system=makefile
```