### PR TITLE
g2tmpl: remove 'generated' tags

### DIFF
--- a/var/spack/repos/builtin/packages/g2tmpl/package.py
+++ b/var/spack/repos/builtin/packages/g2tmpl/package.py
@@ -24,8 +24,8 @@ class G2tmpl(CMakePackage):
     version("1.10.1", sha256="0be425e5128fabb89915a92261aa75c27a46a3e115e00c686fc311321e5d1e2a")
     version("1.10.0", sha256="dcc0e40b8952f91d518c59df7af64e099131c17d85d910075bfa474c8822649d")
 
-    depends_on("c", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     variant("shared", default=False, description="Build shared library")
 


### PR DESCRIPTION
This PR removes the 'generated' tags for the compiler dependencies (which are correct).