### PR TITLE
pass: new package

### DIFF
--- a/var/spack/repos/builtin/packages/pass/package.py
+++ b/var/spack/repos/builtin/packages/pass/package.py
@@ -6,13 +6,13 @@
 from spack.package import *
 
 
-class PasswordStore(MakefilePackage):
-    """the standard unix password manager"""
+class Pass(MakefilePackage):
+    """A minimal password manager following the UNIX philosphy."""
 
     homepage = "https://www.passwordstore.org/"
     url = "https://git.zx2c4.com/password-store/snapshot/password-store-1.7.4.tar.xz"
 
-    maintainers("taliaferro")
+    maintainers("alecbcs", "taliaferro")
 
     license("GPL-2.0", checked_by="taliaferro")
 

--- a/var/spack/repos/builtin/packages/pass/package.py
+++ b/var/spack/repos/builtin/packages/pass/package.py
@@ -36,10 +36,9 @@ class Pass(MakefilePackage):
         env.set("PREFIX", prefix)
         env.set(
             "BASHCOMPDIR",
-            self.spec["bash-completion"].prefix + "/share/bash-completion/completions",
+            self.prefix + "/share/bash-completion/completions",
         )
-        if self.spec.satisfies("+completion"):
-            env.set("WITH_BASHCOMP", "yes")
+        env.set("WITH_BASHCOMP", "yes")
 
     def edit(self, spec, prefix):
         """

--- a/var/spack/repos/builtin/packages/pass/package.py
+++ b/var/spack/repos/builtin/packages/pass/package.py
@@ -24,10 +24,7 @@ class Pass(MakefilePackage):
     depends_on("tree")
     depends_on("util-linux")  # for GNU getopt
     depends_on("libqrencode")
-    depends_on("openssl")  # not listed as a dependency, but used for base64
-
-    # documentation also lists dependencies on xclip, wl-clipboard, etc. but
-    # those are platform-dependent
+    depends_on("openssl")  # used for base64 only
 
     def setup_build_environment(self, env):
         env.set("PREFIX", prefix)

--- a/var/spack/repos/builtin/packages/pass/package.py
+++ b/var/spack/repos/builtin/packages/pass/package.py
@@ -28,7 +28,6 @@ class Pass(MakefilePackage):
 
     def setup_build_environment(self, env):
         env.set("PREFIX", prefix)
-        env.set("BASHCOMPDIR", self.prefix + "/share/bash-completion/completions")
         env.set("WITH_BASHCOMP", "yes")
 
     def edit(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/pass/package.py
+++ b/var/spack/repos/builtin/packages/pass/package.py
@@ -18,8 +18,6 @@ class Pass(MakefilePackage):
 
     version("1.7.4", sha256="cfa9faf659f2ed6b38e7a7c3fb43e177d00edbacc6265e6e32215ff40e3793c0")
 
-    variant("completion", default=True, description="install BASH completion scripts")
-
     depends_on("bash")
     depends_on("bash-completion", when="+completion")
     depends_on("gnupg")

--- a/var/spack/repos/builtin/packages/pass/package.py
+++ b/var/spack/repos/builtin/packages/pass/package.py
@@ -19,7 +19,7 @@ class Pass(MakefilePackage):
     version("1.7.4", sha256="cfa9faf659f2ed6b38e7a7c3fb43e177d00edbacc6265e6e32215ff40e3793c0")
 
     depends_on("bash")
-    depends_on("bash-completion", when="+completion")
+    depends_on("bash-completion")
     depends_on("gnupg")
     depends_on("git")
     depends_on("tree")

--- a/var/spack/repos/builtin/packages/pass/package.py
+++ b/var/spack/repos/builtin/packages/pass/package.py
@@ -32,10 +32,7 @@ class Pass(MakefilePackage):
 
     def setup_build_environment(self, env):
         env.set("PREFIX", prefix)
-        env.set(
-            "BASHCOMPDIR",
-            self.prefix + "/share/bash-completion/completions",
-        )
+        env.set("BASHCOMPDIR", self.prefix + "/share/bash-completion/completions")
         env.set("WITH_BASHCOMP", "yes")
 
     def edit(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/pass/package.py
+++ b/var/spack/repos/builtin/packages/pass/package.py
@@ -27,6 +27,7 @@ class Pass(MakefilePackage):
     depends_on("util-linux")  # for GNU getopt
     depends_on("libqrencode")
     depends_on("openssl")  # used for base64 only
+
     depends_on("xclip", when="+xclip")
 
     def setup_build_environment(self, env):
@@ -60,4 +61,3 @@ class Pass(MakefilePackage):
         platform_files.filter('^GPG="gpg"$', f'GPG="{gpg_exec}"')
         platform_files.filter('^GETOPT=".*"$', f'GETOPT="{getopt_exec}"')
         platform_files.filter('^BASE64=".*"$', f'BASE64="{openssl_exec} base64"')
-

--- a/var/spack/repos/builtin/packages/pass/package.py
+++ b/var/spack/repos/builtin/packages/pass/package.py
@@ -19,7 +19,6 @@ class Pass(MakefilePackage):
     version("1.7.4", sha256="cfa9faf659f2ed6b38e7a7c3fb43e177d00edbacc6265e6e32215ff40e3793c0")
 
     depends_on("bash")
-    depends_on("bash-completion")
     depends_on("gnupg")
     depends_on("git")
     depends_on("tree")

--- a/var/spack/repos/builtin/packages/pass/package.py
+++ b/var/spack/repos/builtin/packages/pass/package.py
@@ -18,6 +18,8 @@ class Pass(MakefilePackage):
 
     version("1.7.4", sha256="cfa9faf659f2ed6b38e7a7c3fb43e177d00edbacc6265e6e32215ff40e3793c0")
 
+    variant("xclip", default=False, description="install the X11 clipboard provider")
+
     depends_on("bash")
     depends_on("gnupg")
     depends_on("git")
@@ -25,6 +27,7 @@ class Pass(MakefilePackage):
     depends_on("util-linux")  # for GNU getopt
     depends_on("libqrencode")
     depends_on("openssl")  # used for base64 only
+    depends_on("xclip", when="+xclip")
 
     def setup_build_environment(self, env):
         env.set("PREFIX", prefix)
@@ -57,3 +60,4 @@ class Pass(MakefilePackage):
         platform_files.filter('^GPG="gpg"$', f'GPG="{gpg_exec}"')
         platform_files.filter('^GETOPT=".*"$', f'GETOPT="{getopt_exec}"')
         platform_files.filter('^BASE64=".*"$', f'BASE64="{openssl_exec} base64"')
+

--- a/var/spack/repos/builtin/packages/pass/package.py
+++ b/var/spack/repos/builtin/packages/pass/package.py
@@ -45,10 +45,10 @@ class Pass(MakefilePackage):
         it looks for getopt in /opt/homebrew.) We can hardcode those paths here.
         """
 
