### PR TITLE
py-tensorflow: fix linking with ubuntu's gcc

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -450,6 +450,22 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     )
     phases = ["configure", "build", "install"]
 
+    def flag_handler(self, name, flags):
+        spec = self.spec
+        # ubuntu gcc has this workaround turned on by default in aarch64
+        # and it causes issues with symbol relocation during link
+        # note, archspec doesn't currently ever report cortex_a53!
+        if (
+            name == "ldflags"
+            and spec.target.family == "aarch64"
+            and "ubuntu" in spec.os
+            and spec.compiler.name == "gcc"
+            and "cortex_a53" not in spec.target.name
+        ):
+            flags.append("-mno-fix-cortex-a53-843419")
+
+        return (flags, None, None)
+
     # https://www.tensorflow.org/install/source
     def setup_build_environment(self, env):
         spec = self.spec


### PR DESCRIPTION
gcc on ubuntu has fix-cortex-a53-843419 set by default - this causes linking issues (symbol relocation truncation errors) for tf, even when compiling for different cpus. Errors like so, issue goes away if we turn fix-cortex-a53-843419 off with compiler flags (or compile with a gcc that doesn't have that set by default)

```
    4956    tf_to_tfl_flatbuffer.cc:(.text.unlikely._ZN4absl12lts_2023080212lo
             g_internal10LogMessagelsINS0_6StatusELi0EEERS2_RKT_.isra.0+0x28): 
             relocation truncated to fit: R_AARCH64_CALL26 against symbol `absl
             ::lts_20230802::log_internal::LogMessage::OstreamView::stream()' d
             efined in .text._ZN4absl12lts_2023080212log_internal10LogMessage11
             OstreamView6streamEv section in bazel-out/aarch64-opt/bin/external
             /com_google_absl/absl/log/internal/liblog_message.pic.a(log_messag
             e.pic.o)
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
