### PR TITLE
Update ESMF: add missing python/py-pyyaml dependency since 8.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -69,6 +69,10 @@ class Esmf(MakefilePackage):
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
+    # In esmf@8.4.0, esmx was introduced which depends on py-pyyaml
+    depends_on("python", when="@8.4.0:", type="run")
+    depends_on("py-pyyaml", when="@8.4.0:", type="run")
+
     variant("mpi", default=True, description="Build with MPI support")
     variant("external-lapack", default=False, description="Build with external LAPACK library")
     variant("netcdf", default=True, description="Build with NetCDF support")


### PR DESCRIPTION
In `esmf@8.4.0`, the `esmx` tool was added and it looks like it is always built (i.e. no optional component/variant):

https://github.com/esmf-org/esmf/blob/v8.4.0/makefile

`esmx` depends on `py-pyyaml` (and therefore `python`) at runtime. The minimum Python version in spack is 3.7, and lacking any further information on the Python requirements for `esmx` (see https://earthsystemmodeling.org/docs/nightly/develop/ESMF_usrdoc), I simply added `python` and `py-pyyaml` as dependencies.

If any of the ESMF developers knows better which versions of `python` and `py-pyyaml` are required, please let me know!

**Update** Based on the exchange below, the minimum versions in spack are safe options, and so are the current defaults. Therefore, not specifying any version constraints.