### PR TITLE
external find --not-buildable: mark virtuals

### DIFF
--- a/lib/spack/spack/detection/__init__.py
+++ b/lib/spack/spack/detection/__init__.py
@@ -2,7 +2,12 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from .common import DetectedPackage, executable_prefix, update_configuration
+from .common import (
+    DetectedPackage,
+    executable_prefix,
+    set_virtuals_nonbuildable,
+    update_configuration,
+)
 from .path import by_path, executables_in_path
 from .test import detection_tests
 
@@ -12,5 +17,6 @@ __all__ = [
     "executables_in_path",
     "executable_prefix",
     "update_configuration",
+    "set_virtuals_nonbuildable",
     "detection_tests",
 ]

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -252,6 +252,27 @@ def update_configuration(
     return all_new_specs
 
 
+def set_virtuals_nonbuildable(virtuals: Set[str], scope: Optional[str] = None) -> List[str]:
+    """Update packages:virtual:buildable:False for the provided virtual packages, if the property
+    is not set by the user. Returns the list of virtual packages that have been updated."""
+    packages = spack.config.get("packages")
+    new_config = {}
+    for virtual in virtuals:
+        # If the user has set the buildable prop do not override it
+        if virtual in packages and "buildable" in packages[virtual]:
+            continue
+        new_config[virtual] = {"buildable": False}
+
+    # Update the provided scope
+    spack.config.set(
+        "packages",
+        spack.config.merge_yaml(spack.config.get("packages", scope=scope), new_config),
+        scope=scope,
+    )
+
+    return list(new_config.keys())
+
+
 def _windows_drive() -> str:
     """Return Windows drive string extracted from the PROGRAMFILES environment variable,
     which is guaranteed to be defined for all logins.

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -115,10 +115,10 @@ def test_find_external_cmd_not_buildable(mutable_config, working_env, mock_execu
     "names,tags,exclude,expected",
     [
         # find --all
-        (None, ["detectable"], [], ["builtin.mock.find-externals1", "builtin.mock.mpich"]),
+        (None, ["detectable"], [], ["builtin.mock.find-externals1"]),
         # find --all --exclude find-externals1
-        (None, ["detectable"], ["builtin.mock.find-externals1"], ["builtin.mock.mpich"]),
-        (None, ["detectable"], ["find-externals1"], ["builtin.mock.mpich"]),
+        (None, ["detectable"], ["builtin.mock.find-externals1"], []),
+        (None, ["detectable"], ["find-externals1"], []),
         # find cmake (and cmake is not detectable)
         (["cmake"], ["detectable"], [], []),
     ],
@@ -314,8 +314,9 @@ def test_failures_in_scanning_do_not_result_in_an_error(
     assert "3.19.1" not in output
 
 
-def test_detect_virtuals(mock_executable, mutable_config, mock_packages, monkeypatch):
-    # Prepare an environment to detect a fake cmake
+def test_detect_virtuals(mock_executable, mutable_config, monkeypatch):
+    """Test whether external find --not-buildable sets virtuals as non-buildable (unless user
+    config sets them to buildable)"""
     mpich = mock_executable("mpichversion", output="echo MPICH Version:    4.0.2")
     prefix = os.path.dirname(mpich)
     external("find", "--path", prefix, "--not-buildable", "mpich")
@@ -323,7 +324,7 @@ def test_detect_virtuals(mock_executable, mutable_config, mock_packages, monkeyp
     # Check that mpich was correctly detected
     mpich = mutable_config.get("packages:mpich")
     assert mpich["buildable"] is False
-    assert mpich["externals"][0]["spec"] == "mpich@4.0.2"
+    assert Spec(mpich["externals"][0]["spec"]).satisfies("mpich@4.0.2")
 
     # Check that the virtual package mpi was marked as non-buildable
     assert mutable_config.get("packages:mpi:buildable") is False

--- a/var/spack/repos/builtin.mock/packages/mpich/package.py
+++ b/var/spack/repos/builtin.mock/packages/mpich/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import re
-
 from spack.package import *
 
 
@@ -15,13 +13,6 @@ class Mpich(Package):
     list_depth = 2
 
     tags = ["tag1", "tag2"]
-    executables = ["^mpichversion$"]
-
-    @classmethod
-    def determine_version(cls, exe):
-        output = Executable(exe)(output=str, error=str)
-        match = re.search(r"MPICH Version:\s+(\S+)", output)
-        return match.group(1) if match else None
 
     variant("debug", default=False, description="Compile MPICH with debug flags.")
 

--- a/var/spack/repos/builtin.mock/packages/mpich/package.py
+++ b/var/spack/repos/builtin.mock/packages/mpich/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 from spack.package import *
 
 
@@ -13,6 +15,13 @@ class Mpich(Package):
     list_depth = 2
 
     tags = ["tag1", "tag2"]
+    executables = ["^mpichversion$"]
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)(output=str, error=str)
+        match = re.search(r"MPICH Version:\s+(\S+)", output)
+        return match.group(1) if match else None
 
     variant("debug", default=False, description="Compile MPICH with debug flags.")
 


### PR DESCRIPTION
This change makes `spack external find --not-buildable` mark virtuals
provided by detected packages as non-buildable, so that it's sufficient
for users to let spack detect say mpich and have the concretizer pick it
up as mpi provider even when openmpi is "more preferred".

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
