### PR TITLE
htslib: add variants

### DIFF
--- a/var/spack/repos/builtin/packages/htslib/package.py
+++ b/var/spack/repos/builtin/packages/htslib/package.py
@@ -49,16 +49,16 @@ class Htslib(AutotoolsPackage):
         default=True,
         description="use libdeflate for faster crc and deflate algorithms",
     )
-    variant("gcs", default=False, description="enable gcs url support")
-    variant("s3", default=False, description="enable s3 url support")
+    variant("gcs", default=True, description="enable gcs url support", when="+libcurl@1.5")
+    variant("s3", default=True, description="enable s3 url support", when="+libcurl@1.5")
     variant("plugins", default=False, description="enable support for separately compiled plugins")
-    variant("year2038", default=False, description="enable support for timestamps beyond 2038")
     variant("pic", default=True, description="Compile with PIC support")
 
     depends_on("zlib-api")
     depends_on("bzip2", when="@1.4:")
     depends_on("xz", when="@1.4:")
     depends_on("curl", when="@1.3:+libcurl")
+    depends_on("openssl", when="+s3")
     depends_on("libdeflate", when="@1.8:+libdeflate")
 
     depends_on("m4", when="@1.2")
@@ -100,8 +100,5 @@ class Htslib(AutotoolsPackage):
 
         if spec.satisfies("@1.8:"):
             args.extend(self.enable_or_disable("libdeflate"))
-
-        if spec.satisfies("@1.19:"):
-            args.extend(self.enable_or_disable("year2038"))
 
         return args

--- a/var/spack/repos/builtin/packages/htslib/package.py
+++ b/var/spack/repos/builtin/packages/htslib/package.py
@@ -42,15 +42,15 @@ class Htslib(AutotoolsPackage):
         "libcurl",
         default=True,
         description="Enable libcurl-based support for http/https/etc URLs,"
-        " for versions >= 1.3. This also enables S3 and GCS support.",
+        " for versions >= 1.3. This also enables S3 and GCS support by default.",
     )
     variant(
         "libdeflate",
         default=True,
         description="use libdeflate for faster crc and deflate algorithms",
     )
-    variant("gcs", default=True, description="enable gcs url support", when="+libcurl@1.5")
-    variant("s3", default=True, description="enable s3 url support", when="+libcurl@1.5")
+    variant("gcs", default=True, description="enable gcs url support", when="@1.5:+libcurl")
+    variant("s3", default=True, description="enable s3 url support", when="@1.5:+libcurl")
     variant("plugins", default=False, description="enable support for separately compiled plugins")
     variant("pic", default=True, description="Compile with PIC support")
 
@@ -83,7 +83,7 @@ class Htslib(AutotoolsPackage):
 
     def flag_handler(self, name, flags):
         if name == "cflags" and self.spec.satisfies("+pic"):
-            flags.append("-fPIC")
+            flags.append(self.compiler.cc_pic_flag)
         return (flags, None, None)
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/htslib/package.py
+++ b/var/spack/repos/builtin/packages/htslib/package.py
@@ -49,6 +49,7 @@ class Htslib(AutotoolsPackage):
         default=True,
         description="use libdeflate for faster crc and deflate algorithms",
     )
+    variant("gcs", default=False, description="enable gcs url support")
     variant("s3", default=False, description="enable s3 url support")
     variant("plugins", default=False, description="enable support for separately compiled plugins")
     variant("year2038", default=False, description="enable support for timestamps beyond 2038")

--- a/var/spack/repos/builtin/packages/htslib/package.py
+++ b/var/spack/repos/builtin/packages/htslib/package.py
@@ -49,6 +49,10 @@ class Htslib(AutotoolsPackage):
         default=True,
         description="use libdeflate for faster crc and deflate algorithms",
     )
+    variant("s3", default=False, description="enable s3 url support")
+    variant("plugins", default=False, description="enable support for separately compiled plugins")
+    variant("year2038", default=False, description="enable support for timestamps beyond 2038")
+    variant("pic", default=True, description="Compile with PIC support")
 
     depends_on("zlib-api")
     depends_on("bzip2", when="@1.4:")
@@ -76,6 +80,11 @@ class Htslib(AutotoolsPackage):
             url = "https://github.com/samtools/htslib/releases/download/{0}/htslib-{0}.tar.bz2"
             return url.format(version.dotted)
 
+    def flag_handler(self, name, flags):
+        if name == "cflags" and self.spec.satisfies("+pic"):
+            flags.append("-fPIC")
+        return (flags, None, None)
+
     def configure_args(self):
         spec = self.spec
         args = []
@@ -83,7 +92,15 @@ class Htslib(AutotoolsPackage):
         if spec.satisfies("@1.3:"):
             args.extend(self.enable_or_disable("libcurl"))
 
+        if spec.satisfies("@1.5:"):
+            args.extend(self.enable_or_disable("s3"))
+            args.extend(self.enable_or_disable("gcs"))
+            args.extend(self.enable_or_disable("plugins"))
+
         if spec.satisfies("@1.8:"):
             args.extend(self.enable_or_disable("libdeflate"))
+
+        if spec.satisfies("@1.19:"):
+            args.extend(self.enable_or_disable("year2038"))
 
         return args


### PR DESCRIPTION
Adding variants based on configure script (and checked historical compatibility):
 - S3 Support
 - GCS Support
 - Year 2038 timestamp support
 - Plugin support

Added an additional variant for -fPIC compilation for as I noticed it was needed with `kentutils` as well. This change was also included in #44413 as it was needed for audit to pass. 
