### PR TITLE
util-linux: provide uuid when new variant +uuid

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -60,7 +60,7 @@ packages:
       szip: [libaec, libszip]
       tbb: [intel-tbb]
       unwind: [libunwind]
-      uuid: [util-linux-uuid, libuuid]
+      uuid: [util-linux-uuid, util-linux+uuid, libuuid]
       xxd: [xxd-standalone, vim]
       yacc: [bison, byacc]
       ziglang: [zig]


### PR DESCRIPTION
This PR combines the packages util-linux and util-linux-uuid again so util-linux can provide uuid, but this doesn't remove util-linux-uuid.

Only after I made the changes did I really appreciate the reasons in #18322. I think the circular dependency on python is still a valid concern.