### PR TITLE
libtiff: add v4.6.0 and default disable opengl (Fixes #44545)

### DIFF
--- a/var/spack/repos/builtin/packages/libtiff/package.py
+++ b/var/spack/repos/builtin/packages/libtiff/package.py
@@ -40,6 +40,7 @@ class Libtiff(CMakePackage, AutotoolsPackage):
 
     license("libtiff")
 
+    version("4.6.0", sha256="88b3979e6d5c7e32b50d7ec72fb15af724f6ab2cbf7e10880c360a77e4b5d99a")
     version("4.5.1", sha256="d7f38b6788e4a8f5da7940c5ac9424f494d8a79eba53d555f4a507167dca5e2b")
     version("4.5.0", sha256="c7a1d9296649233979fa3eacffef3fa024d73d05d589cb622727b5b08c423464")
     version("4.4.0", sha256="917223b37538959aca3b790d2d73aa6e626b688e02dcda272aec24c2f498abed")
@@ -54,6 +55,9 @@ class Libtiff(CMakePackage, AutotoolsPackage):
     version("4.0.5", sha256="e25eaa83ed7fab43ddd278b9b14d91a406a4b674cedc776adb95535f897f309c")
     version("4.0.4", sha256="8cb1d90c96f61cdfc0bcf036acc251c9dbe6320334da941c7a83cfe1576ef890")
     version("3.9.7", sha256="f5d64dd4ce61c55f5e9f6dc3920fbe5a41e02c2e607da7117a35eb5c320cef6a")
+
+    # GUI
+    variant("opengl", default=False, description="build tiffgt viewer", when="@4.5:")
 
     # Internal codecs
     variant("ccitt", default=True, description="support for CCITT Group 3 & 4 algorithms")
@@ -118,6 +122,7 @@ class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
         args = [self.define_from_variant(var) for var in VARIANTS]
         args.append("-Dsphinx=OFF")
+        args += [self.define_from_variant("tiff-opengt", "opengl")]
         args += [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]
         args += [self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic")]
 

--- a/var/spack/repos/builtin/packages/libtiff/package.py
+++ b/var/spack/repos/builtin/packages/libtiff/package.py
@@ -57,7 +57,7 @@ class Libtiff(CMakePackage, AutotoolsPackage):
     version("3.9.7", sha256="f5d64dd4ce61c55f5e9f6dc3920fbe5a41e02c2e607da7117a35eb5c320cef6a")
 
     # GUI
-    variant("opengl", default=False, description="build tiffgt viewer", when="@4.5:")
+    variant("opengl", default=False, description="use OpenGL (required for tiffgt viewer)", when="@4.5,4.7:")
 
     # Internal codecs
     variant("ccitt", default=True, description="support for CCITT Group 3 & 4 algorithms")

--- a/var/spack/repos/builtin/packages/libtiff/package.py
+++ b/var/spack/repos/builtin/packages/libtiff/package.py
@@ -145,6 +145,7 @@ class AutotoolsBuilder(AutotoolsBuilder):
 
         args.append("--disable-sphinx")
 
+        args.extend(self.enable_or_disable("opengl"))
         args.extend(self.enable_or_disable("shared"))
         args.extend(self.with_or_without("pic"))
 

--- a/var/spack/repos/builtin/packages/libtiff/package.py
+++ b/var/spack/repos/builtin/packages/libtiff/package.py
@@ -122,7 +122,7 @@ class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
         args = [self.define_from_variant(var) for var in VARIANTS]
         args.append("-Dsphinx=OFF")
-        args += [self.define_from_variant("tiff-opengt", "opengl")]
+        args += [self.define_from_variant("tiff-opengl", "opengl")]
         args += [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]
         args += [self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic")]
 

--- a/var/spack/repos/builtin/packages/libtiff/package.py
+++ b/var/spack/repos/builtin/packages/libtiff/package.py
@@ -57,7 +57,12 @@ class Libtiff(CMakePackage, AutotoolsPackage):
     version("3.9.7", sha256="f5d64dd4ce61c55f5e9f6dc3920fbe5a41e02c2e607da7117a35eb5c320cef6a")
 
     # GUI
-    variant("opengl", default=False, description="use OpenGL (required for tiffgt viewer)", when="@4.5,4.7:")
+    variant(
+        "opengl",
+        default=False,
+        description="use OpenGL (required for tiffgt viewer)",
+        when="@4.5,4.7:",
+    )
 
     # Internal codecs
     variant("ccitt", default=True, description="support for CCITT Group 3 & 4 algorithms")


### PR DESCRIPTION
Fixes #44545 