### PR TITLE
libpressio: old to new test API

### DIFF
--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -413,7 +413,7 @@ class Libpressio(CMakePackage, CudaPackage):
             join_path("test", "smoke_test", "smoke_test.cc"),
             join_path("test", "smoke_test", "CMakeLists.txt"),
         ]
-        self.cache_extra_test_sources(srcs)
+        cache_extra_test_sources(self)
 
     def test_smoke(self):
         """Run smoke test"""

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -407,7 +407,7 @@ class Libpressio(CMakePackage, CudaPackage):
 
     @run_after("install")
     def copy_test_sources(self):
-        if self.spec.satisfies("@0.88.2"):
+        if self.spec.satisfies("@:0.88.2"):
             raise SkipTest("Package must be installed as version @0.88.3 or later")
         srcs = [
             join_path("test", "smoke_test", "smoke_test.cc"),
@@ -417,7 +417,7 @@ class Libpressio(CMakePackage, CudaPackage):
 
     def test_cmake(self):
         """Test cmake config"""
-        if self.spec.satisfies("@0.88.2"):
+        if self.spec.satisfies("@:0.88.2"):
             raise SkipTest("Package must be installed as version @0.88.3 or later")
 
         args = self.cmake_args()
@@ -434,14 +434,14 @@ class Libpressio(CMakePackage, CudaPackage):
     def test_build(self):
         """Cmake build test"""
         # this works for cmake@3.14: which is required for this package
-        if self.spec.satisfies("@0.88.2"):
+        if self.spec.satisfies("@:0.88.2"):
             raise SkipTest("Package must be installed as version @0.88.3 or later")
         exe = which("cmake")
         exe("--build", ".")
 
     def test_smoke(self):
         """Run smoke test"""
-        if self.spec.satisfies("@0.88.2"):
+        if self.spec.satisfies("@:0.88.2"):
             raise SkipTest("Package must be installed as version @0.88.3 or later")
         exe = which("./pressio_smoke_tests")
         out = exe()

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -300,7 +300,7 @@ class Libpressio(CMakePackage, CudaPackage):
     )
     for cuda_compressor in ["cusz", "mgard", "zfp", "ndzip"]:
         conflicts(
-            "~cuda+{pkg} ^ {pkg}+cuda".format(pkg=cuda_compressor),
+            f"~cuda+{cuda_compressor} ^ {cuda_compressor}+cuda",
             msg="compiling a CUDA compressor without a CUDA support makes no sense",
         )
     depends_on("sz3", when="+sz3")

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -407,17 +407,18 @@ class Libpressio(CMakePackage, CudaPackage):
 
     @run_after("install")
     def copy_test_sources(self):
-        if self.version < Version("0.88.3"):
-            return
+        if self.spec.satisfies("@0.88.2"):
+            raise SkipTest("Package must be installed as version @0.88.3 or later")
         srcs = [
             join_path("test", "smoke_test", "smoke_test.cc"),
             join_path("test", "smoke_test", "CMakeLists.txt"),
         ]
         self.cache_extra_test_sources(srcs)
 
-    def test(self):
-        if self.version < Version("0.88.3"):
-            return
+    def test_cmake(self):
+        """Test cmake config"""
+        if self.spec.satisfies("@0.88.2"):
+            raise SkipTest("Package must be installed as version @0.88.3 or later")
 
         args = self.cmake_args()
         args.append(
@@ -427,10 +428,22 @@ class Libpressio(CMakePackage, CudaPackage):
             "-DCMAKE_PREFIX_PATH={};{}".format(self.spec["libstdcompat"].prefix, self.prefix)
         )
 
-        self.run_test("cmake", args, purpose="cmake configuration works")
+        cmake = which("cmake")
+        cmake(*args)
 
+    def test_build(self):
+        """Cmake build test"""
         # this works for cmake@3.14: which is required for this package
-        args = ["--build", "."]
-        self.run_test("cmake", args, purpose="cmake builds works")
+        if self.spec.satisfies("@0.88.2"):
+            raise SkipTest("Package must be installed as version @0.88.3 or later")
+        exe = which("cmake")
+        exe("--build", ".")
 
-        self.run_test("./pressio_smoke_tests", expected="all passed")
+    def test_smoke(self):
+        """Run smoke test"""
+        if self.spec.satisfies("@0.88.2"):
+            raise SkipTest("Package must be installed as version @0.88.3 or later")
+        exe = which("./pressio_smoke_tests")
+        out = exe()
+        expected = "all passed"
+        assert out in expected

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -409,10 +409,6 @@ class Libpressio(CMakePackage, CudaPackage):
     def copy_test_sources(self):
         if self.spec.satisfies("@:0.88.2"):
             raise SkipTest("Package must be installed as version @0.88.3 or later")
