### PR TITLE
qt-*: add v6.7.1, v6.7.2

### DIFF
--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -93,6 +93,8 @@ class QtBase(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.7.2", sha256="96b96e4fd0fc306502ed8b94a34cfa0bacc8a25d43c2e958dd6772b28f6b0e42")
+    version("6.7.1", sha256="d6950597ce1fc2e1cf374c3aa70c2d72532bb74150e9853d7127af86a8a6c7b4")
     version("6.7.0", sha256="e17f016ec987092423e86d732c0f9786124598877fa00970fd806da113c02ca5")
     version("6.6.3", sha256="11abfcae323d295129f644f1828064e05af7d64d49edb0e00bfb8e8cb9691259")
     version("6.6.2", sha256="2cbdc4791c5838fddb1ce7ee693b165bb4acf3f81acd6c1bf9e56413b25050df")

--- a/var/spack/repos/builtin/packages/qt-declarative/package.py
+++ b/var/spack/repos/builtin/packages/qt-declarative/package.py
@@ -16,6 +16,8 @@ class QtDeclarative(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.7.2", sha256="3b91d1b75f22221f39b93647d73c9fe7fc4b9c8d45ff0cec402626eab15d8dd8")
+    version("6.7.1", sha256="fdf4099cbced3ce56e5151122ae1eb924886492f9fc2eb6a353d60a23e8fde14")
     version("6.7.0", sha256="dc3fec16cbe0f706b2b6114e5dbb884269543f2d679a0a3a63b4f686156adf73")
     version("6.6.3", sha256="34757cb6f2960aaee2849ff9fabe3ec06499fb07f41ab4f9351ce602b85bebd3")
     version("6.6.2", sha256="6079545e04e7704fcab8e50687e1ee9df8d3bb43288a1602ff0f142e640a5b51")

--- a/var/spack/repos/builtin/packages/qt-quick3d/package.py
+++ b/var/spack/repos/builtin/packages/qt-quick3d/package.py
@@ -16,6 +16,8 @@ class QtQuick3d(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.7.2", sha256="67021658cb10bfa6d969c4219d599ab2f4775d08fb4ae56da17fbec305088b55")
+    version("6.7.1", sha256="c889b70305da7595df87c3bd062474787b722ab216bc2e6226e33fae3ec3459d")
     version("6.7.0", sha256="3adb7cc458c21a4642e7138cc0ca12934cd7075633d06c46c689f65718c8ba73")
     version("6.6.3", sha256="6990aac1434722cdf54fa6b3ebbae6d2af4d4dc89d6d33a2146c83c49be59ecb")
     version("6.6.2", sha256="b99184a1ef912219374b2bb9a9b1899c1c55694736bc3185e2306db16c66b4ab")

--- a/var/spack/repos/builtin/packages/qt-quicktimeline/package.py
+++ b/var/spack/repos/builtin/packages/qt-quicktimeline/package.py
@@ -16,6 +16,8 @@ class QtQuicktimeline(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.7.2", sha256="ad5370a3b193c5d30a824a1def0608e12fb735c4ff20ae55161a6f6e202e091d")
+    version("6.7.1", sha256="98766368b4650eef583f76d257573e6785938b89c9eb2fc57577f4c199b12a1f")
     version("6.7.0", sha256="9c8d953d4dfbe2a42dbbd88c26b4b01f6caab4d525ec01eb66edc71e9ee39172")
     version("6.6.3", sha256="6dccea9ebc8a6507ffb046cada1dd339b8187923bb74b938f8ccdcb0a5590095")
     version("6.6.2", sha256="76e629f019f6bdd9d46efbde2704dfe104231879ad60eebd81d9585250aa618b")

--- a/var/spack/repos/builtin/packages/qt-shadertools/package.py
+++ b/var/spack/repos/builtin/packages/qt-shadertools/package.py
@@ -18,6 +18,8 @@ class QtShadertools(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.7.2", sha256="256ff8199d9f6e97bef57f602c5fa7a32e3c7588bf7efe39e412b810c7ed4ffc")
+    version("6.7.1", sha256="56cfba20c7e8f7a218cac68d237a63ea342ac9a67211ecdf3c7152572632448b")
     version("6.7.0", sha256="82d9ef04a470db30e90253ddc72fcbc8fea2ecad419a735ecf64bb965560197f")
     version("6.6.3", sha256="a0e44248cec9011166794da895952cc1f98ddbfa77180174da925c5f749391a8")
     version("6.6.2", sha256="c6d06a660779990f69b8b2e21eb01ada784f9144cbaeb718ee0da01c33ce2141")

--- a/var/spack/repos/builtin/packages/qt-svg/package.py
+++ b/var/spack/repos/builtin/packages/qt-svg/package.py
@@ -18,6 +18,8 @@ class QtSvg(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.7.2", sha256="c0e140bbba4157cdbbe0e84ddbb4e238b87aa0ca7b870bad283d8cf2a7fa74b6")
+    version("6.7.1", sha256="55134e1242305e554610bf1a77e71d3d15104ee819a3c87def1f8b736d5ecf0e")
     version("6.7.0", sha256="ea023d11c710145786833649c3dc79dd099110fc3a9756a8a88699eeaac949f1")
     version("6.6.3", sha256="75006cc389ac86f2705dbb93a8c278b6b96c6cfa46304640312367e61740170d")
     version("6.6.2", sha256="4228731a00899ee27bf59e131fa0d3e9105d3f479ac27bc8cfd458e409398ec0")


### PR DESCRIPTION
This PR adds versions 6.7.1 and 6.7.2 of the Qt ecosystem. No build system changes needed (the vendored version of harfbuzz was [increased](https://github.com/qt/qtbase/commit/cff114273278d65dcdb80409e3f1013138acaa12) from 8.3 to 8.5 with 6.7.2, but there's no indication this is a change of requirement).