### PR TITLE
warpx: fix openpmd backward compat bound

### DIFF
--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -144,6 +144,7 @@ class Warpx(CMakePackage):
     with when("+openpmd"):
         depends_on("openpmd-api@0.13.1:")
         depends_on("openpmd-api@0.14.2:", when="@21.09:")
+        depends_on("openpmd-api@0.15.1:", when="@23.05:")
         depends_on("openpmd-api ~mpi", when="~mpi")
         depends_on("openpmd-api +mpi", when="+mpi")
 


### PR DESCRIPTION
Extracted from #45217.

Separate PR so it's easier to revert 45217 if necessary.