### PR TITLE
apptainer: add v1.3.2, v1.3.3

### DIFF
--- a/var/spack/repos/builtin/packages/apptainer/package.py
+++ b/var/spack/repos/builtin/packages/apptainer/package.py
@@ -36,7 +36,8 @@ class Apptainer(SingularityBase):
     )
 
     version("main", branch="main")
-    version("1.3.1", sha256="6956c689c4a8f148789c5c34b33c15ad8f3460b4cee3f48022119fd872eacee9")
+    version("1.3.3", sha256="94a274ab4898cdb131f4e3867c4e15f7e16bc2823303d2afcbafee0242f0838d")
+    version("1.3.2", sha256="483910727e1a15843b93d9f2db1fc87e27804de9c74da13cc32cd4bd0d35e079")
     version("1.2.5", sha256="606b67ef97683e1420401718687d258b1034fdf2edae72eeacd0828dffbfc2c2")
     version("1.1.9", sha256="c615777539154288542cf393d3fd44c04ccb3260bc6330dc324d4e4ebe902bfa")
     version("1.1.7", sha256="e6d3956a26c3965703402e17f153ba07f59bf710068806462b314d2d04e825e7")

--- a/var/spack/repos/builtin/packages/apptainer/package.py
+++ b/var/spack/repos/builtin/packages/apptainer/package.py
@@ -38,6 +38,8 @@ class Apptainer(SingularityBase):
     version("main", branch="main")
     version("1.3.3", sha256="94a274ab4898cdb131f4e3867c4e15f7e16bc2823303d2afcbafee0242f0838d")
     version("1.3.2", sha256="483910727e1a15843b93d9f2db1fc87e27804de9c74da13cc32cd4bd0d35e079")
+    # version "1.3.1" has security vulnerability CVE-2024-3727
+    # see also https://github.com/advisories/GHSA-6wvf-f2vw-3425
     version("1.2.5", sha256="606b67ef97683e1420401718687d258b1034fdf2edae72eeacd0828dffbfc2c2")
     version("1.1.9", sha256="c615777539154288542cf393d3fd44c04ccb3260bc6330dc324d4e4ebe902bfa")
     version("1.1.7", sha256="e6d3956a26c3965703402e17f153ba07f59bf710068806462b314d2d04e825e7")


### PR DESCRIPTION
apptainer 1.3.1 has a high severity security issue: CVE-2024-3727
Upgrade to 1.3.2 or preferably 1.3.3

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
