### PR TITLE
sundials+rocm: patch hip platform for rocm 5.7-6

### DIFF
--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -284,6 +284,10 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     # ==========================================================================
     # Patches
     # ==========================================================================
+    # https://github.com/LLNL/sundials/pull/434
+    # https://github.com/LLNL/sundials/pull/437
+    patch("sundials-hip-platform.patch", when="@7.0.0 +rocm")
+
     # https://github.com/spack/spack/issues/29526
     patch("nvector-pic.patch", when="@6.1.0:6.2.0 +rocm")
 

--- a/var/spack/repos/builtin/packages/sundials/sundials-hip-platform.patch
+++ b/var/spack/repos/builtin/packages/sundials/sundials-hip-platform.patch
@@ -1,0 +1,33 @@
+diff -ruN spack-src/cmake/SundialsSetupHIP.cmake spack-src-patched/cmake/SundialsSetupHIP.cmake
+--- spack-src/cmake/SundialsSetupHIP.cmake	2024-02-29 22:47:30.000000000 +0000
++++ spack-src-patched/cmake/SundialsSetupHIP.cmake	2024-06-07 15:22:57.920619263 +0000
+@@ -32,9 +32,9 @@
+ 
+ if(NOT DEFINED HIP_PLATFORM)
+   if(NOT DEFINED ENV{HIP_PLATFORM})
+-    set(HIP_PLATFORM "hcc" CACHE STRING "HIP platform (hcc, nvcc)")
++    set(HIP_PLATFORM "amd" CACHE STRING "HIP platform (amd, nvidia)")
+   else()
+-    set(HIP_PLATFORM "$ENV{HIP_PLATFORM}" CACHE STRING "HIP platform (hcc, nvcc)")
++    set(HIP_PLATFORM "$ENV{HIP_PLATFORM}" CACHE STRING "HIP platform (amd, nvidia)")
+   endif()
+ endif()
+ 
+diff -ruN spack-src/include/sundials/sundials_hip_policies.hpp spack-src-patched/include/sundials/sundials_hip_policies.hpp
+--- spack-src/include/sundials/sundials_hip_policies.hpp	2024-02-29 22:47:30.000000000 +0000
++++ spack-src-patched/include/sundials/sundials_hip_policies.hpp	2024-06-07 15:23:15.752724851 +0000
+@@ -27,10 +27,12 @@
+ namespace sundials {
+ namespace hip {
+ 
+-#if defined(__HIP_PLATFORM_HCC__)
++#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
+ constexpr const sunindextype WARP_SIZE = 64;
+-#elif defined(__HIP_PLATFORM_NVCC__)
++#elif defined(__HIP_PLATFORM_NVCC__) || defined(__HIP_PLATFORM_NVDIA__)
+ constexpr const sunindextype WARP_SIZE = 32;
++#else
++#error "Unknown HIP_PLATFORM, report to github.com/LLNL/sundials/issues"
+ #endif
+ constexpr const sunindextype MAX_BLOCK_SIZE = 1024;
+ constexpr const sunindextype MAX_WARPS      = MAX_BLOCK_SIZE / WARP_SIZE;


### PR DESCRIPTION
Patch hip platform for rocm >=5.7. Changes from:
* https://github.com/LLNL/sundials/pull/434
* https://github.com/LLNL/sundials/pull/437

Fixes https://github.com/spack/spack/issues/44601

```
...
[+] /usr (external glibc-2.35-a7drdl4tlx4bu3mzhor75pskvd3pdot6)
[+] /opt/rocm-6.1.1 (external hip-6.1.1-abm43bumwjxh5tktume7pv7mrrgvofjz)
[+] /opt/rocm-6.1.1/ (external hsa-rocr-dev-6.1.1-qyqwwsezn4542hrilckbo5xv7qtxmvd4)
[+] /opt/rocm-6.1.1/llvm (external llvm-amdgpu-6.1.1-l4maeaq7u34k6auz6uteib2xfazmzl43)
[+] /spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/gcc-runtime-11.4.0-hshzy762rns57ibvxiyi3qqvc4nehse2
[+] /spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/xz-5.4.6-imwcbq7jfwsydglixtbolderdyxsrfc4
[+] /spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/zlib-ng-2.1.6-54554grl2shlnbzqpsdvdw6urpc2hyvc
[+] /spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/yaksa-0.3-x2wkmjdfnydby5o2ef6uneujkg65xqul
[+] /spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/nghttp2-1.62.0-zc6oo3euja7nui5gzon5m5uektquerpq
[+] /spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/gmake-4.4.1-aevr47sjw22uhmuraymiunex7lm3wf3s
[+] /spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/openssl-3.3.0-r3wk5bbuwphn7pbggyyidg6v5dhskddd
[+] /spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/ncurses-6.5-sqasgz3hwqgd3x7gq4qnxgx6526wjg3k
[+] /spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/libfabric-1.21.0-grokknt2yihapnpwamxpei4zaxwoqgax
[+] /spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/libxml2-2.10.3-blvm6hbgo7g4pchh5hgv25r337sxiups
[+] /spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/libpciaccess-0.17-cinntmrg32y4dak5d3vo52zdywaot5kd
[+] /spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/curl-8.7.1-7wjyjza7ss3xhcmrmddjnhols7nvpdau
[+] /spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/mpich-4.2.1-q73zij2acabvp27dqu6eakamcxfxcsja
[+] /spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/cmake-3.29.2-45jczu57cadhtdehiz423qzpr73zsitr
==> Installing sundials-7.0.0-2ftubecgtnvyxcu5oskvr3asm73y4jce [19/19]
==> No binary for sundials-7.0.0-2ftubecgtnvyxcu5oskvr3asm73y4jce found: installing from source
==> Fetching https://github.com/LLNL/sundials/releases/download/v7.0.0/sundials-7.0.0.tar.gz
==> Applied patch /spack/var/spack/repos/builtin/packages/sundials/sundials-hip-platform.patch
==> sundials: Executing phase: 'cmake'
==> sundials: Executing phase: 'build'
==> sundials: Executing phase: 'install'
==> sundials: Successfully installed sundials-7.0.0-2ftubecgtnvyxcu5oskvr3asm73y4jce
  Stage: 4.44s.  Cmake: 13.34s.  Build: 9.22s.  Install: 1.29s.  Post-install: 0.37s.  Total: 28.87s
[+] /spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/sundials-7.0.0-2ftubecgtnvyxcu5oskvr3asm73y4jce
```

CC @gardner48 