### PR TITLE
hypre: old to new test API

### DIFF
--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -399,7 +399,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
                 exe("HYPRE_DIR={0}".format(self.prefix), "bigint")
 
         for exeName in ["ex5big", "ex15big"]:
-            with test_part(self, f"test_hypre_" + exeName, purpose=f"Ensuring {exeName} runs"):
+            with test_part(self, f"test_hypre_{exeName}", purpose=f"Ensuring {exeName} runs"):
                 with working_dir(self._cached_tests_work_dir):
                     exe = which(exeName)
                     if not os.path.exists("./" + exeName):

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -393,9 +393,8 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
             exe = which("make")
             exe(f"HYPRE_DIR={self.prefix}", "bigint")
 
-        for exeName in ["ex5big", "ex15big"]:
-            with test_part(self, f"test_hypre_{exeName}", purpose=f"Ensuring {exeName} runs"):
-                with working_dir(self._cached_tests_work_dir):
+            for exeName in ["ex5big", "ex15big"]:
+                with test_part(self, f"test_hypre_{exeName}", purpose=f"Ensuring {exeName} runs"):
                     if not os.path.exists("./" + exeName):
                         raise SkipTest(f"{exeName} does not exist in version {self.version}")
                     exe = which(exeName)

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -384,21 +384,27 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
         """The working directory for cached test sources."""
         return join_path(self.test_suite.current_test_cache_dir, self.extra_install_tests)
 
-    def test_hypre(self):
+    def run_hypre(self, exe_name):
         """Perform smoke test on installed HYPRE package."""
         if "+mpi" not in self.spec:
             raise SkipTest("Package must be installed with +mpi")
 
         with working_dir(self._cached_tests_work_dir):
-            exe = which("make")
-            exe(f"HYPRE_DIR={self.prefix}", "bigint")
+            make = which("make")
+            make(f"HYPRE_DIR={self.prefix}", "bigint")
 
-            for exeName in ["ex5big", "ex15big"]:
-                with test_part(self, f"test_hypre_{exeName}", purpose=f"Ensuring {exeName} runs"):
-                    if not os.path.exists("./" + exeName):
-                        raise SkipTest(f"{exeName} does not exist in version {self.version}")
-                    exe = which(exeName)
-                    exe()
+            exe = which("./" + exe_name)
+            if exe is None:
+                raise SkipTest(f"{exe_name} does not exist in version {self.version}")
+            exe()
+
+    def test_ex5big(self):
+        """Ensuring ex5big runs"""
+        self.run_hypre("ex5big")
+
+    def test_ex15big(self):
+        """Ensuring ex15big runs"""
+        self.run_hypre("ex15big")
 
     @property
     def headers(self):


### PR DESCRIPTION
Update standalone testing API. See below comment below for test error output.

Supersedes #38501  (for one package)

Results after https://github.com/spack/spack/pull/45066/commits/fb87f3a6c157559c79cb5e6e6ad15aea967eb7ec:

```
$ spack -v test run hypre
==> Spack test djrgnu7zlmqfczbt25ye2t3xis7mjbs3
==> Testing package hypre-2.31.0-d2wa3ld
..
==> [2024-08-09-15:13:01.433013] test: test_bigint: build and run bigint tests
SKIPPED: Hypre::test_bigint: Package must be installed with +mpi
==> [2024-08-09-15:13:01.434978] Completed testing
==> [2024-08-09-15:13:01.435109] 
======================== SUMMARY: hypre-2.31.0-d2wa3ld =========================
Hypre::test_bigint .. SKIPPED
============================= 1 skipped of 1 parts =============================
==> Testing package hypre-2.31.0-wf7yzr5
..
==> [2024-08-09-15:13:03.705410] test: test_bigint: build and run bigint tests
==> [2024-08-09-15:13:03.707840] '/usr/bin/make' 'bigint'
..
==> [2024-08-09-15:13:04.362496] test: test_bigint_ex5big: ensure ex5big runs
==> [2024-08-09-15:13:04.363604] 'ex5big'
..

 Num MPI tasks = 1

 Num OpenMP threads = 1
..
Iterations = 6
Final Relative Residual Norm = 1.770275e-08

PASSED: Hypre::test_bigint_ex5big
==> [2024-08-09-15:13:04.477335] test: test_bigint_ex15big: ensure ex15big runs
==> [2024-08-09-15:13:04.479020] 'ex15big'
..
..
Iterations = 4
Final Relative Residual Norm = 1.58866e-07

PASSED: Hypre::test_bigint_ex15big
PASSED: Hypre::test_bigint
==> [2024-08-09-15:13:04.774105] Completed testing
==> [2024-08-09-15:13:04.774284] 
======================== SUMMARY: hypre-2.31.0-wf7yzr5 =========================
Hypre::test_bigint_ex5big .. PASSED
Hypre::test_bigint_ex15big .. PASSED
Hypre::test_bigint .. PASSED
============================= 3 passed of 3 parts ==============================
======================== 1 skipped, 1 passed of 2 specs ========================
```