### PR TITLE
Update py-vl-convert-python

### DIFF
--- a/var/spack/repos/builtin/packages/py-vl-convert-python/package.py
+++ b/var/spack/repos/builtin/packages/py-vl-convert-python/package.py
@@ -12,11 +12,7 @@ class PyVlConvertPython(PythonPackage):
     homepage = "https://github.com/vega/vl-convert"
     pypi = "vl_convert_python/vl_convert_python-1.4.0.tar.gz"
 
-    version(
-        "1.4.0",
-        sha256="264d6f2338c7d3474e60c6907cca016b880b0c1c9be302bb84abc6690188a7e9",
-        deprecated=True,
-    )
+    version("1.4.0", sha256="264d6f2338c7d3474e60c6907cca016b880b0c1c9be302bb84abc6690188a7e9")
     version(
         "1.3.0",
         sha256="de1462151dfbba7b2a17881dac1d2269662012c252f1e9d1537a4daed5e36067",

--- a/var/spack/repos/builtin/packages/py-vl-convert-python/package.py
+++ b/var/spack/repos/builtin/packages/py-vl-convert-python/package.py
@@ -10,10 +10,23 @@ class PyVlConvertPython(PythonPackage):
     """Convert Vega-Lite chart specifications to SVG, PNG, PDF, or Vega"""
 
     homepage = "https://github.com/vega/vl-convert"
-    pypi = "vl_convert_python/vl_convert_python-0.13.1.tar.gz"
+    pypi = "vl_convert_python/vl_convert_python-1.4.0.tar.gz"
 
-    version("1.3.0", sha256="de1462151dfbba7b2a17881dac1d2269662012c252f1e9d1537a4daed5e36067")
-    version("0.13.1", sha256="d70a608257dd6b5b782d96cccebfe7289992e522e47a8bebb7d928253ca8b396")
+    version(
+        "1.4.0",
+        sha256="264d6f2338c7d3474e60c6907cca016b880b0c1c9be302bb84abc6690188a7e9",
+        deprecated=True,
+    )
+    version(
+        "1.3.0",
+        sha256="de1462151dfbba7b2a17881dac1d2269662012c252f1e9d1537a4daed5e36067",
+        deprecated=True,
+    )
+    version(
+        "0.13.1",
+        sha256="d70a608257dd6b5b782d96cccebfe7289992e522e47a8bebb7d928253ca8b396",
+        deprecated=True,
+    )
 
     depends_on("python@3.7:", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/py-vl-convert-python/package.py
+++ b/var/spack/repos/builtin/packages/py-vl-convert-python/package.py
@@ -12,10 +12,7 @@ class PyVlConvertPython(PythonPackage):
     homepage = "https://github.com/vega/vl-convert"
     pypi = "vl_convert_python/vl_convert_python-1.4.0.tar.gz"
 
-    version(
-        "1.4.0",
-        sha256="264d6f2338c7d3474e60c6907cca016b880b0c1c9be302bb84abc6690188a7e9",
-    )
+    version("1.4.0", sha256="264d6f2338c7d3474e60c6907cca016b880b0c1c9be302bb84abc6690188a7e9")
 
     version(
         "1.3.0",

--- a/var/spack/repos/builtin/packages/py-vl-convert-python/package.py
+++ b/var/spack/repos/builtin/packages/py-vl-convert-python/package.py
@@ -12,7 +12,11 @@ class PyVlConvertPython(PythonPackage):
     homepage = "https://github.com/vega/vl-convert"
     pypi = "vl_convert_python/vl_convert_python-1.4.0.tar.gz"
 
-    version("1.4.0", sha256="264d6f2338c7d3474e60c6907cca016b880b0c1c9be302bb84abc6690188a7e9")
+    version(
+        "1.4.0",
+        sha256="264d6f2338c7d3474e60c6907cca016b880b0c1c9be302bb84abc6690188a7e9",
+    )
+
     version(
         "1.3.0",
         sha256="de1462151dfbba7b2a17881dac1d2269662012c252f1e9d1537a4daed5e36067",


### PR DESCRIPTION
1. set version to 1.4.0
2. set version 1.3.0 deprecated since its rust dependency curve@4.1.1 is not able to compile

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
