### PR TITLE
ROOT should add_include_path virtual glu for consistency.

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -768,7 +768,7 @@ class Root(CMakePackage):
             add_include_path("xproto")
         if "+opengl" in spec and "platform=darwin" not in spec:
             add_include_path("glew")
-            add_include_path("mesa-glu")
+            add_include_path("glu")
         if "platform=darwin" in spec:
             # Newer deployment targets cause fatal errors in rootcling, so
             # override with an empty value even though it may lead to link


### PR DESCRIPTION
The building of ROOT with OpenGL in my setup fails with the following error ([example log](https://github.com/kkrizka/MuonCollider-docker/actions/runs/9750199780/job/26909070451#step:7:2145)):

```
#12 6046.7 ==> Installing root-6.30.06-jhptt6lr6bosp5gsuxb77ypxfpny33vn [116/116]
#12 6046.7 ==> No binary for root-6.30.06-jhptt6lr6bosp5gsuxb77ypxfpny33vn found: installing from source
#12 6047.7 ==> Error: KeyError: 'No spec with name mesa-glu in 
```

Upon investigation, I believe this is due to an consistency inside the ROOT `package.py`. The package 
- depends on the `glu` virtual package ([L231](https://github.com/spack/spack/blob/95cf341b5064608650ccdd67f5fed35ba6c56a7d/var/spack/repos/builtin/packages/root/package.py#L321)),
- but uses the includes of the specific `mesa-glu` implementation ([L771](https://github.com/spack/spack/blob/95cf341b5064608650ccdd67f5fed35ba6c56a7d/var/spack/repos/builtin/packages/root/package.py#L771)).
- When the `openglu` implementation is chosen by spack for the `glu` package, you get the reported error.

This PR changes the `package.py` consistent by changing the `mesa-glu` include path to the virtual `glu` package.