### PR TITLE
OpenFOAM-org: Add missing dependency on readline

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -103,6 +103,8 @@ class OpenfoamOrg(Package):
     depends_on("zlib-api")
     depends_on("flex")
     depends_on("cmake", type="build")
+    # The setSet tool (removed in version 10) depends on readline
+    depends_on("readline", when="@:9")
 
     # Require scotch with ptscotch - corresponds to standard OpenFOAM setup
     depends_on("scotch~metis+mpi~int64", when="+scotch~int64")


### PR DESCRIPTION
The setSet tool (removed in version 10) has an optional dependency on readline. The build script will use the system readline if not provided by Spack.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
