### PR TITLE
rccl: new test API

### DIFF
--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -126,8 +126,9 @@ class Rccl(CMakePackage):
             args.append(self.define("BUILD_TESTS", "ON"))
         return args
 
-    def test(self):
+    def test_unit(self):
+        """Run rccl-UnitTests"""
         test_dir = join_path(self.spec["rccl"].prefix, "bin")
         with working_dir(test_dir, create=True):
-            exe = Executable("rccl-UnitTests")
+            exe = which("rccl-UnitTests")
             exe()

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -129,6 +129,5 @@ class Rccl(CMakePackage):
     def test_unit(self):
         """Run rccl-UnitTests"""
         test_dir = join_path(self.spec["rccl"].prefix, "bin")
-        with working_dir(test_dir, create=True):
-            exe = which("rccl-UnitTests")
-            exe()
+        exe = which("rccl-UnitTests")
+        exe()

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -128,6 +128,5 @@ class Rccl(CMakePackage):
 
     def test_unit(self):
         """Run rccl-UnitTests"""
-        test_dir = join_path(self.spec["rccl"].prefix, "bin")
-        exe = which("rccl-UnitTests")
-        exe()
+        unit_tests = which("rccl-UnitTests")
+        unit_tests()

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -127,6 +127,6 @@ class Rccl(CMakePackage):
         return args
 
     def test_unit(self):
-        """Run rccl-UnitTests"""
+        """Run unit tests"""
         unit_tests = which(join_path(self.prefix.bin, "rccl-UnitTests"))
         unit_tests()

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -128,5 +128,5 @@ class Rccl(CMakePackage):
 
     def test_unit(self):
         """Run rccl-UnitTests"""
-        unit_tests = which("rccl-UnitTests")
+        unit_tests = which(join_path(self.prefix.bin, "rccl-UnitTests"))
         unit_tests()


### PR DESCRIPTION
Supersedes #44907 

Update standalone test API. 

