### PR TITLE
py-pyyaml: add 6.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyyaml/package.py
+++ b/var/spack/repos/builtin/packages/py-pyyaml/package.py
@@ -13,6 +13,8 @@ class PyPyyaml(PythonPackage):
     pypi = "PyYAML/PyYAML-5.3.1.tar.gz"
     git = "https://github.com/yaml/pyyaml.git"
 
+    maintainers("mathomp4")
+
     license("MIT")
 
     # Advice for Maintainers:

--- a/var/spack/repos/builtin/packages/py-pyyaml/package.py
+++ b/var/spack/repos/builtin/packages/py-pyyaml/package.py
@@ -15,7 +15,8 @@ class PyPyyaml(PythonPackage):
 
     license("MIT")
 
-    # NOTE: PyYAML went from a mixed case tarfile name to a lowercase one in 6.0.2
+    # Advice for Maintainers:
+    # PyYAML went from a mixed case tarfile name to a lowercase one in 6.0.2
     # (see url_for_version below). Since "spack checksum" does not use url_for_version,
     # from now on, you'll need to use "spack checksum py-pyyaml x.y.z" because
     # the versioned call into "spack checksum" does use url_for_version.

--- a/var/spack/repos/builtin/packages/py-pyyaml/package.py
+++ b/var/spack/repos/builtin/packages/py-pyyaml/package.py
@@ -10,7 +10,7 @@ class PyPyyaml(PythonPackage):
     """PyYAML is a YAML parser and emitter for Python."""
 
     homepage = "https://pyyaml.org/wiki/PyYAML"
-    pypi = "PyYAML/PyYAML-5.3.1.tar.gz"
+    pypi = "pyyaml/pyyaml-6.0.2.tar.gz"
     git = "https://github.com/yaml/pyyaml.git"
 
     maintainers("mathomp4")
@@ -20,8 +20,8 @@ class PyPyyaml(PythonPackage):
     # Advice for Maintainers:
     # PyYAML went from a mixed case tarfile name to a lowercase one in 6.0.2
     # (see url_for_version below). Since "spack checksum" does not use url_for_version,
-    # from now on, you'll need to use "spack checksum py-pyyaml x.y.z" because
-    # the versioned call into "spack checksum" does use url_for_version.
+    # for versions older than 6.0.2, you'll need to use "spack checksum py-pyyaml x.y.z"
+    # as we changed the pypi url above to lowercase.
     version("6.0.2", sha256="d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e")
     version("6.0.1", sha256="bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43")
     version("6.0", sha256="68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2")

--- a/var/spack/repos/builtin/packages/py-pyyaml/package.py
+++ b/var/spack/repos/builtin/packages/py-pyyaml/package.py
@@ -15,6 +15,11 @@ class PyPyyaml(PythonPackage):
 
     license("MIT")
 
+    # NOTE: PyYAML went from a mixed case tarfile name to a lowercase one in 6.0.2
+    # (see url_for_version below). Since "spack checksum" does not use url_for_version,
+    # from now on, you'll need to use "spack checksum py-pyyaml x.y.z" because
+    # the versioned call into "spack checksum" does use url_for_version.
+    version("6.0.2", sha256="d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e")
     version("6.0.1", sha256="bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43")
     version("6.0", sha256="68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2")
     version("5.4.1", sha256="607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e")
@@ -38,7 +43,16 @@ class PyPyyaml(PythonPackage):
     conflicts("^python@3.11:", when="@:5.3")
 
     # https://github.com/yaml/pyyaml/issues/601
-    conflicts("^py-cython@3:")
+    # 6.0.2+ do now support Cython 3 per release notes
+    conflicts("^py-cython@3:", when="@:6.0.1")
+
+    # With pyyaml 6.0.2, the tarfile changed from PyYAML-6.0.1.tar.gz to pyyaml-6.0.2.tar.gz
+    def url_for_version(self, version):
+        if version >= Version("6.0.2"):
+            url = "https://pypi.io/packages/source/p/pyyaml/pyyaml-{0}.tar.gz"
+        else:
+            url = "https://pypi.io/packages/source/P/PyYAML/PyYAML-{0}.tar.gz"
+        return url.format(version.dotted)
 
     @property
     def import_modules(self):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This updates py-pyyaml to 6.0.2

Note 1: With py-pyyaml 6.0.2, the tarfile name on PyPI changed to lowercase, so we add an `url_for_version()` function. I also added some "advice for maintainers" as it turns out a plain `spack checksum` does not go through `url_for_version()` (see https://github.com/spack/spack/issues/5356#issuecomment-329825538 by @adamjstewart), but `spack checksum package version` does. Per @adamjstewart below, we also make the `pypi` url lowercase. So now `spack checksum` works for future versions, though checksumming any older versions will need the long command.

Note 2: Per the [release notes for 6.0.2](https://github.com/yaml/pyyaml/releases/tag/6.0.2), @nitzmahone says:

> ## What's Changed
> Support for Cython 3.x and Python 3.13.

Per that, we relax a `conflict()` in the recipe. I tested this with:
```
spack install pyyaml@6.0.2 ^py-cython@3
spack install mepo
```
where `spack spec mepo` does show `py-pyyaml` based on `py-cython@3` and `mepo` worked so...seems good.