### PR TITLE
hypre: get rid of use of deprecated run_test method

### DIFF
--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -374,8 +374,10 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
             make("install")
             if spec.satisfies("+gptune"):
                 make("test")
-                self.run_test("mkdir", options=["-p", self.prefix.bin])
-                self.run_test("cp", options=["test/ij", self.prefix.bin + "/."])
+                mkdir = which("mkdir")
+                mkdir("-p", self.prefix.bin)
+                cp = which("cp")
+                cp("test/ij", self.prefix.bin + "/.")
 
     extra_install_tests = join_path("src", "examples")
 

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -375,8 +375,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
             if spec.satisfies("+gptune"):
                 make("test")
                 mkdirp(self.prefix.bin)
-                cp = which("cp")
-                cp("test/ij", self.prefix.bin + "/.")
+                install(join_path("test", "ij"), self.prefix.bin)
 
     extra_install_tests = join_path("src", "examples")
 

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -374,8 +374,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
             make("install")
             if spec.satisfies("+gptune"):
                 make("test")
-                mkdir = which("mkdir")
-                mkdir("-p", self.prefix.bin)
+                mkdirp(self.prefix.bin)
                 cp = which("cp")
                 cp("test/ij", self.prefix.bin + "/.")
 


### PR DESCRIPTION
Example use of copied file:

```
$ spack find -v hypre
..
hypre@2.31.0~caliper~complex~cublas~cuda~debug+fortran+gptune~gpu-aware-mpi~int64~internal-superlu~magma~mixedint+mpi~openmp~rocblas~rocm+shared~superlu-dist~sycl~umpire~unified-memory build_system=autotools precision=double
==> 1 installed package


$ spack load hypre
$ ij
..
=============================================
Hypre init times:
=============================================
..
=============================================
Generate Matrix:
=============================================
..
=============================================
IJ Vector Setup:
=============================================
..
=============================================
Setup phase times:
=============================================
..
=============================================
Solve phase times:
=============================================
BoomerAMG Solve:
  wall clock time = 0.001570 seconds
  wall MFLOPS     = 0.000000
  cpu clock time  = 0.001555 seconds
  cpu MFLOPS      = 0.000000


BoomerAMG Iterations = 11
Final Relative Residual Norm = 1.847657e-09
```