### PR TITLE
runc: add v1.1.13

### DIFF
--- a/var/spack/repos/builtin/packages/runc/package.py
+++ b/var/spack/repos/builtin/packages/runc/package.py
@@ -15,6 +15,7 @@ class Runc(MakefilePackage):
 
     license("Apache-2.0")
 
+    version("1.1.13", sha256="d20e76688ce0681dc687369e18b47aeffcfdac5184c978befa7ce5da35e797fe")
     version("1.1.6", sha256="548506fc1de8f0a4790d8e937eeede17db4beb79c53d66acb4f7ec3edbc31668")
     version("1.1.4", sha256="9f5972715dffb0b2371e4d678c1206cc8c4ec5eb80f2d48755d150bac49be35b")
     version("1.0.2", sha256="740acb49e33eaf4958b5109c85363c1d3900f242d4cab47fbdbefa6f8f3c6909")


### PR DESCRIPTION
This PR adds runc v1.1.13 ([release notes](https://github.com/opencontainers/runc/releases/tag/v1.1.13), [diff](https://github.com/opencontainers/runc/compare/v1.1.6...v1.1.13)). This version supports a newer version of `go` (1.22.4), but the package was not already keeping track of go version compatibility, so I didn't add it.

Test build:
```
-- linux-ubuntu24.04-skylake / gcc@13.2.0 -----------------------
yqk4i63 runc@1.1.13 build_system=makefile
==> 1 installed package
```