### PR TITLE
Bugfix: test_is_externally_detectable needs to use mock packages

### DIFF
--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -57,9 +57,9 @@ def test_info_noversion(mock_packages, print_buffer):
 
 
 @pytest.mark.parametrize(
-    "pkg_query,expected", [("zlib", "False"), ("gcc", "True (version, variants)")]
+    "pkg_query,expected", [("zlib", "False"), ("find-externals1", "True (version)")]
 )
-def test_is_externally_detectable(pkg_query, expected, parser, print_buffer):
+def test_is_externally_detectable(mock_packages, pkg_query, expected, parser, print_buffer):
     args = parser.parse_args(["--detectable", pkg_query])
     spack.cmd.info.info(parser, args)
 

--- a/var/spack/repos/builtin.mock/packages/find-externals1/package.py
+++ b/var/spack/repos/builtin.mock/packages/find-externals1/package.py
@@ -17,6 +17,10 @@ class FindExternals1(AutotoolsPackage):
     version("1.0", md5="abcdef1234567890abcdef1234567890")
 
     @classmethod
+    def determine_version(cls, exe):
+        return "1.0"
+
+    @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
         exe_to_path = dict((os.path.basename(p), p) for p in exes_in_prefix)
         exes = [x for x in exe_to_path.keys() if "find-externals1-exe" in x]


### PR DESCRIPTION
CI is not set up to catch unit test failures with package-only PRs.  This PR ensures `test_is_externally_detectable` uses mock packages to avoid the inadvertent introduction of unit test failures.  

The mock `zlib` package still does not have external detection.  I switched out `gcc` for `find-externals1`, which is a mock package that I modified slightly to get a bit more of the new output.

MOTIVATION:
First encountered this problem with an unexpected failure for #44755, which only changes the docs.  The PR's checks are failing unit tests because the merged #44694 makes the real `zlib` package detectable.

The failure output from #44755 is/was:

```
    @pytest.mark.parametrize(
        "pkg_query,expected", [("zlib", "False"), ("gcc", "True (version, variants)")]
    )
    def test_is_externally_detectable(pkg_query, expected, parser, print_buffer):
        args = parser.parse_args(["--detectable", pkg_query])
        spack.cmd.info.info(parser, args)
    
        line_iter = iter(print_buffer)
        for line in line_iter:
            if "Externally Detectable" in line:
                is_externally_detectable = next(line_iter).strip()
>               assert is_externally_detectable == expected
E               AssertionError: assert 'True (version, variants)' == 'False'
E                 - False
E                 + True (version, variants)
```