### PR TITLE
Add with-lsf-libdir switch to OpenMPI

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -1038,6 +1038,11 @@ class Openmpi(AutotoolsPackage, CudaPackage):
         if "schedulers=auto" not in spec:
             config_args.extend(self.with_or_without("schedulers"))
 
+        if spec.satisfies("schedulers=lsf"):
+            config_args.append(
+                "--with-lsf-libdir={0}".format(spec["lsf"].libs.directories[0])
+            )
+
         config_args.extend(self.enable_or_disable("memchecker"))
         if spec.satisfies("+memchecker"):
             config_args.extend(["--enable-debug"])

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -1039,9 +1039,7 @@ class Openmpi(AutotoolsPackage, CudaPackage):
             config_args.extend(self.with_or_without("schedulers"))
 
         if spec.satisfies("schedulers=lsf"):
-            config_args.append(
-                "--with-lsf-libdir={0}".format(spec["lsf"].libs.directories[0])
-            )
+            config_args.append("--with-lsf-libdir={0}".format(spec["lsf"].libs.directories[0]))
 
         config_args.extend(self.enable_or_disable("memchecker"))
         if spec.satisfies("+memchecker"):


### PR DESCRIPTION
As outlined in #44255, I've been struggling with getting OpenMPI compile with LSF support on a RHEL systems. Adding `--with-lsf-libdir` seems to solve my issue.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
