### PR TITLE
util-linux{-uuid}: add v2.40.2

### DIFF
--- a/var/spack/repos/builtin/packages/util-linux-uuid/package.py
+++ b/var/spack/repos/builtin/packages/util-linux-uuid/package.py
@@ -14,8 +14,9 @@ class UtilLinuxUuid(AutotoolsPackage):
     list_url = "https://www.kernel.org/pub/linux/utils/util-linux"
     list_depth = 1
 
-    license("GPL-2.0-or-later")
+    license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("2.40.2", sha256="7bec316b713a14c6be1a5721aa0e56a3b6170277329e6e1f1a56013cc91eece0")
     version("2.40.1", sha256="8e396eececae2b3b68db232c33b8810faa7c31f6df19f98f512739293d5829b7")
     version("2.38.1", sha256="0820eb8eea90408047e3715424bc6be771417047f683950fecb4bdd2e2cbbc6e")
     version("2.37.4", sha256="c8b7b4fa541f974cc32c1c6559d9bfca33651020a456ad6ee5fc9b0cacd00151")

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -18,7 +18,7 @@ class UtilLinux(AutotoolsPackage):
 
     license("GPL-2.0-only", checked_by="wdconinc")
 
-    version("2.40.2", sha256="7bec316b713a14c6be1a5721aa0e56a3b6170277329e6e1f1a56013cc91eece0") 
+    version("2.40.2", sha256="7bec316b713a14c6be1a5721aa0e56a3b6170277329e6e1f1a56013cc91eece0")
     version("2.40", sha256="2a51d08cb71fd8e491e0cf633032c928f9a2848417f8441cb8cf7ef9971de916")
     version("2.39.3", sha256="40ea07584d56c310455471afa92c119ec259776a561af7159cc802344c2c370d")
     version("2.39.1", sha256="d7c8a58eb2c7248a32754eb3a3b6772e368b984d9907ada834c2cf3e13024270")

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -18,6 +18,7 @@ class UtilLinux(AutotoolsPackage):
 
     license("GPL-2.0-only", checked_by="wdconinc")
 
+    version("2.40.2", sha256="7bec316b713a14c6be1a5721aa0e56a3b6170277329e6e1f1a56013cc91eece0") 
     version("2.40", sha256="2a51d08cb71fd8e491e0cf633032c928f9a2848417f8441cb8cf7ef9971de916")
     version("2.39.3", sha256="40ea07584d56c310455471afa92c119ec259776a561af7159cc802344c2c370d")
     version("2.39.1", sha256="d7c8a58eb2c7248a32754eb3a3b6772e368b984d9907ada834c2cf3e13024270")


### PR DESCRIPTION
This PR adds bugfix releases for `util-linux` and `util-linux-uuid` (which are based on the same code base). No changes to dependencies or build system.

License of the `libuuid` subtree of `util-linux` is BSD-3-Clause, per https://github.com/util-linux/util-linux/blob/master/libuuid/COPYING.