### PR TITLE
netlib-lapack: provide blas and lapack together

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -108,8 +108,9 @@ class NetlibLapack(CMakePackage):
     # https://github.com/Reference-LAPACK/lapack/pull/268
     patch("testing.patch", when="@3.7.0:3.8")
 
-    # virtual dependency
-    provides("blas", when="~external-blas")
+    # liblapack links to libblas, so if this package is used as a lapack
+    # provider, it must also provide blas.
+    provides("lapack", "blas", when="~external-blas")
     provides("lapack")
 
     depends_on("blas", when="+external-blas")


### PR DESCRIPTION
If netlib-lapack is built with ~external-blas, it internally links
liblapack.so with libblas.so, meaning that whenever netlib-lapack is
used as a lapack provider, the package must also be a blas provider.

Conversely using netlib-lapack as a blas provider does not imply that it
also must provide lapack, but nothing is lost disallowing that...

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
