### PR TITLE
Win: support proper meson dependent environments

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1273,7 +1273,6 @@ print(json.dumps(config))
 
         if self.spec.satisfies("platform=windows"):
             env.prepend_path("PATH", dependent_spec.prefix.Scripts)
-            env.prepend_path("PATH", self.spec.prefix)
             # The logic below is linux specific, and used to inject the
             # compiler wrapper to compile Python extensions.
             # Thus, it is not needed on Windows.

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1274,13 +1274,11 @@ print(json.dumps(config))
         if self.spec.satisfies("platform=windows"):
             env.prepend_path("PATH", dependent_spec.prefix.Scripts)
             env.prepend_path("PATH", self.spec.prefix)
-            # The logic below is linux specific, and used to inject the 
+            # The logic below is linux specific, and used to inject the
             # compiler wrapper to compile Python extensions.
             # Thus, it is not needed on Windows.
             return
 
-
-    
         # We need to make sure that the extensions are compiled and linked with
         # the Spack wrapper. Paths to the executables that are used for these
         # operations are normally taken from the sysconfigdata file, which we

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1272,8 +1272,9 @@ print(json.dumps(config))
         """
         # The logic below is linux specific, and used to inject the compiler wrapper to
         # compile Python extensions. Thus, it is not needed on Windows.
-        if sys.platform == "win32":
-            return
+        if self.spec.satisfies("platform=windows"):
+            env.prepend_path("PATH", dependent_spec.prefix.scripts)
+            env.prepend_path("PATH", self.spec.prefix)
 
         # We need to make sure that the extensions are compiled and linked with
         # the Spack wrapper. Paths to the executables that are used for these
@@ -1343,6 +1344,9 @@ print(json.dumps(config))
         """Set PYTHONPATH to include the site-packages directory for the
         extension and any other python extensions it depends on.
         """
+        if self.spec.satisfies("platform=windows"):
+            env.prepend_path("PATH", dependent_spec.prefix.scripts)
+            env.prepend_path("PATH", self.spec.prefix)
         if not dependent_spec.package.extends(self.spec) or dependent_spec.dependencies(
             "python-venv"
         ):

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1349,7 +1349,6 @@ print(json.dumps(config))
         """
         if self.spec.satisfies("platform=windows"):
             env.prepend_path("PATH", dependent_spec.prefix.Scripts)
-            env.prepend_path("PATH", self.spec.prefix)
 
         if not dependent_spec.package.extends(self.spec) or dependent_spec.dependencies(
             "python-venv"
@@ -1367,6 +1366,13 @@ print(json.dumps(config))
         module.python_include = join_path(dependent_spec.prefix, self.include)
         module.python_platlib = join_path(dependent_spec.prefix, self.platlib)
         module.python_purelib = join_path(dependent_spec.prefix, self.purelib)
+
+    def setup_run_environment(self, env):
+        """Adds Python's base install prefix to the PATH on Windows so
+        components with a run dep on Python can access the launcher/other tooling
+        """
+        if self.spec.satisfies("platform=windows"):
+            env.prepend_path("PATH", self.spec.prefix)
 
     def add_files_to_view(self, view, merge_map, skip_if_exists=True):
         """Make the view a virtual environment if it isn't one already.

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1270,12 +1270,17 @@ print(json.dumps(config))
         """Set PYTHONPATH to include the site-packages directory for the
         extension and any other python extensions it depends on.
         """
-        # The logic below is linux specific, and used to inject the compiler wrapper to
-        # compile Python extensions. Thus, it is not needed on Windows.
-        if self.spec.satisfies("platform=windows"):
-            env.prepend_path("PATH", dependent_spec.prefix.scripts)
-            env.prepend_path("PATH", self.spec.prefix)
 
+        if self.spec.satisfies("platform=windows"):
+            env.prepend_path("PATH", dependent_spec.prefix.Scripts)
+            env.prepend_path("PATH", self.spec.prefix)
+            # The logic below is linux specific, and used to inject the 
+            # compiler wrapper to compile Python extensions.
+            # Thus, it is not needed on Windows.
+            return
+
+
+    
         # We need to make sure that the extensions are compiled and linked with
         # the Spack wrapper. Paths to the executables that are used for these
         # operations are normally taken from the sysconfigdata file, which we
@@ -1345,8 +1350,9 @@ print(json.dumps(config))
         extension and any other python extensions it depends on.
         """
         if self.spec.satisfies("platform=windows"):
-            env.prepend_path("PATH", dependent_spec.prefix.scripts)
+            env.prepend_path("PATH", dependent_spec.prefix.Scripts)
             env.prepend_path("PATH", self.spec.prefix)
+
         if not dependent_spec.package.extends(self.spec) or dependent_spec.dependencies(
             "python-venv"
         ):


### PR DESCRIPTION
On Windows the `meson` executable is placed in the `Scripts` directory, so we need to add that to the PATH so consuming packages can access the meson executable.

Without this, `py-meson-python` will fail to build as it cannot find `meson`.
Alternatively, we can set the `MESON` environment variable to the meson executable, but this seems like a more robust option.