### PR TITLE
Add cuda_arch 90a for Grace-Hopper only

### DIFF
--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -44,6 +44,7 @@ class CudaPackage(PackageBase):
         "87",
         "89",
         "90",
+        "90a",
     )
 
     # FIXME: keep cuda and cuda_arch separate to make usage easier until


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Description in the CUDA documentation has:

```
Application binaries that include PTX version of kernels with architecture 
conditional features using sm_90a or compute_90a in order to take full 
advantage of Hopper GPU architecture, are not forward or backward compatible.
```

Latest version of document: https://docs.nvidia.com/cuda/hopper-compatibility-guide/