### PR TITLE
umpire: old to new test API and refactor

### DIFF
--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -455,7 +455,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     def cmake_args(self):
         return []
 
-    def run_test(self, exe, expected):
+    def run_example(self, exe, expected):
         """Perform stand-alone checks on the installed package."""
 
         exe_run = which(join_path(self.prefix.bin, exe))

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 import socket
 
 from spack.package import *

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import socket
 
 from spack.package import *
@@ -454,6 +455,12 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     def cmake_args(self):
         return []
+
+    def setup_run_environment(self, env):
+        for library in ["lib", "lib64"]:
+            lib_path = join_path(self.prefix, library)
+            if os.path.exists(lib_path):
+                env.append_path("LD_LIBRARY_PATH", lib_path)
 
     def run_example(self, exe, expected):
         """Perform stand-alone checks on the installed package."""

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -457,21 +457,21 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     def cmake_args(self):
         return []
-    
+
     def run_umpire(self, exe, expected):
-       """Perform stand-alone checks on the installed package."""
-       if self.spec.satisfies("@:1"):
-           raise SkipTest("Package must be installed as version @1.0.1 or later")
+        """Perform stand-alone checks on the installed package."""
+        if self.spec.satisfies("@:1"):
+            raise SkipTest("Package must be installed as version @1.0.1 or later")
 
-       if os.path.isdir(self.prefix.bin):
-           raise SkipTest(f"{self.prefix.bin} does not eixst")
+        if os.path.isdir(self.prefix.bin):
+            raise SkipTest(f"{self.prefix.bin} does not eixst")
 
-       reason = "test: checking output from {0}".format(exe)
-       exe_run = which(join_path(self.prefix.bin, exe))
-       if exe_run is None:
-           raise SkipTest("Executable not present within directory")
-       out = exe_run(output=str.split, error=str.split)
-       check_outputs(expected, out)
+        reason = "test: checking output from {0}".format(exe)
+        exe_run = which(join_path(self.prefix.bin, exe))
+        if exe_run is None:
+            raise SkipTest("Executable not present within directory")
+        out = exe_run(output=str.split, error=str.split)
+        check_outputs(expected, out)
 
     def test_malloc(self):
         """Malloc Test"""
@@ -495,9 +495,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     def test_tut_introspection(self):
         """Keep track of pointer allocation test"""
-        self.run_umpire(
-            "tut_introspection", ["Allocator used is HOST", "size of the allocation"]
-        )
+        self.run_umpire("tut_introspection", ["Allocator used is HOST", "size of the allocation"])
 
     def test_tut_memset(self):
         """Set entire block of memory to one value test"""

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -457,63 +457,60 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     def cmake_args(self):
         return []
+    
+    def run_umpire(self, exe, expected):
+       """Perform stand-alone checks on the installed package."""
+       if self.spec.satisfies("@:1"):
+           raise SkipTest("Package must be installed as version @1.0.1 or later")
 
-    def run_umpire(self,exe,expected):
-        """Perform stand-alone checks on the installed package."""
-        """
-        if self.spec.satisfies("@:1") or not os.path.isdir(self.prefix.bin):
-            tty.info("Skipping: checks not installed in bin for v{0}".format(self.version))
-            return
-        """
-        if self.spec.satisfies("@:1"):
-            raise SkipTest("Package must be installed as version @1.0.1 or later")
+       if os.path.isdir(self.prefix.bin):
+           raise SkipTest(f"{self.prefix.bin} does not eixst")
 
-        if os.path.isdir(self.prefix.bin): 
-            raise SkipTest(f"{self.prefix.bin} does not eixst")
-        
-        reason = "test: checking output from {0}".format(exe)
-        exe_run = which(join_path(self.prefix.bin,exe))
-        if exe_run is None:
-           raise SkipTest("Executable not present within directory") 
-        out = exe_run(output=str.split,error=str.split)
-        check_outputs(expected, out)
+       reason = "test: checking output from {0}".format(exe)
+       exe_run = which(join_path(self.prefix.bin, exe))
+       if exe_run is None:
+           raise SkipTest("Executable not present within directory")
+       out = exe_run(output=str.split, error=str.split)
+       check_outputs(expected, out)
 