-        bash_exec = self.spec["bash"].prefix + "/bin/bash"
-        gpg_exec = self.spec["gnupg"].prefix + "/bin/gpg"
-        getopt_exec = self.spec["util-linux"].prefix + "/bin/getopt"
-        base64_exec = self.spec["openssl"].prefix + "/bin/openssl base64"
+        bash_exec = self.spec["bash"].command
+        gpg_exec = self.spec["gnupg"].prefix.bin.gpg
+        getopt_exec = self.spec["util-linux"].prefix.bin.getopt
+        openssl_exec = self.spec["openssl"].command
 
         platform_files = FileFilter(
             "src/password-store.sh",
@@ -61,4 +61,4 @@ class Pass(MakefilePackage):
         platform_files.filter("^#!.*$", f"#! {bash_exec}")
         platform_files.filter('^GPG="gpg"$', f'GPG="{gpg_exec}"')
         platform_files.filter('^GETOPT=".*"$', f'GETOPT="{getopt_exec}"')
-        platform_files.filter('^BASE64=".*"$', f'BASE64="{base64_exec}"')
+        platform_files.filter('^BASE64=".*"$', f'BASE64="{openssl_exec} base64"')

--- a/var/spack/repos/builtin/packages/password-store/package.py
+++ b/var/spack/repos/builtin/packages/password-store/package.py
@@ -1,0 +1,60 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PasswordStore(MakefilePackage):
+    """the standard unix password manager"""
+
+    homepage = "https://www.passwordstore.org/"
+    url = "https://git.zx2c4.com/password-store/snapshot/password-store-1.7.4.tar.xz"
+
+    maintainers("taliaferro")
+
+    license("GPL-2.0", checked_by="taliaferro")
+
+    version("1.7.4", sha256="cfa9faf659f2ed6b38e7a7c3fb43e177d00edbacc6265e6e32215ff40e3793c0")
+
+    depends_on("bash")
+    depends_on("gnupg")
+    depends_on("git")
+    depends_on("tree")
+    depends_on("util-linux")  # for GNU getopt
+    depends_on("libqrencode")
+    depends_on("openssl")  # not listed as a dependency, but used for base64
+
+    # documentation also lists dependencies on xclip, wl-clipboard, etc. but
+    # those are platform-dependent
+
+    def setup_build_environment(self, env):
+        env.set("PREFIX", prefix)
+
+    def edit(self, spec, prefix):
+        """
+        Pass's install process involves slotting in a small script snippet at
+        the start of the file, defining certain platform-specific behaviors
+        including the paths where some of its key dependencies are likely to
+        be found. Most of this logic still works when installed with Spack,
+        but the paths to the dependencies are wrong (for example, on MacOS
+        it looks for getopt in /opt/homebrew.) We can hardcode those paths here.
+        """
+
+        bash_exec = self.spec["bash"].prefix + "/bin/bash"
+        gpg_exec = self.spec["gnupg"].prefix + "/bin/gpg"
+        getopt_exec = self.spec["util-linux"].prefix + "/bin/getopt"
+        base64_exec = self.spec["openssl"].prefix + "/bin/openssl base64"
+
+        platform_files = FileFilter(
+            "src/password-store.sh",
+            "src/platform/darwin.sh",
+            "src/platform/freebsd.sh",
+            "src/platform/openbsd.sh",
+        )
+
+        platform_files.filter("^#!.*$", f"#! {bash_exec}")
+        platform_files.filter('^GPG="gpg"$', f'GPG="{gpg_exec}"')
+        platform_files.filter('^GETOPT=".*"$', f'GETOPT="{getopt_exec}"')
+        platform_files.filter('^BASE64=".*"$', f'BASE64="{base64_exec}"')

--- a/var/spack/repos/builtin/packages/password-store/package.py
+++ b/var/spack/repos/builtin/packages/password-store/package.py
@@ -18,7 +18,10 @@ class PasswordStore(MakefilePackage):
 
     version("1.7.4", sha256="cfa9faf659f2ed6b38e7a7c3fb43e177d00edbacc6265e6e32215ff40e3793c0")
 
+    variant("completion", default=True, description="install BASH completion scripts")
+
     depends_on("bash")
+    depends_on("bash-completion", when="+completion")
     depends_on("gnupg")
     depends_on("git")
     depends_on("tree")
@@ -31,6 +34,12 @@ class PasswordStore(MakefilePackage):
 
     def setup_build_environment(self, env):
         env.set("PREFIX", prefix)
+        env.set(
+            "BASHCOMPDIR",
+            self.spec["bash-completion"].prefix + "/share/bash-completion/completions",
+        )
+        if self.spec.satisfies("+completion"):
+            env.set("WITH_BASHCOMP", "yes")
 
     def edit(self, spec, prefix):
         """

--- a/var/spack/repos/builtin/packages/password-store/package.py
+++ b/var/spack/repos/builtin/packages/password-store/package.py
@@ -61,6 +61,7 @@ class PasswordStore(MakefilePackage):
             "src/platform/darwin.sh",
             "src/platform/freebsd.sh",
             "src/platform/openbsd.sh",
+            "src/platform/cygwin.sh",
         )
 
         platform_files.filter("^#!.*$", f"#! {bash_exec}")


### PR DESCRIPTION
Jason Donenfeld's `pass` script aspires to be the standard Unix password manager. It's written in bash and encrypts passwords using GPG.

Some things to note about this package:
- It depends on `util-linux`, but only for GNU getopt. If the individual tools in util-linux were broken out, or getopt was made available separately based on [the upstream source](https://frodo.looijaard.name/project/getopt) it might take a bit less time to install.
- Although it's not mentioned in the documentation, the script also depends on openssl -- but only for the `openssl base64` subcommand.
- The install mechanism for the script slots in a snippet from `src/platform/$(uname | tr "A-Z" "a-z").sh` to cover any platform-specific behaviors; this package patches all of those to hardcode the paths to dependencies like `gpg`.