### PR TITLE
iconv: require libiconv on linux

### DIFF
--- a/etc/spack/defaults/linux/packages.yaml
+++ b/etc/spack/defaults/linux/packages.yaml
@@ -1,0 +1,3 @@
+packages:
+  iconv:
+    require: [libiconv]


### PR DESCRIPTION
Because of a combination of factors, libiconv was still not picked as the
default provider for iconv on linux. With this config file, it is.

People can put `iconv:require:[glibc]` in their config file at a different 
scope to override this.

The issue was a concretizer rule that says that externals that provide any
virtual are equally good as the corresponding most preferred provider in
config, combined with the fact that glibc and musl libc are always externals.

