### PR TITLE
scr: release v3.1.0, including components

### DIFF
--- a/var/spack/repos/builtin/packages/axl/package.py
+++ b/var/spack/repos/builtin/packages/axl/package.py
@@ -27,6 +27,7 @@ class Axl(CMakePackage):
     license("MIT")
 
     version("main", branch="main")
+    version("0.9.0", sha256="da2d74092fb230754a63db3cd5ba72a233ee8153dec28cc604fa8465280299ba")
     version("0.8.0", sha256="9fcd4eae143a67ff02622feda2a541b85e9a108749c039faeb473cbbc2330459")
     version("0.7.1", sha256="526a055c072c85cc989beca656717e06b128f148fda8eb19d1d9b43a3325b399")
     version("0.7.0", sha256="840ef61eadc9aa277d128df08db4cdf6cfa46b8fcf47b0eee0972582a61fbc50")
@@ -64,6 +65,9 @@ class Axl(CMakePackage):
         validator=async_api_validator,
     )
 
+    variant("mpi", default=True, description="Build with MPI support", when="@0.7.1:")
+    depends_on("mpi", when="@0.7.1: +mpi")
+
     variant("pthreads", default=True, description="Enable Pthread support", when="@0.6:")
 
     variant("bbapi", default=True, description="Enable IBM BBAPI support")
@@ -85,6 +89,10 @@ class Axl(CMakePackage):
         spec = self.spec
         args = []
         args.append(self.define("WITH_KVTREE_PREFIX", spec["kvtree"].prefix))
+
+        args.append(self.define_from_variant("MPI"))
+        if spec.satisfies("+mpi"):
+            args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
 
         if spec.satisfies("@:0.3.0"):
             apis = list(spec.variants["async_api"].value)

--- a/var/spack/repos/builtin/packages/dtcmp/package.py
+++ b/var/spack/repos/builtin/packages/dtcmp/package.py
@@ -17,6 +17,7 @@ class Dtcmp(AutotoolsPackage):
     maintainers("gonsie", "camstan", "adammoody")
 
     version("main", branch="main")
+    version("1.1.5", sha256="959c28999b8d1dd2e8703172db55392e38114fde0cd54dfad04555622c5e5974")
     version("1.1.4", sha256="dd83d8cecd68e13b78b68e88675cc5847cde06742b7740e140b98f4a08127dd3")
     version("1.1.3", sha256="90b32cadd0ff2f4fa7fc916f8dcfdbe6918e3e285e0292a2470772478ca0aab5")
     version("1.1.2", sha256="76e1d1fed89bf6abf003179a7aed93350d5ce6282cb000b02a241ec802ec399d")
@@ -30,7 +31,8 @@ class Dtcmp(AutotoolsPackage):
     depends_on("lwgrp")
 
     depends_on("lwgrp@main", when="@main")
-    depends_on("lwgrp@1.0.5", when="@1.1.4")
+    depends_on("lwgrp@1.0.3:", when="@1.1.2:")
+    depends_on("lwgrp@1.0.5:", when="@1.1.4:")
 
     variant("shared", default=True, description="Build with shared libraries")
     depends_on("lwgrp+shared", when="+shared")

--- a/var/spack/repos/builtin/packages/er/package.py
+++ b/var/spack/repos/builtin/packages/er/package.py
@@ -19,6 +19,7 @@ class Er(CMakePackage):
     license("MIT")
 
     version("main", branch="main")
+    version("0.5.0", sha256="dbde4da1fe115b67334085446d413f7365ba94c0a34cb1c38b83944e8fba4d0b")
     version("0.4.0", sha256="6cb5b6724ddac5c1f5ed6b326a5f3bf5d4eb1c6958a48218e6ca9bb7c02e48a8")
     version("0.3.0", sha256="01bc71bfb2ebb015ccb948f2bb9138b70972a3e8be0e53f9a4844e46b106a36c")
     version("0.2.0", sha256="9ddfe2b63682ed0e89685f9b7d5259ef82b802aba55c8ee78cc15a7adbad6bc0")

