### PR TITLE
py-gssapi: add v1.8.3

### DIFF
--- a/var/spack/repos/builtin/packages/py-gssapi/package.py
+++ b/var/spack/repos/builtin/packages/py-gssapi/package.py
@@ -15,9 +15,11 @@ class PyGssapi(PythonPackage):
 
     maintainers("wdconinc")
 
+    version("1.8.3", sha256="aa3c8d0b1526f52559552bb2c9d2d6be013d76a8e5db00b39a1db5727e93b0b0")
     version("1.8.2", sha256="b78e0a021cc91158660e4c5cc9263e07c719346c35a9c0f66725e914b235c89a")
 
-    depends_on("py-cython@0.29.29:2", type="build")
+    depends_on("py-cython@0.29.29:2", type="build", when="@:1.8.2")
+    depends_on("py-cython@0.29.29:3", type="build", when="@1.8.3:")
     depends_on("py-setuptools@40.6.0:", type="build")
 
     depends_on("py-decorator", type=("build", "run"))


### PR DESCRIPTION
Python-GSSAPI, i.e. `py-gssapi`, version 1.8.3 ([diff](https://github.com/pythongssapi/python-gssapi/compare/v1.8.2...v1.8.3)) fixes Cython 3 compatibility.

Test build:
```
-- linux-ubuntu24.04-skylake / gcc@13.2.0 -----------------------
ckinfqu py-gssapi@1.8.3 build_system=python_pip
==> 1 installed package
```