### PR TITLE
fix: mariadb conflict issue

### DIFF
--- a/var/spack/repos/builtin/packages/mariadb/package.py
+++ b/var/spack/repos/builtin/packages/mariadb/package.py
@@ -68,7 +68,7 @@ class Mariadb(CMakePackage):
     depends_on("krb5")
 
     conflicts("%gcc@9.1.0:", when="@:5.5")
-    conflicts("%gcc@13:", when="@:10.8.8")  # https://github.com/spack/spack/issues/41377
+    conflicts("%gcc@13:", when="@:10.8.7")  # https://github.com/spack/spack/issues/41377
 
     # patch needed for cmake-3.20
     patch(


### PR DESCRIPTION
This is a small fix the the conflicts of mariadb recently pushed. The max conflict version for gcc>=13 was off by one.
