### PR TITLE
py-onnxruntime: add v1.17.3

### DIFF
--- a/var/spack/repos/builtin/packages/py-onnxruntime/package.py
+++ b/var/spack/repos/builtin/packages/py-onnxruntime/package.py
@@ -22,6 +22,7 @@ class PyOnnxruntime(CMakePackage, PythonExtension):
 
     license("MIT")
 
+    version("1.17.3", tag="v1.17.3", commit="56b660f36940a919295e6f1e18ad3a9a93a10bf7")
     version("1.17.1", tag="v1.17.1", commit="8f5c79cb63f09ef1302e85081093a3fe4da1bc7d")
     version("1.10.0", tag="v1.10.0", commit="0d9030e79888d1d5828730b254fedc53c7b640c1")
     version("1.7.2", tag="v1.7.2", commit="5bc92dff16b0ddd5063b717fb8522ca2ad023cb0")

--- a/var/spack/repos/builtin/packages/py-onnxruntime/package.py
+++ b/var/spack/repos/builtin/packages/py-onnxruntime/package.py
@@ -56,7 +56,7 @@ class PyOnnxruntime(CMakePackage, PythonExtension):
     depends_on("protobuf@:3.19", when="@:1.11")
     depends_on("py-cerberus", type=("build", "run"))
     depends_on("py-onnx", type=("build", "run"))
-    depends_on("py-onnx@:1.15.0", type=("build", "run"), when="@:1.17.1")
+    depends_on("py-onnx@:1.15.0", type=("build", "run"), when="@:1.17")
     depends_on("zlib-api")
     depends_on("libpng")
     depends_on("cuda", when="+cuda")


### PR DESCRIPTION
This PR adds ONNX Runtime 1.17.3 ([release notes](https://github.com/Microsoft/onnxruntime/releases/tag/v1.17.3)). It's a bugfix release, no changes to build system needed.