### PR TITLE
sigio: update recipe

### DIFF
--- a/var/spack/repos/builtin/packages/sigio/package.py
+++ b/var/spack/repos/builtin/packages/sigio/package.py
@@ -21,7 +21,11 @@ class Sigio(CMakePackage):
     version("develop", branch="develop")
     version("2.3.2", sha256="333f3cf3a97f97103cbafcafc2ad89b24faa55b1332a98adc1637855e8a5b613")
 
-    depends_on("fortran", type="build")  # generated
+    depends_on("fortran", type="build")
+
+    def cmake_args(self):
+        args = [self.define("ENABLE_TESTS", self.run_tests)]
+        return args
 
     def setup_run_environment(self, env):
         lib = find_libraries("libsigio", root=self.prefix, shared=False, recursive=True)
@@ -35,3 +39,7 @@ class Sigio(CMakePackage):
             if name == "fflags":
                 flags.append("-Free")
         return (None, None, flags)
+
+    def check(self):
+        with working_dir(self.builder.build_directory):
+            make("test")


### PR DESCRIPTION
This PR removes the 'generated' tag for the compiler dependency (which is correct), and adds unit testing with pfunit.