### PR TITLE
vecmem: add infrastructure for working with SYCL

### DIFF
--- a/var/spack/repos/builtin/packages/vecmem/package.py
+++ b/var/spack/repos/builtin/packages/vecmem/package.py
@@ -66,7 +66,8 @@ class Vecmem(CMakePackage, CudaPackage):
     def setup_build_environment(self, env):
         if self.spec.satisfies("+sycl"):
             env.set("SYCLCXX", self.compiler.cxx)
-            env.set("SYCLFLAGS", "-fsycl")
+            if self.spec.satisfies("%oneapi"):
+                env.set("SYCLFLAGS", "-fsycl")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/vecmem/package.py
+++ b/var/spack/repos/builtin/packages/vecmem/package.py
@@ -63,6 +63,11 @@ class Vecmem(CMakePackage, CudaPackage):
     # and we can choose between always depending on googletest, or using FetchContent
     # depends_on("googletest", type="test")
 
+    def setup_build_environment(self, env):
+        if self.spec.satisfies("+sycl"):
+            env.set("SYCLCXX", self.compiler.cxx)
+            env.set("SYCLFLAGS", "-fsycl")
+
     def cmake_args(self):
         args = [
             self.define("FETCHCONTENT_FULLY_DISCONNECTED", False),  # see FIXME above
@@ -71,6 +76,7 @@ class Vecmem(CMakePackage, CudaPackage):
             self.define_from_variant("VECMEM_BUILD_SYCL_LIBRARY", "sycl"),
             self.define("BUILD_TESTING", self.run_tests),
             self.define("VECMEM_BUILD_TESTING", self.run_tests),
+            self.define("VECMEM_USE_SYSTEM_LIBS", True),
             self.define("VECMEM_USE_SYSTEM_GOOGLETEST", False),  # see FIXME above
         ]
 


### PR DESCRIPTION
The vecmem package uses an unorthodox build system where, instead of expecting a SYCL-capable compiler in the `CXX` environment variable, it expects one in `SYCLCXX`. It also needs the correct SYCL flags to be set. This commit adds a custom build environment for the vecmem package which allows it to be built in this way. I've also added an extra CMake flag to ensure that the build system doesn't download any unwanted dependencies.