### PR TITLE
CI Bootstrap Clingo: Add x-platform exit code validation step

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -71,12 +71,14 @@ jobs:
           SETUP_SCRIPT_EXT: ${{ matrix.runner == 'windows-latest' && 'ps1' || 'sh' }}
           SETUP_SCRIPT_SOURCE: ${{ matrix.runner == 'windows-latest' && './' || 'source ' }}
           USER_SCOPE_PARENT_DIR: ${{ matrix.runner == 'windows-latest' && '$env:userprofile' || '$HOME' }}
+          VALIDATE_LAST_EXIT: ${{ matrix.runner == 'windows-latest' && './share/spack/qa/validate_last_exit.ps1' || 'if [ $? -ne 0 ]; then exit $?; fi' }}
         run: |
           ${{ env.SETUP_SCRIPT_SOURCE }}share/spack/setup-env.${{ env.SETUP_SCRIPT_EXT }}
           spack bootstrap disable github-actions-v0.5
           spack bootstrap disable github-actions-v0.4
           spack external find --not-buildable cmake bison
           spack -d solve zlib
+          ${{ env.VALIDATE_LAST_EXIT }}
           tree ${{ env.USER_SCOPE_PARENT_DIR }}/.spack/bootstrap/store/
 
   gnupg-sources:

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -71,7 +71,7 @@ jobs:
           SETUP_SCRIPT_EXT: ${{ matrix.runner == 'windows-latest' && 'ps1' || 'sh' }}
           SETUP_SCRIPT_SOURCE: ${{ matrix.runner == 'windows-latest' && './' || 'source ' }}
           USER_SCOPE_PARENT_DIR: ${{ matrix.runner == 'windows-latest' && '$env:userprofile' || '$HOME' }}
-          VALIDATE_LAST_EXIT: ${{ matrix.runner == 'windows-latest' && './share/spack/qa/validate_last_exit.ps1' || 'if [ $? -ne 0 ]; then exit $?; fi' }}
+          VALIDATE_LAST_EXIT: ${{ matrix.runner == 'windows-latest' && './share/spack/qa/validate_last_exit.ps1' || '' }}
         run: |
           ${{ env.SETUP_SCRIPT_SOURCE }}share/spack/setup-env.${{ env.SETUP_SCRIPT_EXT }}
           spack bootstrap disable github-actions-v0.5

--- a/share/spack/qa/validate_last_exit.ps1
+++ b/share/spack/qa/validate_last_exit.ps1
@@ -1,3 +1,3 @@
 if ($LASTEXITCODE -ne 0){
-    throw "Unit Tests have failed"
+    throw "Tests have failed"
 }


### PR DESCRIPTION
Title pretty much sums it up

Powershell does not actually error if native (non powershell commandlets) scripts and programs exit with non-zero codes.
Add handling to the bootstrap GHA test to ensure that we're always reporting failures.
On Windows we call an existing script that validates that the last exit code was 0, or throws an error powershell will report as a failure.
On unix, check the error code and if non zero we exit with that error code.
