### PR TITLE
gptune: new test API

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -2,7 +2,6 @@ ci:
   target: gitlab
 
   broken-tests-packages:
-    - gptune
     - superlu-dist    # srun -n 4 hangs
     - papyrus
 

--- a/var/spack/repos/builtin/packages/gptune/package.py
+++ b/var/spack/repos/builtin/packages/gptune/package.py
@@ -206,7 +206,8 @@ class Gptune(CMakePackage):
 
     def test_hypre(self):
         """set up and run hypre example"""
-        if "~hypre" in self.spec or "~mpispawn" in self.spec:
+        spec = self.spec
+        if spec.satisfies("~hypre") or spec.satisfies("~mpispawn"):
             raise SkipTest("Package must be installed with +hypre+mpispawn")
 
         # https://github.com/spack/spack/pull/45383#discussion_r1737987370
@@ -239,7 +240,7 @@ class Gptune(CMakePackage):
 
     def test_superlu(self):
         """set up and run superlu tests"""
-        if "~superlu" in self.spec:
+        if self.spec.satisfies("~superlu"):
             raise SkipTest("Package must be installed with +superlu")
 
         # https://github.com/spack/spack/pull/45383#discussion_r1737987370
@@ -274,7 +275,7 @@ class Gptune(CMakePackage):
         apps = ["SuperLU_DIST", "SuperLU_DIST_RCI"]
         for app in apps:
             with test_part(self, f"test_superlu_{app}", purpose=f"run {app} example"):
-                if app == "SuperLU_DIST" and "~mpispawn" in self.spec:
+                if app == "SuperLU_DIST" and self.spec.satisfies("~mpispawn"):
                     raise SkipTest("Package must be installed with +superlu+mpispawn")
                 with working_dir(join_path(test_dir, app)):
                     terminate_bash_failures(".")
@@ -282,7 +283,7 @@ class Gptune(CMakePackage):
 
     def test_demo(self):
         """Run the demo test"""
-        if "~mpispawn" in self.spec:
+        if self.spec.satisfies("~mpispawn"):
             raise SkipTest("Package must be installed with +mpispawn")
 
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
@@ -298,7 +299,7 @@ class Gptune(CMakePackage):
         apps = ["Scalapack-PDGEQRF", "Scalapack-PDGEQRF_RCI"]
         for app in apps:
             with test_part(self, f"test_scalapack_{app}", purpose=f"run {app} example"):
-                if app == "Scalapack-PDGEQRF" and "~mpispawn" in self.spec:
+                if app == "Scalapack-PDGEQRF" and self.spec.satisfies("~mpispawn"):
                     raise SkipTest("Package must be installed with +superlu+mpispawn")
                 with working_dir(join_path(test_dir, app)):
                     terminate_bash_failures(".")

--- a/var/spack/repos/builtin/packages/gptune/package.py
+++ b/var/spack/repos/builtin/packages/gptune/package.py
@@ -128,13 +128,8 @@ class Gptune(CMakePackage):
 
             with working_dir(wd + "/superlu_dist"):
 
-                exe = which("mkdir")
-                exe("-p", "build")
-
-            with working_dir(wd + "/superlu_dist/build"):
-
-                exe = which("mkdir")
-                exe("-p", "EXAMPLE")
+                mkdir = which("mkdir")
+                mkdir("-p", join_path(wd, "superlu_dist", "build", "EXAMPLE"))
 
             with working_dir(wd + "/superlu_dist/build/EXAMPLE"):
 

--- a/var/spack/repos/builtin/packages/gptune/package.py
+++ b/var/spack/repos/builtin/packages/gptune/package.py
@@ -115,7 +115,6 @@ class Gptune(CMakePackage):
 
         if spec.satisfies("+superlu"):
             superludriver = join_path(spec["superlu-dist"].prefix.lib, "EXAMPLE/pddrive_spawn")
-            op = ["-r", superludriver, "."]
             # copy superlu-dist executables to the correct place
             wd = join_path(test_dir, "SuperLU_DIST")
             with working_dir(wd):

--- a/var/spack/repos/builtin/packages/gptune/package.py
+++ b/var/spack/repos/builtin/packages/gptune/package.py
@@ -131,10 +131,8 @@ class Gptune(CMakePackage):
                 mkdir = which("mkdir")
                 mkdir("-p", join_path(wd, "superlu_dist", "build", "EXAMPLE"))
 
