### PR TITLE
*: avoid js redirect for homepages on sourceforge

### DIFF
--- a/var/spack/repos/builtin/packages/7zip/package.py
+++ b/var/spack/repos/builtin/packages/7zip/package.py
@@ -15,7 +15,7 @@ from spack.package import *
 class _7zip(SourceforgePackage, Package):
     """7-Zip is a file archiver for Windows"""
 
-    homepage = "https://sourceforge.net/projects/sevenzip"
+    homepage = "https://sourceforge.net/projects/sevenzip/"
     sourceforge_mirror_path = "sevenzip/files/7z2107-src.tar.xz"
     tags = ["windows"]
 

--- a/var/spack/repos/builtin/packages/iperf2/package.py
+++ b/var/spack/repos/builtin/packages/iperf2/package.py
@@ -11,7 +11,7 @@ class Iperf2(AutotoolsPackage, SourceforgePackage):
     2.0.5 code base. Iperf 2.0.5 is still widely deployed and used by many for
     testing networks and for qualifying networking products."""
 
-    homepage = "https://sourceforge.net/projects/iperf2"
+    homepage = "https://sourceforge.net/projects/iperf2/"
     sourceforge_mirror_path = "iperf2/iperf-2.0.12.tar.gz"
 
     version("2.1.9", sha256="5c0771aab00ef14520013aef01675977816e23bb8f5d9fde016f90eb2f1be788")

--- a/var/spack/repos/builtin/packages/kaks-calculator/package.py
+++ b/var/spack/repos/builtin/packages/kaks-calculator/package.py
@@ -12,7 +12,7 @@ class KaksCalculator(MakefilePackage, SourceforgePackage):
     include as many features as needed for accurately capturing evolutionary
     information in protein-coding sequences."""
 
-    homepage = "https://sourceforge.net/projects/kakscalculator2"
+    homepage = "https://sourceforge.net/projects/kakscalculator2/"
     sourceforge_mirror_path = "kakscalculator2/KaKs_Calculator2.0.tar.gz"
 
     version("2.0", sha256="e2df719a2fecc549d8ddc4e6d8f5cfa4b248282dca319c1928eaf886d68ec3c5")

--- a/var/spack/repos/builtin/packages/lesstif/package.py
+++ b/var/spack/repos/builtin/packages/lesstif/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class Lesstif(AutotoolsPackage):
     """LessTif is the Hungry Programmers' version of OSF/Motif."""
 
-    homepage = "https://sourceforge.net/projects/lesstif"
+    homepage = "https://sourceforge.net/projects/lesstif/"
     url = "https://sourceforge.net/projects/lesstif/files/lesstif/0.95.2/lesstif-0.95.2.tar.bz2/download"
 
     license("LGPL-2.0-only")

--- a/var/spack/repos/builtin/packages/libcerf/package.py
+++ b/var/spack/repos/builtin/packages/libcerf/package.py
@@ -14,7 +14,7 @@ class Libcerf(AutotoolsPackage, SourceforgePackage):
 
     """
 
-    homepage = "https://sourceforge.net/projects/libcerf"
+    homepage = "https://sourceforge.net/projects/libcerf/"
     sourceforge_mirror_path = "libcerf/libcerf-1.3.tgz"
 
     version("1.3", sha256="d7059e923d3f370c89fb4d19ed4f827d381bc3f0e36da5595a04aeaaf3e6a859")

--- a/var/spack/repos/builtin/packages/libexif/package.py
+++ b/var/spack/repos/builtin/packages/libexif/package.py
@@ -8,7 +8,7 @@ from spack.package import *
 class Libexif(AutotoolsPackage, SourceforgePackage):
     """A library to parse an EXIF file and read the data from those tags"""
 
-    homepage = "https://sourceforge.net/projects/libexif"
+    homepage = "https://sourceforge.net/projects/libexif/"
     sourceforge_mirror_path = "libexif/libexif-0.6.21.tar.bz2"
 
     maintainers("TheQueasle")

--- a/var/spack/repos/builtin/packages/poamsa/package.py
+++ b/var/spack/repos/builtin/packages/poamsa/package.py
@@ -12,7 +12,7 @@ class Poamsa(MakefilePackage):
     sensitivity, and the superior ability to handle branching / indels
     in the alignment."""
 
