### PR TITLE
Parent runtime can only be equal or newer than child

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3234,6 +3234,39 @@ class RuntimePropertyRecorder:
         self.runtime_conditions.add((imposed_spec, when_spec))
         self.reset()
 
+    def propagate(self, constraint_str: str, *, when: str):
+        msg = "the 'propagate' method can be called only with pkg('*')"
+        assert self.current_package == "*", msg
+
+        when_spec = spack.spec.Spec(when)
+        assert when_spec.name is None, "only anonymous when specs are accepted"
+
+        placeholder = "XXX"
+        node_variable = "node(ID, Package)"
+        when_spec.name = placeholder
+
+        body_clauses = self._setup.spec_clauses(when_spec, body=True)
+        body_str = (
+            f"  {f',{os.linesep}  '.join(str(x) for x in body_clauses)},\n"
+            f"  not external({node_variable}),\n"
+            f"  not runtime(Package)"
+        ).replace(f'"{placeholder}"', f"{node_variable}")
+
+        constraint_spec = spack.spec.Spec(constraint_str)
+        assert constraint_spec.name is None, "only anonymous constraint specs are accepted"
+
+        constraint_spec.name = placeholder
+        constraint_clauses = self._setup.spec_clauses(constraint_spec, body=False)
+        for clause in constraint_clauses:
+            if clause.args[0] == "node_compiler_version_satisfies":
+                self._setup.compiler_version_constraints.add(constraint_spec.compiler)
+                args = f'"{constraint_spec.compiler.name}", "{constraint_spec.compiler.versions}"'
+                head_str = f"propagate({node_variable}, node_compiler_version_satisfies({args}))"
+                rule = f"{head_str} :-\n{body_str}.\n\n"
+                self.rules.append(rule)
+
+        self.reset()
+
     def consume_facts(self):
         """Consume the facts collected by this object, and emits rules and
         facts for the runtimes.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -996,6 +996,30 @@ variant_is_propagated(PackageNode, Variant) :-
    attr("variant_value", PackageNode, Variant, Value),
    not propagate(PackageNode, variant_value(Variant, Value)).
 
+%----
+% Compiler constraints
+%----
+
+attr("node_compiler_version_satisfies", node(ID, Package), Compiler, Version) :-
+  propagate(node(ID, Package), node_compiler_version_satisfies(Compiler, Version)),
+  node_compiler(node(ID, Package), CompilerID),
+  compiler_name(CompilerID, Compiler),
+  not runtime(Package),
+  not external(Package).
+
+%-----------------------------------------------------------------------------
+% Runtimes
+%-----------------------------------------------------------------------------
+
+% Check whether the DAG has any built package
+has_built_packages() :- build(X), not external(X).
+
+% If we build packages, the runtime nodes must use an available compiler
+1 { node_compiler(PackageNode, CompilerID) : build(PackageNode), not external(PackageNode) } :-
+  has_built_packages(),
+  runtime(RuntimePackage),
+  node_compiler(node(_, RuntimePackage), CompilerID).
+
 %-----------------------------------------------------------------------------
 % Platform semantics
 %-----------------------------------------------------------------------------
@@ -1097,10 +1121,15 @@ attr("node_target", PackageNode, Target)
  :- attr("node", PackageNode), attr("node_target_set", PackageNode, Target).
 
 % each node has the weight of its assigned target
-node_target_weight(node(ID, Package), Weight)
- :- attr("node", node(ID, Package)),
-    attr("node_target", node(ID, Package), Target),
-    target_weight(Target, Weight).
+target_weight(Target, 0)
+ :- attr("node", PackageNode),
+    attr("node_target", PackageNode, Target),
+    attr("node_target_set", PackageNode, Target).
+
+node_target_weight(PackageNode, MinWeight)
+ :- attr("node", PackageNode),
+    attr("node_target", PackageNode, Target),
+    MinWeight = #min { Weight : target_weight(Target, Weight) }.
 
 % compatibility rules for targets among nodes
 node_target_match(ParentNode, DependencyNode)
@@ -1162,12 +1191,12 @@ error(10, "No valid compiler for {0} satisfies '%{1}'", Package, Compiler)
 
 % If the compiler of a node must satisfy a constraint, then its version
 % must be chosen among the ones that satisfy said constraint
-error(100, "No valid version for '{0}' compiler '{1}' satisfies '@{2}'", Package, Compiler, Constraint)
+error(100, "Package {0} cannot satisfy '%{1}@{2}'", Package, Compiler, Constraint)
   :- attr("node", node(X, Package)),
      attr("node_compiler_version_satisfies", node(X, Package), Compiler, Constraint),
-		 not compiler_version_satisfies(Compiler, Constraint, _).
+	 not compiler_version_satisfies(Compiler, Constraint, _).
 
-error(100, "No valid version for '{0}' compiler '{1}' satisfies '@{2}'", Package, Compiler, Constraint)
+error(100, "Package {0} cannot satisfy '%{1}@{2}'", Package, Compiler, Constraint)
   :- attr("node", node(X, Package)),
      attr("node_compiler_version_satisfies", node(X, Package), Compiler, Constraint),
      not compiler_version_satisfies(Compiler, Constraint, ID),

--- a/lib/spack/spack/solver/libc_compatibility.lp
+++ b/lib/spack/spack/solver/libc_compatibility.lp
@@ -18,9 +18,6 @@ error(100, "Cannot reuse {0} since we cannot determine libc compatibility", Reus
      ReusedPackage != LibcPackage,
      not attr("compatible_libc", node(R, ReusedPackage), LibcPackage, LibcVersion).
 
-% Check whether the DAG has any built package
-has_built_packages() :- build(X), not external(X).
-
 % A libc is needed in the DAG
 :- has_built_packages(), not provider(_, node(0, "libc")).
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -1150,6 +1150,9 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         # The version of gcc-runtime is the same as the %gcc used to "compile" it
         pkg("gcc-runtime").requires(f"@={str(spec.version)}", when=f"%{str(spec)}")
 
+        # If a node used %gcc@X.Y its dependencies must use gcc-runtime@:X.Y
+        pkg("*").propagate(f"%gcc@:{str(spec.version)}", when=f"%{str(spec)}")
+
     def _post_buildcache_install_hook(self):
         if not self.spec.satisfies("platform=linux"):
             return

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -1151,6 +1151,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         pkg("gcc-runtime").requires(f"@={str(spec.version)}", when=f"%{str(spec)}")
 
         # If a node used %gcc@X.Y its dependencies must use gcc-runtime@:X.Y
+        # (technically @:X is broader than ... <= @=X but this should work in practice)
         pkg("*").propagate(f"%gcc@:{str(spec.version)}", when=f"%{str(spec)}")
 
     def _post_buildcache_install_hook(self):

--- a/var/spack/repos/compiler_runtime.test/packages/gcc/package.py
+++ b/var/spack/repos/compiler_runtime.test/packages/gcc/package.py
@@ -30,3 +30,6 @@ class Gcc(Package):
         )
         # The version of gcc-runtime is the same as the %gcc used to "compile" it
         pkg("gcc-runtime").requires(f"@={str(spec.version)}", when=f"%{str(spec)}")
+
+        # If a node used %gcc@X.Y its dependencies must use gcc-runtime@:X.Y
+        pkg("*").propagate(f"%gcc@:{str(spec.version)}", when=f"%{str(spec)}")


### PR DESCRIPTION
fixes #44444 
depends on #44893 

This PR solves a modeling issue, where we allowed `a%gcc@<old> ^b%gcc@<new>`. It turns out that this, though always allowed, is wrong and we should constrain child nodes to have a runtime older or equal than the parent. 

After the PR we would get this for a similar situation:
```console
$ spack spec hdf5%gcc@9 ^zlib%gcc@13
==> Error: concretization failed for the following reasons:

   1. Package hdf5 cannot satisfy '%gcc@9'
```

To solve the issue we have written a new generic rule:
```asp
propagate(ChildNode, PropagatedAttribute) :-  
  propagate(ParentNode, PropagatedAttribute),
  depends_on(ParentNode, ChildNode).
```
to propagate a fact from parents to children. At the moment only variants and compiler constraints are propagated this way. In particular, runtimes now emit rules like:
```asp
propagate(node(ID, Package), node_compiler_version_satisfies("gcc", ":13.2.0")) :-
  attr("node", node(ID, Package)),
  attr("node_compiler", node(ID, Package), "gcc"),
  attr("node_compiler_version", node(ID, Package), "gcc", "13.2.0"),
  not external(node(ID, Package)),
  not runtime(Package).
```

In a following PR, we can move to this mechanism also targets and compiler flags, and try to make the propagation logic homogeneous.

