### PR TITLE
Fix conflicting use of `config` and `mutable_config` fixtures in unit tests

### DIFF
--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -177,7 +177,7 @@ def test_cc_not_changed_by_modules(monkeypatch, working_env):
 
 
 def test_setup_dependent_package_inherited_modules(
-    config, working_env, mock_packages, install_mockery, mock_fetch
+    working_env, mock_packages, install_mockery, mock_fetch
 ):
     # This will raise on regression
     s = spack.spec.Spec("cmake-client-inheritor").concretized()

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -94,7 +94,7 @@ class TestTargets:
 
 
 @pytest.mark.not_on_windows("autotools not available on windows")
-@pytest.mark.usefixtures("config", "mock_packages")
+@pytest.mark.usefixtures("mock_packages")
 class TestAutotoolsPackage:
     def test_with_or_without(self, default_mock_concretization):
         s = default_mock_concretization("a")
@@ -139,11 +139,9 @@ class TestAutotoolsPackage:
         assert "--without-baz" in options
         assert "--no-fee" in options
 
-    def test_libtool_archive_files_are_deleted_by_default(
-        self, default_mock_concretization, mutable_database
-    ):
+    def test_libtool_archive_files_are_deleted_by_default(self, mutable_database):
         # Install a package that creates a mock libtool archive
-        s = default_mock_concretization("libtool-deletion")
+        s = Spec("libtool-deletion").concretized()
         s.package.do_install(explicit=True)
 
         # Assert the libtool archive is not there and we have
@@ -154,25 +152,23 @@ class TestAutotoolsPackage:
         assert libtool_deletion_log
 
     def test_libtool_archive_files_might_be_installed_on_demand(
-        self, mutable_database, monkeypatch, default_mock_concretization
+        self, mutable_database, monkeypatch
     ):
         # Install a package that creates a mock libtool archive,
         # patch its package to preserve the installation
-        s = default_mock_concretization("libtool-deletion")
+        s = Spec("libtool-deletion").concretized()
         monkeypatch.setattr(type(s.package.builder), "install_libtool_archives", True)
         s.package.do_install(explicit=True)
 
         # Assert libtool archives are installed
         assert os.path.exists(s.package.builder.libtool_archive_file)
 
-    def test_autotools_gnuconfig_replacement(self, default_mock_concretization, mutable_database):
+    def test_autotools_gnuconfig_replacement(self, mutable_database):
         """
         Tests whether only broken config.sub and config.guess are replaced with
         files from working alternatives from the gnuconfig package.
         """
-        s = default_mock_concretization(
-            "autotools-config-replacement +patch_config_files +gnuconfig"
-        )
+        s = Spec("autotools-config-replacement +patch_config_files +gnuconfig").concretized()
         s.package.do_install()
 
         with open(os.path.join(s.prefix.broken, "config.sub")) as f:
@@ -187,15 +183,11 @@ class TestAutotoolsPackage:
         with open(os.path.join(s.prefix.working, "config.guess")) as f:
             assert "gnuconfig version of config.guess" not in f.read()
 
-    def test_autotools_gnuconfig_replacement_disabled(
-        self, default_mock_concretization, mutable_database
-    ):
+    def test_autotools_gnuconfig_replacement_disabled(self, mutable_database):
         """
         Tests whether disabling patch_config_files
         """
