### PR TITLE
etsf-io: make object relocatable

### DIFF
--- a/var/spack/repos/builtin/packages/etsf-io/package.py
+++ b/var/spack/repos/builtin/packages/etsf-io/package.py
@@ -32,6 +32,13 @@ class EtsfIo(Package):
     patch("tests_module.patch")
     patch("tests_init.patch")
 
+    def flag_handler(self, name, flags):
+        if name == "fflags":
+            flags.append(self.compiler.f77_pic_flag)
+        elif name == "fcflags":
+            flags.append(self.compiler.fc_pic_flag)
+        return flags, None, None
+
     def install(self, spec, prefix):
         options = ["--prefix=%s" % prefix]
         oapp = options.append


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Fixes errors like this:
```
/spack/opt/spack/linux-debian11-sandybridge/gcc-12.3.0/binutils-2.40-4fbnejarvo7chmfhnyfa55fk7n5nrouh/bin/ld: /spack/opt/spack/linux-debian11-sandybridge/gcc-12.3.0/etsf-io-1.0.4-d33ifmk5oidh6nqltk2hmda2wusrquhd/lib/libetsf_io.a(etsf_io.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
```

The upstream package doesn't support building shared libraries and has been abandoned about 9 years ago, so it doesn't see likely that support will ever be added.

For comparison, Debian also simply adds `-fPIC` to make it possible to link etsf-io into a shared library: https://salsa.debian.org/science-team/etsf-io/-/blob/master/debian/rules?ref_type=heads#L9