### PR TITLE
flux-sched: fixed missing modules in PATH 

### DIFF
--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -185,6 +185,9 @@ class FluxSched(CMakePackage, AutotoolsPackage):
 
         env.prepend_path("FLUX_MODULE_PATH", self.prefix.lib.flux.modules)
         env.prepend_path("FLUX_MODULE_PATH", self.prefix.lib.flux.modules.sched)
+        # On some systems modules are in lib64 and lib
+        env.prepend_path("FLUX_MODULE_PATH", self.prefix.lib64.flux.modules)
+        env.prepend_path("FLUX_MODULE_PATH", self.prefix.lib64.flux.modules.sched)
         env.prepend_path("FLUX_EXEC_PATH", self.prefix.libexec.flux.cmd)
         env.prepend_path("FLUX_RC_EXTRA", self.prefix.etc.flux)
 


### PR DESCRIPTION
Modules can be missing from PATH when lib64 and lib are both used on a systen

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
