### PR TITLE
rayleigh: add v1.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/rayleigh/package.py
+++ b/var/spack/repos/builtin/packages/rayleigh/package.py
@@ -26,8 +26,8 @@ class Rayleigh(MakefilePackage):
     version("0.9.1", sha256="ab96445fc61822fe2d2cba8729a85b36de6b541febf5759de6d614847844573f")
     version("0.9.0", sha256="63a80d1619cb639f3cb01ab82a441b77d736eee94469c47c50ab740fa81c08f4")
 
-    depends_on("c", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     depends_on("mpi")
     depends_on("fftw-api@3")

--- a/var/spack/repos/builtin/packages/rayleigh/package.py
+++ b/var/spack/repos/builtin/packages/rayleigh/package.py
@@ -19,6 +19,7 @@ class Rayleigh(MakefilePackage):
     maintainers("tukss")
 
     version("main", branch="main")
+    version("1.2.0", sha256="e90acf18d47f6066fa68fd7b16c70ad9781a00be9e97467e9a388773e21e9e09")
     version("1.1.0", sha256="93fbbdbde6088807638e4dcbd4d622203fd4753c1831bab2cb8eaeca5cba45c3")
     version("1.0.1", sha256="9c9e3b0b180f32a889f158e2ea2967f4ac2bb2124f5d264f230efb8c8f19ea36")
     version("1.0.0", sha256="4f2e8249256adff8c4b0bc377ceacf8a6441dcee54b7d36c784f05a454dc6dcf")


### PR DESCRIPTION
This adds Rayleigh 1.2.0 and confirms the depenence on C and Fortran compilers.