### PR TITLE
Allow remapping of compiler names

### DIFF
--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -160,9 +160,7 @@ class Scorep(AutotoolsPackage):
     # handle any mapping of Spack compiler names to Score-P args
     # this should continue to exist for backward compatibility
     def clean_compiler(self, compiler):
-        renames = {
-            "cce": "cray",
-        }
+        renames = {"cce": "cray"}
         if compiler in renames:
             return renames[compiler]
         return compiler
@@ -177,7 +175,7 @@ class Scorep(AutotoolsPackage):
         ]
 
         cname = self.clean_compiler(spec.compiler.name)
-        
+
         config_args.append("--with-nocross-compiler-suite={0}".format(cname))
 
         if self.version >= Version("4.0"):

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -157,6 +157,16 @@ class Scorep(AutotoolsPackage):
             return None
         return libs.directories[0]
 
+    # handle any mapping of Spack compiler names to Score-P args
+    # this should continue to exist for backward compatibility
+    def clean_compiler(self, compiler):
+        renames = {
+            "cce": "cray",
+        }
+        if compiler in renames:
+            return renames[compiler]
+        return compiler
+
     def configure_args(self):
         spec = self.spec
 
@@ -166,7 +176,8 @@ class Scorep(AutotoolsPackage):
             "--enable-shared",
         ]
 
-        cname = spec.compiler.name
+        cname = self.clean_compiler(spec.compiler.name)
+        
         config_args.append("--with-nocross-compiler-suite={0}".format(cname))
 
         if self.version >= Version("4.0"):


### PR DESCRIPTION
CCE in spack is Cray on the Score-P configure line. Others can be added as discrepancies are found/created/discovered.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
