### PR TITLE
sundials: new test API

### DIFF
--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -757,7 +757,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     @run_after("install")
     def setup_smoke_tests(self):
         if "+examples-install" in self.spec:
-            install_tree(self._smoke_tests_path, join_path(self.install_test_root, "testing"))
+            install_tree(self._smoke_tests_path, join_path(install_test_root(self), "testing"))
 
     def build_smoke_tests(self):
 

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -771,7 +771,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
                 make = which("make")
                 make()
 
-    def test_serial_nvector(self):
+    def test_nvector_serial(self):
         """Run serial N Vector test"""
 
         self.run_sundials("nvector/serial/test_nvector_serial", ["10", "0"], False)

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -744,7 +744,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
 
     @run_after("install")
     @on_package_attributes(run_tests=True)
-    def test_install(self):
+    def make_test_install(self):
         """Perform make test_install."""
         with working_dir(self.build_directory):
             make("test_install")

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -845,6 +845,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
                 if not cmake:
                     raise SkipTest("cmake not found")
                 cmake(".")
+            make = which("make")
             make()
             exe = which(join_path(self._smoke_tests_path, exe_path))
             if exe is None:

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -830,7 +830,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
         if "+sycl" not in self.spec or "+CVODE" not in self.spec:
             raise SkipTest("Package must be installed with +sycl and +CVODE")
 
-        self.run_sundials("cvode/sycl/cvAdvDiff_kry_sycl", [], True)
+        self.run_sundials(join_path("cvode", "sycl", "cvAdvDiff_kry_sycl"), [], True)
 
     def run_sundials(self, exe_path, opts, cmake_bool):
         """Common sundials test method"""

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -842,8 +842,6 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
         with working_dir(work_dir):
             if cmake_bool:
                 cmake = self.spec["cmake"].command
-                if not cmake:
-                    raise SkipTest("cmake not found")
                 cmake(".")
             make = which("make")
             make()

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -348,7 +348,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
             args.extend(
                 [
                     define("SUNDIALS_INDEX_SIZE", intsize),
-                    define("SUNDIALS_INDEX_TYPE", "int{}_t".format(intsize)),
+                    define("SUNDIALS_INDEX_TYPE", f"int{intsize}_t"),
                 ]
             )
 

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -768,7 +768,8 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
         for smoke_test in self._smoke_tests:
             work_dir = join_path(self._smoke_tests_path, os.path.dirname(smoke_test[0]))
             with working_dir(work_dir):
-                self.run_test(exe="make")
+                make = which("make")
+                make()
 
     def test_serial_nvector(self):
         """Run serial N Vector test"""

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -769,7 +769,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
             work_dir = join_path(self._smoke_tests_path, os.path.dirname(smoke_test[0]))
             with working_dir(work_dir):
                 make = which("make")
-                make()
+                make("clean")
 
     def test_serial_nvector(self):
         """Run serial N Vector test"""

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -6,8 +6,6 @@
 import os
 import sys
 
-from llnl.util import tty
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -760,7 +760,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
         (dirname, basename) = os.path.split(exe_path)
         srcpath = join_path(self._smoke_tests_path, dirname)
         if not os.path.exists(srcpath):
-            raise SkipTest(f"Example '{dirname}' not found in {self.version}")
+            raise SkipTest(f"Example '{basename}' source directory not found in {self.version}")
 
         # copy the example's directory to the test stage
         mkdirp(dirname)

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -769,7 +769,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
             work_dir = join_path(self._smoke_tests_path, os.path.dirname(smoke_test[0]))
             with working_dir(work_dir):
                 make = which("make")
-                make("clean")
+                make()
 
     def test_serial_nvector(self):
         """Run serial N Vector test"""

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -819,8 +819,6 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
         if "~examples-install" in self.spec:
             raise SkipTest("Package must be installed with +examples-install")
 
