### PR TITLE
Use https, not ssh, for AMS git clones

### DIFF
--- a/var/spack/repos/builtin/packages/ams/package.py
+++ b/var/spack/repos/builtin/packages/ams/package.py
@@ -10,7 +10,7 @@ class Ams(CMakePackage, CudaPackage):
     """AMS Autonomous Multiscale Framework."""
 
     homepage = "https://github.com/LLNL/AMS"
-    git = "git@github.com:LLNL/AMS.git"
+    git = "https://github.com/LLNL/AMS.git"
 
     maintainers("koparasy", "lpottier")
 


### PR DESCRIPTION
Hey,

Just an obvious fix to allow everybody to use AMS.
Closes LLNL/AMS#70.

Cheers,
-Nuno