### PR TITLE
xmlto: hotfix upstream patch removed by fedora

### DIFF
--- a/var/spack/repos/builtin/packages/xmlto/package.py
+++ b/var/spack/repos/builtin/packages/xmlto/package.py
@@ -30,10 +30,10 @@ class Xmlto(AutotoolsPackage):
     depends_on("docbook-xml", type="run")
 
     patch(
-        "https://src.fedoraproject.org/rpms/xmlto/raw/rawhide/f/xmlto-c99-1.patch",
+        "https://src.fedoraproject.org/rpms/xmlto/raw/571fc033c0ff5d6cf448e2ca20d8ae8ac61a7cb8/f/xmlto-c99-1.patch",
         sha256="056c8bebc25d8d1488cc6a3724e2bcafc0e5e0df5c50080559cdef99bd377839",
     )
     patch(
-        "https://src.fedoraproject.org/rpms/xmlto/raw/rawhide/f/xmlto-c99-2.patch",
+        "https://src.fedoraproject.org/rpms/xmlto/raw/571fc033c0ff5d6cf448e2ca20d8ae8ac61a7cb8/f/xmlto-c99-2.patch",
         sha256="50e39b1810bbf22a1d67944086c5681bcd58b8c325dfb251d56ac15d088fc17a",
     )


### PR DESCRIPTION
Fedora [removed two patches](https://src.fedoraproject.org/rpms/xmlto/c/cb08ff9a604d5a9d4f25595a4a4df0141d706aaa) for xmlto v0.28.0 in their rawhide branch (since they are switching to v0.29.0). We were linking the two patches by branch name, not commit.

This PR makes the patch URLs definite by attaching them to the original commit. Hashes are unchanged.

Note: no other similar cases in tree, at least not for Fedora (`grep -iIr fedoraproject var/spack/repos/builtin/packages/ | grep rawhide`).