### PR TITLE
Clean up some tests in `cmd/ci.py`

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1433,10 +1433,6 @@ def copy_stage_logs_to_artifacts(job_spec: spack.spec.Spec, job_log_dir: str) ->
         job_log_dir: path into which build log should be copied
     """
     tty.debug(f"job spec: {job_spec}")
-    if not job_spec:
-        msg = f"Cannot copy stage logs: job spec ({job_spec}) is required"
-        tty.error(msg)
-        return
 
     try:
         pkg_cls = spack.repo.PATH.get_pkg_class(job_spec.name)

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -233,7 +233,7 @@ spack:
 
 
 def test_ci_generate_with_env_missing_section(
-    tmpdir,
+    tmp_path,
     working_env,
     mutable_mock_env_path,
     install_mockery,
@@ -242,26 +242,21 @@ def test_ci_generate_with_env_missing_section(
     mock_binary_index,
 ):
     """Make sure we get a reasonable message if we omit gitlab-ci section"""
-    filename = str(tmpdir.join("spack.yaml"))
-    with open(filename, "w") as f:
-        f.write(
-            """\
+    spack_yaml = tmp_path / "spack.yaml"
+    spack_yaml.write_text(
+        f"""\
 spack:
   specs:
     - archive-files
   mirrors:
-    some-mirror: file://my.fake.mirror
+    some-mirror: {tmp_path / 'ci-mirror'}
 """
-        )
+    )
 
-    expect_out = "Environment does not have `ci` a configuration"
-
-    with tmpdir.as_cwd():
-        env_cmd("create", "test", "./spack.yaml")
-
-        with ev.read("test"):
-            output = ci_cmd("generate", fail_on_error=False, output=str)
-            assert expect_out in output
+    env_cmd("create", "test", str(spack_yaml))
+    with ev.read("test"):
+        output = ci_cmd("generate", fail_on_error=False, output=str)
+    assert "Environment does not have `ci` a configuration" in output
 
 
 def test_ci_generate_with_cdash_token(

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -272,7 +272,7 @@ spack:
   specs:
     - archive-files
   mirrors:
-    some-mirror: {tmp_path / 'ci-mirror'}
+    some-mirror: {tmp_path / "ci-mirror"}
   ci:
     enable-artifacts-buildcache: True
     pipeline-gen:
@@ -285,7 +285,7 @@ spack:
           image: donotcare
   cdash:
     build-group: Not important
-    url: https://my.fake.cdash
+    url: {(tmp_path / "cdash").as_uri()}
     project: Not used
     site: Nothing
 """

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -155,7 +155,7 @@ def test_ci_generate_with_env(
 ):
     """Make sure we can get a .gitlab-ci.yml from an environment file
     which has the gitlab-ci, cdash, and mirrors sections."""
-    mirror_url = "https://my.fake.mirror"
+    mirror_url = "file://my.fake.mirror"
     filename = str(tmpdir.join("spack.yaml"))
     with open(filename, "w") as f:
         f.write(
@@ -254,7 +254,7 @@ spack:
   specs:
     - archive-files
   mirrors:
-    some-mirror: https://my.fake.mirror
+    some-mirror: file://my.fake.mirror
 """
         )
 
@@ -286,7 +286,7 @@ spack:
   specs:
     - archive-files
   mirrors:
-    some-mirror: https://my.fake.mirror
+    some-mirror: file://my.fake.mirror
   ci:
     enable-artifacts-buildcache: True
     pipeline-gen:
@@ -345,7 +345,7 @@ spack:
   specs:
     - archive-files
   mirrors:
-    some-mirror: https://my.fake.mirror
+    some-mirror: file://my.fake.mirror
   ci:
     pipeline-gen:
     - submapping:
@@ -442,7 +442,7 @@ spack:
   specs:
     - flatten-deps
   mirrors:
-    some-mirror: https://my.fake.mirror
+    some-mirror: file://my.fake.mirror
   ci:
     enable-artifacts-buildcache: True
     pipeline-gen:
@@ -509,7 +509,7 @@ spack:
   specs:
     - flatten-deps
   mirrors:
-    some-mirror: https://my.fake.mirror
+    some-mirror: file://my.fake.mirror
   ci:
     enable-artifacts-buildcache: True
     pipeline-gen:
@@ -531,7 +531,7 @@ spack:
 """
         )
 
-    monkeypatch.setattr(spack.ci, "SHARED_PR_MIRROR_URL", "https://fake.shared.pr.mirror")
+    monkeypatch.setattr(spack.ci, "SHARED_PR_MIRROR_URL", "file://fake.shared.pr.mirror")
 
     with tmpdir.as_cwd():
         env_cmd("create", "test", "./spack.yaml")
@@ -571,7 +571,7 @@ spack:
     - archive-files
     - externaltest
   mirrors:
-    some-mirror: https://my.fake.mirror
+    some-mirror: file://my.fake.mirror
   ci:
     pipeline-gen:
     - submapping:
@@ -1292,7 +1292,7 @@ spack:
     - flatten-deps
     - pkg-a
   mirrors:
-    some-mirror: https://my.fake.mirror
+    some-mirror: file://my.fake.mirror
   ci:
     pipeline-gen:
     - match_behavior: {0}
@@ -1501,7 +1501,7 @@ def test_ci_generate_prune_untouched(
     """Test pipeline generation with pruning works to eliminate
     specs that were not affected by a change"""
     os.environ.update({"SPACK_PRUNE_UNTOUCHED": "TRUE"})  # enables pruning of untouched specs
-    mirror_url = "https://my.fake.mirror"
+    mirror_url = "file://my.fake.mirror"
     filename = str(tmpdir.join("spack.yaml"))
     with open(filename, "w") as f:
         f.write(
@@ -1733,7 +1733,7 @@ spack:
   specs:
     - archive-files
   mirrors:
-    some-mirror: https://my.fake.mirror
+    some-mirror: file://my.fake.mirror
   ci:
     temporary-storage-url-prefix: file:///work/temp/mirror
     pipeline-gen:
@@ -1809,7 +1809,7 @@ spack:
     - flatten-deps
     - pkg-a
   mirrors:
-    some-mirror: https://my.fake.mirror
+    some-mirror: file://my.fake.mirror
   ci:
     broken-specs-url: "{0}"
     pipeline-gen:
@@ -1859,7 +1859,7 @@ spack:
   specs:
     - archive-files
   mirrors:
-    some-mirror: https://my.fake.mirror
+    some-mirror: file://my.fake.mirror
   ci:
     temporary-storage-url-prefix: file:///work/temp/mirror
     pipeline-gen:
@@ -2198,7 +2198,7 @@ spack:
   specs:
     - flatten-deps
   mirrors:
-    some-mirror: https://my.fake.mirror
+    some-mirror: file://my.fake.mirror
   ci:
     pipeline-gen:
     - build-job:


### PR DESCRIPTION
Modifications:
- [x] Use absolute fs paths instead of `https://` for fake mirrors. This speeds-up tests when DNS resolution is slow, and tests appear to be hanging.
- [x] Added a fixture to gather in a single place code that is copy/pasted in a lot of tests
- [x] Cleaned many (but not all) tests
- [x] Remove test_ci_rebuild (broken) 
- [x] Remove test_ci_generate_prune_env_vars (not asserting anything) 