### PR TITLE
yafyaml: conflict gcc 13.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/yafyaml/package.py
+++ b/var/spack/repos/builtin/packages/yafyaml/package.py
@@ -60,11 +60,8 @@ class Yafyaml(CMakePackage):
         msg="yaFyaml only works with the Fujitsu compiler from 1.3.0 onwards",
     )
 
-    # yafyaml does not seem to build with gcc 13.3 at the moment
-    conflicts(
-        "%gcc@13.3:",
-        msg="yaFyaml does not successfully build with gfortran 13.3",
-    )
+    # yafyaml does not currently build with gcc 13.3
+    conflicts("%gcc@13.3:", msg="yaFyaml does not successfully build with gfortran 13.3")
 
     variant(
         "build_type",

--- a/var/spack/repos/builtin/packages/yafyaml/package.py
+++ b/var/spack/repos/builtin/packages/yafyaml/package.py
@@ -60,6 +60,12 @@ class Yafyaml(CMakePackage):
         msg="yaFyaml only works with the Fujitsu compiler from 1.3.0 onwards",
     )
 
+    # yafyaml does not seem to build with gcc 13.3 at the moment
+    conflicts(
+        "%gcc@13.3:",
+        msg="yaFyaml does not successfully build with gfortran 13.3",
+    )
+
     variant(
         "build_type",
         default="Release",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Recent tests of yafyaml with gcc 13.3 point to a build issue, see https://github.com/Goddard-Fortran-Ecosystem/yaFyaml/issues/77

Until this can be fixed, we conflict out `gcc@13.3`. 

---

NOTE: I cannot figure out (yet?) how to express this for macOS mixed clang-gfortran builds. For example, on my box, I use Homebrew as my gfortran provider because, well, lazy, and point to `gfortran-13`:
```
- compiler:
    spec: apple-clang@=15.0.0
    paths:
      cc: /usr/bin/clang
      cxx: /usr/bin/clang++
      f77: /Users/mathomp4/.homebrew/brew/bin/gfortran-13
      fc: /Users/mathomp4/.homebrew/brew/bin/gfortran-13
    flags: {}
    operating_system: sonoma
    target: aarch64
    modules: []
    environment: {}
    extra_rpaths: []
```

But in this case, the compiler spec is `%apple-clang@15` and yafyaml is a Fortran code that doesn't care about the C version. But, as far as I know, there is no easy way to get the `FC` version out.