### PR TITLE
Use ROOT_LIBRARY_PATH and adjust other environment variables

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -774,6 +774,15 @@ class Root(CMakePackage):
             # warnings when building against ROOT
             env.unset("MACOSX_DEPLOYMENT_TARGET")
 
+    @property
+    def root_library_path(self):
+        # Where possible, we do not use LD_LIBRARY_PATH as that is non-portable
+        # and pollutes the standard library-loading mechanisms on Linux systems.
+        # The ROOT_LIBRARY_PATH environment variable was added to ROOT 6.26.
+        if self.spec.satisfies("@:6.25"):
+            return "LD_LIBRARY_PATH"
+        return "ROOT_LIBRARY_PATH"
+
     def setup_run_environment(self, env):
         env.set("ROOTSYS", self.prefix)
         env.set("ROOT_VERSION", "v{0}".format(self.version.up_to(1)))
@@ -782,7 +791,7 @@ class Root(CMakePackage):
         env.set("CLING_STANDARD_PCH", "none")
         env.set("CPPYY_API_PATH", "none")
         if "+rpath" not in self.spec:
-            env.prepend_path("ROOT_LIBRARY_PATH", self.prefix.lib.root)
+            env.prepend_path(self.root_library_path, self.prefix.lib.root)
 
     def setup_dependent_build_environment(
         self, env: spack.util.environment.EnvironmentModifications, dependent_spec
@@ -794,7 +803,7 @@ class Root(CMakePackage):
         env.append_path("CMAKE_MODULE_PATH", self.prefix.cmake)
         env.prepend_path("ROOT_INCLUDE_PATH", dependent_spec.prefix.include)
         if "+rpath" not in self.spec:
-            env.prepend_path("ROOT_LIBRARY_PATH", self.prefix.lib.root)
+            env.prepend_path(self.root_library_path, self.prefix.lib.root)
         if "platform=darwin" in self.spec:
             # Newer deployment targets cause fatal errors in rootcling
             env.unset("MACOSX_DEPLOYMENT_TARGET")
@@ -806,9 +815,9 @@ class Root(CMakePackage):
         # For dependents that build dictionaries, ROOT needs to know where the
         # dictionaries have been installed.  This can be facilitated by
         # automatically prepending dependent package library paths to
-        # ROOT_LIBRARY_PATH.  We do not adjust LD_LIBRARY_PATH as that would
-        # pollute the standard library-loading mechanisms.
+        # ROOT_LIBRARY_PATH (for @6.26:) or LD_LIBRARY_PATH (for older
+        # versions).
         for suffix in ("lib", "lib64"):
             lib_path = Path(dependent_spec.prefix) / suffix
             if lib_path.exists():
-                env.prepend_path("ROOT_LIBRARY_PATH", str(lib_path))
+                env.prepend_path(self.root_library_path, str(lib_path))

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+import os
 import sys
-from pathlib import Path
 
 from spack.operating_systems.mac_os import macos_version
 from spack.package import *
@@ -817,7 +817,6 @@ class Root(CMakePackage):
         # automatically prepending dependent package library paths to
         # ROOT_LIBRARY_PATH (for @6.26:) or LD_LIBRARY_PATH (for older
         # versions).
-        for suffix in ("lib", "lib64"):
-            lib_path = Path(dependent_spec.prefix) / suffix
-            if lib_path.exists():
-                env.prepend_path(self.root_library_path, str(lib_path))
+        for lib_path in (dependent_spec.prefix.lib, dependent_spec.prefix.lib64):
+            if os.path.exists(lib_path):
+                env.prepend_path(self.root_library_path, lib_path)


### PR DESCRIPTION
This PR makes the following changes:

1. Replaces adjustment of `LD_LIBRARY_PATH` with `ROOT_LIBRARY_PATH`, which ROOT recognizes as a colon-delimited list of directories that are used for locating dictionaries.  This avoids polluting the `LD_LIBRARY_PATH` environment variable, which is used for generically loading shared object files.  Using `ROOT_LIBRARY_PATH` is also more portable across platforms.
2. Prepends dependent library directories to the `ROOT_LIBRARY_PATH` environment variable, such that dependent packages with built dictionaries are loaded with an appropriately set `ROOT_LIBRARY_PATH` variable.  This follows precedent for `ROOT_INCLUDE_PATH`, which does something very similar.
3. Several environment variables were repeatedly being adjusted with the same values for each dependent library of ROOT.  This PR keeps/moves the adjustment of ROOT-wide environment variables (`ROOTSYS`, `ROOT_VERSION`, etc.) to the `setup_run_environment(...)` method.