-        srcs = [
-            join_path("test", "smoke_test", "smoke_test.cc"),
-            join_path("test", "smoke_test", "CMakeLists.txt"),
-        ]
         cache_extra_test_sources(self)
 
     def test_smoke(self):

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -384,7 +384,7 @@ class Libpressio(CMakePackage, CudaPackage):
             args.append("-DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined")
         # libpressio needs to know where to install the python libraries
         if "+python" in self.spec:
-            args.append("-DLIBPRESSIO_PYTHON_SITELIB={0}".format(python_platlib))
+            args.append(f"-DLIBPRESSIO_PYTHON_SITELIB={python_platlib}")
         # help ensure that libpressio finds the correct HDF5 package
         if "+hdf5" in self.spec:
             args.append("-DHDF5_ROOT=" + self.spec["hdf5"].prefix)
@@ -422,19 +422,15 @@ class Libpressio(CMakePackage, CudaPackage):
             raise SkipTest("Package must be installed as version @0.88.3 or later")
 
         args = self.cmake_args()
-        args.append(
-            "-S{}".format(join_path(self.test_suite.current_test_cache_dir, "test", "smoke_test"))
-        )
-        args.append(
-            "-DCMAKE_PREFIX_PATH={};{}".format(self.spec["libstdcompat"].prefix, self.prefix)
-        )
+        args.append(f"-S{join_path(self.test_suite.current_test_cache_dir, 'test', 'smoke_test')}")
+        args.append(f"-DCMAKE_PREFIX_PATH={self.spec['libstdcompat'].prefix};{self.prefix}")
 
         cmake = which("cmake")
         cmake(*args)
         cmake("--build", ".")
 
         exe = which("./pressio_smoke_tests")
-        out = exe()
+        out = exe(output=str.split, error=str.split)
 
         expected = "all passed"
         assert out in expected

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -429,4 +429,4 @@ class Libpressio(CMakePackage, CudaPackage):
         out = exe(output=str.split, error=str.split)
 
         expected = "all passed"
-        assert out in expected
+        assert expected in out

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -415,8 +415,9 @@ class Libpressio(CMakePackage, CudaPackage):
         ]
         self.cache_extra_test_sources(srcs)
 
-    def test_cmake(self):
-        """Test cmake config"""
+    def test_smoke(self):
+        """Run smoke test"""
+        # this works for cmake@3.14: which is required for this package
         if self.spec.satisfies("@:0.88.2"):
             raise SkipTest("Package must be installed as version @0.88.3 or later")
 
@@ -430,20 +431,10 @@ class Libpressio(CMakePackage, CudaPackage):
 
         cmake = which("cmake")
         cmake(*args)
+        cmake("--build", ".")
 
-    def test_build(self):
-        """Cmake build test"""
-        # this works for cmake@3.14: which is required for this package
-        if self.spec.satisfies("@:0.88.2"):
-            raise SkipTest("Package must be installed as version @0.88.3 or later")
-        exe = which("cmake")
-        exe("--build", ".")
-
-    def test_smoke(self):
-        """Run smoke test"""
-        if self.spec.satisfies("@:0.88.2"):
-            raise SkipTest("Package must be installed as version @0.88.3 or later")
         exe = which("./pressio_smoke_tests")
         out = exe()
+
         expected = "all passed"
         assert out in expected

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -409,7 +409,7 @@ class Libpressio(CMakePackage, CudaPackage):
     def copy_test_sources(self):
         if self.spec.satisfies("@:0.88.2"):
             raise SkipTest("Package must be installed as version @0.88.3 or later")
-        cache_extra_test_sources(self)
+        cache_extra_test_sources(self, srcs)
 
     def test_smoke(self):
         """Run smoke test"""

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -408,7 +408,7 @@ class Libpressio(CMakePackage, CudaPackage):
     @run_after("install")
     def copy_test_sources(self):
         if self.spec.satisfies("@:0.88.2"):
