### PR TITLE
PythonExtension: ensure Scripts dir is available to build, run contexts on Windows

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1043,8 +1043,6 @@ class SetupContext:
 
                 for root in self.specs:  # there is only one root in build context
                     spack.builder.create(pkg).setup_dependent_build_environment(env, root)
-                    if sys.platform == "win32" and isinstance(pkg, spack.build_systems.python.PythonPackage):
-                        env.prepend_path("PATH", pkg.spec.prefix.scripts)
 
             if self.should_setup_build_env & flag:
                 spack.builder.create(pkg).setup_build_environment(env)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1043,6 +1043,8 @@ class SetupContext:
 
                 for root in self.specs:  # there is only one root in build context
                     spack.builder.create(pkg).setup_dependent_build_environment(env, root)
+                    if sys.platform == "win32" and isinstance(pkg, spack.build_systems.python.PythonPackage):
+                        env.prepend_path("PATH", pkg.spec.prefix.scripts)
 
             if self.should_setup_build_env & flag:
                 spack.builder.create(pkg).setup_build_environment(env)

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -17,7 +17,7 @@ import archspec
 import llnl.util.filesystem as fs
 import llnl.util.lang as lang
 import llnl.util.tty as tty
-from llnl.util.filesystem import HeaderList, LibraryList
+from llnl.util.filesystem import HeaderList, LibraryList, join_path
 
 import spack.builder
 import spack.config
@@ -119,6 +119,11 @@ class PythonExtension(spack.package_base.PackageBase):
             List of strings of module names.
         """
         return []
+
+    @property
+    def bindir(self):
+        windows = self.spec.satisfies("platform=windows")
+        return join_path(self.prefix, "Scripts" if windows else "bin")
 
     def view_file_conflicts(self, view, merge_map):
         """Report all file conflicts, excepting special cases for python.

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -17,7 +17,7 @@ import archspec
 import llnl.util.filesystem as fs
 import llnl.util.lang as lang
 import llnl.util.tty as tty
-from llnl.util.filesystem import HeaderList, LibraryList
+from llnl.util.filesystem import HeaderList, LibraryList, join_path
 
 import spack.builder
 import spack.config
@@ -119,6 +119,12 @@ class PythonExtension(spack.package_base.PackageBase):
             List of strings of module names.
         """
         return []
+
+    @property
+    def bindir(self) -> str:
+        """Path to Python package's bindir, bin on unix like OS's Scripts on Windows"""
+        windows = self.spec.satisfies("platform=windows")
+        return join_path(self.spec.prefix, "Scripts" if windows else "bin")
 
     def view_file_conflicts(self, view, merge_map):
         """Report all file conflicts, excepting special cases for python.

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -120,11 +120,6 @@ class PythonExtension(spack.package_base.PackageBase):
         """
         return []
 
-    @property
-    def bindir(self):
-        windows = self.spec.satisfies("platform=windows")
-        return join_path(self.prefix, "Scripts" if windows else "bin")
-
     def view_file_conflicts(self, view, merge_map):
         """Report all file conflicts, excepting special cases for python.
         Specifically, this does not report errors for duplicate

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -17,7 +17,7 @@ import archspec
 import llnl.util.filesystem as fs
 import llnl.util.lang as lang
 import llnl.util.tty as tty
-from llnl.util.filesystem import HeaderList, LibraryList, join_path
+from llnl.util.filesystem import HeaderList, LibraryList
 
 import spack.builder
 import spack.config

--- a/var/spack/repos/builtin/packages/python-venv/package.py
+++ b/var/spack/repos/builtin/packages/python-venv/package.py
@@ -89,10 +89,11 @@ class PythonVenv(Package):
         extension and any other python extensions it depends on."""
         # Packages may be installed in platform-specific or platform-independent site-packages
         # directories
-        for directory in {self.platlib, self.purelib, self.bindir}:
+        for directory in {self.platlib, self.purelib}:
             path = os.path.join(dependent_spec.prefix, directory)
             if os.path.isdir(path):
                 env.prepend_path("PYTHONPATH", path)
+        env.prepend_path("PATH", self.bindir)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.setup_dependent_run_environment(env, dependent_spec)

--- a/var/spack/repos/builtin/packages/python-venv/package.py
+++ b/var/spack/repos/builtin/packages/python-venv/package.py
@@ -93,17 +93,10 @@ class PythonVenv(Package):
             path = os.path.join(dependent_spec.prefix, directory)
             if os.path.isdir(path):
                 env.prepend_path("PYTHONPATH", path)
-        try:
-            dep_bin_dir = dependent_spec.package.bindir
-            if os.path.isdir(dep_bin_dir):
-                env.prepend_path("PATH", dep_bin_dir)
-        except AttributeError:
-            # not all dependents will be python packages
-            # so will not have a bindir defined.
-            pass
+        dep_bin_dir = getattr(dependent_spec.package, "bindir", None)
+        if dep_bin_dir and os.path.isdir(dep_bin_dir):
+            env.prepend_path("PATH", dep_bin_dir)
 
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_dependent_run_environment(env, dependent_spec)
 
     def setup_dependent_package(self, module, dependent_spec):
         """Called before python modules' install() methods."""

