### PR TITLE
cxx: new test API

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -20,6 +20,7 @@ packages:
       awk: [gawk]
       armci: [armcimpi]
       blas: [openblas, amdblis]
+      cxx: [gcc]
       D: [ldc]
       daal: [intel-oneapi-daal]
       elf: [elfutils]

--- a/var/spack/repos/builtin/packages/cxx/package.py
+++ b/var/spack/repos/builtin/packages/cxx/package.py
@@ -24,7 +24,7 @@ class Cxx(Package):
             raise SkipTest(f"{os.environ['CXX']} not found in {self.version}")
 
         for test in os.listdir(test_source):
-            with test_part(self, f"test_hello_world_{test}", f"Test {test}"):
+            with test_part(self, f"test_cxx_{test}", f"Test {test}"):
                 filepath = os.path.join(test_source, test)
                 exe_name = "%s.exe" % test
                 # standard options

--- a/var/spack/repos/builtin/packages/cxx/package.py
+++ b/var/spack/repos/builtin/packages/cxx/package.py
@@ -14,12 +14,14 @@ class Cxx(Package):
     homepage = "https://isocpp.org/std/the-standard"
     virtual = True
 
-    def test_hello_world(self):
+    def test_c(self):
         """Compile and run 'Hello World'"""
         test_source = self.test_suite.current_test_data_dir
 
         cxx_exe = os.environ["CXX"]
         cxx_exe = which(join_path(self.prefix.bin, cxx_exe))
+        if cxx_exe is None:
+            raise SkipTest(f"{os.environ['CXX']} not found in {self.version}")
 
         for test in os.listdir(test_source):
             with test_part(self, f"test_hello_world_{test}", f"Test {test}"):

--- a/var/spack/repos/builtin/packages/cxx/package.py
+++ b/var/spack/repos/builtin/packages/cxx/package.py
@@ -26,7 +26,7 @@ class Cxx(Package):
         for test in os.listdir(test_source):
             with test_part(self, f"test_cxx_{test}", f"Test {test}"):
                 filepath = os.path.join(test_source, test)
-                exe_name = "%s.exe" % test
+                exe_name = f"{test}.exe"
                 # standard options
                 # Hack to get compiler attributes
                 # TODO: remove this when compilers are dependencies

--- a/var/spack/repos/builtin/packages/cxx/package.py
+++ b/var/spack/repos/builtin/packages/cxx/package.py
@@ -14,7 +14,8 @@ class Cxx(Package):
     homepage = "https://isocpp.org/std/the-standard"
     virtual = True
 
-    def test(self):
+    def test_hello_world(self):
+        """Compile and run 'Hello World'"""
         test_source = self.test_suite.current_test_data_dir
 
         for test in os.listdir(test_source):
@@ -34,8 +35,13 @@ class Cxx(Package):
             cxx_opts = [compiler.cxx11_flag] if "c++11" in test else []
 
             cxx_opts += ["-o", exe_name, filepath]
-            compiled = self.run_test(cxx_exe, options=cxx_opts, installed=True)
+            cxx_exe = which(join_path(self.prefix.bin, cxx_exe))
+            compiled = cxx_exe(*cxx_opts)
 
             if compiled:
                 expected = ["Hello world", "YES!"]
-                self.run_test(exe_name, expected=expected)
+                exe_run = which(join_path(self.prefix.bin, exe_name))
+                out = exe_run(output=str.split, error=str.split)
+                assert expected in out
+            else:
+                assert False, "Did not compile"

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -18,6 +18,8 @@ import spack.util.libc
 from spack.operating_systems.mac_os import macos_sdk_path, macos_version
 from spack.package import *
 
+provides("cxx")
+
 
 class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     """The GNU Compiler Collection includes front ends for C, C++, Objective-C,

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -18,8 +18,6 @@ import spack.util.libc
 from spack.operating_systems.mac_os import macos_sdk_path, macos_version
 from spack.package import *
 
-provides("cxx")
-
 
 class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     """The GNU Compiler Collection includes front ends for C, C++, Objective-C,
