### PR TITLE
sqlite: fix AttributeError when +functions

### DIFF
--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -279,7 +279,7 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
             libraryname = "libsqlitefunctions." + dso_suffix
             cc = Executable(spack_cc)
             cc(
-                self.compiler.cc_pic_flag,
+                self.pkg.compiler.cc_pic_flag,
                 "-lm",
                 "-shared",
                 "extension-functions.c",


### PR DESCRIPTION
using self.compiler.cc_pic_flag here results in these errors:

==> sqlite: Executing phase: 'install'
==> Error: AttributeError: 'AutotoolsBuilder' object has no attribute 'compiler'

change it to self.pkg.compiler.cc_pic_flag instead.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
