### PR TITLE
installer: show tracebacks from builds to debug failed installs

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2242,7 +2242,7 @@ class PackageInstaller:
         if failed_build_requests or missing:
             for _, pkg_id, err in failed_build_requests:
                 tty.error(f"{pkg_id}: {err}")
-                if spack.error.debug:
+                if spack.error.SHOW_BACKTRACE:
                     # note: in python 3.10+ this can just be print_exception(err)
                     traceback.print_exception(type(err), err, err.__traceback__)
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -36,6 +36,7 @@ import os
 import shutil
 import sys
 import time
+import traceback
 from collections import defaultdict
 from gzip import GzipFile
 from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
@@ -2214,7 +2215,7 @@ class PackageInstaller:
                 if task.is_build_request:
                     if single_requested_spec:
                         raise
-                    failed_build_requests.append((pkg, pkg_id, str(exc)))
+                    failed_build_requests.append((pkg, pkg_id, exc))
 
             finally:
                 # Remove the install prefix if anything went wrong during
@@ -2241,6 +2242,9 @@ class PackageInstaller:
         if failed_build_requests or missing:
             for _, pkg_id, err in failed_build_requests:
                 tty.error(f"{pkg_id}: {err}")
+                if spack.error.debug:
+                    # note: in python 3.10+ this can just be print_exception(err)
+                    traceback.print_exception(type(err), err, err.__traceback__)
 
             for _, pkg_id in missing:
                 tty.error(f"{pkg_id}: Package was not installed")


### PR DESCRIPTION
`installer.py` currently swallows the traceback and preserves only the error messaege if a build process fails.

- [x] preserve exceptions from failed build processes
- [x] print a full traceback for each one when running with `spack -d`
