### PR TITLE
bigdft : add v1.9.5

### DIFF
--- a/var/spack/repos/builtin/packages/bigdft-atlab/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-atlab/package.py
@@ -14,6 +14,7 @@ class BigdftAtlab(AutotoolsPackage):
     git = "https://gitlab.com/l_sim/bigdft-suite.git"
 
     version("develop", branch="devel")
+    version("1.9.5", sha256="5fe51e92bb746569207295feebbcd154ce4f1b364a3981bace75c45e983b2741")
     version("1.9.4", sha256="fa22115e6353e553d2277bf054eb73a4710e92dfeb1ed9c5bf245337187f393d")
     version("1.9.3", sha256="f5f3da95d7552219f94366b4d2a524b2beac988fb2921673a65a128f9a8f0489")
     version("1.9.2", sha256="dc9e49b68f122a9886fa0ef09970f62e7ba21bb9ab1b86be9b7d7e22ed8fbe0f")
@@ -38,7 +39,7 @@ class BigdftAtlab(AutotoolsPackage):
     depends_on("mpi", when="+mpi")
     depends_on("openbabel", when="+openbabel")
 
-    for vers in ["1.9.0", "1.9.1", "1.9.2", "1.9.3", "1.9.4", "develop"]:
+    for vers in ["1.9.0", "1.9.1", "1.9.2", "1.9.3", "1.9.4", "1.9.5", "develop"]:
         depends_on(f"bigdft-futile@{vers}", when=f"@{vers}")
 
     configure_directory = "atlab"

--- a/var/spack/repos/builtin/packages/bigdft-core/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-core/package.py
@@ -15,6 +15,9 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
     git = "https://gitlab.com/l_sim/bigdft-suite.git"
 
     version("develop", branch="devel")
+    version("1.9.5", sha256="5fe51e92bb746569207295feebbcd154ce4f1b364a3981bace75c45e983b2741")
+    version("1.9.4", sha256="fa22115e6353e553d2277bf054eb73a4710e92dfeb1ed9c5bf245337187f393d")
+    # version("1.9.3", sha256="f5f3da95d7552219f94366b4d2a524b2beac988fb2921673a65a128f9a8f0489") # broken
     version("1.9.2", sha256="dc9e49b68f122a9886fa0ef09970f62e7ba21bb9ab1b86be9b7d7e22ed8fbe0f")
     version("1.9.1", sha256="3c334da26d2a201b572579fc1a7f8caad1cbf971e848a3e10d83bc4dc8c82e41")
     version("1.9.0", sha256="4500e505f5a29d213f678a91d00a10fef9dc00860ea4b3edf9280f33ed0d1ac8")
@@ -34,6 +37,7 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
+    depends_on("pkg-config", type="build")
 
     depends_on("python@3.0:", type=("build", "run"))
 
@@ -48,11 +52,14 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
     depends_on("libxc@:4.3.4", when="@1.9.2:")
     depends_on("libxc@:4.3.4", when="@develop")
 
-    for vers in ["1.9.0", "1.9.1", "1.9.2", "develop"]:
+    for vers in ["1.9.0", "1.9.1", "1.9.2", "1.9.4", "1.9.5", "develop"]:
         depends_on(f"bigdft-futile@{vers}", when=f"@{vers}")
         depends_on(f"bigdft-chess@{vers}", when=f"@{vers}")
         depends_on(f"bigdft-psolver@{vers}", when=f"@{vers}")
         depends_on(f"bigdft-libabinit@{vers}", when=f"@{vers}")
+
+    for vers in ["1.9.3", "1.9.4", "1.9.5", "develop"]:
+        depends_on(f"bigdft-liborbs@{vers}", when=f"@{vers}")
 
     configure_directory = "bigdft"
 

--- a/var/spack/repos/builtin/packages/bigdft-futile/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-futile/package.py
@@ -18,6 +18,7 @@ class BigdftFutile(AutotoolsPackage, CudaPackage):
     git = "https://gitlab.com/l_sim/bigdft-suite.git"
 
     version("develop", branch="devel")
+    version("1.9.5", sha256="5fe51e92bb746569207295feebbcd154ce4f1b364a3981bace75c45e983b2741")
     version("1.9.4", sha256="fa22115e6353e553d2277bf054eb73a4710e92dfeb1ed9c5bf245337187f393d")
     version("1.9.3", sha256="f5f3da95d7552219f94366b4d2a524b2beac988fb2921673a65a128f9a8f0489")
     version("1.9.2", sha256="dc9e49b68f122a9886fa0ef09970f62e7ba21bb9ab1b86be9b7d7e22ed8fbe0f")

