### PR TITLE
Steal source was not assigning the package class

### DIFF
--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -76,6 +76,7 @@ def _retrieve_develop_source(spec, abspath):
         # mirror might store an instance with truncated history.
         package.stage[0].disable_mirrors()
 
+    package.stage[0].fetcher.set_package(package)
     package.stage.steal_source(abspath)
 
 


### PR DESCRIPTION
Fetcher was missing the package class assignment.  This was an issue if you were dynamically setting submodules via a function.

example:
```
=> [2024-06-25-16:24:16.075783] Cloning git repository: https://github.com/exawind/nalu-wind.git on branch master
==> [2024-06-25-16:24:16.076522] '/Users/psakiev/bin/spack-core/bin/git' '--version'
==> [2024-06-25-16:24:16.119454] '/Users/psakiev/bin/spack-core/bin/git' '-c' 'advice.detachedHead=false' '--version'
==> [2024-06-25-16:24:16.128450] '/Users/psakiev/bin/spack-core/bin/git' '-c' 'advice.detachedHead=false' 'clone' '--branch' 'master' '--no-single-branch' 'https://github.com/exawind/nalu-wind.git'
Cloning into 'nalu-wind'...
remote: Enumerating objects: 31939, done.
remote: Counting objects: 100% (4512/4512), done.
remote: Compressing objects: 100% (911/911), done.
remote: Total 31939 (delta 3968), reused 3776 (delta 3599), pack-reused 27427
Receiving objects: 100% (31939/31939), 21.39 MiB | 1.72 MiB/s, done.
Resolving deltas: 100% (25642/25642), done.
Traceback (most recent call last):
  File "/Users/psakiev/scratch/exawind-manager/spack/bin/spack", line 52, in <module>
    sys.exit(main())
  File "/Users/psakiev/scratch/exawind-manager/spack/lib/spack/spack_installable/main.py", line 42, in main
    sys.exit(spack.main.main(argv))
  File "/Users/psakiev/scratch/exawind-manager/spack/lib/spack/spack/main.py", line 1069, in main
    return _main(argv)
  File "/Users/psakiev/scratch/exawind-manager/spack/lib/spack/spack/main.py", line 1022, in _main
    return finish_parse_and_run(parser, cmd_name, args, env_format_error)
  File "/Users/psakiev/scratch/exawind-manager/spack/lib/spack/spack/main.py", line 1052, in finish_parse_and_run
    return _invoke_command(command, parser, args, unknown)
  File "/Users/psakiev/scratch/exawind-manager/spack/lib/spack/spack/main.py", line 649, in _invoke_command
    return_val = command(parser, args)
  File "/Users/psakiev/scratch/exawind-manager/spack/lib/spack/spack/cmd/develop.py", line 145, in develop
    _retrieve_develop_source(spec, abspath)
  File "/Users/psakiev/scratch/exawind-manager/spack/lib/spack/spack/cmd/develop.py", line 79, in _retrieve_develop_source
    package.stage.steal_source(abspath)
  File "/Users/psakiev/scratch/exawind-manager/spack/lib/spack/spack/util/pattern.py", line 16, in __call__
    return [getattr(item, self.name)(*args, **kwargs) for item in self.container]
  File "/Users/psakiev/scratch/exawind-manager/spack/lib/spack/spack/util/pattern.py", line 16, in <listcomp>
    return [getattr(item, self.name)(*args, **kwargs) for item in self.container]
  File "/Users/psakiev/scratch/exawind-manager/spack/lib/spack/spack/stage.py", line 574, in steal_source
    self.fetch()
  File "/Users/psakiev/scratch/exawind-manager/spack/lib/spack/spack/stage.py", line 548, in fetch
    self.fetcher.fetch()
  File "/Users/psakiev/scratch/exawind-manager/spack/lib/spack/spack/fetch_strategy.py", line 83, in wrapper
    return fun(self, *args, **kwargs)
  File "/Users/psakiev/scratch/exawind-manager/spack/lib/spack/spack/fetch_strategy.py", line 810, in fetch
    self.clone(commit=self.commit, branch=self.branch, tag=self.tag)
  File "/Users/psakiev/scratch/exawind-manager/spack/lib/spack/spack/fetch_strategy.py", line 932, in clone
    submodules = submodules(self.package)
  File "/Users/psakiev/scratch/exawind-manager/spack/var/spack/repos/builtin/packages/nalu-wind/package.py", line 19, in submodules
    submodules.append("wind-utils")
AttributeError: 'NoneType' object has no attribute 'spec'
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
