### PR TITLE
WarpX: Python on pyAMReX

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -258,7 +258,6 @@ ci:
       - py-scipy
       - py-statsmodels
       - py-warlock
-      - py-warpx
       - raja
       - slepc
       - slurm
@@ -272,6 +271,7 @@ ci:
       - vtk
       - vtk-h
       - vtk-m
+      - warpx +python
       - zfp
       build-job:
         tags: [ "spack", "medium" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-rhel/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-rhel/spack.yaml
@@ -169,13 +169,13 @@ spack:
   # - phist               # fortran_bindings/CMakeFiles/phist_fort.dir/phist_testing.F90.o: ftn-78 ftn: ERROR in command line. The -f option has an invalid argument, "no-math-errno".
   # - plasma              # %cce conflict
   # - py-jupyterhub       # rust: ld.lld: error: relocation R_X86_64_32 cannot be used against local symbol; recompile with -fPIC'; defined in /opt/cray/pe/cce/15.0.1/cce/x86_64/lib/no_mmap.o, referenced by /opt/cray/pe/cce/15.0.1/cce/x86_64/lib/no_mmap.o:(__no_mmap_for_malloc)
-  # - py-warpx            # py-scipy: meson.build:82:0: ERROR: Unknown compiler(s): [['/home/gitlab-runner-3/builds/dWfnZWPh/0/spack/spack/lib/spack/env/cce/ftn']]
   # - quantum-espresso    # quantum-espresso: CMake Error at cmake/FindSCALAPACK.cmake:503 (message): A required library with SCALAPACK API not found.  Please specify library
   # - scr                 # scr: make[2]: *** [examples/CMakeFiles/test_ckpt_F.dir/build.make:112: examples/test_ckpt_F] Error 1: /opt/cray/pe/cce/15.0.1/binutils/x86_64/x86_64-pc-linux-gnu/bin/ld: /opt/cray/pe/mpich/8.1.25/ofi/cray/10.0/lib/libmpi_cray.so: undefined reference to `PMI_Barrier'
   # - strumpack ~slate    # strumpack: [test/CMakeFiles/test_HSS_seq.dir/build.make:117: test/test_HSS_seq] Error 1: ld.lld: error: undefined reference due to --no-allow-shlib-undefined: mpi_abort_
   # - upcxx               # upcxx: configure error: User requested --enable-ofi but I don't know how to build ofi programs for your system
   # - variorum            # variorum: /opt/cray/pe/cce/15.0.1/binutils/x86_64/x86_64-pc-linux-gnu/bin/ld: /opt/cray/pe/lib64/libpals.so.0: undefined reference to `json_array_append_new@@libjansson.so.4'
   # - xyce +mpi +shared +pymi +pymi_static_tpls ^trilinos~shylu # openblas: ftn-2307 ftn: ERROR in command line: The "-m" option must be followed by 0, 1, 2, 3 or 4.; make[2]: *** [<builtin>: spotrf2.o] Error 1; make[1]: *** [Makefile:27: lapacklib] Error 2; make: *** [Makefile:250: netlib] Error 2
+  # - warpx +python       # py-scipy: meson.build:82:0: ERROR: Unknown compiler(s): [['/home/gitlab-runner-3/builds/dWfnZWPh/0/spack/spack/lib/spack/env/cce/ftn']]
 
   cdash:
     build-group: E4S Cray

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-sles/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-sles/spack.yaml
@@ -163,13 +163,13 @@ spack:
   # - phist
   # - plasma
   # - py-jupyterhub
-  # - py-warpx
   # - quantum-espresso
   # - scr
   # - strumpack ~slate
   # - upcxx
   # - variorum
   # - xyce +mpi +shared +pymi +pymi_static_tpls ^trilinos~shylu
+  # - warpx +python
 
   cdash:
     build-group: E4S Cray SLES

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse-v2/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse-v2/spack.yaml
@@ -133,7 +133,6 @@ spack:
   - py-jupyterhub
   - py-libensemble
   - py-petsc4py
-  - py-warpx
   - qthreads scheduler=distrib
   - quantum-espresso
   - raja
@@ -157,6 +156,7 @@ spack:
   - upcxx
   # - veloc
   - wannier90
+  - warpx +python
   - xyce +mpi +shared +pymi +pymi_static_tpls
   # INCLUDED IN ECP DAV CPU
   # - adios2

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse_v1/spack.yaml
@@ -134,7 +134,6 @@ spack:
   - py-jupyterhub
   - py-libensemble
   - py-petsc4py
-  - py-warpx
   - qthreads scheduler=distrib
   - quantum-espresso
   - raja
@@ -157,6 +156,7 @@ spack:
   - umpire
   - upcxx
   - wannier90
+  - warpx +python
   - wps
   - wrf
   - xyce +mpi +shared +pymi +pymi_static_tpls

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -143,12 +143,11 @@ spack:
   - precice
   - pruners-ninja
   - pumi
-  - py-amrex
+  - py-amrex ~ipo                   # oneAPI 2024.2.0 builds do not support IPO/LTO says CMake, even though pybind11 strongly encourages it
   - py-h5py
   - py-jupyterhub
   - py-libensemble
   - py-petsc4py
-  - py-warpx
   - qthreads scheduler=distrib
   - raja
   - rempi
@@ -189,6 +188,7 @@ spack:
   - veloc
   # - visit                                                 # visit: +visit: visit_vtk/lightweight/vtkSkewLookupTable.C:32:10: error: cannot initialize return object of type 'unsigned char *' with an rvalue of type 'const unsigned char *'
   - vtk-m ~openmp
+  - warpx +python ~python_ipo ^py-amrex ~ipo                # oneAPI 2024.2.0 builds do not support IPO/LTO says CMake, even though pybind11 strongly encourages it
   - zfp
   # --
   # - chapel ~cuda ~rocm                                    # llvm: closures.c:(.text+0x305e): undefined reference to `_intel_fast_memset'
@@ -234,10 +234,10 @@ spack:
   - sundials +sycl cxxstd=17 +examples-install
   - tau +mpi +opencl +level_zero ~pdt +syscall                # requires libdrm.so to be installed
   - upcxx +level_zero
+  - warpx ~qed +python ~python_ipo compute=sycl ^py-amrex ~ipo  # qed for https://github.com/ECP-WarpX/picsar/pull/53 prior to 24.09 release; ~ipo for oneAPI 2024.2.0 GPU builds do not support IPO/LTO says CMake, even though pybind11 strongly encourages it
   # --
   # - hpctoolkit +level_zero                                  # dyninst@12.3.0%gcc: /usr/bin/ld: libiberty/./d-demangle.c:142: undefined reference to `_intel_fast_memcpy'; can't mix intel-tbb@%oneapi with dyninst%gcc
   # - slate +sycl                                             # slate: ifx: error #10426: option '-fopenmp-targets' requires '-fiopenmp'
-  # - warpx compute=sycl                                      # warpx: fetchedamrex-src/Src/Base/AMReX_RandomEngine.H:18:10: fatal error: 'oneapi/mkl/rng/device.hpp' file not found
 
 
   ci:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
@@ -137,7 +137,6 @@ spack:
   - py-jupyterhub
   - py-libensemble
   - py-petsc4py
-  - py-warpx
   - qthreads scheduler=distrib
   - quantum-espresso
   - raja
@@ -160,6 +159,7 @@ spack:
   - umpire
   - upcxx
   - wannier90
+  - warpx +python
   - wps
   - wrf
   - xyce +mpi +shared +pymi +pymi_static_tpls

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -147,7 +147,6 @@ spack:
   - py-jupyterhub
   - py-libensemble
   - py-petsc4py
-  - py-warpx
   - qthreads scheduler=distrib
   - quantum-espresso
   - raja
@@ -190,6 +189,7 @@ spack:
   - veloc
   - visit                           # silo: https://github.com/spack/spack/issues/39538
   - vtk-m
+  - warpx +python
   - zfp
   # --
   # - geopm                           # geopm: https://github.com/spack/spack/issues/38795

--- a/var/spack/repos/builtin/packages/py-amrex/package.py
+++ b/var/spack/repos/builtin/packages/py-amrex/package.py
@@ -3,14 +3,15 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
-class PyAmrex(PythonPackage, CudaPackage, ROCmPackage):
+class PyAmrex(CMakePackage, PythonExtension, CudaPackage, ROCmPackage):
     """AMReX Python Bindings with pybind11"""
 
     homepage = "https://amrex-codes.github.io/amrex/"
-    url = "https://github.com/AMReX-Codes/pyamrex/archive/refs/tags/24.04.tar.gz"
+    url = "https://github.com/AMReX-Codes/pyamrex/archive/refs/tags/24.08.tar.gz"
     git = "https://github.com/AMReX-Codes/pyamrex.git"
 
     maintainers("ax3l", "RTSandberg", "sayerhs", "WeiqunZhang")
@@ -18,12 +19,20 @@ class PyAmrex(PythonPackage, CudaPackage, ROCmPackage):
     license("BSD-3-Clause-LBNL")
 
     version("develop", branch="development")
-    version("24.04", sha256="ab85695bb9644b702d0fc84e77205d264d27ba94999cab912c8a3212a7eb77fc")
-    version("24.03", sha256="bf85b4ad35b623278cbaae2c07e22138545dec0732d15c4ab7c53be76a7f2315")
+    version("24.08", sha256="e7179d88261f64744f392a2194ff2744fe323fe0e21d0742ba60458709a1b47e")
+    version(
+        "24.04",
+        sha256="ab85695bb9644b702d0fc84e77205d264d27ba94999cab912c8a3212a7eb77fc",
+        deprecated=True,
+    )
 
-    depends_on("cxx", type="build")  # generated
+    version(
+        "24.03",
+        sha256="bf85b4ad35b623278cbaae2c07e22138545dec0732d15c4ab7c53be76a7f2315",
+        deprecated=True,
+    )
 
-    for v in ["24.04", "24.03"]:
+    for v in ["24.08", "24.04", "24.03"]:
         depends_on("amrex@{0}".format(v), when="@{0}".format(v), type=("build", "link"))
 
     variant(
@@ -33,6 +42,9 @@ class PyAmrex(PythonPackage, CudaPackage, ROCmPackage):
         multi=True,
         description="Dimensionality",
     )
+    # Spack defaults to False but pybind11 defaults to True (and IPO is highly
+    # encouraged to be used with pybind11 projects)
+    variant("ipo", default=True, description="CMake interprocedural optimization")
     variant("mpi", default=True, description="Build with MPI support")
     variant("openmp", default=False, description="Build with OpenMP support")
     variant(
@@ -42,14 +54,21 @@ class PyAmrex(PythonPackage, CudaPackage, ROCmPackage):
         values=("single", "double"),
     )
     variant("tiny_profile", default=False, description="Enable tiny profiling")
+    variant("sycl", default=False, description="Enable SYCL backend")
 
+    extends("python")
+
+    depends_on("cxx", type="build")
+
+    depends_on("cmake@3.20:", type="build")
     depends_on("python@3.8:", type=("build", "run"))
-    depends_on("py-numpy@1.15.0:1", type=("build", "run"))
     depends_on("py-mpi4py@2.1.0:", type=("build", "run"), when="+mpi")
+    depends_on("py-numpy@1.15.0:1", type=("build", "run"))
     depends_on("py-packaging@23:", type="build")
+    depends_on("py-pip@23:", type="build")
     depends_on("py-setuptools@42:", type="build")
-    depends_on("cmake@3.20:3", type="build")
-    depends_on("py-pybind11@2.11.1:", type="link")
+    depends_on("py-pybind11@2.12.0:", type=("build", "link"))
+    depends_on("py-wheel@0.40:", type="build")
 
     # AMReX options
     #   required variants
@@ -63,53 +82,65 @@ class PyAmrex(PythonPackage, CudaPackage, ROCmPackage):
         depends_on("amrex dimensions=3")
     with when("+mpi"):
         depends_on("amrex +mpi")
+    with when("~mpi"):
+        depends_on("amrex ~mpi")
     with when("+openmp"):
         depends_on("amrex +openmp")
+    with when("~openmp"):
+        depends_on("amrex ~openmp")
     with when("+tiny_profile"):
         depends_on("amrex +tiny_profile")
     with when("+cuda"):
         depends_on("amrex +cuda")
         # todo: how to forward cuda_arch?
+    with when("~cuda"):
+        depends_on("amrex ~cuda")
     with when("+rocm"):
         depends_on("amrex +rocm")
         # todo: how to forward amdgpu_target?
+    with when("~rocm"):
+        depends_on("amrex ~rocm")
+    with when("+sycl"):
+        depends_on("amrex +sycl")
+    with when("~sycl"):
+        depends_on("amrex ~sycl")
 
     depends_on("py-pytest", type="test")
     depends_on("py-pandas", type="test")
     depends_on("py-cupy", type="test", when="+cuda")
 
+    phases = ("cmake", "build", "install", "pip_install_nodeps")
+    build_targets = ["all", "pip_wheel"]
+
     tests_src_dir = "tests/"
 
-    def setup_build_environment(self, env):
-        spec = self.spec
+    def cmake_args(self):
+        args = ["-DpyAMReX_amrex_internal=OFF", "-DpyAMReX_pybind11_internal=OFF"]
+        return args
 
-        # disable superbuilds: use external dependencies
-        env.set("AMREX_INTERNAL", "OFF")
-        env.set("PYAMREX_CCACHE", "OFF")
-        env.set("PYAMREX_IPO", "ON")
-        env.set("PYBIND11_INTERNAL", "OFF")
+    def pip_install_nodeps(self, spec, prefix):
+        """Install everything from build directory."""
+        pip = spec["python"].command
+        pip.add_default_arg("-m", "pip")
 
-        # configure to require the exact AMReX configs provided by Spack
-        env.set("AMREX_SPACEDIM", ";".join(spec.variants["dimensions"].value))
-        env.set("AMREX_MPI", "ON" if spec.satisfies("+mpi") else "OFF")
-        env.set("AMREX_OMP", "ON" if spec.satisfies("+omp") else "OFF")
-        env.set("AMREX_PRECISION", spec.variants["precision"].value.upper())
-        with when("+cuda"):
-            env.set("AMREX_GPU_BACKEND", "CUDA")
-        with when("+rocm"):
-            env.set("AMREX_GPU_BACKEND", "HIP")
-        # with when("+sycl"):
-        #     env.set("AMREX_GPU_BACKEND", "SYCL")
+        args = PythonPipBuilder.std_args(self) + [
+            f"--prefix={prefix}",
+            "--find-links=amrex-whl",
+            "amrex",
+        ]
 
-        # control build parallelism
-        env.set("CMAKE_BUILD_PARALLEL_LEVEL", make_jobs)
+        with working_dir(self.build_directory):
+            pip(*args)
+
+        # todo: from PythonPipBuilder
+        # ....execute_install_time_tests()
 
     def check(self):
         """Checks after the build phase"""
         pytest = which("pytest")
         pytest(join_path(self.stage.source_path, self.tests_src_dir))
 
-    @run_after("install")
+    @run_after("pip_install_nodeps")
     def copy_test_sources(self):
         """Copy the example test files after the package is installed to an
         install test subdirectory for use during `spack test run`."""

--- a/var/spack/repos/builtin/packages/py-picmistandard/package.py
+++ b/var/spack/repos/builtin/packages/py-picmistandard/package.py
@@ -11,25 +11,47 @@ class PyPicmistandard(PythonPackage):
 
     homepage = "https://picmi-standard.github.io"
     git = "https://github.com/picmi-standard/picmi.git"
-    pypi = "picmistandard/picmistandard-0.26.0.tar.gz"
+    pypi = "picmistandard/picmistandard-0.29.0.tar.gz"
 
     maintainers("ax3l", "dpgrote", "RemiLehe")
 
     version("master", branch="master")
+    version("0.29.0", sha256="dc0bf3ddd3635df9935ac569b3085de387150c4f8e9851897078bb12d123dde8")
+    version("0.28.0", sha256="aa980b0fb49fc3ff9c7e32b5927b3700c4660aefbf96567bac1f8c9c93bb7831")
     version("0.26.0", sha256="b22689f576d064bf0cd8f435621e912359fc2ee9347350eab845d2d36ebb62eb")
     version("0.25.0", sha256="3fe6a524822d382e52bfc9d3378249546075d28620969954c5ffb43e7968fb02")
     version("0.24.0", sha256="55a82adcc14b41eb612caf0d9e47b0e2a56ffc196a58b41fa0cc395c6924be9a")
     version("0.23.2", sha256="2853fcfaf2f226a88bb6063ae564832b7e69965294fd652cd2ac04756fa4599a")
     version("0.23.1", sha256="c7375010b7a3431b519bc0accf097f2aafdb520e2a0126f42895cb96dcc7dcf1")
-    version("0.0.22", sha256="e234a431274254b22cd70be64d6555b383d98426b2763ea0c174cf77bf4d0890")
-    version("0.0.21", sha256="930056a23ed92dac7930198f115b6248606b57403bffebce3d84579657c8d10b")
-    version("0.0.20", sha256="9c1822eaa2e4dd543b5afcfa97940516267dda3890695a6cf9c29565a41e2905")
-    version("0.0.19", sha256="4b7ba1330964fbfd515e8ea2219966957c1386e0896b92d36bd9e134afb02f5a")
-    version("0.0.18", sha256="68c208c0c54b4786e133bb13eef0dd4824998da4906285987ddee84e6d195e71")
+    version(
+        "0.0.22",
+        sha256="e234a431274254b22cd70be64d6555b383d98426b2763ea0c174cf77bf4d0890",
+        deprecated=True,
+    )
+    version(
+        "0.0.21",
+        sha256="930056a23ed92dac7930198f115b6248606b57403bffebce3d84579657c8d10b",
+        deprecated=True,
+    )
+    version(
+        "0.0.20",
+        sha256="9c1822eaa2e4dd543b5afcfa97940516267dda3890695a6cf9c29565a41e2905",
+        deprecated=True,
+    )
+    version(
+        "0.0.19",
+        sha256="4b7ba1330964fbfd515e8ea2219966957c1386e0896b92d36bd9e134afb02f5a",
+        deprecated=True,
+    )
+    version(
+        "0.0.18",
+        sha256="68c208c0c54b4786e133bb13eef0dd4824998da4906285987ddee84e6d195e71",
+        deprecated=True,
+    )
 
     depends_on("python@3.6:", type=("build", "run"))
-    depends_on("py-numpy@1.15:1", type=("build", "run"))
-    depends_on("py-scipy@1.5:1", type=("build", "run"))
+    depends_on("py-numpy@1.15:", type=("build", "run"))
+    depends_on("py-scipy@1.5:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
 
     @property

--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -61,6 +61,10 @@ class PyPybind11(CMakePackage, PythonExtension):
     depends_on("py-wheel", type="build")
     extends("python")
 
+    # Spack defaults to False but pybind11 defaults to True (and IPO is highly
+    # encouraged to be used)
+    variant("ipo", default=True, description="CMake interprocedural optimization")
+
     with when("build_system=cmake"):
         generator("ninja")
         depends_on("cmake@3.13:", type="build")

--- a/var/spack/repos/builtin/packages/py-warpx/package.py
+++ b/var/spack/repos/builtin/packages/py-warpx/package.py
@@ -7,7 +7,9 @@ from spack.package import *
 
 
 class PyWarpx(PythonPackage):
-    """WarpX is an advanced electromagnetic Particle-In-Cell code. It supports
+    """This package is deprecated. Please use `warpx +python`.
+
+    WarpX is an advanced electromagnetic Particle-In-Cell code. It supports
     many features including Perfectly-Matched Layers (PML) and mesh refinement.
     In addition, WarpX is a highly-parallel and highly-optimized code and
     features hybrid OpenMP/MPI parallelization, advanced vectorization
@@ -21,34 +23,114 @@ class PyWarpx(PythonPackage):
     url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/23.08.tar.gz"
     git = "https://github.com/ECP-WarpX/WarpX.git"
 
-    maintainers("ax3l", "dpgrote", "RemiLehe")
+    maintainers("ax3l", "dpgrote", "EZoni", "RemiLehe")
 
     tags = ["e4s", "ecp"]
 
     license("BSD-3-Clause-LBNL")
 
     # NOTE: if you update the versions here, also see warpx
-    version("develop", branch="development")
-    version("23.08", sha256="67695ff04b83d1823ea621c19488e54ebaf268532b0e5eb4ea8ad293d7ab3ddc")
-    version("23.07", sha256="511633f94c0d0205013609bde5bbf92a29c2e69f6e69b461b80d09dc25602945")
-    version("23.06", sha256="75fcac949220c44dce04de581860c9a2caa31a0eee8aa7d49455fa5fc928514b")
-    version("23.05", sha256="34306a98fdb1f5f44ab4fb92f35966bfccdcf1680a722aa773af2b59a3060d73")
-    version("23.04", sha256="e5b285c73e13a0d922eba5d83760c168d4fd388e54a519830003b2e692dab823")
-    version("23.03", sha256="e1274aaa2a2c83d599d61c6e4c426db4ed5d4c5dc61a2002715783a6c4843718")
-    version("23.02", sha256="a6c63ebc38cbd224422259a814be501ac79a3b734dab7f59500b6957cddaaac1")
-    version("23.01", sha256="e853d01c20ea00c8ddedfa82a31a11d9d91a7f418d37d7f064cf8a241ea4da0c")
-    version("22.12", sha256="96019902cd6ea444a1ae515e8853048e9074822c168021e4ec1687adc72ef062")
-    version("22.11", sha256="528f65958f2f9e60a094e54eede698e871ccefc89fa103fe2a6f22e4a059515e")
-    version("22.10", sha256="3cbbbbb4d79f806b15e81c3d0e4a4401d1d03d925154682a3060efebd3b6ca3e")
-    version("22.09", sha256="dbef1318248c86c860cc47f7e18bbb0397818e3acdfb459e48075004bdaedea3")
-    version("22.08", sha256="5ff7fd628e8bf615c1107e6c51bc55926f3ef2a076985444b889d292fecf56d4")
-    version("22.07", sha256="0286adc788136cb78033cb1678d38d36e42265bcfd3d0c361a9bcc2cfcdf241b")
-    version("22.06", sha256="e78398e215d3fc6bc5984f5d1c2ddeac290dcbc8a8e9d196e828ef6299187db9")
-    version("22.05", sha256="2fa69e6a4db36459b67bf663e8fbf56191f6c8c25dc76301dbd02a36f9b50479")
-    version("22.04", sha256="9234d12e28b323cb250d3d2cefee0b36246bd8a1d1eb48e386f41977251c028f")
-    version("22.03", sha256="ddbef760c8000f2f827dfb097ca3359e7aecbea8766bec5c3a91ee28d3641564")
-    version("22.02", sha256="d74b593d6f396e037970c5fbe10c2e5d71d557a99c97d40e4255226bc6c26e42")
-    version("22.01", sha256="e465ffadabb7dc360c63c4d3862dc08082b5b0e77923d3fb05570408748b0d28")
+    version("develop", branch="development", deprecated=True)
+    version(
+        "23.08",
+        sha256="67695ff04b83d1823ea621c19488e54ebaf268532b0e5eb4ea8ad293d7ab3ddc",
+        deprecated=True,
+    )
+    version(
+        "23.07",
+        sha256="511633f94c0d0205013609bde5bbf92a29c2e69f6e69b461b80d09dc25602945",
+        deprecated=True,
+    )
+    version(
+        "23.06",
+        sha256="75fcac949220c44dce04de581860c9a2caa31a0eee8aa7d49455fa5fc928514b",
+        deprecated=True,
+    )
+    version(
+        "23.05",
+        sha256="34306a98fdb1f5f44ab4fb92f35966bfccdcf1680a722aa773af2b59a3060d73",
+        deprecated=True,
+    )
+    version(
+        "23.04",
+        sha256="e5b285c73e13a0d922eba5d83760c168d4fd388e54a519830003b2e692dab823",
+        deprecated=True,
+    )
+    version(
+        "23.03",
+        sha256="e1274aaa2a2c83d599d61c6e4c426db4ed5d4c5dc61a2002715783a6c4843718",
+        deprecated=True,
+    )
+    version(
+        "23.02",
+        sha256="a6c63ebc38cbd224422259a814be501ac79a3b734dab7f59500b6957cddaaac1",
+        deprecated=True,
+    )
+    version(
+        "23.01",
+        sha256="e853d01c20ea00c8ddedfa82a31a11d9d91a7f418d37d7f064cf8a241ea4da0c",
+        deprecated=True,
+    )
+    version(
+        "22.12",
+        sha256="96019902cd6ea444a1ae515e8853048e9074822c168021e4ec1687adc72ef062",
+        deprecated=True,
+    )
+    version(
+        "22.11",
+        sha256="528f65958f2f9e60a094e54eede698e871ccefc89fa103fe2a6f22e4a059515e",
+        deprecated=True,
+    )
+    version(
+        "22.10",
+        sha256="3cbbbbb4d79f806b15e81c3d0e4a4401d1d03d925154682a3060efebd3b6ca3e",
+        deprecated=True,
+    )
+    version(
+        "22.09",
+        sha256="dbef1318248c86c860cc47f7e18bbb0397818e3acdfb459e48075004bdaedea3",
+        deprecated=True,
+    )
+    version(
+        "22.08",
+        sha256="5ff7fd628e8bf615c1107e6c51bc55926f3ef2a076985444b889d292fecf56d4",
+        deprecated=True,
+    )
+    version(
+        "22.07",
+        sha256="0286adc788136cb78033cb1678d38d36e42265bcfd3d0c361a9bcc2cfcdf241b",
+        deprecated=True,
+    )
+    version(
+        "22.06",
+        sha256="e78398e215d3fc6bc5984f5d1c2ddeac290dcbc8a8e9d196e828ef6299187db9",
+        deprecated=True,
+    )
+    version(
+        "22.05",
+        sha256="2fa69e6a4db36459b67bf663e8fbf56191f6c8c25dc76301dbd02a36f9b50479",
+        deprecated=True,
+    )
+    version(
+        "22.04",
+        sha256="9234d12e28b323cb250d3d2cefee0b36246bd8a1d1eb48e386f41977251c028f",
+        deprecated=True,
+    )
+    version(
+        "22.03",
+        sha256="ddbef760c8000f2f827dfb097ca3359e7aecbea8766bec5c3a91ee28d3641564",
+        deprecated=True,
+    )
+    version(
+        "22.02",
+        sha256="d74b593d6f396e037970c5fbe10c2e5d71d557a99c97d40e4255226bc6c26e42",
+        deprecated=True,
+    )
+    version(
+        "22.01",
+        sha256="e465ffadabb7dc360c63c4d3862dc08082b5b0e77923d3fb05570408748b0d28",
+        deprecated=True,
+    )
 
     depends_on("cxx", type="build")  # generated
 

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -3,62 +3,176 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
-class Warpx(CMakePackage):
+class Warpx(CMakePackage, PythonExtension):
     """WarpX is an advanced electromagnetic Particle-In-Cell code. It supports
     many features including Perfectly-Matched Layers (PML) and mesh refinement.
-    In addition, WarpX is a highly-parallel and highly-optimized code and
-    features hybrid OpenMP/MPI parallelization, advanced vectorization
-    techniques and load balancing capabilities.
 
-    For WarpX' Python bindings and PICMI input support, see the 'py-warpx' package.
+    In addition, WarpX is a highly-parallel and highly-optimized code and
+    features hybrid GPU/OpenMP/MPI parallelization and load balancing capabilities.
     """
 
     homepage = "https://ecp-warpx.github.io"
-    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/23.08.tar.gz"
+    url = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/24.08.tar.gz"
     git = "https://github.com/ECP-WarpX/WarpX.git"
 
-    maintainers("ax3l", "dpgrote", "MaxThevenet", "RemiLehe")
+    maintainers("ax3l", "dpgrote", "EZoni", "RemiLehe")
     tags = ["e4s", "ecp"]
 
     license("BSD-3-Clause-LBNL")
 
     # NOTE: if you update the versions here, also see py-warpx
     version("develop", branch="development")
-    version("23.08", sha256="67695ff04b83d1823ea621c19488e54ebaf268532b0e5eb4ea8ad293d7ab3ddc")
-    version("23.07", sha256="511633f94c0d0205013609bde5bbf92a29c2e69f6e69b461b80d09dc25602945")
-    version("23.06", sha256="75fcac949220c44dce04de581860c9a2caa31a0eee8aa7d49455fa5fc928514b")
-    version("23.05", sha256="34306a98fdb1f5f44ab4fb92f35966bfccdcf1680a722aa773af2b59a3060d73")
-    version("23.04", sha256="e5b285c73e13a0d922eba5d83760c168d4fd388e54a519830003b2e692dab823")
-    version("23.03", sha256="e1274aaa2a2c83d599d61c6e4c426db4ed5d4c5dc61a2002715783a6c4843718")
-    version("23.02", sha256="a6c63ebc38cbd224422259a814be501ac79a3b734dab7f59500b6957cddaaac1")
-    version("23.01", sha256="e853d01c20ea00c8ddedfa82a31a11d9d91a7f418d37d7f064cf8a241ea4da0c")
-    version("22.12", sha256="96019902cd6ea444a1ae515e8853048e9074822c168021e4ec1687adc72ef062")
-    version("22.11", sha256="528f65958f2f9e60a094e54eede698e871ccefc89fa103fe2a6f22e4a059515e")
-    version("22.10", sha256="3cbbbbb4d79f806b15e81c3d0e4a4401d1d03d925154682a3060efebd3b6ca3e")
-    version("22.09", sha256="dbef1318248c86c860cc47f7e18bbb0397818e3acdfb459e48075004bdaedea3")
-    version("22.08", sha256="5ff7fd628e8bf615c1107e6c51bc55926f3ef2a076985444b889d292fecf56d4")
-    version("22.07", sha256="0286adc788136cb78033cb1678d38d36e42265bcfd3d0c361a9bcc2cfcdf241b")
-    version("22.06", sha256="e78398e215d3fc6bc5984f5d1c2ddeac290dcbc8a8e9d196e828ef6299187db9")
-    version("22.05", sha256="2fa69e6a4db36459b67bf663e8fbf56191f6c8c25dc76301dbd02a36f9b50479")
-    version("22.04", sha256="9234d12e28b323cb250d3d2cefee0b36246bd8a1d1eb48e386f41977251c028f")
-    version("22.03", sha256="ddbef760c8000f2f827dfb097ca3359e7aecbea8766bec5c3a91ee28d3641564")
-    version("22.02", sha256="d74b593d6f396e037970c5fbe10c2e5d71d557a99c97d40e4255226bc6c26e42")
-    version("22.01", sha256="e465ffadabb7dc360c63c4d3862dc08082b5b0e77923d3fb05570408748b0d28")
+    version("24.08", sha256="8da1f2967f613a65a295260260aa4f081ac1d1b7c1d6987d294e02b86099df08")
+    version(
+        "23.08",
+        sha256="67695ff04b83d1823ea621c19488e54ebaf268532b0e5eb4ea8ad293d7ab3ddc",
+        deprecated=True,
+    )
+    version(
+        "23.07",
+        sha256="511633f94c0d0205013609bde5bbf92a29c2e69f6e69b461b80d09dc25602945",
+        deprecated=True,
+    )
+    version(
+        "23.06",
+        sha256="75fcac949220c44dce04de581860c9a2caa31a0eee8aa7d49455fa5fc928514b",
+        deprecated=True,
+    )
+    version(
+        "23.05",
+        sha256="34306a98fdb1f5f44ab4fb92f35966bfccdcf1680a722aa773af2b59a3060d73",
+        deprecated=True,
+    )
+    version(
+        "23.04",
+        sha256="e5b285c73e13a0d922eba5d83760c168d4fd388e54a519830003b2e692dab823",
+        deprecated=True,
+    )
+    version(
+        "23.03",
+        sha256="e1274aaa2a2c83d599d61c6e4c426db4ed5d4c5dc61a2002715783a6c4843718",
+        deprecated=True,
+    )
+    version(
+        "23.02",
+        sha256="a6c63ebc38cbd224422259a814be501ac79a3b734dab7f59500b6957cddaaac1",
+        deprecated=True,
+    )
+    version(
+        "23.01",
+        sha256="e853d01c20ea00c8ddedfa82a31a11d9d91a7f418d37d7f064cf8a241ea4da0c",
+        deprecated=True,
+    )
+    version(
+        "22.12",
+        sha256="96019902cd6ea444a1ae515e8853048e9074822c168021e4ec1687adc72ef062",
+        deprecated=True,
+    )
+    version(
+        "22.11",
+        sha256="528f65958f2f9e60a094e54eede698e871ccefc89fa103fe2a6f22e4a059515e",
+        deprecated=True,
+    )
+    version(
+        "22.10",
+        sha256="3cbbbbb4d79f806b15e81c3d0e4a4401d1d03d925154682a3060efebd3b6ca3e",
+        deprecated=True,
+    )
+    version(
+        "22.09",
+        sha256="dbef1318248c86c860cc47f7e18bbb0397818e3acdfb459e48075004bdaedea3",
+        deprecated=True,
+    )
+    version(
+        "22.08",
+        sha256="5ff7fd628e8bf615c1107e6c51bc55926f3ef2a076985444b889d292fecf56d4",
+        deprecated=True,
+    )
+    version(
+        "22.07",
+        sha256="0286adc788136cb78033cb1678d38d36e42265bcfd3d0c361a9bcc2cfcdf241b",
+        deprecated=True,
+    )
+    version(
+        "22.06",
+        sha256="e78398e215d3fc6bc5984f5d1c2ddeac290dcbc8a8e9d196e828ef6299187db9",
+        deprecated=True,
+    )
+    version(
+        "22.05",
+        sha256="2fa69e6a4db36459b67bf663e8fbf56191f6c8c25dc76301dbd02a36f9b50479",
+        deprecated=True,
+    )
+    version(
+        "22.04",
+        sha256="9234d12e28b323cb250d3d2cefee0b36246bd8a1d1eb48e386f41977251c028f",
+        deprecated=True,
+    )
+    version(
+        "22.03",
+        sha256="ddbef760c8000f2f827dfb097ca3359e7aecbea8766bec5c3a91ee28d3641564",
+        deprecated=True,
+    )
+    version(
+        "22.02",
+        sha256="d74b593d6f396e037970c5fbe10c2e5d71d557a99c97d40e4255226bc6c26e42",
+        deprecated=True,
+    )
+    version(
+        "22.01",
+        sha256="e465ffadabb7dc360c63c4d3862dc08082b5b0e77923d3fb05570408748b0d28",
+        deprecated=True,
+    )
     # 22.01+ requires C++17 or newer
-    version("21.12", sha256="847c98aac20c73d94c823378803c82be9a14139f1c14ea483757229b452ce4c1")
-    version("21.11", sha256="ce60377771c732033a77351cd3500b24b5d14b54a5adc7a622767b9251c10d0b")
-    version("21.10", sha256="d372c573f0360094d5982d64eceeb0149d6620eb75e8fdbfdc6777f3328fb454")
-    version("21.09", sha256="861a65f11846541c803564db133c8678b9e8779e69902ef1637b21399d257eab")
-    version("21.08", sha256="6128a32cfd075bc63d08eebea6d4f62d33ce0570f4fd72330a71023ceacccc86")
-    version("21.07", sha256="a8740316d813c365715f7471201499905798b50bd94950d33f1bd91478d49561")
-    version("21.06", sha256="a26039dc4061da45e779dd5002467c67a533fc08d30841e01e7abb3a890fbe30")
-    version("21.05", sha256="f835f0ae6c5702550d23191aa0bb0722f981abb1460410e3d8952bc3d945a9fc")
-    version("21.04", sha256="51d2d8b4542eada96216e8b128c0545c4b7527addc2038efebe586c32c4020a0")
-
-    depends_on("cxx", type="build")  # generated
+    version(
+        "21.12",
+        sha256="847c98aac20c73d94c823378803c82be9a14139f1c14ea483757229b452ce4c1",
+        deprecated=True,
+    )
+    version(
+        "21.11",
+        sha256="ce60377771c732033a77351cd3500b24b5d14b54a5adc7a622767b9251c10d0b",
+        deprecated=True,
+    )
+    version(
+        "21.10",
+        sha256="d372c573f0360094d5982d64eceeb0149d6620eb75e8fdbfdc6777f3328fb454",
+        deprecated=True,
+    )
+    version(
+        "21.09",
+        sha256="861a65f11846541c803564db133c8678b9e8779e69902ef1637b21399d257eab",
+        deprecated=True,
+    )
+    version(
+        "21.08",
+        sha256="6128a32cfd075bc63d08eebea6d4f62d33ce0570f4fd72330a71023ceacccc86",
+        deprecated=True,
+    )
+    version(
+        "21.07",
+        sha256="a8740316d813c365715f7471201499905798b50bd94950d33f1bd91478d49561",
+        deprecated=True,
+    )
+    version(
+        "21.06",
+        sha256="a26039dc4061da45e779dd5002467c67a533fc08d30841e01e7abb3a890fbe30",
+        deprecated=True,
+    )
+    version(
+        "21.05",
+        sha256="f835f0ae6c5702550d23191aa0bb0722f981abb1460410e3d8952bc3d945a9fc",
+        deprecated=True,
+    )
+    version(
+        "21.04",
+        sha256="51d2d8b4542eada96216e8b128c0545c4b7527addc2038efebe586c32c4020a0",
+        deprecated=True,
+    )
     # 20.01+ requires C++14 or newer
 
     variant("app", default=True, description="Build the WarpX executable application")
@@ -88,6 +202,13 @@ class Warpx(CMakePackage):
         when="@23.06:",
     )
     variant("eb", default=False, description="Embedded boundary support (in development)")
+    # Spack defaults to False but pybind11 defaults to True (and IPO is highly
+    # encouraged to be used)
+    variant(
+        "python_ipo",
+        default=True,
+        description="CMake interprocedural optimization for Python bindings (recommended)",
+    )
     variant("lib", default=True, description="Build WarpX as a shared library")
     variant("mpi", default=True, description="Enable MPI support")
     variant(
@@ -103,14 +224,22 @@ class Warpx(CMakePackage):
         multi=False,
         description="Floating point precision (single/double)",
     )
-    variant("psatd", default=True, description="Enable PSATD solver support")
+    variant("fft", default=True, description="Enable support for FFT-based solvers")
+    variant("python", default=False, description="Enable Python bindings")
     variant("qed", default=True, description="Enable QED support")
     variant("qedtablegen", default=False, description="QED table generation support")
     variant("shared", default=True, description="Build a shared version of the library")
     variant("tprof", default=True, description="Enable tiny profiling features")
 
-    depends_on("sensei@4.0.0:", when="@22.07: +sensei")
-    conflicts("+sensei", when="@:22.06", msg="WarpX supports SENSEI 4.0+ with 22.07 and newer")
+    depends_on("cxx", type="build")
+
+    for v in ["24.08", "develop"]:
+        depends_on(
+            f"amrex@{v} build_system=cmake +linear_solvers +pic +particles +shared +tiny_profile",
+            when=f"@{v}",
+            type=("build", "link"),
+        )
+        depends_on("py-amrex@{0}".format(v), when="@{0} +python".format(v), type=("build", "run"))
 
     depends_on("ascent", when="+ascent")
     depends_on("ascent +cuda", when="+ascent compute=cuda")
@@ -119,27 +248,53 @@ class Warpx(CMakePackage):
     depends_on("cmake@3.15.0:", type="build")
     depends_on("cmake@3.18.0:", type="build", when="@22.01:")
     depends_on("cmake@3.20.0:", type="build", when="@22.08:")
+    with when("dims=1"):
+        depends_on("amrex dimensions=1")
+    with when("dims=2"):
+        depends_on("amrex dimensions=2")
+    with when("dims=rz"):
+        depends_on("amrex dimensions=2")
+    with when("dims=3"):
+        depends_on("amrex dimensions=3")
+    with when("+eb"):
+        depends_on("amrex +eb")
     depends_on("mpi", when="+mpi")
+    with when("+mpi"):
+        depends_on("amrex +mpi")
+        depends_on("py-amrex +mpi", when="+python")
+    with when("~mpi"):
+        depends_on("amrex ~mpi")
+        depends_on("py-amrex ~mpi", when="~python")
+    with when("precision=single"):
+        depends_on("amrex precision=single")
+    with when("precision=double"):
+        depends_on("amrex precision=double")
+    depends_on("py-pybind11@2.12.0:", when="@24.04: +python", type=("build", "link"))
+    depends_on("sensei@4.0.0:", when="@22.07: +sensei")
     with when("compute=cuda"):
+        depends_on("amrex +cuda")
         depends_on("cuda@9.2.88:")
         depends_on("cuda@11.0:", when="@22.01:")
     with when("compute=hip"):
-        depends_on("rocfft", when="+psatd")
+        depends_on("amrex +rocm")
+        depends_on("rocfft", when="+fft")
         depends_on("rocprim")
         depends_on("rocrand")
     with when("compute=noacc"):
-        with when("+psatd"):
+        depends_on("amrex ~cuda ~openmp ~rocm ~sycl")
+        with when("+fft"):
             depends_on("fftw@3: ~mpi", when="~mpi")
             depends_on("fftw@3: +mpi", when="+mpi")
             depends_on("pkgconfig", type="build")
     with when("compute=omp"):
+        depends_on("amrex +openmp")
         depends_on("llvm-openmp", when="%apple-clang")
-        with when("+psatd"):
+        with when("+fft"):
             depends_on("fftw@3: +openmp")
             depends_on("fftw ~mpi", when="~mpi")
             depends_on("fftw +mpi", when="+mpi")
             depends_on("pkgconfig", type="build")
-    with when("+psatd dims=rz"):
+    with when("+fft dims=rz"):
         depends_on("lapackpp")
         depends_on("blaspp")
         depends_on("blaspp +cuda", when="compute=cuda")
@@ -150,13 +305,30 @@ class Warpx(CMakePackage):
         depends_on("openpmd-api ~mpi", when="~mpi")
         depends_on("openpmd-api +mpi", when="+mpi")
 
+    # Python bindings
+    # note: in Spack, we only need the cmake package, not py-cmake
+    with when("+python"):
+        extends("python")
+        depends_on("python@3.8:", type=("build", "run"))
+        depends_on("py-numpy@1.15.0:", type=("build", "run"))
+        depends_on("py-mpi4py@2.1.0:", type=("build", "run"), when="+mpi")
+        depends_on("py-periodictable@1.5:1", type=("build", "run"))
+        depends_on("py-picmistandard@0.28.0", type=("build", "run"), when="@23.11:24.07")
+        depends_on("py-picmistandard@0.29.0", type=("build", "run"), when="@24.08:")
+        depends_on("py-pip@23:", type="build")
+        depends_on("py-setuptools@42:", type="build")
+        depends_on("py-pybind11@2.12.0:", type=("build", "link"))
+        depends_on("py-wheel@0.40:", type="build")
+
+    conflicts("+python", when="@:24.04", msg="Python bindings only supported in 24.04+")
     conflicts("dims=1", when="@:21.12", msg="WarpX 1D support starts in 22.01+")
     conflicts("~qed +qedtablegen", msg="WarpX PICSAR QED table generation needs +qed")
     conflicts(
         "compute=sycl",
-        when="+psatd",
-        msg="WarpX spectral solvers are not yet tested with SYCL " '(use "warpx ~psatd")',
+        when="+fft",
+        msg="WarpX spectral solvers are not yet tested with SYCL " '(use "warpx ~fft")',
     )
+    conflicts("+sensei", when="@:22.06", msg="WarpX supports SENSEI 4.0+ with 22.07 and newer")
 
     # The symbolic aliases for our +lib target were missing in the install
     # location
@@ -210,10 +382,16 @@ class Warpx(CMakePackage):
             self.define_from_variant("WarpX_MPI_THREAD_MULTIPLE", "mpithreadmultiple"),
             self.define_from_variant("WarpX_OPENPMD", "openpmd"),
             "-DWarpX_PRECISION={0}".format(spec.variants["precision"].value.upper()),
-            self.define_from_variant("WarpX_PSATD", "psatd"),
+            self.define_from_variant("WarpX_PYTHON", "python"),
             self.define_from_variant("WarpX_QED", "qed"),
             self.define_from_variant("WarpX_QED_TABLE_GEN", "qedtablegen"),
         ]
