### PR TITLE
Windows: Port Libuv

### DIFF
--- a/var/spack/repos/builtin/packages/gloo/package.py
+++ b/var/spack/repos/builtin/packages/gloo/package.py
@@ -47,6 +47,7 @@ class Gloo(CMakePackage, CudaPackage):
 
     generator("ninja")
     depends_on("cmake@2.8.12:", type="build")
+    depends_on("libuv", when="platform=windows")
 
     def cmake_args(self):
         return [self.define_from_variant("USE_CUDA", "cuda")]

--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -51,9 +51,25 @@ class Libuv(AutotoolsPackage, CMakePackage):
         depends_on("libtool", type="build", when="@:1.43.0")
         depends_on("m4", type="build", when="@:1.43.0")
 
+    # CMake is Windows only for now due to the constraints
+    # placed by the libuv-dist source distribution.
+    # The '-dist' source distribution does not have CMake files.
+    # To build with CMake we need to use the standard distribution,
+    # however this has a different hash per version and the version
+    # directive does not support spec conditions (when).
+    # This means we need a version directive for each build system but as
+    # conditions over specs are not an option, we are limited to python
+    # conditionals, so we vary over platform.
+    # Allowing multiple platforms to use CMake would result in either autotools
+    # being forced to use the non dist source distribution or in a hash conflict
+
+    # new libuv versions should only use CMake to prevent the scenario
+    # described above
+
     build_system(
-        conditional("cmake", when="@1.25:"),
-        "autotools",
+        conditional("cmake+ownlibs", when="@1.48: platform=windows"),
+        conditional("cmake+ownlibs", when="@1.49:"),
+        conditional("autotools", when="@:1.48"),
         default="autotools"
     )
 

--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -54,6 +54,9 @@ class Libuv(CMakePackage, AutotoolsPackage):
         depends_on("libtool", type="build", when="@:1.43.0")
         depends_on("m4", type="build", when="@:1.43.0")
 
+    with when("build_system=cmake"):
+        depends_on("cmake+ownlibs")
+
     # CMake is Windows only for now due to the constraints
     # placed by the libuv-dist source distribution.
     # The '-dist' source distribution does not have CMake files.

--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -5,7 +5,6 @@
 import sys
 
 import spack.build_systems
-import spack.build_systems
 from spack.package import *
 
 
@@ -20,23 +19,55 @@ class Libuv(CMakePackage, AutotoolsPackage):
     license("MIT")
 
     if sys.platform == "win32":
-        version("1.48.0", sha256="7f1db8ac368d89d1baf163bac1ea5fe5120697a73910c8ae6b2fffb3551d59fb")
+        version(
+            "1.48.0", sha256="7f1db8ac368d89d1baf163bac1ea5fe5120697a73910c8ae6b2fffb3551d59fb"
+        )
     else:
