### PR TITLE
link: directly bind to os.* on non-windows

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -766,7 +766,6 @@ def copy_tree(
     src: str,
     dest: str,
     symlinks: bool = True,
-    allow_broken_symlinks: bool = sys.platform != "win32",
     ignore: Optional[Callable[[str], bool]] = None,
     _permissions: bool = False,
 ):
@@ -789,8 +788,6 @@ def copy_tree(
         src (str): the directory to copy
         dest (str): the destination directory
         symlinks (bool): whether or not to preserve symlinks
-        allow_broken_symlinks (bool): whether or not to allow broken (dangling) symlinks,
-            On Windows, setting this to True will raise an exception. Defaults to true on unix.
         ignore (typing.Callable): function indicating which files to ignore
         _permissions (bool): for internal use only
 
@@ -798,8 +795,6 @@ def copy_tree(
         IOError: if *src* does not match any files or directories
         ValueError: if *src* is a parent directory of *dest*
     """
-    if allow_broken_symlinks and sys.platform == "win32":
-        raise llnl.util.symlink.SymlinkError("Cannot allow broken symlinks on Windows!")
     if _permissions:
         tty.debug("Installing {0} to {1}".format(src, dest))
     else:
@@ -872,16 +867,14 @@ def copy_tree(
                 copy_mode(s, d)
 
     for target, d, s in links:
-        symlink(target, d, allow_broken_symlinks=allow_broken_symlinks)
+        symlink(target, d)
         if _permissions:
             set_install_permissions(d)
             copy_mode(s, d)
 
 
 @system_path_filter
-def install_tree(
-    src, dest, symlinks=True, ignore=None, allow_broken_symlinks=sys.platform != "win32"
-):
+def install_tree(src, dest, symlinks=True, ignore=None):
     """Recursively install an entire directory tree rooted at *src*.
 
     Same as :py:func:`copy_tree` with the addition of setting proper
@@ -892,21 +885,12 @@ def install_tree(
         dest (str): the destination directory
         symlinks (bool): whether or not to preserve symlinks
         ignore (typing.Callable): function indicating which files to ignore
-        allow_broken_symlinks (bool): whether or not to allow broken (dangling) symlinks,
-            On Windows, setting this to True will raise an exception.
 
     Raises:
         IOError: if *src* does not match any files or directories
         ValueError: if *src* is a parent directory of *dest*
     """
-    copy_tree(
-        src,
-        dest,
-        symlinks=symlinks,
-        allow_broken_symlinks=allow_broken_symlinks,
-        ignore=ignore,
-        _permissions=True,
-    )
+    copy_tree(src, dest, symlinks=symlinks, ignore=ignore, _permissions=True)
 
 
 @system_path_filter

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -600,9 +600,7 @@ def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
         if node is spec:
             spack.repo.PATH.dump_provenance(node, dest_pkg_dir)
         elif source_pkg_dir:
-            fs.install_tree(
-                source_pkg_dir, dest_pkg_dir, allow_broken_symlinks=(sys.platform != "win32")
-            )
+            fs.install_tree(source_pkg_dir, dest_pkg_dir)
 
 
 def get_dependent_ids(spec: "spack.spec.Spec") -> List[str]:
@@ -2380,9 +2378,7 @@ class BuildProcessInstaller:
         src_target = os.path.join(pkg.spec.prefix, "share", pkg.name, "src")
         tty.debug(f"{self.pre} Copying source to {src_target}")
 
-        fs.install_tree(
-            pkg.stage.source_path, src_target, allow_broken_symlinks=(sys.platform != "win32")
-        )
+        fs.install_tree(pkg.stage.source_path, src_target)
 
     def _real_install(self) -> None:
         import spack.builder

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -278,8 +278,8 @@ class TestInstallTree:
     def test_allow_broken_symlinks(self, stage):
         """Test installing with a broken symlink."""
         with fs.working_dir(str(stage)):
-            symlink("nonexistant.txt", "source/broken", allow_broken_symlinks=True)
-            fs.install_tree("source", "dest", symlinks=True, allow_broken_symlinks=True)
+            symlink("nonexistant.txt", "source/broken")
+            fs.install_tree("source", "dest", symlinks=True)
             assert os.path.islink("dest/broken")
             assert not os.path.exists(readlink("dest/broken"))
 

--- a/lib/spack/spack/test/llnl/util/symlink.py
+++ b/lib/spack/spack/test/llnl/util/symlink.py
@@ -20,7 +20,7 @@ def test_symlink_file(tmpdir):
         fd, real_file = tempfile.mkstemp(prefix="real", suffix=".txt", dir=test_dir)
         link_file = str(tmpdir.join("link.txt"))
         assert os.path.exists(link_file) is False
-        symlink.symlink(source_path=real_file, link_path=link_file)
+        symlink.symlink(real_file, link_file)
         assert os.path.exists(link_file)
         assert symlink.islink(link_file)
 
@@ -32,11 +32,12 @@ def test_symlink_dir(tmpdir):
         real_dir = os.path.join(test_dir, "real_dir")
         link_dir = os.path.join(test_dir, "link_dir")
         os.mkdir(real_dir)
-        symlink.symlink(source_path=real_dir, link_path=link_dir)
+        symlink.symlink(real_dir, link_dir)
         assert os.path.exists(link_dir)
         assert symlink.islink(link_dir)
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
 def test_symlink_source_not_exists(tmpdir):
     """Test the symlink.symlink method for the case where a source path does not exist"""
     with tmpdir.as_cwd():
@@ -44,7 +45,7 @@ def test_symlink_source_not_exists(tmpdir):
         real_dir = os.path.join(test_dir, "real_dir")
         link_dir = os.path.join(test_dir, "link_dir")
         with pytest.raises(symlink.SymlinkError):
-            symlink.symlink(source_path=real_dir, link_path=link_dir, allow_broken_symlinks=False)
+            symlink._windows_symlink(real_dir, link_dir)
 
 
 def test_symlink_src_relative_to_link(tmpdir):
@@ -61,18 +62,16 @@ def test_symlink_src_relative_to_link(tmpdir):
         fd, real_file = tempfile.mkstemp(prefix="real", suffix=".txt", dir=subdir_2)
         link_file = os.path.join(subdir_1, "link.txt")
 
-        symlink.symlink(
-            source_path=f"b/{os.path.basename(real_file)}",
-            link_path=f"a/{os.path.basename(link_file)}",
-        )
+        symlink.symlink(f"b/{os.path.basename(real_file)}", f"a/{os.path.basename(link_file)}")
         assert os.path.exists(link_file)
         assert symlink.islink(link_file)
         # Check dirs
         assert not os.path.lexists(link_dir)
-        symlink.symlink(source_path="b", link_path="a/c")
+        symlink.symlink("b", "a/c")
         assert os.path.lexists(link_dir)
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
 def test_symlink_src_not_relative_to_link(tmpdir):
     """Test the symlink.symlink functionality where the source value does not exist relative to
     the link and not relative to the cwd. NOTE that this symlink api call is EXPECTED to raise
@@ -88,19 +87,18 @@ def test_symlink_src_not_relative_to_link(tmpdir):
         link_file = str(tmpdir.join("link.txt"))
         # Expected SymlinkError because source path does not exist relative to link path
         with pytest.raises(symlink.SymlinkError):
-            symlink.symlink(
-                source_path=f"d/{os.path.basename(real_file)}",
-                link_path=f"a/{os.path.basename(link_file)}",
-                allow_broken_symlinks=False,
+            symlink._windows_symlink(
+                f"d/{os.path.basename(real_file)}", f"a/{os.path.basename(link_file)}"
             )
         assert not os.path.exists(link_file)
         # Check dirs
         assert not os.path.lexists(link_dir)
         with pytest.raises(symlink.SymlinkError):
-            symlink.symlink(source_path="d", link_path="a/c", allow_broken_symlinks=False)
+            symlink._windows_symlink("d", "a/c")
         assert not os.path.lexists(link_dir)
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
 def test_symlink_link_already_exists(tmpdir):
     """Test the symlink.symlink method for the case where a link already exists"""
     with tmpdir.as_cwd():
@@ -108,10 +106,10 @@ def test_symlink_link_already_exists(tmpdir):
         real_dir = os.path.join(test_dir, "real_dir")
         link_dir = os.path.join(test_dir, "link_dir")
         os.mkdir(real_dir)
-        symlink.symlink(real_dir, link_dir, allow_broken_symlinks=False)
+        symlink._windows_symlink(real_dir, link_dir)
         assert os.path.exists(link_dir)
         with pytest.raises(symlink.SymlinkError):
-            symlink.symlink(source_path=real_dir, link_path=link_dir, allow_broken_symlinks=False)
+            symlink._windows_symlink(real_dir, link_dir)
 
 
 @pytest.mark.skipif(not symlink._windows_can_symlink(), reason="Test requires elevated privileges")
@@ -122,7 +120,7 @@ def test_symlink_win_file(tmpdir):
         test_dir = str(tmpdir)
         fd, real_file = tempfile.mkstemp(prefix="real", suffix=".txt", dir=test_dir)
         link_file = str(tmpdir.join("link.txt"))
-        symlink.symlink(source_path=real_file, link_path=link_file)
+        symlink.symlink(real_file, link_file)
         # Verify that all expected conditions are met
         assert os.path.exists(link_file)
         assert symlink.islink(link_file)
@@ -140,7 +138,7 @@ def test_symlink_win_dir(tmpdir):
         real_dir = os.path.join(test_dir, "real")
         link_dir = os.path.join(test_dir, "link")
         os.mkdir(real_dir)
-        symlink.symlink(source_path=real_dir, link_path=link_dir)
+        symlink.symlink(real_dir, link_dir)
         # Verify that all expected conditions are met
         assert os.path.exists(link_dir)
         assert symlink.islink(link_dir)


### PR DESCRIPTION
The windows wrappers for basic functions like `os.symlink`,
`os.readlink` and `os.path.islink` in the `llnl.util.symlink` module
have bugs, and trigger more file system operations on non-windows than
they should.

Since we run those functions *lots* of times during view creation, they better
be correct and optimal.

This commit just binds `llnl.util.symlink.symlink = os.symlink` etc so
that the bugs and performance hits that windows support introduces are
experienced only on windows

It also removes `allow_broken_symlinks=...`, which was introduced only
to be used in tests, which signals bad API design.

