### PR TITLE
Added non-system gcc support for hipfort

### DIFF
--- a/var/spack/repos/builtin/packages/hipfort/package.py
+++ b/var/spack/repos/builtin/packages/hipfort/package.py
@@ -73,5 +73,8 @@ class Hipfort(CMakePackage):
                 "-DHIPFORT_RANLIB=" + join_path(self.spec["binutils"].prefix.bin, "ranlib")
             )
             args.append("-DHIPFORT_COMPILER_FLAGS='-ffree -eT'")
+        elif self.spec.satisfies("%gcc"):
+            args.append("-DHIPFORT_COMPILER={}".format(spack_fc))
+            args.append("-DHIPFORT_COMPILER_FLAGS='-ffree-form -cpp -ffree-line-length-none'")
 
         return args


### PR DESCRIPTION

Current hipfort build does not support gcc compilers that are not /usr/bin/gcc. This simple `elif` statement allows gcc compilers installed in arbitrary locations to be used.

The compiler flags passed for the gcc build are copied from the default hipfort flags found in CMakeLists.txt, and this is done intentionally for increased visibility of flags.

Note than `ar` and `ranlib` will still be found in `/usr/bin/ranlib` and `/usr/bin/ar`, but that is expected.