### PR TITLE
Chapel updates post release

### DIFF
--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -6,9 +6,9 @@
 import os
 import subprocess
 
+import spack.platforms.cray
 from spack.package import *
 from spack.util.environment import is_system_path, set_env
-import spack.platforms.cray
 
 
 @llnl.util.lang.memoized

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -849,6 +849,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             "util/test",
             "util/chplenv",
             "util/config",
+            "util/printchplenv",
             #   "test/library/packages/Curl",
             #   "test/library/packages/URL/",
             #   "test/library/packages/ProtobufProtocolSupport/",

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -310,7 +310,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         requires(
             "^libfabric fabrics=cxi",
             when="libfabric=spack",
-            msg="libfabric requires cxi fabric on HPE-Cray EX machines"
+            msg="libfabric requires cxi fabric on HPE-Cray EX machines",
         )
 
     variant(
@@ -460,10 +460,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     # comm_substrate=udp gasnet_segment=unset defaults to everything,
     # which is incompatible with +pshm
-    requires(
-        "gasnet_segment=fast",
-        when="+pshm comm_substrate=udp",
-    )
+    requires("gasnet_segment=fast", when="+pshm comm_substrate=udp")
 
     conflicts(
         "^python@3.12:",
@@ -578,7 +575,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             env.set("CHPL_TARGET_COMPILER", "llvm")
             env.set(
                 "CHPL_LLVM_CONFIG",
-                join_path(self.spec["llvm-amdgpu"].prefix, "bin", "llvm-config")
+                join_path(self.spec["llvm-amdgpu"].prefix, "bin", "llvm-config"),
             )
             real_cc = join_path(self.spec["llvm-amdgpu"].prefix, "bin", "clang")
             real_cxx = join_path(self.spec["llvm-amdgpu"].prefix, "bin", "clang++")
@@ -590,10 +587,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         elif self.spec.satisfies("llvm=spack"):
             env.set("CHPL_TARGET_COMPILER", "llvm")
-            env.set(
-                "CHPL_LLVM_CONFIG",
-                join_path(self.spec["llvm"].prefix, "bin", "llvm-config")
-            )
+            env.set("CHPL_LLVM_CONFIG", join_path(self.spec["llvm"].prefix, "bin", "llvm-config"))
             real_cc = join_path(self.spec["llvm"].prefix, "bin", "clang")
             real_cxx = join_path(self.spec["llvm"].prefix, "bin", "clang++")
         else:

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -525,13 +525,10 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         # Undo spack compiler wrappers:
         # the C/C++ compilers must work post-install
-        if self.spec.satisfies("+cuda") or self.spec.satisfies("+rocm"):
+        if self.spec.satisfies("llvm=spack"):
             env.set("CHPL_TARGET_COMPILER", "llvm")
             real_cc = join_path(self.spec["llvm"].prefix, "bin", "clang")
             real_cxx = join_path(self.spec["llvm"].prefix, "bin", "clang++")
-        elif is_CrayEX() and os.environ.get("CRAYPE_DIR"):
-            real_cc = join_path(os.environ["CRAYPE_DIR"], "bin", "cc")
-            real_cxx = join_path(os.environ["CRAYPE_DIR"], "bin", "CC")
         else:
             real_cc = self.compiler.cc
             real_cxx = self.compiler.cxx

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -410,7 +410,9 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     conflicts("platform=windows")  # Support for windows is through WSL only
 
     conflicts("+rocm", when="+cuda", msg="Chapel must be built with either CUDA or ROCm, not both")
-    conflicts("+rocm", when="@:2.0.0", msg="ROCm support in spack requires Chapel 2.0.0 or later")
+    conflicts(
+        "+rocm", when="@:1.99.99", msg="ROCm support in spack requires Chapel 2.0.0 or later"
+    )
 
     conflicts(
         "comm_substrate=unset",
@@ -420,7 +422,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     conflicts(
         "^python@3.12:",
-        when="@:2.1.0",
+        when="@:2.0.99",
         msg="Chapel versions prior to 2.1.0 may produce SyntaxWarnings with Python >= 3.12",
     )
 

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -372,7 +372,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             ),
             default=True,
         )
-        depends_on(dep, when="+{0}".format(variant_name))
+        depends_on(dep, when="+{0}".format(variant_name), type=("build", "link", "run", "test"))
 
     # TODO: for CHPL_X_CC and CHPL_X_CXX, can we capture an arbitrary path, possibly
     # with arguments?
@@ -485,8 +485,6 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         when="llvm=spack +cuda",
     )
 
