### PR TITLE
mlpack: add v4.2.1, v4.3.0, v4.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/mlpack/package.py
+++ b/var/spack/repos/builtin/packages/mlpack/package.py
@@ -18,8 +18,11 @@ class Mlpack(CMakePackage):
 
     maintainers("wdconinc")
 
-    license("BSD-3-Clause")
+    license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("4.4.0", sha256="61c604026d05af26c244b0e47024698bbf150dfcc9d77b64057941d7d64d6cf6")
+    version("4.3.0", sha256="08cd54f711fde66fc3b6c9db89dc26776f9abf1a6256c77cfa3556e2a56f1a3d")
+    version("4.2.1", sha256="2d2b8d61dc2e3179e0b6fefd5c217c57aa168c4d0b9c6868ddb94f6395a80dd5")
     version("4.2.0", sha256="f780df984a71029e62eeecdd145fb95deb71b133cefc7840de0ec706d116dd60")
     version("4.1.0", sha256="e0c760baf15fd0af5601010b7cbc536e469115e9dd45f96712caa3b651b1852a")
     version("4.0.1", sha256="4c746936ed9da9f16744240ed7b9f2815d3abb90c904071a1d1a628a9bbfb3a5")
@@ -38,6 +41,10 @@ class Mlpack(CMakePackage):
     depends_on("armadillo@9.800:")
     depends_on("ensmallen@2.10.0:")
     depends_on("cereal@1.1.2:")
+
+    # Compiler conflicts
+    conflicts("%gcc@:4", when="@4.0:", msg="mlpack 4.0+ requires at least gcc-5 with C++14")
+    conflicts("%gcc@:7", when="@4.4:", msg="mlpack 4.4+ requires at least gcc-8 with C++17")
 
     # TODO: Go bindings are not supported due to the absence of gonum in spack
     # with when("+go"):


### PR DESCRIPTION
This PR adds `mlpack` versions through v4.4.0 (last patch level of the minor versions), [release notes](https://github.com/mlpack/mlpack/releases/tag/4.4.0). No dependency versions have changed, but due to the requirement for C++17, the minimum gcc version has increased (that is the only compiler with a hard requirement).

Test build:
```
==> Installing mlpack-4.4.0-ko45rvu67rfqmw7epkfhjaysehl3lvqr [61/61]
==> No binary for mlpack-4.4.0-ko45rvu67rfqmw7epkfhjaysehl3lvqr found: installing from source
==> Fetching https://github.com/mlpack/mlpack/archive/refs/tags/4.4.0.tar.gz
==> No patches needed for mlpack
==> mlpack: Executing phase: 'cmake'
==> mlpack: Executing phase: 'build'
==> mlpack: Executing phase: 'install'
==> mlpack: Successfully installed mlpack-4.4.0-ko45rvu67rfqmw7epkfhjaysehl3lvqr
  Stage: 2.83s.  Cmake: 2.10s.  Build: 47m 29.38s.  Install: 4m 42.14s.  Post-install: 5.59s.  Total: 52m 24.65s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/mlpack-4.4.0-ko45rvu67rfqmw7epkfhjaysehl3lvqr
```