### PR TITLE
t8code: fix build with gcc14

### DIFF
--- a/var/spack/repos/builtin/packages/t8code/package.py
+++ b/var/spack/repos/builtin/packages/t8code/package.py
@@ -65,9 +65,14 @@ class T8code(AutotoolsPackage):
 
             # vtk paths need to be passed to configure command
             args.append(f"CPPFLAGS=-I{include_dir}")
-            args.append(f"LDFLAGS=-L{lib_dir}")
+            if "%gcc@14:" in spec:
+                args.append(f"LDFLAGS=-L{lib_dir} -lm")
+            else:
+                args.append(f"LDFLAGS=-L{lib_dir}")
             # Chosen vtk version number is needed for t8code to find the right version
             args.append(f"--with-vtk_version_number={vtk_ver}")
+        elif "%gcc@14:" in spec:
+            args.append("LDFLAGS=-lm")
 
         if "+petsc" in spec:
             args.append(f"--with-petsc={spec['petsc'].prefix}")


### PR DESCRIPTION
Somehow with GCC 14, t8code is missing a "-lm" flags in some internal dependencies.