### PR TITLE
Set `LD_LIBRARY_PATH` for OneAPI compiler

### DIFF
--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-from os.path import dirname
+from os.path import dirname, join
 
 from llnl.util import tty
 
@@ -135,8 +135,12 @@ class Oneapi(Compiler):
         # It is located in the same directory as the driver. Error message:
         #   clang++: error: unable to execute command:
         #   Executable "sycl-post-link" doesn't exist!
-        if self.cxx:
+        # also ensures that shared objects and libraries required by the compiler,
+        # e.g. libonnx, can be found succesfully
+        # due to a fix, this is no longer required for OneAPI versions >= 2024.2
+        if self.cxx and pkg.spec.satisfies("%oneapi@:2024.1"):
             env.prepend_path("PATH", dirname(self.cxx))
+            env.prepend_path("LD_LIBRARY_PATH", join(dirname(dirname(self.cxx)), "lib"))
 
         # 2024 release bumped the libsycl version because of an ABI
         # change, 2024 compilers are required.  You will see this


### PR DESCRIPTION
While trying to build packages with the OneAPI compiler version 2024.1 I ran into the following error, indicating that the compiler is unable to find some necessary libraries:

```
/storage/Software/oneapi/2024.1/compiler/2024.1/bin/sycl-post-link: error
  while loading shared libraries: libonnxruntime.1.12.22.721.so: cannot open
  shared object file: No such file or directory

  icpx: error: unable to execute command: No such file or directory

  icpx: error: sycl-post-link command failed due to signal (use -v to see
  invocation)
```

Indeed, `libonnxruntime.1.12.22.721.so` does come bundled with the OneAPI compiler, but it is not available in the build environment by default. In this commit, I update the custom environment created by OneAPI to include the `lib/` directory in which these libraries reside in the `LD_LIBRARY_PATH` environment variable.