### PR TITLE
ip2: remove 'generated' tags

### DIFF
--- a/var/spack/repos/builtin/packages/ip2/package.py
+++ b/var/spack/repos/builtin/packages/ip2/package.py
@@ -25,8 +25,8 @@ class Ip2(CMakePackage):
         deprecated=True,
     )
 
-    depends_on("c", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     depends_on("sp")
     requires("^sp precision=4,8,d", when="^sp@2.4:")


### PR DESCRIPTION
This PR removes the 'generated' tags for the compiler dependencies (which are correct).