### PR TITLE
biobambam2: fix test scripts to use installed binaries

### DIFF
--- a/var/spack/repos/builtin/packages/biobambam2/package.py
+++ b/var/spack/repos/builtin/packages/biobambam2/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
@@ -37,6 +39,12 @@ class Biobambam2(AutotoolsPackage):
         """Copy the test source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources(self.test_src_dir)
+
+        # Fix test scripts to run installed binaries
+        scripts_dir = join_path(install_test_root(self), self.test_src_dir)
+        for path in os.listdir(scripts_dir):
+            if path.endswith(".sh"):
+                filter_file(r"../src/", r"", join_path(scripts_dir, path))
 
     def test_short_sort(self):
         """run testshortsort.sh to check alignments sorted by coordinate"""


### PR DESCRIPTION
This PR uses `filter_file` to fix the test scripts so they utilize the installed binaries instead of invalid relative paths.

Stand-alone test results before this PR:
```
$ spack -v test run biobambam2
==> Spack test nexgj5uzwigrs6vugpi7c4jj3fjz5hta
==> Testing package biobambam2-2.0.177-ymrguh5
..
==> [2024-08-06-18:03:05.585297] test: test_short_sort: run testshortsort.sh to check alignments sorted by coordinate
==> [2024-08-06-18:03:05.587674] '/usr/bin/sh' 'testshortsort.sh'
...
~/.spack/test/nexgj5uzwigrs6vugpi7c4jj3fjz5hta/biobambam2-2.0.177-ymrguh5/cache/biobambam2/test
bamsort failed
testshortsort.sh: line 9: ../src/bamchecksort: No such file or directory
testshortsort.sh: line 9: ../src/bamsort: No such file or directory
...
==> [2024-08-06-18:03:05.630009] Completed testing
==> [2024-08-06-18:03:05.630192]
===================== SUMMARY: biobambam2-2.0.177-ymrguh5 ======================
Biobambam2::test_short_sort .. FAILED
============================= 1 failed of 1 parts ==============================
```

Stand-alone test results *after* installing the software using the changes in this PR:
```
$ spack -v test run biobambam2
==> [2024-08-06-18:33:04.573437] Installing /usr/WS1/dahlgren/releases/spack/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/biobambam2-2.0.177-vpcomckgagtx5z3shmp77r2s32pdbqwt/.spack/test to /g/g21/dahlgren/.spack/test/i6nl2igsaaklxnwarc2bfvetgyaof2be/biobambam2-2.0.177-vpcomck/cache/biobambam2
==> [2024-08-06-18:33:04.667874] test: test_short_sort: run testshortsort.sh to check alignments sorted by coordinate
==> [2024-08-06-18:33:04.670197] '/usr/bin/sh' 'testshortsort.sh'
...
[V] Reading alignments from source.
[V] read 4 alignments
[V] producing sorted output
[V] wrote 4 alignments
[V] 3
Alignments sorted by coordinate.
PASSED: Biobambam2::test_short_sort
==> [2024-08-06-18:33:04.754320] Completed testing
==> [2024-08-06-18:33:04.754442]
===================== SUMMARY: biobambam2-2.0.177-vpcomck ======================
Biobambam2::test_short_sort .. PASSED
============================= 1 passed of 1 parts ==============================
============================== 1 passed of 1 spec ==============================
```