### PR TITLE
qwt: add v6.2.0, v6.3.0, support Qt6

### DIFF
--- a/var/spack/repos/builtin/packages/qwt/package.py
+++ b/var/spack/repos/builtin/packages/qwt/package.py
@@ -18,6 +18,8 @@ class Qwt(QMakePackage):
 
     license("custom")
 
+    version("6.3.0", sha256="dcb085896c28aaec5518cbc08c0ee2b4e60ada7ac929d82639f6189851a6129a")
+    version("6.2.0", sha256="9194f6513955d0fd7300f67158175064460197abab1a92fa127a67a4b0b71530")
     version("6.1.6", sha256="99460d31c115ee4117b0175d885f47c2c590d784206f09815dc058fbe5ede1f6")
     version("6.1.4", sha256="1529215329e51fc562e0009505a838f427919a18b362afff441f035b2d9b5bd9")
     version("6.1.3", sha256="f3ecd34e72a9a2b08422fb6c8e909ca76f4ce5fa77acad7a2883b701f4309733")
@@ -31,11 +33,17 @@ class Qwt(QMakePackage):
     patch("no-designer.patch", when="~designer")
     patch("no-opengl_6_1.patch", when="@6.1 ~opengl")
 
-    depends_on("qt+tools", when="+designer")
-    depends_on("qt+opengl", when="+opengl")
+    depends_on("qmake")
+    with when("^[virtuals=qmake] qt-base"):
+        depends_on("qt-svg")
+        depends_on("qt-tools", when="+designer")
+        depends_on("qt-base+opengl", when="+opengl")
+    with when("^[virtuals=qmake] qt"):
+        depends_on("qt+tools", when="+designer")
+        depends_on("qt+opengl", when="+opengl")
 
-    # Qwt does not support Qt6; this picks the right qmake provider
-    conflicts("^qt-base", msg="Qwt requires Qt5")
+    # Qwt@:6.1 does not support Qt6; this picks the right qmake provider
+    conflicts("^[virtuals=qmake] qt-base", when="@:6.1", msg="Qwt support for Qt6 was added in v6.2.0")
 
     # the qt@5.14.2 limitation was lifted in qwt@6.1.5
     # https://sourceforge.net/p/qwt/code/HEAD/tree/tags/qwt-6.1.6/CHANGES-6.1

--- a/var/spack/repos/builtin/packages/qwt/package.py
+++ b/var/spack/repos/builtin/packages/qwt/package.py
@@ -43,7 +43,9 @@ class Qwt(QMakePackage):
         depends_on("qt+opengl", when="+opengl")
 
     # Qwt@:6.1 does not support Qt6; this picks the right qmake provider
-    conflicts("^[virtuals=qmake] qt-base", when="@:6.1", msg="Qwt support for Qt6 was added in v6.2.0")
+    conflicts(
+        "^[virtuals=qmake] qt-base", when="@:6.1", msg="Qwt support for Qt6 was added in v6.2.0"
+    )
 
     # the qt@5.14.2 limitation was lifted in qwt@6.1.5
     # https://sourceforge.net/p/qwt/code/HEAD/tree/tags/qwt-6.1.6/CHANGES-6.1

--- a/var/spack/repos/builtin/packages/qwt/package.py
+++ b/var/spack/repos/builtin/packages/qwt/package.py
@@ -37,7 +37,7 @@ class Qwt(QMakePackage):
     with when("^[virtuals=qmake] qt-base"):
         depends_on("qt-svg")
         depends_on("qt-tools", when="+designer")
-        depends_on("qt-base+opengl", when="+opengl")
+        depends_on("qt-base+opengl+widgets", when="+opengl")
     with when("^[virtuals=qmake] qt"):
         depends_on("qt+tools", when="+designer")
         depends_on("qt+opengl", when="+opengl")

--- a/var/spack/repos/builtin/packages/visit/20270-missing-cmath-QvisStripChart.patch
+++ b/var/spack/repos/builtin/packages/visit/20270-missing-cmath-QvisStripChart.patch
@@ -1,0 +1,12 @@
+diff --git a/src/gui/QvisStripChart.C b/src/gui/QvisStripChart.C
+index 452e2c29e93b0f1b4a1b6e9b5be48288ac5fdd3f..cbb8582e9ab72c5afa29d606ce86e0a4573c0b89 100644
+--- a/src/gui/QvisStripChart.C
++++ b/src/gui/QvisStripChart.C
+@@ -18,6 +18,7 @@
+ 
+ #include <DebugStream.h>
+ 
++#include <cmath>
+ #include <sstream>
+ #include <iostream>
+ #include <limits>

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -120,6 +120,9 @@ class Visit(CMakePackage):
     patch("19958-enable-python-and-check-pip.patch", when="@3.4:3.4.1 +python")
     patch("20127-remove-relink-visitmodule-py-setup.patch", when="@3.4.1 +python")
 
+    # Fix missing cmath include in QvisStripChart.C
+    patch("20270-missing-cmath-QvisStripChart.patch", when="@:3.4.2")
+
     conflicts(
         "+gui", when="^[virtuals=gl] osmesa", msg="GUI cannot be activated with OSMesa front-end"
     )


### PR DESCRIPTION
This PR adds support to `qwt` for building against Qt6.

Needs:
- [x] #45602
- [x] #45603

Cherry-picked from #45300. This has been used to build `paraview ^qwt ^qt-svg ^qt-base` successfully in the pipelines in that branch.

Test build:
```
==> Installing qwt-6.3.0-qfii2gdxaexkeqybmkwxjqiai7eksz3u [95/95]
==> No binary for qwt-6.3.0-qfii2gdxaexkeqybmkwxjqiai7eksz3u found: installing from source
==> Fetching https://sourceforge.net/projects/qwt/files/qwt/6.3.0/qwt-6.3.0.tar.bz2
==> Ran patch() for qwt
==> qwt: Executing phase: 'qmake'
==> qwt: Executing phase: 'build'
==> qwt: Executing phase: 'install'
==> qwt: Successfully installed qwt-6.3.0-qfii2gdxaexkeqybmkwxjqiai7eksz3u
  Stage: 3.95s.  Qmake: 0.04s.  Build: 3m 38.02s.  Install: 6.14s.  Post-install: 0.57s.  Total: 3m 49.99s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qwt-6.3.0-qfii2gdxaexkeqybmkwxjqiai7eksz3u
```