### PR TITLE
CP2K: add 2024.2 and fix dbcsr+g2g

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -237,7 +237,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
             depends_on("dla-future +cuda", when="+cuda")
             depends_on("dla-future +rocm", when="+rocm")
 
-        with when("@2024.2"):
+        with when("@2024.2:"):
             depends_on("dla-future-fortran@0.1.0:")
 
             # Use a direct dependency on dla-future so that constraints can be expressed

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -20,6 +20,7 @@ GPU_MAP = {
     "60": "P100",
     "70": "V100",
     "80": "A100",
+    "90": "H100",
     "gfx906": "Mi50",
     "gfx908": "Mi100",
     "gfx90a": "Mi250",
@@ -45,6 +46,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
 
     license("GPL-2.0-or-later")
 
+    version("2024.2", sha256="cc3e56c971dee9e89b705a1103765aba57bf41ad39a11c89d3de04c8b8cdf473")
     version("2024.1", sha256="a7abf149a278dfd5283dc592a2c4ae803b37d040df25d62a5e35af5c4557668f")
     version("2023.2", sha256="adbcc903c1a78cba98f49fe6905a62b49f12e3dfd7cedea00616d1a5f50550db")
     version("2023.1", sha256="dff343b4a80c3a79363b805429bdb3320d3e1db48e0ff7d20a3dfd1c946a51ce")
@@ -235,7 +237,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
             depends_on("dla-future +cuda", when="+cuda")
             depends_on("dla-future +rocm", when="+rocm")
 
-        with when("@master"):
+        with when("@2024.2"):
             depends_on("dla-future-fortran@0.1.0:")
 
             # Use a direct dependency on dla-future so that constraints can be expressed
@@ -315,7 +317,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
     # from the parent class, since the parent class defines constraints for all
     # versions. Instead just mark all unsupported cuda archs as conflicting.
 
-    supported_cuda_arch_list = ("35", "37", "60", "70", "80")
+    supported_cuda_arch_list = ("35", "37", "60", "70", "80", "90")
     supported_rocm_arch_list = ("gfx906", "gfx908", "gfx90a", "gfx90a:xnack-", "gfx90a:xnack+")
     cuda_msg = "cp2k only supports cuda_arch {0}".format(supported_cuda_arch_list)
     rocm_msg = "cp2k only supports amdgpu_target {0}".format(supported_rocm_arch_list)

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -248,6 +248,11 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
             depends_on("dla-future +cuda", when="+cuda")
             depends_on("dla-future +rocm", when="+rocm")
 
+    conflicts(
+        "+plumed",
+        when="@:2024.1 build_system=cmake",
+        msg="PLUMED support is broken in cp2k@:2024.1 with CMake",
+    )
     with when("+plumed"):
         depends_on("plumed+shared")
         depends_on("plumed+mpi", when="+mpi")

--- a/var/spack/repos/builtin/packages/dbcsr/package.py
+++ b/var/spack/repos/builtin/packages/dbcsr/package.py
@@ -147,6 +147,7 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
             "-DLAPACK_LIBRARIES=%s" % (spec["lapack"].libs.joined(";")),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("WITH_EXAMPLES", "examples"),
+            self.define_from_variant("WITH_G2G", "g2g"),
         ]
 
         # Switch necessary as a result of a bug.

--- a/var/spack/repos/builtin/packages/dla-future-fortran/package.py
+++ b/var/spack/repos/builtin/packages/dla-future-fortran/package.py
@@ -31,6 +31,7 @@ class DlaFutureFortran(CMakePackage):
 
     generator("ninja")
     depends_on("cmake@3.22:", type="build")
+    depends_on("pkgconfig", type="build")
 
     depends_on("dla-future@0.4.1:0.5 +scalapack", when="@0.1.0")
     depends_on("dla-future@0.6.0: +scalapack", when="@0.2.0:")


### PR DESCRIPTION
Add CP2K version `2024.2`.

https://github.com/cp2k/cp2k/releases/tag/v2024.2

This PR also adds a missing CMake option that was supposed to be in #45501.