### PR TITLE
magma: old to new test API

### DIFF
--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -192,7 +192,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
         """Run benchmark tests"""
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         with working_dir(test_dir, create=False):
-            pkg_config_path = f"{self.prefix.lib.pkgconfig}/lib/pkgconfig"
+            pkg_config_path = self.prefix.lib.pkgconfig
             with spack.util.environment.set_env(PKG_CONFIG_PATH=pkg_config_path):
 
                 make("c")
@@ -217,7 +217,9 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
         if "+fortran" not in self.spec:
             raise SkipTest("Package must be installed with +fortran")
 
-        make("fortran")
-        exe_fortran = which("./example_f")
-        exe_fortran()
-        make("clean")
+        test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
+        with working_dir(test_dir):
+            make("fortran")
+            exe_fortran = which("./example_f")
+            exe_fortran()
+            make("clean")

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -218,7 +218,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
             raise SkipTest("Package must be installed with +fortran")
 
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
-        with working_dir(test_dir):
+        with working_dir(test_dir, create=False):
             make("fortran")
             exe_fortran = which("./example_f")
             exe_fortran()

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -186,7 +186,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources([self.test_src_dir])
+        cache_extra_test_sources(self)
 
     def test_all_c(self):
         """Run benchmark tests"""

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -192,7 +192,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
         """Run benchmark tests"""
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         with working_dir(test_dir, create=False):
-            pkg_config_path = self.prefix.lib.pkgconfig
+            pkg_config_path = f"{self.prefix}/lib/pkgconfig"
             with spack.util.environment.set_env(PKG_CONFIG_PATH=pkg_config_path):
 
                 make("c")

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -186,7 +186,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        cache_extra_test_sources([self.test_src_dir])
+        cache_extra_test_sources(self, [self.test_src_dir])
 
     def test_all_c(self):
         """Run benchmark tests"""

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -205,7 +205,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
 
                 for test in tests:
                     with test_part(
-                        self, f"test_magma_{test[0]}", purpose=f"MAGMA smoke test - {test[1]}"
+                        self, f"test_all_c_{test[0]}", purpose=f"MAGMA smoke test - {test[1]}"
                     ):
                         exe = which("./" + test[0])
                         exe()

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -220,6 +220,6 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         with working_dir(test_dir, create=False):
             make("fortran")
-            exe_fortran = which("./example_f")
-            exe_fortran()
+            example_f = which("./example_f")
+            example_f()
             make("clean")

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -192,7 +192,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
         """Run benchmark tests"""
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         with working_dir(test_dir, create=False):
-            pkg_config_path = f"{self.prefix}/lib/pkgconfig"
+            pkg_config_path = self.prefix.lib.pkgconfig
             with spack.util.environment.set_env(PKG_CONFIG_PATH=pkg_config_path):
 
                 make("c")

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -188,7 +188,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources([self.test_src_dir])
 
-    def test_magma(self):
+    def test_all_c(self):
         """Run benchmark tests"""
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         with working_dir(test_dir, create=False):

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -188,19 +188,33 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources([self.test_src_dir])
 
-    def test(self):
+    def test_magma(self):
+        """Run benchmark tests"""
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         with working_dir(test_dir, create=False):
             pkg_config_path = "{0}/lib/pkgconfig".format(self.prefix)
             with spack.util.environment.set_env(PKG_CONFIG_PATH=pkg_config_path):
+
                 make("c")
-                self.run_test("./example_sparse", purpose="MAGMA smoke test - sparse solver")
-                self.run_test(
-                    "./example_sparse_operator", purpose="MAGMA smoke test - sparse operator"
-                )
-                self.run_test("./example_v1", purpose="MAGMA smoke test - legacy v1 interface")
-                self.run_test("./example_v2", purpose="MAGMA smoke test - v2 interface")
+                tests = [
+                    ("example_sparse", "sparse solver"),
+                    ("example_sparse_operator", "sparse operator"),
+                    ("example_v1", "legacy v1 interface"),
+                    ("example_v2", "v2 interface"),
+                ]
+
+                for test in tests:
+                    with test_part(
+                        self, f"test_magma_{test[0]}", purpose=f"MAGMA smoke test - {test[1]}"
+                    ):
+                        exe = which("./" + test[0])
+                        exe()
+
                 if "+fortran" in self.spec:
