### PR TITLE
py-numexpr: add v2.8.8, v2.9.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-numexpr/package.py
+++ b/var/spack/repos/builtin/packages/py-numexpr/package.py
@@ -14,6 +14,8 @@ class PyNumexpr(PythonPackage):
 
     license("MIT")
 
+    version("2.9.0", sha256="4df4163fcab20030137e8f2aa23e88e1e42e6fe702387cfd95d7675e1d84645e")
+    version("2.8.8", sha256="10b377c6ec6d9c01349d00e16dd82e6a6f4439c8c2b1945e490df1436c1825f5")
     version("2.8.4", sha256="0e21addd25db5f62d60d97e4380339d9c1fb2de72c88b070c279776ee6455d10")
     version("2.8.3", sha256="389ceefca74eff30ec3fd03fc4c3b7ab3df8f22d1f235117a392ce702ed208c0")
     version("2.7.3", sha256="00d6b1518605afe0ed10417e0ff07123e5d531c02496c6eed7dd4b9923238e1e")
@@ -26,6 +28,7 @@ class PyNumexpr(PythonPackage):
     version("2.4.6", sha256="2681faf55a3f19ba4424cc3d6f0a10610ebd49f029f8453f0ba64dd5c0fe4e0f")
 
     depends_on("python@3.7:", when="@2.8.3:", type=("build", "run"))
+    depends_on("python@3.9:", when="@2.8.7:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
 
     depends_on("py-numpy@1.13.3:", type=("build", "run"), when="@2.8.3:")


### PR DESCRIPTION
This PR adds py-numexpr v2.8.8 and v2.9.0.

(These are the last ones before 2.10.0 when apparently py-numpy@2 becomes a dependency. Not managed to make those work yet, and I currently need a working system so numpy-2 is not in the cards.)

Test build for 2.9.0:
```
==> Installing py-numexpr-2.9.0-4epueaxy3vessnfigavaamqpjxdzezta [31/31]
==> No binary for py-numexpr-2.9.0-4epueaxy3vessnfigavaamqpjxdzezta found: installing from source
==> Fetching https://github.com/pydata/numexpr/archive/v2.9.0.tar.gz
==> No patches needed for py-numexpr
==> py-numexpr: Executing phase: 'install'
==> py-numexpr: Successfully installed py-numexpr-2.9.0-4epueaxy3vessnfigavaamqpjxdzezta
  Stage: 1.67s.  Install: 22.54s.  Post-install: 0.21s.  Total: 25.70s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/py-numexpr-2.9.0-4epueaxy3vessnfigavaamqpjxdzezta
```