### PR TITLE
ParaView: add 5.13.0-RC1

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -30,7 +30,9 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     license("Apache-2.0")
 
     version("master", branch="master", submodules=True)
-    version("5.13.0-RC1", sha256="00aea2bbaf2eacd288a6cc95c1f4ed1a8a4965f27548b53ae473c1ee7caec30e")
+    version(
+        "5.13.0-RC1", sha256="00aea2bbaf2eacd288a6cc95c1f4ed1a8a4965f27548b53ae473c1ee7caec30e"
+    )
     version(
         "5.12.1",
         sha256="927f880c13deb6dde4172f4727d2b66f5576e15237b35778344f5dd1ddec863e",

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -30,6 +30,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     license("Apache-2.0")
 
     version("master", branch="master", submodules=True)
+    version("5.13.0-RC1", sha256="00aea2bbaf2eacd288a6cc95c1f4ed1a8a4965f27548b53ae473c1ee7caec30e")
     version(
         "5.12.1",
         sha256="927f880c13deb6dde4172f4727d2b66f5576e15237b35778344f5dd1ddec863e",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
🎉 🎉 🎉

ParaView 5.13.0-RC1 is out

This PR updates the ParaView Spack package to include this new release ParaView v5.13.0-RC1.

Let me know if we need to change anything else in the package.

🎉 🎉 🎉