### PR TITLE
Simplify flag propagation encoding

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1918,7 +1918,7 @@ class SpackSolverSetup:
             for flag in flags:
                 clauses.append(f.node_flag(spec.name, flag_type, flag))
                 if not spec.concrete and flag.propagate is True:
-                    clauses.append(f.node_flag_propagate(spec.name, flag_type))
+                    clauses.append(f.propagate(spec.name, fn.node_flag(flag_type, flag)))
 
         # dependencies
         if spec.concrete:
@@ -2744,7 +2744,6 @@ class _Head:
     node_compiler_version = fn.attr("node_compiler_version_set")
     node_flag = fn.attr("node_flag_set")
     node_flag_source = fn.attr("node_flag_source")
-    node_flag_propagate = fn.attr("node_flag_propagate")
     propagate = fn.attr("propagate")
 
 
@@ -2761,7 +2760,6 @@ class _Body:
     node_compiler_version = fn.attr("node_compiler_version")
     node_flag = fn.attr("node_flag")
     node_flag_source = fn.attr("node_flag_source")
-    node_flag_propagate = fn.attr("node_flag_propagate")
     propagate = fn.attr("propagate")
 
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1912,9 +1912,6 @@ class SpackSolverSetup:
 
         # compiler flags
         for flag_type, flags in spec.compiler_flags.items():
-            if not flags:
-                continue
-            clauses.append(f.node_flag_source(spec.name, flag_type, spec.name))
             for flag in flags:
                 clauses.append(f.node_flag(spec.name, flag_type, flag))
                 if not spec.concrete and flag.propagate is True:
@@ -2743,7 +2740,6 @@ class _Head:
     node_compiler = fn.attr("node_compiler_set")
     node_compiler_version = fn.attr("node_compiler_version_set")
     node_flag = fn.attr("node_flag_set")
-    node_flag_source = fn.attr("node_flag_source")
     propagate = fn.attr("propagate")
 
 
@@ -2759,7 +2755,6 @@ class _Body:
     node_compiler = fn.attr("node_compiler")
     node_compiler_version = fn.attr("node_compiler_version")
     node_flag = fn.attr("node_flag")
-    node_flag_source = fn.attr("node_flag_source")
     propagate = fn.attr("propagate")
 
 
@@ -3492,7 +3487,7 @@ class SpecBuilder:
                 ordered_compiler_flags = list(llnl.util.lang.dedupe(from_compiler + from_sources))
                 compiler_flags = spec.compiler_flags.get(flag_type, [])
 
-                msg = "%s does not equal %s" % (set(compiler_flags), set(ordered_compiler_flags))
+                msg = f"{set(compiler_flags)} does not equal {set(ordered_compiler_flags)}"
                 assert set(compiler_flags) == set(ordered_compiler_flags), msg
 
                 spec.compiler_flags.update({flag_type: ordered_compiler_flags})
@@ -3562,9 +3557,8 @@ class SpecBuilder:
                 # do not bother calling actions on it except for node_flag_source,
                 # since node_flag_source is tracking information not in the spec itself
                 spec = self._specs.get(args[0])
-                if spec and spec.concrete:
-                    if name != "node_flag_source":
-                        continue
+                if spec and spec.concrete and name != "node_flag_source":
+                    continue
 
             action(*args)
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1912,9 +1912,11 @@ class SpackSolverSetup:
 
         # compiler flags
         for flag_type, flags in spec.compiler_flags.items():
+            if not flags:
+                continue
+            clauses.append(f.node_flag_source(spec.name, flag_type, spec.name))
             for flag in flags:
                 clauses.append(f.node_flag(spec.name, flag_type, flag))
-                clauses.append(f.node_flag_source(spec.name, flag_type, spec.name))
                 if not spec.concrete and flag.propagate is True:
                     clauses.append(f.node_flag_propagate(spec.name, flag_type))
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1915,7 +1915,7 @@ class SpackSolverSetup:
             for flag in flags:
                 clauses.append(f.node_flag(spec.name, flag_type, flag))
                 if not spec.concrete and flag.propagate is True:
-                    clauses.append(f.propagate(spec.name, fn.node_flag(flag_type, flag)))
+                    clauses.append(f.propagate(spec.name, fn.node_flag(flag_type, flag), "link"))
 
         # dependencies
         if spec.concrete:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3346,6 +3346,8 @@ class SpecBuilder:
     def node(self, node):
         if node not in self._specs:
             self._specs[node] = spack.spec.Spec(node.pkg)
