### PR TITLE
py-heat: new versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-heat/package.py
+++ b/var/spack/repos/builtin/packages/py-heat/package.py
@@ -18,6 +18,9 @@ class PyHeat(PythonPackage):
 
     license("MIT")
 
+    version("1.4.1", sha256="ecd871717c372a6983f643c0178dda44bc017d6b32b9258dbf3775af95f580ce")
+    version("1.4.0", sha256="6836fa10f9ce62ea61cf1bdc3283d7ad0c305836cc5a08c4edfd30695708e788")
+    version("1.3.1", sha256="8997ddc56a1d3078b44a1e2933adc0a7fbf678bd19bade3ae015bc0e13d40d3b")
     version("1.3.0", sha256="fa247539a559881ffe574a70227d3c72551e7c4a9fb29b0945578d6a840d1c87")
 
     variant("docutils", default=False, description="Use the py-docutils package")
@@ -32,14 +35,25 @@ class PyHeat(PythonPackage):
         description="Use py-scikit-learn and py-matplotlib for the example tests",
     )
 
-    depends_on("python@3.8:", type=("build", "run"))
-    depends_on("py-numpy@1.20:", type=("build", "run"))
-    depends_on("py-torch@1.8:2.0.1", type=("build", "run"))
-    depends_on("py-scipy@0.14:", type=("build", "run"))
-    depends_on("pil@6:", type=("build", "run"))
-    depends_on("py-torchvision@0.8:", type=("build", "run"))
-    depends_on("py-mpi4py@3:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
+
+    with when("@1.3"):
+        depends_on("python@3.8:3.10", type=("build", "run"))
+        depends_on("py-mpi4py@3:", type=("build", "run"))
+        depends_on("py-numpy@1.20:1", type=("build", "run"))
+        depends_on("py-torch@1.8:2.0.1", type=("build", "run"))
+        depends_on("py-scipy@0.14:", type=("build", "run"))
+        depends_on("pil@6:", type=("build", "run"))
+        depends_on("py-torchvision@0.8:", type=("build", "run"))
+
+    with when("@1.4"):
+        depends_on("python@3.8:3.11", type=("build", "run"))
+        depends_on("py-mpi4py@3:", type=("build", "run"))
+        depends_on("py-numpy@1.22:1", type=("build", "run"))
+        depends_on("py-torch@1.11:2.2.2", type=("build", "run"))
+        depends_on("py-scipy@1.10:", type=("build", "run"))
+        depends_on("pil@6:", type=("build", "run"))
+        depends_on("py-torchvision@0.12:", type=("build", "run"))
 
     depends_on("py-docutils@0.16:", when="+docutils", type=("build", "link", "run"))
     depends_on("py-h5py@2.8.0:", when="+hdf5", type=("build", "link", "run"))


### PR DESCRIPTION
New versions, checked setup.py for versions of dependencies. 1.4.1 builds and imports fine for me.

Added py-numpy < 2 (in setup.py of current main: https://github.com/helmholtz-analytics/heat/blob/main/setup.py, I assume this yields for older versions, too).
