### PR TITLE
hugo: add v0.126.3

### DIFF
--- a/var/spack/repos/builtin/packages/hugo/package.py
+++ b/var/spack/repos/builtin/packages/hugo/package.py
@@ -20,6 +20,7 @@ class Hugo(Package):
 
     license("Apache-2.0")
 
+    version("0.126.3", sha256="2a1d65b09884e3c57a8705db99487404856c947dd847cf7bb845e0e1825b33ec")
     version("0.118.2", sha256="915d7dcb44fba949c80858f9c2a55a11256162ba28a9067752f808cfe8faedaa")
     version("0.112.7", sha256="d706e52c74f0fb00000caf4e95b98e9d62c3536a134d5e26b433b1fa1e2a74aa")
     version("0.111.3", sha256="b6eeb13d9ed2e5d5c6895bae56480bf0fec24a564ad9d17c90ede14a7b240999")


### PR DESCRIPTION
Add updated hugo release 0.126.3

Tested on Centos 7 w/ gcc 8.4.0