### PR TITLE
New command: spack cmake - Configure a CMake project using a Spack spec 

### DIFF
--- a/lib/spack/spack/cmd/cmake.py
+++ b/lib/spack/spack/cmd/cmake.py
@@ -1,0 +1,191 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+import llnl.util.tty as tty
+from llnl.util.tty.color import colorize
+
+import spack
+import spack.cmd
+from spack.cmd.common import arguments
+from spack.error import SpackError
+from spack.util.environment import EnvironmentModifications
+
+description = "configure CMake project in current working directory using a Spack spec"
+section = "developer"
+level = "long"
+
+# first assumption, we're in the source directory
+source_dir = os.getcwd()
+binary_dir = "build"
+
+while source_dir != "/" and not os.path.exists(os.path.join(source_dir, "CMakeLists.txt")):
+    # now assume we're in a build folder, try to find source_dir as parent
+    binary_dir = "."
+    source_dir = os.path.dirname(source_dir)
+
+
+def setup_parser(subparser):
+    subparser.usage = """spack cmake [-h] [-B BINARY_DIR] [-S SOURCE_DIR]
+                   [-c|--compiler-only] [-i|--inherit] [-t|--test] [-d|--dry-run]
+                   spec [-- CMAKE_OPTIONS]"""
+    subparser.add_argument("-B", "--binary_dir", default=binary_dir)
+    subparser.add_argument("-S", "--source_dir", default=source_dir)
+    subparser.add_argument("-t", "--test", action="store_true", help="Enable testing")
+    subparser.add_argument(
+        "-d", "--dry-run", action="store_true", help="Only generate command line"
+    )
+    subparser.add_argument(
+        "-c", "--compiler-only", action="store_true", help="Only generate CMake compiler options"
+    )
+    subparser.add_argument(
+        "-i", "--inherit", action="store_true", help="Inherit variants from Spack environment"
+    )
+    arguments.add_common_arguments(subparser, ["spec"])
+
+
+def cmake(parser, args, unparsed_args):
+    source_dir = os.path.abspath(args.source_dir)
+    binary_dir = os.path.abspath(args.binary_dir)
+
+    # check final source_dir location
+    if not os.path.exists(os.path.join(source_dir, "CMakeLists.txt")):
+        raise SpackError("Couldn't find source directory. Please specify with -S <path>!")
+
+    active_env = spack.environment.active_environment()
+
+    if args.inherit and not active_env:
+        raise SpackError("No active environment found to inherit from!")
+
+    specs = spack.cmd.parse_specs(args.spec)
+
+    if len(specs) > 1:
+        raise SpackError("spack cmake requires at most one named spec")
+
+    app_spec = specs[0]
+
+    print("Input spec")
+    print("--------------------------------")
+    print(app_spec.tree())
+
+    if active_env:
+
+        def unwrap(x, zero_msg, ambiguous_msg, zero=tty.die, ambiguous=tty.die):
+            if not x:
+                zero(zero_msg)
+            if len(x) > 1:
+                ambiguous(ambiguous_msg)
+            return next(iter(x))
+
+        if args.inherit:
+            app_spec = unwrap(
+                {r for _, r in active_env.concretized_specs() if r.satisfies(app_spec)},
+                "No compatible spec in environment",
+                "Choice of compatible spec is ambiguous",
+            )
+            tty.info(f"Reusing environment spec for {app_spec.name}\n")
+            print("Concretized")
+            print("--------------------------------")
+            print(app_spec.tree())
+        else:
+            roots = {r for _, r in active_env.concretized_specs() if r.satisfies(app_spec.name)}
+            compilers = {r.compiler for r in roots}
+
+            if app_spec.compiler:
+                if not any(c.satisfies(app_spec.compiler) for c in compilers):
+                    tty.warn(
+                        "Compilers used in environment not compatible with spec!",
+                        f"environment: {' '.join([str(c) for c in compilers])}",
+                        f"spec:        {app_spec.compiler}\n",
+                    )
+            else:
+                app_spec.compiler = unwrap(
+                    compilers,
+                    "No compatible environment compiler available",
+                    "Choice of environment compiler is ambiguous",
+                )
+
+            app_spec.concretize()
+            print("Concretized")
+            print("--------------------------------")
+            print(app_spec.tree())
+
+            for dep in app_spec.dependencies():
+                if not any(dep.name in r for r in roots):
+                    tty.warn(
+                        f"Missing dependency {dep.name} in environment!\n  {dep.short_spec}\n"
+                    )
+                else:
+                    selected = unwrap(
+                        {r[dep.name] for r in roots if dep.name in r},
+                        f"Missing dependency {dep.name} in environment!\n  {dep.short_spec}\n",
+                        f"Dependency {dep.name} is ambiguous in environment!\n",
+                        zero=tty.warn,
+                        ambiguous=tty.warn,
+                    )
+                    if not selected.satisfies(dep):
+                        tty.warn(
+                            f"{dep.name} in environment not compatible with provided spec!",
+                            f"environment: {selected.cshort_spec}",
+                            f"spec:        {dep.cshort_spec}\n",
+                        )
+    else:
+        app_spec.concretize()
+        print("Concretized")
+        print("--------------------------------")
+        print(app_spec.tree())
+
+    app = app_spec.package
+    app.run_tests = args.test
+
+    if app_spec.satisfies("^hip"):
+        # Needed, so hipcc is set
+        app_spec["hip"].package.setup_dependent_package(None, None)
+
+    # TODO add Fortran, CUDA, HIP compilers
+    compiler = spack.compilers.compiler_for_spec(app_spec.compiler, app_spec.architecture)
+    compiler_args = [f"-DCMAKE_CXX_COMPILER={compiler.cxx}", f"-DCMAKE_C_COMPILER={compiler.cc}"]
+
+    if app_spec.satisfies("^kokkos"):
+        # Needed so kokkos_cxx is set (e.g. to nvcc_wrapper) and can be used in cmake_args()
+        app_spec["kokkos"].package.module.spack_cxx = compiler.cxx
+        if app_spec.satisfies("^kokkos-nvcc-wrapper"):
+            env = EnvironmentModifications()
+            app_spec["kokkos-nvcc-wrapper"].package.setup_dependent_build_environment(
+                env, app_spec
+            )
+            app_spec["kokkos-nvcc-wrapper"].package.setup_dependent_package(None, None)
+            env.apply_modifications()
+        app_spec["kokkos"].package.setup_dependent_package(None, None)
+
+    dir_args = ["-B", binary_dir, "-S", source_dir]
+
+    accepted_std_args = (
+        "-G",
+        "Unix Makefiles",
+        "Ninja",
+        "CMAKE_BUILD_TYPE",
+        "CMAKE_INTERPROCEDURAL_OPTIMIZATION",
+    )
+    std_args = (
+        []
+        if args.compiler_only
+        else [x for x in app.builder.std_cmake_args if any(n in x for n in accepted_std_args)]
+    )
+
+    app_args = app.cmake_args()
+    if args.compiler_only:
+        app_args = [
+            x for x in app_args if any(n in x for n in ("CMAKE_CXX_COMPILER", "CMAKE_C_COMPILER"))
+        ]
+
+    cmake_args = std_args + compiler_args + app_args + unparsed_args + dir_args
+
+    cmake = os.path.join(app_spec["cmake"].prefix, "bin", "cmake")
+    cmd = " ".join([cmake] + cmake_args)
+    tty.msg(f"CMake Command: {colorize(f'@c{{{cmd}}}')}")
+    if not args.dry_run:
+        os.execl(cmake, cmake, *cmake_args)

