### PR TITLE
proj@7: support the new tiff interface in `cmake@3.19:`

### DIFF
--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -93,6 +93,7 @@ class Proj(CMakePackage, AutotoolsPackage):
         # to be compatible with this "new" interface
         # patch replaces the TIFF_LIBRARY variable (no longer used) with TIFF_LIBRARIES
         patch("proj-8.1-cmake-3.29-new-tiff-interface.patch", when="+tiff @8:9.1.0 ^cmake@3.19:")
+        patch("proj-7-cmake-3.29-new-tiff-interface.patch", when="+tiff @7 ^cmake@3.19:")
         patch("proj.cmakelists.5.0.patch", when="@5.0")
         patch("proj.cmakelists.5.1.patch", when="@5.1:5.2")
         conflicts("cmake@3.19:", when="@:7")

--- a/var/spack/repos/builtin/packages/proj/proj-7-cmake-3.29-new-tiff-interface.patch
+++ b/var/spack/repos/builtin/packages/proj/proj-7-cmake-3.29-new-tiff-interface.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lib_proj.cmake b/src/lib_proj.cmake
+index cf30734e5779b102dac3e72ac13962687f6e376e..b2f42c13bc43b6cf5475965c2ce0077daefc47e2 100644
+--- a/src/lib_proj.cmake
++++ b/src/lib_proj.cmake
+@@ -420,7 +420,7 @@ target_link_libraries(${PROJ_CORE_TARGET} ${SQLITE3_LIBRARY})
+ if(TIFF_ENABLED)
+   target_compile_definitions(${PROJ_CORE_TARGET} PRIVATE -DTIFF_ENABLED)
+   target_include_directories(${PROJ_CORE_TARGET} PRIVATE ${TIFF_INCLUDE_DIR})
+-  target_link_libraries(${PROJ_CORE_TARGET} ${TIFF_LIBRARY})
++  target_link_libraries(${PROJ_CORE_TARGET} ${TIFF_LIBRARIES})
+ endif()
+ 
+ if(CURL_ENABLED)


### PR DESCRIPTION
This PR adds a patch for `proj@7` to support the new TIFF interface in `cmake@3.19:`. 

This PR compliments the existing patch that targets `proj@8:`. Previously, the `@8:` patch incorrectly targeted `proj@7:` which I removed in #44367. 

This PR also resolves the review from @johnwparent in #42767 