### PR TITLE
derived from openmpi; set correct compilers based on dependent spec

### DIFF
--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -54,6 +54,12 @@ class FujitsuMpi(Package):
             self.spec.mpifc = self.prefix.bin.mpifrt
 
     def setup_dependent_build_environment(self, env, dependent_spec):
+        # Use the spack compiler wrappers under MPI
+        dependent_module = dependent_spec.package.module
+        env.set("OMPI_CC", dependent_module.spack_cc)
+        env.set("OMPI_CXX", dependent_module.spack_cxx)
+        env.set("OMPI_FC", dependent_module.spack_fc)
+        env.set("OMPI_F77", dependent_module.spack_f77)
         if self.spec.satisfies("%gcc"):
             env.set("MPI_C_COMPILER", self.prefix.bin.mpicc)
             env.set("MPI_CXX_COMPILER", self.prefix.bin.mpicxx)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
