### PR TITLE
libuuid: deprecate entirely

### DIFF
--- a/var/spack/repos/builtin/packages/antlr4-cpp-runtime/package.py
+++ b/var/spack/repos/builtin/packages/antlr4-cpp-runtime/package.py
@@ -26,7 +26,7 @@ class Antlr4CppRuntime(CMakePackage):
         "clanglibcpp", default=False, description="Compile with clang libc++ instead of libstdc++"
     )
 
-    depends_on("libuuid", type=["build", "link"], when="@:4.10.1")
+    depends_on("uuid", type=["build", "link"], when="@:4.10.1")
     depends_on("git", type=["build"])
     depends_on("pkgconfig", type=["build"])
 

--- a/var/spack/repos/builtin/packages/blat/package.py
+++ b/var/spack/repos/builtin/packages/blat/package.py
@@ -18,7 +18,7 @@ class Blat(Package):
     version("35", sha256="06d9bcf114ec4a4b21fef0540a0532556b6602322a5a2b33f159dc939ae53620")
 
     depends_on("libpng")
-    depends_on("libuuid", when="@37:")
+    depends_on("uuid", when="@37:")
     depends_on("mysql-client", when="@37:")
 
     @when("@37")

--- a/var/spack/repos/builtin/packages/daos/package.py
+++ b/var/spack/repos/builtin/packages/daos/package.py
@@ -36,7 +36,7 @@ class Daos(SConsPackage):
     depends_on("isa-l-crypto@2.23.0:")
     depends_on("libfabric@1.15.1:")
     depends_on("libfuse@3.6.1:")
-    depends_on("libuuid")
+    depends_on("uuid")
     depends_on("libunwind")
     depends_on("libyaml")
     depends_on("mercury@2.2.0:+boostsys")

--- a/var/spack/repos/builtin/packages/elbencho/package.py
+++ b/var/spack/repos/builtin/packages/elbencho/package.py
@@ -56,7 +56,7 @@ class Elbencho(MakefilePackage):
     depends_on("curl", when="+s3")
     depends_on("libarchive", when="+s3")
     depends_on("openssl", when="+s3")
-    depends_on("libuuid", when="+s3")
+    depends_on("uuid", when="+s3")
     depends_on("zlib", when="+s3")
     depends_on("cmake", when="+s3")
 

--- a/var/spack/repos/builtin/packages/flux-security/package.py
+++ b/var/spack/repos/builtin/packages/flux-security/package.py
@@ -35,7 +35,7 @@ class FluxSecurity(AutotoolsPackage):
     depends_on("pkgconfig")
     depends_on("libsodium@1.0.14:")
     depends_on("jansson")
-    depends_on("libuuid")
+    depends_on("uuid")
     depends_on("munge")
     depends_on("libpam")
 

--- a/var/spack/repos/builtin/packages/kentutils/package.py
+++ b/var/spack/repos/builtin/packages/kentutils/package.py
@@ -24,7 +24,7 @@ class Kentutils(MakefilePackage):
 
     depends_on("libpng")
     depends_on("openssl")
-    depends_on("libuuid")
+    depends_on("uuid")
     depends_on("mariadb")
     depends_on("zlib-api")
     depends_on("freetype")

--- a/var/spack/repos/builtin/packages/libuuid/package.py
+++ b/var/spack/repos/builtin/packages/libuuid/package.py
@@ -12,6 +12,10 @@ class Libuuid(AutotoolsPackage, SourceforgePackage):
     homepage = "https://sourceforge.net/projects/libuuid/"
     sourceforge_mirror_path = "libuuid/libuuid-1.0.3.tar.gz"
 
-    version("1.0.3", sha256="46af3275291091009ad7f1b899de3d0cea0252737550e7919d17237997db5644")
+    version(
+        "1.0.3",
+        sha256="46af3275291091009ad7f1b899de3d0cea0252737550e7919d17237997db5644",
+        deprecated=True,
+    )
 
     provides("uuid")

--- a/var/spack/repos/builtin/packages/ucsc-bedclip/package.py
+++ b/var/spack/repos/builtin/packages/ucsc-bedclip/package.py
@@ -17,7 +17,7 @@ class UcscBedclip(Package):
     version("449", sha256="b5a86863d6cfe2120f6c796a13b1572ad05b22622f6534b95c9d26ccbede09b7")
 
     depends_on("libpng")
-    depends_on("libuuid")
+    depends_on("uuid")
     depends_on("gmake")
     depends_on("mysql-connector-c")
     depends_on("openssl")

--- a/var/spack/repos/builtin/packages/ucsc-bedgraphtobigwig/package.py
+++ b/var/spack/repos/builtin/packages/ucsc-bedgraphtobigwig/package.py
@@ -17,7 +17,7 @@ class UcscBedgraphtobigwig(Package):
     version("445", sha256="c7abb5db6a5e16a79aefcee849d2b59dbc71ee112ca1e41fea0afb25229cf56c")
 
     depends_on("libpng")
-    depends_on("libuuid")
+    depends_on("uuid")
     depends_on("gmake")
     depends_on("openssl")
     depends_on("zlib-api")


### PR DESCRIPTION
There hasn't been a release in almost a decade, and build failures with
GCC 14 were reported. I don't think it makes sense to patch it, since
the project moved over to `util-linux`, and Spack's default provider is
that package. Better to just get rid of it in the next Spack release.

And move some packages from `libuuid` -> `uuid`.

Ping @teaguesterling