### PR TITLE
damask: add v3.0.0-beta2

### DIFF
--- a/var/spack/repos/builtin/packages/damask-grid/package.py
+++ b/var/spack/repos/builtin/packages/damask-grid/package.py
@@ -18,6 +18,9 @@ class DamaskGrid(CMakePackage):
     license("AGPL-3.0-or-later")
 
     version(
+        "3.0.0-beta2", sha256="513567b4643f39e27ae32b9f75463fc6f388c1548d42f0393cc87ba02d075f6a"
+    )
+    version(
         "3.0.0-beta", sha256="1e25e409ac559fc437d1887c6ca930677a732db89a3a32499d545dd75e93925c"
     )
     version(
@@ -36,8 +39,9 @@ class DamaskGrid(CMakePackage):
         "3.0.0-alpha4", sha256="0bb8bde43b27d852b1fb6e359a7157354544557ad83d87987b03f5d629ce5493"
     )
 
-    depends_on("petsc@3.20.3:3.21", when="@3.0.0-beta")
-    depends_on("petsc@3.20.2:3.21", when="@3.0.0-alpha8")
+    depends_on("petsc@3.21", when="@3.0.0-beta2")
+    depends_on("petsc@3.20.3:3.20", when="@3.0.0-beta")
+    depends_on("petsc@3.20.2:3.20", when="@3.0.0-alpha8")
     depends_on("petsc@3.17.1:3.18", when="@3.0.0-alpha7")
     depends_on("petsc@3.16.5:3.16", when="@3.0.0-alpha6")
     depends_on("petsc@3.14.0:3.14,3.15.1:3.16", when="@3.0.0-alpha5")

--- a/var/spack/repos/builtin/packages/damask-mesh/package.py
+++ b/var/spack/repos/builtin/packages/damask-mesh/package.py
@@ -18,6 +18,9 @@ class DamaskMesh(CMakePackage):
     license("AGPL-3.0-or-later")
 
     version(
+        "3.0.0-beta2", sha256="513567b4643f39e27ae32b9f75463fc6f388c1548d42f0393cc87ba02d075f6a"
+    )
+    version(
         "3.0.0-beta", sha256="1e25e409ac559fc437d1887c6ca930677a732db89a3a32499d545dd75e93925c"
     )
     version(
@@ -36,8 +39,9 @@ class DamaskMesh(CMakePackage):
         "3.0.0-alpha4", sha256="0bb8bde43b27d852b1fb6e359a7157354544557ad83d87987b03f5d629ce5493"
     )
 
-    depends_on("petsc@3.20.3:3.21", when="@3.0.0-beta")
-    depends_on("petsc@3.20.2:3.21", when="@3.0.0-alpha8")
+    depends_on("petsc@3.21", when="@3.0.0-beta2")
+    depends_on("petsc@3.20.3:3.20", when="@3.0.0-beta")
+    depends_on("petsc@3.20.2:3.20", when="@3.0.0-alpha8")
     depends_on("petsc@3.17.1:3.18", when="@3.0.0-alpha7")
     depends_on("petsc@3.16.5:3.16", when="@3.0.0-alpha6")
     depends_on("petsc@3.14.0:3.14,3.15.1:3.16", when="@3.0.0-alpha5")

--- a/var/spack/repos/builtin/packages/damask/package.py
+++ b/var/spack/repos/builtin/packages/damask/package.py
@@ -28,12 +28,17 @@ class Damask(BundlePackage):
 
     maintainers("MarDiehl")
 
+    version("3.0.0-beta2")
     version("3.0.0-beta")
     version("3.0.0-alpha8")
     version("3.0.0-alpha7")
     version("3.0.0-alpha6")
     version("3.0.0-alpha5")
     version("3.0.0-alpha4")
+
+    depends_on("damask-grid@3.0.0-beta2", when="@3.0.0-beta2", type="run")
+    depends_on("damask-mesh@3.0.0-beta2", when="@3.0.0-beta2", type="run")
+    depends_on("py-damask@3.0.0-beta2", when="@3.0.0-beta2", type="run")
 
     depends_on("damask-grid@3.0.0-beta", when="@3.0.0-beta", type="run")
     depends_on("damask-mesh@3.0.0-beta", when="@3.0.0-beta", type="run")

--- a/var/spack/repos/builtin/packages/py-damask/package.py
+++ b/var/spack/repos/builtin/packages/py-damask/package.py
@@ -18,6 +18,9 @@ class PyDamask(PythonPackage):
     license("AGPL-3.0-or-later")
 
     version(
+        "3.0.0-beta2", sha256="513567b4643f39e27ae32b9f75463fc6f388c1548d42f0393cc87ba02d075f6a"
+    )
+    version(
         "3.0.0-beta", sha256="1e25e409ac559fc437d1887c6ca930677a732db89a3a32499d545dd75e93925c"
     )
     version(


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
update damask, py-damask, damask-grid, and damask-mesh to v3.0.0-beta2. Fixed version constraints for v3.0.0-beta, PETSc 3.21.x does not work.