-    depends_on("cuda@11:", when="+cuda", type=("build", "link", "run", "test"))
-
     # This is because certain systems have binutils installed as a system package
     # but do not include the headers. Spack incorrectly supplies those external
     # packages as proper dependencies for LLVM, but then LLVM will fail to build
@@ -495,11 +493,17 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     depends_on("m4")
 
-    depends_on("gmp", when="gmp=spack", type=("build", "link", "run", "test"))
-    depends_on("hwloc", when="hwloc=spack", type=("build", "link", "run", "test"))
-    depends_on("libfabric", when="libfabric=spack", type=("build", "link", "run", "test"))
-    depends_on("libunwind", when="unwind=spack", type=("build", "link", "run", "test"))
-    depends_on("jemalloc", when="host_jemalloc=spack", type=("build", "link", "run", "test"))
+    # Runtime dependencies:
+    # Note here "run" is run of the Chapel compiler built by this package,
+    # but many of these are ALSO run-time dependencies of the executable
+    # application built by that Chapel compiler from user-provided sources.
+    with default_args(type=("build", "link", "run", "test")):
+        depends_on("cuda@11:", when="+cuda")
+        depends_on("gmp", when="gmp=spack")
+        depends_on("hwloc", when="hwloc=spack")
+        depends_on("libfabric", when="libfabric=spack")
+        depends_on("libunwind", when="unwind=spack")
+        depends_on("jemalloc", when="host_jemalloc=spack")
 
     depends_on("gasnet conduits=none", when="gasnet=spack")
     depends_on("gasnet@2024.5.0: conduits=none", when="@2.1.0: gasnet=spack")

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -298,6 +298,15 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     )
 
     variant(
+        "libfabric",
+        default="unset",
+        description="Control the libfabric version used for multi-locale communication",
+        values=("bundled", "spack", "unset"),
+        multi=False,
+        when="comm=gasnet comm_substrate=ofi",
+    )
+
+    variant(
         "llvm",
         default="spack",
         description="LLVM backend type. The 'spack' value can use an external "

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -608,8 +608,6 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             # could not compile test/library/packages/ZMQ/hello.chpl without this
             env.prepend_path("LIBRARY_PATH", self.spec["libzmq"].prefix.lib)
             env.prepend_path("LD_LIBRARY_PATH", self.spec["libzmq"].prefix.lib)
-            # could not compile test/library/packages/ZMQ/hello.chpl without this
-            env.prepend_path("LIBRARY_PATH", self.spec["libzmq"].prefix.lib)
             env.prepend_path("PKG_CONFIG_PATH", self.spec["libzmq"].prefix.lib.pkgconfig)
             env.prepend_path("PKG_CONFIG_PATH", self.spec["libsodium"].prefix.lib.pkgconfig)
 

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -306,12 +306,11 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         when="comm=gasnet comm_substrate=ofi",
     )
 
