### PR TITLE
Spack on Windows: Update install tests for Windows

### DIFF
--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -491,10 +491,7 @@ def test_env_definition_symlink(install_mockery, mock_fetch, tmpdir):
 
 
 def test_env_install_two_specs_same_dep(install_mockery, mock_fetch, tmpdir, capsys):
-    """Test installation of two packages that share a dependency with no
-    connection and the second specifying the dependency as a 'build'
-    dependency.
-    """
+    """Test installation of two packages that share a dependency with no connection."""
     path = tmpdir.join("spack.yaml")
 
     with tmpdir.as_cwd():

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -725,7 +725,6 @@ def test_install_deps_then_package(tmpdir, mock_fetch, install_mockery):
     assert os.path.exists(root.prefix)
 
 
-@pytest.mark.not_on_windows("Environment views not supported on windows. Revisit after #34701")
 @pytest.mark.regression("12002")
 def test_install_only_dependencies_in_env(
     tmpdir, mock_fetch, install_mockery, mutable_mock_env_path
@@ -1002,7 +1001,6 @@ def test_install_fails_no_args_suggests_env_activation(tmpdir):
     assert "using the `spack.yaml` in this directory" in output
 
 
-@pytest.mark.not_on_windows("Environment views not supported on windows. Revisit after #34701")
 def test_install_env_with_tests_all(
     tmpdir, mock_packages, mock_fetch, install_mockery, mutable_mock_env_path
 ):
@@ -1014,7 +1012,6 @@ def test_install_env_with_tests_all(
         assert os.path.exists(test_dep.prefix)
 
 
-@pytest.mark.not_on_windows("Environment views not supported on windows. Revisit after #34701")
 def test_install_env_with_tests_root(
     tmpdir, mock_packages, mock_fetch, install_mockery, mutable_mock_env_path
 ):
@@ -1026,7 +1023,6 @@ def test_install_env_with_tests_root(
         assert not os.path.exists(test_dep.prefix)
 
 
-@pytest.mark.not_on_windows("Environment views not supported on windows. Revisit after #34701")
 def test_install_empty_env(
     tmpdir, mock_packages, mock_fetch, install_mockery, mutable_mock_env_path
 ):

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -58,7 +58,7 @@ def test_list_filter(mock_packages):
 
 
 def test_list_search_description(mock_packages):
-    output = list("--search-description", "one build dependency")
+    output = list("--search-description", "one dependency")
     assert "depb" in output
 
 

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -58,7 +58,7 @@ def test_list_filter(mock_packages):
 
 
 def test_list_search_description(mock_packages):
-    output = list("--search-description", "one dependency")
+    output = list("--search-description", "one direct dependency")
     assert "depb" in output
 
 

--- a/var/spack/repos/builtin.mock/packages/depb/package.py
+++ b/var/spack/repos/builtin.mock/packages/depb/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 
 
 class Depb(Package):
-    """Simple package with one build dependency"""
+    """Simple package with one dependency"""
 
     homepage = "http://www.example.com"
     url = "http://www.example.com/a-1.0.tar.gz"
@@ -18,5 +18,5 @@ class Depb(Package):
 
     def install(self, spec, prefix):
         # sanity_check_prefix requires something in the install directory
-        # Test requires overriding the one provided by `AutotoolsPackage`
+        # Test requires overriding the one provided by `Package`
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin.mock/packages/depb/package.py
+++ b/var/spack/repos/builtin.mock/packages/depb/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 
 
 class Depb(Package):
-    """Simple package with one dependency"""
+    """Simple package with one direct dependency"""
 
     homepage = "http://www.example.com"
     url = "http://www.example.com/a-1.0.tar.gz"

--- a/var/spack/repos/builtin.mock/packages/depb/package.py
+++ b/var/spack/repos/builtin.mock/packages/depb/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Depb(AutotoolsPackage):
+class Depb(Package):
     """Simple package with one build dependency"""
 
     homepage = "http://www.example.com"

--- a/var/spack/repos/builtin.mock/packages/depb/package.py
+++ b/var/spack/repos/builtin.mock/packages/depb/package.py
@@ -18,5 +18,5 @@ class Depb(Package):
 
     def install(self, spec, prefix):
         # sanity_check_prefix requires something in the install directory
-        # Test requires overriding the one provided by `Package`
+        # `Package` does not define an `install` method by default
         mkdirp(prefix.bin)


### PR DESCRIPTION
Updated cmd install tests. This included four tests that dealt with environment views as they are supported on Windows.
