### PR TITLE
util-macros: ensure url_for_version works for older versions

### DIFF
--- a/var/spack/repos/builtin/packages/util-macros/package.py
+++ b/var/spack/repos/builtin/packages/util-macros/package.py
@@ -15,9 +15,9 @@ class UtilMacros(AutotoolsPackage, XorgPackage):
     xorg_mirror_path = "util/util-macros-1.19.1.tar.xz"
 
     # note: url_for_version can only return a single url, no mirrors
-    @when("@:1.19")
     def url_for_version(self, version):
-        return self.urls[0].replace("xz", "bz2")
+        if self.spec.satisfies("@:1.19"):
+            return spack.url.substitute_version(self.urls[0].replace("xz", "bz2"), version)
 
     maintainers("robert-mijakovic", "wdconinc")
 

--- a/var/spack/repos/builtin/packages/util-macros/package.py
+++ b/var/spack/repos/builtin/packages/util-macros/package.py
@@ -14,11 +14,6 @@ class UtilMacros(AutotoolsPackage, XorgPackage):
     homepage = "https://gitlab.freedesktop.org/xorg/util/macros"
     xorg_mirror_path = "util/util-macros-1.19.1.tar.xz"
 
-    # note: url_for_version can only return a single url, no mirrors
-    def url_for_version(self, version):
-        if self.spec.satisfies("@:1.19"):
-            return spack.url.substitute_version(self.urls[0].replace("xz", "bz2"), version)
-
     maintainers("robert-mijakovic", "wdconinc")
 
     license("MIT")
@@ -28,6 +23,11 @@ class UtilMacros(AutotoolsPackage, XorgPackage):
     version("1.19.2", sha256="d7e43376ad220411499a79735020f9d145fdc159284867e99467e0d771f3e712")
     version("1.19.1", sha256="18d459400558f4ea99527bc9786c033965a3db45bf4c6a32eefdc07aa9e306a6")
     version("1.19.0", sha256="2835b11829ee634e19fa56517b4cfc52ef39acea0cd82e15f68096e27cbed0ba")
+
+    # note: url_for_version can only return a single url, no mirrors
+    def url_for_version(self, version):
+        if self.spec.satisfies("@:1.19"):
+            return spack.url.substitute_version(self.urls[0].replace("xz", "bz2"), version)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Adds the ACLOCAL path for autotools."""

--- a/var/spack/repos/builtin/packages/util-macros/package.py
+++ b/var/spack/repos/builtin/packages/util-macros/package.py
@@ -15,9 +15,9 @@ class UtilMacros(AutotoolsPackage, XorgPackage):
     xorg_mirror_path = "util/util-macros-1.19.1.tar.xz"
 
     # note: url_for_version can only return a single url, no mirrors
+    @when("@:1.19")
     def url_for_version(self, version):
-        if self.spec.satisfies("@:1.19"):
-            return self.urls[0].replace("xz", "bz2")
+        return self.urls[0].replace("xz", "bz2")
 
     maintainers("robert-mijakovic", "wdconinc")
 


### PR DESCRIPTION
This PR should fix the issue raised in https://github.com/spack/spack/pull/44388#discussion_r1617785674.