### PR TITLE
w3m: add v0.5.3.git20230121

### DIFF
--- a/var/spack/repos/builtin/packages/w3m/package.py
+++ b/var/spack/repos/builtin/packages/w3m/package.py
@@ -78,9 +78,7 @@ class W3m(AutotoolsPackage):
     def url_for_version(self, version):
         if ".git" in version.string:
             v = version.string.replace(".git", "+git")
-            return (
-                f"https://salsa.debian.org/debian/w3m/-/archive/upstream/{v}/w3m-upstream-{v}.tar.gz"
-            )
+            return f"https://salsa.debian.org/debian/w3m/-/archive/upstream/{v}/w3m-upstream-{v}.tar.gz"
         else:
             return f"https://downloads.sourceforge.net/project/w3m/w3m/w3m-{version}/w3m-{version}.tar.gz"
 

--- a/var/spack/repos/builtin/packages/w3m/package.py
+++ b/var/spack/repos/builtin/packages/w3m/package.py
@@ -22,11 +22,17 @@ class W3m(AutotoolsPackage):
     # Currently, Arch and Ubuntu (and Debian derivatives) use Debian's branch.
     # Also, Gentoo, Fedora and openSUSE switched to Debian's branch.
     homepage = "https://w3m.sourceforge.net/index.en.html"
-    url = "https://downloads.sourceforge.net/project/w3m/w3m/w3m-0.5.3/w3m-0.5.3.tar.gz"
+    url = "https://salsa.debian.org/debian/w3m/-/archive/upstream/0.5.3+git20230121/w3m-upstream-0.5.3+git20230121.tar.gz"
+    git = "https://salsa.debian.org/debian/w3m.git"
+
     maintainers("ronin_gw")
 
     license("MIT")
 
+    version(
+        "0.5.3.git20230121",
+        sha256="8f0592e1cf7cf1de053e22c114cd79b85ebdb8dab925be7d343a130343b97c25",
+    )
     version("0.5.3", sha256="e994d263f2fd2c22febfbe45103526e00145a7674a0fda79c822b97c2770a9e3")
 
     depends_on("c", type="build")  # generated
@@ -66,8 +72,17 @@ class W3m(AutotoolsPackage):
     depends_on("imlib2@1.0.5:", when="imagelib=imlib2 +image")
 
     # fix for modern libraries
-    patch("fix_redef.patch")
-    patch("fix_gc.patch")
+    patch("fix_redef.patch", when="@=0.5.3")
+    patch("fix_gc.patch", when="@=0.5.3")
+
+    def url_for_version(self, version):
+        if ".git" in version.string:
+            v = version.string.replace(".git", "+git")
+            return (
+                f"https://salsa.debian.org/debian/w3m/-/archive/upstream/{v}/w3m-upstream-{v}.tar.gz"
+            )
+        else:
+            return f"https://downloads.sourceforge.net/project/w3m/w3m/w3m-{version}/w3m-{version}.tar.gz"
 
     def patch(self):
         # w3m is not developed since 2012, everybody is doing this:


### PR DESCRIPTION
Switch w3m to debian branch, like the rest of the world. Fixes some CVEs.

Test builds (new was built earlier, old still builds too):
```
==> Installing w3m-0.5.3-p3hxkj4tgry27benkrsn4lvivoxb3bjg [29/30]
==> No binary for w3m-0.5.3-p3hxkj4tgry27benkrsn4lvivoxb3bjg found: installing from source
==> Fetching https://downloads.sourceforge.net/project/w3m/w3m/w3m-0.5.3/w3m-0.5.3.tar.gz
==> Applied patch /home/wdconinc/git/spack/var/spack/repos/builtin/packages/w3m/fix_redef.patch
==> Applied patch /home/wdconinc/git/spack/var/spack/repos/builtin/packages/w3m/fix_gc.patch
==> Ran patch() for w3m
==> w3m: Executing phase: 'autoreconf'
==> w3m: Executing phase: 'configure'
==> w3m: Executing phase: 'build'
==> w3m: Executing phase: 'install'
==> w3m: Successfully installed w3m-0.5.3-p3hxkj4tgry27benkrsn4lvivoxb3bjg
  Stage: 3.12s.  Autoreconf: 0.00s.  Configure: 6.47s.  Build: 25.32s.  Install: 0.12s.  Post-install: 0.30s.  Total: 35.50s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/w3m-0.5.3-p3hxkj4tgry27benkrsn4lvivoxb3bjg
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/w3m-0.5.3.git20230121-3bslhgewrnatdoqlkktysb4dhymacbsu
```