### PR TITLE
openblas: %intel@2021: conflict with avx512

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -90,7 +90,7 @@ class Openblas(CMakePackage, MakefilePackage):
         "noavx512",
         default=False,
         description="Disable AVX-512 with NO_AVX512=1 (internal compiler error with AVX512 "
-        + "when using Intel 2021/2022)",
+        + "when using Intel 2021)",
     )
     variant("symbol_suffix", default="none", description="Set a symbol suffix")
 
@@ -266,7 +266,7 @@ class Openblas(CMakePackage, MakefilePackage):
         msg="Visual Studio does not support OpenBLAS dynamic dispatch features",
     )
 
-    requires("+noavx512", when="%intel@2021:2022")
+    requires("+noavx512", when="%intel@2021")
 
     depends_on("perl", type="build")
 

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -86,12 +86,6 @@ class Openblas(CMakePackage, MakefilePackage):
         default=False,
         description="Enable experimental support for up to 1024 CPUs/Cores and 128 numa nodes",
     )
-    variant(
-        "noavx512",
-        default=False,
-        description="Disable AVX-512 with NO_AVX512=1 (internal compiler error with AVX512 "
-        + "when using Intel 2021)",
-    )
     variant("symbol_suffix", default="none", description="Set a symbol suffix")
 
     variant("locking", default=True, description="Build with thread safety")
@@ -266,7 +260,7 @@ class Openblas(CMakePackage, MakefilePackage):
         msg="Visual Studio does not support OpenBLAS dynamic dispatch features",
     )
 
-    requires("+noavx512", when="%intel@2021")
+    conflicts("target=avx512", when="%intel@2021")
 
     depends_on("perl", type="build")
 
@@ -547,7 +541,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
         if self.spec.satisfies("+bignuma"):
             make_defs.append("BIGNUMA=1")
 
-        if self.spec.satisfies("+noavx512"):
+        if not self.spec.satisfies("target=avx512"):
             make_defs.append("NO_AVX512=1")
 
         # Avoid that NUM_THREADS gets initialized with the host's number of CPUs.

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -86,6 +86,12 @@ class Openblas(CMakePackage, MakefilePackage):
         default=False,
         description="Enable experimental support for up to 1024 CPUs/Cores and 128 numa nodes",
     )
+    variant(
+        "noavx512",
+        default=False,
+        description="Disable AVX-512 with NO_AVX512=1 (internal compiler error with AVX512 "
+        + "when using Intel 2021/2022)",
+    )
     variant("symbol_suffix", default="none", description="Set a symbol suffix")
 
     variant("locking", default=True, description="Build with thread safety")
@@ -259,6 +265,8 @@ class Openblas(CMakePackage, MakefilePackage):
         when="platform=windows",
         msg="Visual Studio does not support OpenBLAS dynamic dispatch features",
     )
+
+    requires("+noavx512", when="%intel@2021:2022")
 
     depends_on("perl", type="build")
 
@@ -538,6 +546,9 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
 
         if self.spec.satisfies("+bignuma"):
             make_defs.append("BIGNUMA=1")
+
+        if self.spec.satisfies("+noavx512"):
+            make_defs.append("NO_AVX512=1")
 
         # Avoid that NUM_THREADS gets initialized with the host's number of CPUs.
         if self.spec.satisfies("threads=openmp") or self.spec.satisfies("threads=pthreads"):

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -260,9 +260,7 @@ class Openblas(CMakePackage, MakefilePackage):
         msg="Visual Studio does not support OpenBLAS dynamic dispatch features",
     )
 
-    conflicts("target=x86_64_v4", when="%intel@2021")
-    conflicts("target=zen4", when="%intel@2021")
-    conflicts("target=skylake_avx512", when="%intel@2021")
+    conflicts("target=x86_64_v4:", when="%intel@2021")
 
     depends_on("perl", type="build")
 

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -260,7 +260,9 @@ class Openblas(CMakePackage, MakefilePackage):
         msg="Visual Studio does not support OpenBLAS dynamic dispatch features",
     )
 
-    conflicts("target=avx512", when="%intel@2021")
+    conflicts("target=x86_64_v4", when="%intel@2021")
+    conflicts("target=zen4", when="%intel@2021")
+    conflicts("target=skylake_avx512", when="%intel@2021")
 
     depends_on("perl", type="build")
 

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -541,7 +541,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
         if self.spec.satisfies("+bignuma"):
             make_defs.append("BIGNUMA=1")
 
-        if not self.spec.satisfies("target=avx512"):
+        if not self.spec.satisfies("target=x86_64_v4:"):
             make_defs.append("NO_AVX512=1")
 
         # Avoid that NUM_THREADS gets initialized with the host's number of CPUs.


### PR DESCRIPTION
This PR adds a "noavx512" variant for openblas, which is needed in order to compile with intel classic 2021 & 2022.