### PR TITLE
pumi: new test API

### DIFF
--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -131,7 +131,7 @@ class Pumi(CMakePackage):
 
     def test_refine(self):
         """Testing pumi uniform mesh refinement"""
-        if self.spec.satisfies("@2.2.6"):
+        if self.spec.satisfies("@:2.2.6"):
             raise SkipTest("Package must be installed as version @2.2.7 or later")
 
         options = [

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -111,25 +111,37 @@ class Pumi(CMakePackage):
                 args.append("-DSIM_DISCRETE=ON")
         return args
 
-    def test(self):
-        if self.spec.version <= Version("2.2.6"):
-            return
-        exe = "uniform"
-        options = ["../testdata/pipe.dmg", "../testdata/pipe.smb", "pipe_unif.smb"]
-        expected = "mesh pipe_unif.smb written"
-        description = "testing pumi uniform mesh refinement"
-        self.run_test(exe, options, expected, purpose=description, work_dir=self.prefix.bin)
+    def test_partition(self):
+        """Testing pumi mesh partitioning"""
+        if self.spec.satisfies("@2.2.6"):
+            raise SkipTest("Package must be installed as version @2.2.7 or later")
 
-        mpiexec = Executable(join_path(self.spec["mpi"].prefix.bin, "mpiexec")).command
-        mpiopt = ["-n", "2"]
-        exe = ["split"]
-        options = ["../testdata/pipe.dmg", "../testdata/pipe.smb", "pipe_2_.smb", "2"]
-        expected = "mesh pipe_2_.smb written"
-        description = "testing pumi mesh partitioning"
-        self.run_test(
-            mpiexec,
-            mpiopt + exe + options,
-            expected,
-            purpose=description,
-            work_dir=self.prefix.bin,
-        )
+        options = [
+            "-n",
+            "2",
+            join_path(self.prefix.bin, "split"),
+            join_path(self.prefix.share.testdata, "pipe.dmg"),
+            join_path(self.prefix.share.testdata, "pipe.smb"),
+            "pipe_2_.smb",
+            "2",
+        ]
+        print(f"{options}")
+        exe = which(self.spec["mpi"].prefix.bin.mpiexec)
+        print(f"{exe}")
+        out = exe(*options, output=str.split, error=str.split)
+        print(f"{out}")
+        assert "mesh pipe_2_.smb written" in out
+
+    def test_refine(self):
+        """Testing pumi uniform mesh refinement"""
+        if self.spec.satisfies("@2.2.6"):
+            raise SkipTest("Package must be installed as version @2.2.7 or later")
+
+        options = [
+            join_path(self.prefix.share.testdata, "pipe.dmg"),
+            join_path(self.prefix.share.testdata, "pipe.smb"),
+            "pipe_unif.smb",
+        ]
+        exe = which(self.prefix.bin.uniform)
+        out = exe(*options, output=str.split, error=str.split)
+        assert "mesh pipe_unif.smb written" in out

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -113,7 +113,7 @@ class Pumi(CMakePackage):
 
     def test_partition(self):
         """Testing pumi mesh partitioning"""
-        if self.spec.satisfies("@2.2.6"):
+        if self.spec.satisfies("@:2.2.6"):
             raise SkipTest("Package must be installed as version @2.2.7 or later")
 
         options = [

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -125,11 +125,8 @@ class Pumi(CMakePackage):
             "pipe_2_.smb",
             "2",
         ]
-        print(f"{options}")
         exe = which(self.spec["mpi"].prefix.bin.mpiexec)
-        print(f"{exe}")
         out = exe(*options, output=str.split, error=str.split)
-        print(f"{out}")
         assert "mesh pipe_2_.smb written" in out
 
     def test_refine(self):


### PR DESCRIPTION
Update standalone test API. See below comment for test results.

Supersedes #35807 (for one package)

https://spack.readthedocs.io/en/latest/packaging_guide.html#stand-alone-testsUpdate standalone test API. See below comment for test results.