### PR TITLE
vtk-m: Changed test method names and skipping non-applicable tests to use new API

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -226,8 +226,8 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
 
         return options
 
-    # Delegate in the vtk-m built smoke test
     def test_smoke_test(self):
+        """Test vtk-m with +examples"""
         spec = self.spec
 
         if "+examples" not in spec:

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -227,13 +227,11 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
         return options
 
     # Delegate in the vtk-m built smoke test
-    def smoke_test(self):
+    def test_smoke_test(self):
         spec = self.spec
 
         if "+examples" not in spec:
-            raise RuntimeError(
-                "Examples needed for smoke test missing", "reinstall with `+examples` variant"
-            )
+            raise SkipTest("Package must be installed with 'examples'")
 
         testdir = "smoke_test_build"
         with working_dir(testdir, create=True):
@@ -248,7 +246,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
     @run_after("install")
     @on_package_attributes(run_tests=True)
     def build_test(self):
-        self.smoke_test()
+        self.test_smoke_test()
 
-    def test(self):
-        self.smoke_test()
+    def test_build(self):
+        self.test_smoke_test()

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -227,7 +227,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
         return options
 
     def test_smoke_test(self):
-        """Test vtk-m with +examples"""
+        """Build and run ctests"""
         spec = self.spec
 
         if "+examples" not in spec:

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -231,7 +231,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
         spec = self.spec
 
         if "+examples" not in spec:
-            raise SkipTest("Package must be installed with 'examples'")
+            raise SkipTest("Package must be installed with +examples")
 
         testdir = "smoke_test_build"
         with working_dir(testdir, create=True):
@@ -246,7 +246,4 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
     @run_after("install")
     @on_package_attributes(run_tests=True)
     def build_test(self):
-        self.test_smoke_test()
-
-    def test_build(self):
         self.test_smoke_test()


### PR DESCRIPTION
Update standalone test API. See below comment for test output.

Supersedes #35807 updates for the package

https://spack.readthedocs.io/en/latest/packaging_guide.html#stand-alone-tests