### PR TITLE
n2p2: convert from old to new test API

### DIFF
--- a/var/spack/repos/builtin/packages/n2p2/package.py
+++ b/var/spack/repos/builtin/packages/n2p2/package.py
@@ -57,16 +57,15 @@ class N2p2(MakefilePackage):
 
     def edit(self, spec, prefix):
         makefile = FileFilter(join_path("src", "makefile"))
-        makefile.filter("MODE=.*", "MODE={0}".format("shared" if "+shared" in spec else "static"))
+        makefile.filter("MODE=.*", f"MODE={'shared' if '+shared' in spec else 'static'}")
 
         makefile = FileFilter(join_path("src", "makefile.gnu"))
         blas_libs = self.spec["blas"].libs
-        makefile.filter("PROJECT_CC=.*", "PROJECT_CC={0}".format(spack_cxx))
-        makefile.filter("PROJECT_MPICC=.*", "PROJECT_MPICC={0}".format(self.spec["mpi"].mpicxx))
-        makefile.filter("PROJECT_CFLAGS=.*", "PROJECT_CFLAGS={0}".format(self.compiler.cxx11_flag))
+        makefile.filter("PROJECT_CC=.*", f"PROJECT_CC={spack_cxx}")
+        makefile.filter("PROJECT_MPICC=.*", f"PROJECT_MPICC={self.spec['mpi'].mpicxx}")
+        makefile.filter("PROJECT_CFLAGS=.*", f"PROJECT_CFLAGS={self.compiler.cxx11_flag}")
         makefile.filter(
-            "PROJECT_LDFLAGS_BLAS.*",
-            "PROJECT_LDFLAGS_BLAS={0} -lgsl -lgslcblas".format(blas_libs.ld_flags),
+            "PROJECT_LDFLAGS_BLAS.*", f"PROJECT_LDFLAGS_BLAS={blas_libs.ld_flags} -lgsl -lgslcblas"
         )
 
     def build(self, spec, prefix):
@@ -92,7 +91,7 @@ class N2p2(MakefilePackage):
     def setup_build_tests(self):
         """Copy the build test files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources(".")
+        cache_extra_test_sources(self)
 
     def test_n2p2(self):
         """Run benchmark tests"""
@@ -103,25 +102,22 @@ class N2p2(MakefilePackage):
             make("clean")
             make(
                 "MODE=test",
-                "PROJECT_GSL={0}".format(self.spec["gsl"].prefix.include),
-                "PROJECT_EIGEN={0}".format(self.spec["eigen"].prefix.include.eigen3),
+                f"PROJECT_GSL={self.spec['gsl'].prefix.include}",
+                f"PROJECT_EIGEN={self.spec['eigen'].prefix.include.eigen3}",
             )
             make(
                 "MODE=test",
                 "lammps-nnp",
-                "PROJECT_GSL={0}".format(self.spec["gsl"].prefix.include),
-                "PROJECT_EIGEN={0}".format(self.spec["eigen"].prefix.include.eigen3),
+                f"PROJECT_GSL={self.spec['gsl'].prefix.include}",
+                f"PROJECT_EIGEN={self.spec['eigen'].prefix.include.eigen3}",
             )
             make("pynnp", "MODE=test")
 
         with working_dir(join_path(self.install_test_root, "test"), create=False):
             if self.spec.satisfies("%fj"):
                 f = FileFilter(join_path("cpp", "nnp_test.h"))
-                f.filter(
-                    "(example.co",
-                    '("{0} -n 1 " + example.co'.format(self.spec["mpi"].prefix.bin.mpirun),
-                    string=True,
-                )
+                mpirun = self.spec["mpi"].prefix.bin.mpirun
+                f.filter("(example.co", f'("{mpirun} -n 1 " + example.co', string=True)
 
             f = FileFilter(join_path("cpp", "makefile"))
             f.filter("log_level=.*", "log_level=$(LOG_LEVEL) 2>&1 | tee -a ../output_cpp.txt")
@@ -133,6 +129,6 @@ class N2p2(MakefilePackage):
             make("python", parallel=False)
 
             test_dir = self.test_suite.current_test_data_dir
-            expected_file = join_path(test_dir, "expected-result-{0}.txt".format(self.version))
+            expected_file = join_path(test_dir, f"expected-result-{self.version}.txt")
             check_n2p2 = Executable(join_path(test_dir, "result-check.sh"))
             check_n2p2("./output_cpp.txt", "./output_python.txt", expected_file)

--- a/var/spack/repos/builtin/packages/n2p2/package.py
+++ b/var/spack/repos/builtin/packages/n2p2/package.py
@@ -91,14 +91,15 @@ class N2p2(MakefilePackage):
     def setup_build_tests(self):
         """Copy the build test files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        cache_extra_test_sources(self)
