### PR TITLE
rocm-clang-ocl: old to new test API

### DIFF
--- a/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
@@ -14,6 +14,8 @@ class RocmClangOcl(CMakePackage):
     url = "https://github.com/ROCm/clang-ocl/archive/rocm-6.1.1.tar.gz"
     tags = ["rocm"]
 
+    test_requires_compiler = True
+
     license("MIT")
 
     maintainers("srekolam", "renjithravindrankannath")
@@ -81,13 +83,10 @@ class RocmClangOcl(CMakePackage):
         self.cache_extra_test_sources([self.test_src_dir])
 
     def test_make(self):
-        """Test make and cmake"""
+        """Test make"""
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
-        with working_dir(test_dir, create=True):
-            prefixes = ";".join([self.spec["rocm-clang-ocl"].prefix])
-            cc_options = ["-DCMAKE_PREFIX_PATH=" + prefixes, "."]
-            exe = which(self.spec["cmake"].prefix.bin.cmake)
-            exe(*cc_options)
+        with working_dir(test_dir):
+            cmake = self.spec["cmake"].command
+            cmake("-DCMAKE_PREFIX_PATH=" + self.spec["rocm-clang-ocl"].prefix, ".")
             make = which("make")
             make()
-            make("clean")

--- a/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
@@ -80,12 +80,14 @@ class RocmClangOcl(CMakePackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources([self.test_src_dir])
 
-    def test(self):
+    def test_make(self):
+        """Test make and cmake"""
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         with working_dir(test_dir, create=True):
-            cmake_bin = join_path(self.spec["cmake"].prefix.bin, "cmake")
             prefixes = ";".join([self.spec["rocm-clang-ocl"].prefix])
             cc_options = ["-DCMAKE_PREFIX_PATH=" + prefixes, "."]
-            self.run_test(cmake_bin, cc_options)
+            exe = which(self.spec["cmake"].prefix.bin.cmake)
+            exe(*cc_options)
+            make = which("make")
             make()
             make("clean")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Update standalone test API. See below comment for test output.