### PR TITLE
parflow: Old test method to new test method

### DIFF
--- a/var/spack/repos/builtin/packages/parflow/package.py
+++ b/var/spack/repos/builtin/packages/parflow/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/parflow/package.py
+++ b/var/spack/repos/builtin/packages/parflow/package.py
@@ -65,21 +65,18 @@ class Parflow(CMakePackage):
 
     examples_dir = "examples"
 
-    def test(self):
+    def test_smoke(self):
         """Perform smoke test on installed ParFlow package."""
         # Run the single phase flow test
         run_path = join_path(self.spec.prefix, self.examples_dir)
         if os.path.isdir(run_path):
+            options = ["default_single.tcl", "1", "1" "1"]
             with working_dir(run_path):
-                self.run_test(
-                    "{0}/tclsh".format(self.spec["tcl"].prefix.bin),
-                    ["default_single.tcl", "1", "1" "1"],
-                )
+                exe = which("{0}/tclsh".format(self.spec["tcl"].prefix.bin))
+                exe(*options)
         else:
             # If examples are not installed test if exe executes
-            exes = ["parflow"]
+            exes = [join_path(self.prefix.bin, "parflow")]
             for exe in exes:
-                reason = "test version of {0} is {1}".format(exe, self.spec.version)
-                self.run_test(
-                    exe, ["-v"], [self.spec.version.string], installed=True, purpose=reason
-                )
+                exe = which(exe)
+                exe("-v")

--- a/var/spack/repos/builtin/packages/parflow/package.py
+++ b/var/spack/repos/builtin/packages/parflow/package.py
@@ -65,19 +65,16 @@ class Parflow(CMakePackage):
 
     examples_dir = "examples"
 
-    def test_parflow(self):
-        """Perform smoke test on installed ParFlow package."""
-        # Run the single phase flow test
+    def test_single_phase_flow(self):
+        """Run the single phase flow test"""
         run_path = join_path(self.spec.prefix, self.examples_dir)
-        if os.path.isdir(run_path):
-            options = ["default_single.tcl", "1", "1" "1"]
-            with working_dir(run_path):
-                exe = which("{0}/tclsh".format(self.spec["tcl"].prefix.bin))
-                exe(*options)
-        else:
-            # If examples are not installed test if exe executes
-            exes = [join_path(self.prefix.bin, "parflow")]
-            for exe in exes:
-                exe = which(exe)
-                out = exe("-v", output=str.split, error=str.split)
-                assert self.spec.version in out
+        options = ["default_single.tcl", "1", "1" "1"]
+        with working_dir(run_path):
+            exe = which(f"{self.spec['tcl'].prefix.bin}/tclsh")
+            exe(*options)
+
+    def test_check_version(self):
+        """Test if exe executes"""
+        exe = which(join_path(self.prefix.bin, "parflow"))
+        out = exe("-v", output=str.split, error=str.split)
+        assert str(self.spec.version) in out

--- a/var/spack/repos/builtin/packages/parflow/package.py
+++ b/var/spack/repos/builtin/packages/parflow/package.py
@@ -65,7 +65,7 @@ class Parflow(CMakePackage):
 
     examples_dir = "examples"
 
-    def test_smoke(self):
+    def test_parflow(self):
         """Perform smoke test on installed ParFlow package."""
         # Run the single phase flow test
         run_path = join_path(self.spec.prefix, self.examples_dir)
@@ -79,4 +79,5 @@ class Parflow(CMakePackage):
             exes = [join_path(self.prefix.bin, "parflow")]
             for exe in exes:
                 exe = which(exe)
-                exe("-v")
+                out = exe("-v", output=str.split, error=str.split)
+                assert self.spec.version in out


### PR DESCRIPTION
Update standalone test API. See below comment for test output.

Supersedes #35805  (for one package)
