### PR TITLE
python: factor out `find_python_in_prefix`

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/python/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/python/package.py
@@ -52,7 +52,7 @@ def find_python_in_prefix(spec: "spack.spec.Spec", prefix: Optional[str] = None)
         Executable: the Python command
 
     """
-    if not spec.name == "python":
+    if spec.name != "python":
         raise ValueError("find_python_in_prefix() only works on Python installations.")
 
     prefix = Prefix(prefix or spec.prefix)

--- a/var/spack/repos/spack_repo/builtin/packages/python/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/python/package.py
@@ -14,6 +14,7 @@ from typing import Dict, List, Optional
 
 from spack_repo.builtin.build_systems.generic import Package
 
+import llnl.util.filesystem as fs
 from llnl.util.lang import dedupe
 
 from spack.build_environment import dso_suffix, stat_suffix
@@ -51,6 +52,9 @@ def find_python_in_prefix(spec: "spack.spec.Spec", prefix: Optional[str] = None)
         Executable: the Python command
 
     """
+    if not spec.name == "python":
+        raise ValueError("find_python_in_prefix() only works on Python installations.")
+
     prefix = Prefix(prefix or spec.prefix)
 
     # We need to be careful here. If the user is using an externally
@@ -69,7 +73,7 @@ def find_python_in_prefix(spec: "spack.spec.Spec", prefix: Optional[str] = None)
     patterns = [f"python{ver}{file_extension}" for ver in suffixes]
     root = prefix.bin if sys.platform != "win32" else prefix
 
-    path = find_first(root, files=patterns)
+    path = fs.find_first(root, files=patterns)
     if path is not None:
         return Executable(path)
 


### PR DESCRIPTION
Pull a free-standing `find_python_in_prefix` function out of `python`'s `command()` property.

Originally done for #44382 but not ultimately used, I still think this is a good refactor, so submitting as a separate pull request.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
