### PR TITLE
openmpi@5: Fix fortran linker incompatibility with `%apple-clang@15`

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -986,6 +986,11 @@ class Openmpi(AutotoolsPackage, CudaPackage):
         spec = self.spec
         config_args = ["--enable-shared", "--disable-silent-rules", "--disable-sphinx"]
 
+        # Work around incompatibility with new apple-clang linker
+        # https://github.com/open-mpi/ompi/issues/12427
+        if spec.satisfies("@5: %apple-clang@15:"):
+            config_args.append("--with-wrapper-fcflags=-Wl,-ld_classic")
+
         # All rpath flags should be appended with self.compiler.cc_rpath_arg.
         # Later, we might need to update share/openmpi/mpic++-wrapper-data.txt
         # and mpifort-wrapper-data.txt (see filter_rpaths()).


### PR DESCRIPTION
When linking fortran code with `openmpi@5` the following type of error is raised

```
 ld: warning: -commons use_dylibs is no longer supported, using error treatment instead
     1542    ld: warning: duplicate -rpath '/Users/cmarsh/Documents/science/code/spack/opt/spack/darwin-sonoma-m1/gcc-14.1.0/gcc-14.1.0-coujsgwsxtrfjh7nanahdmng7s4ymdok/lib' ignored
     1543    ld: common symbol '_mpi_fortran_argv_null_' from '/Users/cmarsh/Documents/science/code/spack/stage/spack-stage-arpack-ng-3.9.0-gn4ydyregyv2ypilvlpr6ivdnwwmyhgt/spack-build-gn4ydyr/CMakeFiles/parpack.dir/PARPACK/SRC/MPI/pcgetv0.f.o' conflic
             ts with definition from dylib '_mpi_fortran_argv_null_' from '/Users/cmarsh/Documents/science/code/spack/opt/spack/darwin-sonoma-m1/apple-clang-15.0.0/openmpi-5.0.3-qi3xrlef3htzl54ag7u4xnlije5ekekj/lib/libmpi_usempi_ignore_tkr.40.dylib'
  >> 1544    collect2: error: ld returned 1 exit status
  >> 1545    make[2]: *** [CMakeFiles/parpack.dir/build.make:1110: lib/libparpack.2.1.0.dylib] Error 1
```

This is reported upstream 
https://github.com/open-mpi/ompi/issues/12427

and is related to apple-clang linker changes. 

This patch applies a work around that enables the classic linker for the fortran wrapper. The problem only applies to fortran code and this PR follows what is done in homebrew (https://github.com/Homebrew/homebrew-core/blob/master/Formula/o/open-mpi.rb#L82)