### PR TITLE
catch2: add v3.5.4, v3.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/catch2/package.py
+++ b/var/spack/repos/builtin/packages/catch2/package.py
@@ -34,11 +34,13 @@ class Catch2(CMakePackage):
     version("3.1.0", sha256="c252b2d9537e18046d8b82535069d2567f77043f8e644acf9a9fffc22ea6e6f7")
     version("3.0.1", sha256="8c4173c68ae7da1b5b505194a0c2d6f1b2aef4ec1e3e7463bde451f26bbaf4e7")
     version(
-        "3.0.0-preview4", sha256="2458d47d923b65ab611656cb7669d1810bcc4faa62e4c054a7405b1914cd4aee",
+        "3.0.0-preview4",
+        sha256="2458d47d923b65ab611656cb7669d1810bcc4faa62e4c054a7405b1914cd4aee",
         deprecated=True,
     )
     version(
-        "3.0.0-preview3", sha256="06a4f903858f21c553e988f8b76c9c6915d1f95f95512d6a58c421e02a2c4975",
+        "3.0.0-preview3",
+        sha256="06a4f903858f21c553e988f8b76c9c6915d1f95f95512d6a58c421e02a2c4975",
         deprecated=True,
     )
     version("2.13.10", sha256="d54a712b7b1d7708bc7a819a8e6e47b2fde9536f487b89ccbca295072a7d9943")

--- a/var/spack/repos/builtin/packages/catch2/package.py
+++ b/var/spack/repos/builtin/packages/catch2/package.py
@@ -22,6 +22,8 @@ class Catch2(CMakePackage):
     version("develop", branch="devel")
 
     # Releases
+    version("3.6.0", sha256="485932259a75c7c6b72d4b874242c489ea5155d17efa345eb8cc72159f49f356")
+    version("3.5.4", sha256="b7754b711242c167d8f60b890695347f90a1ebc95949a045385114165d606dbb")
     version("3.4.0", sha256="122928b814b75717316c71af69bd2b43387643ba076a6ec16e7882bfb2dfacbb")
     version("3.3.2", sha256="8361907f4d9bff3ae7c1edb027f813659f793053c99b67837a0c0375f065bae2")
     version("3.3.1", sha256="d90351cdc55421f640c553cfc0875a8c834428679444e8062e9187d05b18aace")
@@ -32,10 +34,12 @@ class Catch2(CMakePackage):
     version("3.1.0", sha256="c252b2d9537e18046d8b82535069d2567f77043f8e644acf9a9fffc22ea6e6f7")
     version("3.0.1", sha256="8c4173c68ae7da1b5b505194a0c2d6f1b2aef4ec1e3e7463bde451f26bbaf4e7")
     version(
-        "3.0.0-preview4", sha256="2458d47d923b65ab611656cb7669d1810bcc4faa62e4c054a7405b1914cd4aee"
+        "3.0.0-preview4", sha256="2458d47d923b65ab611656cb7669d1810bcc4faa62e4c054a7405b1914cd4aee",
+        deprecated=True,
     )
     version(
-        "3.0.0-preview3", sha256="06a4f903858f21c553e988f8b76c9c6915d1f95f95512d6a58c421e02a2c4975"
+        "3.0.0-preview3", sha256="06a4f903858f21c553e988f8b76c9c6915d1f95f95512d6a58c421e02a2c4975",
+        deprecated=True,
     )
     version("2.13.10", sha256="d54a712b7b1d7708bc7a819a8e6e47b2fde9536f487b89ccbca295072a7d9943")
     version("2.13.9", sha256="06dbc7620e3b96c2b69d57bf337028bf245a211b3cddb843835bfe258f427a52")


### PR DESCRIPTION
This PR adds two newer minor releases (at latest patch release) for catch2: v3.5.4 and v3.6.0 ([diff between latest and newest](https://github.com/catchorg/Catch2/compare/v3.4.0...v3.6.0)). No changes in CMakeLists.txt that need to be propagated.

Also marked two older v3 release preview versions as deprecated.

Test build:
```
==> Installing catch2-3.6.0-fmqgsxqjuzpwad3iq66y5yd2iw7cafva [10/10]
==> No binary for catch2-3.6.0-fmqgsxqjuzpwad3iq66y5yd2iw7cafva found: installing from source
==> Fetching https://github.com/catchorg/Catch2/archive/refs/tags/v3.6.0.tar.gz
==> Ran patch() for catch2
==> catch2: Executing phase: 'cmake'
==> catch2: Executing phase: 'build'
==> catch2: Executing phase: 'install'
==> catch2: Successfully installed catch2-3.6.0-fmqgsxqjuzpwad3iq66y5yd2iw7cafva
  Stage: 2.27s.  Cmake: 0.25s.  Build: 20.24s.  Install: 0.12s.  Post-install: 0.15s.  Total: 23.10s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/catch2-3.6.0-fmqgsxqjuzpwad3iq66y5yd2iw7cafva
```