### PR TITLE
Fixing netlib-scalapack for some clang derivative (cce/rocmcc)

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -41,15 +41,14 @@ class ScalapackBase(CMakePackage):
     patch("fix-build-macos.patch", when="@2.2.0")
 
     def flag_handler(self, name, flags):
-        iflags = []
         if name == "cflags":
             if self.spec.satisfies("%gcc@14:"):
                 # https://bugzilla.redhat.com/show_bug.cgi?id=2178710
-                iflags.append("-std=gnu89")
+                flags.append("-std=gnu89")
         elif name == "fflags":
             if self.spec.satisfies("%cce"):
-                iflags.append("-hnopattern")
-        return (iflags, None, None)
+                flags.append("-hnopattern")
+        return (flags, None, None)
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -91,6 +91,7 @@ class ScalapackBase(CMakePackage):
             or spec.satisfies("%apple-clang")
             or spec.satisfies("%oneapi")
             or spec.satisfies("%arm")
+            or spec.satisfies("%cce")
         ):
             c_flags.append("-Wno-error=implicit-function-declaration")
 

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -91,6 +91,7 @@ class ScalapackBase(CMakePackage):
             or spec.satisfies("%oneapi")
             or spec.satisfies("%arm")
             or spec.satisfies("%cce")
+            or spec.satisfies("%rocmcc")
         ):
             c_flags.append("-Wno-error=implicit-function-declaration")
 

--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -116,6 +116,8 @@ class NetlibScalapack(ScalapackBase):
     git = "https://github.com/Reference-ScaLAPACK/scalapack"
     tags = ["e4s"]
 
+    maintainers("etiennemlb")
+
     license("BSD-3-Clause-Open-MPI")
 
     version("2.2.0", sha256="40b9406c20735a9a3009d863318cb8d3e496fb073d201c5463df810e01ab2a57")


### PR DESCRIPTION
Ensure Cray's CCE also gets its share of `-Wno-error=implicit-function-declaration`.

Additionally, ensure that `cflags/cxxflags` etc., get correctly forwarded. They are currently being clobbered.
