### PR TITLE
fix gmsh 4.13.0 checksum

### DIFF
--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -25,7 +25,7 @@ class Gmsh(CMakePackage):
     license("GPL-2.0-or-later")
 
     version("master", branch="master")
-    version("4.13.0", sha256="0208110adb1792d1c59dcbcbea5d5ecb1272dfef63f69ceedb91923c40e1a652")
+    version("4.13.0", sha256="c85f056ee549a433e814a61c385c97952bbfe514b442b999f6149fffb1e54f64.")
     version("4.12.2", sha256="13e09d9ca8102e5c40171d6ee150c668742b98c3a6ca57f837f7b64e1e2af48f")
     version("4.12.0", sha256="2a6007872ba85abd9901914826f6986a2437ab7104f564ccefa1b7a3de742c17")
     version("4.11.1", sha256="c5fe1b7cbd403888a814929f2fd0f5d69e27600222a18c786db5b76e8005b365")

--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -25,6 +25,7 @@ class Gmsh(CMakePackage):
     license("GPL-2.0-or-later")
 
     version("master", branch="master")
+    version("4.13.1", sha256="77972145f431726026d50596a6a44fb3c1c95c21255218d66955806b86edbe8d")
     version("4.13.0", sha256="c85f056ee549a433e814a61c385c97952bbfe514b442b999f6149fffb1e54f64.")
     version("4.12.2", sha256="13e09d9ca8102e5c40171d6ee150c668742b98c3a6ca57f837f7b64e1e2af48f")
     version("4.12.0", sha256="2a6007872ba85abd9901914826f6986a2437ab7104f564ccefa1b7a3de742c17")


### PR DESCRIPTION
Got a checksum error when trying to install Gmsh 4.13.0:

```
==> [2024-06-26-17:19:36.248179] Error: ChecksumError: sha256 checksum failed for /tmp/spack-stage/spack-stage-gmsh-4.13.0-qbl7u526hbt4coisbt2ktvuogxmvpjuv/gmsh-4.13.0-source.tgz
    Expected 0208110adb1792d1c59dcbcbea5d5ecb1272dfef63f69ceedb91923c40e1a652 but got c85f056ee549a433e814a61c385c97952bbfe514b442b999f6149fffb1e54f64. File size = 18382303 bytes. Contents = b'\x1f\x8b\x08\x00\xf3\xce9f\x00\x03\xec}{\x7f\xdb6...?\xfe\xf3\xff\xd5\xff\xfc/9\x82\xa0J\x00\xa8\x8f\x04'
```

Correct result of `sha256sum gmsh-4.13.0-source.tgz` from https://gmsh.info/src/gmsh-4.13.0-source.tgz is `c85f056ee549a433e814a61c385c97952bbfe514b442b999f6149fffb1e54f64`.