### PR TITLE
[intel-oneapi-mpi]: restore support for classic wrapper names

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -129,6 +129,7 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
     depends_on("libfabric", when="+external-libfabric", type=("link", "run"))
 
     provides("mpi@:3.1")
+    conflicts("+generic-names +classic-names")
 
     @property
     def mpiexec(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -159,7 +159,7 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
 
     def wrapper_paths(self):
         return [self.component_prefix.bin.join(name) for name in self.wrapper_names()]
-    
+
     def setup_dependent_package(self, module, dep_spec):
         wrappers = self.wrapper_paths()
         self.spec.mpicc = wrappers[0]


### PR DESCRIPTION
https://github.com/spack/spack/pull/44688 switched default for wrapper names from classic to oneapi (icc->icx). Some people still need to use classic compilers. See the comments for that PR. Add +classic-names variant to request classic names. This is similar to +generic-names variant which is already there.

I don't have a good test for this fucntionality so I compiled:
```
spack install fftw +mpi ^intel-oneapi-mpi +classic-names
```
and inspected the `spack-build-env.txt` file


