### PR TITLE
nvhpc: Update sha256s for v24.5

### DIFF
--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -23,11 +23,11 @@ from spack.util.prefix import Prefix
 _versions = {
     "24.5": {
         "Linux-aarch64": (
-            "c199ad9e5d260471a7d30fd3ebc527e8a66b656db42541f9b022db25a80ad843",
+            "c52b5ba370e053472cbffb825ba1da5b6abaee93d4e15479ec12c32d6ebc47d5",
             "https://developer.download.nvidia.com/hpc-sdk/24.5/nvhpc_2024_245_Linux_aarch64_cuda_multi.tar.gz",
         ),
         "Linux-x86_64": (
-            "58019f85edab2fa2e424d3623ab3312d08fcabd6834af2ef5acb060860a99cd7",
+            "e26c5027ffd83fd9e854946670a97253e950cdbacd4894a6715aea91070042ae",
             "https://developer.download.nvidia.com/hpc-sdk/24.5/nvhpc_2024_245_Linux_x86_64_cuda_multi.tar.gz",
         ),
     },


### PR DESCRIPTION
New tarfiles for HPC SDK 24.5.  Release is 24.5-2.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
