### PR TITLE
ghostscript: add v10.01.2, v10.02.1, v10.03.1

### DIFF
--- a/var/spack/repos/builtin/packages/ghostscript/package.py
+++ b/var/spack/repos/builtin/packages/ghostscript/package.py
@@ -14,11 +14,15 @@ class Ghostscript(AutotoolsPackage):
 
     homepage = "https://ghostscript.com/"
     url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs926/ghostscript-9.26.tar.gz"
+    git = "https://git.ghostscript.com/ghostpdl.git"
 
     executables = [r"^gs$"]
 
-    license("AGPL-3.0-or-later")
+    license("AGPL-3.0-or-later", checked_by="wdconinc")
 
+    version("10.03.1", sha256="31cd01682ad23a801cc3bbc222a55f07c4ea3e068bdfb447792d54db21a2e8ad")
+    version("10.02.1", sha256="e429e4f5b01615a4f0f93a4128e8a1a4d932dff983b1774174c79c0630717ad9")
+    version("10.01.2", sha256="a4cd61a07fec161bee35da0211a5e5cde8ff8a0aaf942fc0176715e499d21661")
     version("10.0.0", sha256="a57764d70caf85e2fc0b0f59b83b92e25775631714dcdb97cc6e0cea414bb5a3")
     version("9.56.1", sha256="1598b9a38659cce8448d42a73054b2f9cbfcc40a9b97eeec5f22d4d6cd1de8e6")
     version("9.54.0", sha256="0646bb97f6f4d10a763f4919c54fa28b4fbdd3dff8e7de3410431c81762cade0")
@@ -29,8 +33,11 @@ class Ghostscript(AutotoolsPackage):
     version("9.21", sha256="02bceadbc4dddeb6f2eec9c8b1623d945d355ca11b8b4df035332b217d58ce85")
     version("9.18", sha256="5fc93079749a250be5404c465943850e3ed5ffbc0d5c07e10c7c5ee8afbbdb1b")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+
+    # --enable-dynamic is deprecated, but kept as a variant since it used to be default
+    # https://github.com/ArtifexSoftware/ghostpdl/commit/fe0f842da782b097ce13c31fccacce2374ed6d4b
+    variant("dynamic", default=False, description="Enable dynamically loaded drivers")
 
     # https://www.ghostscript.com/ocr.html
     variant("tesseract", default=False, description="Use the Tesseract library for OCR")
@@ -64,6 +71,9 @@ class Ghostscript(AutotoolsPackage):
         sha256="f3c2e56aa552a030c6db2923276ff2d140e39c511f92d9ef6c74a24776940af7",
     )
 
+    build_targets = ["default", "so"]
+    install_targets = ["install", "soinstall"]
+
     def url_for_version(self, version):
         baseurl = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs{0}/ghostscript-{1}.tar.gz"
         return baseurl.format(version.joined, version.dotted)
@@ -93,20 +103,19 @@ class Ghostscript(AutotoolsPackage):
         )
 
     def configure_args(self):
-        args = ["--disable-compile-inits", "--enable-dynamic", "--with-system-libtiff"]
+        args = ["--disable-compile-inits", "--with-system-libtiff"]
 
         if self.spec.satisfies("@9.53:"):
             args.extend(self.with_or_without("tesseract"))
 
+        if self.spec.satisfies("+dynamic"):
+            args.append("--enable-dynamic")
+            if self.spec.satisfies("@10.01.0:"):
+                args.append("--disable-hidden-visibility")
+        else:
+            args.append("--disable-dynamic")
+
         return args
-
-    def build(self, spec, prefix):
-        make()
-        make("so")
-
-    def install(self, spec, prefix):
-        make("install")
-        make("soinstall")
 
     @classmethod
     def determine_version(cls, exe):


### PR DESCRIPTION
This PR adds ghostscript versions through v10.03.1.
- `git` attributed added,
- `license` checked,
- `cxx` was due to false positives in vendored zlib and libpng (which are rmtree'd before build),
- variant `dynamic` added since this is deprecated but was default enabled before,
- add `--disable-hidden-visibility` when `--enable-dynamic` for recent versions,
- replace `build()` and `install()` overrides with `build_targets` and `install_targets` attributes.

Test builds (one `+dynamic` and one `~dynamic`):
```
==> Installing ghostscript-10.03.1-opg34x7dmizs6asweuq3cuq243tvw4dr [117/118]
==> No binary for ghostscript-10.03.1-opg34x7dmizs6asweuq3cuq243tvw4dr found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/31/31cd01682ad23a801cc3bbc222a55f07c4ea3e068bdfb447792d54db21a2e8ad.tar.gz
==> Ran patch() for ghostscript
==> ghostscript: Executing phase: 'autoreconf'
==> ghostscript: Executing phase: 'configure'
==> ghostscript: Executing phase: 'build'
==> ghostscript: Executing phase: 'install'
==> ghostscript: Successfully installed ghostscript-10.03.1-opg34x7dmizs6asweuq3cuq243tvw4dr
  Stage: 1.36s.  Autoreconf: 0.00s.  Configure: 11.46s.  Build: 24.18s.  Install: 24.71s.  Post-install: 0.59s.  Total: 1m 2.64s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/ghostscript-10.03.1-opg34x7dmizs6asweuq3cuq243tvw4dr
==> Installing ghostscript-10.03.1-pzswnnunfqrqhllljx2cjaztezlyjj56 [118/118]
==> No binary for ghostscript-10.03.1-pzswnnunfqrqhllljx2cjaztezlyjj56 found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/31/31cd01682ad23a801cc3bbc222a55f07c4ea3e068bdfb447792d54db21a2e8ad.tar.gz
==> Ran patch() for ghostscript
==> ghostscript: Executing phase: 'autoreconf'
==> ghostscript: Executing phase: 'configure'
==> ghostscript: Executing phase: 'build'
==> ghostscript: Executing phase: 'install'
==> ghostscript: Successfully installed ghostscript-10.03.1-pzswnnunfqrqhllljx2cjaztezlyjj56
  Stage: 1.08s.  Autoreconf: 0.00s.  Configure: 10.03s.  Build: 26.02s.  Install: 31.42s.  Post-install: 0.59s.  Total: 1m 9.62s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/ghostscript-10.03.1-pzswnnunfqrqhllljx2cjaztezlyjj56
```