### PR TITLE
py-numcodecs: add v0.12.0, v0.12.1, v0.13.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-numcodecs/package.py
+++ b/var/spack/repos/builtin/packages/py-numcodecs/package.py
@@ -24,6 +24,9 @@ class PyNumcodecs(PythonPackage):
 
     version("main", branch="main", submodules=True)
     version("master", branch="main", submodules=True, deprecated=True)
+    version("0.13.0", sha256="ba4fac7036ea5a078c7afe1d4dffeb9685080d42f19c9c16b12dad866703aa2e")
+    version("0.12.1", sha256="05d91a433733e7eef268d7e80ec226a0232da244289614a8f3826901aec1098e")
+    version("0.12.0", sha256="6388e5f4e94d18a7165fbd1c9d3637673b74157cff8bc644005f9e2a4c717d6e")
     version("0.11.0", sha256="6c058b321de84a1729299b0eae4d652b2e48ea1ca7f9df0da65cb13470e635eb")
     version("0.7.3", sha256="022b12ad83eb623ec53f154859d49f6ec43b15c36052fa864eaf2d9ee786dd85")
     version("0.6.4", sha256="ef4843d5db4d074e607e9b85156835c10d006afc10e175bda62ff5412fca6e4d")
@@ -32,7 +35,8 @@ class PyNumcodecs(PythonPackage):
 
     variant("msgpack", default=False, description="Codec to encode data as msgpacked bytes.")
 
-    depends_on("python@3.8:", when="@0.11:", type=("build", "link", "run"))
+    depends_on("python@3.10:", when="@0.13:", type=("build", "link", "run"))
+    depends_on("python@3.8:", when="@0.11:0.12", type=("build", "link", "run"))
     depends_on("python@3.6:3", when="@0.7:0.10", type=("build", "link", "run"))
     depends_on("py-setuptools@64:", when="@0.11:", type="build")
     depends_on("py-setuptools@18.1:", type="build")


### PR DESCRIPTION
- add new available versions of py-numcodecs
- update compatible Python versions
- change git branch from master to main (as done on numcodecs repository)