### PR TITLE
opencascade: add v7.8.1

### DIFF
--- a/var/spack/repos/builtin/packages/opencascade/package.py
+++ b/var/spack/repos/builtin/packages/opencascade/package.py
@@ -23,76 +23,29 @@ class Opencascade(CMakePackage):
 
     license("LGPL-2.1-only")
 
-    version(
-        "7.8.1",
-        extension="tar.gz",
-        sha256="33f2bdb67e3f6ae469f3fa816cfba34529a23a9cb736bf98a32b203d8531c523",
-    )
-    version(
-        "7.8.0",
-        extension="tar.gz",
-        sha256="b9c8f0a9d523ac1a606697f95fc39d8acf1140d3728561b8010a604431b4e9cf",
-    )
-    version(
-        "7.7.2",
-        extension="tar.gz",
-        sha256="2fb23c8d67a7b72061b4f7a6875861e17d412d524527b2a96151ead1d9cfa2c1",
-    )
-    version(
-        "7.7.1",
-        extension="tar.gz",
-        sha256="f413d30a8a06d6164e94860a652cbc96ea58fe262df36ce4eaa92a9e3561fd12",
-    )
-    version(
-        "7.7.0",
-        extension="tar.gz",
-        sha256="075ca1dddd9646fcf331a809904925055747a951a6afd07a463369b9b441b445",
-    )
-    version(
-        "7.6.3",
-        extension="tar.gz",
-        sha256="baae5b3a7a38825396fc45ef9d170db406339f5eeec62e21b21036afeda31200",
-    )
-    version(
-        "7.6.0",
-        extension="tar.gz",
-        sha256="e7f989d52348c3b3acb7eb4ee001bb5c2eed5250cdcceaa6ae97edc294f2cabd",
-    )
-    version(
-        "7.5.3p5",
-        extension="tar.gz",
-        sha256="29a4b4293f725bea2f32de5641b127452fc836a30e207d0daa5a0d1b746226b8",
-    )
-    version(
-        "7.5.3p4",
-        extension="tar.gz",
-        sha256="f7571462041694f6bc7fadd94b0c251762078713cb5b0484845b6b8a4d8a0b99",
-    )
-    version(
-        "7.5.3",
-        extension="tar.gz",
-        sha256="cc3d3fd9f76526502c3d9025b651f45b034187430f231414c97dda756572410b",
-    )
-    version(
-        "7.5.2",
-        extension="tar.gz",
-        sha256="1a32d2b0d6d3c236163cb45139221fb198f0f3cdad56606c5b1c9a2a8869b3ac",
-    )
-    version(
-        "7.4.0p2",
-        extension="tar.gz",
-        sha256="93565f9bdc9575e0d6fcb34c11c8f06d8f9394250bb427870da65424e8537f60",
-    )
-    version(
-        "7.4.0p1",
-        extension="tar.gz",
-        sha256="e00fedc221560fda31653c23a8f3d0eda78095c87519f338d4f4088e2ee9a9c0",
-    )
-    version(
-        "7.4.0",
-        extension="tar.gz",
-        sha256="655da7717dac3460a22a6a7ee68860c1da56da2fec9c380d8ac0ac0349d67676",
-    )
+    with default_args(extension="tar.gz"):
+        version("7.8.1", sha256="33f2bdb67e3f6ae469f3fa816cfba34529a23a9cb736bf98a32b203d8531c523")
+        version("7.8.0", sha256="b9c8f0a9d523ac1a606697f95fc39d8acf1140d3728561b8010a604431b4e9cf")
+        version("7.7.2", sha256="2fb23c8d67a7b72061b4f7a6875861e17d412d524527b2a96151ead1d9cfa2c1")
+        version("7.7.1", sha256="f413d30a8a06d6164e94860a652cbc96ea58fe262df36ce4eaa92a9e3561fd12")
+        version("7.7.0", sha256="075ca1dddd9646fcf331a809904925055747a951a6afd07a463369b9b441b445")
+        version("7.6.3", sha256="baae5b3a7a38825396fc45ef9d170db406339f5eeec62e21b21036afeda31200")
+        version("7.6.0", sha256="e7f989d52348c3b3acb7eb4ee001bb5c2eed5250cdcceaa6ae97edc294f2cabd")
+        version(
+            "7.5.3p5", sha256="29a4b4293f725bea2f32de5641b127452fc836a30e207d0daa5a0d1b746226b8"
+        )
+        version(
+            "7.5.3p4", sha256="f7571462041694f6bc7fadd94b0c251762078713cb5b0484845b6b8a4d8a0b99"
+        )
+        version("7.5.3", sha256="cc3d3fd9f76526502c3d9025b651f45b034187430f231414c97dda756572410b")
+        version("7.5.2", sha256="1a32d2b0d6d3c236163cb45139221fb198f0f3cdad56606c5b1c9a2a8869b3ac")
+        version(
+            "7.4.0p2", sha256="93565f9bdc9575e0d6fcb34c11c8f06d8f9394250bb427870da65424e8537f60"
+        )
+        version(
+            "7.4.0p1", sha256="e00fedc221560fda31653c23a8f3d0eda78095c87519f338d4f4088e2ee9a9c0"
+        )
+        version("7.4.0", sha256="655da7717dac3460a22a6a7ee68860c1da56da2fec9c380d8ac0ac0349d67676")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated

--- a/var/spack/repos/builtin/packages/opencascade/package.py
+++ b/var/spack/repos/builtin/packages/opencascade/package.py
@@ -24,6 +24,11 @@ class Opencascade(CMakePackage):
     license("LGPL-2.1-only")
 
     version(
+        "7.8.1",
+        extension="tar.gz",
+        sha256="33f2bdb67e3f6ae469f3fa816cfba34529a23a9cb736bf98a32b203d8531c523",
+    )
+    version(
         "7.8.0",
         extension="tar.gz",
         sha256="b9c8f0a9d523ac1a606697f95fc39d8acf1140d3728561b8010a604431b4e9cf",


### PR DESCRIPTION
A new bugfix version of opencascade, 7.8.1 ([diff](https://git.dev.opencascade.org/gitweb/?p=occt.git;a=commitdiff;h=refs/tags/V7_8_1;hp=refs/tags/V7_8_0), no changes needed in spack).