### PR TITLE
feat: concretizer: prefer_older to force oldest dependency optimization

### DIFF
--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -44,6 +44,7 @@ properties: Dict[str, Any] = {
                     },
                 ]
             },
+            "prefer_older": {"type": "boolean"},
             "enable_node_namespace": {"type": "boolean"},
             "targets": {
                 "type": "object",

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1026,7 +1026,6 @@ class SpackSolverSetup:
     """Class to set up and run a Spack concretization solve."""
 
     def __init__(self, tests: bool = False, prefer_older=False):
-        
         # these are all initialized in setup()
         self.gen: "ProblemInstanceBuilder" = ProblemInstanceBuilder()
         self.possible_virtuals: Set[str] = set()
@@ -1094,7 +1093,9 @@ class SpackSolverSetup:
                 list(sorted(group, reverse=True, key=lambda x: vn.ver(x.version)))
             )
 
-        for weight, declared_version in enumerate(reversed(most_to_least_preferred) if self.prefer_older else most_to_least_preferred):
+        for weight, declared_version in enumerate(
+            reversed(most_to_least_preferred) if self.prefer_older else most_to_least_preferred
+        ):
             self.gen.fact(
                 fn.pkg_fact(
                     pkg.name,


### PR DESCRIPTION
This PR is a bit of testing infrastructure to force concretization of environments with dependencies as old as allowed. It is intended to probe dependency lower limits.

Example:
```yaml
spack:
  specs:
  - zlib
  concretizer:
    prefer_older: true
    unify: true
```
results in
```console
# spack concretize --fresh --force
==> Concretized zlib
 -   nhn5bv4  zlib@1.2.13%gcc@11.4.0+optimize+pic+shared build_system=makefile arch=linux-ubuntu20.04-x86_64_v3
[+]  2mu665n      ^gcc-runtime@11.4.0%gcc@11.4.0 build_system=generic arch=linux-ubuntu20.04-x86_64_v3
[e]  ifnzkwq      ^glibc@2.31%gcc@11.4.0 build_system=autotools arch=linux-ubuntu20.04-x86_64_v3
 -   cspzls2      ^gmake@4.2.1%gcc@11.4.0~guile build_system=generic patches=ca60bd9,fe5b60d arch=linux-ubuntu20.04-x86_64_v3
```
(most recent version of gmake is 4.4.1).

This then fails to build because gmake-4.2.1 fails to build... (https://github.com/spack/spack/issues/41979)

---

Note: this is a hack, and mainly intended to have a branch with this feature for others to use. If this is to become a more scalable solution, it may make more sense to provide a way to define sets of ASP concretizer weights. That way, a set for this functionality could actually just prefer older versions (instead of turning the entire priority upside down, which does more than that).