### PR TITLE
hipsolver: remove use of deprecated `run_test` method

### DIFF
--- a/var/spack/repos/builtin/packages/hipsolver/package.py
+++ b/var/spack/repos/builtin/packages/hipsolver/package.py
@@ -114,7 +114,7 @@ class Hipsolver(CMakePackage, CudaPackage, ROCmPackage):
     patch("001-suite-sparse-include-path.patch", when="@6.1.0")
     patch("0001-suite-sparse-include-path-6.1.1.patch", when="@6.1.1:")
 
-    def check_install(self):
+    def check(self):
         exe = join_path(self.builder.build_directory, "clients", "staging", "hipsolver-test")
         exe = which(exe)
         exe(["--gtest_filter=-*known_bug*"])

--- a/var/spack/repos/builtin/packages/hipsolver/package.py
+++ b/var/spack/repos/builtin/packages/hipsolver/package.py
@@ -114,8 +114,7 @@ class Hipsolver(CMakePackage, CudaPackage, ROCmPackage):
     patch("001-suite-sparse-include-path.patch", when="@6.1.0")
     patch("0001-suite-sparse-include-path-6.1.1.patch", when="@6.1.1:")
 
-    def test_hipsolver(self):
-        """Test if hipsolver runs"""
+    def check_install(self):
         exe = join_path(self.builder.build_directory, "clients", "staging", "hipsolver-test")
         exe = which(exe)
         exe(["--gtest_filter=-*known_bug*"])

--- a/var/spack/repos/builtin/packages/hipsolver/package.py
+++ b/var/spack/repos/builtin/packages/hipsolver/package.py
@@ -114,9 +114,11 @@ class Hipsolver(CMakePackage, CudaPackage, ROCmPackage):
     patch("001-suite-sparse-include-path.patch", when="@6.1.0")
     patch("0001-suite-sparse-include-path-6.1.1.patch", when="@6.1.1:")
 
-    def check(self):
-        exe = join_path(self.build_directory, "clients", "staging", "hipsolver-test")
-        self.run_test(exe, options=["--gtest_filter=-*known_bug*"])
+    def test_hipsolver(self):
+        """Test if hipsolver runs"""
+        exe = join_path(self.builder.build_directory, "clients", "staging", "hipsolver-test")
+        exe = which(exe)
+        exe(["--gtest_filter=-*known_bug*"])
 
     @classmethod
     def determine_version(cls, lib):


### PR DESCRIPTION
get rid of deprecated `self.run_test` method

`$spack install --test=root hipsolver` results:

```

4 errors found in build log:
     9     -- The Fortran compiler identification is GNU 10.3.1
     10    -- Detecting Fortran compiler ABI info
     11    -- Detecting Fortran compiler ABI info - done
     12    -- Check for working Fortran compiler: /usr/WS2/lawrence31/spack/lib/spack/env/gcc/gfortran - skipped
     13    CMake Warning (dev) at /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hip-6.1.1-ei
           jimg5dm6ailpfk2hkz62t4pj4ghoep/lib/cmake/hip/hip-config-amd.cmake:86 (message):
     14      amdgpu-arch failed with error Failed to load libamdhip64.so:
  >> 15    libamdhip64.so: cannot open shared object file: No such file or directory
     16    Call Stack (most recent call first):
     17      /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hip-6.1.1-eijimg5dm6ailpfk2hkz62t
           4pj4ghoep/lib/cmake/hip/hip-config.cmake:149 (include)
     18      CMakeLists.txt:151 (find_package)
     19    This warning is for project developers.  Use -Wno-dev to suppress it.
     20    
     21    and the output is

     ...

     25    -- Looking for pthread_create in pthreads - not found
     26    -- Looking for pthread_create in pthread
     27    -- Looking for pthread_create in pthread - found
     28    -- Found Threads: TRUE
     29    CMake Warning (dev) at /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hip-6.1.1-ei
           jimg5dm6ailpfk2hkz62t4pj4ghoep/lib/cmake/hip/hip-config-amd.cmake:86 (message):
     30      amdgpu-arch failed with error Failed to load libamdhip64.so:
  >> 31    libamdhip64.so: cannot open shared object file: No such file or directory
     32    Call Stack (most recent call first):
     33      /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hip-6.1.1-eijimg5dm6ailpfk2hkz62t
           4pj4ghoep/lib/cmake/hip/hip-config.cmake:149 (include)
     34      library/CMakeLists.txt:50 (find_package)
     35    This warning is for project developers.  Use -Wno-dev to suppress it.
     36    
     37    and the output is
     38    CMake Warning (dev) at /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hip-6.1.1-ei
           jimg5dm6ailpfk2hkz62t4pj4ghoep/lib/cmake/hip/hip-config-amd.cmake:86 (message):
     39      amdgpu-arch failed with error Failed to load libamdhip64.so:
  >> 40    libamdhip64.so: cannot open shared object file: No such file or directory
     41    Call Stack (most recent call first):
     42      /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/hip-6.1.1-eijimg5dm6ailpfk2hkz62t
           4pj4ghoep/lib/cmake/hip/hip-config.cmake:149 (include)
     43      /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/cmake-3.29.4-eplcyjvolizfqs4g7zvm
           ma6hrfkif4cg/share/cmake-3.29/Modules/CMakeFindDependencyMacro.cmake:76 (find_package)
     44      /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/rocblas-6.1.1-hjr2z6pl7ac7g6m7luh
           tx2l3f6zscanb/lib/cmake/rocblas/rocblas-config.cmake:90 (find_dependency)
     45      library/src/CMakeLists.txt:107 (find_package)
     46    This warning is for project developers.  Use -Wno-dev to suppress it.

     ...

     53    -- Performing Test COMPILER_HAS_DEPRECATED_ATTR
     54    -- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
     55    -- Backward Compatible Sym Link Created for include directories
     56    -- Check if compiler accepts -pthread
     57    -- Check if compiler accepts -pthread - yes
     58    -- Found GTest: /usr/WS2/lawrence31/spack/opt/spack/linux-rhel8-broadwell/gcc-10.3.1/googletest-1.12.1-q
           a737cbas22jtdx6k4bdoqes44wyz3ak/lib64/cmake/GTest/GTestConfig.cmake (found version "1.12.1")
  >> 59    CMake Error at clients/gtest/CMakeLists.txt:42 (find_package):
     60      Could not find a package configuration file provided by "hipsparse" with
     61      any of the following names:
     62    
     63        hipsparseConfig.cmake
     64        hipsparse-config.cmake
     65    

```