-        version("1.48.0", sha256="c593139feb9061699fdd2f7fde47bb6c1ca77761ae9ec04f052083f1ef46c13b")
-        version("1.46.0", sha256="94f101111ef3209340d7f09c2aa150ddb4feabd2f9d87d47d9f5bded835b8094")
-        version("1.45.0", sha256="3793d8c0d6fa587721d010d0555b7e82443fd4e8b3c91e529eb6607592f52b87")
-        version("1.44.2", sha256="8ff28f6ac0d6d2a31d2eeca36aff3d7806706c7d3f5971f5ee013ddb0bdd2e9e")
-        version("1.44.1", sha256="b7293cefb470e17774dcf5d62c4c969636172726155b55ceef5092b7554863cc")
-        version("1.44.0", sha256="6c52494401cfe8d08fb4ec245882f0bd4b1572b5a8e79d6c418b855422a1a27d")
-        version("1.43.0", sha256="90d72bb7ae18de2519d0cac70eb89c319351146b90cd3f91303a492707e693a4")
-        version("1.42.0", sha256="43129625155a8aed796ebe90b8d4c990a73985ec717de2b2d5d3a23cfe4deb72")
-        version("1.41.1", sha256="65db0c7f2438bc8cd48865de282bf6670027f3557d6e3cb62fb65b2e350a687d")
-        version("1.41.0", sha256="1184533907e1ddad9c0dcd30a5abb0fe25288c287ff7fee303fff7b9b2d6eb6e")
-        version("1.40.0", sha256="61a90db95bac00adec1cc5ddc767ebbcaabc70242bd1134a7a6b1fb1d498a194")
-        version("1.39.0", sha256="5c52de5bdcfb322dbe10f98feb56e45162e668ad08bc28ab4b914d4f79911697")
-        version("1.38.1", sha256="0ece7d279e480fa386b066130a562ad1a622079d43d1c30731f2f66cd3f5c647")
-        version("1.25.0", sha256="0e927ddc0f1c83899000a63e9286cac5958222f8fb5870a49b0c81804944a912")
-        version("1.10.0", sha256="0307a0eec6caddd476f9cad39e18fdd6f22a08aa58103c4b0aead96d638be15e")
+        version(
+            "1.48.0", sha256="c593139feb9061699fdd2f7fde47bb6c1ca77761ae9ec04f052083f1ef46c13b"
+        )
+        version(
+            "1.46.0", sha256="94f101111ef3209340d7f09c2aa150ddb4feabd2f9d87d47d9f5bded835b8094"
+        )
+        version(
+            "1.45.0", sha256="3793d8c0d6fa587721d010d0555b7e82443fd4e8b3c91e529eb6607592f52b87"
+        )
+        version(
+            "1.44.2", sha256="8ff28f6ac0d6d2a31d2eeca36aff3d7806706c7d3f5971f5ee013ddb0bdd2e9e"
+        )
+        version(
+            "1.44.1", sha256="b7293cefb470e17774dcf5d62c4c969636172726155b55ceef5092b7554863cc"
+        )
+        version(
+            "1.44.0", sha256="6c52494401cfe8d08fb4ec245882f0bd4b1572b5a8e79d6c418b855422a1a27d"
+        )
+        version(
+            "1.43.0", sha256="90d72bb7ae18de2519d0cac70eb89c319351146b90cd3f91303a492707e693a4"
+        )
+        version(
+            "1.42.0", sha256="43129625155a8aed796ebe90b8d4c990a73985ec717de2b2d5d3a23cfe4deb72"
+        )
+        version(
+            "1.41.1", sha256="65db0c7f2438bc8cd48865de282bf6670027f3557d6e3cb62fb65b2e350a687d"
+        )
+        version(
+            "1.41.0", sha256="1184533907e1ddad9c0dcd30a5abb0fe25288c287ff7fee303fff7b9b2d6eb6e"
+        )
+        version(
+            "1.40.0", sha256="61a90db95bac00adec1cc5ddc767ebbcaabc70242bd1134a7a6b1fb1d498a194"
+        )
+        version(
+            "1.39.0", sha256="5c52de5bdcfb322dbe10f98feb56e45162e668ad08bc28ab4b914d4f79911697"
+        )
+        version(
+            "1.38.1", sha256="0ece7d279e480fa386b066130a562ad1a622079d43d1c30731f2f66cd3f5c647"
+        )
+        version(
+            "1.25.0", sha256="0e927ddc0f1c83899000a63e9286cac5958222f8fb5870a49b0c81804944a912"
+        )
+        version(
+            "1.10.0", sha256="0307a0eec6caddd476f9cad39e18fdd6f22a08aa58103c4b0aead96d638be15e"
+        )
         version("1.9.0", sha256="d595b2725abcce851c76239aab038adc126c58714cfb572b2ebb2d21b3593842")
 
     def url_for_version(self, version):