-        test = ("nvector/serial/test_nvector_serial", ["10", "0"], "Test serial N_Vector", False)
-
         work_dir = join_path(
             self._smoke_tests_path, os.path.dirname("nvector/serial/test_nvector_serial")
         )
@@ -843,8 +841,6 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
 
         if "+CVODE" not in self.spec:
             raise SkipTest("Package must be installed with +CVODE")
-
-        test = ("cvode/serial/cvAdvDiff_bnd", [], "Test CVODE", True)
 
         work_dir = join_path(self._smoke_tests_path, os.path.dirname("cvode/serial/cvAdvDiff_bnd"))
         with working_dir(work_dir):

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -744,7 +744,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
 
     @run_after("install")
     @on_package_attributes(run_tests=True)
-    def make_test_install(self):
+    def test_install(self):
         """Perform make test_install."""
         with working_dir(self.build_directory):
             make("test_install")

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -774,7 +774,9 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     def test_nvector_serial(self):
         """Run serial N Vector test"""
 
-        self.run_sundials("nvector/serial/test_nvector_serial", ["10", "0"], False)
+        self.run_sundials(
+            join_path("nvector", "serial", "test_nvector_serial"), ["10", "0"], False
+        )
 
     def test_cvode(self):
         """Run CVODE test"""
@@ -782,7 +784,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
         if "+CVODE" not in self.spec:
             raise SkipTest("Package must be installed with +CVODE")
 
-        self.run_sundials("cvode/serial/cvAdvDiff_bnd", [], True)
+        self.run_sundials(join_path("cvode", "serial", "cvAdvDiff_bnd"), [], True)
 
     def test_cuda(self):
         """Run cuda test"""
@@ -790,7 +792,9 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
         if "+cuda" not in self.spec:
             raise SkipTest("Package must be installed with +cuda")
 
-        self.run_sundials("nvector/cuda/test_nvector_cuda", ["10", "0", "0"], True)
+        self.run_sundials(
+            join_path("nvector", "cuda", "test_nvector_cuda"), ["10", "0", "0"], True
+        )
 
     def test_cuda_cvode(self):
         """Run cuda CVODE test"""
@@ -798,7 +802,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
         if "+cuda" not in self.spec or "+CVODE" not in self.spec:
             raise SkipTest("Package must be installed with +cuda and +CVODE")
 
-        self.run_sundials("cvode/cuda/cvAdvDiff_kry_cuda", [], True)
+        self.run_sundials(join_path("cvode", "cuda", "cvAdvDiff_kry_cuda"), [], True)
 
     def test_rocm(self):
         """Run rocm test"""
@@ -806,7 +810,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
         if "+rocm" not in self.spec:
             raise SkipTest("Package must be installed with +rocm")
 
-        self.run_sundials("nvector/hip/test_nvector_hip", ["10", "0", "0"], True)
+        self.run_sundials(join_path("nvector", "hip", "test_nvector_hip"), ["10", "0", "0"], True)
 
     def test_rocm_cvode(self):
         """Run rocm CVODE test"""
@@ -814,7 +818,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
         if "+rocm" not in self.spec or "+CVODE" not in self.spec:
             raise SkipTest("Package must be installed with +rocm and +CVODE")
 
-        self.run_sundials("cvode/hip/cvAdvDiff_kry_hip", [], True)
+        self.run_sundials(join_path("cvode", "hip", "cvAdvDiff_kry_hip"), [], True)
 
     def test_sycl(self):
         """Run sycl test"""
@@ -822,7 +826,9 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
         if "+sycl" not in self.spec:
             raise SkipTest("Package must be installed with +sycl")
 
-        self.run_sundials("nvector/sycl/test_nvector_sycl", ["10", "0", "0"], True)
+        self.run_sundials(
+            join_path("nvector", "sycl", "test_nvector_sycl"), ["10", "0", "0"], True
+        )
 
     def test_sycl_cvode(self):
         """Run sycl CVODE test"""


