### PR TITLE
Forward some attributes from `Compiler` classes to packages

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -41,10 +41,6 @@ SPACK_ENV_PATH
 SPACK_DEBUG_LOG_DIR
 SPACK_DEBUG_LOG_ID
 SPACK_COMPILER_SPEC
-SPACK_CC_RPATH_ARG
-SPACK_CXX_RPATH_ARG
-SPACK_F77_RPATH_ARG
-SPACK_FC_RPATH_ARG
 SPACK_LINKER_ARG
 SPACK_SHORT_SPEC
 SPACK_SYSTEM_DIRS
@@ -277,6 +273,7 @@ fi
 command="${0##*/}"
 comp="CC"
 vcheck_flags=""
+rpath_var_name="SPACK_CC_RPATH_ARG"
 case "$command" in
     cpp)
         mode=cpp
@@ -287,6 +284,7 @@ case "$command" in
         command="$SPACK_CC"
         language="C"
         comp="CC"
+	rpath_var_name="SPACK_CC_RPATH_ARG"
         lang_flags=C
         debug_flags="-g"
         vcheck_flags="${SPACK_ALWAYS_CFLAGS}"
@@ -295,6 +293,7 @@ case "$command" in
         command="$SPACK_CXX"
         language="C++"
         comp="CXX"
+	rpath_var_name="SPACK_CXX_RPATH_ARG"
         lang_flags=CXX
         debug_flags="-g"
         vcheck_flags="${SPACK_ALWAYS_CXXFLAGS}"
@@ -303,6 +302,7 @@ case "$command" in
         command="$SPACK_FC"
         language="Fortran 90"
         comp="FC"
+	rpath_var_name="SPACK_FC_RPATH_ARG"
         lang_flags=F
         debug_flags="-g"
         vcheck_flags="${SPACK_ALWAYS_FFLAGS}"
@@ -311,6 +311,7 @@ case "$command" in
         command="$SPACK_F77"
         language="Fortran 77"
         comp="F77"
+	rpath_var_name="SPACK_F77_RPATH_ARG"
         lang_flags=F
         debug_flags="-g"
         vcheck_flags="${SPACK_ALWAYS_FFLAGS}"
@@ -322,6 +323,11 @@ case "$command" in
         die "Unknown compiler: $command"
         ;;
 esac
+
+if eval "test -z \"\${${rpath_var_name}:-}\""; then
+    die "Spack compiler must be run from Spack! Input '$rpath_var_name' is missing."
+fi
+
 
 # If any of the arguments below are present, then the mode is vcheck.
 # In vcheck mode, nothing is added in terms of extra search paths or

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -321,30 +321,33 @@ def set_compiler_environment_variables(pkg, env):
     # wrapper which will emit an error if it is used.
     if compiler.cc:
         env.set("SPACK_CC", compiler.cc)
+        env.set("SPACK_CC_RPATH_ARG", compiler.cc_rpath_arg)
         env.set("CC", os.path.join(link_dir, compiler.link_paths["cc"]))
     else:
         env.set("CC", os.path.join(link_dir, "cc"))
+
     if compiler.cxx:
         env.set("SPACK_CXX", compiler.cxx)
+        env.set("SPACK_CXX_RPATH_ARG", compiler.cxx_rpath_arg)
         env.set("CXX", os.path.join(link_dir, compiler.link_paths["cxx"]))
     else:
-        env.set("CC", os.path.join(link_dir, "c++"))
+        env.set("CXX", os.path.join(link_dir, "c++"))
+
     if compiler.f77:
         env.set("SPACK_F77", compiler.f77)
+        env.set("SPACK_F77_RPATH_ARG", compiler.f77_rpath_arg)
         env.set("F77", os.path.join(link_dir, compiler.link_paths["f77"]))
     else:
         env.set("F77", os.path.join(link_dir, "f77"))
+
     if compiler.fc:
         env.set("SPACK_FC", compiler.fc)
+        env.set("SPACK_FC_RPATH_ARG", compiler.fc_rpath_arg)
         env.set("FC", os.path.join(link_dir, compiler.link_paths["fc"]))
     else:
         env.set("FC", os.path.join(link_dir, "fc"))
 
     # Set SPACK compiler rpath flags so that our wrapper knows what to use
-    env.set("SPACK_CC_RPATH_ARG", compiler.cc_rpath_arg)
-    env.set("SPACK_CXX_RPATH_ARG", compiler.cxx_rpath_arg)
-    env.set("SPACK_F77_RPATH_ARG", compiler.f77_rpath_arg)
-    env.set("SPACK_FC_RPATH_ARG", compiler.fc_rpath_arg)
     env.set("SPACK_LINKER_ARG", compiler.linker_arg)
 
     # Check whether we want to force RPATH or RUNPATH

--- a/lib/spack/spack/build_systems/compiler.py
+++ b/lib/spack/spack/build_systems/compiler.py
@@ -7,7 +7,7 @@ import os
 import pathlib
 import re
 import sys
-from typing import Dict, List, Sequence, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import llnl.util.tty as tty
 from llnl.util.lang import classproperty
@@ -142,3 +142,6 @@ class CompilerPackage(spack.package_base.PackageBase):
     def determine_variants(cls, exes: Sequence[Path], version_str: str) -> Tuple:
         # path determination is separated so it can be reused in subclasses
         return "", {"compilers": cls.determine_compiler_paths(exes=exes)}
+
+    #: Returns the argument needed to set the RPATH, or None if it does not exist
+    rpath_arg: Optional[str] = "-Wl,-rpath,"

--- a/lib/spack/spack/build_systems/compiler.py
+++ b/lib/spack/spack/build_systems/compiler.py
@@ -5,6 +5,7 @@
 import itertools
 import os
 import pathlib
