### PR TITLE
kokkos-tools: new package

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos-tools/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-tools/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class KokkosTools(CMakePackage):
+    """Kokkos Profiling and Debugging Tools"""
+
+    homepage = "https://github.com/kokkos/kokkos-tools/"
+    git = "https://github.com/kokkos/kokkos-tools.git"
+
+    license("Apache-2.0 WITH LLVM-exception")
+
+    version("develop", branch="develop")
+
+    variant("mpi", default=False, description="Enable MPI support")
+    variant("papi", default=False, description="Enable PAPI support")
+
+    depends_on("kokkos")
+    depends_on("mpi", when="+mpi")
+    depends_on("papi", when="+papi")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("KokkosTools_ENABLE_MPI", "mpi"),
+            self.define_from_variant("KokkosTools_ENABLE_PAPI", "papi"),
+        ]
+        return args


### PR DESCRIPTION
Adds a basic spackage for kokkos-tools

I've deliberately didn't include any of the releases, since the last one is many years old.

The CMake configuration will primarily be dependent on how kokkos was configured and built. So I've only added the `mpi` and `papi` variant for now to create the base skeleton for this.

Basic usage after install:
```bash
export KOKKOS_TOOLS_LIBS=$(spack location -i kokkos-tools)/lib/<name_of_tool_shared_lib>.so
```

Closes #45149 

FYI @dhope-lab @lucbv 