### PR TITLE
shared-mime-info: fix url for certificate hostname mismatch

### DIFF
--- a/var/spack/repos/builtin/packages/shared-mime-info/package.py
+++ b/var/spack/repos/builtin/packages/shared-mime-info/package.py
@@ -10,7 +10,7 @@ class SharedMimeInfo(AutotoolsPackage):
     """Database of common MIME types."""
 
     homepage = "https://freedesktop.org/wiki/Software/shared-mime-info"
-    url = "http://freedesktop.org/~hadess/shared-mime-info-1.8.tar.xz"
+    url = "https://people.freedesktop.org/~hadess/shared-mime-info-1.8.tar.xz"
 
     license("GPL-2.0-or-later")
 


### PR DESCRIPTION
Fetching fails for `shared-mime-info` due to:
```
==> [2024-08-15-10:12:42.634411] Failure reading URL: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, certificate is not valid for 'freedesktop.org'. (_ssl.c:1000)>
==> [2024-08-15-10:12:42.634518] URL does not exist: http://freedesktop.org/~hadess/shared-mime-info-1.10.tar.xz
```
The certificate of `people.freedesktop.org` is valid, and this PR changes the url to that new location.

For a future PR, this project is not a personal project, and releases up to 2.4 are now at https://gitlab.freedesktop.org/xdg/shared-mime-info/-/releases. This is just to get fetchers unstuck.