### PR TITLE
qt-tools: new package

### DIFF
--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -28,6 +28,11 @@ class QtPackage(CMakePackage):
         return _url.format(qualname.lower())
 
     @staticmethod
+    def get_git(qualname):
+        _git = "https://github.com/qt/{}.git"
+        return _git.format(qualname.lower())
+
+    @staticmethod
     def get_list_url(qualname):
         _list_url = "https://github.com/qt/{}/tags"
         return _list_url.format(qualname.lower())

--- a/var/spack/repos/builtin/packages/qt-tools/package.py
+++ b/var/spack/repos/builtin/packages/qt-tools/package.py
@@ -1,0 +1,48 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+from spack.pkg.builtin.qt_base import QtBase, QtPackage
+
+
+class QtTools(QtPackage):
+    """Qt Tools contains tools like Qt Designer."""
+
+    url = QtPackage.get_url(__qualname__)
+    list_url = QtPackage.get_list_url(__qualname__)
+
+    license("BSD-3-Clause")
+
+    version("6.7.2", sha256="3ae2db630606edf94cc368691ee1da9c0bae7a06ff46c544c459cece8b60b62a")
+
+    variant(
+          "designer",
+          default=False,
+          description="Qt Widgets Designer for designing and building GUIs with Qt Widgets.",
+    )
+
+    depends_on("qt-base +network")
+    depends_on("qt-base +widgets", when="+designer")
+
+    for _v in QtBase.versions:
+        v = str(_v)
+        depends_on("qt-base@" + v, when="@" + v)
+
+    def cmake_args(self):
+        spec = self.spec
+
+        args = super().cmake_args() + []
+
+        def define(cmake_var, value):
+            args.append(self.define(cmake_var, value))
+
+        if self.spec.satisfies("+designer"):
+            define("FEATURE_designer", True)
+
+        return args
+
+    def setup_run_environment(self, env):
+        env.prepend_path("QT_PLUGIN_PATH", self.prefix.plugins)

--- a/var/spack/repos/builtin/packages/qt-tools/package.py
+++ b/var/spack/repos/builtin/packages/qt-tools/package.py
@@ -19,9 +19,9 @@ class QtTools(QtPackage):
     version("6.7.2", sha256="3ae2db630606edf94cc368691ee1da9c0bae7a06ff46c544c459cece8b60b62a")
 
     variant(
-          "designer",
-          default=False,
-          description="Qt Widgets Designer for designing and building GUIs with Qt Widgets.",
+        "designer",
+        default=False,
+        description="Qt Widgets Designer for designing and building GUIs with Qt Widgets.",
     )
 
     depends_on("qt-base +network")

--- a/var/spack/repos/builtin/packages/qt-tools/package.py
+++ b/var/spack/repos/builtin/packages/qt-tools/package.py
@@ -39,7 +39,7 @@ class QtTools(QtPackage):
         def define(cmake_var, value):
             args.append(self.define(cmake_var, value))
 
-        if self.spec.satisfies("+designer"):
+        if spec.satisfies("+designer"):
             define("FEATURE_designer", True)
 
         return args

--- a/var/spack/repos/builtin/packages/qt-tools/package.py
+++ b/var/spack/repos/builtin/packages/qt-tools/package.py
@@ -43,6 +43,3 @@ class QtTools(QtPackage):
             define("FEATURE_designer", True)
 
         return args
-
-    def setup_run_environment(self, env):
-        env.prepend_path("QT_PLUGIN_PATH", self.prefix.plugins)

--- a/var/spack/repos/builtin/packages/qt-tools/package.py
+++ b/var/spack/repos/builtin/packages/qt-tools/package.py
@@ -14,6 +14,8 @@ class QtTools(QtPackage):
     url = QtPackage.get_url(__qualname__)
     list_url = QtPackage.get_list_url(__qualname__)
 
+    maintainers("wdconinc")
+
     license("BSD-3-Clause")
 
     version("6.7.2", sha256="3ae2db630606edf94cc368691ee1da9c0bae7a06ff46c544c459cece8b60b62a")

--- a/var/spack/repos/builtin/packages/qt-tools/package.py
+++ b/var/spack/repos/builtin/packages/qt-tools/package.py
@@ -12,19 +12,29 @@ class QtTools(QtPackage):
     """Qt Tools contains tools like Qt Designer."""
 
     url = QtPackage.get_url(__qualname__)
+    git = QtPackage.get_git(__qualname__)
     list_url = QtPackage.get_list_url(__qualname__)
 
     maintainers("wdconinc")
 
     license("BSD-3-Clause")
 
-    version("6.7.2", sha256="3ae2db630606edf94cc368691ee1da9c0bae7a06ff46c544c459cece8b60b62a")
+    # src/assistant/qlitehtml is a submodule that is not in the git archive
+    version("6.7.3", commit="ec4747e62a837a0262212a5f4fb03734660c7360", submodules=True)
+    version("6.7.2", commit="46ffaed90df8c14d67b4b16fdf5e0b87ab227c88", submodules=True)
 
+    variant(
+        "assistant",
+        default=False,
+        description="Qt Assistant for viewing on-line documentation in Qt help file format.",
+    )
     variant(
         "designer",
         default=False,
         description="Qt Widgets Designer for designing and building GUIs with Qt Widgets.",
     )
+
+    depends_on("llvm +clang")
 
     depends_on("qt-base +network")
     depends_on("qt-base +widgets", when="+designer")
@@ -40,6 +50,9 @@ class QtTools(QtPackage):
 
         def define(cmake_var, value):
             args.append(self.define(cmake_var, value))
+
+        if spec.satisfies("+assistant"):
+            define("FEATURE_assistant", True)
 
         if spec.satisfies("+designer"):
             define("FEATURE_designer", True)


### PR DESCRIPTION
This PR adds the Qt Tools module, since used by paraview.

Cherry-picked from #45300.