### PR TITLE
re2: fix cmake cxx std

### DIFF
--- a/var/spack/repos/builtin/packages/re2/package.py
+++ b/var/spack/repos/builtin/packages/re2/package.py
@@ -42,6 +42,10 @@ class Re2(CMakePackage):
         args = [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
-            f"-DCMAKE_CXX_STANDARD={self.spec['abseil-cpp'].variants['cxxstd'].value}",
         ]
+
+        abseil = self.spec.dependencies("abseil-cpp")
+
+        if abseil:
+            args.append(self.define("CMAKE_CXX_STANDARD", abseil[0].variants["cxxstd"].value))
         return args


### PR DESCRIPTION
I didn't check the original issue. AFAIK abseil should do `target_compile_features(absl::... PUBLIC cxx_std_...)`, and Spack shouldn't be bothered... But well.

Edit: note to self for later (https://github.com/abseil/abseil-cpp/commit/ee0ebdae4a9e789b92f5abbe8573ddeeaead4864)