### PR TITLE
[WIP] Error messages for package config requirements

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -760,23 +760,28 @@ def _concretize_specs_together_new(*abstract_specs, **kwargs):
     return [s.copy() for s in result.specs]
 
 
-def _concretize_specs_together_original(*abstract_specs, **kwargs):
-    abstract_specs = [spack.spec.Spec(s) for s in abstract_specs]
+@contextmanager
+def _as_unified(init_specs):
     tmpdir = tempfile.mkdtemp()
     builder = spack.repo.MockRepositoryBuilder(tmpdir)
     # Split recursive specs, as it seems the concretizer has issue
     # respecting conditions on dependents expressed like
     # depends_on('foo ^bar@1.0'), see issue #11160
     split_specs = [
-        dep.copy(deps=False) for spec1 in abstract_specs for dep in spec1.traverse(root=True)
+        dep.copy(deps=False) for spec1 in init_specs for dep in spec1.traverse(root=True)
     ]
     builder.add_package(
         "concretizationroot", dependencies=[(str(x), None, None) for x in split_specs]
     )
-
     with spack.repo.use_repositories(builder.root, override=False):
         # Spec from a helper package that depends on all the abstract_specs
-        concretization_root = spack.spec.Spec("concretizationroot")
+        unified_root = spack.spec.Spec("concretizationroot")
+        yield unified_root
+
+
+def _concretize_specs_together_original(*abstract_specs, **kwargs):
+    abstract_specs = [spack.spec.Spec(s) for s in abstract_specs]
+    with _as_unified(abstract_specs) as concretization_root:
         concretization_root.concretize(tests=kwargs.get("tests", False))
         # Retrieve the direct dependencies
         concrete_specs = [concretization_root[spec.name].copy() for spec in abstract_specs]

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2850,7 +2850,9 @@ class RequirementParser:
         for item in preferences:
             spec, condition, message = self._parse_prefer_conflict_item(item)
             if not message:
