### PR TITLE
Improve external detection tests for compilers

### DIFF
--- a/var/spack/repos/builtin/packages/aocc/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/aocc/detection_test.yaml
@@ -5,9 +5,9 @@ paths:
     - "bin/clang++"
     - "bin/flang"
     script: |
-      echo "AMD clang version 12.0.0 (CLANG: AOCC_3_1_0-Build#126 2021_06_07)(based on LLVM Mirror.Version.12.0.0)\n"
-      echo "Target: x86_64-unknown-linux-gnu\n"
-      echo "Thread model: posix\n"
+      echo "AMD clang version 12.0.0 (CLANG: AOCC_3_1_0-Build#126 2021_06_07)(based on LLVM Mirror.Version.12.0.0)"
+      echo "Target: x86_64-unknown-linux-gnu"
+      echo "Thread model: posix"
   platforms: [linux]
   results:
   - spec: aocc@3.1.0
@@ -21,9 +21,9 @@ paths:
     - "bin/clang"
     - "bin/clang++"
     script: |
-      echo "AMD clang version 12.0.0 (CLANG: AOCC_3_1_0-Build#126 2021_06_07)(based on LLVM Mirror.Version.12.0.0)\n"
-      echo "Target: x86_64-unknown-linux-gnu\n"
-      echo "Thread model: posix\n"
+      echo "AMD clang version 12.0.0 (CLANG: AOCC_3_1_0-Build#126 2021_06_07)(based on LLVM Mirror.Version.12.0.0)"
+      echo "Target: x86_64-unknown-linux-gnu"
+      echo "Thread model: posix"
   platforms: [linux]
   results:
   - spec: aocc@3.1.0
@@ -37,17 +37,17 @@ paths:
     - "bin/clang++"
     - "bin/flang"
     script: |
-      echo "AMD clang version 12.0.0 (CLANG: AOCC_3_0_0-Build#78 2020_12_10)(based on LLVM Mirror.Version.12.0.0)\n"
-      echo "Target: x86_64-unknown-linux-gnu\n"
-      echo "Thread model: posix\n"
+      echo "AMD clang version 12.0.0 (CLANG: AOCC_3_0_0-Build#78 2020_12_10)(based on LLVM Mirror.Version.12.0.0)"
+      echo "Target: x86_64-unknown-linux-gnu"
+      echo "Thread model: posix"
   - executables:
     - "bin/clang-11"
     - "bin/clang++-11"
     - "bin/flang-11"
     script: |
-      echo "AMD clang version 11.0.0 (CLANG: AOCC_2_3_0-Build#85 2020_11_10)(based on LLVM Mirror.Version.11.0.0)\n"
-      echo "Target: x86_64-unknown-linux-gnu\n"
-      echo "Thread model: posix\n"
+      echo "AMD clang version 11.0.0 (CLANG: AOCC_2_3_0-Build#85 2020_11_10)(based on LLVM Mirror.Version.11.0.0)"
+      echo "Target: x86_64-unknown-linux-gnu"
+      echo "Thread model: posix"
   platforms: [linux]
   results:
   - spec: aocc@3.0.0
@@ -67,7 +67,7 @@ paths:
     - "bin/clang"
     - "bin/clang++"
     script: |
-      echo "clang version 8.0.0 (tags/RELEASE_800/final"
+      echo "clang version 8.0.0 (tags/RELEASE_800/final)"
       echo "Target: x86_64-unknown-linux-gnu\n"
       echo "Thread model: posix\n"
       echo "InstalledDir: /usr/bin"

--- a/var/spack/repos/builtin/packages/cce/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/cce/detection_test.yaml
@@ -42,3 +42,16 @@ paths:
         c: ".*/bin/craycc"
         cxx: ".*/bin/crayCC"
         fortran: ".*/bin/crayftn"
+
+# Apple Clang should not be detected
+- layout:
+  - executables:
+    - "bin/clang"
+    - "bin/clang++"
+    script: |
+      echo "Apple clang version 11.0.0 (clang-1100.0.33.8)"
+      echo "Target: x86_64-apple-darwin19.5.0"
+      echo "Thread model: posix"
+      echo "InstalledDir: /Library/Developer/CommandLineTools/usr/bin"
+  platforms: ["darwin"]
+  results: []

--- a/var/spack/repos/builtin/packages/llvm/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/llvm/detection_test.yaml
@@ -2,12 +2,6 @@ paths:
 - layout:
   - executables:
     - "bin/clang-3.9"
-    script: |
-      echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
-      echo "Target: x86_64-pc-linux-gnu"
-      echo "Thread model: posix"
-      echo "InstalledDir: /usr/bin"
-  - executables:
     - "bin/clang++-3.9"
     script: |
       echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
@@ -21,6 +15,42 @@ paths:
       compilers:
         c: ".*/bin/clang-3.9$"
         cxx: ".*/bin/clang[+][+]-3.9$"
+
+# `~` and other weird characters in the version string
+- layout:
+  - executables:
+    - "bin/clang-6.0"
+    - "bin/clang++-6.0"
+    script: |
+        echo "clang version 6.0.1-svn334776-1~exp1~20181018152737.116 (branches/release_60)"
+        echo "Target: x86_64-pc-linux-gnu"
+        echo "Thread model: posix"
+        echo "InstalledDir: /usr/bin",
+
+  platforms: ["darwin", "linux"]
+  results:
+  - spec: 'llvm@6.0.1 +clang~lld~lldb'
+    extra_attributes:
+      compilers:
+        c: ".*/bin/clang-6.0$"
+        cxx: ".*/bin/clang[+][+]-6.0$"
+- layout:
+  - executables:
+    - "bin/clang-9.0"
+    - "bin/clang++-9.0"
+    script: |      
+        echo "clang version 9.0.1-+201911131414230800840845a1eea-1~exp1~20191113231141.78"
+        echo "Target: x86_64-pc-linux-gnu"
+        echo "Thread model: posix"
+        echo "InstalledDir: /usr/bin"
+
+  platforms: ["darwin", "linux"]
+  results:
+  - spec: 'llvm@9.0.1 +clang~lld~lldb'
+    extra_attributes:
+      compilers:
+        c: ".*/bin/clang-9.0$"
+        cxx: ".*/bin/clang[+][+]-9.0$"
 
 # Multiple LLVM packages in the same prefix
 - layout:

--- a/var/spack/repos/builtin/packages/pgi/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/pgi/detection_test.yaml
@@ -9,3 +9,25 @@ paths:
   platforms: [linux]
   results:
   - spec: pgi@15.10
+
+- layout:
+  - executables:
+    - bin/pgcc
+    script: |
+        echo "pgcc 17.4-0 linuxpower target on Linuxpower"
+        echo "PGI Compilers and Tools"
+        echo "Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved."
+  platforms: [linux]
+  results:
+  - spec: pgi@17.4
+
+- layout:
+  - executables:
+    - bin/pgcc
+    script: |
+        echo "pgcc-llvm 18.4-0 LLVM 64-bit target on x86-64 Linux -tp haswell"
+        echo "PGI Compilers and Tools"
+        echo "Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved."
+  platforms: [linux]
+  results:
+  - spec: pgi@18.4


### PR DESCRIPTION
Extracted from #44419

This adds / modifies some external detection tests for compilers, to reproduce cases that are currently tested in unit tests.

The unit tests will later be removed.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
