### PR TITLE
hiop: Update package.py with correct cusolver_lu CMake variable

### DIFF
--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -208,7 +208,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
                 self.define_from_variant("HIOP_USE_COINHSL", "sparse"),
                 self.define_from_variant("HIOP_TEST_WITH_BSUB", "jsrun"),
                 self.define_from_variant("HIOP_USE_GINKGO", "ginkgo"),
-                self.define_from_variant("HIOP_USE_CUSOLVER_LU", "cusolver_lu"),
+                self.define_from_variant("HIOP_USE_RESOLVE", "cusolver_lu"),
             ]
         )
 


### PR DESCRIPTION
@pelesh as we discussed offline, this is the correct name for the cusolver_lu CMake variable

Thanks to @nkoukpaizan for identifying this! 

https://github.com/LLNL/hiop/blob/develop/CMakeLists.txt#L93 - eventually ReSolve as a spack package will be properly modeled as a dependency, but this fix is necessary for now.