### PR TITLE
ESMF: set ESMF_LAPACK_LIBPATH if +external-lapack

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -330,9 +330,8 @@ class Esmf(MakefilePackage):
             # ESMF code.
             env.set("ESMF_LAPACK", "system")
 
-            # FIXME: determine whether or not we need to set this
             # Specifies the path where the LAPACK library is located.
-            # env.set("ESMF_LAPACK_LIBPATH", spec["lapack"].prefix.lib)
+            env.set("ESMF_LAPACK_LIBPATH", spec["lapack"].prefix.lib)
 
             # Specifies the linker directive needed to link the LAPACK library
             # to the application.


### PR DESCRIPTION
CC @hzfywhn @AnonNick

This PR set the `ESMF_LAPACK_LIBPATH` variable (from the `lapack` spec attributes), removing the previous FIXME and commented example.

The original PR for ESMF has those lines and is from 2017: https://github.com/spack/spack/pull/2831

The comments there describes RPATH issues, but perhaps they've been solved by now or weren't relevant to this line to begin with?

Without this line, our software compilation (using Fortran fwiw) fails with link errors, ex:

```
ld: src/esmf.F:73: undefined reference to `esmf_initmod_mp_esmf_initialize_'
```

since the LIBPATH is not set in the `esmf.mk` file.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
