### PR TITLE
ffmpeg: fix patch hashes

### DIFF
--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -135,7 +135,7 @@ class Ffmpeg(AutotoolsPackage):
     # Solve build failure against vulkan headers 1.3.279
     patch(
         "https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff_plain/fef22c87ada4",
-        sha256="856bdc2b6e2a7066cf683a235193b9025d4d73dd7686eda2fbcf83e7e65f8bf9",
+        sha256="5726e8e999e3fc7a5ae4c4c846c9151246e5846c54dc3b8ff8326ee31c59631a",
         when="@6.1.1",
     )
 
@@ -162,12 +162,12 @@ class Ffmpeg(AutotoolsPackage):
     # fix incompatibility with texinfo@7, especially @7.1:
     patch(
         "https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff_plain/f01fdedb69e4accb1d1555106d8f682ff1f1ddc7",
-        sha256="416751f41cfbf086c28b4bbf01ace4c08e5651e59911dca6240292bb1b5c6b53",
+        sha256="673813d13f5c37b75ff5bcb56790ccd6b16962fdb9bddcbbeeead979d47d31b3",
         when="@6.0",
     )
     patch(
         "https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff_plain/f01fdedb69e4accb1d1555106d8f682ff1f1ddc7",
-        sha256="416751f41cfbf086c28b4bbf01ace4c08e5651e59911dca6240292bb1b5c6b53",
+        sha256="673813d13f5c37b75ff5bcb56790ccd6b16962fdb9bddcbbeeead979d47d31b3",
         when="@5:5.1.3",
     )
 


### PR DESCRIPTION
`ffmpeg` pulls patches from git.ffmpeg.org, and that server started to add `X-Git-Tag` lines to the patch. This makes the patch hashes invalid. See also #43269. This causes gitlab pipeline failures at e.g. https://gitlab.spack.io/spack/spack/-/jobs/12096934.

This PR updates the patch hashes.

Below the proof that this is due to the addition of the `X-Git-Tag` line:
### patch for 6.1.1
```diff
--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -135,7 +135,7 @@ class Ffmpeg(AutotoolsPackage):
     # Solve build failure against vulkan headers 1.3.279
     patch(
         "https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff_plain/fef22c87ada4",
-        sha256="856bdc2b6e2a7066cf683a235193b9025d4d73dd7686eda2fbcf83e7e65f8bf9",
+        sha256="5726e8e999e3fc7a5ae4c4c846c9151246e5846c54dc3b8ff8326ee31c59631a",
         when="@6.1.1",
     )
 
```

```console
14:18:43 wdconinc@menelaos ~/git/spack (develop *$%>) $ curl -L https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff_plain/fef22c87ada4 | grep -v X-Git-Tag | sha256sum 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5124    0  5124    0     0   5199      0 --:--:-- --:--:-- --:--:--  5196
856bdc2b6e2a7066cf683a235193b9025d4d73dd7686eda2fbcf83e7e65f8bf9  -
14:20:44 wdconinc@menelaos ~/git/spack (develop *$%>) $ curl -L https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff_plain/fef22c87ada4 | sha256sum 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5124    0  5124    0     0   5262      0 --:--:-- --:--:-- --:--:--  5260
5726e8e999e3fc7a5ae4c4c846c9151246e5846c54dc3b8ff8326ee31c59631a  -
```

### patch for 6.0
```diff
--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -162,12 +162,12 @@ class Ffmpeg(AutotoolsPackage):
     # fix incompatibility with texinfo@7, especially @7.1:
     patch(
         "https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff_plain/f01fdedb69e4accb1d1555106d8f682ff1f1ddc7",
-        sha256="416751f41cfbf086c28b4bbf01ace4c08e5651e59911dca6240292bb1b5c6b53",
+        sha256="673813d13f5c37b75ff5bcb56790ccd6b16962fdb9bddcbbeeead979d47d31b3",
         when="@6.0",
     )
     patch(
         "https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff_plain/f01fdedb69e4accb1d1555106d8f682ff1f1ddc7",
-        sha256="416751f41cfbf086c28b4bbf01ace4c08e5651e59911dca6240292bb1b5c6b53",
+        sha256="673813d13f5c37b75ff5bcb56790ccd6b16962fdb9bddcbbeeead979d47d31b3",
         when="@5:5.1.3",
     )
```

```console
14:18:34 wdconinc@menelaos ~/git/spack (develop *$%>) $ curl -L https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff_plain/f01fdedb69e4accb1d1555106d8f682ff1f1ddc7 | grep -v X-Git-Tag | sha256sum 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  8260    0  8260    0     0   8945      0 --:--:-- --:--:-- --:--:--  8939
416751f41cfbf086c28b4bbf01ace4c08e5651e59911dca6240292bb1b5c6b53  -
14:18:54 wdconinc@menelaos ~/git/spack (develop *$%>) $ curl -L https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff_plain/f01fdedb69e4accb1d1555106d8f682ff1f1ddc7 | sha256sum 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  8260    0  8260    0     0   8687      0 --:--:-- --:--:-- --:--:--  8685
673813d13f5c37b75ff5bcb56790ccd6b16962fdb9bddcbbeeead979d47d31b3  -
```

Other patches not affected.