### PR TITLE
@on_package_attributes(run_tests=True) test name change

### DIFF
--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -324,7 +324,7 @@ class Phist(CMakePackage):
 
     @run_after("install")
     @on_package_attributes(run_tests=True)
-    def test_install(self):
+    def make_test_install(self):
         # The build script of test_install expects the sources to be copied here:
         install_tree(
             join_path(self.stage.source_path, "exampleProjects"),

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
@@ -119,7 +119,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
 
     @run_after("install")
     @on_package_attributes(run_tests=True)
-    def test_lightning_build(self):
+    def run_lightning_tests(self):
         with working_dir(self.stage.source_path):
             pl_runner = Executable(self.prefix.bin.pennylane_lightning_test_runner)
             pl_runner()

--- a/var/spack/repos/builtin/packages/py-shapely/package.py
+++ b/var/spack/repos/builtin/packages/py-shapely/package.py
@@ -100,7 +100,7 @@ class PyShapely(PythonPackage):
 
     @run_after("install")
     @on_package_attributes(run_tests=True)
-    def test_install(self):
+    def run_pytest_tests(self):
         # https://shapely.readthedocs.io/en/latest/installation.html#testing-shapely
         if self.version >= Version("2"):
             with working_dir("spack-test", create=True):


### PR DESCRIPTION
Changed the name of methods that started with `test_` and had `@on_package_attributes(run_tests=True)` to better suit their purpose.

NOTE:  This PR is not needed if #45699 is approved and merged.