+import platform
 import re
 import sys
 from typing import Dict, List, Optional, Sequence, Tuple, Union
@@ -147,3 +148,15 @@ class CompilerPackage(spack.package_base.PackageBase):
     rpath_arg: Optional[str] = "-Wl,-rpath,"
     #: Flag that needs to be used to pass an argument to the linker
     linker_arg: str = "-Wl,"
+
+    @property
+    def disable_new_dtags(self) -> str:
+        if platform.system() == "Darwin":
+            return ""
+        return "--disable-new-dtags"
+
+    @property
+    def enable_new_dtags(self) -> str:
+        if platform.system() == "Darwin":
+            return ""
+        return "--enable-new-dtags"

--- a/lib/spack/spack/build_systems/compiler.py
+++ b/lib/spack/spack/build_systems/compiler.py
@@ -145,3 +145,5 @@ class CompilerPackage(spack.package_base.PackageBase):
 
     #: Returns the argument needed to set the RPATH, or None if it does not exist
     rpath_arg: Optional[str] = "-Wl,-rpath,"
+    #: Flag that needs to be used to pass an argument to the linker
+    linker_arg: str = "-Wl,"

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -274,7 +274,10 @@ class Compiler:
 
     @property
     def debug_flags(self):
-        return ["-g"]
+        try:
+            return ForwardToPackage(self).select("c").debug_flags
+        except AttributeError:
+            return []
 
     @property
     def opt_flags(self):
@@ -757,7 +760,10 @@ class ForwardToPackage:
 
     def __init__(self, compiler: Compiler) -> None:
         if compiler not in self._CACHE:
-            self._CACHE[compiler] = packages_from_compiler(compiler.to_dict())
+            try:
+                self._CACHE[compiler] = packages_from_compiler(compiler.to_dict())
+            except Exception as e:
+                raise RuntimeError(f"no compiler package matches {compiler}") from e
         self.packages = self._CACHE[compiler]
 
     def select(self, language: str) -> "spack.package_base.PackageBase":

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -6,7 +6,6 @@
 import contextlib
 import itertools
 import os
-import platform
 import re
 import shutil
 import sys
@@ -267,15 +266,11 @@ class Compiler:
 
     @property
     def disable_new_dtags(self):
-        if platform.system() == "Darwin":
-            return ""
-        return "--disable-new-dtags"
+        return ForwardToPackage(self).select("c").disable_new_dtags
 
     @property
     def enable_new_dtags(self):
-        if platform.system() == "Darwin":
-            return ""
-        return "--enable-new-dtags"
+        return ForwardToPackage(self).select("c").enable_new_dtags
 
     @property
     def debug_flags(self):

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -263,8 +263,7 @@ class Compiler:
 
     @property
     def linker_arg(self):
-        """Flag that need to be used to pass an argument to the linker."""
-        return "-Wl,"
+        return ForwardToPackage(self).select("c").linker_arg
 
     @property
     def disable_new_dtags(self):

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -704,29 +704,28 @@ class Compiler:
             os.environ.update(backup_env)
 
     def to_dict(self):
