### PR TITLE
cmd/develop.py: fix readability

### DIFF
--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -9,6 +9,8 @@ import llnl.util.tty as tty
 
 import spack.cmd
 import spack.config
+import spack.fetch_strategy
+import spack.repo
 import spack.spec
 import spack.util.path
 import spack.version
@@ -69,14 +71,15 @@ def _retrieve_develop_source(spec, abspath):
     # We construct a package class ourselves, rather than asking for
     # Spec.package, since Spec only allows this when it is concrete
     package = pkg_cls(spec)
-    if isinstance(package.stage[0].fetcher, spack.fetch_strategy.GitFetchStrategy):
-        package.stage[0].fetcher.get_full_repo = True
+    source_stage = package.stage[0]
+    if isinstance(source_stage.fetcher, spack.fetch_strategy.GitFetchStrategy):
+        source_stage.fetcher.get_full_repo = True
         # If we retrieved this version before and cached it, we may have
         # done so without cloning the full git repo; likewise, any
         # mirror might store an instance with truncated history.
-        package.stage[0].disable_mirrors()
+        source_stage.disable_mirrors()
 
-    package.stage[0].fetcher.set_package(package)
+    source_stage.fetcher.set_package(package)
     package.stage.steal_source(abspath)
 
 


### PR DESCRIPTION
stage[0] is assumed to be for sources, 1: and onwards is
patches/resources, make that a bit more clear.

the implementation isn't very satisfactory cause it fetches
some (unconditional) patches too, but does not apply them, because
that requires a concrete spec.

patches are only applied upon install, at which point even
more may be fetched...