--- a/lib/spack/spack/cmd/cmake.py
+++ b/lib/spack/spack/cmd/cmake.py
@@ -10,6 +10,7 @@ from llnl.util.tty.color import colorize
 
 import spack
 import spack.cmd
+import spack.builder
 from spack.cmd.common import arguments
 from spack.error import SpackError
 from spack.util.environment import EnvironmentModifications
@@ -173,7 +174,7 @@ def cmake(parser, args, unparsed_args):
     std_args = (
         []
         if args.compiler_only
-        else [x for x in app.builder.std_cmake_args if any(n in x for n in accepted_std_args)]
+        else [x for x in spack.builder.create(app).std_cmake_args if any(n in x for n in accepted_std_args)]
     )
 
     app_args = app.cmake_args()

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -582,10 +582,34 @@ def allows_unknown_args(command):
     return argcount == 3 and varnames[2] == "unknown_args"
 
 
-def _invoke_command(command, parser, args, unknown_args):
+def allows_unparsed_args(command):
+    """Implements really simple argument injection for unparsed arguments.
+
+    Commands may add an optional argument called "unparsed args" to
+    indicate they can handle unparsed args after --, and we'll pass the unparsed
+    args in.
+    """
+    info = dict(inspect.getmembers(command))
+    varnames = info["__code__"].co_varnames
+    argcount = info["__code__"].co_argcount
+    return argcount == 3 and varnames[2] == "unparsed_args"
+
+
+def _filter_unparsed(command, argv):
+    unparsed = []
+    if allows_unparsed_args(command) and "--" in argv:
+        divider = argv.index("--")
+        unparsed = argv[divider + 1 :]
+        argv = argv[0:divider]
+    return argv, unparsed
+
+
+def _invoke_command(command, parser, args, unknown_args, unparsed_args):
     """Run a spack command *without* setting spack global options."""
     if allows_unknown_args(command):
         return_val = command(parser, args, unknown_args)
