### PR TITLE
Spack Windows: Update file paths for mirror test

### DIFF
--- a/lib/spack/spack/test/cmd/blame.py
+++ b/lib/spack/spack/test/cmd/blame.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 import pytest
 
 from llnl.util.filesystem import working_dir
@@ -33,11 +35,10 @@ def test_blame_by_percent(mock_packages):
     assert "EMAIL" in out
 
 
-@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_blame_file(mock_packages):
     """Sanity check the blame command to make sure it works."""
     with working_dir(spack.paths.prefix):
-        out = blame("bin/spack")
+        out = blame(os.path.join("bin", "spack"))
     assert "LAST_COMMIT" in out
     assert "AUTHOR" in out
     assert "EMAIL" in out

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -20,10 +20,7 @@ from spack.stage import Stage
 from spack.util.executable import which
 from spack.util.spack_yaml import SpackYAMLError
 
-pytestmark = [
-    pytest.mark.not_on_windows("does not run on windows"),
-    pytest.mark.usefixtures("mutable_config", "mutable_mock_repo"),
-]
+pytestmark = [pytest.mark.usefixtures("mutable_config", "mutable_mock_repo")]
 
 # paths in repos that shouldn't be in the mirror tarballs.
 exclude = [".hg", ".git", ".svn"]
@@ -270,8 +267,8 @@ def test_mirror_cache_symlinks(tmpdir):
     """Confirm that the cosmetic symlink created in the mirror cache (which may
     be relative) targets the storage path correctly.
     """
-    cosmetic_path = "zlib/zlib-1.2.11.tar.gz"
-    global_path = "_source-cache/archive/c3/c3e5.tar.gz"
+    cosmetic_path = os.path.join("zlib", "zlib-1.2.11.tar.gz")
+    global_path = os.path.join("_source-cache", "archive", "c3", "c3e5.tar.gz")
     cache = spack.caches.MirrorCache(str(tmpdir), False)
     reference = spack.mirror.MirrorReference(cosmetic_path, global_path)
 


### PR DESCRIPTION
Updates files paths in some tests to support multiplatform

- Specifically changed mirror test and the cmd test for blame
