### PR TITLE
py-pyyaml: add 6.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyyaml/package.py
+++ b/var/spack/repos/builtin/packages/py-pyyaml/package.py
@@ -15,6 +15,7 @@ class PyPyyaml(PythonPackage):
 
     license("MIT")
 
+    version("6.0.1", sha256="bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43")
     version("6.0", sha256="68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2")
     version("5.4.1", sha256="607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e")
     version("5.3.1", sha256="b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d")

--- a/var/spack/repos/builtin/packages/py-pyyaml/package.py
+++ b/var/spack/repos/builtin/packages/py-pyyaml/package.py
@@ -32,7 +32,7 @@ class PyPyyaml(PythonPackage):
     depends_on("python@3.6:", when="@6:", type=("build", "link", "run"))
     depends_on("libyaml", when="+libyaml", type="link")
     depends_on("py-setuptools", type="build")
-    depends_on("py-cython@0.29.8:2", when="@6:+libyaml", type="build")
+    depends_on("py-cython", when="@6:+libyaml", type="build")
 
     # Includes "longintrepr.h" instead of Python.h
     conflicts("^python@3.11:", when="@:5.3")

--- a/var/spack/repos/builtin/packages/py-pyyaml/package.py
+++ b/var/spack/repos/builtin/packages/py-pyyaml/package.py
@@ -32,7 +32,7 @@ class PyPyyaml(PythonPackage):
     depends_on("python@3.6:", when="@6:", type=("build", "link", "run"))
     depends_on("libyaml", when="+libyaml", type="link")
     depends_on("py-setuptools", type="build")
-    depends_on("py-cython", when="@6:+libyaml", type="build")
+    depends_on("py-cython@0.29.8:2", when="@6:+libyaml", type="build")
 
     # Includes "longintrepr.h" instead of Python.h
     conflicts("^python@3.11:", when="@:5.3")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

In another PR (see #44879), I realized that in our `pyproject.toml` we had:

```toml
dependencies = [
    "pyyaml>=6.0.1",
    "colorama>=0.4.6",
]
```
but spack only had `py-pyyaml` 6.0. Now, our code doesn't seem to care between 6.0 and 6.0.1 and the changes seem to be "pin cython < 3":

https://github.com/yaml/pyyaml/compare/6.0...6.0.1

But in order to (in the future) be consistent with our requirement, in this PR I've added 6.0.1. I believe @adamjstewart took care of the cython requirement in #38961 .

Unfortunately, this package doesn't have any maintainers. So, I'll tag @nitzmahone as the last committer to pyyaml so they are aware and in case there is a compelling case *not* to add 6.0.1... (other than, it's functionally the same code 🤷🏼 )