### PR TITLE
pinentry: old to new test API

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -408,39 +408,45 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         self.cache_extra_test_sources(cmake_out_path)
         self.cmake_bin(set=True)
 
-    def build_tests(self, cmake_path):
+    def test_build(self):
         """Build test."""
-        cmake_bin = self.cmake_bin(set=False)
-
-        if not cmake_bin:
-            tty.msg("Skipping kokkos test: cmake_bin_path.txt not found")
-            return
-
-        cmake_args = [cmake_path, "-DEXECUTABLE_OUTPUT_PATH=" + cmake_path]
-
-        if not self.run_test(cmake_bin, options=cmake_args, purpose="Generate the Makefile"):
-            tty.warn("Skipping kokkos test: failed to generate Makefile")
-            return
-
-        if not self.run_test("make", purpose="Build test software"):
-            tty.warn("Skipping kokkos test: failed to build test")
-
-    def run_tests(self, cmake_path):
-        """Run test."""
-        if not self.run_test(
-            "make", options=[cmake_path, "test"], purpose="Checking ability to execute."
-        ):
-            tty.warn("Failed to run kokkos test")
-
-    def test(self):
         # Skip if unsupported version
         cmake_path = join_path(
             self.test_suite.current_test_cache_dir, self.test_script_relative_path, "out"
         )
 
         if not os.path.exists(cmake_path):
-            tty.warn("Skipping smoke tests: {0} is missing".format(cmake_path))
-            return
+            raise SkipTest(f"{cmake_path} is missing")
 
-        self.build_tests(cmake_path)
-        self.run_tests(cmake_path)
+        cmake_bin = self.cmake_bin(set=False)
+        if not cmake_bin:
+            assert False, "cmake_bin_path.txt not found"
+
+        try:
+            exe = which(cmake_bin)
+            exe(cmake_path, "-DEXECUTABLE_OUTPUT_PATH=" + cmake_path)
+        except:
+            assert False, "Failed to generate the MakeFile"
+
+        try:
+            make = which("make")
+            make()
+        except:
+            assert False, "Failed to build test"
+
+    def test_run(self):
+        """Test if kokkos runs"""
+        # Skip if unsupported version
+        cmake_path = join_path(
+            self.test_suite.current_test_cache_dir, self.test_script_relative_path, "out"
+        )
+
+        if not os.path.exists(cmake_path):
+            raise SkipTest(f"{cmake_path} is missing")
+
+        """Run test."""
+        try:
+            exe = which("make")
+            exe(cmake_path, "test")
+        except:
+            assert False, "Failed to run kokkos test"

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -422,17 +422,11 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         if not cmake_bin:
             assert False, "cmake_bin_path.txt not found"
 
-        try:
-            exe = which(cmake_bin)
-            exe(cmake_path, "-DEXECUTABLE_OUTPUT_PATH=" + cmake_path)
-        except:
-            assert False, "Failed to generate the MakeFile"
+        exe = which(cmake_bin)
+        exe(cmake_path, "-DEXECUTABLE_OUTPUT_PATH=" + cmake_path)
 
-        try:
-            make = which("make")
-            make()
-        except:
-            assert False, "Failed to build test"
+        make = which("make")
+        make()
 
     def test_run(self):
         """Test if kokkos runs"""
@@ -444,9 +438,5 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         if not os.path.exists(cmake_path):
             raise SkipTest(f"{cmake_path} is missing")
 
-        """Run test."""
-        try:
-            exe = which("make")
-            exe(cmake_path, "test")
-        except:
-            assert False, "Failed to run kokkos test"
+        exe = which("make")
+        exe(cmake_path, "test")

--- a/var/spack/repos/builtin/packages/pinentry/package.py
+++ b/var/spack/repos/builtin/packages/pinentry/package.py
@@ -95,7 +95,7 @@ class Pinentry(AutotoolsPackage):
     def check_version(self, gui):
         """Version check"""
         exe = which(self.prefix.bin.pinentry + "-" + gui)
-        out = exe("--version", output=str.split, error=str.split)
+        exe("--version", output=str.split, error=str.split)
 
     def test_pinentry(self):
         """Confirm pinentry version"""

--- a/var/spack/repos/builtin/packages/pinentry/package.py
+++ b/var/spack/repos/builtin/packages/pinentry/package.py
@@ -6,6 +6,7 @@
 
 from spack.package import *
 
