### PR TITLE
groff: Add a dependency on m4

### DIFF
--- a/var/spack/repos/builtin/packages/groff/package.py
+++ b/var/spack/repos/builtin/packages/groff/package.py
@@ -44,6 +44,7 @@ class Groff(AutotoolsPackage, GNUMirrorPackage):
 
     conflicts("+uchardet", when="@:1.22.3")
 
+    depends_on("m4", type="build")
     depends_on("gawk", type="build")
     depends_on("gmake", type="build")
     depends_on("sed", type="build")


### PR DESCRIPTION
Building on Ubuntu (`^groff@1.23.0%gcc@11.4.0~pdf+uchardet~x build_system=autotools arch=linux-ubuntu22.04-x86_64`) failed for me, complaining about `m4` missing. Adding the dependency fixed it. I made a similar build on AlmaLinux9 but didn't need this.