### PR TITLE
grib-util: remove 'generated' tags

### DIFF
--- a/var/spack/repos/builtin/packages/grib-util/package.py
+++ b/var/spack/repos/builtin/packages/grib-util/package.py
@@ -23,8 +23,8 @@ class GribUtil(CMakePackage):
     version("1.2.4", sha256="f021d6df3186890b0b1781616dabf953581d71db63e7c2913360336985ccaec7")
     version("1.2.3", sha256="b17b08e12360bb8ad01298e615f1b4198e304b0443b6db35fe990a817e648ad5")
 
-    depends_on("c", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     variant("openmp", default=False, description="Use OpenMP multithreading")
     variant("tests", default=False, description="Enable this variant when installing with --test")


### PR DESCRIPTION
This PR removes the 'generated' tags for the compiler dependencies (which are correct) for the grib-util recipe.