### PR TITLE
Fix a bug with automatic tag detection

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -201,9 +201,12 @@ class DetectablePackageMeta(type):
         if hasattr(cls, "executables") or hasattr(cls, "libraries"):
             # Append a tag to each detectable package, so that finding them is faster
             if not hasattr(cls, "tags"):
-                setattr(cls, "tags", [DetectablePackageMeta.TAG])
+                cls.tags = [DetectablePackageMeta.TAG]
             elif DetectablePackageMeta.TAG not in cls.tags:
-                cls.tags.append(DetectablePackageMeta.TAG)
+                if "tags" in attr_dict:
+                    cls.tags.append(DetectablePackageMeta.TAG)
+                else:
+                    cls.tags = cls.tags[:] + [DetectablePackageMeta.TAG]
 
             @classmethod
             def platform_executables(cls):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -197,16 +197,12 @@ class DetectablePackageMeta(type):
         # that "foo" was a possible executable.
 
         # If a package has the executables or libraries  attribute then it's
-        # assumed to be detectable
+        # assumed to be detectable. Add a tag, so finding them is faster
         if hasattr(cls, "executables") or hasattr(cls, "libraries"):
-            # Append a tag to each detectable package, so that finding them is faster
-            if not hasattr(cls, "tags"):
-                cls.tags = [DetectablePackageMeta.TAG]
-            elif DetectablePackageMeta.TAG not in cls.tags:
-                if "tags" in attr_dict:
-                    cls.tags.append(DetectablePackageMeta.TAG)
-                else:
-                    cls.tags = cls.tags[:] + [DetectablePackageMeta.TAG]
+            # To add the tag, we need to copy the tags attribute, and attach it to
+            # the current class. We don't use append, since it might modify base classes,
+            # if "tags" is retrieved following the MRO.
+            cls.tags = getattr(cls, "tags", []) + [DetectablePackageMeta.TAG]
 
             @classmethod
             def platform_executables(cls):

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -114,11 +114,31 @@ def test_find_external_cmd_not_buildable(mutable_config, working_env, mock_execu
 @pytest.mark.parametrize(
     "names,tags,exclude,expected",
     [
-        # find --all
-        (None, ["detectable"], [], ["builtin.mock.find-externals1"]),
+        # find -all
+        (
+            None,
+            ["detectable"],
+            [],
+            [
+                "builtin.mock.find-externals1",
+                "builtin.mock.gcc",
+                "builtin.mock.llvm",
+                "builtin.mock.intel-oneapi-compilers",
+            ],
+        ),
         # find --all --exclude find-externals1
-        (None, ["detectable"], ["builtin.mock.find-externals1"], []),
-        (None, ["detectable"], ["find-externals1"], []),
+        (
+            None,
+            ["detectable"],
+            ["builtin.mock.find-externals1"],
+            ["builtin.mock.gcc", "builtin.mock.llvm", "builtin.mock.intel-oneapi-compilers"],
+        ),
+        (
+            None,
+            ["detectable"],
+            ["find-externals1"],
+            ["builtin.mock.gcc", "builtin.mock.llvm", "builtin.mock.intel-oneapi-compilers"],
+        ),
         # find cmake (and cmake is not detectable)
         (["cmake"], ["detectable"], [], []),
     ],

--- a/lib/spack/spack/test/tag.py
+++ b/lib/spack/spack/test/tag.py
@@ -153,7 +153,7 @@ def test_tag_no_tags(mock_packages):
 
 
 def test_tag_update_package(mock_packages):
-    mock_index = spack.repo.PATH.tag_index
+    mock_index = mock_packages.tag_index
     index = spack.tag.TagIndex(repository=mock_packages)
     for name in spack.repo.all_package_names():
         index.update_package(name)

--- a/var/spack/repos/builtin.mock/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin.mock/packages/intel-oneapi-compilers/package.py
@@ -8,7 +8,7 @@ import sys
 from spack.package import *
 
 
-class IntelOneapiCompilers(Package):
+class IntelOneapiCompilers(Package, CompilerPackage):
     """Simple compiler package."""
 
     homepage = "http://www.example.com"
@@ -17,6 +17,10 @@ class IntelOneapiCompilers(Package):
     version("1.0", md5="0123456789abcdef0123456789abcdef")
     version("2.0", md5="abcdef0123456789abcdef0123456789")
     version("3.0", md5="def0123456789abcdef0123456789abc")
+
+    c_names = ["icx"]
+    cxx_names = ["icpx"]
+    fortran_names = ["ifx"]
 
     @property
     def compiler_search_prefix(self):

--- a/var/spack/repos/builtin.mock/packages/llvm/package.py
+++ b/var/spack/repos/builtin.mock/packages/llvm/package.py
@@ -6,21 +6,21 @@
 from spack.package import *
 
 
-class Gcc(CompilerPackage, Package):
+class Llvm(Package, CompilerPackage):
     """Simple compiler package."""
 
     homepage = "http://www.example.com"
     url = "http://www.example.com/gcc-1.0.tar.gz"
 
-    version("1.0", md5="0123456789abcdef0123456789abcdef")
-    version("2.0", md5="abcdef0123456789abcdef0123456789")
-    version("3.0", md5="def0123456789abcdef0123456789abc")
+    version("18.1.8", md5="0123456789abcdef0123456789abcdef")
 
-    depends_on("conflict", when="@3.0")
+    variant(
+        "clang", default=True, description="Build the LLVM C/C++/Objective-C compiler frontend"
+    )
 
-    c_names = ["gcc"]
-    cxx_names = ["g++"]
-    fortran_names = ["gfortran"]
+    c_names = ["clang"]
+    cxx_names = ["clang++"]
+    fortran_names = ["flang"]
 
     def install(self, spec, prefix):
         # Create the minimal compiler that will fool `spack compiler find`


### PR DESCRIPTION
Extracted from #45638

When adding the "detectable" tag to a package class that has the "tag" attribute inherited from a base class, we need to copy it before appending.

Otherwise, we'll append to the base class, and affect anything that inherits from it afterward.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
