### PR TITLE
py-nodeenv: depends_on python +ssl

### DIFF
--- a/var/spack/repos/builtin/packages/py-nodeenv/package.py
+++ b/var/spack/repos/builtin/packages/py-nodeenv/package.py
@@ -16,5 +16,6 @@ class PyNodeenv(PythonPackage):
     version("1.7.0", sha256="e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b")
     version("1.3.3", sha256="ad8259494cf1c9034539f6cced78a1da4840a4b157e23640bc4a0c0546b0cb7a")
 
+    depends_on("python +ssl", type=("build", "run"))
     depends_on("py-setuptools", when="@1.7:", type=("build", "run"))
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-nodeenv/package.py
+++ b/var/spack/repos/builtin/packages/py-nodeenv/package.py
@@ -16,6 +16,6 @@ class PyNodeenv(PythonPackage):
     version("1.7.0", sha256="e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b")
     version("1.3.3", sha256="ad8259494cf1c9034539f6cced78a1da4840a4b157e23640bc4a0c0546b0cb7a")
 
-    depends_on("python +ssl", type=("build", "run"))
+    depends_on("python +ssl", when="@1.5:", type=("build", "run"))
     depends_on("py-setuptools", when="@1.7:", type=("build", "run"))
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
As of v1.5.0, `nodeenv` requires Python with the `ssl` module, [1]. This PR makes that explicit in the package dependencies.

[1]: https://github.com/ekalinin/nodeenv/commit/f12a4ef353040f454f8ef3152ff912a51555a835.