+
 class Pinentry(AutotoolsPackage):
     """pinentry is a small collection of dialog programs that allow GnuPG to
     read passphrases and PIN numbers in a secure manner.

--- a/var/spack/repos/builtin/packages/pinentry/package.py
+++ b/var/spack/repos/builtin/packages/pinentry/package.py
@@ -92,27 +92,21 @@ class Pinentry(AutotoolsPackage):
                 args.append("--disable-pinentry-" + gui)
         return args
 
-    def check_version(self, gui):
+    def check_version(self, exe_name):
         """Version check"""
-        exe = which(self.prefix.bin.pinentry + "-" + gui)
+        exe = which(join_path(self.prefix.bin, exe_name))
         out = exe("--version", output=str.split, error=str.split)
         assert str(self.version) in out
 
     def test_pinentry(self):
         """Confirm pinentry version"""
-        exe = which(self.prefix.bin.pinentry)
-        out = exe("--version", output=str.split, error=str.split)
-        assert str(self.version) in out
+        self.check_version("pinentry")
 
     def test_guis(self):
         """Check gui versions"""
         for gui in self.supported_guis:
-            exe = which(self.prefix.bin.pinentry + "-" + gui)
-            with test_part(
-                self, "test_guis_" + gui, purpose="Check " + gui + "and os path basename"
-            ):
-                if "gui=" + gui not in self.spec:
+            exe_name = f"pinentry-{gui}"
+            with test_part(self, f"test_guis_{gui}", purpose=f"Check {exe_name} version"):
+                if f"gui={gui}" not in self.spec:
                     raise SkipTest(f"Package must be installed with {gui}")
-                self.check_version(gui)
-                out = exe("--version", output=str.split, error=str.split)
-                assert str(self.version) in out, "Wrong version!"
+                self.check_version(exe_name)

--- a/var/spack/repos/builtin/packages/pinentry/package.py
+++ b/var/spack/repos/builtin/packages/pinentry/package.py
@@ -6,7 +6,6 @@
 
 from spack.package import *
 
-
 class Pinentry(AutotoolsPackage):
     """pinentry is a small collection of dialog programs that allow GnuPG to
     read passphrases and PIN numbers in a secure manner.

--- a/var/spack/repos/builtin/packages/pinentry/package.py
+++ b/var/spack/repos/builtin/packages/pinentry/package.py
@@ -91,17 +91,24 @@ class Pinentry(AutotoolsPackage):
                 args.append("--enable-pinentry-" + gui)
             else:
                 args.append("--disable-pinentry-" + gui)
-
         return args
 
-    def test(self):
-        kwargs = {
-            "exe": self.prefix.bin.pinentry,
-            "options": ["--version"],
-            "expected": [str(self.version)],
-        }
-        self.run_test(**kwargs)
+    def check_version(self, gui):
+        if "gui=" + gui not in self.spec:
+            raise SkipTest(f"Package must be installed with {gui}")
+
+        exe = which(self.prefix.bin.pinentry + "-" + gui)
+        out = exe("--version", output=str.split, error=str.split)
+        assert str(self.version) in out
+
+    def test_pinentry(self):
+        """Confirm pinentry version"""
+        exe = which(self.prefix.bin.pinentry)
+        out = exe("--version", output=str.split, error=str.split)
+        assert str(self.version) in out
+
+    def test_guis(self):
+        """Check gui versions"""
         for gui in self.supported_guis:
-            if "gui=" + gui in self.spec:
-                kwargs["exe"] = self.prefix.bin.pinentry + "-" + gui
-                self.run_test(**kwargs)
+            with test_part(self, "test_guis_" + gui, purpose="Check " + gui):
+                self.check_version(gui)

--- a/var/spack/repos/builtin/packages/pinentry/package.py
+++ b/var/spack/repos/builtin/packages/pinentry/package.py
@@ -95,7 +95,8 @@ class Pinentry(AutotoolsPackage):
     def check_version(self, gui):
         """Version check"""
         exe = which(self.prefix.bin.pinentry + "-" + gui)
-        exe("--version", output=str.split, error=str.split)
+        out = exe("--version", output=str.split, error=str.split)
+        assert str(self.version) in out
 
     def test_pinentry(self):
         """Confirm pinentry version"""
