### PR TITLE
QE SIRIUS hard dependency on mpi

### DIFF
--- a/var/spack/repos/builtin/packages/q-e-sirius/package.py
+++ b/var/spack/repos/builtin/packages/q-e-sirius/package.py
@@ -27,7 +27,6 @@ class QESirius(CMakePackage):
         submodules=True,
     )
 
-    variant("mpi", default=True, description="Builds with MPI support")
     variant("openmp", default=True, description="Enables OpenMP support")
     variant("libxc", default=False, description="Support functionals through libxc")
     variant("sirius_apps", default=False, description="Build SIRIUS standalone binaries")
@@ -47,7 +46,7 @@ class QESirius(CMakePackage):
     depends_on("sirius +openmp", when="+openmp")
     depends_on("sirius@develop", when="@develop-ristretto")
 
-    depends_on("mpi", when="+mpi")
+    depends_on("mpi")
     depends_on("elpa", when="+elpa")
     depends_on("libxc", when="+libxc")
     depends_on("fftw-api@3")
@@ -56,12 +55,9 @@ class QESirius(CMakePackage):
     depends_on("git", type="build")
     depends_on("pkgconfig", type="build")
 
-    conflicts("~mpi", when="+scalapack", msg="SCALAPACK requires MPI support")
     conflicts("~scalapack", when="+elpa", msg="ELPA requires SCALAPACK support")
 
-    with when("+mpi"):
-        depends_on("mpi")
-        variant("scalapack", default=True, description="Enables scalapack support")
+    variant("scalapack", default=True, description="Enables scalapack support")
 
     with when("+scalapack"):
         depends_on("scalapack")
@@ -82,7 +78,7 @@ class QESirius(CMakePackage):
             "-DQE_ENABLE_CUDA=OFF",
             "-DQE_LAPACK_INTERNAL=OFF",
             "-DQE_ENABLE_DOC=OFF",
-            self.define_from_variant("QE_ENABLE_MPI", "mpi"),
+            "-DQE_ENABLE_MPI=ON",
             self.define_from_variant("QE_ENABLE_OPENMP", "openmp"),
             self.define_from_variant("QE_ENABLE_ELPA", "elpa"),
             self.define_from_variant("QE_ENABLE_LIBXC", "libxc"),


### PR DESCRIPTION
SIRIUS adds a hard dependency on mpi.

Replace `variant("mpi")` by `depends_on("mpi")`.