### PR TITLE
py-scikit-build-core: typing-extensions dependency fix

### DIFF
--- a/var/spack/repos/builtin/packages/py-scikit-build-core/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-build-core/package.py
@@ -45,7 +45,8 @@ class PyScikitBuildCore(PythonPackage):
     depends_on("py-pathspec@0.10.1:", type=("build", "run"), when="@0.9:")
     depends_on("py-tomli@1.2.2:", when="@0.9: ^python@:3.10", type=("build", "run"))
     depends_on("py-tomli@1.1:", when="^python@:3.10", type=("build", "run"))
-    depends_on("py-typing-extensions@3.10:", when="^python@:3.7", type=("build", "run"))
+    depends_on("py-typing-extensions@3.10:", when="@0.8: ^python@:3.8", type=("build", "run"))
+    depends_on("py-typing-extensions@3.10:", when="@:0.7 ^python@:3.7", type=("build", "run"))
     depends_on("cmake@3.15:", type=("build", "run"))
 
     # Optional dependencies


### PR DESCRIPTION
As of https://github.com/scikit-build/scikit-build-core/commit/37ba268d04ab0816816bb8c7b0b1bc3388f91308, the typing-extensions dependency applies for python 3.8 as well. This should fix e.g. https://gitlab.spack.io/spack/spack/-/jobs/11658696.
