### PR TITLE
ci: mgard build failure w/ system zlib

### DIFF
--- a/var/spack/repos/builtin/packages/mgard/package.py
+++ b/var/spack/repos/builtin/packages/mgard/package.py
@@ -47,6 +47,7 @@ class Mgard(CMakePackage, CudaPackage):
     depends_on("python", type=("build",), when="@2022-11-18:")
     depends_on("sed", type=("build",), when="@2022-11-18:")
     depends_on("zlib-api")
+    depends_on("zlib@1.2.9:", when="^[virtuals=zlib-api] zlib")  # crc32_z
     depends_on("pkgconfig", type=("build",), when="@2022-11-18:")
     depends_on("zstd")
     depends_on("protobuf@3.4:", when="@2022-11-18:")


### PR DESCRIPTION
The pcluster pipeline runs `spack external find` and autodetects the most ancient of zlib versions on the system: 1.2.7, release date May 3, 2012.

Turns out some packages require parts of the zlib api added within the last decade.
