### PR TITLE
py-gevent: @:23.9.0 conflicts with py-cython@3.0.10 (#45257)

### DIFF
--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -41,6 +41,8 @@ class PyGevent(PythonPackage):
 
     # https://github.com/gevent/gevent/issues/1599
     conflicts("^py-cython@3:", when="@:20.5.0")
+    # https://github.com/gevent/gevent/issues/2031
+    conflicts("^py-cython@3.0.10", msg="py-gevent fails to build when using cython@3.0.10")
 
     # Deprecated compiler options. upstream PR: https://github.com/gevent/gevent/pull/1896
     patch("icc.patch", when="@:21.12.0 %intel")

--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -42,7 +42,11 @@ class PyGevent(PythonPackage):
     # https://github.com/gevent/gevent/issues/1599
     conflicts("^py-cython@3:", when="@:20.5.0")
     # https://github.com/gevent/gevent/issues/2031
-    conflicts("^py-cython@3.0.10", when="@:23.9.0", msg="py-gevent fails to build when using cython@3.0.10")
+    conflicts(
+        "^py-cython@3.0.10",
+        when="@:23.9.0",
+        msg="py-gevent fails to build when using cython@3.0.10"
+    )
 
     # Deprecated compiler options. upstream PR: https://github.com/gevent/gevent/pull/1896
     patch("icc.patch", when="@:21.12.0 %intel")

--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -45,7 +45,7 @@ class PyGevent(PythonPackage):
     conflicts(
         "^py-cython@3.0.10",
         when="@:23.9.0",
-        msg="py-gevent fails to build when using cython@3.0.10"
+        msg="py-gevent fails to build when using cython@3.0.10",
     )
 
     # Deprecated compiler options. upstream PR: https://github.com/gevent/gevent/pull/1896

--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -42,7 +42,7 @@ class PyGevent(PythonPackage):
     # https://github.com/gevent/gevent/issues/1599
     conflicts("^py-cython@3:", when="@:20.5.0")
     # https://github.com/gevent/gevent/issues/2031
-    conflicts("^py-cython@3.0.10", msg="py-gevent fails to build when using cython@3.0.10")
+    conflicts("^py-cython@3.0.10", when="@:23.9.1", msg="py-gevent fails to build when using cython@3.0.10")
 
     # Deprecated compiler options. upstream PR: https://github.com/gevent/gevent/pull/1896
     patch("icc.patch", when="@:21.12.0 %intel")

--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -42,7 +42,7 @@ class PyGevent(PythonPackage):
     # https://github.com/gevent/gevent/issues/1599
     conflicts("^py-cython@3:", when="@:20.5.0")
     # https://github.com/gevent/gevent/issues/2031
-    conflicts("^py-cython@3.0.10", when="@:23.9.1", msg="py-gevent fails to build when using cython@3.0.10")
+    conflicts("^py-cython@3.0.10", when="@:23.9.0", msg="py-gevent fails to build when using cython@3.0.10")
 
     # Deprecated compiler options. upstream PR: https://github.com/gevent/gevent/pull/1896
     patch("icc.patch", when="@:21.12.0 %intel")


### PR DESCRIPTION
Adds a conflict statement for py-cython@3.0.10, which fails to build py-gevent.
@spackbot fix style
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
