### PR TITLE
perl-json: Add optional dependency on perl-json-xs

### DIFF
--- a/var/spack/repos/builtin/packages/perl-json/package.py
+++ b/var/spack/repos/builtin/packages/perl-json/package.py
@@ -16,3 +16,12 @@ class PerlJson(PerlPackage):
 
     version("4.10", sha256="df8b5143d9a7de99c47b55f1a170bd1f69f711935c186a6dc0ab56dd05758e35")
     version("2.97001", sha256="e277d9385633574923f48c297e1b8acad3170c69fa590e31fa466040fc6f8f5a")
+
+    variant(
+        "json-xs",
+        default=True,
+        description="""Makes the preferred backend JSON::XS available to avoid defaulting to the
+        slower JSON::PP""",
+    )
+
+    depends_on("perl-json-xs", when="+json-xs", type=("run"))


### PR DESCRIPTION
[JSON](https://metacpan.org/pod/JSON) uses [JSON::XS](https://metacpan.org/pod/JSON::XS) by default, and when JSON::XS is not available, falls back on [JSON::PP](https://metacpan.org/pod/JSON::PP), which is in the Perl core since 5.14.

Since JSON::XS is the preferred (and faster) backend, this PR adds an optional dependency on `perl-json-xs` that is *on* by default.