@@ -72,10 +103,7 @@ class Libuv(CMakePackage, AutotoolsPackage):
     # new libuv versions should only use CMake to prevent the scenario
     # described above
 
-    build_system(
-        conditional("cmake", when="@1.48: platform=windows"),
-        "autotools"
-    )
+    build_system(conditional("cmake", when="@1.48: platform=windows"), "autotools")
     conflicts(
         "%gcc@:4.8",
         when="@1.45:",
@@ -96,8 +124,9 @@ class Libuv(CMakePackage, AutotoolsPackage):
         "platform=windows",
         when="@:1.20",
         msg="Build system for Windows in versions older than 1.21 is"
-        "broken for versions of MSVC supported by Spack"
+        "broken for versions of MSVC supported by Spack",
     )
+
 
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
     @when("@:1.43")

--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -20,7 +20,7 @@ class Libuv(CMakePackage, AutotoolsPackage):
     license("MIT")
 
     if sys.platform == "win32":
-        version("1.48.0", sha256="")
+        version("1.48.0", sha256="7f1db8ac368d89d1baf163bac1ea5fe5120697a73910c8ae6b2fffb3551d59fb")
     else:
         version("1.48.0", sha256="c593139feb9061699fdd2f7fde47bb6c1ca77761ae9ec04f052083f1ef46c13b")
         version("1.46.0", sha256="94f101111ef3209340d7f09c2aa150ddb4feabd2f9d87d47d9f5bded835b8094")
@@ -74,11 +74,8 @@ class Libuv(CMakePackage, AutotoolsPackage):
 
     build_system(
         conditional("cmake", when="@1.48: platform=windows"),
-        conditional("cmake", when="@1.49:"),
-        conditional("autotools", when="@:1.48"),
-        default="autotools"
+        "autotools"
     )
