### PR TITLE
Bugfix: omega-h stand-alone tests: ensure proper ordering

### DIFF
--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -158,27 +158,20 @@ class OmegaH(CMakePackage, CudaPackage):
 
         return (None, None, flags)
 
-    def test_osh_box(self):
-        """testing mesh construction"""
-        if self.spec.version < Version("9.34.1"):
+    def test_mesh(self):
+        """test construction, adaptation, and conversion of a mesh"""
+        if self.spec.satisfies("@:9.34.0"):
             raise SkipTest("Package must be installed as version 9.34.1 or later")
-        exe = which(join_path(self.prefix.bin, "osh_box"))
-        options = ["1", "1", "1", "2", "2", "2", "box.osh"]
-        exe(*options)
 
-    def test_osh_scale(self):
-        """testing mesh adaptation"""
-        if self.spec.version < Version("9.34.1"):
-            raise SkipTest("Package must be installed as version 9.34.1 or later")
-        exe = which(join_path(self.prefix.bin, "osh_scale"))
-        options = ["box.osh", "100", "box_100.osh"]
-        actual = exe(*options, output=str.split, error=str.split)
-        assert "adapting took" in actual
+        with test_part(self, "test_mesh_create", purpose="mesh construction"):
+            exe = which(self.prefix.bin.osh_box)
+            exe("1", "1", "1", "2", "2", "2", "box.osh")
 
-    def test_osh2vtk(self):
-        """testing mesh to vtu conversion"""
-        if self.spec.version < Version("9.34.1"):
-            raise SkipTest("Package must be installed as version 9.34.1 or later")
-        exe = which(join_path(self.prefix.bin, "osh2vtk"))
-        options = ["box_100.osh", "box_100_vtk"]
-        exe(*options)
+        with test_part(self, "test_mesh_adapt", purpose="mesh adaptation"):
+            exe = which(self.prefix.bin.osh_scale)
+            actual = exe("box.osh", "100", "box_100.osh", output=str.split, error=str.split)
+            assert "adapting took" in actual
+
+        with test_part(self, "test_mesh_convert", purpose="mesh to vtu conversion"):
+            exe = which(self.prefix.bin.osh2vtk)
+            exe("box_100.osh", "box_100_vtk")


### PR DESCRIPTION
Fixes #44732 

This PR fixes the test sequencing issue introduced in #44712.  The outputs from running the tests for two versions -- one before testing supported and one after -- are:

```
$ spack -v test run omega-h
==> Spack test owtb2toavrro6csip3xtop2sme53ea4i
==> Testing package omega-h-9.32.5-4ui5qpw
==> [2024-06-17-11:55:43.817654] test: test_mesh: test construction, adaptation, and conversion of a mesh
SKIPPED: OmegaH::test_mesh: Package must be installed as version 9.34.1 or later
==> [2024-06-17-11:55:43.820440] Completed testing
==> [2024-06-17-11:55:43.820539] 
======================= SUMMARY: omega-h-9.32.5-4ui5qpw ========================
OmegaH::test_mesh .. SKIPPED
============================= 1 skipped of 1 parts =============================
==> Testing package omega-h-9.34.13-c6j2caz
==> [2024-06-17-11:55:45.010559] test: test_mesh: test construction, adaptation, and conversion of a mesh
==> [2024-06-17-11:55:45.010974] test: test_mesh_create: mesh construction
...
PASSED: OmegaH::test_mesh_create
==> [2024-06-17-11:55:45.165630] test: test_mesh_adapt: mesh adaptation
...
PASSED: OmegaH::test_mesh_adapt
==> [2024-06-17-11:55:45.288991] test: test_mesh_convert: mesh to vtu conversion
...
PASSED: OmegaH::test_mesh_convert
PASSED: OmegaH::test_mesh
==> [2024-06-17-11:55:45.405904] Completed testing
==> [2024-06-17-11:55:45.406043] 
======================= SUMMARY: omega-h-9.34.13-c6j2caz =======================
OmegaH::test_mesh_create .. PASSED
OmegaH::test_mesh_adapt .. PASSED
OmegaH::test_mesh_convert .. PASSED
OmegaH::test_mesh .. PASSED
============================= 4 passed of 4 parts ==============================
======================== 1 skipped, 1 passed of 2 specs ========================
```