### PR TITLE
libxcb, xcb-proto: add v1.17.1

### DIFF
--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -13,16 +13,23 @@ class Libxcb(AutotoolsPackage):
     extensibility."""
 
     homepage = "https://xcb.freedesktop.org/"
-    url = "https://xorg.freedesktop.org/archive/individual/lib/libxcb-1.14.tar.xz"
+    xorg_mirror_path = "lib/libxcb-1.14.tar.xz"
 
     license("MIT")
 
     maintainers("wdconinc")
 
+    version("1.17.0", sha256="599ebf9996710fea71622e6e184f3a8ad5b43d0e5fa8c4e407123c88a59a6d55")
+    version("1.16.1", sha256="f24d187154c8e027b358fc7cb6588e35e33e6a92f11c668fe77396a7ae66e311")
     version("1.16", sha256="4348566aa0fbf196db5e0a576321c65966189210cb51328ea2bb2be39c711d71")
     version("1.15", sha256="cc38744f817cf6814c847e2df37fcb8997357d72fa4bcbc228ae0fe47219a059")
     version("1.14", sha256="a55ed6db98d43469801262d81dc2572ed124edc3db31059d4e9916eb9f844c34")
-    version("1.13", sha256="0bb3cfd46dbd90066bf4d7de3cad73ec1024c7325a4a0cbf5f4a0d4fa91155fb")
+    version(
+        "1.13",
+        sha256="0bb3cfd46dbd90066bf4d7de3cad73ec1024c7325a4a0cbf5f4a0d4fa91155fb",
+        url="https://xcb.freedesktop.org/dist/libxcb-1.13.tar.gz",
+        deprecated=True,
+    )
 
     depends_on("libpthread-stubs")
     depends_on("libxau@0.99.2:")
@@ -30,6 +37,8 @@ class Libxcb(AutotoolsPackage):
 
     # libxcb 1.X requires xcb-proto >= 1.X
     depends_on("xcb-proto")
+    depends_on("xcb-proto@1.17:", when="@1.17")
+    depends_on("xcb-proto@1.16:", when="@1.16")
     depends_on("xcb-proto@1.15:", when="@1.15")
     depends_on("xcb-proto@1.14:", when="@1.14")
     depends_on("xcb-proto@1.13:", when="@1.13")
@@ -37,14 +46,6 @@ class Libxcb(AutotoolsPackage):
     depends_on("python", type="build")
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
-
-    def url_for_version(self, version):
-        if version >= Version("1.14"):
-            url = "https://xorg.freedesktop.org/archive/individual/lib/libxcb-{0}.tar.xz"
-        else:
-            url = "https://xcb.freedesktop.org/dist/libxcb-{0}.tar.gz"
-
-        return url.format(version)
 
     def configure_args(self):
         config_args = []

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Libxcb(AutotoolsPackage):
+class Libxcb(AutotoolsPackage, XorgPackage):
     """The X protocol C-language Binding (XCB) is a replacement
     for Xlib featuring a small footprint, latency hiding, direct
     access to the protocol, improved threading support, and

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -11,28 +11,36 @@ class XcbProto(AutotoolsPackage):
     generate the majority of its code and API."""
 
     homepage = "https://xcb.freedesktop.org/"
-    url = "https://xorg.freedesktop.org/archive/individual/proto/xcb-proto-1.14.1.tar.xz"
+    xorg_mirror_path = "proto/xcb-proto-1.14.1.tar.xz"
 
     license("MIT")
 
     maintainers("wdconinc")
 
+    version("1.17.0", sha256="2c1bacd2110f4799f74de6ebb714b94cf6f80fb112316b1219480fd22562148c")
     version("1.16.0", sha256="a75a1848ad2a89a82d841a51be56ce988ff3c63a8d6bf4383ae3219d8d915119")
     version("1.15.2", sha256="7072beb1f680a2fe3f9e535b797c146d22528990c72f63ddb49d2f350a3653ed")
     version("1.14.1", sha256="f04add9a972ac334ea11d9d7eb4fc7f8883835da3e4859c9afa971efdf57fcc3")
     version("1.14", sha256="186a3ceb26f9b4a015f5a44dcc814c93033a5fc39684f36f1ecc79834416a605")
-    version("1.13", sha256="0698e8f596e4c0dbad71d3dc754d95eb0edbb42df5464e0f782621216fa33ba7")
-    version("1.12", sha256="cfa49e65dd390233d560ce4476575e4b76e505a0e0bacdfb5ba6f8d0af53fd59")
-    version("1.11", sha256="d12152193bd71aabbdbb97b029717ae6d5d0477ab239614e3d6193cc0385d906")
+    version(
+        "1.13",
+        sha256="0698e8f596e4c0dbad71d3dc754d95eb0edbb42df5464e0f782621216fa33ba7",
+        url="http://xcb.freedesktop.org/dist/xcb-proto-1.13.tar.gz",
+        deprecated=True,
+    )
+    version(
+        "1.12",
+        sha256="cfa49e65dd390233d560ce4476575e4b76e505a0e0bacdfb5ba6f8d0af53fd59",
+        url="http://xcb.freedesktop.org/dist/xcb-proto-1.12.tar.gz",
+        deprecated=True,
+    )
+    version(
+        "1.11",
+        sha256="d12152193bd71aabbdbb97b029717ae6d5d0477ab239614e3d6193cc0385d906",
+        url="http://xcb.freedesktop.org/dist/xcb-proto-1.11.tar.gz",
+        deprecated=True,
+    )
 
     extends("python")
 
     patch("xcb-proto-1.12-schema-1.patch", when="@1.12")
-
-    def url_for_version(self, version):
-        if version >= Version("1.14"):
-            url = "https://xorg.freedesktop.org/archive/individual/proto/xcb-proto-{0}.tar.xz"
-        else:
-            url = "http://xcb.freedesktop.org/dist/xcb-proto-{0}.tar.gz"
-
-        return url.format(version)

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class XcbProto(AutotoolsPackage):
+class XcbProto(AutotoolsPackage, XorgPackage):
     """xcb-proto provides the XML-XCB protocol descriptions that libxcb uses to
     generate the majority of its code and API."""
 

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -25,19 +25,19 @@ class XcbProto(AutotoolsPackage, XorgPackage):
     version(
         "1.13",
         sha256="0698e8f596e4c0dbad71d3dc754d95eb0edbb42df5464e0f782621216fa33ba7",
-        url="http://xcb.freedesktop.org/dist/xcb-proto-1.13.tar.gz",
+        url="https://xcb.freedesktop.org/dist/xcb-proto-1.13.tar.gz",
         deprecated=True,
     )
     version(
         "1.12",
         sha256="cfa49e65dd390233d560ce4476575e4b76e505a0e0bacdfb5ba6f8d0af53fd59",
-        url="http://xcb.freedesktop.org/dist/xcb-proto-1.12.tar.gz",
+        url="https://xcb.freedesktop.org/dist/xcb-proto-1.12.tar.gz",
         deprecated=True,
     )
     version(
         "1.11",
         sha256="d12152193bd71aabbdbb97b029717ae6d5d0477ab239614e3d6193cc0385d906",
-        url="http://xcb.freedesktop.org/dist/xcb-proto-1.11.tar.gz",
+        url="https://xcb.freedesktop.org/dist/xcb-proto-1.11.tar.gz",
         deprecated=True,
     )
 

--- a/var/spack/repos/builtin/packages/xcb-util-cursor/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-cursor/package.py
@@ -24,6 +24,7 @@ class XcbUtilCursor(AutotoolsPackage, XorgPackage):
         "0.1.3",
         sha256="a322332716a384c94d3cbf98f2d8fe2ce63c2fe7e2b26664b6cea1d411723df8",
         url="https://xcb.freedesktop.org/dist/xcb-util-cursor-0.1.4.tar.gz",
+        deprecated=True,
     )
 
     depends_on("libxcb@1.4:")

--- a/var/spack/repos/builtin/packages/xcb-util-errors/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-errors/package.py
@@ -22,6 +22,7 @@ class XcbUtilErrors(AutotoolsPackage, XorgPackage):
         "1.0",
         sha256="7752a722e580efdbada30632cb23aed35c18757399ac3b547b59fd7257cf5e33",
         url="https://xcb.freedesktop.org/dist/xcb-util-errors-1.0.tar.gz",
+        deprecated=True,
     )
 
     depends_on("libxcb@1.4:")

--- a/var/spack/repos/builtin/packages/xcb-util-image/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-image/package.py
@@ -24,6 +24,7 @@ class XcbUtilImage(AutotoolsPackage, XorgPackage):
         "0.4.0",
         sha256="cb2c86190cf6216260b7357a57d9100811bb6f78c24576a3a5bfef6ad3740a42",
         url="https://xcb.freedesktop.org/dist/xcb-util-image-0.4.0.tar.gz",
+        deprecated=True,
     )
 
     depends_on("libxcb@1.4:")

--- a/var/spack/repos/builtin/packages/xcb-util-keysyms/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-keysyms/package.py
@@ -24,6 +24,7 @@ class XcbUtilKeysyms(AutotoolsPackage, XorgPackage):
         "0.4.0",
         sha256="0807cf078fbe38489a41d755095c58239e1b67299f14460dec2ec811e96caa96",
         url="https://xcb.freedesktop.org/dist/xcb-util-keysyms-0.4.0.tar.gz",
+        deprecated=True,
     )
 
     depends_on("libxcb@1.4:")

--- a/var/spack/repos/builtin/packages/xcb-util-renderutil/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-renderutil/package.py
@@ -24,6 +24,7 @@ class XcbUtilRenderutil(AutotoolsPackage, XorgPackage):
         "0.3.9",
         sha256="55eee797e3214fe39d0f3f4d9448cc53cffe06706d108824ea37bb79fcedcad5",
         url="https://xcb.freedesktop.org/dist/xcb-util-renderutil-0.3.9.tar.gz",
+        deprecated=True,
     )
 
     depends_on("libxcb@1.4:")

--- a/var/spack/repos/builtin/packages/xcb-util-wm/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-wm/package.py
@@ -24,6 +24,7 @@ class XcbUtilWm(AutotoolsPackage, XorgPackage):
         "0.4.1",
         sha256="038b39c4bdc04a792d62d163ba7908f4bb3373057208c07110be73c1b04b8334",
         url="https://xcb.freedesktop.org/dist/xcb-util-wm-0.4.1.tar.gz",
+        deprecated=True,
     )
 
     depends_on("m4", type="build")


### PR DESCRIPTION
This PR updates libxcb and xcb-proto to v1.17.1 (v1.17.0 for xcb-proto). It adds an overlooked missing dependency synchronization between library and protocols. It turns both packages into XorgPackages with an xorg_mirror_path, reflecting where these packages are now developed. It deprecates the versions for which files are only available at the previous separate xcb server.