### PR TITLE
DCMTK: fix build with libtiff

### DIFF
--- a/var/spack/repos/builtin/packages/dcmtk/package.py
+++ b/var/spack/repos/builtin/packages/dcmtk/package.py
@@ -50,6 +50,8 @@ class Dcmtk(CMakePackage):
 
     conflicts("platform=darwin target=aarch64:", when="@:3.6.6")
 
+    patch("tiff-3.6.7.patch", when="@3.6.7")
+
     def patch(self):
         # Backport 3.6.4
         if self.spec.satisfies("@:3.6.3 %fj"):

--- a/var/spack/repos/builtin/packages/dcmtk/tiff-3.6.7.patch
+++ b/var/spack/repos/builtin/packages/dcmtk/tiff-3.6.7.patch
@@ -1,12 +1,12 @@
 diff --color=auto --color=never -Naur a/CMake/3rdparty.cmake b/CMake/3rdparty.cmake
 --- a/CMake/3rdparty.cmake	2022-04-28 15:47:25
-+++ b/CMake/3rdparty.cmake	2024-07-12 14:55:11
++++ b/CMake/3rdparty.cmake	2024-07-12 15:04:19
 @@ -38,7 +38,7 @@
          message(STATUS "Info: DCMTK TIFF support will be enabled")
          include_directories(${TIFF_INCLUDE_DIR} ${JPEG_INCLUDE_DIR})
        endif()
 -      set(LIBTIFF_LIBS ${TIFF_LIBRARY} ${TIFF_EXTRA_LIBS_STATIC} ${JPEG_LIBRARY})
-+      set(LIBTIFF_LIBS ${TIFF_LIBRARIES} ${TIFF_EXTRA_LIBS_STATIC} ${JPEG_LIBRARY})
++      set(LIBTIFF_LIBS ${TIFF_LIBRARIES} ${TIFF_EXTRA_LIBS_STATIC} ${JPEG_LIBRARIES})
      endif()
    endif()
  

--- a/var/spack/repos/builtin/packages/dcmtk/tiff-3.6.7.patch
+++ b/var/spack/repos/builtin/packages/dcmtk/tiff-3.6.7.patch
@@ -1,0 +1,12 @@
+diff --color=auto --color=never -Naur a/CMake/3rdparty.cmake b/CMake/3rdparty.cmake
+--- a/CMake/3rdparty.cmake	2022-04-28 15:47:25
++++ b/CMake/3rdparty.cmake	2024-07-12 14:55:11
+@@ -38,7 +38,7 @@
+         message(STATUS "Info: DCMTK TIFF support will be enabled")
+         include_directories(${TIFF_INCLUDE_DIR} ${JPEG_INCLUDE_DIR})
+       endif()
+-      set(LIBTIFF_LIBS ${TIFF_LIBRARY} ${TIFF_EXTRA_LIBS_STATIC} ${JPEG_LIBRARY})
++      set(LIBTIFF_LIBS ${TIFF_LIBRARIES} ${TIFF_EXTRA_LIBS_STATIC} ${JPEG_LIBRARY})
+     endif()
+   endif()
+ 


### PR DESCRIPTION
Recent changes in CMake mean that `TIFF_LIBRARY` is no longer set. The correct variable is `TIFF_LIBRARIES`. I modified the patch from https://github.com/DCMTK/dcmtk/pull/93 to solve this issue. Note that this patch does not apply to any other versions. If desired, someone can make similar patches for other versions.

Fixes #45198 @moloney 