### PR TITLE
elpa: new version and recipe tuning

### DIFF
--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -54,7 +54,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
     variant(
         "autotune",
         default=False,
-        when="@2021.11.01",
+        when="@2021.11.01:",
         description="Enables autotuning for matrix restribution",
     )
     variant(

--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -25,6 +25,9 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
     version("master", branch="master")
 
     version(
+        "2024.03.001", sha256="41c6cbf56d2dac26443faaba8a77307d261bf511682a64b96e24def77c813622"
+    )
+    version(
         "2023.11.001-patched",
         sha256="62ee109afc06539507f459c08b958dc4db65b757dbd77f927678c77f7687415e",
         url="https://elpa.mpcdf.mpg.de/software/tarball-archive/Releases/2023.11.001/elpa-2023.11.001-patched.tar.gz",
@@ -48,11 +51,22 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     variant("openmp", default=True, description="Activates OpenMP support")
     variant("mpi", default=True, description="Activates MPI support")
-    variant("gpu_streams", default=True, description="Activates GPU streams support")
+    variant(
+        "autotune",
+        default=False,
+        when="@2021.11.01",
+        description="Enables autotuning for matrix restribution",
+    )
+    variant(
+        "gpu_streams",
+        default=True,
+        when="@2021.11.001: +cuda",
+        description="Activates GPU streams support",
+    )
 
     patch("fujitsu.patch", when="%fj")
 
-    depends_on("autoconf", type="build", when="@master")
+    depends_on("autoconf@2.71:", type="build", when="@master")
     depends_on("automake", type="build", when="@master")
 
     depends_on("blas")
@@ -62,12 +76,20 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
     depends_on("rocblas", when="+rocm")
     depends_on("libtool", type="build")
     depends_on("python@3:", type="build")
+    depends_on("scalapack", when="+autotune")
 
-    with when("@2021.11.01:"):
-        variant(
-            "autotune", default=False, description="Enables autotuning for matrix restribution"
+    # Force openmp propagation on some providers of blas/lapack, as adviced by docs
+    # https://gitlab.mpcdf.mpg.de/elpa/elpa/-/blob/master/documentation/PERFORMANCE_TUNING.md?ref_type=heads#builds-with-openmp-enabled
+    with when("+openmp"):
+        requires("^openblas threads=openmp", when="^[virtuals=blas,lapack] openblas")
+        requires("^intel-mkl threads=openmp", when="^[virtuals=blas,lapack] intel-mkl")
+        requires(
+            "^intel-oneapi-mkl threads=openmp", when="^[virtuals=blas,lapack] intel-oneapi-mkl"
         )
-        depends_on("scalapack", when="+autotune")
+        requires(
+            "^intel-parallel-studio threads=openmp",
+            when="^[virtuals=blas,lapack] intel-parallel-studio",
+        )
 
     # fails to build due to broken type-bound procedures in OMP parallel regions
     conflicts(
@@ -76,10 +98,9 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
         msg="ELPA-2021.05.001+ requires GCC-8+ for OpenMP support",
     )
     conflicts("+mpi", when="+rocm", msg="ROCm support and MPI are not yet compatible")
-
     conflicts(
         "+gpu_streams",
-        when="+openmp",
+        when="@:2023.11.001-patched +openmp",
         msg="GPU streams currently not supported in combination with OpenMP",
     )
 
@@ -193,13 +214,8 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
         options += self.enable_or_disable("openmp")
 
         # Additional linker search paths and link libs
-        ldflags = [spec["blas"].libs.search_flags, spec["lapack"].libs.search_flags]
+        ldflags = [spec["blas"].libs.search_flags, spec["lapack"].libs.search_flags, "-lstdc++"]
         libs = [spec["lapack"].libs.link_flags, spec["blas"].libs.link_flags]
-
-        # If using blas with openmp support, link with openmp
-        # Needed for Spack-provided OneAPI MKL and for many externals
-        if self.spec["blas"].satisfies("threads=openmp"):
-            ldflags.append(self.compiler.openmp_flag)
 
         options += [f'LDFLAGS={" ".join(ldflags)}', f'LIBS={" ".join(libs)}']
 

--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -52,7 +52,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
     variant("openmp", default=True, description="Activates OpenMP support")
     variant("mpi", default=True, description="Activates MPI support")
 
-    with when("@2021.11.01:"):
+    with when("@2021.11.001:"):
         variant(
             "autotune", default=False, description="Enables autotuning for matrix restribution"
         )

--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -51,18 +51,14 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     variant("openmp", default=True, description="Activates OpenMP support")
     variant("mpi", default=True, description="Activates MPI support")
-    variant(
-        "autotune",
-        default=False,
-        when="@2021.11.01:",
-        description="Enables autotuning for matrix restribution",
-    )
-    variant(
-        "gpu_streams",
-        default=True,
-        when="@2021.11.001: +cuda",
-        description="Activates GPU streams support",
-    )
+
+    with when("@2021.11.01:"):
+        variant(
+            "autotune", default=False, description="Enables autotuning for matrix restribution"
+        )
+        variant(
+            "gpu_streams", default=True, when="+cuda", description="Activates GPU streams support"
+        )
 
     patch("fujitsu.patch", when="%fj")
 


### PR DESCRIPTION
I added the new 2024 version of `elpa`, and updated its recipe following the suggestions of the [installation
guide](https://gitlab.mpcdf.mpg.de/elpa/elpa/-/blob/master/documentation/INSTALL.md?ref_type=heads#221-enabling-openmp-support). 
- Threaded BLAS/LAPACK libraries are enforced when using the `openmp` variant.
- Fixes #43902: Cmake will take care of adding the `-fopenmp` flags when OpenMP is activated.
I verified this is the case for both `openblas` and `intel-oneapi-mkl` BLAS/LAPACK providers.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
