### PR TITLE
CI: Developer Tools uses ubuntu20.04 image

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -493,6 +493,7 @@ build_systems-build:
 
 developer-tools-generate:
   extends: [ ".developer-tools", ".generate-x86_64"]
+  image: "ghcr.io/spack/ubuntu20.04-runner-amd64-gcc-11.4:2023.08.01"
 
 developer-tools-build:
   extends: [ ".developer-tools", ".build" ]


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Make the images consistent.