### PR TITLE
tests: use fewer default paths

### DIFF
--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -492,7 +492,7 @@ full_padded_string = os.path.join(os.sep + "path", os.sep.join(reps))[:MAX_PADDE
     ],
 )
 def test_parse_install_tree(config_settings, expected, mutable_config):
-    expected_root = expected[0] or spack.store.DEFAULT_INSTALL_TREE_ROOT
+    expected_root = expected[0] or mutable_config.get("config:install_tree:root")
     expected_unpadded_root = expected[1] or expected_root
     expected_proj = expected[2] or spack.directory_layout.default_projections
 
@@ -575,7 +575,7 @@ def test_change_or_add(mutable_config, mock_packages):
     ],
 )
 def test_parse_install_tree_padded(config_settings, expected, mutable_config):
-    expected_root = expected[0] or spack.store.DEFAULT_INSTALL_TREE_ROOT
+    expected_root = expected[0] or mutable_config.get("config:install_tree:root")
     expected_unpadded_root = expected[1] or expected_root
     expected_proj = expected[2] or spack.directory_layout.default_projections
 
@@ -761,25 +761,20 @@ def test_internal_config_from_data():
     assert config.get("config:checksum", scope="higher") is True
 
 
-def test_keys_are_ordered():
+def test_keys_are_ordered(configuration_dir):
     """Test that keys in Spack YAML files retain their order from the file."""
     expected_order = (
-        "bin",
-        "man",
-        "share/man",
-        "share/aclocal",
-        "lib",
-        "lib64",
-        "include",
-        "lib/pkgconfig",
-        "lib64/pkgconfig",
-        "share/pkgconfig",
-        "",
+        "./bin",
+        "./man",
+        "./share/man",
+        "./share/aclocal",
+        "./lib/pkgconfig",
+        "./lib64/pkgconfig",
+        "./share/pkgconfig",
+        "./",
     )
 
-    config_scope = spack.config.ConfigScope(
-        "modules", os.path.join(spack.paths.test_path, "data", "config")
-    )
+    config_scope = spack.config.ConfigScope("modules", configuration_dir.join("site"))
 
     data = config_scope.get_section("modules")
 

--- a/lib/spack/spack/test/data/config/concretizer.yaml
+++ b/lib/spack/spack/test/data/config/concretizer.yaml
@@ -1,5 +1,5 @@
 concretizer:
-  reuse: True
+  reuse: true
   targets:
     granularity: microarchitectures
     host_compatible: false

--- a/lib/spack/spack/test/data/config/config.yaml
+++ b/lib/spack/spack/test/data/config/config.yaml
@@ -1,6 +1,6 @@
 config:
   install_tree:
-    root: $spack/opt/spack
+    root: {0}
   template_dirs:
   - $spack/share/spack/templates
   - $spack/lib/spack/spack/test/data/templates
@@ -13,5 +13,5 @@ config:
   ssl_certs: $SSL_CERT_FILE
   checksum: true
   dirty: false
-  concretizer: {0}
-  locks: {1}
+  concretizer: {1}
+  locks: {2}

--- a/lib/spack/spack/test/data/config/modules.yaml
+++ b/lib/spack/spack/test/data/config/modules.yaml
@@ -14,29 +14,25 @@
 #   ~/.spack/modules.yaml
 # -------------------------------------------------------------------------
 modules:
-  default: {}
   prefix_inspections:
-    bin:
-      - PATH
-    man:
-      - MANPATH
-    share/man:
-      - MANPATH
-    share/aclocal:
-      - ACLOCAL_PATH
-    lib:
-      - LIBRARY_PATH
-      - LD_LIBRARY_PATH
-    lib64:
-      - LIBRARY_PATH
-      - LD_LIBRARY_PATH
-    include:
-      - CPATH
-    lib/pkgconfig:
-      - PKG_CONFIG_PATH
-    lib64/pkgconfig:
-      - PKG_CONFIG_PATH
-    share/pkgconfig:
-      - PKG_CONFIG_PATH
-    '':
-      - CMAKE_PREFIX_PATH
+    ./bin: [PATH]
+    ./man: [MANPATH]
+    ./share/man: [MANPATH]    
+    ./share/aclocal: [ACLOCAL_PATH]
+    ./lib/pkgconfig: [PKG_CONFIG_PATH]
+    ./lib64/pkgconfig: [PKG_CONFIG_PATH]
+    ./share/pkgconfig: [PKG_CONFIG_PATH]
+    ./: [CMAKE_PREFIX_PATH]
+  default:
+    roots:
+     tcl: {0}
+     lmod: {1}
+    enable: []
+    tcl:
+      all:
+        autoload: direct
+    lmod:
+      all:
+        autoload: direct
+      hierarchy:
+        - mpi


### PR DESCRIPTION
Set `config:install_tree:root` and `modules:default:roots` to something
temporary in tests. The latter was silently broken for years now.
