### PR TITLE
environments.rst: go from simple to advanced

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -940,7 +940,7 @@ with a more traditional structure ``<view>/bin``, ``<view>/lib``, ``<view>/inclu
 in which all files of the installed packages are linked.
 
 By default a view is created for each environment, thanks to the ``view: true``
-option in the manifest file:
+option in the ``spack.yaml`` manifest file:
 
 .. code-block:: yaml
 
@@ -955,13 +955,13 @@ you can directly run executables from all installed packages in the environment.
 
 Views are highly customizable: you can control where they are put, modify their structure,
 include and exclude specs, change how files are linked, and you can even generate multiple
-views for a single environment. The following sections describe advanced view configuration.
+views for a single environment.
 
 .. _configuring_environment_views:
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Configuration in ``spack.yaml``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+Minimal view configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The minimal configuration
 
@@ -982,9 +982,15 @@ Another short way to configure a view is to specify just where to put it:
      # ...
      view: /path/to/view
 
-For more advanced configuration, one ore more **view descriptors** can be defined 
-under the ``view`` key, each with a name. The short configuration we have seen
-so far is equivalent to the following:
+Views can also be disabled by setting ``view: false``.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Advanced view configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+One or more **view descriptors** can be defined under ``view``, keyed by a name.
+The example from the previous section with ``view: /path/to/view`` is equivalent
+to defining a view descriptor named ``default`` with a ``root`` attribute:
 
 .. code-block:: yaml
 
@@ -992,11 +998,15 @@ so far is equivalent to the following:
      # ...
      view:
        default:  # name of the view
-         root: /path/to/view  # view descriptor
+         root: /path/to/view  # view descriptor attribute
 
-The view descriptor contains the root of the view, and optionally the projections
-for the view, ``select`` and ``exclude`` lists for the view and link information via
-``link`` and ``link_type``.
+The ``default`` view descriptor name is special: when you ``spack env activate`` your
+environment, this view will be used to update (among other things) your ``PATH``
+variable.
+
+View descriptors must contain the root of the view, and optionally projections,
+``select`` and ``exclude`` lists and link information via ``link`` and
+``link_type``.
 
 As a more advanced example, in the following manifest
 file snippet we define a view named ``mpis``, rooted at

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -1122,11 +1122,18 @@ the projection under ``all`` before reaching those entries.
 Activating environment views
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``spack env activate`` command will put the default view for the
-environment into the user's path, in addition to activating the
-environment for Spack commands. The arguments ``-v,--with-view`` and
-``-V,--without-view`` can be used to tune this behavior. The default
-behavior is to activate with the environment view if there is one.
+The ``spack env activate <env>`` has two effects:
+
+1. It activates the environment so that further Spack commands such
+   as ``spack install`` will run in the context of the environment.
+2. It activates the view so that environment variables such as
+   ``PATH`` are updated to include the view.
+
+Without further arguments, the ``default`` view of the environment is
+activated. If a view with a different name has to be activated,
+``spack env activate --with-view <name> <env>`` can be
+used instead. You can also activate the environment without modifying
+further environment variables using ``--without-view``.
 
 The environment variables affected by the ``spack env activate``
 command and the paths that are used to update them are determined by
@@ -1149,8 +1156,8 @@ relevant variable if the path exists. For this reason, it is not
 recommended to use non-default projections with the default view of an
 environment.
 
-The ``spack env deactivate`` command will remove the default view of
-the environment from the user's path.
+The ``spack env deactivate`` command will remove the active view of
+the Spack environment from the user's environment variables.
 
 
 .. _env-generate-depfile:


### PR DESCRIPTION
Previously it went from advanced example to "by the way, there is short config too".

Also I think it's better to call the section "environment views", cause that's what people
probably google?