### PR TITLE
gobject-introspection: add v1.60.2

### DIFF
--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -20,10 +20,12 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
 
     license("LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT")
 
+    version("1.80.1", sha256="a1df7c424e15bda1ab639c00e9051b9adf5cea1a9e512f8a603b53cd199bc6d8")
     version("1.78.1", sha256="bd7babd99af7258e76819e45ba4a6bc399608fe762d83fde3cac033c50841bb4")
     version("1.76.1", sha256="196178bf64345501dcdc4d8469b36aa6fe80489354efe71cb7cb8ab82a3738bf")
     version("1.72.1", sha256="012e313186e3186cf0fde6decb57d970adf90e6b1fac5612fe69cbb5ba99543a")
     version("1.72.0", sha256="02fe8e590861d88f83060dd39cda5ccaa60b2da1d21d0f95499301b186beaabc")
+    version("1.60.2", sha256="ffdfe2368fb2e34a547898b01aac0520d52d8627fdeb1c306559bcb503ab5e9c")
     version("1.56.1", sha256="5b2875ccff99ff7baab63a34b67f8c920def240e178ff50add809e267d9ea24b")
     version("1.49.2", sha256="73d59470ba1a546b293f54d023fd09cca03a951005745d86d586b9e3a8dde9ac")
     version("1.48.0", sha256="fa275aaccdbfc91ec0bc9a6fd0562051acdba731e7d584b64a277fec60e75877")

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -20,7 +20,6 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
 
     license("LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT")
 
-    version("1.80.1", sha256="a1df7c424e15bda1ab639c00e9051b9adf5cea1a9e512f8a603b53cd199bc6d8")
     version("1.78.1", sha256="bd7babd99af7258e76819e45ba4a6bc399608fe762d83fde3cac033c50841bb4")
     version("1.76.1", sha256="196178bf64345501dcdc4d8469b36aa6fe80489354efe71cb7cb8ab82a3738bf")
     version("1.72.1", sha256="012e313186e3186cf0fde6decb57d970adf90e6b1fac5612fe69cbb5ba99543a")

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -45,7 +45,7 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     depends_on("cairo+gobject")
     depends_on("glib@2.78:", when="@1.78")
     depends_on("glib@2.76:", when="@1.76")
-    depends_on("glib@2.58:", when="@1.60,1.72")
+    depends_on("glib@2.58:", when="@1.60:1.72")
     depends_on("glib@2.56:", when="@1.56")
     depends_on("glib@2.49.2:", when="@1.49.2")
     depends_on("glib@2.48.1", when="@1.48.0")
@@ -75,8 +75,10 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     #   extra sed expression in its TOOL_SUBSTITUTION that results in
     #   an `#!/bin/bash /path/to/spack/bin/sbang` unconditionally being
     #   inserted into the scripts as they're generated.
-    patch("sbang.patch", when="@:1.60.0")
-    patch("sbang-1.60.2.patch", when="@1.60.2")  # Not sure of the upper bound
+    patch("sbang.patch", when="@:1.56")
+    # The TOOL_SUBSITUTION line changed after 1.58 to include /usr/bin/env in
+    # the Python substituion more explicitly. The Makefile.am was removed in 1.61.
+    patch("sbang-1.60.2.patch", when="@1.58:1.60")
 
     # Drop deprecated xml.etree.ElementTree.Element.getchildren() which leads
     # to compilation issues with Python 3.9.
@@ -90,8 +92,8 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
 
     conflicts(
         "^python@3.11:",
-        when="@:2.60",
-        msg="Versions prior to 2.72 not compatible with Python 3.11 or later.",
+        when="@:1.60",
+        msg="giscannermodule.c in <=v1.60 uses syntax incompatible with Python >=3.11",
     )
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -88,6 +88,12 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
         when="@:1.63.1",
     )
 
+    conflicts(
+        "^python@3.11:",
+        when="@:2.60",
+        msg="Versions prior to 2.72 not compatible with Python 3.11 or later.",
+    )
+
     def url_for_version(self, version):
         url = "https://download.gnome.org/sources/gobject-introspection/{0}/gobject-introspection-{1}.tar.xz"
         return url.format(version.up_to(2), version)

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -76,7 +76,7 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     #   an `#!/bin/bash /path/to/spack/bin/sbang` unconditionally being
     #   inserted into the scripts as they're generated.
     patch("sbang.patch", when="@:1.60.0")
-    patch("sbang-1.60.2.patch", when="@:1.60.2")
+    patch("sbang-1.60.2.patch", when="@1.60.2")  # Not sure of the upper bound
 
     # Drop deprecated xml.etree.ElementTree.Element.getchildren() which leads
     # to compilation issues with Python 3.9.

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -45,7 +45,7 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     depends_on("cairo+gobject")
     depends_on("glib@2.78:", when="@1.78")
     depends_on("glib@2.76:", when="@1.76")
-    depends_on("glib@2.58:", when="@1.72")
+    depends_on("glib@2.58:", when="@1.60,1.72")
     depends_on("glib@2.56:", when="@1.56")
     depends_on("glib@2.49.2:", when="@1.49.2")
     depends_on("glib@2.48.1", when="@1.48.0")

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -75,7 +75,8 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     #   extra sed expression in its TOOL_SUBSTITUTION that results in
     #   an `#!/bin/bash /path/to/spack/bin/sbang` unconditionally being
     #   inserted into the scripts as they're generated.
