### PR TITLE
kakoune: add v2024.05.18

### DIFF
--- a/var/spack/repos/builtin/packages/kakoune/package.py
+++ b/var/spack/repos/builtin/packages/kakoune/package.py
@@ -18,7 +18,9 @@ class Kakoune(MakefilePackage):
 
     license("Unlicense")
 
-    version("2024.05.18", sha256="dae8ac2e61d21d9bcd10145aa70b421234309a7b0bc57fad91bc34dbae0cb9fa")
+    version(
+        "2024.05.18", sha256="dae8ac2e61d21d9bcd10145aa70b421234309a7b0bc57fad91bc34dbae0cb9fa"
+    )
     version(
         "2024.05.09", sha256="2190bddfd3af590c0593c38537088976547506f47bd6eb6c0e22350dbd16a229"
     )

--- a/var/spack/repos/builtin/packages/kakoune/package.py
+++ b/var/spack/repos/builtin/packages/kakoune/package.py
@@ -18,6 +18,7 @@ class Kakoune(MakefilePackage):
 
     license("Unlicense")
 
+    version("2024.05.18", sha256="dae8ac2e61d21d9bcd10145aa70b421234309a7b0bc57fad91bc34dbae0cb9fa")
     version(
         "2024.05.09", sha256="2190bddfd3af590c0593c38537088976547506f47bd6eb6c0e22350dbd16a229"
     )
@@ -38,4 +39,4 @@ class Kakoune(MakefilePackage):
 
     @property
     def install_targets(self):
-        return ["-e", f"PREFIX={prefix}", "install"]
+        return ["-e", f"PREFIX={prefix}", "installdirs", "install"]


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Adds a new version of Kakoune which fixes some tests on Alpine and BSD.
While I was at it, I fixed an issue where sometimes the install targets would come in the wrong order -- I set it to always create the directories where it's going to be installed first.