### PR TITLE
py-lightning: setuptools required at run-time

### DIFF
--- a/var/spack/repos/builtin/packages/py-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-lightning/package.py
@@ -79,6 +79,9 @@ class PyLightning(PythonPackage):
         # depends_on("py-pytorch-lightning", when="@2:")
 
         # Historical requirements
+        # https://github.com/Lightning-AI/pytorch-lightning/pull/20081
+        depends_on("py-setuptools", when="@:2.3")
+
         with when("@:2.0"):
             depends_on("py-jinja2@:4")
             depends_on("py-arrow@1.2:2")

--- a/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
@@ -51,7 +51,8 @@ class PyPytorchLightning(PythonPackage):
 
     # src/pytorch_lightning/__setup__.py
     depends_on("python@3.8:", when="@2:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
+    # https://github.com/Lightning-AI/pytorch-lightning/pull/20081
+    depends_on("py-setuptools", type=("build", "run"))
 
     # requirements/pytorch/base.txt
     depends_on("py-numpy@1.17.2:", when="@1.3:", type=("build", "run"))


### PR DESCRIPTION
Until https://github.com/Lightning-AI/pytorch-lightning/pull/20081 was merged, lightning actually required setuptools at run-time and we weren't correctly modeling this.