### PR TITLE
flux-core and flux-sched: disables environment variable setting for externally found Flux

### DIFF
--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -248,6 +248,12 @@ class FluxCore(AutotoolsPackage):
         env.append_path("LUA_PATH", "./?.lua", separator=";")
 
     def setup_run_environment(self, env):
+        # If this package is external, we expect the external provider to set things
+        # like LUA paths. So, we early return. If the package is not external,
+        # properly set these environment variables to make sure the user environment
+        # is configured correctly
+        if self.spec.external:
+            return
         env.prepend_path(
             "LUA_PATH", os.path.join(self.spec.prefix, self.lua_share_dir, "?.lua"), separator=";"
         )

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -176,6 +176,12 @@ class FluxSched(CMakePackage, AutotoolsPackage):
         return os.path.join("lib", "lua", str(self.lua_version))
 
     def setup_run_environment(self, env):
+        # If this package is external, we expect the external provider to set
+        # things like LUA paths. So, we early return. If the package is not
+        # external, properly set these environment variables to make sure the
+        # user environment is configured correctly
+        if self.spec.external:
+            return
         env.prepend_path(
             "LUA_PATH", os.path.join(self.spec.prefix, self.lua_share_dir, "?.lua"), separator=";"
         )


### PR DESCRIPTION
While trying to test a Spack package I am currently developing for a new benchmark in Benchpark, I found that environments where Flux is found externally (i.e., `flux-core` in the `packages` section of `spack.yaml`) will fail to install. When digging into this issue, I found that the root of the problem was the use of `self.spec["lua"]` to set environment variables (e.g., `LUA_PATH` and `LUA_CPATH`) in the `setup_run_environment` function of the `flux-core` package. So, this issue I ran into is essentially a variant of #9149.

However, in the case of `flux-core`, this issue can be easily fixed by adding a conditional that disables the code using `self.spec["lua"]` when `flux-core` is external. Additionally, since the environment variables set in `setup_run_environment` should already by set for an external install, this change could avoid possible corner cases that might have popped up when using an external install of Flux (e.g., the system-wide install on Corona, which is where I encountered this issue).

Finally, I also noticed the same logic regarding `self.spec["lua"]` and environment variables in the `flux-sched` package, so I've also applied this fix to that package.