### PR TITLE
whizard: add a dependency on ghostscript and fix +openmp

### DIFF
--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -161,7 +161,7 @@ class Whizard(AutotoolsPackage):
         if "+openloops" in spec:
             args.append(f"--with-openloops={spec['openloops'].prefix}")
         if "+openmp" in spec:
-            args.append(f"--enable-fc-openmp")
+            args.append("--enable-fc-openmp")
         return args
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -80,6 +80,7 @@ class Whizard(AutotoolsPackage):
         when="+openloops",
     )
     depends_on("texlive", when="+latex")
+    depends_on("ghostscript", when="+latex")
     depends_on("zlib-api")
 
     # Fix for https://github.com/key4hep/key4hep-spack/issues/71
@@ -159,8 +160,8 @@ class Whizard(AutotoolsPackage):
 
         if "+openloops" in spec:
             args.append(f"--with-openloops={spec['openloops'].prefix}")
-        if "+openmp" not in spec:
-            args.append("--disable-openmp")
+        if "+openmp" in spec:
+            args.append(f"--enable-fc-openmp")
         return args
 
     def url_for_version(self, version):


### PR DESCRIPTION
A dependency with ghostscript is needed to be able to find `ps2pdf` which is used when generating latex. The correct flag when building with `+openmp` is (and has been for a very long time) `--enable-fd-openmp` (see https://gitlab.tp.nt.uni-siegen.de/whizard/public/-/blob/a4bb8de1d287db238e47b89edbd8d270019ca485/INSTALL#L240)