### PR TITLE
spack_yaml: add anchorify function

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -22,6 +22,8 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import HTTPHandler, Request, build_opener
 
+import ruamel.yaml
+
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 from llnl.util.lang import memoized
@@ -1310,8 +1312,11 @@ def generate_gitlab_ci_yaml(
         if not rebuild_everything:
             sys.exit(1)
 
-    with open(output_file, "w") as outf:
-        outf.write(syaml.dump(sorted_output, default_flow_style=True))
+    # Minimize yaml output size through use of anchors
+    syaml.anchorify(sorted_output)
+
+    with open(output_file, "w") as f:
+        ruamel.yaml.YAML().dump(sorted_output, f)
 
 
 def _url_encode_string(input_string):

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -534,11 +534,12 @@ b: *id001
 
 
 def test_anchorify_2():
-    before = {"a": {"b": {"c": True}}, "d": {"c": True}, "e": {"c": True}}
-    after = {"a": {"b": {"c": True}}, "d": {"c": True}, "e": {"c": True}}
+    before = {"a": {"b": {"c": True}}, "d": {"b": {"c": True}}, "e": {"c": True}}
+    after = {"a": {"b": {"c": True}}, "d": {"b": {"c": True}}, "e": {"c": True}}
     syaml.anchorify(after)
     assert before == after
-    assert after["a"]["b"] is after["d"] is after["e"]
+    assert after["a"] is after["d"]
+    assert after["a"]["b"] is after["e"]
 
     # Check if anchors are used
     out = io.StringIO()
@@ -546,10 +547,10 @@ def test_anchorify_2():
     assert (
         out.getvalue()
         == """\
-a:
-  b: &id001
+a: &id001
+  b: &id002
     c: true
 d: *id001
-e: *id001
+e: *id002
 """
     )

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -13,10 +13,12 @@ import collections
 import collections.abc
 import gzip
 import inspect
+import io
 import json
 import os
 
 import pytest
+import ruamel.yaml
 
 import spack.hash_types as ht
 import spack.paths
@@ -505,3 +507,49 @@ def test_load_json_specfiles(specfile, expected_hash, reader_cls):
     # JSON or YAML file, not a list
     for edge in s2.traverse_edges():
         assert isinstance(edge.virtuals, tuple), edge
+
+
+def test_anchorify_1():
+    """Test that anchorify replaces duplicate values with references to a single instance, and
+    that that results in anchors in the output YAML."""
+    before = {"a": [1, 2, 3], "b": [1, 2, 3]}
+    after = {"a": [1, 2, 3], "b": [1, 2, 3]}
+    syaml.anchorify(after)
+    assert before == after
+    assert after["a"] is after["b"]
+
+    # Check if anchors are used
+    out = io.StringIO()
+    ruamel.yaml.YAML().dump(after, out)
+    assert (
+        out.getvalue()
+        == """\
+a: &id001
+- 1
+- 2
+- 3
+b: *id001
+"""
+    )
+
+
+def test_anchorify_2():
+    before = {"a": {"b": {"c": True}}, "d": {"c": True}, "e": {"c": True}}
+    after = {"a": {"b": {"c": True}}, "d": {"c": True}, "e": {"c": True}}
+    syaml.anchorify(after)
+    assert before == after
+    assert after["a"]["b"] is after["d"] is after["e"]
+
+    # Check if anchors are used
+    out = io.StringIO()
+    ruamel.yaml.YAML().dump(after, out)
+    assert (
+        out.getvalue()
+        == """\
+a:
+  b: &id001
+    c: true
+d: *id001
+e: *id001
+"""
+    )

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -494,8 +494,8 @@ def name_mark(name):
 
 
 def anchorify(data: Union[dict, list], identifier: Callable[[Any], str] = repr) -> None:
-    """Modify a dict/list tree structure in-place, replacing identical branches with references to
-    earlier instances. The YAML serializer generate anchors then, resulting in small yaml files."""
+    """Replace identical branches in tree structure with references to earlier instances. The YAML
+    serializer generate anchors for them, resulting in small yaml files."""
     anchors: Dict[str, Any] = {}
     queue: List[Union[dict, list]] = [data]
 
@@ -503,17 +503,16 @@ def anchorify(data: Union[dict, list], identifier: Callable[[Any], str] = repr) 
         item = queue.pop()
 
         for key, value in item.items() if isinstance(item, dict) else enumerate(item):
+            if not isinstance(value, (dict, list)):
+                continue
+
             id = identifier(value)
             anchor = anchors.get(id)
 
-            # Replace value with back reference if seen before
             if anchor is not None:
                 item[key] = anchor
-                continue
-
-            anchors[id] = value
-
-            if isinstance(value, (dict, list)):
+            else:
+                anchors[id] = value
                 queue.append(value)
 
 

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -494,9 +494,9 @@ def name_mark(name):
 
 
 def anchorify(data: Union[dict, list], identifier: Callable[[Any], str] = repr) -> None:
-    """Replace identical branches in tree structure with references to earlier instances. The YAML
+    """Replace identical dict/list branches in tree with references to earlier instances. The YAML
     serializer generate anchors for them, resulting in small yaml files."""
-    anchors: Dict[str, Any] = {}
+    anchors: Dict[str, Union[dict, list]] = {}
     queue: List[Union[dict, list]] = [data]
 
     while queue:
@@ -509,11 +509,11 @@ def anchorify(data: Union[dict, list], identifier: Callable[[Any], str] = repr) 
             id = identifier(value)
             anchor = anchors.get(id)
 
-            if anchor is not None:
-                item[key] = anchor
-            else:
+            if anchor is None:
                 anchors[id] = value
                 queue.append(value)
+            else:
+                item[key] = anchor  # replace with reference
 
 
 class SpackYAMLError(spack.error.SpackError):

--- a/var/spack/repos/builtin/packages/zlib-ng/package.py
+++ b/var/spack/repos/builtin/packages/zlib-ng/package.py
@@ -77,7 +77,7 @@ class AutotoolsBuilder(autotools.AutotoolsBuilder):
             filter_file(r"^gcc=0$", "gcc=1", join_path(self.configure_directory, "configure"))
 
     def configure_args(self):
-        args = ["--with-please-remove-me"]
+        args = []
         if self.spec.satisfies("+compat"):
             args.append("--zlib-compat")
         if self.spec.satisfies("~opt"):

--- a/var/spack/repos/builtin/packages/zlib-ng/package.py
+++ b/var/spack/repos/builtin/packages/zlib-ng/package.py
@@ -77,7 +77,7 @@ class AutotoolsBuilder(autotools.AutotoolsBuilder):
             filter_file(r"^gcc=0$", "gcc=1", join_path(self.configure_directory, "configure"))
 
     def configure_args(self):
-        args = []
+        args = ["--with-please-remove-me"]
         if self.spec.satisfies("+compat"):
             args.append("--zlib-compat")
         if self.spec.satisfies("~opt"):


### PR DESCRIPTION
This adds `spack.util.spack_yaml.anchorify`, which takes a tree
structure, and replaces identical branches with (back) references
to the first instance, so that yaml serialization will use
anchors.

`repr` is used to (recursively) identify values/branches, which makes things
quadratric complexity worst case, but in practice the tree depth is O(1)
and many anchors will avoid traversal in repeated branches, meaning that
it's OK.

Then this is used in CI to reduce the size of generated YAML files to
a third of their original size.

This way we can revert #44986

Example: https://gitlab.spack.io/spack/spack/-/jobs/11781337/artifacts/raw/jobs_scratch_dir/cloud-ci-pipeline.yml (596KB instead of 1.8MB)