### PR TITLE
CMake: Add guards against detecting system packages

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -410,7 +410,7 @@ class CMakeBuilder(BaseBuilder):
                 define("CMAKE_FIND_USE_PACKAGE_ROOT_PATH", False),
                 define("CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY", False),
                 define("CMAKE_FIND_USE_PACKAGE_REGISTRY", False),
-                define("CMAKE_FIND_USE_SYSTEM_PATH", False)
+                define("CMAKE_FIND_USE_SYSTEM_PATH", False),
             ]
         )
 

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -406,10 +406,27 @@ class CMakeBuilder(BaseBuilder):
 
         args.extend(
             [
+                # CMake bundles a number of find modules with
+                # its distribution. During package search these
+                # find modules are prefered in the search order.
+                # Spack based installations of CMake pacakges
+                # export their interface in the form of config modules
+                # by default these are secondary to the find modules
+                # Ensure CMake prefers Spack derived modules always
+                # by prefering config modules
                 define("CMAKE_FIND_PACKAGE_PREFER_CONFIG", True),
+                # By default Spack searches given system locations
+                # for package roots, this can bring in non Spack derived, non
+                # externally modeled packages, prevent this by setting this to false
                 define("CMAKE_FIND_USE_PACKAGE_ROOT_PATH", False),
+                # Similar to above, the system package registry can bring in undeterminable
+                # non-spack packages, so we should prevent its use
                 define("CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY", False),
+                # Spack in general does not leverage or require the use of the Package registry
                 define("CMAKE_FIND_USE_PACKAGE_REGISTRY", False),
+                # By default Spack searches some system paths for packages and libraries
+                # disabling that default behavior insulates builds from system libraries
+                # pulled in by CMake unexpectedly
                 define("CMAKE_FIND_USE_SYSTEM_PATH", False),
             ]
         )

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -402,6 +402,18 @@ class CMakeBuilder(BaseBuilder):
         _conditional_cmake_defaults(pkg, args)
         _maybe_set_python_hints(pkg, args)
 
+        # Establish some CMake based sandboxing from the user env
+
+        args.extend(
+            [
+                define("CMAKE_FIND_PACKAGE_PREFER_CONFIG", True),
+                define("CMAKE_FIND_USE_PACKAGE_ROOT_PATH", False),
+                define("CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY", False),
+                define("CMAKE_FIND_USE_PACKAGE_REGISTRY", False),
+                define("CMAKE_FIND_USE_SYSTEM_PATH", False)
+            ]
+        )
+
         return args
 
     @staticmethod

--- a/var/spack/repos/builtin/packages/c-blosc/package.py
+++ b/var/spack/repos/builtin/packages/c-blosc/package.py
@@ -44,6 +44,12 @@ class CBlosc(CMakePackage):
     depends_on("zstd")
     depends_on("lz4")
 
+    # enables c-blosc to properly engage lz4's config module
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/Blosc/c-blosc/pull/386.patch",
+        sha256="5ed8a9187f86e741d539283ad7402ac5985dba6ab7ef757ee4368b42f1eacad3",
+        when="@1.21.2:",
+    )
     patch("gcc.patch", when="@1.12.1:1.17.0")
     patch("test_forksafe.patch", when="@1.15.0:1.17.0%intel")
 

--- a/var/spack/repos/builtin/packages/c-blosc/package.py
+++ b/var/spack/repos/builtin/packages/c-blosc/package.py
@@ -46,8 +46,8 @@ class CBlosc(CMakePackage):
 
     # enables c-blosc to properly engage lz4's config module
     patch(
-        "https://patch-diff.githubusercontent.com/raw/Blosc/c-blosc/pull/386.patch",
-        sha256="ef340ca029ef08729a14789e04bd7f26adf1438ddafbd92beb3c1197b7bd2e1f",
+        "https://patch-diff.githubusercontent.com/raw/Blosc/c-blosc/pull/386.patch?full_index=1",
+        sha256="fe26e1f13eaa526f5eb2c80ea3c69986a026189d278c66391112169b5b74c05a",
         when="@1.21.2:",
     )
     patch("gcc.patch", when="@1.12.1:1.17.0")

--- a/var/spack/repos/builtin/packages/c-blosc/package.py
+++ b/var/spack/repos/builtin/packages/c-blosc/package.py
@@ -47,7 +47,7 @@ class CBlosc(CMakePackage):
     # enables c-blosc to properly engage lz4's config module
     patch(
         "https://patch-diff.githubusercontent.com/raw/Blosc/c-blosc/pull/386.patch",
-        sha256="5ed8a9187f86e741d539283ad7402ac5985dba6ab7ef757ee4368b42f1eacad3",
+        sha256="ef340ca029ef08729a14789e04bd7f26adf1438ddafbd92beb3c1197b7bd2e1f",
         when="@1.21.2:",
     )
     patch("gcc.patch", when="@1.12.1:1.17.0")

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -414,8 +414,6 @@ class Cmake(Package):
         env.set(f"{dependent_spec.name.upper()}_DIR", dependent_spec.prefix)
         env.set(f"{dependent_spec.name.upper()}_ROOT", dependent_spec.prefix)
 
