### PR TITLE
paraview: add new v5.13.0-RC2 release

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -31,7 +31,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master", submodules=True)
     version(
-        "5.13.0-RC1", sha256="00aea2bbaf2eacd288a6cc95c1f4ed1a8a4965f27548b53ae473c1ee7caec30e"
+        "5.13.0-RC2", sha256="d10d0cec48c662d8c78470726af1b28cd39cbe434aef7fd0f75eec0112fa3f89"
     )
     version(
         "5.12.1",


### PR DESCRIPTION



🎉 🎉 🎉

ParaView 5.13.0-RC2 is out

This PR updates the ParaView Spack package to include this new release (and remove the RC1) while keeping its last final release ParaView v5.12.0 as the preferred version.

Let me know if we need to change anything else in the package.

🎉 🎉 🎉
