### PR TITLE
`py-xarray`: Update and ensure dask compatibility

### DIFF
--- a/var/spack/repos/builtin/packages/py-xarray/package.py
+++ b/var/spack/repos/builtin/packages/py-xarray/package.py
@@ -97,7 +97,7 @@ class PyXarray(PythonPackage):
         when="@:2022.05.0 +parallel",
         type=("build", "run"),
     )
-    
+
     # xarray uses inline_array starting in v2022.06.0 which only exists
     # since dask 2021.01.0
     depends_on(

--- a/var/spack/repos/builtin/packages/py-xarray/package.py
+++ b/var/spack/repos/builtin/packages/py-xarray/package.py
@@ -91,9 +91,18 @@ class PyXarray(PythonPackage):
     depends_on("py-rasterio", when="@:2022.3.0 +io", type=("build", "run"))
     depends_on("py-cfgrib", when="@:2022.3.0 +io", type=("build", "run"))
     depends_on("py-pooch", when="+io", type=("build", "run"))
+
     depends_on(
         "py-dask+array+dataframe+distributed+diagnostics+delayed",
         when="+parallel",
+        type=("build", "run"),
+    )
+    
+    # xarray uses inline_array starting in v2022.06.0 which only exists
+    # since dask 2021.01.0
+    depends_on(
+        "py-dask+array+dataframe+distributed+diagnostics+delayed@2021.01.0:",
+        when="@2022.06.0: +parallel",
         type=("build", "run"),
     )
 

--- a/var/spack/repos/builtin/packages/py-xarray/package.py
+++ b/var/spack/repos/builtin/packages/py-xarray/package.py
@@ -39,7 +39,7 @@ class PyXarray(PythonPackage):
 
     variant("io", default=False, description="Build io backends")
     variant("parallel", default=False, description="Build parallel backend")
-    variant("viz", default=False, description="Buid viz backends")
+    variant("viz", default=False, when="2024.7.0:", description="Buid viz backends")
 
     # pyproject.toml
     depends_on("py-setuptools", when="@:0.15", type="build")

--- a/var/spack/repos/builtin/packages/py-xarray/package.py
+++ b/var/spack/repos/builtin/packages/py-xarray/package.py
@@ -39,7 +39,7 @@ class PyXarray(PythonPackage):
 
     variant("io", default=False, description="Build io backends")
     variant("parallel", default=False, description="Build parallel backend")
-    variant("viz", default=False, when="2024.7.0:", description="Buid viz backends")
+    variant("viz", default=False, when="@2024.7.0:", description="Buid viz backends")
 
     # pyproject.toml
     depends_on("py-setuptools", when="@:0.15", type="build")

--- a/var/spack/repos/builtin/packages/py-xarray/package.py
+++ b/var/spack/repos/builtin/packages/py-xarray/package.py
@@ -93,15 +93,16 @@ class PyXarray(PythonPackage):
     depends_on("py-pooch", when="+io", type=("build", "run"))
 
     depends_on(
-        "py-dask+array+dataframe+distributed+diagnostics+delayed",
-        when="+parallel",
+        "py-dask@:2021 +array+dataframe+distributed+diagnostics+delayed",
+        when="@:2022.05.0 +parallel",
         type=("build", "run"),
     )
     
     # xarray uses inline_array starting in v2022.06.0 which only exists
     # since dask 2021.01.0
     depends_on(
-        "py-dask+array+dataframe+distributed+diagnostics+delayed@2021.01.0:",
+        # +delayed is :2021.3.0
+        "py-dask@2022: +array+dataframe+distributed+diagnostics",
         when="@2022.06.0: +parallel",
         type=("build", "run"),
     )

--- a/var/spack/repos/builtin/packages/py-xarray/package.py
+++ b/var/spack/repos/builtin/packages/py-xarray/package.py
@@ -25,6 +25,7 @@ class PyXarray(PythonPackage):
 
     license("Apache-2.0")
 
+    version("2024.7.0", sha256="4cae512d121a8522d41e66d942fb06c526bc1fd32c2c181d5fe62fe65b671638")
     version("2023.7.0", sha256="dace2fdbf1b7ff185d9c1226a24bf83c2ae52f3253dbfe80e17d1162600d055c")
     version("2022.3.0", sha256="398344bf7d170477aaceff70210e11ebd69af6b156fe13978054d25c48729440")
     version("0.18.2", sha256="5d2e72a228286fcf60f66e16876bd27629a1a70bf64822c565f16515c4d10284")
@@ -38,6 +39,7 @@ class PyXarray(PythonPackage):
 
     variant("io", default=False, description="Build io backends")
     variant("parallel", default=False, description="Build parallel backend")
+    variant("viz", default=False, description="Buid viz backends")
 
     # pyproject.toml
     depends_on("py-setuptools", when="@:0.15", type="build")
@@ -64,6 +66,7 @@ class PyXarray(PythonPackage):
     depends_on("py-numpy@1.17:", when="@0.18:", type=("build", "run"))
     depends_on("py-numpy@1.18:", when="@0.20:", type=("build", "run"))
     depends_on("py-numpy@1.21:", when="@2023.7.0:", type=("build", "run"))
+    depends_on("py-numpy@1.23:", when="@2024.7.0:", type=("build", "run"))
 
     depends_on("py-pandas@0.15.0:", when="@0.9.1", type=("build", "run"))
     depends_on("py-pandas@0.19.2:", when="@0.11:0.13", type=("build", "run"))
@@ -72,9 +75,11 @@ class PyXarray(PythonPackage):
     depends_on("py-pandas@1:", when="@0.18:", type=("build", "run"))
     depends_on("py-pandas@1.1:", when="@0.20:", type=("build", "run"))
     depends_on("py-pandas@1.4:", when="@2023.7.0:", type=("build", "run"))
+    depends_on("py-pandas@2.0:", when="@2024.7.0:", type=("build", "run"))
 
     depends_on("py-packaging@20:", when="@0.21:", type=("build", "run"))
     depends_on("py-packaging@21.3:", when="@2023.7.0:", type=("build", "run"))
+    depends_on("py-packaging@23.1:", when="@2024.7.0:", type=("build", "run"))
 
     depends_on("py-netcdf4", when="+io", type=("build", "run"))
     depends_on("py-h5netcdf", when="+io", type=("build", "run"))
@@ -91,3 +96,7 @@ class PyXarray(PythonPackage):
         when="+parallel",
         type=("build", "run"),
     )
