### PR TITLE
giflib: remove convert call in doc generation

### DIFF
--- a/var/spack/repos/builtin/packages/giflib/package.py
+++ b/var/spack/repos/builtin/packages/giflib/package.py
@@ -73,3 +73,6 @@ class Giflib(MakefilePackage, SourceforgePackage):
         if spec.satisfies("@:5.2.0"):
             configure = Executable("./configure")
             configure("--prefix={0}".format(prefix))
+        # remove call to convert in doc makefile
+        with working_dir("doc"):
+            filter_file("^.*convert.*-resize.*$", "", "Makefile")


### PR DESCRIPTION
There's a step in the doc generation that calls the convert command from ImageMagick to resize a gif, this is the only thing that this package would need ImageMagick for; so I opted to remove it instead of add that as a dep.
