### PR TITLE
uftrace: change executable declaration in stand-alone test

### DIFF
--- a/var/spack/repos/builtin/packages/uftrace/package.py
+++ b/var/spack/repos/builtin/packages/uftrace/package.py
@@ -56,7 +56,7 @@ class Uftrace(AutotoolsPackage):
 
     def test_uftrace(self):
         """Perform stand-alone/smoke tests using the installed package."""
-        uftrace = self.prefix.bin.uftrace
+        uftrace = which(self.prefix.bin.uftrace)
         options = (["-A", ".", "-R", ".", "-P", "main", uftrace, "-V"],)
         expected = [
             r"dwarf",


### PR DESCRIPTION
earlier version (#45364) should have preformed `which` on the `uftrace` executable. This PR adresseses this.