### PR TITLE
r-colourpicker: add 1.3.0 and r-shiny: add 1.8.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/r-colourpicker/package.py
+++ b/var/spack/repos/builtin/packages/r-colourpicker/package.py
@@ -20,6 +20,7 @@ class RColourpicker(RPackage):
 
     license("MIT")
 
+    version("1.3.0", sha256="c7f2618cd1ae1f7ac15aee072c648e6494dfff6714e13dc7cd1da993d1102510")
     version("1.2.0", sha256="bc2c80eee046219038baef9f8f213c9824d7fec7f893f6a1b881dd44b4a8638a")
     version("1.1.1", sha256="a0d09982b048b143e2c3438ccec039dd20d6f892fa0dedc9fdcb0d40de883ce0")
     version("1.1.0", sha256="2dfbb6262d187d3b17357ff9c22670ced3621feda5b2a2a500558478e4d551e2")

--- a/var/spack/repos/builtin/packages/r-shiny/package.py
+++ b/var/spack/repos/builtin/packages/r-shiny/package.py
@@ -18,6 +18,7 @@ class RShiny(RPackage):
 
     license("GPL-3.0-only OR custom")
 
+    version("1.8.1.1", sha256="a38d5fb5d750e2c2091ce9101f138c1f9bc7009bbb195227a3519c5d97e36753")
     version("1.7.4", sha256="bbfcdd7375013b8f59248b3f3f4e752acd445feb25179f3f7f65cd69614da4b5")
     version("1.7.3", sha256="b8ca9a39fa69ea9b270a7e9037198d95122c79bd493b865d909d343dd3523ada")
     version("1.7.2", sha256="23b5bfee8d597b4147e07c89391a735361cd9f69abeecfd9bd38a14d35fe6252")
@@ -51,12 +52,13 @@ class RShiny(RPackage):
     depends_on("r-rlang@0.4.10:", type=("build", "run"), when="@1.7.1:")
     depends_on("r-fastmap@1.0.0:", type=("build", "run"), when="@1.5.0:")
     depends_on("r-fastmap@1.1.0:", type=("build", "run"), when="@1.7.1:")
+    depends_on("r-fastmap@1.1.1:", type=("build", "run"), when="@1.7.5:")
     depends_on("r-withr", type=("build", "run"), when="@1.5.0:")
     depends_on("r-commonmark@1.7:", type=("build", "run"), when="@1.5.0:")
     depends_on("r-glue@1.3.2:", type=("build", "run"), when="@1.5.0:")
     depends_on("r-bslib@0.3.0:", type=("build", "run"), when="@1.7.1:")
     depends_on("r-cachem", type=("build", "run"), when="@1.7.1:")
-    depends_on("r-ellipsis", type=("build", "run"), when="@1.7.1:")
     depends_on("r-lifecycle@0.2.0:", type=("build", "run"), when="@1.7.1:")
 
     depends_on("r-digest", type=("build", "run"), when="@:1.5.0")
+    depends_on("r-ellipsis", type=("build", "run"), when="@1.7.1:1.8.0")


### PR DESCRIPTION
Also updates `r-shiny` because `r-colourpicker` did not build with the error message
```
1 error found in build log:
     3    * installing *source* package 'colourpicker' ...
     4    ** package 'colourpicker' successfully unpacked and MD5 sums checked
     5    ** using staged installation
     6    ** R
     7    ** inst
     8    ** byte-compile and prepare package for lazy loading
  >> 9    Error: .onLoad failed in loadNamespace() for 'shiny', details:
     10     call: .make_numeric_version(x, strict, .standard_regexps()$valid_numeric_version)
     11     error: invalid non-character version specification 'x' (type: double)
     12   Execution halted
     13   ERROR: lazy loading failed for package 'colourpicker'
     14   * removing '/spack/opt/spack/linux-rocky8-skylake/gcc-12.2.0/r-colourpicker-1.2.0-ocqk4o6zmpackljiteopznuvtby
          mzipo/rlib/R/library/colourpicker'
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
