### PR TITLE
Run minimization of weights only on known targets

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1155,7 +1155,10 @@ target_weight(Target, 0)
 node_target_weight(PackageNode, MinWeight)
  :- attr("node", PackageNode),
     attr("node_target", PackageNode, Target),
+    target(Target),
     MinWeight = #min { Weight : target_weight(Target, Weight) }.
+
+:- attr("node_target", PackageNode, Target), not node_target_weight(PackageNode, _).
 
 % compatibility rules for targets among nodes
 node_target_match(ParentNode, DependencyNode)


### PR DESCRIPTION
fixes #45030 

This prevents excessive output from clingo of the kind:
```
.../spack/lib/spack/spack/solver/concretize.lp:1640:5-11: info: tuple ignored:
  #sup@2
```
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
