### PR TITLE
Add instrumentation=thread_debug

### DIFF
--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -16,7 +16,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
     homepage = "https://hpx.stellar-group.org/"
     url = "https://github.com/STEllAR-GROUP/hpx/archive/v0.0.0.tar.gz"
     git = "https://github.com/STEllAR-GROUP/hpx.git"
-    maintainers("msimberg", "albestro", "teonnik", "hkaiser","diehlpk")
+    maintainers("msimberg", "albestro", "teonnik", "hkaiser", "diehlpk")
 
     license("BSL-1.0")
 
@@ -229,7 +229,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
             args.append(self.define("CMAKE_C_COMPILER", spec["mpi"].mpicc))
             args.append(self.define("CMAKE_CXX_COMPILER", spec["mpi"].mpicxx))
             args.append(self.define("CMAKE_Fortran_COMPILER", spec["mpi"].mpifc))
-        
+
         format_max_cpu_count = lambda max_cpu_count: (
             "" if max_cpu_count == "auto" else max_cpu_count
         )

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -16,7 +16,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
     homepage = "https://hpx.stellar-group.org/"
     url = "https://github.com/STEllAR-GROUP/hpx/archive/v0.0.0.tar.gz"
     git = "https://github.com/STEllAR-GROUP/hpx.git"
-    maintainers("msimberg", "albestro", "teonnik", "hkaiser")
+    maintainers("msimberg", "albestro", "teonnik", "hkaiser","diehlpk")
 
     license("BSL-1.0")
 
@@ -225,6 +225,11 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
     def cmake_args(self):
         spec, args = self.spec, []
 
+        if "networking=mpi" in spec:
+            args.append(self.define("CMAKE_C_COMPILER", spec["mpi"].mpicc))
+            args.append(self.define("CMAKE_CXX_COMPILER", spec["mpi"].mpicxx))
+            args.append(self.define("CMAKE_Fortran_COMPILER", spec["mpi"].mpifc))
+        
         format_max_cpu_count = lambda max_cpu_count: (
             "" if max_cpu_count == "auto" else max_cpu_count
         )

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -66,7 +66,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
         values=lambda x: isinstance(x, str) and (x.isdigit() or x == "auto"),
     )
 
-    instrumentation_values = ("apex", "google_perftools", "papi", "valgrind")
+    instrumentation_values = ("apex", "google_perftools", "papi", "valgrind","thread_debug")
     variant(
         "instrumentation",
         values=any_combination_of(*instrumentation_values),
@@ -225,11 +225,6 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
     def cmake_args(self):
         spec, args = self.spec, []
 
-        if "networking=mpi" in spec:
-            args.append(self.define("CMAKE_C_COMPILER", spec["mpi"].mpicc))
-            args.append(self.define("CMAKE_CXX_COMPILER", spec["mpi"].mpicxx))
-            args.append(self.define("CMAKE_Fortran_COMPILER", spec["mpi"].mpifc))
-
         format_max_cpu_count = lambda max_cpu_count: (
             "" if max_cpu_count == "auto" else max_cpu_count
         )
@@ -271,6 +266,12 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
         # Instrumentation
         args += self.instrumentation_args()
 
+        if "instrumentation=thread_debug" in spec:
+            args += [
+                self.define("HPX_WITH_THREAD+DEBUG_INFO",True),
+                self.define("HPX_WITH_LOGGING",True)
+            ]
+        
         if "instrumentation=apex" in spec:
             args += [
                 self.define("APEX_WITH_OTF2", True),

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -268,7 +268,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
 
         if "instrumentation=thread_debug" in spec:
             args += [
-                self.define("HPX_WITH_THREAD+DEBUG_INFO", True),
+                self.define("HPX_WITH_THREAD_DEBUG_INFO", True),
                 self.define("HPX_WITH_LOGGING", True),
             ]
 

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -66,7 +66,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
         values=lambda x: isinstance(x, str) and (x.isdigit() or x == "auto"),
     )
 
-    instrumentation_values = ("apex", "google_perftools", "papi", "valgrind","thread_debug")
+    instrumentation_values = ("apex", "google_perftools", "papi", "valgrind", "thread_debug")
     variant(
         "instrumentation",
         values=any_combination_of(*instrumentation_values),
@@ -268,10 +268,10 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
 
         if "instrumentation=thread_debug" in spec:
             args += [
-                self.define("HPX_WITH_THREAD+DEBUG_INFO",True),
-                self.define("HPX_WITH_LOGGING",True)
+                self.define("HPX_WITH_THREAD+DEBUG_INFO", True),
+                self.define("HPX_WITH_LOGGING", True),
             ]
-        
+
         if "instrumentation=apex" in spec:
             args += [
                 self.define("APEX_WITH_OTF2", True),


### PR DESCRIPTION
This pull requests adds `instrumentation=thread_debug` ton enable debugging logs for threads. 