-                    make("fortran")
-                    self.run_test("./example_f", purpose="MAGMA smoke test - Fortran interface")
+                    with test_part(
+                        self, "test_magma_fortran", purpose="MAGMA smoke test - Fortran interface"
+                    ):
+                        make("fortran")
+                        exe_fortran = which("./example_f")
+                        exe_fortran()
                 make("clean")

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -186,7 +186,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        cache_extra_test_sources(self)
+        cache_extra_test_sources([self.test_src_dir])
 
     def test_all_c(self):
         """Run benchmark tests"""

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -191,7 +191,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
     def test_c(self):
         """Run benchmark tests"""
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
-        with working_dir(test_dir, create=False):
+        with working_dir(test_dir):
             pkg_config_path = self.prefix.lib.pkgconfig
             with spack.util.environment.set_env(PKG_CONFIG_PATH=pkg_config_path):
 

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -217,7 +217,9 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
 
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         with working_dir(test_dir):
-            make("fortran")
-            example_f = which("example_f")
-            example_f()
-            make("clean")
+            pkg_config_path = self.prefix.lib.pkgconfig
+            with spack.util.environment.set_env(PKG_CONFIG_PATH=pkg_config_path):
+                make("fortran")
+                example_f = which("example_f")
+                example_f()
+                make("clean")

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -211,7 +211,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
                 make("clean")
 
     def test_fortran(self):
-        """MAGMA smoke test - Fortran interface"""
+        """Run Fortran example"""
         if "+fortran" not in self.spec:
             raise SkipTest("Package must be installed with +fortran")
 

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -189,7 +189,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
         cache_extra_test_sources(self, [self.test_src_dir])
 
     def test_c(self):
-        """Run benchmark tests"""
+        """Run C examples"""
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         with working_dir(test_dir):
             pkg_config_path = self.prefix.lib.pkgconfig

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -203,11 +203,11 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
                     ("example_v2", "v2 interface"),
                 ]
 
-                for test in tests:
+                for test, desc in tests:
                     with test_part(
-                        self, f"test_all_c_{test[0]}", purpose=f"MAGMA smoke test - {test[1]}"
+                        self, f"test_c_{test}", purpose=f"MAGMA smoke test - {desc}"
                     ):
-                        exe = which("./" + test[0])
+                        exe = which(test)
                         exe()
 
                 make("clean")

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -204,9 +204,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
                 ]
 
                 for test, desc in tests:
