### PR TITLE
paraview: support Qt6 for 5.12 and newer

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -36,8 +36,10 @@ spack:
   - paraview_specs:
     - matrix:
       - - paraview +raytracing +adios2 +fides
-      - - +qt ^[virtuals=gl] glx # GUI Support w/ GLX Rendering
-        - ~qt ^[virtuals=gl] glx # GLX Rendering
+      - - +qt ^[virtuals=gl] glx ^[virtuals=qmake] qt-base # Qt6 GUI Support w/ GLX Rendering
+        - ~qt ^[virtuals=gl] glx ^[virtuals=qmake] qt-base # Qt6 GLX Rendering
+        - +qt ^[virtuals=gl] glx ^[virtuals=qmake] qt # Qt5 GUI Support w/ GLX Rendering
+        - ~qt ^[virtuals=gl] glx ^[virtuals=qmake] qt # Qt5 GLX Rendering
         - ^[virtuals=gl] osmesa # OSMesa Rendering
   - visit_specs:
     - matrix:

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -62,6 +62,7 @@ spack:
   - matrix:
     - [$sdk_base_spec]
     - ["+paraview ~visit"]
+    - ["^sensei ~libsim"]
     - [$^paraview_specs]
   - matrix:
     - [$sdk_base_spec]

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -62,7 +62,6 @@ spack:
   - matrix:
     - [$sdk_base_spec]
     - ["+paraview ~visit"]
-    - ["^sensei ~libsim"]
     - [$^paraview_specs]
   - matrix:
     - [$sdk_base_spec]

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -37,9 +37,8 @@ spack:
     - matrix:
       - - paraview +raytracing +adios2 +fides
       - - +qt ^[virtuals=gl] glx ^[virtuals=qmake] qt-base # Qt6 GUI Support w/ GLX Rendering
-        - ~qt ^[virtuals=gl] glx ^[virtuals=qmake] qt-base # Qt6 GLX Rendering
         - +qt ^[virtuals=gl] glx ^[virtuals=qmake] qt # Qt5 GUI Support w/ GLX Rendering
-        - ~qt ^[virtuals=gl] glx ^[virtuals=qmake] qt # Qt5 GLX Rendering
+        - ~qt ^[virtuals=gl] glx # GLX Rendering
         - ^[virtuals=gl] osmesa # OSMesa Rendering
   - visit_specs:
     - matrix:

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -231,11 +231,16 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi", when="+mpi")
     conflicts("mpi", when="~mpi")
 
+    depends_on("qmake", when="@5.12.0:+qt")
+    depends_on("qt", when="@5.3.0:5.11+qt")
+    with when("^[virtuals=qmake] qt-base"):
+        depends_on("qt-base+opengl", when="+opengl2")
+        depends_on("qt-base~opengl", when="~opengl2")
+    with when("^[virtuals=qmake] qt"):
+        depends_on("qt+opengl", when="+opengl2")
+        depends_on("qt~opengl", when="~opengl2")
     depends_on("qt@:4", when="@:5.2.0+qt")
     depends_on("qt+sql", when="+qt")
-    with when("+qt"):
-        depends_on("qt+opengl", when="@5.3.0:+opengl2")
-        depends_on("qt~opengl", when="@5.3.0:~opengl2")
 
     depends_on("gl@3.2:", when="+opengl2")
     depends_on("gl@1.2:", when="~opengl2")

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -237,6 +237,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("qt-base+gui+network+widgets")
         depends_on("qt-base+opengl", when="+opengl2")
         depends_on("qt-base~opengl", when="~opengl2")
+        depends_on("qt-5compat")
     with when("^[virtuals=qmake] qt"):
         depends_on("qt+opengl", when="+opengl2")
         depends_on("qt~opengl", when="~opengl2")

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -234,6 +234,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("qmake", when="@5.12.0:+qt")
     depends_on("qt", when="@5.3.0:5.11+qt")
     with when("^[virtuals=qmake] qt-base"):
+        depends_on("qt-base+gui+network+widgets")
         depends_on("qt-base+opengl", when="+opengl2")
         depends_on("qt-base~opengl", when="~opengl2")
     with when("^[virtuals=qmake] qt"):

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -231,7 +231,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi", when="+mpi")
     conflicts("mpi", when="~mpi")
 
-    with when("+qt")
+    with when("+qt"):
         depends_on("qmake", when="@5.12.0:")
         depends_on("qt", when="@5.3.0:5.11")
         depends_on("qt@:4", when="@:5.2.0")

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -237,6 +237,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("qt-base+gui+network+widgets")
         depends_on("qt-base+opengl", when="+opengl2")
         depends_on("qt-base~opengl", when="~opengl2")
+        depends_on("qt-tools +assistant")  # Qt::Help
         depends_on("qt-5compat")
         depends_on("qt-svg")
     with when("^[virtuals=qmake] qt"):

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -231,8 +231,10 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("mpi", when="+mpi")
     conflicts("mpi", when="~mpi")
 
-    depends_on("qmake", when="@5.12.0:+qt")
-    depends_on("qt", when="@5.3.0:5.11+qt")
+    with when("+qt")
+        depends_on("qmake", when="@5.12.0:")
+        depends_on("qt", when="@5.3.0:5.11")
+        depends_on("qt@:4", when="@:5.2.0")
     with when("^[virtuals=qmake] qt-base"):
         depends_on("qt-base+gui+network+widgets")
         depends_on("qt-base+opengl", when="+opengl2")
@@ -241,10 +243,9 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("qt-5compat")
         depends_on("qt-svg")
     with when("^[virtuals=qmake] qt"):
+        depends_on("qt+sql")
         depends_on("qt+opengl", when="+opengl2")
         depends_on("qt~opengl", when="~opengl2")
-    depends_on("qt@:4", when="@:5.2.0+qt")
-    depends_on("qt+sql", when="+qt")
 
     depends_on("gl@3.2:", when="+opengl2")
     depends_on("gl@1.2:", when="~opengl2")

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -609,7 +609,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
         # The assumed qt version changed to QT5 (as of paraview 5.2.1),
         # so explicitly specify which QT major version is actually being used
         if spec.satisfies("+qt"):
-            cmake_args.extend(["-DPARAVIEW_QT_VERSION=%s" % spec["qt"].version[0]])
+            cmake_args.extend(["-DPARAVIEW_QT_VERSION=%s" % spec["qmake"].version[0]])
             if IS_WINDOWS:
                 # Windows does not currently support Qt Quick
                 cmake_args.append("-DVTK_MODULE_ENABLE_VTK_GUISupportQtQuick:STRING=NO")

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -238,6 +238,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("qt-base+opengl", when="+opengl2")
         depends_on("qt-base~opengl", when="~opengl2")
         depends_on("qt-5compat")
+        depends_on("qt-svg")
     with when("^[virtuals=qmake] qt"):
         depends_on("qt+opengl", when="+opengl2")
         depends_on("qt~opengl", when="~opengl2")


### PR DESCRIPTION
This PR adds some support for paraview builds with Qt6, and enables it in data-vis-sdk build matrix.

Note: This is WIP but I want it to build in the pipelines, so not marking as draft.