### PR TITLE
elsi: improve package and add external libOMM

### DIFF
--- a/var/spack/repos/builtin/packages/elsi/package.py
+++ b/var/spack/repos/builtin/packages/elsi/package.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os.path
 
-from spack.package import *
 from spack.error import NoHeadersError
+from spack.package import *
 
 
 class Elsi(CMakePackage, CudaPackage):
@@ -19,10 +19,19 @@ class Elsi(CMakePackage, CudaPackage):
     license("BSD-3-Clause")
 
     version("2.10.1", sha256="b3c7526d46a9139a26680787172a3df15bc648715a35bdf384053231e94ab829")
-    version("2.2.1", sha256="5b4b2e8fa4b3b68131fe02cc1803a884039b89a1b1138af474af66453bec0b4d", deprecated=True)
+    version(
+        "2.2.1",
+        sha256="5b4b2e8fa4b3b68131fe02cc1803a884039b89a1b1138af474af66453bec0b4d",
+        deprecated=True,
+    )
     version("master", branch="master")
 
-    variant("add_underscore", default=True, description="Suffix C functions with an underscore", when="@2.2.1")
+    variant(
+        "add_underscore",
+        default=True,
+        description="Suffix C functions with an underscore",
+        when="@2.2.1",
+    )
     variant(
         "elpa2_kernel",
         default="none",
@@ -34,11 +43,21 @@ class Elsi(CMakePackage, CudaPackage):
     variant("enable_sips", default=False, description="Enable SLEPc-SIPs support")
     variant("use_external_elpa", default=True, description="Build ELPA using SPACK")
     variant("use_external_ntpoly", default=True, description="Build NTPoly using SPACK")
-    variant("use_external_superlu", default=True, description="Use external SuperLU DIST", when="@:2.2")
-    variant("use_external_pexsi", default=True, description="Use external PEXSI", when="@2.3: +enable_pexsi")
+    variant(
+        "use_external_superlu", default=True, description="Use external SuperLU DIST", when="@:2.2"
+    )
+    variant(
+        "use_external_pexsi",
+        default=True,
+        description="Use external PEXSI",
+        when="@2.3: +enable_pexsi",
+    )
     variant("use_external_omm", default=True, description="Use external libOMM")
     variant(
-        "use_mpi_iallgather", default=True, description="Use non-blocking collective MPI functions", when="@:2.5"
+        "use_mpi_iallgather",
+        default=True,
+        description="Use non-blocking collective MPI functions",
+        when="@:2.5",
     )
     variant(
         "internal_elpa_version",
@@ -131,8 +150,9 @@ class Elsi(CMakePackage, CudaPackage):
         ]
 
         if not self.spec.satisfies("+use_external_elpa"):
-            args.append(self.define(f"USE_ELPA_{self.spec.variants['internal_elpa_version'].value}", True))
-
+            args.append(
+                self.define(f"USE_ELPA_{self.spec.variants['internal_elpa_version'].value}", True)
+            )
 
         if self.spec.variants["elpa2_kernel"].value != "none":
             args.append(self.define_from_variant("ELPA2_KERNEL", "elpa2_kernel"))

--- a/var/spack/repos/builtin/packages/elsi/package.py
+++ b/var/spack/repos/builtin/packages/elsi/package.py
@@ -19,10 +19,10 @@ class Elsi(CMakePackage, CudaPackage):
     license("BSD-3-Clause")
 
     version("2.10.1", sha256="b3c7526d46a9139a26680787172a3df15bc648715a35bdf384053231e94ab829")
-    version("2.2.1", sha256="5b4b2e8fa4b3b68131fe02cc1803a884039b89a1b1138af474af66453bec0b4d")
+    version("2.2.1", sha256="5b4b2e8fa4b3b68131fe02cc1803a884039b89a1b1138af474af66453bec0b4d", deprecated=True)
     version("master", branch="master")
 
-    variant("add_underscore", default=True, description="Suffix C functions with an underscore")
+    variant("add_underscore", default=True, description="Suffix C functions with an underscore", when="@2.2.1")
     variant(
         "elpa2_kernel",
         default="none",
@@ -34,10 +34,11 @@ class Elsi(CMakePackage, CudaPackage):
     variant("enable_sips", default=False, description="Enable SLEPc-SIPs support")
     variant("use_external_elpa", default=True, description="Build ELPA using SPACK")
     variant("use_external_ntpoly", default=True, description="Build NTPoly using SPACK")
-    variant("use_external_superlu", default=True, description="Use external SuperLU DIST")
+    variant("use_external_superlu", default=True, description="Use external SuperLU DIST", when="@:2.2")
+    variant("use_external_pexsi", default=True, description="Use external PEXSI", when="@2.3: +enable_pexsi")
     variant("use_external_omm", default=True, description="Use external libOMM")
     variant(
-        "use_mpi_iallgather", default=True, description="Use non-blocking collective MPI functions"
+        "use_mpi_iallgather", default=True, description="Use non-blocking collective MPI functions", when="@:2.5"
     )
     variant(
         "internal_elpa_version",
@@ -54,10 +55,10 @@ class Elsi(CMakePackage, CudaPackage):
     depends_on("mpi")
 
     # Library dependencies
+    depends_on("ntpoly", when="+use_external_ntpoly")
     with when("+use_external_elpa"):
         depends_on("elpa+cuda", when="+cuda")
         depends_on("elpa~cuda", when="~cuda")
-    depends_on("ntpoly", when="+use_external_ntpoly")
     with when("+enable_sips"):
         depends_on("slepc+cuda", when="+cuda")
         depends_on("slepc~cuda", when="~cuda")
@@ -66,7 +67,10 @@ class Elsi(CMakePackage, CudaPackage):
     with when("+use_external_superlu"):
         depends_on("superlu-dist+cuda", when="+cuda")
         depends_on("superlu-dist~cuda", when="~cuda")
-
+    with when("+enable_pexsi +use_external_pexsi"):
+        depends_on("pexsi+fortran")
+        depends_on("superlu-dist+cuda", when="+cuda")
+        depends_on("superlu-dist~cuda", when="~cuda")
     with when("+use_external_omm"):
         depends_on("omm")
         depends_on("matrix-switch")  # Direct dependency
@@ -81,6 +85,9 @@ class Elsi(CMakePackage, CudaPackage):
             libs_names.append("ntpoly")
         if self.spec.satisfies("+use_external_superlu"):
             libs_names.append("superlu-dist")
+        if self.spec.satisfies("+use_external_pexsi"):
+            libs_names.append("superlu-dist")
+            libs_names.append("pexsi")
         if self.spec.satisfies("+use_external_omm"):
             libs_names.append("omm")
             libs_names.append("matrix-switch")
@@ -112,16 +119,20 @@ class Elsi(CMakePackage, CudaPackage):
             self.define_from_variant("ENABLE_SIPS", "enable_sips"),
             self.define_from_variant("USE_EXTERNAL_ELPA", "use_external_elpa"),
             self.define_from_variant("USE_EXTERNAL_NTPOLY", "use_external_ntpoly"),
-            self.define_from_variant("USE_EXTERNAL_SUPERLU", "use_external_superlu"),
             self.define_from_variant("USE_EXTERNAL_OMM", "use_external_omm"),
+            self.define_from_variant("USE_EXTERNAL_SUPERLU", "use_external_superlu"),
+            self.define_from_variant("USE_EXTERNAL_PEXSI", "use_external_pexsi"),
             self.define_from_variant("USE_MPI_IALLGATHER", "use_mpi_iallgather"),
             self.define("ENABLE_TESTS", self.run_tests),
             self.define("ENABLE_C_TESTS", self.run_tests),
             self.define_from_variant("USE_GPU_CUDA", "cuda"),
             self.define("LIB_PATHS", ";".join(set(lib_paths))),
             self.define("LIBS", ";".join(set(libs))),
-            self.define(f"USE_ELPA_{self.spec.variants['internal_elpa_version'].value}", True),
         ]
+
+        if not self.spec.satisfies("+use_external_elpa"):
+            args.append(self.define(f"USE_ELPA_{self.spec.variants['internal_elpa_version'].value}", True))
+
 
         if self.spec.variants["elpa2_kernel"].value != "none":
             args.append(self.define_from_variant("ELPA2_KERNEL", "elpa2_kernel"))

--- a/var/spack/repos/builtin/packages/matrix-switch/package.py
+++ b/var/spack/repos/builtin/packages/matrix-switch/package.py
@@ -44,6 +44,10 @@ class MatrixSwitch(CMakePackage):
         ]
 
         if self.spec.satisfies("+dbcsr"):
-            args.append(self.define("DBCSR_ROOT", self.spec["dbcsr"]._prefix))
+            args.append(self.define("DBCSR_ROOT", self.spec["dbcsr"].prefix))
 
         return args
+    
+    @property
+    def libs(self):
+        return find_libraries("libmatrixswitch", root=self.home, recursive=True, shared=False)

--- a/var/spack/repos/builtin/packages/matrix-switch/package.py
+++ b/var/spack/repos/builtin/packages/matrix-switch/package.py
@@ -1,0 +1,49 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class MatrixSwitch(CMakePackage):
+    """Intermediary interface between high-level routines for physics-related algorithms and low-level routines dealing 
+    with matrix storage and manipulation."""
+
+    homepage = "https://gitlab.com/ElectronicStructureLibrary/omm/matrixswitch"
+    url = "https://gitlab.com/ElectronicStructureLibrary/omm/matrixswitch/-/archive/1.2.1/matrixswitch-1.2.1.tar.gz"
+    git = "https://gitlab.com/ElectronicStructureLibrary/omm/matrixswitch.git"
+
+    maintainers("RMeli")
+
+    license("BSD-2-Clause", checked_by="RMeli")
+
+    version("1.2.1", sha256="a3c2bac20435a8217cd1a1abefa8b7f8c52b1c6f55a75b2861565ade5ecfe37f")
+    version("master", branch="master")
+
+    variant("lapack", default=True, description="Build libOMM with LAPACK interface.")
+    variant("mpi", default=True, description="Build libOMM with MPI support.")
+    variant("scalapack", default=True, when="+mpi", description="Build libOMM with ScaLAPACK interface.")
+    variant("dbcsr", default=False, when="+mpi", description="Build libOMM with DBCSR interface.")
+
+    depends_on("cmake@3.22:", type="build")
+    generator("ninja")
+
+    depends_on("lapack", when="+lapack")
+    depends_on("mpi", when="+mpi")
+    depends_on("scalapack", when="+scalapack")
+    depends_on("dbcsr~shared", when="+dbcsr") # Expects static library (FindCustomDbcsr)
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("WITH_LAPACK", "lapack"),
+            self.define_from_variant("WITH_MPI", "mpi"),
+            self.define_from_variant("WITH_SCALAPACK", "scalapack"),
+            self.define_from_variant("WITH_DBCSR", "dbcsr"),
+
+        ]
+
+        if self.spec.satisfies("+dbcsr"):
+            args.append(self.define("DBCSR_ROOT", self.spec["dbcsr"]._prefix))
+
+        return args

