### PR TITLE
hepmc3: add v3.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -20,6 +20,7 @@ class Hepmc3(CMakePackage):
 
     license("LGPL-3.0-or-later")
 
+    version("3.3.0", sha256="6f876091edcf7ee6d0c0db04e080056e89efc1a61abe62355d97ce8e735769d6")
     version("3.2.7", sha256="587faa6556cc54ccd89ad35421461b4761d7809bc17a2e72f5034daea142232b")
     version("3.2.6", sha256="248f3b5b36dd773844cbe73d51f60891458334b986b259754c59dbf4bbf1d525")
     version("3.2.5", sha256="cd0f75c80f75549c59cc2a829ece7601c77de97cb2a5ab75790cac8e1d585032")
@@ -79,7 +80,7 @@ class Hepmc3(CMakePackage):
 
         if spec.satisfies("+rootio"):
             args.append(self.define("ROOT_DIR", spec["root"].prefix))
-            if spec.satisfies("@3.2.4:"):
+            if spec.satisfies("@3.2.4:3.2"):
                 args.append(
                     self.define("HEPMC3_CXX_STANDARD", spec["root"].variants["cxxstd"].value)
                 )


### PR DESCRIPTION
This PR adds HepMC3 v3.3.0, which (as only relevant change) deduces the C++ standard that ROOT was built with, and uses it for the HepMC3 build. Since that is now provided by the package, we don't have to force the standard.

Test build:
```
==> Installing hepmc3-3.3.0-gocuipxl3qyy4imx3fafl4pbsaho7veo [75/75]
==> No binary for hepmc3-3.3.0-gocuipxl3qyy4imx3fafl4pbsaho7veo found: installing from source
==> Fetching https://gitlab.cern.ch/hepmc/HepMC3/-/archive/3.3.0/HepMC3-3.3.0.tar.gz
==> No patches needed for hepmc3
==> hepmc3: Executing phase: 'cmake'
==> hepmc3: Executing phase: 'build'
==> hepmc3: Executing phase: 'install'
==> hepmc3: Successfully installed hepmc3-3.3.0-gocuipxl3qyy4imx3fafl4pbsaho7veo
  Stage: 6.00s.  Cmake: 1.13s.  Build: 1m 4.62s.  Install: 0.12s.  Post-install: 0.33s.  Total: 1m 12.51s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/hepmc3-3.3.0-gocuipxl3qyy4imx3fafl4pbsaho7veo
```