### PR TITLE
yosys: add v0.42

### DIFF
--- a/var/spack/repos/builtin/packages/yosys/package.py
+++ b/var/spack/repos/builtin/packages/yosys/package.py
@@ -20,7 +20,7 @@ class Yosys(MakefilePackage):
     """
 
     homepage = "https://yosyshq.net/yosys"
-    url = "https://github.com/YosysHQ/yosys/archive/refs/tags/yosys-0.40.tar.gz"
+    url = "https://github.com/YosysHQ/yosys/archive/refs/tags/yosys-0.42.tar.gz"
     git = "https://github.com/YosysHQ/yosys.git"
 
     maintainers("davekeeshan")
@@ -29,6 +29,7 @@ class Yosys(MakefilePackage):
 
     version("master", branch="master")
 
+    version("0.42", commit="9b6afcf3f83fea413b57c3790c25ba43b9914ce2", submodules=True)
     version("0.41", sha256="b0037d0a5864550a07a72ba81346e52a7d5f76b3027ef1d7c71b975d2c8bd2b2")
     version("0.40", sha256="c1d42ad90d587b587210b40cf3c5584e41e20f656e8630c33b6583322e8b764e")
     version("0.39", sha256="a66d95747b21d03e5b9c274d3f7cb0f7dd99610891dd66920bfaee25bc30dad1")


### PR DESCRIPTION
This release now needs to fill in a git submodule, `abc`, before the makefile will work, so moving from `sha256` releases to `git` commits

