### PR TITLE
Support `spack --config-scope <env>`

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -444,8 +444,9 @@ def make_argument_parser(**kwargs):
         "--config-scope",
         dest="config_scopes",
         action="append",
-        metavar="DIR",
-        help="add a custom configuration scope",
+        metavar="DIR|ENV",
+        help="add directory or environment as read-only configuration scope, without activating "
+        "the environment.",
     )
     parser.add_argument(
         "-d",

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -13,7 +13,7 @@ from datetime import date
 import pytest
 
 import llnl.util.tty as tty
-from llnl.util.filesystem import getuid, join_path, mkdirp, touch, touchp
+from llnl.util.filesystem import join_path, touch, touchp
 
 import spack.config
 import spack.directory_layout
@@ -864,26 +864,18 @@ def test_bad_config_section(mock_low_high_config):
         spack.config.get("foobar")
 
 
-@pytest.mark.not_on_windows("chmod not supported on Windows")
-@pytest.mark.skipif(getuid() == 0, reason="user is root")
-def test_bad_command_line_scopes(tmpdir, config):
+def test_bad_command_line_scopes(tmp_path, config):
     cfg = spack.config.Configuration()
+    file_path = tmp_path / "file_instead_of_dir"
+    non_existing_path = tmp_path / "non_existing_dir"
 
-    with tmpdir.as_cwd():
-        with pytest.raises(spack.config.ConfigError):
-            spack.config._add_command_line_scopes(cfg, ["bad_path"])
+    file_path.write_text("")
 
-        touch("unreadable_file")
-        with pytest.raises(spack.config.ConfigError):
-            spack.config._add_command_line_scopes(cfg, ["unreadable_file"])
+    with pytest.raises(spack.config.ConfigError):
+        spack.config._add_command_line_scopes(cfg, [str(file_path)])
 
-        mkdirp("unreadable_dir")
-        with pytest.raises(spack.config.ConfigError):
-            try:
-                os.chmod("unreadable_dir", 0)
-                spack.config._add_command_line_scopes(cfg, ["unreadable_dir"])
-            finally:
-                os.chmod("unreadable_dir", 0o700)  # so tmpdir can be removed
+    with pytest.raises(spack.config.ConfigError):
+        spack.config._add_command_line_scopes(cfg, [str(non_existing_path)])
 
 
 def test_add_command_line_scopes(tmpdir, mutable_config):
@@ -898,6 +890,45 @@ config:
         )
 
     spack.config._add_command_line_scopes(mutable_config, [str(tmpdir)])
+    assert mutable_config.get("config:verify_ssl") is False
+    assert mutable_config.get("config:dirty") is False
+
+
+def test_add_command_line_scope_env(tmp_path, mutable_mock_env_path):
+    """Test whether --config-scope <env> works, either by name or path."""
+    managed_env = ev.create("example").manifest_path
+
+    with open(managed_env, "w") as f:
+        f.write(
+            """\
+spack:
+  config:
+    install_tree:
+      root: /tmp/first
+"""
+        )
+
+    with open(tmp_path / "spack.yaml", "w") as f:
+        f.write(
+            """\
+spack:
+  config:
+    install_tree:
+      root: /tmp/second
+"""
+        )
+
+    config = spack.config.Configuration()
+    spack.config._add_command_line_scopes(config, ["example", str(tmp_path)])
+    assert len(config.scopes) == 2
+    assert config.get("config:install_tree:root") == "/tmp/second"
+
+    config = spack.config.Configuration()
+    spack.config._add_command_line_scopes(config, [str(tmp_path), "example"])
+    assert len(config.scopes) == 2
+    assert config.get("config:install_tree:root") == "/tmp/first"
+
+    assert ev.active_environment() is None  # shouldn't cause an environment to be activated
 
 
 def test_nested_override():

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -438,7 +438,7 @@ complete -c spack -n '__fish_spack_using_command ' -l color -r -d 'when to color
 complete -c spack -n '__fish_spack_using_command ' -s c -l config -r -f -a config_vars
 complete -c spack -n '__fish_spack_using_command ' -s c -l config -r -d 'add one or more custom, one off config settings'
 complete -c spack -n '__fish_spack_using_command ' -s C -l config-scope -r -f -a config_scopes
-complete -c spack -n '__fish_spack_using_command ' -s C -l config-scope -r -d 'add a custom configuration scope'
+complete -c spack -n '__fish_spack_using_command ' -s C -l config-scope -r -d 'add directory or environment as read-only configuration scope, without activating the environment.'
 complete -c spack -n '__fish_spack_using_command ' -s d -l debug -f -a debug
 complete -c spack -n '__fish_spack_using_command ' -s d -l debug -d 'write out debug messages'
 complete -c spack -n '__fish_spack_using_command ' -l timestamp -f -a timestamp


### PR DESCRIPTION
Depends on #45044 

Support `spack -C <env|dir>`, with the following precedence:

1. Named environment `<env>`
2. Anonymous environment in `<dir>`
3. Generic config in `<dir>`

This allows you to use an environment as a config scope without activating it,
which is useful when you don't want commands to be environment aware. For
example:

`spack -C my_env find` shows specs from the database and upstreams configured
in the env, without limiting the results to concrete specs in the environment.



