### PR TITLE
libgudev: new package

### DIFF
--- a/var/spack/repos/builtin/packages/libgudev/package.py
+++ b/var/spack/repos/builtin/packages/libgudev/package.py
@@ -2,8 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/libgudev/package.py
+++ b/var/spack/repos/builtin/packages/libgudev/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class Libgudev(MesonPackage):
+    """Provides GObject bindings for libudev."""
+
+    homepage = "https://gitlab.gnome.org/GNOME/libgudev/"
+    url = "https://download.gnome.org/sources/libgudev/237/libgudev-237.tar.xz"
+
+    maintainers("teaguesterling")
+
+    license("LGPL2.1", checked_by="teaguesterling")
+
+    version("238", sha256="61266ab1afc9d73dbc60a8b2af73e99d2fdff47d99544d085760e4fa667b5dd1")
+
+    with default_args(when="@238", type=("build", "link", "run")):
+        depends_on("glib@2.38:")
+        depends_on("systemd@251:")  # For libuvdev
+
+    def meson_args(self):
+        args = []
+        return args

--- a/var/spack/repos/builtin/packages/libgudev/package.py
+++ b/var/spack/repos/builtin/packages/libgudev/package.py
@@ -19,10 +19,6 @@ class Libgudev(MesonPackage):
 
     version("238", sha256="61266ab1afc9d73dbc60a8b2af73e99d2fdff47d99544d085760e4fa667b5dd1")
 
-    with default_args(when="@238", type=("build", "link", "run")):
+    with default_args(type=("build", "link", "run")):
         depends_on("glib@2.38:")
         depends_on("systemd@251:")  # For libuvdev
-
-    def meson_args(self):
-        args = []
-        return args

--- a/var/spack/repos/builtin/packages/libgudev/package.py
+++ b/var/spack/repos/builtin/packages/libgudev/package.py
@@ -9,7 +9,7 @@ class Libgudev(MesonPackage):
     """Provides GObject bindings for libudev."""
 
     homepage = "https://gitlab.gnome.org/GNOME/libgudev/"
-    url = "https://download.gnome.org/sources/libgudev/237/libgudev-237.tar.xz"
+    url = "https://download.gnome.org/sources/libgudev/238/libgudev-238.tar.xz"
 
     maintainers("teaguesterling")
 


### PR DESCRIPTION
Adding a simple package to build include the libgudev libraries required for building some GObject-based applications. 