### PR TITLE
Micro-optimize finding executables

### DIFF
--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -136,10 +136,10 @@ def path_to_dict(search_paths: List[str]):
     # entry overrides later entries
     for search_path in reversed(search_paths):
         try:
-            for lib in os.listdir(search_path):
-                lib_path = os.path.join(search_path, lib)
-                if llnl.util.filesystem.is_readable_file(lib_path):
-                    path_to_lib[lib_path] = lib
+            with os.scandir(search_path) as entries:
+                path_to_lib.update(
+                    {entry.path: entry.name for entry in entries if entry.is_file()}
+                )
         except OSError as e:
             msg = f"cannot scan '{search_path}' for external software: {str(e)}"
             llnl.util.tty.debug(msg)

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -335,13 +335,9 @@ class ExecutablesFinder(Finder):
 
     def candidate_files(self, *, patterns: List[str], paths: List[str]) -> List[str]:
         executables_by_path = executables_in_path(path_hints=paths)
-        patterns = [re.compile(x) for x in patterns]
-        result = []
-        for compiled_re in patterns:
-            for path, exe in executables_by_path.items():
-                if compiled_re.search(exe):
-                    result.append(path)
-        return list(sorted(set(result)))
+        joined_pattern = re.compile(r"|".join(patterns))
+        result = [path for path, exe in executables_by_path.items() if joined_pattern.search(exe)]
+        return sorted(set(result))
 
     def prefix_from_path(self, *, path: str) -> str:
         result = executable_prefix(path)

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -337,7 +337,8 @@ class ExecutablesFinder(Finder):
         executables_by_path = executables_in_path(path_hints=paths)
         joined_pattern = re.compile(r"|".join(patterns))
         result = [path for path, exe in executables_by_path.items() if joined_pattern.search(exe)]
-        return sorted(set(result))
+        result.sort()
+        return result
 
     def prefix_from_path(self, *, path: str) -> str:
         result = executable_prefix(path)


### PR DESCRIPTION
Extracted from #44419

From Python docs:

> The [scandir()](https://docs.python.org/3/library/os.html#os.scandir) function returns directory entries along with file attribute information, giving better performance for many common use cases.

On my system this brings:
```console
$ time spack external find
==> The following specs have been detected on this system and added to /home/culpo/.spack/packages.yaml
autoconf@2.69    bison@3.5.1   cmake@3.27.9    curl@8.4.0       flex@2.6.4        gettext@0.22.4  gmake@4.4.1    m4@1.4.18     openssh@8.2p1   perl@5.30.0        python@3.8.10  subversion@1.13.0  texinfo@6.7
automake@1.16.1  bison@3.8.2   coreutils@8.30  diffutils@3.7    gawk@5.0.1        git@2.25.1      groff@1.22.4   m4@1.4.19     openssl@1.1.1f  pkg-config@0.29.1  python@3.11.5  tar@1.30
binutils@2.34    ccache@4.8.2  curl@7.68.0     findutils@4.7.0  gettext@0.19.8.1  gmake@4.2.1     libtool@2.4.6  ninja@1.10.0  openssl@3.1.3   python@2.7.18      sed@4.7        tar@1.34

real	0m3,482s
user	0m6,686s
sys	0m1,883s
```
on b61cd74707fb37bb09f322060fb123b664d7ebe6 to:
```console
$ time spack external find
==> The following specs have been detected on this system and added to /home/culpo/.spack/packages.yaml
autoconf@2.69    bison@3.5.1   cmake@3.27.9    curl@8.4.0       flex@2.6.4        gettext@0.22.4  gmake@4.4.1    m4@1.4.18     openssh@8.2p1   perl@5.30.0        python@3.8.10  subversion@1.13.0  texinfo@6.7
automake@1.16.1  bison@3.8.2   coreutils@8.30  diffutils@3.7    gawk@5.0.1        git@2.25.1      groff@1.22.4   m4@1.4.19     openssl@1.1.1f  pkg-config@0.29.1  python@3.11.5  tar@1.30
binutils@2.34    ccache@4.8.2  curl@7.68.0     findutils@4.7.0  gettext@0.19.8.1  gmake@4.2.1     libtool@2.4.6  ninja@1.10.0  openssl@3.1.3   python@2.7.18      sed@4.7        tar@1.34

real	0m3,079s
user	0m5,801s
sys	0m1,195s
```
in this branch.