--- a/var/spack/repos/builtin/packages/bigdft-libabinit/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-libabinit/package.py
@@ -17,6 +17,9 @@ class BigdftLibabinit(AutotoolsPackage):
     git = "https://gitlab.com/l_sim/bigdft-suite.git"
 
     version("develop", branch="devel")
+    version("1.9.5", sha256="5fe51e92bb746569207295feebbcd154ce4f1b364a3981bace75c45e983b2741")
+    version("1.9.4", sha256="fa22115e6353e553d2277bf054eb73a4710e92dfeb1ed9c5bf245337187f393d")
+    version("1.9.3", sha256="f5f3da95d7552219f94366b4d2a524b2beac988fb2921673a65a128f9a8f0489")
     version("1.9.2", sha256="dc9e49b68f122a9886fa0ef09970f62e7ba21bb9ab1b86be9b7d7e22ed8fbe0f")
     version("1.9.1", sha256="3c334da26d2a201b572579fc1a7f8caad1cbf971e848a3e10d83bc4dc8c82e41")
     version("1.9.0", sha256="4500e505f5a29d213f678a91d00a10fef9dc00860ea4b3edf9280f33ed0d1ac8")
@@ -40,7 +43,7 @@ class BigdftLibabinit(AutotoolsPackage):
     depends_on("libxc@:2.2.2", when="@:1.9.1")
     depends_on("libxc@:4.3.4", when="@1.9.1:")
 
-    for vers in ["1.9.0", "1.9.1", "1.9.2", "develop"]:
+    for vers in ["1.9.0", "1.9.1", "1.9.2", "1.9.3", "1.9.4", "1.9.5", "develop"]:
         depends_on(f"bigdft-futile@{vers}", when=f"@{vers}")
 
     configure_directory = "libABINIT"

--- a/var/spack/repos/builtin/packages/bigdft-liborbs/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-liborbs/package.py
@@ -6,63 +6,43 @@
 from spack.package import *
 
 
-class BigdftChess(AutotoolsPackage, CudaPackage):
-    """BigDFT-CheSS: A module for performing Fermi Operator Expansions
-    via Chebyshev Polynomials."""
+class BigdftLiborbs(AutotoolsPackage, CudaPackage):
+    """BigDFT-liborbs: a library for orbital treatments in DFT."""
 
     homepage = "https://bigdft.org/"
-    url = "https://gitlab.com/l_sim/bigdft-suite/-/archive/1.9.2/bigdft-suite-1.9.2.tar.gz"
+    url = "https://gitlab.com/l_sim/bigdft-suite/-/archive/1.9.5/bigdft-suite-1.9.5.tar.gz"
     git = "https://gitlab.com/l_sim/bigdft-suite.git"
 
     version("develop", branch="devel")
     version("1.9.5", sha256="5fe51e92bb746569207295feebbcd154ce4f1b364a3981bace75c45e983b2741")
     version("1.9.4", sha256="fa22115e6353e553d2277bf054eb73a4710e92dfeb1ed9c5bf245337187f393d")
     version("1.9.3", sha256="f5f3da95d7552219f94366b4d2a524b2beac988fb2921673a65a128f9a8f0489")
-    version("1.9.2", sha256="dc9e49b68f122a9886fa0ef09970f62e7ba21bb9ab1b86be9b7d7e22ed8fbe0f")
-    version("1.9.1", sha256="3c334da26d2a201b572579fc1a7f8caad1cbf971e848a3e10d83bc4dc8c82e41")
-    version("1.9.0", sha256="4500e505f5a29d213f678a91d00a10fef9dc00860ea4b3edf9280f33ed0d1ac8")
-
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
 
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("scalapack", default=True, description="Enable SCALAPACK support")
-    variant("ntpoly", default=True, description="Option to use NTPoly")
     variant(
         "shared", default=True, description="Build shared libraries"
     )  # Not default in bigdft, but is typically the default expectation
-    # variant('minpack', default=False,  description='Give the link-line for MINPACK')
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
-    depends_on("pkg-config", type="build")
-
-    depends_on("python@3.0:", type=("build", "run"))
 
     depends_on("blas")
     depends_on("lapack")
