### PR TITLE
Changes to DLIOProfiler and DFTracer Package

### DIFF
--- a/var/spack/repos/builtin/packages/py-dlio-profiler-py/package.py
+++ b/var/spack/repos/builtin/packages/py-dlio-profiler-py/package.py
@@ -16,12 +16,6 @@ class PyDlioProfilerPy(PythonPackage):
     license("MIT")
 
     version(
-        "0.0.7", tag="v0.0.7", commit="e47ec476b58e14157b807cbadb4187bd4fe811d9", deprecated=True
-    )
-    version(
-        "0.0.6", tag="v0.0.6", commit="3be111c973883387418ad96f63a18de63555c540", deprecated=True
-    )
-    version(
         "0.0.5", tag="v0.0.5", commit="08f1a43c67c8dbb458d547020674c86118c9742e", deprecated=True
     )
     version(

--- a/var/spack/repos/builtin/packages/py-dlio-profiler-py/package.py
+++ b/var/spack/repos/builtin/packages/py-dlio-profiler-py/package.py
@@ -16,6 +16,12 @@ class PyDlioProfilerPy(PythonPackage):
     license("MIT")
 
     version(
+        "0.0.7", tag="v0.0.7", commit="e47ec476b58e14157b807cbadb4187bd4fe811d9", deprecated=True
+    )
+    version(
+        "0.0.6", tag="v0.0.6", commit="3be111c973883387418ad96f63a18de63555c540", deprecated=True
+    )
+    version(
         "0.0.5", tag="v0.0.5", commit="08f1a43c67c8dbb458d547020674c86118c9742e", deprecated=True
     )
     version(

--- a/var/spack/repos/builtin/packages/py-dlio-profiler-py/package.py
+++ b/var/spack/repos/builtin/packages/py-dlio-profiler-py/package.py
@@ -15,8 +15,8 @@ class PyDlioProfilerPy(PythonPackage):
 
     license("MIT")
 
-    version("develop", branch="dev")
-    version("master", branch="master")
+    version("0.0.7", tag="v0.0.7", commit="e47ec476b58e14157b807cbadb4187bd4fe811d9")
+    version("0.0.6", tag="v0.0.6", commit="3be111c973883387418ad96f63a18de63555c540")
     version("0.0.5", tag="v0.0.5", commit="08f1a43c67c8dbb458d547020674c86118c9742e")
     version("0.0.4", tag="v0.0.4", commit="f9ba207f4c3e3789eb7759653a94013e6b76c91c")
     version("0.0.3", tag="v0.0.3", commit="531f4475cf03312e121c78bf644445882b51ad57")
@@ -25,10 +25,12 @@ class PyDlioProfilerPy(PythonPackage):
 
     depends_on("cpp-logger@0.0.1", when="@:0.0.1")
     depends_on("cpp-logger@0.0.2", when="@0.0.2")
-    depends_on("cpp-logger@0.0.3", when="@0.0.3:")
+    depends_on("cpp-logger@0.0.3", when="@0.0.3:0.0.5")
+    depends_on("cpp-logger@0.0.4", when="@0.0.6:")
     depends_on("brahma@0.0.1", when="@:0.0.1")
     depends_on("brahma@0.0.2", when="@0.0.2")
-    depends_on("brahma@0.0.3", when="@0.0.3:")
+    depends_on("brahma@0.0.3", when="@0.0.3:0.0.5")
+    depends_on("brahma@0.0.5", when="@0.0.6:")
     depends_on("yaml-cpp@0.6.3", when="@0.0.2:")
     depends_on("py-setuptools@42:", type="build")
     depends_on("py-pybind11", type=("build", "run"))
@@ -36,6 +38,10 @@ class PyDlioProfilerPy(PythonPackage):
     depends_on("cmake@3.12:", type="build")
 
     def setup_build_environment(self, env):
-        env.set("DLIO_PROFILER_DIR", self.prefix)
-        env.set("DLIO_PYTHON_SITE", python_purelib)
+        if self.spec.satisfies("@0.0.6:"):
+            env.set("DLIO_PROFILER_INSTALL_DIR", self.prefix)
+            env.set("DLIO_PROFILER_PYTHON_SITE", python_purelib)
+        else:
+            env.set("DLIO_PROFILER_DIR", self.prefix)
+            env.set("DLIO_PYTHON_SITE", python_purelib)
         env.set("DLIO_BUILD_DEPENDENCIES", "0")

--- a/var/spack/repos/builtin/packages/py-dlio-profiler-py/package.py
+++ b/var/spack/repos/builtin/packages/py-dlio-profiler-py/package.py
@@ -15,13 +15,27 @@ class PyDlioProfilerPy(PythonPackage):
 
     license("MIT")
 
-    version("0.0.7", tag="v0.0.7", commit="e47ec476b58e14157b807cbadb4187bd4fe811d9")
-    version("0.0.6", tag="v0.0.6", commit="3be111c973883387418ad96f63a18de63555c540")
-    version("0.0.5", tag="v0.0.5", commit="08f1a43c67c8dbb458d547020674c86118c9742e")
-    version("0.0.4", tag="v0.0.4", commit="f9ba207f4c3e3789eb7759653a94013e6b76c91c")
-    version("0.0.3", tag="v0.0.3", commit="531f4475cf03312e121c78bf644445882b51ad57")
-    version("0.0.2", tag="v0.0.2", commit="b72144abf1499e03d1db87ef51e780633e9e9533")
-    version("0.0.1", tag="v0.0.1", commit="28affe716211315dd6936ddc8e25ce6c43cdf491")
+    version(
+        "0.0.7", tag="v0.0.7", commit="e47ec476b58e14157b807cbadb4187bd4fe811d9", deprecated=True
+    )
+    version(
+        "0.0.6", tag="v0.0.6", commit="3be111c973883387418ad96f63a18de63555c540", deprecated=True
+    )
+    version(
+        "0.0.5", tag="v0.0.5", commit="08f1a43c67c8dbb458d547020674c86118c9742e", deprecated=True
+    )
+    version(
+        "0.0.4", tag="v0.0.4", commit="f9ba207f4c3e3789eb7759653a94013e6b76c91c", deprecated=True
+    )
+    version(
+        "0.0.3", tag="v0.0.3", commit="531f4475cf03312e121c78bf644445882b51ad57", deprecated=True
+    )
+    version(
+        "0.0.2", tag="v0.0.2", commit="b72144abf1499e03d1db87ef51e780633e9e9533", deprecated=True
+    )
+    version(
+        "0.0.1", tag="v0.0.1", commit="28affe716211315dd6936ddc8e25ce6c43cdf491", deprecated=True
+    )
 
     depends_on("cpp-logger@0.0.1", when="@:0.0.1")
     depends_on("cpp-logger@0.0.2", when="@0.0.2")

--- a/var/spack/repos/builtin/packages/py-pydftracer/package.py
+++ b/var/spack/repos/builtin/packages/py-pydftracer/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPyDFTracer(PythonPackage):
+    """A low-level profiler for capture I/O calls from deep learning applications."""
+
+    homepage = "https://github.com/hariharan-devarajan/dlio-profiler.git"
+    git = "https://github.com/hariharan-devarajan/dlio-profiler.git"
+    maintainers("hariharan-devarajan")
+
+    license("MIT")
+
+    version("develop", branch="develop")
+    version("master", branch="master")
+    version("1.0.2", tag="v1.0.2", commit="8a15f09ff54a909605eda0070689c0b99401db20")
+    version("1.0.1", tag="v1.0.1", commit="dc1ce44042e669e6da495f906ca5f8b155c9f155")
+    version("1.0.0", tag="v1.0.0", commit="b6df57d81ffb043b468e2bd3e8df9959fdb4af53")
+
+    depends_on("cpp-logger@0.0.4", when="@1.0.0:")
+    depends_on("brahma@0.0.5", when="@1.0.0:")
+    depends_on("yaml-cpp@0.6.3", when="@1.0.0:")
+    depends_on("py-setuptools@42:", type="build")
+    depends_on("py-pybind11", type=("build", "run"))
+    depends_on("ninja", type="build")
+    depends_on("cmake@3.12:", type="build")
+
+    def setup_build_environment(self, env):
+        env.set("DFTRACER_INSTALL_DIR", self.prefix)
+        env.set("DFTRACER_PYTHON_SITE", python_purelib)
+        env.set("DFTRACER_BUILD_DEPENDENCIES", "0")

--- a/var/spack/repos/builtin/packages/py-pydftracer/package.py
+++ b/var/spack/repos/builtin/packages/py-pydftracer/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class PyPyDFTracer(PythonPackage):
+class PyPydftracer(PythonPackage):
     """A low-level profiler for capture I/O calls from deep learning applications."""
 
     homepage = "https://github.com/hariharan-devarajan/dlio-profiler.git"

--- a/var/spack/repos/builtin/packages/py-pydftracer/package.py
+++ b/var/spack/repos/builtin/packages/py-pydftracer/package.py
@@ -17,6 +17,7 @@ class PyPydftracer(PythonPackage):
 
     version("develop", branch="develop")
     version("master", branch="master")
+    version("1.0.3", tag="v1.0.3", commit="856de0b958a22081d80a9a25bea3f74e2759d9ee")
     version("1.0.2", tag="v1.0.2", commit="8a15f09ff54a909605eda0070689c0b99401db20")
     version("1.0.1", tag="v1.0.1", commit="dc1ce44042e669e6da495f906ca5f8b155c9f155")
     version("1.0.0", tag="v1.0.0", commit="b6df57d81ffb043b468e2bd3e8df9959fdb4af53")


### PR DESCRIPTION
The DLIOProfiler got renamed to DFTracer. Therefore, this commit makes the current dlio-profiler package to the latest stable version 0.0.7 and remove the develop and master as they point to dftracer.

For DFTracer, the version starts from 1.0.0.