### PR TITLE
py-maturin: fix rust version dependencies to build

### DIFF
--- a/var/spack/repos/builtin/packages/py-maturin/package.py
+++ b/var/spack/repos/builtin/packages/py-maturin/package.py
@@ -14,6 +14,8 @@ class PyMaturin(PythonPackage):
     homepage = "https://github.com/pyo3/maturin"
     pypi = "maturin/maturin-0.13.7.tar.gz"
 
+    maintainers("teaguesterling")
+
     license("Apache-2.0")
 
     version("1.5.1", sha256="3dd834ece80edb866af18cbd4635e0ecac40139c726428d5f1849ae154b26dca")
@@ -22,8 +24,19 @@ class PyMaturin(PythonPackage):
     version("0.14.17", sha256="fb4e3311e8ce707843235fbe8748a05a3ae166c3efd6d2aa335b53dfc2bd3b88")
     version("0.13.7", sha256="c0a77aa0c57f945649ca711c806203a1b6888ad49c2b8b85196ffdcf0421db77")
 
-    depends_on("py-setuptools", type="build")
-    depends_on("py-wheel@0.36.2:", type="build")
-    depends_on("py-setuptools-rust@1.4:", type="build")
-    depends_on("py-tomli@1.1:", when="^python@:3.10", type=("build", "run"))
-    depends_on("rust", type=("build", "run"))
+    with default_args(type="build"):
+        depends_on("py-setuptools")
+        depends_on("py-wheel@0.36.2:")
+        depends_on("py-setuptools-rust@1.4:")
+
+    with default_args(type=("build", "run")):
+        depends_on("py-tomli@1.1:", when="^python@:3.10")
+        for rust, maturin in [
+            ("1.70", "1.5.0"),
+            ("1.64", "1.0.0"),
+            ("1.62", "0.14.3"),
+            ("1.59", "0.13.3"),
+        ]:
+            depends_on(f"rust@{rust}:", when=f"@{maturin}:")
+
+    conflicts("python@3.11:")

--- a/var/spack/repos/builtin/packages/py-orjson/package.py
+++ b/var/spack/repos/builtin/packages/py-orjson/package.py
@@ -14,15 +14,6 @@ class PyOrjson(PythonPackage):
 
     license("Apache-2.0")
 
-    version("3.10.3", sha256="2b166507acae7ba2f7c315dcf185a9111ad5e992ac81f2d507aac39193c2c818")
-    version("3.9.15", sha256="95cae920959d772f30ab36d3b25f83bb0f3be671e986c72ce22f8fa700dae061")
-    version("3.8.14", sha256="5ea93fd3ef7be7386f2516d728c877156de1559cda09453fc7dd7b696d0439b3")
     version("3.8.7", sha256="8460c8810652dba59c38c80d27c325b5092d189308d8d4f3e688dbd8d4f3b2dc")
 
-    with default_args(type="build"):
-        with when("@3.8"):
-            depends_on("rust@1.60:")
-            depends_on("py-maturin@0.13:0.14")
-        with when("@03.9:"):
-            depends_on("rust@1.72:")
-            depends_on("py-maturin@1")
+    depends_on("py-maturin@0.13:0.14", type="build")

--- a/var/spack/repos/builtin/packages/py-orjson/package.py
+++ b/var/spack/repos/builtin/packages/py-orjson/package.py
@@ -14,6 +14,15 @@ class PyOrjson(PythonPackage):
 
     license("Apache-2.0")
 
+    version("3.10.3", sha256="2b166507acae7ba2f7c315dcf185a9111ad5e992ac81f2d507aac39193c2c818")
+    version("3.9.15", sha256="95cae920959d772f30ab36d3b25f83bb0f3be671e986c72ce22f8fa700dae061")
+    version("3.8.14", sha256="5ea93fd3ef7be7386f2516d728c877156de1559cda09453fc7dd7b696d0439b3")
     version("3.8.7", sha256="8460c8810652dba59c38c80d27c325b5092d189308d8d4f3e688dbd8d4f3b2dc")
 
-    depends_on("py-maturin@0.13:0.14", type="build")
+    with default_args(type="build"):
+        with when("@3.8"):
+            depends_on("rust@1.60:")
+            depends_on("py-maturin@0.13:0.14")
+        with when("@03.9:"):
+            depends_on("rust@1.72:")
+            depends_on("py-maturin@1")


### PR DESCRIPTION
This addresses some observed issues trying to build/use `py-maturin` relating to minimum `rust` version dependencies.

These were located by looking through the `Cargo.toml` file through the various versions.