### PR TITLE
libxcvt: new package

### DIFF
--- a/var/spack/repos/builtin/packages/libxcvt/package.py
+++ b/var/spack/repos/builtin/packages/libxcvt/package.py
@@ -2,8 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/libxcvt/package.py
+++ b/var/spack/repos/builtin/packages/libxcvt/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class Libxcvt(MesonPackage):
+    """Implementation of the VESA CVT standard timing modelines generator."""
+
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcvt"
+    url = "https://gitlab.freedesktop.org/xorg/lib/libxcvt/-/archive/libxcvt-0.1.2/libxcvt-libxcvt-0.1.2.tar.bz2"
+
+    license("MIT", checked_by="teaguesterling")
+
+    version("0.1.2", sha256="590e5a6da87ace7aa7857026b207a2c4d378620035441e20ea97efedd15d6d4a")
+

--- a/var/spack/repos/builtin/packages/libxcvt/package.py
+++ b/var/spack/repos/builtin/packages/libxcvt/package.py
@@ -16,4 +16,3 @@ class Libxcvt(MesonPackage):
     license("MIT", checked_by="teaguesterling")
 
     version("0.1.2", sha256="590e5a6da87ace7aa7857026b207a2c4d378620035441e20ea97efedd15d6d4a")
-

--- a/var/spack/repos/builtin/packages/libxcvt/package.py
+++ b/var/spack/repos/builtin/packages/libxcvt/package.py
@@ -9,8 +9,8 @@ class Libxcvt(MesonPackage, XorgPackage):
     """Implementation of the VESA CVT standard timing modelines generator."""
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcvt"
-    xorg_mirror_path = "libxcvt/libxcvt-libxcvt-0.1.2.tar.bz2"
+    xorg_mirror_path = "lib/libxcvt-0.1.2.tar.xz"
 
     license("MIT", checked_by="teaguesterling")
 
-    version("0.1.2", sha256="590e5a6da87ace7aa7857026b207a2c4d378620035441e20ea97efedd15d6d4a")
+    version("0.1.2", sha256="0561690544796e25cfbd71806ba1b0d797ffe464e9796411123e79450f71db38")

--- a/var/spack/repos/builtin/packages/libxcvt/package.py
+++ b/var/spack/repos/builtin/packages/libxcvt/package.py
@@ -5,11 +5,11 @@
 from spack.package import *
 
 
-class Libxcvt(MesonPackage):
+class Libxcvt(MesonPackage, XorgPackage):
     """Implementation of the VESA CVT standard timing modelines generator."""
 
     homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcvt"
-    url = "https://gitlab.freedesktop.org/xorg/lib/libxcvt/-/archive/libxcvt-0.1.2/libxcvt-libxcvt-0.1.2.tar.bz2"
+    xorg_mirror_path = "libxcvt/libxcvt-libxcvt-0.1.2.tar.bz2"
 
     license("MIT", checked_by="teaguesterling")
 


### PR DESCRIPTION
Adding a dependent package required for building `xorg-server` (which still isn't building, but needed this).