### PR TITLE
adios2: add patch to support rocm6

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -245,7 +245,7 @@ spack:
   # - paraview +rocm amdgpu_target=gfx908 # mesa: https://github.com/spack/spack/issues/44745
   # - vtk-m ~openmp +rocm amdgpu_target=gfx908  # vtk-m: https://github.com/spack/spack/issues/40268
   # --
-  # - adios2 +kokkos +rocm amdgpu_target=gfx908 # adios2:https://github.com/spack/spack/issues/44594
+  - adios2 +kokkos +rocm amdgpu_target=gfx908 # adios2:https://github.com/spack/spack/issues/44594
   # - cp2k +mpi +rocm amdgpu_target=gfx908      # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
   # - exago +mpi +python +raja +hiop +rocm amdgpu_target=gfx908 ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target=gfx908 # raja: https://github.com/spack/spack/issues/44593
   # - lbann ~cuda +rocm amdgpu_target=gfx908    # aluminum: https://github.com/spack/spack/issues/38807
@@ -287,7 +287,7 @@ spack:
   # - paraview +rocm amdgpu_target=gfx90a # mesa: https://github.com/spack/spack/issues/44745
   # - vtk-m ~openmp +rocm amdgpu_target=gfx90a  # vtk-m: https://github.com/spack/spack/issues/40268
   # --
-  # - adios2 +kokkos +rocm amdgpu_target=gfx90a # adios2: https://github.com/spack/spack/issues/44594  
+  - adios2 +kokkos +rocm amdgpu_target=gfx90a # adios2: https://github.com/spack/spack/issues/44594
   # - cp2k +mpi +rocm amdgpu_target=gfx90a      # cp2k: Error: KeyError: 'No spec with name rocm in... "-L{}".format(spec["rocm"].libs.directories[0]),
   # - exago +mpi +python +raja +hiop +rocm amdgpu_target=gfx90a ~ipopt cxxflags="-Wno-error=non-pod-varargs" ^hiop@1.0.0 ~sparse +mpi +raja +rocm amdgpu_target=gfx90a # raja: https://github.com/spack/spack/issues/44593
   # - lbann ~cuda +rocm amdgpu_target=gfx90a    # aluminum: https://github.com/spack/spack/issues/38807

--- a/var/spack/repos/builtin/packages/adios2/2.10-enable-rocm6.patch
+++ b/var/spack/repos/builtin/packages/adios2/2.10-enable-rocm6.patch
@@ -1,0 +1,28 @@
+From c718e99a9e226b7327ab41396823873999206e38 Mon Sep 17 00:00:00 2001
+From: Vicente Adolfo Bolea Sanchez <vicente.bolea@kitware.com>
+Date: Thu, 27 Jun 2024 18:25:58 -0400
+Subject: [PATCH] kokkos: support ROCM >=6
+
+---
+ source/adios2/helper/kokkos/adiosKokkos.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/source/adios2/helper/kokkos/adiosKokkos.cpp b/source/adios2/helper/kokkos/adiosKokkos.cpp
+index e0599944e..d2619f0d4 100644
+--- a/source/adios2/helper/kokkos/adiosKokkos.cpp
++++ b/source/adios2/helper/kokkos/adiosKokkos.cpp
+@@ -85,7 +85,11 @@ bool IsGPUbuffer(const void *ptr)
+     hipError_t ret;
+     hipPointerAttribute_t attr;
+     ret = hipPointerGetAttributes(&attr, ptr);
++#if defined(ROCM_VERSION_MAJOR) && ROCM_VERSION_MAJOR < 6
+     if (ret == hipSuccess && attr.memoryType == hipMemoryTypeDevice)
++#else
++    if (ret == hipSuccess && attr.type == hipMemoryTypeDevice)
++#endif
+     {
+         return true;
+     }
+-- 
+2.35.3
+

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -232,6 +232,10 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     # https://github.com/ornladios/ADIOS2/pull/3893
     patch("2.9.2-cmake-find-threads-package-first.patch", when="@2.9")
 
+    # ROCM: enable support for rocm >= 6
+    # https://github.com/ornladios/ADIOS2/pull/4214
+    patch("2.10-enable-rocm6.patch", when="@2.9.1:")
+
     @when("%fj")
     def patch(self):
         """add fujitsu mpi commands #16864"""


### PR DESCRIPTION
Fixes: #44594

Fix in upstream: https://github.com/ornladios/ADIOS2/pull/4214 