### PR TITLE
xterm: add v393

### DIFF
--- a/var/spack/repos/builtin/packages/xterm/package.py
+++ b/var/spack/repos/builtin/packages/xterm/package.py
@@ -12,10 +12,11 @@ class Xterm(AutotoolsPackage):
     that can't use the window system directly."""
 
     homepage = "https://invisible-island.net/xterm/"
-    url = "ftp://ftp.invisible-island.net/xterm/xterm-327.tgz"
+    url = "https://invisible-island.net/archives/xterm/xterm-327.tgz"
 
     license("MIT")
 
+    version("393", sha256="dc3abf533d66ae3db49e6783b0e1e29f0e4d045b4b3dac797a5e93be2735ec7b")
     version("353", sha256="e521d3ee9def61f5d5c911afc74dd5c3a56ce147c7071c74023ea24cac9bb768")
     version("350", sha256="aefb59eefd310268080d1a90a447368fb97a9a6737bfecfc3800bf6cc304104d")
     version("340", sha256="b5c7f77b7afade798461e2a2f86d5af64f9c9c9f408b1af0f545add978df722a")


### PR DESCRIPTION
This PR adds xterm v393. There is no easy git repo to link to, but a diff of configure.in between 353 and 393 didn't reveal any changes that require adapting the spack recipe.

This PR also updates the URL so `spack checksum` can find new versions.

Test build:
```
==> Installing xterm-393-7lpjxv55kr4khzj4piu43tjtyowu5q3c [45/45]
==> No binary for xterm-393-7lpjxv55kr4khzj4piu43tjtyowu5q3c found: installing from source
==> Fetching https://invisible-island.net/archives/xterm/xterm-393.tgz
==> No patches needed for xterm
==> xterm: Executing phase: 'autoreconf'
==> xterm: Executing phase: 'configure'
==> xterm: Executing phase: 'build'
==> xterm: Executing phase: 'install'
==> xterm: Successfully installed xterm-393-7lpjxv55kr4khzj4piu43tjtyowu5q3c
  Stage: 1.42s.  Autoreconf: 0.00s.  Configure: 8.08s.  Build: 6.25s.  Install: 0.34s.  Post-install: 0.18s.  Total: 16.41s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/xterm-393-7lpjxv55kr4khzj4piu43tjtyowu5q3c
```