### PR TITLE
Add language depends_on on several packages

### DIFF
--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -28,8 +28,6 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     version("2.1.0", tag="v2.1.0", commit="533df139c267e2a93c268dfe68f9aec55de11cf0")
     version("2.0.0", tag="v2.0.0", commit="5ceebadf75d1c98999ea9e9446926722d061ec22")
 
-    depends_on("cxx", type="build")  # generated
-
     variant(
         "backend",
         default="mpi",
@@ -51,6 +49,9 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
     )
     variant("kokkos", default=False, description="Enable Kokkos Support")
     variant("openmp", default=False, description="Enable OpenMP Support")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     # All Current FleCSI Releases
     for level in ("low", "medium", "high"):

--- a/var/spack/repos/builtin/packages/lammps-example-plugin/package.py
+++ b/var/spack/repos/builtin/packages/lammps-example-plugin/package.py
@@ -43,9 +43,7 @@ class LammpsExamplePlugin(CMakePackage):
         preferred=True,
     )
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("cxx", type="build")
 
     def url_for_version(self, version):
         split_ver = str(version).split(".")

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -369,9 +369,15 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
         deprecated=True,
     )
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("cxx", type="build")
+
+    # mdi, scafacos, ml-quip, qmmm require C, but not available in Spack
+    for c_pkg in ("adios", "atc", "awpmd", "ml-pod", "electrode", "kim", "h5md", "tools"):
+        depends_on("c", type="build", when=f"+{c_pkg}")
+
+    # scafacos, ml-quip require Fortran, but not available in Spack
+    for fc_pkg in ("kim",):
+        depends_on("fortran", type="build", when=f"+{fc_pkg}")
 
     stable_versions = {
         "20230802.3",

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -602,6 +602,7 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
         values=("double", "mixed", "single"),
         multi=False,
     )
+    variant("tools", default=False, description="Build LAMMPS tools (msi2lmp, binary2txt, chain)")
 
     depends_on("cmake@3.16:", when="@20231121:")
     depends_on("mpi", when="+mpi")
@@ -780,6 +781,7 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
             self.define_from_variant("LAMMPS_EXCEPTIONS", "exceptions"),
             self.define_from_variant("{}_MPI".format(mpi_prefix), "mpi"),
             self.define_from_variant("BUILD_OMP", "openmp"),
+            self.define_from_variant("BUILD_TOOLS", "tools"),
             self.define("ENABLE_TESTING", self.run_tests),
             self.define("DOWNLOAD_POTENTIALS", False),
         ]

--- a/var/spack/repos/builtin/packages/ports-of-call/package.py
+++ b/var/spack/repos/builtin/packages/ports-of-call/package.py
@@ -34,7 +34,8 @@ class PortsOfCall(CMakePackage):
         deprecated=True,
     )
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")  # todo: disable cmake default?
+    depends_on("cxx", type="build")
 
     variant(
         "portability_strategy",

--- a/var/spack/repos/builtin/packages/singularity-eos/package.py
+++ b/var/spack/repos/builtin/packages/singularity-eos/package.py
@@ -34,9 +34,6 @@ class SingularityEos(CMakePackage, CudaPackage):
         deprecated=True,
     )
 
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
-
     # build with kokkos, kokkos-kernels for offloading support
     variant("kokkos", default=False, description="Enable kokkos")
     variant(
@@ -68,6 +65,10 @@ class SingularityEos(CMakePackage, CudaPackage):
     variant("spiner", default=True, description="Use Spiner")
 
     variant("closure", default=True, description="Build closure module")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build", when="+fortran")
 
     # building/testing/docs
     depends_on("cmake@3.19:", type="build")

--- a/var/spack/repos/builtin/packages/spiner/package.py
+++ b/var/spack/repos/builtin/packages/spiner/package.py
@@ -38,7 +38,8 @@ class Spiner(CMakePackage, CudaPackage):
         deprecated=True,
     )
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")  # todo: disable cmake default?
+    depends_on("cxx", type="build")
 
     # When overriding/overloading varaints, the last variant is always used, except for
     # "when" clauses. Therefore, call the whens FIRST then the non-whens.


### PR DESCRIPTION
- adds `depends_on` for the various languages needed for:
   * lammps
   * flecsi
   * ports-of-call
   * spiner
   * singularity-eos
- also adds a missing `tools` variant in the lammps spackage