### PR TITLE
gdk-pixbuf: adding variant version constraint

### DIFF
--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -46,7 +46,7 @@ class GdkPixbuf(Package):
         deprecated=True,
     )
 
-    variant("x11", default=False, description="Enable X11 support")
+    variant("x11", default=False, description="Enable X11 support", when="@:2.41")
     variant("tiff", default=False, description="Enable TIFF support(partially broken)")
     # Man page creation was getting docbook errors, see issue #18853
     variant("man", default=False, description="Enable man page creation")


### PR DESCRIPTION
Versions of `gdk-pixbuf` after 2.41 no longer have can accept the `x11` variant.