### PR TITLE
Remove `Compiler.PrgEnv*` attributes

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -280,8 +280,6 @@ class Compiler:
 
     # Cray PrgEnv name that can be used to load this compiler
     PrgEnv: Optional[str] = None
-    # Name of module used to switch versions of this compiler
-    PrgEnv_compiler: Optional[str] = None
 
     def __init__(
         self,

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -278,9 +278,6 @@ class Compiler:
     def opt_flags(self):
         return ["-O", "-O0", "-O1", "-O2", "-O3"]
 
-    # Cray PrgEnv name that can be used to load this compiler
-    PrgEnv: Optional[str] = None
-
     def __init__(
         self,
         cspec,

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -25,8 +25,6 @@ class Aocc(Compiler):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ["flang"]
 
-    PrgEnv = "PrgEnv-aocc"
-
     version_argument = "--version"
 
     @property

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -26,7 +26,6 @@ class Aocc(Compiler):
     fc_names = ["flang"]
 
     PrgEnv = "PrgEnv-aocc"
-    PrgEnv_compiler = "aocc"
 
     version_argument = "--version"
 

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -34,11 +34,9 @@ class Cce(Compiler):
     # MacPorts builds gcc versions with prefixes and -mp-X.Y suffixes.
     suffixes = [r"-mp-\d\.\d"]
 
-    PrgEnv = "PrgEnv-cray"
-
     @property
     def link_paths(self):
-        if any(self.PrgEnv in m for m in self.modules):
+        if any("PrgEnv-cray" in m for m in self.modules):
             # Old module-based interface to cray compilers
             return {
                 "cc": os.path.join("cce", "cc"),

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -35,7 +35,6 @@ class Cce(Compiler):
     suffixes = [r"-mp-\d\.\d"]
 
     PrgEnv = "PrgEnv-cray"
-    PrgEnv_compiler = "cce"
 
     @property
     def link_paths(self):

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -40,8 +40,6 @@ class Gcc(spack.compiler.Compiler):
         "fc": os.path.join("gcc", "gfortran"),
     }
 
-    PrgEnv = "PrgEnv-gnu"
-
     @property
     def verbose_flag(self):
         return "-v"

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -41,7 +41,6 @@ class Gcc(spack.compiler.Compiler):
     }
 
     PrgEnv = "PrgEnv-gnu"
-    PrgEnv_compiler = "gcc"
 
     @property
     def verbose_flag(self):

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -31,8 +31,6 @@ class Intel(Compiler):
         "fc": os.path.join("intel", "ifort"),
     }
 
-    PrgEnv = "PrgEnv-intel"
-
     if sys.platform == "win32":
         version_argument = "/QV"
     else:

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -32,7 +32,6 @@ class Intel(Compiler):
     }
 
     PrgEnv = "PrgEnv-intel"
-    PrgEnv_compiler = "intel"
 
     if sys.platform == "win32":
         version_argument = "/QV"

--- a/lib/spack/spack/compilers/nvhpc.py
+++ b/lib/spack/spack/compilers/nvhpc.py
@@ -30,7 +30,6 @@ class Nvhpc(Compiler):
     }
 
     PrgEnv = "PrgEnv-nvhpc"
-    PrgEnv_compiler = "nvhpc"
 
     version_argument = "--version"
     version_regex = r"nv[^ ]* (?:[^ ]+ Dev-r)?([0-9.]+)(?:-[0-9]+)?"

--- a/lib/spack/spack/compilers/nvhpc.py
+++ b/lib/spack/spack/compilers/nvhpc.py
@@ -29,8 +29,6 @@ class Nvhpc(Compiler):
         "fc": os.path.join("nvhpc", "nvfortran"),
     }
 
-    PrgEnv = "PrgEnv-nvhpc"
-
     version_argument = "--version"
     version_regex = r"nv[^ ]* (?:[^ ]+ Dev-r)?([0-9.]+)(?:-[0-9]+)?"
 

--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -33,7 +33,6 @@ class Oneapi(Compiler):
     }
 
     PrgEnv = "PrgEnv-oneapi"
-    PrgEnv_compiler = "oneapi"
 
     version_argument = "--version"
     version_regex = r"(?:(?:oneAPI DPC\+\+(?:\/C\+\+)? Compiler)|(?:\(IFORT\))|(?:\(IFX\))) (\S+)"

--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -32,8 +32,6 @@ class Oneapi(Compiler):
         "fc": os.path.join("oneapi", "ifx"),
     }
 
-    PrgEnv = "PrgEnv-oneapi"
-
     version_argument = "--version"
     version_regex = r"(?:(?:oneAPI DPC\+\+(?:\/C\+\+)? Compiler)|(?:\(IFORT\))|(?:\(IFX\))) (\S+)"
 

--- a/lib/spack/spack/compilers/pgi.py
+++ b/lib/spack/spack/compilers/pgi.py
@@ -30,8 +30,6 @@ class Pgi(Compiler):
         "fc": os.path.join("pgi", "pgfortran"),
     }
 
-    PrgEnv = "PrgEnv-pgi"
-
     version_argument = "-V"
     ignore_version_errors = [2]  # `pgcc -V` on PowerPC annoyingly returns 2
     version_regex = r"pg[^ ]* ([0-9.]+)-[0-9]+ (LLVM )?[^ ]+ target on "

--- a/lib/spack/spack/compilers/pgi.py
+++ b/lib/spack/spack/compilers/pgi.py
@@ -31,7 +31,6 @@ class Pgi(Compiler):
     }
 
     PrgEnv = "PrgEnv-pgi"
-    PrgEnv_compiler = "pgi"
 
     version_argument = "-V"
     ignore_version_errors = [2]  # `pgcc -V` on PowerPC annoyingly returns 2

--- a/lib/spack/spack/compilers/rocmcc.py
+++ b/lib/spack/spack/compilers/rocmcc.py
@@ -24,7 +24,6 @@ class Rocmcc(spack.compilers.clang.Clang):
     fc_names = ["amdflang"]
 
     PrgEnv = "PrgEnv-amd"
-    PrgEnv_compiler = "amd"
 
     @property
     def link_paths(self):

--- a/lib/spack/spack/compilers/rocmcc.py
+++ b/lib/spack/spack/compilers/rocmcc.py
@@ -23,8 +23,6 @@ class Rocmcc(spack.compilers.clang.Clang):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ["amdflang"]
 
-    PrgEnv = "PrgEnv-amd"
-
     @property
     def link_paths(self):
         link_paths = {


### PR DESCRIPTION
Removes a few attributes that are currently unused in the code