### PR TITLE
spec.py: print right deptype in tree

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1332,6 +1332,12 @@ def tree(
     if color is None:
         color = clr.get_color_when()
 
+    # reduce deptypes over all in-edges when covering nodes
+    if show_types and cover == "nodes":
+        deptype_lookup: Dict[str, dt.DepFlag] = collections.defaultdict(dt.DepFlag)
+        for edge in traverse.traverse_edges(specs, cover="edges", deptype=deptypes, root=False):
+            deptype_lookup[edge.spec.dag_hash()] |= edge.depflag
+
     for d, dep_spec in traverse.traverse_tree(
         sorted(specs), cover=cover, deptype=deptypes, depth_first=depth_first, key=key
     ):
@@ -1358,11 +1364,7 @@ def tree(
 
         if show_types:
             if cover == "nodes":
-                # when only covering nodes, we merge dependency types
-                # from all dependents before showing them.
-                depflag = 0
-                for ds in node.edges_from_dependents():
-                    depflag |= ds.depflag
+                depflag = deptype_lookup[dep_spec.spec.dag_hash()]
             else:
                 # when covering edges or paths, we show dependency
                 # types only for the edge through which we visited

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -978,6 +978,31 @@ class TestSpecDag:
         assert "version-test-pkg" not in out
 
 
+def test_tree_cover_nodes_reduce_deptype():
+    """Test that tree output with deptypes sticks to the sub-dag of interest, instead of looking
+    at in-edges from nodes not reachable from the root."""
+    a, b, c, d = Spec("a"), Spec("b"), Spec("c"), Spec("d")
+    a.add_dependency_edge(d, depflag=dt.BUILD, virtuals=())
+    a.add_dependency_edge(b, depflag=dt.LINK, virtuals=())
+    b.add_dependency_edge(d, depflag=dt.LINK, virtuals=())
+    c.add_dependency_edge(d, depflag=dt.RUN | dt.TEST, virtuals=())
+    assert (
+        a.tree(cover="nodes", show_types=True)
+        == """\
+[    ]  a
+[ l  ]      ^b
+[bl  ]      ^d
+"""
+    )
+    assert (
+        c.tree(cover="nodes", show_types=True)
+        == """\
+[    ]  c
+[  rt]      ^d
+"""
+    )
+
+
 def test_synthetic_construction_of_split_dependencies_from_same_package(mock_packages, config):
     # Construct in a synthetic way (i.e. without using the solver)
     # the following spec:


### PR DESCRIPTION
Fix a bug where Spec.tree with cover=nodes reduces deptypes from all
in-edges, including from nodes not reachable from the root, which almost
always happens for concrete specs

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
