### PR TITLE
installer.py: handle external roots the same

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1542,17 +1542,6 @@ class PackageInstaller:
             tty.warn(f"Installation request refused: {str(err)}")
             return
 
-        # Skip out early if the spec is not being installed locally (i.e., if
-        # external or upstream).
-        #
-        # External and upstream packages need to get flagged as installed to
-        # ensure proper status tracking for environment build.
-        explicit = request.pkg.spec.dag_hash() in request.install_args.get("explicit", [])
-        not_local = _handle_external_and_upstream(request.pkg, explicit)
-        if not_local:
-            self._flag_installed(request.pkg)
-            return
-
         install_compilers = spack.config.get("config:install_missing_compilers", False)
 
         install_deps = request.install_args.get("install_deps")
@@ -2029,11 +2018,10 @@ class PackageInstaller:
             # Skip the installation if the spec is not being installed locally
             # (i.e., if external or upstream) BUT flag it as installed since
             # some package likely depends on it.
-            if not task.explicit:
-                if _handle_external_and_upstream(pkg, False):
-                    term_status.clear()
-                    self._flag_installed(pkg, task.dependents)
-                    continue
+            if _handle_external_and_upstream(pkg, task.explicit):
+                term_status.clear()
+                self._flag_installed(pkg, task.dependents)
+                continue
 
             # Flag a failed spec.  Do not need an (install) prefix lock since
             # assume using a separate (failed) prefix lock file.


### PR DESCRIPTION
There was logic not to enqueue build requests for externals if they occur as
roots. That's unnecessary.

Also fixes repeated printing of 

```
[+] /usr (external perl-5.36.0-xk2onjulzmd6vdi4scmuxf3qpputx6wq)
...
[+] /usr (external perl-5.36.0-xk2onjulzmd6vdi4scmuxf3qpputx6wq)
```

which already happened before #44374

Closes #44533 
