### PR TITLE
openpa: change version URL to v1.0.5 archive file

### DIFF
--- a/var/spack/repos/builtin/packages/openpa/package.py
+++ b/var/spack/repos/builtin/packages/openpa/package.py
@@ -10,7 +10,7 @@ class Openpa(AutotoolsPackage):
     (and related constructs) for high performance, concurrent software"""
 
     homepage = "https://github.com/pmodels/openpa"
-    url = "https://github.com/pmodels/openpa/releases/download/v1.0.4/openpa-1.0.4.tar.gz"
+    url = "https://github.com/pmodels/openpa/releases/download/v1.0.5/openpa-1.0.5.tar.gz"
 
     license("mpich2")
 


### PR DESCRIPTION
https://github.com/pmodels/openpa/releases/tag/v1.0.5