### PR TITLE
llvm: detect executables with consistent naming

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/llvm/detection_test.yaml
@@ -53,7 +53,6 @@ paths:
       compilers:
         c: ".*/bin/clang-8$"
         cxx: ".*/bin/clang[+][+]-8$"
-        ld: ".*/bin/ld.lld-8$"
 
   - spec: 'llvm@3.9.1+clang~lld~lldb'
     extra_attributes:

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -669,21 +669,19 @@ class Llvm(CMakePackage, CudaPackage, CompilerPackage):
         # because LLVM has kindly named compilers
         variants, compilers = ["+clang"], {}
         lld_found, lldb_found = False, False
-        for exe in exes:
+        for exe in sorted(exes):
             name = os.path.basename(exe)
             if "clang++" in name:
-                compilers["cxx"] = exe
+                compilers.setdefault("cxx", exe)
             elif "clang" in name:
-                compilers["c"] = exe
+                compilers.setdefault("c", exe)
             elif "flang" in name:
                 variants.append("+flang")
-                compilers["fortran"] = exe
+                compilers.setdefault("fortran", exe)
             elif "ld.lld" in name:
                 lld_found = True
-                compilers["ld"] = exe
             elif "lldb" in name:
                 lldb_found = True
-                compilers["lldb"] = exe
 
         variants.append("+lld" if lld_found else "~lld")
         variants.append("+lldb" if lldb_found else "~lldb")

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -669,7 +669,7 @@ class Llvm(CMakePackage, CudaPackage, CompilerPackage):
         # because LLVM has kindly named compilers
         variants, compilers = ["+clang"], {}
         lld_found, lldb_found = False, False
-        for exe in sorted(exes):
+        for exe in sorted(exes, key=len):
             name = os.path.basename(exe)
             if "clang++" in name:
                 compilers.setdefault("cxx", exe)


### PR DESCRIPTION
Address an issue in #44419 

**Before the PR**
```yaml
packages:
  llvm:
    externals:
    - spec: llvm@10.0.0+clang+lld+lldb
      prefix: /usr
      extra_attributes:
        compilers:
          c: /usr/bin/clang-10
          cxx: /usr/bin/clang++
          ld: /usr/bin/ld.lld-10
          lldb: /usr/bin/lldb
    - spec: llvm@12.0.0+clang+lld~lldb
      prefix: /usr
      extra_attributes:
        compilers:
          c: /usr/bin/clang-12
          cxx: /usr/bin/clang++-12
          ld: /usr/bin/ld.lld-12
```

**After the PR**
```yaml
packages:
  llvm:
    externals:
    - spec: llvm@10.0.0+clang+lld+lldb
      prefix: /usr
      extra_attributes:
        compilers:
          c: /usr/bin/clang
          cxx: /usr/bin/clang++
    - spec: llvm@12.0.0+clang+lld~lldb
      prefix: /usr
      extra_attributes:
        compilers:
          c: /usr/bin/clang-12
          cxx: /usr/bin/clang++-12
```

