### PR TITLE
octopus: old to new test API

### DIFF
--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -330,24 +330,24 @@ class Octopus(AutotoolsPackage, CudaPackage):
         #
         # spack-v0.17.2$ octopus --version
         # octopus 11.3 (git commit )
-        expected = ["octopus "]
 
-        exe = which(self.spec.prefix.bin, "octopus")
+        exe = which(self.spec.prefix.bin.octopus)
         out = exe("--version", output=str.split, error=str.split)
-        check_outputs(expected, out)
+        assert "octopus " in out
+
+    def test_recipe(self):
+        """run recipe example"""
 
         # Octopus expects a file with name `inp` in the current working
         # directory to read configuration information for a simulation run from
         # that file. We copy the relevant configuration file in a dedicated
-        # subfolder for each test.
+        # subfolder for the test.
         #
         # As we like to be able to run these tests also with the
         # `spack install --test=root` command, we cannot rely on
         # self.test_suite.current_test_data_dir, and need to copy the test
         # input files manually (see below).
 
-    def test_recipe(self):
-        """run recipe example"""
         expected = [
             "Running octopus",
             "CalculationMode = recipe",
@@ -359,12 +359,23 @@ class Octopus(AutotoolsPackage, CudaPackage):
         with working_dir("example-recipe", create=True):
             print("Current working directory (in example-recipe)")
             fs.copy(join_path(os.path.dirname(__file__), "test", "recipe.inp"), "inp")
-            exe = which(join_path(self.spec.prefix.bin, "octopus"))
+            exe = which(self.spec.prefix.bin.octopus)
             out = exe(output=str.split, error=str.split)
             check_outputs(expected, out)
 
     def test_he(self):
         """run He example"""
+
+        # Octopus expects a file with name `inp` in the current working
+        # directory to read configuration information for a simulation run from
+        # that file. We copy the relevant configuration file in a dedicated
+        # subfolder for the test.
+        #
+        # As we like to be able to run these tests also with the
+        # `spack install --test=root` command, we cannot rely on
+        # self.test_suite.current_test_data_dir, and need to copy the test
+        # input files manually (see below).
+
         expected = [
             "Running octopus",
             "Info: Starting calculation mode.",
@@ -377,6 +388,6 @@ class Octopus(AutotoolsPackage, CudaPackage):
         with working_dir("example-he", create=True):
             print("Current working directory (in example-he)")
             fs.copy(join_path(os.path.dirname(__file__), "test", "he.inp"), "inp")
-            exe = which(join_path(self.spec.prefix.bin, "octopus"))
+            exe = which(self.spec.prefix.bin.octopus)
             out = exe(output=str.split, error=str.split)
             check_outputs(expected, out)

--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -316,39 +316,25 @@ class Octopus(AutotoolsPackage, CudaPackage):
 
     @run_after("install")
     @on_package_attributes(run_tests=True)
-    def smoke_tests_after_install(self):
+    def benchmark_tests_after_install(self):
         """Function stub to run tests after install if desired
         (for example through `spack install --test=root octopus`)
         """
-        self.smoke_tests()
+        self.test_version()
+        self.test_example()
+        self.test_he()
 
-    def test(self):
-        """Entry point for smoke tests run through `spack test run octopus`."""
-        self.smoke_tests()
-
-    def smoke_tests(self):
-        """Actual smoke tests for Octopus."""
-        #
-        # run "octopus --version"
-        #
-        exe = join_path(self.spec.prefix.bin, "octopus")
-        options = ["--version"]
-        purpose = "Check octopus can execute (--version)"
+    def test_version(self):
+        """Check octopus can execute (--version)"""
         # Example output:
         #
         # spack-v0.17.2$ octopus --version
         # octopus 11.3 (git commit )
         expected = ["octopus "]
 
-        self.run_test(
-            exe,
-            options=options,
-            expected=expected,
-            status=[0],
-            installed=False,
-            purpose=purpose,
-            skip_missing=False,
-        )
+        exe = which(self.spec.prefix.bin, "octopus")
+        out = exe("--version", output=str.split, error=str.split)
+        check_outputs(expected, out)
 
         # Octopus expects a file with name `inp` in the current working
         # directory to read configuration information for a simulation run from
@@ -360,10 +346,8 @@ class Octopus(AutotoolsPackage, CudaPackage):
         # self.test_suite.current_test_data_dir, and need to copy the test
         # input files manually (see below).
 
-        #
-        # run recipe example
-        #
-
+    def test_recipe(self):
+        """run recipe example"""
         expected = [
             "Running octopus",
             "CalculationMode = recipe",
@@ -371,24 +355,16 @@ class Octopus(AutotoolsPackage, CudaPackage):
             "recipe leads to an edible dish, " 'for it is clearly "system-dependent".',
             "Calculation ended on",
         ]
-        options = []
-        purpose = "Run Octopus recipe example"
+
         with working_dir("example-recipe", create=True):
             print("Current working directory (in example-recipe)")
             fs.copy(join_path(os.path.dirname(__file__), "test", "recipe.inp"), "inp")
-            self.run_test(
-                exe,
-                options=options,
-                expected=expected,
-                status=[0],
-                installed=False,
-                purpose=purpose,
-                skip_missing=False,
-            )
+            exe = which(join_path(self.spec.prefix.bin, "octopus"))
+            out = exe(output=str.split, error=str.split)
+            check_outputs(expected, out)
 
-        #
-        # run He example
-        #
+    def test_he(self):
+        """run He example"""
         expected = [
             "Running octopus",
             "Info: Starting calculation mode.",
@@ -397,17 +373,10 @@ class Octopus(AutotoolsPackage, CudaPackage):
             "Info: Writing states.",
             "Calculation ended on",
         ]
-        options = []
-        purpose = "Run tiny calculation for He"
+
         with working_dir("example-he", create=True):
             print("Current working directory (in example-he)")
             fs.copy(join_path(os.path.dirname(__file__), "test", "he.inp"), "inp")
-            self.run_test(
-                exe,
-                options=options,
-                expected=expected,
-                status=[0],
-                installed=False,
-                purpose=purpose,
-                skip_missing=False,
-            )
+            exe = which(join_path(self.spec.prefix.bin, "octopus"))
+            out = exe(output=str.split, error=str.split)
+            check_outputs(expected, out)


### PR DESCRIPTION
Update standalone test API. See below comment for test results.

Supersedes #38010 

https://spack.readthedocs.io/en/latest/packaging_guide.html#stand-alone-tests