### PR TITLE
libmesh: explicitly disable metis in ~metis case

### DIFF
--- a/var/spack/repos/builtin/packages/libmesh/package.py
+++ b/var/spack/repos/builtin/packages/libmesh/package.py
@@ -261,6 +261,8 @@ class Libmesh(AutotoolsPackage):
             if "+petsc" in self.spec:
                 options.append("--with-metis=PETSc")
                 options.append("--with-parmetis=PETSc")
+        else:
+            options.append("--disable-metis")
 
         if "+petsc" in self.spec or "+slepc" in self.spec:
             options.append("--enable-petsc=yes")


### PR DESCRIPTION
Fixes corner case where `~metis` is requested but build system would still use it by default.
