### PR TITLE
hip@6.1: fix reference to hsa-rocr-dev so it works when externally de…

### DIFF
--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -413,7 +413,7 @@ class Hip(CMakePackage):
             if self.spec.satisfies("@5.4:"):
                 env.set("HIPIFY_CLANG_PATH", paths["hipify-clang"])
             if self.spec.satisfies("@6.1:"):
-                env.prepend_path("LD_LIBRARY_PATH", self.spec["hsa-rocr-dev"].prefix.lib)
+                env.prepend_path("LD_LIBRARY_PATH", paths["hsa-rocr-dev"].lib)
 
             # hipcc recognizes HIP_PLATFORM == hcc and HIP_COMPILER == clang, even
             # though below we specified HIP_PLATFORM=rocclr and HIP_COMPILER=clang


### PR DESCRIPTION
`hsa-rocr-dev` path needs to be accessed differently to work when it is externally defined.

This should address issue identified:
* https://github.com/spack/spack/pull/44449
* https://github.com/spack/spack/pull/44449#issuecomment-2143980786