+        cache_extra_test_sources(self, ["src"])
 
     def test_n2p2(self):
         """Run benchmark tests"""
-        with working_dir(join_path(self.install_test_root, "test"), create=False):
+        make = which("make")
+        with working_dir("test"):
             make("clean")
-
-        with working_dir(join_path(self.install_test_root, "src"), create=False):
+        print("Calling make inside src dir")
+        with working_dir("src"):
             make("clean")
             make(
                 "MODE=test",
@@ -112,8 +113,8 @@ class N2p2(MakefilePackage):
                 f"PROJECT_EIGEN={self.spec['eigen'].prefix.include.eigen3}",
             )
             make("pynnp", "MODE=test")
-
-        with working_dir(join_path(self.install_test_root, "test"), create=False):
+        print("Making and running the test")
+        with working_dir("test"):
             if self.spec.satisfies("%fj"):
                 f = FileFilter(join_path("cpp", "nnp_test.h"))
                 mpirun = self.spec["mpi"].prefix.bin.mpirun

--- a/var/spack/repos/builtin/packages/n2p2/package.py
+++ b/var/spack/repos/builtin/packages/n2p2/package.py
@@ -94,7 +94,8 @@ class N2p2(MakefilePackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources(".")
 
-    def test(self):
+    def test_n2p2(self):
+        """Run benchmark tests"""
         with working_dir(join_path(self.install_test_root, "test"), create=False):
             make("clean")
 

--- a/var/spack/repos/builtin/packages/n2p2/package.py
+++ b/var/spack/repos/builtin/packages/n2p2/package.py
@@ -91,14 +91,14 @@ class N2p2(MakefilePackage):
     def setup_build_tests(self):
         """Copy the build test files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        # cache_extra_test_sources(self, [".", "src", "test"])
         cache_extra_test_sources(self, ["."])
 
-    def test_n2p2(self):
-        """Run benchmark tests"""
+    def test_result_check(self):
+        """Build and run result-check.sh"""
         make = which("make")
         with working_dir(self.test_suite.current_test_cache_dir.test):
             make("clean")
+
         print("Calling make inside src dir")
         with working_dir(self.test_suite.current_test_cache_dir.src):
             make("clean")
@@ -114,6 +114,7 @@ class N2p2(MakefilePackage):
                 f"PROJECT_EIGEN={self.spec['eigen'].prefix.include.eigen3}",
             )
             make("pynnp", "MODE=test")
+
         print("Making and running the test")
         with working_dir(self.test_suite.current_test_cache_dir.test):
             if self.spec.satisfies("%fj"):
@@ -132,5 +133,5 @@ class N2p2(MakefilePackage):
 
             test_dir = self.test_suite.current_test_data_dir
             expected_file = join_path(test_dir, f"expected-result-{self.version}.txt")
-            check_n2p2 = Executable(join_path(test_dir, "result-check.sh"))
-            check_n2p2("./output_cpp.txt", "./output_python.txt", expected_file)
+            result_check = which(join_path(test_dir, "result-check.sh"))
+            result_check("./output_cpp.txt", "./output_python.txt", expected_file)

--- a/var/spack/repos/builtin/packages/n2p2/package.py
+++ b/var/spack/repos/builtin/packages/n2p2/package.py
@@ -69,7 +69,7 @@ class N2p2(MakefilePackage):
         )
 
     def build(self, spec, prefix):
-        with working_dir(self.test_suite.current_test_cache_dir.src):
+        with working_dir("src"):
             # Add --no-print-directory flag to avoid issues when variables set
             # to value of shell function with cd cmd used as target (see #43192)
             make("--no-print-directory")

--- a/var/spack/repos/builtin/packages/n2p2/package.py
+++ b/var/spack/repos/builtin/packages/n2p2/package.py
@@ -69,7 +69,7 @@ class N2p2(MakefilePackage):
         )
 
     def build(self, spec, prefix):
-        with working_dir("src"):
+        with working_dir(self.test_suite.current_test_cache_dir.src):
             # Add --no-print-directory flag to avoid issues when variables set
             # to value of shell function with cd cmd used as target (see #43192)
             make("--no-print-directory")
@@ -91,7 +91,8 @@ class N2p2(MakefilePackage):
     def setup_build_tests(self):
         """Copy the build test files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        cache_extra_test_sources(self, ["src", "test"])
+        # cache_extra_test_sources(self, [".", "src", "test"])
+        cache_extra_test_sources(self, ["."])
 
     def test_n2p2(self):
         """Run benchmark tests"""
@@ -114,7 +115,7 @@ class N2p2(MakefilePackage):
             )
             make("pynnp", "MODE=test")
         print("Making and running the test")
