### PR TITLE
[cp2k] Enforce exclusion of libxsmm main

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -169,15 +169,12 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("cray-libsci+openmp", when="^[virtuals=blas] cray-libsci")
 
     with when("smm=libxsmm"):
-        depends_on("libxsmm@:1~header-only")
-        depends_on("libxsmm@1.17:~header-only", when="@9.1:")
+        depends_on("libxsmm~header-only")
+        depends_on("libxsmm@1.17", when="@9.1:")
         # require libxsmm-1.11+ since 1.10 can leak file descriptors in Fortran
-        depends_on("libxsmm@1.11:~header-only", when="@:8.9")
+        depends_on("libxsmm@1.11", when="@:8.9")
         # use pkg-config (support added in libxsmm-1.10) to link to libxsmm
         depends_on("pkgconfig", type="build")
-        # please set variants: smm=blas by configuring packages.yaml or install
-        # cp2k with option smm=blas on aarch64
-        conflicts("target=aarch64:", msg="libxsmm is not available on arm")
 
     with when("+libint"):
         depends_on("pkgconfig", type="build", when="@7.0:")

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -169,6 +169,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("cray-libsci+openmp", when="^[virtuals=blas] cray-libsci")
 
     with when("smm=libxsmm"):
+        depends_on("libxsmm@:1~header-only")
         depends_on("libxsmm@1.17:~header-only", when="@9.1:")
         # require libxsmm-1.11+ since 1.10 can leak file descriptors in Fortran
         depends_on("libxsmm@1.11:~header-only", when="@:8.9")

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -170,9 +170,11 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
 
     with when("smm=libxsmm"):
         depends_on("libxsmm~header-only")
-        depends_on("libxsmm@1.17", when="@9.1:")
         # require libxsmm-1.11+ since 1.10 can leak file descriptors in Fortran
-        depends_on("libxsmm@1.11", when="@:8.9")
+        depends_on("libxsmm@1.11:")
+        depends_on("libxsmm@1.17:", when="@9.1:")
+        # build needs to be fixed for libxsmm@2 once it is released
+        depends_on("libxsmm@:1")
         # use pkg-config (support added in libxsmm-1.10) to link to libxsmm
         depends_on("pkgconfig", type="build")
 
@@ -286,6 +288,8 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("dbcsr+mpi", when="+mpi")
         depends_on("dbcsr+cuda", when="+cuda")
         depends_on("dbcsr+rocm", when="+rocm")
+        depends_on("dbcsr smm=libxsmm", when="smm=libxsmm")
+        depends_on("dbcsr smm=blas", when="smm=blas")
 
     with when("@2022: +rocm"):
         depends_on("hipblas")

--- a/var/spack/repos/builtin/packages/dbcsr/package.py
+++ b/var/spack/repos/builtin/packages/dbcsr/package.py
@@ -54,7 +54,8 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("blas")
     depends_on("lapack")
     depends_on("mpi", when="+mpi")
-    depends_on("libxsmm@1.11:~header-only", when="smm=libxsmm")
+
+    depends_on("libxsmm@:1~header-only", when="smm=libxsmm")
 
     depends_on("cmake@3.10:", type="build")
     depends_on("cmake@3.12:", type="build", when="@2.1:")

--- a/var/spack/repos/builtin/packages/dbcsr/package.py
+++ b/var/spack/repos/builtin/packages/dbcsr/package.py
@@ -55,7 +55,9 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("lapack")
     depends_on("mpi", when="+mpi")
 
-    depends_on("libxsmm@:1~header-only", when="smm=libxsmm")
+    with when("smm=libxsmm"):
+        depends_on("libxsmm~header-only")
+        depends_on("libxsmm@1.11:1")
 
     depends_on("cmake@3.10:", type="build")
     depends_on("cmake@3.12:", type="build", when="@2.1:")


### PR DESCRIPTION
Enforce the exclusion of libxsmm main with cp2k and dbcsr

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
