### PR TITLE
activeharmony: replace dead links

### DIFF
--- a/var/spack/repos/builtin/packages/activeharmony/package.py
+++ b/var/spack/repos/builtin/packages/activeharmony/package.py
@@ -10,13 +10,13 @@ class Activeharmony(MakefilePackage):
     """Active Harmony: a framework for auto-tuning (the automated search for
     values to improve the performance of a target application)."""
 
-    homepage = "https://www.dyninst.org/harmony"
-    url = "https://www.dyninst.org/sites/default/files/downloads/harmony/ah-4.5.tar.gz"
+    homepage = "https://github.com/ActiveHarmony/harmony"
+    url = "https://github.com/ActiveHarmony/harmony/archive/refs/tags/v4.5.tar.gz"
 
     license("LGPL-3.0-only")
 
-    version("4.6.0", sha256="9ce5009cfd8e2f4cf5f3536e1fea9993414fc25920fc90d0a2cb56f044787dbb")
-    version("4.5", sha256="31d9990c8dd36724d336707d260aa4d976e11eaa899c4c7cc11f80a56cdac684")
+    version("4.6.0", sha256="01011c0c455fca31e5806b03743e27a12161c152253370894876f851242ccd51")
+    version("4.5", sha256="74bde94f6c4f710a5003b0111f27fe3ba98161505e0155a87e94dd209b586951")
 
     patch(
         "fix_logical_bug_in_slave_list_parsing.patch",


### PR DESCRIPTION
The URLs in activeharmony are dead. This replaces them with GitHub equivalents.

The original sha checksums can be confirmed using the Internet archive:
```console
17:08:53 wdconinc@menelaos ~ $ curl -L https://web.archive.org/web/20170307142744/https://www.dyninst.org/sites/default/files/downloads/harmony/ah-4.6.0.tar.gz | sha256sum
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- -  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
 10  785k   10 81902    0     0   118k      0  0:00:06 --:--:--  100  785k  100  785k    0     0   819k      0 --:--:-- --:--:-- --:--:-- 2500k
9ce5009cfd8e2f4cf5f3536e1fea9993414fc25920fc90d0a2cb56f044787dbb  -
17:09:01 wdconinc@menelaos ~ $ curl -L https://web.archive.org/web/20170307142744/https://www.dyninst.org/sites/default/files/downloads/harmony/ah-4.5.tar.gz | sha256sum
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- -  0     0    0     0    0     0      0      0 --:--:-- --:--:-- -  0     0    0     0    0     0      0      0 --:--:--  0:00:01 -  0     0    0     0    0     0      0      0 --:--:--  0:00:02 -  0     0    0     0    0     0      0      0 --:--:--  0:00:03 - 25  830k   25  207k    0     0  51141      0  0:00:16  0:00:04   70  830k   70  589k    0     0   113k      0  0:00:07  0:00:05  100  830k  100  830k    0     0   145k      0  0:00:05  0:00:05 --:--:--  194k
31d9990c8dd36724d336707d260aa4d976e11eaa899c4c7cc11f80a56cdac684  -
```

The GitHub versions are different in gitignore and documentation:
```console
17:03:14 wdconinc@menelaos ~ $ diff -r activeharmony-4.5/ harmony-4.5/
Only in harmony-4.5/code-server: .gitignore
Only in harmony-4.5/doc: .gitignore
Only in activeharmony-4.5/doc: Users_Guide.html
Only in activeharmony-4.5/doc: Users_Guide.pdf
Only in harmony-4.5/example: .gitignore
Only in harmony-4.5/: .gitignore
Only in harmony-4.5/src: .gitignore
Only in harmony-4.5/: WIP
17:03:49 wdconinc@menelaos ~ $ diff -r activeharmony-4.6.0/ harmony-4.6.0/
Only in harmony-4.6.0/code-server: .gitignore
Only in harmony-4.6.0/doc: doxygen
Only in harmony-4.6.0/doc: .gitignore
Only in harmony-4.6.0/doc: images
Only in harmony-4.6.0/doc: Makefile
Only in harmony-4.6.0/doc: Message-Flow-Diagrams
Only in activeharmony-4.6.0/doc: Users_Guide.html
Only in activeharmony-4.6.0/doc: Users_Guide.pdf
Only in harmony-4.6.0/example: .gitignore
Only in harmony-4.6.0/: .gitignore
Only in harmony-4.6.0/src: .gitignore
```