--- a/var/spack/repos/builtin/packages/kvtree/package.py
+++ b/var/spack/repos/builtin/packages/kvtree/package.py
@@ -20,6 +20,7 @@ class Kvtree(CMakePackage):
     license("MIT")
 
     version("main", branch="main")
+    version("1.5.0", sha256="9617948bdb905615aeb0604d4998d92eb970ecd5c9c851116266972462f0b350")
     version("1.4.0", sha256="48a36fd578f0d1198a9c1512d6446c830b915ace5bb97539eec615495bee5a51")
     version("1.3.0", sha256="8281e075772d3534183c46133553d5765455d79ed98a895743663db891755ca9")
     version("1.2.0", sha256="ecd4b8bc479c33ab4f23fc764445a3bb353a1d15c208d011f5577a32c182477f")

--- a/var/spack/repos/builtin/packages/lwgrp/package.py
+++ b/var/spack/repos/builtin/packages/lwgrp/package.py
@@ -17,6 +17,7 @@ class Lwgrp(AutotoolsPackage):
     maintainers("CamStan", "gonsie", "adammoody")
 
     version("main", branch="main")
+    version("1.0.6", sha256="9f697978361b4bd9914beaaafffcee0b62a480a9a7dd3d75176910cebda81438")
     version("1.0.5", sha256="16b579e13b8a5218f4fe1b8715f6aafb09133a0cefbcd6b2eaf73802955dee6b")
     version("1.0.4", sha256="0c933df7658660a0225f8e3a940eb2621efa4421397859417c8d90d906d4e90a")
     version("1.0.3", sha256="20b2fc3908bfdf04d1c177f86e227a147214cd155c548b3dd75e54c78e1c1c47")

--- a/var/spack/repos/builtin/packages/rankstr/package.py
+++ b/var/spack/repos/builtin/packages/rankstr/package.py
@@ -19,6 +19,7 @@ class Rankstr(CMakePackage):
     license("MIT")
 
     version("main", branch="main")
+    version("0.4.0", sha256="f33c920aa67b867d0fa2001d98f6762e90f59a41b2f66c27a63cff6bd6afeb1b")
     version("0.3.0", sha256="5e6378a8fe155b4c6c5cf45db8aaf0562d88e93471d0e12c1e922252ffcce5e6")
     version("0.2.0", sha256="a3f7fd8015156c1b600946af759a03e099e05c83e7b2da6bac394fe7c0d4efae")
     version("0.1.0", sha256="b68239d67b2359ecc067cc354f86ccfbc8f02071e60d28ae0a2449f2e7f88001")

--- a/var/spack/repos/builtin/packages/redset/package.py
+++ b/var/spack/repos/builtin/packages/redset/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Redset(CMakePackage):
+class Redset(CMakePackage, CudaPackage):
     """Create MPI communicators for disparate redundancy sets"""
 
     homepage = "https://github.com/ecp-veloc/redset"
@@ -19,6 +19,7 @@ class Redset(CMakePackage):
     license("MIT")
 
     version("main", branch="main")
+    version("0.4.0", sha256="d278a5d3c1323915c379e2077dbfab1248044c86a04fc56faee6681c66380451")
     version("0.3.0", sha256="007ca5e7e5f4400e22ad7bca82e366cd51c73f28067c955cc16d7d0ff0c06a1b")
     version("0.2.0", sha256="0438b0ba56dafcd5694a8fceeb5a932901307353e056ab29817d30b8387f787f")
     version("0.1.0", sha256="baa75de0d0d6de64ade50cff3d38ee89fd136ce69869182bdaefccf5be5d286d")
@@ -38,7 +39,11 @@ class Redset(CMakePackage):
     depends_on("rankstr@:0.2.0", when="@:0.2.0")
     depends_on("rankstr@0.3.0:", when="@0.3.0:")
 
