### PR TITLE
rust: update `cmake` dependency ranges

### DIFF
--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -54,7 +54,6 @@ class Rust(Package):
     variant("src", default=True, description="Include standard library source files.")
 
     # Core dependencies
-    depends_on("cmake@3.13.4:", type="build")
     depends_on("curl+nghttp2")
     depends_on("libgit2")
     depends_on("libssh2")
@@ -64,6 +63,11 @@ class Rust(Package):
     depends_on("python", type="build")
     depends_on("zlib-api")
 
+    depends_on("cmake@3.4.3:", type="build", when="@:1.51")
+    depends_on("cmake@3.13.4:", type="build", when="@1.52:1.72")
+    depends_on("cmake@3.20.0:", type="build", when="@1.73:")
+    
+    
     # Compiling Rust requires a previous version of Rust.
     # The easiest way to bootstrap a Rust environment is to
     # download the binary distribution of the compiler and build with that.

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -63,6 +63,8 @@ class Rust(Package):
     depends_on("python", type="build")
     depends_on("zlib-api")
 
+    # cmake dependency comes from LLVM. Rust has their own fork of LLVM, with tags corresponding
+    # to each Rust release, so it's easy to loop through tags and grep for "cmake_minimum_required"
     depends_on("cmake@3.4.3:", type="build", when="@:1.51")
     depends_on("cmake@3.13.4:", type="build", when="@1.52:1.72")
     depends_on("cmake@3.20.0:", type="build", when="@1.73:")

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -68,8 +68,7 @@ class Rust(Package):
     depends_on("cmake@3.4.3:", type="build", when="@:1.51")
     depends_on("cmake@3.13.4:", type="build", when="@1.52:1.72")
     depends_on("cmake@3.20.0:", type="build", when="@1.73:")
-    
-    
+
     # Compiling Rust requires a previous version of Rust.
     # The easiest way to bootstrap a Rust environment is to
     # download the binary distribution of the compiler and build with that.


### PR DESCRIPTION
fixes the cmake dependency versions for the rust package.

To find this information, I cloned the Rust fork of the LLVM project, and grepped the Cmake files after checking out each Rust release tag:
```
$ git tag | grep rustc | sort -n | while read -r tag; do printf "$tag -> "; git checkout -q "$tag"; grep cmake_minimum_required ./lld/CmakeLists.txt | sed -E 's|^.*VERSION ([^\)]+).*$|\1|'; done
rustc-1.34.0 -> 3.4.3
rustc-1.34.1 -> 3.4.3
rustc-1.34.2 -> 3.4.3
rustc-1.35.0 -> 3.4.3
rustc-1.36.0 -> 3.4.3
rustc-1.37.0 -> 3.4.3
rustc-1.38.0 -> 3.4.3
rustc-1.39.0 -> 3.4.3
rustc-1.40.0 -> 3.4.3
rustc-1.41.0 -> 3.4.3
rustc-1.41.1 -> 3.4.3
rustc-1.42.0 -> 3.4.3
rustc-1.43.0 -> 3.4.3
rustc-1.43.1 -> 3.4.3
rustc-1.44.0 -> 3.4.3
rustc-1.44.1 -> 3.4.3
rustc-1.45.0 -> 3.4.3
rustc-1.45.1 -> 3.4.3
rustc-1.45.2 -> 3.4.3
rustc-1.46.0 -> 3.4.3
rustc-1.47.0 -> 3.4.3
rustc-1.48.0 -> 3.4.3
rustc-1.49.0 -> 3.4.3
rustc-1.50.0 -> 3.4.3
rustc-1.51.0 -> 3.4.3
rustc-1.52.0 -> 3.13.4
rustc-1.52.1 -> 3.13.4
rustc-1.53.0 -> 3.13.4
rustc-1.54.0 -> 3.13.4
rustc-1.55.0 -> 3.13.4
rustc-1.56.0 -> 3.13.4
rustc-1.56.1 -> 3.13.4
rustc-1.57.0 -> 3.13.4
rustc-1.58.0 -> 3.13.4
rustc-1.58.1 -> 3.13.4
rustc-1.59.0 -> 3.13.4
rustc-1.60.0 -> 3.13.4
rustc-1.61.0 -> 3.13.4
rustc-1.62.0 -> 3.13.4
rustc-1.62.1 -> 3.13.4
rustc-1.63.0 -> 3.13.4
rustc-1.64.0 -> 3.13.4
rustc-1.65.0 -> 3.13.4
rustc-1.66.0 -> 3.13.4
rustc-1.66.1 -> 3.13.4
rustc-1.67.0 -> 3.13.4
rustc-1.67.1 -> 3.13.4
rustc-1.68.0 -> 3.13.4
rustc-1.68.1 -> 3.13.4
rustc-1.68.2 -> 3.13.4
rustc-1.69.0 -> 3.13.4
rustc-1.70.0 -> 3.13.4
rustc-1.71.0 -> 3.13.4
rustc-1.71.1 -> 3.13.4
rustc-1.72.0 -> 3.13.4
rustc-1.72.1 -> 3.13.4
rustc-1.73.0 -> 3.20.0
rustc-1.74.0 -> 3.20.0
rustc-1.74.1 -> 3.20.0
rustc-1.75.0 -> 3.20.0
rustc-1.76.0 -> 3.20.0
rustc-1.77.0 -> 3.20.0
rustc-1.77.1 -> 3.20.0
rustc-1.77.2 -> 3.20.0
rustc-1.78.0 -> 3.20.0
rustc-1.79.0 -> 3.20.0
```