### PR TITLE
parallel-netcdf: new test API

### DIFF
--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -97,10 +97,8 @@ class ParallelNetcdf(AutotoolsPackage):
         if libs:
             return libs
 
-        msg = "Unable to recursively locate {0} {1} libraries in {2}"
-        raise spack.error.NoLibrariesError(
-            msg.format("shared" if shared else "static", self.spec.name, self.spec.prefix)
-        )
+        msg = f"Unable to recursively locate {'shared' if shared else 'static'} {self.spec.name} libraries in {self.spec.prefix}"
+        raise spack.error.NoLibrariesError(msg)
 
     @when("@master")
     def autoreconf(self, spec, prefix):
@@ -130,7 +128,7 @@ class ParallelNetcdf(AutotoolsPackage):
 
         for key, value in sorted(flags.items()):
             if value:
-                args.append("{0}={1}".format(key, " ".join(value)))
+                args.append(f"{key}={' '.join(value)}")
 
         if self.version >= Version("1.8"):
             args.append("--enable-relax-coord-bound")
@@ -163,16 +161,16 @@ class ParallelNetcdf(AutotoolsPackage):
         # examples should work as well.
         test_exe = "column_wise"
         options = [
-            "{0}.cpp".format(test_exe),
+            f"{test_exe}.cpp",
             "-o",
             test_exe,
             "-lpnetcdf",
-            "-L{0}".format(self.prefix.lib),
-            "-I{0}".format(self.prefix.include),
+            f"-L{self.prefix.lib}",
+            f"-I{self.prefix.include}",
         ]
 
         with test_part(
-            self, f"test_pnetcdf_comp_link", purpose="compiling and linking pnetcdf example"
+            self, "test_pnetcdf_comp_link", purpose="compiling and linking pnetcdf example"
         ):
             with working_dir(test_dir):
                 exe = which(self.spec["mpi"].prefix.bin.mpicxx)
@@ -197,4 +195,4 @@ class ParallelNetcdf(AutotoolsPackage):
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
         with working_dir(test_dir):
             exe = which("rm")
-            exe("-f", "column_wise")
+            exe("-f", "cmlumn_wise")

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -152,7 +152,7 @@ class ParallelNetcdf(AutotoolsPackage):
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources([self.examples_src_dir])
+        cache_extra_test_sources(self)
 
     def test_pnetcdf(self):
         """Test pnetcdf"""

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -97,7 +97,8 @@ class ParallelNetcdf(AutotoolsPackage):
         if libs:
             return libs
 