-        def test_malloc(self):
-            """Malloc Test"""
-            self.run_umpire("malloc",["99 should be 99"])
+    def test_malloc(self):
+        """Malloc Test"""
+        self.run_umpire("malloc", ["99 should be 99"])
 
-        def test_recipe_dynamic_pool_heuristic(self):
-            """Test heurisitc that uses an allocator for more than just initial allocation"""
-            self.run_umpire("recipe_dynamic_pool_heuristic", ["in the pool", "releas"])
+    def test_recipe_dynamic_pool_heuristic(self):
+        """Test heurisitc that uses an allocator for more than just initial allocation"""
+        self.run_umpire("recipe_dynamic_pool_heuristic", ["in the pool", "releas"])
 
-        def test_recipe_no_introspection(self):
-            """Test without introspection"""
-            self.run_umpire("recipe_no_introspection", ["has allocated", "used"])
+    def test_recipe_no_introspection(self):
+        """Test without introspection"""
+        self.run_umpire("recipe_no_introspection", ["has allocated", "used"])
 
-        def test_strategy_example(self):
-            """Memory allocation strategy test"""
-            self.run_umpire("strategy_example", ["Available allocators", "HOST"])
+    def test_strategy_example(self):
+        """Memory allocation strategy test"""
+        self.run_umpire("strategy_example", ["Available allocators", "HOST"])
 
-        def test_tut_copy(self):
-            """Copy data test"""
-            self.run_umpire("tut_copy", ["Copied source data"])
+    def test_tut_copy(self):
+        """Copy data test"""
+        self.run_umpire("tut_copy", ["Copied source data"])
 
-        def test_tut_introspection(self):
-            """Keep track of pointer allocation test"""
-            self.run_umpire("tut_introspection", ["Allocator used is HOST", "size of the allocation"])
+    def test_tut_introspection(self):
+        """Keep track of pointer allocation test"""
+        self.run_umpire(
+            "tut_introspection", ["Allocator used is HOST", "size of the allocation"]
+        )
 
-        def test_tut_memset(self):
-            """Set entire block of memory to one value test"""
-            self.run_umpire("tut_memset", ["Set data from HOST"])
+    def test_tut_memset(self):
+        """Set entire block of memory to one value test"""
+        self.run_umpire("tut_memset", ["Set data from HOST"])
 
-        def test_tut_move(self):
-            """Move memory test"""
-            self.run_umpire("tut_move", ["Moved source data", "HOST"])
+    def test_tut_move(self):
+        """Move memory test"""
+        self.run_umpire("tut_move", ["Moved source data", "HOST"])
 
-        def test_tut_reallocate(self):
-            """Reallocate memory test"""
-            self.run_umpire("tut_reallocate", ["Reallocated data"])
+    def test_tut_reallocate(self):
+        """Reallocate memory test"""
+        self.run_umpire("tut_reallocate", ["Reallocated data"])
 
-        def test_vector_allocator(self):
-            """Allocate vector memory test"""
-            self.run_umpire("vector_allocator", [""])
+    def test_vector_allocator(self):
+        """Allocate vector memory test"""
+        self.run_umpire("vector_allocator", [""])

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -458,11 +458,13 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     def cmake_args(self):
         return []
 
-    def test(self):
+    def test_umpire_set(self):
         """Perform stand-alone checks on the installed package."""
-        if self.spec.satisfies("@:1") or not os.path.isdir(self.prefix.bin):
-            tty.info("Skipping: checks not installed in bin for v{0}".format(self.version))
-            return
+        if self.spec.satisfies("@:1"):
+            raise SkipTest("Package must be installed as version @1.0.1 or later")
+
+        if os.path.isdir(self.prefix.bin): 
+            raise SkipTest(f"{self.prefix.bin} does not eixst")
 
         # Run a subset of examples PROVIDED installed
         # tutorials with readily checkable outputs.
