### PR TITLE
harfbuzz: enable freetype in MesonBuilder

### DIFF
--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -81,6 +81,9 @@ class Harfbuzz(MesonPackage, AutotoolsPackage):
         description="Enable CoreText shaper backend on macOS",
     )
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     depends_on("pkgconfig", type="build")
     depends_on("glib")
     depends_on("gobject-introspection")

--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -11,7 +11,7 @@ class Harfbuzz(MesonPackage, AutotoolsPackage):
     """The Harfbuzz package contains an OpenType text shaping engine."""
 
     homepage = "https://github.com/harfbuzz/harfbuzz"
-    url = "https://github.com/harfbuzz/harfbuzz/releases/download/2.9.1/harfbuzz-2.9.1.tar.xz"
+    url = "https://github.com/harfbuzz/harfbuzz/releases/download/9.0.0/harfbuzz-9.0.0.tar.xz"
     git = "https://github.com/harfbuzz/harfbuzz.git"
 
     build_system(
@@ -23,6 +23,7 @@ class Harfbuzz(MesonPackage, AutotoolsPackage):
     version("9.0.0", sha256="a41b272ceeb920c57263ec851604542d9ec85ee3030506d94662067c7b6ab89e")
     version("8.5.0", sha256="77e4f7f98f3d86bf8788b53e6832fb96279956e1c3961988ea3d4b7ca41ddc27")
     version("8.4.0", sha256="af4ea73e25ab748c8c063b78c2f88e48833db9b2ac369e29bd115702e789755e")
+    version("8.3.1", sha256="f73e1eacd7e2ffae687bc3f056bb0c705b7a05aee86337686e09da8fc1c2030c")
     version("8.3.0", sha256="109501eaeb8bde3eadb25fab4164e993fbace29c3d775bcaa1c1e58e2f15f847")
     version("7.3.0", sha256="20770789749ac9ba846df33983dbda22db836c70d9f5d050cb9aa5347094a8fb")
     version("7.2.0", sha256="fc5560c807eae0efd5f95b5aa4c65800c7a8eed6642008a6b1e7e3ffff7873cc")
@@ -72,8 +73,12 @@ class Harfbuzz(MesonPackage, AutotoolsPackage):
         deprecated=True,
     )
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    variant("freetype", default=True, description="enable support for freetype font rendering")
+    variant(
+        "coretext",
+        default=True,
+        description="Enable FreeType font rendering",
+    )
 
     variant("graphite2", default=False, description="enable support for graphite2 font engine")
     variant(
@@ -134,11 +139,13 @@ class SetupEnvironment:
 
 class MesonBuilder(spack.build_systems.meson.MesonBuilder, SetupEnvironment):
     def meson_args(self):
+        freetype = "enabled" if self.pkg.spec.satisfies("+freetype") else "disabled"
         graphite2 = "enabled" if self.pkg.spec.satisfies("+graphite2") else "disabled"
         coretext = "enabled" if self.pkg.spec.satisfies("+coretext") else "disabled"
         return [
             # disable building of gtk-doc files following #9885 and #9771
             "-Ddocs=disabled",
+            f"-Dfreetype={freetype}",
             f"-Dgraphite2={graphite2}",
             f"-Dcoretext={coretext}",
         ]

--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -73,6 +73,9 @@ class Harfbuzz(MesonPackage, AutotoolsPackage):
         deprecated=True,
     )
 
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
     variant("graphite2", default=False, description="enable support for graphite2 font engine")
     variant(
         "coretext",
@@ -80,9 +83,6 @@ class Harfbuzz(MesonPackage, AutotoolsPackage):
         when="platform=darwin",
         description="Enable CoreText shaper backend on macOS",
     )
-
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
 
     depends_on("pkgconfig", type="build")
     depends_on("glib")

--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -74,11 +74,7 @@ class Harfbuzz(MesonPackage, AutotoolsPackage):
     )
 
     variant("freetype", default=True, description="enable support for freetype font rendering")