-        d = {}
-        d["spec"] = str(self.spec)
-        d["paths"] = dict((attr, getattr(self, attr, None)) for attr in PATH_INSTANCE_VARS)
-        d["flags"] = dict((fname, " ".join(fvals)) for fname, fvals in self.flags.items())
-        d["flags"].update(
-            dict(
-                (attr, getattr(self, attr, None))
-                for attr in FLAG_INSTANCE_VARS
-                if hasattr(self, attr)
-            )
+        flags_dict = {fname: " ".join(fvals) for fname, fvals in self.flags.items()}
+        flags_dict.update(
+            {attr: getattr(self, attr, None) for attr in FLAG_INSTANCE_VARS if hasattr(self, attr)}
         )
-        d["operating_system"] = str(self.operating_system)
-        d["target"] = str(self.target)
-        d["modules"] = self.modules or []
-        d["environment"] = self.environment or {}
-        d["extra_rpaths"] = self.extra_rpaths or []
+        result = {
+            "spec": str(self.spec),
+            "paths": {attr: getattr(self, attr, None) for attr in PATH_INSTANCE_VARS},
+            "flags": flags_dict,
+            "operating_system": str(self.operating_system),
+            "target": str(self.target),
+            "modules": self.modules or [],
+            "environment": self.environment or {},
+            "extra_rpaths": self.extra_rpaths or [],
+        }
+
         if self.enable_implicit_rpaths is not None:
-            d["implicit_rpaths"] = self.enable_implicit_rpaths
+            result["implicit_rpaths"] = self.enable_implicit_rpaths
 
         if self.alias:
-            d["alias"] = self.alias
+            result["alias"] = self.alias
 
-        return d
+        return result
 
 
 class CompilerAccessError(spack.error.SpackError):

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -281,7 +281,10 @@ class Compiler:
 
     @property
     def opt_flags(self):
-        return ["-O", "-O0", "-O1", "-O2", "-O3"]
+        try:
+            return ForwardToPackage(self).select("c").opt_flags
+        except AttributeError:
+            return []
 
     def __init__(
         self,

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -251,7 +251,7 @@ class Compiler:
 
     @property
     def cxx_rpath_arg(self):
-        return "-Wl,-rpath,"
+        return ForwardToPackage(self).select("cxx").rpath_arg
 
     @property
     def f77_rpath_arg(self):

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -255,11 +255,11 @@ class Compiler:
 
     @property
     def f77_rpath_arg(self):
-        return "-Wl,-rpath,"
+        return ForwardToPackage(self).select("fortran").rpath_arg
 
     @property
     def fc_rpath_arg(self):
-        return "-Wl,-rpath,"
+        return ForwardToPackage(self).select("fortran").rpath_arg
 
     @property
     def linker_arg(self):

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -30,7 +30,6 @@ import spack.version
 from spack.util.environment import get_path
 from spack.util.naming import mod_to_class
 
-PATH_INSTANCE_VARS = ["cc", "cxx", "f77", "fc"]
 _other_instance_vars = [
     "modules",
     "operating_system",
@@ -578,13 +577,15 @@ def compiler_from_dict(items):
     os = items.get("operating_system", None)
     target = items.get("target", None)
 
-    if not ("paths" in items and all(n in items["paths"] for n in PATH_INSTANCE_VARS)):
+    if not (
+        "paths" in items and all(n in items["paths"] for n in spack.compiler.PATH_INSTANCE_VARS)
+    ):
         raise InvalidCompilerConfigurationError(cspec)
 
     cls = class_for_compiler_name(cspec.name)
 
     compiler_paths = []
-    for c in PATH_INSTANCE_VARS:
+    for c in spack.compiler.PATH_INSTANCE_VARS:
         compiler_path = items["paths"][c]
         if compiler_path != "None":
             compiler_paths.append(compiler_path)
@@ -1067,9 +1068,9 @@ def is_mixed_toolchain(compiler):
 class InvalidCompilerConfigurationError(spack.error.SpackError):
     def __init__(self, compiler_spec):
         super().__init__(
-            'Invalid configuration for [compiler "%s"]: ' % compiler_spec,
-            "Compiler configuration must contain entries for all compilers: %s"
-            % PATH_INSTANCE_VARS,
+            f'Invalid configuration for [compiler "{compiler_spec}"]: ',
+            f"Compiler configuration must contain entries for "
+            f"all compilers: {spack.compiler.PATH_INSTANCE_VARS}",
         )
 
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -30,8 +30,7 @@ import spack.version
 from spack.util.environment import get_path
 from spack.util.naming import mod_to_class
 
-_path_instance_vars = ["cc", "cxx", "f77", "fc"]
-_flags_instance_vars = ["cflags", "cppflags", "cxxflags", "fflags"]
+PATH_INSTANCE_VARS = ["cc", "cxx", "f77", "fc"]
 _other_instance_vars = [
     "modules",
     "operating_system",
@@ -85,29 +84,7 @@ def _auto_compiler_spec(function):
 
 def _to_dict(compiler):
     """Return a dict version of compiler suitable to insert in YAML."""
-    d = {}
-    d["spec"] = str(compiler.spec)
-    d["paths"] = dict((attr, getattr(compiler, attr, None)) for attr in _path_instance_vars)
-    d["flags"] = dict((fname, " ".join(fvals)) for fname, fvals in compiler.flags.items())
-    d["flags"].update(
-        dict(
-            (attr, getattr(compiler, attr, None))
-            for attr in _flags_instance_vars
-            if hasattr(compiler, attr)
-        )
-    )
-    d["operating_system"] = str(compiler.operating_system)
-    d["target"] = str(compiler.target)
-    d["modules"] = compiler.modules or []
-    d["environment"] = compiler.environment or {}
-    d["extra_rpaths"] = compiler.extra_rpaths or []
-    if compiler.enable_implicit_rpaths is not None:
-        d["implicit_rpaths"] = compiler.enable_implicit_rpaths
-
-    if compiler.alias:
-        d["alias"] = compiler.alias
-
-    return {"compiler": d}
+    return {"compiler": compiler.to_dict()}
 
 
 def get_compiler_config(
@@ -601,13 +578,13 @@ def compiler_from_dict(items):
     os = items.get("operating_system", None)
     target = items.get("target", None)
 
-    if not ("paths" in items and all(n in items["paths"] for n in _path_instance_vars)):
+    if not ("paths" in items and all(n in items["paths"] for n in PATH_INSTANCE_VARS)):
         raise InvalidCompilerConfigurationError(cspec)
 
     cls = class_for_compiler_name(cspec.name)
 
     compiler_paths = []
-    for c in _path_instance_vars:
+    for c in PATH_INSTANCE_VARS:
         compiler_path = items["paths"][c]
         if compiler_path != "None":
             compiler_paths.append(compiler_path)
@@ -1092,7 +1069,7 @@ class InvalidCompilerConfigurationError(spack.error.SpackError):
         super().__init__(
             'Invalid configuration for [compiler "%s"]: ' % compiler_spec,
             "Compiler configuration must contain entries for all compilers: %s"
-            % _path_instance_vars,
+            % PATH_INSTANCE_VARS,
         )
 
 

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -28,19 +28,6 @@ class Aocc(Compiler):
     version_argument = "--version"
 
     @property
-    def debug_flags(self):
-        return [
-            "-gcodeview",
-            "-gdwarf-2",
-            "-gdwarf-3",
-            "-gdwarf-4",
-            "-gdwarf-5",
-            "-gline-tables-only",
-            "-gmodules",
-            "-g",
-        ]
-
-    @property
     def opt_flags(self):
         return ["-O0", "-O1", "-O2", "-O3", "-Ofast", "-Os", "-Oz", "-Og", "-O", "-O4"]
 

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -28,10 +28,6 @@ class Aocc(Compiler):
     version_argument = "--version"
 
     @property
-    def opt_flags(self):
-        return ["-O0", "-O1", "-O2", "-O3", "-Ofast", "-Os", "-Oz", "-Og", "-O", "-O4"]
-
-    @property
     def link_paths(self):
         link_paths = {
             "cc": os.path.join("aocc", "clang"),

--- a/lib/spack/spack/compilers/arm.py
+++ b/lib/spack/spack/compilers/arm.py
@@ -46,10 +46,6 @@ class Arm(spack.compiler.Compiler):
         return "-v"
 
     @property
-    def opt_flags(self):
-        return ["-O", "-O0", "-O1", "-O2", "-O3", "-Ofast"]
-
-    @property
     def openmp_flag(self):
         return "-fopenmp"
 

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -65,10 +65,6 @@ class Cce(Compiler):
         return "-v"
 
     @property
-    def debug_flags(self):
-        return ["-g", "-G0", "-G1", "-G2", "-Gfast"]
-
-    @property
     def openmp_flag(self):
         if self.is_clang_based:
             return "-fopenmp"

--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -46,19 +46,6 @@ class Clang(Compiler):
     version_argument = "--version"
 
     @property
-    def debug_flags(self):
-        return [
-            "-gcodeview",
-            "-gdwarf-2",
-            "-gdwarf-3",
-            "-gdwarf-4",
-            "-gdwarf-5",
-            "-gline-tables-only",
-            "-gmodules",
-            "-g",
-        ]
-
-    @property
     def opt_flags(self):
         return ["-O0", "-O1", "-O2", "-O3", "-Ofast", "-Os", "-Oz", "-Og", "-O", "-O4"]
 

--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -45,10 +45,6 @@ class Clang(Compiler):
 
     version_argument = "--version"
 
-    @property
-    def opt_flags(self):
-        return ["-O0", "-O1", "-O2", "-O3", "-Ofast", "-Os", "-Oz", "-Og", "-O", "-O4"]
-
     # Clang has support for using different fortran compilers with the
     # clang executable.
     @property

--- a/lib/spack/spack/compilers/fj.py
+++ b/lib/spack/spack/compilers/fj.py
@@ -39,10 +39,6 @@ class Fj(spack.compiler.Compiler):
         return "-v"
 
     @property
-    def opt_flags(self):
-        return ["-O0", "-O1", "-O2", "-O3", "-Ofast"]
-
-    @property
     def openmp_flag(self):
         return "-Kopenmp"
 

--- a/lib/spack/spack/compilers/fj.py
+++ b/lib/spack/spack/compilers/fj.py
@@ -39,10 +39,6 @@ class Fj(spack.compiler.Compiler):
         return "-v"
 
     @property
-    def debug_flags(self):
-        return "-g"
-
-    @property
     def opt_flags(self):
         return ["-O0", "-O1", "-O2", "-O3", "-Ofast"]
 

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -45,10 +45,6 @@ class Gcc(spack.compiler.Compiler):
         return "-v"
 
     @property
-    def opt_flags(self):
-        return ["-O", "-O0", "-O1", "-O2", "-O3", "-Os", "-Ofast", "-Og"]
-
-    @property
     def openmp_flag(self):
         return "-fopenmp"
 

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -45,10 +45,6 @@ class Gcc(spack.compiler.Compiler):
         return "-v"
 
     @property
-    def debug_flags(self):
-        return ["-g", "-gstabs+", "-gstabs", "-gxcoff+", "-gxcoff", "-gvms"]
-
-    @property
     def opt_flags(self):
         return ["-O", "-O0", "-O1", "-O2", "-O3", "-Os", "-Ofast", "-Og"]
 

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -48,10 +48,6 @@ class Intel(Compiler):
     required_libs = ["libirc", "libifcore", "libifcoremt", "libirng"]
 
     @property
-    def debug_flags(self):
-        return ["-debug", "-g", "-g0", "-g1", "-g2", "-g3"]
-
-    @property
     def opt_flags(self):
         return ["-O", "-O0", "-O1", "-O2", "-O3", "-Ofast", "-Os"]
 

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -48,10 +48,6 @@ class Intel(Compiler):
     required_libs = ["libirc", "libifcore", "libifcoremt", "libirng"]
 
     @property
-    def opt_flags(self):
-        return ["-O", "-O0", "-O1", "-O2", "-O3", "-Ofast", "-Os"]
-
-    @property
     def openmp_flag(self):
         if self.real_version < Version("16.0"):
             return "-openmp"

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -98,13 +98,3 @@ class Nag(spack.compiler.Compiler):
     @property
     def fc_pic_flag(self):
         return "-PIC"
-
-    @property
-    def disable_new_dtags(self):
-        # Disable RPATH/RUNPATH forcing for NAG/GCC mixed toolchains:
-        return ""
-
-    @property
-    def enable_new_dtags(self):
-        # Disable RPATH/RUNPATH forcing for NAG/GCC mixed toolchains:
-        return ""

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -78,10 +78,6 @@ class Nag(spack.compiler.Compiler):
         return "-openmp"
 
     @property
-    def debug_flags(self):
-        return ["-g", "-gline", "-g90"]
-
-    @property
     def opt_flags(self):
         return ["-O", "-O0", "-O1", "-O2", "-O3", "-O4"]
 

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -99,17 +99,6 @@ class Nag(spack.compiler.Compiler):
     def fc_pic_flag(self):
         return "-PIC"
 
-    # Unlike other compilers, the NAG compiler passes options to GCC, which
-    # then passes them to the linker. Therefore, we need to doubly wrap the
-    # options with '-Wl,-Wl,,'
-    @property
-    def f77_rpath_arg(self):
-        return "-Wl,-Wl,,-rpath,,"
-
-    @property
-    def fc_rpath_arg(self):
-        return "-Wl,-Wl,,-rpath,,"
-
     @property
     def linker_arg(self):
         return "-Wl,-Wl,,"

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -78,10 +78,6 @@ class Nag(spack.compiler.Compiler):
         return "-openmp"
 
     @property
-    def opt_flags(self):
-        return ["-O", "-O0", "-O1", "-O2", "-O3", "-O4"]
-
-    @property
     def cxx11_flag(self):
         # NAG does not have a C++ compiler
         # However, it can be mixed with a compiler that does support it

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -100,10 +100,6 @@ class Nag(spack.compiler.Compiler):
         return "-PIC"
 
     @property
-    def linker_arg(self):
-        return "-Wl,-Wl,,"
-
-    @property
     def disable_new_dtags(self):
         # Disable RPATH/RUNPATH forcing for NAG/GCC mixed toolchains:
         return ""

--- a/lib/spack/spack/compilers/nvhpc.py
+++ b/lib/spack/spack/compilers/nvhpc.py
@@ -37,10 +37,6 @@ class Nvhpc(Compiler):
         return "-v"
 
     @property
-    def opt_flags(self):
-        return ["-O", "-O0", "-O1", "-O2", "-O3", "-O4"]
-
-    @property
     def openmp_flag(self):
         return "-mp"
 

--- a/lib/spack/spack/compilers/nvhpc.py
+++ b/lib/spack/spack/compilers/nvhpc.py
@@ -37,10 +37,6 @@ class Nvhpc(Compiler):
         return "-v"
 
     @property
-    def debug_flags(self):
-        return ["-g", "-gopt"]
-
-    @property
     def opt_flags(self):
         return ["-O", "-O0", "-O1", "-O2", "-O3", "-O4"]
 

--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -53,10 +53,6 @@ class Oneapi(Compiler):
     ]
 
     @property
-    def debug_flags(self):
-        return ["-debug", "-g", "-g0", "-g1", "-g2", "-g3"]
-
-    @property
     def opt_flags(self):
         return ["-O", "-O0", "-O1", "-O2", "-O3", "-Ofast", "-Os"]
 

--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -53,10 +53,6 @@ class Oneapi(Compiler):
     ]
 
     @property
-    def opt_flags(self):
-        return ["-O", "-O0", "-O1", "-O2", "-O3", "-Ofast", "-Os"]
-
-    @property
     def openmp_flag(self):
         return "-fiopenmp"
 

--- a/lib/spack/spack/compilers/pgi.py
+++ b/lib/spack/spack/compilers/pgi.py
@@ -39,10 +39,6 @@ class Pgi(Compiler):
         return "-v"
 
     @property
-    def debug_flags(self):
-        return ["-g", "-gopt"]
-
-    @property
     def opt_flags(self):
         return ["-O", "-O0", "-O1", "-O2", "-O3", "-O4"]
 

--- a/lib/spack/spack/compilers/pgi.py
+++ b/lib/spack/spack/compilers/pgi.py
@@ -39,10 +39,6 @@ class Pgi(Compiler):
         return "-v"
 
     @property
-    def opt_flags(self):
-        return ["-O", "-O0", "-O1", "-O2", "-O3", "-O4"]
-
-    @property
     def openmp_flag(self):
         return "-mp"
 

--- a/lib/spack/spack/compilers/xl.py
+++ b/lib/spack/spack/compilers/xl.py
@@ -38,10 +38,6 @@ class Xl(Compiler):
         return "-V"
 
     @property
-    def debug_flags(self):
-        return ["-g", "-g0", "-g1", "-g2", "-g8", "-g9"]
-
-    @property
     def opt_flags(self):
         return ["-O", "-O0", "-O1", "-O2", "-O3", "-O4", "-O5", "-Ofast"]
 

--- a/lib/spack/spack/compilers/xl.py
+++ b/lib/spack/spack/compilers/xl.py
@@ -38,10 +38,6 @@ class Xl(Compiler):
         return "-V"
 
     @property
-    def opt_flags(self):
-        return ["-O", "-O0", "-O1", "-O2", "-O3", "-O4", "-O5", "-Ofast"]
-
-    @property
     def openmp_flag(self):
         return "-qsmp=omp"
 

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -292,7 +292,6 @@ def supported_flag_test(flag, flag_value_ref, spec=None):
 # Tests for UnsupportedCompilerFlag exceptions from default
 # implementations of flags.
 def test_default_flags():
-    supported_flag_test("cxx_rpath_arg", "-Wl,-rpath,")
     supported_flag_test("f77_rpath_arg", "-Wl,-rpath,")
     supported_flag_test("fc_rpath_arg", "-Wl,-rpath,")
     supported_flag_test("linker_arg", "-Wl,")
@@ -556,7 +555,6 @@ def test_nag_flags():
     supported_flag_test("cxx_pic_flag", "-fPIC", "nag@=1.0")
     supported_flag_test("f77_pic_flag", "-PIC", "nag@=1.0")
     supported_flag_test("fc_pic_flag", "-PIC", "nag@=1.0")
-    supported_flag_test("cxx_rpath_arg", "-Wl,-rpath,", "nag@=1.0")
     supported_flag_test("f77_rpath_arg", "-Wl,-Wl,,-rpath,,", "nag@=1.0")
     supported_flag_test("fc_rpath_arg", "-Wl,-Wl,,-rpath,,", "nag@=1.0")
     supported_flag_test("linker_arg", "-Wl,-Wl,,", "nag@=1.0")

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -294,7 +294,6 @@ def supported_flag_test(flag, flag_value_ref, spec=None):
 # Tests for UnsupportedCompilerFlag exceptions from default
 # implementations of flags.
 def test_default_flags():
-    supported_flag_test("linker_arg", "-Wl,")
     unsupported_flag_test("openmp_flag")
     unsupported_flag_test("cxx11_flag")
     unsupported_flag_test("cxx14_flag")

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -18,6 +18,8 @@ import spack.util.module_cmd
 from spack.compiler import Compiler
 from spack.util.executable import Executable, ProcessError
 
+pytestmark = pytest.mark.usefixtures("mock_compiler_forwarder")
+
 
 @pytest.fixture()
 def make_args_for_version(monkeypatch):
@@ -292,8 +294,6 @@ def supported_flag_test(flag, flag_value_ref, spec=None):
 # Tests for UnsupportedCompilerFlag exceptions from default
 # implementations of flags.
 def test_default_flags():
-    supported_flag_test("f77_rpath_arg", "-Wl,-rpath,")
-    supported_flag_test("fc_rpath_arg", "-Wl,-rpath,")
     supported_flag_test("linker_arg", "-Wl,")
     unsupported_flag_test("openmp_flag")
     unsupported_flag_test("cxx11_flag")

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -292,7 +292,6 @@ def supported_flag_test(flag, flag_value_ref, spec=None):
 # Tests for UnsupportedCompilerFlag exceptions from default
 # implementations of flags.
 def test_default_flags():
-    supported_flag_test("cc_rpath_arg", "-Wl,-rpath,")
     supported_flag_test("cxx_rpath_arg", "-Wl,-rpath,")
     supported_flag_test("f77_rpath_arg", "-Wl,-rpath,")
     supported_flag_test("fc_rpath_arg", "-Wl,-rpath,")
@@ -557,7 +556,6 @@ def test_nag_flags():
     supported_flag_test("cxx_pic_flag", "-fPIC", "nag@=1.0")
     supported_flag_test("f77_pic_flag", "-PIC", "nag@=1.0")
     supported_flag_test("fc_pic_flag", "-PIC", "nag@=1.0")
-    supported_flag_test("cc_rpath_arg", "-Wl,-rpath,", "nag@=1.0")
     supported_flag_test("cxx_rpath_arg", "-Wl,-rpath,", "nag@=1.0")
     supported_flag_test("f77_rpath_arg", "-Wl,-Wl,,-rpath,,", "nag@=1.0")
     supported_flag_test("fc_rpath_arg", "-Wl,-Wl,,-rpath,,", "nag@=1.0")

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -305,7 +305,6 @@ def test_default_flags():
     supported_flag_test("cxx_pic_flag", "-fPIC")
     supported_flag_test("f77_pic_flag", "-fPIC")
     supported_flag_test("fc_pic_flag", "-fPIC")
-    supported_flag_test("opt_flags", ["-O", "-O0", "-O1", "-O2", "-O3"])
 
 
 # Verify behavior of particular compiler definitions.

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -305,7 +305,6 @@ def test_default_flags():
     supported_flag_test("cxx_pic_flag", "-fPIC")
     supported_flag_test("f77_pic_flag", "-fPIC")
     supported_flag_test("fc_pic_flag", "-fPIC")
-    supported_flag_test("debug_flags", ["-g"])
     supported_flag_test("opt_flags", ["-O", "-O0", "-O1", "-O2", "-O3"])
 
 
@@ -470,7 +469,7 @@ def test_fj_flags():
     supported_flag_test("f77_pic_flag", "-KPIC", "fj@4.0.0")
     supported_flag_test("fc_pic_flag", "-KPIC", "fj@4.0.0")
     supported_flag_test("opt_flags", ["-O0", "-O1", "-O2", "-O3", "-Ofast"], "fj@4.0.0")
-    supported_flag_test("debug_flags", "-g", "fj@4.0.0")
+    supported_flag_test("debug_flags", ["-g"], "fj@4.0.0")
 
 
 def test_gcc_flags():

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -594,6 +594,8 @@ def _mock_init(self, compiler):
         spec.name = "intel-oneapi-compilers"
     elif spec.name == "intel":
         spec.name = "intel-oneapi-compilers-classic"
+    elif spec.name == "arm":
+        spec.name = "acfl"
 
     spec.external_path = prefix
     spec.extra_attributes = {

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -592,6 +592,8 @@ def _mock_init(self, compiler):
         spec.name = "llvm"
     elif spec.name == "oneapi":
         spec.name = "intel-oneapi-compilers"
+    elif spec.name == "intel":
+        spec.name = "intel-oneapi-compilers-classic"
 
     spec.external_path = prefix
     spec.extra_attributes = {

--- a/var/spack/repos/builtin/packages/acfl/package.py
+++ b/var/spack/repos/builtin/packages/acfl/package.py
@@ -317,6 +317,8 @@ class Acfl(Package, CompilerPackage):
         r"Arm C\/C\+\+\/Fortran Compiler version ([\d\.]+) \(build number \d+\) "
     )
 
+    opt_flags = ["-O", "-O0", "-O1", "-O2", "-O3", "-Ofast"]
+
     @property
     def cc(self):
         msg = "cannot retrieve C compiler [spec is not concrete]"

--- a/var/spack/repos/builtin/packages/aocc/package.py
+++ b/var/spack/repos/builtin/packages/aocc/package.py
@@ -121,3 +121,5 @@ class Aocc(Package, LlvmDetection, CompilerPackage):
         "-gmodules",
         "-g",
     ]
+
+    opt_flags = ["-O0", "-O1", "-O2", "-O3", "-Ofast", "-Os", "-Oz", "-Og", "-O", "-O4"]

--- a/var/spack/repos/builtin/packages/aocc/package.py
+++ b/var/spack/repos/builtin/packages/aocc/package.py
@@ -110,3 +110,14 @@ class Aocc(Package, LlvmDetection, CompilerPackage):
 
     compiler_version_regex = r"AOCC_(\d+[._]\d+[._]\d+)"
     fortran_names = ["flang"]
+
+    debug_flags = [
+        "-gcodeview",
+        "-gdwarf-2",
+        "-gdwarf-3",
+        "-gdwarf-4",
+        "-gdwarf-5",
+        "-gline-tables-only",
+        "-gmodules",
+        "-g",
+    ]

--- a/var/spack/repos/builtin/packages/cce/package.py
+++ b/var/spack/repos/builtin/packages/cce/package.py
@@ -21,8 +21,9 @@ class Cce(Package, CompilerPackage):
         r"[Cc]ray (?:clang|C :|C\+\+ :|Fortran :) [Vv]ersion.*?(\d+(?:\.\d+)+)"
     )
 
-    # notify when the package is updated.
     maintainers("becker33")
+
+    debug_flags = ["-g", "-G0", "-G1", "-G2", "-Gfast"]
 
     version("16.0.0")
 

--- a/var/spack/repos/builtin/packages/fj/package.py
+++ b/var/spack/repos/builtin/packages/fj/package.py
@@ -29,3 +29,4 @@ class Fj(Package, CompilerPackage):
     compiler_version_argument = "--version"
 
     debug_flags = ["-g"]
+    opt_flags = ["-O0", "-O1", "-O2", "-O3", "-Ofast"]

--- a/var/spack/repos/builtin/packages/fj/package.py
+++ b/var/spack/repos/builtin/packages/fj/package.py
@@ -27,3 +27,5 @@ class Fj(Package, CompilerPackage):
     fortran_names = ["frt"]
     compiler_version_regex = r"\((?:FCC|FRT)\) ([a-z\d.]+)"
     compiler_version_argument = "--version"
+
+    debug_flags = ["-g"]

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -539,6 +539,8 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     compiler_version_regex = r"(?<!clang version)\s?([0-9.]+)"
     compiler_version_argument = ("-dumpfullversion", "-dumpversion")
 
+    debug_flags = ["-g", "-gstabs+", "-gstabs", "-gxcoff+", "-gxcoff", "-gvms"]
+
     @classmethod
     def filter_detected_exes(cls, prefix, exes_in_prefix):
         # Apple's gcc is actually apple clang, so skip it.

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -540,6 +540,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     compiler_version_argument = ("-dumpfullversion", "-dumpversion")
 
     debug_flags = ["-g", "-gstabs+", "-gstabs", "-gxcoff+", "-gxcoff", "-gvms"]
+    opt_flags = ["-O", "-O0", "-O1", "-O2", "-O3", "-Os", "-Ofast", "-Og"]
 
     @classmethod
     def filter_detected_exes(cls, prefix, exes_in_prefix):

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
@@ -41,6 +41,8 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
             return r"([1-9][0-9]*\.[0-9]*\.[0-9]*)"
         return r"\((?:IFORT|ICC)\) ([^ ]+)"
 
+    debug_flags = ["-debug", "-g", "-g0", "-g1", "-g2", "-g3"]
+
     # Versions before 2021 are in the `intel` package
     # intel-oneapi versions before 2022 use intel@19.0.4
     for ver, oneapi_ver in {

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
@@ -42,6 +42,7 @@ class IntelOneapiCompilersClassic(Package, CompilerPackage):
         return r"\((?:IFORT|ICC)\) ([^ ]+)"
 
     debug_flags = ["-debug", "-g", "-g0", "-g1", "-g2", "-g3"]
+    opt_flags = ["-O", "-O0", "-O1", "-O2", "-O3", "-Ofast", "-Os"]
 
     # Versions before 2021 are in the `intel` package
     # intel-oneapi versions before 2022 use intel@19.0.4

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -270,6 +270,8 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
         r"(?:(?:oneAPI DPC\+\+(?:\/C\+\+)? Compiler)|(?:\(IFORT\))|(?:\(IFX\))) (\S+)"
     )
 
+    debug_flags = ["-debug", "-g", "-g0", "-g1", "-g2", "-g3"]
+
     # See https://github.com/spack/spack/issues/39252
     depends_on("patchelf@:0.17", type="build", when="@:2024.1")
     # Add the nvidia variant

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -271,6 +271,7 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
     )
 
     debug_flags = ["-debug", "-g", "-g0", "-g1", "-g2", "-g3"]
+    opt_flags = ["-O", "-O0", "-O1", "-O2", "-O3", "-Ofast", "-Os"]
 
     # See https://github.com/spack/spack/issues/39252
     depends_on("patchelf@:0.17", type="build", when="@:2024.1")

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -750,6 +750,17 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
             result = os.path.join(self.spec.prefix.bin, "flang")
         return result
 
+    debug_flags = [
+        "-gcodeview",
+        "-gdwarf-2",
+        "-gdwarf-3",
+        "-gdwarf-4",
+        "-gdwarf-5",
+        "-gline-tables-only",
+        "-gmodules",
+        "-g",
+    ]
+
     @property
     def libs(self):
         return LibraryList(self.llvm_config("--libfiles", "all", result="list"))

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -761,6 +761,8 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
         "-g",
     ]
 
+    opt_flags = ["-O0", "-O1", "-O2", "-O3", "-Ofast", "-Os", "-Oz", "-Og", "-O", "-O4"]
+
     @property
     def libs(self):
         return LibraryList(self.llvm_config("--libfiles", "all", result="list"))

--- a/var/spack/repos/builtin/packages/nag/package.py
+++ b/var/spack/repos/builtin/packages/nag/package.py
@@ -80,6 +80,7 @@ class Nag(Package, CompilerPackage):
     linker_arg = "-Wl,-Wl,,"
     disable_new_dtags = ""
     enable_new_dtags = ""
+    debug_flags = ["-g", "-gline", "-g90"]
 
     @property
     def fortran(self):

--- a/var/spack/repos/builtin/packages/nag/package.py
+++ b/var/spack/repos/builtin/packages/nag/package.py
@@ -78,6 +78,8 @@ class Nag(Package, CompilerPackage):
     # options with '-Wl,-Wl,,'
     rpath_arg = "-Wl,-Wl,,-rpath,,"
     linker_arg = "-Wl,-Wl,,"
+    disable_new_dtags = ""
+    enable_new_dtags = ""
 
     @property
     def fortran(self):

--- a/var/spack/repos/builtin/packages/nag/package.py
+++ b/var/spack/repos/builtin/packages/nag/package.py
@@ -73,6 +73,11 @@ class Nag(Package, CompilerPackage):
     compiler_version_regex = r"NAG Fortran Compiler Release (\d+).(\d+)\(.*\) Build (\d+)"
     compiler_version_argument = "-V"
 
+    # Unlike other compilers, the NAG compiler passes options to GCC, which
+    # then passes them to the linker. Therefore, we need to doubly wrap the
+    # options with '-Wl,-Wl,,'
+    rpath_arg = "-Wl,-Wl,,-rpath,,"
+
     @property
     def fortran(self):
         msg = "cannot retrieve Fortran compiler [spec is not concrete]"

--- a/var/spack/repos/builtin/packages/nag/package.py
+++ b/var/spack/repos/builtin/packages/nag/package.py
@@ -81,6 +81,7 @@ class Nag(Package, CompilerPackage):
     disable_new_dtags = ""
     enable_new_dtags = ""
     debug_flags = ["-g", "-gline", "-g90"]
+    opt_flags = ["-O", "-O0", "-O1", "-O2", "-O3", "-O4"]
 
     @property
     def fortran(self):

--- a/var/spack/repos/builtin/packages/nag/package.py
+++ b/var/spack/repos/builtin/packages/nag/package.py
@@ -77,6 +77,7 @@ class Nag(Package, CompilerPackage):
     # then passes them to the linker. Therefore, we need to doubly wrap the
     # options with '-Wl,-Wl,,'
     rpath_arg = "-Wl,-Wl,,-rpath,,"
+    linker_arg = "-Wl,-Wl,,"
 
     @property
     def fortran(self):

--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -453,6 +453,7 @@ class Nvhpc(Package, CompilerPackage):
     compiler_version_regex = r"nv[^ ]* (?:[^ ]+ Dev-r)?([0-9.]+)(?:-[0-9]+)?"
 
     debug_flags = ["-g", "-gopt"]
+    opt_flags = ["-O", "-O0", "-O1", "-O2", "-O3", "-O4"]
 
     @classmethod
     def determine_variants(cls, exes, version_str):

--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -452,6 +452,8 @@ class Nvhpc(Package, CompilerPackage):
     compiler_version_argument = "--version"
     compiler_version_regex = r"nv[^ ]* (?:[^ ]+ Dev-r)?([0-9.]+)(?:-[0-9]+)?"
 
+    debug_flags = ["-g", "-gopt"]
+
     @classmethod
     def determine_variants(cls, exes, version_str):
         # TODO: use other exes to determine default_cuda/install_type/blas/lapack/mpi variants

--- a/var/spack/repos/builtin/packages/pgi/package.py
+++ b/var/spack/repos/builtin/packages/pgi/package.py
@@ -66,6 +66,7 @@ class Pgi(Package, CompilerPackage):
     compiler_version_regex = r"pg[^ ]* ([0-9.]+)-[0-9]+ (?:LLVM )?[^ ]+ target on "
 
     debug_flags = ["-g", "-gopt"]
+    opt_flags = ["-O", "-O0", "-O1", "-O2", "-O3", "-O4"]
 
     def install(self, spec, prefix):
         # Enable the silent installation feature

--- a/var/spack/repos/builtin/packages/pgi/package.py
+++ b/var/spack/repos/builtin/packages/pgi/package.py
@@ -65,6 +65,8 @@ class Pgi(Package, CompilerPackage):
     compiler_version_argument = "-V"
     compiler_version_regex = r"pg[^ ]* ([0-9.]+)-[0-9]+ (?:LLVM )?[^ ]+ target on "
 
+    debug_flags = ["-g", "-gopt"]
+
     def install(self, spec, prefix):
         # Enable the silent installation feature
         os.environ["PGI_SILENT"] = "true"

--- a/var/spack/repos/builtin/packages/xl/package.py
+++ b/var/spack/repos/builtin/packages/xl/package.py
@@ -28,6 +28,8 @@ class Xl(Package, CompilerPackage):
     compiler_version_argument = "-qversion"
     compiler_version_regex = r"([0-9]?[0-9]\.[0-9])"
 
+    debug_flags = ["-g", "-g0", "-g1", "-g2", "-g8", "-g9"]
+
     @classmethod
     def determine_variants(cls, exes, version_str):
         _r_exes = [e for e in exes if e.endswith("_r")]

--- a/var/spack/repos/builtin/packages/xl/package.py
+++ b/var/spack/repos/builtin/packages/xl/package.py
@@ -29,6 +29,7 @@ class Xl(Package, CompilerPackage):
     compiler_version_regex = r"([0-9]?[0-9]\.[0-9])"
 
     debug_flags = ["-g", "-g0", "-g1", "-g2", "-g8", "-g9"]
+    opt_flags = ["-O", "-O0", "-O1", "-O2", "-O3", "-O4", "-O5", "-Ofast"]
 
     @classmethod
     def determine_variants(cls, exes, version_str):


### PR DESCRIPTION
In view of turning compiler into dependencies, we need to move some logic that is now part of Spack core into the corresponding packages. This PR introduces a class to forward requests from a `Compiler` object to a package.