### PR TITLE
Fix SIP build system installing files into python-venv

### DIFF
--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -139,6 +139,10 @@ class SIPBuilder(BaseBuilder):
         args = ["--verbose", "--target-dir", inspect.getmodule(self.pkg).python_platlib]
         args.extend(self.configure_args())
 
+        # https://github.com/Python-SIP/sip/commit/cb0be6cb6e9b756b8b0db3136efb014f6fb9b766
+        if spec["py-sip"].satisfies("@6.1.0:"):
+            args.extend(["--scripts-dir", pkg.prefix.bin])
+
         sip_build = Executable(spec["py-sip"].prefix.bin.join("sip-build"))
         sip_build(*args)
 


### PR DESCRIPTION
Fix #45359 Installation issue: py-pyqt5 installs files into python-venv install prefix.

This fix only works when using py-sip 6.1.0 and above.


