### PR TITLE
py-pyfr: Add v2.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-gimmik/package.py
+++ b/var/spack/repos/builtin/packages/py-gimmik/package.py
@@ -19,6 +19,7 @@ class PyGimmik(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.2.1", sha256="048644bd71497eb07e144f2c22fdee49ba23e1cde5fb954c3c30c4e3ea23687a")
     version("3.0", sha256="45c2da7acff3201b7796ba731e4be7f3b4f39469ff1f1bc0ddf4f19c4a6af010")
     version("2.3", sha256="c019c85316bcf0d5e84de9b7d10127355dfe8037c0e37f1880a9819ce92b74e1")
     version("2.2", sha256="9144640f94aab92f9c5dfcaf16885a79428ab97337cf503a4b2dddeb870f3cf0")

--- a/var/spack/repos/builtin/packages/py-pyfr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfr/package.py
@@ -24,46 +24,55 @@ class PyPyfr(PythonPackage, CudaPackage, ROCmPackage):
     version("master", branch="master")
 
     # pypi releases
+    version(
+        "2.0.2",
+        sha256="2c6bf460ffec446a933451792c09d3cd85d6703f14636d99810d61823b8d92c7",
+        preferred=True,
+    )
     version("1.15.0", sha256="6a634b9d32447f45d3c24c9de0ed620a0a0a781be7cc5e57b1c1bf44a4650d8d")
     version("1.14.0", sha256="ebf40ce0896cce9ac802e03fd9430b5be30ea837c31224531a6d5fd68f820766")
     version("1.13.0", sha256="ac6ecec738d4e23799ab8c50dea9bdbd7d37bc971bd33f22720c5a230b8e7b2f")
 
-    variant("metis", default=True, description="Metis for mesh partitioning")
-    variant("scotch", default=False, description="Scotch for mesh partitioning")
+    variant("metis", default=False, when="@:1.15.0", description="Metis for mesh partitioning")
+    variant("scotch", default=True, description="Scotch for mesh partitioning")
     variant("cuda", default=False, description="CUDA backend support")
     variant("hip", default=False, description="HIP backend support")
     variant("libxsmm", default=True, description="LIBXSMM for OpenMP backend")
-    variant("scipy", default=True, description="Scipy acceleration for point sampling")
 
     # Required dependencies
-    depends_on("python@3.9:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
+    depends_on("python@3.9:", when="@:1.15.0", type=("build", "run"))
+    depends_on("python@3.10:", when="@2.0.2:", type=("build", "run"))
+    depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-gimmik@2.3:2", when="@:1.14.0", type=("build", "run"))
-    depends_on("py-gimmik@3", when="@1.15.0:", type=("build", "run"))
+    depends_on("py-gimmik@3", when="@1.15.0", type=("build", "run"))
+    depends_on("py-gimmik@3.2.1:", when="@2.0.2:", type=("build", "run"))
     depends_on("py-h5py@2.10:", type=("build", "run"))
     depends_on("py-mako@1.0.0:", type=("build", "run"))
     depends_on("py-mpi4py@3.1.0:", type=("build", "run"))
-    depends_on("py-numpy@1.20:", type=("build", "run"))
+    depends_on("py-numpy@1.20:", when="@:1.15.0", type=("build", "run"))
+    depends_on("py-numpy@1.26.4:", when="@2.0.2:", type=("build", "run"))
     depends_on("py-platformdirs@2.2.0:", type=("build", "run"))
     depends_on("py-pytools@2016.2.1:", type=("build", "run"))
+    depends_on("py-rtree@1.0.1:", when="@2.0.2:", type=("build", "run"))
 
     # Optional dependencies
-    depends_on("py-scipy", when="+scipy", type=("build", "run"))
-    depends_on("metis@5.0:", when="+metis", type=("run"))
+    depends_on("metis@5.0.0:5.1.0", when="@:1.15.0 +metis", type=("run"))
     depends_on("scotch@7.0.1: +link_error_lib", when="+scotch", type=("run"))
     depends_on("cuda@8.0: +allow-unsupported-compilers", when="@:1.14.0 +cuda", type=("run"))
     depends_on("cuda@11.4.0: +allow-unsupported-compilers", when="@1.15.0: +cuda", type=("run"))
-    depends_on("rocblas@5.2.0:", when="+hip", type=("run"))
+    depends_on("rocblas@5.2.0:", when="@:1.15.0 +hip", type=("run"))
+    depends_on("rocblas@6.0.0:", when="@2.0.2: +hip", type=("run"))
     depends_on("libxsmm@1.18:+shared blas=0", when="+libxsmm", type=("run"))
 
-    # Conflicts for compilers not supporting OpenMP 5.1+ from v1.15.0:
-    conflicts("%gcc@:11", when="@1.15.0: +libxsmm", msg="OpenMP 5.1+ supported compiler required!")
-
-    # Explicitly add dependencies to PYFR_LIBRARY_PATH environment variable
+    # Explicitly add dependencies to environment variables
     def setup_run_environment(self, env):
-        deps = ["metis", "scotch", "libxsmm", "cuda", "hip", "rocblas"]
+        deps = ["metis", "scotch", "libxsmm", "hip", "rocblas"]
         pyfr_library_path = []
         for dep in deps:
             if "+{}".format(dep) in self.spec:
                 pyfr_library_path.extend(self.spec[dep].libs.directories)
         env.set("PYFR_LIBRARY_PATH", ":".join(pyfr_library_path))
+
+        # LD_LIBRARY_PATH needed for cuda
+        if "+cuda" in self.spec:
+            env.prepend_path("LD_LIBRARY_PATH", self.spec["cuda"].libs.directories[0])


### PR DESCRIPTION
* Adds PyFR v2.0.2
* Removes no longer used scipy variant (was never a hard dependency)
* Removes compiler conflicts as this not really necessary as compilers are used JIT in PyFR and not build time.
* Fixes LD_LIBRARY_PATH issue with cuda backend.
* Updates Gimmik to required v3.2.1.
* Changes default partitioner to Scotch

FYI: @FreddieWitherden