### PR TITLE
embree: add v4.3.3

### DIFF
--- a/var/spack/repos/builtin/packages/embree/package.py
+++ b/var/spack/repos/builtin/packages/embree/package.py
@@ -15,6 +15,8 @@ class Embree(CMakePackage):
 
     license("Apache-2.0")
 
+    version("4.3.3", sha256="8a3bc3c3e21aa209d9861a28f8ba93b2f82ed0dc93341dddac09f1f03c36ef2d")
+    version("4.3.2", sha256="dc7bb6bac095b2e7bc64321435acd07c6137d6d60e4b79ec07bb0b215ddf81cb")
     version("4.3.1", sha256="824edcbb7a8cd393c5bdb7a16738487b21ecc4e1d004ac9f761e934f97bb02a4")
     version("4.3.0", sha256="baf0a57a45837fc055ba828a139467bce0bc0c6a9a5f2dccb05163d012c12308")
     version("4.2.0", sha256="b0479ce688045d17aa63ce6223c84b1cdb5edbf00d7eda71c06b7e64e21f53a0")


### PR DESCRIPTION
This PR adds `embree` v4.3.3 ([diff](https://github.com/RenderKit/embree/compare/v4.3.2...v4.3.3)). No build system changes, or other dependency changes that would require an update to the package here.

Test build:
```
==> Installing embree-4.3.3-aeboezp26gktplc6m5x4ssw6z7x2cylt [12/12]
==> No binary for embree-4.3.3-aeboezp26gktplc6m5x4ssw6z7x2cylt found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/8a/8a3bc3c3e21aa209d9861a28f8ba93b2f82ed0dc93341dddac09f1f03c36ef2d.tar.gz
==> No patches needed for embree
==> embree: Executing phase: 'cmake'
==> embree: Executing phase: 'build'
==> embree: Executing phase: 'install'
==> embree: Successfully installed embree-4.3.3-aeboezp26gktplc6m5x4ssw6z7x2cylt
  Stage: 0.98s.  Cmake: 0.93s.  Build: 1.87s.  Install: 0.98s.  Post-install: 0.16s.  Total: 5.06s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/embree-4.3.3-aeboezp26gktplc6m5x4ssw6z7x2cylt
```