### PR TITLE
landsfcutil: update recipe

### DIFF
--- a/var/spack/repos/builtin/packages/landsfcutil/package.py
+++ b/var/spack/repos/builtin/packages/landsfcutil/package.py
@@ -21,7 +21,15 @@ class Landsfcutil(CMakePackage):
     version("develop", branch="develop")
     version("2.4.1", sha256="831c5005a480eabe9a8542b4deec838c2650f6966863ea2711cc0cc5db51ca14")
 
-    depends_on("fortran", type="build")  # generated
+    depends_on("fortran", type="build")
+
+    depends_on("pfunit", type="test")
+
+    def cmake_args(self):
+        args = [
+            self.define("ENABLE_TESTS", self.run_tests),
+        ]
+        return args
 
     def setup_run_environment(self, env):
         for suffix in ("4", "d"):
@@ -37,3 +45,7 @@ class Landsfcutil(CMakePackage):
             if name == "fflags":
                 flags.append("-Free")
         return (None, None, flags)
+
+    def check(self):
+        with working_dir(self.builder.build_directory):
+            make("test")

--- a/var/spack/repos/builtin/packages/landsfcutil/package.py
+++ b/var/spack/repos/builtin/packages/landsfcutil/package.py
@@ -26,9 +26,7 @@ class Landsfcutil(CMakePackage):
     depends_on("pfunit", type="test")
 
     def cmake_args(self):
-        args = [
-            self.define("ENABLE_TESTS", self.run_tests),
-        ]
+        args = [self.define("ENABLE_TESTS", self.run_tests)]
         return args
 
     def setup_run_environment(self, env):


### PR DESCRIPTION
This PR removes the 'generated' tag for the compiler dependency (which is correct), and adds testing with pfunit.