### PR TITLE
py-cryptography: add v41.0.7, v42.0.8; py-setuptools-rust: add v1.7.0, v1.8.1, v1.9.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-cryptography/package.py
+++ b/var/spack/repos/builtin/packages/py-cryptography/package.py
@@ -15,6 +15,8 @@ class PyCryptography(PythonPackage):
 
     license("Apache-2.0")
 
+    version("42.0.8", sha256="8d09d05439ce7baa8e9e95b07ec5b6c886f548deb7e0f69ef25f64b3bce842f2")
+    version("41.0.7", sha256="13f93ce9bea8016c253b34afc6bd6a75993e5c40672ed5405a9c832f0d4a00bc")
     version("41.0.3", sha256="6d192741113ef5e30d89dcb5b956ef4e1578f304708701b8b73d38e3e1461f34")
     version("40.0.2", sha256="c33c0d32b8594fa647d2e01dbccc303478e16fdd7cf98652d5b3ed11aa5e5c99")
     version("38.0.1", sha256="1db3d807a14931fa317f96435695d9ec386be7b84b618cc61cfa5d08b0ae33d7")
@@ -39,6 +41,7 @@ class PyCryptography(PythonPackage):
     depends_on("py-setuptools@40.6:", when="@2.7:36", type="build")
     depends_on("py-setuptools@18.5:", when="@2.2:2.6", type="build")
     depends_on("py-setuptools@11.3:", when="@:2.1", type="build")
+    depends_on("py-setuptools-rust@1.7.0:", when="@42:", type=("build", "run"))
     depends_on("py-setuptools-rust@0.11.4:", when="@3.4.2:", type="build")
     depends_on("py-setuptools-rust@0.11.4:", when="@3.4:3.4.1", type=("build", "run"))
     depends_on("rust@1.56:", when="@41:", type="build")

--- a/var/spack/repos/builtin/packages/py-setuptools-rust/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools-rust/package.py
@@ -14,6 +14,9 @@ class PySetuptoolsRust(PythonPackage):
 
     license("MIT")
 
+    version("1.9.0", sha256="704df0948f2e4cc60c2596ad6e840ea679f4f43e58ed4ad0c1857807240eab96")
+    version("1.8.1", sha256="94b1dd5d5308b3138d5b933c3a2b55e6d6927d1a22632e509fcea9ddd0f7e486")
+    version("1.7.0", sha256="c7100999948235a38ae7e555fe199aa66c253dc384b125f5d85473bf81eae3a3")
     version("1.6.0", sha256="c86e734deac330597998bfbc08da45187e6b27837e23bd91eadb320732392262")
     version("1.5.1", sha256="0e05e456645d59429cb1021370aede73c0760e9360bbfdaaefb5bced530eb9d7")
     version("1.4.1", sha256="18ff850831f58ee21d5783825c99fad632da21e47645e9427fd7dec048029e76")
@@ -23,12 +26,14 @@ class PySetuptoolsRust(PythonPackage):
     depends_on("py-setuptools@62.4:", when="@1.4.0:", type=("build", "run"))
     depends_on("py-setuptools@46.1:", type=("build", "run"))
     depends_on("py-setuptools", type=("build", "run"))
+    depends_on("py-setuptools-scm", when="@1.7.0:", type=("build", "run"))
     depends_on("py-semantic-version@2.8.2:2", when="@1.2.0:", type=("build", "run"))
     depends_on("py-semantic-version@2.6.0:", type=("build", "run"))
-    depends_on("py-typing-extensions@3.7.4.3:", when="@1.2.0:", type=("build", "run"))
+    depends_on("py-tomli@1.2.1:", when="^python@:3.10", type=("build", "run"))
     depends_on("rust", type="run")
 
     # Historical dependencies
+    depends_on("py-typing-extensions@3.7.4.3:", when="@1.2.0:1.7.0", type=("build", "run"))
     depends_on("py-setuptools-scm+toml@6.3.2:", when="@1.2.0:1.4.1", type="build")
     depends_on("py-setuptools-scm+toml@3.4.3:", when="@:1.1", type="build")
     depends_on("py-toml@0.9.0:", type=("build", "run"), when="@0.12.1")


### PR DESCRIPTION
This PR adds two new versions of `py-cryptography`, and the required `py-setuptools-rust` updates for them.

Test builds:
```
[+] x5uljap py-cryptography@41.0.7  [+] znmglcx py-cryptography@42.0.8  [+] etjhlae py-setuptools-rust@1.7.0  [+] ghhrouc py-setuptools-rust@1.8.1  [+] obfouam py-setuptools-rust@1.9.0
```