### PR TITLE
upcxx: Add resilience to broken libfabric

### DIFF
--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -22,7 +22,8 @@ def is_CrayEX():
             return True
         elif target is None:  # but some systems lack Cray PrgEnv
             fi_info = which("fi_info")
-            if fi_info and fi_info("-l", output=str).find("cxi") >= 0:
+            if fi_info and \
+               fi_info("-l", output=str, error=str, fail_on_error=False).find("cxi") >= 0:
                 return True
     return False
 

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -22,8 +22,10 @@ def is_CrayEX():
             return True
         elif target is None:  # but some systems lack Cray PrgEnv
             fi_info = which("fi_info")
-            if fi_info and \
-               fi_info("-l", output=str, error=str, fail_on_error=False).find("cxi") >= 0:
+            if (
+                fi_info
+                and fi_info("-l", output=str, error=str, fail_on_error=False).find("cxi") >= 0
+            ):
                 return True
     return False
 

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -9,12 +9,14 @@ import re
 from spack.package import *
 
 
+@llnl.util.lang.memoized
 def is_CrayXC():
     return spack.platforms.host().name == "linux" and (
         os.environ.get("CRAYPE_NETWORK_TARGET") == "aries"
     )
 
 
+@llnl.util.lang.memoized
 def is_CrayEX():
     if spack.platforms.host().name == "linux":
         target = os.environ.get("CRAYPE_NETWORK_TARGET")
@@ -30,6 +32,7 @@ def is_CrayEX():
     return False
 
 
+@llnl.util.lang.memoized
 def cross_detect():
     if is_CrayXC():
         if which("srun"):


### PR DESCRIPTION
Some systems have a libfabric install that doesn't work, so don't drop dead if a call to `fi_info` fails (e.g. due to missing shared libraries)

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
