### PR TITLE
diy: add smoke test

### DIFF
--- a/var/spack/repos/builtin/packages/diy/package.py
+++ b/var/spack/repos/builtin/packages/diy/package.py
@@ -10,6 +10,8 @@ class Diy(CMakePackage):
     """Data-parallel out-of-core library"""
 
     homepage = "https://github.com/diatomic/diy"
+    maintainers("vicentebolea")
+
     url = "https://github.com/diatomic/diy/archive/3.6.0.tar.gz"
     git = "https://github.com/diatomic/diy.git"
 
@@ -23,10 +25,42 @@ class Diy(CMakePackage):
 
     depends_on("mpi")
 
+    # https://gitlab.kitware.com/diatomic/diy/-/merge_requests/82
+    patch(
+        "https://gitlab.kitware.com/diatomic/diy/-/commit/1d85dd5205b9f0035840e1840a49ea7028618d16.diff",
+        sha256="047bed205c905064923d7ecf1d03e38c07f3ae0baa0f4afe1b234f68315472d3",
+        when="@3.6:",
+    )
+
     def cmake_args(self):
         args = [
             "-Dbuild_examples=off",
             "-Dbuild_tests=off",
+            "-Dinstall_examples=on",
             "-DCMAKE_CXX_COMPILER=%s" % self.spec["mpi"].mpicxx,
         ]
         return args
+
+    def test_smoke_test(self):
+        """Build and run ctests"""
+        spec = self.spec
+
+        if spec.satisfies("@:3.5"):
+            raise SkipTest("Smoke test requires DIY>=3.6")
+
+        with working_dir("smoke_test_build", create=True):
+            cmake = Executable(spec["cmake"].prefix.bin.cmake)
+            ctest = Executable(spec["cmake"].prefix.bin.ctest)
+
+            cmake(
+                spec["diy"].prefix.share.DIY.examples.smoke_test,
+                f"-DMPI_HOME={spec['mpi'].prefix}",
+                f"-DCMAKE_PREFIX_PATH={spec['diy'].prefix}",
+            )
+            cmake("--build", ".")
+            ctest("--verbose")
+
+    @run_after("install")
+    @on_package_attributes(run_tests=True)
+    def build_test(self):
+        self.test_smoke_test()


### PR DESCRIPTION
This adds a install test (smoke test) to the DIY package. This is done after submitting upstream changes that adds a smoke test to the project and fixes the cmake files installation location.


cc @kwryankrattiger 

x-ref: https://gitlab.kitware.com/diatomic/diy/-/merge_requests/82