### PR TITLE
fastor: add git attribute, verify language dependency

### DIFF
--- a/var/spack/repos/builtin/packages/fastor/package.py
+++ b/var/spack/repos/builtin/packages/fastor/package.py
@@ -12,6 +12,7 @@ class Fastor(CMakePackage):
 
     homepage = "https://github.com/romeric/Fastor"
     url = "https://github.com/romeric/Fastor/archive/refs/tags/V0.6.4.tar.gz"
+    git = "https://github.com/romeric/Fastor.git"
 
     maintainers("wdconinc")
 
@@ -19,7 +20,7 @@ class Fastor(CMakePackage):
 
     version("0.6.4", sha256="c97a3b9dbb92413be90689af9d942cddee12a74733cf42f1a8014965553a11f8")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.20:", type="build")
 

--- a/var/spack/repos/builtin/packages/fastor/package.py
+++ b/var/spack/repos/builtin/packages/fastor/package.py
@@ -20,7 +20,7 @@ class Fastor(CMakePackage):
 
     version("0.6.4", sha256="c97a3b9dbb92413be90689af9d942cddee12a74733cf42f1a8014965553a11f8")
 
-    depends_on("cxx", type="test")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.20:", type="build")
 

--- a/var/spack/repos/builtin/packages/fastor/package.py
+++ b/var/spack/repos/builtin/packages/fastor/package.py
@@ -20,7 +20,7 @@ class Fastor(CMakePackage):
 
     version("0.6.4", sha256="c97a3b9dbb92413be90689af9d942cddee12a74733cf42f1a8014965553a11f8")
 
-    depends_on("cxx", type="build")
+    depends_on("cxx", type="test")
 
     depends_on("cmake@3.20:", type="build")
 


### PR DESCRIPTION
This PR adds the git attribute for `fastor` (and removes the `# generated` comment).
