### PR TITLE
migraphx: Old to new test API

### DIFF
--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -134,6 +134,5 @@ class Migraphx(CMakePackage):
     def test_dirvers(self):
         if self.spec.satisfies("@:5.5.0"):
             raise SkipTest("Package must be installed as version @5.5.1 or later")
-        test_dir = join_path(self.spec["migraphx"].prefix, "bin")
         exe = which("migraphx-driver", "migraphx-hiprtc-driver")
         exe()

--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -135,5 +135,7 @@ class Migraphx(CMakePackage):
         """Test drivers"""
         if self.spec.satisfies("@:5.5.0"):
             raise SkipTest("Package must be installed as version @5.5.1 or later")
-        exe = which("migraphx-driver", "migraphx-hiprtc-driver")
-        exe()
+        test_dir = join_path(self.spec["migraphx"].prefix, "bin")
+        with working_dir(test_dir, create=True):
+            exe = which("UnitTests")
+            exe()

--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -131,7 +131,8 @@ class Migraphx(CMakePackage):
             )
         return args
 
-    def test_dirvers(self):
+    def test_drivers(self):
+        """Test drivers"""
         if self.spec.satisfies("@:5.5.0"):
             raise SkipTest("Package must be installed as version @5.5.1 or later")
         exe = which("migraphx-driver", "migraphx-hiprtc-driver")

--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -133,8 +133,7 @@ class Migraphx(CMakePackage):
 
     def test(self):
         if self.spec.satisfies("@:5.5.0"):
-            print("Skipping: stand-alone tests")
-            return
+            raise SkipTest("Package must be installed as version @5.5.1 or later")
         test_dir = join_path(self.spec["migraphx"].prefix, "bin")
-        with working_dir(test_dir, create=True):
-            self.run_test("UnitTests")
+        exe = which("migraphx-driver", "migraphx-hiprtc-driver")
+        exe()

--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -131,7 +131,7 @@ class Migraphx(CMakePackage):
             )
         return args
 
-    def test(self):
+    def test_dirvers(self):
         if self.spec.satisfies("@:5.5.0"):
             raise SkipTest("Package must be installed as version @5.5.1 or later")
         test_dir = join_path(self.spec["migraphx"].prefix, "bin")

--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -131,8 +131,8 @@ class Migraphx(CMakePackage):
             )
         return args
 
-    def test_drivers(self):
-        """Test drivers"""
+    def test_unit_tests(self):
+        """Run installed UnitTests"""
         if self.spec.satisfies("@:5.5.0"):
             raise SkipTest("Package must be installed as version @5.5.1 or later")
         unit_tests = which(self.prefix.bin.UnitTests)

--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -135,7 +135,6 @@ class Migraphx(CMakePackage):
         """Test drivers"""
         if self.spec.satisfies("@:5.5.0"):
             raise SkipTest("Package must be installed as version @5.5.1 or later")
-        test_dir = join_path(self.spec["migraphx"].prefix, "bin")
-        with working_dir(test_dir, create=True):
-            exe = which("UnitTests")
-            exe()
+        unit_tests = which("UnitTests")
+        assert unit_tests is not None, "UnitTests is not installed!"
+        unit_tests()

--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -135,6 +135,6 @@ class Migraphx(CMakePackage):
         """Test drivers"""
         if self.spec.satisfies("@:5.5.0"):
             raise SkipTest("Package must be installed as version @5.5.1 or later")
-        unit_tests = which("UnitTests")
+        unit_tests = which(self.prefix.bin.UnitTests)
         assert unit_tests is not None, "UnitTests is not installed!"
         unit_tests()


### PR DESCRIPTION
Update standalone testing API. See below comment below for test output.

```
$ spack -v test run migraphx
==> Spack test auzdcasfssqtxxjxbkqy75tw4exncjlz
==> Testing package migraphx-6.1.1-kzk2uav
==> [2024-08-12-16:52:11.110464] test: test_unit_tests: Run installed UnitTests
FAILED: Migraphx::test_unit_tests: UnitTests is not installed!
...
==> [2024-08-12-16:52:11.127173] Completed testing
==> [2024-08-12-16:52:11.127278] 
======================= SUMMARY: migraphx-6.1.1-kzk2uav ========================
Migraphx::test_unit_tests .. FAILED
============================= 1 failed of 1 parts ==============================
```