### PR TITLE
llvm-amdgpu: conflict with macOS

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -75,6 +75,11 @@ class LlvmAmdgpu(CMakePackage, CompilerPackage):
     depends_on("ncurses+termlib", type="link")
     depends_on("pkgconfig", type="build")
 
+    # This flavour of LLVM doesn't work on MacOS, so we should ensure that it
+    # isn't used to satisfy any of the libllvm dependencies on the Darwin
+    # platform.
+    conflicts("platform=darwin")
+
     # OpenMP clang toolchain looks for bitcode files in llvm/bin/../lib
     # as per 5.2.0 llvm code. It used to be llvm/bin/../lib/libdevice.
     # Below patch is to look in the old path.


### PR DESCRIPTION
Currently, the llvm-amdgpu package doesn't compile on MacOS, but it is also not marked as a conflict. This causes problems because it seems that Spack is very happy to pull in llvm-amdgpu as the default package to satisfy any virtual libllvm dependency, which can cause dependent specs to fail to install on MacOS. This commit marks a conflict between this llvm package and the Darwin platform.