### PR TITLE
py-colorlog: added new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-colorlog/package.py
+++ b/var/spack/repos/builtin/packages/py-colorlog/package.py
@@ -12,6 +12,7 @@ class PyColorlog(PythonPackage):
     homepage = "https://github.com/borntyping/python-colorlog"
     pypi = "colorlog/colorlog-4.0.2.tar.gz"
 
+    version("6.8.2", sha256="3e3e079a41feb5a1b64f978b5ea4f46040a94f11f0e8bbb8261e3dbbeca64d44")
     version("4.0.2", sha256="3cf31b25cbc8f86ec01fef582ef3b840950dea414084ed19ab922c8b493f9b42")
     version("3.1.4", sha256="418db638c9577f37f0fae4914074f395847a728158a011be2a193ac491b9779d")
 

--- a/var/spack/repos/builtin/packages/py-colorlog/package.py
+++ b/var/spack/repos/builtin/packages/py-colorlog/package.py
@@ -17,3 +17,4 @@ class PyColorlog(PythonPackage):
     version("3.1.4", sha256="418db638c9577f37f0fae4914074f395847a728158a011be2a193ac491b9779d")
 
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@38.6.0:", when="@6.8.0:", type="build")


### PR DESCRIPTION
This PR adds version 6.8.2.
I didn't bother adding the (roughly) 65 missing version, just added the latest.