### PR TITLE
making suite-sparse library path generic in hipsolver

### DIFF
--- a/var/spack/repos/builtin/packages/hipsolver/0001-suite-sparse-include-path-6.1.1.patch
+++ b/var/spack/repos/builtin/packages/hipsolver/0001-suite-sparse-include-path-6.1.1.patch
@@ -1,7 +1,7 @@
-From 4bea73ab74deb313030a1abb135fd668f7f5b96a Mon Sep 17 00:00:00 2001
-From: sreenivasa murthy kolam <sreenivasamurthy.kolam@amd.com>
-Date: Tue, 21 May 2024 06:52:30 +0000
-Subject: [PATCH] add SUITE_SPARSE_PATH to the CMakeLists.txt
+From 329ee96fa7004c6fb0a8f93375e9081ef717fbab Mon Sep 17 00:00:00 2001
+From: Renjith Ravindran <Renjith.RavindranKannath@amd.com>
+Date: Fri, 31 May 2024 19:51:49 +0000
+Subject: [PATCH] suite-sparse include and library path 6.1.1
 
 ---
  CMakeLists.txt             | 1 +
@@ -21,7 +21,7 @@ index 52a059a..fddda0b 100644
  set ( VERSION_STRING "2.1.1" )
  rocm_setup_version( VERSION ${VERSION_STRING} )
 diff --git a/library/src/CMakeLists.txt b/library/src/CMakeLists.txt
-index ec708df..224e5a5 100644
+index ec708df..7b0e414 100644
 --- a/library/src/CMakeLists.txt
 +++ b/library/src/CMakeLists.txt
 @@ -135,7 +135,7 @@ if( NOT USE_CUDA )
@@ -29,10 +29,10 @@ index ec708df..224e5a5 100644
      endif( )
  
 -    target_link_libraries( hipsolver PRIVATE roc::rocsparse suitesparseconfig cholmod )
