### PR TITLE
root: depends_on libc only on linux

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -283,7 +283,6 @@ class Root(CMakePackage):
     depends_on("pkgconfig", type="build")
 
     # 6.32.00 requires sys/random.h
-    depends_on("libc", when="@6.32.00: platform=linux")
     depends_on("glibc@2.25:", when="^[virtuals=libc] glibc")
     depends_on("musl@1.1.20:", when="^[virtuals=libc] musl")
 

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -283,7 +283,7 @@ class Root(CMakePackage):
     depends_on("pkgconfig", type="build")
 
     # 6.32.00 requires sys/random.h
-    depends_on("libc", when="@6.32.00:")
+    depends_on("libc", when="@6.32.00: platform=linux")
     depends_on("glibc@2.25:", when="^[virtuals=libc] glibc")
     depends_on("musl@1.1.20:", when="^[virtuals=libc] musl")
 

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -283,8 +283,9 @@ class Root(CMakePackage):
     depends_on("pkgconfig", type="build")
 
     # 6.32.00 requires sys/random.h
-    depends_on("glibc@2.25:", when="^[virtuals=libc] glibc")
-    depends_on("musl@1.1.20:", when="^[virtuals=libc] musl")
+    with when("@6.32.00:"):
+        depends_on("glibc@2.25:", when="^[virtuals=libc] glibc")
+        depends_on("musl@1.1.20:", when="^[virtuals=libc] musl")
 
     depends_on("freetype")
     depends_on("jpeg")


### PR DESCRIPTION
This PR ensures that libc is only required for `root` on Linux.