### PR TITLE
verilator: Some environment varibles are no longer required

### DIFF
--- a/var/spack/repos/builtin/packages/verilator/package.py
+++ b/var/spack/repos/builtin/packages/verilator/package.py
@@ -86,9 +86,9 @@ class Verilator(AutotoolsPackage):
     filter_compiler_wrappers("verilated.mk", relative_root="include")
     filter_compiler_wrappers("verilated.mk", relative_root="share/verilator/include")
 
+    @when("@:5.022")
     def setup_run_environment(self, env):
-        if self.spec.satisfies("@:5.022"):
-            env.prepend_path("VERILATOR_ROOT", self.prefix)
+        env.prepend_path("VERILATOR_ROOT", self.prefix)
 
     def autoreconf(self, spec, prefix):
         autoconf()

--- a/var/spack/repos/builtin/packages/verilator/package.py
+++ b/var/spack/repos/builtin/packages/verilator/package.py
@@ -75,7 +75,7 @@ class Verilator(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("help2man", type="build")
     depends_on("bison", type="build")
-    depends_on("flex", type=("build", "link"))
+    depends_on("flex")
     depends_on("perl", type=("build", "run"))
     depends_on("ccache", type=("build", "run"), when="@5.018:")
 

--- a/var/spack/repos/builtin/packages/verilator/package.py
+++ b/var/spack/repos/builtin/packages/verilator/package.py
@@ -75,18 +75,20 @@ class Verilator(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("help2man", type="build")
     depends_on("bison", type="build")
-    depends_on("flex")
-    depends_on("ccache", type=("build", "run"), when="@5.018:")
+    depends_on("flex", type=("build", "link"))
     depends_on("perl", type=("build", "run"))
+    depends_on("ccache", type=("build", "run"), when="@5.018:")
 
     conflicts("%gcc@:6", msg="C++14 support required")
 
     # we need to fix the CXX and LINK paths, as they point to the spack
     # wrapper scripts which aren't usable without spack
     filter_compiler_wrappers("verilated.mk", relative_root="include")
+    filter_compiler_wrappers("verilated.mk", relative_root="share/verilator/include")
 
     def setup_run_environment(self, env):
-        env.prepend_path("VERILATOR_ROOT", self.prefix)
+        if self.spec.satisfies("@:5.022"):
+            env.prepend_path("VERILATOR_ROOT", self.prefix)
 
     def autoreconf(self, spec, prefix):
         autoconf()


### PR DESCRIPTION
- `VERILATOR_ROOT` is no longer required to be set to get verilator to work
- `flex` needs to be used during `link` phase, if not the system one might be getting picked up
- A second file, inside `share/verilator/include`, needs to be edited, this may turn out to be instead of the one in `include`, doing both for now