### PR TITLE
omega-h: reformatted from old to new test API

### DIFF
--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -158,23 +158,26 @@ class OmegaH(CMakePackage, CudaPackage):
 
         return (None, None, flags)
 
-    def test(self):
+    def test_osh_box(self):
+        """testing mesh construction"""
         if self.spec.version < Version("9.34.1"):
-            print("Skipping tests since only relevant for versions > 9.34.1")
-            return
-
-        exe = join_path(self.prefix.bin, "osh_box")
+            raise SkipTest("Package must be installed as version 9.34.1 or later")
+        exe = which(join_path(self.prefix.bin, "osh_box"))
         options = ["1", "1", "1", "2", "2", "2", "box.osh"]
-        description = "testing mesh construction"
-        self.run_test(exe, options, purpose=description)
+        exe(*options)
 
-        exe = join_path(self.prefix.bin, "osh_scale")
+    def test_osh_scale(self):
+        """testing mesh adaptation"""
+        if self.spec.version < Version("9.34.1"):
+            raise SkipTest("Package must be installed as version 9.34.1 or later")
+        exe = which(join_path(self.prefix.bin, "osh_scale"))
         options = ["box.osh", "100", "box_100.osh"]
-        expected = "adapting took"
-        description = "testing mesh adaptation"
-        self.run_test(exe, options, expected, purpose=description)
+        exe(*options)
 
-        exe = join_path(self.prefix.bin, "osh2vtk")
+    def test_vtu(self):
+        """testing mesh to vtu conversion"""
+        if self.spec.version < Version("9.34.1"):
+            raise SkipTest("Package must be installed as version 9.34.1 or later")
+        exe = which(join_path(self.prefix.bin, "osh2vtk"))
         options = ["box_100.osh", "box_100_vtk"]
-        description = "testing mesh to vtu conversion"
-        self.run_test(exe, options, purpose=description)
+        exe(*options)

--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -172,9 +172,10 @@ class OmegaH(CMakePackage, CudaPackage):
             raise SkipTest("Package must be installed as version 9.34.1 or later")
         exe = which(join_path(self.prefix.bin, "osh_scale"))
         options = ["box.osh", "100", "box_100.osh"]
-        exe(*options)
+        actual = exe(*options, output=str.split, error=str.split)
+        assert "adapting took" in actual
 
-    def test_vtu(self):
+    def test_osh2vtk(self):
         """testing mesh to vtu conversion"""
         if self.spec.version < Version("9.34.1"):
             raise SkipTest("Package must be installed as version 9.34.1 or later")


### PR DESCRIPTION
Update standalone test API. See below for test output.

Test Failure Reported: #44732 
Supersedes #35807 for the package

https://spack.readthedocs.io/en/latest/packaging_guide.html#stand-alone-tests

```
==> Testing package omega-h-9.34.13-v5rpb5a
==> [2024-06-14-17:32:50.506378] test: test_osh2vtk: testing mesh to vtu conversion
==> [2024-06-14-17:32:50.508341] '$spack/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/omega-h-9.34.13-v5rpb5aswwlnwkfx7u4rr72a5in2sero/bin/osh2vtk' 'box_100.osh' 'box_100_vtk'
--------------------------------------------------------------------------
WARNING: Open MPI failed to open the /dev/knem device due to a local
error. Please check with your system administrator to get the problem
fixed, or set the smsc MCA variable to "^knem" to silence this warning
and run without knem support.

Open MPI will try to fall back on another single-copy mechanism if one
is available.  This may result in lower performance.

  Local host: quartz764
  Errno:      2 (No such file or directory)
--------------------------------------------------------------------------
could not open file "box_100.osh/nparts"
[quartz764:4136989] *** Process received signal ***
[quartz764:4136989] Signal: Aborted (6)
[quartz764:4136989] Signal code:  (-6)
...
======================= SUMMARY: omega-h-9.34.13-v5rpb5a =======================
OmegaH::test_osh2vtk .. FAILED
OmegaH::test_osh_box .. PASSED
OmegaH::test_osh_scale .. PASSED
======================== 1 failed, 2 passed of 3 parts =========================
```