--- a/var/spack/repos/builtin/packages/matrix-switch/package.py
+++ b/var/spack/repos/builtin/packages/matrix-switch/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 
 
 class MatrixSwitch(CMakePackage):
-    """Intermediary interface between high-level routines for 
+    """Intermediary interface between high-level routines for
     physics-related algorithms and low-level routines dealing
     with matrix storage and manipulation."""
 

--- a/var/spack/repos/builtin/packages/matrix-switch/package.py
+++ b/var/spack/repos/builtin/packages/matrix-switch/package.py
@@ -7,7 +7,8 @@ from spack.package import *
 
 
 class MatrixSwitch(CMakePackage):
-    """Intermediary interface between high-level routines for physics-related algorithms and low-level routines dealing
+    """Intermediary interface between high-level routines for 
+    physics-related algorithms and low-level routines dealing
     with matrix storage and manipulation."""
 
     homepage = "https://gitlab.com/ElectronicStructureLibrary/omm/matrixswitch"

--- a/var/spack/repos/builtin/packages/matrix-switch/package.py
+++ b/var/spack/repos/builtin/packages/matrix-switch/package.py
@@ -23,12 +23,7 @@ class MatrixSwitch(CMakePackage):
 
     variant("lapack", default=True, description="Build with LAPACK interface.")
     variant("mpi", default=True, description="Build with MPI support.")
