### PR TITLE
c: new test API

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -20,6 +20,7 @@ packages:
       awk: [gawk]
       armci: [armcimpi]
       blas: [openblas, amdblis]
+      c: [gcc]
       cxx: [gcc]
       D: [ldc]
       daal: [intel-oneapi-daal]

--- a/var/spack/repos/builtin/packages/c/package.py
+++ b/var/spack/repos/builtin/packages/c/package.py
@@ -16,10 +16,11 @@ class C(Package):
 
     def test_c(self):
         """Compile and run 'Hello world'"""
+
         test_source = self.test_suite.current_test_data_dir
 
         cc_exe = os.environ["CC"]
-        cc_exe = which(join_path(self.prefix.bin, cxx_exe))
+        cc_exe = which(join_path(self.prefix.bin, cc_exe))
         if cc_exe is None:
             raise SkipTest(f"{os.environ['CC']} not found in {self.version}")
 

--- a/var/spack/repos/builtin/packages/c/package.py
+++ b/var/spack/repos/builtin/packages/c/package.py
@@ -26,7 +26,7 @@ class C(Package):
         for test in os.listdir(test_source):
             with test_part(self, f"test_c_{test}", f"Test {test}"):
                 filepath = test_source.join(test)
-                exe_name = "%s.exe" % test
+                exe_name = f"{test}.exe"
                 cc_opts = ["-o", exe_name, filepath]
                 comp_exe = which(join_path(self.prefix.bin, cc_exe))
                 if comp_exe is None:

--- a/var/spack/repos/builtin/packages/c/package.py
+++ b/var/spack/repos/builtin/packages/c/package.py
@@ -14,17 +14,23 @@ class C(Package):
     homepage = "http://open-std.org/JTC1/SC22/WG14/www/standards"
     virtual = True
 
-    def test(self):
+    def test_hello_world(self):
+        """Compile and run 'Hello world'"""
         test_source = self.test_suite.current_test_data_dir
 
         for test in os.listdir(test_source):
-            filepath = test_source.join(test)
-            exe_name = "%s.exe" % test
+            with test_part(self, f"test_hello_world_{test}", f"Test {test}"):
+                filepath = test_source.join(test)
+                exe_name = "%s.exe" % test
 
-            cc_exe = os.environ["CC"]
-            cc_opts = ["-o", exe_name, filepath]
-            compiled = self.run_test(cc_exe, options=cc_opts, installed=True)
+                cc_exe = os.environ["CC"]
+                cc_opts = ["-o", exe_name, filepath]
+                compiled = self.run_test(cc_exe, options=cc_opts, installed=True)
 
-            if compiled:
-                expected = ["Hello world", "YES!"]
-                self.run_test(exe_name, expected=expected)
+                if compiled:
+                    expected = ["Hello world", "YES!"]
+                    exe = which(join_path(self.prefix.bin, exe_name))
+                    out = exe(output=str.split, error=str.split)
+                    check_outputs(expected, out)
+                else:
+                    assert False, "Did not compile"

--- a/var/spack/repos/builtin/packages/c/package.py
+++ b/var/spack/repos/builtin/packages/c/package.py
@@ -18,11 +18,15 @@ class C(Package):
         """Compile and run 'Hello world'"""
         test_source = self.test_suite.current_test_data_dir
 
+        cc_exe = os.environ["CC"]
+        cc_exe = which(join_path(self.prefix.bin, cxx_exe))
+        if cc_exe is None:
+            raise SkipTest(f"{os.environ['CC']} not found in {self.version}")
+
         for test in os.listdir(test_source):
             with test_part(self, f"test_c_{test}", f"Test {test}"):
                 filepath = test_source.join(test)
                 exe_name = "%s.exe" % test
-                cc_exe = os.environ["CC"]
                 cc_opts = ["-o", exe_name, filepath]
                 comp_exe = which(join_path(self.prefix.bin, cc_exe))
                 if comp_exe is None:
