### PR TITLE
intel-xed: Rewrite recipe to match upstream install layout (v2)

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -189,7 +189,6 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
     depends_on("intel-gtpin", when="+gtpin")
     depends_on("opencl-c-headers", when="+opencl")
 
-    depends_on("intel-xed+pic", when="target=x86_64:")
     depends_on("memkind", type=("build", "run"), when="@2021.05.01:2023.08")
     depends_on("papi", when="+papi")
     depends_on("libpfm4", when="~papi")
@@ -198,6 +197,10 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
     depends_on("hpcviewer@2022.10:", type="run", when="@2022.10: +viewer")
     depends_on("hpcviewer", type="run", when="+viewer")
     depends_on("python@3.10:", type=("build", "run"), when="+python")
+
+    with when("target=x86_64:"):
+        depends_on("intel-xed+pic")
+        depends_on("intel-xed+deprecated-includes", when="@:2024.01.1")
 
     # Avoid 'link' dep, we don't actually link, and that adds rpath
     # that conflicts with app.

--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -40,8 +40,8 @@ class IntelXed(Package):
     # The old 2019.03.01 version (before there were tags).
     version("10.2019.03", commit="b7231de4c808db821d64f4018d15412640c34113", deprecated=True)
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     # XED wants the mbuild directory adjacent to xed in the same directory.
     mdir = join_path("..", "mbuild")

--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -23,6 +23,9 @@ class IntelXed(Package):
 
     # Current versions now have actual releases and tags.
     version("main", branch="main")
+    version("2024.05.20", tag="v2024.05.20", commit="7e88c3e00274a10daa6b9d053decc057f65aa0ec")
+    version("2024.04.01", tag="v2024.04.01", commit="6d87b5481aa53b5ab1fc2b5a5622759c46746bf9")
+    version("2024.02.22", tag="v2024.02.22", commit="d08a6f66f780a685f26322960cd3ae297dbad931")
     version("2023.10.11", tag="v2023.10.11", commit="d7d46c73fb04a1742e99c9382a4acb4ed07ae272")
     version("2023.08.21", tag="v2023.08.21", commit="01a6da8090af84cd52f6c1070377ae6e885b078f")
     version("2023.07.09", tag="v2023.07.09", commit="539a6a349cf7538a182ed3ee1f48bb9317eb185f")

--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import stat
+from pathlib import Path
 
 from spack.package import *
 
@@ -62,8 +64,21 @@ class IntelXed(Package):
         when="@:2022.06",
     )
 
+    variant("optimize", default=True, description="Build with -O2")
     variant("debug", default=False, description="Enable debug symbols")
     variant("pic", default=False, description="Compile with position independent code.")
+    variant("examples", default=False, description="Build and install the examples")
+
+    # Previous versions of this recipe used a different install layout than upstream Xed.
+    # This has since been fixed, but some packages were written on the older install layout and
+    # will not build on the upstream Xed layout.
+    # Enabling this variant adds compatibility headers for such software to build successfully.
+    variant(
+        "deprecated-includes",
+        default=False,
+        sticky=True,
+        description="Add compatibility headers for software written on the old include layout",
+    )
 
     # The current mfile uses python3 by name.
     depends_on("python@3.7:", type="build")
@@ -72,26 +87,10 @@ class IntelXed(Package):
     patch("2019-python3.patch", when="@10.2019.03")
     patch("libxed-ild.patch", when="@12.0:2022.12")
 
-    requires("target=x86_64:", msg="intel-xed only runs on x86/x86_64")
+    requires("target=x86_64:,aarch64:", msg="intel-xed only builds on x86-64 or aarch64")
 
-    mycflags = []  # type: List[str]
-
-    # Save CFLAGS for use in install.
-    def flag_handler(self, name, flags):
-        if name == "cflags":
-            self.mycflags = flags
-
-            if "+pic" in self.spec:
-                flags.append(self.compiler.cc_pic_flag)
-
-        return (flags, None, None)
-
-    def install(self, spec, prefix):
-        # XED needs PYTHONPATH to find the mbuild directory.
-        mbuild_dir = join_path(self.stage.source_path, "..", "mbuild")
-        python_path = os.getenv("PYTHONPATH", "")
-        os.environ["PYTHONPATH"] = mbuild_dir + ":" + python_path
-
+    @when("@2023.04.16")
+    def patch(self):
         # In 2023.04.16, the xed source directory must be exactly 'xed',
         # so add a symlink, but don't fail if the link already exists.
         # See: https://github.com/intelxed/xed/issues/300
@@ -101,45 +100,66 @@ class IntelXed(Package):
         except OSError:
             pass
 
+    def setup_build_environment(self, env):
+        # XED needs PYTHONPATH to find the mbuild directory.
+        env.prepend_path("PYTHONPATH", self.mdir)
+
+    @staticmethod
+    def _make_writable(root) -> None:
+        for dirpath, _, filenames in os.walk(root):
+            for fn in filenames:
+                path = Path(dirpath) / fn
+                if not path.is_symlink():
+                    path.chmod(path.stat().st_mode | stat.S_IWUSR)
+
+    def install(self, spec, prefix):
         mfile = Executable(join_path(".", "mfile.py"))
