### PR TITLE
aspell: add v0.60.8.1

### DIFF
--- a/var/spack/repos/builtin/packages/aspell/package.py
+++ b/var/spack/repos/builtin/packages/aspell/package.py
@@ -18,6 +18,7 @@ class Aspell(AutotoolsPackage, GNUMirrorPackage):
 
     license("LGPL-2.1-or-later")
 
+    version("0.60.8.1", sha256="d6da12b34d42d457fa604e435ad484a74b2effcd120ff40acd6bb3fb2887d21b")
     version("0.60.8", sha256="f9b77e515334a751b2e60daab5db23499e26c9209f5e7b7443b05235ad0226f2")
     version("0.60.6.1", sha256="f52583a83a63633701c5f71db3dc40aab87b7f76b29723aeb27941eff42df6e1")
 


### PR DESCRIPTION
This PR adds aspell 0.60.8.1, bugfixes only (incl CVE).

Test build:
```
==> Installing aspell-0.60.8.1-kyeps7bnshbsuzzbpx3abxmktoaetadl [5/5]
==> No binary for aspell-0.60.8.1-kyeps7bnshbsuzzbpx3abxmktoaetadl found: installing from source
==> Fetching https://ftpmirror.gnu.org/aspell/aspell-0.60.8.1.tar.gz==> Applied patch /home/wdconinc/git/spack/var/spack/repos/builtin/packages/aspell/fix_cpp.patch
==> aspell: Executing phase: 'autoreconf'
==> aspell: Executing phase: 'configure'
==> aspell: Executing phase: 'build'
==> aspell: Executing phase: 'install'
==> aspell: Successfully installed aspell-0.60.8.1-kyeps7bnshbsuzzbpx3abxmktoaetadl
  Stage: 3.18s.  Autoreconf: 0.00s.  Configure: 3.32s.  Build: 12.86s.  Install: 0.93s.  Post-install: 0.14s.  Total: 20.48s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/aspell-0.60.8.1-kyeps7bnshbsuzzbpx3abxmktoaetadl
```