### PR TITLE
lcov: Add missing perl dependency

### DIFF
--- a/var/spack/repos/builtin/packages/lcov/package.py
+++ b/var/spack/repos/builtin/packages/lcov/package.py
@@ -54,6 +54,7 @@ class Lcov(MakefilePackage):
     depends_on("perl-specio", type=("run"))
     depends_on("perl-sub-identify", type=("run"))
     depends_on("perl-time-hires", type=("run"))
+    depends_on("perl-timedate", type=("run"))
 
     def install(self, spec, prefix):
         make(


### PR DESCRIPTION
Date::Parse, provided by TimeDate, is an undocumented run-time dependency of lcov 2

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
