### PR TITLE
Install test root update: old to new API

### DIFF
--- a/var/spack/repos/builtin/packages/heffte/package.py
+++ b/var/spack/repos/builtin/packages/heffte/package.py
@@ -129,7 +129,7 @@ class Heffte(CMakePackage, CudaPackage, ROCmPackage):
         if self.spec.satisfies("@:2.2.0"):
             return
         install_tree(
-            self.prefix.share.heffte.testing, join_path(self.install_test_root, "testing")
+            self.prefix.share.heffte.testing, join_path(install_test_root(self), "testing")
         )
 
     def test_make_test(self):

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -392,7 +392,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
             cmake_source_path,
             "-DSPACK_PACKAGE_SOURCE_DIR:PATH={0}".format(self.stage.source_path),
             "-DSPACK_PACKAGE_TEST_ROOT_DIR:PATH={0}".format(
-                join_path(self.install_test_root, cmake_out_path)
+                join_path(install_test_root(self), cmake_out_path)
             ),
             "-DSPACK_PACKAGE_INSTALL_DIR:PATH={0}".format(self.prefix),
         ]

--- a/var/spack/repos/builtin/packages/py-chainer/package.py
+++ b/var/spack/repos/builtin/packages/py-chainer/package.py
@@ -59,7 +59,7 @@ class PyChainer(PythonPackage):
         if "+mn" not in self.spec:
             raise SkipTest("Test only supported when built with +mn")
 
-        mnist_file = join_path(self.install_test_root.examples.chainermn.mnist, "train_mnist.py")
+        mnist_file = join_path(install_test_root(self).examples.chainermn.mnist, "train_mnist.py")
         mpirun = which(self.spec["mpi"].prefix.bin.mpirun)
         opts = ["-n", "4", python.path, mnist_file, "-o", "."]
         env["OMP_NUM_THREADS"] = "4"

--- a/var/spack/repos/builtin/packages/tasmanian/package.py
+++ b/var/spack/repos/builtin/packages/tasmanian/package.py
@@ -122,7 +122,7 @@ class Tasmanian(CMakePackage, CudaPackage, ROCmPackage):
     @run_after("install")
     def setup_smoke_test(self):
         install_tree(
-            self.prefix.share.Tasmanian.testing, join_path(self.install_test_root, "testing")
+            self.prefix.share.Tasmanian.testing, join_path(install_test_root(self), "testing")
         )
 
     def test_make_test(self):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Replace depreciated test method of `self.install test root`. For the remaining packages that have it (gptune, mptensor, n2p2m,parsec,raja, and sundials), the removal of this depreciated method is addressed in their respective PR's to transition them to the new test API,=.