### PR TITLE
neovim: update libvterm minimum requirement for 0.10.0

### DIFF
--- a/var/spack/repos/builtin/packages/neovim/package.py
+++ b/var/spack/repos/builtin/packages/neovim/package.py
@@ -139,6 +139,7 @@ class Neovim(CMakePackage):
         depends_on("tree-sitter@0.20.8:")
     with when("@0.10:"):
         depends_on("cmake@3.13:", type="build")
+        depends_on("libvterm@0.3.3:")
         depends_on("tree-sitter@0.20.9:")
 
     # Support for `libvterm@0.2:` has been added in neovim@0.8.0


### PR DESCRIPTION
According to https://github.com/neovim/neovim/commit/7a5effb0f95e295c265fe09e7414d859a6d79657 this has been forgot in #44365.