@@ -114,4 +115,4 @@ class Pinentry(AutotoolsPackage):
                     raise SkipTest(f"Package must be installed with {gui}")
                 self.check_version(gui)
                 out = exe("--version", output=str.split, error=str.split)
-                assert str(self.version) in out
+                assert str(self.version) in out, "Wrong version!"

--- a/var/spack/repos/builtin/packages/pinentry/package.py
+++ b/var/spack/repos/builtin/packages/pinentry/package.py
@@ -105,8 +105,9 @@ class Pinentry(AutotoolsPackage):
     def test_guis(self):
         """Check gui versions"""
         for gui in self.supported_guis:
+            if f"gui={gui}" not in self.spec:
+                continue
+
             exe_name = f"pinentry-{gui}"
             with test_part(self, f"test_guis_{gui}", purpose=f"Check {exe_name} version"):
-                if f"gui={gui}" not in self.spec:
-                    raise SkipTest(f"Package must be installed with {gui}")
                 self.check_version(exe_name)

--- a/var/spack/repos/builtin/packages/pinentry/package.py
+++ b/var/spack/repos/builtin/packages/pinentry/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
 from spack.package import *
 
 
@@ -94,8 +93,6 @@ class Pinentry(AutotoolsPackage):
         return args
 
     def check_version(self, gui):
-        if "gui=" + gui not in self.spec:
-            raise SkipTest(f"Package must be installed with {gui}")
 
         exe = which(self.prefix.bin.pinentry + "-" + gui)
         out = exe("--version", output=str.split, error=str.split)
@@ -110,5 +107,9 @@ class Pinentry(AutotoolsPackage):
     def test_guis(self):
         """Check gui versions"""
         for gui in self.supported_guis:
-            with test_part(self, "test_guis_" + gui, purpose="Check " + gui):
+            with test_part(
+                self, "test_guis_" + gui, purpose="Check " + gui + "and os path basename"
+            ):
+                if "gui=" + gui not in self.spec:
+                    raise SkipTest(f"Package must be installed with {gui}")
                 self.check_version(gui)

--- a/var/spack/repos/builtin/packages/pinentry/package.py
+++ b/var/spack/repos/builtin/packages/pinentry/package.py
@@ -92,12 +92,6 @@ class Pinentry(AutotoolsPackage):
                 args.append("--disable-pinentry-" + gui)
         return args
 
-    def check_version(self, gui):
-
-        exe = which(self.prefix.bin.pinentry + "-" + gui)
-        out = exe("--version", output=str.split, error=str.split)
-        assert str(self.version) in out
-
     def test_pinentry(self):
         """Confirm pinentry version"""
         exe = which(self.prefix.bin.pinentry)
@@ -107,9 +101,11 @@ class Pinentry(AutotoolsPackage):
     def test_guis(self):
         """Check gui versions"""
         for gui in self.supported_guis:
+            exe = which(self.prefix.bin.pinentry + "-" + gui)
             with test_part(
                 self, "test_guis_" + gui, purpose="Check " + gui + "and os path basename"
             ):
                 if "gui=" + gui not in self.spec:
                     raise SkipTest(f"Package must be installed with {gui}")
-                self.check_version(gui)
+                out = exe("--version", output=str.split, error=str.split)
+                assert str(self.version) in out

--- a/var/spack/repos/builtin/packages/pinentry/package.py
+++ b/var/spack/repos/builtin/packages/pinentry/package.py
@@ -92,6 +92,11 @@ class Pinentry(AutotoolsPackage):
                 args.append("--disable-pinentry-" + gui)
         return args
 
+    def check_version(self, gui):
+        """Version check"""
+        exe = which(self.prefix.bin.pinentry + "-" + gui)
+        out = exe("--version", output=str.split, error=str.split)
+
     def test_pinentry(self):
         """Confirm pinentry version"""
         exe = which(self.prefix.bin.pinentry)
@@ -107,5 +112,6 @@ class Pinentry(AutotoolsPackage):
             ):
                 if "gui=" + gui not in self.spec:
                     raise SkipTest(f"Package must be installed with {gui}")
+                self.check_version(gui)
                 out = exe("--version", output=str.split, error=str.split)
                 assert str(self.version) in out


### PR DESCRIPTION
Update standalone testing API. See below comment below for test output.

Supersedes #35805 (for one package).
