### PR TITLE
omit test on windows

### DIFF
--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -123,6 +123,7 @@ def test_location_env_missing():
 
 
 @pytest.mark.db
+@pytest.mark.not_on_windows("Broken on Windows")
 def test_location_install_dir(mock_spec):
     """Tests spack location --install-dir."""
     spec, _ = mock_spec


### PR DESCRIPTION
A test enabled in https://github.com/spack/spack/pull/45031 appears to be failing now

I'm not sure whether it's an intermittent or repeatable failure. But I've seen it in the develop CI and at least one unrelated PR (https://github.com/spack/spack/pull/45281).

For now, I am disabling it here.