### PR TITLE
Update cudnn/package.py

### DIFF
--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -382,7 +382,6 @@ class Cudnn(Package):
             env.set("cuDNN_ROOT", os.path.join(self.prefix, "targets", "ppc64le-linux"))
             env.set("cuDNN_HOME", os.path.join(self.prefix, "targets", "ppc64le-linux"))
             env.set("cuDNN_PATH", os.path.join(self.prefix, "targets", "ppc64le-linux"))
-            
 
     def install(self, spec, prefix):
         install_tree(".", prefix)

--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -380,6 +380,9 @@ class Cudnn(Package):
 
         if "target=ppc64le: platform=linux" in self.spec:
             env.set("cuDNN_ROOT", os.path.join(self.prefix, "targets", "ppc64le-linux"))
+            env.set("cuDNN_HOME", os.path.join(self.prefix, "targets", "ppc64le-linux"))
+            env.set("cuDNN_PATH", os.path.join(self.prefix, "targets", "ppc64le-linux"))
+            
 
     def install(self, spec, prefix):
         install_tree(".", prefix)


### PR DESCRIPTION
Some software is using CUDNN_HOME and CUDNN_PATH instead of CUDNN_ROOT

This will help useres with some python libs depending on cudnn, e.g. pytorch with C++ extensions


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
