### PR TITLE
libxcb: xcb-proto is a build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/libxcb/package.py
+++ b/var/spack/repos/builtin/packages/libxcb/package.py
@@ -38,12 +38,12 @@ class Libxcb(AutotoolsPackage, XorgPackage):
     depends_on("libxdmcp")
 
     # libxcb 1.X requires xcb-proto >= 1.X
-    depends_on("xcb-proto")
-    depends_on("xcb-proto@1.17:", when="@1.17")
-    depends_on("xcb-proto@1.16:", when="@1.16")
-    depends_on("xcb-proto@1.15:", when="@1.15")
-    depends_on("xcb-proto@1.14:", when="@1.14")
-    depends_on("xcb-proto@1.13:", when="@1.13")
+    depends_on("xcb-proto", type="build")
+    depends_on("xcb-proto@1.17:", when="@1.17", type="build")
+    depends_on("xcb-proto@1.16:", when="@1.16", type="build")
+    depends_on("xcb-proto@1.15:", when="@1.15", type="build")
+    depends_on("xcb-proto@1.14:", when="@1.14", type="build")
+    depends_on("xcb-proto@1.13:", when="@1.13", type="build")
 
     depends_on("python", type="build")
     depends_on("pkgconfig", type="build")


### PR DESCRIPTION
related to #44289 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
