### PR TITLE
py-arrow: add v1.3.0 (switch to flit-core)

### DIFF
--- a/var/spack/repos/builtin/packages/py-arrow/package.py
+++ b/var/spack/repos/builtin/packages/py-arrow/package.py
@@ -19,6 +19,7 @@ class PyArrow(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.3.0", sha256="d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85")
     version("1.2.3", sha256="3934b30ca1b9f292376d9db15b19446088d12ec58629bc3f0da28fd55fb633a1")
     version("1.2.2", sha256="05caf1fd3d9a11a1135b2b6f09887421153b94558e5ef4d090b567b47173ac2b")
     version("1.2.1", sha256="c2dde3c382d9f7e6922ce636bf0b318a7a853df40ecb383b29192e6c5cc82840")
@@ -26,9 +27,12 @@ class PyArrow(PythonPackage):
     version("0.14.7", sha256="67f8be7c0cf420424bc62d8d7dc40b44e4bb2f7b515f9cc2954fb36e35797656")
     version("0.14.1", sha256="2d30837085011ef0b90ff75aa0a28f5c7d063e96b7e76b6cbc7e690310256685")
 
+    depends_on("python@3.8:", type=("build", "run"), when="@1.3:")
     depends_on("python@3.6:", type=("build", "run"), when="@1.2.1:")
     depends_on("python@2.7:2.8,3.5:", type=("build", "run"), when="@:0.16.0")
-    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools", type="build", when="@:1.2")
+    depends_on("py-flit-core@3.2:3", type="build", when="@1.3:")
     depends_on("py-python-dateutil", type=("build", "run"))
-    depends_on("py-typing-extensions", type=("build", "run"), when="@1.2.1: ^python@:3.7")
+    depends_on("py-typing-extensions", type=("build", "run"), when="@1.2.1:1.2 ^python@:3.7")
     depends_on("py-python-dateutil@2.7.0:", type=("build", "run"), when="@1.2.1:")
+    depends_on("py-types-python-dateutil@2.8.10:", type=("build", "run"), when="@1.3:")


### PR DESCRIPTION
This PR adds py-arrow v1.3.0, which switches from setuptools to flit-core as build system.