### PR TITLE
traverse: fewer allocations

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -828,7 +828,7 @@ def setup_package(pkg, dirty, context: Context = Context.BUILD):
     return env_base
 
 
-class EnvironmentVisitor:
+class EnvironmentVisitor(traverse.AbstractVisitor):
     def __init__(self, *roots: spack.spec.Spec, context: Context):
         # For the roots (well, marked specs) we follow different edges
         # than for their deps, depending on the context.
@@ -846,7 +846,7 @@ class EnvironmentVisitor:
             self.root_depflag = dt.RUN | dt.LINK
 
     def neighbors(self, item):
-        spec = item.edge.spec
+        spec = item[0].spec
         if spec.dag_hash() in self.root_hashes:
             depflag = self.root_depflag
         else:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1454,7 +1454,9 @@ class Spec:
             raise spack.error.SpecError(err_msg.format(name, len(deps)))
         return deps[0]
 
-    def edges_from_dependents(self, name=None, depflag: dt.DepFlag = dt.ALL):
+    def edges_from_dependents(
+        self, name=None, depflag: dt.DepFlag = dt.ALL
+    ) -> List[DependencySpec]:
         """Return a list of edges connecting this node in the DAG
         to parents.
 
@@ -1464,7 +1466,9 @@ class Spec:
         """
         return [d for d in self._dependents.select(parent=name, depflag=depflag)]
 
-    def edges_to_dependencies(self, name=None, depflag: dt.DepFlag = dt.ALL):
+    def edges_to_dependencies(
+        self, name=None, depflag: dt.DepFlag = dt.ALL
+    ) -> List[DependencySpec]:
         """Return a list of edges connecting this node in the DAG
         to children.
 


### PR DESCRIPTION
- Add types in `spack.traverse`
- Turn `EdgeAndDepth` into tuple.

Traversal instantiates `O(v)` to `O(e)` `EdgeAndDepth` instances, which is a
namedtuple. That's pretty slow, probably cause it needs to be allocated, and
triggers more gc pauses, or more function calls to constructors...

Traversal is used almost everywhere in Spack, so would be nice if it were a bit
faster. Builtin types are much faster, so use a tuple instead.

On a graph with 64 nodes:

```python
# before
In [3]: %timeit list(spack.traverse.traverse_nodes([s]))
231 µs ± 200 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

# after
In [3]: %timeit list(spack.traverse.traverse_nodes([s]))
186 µs ± 1.12 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

There are some other improvements to be done, in particular 
- `edges_from_dependents`
- `edges_to_dependencies`
but I'll leave that for another PR.