### PR TITLE
mptensor: Changed skiptest, test name, and added docstring

### DIFF
--- a/var/spack/repos/builtin/packages/mptensor/package.py
+++ b/var/spack/repos/builtin/packages/mptensor/package.py
@@ -70,25 +70,25 @@ class Mptensor(CMakePackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources(".")
 
+        with working_dir(join_path(install_test_root(pkg), "tests"), create=False):
+            make("clean")
+            makefile = FileFilter("Makefile")
+            makefile.filter("g++", f"{spack_cxx}", string=True)
+
+        with working_dir(join_path(install_test_root(pkg)), create=False):
+            makefile = FileFilter("Makefile.option")
+            makefile.filter("CXX =.*", f"CXX ={self.spec['mpi'].mpicxx}")
+            makefile.filter("CXXFLAGS =.*", f"CXXFLAGS ={self.compiler.cxx11_flag}")
+
     def test_mpi(self):
         """test with +mpi"""
         if "+mpi" not in self.spec:
             raise SkipTest("Package must be installed with +mpi")
 
-        with working_dir(join_path(self.install_test_root, "tests"), create=False):
-            make("clean")
-            makefile = FileFilter("Makefile")
-            makefile.filter("g++", "{0}".format(spack_cxx), string=True)
-
-        with working_dir(join_path(self.install_test_root), create=False):
-            makefile = FileFilter("Makefile.option")
-            makefile.filter("CXX =.*", "CXX ={0}".format(self.spec["mpi"].mpicxx))
-            makefile.filter("CXXFLAGS =.*", "CXXFLAGS ={0}".format(self.compiler.cxx11_flag))
-
         math_libs = self.spec["scalapack"].libs + self.spec["lapack"].libs + self.spec["blas"].libs
 
-        with working_dir(join_path(self.install_test_root, "tests"), create=False):
-            make("LDFLAGS={0}".format(math_libs.ld_flags))
+        with working_dir(join_path(install_test_root(pkg), "tests"), create=False):
+            make(f"LDFLAGS={math_libs.ld_flags}")
 
             mpirun = self.spec["mpi"].prefix.bin.mpirun
             mpiexec = Executable(mpirun)

--- a/var/spack/repos/builtin/packages/mptensor/package.py
+++ b/var/spack/repos/builtin/packages/mptensor/package.py
@@ -70,31 +70,31 @@ class Mptensor(CMakePackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources(".")
 
-    def test(self):
+    def test_mpi(self):
+        """test with +mpi"""
         if "+mpi" not in self.spec:
-            print("Test of mptensor only runs with +mpi option.")
-        else:
-            with working_dir(join_path(self.install_test_root, "tests"), create=False):
-                make("clean")
-                makefile = FileFilter("Makefile")
-                makefile.filter("g++", "{0}".format(spack_cxx), string=True)
+            raise SkipTest("Package must be installed with +mpi")
+        with working_dir(join_path(self.install_test_root, "tests"), create=False):
+            make("clean")
+            makefile = FileFilter("Makefile")
+            makefile.filter("g++", "{0}".format(spack_cxx), string=True)
 
-            with working_dir(join_path(self.install_test_root), create=False):
-                makefile = FileFilter("Makefile.option")
-                makefile.filter("CXX =.*", "CXX ={0}".format(self.spec["mpi"].mpicxx))
-                makefile.filter("CXXFLAGS =.*", "CXXFLAGS ={0}".format(self.compiler.cxx11_flag))
+        with working_dir(join_path(self.install_test_root), create=False):
+            makefile = FileFilter("Makefile.option")
+            makefile.filter("CXX =.*", "CXX ={0}".format(self.spec["mpi"].mpicxx))
+            makefile.filter("CXXFLAGS =.*", "CXXFLAGS ={0}".format(self.compiler.cxx11_flag))
 
-            math_libs = (
-                self.spec["scalapack"].libs + self.spec["lapack"].libs + self.spec["blas"].libs
-            )
+        math_libs = (
+            self.spec["scalapack"].libs + self.spec["lapack"].libs + self.spec["blas"].libs
+        )
 
-            with working_dir(join_path(self.install_test_root, "tests"), create=False):
-                make("LDFLAGS={0}".format(math_libs.ld_flags))
+        with working_dir(join_path(self.install_test_root, "tests"), create=False):
+            make("LDFLAGS={0}".format(math_libs.ld_flags))
 
-                mpirun = self.spec["mpi"].prefix.bin.mpirun
-                mpiexec = Executable(mpirun)
-                mpiexec("-n", "1", "tensor_test.out")
+            mpirun = self.spec["mpi"].prefix.bin.mpirun
+            mpiexec = Executable(mpirun)
+            mpiexec("-n", "1", "tensor_test.out")
 
-                # Test of mptensor has checker
-                # and checker is abort when check detect any errors.
-                print("Test of mptensor PASSED !")
+            # Test of mptensor has checker
+            # and checker is abort when check detect any errors.
+            print("Test of mptensor PASSED !")

--- a/var/spack/repos/builtin/packages/mptensor/package.py
+++ b/var/spack/repos/builtin/packages/mptensor/package.py
@@ -74,6 +74,7 @@ class Mptensor(CMakePackage):
         """test with +mpi"""
         if "+mpi" not in self.spec:
             raise SkipTest("Package must be installed with +mpi")
+
         with working_dir(join_path(self.install_test_root, "tests"), create=False):
             make("clean")
             makefile = FileFilter("Makefile")

--- a/var/spack/repos/builtin/packages/mptensor/package.py
+++ b/var/spack/repos/builtin/packages/mptensor/package.py
@@ -85,9 +85,7 @@ class Mptensor(CMakePackage):
             makefile.filter("CXX =.*", "CXX ={0}".format(self.spec["mpi"].mpicxx))
             makefile.filter("CXXFLAGS =.*", "CXXFLAGS ={0}".format(self.compiler.cxx11_flag))
 
-        math_libs = (
-            self.spec["scalapack"].libs + self.spec["lapack"].libs + self.spec["blas"].libs
-        )
+        math_libs = self.spec["scalapack"].libs + self.spec["lapack"].libs + self.spec["blas"].libs
 
         with working_dir(join_path(self.install_test_root, "tests"), create=False):
             make("LDFLAGS={0}".format(math_libs.ld_flags))

--- a/var/spack/repos/builtin/packages/mptensor/package.py
+++ b/var/spack/repos/builtin/packages/mptensor/package.py
@@ -68,7 +68,7 @@ class Mptensor(CMakePackage):
     def setup_build_tests(self):
         """Copy the build test files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources(".")
+        cache_extra_test_sources(self)
 
         with working_dir(join_path(install_test_root(self), "tests"), create=False):
             make("clean")

--- a/var/spack/repos/builtin/packages/mptensor/package.py
+++ b/var/spack/repos/builtin/packages/mptensor/package.py
@@ -70,12 +70,12 @@ class Mptensor(CMakePackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources(".")
 
-        with working_dir(join_path(install_test_root(pkg), "tests"), create=False):
+        with working_dir(join_path(install_test_root(self), "tests"), create=False):
             make("clean")
             makefile = FileFilter("Makefile")
             makefile.filter("g++", f"{spack_cxx}", string=True)
 
-        with working_dir(join_path(install_test_root(pkg)), create=False):
+        with working_dir(join_path(install_test_root(self)), create=False):
             makefile = FileFilter("Makefile.option")
             makefile.filter("CXX =.*", f"CXX ={self.spec['mpi'].mpicxx}")
             makefile.filter("CXXFLAGS =.*", f"CXXFLAGS ={self.compiler.cxx11_flag}")
@@ -87,7 +87,7 @@ class Mptensor(CMakePackage):
 
         math_libs = self.spec["scalapack"].libs + self.spec["lapack"].libs + self.spec["blas"].libs
 
-        with working_dir(join_path(install_test_root(pkg), "tests"), create=False):
+        with working_dir(join_path(install_test_root(self), "tests"), create=False):
             make(f"LDFLAGS={math_libs.ld_flags}")
 
             mpirun = self.spec["mpi"].prefix.bin.mpirun

--- a/var/spack/repos/builtin/packages/mptensor/package.py
+++ b/var/spack/repos/builtin/packages/mptensor/package.py
@@ -84,7 +84,7 @@ class Mptensor(CMakePackage):
             makefile.filter("g++", "{0}".format(spack_cxx), string=True)
 
         print("Converting cached Makefile.option for stand-alone test use")
-        with working_dir(join_path(self.install_test_root), create=False):
+        with working_dir(join_path(install_test_root(self)), create=False):
             makefile = FileFilter("Makefile.option")
             makefile.filter("CXX =.*", "CXX ={0}".format(self.spec["mpi"].mpicxx))
             makefile.filter("CXXFLAGS =.*", "CXXFLAGS ={0}".format(self.compiler.cxx11_flag))

--- a/var/spack/repos/builtin/packages/mptensor/package.py
+++ b/var/spack/repos/builtin/packages/mptensor/package.py
@@ -100,10 +100,8 @@ class Mptensor(CMakePackage):
             make = which("make")
             make(f"LDFLAGS={math_libs.ld_flags}")
 
-            mpirun = self.spec["mpi"].prefix.bin.mpirun
-            # mpiexec = Executable(mpirun)
-            mpiexec = which(mpirun)
-            mpiexec("-n", "1", "tensor_test.out")
+            mpirun = which(self.spec["mpi"].prefix.bin.mpirun)
+            mpirun("-n", "1", "tensor_test.out")
 
             # Test of mptensor has checker
             # and checker is abort when check detect any errors.

--- a/var/spack/repos/builtin/packages/mptensor/package.py
+++ b/var/spack/repos/builtin/packages/mptensor/package.py
@@ -78,16 +78,16 @@ class Mptensor(CMakePackage):
 
         # Clean cached makefiles now so only done once
         print("Converting cached Makefile for stand-alone test use")
-        with working_dir(join_path(self.install_test_root, "tests"), create=False):
+        with working_dir(join_path(install_test_root(self), "tests"), create=False):
             make("clean")
             makefile = FileFilter("Makefile")
-            makefile.filter("g++", "{0}".format(spack_cxx), string=True)
+            makefile.filter("g++", f"{spack_cxx}", string=True)
 
         print("Converting cached Makefile.option for stand-alone test use")
         with working_dir(join_path(install_test_root(self)), create=False):
             makefile = FileFilter("Makefile.option")
-            makefile.filter("CXX =.*", "CXX ={0}".format(self.spec["mpi"].mpicxx))
-            makefile.filter("CXXFLAGS =.*", "CXXFLAGS ={0}".format(self.compiler.cxx11_flag))
+            makefile.filter("CXX =.*", f"CXX ={self.spec['mpi'].mpicxx}")
+            makefile.filter("CXXFLAGS =.*", "CXXFLAGS ={self.compiler.cxx11_flag}")
 
     def test_mpi(self):
         """test with +mpi"""

--- a/var/spack/repos/builtin/packages/mptensor/package.py
+++ b/var/spack/repos/builtin/packages/mptensor/package.py
@@ -89,8 +89,8 @@ class Mptensor(CMakePackage):
             makefile.filter("CXX =.*", f"CXX ={self.spec['mpi'].mpicxx}")
             makefile.filter("CXXFLAGS =.*", f"CXXFLAGS ={self.compiler.cxx11_flag}")
 
-    def test_mpi(self):
-        """test with +mpi"""
+    def test_mptensor(self):
+        """test if mptensor works"""
         if "+mpi" not in self.spec:
             raise SkipTest("Package must be installed with +mpi")
 

--- a/var/spack/repos/builtin/packages/mptensor/package.py
+++ b/var/spack/repos/builtin/packages/mptensor/package.py
@@ -87,7 +87,7 @@ class Mptensor(CMakePackage):
         with working_dir(join_path(install_test_root(self)), create=False):
             makefile = FileFilter("Makefile.option")
             makefile.filter("CXX =.*", f"CXX ={self.spec['mpi'].mpicxx}")
-            makefile.filter("CXXFLAGS =.*", "CXXFLAGS ={self.compiler.cxx11_flag}")
+            makefile.filter("CXXFLAGS =.*", f"CXXFLAGS ={self.compiler.cxx11_flag}")
 
     def test_mpi(self):
         """test with +mpi"""

--- a/var/spack/repos/builtin/packages/mptensor/package.py
+++ b/var/spack/repos/builtin/packages/mptensor/package.py
@@ -78,19 +78,19 @@ class Mptensor(CMakePackage):
 
         # Clean cached makefiles now so only done once
         print("Converting cached Makefile for stand-alone test use")
-        with working_dir(join_path(install_test_root(self), "tests"), create=False):
+        with working_dir(join_path(install_test_root(self), "tests")):
             make("clean")
             makefile = FileFilter("Makefile")
             makefile.filter("g++", f"{spack_cxx}", string=True)
 
         print("Converting cached Makefile.option for stand-alone test use")
-        with working_dir(join_path(install_test_root(self)), create=False):
+        with working_dir(join_path(install_test_root(self))):
             makefile = FileFilter("Makefile.option")
             makefile.filter("CXX =.*", f"CXX ={self.spec['mpi'].mpicxx}")
             makefile.filter("CXXFLAGS =.*", f"CXXFLAGS ={self.compiler.cxx11_flag}")
 
-    def test_mptensor(self):
-        """test if mptensor works"""
+    def test_tensor_test(self):
+        """build and run tensor_test"""
         if "+mpi" not in self.spec:
             raise SkipTest("Package must be installed with +mpi")
 


### PR DESCRIPTION
Update standalone testing API. See comments for test error output.

Supersedes #38633 

Test results now:

```
$ spack find -v mptensor
-- linux-rhel8-x86_64_v3 / gcc@12.1.1 ---------------------------
mptensor@0.3.0~doc~ipo~mpi build_system=cmake build_type=Release generator=make
mptensor@0.3.0~doc~ipo+mpi build_system=cmake build_type=Release generator=make
==> 2 installed packages


$ spack -v test run mptensor
==> Spack test 7plbi5qgswwdlesjskiqueotemeohxlw
==> Testing package mptensor-0.3.0-7yomia3
..
==> [2024-08-13-15:15:15.921561] test: test_tensor_test: build and run tensor_test
==> [2024-08-13-15:15:46.105969] '$spack/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/openmpi-5.0.3-tssouwvohaz546p3n64yvo24aciub4sq/bin/mpirun' '-n' '1' 'tensor_test.out'
..
Usage: a.out N
Warning: assuming N=10
========================================
transpose <double> (A[N0,N1,N2,N3], Axes(2,0,3,1)) = B[N2,N0,N3,N1]
[N0, N1, N2, N3] = [10, 11, 12, 13]
Error= 0
Time= 0.000139 [sec]
Time(check)= 0.01544 [sec]
..
Test of mptensor PASSED !
PASSED: Mptensor::test_tensor_test
==> [2024-08-13-15:15:53.097024] Completed testing
==> [2024-08-13-15:15:53.097147] 
======================= SUMMARY: mptensor-0.3.0-7yomia3 ========================
Mptensor::test_tensor_test .. PASSED
============================= 1 passed of 1 parts ==============================
==> Testing package mptensor-0.3.0-fua3pdp
==> [2024-08-13-15:16:02.720560] test: test_tensor_test: build and run tensor_test
SKIPPED: Mptensor::test_tensor_test: Package must be installed with +mpi
==> [2024-08-13-15:16:02.724884] Completed testing
==> [2024-08-13-15:16:02.724987] 
======================= SUMMARY: mptensor-0.3.0-fua3pdp ========================
Mptensor::test_tensor_test .. SKIPPED
============================= 1 skipped of 1 parts =============================
======================== 1 passed, 1 skipped of 2 specs ========================
```