+    elif allows_unparsed_args(command):
+        return_val = command(parser, args, unparsed_args)
     else:
         if unknown_args:
             tty.die("unrecognized arguments: %s" % " ".join(unknown_args))
@@ -655,6 +679,7 @@ class SpackCommand:
             out = out.decode()
         else:
             command = self.parser.add_command(self.command_name)
+            argv, unparsed = _filter_unparsed(command, argv)
             args, unknown = self.parser.parse_known_args(
                 prepend + [self.command_name] + list(argv)
             )
@@ -662,7 +687,9 @@ class SpackCommand:
             out = io.StringIO()
             try:
                 with log_output(out, echo=True):
-                    self.returncode = _invoke_command(command, self.parser, args, unknown)
+                    self.returncode = _invoke_command(
+                        command, self.parser, args, unknown, unparsed
+                    )
 
             except SystemExit as e:
                 self.returncode = e.code
@@ -692,7 +719,7 @@ class SpackCommand:
                     tty.verbose(fmt.format(ln.replace("==> ", "")))
 
 
-def _profile_wrapper(command, parser, args, unknown_args):
+def _profile_wrapper(command, parser, args, unknown_args, unparsed_args):
     import cProfile
 
     try:
@@ -714,7 +741,7 @@ def _profile_wrapper(command, parser, args, unknown_args):
         # make a profiler and run the code.
         pr = cProfile.Profile()
         pr.enable()
-        return _invoke_command(command, parser, args, unknown_args)
+        return _invoke_command(command, parser, args, unknown_args, unparsed_args)
 
     finally:
         pr.disable()
@@ -970,7 +997,8 @@ def finish_parse_and_run(parser, cmd_name, main_args, env_format_error):
     """Finish parsing after we know the command to run."""
     # add the found command to the parser and re-run then re-parse
     command = parser.add_command(cmd_name)
-    args, unknown = parser.parse_known_args(main_args.command)
+    argv, unparsed = _filter_unparsed(command, main_args.command)
+    args, unknown = parser.parse_known_args(argv)
     # we need to inherit verbose since the install command checks for it
     args.verbose = main_args.verbose
 
@@ -986,14 +1014,16 @@ def finish_parse_and_run(parser, cmd_name, main_args, env_format_error):
 
     # now we can actually execute the command.
     if main_args.spack_profile or main_args.sorted_profile:
-        _profile_wrapper(command, parser, args, unknown)
+        _profile_wrapper(command, parser, args, unknown, unparsed)
     elif main_args.pdb:
         import pdb
 