-    variant(
-        "coretext",
-        default=True,
-        description="Enable FreeType font rendering",
-    )
+    variant("coretext", default=True, description="Enable FreeType font rendering")
 
     variant("graphite2", default=False, description="enable support for graphite2 font engine")
     variant(

--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -73,9 +73,6 @@ class Harfbuzz(MesonPackage, AutotoolsPackage):
         deprecated=True,
     )
 
-    variant("freetype", default=True, description="enable support for freetype font rendering")
-    variant("coretext", default=True, description="Enable FreeType font rendering")
-
     variant("graphite2", default=False, description="enable support for graphite2 font engine")
     variant(
         "coretext",
@@ -135,13 +132,12 @@ class SetupEnvironment:
 
 class MesonBuilder(spack.build_systems.meson.MesonBuilder, SetupEnvironment):
     def meson_args(self):
-        freetype = "enabled" if self.pkg.spec.satisfies("+freetype") else "disabled"
         graphite2 = "enabled" if self.pkg.spec.satisfies("+graphite2") else "disabled"
         coretext = "enabled" if self.pkg.spec.satisfies("+coretext") else "disabled"
         return [
             # disable building of gtk-doc files following #9885 and #9771
             "-Ddocs=disabled",
-            f"-Dfreetype={freetype}",
+            "-Dfreetype=enabled",
             f"-Dgraphite2={graphite2}",
             f"-Dcoretext={coretext}",
         ]


### PR DESCRIPTION
harfbuzz: enable freetype in MesonBuilder to facilitate depends_on("freetype")

this fixes `hb-ft.h: No such file or directory` build errors for harfbuzz, and other packages like r-textshaping that have it as a dependency

---

resolves https://github.com/spack/spack/issues/43614

---

spack version:
- `0.22.1 (d66dce2d668a6234504594661506cdd1eaca4adc)`

arch / compiler:
- `linux-ubuntu22.04-sapphirerapids` / `gcc@13.2.0`

concretization (and install) succeeds for:
- `$ spack spec -I r@4.4.0 r-textshaping harfbuzz`

<details>

```
$ spack spec -I r@4.4.0 r-textshaping harfbuzz
Input spec
--------------------------------
 -   r@4.4.0

Concretized
--------------------------------
[+]  r@4.4.0%gcc@13.2.0~X~memory_profiling~rmath build_system=autotools patches=abc572d arch=linux-ubuntu22.04-sapphirerapids
[+]      ^bzip2@1.0.8%gcc@13.2.0~debug~pic+shared build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]          ^diffutils@3.10%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^libiconv@1.17%gcc@13.2.0 build_system=autotools libs=shared,static arch=linux-ubuntu22.04-sapphirerapids
[+]      ^curl@8.7.1%gcc@13.2.0~gssapi~ldap+libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-ubuntu22.04-sapphirerapids
[+]          ^libidn2@2.3.7%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^libunistring@1.2%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^nghttp2@1.57.0%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^openssl@3.3.0%gcc@13.2.0~docs+shared build_system=generic certs=mozilla arch=linux-ubuntu22.04-sapphirerapids
[+]              ^ca-certificates-mozilla@2023-05-30%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]          ^perl@5.38.0%gcc@13.2.0+cpanm+opcode+open+shared+threads build_system=generic patches=714e4d1 arch=linux-ubuntu22.04-sapphirerapids
[+]              ^berkeley-db@18.1.40%gcc@13.2.0+cxx~docs+stl build_system=autotools patches=26090f4,b231fcc arch=linux-ubuntu22.04-sapphirerapids
[+]              ^gdbm@1.23%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^pkgconf@2.2.0%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]      ^gcc-runtime@13.2.0%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[e]      ^glibc@2.35%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]      ^gmake@4.4.1%gcc@13.2.0~guile build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]      ^icu4c@67.1%gcc@13.2.0 build_system=autotools cxxstd=11 arch=linux-ubuntu22.04-sapphirerapids
[+]          ^python@3.11.7%gcc@13.2.0+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=13fa8bf,b0615b2,ebdca64,f2fd060 arch=linux-ubuntu22.04-sapphirerapids
[+]              ^expat@2.6.2%gcc@13.2.0+libbsd build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^libbsd@0.12.1%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                      ^libmd@1.0.4%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^libffi@3.4.6%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^libxcrypt@4.4.35%gcc@13.2.0~obsolete_api build_system=autotools patches=4885da3 arch=linux-ubuntu22.04-sapphirerapids
[+]              ^sqlite@3.43.2%gcc@13.2.0+column_metadata+dynamic_extensions+fts~functions+rtree build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^util-linux-uuid@2.38.1%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]      ^libtirpc@1.3.3%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^krb5@1.20.1%gcc@13.2.0+shared build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^bison@3.8.2%gcc@13.2.0~color build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^m4@1.4.19%gcc@13.2.0+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-ubuntu22.04-sapphirerapids
[+]                      ^libsigsegv@2.14%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^findutils@4.9.0%gcc@13.2.0 build_system=autotools patches=440b954 arch=linux-ubuntu22.04-sapphirerapids
[+]      ^ncurses@6.5%gcc@13.2.0~symlinks+termlib abi=none build_system=autotools patches=7a351bc arch=linux-ubuntu22.04-sapphirerapids
[+]      ^openblas@0.3.26%gcc@13.2.0~bignuma~consistent_fpcsr+dynamic_dispatch+fortran~ilp64+locking+pic+shared build_system=makefile symbol_suffix=none threads=none arch=linux-ubuntu22.04-sapphirerapids
[+]      ^openjdk@11.0.20.1_1%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]      ^pcre2@10.43%gcc@13.2.0~jit+multibyte build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]      ^readline@8.2%gcc@13.2.0 build_system=autotools patches=bbf97f1 arch=linux-ubuntu22.04-sapphirerapids
[+]      ^texinfo@7.0.3%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^gettext@0.22.5%gcc@13.2.0+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^libxml2@2.10.3%gcc@13.2.0+pic~python+shared build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^tar@1.34%gcc@13.2.0 build_system=autotools zip=pigz arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^pigz@2.8%gcc@13.2.0 build_system=makefile arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^zstd@1.5.6%gcc@13.2.0+programs build_system=makefile compression=none libs=shared,static arch=linux-ubuntu22.04-sapphirerapids
[+]      ^which@2.21%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]      ^xz@5.4.6%gcc@13.2.0~pic build_system=autotools libs=shared,static arch=linux-ubuntu22.04-sapphirerapids
[+]      ^zlib-ng@2.1.6%gcc@13.2.0+compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-ubuntu22.04-sapphirerapids

Input spec
--------------------------------
 -   r-textshaping

Concretized
--------------------------------
[+]  r-textshaping@0.3.6%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]      ^freetype@2.13.2%gcc@13.2.0+pic+shared build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^bzip2@1.0.8%gcc@13.2.0~debug~pic+shared build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]              ^diffutils@3.10%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^gmake@4.4.1%gcc@13.2.0~guile build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]          ^libpng@1.6.39%gcc@13.2.0~ipo~pic build_system=cmake build_type=Release generator=make libs=shared,static arch=linux-ubuntu22.04-sapphirerapids
[+]              ^cmake@3.27.9%gcc@13.2.0~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-ubuntu22.04-sapphirerapids
[+]          ^pkgconf@2.2.0%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]      ^fribidi@1.0.12%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^autoconf@2.72%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^perl@5.38.0%gcc@13.2.0+cpanm+opcode+open+shared+threads build_system=generic patches=714e4d1 arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^berkeley-db@18.1.40%gcc@13.2.0+cxx~docs+stl build_system=autotools patches=26090f4,b231fcc arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^gdbm@1.23%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^automake@1.16.5%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^libtool@2.4.7%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^findutils@4.9.0%gcc@13.2.0 build_system=autotools patches=440b954 arch=linux-ubuntu22.04-sapphirerapids
[+]          ^m4@1.4.19%gcc@13.2.0+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-ubuntu22.04-sapphirerapids
[+]              ^libsigsegv@2.14%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]      ^gcc-runtime@13.2.0%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[e]      ^glibc@2.35%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]      ^harfbuzz@9.0.0%gcc@13.2.0~coretext+freetype~graphite2~strip build_system=meson buildtype=release default_library=shared arch=linux-ubuntu22.04-sapphirerapids
[+]          ^cairo@1.16.0%gcc@13.2.0~X~fc+ft+gobject+pdf+pic~png+shared~svg build_system=autotools patches=7097196,7c4da77 arch=linux-ubuntu22.04-sapphirerapids
[+]              ^pixman@0.42.2%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^glib@2.78.3%gcc@13.2.0~libmount~strip build_system=meson buildtype=release default_library=shared tracing=none arch=linux-ubuntu22.04-sapphirerapids
[+]              ^elfutils@0.190%gcc@13.2.0~debuginfod+exeprefix+nls build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^zstd@1.5.6%gcc@13.2.0+programs build_system=makefile compression=none libs=shared,static arch=linux-ubuntu22.04-sapphirerapids
[+]              ^gettext@0.22.5%gcc@13.2.0+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^tar@1.34%gcc@13.2.0 build_system=autotools zip=pigz arch=linux-ubuntu22.04-sapphirerapids
[+]                      ^pigz@2.8%gcc@13.2.0 build_system=makefile arch=linux-ubuntu22.04-sapphirerapids
[+]              ^libffi@3.4.6%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^libiconv@1.17%gcc@13.2.0 build_system=autotools libs=shared,static arch=linux-ubuntu22.04-sapphirerapids
[+]              ^python@3.11.7%gcc@13.2.0+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=13fa8bf,b0615b2,ebdca64,f2fd060 arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^expat@2.6.2%gcc@13.2.0+libbsd build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                      ^libbsd@0.12.1%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                          ^libmd@1.0.4%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^libxcrypt@4.4.35%gcc@13.2.0~obsolete_api build_system=autotools patches=4885da3 arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^sqlite@3.43.2%gcc@13.2.0+column_metadata+dynamic_extensions+fts~functions+rtree build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^gobject-introspection@1.78.1%gcc@13.2.0~strip build_system=meson buildtype=release default_library=shared arch=linux-ubuntu22.04-sapphirerapids
[+]              ^bison@3.8.2%gcc@13.2.0~color build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^flex@2.6.3%gcc@13.2.0+lex~nls build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^icu4c@67.1%gcc@13.2.0 build_system=autotools cxxstd=11 arch=linux-ubuntu22.04-sapphirerapids
[+]          ^meson@1.3.2%gcc@13.2.0 build_system=python_pip patches=0f0b1bd arch=linux-ubuntu22.04-sapphirerapids
[+]              ^py-pip@23.1.2%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]              ^py-setuptools@69.2.0%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]              ^py-wheel@0.41.2%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]              ^python-venv@1.0%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]          ^ninja@1.11.1%gcc@13.2.0+re2c build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]              ^re2c@2.2%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]          ^zlib-ng@2.1.6%gcc@13.2.0+compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]      ^r@4.4.0%gcc@13.2.0~X~memory_profiling~rmath build_system=autotools patches=abc572d arch=linux-ubuntu22.04-sapphirerapids
[+]          ^curl@8.7.1%gcc@13.2.0~gssapi~ldap+libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-ubuntu22.04-sapphirerapids
[+]              ^libidn2@2.3.7%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^libunistring@1.2%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^nghttp2@1.57.0%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^openssl@3.3.0%gcc@13.2.0~docs+shared build_system=generic certs=mozilla arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^ca-certificates-mozilla@2023-05-30%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]          ^libtirpc@1.3.3%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^krb5@1.20.1%gcc@13.2.0+shared build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^ncurses@6.5%gcc@13.2.0~symlinks+termlib abi=none build_system=autotools patches=7a351bc arch=linux-ubuntu22.04-sapphirerapids
[+]          ^openblas@0.3.26%gcc@13.2.0~bignuma~consistent_fpcsr+dynamic_dispatch+fortran~ilp64+locking+pic+shared build_system=makefile symbol_suffix=none threads=none arch=linux-ubuntu22.04-sapphirerapids
[+]          ^openjdk@11.0.20.1_1%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]          ^pcre2@10.43%gcc@13.2.0~jit+multibyte build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^readline@8.2%gcc@13.2.0 build_system=autotools patches=bbf97f1 arch=linux-ubuntu22.04-sapphirerapids
[+]          ^texinfo@7.0.3%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^which@2.21%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^xz@5.4.6%gcc@13.2.0~pic build_system=autotools libs=shared,static arch=linux-ubuntu22.04-sapphirerapids
[+]      ^r-cpp11@0.4.3%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]      ^r-systemfonts@1.0.4%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]          ^fontconfig@2.15.0%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^font-util@1.4.0%gcc@13.2.0 build_system=autotools fonts=encodings,font-adobe-100dpi,font-adobe-75dpi,font-adobe-utopia-100dpi,font-adobe-utopia-75dpi,font-adobe-utopia-type1,font-alias,font-arabic-misc,font-bh-100dpi,font-bh-75dpi,font-bh-lucidatypewriter-100dpi,font-bh-lucidatypewriter-75dpi,font-bh-type1,font-bitstream-100dpi,font-bitstream-75dpi,font-bitstream-speedo,font-bitstream-type1,font-cronyx-cyrillic,font-cursor-misc,font-daewoo-misc,font-dec-misc,font-ibm-type1,font-isas-misc,font-jis-misc,font-micro-misc,font-misc-cyrillic,font-misc-ethiopic,font-misc-meltho,font-misc-misc,font-mutt-misc,font-schumacher-misc,font-screen-cyrillic,font-sun-misc,font-winitzki-cyrillic,font-xfree86-type1 arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^bdftopcf@1.1%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                      ^fontsproto@2.1.3%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                      ^libxfont@1.5.4%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                          ^xtrans@1.5.0%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                      ^xproto@7.0.31%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^mkfontdir@1.0.7%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^mkfontscale@1.2.3%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                      ^libfontenc@1.1.8%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^util-macros@1.19.3%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^gperf@3.1%gcc@13.2.0 build_system=autotools patches=3dd36db arch=linux-ubuntu22.04-sapphirerapids
[+]              ^libxml2@2.10.3%gcc@13.2.0+pic~python+shared build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^util-linux-uuid@2.38.1%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids

Input spec
--------------------------------
 -   harfbuzz

Concretized
--------------------------------
[+]  harfbuzz@9.0.0%gcc@13.2.0~coretext+freetype~graphite2~strip build_system=meson buildtype=release default_library=shared arch=linux-ubuntu22.04-sapphirerapids
[+]      ^cairo@1.16.0%gcc@13.2.0~X~fc+ft+gobject+pdf+pic~png+shared~svg build_system=autotools patches=7097196,7c4da77 arch=linux-ubuntu22.04-sapphirerapids
[+]          ^autoconf@2.72%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^automake@1.16.5%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^gmake@4.4.1%gcc@13.2.0~guile build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]          ^libtool@2.4.7%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^findutils@4.9.0%gcc@13.2.0 build_system=autotools patches=440b954 arch=linux-ubuntu22.04-sapphirerapids
[+]          ^m4@1.4.19%gcc@13.2.0+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-ubuntu22.04-sapphirerapids
[+]              ^diffutils@3.10%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^libsigsegv@2.14%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^pixman@0.42.2%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^which@2.21%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]      ^freetype@2.13.2%gcc@13.2.0+pic+shared build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^bzip2@1.0.8%gcc@13.2.0~debug~pic+shared build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]          ^libpng@1.6.39%gcc@13.2.0~ipo~pic build_system=cmake build_type=Release generator=make libs=shared,static arch=linux-ubuntu22.04-sapphirerapids
[+]              ^cmake@3.27.9%gcc@13.2.0~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^curl@8.7.1%gcc@13.2.0~gssapi~ldap+libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-ubuntu22.04-sapphirerapids
[+]                      ^libidn2@2.3.7%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                          ^libunistring@1.2%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                      ^nghttp2@1.57.0%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]      ^gcc-runtime@13.2.0%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]      ^glib@2.78.3%gcc@13.2.0~libmount~strip build_system=meson buildtype=release default_library=shared tracing=none arch=linux-ubuntu22.04-sapphirerapids
[+]          ^elfutils@0.190%gcc@13.2.0~debuginfod+exeprefix+nls build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^xz@5.4.6%gcc@13.2.0~pic build_system=autotools libs=shared,static arch=linux-ubuntu22.04-sapphirerapids
[+]              ^zstd@1.5.6%gcc@13.2.0+programs build_system=makefile compression=none libs=shared,static arch=linux-ubuntu22.04-sapphirerapids
[+]          ^gettext@0.22.5%gcc@13.2.0+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^libxml2@2.10.3%gcc@13.2.0+pic~python+shared build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^ncurses@6.5%gcc@13.2.0~symlinks+termlib abi=none build_system=autotools patches=7a351bc arch=linux-ubuntu22.04-sapphirerapids
[+]              ^tar@1.34%gcc@13.2.0 build_system=autotools zip=pigz arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^pigz@2.8%gcc@13.2.0 build_system=makefile arch=linux-ubuntu22.04-sapphirerapids
[+]          ^libffi@3.4.6%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^libiconv@1.17%gcc@13.2.0 build_system=autotools libs=shared,static arch=linux-ubuntu22.04-sapphirerapids
[+]          ^pcre2@10.43%gcc@13.2.0~jit+multibyte build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^perl@5.38.0%gcc@13.2.0+cpanm+opcode+open+shared+threads build_system=generic patches=714e4d1 arch=linux-ubuntu22.04-sapphirerapids
[+]              ^berkeley-db@18.1.40%gcc@13.2.0+cxx~docs+stl build_system=autotools patches=26090f4,b231fcc arch=linux-ubuntu22.04-sapphirerapids
[+]              ^gdbm@1.23%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^python@3.11.7%gcc@13.2.0+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=13fa8bf,b0615b2,ebdca64,f2fd060 arch=linux-ubuntu22.04-sapphirerapids
[+]              ^expat@2.6.2%gcc@13.2.0+libbsd build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^libbsd@0.12.1%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]                      ^libmd@1.0.4%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^libxcrypt@4.4.35%gcc@13.2.0~obsolete_api build_system=autotools patches=4885da3 arch=linux-ubuntu22.04-sapphirerapids
[+]              ^openssl@3.3.0%gcc@13.2.0~docs+shared build_system=generic certs=mozilla arch=linux-ubuntu22.04-sapphirerapids
[+]                  ^ca-certificates-mozilla@2023-05-30%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]              ^readline@8.2%gcc@13.2.0 build_system=autotools patches=bbf97f1 arch=linux-ubuntu22.04-sapphirerapids
[+]              ^sqlite@3.43.2%gcc@13.2.0+column_metadata+dynamic_extensions+fts~functions+rtree build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]              ^util-linux-uuid@2.38.1%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[e]      ^glibc@2.35%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]      ^gobject-introspection@1.78.1%gcc@13.2.0~strip build_system=meson buildtype=release default_library=shared arch=linux-ubuntu22.04-sapphirerapids
[+]          ^bison@3.8.2%gcc@13.2.0~color build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]          ^flex@2.6.3%gcc@13.2.0+lex~nls build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]      ^icu4c@67.1%gcc@13.2.0 build_system=autotools cxxstd=11 arch=linux-ubuntu22.04-sapphirerapids
[+]      ^meson@1.3.2%gcc@13.2.0 build_system=python_pip patches=0f0b1bd arch=linux-ubuntu22.04-sapphirerapids
[+]          ^py-pip@23.1.2%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]          ^py-setuptools@69.2.0%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]          ^py-wheel@0.41.2%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]          ^python-venv@1.0%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]      ^ninja@1.11.1%gcc@13.2.0+re2c build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]          ^re2c@2.2%gcc@13.2.0 build_system=generic arch=linux-ubuntu22.04-sapphirerapids
[+]      ^pkgconf@2.2.0%gcc@13.2.0 build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
[+]      ^zlib-ng@2.1.6%gcc@13.2.0+compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-ubuntu22.04-sapphirerapids
```

</details>