### PR TITLE
abseil-cpp: add v20240722; support tests

### DIFF
--- a/var/spack/repos/builtin/packages/abseil-cpp/package.py
+++ b/var/spack/repos/builtin/packages/abseil-cpp/package.py
@@ -15,8 +15,11 @@ class AbseilCpp(CMakePackage):
     maintainers("jcftang")
     tags = ["windows"]
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked_by="wdconinc")
 
+    version(
+        "20240722.0", sha256="f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3"
+    )
     version(
         "20240116.2", sha256="733726b8c3a6d39a4120d7e45ea8b41a434cdacde401cba500f14236c49b39dc"
     )
@@ -86,13 +89,19 @@ class AbseilCpp(CMakePackage):
         description="C++ standard used during compilation",
     )
 
+    depends_on("cmake@3.16:", when="@20240722:", type="build")
     depends_on("cmake@3.10:", when="@20220907:", type="build")
     depends_on("cmake@3.5:", when="@20190312:", type="build")
     depends_on("cmake@3.1:", type="build")
 
+    depends_on("googletest", type="build")
+
     def cmake_args(self):
         return [
-            self.define("BUILD_TESTING", False),
+            self.define("BUILD_TESTING", self.run_tests),
+            self.define("ABSL_BUILD_TESTING", self.run_tests),
+            self.define("ABSL_USE_EXTERNAL_GOOGLETEST", self.run_tests),
+            self.define("ABSL_FIND_GOOGLETEST", self.run_tests),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
         ]

--- a/var/spack/repos/builtin/packages/abseil-cpp/package.py
+++ b/var/spack/repos/builtin/packages/abseil-cpp/package.py
@@ -94,14 +94,15 @@ class AbseilCpp(CMakePackage):
     depends_on("cmake@3.5:", when="@20190312:", type="build")
     depends_on("cmake@3.1:", type="build")
 
-    depends_on("googletest", type="build")
+    depends_on("googletest", type="build", when="@20220623:")
 
     def cmake_args(self):
+        run_tests = self.run_tests and self.spec.satisfies("@20220623:")
         return [
-            self.define("BUILD_TESTING", self.run_tests),
-            self.define("ABSL_BUILD_TESTING", self.run_tests),
-            self.define("ABSL_USE_EXTERNAL_GOOGLETEST", self.run_tests),
-            self.define("ABSL_FIND_GOOGLETEST", self.run_tests),
+            self.define("BUILD_TESTING", run_tests),
+            self.define("ABSL_BUILD_TESTING", run_tests),
+            self.define("ABSL_USE_EXTERNAL_GOOGLETEST", run_tests),
+            self.define("ABSL_FIND_GOOGLETEST", run_tests),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
         ]


### PR DESCRIPTION
This PR adds v20240722 of `abseil-cpp` ([diff](https://github.com/abseil/abseil-cpp/compare/20240116.2...20240722.0)).

This PR also enables testing in the package for versions starting with [20220623](https://github.com/abseil/abseil-cpp/releases/tag/20220623.0), which is when `ABSL_BUILD_TESTING` was added (https://github.com/abseil/abseil-cpp/commit/fb7dd24b18e82893e5922be5d1c8ae0f3fe3c9fa). Before then, testing was enabled with different variables than the three variables provided here (or was not able to use an external GoogleTest).

Besides an increased minimum CMake version no other changes are needed to package.py based on the CMakeLists.txt files throughout the source tree.

Test build:
```
-- linux-ubuntu24.04-skylake / gcc@13.2.0 -----------------------
jm5r5mr abseil-cpp@20240722.0~ipo+shared build_system=cmake build_type=Release cxxstd=14 generator=make
==> 1 installed package
```
Test results:
```
<snip>
219/221 Test  #87: absl_absl_check_test ...............................   Passed  160.91 sec
220/221 Test  #89: absl_check_test ....................................   Passed  157.28 sec
221/221 Test #202: absl_mutex_test ....................................   Passed   81.01 sec

100% tests passed, 0 tests failed out of 221

Total Test time (real) = 174.85 sec
==> [2024-08-11-16:00:10.330879] 'make' '-j8' '-n' 'check'
==> [2024-08-11-16:00:10.344069] Target 'check' not found in Makefile
```