### PR TITLE
Check if a child process has a logfile available, before executing path operations on it

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1473,7 +1473,7 @@ class ChildError(InstallError):
             out.write("  {0}\n".format(self.log_name))
 
         # Also output the test log path IF it exists
-        if self.context != "test":
+        if self.context != "test" and have_log:
             test_log = join_path(os.path.dirname(self.log_name), spack_install_test_log)
             if os.path.isfile(test_log):
                 out.write("\nSee test log for details:\n")


### PR DESCRIPTION
If we don't have a log, we'll mask the real error in a Child process with another caused by using None as an argument to `os.path.join`. With this PR the error in #45197 would read:
```console
$ spack -d install
[ ... ]
==> [2024-07-15-09:43:23.297381] Error: ModuleNotFoundError: No module named 'spack.pkg.tutorial'
Traceback (most recent call last):
  File "/Users/spack-bootstrap-runner/github/spack/lib/spack/spack/build_environment.py", line 1129, in _setup_pkg_and_run
    pkg = serialized_pkg.restore()
  File "/Users/spack-bootstrap-runner/github/spack/lib/spack/spack/subprocess_context.py", line 82, in restore
    pkg = pickle.load(self.serialized_pkg) if _SERIALIZE else self.pkg
ModuleNotFoundError: No module named 'spack.pkg.tutorial'
==> [2024-07-15-09:43:23.297725] Flagging hdf5-1.10.7-pdf2me4doer5i2xtjlsenmzgzm3gxwjt as failed: ModuleNotFoundError: No module named 'spack.pkg.tutorial'
==> [2024-07-15-09:43:23.318226] Reading config from file /var/folders/2r/4nzyg3dx54d658l9mlxfw0vm0000gz/T/spack-8sqf70_j/spack.yaml
==> [2024-07-15-09:43:23.320067] Deactivated environment '/var/folders/2r/4nzyg3dx54d658l9mlxfw0vm0000gz/T/spack-8sqf70_j'
==> [2024-07-15-09:43:23.324500] Using environment '/var/folders/2r/4nzyg3dx54d658l9mlxfw0vm0000gz/T/spack-8sqf70_j'
==> [2024-07-15-09:43:23.330450] '/usr/bin/git' '-C' '/Users/spack-bootstrap-runner/github/spack' 'rev-parse' 'HEAD'
==> [2024-07-15-09:43:23.348727] View at /var/folders/2r/4nzyg3dx54d658l9mlxfw0vm0000gz/T/spack-8sqf70_j/.spack-env/view does not need regeneration.
==> [2024-07-15-09:43:23.348818] ChildError: ModuleNotFoundError: No module named 'spack.pkg.tutorial'
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
