### PR TITLE
geant4: add v11.3.0.beta

### DIFF
--- a/var/spack/repos/builtin/packages/g4emlow/package.py
+++ b/var/spack/repos/builtin/packages/g4emlow/package.py
@@ -18,6 +18,7 @@ class G4emlow(Package):
     maintainers("drbenmorgan")
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version("8.6", sha256="fb7abed0d1db1d8b9ea364279b95e228d7bf3e3a5dc8d449b81665cada4a1a9e")
     version("8.5", sha256="66baca49ac5d45e2ac10c125b4fb266225e511803e66981909ce9cd3e9bcef73")
     version("8.4", sha256="d87de4d2a364cb0a1e1846560525ffc3f735ccdeea8bc426d61775179aebbe8e")
     version("8.2", sha256="3d7768264ff5a53bcb96087604bbe11c60b7fea90aaac8f7d1252183e1a8e427")

--- a/var/spack/repos/builtin/packages/g4nudexlib/package.py
+++ b/var/spack/repos/builtin/packages/g4nudexlib/package.py
@@ -32,6 +32,4 @@ class G4nudexlib(Package):
 
     def url_for_version(self, version):
         """Handle version string."""
-        return (
-            "http://geant4-data.web.cern.ch/geant4-data/datasets/G4NUDEXLIB.%s.tar.gz" % version
-        )
+        return "http://geant4-data.web.cern.ch/geant4-data/datasets/G4NUDEXLIB.%s.tar.gz" % version

--- a/var/spack/repos/builtin/packages/g4nudexlib/package.py
+++ b/var/spack/repos/builtin/packages/g4nudexlib/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class G4nudexlib(Package):
+    """Geant4 data for evaluated particle cross-sections on
+    natural composition of elements"""
+
+    homepage = "https://geant4.web.cern.ch"
+    url = "https://geant4-data.web.cern.ch/geant4-data/datasets/G4NUDEXLIB.1.0.tar.gz"
+
+    tags = ["hep"]
+
+    maintainers("drbenmorgan")
+
+    # Only versions relevant to Geant4 releases built by spack are added
+    version("1.0", sha256="cac7d65e9c5af8edba2b2667d5822e16aaf99065c95f805e76de4cc86395f415")
+
+    def install(self, spec, prefix):
+        mkdirp(join_path(prefix.share, "data"))
+        install_path = join_path(prefix.share, "data", "G4NUDEXLIB{0}".format(self.version))
+        install_tree(self.stage.source_path, install_path)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        install_path = join_path(self.prefix.share, "data", "G4NUDEXLIB{0}".format(self.version))
+        env.set("G4NUDEXLIBDATA", install_path)
+
+    def url_for_version(self, version):
+        """Handle version string."""
+        return (
+            "http://geant4-data.web.cern.ch/geant4-data/datasets/G4NUDEXLIB.%s.tar.gz" % version
+        )

--- a/var/spack/repos/builtin/packages/g4particlexs/package.py
+++ b/var/spack/repos/builtin/packages/g4particlexs/package.py
@@ -19,6 +19,7 @@ class G4particlexs(Package):
     maintainers("drbenmorgan")
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version("4.1", sha256="07ae1e048e9ac8e7f91f6696497dd55bd50ccc822d97af1a0b9e923212a6d7d1")
     version("4.0", sha256="9381039703c3f2b0fd36ab4999362a2c8b4ff9080c322f90b4e319281133ca95")
     version("3.1.1", sha256="66c17edd6cb6967375d0497add84c2201907a25e33db782ebc26051d38f2afda")
     version("3.1", sha256="404da84ead165e5cccc0bb795222f6270c9bf491ef4a0fd65195128b27f0e9cd")

--- a/var/spack/repos/builtin/packages/g4urrpt/package.py
+++ b/var/spack/repos/builtin/packages/g4urrpt/package.py
@@ -32,6 +32,4 @@ class G4urrpt(Package):
 
     def url_for_version(self, version):
         """Handle version string."""
-        return (
-            "http://geant4-data.web.cern.ch/geant4-data/datasets/G4URRPT.%s.tar.gz" % version
-        )
+        return "http://geant4-data.web.cern.ch/geant4-data/datasets/G4URRPT.%s.tar.gz" % version

--- a/var/spack/repos/builtin/packages/g4urrpt/package.py
+++ b/var/spack/repos/builtin/packages/g4urrpt/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class G4urrpt(Package):
+    """Geant4 data for evaluated particle cross-sections on
+    natural composition of elements"""
+
+    homepage = "https://geant4.web.cern.ch"
+    url = "https://geant4-data.web.cern.ch/geant4-data/datasets/G4URRPT.1.0.tar.gz"
+
+    tags = ["hep"]
+
+    maintainers("drbenmorgan")
+
+    # Only versions relevant to Geant4 releases built by spack are added
+    version("1.0", sha256="278eb6c4086e919d2c2a718eb44d4897b7e06d2a32909f6ed48eb8590b3f9977")
+
+    def install(self, spec, prefix):
+        mkdirp(join_path(prefix.share, "data"))
+        install_path = join_path(prefix.share, "data", "G4URRPT{0}".format(self.version))
+        install_tree(self.stage.source_path, install_path)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        install_path = join_path(self.prefix.share, "data", "G4URRPT{0}".format(self.version))
+        env.set("G4URRPTDATA", install_path)
+
+    def url_for_version(self, version):
+        """Handle version string."""
+        return (
+            "http://geant4-data.web.cern.ch/geant4-data/datasets/G4URRPT.%s.tar.gz" % version
+        )

