### PR TITLE
gfsio: update recipe

### DIFF
--- a/var/spack/repos/builtin/packages/gfsio/package.py
+++ b/var/spack/repos/builtin/packages/gfsio/package.py
@@ -26,9 +26,7 @@ class Gfsio(CMakePackage):
     depends_on("pfunit", type="test")
 
     def cmake_args(self):
-        args = [
-            self.define("ENABLE_TESTS", self.run_tests),
-        ]
+        args = [self.define("ENABLE_TESTS", self.run_tests)]
         return args
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/gfsio/package.py
+++ b/var/spack/repos/builtin/packages/gfsio/package.py
@@ -21,7 +21,15 @@ class Gfsio(CMakePackage):
     version("develop", branch="develop")
     version("1.4.1", sha256="eab106302f520600decc4f9665d7c6a55e7b4901fab6d9ef40f29702b89b69b1")
 
-    depends_on("fortran", type="build")  # generated
+    depends_on("fortran", type="build")
+
+    depends_on("pfunit", type="test")
+
+    def cmake_args(self):
+        args = [
+            self.define("ENABLE_TESTS", self.run_tests),
+        ]
+        return args
 
     def setup_run_environment(self, env):
         lib = find_libraries("libgfsio", root=self.prefix, shared=False, recursive=True)
@@ -35,3 +43,7 @@ class Gfsio(CMakePackage):
             if name == "fflags":
                 flags.append("-Free")
         return (None, None, flags)
+
+    def check(self):
+        with working_dir(self.builder.build_directory):
+            make("test")


### PR DESCRIPTION
This PR removes the 'generated' tag for the compiler dependency (which is correct), and adds testing with pfunit.