### PR TITLE
gmake: default to generic CXX

### DIFF
--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -75,12 +75,17 @@ class Gmake(Package, GNUMirrorPackage):
 
     def install(self, spec, prefix):
         configure = Executable(join_path(self.stage.source_path, "configure"))
-        build_sh = Executable(join_path(self.stage.source_path, "build.sh"))
         with working_dir(self.build_directory, create=True):
             configure(f"--prefix={prefix}", *self.configure_args())
             # The default CXX value should be generic, not CXX from the current build as it points
             # to the compiler wrapper by absolute path.
             filter_file(r"^#define MAKE_CXX .*$", "#undef MAKE_CXX", join_path("src", "config.h"))
+            if spec.satisfies("@:4.2.1"):
+                # older configure creates build.sh in current directory
+                build_sh = Executable(join_path(".", "build.sh"))
+            else:
+                # newer configure creates build.sh in source directory
+                build_sh = Executable(join_path(self.stage.source_path, "build.sh"))
             build_sh()
             os.mkdir(prefix.bin)
             install("make", prefix.bin)

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -78,6 +78,9 @@ class Gmake(Package, GNUMirrorPackage):
         build_sh = Executable(join_path(self.stage.source_path, "build.sh"))
         with working_dir(self.build_directory, create=True):
             configure(f"--prefix={prefix}", *self.configure_args())
+            # The default CXX value should be generic, not CXX from the current build as it points
+            # to the compiler wrapper by absolute path.
+            filter_file(r"^#define MAKE_CXX .*$", "#undef MAKE_CXX", join_path("src", "config.h"))
             build_sh()
             os.mkdir(prefix.bin)
             install("make", prefix.bin)

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -24,7 +24,12 @@ class Gmake(Package, GNUMirrorPackage):
     version("4.4", sha256="581f4d4e872da74b3941c874215898a7d35802f03732bdccee1d4a7979105d18")
     version("4.3", sha256="e05fdde47c5f7ca45cb697e973894ff4f5d79e13b750ed57d7b66d8defc78e19")
     version("4.2.1", sha256="e40b8f018c1da64edd1cc9a6fce5fa63b2e707e404e20cad91fbae337c98a5b7")
-    version("4.0", sha256="fc42139fb0d4b4291929788ebaf77e2a4de7eaca95e31f3634ef7d4932051f69")
+    version("4.1", sha256="9fc7a9783d3d2ea002aa1348f851875a2636116c433677453cc1d1acc3fc4d55")
+    version(
+        "4.0",
+        deprecated=True,
+        sha256="fc42139fb0d4b4291929788ebaf77e2a4de7eaca95e31f3634ef7d4932051f69",
+    )
 
     variant("guile", default=False, description="Support GNU Guile for embedded scripting")
 
@@ -32,9 +37,6 @@ class Gmake(Package, GNUMirrorPackage):
         depends_on("guile@:2.0", when="@:4.2")
         depends_on("guile@:3.0")
         depends_on("pkgconfig", type="build")
-
-    # build.sh requires it in 4.0 (SV 40254)
-    conflicts("~guile", when="@4.0")
 
     patch(
         "https://src.fedoraproject.org/rpms/make/raw/519a7c5bcbead22e6ea2d2c2341d981ef9e25c0d/f/make-4.2.1-glob-fix-2.patch",
@@ -77,16 +79,16 @@ class Gmake(Package, GNUMirrorPackage):
         configure = Executable(join_path(self.stage.source_path, "configure"))
         with working_dir(self.build_directory, create=True):
             configure(f"--prefix={prefix}", *self.configure_args())
+            if spec.satisfies("@:4.2.1"):  # generated files in build dir
+                build_sh = join_path(".", "build.sh")
+                config_h = join_path(".", "config.h")
+            else:  # generated files in source dir
+                build_sh = join_path(self.stage.source_path, "build.sh")
+                config_h = join_path("src", "config.h")
             # The default CXX value should be generic, not CXX from the current build as it points
             # to the compiler wrapper by absolute path.
-            filter_file(r"^#define MAKE_CXX .*$", "#undef MAKE_CXX", join_path("src", "config.h"))
-            if spec.satisfies("@:4.2.1"):
-                # older configure creates build.sh in current directory
-                build_sh = Executable(join_path(".", "build.sh"))
-            else:
-                # newer configure uses build.sh in source directory
-                build_sh = Executable(join_path(self.stage.source_path, "build.sh"))
-            build_sh()
+            filter_file(r"^#define MAKE_CXX .*$", "#undef MAKE_CXX", config_h)
+            Executable(build_sh)()
             os.mkdir(prefix.bin)
             install("make", prefix.bin)
             os.symlink("make", prefix.bin.gmake)

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -84,7 +84,7 @@ class Gmake(Package, GNUMirrorPackage):
                 # older configure creates build.sh in current directory
                 build_sh = Executable(join_path(".", "build.sh"))
             else:
-                # newer configure creates build.sh in source directory
+                # newer configure uses build.sh in source directory
                 build_sh = Executable(join_path(self.stage.source_path, "build.sh"))
             build_sh()
             os.mkdir(prefix.bin)


### PR DESCRIPTION
Closes #45136

gmake sets CXX for runtime to MAKE_CXX which is initialized to $CXX
during the build, which in the case of Spack means an absolute path to
the compiler wrapper. Undefining MAKE_CXX is enough to get something
generic (apparently `CXX=g++`).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
