### PR TITLE
graphviz: add v8.1.0 -> v12.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -49,7 +49,7 @@ class Graphviz(AutotoolsPackage):
 
     # Additional language bindings are nominally supported by GraphViz via SWIG
     # but are untested and need the proper dependencies added:
-    # language_bindings += ['sharp', 'go', 'guile', 'io', 'lua', 'ocaml',
+    # language_bindings += ['sharp', 'go', 'guile', 'io', 'lua',
     #                       'perl', 'php', 'python', 'r', 'ruby', 'tcl']
 
     for lang in language_bindings:
@@ -203,8 +203,9 @@ class Graphviz(AutotoolsPackage):
             "x",
         ]:
             args += self.with_or_without(var)
-        for var in ("expat", "java"):
-            if "+" + var in spec:
+
+        for var, when in [("expat", "@:8.0"), ("java", "@:")]:
+            if spec.satisfies("+" + var + when):
                 args.append("--with-{0}includedir={1}".format(var, spec[var].prefix.include))
                 args.append("--with-{0}libdir={1}".format(var, spec[var].prefix.lib))
 

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -21,6 +21,11 @@ class Graphviz(AutotoolsPackage):
 
     license("EPL-1.0")
 
+    version("12.1.0", sha256="ad2023c23935397d4b5a34c14682f8098d2f20d2144c63d20d05be372757fdb1")
+    version("11.0.0", sha256="95173d21922082b0b2649fb24c1dc4bbc1e39504a92903b88df39804778cbb9d")
+    version("10.0.1", sha256="eaa60fea2b3ad904e3bf6919710c1ba3207ce31b5d7da1687dd3b734de8736f6")
+    version("9.0.0", sha256="5c0a6e60761e2e0f6cbb8baca958b643a06b9bb74ed5a2e4937ee7dbb49dead3")
+    version("8.1.0", sha256="ce8911695752aa2c3929147e3dee016e58aa624d81d7c18dd16f895ae79460de")
     version("8.0.5", sha256="c1901fe52483fad55fbf893ccd59a3dcaedd53f0d50b5aebbbf3deaba93b674d")
     version("8.0.1", sha256="19928f09f759676578b50101420b24475eb35f712ffbe8a97254f64b20fdbd03")
     version("7.1.0", sha256="7943c3fa0c55c779f595259f3b9e41c7ea6ed92f0aca0d24df917f631322dc01")


### PR DESCRIPTION
This PR adds `graphviz` versions through v12.1.0. Per the [changelog](https://gitlab.com/graphviz/graphviz/-/blob/main/CHANGELOG.md), a few minor changes were applied:
- ocaml language bindings have been removed for lack of users (we didn't support them, but a comment was updated),
- the expat include and lib dirs are retrieved from pkgconfig since 8.1.0, so we don't need to pass them anymore,
- no dependency versions needed updating.

Test build of `graphviz+expat`:
```
==> Installing graphviz-12.1.0-wo5ol25zeyrw3ezyzq6zacxrdh6innpf [27/27]
==> No binary for graphviz-12.1.0-wo5ol25zeyrw3ezyzq6zacxrdh6innpf found: installing from source
==> Fetching https://gitlab.com/graphviz/graphviz/-/archive/12.1.0/graphviz-12.1.0.tar.bz2
==> No patches needed for graphviz
==> graphviz: Executing phase: 'autoreconf'
==> graphviz: Executing phase: 'configure'
==> graphviz: Executing phase: 'build'
==> graphviz: Executing phase: 'install'
==> graphviz: Successfully installed graphviz-12.1.0-wo5ol25zeyrw3ezyzq6zacxrdh6innpf
  Stage: 3.57s.  Autoreconf: 9.58s.  Configure: 15.55s.  Build: 1m 9.02s.  Install: 5.32s.  Post-install: 0.12s.  Total: 1m 43.39s
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-x86_64_v3/gcc-11.4.0/graphviz-12.1.0-wo5ol25zeyrw3ezyzq6zacxrdh6innpf
```