### PR TITLE
py-maturin: add v1.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-maturin/package.py
+++ b/var/spack/repos/builtin/packages/py-maturin/package.py
@@ -18,12 +18,14 @@ class PyMaturin(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.6.0", sha256="b955025c24c8babc808db49e0ff90db8b4b1320dcc16b14eb26132841737230d")
     version("1.5.1", sha256="3dd834ece80edb866af18cbd4635e0ecac40139c726428d5f1849ae154b26dca")
     version("1.4.0", sha256="ed12e1768094a7adeafc3a74ebdb8dc2201fa64c4e7e31f14cfc70378bf93790")
     version("1.1.0", sha256="4650aeaa8debd004b55aae7afb75248cbd4d61cd7da2dcf4ead8b22b58cecae0")
     version("0.14.17", sha256="fb4e3311e8ce707843235fbe8748a05a3ae166c3efd6d2aa335b53dfc2bd3b88")
     version("0.13.7", sha256="c0a77aa0c57f945649ca711c806203a1b6888ad49c2b8b85196ffdcf0421db77")
 
+    depends_on("bzip2")
     with default_args(type="build"):
         depends_on("py-setuptools")
         depends_on("py-wheel@0.36.2:")
@@ -38,5 +40,3 @@ class PyMaturin(PythonPackage):
             ("1.59", "0.13.3"),
         ]:
             depends_on(f"rust@{rust}:", when=f"@{maturin}:")
-
-    conflicts("python@3.11:")

--- a/var/spack/repos/builtin/packages/py-maturin/package.py
+++ b/var/spack/repos/builtin/packages/py-maturin/package.py
@@ -25,7 +25,6 @@ class PyMaturin(PythonPackage):
     version("0.14.17", sha256="fb4e3311e8ce707843235fbe8748a05a3ae166c3efd6d2aa335b53dfc2bd3b88")
     version("0.13.7", sha256="c0a77aa0c57f945649ca711c806203a1b6888ad49c2b8b85196ffdcf0421db77")
 
-    depends_on("bzip2")
     with default_args(type="build"):
         depends_on("py-setuptools")
         depends_on("py-wheel@0.36.2:")
@@ -40,3 +39,8 @@ class PyMaturin(PythonPackage):
             ("1.59", "0.13.3"),
         ]:
             depends_on(f"rust@{rust}:", when=f"@{maturin}:")
+
+    # May be an accidental dependency, remove in the future
+    # https://git.alpinelinux.org/aports/commit/?id=7ad298b467403b96a6b97d050170e367f147a75f
+    # https://patchwork.yoctoproject.org/project/oe-core/patch/8803dc101b641c948805cab9e5784c38f43b0e51.1702791173.git.tim.orling@konsulko.com/
+    depends_on("bzip2", when="platform=darwin")


### PR DESCRIPTION
Missing bzip2 dep broke things, but I didn't encounter any issues with Python 3.11.