### PR TITLE
Bug fix for mapl: configure mvapich2

### DIFF
--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -349,6 +349,8 @@ class Mapl(CMakePackage):
 
         if self.spec.satisfies("^mpich"):
             args.append(self.define("MPI_STACK", "mpich"))
+        elif self.spec.satisfies("^mvapich2"):
+            args.append(self.define("MPI_STACK", "mpich"))
         elif self.spec.satisfies("^openmpi"):
             args.append(self.define("MPI_STACK", "openmpi"))
         elif self.spec.satisfies("^intel-oneapi-mpi"):

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -350,7 +350,7 @@ class Mapl(CMakePackage):
         if self.spec.satisfies("^mpich"):
             args.append(self.define("MPI_STACK", "mpich"))
         elif self.spec.satisfies("^mvapich2"):
-            args.append(self.define("MPI_STACK", "mpich"))
+            args.append(self.define("MPI_STACK", "mvapich"))
         elif self.spec.satisfies("^openmpi"):
             args.append(self.define("MPI_STACK", "openmpi"))
         elif self.spec.satisfies("^intel-oneapi-mpi"):


### PR DESCRIPTION
## Description

For some reason `mapl` needs to configure the `MPI` provider itself, and `mvapich2` (which is basically `mpich`) is missing.

I tested installing this on MSU Hercules with `gcc@12.2.0` and `mvapich2@2.3.7`.