### PR TITLE
upcxx: update to latest gasnet and fix some bitrot

### DIFF
--- a/var/spack/repos/builtin/packages/upcxx/fix_configure_ldflags.patch
+++ b/var/spack/repos/builtin/packages/upcxx/fix_configure_ldflags.patch
@@ -1,0 +1,26 @@
+diff --git a/configure b/configure
+index 27c35a43..b0f3cbe9 100755
+--- a/configure
++++ b/configure
+@@ -1168,7 +1168,7 @@ if [[ $UPCXX_CUDA -eq 1 ]]; then
+   # check that the CUDA Driver API is linkable, adding explicit link flags if needed
+   echo -e "#include <cuda.h>\n#include <cuda_runtime_api.h>\nint main() { cuInit(0); return 0; }" >| conftest.cpp
+   for ldextra in '' '-lcuda' '-framework CUDA' 'FAIL'; do
+-    eval $CXX $UPCXX_CUDA_CPPFLAGS conftest.cpp -o conftest.exe $UPCXX_CUDA_LIBFLAGS $ldextra &> /dev/null
++    eval $CXX $UPCXX_CUDA_CPPFLAGS $LDFLAGS conftest.cpp -o conftest.exe $UPCXX_CUDA_LIBFLAGS $ldextra &> /dev/null
+     if [[ $? -eq 0 ]] && ( ./conftest.exe 2>/dev/null ); then
+       [[ -n "$ldextra" ]] && UPCXX_CUDA_LIBFLAGS+=" $ldextra"
+       break
+diff --git a/utils/system-checks.sh b/utils/system-checks.sh
+index 728792d0..e065f636 100644
+--- a/utils/system-checks.sh
++++ b/utils/system-checks.sh
+@@ -493,7 +493,7 @@ _EOF
+         check_maybe_c_compiler
+         return 2
+     fi
+-    if ! (set -x; eval $CXX $CXXFLAGS $CXXSTDFLAG -o conftest.o conftest-cc.o conftest-cxx.o -lm) >> $DETAIL_LOG 2>&1 ; then
++    if ! (set -x; eval $CXX $CXXFLAGS $CXXSTDFLAG $LDFLAGS -o conftest.o conftest-cc.o conftest-cxx.o -lm) >> $DETAIL_LOG 2>&1 ; then
+         echo "ERROR: CXX=$CXX failed to link object files produced by CC=$CC and CXX=$CXX"
+         echo "ERROR: See $DETAIL_LOG for details. Last four lines are as follows:"
+         tail -4 $DETAIL_LOG

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -140,7 +140,7 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
     # UPC++ always relies on GASNet-EX.
     # This variant allows overriding with a particular version of GASNet-EX sources,
     # although this is not officially supported and some combinations might be rejected.
-    # Original default was to use the embedded version of GASNet-EX, 
+    # Original default was to use the embedded version of GASNet-EX,
     # but currently there are newer versions in Spack so we default to that instead.
     variant("gasnet", default=True, description="Override embedded GASNet-EX with Spack's")
     depends_on("gasnet conduits=none", when="+gasnet")
@@ -252,9 +252,7 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
         if "+rocm" in spec:
             options.append("--enable-hip")
             options.append("--with-hip-home=" + spec["hip"].prefix)
-            options.append(
-                "--with-ldflags=" + self.compiler.cc_rpath_arg + spec["hip"].prefix.lib
-            )
+            options.append("--with-ldflags=" + self.compiler.cc_rpath_arg + spec["hip"].prefix.lib)
 
         if "+level_zero" in spec:
             options.append("--enable-ze")

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -16,7 +16,7 @@ def is_CrayXC():
 
 
 def is_CrayEX():
-    if spack.platforms.host().name in ["linux", "cray"]:
+    if spack.platforms.host().name == "linux":
         target = os.environ.get("CRAYPE_NETWORK_TARGET")
         if target in ["ofi", "ucx"]:  # normal case
             return True
@@ -93,6 +93,8 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
     # Do NOT add older versions here.
     # UPC++ releases over 2 years old are not supported.
 
+    patch("fix_configure_ldflags.patch", when="@2021.9.0:master")
+
     variant("mpi", default=False, description="Enables MPI-based spawners and mpi-conduit")
 
     variant(
@@ -136,14 +138,17 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
     )
 
     # UPC++ always relies on GASNet-EX.
-    # The default (and recommendation) is to use the implicit, embedded version.
     # This variant allows overriding with a particular version of GASNet-EX sources,
     # although this is not officially supported and some combinations might be rejected.
-    variant("gasnet", default=False, description="Override embedded GASNet-EX version")
+    # Original default was to use the embedded version of GASNet-EX, 
+    # but currently there are newer versions in Spack so we default to that instead.
+    variant("gasnet", default=True, description="Override embedded GASNet-EX with Spack's")
     depends_on("gasnet conduits=none", when="+gasnet")
 
     depends_on("mpi", when="+mpi")
     depends_on("python@2.7.5:", type=("build", "run"))
+
+    depends_on("libfabric", when=is_CrayEX())
 
     conflicts("^hip@:4.4.0", when="+rocm")
 
@@ -206,8 +211,8 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
 
         if is_CrayEX():
             # Probe to find the right libfabric provider (SlingShot 10 vs 11)
-            fi_info = which("fi_info")("-l", output=str)
-            if fi_info.find("cxi") >= 0:
+            fi_info = which(spec["libfabric"].prefix.bin.fi_info) or which("fi_info")
+            if fi_info is None or fi_info("-l", output=str).find("cxi") >= 0:
                 provider = "cxi"
             else:
                 provider = "verbs;ofi_rxm"
@@ -238,12 +243,17 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
 
         if "+cuda" in spec:
             options.append("--enable-cuda")
+            options.append("--with-cuda-home=" + spec["cuda"].prefix)
             options.append("--with-nvcc=" + spec["cuda"].prefix.bin.nvcc)
+            options.append(
+                "--with-ldflags=" + self.compiler.cc_rpath_arg + spec["cuda"].prefix.lib64
+            )
 
         if "+rocm" in spec:
             options.append("--enable-hip")
+            options.append("--with-hip-home=" + spec["hip"].prefix)
             options.append(
-                "--with-ld-flags=" + self.compiler.cc_rpath_arg + spec["hip"].prefix.lib
+                "--with-ldflags=" + self.compiler.cc_rpath_arg + spec["hip"].prefix.lib
             )
 
         if "+level_zero" in spec:


### PR DESCRIPTION
Updates to use the latest release of the gasnet dependency; now default to Spack's copy of GASNet-EX, which is newer than the embedded version.

Also fix some bitrot due to changes in Spack and Cray system environments since the last UPC++ release:

* Now need to explicitly depend on libfabric for Cray EX
* Ensure build uses the selected CUDA and ROCm versions
* Correct spelling on `configure --with-ldflags`
* Patch a defect regarding `configure --with-ldflags`
