### PR TITLE
gaudi: add v38.2, v38.3

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -17,6 +17,8 @@ class Gaudi(CMakePackage):
     tags = ["hep"]
 
     version("master", branch="master")
+    version("38.3", sha256="47e8c65ea446656d2dae54a32205525e08257778cf80f9f029cd244d6650486e")
+    version("38.2", sha256="08759b1398336987ad991602e37079f0744e8d8e4e3d5df2d253b8dedf925068")
     version("38.1", sha256="79d42833edcebc2099f91badb6f72708640c05f678cc4521a86e857f112486dc")
     version("38.0", sha256="52f2733fa0af760c079b3438bb9c7e36b28ea704f78b0085458e1918c11e1653")
     version("37.2", sha256="9b866caab46e182de98b59eddbde80d6fa0e670fe4a35906f1518b04bd99b2d2")
@@ -87,6 +89,7 @@ class Gaudi(CMakePackage):
     depends_on("cppgsl")
     depends_on("fmt")
     depends_on("fmt@:8", when="@:36.9")
+    depends_on("fmt@:10", when="@:39.0")
     depends_on("intel-tbb@:2020.3", when="@:37.0")
     depends_on("tbb", when="@37.1:")
     depends_on("uuid")


### PR DESCRIPTION
fmt 11 appeared a few days ago and Gaudi doesn't compile with it. I'm setting
the range up to v39 since it's not fixed in master and v39 is going to be released in the coming days.