### PR TITLE
openblas: add v0.3.27

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -26,6 +26,7 @@ class Openblas(CMakePackage, MakefilePackage):
     license("BSD-3-Clause")
 
     version("develop", branch="develop")
+    version("0.3.27", sha256="aa2d68b1564fe2b13bc292672608e9cdeeeb6dc34995512e65c3b10f4599e897")
     version("0.3.26", sha256="4e6e4f5cb14c209262e33e6816d70221a2fe49eb69eaf0a06f065598ac602c68")
     version("0.3.25", sha256="4c25cb30c4bb23eddca05d7d0a85997b8db6144f5464ba7f8c09ce91e2f35543")
     version("0.3.24", sha256="ceadc5065da97bd92404cac7254da66cc6eb192679cf1002098688978d4d5132")


### PR DESCRIPTION
OpenBLAS v0.3.27 is available but not yet in package.py, this adds it as the default.  

v0.3.26 failed to build past the unit tests with the Arm compiler, this 0.3.27 release fixes that - amongst many other changes (https://github.com/OpenMathLib/OpenBLAS/releases/tag/v0.3.27)  
