### PR TITLE
Add schema for compiler options in packages.yaml

### DIFF
--- a/lib/spack/spack/schema/compilers.py
+++ b/lib/spack/spack/schema/compilers.py
@@ -11,6 +11,26 @@ from typing import Any, Dict
 
 import spack.schema.environment
 
+flags: Dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "cflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+        "cxxflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+        "fflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+        "cppflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+        "ldflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+        "ldlibs": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+    },
+}
+
+
+extra_rpaths: Dict[str, Any] = {"type": "array", "default": [], "items": {"type": "string"}}
+
+implicit_rpaths: Dict[str, Any] = {
+    "anyOf": [{"type": "array", "items": {"type": "string"}}, {"type": "boolean"}]
+}
+
 #: Properties for inclusion in other schemas
 properties: Dict[str, Any] = {
     "compilers": {
@@ -35,18 +55,7 @@ properties: Dict[str, Any] = {
                                 "fc": {"anyOf": [{"type": "string"}, {"type": "null"}]},
                             },
                         },
-                        "flags": {
-                            "type": "object",
-                            "additionalProperties": False,
-                            "properties": {
-                                "cflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                                "cxxflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                                "fflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                                "cppflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                                "ldflags": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                                "ldlibs": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                            },
-                        },
+                        "flags": flags,
                         "spec": {"type": "string"},
                         "operating_system": {"type": "string"},
                         "target": {"type": "string"},
@@ -54,18 +63,9 @@ properties: Dict[str, Any] = {
                         "modules": {
                             "anyOf": [{"type": "string"}, {"type": "null"}, {"type": "array"}]
                         },
-                        "implicit_rpaths": {
-                            "anyOf": [
-                                {"type": "array", "items": {"type": "string"}},
-                                {"type": "boolean"},
-                            ]
-                        },
+                        "implicit_rpaths": implicit_rpaths,
                         "environment": spack.schema.environment.definition,
-                        "extra_rpaths": {
-                            "type": "array",
-                            "default": [],
-                            "items": {"type": "string"},
-                        },
+                        "extra_rpaths": extra_rpaths,
                     },
                 }
             },

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -11,6 +11,8 @@ from typing import Any, Dict
 
 import spack.schema.environment
 
+from .compilers import extra_rpaths, flags, implicit_rpaths
+
 permissions = {
     "type": "object",
     "additionalProperties": False,
@@ -184,7 +186,16 @@ properties: Dict[str, Any] = {
                                     "type": "object",
                                     "additionalProperties": True,
                                     "properties": {
-                                        "environment": spack.schema.environment.definition
+                                        "compilers": {
+                                            "type": "object",
+                                            "patternProperties": {
+                                                r"(^\w[\w-]*)": {"type": "string"}
+                                            },
+                                        },
+                                        "environment": spack.schema.environment.definition,
+                                        "extra_rpaths": extra_rpaths,
+                                        "implicit_rpaths": implicit_rpaths,
+                                        "flags": flags,
                                     },
                                 },
                             },


### PR DESCRIPTION
Extracted from #44419

Compilers can be declared as part of `packages.yaml` since v0.22 Here we just add a schema for the properties they support.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
