### PR TITLE
tamaas: added version 2.8.0 and petsc variant

### DIFF
--- a/var/spack/repos/builtin/packages/tamaas/package.py
+++ b/var/spack/repos/builtin/packages/tamaas/package.py
@@ -35,6 +35,7 @@ class Tamaas(SConsPackage):
         when="+python",
         description="Enables extra Scipy-based nonlinear solvers",
     )
+    variant("petsc", default=False, when="@2.8.0:", description="Additional PETSc solvers")
 
     # Python 3.6 causes unicode issues with scons
     depends_on("python@3.7:", type="build", when="~python")
@@ -62,6 +63,8 @@ class Tamaas(SConsPackage):
         depends_on("py-wheel", type="build")
         depends_on("py-pip", type="build")
 
+    depends_on("petsc", type="build", when="+petsc")
+
     def build_args(self, spec, prefix):
         args = [
             "build_type=release",
@@ -83,6 +86,9 @@ class Tamaas(SConsPackage):
 
         if spec.satisfies("+python"):
             args += ["PYBIND11_ROOT={}".format(spec["py-pybind11"].prefix)]
+
+        if spec.satisfies("+petsc"):
+            args += ["PETSC_ROOT={}".format(spec["petsc"].prefix), "use_petsc=True"]
 
         return args
 

--- a/var/spack/repos/builtin/packages/tamaas/package.py
+++ b/var/spack/repos/builtin/packages/tamaas/package.py
@@ -17,6 +17,7 @@ class Tamaas(SConsPackage):
     maintainers("prs513rosewood")
 
     version("master", branch="master")
+    version("2.8.0", sha256="8ec49bf484a622c0554452416d1804eefbd545da79ced352f2ea63bbd17c83f0")
     version("2.7.1", sha256="d7de6db3f5532bb9c8ab7e8cca1cdb5c133050dd5720249dde07027b0d41641f")
     version("2.7.0", sha256="bc5717c1ead621cb9c18a073fdafbe8778fd160ad23d80c98283445d79066579")
     version("2.6.0", sha256="4aafa0f727f43afc6ae45705ae80cf113a6a95e728bdf536c22b3b39be87f153")


### PR DESCRIPTION
This PR adds a new release and a petsc variant for Tamaas. I've found that archive checksums associated with tags on gitlab can change over time, hopefully this one is stable. Cheers!

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
