### PR TITLE
py-xtb: fix problem with meson file

### DIFF
--- a/var/spack/repos/builtin/packages/py-xtb/package.py
+++ b/var/spack/repos/builtin/packages/py-xtb/package.py
@@ -25,3 +25,10 @@ class PyXtb(PythonPackage):
     depends_on("py-meson-python", type="build")
     depends_on("py-numpy", type=("build", "run"))
     depends_on("xtb", type=("build", "run"))
+
+    # from https://github.com/grimme-lab/xtb-python/pull/114
+    patch(
+        "https://github.com/grimme-lab/xtb-python/commit/df7e0010a679f5f00456bf09fcd9330cd7c56c39.patch?full_index=1",
+        when="@:22.1",
+        sha256="0242a4b79b7e24cfec3c0e6661e744eeb6a786d7",
+    )


### PR DESCRIPTION
Using meson 1.3.2 the py-xtb package fails
during the install process.  Error signature shown in

https://github.com/grimme-lab/xtb-python/pull/114

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
