### PR TITLE
py-fortranformat: add v1.1.1, v1.2.2, v2.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-fortranformat/package.py
+++ b/var/spack/repos/builtin/packages/py-fortranformat/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyFortranformat(PythonPackage):
     """Mimics Fortran textual IO in Python"""
 
-    homepage = "http://bitbucket.org/brendanarnold/py-fortranformat"
+    homepage = "https://github.com/brendanarnold/py-fortranformat"
     pypi = "fortranformat/fortranformat-2.0.0.tar.gz"
 
     license("MIT")

--- a/var/spack/repos/builtin/packages/py-fortranformat/package.py
+++ b/var/spack/repos/builtin/packages/py-fortranformat/package.py
@@ -10,10 +10,13 @@ class PyFortranformat(PythonPackage):
     """Mimics Fortran textual IO in Python"""
 
     homepage = "http://bitbucket.org/brendanarnold/py-fortranformat"
-    pypi = "fortranformat/fortranformat-0.2.5.tar.gz"
+    pypi = "fortranformat/fortranformat-2.0.0.tar.gz"
 
     license("MIT")
 
+    version("2.0.0", sha256="52473831d6f6bad7c2de0f26ad51856ea5d0ef097bcba5af3b855b871b815b0d")
+    version("1.2.2", sha256="a8c41ab39bb40444e6ca17f38755d64df51799b064206833c137a28bbdca1b2b")
+    version("1.1.1", sha256="9b7aa2148af7a5f4f5fd955d121bd6869d44b82ac2182d459813b849aa87d831")
     version("0.2.5", sha256="6b5fbc1f129c7a70543c3a81f334fb4d57f07df2834b22ce69f6d7e8539cd3f9")
 
     # pip silently replaces distutils with setuptools


### PR DESCRIPTION
This change adds several recent versions of py-fortranformat and updates the homepage which has moved to GitHub. The currently included release (0.2.5) is from 2014. I've added the latest point release of each of the major versions from the last 4 years.

I've tested this on an ubuntu host using the gnu-11 toolchain. [See this gist](https://gist.github.com/eap/d8a4191020e0b55d58c050532f206ba5).