### PR TITLE
ip2: Update sp dependency

### DIFF
--- a/var/spack/repos/builtin/packages/ip2/package.py
+++ b/var/spack/repos/builtin/packages/ip2/package.py
@@ -22,6 +22,7 @@ class Ip2(CMakePackage):
     version("1.1.2", sha256="73c6beec8fd463ec7ccba3633d8c5d53d385c43d507367efde918c2db0af42ab")
 
     depends_on("sp")
+    requires("^sp precision=4,8,d", when="^sp@2.4:")
 
     def setup_run_environment(self, env):
         for suffix in ("4", "8", "d"):

--- a/var/spack/repos/builtin/packages/ip2/package.py
+++ b/var/spack/repos/builtin/packages/ip2/package.py
@@ -19,7 +19,11 @@ class Ip2(CMakePackage):
 
     maintainers("t-brown", "AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
-    version("1.1.2", sha256="73c6beec8fd463ec7ccba3633d8c5d53d385c43d507367efde918c2db0af42ab", deprecated=True)
+    version(
+        "1.1.2",
+        sha256="73c6beec8fd463ec7ccba3633d8c5d53d385c43d507367efde918c2db0af42ab",
+        deprecated=True,
+    )
 
     depends_on("sp")
     requires("^sp precision=4,8,d", when="^sp@2.4:")

--- a/var/spack/repos/builtin/packages/ip2/package.py
+++ b/var/spack/repos/builtin/packages/ip2/package.py
@@ -19,7 +19,7 @@ class Ip2(CMakePackage):
 
     maintainers("t-brown", "AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
-    version("1.1.2", sha256="73c6beec8fd463ec7ccba3633d8c5d53d385c43d507367efde918c2db0af42ab")
+    version("1.1.2", sha256="73c6beec8fd463ec7ccba3633d8c5d53d385c43d507367efde918c2db0af42ab", deprecated=True)
 
     depends_on("sp")
     requires("^sp precision=4,8,d", when="^sp@2.4:")


### PR DESCRIPTION
This PR clarifies ip2's dependency on sp, since newer versions of sp have selectable build types (4/8/d), and ip2 needs all three.