### PR TITLE
Fixed typo in hypre package

### DIFF
--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -282,7 +282,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
             else:
                 configure_args.append("--enable-cub")
             if spec.satisfies("+cublas"):
-                conigure_args.append("--enable-cublas")
+                configure_args.append("--enable-cublas")
         else:
             configure_args.extend(["--without-cuda", "--disable-curand", "--disable-cusparse"])
             if spec.satisfies("@:2.20.99"):


### PR DESCRIPTION
Hypre's `package.py` contains a typo where it says `conigure_args` instead of `configure_args` when enabling `cublas`. Thi of course crashes the install when it is set with `+cublas`. This PR fixes this issue.