### PR TITLE
OpenFOAM: Add missing dependency on readline

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -376,6 +376,8 @@ class Openfoam(Package):
     depends_on("flex@:2.6.1,2.6.4:")
     depends_on("cmake", type="build")
     depends_on("m4", type="build")
+    # The setSet tool depends on readline
+    depends_on("readline")
 
     # Require scotch with ptscotch - corresponds to standard OpenFOAM setup
     depends_on("scotch~metis+mpi~int64", when="+scotch~int64")


### PR DESCRIPTION
The setSet tool has an optional dependency on readline. The build script will use the system readline if not provided by Spack.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
