### PR TITLE
Add support for compiling qt@5.15.14 with Intel oneAPI compilers (icx, icpx)

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -253,6 +253,11 @@ class Qt(Package):
     # https://doc.qt.io/qt-5.14/supported-platforms.html
     conflicts("%gcc@:4", when="@5.14:")
 
+    # Compiling with oneAPI compilers icx, icpx requires patching
+    # This has only been tested for 5.15.14 so far
+    conflicts("%oneapi", when="@:5.15.13")
+    patch("qt51514-oneapi.patch", when="@5.15.14: %oneapi")
+
     # Non-macOS dependencies and special macOS constraints
     if MACOS_VERSION is None:
         with when("+gui"):
@@ -282,6 +287,10 @@ class Qt(Package):
     # Mapping for compilers/systems in the QT 'mkspecs'
     compiler_mapping = {
         "intel": ("icc",),
+        # This only works because we apply patch "qt51514-oneapi.patch"
+        # above that replaces calls to "icc" with calls to "icx" in
+        # qtbase/mkspecs/*
+        "oneapi": ("icc",),
         "apple-clang": ("clang-libc++", "clang"),
         "clang": ("clang-libc++", "clang"),
         "aocc": ("clang-libc++", "clang"),

--- a/var/spack/repos/builtin/packages/qt/qt51514-oneapi.patch
+++ b/var/spack/repos/builtin/packages/qt/qt51514-oneapi.patch
@@ -1,0 +1,31 @@
+--- a/qtbase/mkspecs/common/icc-base-unix.conf	2024-05-07 23:17:16.000000000 -0600
++++ b/qtbase/mkspecs/common/icc-base-unix.conf	2024-07-10 21:32:47.808327220 -0600
+@@ -16,7 +16,7 @@
+ QMAKE_CFLAGS_OPTIMIZE      = -O2
+ QMAKE_CFLAGS_OPTIMIZE_SIZE = -Os
+ 
+-QMAKE_CC                = icc
++QMAKE_CC                = icx
+ QMAKE_LEX               = flex
+ QMAKE_LEXFLAGS          =
+ QMAKE_YACC              = yacc
+@@ -61,7 +61,7 @@
+ QMAKE_CFLAGS_SHANI     += -msha
+ QMAKE_CFLAGS_VAES      += -mvaes
+ 
+-QMAKE_CXX               = icpc
++QMAKE_CXX               = icpx
+ QMAKE_CXXFLAGS          = $$QMAKE_CFLAGS
+ QMAKE_CXXFLAGS_APP      = $$QMAKE_CFLAGS_APP
+ QMAKE_CXXFLAGS_DEPS     = $$QMAKE_CFLAGS_DEPS
+@@ -92,8 +92,8 @@
+ QMAKE_CFLAGS_HIDESYMS   += -fvisibility=hidden
+ QMAKE_CXXFLAGS_HIDESYMS += $$QMAKE_CFLAGS_HIDESYMS -fvisibility-inlines-hidden
+ 
+-QMAKE_LINK              = icpc
+-QMAKE_LINK_SHLIB        = icpc
++QMAKE_LINK              = icpx
++QMAKE_LINK_SHLIB        = icpx
+ QMAKE_LFLAGS            =
+ QMAKE_LFLAGS_RELEASE    =
+ QMAKE_LFLAGS_DEBUG      =


### PR DESCRIPTION
## Description

`qt@5` currently doesn't compile with the Intel oneAPI compilers (`icx`, `icpx`) and, looking at the source code in the latest release `5.15.14`, it doesn't even know about them. Assuming that most development efforts go into `qt@6` nowadays, let's try a minimum-effort approach for making the latest release compile with Intel oneAPI.

I tested this code with oneapi@2024.1.2 - I was able to build `qt@5.15.14` and then `ecflow@5.11.4`, and launch the ecflow GUI.

I will note that I am seeing warnings about unsupported compiler options, but these are all flags turning off and on warnings, and they don't hurt:
```
icpx -c -O2 -std=c++1z -fvisibility=hidden -fvisibility-inlines-hidden -fno-exceptions -w1 -Wcheck -wd654,1572,411,873,1125,2259,2261,3280,3373 -D_REENTRANT -D_REENTRANT -D_REENTRANT -fPIC -DQT_NO_LINKED_LIST -DQT_NO_JAVA_STYLE_ITERATORS -DQT_NO_USING_NAMESPACE -DQT_NO_FOREACH -DMD4C_USE_UTF8 -DENABLE_PIXMAN_DRAWHELPERS -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT -DQT_BUILD_GUI_LIB -DQT_BUILDING_QT -DQT_NO_CAST_TO_ASCII -DQT_ASCII_CAST_WARNINGS -DQT_MOC_COMPAT -DQT_USE_QSTRINGBUILDER -DQT_DEPRECATED_WARNINGS -DQT_DISABLE_DEPRECATED_BEFORE=0x050000 -DQT_DEPRECATED_WARNINGS_SINCE=0x060000 -DQT_NO_EXCEPTIONS -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE -DQT_NO_DEBUG -DQT_CORE_LIB -DWITH_GZFILEOP -I. -I../3rdparty/md4c -I../3rdparty/VulkanMemoryAllocator -I../../include -I../../include/QtGui -I../../include/QtGui/5.15.14 -I../../include/QtGui/5.15.14/QtGui -I.tracegen -I../../include/QtCore/5.15.14 -I../../include/QtCore/5.15.14/QtCore -I../../include/QtCore -I.moc -I/home/dom/work/spack-stack/spack-stack-reduce-modulefiles/envs/ue-oneapi-2024.1.2/install/oneapi/2024.1.2/libpng-1.6.37-wx7fdm5/include/libpng16 -I/home/dom/work/spack-stack/spack-stack-reduce-modulefiles/envs/ue-oneapi-2024.1.2/install/oneapi/2024.1.2/zlib-ng-2.1.6-46s7mox/include -I/home/dom/work/spack-stack/spack-stack-reduce-modulefiles/envs/ue-oneapi-2024.1.2/install/oneapi/2024.1.2/freetype-2.13.2-6amavd5/include/freetype2 -I/home/dom/work/spack-stack/spack-stack-reduce-modulefiles/envs/ue-oneapi-2024.1.2/install/oneapi/2024.1.2/openssl-3.3.0-bastlp2/include -I/home/dom/work/spack-stack/spack-stack-reduce-modulefiles/envs/ue-oneapi-2024.1.2/install/oneapi/2024.1.2/sqlite-3.43.2-pmwzzb4/include -I/home/dom/work/spack-stack/spack-stack-reduce-modulefiles/envs/ue-oneapi-2024.1.2/install/oneapi/2024.1.2/pcre2-10.43-usuxvsu/include -I/home/dom/work/spack-stack/spack-stack-reduce-modulefiles/envs/ue-oneapi-2024.1.2/install/oneapi/2024.1.2/harfbuzz-8.4.0-kqyqam5/include -I/home/dom/work/spack-stack/spack-stack-reduce-modulefiles/envs/ue-oneapi-2024.1.2/install/oneapi/2024.1.2/double-conversion-3.3.0-bocdjkw/include -I/home/dom/work/spack-stack/spack-stack-reduce-modulefiles/envs/ue-oneapi-2024.1.2/install/oneapi/2024.1.2/libpng-1.6.37-wx7fdm5/include -I/home/dom/work/spack-stack/spack-stack-reduce-modulefiles/envs/ue-oneapi-2024.1.2/install/oneapi/2024.1.2/libjpeg-turbo-2.1.0-np2d2df/include -I/home/dom/work/spack-stack/spack-stack-reduce-modulefiles/envs/ue-oneapi-2024.1.2/install/oneapi/2024.1.2/zlib-ng-2.1.6-46s7mox/include -I../../mkspecs/linux-icc -o .obj/qplatforminputcontext.o kernel/qplatforminputcontext.cpp
icpx: command line warning #10430: Unsupported command line options encountered
These options as listed are not supported.
For more information, use '-qnextgen-diag'.
option list:
        -w1
        -wd654,1572,411,873,1125,2259,2261,3280,3373
warning: unknown warning option '-Wcheck' [-Wunknown-warning-option]
```