### PR TITLE
libgcrypt: conflict with darwin when @1.11.0

### DIFF
--- a/var/spack/repos/builtin/packages/libgcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libgcrypt/package.py
@@ -41,6 +41,8 @@ class Libgcrypt(AutotoolsPackage):
     depends_on("libgpg-error@1.27:", when="@1.9:")
     depends_on("libgpg-error@1.49:", when="@1.11:")
 
+    conflicts("platform=darwin", when="@1.11.0")
+
     def flag_handler(self, name, flags):
         # We should not inject optimization flags through the wrapper, because
         # the jitter entropy code should never be compiled with optimization

--- a/var/spack/repos/builtin/packages/libgcrypt/package.py
+++ b/var/spack/repos/builtin/packages/libgcrypt/package.py
@@ -41,6 +41,7 @@ class Libgcrypt(AutotoolsPackage):
     depends_on("libgpg-error@1.27:", when="@1.9:")
     depends_on("libgpg-error@1.49:", when="@1.11:")
 
+    # See  https://dev.gnupg.org/T7170
     conflicts("platform=darwin", when="@1.11.0")
 
     def flag_handler(self, name, flags):


### PR DESCRIPTION
Follow on to https://github.com/spack/spack/pull/44915#issuecomment-2224146548.

Building `gnupg@2.4.5 ^libgcrypt@1.11.0` on MacOS I get the following error.

```
alec@laptop:~/s/s/spack (develop)
> gpg --list-keys
dyld[11908]: missing symbol called
zsh: abort      gpg --list-keys
```

`gnupg@2.4.5 ^libgcrypt@1.10.3` appears to link and execute correctly.

I attempted patching `libgcrypt@1.11.0` as suggested by https://dev.gnupg.org/T7170, but got the same result. I think something else is going on here, but for now we need a working `gnupg`.

We should track https://github.com/Homebrew/homebrew-core/pull/175100 to see if brew finds another solution.