### PR TITLE
flux-core: add 0.62.0 -> 0.63.0

### DIFF
--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -22,6 +22,8 @@ class FluxCore(AutotoolsPackage):
     license("LGPL-3.0-only")
 
     version("master", branch="master")
+    version("0.63.0", sha256="f0fd339f0e24cb26331ad55062d3c1e1c7c81df41c0d7f8727aa0700c7baa1ae")
+    version("0.62.0", sha256="54a227741901ca758236c024296b8cd53718eea0050fc6363d2b2979aa0bf1e9")
     version("0.61.2", sha256="06f38143723e3f8331f55893ad8f74d43eb0588078f91abb603690c3e5f5112c")
     version("0.61.1", sha256="59cc730b34b732a1d00355bb5589bf2d26bf522b4a31ebfabff70ddb3afb51d6")
     version("0.61.0", sha256="02cedc6abb12816cbb01f2195c1acf7b6552c1d8b9029f899148df48a7cd05e2")


### PR DESCRIPTION
The updates for each version are seriously impressive - just so many things!

- https://flux-framework.org/release/2024/06/05/flux-core-0.63.0.html
- https://flux-framework.org/release/2024/05/08/flux-core-0.62.0.html

I must have missed opening for 0.62.0, unless it got lost somewhere (totally possible).