### PR TITLE
gdrcopy: specify CUDA envvar during build

### DIFF
--- a/var/spack/repos/builtin/packages/gdrcopy/package.py
+++ b/var/spack/repos/builtin/packages/gdrcopy/package.py
@@ -34,6 +34,9 @@ class Gdrcopy(MakefilePackage, CudaPackage):
     depends_on("check")
     requires("+cuda")
 
+    def setup_build_environment(self, env):
+        env.set("CUDA", self.spec["cuda"].prefix)
+
     def build(self, spec, prefix):
         make("lib")
         make("exes")


### PR DESCRIPTION
otherwise /usr/local/cuda is used

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