+
+        if spec.satisfies("@24.08:"):
+            args.append("-DWarpX_amrex_internal=OFF")
+            args.append(self.define_from_variant("WarpX_FFT", "fft"))
+        else:
+            args.append(self.define_from_variant("WarpX_PSATD", "fft"))
 
         # FindMPI needs an extra hint sometimes, particularly on cray systems
         if "+mpi" in spec:
@@ -222,6 +400,12 @@ class Warpx(CMakePackage):
 
         if "+openpmd" in spec:
             args.append("-DWarpX_openpmd_internal=OFF")
+
+        if "+python" in spec:
+            if spec.satisfies("@24.08:"):
+                args.append("-DWarpX_pyamrex_internal=OFF")
+                args.append("-DWarpX_pybind11_internal=OFF")
+                args.append(self.define_from_variant("WarpX_PYTHON_IPO", "python_ipo"))
 
         # Work-around for SENSEI 4.0: wrong install location for CMake config
         #   https://github.com/SENSEI-insitu/SENSEI/issues/79
@@ -233,6 +417,28 @@ class Warpx(CMakePackage):
         args.append(self.define(ccache_var, False))
 
         return args
+
+    phases = ("cmake", "build", "install", "pip_install_nodeps")
+    build_targets = ["all"]
+    with when("+python"):
+        build_targets += ["pip_wheel"]
+
+    def pip_install_nodeps(self, spec, prefix):
+        """Install everything from build directory."""
+        pip = spec["python"].command
+        pip.add_default_arg("-m", "pip")
+
+        args = PythonPipBuilder.std_args(self) + [
+            f"--prefix={prefix}",
+            "--find-links=warpx-whl",
+            "pywarpx",
+        ]
+
+        with working_dir(self.build_directory):
+            pip(*args)
+
+        # todo: from PythonPipBuilder
+        # ....execute_install_time_tests()
 
     @property
     def libs(self):
