### PR TITLE
Rename build-time test methods

### DIFF
--- a/var/spack/repos/builtin/packages/libdistributed/package.py
+++ b/var/spack/repos/builtin/packages/libdistributed/package.py
@@ -49,5 +49,5 @@ class Libdistributed(CMakePackage):
 
     @run_after("build")
     @on_package_attributes(run_tests=True)
-    def test(self):
+    def check_test(self):
         make("test")

--- a/var/spack/repos/builtin/packages/libpressio-opt/package.py
+++ b/var/spack/repos/builtin/packages/libpressio-opt/package.py
@@ -51,5 +51,5 @@ class LibpressioOpt(CMakePackage):
 
     @run_after("build")
     @on_package_attributes(run_tests=True)
-    def test(self):
+    def check_test(self):
         make("test")

--- a/var/spack/repos/builtin/packages/libpressio-rmetric/package.py
+++ b/var/spack/repos/builtin/packages/libpressio-rmetric/package.py
@@ -42,5 +42,5 @@ class LibpressioRmetric(CMakePackage):
 
     @run_after("build")
     @on_package_attributes(run_tests=True)
-    def test(self):
+    def check_test(self):
         make("test")

--- a/var/spack/repos/builtin/packages/libpressio-tools/package.py
+++ b/var/spack/repos/builtin/packages/libpressio-tools/package.py
@@ -114,5 +114,5 @@ class LibpressioTools(CMakePackage):
 
     @run_after("build")
     @on_package_attributes(run_tests=True)
-    def test(self):
+    def check_test(self):
         make("test")

--- a/var/spack/repos/builtin/packages/libpressio-tthresh/package.py
+++ b/var/spack/repos/builtin/packages/libpressio-tthresh/package.py
@@ -40,5 +40,5 @@ class LibpressioTthresh(CMakePackage):
 
     @run_after("build")
     @on_package_attributes(run_tests=True)
-    def test(self):
+    def check_test(self):
         make("test")

--- a/var/spack/repos/builtin/packages/open3d/package.py
+++ b/var/spack/repos/builtin/packages/open3d/package.py
@@ -116,7 +116,7 @@ class Open3d(CMakePackage, CudaPackage):
 
     @run_after("install")
     @on_package_attributes(run_tests=True)
-    def test(self):
+    def check_import(self):
         if "+python" in self.spec:
             self.run_test(
                 python.path,


### PR DESCRIPTION
Supersedes #35777 (for 5 of the packages)

This PR renames build-/install-time test methods to avoid the convention used for stand-alone test methods (https://spack.readthedocs.io/en/latest/packaging_guide.html#stand-alone-tests).

TODO:
- [x] libdistributed:         def test -> def check_test
- [x] libpressio-opt:        def test -> def check_test (see #44590)
- [x] libpressio-rmetric:  def test -> def check_test
- [x] libpressio-tools:      def test -> def check_test
- [x] libpressio-tthresh:   def test -> def check_test (see #44621)
- [x] open3d:                   def test -> def check_import (see #44619)