### PR TITLE
py-avro: add v1.11.3, v1.12.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-avro/package.py
+++ b/var/spack/repos/builtin/packages/py-avro/package.py
@@ -12,6 +12,8 @@ class PyAvro(PythonPackage):
     homepage = "https://avro.apache.org/docs/current/"
     pypi = "avro/avro-1.8.2.tar.gz"
 
+    version("1.12.0", sha256="cad9c53b23ceed699c7af6bddced42e2c572fd6b408c257a7d4fc4e8cf2e2d6b")
+    version("1.11.3", sha256="3393bb5139f9cf0791d205756ce1e39a5b58586af5b153d6a3b5a199610e9d17")
     version("1.11.1", sha256="f123623ecc648d0e20ce14f8ed85162140c13cc4b108865d1b2529fbfa06c008")
     version("1.11.0", sha256="1206365cc30ad561493f735329857dd078533459cee4e928aec2505f341ce445")
     version("1.10.2", sha256="381b990cc4c4444743c3297348ffd46e0c3a5d7a17e15b2f4a9042f6e955c31a")
@@ -21,4 +23,5 @@ class PyAvro(PythonPackage):
     depends_on("py-setuptools@40.8.0:", when="@1.11.1:", type="build")
     depends_on("python@2.7:", type=("build", "run"))
     depends_on("python@3.6:", when="@1.11.1:", type=("build", "run"))
+    depends_on("python@3.7:", when="@1.12:", type=("build", "run"))
     depends_on("py-typing-extensions", when="^python@:3.7", type=("build", "run"))


### PR DESCRIPTION
This PR adds avro v1.12.0. No major changes, except for dropping python 3.6 support.

```
==> Waiting for py-avro-1.12.0-uqz73lglfucndvtdv3vdl3n4pgcncqom
==> Installing py-avro-1.12.0-uqz73lglfucndvtdv3vdl3n4pgcncqom [28/28]
==> No binary for py-avro-1.12.0-uqz73lglfucndvtdv3vdl3n4pgcncqom found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/a/avro/avro-1.12.0.tar.gz
==> No patches needed for py-avro
==> py-avro: Executing phase: 'install'
==> py-avro: Successfully installed py-avro-1.12.0-uqz73lglfucndvtdv3vdl3n4pgcncqom
  Stage: 1.37s.  Install: 0.90s.  Post-install: 0.14s.  Total: 2.48s[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/py-avro-1.12.0-uqz73lglfucndvtdv3vdl3n4pgcncqom
```