### PR TITLE
parsec: old to new test API

### DIFF
--- a/var/spack/repos/builtin/packages/parsec/package.py
+++ b/var/spack/repos/builtin/packages/parsec/package.py
@@ -104,24 +104,27 @@ class Parsec(CMakePackage, CudaPackage):
                 warn += "https://bitbucket.org/icldistcomp/parsec/issues"
                 tty.msg(warn)
 
-    def test_parsec(self):
-        """Compile and run a user program with the installed library"""
+    def test_allreduce(self):
+        """Compile and run a user program with allreduce"""
 
-        with test_part(
-            self, "test_parsec_cmake", purpose="Check if CMake can find PaRSEC and its targets"
-        ):
-            cmake = which("cmake")
-            cmake(".")
+        cmake = self.spec["cmake"].command
+        cmake(".")
+        make = which("make")
+        make()
 
-        with test_part(self, "test_parsec_make", purpose="Check if tests can compile"):
-            make = which("make")
-            make()
+        exe = which("./dtd_test_allreduce")
+        exe()
 
-        programs = ["dtd_test_allreduce", "write_check"]
-        for program in programs:
-            with test_part(self, "test_parsec_" + program, purpose="Run " + program):
-                exe = which("./" + program)
-                exe()
+    def test_writecheck(self):
+        """Compile and run a user program with writecheck"""
+
+        cmake = self.spec["cmake"].command
+        cmake(".")
+        make = which("make")
+        make()
+
+        exe = which("./write_check")
+        exe()
 
     @run_after("install")
     def cache_test_sources(self):

--- a/var/spack/repos/builtin/packages/parsec/package.py
+++ b/var/spack/repos/builtin/packages/parsec/package.py
@@ -108,7 +108,7 @@ class Parsec(CMakePackage, CudaPackage):
         """Common parsec testing method"""
         with working_dir(join_path(install_test_root(self), "contrib/build_with_parsec")):
             cmake = self.spec["cmake"].command
-            cmake(".")
+            cmake(".", f"-DCUDA_TOOLKIT_ROOT_DIR={self.spec['cuda'].prefix}")
             make = which("make")
             make()
 

--- a/var/spack/repos/builtin/packages/parsec/package.py
+++ b/var/spack/repos/builtin/packages/parsec/package.py
@@ -106,7 +106,6 @@ class Parsec(CMakePackage, CudaPackage):
 
     def run_parsec(self, exe_name):
         """Common parsec testing method"""
-
         cmake = self.spec["cmake"].command
         cmake(".")
         make = which("make")

--- a/var/spack/repos/builtin/packages/parsec/package.py
+++ b/var/spack/repos/builtin/packages/parsec/package.py
@@ -106,13 +106,14 @@ class Parsec(CMakePackage, CudaPackage):
 
     def run_parsec(self, exe_name):
         """Common parsec testing method"""
-        cmake = self.spec["cmake"].command
-        cmake(".")
-        make = which("make")
-        make()
+        with working_dir(join_path(install_test_root(self), "contrib/build_with_parsec")):
+            cmake = self.spec["cmake"].command
+            cmake(".")
+            make = which("make")
+            make()
 
-        exe = which("./" + exe_name)
-        exe()
+            exe = which("./" + exe_name)
+            exe()
 
     def test_allreduce(self):
         """Compile and run a DTD user program"""

--- a/var/spack/repos/builtin/packages/parsec/package.py
+++ b/var/spack/repos/builtin/packages/parsec/package.py
@@ -106,23 +106,22 @@ class Parsec(CMakePackage, CudaPackage):
 
     def test_parsec(self):
         """Compile and run a user program with the installed library"""
-        with working_dir(join_path(self.install_test_root, "contrib/build_with_parsec")):
 
-            with test_part(
-                self, "test_parsec_cmake", purpose="Check if CMake can find PaRSEC and its targets"
-            ):
-                cmake = which("cmake")
-                cmake(".")
+        with test_part(
+            self, "test_parsec_cmake", purpose="Check if CMake can find PaRSEC and its targets"
+        ):
+            cmake = which("cmake")
+            cmake(".")
 
-            with test_part(self, "test_parsec_make", purpose="Check if tests can compile"):
-                make = which("make")
-                make()
+        with test_part(self, "test_parsec_make", purpose="Check if tests can compile"):
+            make = which("make")
+            make()
 
-            programs = ["dtd_test_allreduce", "write_check"]
-            for program in programs:
-                with test_part(self, "test_parsec_" + program, purpose="Run " + program):
-                    exe = which("./" + program)
-                    exe()
+        programs = ["dtd_test_allreduce", "write_check"]
+        for program in programs:
+            with test_part(self, "test_parsec_" + program, purpose="Run " + program):
+                exe = which("./" + program)
+                exe()
 
     @run_after("install")
     def cache_test_sources(self):

--- a/var/spack/repos/builtin/packages/parsec/package.py
+++ b/var/spack/repos/builtin/packages/parsec/package.py
@@ -104,27 +104,24 @@ class Parsec(CMakePackage, CudaPackage):
                 warn += "https://bitbucket.org/icldistcomp/parsec/issues"
                 tty.msg(warn)
 
