### PR TITLE
hpctoolkit: Add conflict for `elfutils @0.191:`

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -213,6 +213,12 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
     conflicts("^xz@5.2.7:5.2.8", msg="avoid xz 5.2.7:5.2.8 (broken symbol versions)")
     conflicts("^intel-xed@2023.08:", when="@:2023.09")
 
+    # https://gitlab.com/hpctoolkit/hpctoolkit/-/issues/831
+    conflicts(
+        "^elfutils@0.191:",
+        msg="avoid elfutils 0.191 (known critical errors in hpcstruct for CUDA binaries)",
+    )
+
     conflicts("+cray", when="@2022.10.01", msg="hpcprof-mpi is not available in 2022.10.01")
     conflicts("+mpi", when="@2022.10.01", msg="hpcprof-mpi is not available in 2022.10.01")
 


### PR DESCRIPTION
When built with `elfutils @0.191`, `hpcstruct` generates unusable data for CUDA binaries. See https://gitlab.com/hpctoolkit/hpctoolkit/-/issues/831 for details.

Add a `conflicts()` so that `hpctoolkit` isn't built with the newer `elfutils` until this issue is resolved.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
