### PR TITLE
Patch FFTW detection in libvdwxc

### DIFF
--- a/var/spack/repos/builtin/packages/libvdwxc/fftw-detection.patch
+++ b/var/spack/repos/builtin/packages/libvdwxc/fftw-detection.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 494ea9f..1ca6516 100755
+--- a/configure
++++ b/configure
+@@ -17006,7 +17006,7 @@ int
+ main ()
+ {
+ 
+-        fftw_plan *plan;
++        fftw_plan plan;
+         fftw_complex *a1, *a2;
+         fftw_execute_dft(plan, a1, a2);
+ 

--- a/var/spack/repos/builtin/packages/libvdwxc/package.py
+++ b/var/spack/repos/builtin/packages/libvdwxc/package.py
@@ -52,6 +52,11 @@ class Libvdwxc(AutotoolsPackage):
 
         return args
 
-    # misuse of fftw_plan in m4 for fftw detection
-    # fails with gcc 14 (and presumably newer)
-    patch("fftw-detection.patch", when="%gcc@14:")
+    # misuse of fftw_plan in m4 for fftw detection (configure fails with gcc 14)
+    # two patches for (1) m4 macro from upstream and (2) pre-generated configure in tarball
+    patch(
+        "https://gitlab.com/libvdwxc/libvdwxc/-/commit/9340f857515c4a2e56d2aa7cf3a21c41ba8559c3.diff",
+        sha256="b9ad695e54a25d7ffa92f783bb0a31d3b421225f97958972e32ba42893844b80",
+        when="@:0.4.0",
+    )
+    patch("fftw-detection.patch", when="@:0.4.0")

--- a/var/spack/repos/builtin/packages/libvdwxc/package.py
+++ b/var/spack/repos/builtin/packages/libvdwxc/package.py
@@ -51,3 +51,7 @@ class Libvdwxc(AutotoolsPackage):
             args += ["--without-mpi"]
 
         return args
+
+    # misuse of fftw_plan in m4 for fftw detection
+    # fails with gcc 14 (and presumably newer)
+    patch("fftw-detection.patch", when="%gcc@14:")


### PR DESCRIPTION
With GCC 14.1 configure fails during the FFTW detection with:
```
conftest.c:42:26: error: passing argument 1 of 'fftw_execute_dft' from incompatible pointer type [-Wincompatible-pointer-types]
   42 |         fftw_execute_dft(plan, a1, a2);
      |                          ^~~~
      |                          |
      |                          struct fftw_plan_s **
```

The same fix would also be required for `config/m4/fftw3.m4`. I did not change it because `configure` is not re-created during the `autoreconf` step and this seems in line with https://spack.readthedocs.io/en/latest/build_systems/autotoolspackage.html#patching-configure-or-makefile-in-files. If require, I can update the patch.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
