### PR TITLE
Add autouse test fixture for sandboxing env changes

### DIFF
--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -272,6 +272,17 @@ def clean_test_environment():
     ev.deactivate()
 
 
+@pytest.fixture(scope="function", autouse=True)
+def sandbox_test_env():
+    saved_env = os.environ.copy()
+    yield
+    # os.environ = saved_env doesn't work
+    # it causes module_parsing::test_module_function to fail
+    # when it's run after any test using this fixutre
+    os.environ.clear()
+    os.environ.update(saved_env)
+
+
 def _host():
     """Mock archspec host so there is no inconsistency on the Windows platform
     This function cannot be local as it needs to be pickleable"""


### PR DESCRIPTION
Add autouse test fixture for sandboxing env changes on a per function basis.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
