### PR TITLE
gcc: consider link when detecting compilers

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -561,9 +561,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
             ]
             if any(x in basename for x in substring_to_be_filtered):
                 continue
-            # Filter out links in favor of real executables
-            if os.path.islink(exe):
-                continue
 
             result.append(exe)
 


### PR DESCRIPTION
Address an issue in #44419 

**Before the PR**
```yaml
packages:
  gcc:
    externals:
    - spec: gcc@9.4.0 languages='c,c++,fortran'
      prefix: /usr
      extra_attributes:
        compilers:
          c: /usr/bin/x86_64-linux-gnu-gcc-9
          cxx: /usr/bin/x86_64-linux-gnu-g++-9
          fortran: /usr/bin/x86_64-linux-gnu-gfortran-9
```

**After the PR**
```yaml
packages:
  gcc:
    externals:
    - spec: gcc@9.4.0 languages='c,c++,fortran'
      prefix: /usr
      extra_attributes:
        compilers:
          c: /usr/bin/gcc
          cxx: /usr/bin/g++
          fortran: /usr/bin/gfortran
```