### PR TITLE
cli11: add v2.4.2

### DIFF
--- a/var/spack/repos/builtin/packages/cli11/package.py
+++ b/var/spack/repos/builtin/packages/cli11/package.py
@@ -16,6 +16,7 @@ class Cli11(CMakePackage):
 
     license("BSD-3-Clause")
 
+    version("2.4.2", sha256="f2d893a65c3b1324c50d4e682c0cdc021dd0477ae2c048544f39eed6654b699a")
     version("2.4.1", sha256="73b7ec52261ce8fe980a29df6b4ceb66243bb0b779451dbd3d014cfec9fdbb58")
     version("2.3.2", sha256="aac0ab42108131ac5d3344a9db0fdf25c4db652296641955720a4fbe52334e22")
     version("2.3.1", sha256="378da73d2d1d9a7b82ad6ed2b5bda3e7bc7093c4034a1d680a2e009eb067e7b2")
@@ -27,6 +28,7 @@ class Cli11(CMakePackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@3.4:", type="build")
+    depends_on("cmake@3.5:", type="build", when="@2.4:")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
This PR adds `cli11`, v2.4.2 ([release notes](https://github.com/CLIUtils/CLI11/releases/tag/v2.4.2), [diff](https://github.com/CLIUtils/CLI11/compare/v2.4.1...v2.4.2)).

The somewhat extensive CMake build system updates and refactoring are related to single-file installation, which is not something spack users are likely to care that much about, so no variant is added for this functionality. This version also adds improved support for meson and bazel build systems, but this is not added in this PR.

Test build:
```console
==> Installing cli11-2.4.2-5i6mz577jwcwmpz2i4f5dfchyhbtww32 [10/10]
==> No binary for cli11-2.4.2-5i6mz577jwcwmpz2i4f5dfchyhbtww32 found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/f2/f2d893a65c3b1324c50d4e682c0cdc021dd0477ae2c048544f39eed6654b699a.tar.gz
==> No patches needed for cli11
==> cli11: Executing phase: 'cmake'
==> cli11: Executing phase: 'build'
==> cli11: Executing phase: 'install'
==> cli11: Successfully installed cli11-2.4.2-5i6mz577jwcwmpz2i4f5dfchyhbtww32
  Stage: 0.02s.  Cmake: 0.19s.  Build: 0.08s.  Install: 0.03s.  Post-install: 0.12s.  Total: 0.51s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/cli11-2.4.2-5i6mz577jwcwmpz2i4f5dfchyhbtww32
```