### PR TITLE
sirius: fix spla+openmp requirement

### DIFF
--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -155,7 +155,8 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("spla@1.1.0:")
         depends_on("spla+cuda", when="+cuda")
         depends_on("spla+rocm", when="+rocm")
-        depends_on("spla+openmp", when="+openmp")
+        # spla removed the openmp option in 1.6.0
+        depends_on("spla+openmp", when="+openmp ^spla@:1.5")
 
     depends_on("nlcglib", when="+nlcglib")
     depends_on("nlcglib+rocm", when="+nlcglib+rocm")

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -156,7 +156,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("spla+cuda", when="+cuda")
         depends_on("spla+rocm", when="+rocm")
         # spla removed the openmp option in 1.6.0
-        depends_on("spla+openmp", when="+openmp ^spla@:1.5")
+        conflicts("^spla@:1.5~openmp", when="+openmp")
 
     depends_on("nlcglib", when="+nlcglib")
     depends_on("nlcglib+rocm", when="+nlcglib+rocm")


### PR DESCRIPTION
spla v1.6.0 removed the openmp option and now relies only on the BLAS library for multithreading (#44609). 
The current restriction unnecessarily limits the spla version if `sirius+openmp` is specified. 