-            raise SkipTest("Package must be installed as version @0.88.3 or later")
+            return
         srcs = [
             join_path("test", "smoke_test", "smoke_test.cc"),
             join_path("test", "smoke_test", "CMakeLists.txt"),

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -429,7 +429,7 @@ class Libpressio(CMakePackage, CudaPackage):
         cmake(*args)
         cmake("--build", ".")
 
-        exe = which("./pressio_smoke_tests")
+        exe = which("pressio_smoke_tests")
         out = exe(output=str.split, error=str.split)
 
         expected = "all passed"

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -425,7 +425,7 @@ class Libpressio(CMakePackage, CudaPackage):
         args.append(f"-S{join_path(self.test_suite.current_test_cache_dir, 'test', 'smoke_test')}")
         args.append(f"-DCMAKE_PREFIX_PATH={self.spec['libstdcompat'].prefix};{self.prefix}")
 
-        cmake = which("cmake")
+        cmake = self.spec["cmake"].command
         cmake(*args)
         cmake("--build", ".")
 

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -409,6 +409,10 @@ class Libpressio(CMakePackage, CudaPackage):
     def copy_test_sources(self):
         if self.spec.satisfies("@:0.88.2"):
             raise SkipTest("Package must be installed as version @0.88.3 or later")
+        srcs = [
+            join_path("test", "smoke_test", "smoke_test.cc"),
+            join_path("test", "smoke_test", "CMakeLists.txt"),
+        ]
         cache_extra_test_sources(self, srcs)
 
     def test_smoke(self):


### PR DESCRIPTION
Update standalone testing API. See below comment below for test error output.

Supersedes #35777  (for one package).

https://spack.readthedocs.io/en/latest/packaging_guide.html#stand-alone-tests

Results from a test run indicate the test API conversion *appears* to work.
```
$ spack find -v libpressio
..
libpressio@0.99.4~arc~bitgrooming~blosc~blosc2~boost~bzip2~clang+core~cuda~cusz~digitrounding~docs~fpzip~ftk~hdf5~ipo~json+libdistributed~lua~magick~matio~mgard~mgardx+mpi~ndzip~netcdf~openmp~openssl~petsc~pybind~python~qoz~remote~sz~sz3~szauto~szx~unix~zfp build_system=cmake build_type=Release generator=make
libpressio@0.99.4~arc~bitgrooming~blosc~blosc2~boost~bzip2~clang+core~cuda~cusz~digitrounding~docs~fpzip~ftk+hdf5~ipo~json~libdistributed~lua~magick~matio~mgard~mgardx~mpi~ndzip~netcdf~openmp~openssl~petsc~pybind~python~qoz~remote~sz~sz3~szauto~szx~unix~zfp build_system=cmake build_type=Release generator=make
==> 2 installed packages


$ spack -v test run libpressio
==> Spack test 4v6ig5pxewh6apipfb5tbwql23smsypu
==> Testing package libpressio-0.99.4-kygoluy
==> [2024-08-14-15:37:50.735465] '/usr/bin/fi_info' '-l'
..
==> [2024-08-14-15:40:19.683755] test: test_smoke: Run smoke test
==> [2024-08-14-15:40:19.685704] '/usr/tce/packages/gcc/gcc-12.1.1/bin/gcc' '-dumpversion'
..
-- The C compiler identification is GNU 8.5.0
-- The CXX compiler identification is GNU 8.5.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/lib64/ccache/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/lib64/ccache/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (1.8s)
CMake Error in CMakeLists.txt:
  The compiler feature "cxx_std_23" is not known to CXX compiler

  "GNU"

  version 8.5.0.


CMake Generate step failed.  Build files cannot be regenerated correctly.
FAILED: Libpressio::test_smoke: Command exited with status 1:
..
==> [2024-08-14-15:40:21.859118] Completed testing
==> [2024-08-14-15:40:21.859223] 
====================== SUMMARY: libpressio-0.99.4-kygoluy ======================
Libpressio::test_smoke .. FAILED
============================= 1 failed of 1 parts ==============================
..
==> Testing package libpressio-0.99.4-gnfpovh
..
==> [2024-08-14-15:41:20.449177] test: test_smoke: Run smoke test
==> [2024-08-14-15:41:20.451314] '/usr/tce/packages/gcc/gcc-12.1.1/bin/gcc' '-dumpversion'
..
-- The C compiler identification is GNU 8.5.0
-- The CXX compiler identification is GNU 8.5.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/lib64/ccache/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/lib64/ccache/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (1.4s)
CMake Error in CMakeLists.txt:
  The compiler feature "cxx_std_23" is not known to CXX compiler

  "GNU"

  version 8.5.0.


CMake Generate step failed.  Build files cannot be regenerated correctly.
FAILED: Libpressio::test_smoke: Command exited with status 1:
..
==> [2024-08-14-15:41:22.061827] Completed testing
==> [2024-08-14-15:41:22.061949] 
====================== SUMMARY: libpressio-0.99.4-gnfpovh ======================
Libpressio::test_smoke .. FAILED
============================= 1 failed of 1 parts ==============================
```