-    variant(
-        "scalapack",
-        default=True,
-        when="+mpi",
-        description="Build with ScaLAPACK interface.",
-    )
+    variant("scalapack", default=True, when="+mpi", description="Build with ScaLAPACK interface.")
     variant("dbcsr", default=False, when="+mpi", description="Build with DBCSR interface.")
 
     depends_on("cmake@3.22:", type="build")

--- a/var/spack/repos/builtin/packages/matrix-switch/package.py
+++ b/var/spack/repos/builtin/packages/matrix-switch/package.py
@@ -21,15 +21,15 @@ class MatrixSwitch(CMakePackage):
     version("1.2.1", sha256="a3c2bac20435a8217cd1a1abefa8b7f8c52b1c6f55a75b2861565ade5ecfe37f")
     version("master", branch="master")
 
-    variant("lapack", default=True, description="Build libOMM with LAPACK interface.")
-    variant("mpi", default=True, description="Build libOMM with MPI support.")
+    variant("lapack", default=True, description="Build with LAPACK interface.")
+    variant("mpi", default=True, description="Build with MPI support.")
     variant(
         "scalapack",
         default=True,
         when="+mpi",
-        description="Build libOMM with ScaLAPACK interface.",
+        description="Build with ScaLAPACK interface.",
     )
