### PR TITLE
geant4: add v11.2.2, incl g4ndl v4.7.1

### DIFF
--- a/var/spack/repos/builtin/packages/g4ndl/package.py
+++ b/var/spack/repos/builtin/packages/g4ndl/package.py
@@ -17,6 +17,7 @@ class G4ndl(Package):
 
     maintainers("drbenmorgan")
 
+    version("4.7.1", sha256="d3acae48622118d2579de24a54d533fb2416bf0da9dd288f1724df1485a46c7c")
     version("4.7", sha256="7e7d3d2621102dc614f753ad928730a290d19660eed96304a9d24b453d670309")
     version("4.6", sha256="9d287cf2ae0fb887a2adce801ee74fb9be21b0d166dab49bcbee9408a5145408")
     version("4.5", sha256="cba928a520a788f2bc8229c7ef57f83d0934bb0c6a18c31ef05ef4865edcdf8e")

--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -18,6 +18,7 @@ class Geant4Data(BundlePackage):
 
     tags = ["hep"]
 
+    version("11.2.2")
     version("11.2.0")
     version("11.1.0")
     version("11.0.0")
@@ -43,8 +44,21 @@ class Geant4Data(BundlePackage):
     # they generally don't change on the patch level
     # Can move to declaring on a dataset basis if needed
     _datasets = {
-        "11.2.0:11.2": [
-            "g4ndl@4.7",
+        "11.2.2:11.2": [
+            "g4ndl@4.7.1",
+            "g4emlow@8.5",
+            "g4photonevaporation@5.7",
+            "g4radioactivedecay@5.6",
+            "g4particlexs@4.0",
+            "g4pii@1.3",
+            "g4realsurface@2.2",
+            "g4saiddata@2.0",
+            "g4abla@3.3",
+            "g4incl@1.2",
+            "g4ensdfstate@2.3",
+        ],
+        "11.2.0:11.2.1": [
+            "g4ndl@=4.7",
             "g4emlow@8.5",
             "g4photonevaporation@5.7",
             "g4radioactivedecay@5.6",

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -94,7 +94,8 @@ class Geant4(CMakePackage):
         "10.7.4",
         "11.0",
         "11.1",
-        "11.2:",
+        "11.2.0:11.2.1",
+        "11.2.2:",
     ]:
         depends_on("geant4-data@" + _vers, type="run", when="@" + _vers)
 

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -22,6 +22,7 @@ class Geant4(CMakePackage):
 
     maintainers("drbenmorgan", "sethrj")
 
+    version("11.2.2", sha256="3a8d98c63fc52578f6ebf166d7dffaec36256a186d57f2520c39790367700c8d")
     version("11.2.1", sha256="76c9093b01128ee2b45a6f4020a1bcb64d2a8141386dea4674b5ae28bcd23293")
     version("11.2.0", sha256="9ff544739b243a24dac8f29a4e7aab4274fc0124fd4e1c4972018213dc6991ee")
     version("11.1.3", sha256="5d9a05d4ccf8b975649eab1d615fc1b8dce5937e01ab9e795bffd04149240db6")


### PR DESCRIPTION
This PR adds the new bugfix release 11.2.2 of geant4. Release notes at https://geant4.web.cern.ch/download/release-notes/notes-v11.2.2.txt.

This version comes with a new version of g4ndl, v4.7.1. I interpret the release notes such that this bugfix release of g4ndl should work for (and be preferred for) geant4 v11.2.0 and v11.2.1 as well. @drbenmorgan Is that correct?

>   o Data
>     ----
>     + G4NDL-4.7.1:
>       o Removed all files for Argon-36 and Argon-38 as significantly different
>         from those of ENDF/B-VIII.0.
>       o Reprocessed thermal scattering files after fixing a problem in NJOY.
>         Addressing problem report # 2552.

If my interpretation is incorrect, and geant4 v11.2.1 must use g4ndl v4.7, then we will need to make some changes to geant4-data as well.

EDIT: For validation purposes, discussed [below](https://github.com/spack/spack/pull/44830#issuecomment-2186564662), the older versions of geant4 are pinned against g4ndl v4.7, and only 11.2.2 is set to use g4ndl v4.7.1.