-    def test_allreduce(self):
-        """Compile and run a user program with allreduce"""
+    def run_parsec(self, exe_name):
+        """Common parsec testing method"""
 
         cmake = self.spec["cmake"].command
         cmake(".")
         make = which("make")
         make()
 
-        exe = which("./dtd_test_allreduce")
+        exe = which("./" + exe_name)
         exe()
+
+    def test_allreduce(self):
+        """Compile and run a DTD user program"""
+        self.run_parsec("dtd_test_allreduce")
 
     def test_writecheck(self):
-        """Compile and run a user program with writecheck"""
-
-        cmake = self.spec["cmake"].command
-        cmake(".")
-        make = which("make")
-        make()
-
-        exe = which("./write_check")
-        exe()
+        """Compile and run a PTG user program"""
+        self.run_parsec("write_check")
 
     @run_after("install")
     def cache_test_sources(self):

--- a/var/spack/repos/builtin/packages/parsec/package.py
+++ b/var/spack/repos/builtin/packages/parsec/package.py
@@ -104,26 +104,24 @@ class Parsec(CMakePackage, CudaPackage):
                 warn += "https://bitbucket.org/icldistcomp/parsec/issues"
                 tty.msg(warn)
 
-    def run_parsec(self, exe_name):
-        """Common parsec testing method"""
-        with working_dir(join_path(install_test_root(self), "contrib/build_with_parsec")):
-            cmake = self.spec["cmake"].command
-            cmake(".", f"-DCUDA_TOOLKIT_ROOT_DIR={self.spec['cuda'].prefix}")
-            make = which("make")
-            make()
-
-            exe = which("./" + exe_name)
-            exe()
-
     def test_allreduce(self):
         """Compile and run a DTD user program"""
-        self.run_parsec("dtd_test_allreduce")
+        with working_dir(join_path("contrib", "build_with_parsec")):
+            allreduce = which("dtd_test_allreduce")
+            allreduce()
 
     def test_writecheck(self):
         """Compile and run a PTG user program"""
-        self.run_parsec("write_check")
+        with working_dir(join_path("contrib", "build_with_parsec")):
+            writecheck = which("write_check")
+            writecheck()
 
     @run_after("install")
     def cache_test_sources(self):
         srcs = ["contrib/build_with_parsec"]
         cache_extra_test_sources(self, srcs)
+        with working_dir(join_path(install_test_root(self), "contrib", "build_with_parsec")):
+            cmake = self.spec["cmake"].command
+            cmake(".")
+            make = which("make")
+            make()

--- a/var/spack/repos/builtin/packages/parsec/package.py
+++ b/var/spack/repos/builtin/packages/parsec/package.py
@@ -104,15 +104,25 @@ class Parsec(CMakePackage, CudaPackage):
                 warn += "https://bitbucket.org/icldistcomp/parsec/issues"
                 tty.msg(warn)
 
-    def test(self):
+    def test_parsec(self):
         """Compile and run a user program with the installed library"""
         with working_dir(join_path(self.install_test_root, "contrib/build_with_parsec")):
-            self.run_test(
-                "cmake", options=["."], purpose="Check if CMake can find PaRSEC and its targets"
-            )
-            self.run_test("make", purpose="Check if tests can compile")
-            self.run_test("./dtd_test_allreduce")
-            self.run_test("./write_check")
+
+            with test_part(
+                self, "test_parsec_cmake", purpose="Check if CMake can find PaRSEC and its targets"
+            ):
+                cmake = which("cmake")
+                cmake(".")
+
+            with test_part(self, "test_parsec_make", purpose="Check if tests can compile"):
+                make = which("make")
+                make()
+
+            programs = ["dtd_test_allreduce", "write_check"]
+            for program in programs:
+                with test_part(self, "test_parsec_" + program, purpose="Run " + program):
+                    exe = which("./" + program)
+                    exe()
 
     @run_after("install")
     def cache_test_sources(self):

--- a/var/spack/repos/builtin/packages/parsec/package.py
+++ b/var/spack/repos/builtin/packages/parsec/package.py
@@ -126,4 +126,4 @@ class Parsec(CMakePackage, CudaPackage):
     @run_after("install")
     def cache_test_sources(self):
         srcs = ["contrib/build_with_parsec"]
-        self.cache_extra_test_sources(srcs)
+        cache_extra_test_sources(self, srcs)


### PR DESCRIPTION
Update standalone testing API. See #45112 for test error output.

Supersedes #35807 (for one package)

While there are issues with running the tests, the current version does get beyond the prior build issues and attempts to run them (shown below).  As demonstrated below, the test API conversion has been completed.  Resolution of the remaining stand-alone test issue(s) is expected to be addressed in a subsequent PR (by someone else).

```
$ spack find -v parsec
..
parsec@3.0.2209+cuda~debug_verbose~ipo~profile+shared build_system=cmake build_type=RelWithDebInfo cuda_arch=none generator=make
==> 1 installed package
```