-            with working_dir(wd + "/superlu_dist/build/EXAMPLE"):
-
-                exe = which("cp")
-                exe(*op)
+                cp = which("cp")
+                cp("-r", superludriver, join_path(wd, "superlu_dist", "build", "EXAMPLE"))
 
         if spec.satisfies("+hypre"):
             hypredriver = join_path(spec["hypre"].prefix.bin, "ij")

--- a/var/spack/repos/builtin/packages/gptune/package.py
+++ b/var/spack/repos/builtin/packages/gptune/package.py
@@ -120,33 +120,26 @@ class Gptune(CMakePackage):
             wd = join_path(test_dir, "SuperLU_DIST")
             with working_dir(wd):
 
-                with test_part(self, "test_part_rm", purpose="gptune rm test"):
-                    exe = which("rm")
-                    exe("-rf", "superlu_dist")
+                exe = which("rm")
+                exe("-rf", "superlu_dist")
 
-                with test_part(self, "test_part_git", purpose="gptune git test"):
-                    exe = which("git")
-                    exe("clone", "https://github.com/xiaoyeli/superlu_dist.git")
+                exe = which("git")
+                exe("clone", "https://github.com/xiaoyeli/superlu_dist.git")
 
             with working_dir(wd + "/superlu_dist"):
 
-                with test_part(self, "test_part_mkdir_build", purpose="gptune mkdir build test"):
-                    exe = which("mkdir")
-                    exe("-p", "build")
+                exe = which("mkdir")
+                exe("-p", "build")
 
             with working_dir(wd + "/superlu_dist/build"):
 
-                with test_part(
-                    self, "test_part_mkdir_example", purpose="gptune cp mkdir example test"
-                ):
-                    exe = which("mkdir")
-                    exe("-p", "EXAMPLE")
+                exe = which("mkdir")
+                exe("-p", "EXAMPLE")
 
             with working_dir(wd + "/superlu_dist/build/EXAMPLE"):
 
-                with test_part(self, "test_part_cp_basic", purpose="gptune cp basic test"):
-                    exe = which("cp")
-                    exe(*op)
+                exe = which("cp")
+                exe(*op)
 
         if spec.satisfies("+hypre"):
             hypredriver = join_path(spec["hypre"].prefix.bin, "ij")
@@ -155,22 +148,19 @@ class Gptune(CMakePackage):
             wd = join_path(test_dir, "Hypre")
             with working_dir(wd):
 
-                with test_part(self, "test_part_rm_hypre", purpose="gptune rm hypre test"):
-                    exe = which("rm")
-                    exe("-rf", "hypre")
+                exe = which("rm")
+                exe("-rf", "hypre")
 
-                with test_part(self, "test_part_git_hypre", purpose="gptune git hypre test"):
-                    exe = which("git")
-                    exe("clone", "https://github.com/hypre-space/hypre.git")
+                exe = which("git")
+                exe("clone", "https://github.com/hypre-space/hypre.git")
 
             with working_dir(wd + "/hypre/src/test/"):
 
-                with test_part(self, "test_part_cp_hypre", purpose="gptune cp hypre test"):
-                    exe = which("cp")
-                    exe(*op)
+                exe = which("cp")
+                exe(*op)
 
         wd = self.test_suite.current_test_cache_dir
-        with open("{0}/run_env.sh".format(wd), "w") as envfile:
+        with open(f"{wd}/run_env.sh", "w") as envfile:
             envfile.write('if [[ $NERSC_HOST = "cori" ]]; then\n')
             envfile.write("    export machine=cori\n")
             envfile.write('elif [[ $(uname -s) = "Darwin" ]]; then\n')
@@ -185,13 +175,13 @@ class Gptune(CMakePackage):
             envfile.write("    export machine=unknownlinux\n")
             envfile.write("fi\n")
             envfile.write("export GPTUNEROOT=$PWD\n")
-            envfile.write("export MPIRUN={0}\n".format(which(spec["mpi"].prefix.bin + "/mpirun")))
-            envfile.write("export PYTHONPATH={0}:$PYTHONPATH\n".format(python_platlib + "/gptune"))
+            envfile.write(f"export MPIRUN={which(spec['mpi'].prefix.bin + '/mpirun')}\n")
+            envfile.write(f"export PYTHONPATH={python_platlib + '/gptune'}:$PYTHONPATH\n")
             envfile.write("export proc=$(spack arch)\n")
