### PR TITLE
libstdcompat: removed duplicate build-time test method

### DIFF
--- a/var/spack/repos/builtin/packages/libstdcompat/package.py
+++ b/var/spack/repos/builtin/packages/libstdcompat/package.py
@@ -107,9 +107,3 @@ class Libstdcompat(CMakePackage):
         else:
             args.append("-DBUILD_TESTING=OFF")
         return args
-
-    @run_after("build")
-    @on_package_attributes(run_tests=True)
-    def test_execute(self):
-        """Test if libstdcompat executes correctly"""
-        make("test")

--- a/var/spack/repos/builtin/packages/libstdcompat/package.py
+++ b/var/spack/repos/builtin/packages/libstdcompat/package.py
@@ -110,5 +110,6 @@ class Libstdcompat(CMakePackage):
 
     @run_after("build")
     @on_package_attributes(run_tests=True)
-    def test(self):
+    def test_execute(self):
+        """Test if libstdcompat executes correctly"""
         make("test")


### PR DESCRIPTION
Update standalone test API. See below comment for test output.

Supersedes #35777 (for one package)

https://spack.readthedocs.io/en/latest/packaging_guide.html#stand-alone-tests