--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -18,6 +18,7 @@ class Geant4Data(BundlePackage):
 
     tags = ["hep"]
 
+    version("11.3.0")
     version("11.2.2")
     version("11.2.0")
     version("11.1.0")
@@ -44,6 +45,21 @@ class Geant4Data(BundlePackage):
     # they generally don't change on the patch level
     # Can move to declaring on a dataset basis if needed
     _datasets = {
+        "11.3.0:11.3": [
+            "g4ndl@4.7.1",
+            "g4emlow@8.6",
+            "g4photonevaporation@5.7",
+            "g4radioactivedecay@5.6",
+            "g4particlexs@4.1",
+            "g4pii@1.3",
+            "g4realsurface@2.2",
+            "g4saiddata@2.0",
+            "g4abla@3.3",
+            "g4incl@1.2",
+            "g4ensdfstate@2.3",
+            "g4nudexlib@1.0",
+            "g4urrpt@1.0",
+        ],
         "11.2.2:11.2": [
             "g4ndl@4.7.1",
             "g4emlow@8.5",

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -22,7 +22,9 @@ class Geant4(CMakePackage):
 
     maintainers("drbenmorgan", "sethrj")
     version(
-        "11.3.0.beta", sha256="572ba1570ca3b5b6f2a28ccbffa459901f6a986b79da1ebfdbf2f6f3dc5e14bf"
+        "11.3.0.beta",
+        sha256="572ba1570ca3b5b6f2a28ccbffa459901f6a986b79da1ebfdbf2f6f3dc5e14bf",
+        deprecated=True,
     )
     version(
         "11.2.2",

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -21,8 +21,8 @@ class Geant4(CMakePackage):
     executables = ["^geant4-config$"]
 
     maintainers("drbenmorgan", "sethrj")
-
-    version("11.2.2", sha256="3a8d98c63fc52578f6ebf166d7dffaec36256a186d57f2520c39790367700c8d")
+    version("11.3.0.beta", sha256="572ba1570ca3b5b6f2a28ccbffa459901f6a986b79da1ebfdbf2f6f3dc5e14bf")
+    version("11.2.2", sha256="3a8d98c63fc52578f6ebf166d7dffaec36256a186d57f2520c39790367700c8d", preferred=True)
     version("11.2.1", sha256="76c9093b01128ee2b45a6f4020a1bcb64d2a8141386dea4674b5ae28bcd23293")
     version("11.2.0", sha256="9ff544739b243a24dac8f29a4e7aab4274fc0124fd4e1c4972018213dc6991ee")
     version("11.1.3", sha256="5d9a05d4ccf8b975649eab1d615fc1b8dce5937e01ab9e795bffd04149240db6")
@@ -95,7 +95,8 @@ class Geant4(CMakePackage):
         "11.0",
         "11.1",
         "11.2.0:11.2.1",
-        "11.2.2:",
+        "11.2.2:11.2",
+        "11.3:",
     ]:
         depends_on("geant4-data@" + _vers, type="run", when="@" + _vers)
 
@@ -111,6 +112,7 @@ class Geant4(CMakePackage):
     extends("python", when="+python")
 
     # CLHEP version requirements to be reviewed
+    depends_on("clhep@2.4.7.1:", when="@11.3:")
     depends_on("clhep@2.4.6.0:", when="@11.1:")
     depends_on("clhep@2.4.5.1:", when="@11.0.0:")
     depends_on("clhep@2.4.4.0:", when="@10.7.0:")

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -121,6 +121,7 @@ class Geant4(CMakePackage):
 
     # Vecgeom specific versions for each Geant4 version
     with when("+vecgeom"):
+        depends_on("vecgeom@1.2.8:", when="@11.3:")
         depends_on("vecgeom@1.2.6:", when="@11.2:")
         depends_on("vecgeom@1.2.0:", when="@11.1")
         depends_on("vecgeom@1.1.18:1.1", when="@11.0.0:11.0")

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -21,8 +21,14 @@ class Geant4(CMakePackage):
     executables = ["^geant4-config$"]
 
     maintainers("drbenmorgan", "sethrj")
-    version("11.3.0.beta", sha256="572ba1570ca3b5b6f2a28ccbffa459901f6a986b79da1ebfdbf2f6f3dc5e14bf")
-    version("11.2.2", sha256="3a8d98c63fc52578f6ebf166d7dffaec36256a186d57f2520c39790367700c8d", preferred=True)
+    version(
+        "11.3.0.beta", sha256="572ba1570ca3b5b6f2a28ccbffa459901f6a986b79da1ebfdbf2f6f3dc5e14bf"
+    )
+    version(
+        "11.2.2",
+        sha256="3a8d98c63fc52578f6ebf166d7dffaec36256a186d57f2520c39790367700c8d",
+        preferred=True,
+    )
     version("11.2.1", sha256="76c9093b01128ee2b45a6f4020a1bcb64d2a8141386dea4674b5ae28bcd23293")
     version("11.2.0", sha256="9ff544739b243a24dac8f29a4e7aab4274fc0124fd4e1c4972018213dc6991ee")
     version("11.1.3", sha256="5d9a05d4ccf8b975649eab1d615fc1b8dce5937e01ab9e795bffd04149240db6")


### PR DESCRIPTION
This PR adds geant4 v11.3.0.beta ([release notes](https://github.com/Geant4/geant4/blob/v11.3.0.beta/ReleaseNotes/Beta4.11.3-1.txt)). Normally I wouldn't add beta versions, but I'm already seeing some breakage in dependent packages due to changed headers, so in the interest of identifying downstream issues more broadly this might be useful to have in spack. 