### PR TITLE
hadoop: add v3.3.3 -> v3.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/hadoop/package.py
+++ b/var/spack/repos/builtin/packages/hadoop/package.py
@@ -14,9 +14,16 @@ class Hadoop(Package):
 
     homepage = "https://hadoop.apache.org/"
     url = "https://archive.apache.org/dist/hadoop/common/hadoop-3.3.2/hadoop-3.3.2.tar.gz"
+    list_url = "https://archive.apache.org/dist/hadoop/common"
+    list_depth = 1
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked="wdconinc")
 
+    version("3.4.0", sha256="e311a78480414030f9ec63549a5d685e69e26f207103d9abf21a48b9dd03c86c")
+    version("3.3.6", sha256="f5195059c0d4102adaa7fff17f7b2a85df906bcb6e19948716319f9978641a04")
+    version("3.3.5", sha256="446e05ca92fa23a60617a8b17946dede47281af1504041617cb7d5f62e74252a")
+    version("3.3.4", sha256="6a483d1a0b123490ebd8df3f71b64eb39f333f78b95f090aeb58e433cbc2416d")
+    version("3.3.3", sha256="fa71c61bbaa427129aef09fec028b34dd542c65ad90fdccec5e7ef93d83b8764")
     version("3.3.2", sha256="b341587495b12eec0b244b517f21df88eb46ef634dc7dc3e5969455b80ce2ce5")
     version("3.3.0", sha256="ea1a0f0afcdfb9b6b9d261cdce5a99023d7e8f72d26409e87f69bda65c663688")
     version("3.2.2", sha256="97e73b46c3972cd3c40c2295bd9488843c24e8503c36e7c57f6e6ecc4e12b8c3")
@@ -28,8 +35,6 @@ class Hadoop(Package):
     version("2.8.5", sha256="f9c726df693ce2daa4107886f603270d66e7257f77a92c9886502d6cd4a884a4")
     version("2.7.7", sha256="d129d08a2c9dafec32855a376cbd2ab90c6a42790898cabbac6be4d29f9c2026")
     version("2.7.5", sha256="0bfc4d9b04be919be2fdf36f67fa3b4526cdbd406c512a7a1f5f1b715661f831")
-
-    depends_on("cxx", type="build")  # generated
 
     depends_on("java", type="run")
 

--- a/var/spack/repos/builtin/packages/hadoop/package.py
+++ b/var/spack/repos/builtin/packages/hadoop/package.py
@@ -17,7 +17,7 @@ class Hadoop(Package):
     list_url = "https://archive.apache.org/dist/hadoop/common"
     list_depth = 1
 
-    license("Apache-2.0", checked="wdconinc")
+    license("Apache-2.0", checked_by="wdconinc")
 
     version("3.4.0", sha256="e311a78480414030f9ec63549a5d685e69e26f207103d9abf21a48b9dd03c86c")
     version("3.3.6", sha256="f5195059c0d4102adaa7fff17f7b2a85df906bcb6e19948716319f9978641a04")


### PR DESCRIPTION
`hadoop` v3.4.0, checked license. Installation is just an install_tree... nothing can go wrong (other than running out of disk space when doing this 5 times for a 1GB package).