### PR TITLE
py-globus-sdk: add through v3.42; pypi now uses underscores

### DIFF
--- a/var/spack/repos/builtin/packages/py-globus-sdk/package.py
+++ b/var/spack/repos/builtin/packages/py-globus-sdk/package.py
@@ -56,7 +56,7 @@ class PyGlobusSdk(PythonPackage):
     depends_on("py-importlib-resources@5.12.0:", when="@3.41: ^python@:3.8", type=("build", "run"))
 
     def url_for_version(self, version):
-        if version <= Version("3.39"): 
+        if version <= Version("3.39"):
             return super().url_for_version(version).replace("_", "-")
         else:
             return super().url_for_version(version)

--- a/var/spack/repos/builtin/packages/py-globus-sdk/package.py
+++ b/var/spack/repos/builtin/packages/py-globus-sdk/package.py
@@ -13,12 +13,29 @@ class PyGlobusSdk(PythonPackage):
     """
 
     homepage = "https://github.com/globus/globus-sdk-python"
-    pypi = "globus-sdk/globus-sdk-3.0.2.tar.gz"
+    pypi = "globus_sdk/globus_sdk-3.0.2.tar.gz"
 
     maintainers("hategan", "climbfuji")
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked_by="wdconinc")
 
+    version("3.42.0", sha256="7f239acf26cd98c72568b07cc69d7e8d84511004881435c83129bf37c9495f43")
+    version("3.41.0", sha256="a097829e7516735675c1535bd17a8d9137636678bdbf50e95b3e7af8b32638ef")
+    version("3.40.0", sha256="6394f01c35b2b3275622f4f7c194eaf6750cb6c1e82cb2448dac2eb4ec394d75")
+    version("3.39.0", sha256="10af5291ba261e817665d5951948206232ecebccdc2aa8adc0528f0031ab80c3")
+    version("3.38.0", sha256="b83faacc103e3d3d3ac2ae33fd73a20a09d4d566cfa0cb03716b3fd8f51adcff")
+    version("3.37.0", sha256="87cd4cc191bca5912138c1f992589c735e13436208db10f2de5831efbebc83a7")
+    version("3.36.0", sha256="7693954a9ee3d69d09a0914c934ebcf4b4f47f016baa5c33612a03e367ee65a3")
+    version("3.35.0", sha256="9da40d5f251f98d89297c2a92abd9f24bfa3c041dfd0e957579884ef0c882cf2")
+    version("3.34.0", sha256="4db2ff439de9bd650bc2ba2d7c00614bd3dee34bd9b79da708951b8148236a36")
+    version("3.33.0", sha256="38b048590cf7bbd01c5ac82346401c3f42c3f105c81421d61bcb771aa788f481")
+    version("3.32.0", sha256="fe9df4ca2f2d16bbf40098df482e1713070946c70e2d6ec6a687c7086c1b559c")
+    version("3.31.0", sha256="5f077a8e532828a137a54f2858e63695af16d02577de058278da4ec873556cc1")
+    version("3.30.0", sha256="29d25f83d3b250d28a3a4bca8d046601a4bbb725330f409e6401295fa6bfb0ce")
+    version("3.29.0", sha256="a5f3c2da86ac6e7165841c9364ae80893f2ae667add5af5cd2237fc3fa14a1be")
+    version("3.28.0", sha256="249423dda76f162bb0d5515509135b68d6a779ad0cf2cd02a8204b2c7903e365")
+    version("3.27.0", sha256="1e9afac3bcce7dd69199c6e85372b0d6cadcc0906b27129d88db7e41dc32f195")
+    version("3.26.0", sha256="5a2bca267635c62e0f7c60fce10c47c7fd0fa8923c3363d44871c4abca8a68d1")
     version("3.25.0", sha256="d9be275d4ec18054db04732f75649c4227800c79b31fbcfb3f4f31eccfa5f4f7")
     version("3.10.1", sha256="c20fec55fc7e099f4d0c8224a36e194604577539445c5985cb465b23779baee8")
     version("3.10.0", sha256="7a7e7cd5cfbc40c6dc75bdb92b050c4191f992b5f7081cd08895bf119fd97bbf")
@@ -28,9 +45,18 @@ class PyGlobusSdk(PythonPackage):
     version("3.0.2", sha256="765b577b37edac70c513179607f1c09de7b287baa855165c9dd68de076d67f16")
 
     depends_on("python@3.6:", type=("build", "run"))
+    depends_on("python@3.7:", type=("build", "run"), when="@3.17:")
+    depends_on("python@3.8:", type=("build", "run"), when="@3.42:")
     depends_on("py-setuptools", type="build")
     depends_on("py-requests@2.19.1:2", type=("build", "run"))
     depends_on("py-pyjwt@2.0.0:2+crypto", type=("build", "run"))
     depends_on("py-cryptography@3.3.1:3.3,3.4.1:", when="@3.7:", type=("build", "run"))
     depends_on("py-cryptography@2:3.3,3.4.1:3.6", when="@:3.0", type=("build", "run"))
-    depends_on("py-typing-extensions@4:", when="@3.25:", type=("build", "run"))
+    depends_on("py-typing-extensions@4:", when="@3.25: ^python@:3.9", type=("build", "run"))
+    dpeends_on("py-importlib-resources@5.12.0:", when="@3.41: ^python@:3.8", type=("build", "run"))
+
+    def url_for_version(self, version):
+        if version <= Version("3.39"): 
+            return super().url_for_version(version).replace("_", "-")
+        else:
+            return super().url_for_version(version)

--- a/var/spack/repos/builtin/packages/py-globus-sdk/package.py
+++ b/var/spack/repos/builtin/packages/py-globus-sdk/package.py
@@ -53,7 +53,7 @@ class PyGlobusSdk(PythonPackage):
     depends_on("py-cryptography@3.3.1:3.3,3.4.1:", when="@3.7:", type=("build", "run"))
     depends_on("py-cryptography@2:3.3,3.4.1:3.6", when="@:3.0", type=("build", "run"))
     depends_on("py-typing-extensions@4:", when="@3.25: ^python@:3.9", type=("build", "run"))
-    dpeends_on("py-importlib-resources@5.12.0:", when="@3.41: ^python@:3.8", type=("build", "run"))
+    depends_on("py-importlib-resources@5.12.0:", when="@3.41: ^python@:3.8", type=("build", "run"))
 
     def url_for_version(self, version):
         if version <= Version("3.39"): 


### PR DESCRIPTION
This adds `py-globus-sdk` versions through v3.42 (with slightly updated dependencies), updates the package to deal with the dash-to-underscore transition at v3.40 (fixes #45186; doing this threewide by using the PyPI API is out of scope), checked the license.

`spack checksum -a py-globus-sdk` will now pick up any new versions since that still spiders for the `pypi` attribute.

Build test for all new versions (codespaces with ubuntu-jammy:develop; external git, openssl, python, rust:
```console
# spack find -lv 
-- linux-ubuntu20.04-x86_64_v3 / gcc@11.4.0 ---------------------
2mu665n gcc-runtime@11.4.0 build_system=generic
3xsinfh git@2.25.1+man+nls+perl+subtree~svn~tcltk build_system=autotools
ifnzkwq glibc@2.31 build_system=autotools
7wpxmbk gmake@4.4.1~guile build_system=generic
2tblez6 libffi@3.4.6 build_system=autotools
rpsayyp openssl@3.1.1~docs+shared build_system=generic certs=mozilla
i6gcral pkgconf@2.2.0 build_system=autotools
zsli3aq py-calver@2022.6.26 build_system=python_pip
ai7w22g py-certifi@2023.7.22 build_system=python_pip
2ksw2gl py-cffi@1.15.1 build_system=python_pip
efwpjbm py-charset-normalizer@3.3.0 build_system=python_pip
kwyrvsw py-cryptography@42.0.8 build_system=python_pip
76w6tfr py-editables@0.5 build_system=python_pip
htbldsq py-flit-core@3.9.0 build_system=python_pip
36psi4k py-globus-sdk@3.26.0 build_system=python_pip
afu7gpl py-globus-sdk@3.27.0 build_system=python_pip
wd7piez py-globus-sdk@3.28.0 build_system=python_pip
ystgyb3 py-globus-sdk@3.29.0 build_system=python_pip
ud73qly py-globus-sdk@3.30.0 build_system=python_pip
gm3kbmd py-globus-sdk@3.31.0 build_system=python_pip
hzxagyw py-globus-sdk@3.32.0 build_system=python_pip
pk3p3gx py-globus-sdk@3.33.0 build_system=python_pip
hyvrh6w py-globus-sdk@3.34.0 build_system=python_pip
gladl4f py-globus-sdk@3.35.0 build_system=python_pip
ymhcvv2 py-globus-sdk@3.36.0 build_system=python_pip
erwchra py-globus-sdk@3.37.0 build_system=python_pip
pzpjpf4 py-globus-sdk@3.38.0 build_system=python_pip
zrf2h2g py-globus-sdk@3.40.0 build_system=python_pip
4e6ppgz py-globus-sdk@3.41.0 build_system=python_pip
tk2iqui py-globus-sdk@3.42.0 build_system=python_pip
3sqndra py-hatchling@1.21.0 build_system=python_pip
i2oqpjz py-idna@3.4 build_system=python_pip
73sj7kl py-importlib-resources@5.12.0 build_system=python_pip
eayk54n py-packaging@23.1 build_system=python_pip
s3tthjn py-pathspec@0.11.1 build_system=python_pip
saqbivf py-pip@23.1.2 build_system=generic
5pkoysm py-pluggy@1.5.0 build_system=python_pip
a3jeee3 py-pycparser@2.21 build_system=python_pip
ep64knr py-pyjwt@2.4.0+crypto build_system=python_pip
hq43q3f py-requests@2.32.2~socks build_system=python_pip
yjifu24 py-semantic-version@2.10.0 build_system=python_pip
qg5iotm py-setuptools@69.2.0 build_system=generic
5zho2b7 py-setuptools-rust@1.9.0 build_system=python_pip
6meedru py-setuptools-scm@8.0.4+toml build_system=python_pip
s3rpmpw py-tomli@2.0.1 build_system=python_pip
c2v2ohn py-trove-classifiers@2023.8.7 build_system=python_pip
3nckz6k py-typing-extensions@4.8.0 build_system=python_pip
r42tkyu py-urllib3@2.1.0~brotli~socks build_system=python_pip
gq6rfse py-wheel@0.41.2 build_system=generic
4eropc2 py-zipp@3.17.0 build_system=python_pip
4mqitvv python@3.8.10+bz2+crypt+ctypes+dbm~debug+libxml2+lzma+nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=0d98e93,4c24573,ebdca64,f2fd060
aene6ou python-venv@1.0 build_system=generic
momnuwp rust@1.75.0~dev~docs+src build_system=generic
==> 53 installed packages
```