@@ -37,4 +41,4 @@ class C(Package):
                     out = exe(output=str.split, error=str.split)
                     check_outputs(expected, out)
                 else:
-                   assert False, "Did not compile"
+                    assert False, "Did not compile"

--- a/var/spack/repos/builtin/packages/c/package.py
+++ b/var/spack/repos/builtin/packages/c/package.py
@@ -14,17 +14,20 @@ class C(Package):
     homepage = "http://open-std.org/JTC1/SC22/WG14/www/standards"
     virtual = True
 
-    def test_hello_world(self):
+    def test_c(self):
         """Compile and run 'Hello world'"""
         test_source = self.test_suite.current_test_data_dir
 
         for test in os.listdir(test_source):
-            with test_part(self, f"test_hello_world_{test}", f"Test {test}"):
+            with test_part(self, f"test_c_{test}", f"Test {test}"):
                 filepath = test_source.join(test)
                 exe_name = "%s.exe" % test
                 cc_exe = os.environ["CC"]
                 cc_opts = ["-o", exe_name, filepath]
-                compiled = self.run_test(cc_exe, options=cc_opts, installed=True)
+                comp_exe = which(join_path(self.prefix.bin, cc_exe))
+                if comp_exe is None:
+                    raise SkipTest(f"{str(cc_exe)} not found in {self.version}")
+                compiled = cc_exe(*cc_opts)
 
                 if compiled:
                     expected = ["Hello world", "YES!"]
@@ -34,4 +37,4 @@ class C(Package):
                     out = exe(output=str.split, error=str.split)
                     check_outputs(expected, out)
                 else:
-                    assert False, "Did not compile"
+                   assert False, "Did not compile"

--- a/var/spack/repos/builtin/packages/c/package.py
+++ b/var/spack/repos/builtin/packages/c/package.py
@@ -15,31 +15,16 @@ class C(Package):
     virtual = True
 
     def test_c(self):
-        """Compile and run 'Hello world'"""
+        """build and run C examples"""
+        cc = which(os.environ["CC"])
+        expected = ["Hello world", "YES!"]
 
         test_source = self.test_suite.current_test_data_dir
-
-        cc_exe = os.environ["CC"]
-        cc_exe = which(join_path(self.prefix.bin, cc_exe))
-        if cc_exe is None:
-            raise SkipTest(f"{os.environ['CC']} not found in {self.version}")
-
         for test in os.listdir(test_source):
-            with test_part(self, f"test_c_{test}", f"Test {test}"):
-                filepath = test_source.join(test)
-                exe_name = f"{test}.exe"
-                cc_opts = ["-o", exe_name, filepath]
-                comp_exe = which(join_path(self.prefix.bin, cc_exe))
-                if comp_exe is None:
-                    raise SkipTest(f"{str(cc_exe)} not found in {self.version}")
-                compiled = cc_exe(*cc_opts)
-
-                if compiled:
-                    expected = ["Hello world", "YES!"]
-                    exe = which(join_path(self.prefix.bin, exe_name))
-                    if exe is None:
-                        raise SkipTest(f"{exe} not found in {self.version}")
-                    out = exe(output=str.split, error=str.split)
-                    check_outputs(expected, out)
-                else:
-                    assert False, "Did not compile"
+            exe_name = f"{test}.exe"
+            with test_part(self, f"test_c_{test}", f"build and run {exe_name}"):
+                filepath = join_path(test_source, test)
+                cc("-o", exe_name, filepath)
+                exe = which(exe_name)
+                out = exe(output=str.split, error=str.split)
+                check_outputs(expected, out)

--- a/var/spack/repos/builtin/packages/c/package.py
+++ b/var/spack/repos/builtin/packages/c/package.py
@@ -22,7 +22,6 @@ class C(Package):
             with test_part(self, f"test_hello_world_{test}", f"Test {test}"):
                 filepath = test_source.join(test)
                 exe_name = "%s.exe" % test
