### PR TITLE
Remove `# generated` comments from many packages, add some missing `depends_on("cxx")`

### DIFF
--- a/var/spack/repos/builtin/packages/asio/package.py
+++ b/var/spack/repos/builtin/packages/asio/package.py
@@ -62,7 +62,7 @@ class Asio(AutotoolsPackage):
     version("1.16.1", sha256="e40bbd531530f08318b7c7d7e84e457176d8eae6f5ad2e3714dc27b9131ecd35")
     version("1.16.0", sha256="c87410ea62de6245aa239b9ed2057edf01d7f66acc3f5e50add9a29343c87512")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")

--- a/var/spack/repos/builtin/packages/dla-future/package.py
+++ b/var/spack/repos/builtin/packages/dla-future/package.py
@@ -27,8 +27,8 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
     version("0.1.0", sha256="f7ffcde22edabb3dc24a624e2888f98829ee526da384cd752b2b271c731ca9b1")
     version("master", branch="master")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     variant("shared", default=True, description="Build shared libraries.")
 

--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -46,6 +46,8 @@ class Fmt(CMakePackage):
     version("3.0.0", sha256="1b050b66fa31b74f1d75a14f15e99e728ab79572f176a53b2f8ad7c201c30ceb")
     version("master", branch="master")
 
+    depends_on("cxx", type="build")
+
     variant(
         "cxxstd",
         default="11",

--- a/var/spack/repos/builtin/packages/gperftools/package.py
+++ b/var/spack/repos/builtin/packages/gperftools/package.py
@@ -34,8 +34,8 @@ class Gperftools(AutotoolsPackage, CMakePackage):
     version("2.4", sha256="982a37226eb42f40714e26b8076815d5ea677a422fb52ff8bfca3704d9c30a2d")
     version("2.3", sha256="093452ad45d639093c144b4ec732a3417e8ee1f3744f2b0f8d45c996223385ce")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     variant("sized_delete", default=False, description="Build sized delete operator")
     variant(

--- a/var/spack/repos/builtin/packages/hpx-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/hpx-kokkos/package.py
@@ -24,7 +24,7 @@ class HpxKokkos(CMakePackage, CudaPackage, ROCmPackage):
     version("0.2.0", sha256="289b711cea26afe80be002fc521234c9194cd0e8f69863f3b08b654674dbe5d5")
     version("0.1.0", sha256="24edb817d0969f4aea1b68eab4984c2ea9a58f4760a9b8395e20f85b178f0850")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     cxxstds = ("14", "17", "20")
     variant(

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -41,7 +41,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
     version("1.2.0", sha256="20942314bd90064d9775f63b0e58a8ea146af5260a4c84d0854f9f968077c170")
     version("1.1.0", sha256="1f28bbe58d8f0da600d60c3a74a644d75ac777b20a018a5c1c6030a470e8a1c9")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     generator("ninja")
 

--- a/var/spack/repos/builtin/packages/mimalloc/package.py
+++ b/var/spack/repos/builtin/packages/mimalloc/package.py
@@ -32,8 +32,8 @@ class Mimalloc(CMakePackage):
     version("1.7.7", sha256="0f6663be1e1764851bf9563fcf7a6b3330e23b933eb4737dd07e3289b87895fe")
     version("1.7.6", sha256="d74f86ada2329016068bc5a243268f1f555edd620b6a7d6ce89295e7d6cf18da")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.0:", type="build")
 

--- a/var/spack/repos/builtin/packages/mold/package.py
+++ b/var/spack/repos/builtin/packages/mold/package.py
@@ -29,8 +29,8 @@ class Mold(CMakePackage):
     version("1.11.0", sha256="99318eced81b09a77e4c657011076cc8ec3d4b6867bd324b8677974545bc4d6f")
     version("1.7.1", sha256="fa2558664db79a1e20f09162578632fa856b3cde966fbcb23084c352b827dfa9")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("blake3", when="@2.2:")
     depends_on("mimalloc")

--- a/var/spack/repos/builtin/packages/pika-algorithms/package.py
+++ b/var/spack/repos/builtin/packages/pika-algorithms/package.py
@@ -24,7 +24,7 @@ class PikaAlgorithms(CMakePackage):
     version("0.1.0", sha256="64da008897dfa7373155595c46d2ce6b97a8a3cb5bea33ae7f2d1ff359f0d9b6")
     version("main", branch="main")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     generator("ninja")
 

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -51,7 +51,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     version("0.1.0", sha256="aa0ae2396cd264d821a73c4c7ecb118729bb3de042920c9248909d33755e7327")
     version("main", branch="main")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     generator("ninja")
 

--- a/var/spack/repos/builtin/packages/stdexec/package.py
+++ b/var/spack/repos/builtin/packages/stdexec/package.py
@@ -19,7 +19,7 @@ class Stdexec(CMakePackage):
     version("23.03", sha256="2c9dfb6e56a190543049d2300ccccd1b626f4bb82af5b607869c626886fadd15")
     version("main", branch="main")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.23.1:", type="build")
 

--- a/var/spack/repos/builtin/packages/tracy-client/package.py
+++ b/var/spack/repos/builtin/packages/tracy-client/package.py
@@ -22,8 +22,8 @@ class TracyClient(CMakePackage):
     version("0.8.2", sha256="4784eddd89c17a5fa030d408392992b3da3c503c872800e9d3746d985cfcc92a")
     version("0.8.1", sha256="004992012b2dc879a9f6d143cbf94d7ea30e88135db3ef08951605d214892891")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     variant("shared", default=True, description="Build the client library as a shared library")
 

--- a/var/spack/repos/builtin/packages/tracy/package.py
+++ b/var/spack/repos/builtin/packages/tracy/package.py
@@ -22,8 +22,8 @@ class Tracy(MakefilePackage):
     version("0.8.2", sha256="4784eddd89c17a5fa030d408392992b3da3c503c872800e9d3746d985cfcc92a")
     version("0.8.1", sha256="004992012b2dc879a9f6d143cbf94d7ea30e88135db3ef08951605d214892891")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("capstone")
     depends_on("dbus")

--- a/var/spack/repos/builtin/packages/ut/package.py
+++ b/var/spack/repos/builtin/packages/ut/package.py
@@ -22,7 +22,7 @@ class Ut(CMakePackage):
     version("2.0.0", sha256="8b5b11197d1308dfc1fe20efd6a656e0c833dbec2807e2292967f6e2f7c0420f")
     version("1.1.9", sha256="1a666513157905aa0e53a13fac602b5673dcafb04a869100a85cd3f000c2ed0d")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     generator("ninja")
 

--- a/var/spack/repos/builtin/packages/whip/package.py
+++ b/var/spack/repos/builtin/packages/whip/package.py
@@ -22,6 +22,8 @@ class Whip(CMakePackage, CudaPackage, ROCmPackage):
     version("0.2.0", sha256="d8fec662526accbd1624922fdf01a077d6f312cf253382660e4a2f65e28e8686")
     version("0.1.0", sha256="5d557794f4afc8332fc660948a342f69e22bc9e5d575ffb3e3944cf526db5ec9")
 
+    depends_on("cxx", type="build")
+
     depends_on("cmake@3.22:", type="build")
 
     # Exactly one of +cuda and +rocm need to be set


### PR DESCRIPTION
This updates all the packages that I'm maintaining. The auto-generated ones were correct so I've removed the `# generated` comments. I've added `depends_on("cxx")` to a couple that didn't have any language dependency (`fmt` and `whip`).