### PR TITLE
gaudi: depends_on python +dbm

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -89,7 +89,7 @@ class Gaudi(CMakePackage):
     depends_on("tbb", when="@37.1:")
     depends_on("uuid")
     depends_on("nlohmann-json")
-    depends_on("python", type=("build", "run"))
+    depends_on("python +dbm", type=("build", "run"))
     depends_on("py-networkx", type=("build", "run"))
     depends_on("py-six", type=("build", "run"))
     depends_on("py-pyyaml", type=("build", "run", "test"))


### PR DESCRIPTION
As indicated in the discussion in https://gitlab.cern.ch/gaudi/Gaudi/-/issues/258, gaudi depends on `python +dbm` (which is a default for python anyway). This PR adds the explicit dependency.