### PR TITLE
OneapiPackage: do not use getpass.getuser

### DIFF
--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -12,12 +12,12 @@ from llnl.util import tty
 from llnl.util.filesystem import HeaderList, LibraryList, find_libraries, join_path, mkdirp
 from llnl.util.link_tree import LinkTree
 
+import spack.util.path
 from spack.build_environment import dso_suffix
 from spack.directives import conflicts, license, redistribute, variant
 from spack.package_base import InstallError
 from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable
-import spack.util.path
 
 from .generic import Package
 

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Common utilities for managing intel oneapi packages."""
-import getpass
 import os
 import platform
 import shutil
@@ -18,6 +17,7 @@ from spack.directives import conflicts, license, redistribute, variant
 from spack.package_base import InstallError
 from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable
+import spack.util.path
 
 from .generic import Package
 
@@ -99,7 +99,7 @@ class IntelOneApiPackage(Package):
             # with other install depends on the userid. For root, we
             # delete the installercache before and after install. For
             # non root we redefine the HOME environment variable.
-            if getpass.getuser() == "root":
+            if spack.util.path.get_user() == "root":
                 shutil.rmtree("/var/intel/installercache", ignore_errors=True)
 
             bash = Executable("bash")
@@ -122,7 +122,7 @@ class IntelOneApiPackage(Package):
                 self.prefix,
             )
 
-            if getpass.getuser() == "root":
+            if spack.util.path.get_user() == "root":
                 shutil.rmtree("/var/intel/installercache", ignore_errors=True)
 
         # Some installers have a bug and do not return an error code when failing


### PR DESCRIPTION
`OneapiPackage` has conditional logic to avoid caching the intel install root between separate packages when running as root, conditioned by `getpass.getuser`.

`getpass.getuser` reports the user incorrectly on linux when running in a Charliecloud container (have not tested other container runtimes). We already have a method `spack.util.path.get_user` that uses more advanced detection for linux and falls back on getpass.

This PR updates `OneapiPackage` to use `spack.util.path.get_user`.

@rscohn2 @nicholas-sly 