### PR TITLE
root: fix X11 and OpenGL-related issues on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -413,7 +413,9 @@ class Root(CMakePackage):
     conflicts("target=ppc64le:", when="@:6.24")
 
     # Incompatible variants
-    if sys.platform != "darwin":
+    if sys.platform == "darwin":
+        conflicts("+opengl", when="~x ~aqua", msg="root+opengl requires X or Aqua")
+    else:
         conflicts("+opengl", when="~x", msg="root+opengl requires X")
     conflicts("+math", when="~gsl", msg="root+math requires GSL")
     conflicts("+tmva", when="~gsl", msg="root+tmva requires GSL")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -601,7 +601,7 @@ class Root(CMakePackage):
             define("builtin_freetype", False),
             define("builtin_ftgl", False),
             define("builtin_gl2ps", False),
-            define("builtin_glew", False),
+            define("builtin_glew", self.spec.satisfies("platform=darwin")),
             define("builtin_gsl", False),
             define("builtin_llvm", True),
             define("builtin_lz4", self.spec.satisfies("@6.12.02:6.12")),

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -329,6 +329,7 @@ class Root(CMakePackage):
     depends_on("gl2ps", when="+opengl")
     depends_on("gl", when="+opengl")
     depends_on("glu", when="+opengl")
+    depends_on("libglx", when="+opengl+x")
 
     # Qt4
     depends_on("qt@:4", when="+qt4")


### PR DESCRIPTION
We have been trying to build the Acts package on macOS, and in this process we have been running into problems with the ROOT spec on that operating system; the primary issue we are encountering is that the compiler is unable to find the `GL/glx.h` header, which is part of glx. It seems, therefore, that ROOT depends on libglx, but this is not currently encoded in the spec. This commit ensures that ROOT depends on the virtual libglx package when both the OpenGL and X11 variants are enabled.