### PR TITLE
fms: add llvm-openmp for apple-clang +openmp

### DIFF
--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -105,6 +105,9 @@ class Fms(CMakePackage):
     depends_on("mpi")
     depends_on("libyaml", when="+yaml")
 
+    # when using apple-clang version 15.x or newer, need to use the llvm-openmp library when +openmp
+    depends_on("llvm-openmp", when="+openmp %apple-clang@15:", type=("build", "run"))
+
     def cmake_args(self):
         args = [
             self.define_from_variant("GFS_PHYS"),

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -104,7 +104,7 @@ class Fms(CMakePackage):
     depends_on("netcdf-fortran")
     depends_on("mpi")
     depends_on("libyaml", when="+yaml")
-    depends_on("llvm-openmp", when="+openmp %apple-clang@15:", type=("build", "run"))
+    depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/fms/package.py
+++ b/var/spack/repos/builtin/packages/fms/package.py
@@ -104,8 +104,6 @@ class Fms(CMakePackage):
     depends_on("netcdf-fortran")
     depends_on("mpi")
     depends_on("libyaml", when="+yaml")
-
-    # when using apple-clang version 15.x or newer, need to use the llvm-openmp library when +openmp
     depends_on("llvm-openmp", when="+openmp %apple-clang@15:", type=("build", "run"))
 
     def cmake_args(self):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

In testing out building `fms` on my mac with apple-clang, I encountered this error:
```
1 error found in build log:
     26    --   - NetCDF_VERSION [4.9.2]
     27    --   - NetCDF_PARALLEL [TRUE]
     28    --   - NetCDF_C_CONFIG_EXECUTABLE [/Users/mathomp4/spack-mathomp4/opt/spack/darwin-sonoma-m1/apple-clang-15.0.0/netcdf-c-4.9.2-wrhfihqr2azsmhhegowdvgrq2l2dbkso/bin/nc-config]
     29    --   - NetCDF::NetCDF_C [SHARED] [Root: /Users/mathomp4/spack-mathomp4/opt/spack/darwin-sonoma-m1/apple-clang-15.0.0/netcdf-c-4.9.2-wrhfihqr2azsmhhegowdvgrq2l2dbkso] Lib: /Users/mathomp4/spack-
           mathomp4/opt/spack/darwin-sonoma-m1/apple-clang-15.0.0/netcdf-c-4.9.2-wrhfihqr2azsmhhegowdvgrq2l2dbkso/lib/libnetcdf.dylib
     30    --   - NetCDF_Fortran_CONFIG_EXECUTABLE [/Users/mathomp4/spack-mathomp4/opt/spack/darwin-sonoma-m1/apple-clang-15.0.0/netcdf-fortran-4.6.1-zlyiszthkdsjwl4jq3mbo5bdbqtl2y54/bin/nf-config]
     31    --   - NetCDF::NetCDF_Fortran [SHARED] [Root: /Users/mathomp4/spack-mathomp4/opt/spack/darwin-sonoma-m1/apple-clang-15.0.0/netcdf-fortran-4.6.1-zlyiszthkdsjwl4jq3mbo5bdbqtl2y54] Lib: /Users/mat
           homp4/spack-mathomp4/opt/spack/darwin-sonoma-m1/apple-clang-15.0.0/netcdf-fortran-4.6.1-zlyiszthkdsjwl4jq3mbo5bdbqtl2y54/lib/libnetcdff.dylib
  >> 32    CMake Error at /Users/mathomp4/.homebrew/brew/Cellar/cmake/3.29.5/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
     33      Could NOT find OpenMP_C (missing: OpenMP_C_FLAGS OpenMP_C_LIB_NAMES)
     34    Call Stack (most recent call first):
     35      /Users/mathomp4/.homebrew/brew/Cellar/cmake/3.29.5/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
     36      /Users/mathomp4/.homebrew/brew/Cellar/cmake/3.29.5/share/cmake/Modules/FindOpenMP.cmake:581 (find_package_handle_standard_args)
     37      CMakeLists.txt:89 (find_package)
     38

See build log for details:
  /var/folders/31/16x8_l1s72s2kw0w7byr03qm0000gp/T/mathomp4/spack-stage/spack-stage-fms-2024.01.01-ecxair2fdahk62znrvcaoysilu7zal6g/spack-build-out.txt
```

I believe @srherbener found a fix for this in previous packages which is to depend on `llvm-openmp` with apple-clang. So we do the same thing here.

--- 

Maintainers: @AlexanderRichert-NOAA  @Hang-Lei-NOAA  @climbfuji  @edwardhartnett  @rem1776