### PR TITLE
asciidoc: Fix asciidoc install

### DIFF
--- a/var/spack/repos/builtin/packages/asciidoc/package.py
+++ b/var/spack/repos/builtin/packages/asciidoc/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Asciidoc(AutotoolsPackage):
+class Asciidoc(AutotoolsPackage, PythonPackage):
     """A presentable text document format for writing articles, UNIX man
     pages and other small to medium sized documents."""
 
@@ -16,6 +16,12 @@ class Asciidoc(AutotoolsPackage):
     git = "https://github.com/asciidoc-py/asciidoc-py.git"
 
     license("GPL-2.0-only", checked_by="tgamblin")
+
+    build_system(
+        conditional("autotools", when="@:9"),
+        conditional("python_pip", when="@10:"),
+        default="python_pip",
+    )
 
     version("master", branch="master")
     version("10.2.0", sha256="684ea53c1f5b71d6d1ac6086bbc96906b1f709ecc7ab536615b0f0c9e1baa3cc")
@@ -31,6 +37,9 @@ class Asciidoc(AutotoolsPackage):
     depends_on("docbook-xml", type=("build", "run"))
     depends_on("docbook-xsl", type=("build", "run"))
     depends_on("python@3.5:", type=("build", "run"))
-    depends_on("autoconf", type="build")
-    depends_on("automake", type="build")
-    depends_on("libtool", type="build")
+    with when("build_system=python_pip"):
+        depends_on("py-setuptools", type="build")
+    with when("build_system=autotools"):
+        depends_on("autoconf", type="build")
+        depends_on("automake", type="build")
+        depends_on("libtool", type="build")


### PR DESCRIPTION
Asciidoc 10 is now a python package according to [its changelog](https://asciidoc-py.github.io/CHANGELOG.html#_version_10_0_0_2021_10_16).

Before this PR, I could not install asciidoc@10 (since its introduction in #44021), I got the error:

```
==> No binary for asciidoc-10.2.0-ufn3av2prypupwhl7lhpizv4pacby3wh found: installing from source
==> Fetching https://github.com/asciidoc-py/asciidoc-py/archive/10.2.0.tar.gz
==> No patches needed for asciidoc
==> asciidoc: Executing phase: 'autoreconf'
==> asciidoc: Executing phase: 'configure'
==> asciidoc: Executing phase: 'build'
==> asciidoc: Executing phase: 'install'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j8' 'install'

1 error found in build log:
     38    python3 -m asciidoc.a2x -f manpage doc/a2x.1.txt
     39    python3 -m asciidoc.a2x -f manpage doc/testasciidoc.1.txt
     40    ==> asciidoc: Executing phase: 'install'
     41    ==> [2024-06-27-10:58:47.441415] 'make' '-j8' 'install'
     42    python3 -m pip install --root / .
     43    /.../spack2/opt/spack/linux-ubuntu22.04-skylake/gcc-11.3.0/python-3.11.9-5md6fn5crtra7jg6vsdylcvwufm2nr35/bin/python3: No module named pip
  >> 44    make: *** [Makefile:81: pip] Error 1
```