-
-
     @property
     def libs(self):
         """CMake has no libraries, so if you ask for `spec['cmake'].libs`

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -411,8 +411,8 @@ class Cmake(Package):
             env.unset("CMAKE_FRAMEWORK_PATH")
         # prevent detection of external copies of our dependent
         # package from being detected
-        env.unset(f"{dependent_spec.name.upper()}_DIR")
-        env.unset(f"{dependent_spec.name.upper()}_ROOT")
+        env.set(f"{dependent_spec.name.upper()}_DIR", dependent_spec.prefix)
+        env.set(f"{dependent_spec.name.upper()}_ROOT", dependent_spec.prefix)
 
 
 

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -401,6 +401,21 @@ class Cmake(Package):
         module.cmake = Executable(self.spec.prefix.bin.cmake)
         module.ctest = Executable(self.spec.prefix.bin.ctest)
 
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        """Ensure certain environment variables are unset to prevent
+        CMake from bringing in unwanted system pollution"""
+        # Prevent env set appbundles from being detected
+        env.unset("CMAKE_APPBUNDLE_PATH")
+        if dependent_spec.satisfies("platform=darwin"):
+            # Prevent env set frameworks from being detected
+            env.unset("CMAKE_FRAMEWORK_PATH")
+        # prevent detection of external copies of our dependent
+        # package from being detected
+        env.unset(f"{dependent_spec.name.upper()}_DIR")
+        env.unset(f"{dependent_spec.name.upper()}_ROOT")
+
+
+
     @property
     def libs(self):
         """CMake has no libraries, so if you ask for `spec['cmake'].libs`

--- a/var/spack/repos/builtin/packages/lz4/package.py
+++ b/var/spack/repos/builtin/packages/lz4/package.py
@@ -54,8 +54,8 @@ class Lz4(CMakePackage, MakefilePackage):
     # Patches issue where Lz4's CMake interface was failing to export
     # include useage requirements properly
     patch(
-        "https://github.com/lz4/lz4/commit/38cc73c9c70a4954571a5faaedc9b87302a0ab9f.patch",
-        sha256="331ed53b57b825a40a1b60ea820e682c9218413b26c021f91c118c9134472040",
+        "https://github.com/lz4/lz4/commit/38cc73c9c70a4954571a5faaedc9b87302a0ab9f.patch?full_index=1",
+        sha256="afbca100e5c4fcd2759f8c463e59b6c5a29742461b7e0f9e7ebd2d7606b8528b",
         when="@1.9.3:1.10",
     )
 

--- a/var/spack/repos/builtin/packages/lz4/package.py
+++ b/var/spack/repos/builtin/packages/lz4/package.py
@@ -51,6 +51,14 @@ class Lz4(CMakePackage, MakefilePackage):
     )
     variant("pic", default=True, description="Enable position-independent code (PIC)")
 
+    # Patches issue where Lz4's CMake interface was failing to export
+    # include useage requirements properly
+    patch(
+        "https://github.com/lz4/lz4/commit/38cc73c9c70a4954571a5faaedc9b87302a0ab9f.patch",
+        sha256="331ed53b57b825a40a1b60ea820e682c9218413b26c021f91c118c9134472040",
+        when="@1.9.3:1.10",
+    )
+
     def url_for_version(self, version):
         url = "https://github.com/lz4/lz4/archive"
 


### PR DESCRIPTION
**Work in Progress, non draft for Gitlab testing purposes**

CMake has a powerful package detection framework via `find_package`. Numerous Spack packages take advantage of this, and Spack itself of course leverages the `CMAKE_PRFEFIX_PATH` to populate that variable with packages in a given DAG so CMake can detect them. However, CMake is almost too good at finding packages available on the system, which is bad for Spack, as it allows for the subtle, hard to detect pollution of Spack build environments with non Spack controlled packages.

Consider the scenario:

1. A package has a new version added.
1. A Spack dev updates that package's version, and attempts to build
1. Unbeknownst to our Spack dev, this new version has a dependency on `zlib`
1. The package with a new version is a `CMakePackage`, the Spack dev has a system `zlib` at `/usr/lib/zlib`
1. At this point, attempting to build the new version should fail because Spack is not vendoring `zlib`, however...
1. The build succeeds because CMake find the system `zlib` and uses that to fulfill the requirement
1. The Spack dev, unaware of the new requirement for `zlib` pushes the new version and its is merged
1. A user tries to build this new version and has an incompatible version of `zlib` on their system
1. They get a bunch of weird build errors griping about zlib, but when they run `spack solve` or `spack spec` zlib is not in the DAG


Outside of that scenario (which actually happened), Spack should not be allowing system packages to infiltrate our build contexts.

TODO:
- [x] Document why each CMake variable is defined for sandboxing
- [x] Ensure `<PKG>_ROOT` and `<PKG>_DIR` env variables are sanitized
- [x] Ensure `CMAKE_FRAMEOWKR_PATH` and `CMAKE_APPBUNDLE_PATH` env vars are purged
- [x] Ensure packages that rely on these mechanisms to consume other Spack packages still can 


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
