### PR TITLE
qt-base: let QtPackage base class handle module files

### DIFF
--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -117,8 +117,10 @@ class QtPackage(CMakePackage):
 
     def setup_run_environment(self, env):
         env.prepend_path("QMAKEPATH", self.prefix)
-        env.prepend_path("QMAKE_MODULE_PATH", self.prefix.mkspecs.modules)
-        env.prepend_path("QT_PLUGIN_PATH", self.prefix.plugins)
+        if os.path.exists(self.prefix.mkspecs.modules):
+            env.prepend_path("QMAKE_MODULE_PATH", self.prefix.mkspecs.modules)
+        if os.path.exists(self.prefix.plugins):
+            env.prepend_path("QT_PLUGIN_PATH", self.prefix.plugins)
 
 
 class QtBase(QtPackage):

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -7,6 +7,7 @@ import os
 import re
 import shutil
 import sys
+import tempfile
 
 import llnl.util.tty as tty
 
@@ -81,6 +82,42 @@ class QtPackage(CMakePackage):
         # Warn users that this config summary is only for info purpose,
         # and should not be relied upon for downstream parsing.
         tty.warn("config.summary in prefix is a temporary feature only")
+
+    @run_after("install")
+    def add_qt_module_files(self):
+        """Qt modules need to drop a forwarding qt_module.pri file in the qt-base
+        mkspecs/modules directory. This violates the spack install prefix separation,
+        so we modify the downstream module files to work regardless."""
+
+        # No need to modify qt-base itself
+        if self.spec.name == "qt-base":
+            return
+
+        # Define qt_module.pri filename, but postpone writing until after loop
+        qt_module_pri = join_path(self.prefix.mkspecs.modules, "qt_module.pri")
+
+        # Include qt_module.pri file in every pri file
+        for old_file in find(self.prefix.mkspecs.modules, "*.pri"):
+            new_fd, new_file = tempfile.mkstemp(
+                prefix=os.path.basename(old_file), dir=self.prefix.mkspecs.modules
+            )
+            with os.fdopen(new_fd, "w") as new_fh:
+                new_fh.write(f"include(qt_module.pri)\n")
+                with open(old_file, "r") as old_fh:
+                    new_fh.write(old_fh.read())
+            shutil.move(new_file, old_file)
+
+        # Create qt_module.pri file with definitions
+        defs = []
+        for dir in ["BIN", "INCLUDE", "LIB"]:
+            if os.path.exists(join_path(self.prefix, dir.lower())):
+                defs.append(f"QT_MODULE_{dir}_BASE = {join_path(self.prefix, dir.lower())}\n")
+        with open(qt_module_pri, "w") as file:
+            file.write("\n".join(defs))
+
+    def setup_run_environment(self, env):
+        env.prepend_path("QMAKE_MODULE_PATH", self.prefix.mkspecs.modules)
+        env.prepend_path("QT_PLUGIN_PATH", self.prefix.plugins)
 
 
 class QtBase(QtPackage):

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -116,6 +116,7 @@ class QtPackage(CMakePackage):
             file.write("\n".join(defs))
 
     def setup_run_environment(self, env):
+        env.prepend_path("QMAKEPATH", self.prefix)
         env.prepend_path("QMAKE_MODULE_PATH", self.prefix.mkspecs.modules)
         env.prepend_path("QT_PLUGIN_PATH", self.prefix.plugins)
 

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -102,7 +102,7 @@ class QtPackage(CMakePackage):
                 prefix=os.path.basename(old_file), dir=self.prefix.mkspecs.modules
             )
             with os.fdopen(new_fd, "w") as new_fh:
-                new_fh.write(f"include(qt_module.pri)\n")
+                new_fh.write("include(qt_module.pri)\n")
                 with open(old_file, "r") as old_fh:
                     new_fh.write(old_fh.read())
             shutil.move(new_file, old_file)

--- a/var/spack/repos/builtin/packages/qt-svg/package.py
+++ b/var/spack/repos/builtin/packages/qt-svg/package.py
@@ -49,7 +49,3 @@ class QtSvg(QtPackage):
     def cmake_args(self):
         args = super().cmake_args() + []
         return args
-
-    def setup_run_environment(self, env):
-        # to make plugins from SVG module to base, for e.g. icon loading
-        env.prepend_path("QT_PLUGIN_PATH", self.prefix.plugins)


### PR DESCRIPTION
Qt6 installs pri files in `mkspecs/modules` under one common prefix. Additional modules (e.g. QtSvg in `qt-svg`) normally install in that same `mkspecs/modules` directory, but that breaks the prefix separation of Spack. Wen we try to use the `qt-svg` pri files in their `mkspecs/modules` directory, the calling script (`mkspecs/features/qt_config.prf` in `qt-base`) defines `QT_MODULE_INCLUDE_BASE` to point to the `qt-base` prefix, not the `qt-svg` prefix. This, in turn, causes the incorrect include path to be passed, resulting in e.g. in https://gitlab.spack.io/spack/spack/-/jobs/11977726#L551.

To ensure the correct `QT_MODULE_INCLUDE_BASE` values are used, this PR modifies the pri files that QtPackages install to define the correct directory values.

Cherry-picked from #45300. This has been used to build `qwt ^qt-svg ^qt-base` successfully in the pipelines in that branch.