### PR TITLE
otf2: fix package

### DIFF
--- a/var/spack/repos/builtin/packages/otf2/package.py
+++ b/var/spack/repos/builtin/packages/otf2/package.py
@@ -61,19 +61,19 @@ class Otf2(AutotoolsPackage):
 
     def url_for_version(self, version):
         if version < Version("2.3"):
-            return "https://www.vi-hps.org/cms/upload/packages/otf2/otf2-{0}.tar.gz".format(
-                version
-            )
+            return f"https://www.vi-hps.org/cms/upload/packages/otf2/otf2-{version}.tar.gz"
 
-        return "https://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-{0}/otf2-{0}.tar.gz".format(
-            version
-        )
+        return f"https://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-{version}/otf2-{version}.tar.gz"
+
+    extends("python")
+
+    # `imp` module required
+    depends_on("python@:3.11", type=("build", "run"))
 
     with when("@2.2 %cce"):
         depends_on("autoconf", type="build")
         depends_on("automake", type="build")
         depends_on("libtool", type="build")
-        depends_on("m4", type="build")
 
     # Fix missing initialization of variable resulting in issues when used by
     # APEX/HPX: https://github.com/STEllAR-GROUP/hpx/issues/5239
@@ -86,14 +86,19 @@ class Otf2(AutotoolsPackage):
     def force_autoreconf(self):
         return self.spec.satisfies("@2.2 %cce")
 
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            flags.append(self.compiler.cc_pic_flag)
+        elif name == "cxxflags":
+            flags.append(self.compiler.cxx_pic_flag)
+        return (flags, None, None)
+
     def configure_args(self):
         return [
             "--enable-shared",
-            "CC={0}".format(spack_cc),
-            "CXX={0}".format(spack_cxx),
-            "F77={0}".format(spack_f77),
-            "FC={0}".format(spack_fc),
-            "CFLAGS={0}".format(self.compiler.cc_pic_flag),
-            "CXXFLAGS={0}".format(self.compiler.cxx_pic_flag),
+            f"CC={spack_cc}",
+            f"CXX={spack_cxx}",
+            f"F77={spack_f77}",
+            f"FC={spack_fc}",
             "PYTHON_FOR_GENERATOR=:",
         ]


### PR DESCRIPTION
- extend python
- forward compat bound with python due to imp import
- restore -O2 flags (CFLAGS do not compose)

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