-
     conflicts(
         "%gcc@:4.8",
         when="@1.45:",

--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -101,7 +101,7 @@ class Libuv(CMakePackage, AutotoolsPackage):
 
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
     @when("@:1.43")
-    def autoreconf(self, spec, prefix):
+    def autoreconf(self, pkg, spec, prefix):
         # This is needed because autogen.sh generates on-the-fly
         # an m4 macro needed during configuration
         Executable("./autogen.sh")()

--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -9,7 +9,7 @@ import spack.build_systems
 from spack.package import *
 
 
-class Libuv(AutotoolsPackage, CMakePackage):
+class Libuv(CMakePackage, AutotoolsPackage):
     """Multi-platform library with a focus on asynchronous IO"""
 
     homepage = "https://libuv.org"
@@ -19,22 +19,25 @@ class Libuv(AutotoolsPackage, CMakePackage):
 
     license("MIT")
 
-    version("1.48.0", sha256="c593139feb9061699fdd2f7fde47bb6c1ca77761ae9ec04f052083f1ef46c13b")
-    version("1.46.0", sha256="94f101111ef3209340d7f09c2aa150ddb4feabd2f9d87d47d9f5bded835b8094")
-    version("1.45.0", sha256="3793d8c0d6fa587721d010d0555b7e82443fd4e8b3c91e529eb6607592f52b87")
-    version("1.44.2", sha256="8ff28f6ac0d6d2a31d2eeca36aff3d7806706c7d3f5971f5ee013ddb0bdd2e9e")
-    version("1.44.1", sha256="b7293cefb470e17774dcf5d62c4c969636172726155b55ceef5092b7554863cc")
-    version("1.44.0", sha256="6c52494401cfe8d08fb4ec245882f0bd4b1572b5a8e79d6c418b855422a1a27d")
-    version("1.43.0", sha256="90d72bb7ae18de2519d0cac70eb89c319351146b90cd3f91303a492707e693a4")
-    version("1.42.0", sha256="43129625155a8aed796ebe90b8d4c990a73985ec717de2b2d5d3a23cfe4deb72")
-    version("1.41.1", sha256="65db0c7f2438bc8cd48865de282bf6670027f3557d6e3cb62fb65b2e350a687d")
-    version("1.41.0", sha256="1184533907e1ddad9c0dcd30a5abb0fe25288c287ff7fee303fff7b9b2d6eb6e")
-    version("1.40.0", sha256="61a90db95bac00adec1cc5ddc767ebbcaabc70242bd1134a7a6b1fb1d498a194")
-    version("1.39.0", sha256="5c52de5bdcfb322dbe10f98feb56e45162e668ad08bc28ab4b914d4f79911697")
-    version("1.38.1", sha256="0ece7d279e480fa386b066130a562ad1a622079d43d1c30731f2f66cd3f5c647")
-    version("1.25.0", sha256="0e927ddc0f1c83899000a63e9286cac5958222f8fb5870a49b0c81804944a912")
-    version("1.10.0", sha256="0307a0eec6caddd476f9cad39e18fdd6f22a08aa58103c4b0aead96d638be15e")
-    version("1.9.0", sha256="d595b2725abcce851c76239aab038adc126c58714cfb572b2ebb2d21b3593842")
+    if sys.platform == "win32":
+        version("1.48.0", sha256="")
+    else:
+        version("1.48.0", sha256="c593139feb9061699fdd2f7fde47bb6c1ca77761ae9ec04f052083f1ef46c13b")
+        version("1.46.0", sha256="94f101111ef3209340d7f09c2aa150ddb4feabd2f9d87d47d9f5bded835b8094")
+        version("1.45.0", sha256="3793d8c0d6fa587721d010d0555b7e82443fd4e8b3c91e529eb6607592f52b87")
+        version("1.44.2", sha256="8ff28f6ac0d6d2a31d2eeca36aff3d7806706c7d3f5971f5ee013ddb0bdd2e9e")
+        version("1.44.1", sha256="b7293cefb470e17774dcf5d62c4c969636172726155b55ceef5092b7554863cc")
+        version("1.44.0", sha256="6c52494401cfe8d08fb4ec245882f0bd4b1572b5a8e79d6c418b855422a1a27d")
+        version("1.43.0", sha256="90d72bb7ae18de2519d0cac70eb89c319351146b90cd3f91303a492707e693a4")
+        version("1.42.0", sha256="43129625155a8aed796ebe90b8d4c990a73985ec717de2b2d5d3a23cfe4deb72")
+        version("1.41.1", sha256="65db0c7f2438bc8cd48865de282bf6670027f3557d6e3cb62fb65b2e350a687d")
+        version("1.41.0", sha256="1184533907e1ddad9c0dcd30a5abb0fe25288c287ff7fee303fff7b9b2d6eb6e")
+        version("1.40.0", sha256="61a90db95bac00adec1cc5ddc767ebbcaabc70242bd1134a7a6b1fb1d498a194")
+        version("1.39.0", sha256="5c52de5bdcfb322dbe10f98feb56e45162e668ad08bc28ab4b914d4f79911697")
+        version("1.38.1", sha256="0ece7d279e480fa386b066130a562ad1a622079d43d1c30731f2f66cd3f5c647")
+        version("1.25.0", sha256="0e927ddc0f1c83899000a63e9286cac5958222f8fb5870a49b0c81804944a912")
+        version("1.10.0", sha256="0307a0eec6caddd476f9cad39e18fdd6f22a08aa58103c4b0aead96d638be15e")
+        version("1.9.0", sha256="d595b2725abcce851c76239aab038adc126c58714cfb572b2ebb2d21b3593842")
 
     def url_for_version(self, version):
         if self.spec.satisfies("@:1.43") or self.spec.satisfies("build_system=cmake"):
@@ -67,8 +70,8 @@ class Libuv(AutotoolsPackage, CMakePackage):
     # described above
 
     build_system(
-        conditional("cmake+ownlibs", when="@1.48: platform=windows"),
-        conditional("cmake+ownlibs", when="@1.49:"),
+        conditional("cmake", when="@1.48: platform=windows"),
+        conditional("cmake", when="@1.49:"),
         conditional("autotools", when="@:1.48"),
         default="autotools"
     )

--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -100,7 +100,6 @@ class Libuv(CMakePackage, AutotoolsPackage):
     # pull different sources if you are on Windows and (b) make sure cmake
     # build is not chosen on Linux
     # (because Linux does not download the cmake-enabled source).
-
     # new libuv versions should only use CMake to prevent the scenario
     # described above
     build_system(
@@ -114,7 +113,8 @@ class Libuv(CMakePackage, AutotoolsPackage):
         depends_on("m4", type="build", when="@:1.43.0")
 
     with when("build_system=cmake"):
-        # explictly require ownlibs
+        # explicitly require ownlibs to indicate we're short
+        # circuiting the cmake<->libuv cyclic dependency here
         depends_on("cmake+ownlibs")
 
     conflicts(

--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -87,7 +87,7 @@ class Libuv(CMakePackage, AutotoolsPackage):
     # new libuv versions should only use CMake to prevent the scenario
     # described above
     build_system(
-        conditional("cmake", when="@1.48: platform=windows"), "autotools", default="autotools"
+        conditional("cmake", when="platform=windows"), "autotools", default="autotools"
     )
 
     with when("build_system=autotools"):

--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -86,9 +86,7 @@ class Libuv(CMakePackage, AutotoolsPackage):
     # (because Linux does not download the cmake-enabled source).
     # new libuv versions should only use CMake to prevent the scenario
     # described above
-    build_system(
-        conditional("cmake", when="platform=windows"), "autotools", default="autotools"
-    )
+    build_system(conditional("cmake", when="platform=windows"), "autotools", default="autotools")
 
     with when("build_system=autotools"):
         depends_on("automake", type="build", when="@:1.43.0")

--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -59,30 +59,14 @@ class Libuv(CMakePackage, AutotoolsPackage):
         version(
             "1.44.0", sha256="6c52494401cfe8d08fb4ec245882f0bd4b1572b5a8e79d6c418b855422a1a27d"
         )
-    version(
-        "1.43.0", sha256="90d72bb7ae18de2519d0cac70eb89c319351146b90cd3f91303a492707e693a4"
-    )
-    version(
-        "1.42.0", sha256="43129625155a8aed796ebe90b8d4c990a73985ec717de2b2d5d3a23cfe4deb72"
-    )
-    version(
-        "1.41.1", sha256="65db0c7f2438bc8cd48865de282bf6670027f3557d6e3cb62fb65b2e350a687d"
-    )
-    version(
-        "1.41.0", sha256="1184533907e1ddad9c0dcd30a5abb0fe25288c287ff7fee303fff7b9b2d6eb6e"
-    )
-    version(
-        "1.40.0", sha256="61a90db95bac00adec1cc5ddc767ebbcaabc70242bd1134a7a6b1fb1d498a194"
-    )
-    version(
-        "1.39.0", sha256="5c52de5bdcfb322dbe10f98feb56e45162e668ad08bc28ab4b914d4f79911697"
-    )
-    version(
-        "1.38.1", sha256="0ece7d279e480fa386b066130a562ad1a622079d43d1c30731f2f66cd3f5c647"
-    )
-    version(
-        "1.25.0", sha256="0e927ddc0f1c83899000a63e9286cac5958222f8fb5870a49b0c81804944a912"
-    )
+    version("1.43.0", sha256="90d72bb7ae18de2519d0cac70eb89c319351146b90cd3f91303a492707e693a4")
+    version("1.42.0", sha256="43129625155a8aed796ebe90b8d4c990a73985ec717de2b2d5d3a23cfe4deb72")
+    version("1.41.1", sha256="65db0c7f2438bc8cd48865de282bf6670027f3557d6e3cb62fb65b2e350a687d")
+    version("1.41.0", sha256="1184533907e1ddad9c0dcd30a5abb0fe25288c287ff7fee303fff7b9b2d6eb6e")
+    version("1.40.0", sha256="61a90db95bac00adec1cc5ddc767ebbcaabc70242bd1134a7a6b1fb1d498a194")
+    version("1.39.0", sha256="5c52de5bdcfb322dbe10f98feb56e45162e668ad08bc28ab4b914d4f79911697")
+    version("1.38.1", sha256="0ece7d279e480fa386b066130a562ad1a622079d43d1c30731f2f66cd3f5c647")
+    version("1.25.0", sha256="0e927ddc0f1c83899000a63e9286cac5958222f8fb5870a49b0c81804944a912")
     version("1.10.0", sha256="0307a0eec6caddd476f9cad39e18fdd6f22a08aa58103c4b0aead96d638be15e")
     version("1.9.0", sha256="d595b2725abcce851c76239aab038adc126c58714cfb572b2ebb2d21b3593842")
 

--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -40,24 +40,6 @@ class Libuv(CMakePackage, AutotoolsPackage):
         version(
             "1.44.0", sha256="d969fc47b8e39ec909d3f8cfa6a6e616e7c370637068ce2d95fdfcbb7f8467f5"
         )
-        version(
-            "1.43.0", sha256="90d72bb7ae18de2519d0cac70eb89c319351146b90cd3f91303a492707e693a4"
-        )
-        version(
-            "1.42.0", sha256="43129625155a8aed796ebe90b8d4c990a73985ec717de2b2d5d3a23cfe4deb72"
-        )
-        version(
-            "1.41.1", sha256="65db0c7f2438bc8cd48865de282bf6670027f3557d6e3cb62fb65b2e350a687d"
-        )
-        version(
-            "1.41.0", sha256="1184533907e1ddad9c0dcd30a5abb0fe25288c287ff7fee303fff7b9b2d6eb6e"
-        )
-        version(
-            "1.40.0", sha256="61a90db95bac00adec1cc5ddc767ebbcaabc70242bd1134a7a6b1fb1d498a194"
-        )
-        version(
-            "1.39.0", sha256="5c52de5bdcfb322dbe10f98feb56e45162e668ad08bc28ab4b914d4f79911697"
-        )
     else:
         version(
             "1.48.0", sha256="c593139feb9061699fdd2f7fde47bb6c1ca77761ae9ec04f052083f1ef46c13b"
@@ -77,30 +59,30 @@ class Libuv(CMakePackage, AutotoolsPackage):
         version(
             "1.44.0", sha256="6c52494401cfe8d08fb4ec245882f0bd4b1572b5a8e79d6c418b855422a1a27d"
         )
-        version(
-            "1.43.0", sha256="90d72bb7ae18de2519d0cac70eb89c319351146b90cd3f91303a492707e693a4"
-        )
-        version(
-            "1.42.0", sha256="43129625155a8aed796ebe90b8d4c990a73985ec717de2b2d5d3a23cfe4deb72"
-        )
-        version(
-            "1.41.1", sha256="65db0c7f2438bc8cd48865de282bf6670027f3557d6e3cb62fb65b2e350a687d"
-        )
-        version(
-            "1.41.0", sha256="1184533907e1ddad9c0dcd30a5abb0fe25288c287ff7fee303fff7b9b2d6eb6e"
-        )
-        version(
-            "1.40.0", sha256="61a90db95bac00adec1cc5ddc767ebbcaabc70242bd1134a7a6b1fb1d498a194"
-        )
-        version(
-            "1.39.0", sha256="5c52de5bdcfb322dbe10f98feb56e45162e668ad08bc28ab4b914d4f79911697"
-        )
-        version(
-            "1.38.1", sha256="0ece7d279e480fa386b066130a562ad1a622079d43d1c30731f2f66cd3f5c647"
-        )
-        version(
-            "1.25.0", sha256="0e927ddc0f1c83899000a63e9286cac5958222f8fb5870a49b0c81804944a912"
-        )
+    version(
+        "1.43.0", sha256="90d72bb7ae18de2519d0cac70eb89c319351146b90cd3f91303a492707e693a4"
+    )
+    version(
+        "1.42.0", sha256="43129625155a8aed796ebe90b8d4c990a73985ec717de2b2d5d3a23cfe4deb72"
+    )
+    version(
+        "1.41.1", sha256="65db0c7f2438bc8cd48865de282bf6670027f3557d6e3cb62fb65b2e350a687d"
+    )
+    version(
+        "1.41.0", sha256="1184533907e1ddad9c0dcd30a5abb0fe25288c287ff7fee303fff7b9b2d6eb6e"
+    )
+    version(
+        "1.40.0", sha256="61a90db95bac00adec1cc5ddc767ebbcaabc70242bd1134a7a6b1fb1d498a194"
+    )
+    version(
+        "1.39.0", sha256="5c52de5bdcfb322dbe10f98feb56e45162e668ad08bc28ab4b914d4f79911697"
+    )
+    version(
+        "1.38.1", sha256="0ece7d279e480fa386b066130a562ad1a622079d43d1c30731f2f66cd3f5c647"
+    )
+    version(
+        "1.25.0", sha256="0e927ddc0f1c83899000a63e9286cac5958222f8fb5870a49b0c81804944a912"
+    )
     version("1.10.0", sha256="0307a0eec6caddd476f9cad39e18fdd6f22a08aa58103c4b0aead96d638be15e")
     version("1.9.0", sha256="d595b2725abcce851c76239aab038adc126c58714cfb572b2ebb2d21b3593842")
 

--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -12,7 +12,7 @@ class Libuv(CMakePackage, AutotoolsPackage):
     """Multi-platform library with a focus on asynchronous IO"""
 
     homepage = "https://libuv.org"
-    url = "https://dist.libuv.org/dist/v1.44.1/libuv-v1.44.1-dist.tar.gz"
+    url = "https://dist.libuv.org/dist/v1.44.1/libuv-v1.44.1.tar.gz"
     list_url = "https://dist.libuv.org/dist"
     list_depth = 1
 
@@ -21,6 +21,42 @@ class Libuv(CMakePackage, AutotoolsPackage):
     if sys.platform == "win32":
         version(
             "1.48.0", sha256="7f1db8ac368d89d1baf163bac1ea5fe5120697a73910c8ae6b2fffb3551d59fb"
+        )
+        version(
+            "1.47.0", sha256="20c37a4ca77a2107879473c6c8fa0dc1350e80045df98bfbe78f7cd6d7dd2965"
+        )
+        version(
+            "1.46.0", sha256="111f83958b9fdc65f1489195d25f342b9f7a3e683140c60e62c00fbaccddddce"
+        )
+        version(
+            "1.45.0", sha256="f5b07f65a1e8166e47983a7ed1f42fae0bee08f7458142170c37332fc676a748"
+        )
+        version(
+            "1.44.2", sha256="ccfcdc968c55673c6526d8270a9c8655a806ea92468afcbcabc2b16040f03cb4"
+        )
+        version(
+            "1.44.1", sha256="9d37b63430fe3b92a9386b949bebd8f0b4784a39a16964c82c9566247a76f64a"
+        )
+        version(
+            "1.44.0", sha256="d969fc47b8e39ec909d3f8cfa6a6e616e7c370637068ce2d95fdfcbb7f8467f5"
+        )
+        version(
+            "1.43.0", sha256="90d72bb7ae18de2519d0cac70eb89c319351146b90cd3f91303a492707e693a4"
+        )
+        version(
+            "1.42.0", sha256="43129625155a8aed796ebe90b8d4c990a73985ec717de2b2d5d3a23cfe4deb72"
+        )
+        version(
+            "1.41.1", sha256="65db0c7f2438bc8cd48865de282bf6670027f3557d6e3cb62fb65b2e350a687d"
+        )
+        version(
+            "1.41.0", sha256="1184533907e1ddad9c0dcd30a5abb0fe25288c287ff7fee303fff7b9b2d6eb6e"
+        )
+        version(
+            "1.40.0", sha256="61a90db95bac00adec1cc5ddc767ebbcaabc70242bd1134a7a6b1fb1d498a194"
+        )
+        version(
+            "1.39.0", sha256="5c52de5bdcfb322dbe10f98feb56e45162e668ad08bc28ab4b914d4f79911697"
         )
     else:
         version(
@@ -65,10 +101,8 @@ class Libuv(CMakePackage, AutotoolsPackage):
         version(
             "1.25.0", sha256="0e927ddc0f1c83899000a63e9286cac5958222f8fb5870a49b0c81804944a912"
         )
-        version(
-            "1.10.0", sha256="0307a0eec6caddd476f9cad39e18fdd6f22a08aa58103c4b0aead96d638be15e"
-        )
-        version("1.9.0", sha256="d595b2725abcce851c76239aab038adc126c58714cfb572b2ebb2d21b3593842")
+    version("1.10.0", sha256="0307a0eec6caddd476f9cad39e18fdd6f22a08aa58103c4b0aead96d638be15e")
+    version("1.9.0", sha256="d595b2725abcce851c76239aab038adc126c58714cfb572b2ebb2d21b3593842")
 
     def url_for_version(self, version):
         if self.spec.satisfies("@:1.43") or self.spec.satisfies("build_system=cmake"):
@@ -79,18 +113,16 @@ class Libuv(CMakePackage, AutotoolsPackage):
             url = "https://dist.libuv.org/dist/v{0}/libuv-v{0}-dist.tar.gz"
         return url.format(version, version)
 
-
-    #Windows needs a CMake build, but the cmake-enabled sources do not have a pre-generated configure
-    # script to enable the autotools build, so: (a) pull different sources if you are on Windows
-    # and (b) make sure cmake build is not chosen on Linux (because Linux does not
-    # download the cmake-enabled source).
+    # Windows needs a CMake build, but the cmake-enabled sources do not have a
+    # pre-generated configure script to enable the autotools build, so: (a)
+    # pull different sources if you are on Windows and (b) make sure cmake
+    # build is not chosen on Linux
+    # (because Linux does not download the cmake-enabled source).
 
     # new libuv versions should only use CMake to prevent the scenario
     # described above
     build_system(
-        conditional("cmake", when="@1.48: platform=windows"),
-        "autotools",
-        default="autotools"
+        conditional("cmake", when="@1.48: platform=windows"), "autotools", default="autotools"
     )
 
     with when("build_system=autotools"):
@@ -100,6 +132,7 @@ class Libuv(CMakePackage, AutotoolsPackage):
         depends_on("m4", type="build", when="@:1.43.0")
 
     with when("build_system=cmake"):
+        # explictly require ownlibs
         depends_on("cmake+ownlibs")
 
     conflicts(


### PR DESCRIPTION
Part of an effort to port torch to Windows

Ports  libuv

Libuv requires two considerations:

* On Windows it is built with CMake, however CMake is built against libuv, so libuv must depend on `cmake+ownlibs` to short circuit the circular dependency
* libuv currently fetches the `-dist` source distribution of libuv for certain versions because those versions contain a pre-generated `./configure` script. However those distributions have all CMake files removed, so they cannot be used to build on Windows. Because the source distributions are different, this means the checksums are different, and necessitates an additional `version` declaration for each version we want to support with CMake. Due to the inability to condition versions on specs, we, for now, must make CMake Windows only so we can appropriately declare the additional "versions".