### PR TITLE
docs: util/environment.py: use `re.Pattern[str]` instead of `re`

### DIFF
--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==7.2.6
+sphinx==7.4.6
 sphinxcontrib-programoutput==0.17
 sphinx_design==0.6.0
 sphinx-rtd-theme==2.0.0

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -718,9 +718,9 @@ class EnvironmentModifications:
                 (default: ``&> /dev/null``)
             concatenate_on_success (str): operator used to execute a command
                 only when the previous command succeeds (default: ``&&``)
-            exclude ([str or re]): ignore any modifications of these
+            exclude ([str or re.Pattern[str]]): ignore any modifications of these
                 variables (default: [])
-            include ([str or re]): always respect modifications of these
+            include ([str or re.Pattern[str]]): always respect modifications of these
                 variables (default: []). Supersedes any excluded variables.
             clean (bool): in addition to removing empty entries,
                 also remove duplicate entries (default: False).


### PR DESCRIPTION
As of sphinx 7.3.0, we have been having warnings in the rtd generation pipelines which cause the rtd job to fail (e.g. most recently in https://github.com/spack/spack/pull/45311, but since https://github.com/spack/spack/pull/43694).

This PR adds the docstring type fix that should remove the warnings, and updates the version of sphinx to 7.4.6 (closing https://github.com/spack/spack/pull/45311).

Not sure exactly what in 7.3.0 ([release notes](https://www.sphinx-doc.org/en/master/changes.html#release-7-3-0-released-apr-16-2024)) causes the failure, though.