### PR TITLE
Bugfix: allow test_* build-time and stand-alone tests

### DIFF
--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -757,6 +757,10 @@ def test_process(pkg: Pb, kwargs):
             pkg.tester.status(pkg.spec.name, TestStatus.SKIPPED)
             return
 
+        # Make sure properly named build-time test methods actually run as
+        # stand-alone tests.
+        pkg.run_tests = True
+
         # run test methods from the package and all virtuals it provides
         v_names = virtuals(pkg)
         test_specs = [pkg.spec] + [spack.spec.Spec(v_name) for v_name in sorted(v_names)]

--- a/var/spack/repos/builtin/packages/py-shapely/package.py
+++ b/var/spack/repos/builtin/packages/py-shapely/package.py
@@ -101,6 +101,7 @@ class PyShapely(PythonPackage):
     @run_after("install")
     @on_package_attributes(run_tests=True)
     def test_install(self):
+        """Run pytest tests"""
         # https://shapely.readthedocs.io/en/latest/installation.html#testing-shapely
         if self.version >= Version("2"):
             with working_dir("spack-test", create=True):


### PR DESCRIPTION
Fixes #45698 

Use of the `on_package_attributes(run_tests=True)` decorator causes test methods whose names start `test` to be erroneously reported as passing stand-alone tests when they don't actually run. 

This PR resolves that issue.  For example, `py-shapely` stand-alone test *before* this fix:

```
$ spack -v test run py-shapely
...
==> [2024-08-12-12:23:36.310686] test: test_install: Run pytest tests
PASSED: PyShapely::test_install
==> [2024-08-12-12:23:36.312708] Completed testing
...
```

and *after* this fix:

```
$ spack -v test run py-shapely
...
==> [2024-08-12-12:40:16.311638] test: test_install: Run pytest tests
Running test_install
==> [2024-08-12-12:40:16.312198] '$spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10' '-m' 'pytest' '--pyargs' 'shapely.tests'
$spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/python-3.10.10-uypaufv2bj3q56bfc2qpr3pfujo6odba/bin/python3.10: No module named pytest
FAILED: PyShapely::test_install: Command exited with status 1:
...
```


Note: This PR does *not* address the issue with Spack not tracking `test` dependencies needed (in the package above, for example) for stand-alone testing.