### PR TITLE
openpmd-api: Changed from old to new test API

### DIFF
--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -174,7 +174,7 @@ class OpenpmdApi(CMakePackage):
 
     def test_run_openpmd_ls(self):
         """Test if openpmd-ls runs correctly"""
-        if self.spec.satisfies("0.11.0"):
+        if self.spec.satisfies("@:0.11.0"):
             raise SkipTest("Package must be installed as version 0.11.1 or later")
         exe = which(join_path(self.prefix.bin, "openpmd-ls"))
         exe()

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -172,17 +172,9 @@ class OpenpmdApi(CMakePackage):
             # later tests
             ctest("--output-on-failure", "-j1")
 
-    def test(self):
-        """Perform smoke tests on the installed package."""
-        exes = ["openpmd-ls"]  # in 0.11.1+
-        for exe in exes:
-            spec_vers_str = "{0}".format(self.spec.version)
-            reason = "test version of {0} is {1}".format(exe, spec_vers_str)
-            self.run_test(
-                exe,
-                ["--version"],
-                [spec_vers_str],
-                installed=True,
-                purpose=reason,
-                skip_missing=False,
-            )
+    def test_run_openpmd-ls(self):
+        """Test if openpmd-ls runs"""
+        if self.spec.satisfies("0.11.0"):
+            raise SkipTest("Package must be installed as version 0.11.1 or later")
+        exe = which(join_path(self.prefix.bin, "openpmd-ls"))
+        exe()

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -177,4 +177,5 @@ class OpenpmdApi(CMakePackage):
         if self.spec.satisfies("@:0.11.0"):
             raise SkipTest("Package must be installed as version 0.11.1 or later")
         exe = which(join_path(self.prefix.bin, "openpmd-ls"))
-        exe()
+        out = exe(output=str.split,error=str.split)
+        assert str(self.spec.version) in out

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -177,5 +177,5 @@ class OpenpmdApi(CMakePackage):
         if self.spec.satisfies("@:0.11.0"):
             raise SkipTest("Package must be installed as version 0.11.1 or later")
         exe = which(join_path(self.prefix.bin, "openpmd-ls"))
-        out = exe(output=str.split,error=str.split)
+        out = exe(output=str.split, error=str.split)
         assert str(self.spec.version) in out

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -173,7 +173,7 @@ class OpenpmdApi(CMakePackage):
             ctest("--output-on-failure", "-j1")
 
     def test_run_openpmd_ls(self):
-        """Test if openpmd-ls runs"""
+        """Test if openpmd-ls runs correctly"""
         if self.spec.satisfies("0.11.0"):
             raise SkipTest("Package must be installed as version 0.11.1 or later")
         exe = which(join_path(self.prefix.bin, "openpmd-ls"))

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -172,7 +172,7 @@ class OpenpmdApi(CMakePackage):
             # later tests
             ctest("--output-on-failure", "-j1")
 
-    def test_run_openpmd-ls(self):
+    def test_run_openpmd_ls(self):
         """Test if openpmd-ls runs"""
         if self.spec.satisfies("0.11.0"):
             raise SkipTest("Package must be installed as version 0.11.1 or later")


### PR DESCRIPTION
Update standalone test API. See below comment for test output.

Supersedes #35799 (one package)

https://spack.readthedocs.io/en/latest/packaging_guide.html#stand-alone-tests