### PR TITLE
py-lxml: add v5.2.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-lxml/package.py
+++ b/var/spack/repos/builtin/packages/py-lxml/package.py
@@ -45,4 +45,7 @@ class PyLxml(PythonPackage):
     depends_on("py-html5lib", when="+html5", type=("build", "run"))
     depends_on("py-beautifulsoup4", when="+htmlsoup", type=("build", "run"))
     depends_on("py-cssselect@0.7:", when="+cssselect", type=("build", "run"))
-    depends_on("py-cython@3.0.10:", type="build", when="@5.2.2:")
+    depends_on("py-cython@3.0.10:", type="build", when="@5.2:")
+    depends_on("py-cython@3.0.9:", type="build", when="@5.1.1:")
+    depends_on("py-cython@3.0.8:", type="build", when="@5:")
+    depends_on("py-cython@0.29.7:", type="build")

--- a/var/spack/repos/builtin/packages/py-lxml/package.py
+++ b/var/spack/repos/builtin/packages/py-lxml/package.py
@@ -16,6 +16,7 @@ class PyLxml(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("5.2.2", sha256="bb2dc4898180bea79863d5487e5f9c7c34297414bad54bcd0f0852aee9cfdb87")
     version("4.9.2", sha256="2455cfaeb7ac70338b3257f41e21f0724f4b5b0c0e7702da67ee6c3640835b67")
     version("4.9.1", sha256="fe749b052bb7233fe5d072fcb549221a8cb1a16725c47c37e42b0b9cb3ff2c3f")
     version("4.9.0", sha256="520461c36727268a989790aef08884347cd41f2d8ae855489ccf40b50321d8d7")
@@ -44,3 +45,4 @@ class PyLxml(PythonPackage):
     depends_on("py-html5lib", when="+html5", type=("build", "run"))
     depends_on("py-beautifulsoup4", when="+htmlsoup", type=("build", "run"))
     depends_on("py-cssselect@0.7:", when="+cssselect", type=("build", "run"))
+    depends_on("py-cython@3.0.10:", type="build", when="@5.2.2:")


### PR DESCRIPTION
Minimal change to add a recent version of py-lxml and one that also works (indirectly) with modern strict compilers such as gcc14. The newest lxml version 5.3.0 appears to need cython 3.0.11, which is not yet available in spack.