-                    with test_part(
-                        self, f"test_c_{test}", purpose=f"MAGMA smoke test - {desc}"
-                    ):
+                    with test_part(self, f"test_c_{test}", purpose=f"MAGMA smoke test - {desc}"):
                         exe = which(test)
                         exe()
 

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -188,7 +188,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
         install test subdirectory for use during `spack test run`."""
         cache_extra_test_sources(self, [self.test_src_dir])
 
-    def test_all_c(self):
+    def test_c(self):
         """Run benchmark tests"""
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         with working_dir(test_dir, create=False):

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -220,6 +220,6 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
         with working_dir(test_dir, create=False):
             make("fortran")
-            example_f = which("./example_f")
+            example_f = which("example_f")
             example_f()
             make("clean")

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -218,7 +218,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
             raise SkipTest("Package must be installed with +fortran")
 
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.test_src_dir)
-        with working_dir(test_dir, create=False):
+        with working_dir(test_dir):
             make("fortran")
             example_f = which("example_f")
             example_f()

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -204,7 +204,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
                 ]
 
                 for test, desc in tests:
-                    with test_part(self, f"test_c_{test}", purpose=f"MAGMA smoke test - {desc}"):
+                    with test_part(self, f"test_c_{test}", purpose=f"Run {desc} example"):
                         exe = which(test)
                         exe()
 


### PR DESCRIPTION
Update standalone testing API. See below comment below for test error output.

Supersedes #35795 (for one package)

https://spack.readthedocs.io/en/latest/packaging_guide.html#stand-alone-tests

Test results from a probably an inappropriately configured build at least shows that the stand-alone test API conversion works.
```
$ spack find -v magma
..
magma@2.8.0+cuda+fortran~ipo~rocm+shared build_system=cmake build_type=Release cuda_arch=70 generator=make
==> 1 installed package

$ spack -v test run magma
==> Spack test q7bxbne6c5h573vbu3nv6qj7vfa4ur3y
==> Testing package magma-2.8.0-nsdakwn
..
==> [2024-08-14-15:07:07.719065] test: test_c: Run C examples
==> [2024-08-14-15:07:07.719730] 'make' '-j16' 'c'
..
example_sparse.cpp:46:11: warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'magma_dopts' {aka 'struct magma_dopts'}; use assignment or value-initialization instead [-Wclass-memaccess]
   46 |     memset(&opts, 0, sizeof(magma_dopts));
      |     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
..
==> [2024-08-14-15:07:08.977939] test: test_c_example_sparse: Run sparse solver example
==> [2024-08-14-15:07:08.979441] 'example_sparse'
 ** On entry to cusparseCreate(): CUDA context cannot be initialized

 ** On entry to cusparseSetStream() parameter number 1 (handle) had an illegal value: NULL pointer


Memory Free Error.
..
PASSED: Magma::test_c_example_sparse
==> [2024-08-14-15:07:09.277533] test: test_c_example_sparse_operator: Run sparse operator example
==> [2024-08-14-15:07:09.279254] 'example_sparse_operator'
 ** On entry to cusparseCreate(): CUDA context cannot be initialized

 ** On entry to cusparseSetStream() parameter number 1 (handle) had an illegal value: NULL pointer

Memory Free Error.
Memory Free Error.
iterations: 0 residual: 6.9534e-310
..
PASSED: Magma::test_c_example_sparse_operator
==> [2024-08-14-15:07:09.537869] test: test_c_example_v1: Run legacy v1 interface example
==> [2024-08-14-15:07:09.539384] 'example_v1'
Error in magma_getdevice_arch: MAGMA not initialized (call magma_init() first) or bad device
..
==> [2024-08-14-15:07:09.985373] test: test_c_example_v2: Run v2 interface example
==> [2024-08-14-15:07:09.986653] 'example_v2'
Error in magma_getdevice_arch: MAGMA not initialized (call magma_init() first) or bad device
 ** On entry to cusparseCreate(): CUDA context cannot be initialized
..
==> [2024-08-14-15:07:10.390404] 'make' '-j16' 'clean'
rm -f example_v1 example_v2 example_sparse example_sparse_operator example_f *.o *.mod
FAILED: Magma::test_c
==> [2024-08-14-15:07:10.445003] test: test_fortran: Run Fortran example
==> [2024-08-14-15:07:10.446398] 'make' '-j16' 'fortran'
..
==> [2024-08-14-15:07:10.956568] 'example_f'
using MAGMA CPU interface
Error in magma_getdevice_arch: MAGMA not initialized (call magma_init() first) or bad device
 ** On entry to cusparseCreate(): CUDA context cannot be initialized
..
FAILED: Magma::test_fortran: Command exited with status -11:
    'example_f'
..
==> [2024-08-14-15:07:11.371784] Completed testing
==> [2024-08-14-15:07:11.371953] 
========================= SUMMARY: magma-2.8.0-nsdakwn =========================
Magma::test_c_example_sparse .. PASSED
Magma::test_c_example_sparse_operator .. PASSED
Magma::test_c_example_v1 .. FAILED
Magma::test_c_example_v2 .. FAILED
Magma::test_c .. FAILED
Magma::test_fortran .. FAILED
======================== 2 passed, 4 failed of 6 parts =========================
```