### PR TITLE
libelf: Fix build with GCC 14

### DIFF
--- a/var/spack/repos/builtin/packages/libelf/package.py
+++ b/var/spack/repos/builtin/packages/libelf/package.py
@@ -55,7 +55,7 @@ class Libelf(AutotoolsPackage):
 
     def flag_handler(self, name, flags):
         if name == "cflags":
-            if self.spec.satisfies("%clang@16:"):
+            if self.spec.satisfies("%clang@16:") or self.spec.satisfies("%gcc@14:"):
                 flags.append("-Wno-error=implicit-int")
                 flags.append("-Wno-error=implicit-function-declaration")
         return (flags, None, None)


### PR DESCRIPTION
GCC 14 needs the same workaround as Clang 16.