+
+    depends_on("py-matplotlib", when="@2024.7.0: +viz", type=("build", "run"))
+    depends_on("py-seaborn", when="@2024.7.0: +viz", type=("build", "run"))
+    depends_on("py-nc-time-axis", when="@2024.7.0: +viz", type=("build", "run"))


### PR DESCRIPTION
- Add the newest version of xarray and ensure that a compatible xarray/dask combo is used. 
- Add `viz` variant to match what is in the 2024+ xarray
- Refine how py-xarray depends on py-dask to ensure `+distributed` variant isn't used for modern dask:
```
$ spack spec -I -U py-dask@2023+delayed
==> Error: failed to concretize `py-dask@2023+delayed` for the following reasons:
     1. Cannot select a single "version" for package "py-dask"
     2. Cannot satisfy 'py-dask@:2021.6.1'
     3. Cannot satisfy 'py-dask@:2021.3.0'
     4. Cannot satisfy 'py-dask@2023.4.1:'
     5. Cannot satisfy 'py-dask@2023.4.1'
     6. Cannot satisfy 'py-dask@2023.4.0:'
     7. Cannot satisfy 'py-dask@2023'
     8. Cannot satisfy 'py-dask@2022.10.2:'
     9. Cannot satisfy 'py-dask@2021.3.1:'
    10. Cannot satisfy 'py-dask@2.13.0:2021.3.0'
    11. Cannot satisfy 'py-dask@2023'
        required because py-dask@2023+delayed requested explicitly
```