### PR TITLE
Score-P: Add remapping for rocmcc

### DIFF
--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -160,8 +160,7 @@ class Scorep(AutotoolsPackage):
     # handle any mapping of Spack compiler names to Score-P args
     # this should continue to exist for backward compatibility
     def clean_compiler(self, compiler):
-        renames = {"cce": "cray",
-                   "rocmcc": "amdclang"}
+        renames = {"cce": "cray", "rocmcc": "amdclang"}
         if compiler in renames:
             return renames[compiler]
         return compiler

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -160,7 +160,8 @@ class Scorep(AutotoolsPackage):
     # handle any mapping of Spack compiler names to Score-P args
     # this should continue to exist for backward compatibility
     def clean_compiler(self, compiler):
-        renames = {"cce": "cray"}
+        renames = {"cce": "cray",
+                   "rocmcc": "amdclang"}
         if compiler in renames:
             return renames[compiler]
         return compiler


### PR DESCRIPTION
rocmcc -> amdclang for Score-P, as discovered on Frontier.


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
