### PR TITLE
Fixed url_fetch tests

### DIFF
--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -173,8 +173,6 @@ def test_fetch(
             assert "echo Building..." in contents
 
 
-# TODO-27021
-@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 @pytest.mark.parametrize(
     "spec,url,digest",
     [
@@ -205,7 +203,6 @@ def test_from_list_url(mock_packages, config, spec, url, digest, _fetch_method):
         assert fetch_strategy.extra_options == {"timeout": 60}
 
 
-@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
 @pytest.mark.parametrize(
     "requested_version,tarball,digest",

--- a/var/spack/repos/builtin.mock/packages/url-list-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/url-list-test/package.py
@@ -7,6 +7,7 @@ import sys
 
 import spack.paths
 from spack.package import *
+from spack.util.url import path_to_file_url
 
 
 class UrlListTest(Package):
@@ -14,10 +15,9 @@ class UrlListTest(Package):
 
     homepage = "http://www.url-list-example.com"
 
-    drive_escape = "/" if sys.platform == "win32" else ""
     web_data_path = join_path(spack.paths.test_path, "data", "web")
-    url = "file://" + drive_escape + web_data_path + "/foo-0.0.0.tar.gz"
-    list_url = "file://" + drive_escape + web_data_path + "/index.html"
+    url = path_to_file_url(join_path(spack.paths.test_path, "data", "web") + "/foo-0.0.0.tar.gz")
+    list_url = path_to_file_url(join_path(spack.paths.test_path, "data", "web") + "/index.html")
     list_depth = 3
 
     version("0.0.0", md5="00000000000000000000000000000000")

--- a/var/spack/repos/builtin.mock/packages/url-list-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/url-list-test/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import sys
+
 import spack.paths
 from spack.package import *
 
@@ -15,8 +16,8 @@ class UrlListTest(Package):
 
     drive_escape = "/" if sys.platform == "win32" else ""
     web_data_path = join_path(spack.paths.test_path, "data", "web")
-    url = "file://"+ drive_escape + web_data_path + "/foo-0.0.0.tar.gz"
-    list_url = "file://"+ drive_escape + web_data_path + "/index.html"
+    url = "file://" + drive_escape + web_data_path + "/foo-0.0.0.tar.gz"
+    list_url = "file://" + drive_escape + web_data_path + "/index.html"
     list_depth = 3
 
     version("0.0.0", md5="00000000000000000000000000000000")

--- a/var/spack/repos/builtin.mock/packages/url-list-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/url-list-test/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
-
 import spack.paths
 from spack.package import *
 from spack.util.url import path_to_file_url

--- a/var/spack/repos/builtin.mock/packages/url-list-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/url-list-test/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
 import spack.paths
 from spack.package import *
 
@@ -12,9 +13,10 @@ class UrlListTest(Package):
 
     homepage = "http://www.url-list-example.com"
 
+    drive_escape = "/" if sys.platform == "win32" else ""
     web_data_path = join_path(spack.paths.test_path, "data", "web")
-    url = "file://" + web_data_path + "/foo-0.0.0.tar.gz"
-    list_url = "file://" + web_data_path + "/index.html"
+    url = "file://"+ drive_escape + web_data_path + "/foo-0.0.0.tar.gz"
+    list_url = "file://"+ drive_escape + web_data_path + "/index.html"
     list_depth = 3
 
     version("0.0.0", md5="00000000000000000000000000000000")


### PR DESCRIPTION
Fixed url_fetch: test_from_list_url by updating package to handle windows paths

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
