### PR TITLE
oci: support --only=package

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1431,12 +1431,9 @@ def _oci_put_manifest(
     for s in expected_blobs:
         # If a layer for a dependency has gone missing (due to removed manifest in the registry, a
         # failed push, or a local forced uninstall), we cannot create a runnable container image.
-        # If an OCI registry is only used for storage, this is not a hard error, but for now we
-        # raise an exception unconditionally, until someone requests a more lenient behavior.
         checksum = checksums.get(s.dag_hash())
-        if not checksum:
-            raise MissingLayerError(f"missing layer for {_format_spec(s)}")
-        config["rootfs"]["diff_ids"].append(str(checksum.uncompressed_digest))
+        if checksum:
+            config["rootfs"]["diff_ids"].append(str(checksum.uncompressed_digest))
 
     # Set the environment variables
     config["config"]["Env"] = [f"{k}={v}" for k, v in env.items()]
@@ -1481,6 +1478,7 @@ def _oci_put_manifest(
                     "size": checksums[s.dag_hash()].size,
                 }
                 for s in expected_blobs
+                if s.dag_hash() in checksums
             ),
         ],
     }

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -3094,7 +3094,3 @@ class CannotListKeys(GenerateIndexError):
 
 class PushToBuildCacheError(spack.error.SpackError):
     """Raised when unable to push objects to binary mirror"""
-
-
-class MissingLayerError(spack.error.SpackError):
-    """Raised when a required layer for a dependency is missing in an OCI registry."""

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -410,8 +410,6 @@ def push_fn(args):
 
     # For OCI images, we require dependencies to be pushed for now.
     if target_image:
-        if "dependencies" not in args.things_to_install:
-            tty.die("Dependencies must be pushed for OCI images.")
         if not unsigned:
             tty.warn(
                 "Code signing is currently not supported for OCI images. "


### PR DESCRIPTION
Previously `spack buildcache push --only=package` errored in the OCI
case, but it's been requested that OCI can be used as pure storage w/o
the need for runnable container images.

Short version: allow tagged images that do not list all their runtime deps
as layers. The trade-off is between a more useful build cache vs always 
runnable container images. The former was in practice more useful that
the latter.

This commit makes it so that manifests refer only to runtime dependencies
that were selected to be pushed and have blobs available in the build cache.

So if you do `spack buildcache push --only=package` the manifest will not
refer to any dependencies because they were not selected. Similarly with
`spack buildcache push ...` if any of the dependencies is not installed, it
pushes dependents before ultimately failing the command over non-installed
but selected packages.

This fixes the following issues:

1. dependents of non-redistributable specs can now be pushed to oci
   build caches without error
2. failure to upload one tarball does not cause cascading failures for
   dependents whose tarballs do upload successfully -- so it's better
   best-effort behavior
3. for some people uploading with deps caused a massive amount of
   fetches of manifests of deps (which certain registries count as a
   download of an image, even though their layers are not fetched) --
   being able to specify --only=package reduces the number of fetches
   to 1.

Note: I'm not making `spack buildcache push --only=package --base-image=... <build cache> x`
a failure if x has runtime dependencies. It could still be useful to `docker run` a
container image with missing deps to see what's in it, I guess.