```
$ spack -v test run parsec
==> Spack test pylltxlgiqv4czzgqbwljnae4j3enztq
==> Testing package parsec-3.0.2209-osdfyfd
..
==> [2024-08-15-15:34:21.016914] test: test_contrib: build and run contrib examples
..
-- The C compiler identification is GNU 12.1.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: $spack/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/openmpi-5.0.3-f5ygxxtjeqc4ojip4grvfarbhi6i3rnb/bin/mpicc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Found HWLOC: /usr/lib64/libhwloc.so  
-- Performing Test PARSEC_HAVE_HWLOC_PARENT_MEMBER
-- Performing Test PARSEC_HAVE_HWLOC_PARENT_MEMBER - Success
-- Performing Test PARSEC_HAVE_HWLOC_CACHE_ATTR
-- Performing Test PARSEC_HAVE_HWLOC_CACHE_ATTR - Success
-- Performing Test PARSEC_HAVE_HWLOC_OBJ_PU
-- Performing Test PARSEC_HAVE_HWLOC_OBJ_PU - Success
-- Looking for hwloc_bitmap_free in /usr/lib64/libhwloc.so
-- Looking for hwloc_bitmap_free in /usr/lib64/libhwloc.so - found
-- Found PAPI: /lib64/libpapi.so  
-- PAPI Library found at /usr/include /lib64/libpapi.so
-- Found MPI_C: $spack/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/openmpi-5.0.3-f5ygxxtjeqc4ojip4grvfarbhi6i3rnb/bin/mpicc (found version "3.1") 
-- Found MPI: TRUE (found version "3.1")  
-- Found CUDA: $spack/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/cuda-12.5.0-jsv752pej3he4boxopndndkt5apk4kcw (found version "12.5") 
-- Configuring done (4.2s)
CMake Warning at CMakeLists.txt:17 (add_executable):
  Cannot generate a safe runtime search path for target dtd_test_allreduce
  because files in some directories may conflict with libraries in implicit
  directories:

    runtime library [libhwloc.so.15] in /usr/lib64 may be hidden by files in:
      $spack/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/hwloc-2.9.1-4e3jus7h6gtluukhjxj2hd7x4yoqg2m6/lib

  Some of these libraries may not be found correctly.


CMake Warning at CMakeLists.txt:22 (add_executable):
  Cannot generate a safe runtime search path for target write_check because
  files in some directories may conflict with libraries in implicit
  directories:

    runtime library [libhwloc.so.15] in /usr/lib64 may be hidden by files in:
      $spack/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/hwloc-2.9.1-4e3jus7h6gtluukhjxj2hd7x4yoqg2m6/lib

  Some of these libraries may not be found correctly.


-- Generating done (0.1s)
..
==> [2024-08-15-15:34:25.396053] 'make' '-j16'
[ 20%] Generating write_check.h, write_check.c
[ 40%] Building C object CMakeFiles/dtd_test_allreduce.dir/dtd_test_allreduce.c.o
[ 60%] Building C object CMakeFiles/write_check.dir/write_check.c.o
[ 80%] Linking C executable dtd_test_allreduce
[ 80%] Built target dtd_test_allreduce
[100%] Linking C executable write_check
[100%] Built target write_check
==> [2024-08-15-15:34:26.262483] test: test_contrib_dtd_test_allreduce: run dtd_test_allreduce
==> [2024-08-15-15:34:26.264385] 'dtd_test_allreduce'
--------------------------------------------------------------------------
WARNING: Open MPI failed to open the /dev/knem device due to a local
error. Please check with your system administrator to get the problem
fixed, or set the smsc MCA variable to "^knem" to silence this warning
and run without knem support.

Open MPI will try to fall back on another single-copy mechanism if one
is available.  This may result in lower performance.

..
--------------------------------------------------------------------------
Root: 0

PASSED: Parsec::test_contrib_dtd_test_allreduce
==> [2024-08-15-15:34:26.383175] test: test_contrib_write_check: run write_check
==> [2024-08-15-15:34:26.384537] 'write_check'
--------------------------------------------------------------------------
WARNING: Open MPI failed to open the /dev/knem device due to a local
error. Please check with your system administrator to get the problem
fixed, or set the smsc MCA variable to "^knem" to silence this warning
and run without knem support.

Open MPI will try to fall back on another single-copy mechanism if one
is available.  This may result in lower performance.

..
--------------------------------------------------------------------------
PASSED: Parsec::test_contrib_write_check
PASSED: Parsec::test_contrib
==> [2024-08-15-15:34:26.491611] Completed testing
==> [2024-08-15-15:34:26.491747] 
======================= SUMMARY: parsec-3.0.2209-osdfyfd =======================
Parsec::test_contrib_dtd_test_allreduce .. PASSED
Parsec::test_contrib_write_check .. PASSED
Parsec::test_contrib .. PASSED
============================= 3 passed of 3 parts ==============================
============================== 1 passed of 1 spec ==============================
```