### PR TITLE
openblas: fix AttributeError when `threads=openmp`

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -570,17 +570,19 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
         # Openblas may pass its own test but still fail to compile Lapack
         # symbols. To make sure we get working Blas and Lapack, do a small
         # test.
-        source_file = join_path(os.path.dirname(self.module.__file__), "test_cblas_dgemm.c")
-        blessed_file = join_path(os.path.dirname(self.module.__file__), "test_cblas_dgemm.output")
+        source_file = join_path(os.path.dirname(self.pkg.module.__file__), "test_cblas_dgemm.c")
+        blessed_file = join_path(
+            os.path.dirname(self.pkg.module.__file__), "test_cblas_dgemm.output"
+        )
 
         include_flags = spec["openblas"].headers.cpp_flags
         link_flags = spec["openblas"].libs.ld_flags
-        if self.compiler.name == "intel":
+        if self.pkg.compiler.name == "intel":
             link_flags += " -lifcore"
         if self.spec.satisfies("threads=pthreads"):
             link_flags += " -lpthread"
         if spec.satisfies("threads=openmp"):
-            link_flags += " -lpthread " + self.compiler.openmp_flag
+            link_flags += " -lpthread " + self.pkg.compiler.openmp_flag
 
         output = compile_c_and_execute(source_file, [include_flags], link_flags.split())
         compare_output_file(output, blessed_file)


### PR DESCRIPTION
This PR fixes a similar issue as in #45327.

Note: This wasn't caught yet (despite `openblas` certainly being built on gitlab somewhere with tests enabled) because this is actually unreachable code. While trying to test this, it appears that `@on_package_attributes(run_tests=True)` in a builder doesn't do what it is supposed to do.