-    variant("shared", default=True, description="Build with shared libraries")
+    variant("cuda", default=False, description="Enable CUDA support", when="@0.4:")
+    variant("openmp", default=False, description="Enable OpenMP support", when="@0.4:")
+    variant("pthreads", default=False, description="Enable Pthread support", when="@0.4:")
+
+    variant("shared", default=True, description="Build with shared libraries", when="@0.1:")
     depends_on("kvtree+shared", when="@0.1: +shared")
     depends_on("kvtree~shared", when="@0.1: ~shared")
     depends_on("rankstr+shared", when="@0.1: +shared")
@@ -51,7 +56,9 @@ class Redset(CMakePackage):
         args.append(self.define("WITH_KVTREE_PREFIX", spec["kvtree"].prefix))
         args.append(self.define("WITH_RANKSTR_PREFIX", spec["rankstr"].prefix))
 
-        if spec.satisfies("@0.1.0:"):
-            args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+        args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+        args.append(self.define_from_variant("ENABLE_CUDA", "cuda"))
+        args.append(self.define_from_variant("ENABLE_OPENMP", "openmp"))
+        args.append(self.define_from_variant("ENABLE_PTHREADS", "pthreads"))
 
         return args

--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -12,6 +12,8 @@ from spack.package import *
 def detect_scheduler():
     if which("aprun"):
         return "APRUN"
+    if which("flux"):
+        return "FLUX"
     if which("jsrun"):
         return "LSF"
     return "SLURM"
@@ -33,21 +35,12 @@ class Scr(CMakePackage):
     version("legacy", branch="legacy")
 
     version(
-        "3.0.1",
-        sha256="ba8f9e676aec8176ecc46c31a4f470ac95047101654de8cc88e01a1f9d95665a",
+        "3.1.0",
+        sha256="ca1f37c84e0ff7a307e68f213c8cc868974d7fb30f16826853a711c7c3a55ffa",
         preferred=True,
     )