@@ -294,7 +500,14 @@ class Warpx(CMakePackage):
         install test subdirectory for use during `spack test run`."""
         cache_extra_test_sources(self, [self.examples_src_dir])
 
+    # TODO: remove installed static ablastr lib
+    #       (if build as static lib - Spack default is shared)
+    #    @run_after("install")
+    #    def remove_unwanted_library(self):
+    #        ... libablastr_{1d,2d,3d,rz}.a ...
+
     def run_warpx(self, dim):
+        """Perform smoke tests on the installed package."""
         if "+app" not in self.spec:
             raise SkipTest("Package must be installed with +app")
         if dim not in self.spec.variants["dims"].value:


### PR DESCRIPTION
Long overdue update for WarpX: in 2024, we updated our Python bindings to rely on the new pyAMReX package. This deprecates the old `py-warpx` package and adds a new dependency and variant to WarpX. This update also removes any vendored (auto-downloaded) packages from our superbuilds (i.e., AMReX) and properly uses external dependencies now.

Add @EZoni to WarpX package co-maintainers.

Also deprecates old versions that we will not continue to support.

- [x] needs 24.08 releases for
  - https://github.com/AMReX-Codes/pyamrex/pull/339
  - https://github.com/ECP-WarpX/WarpX/pull/5055
  - https://github.com/ECP-WarpX/impactx/pull/644