-        msg = f"Unable to recursively locate {'shared' if shared else 'static'} {self.spec.name} libraries in {self.spec.prefix}"
+        msg = f"Unable to recursively locate {'shared' if shared else 'static'} \
+{self.spec.name} libraries in {self.spec.prefix}"
         raise spack.error.NoLibrariesError(msg)
 
     @when("@master")

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -154,8 +154,8 @@ class ParallelNetcdf(AutotoolsPackage):
         install test subdirectory for use during `spack test run`."""
         cache_extra_test_sources(self)
 
-    def test_pnetcdf(self):
-        """Test pnetcdf"""
+    def test_column_wise(self):
+        """Test column_wise executable"""
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
         # pnetcdf has many examples to serve as a suitable smoke check.
         # column_wise was chosen based on the E4S test suite. Other

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -27,11 +27,11 @@ class ParallelNetcdf(AutotoolsPackage):
 
     def url_for_version(self, version):
         if version >= Version("1.11.0"):
-            url = "https://parallel-netcdf.github.io/Release/pnetcdf-{0}.tar.gz"
+            url = f"https://parallel-netcdf.github.io/Release/pnetcdf-{version.dotted}.tar.gz"
         else:
-            url = "https://parallel-netcdf.github.io/Release/parallel-netcdf-{0}.tar.gz"
+            url = f"https://parallel-netcdf.github.io/Release/parallel-netcdf-{version.dotted}.tar.gz"
 
-        return url.format(version.dotted)
+        return url
 
     version("master", branch="master")
     version("1.12.3", sha256="439e359d09bb93d0e58a6e3f928f39c2eae965b6c97f64e67cd42220d6034f77")

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -170,26 +170,28 @@ class ParallelNetcdf(AutotoolsPackage):
             f"-I{self.prefix.include}",
         ]
 
-        with test_part(
-            self, "test_pnetcdf_comp_link", purpose="compiling and linking pnetcdf example"
-        ):
-            with working_dir(test_dir):
+        with working_dir(test_dir):
+
+            with test_part(
+                self, "test_column_wise_comp_link", purpose="compiling and linking pnetcdf example"
+            ):
                 exe = which(self.spec["mpi"].prefix.bin.mpicxx)
                 exe(*options)
 
-        mpiexe_list = [
-            self.spec["mpi"].prefix.bin.srun,
-            self.spec["mpi"].prefix.bin.mpirun,
-            self.spec["mpi"].prefix.bin.mpiexec,
-        ]
+            mpiexe_list = [
+                self.spec["mpi"].prefix.bin.srun,
+                self.spec["mpi"].prefix.bin.mpirun,
+                self.spec["mpi"].prefix.bin.mpiexec,
+            ]
 
-        for mpiexe in mpiexe_list:
-            if os.path.isfile(mpiexe):
-                with test_part(self, f"test_pnetcdf_{mpiexe}", purpose="pnetcdf smoke test"):
-                    with working_dir(test_dir):
+            for mpiexe in mpiexe_list:
+                if os.path.isfile(mpiexe):
+                    with test_part(self, "test_column_wise_mpiexe", purpose="pnetcdf smoke test"):
                         exe = which(mpiexe)
+                        if exe is None:
+                            raise SkipTest(f"{mpiexe} is not installed for {self.version}")
                         exe("-n", "1", test_exe)
-                break
+                    break
 
     def test_rm(self):
         """Test rm"""

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -187,8 +187,9 @@ class ParallelNetcdf(AutotoolsPackage):
             for mpiexe in mpiexe_list:
                 tty.info(f"Attempting to build and launch with {os.path.basename(mpiexe)}")
                 try:
+                    args = ["--immediate=30"] if exe == "srun" else []
                     exe = which(mpiexe)
-                    exe("-n", "1", test_exe)
+                    exe("-n", "1", test_exe, args)
                     rm = which("rm")
                     rm("-f", "column_wise")
                     return
@@ -196,4 +197,4 @@ class ParallelNetcdf(AutotoolsPackage):
                 except (Exception, ProcessError) as err:
                     tty.info(f"Skipping {mpiexe}: {str(err)}")
 
-            assert False, "No MPI executable was found"
+        assert False, "No MPI executable was found"

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -5,9 +5,7 @@
 
 
 import llnl.util.tty as tty
-
 import os
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 
 import llnl.util.tty as tty
-import os
+
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -157,7 +157,7 @@ class ParallelNetcdf(AutotoolsPackage):
         cache_extra_test_sources(self, [self.examples_src_dir])
 
     def test_column_wise(self):
-        """Test column_wise executable"""
+        """build and run column_wise"""
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
         # pnetcdf has many examples to serve as a suitable smoke check.
         # column_wise was chosen based on the E4S test suite. Other
@@ -173,9 +173,8 @@ class ParallelNetcdf(AutotoolsPackage):
         ]
 
         with working_dir(test_dir):
-
-            exe = which(self.spec["mpi"].prefix.bin.mpicxx)
-            exe(*options)
+            mpicxx = which(self.spec["mpi"].prefix.bin.mpicxx)
+            mpicxx(*options)
 
             mpiexe_list = [
                 "srun",
@@ -186,9 +185,10 @@ class ParallelNetcdf(AutotoolsPackage):
             for mpiexe in mpiexe_list:
                 tty.info(f"Attempting to build and launch with {os.path.basename(mpiexe)}")
                 try:
-                    args = ["--immediate=30"] if exe == "srun" else []
+                    args = ["--immediate=30"] if mpiexe == "srun" else []
+                    args += ["-n", "1", test_exe]
                     exe = which(mpiexe)
-                    exe("-n", "1", test_exe, args)
+                    exe(*args)
                     rm = which("rm")
                     rm("-f", "column_wise")
                     return

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -174,7 +174,7 @@ class ParallelNetcdf(AutotoolsPackage):
             exe(*options)
 
             mpiexe_list = [
-                self.spec["mpi"].prefix.bin.srun,
+                "srun",
                 self.spec["mpi"].prefix.bin.mpirun,
                 self.spec["mpi"].prefix.bin.mpiexec,
             ]

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -3,6 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+
+import llnl.util.tty as tty
+
+import os
+
 from spack.package import *
 
 
@@ -180,6 +185,7 @@ class ParallelNetcdf(AutotoolsPackage):
             ]
 
             for mpiexe in mpiexe_list:
+                tty.info(f"Attempting to build and launch with {os.path.basename(mpiexe)}")
                 try:
                     exe = which(mpiexe)
                     exe("-n", "1", test_exe)
@@ -189,3 +195,5 @@ class ParallelNetcdf(AutotoolsPackage):
 
                 except (Exception, ProcessError) as err:
                     tty.info(f"Skipping {mpiexe}: {str(err)}")
+
+            assert False, "No MPI executable was found"

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -152,7 +152,7 @@ class ParallelNetcdf(AutotoolsPackage):
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        cache_extra_test_sources(self)
+        cache_extra_test_sources(self, [self.examples_src_dir])
 
     def test_column_wise(self):
         """Test column_wise executable"""


### PR DESCRIPTION
Supersedes #35807 (one package)

Update standalone testing API. 

Latest test output:

```
$ spack find -v parallel-netcdf
..
parallel-netcdf@1.12.3~burstbuffer+cxx+fortran+pic+shared build_system=autotools
==> 1 installed package


$ spack -v test run parallel-netcdf
==> Spack test au2nkt3vxn2htbg7h27vcsq4ohbzusoe
==> Testing package parallel-netcdf-1.12.3-55jhqib
..
==> [2024-08-15-17:29:52.574350] test: test_column_wise: build and run column_wise
..
==> [2024-08-15-17:29:53.919856] Attempting to build and launch with srun
==> [2024-08-15-17:29:53.921729] '/usr/bin/srun' '--immediate=30' '-n' '1' 'column_wise'
--------------------------------------------------------------------------
WARNING: Open MPI failed to open the /dev/knem device due to a local
error. Please check with your system administrator to get the problem
fixed, or set the smsc MCA variable to "^knem" to silence this warning
and run without knem support.

Open MPI will try to fall back on another single-copy mechanism if one
is available.  This may result in lower performance.

..
--------------------------------------------------------------------------
 0: myOff=  0 myNX=  4
 0: start=  0   0 count= 10   1
==> [2024-08-15-17:30:02.026480] '/usr/bin/rm' '-f' 'column_wise'
PASSED: ParallelNetcdf::test_column_wise
==> [2024-08-15-17:30:02.031999] Completed testing
==> [2024-08-15-17:30:02.032088] 
=================== SUMMARY: parallel-netcdf-1.12.3-55jhqib ====================
ParallelNetcdf::test_column_wise .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
```