### PR TITLE
hypre-cmake: old to new test API

### DIFF
--- a/var/spack/repos/builtin/packages/hypre-cmake/package.py
+++ b/var/spack/repos/builtin/packages/hypre-cmake/package.py
@@ -101,7 +101,7 @@ class HypreCmake(CMakePackage, CudaPackage):
         """The working directory for cached test sources."""
         return join_path(self.test_suite.current_test_cache_dir, self.extra_install_tests)
 
-    def test_hypre_cmake(self):
+    def run_hypre_cmake(self, exe_name):
         """Perform smoke test on installed HYPRE package."""
         if "+mpi" not in self.spec:
             raise SkipTest("Package must be installed with +mpi to run tests")
@@ -111,13 +111,23 @@ class HypreCmake(CMakePackage, CudaPackage):
             make = which("make")
             make(f"HYPRE_DIR={self.prefix}", "bigint")
 
-            # Run the examples built above
-            for exe in ["./ex5big", "./ex15big"]:
-                with test_part(self, "test_hypre_cmake_build", purpose=f"Ensuring {exe} runs"):
-                    if not os.path.exists(exe):
-                        raise SkipTest(f"{exe} does not exist in version {self.version}")
-                    program = which(exe)
-                    program()
+            # Run the example built above
+            if not os.path.exists("./" + exe_name):
+                raise SkipTest(f"{exe_name} does not exist in version {self.version}")
+
+            program = which("./" + exe_name)
+            if program is None:
+                raise SkipTest(f"{exe_name} does not exist in version {self.version}")
+
+            program()
+
+    def test_ex5big(self):
+        """Ensure ex5big runs"""
+        self.run_hypre_cmake(ex5big)
+
+    def test_ex15big(self):
+        """Ensure ex15big runs"""
+        self.run_hypre_cmake(ex15big)
 
     @property
     def headers(self):

--- a/var/spack/repos/builtin/packages/hypre-cmake/package.py
+++ b/var/spack/repos/builtin/packages/hypre-cmake/package.py
@@ -94,7 +94,7 @@ class HypreCmake(CMakePackage, CudaPackage):
 
     @run_after("install")
     def cache_test_sources(self):
-        self.cache_extra_test_sources(self.extra_install_tests)
+        cache_extra_test_sources(self, self.extra_install_tests)
 
     @property
     def _cached_tests_work_dir(self):

--- a/var/spack/repos/builtin/packages/hypre-cmake/package.py
+++ b/var/spack/repos/builtin/packages/hypre-cmake/package.py
@@ -52,11 +52,13 @@ class HypreCmake(CMakePackage, CudaPackage):
 
     def url_for_version(self, version):
         if version >= Version("2.12.0"):
-            url = "https://github.com/hypre-space/hypre/archive/v{0}.tar.gz"
+            url = f"https://github.com/hypre-space/hypre/archive/v{version}.tar.gz"
         else:
-            url = "http://computing.llnl.gov/project/linear_solvers/download/hypre-{0}.tar.gz"
+            url = (
+                f"http://computing.llnl.gov/project/linear_solvers/download/hypre-{version}.tar.gz"
+            )
 
-        return url.format(version)
+        return url
 
     root_cmakelists_dir = "src"
 
@@ -105,15 +107,15 @@ class HypreCmake(CMakePackage, CudaPackage):
             raise SkipTest("Package must be installed with +mpi to run tests")
 
         # Build copied and cached test examples
-        with test_part(self, "test_hypre_cmake_build", purpose="Building selected examples"):
-            with working_dir(self._cached_tests_work_dir):
-                make = which("make")
-                make("HYPRE_DIR={0}".format(self.prefix), "bigint")
-
         with working_dir(self._cached_tests_work_dir):
+            make = which("make")
+            make(f"HYPRE_DIR={self.prefix}", "bigint")
+
             # Run the examples built above
             for exe in ["./ex5big", "./ex15big"]:
                 with test_part(self, "test_hypre_cmake_build", purpose=f"Ensuring {exe} runs"):
+                    if not os.path.exists(exe):
+                        raise SkipTest(f"{exe} does not exist in version {self.version}")
                     program = which(exe)
                     program()
 

--- a/var/spack/repos/builtin/packages/hypre-cmake/package.py
+++ b/var/spack/repos/builtin/packages/hypre-cmake/package.py
@@ -123,11 +123,11 @@ class HypreCmake(CMakePackage, CudaPackage):
 
     def test_ex5big(self):
         """Ensure ex5big runs"""
-        self.run_hypre_cmake(ex5big)
+        self.run_hypre_cmake("ex5big")
 
     def test_ex15big(self):
         """Ensure ex15big runs"""
-        self.run_hypre_cmake(ex15big)
+        self.run_hypre_cmake("ex15big")
 
     @property
     def headers(self):

--- a/var/spack/repos/builtin/packages/hypre-cmake/package.py
+++ b/var/spack/repos/builtin/packages/hypre-cmake/package.py
@@ -117,22 +117,20 @@ class HypreCmake(CMakePackage, CudaPackage):
         """The working directory for cached test sources."""
         return join_path(self.test_suite.current_test_cache_dir, self.extra_install_tests)
 
