### PR TITLE
hepmc3: pass `root` variant `cxxstd` as `HEPMC3_CXX_STANDARD`

### DIFF
--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -44,7 +44,9 @@ class Hepmc3(CMakePackage):
     )
 
     depends_on("cmake@2.8.9:", type="build")
-    depends_on("root", when="+rootio")
+    with when("+rootio"):
+        depends_on("root")
+        depends_on("root cxxstd=11", when="@:3.2.3")
     depends_on("protobuf", when="+protobuf")
     depends_on("python", when="+python")
 

--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -76,6 +76,8 @@ class Hepmc3(CMakePackage):
         if spec.satisfies("+rootio"):
             args.append(self.define("ROOT_DIR", spec["root"].prefix))
             if spec.satisfies("@3.2.4:"):
-                args.append(self.define("HEPMC3_CXX_STANDARD", spec["root"].variants["cxxstd"].value))
+                args.append(
+                    self.define("HEPMC3_CXX_STANDARD", spec["root"].variants["cxxstd"].value)
+                )
 
         return args

--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -62,7 +62,7 @@ class Hepmc3(CMakePackage):
             self.define("HEPMC3_ENABLE_TEST", self.run_tests),
         ]
 
-        if "+python" in spec:
+        if spec.satisfies("+python"):
             py_ver = spec["python"].version.up_to(2)
             args.extend(
                 [
@@ -71,7 +71,9 @@ class Hepmc3(CMakePackage):
                 ]
             )
 
-        if "+rootio" in spec:
+        if spec.satisfies("+rootio"):
             args.append(self.define("ROOT_DIR", spec["root"].prefix))
+            if spec.satisfies("@3.2.4:"):
+                args.append(self.define("HEPMC3_CXX_STANDARD", spec["root"].variants["cxxstd"].value))
 
         return args


### PR DESCRIPTION
The `hepmc3` configuration defaults to C++11 in the latest release 3.2.7 in spack, see https://gitlab.cern.ch/hepmc/HepMC3/-/blob/3.2.7/CMakeLists.txt?ref_type=tags#L122. This leads to issues when using `+rootio` and when `root` is compiled with a more recent C++ standard.

This PR:
- The configuration option `HEPMC3_CXX_STANDARD` was introduced in HepMC3 v3.2.4; this PR sets that option to the `root` variant `cxxstd` value for the versions of `hepmc3` that support it.
- For earlier versions, up to 3.2.3, this PR changes the dependency to `root cxxstd=11`, per https://gitlab.cern.ch/hepmc/HepMC3/-/blob/3.2.3/CMakeLists.txt?ref_type=tags#L100-110.