### PR TITLE
py-markupsafe: Recent versions require Python >=3.7

### DIFF
--- a/var/spack/repos/builtin/packages/py-markupsafe/package.py
+++ b/var/spack/repos/builtin/packages/py-markupsafe/package.py
@@ -32,3 +32,4 @@ class PyMarkupsafe(PythonPackage):
     depends_on("c", type="build")  # generated
 
     depends_on("py-setuptools", type="build")
+    depends_on("python@3.7:", when="@2.0:")


### PR DESCRIPTION
As per PyPI, recent versions of py-markupsafe (>=2) require Python >=3.7.

