### PR TITLE
uftrace: new test API, new version, new libtraceevent, capstone cmake_args change

### DIFF
--- a/var/spack/repos/builtin/packages/capstone/package.py
+++ b/var/spack/repos/builtin/packages/capstone/package.py
@@ -21,5 +21,8 @@ class Capstone(CMakePackage):
     version("4.0.2", sha256="7c81d798022f81e7507f1a60d6817f63aa76e489aa4e7055255f21a22f5e526a")
     version("4.0.1", sha256="79bbea8dbe466bd7d051e037db5961fdb34f67c9fac5c3471dd105cfb1e05dc7")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    def cmake_args(self):
+        return ["-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=TRUE"]

--- a/var/spack/repos/builtin/packages/libtraceevent/package.py
+++ b/var/spack/repos/builtin/packages/libtraceevent/package.py
@@ -1,0 +1,50 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Libtraceevent(MakefilePackage):
+    """Library to parse raw trace event formats."""
+
+    homepage = "https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git"
+    url = "https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/snapshot/libtraceevent-1.8.2.tar.gz"
+    git = "https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git"
+
+    maintainers("Jordan474")
+
+    license("LGPL-2.1-or-later AND GPL-2.0-or-later")
+
+    version("1.8.2", sha256="919f0c024c7b5059eace52d854d4df00ae7e361a4033e1b4d6fe01d97064a1b9")
+
+    variant("doc", default=False, description="Build documentation")
+
+    depends_on("c", type="build")
+    depends_on("asciidoc", when="+doc", type="build")
+    depends_on("xmlto", when="+doc", type="build")
+
+    def patch(self):
+        set_executable("Documentation/install-docs.sh.in")
+
+    @property
+    def common_targets(self):
+        return [
+            "prefix=" + self.prefix,
+            "pkgconfig_dir=" + join_path(self.prefix.lib, "pkgconfig"),
+        ]
+
+    @property
+    def build_targets(self):
+        result = self.common_targets + ["all"]
+        if "+doc" in self.spec:
+            result.append("doc")
+        return result
+
+    @property
+    def install_targets(self):
+        result = self.common_targets + ["install"]
+        if "+doc" in self.spec:
+            result.append("doc-install")
+        return result

--- a/var/spack/repos/builtin/packages/uftrace/package.py
+++ b/var/spack/repos/builtin/packages/uftrace/package.py
@@ -59,26 +59,23 @@ class Uftrace(AutotoolsPackage):
     def installcheck(self):
         pass
 
-    def test(self):
+    def test_uftrace(self):
         """Perform stand-alone/smoke tests using the installed package."""
         uftrace = self.prefix.bin.uftrace
-        self.run_test(
-            uftrace,
-            ["-A", ".", "-R", ".", "-P", "main", uftrace, "-V"],
-            [
-                r"dwarf",
-                r"luajit",
-                r"tui",
-                r"sched",
-                r"dynamic",
-                r"main\(2, ",
-                r"  getopt_long\(2, ",
-                r"  .*printf.*\(",
-                r"} = 0; /\* main \*/",
-            ],
-            installed=True,
-            purpose="test: testing the installation",
-        )
+        options = (["-A", ".", "-R", ".", "-P", "main", uftrace, "-V"],)
+        expected = [
+            r"dwarf",
+            r"luajit",
+            r"tui",
+            r"sched",
+            r"dynamic",
+            r"main\(2, ",
+            r"  getopt_long\(2, ",
+            r"  .*printf.*\(",
+            r"} = 0; /\* main \*/",
+        ]
+        out = uftrace(*options, output=str.split, error=str.split)
+        check_outputs(expected, out)
 
     @classmethod
     def determine_version(cls, exe):

--- a/var/spack/repos/builtin/packages/uftrace/package.py
+++ b/var/spack/repos/builtin/packages/uftrace/package.py
@@ -13,7 +13,7 @@ class Uftrace(AutotoolsPackage):
     """Dynamic function graph tracer for Linux which demangles C, C++ and Rust calls"""
 
     homepage = "https://uftrace.github.io/slide/"
-    url = "https://github.com/namhyung/uftrace/archive/v0.11.tar.gz"
+    url = "https://github.com/namhyung/uftrace/archive/v0.16.tar.gz"
     git = "https://github.com/namhyung/uftrace.git"
     executables = ["^uftrace$"]
     maintainers("bernhardkaindl")
@@ -23,11 +23,10 @@ class Uftrace(AutotoolsPackage):
 
     # The build process uses 'git describe --tags' to get the package version
     version("master", branch="master", get_full_repo=True)
-    version("0.11", sha256="101dbb13cb3320ee76525ec26426f2aa1de4e3ee5af74f79cb403ae4d2c6c871")
-    version("0.10", sha256="b8b56d540ea95c3eafe56440d6a998e0a140d53ca2584916b6ca82702795bbd9")
+    version("0.16", sha256="dd0549f610d186b6f25fa2334a5e82b6ddc232ec6ca088dbb41b3fe66961d6bb")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")  # full demangler support with libstdc++
     variant("doc", default=False, description="Build uftrace's documentation")
     variant("python2", default=False, description="Build uftrace with python2 support")
     variant("python3", default=True, description="Build uftrace with python3 support")
@@ -38,15 +37,11 @@ class Uftrace(AutotoolsPackage):
     depends_on("lsof", type="test")
     depends_on("pkgconfig", type="build")
     depends_on("libunwind")
+    depends_on("libtraceevent")
     depends_on("ncurses")
     depends_on("python@2.7:", when="+python2")
     depends_on("python@3.5:", when="+python3")
     depends_on("lua-luajit")
-
-    # Fix the version string if building below another git repo. Submitted upstream:
-    @when("@:0.11")
-    def patch(self):
-        filter_file("shell git", "shell test -e .git && git", "Makefile")
 
     def check(self):
         make("test", *["V=1", "-j{0}".format(max(int(make_jobs), 20))])


### PR DESCRIPTION
Supersedes #35805 (one package)

@AcriusWinter opened with:
Cannot test because no available versions of uftrace install without error. See issue #44729 

@bernhardkaindl added:
- Added a 2nd commit ([Fix build with libcapstone (-fPIC), upgrade to 0.16 with libtraceevent](https://github.com/spack/spack/pull/45364/commits/1d0a2ff8054b21a91cc6cce9784e74a972be1384)) to fix the build with libcapstone (-fPIC) and upgrade to 0.16 with `libtraceevent`.
- It removes the old versions: They are outdated and obsoleted by 0.16.

The PR is ready for review now.
There are runner issues with GitLab CI, retries may be needed.