### PR TITLE
Fix spec.satisfies("pthread")

### DIFF
--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -47,7 +47,7 @@ class Googletest(CMakePackage):
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
         ]
-        args.append(self.define("gtest_disable_pthreads", not spec.satisfies("pthreads")))
+        args.append(self.define("gtest_disable_pthreads", not spec.satisfies("+pthreads")))
         if spec.satisfies("@1.8:"):
             # New style (contains both Google Mock and Google Test)
             args.append(self.define("BUILD_GTEST", True))


### PR DESCRIPTION
Change "pthread" to "+pthread" since otherwise the spec is never satisfied and pthread is never used.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
