### PR TITLE
openjdk: update default version to 17.x

### DIFF
--- a/var/spack/repos/builtin/packages/astral/package.py
+++ b/var/spack/repos/builtin/packages/astral/package.py
@@ -25,7 +25,7 @@ class Astral(Package):
     )
     version("4.10.7", sha256="314b49e0129ec06a7c78a1b60d590259ede6a5e75253407031e108d8048fcc79")
 
-    depends_on("java", type=("build", "run"))
+    depends_on("java@11", type=("build", "run"))
     depends_on("zip", type="build")
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/openjdk/package.py
+++ b/var/spack/repos/builtin/packages/openjdk/package.py
@@ -393,7 +393,7 @@ class Openjdk(Package):
     """The free and opensource java implementation"""
 
     homepage = "https://openjdk.org/"
-    preferred_prefix = "11."
+    preferred_prefix = "17."
 
     preferred_defined = False
     for ver, packages in _versions.items():

--- a/var/spack/repos/builtin/packages/openjdk/package.py
+++ b/var/spack/repos/builtin/packages/openjdk/package.py
@@ -27,7 +27,7 @@ _versions = {
             "7d3ab0e8eba95bd682cfda8041c6cb6fa21e09d0d9131316fd7c96c78969de31",
             "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.3_9.tar.gz",
         ),
-        "Darwin-aarch64": (
+        "Darwin-arm64": (
             "b6be6a9568be83695ec6b7cb977f4902f7be47d74494c290bc2a5c3c951e254f",
             "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.3_9.tar.gz",
         ),
@@ -47,7 +47,7 @@ _versions = {
             "a900acf3ae56b000afc35468a083b6d6fd695abec87a8abdb02743d5c72f6d6d",
             "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.11_9.tar.gz",
         ),
-        "Darwin-aarch64": (
+        "Darwin-arm64": (
             "09a162c58dd801f7cfacd87e99703ed11fb439adc71cfa14ceb2d3194eaca01c",
             "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.11_9.tar.gz",
         ),
@@ -65,7 +65,7 @@ _versions = {
             "18be56732c1692ef131625d814dcb02ee091a43fdd6f214a33d87cc14842fc3f",
             "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_x64_mac_hotspot_17.0.8.1_1.tar.gz",
         ),
-        "Darwin-aarch64": (
+        "Darwin-arm64": (
             "2e95eed48650f00650e963c8213b6c6ecda54458edf8d254ebc99d6a6966ffad",
             "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.8.1_1.tar.gz",
         ),
@@ -97,7 +97,7 @@ _versions = {
             "ac21a5a87f7cfa00212ab7c41f7eb80ca33640d83b63ad850be811c24095d61a",
             "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_x64_mac_hotspot_17.0.4.1_1.tar.gz",
         ),
-        "Darwin-aarch64": (
+        "Darwin-arm64": (
             "3a976943a9e6a635e68e2b06bd093fc096aad9f5894acda673d3bea0cb3a6f38",
             "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.4.1_1.tar.gz",
         ),
@@ -197,7 +197,7 @@ _versions = {
             "e00476a7be3c4adfa9b3d55d30768967fd246a8352e518894e183fa444d4d3ce",
             "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.23_9.tar.gz",
         ),
-        "Darwin-aarch64": (
+        "Darwin-arm64": (
             "49122443bdeab2c9f468bd400f58f85a9ea462846faa79084fd6fd786d9b492d",
             "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.23_9.tar.gz",
         ),
@@ -215,7 +215,7 @@ _versions = {
             "42fd1373ee3f7c24f13551be20c8a5ae7ade778f83c45476ea333b2e3e025267",
             "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1%2B1/OpenJDK11U-jdk_x64_mac_hotspot_11.0.20.1_1.tar.gz",
         ),
-        "Darwin-aarch64": (
+        "Darwin-arm64": (
             "d36abd2f8a8cd2c73a7893306d65a5ae03eaa73565c1fc197a69d1d6fb02405e",
             "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1%2B1/OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.20.1_1.tar.gz",
         ),
@@ -233,7 +233,7 @@ _versions = {
             "18c636bd103e240d29cdb30d7867720ea9fb9ff7c645738bfb4d5b8027269263",
             "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.17%2B8/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.17_8.tar.gz",
         ),
-        "Darwin-aarch64": (
+        "Darwin-arm64": (
             "79b18cbd398b67a52ebaf033dfca15c7af4c1a84ec5fa68a88f3bf742bb082f7",
             "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.17%2B8/OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.17_8.tar.gz",
         ),
@@ -255,7 +255,7 @@ _versions = {
             "723548e36e0b3e0a5a2f36a38b22ea825d3004e26054a0e254854adc57045352",
             "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1%2B1/OpenJDK11U-jdk_x64_mac_hotspot_11.0.16.1_1.tar.gz",
         ),
-        "Darwin-aarch64": (
+        "Darwin-arm64": (
             "1953f06702d45eb54bae3ccf453b57c33de827015f5623a2dfc16e1c83e6b0a1",
             "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1%2B1/OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.16.1_1.tar.gz",
         ),

--- a/var/spack/repos/builtin/packages/stc/package.py
+++ b/var/spack/repos/builtin/packages/stc/package.py
@@ -21,7 +21,7 @@ class Stc(AutotoolsPackage):
     version("0.8.3", sha256="d61ca80137a955b12e84e41cb8a78ce1a58289241a2665076f12f835cf68d798")
     version("0.8.2", sha256="13f0f03fdfcca3e63d2d58d7e7dbdddc113d5b9826c9357ab0713b63e8e42c5e")
 
-    depends_on("java", type=("build", "run"))
+    depends_on("java@11", type=("build", "run"))
     depends_on("ant", type="build")
     depends_on("turbine", type=("build", "run"))
     depends_on("turbine@master", type=("build", "run"), when="@master")


### PR DESCRIPTION
This PR updates the default version of OpenJDK from 11.x to the next LTS version, 17.x.

Measuring the full impact of this change is challenging. As an aproximation, I tested several packages that list Java as a dependency, focusing on those that do not specify a particular version and list the dependency as "build".

Here are the results. To test if a package "runs", I executed each program with `-h/--help` to verify if the output is correct and free of warnings. For some programs or libraries, I couldn't determine how to run or test them, so I marked those with a `?`. The only package in this list that builds with 11.x but not with 17.x is astral.

| package      | last_update | dependency_type | build | run |
|--------------|-------------|-----------------|-------|-----|
| ant          | 2024-03-12  | default         | yes   | yes |
| astral       | 2022-04-11  | build,run       | no    | -   |
| bbmap        | 2019-07/09  | default         | yes   | yes |
| fastqc       | 2023-06-05  | run             | -     | yes |
| hdf5+java    | 2024-01-10  | build,run       | yes   | ?   |
| lucene       | 2023-03-08  | run             | -     | yes |
| opencv       | 2023-09-26  | default         | yes   | ?   |
| openmpi+java | 2024-04-11  | default         | yes   | ?   |
| solr         | 2023-04-11  | run             | -     | yes |
| spark        | 2024-05-18  | build,run       | yes   | ?   |
| snpeff       | 2022-04-26  | build,run       | yes   | yes |
| tassel       | 2022-11-03  | build,run       | yes   | ?   |

Based on these results, the change appears to be safe. For any packages having issues, specifying the required version of OpenJDK should be neccesary.

I also include the propagation of the fix in #30826 for the newer MacOS versions.

EDIT:
From the pipeline results, it also seems that stc doesn't build, so it will also require to limit the java version in the package (or add a newer version, perhaps).