### PR TITLE
magma: add rocm-core versions >=6

### DIFF
--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -50,7 +50,18 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("hipsparse", when="+rocm")
     # This ensures that rocm-core matches the hip package version in the case that
     # hip is an external package.
-    for ver in ["5.5.0", "5.5.1", "5.6.0", "5.6.1", "5.7.0", "5.7.1", "6.0.0", "6.0.2"]:
+    for ver in [
+        "5.5.0",
+        "5.5.1",
+        "5.6.0",
+        "5.6.1",
+        "5.7.0",
+        "5.7.1",
+        "6.0.0",
+        "6.0.2",
+        "6.1.0",
+        "6.1.1",
+    ]:
         depends_on(f"rocm-core@{ver}", when=f"@2.8.0: +rocm ^hip@{ver}")
     depends_on("python", when="@master", type="build")
 


### PR DESCRIPTION
Adding the latest rocm-core versions.

Without this PR, building `magma+rocm` with ROCm >6 yields these errors:
```
...
/spack/var/spack/repos/builtin/packages/magma/package.py:159, in cmake_args:
        156            if spec.satisfies("^cmake@3.21.0:3.21.2"):
        157                options.append(define("__skip_rocmclang", True))
        158            if spec.satisfies("@2.8.0:"):
  >>    159                options.append(define("ROCM_CORE", spec["rocm-core"].prefix))
        160        else:
```