### PR TITLE
[wrf] explicit conflict oneapi + older versions

### DIFF
--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -256,6 +256,8 @@ class Wrf(Package):
     depends_on("m4", type="build")
     depends_on("libtool", type="build")
     depends_on("adios2", when="@4.5: +adios2")
+
+    conflicts("%oneapi", when="@:4.3", msg="Intel oneapi compiler patch only added for version 4.4")
     phases = ["configure", "build", "install"]
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -257,7 +257,9 @@ class Wrf(Package):
     depends_on("libtool", type="build")
     depends_on("adios2", when="@4.5: +adios2")
 
-    conflicts("%oneapi", when="@:4.3", msg="Intel oneapi compiler patch only added for version 4.4")
+    conflicts(
+        "%oneapi", when="@:4.3", msg="Intel oneapi compiler patch only added for version 4.4"
+    )
     phases = ["configure", "build", "install"]
 
     def setup_run_environment(self, env):


### PR DESCRIPTION
The patch which enables icx/ifx compilers is only added for `wrf@4.4:`. This PR prints a useful message at concretization time instead of failing the installation later on.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
