### PR TITLE
(py-)onnx: add v1.16.1

### DIFF
--- a/var/spack/repos/builtin/packages/onnx/package.py
+++ b/var/spack/repos/builtin/packages/onnx/package.py
@@ -20,6 +20,7 @@ class Onnx(CMakePackage):
     license("Apache-2.0")
 
     version("master", branch="master")
+    version("1.16.1", sha256="0e6aa2c0a59bb2d90858ad0040ea1807117cc2f05b97702170f18e6cd6b66fb3")
     version("1.16.0", sha256="0ce153e26ce2c00afca01c331a447d86fbf21b166b640551fe04258b4acfc6a4")
     version("1.15.0", sha256="c757132e018dd0dd171499ef74fca88b74c5430a20781ec53da19eb7f937ef68")
     version("1.14.1", sha256="e296f8867951fa6e71417a18f2e550a730550f8829bd35e947b4df5e3e777aa1")

--- a/var/spack/repos/builtin/packages/py-onnx/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx/package.py
@@ -21,6 +21,7 @@ class PyOnnx(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.16.1", sha256="8299193f0f2a3849bfc069641aa8e4f93696602da8d165632af8ee48ec7556b6")
     version("1.16.0", sha256="237c6987c6c59d9f44b6136f5819af79574f8d96a760a1fa843bede11f3822f7")
     version("1.15.0", sha256="b18461a7d38f286618ca2a6e78062a2a9c634ce498e631e708a8041b00094825")
     version("1.14.1", sha256="70903afe163643bd71195c78cedcc3f4fa05a2af651fd950ef3acbb15175b2d1")


### PR DESCRIPTION
This PR adds onnx and py-onnx 1.16.1. This is a bugfix releases, https://github.com/onnx/onnx/compare/v1.16.0...v1.16.1, https://github.com/onnx/onnx/pull/6108.

Of potential interest, this version fixes running after gcc-8, but we haven't been keeping compiler conflicts in this package so I didn't add it to 1.16.0.