### PR TITLE
py-partd: add v1.4.1, v1.4.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-partd/package.py
+++ b/var/spack/repos/builtin/packages/py-partd/package.py
@@ -12,8 +12,10 @@ class PyPartd(PythonPackage):
     homepage = "https://github.com/dask/partd/"
     pypi = "partd/partd-0.3.8.tar.gz"
 
-    license("BSD-3-Clause")
+    license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("1.4.2", sha256="d022c33afbdc8405c226621b015e8067888173d85f7f5ecebb3cafed9a20f02c")
+    version("1.4.1", sha256="56c25dd49e6fea5727e731203c466c6e092f308d8f0024e199d02f6aa2167f67")
     version("1.4.0", sha256="aa0ff35dbbcc807ae374db56332f4c1b39b46f67bf2975f5151e0b4186aed0d5")
     version("1.1.0", sha256="6e258bf0810701407ad1410d63d1a15cfd7b773fd9efe555dac6bb82cc8832b0")
     version("0.3.10", sha256="33722a228ebcd1fa6f44b1631bdd4cff056376f89eb826d7d880b35b637bcfba")
@@ -21,6 +23,9 @@ class PyPartd(PythonPackage):
 
     depends_on("python@3.5:", type=("build", "run"), when="@1.1.0:")
     depends_on("python@3.7:", type=("build", "run"), when="@1.4.0:")
+    depends_on("python@3.9:", type=("build", "run"), when="@1.4.2:")
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@61.2:", type="build", when="@1.4.2:")
+    depends_on("py-versioneer@0.29 +toml", type="build", when="@1.4.2:")
     depends_on("py-locket", type=("build", "run"))
     depends_on("py-toolz", type=("build", "run"))


### PR DESCRIPTION
This PR adds versions 1.4.1 and 1.4.2. I chose to add 1.4.1 since it's the last version with a bundled install of versioneer, and without a pyproject.toml. As of 1.4.2, pyproject.toml is there as an easier reference source of info, and the package depends on py-versioneer of exactly(!) version 0.29.