### PR TITLE
rocm-openmp-extras: Avoiding registration of duplicate check-targets and fix for the failure in hostexec

### DIFF
--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/0001-Avoid-duplicate-registration-on-cuda-env.patch
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/0001-Avoid-duplicate-registration-on-cuda-env.patch
@@ -1,0 +1,26 @@
+From 518621c818c285d8b5d11f56c331243b985d7654 Mon Sep 17 00:00:00 2001
+From: Renjith Ravindran <Renjith.RavindranKannath@amd.com>
+Date: Fri, 9 Aug 2024 22:04:55 +0000
+Subject: [PATCH] Avoiding registration of duplicate when built on cuda
+ environemnt
+
+---
+ .../openmp/libomptarget/plugins/cuda/CMakeLists.txt             | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/rocm-openmp-extras/llvm-project/openmp/libomptarget/plugins/cuda/CMakeLists.txt b/rocm-openmp-extras/llvm-project/openmp/libomptarget/plugins/cuda/CMakeLists.txt
+index 9b991c735..f21cccdd5 100644
+--- a/rocm-openmp-extras/llvm-project/openmp/libomptarget/plugins/cuda/CMakeLists.txt
++++ b/rocm-openmp-extras/llvm-project/openmp/libomptarget/plugins/cuda/CMakeLists.txt
+@@ -102,8 +102,6 @@ target_include_directories(omptarget.rtl.cuda PRIVATE
+ option(LIBOMPTARGET_FORCE_NVIDIA_TESTS "Build NVIDIA libomptarget tests" OFF)
+ if (LIBOMPTARGET_FOUND_NVIDIA_GPU OR LIBOMPTARGET_FORCE_NVIDIA_TESTS)
+   libomptarget_say("Enable tests using CUDA plugin")
+-  set(LIBOMPTARGET_SYSTEM_TARGETS "${LIBOMPTARGET_SYSTEM_TARGETS} nvptx64-nvidia-cuda nvptx64-nvidia-cuda-oldDriver" PARENT_SCOPE)
+-  set(LIBOMPTARGET_SYSTEM_TARGETS "${LIBOMPTARGET_SYSTEM_TARGETS} nvptx64-nvidia-cuda nvptx64-nvidia-cuda-LTO" PARENT_SCOPE)
+   list(APPEND LIBOMPTARGET_TESTED_PLUGINS "omptarget.rtl.cuda")
+   set(LIBOMPTARGET_TESTED_PLUGINS "${LIBOMPTARGET_TESTED_PLUGINS}" PARENT_SCOPE)
+ else()
+-- 
+2.34.1
+

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -309,6 +309,8 @@ class RocmOpenmpExtras(Package):
         llvm_prefix = self.spec["llvm-amdgpu"].prefix
         env.set("AOMP", "{0}".format(llvm_prefix))
         env.set("FC", "{0}/bin/flang".format(openmp_extras_prefix))
+        if self.spec.satisfies("@5.3.0:"):
+            env.prepend_path("LD_LIBRARY_PATH", self.spec["rocm-openmp-extras"].prefix.lib)
         if self.spec.satisfies("+asan"):
             env.set("SANITIZER", 1)
             env.set("VERBOSE", 1)

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -288,6 +288,7 @@ class RocmOpenmpExtras(Package):
         working_dir="rocm-openmp-extras/llvm-project/openmp/libomptarget",
         when="@6.1",
     )
+    patch("0001-Avoid-duplicate-registration-on-cuda-env.patch", when="@6.1:")
 
     def setup_run_environment(self, env):
         devlibs_prefix = self.spec["llvm-amdgpu"].prefix

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -309,8 +309,8 @@ class RocmOpenmpExtras(Package):
         llvm_prefix = self.spec["llvm-amdgpu"].prefix
         env.set("AOMP", "{0}".format(llvm_prefix))
         env.set("FC", "{0}/bin/flang".format(openmp_extras_prefix))
-        if self.spec.satisfies("@5.3.0:"):
-            env.prepend_path("LD_LIBRARY_PATH", self.spec["rocm-openmp-extras"].prefix.lib)
+        if self.spec.satisfies("@6.1:"):
+            env.prepend_path("LD_LIBRARY_PATH", self.spec["hsa-rocr-dev"].prefix.lib)
         if self.spec.satisfies("+asan"):
             env.set("SANITIZER", 1)
             env.set("VERBOSE", 1)

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -547,9 +547,6 @@ class RocmOpenmpExtras(Package):
         if self.spec.satisfies("@5.3.0:"):
             openmp_common_args += ["-DLIBOMPTARGET_ENABLE_DEBUG=ON"]
 
-        if self.spec.satisfies("@6.1:"):
-            openmp_common_args += ["-DLIBOMPTARGET_BUILD_CUDA_PLUGIN=OFF"]
-
         components["openmp"] = ["../rocm-openmp-extras/llvm-project/openmp"]
         components["openmp"] += openmp_common_args
 

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -546,6 +546,9 @@ class RocmOpenmpExtras(Package):
         if self.spec.satisfies("@5.3.0:"):
             openmp_common_args += ["-DLIBOMPTARGET_ENABLE_DEBUG=ON"]
 
+        if self.spec.satisfies("@6.1:"):
+            openmp_common_args += ["-DLIBOMPTARGET_BUILD_CUDA_PLUGIN=OFF"]
+
         components["openmp"] = ["../rocm-openmp-extras/llvm-project/openmp"]
         components["openmp"] += openmp_common_args
 

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -437,6 +437,13 @@ class RocmOpenmpExtras(Package):
             flang.format(src) + "CMakeLists.txt",
         )
 
+        filter_file(
+            "if (LIBOMPTARGET_DEP_CUDA_FOUND)",
+            "if (LIBOMPTARGET_DEP_CUDA_FOUND AND NOT LIBOMPTARGET_AMDGPU_ARCH)",
+            libomptarget.format(src) + "/hostexec/CMakeLists.txt",
+            string=True,
+        )
+
     def install(self, spec, prefix):
         src = self.stage.source_path
         gfx_list = os.environ["GFXLIST"]


### PR DESCRIPTION
Avoiding registration of duplicate check-targets and fix for the failure in hostexec due to a mismatch of older nvptx archs trying to be compiled with newer features.