-    with when("libfabric=spack"):
-        requires(
-            "^libfabric fabrics=cxi",
-            when=is_CrayEX(),
-            msg="libfabric requires cxi fabric on HPE-Cray EX machines",
-        )
+    requires(
+        "^libfabric" + (" fabrics=cxi" if spack.platforms.cray.slingshot_network() else ""),
+        when="libfabric=spack",
+        msg="libfabric requires cxi fabric provider on HPE-Cray EX machines",
+    )
 
     variant(
         "llvm",

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -596,6 +596,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             # Need this for the test env, where it does not appear automatic:
             env.prepend_path("PKG_CONFIG_PATH", self.spec["libpciaccess"].prefix.lib.pkgconfig)
 
+        # TODO: unwind builds but resulting binaries fail to run, producing linker errors
         if self.spec.variants["unwind"].value == "spack":
             # chapel package would not build without cpath, missing libunwind.h
             self.prepend_cpath_include(env, self.spec["libunwind"].prefix)

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -611,6 +611,19 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         if self.spec.satisfies("+developer"):
             env.set("CHPL_DEVELOPER", "true")
 
+        if not self.spec.satisfies("llvm=none"):
+            # workaround Spack issue #44746:
+            # Chapel does not directly utilize lua, but many of its
+            # launchers depend on system installs of batch schedulers
+            # (notably Slurm on Cray EX) which depend on a system Lua.
+            # LLVM includes lua as a dependency, but a barebones lua
+            # install lacks many packages provided by a system Lua,
+            # which are often required by system services like Slurm.
+            # Disable the incomplete Spack lua package directory to
+            # allow the system one to function.
+            env.unset("LUA_PATH")
+            env.unset("LUA_CPATH")
+
         if self.spec.variants["gmp"].value == "spack":
             # TODO: why must we add to CPATH to find gmp.h
             # TODO: why must we add to LIBRARY_PATH to find lgmp

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -8,6 +8,7 @@ import subprocess
 
 from spack.package import *
 from spack.util.environment import is_system_path, set_env
+import spack.platforms.cray
 
 
 @llnl.util.lang.memoized

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -59,7 +59,6 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
 
     patch("fix_spack_cc_wrapper_in_cray_prgenv.patch", when="@2.0.0:")
 

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -801,11 +801,9 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         if not self.spec.satisfies("+chpldoc"):
             print("Skipping chpldoc test as chpldoc variant is not set")
             return
-        with working_dir(self.test_suite.current_test_cache_dir):
-            with set_env(CHPL_HOME=self.test_suite.current_test_cache_dir):
-                with test_part(self, "test_chpldoc", purpose="test chpldoc"):
-                    res = subprocess.run(["util/test/checkChplDoc"])
-                    assert res.returncode == 0
+        else:
+            # TODO: Need to update checkChplDoc to work in the spack testing environment
+            pass
 
     # TODO: In order to run these tests, there's a lot of infrastructure to copy
     # from the Chapel test suite and there are conflicts with CHPL_HOME needing

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -306,10 +306,10 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         when="comm=gasnet comm_substrate=ofi",
     )
 
-    with when(is_CrayEX()):
+    with when("libfabric=spack"):
         requires(
             "^libfabric fabrics=cxi",
-            when="libfabric=spack",
+            when=is_CrayEX(),
             msg="libfabric requires cxi fabric on HPE-Cray EX machines",
         )
 

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -306,6 +306,13 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         when="comm=gasnet comm_substrate=ofi",
     )
 
+    with when(is_CrayEX()):
+        requires(
+            "^libfabric fabrics=cxi",
+            when="libfabric=spack",
+            msg="libfabric requires cxi fabric on HPE-Cray EX machines"
+        )
+
     variant(
         "llvm",
         default="spack",

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -291,9 +291,10 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     variant(
         "libfabric",
         default="unset",
-        description="When building with ofi support, specify libfabric option",
+        description="Control the libfabric version used for multi-locale communication",
         values=("bundled", "spack", "unset"),
         multi=False,
+        when="comm=ofi",
     )
 
     variant(


### PR DESCRIPTION
Fixes and updates after Chapel's 2.1.0 release. 

# Change Highlights:
(thank you @bonachea!)
* Fix `+rocm` variant, to ensure correct dependencies on `ROCm` packages and use of AMD LLVM
* Add a `+pshm` variant for `comm=gasnet` to enable fast shared-memory comms between co-locales
* Add logic to ensure we get the native CXI `libfabric` network provider on Cray EX
* Expand dependency type for package modules to encompass runtime dependencies
* Factor logic for setting `(LD_)LIBRARY_PATH` and `PKG_CONFIG_PATH` of runtime dependencies
* Workaround issue #44746 that causes a transitive dependency on `lua` to break SLURM
* Disable nonfunctional `checkChplDoc` test
* Annotate some variants as conditional, to improve `spack info` output and reduce confusion

