### PR TITLE
libmesh updates

### DIFF
--- a/var/spack/repos/builtin/packages/libmesh/package.py
+++ b/var/spack/repos/builtin/packages/libmesh/package.py
@@ -120,6 +120,7 @@ class Libmesh(AutotoolsPackage):
         values=("none", "pthreads", "tbb", "openmp"),
         multi=False,
     )
+    variant("shared", default=True,  description="Enables the build of shared libraries")
 
     conflicts(
         "+metaphysicl",
@@ -150,6 +151,11 @@ class Libmesh(AutotoolsPackage):
 
     def configure_args(self):
         options = []
+
+        if "+shared" in self.spec:
+          options.extend(["--enable-shared", "--disable-static"])
+        else:
+          options.extend(["--disable-shared", "--enable-static"])
 
         # GLIBCXX debugging is not, by default, supported by other libraries,
         # so unconditionally disable it for libmesh

--- a/var/spack/repos/builtin/packages/libmesh/package.py
+++ b/var/spack/repos/builtin/packages/libmesh/package.py
@@ -141,8 +141,8 @@ class Libmesh(AutotoolsPackage):
     depends_on("mpi", when="+slepc")
     # compilation dependencies depend on perl
     depends_on("perl")
-    depends_on("petsc+mpi", when="+mpi")
-    depends_on("petsc+metis", when="+metis")
+    depends_on("petsc+mpi", when="+petsc+mpi")
+    depends_on("petsc+metis", when="+petsc+metis")
     depends_on("slepc", when="+slepc")
     depends_on("petsc", when="+petsc")
     depends_on("tbb", when="threads=tbb")

--- a/var/spack/repos/builtin/packages/libmesh/package.py
+++ b/var/spack/repos/builtin/packages/libmesh/package.py
@@ -20,6 +20,7 @@ class Libmesh(AutotoolsPackage):
 
     version("master", branch="master", submodules=True)
 
+    version("1.7.1", sha256="0387d62773cf92356eb128ba92f767e56c298d78f4b97446e68bf288da1eb6b4")
     version("1.4.1", sha256="67eb7d5a9c954d891ca1386b70f138333a87a141d9c44213449ca6be69a66414")
     version("1.4.0", sha256="62d7fce89096c950d1b38908484856ea63df57754b64cde6582e7ac407c8c81d")
     version("1.3.1", sha256="638cf30d05c249315760f16cbae4804964db8857a04d5e640f37617bef17ab0f")

--- a/var/spack/repos/builtin/packages/libmesh/package.py
+++ b/var/spack/repos/builtin/packages/libmesh/package.py
@@ -120,7 +120,7 @@ class Libmesh(AutotoolsPackage):
         values=("none", "pthreads", "tbb", "openmp"),
         multi=False,
     )
-    variant("shared", default=True,  description="Enables the build of shared libraries")
+    variant("shared", default=True, description="Enables the build of shared libraries")
 
     conflicts(
         "+metaphysicl",
@@ -153,9 +153,9 @@ class Libmesh(AutotoolsPackage):
         options = []
 
         if "+shared" in self.spec:
-          options.extend(["--enable-shared", "--disable-static"])
+            options.extend(["--enable-shared", "--disable-static"])
         else:
-          options.extend(["--disable-shared", "--enable-static"])
+            options.extend(["--disable-shared", "--enable-static"])
 
         # GLIBCXX debugging is not, by default, supported by other libraries,
         # so unconditionally disable it for libmesh


### PR DESCRIPTION
- adds missing v1.7.1 release
- fixes petsc being pulled in when only `+mpi` or +`metis` is given
- adds a shared variant to chose between shared and static build