### PR TITLE
root: add v6.30.08, v6.32.02

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -35,7 +35,9 @@ class Root(CMakePackage):
     version("develop", branch="master")
 
     # Production version
+    version("6.32.02", sha256="3d0f76bf05857e1807ccfb2c9e014f525bcb625f94a2370b455f4b164961602d")
     version("6.32.00", sha256="12f203681a59041c474ce9523761e6f0e8861b3bee78df5f799a8db55189e5d2")
+    version("6.30.08", sha256="8bb8594867b9ded20a65e59f2cb6da965aa30851b8960f8cbf76293aec046b69")
     version("6.30.06", sha256="300db7ed1b678ed2fb9635ca675921a1945c7c2103da840033b493091f55700c")
     version("6.30.04", sha256="2b4180b698f39cc65d91084d833a884515b325bc5f673c8e39abe818b025d8cc")
     version("6.30.02", sha256="7965a456d1ad1ee0d5fe4769bf5a8fec291af684ed93db0f3080a9c362435183")


### PR DESCRIPTION
This PR adds two new bugfix releases for `root`, in the 6.30 and 6.32 cycles. No changes to the spack package needed per diffs at:
- https://github.com/root-project/root/compare/v6-32-00...v6-32-02
- https://github.com/root-project/root/compare/v6-30-06...v6-30-08