-            envfile.write("export mpi={0}\n".format(spec["mpi"].name))
-            envfile.write("export compiler={0}\n".format(comp_name))
-            envfile.write("export nodes={0} \n".format(self.nodes))
-            envfile.write("export cores={0} \n".format(self.cores))
+            envfile.write(f"export mpi={spec['mpi'].name}\n")
+            envfile.write(f"export compiler={comp_name}\n")
+            envfile.write(f"export nodes={self.nodes} \n")
+            envfile.write(f"export cores={self.cores} \n")
             envfile.write("export ModuleEnv=$machine-$proc-$mpi-$compiler \n")
             envfile.write(
                 'software_json=$(echo ",\\"software_configuration\\":'
@@ -251,10 +241,9 @@ class Gptune(CMakePackage):
             ["run_env.sh", self.install_test_root + "/."],
         ]
         for op in ops:
-            with test_part(self, f"test_part_cp_{op[1]}", purpose=f"gptune cp {op[1]} test"):
-                with working_dir(wd):
-                    exe = which("cp")
-                    exe(*op)
+            with working_dir(wd):
+                exe = which("cp")
+                exe(*op)
 
         apps = ["Scalapack-PDGEQRF_RCI"]
         if spec.satisfies("+mpispawn"):

--- a/var/spack/repos/builtin/packages/gptune/package.py
+++ b/var/spack/repos/builtin/packages/gptune/package.py
@@ -7,11 +7,12 @@ import os
 from spack.package import *
 
 
-def terminate_bash_failures():
-    """Ensure bash scripts fail as soon as a command within fails."""
-    for f in os.listdir("."):
+def terminate_bash_failures(dir):
+    """Ensure bash scripts within the directory fail as soon as a command
+    within fails."""
+    for f in os.listdir(dir):
         if f.endswith(".sh"):
-            filter_file(r"#!/bin/bash", r"#!/bin/bash" + "\nset -e", f)
+            filter_file(r"#!/bin/bash", r"#!/bin/bash" + "\nset -e", join_path(dir, f))
 
 
 class Gptune(CMakePackage):
@@ -233,7 +234,7 @@ class Gptune(CMakePackage):
 
         # now run the test example
         with working_dir(join_path(test_dir, "Hypre")):
-            terminate_bash_failures()
+            terminate_bash_failures(".")
             self.bash("run_examples.sh")
 
     def test_superlu(self):
@@ -276,7 +277,7 @@ class Gptune(CMakePackage):
                 if app == "SuperLU_DIST" and "~mpispawn" in self.spec:
                     raise SkipTest("Package must be installed with +superlu+mpispawn")
                 with working_dir(join_path(test_dir, app)):
-                    terminate_bash_failures()
+                    terminate_bash_failures(".")
                     self.bash("run_examples.sh")
 
     def test_demo(self):
@@ -287,7 +288,7 @@ class Gptune(CMakePackage):
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
 
         with working_dir(join_path(test_dir, "GPTune-Demo")):
-            terminate_bash_failures()
+            terminate_bash_failures(".")
             self.bash("run_examples.sh")
 
     def test_scalapack(self):
@@ -300,5 +301,5 @@ class Gptune(CMakePackage):
                 if app == "Scalapack-PDGEQRF" and "~mpispawn" in self.spec:
                     raise SkipTest("Package must be installed with +superlu+mpispawn")
                 with working_dir(join_path(test_dir, app)):
-                    terminate_bash_failures()
+                    terminate_bash_failures(".")
                     self.bash("run_examples.sh")

--- a/var/spack/repos/builtin/packages/gptune/package.py
+++ b/var/spack/repos/builtin/packages/gptune/package.py
@@ -148,16 +148,16 @@ class Gptune(CMakePackage):
             wd = join_path(test_dir, "Hypre")
             with working_dir(wd):
 
-                exe = which("rm")
-                exe("-rf", "hypre")
+                rm = which("rm")
+                rm("-rf", "hypre")
 
-                exe = which("git")
-                exe("clone", "https://github.com/hypre-space/hypre.git")
+                git = which("git")
+                git("clone", "https://github.com/hypre-space/hypre.git")
 
             with working_dir(wd + "/hypre/src/test/"):
 
-                exe = which("cp")
-                exe(*op)
+                cp = which("cp")
+                cp(*op)
 
         wd = self.test_suite.current_test_cache_dir
         with open(f"{wd}/run_env.sh", "w") as envfile:

