### PR TITLE
`spack find`/`-c`: improve wording for size-zero cases

### DIFF
--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -374,13 +374,9 @@ def find(parser, args):
                     concretized_suffix += " (show with `spack find -c`)"
 
             pkg_type = "loaded" if args.loaded else "installed"
-            spack.cmd.print_how_many_pkgs(
-                already_installed, pkg_type, suffix=installed_suffix
-            )
+            spack.cmd.print_how_many_pkgs(already_installed, pkg_type, suffix=installed_suffix)
 
             if env:
                 spack.cmd.print_how_many_pkgs(
-                    to_be_installed,
-                    "concretized",
-                    suffix=concretized_suffix,
+                    to_be_installed, "concretized", suffix=concretized_suffix
                 )

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -368,10 +368,10 @@ def find(parser, args):
             to_be_installed = list(x for x in results if not x.installed)
             if env and (to_be_installed or args.show_concretized):
                 concretized_suffix = " to be installed"
-                if args.only_roots and to_be_installed:
-                    concretized_suffix += " (not shown)"
-                else:
-                    if (not args.show_concretized) and to_be_installed:
+                if to_be_installed:
+                    if args.only_roots:
+                        concretized_suffix += " (not shown)"
+                    elif not args.show_concretized:
                         concretized_suffix += " (show with `spack find -c`)"
 
                 spack.cmd.print_how_many_pkgs(

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -366,12 +366,12 @@ def find(parser, args):
             spack.cmd.print_how_many_pkgs(already_installed, pkg_type, suffix=installed_suffix)
 
             to_be_installed = list(x for x in results if not x.installed)
-            if env and to_be_installed:
+            if env and (to_be_installed or args.show_concretized):
                 concretized_suffix = " to be installed"
-                if args.only_roots:
+                if args.only_roots and to_be_installed:
                     concretized_suffix += " (not shown)"
                 else:
-                    if not args.show_concretized:
+                    if (not args.show_concretized) and to_be_installed:
                         concretized_suffix += " (show with `spack find -c`)"
             
                 spack.cmd.print_how_many_pkgs(

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -359,24 +359,21 @@ def find(parser, args):
         # print number of installed packages last (as the list may be long)
         if sys.stdout.isatty() and args.groups:
             already_installed = list(x for x in results if x.installed)
-            to_be_installed = list(x for x in results if not x.installed)
-
             installed_suffix = ""
-            concretized_suffix = " to be installed"
-
-            if args.only_roots:
-                if already_installed:
-                    installed_suffix += " (not shown)"
-                if to_be_installed:
-                    concretized_suffix += " (not shown)"
-            else:
-                if env and (not args.show_concretized) and to_be_installed:
-                    concretized_suffix += " (show with `spack find -c`)"
-
+            if args.only_roots and already_installed:
+                installed_suffix += " (not shown)"
             pkg_type = "loaded" if args.loaded else "installed"
             spack.cmd.print_how_many_pkgs(already_installed, pkg_type, suffix=installed_suffix)
 
-            if env:
+            to_be_installed = list(x for x in results if not x.installed)
+            if env and to_be_installed:
+                concretized_suffix = " to be installed"
+                if args.only_roots:
+                    concretized_suffix += " (not shown)"
+                else:
+                    if not args.show_concretized:
+                        concretized_suffix += " (show with `spack find -c`)"
+            
                 spack.cmd.print_how_many_pkgs(
                     to_be_installed, "concretized", suffix=concretized_suffix
                 )

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -373,7 +373,7 @@ def find(parser, args):
                 else:
                     if (not args.show_concretized) and to_be_installed:
                         concretized_suffix += " (show with `spack find -c`)"
-            
+
                 spack.cmd.print_how_many_pkgs(
                     to_be_installed, "concretized", suffix=concretized_suffix
                 )

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -358,24 +358,29 @@ def find(parser, args):
 
         # print number of installed packages last (as the list may be long)
         if sys.stdout.isatty() and args.groups:
+            already_installed = list(x for x in results if x.installed)
+            to_be_installed = list(x for x in results if not x.installed)
+
             installed_suffix = ""
             concretized_suffix = " to be installed"
 
             if args.only_roots:
-                installed_suffix += " (not shown)"
-                concretized_suffix += " (not shown)"
+                if already_installed:
+                    installed_suffix += " (not shown)"
+                if to_be_installed:
+                    concretized_suffix += " (not shown)"
             else:
-                if env and not args.show_concretized:
+                if env and (not args.show_concretized) and to_be_installed:
                     concretized_suffix += " (show with `spack find -c`)"
 
             pkg_type = "loaded" if args.loaded else "installed"
             spack.cmd.print_how_many_pkgs(
-                list(x for x in results if x.installed), pkg_type, suffix=installed_suffix
+                already_installed, pkg_type, suffix=installed_suffix
             )
 
             if env:
                 spack.cmd.print_how_many_pkgs(
-                    list(x for x in results if not x.installed),
+                    to_be_installed,
                     "concretized",
                     suffix=concretized_suffix,
                 )


### PR DESCRIPTION
https://github.com/spack/spack/pull/44713 added information about concretized-but-not-yet-installed packages, but the wording is awkward when there are no such packages in this category:

```
bash-3.2$ spack find
...
==> 1 installed package
==> 0 concretized packages to be installed (show with `spack find -c`)


bash-3.2$ spack find -r
...
==> 1 installed package (not shown)
==> 0 concretized packages to be installed (not shown)
```

This improves the messages, e.g. removing "not shown" if there is in fact nothing to show:

```
$ spack find
...
==> 1 installed package
==> 0 concretized packages to be installed

$ spack find -r
...
==> 1 installed package (not shown)
==> 0 concretized packages to be installed
```

This could completely omit any message if there are 0 such packages, although IMO knowing that there are 0 is useful (and it's consistent with the behavior for installed packages).