### PR TITLE
Documenting rust conflicts with gcc >= 13

### DIFF
--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -86,6 +86,8 @@ class Rust(Package):
 
     # src/llvm-project/llvm/cmake/modules/CheckCompilerVersion.cmake
     conflicts("%gcc@:7.3", when="@1.73:", msg="Host GCC version must be at least 7.4")
+    # https://github.com/rust-lang/llvm-project/commit/4d039a7a71899038b3bc6ed6fe5a8a48d915caa0
+    conflicts("%gcc@13:", when="@:1.63", msg="Rust<1.64 not compatible with GCC>=13")
 
     extendable = True
     executables = ["^rustc$", "^cargo$"]


### PR DESCRIPTION
Rust versions prior to 1.64 had a conflict with gcc 13+'s stricter requirements for explicit import of cstdint

This is technically patched in the paired llvm submodule, but fixes rust compiling on gcc13/14:
https://github.com/rust-lang/llvm-project/commit/4d039a7a71899038b3bc6ed6fe5a8a48d915caa0
