### PR TITLE
spec_list: do not resolve abstract hashes

### DIFF
--- a/lib/spack/spack/spec_list.py
+++ b/lib/spack/spack/spec_list.py
@@ -212,10 +212,7 @@ def _expand_matrix_constraints(matrix_config):
     results = []
     for combo in itertools.product(*expanded_rows):
         # Construct a combined spec to test against excludes
-        flat_combo = [constraint for constraint_list in combo for constraint in constraint_list]
-
-        # Resolve abstract hashes so we can exclude by their concrete properties
-        flat_combo = [Spec(x).lookup_hash() for x in flat_combo]
+        flat_combo = [Spec(constraint) for constraints in combo for constraint in constraints]
 
         test_spec = flat_combo[0].copy()
         for constraint in flat_combo[1:]:
@@ -231,7 +228,9 @@ def _expand_matrix_constraints(matrix_config):
             spack.variant.substitute_abstract_variants(test_spec)
         except spack.variant.UnknownVariantError:
             pass
-        if any(test_spec.satisfies(x) for x in excludes):
+
+        # Resolve abstract hashes for exclusion criteria
+        if any(test_spec.lookup_hash().satisfies(x) for x in excludes):
             continue
 
         if sigil:

--- a/lib/spack/spack/test/spec_list.py
+++ b/lib/spack/spack/test/spec_list.py
@@ -196,21 +196,29 @@ class TestSpecList:
         speclist = SpecList("specs", matrix)
         assert len(speclist.specs) == 1
 
-    @pytest.mark.regression("22991")
-    def test_spec_list_constraints_with_structure(
-        self, mock_packages, mock_fetch, install_mockery
-    ):
-        # Setup by getting hash and installing package with dep
-        libdwarf_spec = Spec("libdwarf").concretized()
-        libdwarf_spec.package.do_install()
+    def test_spec_list_exclude_with_abstract_hashes(self, mock_packages, install_mockery):
+        # Put mpich in the database so it can be referred to by hash.
+        mpich_1 = Spec("mpich+debug").concretized()
+        mpich_2 = Spec("mpich~debug").concretized()
+        mpich_1.package.do_install(fake=True)
+        mpich_2.package.do_install(fake=True)
 
-        # Create matrix
-        matrix = {
-            "matrix": [["mpileaks"], ["^callpath"], ["^libdwarf/%s" % libdwarf_spec.dag_hash()]]
-        }
+        # Create matrix and exclude +debug, which excludes the first mpich after its abstract hash
+        # is resolved.
+        speclist = SpecList(
+            "specs",
+            [
+                {
+                    "matrix": [
+                        ["mpileaks"],
+                        ["^callpath"],
+                        [f"^mpich/{mpich_1.dag_hash(5)}", f"^mpich/{mpich_2.dag_hash(5)}"],
+                    ],
+                    "exclude": ["^mpich+debug"],
+                }
+            ],
+        )
 
-        # ensure the concrete spec was retained in the matrix entry of which
-        # it is a dependency
-        speclist = SpecList("specs", [matrix])
+        # Ensure that only mpich~debug is selected, and that the assembled spec remains abstract.
         assert len(speclist.specs) == 1
-        assert libdwarf_spec in speclist.specs[0]
+        assert speclist.specs[0] == Spec(f"mpileaks ^callpath ^mpich/{mpich_2.dag_hash(5)}")


### PR DESCRIPTION
In a spec list, `exclude` criteria are applied to resolved specs if they have
abstract hashes. The implementation however made abstract specs become
concrete.

That is problematic cause later we expect `Spec(str(spec)) == spec` when
sending specs as strings to a concretizer subprocess.

That only happened with `unify: false` (parallel concretization).

