### PR TITLE
Abinit fix hdf5

### DIFF
--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -186,7 +186,7 @@ class Abinit(AutotoolsPackage):
                 oapp(f"F90={spec['mpi'].mpifc}")
 
             # MPI version:
-            # let the confgiure script auto-detect MPI support from mpi_prefix
+            # let the configure script auto-detect MPI support from mpi_prefix
             if "@:8" in spec:
                 oapp("--enable-mpi=yes")
             else:

--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -325,7 +325,7 @@ class Abinit(AutotoolsPackage):
             "sd_hdf5_libs_extra=%s" % self.spec["hdf5"].libs.ld_flags,
             "configure",
         )
-            
+
     def install(self, spec, prefix):
         make("install")
         if "+install-tests" in spec:

--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -186,7 +186,7 @@ class Abinit(AutotoolsPackage):
                 oapp(f"F90={spec['mpi'].mpifc}")
 
             # MPI version:
-            # let the configure script auto-detect MPI support from mpi_prefix
+            # let the confgiure script auto-detect MPI support from mpi_prefix
             if "@:8" in spec:
                 oapp("--enable-mpi=yes")
             else:
@@ -316,6 +316,16 @@ class Abinit(AutotoolsPackage):
         if "~mpi" in self.spec:
             make("tests_in")
 
+    # Abinit assumes the *old* behavior of HDF5 where the library flags to link
+    # to the library were stored in the lib/libhdf5.settings file.
+    # Spack already knows how to link to HDF5, disable this check in configure
+    def patch(self):
+        filter_file(
+            r"sd_hdf5_libs_extra=.*",
+            "sd_hdf5_libs_extra=%s" % self.spec["hdf5"].libs.ld_flags,
+            "configure",
+        )
+            
     def install(self, spec, prefix):
         make("install")
         if "+install-tests" in spec:


### PR DESCRIPTION
The configure script fails to properly find the location of HDF5.  This PR should fix that by using Spack to find the location of HDF5.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
