### PR TITLE
BF: Update approach to disabling OpenMP CUDA target in LLVM

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -860,6 +860,7 @@ class Llvm(CMakePackage, CudaPackage, CompilerPackage):
                     define("CUDA_SDK_ROOT_DIR", "IGNORE"),
                     define("CUDA_NVCC_EXECUTABLE", "IGNORE"),
                     define("LIBOMPTARGET_DEP_CUDA_DRIVER_LIBRARIES", "IGNORE"),
+                    define("LIBOMPTARGET_BUILD_CUDA_PLUGIN", "FALSE"),
                 ]
             )
 

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -854,15 +854,19 @@ class Llvm(CMakePackage, CudaPackage, CompilerPackage):
                 cmake_args.append(define("LIBOMPTARGET_NVPTX_ENABLE_BCLIB", True))
         else:
             # still build libomptarget but disable cuda
-            cmake_args.extend(
-                [
-                    define("CUDA_TOOLKIT_ROOT_DIR", "IGNORE"),
-                    define("CUDA_SDK_ROOT_DIR", "IGNORE"),
-                    define("CUDA_NVCC_EXECUTABLE", "IGNORE"),
-                    define("LIBOMPTARGET_DEP_CUDA_DRIVER_LIBRARIES", "IGNORE"),
-                    define("LIBOMPTARGET_BUILD_CUDA_PLUGIN", "FALSE"),
-                ]
-            )
+            if spec.satisfies("@:13"):
+                cmake_args.extend(
+                    [
+                        define("CUDA_TOOLKIT_ROOT_DIR", "IGNORE"),
+                        define("CUDA_SDK_ROOT_DIR", "IGNORE"),
+                        define("CUDA_NVCC_EXECUTABLE", "IGNORE"),
+                        define("LIBOMPTARGET_DEP_CUDA_DRIVER_LIBRARIES", "IGNORE"),
+                    ]
+                )
+            elif spec.satisfies("@14:18"):
+                cmake_args += define("LIBOMPTARGET_BUILD_CUDA_PLUGIN", False)
+            elif spec.satisfies("@19:"):
+                cmake_args += define("LIBOMPTARGET_PLUGINS_TO_BUILD", "host")
 
         cmake_args.append(from_variant("LIBOMPTARGET_ENABLE_DEBUG", "libomptarget_debug"))
 

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -864,9 +864,9 @@ class Llvm(CMakePackage, CudaPackage, CompilerPackage):
                     ]
                 )
             elif spec.satisfies("@14:18"):
-                cmake_args += define("LIBOMPTARGET_BUILD_CUDA_PLUGIN", False)
+                cmake_args.append(define("LIBOMPTARGET_BUILD_CUDA_PLUGIN", False))
             elif spec.satisfies("@19:"):
-                cmake_args += define("LIBOMPTARGET_PLUGINS_TO_BUILD", "host")
+                cmake_args.append(define("LIBOMPTARGET_PLUGINS_TO_BUILD", "host"))
 
         cmake_args.append(from_variant("LIBOMPTARGET_ENABLE_DEBUG", "libomptarget_debug"))
 


### PR DESCRIPTION
At some point (at least in 17.0.6) the previous approach stopped working, so if CUDA was auto detected it would try to build the CUDA target even if the "cuda" variant was disabled in spack.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
