### PR TITLE
cuda: set `CMAKE_PREFIX_PATH` for CCCL

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -691,6 +691,11 @@ class Cuda(Package):
         env.set("CUDA_HOME", self.prefix)
         env.set("NVHPC_CUDA_HOME", self.prefix)
 
+        # Ensure that libraries such as CCCL (e.g. Thrust, CUB, and libcudacxx)
+        # are available via CMake when the CUDA spec is loaded.
+        for prefix in self.cmake_prefix_paths:
+            env.prepend_path("CMAKE_PREFIX_PATH", prefix)
+
     def install(self, spec, prefix):
         if os.path.exists("/tmp/cuda-installer.log"):
             try:


### PR DESCRIPTION
The newer CUDA toolkits come with CCCL included, i.e. a bundling of Thrust, CUB, and libcudacxx. When the CUDA spec is active, however, the relevant prefix is not added to the `CMAKE_PREFIX_PATH` environment variable, which makes it difficult to use these libraries. This commit ensures that the CUDA spec adds the CCCL prefix to the environment in a way that allows CMake to find these packages.