### PR TITLE
Generate jobs should use `x86_64_v3` runners to match build jobs

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -187,7 +187,7 @@ default:
 
 .generate-x86_64:
   extends: [ ".generate-base" ]
-  tags: ["spack", "public", "medium", "x86_64"]
+  tags: ["spack", "public", "medium", "x86_64_v3"]
 
 .generate-aarch64:
   extends: [ ".generate-base" ]


### PR DESCRIPTION
ref. https://gitlab.spack.io/spack/spack/-/pipelines/726149

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

cc: @haampie @zackgalbreath @scottwittenburg 