### PR TITLE
checksum: fix circular imports on macOS

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -18,7 +18,6 @@ import llnl.util.lang
 import llnl.util.tty as tty
 from llnl.util.filesystem import path_contains_subdirectory, paths_containing_libs
 
-import spack.compilers
 import spack.error
 import spack.schema.environment
 import spack.spec

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -488,7 +488,7 @@ def supported_compilers_for_host_platform() -> List[str]:
     return supported_compilers_for_platform(host_plat)
 
 
-def supported_compilers_for_platform(platform: spack.platforms.Platform) -> List[str]:
+def supported_compilers_for_platform(platform: "spack.platforms.Platform") -> List[str]:
     """Return a set of compiler class objects supported by Spack
     that are also supported by the provided platform
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -39,7 +39,6 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 
 from llnl.util import filesystem, lang, tty
 
-import spack.compilers
 import spack.paths
 import spack.platforms
 import spack.schema

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -590,7 +590,7 @@ class RepoIndex:
         self,
         package_checker: FastPackageChecker,
         namespace: str,
-        cache: spack.caches.FileCacheType,
+        cache: "spack.caches.FileCacheType",
     ):
         self.checker = package_checker
         self.packages_path = self.checker.packages_path
@@ -683,7 +683,7 @@ class RepoPath:
     def __init__(
         self,
         *repos: Union[str, "Repo"],
-        cache: spack.caches.FileCacheType,
+        cache: "spack.caches.FileCacheType",
         overrides: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.repos: List[Repo] = []
@@ -950,7 +950,7 @@ class Repo:
         self,
         root: str,
         *,
-        cache: spack.caches.FileCacheType,
+        cache: "spack.caches.FileCacheType",
         overrides: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Instantiate a package repository from a filesystem path.


### PR DESCRIPTION
fixes #45156

```console
% spack debug report
* **Spack:** 0.23.0.dev0 (60e75c92348749bedfcfc64b88d11ebd61c1a7c5)
* **Python:** 3.9.6
* **Platform:** darwin-ventura-m1
* **Concretizer:** clingo

% spack checksum zlib 1.3.1
==> Found 1 version of zlib
==> Fetching http://zlib.net/fossils/zlib-1.3.1.tar.gz

    version("1.3.1", sha256="9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23")

```
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
