### PR TITLE
Add support for macOS Sequoia

### DIFF
--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -143,6 +143,7 @@ class MacOs(OperatingSystem):
             "12": "monterey",
             "13": "ventura",
             "14": "sonoma",
+            "15": "sequoia",
         }
 
         version = macos_version()


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
The next macOS release will be named macOS Sequoia: https://en.wikipedia.org/wiki/MacOS_Sequoia

This PR adds support for this new platform. Otherwise, Spack will be unable to detect the OS version.