### PR TITLE
fortran: new test API

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -26,6 +26,7 @@ packages:
       elf: [elfutils]
       fftw-api: [fftw, amdfftw]
       flame: [libflame, amdlibflame]
+      fortran: [gcc]
       fortran-rt: [gcc-runtime, intel-oneapi-runtime]
       fuse: [libfuse]
       gl: [glx, osmesa]

--- a/var/spack/repos/builtin/packages/fortran/package.py
+++ b/var/spack/repos/builtin/packages/fortran/package.py
@@ -16,26 +16,14 @@ class Fortran(Package):
 
     def test_fortran(self):
         """Compile and run 'Hello world'"""
+        expected = ["Hello world", "YES!"]
+        fc = which(os.environ["FC"])
+
         test_source = self.test_suite.current_test_data_dir
-
-        fc_exe = os.environ["FC"]
-        fc_exe = which(join_path(self.prefix.bin, fc_exe))
-        if fc_exe is None:
-            raise SkipTest(f"{os.environ['FC']} not found in {self.version}")
-
         for test in os.listdir(test_source):
-            with test_part(self, f"test_fortran_{test}", f"Test {test}"):
-                filepath = os.path.join(test_source, test)
-                exe_name = f"{test}.exe"
-                fc_opts = ["-o", exe_name, filepath]
-                compiled = fc_exe(*fc_opts, output=str.split, error=str.split)
-
-                if compiled:
-                    exe = which(join_path(self.prefix.bin, exe_name))
-                    if exe is None:
-                        raise SkipTest(f"{exe} not found in {self.version}")
-                        expected = ["Hello world", "YES!"]
-                        out = exe(output=str.split, error=str.split)
-                        check_outputs(expected, out)
-                    else:
-                        assert False, "Did not compile"
+            exe_name = f"{test}.exe"
+            with test_part(self, f"test_fortran_{test}", f"run {exe_name}"):
+                fc("-o", exe_name, join_path(test_source, test))
+                exe = which(exe_name)
+                out = exe(output=str.split, error=str.split)
+                check_outputs(expected, out)

--- a/var/spack/repos/builtin/packages/fortran/package.py
+++ b/var/spack/repos/builtin/packages/fortran/package.py
@@ -14,17 +14,20 @@ class Fortran(Package):
     homepage = "https://wg5-fortran.org/"
     virtual = True
 
-    def test_hello_world(self):
+    def test_fortran(self):
         """Compile and run 'Hello world'"""
         test_source = self.test_suite.current_test_data_dir
 
         for test in os.listdir(test_source):
-            with test_part(self, f"test_hello_world_{test}", f"Test {test}"):
+            with test_part(self, f"test_fortran_{test}", f"Test {test}"):
                 filepath = os.path.join(test_source, test)
                 exe_name = "%s.exe" % test
                 fc_exe = os.environ["FC"]
                 fc_opts = ["-o", exe_name, filepath]
-                compiled = self.run_test(fc_exe, options=fc_opts, installed=True)
+                fc_exe = which(join_path(self.prefix.bin, fc_exe))
+                if fc_exe is None:
+                    raise SkipTest(f"{os.environ['FC']} not found in {self.version}")
+                fc_exe(*fc_opts)
 
                 if compiled:
                     exe = which(join_path(self.prefix.bin, exe_name))

--- a/var/spack/repos/builtin/packages/fortran/package.py
+++ b/var/spack/repos/builtin/packages/fortran/package.py
@@ -14,18 +14,24 @@ class Fortran(Package):
     homepage = "https://wg5-fortran.org/"
     virtual = True
 
-    def test(self):
+    def test_hello_world(self):
+        """Compile and run 'Hello world'"""
         test_source = self.test_suite.current_test_data_dir
 
         for test in os.listdir(test_source):
-            filepath = os.path.join(test_source, test)
-            exe_name = "%s.exe" % test
+            with test_part(self, f"test_hello_world_{test}", f"Test {test}"):
+                filepath = os.path.join(test_source, test)
+                exe_name = "%s.exe" % test
+                fc_exe = os.environ["FC"]
+                fc_opts = ["-o", exe_name, filepath]
+                compiled = self.run_test(fc_exe, options=fc_opts, installed=True)
 
-            fc_exe = os.environ["FC"]
-            fc_opts = ["-o", exe_name, filepath]
-
-            compiled = self.run_test(fc_exe, options=fc_opts, installed=True)
-
-            if compiled:
-                expected = ["Hello world", "YES!"]
-                self.run_test(exe_name, expected=expected)
+                if compiled:
+                    exe = which(join_path(self.prefix.bin, exe_name))
+                    if exe is None:
+                        raise SkipTest(f"{exe} not found in {self.version}")
+                        expected = ["Hello world", "YES!"]
+                        out = exe(output=str.split, error=str.split)
+                        check_outputs(expected, out)
+                    else:
+                        assert False, "Did not compile"

