### PR TITLE
actsvg: add versions up to 0.4.44

### DIFF
--- a/var/spack/repos/builtin/packages/actsvg/package.py
+++ b/var/spack/repos/builtin/packages/actsvg/package.py
@@ -16,10 +16,13 @@ class Actsvg(CMakePackage):
     list_url = "https://github.com/acts-project/actsvg/tags"
     git = "https://github.com/acts-project/actsvg.git"
 
-    maintainers("HadrienG2", "wdconinc")
+    maintainers("HadrienG2", "wdconinc", "stephenswat")
 
     license("MPL-2.0")
 
+    version("0.4.44", sha256="6eda7306b8b863e1860e090f328ac6e7982dc2d3b3d674db2799c13007ffd07f")
+    version("0.4.43", sha256="e2aef32185db37cfdc023282b25c003e63dc974a11118ab2040bd30b2d346147")
+    version("0.4.42", sha256="a8439d50b469ccc4428973507db1adf56aa68b34900ce0c6077ddb92a133a4f2")
     version("0.4.41", sha256="c675795e74efcf42c3015d6efc8d7a1848b677f1d4efe6dcaa4fb490b46268ff")
     version("0.4.40", sha256="e24f51e70cff57c74d3b5f51c08f6ea1f409ef85ef7b4bad4a29520ecda032a6")
     version("0.4.39", sha256="2d9605ecf8c9975d600cafb6d076969d77c634fa92844bd9586c38066da31739")


### PR DESCRIPTION
This commit adds new versions of actsvg. I have also taken the liberty of adding myself a maintainer as I work actively on the ACTS project and its dependencies, and would like to start keeping the Spack specs more up to date.