### PR TITLE
GoPackage: default `-modcacherw` to ensure stage cleanup

### DIFF
--- a/lib/spack/spack/build_systems/go.py
+++ b/lib/spack/spack/build_systems/go.py
@@ -72,7 +72,7 @@ class GoBuilder(BaseBuilder):
     def build_args(self):
         """Arguments for ``go build``."""
         # Pass ldflags -s = --strip-all and -w = --no-warnings by default
-        return ["-ldflags", "-s -w", "-o", f"{self.pkg.name}"]
+        return ["-modcacherw", "-ldflags", "-s -w", "-o", f"{self.pkg.name}"]
 
     @property
     def check_args(self):


### PR DESCRIPTION
By default, `go build` writes the module cache as read-only. This prevents spack from cleaning the stage path, resulting in leftover files (e.g. #44361).

This PR adds `-modcacherw` by default. The option was [added in go@1.14](https://go.dev/doc/go1.14#go-command) which is already the minimum required version.

~~Fixes #44361.~~ Sorry, doesn't fix just yet; `gh` should be made a `GoPackage` first. That is spun off in #45351.