### PR TITLE
python: add underscored PyPI url when dash in `pypi`

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -365,7 +365,7 @@ class PythonPackage(PythonExtension):
                 pypi = "/".join([name, file.replace("-", "_", name_dash_count)])
                 urls.append(f"https://files.pythonhosted.org/packages/source/{pypi[0]}/{pypi}")
             return urls
-        return None
+        return []
 
     @lang.classproperty
     def list_url(cls) -> Optional[str]:  # type: ignore[override]

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -365,7 +365,7 @@ class PythonPackage(PythonExtension):
                 pypi = "/".join([name, file.replace("-", "_", name_dash_count)])
                 urls.append(f"https://files.pythonhosted.org/packages/source/{pypi[0]}/{pypi}")
             return urls
-        return []
+        return [None]
 
     @lang.classproperty
     def list_url(cls) -> Optional[str]:  # type: ignore[override]

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -354,9 +354,21 @@ class PythonPackage(PythonExtension):
         return None
 
     @lang.classproperty
-    def url(cls) -> Optional[str]:
+    def urls(cls) -> Optional[List[str]]:
         if cls.pypi:
-            return f"https://files.pythonhosted.org/packages/source/{cls.pypi[0]}/{cls.pypi}"
+            urls = [
+                f"https://files.pythonhosted.org/packages/source/{cls.pypi[0]}/{cls.pypi}"
+            ]
+            assert cls.pypi.count("/") == 1, "PyPI class attribute must include a single slash"
+            name, file = cls.pypi.split("/")
+            name_dash_count = name.count("-")
+            if name_dash_count > 0:
+                # replace all but last dash with underscores for pypi.org listing changes
+                pypi = "/".join([name, file.replace("-", "_", name_dash_count)])
+                urls.append(
+                    f"https://files.pythonhosted.org/packages/source/{pypi[0]}/{pypi}"
+                )
+            return urls
         return None
 
     @lang.classproperty

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -356,18 +356,14 @@ class PythonPackage(PythonExtension):
     @lang.classproperty
     def urls(cls) -> Optional[List[str]]:
         if cls.pypi:
-            urls = [
-                f"https://files.pythonhosted.org/packages/source/{cls.pypi[0]}/{cls.pypi}"
-            ]
+            urls = [f"https://files.pythonhosted.org/packages/source/{cls.pypi[0]}/{cls.pypi}"]
             assert cls.pypi.count("/") == 1, "PyPI class attribute must include a single slash"
             name, file = cls.pypi.split("/")
             name_dash_count = name.count("-")
             if name_dash_count > 0:
                 # replace all but last dash with underscores for pypi.org listing changes
                 pypi = "/".join([name, file.replace("-", "_", name_dash_count)])
-                urls.append(
-                    f"https://files.pythonhosted.org/packages/source/{pypi[0]}/{pypi}"
-                )
+                urls.append(f"https://files.pythonhosted.org/packages/source/{pypi[0]}/{pypi}")
             return urls
         return None
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2426,9 +2426,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
         if hasattr(self, "url") and self.url:
             urls.append(self.url)
 
-        # fetch from first entry in urls to save time
         if hasattr(self, "urls") and self.urls:
-            urls.append(self.urls[0])
+            urls.extend(self.urls)
 
         for args in self.versions.values():
             if "url" in args:


### PR DESCRIPTION
Some time ago, PyPI.org started to change dashes into underscores for newer versions of packags with dashes in their names. This interferes with `spack checksum` and requires `url_for_version` on individual packages.

This PR aims to solve the issue centrally by automatically adding the underscore `pypi`-derived URL to the `urls` attribute.

With this PR we get now, for example:
```console
root@codespaces-4ccc57:/workspaces/spack# spack checksum py-pytest-subprocess
==> Selected 21 versions. 20 new versions
  1.5.2  https://files.pythonhosted.org/packages/source/p/pytest-subprocess/pytest_subprocess-1.5.2.tar.gz
  1.5.1  https://files.pythonhosted.org/packages/source/p/pytest-subprocess/pytest_subprocess-1.5.1.tar.gz
  1.5.0  https://files.pythonhosted.org/packages/source/p/pytest-subprocess/pytest-subprocess-1.5.0.tar.gz
  1.4.2  https://files.pythonhosted.org/packages/source/p/pytest-subprocess/pytest-subprocess-1.4.2.tar.gz
  1.4.1  https://files.pythonhosted.org/packages/source/p/pytest-subprocess/pytest-subprocess-1.4.1.tar.gz
```
whereas previously we would only get versions up to 1.5.0, inclusive.

For packages that have already switched to `url_for_version`, e.g. `py-setuptools-scm`, this should not make any difference since those packages should have a filename with an underscore already, so nothing gets added.

Note: the restriction to the first of `urls` in `all_urls` was introduced and discussed in https://github.com/spack/spack/pull/16435#discussion_r419017169.

TODO:
- [ ] `urls` must be iterable and contain at least one element if `url` does not exist (per package_base.py L1055): this means that once we enter the property `urls` we cannot just return an empty list,
- [ ] multiple inheritance without `pypi` can result in overwriting `urls` (e.g. `py-crossmap`): which `urls` property will/should get used?
- [ ] `urls` must not exist when `url` is defined (e.g. `asciidoc`): can we use a conditional property decorator that only defines `urls` if `url` doesn't exist?
- [ ] unit tests for coverage.

*Edit*: reference to `py-setuptools-scm` is a bit out of place since for that package changed from using underscore to using dash. `py-globus-sdk` is a better example.