### PR TITLE
hpl configure uses CC instead of MPICC if both are provided

### DIFF
--- a/var/spack/repos/builtin/packages/hpl/package.py
+++ b/var/spack/repos/builtin/packages/hpl/package.py
@@ -103,7 +103,7 @@ class Hpl(AutotoolsPackage):
     def configure_args(self):
         filter_file(r"^libs10=.*", "libs10=%s" % self.spec["blas"].libs.ld_flags, "configure")
 
-        cflags, ldflags = ["-O3"], []
+        cc, cflags, ldflags = self.spec['mpi'].mpicc, ["-O3"], []
         if "+openmp" in self.spec:
             cflags.append(self.compiler.openmp_flag)
 
@@ -120,13 +120,9 @@ class Hpl(AutotoolsPackage):
             if "%aocc@4:" in self.spec:
                 ldflags.append("-lamdalloc")
 
-        if self.spec["blas"].name == "fujitsu-ssl2" and (
-            self.spec.satisfies("%fj") or self.spec.satisfies("%clang@17:")
-        ):
-            cflags.append("-SSL2BLAMP")
-            ldflags.append("-SSL2BLAMP")
-
-        return ["CFLAGS={0}".format(" ".join(cflags)), "LDFLAGS={0}".format(" ".join(ldflags))]
+        return [f"CC={cc}",
+                f"CFLAGS={' '.join(cflags)}",
+                f"LDFLAGS={' '.join(ldflags)}"]
 
     @when("@:2.2")
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/hpl/package.py
+++ b/var/spack/repos/builtin/packages/hpl/package.py
@@ -103,7 +103,7 @@ class Hpl(AutotoolsPackage):
     def configure_args(self):
         filter_file(r"^libs10=.*", "libs10=%s" % self.spec["blas"].libs.ld_flags, "configure")
 
-        cc, cflags, ldflags = self.spec['mpi'].mpicc, ["-O3"], []
+        cc, cflags, ldflags = self.spec["mpi"].mpicc, ["-O3"], []
         if "+openmp" in self.spec:
             cflags.append(self.compiler.openmp_flag)
 
@@ -120,9 +120,7 @@ class Hpl(AutotoolsPackage):
             if "%aocc@4:" in self.spec:
                 ldflags.append("-lamdalloc")
 
-        return [f"CC={cc}",
-                f"CFLAGS={' '.join(cflags)}",
-                f"LDFLAGS={' '.join(ldflags)}"]
+        return [f"CC={cc}", f"CFLAGS={' '.join(cflags)}", f"LDFLAGS={' '.join(ldflags)}"]
 
     @when("@:2.2")
     def install(self, spec, prefix):


### PR DESCRIPTION
- hpl configure script uses CC instead of MPICC if both are provided (which seems default for spack); thats obviously wrong, but we have to deal will it
- setting blas flags here makes no sense and will be fixed in another PR for fujitsu-ssl2

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