-
                 cc_exe = os.environ["CC"]
                 cc_opts = ["-o", exe_name, filepath]
                 compiled = self.run_test(cc_exe, options=cc_opts, installed=True)
@@ -30,6 +29,8 @@ class C(Package):
                 if compiled:
                     expected = ["Hello world", "YES!"]
                     exe = which(join_path(self.prefix.bin, exe_name))
+                    if exe is None:
+                        raise SkipTest(f"{exe} not found in {self.version}")
                     out = exe(output=str.split, error=str.split)
                     check_outputs(expected, out)
                 else:

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -18,6 +18,7 @@ import spack.util.libc
 from spack.operating_systems.mac_os import macos_sdk_path, macos_version
 from spack.package import *
 
+provides("c")
 
 class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     """The GNU Compiler Collection includes front ends for C, C++, Objective-C,

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -18,7 +18,6 @@ import spack.util.libc
 from spack.operating_systems.mac_os import macos_sdk_path, macos_version
 from spack.package import *
 
-provides("c")
 
 class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     """The GNU Compiler Collection includes front ends for C, C++, Objective-C,
@@ -35,6 +34,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
 
     license("GPL-2.0-or-later AND LGPL-2.1-or-later")
 
+    provides("c")
     provides("cxx")
     provides("fortran")
 


### PR DESCRIPTION
Supersedes #35692 (for one package)

New standalone test API. ~Cannot give results as you cannot install the package.~

Results (after rebase with cxx and fortran conversions):

