### PR TITLE
py-gcovr: add version 7.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-gcovr/package.py
+++ b/var/spack/repos/builtin/packages/py-gcovr/package.py
@@ -30,4 +30,4 @@ class PyGcovr(PythonPackage):
     depends_on("py-pygments", when="@5:", type=("build", "run"))
     depends_on("py-pygments@2.13.0:", when="@7.2:", type=("build", "run"))
     depends_on("py-colorlog", when="@7.2:", type=("build", "run"))
-    depends_on("py-tomli", when="@7.2:", type=("build", "run"))
+    depends_on("py-tomli@1.1:", when="@7.2: ^python@:3.10", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-gcovr/package.py
+++ b/var/spack/repos/builtin/packages/py-gcovr/package.py
@@ -15,9 +15,11 @@ class PyGcovr(PythonPackage):
     homepage = "https://gcovr.com/"
     pypi = "gcovr/gcovr-4.2.tar.gz"
 
+    version("7.2", sha256="e3e95cb56ca88dbbe741cb5d69aa2be494eb2fc2a09ee4f651644a670ee5aeb3")
     version("5.2", sha256="217195085ec94346291a87b7b1e6d9cfdeeee562b3e0f9a32b25c9530b3bce8f")
     version("4.2", sha256="5aae34dc81e51600cfecbbbce3c3a80ce3f7548bc0aa1faa4b74ecd18f6fca3f")
 
+    depends_on("python@3.8:", when="@7.2:", type=("build", "run"))
     depends_on("python@3.7:", when="@5.1:", type=("build", "run"))
     depends_on("python@3.6:", when="@5.0", type=("build", "run"))
     depends_on("python@2.7:2,3.5:", when="@:4", type=("build", "run"))
@@ -26,3 +28,6 @@ class PyGcovr(PythonPackage):
     depends_on("py-jinja2", type=("build", "run"))
     depends_on("py-lxml", type=("build", "run"))
     depends_on("py-pygments", when="@5:", type=("build", "run"))
+    depends_on("py-pygments@2.13.0:", when="@7.2:", type=("build", "run"))
+    depends_on("py-colorlog", when="@7.2:", type=("build", "run"))
+    depends_on("py-tomli", when="@7.2:", type=("build", "run"))


### PR DESCRIPTION
Add version 7.2 of py-gcovr. I didn't bother adding versions between 5.2 and 7.2.

Note: gcovr 7.2 fails to run with py-colorlog 4.0.2, hence this PR: https://github.com/spack/spack/pull/45596
However its [setup.py](https://github.com/gcovr/gcovr/blob/main/setup.py) does not specify which version of colorlog is required, so I don't know what would be sensible to put in the spack package.