### PR TITLE
wayland-protocols: add v1.35, v1.36; support tests

### DIFF
--- a/var/spack/repos/builtin/packages/wayland-protocols/package.py
+++ b/var/spack/repos/builtin/packages/wayland-protocols/package.py
@@ -28,6 +28,8 @@ class WaylandProtocols(MesonPackage, AutotoolsPackage):
 
     license("MIT")
 
+    version("1.36", sha256="c839dd4325565fd59a93d6cde17335357328f66983c2e1fb03c33e92d6918b17")
+    version("1.35", sha256="6e62dfa92ce82487d107b76064cfe2d7ca107c87c239ea9036a763d79c09105a")
     version("1.34", sha256="cd3cc9dedb838e6fc8f55bbeb688e8569ffac7df53bc59dbfac8acbb39267f05")
     version("1.33", sha256="71a7d2f062d463aa839497ddfac97e4bd3f00aa306e014f94529aa3a2be193a8")
     version("1.32", sha256="444b5d823ad0163dfe505c97ea1a0689ca7e2978a87cf59b03f06573b87db260")
@@ -53,7 +55,9 @@ class WaylandProtocols(MesonPackage, AutotoolsPackage):
         depends_on("meson@0.55:")
 
     depends_on("pkgconfig", type="build")
-    depends_on("doxygen", type="build")
-    depends_on("xmlto", type="build")
-    depends_on("libxslt", type="build")
     depends_on("wayland")
+
+
+class MesonBuilder(spack.build_systems.meson.MesonBuilder):
+    def meson_args(self):
+        return ["-Dtests={}".format("true" if self.pkg.run_tests else "false")]


### PR DESCRIPTION
This PR adds two newer versions of the wayland protocols, v1.35 and v1.36. No changes to the build system or dependencies needed.

This PR also cleans up unneeded dependencies which have been in here since the beginning, and which are not needed in even the oldest version of `wayland-protocols` (see e.g. [`configure.ac` for 1.23](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/1.23/configure.ac?ref_type=tags)). I could find no hits when searching for [xmlto](https://gitlab.freedesktop.org/search?search=xmlto&project_id=2891), [xslt](https://gitlab.freedesktop.org/search?search=xslt&project_id=2891), or [doxygen](https://gitlab.freedesktop.org/search?search=doxygen&project_id=2891) anywhere in the commit history of `wayland-protocols`. The only references to these dependencies are in https://gitlab.freedesktop.org/wayland/wayland-protocols/-/issues/32, but not in commits.

Finally, this PR adds support for testing when using the meson build system (the autotools build system does not have an easy way to turn on or off testing).

Test builds (of the older version as well, to demonstrate that the dependencies were not required for the historical versions either):
```console
$ spack find -lv wayland-protocols
-- linux-ubuntu24.04-skylake / gcc@13.2.0 -----------------------
zhtiqdq wayland-protocols@1.22 build_system=autotools
rsp543x wayland-protocols@1.22~strip build_system=meson buildtype=release default_library=shared
qe6pzep wayland-protocols@1.36~strip build_system=meson buildtype=release default_library=shared
```