### PR TITLE
wasi-sdk: add default provider

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -44,6 +44,7 @@ jobs:
       run: |
           . share/spack/setup-env.sh
           coverage run $(which spack) audit packages
+          coverage run $(which spack) audit configs
           coverage run $(which spack) -d audit externals
           coverage combine
           coverage xml
@@ -52,12 +53,15 @@ jobs:
       run: |
           . share/spack/setup-env.sh          
           spack -d audit packages
+          spack -d audit configs
           spack -d audit externals
     - name: Package audits (without coverage)
       if: ${{ runner.os == 'Windows' }}
       run: |
           . share/spack/setup-env.sh          
           spack -d audit packages
+          ./share/spack/qa/validate_last_exit.ps1
+          spack -d audit configs
           ./share/spack/qa/validate_last_exit.ps1
           spack -d audit externals
           ./share/spack/qa/validate_last_exit.ps1

--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -61,6 +61,7 @@ packages:
       tbb: [intel-tbb]
       unwind: [libunwind]
       uuid: [util-linux-uuid, libuuid]
+      wasi-sdk: [wasi-sdk-prebuilt]
       xxd: [xxd-standalone, vim]
       yacc: [bison, byacc]
       ziglang: [zig]

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -351,6 +351,22 @@ def _wrongly_named_spec(error_cls):
     return errors
 
 
+@config_packages
+def _ensure_all_virtual_packages_have_default_providers(error_cls):
+    """All virtual packages must have a default provider explicitly set."""
+    configuration = spack.config.create()
+    defaults = configuration.get("packages", scope="defaults")
+    default_providers = defaults["all"]["providers"]
+    virtuals = spack.repo.PATH.provider_index.providers
+    default_providers_filename = configuration.scopes["defaults"].get_section_filename("packages")
+
+    return [
+        error_cls(f"'{virtual}' must have a default provider in {default_providers_filename}", [])
+        for virtual in virtuals
+        if virtual not in default_providers
+    ]
+
+
 def _make_config_error(config_data, summary, error_cls):
     s = io.StringIO()
     s.write("Occurring in the following file:\n")

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -131,19 +131,6 @@ def test_relative_import_spack_packages_as_python_modules(mock_packages):
     assert issubclass(Mpileaks, spack.package_base.PackageBase)
 
 
-def test_all_virtual_packages_have_default_providers():
-    """All virtual packages must have a default provider explicitly set."""
-    configuration = spack.config.create()
-    defaults = configuration.get("packages", scope="defaults")
-    default_providers = defaults["all"]["providers"]
-    providers = spack.repo.PATH.provider_index.providers
-    default_providers_filename = configuration.scopes["defaults"].get_section_filename("packages")
-    for provider in providers:
-        assert provider in default_providers, (
-            "all providers must have a default in %s" % default_providers_filename
-        )
-
-
 def test_get_all_mock_packages(mock_packages):
     """Get the mock packages once each too."""
     for name in mock_packages.all_package_names():


### PR DESCRIPTION
This was missed in #45394 because we don't run unit tests for package PRs, and `test_all_virtual_packages_have_default_providers`, which would've caught it, was a unit test, not an audit.

- [x] add a default provider for `wasi-sdk` in `etc/spack/defaults/packages.yaml` (which we require for all virtuals)
- [x] rework `test_all_virtual_packages_have_default_providers` as a config audit called `_ensure_all_virtual_packages_have_default_providers`
- [x] add config audits to our pre-checks in CI