### PR TITLE
bind9: add v9.18.28, v9.20.0

### DIFF
--- a/var/spack/repos/builtin/packages/bind9/package.py
+++ b/var/spack/repos/builtin/packages/bind9/package.py
@@ -30,8 +30,5 @@ class Bind9(AutotoolsPackage):
     depends_on("liburcu@0.14:", type="link", when="@9.20:")
 
     def configure_args(self):
-        args = [
-            "--without-python",
-            "--disable-doh",
-        ]
+        args = ["--without-python", "--disable-doh"]
         return args

--- a/var/spack/repos/builtin/packages/bind9/package.py
+++ b/var/spack/repos/builtin/packages/bind9/package.py
@@ -11,22 +11,27 @@ class Bind9(AutotoolsPackage):
     BIND 9 has evolved to be a very flexible, full-featured DNS system.
     """
 
-    homepage = "https://github.com/isc-projects/bind9"
-    url = "https://github.com/isc-projects/bind9/archive/v9_14_6.tar.gz"
+    homepage = "https://www.isc.org"
+    url = "https://downloads.isc.org/isc/bind9/9.18.28/bind-9.18.28.tar.xz"
+    list_url = "https://downloads.isc.org/isc/bind9/"
+    git = "https://gitlab.isc.org/isc-projects/bind9"
 
-    license("Apache-2.0")
+    license("MPL-2.0", checked_by="wdconinc")
 
-    version("9_14_6", sha256="98be7a7b6d614b519f6c8d6ec7a8a39759ae9604d87228d9dc7c034471e5433e")
+    # Only even minor releases are stable
+    version("9.20.0", sha256="cc580998017b51f273964058e8cb3aa5482bc785243dea71e5556ec565a13347")
+    version("9.18.28", sha256="e7cce9a165f7b619eefc4832f0a8dc16b005d29e3890aed6008c506ea286a5e7")
 
-    depends_on("libuv", type="link")
     depends_on("pkgconfig", type="build")
-    depends_on("openssl", type="link")
-    depends_on("iconv", type="link")
+
+    depends_on("libuv@1.34,1.37:", type="link")
+    depends_on("openssl@1.1.1:", type="link")
+    depends_on("libcap", type="link")
+    depends_on("liburcu@0.14:", type="link", when="@9.20:")
 
     def configure_args(self):
         args = [
             "--without-python",
-            "--disable-linux-caps",
-            "--with-openssl={0}".format(self.spec["openssl"].prefix),
+            "--disable-doh",
         ]
         return args

--- a/var/spack/repos/builtin/packages/liburcu/package.py
+++ b/var/spack/repos/builtin/packages/liburcu/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Liburcu(AutotoolsPackage):
+    """liburcu is a LGPLv2.1 userspace RCU (read-copy-update) library.
+    This data synchronization library provides read-side access which
+    scales linearly with the number of cores."""
+
+    homepage = "https://liburcu.org"
+    url = "https://lttng.org/files/urcu/userspace-rcu-0.14.0.tar.bz2"
+    git = "https://git.lttng.org/userspace-rcu.git"
+
+    license("LGPL-2.1", checked_by="wdconinc")
+
+    version("0.14.0", sha256="ca43bf261d4d392cff20dfae440836603bf009fce24fdc9b2697d837a2239d4f")
+
+    depends_on("autoconf@2.69:", type="build")
+    depends_on("automake@1.12:", type="build")
+
+    def patch(self):
+        filter_file("-Wl,-rpath ", "-Wl,-rpath,", "doc/examples/Makefile.in")


### PR DESCRIPTION
The URL for the version of `bind9` in spack was dead (and ancient), and its license had been incorrectly deduced (gitlab claims it's Apache-2.0, but both https://www.isc.org/bind/ and source code headers claim MPL-2.0).

This PR adds the latest version of `bind9`, which now depends on `liburcu` so that was added too.

Test build:
```
==> Installing bind9-9.20.0-7lf5mvfpsmrmu6ex5cxv4gbplp5shqd6 [10/10]
==> No binary for bind9-9.20.0-7lf5mvfpsmrmu6ex5cxv4gbplp5shqd6 found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/cc/cc580998017b51f273964058e8cb3aa5482bc785243dea71e5556ec565a13347.tar.xz
==> No patches needed for bind9
==> bind9: Executing phase: 'autoreconf'
==> bind9: Executing phase: 'configure'
==> bind9: Executing phase: 'build'
==> bind9: Executing phase: 'install'
==> bind9: Successfully installed bind9-9.20.0-7lf5mvfpsmrmu6ex5cxv4gbplp5shqd6
  Stage: 1.61s.  Autoreconf: 0.00s.  Configure: 16.49s.  Build: 20.44s.  Install: 2.81s.  Post-install: 0.22s.  Total: 41.80s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/bind9-9.20.0-7lf5mvfpsmrmu6ex5cxv4gbplp5shqd6
```