### PR TITLE
nemsiogfs: update recipe

### DIFF
--- a/var/spack/repos/builtin/packages/nemsiogfs/package.py
+++ b/var/spack/repos/builtin/packages/nemsiogfs/package.py
@@ -21,6 +21,10 @@ class Nemsiogfs(CMakePackage):
     version("develop", branch="develop")
     version("2.5.3", sha256="bf84206b08c8779787bef33e4aba18404df05f8b2fdd20fc40b3af608ae4b9af")
 
-    depends_on("fortran", type="build")  # generated
+    depends_on("fortran", type="build")
 
     depends_on("nemsio")
+
+    def check(self):
+        with working_dir(self.builder.build_directory):
+            make("test")


### PR DESCRIPTION
This PR removes the 'generated' tag for the compiler dependency (which is correct), and specifies that the make test target should be used for running unit tests.