### PR TITLE
perl-archive-zip: add dependency

### DIFF
--- a/var/spack/repos/builtin/packages/perl-archive-zip/package.py
+++ b/var/spack/repos/builtin/packages/perl-archive-zip/package.py
@@ -16,4 +16,5 @@ class PerlArchiveZip(PerlPackage):
 
     version("1.68", sha256="984e185d785baf6129c6e75f8eb44411745ac00bf6122fb1c8e822a3861ec650")
 
+    depends_on("perl-carp")
     depends_on("perl-compress-raw-zlib")

--- a/var/spack/repos/builtin/packages/perl-archive-zip/package.py
+++ b/var/spack/repos/builtin/packages/perl-archive-zip/package.py
@@ -15,3 +15,5 @@ class PerlArchiveZip(PerlPackage):
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
     version("1.68", sha256="984e185d785baf6129c6e75f8eb44411745ac00bf6122fb1c8e822a3861ec650")
+
+    depends_on("perl-compress-raw-zlib")


### PR DESCRIPTION
Adding the dependency of `perl-compress-raw-zlib` to `perl-archive-zip`.