### PR TITLE
py-pyzmq: add v25.1.2, v26.0.3, v26.1.1, v26.2.0 (switch to py-scikit-build-core)

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyzmq/package.py
+++ b/var/spack/repos/builtin/packages/py-pyzmq/package.py
@@ -24,6 +24,8 @@ class PyPyzmq(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("26.0.3", sha256="dba7d9f2e047dfa2bca3b01f4f84aa5246725203d6284e3790f2ca15fba6b40a")
+    version("25.1.2", sha256="93f1aa311e8bb912e34f004cf186407a4e90eec4f0ecc0efd26056bf7eda0226")
     version("25.0.2", sha256="6b8c1bbb70e868dc88801aa532cae6bd4e3b5233784692b786f17ad2962e5149")
     version("24.0.1", sha256="216f5d7dbb67166759e59b0479bca82b8acf9bed6015b526b8eb10143fb08e77")
     version("22.3.0", sha256="8eddc033e716f8c91c6a2112f0a8ebc5e00532b4a6ae1eb0ccc48e027f9c671c")
@@ -39,13 +41,17 @@ class PyPyzmq(PythonPackage):
     depends_on("python@2.6:2.7,3.2:3.8", type=("build", "run"), when="@:14")
 
     # pyproject.toml
-    depends_on("py-setuptools", type="build")
-    # https://github.com/zeromq/pyzmq/issues/1278
-    # https://github.com/zeromq/pyzmq/pull/1317
-    depends_on("py-setuptools@:59", when="@17:18.0", type="build")
-    depends_on("py-packaging", type="build")
+    with when("@26:"):
+        depends_on("py-scikit-build-core", type="build")
+    with when("@:25"):
+        depends_on("py-setuptools", type="build")
+        # https://github.com/zeromq/pyzmq/issues/1278
+        # https://github.com/zeromq/pyzmq/pull/1317
+        depends_on("py-setuptools@:59", when="@17:18.0", type="build")
 
-    # setup.py
+    depends_on("py-packaging", type="build")
+    depends_on("py-cython@3:", type="build", when="@26:")
+    depends_on("py-cython@0.29.35:", type="build", when="@25.1.1: ^python@3.12:")
     depends_on("py-cython@0.29:", type="build", when="@22.3.0:")
     depends_on("py-cython@0.20:", type="build", when="@18:")
     depends_on("py-cython@0.16:", type="build")
@@ -66,7 +72,7 @@ class PyPyzmq(PythonPackage):
         for f in find(".", "*.pyx"):
             touch(f)
 
-    @run_before("install")
+    @run_before("install", when="@:25")
     def setup(self):
         """Create config file listing dependency information."""
 

--- a/var/spack/repos/builtin/packages/py-pyzmq/package.py
+++ b/var/spack/repos/builtin/packages/py-pyzmq/package.py
@@ -42,7 +42,7 @@ class PyPyzmq(PythonPackage):
 
     # pyproject.toml
     with when("@26:"):
-        depends_on("py-scikit-build-core", type="build")
+        depends_on("py-scikit-build-core +pyproject", type="build")
     with when("@:25"):
         depends_on("py-setuptools", type="build")
         # https://github.com/zeromq/pyzmq/issues/1278

--- a/var/spack/repos/builtin/packages/py-pyzmq/package.py
+++ b/var/spack/repos/builtin/packages/py-pyzmq/package.py
@@ -24,6 +24,8 @@ class PyPyzmq(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("26.2.0", sha256="070672c258581c8e4f640b5159297580a9974b026043bd4ab0470be9ed324f1f")
+    version("26.1.1", sha256="a7db05d8b7cd1a8c6610e9e9aa55d525baae7a44a43e18bc3260eb3f92de96c6")
     version("26.0.3", sha256="dba7d9f2e047dfa2bca3b01f4f84aa5246725203d6284e3790f2ca15fba6b40a")
     version("25.1.2", sha256="93f1aa311e8bb912e34f004cf186407a4e90eec4f0ecc0efd26056bf7eda0226")
     version("25.0.2", sha256="6b8c1bbb70e868dc88801aa532cae6bd4e3b5233784692b786f17ad2962e5149")


### PR DESCRIPTION
This PR adds versions 25.1.2 (last with setuptools), and 26.0.3 thru 26.2.0 (latest, switched to py-scikit-build-core).