### PR TITLE
gmake: fix `build.sh` location for 4.2.1

### DIFF
--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -75,9 +75,14 @@ class Gmake(Package, GNUMirrorPackage):
 
     def install(self, spec, prefix):
         configure = Executable(join_path(self.stage.source_path, "configure"))
-        build_sh = Executable(join_path(self.stage.source_path, "build.sh"))
         with working_dir(self.build_directory, create=True):
             configure(f"--prefix={prefix}", *self.configure_args())
+            if spec.satisfies("@:4.2.1"):
+                # older configure creates build.sh in current directory
+                build_sh = Executable(join_path(".", "build.sh"))
+            else:
+                # newer configure creates build.sh in source directory
+                build_sh = Executable(join_path(self.stage.source_path, "build.sh"))
             build_sh()
             os.mkdir(prefix.bin)
             install("make", prefix.bin)

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -81,7 +81,7 @@ class Gmake(Package, GNUMirrorPackage):
                 # older configure creates build.sh in current directory
                 build_sh = Executable(join_path(".", "build.sh"))
             else:
-                # newer configure creates build.sh in source directory
+                # newer configure uses build.sh in source directory
                 build_sh = Executable(join_path(self.stage.source_path, "build.sh"))
             build_sh()
             os.mkdir(prefix.bin)


### PR DESCRIPTION
Until gmake-4.2.1, `configure` creates the `build.sh` script in the current directory.

As of gmake-4.3, `configure` creates `build.cfg` in the current directory and a fixed `build.sh` scripts in the source directory reads the config.

When we started building gmake in a dedicated `spack-build` directory instead of the source path (introduced in f576b4b6c59), this broke the older versions.

This PR fixes #41979.

Verified that this builds fine for 4.2.1. For 4.0 there is a different problem during the actual build (it doesn't find `libguile.h`) but at least it gets past the point where it failed before.