### PR TITLE
Docs: include cmake spec property for the command

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -5589,7 +5589,8 @@ compiler configuration. This is accomplished by setting the package's
    Setting the property to ``True`` ensures access to the compiler through
    canonical environment variables (e.g., ``CC``, ``CXX``, ``FC``, ``F77``).
    It also gives access to build dependencies like ``cmake`` through their
-   ``spec objects`` (e.g., ``self.spec["cmake"].prefix.bin.cmake``).
+   ``spec objects`` (e.g., ``self.spec["cmake"].prefix.bin.cmake`` for the
+   path or ``self.spec["cmake"].command`` for the ``Executable`` instance).
 
    Be sure to add the property at the top of the package class under other
    properties like the ``homepage``.


### PR DESCRIPTION
Using `self.spec["cmake"].command` instead of `which(self.spec["cmake"].prefix.bin.cmake)` is the preferred way to get the `cmake` `Executable` for stand-alone tests.  

So this PR simply highlights that in the note in a somewhat easy location to reference when providing PR feedback.