--- a/var/spack/repos/builtin/packages/gptune/package.py
+++ b/var/spack/repos/builtin/packages/gptune/package.py
@@ -238,7 +238,7 @@ class Gptune(CMakePackage):
         # copy the environment configuration files to non-cache directories
         ops = [
             ["run_env.sh", python_platlib + "/gptune/."],
-            ["run_env.sh", self.install_test_root + "/."],
+            ["run_env.sh", install_test_root(self) + "/."],
         ]
         for op in ops:
             with working_dir(wd):

--- a/var/spack/repos/builtin/packages/gptune/package.py
+++ b/var/spack/repos/builtin/packages/gptune/package.py
@@ -144,7 +144,7 @@ class Gptune(CMakePackage):
 
             with working_dir(wd + "/superlu_dist/build/EXAMPLE"):
 
-                with test_part(self, f"test_part_cp_basic", purpose=f"gptune cp basic test"):
+                with test_part(self, "test_part_cp_basic", purpose="gptune cp basic test"):
                     exe = which("cp")
                     exe(*op)
 

--- a/var/spack/repos/builtin/packages/gptune/package.py
+++ b/var/spack/repos/builtin/packages/gptune/package.py
@@ -101,7 +101,7 @@ class Gptune(CMakePackage):
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources([self.examples_src_dir])
+        cache_extra_test_sources(self, [self.examples_src_dir])
 
     def setup_run_environment(self, env):
         env.set("GPTUNE_INSTALL_PATH", python_platlib)


### PR DESCRIPTION
Change to the new stand-alone test API.

Supersedes #35747 

~No test output possible as running tests leads to an infinite loop.~

~Ended up adding timeouts when running the stand-alone test scripts.  Unfortunately, several tests appear to have infinite loops if they make it to running the scripts for any meaningful length of time. So the timeouts were dropped to 1 second.  The values can be increased to 1.5+ seconds to yield, IME, the "infinite loop" behavior.~

UPDATE (2024 Sep 4):
Foregoing subtleties by replacing timeouts with bash script updates that ensure termination on command failures, which should now allow us to perform stand-alone test checks on `gptune` in CI.  The appropriate version(s) of cloned packages for testing are also used.  A nice side-effect is that `test_hypre` now fails as it should based on its execution.  A drawback is you don't see the `jq` failure details (pasted in previous version of the description and copied below but is essentially the `numpy` problem reported for other tests):

```
...
jq: parse error: Invalid numeric literal at line 1, column 186
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'cfloat'?
run_examples.sh: line 71: syntax error near unexpected token `fi'
run_examples.sh: line 71: `fi'
FAILED: Gptune::test_demo: Command exited with status 2:
...
```

The latest output from running against 3 installed packages is:

