### PR TITLE
camp@0.2.3 +rocm: patch for rocm 6 from LLNL/camp PR#143

### DIFF
--- a/var/spack/repos/builtin/packages/camp/camp-rocm6.patch
+++ b/var/spack/repos/builtin/packages/camp/camp-rocm6.patch
@@ -1,0 +1,15 @@
+diff -ruN spack-src/include/camp/resource/hip.hpp spack-src-patched/include/camp/resource/hip.hpp
+--- spack-src/include/camp/resource/hip.hpp	2021-08-20 23:38:39.000000000 +0000
++++ spack-src-patched/include/camp/resource/hip.hpp	2024-06-06 21:34:25.174477941 +0000
+@@ -111,7 +111,11 @@
+         hipPointerAttribute_t a;
+         hipError_t status = hipPointerGetAttributes(&a, p);
+         if (status == hipSuccess) {
++#if (HIP_VERSION_MAJOR >= 6)
++          switch (a.type) {
++#else
+           switch (a.memoryType) {
++#endif
+             case hipMemoryTypeHost:
+               return MemoryAccess::Pinned;
+             case hipMemoryTypeDevice:

--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -54,6 +54,8 @@ class Camp(CMakePackage, CudaPackage, ROCmPackage):
 
     patch("libstdc++-13-missing-header.patch", when="@:2022.10")
 
+    patch("camp-rocm6.patch", when="@0.2.3 +rocm ^hip@6:")
+
     conflicts("^blt@:0.3.6", when="+rocm")
 
     def cmake_args(self):


### PR DESCRIPTION
Fix ROCm 6 build for older camp. 
* https://github.com/LLNL/camp/pull/143/files

Fixes https://github.com/spack/spack/issues/44593