-        pdb.runctx("_invoke_command(command, parser, args, unknown)", globals(), locals())
+        pdb.runctx(
+            "_invoke_command(command, parser, args, unknown, unparsed)", globals(), locals()
+        )
         return 0
     else:
-        return _invoke_command(command, parser, args, unknown)
+        return _invoke_command(command, parser, args, unknown, unparsed)
 
 
 def main(argv=None):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -401,7 +401,7 @@ _spack() {
     then
         SPACK_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -b --bootstrap -p --profile --sorted-profile --lines -v --verbose --stacktrace -t --backtrace -V --version --print-shell-vars"
     else
-        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean clone commands compiler compilers concretize concretise config containerize containerise create debug deconcretize dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse logs maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
+        SPACK_COMPREPLY="add arch audit blame bootstrap build-env buildcache cd change checksum ci clean clone cmake commands compiler compilers concretize concretise config containerize containerise create debug deconcretize dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse logs maintainers make-installer mark mirror module patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi
 }
 
@@ -728,6 +728,15 @@ _spack_clone() {
         SPACK_COMPREPLY="-h --help -r --remote"
     else
         SPACK_COMPREPLY=""
+    fi
+}
+
+_spack_cmake() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -B --binary_dir -S --source_dir -t --test -d --dry-run -c --compiler-only -i --inherit"
+    else
+        _all_packages
     fi
 }
 

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -361,6 +361,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a checksum -d 'chec
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a ci -d 'manage continuous integration pipelines'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a clean -d 'remove temporary build files and/or downloaded archives'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a clone -d 'create a new installation of spack in another prefix'
+complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a cmake -d 'configure CMake project in current working directory using a Spack spec'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a commands -d 'list available spack commands'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a compiler -d 'manage compilers'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a compilers -d 'list available compilers'
@@ -1030,6 +1031,22 @@ complete -c spack -n '__fish_spack_using_command clone' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command clone' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command clone' -s r -l remote -r -f -a remote
 complete -c spack -n '__fish_spack_using_command clone' -s r -l remote -r -d 'name of the remote to clone from'
+
+# spack cmake
+set -g __fish_spack_optspecs_spack_cmake h/help B/binary_dir= S/source_dir= t/test d/dry-run c/compiler-only i/inherit
+complete -c spack -n '__fish_spack_using_command_pos_remainder 0 cmake' -f -k -a '(__fish_spack_specs)'
+complete -c spack -n '__fish_spack_using_command cmake' -s h -l help -f -a help
+complete -c spack -n '__fish_spack_using_command cmake' -s h -l help -d 'show this help message and exit'
+complete -c spack -n '__fish_spack_using_command cmake' -s B -l binary_dir -r -f -a binary_dir
+complete -c spack -n '__fish_spack_using_command cmake' -s S -l source_dir -r -f -a source_dir
+complete -c spack -n '__fish_spack_using_command cmake' -s t -l test -f -a test
+complete -c spack -n '__fish_spack_using_command cmake' -s t -l test -d 'Enable testing'
+complete -c spack -n '__fish_spack_using_command cmake' -s d -l dry-run -f -a dry_run
+complete -c spack -n '__fish_spack_using_command cmake' -s d -l dry-run -d 'Only generate command line'
+complete -c spack -n '__fish_spack_using_command cmake' -s c -l compiler-only -f -a compiler_only
+complete -c spack -n '__fish_spack_using_command cmake' -s c -l compiler-only -d 'Only generate CMake compiler options'
+complete -c spack -n '__fish_spack_using_command cmake' -s i -l inherit -f -a inherit
+complete -c spack -n '__fish_spack_using_command cmake' -s i -l inherit -d 'Inherit variants from Spack environment'
 
 # spack commands
 set -g __fish_spack_optspecs_spack_commands h/help update-completion a/aliases format= header= update=


