### PR TITLE
py-tesorter: add post install hmmpress step

### DIFF
--- a/var/spack/repos/builtin/packages/py-tesorter/package.py
+++ b/var/spack/repos/builtin/packages/py-tesorter/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from glob import glob
+
 from spack.package import *
 
 
@@ -29,5 +31,20 @@ class PyTesorter(PythonPackage):
     depends_on("py-biopython", type=("build", "run"))
     depends_on("py-xopen", type=("build", "run"))
 
-    depends_on("hmmer@3.3:", type="run")
+    depends_on("hmmer@3.3:", type=("build", "run"))
     depends_on("blast-plus", type="run")
+
+    @run_after("install")
+    def run_hmmpress(self):
+        hmmpress = Executable(self.spec["hmmer"].prefix.bin.hmmpress)
+        db_dir = join_path(
+            self.prefix,
+            "lib",
+            f"python{self.spec['python'].version.dotted[:2]}",
+            "site-packages",
+            "TEsorter",
+            "database",
+        )
+        with working_dir(db_dir):
+            for f in glob("*.hmm"):
+                hmmpress(f)


### PR DESCRIPTION
This has some hmm db files in it, which need some processing with hmmpress before use.