### PR TITLE
Update fckit to build with Intel oneAPI compilers (icx, icpx) and nvhpc compilers

### DIFF
--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -74,7 +74,12 @@ class Fckit(CMakePackage):
             # See comment above (conflicts for finalize_ddts)
             args.append("-DENABLE_FINAL=OFF")
 
-        if self.spec.satisfies("%intel") or self.spec.satisfies("%gcc"):
+        if (
+            self.spec.satisfies("%intel")
+            or self.spec.satisfies("%oneapi")
+            or self.spec.satisfies("%gcc")
+            or self.spec.satisfies("%nvhpc")
+        ):
             cxxlib = "stdc++"
         elif self.spec.satisfies("%clang") or self.spec.satisfies("%apple-clang"):
             cxxlib = "c++"


### PR DESCRIPTION
## Description

All in the title. This is simple and I tested it for both compilers.