### PR TITLE
protobuf: fix 3.4:3.21 patch checksum

### DIFF
--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -110,9 +110,9 @@ class Protobuf(CMakePackage):
 
     # fix build on Centos 8, see also https://github.com/protocolbuffers/protobuf/issues/5144
     patch(
-        "https://github.com/protocolbuffers/protobuf/commit/3039f932aaf212bcf2f14a3f2fd00dbfb881e46b.patch?full_index=1",
+        "https://github.com/protocolbuffers/protobuf/commit/462964ed322503af52638d54c00a0a67d7133349.patch?full_index=1",
         when="@3.4:3.21",
-        sha256="a779238fb7957514d4fb393410111419a964771e826ec2a8f09c21aa1efbb4d1",
+        sha256="9b6dcfa30dd3ae0abb66ab0f252a4fc1e1cc82a9820d2bdb72da35c4f80c3603",
     )
 
     patch("msvc-abseil-target-namespace.patch", when="@3.22 %msvc")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

```
$ spack install protobuf@3.21.12 %gcc@12.2.0
...
==> Installing protobuf-3.21.12-4fqlco7zi42owopbvhonvys5mmmayc2c [12/12]
==> No binary for protobuf-3.21.12-4fqlco7zi42owopbvhonvys5mmmayc2c found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/93/930c2c3b5ecc6c9c12615cf5ad93f1cd6e12d0aba862b572e076259970ac3a53.tar.gz
==> Fetching https://github.com/protocolbuffers/protobuf/pull/11032/commits/3039f932aaf212bcf2f14a3f2fd00dbfb881e46b.patch?full_index=1
==> Error: ChecksumError: sha256 checksum failed for /tmp/3597084.1.all.q/user/spack-stage/spack-stage-patch-cefc4bf4aadf9ca33a336b2aa6d0d82006b6563e85122ae8cfb70345f85321dd/3039f932aaf212bcf2f14a3f2fd00dbfb881e46b.patch?full_index=1
    Expected cefc4bf4aadf9ca33a336b2aa6d0d82006b6563e85122ae8cfb70345f85321dd but got ae8639a308294bed85d3f6ebb7e005ee4fde6b2884d41cb75543191c9c5c98ef. File size = 1171 bytes. Contents = b'From 3039f932aaf... local:\n     *;\n'
```

after fix:

```
==> Installing protobuf-3.21.12-y4daomoulazdqvflzzr7ujocs5xqrhih [12/12]
==> No binary for protobuf-3.21.12-y4daomoulazdqvflzzr7ujocs5xqrhih found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/93/930c2c3b5ecc6c9c12615cf5ad93f1cd6e12d0aba862b572e076259970ac3a53.tar.gz
==> Fetching https://github.com/protocolbuffers/protobuf/pull/11032/commits/3039f932aaf212bcf2f14a3f2fd00dbfb881e46b.patch?full_index=1
==> Applied patch https://github.com/protocolbuffers/protobuf/pull/11032/commits/3039f932aaf212bcf2f14a3f2fd00dbfb881e46b.patch?full_index=1
==> protobuf: Executing phase: 'cmake'
==> protobuf: Executing phase: 'build'
==> protobuf: Executing phase: 'install'
==> protobuf: Successfully installed protobuf-3.21.12-y4daomoulazdqvflzzr7ujocs5xqrhih
  Stage: 2.30s.  Cmake: 1.72s.  Build: 30.73s.  Install: 0.53s.  Post-install: 0.58s.  Total: 36.26s
[+] /home/user/spack/apps/rocky9/linux-rocky9-x86_64_v4/gcc-12.2.0/protobuf/3.21.12-y4daomo
```