### PR TITLE
startup-notification: fixes #44708

### DIFF
--- a/var/spack/repos/builtin/packages/startup-notification/package.py
+++ b/var/spack/repos/builtin/packages/startup-notification/package.py
@@ -20,3 +20,4 @@ class StartupNotification(AutotoolsPackage):
     depends_on("libx11")
     depends_on("libxcb")
     depends_on("xcb-util")
+    depends_on("pkgconfig", type="build")


### PR DESCRIPTION
This adds `pkgconfig` as a build dependency to `startup-notification`. Without this the configure script fails to find libxcb and fails.

Fixes: #44708