### PR TITLE
py-scipy: add v1.14.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-pythran/package.py
+++ b/var/spack/repos/builtin/packages/py-pythran/package.py
@@ -39,8 +39,8 @@ class PyPythran(PythonPackage):
     version("0.9.3", sha256="217427a8225a331fdc8f3efe57871aed775cdf2c6e847a0a83df0aaae4b02493")
 
     # https://github.com/serge-sans-paille/pythran/pull/2196
-    depends_on("py-setuptools@62:", when="@0.15:", type="build")
-    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@62:", when="@0.15:", type=("build", "run"))
+    depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-ply@3.4:", type=("build", "run"))
     depends_on("py-gast@0.5", when="@0.15:", type=("build", "run"))
     # upper bound due to https://github.com/scipy/scipy/issues/18390

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -18,6 +18,7 @@ class PyScipy(PythonPackage):
     license("BSD-3-Clause")
 
     version("main", branch="main")
+    version("1.14.0", sha256="b5923f48cb840380f9854339176ef21763118a7300a88203ccd0bdd26e58527b")
     version("1.13.1", sha256="095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c")
     version("1.13.0", sha256="58569af537ea29d3f78e5abd18398459f195546bb3be23d16677fb26616cc11e")
     version("1.12.0", sha256="4bf5abab8a36d20193c698b0f1fc282c1d083c94723902c447e5d2f1780936a3")
@@ -54,7 +55,8 @@ class PyScipy(PythonPackage):
 
     # Based on wheel availability on PyPI
     with default_args(type=("build", "link", "run")):
-        depends_on("python@3.9:3.12", when="@1.11.2:")
+        depends_on("python@3.10:3.12", when="@1.14:")
+        depends_on("python@3.9:3.12", when="@1.11.2:1.13")
         depends_on("python@3.8:3.11", when="@1.9.2:1.11.1")
         depends_on("python@3.8:3.10", when="@1.8:1.9.1")
         depends_on("python@:3.10", when="@1.7.2:1.7")
@@ -92,7 +94,8 @@ class PyScipy(PythonPackage):
 
     # Run dependencies
     with default_args(type=("build", "link", "run")):
-        depends_on("py-numpy@1.22.4:2.2", when="@1.13:")
+        depends_on("py-numpy@1.23.5:2.2", when="@1.14:")
+        depends_on("py-numpy@1.22.4:2.2", when="@1.13")
         depends_on("py-numpy@1.22.4:1.28", when="@1.12")
         depends_on("py-numpy@1.21.6:1.27", when="@1.11")
         depends_on("py-numpy@1.19.5:1.26", when="@1.10")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
https://github.com/scipy/scipy/releases/tag/v1.14.0

@rgommers I would be interested in getting Accelerate working in the future. Spack only supports a single BLAS/LAPACK library in the DAG at a time. If I understand correctly, SciPy supports Accelerate now, but NumPy still doesn't? Are there plans for NumPy to support Accelerate? I don't even know where to start with adding an Accelerate package to Spack, not sure if you know where libraries live, how to check what versions are present, how those versions map to BLAS/LAPACK API versions, etc.