### PR TITLE
bacio: update recipe

### DIFF
--- a/var/spack/repos/builtin/packages/bacio/package.py
+++ b/var/spack/repos/builtin/packages/bacio/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 
 
 class Bacio(CMakePackage):
-    """The bacio ibrary performs binary I/O for the NCEP models, processing
+    """The bacio library performs binary I/O for the NCEP models, processing
     unformatted byte-addressable data records, and transforming the little
     endian files and big endian files."""
 
@@ -15,15 +15,15 @@ class Bacio(CMakePackage):
     url = "https://github.com/NOAA-EMC/NCEPLIBS-bacio/archive/refs/tags/v2.4.1.tar.gz"
     git = "https://github.com/NOAA-EMC/NCEPLIBS-bacio"
 
-    maintainers("t-brown", "edwardhartnett", "AlexanderRichert-NOAA", "Hang-Lei-NOAA")
+    maintainers("edwardhartnett", "AlexanderRichert-NOAA", "Hang-Lei-NOAA")
 
     version("develop", branch="develop")
     version("2.6.0", sha256="03fef581e1bd3710fb8d2f2659a6c3e01a0437c1350ba53958d2ff1ffef47bcb")
     version("2.5.0", sha256="540a0ed73941d70dbf5d7b21d5d0a441e76fad2bfe37dfdfea0db3e98fc0fbfb")
     version("2.4.1", sha256="7b9b6ba0a288f438bfba6a08b6e47f8133f7dba472a74ac56a5454e2260a7200")
 
-    depends_on("c", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     variant("pic", default=True, description="Build with position-independent-code")
     variant("shared", default=False, description="Build shared library", when="@2.6.0:")


### PR DESCRIPTION
This PR updates the bacio recipe. It fixes a typo, removes an old maintainer, and removes the 'generated' tags for the compiler dependencies (which are correct).