### PR TITLE
spack audit: Fix error message

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -791,7 +791,7 @@ def _issues_in_depends_on_directive(pkgs, error_cls):
                         return
                     error = error_cls(
                         f"{pkg_name}: {msg}",
-                        f"remove variants from '{spec}' in depends_on directive in {filename}",
+                        [f"remove variants from '{spec}' in depends_on directive in {filename}"],
                     )
                     errors.append(error)
 


### PR DESCRIPTION
Fix message formatting of the "virtual dependency cannot have variants" package audit.

One can artificially reproduce the bug by adding `zlib-api+shared` to zstd's `package.py`, then:

Before:
```console
$ spack audit packages zstd
PKG-DIRECTIVES: 2 issues found
1. zstd: virtual dependency cannot have variants
    r
    e
    m
    o
    v
    e
     
    v
    a
    r
    i
    a
    n
    t
    s
[...]
    p
    a
    c
    k
    a
    g
    e
    .
    p
    y
```
After:
```console
$ spack audit packages zstd
PKG-DIRECTIVES: 2 issues found
1. zstd: virtual dependency cannot have variants
    remove variants from 'zlib-api+shared' in depends_on directive in /.../spack/spack/var/spack/repos/builtin/packages/zstd/package.py
2. zstd: virtual when= spec cannot have variants
    remove variants from 'zlib-api+shared' in depends_on directive in /.../spack/spack/var/spack/repos/builtin/packages/zstd/package.py
```

The audit was introduced in https://github.com/spack/spack/commit/6753cc0b814d80ab240d6aebf6d756497dd046d3 (0.22.0)