Latest test output:
```
$ spack find -v rccl
..
rccl@6.1.1~ipo amdgpu_target=auto build_system=cmake build_type=Release generator=make patches=68a55d8
==> 1 installed package


$ spack -v test run rccl
==> Spack test lp3wzboovp3fsoryjt3vwa4kgtpzm24m
==> Testing package rccl-6.1.1-dgzuajk
==> [2024-08-15-16:01:29.666957] test: test_unit: Run rccl-UnitTests
..
================================================================================
 Environment variables:
 - UT_SHOW_NAMES        Show test case names                       (  1) <unset>
 - UT_MIN_GPUS          Minimum number of GPUs to use              (  2) <unset>
 - UT_MAX_GPUS          Maximum number of GPUs to use              (  0) <unset>
 - UT_POW2_GPUS         Only allow power-of-2 # of GPUs            (  0) <unset>
 - UT_PROCESS_MASK      Whether to run single/multi process        (  3) <unset>
 - UT_VERBOSE           Show verbose unit test output              (  0) <unset>
 - UT_REDOPS            List of reduction ops to test              ( -1) <unset>
 - UT_DATATYPES         List of datatypes to test                  ( -1) <unset>
 - UT_MAX_RANKS_PER_GPU Maximum number of ranks using the same GPU (  1) <unset>
 - UT_PRINT_VALUES      Print array values (-1 for all)            (  0) <unset>
 - UT_SHOW_TIMING       Show timing table                          (  1) <unset>
 - UT_INTERACTIVE       Run in interactive mode                    (  0) <unset>
 - UT_TIMEOUT_US        Timeout limit for collective calls in us   (5000000) <unset>
================================================================================
[==========] Running 58 tests from 13 test suites.
[----------] Global test environment set-up.
[----------] 6 tests from AllGather
[ RUN      ] AllGather.OutOfPlace
[       OK ] AllGather.OutOfPlace (4 ms)
[ RUN      ] AllGather.OutOfPlaceGraph
[       OK ] AllGather.OutOfPlaceGraph (4 ms)
[ RUN      ] AllGather.InPlace
[       OK ] AllGather.InPlace (4 ms)
[ RUN      ] AllGather.InPlaceGraph
[       OK ] AllGather.InPlaceGraph (4 ms)
[ RUN      ] AllGather.ManagedMem
[       OK ] AllGather.ManagedMem (6 ms)
[ RUN      ] AllGather.ManagedMemGraph
[       OK ] AllGather.ManagedMemGraph (4 ms)
[----------] 6 tests from AllGather (28 ms total)

[----------] 7 tests from AllReduce
[ RUN      ] AllReduce.OutOfPlace
[       OK ] AllReduce.OutOfPlace (4 ms)
[ RUN      ] AllReduce.OutOfPlaceGraph
[       OK ] AllReduce.OutOfPlaceGraph (3 ms)
[ RUN      ] AllReduce.InPlace
[       OK ] AllReduce.InPlace (3 ms)
[ RUN      ] AllReduce.InPlaceGraph
[       OK ] AllReduce.InPlaceGraph (5 ms)
[ RUN      ] AllReduce.ManagedMem
[       OK ] AllReduce.ManagedMem (4 ms)
[ RUN      ] AllReduce.ManagedMemGraph
[       OK ] AllReduce.ManagedMemGraph (3 ms)
[ DISABLED ] AllReduce.DISABLED_Clique
[ RUN      ] AllReduce.PreMultScalar
[       OK ] AllReduce.PreMultScalar (3 ms)
[----------] 7 tests from AllReduce (28 ms total)

[----------] 4 tests from AllToAll
[ RUN      ] AllToAll.OutOfPlace
[       OK ] AllToAll.OutOfPlace (3 ms)
[ RUN      ] AllToAll.OutOfPlaceGraph
[       OK ] AllToAll.OutOfPlaceGraph (3 ms)
[ RUN      ] AllToAll.ManagedMem
[       OK ] AllToAll.ManagedMem (3 ms)
[ RUN      ] AllToAll.ManagedMemGraph
[       OK ] AllToAll.ManagedMemGraph (4 ms)
[----------] 4 tests from AllToAll (15 ms total)

[----------] 2 tests from AllToAllv
[ RUN      ] AllToAllv.OutOfPlace
[       OK ] AllToAllv.OutOfPlace (4 ms)
[ RUN      ] AllToAllv.OutOfPlaceGraph
[       OK ] AllToAllv.OutOfPlaceGraph (5 ms)
[----------] 2 tests from AllToAllv (9 ms total)

[----------] 6 tests from Broadcast
[ RUN      ] Broadcast.OutOfPlace
[       OK ] Broadcast.OutOfPlace (4 ms)
[ RUN      ] Broadcast.OutOfPlaceGraph
[       OK ] Broadcast.OutOfPlaceGraph (4 ms)
[ RUN      ] Broadcast.InPlace
[       OK ] Broadcast.InPlace (4 ms)
[ RUN      ] Broadcast.InPlaceGraph
[       OK ] Broadcast.InPlaceGraph (4 ms)
[ RUN      ] Broadcast.ManagedMem
[       OK ] Broadcast.ManagedMem (4 ms)
[ RUN      ] Broadcast.ManagedMemGraph
[       OK ] Broadcast.ManagedMemGraph (4 ms)
[----------] 6 tests from Broadcast (26 ms total)

[----------] 6 tests from Gather
[ RUN      ] Gather.OutOfPlace
[       OK ] Gather.OutOfPlace (4 ms)
[ RUN      ] Gather.OutOfPlaceGraph
[       OK ] Gather.OutOfPlaceGraph (4 ms)
[ RUN      ] Gather.InPlace
[       OK ] Gather.InPlace (4 ms)
[ RUN      ] Gather.InPlaceGraph
[       OK ] Gather.InPlaceGraph (3 ms)
[ RUN      ] Gather.ManagedMem
[       OK ] Gather.ManagedMem (3 ms)
[ RUN      ] Gather.ManagedMemGraph
[       OK ] Gather.ManagedMemGraph (4 ms)
[----------] 6 tests from Gather (24 ms total)

[----------] 3 tests from GroupCall
[ RUN      ] GroupCall.Identical
[       OK ] GroupCall.Identical (3 ms)
[ RUN      ] GroupCall.Different
[       OK ] GroupCall.Different (3 ms)
[ RUN      ] GroupCall.Multistream
[       OK ] GroupCall.Multistream (3 ms)
[----------] 3 tests from GroupCall (11 ms total)

[----------] 1 test from NonBlocking
[ RUN      ] NonBlocking.SingleCalls
[       OK ] NonBlocking.SingleCalls (3 ms)
[----------] 1 test from NonBlocking (3 ms total)

[----------] 6 tests from ReduceScatter
[ RUN      ] ReduceScatter.OutOfPlace
[       OK ] ReduceScatter.OutOfPlace (3 ms)
[ RUN      ] ReduceScatter.OutOfPlaceGraph
[       OK ] ReduceScatter.OutOfPlaceGraph (3 ms)
[ RUN      ] ReduceScatter.InPlace
[       OK ] ReduceScatter.InPlace (3 ms)
[ RUN      ] ReduceScatter.InPlaceGraph
[       OK ] ReduceScatter.InPlaceGraph (3 ms)
[ RUN      ] ReduceScatter.ManagedMem
[       OK ] ReduceScatter.ManagedMem (3 ms)
[ RUN      ] ReduceScatter.ManagedMemGraph
[       OK ] ReduceScatter.ManagedMemGraph (3 ms)
[----------] 6 tests from ReduceScatter (22 ms total)

[----------] 6 tests from Reduce
[ RUN      ] Reduce.OutOfPlace
[       OK ] Reduce.OutOfPlace (3 ms)
[ RUN      ] Reduce.OutOfPlaceGraph
[       OK ] Reduce.OutOfPlaceGraph (3 ms)
[ RUN      ] Reduce.InPlace
[       OK ] Reduce.InPlace (3 ms)
[ RUN      ] Reduce.InPlaceGraph
[       OK ] Reduce.InPlaceGraph (3 ms)
[ RUN      ] Reduce.ManagedMem
[       OK ] Reduce.ManagedMem (3 ms)
[ RUN      ] Reduce.ManagedMemGraph
[       OK ] Reduce.ManagedMemGraph (3 ms)
[----------] 6 tests from Reduce (21 ms total)

[----------] 6 tests from Scatter
[ RUN      ] Scatter.OutOfPlace
[       OK ] Scatter.OutOfPlace (3 ms)
[ RUN      ] Scatter.OutOfPlaceGraph
[       OK ] Scatter.OutOfPlaceGraph (3 ms)
[ RUN      ] Scatter.InPlace
[       OK ] Scatter.InPlace (3 ms)
[ RUN      ] Scatter.InPlaceGraph
[       OK ] Scatter.InPlaceGraph (3 ms)
[ RUN      ] Scatter.ManagedMem
[       OK ] Scatter.ManagedMem (3 ms)
[ RUN      ] Scatter.ManagedMemGraph
[       OK ] Scatter.ManagedMemGraph (3 ms)
[----------] 6 tests from Scatter (21 ms total)

[----------] 1 test from SendRecv
[ RUN      ] SendRecv.SinglePairs
$TMPDIR/spack-stage/spack-stage-rccl-6.1.1-dgzuajkf2gnbmipduscm2w5ous6dyq66/spack-src/test/common/TestBed.cpp:129: Failure
Expected equality of these values:
  write(childList[0]->parentWriteFd, &getIdCmd, sizeof(getIdCmd))
    Which is: -1
  sizeof(getIdCmd)
    Which is: 4
$TMPDIR/spack-stage/spack-stage-rccl-6.1.1-dgzuajkf2gnbmipduscm2w5ous6dyq66/spack-src/test/common/TestBed.cpp:129: Failure
Expected equality of these values:
  write(childList[0]->parentWriteFd, &getIdCmd, sizeof(getIdCmd))
    Which is: -1
  sizeof(getIdCmd)
    Which is: 4
[  FAILED  ] SendRecv.SinglePairs (65 ms)
[----------] 1 test from SendRecv (65 ms total)

[----------] 4 tests from Standalone
[ RUN      ] Standalone.SplitComms_RankCheck
Encountered HIP error (no ROCm-capable device is detected) at line 17 in file $TMPDIR/spack-stage/spack-stage-rccl-6.1.1-dgzuajkf2gnbmipduscm2w5ous6dyq66/spack-src/test/StandaloneTests.cpp
FAILED: Rccl::test_unit: Command exited with status 255:
..
==> [2024-08-15-16:01:39.636704] Completed testing
==> [2024-08-15-16:01:39.636936] 
========================= SUMMARY: rccl-6.1.1-dgzuajk ==========================
Rccl::test_unit .. FAILED
============================= 1 failed of 1 parts ==============================
```