-    def test_hypre_cmake(self):
+    def test_bigint(self):
         """Perform smoke tests on installed HYPRE package."""
         if "+mpi" not in self.spec:
             raise SkipTest("Package must be installed with +mpi to run tests")
 
-        # Build copied and cached test examples
+        # Build and run cached examples
         with working_dir(self._cached_tests_work_dir):
             make = which("make")
             make("bigint")
 
             for exe_name in ["ex5big", "ex15big"]:
-                with test_part(
-                    self, f"test_hypre_cmake_{exe_name}", purpose=f"Ensure {exe_name} runs"
-                ):
+                with test_part(self, f"test_bigint_{exe_name}", purpose=f"Ensure {exe_name} runs"):
 
-                    program = which("./" + exe_name)
+                    program = which(exe_name)
                     if program is None:
                         raise SkipTest(f"{exe_name} does not exist in version {self.version}")
 

--- a/var/spack/repos/builtin/packages/hypre-cmake/package.py
+++ b/var/spack/repos/builtin/packages/hypre-cmake/package.py
@@ -101,8 +101,8 @@ class HypreCmake(CMakePackage, CudaPackage):
         """The working directory for cached test sources."""
         return join_path(self.test_suite.current_test_cache_dir, self.extra_install_tests)
 
-    def run_hypre_cmake(self, exe_name):
-        """Perform smoke test on installed HYPRE package."""
+    def test_hypre_cmake(self):
+        """Perform smoke tests on installed HYPRE package."""
         if "+mpi" not in self.spec:
             raise SkipTest("Package must be installed with +mpi to run tests")
 
@@ -111,23 +111,19 @@ class HypreCmake(CMakePackage, CudaPackage):
             make = which("make")
             make(f"HYPRE_DIR={self.prefix}", "bigint")
 
-            # Run the example built above
-            if not os.path.exists("./" + exe_name):
-                raise SkipTest(f"{exe_name} does not exist in version {self.version}")
+            for exe_name in ["ex5big", "ex15big"]:
+                with test_part(
+                    self, f"test_hypre_cmake_{exe_name}", purpose=f"Ensure {exe_name} runs"
+                ):
+                    # Run the examples built above
+                    if not os.path.exists("./" + exe_name):
+                        raise SkipTest(f"{exe_name} does not exist in version {self.version}")
 
-            program = which("./" + exe_name)
-            if program is None:
-                raise SkipTest(f"{exe_name} does not exist in version {self.version}")
+                    program = which("./" + exe_name)
+                    if program is None:
+                        raise SkipTest(f"{exe_name} does not exist in version {self.version}")
 
-            program()
-
-    def test_ex5big(self):
-        """Ensure ex5big runs"""
-        self.run_hypre_cmake("ex5big")
-
-    def test_ex15big(self):
-        """Ensure ex15big runs"""
-        self.run_hypre_cmake("ex15big")
+                    program()
 
     @property
     def headers(self):


### PR DESCRIPTION
Update standalone testing API. See below comment below for test error output.

Supersedes #38501 (for one package)

Final results:
```
$ spack -v test run hypre-cmake
==> Spack test 7a4nvjh22znoayqzqfteknji7xuvz74f
==> Testing package hypre-cmake-2.22.0-iim6mdw
==> [2024-08-09-15:37:46.583737] test: test_bigint: Perform smoke tests on installed HYPRE package.
SKIPPED: HypreCmake::test_bigint: Package must be installed with +mpi to run tests
==> [2024-08-09-15:37:46.585888] Completed testing
==> [2024-08-09-15:37:46.586022] 
===================== SUMMARY: hypre-cmake-2.22.0-iim6mdw ======================
HypreCmake::test_bigint .. SKIPPED
============================= 1 skipped of 1 parts =============================
==> Testing package hypre-cmake-2.22.0-ynxtvrx
..
==> [2024-08-09-15:37:48.841308] test: test_bigint: Perform smoke tests on installed HYPRE package.
==> [2024-08-09-15:37:48.843304] '/usr/bin/make' 'bigint'
..
==> [2024-08-09-15:37:50.509556] test: test_bigint_ex5big: Ensure ex5big runs
..
..
 Num MPI tasks = 1

 Num OpenMP threads = 1
..
Iterations = 6
Final Relative Residual Norm = 1.770275e-08

PASSED: HypreCmake::test_bigint_ex5big
==> [2024-08-09-15:37:50.612490] test: test_bigint_ex15big: Ensure ex15big runs
..
..
Iterations = 4
Final Relative Residual Norm = 1.58866e-07

PASSED: HypreCmake::test_bigint_ex15big
PASSED: HypreCmake::test_bigint
==> [2024-08-09-15:37:50.870538] Completed testing
==> [2024-08-09-15:37:50.870670] 
===================== SUMMARY: hypre-cmake-2.22.0-ynxtvrx ======================
HypreCmake::test_bigint_ex5big .. PASSED
HypreCmake::test_bigint_ex15big .. PASSED
HypreCmake::test_bigint .. PASSED
============================= 3 passed of 3 parts ==============================
======================== 1 skipped, 1 passed of 2 specs ========================
```