### PR TITLE
snakemake: Changed test method name and added docstring

### DIFF
--- a/var/spack/repos/builtin/packages/snakemake/package.py
+++ b/var/spack/repos/builtin/packages/snakemake/package.py
@@ -130,5 +130,6 @@ class Snakemake(PythonPackage):
     )
     depends_on("py-requests", when="+http", type=("build", "run"))
 
-    def test(self):
+    def test_build(self):
+        """Test if snakemake builds correctly"""
         Executable("snakemake")("--version")

--- a/var/spack/repos/builtin/packages/snakemake/package.py
+++ b/var/spack/repos/builtin/packages/snakemake/package.py
@@ -130,6 +130,6 @@ class Snakemake(PythonPackage):
     )
     depends_on("py-requests", when="+http", type=("build", "run"))
 
-    def test_build(self):
-        """Test if snakemake builds correctly"""
+    def test_run(self):
+        """Test if snakemake runs correctly"""
         Executable("snakemake")("--version")

--- a/var/spack/repos/builtin/packages/snakemake/package.py
+++ b/var/spack/repos/builtin/packages/snakemake/package.py
@@ -132,4 +132,4 @@ class Snakemake(PythonPackage):
 
     def test_run(self):
         """Test if snakemake runs correctly"""
-        Executable("snakemake")("--version")
+        Executable(self.prefix.bin.snakemake)("--version")

--- a/var/spack/repos/builtin/packages/snakemake/package.py
+++ b/var/spack/repos/builtin/packages/snakemake/package.py
@@ -131,5 +131,5 @@ class Snakemake(PythonPackage):
     depends_on("py-requests", when="+http", type=("build", "run"))
 
     def test_run(self):
-        """Test if snakemake runs correctly"""
+        """Test if snakemake runs with the version option"""
         Executable(self.prefix.bin.snakemake)("--version")


### PR DESCRIPTION
Update standalone test API. See below for test output.

Supersedes #35805 (for one package)

https://spack.readthedocs.io/en/latest/packaging_guide.html#stand-alone-tests

The renamed test passes; however, the inherited import test fails (see below). 

If this is expected, a separate PR can be created to add the `skip_modules` property with a list of those failing test modules below (see the docs at https://spack.readthedocs.io/en/latest/build_systems/pythonpackage.html#import-tests).

```
...
==> [2024-06-14-18:08:29.611305] test: test_run: Test if snakemake runs correctly
==> [2024-06-14-18:08:29.611701] 'snakemake' '--version'
8.5.2
PASSED: Snakemake::test_run
==> [2024-06-14-18:08:30.926146] Completed testing
==> [2024-06-14-18:08:30.926564] 
============== SUMMARY: snakemake-8.5.2-tubxkns =======================
Snakemake::test_imports_snakemake .. PASSED
Snakemake::test_imports_snakemake.caching .. PASSED
Snakemake::test_imports_snakemake.common .. PASSED
Snakemake::test_imports_snakemake.common.tests .. FAILED
Snakemake::test_imports_snakemake.common.tests.testcases .. FAILED
Snakemake::test_imports_snakemake.common.tests.testcases.groups .. FAILED
Snakemake::test_imports_snakemake.common.tests.testcases.simple .. FAILED
Snakemake::test_imports_snakemake.deployment .. PASSED
Snakemake::test_imports_snakemake.executors .. PASSED
Snakemake::test_imports_snakemake.linting .. PASSED
Snakemake::test_imports_snakemake.remote .. PASSED
Snakemake::test_imports_snakemake.report .. PASSED
Snakemake::test_imports_snakemake.report.html_reporter .. PASSED
Snakemake::test_imports_snakemake.report.html_reporter.data .. PASSED
Snakemake::test_imports_snakemake.report.html_reporter.template .. PASSED
Snakemake::test_imports_snakemake.report.html_reporter.template.components .. PASSED
Snakemake::test_imports_snakemake.script .. PASSED
Snakemake::test_imports_snakemake.template_rendering .. PASSED
Snakemake::test_imports_snakemake.unit_tests .. PASSED
Snakemake::test_imports_snakemake.unit_tests.templates .. PASSED
Snakemake::test_imports .. FAILED
Snakemake::test_run .. PASSED
======================= 17 passed, 5 failed of 22 parts ========================
```