### PR TITLE
py-humanize: add v1.0.0, v1.1.0, v2.6.0, v3.14.0, v4.8.0, v4.9.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-humanize/package.py
+++ b/var/spack/repos/builtin/packages/py-humanize/package.py
@@ -18,10 +18,16 @@ class PyHumanize(PythonPackage):
 
     license("MIT")
 
+    version("4.9.0", sha256="582a265c931c683a7e9b8ed9559089dea7edcf6cc95be39a3cbc2c5d5ac2bcfa")
+    version("4.8.0", sha256="9783373bf1eec713a770ecaa7c2d7a7902c98398009dfa3d8a2df91eec9311e8")
     version("4.6.0", sha256="5f1f22bc65911eb1a6ffe7659bd6598e33dcfeeb904eb16ee1e705a09bf75916")
     version("4.4.0", sha256="efb2584565cc86b7ea87a977a15066de34cdedaf341b11c851cfcfd2b964779c")
     version("4.0.0", sha256="ee1f872fdfc7d2ef4a28d4f80ddde9f96d36955b5d6b0dac4bdeb99502bddb00")
+    version("3.14.0", sha256="60dd8c952b1df1ad83f0903844dec50a34ba7a04eea22a6b14204ffb62dbb0a4")
     version("3.12.0", sha256="5ec1a66e230a3e31fb3f184aab9436ea13d4e37c168e0ffc345ae5bb57e58be6")
+    version("2.6.0", sha256="8ee358ea6c23de896b9d1925ebe6a8504bb2ba7e98d5ccf4d07ab7f3b28f3819")
+    version("1.1.0", sha256="ad83016fae2453a7486f5be5dba8e19883020c77f6c12c63702f3b6c15ae3c5e")
+    version("1.0.0", sha256="38ace9b66bcaeb7f8186b9dbf0b3448e00148e5b4fbaf726f96c789e52c3e741")
     version("0.5.1", sha256="a43f57115831ac7c70de098e6ac46ac13be00d69abbf60bdcac251344785bb19")
 
     depends_on("py-hatch-vcs", when="@4.6:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-humanize/package.py
+++ b/var/spack/repos/builtin/packages/py-humanize/package.py
@@ -30,6 +30,7 @@ class PyHumanize(PythonPackage):
     version("1.0.0", sha256="38ace9b66bcaeb7f8186b9dbf0b3448e00148e5b4fbaf726f96c789e52c3e741")
     version("0.5.1", sha256="a43f57115831ac7c70de098e6ac46ac13be00d69abbf60bdcac251344785bb19")
 
+    depends_on("python@3.8:", when="@4.6:")
     depends_on("py-hatch-vcs", when="@4.6:", type=("build", "run"))
     depends_on("py-hatchling", when="@4.6:", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/py-orjson/package.py
+++ b/var/spack/repos/builtin/packages/py-orjson/package.py
@@ -14,15 +14,6 @@ class PyOrjson(PythonPackage):
 
     license("Apache-2.0")
 
-    version("3.10.3", sha256="2b166507acae7ba2f7c315dcf185a9111ad5e992ac81f2d507aac39193c2c818")
-    version("3.9.15", sha256="95cae920959d772f30ab36d3b25f83bb0f3be671e986c72ce22f8fa700dae061")
-    version("3.8.14", sha256="5ea93fd3ef7be7386f2516d728c877156de1559cda09453fc7dd7b696d0439b3")
     version("3.8.7", sha256="8460c8810652dba59c38c80d27c325b5092d189308d8d4f3e688dbd8d4f3b2dc")
 
-    with default_args(type="build"):
-        with when("@3.8"):
-            depends_on("rust@1.60:")
-            depends_on("py-maturin@0.13:0.14")
-        with when("@03.9:"):
-            depends_on("rust@1.72:")
-            depends_on("py-maturin@1")
+    depends_on("py-maturin@0.13:0.14", type="build")

--- a/var/spack/repos/builtin/packages/py-orjson/package.py
+++ b/var/spack/repos/builtin/packages/py-orjson/package.py
@@ -14,6 +14,15 @@ class PyOrjson(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.10.3", sha256="2b166507acae7ba2f7c315dcf185a9111ad5e992ac81f2d507aac39193c2c818")
+    version("3.9.15", sha256="95cae920959d772f30ab36d3b25f83bb0f3be671e986c72ce22f8fa700dae061")
+    version("3.8.14", sha256="5ea93fd3ef7be7386f2516d728c877156de1559cda09453fc7dd7b696d0439b3")
     version("3.8.7", sha256="8460c8810652dba59c38c80d27c325b5092d189308d8d4f3e688dbd8d4f3b2dc")
 
-    depends_on("py-maturin@0.13:0.14", type="build")
+    with default_args(type="build"):
+        with when("@3.8"):
+            depends_on("rust@1.60:")
+            depends_on("py-maturin@0.13:0.14")
+        with when("@03.9:"):
+            depends_on("rust@1.72:")
+            depends_on("py-maturin@1")


### PR DESCRIPTION
Adding multiple versions of `py-humanize` to get package up-to-date and address some legacy dependent package needs.