### PR TITLE
Concretize for vcvars

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -29,9 +29,8 @@ import spack.platforms
 import spack.spec
 import spack.version
 from spack.util.environment import get_path
-from spack.util.naming import mod_to_class
 from spack.util.executable import which_string
-
+from spack.util.naming import mod_to_class
 
 IS_WINDOWS = sys.platform == "win32"
 
@@ -371,7 +370,9 @@ def compiler_from_vcenv() -> Union[spack.compiler.CompilerSpec, None]:
     if not active_compiler:
         return
     active_compiler_dir = os.path.dirname(active_compiler)
-    args = arguments_to_detect_version_fn(spack.operating_systems.WindowsOs(), [active_compiler_dir])
+    args = arguments_to_detect_version_fn(
+        spack.operating_systems.WindowsOs(), [active_compiler_dir]
+    )
     detected_compilers = detect_version(args)
     return make_compiler_list(detected_compilers)[0]
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -12,7 +12,7 @@ import multiprocessing.pool
 import os
 import sys
 import warnings
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple
 
 import archspec.cpu
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -360,7 +360,7 @@ def _is_active_vcvars_session(env=None) -> bool:
     return bool(env.get("VisualStudioVersion", False))
 
 
-def compiler_from_vcenv() -> Union[spack.compiler.CompilerSpec, None]:
+def compiler_from_vcenv():
     # not intended to function on non Windows platforms
     # or if there's no active VCVars, not worth considering
     if not IS_WINDOWS or not _is_active_vcvars_session():

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2989,7 +2989,14 @@ class CompilerParser:
 
     def __init__(self, configuration) -> None:
         self.compilers: Set[KnownCompiler] = set()
-        for c in all_compilers_in_config(configuration):
+        # If we're on Windows, first check for a compiler in an
+        # active vcvars environment
+        candidate_compilers = all_compilers_in_config(configuration)
+        if sys.platform == "win32":
+            vc_comp = spack.compilers.compiler_from_vcenv()
+            if vc_comp:
+                candidate_compilers = [vc_comp]
+        for c in candidate_compilers:
             if using_libc_compatibility() and not c_compiler_runs(c):
                 tty.debug(
                     f"the C compiler {c.cc} does not exist, or does not run correctly."


### PR DESCRIPTION
On Windows a compiler is selected and environment established via the VCVARS script, which is responsible for populating the environment with relevant vars and making the compiler accesible

Spack typically does this behind the scenes, for a user, when a given compiler is selected for the concretizer. However, vcvars envs do not play well together, to the point where invoking a vcvars script, from inside another vcvars context (even if they're the same version) leads to undefined behavior. Particularly if the vcvars is for different compilers, this can result in complex build errors and the inability to use the Spack compiler

If a user is invoking Spack from inside a vcvars environment, we should respect that, and concretize to that compiler.


TODO:
- [ ]  Update compiler detection logic to find only vcvars compilers
- [ ]  Ensure envs and commands like `spack load` respect this


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
