### PR TITLE
sleef: add v3.6.1

### DIFF
--- a/var/spack/repos/builtin/packages/sleef/package.py
+++ b/var/spack/repos/builtin/packages/sleef/package.py
@@ -10,7 +10,7 @@ class Sleef(CMakePackage):
     """SIMD Library for Evaluating Elementary Functions, vectorized libm and DFT."""
 
     homepage = "https://sleef.org"
-    url = "https://github.com/shibatch/sleef/archive/3.6.tar.gz"
+    url = "https://github.com/shibatch/sleef/archive/3.6.1.tar.gz"
     git = "https://github.com/shibatch/sleef.git"
 
     maintainers("blapie")
@@ -18,7 +18,8 @@ class Sleef(CMakePackage):
     license("BSL-1.0")
 
     version("master", branch="master")
-    version("3.6", commit="a99491afee2bae0b11e9ffbf3211349f43a5fd10", preferred=True)
+    version("3.6.1", commit="6ee14bcae5fe92c2ff8b000d5a01102dab08d774", preferred=True)
+    version("3.6", commit="a99491afee2bae0b11e9ffbf3211349f43a5fd10")
     version("3.5.1_2020-12-22", commit="e0a003ee838b75d11763aa9c3ef17bf71a725bff")  # py-torch@1.8:
     version("3.5.1", sha256="415ee9b1bcc5816989d3d4d92afd0cd3f9ee89cbd5a33eb008e69751e40438ab")
     version(


### PR DESCRIPTION
Update preferred package to SLEEF 3.6.1

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