--- a/var/spack/repos/builtin/packages/python-venv/package.py
+++ b/var/spack/repos/builtin/packages/python-venv/package.py
@@ -93,10 +93,14 @@ class PythonVenv(Package):
             path = os.path.join(dependent_spec.prefix, directory)
             if os.path.isdir(path):
                 env.prepend_path("PYTHONPATH", path)
-        windows = self.spec.satisfies("platform=windows")
-        dependent_bin_path = join_path(dependent_spec.prefix, "Scripts" if windows else "bin")
-        if os.path.isdir(dependent_bin_path):
-            env.prepend_path("PATH", dependent_bin_path)
+        try:
+            dep_bin_dir = dependent_spec.package.bindir
+            if os.path.isdir(dep_bin_dir):
+                env.prepend_path("PATH", dep_bin_dir)
+        except AttributeError:
+            # not all dependents will be python packages
+            # so will not have a bindir defined.
+            pass
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.setup_dependent_run_environment(env, dependent_spec)

--- a/var/spack/repos/builtin/packages/python-venv/package.py
+++ b/var/spack/repos/builtin/packages/python-venv/package.py
@@ -93,7 +93,7 @@ class PythonVenv(Package):
             path = os.path.join(dependent_spec.prefix, directory)
             if os.path.isdir(path):
                 env.prepend_path("PYTHONPATH", path)
-        env.prepend_path("PATH", self.bindir)
+        env.prepend_path("PATH", dependent_spec.bindir)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.setup_dependent_run_environment(env, dependent_spec)

--- a/var/spack/repos/builtin/packages/python-venv/package.py
+++ b/var/spack/repos/builtin/packages/python-venv/package.py
@@ -97,7 +97,6 @@ class PythonVenv(Package):
         if dep_bin_dir and os.path.isdir(dep_bin_dir):
             env.prepend_path("PATH", dep_bin_dir)
 
-
     def setup_dependent_package(self, module, dependent_spec):
         """Called before python modules' install() methods."""
         module.python = self.command

--- a/var/spack/repos/builtin/packages/python-venv/package.py
+++ b/var/spack/repos/builtin/packages/python-venv/package.py
@@ -93,7 +93,10 @@ class PythonVenv(Package):
             path = os.path.join(dependent_spec.prefix, directory)
             if os.path.isdir(path):
                 env.prepend_path("PYTHONPATH", path)
-        env.prepend_path("PATH", dependent_spec.package.bindir)
+        windows = self.spec.satisfies("platform=windows")
+        dependent_bin_path = join_path(dependent_spec.prefix, "Scripts" if windows else "bin")
+        if os.path.isdir(dependent_bin_path):
+            env.prepend_path("PATH", dependent_spec.package.bindir)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.setup_dependent_run_environment(env, dependent_spec)

--- a/var/spack/repos/builtin/packages/python-venv/package.py
+++ b/var/spack/repos/builtin/packages/python-venv/package.py
@@ -96,7 +96,7 @@ class PythonVenv(Package):
         windows = self.spec.satisfies("platform=windows")
         dependent_bin_path = join_path(dependent_spec.prefix, "Scripts" if windows else "bin")
         if os.path.isdir(dependent_bin_path):
-            env.prepend_path("PATH", dependent_spec.package.bindir)
+            env.prepend_path("PATH", dependent_bin_path)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.setup_dependent_run_environment(env, dependent_spec)

--- a/var/spack/repos/builtin/packages/python-venv/package.py
+++ b/var/spack/repos/builtin/packages/python-venv/package.py
@@ -93,7 +93,7 @@ class PythonVenv(Package):
             path = os.path.join(dependent_spec.prefix, directory)
             if os.path.isdir(path):
                 env.prepend_path("PYTHONPATH", path)
-        env.prepend_path("PATH", dependent_spec.bindir)
+        env.prepend_path("PATH", dependent_spec.package.bindir)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.setup_dependent_run_environment(env, dependent_spec)

--- a/var/spack/repos/builtin/packages/python-venv/package.py
+++ b/var/spack/repos/builtin/packages/python-venv/package.py
@@ -89,10 +89,13 @@ class PythonVenv(Package):
         extension and any other python extensions it depends on."""
         # Packages may be installed in platform-specific or platform-independent site-packages
         # directories
-        for directory in {self.platlib, self.purelib}:
+        for directory in {self.platlib, self.purelib, self.bindir}:
             path = os.path.join(dependent_spec.prefix, directory)
             if os.path.isdir(path):
                 env.prepend_path("PYTHONPATH", path)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self.setup_dependent_run_environment(env, dependent_spec)
 
     def setup_dependent_package(self, module, dependent_spec):
         """Called before python modules' install() methods."""


### PR DESCRIPTION
Many Windows Python packages don't define a "bin" dir, instead they add any executables/run time artifacts into a "scripts" directory. 
Spack does not have any generic logic to handle populating the environment with this the way we do for the bin directories of dependencies. This PR is an effort to add that.

Current approach: python-venv is responsible for adding dependent specs `prefix.Scripts` directory to the environment PATH 
and PythonExtension implements the `bindir` property for all python packages in a cross platform manner. 
