### PR TITLE
libxshmfence: add v1.3.1, v1.3.2

### DIFF
--- a/var/spack/repos/builtin/packages/libxshmfence/package.py
+++ b/var/spack/repos/builtin/packages/libxshmfence/package.py
@@ -16,14 +16,6 @@ class Libxshmfence(AutotoolsPackage, XorgPackage):
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libxshmfence"
     xorg_mirror_path = "lib/libxshmfence-1.3.2.tar.xz"
 
-    # note: url_for_version can only return a single url, no mirrors
-    def url_for_version(self, version):
-        url = super().url_for_version(version)
-        if version <= Version("1.3"):
-            return url.replace("xz", "bz2")
-
-        return url
-
     license("MIT")
 
     version("1.3.2", sha256="870df257bc40b126d91b5a8f1da6ca8a524555268c50b59c0acd1a27f361606f")
@@ -34,3 +26,10 @@ class Libxshmfence(AutotoolsPackage, XorgPackage):
     depends_on("xproto")
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
+
+    def url_for_version(self, version):
+        url = super().url_for_version(version)
+        if version <= Version("1.3"):
+            return url.replace("xz", "bz2")
+
+        return url

--- a/var/spack/repos/builtin/packages/libxshmfence/package.py
+++ b/var/spack/repos/builtin/packages/libxshmfence/package.py
@@ -18,8 +18,11 @@ class Libxshmfence(AutotoolsPackage, XorgPackage):
 
     # note: url_for_version can only return a single url, no mirrors
     def url_for_version(self, version):
-        if self.spec.satisfies("@:1.3.0"):
-            return spack.url.substitute_version(self.urls[0].replace("xz", "bz2"), version)
+        url = super().url_for_version(version)
+        if version <= Version("1.3"):
+            return url.replace("xz", "bz2")
+
+        return url
 
     license("MIT")
 

--- a/var/spack/repos/builtin/packages/libxshmfence/package.py
+++ b/var/spack/repos/builtin/packages/libxshmfence/package.py
@@ -14,12 +14,12 @@ class Libxshmfence(AutotoolsPackage, XorgPackage):
     using file descriptor passing."""
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libxshmfence"
-    xorg_mirror_path = "lib/libxshmfence-1.3.tar.bz2"
+    xorg_mirror_path = "lib/libxshmfence-1.3.2.tar.xz"
 
     # note: url_for_version can only return a single url, no mirrors
     def url_for_version(self, version):
-        if version < Version("1.3.1"):
-            return self.urls[0].replace("xz", "bz2")
+        if self.spec.satisfies("@:1.3.0"):
+            return spack.url.substitute_version(self.urls[0].replace("xz", "bz2"), version)
 
     license("MIT")
 

--- a/var/spack/repos/builtin/packages/libxshmfence/package.py
+++ b/var/spack/repos/builtin/packages/libxshmfence/package.py
@@ -13,11 +13,18 @@ class Libxshmfence(AutotoolsPackage, XorgPackage):
     with the X SyncFence objects that can be shared between processes
     using file descriptor passing."""
 
-    homepage = "https://cgit.freedesktop.org/xorg/lib/libxshmfence/"
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxshmfence"
     xorg_mirror_path = "lib/libxshmfence-1.3.tar.bz2"
+
+    # note: url_for_version can only return a single url, no mirrors
+    def url_for_version(self, version):
+        if version < Version("1.3.1"):
+            return self.urls[0].replace("xz", "bz2")
 
     license("MIT")
 
+    version("1.3.2", sha256="870df257bc40b126d91b5a8f1da6ca8a524555268c50b59c0acd1a27f361606f")
+    version("1.3.1", sha256="1129f95147f7bfe6052988a087f1b7cb7122283d2c47a7dbf7135ce0df69b4f8")
     version("1.3", sha256="b884300d26a14961a076fbebc762a39831cb75f92bed5ccf9836345b459220c7")
     version("1.2", sha256="d21b2d1fd78c1efbe1f2c16dae1cb23f8fd231dcf891465b8debe636a9054b0c")
 


### PR DESCRIPTION
This PR adds the newer versions of libxshmfence, and applies the same treatment as `util-macros` in #44388 for changing from bz2 to xz as archive format. This also ensures that updates will be found by `spack checksum`.

Test builds find the right urls (older are on spack mirrors).
```
==> Installing libxshmfence-1.2-ovebe7ohy3ipjd5zejxhzapb3yx5kx22 [34/37]
==> No binary for libxshmfence-1.2-ovebe7ohy3ipjd5zejxhzapb3yx5kx22 found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/d2/d21b2d1fd78c1efbe1f2c16dae1cb23f8fd231dcf891465b8debe636a9054b0c.tar.bz2
==> No patches needed for libxshmfence
==> libxshmfence: Executing phase: 'autoreconf'
==> libxshmfence: Executing phase: 'configure'
==> libxshmfence: Executing phase: 'build'
==> libxshmfence: Executing phase: 'install'
==> libxshmfence: Successfully installed libxshmfence-1.2-ovebe7ohy3ipjd5zejxhzapb3yx5kx22
  Stage: 1.44s.  Autoreconf: 0.00s.  Configure: 3.60s.  Build: 0.27s.  Install: 0.08s.  Post-install: 0.05s.  Total: 5.59s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/libxshmfence-1.2-ovebe7ohy3ipjd5zejxhzapb3yx5kx22
==> Installing libxshmfence-1.3.2-v6gwk4qda6rv5x4alclibzxmtfszyebl [35/37]
==> No binary for libxshmfence-1.3.2-v6gwk4qda6rv5x4alclibzxmtfszyebl found: installing from source
==> Fetching https://www.x.org/archive/individual/lib/libxshmfence-1.3.2.tar.xz
==> No patches needed for libxshmfence
==> libxshmfence: Executing phase: 'autoreconf'
==> libxshmfence: Executing phase: 'configure'
==> libxshmfence: Executing phase: 'build'
==> libxshmfence: Executing phase: 'install'
==> libxshmfence: Successfully installed libxshmfence-1.3.2-v6gwk4qda6rv5x4alclibzxmtfszyebl
  Stage: 1.70s.  Autoreconf: 0.00s.  Configure: 3.50s.  Build: 0.36s.  Install: 0.11s.  Post-install: 0.05s.  Total: 5.83s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/libxshmfence-1.3-eu42ddb2o25mneood5i6nsevqbqwhcwr
==> Installing libxshmfence-1.3.1-44xlbm2nngprxpua6u3h3guor527nqbd [37/37]
==> No binary for libxshmfence-1.3.1-44xlbm2nngprxpua6u3h3guor527nqbd found: installing from source
==> Fetching https://www.x.org/archive/individual/lib/libxshmfence-1.3.1.tar.xz
==> No patches needed for libxshmfence
==> libxshmfence: Executing phase: 'autoreconf'
==> libxshmfence: Executing phase: 'configure'
==> libxshmfence: Executing phase: 'build'
==> libxshmfence: Executing phase: 'install'
==> libxshmfence: Successfully installed libxshmfence-1.3.1-44xlbm2nngprxpua6u3h3guor527nqbd
  Stage: 1.64s.  Autoreconf: 0.00s.  Configure: 3.63s.  Build: 0.26s.  Install: 0.11s.  Post-install: 0.04s.  Total: 5.81s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/libxshmfence-1.3.1-44xlbm2nngprxpua6u3h3guor527nqbd
```