### PR TITLE
Remove myself from maintainer lists

### DIFF
--- a/var/spack/repos/builtin/packages/acts-dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/acts-dd4hep/package.py
@@ -12,7 +12,7 @@ class ActsDd4hep(CMakePackage):
     homepage = "https://github.com/acts-project/acts-dd4hep"
     url = "https://github.com/acts-project/acts-dd4hep/archive/refs/tags/v1.0.0.tar.gz"
 
-    maintainers("HadrienG2", "wdconinc")
+    maintainers("wdconinc")
 
     version("1.0.1", sha256="e40f34ebc30b3c33a6802c9d94136e65072d8dcee0b7db57a645f08a64ea5334")
     version("1.0.0", sha256="991f996944c88efa837880f919239e50d12c5c9361e220bc9422438dd608308c")

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -33,7 +33,7 @@ class Acts(CMakePackage, CudaPackage):
     homepage = "https://acts.web.cern.ch/ACTS/"
     git = "https://github.com/acts-project/acts.git"
     list_url = "https://github.com/acts-project/acts/releases/"
-    maintainers("HadrienG2")
+    maintainers("wdconinc")
 
     tags = ["hep"]
 

--- a/var/spack/repos/builtin/packages/actsvg/package.py
+++ b/var/spack/repos/builtin/packages/actsvg/package.py
@@ -16,7 +16,7 @@ class Actsvg(CMakePackage):
     list_url = "https://github.com/acts-project/actsvg/tags"
     git = "https://github.com/acts-project/actsvg.git"
 
-    maintainers("HadrienG2", "wdconinc", "stephenswat")
+    maintainers("wdconinc", "stephenswat")
 
     license("MPL-2.0")
 

--- a/var/spack/repos/builtin/packages/autodiff/package.py
+++ b/var/spack/repos/builtin/packages/autodiff/package.py
@@ -14,7 +14,7 @@ class Autodiff(CMakePackage):
     list_url = "https://github.com/autodiff/autodiff/tags"
     git = "https://github.com/autodiff/autodiff.git"
 
-    maintainers("wdconinc", "HadrienG2")
+    maintainers("wdconinc")
 
     license("MIT")
 

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -22,9 +22,7 @@ class Root(CMakePackage):
 
     tags = ["hep"]
 
-    maintainers(
-        "drbenmorgan", "gartung", "greenc-FNAL", "marcmengel", "vitodb", "vvolkl"
-    )
+    maintainers("drbenmorgan", "gartung", "greenc-FNAL", "marcmengel", "vitodb", "vvolkl")
 
     # ###################### Versions ##########################
 

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -23,7 +23,7 @@ class Root(CMakePackage):
     tags = ["hep"]
 
     maintainers(
-        "drbenmorgan", "gartung", "greenc-FNAL", "HadrienG2", "marcmengel", "vitodb", "vvolkl"
+        "drbenmorgan", "gartung", "greenc-FNAL", "marcmengel", "vitodb", "vvolkl"
     )
 
     # ###################### Versions ##########################

--- a/var/spack/repos/builtin/packages/vecmem/package.py
+++ b/var/spack/repos/builtin/packages/vecmem/package.py
@@ -13,7 +13,7 @@ class Vecmem(CMakePackage, CudaPackage):
     url = "https://github.com/acts-project/vecmem/archive/refs/tags/v0.5.0.tar.gz"
     list_url = "https://github.com/acts-project/vecmem/tags"
 
-    maintainers("wdconinc", "HadrienG2", "stephenswat")
+    maintainers("wdconinc", "stephenswat")
 
     license("MPL-2.0-no-copyleft-exception")
 

--- a/var/spack/repos/builtin/packages/verrou/package.py
+++ b/var/spack/repos/builtin/packages/verrou/package.py
@@ -25,8 +25,6 @@ class Verrou(AutotoolsPackage):
     url = "https://github.com/edf-hpc/verrou/archive/v2.0.0.tar.gz"
     git = "https://github.com/edf-hpc/verrou.git"
 
-    maintainers("HadrienG2")
-
     license("GPL-2.0-only")
 
     version("develop", branch="master")


### PR DESCRIPTION
After a few years of very intermittent presence on this GitHub repo, it's time for me to admit it: I don't have the time budget it takes to properly review issues and PRs on HEP spackages anymore.

My other work projects have grown to the point where allocating time for spack maintenance is becoming a torture, and because of this I'm more and more avoiding the spackbot notifications and waiting a few days hoping that someone else will take the PR. Having my name in the maintainers lists decidedly feels like a lie these days, so let's stop lying.

I'd like to use this PR as an occasion to thank the Spack maintainers for managing to build one of the best options for maintaining compute stacks today, and also to thank @wdconinc and others for taking over and keeping the lights on in the Acts dependency stack when I couldn't.

So long and thanks for all the fish!