### PR TITLE
remove non-existent when kwarg

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -274,19 +274,9 @@ class Hdf5(CMakePackage):
 
     # The parallel compiler wrappers (i.e. h5pcc, h5pfc, etc.) reference MPI
     # compiler wrappers and do not need to be changed.
-    # These do not exist on Windows.
-    # Enable only for supported target platforms.
-    for spack_spec_target_platform in ["linux", "darwin", "cray"]:
-        filter_compiler_wrappers(
-            "h5cc",
-            "h5hlcc",
-            "h5fc",
-            "h5hlfc",
-            "h5c++",
-            "h5hlc++",
-            relative_root="bin",
-            when=f"platform={spack_spec_target_platform}",
-        )
+    filter_compiler_wrappers(
+        "h5cc", "h5hlcc", "h5fc", "h5hlfc", "h5c++", "h5hlc++", relative_root="bin"
+    )
 
     def url_for_version(self, version):
         url = (

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -56,9 +56,7 @@ class Tcl(AutotoolsPackage, NMakePackage, SourceforgePackage, TclHelper):
 
     depends_on("zlib-api")
 
-    # No compiler wrappers on Windows
-    for plat in ["linux", "darwin", "cray", "freebsd"]:
-        filter_compiler_wrappers("tclConfig.sh", relative_root="lib", when=f"platform={plat}")
+    filter_compiler_wrappers("tclConfig.sh", relative_root="lib")
 
     build_system("autotools", "nmake")
     patch("tcl-quote-cc-path.patch", when="platform=windows")


### PR DESCRIPTION
Not sure why this was added, there is no `when` kwarg.

