### PR TITLE
Do not halt concretization on unknown variants in externals

### DIFF
--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2639,7 +2639,7 @@ class TestConcretize:
             "cmake": {
                 "externals": [
                     {"spec": "cmake@3.23.1 %gcc", "prefix": "/tmp/prefix1"},
-                    {"spec": "cmake@3.23.1 %clang", "prefix": "/tmp.prefix2"},
+                    {"spec": "cmake@3.23.1 %clang", "prefix": "/tmp/prefix2"},
                 ]
             }
         }

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2632,6 +2632,7 @@ class TestConcretize:
         assert s.concrete
 
     @pytest.mark.regression("44828")
+    @pytest.mark.not_on_windows("Tests use linux paths")
     def test_correct_external_is_selected_from_packages_yaml(self, mutable_config):
         """Tests that when filtering external specs, the correct external is selected to
         reconstruct the prefix, and other external attributes.

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2615,6 +2615,7 @@ class TestConcretize:
         [
             "cmake@3.4.3 foo=bar",  # cmake has no variant "foo"
             "mvdefaults@1.0 foo=a,d",  # variant "foo" has no value "d"
+            "cmake %gcc",  # spec has no version
         ],
     )
     def test_corrupted_external_does_not_halt_concretization(self, corrupted_str, mutable_config):


### PR DESCRIPTION
fixes #45321
fixes #44828 

This PR fixes two concretization bugs related to externals:
- A malformed external spec does not halt concretization anymore. A warning is emitted instead, and the spec is ignored for concretization.
- Fix indexing external specs when filtering them.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