--- a/var/spack/repos/builtin/packages/fortran/package.py
+++ b/var/spack/repos/builtin/packages/fortran/package.py
@@ -28,7 +28,7 @@ class Fortran(Package):
                 filepath = os.path.join(test_source, test)
                 exe_name = f"{test}.exe"
                 fc_opts = ["-o", exe_name, filepath]
-                fc_exe(*fc_opts)
+                compiled = fc_exe(*fc_opts, output=str.split, error=str.split)
 
                 if compiled:
                     exe = which(join_path(self.prefix.bin, exe_name))

--- a/var/spack/repos/builtin/packages/fortran/package.py
+++ b/var/spack/repos/builtin/packages/fortran/package.py
@@ -18,15 +18,16 @@ class Fortran(Package):
         """Compile and run 'Hello world'"""
         test_source = self.test_suite.current_test_data_dir
 
+        fc_exe = os.environ["FC"]
+        fc_exe = which(join_path(self.prefix.bin, fc_exe))
+        if fc_exe is None:
+            raise SkipTest(f"{os.environ['FC']} not found in {self.version}")
+
         for test in os.listdir(test_source):
             with test_part(self, f"test_fortran_{test}", f"Test {test}"):
                 filepath = os.path.join(test_source, test)
                 exe_name = "%s.exe" % test
-                fc_exe = os.environ["FC"]
                 fc_opts = ["-o", exe_name, filepath]
-                fc_exe = which(join_path(self.prefix.bin, fc_exe))
-                if fc_exe is None:
-                    raise SkipTest(f"{os.environ['FC']} not found in {self.version}")
                 fc_exe(*fc_opts)
 
                 if compiled:

--- a/var/spack/repos/builtin/packages/fortran/package.py
+++ b/var/spack/repos/builtin/packages/fortran/package.py
@@ -26,7 +26,7 @@ class Fortran(Package):
         for test in os.listdir(test_source):
             with test_part(self, f"test_fortran_{test}", f"Test {test}"):
                 filepath = os.path.join(test_source, test)
-                exe_name = "%s.exe" % test
+                exe_name = f"{test}.exe"
                 fc_opts = ["-o", exe_name, filepath]
                 fc_exe(*fc_opts)
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -18,8 +18,6 @@ import spack.util.libc
 from spack.operating_systems.mac_os import macos_sdk_path, macos_version
 from spack.package import *
 
-provides("fortran")
-
 
 class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     """The GNU Compiler Collection includes front ends for C, C++, Objective-C,
@@ -37,6 +35,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     license("GPL-2.0-or-later AND LGPL-2.1-or-later")
 
     provides("cxx")
+    provides("fortran")
 
     version("master", branch="master")
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -18,6 +18,8 @@ import spack.util.libc
 from spack.operating_systems.mac_os import macos_sdk_path, macos_version
 from spack.package import *
 
+provides("fortran")
+
 
 class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     """The GNU Compiler Collection includes front ends for C, C++, Objective-C,


### PR DESCRIPTION
Supersedes #35692 (for one package)

New standalone test API integration. Cannot provide tests results ATM due to being unable to install fortran package.

Relevant results from latest commit:

```
$ spack -v test run gcc
==> Spack test avrhfzeywhxdlx5or6n3nfzfvfneetw4
==> Testing package gcc-11.3.0-iyhqcp3
..
==> [2024-08-09-18:09:38.033430] test: test_fortran: Compile and run 'Hello world'
==> [2024-08-09-18:09:38.034599] test: test_fortran_hello.F: run hello.F.exe
..
==> [2024-08-09-18:09:38.126148] 'hello.F.exe'
 Hello world from FORTRAN
 YES!
PASSED: Gcc::test_fortran_hello.F
==> [2024-08-09-18:09:38.132490] test: test_fortran_hello.f90: run hello.f90.exe
..
==> [2024-08-09-18:09:38.219085] 'hello.f90.exe'
 Hello world from FORTRAN
 YES!
PASSED: Gcc::test_fortran_hello.f90
PASSED: Gcc::test_fortran
==> [2024-08-09-18:09:38.227455] Completed testing
==> [2024-08-09-18:09:38.227594] 
========================= SUMMARY: gcc-11.3.0-iyhqcp3 ==========================
..
Gcc::test_fortran_hello.F .. PASSED
Gcc::test_fortran_hello.f90 .. PASSED
Gcc::test_fortran .. PASSED
====================== 1 no_tests, 18 passed of 19 parts =======================
============================== 1 passed of 1 spec ==============================
```