### PR TITLE
libdrm: add  v2.4.121, v2.4.122 (switch to multiple build systems)

### DIFF
--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -54,7 +54,7 @@ class Libdrm(AutotoolsPackage, MesonPackage):
     build_system(
         conditional("meson", when="@2.4.101:"),
         conditional("autotools", when="@:2.4.100"),
-        default="meson"
+        default="meson",
     )
 
     with when("build_system=meson"):
@@ -77,6 +77,7 @@ class Libdrm(AutotoolsPackage, MesonPackage):
         else:
             return self.list_url + "libdrm-%s.tar.xz" % version
 
+
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
     def configure_args(self):
         args = []
@@ -92,6 +93,7 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
         ):
             args.append("CFLAGS=-fcommon")
         return args
+
 
 class MesonBuilder(spack.build_systems.meson.MesonBuilder):
     def meson_args(self):

--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -6,18 +6,21 @@
 from spack.package import *
 
 
-class Libdrm(Package):
+class Libdrm(AutotoolsPackage, MesonPackage):
     """A userspace library for accessing the DRM, direct rendering manager,
     on Linux, BSD and other systems supporting the ioctl interface."""
 
     homepage = "https://dri.freedesktop.org/libdrm/"
     url = "https://dri.freedesktop.org/libdrm/libdrm-2.4.101.tar.xz"
     list_url = "https://dri.freedesktop.org/libdrm/"
+    git = "https://gitlab.freedesktop.org/mesa/drm"
 
     maintainers("wdconinc")
 
     license("MIT")
 
+    version("2.4.122", sha256="d9f5079b777dffca9300ccc56b10a93588cdfbc9dde2fae111940dfb6292f251")
+    version("2.4.121", sha256="909084a505d7638887f590b70791b3bbd9069c710c948f5d1f1ce6d080cdfcab")
     version("2.4.120", sha256="3bf55363f76c7250946441ab51d3a6cc0ae518055c0ff017324ab76cdefb327a")
     version("2.4.119", sha256="0a49f12f09b5b6e68eaaaff3f02ca7cff9aa926939b212d343161d3e8ac56291")
     version("2.4.118", sha256="a777bd85f2b5fc9c57f886c82058300578317cafdbc77d0a769d7e9a9567ab88")
@@ -39,7 +42,7 @@ class Libdrm(Package):
     version("2.4.59", sha256="ed9d03a92c2d80e6310cc350db3430620f1659ae084a07c6824cee7bc81ae8fa")
     version("2.4.33", sha256="bd2a8fecf28616f2157ca33ede691c139cc294ed2d0c4244b62ca7d22e98e5a4")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     variant("docs", default=False, description="Build man pages")
 
@@ -47,10 +50,16 @@ class Libdrm(Package):
     depends_on("libpciaccess@0.10:")
     depends_on("libpthread-stubs")
 
-    # 2.4.90 is the first version to use meson, spack defaults to meson since
-    # 2.4.101.
-    depends_on("meson@0.53:", type="build", when="@2.4.101:")
-    depends_on("meson@0.59:", type="build", when="@2.4.117:")
+    # 2.4.90 is the first version to use meson, but spack supports meson since 2.4.101.
+    build_system(
+        conditional("meson", when="@2.4.101:"),
+        conditional("autotools", when="@:2.4.100"),
+        default="meson"
+    )
+
+    with when("build_system=meson"):
+        depends_on("meson@0.53:", type="build", when="@2.4.101:")
+        depends_on("meson@0.59:", type="build", when="@2.4.117:")
 
     # >= 2.4.104 uses reStructuredText for man pages.
     with when("@2.4.104: +docs"):
@@ -68,24 +77,7 @@ class Libdrm(Package):
         else:
             return self.list_url + "libdrm-%s.tar.xz" % version
 
-    def meson_args(self):
-        if self.version <= Version("2.4.112"):
-            return ["-Dman-pages=" + ("true" if "+docs" in self.spec else "false")]
-        else:
-            return ["-Dman-pages=" + ("enabled" if "+docs" in self.spec else "disabled")]
-
-    def install(self, spec, prefix):
-        with working_dir("spack-build", create=True):
-            args = []
-            args.extend(std_meson_args)
-            args.extend(self.meson_args())
-            meson("..", *args)
-            ninja("-v")
-            if self.run_tests:
-                ninja("test")
-            ninja("install")
-
-    @when("@:2.4.100")
+class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
     def configure_args(self):
         args = []
         args.append("--enable-static")
@@ -101,12 +93,9 @@ class Libdrm(Package):
             args.append("CFLAGS=-fcommon")
         return args
 
-    @when("@:2.4.100")
-    def install(self, spec, prefix):
-        configure("--prefix={0}".format(prefix), *self.configure_args())
-        make()
-        if self.run_tests:
-            make("check")
-        make("install")
-        if self.run_tests:
-            make("installcheck")
+class MesonBuilder(spack.build_systems.meson.MesonBuilder):
+    def meson_args(self):
+        if self.spec.satisfies("@:2.4.112"):
+            return ["-Dman-pages=" + ("true" if "+docs" in self.spec else "false")]
+        else:
+            return ["-Dman-pages=" + ("enabled" if "+docs" in self.spec else "disabled")]


### PR DESCRIPTION
The `libdrm` package has two new versions, v2.4.121 and v2.4.122 (with no changes required to the spack package, see [diff](https://gitlab.freedesktop.org/mesa/drm/-/compare/libdrm-2.4.120...libdrm-2.4.122)).

This PR also changes the build system to a proper multi-build system setup with two builders, away from an adhoc `Package` implementation.