+            for flag_type in spack.spec.FlagMap.valid_compiler_flags():
+                self._specs[node].compiler_flags[flag_type] = []
 
     def _arch(self, node):
         arch = self._specs[node].architecture
@@ -3397,9 +3399,6 @@ class SpecBuilder:
 
     def node_flag_source(self, node, flag_type, source):
         self._flag_sources[(node, flag_type)].add(source)
-
-    def no_flags(self, node, flag_type):
-        self._specs[node].compiler_flags[flag_type] = []
 
     def external_spec_selected(self, node, idx):
         """This means that the external spec and index idx has been selected for this package."""

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1915,7 +1915,11 @@ class SpackSolverSetup:
             for flag in flags:
                 clauses.append(f.node_flag(spec.name, flag_type, flag))
                 if not spec.concrete and flag.propagate is True:
-                    clauses.append(f.propagate(spec.name, fn.node_flag(flag_type, flag), "link"))
+                    clauses.append(
+                        f.propagate(
+                            spec.name, fn.node_flag(flag_type, flag), fn.edge_types("link", "run")
+                        )
+                    )
 
         # dependencies
         if spec.concrete:

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1279,15 +1279,9 @@ error(100, "Compiler {1}@{2} requested for {0} cannot be found. Set install_miss
 
 % propagate flags when compiler match
 can_inherit_flags(PackageNode, DependencyNode, FlagType)
-  :- same_compiler(PackageNode, DependencyNode),
+  :- compiler_match(PackageNode, DependencyNode),
      not attr("node_flag_set", DependencyNode, FlagType, _),
      flag_type(FlagType).
-
-same_compiler(PackageNode, DependencyNode)
-  :- depends_on(PackageNode, DependencyNode),
-     node_compiler(PackageNode, CompilerID),
-     node_compiler(DependencyNode, CompilerID),
-     compiler_id(CompilerID).
 
 node_flag_inherited(DependencyNode, FlagType, Flag)
   :- attr("node_flag_set", PackageNode, FlagType, Flag),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -964,11 +964,17 @@ pkg_fact(Package, variant_single_value("dev_path"))
 
 % Propagation roots have a corresponding attr("propagate", ...)
 propagate(RootNode, PropagatedAttribute) :- attr("propagate", RootNode, PropagatedAttribute).
+propagate(RootNode, PropagatedAttribute, DepType) :- attr("propagate", RootNode, PropagatedAttribute, DepType).
+
 
 % Propagate an attribute along edges to child nodes
 propagate(ChildNode, PropagatedAttribute) :-
   propagate(ParentNode, PropagatedAttribute),
   depends_on(ParentNode, ChildNode).
+
+propagate(ChildNode, PropagatedAttribute, DepType) :-
+  propagate(ParentNode, PropagatedAttribute, DepType),
+  attr("depends_on", ParentNode, ChildNode, DepType).
 
 %-----------------------------------------------------------------------------
 % Activation of propagated values
@@ -1004,12 +1010,12 @@ variant_is_propagated(PackageNode, Variant) :-
 % 2. This node has the same compiler as the propagation source
 
 propagated_flag(PackageNode, node_flag(FlagType, Flag), SourceNode) :-
-  propagate(PackageNode, node_flag(FlagType, Flag)),
+  propagate(PackageNode, node_flag(FlagType, Flag), _),
   not attr("node_flag_set", PackageNode, FlagType, _),
   % Same compiler as propagation source
   node_compiler(PackageNode, CompilerID),
   node_compiler(SourceNode, CompilerID),
-  attr("propagate", SourceNode, node_flag(FlagType, Flag)),
+  attr("propagate", SourceNode, node_flag(FlagType, Flag), _),
   PackageNode != SourceNode.
 
 attr("node_flag", PackageNode, FlagType, Flag) :- propagated_flag(PackageNode, node_flag(FlagType, Flag), _).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -997,6 +997,32 @@ variant_is_propagated(PackageNode, Variant) :-
    not propagate(PackageNode, variant_value(Variant, Value)).
 
 %----
+% Flags
+%----
+
+% A propagated flag implies:
+% 1. The same flag type is not set on this node
+% 2. This node has the same compiler as the propagation source
+
+propagated_flag(PackageNode, node_flag(FlagType, Flag), SourceNode) :-
+  propagate(PackageNode, node_flag(FlagType, Flag)),
+  not attr("node_flag_set", PackageNode, FlagType, _),
+  % Same compiler as propagation source
+  node_compiler(PackageNode, CompilerID),
+  node_compiler(SourceNode, CompilerID),
+  attr("propagate", SourceNode, node_flag(FlagType, Flag)),
+  PackageNode != SourceNode.
+
+attr("node_flag", PackageNode, FlagType, Flag) :- propagated_flag(PackageNode, node_flag(FlagType, Flag), _).
+attr("node_flag_source", PackageNode, FlagType, SourceNode) :- propagated_flag(PackageNode, node_flag(FlagType, _), SourceNode).
+
+% Cannot propagate the same flag from two distinct sources
+error(100, "{0} and {1} cannot both propagate compiler flags '{2}' to {3}", Source1, Source2, Package, FlagType) :-
+  propagated_flag(node(ID, Package), node_flag(FlagType, _), node(_, Source1)),
+  propagated_flag(node(ID, Package), node_flag(FlagType, _), node(_, Source2)),
+  Source1 < Source2.
+
+%----
 % Compiler constraints
 %----
 
@@ -1277,39 +1303,9 @@ error(100, "Compiler {1}@{2} requested for {0} cannot be found. Set install_miss
 % Compiler flags
 %-----------------------------------------------------------------------------
 
-% propagate flags when compiler match
-can_inherit_flags(PackageNode, DependencyNode, FlagType)
-  :- compiler_match(PackageNode, DependencyNode),
-     not attr("node_flag_set", DependencyNode, FlagType, _),
-     flag_type(FlagType).
-
-node_flag_inherited(DependencyNode, FlagType, Flag)
-  :- attr("node_flag_set", PackageNode, FlagType, Flag),
-     can_inherit_flags(PackageNode, DependencyNode, FlagType),
-     attr("node_flag_propagate", PackageNode, FlagType).
-
-% Ensure propagation
-:- node_flag_inherited(PackageNode, FlagType, Flag),
-   can_inherit_flags(PackageNode, DependencyNode, FlagType),
-   attr("node_flag_propagate", PackageNode, FlagType).
-
-error(100, "{0} and {1} cannot both propagate compiler flags '{2}' to {3}", Source1, Source2, Package, FlagType) :-
-  depends_on(Source1, Package),
-  depends_on(Source2, Package),
-  attr("node_flag_propagate", Source1, FlagType),
-  attr("node_flag_propagate", Source2, FlagType),
-  can_inherit_flags(Source1, Package, FlagType),
-  can_inherit_flags(Source2, Package, FlagType),
-  Source1 < Source2.
-
 % remember where flags came from
 attr("node_flag_source", PackageNode, FlagType, PackageNode)
   :- attr("node_flag_set", PackageNode, FlagType, _).
-
-attr("node_flag_source", DependencyNode, FlagType, Q)
-  :- attr("node_flag_source", PackageNode, FlagType, Q),
-     node_flag_inherited(DependencyNode, FlagType, _),
-     attr("node_flag_propagate", PackageNode, FlagType).
 
 % compiler flags from compilers.yaml are put on nodes if compiler matches
 attr("node_flag", PackageNode, FlagType, Flag)
@@ -1329,9 +1325,8 @@ attr("node_flag_compiler_default", PackageNode)
      compiler_name(CompilerID, CompilerName),
      compiler_version(CompilerID, Version).
 
-% if a flag is set to something or inherited, it's included
+% Flag set to something
 attr("node_flag", PackageNode, FlagType, Flag) :- attr("node_flag_set", PackageNode, FlagType, Flag).
-attr("node_flag", PackageNode, FlagType, Flag) :- node_flag_inherited(PackageNode, FlagType, Flag).
 
 % if no node flags are set for a type, there are no flags.
 attr("no_flags", PackageNode, FlagType)

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -29,7 +29,6 @@
 :- attr("variant_value", PackageNode, _, _), not attr("node", PackageNode).
 :- attr("node_flag_compiler_default", PackageNode), not attr("node", PackageNode).
 :- attr("node_flag", PackageNode, _, _), not attr("node", PackageNode).
-:- attr("no_flags", PackageNode, _), not attr("node", PackageNode).
 :- attr("external_spec_selected", PackageNode, _), not attr("node", PackageNode).
 :- attr("depends_on", ParentNode, _, _), not attr("node", ParentNode).
 :- attr("depends_on", _, ChildNode, _), not attr("node", ChildNode).
@@ -1327,12 +1326,6 @@ attr("node_flag_compiler_default", PackageNode)
 
 % Flag set to something
 attr("node_flag", PackageNode, FlagType, Flag) :- attr("node_flag_set", PackageNode, FlagType, Flag).
-
-% if no node flags are set for a type, there are no flags.
-attr("no_flags", PackageNode, FlagType)
-  :- not attr("node_flag", PackageNode, FlagType, _),
-     attr("node", PackageNode),
-     flag_type(FlagType).
 
 #defined compiler_flag/3.
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1009,14 +1009,15 @@ variant_is_propagated(PackageNode, Variant) :-
 % 1. The same flag type is not set on this node
 % 2. This node has the same compiler as the propagation source
 
-propagated_flag(PackageNode, node_flag(FlagType, Flag), SourceNode) :-
-  propagate(PackageNode, node_flag(FlagType, Flag), _),
-  not attr("node_flag_set", PackageNode, FlagType, _),
+propagated_flag(node(PackageID, Package), node_flag(FlagType, Flag), SourceNode) :-
+  propagate(node(PackageID, Package), node_flag(FlagType, Flag), _),
+  not attr("node_flag_set", node(PackageID, Package), FlagType, _),
   % Same compiler as propagation source
-  node_compiler(PackageNode, CompilerID),
+  node_compiler(node(PackageID, Package), CompilerID),
   node_compiler(SourceNode, CompilerID),
   attr("propagate", SourceNode, node_flag(FlagType, Flag), _),
-  PackageNode != SourceNode.
+  node(PackageID, Package) != SourceNode,
+  not runtime(Package).
 
 attr("node_flag", PackageNode, FlagType, Flag) :- propagated_flag(PackageNode, node_flag(FlagType, Flag), _).
 attr("node_flag_source", PackageNode, FlagType, SourceNode) :- propagated_flag(PackageNode, node_flag(FlagType, _), SourceNode).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1303,8 +1303,8 @@ error(100, "Compiler {1}@{2} requested for {0} cannot be found. Set install_miss
 %-----------------------------------------------------------------------------
 
 % remember where flags came from
-attr("node_flag_source", PackageNode, FlagType, PackageNode)
-  :- attr("node_flag_set", PackageNode, FlagType, _).
+attr("node_flag_source", PackageNode, FlagType, PackageNode) :- attr("node_flag_set", PackageNode, FlagType, _).
+attr("node_flag_source", PackageNode, FlagType, PackageNode) :- attr("node_flag", PackageNode, FlagType, _), attr("hash", PackageNode, _).
 
 % compiler flags from compilers.yaml are put on nodes if compiler matches
 attr("node_flag", PackageNode, FlagType, Flag)

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -964,7 +964,7 @@ pkg_fact(Package, variant_single_value("dev_path"))
 
 % Propagation roots have a corresponding attr("propagate", ...)
 propagate(RootNode, PropagatedAttribute) :- attr("propagate", RootNode, PropagatedAttribute).
-propagate(RootNode, PropagatedAttribute, DepType) :- attr("propagate", RootNode, PropagatedAttribute, DepType).
+propagate(RootNode, PropagatedAttribute, EdgeTypes) :- attr("propagate", RootNode, PropagatedAttribute, EdgeTypes).
 
 
 % Propagate an attribute along edges to child nodes
@@ -972,9 +972,10 @@ propagate(ChildNode, PropagatedAttribute) :-
   propagate(ParentNode, PropagatedAttribute),
   depends_on(ParentNode, ChildNode).
 
-propagate(ChildNode, PropagatedAttribute, DepType) :-
-  propagate(ParentNode, PropagatedAttribute, DepType),
-  attr("depends_on", ParentNode, ChildNode, DepType).
+propagate(ChildNode, PropagatedAttribute, edge_types(DepType1, DepType2)) :-
+  propagate(ParentNode, PropagatedAttribute, edge_types(DepType1, DepType2)),
+  depends_on(ParentNode, ChildNode),
+  1 { attr("depends_on", ParentNode, ChildNode, DepType1);  attr("depends_on", ParentNode, ChildNode, DepType2) }.
 
 %-----------------------------------------------------------------------------
 % Activation of propagated values


### PR DESCRIPTION
fixes #44935

This PR reworks flag propagation to use a generic rule. In this way propagation of a property is treated separately from the "activation" of the propagated property on the node. 

Also:
- [x] Change propagation semantic so that flags are not propagated through `build` dependencies.
- [x] Exclude runtime nodes from flag propagation

