### PR TITLE
ncio: update recipe

### DIFF
--- a/var/spack/repos/builtin/packages/ncio/package.py
+++ b/var/spack/repos/builtin/packages/ncio/package.py
@@ -24,7 +24,7 @@ class Ncio(CMakePackage):
     version("1.1.0", sha256="9de05cf3b8b1291010197737666cede3d621605806379b528d2146c4f02d08f6")
     version("1.0.0", sha256="2e2630b26513bf7b0665619c6c3475fe171a9d8b930e9242f5546ddf54749bd4")
 
-    depends_on("fortran", type="build")  # generated
+    depends_on("fortran", type="build")
 
     depends_on("mpi")
     depends_on("netcdf-fortran")
@@ -34,3 +34,7 @@ class Ncio(CMakePackage):
         env.set("NCIO_LIB", lib[0])
         env.set("NCIO_INC", join_path(self.prefix, "include"))
         env.set("NCIO_LIBDIR", lib[0])
+
+    def check(self):
+        with working_dir(self.builder.build_directory):
+            make("test")


### PR DESCRIPTION
This PR removes the 'generated' tag for the compiler dependency (which is correct), and specifies that the make test target should be used for running unit tests.