### PR TITLE
legion: bugfix for +cuda+cuda_unsupported_compiler

### DIFF
--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -394,6 +394,11 @@ class Legion(CMakePackage, ROCmPackage):
             # default is off.
             options.append("-DLegion_USE_Kokkos=ON")
             os.environ["KOKKOS_CXX_COMPILER"] = spec["kokkos"].kokkos_cxx
+            if spec.satisfies("+cuda+cuda_unsupported_compiler ^kokkos%clang +cuda"):
+                # Keep CMake CUDA compiler detection happy
+                options.append(
+                    self.define("CMAKE_CUDA_FLAGS", "--allow-unsupported-compiler -std=c++17")
+                )
 
         if spec.satisfies("+libdl"):
             # default is on.


### PR DESCRIPTION
When using a newer Clang for Kokkos than supported by a given CUDA version, the CUDA compiler detection in Legion's CMake still needs to be passed `CMAKE_CUDA_FLAGS` to pass the compiler check of NVCC.

E.g., Clang 17.0.6 on CUDA 11.7.0

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
