### PR TITLE
Armadillo: fix for linker error with apple-clang 15

### DIFF
--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -42,7 +42,6 @@ class Armadillo(CMakePackage):
     # platform's compiler is adding `#define linux 1`.
     patch("undef_linux.patch", when="platform=linux")
 
-
     def flag_handler(self, name, flags):
         spec = self.spec
         if name == "ldflags":
@@ -50,7 +49,6 @@ class Armadillo(CMakePackage):
                 flags.append("-Wl,-ld_classic")
 
         return (flags, None, None)
-
 
     def patch(self):
         # Do not include Find{BLAS_type} because we are specifying the

--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -42,6 +42,16 @@ class Armadillo(CMakePackage):
     # platform's compiler is adding `#define linux 1`.
     patch("undef_linux.patch", when="platform=linux")
 
+
+    def flag_handler(self, name, flags):
+        spec = self.spec
+        if name == "ldflags":
+            if spec.satisfies("%apple-clang@15:"):
+                flags.append("-Wl,-ld_classic")
+
+        return (flags, None, None)
+
+
     def patch(self):
         # Do not include Find{BLAS_type} because we are specifying the
         # BLAS/LAPACK libraries explicitly.


### PR DESCRIPTION
The updated linker behaviour in `apple-clang@15` causes armadillo to not compile:

```
[...]
ld: duplicate LC_RPATH '/Users/cmarsh/Documents/science/code/spack/opt/spack/darwin-sonoma-m1/gcc-14.1.0/gcc-14.1.0-coujsgwsxtrfjh7nanahdmng7s4ymdok/lib' in '/Users/cmarsh/Documents/science/code/spack/opt/spack/darwin-sonoma-m1/apple-clang-15.0.0/arpack-ng-3.9.0-u7uhy6bgk6k5phbp5mzdtanqy7m4nmia/lib/libparpack.2.1.0.dylib'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [CMakeFiles/armadillo.dir/build.make:119: libarmadillo.12.8.2.dylib] Error 1
make[2]: Leaving directory '/Users/cmarsh/Documents/science/code/spack/stage/spack-stage-armadillo-12.8.2-lmmxhfqpvbkalmn2mfgfb4gdxj6ysqev/spack-build-lmmxhfq'
make[1]: *** [CMakeFiles/Makefile2:103: CMakeFiles/armadillo.dir/all] Error 2
make[1]: Leaving directory '/Users/cmarsh/Documents/science/code/spack/stage/spack-stage-armadillo-12.8.2-lmmxhfqpvbkalmn2mfgfb4gdxj6ysqev/spack-build-lmmxhfq'
make: *** [Makefile:149: all] Error 2
```

This uses the classic linker flag to ensure this compatibility 