### PR TITLE
thrust: add 1.17 package versions

### DIFF
--- a/var/spack/repos/builtin/packages/thrust/package.py
+++ b/var/spack/repos/builtin/packages/thrust/package.py
@@ -6,15 +6,22 @@
 from spack.package import *
 
 
-class Thrust(Package):
+class Thrust(Package, CMakePackage):
     """Thrust is a parallel algorithms library
     which resembles the C++ Standard Template Library (STL)."""
 
     homepage = "https://thrust.github.io"
     url = "https://github.com/NVIDIA/thrust/archive/1.12.0.tar.gz"
+    git = "https://github.com/NVIDIA/thrust.git"
 
     license("BSL-1.0")
 
+    # to support CMake build system package installation, Thrust
+    # submodules must be downloaded, which aren't included in tarballs
+    version("1.17.2", commit="1ac51f2b6219ff17d15d93f2e0be85038556f346", submodules=True)
+    version("1.17.1", commit="4dd337f41622f5624359d6a958e3cb6ac7c6f57e", submodules=True)
+    version("1.17.0", commit="6a3078c64cab0e2f276340fa5dcafa0d758ed890", submodules=True)
+    # versions prior to 1.17 install from tarballs
     version("1.16.0", sha256="93b9553e3ee544e05395022bea67e6d600f8f3eb680950ec7cf73c0f55162487")
     version("1.15.0", sha256="0eeaf5a77cd7cb143f3443bd96b215ae1c4eacf18a712762e6a5c85213f80cc2")
     version("1.14.0", sha256="ddba9f3ed47b1a33562a4aea2d000a2ca2abcd45ff760af12aa81b8b7e492962")
@@ -45,7 +52,30 @@ class Thrust(Package):
     version("1.8.3", sha256="2254200512fde7f4fd0fc74306286e192ea6ac9037576dbd31309c0579229dbb")
     version("1.8.2", sha256="83bc9e7b769daa04324c986eeaf48fcb53c2dda26bcc77cb3c07f4b1c359feb8")
 
-    def install(self, spec, prefix):
+    # leave the build system of pre-1.17 as originally implemented,
+    # but use CMake for newer versions
+    build_system(
+        conditional("cmake", when="@1.17:"), conditional("generic", when="@:1.16"), default="cmake"
+    )
+
+    # minimum CMake version is 3.15 for plain package installation (no
+    # examples, tests, etc)
+    depends_on("cmake@3.15:", when="@1.17:", type="build")
+
+
+class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+    def cmake_args(self):
+        return [
+            self.define("THRUST_ENABLE_HEADER_TESTING", "OFF"),
+            self.define("THRUST_ENABLE_TESTING", "OFF"),
+            self.define("THRUST_ENABLE_EXAMPLES", "OFF"),
+            self.define("THRUST_ENABLE_BENCHMARKS", "OFF"),
+            self.define("THRUST_INCLUDE_CUB_CMAKE", "OFF"),
+        ]
+
+
+class GenericBuilder(spack.build_systems.generic.GenericBuilder):
+    def install(self, pkg, spec, prefix):
         install_tree("doc", join_path(prefix, "doc"))
         install_tree("examples", join_path(prefix, "examples"))
         install_tree("thrust", join_path(prefix, "include", "thrust"))


### PR DESCRIPTION
Note that the new package versions use the CMake build system, which provides the canonical Thrust installation (replacing the simple copying of source directories to the installation directory in prior versions).

I did not add versions in the v2 series, as I have no need for those versions currently. I don't know much about Thrust, but have a need to use v1.17 as a dependency of another package. I suppose that the newer versions could be added similarly using the CMake build system. I tested installations of v1.17.{0,1,2} and also v1.16.0.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