-    version("3.0", sha256="e204d3e99a49efac50b4bedc7ac05f55a05f1a65429500d919900c82490532cc")
-    version(
-        "3.0rc2",
-        sha256="4b2a718af56b3683e428d25a2269c038e9452db734221d370e3023a491477fad",
-        deprecated=True,
-    )
-    version(
-        "3.0rc1",
-        sha256="bd31548a986f050024429d8ee3644eb135f047f98a3d503a40c5bd4a85291308",
-        deprecated=True,
-    )
+    version("3.0.1", sha256="ba8f9e676aec8176ecc46c31a4f470ac95047101654de8cc88e01a1f9d95665a")
+    version("3.0.0", sha256="e204d3e99a49efac50b4bedc7ac05f55a05f1a65429500d919900c82490532cc")
     version("2.0.0", sha256="471978ae0afb56a20847d3989b994fbd680d1dea21e77a5a46a964b6e3deed6b")
     version(
         "1.2.2",
@@ -79,39 +72,31 @@ class Scr(CMakePackage):
 
     # SCR legacy is anything 2.x.x or earlier
     # SCR components is anything 3.x.x or later
-    depends_on("axl@0.7.1", when="@3.0.1")
-    depends_on("er@0.2.0", when="@3.0.1")
-    depends_on("kvtree@1.3.0", when="@3.0.1")
-    depends_on("rankstr@0.1.0", when="@3.0.1")
-    depends_on("redset@0.2.0", when="@3.0.1")
-    depends_on("shuffile@0.2.0", when="@3.0.1")
-    depends_on("spath@0.2.0 +mpi", when="@3.0.1")
-    depends_on("dtcmp@1.1.4", when="@3.0.1")
+    with when("@3.1.0"):
+        depends_on("axl@0.8.0: +mpi")
+        depends_on("er@0.5.0")
+        depends_on("kvtree@1.4.0:")
+        depends_on("rankstr@0.3.0:")
+        depends_on("redset@0.4.0")
+        depends_on("shuffile@0.3.0:")
+        depends_on("spath@0.3.0: +mpi")
+        depends_on("dtcmp@1.1.5")
 
-    depends_on("axl@0.6.0", when="@3.0.0")
-    depends_on("er@0.2.0", when="@3.0.0")
-    depends_on("kvtree@1.3.0", when="@3.0.0")
-    depends_on("rankstr@0.1.0", when="@3.0.0")
-    depends_on("redset@0.2.0", when="@3.0.0")
-    depends_on("shuffile@0.2.0", when="@3.0.0")
-    depends_on("spath@0.2.0", when="@3.0.0")
-    depends_on("dtcmp@1.1.4", when="@3.0.0")
+    with when("@3.0.1"):
+        depends_on("axl@0.7.1 +mpi")
+        depends_on("er@0.3.0")
 
-    depends_on("axl@0.5.0:", when="@3.0rc2")
-    depends_on("er@0.1.0:", when="@3.0rc2")
-    depends_on("kvtree@1.2.0:", when="@3.0rc2")
-    depends_on("rankstr@0.1.0:", when="@3.0rc2")
-    depends_on("redset@0.1.0:", when="@3.0rc2")
-    depends_on("shuffile@0.1.0:", when="@3.0rc2")
-    depends_on("spath@0.1.0:", when="@3.0rc2")
+    with when("@3.0.0"):
+        depends_on("axl@0.6.0")
+        depends_on("er@0.2.0")
 
-    depends_on("axl@0.4.0", when="@3.0rc1")
-    depends_on("er@0.0.4", when="@3.0rc1")
-    depends_on("kvtree@1.1.1", when="@3.0rc1")
-    depends_on("rankstr@0.0.3", when="@3.0rc1")
-    depends_on("redset@0.0.5", when="@3.0rc1")
-    depends_on("shuffile@0.0.4", when="@3.0rc1")
-    depends_on("spath@0.0.2", when="@3.0rc1")
+    with when("@3.0.0:3.0.1"):
+        depends_on("kvtree@1.3.0")
+        depends_on("rankstr@0.2.0")
+        depends_on("redset@0.2.0")
+        depends_on("shuffile@0.2.0")
+        depends_on("spath@0.2.0 +mpi")
+        depends_on("dtcmp@1.1.4:")
 
     # DTCMP is an optional dependency up until 3.x, required thereafter
     variant(
@@ -127,14 +112,15 @@ class Scr(CMakePackage):
         "libyogrt", default=True, description="Build SCR with libyogrt for get_time_remaining."
     )
     depends_on("libyogrt scheduler=slurm", when="+libyogrt resource_manager=SLURM")
+    depends_on("libyogrt scheduler=flux", when="+libyogrt resource_manager=FLUX")
     depends_on("libyogrt scheduler=lsf", when="+libyogrt resource_manager=LSF")
     depends_on("libyogrt", when="+libyogrt")
 
     # PDSH required up to 3.0rc1, optional thereafter
     # TODO spack currently assumes 3.0.0 = 3.0 = 3 < 3.0rc1 < 3.0rc2
-    variant("pdsh", default=True, when="@3.0.0,3.0rc2:", description="Enable use of PDSH")
+    variant("pdsh", default=True, when="@3:", description="Enable use of PDSH")
     depends_on("pdsh+static_modules", type=("build", "run"), when="+pdsh")
-    depends_on("pdsh+static_modules", type=("build", "run"), when="@:2,3.0rc1")
+    depends_on("pdsh+static_modules", type=("build", "run"), when="@:2")
 
     variant(
         "scr_config",
@@ -154,7 +140,7 @@ class Scr(CMakePackage):
     variant(
         "resource_manager",
         default=detect_scheduler(),
-        values=("SLURM", "APRUN", "LSF", "NONE"),
+        values=("SLURM", "APRUN", "FLUX", "LSF", "NONE"),
         multi=False,
         description="Resource manager for which to configure SCR.",
     )
@@ -169,32 +155,27 @@ class Scr(CMakePackage):
         description="Asynchronous data transfer API to use with SCR.",
     )
 
-    variant("bbapi", default=True, when="@3.0rc2:", description="Enable IBM BBAPI support")
+    variant("pthreads", default=True, when="@3:", description="Enable Pthread support")
+    depends_on("axl+pthreads", when="+pthreads")
+
+    variant("bbapi", default=False, when="@3:", description="Enable IBM BBAPI support")
     depends_on("axl+bbapi", when="+bbapi")
     depends_on("axl~bbapi", when="~bbapi")
 
     variant(
         "bbapi_fallback",
         default=False,
-        when="@3:",
+        when="@3: +bbapi",
         description="Using BBAPI, if source or destination don't support \
             file extents then fallback to pthreads",
     )
-    depends_on("axl+bbapi_fallback", when="+bbapi_fallback")
-    variant(
-        "bbapi_fallback",
-        default=False,
-        when="@3.0rc2: +bbapi",
-        description="Using BBAPI, if source or destination don't support \
-            file extents then fallback to pthreads",
-    )
-    depends_on("axl+bbapi+bbapi_fallback", when="@3.0rc2: +bbapi_fallback")
+    depends_on("axl+bbapi+bbapi_fallback", when="@3: +bbapi_fallback")
 
-    variant("dw", default=False, when="@3.0rc2:", description="Enable Cray DataWarp support")
+    variant("dw", default=False, when="@3:", description="Enable Cray DataWarp support")
     depends_on("axl+dw", when="+dw")
     depends_on("axl~dw", when="~dw")
 
-    variant("examples", default=True, when="@3.0rc2:", description="Build SCR example programs")
+    variant("examples", default=True, when="@3:", description="Build SCR example programs")
 
     variant(
         "file_lock",
@@ -213,7 +194,7 @@ class Scr(CMakePackage):
     #        capturing SCR and syslog messages in a database')
     # depends_on('mysql', when='+mysql')
 
-    variant("shared", default=True, when="@3.0rc2:", description="Build with shared libraries")
+    variant("shared", default=True, when="@3:", description="Build with shared libraries")
     depends_on("libyogrt+static", when="~shared")
     for comp in cmpnts:
         depends_on(comp + "+shared", when="+shared")
@@ -223,7 +204,7 @@ class Scr(CMakePackage):
 
     # TODO: Expose `tests` and `resource_manager` variants in components and
     # then propogate their setting through components.
-    variant("tests", default=True, when="@3.0rc2:", description="Build with CTest included")
+    variant("tests", default=True, when="@3:", description="Build with CTest included")
 
     # The default cache and control directories should be placed in tmpfs if available.
     # On Linux, /dev/shm is a common tmpfs location.  Other platforms, like macOS,
@@ -259,7 +240,17 @@ class Scr(CMakePackage):
         spec = self.spec
         args = []
 
+        args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
         args.append(self.define_from_variant("ENABLE_FORTRAN", "fortran"))
+        args.append(self.define_from_variant("ENABLE_IBM_BBAPI", "bbapi"))
+        args.append(self.define_from_variant("ENABLE_CRAY_DW", "dw"))
+        args.append(self.define_from_variant("ENABLE_EXAMPLES", "examples"))
+        args.append(self.define_from_variant("ENABLE_YOGRT", "libyogrt"))
+        # args.append(self.define_from_variant('ENABLE_MYSQL', 'mysql'))
+        args.append(self.define_from_variant("ENABLE_PDSH", "pdsh"))
+        args.append(self.define_from_variant("ENABLE_PTHREADS", "pthreads"))
+        args.append(self.define_from_variant("ENABLE_TESTS", "tests"))
+        args.append(self.define_from_variant("SCR_ASYNC_API", "async_api"))
         args.append(self.define_from_variant("SCR_FILE_LOCK", "file_lock"))
         args.append(self.define_from_variant("SCR_CACHE_BASE", "cache_base"))
         args.append(self.define_from_variant("SCR_CNTL_BASE", "cntl_base"))
@@ -281,28 +272,15 @@ class Scr(CMakePackage):
             cmpnts = ["axl", "dtcmp", "er", "kvtree", "rankstr", "redset", "shuffile", "spath"]
             for comp in cmpnts:
                 args.append(self.define("WITH_" + comp.upper() + "_PREFIX", spec[comp].prefix))
-        else:
-            # dtcmp optional before this point
-            if "+dtcmp" in spec:
-                args.append(self.define("WITH_DTCMP_PREFIX", spec["dtcmp"].prefix))
-
-            # Only used prior to version 3
-            args.append(self.define_from_variant("SCR_ASYNC_API", "async_api"))
-
-        if spec.satisfies("@3.0rc2:"):
-            args.append(self.define_from_variant("ENABLE_IBM_BBAPI", "bbapi"))
-            args.append(self.define_from_variant("ENABLE_CRAY_DW", "dw"))
-            args.append(self.define_from_variant("ENABLE_EXAMPLES", "examples"))
-            args.append(self.define_from_variant("ENABLE_YOGRT", "libyogrt"))
-            # args.append(self.define_from_variant('ENABLE_MYSQL', 'mysql'))
-            args.append(self.define_from_variant("ENABLE_PDSH", "pdsh"))
-            args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
-            args.append(self.define_from_variant("ENABLE_TESTS", "tests"))
 
             # PDSH optional from this point on
             if "+pdsh" in spec:
                 args.append(self.define("WITH_PDSH_PREFIX", spec["pdsh"].prefix))
         else:
+            # dtcmp optional before this point
+            if "+dtcmp" in spec:
+                args.append(self.define("WITH_DTCMP_PREFIX", spec["dtcmp"].prefix))
+
             # PDSH required before this point
             args.append(self.define("WITH_PDSH_PREFIX", spec["pdsh"].prefix))
 

--- a/var/spack/repos/builtin/packages/shuffile/package.py
+++ b/var/spack/repos/builtin/packages/shuffile/package.py
@@ -19,6 +19,7 @@ class Shuffile(CMakePackage):
     license("MIT")
 
     version("main", branch="main")
+    version("0.4.0", sha256="fc7116d8eaa1ab79480e6e3f04064750e517d2a8aeccbff90c73a2590f726378")
     version("0.3.0", sha256="3463ad4a23fd31aa9a3426346ada04399fb9369dd1f40d22df9f19f9c0c1f8ae")
     version("0.2.0", sha256="467ffef72214c109b69f09d03e42be5e9254f13751b09c71168c14fa99117521")
     version("0.1.0", sha256="9e730cc8b7937517a9cffb08c031d9f5772306341c49d17b87b7f349d55a6d5e")

--- a/var/spack/repos/builtin/packages/spath/package.py
+++ b/var/spack/repos/builtin/packages/spath/package.py
@@ -19,6 +19,7 @@ class Spath(CMakePackage):
     license("MIT")
 
     version("main", branch="main")
+    version("0.4.0", sha256="469c9d36f9244826c6ec264a779eed870a772f467d6964030d336e509d3c9374")
     version("0.3.0", sha256="cb155a31cebde8b7bf397123de3be290fd99d3863509b4ba9b0252caba660082")
     version("0.2.0", sha256="2de8a25547b53ef064664d79b543141bc3020219f40ff0e1076f676e13a9e77a")
     version("0.1.0", sha256="2cfc635b2384d3f92973c7aea173dabe47da112d308f5098e6636e4b2f4a704c")


### PR DESCRIPTION
SCR and the SCR components have new releases

- AXL v0.9.0
- ER v0.5.0
- KVTREE v1.5.0
- Rankstr v0.4.0
- Shuffile v0.4.0
- Spatha v0.4.0
- dtcmp v1.1.5
- lwgrp v1.0.6
- Redset v0.4.0
  - New variants added to Redset

- SCR v3.1.0
  - Added Flux resource manager
  - Added pthreads variant
  - Removed deprecated release candidates and references
  - Cleaned up component dependency versions
  - Updated versions within variants and cleaned up cmake_args

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