-    depends_on("py-pyyaml")
     depends_on("mpi", when="+mpi")
     depends_on("scalapack", when="+scalapack")
 
-    depends_on("ntpoly@:2", when="@:1.9.3")
-    depends_on("ntpoly@3:", when="@1.9.4:")
-
-    for vers in ["1.9.0", "1.9.1", "1.9.2", "1.9.3", "1.9.4", "1.9.5", "develop"]:
+    for vers in ["1.9.3", "1.9.4", "1.9.5", "develop"]:
         depends_on(f"bigdft-futile@{vers}", when=f"@{vers}")
         depends_on(f"bigdft-atlab@{vers}", when=f"@{vers}")
 
-    configure_directory = "chess"
+    configure_directory = "liborbs"
 
     def configure_args(self):
         spec = self.spec
         prefix = self.prefix
-
-        python_version = spec["python"].version.up_to(2)
-        pyyaml = join_path(spec["py-pyyaml"].prefix.lib, f"python{python_version}")
 
         openmp_flag = []
         if "+openmp" in spec:
@@ -76,15 +56,11 @@ class BigdftChess(AutotoolsPackage, CudaPackage):
 
         args = [
             f"FCFLAGS={' '.join(openmp_flag)}",
-            f"LDFLAGS={' '.join(linalg)}",
             f"--with-ext-linalg={' '.join(linalg)}",
-            f"--with-pyyaml-path={pyyaml}",
-            f"--with-futile-libs={spec['bigdft-futile'].libs.ld_flags}",
-            f"--with-futile-incs={spec['bigdft-futile'].headers.include_flags}",
             f"--with-moduledir={prefix.include}",
             f"--prefix={prefix}",
-            "--without-etsf-io",
         ]
+
         if spec.satisfies("+shared"):
             args.append("--enable-dynamic-libraries")
 
@@ -102,22 +78,16 @@ class BigdftChess(AutotoolsPackage, CudaPackage):
         else:
             args.append("--without-openmp")
 
-        args.append(f"--with-atlab-libs={spec['bigdft-atlab'].prefix.lib}")
-
         if "+cuda" in spec:
+            args.append("--enable-opencl")
+            args.append(f"--with-ocl-path={spec['cuda'].prefix}")
             args.append("--enable-cuda-gpu")
             args.append(f"--with-cuda-path={spec['cuda'].prefix}")
             args.append(f"--with-cuda-libs={spec['cuda'].libs.link_flags}")
-
-        if "+minpack" in spec:
-            args.append("--with-minpack")
-
-        if spec.satisfies("+ntpoly"):
-            args.append("--enable-ntpoly")
 
         return args
 
     @property
     def libs(self):
         shared = "+shared" in self.spec
-        return find_libraries("libCheSS-*", root=self.prefix, shared=shared, recursive=True)
+        return find_libraries("libbigdft-*", root=self.prefix, shared=shared, recursive=True)

--- a/var/spack/repos/builtin/packages/bigdft-psolver/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-psolver/package.py
@@ -16,6 +16,7 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
     git = "https://gitlab.com/l_sim/bigdft-suite.git"
 
     version("develop", branch="devel")
+    version("1.9.5", sha256="5fe51e92bb746569207295feebbcd154ce4f1b364a3981bace75c45e983b2741")
     version("1.9.4", sha256="fa22115e6353e553d2277bf054eb73a4710e92dfeb1ed9c5bf245337187f393d")
     version("1.9.3", sha256="f5f3da95d7552219f94366b4d2a524b2beac988fb2921673a65a128f9a8f0489")
     version("1.9.2", sha256="dc9e49b68f122a9886fa0ef09970f62e7ba21bb9ab1b86be9b7d7e22ed8fbe0f")
@@ -36,6 +37,7 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
+    depends_on("pkg-config", type="build")
 
     depends_on("python@3.0:", type=("build", "run"))
 
@@ -45,7 +47,7 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
     depends_on("mpi", when="+mpi")
     depends_on("scalapack", when="+scalapack")
 
-    for vers in ["1.9.0", "1.9.1", "1.9.2", "1.9.3", "1.9.4", "develop"]:
+    for vers in ["1.9.0", "1.9.1", "1.9.2", "1.9.3", "1.9.4", "1.9.5", "develop"]:
         depends_on(f"bigdft-futile@{vers}", when=f"@{vers}")
         depends_on(f"bigdft-atlab@{vers}", when=f"@{vers}")
 

