### PR TITLE
Docs: Update stand-alone test information

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -5701,7 +5701,7 @@ running ``foo`` and ``bar`` as independent test parts.
 
    The key to copying files for stand-alone testing at build time is use
    of the ``run_after`` directive, which ensures the associated files are
-   copied **after** the provided ``install` build stage when the installation
+   copied **after** the provided ``install`` build stage when the installation
    prefix **and** files are available.
 
    The test method can use the path contained in the package's


### PR DESCRIPTION
This PR updates the stand-alone test documentation to improve the examples, emphasize points I find myself making during PR reviews, and provide tips that I think have been useful in my work with others.

- [x] split test parts into separate section for emphasis and an includable link for PRs
- [x] elaborate on and provide a more relevant example of building and running tests
- [x] update, improve, and add examples of stand-alone tests (based on "common" PR feedback I've given)
- [x] Add references (and links) to relevant sections to help people find the information they need
- [x] update the test log's descriptions and status of tests to align with current outputs
- [x] make better use of alternative admonitions for titles and or alternate colors