### PR TITLE
util/web.py: parse new GitLab JS dropdown links

### DIFF
--- a/lib/spack/spack/test/data/web/index_with_javascript.html
+++ b/lib/spack/spack/test/data/web/index_with_javascript.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    This is the root page.
+  </head>
+  <body>
+    This is a page with a Vue javascript drop down with links as used in GitLab.
+
+    <div class="js-source-code-dropdown" data-css-class="" data-download-artifacts="[]" data-download-links="[{&quot;text&quot;:&quot;tar.gz&quot;,&quot;path&quot;:&quot;/foo-5.0.0.tar.gz&quot;}]"></div>
+  </body>
+</html>

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -37,6 +37,7 @@ page_3 = _create_url("3.html")
 page_4 = _create_url("4.html")
 
 root_with_fragment = _create_url("index_with_fragment.html")
+root_with_javascript = _create_url("index_with_javascript.html")
 
 
 @pytest.mark.parametrize(
@@ -145,6 +146,11 @@ def test_find_exotic_versions_of_archive_3():
 
 def test_find_versions_of_archive_with_fragment():
     versions = spack.url.find_versions_of_archive(root_tarball, root_with_fragment, list_depth=0)
+    assert Version("5.0.0") in versions
+
+
+def test_find_versions_of_archive_with_javascript():
+    versions = spack.url.find_versions_of_archive(root_tarball, root_with_javascript, list_depth=0)
     assert Version("5.0.0") in versions
 
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -171,7 +171,7 @@ class LinkParser(HTMLParser):
             try:
                 links_str = next(val for key, val in attrs if key == "data-download-links")
                 links = json.loads(links_str)
-                self.links.extend([x["path"] for x in links])
+                self.links.extend(x["path"] for x in links)
             except Exception:
                 pass
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -162,20 +162,18 @@ class LinkParser(HTMLParser):
 
     def handle_starttag(self, tag, attrs):
         if tag == "a":
-            for attr, val in attrs:
-                if attr == "href":
-                    self.links.append(val)
+            self.links.extend(val for key, val in attrs if key == "href")
 
         # GitLab uses a javascript function to place dropdown links:
         #  <div class="js-source-code-dropdown" ...
         #   data-download-links="[{"path":"/graphviz/graphviz/-/archive/12.0.0/graphviz-12.0.0.zip",...},...]"/>
         if tag == "div" and ("class", "js-source-code-dropdown") in attrs:
-            vals = [x[1] for x in attrs if x[0] == "data-download-links"]
-            for val in vals:
-                data_download_links = json.loads(val)
-                links = [x["path"] for x in data_download_links]
-                for link in links:
-                    self.links.append(link)
+            try:
+                links_str = next(val for key, val in attrs if key == "data-download-links")
+                links = json.loads(links_str)
+                self.links.extend([x["path"] for x in links])
+            except Exception:
+                pass
 
 
 class ExtractMetadataParser(HTMLParser):

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -169,14 +169,13 @@ class LinkParser(HTMLParser):
         # GitLab uses a javascript function to place dropdown links:
         #  <div class="js-source-code-dropdown" ...
         #   data-download-links="[{"path":"/graphviz/graphviz/-/archive/12.0.0/graphviz-12.0.0.zip",...},...]"/>
-        if tag == "div":
-            if ("class", "js-source-code-dropdown") in attrs:
-                vals = [x[1] for x in attrs if x[0] == "data-download-links"]
-                for val in vals:
-                    data_download_links = json.loads(val)
-                    links = [x["path"] for x in data_download_links]
-                    for link in links:
-                        self.links.append(link)
+        if tag == "div" and ("class", "js-source-code-dropdown") in attrs:
+            vals = [x[1] for x in attrs if x[0] == "data-download-links"]
+            for val in vals:
+                data_download_links = json.loads(val)
+                links = [x["path"] for x in data_download_links]
+                for link in links:
+                    self.links.append(link)
 
 
 class ExtractMetadataParser(HTMLParser):


### PR DESCRIPTION
GitLab changed how dropdown links are encoded in html, https://gitlab.com/gitlab-org/gitlab/-/merge_requests/146633. Previously those were still showing up as href anchors, now they require some vue javascript that rewrites the dom when accessed. That has caused `spack checksum` to fail on GitLab servers, both gitlab.com and now also the servers on the free plan:
```console
root@codespaces-50325a:/workspaces/spack# spack checksum graphviz 
==> Found 1 version of graphviz
==> Fetching https://gitlab.com/graphviz/graphviz/-/archive/2.46.0/graphviz-2.46.0.tar.bz2

    version("2.46.0", sha256="1b11684fd5488940b45bf4624393140da6032abafae08f33dc3e986cffd55d71")
```

Looking more into the html at https://gitlab.com/graphviz/graphviz/-/tags/, the segments look like
```html
<div class="js-source-code-dropdown" data-css-class="" data-download-artifacts="[]" data-download-links="
[{&quot;text&quot;:&quot;zip&quot;,&quot;path&quot;:&quot;/graphviz/graphviz/-/archive/12.0.0/graphviz-12.0.0.zip&quot;},
{&quot;text&quot;:&quot;tar.gz&quot;,&quot;path&quot;:&quot;/graphviz/graphviz/-/archive/12.0.0/graphviz-12.0.0.tar.gz&quot;},
{&quot;text&quot;:&quot;tar.bz2&quot;,&quot;path&quot;:&quot;/graphviz/graphviz/-/archive/12.0.0/graphviz-12.0.0.tar.bz2&quot;},
{&quot;text&quot;:&quot;tar&quot;,&quot;path&quot;:&quot;/graphviz/graphviz/-/archive/12.0.0/graphviz-12.0.0.tar&quot;}]"></div>
```

This PR adds a segment in the link parser to pick out the json paths from the data-download-links. With this PR, `spack checksum` works again:
```console
$ spack checksum graphviz 
==> Selected 20 versions. 12 new versions
  12.1.0  https://gitlab.com/graphviz/graphviz/-/archive/12.1.0/graphviz-12.1.0.tar.bz2
  12.0.0  https://gitlab.com/graphviz/graphviz/-/archive/12.0.0/graphviz-12.0.0.tar.bz2
  11.0.0  https://gitlab.com/graphviz/graphviz/-/archive/11.0.0/graphviz-11.0.0.tar.bz2
  10.0.1  https://gitlab.com/graphviz/graphviz/-/archive/10.0.1/graphviz-10.0.1.tar.bz2
  9.0.0   https://gitlab.com/graphviz/graphviz/-/archive/9.0.0/graphviz-9.0.0.tar.bz2
  8.1.0   https://gitlab.com/graphviz/graphviz/-/archive/8.1.0/graphviz-8.1.0.tar.bz2
  8.0.5   https://gitlab.com/graphviz/graphviz/-/archive/8.0.5/graphviz-8.0.5.tar.bz2
  8.0.4   https://gitlab.com/graphviz/graphviz/-/archive/8.0.4/graphviz-8.0.4.tar.bz2
  8.0.3   https://gitlab.com/graphviz/graphviz/-/archive/8.0.3/graphviz-8.0.3.tar.bz2
  ...
  6.0.2   https://gitlab.com/graphviz/graphviz/-/archive/6.0.2/graphviz-6.0.2.tar.bz2
```

TODO:
- [x] unit tests