### PR TITLE
g2c: update recipe

### DIFF
--- a/var/spack/repos/builtin/packages/g2c/package.py
+++ b/var/spack/repos/builtin/packages/g2c/package.py
@@ -24,7 +24,7 @@ class G2c(CMakePackage):
     version("1.6.4", sha256="5129a772572a358296b05fbe846bd390c6a501254588c6a223623649aefacb9d")
     version("1.6.2", sha256="b5384b48e108293d7f764cdad458ac8ce436f26be330b02c69c2a75bb7eb9a2c")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     variant("aec", default=True, description="Use AEC library")
     variant("png", default=True, description="Use PNG library")


### PR DESCRIPTION
This PR removes the 'generated' tag for the compiler dependency (which is correct).