### PR TITLE
WRF4.5.x: Limit the patching of ADIOS function to 4.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -195,7 +195,7 @@ class Wrf(Package):
     patch("patches/4.5/configure.patch", when="@4.5:")
     # Fix WRF to remove deprecated ADIOS2 functions
     # https://github.com/wrf-model/WRF/pull/1860
-    patch("patches/4.5/adios2-remove-deprecated-functions.patch", when="@4.5: ^adios2@2.9:")
+    patch("patches/4.5/adios2-remove-deprecated-functions.patch", when="@=4.5.0 ^adios2@2.9:")
 
     # Various syntax fixes found by FPT tool
     patch(


### PR DESCRIPTION
This change restricts the patch adios2-remove-deprecated-functions.patch to be applied only to version 4.5.0 of WRF, because starting from version 4.5.1, upstream has included patch. 

See release note for [WRF 4.5.1](https://github.com/wrf-model/WRF/releases). "Fix the ADIOS2 init API to support ADIOS2 v2.9.0. "