### PR TITLE
legion: Reformatted Old To New Test Method and skipping tests

### DIFF
--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -476,18 +476,15 @@ class Legion(CMakePackage, ROCmPackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources([join_path("examples", "local_function_tasks")])
 
-    def run_local_function_tasks_test(self):
-        """Run stand alone test: local_function_tasks"""
+    def test_run_local_function_tasks(self):
+        """Run local_function_tasks"""
 
         test_dir = join_path(
             self.test_suite.current_test_cache_dir, "examples", "local_function_tasks"
         )
 
         if not os.path.exists(test_dir):
-            print("Skipping local_function_tasks test")
-            return
-
-        exe = "local_function_tasks"
+            raise SkipTest(f"{test_dir} must exist")
 
         cmake_args = [
             f"-DCMAKE_C_COMPILER={self.compiler.cc}",
@@ -495,16 +492,12 @@ class Legion(CMakePackage, ROCmPackage):
             f"-DLegion_DIR={join_path(self.prefix, 'share', 'Legion', 'cmake')}",
         ]
 
-        self.run_test(
-            "cmake",
-            options=cmake_args,
-            purpose=f"test: generate makefile for {exe} example",
-            work_dir=test_dir,
-        )
+        with working_dir(test_dir):
+            cmake = which("cmake")
+            cmake(*cmake_args)
 
-        self.run_test("make", purpose=f"test: build {exe} example", work_dir=test_dir)
+            make = which("make")
+            make()
 
-        self.run_test(exe, purpose=f"test: run {exe} example", work_dir=test_dir)
-
-    def test(self):
-        self.run_local_function_tasks_test()
+            exe = which("local_function_tasks")
+            exe()

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -477,7 +477,7 @@ class Legion(CMakePackage, ROCmPackage):
         self.cache_extra_test_sources([join_path("examples", "local_function_tasks")])
 
     def test_run_local_function_tasks(self):
-        """Run local_function_tasks"""
+        """Build and run external application example"""
 
         test_dir = join_path(
             self.test_suite.current_test_cache_dir, "examples", "local_function_tasks"
@@ -493,7 +493,7 @@ class Legion(CMakePackage, ROCmPackage):
         ]
 
         with working_dir(test_dir):
-            cmake = which("cmake")
+            cmake = self.spec["cmake"].command
             cmake(*cmake_args)
 
             make = which("make")


### PR DESCRIPTION
Update standalone test API. See below comment for test output.

Supersedes #35807 updates for the package

https://spack.readthedocs.io/en/latest/packaging_guide.html#stand-alone-tests