-    patch("sbang.patch", when="@:1.60")
+    patch("sbang.patch", when="@:1.60.0")
+    patch("sbang-1.60.2.patch", when="@:1.60.2")
 
     # Drop deprecated xml.etree.ElementTree.Element.getchildren() which leads
     # to compilation issues with Python 3.9.

--- a/var/spack/repos/builtin/packages/gobject-introspection/sbang-1.60.2.patch
+++ b/var/spack/repos/builtin/packages/gobject-introspection/sbang-1.60.2.patch
@@ -5,7 +5,7 @@
  typelibsdir = $(libdir)/girepository-1.0
  typelibs_DATA = $(gir_DATA:.gir=.typelib)
 -TOOL_SUBSTITUTIONS = -e s,@libdir\@,$(libdir), -e s,@datarootdir\@,$(datarootdir), -e s,@PYTHON_CMD\@,\/usr\/bin\/env\ $(PYTHON), -e s,@GIR_DIR\@,$(GIR_DIR),g
-+TOOL_SUBSTITUTIONS = -e s,@libdir\@,$(libdir), -e s,@datarootdir\@,$(datarootdir), -e s,@PYTHON\@,\/usr\/bin\/env\ $(PYTHON), -e "1i\#!/bin/bash $(SPACK_SBANG)" -e s,@GIR_DIR\@,$(GIR_DIR),g
++TOOL_SUBSTITUTIONS = -e s,@libdir\@,$(libdir), -e s,@datarootdir\@,$(datarootdir), -e s,@PYTHON_CMD\@,\/usr\/bin\/env\ $(PYTHON), -e s,@GIR_DIR\@,$(GIR_DIR),g -e "1i\#!/bin/bash $(SPACK_SBANG)"
  g_ir_compiler_SOURCES = tools/compiler.c
  g_ir_compiler_CPPFLAGS = -DGIREPO_DEFAULT_SEARCH_PATH="\"$(libdir)\"" \
  			 -I$(top_srcdir)/girepository

--- a/var/spack/repos/builtin/packages/gobject-introspection/sbang-1.60.2.patch
+++ b/var/spack/repos/builtin/packages/gobject-introspection/sbang-1.60.2.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.in	2016-09-13 01:23:59.000000000 -0700
++++ b/Makefile.in	2017-02-22 10:26:31.824509512 -0800
+@@ -1475,7 +1475,7 @@
+ gir_DATA = $(STATIC_GIRSOURCES) $(SUBSTITUTED_GIRSOURCES) $(BUILT_GIRSOURCES)
+ typelibsdir = $(libdir)/girepository-1.0
+ typelibs_DATA = $(gir_DATA:.gir=.typelib)
+-TOOL_SUBSTITUTIONS = -e s,@libdir\@,$(libdir), -e s,@datarootdir\@,$(datarootdir), -e s,@PYTHON_CMD\@,\/usr\/bin\/env\ $(PYTHON), -e s,@GIR_DIR\@,$(GIR_DIR),g
++TOOL_SUBSTITUTIONS = -e s,@libdir\@,$(libdir), -e s,@datarootdir\@,$(datarootdir), -e s,@PYTHON\@,$(PYTHON), -e "1i\#!/bin/bash $(SPACK_SBANG)"
+ g_ir_compiler_SOURCES = tools/compiler.c
+ g_ir_compiler_CPPFLAGS = -DGIREPO_DEFAULT_SEARCH_PATH="\"$(libdir)\"" \
+ 			 -I$(top_srcdir)/girepository

--- a/var/spack/repos/builtin/packages/gobject-introspection/sbang-1.60.2.patch
+++ b/var/spack/repos/builtin/packages/gobject-introspection/sbang-1.60.2.patch
@@ -5,7 +5,7 @@
  typelibsdir = $(libdir)/girepository-1.0
  typelibs_DATA = $(gir_DATA:.gir=.typelib)
 -TOOL_SUBSTITUTIONS = -e s,@libdir\@,$(libdir), -e s,@datarootdir\@,$(datarootdir), -e s,@PYTHON_CMD\@,\/usr\/bin\/env\ $(PYTHON), -e s,@GIR_DIR\@,$(GIR_DIR),g
-+TOOL_SUBSTITUTIONS = -e s,@libdir\@,$(libdir), -e s,@datarootdir\@,$(datarootdir), -e s,@PYTHON\@,$(PYTHON), -e "1i\#!/bin/bash $(SPACK_SBANG)"
++TOOL_SUBSTITUTIONS = -e s,@libdir\@,$(libdir), -e s,@datarootdir\@,$(datarootdir), -e s,@PYTHON\@,\/usr\/bin\/env\ $(PYTHON), -e "1i\#!/bin/bash $(SPACK_SBANG)" -e s,@GIR_DIR\@,$(GIR_DIR),g
  g_ir_compiler_SOURCES = tools/compiler.c
  g_ir_compiler_CPPFLAGS = -DGIREPO_DEFAULT_SEARCH_PATH="\"$(libdir)\"" \
  			 -I$(top_srcdir)/girepository


### PR DESCRIPTION
Adding the latest version of `gobject-introspection` as well as the lowest required version to build XFCE4 4.18 core.