### PR TITLE
geopm: Add v3.1

### DIFF
--- a/var/spack/repos/builtin/packages/geopm-runtime/package.py
+++ b/var/spack/repos/builtin/packages/geopm-runtime/package.py
@@ -15,17 +15,18 @@ class GeopmRuntime(AutotoolsPackage):
 
     homepage = "https://geopm.github.io"
     git = "https://github.com/geopm/geopm.git"
-    url = "https://github.com/geopm/geopm/tarball/v3.0.1"
+    url = "https://github.com/geopm/geopm/tarball/v3.1.0"
 
     maintainers("bgeltz", "cmcantalupo")
     license("BSD-3-Clause")
     tags = ["e4s"]
 
     version("develop", branch="dev", get_full_repo=True)
+    version("3.1.0", sha256="2d890cad906fd2008dc57f4e06537695d4a027e1dc1ed92feed4d81bb1a1449e")
     version("3.0.1", sha256="32ba1948de58815ee055470dcdea64593d1113a6cad70ce00ab0286c127f8234")
 
     variant("debug", default=False, description="Enable debug")
-    variant("docs", default=False, description="Create man pages with Sphinx")
+    variant("docs", default=False, when="@3.0.1", description="Create man pages with Sphinx")
     variant("overhead", default=False, description="Track time spent in GEOPM API calls")
     variant("beta", default=False, description="Enable beta features")
     variant("mpi", default=True, description="Enable MPI dependent components")
