### PR TITLE
libx11: add v1.8.10

### DIFF
--- a/var/spack/repos/builtin/packages/libx11/package.py
+++ b/var/spack/repos/builtin/packages/libx11/package.py
@@ -17,6 +17,7 @@ class Libx11(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("1.8.10", sha256="b7a1a90d881bb7b94df5cf31509e6b03f15c0972d3ac25ab0441f5fbc789650f")
     version("1.8.9", sha256="57ca5f07d263788ad661a86f4139412e8b699662e6b60c20f1f028c25a935e48")
     version("1.8.8", sha256="26997a2bc48c03df7d670f8a4ee961d1d6b039bf947475e5fec6b7635b4efe72")
     version("1.8.7", sha256="793ebebf569f12c864b77401798d38814b51790fce206e01a431e5feb982e20b")


### PR DESCRIPTION
A new version of `libX11`, 1.8.10 ([diff](https://gitlab.freedesktop.org/xorg/lib/libx11/-/compare/libX11-1.8.9...libX11-1.8.10), no changes to build or dependencies).

Test build:
```
==> Installing libx11-1.8.10-7r2zfuh5zimzne7ytrrycg7lfyhorde6 [74/103]
==> No binary for libx11-1.8.10-7r2zfuh5zimzne7ytrrycg7lfyhorde6 found: installing from source
==> Fetching https://www.x.org/archive/individual/lib/libX11-1.8.10.tar.gz
==> No patches needed for libx11
==> libx11: Executing phase: 'autoreconf'
==> libx11: Executing phase: 'configure'
==> libx11: Executing phase: 'build'
==> libx11: Executing phase: 'install'
==> libx11: Successfully installed libx11-1.8.10-7r2zfuh5zimzne7ytrrycg7lfyhorde6
  Stage: 1.74s.  Autoreconf: 0.00s.  Configure: 7.99s.  Build: 49.92s.  Install: 0.99s.  Post-install: 0.39s.  Total: 1m 1.17s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/libx11-1.8.10-7r2zfuh5zimzne7ytrrycg7lfyhorde6
```