@@ -482,13 +484,5 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
         for exe in checks:
             expected = checks[exe]
             reason = "test: checking output from {0}".format(exe)
-            self.run_test(
-                exe,
-                [],
-                expected,
-                0,
-                installed=False,
-                purpose=reason,
-                skip_missing=True,
-                work_dir=self.prefix.bin,
-            )
+            exe_run = which(exe)
+            exe_run(checks[exe])

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -466,40 +466,40 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     def test_malloc(self):
         """Run Malloc"""
-        self.run_test("malloc", ["99 should be 99"])
+        self.run_example("malloc", ["99 should be 99"])
 
     def test_recipe_dynamic_pool_heuristic(self):
         """Multiple use allocator test"""
-        self.run_test("recipe_dynamic_pool_heuristic", ["in the pool", "releas"])
+        self.run_example("recipe_dynamic_pool_heuristic", ["in the pool", "releas"])
 
     def test_recipe_no_introspection(self):
         """Test without introspection"""
-        self.run_test("recipe_no_introspection", ["has allocated", "used"])
+        self.run_example("recipe_no_introspection", ["has allocated", "used"])
 
     def test_strategy_example(self):
         """Memory allocation strategy test"""
-        self.run_test("strategy_example", ["Available allocators", "HOST"])
+        self.run_example("strategy_example", ["Available allocators", "HOST"])
 
     def test_tut_copy(self):
         """Copy data test"""
-        self.run_test("tut_copy", ["Copied source data"])
+        self.run_example("tut_copy", ["Copied source data"])
 
     def test_tut_introspection(self):
         """Keep track of pointer allocation test"""
-        self.run_test("tut_introspection", ["Allocator used is HOST", "size of the allocation"])
+        self.run_example("tut_introspection", ["Allocator used is HOST", "size of the allocation"])
 
     def test_tut_memset(self):
         """Set entire block of memory to one value test"""
-        self.run_test("tut_memset", ["Set data from HOST"])
+        self.run_example("tut_memset", ["Set data from HOST"])
 
     def test_tut_move(self):
         """Move memory test"""
-        self.run_test("tut_move", ["Moved source data", "HOST"])
+        self.run_example("tut_move", ["Moved source data", "HOST"])
 
     def test_tut_reallocate(self):
         """Reallocate memory test"""
-        self.run_test("tut_reallocate", ["Reallocated data"])
+        self.run_example("tut_reallocate", ["Reallocated data"])
 
     def test_vector_allocator(self):
         """Allocate vector memory test"""
-        self.run_test("vector_allocator", [""])
+        self.run_example("vector_allocator", [""])

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -456,56 +456,51 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     def cmake_args(self):
         return []
 
-    def run_umpire(self, exe, expected):
+    def run_test(self, exe, expected):
         """Perform stand-alone checks on the installed package."""
-        if self.spec.satisfies("@:1"):
-            raise SkipTest("Package must be installed as version @1.0.1 or later")
-
-        if os.path.isdir(self.prefix.bin):
-            raise SkipTest(f"{self.prefix.bin} does not eixst")
 
         exe_run = which(join_path(self.prefix.bin, exe))
         if exe_run is None:
-            raise SkipTest("Executable not present within directory")
+            raise SkipTest(f"{exe} is not installed for version {self.version}")
         out = exe_run(output=str.split, error=str.split)
         check_outputs(expected, out)
 
     def test_malloc(self):
-        """Malloc Test"""
-        self.run_umpire("malloc", ["99 should be 99"])
+        """Run Malloc"""
+        self.run_test("malloc", ["99 should be 99"])
 
     def test_recipe_dynamic_pool_heuristic(self):
-        """Test heurisitc that uses an allocator for more than just initial allocation"""
-        self.run_umpire("recipe_dynamic_pool_heuristic", ["in the pool", "releas"])
+        """Multiple use allocator test"""
+        self.run_test("recipe_dynamic_pool_heuristic", ["in the pool", "releas"])
 
     def test_recipe_no_introspection(self):
         """Test without introspection"""