-
-        args = ["-j", str(make_jobs), "--cc=%s" % spack_cc, "--no-werror"]
-
+        mfile.add_default_arg(
+            f"--jobs={make_jobs}",
+            f"--cc={spack_cc}",
+            f"--cxx={spack_cxx}",
+            "--no-werror",
+            f"--prefix={prefix}",
+        )
+        if "+optimize" in spec:
+            mfile.add_default_arg("--opt=2")
         if "+debug" in spec:
-            args.append("--debug")
+            mfile.add_default_arg("--debug")
+        if "+pic" in spec:
+            mfile.add_default_arg(
+                f"--extra-ccflags={self.compiler.cc_pic_flag}",
+                f"--extra-cxxflags={self.compiler.cxx_pic_flag}",
+            )
 
-        # If an optimization flag (-O...) is specified in CFLAGS, use
-        # that, else set default opt level.
-        for flag in self.mycflags:
-            if flag.startswith("-O"):
-                break
-        else:
-            args.append("--opt=2")
+        # Build and install first as static (the default).
+        mfile("--install-dir=" + join_path("kits", "static"), "install")
+        self._make_writable(prefix)
 
-        # Build and install static libxed.a.
+        # Rebuild and reinstall as shared. This overwrites anything installed as static before.
+        shared_kit = join_path("kits", "shared")
         mfile("--clean")
-        mfile(*args)
+        mfile(
+            f"--install-dir={shared_kit}",
+            "--shared",
+            *(["examples"] if "+examples" in spec else []),
+            "install",
+        )
 
-        mkdirp(prefix.include)
-        mkdirp(prefix.lib)
-        mkdirp(prefix.bin)
+        if "+examples" in self.spec:
+            # Install the example binaries to share/xed/examples
+            install_tree(join_path(shared_kit, "bin"), prefix.share.xed.examples)
 
-        install(join_path("obj", "lib*.a"), prefix.lib)
+            # Add a convenience symlink for the xed example/CLI to bin/xed
+            mkdirp(prefix.bin)
+            symlink(prefix.share.xed.examples.xed, prefix.bin.xed)
 
-        # Build and install shared libxed.so and examples (to get the CLI).
-        mfile("--clean")
-        mfile("examples", "--shared", *args)
-
-        install(join_path("obj", "lib*.so"), prefix.lib)
-
-        # Starting with 11.x, the install files are moved or copied into
-        # subdirs of obj/wkit.
-        if spec.satisfies("@11.0:"):
-            wkit = join_path("obj", "wkit")
-            install(join_path(wkit, "bin", "xed"), prefix.bin)
-            install(join_path(wkit, "include", "xed", "*.h"), prefix.include)
-        else:
-            # Old 2019.03.01 paths.
-            install(join_path("obj", "examples", "xed"), prefix.bin)
-            install(join_path("include", "public", "xed", "*.h"), prefix.include)
-            install(join_path("obj", "*.h"), prefix.include)
+    @run_after("install", when="+deprecated-includes")
+    def install_deprecated_include_compat(self):
+        """Install compatibility headers in <prefix>/include for old code"""
+        for hdr in Path(self.prefix.include).glob("xed/*.h"):
+            (Path(self.prefix.include) / hdr.name).write_text(
+                f"""\
+#warning This is a Spack compatibilty header, please update your #includes!
+#include "xed/{hdr.name}"
+"""
+            )


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/41268. Reimplementation based on discussion from https://github.com/spack/spack/pull/45084#issuecomment-2216412554.

For a long time now, the `intel-xed` recipe manually implemented the install phase by copying files out of the Xed build tree. This PR replaces this logic with the upstream install target instead, making the recipe both more accurate and more simpler/elegant. It also adds the latest tagged versions of XED to the recipe.

This is a disruptive change, the install layout in the `intel-xed` recipe has differed from the upstream install layout since its introduction to Spack. In particular, the headers currently installed to `include/xed-*.h` are installed by the upstream install logic to `include/xed/xed-*.h`.

To support packages that depend on the now-deprecated install layout, a new variant `+deprecated-include-compat` can be enabled to install custom `include/xed-*.h` compatibility headers. These headers simply a compiler `#warning` and then `#include` the equivalent header with the `xed/` prefix added. This variant is sticky to prevent it from being enabled when not explicitly required by a package or user. (Note that the upstream install layout is always installed regardless, so software that supports the upstream install layout will never fail due to misplaced headers.)

This PR adjusts the `depends_on` for `hpctoolkit` (the only dependent of `intel-xed`) to enable this compatibility variant for versions affected by the layout change. Versions that support the upstream install layout (`@2024.01.stable` and `@develop`) are unaffected by this change and do not require the compatibility variant.

This PR has been extensively tested by successfully building a large environment ([spack.yaml](https://github.com/user-attachments/files/16156075/spack.yaml.txt)) from scratch.