### PR TITLE
unibilium: add gmake build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/unibilium/package.py
+++ b/var/spack/repos/builtin/packages/unibilium/package.py
@@ -17,6 +17,7 @@ class Unibilium(Package):
     version("2.0.0", sha256="78997d38d4c8177c60d3d0c1aa8c53fd0806eb21825b7b335b1768d7116bc1c1")
     version("1.2.0", sha256="623af1099515e673abfd3cae5f2fa808a09ca55dda1c65a7b5c9424eb304ead8")
 
+    depends_on("gmake", type="build")
     depends_on("libtool", type="build")
     depends_on("perl", type="build")
     depends_on("gzip", type="build")


### PR DESCRIPTION
For the unibilium package, adding explicit build dependency on gmake because the Makefile is written for GNU make. It also fails to build if make is not available on the system.