-        s = default_mock_concretization(
-            "autotools-config-replacement ~patch_config_files +gnuconfig"
-        )
+        s = Spec("autotools-config-replacement ~patch_config_files +gnuconfig").concretized()
         s.package.do_install()
 
         with open(os.path.join(s.prefix.broken, "config.sub")) as f:

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -199,7 +199,7 @@ def test_setup_spack_repro_version(tmpdir, capfd, last_two_git_commits, monkeypa
     assert "Unable to merge {0}".format(c1) in err
 
 
-def test_get_spec_filter_list(mutable_mock_env_path, config, mutable_mock_repo):
+def test_get_spec_filter_list(mutable_mock_env_path, mutable_mock_repo):
     """Test that given an active environment and list of touched pkgs,
     we get the right list of possibly-changed env specs"""
     e1 = ev.create("test")
@@ -253,7 +253,7 @@ def test_get_spec_filter_list(mutable_mock_env_path, config, mutable_mock_repo):
 
 
 @pytest.mark.regression("29947")
-def test_affected_specs_on_first_concretization(mutable_mock_env_path, mock_packages, config):
+def test_affected_specs_on_first_concretization(mutable_mock_env_path, mock_packages):
     e = ev.create("first_concretization")
     e.add("mpileaks~shared")
     e.add("mpileaks+shared")
@@ -322,12 +322,12 @@ def test_ci_run_standalone_tests_missing_requirements(
 
 @pytest.mark.not_on_windows("Reliance on bash script not supported on Windows")
 def test_ci_run_standalone_tests_not_installed_junit(
-    tmp_path, repro_dir, working_env, default_mock_concretization, mock_test_stage, capfd
+    tmp_path, repro_dir, working_env, mock_test_stage, capfd, mock_packages
 ):
     log_file = tmp_path / "junit.xml"
     args = {
         "log_file": str(log_file),
-        "job_spec": default_mock_concretization("printing-package"),
+        "job_spec": spack.spec.Spec("printing-package").concretized(),
         "repro_dir": str(repro_dir),
         "fail_fast": True,
     }
@@ -340,13 +340,13 @@ def test_ci_run_standalone_tests_not_installed_junit(
 
 @pytest.mark.not_on_windows("Reliance on bash script not supported on Windows")
 def test_ci_run_standalone_tests_not_installed_cdash(
-    tmp_path, repro_dir, working_env, default_mock_concretization, mock_test_stage, capfd
+    tmp_path, repro_dir, working_env, mock_test_stage, capfd, mock_packages
 ):
     """Test run_standalone_tests with cdash and related options."""
     log_file = tmp_path / "junit.xml"
     args = {
         "log_file": str(log_file),
-        "job_spec": default_mock_concretization("printing-package"),
+        "job_spec": spack.spec.Spec("printing-package").concretized(),
         "repro_dir": str(repro_dir),
     }
 

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -72,7 +72,6 @@ def test_parse_spec_flags_with_spaces(specs, cflags, propagation, negated_varian
         assert "~{0}".format(v) in s
 
 
-@pytest.mark.usefixtures("config")
 def test_match_spec_env(mock_packages, mutable_mock_env_path):
     """
     Concretize a spec with non-default options in an environment. Make
@@ -93,7 +92,6 @@ def test_match_spec_env(mock_packages, mutable_mock_env_path):
         assert env_spec.concrete
 
 
-@pytest.mark.usefixtures("config")
 def test_multiple_env_match_raises_error(mock_packages, mutable_mock_env_path):
     e = ev.create("test")
     e.add("a foobar=baz")
@@ -106,7 +104,6 @@ def test_multiple_env_match_raises_error(mock_packages, mutable_mock_env_path):
     assert "matches multiple specs" in exc_info.value.message
 
 
-@pytest.mark.usefixtures("config")
 def test_root_and_dep_match_returns_root(mock_packages, mutable_mock_env_path):
     e = ev.create("test")
     e.add("b@0.9")

--- a/lib/spack/spack/test/cmd/concretize.py
+++ b/lib/spack/spack/test/cmd/concretize.py
@@ -10,7 +10,7 @@ import spack.environment as ev
 from spack import spack_version
 from spack.main import SpackCommand
 
-pytestmark = pytest.mark.usefixtures("config", "mutable_mock_repo")
+pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_repo")
 
 env = SpackCommand("env")
 add = SpackCommand("add")

--- a/lib/spack/spack/test/cmd/deconcretize.py
+++ b/lib/spack/spack/test/cmd/deconcretize.py
@@ -12,7 +12,7 @@ deconcretize = SpackCommand("deconcretize")
 
 
 @pytest.fixture(scope="function")
-def test_env(mutable_mock_env_path, config, mock_packages):
+def test_env(mutable_mock_env_path, mock_packages):
     ev.create("test")
     with ev.read("test") as e:
         e.add("a@2.0 foobar=bar ^b@1.0")

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -40,7 +40,7 @@ from spack.version import Version
 # TODO-27021
 # everything here uses the mock_env_path
 pytestmark = [
-    pytest.mark.usefixtures("mutable_mock_env_path", "mutable_mock_repo"),
+    pytest.mark.usefixtures("mutable_config", "mutable_mock_env_path", "mutable_mock_repo"),
     pytest.mark.maybeslow,
     pytest.mark.not_on_windows("Envs unsupported on Window"),
 ]
@@ -812,7 +812,6 @@ spack:
     assert not e2.specs_by_hash
 
 
-@pytest.mark.usefixtures("config")
 def test_env_view_external_prefix(tmp_path, mutable_database, mock_packages):
     fake_prefix = tmp_path / "a-prefix"
     fake_bin = fake_prefix / "bin"
@@ -1559,7 +1558,6 @@ def test_uninstall_removes_from_env(mock_stage, mock_fetch, install_mockery):
     assert not test.user_specs
 
 
-@pytest.mark.usefixtures("config")
 def test_indirect_build_dep(tmp_path):
     """Simple case of X->Y->Z where Y is a build/link dep and Z is a
     build-only dep. Make sure this concrete DAG is preserved when writing the
@@ -1587,7 +1585,6 @@ def test_indirect_build_dep(tmp_path):
         assert x_env_spec == x_concretized
 
 
-@pytest.mark.usefixtures("config")
 def test_store_different_build_deps(tmp_path):
     r"""Ensure that an environment can store two instances of a build-only
     dependency::
@@ -2328,7 +2325,7 @@ spack:
             assert mpileaks_spec not in after_conc
 
 
-def test_stack_concretize_extraneous_deps(tmpdir, config, mock_packages):
+def test_stack_concretize_extraneous_deps(tmpdir, mock_packages):
     # FIXME: The new concretizer doesn't handle yet soft
     # FIXME: constraints for stacks
     # FIXME: This now works for statically-determinable invalid deps
@@ -2367,7 +2364,7 @@ spack:
                 assert concrete.satisfies("^mpi")
 
 
-def test_stack_concretize_extraneous_variants(tmpdir, config, mock_packages):
+def test_stack_concretize_extraneous_variants(tmpdir, mock_packages):
     filename = str(tmpdir.join("spack.yaml"))
     with open(filename, "w") as f:
         f.write(
@@ -2399,7 +2396,7 @@ spack:
                 assert concrete.variants["shared"].value == user.variants["shared"].value
 
 
-def test_stack_concretize_extraneous_variants_with_dash(tmpdir, config, mock_packages):
+def test_stack_concretize_extraneous_variants_with_dash(tmpdir, mock_packages):
     filename = str(tmpdir.join("spack.yaml"))
     with open(filename, "w") as f:
         f.write(
@@ -3750,7 +3747,7 @@ def test_environment_query_spec_by_hash(mock_stage, mock_fetch, install_mockery)
 
 
 @pytest.mark.parametrize("lockfile", ["v1", "v2", "v3"])
-def test_read_old_lock_and_write_new(config, tmpdir, lockfile):
+def test_read_old_lock_and_write_new(tmpdir, lockfile):
     # v1 lockfiles stored by a coarse DAG hash that did not include build deps.
     # They could not represent multiple build deps with different build hashes.
     #
@@ -3816,7 +3813,7 @@ def test_read_old_lock_and_write_new(config, tmpdir, lockfile):
     assert old_hashes == hashes
 
 
-def test_read_v1_lock_creates_backup(config, tmp_path):
+def test_read_v1_lock_creates_backup(tmp_path):
     """When reading a version-1 lockfile, make sure that a backup of that file
     is created.
     """
@@ -4199,7 +4196,7 @@ def test_env_include_packages_url(
         assert "openmpi" in cfg["all"]["providers"]["mpi"]
 
 
-def test_relative_view_path_on_command_line_is_made_absolute(tmp_path, config):
+def test_relative_view_path_on_command_line_is_made_absolute(tmp_path):
     with fs.working_dir(str(tmp_path)):
         env("create", "--with-view", "view", "--dir", "env")
         environment = ev.Environment(os.path.join(".", "env"))

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -40,7 +40,7 @@ from spack.version import Version
 # TODO-27021
 # everything here uses the mock_env_path
 pytestmark = [
-    pytest.mark.usefixtures("mutable_mock_env_path", "config", "mutable_mock_repo"),
+    pytest.mark.usefixtures("mutable_mock_env_path", "mutable_mock_repo"),
     pytest.mark.maybeslow,
     pytest.mark.not_on_windows("Envs unsupported on Window"),
 ]

--- a/lib/spack/spack/test/cmd/extensions.py
+++ b/lib/spack/spack/test/cmd/extensions.py
@@ -24,7 +24,7 @@ def python_database(mock_packages, mutable_database):
 
 @pytest.mark.not_on_windows("All Fetchers Failed")
 @pytest.mark.db
-def test_extensions(mock_packages, python_database, config, capsys):
+def test_extensions(mock_packages, python_database, capsys):
     ext2 = Spec("py-extension2").concretized()
 
     def check_output(ni):

--- a/lib/spack/spack/test/cmd/fetch.py
+++ b/lib/spack/spack/test/cmd/fetch.py
@@ -9,7 +9,9 @@ import spack.environment as ev
 from spack.main import SpackCommand, SpackCommandError
 
 # everything here uses the mock_env_path
-pytestmark = pytest.mark.usefixtures("mutable_mock_env_path", "mutable_config", "mutable_mock_repo")
+pytestmark = pytest.mark.usefixtures(
+    "mutable_mock_env_path", "mutable_config", "mutable_mock_repo"
+)
 
 
 @pytest.mark.disable_clean_stage_check

--- a/lib/spack/spack/test/cmd/fetch.py
+++ b/lib/spack/spack/test/cmd/fetch.py
@@ -9,7 +9,7 @@ import spack.environment as ev
 from spack.main import SpackCommand, SpackCommandError
 
 # everything here uses the mock_env_path
-pytestmark = pytest.mark.usefixtures("mutable_mock_env_path", "config", "mutable_mock_repo")
+pytestmark = pytest.mark.usefixtures("mutable_mock_env_path", "mutable_config", "mutable_mock_repo")
 
 
 @pytest.mark.disable_clean_stage_check

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -337,7 +337,7 @@ def test_find_command_basic_usage(database):
 @pytest.mark.not_on_windows("envirnment is not yet supported on windows")
 @pytest.mark.regression("9875")
 def test_find_prefix_in_env(
-    mutable_mock_env_path, install_mockery, mock_fetch, mock_packages, mock_archive, config
+    mutable_mock_env_path, install_mockery, mock_fetch, mock_packages, mock_archive
 ):
     """Test `find` formats requiring concrete specs work in environments."""
     env("create", "test")

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -349,7 +349,7 @@ def test_find_prefix_in_env(
         # Would throw error on regression
 
 
-def test_find_specs_include_concrete_env(mutable_mock_env_path, config, mutable_mock_repo, tmpdir):
+def test_find_specs_include_concrete_env(mutable_mock_env_path, mutable_mock_repo, tmpdir):
     path = tmpdir.join("spack.yaml")
 
     with tmpdir.as_cwd():
@@ -393,9 +393,7 @@ spack:
     assert "libelf" in output
 
 
-def test_find_specs_nested_include_concrete_env(
-    mutable_mock_env_path, config, mutable_mock_repo, tmpdir
-):
+def test_find_specs_nested_include_concrete_env(mutable_mock_env_path, mutable_mock_repo, tmpdir):
     path = tmpdir.join("spack.yaml")
 
     with tmpdir.as_cwd():

--- a/lib/spack/spack/test/cmd/gc.py
+++ b/lib/spack/spack/test/cmd/gc.py
@@ -20,13 +20,13 @@ pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 @pytest.mark.db
-def test_gc_without_build_dependency(config, mutable_database):
+def test_gc_without_build_dependency(mutable_database):
     assert "There are no unused specs." in gc("-yb")
     assert "There are no unused specs." in gc("-y")
 
 
 @pytest.mark.db
-def test_gc_with_build_dependency(config, mutable_database):
+def test_gc_with_build_dependency(mutable_database):
     s = spack.spec.Spec("simple-inheritance")
     s.concretize()
     s.package.do_install(fake=True, explicit=True)
@@ -37,7 +37,7 @@ def test_gc_with_build_dependency(config, mutable_database):
 
 
 @pytest.mark.db
-def test_gc_with_environment(config, mutable_database, mutable_mock_env_path):
+def test_gc_with_environment(mutable_database, mutable_mock_env_path):
     s = spack.spec.Spec("simple-inheritance")
     s.concretize()
     s.package.do_install(fake=True, explicit=True)
@@ -53,7 +53,7 @@ def test_gc_with_environment(config, mutable_database, mutable_mock_env_path):
 
 
 @pytest.mark.db
-def test_gc_with_build_dependency_in_environment(config, mutable_database, mutable_mock_env_path):
+def test_gc_with_build_dependency_in_environment(mutable_database, mutable_mock_env_path):
     s = spack.spec.Spec("simple-inheritance")
     s.concretize()
     s.package.do_install(fake=True, explicit=True)
@@ -78,7 +78,7 @@ def test_gc_with_build_dependency_in_environment(config, mutable_database, mutab
 
 
 @pytest.mark.db
-def test_gc_except_any_environments(config, mutable_database, mutable_mock_env_path):
+def test_gc_except_any_environments(mutable_database, mutable_mock_env_path):
     """Tests whether the garbage collector can remove all specs except those still needed in some
     environment (needed in the sense of roots + link/run deps)."""
     assert mutable_database.query_local("zmpi")
@@ -105,7 +105,7 @@ def test_gc_except_any_environments(config, mutable_database, mutable_mock_env_p
 
 
 @pytest.mark.db
-def test_gc_except_specific_environments(config, mutable_database, mutable_mock_env_path):
+def test_gc_except_specific_environments(mutable_database, mutable_mock_env_path):
     s = spack.spec.Spec("simple-inheritance")
     s.concretize()
     s.package.do_install(fake=True, explicit=True)
@@ -125,14 +125,14 @@ def test_gc_except_specific_environments(config, mutable_database, mutable_mock_
 
 
 @pytest.mark.db
-def test_gc_except_nonexisting_dir_env(config, mutable_database, mutable_mock_env_path, tmpdir):
+def test_gc_except_nonexisting_dir_env(mutable_database, mutable_mock_env_path, tmpdir):
     output = gc("-ye", tmpdir.strpath, fail_on_error=False)
     assert "No such environment" in output
     gc.returncode == 1
 
 
 @pytest.mark.db
-def test_gc_except_specific_dir_env(config, mutable_database, mutable_mock_env_path, tmpdir):
+def test_gc_except_specific_dir_env(mutable_database, mutable_mock_env_path, tmpdir):
     s = spack.spec.Spec("simple-inheritance")
     s.concretize()
     s.package.do_install(fake=True, explicit=True)

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -49,7 +49,7 @@ def noop_install(monkeypatch):
 
 
 def test_install_package_and_dependency(
-    tmpdir, mock_packages, mock_archive, mock_fetch, config, install_mockery
+    tmpdir, mock_packages, mock_archive, mock_fetch, install_mockery
 ):
     log = "test"
     with tmpdir.as_cwd():
@@ -93,7 +93,7 @@ def test_install_runtests_all(monkeypatch, mock_packages, install_mockery):
 
 
 def test_install_package_already_installed(
-    tmpdir, mock_packages, mock_archive, mock_fetch, config, install_mockery
+    tmpdir, mock_packages, mock_archive, mock_fetch, install_mockery
 ):
     with tmpdir.as_cwd():
         install("libdwarf")
@@ -149,7 +149,7 @@ def test_package_output(tmpdir, capsys, install_mockery, mock_fetch):
 
 @pytest.mark.disable_clean_stage_check
 def test_install_output_on_build_error(
-    mock_packages, mock_archive, mock_fetch, config, install_mockery, capfd
+    mock_packages, mock_archive, mock_fetch, install_mockery, capfd
 ):
     """
     This test used to assume receiving full output, but since we've updated
@@ -163,9 +163,7 @@ def test_install_output_on_build_error(
 
 
 @pytest.mark.disable_clean_stage_check
-def test_install_output_on_python_error(
-    mock_packages, mock_archive, mock_fetch, config, install_mockery
-):
+def test_install_output_on_python_error(mock_packages, mock_archive, mock_fetch, install_mockery):
     out = install("failing-build", fail_on_error=False)
     assert isinstance(install.error, spack.build_environment.ChildError)
     assert install.error.name == "InstallError"
@@ -173,7 +171,7 @@ def test_install_output_on_python_error(
 
 
 @pytest.mark.disable_clean_stage_check
-def test_install_with_source(mock_packages, mock_archive, mock_fetch, config, install_mockery):
+def test_install_with_source(mock_packages, mock_archive, mock_fetch, install_mockery):
     """Verify that source has been copied into place."""
     install("--source", "--keep-stage", "trivial-install-test-package")
     spec = Spec("trivial-install-test-package").concretized()
@@ -183,7 +181,7 @@ def test_install_with_source(mock_packages, mock_archive, mock_fetch, config, in
     )
 
 
-def test_install_env_variables(mock_packages, mock_archive, mock_fetch, config, install_mockery):
+def test_install_env_variables(mock_packages, mock_archive, mock_fetch, install_mockery):
     spec = Spec("libdwarf")
     spec.concretize()
     install("libdwarf")
@@ -191,9 +189,7 @@ def test_install_env_variables(mock_packages, mock_archive, mock_fetch, config, 
 
 
 @pytest.mark.disable_clean_stage_check
-def test_show_log_on_error(
-    mock_packages, mock_archive, mock_fetch, config, install_mockery, capfd
-):
+def test_show_log_on_error(mock_packages, mock_archive, mock_fetch, install_mockery, capfd):
     """
     Make sure --show-log-on-error works.
     """
@@ -206,7 +202,7 @@ def test_show_log_on_error(
     assert "See build log for details:" in out
 
 
-def test_install_overwrite(mock_packages, mock_archive, mock_fetch, config, install_mockery):
+def test_install_overwrite(mock_packages, mock_archive, mock_fetch, install_mockery):
     # Try to install a spec and then to reinstall it.
     spec = Spec("libdwarf")
     spec.concretize()
@@ -240,9 +236,7 @@ def test_install_overwrite(mock_packages, mock_archive, mock_fetch, config, inst
     assert fs.hash_directory(spec.prefix, ignore=ignores) != bad_md5
 
 
-def test_install_overwrite_not_installed(
-    mock_packages, mock_archive, mock_fetch, config, install_mockery
-):
+def test_install_overwrite_not_installed(mock_packages, mock_archive, mock_fetch, install_mockery):
     # Try to install a spec and then to reinstall it.
     spec = Spec("libdwarf")
     spec.concretize()
@@ -277,9 +271,7 @@ def test_install_commit(mock_git_version_info, install_mockery, mock_packages, m
     assert content == "[0]"  # contents are weird for another test
 
 
-def test_install_overwrite_multiple(
-    mock_packages, mock_archive, mock_fetch, config, install_mockery
-):
+def test_install_overwrite_multiple(mock_packages, mock_archive, mock_fetch, install_mockery):
     # Try to install a spec and then to reinstall it.
     libdwarf = Spec("libdwarf")
     libdwarf.concretize()
@@ -337,18 +329,14 @@ def test_install_overwrite_multiple(
     assert cm_hash != bad_cmake_md5
 
 
-@pytest.mark.usefixtures(
-    "mock_packages", "mock_archive", "mock_fetch", "config", "install_mockery"
-)
+@pytest.mark.usefixtures("mock_packages", "mock_archive", "mock_fetch", "install_mockery")
 def test_install_conflicts(conflict_spec):
     # Make sure that spec with conflicts raises a SpackError
     with pytest.raises(SpackError):
         install(conflict_spec)
 
 
-@pytest.mark.usefixtures(
-    "mock_packages", "mock_archive", "mock_fetch", "config", "install_mockery"
-)
+@pytest.mark.usefixtures("mock_packages", "mock_archive", "mock_fetch", "install_mockery")
 def test_install_invalid_spec(invalid_spec):
     # Make sure that invalid specs raise a SpackError
     with pytest.raises(SpecSyntaxError, match="unexpected tokens"):
@@ -390,9 +378,7 @@ def test_install_from_file(spec, concretize, error_code, tmpdir):
 
 
 @pytest.mark.disable_clean_stage_check
-@pytest.mark.usefixtures(
-    "mock_packages", "mock_archive", "mock_fetch", "config", "install_mockery"
-)
+@pytest.mark.usefixtures("mock_packages", "mock_archive", "mock_fetch", "install_mockery")
 @pytest.mark.parametrize(
     "exc_typename,msg",
     [("RuntimeError", "something weird happened"), ("ValueError", "spec is not concrete")],
@@ -448,7 +434,6 @@ def test_junit_output_with_errors(
     mock_archive,
     mock_fetch,
     install_mockery,
-    config,
     tmpdir,
     monkeypatch,
 ):
@@ -509,9 +494,7 @@ def test_install_mix_cli_and_files(clispecs, filespecs, tmpdir):
     assert install.returncode == 0
 
 
-def test_extra_files_are_archived(
-    mock_packages, mock_archive, mock_fetch, config, install_mockery
-):
+def test_extra_files_are_archived(mock_packages, mock_archive, mock_fetch, install_mockery):
     s = Spec("archive-files")
     s.concretize()
 
@@ -629,7 +612,7 @@ def test_cdash_buildstamp_param(tmpdir, mock_fetch, install_mockery, capfd):
 
 @pytest.mark.disable_clean_stage_check
 def test_cdash_install_from_spec_json(
-    tmpdir, mock_fetch, install_mockery, capfd, mock_packages, mock_archive, config
+    tmpdir, mock_fetch, install_mockery, capfd, mock_packages, mock_archive
 ):
     # capfd interferes with Spack's capturing
     with capfd.disabled():

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -17,7 +17,7 @@ from spack.main import SpackCommand, SpackCommandError
 
 # Everything here uses (or can use) the mock config and database.
 pytestmark = [
-    pytest.mark.usefixtures("config", "database"),
+    pytest.mark.usefixtures("mutable_config", "mutable_database"),
     pytest.mark.not_on_windows("does not run on windows"),
 ]
 # location prints out "locations of packages and spack directories"

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -35,7 +35,7 @@ def test_regression_8083(tmpdir, capfd, mock_packages, mock_fetch, config):
 
 
 @pytest.mark.regression("12345")
-def test_mirror_from_env(tmp_path, mock_packages, mock_fetch, config, mutable_mock_env_path):
+def test_mirror_from_env(tmp_path, mock_packages, mock_fetch, mutable_mock_env_path):
     mirror_dir = str(tmp_path / "mirror")
     env_name = "test"
 

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -139,7 +139,7 @@ def test_find_recursive():
 
 
 @pytest.mark.db
-def test_find_recursive_excluded(database, module_configuration):
+def test_find_recursive_excluded(mutable_database, module_configuration):
     module_configuration("exclude")
 
     module("lmod", "refresh", "-y", "--delete-tree")
@@ -147,7 +147,7 @@ def test_find_recursive_excluded(database, module_configuration):
 
 
 @pytest.mark.db
-def test_loads_recursive_excluded(database, module_configuration):
+def test_loads_recursive_excluded(mutable_database, module_configuration):
     module_configuration("exclude")
 
     module("lmod", "refresh", "-y", "--delete-tree")

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -97,7 +97,7 @@ def test_spec_json():
     assert "mpich" in mpileaks
 
 
-def test_spec_format(database, config):
+def test_spec_format(mutable_database):
     output = spec("--format", "{name}-{^mpi.name}", "mpileaks^mpich")
     assert output.rstrip("\n") == "mpileaks-mpich"
 

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -14,7 +14,7 @@ import spack.spec
 import spack.store
 from spack.main import SpackCommand, SpackCommandError
 
-pytestmark = pytest.mark.usefixtures("config", "mutable_mock_repo")
+pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_repo")
 
 spec = SpackCommand("spec")
 
@@ -31,7 +31,7 @@ def test_spec():
 
 
 @pytest.mark.only_clingo("Known failure of the original concretizer")
-def test_spec_concretizer_args(mutable_config, mutable_database, do_not_check_runtimes_on_reuse):
+def test_spec_concretizer_args(mutable_database, do_not_check_runtimes_on_reuse):
     """End-to-end test of CLI concretizer prefs.
 
     It's here to make sure that everything works from CLI

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -25,13 +25,7 @@ pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 def test_test_package_not_installed(
-    tmpdir,
-    mock_packages,
-    mock_archive,
-    mock_fetch,
-    config,
-    install_mockery_mutable_config,
-    mock_test_stage,
+    tmpdir, mock_packages, mock_archive, mock_fetch, install_mockery, mock_test_stage
 ):
     output = spack_test("run", "libdwarf")
 

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -222,7 +222,7 @@ class TestUninstallFromEnv:
 
     @pytest.fixture(scope="function")
     def environment_setup(
-        self, mutable_mock_env_path, config, mock_packages, mutable_database, install_mockery
+        self, mutable_mock_env_path, mock_packages, mutable_database, install_mockery
     ):
         TestUninstallFromEnv.env("create", "e1")
         e1 = spack.environment.read("e1")

--- a/lib/spack/spack/test/cmd/verify.py
+++ b/lib/spack/spack/test/cmd/verify.py
@@ -63,9 +63,7 @@ def test_single_file_verify_cmd(tmpdir):
     assert sorted(errors) == sorted(expected)
 
 
-def test_single_spec_verify_cmd(
-    tmpdir, mock_packages, mock_archive, mock_fetch, config, install_mockery
-):
+def test_single_spec_verify_cmd(tmpdir, mock_packages, mock_archive, mock_fetch, install_mockery):
     # Test the verify command interface to verify a single spec
     install("libelf")
     s = spack.spec.Spec("libelf").concretized()

--- a/lib/spack/spack/test/cmd/view.py
+++ b/lib/spack/spack/test/cmd/view.py
@@ -28,9 +28,7 @@ def create_projection_file(tmpdir, projection):
 
 
 @pytest.mark.parametrize("cmd", ["hardlink", "symlink", "hard", "add", "copy", "relocate"])
-def test_view_link_type(
-    tmpdir, mock_packages, mock_archive, mock_fetch, config, install_mockery, cmd
-):
+def test_view_link_type(tmpdir, mock_packages, mock_archive, mock_fetch, install_mockery, cmd):
     install("libdwarf")
     viewpath = str(tmpdir.mkdir("view_{0}".format(cmd)))
     view(cmd, viewpath, "libdwarf")
@@ -44,7 +42,7 @@ def test_view_link_type(
 
 @pytest.mark.parametrize("add_cmd", ["hardlink", "symlink", "hard", "add", "copy", "relocate"])
 def test_view_link_type_remove(
-    tmpdir, mock_packages, mock_archive, mock_fetch, config, install_mockery, add_cmd
+    tmpdir, mock_packages, mock_archive, mock_fetch, install_mockery, add_cmd
 ):
     install("needs-relocation")
     viewpath = str(tmpdir.mkdir("view_{0}".format(add_cmd)))
@@ -57,9 +55,7 @@ def test_view_link_type_remove(
 
 
 @pytest.mark.parametrize("cmd", ["hardlink", "symlink", "hard", "add", "copy", "relocate"])
-def test_view_projections(
-    tmpdir, mock_packages, mock_archive, mock_fetch, config, install_mockery, cmd
-):
+def test_view_projections(tmpdir, mock_packages, mock_archive, mock_fetch, install_mockery, cmd):
     install("libdwarf@20130207")
 
     viewpath = str(tmpdir.mkdir("view_{0}".format(cmd)))
@@ -76,7 +72,7 @@ def test_view_projections(
 
 
 def test_view_multiple_projections(
-    tmpdir, mock_packages, mock_archive, mock_fetch, config, install_mockery
+    tmpdir, mock_packages, mock_archive, mock_fetch, install_mockery
 ):
     install("libdwarf@20130207")
     install("extendee@1.0%gcc")
@@ -96,7 +92,7 @@ def test_view_multiple_projections(
 
 
 def test_view_multiple_projections_all_first(
-    tmpdir, mock_packages, mock_archive, mock_fetch, config, install_mockery
+    tmpdir, mock_packages, mock_archive, mock_fetch, install_mockery
 ):
     install("libdwarf@20130207")
     install("extendee@1.0%gcc")
@@ -115,14 +111,14 @@ def test_view_multiple_projections_all_first(
     assert os.path.exists(extendee_prefix)
 
 
-def test_view_external(tmpdir, mock_packages, mock_archive, mock_fetch, config, install_mockery):
+def test_view_external(tmpdir, mock_packages, mock_archive, mock_fetch, install_mockery):
     install("externaltool")
     viewpath = str(tmpdir.mkdir("view"))
     output = view("symlink", viewpath, "externaltool")
     assert "Skipping external package: externaltool" in output
 
 
-def test_view_extension(tmpdir, mock_packages, mock_archive, mock_fetch, config, install_mockery):
+def test_view_extension(tmpdir, mock_packages, mock_archive, mock_fetch, install_mockery):
     install("extendee")
     install("extension1@1.0")
     install("extension1@2.0")
@@ -136,9 +132,7 @@ def test_view_extension(tmpdir, mock_packages, mock_archive, mock_fetch, config,
     assert os.path.exists(os.path.join(viewpath, "bin", "extension1"))
 
 
-def test_view_extension_remove(
-    tmpdir, mock_packages, mock_archive, mock_fetch, config, install_mockery
-):
+def test_view_extension_remove(tmpdir, mock_packages, mock_archive, mock_fetch, install_mockery):
     install("extendee")
     install("extension1@1.0")
     viewpath = str(tmpdir.mkdir("view"))
@@ -149,9 +143,7 @@ def test_view_extension_remove(
     assert not os.path.exists(os.path.join(viewpath, "bin", "extension1"))
 
 
-def test_view_extension_conflict(
-    tmpdir, mock_packages, mock_archive, mock_fetch, config, install_mockery
-):
+def test_view_extension_conflict(tmpdir, mock_packages, mock_archive, mock_fetch, install_mockery):
     install("extendee")
     install("extension1@1.0")
     install("extension1@2.0")
@@ -162,7 +154,7 @@ def test_view_extension_conflict(
 
 
 def test_view_extension_conflict_ignored(
-    tmpdir, mock_packages, mock_archive, mock_fetch, config, install_mockery
+    tmpdir, mock_packages, mock_archive, mock_fetch, install_mockery
 ):
     install("extendee")
     install("extension1@1.0")
@@ -184,7 +176,7 @@ def test_view_fails_with_missing_projections_file(tmpdir):
 @pytest.mark.parametrize("with_projection", [False, True])
 @pytest.mark.parametrize("cmd", ["symlink", "copy"])
 def test_view_files_not_ignored(
-    tmpdir, mock_packages, mock_archive, mock_fetch, config, install_mockery, cmd, with_projection
+    tmpdir, mock_packages, mock_archive, mock_fetch, install_mockery, cmd, with_projection
 ):
     spec = Spec("view-not-ignored").concretized()
     pkg = spec.package

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1593,7 +1593,7 @@ class TestConcretize:
     )
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_concrete_specs_are_not_modified_on_reuse(
-        self, mutable_database, spec_str, expect_installed, config
+        self, mutable_database, spec_str, expect_installed
     ):
         # Test the internal consistency of solve + DAG reconstruction
         # when reused specs are added to the mix. This prevents things
@@ -1856,7 +1856,7 @@ class TestConcretize:
         assert counter == occurances, concrete_specs
 
     @pytest.mark.only_clingo("Original concretizer cannot concretize in rounds")
-    def test_solve_in_rounds_all_unsolved(self, monkeypatch, mock_packages, config):
+    def test_solve_in_rounds_all_unsolved(self, monkeypatch, mock_packages):
         specs = [Spec(x) for x in ["libdwarf%gcc", "libdwarf%clang"]]
         solver = spack.solver.asp.Solver()
         solver.reuse = False
@@ -2219,7 +2219,7 @@ class TestConcretize:
         assert result.specs
 
     @pytest.mark.regression("38664")
-    def test_unsolved_specs_raises_error(self, monkeypatch, mock_packages, config):
+    def test_unsolved_specs_raises_error(self, monkeypatch, mock_packages):
         """Check that the solver raises an exception when input specs are not
         satisfied.
         """
@@ -2239,7 +2239,7 @@ class TestConcretize:
 
     @pytest.mark.regression("43141")
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")
-    def test_clear_error_when_unknown_compiler_requested(self, mock_packages, config):
+    def test_clear_error_when_unknown_compiler_requested(self, mock_packages):
         """Tests that the solver can report a case where the compiler cannot be set"""
         with pytest.raises(
             spack.error.UnsatisfiableSpecError, match="Cannot set the required compiler: a%foo"
@@ -2331,9 +2331,9 @@ class TestConcretize:
         assert s.satisfies("%gcc@12.1.0")
 
     @pytest.mark.parametrize("spec_str", ["mpileaks", "mpileaks ^mpich"])
-    def test_virtuals_are_annotated_on_edges(self, spec_str, default_mock_concretization):
+    def test_virtuals_are_annotated_on_edges(self, spec_str):
         """Tests that information on virtuals is annotated on DAG edges"""
-        spec = default_mock_concretization(spec_str)
+        spec = Spec(spec_str).concretized()
         mpi_provider = spec["mpi"].name
 
         edges = spec.edges_to_dependencies(name=mpi_provider)
@@ -2347,7 +2347,7 @@ class TestConcretize:
         "spec_str,mpi_name",
         [("mpileaks", "mpich"), ("mpileaks ^mpich2", "mpich2"), ("mpileaks ^zmpi", "zmpi")],
     )
-    def test_virtuals_are_reconstructed_on_reuse(self, spec_str, mpi_name, database):
+    def test_virtuals_are_reconstructed_on_reuse(self, spec_str, mpi_name, mutable_database):
         """Tests that when we reuse a spec, virtual on edges are reconstructed correctly"""
         with spack.config.override("concretizer:reuse", True):
             spec = Spec(spec_str).concretized()
@@ -3006,7 +3006,7 @@ def test_concretization_version_order():
         ),
     ],
 )
-@pytest.mark.usefixtures("database", "mock_store")
+@pytest.mark.usefixtures("mutable_database", "mock_store")
 @pytest.mark.not_on_windows("Expected length is different on Windows")
 def test_filtering_reused_specs(
     roots, reuse_yaml, expected, not_expected, expected_length, mutable_config, monkeypatch
@@ -3027,7 +3027,7 @@ def test_filtering_reused_specs(
         assert all(not x.satisfies(constraint) for x in specs)
 
 
-@pytest.mark.usefixtures("database", "mock_store")
+@pytest.mark.usefixtures("mutable_database", "mock_store")
 @pytest.mark.parametrize(
     "reuse_yaml,expected_length",
     [({"from": [{"type": "local"}]}, 17), ({"from": [{"type": "buildcache"}]}, 0)],

--- a/lib/spack/spack/test/concretize_compiler_runtimes.py
+++ b/lib/spack/spack/test/concretize_compiler_runtimes.py
@@ -32,7 +32,7 @@ def _concretize_with_reuse(*, root_str, reused_str):
 
 
 @pytest.fixture
-def runtime_repo(config):
+def runtime_repo(mutable_config):
     repo = os.path.join(spack.paths.repos_path, "compiler_runtime.test")
     with spack.repo.use_repositories(repo) as mock_repo:
         yield mock_repo

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -63,6 +63,12 @@ from spack.fetch_strategy import URLFetchStrategy
 from spack.util.pattern import Bunch
 
 
+@pytest.fixture(autouse=True)
+def check_config_fixture(request):
+    if "config" in request.fixturenames and "mutable_config" in request.fixturenames:
+        raise RuntimeError("'config' and 'mutable_config' are both requested")
+
+
 def ensure_configuration_fixture_run_before(request):
     """Ensure that fixture mutating the configuration run before the one where
     the function is called.

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -96,7 +96,7 @@ spack:
 """
 
 
-def test_env_change_spec_in_definition(tmp_path, mock_packages, config, mutable_mock_env_path):
+def test_env_change_spec_in_definition(tmp_path, mock_packages, mutable_mock_env_path):
     manifest_file = tmp_path / ev.manifest_name
     manifest_file.write_text(_test_matrix_yaml)
     e = ev.create("test", manifest_file)
@@ -118,9 +118,7 @@ def test_env_change_spec_in_definition(tmp_path, mock_packages, config, mutable_
     assert not any(x.intersects("mpileaks@2.1%gcc") for x in e.user_specs)
 
 
-def test_env_change_spec_in_matrix_raises_error(
-    tmp_path, mock_packages, config, mutable_mock_env_path
-):
+def test_env_change_spec_in_matrix_raises_error(tmp_path, mock_packages, mutable_mock_env_path):
     manifest_file = tmp_path / ev.manifest_name
     manifest_file.write_text(_test_matrix_yaml)
     e = ev.create("test", manifest_file)

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -200,13 +200,13 @@ def test_invalid_json_mirror_collection(invalid_json, error_message):
     assert error_message in exc_msg
 
 
-def test_mirror_archive_paths_no_version(mock_packages, config, mock_archive):
+def test_mirror_archive_paths_no_version(mock_packages, mock_archive):
     spec = Spec("trivial-install-test-package@=nonexistingversion").concretized()
     fetcher = spack.fetch_strategy.URLFetchStrategy(mock_archive.url)
     spack.mirror.mirror_archive_paths(fetcher, "per-package-ref", spec)
 
 
-def test_mirror_with_url_patches(mock_packages, config, monkeypatch):
+def test_mirror_with_url_patches(mock_packages, monkeypatch):
     spec = Spec("patch-several-dependencies")
     spec.concretize()
 

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -48,7 +48,7 @@ def provider(request):
     return request.param
 
 
-@pytest.mark.usefixtures("config", "mock_packages")
+@pytest.mark.usefixtures("mutable_config", "mock_packages")
 class TestLmod:
     @pytest.mark.regression("37788")
     @pytest.mark.parametrize("modules_config", ["core_compilers", "core_compilers_at_equal"])
@@ -355,7 +355,6 @@ class TestLmod:
         content = modulefile_content(f"mpileaks target={host_architecture_str}")
         assert "Override even better!" in content
 
-    @pytest.mark.usefixtures("config")
     def test_external_configure_args(self, factory):
         # If this package is detected as an external, its configure option line
         # in the module file starts with 'unknown'

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -26,7 +26,7 @@ pytestmark = [
 ]
 
 
-@pytest.mark.usefixtures("config", "mock_packages", "mock_module_filename")
+@pytest.mark.usefixtures("mutable_config", "mock_packages", "mock_module_filename")
 class TestTcl:
     def test_simple_case(self, modulefile_content, module_configuration):
         """Tests the generation of a simple Tcl module file."""
@@ -439,19 +439,19 @@ class TestTcl:
 
     @pytest.mark.regression("4400")
     @pytest.mark.db
-    def test_hide_implicits_no_arg(self, module_configuration, database):
+    def test_hide_implicits_no_arg(self, module_configuration, mutable_database):
         module_configuration("exclude_implicits")
 
         # mpileaks has been installed explicitly when setting up
         # the tests database
-        mpileaks_specs = database.query("mpileaks")
+        mpileaks_specs = mutable_database.query("mpileaks")
         for item in mpileaks_specs:
             writer = writer_cls(item, "default")
             assert not writer.conf.excluded
 
         # callpath is a dependency of mpileaks, and has been pulled
         # in implicitly
-        callpath_specs = database.query("callpath")
+        callpath_specs = mutable_database.query("callpath")
         for item in callpath_specs:
             writer = writer_cls(item, "default")
             assert writer.conf.excluded
@@ -473,8 +473,7 @@ class TestTcl:
         assert writer.conf.excluded
 
     @pytest.mark.regression("9624")
-    @pytest.mark.db
-    def test_autoload_with_constraints(self, modulefile_content, module_configuration, database):
+    def test_autoload_with_constraints(self, modulefile_content, module_configuration):
         """Tests the automatic loading of direct dependencies."""
 
         module_configuration("autoload_with_constraints")

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -506,9 +506,7 @@ def mock_download():
     "manual,instr", [(False, False), (False, True), (True, False), (True, True)]
 )
 @pytest.mark.disable_clean_stage_check
-def test_manual_download(
-    install_mockery, mock_download, default_mock_concretization, monkeypatch, manual, instr
-):
+def test_manual_download(mock_download, default_mock_concretization, monkeypatch, manual, instr):
     """
     Ensure expected fetcher fail message based on manual download and instr.
     """
@@ -539,18 +537,14 @@ def fetching_not_allowed(monkeypatch):
     monkeypatch.setattr(spack.package_base.PackageBase, "fetcher", FetchingNotAllowed())
 
 
-def test_fetch_without_code_is_noop(
-    default_mock_concretization, install_mockery, fetching_not_allowed
-):
+def test_fetch_without_code_is_noop(default_mock_concretization, fetching_not_allowed):
     """do_fetch for packages without code should be a no-op"""
     pkg = default_mock_concretization("a").package
     pkg.has_code = False
     pkg.do_fetch()
 
 
-def test_fetch_external_package_is_noop(
-    default_mock_concretization, install_mockery, fetching_not_allowed
-):
+def test_fetch_external_package_is_noop(default_mock_concretization, fetching_not_allowed):
     """do_fetch for packages without code should be a no-op"""
     spec = default_mock_concretization("a")
     spec.external_path = "/some/where"

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -229,7 +229,7 @@ def test_nested_directives(mock_packages):
 
 
 @pytest.mark.not_on_windows("Test requires Autotools")
-def test_patched_dependency(mock_packages, config, install_mockery, mock_fetch):
+def test_patched_dependency(mock_packages, install_mockery, mock_fetch):
     """Test whether patched dependencies work."""
     spec = Spec("patch-a-dependency")
     spec.concretize()
@@ -268,7 +268,7 @@ def trigger_bad_patch(pkg):
 
 
 def test_patch_failure_develop_spec_exits_gracefully(
-    mock_packages, config, install_mockery, mock_fetch, tmpdir, mock_stage
+    mock_packages, install_mockery, mock_fetch, tmpdir, mock_stage
 ):
     """ensure that a failing patch does not trigger exceptions for develop specs"""
 
@@ -284,7 +284,7 @@ def test_patch_failure_develop_spec_exits_gracefully(
     # success if no exceptions raised
 
 
-def test_patch_failure_restages(mock_packages, config, install_mockery, mock_fetch):
+def test_patch_failure_restages(mock_packages, install_mockery, mock_fetch):
     """
     ensure that a failing patch does not trigger exceptions
     for non-develop specs and the source gets restaged

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -851,12 +851,12 @@ def test_multiple_specs_with_hash(database, config):
 
 
 @pytest.mark.db
-def test_ambiguous_hash(mutable_database, default_mock_concretization, config):
+def test_ambiguous_hash(mutable_database):
     """Test that abstract hash ambiguity is delayed until concretization.
     In the past this ambiguity error would happen during parse time."""
 
     # This is a very sketchy as manually setting hashes easily breaks invariants
-    x1 = default_mock_concretization("a")
+    x1 = spack.spec.Spec("a").concretized()
     x2 = x1.copy()
     x1._hash = "xyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
     x1._process_hash = "xyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"


### PR DESCRIPTION
This PR adds an auto-fixture that detects tests using both the `config` and the `mutable_config` fixtures (which are incompatible, and run in unspecified order). It also fixes all the cases detected.

In a following PR we could make `mutable_database` / `database` more modular, so that they can be used with both `config` and `mutable_config`.