### PR TITLE
Develop specs should have patches fetched and applied

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1141,10 +1141,9 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
             if not link_format:
                 link_format = "build-{arch}-{hash:7}"
             stage_link = self.spec.format_path(link_format)
-            return DevelopStage(compute_stage_name(self.spec), dev_path, stage_link)
-
-        # To fetch the current version
-        source_stage = self._make_root_stage(self.fetcher)
+            source_stage = DevelopStage(compute_stage_name(self.spec), dev_path, stage_link)
+        else:
+            source_stage = self._make_root_stage(self.fetcher)
 
         # all_stages is source + resources + patches
         all_stages = StageComposite()
@@ -1473,10 +1472,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
             return
 
         checksum = spack.config.get("config:checksum")
-        fetch = self.stage.needs_fetching
         if (
             checksum
-            and fetch
             and (self.version not in self.versions)
             and (not isinstance(self.version, GitVersion))
         ):

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -346,8 +346,6 @@ class Stage(LockableStagingDir):
     similar, and are intended to persist for only one run of spack.
     """
 
-    #: Most staging is managed by Spack. DevelopStage is one exception.
-    needs_fetching = True
     requires_patch_success = True
 
     def __init__(
@@ -772,8 +770,6 @@ class StageComposite(pattern.Composite):
                 "cache_mirror",
                 "steal_source",
                 "disable_mirrors",
-                "needs_fetching",
-                "requires_patch_success",
             ]
         )
 
@@ -813,6 +809,10 @@ class StageComposite(pattern.Composite):
         return self[0].archive_file
 
     @property
+    def requires_patch_success(self):
+        return self[0].requires_patch_success
+
+    @property
     def keep(self):
         return self[0].keep
 
@@ -823,7 +823,6 @@ class StageComposite(pattern.Composite):
 
 
 class DevelopStage(LockableStagingDir):
-    needs_fetching = False
     requires_patch_success = False
 
     def __init__(self, name, dev_path, reference_link):

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -270,12 +270,9 @@ def trigger_bad_patch(pkg):
 def test_patch_failure_develop_spec_exits_gracefully(
     mock_packages, config, install_mockery, mock_fetch, tmpdir, mock_stage
 ):
-    """
-    ensure that a failing patch does not trigger exceptions
-    for develop specs
-    """
+    """ensure that a failing patch does not trigger exceptions for develop specs"""
 
-    spec = Spec("patch-a-dependency " "^libelf dev_path=%s" % str(tmpdir))
+    spec = Spec(f"patch-a-dependency ^libelf dev_path={tmpdir}")
     spec.concretize()
     libelf = spec["libelf"]
     assert "patches" in list(libelf.variants.keys())


### PR DESCRIPTION
Closes #44942

Use composite stage also for develop specs, so that remote patches are fetched and applied.