### PR TITLE
tix: old to new test API

### DIFF
--- a/var/spack/repos/builtin/packages/tix/package.py
+++ b/var/spack/repos/builtin/packages/tix/package.py
@@ -77,12 +77,12 @@ class Tix(AutotoolsPackage):
         if "platform=darwin" in self.spec:
             fix_darwin_install_name(self.prefix.lib.Tix + str(self.version))
 
-    def test(self):
+    def test_tcl(self):
+        """Test that tix can be loaded"""
         test_data_dir = self.test_suite.current_test_data_dir
         test_file = test_data_dir.join("test.tcl")
-        self.run_test(
-            self.spec["tcl"].command.path, test_file, purpose="test that tix can be loaded"
-        )
+        tcl = self.spec["tcl"].command
+        tcl(test_file)
 
     @property
     def libs(self):


### PR DESCRIPTION
Update standalone test API.

Supersedes #38577 

Note that tix is currently having an installation issue so I cannot provide test results

UPDATE:  Possible to install and run tests using #45244 