### PR TITLE
[WIP: conflict] Cleanup Bazel output_user_root argument usage

### DIFF
--- a/var/spack/repos/builtin/packages/nccl-fastsocket/package.py
+++ b/var/spack/repos/builtin/packages/nccl-fastsocket/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import tempfile
-
 from spack.package import *
 
 
@@ -23,20 +21,17 @@ class NcclFastsocket(Package):
 
     def setup_build_environment(self, env):
         spec = self.spec
-        tmp_path = tempfile.mkdtemp(prefix="spack")
-        env.set("TEST_TMPDIR", tmp_path)
         env.set("NCCL_INSTALL_PATH", spec["nccl"].prefix)
         env.set("NCCL_HDR_PATH", spec["nccl"].prefix.include)
 
     def install(self, spec, prefix):
-        tmp_path = env["TEST_TMPDIR"]
         # Copied of py-tensorflow
         args = [
             # Don't allow user or system .bazelrc to override build settings
             "--nohome_rc",
             "--nosystem_rc",
-            # Bazel does not work properly on NFS, switch to /tmp
-            "--output_user_root=" + tmp_path,
+            # Bazel needs to be told to use the stage path
+            "--output_user_root=" + self.stage.source_path,
             "build",
             "libnccl-net.so",
             # Spack logs don't handle colored output well

--- a/var/spack/repos/builtin/packages/py-jaxlib/package.py
+++ b/var/spack/repos/builtin/packages/py-jaxlib/package.py
@@ -101,7 +101,6 @@ class PyJaxlib(PythonPackage, CudaPackage):
 
     def patch(self):
         self.tmp_path = tempfile.mkdtemp(prefix="spack")
-        self.buildtmp = tempfile.mkdtemp(prefix="spack")
         filter_file(
             "build --spawn_strategy=standalone",
             f"""
@@ -144,12 +143,10 @@ build --local_cpu_resources={make_jobs}
             )
             args.append("--cuda_compute_capabilities={0}".format(capabilities))
         args.append(
-            "--bazel_startup_options="
-            "--output_user_root={0}".format(self.wrapped_package_object.buildtmp)
+            "--bazel_startup_options=" "--output_user_root={0}".format(self.stage.source_path)
         )
         python(*args)
         with working_dir(self.wrapped_package_object.tmp_path):
             args = std_pip_args + ["--prefix=" + self.prefix, "."]
             pip(*args)
         remove_linked_tree(self.wrapped_package_object.tmp_path)
-        remove_linked_tree(self.wrapped_package_object.buildtmp)

--- a/var/spack/repos/builtin/packages/py-keras/package.py
+++ b/var/spack/repos/builtin/packages/py-keras/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import tempfile
-
 from spack.package import *
 
 
@@ -159,15 +157,12 @@ class PyKeras(PythonPackage):
 
     @when("@2.5:2")
     def install(self, spec, prefix):
-        self.tmp_path = tempfile.mkdtemp(prefix="spack")
-        env["HOME"] = self.tmp_path
-
         args = [
             # Don't allow user or system .bazelrc to override build settings
             "--nohome_rc",
             "--nosystem_rc",
-            # Bazel does not work properly on NFS, switch to /tmp
-            "--output_user_root=" + self.tmp_path,
+            # Bazel needs to be told to use the stage path
+            "--output_user_root=" + self.stage.source_path,
             "build",
             # Spack logs don't handle colored output well
             "--color=no",
@@ -190,4 +185,3 @@ class PyKeras(PythonPackage):
         with working_dir(buildpath):
             args = std_pip_args + ["--prefix=" + prefix, "."]
             pip(*args)
-        remove_linked_tree(self.tmp_path)

--- a/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import tempfile
-
 from spack.package import *
 
 
@@ -63,16 +61,12 @@ class PyTensorflowEstimator(Package):
     depends_on("py-wheel", type="build")
 
     def install(self, spec, prefix):
-        self.tmp_path = tempfile.mkdtemp(prefix="spack")
-        env["TEST_TMPDIR"] = self.tmp_path
-        env["HOME"] = self.tmp_path
-
         args = [
             # Don't allow user or system .bazelrc to override build settings
             "--nohome_rc",
             "--nosystem_rc",
-            # Bazel does not work properly on NFS, switch to /tmp
-            "--output_user_root=" + self.tmp_path,
+            # Bazel needs to be told to use the stage path
+            "--output_user_root=" + self.stage.source_path,
             "build",
             # Spack logs don't handle colored output well
             "--color=no",
@@ -96,4 +90,3 @@ class PyTensorflowEstimator(Package):
         with working_dir(buildpath):
             args = std_pip_args + ["--prefix=" + prefix, "."]
             pip(*args)
-        remove_linked_tree(self.tmp_path)

--- a/var/spack/repos/builtin/packages/py-tensorflow-hub/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-hub/package.py
@@ -37,15 +37,12 @@ class PyTensorflowHub(Package):
     patch("0001-zlib-bump-over-CVE-use-fossils-url-which-is-more-sta.patch", when="@:0.12")
 
     def install(self, spec, prefix):
-        tmp_path = tempfile.mkdtemp(prefix="spack")
-        env["TEST_TMPDIR"] = tmp_path
-        env["HOME"] = tmp_path
         args = [
             # Don't allow user or system .bazelrc to override build settings
             "--nohome_rc",
             "--nosystem_rc",
-            # Bazel does not work properly on NFS, switch to /tmp
-            "--output_user_root=" + tmp_path,
+            # Bazel needs to be told to use the stage path
+            "--output_user_root=" + self.stage.source_path,
             "build",
             # Spack logs don't handle colored output well
             "--color=no",
@@ -81,5 +78,4 @@ class PyTensorflowHub(Package):
             args = std_pip_args + ["--prefix=" + prefix, "."]
             pip(*args)
 
-        remove_linked_tree(tmp_path)
         remove_linked_tree(insttmp_path)

--- a/var/spack/repos/builtin/packages/py-tensorflow-metadata/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-metadata/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import tempfile
-
 from spack.package import *
 
 
@@ -55,5 +53,4 @@ class PyTensorflowMetadata(PythonPackage):
         )
 
     def setup_build_environment(self, env):
-        tmp_path = tempfile.mkdtemp(prefix="spack")
-        env.set("TEST_TMPDIR", tmp_path)
+        env.set("TEST_TMPDIR", self.stage.source_path)

--- a/var/spack/repos/builtin/packages/py-tensorflow-probability/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-probability/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import tempfile
-
 from spack.package import *
 
 
@@ -90,16 +88,12 @@ class PyTensorflowProbability(Package):
     depends_on("bazel@3.2:6", type="build")
 
     def install(self, spec, prefix):
-        self.tmp_path = tempfile.mkdtemp(prefix="spack")
-        env["TEST_TMPDIR"] = self.tmp_path
-        env["HOME"] = self.tmp_path
-
         args = [
             # Don't allow user or system .bazelrc to override build settings
             "--nohome_rc",
             "--nosystem_rc",
-            # Bazel does not work properly on NFS, switch to /tmp
-            "--output_user_root=" + self.tmp_path,
+            # Bazel needs to be told to use the stage path
+            "--output_user_root=" + self.stage.source_path,
             "build",
             # Spack logs don't handle colored output well
             "--color=no",
@@ -120,5 +114,3 @@ class PyTensorflowProbability(Package):
         with working_dir(join_path("bazel-bin", "pip_pkg.runfiles", "tensorflow_probability")):
             args = std_pip_args + ["--prefix=" + prefix, "."]
             pip(*args)
-
-        remove_linked_tree(self.tmp_path)


### PR DESCRIPTION
This PR is motivated by a [Slack conversation on the maintainers list with Adam Stewart](https://spackpm.slack.com/archives/G7XED8NAD/p1720559484588059).  I have explicitly verified these changes yield a build in the desired stage directory for `py-tensorflow`.

@adamjstewart I'm happy to receive suggestions.

----

Bazel needs to be explicitly told to put its output in someplace other than `$XDG_CACHE_HOME` (which is often a subdirectory of `$HOME`).  There are various ways to do this, but two of them are either setting the `TEST_TMPDIR` environment variable, or using the `bazel --output_user_root=<some dir>` option.  Where possible, we favor the latter.

Because Bazel's support for NFS filesystems has been flaky in the past, an output directory as created by Python's `tempfile.mkdtemp(...)` has been used.  This can cause problems for users who have temporary areas with limited space.  The behavior of `tempfile.mkdtemp` can be configured by appropriate adjustment of the environment variables `TMPDIR`, `TEMP`, and `TMP`, but this can be cumbersome as such setting of variables must be limited in scope to avoid unwanted side effects.

As of this writing, Bazel's guidance (https://bazel.build/docs/user-manual) is simply:

> **Note**: We recommend you do not use an NFS or similar networked file system for the root directory, as the higher access latency will cause noticeably slower builds."

We thus interpret this to mean that NFS is supported for an output root directory, thus enabling the removal of `tempfile`.