```
$ spack -v test run c
==> Spack test avrhfzeywhxdlx5or6n3nfzfvfneetw4
==> Testing package gcc-11.3.0-iyhqcp3
NO_TESTS: Gcc::gcc
==> [2024-08-12-09:12:26.926393] test: test_c: build and run C examples
==> [2024-08-12-09:12:26.928514] test: test_c_hello.c: build and run hello.c.exe
..
==> [2024-08-12-09:12:27.020292] 'hello.c.exe'
Hello world from C!
YES!PASSED: Gcc::test_c_hello.c
PASSED: Gcc::test_c
==> [2024-08-12-09:12:27.029760] test: test_c: build and run C examples
==> [2024-08-12-09:12:27.030962] test: test_c_hello.c: build and run hello.c.exe
..
==> [2024-08-12-09:12:27.096279] 'hello.c.exe'
Hello world from C!
YES!PASSED: Gcc::test_c_hello.c
PASSED: Gcc::test_c
==> [2024-08-12-09:12:27.130154] test: test_cxx: Compile and run 'Hello World'
==> [2024-08-12-09:12:27.132550] test: test_cxx_hello.c++: build and run hello.c++.exe
..
==> [2024-08-12-09:12:27.253822] 'hello.c++.exe'
Hello world from C++
YES!PASSED: Gcc::test_cxx_hello.c++
==> [2024-08-12-09:12:27.263630] test: test_cxx_hello.cc: build and run hello.cc.exe
..
==> [2024-08-12-09:12:27.711943] 'hello.cc.exe'
Hello world from C++!
YES!
PASSED: Gcc::test_cxx_hello.cc
==> [2024-08-12-09:12:27.722887] test: test_cxx_hello.cpp: build and run hello.cpp.exe
..
==> [2024-08-12-09:12:28.163188] 'hello.cpp.exe'
Hello world from C++!
YES!
PASSED: Gcc::test_cxx_hello.cpp
==> [2024-08-12-09:12:28.175387] test: test_cxx_hello_c++11.cc: build and run hello_c++11.cc.exe
==> [2024-08-12-09:12:28.176471] 'fakecc' '-dumpversion'
..
==> [2024-08-12-09:12:30.596810] 'hello_c++11.cc.exe'
Hello world from C++11
std::regex r("st|mt|tr") match tr? YES!
  ==> Correct libstdc++11 implementation of regex (4.9.2 or later)
PASSED: Gcc::test_cxx_hello_c++11.cc
PASSED: Gcc::test_cxx
==> [2024-08-12-09:12:30.626156] test: test_cxx: Compile and run 'Hello World'
==> [2024-08-12-09:12:30.628621] test: test_cxx_hello.c++: build and run hello.c++.exe
..
==> [2024-08-12-09:12:30.749591] 'hello.c++.exe'
Hello world from C++
YES!PASSED: Gcc::test_cxx_hello.c++
==> [2024-08-12-09:12:30.764131] test: test_cxx_hello.cc: build and run hello.cc.exe
..
==> [2024-08-12-09:12:31.230108] 'hello.cc.exe'
Hello world from C++!
YES!
PASSED: Gcc::test_cxx_hello.cc
==> [2024-08-12-09:12:31.245706] test: test_cxx_hello.cpp: build and run hello.cpp.exe
..
==> [2024-08-12-09:12:31.701320] 'hello.cpp.exe'
Hello world from C++!
YES!
PASSED: Gcc::test_cxx_hello.cpp
==> [2024-08-12-09:12:31.715218] test: test_cxx_hello_c++11.cc: build and run hello_c++11.cc.exe
==> [2024-08-12-09:12:31.716256] 'fakecc' '-dumpversion'
..
==> [2024-08-12-09:12:34.183783] 'hello_c++11.cc.exe'
Hello world from C++11
std::regex r("st|mt|tr") match tr? YES!
  ==> Correct libstdc++11 implementation of regex (4.9.2 or later)
PASSED: Gcc::test_cxx_hello_c++11.cc
PASSED: Gcc::test_cxx
==> [2024-08-12-09:12:34.217014] test: test_fortran: Compile and run 'Hello world'
==> [2024-08-12-09:12:34.218919] test: test_fortran_hello.F: run hello.F.exe
..
==> [2024-08-12-09:12:34.307749] 'hello.F.exe'
 Hello world from FORTRAN
 YES!
PASSED: Gcc::test_fortran_hello.F
==> [2024-08-12-09:12:34.317720] test: test_fortran_hello.f90: run hello.f90.exe
..
==> [2024-08-12-09:12:34.400248] 'hello.f90.exe'
 Hello world from FORTRAN
 YES!
PASSED: Gcc::test_fortran_hello.f90
PASSED: Gcc::test_fortran
==> [2024-08-12-09:12:34.411188] test: test_fortran: Compile and run 'Hello world'
==> [2024-08-12-09:12:34.412310] test: test_fortran_hello.F: run hello.F.exe
..
==> [2024-08-12-09:12:34.494423] 'hello.F.exe'
 Hello world from FORTRAN
 YES!
PASSED: Gcc::test_fortran_hello.F
==> [2024-08-12-09:12:34.502457] test: test_fortran_hello.f90: run hello.f90.exe
..
==> [2024-08-12-09:12:34.582124] 'hello.f90.exe'
 Hello world from FORTRAN
 YES!
PASSED: Gcc::test_fortran_hello.f90
PASSED: Gcc::test_fortran
==> [2024-08-12-09:12:34.591973] Completed testing
==> [2024-08-12-09:12:34.592212] 
========================= SUMMARY: gcc-11.3.0-iyhqcp3 ==========================
Gcc::gcc .. NO_TESTS
Gcc::test_c_hello.c .. PASSED
Gcc::test_c .. PASSED
Gcc::test_cxx_hello.c++ .. PASSED
Gcc::test_cxx_hello.cc .. PASSED
Gcc::test_cxx_hello.cpp .. PASSED
Gcc::test_cxx_hello_c++11.cc .. PASSED
Gcc::test_cxx .. PASSED
Gcc::test_fortran_hello.F .. PASSED
Gcc::test_fortran_hello.f90 .. PASSED
Gcc::test_fortran .. PASSED
====================== 1 no_tests, 20 passed of 21 parts =======================
============================== 1 passed of 1 spec ==============================
```