### PR TITLE
e4s external rocm ci: bump rocm stack to v6.1.1

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -376,7 +376,7 @@ e4s-neoverse_v1-build:
 
 e4s-rocm-external-generate:
   extends: [ ".e4s-rocm-external", ".generate-x86_64"]
-  image: ecpe4s/ubuntu22.04-runner-amd64-gcc-11.4-rocm5.7.1:2024.03.01
+  image: ecpe4s/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.1.1:2024.06.01
 
 e4s-rocm-external-build:
   extends: [ ".e4s-rocm-external", ".build" ]

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -376,7 +376,7 @@ e4s-neoverse_v1-build:
 
 e4s-rocm-external-generate:
   extends: [ ".e4s-rocm-external", ".generate-x86_64"]
-  image: ecpe4s/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.1.1:2024.06.01
+  image: ecpe4s/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.1.1:2024.06.17
 
 e4s-rocm-external-build:
   extends: [ ".e4s-rocm-external", ".build" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -209,7 +209,6 @@ spack:
   - tau +mpi +rocm +syscall  # tau: has issue with `spack env depfile` build
 
   # ROCM 908
-  - adios2 +kokkos +rocm amdgpu_target=gfx908
   - amrex +rocm amdgpu_target=gfx908
   - arborx +rocm amdgpu_target=gfx908
   - cabana +rocm amdgpu_target=gfx908
@@ -246,12 +245,12 @@ spack:
   - paraview +rocm amdgpu_target=gfx908
   # - vtk-m ~openmp +rocm amdgpu_target=gfx908  # vtk-m: https://github.com/spack/spack/issues/40268
   # --
+  # - adios2 +kokkos +rocm amdgpu_target=gfx908 # adios2:https://github.com/spack/spack/issues/44594
   # - exago +mpi +python +raja +hiop +rocm amdgpu_target=gfx908 ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target=gfx908 # raja: https://github.com/spack/spack/issues/44593
   # - lbann ~cuda +rocm amdgpu_target=gfx908    # aluminum: https://github.com/spack/spack/issues/38807
   # - papi +rocm amdgpu_target=gfx908           # papi: https://github.com/spack/spack/issues/27898
 
   # ROCM 90a
-  - adios2 +kokkos +rocm amdgpu_target=gfx90a
   - amrex +rocm amdgpu_target=gfx90a
   - arborx +rocm amdgpu_target=gfx90a
   - cabana +rocm amdgpu_target=gfx90a
@@ -288,6 +287,7 @@ spack:
   - paraview +rocm amdgpu_target=gfx90a
   # - vtk-m ~openmp +rocm amdgpu_target=gfx90a  # vtk-m: https://github.com/spack/spack/issues/40268
   # --
+  # - adios2 +kokkos +rocm amdgpu_target=gfx90a # adios2: https://github.com/spack/spack/issues/44594  
   # - exago +mpi +python +raja +hiop +rocm amdgpu_target=gfx90a ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target=gfx90a # raja: https://github.com/spack/spack/issues/44593
   # - lbann ~cuda +rocm amdgpu_target=gfx90a    # aluminum: https://github.com/spack/spack/issues/38807
   # - papi +rocm amdgpu_target=gfx90a           # papi: https://github.com/spack/spack/issues/27898

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -217,7 +217,6 @@ spack:
   - chai +rocm amdgpu_target=gfx908
   # - cp2k +mpi +rocm amdgpu_target=gfx908 # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
   - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx908
-  - exago +mpi +python +raja +hiop +rocm amdgpu_target=gfx908 ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target=gfx908
   - gasnet +rocm amdgpu_target=gfx908
   - ginkgo +rocm amdgpu_target=gfx908
   - heffte +rocm amdgpu_target=gfx908
@@ -247,6 +246,7 @@ spack:
   - paraview +rocm amdgpu_target=gfx908
   # - vtk-m ~openmp +rocm amdgpu_target=gfx908  # vtk-m: https://github.com/spack/spack/issues/40268
   # --
+  # - exago +mpi +python +raja +hiop +rocm amdgpu_target=gfx908 ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target=gfx908 # raja: https://github.com/spack/spack/issues/44593
   # - lbann ~cuda +rocm amdgpu_target=gfx908    # aluminum: https://github.com/spack/spack/issues/38807
   # - papi +rocm amdgpu_target=gfx908           # papi: https://github.com/spack/spack/issues/27898
 
@@ -259,7 +259,6 @@ spack:
   - chai +rocm amdgpu_target=gfx90a
   # - cp2k +mpi +rocm amdgpu_target=gfx90a # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
   - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx90a
-  - exago +mpi +python +raja +hiop +rocm amdgpu_target=gfx90a ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target=gfx90a  
   - gasnet +rocm amdgpu_target=gfx90a
   - ginkgo +rocm amdgpu_target=gfx90a
   - heffte +rocm amdgpu_target=gfx90a
@@ -289,6 +288,7 @@ spack:
   - paraview +rocm amdgpu_target=gfx90a
   # - vtk-m ~openmp +rocm amdgpu_target=gfx90a  # vtk-m: https://github.com/spack/spack/issues/40268
   # --
+  # - exago +mpi +python +raja +hiop +rocm amdgpu_target=gfx90a ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target=gfx90a # raja: https://github.com/spack/spack/issues/44593
   # - lbann ~cuda +rocm amdgpu_target=gfx90a    # aluminum: https://github.com/spack/spack/issues/38807
   # - papi +rocm amdgpu_target=gfx90a           # papi: https://github.com/spack/spack/issues/27898
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -300,7 +300,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ecpe4s/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.1.1:2024.06.01
+        image: ecpe4s/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.1.1:2024.06.17
 
   cdash:
     build-group: E4S ROCm External

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -243,7 +243,7 @@ spack:
   # - libcatalyst
   # - paraview +rocm amdgpu_target=gfx908 # mesa: https://github.com/spack/spack/issues/44745
   # - vtk-m ~openmp +rocm amdgpu_target=gfx908  # vtk-m: https://github.com/spack/spack/issues/40268
-  - ecp-data-vis-sdk ~paraview +vtkm +rocm amdgpu_target=gfx908 # +paraview: mesa: https://github.com/spack/spack/issues/44745
+  # - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx908 # +paraview: mesa: https://github.com/spack/spack/issues/44745; +vtkm has its own issue: https://gitlab.spack.io/spack/spack/-/jobs/11632511
   # --
   # - adios2 +kokkos +rocm amdgpu_target=gfx908 # adios2:https://github.com/spack/spack/issues/44594
   # - cp2k +mpi +rocm amdgpu_target=gfx908      # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
@@ -285,7 +285,7 @@ spack:
   # - libcatalyst
   # - paraview +rocm amdgpu_target=gfx90a # mesa: https://github.com/spack/spack/issues/44745
   # - vtk-m ~openmp +rocm amdgpu_target=gfx90a  # vtk-m: https://github.com/spack/spack/issues/40268
-  - ecp-data-vis-sdk ~paraview +vtkm +rocm amdgpu_target=gfx90a  # +paraview: mesa: https://github.com/spack/spack/issues/44745
+  # - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx90a  # +paraview: mesa: https://github.com/spack/spack/issues/44745; +vtkm has its own issue: https://gitlab.spack.io/spack/spack/-/jobs/11632511
   # --
   # - adios2 +kokkos +rocm amdgpu_target=gfx90a # adios2: https://github.com/spack/spack/issues/44594  
   # - cp2k +mpi +rocm amdgpu_target=gfx90a      # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -202,6 +202,11 @@ spack:
       externals:
       - spec: rocprofiler-dev@6.1.1
         prefix: /opt/rocm-6.1.1
+    rocm-core:
+      buildable: false
+      externals:
+      - spec: rocm-core@6.1.1
+        prefix: /opt/rocm-6.1.1
 
   specs:
   # ROCM NOARCH

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -225,7 +225,6 @@ spack:
   - legion +rocm amdgpu_target=gfx908
   - magma ~cuda +rocm amdgpu_target=gfx908
   - mfem +rocm amdgpu_target=gfx908
-  - petsc +rocm amdgpu_target=gfx908
   - raja ~openmp +rocm amdgpu_target=gfx908
   # - slate +rocm amdgpu_target=gfx908          # slate: hip/device_gescale_row_col.hip.cc:58:49: error: use of overloaded operator '*' is ambiguous (with operand types 'HIP_vector_type<double, 2>' and 'const HIP_vector_type<double, 2>')
   - slepc +rocm amdgpu_target=gfx908 ^petsc +rocm amdgpu_target=gfx908
@@ -249,6 +248,7 @@ spack:
   # - exago +mpi +python +raja +hiop +rocm amdgpu_target=gfx908 ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target=gfx908 # raja: https://github.com/spack/spack/issues/44593
   # - lbann ~cuda +rocm amdgpu_target=gfx908    # aluminum: https://github.com/spack/spack/issues/38807
   # - papi +rocm amdgpu_target=gfx908           # papi: https://github.com/spack/spack/issues/27898
+  # - petsc +rocm amdgpu_target=gfx908          # petsc: https://github.com/spack/spack/issues/44600
 
   # ROCM 90a
   - amrex +rocm amdgpu_target=gfx90a
@@ -267,7 +267,6 @@ spack:
   - legion +rocm amdgpu_target=gfx90a
   - magma ~cuda +rocm amdgpu_target=gfx90a
   - mfem +rocm amdgpu_target=gfx90a
-  - petsc +rocm amdgpu_target=gfx90a
   - raja ~openmp +rocm amdgpu_target=gfx90a
   # - slate +rocm amdgpu_target=gfx90a          # slate: hip/device_gescale_row_col.hip.cc:58:49: error: use of overloaded operator '*' is ambiguous (with operand types 'HIP_vector_type<double, 2>' and 'const HIP_vector_type<double, 2>')
   - slepc +rocm amdgpu_target=gfx90a ^petsc +rocm amdgpu_target=gfx90a
@@ -291,6 +290,7 @@ spack:
   # - exago +mpi +python +raja +hiop +rocm amdgpu_target=gfx90a ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target=gfx90a # raja: https://github.com/spack/spack/issues/44593
   # - lbann ~cuda +rocm amdgpu_target=gfx90a    # aluminum: https://github.com/spack/spack/issues/38807
   # - papi +rocm amdgpu_target=gfx90a           # papi: https://github.com/spack/spack/issues/27898
+  # - petsc +rocm amdgpu_target=gfx90a          # petsc: https://github.com/spack/spack/issues/44600
 
   ci:
     pipeline-gen:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -241,9 +241,9 @@ spack:
   # - hdf5-vol-cache
   # - hdf5-vol-log
   # - libcatalyst
-  - paraview +rocm amdgpu_target=gfx908
+  # - paraview +rocm amdgpu_target=gfx908 # mesa: https://github.com/spack/spack/issues/44745
   # - vtk-m ~openmp +rocm amdgpu_target=gfx908  # vtk-m: https://github.com/spack/spack/issues/40268
-  # - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx908 # mesa: https://github.com/spack/spack/issues/44745
+  - ecp-data-vis-sdk ~paraview +vtkm +rocm amdgpu_target=gfx908 # +paraview: mesa: https://github.com/spack/spack/issues/44745
   # --
   # - adios2 +kokkos +rocm amdgpu_target=gfx908 # adios2:https://github.com/spack/spack/issues/44594
   # - cp2k +mpi +rocm amdgpu_target=gfx908      # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
@@ -283,9 +283,9 @@ spack:
   # - hdf5-vol-cache
   # - hdf5-vol-log
   # - libcatalyst
-  - paraview +rocm amdgpu_target=gfx90a
+  # - paraview +rocm amdgpu_target=gfx90a # mesa: https://github.com/spack/spack/issues/44745
   # - vtk-m ~openmp +rocm amdgpu_target=gfx90a  # vtk-m: https://github.com/spack/spack/issues/40268
-  # - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx90a  # mesa: https://github.com/spack/spack/issues/44745
+  - ecp-data-vis-sdk ~paraview +vtkm +rocm amdgpu_target=gfx90a  # +paraview: mesa: https://github.com/spack/spack/issues/44745
   # --
   # - adios2 +kokkos +rocm amdgpu_target=gfx90a # adios2: https://github.com/spack/spack/issues/44594  
   # - cp2k +mpi +rocm amdgpu_target=gfx90a      # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -211,8 +211,7 @@ spack:
   specs:
   # ROCM NOARCH
   - hpctoolkit +rocm
-  # --
-  # - tau +mpi +rocm +syscall  # tau: https://github.com/spack/spack/issues/44659
+  - tau +mpi +rocm +syscall
 
   # ROCM 908
   - amrex +rocm amdgpu_target=gfx908

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -206,7 +206,8 @@ spack:
   specs:
   # ROCM NOARCH
   - hpctoolkit +rocm
-  - tau +mpi +rocm +syscall  # tau: has issue with `spack env depfile` build
+  # --
+  # - tau +mpi +rocm +syscall  # tau: https://github.com/spack/spack/issues/44659
 
   # ROCM 908
   - amrex +rocm amdgpu_target=gfx908

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -215,7 +215,6 @@ spack:
   - cabana +rocm amdgpu_target=gfx908
   - caliper +rocm amdgpu_target=gfx908
   - chai +rocm amdgpu_target=gfx908
-  - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx908
   - gasnet +rocm amdgpu_target=gfx908
   - ginkgo +rocm amdgpu_target=gfx908
   - heffte +rocm amdgpu_target=gfx908
@@ -240,6 +239,7 @@ spack:
   # - libcatalyst
   - paraview +rocm amdgpu_target=gfx908
   # - vtk-m ~openmp +rocm amdgpu_target=gfx908  # vtk-m: https://github.com/spack/spack/issues/40268
+  # - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx908 # mesa: https://github.com/spack/spack/issues/44745
   # --
   # - adios2 +kokkos +rocm amdgpu_target=gfx908 # adios2:https://github.com/spack/spack/issues/44594
   # - cp2k +mpi +rocm amdgpu_target=gfx908      # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
@@ -257,7 +257,6 @@ spack:
   - cabana +rocm amdgpu_target=gfx90a
   - caliper +rocm amdgpu_target=gfx90a
   - chai +rocm amdgpu_target=gfx90a
-  - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx90a
   - gasnet +rocm amdgpu_target=gfx90a
   - ginkgo +rocm amdgpu_target=gfx90a
   - heffte +rocm amdgpu_target=gfx90a
@@ -282,6 +281,7 @@ spack:
   # - libcatalyst
   - paraview +rocm amdgpu_target=gfx90a
   # - vtk-m ~openmp +rocm amdgpu_target=gfx90a  # vtk-m: https://github.com/spack/spack/issues/40268
+  # - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx90a  # mesa: https://github.com/spack/spack/issues/44745
   # --
   # - adios2 +kokkos +rocm amdgpu_target=gfx90a # adios2: https://github.com/spack/spack/issues/44594  
   # - cp2k +mpi +rocm amdgpu_target=gfx90a      # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -214,7 +214,6 @@ spack:
   - cabana +rocm amdgpu_target=gfx908
   - caliper +rocm amdgpu_target=gfx908
   - chai +rocm amdgpu_target=gfx908
-  # - cp2k +mpi +rocm amdgpu_target=gfx908 # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
   - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx908
   - gasnet +rocm amdgpu_target=gfx908
   - ginkgo +rocm amdgpu_target=gfx908
@@ -226,10 +225,8 @@ spack:
   - magma ~cuda +rocm amdgpu_target=gfx908
   - mfem +rocm amdgpu_target=gfx908
   - raja ~openmp +rocm amdgpu_target=gfx908
-  # - slate +rocm amdgpu_target=gfx908          # slate: hip/device_gescale_row_col.hip.cc:58:49: error: use of overloaded operator '*' is ambiguous (with operand types 'HIP_vector_type<double, 2>' and 'const HIP_vector_type<double, 2>')
   - slepc +rocm amdgpu_target=gfx908 ^petsc +rocm amdgpu_target=gfx908
   - strumpack ~slate +rocm amdgpu_target=gfx908
-  - sundials +rocm amdgpu_target=gfx908
   - superlu-dist +rocm amdgpu_target=gfx908
   - tasmanian ~openmp +rocm amdgpu_target=gfx908
   - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack ~ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu ~stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long +rocm amdgpu_target=gfx908
@@ -245,10 +242,13 @@ spack:
   # - vtk-m ~openmp +rocm amdgpu_target=gfx908  # vtk-m: https://github.com/spack/spack/issues/40268
   # --
   # - adios2 +kokkos +rocm amdgpu_target=gfx908 # adios2:https://github.com/spack/spack/issues/44594
+  # - cp2k +mpi +rocm amdgpu_target=gfx908      # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
   # - exago +mpi +python +raja +hiop +rocm amdgpu_target=gfx908 ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target=gfx908 # raja: https://github.com/spack/spack/issues/44593
   # - lbann ~cuda +rocm amdgpu_target=gfx908    # aluminum: https://github.com/spack/spack/issues/38807
   # - papi +rocm amdgpu_target=gfx908           # papi: https://github.com/spack/spack/issues/27898
   # - petsc +rocm amdgpu_target=gfx908          # petsc: https://github.com/spack/spack/issues/44600
+  # - slate +rocm amdgpu_target=gfx908          # slate: hip/device_gescale_row_col.hip.cc:58:49: error: use of overloaded operator '*' is ambiguous (with operand types 'HIP_vector_type<double, 2>' and 'const HIP_vector_type<double, 2>')
+  # - sundials +rocm amdgpu_target=gfx908       # sundials: https://github.com/spack/spack/issues/44601
 
   # ROCM 90a
   - amrex +rocm amdgpu_target=gfx90a
@@ -256,7 +256,6 @@ spack:
   - cabana +rocm amdgpu_target=gfx90a
   - caliper +rocm amdgpu_target=gfx90a
   - chai +rocm amdgpu_target=gfx90a
-  # - cp2k +mpi +rocm amdgpu_target=gfx90a # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
   - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx90a
   - gasnet +rocm amdgpu_target=gfx90a
   - ginkgo +rocm amdgpu_target=gfx90a
@@ -268,10 +267,8 @@ spack:
   - magma ~cuda +rocm amdgpu_target=gfx90a
   - mfem +rocm amdgpu_target=gfx90a
   - raja ~openmp +rocm amdgpu_target=gfx90a
-  # - slate +rocm amdgpu_target=gfx90a          # slate: hip/device_gescale_row_col.hip.cc:58:49: error: use of overloaded operator '*' is ambiguous (with operand types 'HIP_vector_type<double, 2>' and 'const HIP_vector_type<double, 2>')
   - slepc +rocm amdgpu_target=gfx90a ^petsc +rocm amdgpu_target=gfx90a
   - strumpack ~slate +rocm amdgpu_target=gfx90a
-  - sundials +rocm amdgpu_target=gfx90a
   - superlu-dist +rocm amdgpu_target=gfx90a
   - tasmanian ~openmp +rocm amdgpu_target=gfx90a
   - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack ~ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu ~stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long +rocm amdgpu_target=gfx90a
@@ -287,10 +284,13 @@ spack:
   # - vtk-m ~openmp +rocm amdgpu_target=gfx90a  # vtk-m: https://github.com/spack/spack/issues/40268
   # --
   # - adios2 +kokkos +rocm amdgpu_target=gfx90a # adios2: https://github.com/spack/spack/issues/44594  
+  # - cp2k +mpi +rocm amdgpu_target=gfx90a      # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
   # - exago +mpi +python +raja +hiop +rocm amdgpu_target=gfx90a ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target=gfx90a # raja: https://github.com/spack/spack/issues/44593
   # - lbann ~cuda +rocm amdgpu_target=gfx90a    # aluminum: https://github.com/spack/spack/issues/38807
   # - papi +rocm amdgpu_target=gfx90a           # papi: https://github.com/spack/spack/issues/27898
   # - petsc +rocm amdgpu_target=gfx90a          # petsc: https://github.com/spack/spack/issues/44600
+  # - slate +rocm amdgpu_target=gfx90a          # slate: hip/device_gescale_row_col.hip.cc:58:49: error: use of overloaded operator '*' is ambiguous (with operand types 'HIP_vector_type<double, 2>' and 'const HIP_vector_type<double, 2>')
+  # - sundials +rocm amdgpu_target=gfx90a       # sundials: https://github.com/spack/spack/issues/44601
 
   ci:
     pipeline-gen:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -23,185 +23,185 @@ spack:
       # Don't build GUI support or GLX rendering for HPC/container deployments
       require: "@5.11 ~qt ^[virtuals=gl] osmesa"
 
-    # ROCm 5.4.3
+    # ROCm
     comgr:
       buildable: false
       externals:
-      - spec: comgr@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: comgr@6.1.1
+        prefix: /opt/rocm-6.1.1/
     hip-rocclr:
       buildable: false
       externals:
-      - spec: hip-rocclr@5.7.1
-        prefix: /opt/rocm-5.7.1/hip
+      - spec: hip-rocclr@6.1.1
+        prefix: /opt/rocm-6.1.1/hip
     hipblas:
       buildable: false
       externals:
-      - spec: hipblas@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: hipblas@6.1.1
+        prefix: /opt/rocm-6.1.1/
     hipcub:
       buildable: false
       externals:
-      - spec: hipcub@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: hipcub@6.1.1
+        prefix: /opt/rocm-6.1.1/
     hipfft:
       buildable: false
       externals:
-      - spec: hipfft@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: hipfft@6.1.1
+        prefix: /opt/rocm-6.1.1/
     hipsparse:
       buildable: false
       externals:
-      - spec: hipsparse@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: hipsparse@6.1.1
+        prefix: /opt/rocm-6.1.1/
     miopen-hip:
       buildable: false
       externals:
-      - spec: miopen-hip@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: miopen-hip@6.1.1
+        prefix: /opt/rocm-6.1.1/
     miopengemm:
       buildable: false
       externals:
-      - spec: miopengemm@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: miopengemm@6.1.1
+        prefix: /opt/rocm-6.1.1/
     rccl:
       buildable: false
       externals:
-      - spec: rccl@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: rccl@6.1.1
+        prefix: /opt/rocm-6.1.1/
     rocblas:
       buildable: false
       externals:
-      - spec: rocblas@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: rocblas@6.1.1
+        prefix: /opt/rocm-6.1.1/
     rocfft:
       buildable: false
       externals:
-      - spec: rocfft@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: rocfft@6.1.1
+        prefix: /opt/rocm-6.1.1/
     rocm-clang-ocl:
       buildable: false
       externals:
-      - spec: rocm-clang-ocl@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: rocm-clang-ocl@6.1.1
+        prefix: /opt/rocm-6.1.1/
     rocm-cmake:
       buildable: false
       externals:
-      - spec: rocm-cmake@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: rocm-cmake@6.1.1
+        prefix: /opt/rocm-6.1.1/
     rocm-dbgapi:
       buildable: false
       externals:
-      - spec: rocm-dbgapi@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: rocm-dbgapi@6.1.1
+        prefix: /opt/rocm-6.1.1/
     rocm-debug-agent:
       buildable: false
       externals:
-      - spec: rocm-debug-agent@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: rocm-debug-agent@6.1.1
+        prefix: /opt/rocm-6.1.1/
     rocm-device-libs:
       buildable: false
       externals:
-      - spec: rocm-device-libs@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: rocm-device-libs@6.1.1
+        prefix: /opt/rocm-6.1.1/
     rocm-gdb:
       buildable: false
       externals:
-      - spec: rocm-gdb@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: rocm-gdb@6.1.1
+        prefix: /opt/rocm-6.1.1/
     rocm-opencl:
       buildable: false
       externals:
-      - spec: rocm-opencl@5.7.1
-        prefix: /opt/rocm-5.7.1/opencl
+      - spec: rocm-opencl@6.1.1
+        prefix: /opt/rocm-6.1.1/opencl
     rocm-smi-lib:
       buildable: false
       externals:
-      - spec: rocm-smi-lib@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: rocm-smi-lib@6.1.1
+        prefix: /opt/rocm-6.1.1/
     hip:
       buildable: false
       externals:
-      - spec: hip@5.7.1
-        prefix: /opt/rocm-5.7.1
+      - spec: hip@6.1.1
+        prefix: /opt/rocm-6.1.1
         extra_attributes:
           compilers:
-            c: /opt/rocm-5.7.1/llvm/bin/clang++
-            c++: /opt/rocm-5.7.1/llvm/bin/clang++
-            hip: /opt/rocm-5.7.1/hip/bin/hipcc
+            c: /opt/rocm-6.1.1/llvm/bin/clang++
+            c++: /opt/rocm-6.1.1/llvm/bin/clang++
+            hip: /opt/rocm-6.1.1/hip/bin/hipcc
     hipify-clang:
       buildable: false
       externals:
-      - spec: hipify-clang@5.7.1
-        prefix: /opt/rocm-5.7.1
+      - spec: hipify-clang@6.1.1
+        prefix: /opt/rocm-6.1.1
     llvm-amdgpu:
       buildable: false
       externals:
-      - spec: llvm-amdgpu@5.7.1
-        prefix: /opt/rocm-5.7.1/llvm
+      - spec: llvm-amdgpu@6.1.1
+        prefix: /opt/rocm-6.1.1/llvm
         extra_attributes:
           compilers:
-            c: /opt/rocm-5.7.1/llvm/bin/clang++
-            cxx: /opt/rocm-5.7.1/llvm/bin/clang++
+            c: /opt/rocm-6.1.1/llvm/bin/clang++
+            cxx: /opt/rocm-6.1.1/llvm/bin/clang++
     hsakmt-roct:
       buildable: false
       externals:
-      - spec: hsakmt-roct@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: hsakmt-roct@6.1.1
+        prefix: /opt/rocm-6.1.1/
     hsa-rocr-dev:
       buildable: false
       externals:
-      - spec: hsa-rocr-dev@5.7.1
-        prefix: /opt/rocm-5.7.1/
+      - spec: hsa-rocr-dev@6.1.1
+        prefix: /opt/rocm-6.1.1/
         extra_atributes:
           compilers:
-            c: /opt/rocm-5.7.1/llvm/bin/clang++
-            cxx: /opt/rocm-5.7.1/llvm/bin/clang++
+            c: /opt/rocm-6.1.1/llvm/bin/clang++
+            cxx: /opt/rocm-6.1.1/llvm/bin/clang++
     roctracer-dev-api:
       buildable: false
       externals:
-      - spec: roctracer-dev-api@5.7.1
-        prefix: /opt/rocm-5.7.1
+      - spec: roctracer-dev-api@6.1.1
+        prefix: /opt/rocm-6.1.1
     roctracer-dev:
       buildable: false
       externals:
       - spec: roctracer-dev@4.5.3
-        prefix: /opt/rocm-5.7.1
+        prefix: /opt/rocm-6.1.1
     rocprim:
       buildable: false
       externals:
-      - spec: rocprim@5.7.1
-        prefix: /opt/rocm-5.7.1
+      - spec: rocprim@6.1.1
+        prefix: /opt/rocm-6.1.1
     rocrand:
       buildable: false
       externals:
-      - spec: rocrand@5.7.1
-        prefix: /opt/rocm-5.7.1
+      - spec: rocrand@6.1.1
+        prefix: /opt/rocm-6.1.1
     hipsolver:
       buildable: false
       externals:
-      - spec: hipsolver@5.7.1
-        prefix: /opt/rocm-5.7.1
+      - spec: hipsolver@6.1.1
+        prefix: /opt/rocm-6.1.1
     rocsolver:
       buildable: false
       externals:
-      - spec: rocsolver@5.7.1
-        prefix: /opt/rocm-5.7.1
+      - spec: rocsolver@6.1.1
+        prefix: /opt/rocm-6.1.1
     rocsparse:
       buildable: false
       externals:
-      - spec: rocsparse@5.7.1
-        prefix: /opt/rocm-5.7.1
+      - spec: rocsparse@6.1.1
+        prefix: /opt/rocm-6.1.1
     rocthrust:
       buildable: false
       externals:
-      - spec: rocthrust@5.7.1
-        prefix: /opt/rocm-5.7.1
+      - spec: rocthrust@6.1.1
+        prefix: /opt/rocm-6.1.1
     rocprofiler-dev:
       buildable: false
       externals:
-      - spec: rocprofiler-dev@5.7.1
-        prefix: /opt/rocm-5.7.1
+      - spec: rocprofiler-dev@6.1.1
+        prefix: /opt/rocm-6.1.1
 
   specs:
   # ROCM NOARCH
@@ -295,7 +295,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ecpe4s/ubuntu22.04-runner-amd64-gcc-11.4-rocm5.7.1:2024.03.01
+        image: ecpe4s/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.1.1:2024.06.01
 
   cdash:
     build-group: E4S ROCm External

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -225,7 +225,6 @@ spack:
   - magma ~cuda +rocm amdgpu_target=gfx908
   - mfem +rocm amdgpu_target=gfx908
   - raja ~openmp +rocm amdgpu_target=gfx908
-  - slepc +rocm amdgpu_target=gfx908 ^petsc +rocm amdgpu_target=gfx908
   - strumpack ~slate +rocm amdgpu_target=gfx908
   - superlu-dist +rocm amdgpu_target=gfx908
   - tasmanian ~openmp +rocm amdgpu_target=gfx908
@@ -248,6 +247,7 @@ spack:
   # - papi +rocm amdgpu_target=gfx908           # papi: https://github.com/spack/spack/issues/27898
   # - petsc +rocm amdgpu_target=gfx908          # petsc: https://github.com/spack/spack/issues/44600
   # - slate +rocm amdgpu_target=gfx908          # slate: hip/device_gescale_row_col.hip.cc:58:49: error: use of overloaded operator '*' is ambiguous (with operand types 'HIP_vector_type<double, 2>' and 'const HIP_vector_type<double, 2>')
+  # - slepc +rocm amdgpu_target=gfx908 ^petsc +rocm amdgpu_target=gfx908   # - slepc +rocm amdgpu_target=gfx90a ^petsc +rocm amdgpu_target=gfx90a # petsc: https://github.com/spack/spack/issues/44600
   # - sundials +rocm amdgpu_target=gfx908       # sundials: https://github.com/spack/spack/issues/44601
 
   # ROCM 90a
@@ -267,7 +267,6 @@ spack:
   - magma ~cuda +rocm amdgpu_target=gfx90a
   - mfem +rocm amdgpu_target=gfx90a
   - raja ~openmp +rocm amdgpu_target=gfx90a
-  - slepc +rocm amdgpu_target=gfx90a ^petsc +rocm amdgpu_target=gfx90a
   - strumpack ~slate +rocm amdgpu_target=gfx90a
   - superlu-dist +rocm amdgpu_target=gfx90a
   - tasmanian ~openmp +rocm amdgpu_target=gfx90a
@@ -290,6 +289,7 @@ spack:
   # - papi +rocm amdgpu_target=gfx90a           # papi: https://github.com/spack/spack/issues/27898
   # - petsc +rocm amdgpu_target=gfx90a          # petsc: https://github.com/spack/spack/issues/44600
   # - slate +rocm amdgpu_target=gfx90a          # slate: hip/device_gescale_row_col.hip.cc:58:49: error: use of overloaded operator '*' is ambiguous (with operand types 'HIP_vector_type<double, 2>' and 'const HIP_vector_type<double, 2>')
+  # - slepc +rocm amdgpu_target=gfx90a ^petsc +rocm amdgpu_target=gfx90a # petsc: https://github.com/spack/spack/issues/44600  
   # - sundials +rocm amdgpu_target=gfx90a       # sundials: https://github.com/spack/spack/issues/44601
 
   ci:


### PR DESCRIPTION
E4S External ROCm CI: Use latest ROCm 6.1.1