### PR DESCRIPTION
Supersedes #35807 (for one package)

Update standalone test API. ~See below comment for output.~

Example installations and associated test results:
```
$ spack find -v sundials
..
sundials@7.1.1+ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL~cuda~examples+examples-install~f2003~fcmix~ginkgo~hypre~int64~ipo~klu~kokkos~kokkos-kernels~lapack~magma~monitoring+mpi~openmp~petsc~profiling~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~sycl~trilinos build_system=cmake build_type=Release cstd=99 cxxstd=14 generator=make logging-level=2 precision=double
sundials@7.1.1+ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL~cuda+examples+examples-install~f2003~fcmix~ginkgo~hypre~int64~ipo~klu~kokkos~kokkos-kernels~lapack~magma~monitoring+mpi~openmp~petsc~profiling~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~sycl~trilinos build_system=cmake build_type=Release cstd=99 cxxstd=14 generator=make logging-level=2 precision=double
==> 2 installed packages
```

```
$ spack -v test run sundials
==> Spack test g46z5xjn2itetpkpyf65tpl6ngpvs4lq
==> Testing package sundials-7.1.1-5nh6oma
==> [2024-08-21-11:52:56.506137] test: test_cvadvdiff_cuda: build and run CUDA cvAdvDiff_kry
SKIPPED: Sundials::test_cvadvdiff_cuda: Package must be installed with +cuda+CVODE
==> [2024-08-21-11:52:56.506701] test: test_cvadvdiff_hip: build and run ROCM cvAdvDiff_kry
SKIPPED: Sundials::test_cvadvdiff_hip: Package must be installed with +rocm+CVODE
==> [2024-08-21-11:52:56.507035] test: test_cvadvdiff_serial: build and run serial cvAdvDiff_bnd
SKIPPED: Sundials::test_cvadvdiff_serial: Example 'cvAdvDiff_bnd' source directory not found in 7.1.1
==> [2024-08-21-11:52:56.508059] test: test_nvector_cuda: build and run CUDA N_Vector
SKIPPED: Sundials::test_nvector_cuda: Package must be installed with +cuda
==> [2024-08-21-11:52:56.508411] test: test_nvector_hip: build and run ROCM N_Vector
SKIPPED: Sundials::test_nvector_hip: Package must be installed with +rocm
==> [2024-08-21-11:52:56.508697] test: test_nvector_serial: build and run serial N_Vector
SKIPPED: Sundials::test_nvector_serial: Example 'test_nvector_serial' source directory not found in 7.1.1
==> [2024-08-21-11:52:56.509161] test: test_nvector_sycl: build and run SYCL N_Vector
SKIPPED: Sundials::test_nvector_sycl: Package must be installed with +sycl
==> [2024-08-21-11:52:56.509459] test: test_sycl_cvode: build and run SYCL cvAdvDiff_kry
SKIPPED: Sundials::test_sycl_cvode: Package must be installed with +sycl and +CVODE
==> [2024-08-21-11:52:56.511022] Completed testing
==> [2024-08-21-11:52:56.511147] 
======================= SUMMARY: sundials-7.1.1-5nh6oma ========================
Sundials::test_cvadvdiff_cuda .. SKIPPED
Sundials::test_cvadvdiff_hip .. SKIPPED
Sundials::test_cvadvdiff_serial .. SKIPPED
Sundials::test_nvector_cuda .. SKIPPED
Sundials::test_nvector_hip .. SKIPPED
Sundials::test_nvector_serial .. SKIPPED
Sundials::test_nvector_sycl .. SKIPPED
Sundials::test_sycl_cvode .. SKIPPED
============================= 8 skipped of 8 parts =============================
==> Testing package sundials-7.1.1-5srg42r
==> [2024-08-21-11:52:57.763772] test: test_cvadvdiff_cuda: build and run CUDA cvAdvDiff_kry
SKIPPED: Sundials::test_cvadvdiff_cuda: Package must be installed with +cuda+CVODE
==> [2024-08-21-11:52:57.764372] test: test_cvadvdiff_hip: build and run ROCM cvAdvDiff_kry
SKIPPED: Sundials::test_cvadvdiff_hip: Package must be installed with +rocm+CVODE
==> [2024-08-21-11:52:57.764695] test: test_cvadvdiff_serial: build and run serial cvAdvDiff_bnd
..
==> [2024-08-21-11:53:03.501391] '/usr/bin/make'
[  3%] Building C object CMakeFiles/cvAdvDiff_bnd.dir/cvAdvDiff_bnd.c.o
[  6%] Linking C executable cvAdvDiff_bnd
[  6%] Built target cvAdvDiff_bnd
[ 10%] Building C object CMakeFiles/cvAnalytic_mels.dir/cvAnalytic_mels.c.o
[ 13%] Linking C executable cvAnalytic_mels
[ 13%] Built target cvAnalytic_mels
[ 16%] Building C object CMakeFiles/cvDirectDemo_ls.dir/cvDirectDemo_ls.c.o
[ 20%] Linking C executable cvDirectDemo_ls
[ 20%] Built target cvDirectDemo_ls
[ 23%] Building C object CMakeFiles/cvDisc_dns.dir/cvDisc_dns.c.o
[ 26%] Linking C executable cvDisc_dns
[ 26%] Built target cvDisc_dns
[ 30%] Building C object CMakeFiles/cvDiurnal_kry_bp.dir/cvDiurnal_kry_bp.c.o
[ 33%] Linking C executable cvDiurnal_kry_bp
[ 33%] Built target cvDiurnal_kry_bp
[ 36%] Building C object CMakeFiles/cvDiurnal_kry.dir/cvDiurnal_kry.c.o
[ 40%] Linking C executable cvDiurnal_kry
[ 40%] Built target cvDiurnal_kry
[ 43%] Building C object CMakeFiles/cvKrylovDemo_ls.dir/cvKrylovDemo_ls.c.o
[ 46%] Linking C executable cvKrylovDemo_ls
[ 46%] Built target cvKrylovDemo_ls
[ 50%] Building C object CMakeFiles/cvKrylovDemo_prec.dir/cvKrylovDemo_prec.c.o
[ 53%] Linking C executable cvKrylovDemo_prec
[ 53%] Built target cvKrylovDemo_prec
[ 56%] Building C object CMakeFiles/cvParticle_dns.dir/cvParticle_dns.c.o
[ 60%] Linking C executable cvParticle_dns
[ 60%] Built target cvParticle_dns
[ 63%] Building C object CMakeFiles/cvPendulum_dns.dir/cvPendulum_dns.c.o
[ 66%] Linking C executable cvPendulum_dns
[ 66%] Built target cvPendulum_dns
[ 70%] Building C object CMakeFiles/cvRoberts_dns.dir/cvRoberts_dns.c.o
[ 73%] Linking C executable cvRoberts_dns
[ 73%] Built target cvRoberts_dns
[ 76%] Building C object CMakeFiles/cvRoberts_dns_constraints.dir/cvRoberts_dns_constraints.c.o
[ 80%] Linking C executable cvRoberts_dns_constraints
[ 80%] Built target cvRoberts_dns_constraints
[ 83%] Building C object CMakeFiles/cvRoberts_dns_negsol.dir/cvRoberts_dns_negsol.c.o
[ 86%] Linking C executable cvRoberts_dns_negsol
[ 86%] Built target cvRoberts_dns_negsol
[ 90%] Building C object CMakeFiles/cvRoberts_dns_uw.dir/cvRoberts_dns_uw.c.o
[ 93%] Linking C executable cvRoberts_dns_uw
[ 93%] Built target cvRoberts_dns_uw
[ 96%] Building C object CMakeFiles/cvRocket_dns.dir/cvRocket_dns.c.o
[100%] Linking C executable cvRocket_dns
[100%] Built target cvRocket_dns
==> [2024-08-21-11:53:10.601388] 'cvAdvDiff_bnd'

2-D Advection-Diffusion Equation
Mesh dimensions = 10 X 5
Total system size = 50
Tolerance parameters: reltol = 0   abstol = 1e-05

At t = 0      max.norm(u) =  8.954716e+01 
At t = 0.10   max.norm(u) =  4.132889e+00   nst =   85
At t = 0.20   max.norm(u) =  1.039294e+00   nst =  103
At t = 0.30   max.norm(u) =  2.979829e-01   nst =  113
At t = 0.40   max.norm(u) =  8.765774e-02   nst =  120
At t = 0.50   max.norm(u) =  2.625637e-02   nst =  126
At t = 0.60   max.norm(u) =  7.830425e-03   nst =  130
At t = 0.70   max.norm(u) =  2.329387e-03   nst =  134
At t = 0.80   max.norm(u) =  6.953434e-04   nst =  137
At t = 0.90   max.norm(u) =  2.115983e-04   nst =  140
At t = 1.00   max.norm(u) =  6.556853e-05   nst =  142

Final Statistics:
nst = 142    nfe  = 173    nsetups = 23     nfeLS = 0      nje = 3
nni = 170    ncfn = 0      netf = 3
==> [2024-08-21-11:53:10.716146] '/usr/bin/make' 'clean'
PASSED: Sundials::test_cvadvdiff_serial
==> [2024-08-21-11:53:12.228656] test: test_nvector_cuda: build and run CUDA N_Vector
SKIPPED: Sundials::test_nvector_cuda: Package must be installed with +cuda
==> [2024-08-21-11:53:12.229396] test: test_nvector_hip: build and run ROCM N_Vector
SKIPPED: Sundials::test_nvector_hip: Package must be installed with +rocm
==> [2024-08-21-11:53:12.229772] test: test_nvector_serial: build and run serial N_Vector
..
==> [2024-08-21-11:53:12.378480] '/usr/bin/make'
..
In file included from $spack/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/sundials-7.1.1-5srg42ra2etlprjjagagncnezxxmmck5/include/sundials/sundials_math.h:26,
                 from test_nvector.c:33:
$spack/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/sundials-7.1.1-5srg42ra2etlprjjagagncnezxxmmck5/include/sundials/sundials_types.h:57:10: fatal error: mpi.h: No such file or directory
   57 | #include <mpi.h>
      |          ^~~~~~~
compilation terminated.
make: *** [Makefile:90: test_nvector.o] Error 1
FAILED: Sundials::test_nvector_serial: Command exited with status 2:
..
==> [2024-08-21-11:53:12.485642] test: test_nvector_sycl: build and run SYCL N_Vector
SKIPPED: Sundials::test_nvector_sycl: Package must be installed with +sycl
==> [2024-08-21-11:53:12.486049] test: test_sycl_cvode: build and run SYCL cvAdvDiff_kry
SKIPPED: Sundials::test_sycl_cvode: Package must be installed with +sycl and +CVODE
==> [2024-08-21-11:53:12.487596] Completed testing
==> [2024-08-21-11:53:12.487729] 
======================= SUMMARY: sundials-7.1.1-5srg42r ========================
Sundials::test_cvadvdiff_cuda .. SKIPPED
Sundials::test_cvadvdiff_hip .. SKIPPED
Sundials::test_cvadvdiff_serial .. PASSED
Sundials::test_nvector_cuda .. SKIPPED
Sundials::test_nvector_hip .. SKIPPED
Sundials::test_nvector_serial .. FAILED
Sundials::test_nvector_sycl .. SKIPPED
Sundials::test_sycl_cvode .. SKIPPED
=================== 6 skipped, 1 passed, 1 failed of 8 parts ===================
==> [2024-08-21-11:53:12.487796] 
..
======================== 1 skipped, 1 failed of 2 specs ========================
```