### PR TITLE
strumpack: Changed old test method to new test method

### DIFF
--- a/var/spack/repos/builtin/packages/strumpack/package.py
+++ b/var/spack/repos/builtin/packages/strumpack/package.py
@@ -246,10 +246,9 @@ class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
             try:
                 self._test_example(test_exe_mpi, exe, test_args)
                 return
-            except:
-                continue
+            except Exception:
+                pass
         assert False, "No MPI executable was found"
-    
     def check(self):
         """Skip the builtin testsuite, use the stand-alone tests instead."""
         pass

--- a/var/spack/repos/builtin/packages/strumpack/package.py
+++ b/var/spack/repos/builtin/packages/strumpack/package.py
@@ -249,6 +249,7 @@ class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
             except Exception:
                 pass
         assert False, "No MPI executable was found"
+
     def check(self):
         """Skip the builtin testsuite, use the stand-alone tests instead."""
         pass

--- a/var/spack/repos/builtin/packages/strumpack/package.py
+++ b/var/spack/repos/builtin/packages/strumpack/package.py
@@ -195,30 +195,14 @@ class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
         add_sparse = not self.spec.satisfies("@:5.1.1")
         return join_path("examples", "sparse" if add_sparse else "", "data")
 
-    # TODO: Replace this method and its 'get' use for cmake path with
-    #   join_path(self.spec['cmake'].prefix.bin, 'cmake') once stand-alone
-    #   tests can access build dependencies through self.spec['cmake'].
-    def cmake_bin(self, set=True):
-        """(Hack) Set/get cmake dependency path."""
-        filepath = join_path(self.install_test_root, "cmake_bin_path.txt")
-        if set:
-            with open(filepath, "w") as out_file:
-                cmake_bin = join_path(self.spec["cmake"].prefix.bin, "cmake")
-                out_file.write("{0}\n".format(cmake_bin))
-        else:
-            with open(filepath, "r") as in_file:
-                return in_file.read().strip()
-
     @run_after("install")
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources([self.test_data_dir, self.test_src_dir])
 
-        # TODO: Remove once self.spec['cmake'] is available here
-        self.cmake_bin(set=True)
-
-    def _test_example(self, test_prog, test_dir, test_cmd, test_args):
+    def _test_example(self, test_prog, test_cmd, test_args):
+        test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         cmake_filename = join_path(test_dir, "CMakeLists.txt")
         with open(cmake_filename, "w") as mkfile:
             mkfile.write("cmake_minimum_required(VERSION 3.15)\n")
@@ -229,51 +213,43 @@ class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
                 "target_link_libraries({0} ".format(test_prog) + "PRIVATE STRUMPACK::strumpack)\n"
             )
 
-        # TODO: Remove/replace once self.spec['cmake'] is available here
-        cmake_bin = self.cmake_bin(set=False)
+        with working_dir(test_dir):
+            opts = self.builder.std_cmake_args
+            opts += self.cmake_args()
+            opts += ["."]
+            cmake = self.spec["cmake"].command
+            cmake(*opts)
 
-        opts = self.std_cmake_args
-        opts += self.cmake_args()
-        opts += ["."]
+            make = which("make")
+            make(test_prog)
 
-        self.run_test(
-            cmake_bin,
-            opts,
-            [],
-            installed=False,
-            purpose="test: generating makefile",
-            work_dir=test_dir,
-        )
-        self.run_test(
-            "make", test_prog, purpose="test: building {0}".format(test_prog), work_dir=test_dir
-        )
-        with set_env(OMP_NUM_THREADS="1"):
-            self.run_test(
-                test_cmd,
-                test_args,
-                installed=False,
-                purpose="test: running {0}".format(test_prog),
-                skip_missing=False,
-                work_dir=test_dir,
-            )
+            with set_env(OMP_NUM_THREADS="1"):
+                exe = which(test_cmd)
+                exe(*test_args)
 
-    def test(self):
-        """Run the stand-alone tests for the installed software."""
-        test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
-        test_exe = "test_sparse_seq"
-        test_exe_mpi = "test_sparse_mpi"
-        exe_arg = [join_path("..", self.test_data_dir, "pde900.mtx")]
+    def test_sparse_seq(self):
+        """Run sequential test_sparse"""
         if "+mpi" in self.spec:
-            test_args = ["-n", "1", test_exe_mpi]
-            test_args.extend(exe_arg)
-            mpiexe_list = ["srun", "mpirun", "mpiexec"]
-            for mpiexe in mpiexe_list:
-                if which(mpiexe) is not None:
-                    self._test_example(test_exe_mpi, test_dir, mpiexe, test_args)
-                    break
-        else:
-            self._test_example(test_exe, test_dir, test_exe, exe_arg)
+            raise SkipTest("Package must be installed with '~mpi'")
+        test_exe = "test_sparse_seq"
+        exe_arg = [join_path("..", self.test_data_dir, "pde900.mtx")]
+        self._test_example(test_exe, test_exe, exe_arg)
 
+    def test_sparse_mpi(self):
+        """Run parallel test_sparse"""
+        if "+mpi" not in self.spec:
+            raise SkipTest("Package must be installed with '+mpi'")
+        test_exe_mpi = "test_sparse_mpi"
+        test_args = ["-n", "1", test_exe_mpi, join_path("..", self.test_data_dir, "pde900.mtx")]
+        mpiexe_list = ["srun", "mpirun", "mpiexec"]
+        for exe in mpiexe_list:
+            try:
+                self._test_example(test_exe_mpi, exe, test_args)
+                return
+            except:
+                continue
+        assert False, "No MPI executable was found"
+    
     def check(self):
         """Skip the builtin testsuite, use the stand-alone tests instead."""
         pass


### PR DESCRIPTION
Update standalone test API. See 2nd comment for test output.

Fixes #44848 
Supersedes #35807  (for one package)

https://spack.readthedocs.io/en/latest/packaging_guide.html#stand-alone-tests