### PR TITLE
CDO: add patch for missing algorithm header

### DIFF
--- a/var/spack/repos/builtin/packages/cdo/add_algorithm_header.patch
+++ b/var/spack/repos/builtin/packages/cdo/add_algorithm_header.patch
@@ -1,0 +1,22 @@
+diff --git a/src/cdo_module.cc b/src/cdo_module_patched.cc
+index dc408d9..f50c2d3 100644
+--- a/src/cdo_module.cc
++++ b/src/cdo_module_patched.cc
+@@ -1,4 +1,5 @@
+ #include "cdo_module.h"
++#include <algorithm>
+ 
+ oper_t::oper_t() : help(default_help) {}
+ 
+diff --git a/src/cdo_options.cc b/src/cdo_options_patched.cc
+index 465f1f9..0684e78 100644
+--- a/src/cdo_options.cc
++++ b/src/cdo_options_patched.cc
+@@ -12,6 +12,7 @@
+ #include "cdo_output.h"
+ 
+ #include <cstring>
++#include <algorithm>
+ 
+ namespace cdo
+ {

--- a/var/spack/repos/builtin/packages/cdo/add_algorithm_header_222.patch
+++ b/var/spack/repos/builtin/packages/cdo/add_algorithm_header_222.patch
@@ -1,0 +1,23 @@
+diff --git a/src/cdo_options.cc b/src/cdo_options_patched.cc
+index 465f1f9..0684e78 100644
+--- a/src/cdo_options.cc
++++ b/src/cdo_options_patched.cc
+@@ -12,6 +12,7 @@
+ #include "cdo_output.h"
+ 
+ #include <cstring>
++#include <algorithm>
+ 
+ namespace cdo
+ {
+diff -u src/cdo_options.h src/cdo_options_patched.h                                                                            [Mon 2024-09-02|16:00:46]
+--- a/src/cdo_options.h
++++ b/src/cdo_options_patched.h
+@@ -3,6 +3,7 @@
+
+ #include <vector>
+ #include <string>
++#include <algorithm>
+
+ #ifdef HAVE_CONFIG_H
+ #include "config.h" /* _FILE_OFFSET_BITS influence off_t */

--- a/var/spack/repos/builtin/packages/cdo/add_algorithm_header_222.patch
+++ b/var/spack/repos/builtin/packages/cdo/add_algorithm_header_222.patch
@@ -10,7 +10,7 @@ index 465f1f9..0684e78 100644
  
  namespace cdo
  {
-diff -u src/cdo_options.h src/cdo_options_patched.h                                                                            [Mon 2024-09-02|16:00:46]
+diff -u src/cdo_options.h src/cdo_options_patched.h
 --- a/src/cdo_options.h
 +++ b/src/cdo_options_patched.h
 @@ -3,6 +3,7 @@

--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -157,12 +157,17 @@ class Cdo(AutotoolsPackage):
 
     # patches
     # see https://code.mpimet.mpg.de/boards/1/topics/15594
-    patch("add_algorithm_header.patch",
-          when="@2.4.0:2.4.2 %gcc@14",
-          sha256="0bc20d2fcb14d8e4010d4222297f259eb7b4220effd97555ed3f027e63cf8b3")
-    patch("add_algorithm_header_222.patch",
-          when="@2.2.2:2.3.0 %gcc@14",
-          sha256="f713384de9e5eff686053dfb917fdd08f30f9720a8a9182549863f2ba12e779f")
+    patch(
+        "add_algorithm_header.patch",
+        when="@2.4.0:2.4.2 %gcc@14:",
+        sha256="0bc20d2fcb14d8e4010d4222297f259eb7b4220effd97555ed3f027e63cf8b3",
+    )
+    patch(
+        "add_algorithm_header_222.patch",
+        when="@2.2.2:2.3.0 %gcc@14:",
+        sha256="f713384de9e5eff686053dfb917fdd08f30f9720a8a9182549863f2ba12e779f",
+    )
+    conflicts("%gcc@14:", when="@:2.2.0", msg="Compilation with gcc@14: requires cdo@2.2.2:")
 
     variant("netcdf", default=True, description="Enable NetCDF support")
     variant(

--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -155,6 +155,10 @@ class Cdo(AutotoolsPackage):
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
+    # patches
+    # see https://code.mpimet.mpg.de/boards/1/topics/15594
+    patch("add_algorithm_header.patch", when="@2.4.0 %gcc@14")
+
     variant("netcdf", default=True, description="Enable NetCDF support")
     variant(
         "grib2",

--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -165,7 +165,7 @@ class Cdo(AutotoolsPackage):
     patch(
         "add_algorithm_header_222.patch",
         when="@2.2.2:2.3.0 %gcc@14:",
-        sha256="f713384de9e5eff686053dfb917fdd08f30f9720a8a9182549863f2ba12e779f",
+        sha256="db0d9bd32bbee01d914c1dbebd751403e9c918fafd540fd6ecc6a2f27e0900cf",
     )
     conflicts("%gcc@14:", when="@:2.2.0", msg="Compilation with gcc@14: requires cdo@2.2.2:")
 

--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -157,7 +157,12 @@ class Cdo(AutotoolsPackage):
 
     # patches
     # see https://code.mpimet.mpg.de/boards/1/topics/15594
-    patch("add_algorithm_header.patch", when="@2.4.0 %gcc@14")
+    patch("add_algorithm_header.patch",
+          when="@2.4.0:2.4.2 %gcc@14",
+          sha256="0bc20d2fcb14d8e4010d4222297f259eb7b4220effd97555ed3f027e63cf8b3")
+    patch("add_algorithm_header_222.patch",
+          when="@2.2.2:2.3.0 %gcc@14",
+          sha256="f713384de9e5eff686053dfb917fdd08f30f9720a8a9182549863f2ba12e779f")
 
     variant("netcdf", default=True, description="Enable NetCDF support")
     variant(

--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -160,7 +160,7 @@ class Cdo(AutotoolsPackage):
     patch(
         "add_algorithm_header.patch",
         when="@2.4.0:2.4.2 %gcc@14:",
-        sha256="0bc20d2fcb14d8e4010d4222297f259eb7b4220effd97555ed3f027e63cf8b3",
+        sha256="0bc20d2fcb14d8e4010d4222297f259eb7b4220effd97555ed3f027e63cf8b30",
     )
     patch(
         "add_algorithm_header_222.patch",


### PR DESCRIPTION
From [CDO forum](https://code.mpimet.mpg.de/boards/1/topics/15594):
> Yes, the include of \<algorithm\> is missing in this file. Unfortunately, this is only indicated with gcc 14 and we still use gcc 13. We will fix this problem in the next CDO release 2.4.1.

Patch adds missing imports for version 2.4.0