### PR TITLE
`spack-python`: remove superfluous `/usr/bin/env`

### DIFF
--- a/bin/spack-python
+++ b/bin/spack-python
@@ -22,4 +22,4 @@
 #
 # This is compatible across platforms.
 #
-exec /usr/bin/env spack python "$@"
+exec spack python "$@"


### PR DESCRIPTION
Not sure why I had this here, as `/bin/sh` will find the first spack in `PATH` just like `env`.

- [x] remove `/usr/bin/env` and avoid an extra process launch.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
