### PR TITLE
magic-enum: fix minimum compiler versions conflicts

### DIFF
--- a/var/spack/repos/builtin/packages/magic-enum/package.py
+++ b/var/spack/repos/builtin/packages/magic-enum/package.py
@@ -21,7 +21,6 @@ class MagicEnum(CMakePackage):
     version("0.9.6", sha256="814791ff32218dc869845af7eb89f898ebbcfa18e8d81aa4d682d18961e13731")
 
     variant("examples", default=False, description="Enable examples")
-    variant("tests", default=True, description="Enable tests")
 
     # minimum supported versions
     conflicts("%clang@:4")
@@ -38,7 +37,7 @@ class MagicEnum(CMakePackage):
 
         args = [
             from_variant("MAGIC_ENUM_OPT_BUILD_EXAMPLES", "examples"),
-            from_variant("MAGIC_ENUM_OPT_BUILD_TESTS", "tests"),
+            from_variant("MAGIC_ENUM_OPT_BUILD_TESTS", self.run_tests),
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/magic-enum/package.py
+++ b/var/spack/repos/builtin/packages/magic-enum/package.py
@@ -33,11 +33,12 @@ class MagicEnum(CMakePackage):
     depends_on("cmake@3.14:", type="build")
 
     def cmake_args(self):
+        define = self.define
         from_variant = self.define_from_variant
 
         args = [
+            define("MAGIC_ENUM_OPT_BUILD_TESTS", self.run_tests),
             from_variant("MAGIC_ENUM_OPT_BUILD_EXAMPLES", "examples"),
-            from_variant("MAGIC_ENUM_OPT_BUILD_TESTS", self.run_tests),
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/magic-enum/package.py
+++ b/var/spack/repos/builtin/packages/magic-enum/package.py
@@ -24,10 +24,10 @@ class MagicEnum(CMakePackage):
     variant("tests", default=True, description="Enable tests")
 
     # minimum supported versions
-    conflicts("%clang@:5")
-    conflicts("%gcc@:9")
-    conflicts("%msvc@:14.11")
-    conflicts("%apple-clang@:10")
+    conflicts("%clang@:4")
+    conflicts("%gcc@:8")
+    conflicts("%msvc@:14.10")
+    conflicts("%apple-clang@:9")
 
     depends_on("cxx", type="build")
 

--- a/var/spack/repos/builtin/packages/magic-enum/package.py
+++ b/var/spack/repos/builtin/packages/magic-enum/package.py
@@ -22,11 +22,11 @@ class MagicEnum(CMakePackage):
 
     variant("examples", default=False, description="Enable examples")
 
-    # minimum supported versions
-    conflicts("%clang@:4")
-    conflicts("%gcc@:8")
-    conflicts("%msvc@:14.10")
-    conflicts("%apple-clang@:9")
+    with default_args(msg="Compiler version is too old"):
+        conflicts("%clang@:4")
+        conflicts("%gcc@:8")
+        conflicts("%msvc@:14.10")
+        conflicts("%apple-clang@:9")
 
     depends_on("cxx", type="build")
 


### PR DESCRIPTION
I thought versions ranges were exclusive not inclusive. 

Just to double check these conflicts with another reviewer these should match up with the following minimum support compiler versions.
- Clang/LLVM >= 5
- MSVC++ >= 14.11 / Visual Studio >= 2017
- Xcode >= 10
- GCC >= 9

Also remove `tests` variant in favor of `self.run_tests`