### PR TITLE
Do not initialize previous store state in "use_store"

### DIFF
--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -371,7 +371,6 @@ def use_store(
         data.update(extra_data)
 
     # Swap the store with the one just constructed and return it
-    ensure_singleton_created()
     spack.config.CONFIG.push_scope(
         spack.config.InternalConfigScope(name=scope_name, data={"config": {"install_tree": data}})
     )


### PR DESCRIPTION
fixes #45247 

The `use_store` context manager is used to swap the value of a global variable (`spack.store.STORE`), while keeping another global variable consistent (`spack.config.CONFIG`).

When doing that it tries to evaluate the previous value of the store, if that was not done already. This is wrong, since the configuration might be in an "intermediate" state that was never meant to trigger side effects.

Remove that operation, and add a unit test to prevent regressions.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
