### PR TITLE
gettext: Fix unvendor libxml2

### DIFF
--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -80,7 +80,7 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
         # From the configure script: "we don't want to use an external libxml, because its
         # dependencies and their dynamic relocations have an impact on the startup time", well,
         # *we* do.
-        if self.spec.satisfies("@20:"):  # libtextstyle/configure not present prior
+        if self.spec.satisfies("@0.20:"):  # libtextstyle/configure not present prior
             filter_file(
                 "gl_cv_libxml_force_included=yes",
                 "gl_cv_libxml_force_included=no",

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -94,6 +94,11 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
             flags.append("-lxml2")
         return (flags, None, None)
 
+    def setup_build_environment(self, env):
+        if "+libxml2" in self.spec:
+            # Fix include not found when libxml2 is external /usr
+            env.set("INCXML2", self.spec["libxml2"].headers.cpp_flags)
+
     @classmethod
     def determine_version(cls, exe):
         gettext = Executable(exe)

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -94,11 +94,6 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
             flags.append("-lxml2")
         return (flags, None, None)
 
-    def setup_build_environment(self, env):
-        if "+libxml2" in self.spec:
-            # Fix include not found when libxml2 is external /usr
-            env.set("INCXML2", self.spec["libxml2"].headers.cpp_flags)
-
     @classmethod
     def determine_version(cls, exe):
         gettext = Executable(exe)


### PR DESCRIPTION
Fix a typo in gettext version condition for unvendoring libxml2. See #43622 and https://github.com/spack/spack/pull/44680#issuecomment-2183088878.
