### PR TITLE
spack gc: remove HMM debug print statement

### DIFF
--- a/lib/spack/spack/cmd/gc.py
+++ b/lib/spack/spack/cmd/gc.py
@@ -56,7 +56,6 @@ def roots_from_environments(args, active_env):
 
     # -e says "also preserve things needed by this particular env"
     for env_name_or_dir in args.except_environment:
-        print("HMM", env_name_or_dir)
         if ev.exists(env_name_or_dir):
             env = ev.read(env_name_or_dir)
         elif ev.is_env_dir(env_name_or_dir):


### PR DESCRIPTION
Oops. Apparently I left this in.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
