### PR TITLE
py-amrex: old to new test API

### DIFF
--- a/var/spack/repos/builtin/packages/py-amrex/package.py
+++ b/var/spack/repos/builtin/packages/py-amrex/package.py
@@ -113,7 +113,7 @@ class PyAmrex(PythonPackage, CudaPackage, ROCmPackage):
         install test subdirectory for use during `spack test run`."""
         cache_extra_test_sources(self, [self.tests_src_dir])
 
-    def test(self):
+    def test_pytest(self):
         """Perform smoke tests on the installed package."""
         pytest = which("pytest")
         pytest(join_path(install_test_root(self), self.tests_src_dir))

--- a/var/spack/repos/builtin/packages/py-amrex/package.py
+++ b/var/spack/repos/builtin/packages/py-amrex/package.py
@@ -115,5 +115,9 @@ class PyAmrex(PythonPackage, CudaPackage, ROCmPackage):
 
     def test_pytest(self):
         """Perform smoke tests on the installed package."""
-        pytest = which("pytest")
-        pytest(join_path(install_test_root(self), self.tests_src_dir))
+        test_dir = join_path(self.test_suite.current_test_cache_dir,self.tests_src_dir)
+        with working_dir(test_dir):
+            #pytest = which(join_path(self.prefix.bin, "pytest"))
+            pytest = which("pytest")
+            assert pytest is not None, "Pytest is none"
+            pytest(join_path(install_test_root(self), self.tests_src_dir))

--- a/var/spack/repos/builtin/packages/py-amrex/package.py
+++ b/var/spack/repos/builtin/packages/py-amrex/package.py
@@ -115,9 +115,8 @@ class PyAmrex(PythonPackage, CudaPackage, ROCmPackage):
 
     def test_pytest(self):
         """Perform smoke tests on the installed package."""
-        test_dir = join_path(self.test_suite.current_test_cache_dir,self.tests_src_dir)
+        test_dir = join_path(self.test_suite.current_test_cache_dir, self.tests_src_dir)
         with working_dir(test_dir):
-            #pytest = which(join_path(self.prefix.bin, "pytest"))
             pytest = which("pytest")
-            assert pytest is not None, "Pytest is none"
+            assert pytest is not None, "Cannot find pytest"
             pytest(join_path(install_test_root(self), self.tests_src_dir))

--- a/var/spack/repos/builtin/packages/py-amrex/package.py
+++ b/var/spack/repos/builtin/packages/py-amrex/package.py
@@ -118,5 +118,6 @@ class PyAmrex(PythonPackage, CudaPackage, ROCmPackage):
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.tests_src_dir)
         with working_dir(test_dir):
             pytest = which("pytest")
-            assert pytest is not None, "Cannot find pytest"
-            pytest(join_path(install_test_root(self), self.tests_src_dir))
+            # TODO: Remove once test dependencies made available
+            assert pytest is not None, "Make sure a suitable 'pytest' is in your path"
+            pytest()


### PR DESCRIPTION
Update standalone test API.

https://spack.readthedocs.io/en/latest/packaging_guide.html#stand-alone-tests

NOTE: The package has an existing test failure related to the pytests (see #45313 ).

Results:
```
$ spack -v test run py-amrex
==> Spack test 5nrkdwdfyhreoarm3g2ikyhhcfezyrdk
==> Testing package py-amrex-24.04-ys366bp
==> [2024-08-12-16:37:01.963052] '/usr/bin/fi_info' '-l'
...
==> [2024-08-12-16:38:12.548973] test: test_imports: Attempts to import modules of the installed package.
...
==> [2024-08-12-16:38:13.108265] Detected the following modules: ['amrex', 'amrex.space1d', 'amrex.space2d', 'amrex.space3d']
==> [2024-08-12-16:38:13.110567] test: test_imports_amrex: checking import of amrex
..
PASSED: PyAmrex::test_imports_amrex
==> [2024-08-12-16:38:13.768375] test: test_imports_amrex.space1d: checking import of amrex.space1d
..
PASSED: PyAmrex::test_imports_amrex.space1d
==> [2024-08-12-16:38:17.991874] test: test_imports_amrex.space2d: checking import of amrex.space2d
..
PASSED: PyAmrex::test_imports_amrex.space2d
==> [2024-08-12-16:38:19.202168] test: test_imports_amrex.space3d: checking import of amrex.space3d
..
PASSED: PyAmrex::test_imports_amrex.space3d
PASSED: PyAmrex::test_imports
==> [2024-08-12-16:38:21.736778] test: test_pytest: Perform smoke tests on the installed package.
FAILED: PyAmrex::test_pytest: Make sure a suitable 'pytest' is in your path
 ..
==> [2024-08-12-16:38:21.854265] Completed testing
==> [2024-08-12-16:38:21.854406] 
======================= SUMMARY: py-amrex-24.04-ys366bp ========================
PyAmrex::test_imports_amrex .. PASSED
PyAmrex::test_imports_amrex.space1d .. PASSED
PyAmrex::test_imports_amrex.space2d .. PASSED
PyAmrex::test_imports_amrex.space3d .. PASSED
PyAmrex::test_imports .. PASSED
PyAmrex::test_pytest .. FAILED
======================== 5 passed, 1 failed of 6 parts =========================
```