### PR TITLE
kallisto: add version 0.50.1

### DIFF
--- a/var/spack/repos/builtin/packages/kallisto/package.py
+++ b/var/spack/repos/builtin/packages/kallisto/package.py
@@ -15,12 +15,14 @@ class Kallisto(CMakePackage):
 
     license("BSD-2-Clause")
 
+    version("0.50.1", sha256="030752bab3b0e33cd3f23f6d8feddd74194e5513532ffbf23519e84db2a86d34")
     version("0.48.0", sha256="1797ac4d1f0771e3f1f25dd7972bded735fcb43f853cf52184d3d9353a6269b0")
     version("0.46.2", sha256="c447ca8ddc40fcbd7d877d7c868bc8b72807aa8823a8a8d659e19bdd515baaf2")
     version("0.43.1", sha256="7baef1b3b67bcf81dc7c604db2ef30f5520b48d532bf28ec26331cb60ce69400")
 
     # HDF5 support is optional beginning with version 0.46.2.
     variant("hdf5", when="@0.46.2:", default=False, description="Build with HDF5 support")
+    variant("bam", when="@0.50.1:", default=False, description="Build with htslib support")
 
     depends_on("zlib-api")
     depends_on("hdf5", when="@:0.43")
@@ -38,7 +40,7 @@ class Kallisto(CMakePackage):
 
     patch("link_zlib.patch", when="@:0.43")
     patch("limits.patch", when="@:0.46")
-    patch("htslib_configure.patch", when="@0.44.0:^autoconf@2.70:")
+    patch("htslib_configure.patch", when="@0.44.0:0.48.0^autoconf@2.70:")
 
     @run_before("cmake")
     def autoreconf(self):
@@ -64,6 +66,8 @@ class Kallisto(CMakePackage):
             args = [i for i in a if i != "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"]
             if self.spec.satisfies("@0.46.2:"):
                 args.append(self.define_from_variant("USE_HDF5", "hdf5"))
+            if self.spec.satisifes("@0.50.1:"):
+                args.append(self.define_from_variant("USE_BAM", "bam"))
         else:
             args = a
 


### PR DESCRIPTION
Version bump mostly, but they have also added a cmake variable to control building with (a bundled) htslib.