### PR TITLE
hipsycl: remove myself from maintainers

### DIFF
--- a/var/spack/repos/builtin/packages/hipsycl/package.py
+++ b/var/spack/repos/builtin/packages/hipsycl/package.py
@@ -19,8 +19,6 @@ class Hipsycl(CMakePackage):
     url = "https://github.com/illuhad/hipSYCL/archive/v0.8.0.tar.gz"
     git = "https://github.com/illuhad/hipSYCL.git"
 
-    maintainers("nazavode")
-
     provides("sycl")
 
     license("BSD-2-Clause")


### PR DESCRIPTION
This PR removes myself from this package maintainers. Not being a user of it anymore, it's becoming increasingly more difficult for me to ensure that this package is kept in a good order for downstream users.