### PR TITLE
Remove maintainership from some packages and verify generated language dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/cpr/package.py
+++ b/var/spack/repos/builtin/packages/cpr/package.py
@@ -12,14 +12,12 @@ class Cpr(CMakePackage):
     homepage = "https://docs.libcpr.org/"
     url = "https://github.com/libcpr/cpr/archive/refs/tags/1.10.4.tar.gz"
 
-    maintainers("sethrj")
-
     license("MIT")
 
     version("1.10.4", sha256="88462d059cd3df22c4d39ae04483ed50dfd2c808b3effddb65ac3b9aa60b542d")
     version("1.9.2", sha256="3bfbffb22c51f322780d10d3ca8f79424190d7ac4b5ad6ad896de08dbd06bf31")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     depends_on("curl")
     depends_on("git", type="build")

--- a/var/spack/repos/builtin/packages/gnds/package.py
+++ b/var/spack/repos/builtin/packages/gnds/package.py
@@ -15,11 +15,9 @@ class Gnds(CMakePackage):
     homepage = "https://code.ornl.gov/RNSD/gnds"
     url = "https://code.ornl.gov/RNSD/gnds/-/archive/v0.0.1/gnds-v0.0.1.tar.gz"
 
-    maintainers("sethrj")
-
     version("0.0.1", sha256="4c8faaa01a3e6fb08ec3e8e126a76f75b5442509a46b993e325ec79dd9f04879")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     variant("shared", default=True, description="Build shared libraries")
 

--- a/var/spack/repos/builtin/packages/py-qrcode/package.py
+++ b/var/spack/repos/builtin/packages/py-qrcode/package.py
@@ -12,8 +12,6 @@ class PyQrcode(PythonPackage):
     homepage = "https://github.com/lincolnloop/python-qrcode"
     pypi = "qrcode/qrcode-7.3.1.tar.gz"
 
-    maintainers("sethrj")
-
     license("BSD-3-Clause")
 
     version("7.3.1", sha256="375a6ff240ca9bd41adc070428b5dfc1dcfbb0f2507f1ac848f6cded38956578")

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -31,7 +31,7 @@ class QtPackage(CMakePackage):
         _list_url = "https://github.com/qt/{}/tags"
         return _list_url.format(qualname.lower())
 
-    maintainers("wdconinc", "sethrj")
+    maintainers("wdconinc")
 
     # Default dependencies for all qt-* components
     generator("ninja")

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -27,7 +27,6 @@ class Qt(Package):
     url = "https://download.qt.io/archive/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz"
     list_url = "https://download.qt.io/archive/qt/"
     list_depth = 3
-    maintainers("sethrj")
 
     phases = ["configure", "build", "install"]
 

--- a/var/spack/repos/builtin/packages/testu01/package.py
+++ b/var/spack/repos/builtin/packages/testu01/package.py
@@ -16,8 +16,6 @@ class Testu01(AutotoolsPackage):
     homepage = "http://simul.iro.umontreal.ca/testu01/tu01.html"
     git = "https://github.com/umontreal-simul/TestU01-2009/"
 
-    maintainers("sethrj")
-
     version(
         "1.2.3",
         sha256="bc1d1dd2aea7ed3b3d28eaad2c8ee55913f11ce67aec8fe4f643c1c0d2ed1cac",

--- a/var/spack/repos/builtin/packages/torque/package.py
+++ b/var/spack/repos/builtin/packages/torque/package.py
@@ -14,8 +14,6 @@ class Torque(Package):
     homepage = "https://github.com/abarbu/torque"
     has_code = False
 
-    maintainers("sethrj")
-
     version("3.0.4")
     version("3.0.2")
 

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -35,7 +35,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     url = "https://github.com/trilinos/Trilinos/archive/refs/tags/trilinos-release-12-12-1.tar.gz"
     git = "https://github.com/trilinos/Trilinos.git"
 
-    maintainers("keitat", "sethrj", "kuberry", "jwillenbring", "psakievich")
+    maintainers("keitat", "kuberry", "jwillenbring", "psakievich")
 
     tags = ["e4s"]
 


### PR DESCRIPTION
This removes myself as maintainer from packages that satisfy both:
- I don't use or have a stake in
- I don't own.

I haven't directly done anything with Qt not Trilinos in quite a long time.