### PR TITLE
py-transformer-engine: add v1.7

### DIFF
--- a/var/spack/repos/builtin/packages/py-transformer-engine/package.py
+++ b/var/spack/repos/builtin/packages/py-transformer-engine/package.py
@@ -19,24 +19,33 @@ class PyTransformerEngine(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.7", tag="v1.7", submodules=True)
     version("1.4", tag="v1.4", submodules=True)
     version("main", branch="main", submodules=True)
 
     variant("userbuffers", default=True, description="Enable userbuffers, this option needs MPI.")
 
-    depends_on("py-setuptools", type="build")
-    depends_on("cmake@3.18:")
-    depends_on("py-pydantic")
-    depends_on("py-importlib-metadata")
+    with default_args(type="build"):
+        depends_on("cmake@3.18:")
+        depends_on("py-pydantic")
+        depends_on("py-importlib-metadata")
+        depends_on("py-importlib-metadata@1:", when="@1.7:")
+        depends_on("py-setuptools")
 
     with default_args(type=("build", "run")):
+        depends_on("python@:3.8", when="@1.7:")
         depends_on("py-accelerate")
         depends_on("py-datasets")
         depends_on("py-flash-attn@2.2:2.4.2")
+        depends_on("py-flash-attn@2.0.6:2.5.8", when="@1.7")
         depends_on("py-packaging")
         depends_on("py-torchvision")
         depends_on("py-transformers")
         depends_on("mpi", when="+userbuffers")
+
+    with when("@1.7"):
+        conflicts("^py-flash-attn@2.0.9")
+        conflicts("^py-flash-attn@2.1.0")
 
     with default_args(type=("build", "link", "run")):
         depends_on("py-torch+cuda+cudnn")


### PR DESCRIPTION
Still work in progress as there is still a problem building thrift on aarch64

TODO: the user can now specify the architecture in transformer engine, add this feature from `cuda_archs` (cf https://github.com/NVIDIA/TransformerEngine/pull/1126)