### PR TITLE
go: remove invalid deps

### DIFF
--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -25,8 +25,6 @@ class GoBootstrap(Package):
 
     maintainers("alecbcs")
 
-    depends_on("git", type=("build", "link", "run"))
-
     executables = ["^go$"]
 
     # List binary go releases for multiple operating systems and architectures.
@@ -79,10 +77,6 @@ class GoBootstrap(Package):
         if os in go_releases[release] and target in go_releases[release][os]:
             version(release, sha256=go_releases[release][os][target])
             provides(f"go-or-gccgo-bootstrap@{release}", when=f"@{release}")
-
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
 
     # When the user adds a go compiler using ``spack external find go-bootstrap``,
     # this lets us get the version for packages.yaml. Then, the solver can avoid

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -51,6 +51,8 @@ class Go(Package):
     provides("golang")
 
     depends_on("bash", type="build")
+    depends_on("sed", type="build")
+    depends_on("grep", type="build")
     depends_on("go-or-gccgo-bootstrap", type="build")
     depends_on("go-or-gccgo-bootstrap@1.17.13:", type="build", when="@1.20:")
     depends_on("go-or-gccgo-bootstrap@1.20.6:", type="build", when="@1.22:")

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -48,14 +48,9 @@ class Go(Package):
     version("1.21.6", sha256="124926a62e45f78daabbaedb9c011d97633186a33c238ffc1e25320c02046248")
     version("1.21.5", sha256="285cbbdf4b6e6e62ed58f370f3f6d8c30825d6e56c5853c66d3c23bcdb09db19")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
-
     provides("golang")
 
     depends_on("bash", type="build")
-    depends_on("git", type="run")
     depends_on("go-or-gccgo-bootstrap", type="build")
     depends_on("go-or-gccgo-bootstrap@1.17.13:", type="build", when="@1.20:")
     depends_on("go-or-gccgo-bootstrap@1.20.6:", type="build", when="@1.22:")


### PR DESCRIPTION
- Remove generated dependencies from Go and Go-Bootstrap. 
- Remove `git` since it is only required in the go documentation since `git` is how the source is downloaded. 
- Add `grep` and `sed` since both are used in the build and may not be present on a system.