### PR TITLE
libxcb: Set well-known locale for build

### DIFF
--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -69,6 +69,4 @@ class Libxcb(AutotoolsPackage, XorgPackage):
     # then we can limit the following function, e.g.
     # when("@:1.17")
     def setup_build_environment(self, env):
-        env.set(
-            "LC_ALL", "C.UTF-8"
-        )
+        env.set("LC_ALL", "C.UTF-8")

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -60,3 +60,6 @@ class Libxcb(AutotoolsPackage, XorgPackage):
 
     def patch(self):
         filter_file("typedef struct xcb_auth_info_t {", "typedef struct {", "src/xcb.h")
+
+    def setup_build_environment(self, env):
+        env.set('LC_ALL', 'en_US.UTF-8')    # set well defined locale; see: https://www.linuxfromscratch.org/blfs/view/git/x/libxcb.html

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -61,7 +61,14 @@ class Libxcb(AutotoolsPackage, XorgPackage):
     def patch(self):
         filter_file("typedef struct xcb_auth_info_t {", "typedef struct {", "src/xcb.h")
 
+    # libxcb fails to build with non-UTF-8 locales, see:
+    # https://www.linuxfromscratch.org/blfs/view/git/x/libxcb.html
+    # https://gitlab.freedesktop.org/xorg/lib/libxcb/-/merge_requests/53 (merged in 1.17.0)
+    # https://gitlab.freedesktop.org/xorg/lib/libxcb/-/merge_requests/60
+    # If a newer release can be verified to build with LC_ALL=en_US.ISO-8859-1,
+    # then we can limit the following function, e.g.
+    # when("@:1.17")
     def setup_build_environment(self, env):
         env.set(
             "LC_ALL", "C.UTF-8"
-        )  # set well defined locale; see: https://www.linuxfromscratch.org/blfs/view/git/x/libxcb.html
+        )

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -64,4 +64,4 @@ class Libxcb(AutotoolsPackage, XorgPackage):
     def setup_build_environment(self, env):
         env.set(
             "LC_ALL", "C.UTF-8"
-        )    # set well defined locale; see: https://www.linuxfromscratch.org/blfs/view/git/x/libxcb.html
+        )  # set well defined locale; see: https://www.linuxfromscratch.org/blfs/view/git/x/libxcb.html

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -63,5 +63,5 @@ class Libxcb(AutotoolsPackage, XorgPackage):
 
     def setup_build_environment(self, env):
         env.set(
-            "LC_ALL", "en_US.UTF-8"
+            "LC_ALL", "C.UTF-8"
         )    # set well defined locale; see: https://www.linuxfromscratch.org/blfs/view/git/x/libxcb.html

--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -62,4 +62,6 @@ class Libxcb(AutotoolsPackage, XorgPackage):
         filter_file("typedef struct xcb_auth_info_t {", "typedef struct {", "src/xcb.h")
 
     def setup_build_environment(self, env):
-        env.set('LC_ALL', 'en_US.UTF-8')    # set well defined locale; see: https://www.linuxfromscratch.org/blfs/view/git/x/libxcb.html
+        env.set(
+            "LC_ALL", "en_US.UTF-8"
+        )    # set well defined locale; see: https://www.linuxfromscratch.org/blfs/view/git/x/libxcb.html


### PR DESCRIPTION
Builds might fail if no valid locale is set. See https://www.linuxfromscratch.org/blfs/view/git/x/libxcb.html

Following the suggestion in the link above, this patch sets a well-known locale which should be available on most systems. 

