### PR TITLE
[likely obsoleted by v1.17-cp2k] libxsmm: add main-2024-07

### DIFF
--- a/var/spack/repos/builtin/packages/libxsmm/package.py
+++ b/var/spack/repos/builtin/packages/libxsmm/package.py
@@ -26,7 +26,7 @@ class Libxsmm(MakefilePackage):
     # as a stable version that supports other targets than x86. Remove this
     # after 2.0 release.
     version("main-2023-11", commit="0d9be905527ba575c14ca5d3b4c9673916c868b2")
-    version("main-2024-07", commit="92b08d68724e9a2653056acb5a3c6667ecaeaea1") # CP2K
+    version("main-2024-07", commit="92b08d68724e9a2653056acb5a3c6667ecaeaea1")  # CP2K
     version("main", branch="main")
 
     version("1.17", sha256="8b642127880e92e8a75400125307724635ecdf4020ca4481e5efe7640451bb92")

--- a/var/spack/repos/builtin/packages/libxsmm/package.py
+++ b/var/spack/repos/builtin/packages/libxsmm/package.py
@@ -26,6 +26,7 @@ class Libxsmm(MakefilePackage):
     # as a stable version that supports other targets than x86. Remove this
     # after 2.0 release.
     version("main-2023-11", commit="0d9be905527ba575c14ca5d3b4c9673916c868b2")
+    version("main-2024-07", commit="92b08d68724e9a2653056acb5a3c6667ecaeaea1") # CP2K
     version("main", branch="main")
 
     version("1.17", sha256="8b642127880e92e8a75400125307724635ecdf4020ca4481e5efe7640451bb92")


### PR DESCRIPTION
Update by @bernhardkaindl: I think this is obsolete now wit this PR merged:
- #42312

----
Add another version tag to main that support non-x86 architectures (see https://github.com/spack/spack/pull/41193).

The commit hash is the same used in CP2K (see https://github.com/cp2k/cp2k/pull/3577), since it has full functionality for ARM64 with respect to CP2K's needs.

Successfully tested on macOS 14.5:
```
spack install libxsmm@main-2024-07
```