### PR TITLE
[WIP] intel-oneapi-mpi: external detection support

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+import re
+
 from spack.package import *
 
 
@@ -136,6 +138,15 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
 
     provides("mpi@:3.1")
     conflicts("+generic-names +classic-names")
+
+    executables = [r"^mpiicpx$"]
+    version_regex = r"Intel\(R\) MPI Library (\S+)"
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("-v", output=str, error=str)
+        match = re.search(cls.version_regex, output)
+        return match.group(1) if match else None
 
     @property
     def mpiexec(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -146,7 +146,8 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
     def determine_version(cls, exe):
         output = Executable(exe)("-v", output=str, error=str)
         match = re.search(cls.version_regex, output)
-        return match.group(1) if match else None
+        # strip @ from unsubstituted @IMPI_OFFICIALVERSION@
+        return match.group(1).strip("@") if match else None
 
     @property
     def mpiexec(self):


### PR DESCRIPTION
This PR adds external detection support to `intel-oneapi-mpi` based on the executable `mpiicpx`, with version parsed from `mpiicpx -v`.

The more generic `mpirun` is installed in ubuntu by `intel-oneapi-mpi` but only when installing `intel-oneapi-mpi-devel` are the compiler wrappers installed.

Note: On my system this appears to fail due to what appears to be a bug in the ubuntu `intel-oneapi-mpi` package:
```console
$ mpiicpx -v
mpiicpx for the Intel(R) MPI Library @IMPI_OFFICIALVERSION@ for Linux*
```