### PR TITLE
gh: convert to GoPackage

### DIFF
--- a/var/spack/repos/builtin/packages/gh/package.py
+++ b/var/spack/repos/builtin/packages/gh/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Gh(Package):
+class Gh(GoPackage):
     """GitHub's official command line tool."""
 
     homepage = "https://github.com/cli/cli"
@@ -43,14 +43,9 @@ class Gh(Package):
     depends_on("go@1.21:", type="build", when="@2.33.0:")
     depends_on("go@1.22:", type="build", when="@2.47.0:")
 
-    phases = ["build", "install"]
-
-    def setup_build_environment(self, env):
-        # Point GOPATH at the top of the staging dir for the build step.
-        env.prepend_path("GOPATH", self.stage.path)
-
-    def build(self, spec, prefix):
-        make()
-
-    def install(self, spec, prefix):
-        make("install", "prefix=" + prefix)
+class GoBuilder(spack.build_systems.go.GoBuilder):
+    @property
+    def build_args(self):
+        args = super().build_args
+        args.extend(["-trimpath", "./cmd/gh"])
+        return args

--- a/var/spack/repos/builtin/packages/gh/package.py
+++ b/var/spack/repos/builtin/packages/gh/package.py
@@ -43,6 +43,7 @@ class Gh(GoPackage):
     depends_on("go@1.21:", type="build", when="@2.33.0:")
     depends_on("go@1.22:", type="build", when="@2.47.0:")
 
+
 class GoBuilder(spack.build_systems.go.GoBuilder):
     @property
     def build_args(self):


### PR DESCRIPTION
This PR converts `gh` from a `Package` (which calls `make`) to a `GoPackage` that uses `go build` with [two custom arguments](https://github.com/cli/cli/blob/a81a1f7e906ef3666ef3913efd1232afea634bd4/script/build.go#L56).

Together with #45350 (which adds `-modcacherw`), this now fixes #44361.