### PR TITLE
sfcio: update recipe

### DIFF
--- a/var/spack/repos/builtin/packages/sfcio/package.py
+++ b/var/spack/repos/builtin/packages/sfcio/package.py
@@ -21,7 +21,13 @@ class Sfcio(CMakePackage):
     version("develop", branch="develop")
     version("1.4.1", sha256="d9f900cf18ec1a839b4128c069b1336317ffc682086283443354896746b89c59")
 
-    depends_on("fortran", type="build")  # generated
+    depends_on("fortran", type="build")
+
+    depends_on("pfunit", type="test")
+
+    def cmake_args(self):
+        args = [self.define("ENABLE_TESTS", self.run_tests)]
+        return args
 
     def setup_run_environment(self, env):
         lib = find_libraries("libsfcio", root=self.prefix, shared=False, recursive=True)
@@ -35,3 +41,7 @@ class Sfcio(CMakePackage):
             if name == "fflags":
                 flags.append("-Free")
         return (None, None, flags)
+
+    def check(self):
+        with working_dir(self.builder.build_directory):
+            make("test")


### PR DESCRIPTION
This PR removes the 'generated' tag for the compiler dependency (which is correct), and adds unit testing with pfunit.