### PR TITLE
go: remove 1.19.7 -> 1.21.3, fix install location

### DIFF
--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -48,59 +48,9 @@ class Go(Package):
     version("1.21.6", sha256="124926a62e45f78daabbaedb9c011d97633186a33c238ffc1e25320c02046248")
     version("1.21.5", sha256="285cbbdf4b6e6e62ed58f370f3f6d8c30825d6e56c5853c66d3c23bcdb09db19")
 
-    # Deprecated Versions
-    # https://nvd.nist.gov/vuln/detail/CVE-2023-44487
-    version(
-        "1.21.3",
-        sha256="186f2b6f8c8b704e696821b09ab2041a5c1ee13dcbc3156a13adcf75931ee488",
-        deprecated=True,
-    )
-    # https://nvd.nist.gov/vuln/detail/CVE-2023-39533
-    version(
-        "1.20.6",
-        sha256="62ee5bc6fb55b8bae8f705e0cb8df86d6453626b4ecf93279e2867092e0b7f70",
-        deprecated=True,
-    )
-    # https://nvd.nist.gov/vuln/detail/CVE-2023-29405
-    version(
-        "1.20.4",
-        sha256="9f34ace128764b7a3a4b238b805856cc1b2184304df9e5690825b0710f4202d6",
-        deprecated=True,
-    )
-    version(
-        "1.20.3",
-        sha256="e447b498cde50215c4f7619e5124b0fc4e25fb5d16ea47271c47f278e7aa763a",
-        deprecated=True,
-    )
-    version(
-        "1.19.11",
-        sha256="e25c9ab72d811142b7f41ff6da5165fec2d1be5feec3ef2c66bc0bdecb431489",
-        deprecated=True,
-    )
-    version(
-        "1.19.9",
-        sha256="131190a4697a70c5b1d232df5d3f55a3f9ec0e78e40516196ffb3f09ae6a5744",
-        deprecated=True,
-    )
-    version(
-        "1.19.8",
-        sha256="1d7a67929dccafeaf8a29e55985bc2b789e0499cb1a17100039f084e3238da2f",
-        deprecated=True,
-    )
-    # https://nvd.nist.gov/vuln/detail/CVE-2023-24538
-    version(
-        "1.20.2",
-        sha256="4d0e2850d197b4ddad3bdb0196300179d095bb3aefd4dfbc3b36702c3728f8ab",
-        deprecated=True,
-    )
-    version(
-        "1.19.7",
-        sha256="775bdf285ceaba940da8a2fe20122500efd7a0b65dbcee85247854a8d7402633",
-        deprecated=True,
-    )
-
     provides("golang")
 
+    depends_on("bash", type="build")
     depends_on("git", type="run")
     depends_on("go-or-gccgo-bootstrap", type="build")
     depends_on("go-or-gccgo-bootstrap@1.17.13:", type="build", when="@1.20:")
@@ -118,7 +68,7 @@ class Go(Package):
         return match.group(1) if match else None
 
     def setup_build_environment(self, env):
-        env.set("GOROOT_FINAL", self.spec.prefix)
+        env.set("GOROOT_FINAL", self.spec.prefix.go)
         # We need to set CC/CXX_FOR_TARGET, otherwise cgo will use the
         # internal Spack wrappers and fail.
         env.set("CC_FOR_TARGET", self.compiler.cc)
@@ -126,13 +76,15 @@ class Go(Package):
         env.set("GOMAXPROCS", make_jobs)
 
     def build(self, spec, prefix):
+        # Build script depend on bash
         bash = which("bash")
 
         with working_dir("src"):
             bash(f"{'all' if self.run_tests else 'make'}.bash")
 
     def install(self, spec, prefix):
-        install_tree(".", prefix)
+        install_tree(".", prefix.go)
+        os.symlink(prefix.go.bin, prefix.bin)
 
     def setup_dependent_package(self, module, dependent_spec):
         """Called before go modules' build(), install() methods.


### PR DESCRIPTION
Go was being directly installed into `prefix` which was bloating views with a bunch of go specific info in the top level. Most other package managers install into `prefix/go` or `/usr/share/go`.