### PR TITLE
unparser.py: remove print statements

### DIFF
--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -554,9 +554,7 @@ class Unparser:
 
     def _fstring_JoinedStr(self, node, write):
         for value in node.values:
-            print("   ", value)
             meth = getattr(self, "_fstring_" + type(value).__name__)
-            print(meth)
             meth(value, write)
 
     def _fstring_Str(self, node, write):


### PR DESCRIPTION
As a follow-up, we need to check if we need https://github.com/python/cpython/commit/a993e901ebe60c38d46ecb31f771d0b4a206828c or not. Looks like it's both "cosmetic" (i.e. hash breaking in spack) and an improvement in round-tripping (desirable...)