### PR TITLE
Remove some explicit dependencies for py-globus-cli

### DIFF
--- a/var/spack/repos/builtin/packages/py-globus-cli/package.py
+++ b/var/spack/repos/builtin/packages/py-globus-cli/package.py
@@ -26,10 +26,3 @@ class PyGlobusCli(PythonPackage):
     depends_on("py-click@8", type=("build", "run"))
     depends_on("py-jmespath@1.0.1", type=("build", "run"))
     depends_on("py-packaging@17:", type=("build", "run"))
-    # According to the developers, these requirements are implicit
-    # for py-globus-sdk, but they are listed explicitly "in case
-    # the underlying lib ever changes"
-    depends_on("py-requests@2.19.1:2", type=("build", "run"))
-    depends_on("py-pyjwt@2.0.0:2+crypto", type=("build", "run"))
-    depends_on("py-cryptography@3.3.1:3.3", type=("build", "run"))
-    depends_on("py-typing-extensions@4:", type=("build", "run"), when="^python@:3.10")


### PR DESCRIPTION
As discussed in https://github.com/spack/spack/pull/44881#issuecomment-2218411735 a `spack install py-globus-cli` fails to concretize on an Ubuntu 22.04 under Windows WSL2 because of too strict of explicit dependencies.

Let's try to remove them here (since these are "just in case" and in all honesty should be handled by `py-globus-sdk` anyways).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
