### PR TITLE
py-webcolors: add v24.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-webcolors/package.py
+++ b/var/spack/repos/builtin/packages/py-webcolors/package.py
@@ -12,9 +12,14 @@ class PyWebcolors(PythonPackage):
     homepage = "https://pypi.org/project/webcolors/"
     pypi = "webcolors/webcolors-1.11.1.tar.gz"
 
-    license("BSD-3-Clause")
+    license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("24.6.0", sha256="1d160d1de46b3e81e58d0a280d0c78b467dc80f47294b91b1ad8029d2cedb55b")
+    version("1.13", sha256="c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a")
+    version("1.12", sha256="16d043d3a08fd6a1b1b7e3e9e62640d09790dce80d2bdd4792a175b35fe794a9")
     version("1.11.1", sha256="76f360636957d1c976db7466bc71dcb713bb95ac8911944dffc55c01cb516de6")
 
     depends_on("python@3.5:", type=("build", "run"))
-    depends_on("py-setuptools", type=("build"))
+    depends_on("python@3.7:", type=("build", "run"), when="@1.12:")
+    depends_on("python@3.8:", type=("build", "run"), when="@24.6:")
+    depends_on("py-setuptools@61:", type=("build"))


### PR DESCRIPTION
This PR adds a few new versions of `py-webcolors`, which switched to calver versioning.

It also adds an explicit minimum version for `py-setuptools`, which appears to have been implicit anyway (https://github.com/ubernostrum/webcolors/commit/12c21d11c4db72b40604faf642a2057cc0bba39f).