### PR TITLE
Decouple repo objects from globals

### DIFF
--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -34,6 +34,8 @@ def _misc_cache():
     return spack.util.file_cache.FileCache(path)
 
 
+FileCacheType = Union[spack.util.file_cache.FileCache, llnl.util.lang.Singleton]
+
 #: Spack's cache for small data
 MISC_CACHE: Union[spack.util.file_cache.FileCache, llnl.util.lang.Singleton] = (
     llnl.util.lang.Singleton(_misc_cache)

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 import os
 import re
 import sys
@@ -934,7 +933,7 @@ def get_repository(args, name):
     # Figure out where the new package should live
     repo_path = args.repo
     if repo_path is not None:
-        repo = spack.repo.Repo(repo_path)
+        repo = spack.repo.from_path(repo_path)
         if spec.namespace and spec.namespace != repo.namespace:
             tty.die(
                 "Can't create package with namespace {0} in repo with "

--- a/lib/spack/spack/cmd/edit.py
+++ b/lib/spack/spack/cmd/edit.py
@@ -123,7 +123,7 @@ def edit(parser, args):
         spack.util.editor.editor(*paths)
     elif names:
         if args.repo:
-            repo = spack.repo.Repo(args.repo)
+            repo = spack.repo.from_path(args.repo)
         elif args.namespace:
             repo = spack.repo.PATH.get_repo(args.namespace)
         else:

--- a/lib/spack/spack/cmd/repo.py
+++ b/lib/spack/spack/cmd/repo.py
@@ -91,7 +91,7 @@ def repo_add(args):
         tty.die("Not a Spack repository: %s" % path)
 
     # Make sure it's actually a spack repository by constructing it.
-    repo = spack.repo.Repo(canon_path)
+    repo = spack.repo.from_path(canon_path)
 
     # If that succeeds, finally add it to the configuration.
     repos = spack.config.get("repos", scope=args.scope)
@@ -124,7 +124,7 @@ def repo_remove(args):
     # If it is a namespace, remove corresponding repo
     for path in repos:
         try:
-            repo = spack.repo.Repo(path)
+            repo = spack.repo.from_path(path)
             if repo.namespace == namespace_or_path:
                 repos.remove(path)
                 spack.config.set("repos", repos, args.scope)
@@ -142,7 +142,7 @@ def repo_list(args):
     repos = []
     for r in roots:
         try:
-            repos.append(spack.repo.Repo(r))
+            repos.append(spack.repo.from_path(r))
         except spack.repo.RepoError:
             continue
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -24,6 +24,7 @@ import llnl.util.tty.color as clr
 from llnl.util.link_tree import ConflictingSpecsError
 from llnl.util.symlink import readlink, symlink
 
+import spack.caches
 import spack.cmd
 import spack.compilers
 import spack.concretize
@@ -2542,7 +2543,7 @@ def _concretize_task(packed_arguments) -> Tuple[int, Spec, float]:
 
 def make_repo_path(root):
     """Make a RepoPath from the repo subdirectories in an environment."""
-    path = spack.repo.RepoPath()
+    path = spack.repo.RepoPath(cache=spack.caches.MISC_CACHE)
 
     if os.path.isdir(root):
         for repo_root in os.listdir(root):
@@ -2551,7 +2552,7 @@ def make_repo_path(root):
             if not os.path.isdir(repo_root):
                 continue
 
-            repo = spack.repo.Repo(repo_root)
+            repo = spack.repo.from_path(repo_root)
             path.put_last(repo)
 
     return path

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -582,7 +582,7 @@ def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
 
             # Create a source repo and get the pkg directory out of it.
             try:
-                source_repo = spack.repo.Repo(source_repo_root)
+                source_repo = spack.repo.from_path(source_repo_root)
                 source_pkg_dir = source_repo.dirname_for_package_name(node.name)
             except spack.repo.RepoError as err:
                 tty.debug(f"Failed to create source repo for {node.name}: {str(err)}")
@@ -593,7 +593,7 @@ def dump_packages(spec: "spack.spec.Spec", path: str) -> None:
         dest_repo_root = os.path.join(path, node.namespace)
         if not os.path.exists(dest_repo_root):
             spack.repo.create_repo(dest_repo_root)
-        repo = spack.repo.Repo(dest_repo_root)
+        repo = spack.repo.from_path(dest_repo_root)
 
         # Get the location of the package in the dest repo.
         dest_pkg_dir = repo.dirname_for_package_name(node.name)

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -748,11 +748,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
         self._fetch_time = 0.0
 
         self.win_rpath = fsys.WindowsSimulatedRPath(self)
-
-        if self.is_extension:
-            pkg_cls = spack.repo.PATH.get_pkg_class(self.extendee_spec.name)
-            pkg_cls(self.extendee_spec)._check_extendable()
-
         super().__init__()
 
     @classmethod
@@ -2387,10 +2382,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
         # Now that we've handled metadata, uninstall and replace with link
         PackageBase.uninstall_by_spec(spec, force=True, deprecator=deprecator)
         link_fn(deprecator.prefix, spec.prefix)
-
-    def _check_extendable(self):
-        if not self.extendable:
-            raise ValueError("Package %s is not extendable!" % self.name)
 
     def view(self):
         """Create a view with the prefix of this package as the root.

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1108,7 +1108,7 @@ class Repo:
         """
         if spec.namespace and spec.namespace != self.namespace:
             raise UnknownPackageError(
-                "Repository %s does not contain package %s." % (self.namespace, spec.fullname)
+                f"Repository {self.namespace} does not contain package {spec.fullname}."
             )
 
         package_path = self.filename_for_package_name(spec.name)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1041,7 +1041,10 @@ class Repo:
             return import_name
 
         options = nm.possible_spack_module_names(import_name)
-        options.remove(import_name)
+        try:
+            options.remove(import_name)
+        except ValueError:
+            pass
         for name in options:
             if name in self:
                 return name

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -651,7 +651,6 @@ class RepoPath:
     def __init__(self, *repos, cache):
         self.repos = []
         self.by_namespace = nm.NamespaceTrie()
-
         self._provider_index = None
         self._patch_index = None
         self._tag_index = None
@@ -921,11 +920,12 @@ class Repo:
 
     """
 
-    def __init__(self, root, cache):
+    def __init__(self, root: str, *, cache) -> None:
         """Instantiate a package repository from a filesystem path.
 
         Args:
             root: the root directory of the repository
+            cache: file cache associated with this repository
         """
         # Root directory, containing _repo.yaml and package dirs
         # Allow roots to by spack-relative by starting with '$spack'
@@ -966,11 +966,6 @@ class Repo:
             os.path.isdir(self.packages_path),
             "No directory '%s' found in '%s'" % (packages_dir, root),
         )
-
-        # These are internal cache variables.
-        self._modules = {}
-        self._classes = {}
-        self._instances = {}
 
         # Maps that goes from package name to corresponding file stat
         self._fast_package_checker = None
@@ -1083,10 +1078,6 @@ class Repo:
 
         # Install the package.py file itself.
         fs.install(self.filename_for_package_name(spec.name), path)
-
-    def purge(self):
-        """Clear entire package instance cache."""
-        self._instances.clear()
 
     @property
     def index(self):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -25,6 +25,7 @@ import sys
 import traceback
 import types
 import uuid
+import warnings
 from typing import Any, Dict, List, Set, Tuple, Union
 
 import llnl.path
@@ -963,8 +964,7 @@ class Repo:
         packages_dir = config.get("subdirectory", packages_dir_name)
         self.packages_path = os.path.join(self.root, packages_dir)
         check(
-            os.path.isdir(self.packages_path),
-            "No directory '%s' found in '%s'" % (packages_dir, root),
+            os.path.isdir(self.packages_path), f"No directory '{packages_dir}' found in '{root}'"
         )
 
         # Maps that goes from package name to corresponding file stat
@@ -1015,12 +1015,12 @@ class Repo:
                     or "repo" not in yaml_data
                     or not isinstance(yaml_data["repo"], dict)
                 ):
-                    tty.die("Invalid %s in repository %s" % (repo_config_name, self.root))
+                    tty.die(f"Invalid {repo_config_name} in repository {self.root}")
 
                 return yaml_data["repo"]
 
         except IOError:
-            tty.die("Error reading %s when opening %s" % (self.config_file, self.root))
+            tty.die(f"Error reading {self.config_file} when opening {self.root}")
 
     def get(self, spec):
         """Returns the package associated with the supplied spec."""
@@ -1074,7 +1074,7 @@ class Repo:
                     if os.path.exists(patch.path):
                         fs.install(patch.path, path)
                     else:
-                        tty.warn("Patch file did not exist: %s" % patch.path)
+                        warnings.warn(f"Patch file did not exist: {patch.path}")
 
         # Install the package.py file itself.
         fs.install(self.filename_for_package_name(spec.name), path)
@@ -1279,7 +1279,7 @@ class Repo:
         return namespace, pkg_name
 
     def __str__(self):
-        return "[Repo '%s' at '%s']" % (self.namespace, self.root)
+        return f"[Repo '{self.namespace}' at '{self.root}']"
 
     def __repr__(self):
         return self.__str__()

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -38,7 +38,7 @@ def flake8_package(tmpdir):
     change to the ``flake8`` mock package, yields the filename, then undoes the
     change on cleanup.
     """
-    repo = spack.repo.Repo(spack.paths.mock_packages_path)
+    repo = spack.repo.from_path(spack.paths.mock_packages_path)
     filename = repo.filename_for_package_name("flake8")
     rel_path = os.path.dirname(os.path.relpath(filename, spack.paths.prefix))
     tmp = tmpdir / rel_path / "flake8-ci-package.py"
@@ -54,7 +54,7 @@ def flake8_package(tmpdir):
 @pytest.fixture
 def flake8_package_with_errors(scope="function"):
     """A flake8 package with errors."""
-    repo = spack.repo.Repo(spack.paths.mock_packages_path)
+    repo = spack.repo.from_path(spack.paths.mock_packages_path)
     filename = repo.filename_for_package_name("flake8")
     tmp = filename + ".tmp"
 
@@ -130,7 +130,7 @@ def test_changed_files_all_files():
     assert os.path.join(spack.paths.module_path, "spec.py") in files
 
     # a mock package
-    repo = spack.repo.Repo(spack.paths.mock_packages_path)
+    repo = spack.repo.from_path(spack.paths.mock_packages_path)
     filename = repo.filename_for_package_name("flake8")
     assert filename in files
 

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -161,21 +161,24 @@ class TestConcretizePreferences:
         spec = concretize("mpileaks")
         assert "zmpi" in spec
 
-    def test_config_set_pkg_property_url(self, mutable_mock_repo):
+    @pytest.mark.parametrize(
+        "update,expected",
+        [
+            (
+                {"url": "http://www.somewhereelse.com/mpileaks-1.0.tar.gz"},
+                "http://www.somewhereelse.com/mpileaks-2.3.tar.gz",
+            ),
+            ({}, "http://www.llnl.gov/mpileaks-2.3.tar.gz"),
+        ],
+    )
+    def test_config_set_pkg_property_url(self, update, expected, mock_repo_path):
         """Test setting an existing attribute in the package class"""
-        update_packages(
-            "mpileaks",
-            "package_attributes",
-            {"url": "http://www.somewhereelse.com/mpileaks-1.0.tar.gz"},
-        )
-        spec = concretize("mpileaks")
-        assert spec.package.fetcher.url == "http://www.somewhereelse.com/mpileaks-2.3.tar.gz"
+        update_packages("mpileaks", "package_attributes", update)
+        with spack.repo.use_repositories(mock_repo_path):
+            spec = concretize("mpileaks")
+            assert spec.package.fetcher.url == expected
 
-        update_packages("mpileaks", "package_attributes", {})
-        spec = concretize("mpileaks")
-        assert spec.package.fetcher.url == "http://www.llnl.gov/mpileaks-2.3.tar.gz"
-
-    def test_config_set_pkg_property_new(self, mutable_mock_repo):
+    def test_config_set_pkg_property_new(self, mock_repo_path):
         """Test that you can set arbitrary attributes on the Package class"""
         conf = syaml.load_config(
             """\
@@ -194,19 +197,20 @@ mpileaks:
 """
         )
         spack.config.set("packages", conf, scope="concretize")
-
-        spec = concretize("mpileaks")
-        assert spec.package.v1 == 1
-        assert spec.package.v2 is True
-        assert spec.package.v3 == "yesterday"
-        assert spec.package.v4 == "true"
-        assert dict(spec.package.v5) == {"x": 1, "y": 2}
-        assert list(spec.package.v6) == [1, 2]
+        with spack.repo.use_repositories(mock_repo_path):
+            spec = concretize("mpileaks")
+            assert spec.package.v1 == 1
+            assert spec.package.v2 is True
+            assert spec.package.v3 == "yesterday"
+            assert spec.package.v4 == "true"
+            assert dict(spec.package.v5) == {"x": 1, "y": 2}
+            assert list(spec.package.v6) == [1, 2]
 
         update_packages("mpileaks", "package_attributes", {})
-        spec = concretize("mpileaks")
-        with pytest.raises(AttributeError):
-            spec.package.v1
+        with spack.repo.use_repositories(mock_repo_path):
+            spec = concretize("mpileaks")
+            with pytest.raises(AttributeError):
+                spec.package.v1
 
     def test_preferred(self):
         """ "Test packages with some version marked as preferred=True"""

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -2062,3 +2062,9 @@ def _c_compiler_always_exists():
     spack.solver.asp.c_compiler_runs = _true
     yield
     spack.solver.asp.c_compiler_runs = fn
+
+
+@pytest.fixture(scope="session")
+def mock_test_cache(tmp_path_factory):
+    cache_dir = tmp_path_factory.mktemp("cache")
+    return spack.util.file_cache.FileCache(str(cache_dir))

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -561,7 +561,7 @@ def _use_test_platform(test_platform):
 #
 @pytest.fixture(scope="session")
 def mock_repo_path():
-    yield spack.repo.Repo(spack.paths.mock_packages_path)
+    yield spack.repo.from_path(spack.paths.mock_packages_path)
 
 
 def _pkg_install_fn(pkg, spec, prefix):
@@ -588,7 +588,7 @@ def mock_packages(mock_repo_path, mock_pkg_install, request):
 def mutable_mock_repo(mock_repo_path, request):
     """Function-scoped mock packages, for tests that need to modify them."""
     ensure_configuration_fixture_run_before(request)
-    mock_repo = spack.repo.Repo(spack.paths.mock_packages_path)
+    mock_repo = spack.repo.from_path(spack.paths.mock_packages_path)
     with spack.repo.use_repositories(mock_repo) as mock_repo_path:
         yield mock_repo_path
 
@@ -2019,7 +2019,8 @@ repo:
         with open(str(pkg_file), "w") as f:
             f.write(pkg_str)
 
-    return spack.repo.Repo(repo_path)
+    repo_cache = spack.util.file_cache.FileCache(str(tmpdir.join("cache")))
+    return spack.repo.Repo(repo_path, cache=repo_cache)
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -146,7 +146,7 @@ def test_read_and_write_spec(temporary_store, config, mock_packages):
         assert not os.path.exists(install_dir)
 
 
-def test_handle_unknown_package(temporary_store, config, mock_packages):
+def test_handle_unknown_package(temporary_store, config, mock_packages, tmp_path):
     """This test ensures that spack can at least do *some*
     operations with packages that are installed but that it
     does not know about.  This is actually not such an uncommon
@@ -158,7 +158,9 @@ def test_handle_unknown_package(temporary_store, config, mock_packages):
     or query them again if the package goes away.
     """
     layout = temporary_store.layout
-    mock_db = spack.repo.RepoPath(spack.paths.mock_packages_path)
+
+    repo_cache = spack.util.file_cache.FileCache(str(tmp_path / "cache"))
+    mock_db = spack.repo.RepoPath(spack.paths.mock_packages_path, cache=repo_cache)
 
     not_in_mock = set.difference(
         set(spack.repo.all_package_names()), set(mock_db.all_package_names())

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -32,12 +32,12 @@ class TestPackage:
         assert pkg_cls.name == "mpich"
 
     def test_package_filename(self):
-        repo = spack.repo.Repo(mock_packages_path)
+        repo = spack.repo.from_path(mock_packages_path)
         filename = repo.filename_for_package_name("mpich")
         assert filename == os.path.join(mock_packages_path, "packages", "mpich", "package.py")
 
     def test_nonexisting_package_filename(self):
-        repo = spack.repo.Repo(mock_packages_path)
+        repo = spack.repo.from_path(mock_packages_path)
         filename = repo.filename_for_package_name("some-nonexisting-package")
         assert filename == os.path.join(
             mock_packages_path, "packages", "some-nonexisting-package", "package.py"

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -262,3 +262,20 @@ class TestRepo:
         repo = spack.repo.Repo(spack.paths.mock_packages_path, cache=mock_test_cache)
         provider_names = {x.name for x in repo.extensions_for(extended)}
         assert provider_names.issuperset(expected)
+
+    def test_all_package_names(self, mock_test_cache):
+        repo = spack.repo.Repo(spack.paths.mock_packages_path, cache=mock_test_cache)
+        all_names = repo.all_package_names(include_virtuals=True)
+        real_names = repo.all_package_names(include_virtuals=False)
+        assert set(all_names).issuperset(real_names)
+        for name in set(all_names) - set(real_names):
+            assert repo.is_virtual(name)
+            assert repo.is_virtual_safe(name)
+
+    def test_packages_with_tags(self, mock_test_cache):
+        repo = spack.repo.Repo(spack.paths.mock_packages_path, cache=mock_test_cache)
+        r1 = repo.packages_with_tags("tag1")
+        r2 = repo.packages_with_tags("tag1", "tag2")
+        assert "mpich" in r1 and "mpich" in r2
+        assert "mpich2" in r1 and "mpich2" not in r2
+        assert set(r2).issubset(r1)

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -223,3 +223,16 @@ class TestRepo:
         repo = spack.repo.Repo(spack.paths.mock_packages_path, cache=mock_test_cache)
         assert repo.is_virtual(name) is expected
         assert repo.is_virtual_safe(name) is expected
+
+    @pytest.mark.parametrize(
+        "module_name,expected",
+        [
+            ("dla_future", "dla-future"),
+            ("num7zip", "7zip"),
+            # If no package is there, None is returned
+            ("unknown", None),
+        ],
+    )
+    def test_real_name(self, module_name, expected, mock_test_cache):
+        repo = spack.repo.Repo(spack.paths.mock_packages_path, cache=mock_test_cache)
+        assert repo.real_name(module_name) == expected

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -253,3 +253,12 @@ class TestRepo:
         repo = spack.repo.Repo(spack.paths.mock_packages_path, cache=mock_test_cache)
         provider_names = {x.name for x in repo.providers_for(virtual_name)}
         assert provider_names.issuperset(expected)
+
+    @pytest.mark.parametrize(
+        "extended,expected",
+        [("python", ["py-extension1", "python-venv"]), ("perl", ["perl-extension"])],
+    )
+    def test_extensions(self, extended, expected, mock_test_cache):
+        repo = spack.repo.Repo(spack.paths.mock_packages_path, cache=mock_test_cache)
+        provider_names = {x.name for x in repo.extensions_for(extended)}
+        assert provider_names.issuperset(expected)

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -234,5 +234,22 @@ class TestRepo:
         ],
     )
     def test_real_name(self, module_name, expected, mock_test_cache):
+        """Test that we can correctly compute the 'real' name of a package, from the one
+        used to import the Python module.
+        """
         repo = spack.repo.Repo(spack.paths.mock_packages_path, cache=mock_test_cache)
         assert repo.real_name(module_name) == expected
+
+    @pytest.mark.parametrize("name", ["mpileaks", "7zip", "dla-future"])
+    def test_get(self, name, mock_test_cache):
+        repo = spack.repo.Repo(spack.paths.mock_packages_path, cache=mock_test_cache)
+        mock_spec = spack.spec.Spec(name)
+        mock_spec._mark_concrete()
+        pkg = repo.get(mock_spec)
+        assert pkg.__class__ == repo.get_pkg_class(name)
+
+    @pytest.mark.parametrize("virtual_name,expected", [("mpi", ["mpich", "zmpi"])])
+    def test_providers(self, virtual_name, expected, mock_test_cache):
+        repo = spack.repo.Repo(spack.paths.mock_packages_path, cache=mock_test_cache)
+        provider_names = {x.name for x in repo.providers_for(virtual_name)}
+        assert provider_names.issuperset(expected)

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -203,3 +203,23 @@ def test_path_computation_with_names(method_name, mock_repo_path):
     unqualified = method("mpileaks")
     qualified = method("builtin.mock.mpileaks")
     assert qualified == unqualified
+
+
+@pytest.mark.usefixtures("nullify_globals")
+class TestRepo:
+    """Test that the Repo class work correctly, and does not depend on globals,
+    except the REPOS_FINDER.
+    """
+
+    def test_creation(self, mock_test_cache):
+        repo = spack.repo.Repo(spack.paths.mock_packages_path, cache=mock_test_cache)
+        assert repo.config_file.endswith("repo.yaml")
+        assert repo.namespace == "builtin.mock"
+
+    @pytest.mark.parametrize(
+        "name,expected", [("mpi", True), ("mpich", False), ("mpileaks", False)]
+    )
+    def test_is_virtual(self, name, expected, mock_test_cache):
+        repo = spack.repo.Repo(spack.paths.mock_packages_path, cache=mock_test_cache)
+        assert repo.is_virtual(name) is expected
+        assert repo.is_virtual_safe(name) is expected

--- a/var/spack/repos/builtin.mock/packages/7zip/package.py
+++ b/var/spack/repos/builtin.mock/packages/7zip/package.py
@@ -1,0 +1,14 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class _7zip(AutotoolsPackage):
+    """Simple package with a name starting with a digit"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/a-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")


### PR DESCRIPTION
This PR decouples `Repo` objects from globals, with the only exception of `REPOS_FINDER` (needed to hook repositories to the Python import system). It also adds unit tests for `Repo` where the globals are nullified, in an attempt to prevent regression.

Other changes are minor bug fixes, or small code maintenance.

Modifications:
- [x] `ReposFinder` does not reference `spack.repo.PATH` directly, but now _has_ its own instance of `Repo` / `RepoPath` (which can be switched dynamically)
- [x] `Repo` receives the attribute overrides on construction, instead of reading them dynamically from the global configuration
- [x] Removed a few leftover private attributes of `Repo`
- [x] Added type-hints to `Repo`
- [x] Fixed a bug on `Repo.real_name` which prevented to import modules whose package started with a digit (`import spack.pkg.builtin.num7zip`)
- [x] Remove a redundant check for extensions packages in `PackageBase`. Each extension was retrieving its extendee, and checking it could actually be extended. If we want additional security in this sense we should write an audit and run it in CI.
