### PR TITLE
neoverse-v1: comment out py-cinemasci

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse_v1/spack.yaml
@@ -167,7 +167,7 @@ spack:
   - libcatalyst
   - parallel-netcdf
   - paraview
-  - py-cinemasci
+  # - py-cinemasci
   - sz
   - unifyfs
   - veloc


### PR DESCRIPTION
py-cinemasci is taking too long to concretize since yesterday. Comment it out while we investigate the failure.

One thing to note is that, while `py-cinemasci` on its own takes a moderately long time in each pipeline:
- It fails only on neoverse-v1 since https://gitlab.spack.io/spack/spack/-/pipelines/747820 (https://gitlab.spack.io/spack/spack/-/pipelines/747436 was not failing)
- The same spec concretized as a dependency of another `ecp-data-vis-sdk` is fine

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