```
$ spack find -lv gptune
..
qwv6xnz gptune@4.0.0~hypre~ipo~mpispawn~superlu build_system=cmake build_type=Release generator=make
pauqufk gptune@4.0.0~hypre~ipo+mpispawn~superlu build_system=cmake build_type=Release generator=make
m4tr6od gptune@4.0.0+hypre~ipo+mpispawn+superlu build_system=cmake build_type=Release generator=make
==> 3 installed packages


$ spack -v test run gptune
==> Testing package gptune-4.0.0-m4tr6od
..
==> [2024-09-04-14:26:12.691653] test: test_demo: Run the demo test
==> [2024-09-04-14:26:12.693448] FILTER FILE: run_examples.sh [replacing "#!/bin/bash"]
==> [2024-09-04-14:26:12.706400] '/usr/bin/bash' 'run_examples.sh'
..
jq: parse error: Invalid numeric literal at line 1, column 186
FAILED: Gptune::test_demo: Command exited with status 5:
..
==> [2024-09-04-14:26:14.320218] test: test_hypre: set up and run hypre example
==> [2024-09-04-14:26:14.322230] '/usr/bin/rm' '-rf' 'hypre'
==> [2024-09-04-14:26:14.324524] '/usr/tce/bin/git' 'clone' '--depth' '1' '--branch' 'v2.19.0' 'https://github.com/hypre-space/hypre.git'
Cloning into 'hypre'...
..
Updating files: 100% (1805/1805), done.
..
==> [2024-09-04-14:26:22.484246] '/usr/bin/bash' 'run_examples.sh'
..
jq: parse error: Invalid numeric literal at line 1, column 180
FAILED: Gptune::test_hypre: Command exited with status 5:
    '/usr/bin/bash' 'run_examples.sh'
==> [2024-09-04-14:26:23.975145] test: test_scalapack: Run scalapack tests
==> [2024-09-04-14:26:23.975509] test: test_scalapack_Scalapack-PDGEQRF: run Scalapack-PDGEQRF example
..
==> [2024-09-04-14:26:24.033920] '/usr/bin/bash' 'run_examples.sh'
..
  File "$SPACK_ROOT/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/py-scikit-optimize-0.9.0-nws55ccntouttg57lim2ysueb4sr2wyu/lib/python3.11/site-packages/skopt/space/space.py", line 253, in Real
    name=None, dtype=np.float, optimize=True):
                     ^^^^^^^^
  File "$SPACK_ROOT/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/py-numpy-1.24.4-4nixgbzrbsk37nywgsdmtjbypxrfif64/lib/python3.11/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'cfloat'?
FAILED: Gptune::test_scalapack_Scalapack-PDGEQRF: Command exited with status 1:
    '/usr/bin/bash' 'run_examples.sh'
..
==> [2024-09-04-14:26:28.228795] test: test_scalapack_Scalapack-PDGEQRF_RCI: run Scalapack-PDGEQRF_RCI example
..
==> [2024-09-04-14:26:28.261074] '/usr/bin/bash' 'run_examples.sh'
$spack_test/vyexhy2hliv3vxj26w7i6wux4ipnkxmf/gptune-4.0.0-m4tr6od/cache/gptune/examples/Scalapack-PDGEQRF_RCI
jq: parse error: Invalid numeric literal at line 1, column 182
FAILED: Gptune::test_scalapack_Scalapack-PDGEQRF_RCI: Command exited with status 5:
    '/usr/bin/bash' 'run_examples.sh'
..
FAILED: Gptune::test_scalapack
==> [2024-09-04-14:26:29.901544] test: test_superlu: set up and run superlu tests
==> [2024-09-04-14:26:29.903415] '/usr/bin/rm' '-rf' 'superlu_dist'
==> [2024-09-04-14:26:29.905738] '/usr/tce/bin/git' 'clone' '--depth' '1' '--branch' 'master' 'https://github.com/xiaoyeli/superlu_dist.git'
Cloning into 'superlu_dist'...
..
Updating files: 100% (668/668), done.
..
==> [2024-09-04-14:26:33.079654] test: test_superlu_SuperLU_DIST: run SuperLU_DIST example
..
==> [2024-09-04-14:26:33.137714] '/usr/bin/bash' 'run_examples.sh'
..
jq: parse error: Invalid numeric literal at line 1, column 187
FAILED: Gptune::test_superlu_SuperLU_DIST: Command exited with status 5:
    '/usr/bin/bash' 'run_examples.sh'
..
==> [2024-09-04-14:26:34.754140] test: test_superlu_SuperLU_DIST_RCI: run SuperLU_DIST_RCI example
..
==> [2024-09-04-14:26:34.855206] '/usr/bin/bash' 'run_examples.sh'
..
jq: parse error: Invalid numeric literal at line 1, column 187
FAILED: Gptune::test_superlu_SuperLU_DIST_RCI: Command exited with status 5:
    '/usr/bin/bash' 'run_examples.sh'
..
FAILED: Gptune::test_superlu
==> [2024-09-04-14:26:36.450688] Completed testing
==> [2024-09-04-14:26:36.450847] 
======================== SUMMARY: gptune-4.0.0-m4tr6od =========================
Gptune::test_demo .. FAILED
Gptune::test_hypre .. FAILED
Gptune::test_scalapack_Scalapack-PDGEQRF .. FAILED
Gptune::test_scalapack_Scalapack-PDGEQRF_RCI .. FAILED
Gptune::test_scalapack .. FAILED
Gptune::test_superlu_SuperLU_DIST .. FAILED
Gptune::test_superlu_SuperLU_DIST_RCI .. FAILED
Gptune::test_superlu .. FAILED
============================= 8 failed of 8 parts ==============================
==> [2024-09-04-14:26:36.450980] 
..
==> Testing package gptune-4.0.0-pauqufk
..
==> [2024-09-04-14:26:54.682356] test: test_demo: Run the demo test
..
==> [2024-09-04-14:26:54.697207] '/usr/bin/bash' 'run_examples.sh'
..
jq: parse error: Invalid numeric literal at line 1, column 186
FAILED: Gptune::test_demo: Command exited with status 5:
    '/usr/bin/bash' 'run_examples.sh'
..
==> [2024-09-04-14:26:57.134050] test: test_hypre: set up and run hypre example
SKIPPED: Gptune::test_hypre: Package must be installed with +hypre+mpispawn
==> [2024-09-04-14:26:57.134496] test: test_scalapack: Run scalapack tests
==> [2024-09-04-14:26:57.134768] test: test_scalapack_Scalapack-PDGEQRF: run Scalapack-PDGEQRF example
..
==> [2024-09-04-14:26:57.188194] '/usr/bin/bash' 'run_examples.sh'
..
    class Real(Dimension):
..
    name=None, dtype=np.float, optimize=True):
                     ^^^^^^^^
..
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'cfloat'?
FAILED: Gptune::test_scalapack_Scalapack-PDGEQRF: Command exited with status 1:
    '/usr/bin/bash' 'run_examples.sh'
..
==> [2024-09-04-14:27:00.706199] test: test_scalapack_Scalapack-PDGEQRF_RCI: run Scalapack-PDGEQRF_RCI example
..
==> [2024-09-04-14:27:00.735100] '/usr/bin/bash' 'run_examples.sh'
..
jq: parse error: Invalid numeric literal at line 1, column 182
FAILED: Gptune::test_scalapack_Scalapack-PDGEQRF_RCI: Command exited with status 5:
    '/usr/bin/bash' 'run_examples.sh'
..
FAILED: Gptune::test_scalapack
==> [2024-09-04-14:27:02.251953] test: test_superlu: set up and run superlu tests
SKIPPED: Gptune::test_superlu: Package must be installed with +superlu
==> [2024-09-04-14:27:02.254553] Completed testing
==> [2024-09-04-14:27:02.254676] 
======================== SUMMARY: gptune-4.0.0-pauqufk =========================
Gptune::test_demo .. FAILED
Gptune::test_hypre .. SKIPPED
Gptune::test_scalapack_Scalapack-PDGEQRF .. FAILED
Gptune::test_scalapack_Scalapack-PDGEQRF_RCI .. FAILED
Gptune::test_scalapack .. FAILED
Gptune::test_superlu .. SKIPPED
======================== 4 failed, 2 skipped of 6 parts ========================
..
==> Testing package gptune-4.0.0-qwv6xnz
..
==> [2024-09-04-14:27:29.831345] test: test_demo: Run the demo test
SKIPPED: Gptune::test_demo: Package must be installed with +mpispawn
==> [2024-09-04-14:27:29.831938] test: test_hypre: set up and run hypre example
SKIPPED: Gptune::test_hypre: Package must be installed with +hypre+mpispawn
==> [2024-09-04-14:27:29.832265] test: test_scalapack: Run scalapack tests
==> [2024-09-04-14:27:29.832507] test: test_scalapack_Scalapack-PDGEQRF: run Scalapack-PDGEQRF example
SKIPPED: Gptune::test_scalapack_Scalapack-PDGEQRF: Package must be installed with +superlu+mpispawn
==> [2024-09-04-14:27:29.832758] test: test_scalapack_Scalapack-PDGEQRF_RCI: run Scalapack-PDGEQRF_RCI example
..
==> [2024-09-04-14:27:29.860801] '/usr/bin/bash' 'run_examples.sh'
..
jq: parse error: Invalid numeric literal at line 1, column 182
FAILED: Gptune::test_scalapack_Scalapack-PDGEQRF_RCI: Command exited with status 5:
    '/usr/bin/bash' 'run_examples.sh'
..
FAILED: Gptune::test_scalapack
==> [2024-09-04-14:27:31.456576] test: test_superlu: set up and run superlu tests
SKIPPED: Gptune::test_superlu: Package must be installed with +superlu
==> [2024-09-04-14:27:31.459437] Completed testing
==> [2024-09-04-14:27:31.459692] 
======================== SUMMARY: gptune-4.0.0-qwv6xnz =========================
Gptune::test_demo .. SKIPPED
Gptune::test_hypre .. SKIPPED
Gptune::test_scalapack_Scalapack-PDGEQRF .. SKIPPED
Gptune::test_scalapack_Scalapack-PDGEQRF_RCI .. FAILED
Gptune::test_scalapack .. FAILED
Gptune::test_superlu .. SKIPPED
======================== 4 skipped, 2 failed of 6 parts ========================
..
============================= 3 failed of 3 specs ==============================
```