### PR TITLE
stdexec: Don't skip build stage since no longer header only

### DIFF
--- a/var/spack/repos/builtin/packages/stdexec/package.py
+++ b/var/spack/repos/builtin/packages/stdexec/package.py
@@ -24,5 +24,12 @@ class Stdexec(CMakePackage):
     conflicts("%gcc@:10")
     conflicts("%clang@:12")
 
+    @when("@:23.03")
     def build(self, spec, prefix):
         pass
+
+    def cmake_args(self):
+        return [
+            self.define("STDEXEC_BUILD_TESTS", self.run_tests),
+            self.define("STDEXEC_BUILD_EXAMPLES", False),
+        ]


### PR DESCRIPTION
Latest stdexec main is no longer header-only, so this unremoves skipping the build stage. Additionally, this disables examples unconditionally and tests if not testing. Since there have been no tagged releases since 23.03 I'm not making any of this conditional on the version. Older versions e.g. don't have the CMake options to disable building tests/examples, but that's hopefully a small enough price to pay. Most users will likely be using main/pinned commit on recent main and then the options will work.