### PR TITLE
vtk: add python version dependencies and remove broken builds

### DIFF
--- a/var/spack/repos/builtin/packages/memsurfer/package.py
+++ b/var/spack/repos/builtin/packages/memsurfer/package.py
@@ -35,7 +35,7 @@ class Memsurfer(PythonPackage):
     depends_on("cgal@4.13 +shared~core~demos~imageio")
 
     # vtk needs to know whether to build with mesa or opengl
-    depends_on("vtk@8.1.2 ~ffmpeg~mpi+opengl2~qt~xdmf+python")
+    depends_on("vtk@8.1.2: ~ffmpeg~mpi+opengl2~qt~xdmf+python")
 
     # memsurfer's setup needs path to these deps to build extension modules
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/py-mne/package.py
+++ b/var/spack/repos/builtin/packages/py-mne/package.py
@@ -91,7 +91,11 @@ class PyMne(PythonPackage):
         depends_on("py-psutil", type=("build", "run"))
         depends_on("py-dipy@0.10.1:", type=("build", "run"))  # *
         depends_on("vtk+python", type=("build", "run"))
-        depends_on("vtk+python@:8.1", when="platform=darwim", type=("build", "run"))
+        # Since #36408 (in January 2024), vtk@:8.1 could not be built because
+        # it replaced depends_on("netcdf-cxx") with "netcdf-cxx4" and that
+        # introduced a KeyError that would have to be fixed with the PR,
+        # but was never done.
+        # depends_on("vtk+python@:8.1", when="platform=darwim", type=("build", "run"))
         depends_on("py-mayavi", type=("build", "run"))
         depends_on("py-pysurfer+save_movie", type=("build", "run"))
         depends_on("py-nilearn", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -24,11 +24,7 @@ class Vtk(CMakePackage):
 
     license("BSD-3-Clause")
 
-    version(
-        "9.3.1",
-        sha256="8354ec084ea0d2dc3d23dbe4243823c4bfc270382d0ce8d658939fd50061cab8",
-        preferred=True,
-    )
+    version("9.3.1", sha256="8354ec084ea0d2dc3d23dbe4243823c4bfc270382d0ce8d658939fd50061cab8")
     version("9.2.6", sha256="06fc8d49c4e56f498c40fcb38a563ed8d4ec31358d0101e8988f0bb4d539dd12")
     version("9.2.2", sha256="1c5b0a2be71fac96ff4831af69e350f7a0ea3168981f790c000709dcf9121075")
     version("9.1.0", sha256="8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96")
@@ -54,8 +50,8 @@ class Vtk(CMakePackage):
     version("6.3.0", sha256="92a493354c5fa66bea73b5fc014154af5d9f3f6cee8d20a826f4cd5d4b0e8a5e")
     version("6.1.0", sha256="bd7df10a479606d529a8b71f466c44a2bdd11fd534c62ce0aa44fad91883fa34")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     # VTK7 defaults to OpenGL2 rendering backend
     variant("opengl2", default=True, description="Enable OpenGL2 backend")
@@ -94,6 +90,9 @@ class Vtk(CMakePackage):
         depends_on("python@:3.8", when="@:8.2.1a", type=("build", "run"))
         # Python 3.10 support from vtk 9.2
         depends_on("python@:3.9", when="@:9.1", type=("build", "run"))
+        depends_on("python@:3.10", when="@:9.2", type=("build", "run"))
+        # Python 3.12 support from vtk 9.3
+        depends_on("python@:3.12", when="@:9.3", type=("build", "run"))
 
     # We need mpi4py if buidling python wrappers and using MPI
     depends_on("py-mpi4py", when="+python+mpi", type="run")
@@ -298,7 +297,6 @@ class Vtk(CMakePackage):
             cmake_args.extend(
                 [
                     "-DVTK_USE_EXTERNAL:BOOL=ON",
-                    "-DVTK_MODULE_USE_EXTERNAL_VTK_fast_float:BOOL=OFF",
                     "-DVTK_MODULE_USE_EXTERNAL_VTK_libharu:BOOL=OFF",
                     "-DVTK_MODULE_USE_EXTERNAL_VTK_pegtl:BOOL=OFF",
                     "-DHDF5_ROOT={0}".format(spec["hdf5"].prefix),
@@ -314,6 +312,8 @@ class Vtk(CMakePackage):
                 )
             if spec.satisfies("@9.2:"):
                 cmake_args.append("-DVTK_MODULE_USE_EXTERNAL_VTK_verdict:BOOL=OFF")
+            if spec.satisfies("@9.3:"):
+                cmake_args.append("-DVTK_MODULE_USE_EXTERNAL_VTK_fast_float:BOOL=OFF")
 
         # Some variable names have changed
         if spec.satisfies("@8.2.0"):

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -41,13 +41,6 @@ class Vtk(CMakePackage):
         sha256="34c3dc775261be5e45a8049155f7228b6bd668106c72a3c435d95730d17d57bb",
     )
     version("8.2.0", sha256="34c3dc775261be5e45a8049155f7228b6bd668106c72a3c435d95730d17d57bb")
-    version("8.1.2", sha256="0995fb36857dd76ccfb8bb07350c214d9f9099e80b1e66b4a8909311f24ff0db")
-    version("8.1.1", sha256="71a09b4340f0a9c58559fe946dc745ab68a866cf20636a41d97b6046cb736324")
-    version("8.1.0", sha256="6e269f07b64fb13774f5925161fb4e1f379f4e6a0131c8408c555f6b58ef3cb7")
-    version("8.0.1", sha256="49107352923dea6de05a7b4c3906aaf98ef39c91ad81c383136e768dcf304069")
-    version("7.1.0", sha256="5f3ea001204d4f714be972a810a62c0f2277fbb9d8d2f8df39562988ca37497a")
-    version("7.0.0", sha256="78a990a15ead79cdc752e86b83cfab7dbf5b7ef51ba409db02570dbdd9ec32c3")
-    version("6.3.0", sha256="92a493354c5fa66bea73b5fc014154af5d9f3f6cee8d20a826f4cd5d4b0e8a5e")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -317,18 +310,6 @@ class Vtk(CMakePackage):
         # Some variable names have changed
         if spec.satisfies("@8.2.0"):
             cmake_args.append("-DVTK_USE_SYSTEM_PUGIXML:BOOL=OFF")
-        elif spec.satisfies("@:8.1"):
-            # Note: Since #36408 (in January 2024), @:8.1 could not be built because
-            # it replaced depends_on("netcdf-cxx") with "netcdf-cxx4", below is
-            # an attept to make it work again, but really the qestion is that as
-            # since the release of spack-0.22 in May 2024, nobody could build these
-            # versions, could we remove them instead?
-            cmake_args.extend(
-                [
-                    "-DVTK_USE_SYSTEM_LIBPROJ4:BOOL=OFF",
-                    "-DNETCDF_CXX_ROOT={0}".format(spec["netcdf-cxx4"].prefix),
-                ]
-            )
 
         if "+mpi" in spec:
             if spec.satisfies("@:8.2.0"):

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -48,7 +48,6 @@ class Vtk(CMakePackage):
     version("7.1.0", sha256="5f3ea001204d4f714be972a810a62c0f2277fbb9d8d2f8df39562988ca37497a")
     version("7.0.0", sha256="78a990a15ead79cdc752e86b83cfab7dbf5b7ef51ba409db02570dbdd9ec32c3")
     version("6.3.0", sha256="92a493354c5fa66bea73b5fc014154af5d9f3f6cee8d20a826f4cd5d4b0e8a5e")
-    version("6.1.0", sha256="bd7df10a479606d529a8b71f466c44a2bdd11fd534c62ce0aa44fad91883fa34")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -466,41 +465,6 @@ class Vtk(CMakePackage):
                 cmake_args.extend(["-DVTK_USE_X:BOOL=ON", "-DVTK_USE_COCOA:BOOL=OFF"])
 
         compile_flags = []
-
-        if spec.satisfies("@:6.1.0"):
-            # Note: Since #36408 (in January 2024), @6.1.0 could not be built because
-            # it replaced depends_on("netcdf-cxx") with "netcdf-cxx4", below is
-            # an attept to make it work again, but really the qestion is that as
-            # since the release of spack-0.22 in May 2024, nobody could build this
-            # version, could we remove it instead?
-            compile_flags.append("-DGLX_GLXEXT_LEGACY")
-
-            # VTK 6.1.0 (and possibly earlier) does not use
-            # NETCDF_CXX_ROOT to detect NetCDF C++ bindings, so
-            # NETCDF_CXX_INCLUDE_DIR and NETCDF_CXX_LIBRARY must be
-            # used instead to detect these bindings
-            netcdf_cxx_lib = spec["netcdf-cxx4"].libs.joined()
-            cmake_args.extend(
-                [
-                    "-DNETCDF_CXX_INCLUDE_DIR={0}".format(spec["netcdf-cxx4"].prefix.include),
-                    "-DNETCDF_CXX_LIBRARY={0}".format(netcdf_cxx_lib),
-                ]
-            )
-
-            # Garbage collection is unsupported in Xcode starting with
-            # version 5.1; if the Apple clang version of the compiler
-            # is 5.1.0 or later, unset the required Objective-C flags
-            # to remove the garbage collection flags.  Versions of VTK
-            # after 6.1.0 set VTK_REQUIRED_OBJCXX_FLAGS to the empty
-            # string. This fix was recommended on the VTK mailing list
-            # in March 2014 (see
-            # https://public.kitware.com/pipermail/vtkusers/2014-March/083368.html)
-            if self.spec.satisfies("%apple-clang@5.1.0:"):
-                cmake_args.extend(["-DVTK_REQUIRED_OBJCXX_FLAGS="])
-
-            # A bug in tao pegtl causes build failures with intel compilers
-            if "%intel" in spec and spec.version >= Version("8.2"):
-                cmake_args.append("-DVTK_MODULE_ENABLE_VTK_IOMotionFX:BOOL=OFF")
 
         # -no-ipo prevents an internal compiler error from multi-file
         # optimization (https://github.com/spack/spack/issues/20471)

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -319,10 +319,15 @@ class Vtk(CMakePackage):
         if spec.satisfies("@8.2.0"):
             cmake_args.append("-DVTK_USE_SYSTEM_PUGIXML:BOOL=OFF")
         elif spec.satisfies("@:8.1"):
+            # Note: Since #36408 (in January 2024), @:8.1 could not be built because
+            # it replaced depends_on("netcdf-cxx") with "netcdf-cxx4", below is
+            # an attept to make it work again, but really the qestion is that as
+            # since the release of spack-0.22 in May 2024, nobody could build these
+            # versions, could we remove them instead?
             cmake_args.extend(
                 [
                     "-DVTK_USE_SYSTEM_LIBPROJ4:BOOL=OFF",
-                    "-DNETCDF_CXX_ROOT={0}".format(spec["netcdf-cxx"].prefix),
+                    "-DNETCDF_CXX_ROOT={0}".format(spec["netcdf-cxx4"].prefix),
                 ]
             )
 
@@ -463,16 +468,21 @@ class Vtk(CMakePackage):
         compile_flags = []
 
         if spec.satisfies("@:6.1.0"):
+            # Note: Since #36408 (in January 2024), @6.1.0 could not be built because
+            # it replaced depends_on("netcdf-cxx") with "netcdf-cxx4", below is
+            # an attept to make it work again, but really the qestion is that as
+            # since the release of spack-0.22 in May 2024, nobody could build this
+            # version, could we remove it instead?
             compile_flags.append("-DGLX_GLXEXT_LEGACY")
 
             # VTK 6.1.0 (and possibly earlier) does not use
             # NETCDF_CXX_ROOT to detect NetCDF C++ bindings, so
             # NETCDF_CXX_INCLUDE_DIR and NETCDF_CXX_LIBRARY must be
             # used instead to detect these bindings
-            netcdf_cxx_lib = spec["netcdf-cxx"].libs.joined()
+            netcdf_cxx_lib = spec["netcdf-cxx4"].libs.joined()
             cmake_args.extend(
                 [
-                    "-DNETCDF_CXX_INCLUDE_DIR={0}".format(spec["netcdf-cxx"].prefix.include),
+                    "-DNETCDF_CXX_INCLUDE_DIR={0}".format(spec["netcdf-cxx4"].prefix.include),
                     "-DNETCDF_CXX_LIBRARY={0}".format(netcdf_cxx_lib),
                 ]
             )


### PR DESCRIPTION
Update: Copied this here to start a new PR based on it: https://github.com/bernhardkaindl/spack/pull/1

----
Updated message by @bernhardkaindl:

I Updated the PR to resolve the conflict, because #44966 added vtk@9.3.1 meanwhile.

@bernhardkaindl also added more commits in order to raise more questions:
- Since #36408 (in January 2024), `vtk@:8.1` could not be built because #36408 replaced `depends_on("netcdf-cxx")` with `netcdf-cxx4` and that introduced a `KeyError` in uses of `spec["netcdf-cxx"]`. That means those versions cannot not be built in the `spack-0.22` release done in May as well. As nobody reported this issue, since January, I think nobody needed those versions, and I guess they may be removed.

Explanation:

`vtk@@8.1` could not be built since the release of spack-0.22 in May 2024 because in January 2024, #36408 renamed the `depends_on("netcdf-cxx")` to `netcdf-cxx4`, which means that `netcdf-cxx` is not longer in the spec and that caused that since then, 
```py
"-DNETCDF_CXX_ROOT={0}".format(spec["netcdf-cxx"].prefix),
```
and
```py
"-DNETCDF_CXX_INCLUDE_DIR={0}".format(spec["netcdf-cxx4"].prefix.include),
```
raised `KeyError` and these lines were used for `vtk@:8.1` so none of those could be built since then. It appears that nobody needed those versions or else there would have been an issue or an PR about it. Therefore, it appears like this was like (in effect) a deprecation of these old verions as to build them, you had to research the issue and apply the fix (and not submit it as a PR). So I think these versions can be removed.

If the support for these versions should be re-instated instead, just drop (`git reset --hard HEAD~`) the last commit from this PR branch.


- An initial commit that I added may fix this by renaming those to `spec["netcdf-cxx4"]`, which would re-instate the possibility to build these previously broken versions again.
- But even with that fixup, vtk@8.2.1 still does not build as it does apparently not work with "netcdf-cxx4":
```py
  >> 437    CMake Error at /home/bkaindl/spack.4/opt/spack/linux-ubuntu22.04-skylake/gcc-13.1.0/cmake-3.30.2-75b6cbhnvic3ph6wds7z6ctvfhr2ssp7/share/cmake-3.30/Modules/FindPackageHandleStandardAr
            gs.cmake:233 (message):
     438      Could NOT find NetCDF (missing: NETCDF_HAS_INTERFACES)
```
Therefore, in short, it appears that these versions are severely broken and nobody cared. So it looks like better to remove them.

It also appears that vtk@8.2.x are no longer buildable in `spack`, get these errors each time I try:
```py
/usr/bin/ld: CMakeFiles/vtkProbeOpenGLVersion.dir/vtkProbeOpenGLVersion.cxx.o: in function `vtkRenderingOpenGL2_ModuleInit::~vtkRenderingOpenGL2_ModuleInit()':
vtkProbeOpenGLVersion.cxx:(.text._ZN30vtkRenderingOpenGL2_ModuleInitD2Ev[_ZN30vtkRenderingOpenGL2_ModuleInitD5Ev]+0x9): undefined reference to `vtkRenderingOpenGL2_AutoInit_Destruct()'
/usr/bin/ld: CMakeFiles/vtkProbeOpenGLVersion.dir/vtkProbeOpenGLVersion.cxx.o: in function `main':
vtkProbeOpenGLVersion.cxx:(.text.startup+0x29): undefined reference to `vtkRenderer::New()'
/usr/bin/ld: vtkProbeOpenGLVersion.cxx:(.text.startup+0x31): undefined reference to `vtkRenderWindow::New()'
/usr/bin/ld: vtkProbeOpenGLVersion.cxx:(.text.startup+0x6c): undefined reference to `vtkObjectBase::GetClassName() const'
/usr/bin/ld: vtkProbeOpenGLVersion.cxx:(.text.startup+0x164): undefined reference to `vtkOutputWindow::GetInstance()'
/usr/bin/ld: vtkProbeOpenGLVersion.cxx:(.text.startup+0x175): undefined reference to `vtkOutputWindow::GetInstance()'
/usr/bin/ld: CMakeFiles/vtkProbeOpenGLVersion.dir/vtkProbeOpenGLVersion.cxx.o: in function `_GLOBAL__sub_I_main':
vtkProbeOpenGLVersion.cxx:(.text.startup+0x29c): undefined reference to `vtkDebugLeaksManager::vtkDebugLeaksManager()'
/usr/bin/ld: vtkProbeOpenGLVersion.cxx:(.text.startup+0x2a3): undefined reference to `vtkDebugLeaksManager::~vtkDebugLeaksManager()'
/usr/bin/ld: vtkProbeOpenGLVersion.cxx:(.text.startup+0x2ba): undefined reference to `vtkRenderingOpenGL2_AutoInit_Construct()'
/usr/bin/ld: vtkProbeOpenGLVersion.cxx:(.text.startup+0x2d8): undefined reference to `vtkOutputWindowCleanup::vtkOutputWindowCleanup()'
/usr/bin/ld: vtkProbeOpenGLVersion.cxx:(.text.startup+0x2df): undefined reference to `vtkOutputWindowCleanup::~vtkOutputWindowCleanup()'
collect2: error: ld returned 1 exit status
make[2]: *** [Rendering/OpenGL2/CMakeFiles/vtkProbeOpenGLVersion.dir/build.make:114: bin/vtkProbeOpenGLVersion] Error 1
make[2]: Leaving directory '/home/bkaindl/spack.4/.stage/spack-stage-vtk-8.2.1a-lxblbpfuzt6isupa3sjntubookgzyqy6/spack-build-lxblbpf'
make[1]: *** [CMakeFiles/Makefile2:3450: Rendering/OpenGL2/CMakeFiles/vtkProbeOpenGLVersion.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```
I would therefore like to propose to even remove these versions as broken versions.