-                message = f"Preference from config for {pkg.name} encoded as a requirement: {str(spec)}"
+                message = (
+                    f"Preference from config for {pkg.name} encoded as a requirement: {str(spec)}"
+                )
             result.append(
                 # A strong preference is defined as:
                 #
@@ -2953,7 +2955,10 @@ class RequirementParser:
 
                 message = requirement.get("message")
                 if not message:
-                    message = f"Requirement from config (packages.yaml) for {pkg_name}: {str(constraints)}"
+                    message = (
+                        "Requirement from config (packages.yaml) "
+                        f"for {pkg_name}: {str(constraints)}"
+                    )
 
                 rules.append(
                     RequirementRule(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2820,6 +2820,8 @@ class RequirementParser:
         rules = []
         for when_spec, requirement_list in pkg.requirements.items():
             for requirements, policy, message in requirement_list:
+                if not message:
+                    message = f"Requirement from {pkg.name} package.py: {str(requirements)}"
                 rules.append(
                     RequirementRule(
                         pkg_name=pkg.name,
@@ -2847,6 +2849,8 @@ class RequirementParser:
         kind, preferences = self._raw_yaml_data(pkg, section="prefer")
         for item in preferences:
             spec, condition, message = self._parse_prefer_conflict_item(item)
+            if not message:
+                message = f"Preference from config for {pkg.name} encoded as a requirement: {str(spec)}"
             result.append(
                 # A strong preference is defined as:
                 #
@@ -2868,6 +2872,8 @@ class RequirementParser:
         kind, conflicts = self._raw_yaml_data(pkg, section="conflict")
         for item in conflicts:
             spec, condition, message = self._parse_prefer_conflict_item(item)
+            if not message:
+                message = f"Conflict from {pkg.name} package.py: {str(spec)}"
             result.append(
                 # A conflict is defined as:
                 #
@@ -2945,13 +2951,17 @@ class RequirementParser:
                 if not constraints:
                     continue
 
+                message = requirement.get("message")
+                if not message:
+                    message = f"Requirement from config (packages.yaml) for {pkg_name}: {str(constraints)}"
+
                 rules.append(
                     RequirementRule(
                         pkg_name=pkg_name,
                         policy=policy,
                         requirements=constraints,
                         kind=kind,
-                        message=requirement.get("message"),
+                        message=message,
                         condition=when,
                     )
                 )

--- a/scripts/combined-constraints.py
+++ b/scripts/combined-constraints.py
@@ -1,11 +1,13 @@
-import spack.environment as ev
-import spack.config as config
-from spack.spec import Spec
 import argparse
 from collections import defaultdict
+from typing import List
+
+import spack.config as config
+import spack.environment as ev
+from spack.spec import Spec
 
 
-def _collect_always_constraints(pkg_name, pkg_conf):
+def _collect_always_constraints(pkg_name, pkg_conf) -> List[Spec]:
     collected = []
     if "require" not in pkg_conf:
         return []
@@ -66,8 +68,8 @@ def _merge_constraint(dst_spec, extra_spec):
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Combine user specs and requirements')
-    parser.add_argument('--organizing-root', help='Use this to order output specs')
+    parser = argparse.ArgumentParser(description="Combine user specs and requirements")
+    parser.add_argument("--organizing-root", help="Use this to order output specs")
     args = parser.parse_args()
 
     e = ev.active_environment()
@@ -82,7 +84,9 @@ def main():
         if "require" not in pkg_conf:
             continue
         for constraint_spec in _collect_always_constraints(pkg_name, pkg_conf):
-            aggregated_constraints[pkg_name].append((constraint_spec, "require: from packages.yaml"))
+            aggregated_constraints[pkg_name].append(
+                (constraint_spec, "require: from packages.yaml")
+            )
 
     for pkg_name, dev_conf in config.get("develop", dict()).items():
         aggregated_constraints[pkg_name].append((Spec(dev_conf["spec"]), "Develop spec"))

--- a/scripts/combined-constraints.py
+++ b/scripts/combined-constraints.py
@@ -1,0 +1,96 @@
+import spack.environment as ev
+import spack.config as config
+from spack.spec import Spec
+import argparse
+
+
+def _collect_always_constraints(pkg_name, pkg_conf):
+    collected = []
+    if "require" not in pkg_conf:
+        return []
+    requires = pkg_conf["require"]
+    if isinstance(requires, str):
+        return [Spec(requires)]
+
+    for requirement in requires:
+        if "when" in requirement:
+            continue
+
+        if "any_of" in requirement:
+            result = requirement["any_of"]
+        elif "one_of" in requirement:
+            result = requirement["one_of"]
+        elif "spec" in requirement:
+            result = requirement["spec"]
+        else:
+            # Should not happen
+            result = []
+
+        if len(result) == 1:
+            # For one_of/any_of with >1 possibility, it's hard to
+            # produce a single spec that represents the combined
+            # state: only collect singular constraints.
+            result = [Spec(x) for x in result]
+            for x in result:
+                if not x.name:
+                    x.name = pkg_name
+            collected.extend(result)
+
+    return collected
+
+
+def _order_by_root(root, spec_dict):
+    possible_dependencies = root.package_class.possible_dependencies(expand_virtuals=False)
+    ordered = []
+    all_provided = set()
+    for x in spec_dict.values():
+        all_provided.update(x.package_class.provided.keys())
+
+    for x in possible_dependencies:
+        if x in spec_dict or x in all_provided:
+            ordered.append(spec_dict[x])
+    return ordered
+
+
+def _merge_constraint(dst_spec, extra_spec):
+    # Note: this is for abstract specs which have git commit versions
+    # that don't define a numbered-version equivalency like @...=1.0
+    dst_spec.attach_git_version_lookup()
+    extra_spec.attach_git_version_lookup()
+    try:
+        dst_spec.constrain(extra_spec)
+    except:
+        print(f"Failure to constrain {dst_spec} by {extra_spec}")
+        raise
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Combine user specs and requirements')
+    parser.add_argument('--organizing-root', help='Use this to order output specs')
+    args = parser.parse_args()
+
+    e = ev.active_environment()
+    aggregated_constraints = dict((x.name, Spec(x)) for x in e.user_specs)
+
+    conf = config.get("packages")
+    for pkg_name, pkg_conf in conf.items():
+        if pkg_name == "all":
+            continue
+        if "require" not in pkg_conf:
+            continue
+        for constraint_spec in _collect_always_constraints(pkg_name, pkg_conf):
+            if constraint_spec.name not in aggregated_constraints:
+                aggregated_constraints[pkg_name] = constraint_spec
+            else:
+                _merge_constraint(aggregated_constraints[constraint_spec.name], constraint_spec)
+
+    ordered = list(aggregated_constraints.values())
+    if args.organizing_root:
+        ordered = _order_by_root(aggregated_constraints[args.organizing_root], aggregated_constraints)
+
+    print("Aggregated constraints:")
+    print("\t" + "\n\t".join(str(x) for x in ordered))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/combined-constraints.py
+++ b/scripts/combined-constraints.py
@@ -98,6 +98,10 @@ def main():
     for pkg_name, dev_conf in config.get("develop", dict()).items():
         aggregated_constraints[pkg_name].append((Spec(dev_conf["spec"]), "Develop spec"))
 
+    # TODO: if there are constraints on virtuals, and a provider is in the
+    # list of aggregated constraints, the virtual constraints should be
+    # moved to the provider here.
+
     merged_constraints = dict()
     for pkg_name, per_pkg_constraints in aggregated_constraints.items():
         base_spec, reason = per_pkg_constraints[0]

--- a/scripts/combined-constraints.py
+++ b/scripts/combined-constraints.py
@@ -3,6 +3,7 @@ import sys
 from collections import defaultdict
 from typing import List
 
+import spack.concretize
 import spack.config as config
 import spack.environment as ev
 import spack.error
@@ -74,6 +75,11 @@ def _top_level_constraints_error(pkg_name, constraints):
     )
 
 
+def _check_normalized_constraints(specs):
+    with spack.concretize._as_unified(specs) as root:
+        root.normalize()
+
+
 def main():
     parser = argparse.ArgumentParser(description="Combine user specs and requirements")
     parser.add_argument("--organizing-root", help="Use this to order output specs")
@@ -113,6 +119,8 @@ def main():
                 _top_level_constraints_error(pkg_name, per_pkg_constraints)
                 sys.exit(1)
         merged_constraints[pkg_name] = accumulated
+
+    _check_normalized_constraints(merged_constraints.values())
 
     ordered = list(merged_constraints.values())
     if args.organizing_root:

--- a/scripts/combined-constraints.py
+++ b/scripts/combined-constraints.py
@@ -1,6 +1,6 @@
 import argparse
-from collections import defaultdict
 import sys
+from collections import defaultdict
 from typing import List
 
 import spack.config as config
@@ -66,12 +66,12 @@ def _merge_constraint(dst_spec, extra_spec):
 
 
 def _top_level_constraints_error(pkg_name, constraints):
-    formatted_constraints = "\n\t".join(
-        f"{spec} ({reason})" for spec, reason in constraints
-    )
-    print(f"""Conflicting user-specified constraints for {pkg_name}:
+    formatted_constraints = "\n\t".join(f"{spec} ({reason})" for spec, reason in constraints)
+    print(
+        f"""Conflicting user-specified constraints for {pkg_name}:
 \t{formatted_constraints}
-""")
+"""
+    )
 
 
 def main():

--- a/scripts/combined-constraints.py
+++ b/scripts/combined-constraints.py
@@ -27,10 +27,9 @@ def _collect_always_constraints(pkg_name, pkg_conf) -> List[Spec]:
         elif "one_of" in requirement:
             result = requirement["one_of"]
         elif "spec" in requirement:
-            result = requirement["spec"]
+            result = [requirement["spec"]]
         else:
-            # Should not happen
-            result = []
+            raise ValueError(f"Unexpected requirement {str(requirement)}")
 
         if len(result) == 1:
             # For one_of/any_of with >1 possibility, it's hard to


### PR DESCRIPTION
Before this PR, if you have an env like:

```
spack:
  specs:
  - raja
  view: false
  concretizer:
    unify: true
  develop:
    raja:
      spec: raja@=2024.02.0
  packages:
    raja:
      require: "@2023.06.1"
```

and you concretize, the error message is vague:

```
$ spack concretize -f -U
==> Error: concretization failed for the following reasons:

   1. cannot satisfy a requirement for package 'raja'.
```

The more-modest part of this PR (contained in the first couple of commits) adds default explanatory messages to requirements so that the error has more info:

```
$ spack concretize -f -U
==> Error: concretization failed for the following reasons:

   1. Requirement from config (packages.yaml) for raja: [@2023.06.1]
```

The more ambitious part of this adds a `spack python` script called `combined-constraints.py`, which you can run for an active `unify:true` environment:

```
$ spack python scripts/combined-constraints.py 
Conflicting user-specified constraints for raja:
	raja (Environment speclist)
	@2023.06.1 (require: from packages.yaml)
	raja@=2024.02.0 (Develop spec)
```

This script is attempting to identify provably-minimal conflicting constraint groups for a subset of errors where that is possible:

* In this case, the user specified two directly conflicting constraints
* The script also uses `normalize`, which effectively transitively applies all conjunction constraints in the `.lp`
  * There might be some exceptions to this, but `normalize` is "nearly" doing this, so I started with that for now
  * If this fails, then
    * The new solver is also guaranteed to fail
    * We can generate a very informative error message about all the necessary transitive constraints which led to the error (for now that requires re-executing with `spack -d`, which prints each constraint as it's applied, but this could be automated/repackaged into something user-friendly)