### PR TITLE
Add full_hostname host variable

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -893,8 +893,9 @@ The valid variables for a ``when`` clause are:
 
 #. ``env``. The user environment (usually ``os.environ`` in Python).
 
-#. ``hostname``. The hostname of the system (if ``hostname`` is an
-   executable in the user's PATH).
+#. ``hostname``. The hostname of the system.
+
+#. ``full_hostname``. The fully qualified hostname of the system.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^
 SpecLists as Constraints

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4887,6 +4887,7 @@ def get_host_environment() -> Dict[str, Any]:
         "architecture": arch_spec,
         "arch_str": str(arch_spec),
         "hostname": socket.gethostname(),
+        "full_hostname": socket.getfqdn(),
     }
 
 


### PR DESCRIPTION
Makes the fully qualified hostname available as `full_hostname` variable  in `when: ` conditions.

This allows you to test against the site's domain name, rather than just the hostname.

This change also adds `full_hostname` field in the `install_environment.json` file.
