### PR TITLE
containers: centos:stream -> centos:stream9

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -41,7 +41,7 @@ jobs:
         # 2: Base image (e.g. ubuntu:22.04)
         dockerfile: [[amazon-linux, 'linux/amd64,linux/arm64', 'amazonlinux:2'],
                      [centos7, 'linux/amd64,linux/arm64,linux/ppc64le', 'centos:7'],
-                     [centos-stream, 'linux/amd64,linux/arm64,linux/ppc64le', 'centos:stream'],
+                     [centos-stream9, 'linux/amd64,linux/arm64,linux/ppc64le', 'centos:stream9'],
                      [leap15, 'linux/amd64,linux/arm64,linux/ppc64le', 'opensuse/leap:15'],
                      [ubuntu-focal, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:20.04'],
                      [ubuntu-jammy, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:22.04'],

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -206,9 +206,9 @@ The OS that are currently supported are summarized in the table below:
    * - CentOS 7
      - ``centos:7``
      - ``spack/centos7``
-   * - CentOS Stream
-     - ``quay.io/centos/centos:stream``
-     - ``spack/centos-stream``
+   * - CentOS Stream9
+     - ``quay.io/centos/centos:stream9``
+     - ``spack/centos-stream9``
    * - openSUSE Leap
      - ``opensuse/leap``
      - ``spack/leap15``

--- a/lib/spack/spack/container/images.json
+++ b/lib/spack/spack/container/images.json
@@ -78,15 +78,15 @@
         "image": "quay.io/almalinuxorg/almalinux:8"
       }
     },
-    "centos:stream": {
+    "centos:stream9": {
       "bootstrap": {
-        "template": "container/centos_stream.dockerfile",
-        "image": "quay.io/centos/centos:stream"
+        "template": "container/centos_stream9.dockerfile",
+        "image": "quay.io/centos/centos:stream9"
       },
       "os_package_manager": "dnf_epel",
-      "build": "spack/centos-stream",
+      "build": "spack/centos-stream9",
       "final": {
-        "image": "quay.io/centos/centos:stream"
+        "image": "quay.io/centos/centos:stream9"
       }
     },
     "centos:7": {

--- a/lib/spack/spack/container/images.json
+++ b/lib/spack/spack/container/images.json
@@ -80,7 +80,7 @@
     },
     "centos:stream9": {
       "bootstrap": {
-        "template": "container/centos_stream9.dockerfile",
+        "template": "container/centos_stream.dockerfile",
         "image": "quay.io/centos/centos:stream9"
       },
       "os_package_manager": "dnf_epel",

--- a/lib/spack/spack/container/images.json
+++ b/lib/spack/spack/container/images.json
@@ -80,7 +80,7 @@
     },
     "centos:stream9": {
       "bootstrap": {
-        "template": "container/centos_stream.dockerfile",
+        "template": "container/centos_stream9.dockerfile",
         "image": "quay.io/centos/centos:stream9"
       },
       "os_package_manager": "dnf_epel",

--- a/share/spack/templates/container/Dockerfile
+++ b/share/spack/templates/container/Dockerfile
@@ -4,7 +4,7 @@
 {% endif %}
 {% if render_phase.build %}
 # Build stage with Spack pre-installed and ready to be used
-FROM {{ build.image }} as builder
+FROM {{ build.image }} AS builder
 
 {% block build_stage %}
 {% if os_packages_build %}

--- a/share/spack/templates/container/bootstrap-base.dockerfile
+++ b/share/spack/templates/container/bootstrap-base.dockerfile
@@ -1,4 +1,4 @@
-FROM {{ bootstrap.image }} as bootstrap
+FROM {{ bootstrap.image }} AS bootstrap
 
 {% block env_vars %}
 ENV SPACK_ROOT=/opt/spack \

--- a/share/spack/templates/container/centos_stream9.dockerfile
+++ b/share/spack/templates/container/centos_stream9.dockerfile
@@ -1,9 +1,9 @@
 {% extends "container/bootstrap-base.dockerfile" %}
 {% block install_os_packages %}
 RUN dnf update -y \
- # See https://fedoraproject.org/wiki/EPEL#Quickstart for powertools
+ # See https://fedoraproject.org/wiki/EPEL#Quickstart for crb
  && dnf install -y dnf-plugins-core \
- && dnf config-manager --set-enabled powertools \
+ && dnf config-manager --set-enabled crb \
  && dnf install -y epel-release \
  && dnf update -y \
  && dnf --enablerepo epel groupinstall -y "Development Tools" \

--- a/share/spack/templates/container/centos_stream9.dockerfile
+++ b/share/spack/templates/container/centos_stream9.dockerfile
@@ -8,7 +8,7 @@ RUN dnf update -y \
  && dnf update -y \
  && dnf --enablerepo epel groupinstall -y "Development Tools" \
  && dnf --enablerepo epel install -y \
-        curl \
+        curl-minimal \
         findutils \
         gcc-c++ \
         gcc \


### PR DESCRIPTION
As of May 31, 2024, CentOS [Stream 8 is EOL](https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/), and the [base images on quay.io](https://quay.io/repository/centos/centos?tab=tags) for tags `centos:stream` and `centos:stream8` are not being updated anymore (stream: last update Feb 15, 2023; stream8: last update Jun 3, 2024). In fact, it seems that `centos:stream` is an old snapshot of `centos:stream8`, so we were already pulling more updates than necessary and could have used the newer base image for a while.

Moreover, the `dnf update` for these older images fails in CI with
```
$ docker run --rm -it quay.io/centos/centos:stream
[root@3b3be38035c0 /]# dnf update -y
CentOS Stream 8 - AppStream                                                                                                                                                                                 189  B/s |  38  B     00:00    
Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
```
See e.g. https://github.com/spack/spack/actions/runs/9657918135/job/26638081569?pr=44851 in https://github.com/spack/spack/pull/44851. First failure in scheduled runs was https://github.com/spack/spack/actions/runs/9359855573 on Jun 3, 2024.

This PR updates the CentOS Stream base image from `centos:stream` to `centos:stream9`, which is updated and updateable with `dnf update`.

And next week we do this all over again when we remove `centos:7` from rotation since it will probably start failing then (or should we pull the plug on it now?)