### PR TITLE
[openfoam]: use latest cgal

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -124,6 +124,7 @@ spack:
   - netlib-scalapack
   - nrm
   - omega-h
+  - openfoam
   - openmpi
   - papi
   - papyrus
@@ -189,7 +190,6 @@ spack:
   # - glvis ^llvm                                             # glvis: https://github.com/spack/spack/issues/42839
   # - hpctoolkit                                              # dyninst@12.3.0%gcc: /usr/bin/ld: libiberty/./d-demangle.c:142: undefined reference to `_intel_fast_memcpy'; can't mix intel-tbb@%oneapi with dyninst%gcc
   # - mgard +serial +openmp +timing +unstructured ~cuda       # mgard: mgard.tpp:63:48: error: non-constant-expression cannot be narrowed from type 'int' to 'unsigned long' in initializer list [-Wc++11-narrowing]
-  # - openfoam                                                # cgal: https://github.com/spack/spack/issues/39481
   # - openpmd-api                                             # mgard:  mgard.tpp:63:48: error: non-constant-expression cannot be narrowed from type 'int' to 'unsigned long' in initializer list [-Wc++11-narrowing]
   # - pdt                                                     # pdt: pdbType.cc:193:21: warning: ISO C++11 does not allow conversion from string literal to 'char *' [-Wwritable-strings]
   # - quantum-espresso                                        # quantum-espresso@7.2 /i3fqdx5: warning: <unknown>:0:0: loop not unroll-and-jammed: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering

--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -369,8 +369,9 @@ class Openfoam(Package):
     # See https://github.com/spack/spack/pull/22303 for reference
     depends_on(Boost.with_default_variants)
 
-    # OpenFOAM does not play nice with CGAL 5.X
-    depends_on("cgal@:4")
+    # Earlier versions of OpenFOAM did not play nice with CGAL 5.X
+    depends_on("cgal")
+
     # The flex restriction is ONLY to deal with a spec resolution clash
     # introduced by the restriction within scotch!
     depends_on("flex@:2.6.1,2.6.4:")

--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -369,8 +369,11 @@ class Openfoam(Package):
     # See https://github.com/spack/spack/pull/22303 for reference
     depends_on(Boost.with_default_variants)
 
-    # Earlier versions of OpenFOAM did not play nice with CGAL 5.X
-    depends_on("cgal")
+    # Earlier versions of OpenFOAM may not work with CGAL 5.6. I do
+    # not know which OpenFOAM added support for 5.x and conservatively
+    # use 2312 in the check.
+    depends_on("cgal", when="@2312:")
+    depends_on("cgal@:4", when="@:2306")
 
     # The flex restriction is ONLY to deal with a spec resolution clash
     # introduced by the restriction within scotch!


### PR DESCRIPTION
Enable openfoam in e4s oneapi.

openfoam could not build with `%oneapi` because it depends on `cgal%4` and there was a build issue. This restriction was added 3 years ago: https://github.com/spack/spack/pull/22474

Now openfoam works with cgal 5.x. 
https://develop.openfoam.com/Development/openfoam/blob/develop/doc/Requirements.md

Removed the restriction. I don't know when cgal 5.x support was added so I removed the restriction entirely. 

Resolves: https://github.com/spack/spack/issues/39481
