### PR TITLE
py-python-json-logger: add v2.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-orjson/package.py
+++ b/var/spack/repos/builtin/packages/py-orjson/package.py
@@ -14,15 +14,6 @@ class PyOrjson(PythonPackage):
 
     license("Apache-2.0")
 
-    version("3.10.3", sha256="2b166507acae7ba2f7c315dcf185a9111ad5e992ac81f2d507aac39193c2c818")
-    version("3.9.15", sha256="95cae920959d772f30ab36d3b25f83bb0f3be671e986c72ce22f8fa700dae061")
-    version("3.8.14", sha256="5ea93fd3ef7be7386f2516d728c877156de1559cda09453fc7dd7b696d0439b3")
     version("3.8.7", sha256="8460c8810652dba59c38c80d27c325b5092d189308d8d4f3e688dbd8d4f3b2dc")
 
-    with default_args(type="build"):
-        with when("@3.8"):
-            depends_on("rust@1.60:")
-            depends_on("py-maturin@0.13:0.14")
-        with when("@03.9:"):
-            depends_on("rust@1.72:")
-            depends_on("py-maturin@1")
+    depends_on("py-maturin@0.13:0.14", type="build")

--- a/var/spack/repos/builtin/packages/py-orjson/package.py
+++ b/var/spack/repos/builtin/packages/py-orjson/package.py
@@ -14,6 +14,15 @@ class PyOrjson(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.10.3", sha256="2b166507acae7ba2f7c315dcf185a9111ad5e992ac81f2d507aac39193c2c818")
+    version("3.9.15", sha256="95cae920959d772f30ab36d3b25f83bb0f3be671e986c72ce22f8fa700dae061")
+    version("3.8.14", sha256="5ea93fd3ef7be7386f2516d728c877156de1559cda09453fc7dd7b696d0439b3")
     version("3.8.7", sha256="8460c8810652dba59c38c80d27c325b5092d189308d8d4f3e688dbd8d4f3b2dc")
 
-    depends_on("py-maturin@0.13:0.14", type="build")
+    with default_args(type="build"):
+        with when("@3.8"):
+            depends_on("rust@1.60:")
+            depends_on("py-maturin@0.13:0.14")
+        with when("@03.9:"):
+            depends_on("rust@1.72:")
+            depends_on("py-maturin@1")

--- a/var/spack/repos/builtin/packages/py-python-json-logger/package.py
+++ b/var/spack/repos/builtin/packages/py-python-json-logger/package.py
@@ -15,6 +15,7 @@ class PyPythonJsonLogger(PythonPackage):
     license("BSD-2-Clause")
 
     version("2.0.7", sha256="23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c")
+    version("2.0.2", sha256="202a4f29901a4b8002a6d1b958407eeb2dd1d83c18b18b816f5b64476dde9096")
     version("0.1.11", sha256="b7a31162f2a01965a5efb94453ce69230ed208468b0bbc7fdfc56e6d8df2e281")
 
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
Adding an old version of `py-python-json-logger` needed as a strict dependency for another package.