### PR TITLE
vtk-m: add v2.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/mr3258-fix-typo-thrust-dependency-with-rocm.patch
+++ b/var/spack/repos/builtin/packages/vtk-m/mr3258-fix-typo-thrust-dependency-with-rocm.patch
@@ -1,0 +1,73 @@
+From be6649803d199c33bb6abcaab57074dca066f1c0 Mon Sep 17 00:00:00 2001
+From: Vicente Adolfo Bolea Sanchez <vicente.bolea@kitware.com>
+Date: Fri, 2 Aug 2024 17:43:54 -0400
+Subject: [PATCH] ci,thrust: fix typo thrust dependency with kokkos
+
+---
+ CMakeLists.txt                           | 14 ++++++++++++--
+ README.md                                |  1 +
+ vtkm/cont/kokkos/internal/CMakeLists.txt |  8 +++++++-
+ 3 files changed, 20 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 561bee9835..46d1cfc37c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -264,11 +264,21 @@ include(VTKmWrappers)
+ 
+ # By default: Set VTKm_ENABLE_KOKKOS_THRUST to ON if VTKm_ENABLE_KOKKOS is ON, otherwise
+ # disable it (or if the user explicitly turns this option OFF)
+-cmake_dependent_option(VTKm_ENABLE_KOKKOS_THRUST "Enable Kokkos thrust support (only valid with CUDA and HIP)"
+-  ON "VTKm_ENABLE_KOKKOS;Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP" OFF)
++cmake_dependent_option(
++  VTKm_ENABLE_KOKKOS_THRUST
++  "Enable Kokkos thrust support (only valid with CUDA and HIP)"
++  ON
++  "VTKm_ENABLE_KOKKOS;Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP; NOT Kokkos_ENABLE_HIP AND CMAKE_VERSION VERSION_LESS 3.24"
++  OFF
++)
+ 
+ # CUDA already provides thrust
+ if (VTKm_ENABLE_KOKKOS_THRUST AND TARGET vtkm_kokkos_hip)
++  if (CMAKE_VERSION VERSION_LESS 3.24)
++    message(FATAL_ERROR "VTKm_ENABLE_KOKKOS_THRUST=ON with HIP needs CMAKE >= 3.24")
++  endif()
++  # This policy is needed for LINK_ONLY to work in LINK_LIBRARIES.
++  cmake_policy(SET CMP0131 NEW)
+   find_package(rocthrust REQUIRED CONFIG)
+ endif()
+ 
+diff --git a/README.md b/README.md
+index aad908b955..8f5512a7e6 100644
+--- a/README.md
++++ b/README.md
+@@ -76,6 +76,7 @@ VTK-m Requires:
+   + [CMake](http://www.cmake.org/download/)
+       + CMake 3.12+
+       + CMake 3.13+ (for CUDA support)
++      + CMake 3.24+ (for ROCM+THRUST support)
+ 
+ Optional dependencies are:
+ 
+diff --git a/vtkm/cont/kokkos/internal/CMakeLists.txt b/vtkm/cont/kokkos/internal/CMakeLists.txt
+index 7777005f3e..210d9ed25c 100644
+--- a/vtkm/cont/kokkos/internal/CMakeLists.txt
++++ b/vtkm/cont/kokkos/internal/CMakeLists.txt
+@@ -35,7 +35,13 @@ if (TARGET vtkm_kokkos)
+     set_source_files_properties(${sources} TARGET_DIRECTORY vtkm_cont PROPERTIES LANGUAGE HIP)
+     kokkos_compilation(SOURCE ${sources})
+     if (VTKm_ENABLE_KOKKOS_THRUST)
+-      target_link_libraries(vtkm_cont PRIVATE $<$<LINK_LANGUAGE:CUDA>:roc::rocthrust>)
++      # rocthrust does not wrap its compile defs/ops/dirs with $<$<COMPILE_LANGUAGE:HIP>.
++      # We need this workaround since we mix CXX and HIP source files in vtkm_cont.
++      target_link_libraries(vtkm_cont
++        PRIVATE
++          $<$<COMPILE_LANGUAGE:HIP>:roc::rocthrust>
++          $<LINK_ONLY:roc::rocthrust>
++      )
+     endif()
+   endif()
+ 
+-- 
+2.35.3
+

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -29,12 +29,12 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version("release", branch="release")
-    version("2.2.0-rc1", sha256="32643cf3564fa77f8e2a2a5456a574b6b2355bb68918eb62ccde493993ade1a3")
     version(
-        "2.1.0",
-        sha256="9cf3522b6dc0675281a1a16839464ebd1cc5f9c08c20eabee1719b3bcfdcf41f",
+        "2.2.0",
+        sha256="ee66b6bbd33f6ad6f2350e11a7c9328492e53935ba8f66b4b1d01f074eb96341",
         preferred=True,
     )
+    version("2.1.0", sha256="9cf3522b6dc0675281a1a16839464ebd1cc5f9c08c20eabee1719b3bcfdcf41f")
     version("2.0.0", sha256="32643cf3564fa77f8e2a2a5456a574b6b2355bb68918eb62ccde493993ade1a3")
     version("1.9.0", sha256="12355dea1a24ec32767260068037adeb71abb3df2f9f920c92ce483f35ff46e4")
     version("1.8.0", sha256="fcedee6e8f4ac50dde56e8c533d48604dbfb663cea1561542a837e8e80ba8768")
@@ -121,7 +121,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("hip@3.7:", when="+rocm")
     # CUDA thrust is already include in the CUDA pkg
-    depends_on("rocthrust", when="@2.1: +kokkos+rocm")
+    depends_on("rocthrust", when="@2.2: +kokkos+rocm ^cmake@3.24:")
 
     # The rocm variant is only valid options for >= 1.7. It would be better if
     # this could be expressed as a when clause to disable the rocm variant,
@@ -152,13 +152,17 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
 
     # VTK-M PR#3160
     # https://gitlab.kitware.com/vtk/vtk-m/-/merge_requests/3160
-    patch("mr3160-rocthrust-fix.patch", when="@2.1:")
+    patch("mr3160-rocthrust-fix.patch", when="@2.1")
+
+    # VTK-M PR#3258
+    # https://gitlab.kitware.com/vtk/vtk-m/-/merge_requests/3258
+    patch("mr3258-fix-typo-thrust-dependency-with-rocm.patch", when="@2.2:")
 
     # Disable Thrust patch that is no longer needed in modern Thrust
     patch(
         "https://github.com/Kitware/VTK-m/commit/4a4466e7c8cd44d2be2bd3fe6f359faa8e9547aa.patch?full_index=1",
         sha256="58dc104ba05ec99c359eeec3ac094cdb071053a4250f4ad9d72ef6a356c4346e",
-        when="@1.6.0: +cuda ^cuda@12.5:",
+        when="@1.6.0:2.1 +cuda ^cuda@12.5:",
     )
 
     def cmake_args(self):


### PR DESCRIPTION
:tada: :tada: :tada: 


Finally! VTK-m v2.2.0 release is out.

This bring exiting new features and bugfixes. Find the release notes at https://gitlab.kitware.com/vtk/vtk-m/-/blob/master/docs/changelog/2.2/release-notes.md

Let me know if we need to change anything else in the package

ViB

:tada: :tada: :tada: