### PR TITLE
py-multiecho: add v0.29

### DIFF
--- a/var/spack/repos/builtin/packages/py-multiecho/package.py
+++ b/var/spack/repos/builtin/packages/py-multiecho/package.py
@@ -14,11 +14,16 @@ class PyMultiecho(PythonPackage):
 
     license("MIT")
 
+    version("0.29", sha256="df4860fe4478c162f976bdc4bdd2dc1c51ba2c33cb23658ac7218cf1597c4f0a")
     version("0.28", sha256="d0459bd03398547116d8e989b2d2b7922af0ae7ae77e233794dd7253a2abced3")
 
-    depends_on("python@3.6:3.9", type=("build", "run"))
+    depends_on("py-setuptools@62.2.0:", type="build", when="@0.29:")
     depends_on("py-setuptools", type="build")
+    depends_on("py-argparse-manpage+setuptools", type="build", when="@0.29:")
 
     depends_on("py-coloredlogs", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-nibabel", type=("build", "run"))
+
+    # Historical dependencies
+    depends_on("python@3.6:3.9", type=("build", "run"), when="@0.28")


### PR DESCRIPTION
This version finally is able to work with `python@3.10:`

https://github.com/Donders-Institute/multiecho/tree/0.29
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
