### PR TITLE
sp: remove 'generated' tag

### DIFF
--- a/var/spack/repos/builtin/packages/sp/package.py
+++ b/var/spack/repos/builtin/packages/sp/package.py
@@ -22,7 +22,7 @@ class Sp(CMakePackage):
     version("2.4.0", sha256="dbb4280e622d2683b68a28f8e3837744adf9bbbb1e7940856e8f4597f481c708")
     version("2.3.3", sha256="c0d465209e599de3c0193e65671e290e9f422f659f1da928505489a3edeab99f")
 
-    depends_on("fortran", type="build")  # generated
+    depends_on("fortran", type="build")
 
     variant("shared", default=False, description="Build shared library", when="@2.4:")
     variant("openmp", default=False, description="Use OpenMP threading")


### PR DESCRIPTION
This PR removes the 'generated' tag for the compiler dependency (which is correct).