### PR TITLE
grib-util: add v1.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/grib-util/package.py
+++ b/var/spack/repos/builtin/packages/grib-util/package.py
@@ -18,6 +18,7 @@ class GribUtil(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
     version("develop", branch="develop")
+    version("1.5.0", tag="v1.5.0", commit="b84e877a62efe6695546a4b7a02e7adb6e1ece25")
     version("1.4.0", tag="v1.4.0", commit="eeacc9ec93dfe6379f576191883c84a4a1202cc8")
     version("1.3.0", commit="9d3c68a")
     version("1.2.4", sha256="f021d6df3186890b0b1781616dabf953581d71db63e7c2913360336985ccaec7")
@@ -36,7 +37,8 @@ class GribUtil(CMakePackage):
     requires("^w3emc precision=4,d", when="^w3emc@2.10:")
     depends_on("w3nco", when="@:1.2.3")
     depends_on("g2")
-    depends_on("g2@3.4.9:", when="@1.4:")
+    depends_on("g2@3.4.9:", when="@1.4")
+    depends_on("g2@3.5:", when="@1.5:")
     depends_on("g2c@1.8: +utils", when="+tests")
     depends_on("bacio")
     depends_on("ip")


### PR DESCRIPTION
This PR adds grib-util@1.5.0. The only change needed is the g2 version requirement; no changes to build options.