### PR TITLE
bacio: recipe updates

### DIFF
--- a/var/spack/repos/builtin/packages/bacio/package.py
+++ b/var/spack/repos/builtin/packages/bacio/package.py
@@ -20,16 +20,7 @@ class Bacio(CMakePackage):
     version("develop", branch="develop")
     version("2.6.0", sha256="03fef581e1bd3710fb8d2f2659a6c3e01a0437c1350ba53958d2ff1ffef47bcb")
     version("2.5.0", sha256="540a0ed73941d70dbf5d7b21d5d0a441e76fad2bfe37dfdfea0db3e98fc0fbfb")
-
-    # Prefer version 2.4.1 because the library and include directory
-    # names changed in verion 2.5.0 (dropping the "_4" they used to
-    # contain.) We need some time to let all the using packages adjust
-    # to the new names.
-    version(
-        "2.4.1",
-        sha256="7b9b6ba0a288f438bfba6a08b6e47f8133f7dba472a74ac56a5454e2260a7200",
-        preferred=True,
-    )
+    version("2.4.1", sha256="7b9b6ba0a288f438bfba6a08b6e47f8133f7dba472a74ac56a5454e2260a7200")
 
     variant("pic", default=True, description="Build with position-independent-code")
     variant("shared", default=False, description="Build shared library", when="@2.6.0:")
@@ -43,3 +34,7 @@ class Bacio(CMakePackage):
     def patch(self):
         if self.spec.satisfies("@2.4.1"):
             filter_file(".+", "2.4.1", "VERSION")
+
+    def check(self):
+        with working_dir(self.builder.build_directory):
+            make("test")


### PR DESCRIPTION
This PR un-prefers bacio@2.4.1 because it's time to move on, and specifies 'test' as the appropriate make target for testing, as we've done for the other NCEPLIBS (I guess I missed this one).