### PR TITLE
intel-xed: Rewrite recipe to match upstream install layout

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/modern-xed-2022.patch
+++ b/var/spack/repos/builtin/packages/hpctoolkit/modern-xed-2022.patch
@@ -1,0 +1,58 @@
+diff --git a/configure b/configure
+index 3a5894b6a..c7d786665 100755
+--- a/configure
++++ b/configure
+@@ -22290,13 +22290,13 @@ $as_echo_n "checking for xed2... " >&6; }
+ xed2_avail=no
+ case "$XED2" in
+   /* )
+-    if test ! -f "${XED2}/include/xed-interface.h" ; then
++    if test ! -f "${XED2}/include/xed/xed-interface.h" ; then
+       as_fn_error $? "invalid xed2 directory: $XED2" "$LINENO" 5
+     fi
+     if test ! -f "${XED2}/lib/libxed.so" && test ! -f "${XED2}/lib/libxed.a" ; then
+       as_fn_error $? "invalid xed2 directory: $XED2" "$LINENO" 5
+     fi
+-    XED2_INC="${XED2}/include"
++    XED2_INC="${XED2}/include/xed"
+     XED2_LIB_DIR="${XED2}/lib"
+     XED2_COPY=yes
+     xed2_avail=yes
+@@ -22327,7 +22327,7 @@ if test "$xed2_avail" = yes ; then
+   if test -f "${XED2}/lib/libxed.a" ; then
+     ORIG_CFLAGS="$CFLAGS"
+     ORIG_LIBS="$LIBS"
+-    CFLAGS="-shared -fPIC -I${XED2}/include"
++    CFLAGS="-shared -fPIC -I${XED2_INC}"
+     LIBS="${XED2}/lib/libxed.a"
+     ac_ext=c
+ ac_cpp='$CPP $CPPFLAGS'
+diff --git a/configure.ac b/configure.ac
+index a455ff1da..a7c7d000e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3556,13 +3556,13 @@ AC_MSG_CHECKING([for xed2])
+ xed2_avail=no
+ case "$XED2" in
+   /* )
+-    if test ! -f "${XED2}/include/xed-interface.h" ; then
++    if test ! -f "${XED2}/include/xed/xed-interface.h" ; then
+       AC_MSG_ERROR([invalid xed2 directory: $XED2])
+     fi
+     if test ! -f "${XED2}/lib/libxed.so" && test ! -f "${XED2}/lib/libxed.a" ; then
+       AC_MSG_ERROR([invalid xed2 directory: $XED2])
+     fi
+-    XED2_INC="${XED2}/include"
++    XED2_INC="${XED2}/include/xed"
+     XED2_LIB_DIR="${XED2}/lib"
+     XED2_COPY=yes
+     xed2_avail=yes
+@@ -3591,7 +3591,7 @@ if test "$xed2_avail" = yes ; then
+   if test -f "${XED2}/lib/libxed.a" ; then
+     ORIG_CFLAGS="$CFLAGS"
+     ORIG_LIBS="$LIBS"
+-    CFLAGS="-shared -fPIC -I${XED2}/include"
++    CFLAGS="-shared -fPIC -I${XED2_INC}"
+     LIBS="${XED2}/lib/libxed.a"
+     AC_LANG_PUSH([C])
+     AC_MSG_CHECKING([if libxed.a was compiled with -fPIC])

--- a/var/spack/repos/builtin/packages/hpctoolkit/modern-xed-2023.patch
+++ b/var/spack/repos/builtin/packages/hpctoolkit/modern-xed-2023.patch
@@ -1,0 +1,58 @@
+diff --git a/configure b/configure
+index 03474cc9f..79de27601 100755
+--- a/configure
++++ b/configure
+@@ -22002,13 +22002,13 @@ $as_echo_n "checking for xed2... " >&6; }
+ xed2_avail=no
+ case "$XED2" in
+   /* )
+-    if test ! -f "${XED2}/include/xed-interface.h" ; then
++    if test ! -f "${XED2}/include/xed/xed-interface.h" ; then
+       as_fn_error $? "invalid xed2 directory: $XED2" "$LINENO" 5
+     fi
+     if test ! -f "${XED2}/lib/libxed.a" ; then
+       as_fn_error $? "invalid xed2 directory: $XED2" "$LINENO" 5
+     fi
+-    XED2_INC="${XED2}/include"
++    XED2_INC="${XED2}/include/xed"
+     XED2_LIB_DIR="${XED2}/lib"
+     xed2_avail=yes
+     num_pkgs=`expr 1 + $num_pkgs`
+@@ -22038,7 +22038,7 @@ if test "$xed2_avail" = yes ; then
+   if test -f "${XED2}/lib/libxed.a" ; then
+     ORIG_CFLAGS="$CFLAGS"
+     ORIG_LIBS="$LIBS"
+-    CFLAGS="-shared -fPIC -I${XED2}/include"
++    CFLAGS="-shared -fPIC -I${XED2_INC}"
+     LIBS="${XED2}/lib/libxed.a"
+     ac_ext=c
+ ac_cpp='$CPP $CPPFLAGS'
+diff --git a/configure.ac b/configure.ac
+index 75053e9ba..a3d654caa 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3428,13 +3428,13 @@ AC_MSG_CHECKING([for xed2])
+ xed2_avail=no
+ case "$XED2" in
+   /* )
+-    if test ! -f "${XED2}/include/xed-interface.h" ; then
++    if test ! -f "${XED2}/include/xed/xed-interface.h" ; then
+       AC_MSG_ERROR([invalid xed2 directory: $XED2])
+     fi
+     if test ! -f "${XED2}/lib/libxed.a" ; then
+       AC_MSG_ERROR([invalid xed2 directory: $XED2])
+     fi
+-    XED2_INC="${XED2}/include"
++    XED2_INC="${XED2}/include/xed"
+     XED2_LIB_DIR="${XED2}/lib"
+     xed2_avail=yes
+     num_pkgs=`expr 1 + $num_pkgs`
+@@ -3462,7 +3462,7 @@ if test "$xed2_avail" = yes ; then
+   if test -f "${XED2}/lib/libxed.a" ; then
+     ORIG_CFLAGS="$CFLAGS"
+     ORIG_LIBS="$LIBS"
+-    CFLAGS="-shared -fPIC -I${XED2}/include"
++    CFLAGS="-shared -fPIC -I${XED2_INC}"
+     LIBS="${XED2}/lib/libxed.a"
+     AC_LANG_PUSH([C])
+     AC_MSG_CHECKING([if libxed.a was compiled with -fPIC])

--- a/var/spack/repos/builtin/packages/hpctoolkit/modern-xed-2024.01.1.patch
+++ b/var/spack/repos/builtin/packages/hpctoolkit/modern-xed-2024.01.1.patch
@@ -1,0 +1,123 @@
+From c1b2dbe85f5b5734e519bbdf772558562d1aca3c Mon Sep 17 00:00:00 2001
+From: Jonathon Anderson <anderson.jonathonm@gmail.com>
+Date: Mon, 8 Jul 2024 13:22:43 -0500
+Subject: [PATCH] build: Add support for "new-style" Xed includes
+
+Backported from https://gitlab.com/hpctoolkit/hpctoolkit/-/merge_requests/1144
+
+Our code includes the Intel Xed headers as `<xed-*.h>`, this is how the
+current Spack recipe installs it. Upstream Xed installs the headers to
+be included as `<xed/xed-*.h>` instead. Support an upstream Xed install
+configuration by lightly adjusting the build script to match.
+---
+ configure.ac                | 15 +++++++++------
+ src/lib/banal/Makefile.am   |  4 ++--
+ src/tool/hpcrun/Makefile.am |  4 ++--
+ 3 files changed, 13 insertions(+), 10 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 34b261362..02fd96003 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3101,7 +3101,7 @@ AC_SUBST([TBB_LIB_DIR])
+ # Now require static (.a) archive + fPIC for all cases in order to
+ # hide the xed symbols.
+ 
+-XED2_INC=
++XED2_IFLAGS=
+ XED2_LIB_DIR=no
+ XED2_LIB_FLAGS=
+ XED2_HPCRUN_LIBS=
+@@ -3124,13 +3124,16 @@ AC_MSG_CHECKING([for xed2])
+ xed2_avail=no
+ case "$XED2" in
+   /* )
+-    if test ! -f "${XED2}/include/xed-interface.h" ; then
++    if test -f "${XED2}/include/xed-interface.h" ; then
++      XED2_IFLAGS="-I${XED2}/include"
++    elif test -f "${XED2}/include/xed/xed-interface.h" ; then
++      XED2_IFLAGS="-I${XED2}/include -I${XED2}/include/xed"
++    else
+       AC_MSG_ERROR([invalid xed2 directory: $XED2])
+     fi
+     if test ! -f "${XED2}/lib/libxed.a" ; then
+       AC_MSG_ERROR([invalid xed2 directory: $XED2])
+     fi
+-    XED2_INC="${XED2}/include"
+     XED2_LIB_DIR="${XED2}/lib"
+     xed2_avail=yes
+     num_pkgs=`expr 1 + $num_pkgs`
+@@ -3157,7 +3160,7 @@ if test "$xed2_avail" = yes ; then
+   if test -f "${XED2}/lib/libxed.a" ; then
+     ORIG_CFLAGS="$CFLAGS"
+     ORIG_LIBS="$LIBS"
+-    CFLAGS="-shared -fPIC -I${XED2}/include"
++    CFLAGS="-shared -fPIC ${XED2_IFLAGS}"
+     LIBS="${XED2}/lib/libxed.a"
+     AC_LANG_PUSH([C])
+     AC_MSG_CHECKING([if libxed.a was compiled with -fPIC])
+@@ -3178,7 +3181,7 @@ int my_xed_init(void)
+     # Test for xed_operand_values_get_branch_displacement_int64().
+     # XED <= 2023.07.09 uses _int32, and >= 2023.08.21 uses _int64.
+     #
+-    CFLAGS="-I${XED2}/include"
++    CFLAGS="${XED2_IFLAGS}"
+     AC_MSG_CHECKING([if xed uses xed_operand_values_get_branch_displacement_int64])
+     AC_LINK_IFELSE([
+     AC_LANG_SOURCE([[
+@@ -3216,7 +3219,7 @@ if test "$xed_displacement_int64" = yes ; then
+       [xed uses xed_operand_values_get_branch_displacement_int64])
+ fi
+ 
+-AC_SUBST([XED2_INC])
++AC_SUBST([XED2_IFLAGS])
+ AC_SUBST([XED2_LIB_DIR])
+ AC_SUBST([XED2_LIB_FLAGS])
+ AC_SUBST([XED2_HPCRUN_LIBS])
+diff --git a/src/lib/banal/Makefile.am b/src/lib/banal/Makefile.am
+index 419a23ef8..817eda066 100644
+--- a/src/lib/banal/Makefile.am
++++ b/src/lib/banal/Makefile.am
+@@ -54,7 +54,7 @@ BOOST_IFLAGS = @BOOST_IFLAGS@
+ DYNINST_IFLAGS = @DYNINST_IFLAGS@
+ LIBELF_INC = @LIBELF_INC@
+ TBB_IFLAGS = @TBB_IFLAGS@
+-XED2_INC = @XED2_INC@
++XED2_IFLAGS = @XED2_IFLAGS@
+ 
+ if OPT_ENABLE_IGC
+ IGC_IFLAGS = @OPT_IGC_IFLAGS@
+@@ -94,7 +94,7 @@ MYCXXFLAGS = \
+ 	-fvisibility=hidden
+ 
+ if HOST_CPU_X86_FAMILY
+-MYCXXFLAGS += -I$(XED2_INC)
++MYCXXFLAGS += $(XED2_IFLAGS)
+ endif
+ 
+ MYLIBADD = @HOST_LIBTREPOSITORY@
+diff --git a/src/tool/hpcrun/Makefile.am b/src/tool/hpcrun/Makefile.am
+index 32b39f96c..512fbbf79 100644
+--- a/src/tool/hpcrun/Makefile.am
++++ b/src/tool/hpcrun/Makefile.am
+@@ -146,7 +146,7 @@ LIBMONITOR_INC = @LIBMONITOR_INC@
+ LIBMONITOR_LIB = @LIBMONITOR_LIB@
+ PAPI_INC_FLGS =  @OPT_PAPI_IFLAGS@
+ PAPI_LD_FLGS =   @OPT_PAPI_LDFLAGS@
+-XED2_INC = @XED2_INC@
++XED2_IFLAGS = @XED2_IFLAGS@
+ XED2_HPCRUN_LIBS =  @XED2_HPCRUN_LIBS@
+ CUPTI_INC_FLGS = @OPT_CUPTI_IFLAGS@
+ 
+@@ -207,7 +207,7 @@ UNW_X86_FILES = \
+ 
+ UNW_X86_INCLUDE_DIRS = \
+ 	-I$(srcdir)/unwind/x86-family	\
+-	-I$(XED2_INC)
++	$(XED2_IFLAGS)
+ 
+ UNW_PPC64_FILES = \
+ 	$(UNW_COMMON_FILES) \
+-- 
+2.45.2
+

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -188,7 +188,6 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
     depends_on("intel-gtpin", when="+gtpin")
     depends_on("opencl-c-headers", when="+opencl")
 
-    depends_on("intel-xed+pic", when="target=x86_64:")
     depends_on("memkind", type=("build", "run"), when="@2021.05.01:2023.08")
     depends_on("papi", when="+papi")
     depends_on("libpfm4", when="~papi")
@@ -197,6 +196,18 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
     depends_on("hpcviewer@2022.10:", type="run", when="@2022.10: +viewer")
     depends_on("hpcviewer", type="run", when="+viewer")
     depends_on("python@3.10:", type=("build", "run"), when="+python")
+
+    with when("target=x86_64:"):
+        depends_on("intel-xed+pic")
+
+        # The intel-xed recipe used to use a different install layout than upstream Xed. This has
+        # since been fixed, but many versions of hpctoolkit expect the older install layout and
+        # will not build if the upstream install layout is used.
+        # These patches backport support for the upstream Xed install layout to affected versions.
+        # See https://github.com/spack/spack/pull/45084 for details.
+        patch("modern-xed-2024.01.1.patch", when="@2024.01.1")
+        patch("modern-xed-2023.patch", when="@2022.05.15:2023.08")
+        patch("modern-xed-2022.patch", when="@:2022.04.15")
 
     # Avoid 'link' dep, we don't actually link, and that adds rpath
     # that conflicts with app.


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/41268.

For a long time now, the `intel-xed` recipe manually implemented the install phase by copying files out of the Xed build tree. This PR replaces this logic with the upstream install target instead, making the recipe both more accurate and more simpler/elegant.

This is a disruptive change, the install layout in the `intel-xed` recipe has differed from the upstream install layout since its introduction to Spack. In particular, the headers currently installed to `include/xed-*.h` are installed by the upstream install logic to `include/xed/xed-*.h`.

This PR also patches `hpctoolkit` (the only dependent of `intel-xed`) to support the newer install layout:

- The latest rolling versions (`@2024.01.stable` and `@develop`) support both install layouts and require no new patches,
- `@2024.01.1` is patched to support both layouts, and
- Older versions use a simple patch that *only* supports the newer install layout.

***

This PR has been extensively tested by successfully building a large environment ([spack.yaml](https://github.com/user-attachments/files/16118140/spack.yaml.txt)) from scratch.

<details>
<summary>(Concretization of the test environment)</summary>

```
==> Concretized 128 specs:
 -   ukos674  hpctoolkit@2019.08.14%gcc@11.4.1~cray~debug~mpi~opencl+papi+viewer build_system=autotools patches=23a6034,ccf7a31 arch=linux-almalinux9-zen2
 -   wdewue3      ^binutils@2.33.1%gcc@11.4.1~gas~headers~interwork~ld+libiberty~lto~nls+plugins build_system=autotools compress_debug_sections=zlib libs=shared,static arch=linux-almalinux9-zen2
 -   nrmpc3z          ^diffutils@3.10%gcc@11.4.1 build_system=autotools arch=linux-almalinux9-zen2
 -   bxprrn7          ^pkgconf@2.2.0%gcc@11.4.1 build_system=autotools arch=linux-almalinux9-zen2
 -   6gpttg5      ^boost@1.85.0%gcc@11.4.1+atomic+chrono~clanglibcpp~container~context~contract~coroutine+date_time~debug~exception~fiber+filesystem+graph~graph_parallel~icu~iostreams~json~locale~log~math~mpi+multithreaded~nowide~numpy~pic~program_options~python~random+regex~serialization+shared~signals~singlethreaded~stacktrace+system~taggedlayout~test+thread+timer~type_erasure~versionedlayout~wave build_system=generic cxxstd=11 patches=a440f96 visibility=global arch=linux-almalinux9-zen2
 -   hlsoww2      ^bzip2@1.0.8%gcc@11.4.1~debug~pic+shared build_system=generic arch=linux-almalinux9-zen2
 -   k6yu3oq      ^dyninst@12.3.0%gcc@11.4.1~ipo+openmp~stat_dysect~static build_system=cmake build_type=Release generator=make arch=linux-almalinux9-zen2
 -   pjpov5g          ^cmake@3.29.6%gcc@11.4.1~doc+ncurses+ownlibs build_system=generic build_type=Release patches=dbc3892 arch=linux-almalinux9-zen2
 -   okdfymw      ^elfutils@0.190%gcc@11.4.1~debuginfod+exeprefix~nls build_system=autotools arch=linux-almalinux9-zen2
 -   4wegssy          ^libiconv@1.17%gcc@11.4.1 build_system=autotools libs=shared,static arch=linux-almalinux9-zen2
 -   dwgsr5t          ^m4@1.4.19%gcc@11.4.1+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-almalinux9-zen2
 -   ctri7wb              ^libsigsegv@2.14%gcc@11.4.1 build_system=autotools arch=linux-almalinux9-zen2
 -   zfgurm5          ^zstd@1.5.6%gcc@11.4.1+programs build_system=makefile compression=none libs=shared,static arch=linux-almalinux9-zen2
 -   6uswpwv      ^gcc-runtime@11.4.1%gcc@11.4.1 build_system=generic arch=linux-almalinux9-zen2
[e]  vl3x3lm      ^glibc@2.34%gcc@11.4.1 build_system=autotools arch=linux-almalinux9-zen2
 -   xy5to26      ^gmake@4.4.1%gcc@11.4.1~guile build_system=generic arch=linux-almalinux9-zen2
 -   655emwn      ^gotcha@1.0.6%gcc@11.4.1~ipo~test build_system=cmake build_type=Release generator=make arch=linux-almalinux9-zen2
 -   krhbbzf      ^hpcviewer@2024.02%gcc@11.4.1 build_system=generic arch=linux-almalinux9-zen2
 -   pivcy6v          ^openjdk@17.0.11_9%gcc@11.4.1 build_system=generic arch=linux-almalinux9-zen2
 -   3pndgqu      ^intel-tbb@2020.3%gcc@11.4.1+shared+tm build_system=makefile cxxstd=default patches=62ba015,ce1fb16,d62cb66 arch=linux-almalinux9-zen2
 -   uulty6g      ^intel-xed@2023.07.09%gcc@11.4.1~debug+optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   uj62yji      ^libdwarf@20180129%gcc@11.4.1 build_system=generic arch=linux-almalinux9-zen2
 -   zlojzex      ^libmonitor@2023.03.15%gcc@11.4.1~commrank+dlopen+hpctoolkit build_system=autotools arch=linux-almalinux9-zen2
 -   ixi3gdr      ^libunwind@1.6.2%gcc@11.4.1~block_signals~conservative_checks~cxx_exceptions~debug~debug_frame+docs+pic+tests+weak_backtrace+xz~zlib build_system=autotools components=none libs=shared,static arch=linux-almalinux9-zen2
 -   uqxqd2o      ^mbedtls@3.3.0%gcc@11.4.1+pic build_system=makefile build_type=Release libs=static arch=linux-almalinux9-zen2
 -   hddopco      ^papi@7.1.0%gcc@11.4.1~cuda~debug+example~infiniband~lmsensors~nvml~powercap~rapl~rocm~rocm_smi~sde+shared~static_tools build_system=autotools patches=48cb202 arch=linux-almalinux9-zen2
 -   kn3kc3c      ^xerces-c@3.2.5%gcc@11.4.1 build_system=autotools cxxstd=default netaccessor=curl transcoder=iconv arch=linux-almalinux9-zen2
 -   xpitwai          ^curl@8.7.1%gcc@11.4.1~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-almalinux9-zen2
 -   tqsv5gs              ^nghttp2@1.62.0%gcc@11.4.1 build_system=autotools arch=linux-almalinux9-zen2
 -   spnb4rj      ^xz@5.4.6%gcc@11.4.1+pic build_system=autotools libs=shared,static arch=linux-almalinux9-zen2
 -   rlr2wpx      ^zlib-ng@2.1.6%gcc@11.4.1+compat+new_strategies+opt+pic+shared build_system=autotools patches=6614666 arch=linux-almalinux9-zen2
 -   vh45cxg  hpctoolkit@2019.08.14%gcc@11.4.1~cray~debug~mpi~opencl+papi+viewer build_system=autotools patches=23a6034,ccf7a31 arch=linux-almalinux9-zen2
 -   i2jaj7n      ^intel-xed@11.2.0%gcc@11.4.1~debug+optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   7gfbq34  hpctoolkit@2019.12.28%gcc@11.4.1~cray~debug~mpi~opencl+papi+viewer build_system=autotools patches=23a6034,ccf7a31 arch=linux-almalinux9-zen2
 -   vjuuwd7  hpctoolkit@2019.12.28%gcc@11.4.1~cray~debug~mpi~opencl+papi+viewer build_system=autotools patches=23a6034,ccf7a31 arch=linux-almalinux9-zen2
 -   h5bntpv  hpctoolkit@2020.03.01%gcc@11.4.1~cray~cuda~debug~mpi~opencl+papi+viewer build_system=autotools patches=0ef29bc,23a6034,bb1b19c,ccf7a31 arch=linux-almalinux9-zen2
 -   r4wy5ef      ^python@3.11.9%gcc@11.4.1+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=13fa8bf,b0615b2,ebdca64,f2fd060 arch=linux-almalinux9-zen2
 -   cekakxz          ^expat@2.6.2%gcc@11.4.1+libbsd build_system=autotools arch=linux-almalinux9-zen2
 -   5fxfb3g              ^libbsd@0.12.2%gcc@11.4.1 build_system=autotools arch=linux-almalinux9-zen2
 -   zi26fwo                  ^libmd@1.0.4%gcc@11.4.1 build_system=autotools arch=linux-almalinux9-zen2
 -   v3725pe          ^gdbm@1.23%gcc@11.4.1 build_system=autotools arch=linux-almalinux9-zen2
 -   3ml47kx          ^gettext@0.22.5%gcc@11.4.1+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-almalinux9-zen2
 -   uevlwfv              ^libxml2@2.10.3%gcc@11.4.1+pic~python+shared build_system=autotools arch=linux-almalinux9-zen2
 -   4dlqpwb              ^tar@1.34%gcc@11.4.1 build_system=autotools zip=pigz arch=linux-almalinux9-zen2
 -   326vvwj                  ^pigz@2.8%gcc@11.4.1 build_system=makefile arch=linux-almalinux9-zen2
 -   7oorzcx          ^libffi@3.4.6%gcc@11.4.1 build_system=autotools arch=linux-almalinux9-zen2
 -   mvzs4yj          ^libxcrypt@4.4.35%gcc@11.4.1~obsolete_api build_system=autotools patches=4885da3 arch=linux-almalinux9-zen2
 -   ccyutvd          ^ncurses@6.5%gcc@11.4.1~symlinks+termlib abi=none build_system=autotools patches=7a351bc arch=linux-almalinux9-zen2
 -   rpktskg          ^openssl@3.3.1%gcc@11.4.1~docs+shared build_system=generic certs=mozilla arch=linux-almalinux9-zen2
 -   3zd2rwz              ^ca-certificates-mozilla@2023-05-30%gcc@11.4.1 build_system=generic arch=linux-almalinux9-zen2
 -   djs5bpt          ^readline@8.2%gcc@11.4.1 build_system=autotools patches=bbf97f1 arch=linux-almalinux9-zen2
 -   nszz7sl          ^sqlite@3.43.2%gcc@11.4.1+column_metadata+dynamic_extensions+fts~functions+rtree build_system=autotools arch=linux-almalinux9-zen2
 -   h743p6f          ^util-linux-uuid@2.40.1%gcc@11.4.1 build_system=autotools arch=linux-almalinux9-zen2
 -   opls6au  hpctoolkit@2020.03.01%gcc@11.4.1~cray~cuda~debug~mpi~opencl+papi+viewer build_system=autotools patches=0ef29bc,23a6034,bb1b19c,ccf7a31 arch=linux-almalinux9-zen2
 -   yti5pf2  hpctoolkit@2020.06.12%gcc@11.4.1~cray~cuda~debug~mpi~opencl+papi+viewer build_system=autotools patches=0ef29bc,23a6034,bb1b19c,ccf7a31 arch=linux-almalinux9-zen2
 -   aap5mdn      ^binutils@2.39%gcc@11.4.1~gas~gprofng~headers~interwork~ld+libiberty~lto~nls~pgo+plugins build_system=autotools compress_debug_sections=zlib libs=shared,static arch=linux-almalinux9-zen2
 -   blc4lzu          ^texinfo@7.1%gcc@11.4.1 build_system=autotools arch=linux-almalinux9-zen2
 -   7rpd3dq  hpctoolkit@2020.06.12%gcc@11.4.1~cray~cuda~debug~mpi~opencl+papi+viewer build_system=autotools patches=0ef29bc,23a6034,bb1b19c,ccf7a31 arch=linux-almalinux9-zen2
 -   haughe6  hpctoolkit@2020.07.21%gcc@11.4.1~cray~cuda~debug~mpi~opencl+papi+viewer build_system=autotools patches=0ef29bc,23a6034,bb1b19c,ccf7a31 arch=linux-almalinux9-zen2
 -   7juxch6  hpctoolkit@2020.07.21%gcc@11.4.1~cray~cuda~debug~mpi~opencl+papi+viewer build_system=autotools patches=0ef29bc,23a6034,bb1b19c,ccf7a31 arch=linux-almalinux9-zen2
 -   f6mca2v  hpctoolkit@2020.08.03%gcc@11.4.1~cray~cuda~debug~mpi~opencl+papi+viewer build_system=autotools patches=0ef29bc,23a6034,bb1b19c,ccf7a31 arch=linux-almalinux9-zen2
 -   oh2chqq  hpctoolkit@2020.08.03%gcc@11.4.1~cray~cuda~debug~mpi~opencl+papi+viewer build_system=autotools patches=0ef29bc,23a6034,bb1b19c,ccf7a31 arch=linux-almalinux9-zen2
 -   sj66obs  hpctoolkit@2021.03.01%gcc@11.4.1~cray~cuda~debug~mpi~opencl+papi+viewer build_system=autotools patches=23a6034,ccf7a31 arch=linux-almalinux9-zen2
 -   7nqhdul      ^libmonitor@2023.03.15%gcc@11.4.1~commrank~dlopen+hpctoolkit build_system=autotools arch=linux-almalinux9-zen2
 -   fcpwg35  hpctoolkit@2021.03.01%gcc@11.4.1~cray~cuda~debug~mpi~opencl+papi+viewer build_system=autotools patches=23a6034,ccf7a31 arch=linux-almalinux9-zen2
 -   uzx7ewa  hpctoolkit@2021.05.15%gcc@11.4.1~cray~cuda~debug~mpi~opencl+papi+viewer build_system=autotools patches=23a6034 arch=linux-almalinux9-zen2
 -   4gustp6      ^memkind@1.14.0%gcc@11.4.1 build_system=autotools arch=linux-almalinux9-zen2
 -   zxwppxo          ^numactl@2.0.14%gcc@11.4.1 build_system=autotools patches=4e1d78c,62fc8a8,ff37630 arch=linux-almalinux9-zen2
 -   nnnsff7  hpctoolkit@2021.05.15%gcc@11.4.1~cray~cuda~debug~mpi~opencl+papi+viewer build_system=autotools patches=23a6034 arch=linux-almalinux9-zen2
 -   3tv72c5  hpctoolkit@2021.10.15%gcc@11.4.1~cray~cuda~debug~mpi~opencl+papi+viewer build_system=autotools patches=23a6034 arch=linux-almalinux9-zen2
 -   fwgq65x  hpctoolkit@2021.10.15%gcc@11.4.1~cray~cuda~debug~mpi~opencl+papi+viewer build_system=autotools patches=23a6034 arch=linux-almalinux9-zen2
 -   ftvkgox  hpctoolkit@2022.01.15%gcc@11.4.1~cray~cuda~debug~mpi~opencl+papi+viewer build_system=autotools patches=23a6034 arch=linux-almalinux9-zen2
 -   4zr6f27  hpctoolkit@2022.01.15%gcc@11.4.1~cray~cuda~debug~mpi~opencl+papi+viewer build_system=autotools patches=23a6034 arch=linux-almalinux9-zen2
 -   lk3ammz  hpctoolkit@2022.04.15%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~rocm+viewer build_system=autotools patches=23a6034 arch=linux-almalinux9-zen2
 -   emnd3ah  hpctoolkit@2022.04.15%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~rocm+viewer build_system=autotools patches=23a6034 arch=linux-almalinux9-zen2
 -   nuown2o  hpctoolkit@2022.05.15%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~rocm+viewer build_system=autotools patches=db31ec8 arch=linux-almalinux9-zen2
 -   zk62d7s  hpctoolkit@2022.05.15%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~rocm+viewer build_system=autotools patches=db31ec8 arch=linux-almalinux9-zen2
 -   hcc3cor  hpctoolkit@2022.10.01%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~rocm+viewer build_system=autotools patches=db31ec8 arch=linux-almalinux9-zen2
 -   jgpsyep      ^libiberty@2.41%gcc@11.4.1+pic build_system=autotools arch=linux-almalinux9-zen2
 -   yy3rsmd      ^yaml-cpp@0.7.0%gcc@11.4.1~ipo+pic+shared~tests build_system=cmake build_type=Release generator=make arch=linux-almalinux9-zen2
 -   5ju2sjx  hpctoolkit@2022.10.01%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~rocm+viewer build_system=autotools patches=db31ec8 arch=linux-almalinux9-zen2
 -   7aeivrs  hpctoolkit@2023.03.01%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~python~rocm+viewer build_system=autotools patches=db31ec8 arch=linux-almalinux9-zen2
 -   6kbaanr  hpctoolkit@2023.03.01%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~python~rocm+viewer build_system=autotools patches=db31ec8 arch=linux-almalinux9-zen2
 -   g55vb53  hpctoolkit@git.4add0c6eb6c048412dbd497b784a5db4f62585ee=2023.03.stable%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~python~rocm+viewer build_system=autotools patches=db31ec8 arch=linux-almalinux9-zen2
 -   cijcn47  hpctoolkit@git.4add0c6eb6c048412dbd497b784a5db4f62585ee=2023.03.stable%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~python~rocm+viewer build_system=autotools patches=db31ec8 arch=linux-almalinux9-zen2
 -   xngdbqw  hpctoolkit@2023.08.1%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~python~rocm+viewer build_system=autotools patches=db31ec8 arch=linux-almalinux9-zen2
 -   a2uws4n  hpctoolkit@2023.08.1%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~python~rocm+viewer build_system=autotools patches=db31ec8 arch=linux-almalinux9-zen2
 -   jxpyigf  hpctoolkit@git.0165ec064c9e31f7ebc784a02972897536b5165a=2023.08.stable%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~python~rocm+viewer build_system=autotools patches=db31ec8 arch=linux-almalinux9-zen2
 -   zraoji2  hpctoolkit@git.0165ec064c9e31f7ebc784a02972897536b5165a=2023.08.stable%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~python~rocm+viewer build_system=autotools patches=db31ec8 arch=linux-almalinux9-zen2
 -   jrtift5  hpctoolkit@2024.01.1%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~python~rocm+viewer build_system=autotools patches=72feca3 arch=linux-almalinux9-zen2
 -   cdv7p6z      ^autoconf@2.72%gcc@11.4.1 build_system=autotools arch=linux-almalinux9-zen2
 -   yylhdk2          ^perl@5.38.2%gcc@11.4.1+cpanm+opcode+open+shared+threads build_system=generic patches=714e4d1 arch=linux-almalinux9-zen2
 -   omg2cfv              ^berkeley-db@18.1.40%gcc@11.4.1+cxx~docs+stl build_system=autotools patches=26090f4,b231fcc arch=linux-almalinux9-zen2
 -   4k5lw4f      ^automake@1.16.5%gcc@11.4.1 build_system=autotools arch=linux-almalinux9-zen2
 -   6nrvsqu      ^dyninst@13.0.0%gcc@11.4.1~ipo+openmp~stat_dysect~static build_system=cmake build_type=Release generator=make arch=linux-almalinux9-zen2
 -   cindu5j      ^elfutils@0.190%gcc@11.4.1~debuginfod+exeprefix~nls build_system=autotools arch=linux-almalinux9-zen2
 -   vj2gy7h      ^intel-tbb@2021.12.0%gcc@11.4.1~ipo+shared+tm build_system=cmake build_type=Release cxxstd=default generator=make arch=linux-almalinux9-zen2
 -   u2backb          ^hwloc@2.9.3%gcc@11.4.1~cairo~cuda~gl~libudev+libxml2~netloc~nvml~oneapi-level-zero~opencl+pci~rocm build_system=autotools libs=shared,static arch=linux-almalinux9-zen2
 -   hsttpxf              ^libpciaccess@0.17%gcc@11.4.1 build_system=autotools arch=linux-almalinux9-zen2
 -   2zmjirx                  ^util-macros@1.20.1%gcc@11.4.1 build_system=autotools arch=linux-almalinux9-zen2
 -   iyaactp              ^libxml2@2.10.3%gcc@11.4.1+pic~python+shared build_system=autotools arch=linux-almalinux9-zen2
 -   cp32j5p      ^libtool@2.4.7%gcc@11.4.1 build_system=autotools arch=linux-almalinux9-zen2
 -   zhhxamo          ^findutils@4.9.0%gcc@11.4.1 build_system=autotools patches=440b954 arch=linux-almalinux9-zen2
 -   r7bevbu      ^libunwind@1.6.2%gcc@11.4.1~block_signals~conservative_checks~cxx_exceptions~debug~debug_frame+docs~pic+tests+weak_backtrace+xz~zlib build_system=autotools components=none libs=shared,static arch=linux-almalinux9-zen2
 -   zdzorqs      ^xz@5.4.6%gcc@11.4.1~pic build_system=autotools libs=shared,static arch=linux-almalinux9-zen2
 -   g4zazfs  hpctoolkit@2024.01.1%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~python~rocm+viewer build_system=autotools patches=72feca3 arch=linux-almalinux9-zen2
 -   jv2hy3q  hpctoolkit@2024.01.1%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~python~rocm+viewer build_system=autotools patches=72feca3 arch=linux-almalinux9-zen2
 -   kiya2i3  hpctoolkit@git.40a3d6079f87be453029d8b4e8b5fbfd0abd6cb3=2024.01.stable%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~python~rocm+viewer build_system=autotools arch=linux-almalinux9-zen2
 -   i2zagiy  hpctoolkit@git.40a3d6079f87be453029d8b4e8b5fbfd0abd6cb3=2024.01.stable%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~python~rocm+viewer build_system=autotools arch=linux-almalinux9-zen2
 -   wci2pmj  hpctoolkit@git.40a3d6079f87be453029d8b4e8b5fbfd0abd6cb3=2024.01.stable%gcc@11.4.1~cray~cuda~debug~level_zero~mpi~opencl+papi~python~rocm+viewer build_system=autotools arch=linux-almalinux9-zen2
 -   wlvmgfu  intel-xed@10.2019.03%gcc@11.4.1~debug~optimize~pic build_system=generic patches=f029244 arch=linux-almalinux9-zen2
 -   bpilvju      ^python@3.11.9%gcc@11.4.1+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=13fa8bf,b0615b2,ebdca64,f2fd060 arch=linux-almalinux9-zen2
 -   fzkd7uj          ^gettext@0.22.5%gcc@11.4.1+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-almalinux9-zen2
 -   ukrlel7              ^tar@1.34%gcc@11.4.1 build_system=autotools zip=pigz arch=linux-almalinux9-zen2
 -   o6rmxh4  intel-xed@10.2019.03%gcc@11.4.1~debug~optimize+pic build_system=generic patches=f029244 arch=linux-almalinux9-zen2
 -   stixehp  intel-xed@10.2019.03%gcc@11.4.1~debug+optimize~pic build_system=generic patches=f029244 arch=linux-almalinux9-zen2
 -   zvlb5sd  intel-xed@10.2019.03%gcc@11.4.1~debug+optimize+pic build_system=generic patches=f029244 arch=linux-almalinux9-zen2
 -   mghpl32  intel-xed@10.2019.03%gcc@11.4.1+debug~optimize~pic build_system=generic patches=f029244 arch=linux-almalinux9-zen2
 -   siczbui  intel-xed@10.2019.03%gcc@11.4.1+debug~optimize+pic build_system=generic patches=f029244 arch=linux-almalinux9-zen2
 -   lepeljl  intel-xed@10.2019.03%gcc@11.4.1+debug+optimize~pic build_system=generic patches=f029244 arch=linux-almalinux9-zen2
 -   uagvp3m  intel-xed@10.2019.03%gcc@11.4.1+debug+optimize+pic build_system=generic patches=f029244 arch=linux-almalinux9-zen2
 -   bkpy6mf  intel-xed@11.2.0%gcc@11.4.1~debug~optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   as7bana  intel-xed@11.2.0%gcc@11.4.1~debug~optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   cfaggck  intel-xed@11.2.0%gcc@11.4.1~debug+optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   bt7mmwb  intel-xed@11.2.0%gcc@11.4.1~debug+optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   4pbizdn  intel-xed@11.2.0%gcc@11.4.1+debug~optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   4o2cszt  intel-xed@11.2.0%gcc@11.4.1+debug~optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   rzsfb4e  intel-xed@11.2.0%gcc@11.4.1+debug+optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   ats2ij7  intel-xed@11.2.0%gcc@11.4.1+debug+optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   3xwt4kp  intel-xed@12.0.1%gcc@11.4.1~debug~optimize~pic build_system=generic patches=acffa07,c6aa5f7 arch=linux-almalinux9-zen2
 -   a52zaor  intel-xed@12.0.1%gcc@11.4.1~debug~optimize+pic build_system=generic patches=acffa07,c6aa5f7 arch=linux-almalinux9-zen2
 -   lthzjpw  intel-xed@12.0.1%gcc@11.4.1~debug+optimize~pic build_system=generic patches=acffa07,c6aa5f7 arch=linux-almalinux9-zen2
 -   sfjjzco  intel-xed@12.0.1%gcc@11.4.1~debug+optimize+pic build_system=generic patches=acffa07,c6aa5f7 arch=linux-almalinux9-zen2
 -   eo6aon6  intel-xed@12.0.1%gcc@11.4.1+debug~optimize~pic build_system=generic patches=acffa07,c6aa5f7 arch=linux-almalinux9-zen2
 -   t73w4g3  intel-xed@12.0.1%gcc@11.4.1+debug~optimize+pic build_system=generic patches=acffa07,c6aa5f7 arch=linux-almalinux9-zen2
 -   eh4oz2l  intel-xed@12.0.1%gcc@11.4.1+debug+optimize~pic build_system=generic patches=acffa07,c6aa5f7 arch=linux-almalinux9-zen2
 -   iflratt  intel-xed@12.0.1%gcc@11.4.1+debug+optimize+pic build_system=generic patches=acffa07,c6aa5f7 arch=linux-almalinux9-zen2
 -   q3gsa6q  intel-xed@2022.04.17%gcc@11.4.1~debug~optimize~pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   twppkl7  intel-xed@2022.04.17%gcc@11.4.1~debug~optimize+pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   gcmheuq  intel-xed@2022.04.17%gcc@11.4.1~debug+optimize~pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   ehvjbbe  intel-xed@2022.04.17%gcc@11.4.1~debug+optimize+pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   zrrmvon  intel-xed@2022.04.17%gcc@11.4.1+debug~optimize~pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   kfserld  intel-xed@2022.04.17%gcc@11.4.1+debug~optimize+pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   ib4jcbo  intel-xed@2022.04.17%gcc@11.4.1+debug+optimize~pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   sdmlkhm  intel-xed@2022.04.17%gcc@11.4.1+debug+optimize+pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   6zfuu5z  intel-xed@2022.08.11%gcc@11.4.1~debug~optimize~pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   3qwvph5  intel-xed@2022.08.11%gcc@11.4.1~debug~optimize+pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   dkggd57  intel-xed@2022.08.11%gcc@11.4.1~debug+optimize~pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   ba4zajq  intel-xed@2022.08.11%gcc@11.4.1~debug+optimize+pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   w2xhgpa  intel-xed@2022.08.11%gcc@11.4.1+debug~optimize~pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   o3vo76q  intel-xed@2022.08.11%gcc@11.4.1+debug~optimize+pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   be6yfr6  intel-xed@2022.08.11%gcc@11.4.1+debug+optimize~pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   k6l7bbz  intel-xed@2022.08.11%gcc@11.4.1+debug+optimize+pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   mfrptdb  intel-xed@2022.10.11%gcc@11.4.1~debug~optimize~pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   wekcg37  intel-xed@2022.10.11%gcc@11.4.1~debug~optimize+pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   z7zfgud  intel-xed@2022.10.11%gcc@11.4.1~debug+optimize~pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   alcytgf  intel-xed@2022.10.11%gcc@11.4.1~debug+optimize+pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   vz4bkls  intel-xed@2022.10.11%gcc@11.4.1+debug~optimize~pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   ho7feop  intel-xed@2022.10.11%gcc@11.4.1+debug~optimize+pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   7buo7ud  intel-xed@2022.10.11%gcc@11.4.1+debug+optimize~pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   4c3id27  intel-xed@2022.10.11%gcc@11.4.1+debug+optimize+pic build_system=generic patches=c6aa5f7 arch=linux-almalinux9-zen2
 -   vrqigsm  intel-xed@2023.04.16%gcc@11.4.1~debug~optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   uwi6zjb  intel-xed@2023.04.16%gcc@11.4.1~debug~optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   gvfvjmu  intel-xed@2023.04.16%gcc@11.4.1~debug+optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   3zgwczj  intel-xed@2023.04.16%gcc@11.4.1~debug+optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   2kknbn7  intel-xed@2023.04.16%gcc@11.4.1+debug~optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   jzixbv7  intel-xed@2023.04.16%gcc@11.4.1+debug~optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   gsmu5th  intel-xed@2023.04.16%gcc@11.4.1+debug+optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   cut7xtk  intel-xed@2023.04.16%gcc@11.4.1+debug+optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   ep7yzsz  intel-xed@2023.06.07%gcc@11.4.1~debug~optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   lkejj2o  intel-xed@2023.06.07%gcc@11.4.1~debug~optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   rq6jygz  intel-xed@2023.06.07%gcc@11.4.1~debug+optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   qcslwca  intel-xed@2023.06.07%gcc@11.4.1~debug+optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   d6wofyu  intel-xed@2023.06.07%gcc@11.4.1+debug~optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   yte6zue  intel-xed@2023.06.07%gcc@11.4.1+debug~optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   hzq4ipy  intel-xed@2023.06.07%gcc@11.4.1+debug+optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   ljdko7y  intel-xed@2023.06.07%gcc@11.4.1+debug+optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   bmxv2jk  intel-xed@2023.07.09%gcc@11.4.1~debug~optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   z5a3aro  intel-xed@2023.07.09%gcc@11.4.1~debug~optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   vlr4bxd  intel-xed@2023.07.09%gcc@11.4.1~debug+optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   vmvjhrg  intel-xed@2023.07.09%gcc@11.4.1~debug+optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   hek5voh  intel-xed@2023.07.09%gcc@11.4.1+debug~optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   sq4llba  intel-xed@2023.07.09%gcc@11.4.1+debug~optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   gtkdhfa  intel-xed@2023.07.09%gcc@11.4.1+debug+optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   okcw3bi  intel-xed@2023.07.09%gcc@11.4.1+debug+optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   iejn24v  intel-xed@2023.08.21%gcc@11.4.1~debug~optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   vcveq6m  intel-xed@2023.08.21%gcc@11.4.1~debug~optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   reu4nkp  intel-xed@2023.08.21%gcc@11.4.1~debug+optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   hy22tzk  intel-xed@2023.08.21%gcc@11.4.1~debug+optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   l7nuddc  intel-xed@2023.08.21%gcc@11.4.1+debug~optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   pf2nx7t  intel-xed@2023.08.21%gcc@11.4.1+debug~optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   d3utin2  intel-xed@2023.08.21%gcc@11.4.1+debug+optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   yyjenll  intel-xed@2023.08.21%gcc@11.4.1+debug+optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   kod2pwl  intel-xed@2023.10.11%gcc@11.4.1~debug~optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   ln2tfzq  intel-xed@2023.10.11%gcc@11.4.1~debug~optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   vup3ycs  intel-xed@2023.10.11%gcc@11.4.1~debug+optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   vb7mpan  intel-xed@2023.10.11%gcc@11.4.1~debug+optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   e67g3pp  intel-xed@2023.10.11%gcc@11.4.1+debug~optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   wkkefm7  intel-xed@2023.10.11%gcc@11.4.1+debug~optimize+pic build_system=generic arch=linux-almalinux9-zen2
 -   rvvk4lu  intel-xed@2023.10.11%gcc@11.4.1+debug+optimize~pic build_system=generic arch=linux-almalinux9-zen2
 -   qmhcplj  intel-xed@2023.10.11%gcc@11.4.1+debug+optimize+pic build_system=generic arch=linux-almalinux9-zen2
```

</details>