### PR TITLE
Windows: Port icu4c

### DIFF
--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -224,6 +224,30 @@ class Msvc(Compiler):
         self.msvc_compiler_environment = CmdCall(*env_cmds)
 
     @property
+    def cxx11_flag(self):
+        return "/std:c++11"
+
+    @property
+    def cxx14_flag(self):
+        return "/std:c++14"
+
+    @property
+    def cxx17_flag(self):
+        return "/std:c++17"
+
+    @property
+    def cxx20_flag(self):
+        return "/std:c++20"
+
+    @property
+    def c11_flag(self):
+        return "/std:c11"
+
+    @property
+    def c17_flag(self):
+        return "/std:c17"
+
+    @property
     def msvc_version(self):
         """This is the VCToolset version *NOT* the actual version of the cl compiler
         For CL version, query `Msvc.cl_version`"""

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -102,7 +102,8 @@ class MSBuildBuilder(spack.build_systems.msbuild.MSBuildBuilder):
         return [
             "allinone.sln",
             self.define("OutputPath", self.spec.prefix),
-            self.define("Configuration", "Release")
+            self.define("Configuration", "Release"),
+            self.define("SkipUWP", "true")
         ]
 
     @property
@@ -112,3 +113,16 @@ class MSBuildBuilder(spack.build_systems.msbuild.MSBuildBuilder):
             solution_path = solution_path / "icu"
         solution_path = solution_path / "source" / "allinone"
         return str(solution_path)
+
+    def install(self, pkg, spec, prefix):
+        mkdirp(prefix.lib)
+        mkdirp(prefix.bin)
+        mkdirp(prefix.include)
+        mkdirp(prefix.commondata)
+        with working_dir(self.pkg.stage.source_path):
+            # install bin
+            install_tree("bin64", prefix.bin)
+            # install lib
+            install_tree("lib64", prefix.lib)
+            # intstall headers
+            install_tree("include", prefix.include)

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -3,10 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import pathlib
 from spack.package import *
 
 
-class Icu4c(AutotoolsPackage):
+class Icu4c(AutotoolsPackage, MSBuildPackage):
     """ICU is a mature, widely used set of C/C++ and Java libraries providing
     Unicode and Globalization support for software applications. ICU4C is the
     C/C++ interface."""
@@ -15,6 +16,8 @@ class Icu4c(AutotoolsPackage):
     url = "https://github.com/unicode-org/icu/releases/download/release-65-1/icu4c-65_1-src.tgz"
 
     license("Unicode-TOU")
+
+    build_system("autotools", "msbuild")
 
     version("74.2", sha256="68db082212a96d6f53e35d60f47d38b962e9f9d207a74cfac78029ae8ff5e08c")
     version("67.1", sha256="94a80cd6f251a53bd2a997f6f1b5ac6653fe791dfab66e1eb0227740fb86d5dc")
@@ -74,6 +77,8 @@ class Icu4c(AutotoolsPackage):
     def setup_build_environment(self, env):
         env.set("LC_ALL", "en_US.UTF-8")
 
+
+class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
     def configure_args(self):
         args = []
 
@@ -88,3 +93,15 @@ class Icu4c(AutotoolsPackage):
             args.append("--enable-rpath")
 
         return args
+
+
+class MSBuildBuilder(spack.build_systems.msbuild.MSBuildBuilder):
+    def msbuild_args(self):
+        return [
+            "allinone.sln",
+            self.define("OutputPath", self.spec.prefix)
+        ]
+
+    @property
+    def build_directory(self):
+        return str(pathlib.Path(self.pkg.stage.souce_path) / "icu4c" / "source" / "allinone")

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -4,10 +4,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import pathlib
-from spack.package import *
 import sys
 
+from spack.package import *
+
 IS_WINDOWS = sys.platform == "win32"
