### PR TITLE
Update hdf-eos2 package.py to fix build errors with Intel oneAPI

### DIFF
--- a/var/spack/repos/builtin/packages/hdf-eos2/package.py
+++ b/var/spack/repos/builtin/packages/hdf-eos2/package.py
@@ -120,9 +120,11 @@ class HdfEos2(AutotoolsPackage):
         filter_file("CC=./\\$SZIP_CC", "", "configure")
 
     def flag_handler(self, name, flags):
-        if self.spec.compiler.name == "apple-clang":
-            if name == "cflags":
+        if name == "cflags":
+            flags.append(self.compiler.cc_pic_flag)
+            if self.spec.compiler.name in ["apple-clang", "oneapi"]:
                 flags.append("-Wno-error=implicit-function-declaration")
+                flags.append("-Wno-error=implicit-int")
 
         return flags, None, None
 
@@ -159,16 +161,5 @@ class HdfEos2(AutotoolsPackage):
             extra_args.append("--with-szlib={0}".format(self.spec["szip"].prefix))
         if "zlib" in self.spec:
             extra_args.append("--with-zlib={0}".format(self.spec["zlib-api"].prefix))
-
-        # https://forum.hdfgroup.org/t/help-building-hdf4-with-clang-error-implicit-declaration-of-function-test-mgr-szip-is-invalid-in-c99/7680
-        # -fPIC: https://github.com/spack/spack/issues/43792
-        if self.spec.satisfies("%apple-clang"):
-            extra_args.append(
-                "CFLAGS=-Wno-error=implicit-function-declaration {0}".format(
-                    self.compiler.cc_pic_flag
-                )
-            )
-        else:
-            extra_args.append("CFLAGS={0}".format(self.compiler.cc_pic_flag))
 
         return extra_args


### PR DESCRIPTION
The Intel oneAPI (LLVM-based) compilers (`icx`) need `-Wno-error=implicit-function-declaration` and `-Wno-error-implicit-int` to build `hdf-eos2`, same as for `apple-clang`. I took the opportunity to clean up redundant settings in the package while at it.