-    homepage = "https://sourceforge.net/projects/poamsa"
+    homepage = "https://sourceforge.net/projects/poamsa/"
     url = "https://downloads.sourceforge.net/project/poamsa/poamsa/2.0/poaV2.tar.gz"
 
     version("2.0", sha256="d98d8251af558f442d909a6527694825ef6f79881b7636cad4925792559092c2")

--- a/var/spack/repos/builtin/packages/procps-ng/package.py
+++ b/var/spack/repos/builtin/packages/procps-ng/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class ProcpsNg(AutotoolsPackage):
     """Utilities that provide system information."""
 
-    homepage = "https://sourceforge.net/projects/procps-ng"
+    homepage = "https://sourceforge.net/projects/procps-ng/"
     url = "https://udomain.dl.sourceforge.net/project/procps-ng/Production/procps-ng-3.3.16.tar.xz"
 
     license("GPL-2.0-or-later AND LGPL-2.1-or-later", checked_by="tgamblin")

--- a/var/spack/repos/builtin/packages/pwgen/package.py
+++ b/var/spack/repos/builtin/packages/pwgen/package.py
@@ -10,7 +10,7 @@ class Pwgen(AutotoolsPackage):
     """Pwgen is a small, GPL'ed password generator which creates passwords
     which can be easily memorized by a human."""
 
-    homepage = "https://sourceforge.net/projects/pwgen"
+    homepage = "https://sourceforge.net/projects/pwgen/"
     url = "https://downloads.sourceforge.net/project/pwgen/pwgen/2.08/pwgen-2.08.tar.gz"
 
     maintainers("cessenat")

--- a/var/spack/repos/builtin/packages/py-pyke/package.py
+++ b/var/spack/repos/builtin/packages/py-pyke/package.py
@@ -12,7 +12,7 @@ class PyPyke(PythonPackage):
     engine (expert system) written in 100% Python.
     """
 
-    homepage = "https://sourceforge.net/projects/pyke"
+    homepage = "https://sourceforge.net/projects/pyke/"
     url = "https://sourceforge.net/projects/pyke/files/pyke/1.1.1/pyke-1.1.1.zip"
 
     license("MIT")

--- a/var/spack/repos/builtin/packages/quota/package.py
+++ b/var/spack/repos/builtin/packages/quota/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class Quota(AutotoolsPackage):
     """Linux Diskquota system as part of the Linux kernel."""
 
-    homepage = "https://sourceforge.net/projects/linuxquota"
+    homepage = "https://sourceforge.net/projects/linuxquota/"
     url = (
         "https://udomain.dl.sourceforge.net/project/linuxquota/quota-tools/4.05/quota-4.05.tar.gz"
     )

--- a/var/spack/repos/builtin/packages/sblim-sfcc/package.py
+++ b/var/spack/repos/builtin/packages/sblim-sfcc/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class SblimSfcc(AutotoolsPackage):
     """Small Footprint CIM Client Library"""
 
-    homepage = "https://sourceforge.net/projects/sblim"
+    homepage = "https://sourceforge.net/projects/sblim/"
     url = "https://github.com/kkaempf/sblim-sfcc/archive/SFCC_2_2_1.tar.gz"
 
     license("EPL-1.0")


### PR DESCRIPTION
Packages with a homepage on sourceforge trigger a javascript redirect to the project page with trailing slash. This PR makes that change wherever needed.

(Just another housekeeping thing flagged at https://repology.org/repository/spack/problems)