### PR TITLE
ccache: add v4.10.2

### DIFF
--- a/var/spack/repos/builtin/packages/ccache/package.py
+++ b/var/spack/repos/builtin/packages/ccache/package.py
@@ -23,6 +23,7 @@ class Ccache(CMakePackage):
 
     license("GPL-3.0-or-later")
 
+    version("4.10.2", sha256="108100960bb7e64573ea925af2ee7611701241abb36ce0aae3354528403a7d87")
     version("4.9.1", sha256="12834ecaaaf2db069dda1d1d991f91c19e3274cc04a471af5b64195def17e90f")
     version("4.8.3", sha256="d59dd569ad2bbc826c0bc335c8ebd73e78ed0f2f40ba6b30069347e63585d9ef")
     version("4.8.2", sha256="75eef15b8b9da48db9c91e1d0ff58b3645fc70c0e4ca2ef1b6825a12f21f217d")
@@ -83,6 +84,8 @@ class Ccache(CMakePackage):
 
     def cmake_args(self):
         return [
+            # The test suite does not support the compiler being a wrapper script
+            # https://github.com/ccache/ccache/issues/914#issuecomment-922521690
             self.define("ENABLE_TESTING", False),
             self.define("ENABLE_DOCUMENTATION", False),
             self.define_from_variant("REDIS_STORAGE_BACKEND", "redis"),


### PR DESCRIPTION
This PR adds `ccache`, v4.10.2 ([diff](https://github.com/ccache/ccache/compare/v4.9.1...v4.10.2)).

The new version (4.10) restructures directories and dependency management, allowing for better external dependency management. This PR, however, does not adapt to this new capability yet. The dependencies in question are mostly header-only, and continue to be bundled in e.g. https://github.com/ccache/ccache/tree/v4.10.2/src/third_party.

A comment is added to justify the absence of testing ability: the unit tests do indeed fail for the compiler wrapper used by spack.

Test build:
```
==> Installing ccache-4.10.2-jll6rhygxv7hmrrrix2mq7mgibf7o6pg [13/13]
==> No binary for ccache-4.10.2-jll6rhygxv7hmrrrix2mq7mgibf7o6pg found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/10/108100960bb7e64573ea925af2ee7611701241abb36ce0aae3354528403a7d87.tar.gz
==> No patches needed for ccache
==> ccache: Executing phase: 'cmake'
==> ccache: Executing phase: 'build'
==> ccache: Executing phase: 'install'
==> ccache: Successfully installed ccache-4.10.2-jll6rhygxv7hmrrrix2mq7mgibf7o6pg
  Stage: 0.06s.  Cmake: 8.40s.  Build: 1m 20.02s.  Install: 0.22s.  Post-install: 0.22s.  Total: 1m 29.02s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/ccache-4.10.2-jll6rhygxv7hmrrrix2mq7mgibf7o6pg
```