-        self.run_umpire("recipe_no_introspection", ["has allocated", "used"])
+        self.run_test("recipe_no_introspection", ["has allocated", "used"])
 
     def test_strategy_example(self):
         """Memory allocation strategy test"""
-        self.run_umpire("strategy_example", ["Available allocators", "HOST"])
+        self.run_test("strategy_example", ["Available allocators", "HOST"])
 
     def test_tut_copy(self):
         """Copy data test"""
-        self.run_umpire("tut_copy", ["Copied source data"])
+        self.run_test("tut_copy", ["Copied source data"])
 
     def test_tut_introspection(self):
         """Keep track of pointer allocation test"""
-        self.run_umpire("tut_introspection", ["Allocator used is HOST", "size of the allocation"])
+        self.run_test("tut_introspection", ["Allocator used is HOST", "size of the allocation"])
 
     def test_tut_memset(self):
         """Set entire block of memory to one value test"""
-        self.run_umpire("tut_memset", ["Set data from HOST"])
+        self.run_test("tut_memset", ["Set data from HOST"])
 
     def test_tut_move(self):
         """Move memory test"""
-        self.run_umpire("tut_move", ["Moved source data", "HOST"])
+        self.run_test("tut_move", ["Moved source data", "HOST"])
 
     def test_tut_reallocate(self):
         """Reallocate memory test"""
-        self.run_umpire("tut_reallocate", ["Reallocated data"])
+        self.run_test("tut_reallocate", ["Reallocated data"])
 
     def test_vector_allocator(self):
         """Allocate vector memory test"""
-        self.run_umpire("vector_allocator", [""])
+        self.run_test("vector_allocator", [""])

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -6,8 +6,6 @@
 import os
 import socket
 
-import llnl.util.tty as tty
-
 from spack.package import *
 
 from .blt import llnl_link_helpers
@@ -466,7 +464,6 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
         if os.path.isdir(self.prefix.bin):
             raise SkipTest(f"{self.prefix.bin} does not eixst")
 
-        reason = "test: checking output from {0}".format(exe)
         exe_run = which(join_path(self.prefix.bin, exe))
         if exe_run is None:
             raise SkipTest("Executable not present within directory")


### PR DESCRIPTION
Update standalone test API.

Supersedes #35800 (for one package)
Fixes #44960 

