### PR TITLE
podio: Add version 1.0

### DIFF
--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -95,7 +95,7 @@ class Podio(CMakePackage):
 
     conflicts("+rntuple", when="@:0.16", msg="rntuple support requires at least podio@0.17")
 
-    # See https://github.com/AIDASoft/podio/pull/580 that landed after 0.99
+    # See https://github.com/AIDASoft/podio/pull/599 that landed after 0.99
     extends("python", when="@0.99:")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -97,7 +97,7 @@ class Podio(CMakePackage):
     conflicts("+rntuple", when="@:0.16", msg="rntuple support requires at least podio@0.17")
 
     # See https://github.com/AIDASoft/podio/pull/599 that landed after 0.99
-    extends("python", when="@0.99.1:")
+    extends("python", when="@1.0:")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -20,6 +20,7 @@ class Podio(CMakePackage):
     tags = ["hep", "key4hep"]
 
     version("master", branch="master")
+    version("1.0", sha256="491f335e148708e387e90e955a6150e1fc2e01bf6b4980b65e257ab0619559a9")
     version("0.99", sha256="c823918a6ec1365d316e0a753feb9d492e28903141dd124a1be06efac7c1877a")
     version(
         "0.17.4",

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -95,6 +95,9 @@ class Podio(CMakePackage):
 
     conflicts("+rntuple", when="@:0.16", msg="rntuple support requires at least podio@0.17")
 
+    # See https://github.com/AIDASoft/podio/pull/580 that landed after 0.99
+    extends("python", when="@0.99:")
+
     def cmake_args(self):
         args = [
             self.define_from_variant("ENABLE_SIO", "sio"),
@@ -105,7 +108,10 @@ class Podio(CMakePackage):
         return args
 
     def setup_run_environment(self, env):
-        env.prepend_path("PYTHONPATH", self.prefix.python)
+        if self.spec.satisfies("@:0.99"):
+            # After 0.99 podio installs its python bindings into a more standard place
+            env.prepend_path("PYTHONPATH", self.prefix.python)
+
         env.prepend_path("LD_LIBRARY_PATH", self.spec["podio"].libs.directories[0])
         if "+sio" in self.spec:
             # sio needs to be on LD_LIBRARY_PATH for ROOT to be able to
@@ -116,7 +122,9 @@ class Podio(CMakePackage):
         env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        env.prepend_path("PYTHONPATH", self.prefix.python)
+        if self.spec.satisfies("@:0.99"):
+            env.prepend_path("PYTHONPATH", self.prefix.python)
+
         env.prepend_path("LD_LIBRARY_PATH", self.spec["podio"].libs.directories[0])
         env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
         if self.spec.satisfies("+sio @0.17:"):

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -96,7 +96,7 @@ class Podio(CMakePackage):
     conflicts("+rntuple", when="@:0.16", msg="rntuple support requires at least podio@0.17")
 
     # See https://github.com/AIDASoft/podio/pull/599 that landed after 0.99
-    extends("python", when="@0.99:")
+    extends("python", when="@0.99.1:")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Add version 1.0 of podio and make it extend python, since podio now installs it's python bindings into a more conventional place (see https://github.com/AIDASoft/podio/pull/599).

This supersedes https://github.com/spack/spack/pull/44537.