### PR TITLE
apfel: add v3.1.1 (now CMakePackage)

### DIFF
--- a/var/spack/repos/builtin/packages/apfel/package.py
+++ b/var/spack/repos/builtin/packages/apfel/package.py
@@ -43,7 +43,7 @@ class Apfel(AutotoolsPackage, CMakePackage):
     variant("lhapdf", description="Link to LHAPDF", default=False)
 
 
-class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         args = [
             self.define_from_variant("APFEL_ENABLE_PYTHON", "python"),
@@ -55,7 +55,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         return args
 
 
-class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
+class AutotoolsBuilder(autotools.AutotoolsBuilder):
     def configure_args(self):
         args = []
         args += self.enable_or_disable("pywrap", variant="python")

--- a/var/spack/repos/builtin/packages/apfel/package.py
+++ b/var/spack/repos/builtin/packages/apfel/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Apfel(AutotoolsPackage):
+class Apfel(AutotoolsPackage, CMakePackage):
     """APFEL is a library able to perform DGLAP evolution up to NNLO in QCD and
     to NLO in QED, both with pole and MSbar masses. The coupled DGLAP
     QCD+QED evolution equations are solved in x-space by means of higher
@@ -19,25 +19,41 @@ class Apfel(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
+    build_system(
+        conditional("autotools", when="@:3.0"),
+        conditional("cmake", when="@3.1:"),
+        default="cmake",
+    )
+
+    version("3.1.1", sha256="9006b2a9544e504e8f6b5047f665054151870c3c3a4a05db3d4fb46f21908d4b")
     version("3.0.6", sha256="7063c9eee457e030b97926ac166cdaedd84625b31397e1dfd01ae47371fb9f61")
     version("3.0.4", sha256="c7bfae7fe2dc0185981850f2fe6ae4842749339d064c25bf525b4ef412bbb224")
 
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+
+    with when("build_system=cmake"):
+        depends_on("cmake@03.15:")
 
     depends_on("swig", when="+python")
-    depends_on("python", type=("build", "run"))
+    depends_on("python", when="+python", type=("build", "run"))
     depends_on("lhapdf", when="+lhapdf", type=("build", "run"))
 
     variant("python", description="Build python wrapper", default=False)
     variant("lhapdf", description="Link to LHAPDF", default=False)
 
-    def configure_args(self):
-        args = []
-        if self.spec.satisfies("~python"):
-            args.append("--disable-pywrap")
-        else:
-            args.append("--enable-pywrap")
+class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("APFEL_ENABLE_PYTHON", "python"),
+            self.define_from_variant("APFEL_ENABLE_LHAPDF", "lhapdf"),
+        ]
+        return args
 
-        args += self.enable_or_disable("lhapdf")
+class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
+    def configure_args(self):
+        args = [
+            self.enable_or_disable("pywrap", variant="python"),
+            self.enable_or_disable("lhapdf"),
+        ]
         return args

--- a/var/spack/repos/builtin/packages/apfel/package.py
+++ b/var/spack/repos/builtin/packages/apfel/package.py
@@ -20,9 +20,7 @@ class Apfel(AutotoolsPackage, CMakePackage):
     license("GPL-3.0-or-later")
 
     build_system(
-        conditional("autotools", when="@:3.0"),
-        conditional("cmake", when="@3.1:"),
-        default="cmake",
+        conditional("autotools", when="@:3.0"), conditional("cmake", when="@3.1:"), default="cmake"
     )
 
     version("3.1.1", sha256="9006b2a9544e504e8f6b5047f665054151870c3c3a4a05db3d4fb46f21908d4b")
@@ -43,6 +41,7 @@ class Apfel(AutotoolsPackage, CMakePackage):
     variant("python", description="Build python wrapper", default=False)
     variant("lhapdf", description="Link to LHAPDF", default=False)
 
+
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):
         args = [
@@ -53,6 +52,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         if self.spec.satisfies("+python"):
             args.append(self.define("APFEL_Python_SITEARCH", "autoprefix"))
         return args
+
 
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/apfel/package.py
+++ b/var/spack/repos/builtin/packages/apfel/package.py
@@ -52,8 +52,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
 
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
     def configure_args(self):
-        args = [
-            self.enable_or_disable("pywrap", variant="python"),
-            self.enable_or_disable("lhapdf"),
-        ]
+        args = []
+        args += self.enable_or_disable("pywrap", variant="python")
+        args += self.enable_or_disable("lhapdf")
         return args

--- a/var/spack/repos/builtin/packages/apfel/package.py
+++ b/var/spack/repos/builtin/packages/apfel/package.py
@@ -35,6 +35,7 @@ class Apfel(AutotoolsPackage, CMakePackage):
     with when("build_system=cmake"):
         depends_on("cmake@03.15:")
 
+    extends("python", when="+python")
     depends_on("swig", when="+python")
     depends_on("python", when="+python", type=("build", "run"))
     depends_on("lhapdf", when="+lhapdf", type=("build", "run"))
@@ -48,6 +49,9 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             self.define_from_variant("APFEL_ENABLE_PYTHON", "python"),
             self.define_from_variant("APFEL_ENABLE_LHAPDF", "lhapdf"),
         ]
+        # ensure installation of python module under CMAKE_INSTALL_PREFIX
+        if self.spec.satisfies("+python"):
+            args.append(self.define("APFEL_Python_SITEARCH", "autoprefix"))
         return args
 
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):

--- a/var/spack/repos/builtin/packages/apfel/package.py
+++ b/var/spack/repos/builtin/packages/apfel/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems import autotools, cmake
 from spack.package import *
 
 


### PR DESCRIPTION
This PR adds apfel v3.1.1, which now uses CMake as a build system (release notes for [3.1.0](https://github.com/scarrazza/apfel/releases/tag/3.1.0)). No other changes to variants or dependencies.

Test builds:
```console
$ spack find -lv apfel
-- linux-ubuntu24.04-skylake / gcc@13.2.0 -----------------------
oxfk4j3 apfel@3.0.6+lhapdf+python build_system=autotools
p5vksv6 apfel@3.1.1~ipo+lhapdf+python build_system=cmake build_type=Release generator=make
n2vvide apfel@3.1.1~ipo~lhapdf~python build_system=cmake build_type=Release generator=make
```
with correct python installation prefix
```console
$ ls $(spack location -i /p5vksv6)/lib/python3.10/site-packages/apfel
apfel.py  _apfel.so
```