### PR TITLE
Adding platform independent code flag to resolve llvm failure

### DIFF
--- a/var/spack/repos/builtin/packages/libffi/package.py
+++ b/var/spack/repos/builtin/packages/libffi/package.py
@@ -68,4 +68,5 @@ class Libffi(AutotoolsPackage):
         # See: https://github.com/libffi/libffi/issues/571
         if self.spec.satisfies("platform=darwin target=aarch64:"):
             args.append("--build=aarch64-apple-darwin")
+        args.append("CFLAGS=-fPIC")
         return args

--- a/var/spack/repos/builtin/packages/libffi/package.py
+++ b/var/spack/repos/builtin/packages/libffi/package.py
@@ -58,7 +58,7 @@ class Libffi(AutotoolsPackage):
         return (flags, None, None)
 
     def configure_args(self):
-        args = []
+        args = ["--with-pic"]
         if self.spec.version >= Version("3.3"):
             # Spack adds its own target flags, so tell libffi not to
             # second-guess us
@@ -68,5 +68,4 @@ class Libffi(AutotoolsPackage):
         # See: https://github.com/libffi/libffi/issues/571
         if self.spec.satisfies("platform=darwin target=aarch64:"):
             args.append("--build=aarch64-apple-darwin")
-        args.append("CFLAGS=-fPIC")
         return args


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
