### PR TITLE
py-orjson: add v3.8.14, v3.9.15, v3.10.3 and dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-orjson/package.py
+++ b/var/spack/repos/builtin/packages/py-orjson/package.py
@@ -22,7 +22,9 @@ class PyOrjson(PythonPackage):
     with default_args(type="build"):
         with when("@3.8"):
             depends_on("rust@1.60:")
+            depends_on("python@3.7:")
             depends_on("py-maturin@0.13:0.14")
         with when("@03.9:"):
             depends_on("rust@1.72:")
+            depends_on("python@3.8:")
             depends_on("py-maturin@1")

--- a/var/spack/repos/builtin/packages/py-orjson/package.py
+++ b/var/spack/repos/builtin/packages/py-orjson/package.py
@@ -14,15 +14,6 @@ class PyOrjson(PythonPackage):
 
     license("Apache-2.0")
 
-    version("3.10.3", sha256="2b166507acae7ba2f7c315dcf185a9111ad5e992ac81f2d507aac39193c2c818")
-    version("3.9.15", sha256="95cae920959d772f30ab36d3b25f83bb0f3be671e986c72ce22f8fa700dae061")
-    version("3.8.14", sha256="5ea93fd3ef7be7386f2516d728c877156de1559cda09453fc7dd7b696d0439b3")
     version("3.8.7", sha256="8460c8810652dba59c38c80d27c325b5092d189308d8d4f3e688dbd8d4f3b2dc")
 
-    with default_args(type="build"):
-        with when("@3.8"):
-            depends_on("rust@1.60:")
-            depends_on("py-maturin@0.13:0.14")
-        with when("@03.9:"):
-            depends_on("rust@1.72:")
-            depends_on("py-maturin@1")
+    depends_on("py-maturin@0.13:0.14", type="build")

--- a/var/spack/repos/builtin/packages/py-orjson/package.py
+++ b/var/spack/repos/builtin/packages/py-orjson/package.py
@@ -14,6 +14,15 @@ class PyOrjson(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.10.3", sha256="2b166507acae7ba2f7c315dcf185a9111ad5e992ac81f2d507aac39193c2c818")
+    version("3.9.15", sha256="95cae920959d772f30ab36d3b25f83bb0f3be671e986c72ce22f8fa700dae061")
+    version("3.8.14", sha256="5ea93fd3ef7be7386f2516d728c877156de1559cda09453fc7dd7b696d0439b3")
     version("3.8.7", sha256="8460c8810652dba59c38c80d27c325b5092d189308d8d4f3e688dbd8d4f3b2dc")
 
-    depends_on("py-maturin@0.13:0.14", type="build")
+    with default_args(type="build"):
+        with when("@3.8"):
+            depends_on("rust@1.60:")
+            depends_on("py-maturin@0.13:0.14")
+        with when("@03.9:"):
+            depends_on("rust@1.72:")
+            depends_on("py-maturin@1")


### PR DESCRIPTION
Adding new versions for `py-orjson` and fixing dependency issues relating to very old versions of `py-maturin`.

This likely requires #44518 to actually build correctly.