### PR TITLE
deal with TimeoutError from ssl.py

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1107,7 +1107,7 @@ def generate_gitlab_ci_yaml(
     if cdash_handler and cdash_handler.auth_token:
         try:
             cdash_handler.populate_buildgroup(all_job_names)
-        except (SpackError, HTTPError, URLError) as err:
+        except (SpackError, HTTPError, URLError, TimeoutError) as err:
             tty.warn(f"Problem populating buildgroup: {err}")
     else:
         tty.warn("Unable to populate buildgroup without CDash credentials")
@@ -2083,7 +2083,7 @@ def read_broken_spec(broken_spec_url):
     """
     try:
         _, _, fs = web_util.read_from_url(broken_spec_url)
-    except (URLError, web_util.SpackWebError, HTTPError):
+    except web_util.SpackWebError:
         tty.warn(f"Unable to read broken spec from {broken_spec_url}")
         return None
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -554,7 +554,7 @@ class OCIRegistryFetchStrategy(URLFetchStrategy):
 
         try:
             response = self._urlopen(self.url)
-        except urllib.error.URLError as e:
+        except (TimeoutError, urllib.error.URLError) as e:
             # clean up archive on failure.
             if self.archive_file:
                 os.remove(self.archive_file)

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -197,8 +197,8 @@ def read_from_url(url, accept_content_type=None):
 
     try:
         response = urlopen(request)
-    except URLError as err:
-        raise SpackWebError("Download failed: {}".format(str(err)))
+    except (TimeoutError, URLError) as e:
+        raise SpackWebError(f"Download of {url.geturl()} failed: {e}")
 
     if accept_content_type:
         try:
@@ -458,8 +458,8 @@ def url_exists(url, curl=None):
             timeout=spack.config.get("config:connect_timeout", 10),
         )
         return True
-    except URLError as e:
-        tty.debug("Failure reading URL: " + str(e))
+    except (TimeoutError, URLError) as e:
+        tty.debug(f"Failure reading {url}: {e}")
         return False
 
 
@@ -740,10 +740,10 @@ def _spider(url: urllib.parse.ParseResult, collect_nested: bool, _visited: Set[s
                 subcalls.append(abs_link)
                 _visited.add(abs_link)
 
-    except URLError as e:
+    except (TimeoutError, URLError) as e:
         tty.debug(f"[SPIDER] Unable to read: {url}")
         tty.debug(str(e), level=2)
-        if hasattr(e, "reason") and isinstance(e.reason, ssl.SSLError):
+        if isinstance(e, URLError) and isinstance(e.reason, ssl.SSLError):
             tty.warn(
                 "Spack was unable to fetch url list due to a "
                 "certificate verification problem. You can try "


### PR DESCRIPTION
`urllib` (or rather `ssl.py`) can throw `TimeoutError`, which is not caught in various places, causing the error to be fatal.

See for example https://gitlab.spack.io/spack/spack/-/jobs/12182279.