### PR TITLE
doxygen: add v1.11.0, v1.10.0

### DIFF
--- a/var/spack/repos/builtin/packages/doxygen/package.py
+++ b/var/spack/repos/builtin/packages/doxygen/package.py
@@ -20,6 +20,8 @@ class Doxygen(CMakePackage):
 
     license("GPL-2.0-or-later")
 
+    version("1.11.0", sha256="1fea49c69e51fec3dd2599947f6d48d9b1268bd5115b1bb08dffefc1fd5d19ee")
+    version("1.10.0", sha256="795692a53136ca9bb9a6cd72656968af7858a78be7d6d011e12ab1dce6b9533c")
     version("1.9.8", sha256="77371e8a58d22d5e03c52729844d1043e9cbf8d0005ec5112ffa4c8f509ddde8")
     version("1.9.7", sha256="691777992a7240ed1f822a5c2ff2c4273b57c1cf9fc143553d87f91a0c5970ee")
     version("1.9.6", sha256="2a3ee47f7276b759f74bac7614c05a1296a5b028d3f6a79a88e4c213db78e7dc")
@@ -76,6 +78,11 @@ class Doxygen(CMakePackage):
         return variants
 
     depends_on("cmake@2.8.12:", type="build")
+    depends_on("cmake@3.2:", type="build", when="@1.8.16:")
+    depends_on("cmake@3.3:", type="build", when="@1.8.18:")
+    depends_on("cmake@3.12:", type="build", when="@1.9.8:")
+    depends_on("cmake@3.14:", type="build", when="@1.10:")
+
     depends_on("python", type="build")  # 2 or 3 OK; used in CMake build
     depends_on("iconv")
     depends_on("flex", type="build")
@@ -84,6 +91,10 @@ class Doxygen(CMakePackage):
     # but does not recognize 2.6.x as newer...could be patched if needed
     depends_on("flex@2.5.39", type="build", when="@1.8.10")
     depends_on("bison@2.7:", type="build", when="@1.8.10:")
+
+    # originally bundled dependencies
+    depends_on("spdlog", when="@1.9.8:")
+    depends_on("sqlite", when="@1.10:")
 
     # optional dependencies
     depends_on("graphviz", when="+graphviz", type="run")
@@ -124,3 +135,9 @@ class Doxygen(CMakePackage):
             join_path("cmake", "FindIconv.cmake"),
             string=True,
         )
+
+    def cmake_args(self):
+        return [
+            self.define("use_sys_spdlog", self.spec.satisfies("@1.9.8:")),
+            self.define("use_sys_sqlite3", self.spec.satisfies("@1.10:")),
+        ]

--- a/var/spack/repos/builtin/packages/doxygen/package.py
+++ b/var/spack/repos/builtin/packages/doxygen/package.py
@@ -119,6 +119,13 @@ class Doxygen(CMakePackage):
         when="@1.9.4 %gcc@12:",
     )
 
+    # https://github.com/doxygen/doxygen/pull/10896: use correct option name with system sqlite3
+    patch(
+        "https://github.com/doxygen/doxygen/commit/83de58c5f4f685a129127c2501f4fccd9557f6c4.patch?full_index=1",
+        sha256="8b46b763b3f0a2726f765141cbfa3eb6efd746531a4d689531e42ff56fc334e2",
+        when="@1.10:1.11.0",
+    )
+
     # Some GCC 7.x get stuck in an infinite loop
     conflicts("%gcc@7.0:7.9", when="@1.9:")
 


### PR DESCRIPTION
This PR adds doxygen v1.11.0 and v1.10.0, which allow for using system sqlite3 and spdlog instead of using bundled versions (regrettably, no version dependency info for these dependencies is included in the find_package calls). This PR also adds some more cmake dependency granularity.

Linkage indicates external dependents are found and linked in, but there is still a typo in https://github.com/doxygen/doxygen/pull/10896 that needs to be fixed since the wrong includes are used.
```
$ ldd /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/doxygen-1.11.0-in5lbaavb4lmdsjqolvoecsgug5bjjke/bin/doxygen 
        linux-vdso.so.1 (0x00007fff42f23000)
        libsqlite3.so.0 => /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/sqlite-3.43.2-z5rujbwhxm6vnuayate4vuerc7kf6d2k/lib/libsqlite3.so.0 (0x000073eb668a9000)
        libspdlog.so.1.14 => /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/spdlog-1.14.1-6uwbbn2shvfn4i5jddznxr2axutnaa2f/lib/libspdlog.so.1.14 (0x000073eb680dc000)
        libstdc++.so.6 => /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/gcc-runtime-13.2.0-rctl67v3i2zxipyyxl2rehavtti7r4rf/lib/libstdc++.so.6 (0x000073eb66600000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x000073eb66517000)
        libgcc_s.so.1 => /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/gcc-runtime-13.2.0-rctl67v3i2zxipyyxl2rehavtti7r4rf/lib/libgcc_s.so.1 (0x000073eb664ea000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000073eb66200000)
        libfmt.so.10 => /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/fmt-10.2.1-llsj6gjol4ghqa7o47a3osr5cztho75f/lib/libfmt.so.10 (0x000073eb66880000)
        /lib64/ld-linux-x86-64.so.2 (0x000073eb6815b000)
```

TODO:
- [x] wait for merge of https://github.com/doxygen/doxygen/pull/10896 and apply as url patch for `1.10:1.11.0`.