### PR TITLE
py-torch-nvidia-apex: add v22.03 -> v24.04.01

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch-nvidia-apex/package.py
+++ b/var/spack/repos/builtin/packages/py-torch-nvidia-apex/package.py
@@ -17,6 +17,12 @@ class PyTorchNvidiaApex(PythonPackage, CudaPackage):
     license("BSD-3-Clause")
 
     version("master", branch="master")
+    version("24.04.01", tag="24.04.01")
+    version("23.08", tag="23.08")
+    version("23.07", tag="23.07")
+    version("23.06", tag="23.06")
+    version("23.05", tag="23.05")
+    version("22.03", tag="22.03")
     version("2020-10-19", commit="8a1ed9e8d35dfad26fb973996319965e4224dcdd")
 
     depends_on("python@3:", type=("build", "run"))


### PR DESCRIPTION
See #45019 (which conflicts with this PR) as well.