+
 
 class Icu4c(AutotoolsPackage, MSBuildPackage):
     """ICU is a mature, widely used set of C/C++ and Java libraries providing
@@ -19,7 +21,6 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
 
     license("Unicode-TOU")
 
-    build_system("autotools", "msbuild")
 
     version("74.2", sha256="68db082212a96d6f53e35d60f47d38b962e9f9d207a74cfac78029ae8ff5e08c")
     version("67.1", sha256="94a80cd6f251a53bd2a997f6f1b5ac6653fe791dfab66e1eb0227740fb86d5dc")
@@ -35,6 +36,9 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+
+    build_system("autotools", "msbuild", default="autotools")
+
 
     variant(
         "cxxstd",
@@ -103,7 +107,7 @@ class MSBuildBuilder(spack.build_systems.msbuild.MSBuildBuilder):
             "allinone.sln",
             self.define("OutputPath", self.spec.prefix),
             self.define("Configuration", "Release"),
-            self.define("SkipUWP", "true")
+            self.define("SkipUWP", "true"),
         ]
 
     @property

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -21,7 +21,6 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
 
     license("Unicode-TOU")
 
-
     version("74.2", sha256="68db082212a96d6f53e35d60f47d38b962e9f9d207a74cfac78029ae8ff5e08c")
     version("67.1", sha256="94a80cd6f251a53bd2a997f6f1b5ac6653fe791dfab66e1eb0227740fb86d5dc")
     version("66.1", sha256="52a3f2209ab95559c1cf0a14f24338001f389615bf00e2585ef3dbc43ecf0a2e")
@@ -38,7 +37,6 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
     depends_on("cxx", type="build")  # generated
 
     build_system("autotools", "msbuild", default="autotools")
-
 
     variant(
         "cxxstd",
@@ -77,6 +75,8 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
             flags.append(getattr(self.compiler, f"cxx{self.spec.variants['cxxstd'].value}_flag"))
         return (None, flags, None)
 
+
+class BuildEnvironment:
     # Need to make sure that locale is UTF-8 in order to process source
     # files in UTF-8.
     @when("@59:")
@@ -84,7 +84,7 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
         env.set("LC_ALL", "en_US.UTF-8")
 
 
-class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
+class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder, BuildEnvironment):
     def configure_args(self):
         args = []
 
@@ -101,7 +101,7 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
         return args
 
 
-class MSBuildBuilder(spack.build_systems.msbuild.MSBuildBuilder):
+class MSBuildBuilder(spack.build_systems.msbuild.MSBuildBuilder, BuildEnvironment):
     def msbuild_args(self):
         return [
             "allinone.sln",

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -5,7 +5,9 @@
 
 import pathlib
 from spack.package import *
+import sys
 
+IS_WINDOWS = sys.platform == "win32"
 
 class Icu4c(AutotoolsPackage, MSBuildPackage):
     """ICU is a mature, widely used set of C/C++ and Java libraries providing
@@ -99,9 +101,14 @@ class MSBuildBuilder(spack.build_systems.msbuild.MSBuildBuilder):
     def msbuild_args(self):
         return [
             "allinone.sln",
-            self.define("OutputPath", self.spec.prefix)
+            self.define("OutputPath", self.spec.prefix),
+            self.define("Configuration", "Release")
         ]
 
     @property
     def build_directory(self):
-        return str(pathlib.Path(self.pkg.stage.souce_path) / "icu4c" / "source" / "allinone")
+        solution_path = pathlib.Path(self.pkg.stage.source_path)
+        if self.spec.satsifies("@:67"):
+            solution_path = solution_path / "icu"
+        solution_path = solution_path / "source" / "allinone"
+        return str(solution_path)

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -66,8 +66,6 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
         when="@58.0:59",
     )
 
-    configure_directory = "source"
-
     def url_for_version(self, version):
         url = "https://github.com/unicode-org/icu/releases/download/release-{0}/icu4c-{1}-src.tgz"
         return url.format(version.dashed, version.underscored)
@@ -89,6 +87,9 @@ class BuildEnvironment:
 
 
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder, BuildEnvironment):
+
+    configure_directory = "source"
+
     def configure_args(self):
         args = []
 

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -126,7 +126,6 @@ class MSBuildBuilder(spack.build_systems.msbuild.MSBuildBuilder, BuildEnvironmen
         mkdirp(prefix.lib)
         mkdirp(prefix.bin)
         mkdirp(prefix.include)
-        mkdirp(prefix.commondata)
         with working_dir(self.pkg.stage.source_path):
             # install bin
             install_tree("bin64", prefix.bin)

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -37,14 +37,15 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
     depends_on("cxx", type="build")  # generated
 
     build_system("autotools", "msbuild", default="autotools")
-
-    variant(
-        "cxxstd",
-        default="11",
-        values=("11", "14", "17"),
-        multi=False,
-        description="Use the specified C++ standard when building",
-    )
+    for plat in ["linux", "darwin", "freebsd"]:
+        with when(f"platform={plat}"):
+            variant(
+                "cxxstd",
+                default="11",
+                values=("11", "14", "17"),
+                multi=False,
+                description="Use the specified C++ standard when building",
+            )
 
     depends_on("python", type="build", when="@64.1:")
     with when("build_system=autotools"):

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -4,11 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import pathlib
-import sys
 
 from spack.package import *
-
-IS_WINDOWS = sys.platform == "win32"
 
 
 class Icu4c(AutotoolsPackage, MSBuildPackage):

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -47,6 +47,10 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
     )
 
     depends_on("python", type="build", when="@64.1:")
+    with when("build_system=autotools"):
+        depends_on("autoconf", type="build")
+        depends_on("automake", type="build")
+        depends_on("libtool", type="build")
 
     conflicts(
         "%intel@:16",


### PR DESCRIPTION
Adds functionality to the `icu4c` package to allow for building on Windows

* Adds an MSBuild system + Builder to the `icu4c` package
* Adds custom install method as MSBuild system does not vendor an install target
* Adds C++ and C std flags for MSVC class