-+    target_link_libraries( hipsolver PRIVATE roc::rocsparse ${SUITE_SPARSE_PATH}/lib64/libsuitesparseconfig.so ${SUITE_SPARSE_PATH}/lib64/libcholmod.so )
++    target_link_libraries( hipsolver PRIVATE roc::rocsparse ${SUITE_SPARSE_LIBDIR}/libsuitesparseconfig.so ${SUITE_SPARSE_LIBDIR}/libcholmod.so )
      set_source_files_properties(${hipsolver_source}
        PROPERTIES
          COMPILE_DEFINITIONS HAVE_ROCSPARSE
 -- 
-2.39.3
+2.17.1
 

--- a/var/spack/repos/builtin/packages/hipsolver/001-suite-sparse-include-path.patch
+++ b/var/spack/repos/builtin/packages/hipsolver/001-suite-sparse-include-path.patch
@@ -1,7 +1,7 @@
-From 3e3a183267ccdb6b239e8d62d79b1671fdfa58f5 Mon Sep 17 00:00:00 2001
+From 90c1913a29f6ee097aea18a66deb0a4fb0bc0066 Mon Sep 17 00:00:00 2001
 From: Renjith Ravindran <Renjith.RavindranKannath@amd.com>
-Date: Wed, 29 May 2024 15:34:41 +0000
-Subject: [PATCH] suite-sparse include and library path
+Date: Sat, 8 Jun 2024 00:46:22 +0000
+Subject: [PATCH] add SUITE_SPARSE_PATH to the CMakeLists.txt
 
 ---
  CMakeLists.txt             | 1 +
@@ -9,19 +9,19 @@ Subject: [PATCH] suite-sparse include and library path
  2 files changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 95a2393..5dd88bb 100644
+index 95a2393..b403f57 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -88,6 +88,7 @@ include( ROCMPackageConfigHelpers )
  include( ROCMInstallSymlinks )
  include( ROCMClients )
  include( ROCMHeaderWrapper )
-+include_directories(${SUITE_SPARSE_PATH}/include)
++include_directories(${SUITE_SPARSE_PATH}/include/suitesparse)
  
  set ( VERSION_STRING "2.1.0" )
  rocm_setup_version( VERSION ${VERSION_STRING} )
 diff --git a/library/src/CMakeLists.txt b/library/src/CMakeLists.txt
-index ab448f4..9d57765 100644
+index ab448f4..f3d759e 100644
 --- a/library/src/CMakeLists.txt
 +++ b/library/src/CMakeLists.txt
 @@ -135,7 +135,7 @@ if( NOT USE_CUDA )
@@ -29,10 +29,10 @@ index ab448f4..9d57765 100644
      endif( )
  
 -    target_link_libraries( hipsolver PRIVATE roc::rocsparse suitesparseconfig cholmod )
-+    target_link_libraries( hipsolver PRIVATE roc::rocsparse ${SUITE_SPARSE_LIB_PATH}/libsuitesparseconfig.so ${SUITE_SPARSE_LIB_PATH}/libcholmod.so )
++    target_link_libraries( hipsolver PRIVATE roc::rocsparse ${SUITE_SPARSE_LIBDIR}/libsuitesparseconfig.so ${SUITE_SPARSE_LIBDIR}/libcholmod.so )
      target_include_directories( hipsolver
        SYSTEM PRIVATE
        $<BUILD_INTERFACE:/usr/include/suitesparse/>
 -- 
-2.17.1
+2.27.0
 

--- a/var/spack/repos/builtin/packages/hipsolver/001-suite-sparse-include-path.patch
+++ b/var/spack/repos/builtin/packages/hipsolver/001-suite-sparse-include-path.patch
@@ -1,6 +1,6 @@
-From 9adfbf77cff336a0fa01b15e74e4c812302698e8 Mon Sep 17 00:00:00 2001
+From 3e3a183267ccdb6b239e8d62d79b1671fdfa58f5 Mon Sep 17 00:00:00 2001
 From: Renjith Ravindran <Renjith.RavindranKannath@amd.com>
-Date: Mon, 6 May 2024 18:39:02 +0000
+Date: Wed, 29 May 2024 15:34:41 +0000
 Subject: [PATCH] suite-sparse include and library path
 
 ---
@@ -21,7 +21,7 @@ index 95a2393..5dd88bb 100644
  set ( VERSION_STRING "2.1.0" )
  rocm_setup_version( VERSION ${VERSION_STRING} )
 diff --git a/library/src/CMakeLists.txt b/library/src/CMakeLists.txt
-index ab448f4..a0f877d 100644
+index ab448f4..9d57765 100644
 --- a/library/src/CMakeLists.txt
 +++ b/library/src/CMakeLists.txt
 @@ -135,7 +135,7 @@ if( NOT USE_CUDA )
@@ -29,10 +29,10 @@ index ab448f4..a0f877d 100644
      endif( )
  
 -    target_link_libraries( hipsolver PRIVATE roc::rocsparse suitesparseconfig cholmod )
-+    target_link_libraries( hipsolver PRIVATE roc::rocsparse ${SUITE_SPARSE_PATH}/lib64/libsuitesparseconfig.so ${SUITE_SPARSE_PATH}/lib64/libcholmod.so )
++    target_link_libraries( hipsolver PRIVATE roc::rocsparse ${SUITE_SPARSE_LIB_PATH}/libsuitesparseconfig.so ${SUITE_SPARSE_LIB_PATH}/libcholmod.so )
      target_include_directories( hipsolver
        SYSTEM PRIVATE
        $<BUILD_INTERFACE:/usr/include/suitesparse/>
 -- 
-2.31.1
+2.17.1
 

--- a/var/spack/repos/builtin/packages/hipsolver/package.py
+++ b/var/spack/repos/builtin/packages/hipsolver/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 import re
 
 from spack.package import *

--- a/var/spack/repos/builtin/packages/hipsolver/package.py
+++ b/var/spack/repos/builtin/packages/hipsolver/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-
 import re
 
 from spack.package import *

--- a/var/spack/repos/builtin/packages/hipsolver/package.py
+++ b/var/spack/repos/builtin/packages/hipsolver/package.py
@@ -117,7 +117,6 @@ class Hipsolver(CMakePackage, CudaPackage, ROCmPackage):
     patch("001-suite-sparse-include-path.patch", when="@6.1.0")
     patch("0001-suite-sparse-include-path-6.1.1.patch", when="@6.1.1:")
 
-
     def check(self):
         exe = join_path(self.build_directory, "clients", "staging", "hipsolver-test")
         self.run_test(exe, options=["--gtest_filter=-*known_bug*"])

--- a/var/spack/repos/builtin/packages/hipsolver/package.py
+++ b/var/spack/repos/builtin/packages/hipsolver/package.py
@@ -117,14 +117,6 @@ class Hipsolver(CMakePackage, CudaPackage, ROCmPackage):
     patch("001-suite-sparse-include-path.patch", when="@6.1.0")
     patch("0001-suite-sparse-include-path-6.1.1.patch", when="@6.1.1:")
 
-    def patch(self):
-        if self.spec.satisfies("@6.1.1 +rocm"):
-            with working_dir("library/src/amd_detail"):
-                filter_file(
-                    "^#include <suitesparse/cholmod.h>",
-                    "#include <cholmod.h>",
-                    "hipsolver_sparse.cpp",
-                )
 
     def check(self):
         exe = join_path(self.build_directory, "clients", "staging", "hipsolver-test")
@@ -168,5 +160,8 @@ class Hipsolver(CMakePackage, CudaPackage, ROCmPackage):
             args.append(self.define("BUILD_FILE_REORG_BACKWARD_COMPATIBILITY", True))
         if self.spec.satisfies("@5.3.0:"):
             args.append(self.define("CMAKE_INSTALL_LIBDIR", "lib"))
-
+        libloc = self.spec["suite-sparse"].prefix.lib64
+        if not os.path.isdir(libloc):
+            libloc = self.spec["suite-sparse"].prefix.lib
+        args.append(self.define("SUITE_SPARSE_LIBDIR", libloc))
         return args


### PR DESCRIPTION
suite-sparse library path can be lib or lib64. 
Updating patch with generic parameter ${SUITE_SPARSE_LIBDIR} instead of ${SUITE_SPARSE_PATH}/lib64
and setting SUITE_SPARSE_LIBDIR based on the available library directory.