### PR TITLE
aws-pcluster stack: Remove deprecated intel-* packages

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
@@ -19,8 +19,6 @@ packages:
           - "+intel_provided_gcc ^intel-oneapi-mkl target=x86_64_v4"
           - "+intel_provided_gcc ^intel-oneapi-mkl target=x86_64_v3"
         when: "%intel"
-  intel-mpi:
-    variants: +external-libfabric
   intel-oneapi-compilers:
     require: "intel-oneapi-compilers %gcc target=x86_64_v3"
   intel-oneapi-mpi:
@@ -110,12 +108,15 @@ packages:
       read: world
       write: user
     providers:
-      blas: [intel-oneapi-mkl, intel-mkl]
-      daal: [intel-oneapi-dal, intel-daal]
-      fftw-api: [intel-oneapi-mkl, intel-mkl]
-      ipp: [intel-oneapi-ipp, intel-ipp]
-      lapack: [intel-oneapi-mkl, intel-mkl]
-      mkl: [intel-oneapi-mkl, intel-mkl]
+      blas: [intel-oneapi-mkl]
+      daal: [intel-oneapi-dal]
+      fftw-api: [intel-oneapi-mkl]
+      ipp: [intel-oneapi-ipp]
+      lapack: [intel-oneapi-mkl]
+      mkl: [intel-oneapi-mkl]
       mpi: [intel-oneapi-mpi, openmpi, mpich]
       tbb: [intel-oneapi-tbb, intel-tbb]
-      scalapack: [intel-oneapi-mkl, intel-mkl]
+      scalapack: [intel-oneapi-mkl]
+
+
+


### PR DESCRIPTION
Packages will be removed with https://github.com/spack/spack/pull/44689. This PR makes sure that the `aws-pcluster-x86_64_v4` stack still works as expected.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
