### PR TITLE
Extend the py-torch package to explicitly specify the location of FP16

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/fp16.patch
+++ b/var/spack/repos/builtin/packages/py-torch/fp16.patch
@@ -1,0 +1,17 @@
+diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
+index a96075245a..70980fbeef 100644
+--- a/cmake/Dependencies.cmake
++++ b/cmake/Dependencies.cmake
+@@ -1002,7 +1002,11 @@ if(NOT TARGET fp16 AND NOT USE_SYSTEM_FP16)
+     "${FP16_SOURCE_DIR}"
+     "${CONFU_DEPENDENCIES_BINARY_DIR}/FP16")
+ elseif(NOT TARGET fp16 AND USE_SYSTEM_FP16)
+-  add_library(fp16 STATIC "/usr/include/fp16.h")
++  if (DEFINED ENV{FP16_PATH})
++    add_library(fp16 STATIC "$ENV{FP16_PATH}/include/fp16.h")
++  else()
++    add_library(fp16 STATIC "/usr/include/fp16.h")
++  endif()
+   set_target_properties(fp16 PROPERTIES LINKER_LANGUAGE C)
+ endif()
+ list(APPEND Caffe2_DEPENDENCY_LIBS fp16)

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -325,6 +325,9 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     # Fixes build error when ROCm is enabled for pytorch-1.5 release
     patch("rocm.patch", when="@1.5+rocm")
 
+    # Modifies cmake to accept location of fp16 header file only library
+    patch("fp16.patch", when="@2.3")
+
     # Fixes compilation with Clang 9.0.0 and Apple Clang 11.0.3
     # https://github.com/pytorch/pytorch/pull/37086
     patch(
@@ -645,6 +648,9 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         env.set("USE_SYSTEM_CPUINFO", "ON")
         env.set("USE_SYSTEM_EIGEN_INSTALL", "ON")
         env.set("USE_SYSTEM_FP16", "ON")
+        # FP16 is on, set the spack install fp16 to be picked by cmake
+        env.set("FP16_PATH", self.spec["fp16"].prefix)
+
         env.set("USE_SYSTEM_FXDIV", "ON")
         env.set("USE_SYSTEM_GLOO", "ON")
         env.set("USE_SYSTEM_NCCL", "ON")


### PR DESCRIPTION
Add a simple patch to the `cmake` file of torch. 

Torch when using `USE_SYSTEM_FP16` variable assumes  the FP16 headers to exist under a hard code path (`/usr/include/fp16.h`). We patch the cmake to check for an environment variable that sets the path of `fp16.h` and we set that variable in the torch package.py.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
