### PR TITLE
xl: avoid matching "_r" in tempfile.TemporaryDirectory during audit externals

### DIFF
--- a/var/spack/repos/builtin/packages/xl/package.py
+++ b/var/spack/repos/builtin/packages/xl/package.py
@@ -30,8 +30,8 @@ class Xl(Package, CompilerPackage):
 
     @classmethod
     def determine_variants(cls, exes, version_str):
-        _r_exes = [e for e in exes if "_r" in e]
-        _exes = [e for e in exes if "_r" not in e]
+        _r_exes = [e for e in exes if e.endswith("_r")]
+        _exes = [e for e in exes if not e.endswith("_r")]
 
         _r_compilers = cls.determine_compiler_paths(exes=_r_exes) if _r_exes else None
         _compilers = cls.determine_compiler_paths(exes=_exes) if _exes else None


### PR DESCRIPTION
### Problem
I noticed a transient CI error in `spack audit externals xl`, in particular https://github.com/spack/spack/actions/runs/9636498789/job/26574519657?pr=44830.

This is caused occasionally by the presence of a `_r` in the tempfile.TemporaryDirectory tmpdir. You can trigger this with `lib/spack/spack/detection/test.py:59`:
```diff
-        self.tmpdir = tempfile.TemporaryDirectory()
+        self.tmpdir = tempfile.TemporaryDirectory(suffix="_r")
```

This causes the `_exes = [e for e in exes if "_r" not in e]` to always remain None, and fails the audit.

Probability of this happening on one particular instance is .073% (or, it is expected to happen once in 1369 cases), based on https://github.com/python/cpython/blob/69bd1a8da02048fdef0aded10847197bea6e42c0/Lib/tempfile.py#L140.

### Solution
This PR requires that the `_r` is at the end, not just *somewhere* in the path.

### Additional context
Only CompilerPackages are included in `spack audit externals`, and based on a look through those:
- some are using `basename = os.path.basename(exe)` before doing substring matching (e.g. gcc),
- most are just using `c_names` and `cxx_names`, etc, instead of iterating over exes,
- others (llvm) are using sufficiently long matching strings so probability goes down even further (icc matches on three characters).