### PR TITLE
g2: update recipe

### DIFF
--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -43,7 +43,12 @@ class G2(CMakePackage):
     variant("shared", default="False", when="@3.4.7:")
     variant("openmp", default=False, description="Use OpenMP multithreading", when="@develop")
     variant("utils", default=False, description="Build grib utilities", when="@develop")
-    variant("g2c_compare", default=False, description="Enable copygb2 tests using g2c_compare", when="@develop")
+    variant(
+        "g2c_compare",
+        default=False,
+        description="Enable copygb2 tests using g2c_compare",
+        when="@develop",
+    )
 
     depends_on("jasper@:2.0.32", when="@:3.4.7")
     depends_on("jasper")
@@ -81,7 +86,12 @@ class G2(CMakePackage):
             self.spec.variants["precision"].value if self.spec.satisfies("@3.4.6:") else ("4", "d")
         )
         for suffix in precisions:
-            lib = find_libraries("libg2_" + suffix, root=self.prefix, shared=self.spec.satisfies("+shared"), recursive=True)
+            lib = find_libraries(
+                "libg2_" + suffix,
+                root=self.prefix,
+                shared=self.spec.satisfies("+shared"),
+                recursive=True,
+            )
             env.set("G2_LIB" + suffix, lib[0])
             env.set("G2_INC" + suffix, join_path(self.prefix, "include_" + suffix))
 

--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -56,9 +56,9 @@ class G2(CMakePackage):
     depends_on("zlib-api", when="@develop")
     depends_on("bacio", when="@3.4.6:")
     depends_on("ip", when="@develop")
-    depends_on("ip precision=d", when="^ip@4.1:")
+    requires("^ip precision=d", when="^ip@4.1:")
     depends_on("sp", when="^ip@:4")
-    depends_on("sp precision=d", when="^ip@:4 ^sp@2.4:")
+    requires("^sp precision=d", when="^ip@:4 ^sp@2.4:")
     depends_on("g2c@1.8: +utils", when="+g2c_compare")
     with when("+w3emc"):
         depends_on("w3emc")

--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -27,8 +27,8 @@ class G2(CMakePackage):
     version("3.4.5", sha256="c18e991c56964953d778632e2d74da13c4e78da35e8d04cb742a2ca4f52737b6")
     version("3.4.3", sha256="679ea99b225f08b168cbf10f4b29f529b5b011232f298a5442ce037ea84de17c")
 
-    depends_on("c", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     variant("pic", default=True, description="Build with position-independent-code")
     variant(
@@ -40,22 +40,38 @@ class G2(CMakePackage):
         when="@3.4.6:",
     )
     variant("w3emc", default=True, description="Enable GRIB1 through w3emc", when="@3.4.6:")
+    variant("shared", default="False", when="@3.4.7:")
+    variant("openmp", default=False, description="Use OpenMP multithreading", when="@develop")
+    variant("utils", default=False, description="Build grib utilities", when="@develop")
+    variant("g2c_compare", default=False, description="Enable copygb2 tests using g2c_compare", when="@develop")
 
     depends_on("jasper@:2.0.32", when="@:3.4.7")
     depends_on("jasper")
     depends_on("libpng")
+    depends_on("zlib-api", when="@develop")
     depends_on("bacio", when="@3.4.6:")
+    depends_on("ip", when="@develop")
+    depends_on("ip precision=d", when="^ip@4.1:")
+    depends_on("sp", when="^ip@:4")
+    depends_on("sp precision=d", when="^ip@:4 ^sp@2.4:")
+    depends_on("g2c@1.8: +utils", when="+g2c_compare")
     with when("+w3emc"):
         depends_on("w3emc")
         depends_on("w3emc precision=4", when="precision=4")
         depends_on("w3emc precision=d", when="precision=d")
+        depends_on("w3emc +extradeps", when="+utils")
+        depends_on("w3emc precision=4,d", when="+utils")
 
     def cmake_args(self):
         args = [
+            self.define_from_variant("OPENMP", "openmp"),
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
             self.define_from_variant("BUILD_WITH_W3EMC", "w3emc"),
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define("BUILD_4", self.spec.satisfies("precision=4")),
             self.define("BUILD_D", self.spec.satisfies("precision=d")),
+            self.define_from_variant("G2C_COMPARE", "g2c_compare"),
+            self.define_from_variant("BUILD_UTILS", "utils"),
         ]
 
         return args
@@ -65,7 +81,7 @@ class G2(CMakePackage):
             self.spec.variants["precision"].value if self.spec.satisfies("@3.4.6:") else ("4", "d")
         )
         for suffix in precisions:
-            lib = find_libraries("libg2_" + suffix, root=self.prefix, shared=False, recursive=True)
+            lib = find_libraries("libg2_" + suffix, root=self.prefix, shared=self.spec.satisfies("+shared"), recursive=True)
             env.set("G2_LIB" + suffix, lib[0])
             env.set("G2_INC" + suffix, join_path(self.prefix, "include_" + suffix))
 

--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -40,7 +40,7 @@ class G2(CMakePackage):
         when="@3.4.6:",
     )
     variant("w3emc", default=True, description="Enable GRIB1 through w3emc", when="@3.4.6:")
-    variant("shared", default="False", when="@3.4.7:")
+    variant("shared", default="False", description="Build shared library", when="@3.4.7:")
     variant("openmp", default=False, description="Use OpenMP multithreading", when="@develop")
     variant("utils", default=False, description="Build grib utilities", when="@develop")
     variant(


### PR DESCRIPTION
This PR updates the g2 recipe. It removes the 'generated' tags for the compiler dependencies (which are correct), and adds variants/dependencies related to recent releases.