### PR TITLE
cmd/dependents.py: remove unused loop over all packages

### DIFF
--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -47,16 +47,6 @@ def inverted_dependencies():
     dependents of, e.g., `mpi`, but virtuals are not included as
     actual dependents.
     """
-    dag = {}
-    for pkg_cls in spack.repo.PATH.all_package_classes():
-        dag.setdefault(pkg_cls.name, set())
-        for dep in pkg_cls.dependencies_by_name():
-            deps = [dep]
-
-            # expand virtuals if necessary
-            if spack.repo.PATH.is_virtual(dep):
-                deps += [s.name for s in spack.repo.PATH.providers_for(dep)]
-
     dag = collections.defaultdict(set)
     for pkg_cls in spack.repo.PATH.all_package_classes():
         for _, deps_by_name in pkg_cls.dependencies.items():


### PR DESCRIPTION
`spack dependents` loops over `spack.repo.PATH.all_package_classes()` twice. The first time fills `dag` but the second time just overwrites it all again.

Before:
```
===> multitime results
1: spack dependents cmake
            Mean        Std.Dev.    Min         Median      Max
real        35.594      0.000       35.594      35.594      35.594      
user        34.917      0.000       34.917      34.917      34.917      
sys         0.667       0.000       0.667       0.667       0.667       
```

After:
```
===> multitime results
1: spack dependents cmake
            Mean        Std.Dev.    Min         Median      Max
real        31.191      0.000       31.191      31.191      31.191      
user        30.533      0.000       30.533      30.533      30.533      
sys         0.652       0.000       0.652       0.652       0.652       
```

Edit: Since https://github.com/spack/spack/pull/40326.