### PR TITLE
Updated apptainer to support version 1.2.5

### DIFF
--- a/var/spack/repos/builtin/packages/apptainer/package.py
+++ b/var/spack/repos/builtin/packages/apptainer/package.py
@@ -33,6 +33,7 @@ class Apptainer(SingularityBase):
     )
 
     version("main", branch="main")
+    version("1.2.5", sha256="606b67ef97683e1420401718687d258b1034fdf2edae72eeacd0828dffbfc2c2")
     version("1.1.9", sha256="c615777539154288542cf393d3fd44c04ccb3260bc6330dc324d4e4ebe902bfa")
     version("1.1.7", sha256="e6d3956a26c3965703402e17f153ba07f59bf710068806462b314d2d04e825e7")
     version("1.1.6", sha256="5f32d305279a51ce8bdbe69e733c4ac12b1efdcb77758fab8ec9463e96a8fd82")


### PR DESCRIPTION
Updated to 1.2.5, the last release of 1.2. There may be [issues](https://github.com/apptainer/apptainer/issues/2202#issuecomment-2104875476) with versions 1.3. I could not get this to work out of the box without tweaks, e.g. by running with `--unsquash`.