### PR TITLE
fontconfig: add pic variant and support static deps

### DIFF
--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -58,7 +58,6 @@ class Fontconfig(AutotoolsPackage):
         if self.spec.satisfies("+pic"):
             args.append("CFLAGS=-fPIC")
             args.append("FFLAGS=-fPIC")
-            args.append("--with-pic")
         return args
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -56,17 +56,18 @@ class Fontconfig(AutotoolsPackage):
         if not self.spec["libpng"].satisfies("libs=shared"):
             deps.append("libpng")
         if self.spec["libxml2"].satisfies("~shared"):
-            deps.extend(["zlib", "xz", "iconv"])
+            deps.append("libxml-2.0")
         if deps:
+            pc = which("pkg-config")
             for lib in deps:
-                ldflags.append(self.spec[lib].libs.ld_flags)
-                libs.append(self.spec[lib].libs.link_flags)
+                ldflags.append(pc(lib, "--static", "--libs-only-L", output=str).strip())
+                libs.append(pc(lib, "--static", "--libs-only-l", output=str).strip())
             args.append("LDFLAGS=%s" % " ".join(ldflags))
             args.append("LIBS=%s" % " ".join(libs))
 
         if self.spec.satisfies("+pic"):
-            args.append("CFLAGS=-fPIC")
-            args.append("FFLAGS=-fPIC")
+            args.append(f"CFLAGS={self.compiler.cc_pic_flag}")
+            args.append(f"FFLAGS={self.compiler.f77_pic_flag}")
 
         return args
 

--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -53,8 +53,8 @@ class Fontconfig(AutotoolsPackage):
         for lib in ["libpng", "bzip2"]:
             ldflags.append(self.spec[lib].libs.ld_flags)
             libs.append(self.spec[lib].libs.link_flags)
-        args.append("LDFLAGS=-fPIC %s" % " ".join(ldflags))
-        args.append("LIBS=-fPIC %s" % " ".join(libs))
+            args.append("LDFLAGS=%s" % " ".join(ldflags))
+            args.append("LIBS=%s" % " ".join(libs))
         if self.spec.satisfies("+pic"):
             args.append("CFLAGS=-fPIC")
             args.append("FFLAGS=-fPIC")

--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -51,10 +51,12 @@ class Fontconfig(AutotoolsPackage):
         ldflags = []
         libs = []
         deps = []
-        if self.spec["python"].satisfies("~shared"):
-            deps += ["libpng", "bzip2"]
+        if self.spec["bzip2"].satisfies("~shared"):
+            deps.append("bzip2")
+        if not self.spec["libpng"].satisfies("libs=shared"):
+            deps.append("libpng")
         if self.spec["libxml2"].satisfies("~shared"):
-            deps += ["zlib", "xz", "iconv"]
+            deps.extend(["zlib", "xz", "iconv"])
         if deps:
             for lib in deps:
                 ldflags.append(self.spec[lib].libs.ld_flags)

--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -50,16 +50,22 @@ class Fontconfig(AutotoolsPackage):
         args = ["--enable-libxml2", "--disable-docs", f"--with-default-fonts={font_path}"]
         ldflags = []
         libs = []
-        for lib in ["libpng", "bzip2"]:
-            if self.spec[lib].satisfies("+shared") or self.spec[lib].satisfies("libs=shared"):
-                continue
-            ldflags.append(self.spec[lib].libs.ld_flags)
-            libs.append(self.spec[lib].libs.link_flags)
+        deps = []
+        if self.spec["python"].satisfies("~shared"):
+            deps += ["libpng", "bzip2"]
+        if self.spec["libxml2"].satisfies("~shared"):
+            deps += ["zlib", "xz", "iconv"]
+        if deps:
+            for lib in deps:
+                ldflags.append(self.spec[lib].libs.ld_flags)
+                libs.append(self.spec[lib].libs.link_flags)
             args.append("LDFLAGS=%s" % " ".join(ldflags))
             args.append("LIBS=%s" % " ".join(libs))
+
         if self.spec.satisfies("+pic"):
             args.append("CFLAGS=-fPIC")
             args.append("FFLAGS=-fPIC")
+
         return args
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -33,6 +33,8 @@ class Fontconfig(AutotoolsPackage):
     depends_on("uuid", when="@2.13.1:")
     depends_on("python@3:", type="build", when="@2.13.93:")
 
+    variant("pic", default=False, description="Enable position-independent code (PIC)")
+
     def patch(self):
         """Make test/run-test.sh compatible with dash"""
         filter_file("SIGINT SIGTERM SIGABRT EXIT", "2 15 6 0", "test/run-test.sh")
@@ -45,8 +47,19 @@ class Fontconfig(AutotoolsPackage):
 
     def configure_args(self):
         font_path = join_path(self.spec["font-util"].prefix, "share", "fonts")
-
-        return ["--enable-libxml2", "--disable-docs", f"--with-default-fonts={font_path}"]
+        args = ["--enable-libxml2", "--disable-docs", f"--with-default-fonts={font_path}"]
+        ldflags = []
+        libs = []
+        for lib in ["libpng", "bzip2"]:
+            ldflags.append(self.spec[lib].libs.ld_flags)
+            libs.append(self.spec[lib].libs.link_flags)
+        args.append("LDFLAGS=-fPIC %s" % " ".join(ldflags))
+        args.append("LIBS=-fPIC %s" % " ".join(libs))
+        if self.spec.satisfies("+pic"):
+            args.append("CFLAGS=-fPIC")
+            args.append("FFLAGS=-fPIC")
+            args.append("--with-pic")
+        return args
 
     @run_after("install")
     def system_fonts(self):

--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -51,6 +51,8 @@ class Fontconfig(AutotoolsPackage):
         ldflags = []
         libs = []
         for lib in ["libpng", "bzip2"]:
+            if self.spec[lib].satisfies("+shared") or self.spec[lib].satisfies("libs=shared"):
+                continue
             ldflags.append(self.spec[lib].libs.ld_flags)
             libs.append(self.spec[lib].libs.link_flags)
             args.append("LDFLAGS=%s" % " ".join(ldflags))


### PR DESCRIPTION
This PR adds a pic variant and support for static deps to fontconfig.

Tested on CentOS 8 with `fontconfig +pic ^bzip2 ~shared ^libpng libs=shared ^libxml2 ~shared`.
