### PR TITLE
vtk: update vtk to 9.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -20,7 +20,7 @@ class Vtk(CMakePackage):
     url = "https://www.vtk.org/files/release/9.0/VTK-9.0.0.tar.gz"
     list_url = "https://www.vtk.org/download/"
 
-    maintainers("chuckatkins", "danlipsa")
+    maintainers("danlipsa", "vicentebolea")
 
     license("BSD-3-Clause")
 

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -24,6 +24,11 @@ class Vtk(CMakePackage):
 
     license("BSD-3-Clause")
 
+    version(
+        "9.3.1",
+        sha256="8354ec084ea0d2dc3d23dbe4243823c4bfc270382d0ce8d658939fd50061cab8",
+        preferred=True,
+    )
     version("9.2.6", sha256="06fc8d49c4e56f498c40fcb38a563ed8d4ec31358d0101e8988f0bb4d539dd12")
     version("9.2.2", sha256="1c5b0a2be71fac96ff4831af69e350f7a0ea3168981f790c000709dcf9121075")
     version("9.1.0", sha256="8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96")
@@ -278,6 +283,7 @@ class Vtk(CMakePackage):
             cmake_args.extend(
                 [
                     "-DVTK_USE_EXTERNAL:BOOL=ON",
+                    "-DVTK_MODULE_USE_EXTERNAL_VTK_fast_float:BOOL=OFF",
                     "-DVTK_MODULE_USE_EXTERNAL_VTK_libharu:BOOL=OFF",
                     "-DVTK_MODULE_USE_EXTERNAL_VTK_pegtl:BOOL=OFF",
                     "-DHDF5_ROOT={0}".format(spec["hdf5"].prefix),


### PR DESCRIPTION
:tada: :tada: :tada: 


Finally! VTK 9.3.1 release is out.

This bring exiting new features and bugfixes. Find the release notes at https://gitlab.kitware.com/vtk/vtk/-/blob/master/Documentation/release/9.3.md

Let me know if we need to change anything else in the package

ViB

:tada: :tada: :tada: