### PR TITLE
prod-util: remove 'generated' tags

### DIFF
--- a/var/spack/repos/builtin/packages/prod-util/package.py
+++ b/var/spack/repos/builtin/packages/prod-util/package.py
@@ -27,8 +27,8 @@ class ProdUtil(CMakePackage):
         deprecated=True,
     )
 
-    depends_on("c", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     depends_on("w3nco", when="@1")
     depends_on("w3emc", when="@2:")


### PR DESCRIPTION
This PR removes the 'generated' tags for the compiler dependencies (which are correct).