### PR TITLE
odc: add v1.5.2

### DIFF
--- a/var/spack/repos/builtin/packages/odc/package.py
+++ b/var/spack/repos/builtin/packages/odc/package.py
@@ -12,7 +12,7 @@ class Odc(CMakePackage):
     homepage = "https://github.com/ecmwf/odc"
     url = "https://github.com/ecmwf/odc/archive/refs/tags/1.3.0.tar.gz"
 
-    maintainers("skosukhin")
+    maintainers("skosukhin", "climbfuji")
 
     license("Apache-2.0")
 

--- a/var/spack/repos/builtin/packages/odc/package.py
+++ b/var/spack/repos/builtin/packages/odc/package.py
@@ -16,6 +16,7 @@ class Odc(CMakePackage):
 
     license("Apache-2.0")
 
+    version("1.5.2", sha256="49575c3ef9ae8825d588357022d0ff6caf3e557849888c9d2f0677e9efe95869")
     version("1.4.6", sha256="ff99d46175e6032ddd0bdaa3f6a5e2c4729d24b698ba0191a2a4aa418f48867c")
     version("1.4.5", sha256="8532d0453531d62e1f15791d1c5c96540b842913bd211a8ef090211eaf4cccae")
     version("1.3.0", sha256="97a4f10765b341cc8ccbbf203f5559cb1b838cbd945f48d4cecb1bc4305e6cd6")


### PR DESCRIPTION
All in the title. I built odc@1.5.2 successfully on my development system (Oracle Linux 9.1) using gcc@13.3.0.

Also adding myself as maintainer for odc so that I can keep track of updates (managing this package in spack-stack for a few organizations).