Encountered problems running the tests (see old output below) due to library load issue (see #44960 )

Current output:

```
$ spack -v test run umpire
==> Testing package umpire-2024.02.1-brlesvr
==> [2024-07-24-15:45:48.394952] test: test_malloc: Run Malloc
...
PASSED: Umpire::test_malloc
==> [2024-07-24-15:45:48.537442] test: test_recipe_dynamic_pool_heuristic: Multiple use allocator test
...
Pool has 4096 bytes of memory. 3072 bytes are used. 4 blocks are in the pool. 1024 bytes are releaseable. 
Pool has 4096 bytes of memory. 2048 bytes are used. 4 blocks are in the pool. 2048 bytes are releaseable. 
Pool has 4096 bytes of memory. 1024 bytes are used. 2 blocks are in the pool. 3072 bytes are releaseable. 
Pool has 4096 bytes of memory. 0 bytes are used. 1 blocks are in the pool. 4096 bytes are releaseable. 
PASSED: Umpire::test_recipe_dynamic_pool_heuristic
==> [2024-07-24-15:45:48.554376] test: test_recipe_no_introspection: Test without introspection
...
Pool has allocated 536870912 bytes of memory. 1024 bytes are used
PASSED: Umpire::test_recipe_no_introspection
==> [2024-07-24-15:45:48.571611] test: test_strategy_example: Memory allocation strategy test
...
Available allocators: 
terminate called after throwing an instance of 'umpire::unknown_pointer_error'
  what():  ! Umpire runtime_error [/var/tmp/dahlgren/spack-stage/spack-stage-umpire-2024.02.1-brlesvrlcdmvnn6xpk3dpvyivt2kx6ie/spack-src/src/umpire/util/AllocationMap.cpp:191]: Allocation not mapped: 0x662070
    Backtrace: 7 frames
...
FAILED: Umpire::test_strategy_example: Command exited with status -6:
...
==> [2024-07-24-15:45:48.647148] test: test_tut_copy: Copy data test
...
Allocated 8192 bytes using the HOST allocator.
Filling with 0.0...done.
Copied source data (0x638c20) to destination HOST (0x63bc40)
PASSED: Umpire::test_tut_copy
==> [2024-07-24-15:45:48.663397] test: test_tut_introspection: Keep track of pointer allocation test
...
Allocated 8192 bytes using the HOST allocator.
According to the ResourceManager, the Allocator used is HOST, which has the Platform 1
The size of the allocation is << 8192
PASSED: Umpire::test_tut_introspection
==> [2024-07-24-15:45:48.674364] test: test_tut_memset: Set entire block of memory to one value test
..
Allocated 8192 bytes using the HOST allocator.
Set data from HOST (0x638c20) to 0.
PASSED: Umpire::test_tut_memset
==> [2024-07-24-15:45:48.688308] test: test_tut_move: Move memory test
...
Allocated 8192 bytes using the HOST allocator.
Filling with 0.0...done.
Moved source data (0x637c20) to destination HOST (0x637c20)
PASSED: Umpire::test_tut_move
==> [2024-07-24-15:45:48.694284] test: test_tut_reallocate: Reallocate memory test
...
Allocated 8192 bytes using the HOST allocator.
Reallocating data (0x638c20) to size 256...done.  Reallocated data (0x638c20)
PASSED: Umpire::test_tut_reallocate
==> [2024-07-24-15:45:48.700133] test: test_vector_allocator: Allocate vector memory test
...
ASSED: Umpire::test_vector_allocator
==> [2024-07-24-15:45:48.707088] Completed testing
==> [2024-07-24-15:45:48.707217] 
====================== SUMMARY: umpire-2024.02.1-brlesvr =======================
Umpire::test_malloc .. PASSED
Umpire::test_recipe_dynamic_pool_heuristic .. PASSED
Umpire::test_recipe_no_introspection .. PASSED
Umpire::test_strategy_example .. FAILED
Umpire::test_tut_copy .. PASSED
Umpire::test_tut_introspection .. PASSED
Umpire::test_tut_memset .. PASSED
Umpire::test_tut_move .. PASSED
Umpire::test_tut_reallocate .. PASSED
Umpire::test_vector_allocator .. PASSED
======================== 9 passed, 1 failed of 10 parts ========================
```

Pre-https://github.com/spack/spack/pull/44957/commits/35b9166d05f4177b560894da34f7f16db573a0a1 output:

```
====================== SUMMARY: umpire-2024.02.1-mrzsrkl =======================
Umpire::test_malloc .. FAILED
Umpire::test_recipe_dynamic_pool_heuristic .. FAILED
Umpire::test_recipe_no_introspection .. FAILED
Umpire::test_strategy_example .. FAILED
Umpire::test_tut_copy .. FAILED
Umpire::test_tut_introspection .. FAILED
Umpire::test_tut_memset .. FAILED
Umpire::test_tut_move .. FAILED
Umpire::test_tut_reallocate .. FAILED
Umpire::test_vector_allocator .. FAILED
============================ 10 failed of 10 parts =============================
==> [2024-07-23-10:15:53.667166] 

See test results at:
  /g/g16/lawrence31/.spack/test/rfck7xyafguhyz5n3m6rhmlfd6u4dcxf/umpire-2024.02.1-mrzsrkl-test-out.txt
==> Error: TestFailure: 10 tests failed.


Command exited with status 127:
    '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/malloc'
/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/malloc: error while loading shared libraries: libumpire.so: cannot open shared object file: No such file or directory



1 error found in test log:
     1    ==> Testing package umpire-2024.02.1-mrzsrkl
     2    ==> [2024-07-23-10:15:53.070195] test: test_malloc: Run Malloc
     3    ==> [2024-07-23-10:15:53.073453] '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpi
          re-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/malloc'
     4    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysd
          baz7rddm636/bin/malloc: error while loading shared libraries: libumpire.so: cannot open shared object file:
           No such file or directory
     5    FAILED: Umpire::test_malloc: Command exited with status 127:
     6        '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas
          3hysdbaz7rddm636/bin/malloc'
  >> 7    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysd
          baz7rddm636/bin/malloc: error while loading shared libraries: libumpire.so: cannot open shared object file:
           No such file or directory
     8    
     9      File "/usr/WS2/lawrence31/spack/bin/spack", line 52, in <module>



Command exited with status 127:
    '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/recipe_dynamic_pool_heuristic'
/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/recipe_dynamic_pool_heuristic: error while loading shared libraries: libumpire.so: cannot open shared object file: No such file or directory



1 error found in test log:
     54        self.gen.throw(typ, value, traceback)
     55    ==> [2024-07-23-10:15:53.122689] test: test_recipe_dynamic_pool_heuristic: Multiple use allocator test
     56    ==> [2024-07-23-10:15:53.124879] '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/ump
           ire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/recipe_dynamic_pool_heuristic'
     57    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hys
           dbaz7rddm636/bin/recipe_dynamic_pool_heuristic: error while loading shared libraries: libumpire.so: cannot
            open shared object file: No such file or directory
     58    FAILED: Umpire::test_recipe_dynamic_pool_heuristic: Command exited with status 127:
     59        '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwna
           s3hysdbaz7rddm636/bin/recipe_dynamic_pool_heuristic'
  >> 60    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hys
           dbaz7rddm636/bin/recipe_dynamic_pool_heuristic: error while loading shared libraries: libumpire.so: cannot
            open shared object file: No such file or directory
     61    
     62      File "/usr/WS2/lawrence31/spack/bin/spack", line 52, in <module>



Command exited with status 127:
    '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/recipe_no_introspection'
/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/recipe_no_introspection: error while loading shared libraries: libumpire.so: cannot open shared object file: No such file or directory



1 error found in test log:
     107        self.gen.throw(typ, value, traceback)
     108    ==> [2024-07-23-10:15:53.147430] test: test_recipe_no_introspection: Test without introspection
     109    ==> [2024-07-23-10:15:53.149741] '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/um
            pire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/recipe_no_introspection'
     110    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hy
            sdbaz7rddm636/bin/recipe_no_introspection: error while loading shared libraries: libumpire.so: cannot ope
            n shared object file: No such file or directory
     111    FAILED: Umpire::test_recipe_no_introspection: Command exited with status 127:
     112        '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwn
            as3hysdbaz7rddm636/bin/recipe_no_introspection'
  >> 113    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hy
            sdbaz7rddm636/bin/recipe_no_introspection: error while loading shared libraries: libumpire.so: cannot ope
            n shared object file: No such file or directory
     114    
     115      File "/usr/WS2/lawrence31/spack/bin/spack", line 52, in <module>
     116        sys.exit(main())
     117      File "/usr/WS2/lawrence31/spack/lib/spack/spack_installable/main.py", line 42, in main
     118        sys.exit(spack.main.main(argv))
     119      File "/usr/WS2/lawrence31/spack/lib/spack/spack/main.py", line 1069, in main



Command exited with status 127:
    '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/strategy_example'
/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/strategy_example: error while loading shared libraries: libumpire.so: cannot open shared object file: No such file or directory



1 error found in test log:
     160        self.gen.throw(typ, value, traceback)
     161    ==> [2024-07-23-10:15:53.189825] test: test_strategy_example: Memory allocation strategy test
     162    ==> [2024-07-23-10:15:53.191940] '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/um
            pire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/strategy_example'
     163    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hy
            sdbaz7rddm636/bin/strategy_example: error while loading shared libraries: libumpire.so: cannot open share
            d object file: No such file or directory
     164    FAILED: Umpire::test_strategy_example: Command exited with status 127:
     165        '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwn
            as3hysdbaz7rddm636/bin/strategy_example'
  >> 166    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hy
            sdbaz7rddm636/bin/strategy_example: error while loading shared libraries: libumpire.so: cannot open share
            d object file: No such file or directory
     167    
     168      File "/usr/WS2/lawrence31/spack/bin/spack", line 52, in <module>
     169        sys.exit(main())
     170      File "/usr/WS2/lawrence31/spack/lib/spack/spack_installable/main.py", line 42, in main
     171        sys.exit(spack.main.main(argv))
     172      File "/usr/WS2/lawrence31/spack/lib/spack/spack/main.py", line 1069, in main



Command exited with status 127:
    '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/tut_copy'
/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/tut_copy: error while loading shared libraries: libumpire.so: cannot open shared object file: No such file or directory



1 error found in test log:
     213        self.gen.throw(typ, value, traceback)
     214    ==> [2024-07-23-10:15:53.247478] test: test_tut_copy: Copy data test
     215    ==> [2024-07-23-10:15:53.249918] '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/um
            pire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/tut_copy'
     216    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hy
            sdbaz7rddm636/bin/tut_copy: error while loading shared libraries: libumpire.so: cannot open shared object
             file: No such file or directory
     217    FAILED: Umpire::test_tut_copy: Command exited with status 127:
     218        '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwn
            as3hysdbaz7rddm636/bin/tut_copy'
  >> 219    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hy
            sdbaz7rddm636/bin/tut_copy: error while loading shared libraries: libumpire.so: cannot open shared object
             file: No such file or directory
     220    
     221      File "/usr/WS2/lawrence31/spack/bin/spack", line 52, in <module>



Command exited with status 127:
    '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/tut_introspection'
/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/tut_introspection: error while loading shared libraries: libumpire.so: cannot open shared object file: No such file or directory



1 error found in test log:
     266        self.gen.throw(typ, value, traceback)
     267    ==> [2024-07-23-10:15:53.281222] test: test_tut_introspection: Keep track of pointer allocation test
     268    ==> [2024-07-23-10:15:53.283451] '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/um
            pire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/tut_introspection'
     269    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hy
            sdbaz7rddm636/bin/tut_introspection: error while loading shared libraries: libumpire.so: cannot open shar
            ed object file: No such file or directory
     270    FAILED: Umpire::test_tut_introspection: Command exited with status 127:
     271        '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwn
            as3hysdbaz7rddm636/bin/tut_introspection'
  >> 272    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hy
            sdbaz7rddm636/bin/tut_introspection: error while loading shared libraries: libumpire.so: cannot open shar
            ed object file: No such file or directory
     273    
     274      File "/usr/WS2/lawrence31/spack/bin/spack", line 52, in <module>



Command exited with status 127:
    '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/tut_memset'
/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/tut_memset: error while loading shared libraries: libumpire.so: cannot open shared object file: No such file or directory



1 error found in test log:
     319        self.gen.throw(typ, value, traceback)
     320    ==> [2024-07-23-10:15:53.319844] test: test_tut_memset: Set entire block of memory to one value test
     321    ==> [2024-07-23-10:15:53.322268] '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/um
            pire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/tut_memset'
     322    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hy
            sdbaz7rddm636/bin/tut_memset: error while loading shared libraries: libumpire.so: cannot open shared obje
            ct file: No such file or directory
     323    FAILED: Umpire::test_tut_memset: Command exited with status 127:
     324        '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwn
            as3hysdbaz7rddm636/bin/tut_memset'
  >> 325    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hy
            sdbaz7rddm636/bin/tut_memset: error while loading shared libraries: libumpire.so: cannot open shared obje
            ct file: No such file or directory
     326    
     327      File "/usr/WS2/lawrence31/spack/bin/spack", line 52, in <module>



Command exited with status 127:
    '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/tut_move'
/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/tut_move: error while loading shared libraries: libumpire.so: cannot open shared object file: No such file or directory



1 error found in test log:
     372        self.gen.throw(typ, value, traceback)
     373    ==> [2024-07-23-10:15:53.373458] test: test_tut_move: Move memory test
     374    ==> [2024-07-23-10:15:53.375674] '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/um
            pire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/tut_move'
     375    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hy
            sdbaz7rddm636/bin/tut_move: error while loading shared libraries: libumpire.so: cannot open shared object
             file: No such file or directory
     376    FAILED: Umpire::test_tut_move: Command exited with status 127:
     377        '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwn
            as3hysdbaz7rddm636/bin/tut_move'
  >> 378    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hy
            sdbaz7rddm636/bin/tut_move: error while loading shared libraries: libumpire.so: cannot open shared object
             file: No such file or directory
     379    
     380      File "/usr/WS2/lawrence31/spack/bin/spack", line 52, in <module>
     381        sys.exit(main())
     382      File "/usr/WS2/lawrence31/spack/lib/spack/spack_installable/main.py", line 42, in main
     383        sys.exit(spack.main.main(argv))
     384      File "/usr/WS2/lawrence31/spack/lib/spack/spack/main.py", line 1069, in main



Command exited with status 127:
    '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/tut_reallocate'
/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/tut_reallocate: error while loading shared libraries: libumpire.so: cannot open shared object file: No such file or directory



1 error found in test log:
     425        self.gen.throw(typ, value, traceback)
     426    ==> [2024-07-23-10:15:53.471614] test: test_tut_reallocate: Reallocate memory test
     427    ==> [2024-07-23-10:15:53.474055] '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/um
            pire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/tut_reallocate'
     428    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hy
            sdbaz7rddm636/bin/tut_reallocate: error while loading shared libraries: libumpire.so: cannot open shared 
            object file: No such file or directory
     429    FAILED: Umpire::test_tut_reallocate: Command exited with status 127:
     430        '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwn
            as3hysdbaz7rddm636/bin/tut_reallocate'
  >> 431    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hy
            sdbaz7rddm636/bin/tut_reallocate: error while loading shared libraries: libumpire.so: cannot open shared 
            object file: No such file or directory
     432    
     433      File "/usr/WS2/lawrence31/spack/bin/spack", line 52, in <module>
     434        sys.exit(main())
     435      File "/usr/WS2/lawrence31/spack/lib/spack/spack_installable/main.py", line 42, in main
     436        sys.exit(spack.main.main(argv))
     437      File "/usr/WS2/lawrence31/spack/lib/spack/spack/main.py", line 1069, in main



Command exited with status 127:
    '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/vector_allocator'
/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/vector_allocator: error while loading shared libraries: libumpire.so: cannot open shared object file: No such file or directory



1 error found in test log:
     478        self.gen.throw(typ, value, traceback)
     479    ==> [2024-07-23-10:15:53.561459] test: test_vector_allocator: Allocate vector memory test
     480    ==> [2024-07-23-10:15:53.564368] '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/um
            pire-2024.02.1-mrzsrklp7ymtwnas3hysdbaz7rddm636/bin/vector_allocator'
     481    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hy
            sdbaz7rddm636/bin/vector_allocator: error while loading shared libraries: libumpire.so: cannot open share
            d object file: No such file or directory
     482    FAILED: Umpire::test_vector_allocator: Command exited with status 127:
     483        '/usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwn
            as3hysdbaz7rddm636/bin/vector_allocator'
  >> 484    /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/umpire-2024.02.1-mrzsrklp7ymtwnas3hy
            sdbaz7rddm636/bin/vector_allocator: error while loading shared libraries: libumpire.so: cannot open share
            d object file: No such file or directory
     485    
     486      File "/usr/WS2/lawrence31/spack/bin/spack", line 52, in <module>
     487        sys.exit(main())
     488      File "/usr/WS2/lawrence31/spack/lib/spack/spack_installable/main.py", line 42, in main
     489        sys.exit(spack.main.main(argv))
     490      File "/usr/WS2/lawrence31/spack/lib/spack/spack/main.py", line 1069, in main
```