### PR TITLE
New package py-globus-cli, update py-globus-sdk

### DIFF
--- a/var/spack/repos/builtin/packages/py-globus-cli/package.py
+++ b/var/spack/repos/builtin/packages/py-globus-cli/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/py-globus-cli/package.py
+++ b/var/spack/repos/builtin/packages/py-globus-cli/package.py
@@ -20,7 +20,7 @@ class PyGlobusCli(PythonPackage):
 
     version("3.16.0", sha256="0ef721060870d9346505e52b9bf30c7bed6ae136cc08762deb2f8893bd25d8c5")
 
-    depends_on("python@3.7:3.10", type=("build", "run"))
+    depends_on("python@3.7:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-globus-sdk@3.25.0", type=("build", "run"))
     depends_on("py-click@8", type=("build", "run"))
@@ -31,5 +31,5 @@ class PyGlobusCli(PythonPackage):
     # the underlying lib ever changes"
     depends_on("py-requests@2.19.1:2", type=("build", "run"))
     depends_on("py-pyjwt@2.0.0:2+crypto", type=("build", "run"))
-    depends_on("py-cryptography@3.3.1:", type=("build", "run"))
-    depends_on("py-typing-extensions@4:", type=("build", "run"))
+    depends_on("py-cryptography@3.3.1:3.3", type=("build", "run"))
+    depends_on("py-typing-extensions@4:", type=("build", "run"), when="^python@:3.10")

--- a/var/spack/repos/builtin/packages/py-globus-cli/package.py
+++ b/var/spack/repos/builtin/packages/py-globus-cli/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class PyGlobusCli(PythonPackage):
+    """Globus CLI is a standalone application that can be installed on the user's machine
+    and is used to access the Globus service. The CLI provides an interface to Globus
+    services from the shell, and is suited to both interactive and simple scripting use cases."""
+
+    homepage = "https://docs.globus.org/cli"
+    git = "https://github.com/globus/globus-cli.git"
+    url = "https://github.com/globus/globus-cli/archive/refs/tags/3.16.0.zip"
+
+    maintainers("climbfuji")
+
+    version("3.16.0", sha256="0ef721060870d9346505e52b9bf30c7bed6ae136cc08762deb2f8893bd25d8c5")
+
+    depends_on("python@3.7:3.10", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-globus-sdk@3.25.0", type=("build", "run"))
+    depends_on("py-click@8", type=("build", "run"))
+    depends_on("py-jmespath@1.0.1", type=("build", "run"))
+    depends_on("py-packaging@17:", type=("build", "run"))
+    # According to the developers, these requirements are implicit
+    # for py-globus-sdk, but they are listed explicitly "in case
+    # the underlying lib ever changes"
+    depends_on("py-requests@2.19.1:2", type=("build", "run"))
+    depends_on("py-pyjwt@2.0.0:2+crypto", type=("build", "run"))
+    depends_on("py-cryptography@3.3.1:", type=("build", "run"))
+    depends_on("py-typing-extensions@4:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-globus-sdk/package.py
+++ b/var/spack/repos/builtin/packages/py-globus-sdk/package.py
@@ -15,10 +15,11 @@ class PyGlobusSdk(PythonPackage):
     homepage = "https://github.com/globus/globus-sdk-python"
     pypi = "globus-sdk/globus-sdk-3.0.2.tar.gz"
 
-    maintainers("hategan")
+    maintainers("hategan", "climbfuji")
 
     license("Apache-2.0")
 
+    version("3.25.0", sha256="d9be275d4ec18054db04732f75649c4227800c79b31fbcfb3f4f31eccfa5f4f7")
     version("3.10.1", sha256="c20fec55fc7e099f4d0c8224a36e194604577539445c5985cb465b23779baee8")
     version("3.10.0", sha256="7a7e7cd5cfbc40c6dc75bdb92b050c4191f992b5f7081cd08895bf119fd97bbf")
     version("3.9.0", sha256="456f707b25a8c502607134f1d699b5970ef1aa9d17877474db73fc6d87c711e9")
@@ -32,3 +33,4 @@ class PyGlobusSdk(PythonPackage):
     depends_on("py-pyjwt@2.0.0:2+crypto", type=("build", "run"))
     depends_on("py-cryptography@3.3.1:3.3,3.4.1:", when="@3.7:", type=("build", "run"))
     depends_on("py-cryptography@2:3.3,3.4.1:3.6", when="@:3.0", type=("build", "run"))
+    depends_on("py-typing-extensions@4:", when="@3.25:", type=("build", "run"))


### PR DESCRIPTION
This PR adds `var/spack/repos/builtin/packages/py-globus-cli/package.py` from our spack branch. It's been tested regularly (both installation and usage) across several HPCs, compilers and applications.

This package requires a newer version of py-globus-sdk, also added here