### PR TITLE
w3emc: update recipe

### DIFF
--- a/var/spack/repos/builtin/packages/w3emc/package.py
+++ b/var/spack/repos/builtin/packages/w3emc/package.py
@@ -19,6 +19,7 @@ class W3emc(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
     version("develop", branch="develop")
+    version("2.12.0", sha256="77c0732541ade1deb381f5a208547ccc36e65efa91c8f7021b299b20a6ae0d27")
     version("2.11.0", sha256="53a03d03421c5da699b026ca220512ed494a531b83284693f66d2579d570c43b")
     version("2.10.0", sha256="366b55a0425fc3e729ecb9f3b236250349399fe4c8e19f325500463043fd2f18")
     version("2.9.3", sha256="9ca1b08dd13dfbad4a955257ae0cf38d2e300ccd8d983606212bc982370a29bc")
@@ -27,8 +28,8 @@ class W3emc(CMakePackage):
     version("2.9.0", sha256="994f59635ab91e34e96cab5fbaf8de54389d09461c7bac33b3104a1187e6c98a")
     version("2.7.3", sha256="eace811a1365f69b85fdf2bcd93a9d963ba72de5a7111e6fa7c0e6578b69bfbc")
 
-    depends_on("c", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     variant("pic", default=True, description="Build with position-independent-code")
     variant("bufr", default=False, description="Build with BUFR routines", when="@2.10:")
@@ -45,10 +46,17 @@ class W3emc(CMakePackage):
         "extradeps",
         default=False,
         description="Build w3emc with subprograms which call unknown dependencies",
-        when="@2.10:",
+        when="@2.10:2.11",
+    )
+    variant(
+        "build_deprecated",
+        default=False,
+        description="Build deprecated subroutines",
+        when="@2.12:",
     )
 
     conflicts("+shared +extradeps", msg="Shared library cannot be built with unknown dependencies")
+    conflicts("+shared ~pic", msg="Shared library requires PIC")
 
     depends_on("bufr", when="@2.10: +bufr")
     depends_on("bacio", when="@2.9.2:")
@@ -82,6 +90,7 @@ class W3emc(CMakePackage):
             self.define("BUILD_8", self.spec.satisfies("precision=8")),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("BUILD_WITH_EXTRA_DEPS", "extradeps"),
+            self.define_from_variant("BUILD_DEPRECATED", "build_deprecated"),
         ]
 
         return args


### PR DESCRIPTION
This PR adds w3emc@2.12.0, adds a conflict for `+shared~pic`, and removes the 'generated' tags for the compiler dependencies (which are correct).