### PR TITLE
cmd/dependents.py: accept deptype

### DIFF
--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -36,6 +36,7 @@ def setup_parser(subparser):
         default=False,
         help="show all transitive dependents",
     )
+    arguments.add_common_arguments(subparser, ["deptype"])
     arguments.add_common_arguments(subparser, ["spec"])
 
 
@@ -107,7 +108,9 @@ def dependents(parser, args):
         format_string = "{name}{@version}{%compiler}{/hash:7}"
         if sys.stdout.isatty():
             tty.msg("Dependents of %s" % spec.cformat(format_string))
-        deps = spack.store.STORE.db.installed_relatives(spec, "parents", args.transitive)
+        deps = spack.store.STORE.db.installed_relatives(
+            spec, "parents", args.transitive, deptype=args.deptype
+        )
         if deps:
             spack.cmd.display_specs(deps, long=True)
         else:


### PR DESCRIPTION
`spack dependencies` has two more options than `spack dependents`:
```
  --deptype DEPTYPE     comma-separated list of deptypes to traverse (default=build,link,run,test)
  -V, --no-expand-virtuals
                        do not expand virtual dependencies
```

This PR aims to add `--deptype` support to `spack dependents`. This would allow to find e.g. misconfigurations with `spack dependents --deptype link cmake`, where packages likely only need `cmake` as a build dependency.

Implementation:
1. installed packages: trivial addition in `installed_relatives` call
2. all packages: requires creation of an inverted tree in `inverted_dependencies` limited by requested `deptype`