### PR TITLE
strumpack: make standalone test for +mpi more robust

### DIFF
--- a/var/spack/repos/builtin/packages/strumpack/package.py
+++ b/var/spack/repos/builtin/packages/strumpack/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 import llnl.util.tty as tty
 
 from spack.package import *
@@ -244,6 +246,7 @@ class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
         mpi_bin = self.spec["mpi"].prefix.bin
         mpiexe_list = ["srun", mpi_bin.mpirun, mpi_bin.mpiexec]
         for exe in mpiexe_list:
+            tty.info(f"Attempting to build and launch with {os.path.basename(exe)}")
             try:
                 args = ["--immediate=30"] + mpi_args if exe == "srun" else mpi_args
                 self._test_example(test_exe_mpi, exe, args)

--- a/var/spack/repos/builtin/packages/strumpack/package.py
+++ b/var/spack/repos/builtin/packages/strumpack/package.py
@@ -3,8 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import llnl.util.tty as tty
+
 from spack.package import *
 from spack.util.environment import set_env
+from spack.util.executable import ProcessError
 
 
 class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
@@ -201,7 +204,7 @@ class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources([self.test_data_dir, self.test_src_dir])
 
-    def _test_example(self, test_prog, test_cmd, test_args):
+    def _test_example(self, test_prog, test_cmd, pre_args=[]):
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         cmake_filename = join_path(test_dir, "CMakeLists.txt")
         with open(cmake_filename, "w") as mkfile:
@@ -214,9 +217,7 @@ class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
             )
 
         with working_dir(test_dir):
-            opts = self.builder.std_cmake_args
-            opts += self.cmake_args()
-            opts += ["."]
+            opts = self.builder.std_cmake_args + self.cmake_args() + ["."]
             cmake = self.spec["cmake"].command
             cmake(*opts)
 
@@ -225,29 +226,31 @@ class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
 
             with set_env(OMP_NUM_THREADS="1"):
                 exe = which(test_cmd)
+                test_args = pre_args + [join_path("..", self.test_data_dir, "pde900.mtx")]
                 exe(*test_args)
 
     def test_sparse_seq(self):
         """Run sequential test_sparse"""
-        if "+mpi" in self.spec:
-            raise SkipTest("Package must be installed with '~mpi'")
         test_exe = "test_sparse_seq"
-        exe_arg = [join_path("..", self.test_data_dir, "pde900.mtx")]
-        self._test_example(test_exe, test_exe, exe_arg)
+        self._test_example(test_exe, test_exe)
 
     def test_sparse_mpi(self):
         """Run parallel test_sparse"""
         if "+mpi" not in self.spec:
             raise SkipTest("Package must be installed with '+mpi'")
         test_exe_mpi = "test_sparse_mpi"
-        test_args = ["-n", "1", test_exe_mpi, join_path("..", self.test_data_dir, "pde900.mtx")]
-        mpiexe_list = ["srun", "mpirun", "mpiexec"]
+        mpi_args = ["-n", "1", test_exe_mpi]
+
+        mpi_bin = self.spec["mpi"].prefix.bin
+        mpiexe_list = ["srun", mpi_bin.mpirun, mpi_bin.mpiexec]
         for exe in mpiexe_list:
             try:
-                self._test_example(test_exe_mpi, exe, test_args)
+                args = ["--immediate=30"] + mpi_args if exe == "srun" else mpi_args
+                self._test_example(test_exe_mpi, exe, args)
                 return
-            except Exception:
-                pass
+            except (Exception, ProcessError) as err:
+                tty.info(f"Skipping {exe}: {str(err)}")
+
         assert False, "No MPI executable was found"
 
     def check(self):


### PR DESCRIPTION
Depends on #44874 (merged

@shahzebsiddiqui @wspear 

This PR extends the work of #44874 to better support `test_sparse_mpi` processing from a node that cannot run `srun` (e.g., CI stacks, login nodes).  It also does a *little* more tightening of the code and allows the sequential test to run even when `+mpi`.

It handles the `srun` issue with a timeout-like option (`--immediate`) that may or may not be supported but any problems are hopefully handled correctly by catching exceptions and allowing the search for an `mpi` alternative that is actually tied to the `mpi` used in the software's build.

I would appreciate feedback from others who have experienced problems running `strumpack+mpi` standalone tests:
- does this resolve your issues? 
- does it create problems with Spack CI for the package?
- is the `30` second value for `--immediate` sufficient? appropriate?