### PR TITLE
Cpuinfo: static build when on Windows

### DIFF
--- a/var/spack/repos/builtin/packages/cpuinfo/package.py
+++ b/var/spack/repos/builtin/packages/cpuinfo/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
 from spack.package import *
 
 
@@ -32,12 +33,16 @@ class Cpuinfo(CMakePackage):
     depends_on("cmake@3.5:", type="build")
 
     def cmake_args(self):
+        # cpuinfo cannot produce a shared build with MSVC because it does not export
+        # any symbols
+        # cpuinfo CI builds "default" on Windows platform
+        build_type = "default" if sys.platform == "win32" else "shared"
         # https://salsa.debian.org/deeplearning-team/cpuinfo/-/blob/master/debian/rules
         return [
             self.define("CPUINFO_BUILD_UNIT_TESTS", False),
             self.define("CPUINFO_BUILD_MOCK_TESTS", False),
             self.define("CPUINFO_BUILD_BENCHMARKS", False),
-            self.define("CPUINFO_LIBRARY_TYPE", "shared"),
+            self.define("CPUINFO_LIBRARY_TYPE", build_type),
             self.define("CPUINFO_LOG_LEVEL", "error"),
             self.define("CMAKE_SKIP_RPATH", True),
         ]

--- a/var/spack/repos/builtin/packages/cpuinfo/package.py
+++ b/var/spack/repos/builtin/packages/cpuinfo/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import sys
+
 from spack.package import *
 
 


### PR DESCRIPTION
Shared builds of cpuinfo are currently broken on MSVC, upstream included.
This is due to a lack of symbol exporting on Windows required to create DLLs (and if you force that on the CMake/.def side, a lack of the required dll imports).
Support would require some non patchable modifications to the source code.

Instead, we should just do what Cpuinfo CI does, just build "default" (static) on Windows.

Fixes https://github.com/spack/spack/issues/44496

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
