### PR TITLE
py-rich: add v12.6.0,13.7.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-orjson/package.py
+++ b/var/spack/repos/builtin/packages/py-orjson/package.py
@@ -14,15 +14,6 @@ class PyOrjson(PythonPackage):
 
     license("Apache-2.0")
 
-    version("3.10.3", sha256="2b166507acae7ba2f7c315dcf185a9111ad5e992ac81f2d507aac39193c2c818")
-    version("3.9.15", sha256="95cae920959d772f30ab36d3b25f83bb0f3be671e986c72ce22f8fa700dae061")
-    version("3.8.14", sha256="5ea93fd3ef7be7386f2516d728c877156de1559cda09453fc7dd7b696d0439b3")
     version("3.8.7", sha256="8460c8810652dba59c38c80d27c325b5092d189308d8d4f3e688dbd8d4f3b2dc")
 
-    with default_args(type="build"):
-        with when("@3.8"):
-            depends_on("rust@1.60:")
-            depends_on("py-maturin@0.13:0.14")
-        with when("@03.9:"):
-            depends_on("rust@1.72:")
-            depends_on("py-maturin@1")
+    depends_on("py-maturin@0.13:0.14", type="build")

--- a/var/spack/repos/builtin/packages/py-orjson/package.py
+++ b/var/spack/repos/builtin/packages/py-orjson/package.py
@@ -14,6 +14,15 @@ class PyOrjson(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.10.3", sha256="2b166507acae7ba2f7c315dcf185a9111ad5e992ac81f2d507aac39193c2c818")
+    version("3.9.15", sha256="95cae920959d772f30ab36d3b25f83bb0f3be671e986c72ce22f8fa700dae061")
+    version("3.8.14", sha256="5ea93fd3ef7be7386f2516d728c877156de1559cda09453fc7dd7b696d0439b3")
     version("3.8.7", sha256="8460c8810652dba59c38c80d27c325b5092d189308d8d4f3e688dbd8d4f3b2dc")
 
-    depends_on("py-maturin@0.13:0.14", type="build")
+    with default_args(type="build"):
+        with when("@3.8"):
+            depends_on("rust@1.60:")
+            depends_on("py-maturin@0.13:0.14")
+        with when("@03.9:"):
+            depends_on("rust@1.72:")
+            depends_on("py-maturin@1")

--- a/var/spack/repos/builtin/packages/py-rich/package.py
+++ b/var/spack/repos/builtin/packages/py-rich/package.py
@@ -16,7 +16,9 @@ class PyRich(PythonPackage):
 
     license("MIT")
 
+    version("13.7.1", sha256="9be308cb1fe2f1f57d67ce99e95af38a1e2bc71ad9813b0e247cf7ffbcc3a432")
     version("13.4.2", sha256="d653d6bccede5844304c605d5aac802c7cf9621efd700b46c7ec2b51ea914898")
+    version("12.6.0", sha256="ba3a3775974105c221d31141f2c116f4fd65c5ceb0698657a11e9f295ec93fd0")
     version("12.5.1", sha256="63a5c5ce3673d3d5fbbf23cd87e11ab84b6b451436f1b7f19ec54b6bc36ed7ca")
     version("10.14.0", sha256="8bfe4546d56b4131298d3a9e571a0742de342f1593770bd0d4707299f772a0af")
     version("10.9.0", sha256="ba285f1c519519490034284e6a9d2e6e3f16dc7690f2de3d9140737d81304d22")


### PR DESCRIPTION
This adds the latest version of `py-rich` as well an older version that is needed as a dependency for future packages.