### PR TITLE
`parallelio`: Fix install_name for on macos

### DIFF
--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -70,8 +70,7 @@ class Parallelio(CMakePackage):
     # Allow argument mismatch in gfortran versions > 10 for mpi library compatibility
     patch("gfortran.patch", when="@:2.5.8 +fortran %gcc@10:")
 
-    @when("platform=darwin")
-    @run_after("install")
+    @run_after("install", when="platform=darwin")
     def darwin_install_name(self):
         # The shared library is not installed correctly on Darwin; fix this
         fix_darwin_install_name(self.prefix.lib)

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -70,8 +70,8 @@ class Parallelio(CMakePackage):
     # Allow argument mismatch in gfortran versions > 10 for mpi library compatibility
     patch("gfortran.patch", when="@:2.5.8 +fortran %gcc@10:")
 
-    @run_after("install")
     @when("platform=darwin")
+    @run_after("install")
     def darwin_install_name(self):
         # The shared library is not installed correctly on Darwin; fix this
         fix_darwin_install_name(self.prefix.lib)

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -70,6 +70,12 @@ class Parallelio(CMakePackage):
     # Allow argument mismatch in gfortran versions > 10 for mpi library compatibility
     patch("gfortran.patch", when="@:2.5.8 +fortran %gcc@10:")
 
+    @run_after("install")
+    @when("platform=darwin")
+    def darwin_install_name(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        fix_darwin_install_name(self.prefix.lib)
+
     def cmake_args(self):
         define = self.define
         define_from_variant = self.define_from_variant


### PR DESCRIPTION
Parallelio installs with an install_name of just the library name making it problematic to link against; e.g., not `@rpath/` nor and absolute path.

There are many open and stale issues upstream. I can report upstream, but I am not sure how quickly it may get fixed.