### PR TITLE
Add Windows job to Clingo Bootstrap unit test

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -71,13 +71,14 @@ jobs:
           IS_WINDOWS: ${{ matrix.runner == 'windows-latest' }}
           SETUP_SCRIPT_EXT: ${{ env.IS_WINDOWS && 'ps1' || 'sh' }}
           SETUP_SCRIPT_SOURCE: ${{ env.IS_WINDOWS && './' || 'source ' }}
+          HOME: ${{ env.IS_WINDOWS && '$env:userprofile' || '~' }}
         run: |
           ${{ env.SETUP_SCRIPT_SOURCE }}share/spack/setup-env.${{ env.SETUP_SCRIPT_EXT }}
           spack bootstrap disable github-actions-v0.5
           spack bootstrap disable github-actions-v0.4
           spack external find --not-buildable cmake bison
           spack -d solve zlib
-          tree ~/.spack/bootstrap/store/
+          tree ${{ env.HOME }}/.spack/bootstrap/store/
 
   gnupg-sources:
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           SETUP_SCRIPT_EXT: ${{ matrix.runner == 'windows-latest' && 'ps1' || 'sh' }}
           SETUP_SCRIPT_SOURCE: ${{ matrix.runner == 'windows-latest' && './' || 'source ' }}
-          HOME: ${{ matrix.runner == 'windows-latest' && '$env:userprofile' || '~' }}
+          HOME: ${{ matrix.runner == 'windows-latest' && '$env:userprofile' || '$HOME' }}
         run: |
           ${{ env.SETUP_SCRIPT_SOURCE }}share/spack/setup-env.${{ env.SETUP_SCRIPT_EXT }}
           spack bootstrap disable github-actions-v0.5

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -68,9 +68,11 @@ jobs:
           python-version: "3.12"
       - name: Bootstrap clingo
         env:
-          SETUP_SCRIPT_EXT: ${{ matrix.runner == 'windows-latest' && 'ps1' || 'sh' }}
+          IS_WINDOWS: ${{ matrix.runner == 'windows-latest' }}
+          SETUP_SCRIPT_EXT: ${{ env.IS_WINDOWS && 'ps1' || 'sh' }}
+          SETUP_SCRIPT_SOURCE: ${{ env.IS_WINDOWS && './' || 'source ' }}
         run: |
-          source share/spack/setup-env.${{ env.SETUP_SCRIPT_EXT }}
+          ${{ env.SETUP_SCRIPT_SOURCE }}share/spack/setup-env.${{ env.SETUP_SCRIPT_EXT }}
           spack bootstrap disable github-actions-v0.5
           spack bootstrap disable github-actions-v0.4
           spack external find --not-buildable cmake bison

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -70,14 +70,14 @@ jobs:
         env:
           SETUP_SCRIPT_EXT: ${{ matrix.runner == 'windows-latest' && 'ps1' || 'sh' }}
           SETUP_SCRIPT_SOURCE: ${{ matrix.runner == 'windows-latest' && './' || 'source ' }}
-          HOME: ${{ matrix.runner == 'windows-latest' && '$env:userprofile' || '$HOME' }}
+          XP_HOME: ${{ matrix.runner == 'windows-latest' && '$env:userprofile' || '$HOME' }}
         run: |
           ${{ env.SETUP_SCRIPT_SOURCE }}share/spack/setup-env.${{ env.SETUP_SCRIPT_EXT }}
           spack bootstrap disable github-actions-v0.5
           spack bootstrap disable github-actions-v0.4
           spack external find --not-buildable cmake bison
           spack -d solve zlib
-          tree ${{ env.HOME }}/.spack/bootstrap/store/
+          tree ${{ env.XP_HOME }}/.spack/bootstrap/store/
 
   gnupg-sources:
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -70,14 +70,14 @@ jobs:
         env:
           SETUP_SCRIPT_EXT: ${{ matrix.runner == 'windows-latest' && 'ps1' || 'sh' }}
           SETUP_SCRIPT_SOURCE: ${{ matrix.runner == 'windows-latest' && './' || 'source ' }}
-          XP_HOME: ${{ matrix.runner == 'windows-latest' && '$env:userprofile' || '$HOME' }}
+          USER_SCOPE_PARENT_DIR: ${{ matrix.runner == 'windows-latest' && '$env:userprofile' || '$HOME' }}
         run: |
           ${{ env.SETUP_SCRIPT_SOURCE }}share/spack/setup-env.${{ env.SETUP_SCRIPT_EXT }}
           spack bootstrap disable github-actions-v0.5
           spack bootstrap disable github-actions-v0.4
           spack external find --not-buildable cmake bison
           spack -d solve zlib
-          tree ${{ env.XP_HOME }}/.spack/bootstrap/store/
+          tree ${{ env.USER_SCOPE_PARENT_DIR }}/.spack/bootstrap/store/
 
   gnupg-sources:
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -53,10 +53,10 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        runner: ['macos-13', 'macos-14', "ubuntu-latest"]
+        runner: ['macos-13', 'macos-14', "ubuntu-latest", "windows-latest"]
     steps:
       - name: Setup macOS
-        if: ${{ matrix.runner != 'ubuntu-latest' }}
+        if: ${{ matrix.runner != 'ubuntu-latest' && matrix.runner != 'windows-latest' }}
         run: |
           brew install cmake bison tree
       - name: Checkout
@@ -67,8 +67,10 @@ jobs:
         with:
           python-version: "3.12"
       - name: Bootstrap clingo
+        env:
+          SETUP_SCRIPT_EXT: ${{ matrix.runner == 'windows-latest' && 'ps1' || 'sh' }}
         run: |
-          source share/spack/setup-env.sh
+          source share/spack/setup-env.${{ env.SETUP_SCRIPT_EXT }}
           spack bootstrap disable github-actions-v0.5
           spack bootstrap disable github-actions-v0.4
           spack external find --not-buildable cmake bison

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -68,10 +68,9 @@ jobs:
           python-version: "3.12"
       - name: Bootstrap clingo
         env:
-          IS_WINDOWS: ${{ matrix.runner == 'windows-latest' }}
-          SETUP_SCRIPT_EXT: ${{ env.IS_WINDOWS && 'ps1' || 'sh' }}
-          SETUP_SCRIPT_SOURCE: ${{ env.IS_WINDOWS && './' || 'source ' }}
-          HOME: ${{ env.IS_WINDOWS && '$env:userprofile' || '~' }}
+          SETUP_SCRIPT_EXT: ${{ matrix.runner == 'windows-latest' && 'ps1' || 'sh' }}
+          SETUP_SCRIPT_SOURCE: ${{ matrix.runner == 'windows-latest' && './' || 'source ' }}
+          HOME: ${{ matrix.runner == 'windows-latest' && '$env:userprofile' || '~' }}
         run: |
           ${{ env.SETUP_SCRIPT_SOURCE }}share/spack/setup-env.${{ env.SETUP_SCRIPT_EXT }}
           spack bootstrap disable github-actions-v0.5


### PR DESCRIPTION
Removes build-abseil-cpp job from Windows unit tests

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
