### PR TITLE
Windows: Update compilers\basics tests

### DIFF
--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -159,6 +159,7 @@ class MockCompiler(Compiler):
     required_libs = ["libgfortran"]
 
 
+@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_implicit_rpaths(dirs_with_libfiles):
     lib_to_dirs, all_dirs = dirs_with_libfiles
     compiler = MockCompiler()

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Test basic behavior of compilers in Spack"""
 import os
-from copy import copy
 import sys
+from copy import copy
 
 import pytest
 
@@ -713,10 +713,14 @@ def test_compiler_get_real_version(working_env, monkeypatch, tmpdir):
     test_version = "2.2.2"
 
     # Create compiler
-    content = """if "%CMP_ON%"=="1" (echo %CMP_VER%)""" if sys.platform == "win32" else """if [ "$CMP_ON" = "1" ]; then
+    content = (
+        """if "%CMP_ON%"=="1" (echo %CMP_VER%)""" 
+        if sys.platform == "win32" 
+        else """if [ "$CMP_ON" = "1" ]; then
     echo "$CMP_VER"
 fi
 """
+    )
     gcc = make_gcc_script(tmpdir, content)
 
     # Add compiler to config
@@ -797,10 +801,14 @@ def test_compiler_get_real_version_fails(working_env, monkeypatch, tmpdir):
     test_version = "2.2.2"
 
     # Create compiler
-    content = """if %CMP_ON%=="1" (echo %CMP_VER%)""" if sys.platform == "win32" else """if [ "$CMP_ON" = "1" ]; then
+    content = (
+        """if %CMP_ON%=="1" (echo %CMP_VER%)""" 
+        if sys.platform == "win32" 
+        else """if [ "$CMP_ON" = "1" ]; then
     echo "$CMP_VER"
 fi
 """
+    )
     gcc = make_gcc_script(tmpdir, content)
 
     # Add compiler to config

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -714,8 +714,8 @@ def test_compiler_get_real_version(working_env, monkeypatch, tmpdir):
 
     # Create compiler
     content = (
-        """if "%CMP_ON%"=="1" (echo %CMP_VER%)""" 
-        if sys.platform == "win32" 
+        """if "%CMP_ON%"=="1" (echo %CMP_VER%)"""
+        if sys.platform == "win32"
         else """if [ "$CMP_ON" = "1" ]; then
     echo "$CMP_VER"
 fi
@@ -802,8 +802,8 @@ def test_compiler_get_real_version_fails(working_env, monkeypatch, tmpdir):
 
     # Create compiler
     content = (
-        """if %CMP_ON%=="1" (echo %CMP_VER%)""" 
-        if sys.platform == "win32" 
+        """if %CMP_ON%=="1" (echo %CMP_VER%)"""
+        if sys.platform == "win32"
         else """if [ "$CMP_ON" = "1" ]; then
     echo "$CMP_VER"
 fi


### PR DESCRIPTION
- Adds Windows functionality to the compilers\basics.py tests as well as creates a helper function for the test gcc script

- Also removes a couple pytest not_on_windows markers

