### PR TITLE
flux-pmix: Sets appropriately FLUX_PMI_CLIENT_SEARCHPATH  variable

### DIFF
--- a/var/spack/repos/builtin/packages/flux-pmix/package.py
+++ b/var/spack/repos/builtin/packages/flux-pmix/package.py
@@ -57,8 +57,8 @@ class FluxPmix(AutotoolsPackage):
 
     def setup_run_environment(self, env):
         spec = self.spec
-        env.prepend_path("FLUX_SHELL_RC_PATH", join_path(self.prefix, "etc/flux/shell/lua.d"))
+        env.prepend_path("FLUX_SHELL_RC_PATH", join_path(self.prefix.etc, "flux/shell/lua.d"))
         if spec.satisfies("@0.3.0:"):
             env.prepend_path(
-                "FLUX_PMI_CLIENT_SEARCHPATH", join_path(self.prefix, "flux/upmi/plugins")
+                "FLUX_PMI_CLIENT_SEARCHPATH", join_path(self.prefix.lib, "flux/upmi/plugins")
             )


### PR DESCRIPTION
Modifies flux-pmix to point to the correct location of `pmix.so`. 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
