### PR TITLE
Avoid duplicate dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,6 @@ updates:
   # Requirements to run style checks
   - package-ecosystem: "pip"
     directories:
-     - "/.github/workflows/requirements/*"
+     - "/.github/workflows/requirements/style/*"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  # Requirements to build documentation
-  - package-ecosystem: "pip"
-    directory: "/lib/spack/docs"
-    schedule:
-      interval: "daily"
-  # Requirements to run style checks
+  # Requirements to run style checks and build documentation
   - package-ecosystem: "pip"
     directories:
      - "/.github/workflows/requirements/style/*"
+     - "/lib/spack/docs"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Example of a duplicate bump:
- https://github.com/spack/spack/pull/45124
- https://github.com/spack/spack/pull/45125

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