-        with working_dir("test"):
+        with working_dir(self.test_suite.current_test_cache_dir.test):
             if self.spec.satisfies("%fj"):
                 f = FileFilter(join_path("cpp", "nnp_test.h"))
                 mpirun = self.spec["mpi"].prefix.bin.mpirun

--- a/var/spack/repos/builtin/packages/n2p2/package.py
+++ b/var/spack/repos/builtin/packages/n2p2/package.py
@@ -91,15 +91,15 @@ class N2p2(MakefilePackage):
     def setup_build_tests(self):
         """Copy the build test files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        cache_extra_test_sources(self, ["src"])
+        cache_extra_test_sources(self, ["src", "test"])
 
     def test_n2p2(self):
         """Run benchmark tests"""
         make = which("make")
-        with working_dir("test"):
+        with working_dir(self.test_suite.current_test_cache_dir.test):
             make("clean")
         print("Calling make inside src dir")
-        with working_dir("src"):
+        with working_dir(self.test_suite.current_test_cache_dir.src):
             make("clean")
             make(
                 "MODE=test",


### PR DESCRIPTION
Update standalone testing API. See #45110 for test output error.

https://spack.readthedocs.io/en/latest/packaging_guide.html#stand-alone-tests

Results after running the last commit:
```
$ spack find -v n2p2
..
n2p2@2.1.1~doc~shared build_system=makefile patches=75252ce,bbb5c89,d3abef3
n2p2@2.2.0~doc~shared build_system=makefile patches=75252ce,d3abef3
==> 2 installed packages


$ spack -v test run n2p2
==> Spack test itatyztflvk5qfxmpafocuuhoxq5vcin
==> Testing package n2p2-2.2.0-7e6j56e
..
==> [2024-08-15-11:43:53.761675] test: test_result_check: Build and run result-check.sh
SKIPPED: N2p2::test_result_check: The expected results file is missing from the repository for 2.2.0
==> [2024-08-15-11:43:53.764646] Completed testing
==> [2024-08-15-11:43:53.764742] 
========================= SUMMARY: n2p2-2.2.0-7e6j56e ==========================
N2p2::test_result_check .. SKIPPED
============================= 1 skipped of 1 parts =============================
==> Testing package n2p2-2.1.1-mbdy37o
..
==> [2024-08-15-11:47:18.002698] test: test_result_check: Build and run result-check.sh
==> [2024-08-15-11:47:18.047676] '/usr/bin/make' 'clean'
cd cpp && /usr/bin/make clean
..
cd python && /usr/bin/make clean
..
==> [2024-08-15-11:47:18.113602] '/usr/bin/make' 'clean'
cd libnnp && /usr/bin/make clean
..
==> [2024-08-15-11:57:07.031810] '/usr/bin/make' 'cpp'
cd cpp && /usr/bin/make
..
==> [2024-08-15-12:06:32.160393] '/usr/bin/make' 'python'
cd python && /usr/bin/make
..
============================= test session starts ==============================
..
collecting ... collected 255 items

test_Atom.py::Test___cinit__::test_skeleton_initialization PASSED        [  0%]
test_Atom.py::Test___cinit__::test_empty_initialization PASSED           [  0%]
test_Atom.py::Test_hasNeighborList::test_correct_type PASSED             [  1%]
..
test_Vec3D.py::Test_r::test_setter_index_assignment_not_possible PASSED  [100%]Coverage.py warning: Module pynnp was previously imported, but not measured (module-not-measured)
..
  warnings.warn(pytest.PytestWarning(message))
WARNING: Failed to generate report: No data to report.
..
=============================== warnings summary ===============================
..
---------- coverage: platform linux, python 3.11.9-final-0 -----------
Name    Stmts   Miss  Cover
---------------------------

======================= 255 passed, 3 warnings in 3.26s ========================
..
==> [2024-08-15-12:06:40.312590] '$spack_test/itatyztflvk5qfxmpafocuuhoxq5vcin/n2p2-2.1.1-mbdy37o/data/n2p2/result-check.sh' 'output_cpp.txt' 'output_python.txt' '$spack_test/itatyztflvk5qfxmpafocuuhoxq5vcin/n2p2-2.1.1-mbdy37o/data/n2p2/expected-result-2.1.1.txt'
Test of n2p2 Failed !
PASSED: N2p2::test_result_check
==> [2024-08-15-12:06:40.337018] Completed testing
==> [2024-08-15-12:06:40.337179] 
========================= SUMMARY: n2p2-2.1.1-mbdy37o ==========================
N2p2::test_result_check .. PASSED
============================= 1 passed of 1 parts ==============================
======================== 1 skipped, 1 passed of 2 specs ========================
```

WARNING: At on the order of a half hour, these tests likely take too long to run in Spack CI.  