### PR TITLE
librsvg: depends_on cairo +png

### DIFF
--- a/var/spack/repos/builtin/packages/librsvg/package.py
+++ b/var/spack/repos/builtin/packages/librsvg/package.py
@@ -37,9 +37,9 @@ class Librsvg(AutotoolsPackage):
     depends_on("gtk-doc", type="build", when="+doc")
 
     # requirements according to `configure` file
-    depends_on("cairo@1.16:+gobject", when="@2.50:")
-    depends_on("cairo@1.15.12:+gobject", when="@2.44.14:")
-    depends_on("cairo@1.2.0:+gobject")
+    depends_on("cairo@1.16:+gobject+png", when="@2.50:")
+    depends_on("cairo@1.15.12:+gobject+png", when="@2.44.14:")
+    depends_on("cairo@1.2.0:+gobject+png")
     depends_on("libcroco@0.6.1:", when="@:2.44.14")
     depends_on("gdk-pixbuf@2.20:")
     depends_on("glib@2.50:", when="@2.50:")


### PR DESCRIPTION
`librsvg` depends on `cairo +png`, per https://gitlab.gnome.org/GNOME/librsvg/-/commit/231dafaa6e9aee120c14d8f6515548a6603e87df, since 2.32.0 which is before the spack era.