### PR TITLE
geant4: support Qt5 and Qt6

### DIFF
--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -172,7 +172,7 @@ class Geant4(CMakePackage):
         with when("^[virtuals=qmake] qt"):
             depends_on("qt@5: +opengl")
             depends_on("qt@5.9:", when="@11.2:")
-    conflicts("@:11.1 ^[virtuals=qmake] qt-base", msg="Qt6 not supported before 11.1")
+    conflicts("@:11.1 ^[virtuals=qmake] qt-base", msg="Qt6 not supported before 11.2")
 
     # As released, 10.0.4 has inconsistently capitalised filenames
     # in the cmake files; this patch also enables cxxstd 14

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -166,8 +166,13 @@ class Geant4(CMakePackage):
     depends_on("libxmu", when="+x11")
     depends_on("motif", when="+motif")
     with when("+qt"):
-        depends_on("qt@5: +opengl")
-        depends_on("qt@5.9:", when="@11.2:")
+        depends_on("qmake")
+        with when("^[virtuals=qmake] qt-base"):
+            depends_on("qt-base +accessibility +gui +opengl")
+        with when("^[virtuals=qmake] qt"):
+            depends_on("qt@5: +opengl")
+            depends_on("qt@5.9:", when="@11.2:")
+    conflicts("@:11.1 ^[virtuals=qmake] qt-base", msg="Qt6 not supported before 11.1")
 
     # As released, 10.0.4 has inconsistently capitalised filenames
     # in the cmake files; this patch also enables cxxstd 14
@@ -307,7 +312,9 @@ class Geant4(CMakePackage):
 
         if "+qt" in spec:
             options.append(self.define("GEANT4_USE_QT", True))
-            options.append(self.define("QT_QMAKE_EXECUTABLE", spec["qt"].prefix.bin.qmake))
+            if "^[virtuals=qmake] qt-base" in spec:
+                options.append(self.define("GEANT4_USE_QT_QT6", True))
+            options.append(self.define("QT_QMAKE_EXECUTABLE", spec["qmake"].prefix.bin.qmake))
 
         options.append(self.define_from_variant("GEANT4_USE_VTK", "vtk"))
 


### PR DESCRIPTION
As of Geant4 v11.2, Qt6 is supported. This PR adds the support to make sure we can compile Geant4 with Qt6. 

The image below is obtained with Geant4 11.3.0.beta with Qt6 v6.7.2 (`ldd` confirms it, not much else that gives it away).
![image](https://github.com/user-attachments/assets/9c2d6d82-7baa-4711-aba1-b3523ed85049)
