### PR TITLE
Fix order of deserialization in subprocess context

### DIFF
--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -81,6 +81,8 @@ class PackageInstallContext:
         env = pickle.load(self.serialized_env) if _SERIALIZE else self.env
         if env:
             spack.environment.activate(env)
+        # Order of operation is important, since the package might be retrieved
+        # from a repo defined within the environment configuration
         pkg = pickle.load(self.serialized_pkg) if _SERIALIZE else self.pkg
         return pkg
 

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -79,9 +79,9 @@ class PackageInstallContext:
         self.test_state.restore()
         spack.main.spack_working_dir = self.spack_working_dir
         env = pickle.load(self.serialized_env) if _SERIALIZE else self.env
-        pkg = pickle.load(self.serialized_pkg) if _SERIALIZE else self.pkg
         if env:
             spack.environment.activate(env)
+        pkg = pickle.load(self.serialized_pkg) if _SERIALIZE else self.pkg
         return pkg
 
 


### PR DESCRIPTION
fixes #45197

Since the the MetaPathFinder now owns a lazily constructed RepoPath object, we need to deserialize environments _before_ the package that needs to be restored. Before we were relying on globals to be inconsistent in a way that let the entire process go.

After fixing this issue, we might want to take some time to disentangle `spack.subprocess_context` or improve `Environment.__reduce__`.

### Long explanation

`spack.subprocess_context`  has always been in an inconsistent state when restoring the context in a subprocess. In particular, this line:
https://github.com/spack/spack/blob/42232a8ab6d9c31eb0c943111d2639e0d6a3076f/lib/spack/spack/subprocess_context.py#L79

which is documented to be needed only in tests:

https://github.com/spack/spack/blob/42232a8ab6d9c31eb0c943111d2639e0d6a3076f/lib/spack/spack/subprocess_context.py#L91-L92

restores _some_ of the globals that are in the parent process. _These globals are essential for the correct functioning of Spack, not only in tests, so the docstring is misleading._  The inconsistency, at this point, is that:
- The configuration in `spack.config.CONFIG` and `spack.repo.PATH` are as if the environment is active
- But the environment is not yet active, so `spack.environment.active_environment` is inconsistent

When later we restore the environment:

https://github.com/spack/spack/blob/42232a8ab6d9c31eb0c943111d2639e0d6a3076f/lib/spack/spack/subprocess_context.py#L81

we go through a series of calls that are routed to `Environment.__init__`. Within `Environment.__init__`  we read the manifest by temporarily pushing a scope and then removing it. _Except the scope was already in `spack.config.CONFIG` from the restore of globals, so what we're doing here is effectively popping the scope out of `spack.config.CONFIG` that now doesn't contain the environment single file scope anymore_. At this point `spack.repo.PATH` and `spack.config.CONFIG` are inconsistent.

When we finally  restore the package, we need to load `spack.pkg.<custom_repo>`. 

Before #45053 the `MetaPathFinder` was using the global `spack.repo.PATH` so it didn't trigger in this case. The problem with that was that many methods of the `RepoPath` class couldn't be used with an object different from `spack.repo.PATH`, since in the end loading the package code would go through the `MetaPathFinder`.

 After #45053 the MetaPathFinder has its own instance of `RepoPath`, that is lazily constructed from configuration, and can be switched temporarily using a method. This causes the bug reported in #45197. Having an instance there allows things like `spack.repo.RepoPath.get` to work whatever is the `RepoPath` object.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