@@ -56,30 +57,36 @@ class GeopmRuntime(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("file")
 
-    # Docs dependencies
-    depends_on("doxygen", type="build", when="+docs")
-    depends_on("py-sphinx", type="build", when="+docs")
-    depends_on("py-sphinx-rtd-theme@1:", type="build", when="+docs")
-    depends_on("py-sphinxemoji@0.2.0:", type="build", when="+docs")
-    depends_on("py-sphinx-tabs@3.3.1:", type="build", when="+docs")
-    depends_on("py-pygments@2.13.0:", type="build", when="+docs")
+    with when("@3.0.1"):
+        # Docs dependencies
+        #   Moved to python3-geopm-doc as of v3.1
+        depends_on("doxygen", type="build", when="+docs")
+        depends_on("py-sphinx", type="build", when="+docs")
+        depends_on("py-sphinx-rtd-theme@1:", type="build", when="+docs")
+        depends_on("py-sphinxemoji@0.2.0:", type="build", when="+docs")
+        depends_on("py-sphinx-tabs@3.3.1:", type="build", when="+docs")
+        depends_on("py-pygments@2.13.0:", type="build", when="+docs")
 
-    # Other Python dependencies - from scripts/setup.py
-    depends_on("python@3.6:3", type=("build", "run"))
-    depends_on("py-setuptools@53.0.0:", type="build")
-    depends_on("py-cffi@1.14.5:", type="run")
-    depends_on("py-natsort@8.2.0:", type="run")
-    depends_on("py-numpy@1.19.5:", type="run")
-    depends_on("py-pandas@1.1.5:", type="run")
-    depends_on("py-tables@3.7.0:", type="run")
-    depends_on("py-psutil@5.8.0:", type="run")
-    depends_on("py-pyyaml@6.0:", type="run")
-    depends_on("py-docutils@0.18:", type="run", when="+checkprogs")
+        # Other Python dependencies - from scripts/setup.py
+        #   Moved to python3-geopmdpy as of v3.1
+        depends_on("python@3.6:3", type=("build", "run"))
+        depends_on("py-setuptools@53.0.0:", type="build")
+        depends_on("py-cffi@1.14.5:", type="run")
+        depends_on("py-natsort@8.2.0:", type="run")
+        depends_on("py-numpy@1.19.5:", type="run")
+        depends_on("py-pandas@1.1.5:", type="run")
+        depends_on("py-tables@3.7.0:", type="run")
+        depends_on("py-psutil@5.8.0:", type="run")
+        depends_on("py-pyyaml@6.0:", type="run")
+        depends_on("py-docutils@0.18:", type="run", when="+checkprogs")
 
     # Other dependencies
-    for ver in ["3.0.1", "develop"]:
-        depends_on(f"geopm-service@{ver}", type="build", when=f"@{ver}")
+    for ver in ["3.0.1", "3.1.0", "develop"]:
+        depends_on(f"geopm-service@{ver}", type=("build", "run"), when=f"@{ver}")
         depends_on(f"py-geopmdpy@{ver}", type="run", when=f"@{ver}")
+        if ver != "3.0.1":  # geopmpy integrated into autotools build until 3.1
+            depends_on(f"py-geopmpy@{ver}", type="run", when=f"@{ver}")
+    depends_on("py-setuptools-scm@7.0.3:", when="@3.1:", type="build")
     depends_on("bash-completion")
     depends_on("unzip")
     depends_on("mpi@2.2:", when="+mpi")
@@ -93,6 +100,13 @@ class GeopmRuntime(AutotoolsPackage):
     extends("python")
 
     @property
+    def configure_directory(self):
+        if self.version == Version("3.0.1"):
+            return "."
+        else:
+            return "libgeopm"
+
+    @property
     def install_targets(self):
         target = ["install"]
         if "+checkprogs" in self.spec:
@@ -101,20 +115,26 @@ class GeopmRuntime(AutotoolsPackage):
 
     def autoreconf(self, spec, prefix):
         bash = which("bash")
-        if not spec.version.isdevelop():
-            # Required to workaround missing VERSION files
-            # from GitHub generated source tarballs
-            with open("VERSION_OVERRIDE", "w") as fd:
-                fd.write(f"{spec.version}")
-        bash("./autogen.sh")
+        with working_dir(self.configure_directory):
+            if not spec.version.isdevelop():
+                if self.version == Version("3.0.1"):
+                    version_file = "VERSION_OVERRIDE"
+                else:
+                    version_file = "VERSION"
+                # Required to workaround missing VERSION files
+                # from GitHub generated source tarballs
+                with open(version_file, "w") as fd:
+                    fd.write(f"{spec.version}")
+            bash("./autogen.sh")
 
     def configure_args(self):
-        args = [
-            "--with-bash-completion-dir="
-            + join_path(self.spec.prefix, "share", "bash-completion", "completions"),
-            "--disable-geopmd-local",
-            f"--with-geopmd={self.spec['geopm-service'].prefix}",
-        ]
+
+        with when("@3.0.1"):
+            args = [
+                "--with-bash-completion-dir="
+                + join_path(self.spec.prefix, "share", "bash-completion", "completions")
+            ]
+        args += ["--disable-geopmd-local", f"--with-geopmd={self.spec['geopm-service'].prefix}"]
 
         args += self.enable_or_disable("debug")
         args += self.enable_or_disable("docs")

--- a/var/spack/repos/builtin/packages/geopm-service/package.py
+++ b/var/spack/repos/builtin/packages/geopm-service/package.py
@@ -87,8 +87,9 @@ class GeopmService(AutotoolsPackage):
         depends_on("py-cffi@1.14.5:", type="run")
 
     # Other dependencies
+    for ver in ["3.1.0", "develop"]:
+        depends_on(f"py-geopmdpy@{ver}", type="run", when=f"@{ver}")
     depends_on("py-setuptools-scm@7.0.3:", when="@3.1:", type="build")
-    depends_on("py-geopmdpy@3.1:", type="run", when="@3.1:")
     depends_on("bash-completion")
     depends_on("unzip")
     depends_on("systemd", when="+systemd")

--- a/var/spack/repos/builtin/packages/geopm-service/package.py
+++ b/var/spack/repos/builtin/packages/geopm-service/package.py
@@ -75,12 +75,12 @@ class GeopmService(AutotoolsPackage):
     depends_on("py-pygments@2.13.0:", type="build", when="+docs")
 
     # Other Python dependencies - from service/setup.py
-    depends_on("py-dasbus@1.6.0:", type=("build", "run"))
-    depends_on("py-cffi@1.14.5:", type="run")
-    depends_on("py-psutil@5.8.0:", type="run")
-    depends_on("py-jsonschema@3.2.0:", type="run")
-    depends_on("py-pyyaml@6.0:", type="run")
     depends_on("py-setuptools@53.0.0:", type="build")
+    depends_on("py-dasbus@1.6.0:", type=("build", "run"))
+    depends_on("py-psutil@5.8.0:", type=("build", "run"))
+    depends_on("py-jsonschema@3.2.0:", type=("build", "run"))
+    depends_on("py-pyyaml@6.0:", type=("build", "run"))
+    depends_on("py-cffi@1.14.5:", type="run")
 
     # Other dependencies
     depends_on("bash-completion")

--- a/var/spack/repos/builtin/packages/geopm-service/package.py
+++ b/var/spack/repos/builtin/packages/geopm-service/package.py
@@ -18,17 +18,18 @@ class GeopmService(AutotoolsPackage):
 
     homepage = "https://geopm.github.io"
     git = "https://github.com/geopm/geopm.git"
-    url = "https://github.com/geopm/geopm/tarball/v3.0.1"
+    url = "https://github.com/geopm/geopm/tarball/v3.1.0"
 
     maintainers("bgeltz", "cmcantalupo")
     license("BSD-3-Clause")
     tags = ["e4s"]
 
     version("develop", branch="dev", get_full_repo=True)
+    version("3.1.0", sha256="2d890cad906fd2008dc57f4e06537695d4a027e1dc1ed92feed4d81bb1a1449e")
     version("3.0.1", sha256="32ba1948de58815ee055470dcdea64593d1113a6cad70ce00ab0286c127f8234")
 
     variant("debug", default=False, description="Enable debug")
-    variant("docs", default=True, description="Create man pages with Sphinx")
+    variant("docs", default=True, when="@3.0.1", description="Create man pages with Sphinx")
     variant("systemd", default=True, description="Enable use of systemd/DBus")
     variant("liburing", default=True, description="Enables the use of liburing for batch I/O")
     variant(
@@ -65,24 +66,29 @@ class GeopmService(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("file")
 
-    # Docs dependencies
-    depends_on("doxygen", type="build", when="+docs")
-    depends_on("py-docstring-parser@0.13.0:", type="build", when="+docs")
-    depends_on("py-sphinx", type="build", when="+docs")
-    depends_on("py-sphinx-rtd-theme@1:", type="build", when="+docs")
-    depends_on("py-sphinxemoji@0.2.0:", type="build", when="+docs")
-    depends_on("py-sphinx-tabs@3.3.1:", type="build", when="+docs")
-    depends_on("py-pygments@2.13.0:", type="build", when="+docs")
+    with when("@3.0.1"):
+        # Docs dependencies
+        #   Moved to python3-geopm-doc as of v3.1
+        depends_on("doxygen", type="build", when="+docs")
+        depends_on("py-docstring-parser@0.13.0:", type="build", when="+docs")
+        depends_on("py-sphinx", type="build", when="+docs")
+        depends_on("py-sphinx-rtd-theme@1:", type="build", when="+docs")
+        depends_on("py-sphinxemoji@0.2.0:", type="build", when="+docs")
+        depends_on("py-sphinx-tabs@3.3.1:", type="build", when="+docs")
+        depends_on("py-pygments@2.13.0:", type="build", when="+docs")
 
-    # Other Python dependencies - from service/setup.py
-    depends_on("py-setuptools@53.0.0:", type="build")
-    depends_on("py-dasbus@1.6.0:", type=("build", "run"))
-    depends_on("py-psutil@5.8.0:", type=("build", "run"))
-    depends_on("py-jsonschema@3.2.0:", type=("build", "run"))
-    depends_on("py-pyyaml@6.0:", type=("build", "run"))
-    depends_on("py-cffi@1.14.5:", type="run")
+        # Other Python dependencies - from service/setup.py
+        #   Moved to python3-geopmdpy as of v3.1
+        depends_on("py-setuptools@53.0.0:", type="build")
+        depends_on("py-dasbus@1.6.0:", type=("build", "run"))
+        depends_on("py-psutil@5.8.0:", type=("build", "run"))
+        depends_on("py-jsonschema@3.2.0:", type=("build", "run"))
+        depends_on("py-pyyaml@6.0:", type=("build", "run"))
+        depends_on("py-cffi@1.14.5:", type="run")
 
     # Other dependencies
+    depends_on("py-setuptools-scm@7.0.3:", when="@3.1:", type="build")
+    depends_on("py-geopmdpy@3.1:", type="run", when="@3.1:")
     depends_on("bash-completion")
     depends_on("unzip")
     depends_on("systemd", when="+systemd")
@@ -93,15 +99,24 @@ class GeopmService(AutotoolsPackage):
 
     extends("python")
 
-    configure_directory = "service"
+    @property
+    def configure_directory(self):
+        if self.version == Version("3.0.1"):
+            return "service"
+        else:
+            return "libgeopmd"
 
     def autoreconf(self, spec, prefix):
         bash = which("bash")
-        with working_dir("service"):
+        with working_dir(self.configure_directory):
             if not spec.version.isdevelop():
+                if self.version == Version("3.0.1"):
+                    version_file = "VERSION_OVERRIDE"
+                else:
+                    version_file = "VERSION"
                 # Required to workaround missing VERSION files
                 # from GitHub generated source tarballs
-                with open("VERSION_OVERRIDE", "w") as fd:
+                with open(version_file, "w") as fd:
                     fd.write(f"{spec.version}")
             bash("./autogen.sh")
 

--- a/var/spack/repos/builtin/packages/librsvg/package.py
+++ b/var/spack/repos/builtin/packages/librsvg/package.py
@@ -50,6 +50,7 @@ class Librsvg(AutotoolsPackage):
 
     depends_on("libffi")
     depends_on("shared-mime-info")
+    depends_on("py-docutils", type="build")
 
     def url_for_version(self, version):
         url = "https://download.gnome.org/sources/librsvg/"

--- a/var/spack/repos/builtin/packages/py-blosc2/package.py
+++ b/var/spack/repos/builtin/packages/py-blosc2/package.py
@@ -14,6 +14,7 @@ class PyBlosc2(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2.6.2", sha256="8ca29d9aa988b85318bd8a9b707a7a06c8d6604ae1304cae059170437ae4f53a")
     version("2.2.8", sha256="59065aac5e9b01b0e9f3825d8e7f69f64b59bbfab148a47c54e4115f62a97474")
     version("2.0.0", sha256="f19b0b3674f6c825b490f00d8264b0c540c2cdc11ec7e81178d38b83c57790a1")
 

--- a/var/spack/repos/builtin/packages/py-geopmdpy/package.py
+++ b/var/spack/repos/builtin/packages/py-geopmdpy/package.py
@@ -12,13 +12,14 @@ class PyGeopmdpy(PythonPackage):
 
     homepage = "https://geopm.github.io"
     git = "https://github.com/geopm/geopm.git"
-    url = "https://github.com/geopm/geopm/tarball/v3.0.1"
+    url = "https://github.com/geopm/geopm/tarball/v3.1.0"
 
     maintainers("bgeltz", "cmcantalupo")
     license("BSD-3-Clause")
     tags = ["e4s"]
 
-    version("develop", branch="dev")
+    version("develop", branch="dev", get_full_repo=True)
+    version("3.1.0", sha256="2d890cad906fd2008dc57f4e06537695d4a027e1dc1ed92feed4d81bb1a1449e")
     version("3.0.1", sha256="32ba1948de58815ee055470dcdea64593d1113a6cad70ce00ab0286c127f8234")
 
     depends_on("py-dasbus@1.6.0:", type=("build", "run"))
@@ -27,13 +28,23 @@ class PyGeopmdpy(PythonPackage):
     depends_on("py-jsonschema@3.2.0:", type="run")
     depends_on("py-pyyaml@6.0:", type="run")
     depends_on("py-setuptools@53.0.0:", type="build")
+    depends_on("py-setuptools-scm@7.0.3:", when="@3.1:", type="build")
+    depends_on("py-build@0.9.0:", when="@3.1:", type="build")
 
-    build_directory = "service"
+    @property
+    def build_directory(self):
+        if self.version == Version("3.0.1"):
+            return "service"
+        else:
+            return "geopmdpy"
+
+    def setup_build_environment(self, env):
+        if not self.spec.version.isdevelop():
+            env.set("SETUPTOOLS_SCM_PRETEND_VERSION", self.version)
 
     @run_before("install")
     def populate_version(self):
-        # @develop builds will have a version of 0.0.0
-        if not self.spec.version.isdevelop():
-            with working_dir(join_path("service", "geopmdpy")):
+        if self.version == Version("3.0.1"):
+            with working_dir(join_path(self.build_directory, "geopmdpy")):
                 with open("version.py", "w") as fd:
                     fd.write(f"__version__ = '{self.spec.version}'")

--- a/var/spack/repos/builtin/packages/py-geopmpy/package.py
+++ b/var/spack/repos/builtin/packages/py-geopmpy/package.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyGeopmpy(PythonPackage):
+    """The Global Extensible Open Power Manager (GEOPM) Service provides a
+    user interface for accessing hardware telemetry and settings securely."""
+
+    homepage = "https://geopm.github.io"
+    git = "https://github.com/geopm/geopm.git"
+    url = "https://github.com/geopm/geopm/tarball/v3.1.0"
+
+    maintainers("bgeltz", "cmcantalupo")
+    license("BSD-3-Clause")
+    tags = ["e4s"]
+
+    version("develop", branch="dev", get_full_repo=True)
+    version("3.1.0", sha256="2d890cad906fd2008dc57f4e06537695d4a027e1dc1ed92feed4d81bb1a1449e")
+
+    depends_on("python@3.6:3", type=("build", "run"))
+    depends_on("py-setuptools@53.0.0:", type="build")
+    depends_on("py-setuptools-scm@7.0.3:", when="@3.1:", type="build")
+    depends_on("py-build@0.9.0:", when="@3.1:", type="build")
+    depends_on("py-cffi@1.14.5:", type="run")
+    depends_on("py-natsort@8.2.0:", type="run")
+    depends_on("py-numpy@1.19.5:", type="run")
+    depends_on("py-pandas@1.1.5:", type="run")
+    depends_on("py-tables@3.7.0:", type="run")
+    depends_on("py-psutil@5.8.0:", type="run")
+    depends_on("py-pyyaml@6.0:", type="run")
+    depends_on("py-docutils@0.18:", type="run")
+
+    build_directory = "geopmpy"
+
+    def setup_build_environment(self, env):
+        if not self.spec.version.isdevelop():
+            env.set("SETUPTOOLS_SCM_PRETEND_VERSION", self.version)


### PR DESCRIPTION
- Add support for GEOPM v3.1 to all existing packages.
- Add py-geopmpy as it is now built/packaged separately from geopm-runtime.
- Docs have been moved to their own package and as such now build separately.  The docs packaging is WIP and may arrive in a future PR.