### PR TITLE
perl-dbd-mysql: add v4.052, v5.005

### DIFF
--- a/var/spack/repos/builtin/packages/perl-dbd-mysql/package.py
+++ b/var/spack/repos/builtin/packages/perl-dbd-mysql/package.py
@@ -32,13 +32,17 @@ class PerlDbdMysql(PerlPackage):
     )
     version("4.043", sha256="629f865e8317f52602b2f2efd2b688002903d2e4bbcba5427cb6188b043d6f99")
 
+    variant("force_clientonly", default=True, description="Use the client_only mysql variant")
+
     depends_on("perl-devel-checklib", type="build", when="@4.050:")
 
     with default_args(type=("build", "link", "run")):
         # Does it's own version check and mariadb doesn't conform to it's
         # strict checking. This could probably be patched in the future.
-        depends_on("mysql+client_only@8", when="@5")
-        depends_on("mysql+client_only@4:", when="@4")
+        depends_on("mysql+client_only@8", when="@5+force_clientonly")
+        depends_on("mysql@8", when="@5~force_clientonly")
+        depends_on("mysql+client_only@4:", when="@4+force_clientonly")
+        depends_on("mysql@4:", when="@4~force_clientonly")
 
     with default_args(type=("build", "run")):
         depends_on("perl-test-deep")

--- a/var/spack/repos/builtin/packages/perl-dbd-mysql/package.py
+++ b/var/spack/repos/builtin/packages/perl-dbd-mysql/package.py
@@ -15,6 +15,17 @@ class PerlDbdMysql(PerlPackage):
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
     version(
+        "5.005",
+        sha256="1558c203b3911e273d3f83249535b312165be2ca8edba6b6c210645d769d0541",
+        url="https://cpan.metacpan.org/authors/id/D/DV/DVEEDEN/DBD-mysql-5.005.tar.gz",
+    )
+    version(
+        "4.052",
+        sha256="a83f57af7817787de0ef56fb15fdfaf4f1c952c8f32ff907153b66d2da78ff5b",
+        url="https://cpan.metacpan.org/authors/id/D/DV/DVEEDEN/DBD-mysql-4.052.tar.gz",
+    )
+
+    version(
         "4.050",
         sha256="4f48541ff15a0a7405f76adc10f81627c33996fbf56c95c26c094444c0928d78",
         url="https://cpan.metacpan.org/authors/id/D/DV/DVEEDEN/DBD-mysql-4.050.tar.gz",
@@ -22,6 +33,23 @@ class PerlDbdMysql(PerlPackage):
     version("4.043", sha256="629f865e8317f52602b2f2efd2b688002903d2e4bbcba5427cb6188b043d6f99")
 
     depends_on("perl-devel-checklib", type="build", when="@4.050:")
-    depends_on("perl-test-deep", type=("build", "run"))
-    depends_on("perl-dbi", type=("build", "run"))
-    depends_on("mysql-client")
+
+    with default_args(type=("build", "link", "run")):
+        # Does it's own version check and mariadb doesn't conform to it's
+        # strict checking. This could probably be patched in the future.
+        depends_on("mysql@8", when="@5")
+        depends_on("mysql@4:", when="@4")
+        depends_on("zlib-api")
+        depends_on("binutils")
+
+    with default_args(type=("build", "run")):
+        depends_on("perl-test-deep")
+        depends_on("perl-dbi")
+
+    def setup_build_env(self, env):
+        env.append_path("PATH", self.spec["mysql_client"].prefix.bin.mysql_config)
+
+    def configure_args(self):
+        # Work around mysql_config providing incorrect linker args
+        mysql = self.spec["mysql-client"].prefix
+        return [f"--cflags=-I{mysql.include}", f"--libs=-L{mysql.lib} -lmysqlclient"]

--- a/var/spack/repos/builtin/packages/perl-dbd-mysql/package.py
+++ b/var/spack/repos/builtin/packages/perl-dbd-mysql/package.py
@@ -32,17 +32,13 @@ class PerlDbdMysql(PerlPackage):
     )
     version("4.043", sha256="629f865e8317f52602b2f2efd2b688002903d2e4bbcba5427cb6188b043d6f99")
 
-    variant("force_clientonly", default=True, description="Use the client_only mysql variant")
-
     depends_on("perl-devel-checklib", type="build", when="@4.050:")
 
     with default_args(type=("build", "link", "run")):
         # Does it's own version check and mariadb doesn't conform to it's
         # strict checking. This could probably be patched in the future.
-        depends_on("mysql+client_only@8", when="@5+force_clientonly")
-        depends_on("mysql@8", when="@5~force_clientonly")
-        depends_on("mysql+client_only@4:", when="@4+force_clientonly")
-        depends_on("mysql@4:", when="@4~force_clientonly")
+        depends_on("mysql@4:", when="@4")
+        depends_on("mysql@8", when="@5")
 
     with default_args(type=("build", "run")):
         depends_on("perl-test-deep")

--- a/var/spack/repos/builtin/packages/perl-dbd-mysql/package.py
+++ b/var/spack/repos/builtin/packages/perl-dbd-mysql/package.py
@@ -37,8 +37,8 @@ class PerlDbdMysql(PerlPackage):
     with default_args(type=("build", "link", "run")):
         # Does it's own version check and mariadb doesn't conform to it's
         # strict checking. This could probably be patched in the future.
-        depends_on("mysql@8", when="@5")
-        depends_on("mysql@4:", when="@4")
+        depends_on("mysql+client_only@8", when="@5")
+        depends_on("mysql+client_only@4:", when="@4")
 
     with default_args(type=("build", "run")):
         depends_on("perl-test-deep")

--- a/var/spack/repos/builtin/packages/perl-dbd-mysql/package.py
+++ b/var/spack/repos/builtin/packages/perl-dbd-mysql/package.py
@@ -39,15 +39,10 @@ class PerlDbdMysql(PerlPackage):
         # strict checking. This could probably be patched in the future.
         depends_on("mysql@8", when="@5")
         depends_on("mysql@4:", when="@4")
-        depends_on("zlib-api")
-        depends_on("binutils")
 
     with default_args(type=("build", "run")):
         depends_on("perl-test-deep")
         depends_on("perl-dbi")
-
-    def setup_build_env(self, env):
-        env.append_path("PATH", self.spec["mysql_client"].prefix.bin.mysql_config)
 
     def configure_args(self):
         # Work around mysql_config providing incorrect linker args


### PR DESCRIPTION
Adding two new versions for `perl-dbd-mysql` and correcting some failures with the build system:
- The package does a strict version check for 8.x.y that needed to be added as a dependency.
- The version check also fails when mariadb is used, even for equivalent versions, so we require `mysql` explicitly. Technically the `client_only` variant doesn't matter as there isn't a non client_only version for 8 and cxxstd17, but may matter if we want to avoid building the whole mysql for other versions. 
- The package attempts to use `mysql_config` to configure itself but ends up getting the wrong LDFLAGS.