### PR TITLE
xrootd: add mirror to avoid ssl issues on primary url

### DIFF
--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -12,7 +12,10 @@ class Xrootd(CMakePackage):
     tolerant access to data repositories of many kinds."""
 
     homepage = "https://xrootd.slac.stanford.edu"
-    url = "https://xrootd.slac.stanford.edu/download/v5.5.1/xrootd-5.5.1.tar.gz"
+    urls = [
+        "https://xrootd.slac.stanford.edu/download/v5.7.0/xrootd-5.7.0.tar.gz",
+        "https://github.com/xrootd/xrootd/releases/download/v5.7.0/xrootd-5.7.0.tar.gz",
+    ]
     list_url = "https://xrootd.slac.stanford.edu/dload.html"
     git = "https://github.com/xrootd/xrootd.git"
 


### PR DESCRIPTION
This PR adds the GitHub mirror to the spack packages to get past the [certificate issues](https://gitlab.spack.io/spack/spack/-/jobs/12005876#L187) on the primary download location.

Per https://github.com/xrootd/xrootd/issues/2295#issuecomment-2257882306 the tarballs on github.com are identical. Once the fetchers start accepting the certificates on xrootd.slac.stanford.edu again, downloads should happen against that location again, since it is listed as primary location in the url list.

Note that the versions 5.5.1 and older will still not be able to be installed with this PR since they are not on github.com.