### PR TITLE
py-h5py: fix py-cython version constraints

### DIFF
--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -47,11 +47,11 @@ class PyH5py(PythonPackage):
 
     # Build dependencies
     # h5py@3.11 can build with cython@3.x
-    depends_on("py-cython@0.29.31:", type="build", when="@3.11:")
-    depends_on("py-cython@0.29.31:0", type="build", when="@3.9:")
+    depends_on("py-cython@0.29.31:3", type="build", when="@3.11:")
+    depends_on("py-cython@0.29.31:0", type="build", when="@3.9:3.10")
     depends_on("py-cython@0.29.15:0", type=("build"), when="@3:3.7 ^python@3.9.0:")
     depends_on("py-cython@0.29.14:0", type=("build"), when="@3:3.7 ^python@3.8.0:3.8")
-    depends_on("py-cython@0.29:0", type=("build"), when="@3:")
+    depends_on("py-cython@0.29:0", type=("build"), when="@3.0:3.10")
     depends_on("py-cython@0.23:0", type="build", when="@:2")
     depends_on("py-pkgconfig", type="build")
     depends_on("py-setuptools@61:", type="build", when="@3.8.0:")

--- a/var/spack/repos/builtin/packages/py-mpi4py/package.py
+++ b/var/spack/repos/builtin/packages/py-mpi4py/package.py
@@ -19,6 +19,7 @@ class PyMpi4py(PythonPackage):
     license("BSD-2-Clause")
 
     version("master", branch="master")
+    version("3.1.6", sha256="c8fa625e0f92b082ef955bfb52f19fa6691d29273d7d71135d295aa143dee6cb")
     version("3.1.5", sha256="a706e76db9255135c2fb5d1ef54cb4f7b0e4ad9e33cbada7de27626205f2a153")
     version("3.1.4", sha256="17858f2ebc623220d0120d1fa8d428d033dde749c4bc35b33d81a66ad7f93480")
     version("3.1.3", sha256="f1e9fae1079f43eafdd9f817cdb3fd30d709edc093b5d5dada57a461b2db3008")
@@ -32,7 +33,8 @@ class PyMpi4py(PythonPackage):
     version("1.3.1", sha256="e7bd2044aaac5a6ea87a87b2ecc73b310bb6efe5026031e33067ea3c2efc3507")
 
     depends_on("py-setuptools@40.9:", type="build")
-    depends_on("py-cython@0.27:2", type="build")
+    depends_on("py-cython@0.27:2", when="@:3.1.6", type="build")
+    depends_on("py-cython@0.27:3", when="@master", type="build")
     depends_on("mpi")
 
     def setup_build_environment(self, env):


### PR DESCRIPTION
Remove unintended too strict version constraints for py-cython.
(tested py-h5py@3.11.0 ^py-cython@3.0.10)