### PR DESCRIPTION
@tgamblin Here is my attempt to upstream the tool I mentioned in Slack. I've modified it a bit to be more like a regular Spack command, reworked some of the output, added a `--dry-run` option, and stripped some project specific features. The code can likely still be generalized a bit more. Right now, it is very specific to C/C++-based projects that use Kokkos for HIP and CUDA. Below is a bit of motivating text, part of which might end up in the final documentation.

Let me know what you think and how it could be improved to better fit into Spack.

---

This command was built out of a need to simplify developer's workflows while working on codes that also provide Spack packages. The original  [`spack_cmake`](https://github.com/flecsi/flecsi/blob/2.3/tools/spack_cmake) tool was written for the development and CI testing of FleCSI.

We recognized that many complicated use cases and the corresponding CMake command-lines were already
encoded in the Spack package for a given code, and we needed a way to extract that useful logic in a pure CMake-based workflow and avoid duplication.

This new command is closely related to `spack develop` and `spack dev-build`. However, unlike these two existing commands the goal of `spack cmake` is not to build and install the package within Spack, but allow it to be configured and built outside of the Spack build environment and within the same shell (no sub-shells). This is particularly useful in non-interactive CI pipelines. It assumes package dependencies are already visible either by an active environment view, via `spack load`, or modules.

Its primary purpose is to reuse the logic in the Spack package of a given project and generate an equivalent CMake command-line out of a given root spec. Instead of using Spack compiler wrappers, it will inject the compiler's full paths
via the `CMAKE_<LANG>_COMPILER` options.

While the Spack build environment and the Spack compiler wrappers do a lot of heavy-lifting, such as injecting compiler and linker flags, `spack cmake` so far does not attempt to provide feature-parity and focuses on a small subset that has been found useful.

In addition to the generated options that serve as defaults, the command allows to append additional CMake options to the command-line. Options passed after a double-dash (`--`) are directly passed along. (For this the Spack `main.py` needed to be changed to allow this kind of unparsed command-line options)

If `spack cmake` is run in an activated environment, the input spec is compared to that environment and any incompatible differences in its dependency tree are reported as warnings. If no compiler was specified, the spec defaults to using the same compiler as the root spec in that environment. With the `-i/--inherit` option the first compatible concretized root of the environment is selected, otherwise a fresh concretization happens.

By default, this command works out-of-the box if you run it from within the source directory of a CMake project or from a build directory that is a child of the source directory.

 - When launched from the source directory, it will create a `build` folder and configure it.

 - When launched from any other build directory that is a child of the source directory, it will use that build directory and locate the source folder.

 - For any other launch location, the current directory is assumed to be the build directory, unless it is overridden using the `-B <path>` option, and you  must specify the source directory with `-S <path>`

The command will execute the CMake command-line, unless the `-d,--dry-run` flag is set.

Some packages have special logic for testing that depends on the package variable `run_tests`.  The `-t/--test` option sets `run_tests` to `True`.

Finally, the `-c/--compiler-only` option allows to suppress project-specific CMake options. It will only include the selection of the compiler, compiler flags, and user specified options. This is useful for building dependent projects that require the same compiler settings as a given spec (some of which might have been manipulated by the `cmake_args` logic in a Spack spackage).

## Examples:

### Inherit root spec from environment to generate CMake command-line
```bash
spack env create myenv
spack env activate myenv
spack add flecsi%gcc+flog
spack install --only dependencies

spack cmake -i -t flecsi
# inherit flecsi spec from environment, enable testing
```

### Reuse existing environment with different options

```bash
spack cmake flecsi~flog build_type=Debug
# new concretization without flog and Debug as build type. In this case the dependency tree is the
# same, so the existing environment can be reused for this CMake build
```

### Pass additional CMake options

```bash
spack cmake -i flecsi -- -DCMAKE_INSTALL_PREFIX=$PWD/test-install
# reuse environment spec for flecsi and append CMake options
```

### Use same compiler settings as a given root

```bash
spack cmake -i -c flecsi+rocm
# useful in the case a standalone application needs to use the same compiler as the library,
# but doesn't need the library specific CMake options.
```