-    variant("dbcsr", default=False, when="+mpi", description="Build libOMM with DBCSR interface.")
+    variant("dbcsr", default=False, when="+mpi", description="Build with DBCSR interface.")
 
     depends_on("cmake@3.22:", type="build")
     generator("ninja")

--- a/var/spack/repos/builtin/packages/matrix-switch/package.py
+++ b/var/spack/repos/builtin/packages/matrix-switch/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 
 
 class MatrixSwitch(CMakePackage):
-    """Intermediary interface between high-level routines for physics-related algorithms and low-level routines dealing 
+    """Intermediary interface between high-level routines for physics-related algorithms and low-level routines dealing
     with matrix storage and manipulation."""
 
     homepage = "https://gitlab.com/ElectronicStructureLibrary/omm/matrixswitch"
@@ -23,7 +23,12 @@ class MatrixSwitch(CMakePackage):
 
     variant("lapack", default=True, description="Build libOMM with LAPACK interface.")
     variant("mpi", default=True, description="Build libOMM with MPI support.")
-    variant("scalapack", default=True, when="+mpi", description="Build libOMM with ScaLAPACK interface.")
+    variant(
+        "scalapack",
+        default=True,
+        when="+mpi",
+        description="Build libOMM with ScaLAPACK interface.",
+    )
     variant("dbcsr", default=False, when="+mpi", description="Build libOMM with DBCSR interface.")
 
     depends_on("cmake@3.22:", type="build")
@@ -32,7 +37,7 @@ class MatrixSwitch(CMakePackage):
     depends_on("lapack", when="+lapack")
     depends_on("mpi", when="+mpi")
     depends_on("scalapack", when="+scalapack")
-    depends_on("dbcsr~shared", when="+dbcsr") # Expects static library (FindCustomDbcsr)
+    depends_on("dbcsr~shared", when="+dbcsr")  # Expects static library (FindCustomDbcsr)
 
     def cmake_args(self):
         args = [
@@ -40,14 +45,13 @@ class MatrixSwitch(CMakePackage):
             self.define_from_variant("WITH_MPI", "mpi"),
             self.define_from_variant("WITH_SCALAPACK", "scalapack"),
             self.define_from_variant("WITH_DBCSR", "dbcsr"),
-
         ]
 
         if self.spec.satisfies("+dbcsr"):
             args.append(self.define("DBCSR_ROOT", self.spec["dbcsr"].prefix))
 
         return args
-    
+
     @property
     def libs(self):
         return find_libraries("libmatrixswitch", root=self.home, recursive=True, shared=False)

--- a/var/spack/repos/builtin/packages/omm/package.py
+++ b/var/spack/repos/builtin/packages/omm/package.py
@@ -49,6 +49,6 @@ class Omm(CMakePackage):
         ]
 
         if self.spec.satisfies("+dbcsr"):
-            args.append(self.define("DBCSR_ROOT", self.spec["dbcsr"]._prefix))
+            args.append(self.define("DBCSR_ROOT", self.spec["dbcsr"].prefix))
 
         return args

--- a/var/spack/repos/builtin/packages/omm/package.py
+++ b/var/spack/repos/builtin/packages/omm/package.py
@@ -1,0 +1,54 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Omm(CMakePackage):
+    """Solution of Kohn-Sham equations using the Orbital Minimization Method (OMM)."""
+
+    homepage = "https://gitlab.com/ElectronicStructureLibrary/omm/libomm"
+    url = "https://gitlab.com/ElectronicStructureLibrary/omm/libomm/-/archive/1.2.1/libomm-1.2.1.tar.gz"
+    git = "https://gitlab.com/ElectronicStructureLibrary/omm/libomm.git"
+
+    maintainers("RMeli")
+
+    license("BSD-2-Clause", checked_by="RMeli")
+
+    version("1.2.1", sha256="4876990056efabdd83b0caad52ed56632d9926b61d73fe3efbd04d0f8d242ede")
+    version("master", branch="master")
+
+    variant("lapack", default=True, description="Build libOMM with LAPACK interface.")
+    variant("mpi", default=True, description="Build libOMM with MPI support.")
+    variant("scalapack", default=True, when="+mpi", description="Build libOMM with ScaLAPACK interface.")
+    variant("dbcsr", default=False, when="+mpi", description="Build libOMM with DBCSR interface.")
+    
+
+    depends_on("cmake@3.22:", type="build")
+    generator("ninja")
+
+    depends_on("lapack", when="+lapack")
+    depends_on("mpi", when="+mpi")
+    depends_on("scalapack", when="+scalapack")
+    depends_on("dbcsr~shared", when="+dbcsr") # Expects static library (FindCustomDbcsr)
+
+    depends_on("matrix-switch")
+    depends_on("matrix-switch+lapack", when="+lapack")
+    depends_on("matrix-switch+mpi", when="+mpi")
+    depends_on("matrix-switch+scalapack", when="+scalapack")
+    depends_on("matrix-switch+dbcsr", when="+dbcsr")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("WITH_LAPACK", "lapack"),
+            self.define_from_variant("WITH_MPI", "mpi"),
+            self.define_from_variant("WITH_SCALAPACK", "scalapack"),
+            self.define_from_variant("WITH_DBCSR", "dbcsr"),
+        ]
+
+        if self.spec.satisfies("+dbcsr"):
+            args.append(self.define("DBCSR_ROOT", self.spec["dbcsr"]._prefix))
+
+        return args

--- a/var/spack/repos/builtin/packages/omm/package.py
+++ b/var/spack/repos/builtin/packages/omm/package.py
@@ -22,9 +22,13 @@ class Omm(CMakePackage):
 
     variant("lapack", default=True, description="Build libOMM with LAPACK interface.")
     variant("mpi", default=True, description="Build libOMM with MPI support.")
-    variant("scalapack", default=True, when="+mpi", description="Build libOMM with ScaLAPACK interface.")
+    variant(
+        "scalapack",
+        default=True,
+        when="+mpi",
+        description="Build libOMM with ScaLAPACK interface.",
+    )
     variant("dbcsr", default=False, when="+mpi", description="Build libOMM with DBCSR interface.")
-    
 
     depends_on("cmake@3.22:", type="build")
     generator("ninja")
@@ -32,7 +36,7 @@ class Omm(CMakePackage):
     depends_on("lapack", when="+lapack")
     depends_on("mpi", when="+mpi")
     depends_on("scalapack", when="+scalapack")
-    depends_on("dbcsr~shared", when="+dbcsr") # Expects static library (FindCustomDbcsr)
+    depends_on("dbcsr~shared", when="+dbcsr")  # Expects static library (FindCustomDbcsr)
 
     depends_on("matrix-switch")
     depends_on("matrix-switch+lapack", when="+lapack")


### PR DESCRIPTION
* Add MatrixSwitch package
* Add libOMM package
* Use libOMM as external in ELSI
  * Add include paths for all libraries
    * Fortran modules need one directory up (can't use `libs.directories` since they are just the `include/` directories)
 