### PR TITLE
abseil-cpp: patch to avoid googletest build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/abseil-cpp/package.py
+++ b/var/spack/repos/builtin/packages/abseil-cpp/package.py
@@ -66,6 +66,13 @@ class AbseilCpp(CMakePackage):
     version("20181200", sha256="e2b53bfb685f5d4130b84c4f3050c81bf48c497614dc85d91dbd3ed9129bce6d")
     version("20180600", sha256="794d483dd9a19c43dc1fbbe284ce8956eb7f2600ef350dac4c602f9b4eb26e90")
 
+    # Avoid export of testonly target absl::test_allocator in CMake builds
+    patch(
+        "https://github.com/abseil/abseil-cpp/commit/779a3565ac6c5b69dd1ab9183e500a27633117d5.patch?full_index=1",
+        sha256="14ad7abbc20b10d57e00d0940e8338f69fd69f58d8285214848998e8687688cc",
+        when="@20240116",
+    )
+
     variant("shared", default=True, description="Build shared instead of static libraries")
 
     conflicts("+shared", when="@:20190808")


### PR DESCRIPTION
Abseil added an unintentional GTest dependency (https://github.com/abseil/abseil-cpp/commit/821756c32ee197556905a94910e631721113dbb3), which was subsequently fixed (https://github.com/abseil/abseil-cpp/commit/779a3565ac6c5b69dd1ab9183e500a27633117d5).

This PR propagates the upstream patch to the affected versions to fix the build error.

```console
==> Installing abseil-cpp-20240116.2-j4dzge6ffaqd3lgzckjonn73mcb5gwcy [157/447]
==> No binary for abseil-cpp-20240116.2-j4dzge6ffaqd3lgzckjonn73mcb5gwcy found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/73/733726b8c3a6d39a4120d7e45ea8b41a434cdacde401cba500f14236c49b39dc.tar.gz
==> No patches needed for abseil-cpp
==> abseil-cpp: Executing phase: 'cmake'
==> Error: ProcessError: Command exited with status 1:
    '/opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/cmake-3.30.0-yaplr2hngzu4jswtfehnibgp7wiij3l5/bin/cmake' '-G' 'Unix Makefiles' '-DCMAKE_INSTALL_PREFIX:STRING=/opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/abseil-cpp-20240116.2-j4dzge6ffaqd3lgzckjonn73mcb5gwcy' '-DCMAKE_BUILD_TYPE:STRING=Release' '-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON' '-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=OFF' '-DCMAKE_POLICY_DEFAULT_CMP0090:STRING=NEW' '-DCMAKE_FIND_USE_PACKAGE_REGISTRY:BOOL=OFF' '-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON' '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=ON' '-DCMAKE_INSTALL_RPATH:STRING=/opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/abseil-cpp-20240116.2-j4dzge6ffaqd3lgzckjonn73mcb5gwcy/lib;/opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/abseil-cpp-20240116.2-j4dzge6ffaqd3lgzckjonn73mcb5gwcy/lib64;/opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/gcc-runtime-13.2.0-rjdzeospkw5e34uqtojoxashekrwwm7c/lib' '-DCMAKE_PREFIX_PATH:STRING=/opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/cmake-3.30.0-yaplr2hngzu4jswtfehnibgp7wiij3l5;/opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/gmake-4.4.1-hsxivdtzf5u4nk6tp4iibyqlqujfp2sr;/opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/gcc-runtime-13.2.0-rjdzeospkw5e34uqtojoxashekrwwm7c' '-DBUILD_TESTING:BOOL=OFF' '-DBUILD_SHARED_LIBS:BOOL=ON' '-DCMAKE_CXX_STANDARD:STRING=14' '/opt/spack/stage/wdconinc/spack-stage-abseil-cpp-20240116.2-j4dzge6ffaqd3lgzckjonn73mcb5gwcy/spack-src'

1 error found in build log:
     17    -- Performing Test ABSL_INTERNAL_AT_LEAST_CXX20
     18    -- Performing Test ABSL_INTERNAL_AT_LEAST_CXX20 - Failed
     19    -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
     20    -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
     21    -- Found Threads: TRUE
     22    -- Configuring done (0.4s)
  >> 23    CMake Error at CMake/AbseilHelpers.cmake:317 (target_link_libraries):
     24      The link interface of target "test_allocator" contains:
     25    
     26        GTest::gmock
     27    
     28      but the target was not found.  Possible reasons include:
     29    

See build log for details:
  /opt/spack/stage/wdconinc/spack-stage-abseil-cpp-20240116.2-j4dzge6ffaqd3lgzckjonn73mcb5gwcy/spack-build-out.txt

```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
