### PR TITLE
mariadb: add v10.8.8, v10.9.6, v11.3.2

### DIFF
--- a/var/spack/repos/builtin/packages/mariadb/package.py
+++ b/var/spack/repos/builtin/packages/mariadb/package.py
@@ -23,6 +23,9 @@ class Mariadb(CMakePackage):
 
     license("GPL-2.0-or-later")
 
+    version("11.3.2", sha256="5570778f0a2c27af726c751cda1a943f3f8de96d11d107791be5b44a0ce3fb5c")
+    version("10.9.6", sha256="fe6f5287fccc6a65b8bbccae09e841e05dc076fcc13017078854ca387eab8ae9")
+    version("10.8.8", sha256="8de1a151842976a492d6331b543d0ed87259febbbc03b9ebce07c80d754d6361")
     version("10.8.2", sha256="14e0f7f8817a41bbcb5ebdd2345a9bd44035fde7db45c028b6d4c35887ae956c")
     version("10.4.12", sha256="fef1e1d38aa253dd8a51006bd15aad184912fce31c446bb69434fcde735aa208")
     version("10.4.8", sha256="10cc2c3bdb76733c9c6fd1e3c6c860d8b4282c85926da7d472d2a0e00fffca9b")
@@ -65,6 +68,7 @@ class Mariadb(CMakePackage):
     depends_on("krb5")
 
     conflicts("%gcc@9.1.0:", when="@:5.5")
+    conflicts("%gcc@13:", when="@:10.8.8")  # https://github.com/spack/spack/issues/41377
 
     # patch needed for cmake-3.20
     patch(


### PR DESCRIPTION
* Add a conflict for mariadb to capture the GCC 13 issue described in https://github.com/spack/spack/issues/41377 and https://jira.mariadb.org/browse/MDEV-31057.
* Add latest 3 minor versions that correct this issue.