### PR TITLE
rust: rework external find to require both rustc and cargo

### DIFF
--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -107,7 +107,7 @@ class Rust(Package):
         rustc_candidates = list(x for x in exes_in_prefix if os.path.basename(x) == "rustc")
         cargo_candidates = list(x for x in exes_in_prefix if os.path.basename(x) == "cargo")
         # Both rustc and cargo must be present
-        if not rustc_candidates or not cargo_candidates:
+        if not (rustc_candidates and cargo_candidates):
             return
         for rustc in rustc_candidates:
             output = Executable(rustc)("--version", output=str, error=str)

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -104,8 +104,8 @@ class Rust(Package):
 
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
-        rustc_candidates = list(x for x in exes_in_prefix if os.path.basename(x) == "rustc")
-        cargo_candidates = list(x for x in exes_in_prefix if os.path.basename(x) == "cargo")
+        rustc_candidates = [x for x in exes_in_prefix if os.path.basename(x) == "rustc"]
+        cargo_candidates = [x for x in exes_in_prefix if os.path.basename(x) == "cargo"]
         # Both rustc and cargo must be present
         if not (rustc_candidates and cargo_candidates):
             return

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -104,10 +104,8 @@ class Rust(Package):
 
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
-        rustc_candidates = list(x for x in exes_in_prefix
-                                if os.path.basename(x) == "rustc")
-        cargo_candidates = list(x for x in exes_in_prefix
-                                if os.path.basename(x) == "cargo")
+        rustc_candidates = list(x for x in exes_in_prefix if os.path.basename(x) == "rustc")
+        cargo_candidates = list(x for x in exes_in_prefix if os.path.basename(x) == "cargo")
         # Both rustc and cargo must be present
         if not rustc_candidates or not cargo_candidates:
             return
@@ -115,9 +113,7 @@ class Rust(Package):
             output = Executable(rustc)("--version", output=str, error=str)
             match = re.match(r"rustc (\S+)", output)
             version_str = match.group(1) if match else None
-            return Spec.from_detection(
-                "rust@{0}".format(version_str)
-            ) if version_str else None
+            return Spec.from_detection("rust@{0}".format(version_str)) if version_str else None
 
     def setup_dependent_package(self, module, dependent_spec):
         module.cargo = Executable(os.path.join(self.spec.prefix.bin, "cargo"))

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -109,11 +109,11 @@ class Rust(Package):
         # Both rustc and cargo must be present
         if not (rustc_candidates and cargo_candidates):
             return
-        for rustc in rustc_candidates:
-            output = Executable(rustc)("--version", output=str, error=str)
-            match = re.match(r"rustc (\S+)", output)
-            version_str = match.group(1) if match else None
-            return Spec.from_detection("rust@{0}".format(version_str)) if version_str else None
+        output = Executable(rustc_candidates[0])("--version", output=str, error=str)
+        match = re.match(r"rustc (\S+)", output)
+        if match:
+            version_str = match.group(1)
+            return Spec.from_detection(f"rust@{version_str}")
 
     def setup_dependent_package(self, module, dependent_spec):
         module.cargo = Executable(os.path.join(self.spec.prefix.bin, "cargo"))

--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -117,7 +117,7 @@ class Rust(Package):
             version_str = match.group(1) if match else None
             return Spec.from_detection(
                 "rust@{0}".format(version_str)
-            )
+            ) if version_str else None
 
     def setup_dependent_package(self, module, dependent_spec):
         module.cargo = Executable(os.path.join(self.spec.prefix.bin, "cargo"))


### PR DESCRIPTION
In spack, `rust` installs both `rustc` and `cargo`. In most distributions, `cargo` is a separate package, though.

This PR modifies external detection to require *both* `rustc` and `cargo`. Until now it was just one of either. This seems to require the custom detection workflow, https://spack.readthedocs.io/en/latest/packaging_guide.html#custom-detection-workflow.