### PR TITLE
acts: Add a dependency on dfelibs

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -337,6 +337,7 @@ class Acts(CMakePackage, CudaPackage):
     depends_on("dd4hep @1.11: +dddetectors +ddrec", when="+dd4hep")
     depends_on("dd4hep @1.21: +dddetectors +ddrec", when="@20: +dd4hep")
     depends_on("dd4hep +ddg4", when="+dd4hep +geant4 +examples")
+    depends_on("dfelibs", when="@35:")
     depends_on("edm4hep @0.4.1:", when="+edm4hep")
     depends_on("edm4hep @0.7:", when="@25: +edm4hep")
     depends_on("eigen @3.3.7:", when="@15.1:")


### PR DESCRIPTION
After version 35.1.0 this dependency is there by default, see https://github.com/acts-project/acts/blob/9dfb47b8edeb8b9c75115462079bcb003dd3f031/CMakeLists.txt#L58. It's only used in the examples so we could restrict it to that but since it's a small dependency and it may be used in the future outside of the examples now that is ON by default we may want to keep it as a dependency.