### PR TITLE
intel-oneapi-compilers: update description with current compilers

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -234,7 +234,7 @@ versions = [
 
 @IntelOneApiPackage.update_description
 class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
-    """Intel oneAPI Compilers. Includes: icc, icpc, ifort, icx, icpx, and ifx."""
+    """Intel oneAPI Compilers. Includes: icx, icpx, ifx (in recent releases)."""
 
     maintainers("rscohn2")
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -234,7 +234,8 @@ versions = [
 
 @IntelOneApiPackage.update_description
 class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
-    """Intel oneAPI Compilers. Includes: icx, icpx, ifx, and ifort. Releases before 2024.0 include icc/icpc"""
+    """Intel oneAPI Compilers. Includes: icx, icpx, ifx, and ifort.
+    Releases before 2024.0 include icc/icpc"""
 
     maintainers("rscohn2")
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -234,7 +234,7 @@ versions = [
 
 @IntelOneApiPackage.update_description
 class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
-    """Intel oneAPI Compilers. Includes: icx, icpx, ifx (in recent releases)."""
+    """Intel oneAPI Compilers. Includes: icx, icpx, ifx, and ifort. Releases before 2024.0 include icc/icpc"""
 
     maintainers("rscohn2")
 


### PR DESCRIPTION
Fixes #45307 by updating description of `intel-oneapi-compilers` package.