### PR TITLE
ecp rocm ci: add ecp-dav back + use updated container image

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -376,7 +376,7 @@ e4s-neoverse_v1-build:
 
 e4s-rocm-external-generate:
   extends: [ ".e4s-rocm-external", ".generate-x86_64"]
-  image: ecpe4s/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.1.1:2024.06.17
+  image: ecpe4s/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.1.1:2024.06.23
 
 e4s-rocm-external-build:
   extends: [ ".e4s-rocm-external", ".build" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -219,6 +219,7 @@ spack:
   - cabana +rocm amdgpu_target=gfx908
   - caliper +rocm amdgpu_target=gfx908
   - chai +rocm amdgpu_target=gfx908
+  - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx908
   - gasnet +rocm amdgpu_target=gfx908
   - ginkgo +rocm amdgpu_target=gfx908
   - heffte +rocm amdgpu_target=gfx908
@@ -243,7 +244,6 @@ spack:
   # - libcatalyst
   # - paraview +rocm amdgpu_target=gfx908 # mesa: https://github.com/spack/spack/issues/44745
   # - vtk-m ~openmp +rocm amdgpu_target=gfx908  # vtk-m: https://github.com/spack/spack/issues/40268
-  # - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx908 # +paraview: mesa: https://github.com/spack/spack/issues/44745; +vtkm has its own issue: https://gitlab.spack.io/spack/spack/-/jobs/11632511
   # --
   # - adios2 +kokkos +rocm amdgpu_target=gfx908 # adios2:https://github.com/spack/spack/issues/44594
   # - cp2k +mpi +rocm amdgpu_target=gfx908      # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
@@ -261,6 +261,7 @@ spack:
   - cabana +rocm amdgpu_target=gfx90a
   - caliper +rocm amdgpu_target=gfx90a
   - chai +rocm amdgpu_target=gfx90a
+  - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx90a
   - gasnet +rocm amdgpu_target=gfx90a
   - ginkgo +rocm amdgpu_target=gfx90a
   - heffte +rocm amdgpu_target=gfx90a
@@ -285,7 +286,6 @@ spack:
   # - libcatalyst
   # - paraview +rocm amdgpu_target=gfx90a # mesa: https://github.com/spack/spack/issues/44745
   # - vtk-m ~openmp +rocm amdgpu_target=gfx90a  # vtk-m: https://github.com/spack/spack/issues/40268
-  # - ecp-data-vis-sdk +paraview +vtkm +rocm amdgpu_target=gfx90a  # +paraview: mesa: https://github.com/spack/spack/issues/44745; +vtkm has its own issue: https://gitlab.spack.io/spack/spack/-/jobs/11632511
   # --
   # - adios2 +kokkos +rocm amdgpu_target=gfx90a # adios2: https://github.com/spack/spack/issues/44594  
   # - cp2k +mpi +rocm amdgpu_target=gfx90a      # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
@@ -300,7 +300,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ecpe4s/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.1.1:2024.06.17
+        image: ecpe4s/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.1.1:2024.06.23
 
   cdash:
     build-group: E4S ROCm External


### PR DESCRIPTION
E4S ROCm CI: Use updated container image with `rocm-llvm-dev` installed and re-enable `ecp-data-vis-sdk`.
* Ref: https://github.com/spack/spack/issues/44745