### PR TITLE
`spack pkg grep`: don't warn when grepping for quoted strings

### DIFF
--- a/lib/spack/spack/cmd/pkg.py
+++ b/lib/spack/spack/cmd/pkg.py
@@ -169,7 +169,9 @@ def pkg_hash(args):
 
 def get_grep(required=False):
     """Get a grep command to use with ``spack pkg grep``."""
-    return exe.which(os.environ.get("SPACK_GREP") or "grep", required=required)
+    grep = exe.which(os.environ.get("SPACK_GREP") or "grep", required=required)
+    grep.ignore_quotes = True  # allow `spack pkg grep '"quoted string"'` without warning
+    return grep
 
 
 def pkg_grep(args, unknown_args):

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -31,6 +31,7 @@ class Executable:
 
         self.default_envmod = EnvironmentModifications()
         self.returncode = None
+        self.ignore_quotes = False
 
         if not self.exe:
             raise ProcessError("Cannot construct executable for '%s'" % name)
@@ -188,7 +189,7 @@ class Executable:
 
         fail_on_error = kwargs.pop("fail_on_error", True)
         ignore_errors = kwargs.pop("ignore_errors", ())
-        ignore_quotes = kwargs.pop("ignore_quotes", False)
+        ignore_quotes = kwargs.pop("ignore_quotes", self.ignore_quotes)
         timeout = kwargs.pop("timeout", None)
 
         # If they just want to ignore one error code, make it a tuple.


### PR DESCRIPTION
The `Executable` class emits a warning when you pass quoted arguments to it:

```
> spack pkg grep '"namespace"'
==> Warning: Quotes in command arguments can confuse scripts like configure.
  The following arguments may cause problems when executed:
      "namespace"
  Quotes aren't needed because spack doesn't use a shell. Consider removing them.
  If multiple levels of quotation are required, use `ignore_quotes=True`.

... hundreds more warnings ...
```

This is to warn new package authors who aren't used to calling build commands in python. It's not useful for `spack pkg grep`, where we really are passing args on the command line, and if we pass a quoted string, we probably meant to.

- [x] make `ignore_quotes` an instance variable, not just an argument to ``__call__`
- [x] set `ignore_quotes` to `True` in `spack pkg grep`

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
