### PR TITLE
Kokkos sanity checks

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos-kernels/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/package.py
@@ -163,6 +163,10 @@ class KokkosKernels(CMakePackage, CudaPackage):
 
     variant("shared", default=True, description="Build shared libraries")
 
+    # sanity check
+    sanity_check_is_file = [join_path("include", "KokkosKernels_config.h")]
+    sanity_check_is_dir = ["include", "lib"]
+
     def cmake_args(self):
         spec = self.spec
         options = []

--- a/var/spack/repos/builtin/packages/kokkos-kernels/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/package.py
@@ -165,7 +165,7 @@ class KokkosKernels(CMakePackage, CudaPackage):
 
     # sanity check
     sanity_check_is_file = [join_path("include", "KokkosKernels_config.h")]
-    sanity_check_is_dir = ["include", "lib"]
+    sanity_check_is_dir = ["include"]
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -265,6 +265,10 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "KokkosConfigCommon.cmake", relative_root=os.path.join("lib64", "cmake", "Kokkos")
     )
 
+    # sanity check
+    sanity_check_is_file = [join_path("include", "KokkosCore_config.h"), join_path("include", "Kokkos_Core.hpp")]
+    sanity_check_is_dir  = ["bin", "include", "lib"]
+
     @classmethod
     def get_microarch(cls, target):
         """Get the Kokkos microarch name for a Spack target (spec.target)."""

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -266,8 +266,11 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     )
 
     # sanity check
-    sanity_check_is_file = [join_path("include", "KokkosCore_config.h"), join_path("include", "Kokkos_Core.hpp")]
-    sanity_check_is_dir  = ["bin", "include", "lib"]
+    sanity_check_is_file = [
+        join_path("include", "KokkosCore_config.h"),
+        join_path("include", "Kokkos_Core.hpp"),
+    ]
+    sanity_check_is_dir = ["bin", "include", "lib"]
 
     @classmethod
     def get_microarch(cls, target):

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -270,7 +270,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         join_path("include", "KokkosCore_config.h"),
         join_path("include", "Kokkos_Core.hpp"),
     ]
-    sanity_check_is_dir = ["bin", "include", "lib"]
+    sanity_check_is_dir = ["bin", "include"]
 
     @classmethod
     def get_microarch(cls, target):


### PR DESCRIPTION
Adding simple checks to have spack detect expected directories and files after an installation of Kokkos and Kokkos Kernels.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