@@ -35,6 +33,8 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     maintainers("michaelkuhn", "alalazo")
 
     license("GPL-2.0-or-later AND LGPL-2.1-or-later")
+
+    provides("cxx")
 
     version("master", branch="master")
 


### PR DESCRIPTION
Supersedes #35692 (for one package)

Change to the new standalone test API. ~Currently unable to get test results.~

Relevant test results with these changes are:

```
$ spack -v test run cxx
==> Spack test 6klnmfymj2ympjwg4oymgaxbm2ho4cum
==> Testing package gcc-9.3.0-4b7osls
...
==> [2024-08-08-18:12:06.576153] test: test_cxx: Compile and run 'Hello World'
==> [2024-08-08-18:12:06.579111] test: test_cxx_hello.cc: build and run hello.cc.exe
...
==> [2024-08-08-18:12:10.357640] 'hello.cc.exe'
Hello world from C++!
YES!
PASSED: Gcc::test_cxx_hello.cc
==> [2024-08-08-18:12:10.457868] test: test_cxx_hello.c++: build and run hello.c++.exe
...
==> [2024-08-08-18:12:10.564452] 'hello.c++.exe'
Hello world from C++
YES!PASSED: Gcc::test_cxx_hello.c++
==> [2024-08-08-18:12:10.577834] test: test_cxx_hello.cpp: build and run hello.cpp.exe
...
==> [2024-08-08-18:12:10.955723] 'hello.cpp.exe'
Hello world from C++!
YES!
PASSED: Gcc::test_cxx_hello.cpp
==> [2024-08-08-18:12:10.969440] test: test_cxx_hello_c++11.cc: build and run hello_c++11.cc.exe
==> [2024-08-08-18:12:10.970363] 'fakecc' '-dumpversion'
...
==> [2024-08-08-18:12:14.539180] 'hello_c++11.cc.exe'
Hello world from C++11
std::regex r("st|mt|tr") match tr? YES!
  ==> Correct libstdc++11 implementation of regex (4.9.2 or later)
PASSED: Gcc::test_cxx_hello_c++11.cc
PASSED: Gcc::test_cxx
==> [2024-08-08-18:12:14.564896] test: test_cxx: Compile and run 'Hello World'
==> [2024-08-08-18:12:14.565957] test: test_cxx_hello.cc: build and run hello.cc.exe
...
==> [2024-08-08-18:12:14.916809] 'hello.cc.exe'
Hello world from C++!
YES!
PASSED: Gcc::test_cxx_hello.cc
==> [2024-08-08-18:12:14.931496] test: test_cxx_hello.c++: build and run hello.c++.exe
...
Hello world from C++
YES!PASSED: Gcc::test_cxx_hello.c++
==> [2024-08-08-18:12:15.032198] test: test_cxx_hello.cpp: build and run hello.cpp.exe
...
==> [2024-08-08-18:12:15.421255] 'hello.cpp.exe'
Hello world from C++!
YES!
PASSED: Gcc::test_cxx_hello.cpp
==> [2024-08-08-18:12:15.434214] test: test_cxx_hello_c++11.cc: build and run hello_c++11.cc.exe
==> [2024-08-08-18:12:15.435081] 'fakecc' '-dumpversion'
...
==> [2024-08-08-18:12:17.763145] 'hello_c++11.cc.exe'
Hello world from C++11
std::regex r("st|mt|tr") match tr? YES!
  ==> Correct libstdc++11 implementation of regex (4.9.2 or later)
PASSED: Gcc::test_cxx_hello_c++11.cc
PASSED: Gcc::test_cxx
...
==> [2024-08-08-18:12:20.021279] Completed testing
==> [2024-08-08-18:12:20.021466] 
========================== SUMMARY: gcc-9.3.0-4b7osls ==========================
...
Gcc::test_cxx_hello.cc .. PASSED
Gcc::test_cxx_hello.c++ .. PASSED
Gcc::test_cxx_hello.cpp .. PASSED
Gcc::test_cxx_hello_c++11.cc .. PASSED
Gcc::test_cxx .. PASSED
...
====================== 1 no_tests, 18 passed of 19 parts =======================
============================== 1 passed of 1 spec ==============================
```
