### PR TITLE
rocm-cmake: changed test API from old to new

### DIFF
--- a/var/spack/repos/builtin/packages/rocm-cmake/package.py
+++ b/var/spack/repos/builtin/packages/rocm-cmake/package.py
@@ -65,9 +65,6 @@ class RocmCmake(CMakePackage):
 
     def test_cmake(self):
         """Test cmake"""
-        if self.spec.satisfies("@:5.1.0"):
-            raise SkipTest("Package must be installed as version @5.5.1 or later")
-
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         with working_dir(test_dir, create=True):
             prefixes = ";".join([self.spec["rocm-cmake"].prefix])

--- a/var/spack/repos/builtin/packages/rocm-cmake/package.py
+++ b/var/spack/repos/builtin/packages/rocm-cmake/package.py
@@ -63,12 +63,16 @@ class RocmCmake(CMakePackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources([self.test_src_dir])
 
-    def test(self):
+    def test_cmake(self):
+        """Test cmake"""
+        if self.spec.satisfies("@:5.1.0"):
+            raise SkipTest("Package must be installed as version @5.5.1 or later")
+
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         with working_dir(test_dir, create=True):
-            cmake_bin = join_path(self.spec["cmake"].prefix.bin, "cmake")
             prefixes = ";".join([self.spec["rocm-cmake"].prefix])
             cc_options = ["-DCMAKE_PREFIX_PATH=" + prefixes, "."]
-            self.run_test(cmake_bin, cc_options)
+            exe = which(self.spec["cmake"].prefix.bin.cmake)
+            exe(*cc_options)
             make()
             make("clean")

--- a/var/spack/repos/builtin/packages/rocm-cmake/package.py
+++ b/var/spack/repos/builtin/packages/rocm-cmake/package.py
@@ -72,7 +72,7 @@ class RocmCmake(CMakePackage):
         with working_dir(test_dir, create=True):
             prefixes = ";".join([self.spec["rocm-cmake"].prefix])
             cc_options = ["-DCMAKE_PREFIX_PATH=" + prefixes, "."]
-            exe = which(self.spec["cmake"].prefix.bin.cmake)
-            exe(*cc_options)
+            cmake = which(self.spec["cmake"].prefix.bin.cmake)
+            cmake(*cc_options)
             make()
             make("clean")


### PR DESCRIPTION
Update standalone test API. See below comment for test output.

https://spack.readthedocs.io/en/latest/packaging_guide.html#stand-alone-tests