### PR TITLE
py-cellprofiler: add 4.2.6 new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-cellprofiler-core/package.py
+++ b/var/spack/repos/builtin/packages/py-cellprofiler-core/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyCellprofilerCore(PythonPackage):
+    """Core classes and components used by CellProfiler."""
+
+    homepage = "https://github.com/CellProfiler/core"
+    pypi = "cellprofiler-core/cellprofiler-core-4.2.6.tar.gz"
+
+    maintainers("omsai")
+
+    license("BSD-3-Clause", checked_by="omsai")
+
+    version("4.2.6", sha256="91993485783bbab87d89a728260f10e57fda3f7335e6057393702cea774db2d7")
+
+    depends_on("python@3.8:", type=("build", "run"))
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-boto3@1.12.28:", type=("build", "run"))
+    depends_on("py-centrosome@1.2.2:", type=("build", "run"))
+    depends_on("py-docutils@0.15.2:", type=("build", "run"))
+    depends_on("py-h5py@3.6:3.7~mpi", type=("build", "run"))
+    depends_on("py-matplotlib@3.1.3:", type=("build", "run"))
+    depends_on("py-numpy@1.18.2:", type=("build", "run"))
+    depends_on("py-prokaryote@2.4.4:", type=("build", "run"))
+    depends_on("py-psutil@5.7:", type=("build", "run"))
+    depends_on("py-python-bioformats@4.0.7:", type=("build", "run"))
+    depends_on("py-python-javabridge@4.0.3:", type=("build", "run"))
+    depends_on("py-pyzmq@22.3:22", type=("build", "run"))
+    depends_on("py-scikit-image@0.18.3:0", type=("build", "run"))
+    depends_on("py-scipy@1.4.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-cellprofiler/package.py
+++ b/var/spack/repos/builtin/packages/py-cellprofiler/package.py
@@ -1,0 +1,153 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyCellprofiler(PythonPackage):
+    """CellProfiler cell image analysis software.
+
+    CellProfiler is a free open-source software designed to enable biologists
+    without training in computer vision or programming to quantitatively
+    measure phenotypes from thousands of images automatically.
+
+    """
+
+    homepage = "https://cellprofiler.org"
+    pypi = "cellprofiler/CellProfiler-4.2.6.tar.gz"
+    git = "https://github.com/CellProfiler/CellProfiler.git"
+
+    maintainers("omsai")
+
+    license("BSD-3-Clause", checked_by="omsai")
+
+    version("4.2.6", sha256="37e2a35dccff456afda96a4442dff2d23809c8ee271607a347e386aeb4af2628")
+
+    depends_on("python@3.8:", type=("build", "run"))
+
+    depends_on("py-setuptools@64:", type="build")
+    depends_on("py-setuptools-scm@8:", type="build")
+
+    depends_on("py-boto3@1.12.28:", type=("build", "run"))
+    depends_on("py-cellprofiler-core@4.2.6", type=("build", "run"))
+    depends_on("py-centrosome@1.2.2:", type=("build", "run"))
+    depends_on("py-docutils@0.15.2:", type=("build", "run"))
+    # More recent versions of h5py cause:
+    #   AttributeError: module 'h5py' has no attribute 'Dataset
+    depends_on("py-h5py@3.6:3.7~mpi", type=("build", "run"))
+    depends_on("py-imageio@2.5:", type=("build", "run"))
+    depends_on("py-inflect@2.1:6", type=("build", "run"))
+    depends_on("py-jinja2@2.11.2:", type=("build", "run"))
+    depends_on("py-joblib@0.13:", type=("build", "run"))
+    depends_on("py-mahotas@1.4:", type=("build", "run"))
+    # matplotlib.cm.get_cmap does not exist in 3.9.0 onwards.
+    depends_on("py-matplotlib@3.1.3:3.8", type=("build", "run"))
+    depends_on("py-mysqlclient@1.4.6", type=("build", "run"))
+    depends_on("py-numpy@1.20.1:", type=("build", "run"))
+    depends_on("py-pillow@7.1:", type=("build", "run"))
+    depends_on("py-prokaryote@2.4.4:", type=("build", "run"))
+    depends_on("py-python-bioformats@4.0.7:", type=("build", "run"))
+    depends_on("py-python-javabridge@4.0.3:", type=("build", "run"))
+    depends_on("py-pyzmq@22.3:22", type=("build", "run"))
+    depends_on("py-sentry-sdk@0.18:", type=("build", "run"))
+    depends_on("py-requests@2.22:", type=("build", "run"))
+    depends_on("py-scikit-image@0.18.3:", type=("build", "run"))
+    depends_on("py-scikit-learn@0.20:0", type=("build", "run"))
+    depends_on("py-scipy", type=("build", "run"))
+    depends_on("py-six", type=("build", "run"))
+    depends_on("py-tifffile@:2022.4.21", type=("build", "run"))
+    depends_on("py-wxpython@4.1.0:4", type=("build", "run"))
+
+    depends_on("py-pytest", type=("run", "test"), when="@4.2.6 +tests")
+
+    # Run the post-install tests with `spack test run py-cellprofiler`.  We
+    # need the variant to add the pytest executable to the PATH.
+    variant("tests", default=False, description="Post-install tests.")
+
+    # The pypi tests directory is incomplete.
+    resource(
+        name="tests-upstream",
+        destination="",
+        placement={
+            "tests/conftest.py": "tests/conftest.py",
+            "tests/gui": "tests/gui",
+            "tests/__init__.py": "tests/__init__.py",
+            "tests/modules": "tests/modules",
+            "tests/resources": "tests/resources",
+            "tests/test_cellprofiler.py": "tests/test_cellprofiler.py",
+            "tests/test_haralick.py": "tests/test_haralick.py",
+            "tests/test_knime_bridge.py": "tests/test_knime_bridge.py",
+            "tests/test_main.py": "tests/test_main.py",
+            "tests/test_nowx.py": "tests/test_nowx.py",
+            "tests/utilities": "tests/utilities",
+        },
+        git=git,
+        tag="v4.2.6",
+        sha256="5fb562774044d1dc8cffcddf6072d706f71e6649d566980efaab5b30f52ddfa2",
+        when="@4.2.6 +tests",
+    )
+
+    dir_tests = "tests"
+
+    # Leave 'gui' out of 'import_modules' to avoid the curently broken wxpython
+    # dependency.
+    import_modules = [
+        "cellprofiler",
+        "cellprofiler.icons",
+        "cellprofiler.library",
+        "cellprofiler.library.functions",
+        "cellprofiler.library.modules",
+        # "cellprofiler.gui",
+        # "cellprofiler.gui.html",
+        # "cellprofiler.gui.help",
+        # "cellprofiler.gui.module_view",
+        # "cellprofiler.gui.constants",
+        # "cellprofiler.gui.figure",
+        # "cellprofiler.gui.workspace_view",
+        # "cellprofiler.gui.preferences_view",
+        # "cellprofiler.gui.utilities",
+        # "cellprofiler.gui.preferences_dialog",
+        "cellprofiler.modules",
+        "cellprofiler.modules.plugins",
+        "cellprofiler.utilities",
+    ]
+
+    @when("+tests")
+    def patch(self):
+        """Install tests from git."""
+        # Install the tests module.  Using a module name like "tests" may
+        # create a namespace collision with other spack packages in the DAG,
+        # but the alternative would moving tests into cellprofiler and
+        # extensively patching the tests to be a submodule of cellprofiler
+        # instead of a standalone module.
+        filter_file(r"find_packages\([^)]+\)", "find_packages()", "setup.py")
+        # Include required test data files.
+        with open("MANIFEST.in", "a") as h:
+            h.writelines("graft tests")
+
+    # For interactive unittest debugging, run:
+    #
+    # spack env create cp
+    # spack env activate cp
+    # spack add cellprofiler+tests ^hdf5~mpi
+    # spack install
+    # git clone --branch v4.2.6 --depth 1 \
+    #     https://github.com/cellprofiler/cellprofiler
+    # cd cellprofiler/
+    # pytest --pdb -k "not TestExportToDatabase" tests/
+    #
+    # [...]
+    # 1412 passed, 16 skipped, 75 deselected
+    def test_cellprofiler_no_gui(self):
+        """Test installed package."""
+        pytest = which("pytest")
+        prefix = join_path(python_purelib, self.dir_tests)
+        pytest(
+            "-v",
+            # Don't test against the live MySQL database.
+            "-k",
+            "not TestExportToDatabase",
+            prefix,
+        )

--- a/var/spack/repos/builtin/packages/py-centrosome/package.py
+++ b/var/spack/repos/builtin/packages/py-centrosome/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyCentrosome(PythonPackage):
+    """An open source image processing library."""
+
+    homepage = "https://github.com/CellProfiler/centrosome"
+    pypi = "centrosome/centrosome-1.2.2.tar.gz"
+
+    maintainers("omsai")
+
+    license("BSD-3-Clause", checked_by="omsai")
+
+    version("1.2.2", sha256="4b38181d6648cb8b0e896aa2e54b5a6da2e9ebc19a8110582307f5c6da9d9964")
+
+    depends_on("python@2.7:,3.5:", type=("build", "run"))
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-deprecation", type=("build", "run"))
+    depends_on("py-matplotlib@3.1.3:", type=("build", "run"))
+    depends_on("py-numpy@1.18.2:", type=("build", "run"))
+    depends_on("py-pillow@7.1:", type=("build", "run"))
+    depends_on("py-scikit-image@0.17.2:", type=("build", "run"))
+    depends_on("py-scipy@1.4.1:1.10", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-mysqlclient/package.py
+++ b/var/spack/repos/builtin/packages/py-mysqlclient/package.py
@@ -17,6 +17,7 @@ class PyMysqlclient(PythonPackage):
 
     license("GPL-2.0-or-later")
 
+    version("2.2.4", sha256="33bc9fb3464e7d7c10b1eaf7336c5ff8f2a3d3b88bab432116ad2490beb3bf41")
     version("1.4.6", sha256="f3fdaa9a38752a3b214a6fe79d7cae3653731a53e577821f9187e67cbecb2e16")
     version("1.4.5", sha256="e80109b0ae8d952b900b31b623181532e5e89376d707dcbeb63f99e69cefe559")
     version("1.4.4", sha256="9c737cc55a5dc8dd3583a942d5a9b21be58d16f00f5fefca4e575e7d9682e98c")
@@ -24,3 +25,9 @@ class PyMysqlclient(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     depends_on("mysql")
+
+    # Fix "library not found for -lzlib" as described in
+    # https://github.com/PyMySQL/mysqlclient/issues/584 by backporting the
+    # patch from @2.2.0rc1 that uses pkg-config instead of mysql_config
+    # https://github.com/PyMySQL/mysqlclient/pull/586/files
+    patch("use-pkg-config.patch", when="@:2.1")

--- a/var/spack/repos/builtin/packages/py-mysqlclient/package.py
+++ b/var/spack/repos/builtin/packages/py-mysqlclient/package.py
@@ -30,4 +30,4 @@ class PyMysqlclient(PythonPackage):
     # https://github.com/PyMySQL/mysqlclient/issues/584 by backporting the
     # patch from @2.2.0rc1 that uses pkg-config instead of mysql_config
     # https://github.com/PyMySQL/mysqlclient/pull/586/files
-    patch("use-pkg-config.patch", when="@:2.1")
+    patch("use-pkg-config.patch", when="@1.4:2.1")

--- a/var/spack/repos/builtin/packages/py-mysqlclient/use-pkg-config.patch
+++ b/var/spack/repos/builtin/packages/py-mysqlclient/use-pkg-config.patch
@@ -1,0 +1,172 @@
+--- a/setup_posix.py	2019-11-06 02:21:07.000000000 -0500
++++ b/setup_posix.py	2024-05-13 18:22:02.200012959 -0400
+@@ -1,56 +1,31 @@
+-import os, sys
++import os, subprocess, sys
+ try:
+     from ConfigParser import SafeConfigParser
+ except ImportError:
+     from configparser import ConfigParser as SafeConfigParser
+ 
+-# This dequote() business is required for some older versions
+-# of mysql_config
+ 
+-def dequote(s):
+-    if not s:
+-        raise Exception("Wrong MySQL configuration: maybe https://bugs.mysql.com/bug.php?id=86971 ?")
+-    if s[0] in "\"'" and s[0] == s[-1]:
+-        s = s[1:-1]
+-    return s
+-
+-_mysql_config_path = "mysql_config"
+-
+-def mysql_config(what):
+-    from os import popen
+-
+-    f = popen("%s --%s" % (_mysql_config_path, what))
+-    data = f.read().strip().split()
+-    ret = f.close()
+-    if ret:
+-        if ret/256:
+-            data = []
+-        if ret/256 > 1:
+-            raise EnvironmentError("%s not found" % (_mysql_config_path,))
+-    return data
++def find_package_name():
++    """Get available pkg-config package name"""
++    packages = ["mysqlclient", "mariadb"]
++    for pkg in packages:
++        try:
++            cmd = f"pkg-config --exists {pkg}"
++            print(f"Trying {cmd}")
++            subprocess.check_call(cmd, shell=True)
++        except subprocess.CalledProcessError as err:
++            print(err)
++        else:
++            return pkg
++    raise Exception("Cannot find valid pkg-config")
++
+ 
+ def get_config():
+     from setup_common import get_metadata_and_options, enabled, create_release_file
+-    global _mysql_config_path
+ 
+     metadata, options = get_metadata_and_options()
+ 
+-    if 'mysql_config' in options:
+-        _mysql_config_path = options['mysql_config']
+-    else:
+-        try:
+-            mysql_config('version')
+-        except EnvironmentError:
+-            # try mariadb_config
+-            _mysql_config_path = "mariadb_config"
+-            try:
+-                mysql_config('version')
+-            except EnvironmentError:
+-                _mysql_config_path = "mysql_config"
+-
+-    extra_objects = []
+     static = enabled(options, 'static')
+-
+     # allow a command-line option to override the base config file to permit
+     # a static build to be created via requirements.txt
+     #
+@@ -58,65 +33,51 @@
+         static = True
+         sys.argv.remove('--static')
+ 
+-    libs = mysql_config("libs")
+-    library_dirs = [dequote(i[2:]) for i in libs if i.startswith('-L')]
+-    libraries = [dequote(i[2:]) for i in libs if i.startswith('-l')]
+-    extra_link_args = [x for x in libs if not x.startswith(('-l', '-L'))]
+-
+-    removable_compile_args = ('-I', '-L', '-l')
+-    extra_compile_args = [i.replace("%", "%%") for i in mysql_config("cflags")
+-                          if i[:2] not in removable_compile_args]
+-
+-    # Copy the arch flags for linking as well
+-    for i in range(len(extra_compile_args)):
+-        if extra_compile_args[i] == '-arch':
+-            extra_link_args += ['-arch', extra_compile_args[i + 1]]
++    ldflags = os.environ.get("MYSQLCLIENT_LDFLAGS")
++    cflags = os.environ.get("MYSQLCLIENT_CFLAGS")
+ 
+-    include_dirs = [dequote(i[2:])
+-                    for i in mysql_config('include') if i.startswith('-I')]
+-
+-    if static:
+-        # properly handle mysql client libraries that are not called libmysqlclient
+-        client = None
+-        CLIENT_LIST = ['mysqlclient', 'mysqlclient_r', 'mysqld', 'mariadb',
+-                       'mariadbclient', 'perconaserverclient', 'perconaserverclient_r']
+-        for c in CLIENT_LIST:
+-            if c in libraries:
+-                client = c
+-                break
+-
+-        if client == 'mariadb':
+-            client = 'mariadbclient'
+-        if client is None:
+-            raise ValueError("Couldn't identify mysql client library")
+-
+-        extra_objects.append(os.path.join(library_dirs[0], 'lib%s.a' % client))
+-        if client in libraries:
+-            libraries.remove(client)
++    pkg_name = None
++    static_opt = " --static" if static else ""
++    if not (cflags and ldflags):
++        pkg_name = find_package_name()
++    if not cflags:
++        cflags = subprocess.check_output(
++            f"pkg-config{static_opt} --cflags {pkg_name}", encoding="utf-8", shell=True
++        )
++    if not ldflags:
++        ldflags = subprocess.check_output(
++            f"pkg-config{static_opt} --libs {pkg_name}", encoding="utf-8", shell=True
++        )
++
++    cflags = cflags.split()
++    for f in cflags:
++        if f.startswith("-std="):
++            break
++    else:
++        cflags += ["-std=c99"]
+ 
+-    name = "mysqlclient"
+-    metadata['name'] = name
++    ldflags = ldflags.split()
+ 
+     define_macros = [
+         ('version_info', metadata['version_info']),
+         ('__version__', metadata['version']),
+         ]
+-    create_release_file(metadata)
+-    del metadata['version_info']
+     ext_options = dict(
+-        library_dirs = library_dirs,
+-        libraries = libraries,
+-        extra_compile_args = extra_compile_args,
+-        extra_link_args = extra_link_args,
+-        include_dirs = include_dirs,
+-        extra_objects = extra_objects,
+-        define_macros = define_macros,
++        extra_compile_args=cflags,
++        extra_link_args=ldflags,
++        define_macros=define_macros,
+     )
+-
+     # newer versions of gcc require libstdc++ if doing a static build
+     if static:
+         ext_options['language'] = 'c++'
+ 
++    print("Options for building extention module:")
++    for k, v in ext_options.items():
++        print(f"  {k}: {v}")
++
++    create_release_file(metadata)
++    del metadata['version_info']
++        
+     return metadata, ext_options
+ 
+ if __name__ == "__main__":

--- a/var/spack/repos/builtin/packages/py-prokaryote/package.py
+++ b/var/spack/repos/builtin/packages/py-prokaryote/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyProkaryote(PythonPackage):
+    """CellProfiler's Java dependencies."""
+
+    homepage = "https://github.com/CellProfiler/prokaryote"
+    pypi = "prokaryote/prokaryote-2.4.4.tar.gz"
+
+    maintainers("omsai")
+
+    license("GPL-3.0-or-later", checked_by="omsai")
+
+    version("2.4.4", sha256="0a147b8b9a0a7279aa773e6a8fe459eb49f6de479f7afe7203dc4ac10dc8b587")
+
+    depends_on("python@2.7:", type=("build", "run"))
+
+    depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-python-bioformats/package.py
+++ b/var/spack/repos/builtin/packages/py-python-bioformats/package.py
@@ -17,6 +17,7 @@ class PyPythonBioformats(PythonPackage):
 
     license("GPL-2.0-only")
 
+    version("4.0.7", sha256="9cdadd06e2453566bfcc512eb9f774654e9fd35ee02a7fb5e8fb097812c5733b")
     version("4.0.5", sha256="f9fa3a2b3c0f1eac6070dff6c513444e9fde9a1f794ec4c21fca85833dbb5192")
     version("4.0.0", sha256="9a952de4d326d961af0a497753a4b71b2f7844605023d170c931d3624e036506")
 

--- a/var/spack/repos/builtin/packages/py-tifffile/package.py
+++ b/var/spack/repos/builtin/packages/py-tifffile/package.py
@@ -18,6 +18,7 @@ class PyTifffile(PythonPackage):
     version(
         "2022.10.10", sha256="50b61ba943b866d191295bc38a00191c9fdab23ece063544c7f1a264e3f6aa8e"
     )
+    version("2022.4.8", sha256="d4a4057e5cb7afe6e24cf7bde42a163970b593afe44c17249894ede755cf3faa")
     version("2021.11.2", sha256="153e31fa1d892f482fabb2ae9f2561fa429ee42d01a6f67e58cee13637d9285b")
     version("2020.10.1", sha256="799feeccc91965b69e1288c51a1d1118faec7f40b2eb89ad2979591b85324830")
     version("0.12.1", sha256="802367effe86b0d1e64cb5c2ed886771f677fa63260b945e51a27acccdc08fa1")


### PR DESCRIPTION
New `py-cellprofiler` package.
* I run it in headless mode on the Purdue Anvil cluster without issues, and also confirmed all the (non-live MySQL) unit tests work on my Debian laptop.
* NB: Currently, `wx` fails to import due to `py-wxpython` being broken; the `py-wxpython` dependencies are still there because upstream does not support installing a subset of only the headless packages with associated logic.
* The dependencies don't exactly match. Upstream pins exact versions of dependencies which (often unnecessarily). I would rather not create DAG conflicts with other packages with arbitrarily pinned exact versions. Yes, I will fix any additional issues from widening the allowable dependencies.
(Edit: fix grammar)