### PR TITLE
google-cloud-cli: Fix a problem with lmod module refreshing

### DIFF
--- a/var/spack/repos/builtin/packages/google-cloud-cli/package.py
+++ b/var/spack/repos/builtin/packages/google-cloud-cli/package.py
@@ -58,7 +58,7 @@ class GoogleCloudCli(Package):
         # https://cloud.google.com/sdk/gcloud/reference/topic/startup
         env.set("CLOUDSDK_PYTHON", self.spec["python"].command.path)
         # ~70 dependencies with no hints as to what versions are supported, just use bundled deps
-        env.set("CLOUDSDK_PYTHON_SITEPACKAGES", 0)
+        env.set("CLOUDSDK_PYTHON_SITEPACKAGES", "0")
 
     def setup_run_environment(self, env):
         self.setup_build_environment(env)


### PR DESCRIPTION
google-cloud-cli does not recreate modules correctly with `spack module lmod refresh`. This is due to missing quotes when setting one environment variable. This PR fixes this issue.