### PR TITLE
vmd: fix v1.9.3 checksum

### DIFF
--- a/var/spack/repos/builtin/packages/vmd/package.py
+++ b/var/spack/repos/builtin/packages/vmd/package.py
@@ -24,7 +24,7 @@ class Vmd(Package):
     homepage = "https://www.ks.uiuc.edu/Research/vmd/"
     version(
         "1.9.3",
-        sha256="145b4d0cc10b56cadeb71e16c54ab8be713e268f11491714cd617422758ec643",
+        sha256="9427a7acb1c7809525f70f635bceeb7eff8e7574e7e3565d6f71f3d6ce405a71",
         url="file://{0}/vmd-1.9.3.bin.LINUXAMD64-CUDA8-OptiX4-OSPRay111p1.opengl.tar.gz".format(
             os.getcwd()
         ),


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

in 0.22.0 release and develop branch:

```
==> Installing vmd-1.9.3-lkjzea2nohnvhsmckkidpaafzls6g5qe [67/67]
==> No binary for vmd-1.9.3-lkjzea2nohnvhsmckkidpaafzls6g5qe found: installing from source
==> Fetching file:///home/user/vmd-1.9.3.bin.LINUXAMD64-CUDA8-OptiX4-OSPRay111p1.opengl.tar.gz
==> Error: ChecksumError: sha256 checksum failed for /tmp/3595345.1.all.q/user/spack-stage/spack-stage-vmd-1.9.3-lkjzea2nohnvhsmckkidpaafzls6g5qe/vmd-1.9.3.bin.LINUXAMD64-CUDA8-OptiX4-OSPRay111p1.opengl.tar.gz
Expected 145b4d0cc10b56cadeb71e16c54ab8be713e268f11491714cd617422758ec643 but got 
9427a7acb1c7809525f70f635bceeb7eff8e7574e7e3565d6f71f3d6ce405a71.
File size = 64293383 bytes.
Contents = b'\x1f\x8b\x08\x08Ud?X\x00\x03vmd-1....\xff\xbe\xfe\xfd;\xfc\xfd\xff\x81W\xb8z\x00\x88\xb6\x0c'
```

```
$ sha256sum vmd-1.9.3.bin.LINUXAMD64-CUDA8-OptiX4-OSPRay111p1.opengl.tar.gz 
9427a7acb1c7809525f70f635bceeb7eff8e7574e7e3565d6f71f3d6ce405a71  vmd-1.9.3.bin.LINUXAMD64-CUDA8-OptiX4-OSPRay111p1.opengl.tar.gz
```

After modifying this locally and re-running the vmd installation:

```
==> Installing vmd-1.9.3-n6ptk6wmywjk2ss6tjmmfqptxvc56hdi [67/67]
==> No binary for vmd-1.9.3-n6ptk6wmywjk2ss6tjmmfqptxvc56hdi found: installing from source
==> Fetching file:///home/user/vmd-1.9.3.bin.LINUXAMD64-CUDA8-OptiX4-OSPRay111p1.opengl.tar.gz
==> No patches needed for vmd
==> vmd: Executing phase: 'install'
==> vmd: Successfully installed vmd-1.9.3-n6ptk6wmywjk2ss6tjmmfqptxvc56hdi
  Stage: 2.79s.  Install: 2.33s.  Post-install: 3.08s.  Total: 10.19s
[+] /home/user/spack/apps/rocky9/linux-rocky9-x86_64_v4/gcc-12.2.0/vmd/1.9.3-n6ptk6w
```