### PR TITLE
py-pyscf: add v2.6.0, v2.6.1, v2.6.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyscf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyscf/package.py
@@ -18,6 +18,9 @@ class PyPyscf(PythonPackage):
 
     license("Apache-2.0")
 
+    version("2.6.2", sha256="744c89a8e4d38c4b5562f75fa68f9d079faeb23602d255fba0eb6d1bac97bca2")
+    version("2.6.1", sha256="faeaeeb0c07fec5018937655511709a9c2445e3d7c421c0fa1ae5d889e4ab455")
+    version("2.6.0", sha256="08ff920fedd4b257273d235fb4492535147c1e3154de5ab02b5446de93e200d8")
     version("2.5.0", sha256="9596603c914fb3fba853607e96366fa541012faffd59a4ea052f0122dcea5343")
     version("2.4.0", sha256="af0597c481851b5448e7055c3160aef28dc12a1e0b35dda8279555c0780c0d45")
     version("2.3.0", sha256="71781de62c25924fd4e93ffeb0451ec0d0b3646fe426c75023f4f519f0f35d85")
@@ -37,6 +40,7 @@ class PyPyscf(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy@1.8.0:", type=("build", "run"))
     depends_on("py-numpy@1.13.0:", type=("build", "run"), when="@2:")
+    depends_on("py-numpy@1", type=("build", "run"), when="@:1.6.0")
     conflicts("^py-numpy@1.16:1.17", when="@2:")
     depends_on("py-scipy@0.12:1.10", type=("build", "run"), when="@:2.0")
     depends_on("py-scipy@0.19:1.10", type=("build", "run"), when="@2.1:2.2")

--- a/var/spack/repos/builtin/packages/py-pyscf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyscf/package.py
@@ -40,7 +40,7 @@ class PyPyscf(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy@1.8.0:", type=("build", "run"))
     depends_on("py-numpy@1.13.0:", type=("build", "run"), when="@2:")
-    depends_on("py-numpy@1", type=("build", "run"), when="@:1.6.0")
+    depends_on("py-numpy@1", type=("build", "run"), when="@:2.6.0")
     conflicts("^py-numpy@1.16:1.17", when="@2:")
     depends_on("py-scipy@0.12:1.10", type=("build", "run"), when="@:2.0")
     depends_on("py-scipy@0.19:1.10", type=("build", "run"), when="@2.1:2.2")


### PR DESCRIPTION
Add the new versions.

The release notes indicate that 2.6.1 and 2.6.2 have been updated for numpy 2.0, so I added but did not test a new numpy conflict line for older versions for when numpy 2.0 is supported in spack