--- a/var/spack/repos/builtin/packages/bigdft-spred/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-spred/package.py
@@ -15,6 +15,9 @@ class BigdftSpred(AutotoolsPackage):
     git = "https://gitlab.com/l_sim/bigdft-suite.git"
 
     version("develop", branch="devel")
+    version("1.9.5", sha256="5fe51e92bb746569207295feebbcd154ce4f1b364a3981bace75c45e983b2741")
+    version("1.9.4", sha256="fa22115e6353e553d2277bf054eb73a4710e92dfeb1ed9c5bf245337187f393d")
+    # version("1.9.3", sha256="f5f3da95d7552219f94366b4d2a524b2beac988fb2921673a65a128f9a8f0489") # bigdft-core broken
     version("1.9.2", sha256="dc9e49b68f122a9886fa0ef09970f62e7ba21bb9ab1b86be9b7d7e22ed8fbe0f")
     version("1.9.1", sha256="3c334da26d2a201b572579fc1a7f8caad1cbf971e848a3e10d83bc4dc8c82e41")
     version("1.9.0", sha256="4500e505f5a29d213f678a91d00a10fef9dc00860ea4b3edf9280f33ed0d1ac8")
@@ -26,6 +29,7 @@ class BigdftSpred(AutotoolsPackage):
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
+    depends_on("pkg-config", type="build")
 
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
@@ -42,7 +46,7 @@ class BigdftSpred(AutotoolsPackage):
     depends_on("mpi", when="+mpi")
     depends_on("scalapack", when="+scalapack")
 
-    for vers in ["1.9.0", "1.9.1", "1.9.2", "develop"]:
+    for vers in ["1.9.0", "1.9.1", "1.9.2", "1.9.4", "1.9.5", "develop"]:
         depends_on(f"bigdft-futile@{vers}", when=f"@{vers}")
         depends_on(f"bigdft-psolver@{vers}", when=f"@{vers}")
         depends_on(f"bigdft-core@{vers}", when=f"@{vers}")

--- a/var/spack/repos/builtin/packages/bigdft-suite/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-suite/package.py
@@ -15,13 +15,16 @@ class BigdftSuite(BundlePackage):
     git = "https://gitlab.com/l_sim/bigdft-suite.git"
 
     version("develop", branch="devel")
+    version("1.9.5")
+    version("1.9.4")
+    # version("1.9.3") # bigdft-core broken
     version("1.9.2")
     version("1.9.1")
     version("1.9.0")
 
     depends_on("python@3.0:", type=("run"))
 
-    for vers in ["1.9.0", "1.9.1", "1.9.2", "develop"]:
+    for vers in ["1.9.0", "1.9.1", "1.9.2", "1.9.4", "1.9.5", "develop"]:
         depends_on("bigdft-futile@{0}".format(vers), when="@{0}".format(vers))
         depends_on("bigdft-psolver@{0}".format(vers), when="@{0}".format(vers))
         depends_on("bigdft-libabinit@{0}".format(vers), when="@{0}".format(vers))

--- a/var/spack/repos/builtin/packages/libgain/package.py
+++ b/var/spack/repos/builtin/packages/libgain/package.py
@@ -24,6 +24,10 @@ class Libgain(AutotoolsPackage):
 
     depends_on("fortran", type="build")  # generated
 
+    def flag_handler(self, name, flags):
+        flags.append(self.compiler.fc_pic_flag)
+        return (None, None, flags)
+
     @property
     def libs(self):
         shared = "+shared" in self.spec

--- a/var/spack/repos/builtin/packages/ntpoly/package.py
+++ b/var/spack/repos/builtin/packages/ntpoly/package.py
@@ -21,6 +21,7 @@ class Ntpoly(CMakePackage):
     license("MIT")
 
     version("3.1.0", sha256="71cd6827f20c68e384555dbcfc85422d0690e21d21d7b5d4f7375544a2755271")
+    version("2.7.2", sha256="968571a42e93827617c40c4ceefd29be52447c176309f801bb5a454527fe5f49")
     version("2.3.1", sha256="af8c7690321607fbdee9671b9cb3acbed945148014e0541435858cf82bfd887e")
 
     depends_on("cxx", type="build")  # generated

