### PR TITLE
hsakmt-roct: remove use of deprecated run_test method

### DIFF
--- a/var/spack/repos/builtin/packages/hsakmt-roct/package.py
+++ b/var/spack/repos/builtin/packages/hsakmt-roct/package.py
@@ -90,9 +90,8 @@ class HsakmtRoct(CMakePackage):
     @on_package_attributes(run_tests=True)
     def test_check_install(self):
         """Check if package is installed correctly"""
-        test_dir = "tests/kfdtest"
+        test_dir = join_path("tests", "kfdtest")
         with working_dir(test_dir, create=True):
-            cmake_bin = join_path(self.spec["cmake"].prefix.bin, "cmake")
             prefixes = ";".join(
                 [
                     self.spec["libdrm"].prefix,
@@ -110,11 +109,12 @@ class HsakmtRoct(CMakePackage):
                 "-DLIBHSAKMT_PATH=" + hsakmt_path,
                 ".",
             ]
-            cmake = which(cmake_bin)
+            cmake = self.spec["cmake"].command
             cmake(*cc_options)
+            make = which("make")
             make()
             os.environ["LD_LIBRARY_PATH"] = hsakmt_path
             os.environ["BIN_DIR"] = os.getcwd()
-            scripts = which("scripts/run_kfdtest.sh")
+            scripts = which(join_path("scripts", "run_kfdtest.sh"))
             scripts()
             make("clean")

--- a/var/spack/repos/builtin/packages/hsakmt-roct/package.py
+++ b/var/spack/repos/builtin/packages/hsakmt-roct/package.py
@@ -88,7 +88,8 @@ class HsakmtRoct(CMakePackage):
 
     @run_after("install")
     @on_package_attributes(run_tests=True)
-    def check_install(self):
+    def test_check_install(self):
+        """Check if package is installed correctly"""
         test_dir = "tests/kfdtest"
         with working_dir(test_dir, create=True):
             cmake_bin = join_path(self.spec["cmake"].prefix.bin, "cmake")
@@ -109,9 +110,11 @@ class HsakmtRoct(CMakePackage):
                 "-DLIBHSAKMT_PATH=" + hsakmt_path,
                 ".",
             ]
-            self.run_test(cmake_bin, cc_options)
+            cmake = which(cmake_bin)
+            cmake(*cc_options)
             make()
             os.environ["LD_LIBRARY_PATH"] = hsakmt_path
             os.environ["BIN_DIR"] = os.getcwd()
-            self.run_test("scripts/run_kfdtest.sh")
+            scripts = which("scripts/run_kfdtest.sh")
+            scripts()
             make("clean")

--- a/var/spack/repos/builtin/packages/hsakmt-roct/package.py
+++ b/var/spack/repos/builtin/packages/hsakmt-roct/package.py
@@ -115,6 +115,6 @@ class HsakmtRoct(CMakePackage):
             make()
             os.environ["LD_LIBRARY_PATH"] = hsakmt_path
             os.environ["BIN_DIR"] = os.getcwd()
-            scripts = which(join_path("scripts", "run_kfdtest.sh"))
-            scripts()
+            run_kfdtest = which(join_path("scripts", "run_kfdtest.sh"))
+            run_kfdtest()
             make("clean")

--- a/var/spack/repos/builtin/packages/hsakmt-roct/package.py
+++ b/var/spack/repos/builtin/packages/hsakmt-roct/package.py
@@ -88,7 +88,7 @@ class HsakmtRoct(CMakePackage):
 
     @run_after("install")
     @on_package_attributes(run_tests=True)
-    def test_check_install(self):
+    def check_install(self):
         """Check if package is installed correctly"""
         test_dir = join_path("tests", "kfdtest")
         with working_dir(test_dir, create=True):


### PR DESCRIPTION
get rid of depreciate `self.run_test` method

Test log when using `$spack install --test=root hsakmt-roct`:
```
==> Testing package hsakmt-roct-6.1.1-s7kp6nr
==> [2024-08-16-09:53:29.477446] Running build-time tests
==> [2024-08-16-09:53:29.477673] RUN-TESTS: build-time tests [check]
==> [2024-08-16-09:53:29.480406] 'make' '-j16' '-n' 'test'
==> [2024-08-16-09:53:29.525686] Target 'test' not found in Makefile
==> [2024-08-16-09:53:29.526928] 'make' '-j16' '-n' 'check'
==> [2024-08-16-09:53:29.568585] Target 'check' not found in Makefile
```

Build Error when using `$spack install --test=root hsakmt-roct` has over 500k characters, so it will not be listed.  

UPDATE: The output of the above command seems to indicate the aforementioned failure is likely the result of building `kfdtest` (though the package was modified with #45817 before running) [hsakmt-roct-spack-build-out.txt](https://github.com/user-attachments/files/16664376/hsakmt-roct-spack-build-out.txt)