### PR TITLE
elfutils: add v0.191

### DIFF
--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -27,6 +27,7 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
 
     license("GPL-3.0-or-later AND ( GPL-2.0-or-later OR LGPL-3.0-or-later )")
 
+    version("0.191", sha256="df76db71366d1d708365fc7a6c60ca48398f14367eb2b8954efc8897147ad871")
     version("0.190", sha256="8e00a3a9b5f04bc1dc273ae86281d2d26ed412020b391ffcc23198f10231d692")
     version("0.189", sha256="39bd8f1a338e2b7cd4abc3ff11a0eddc6e690f69578a57478d8179b4148708c8")
     version("0.188", sha256="fb8b0e8d0802005b9a309c60c1d8de32dd2951b56f0c3a3cb56d21ce01595dff")


### PR DESCRIPTION
This PR adds version 0.191 of elfutils, titled "Bug fixes in C major". News at top of https://sourceware.org/git/?p=elfutils.git;a=blob_plain;f=NEWS;hb=18a015c0b0787ba5acb39801ab7c17dac50f584d, nothing that looks like it would need adapting in the spack package.

Test build (without debuginfod):
```
==> Installed packages
-- linux-ubuntu24.04-skylake / gcc@13.2.0 -----------------------
orv7bze elfutils@0.191~debuginfod+exeprefix+nls build_system=autotools
==> 1 installed package
```