--- a/var/spack/repos/builtin/packages/py-bigdft/bad_string.patch
+++ b/var/spack/repos/builtin/packages/py-bigdft/bad_string.patch
@@ -1,0 +1,22 @@
+From e12f8694bb40ef4f0d984df67bf2c6e7c6d0a81b Mon Sep 17 00:00:00 2001
+From: Luigi Genovese <luigi.genovese@cea.fr>
+Date: Wed, 19 Jun 2024 13:51:33 +0200
+Subject: [PATCH] type corrected
+
+---
+ PyBigDFT/BigDFT/BioQM.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/PyBigDFT/BigDFT/BioQM.py b/PyBigDFT/BigDFT/BioQM.py
+index 6bb2985fc..20323c535 100644
+--- a/PyBigDFT/BigDFT/BioQM.py
++++ b/PyBigDFT/BigDFT/BioQM.py
+@@ -1,4 +1,4 @@
+-long_ra"""A module to define typical operations that can be done on biological systems
++"""A module to define typical operations that can be done on biological systems
+ 
+ """
+ from BigDFT.Systems import System
+-- 
+2.45.1
+

--- a/var/spack/repos/builtin/packages/py-bigdft/package.py
+++ b/var/spack/repos/builtin/packages/py-bigdft/package.py
@@ -15,6 +15,9 @@ class PyBigdft(PythonPackage):
     git = "https://gitlab.com/l_sim/bigdft-suite.git"
 
     version("develop", branch="devel")
+    version("1.9.5", sha256="5fe51e92bb746569207295feebbcd154ce4f1b364a3981bace75c45e983b2741")
+    version("1.9.4", sha256="fa22115e6353e553d2277bf054eb73a4710e92dfeb1ed9c5bf245337187f393d")
+    version("1.9.3", sha256="f5f3da95d7552219f94366b4d2a524b2beac988fb2921673a65a128f9a8f0489")
     version("1.9.2", sha256="dc9e49b68f122a9886fa0ef09970f62e7ba21bb9ab1b86be9b7d7e22ed8fbe0f")
     version("1.9.1", sha256="3c334da26d2a201b572579fc1a7f8caad1cbf971e848a3e10d83bc4dc8c82e41")
     version("1.9.0", sha256="4500e505f5a29d213f678a91d00a10fef9dc00860ea4b3edf9280f33ed0d1ac8")
@@ -23,11 +26,22 @@ class PyBigdft(PythonPackage):
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
-    depends_on("python@3.0:", type=("build", "run"))
-    depends_on("py-numpy")
-    depends_on("py-setuptools")
+    depends_on("python@3.0:", type=("build", "run"), when="@:1.9.3")
+    depends_on("python@3.6:", type=("build", "run"), when="@1.9.4:")
 
-    for vers in ["1.9.0", "1.9.1", "1.9.2", "develop"]:
+    depends_on("py-setuptools")
+    depends_on("py-hatchling")
+
+    depends_on("py-numpy", type=("run"))
+    depends_on("py-ase", when="@1.9.3", type=("run"))
+    depends_on("py-matplotlib", when="@1.9.3", type=("run"))
+
+    depends_on("py-scipy", when="@1.9.4:", type=("run"))
+
+    for vers in ["1.9.0", "1.9.1", "1.9.2", "1.9.3", "1.9.4", "1.9.5", "develop"]:
         depends_on("bigdft-futile@{0}".format(vers), type="run", when="@{0}".format(vers))
 
     build_directory = "PyBigDFT"
+
+    patch("pyproject_fix.patch", when="@1.9.4")  # based on cb66dd0c4
+    patch("bad_string.patch", when="@1.9.5")

--- a/var/spack/repos/builtin/packages/py-bigdft/pyproject_fix.patch
+++ b/var/spack/repos/builtin/packages/py-bigdft/pyproject_fix.patch
@@ -1,0 +1,9 @@
+--- a/PyBigDFT/pyproject.toml
++++ b/PyBigDFT/pyproject.toml
+@@ -33,3 +33,6 @@ viz = ["py3dmol", "matplotlib"]
+
+ [tool.hatch.build]
+ artifacts = ["*.xyz", "psppar*.yaml", "postprocess.yaml"]
++
++[tool.hatch.build.targets.wheel]
++packages = ["BigDFT"]


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

- Bump all the packages from BigDFT to 1.9.5.
- Add `bigdft-liborbs` as a dependency - it wasn't needed before?
- Removes `ntpoly` variant from `bigdft-chess`. I believe this is a hard-dependency now.
- Compiles `libgain` with `-fPIC`
