### PR TITLE
Add compatibility of sequoia with previous macOS versions

### DIFF
--- a/lib/spack/spack/solver/os_compatibility.lp
+++ b/lib/spack/spack/solver/os_compatibility.lp
@@ -12,7 +12,7 @@
 %=============================================================================
 
 % macOS
-os_compatible("sequoia", ""sonoma").
+os_compatible("sequoia", "sonoma").
 os_compatible("sonoma", "ventura").
 os_compatible("ventura", "monterey").
 os_compatible("monterey", "bigsur").

--- a/lib/spack/spack/solver/os_compatibility.lp
+++ b/lib/spack/spack/solver/os_compatibility.lp
@@ -12,6 +12,7 @@
 %=============================================================================
 
 % macOS
+os_compatible("sequoia", ""sonoma").
 os_compatible("sonoma", "ventura").
 os_compatible("ventura", "monterey").
 os_compatible("monterey", "bigsur").


### PR DESCRIPTION
Follows from #45018
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
