### PR TITLE
libint: add version 2.9.0

### DIFF
--- a/var/spack/repos/builtin/packages/libint/package.py
+++ b/var/spack/repos/builtin/packages/libint/package.py
@@ -242,15 +242,13 @@ class Libint(AutotoolsPackage):
 
     @when("@2.6.0:")
     def check(self):
-        with working_dir(os.path.join(self.build_directory, "generated")):
-            with working_dir("build"):
-                make("check")
+        with working_dir(os.path.join(self.build_directory, "generated", "build")):
+            make("check")
 
     @when("@2.6.0:")
     def install(self, spec, prefix):
-        with working_dir(os.path.join(self.build_directory, "generated")):
-            with working_dir("build"):
-                make("install")
+        with working_dir(os.path.join(self.build_directory, "generated", "build")):
+            make("install")
 
     @when("@:2.6.0")
     def patch(self):

--- a/var/spack/repos/builtin/packages/libint/package.py
+++ b/var/spack/repos/builtin/packages/libint/package.py
@@ -72,6 +72,9 @@ class Libint(AutotoolsPackage):
     depends_on(Boost.with_default_variants, when="@2:")
     depends_on("gmp+cxx", when="@2:")
     depends_on("eigen", when="@2.7.0:")
+    # unicode variable names in @2.9.0:
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67224
+    conflicts("%gcc@:9", when="@2.9.0:", msg="libint@2.9.0: requires at least gcc 10")
 
     for tvariant in TUNE_VARIANTS[1:]:
         conflicts(


### PR DESCRIPTION
The second stage build process is  cmake from 2.6.0 on. It looks like they're in the process of switching to cmake with the first stage too, so we may be able to make this an actual CMakePackage in the future.