### PR TITLE
Apply long path prefix to windows paths in remove_linked_tree

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1624,6 +1624,10 @@ def remove_linked_tree(path):
             shutil.rmtree(os.path.realpath(path), **kwargs)
             os.unlink(path)
         else:
+            if sys.platform == "win32":
+                # Adds support for removing long paths on windows
+                # https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
+                path = "\\\\?\\" + path
             shutil.rmtree(path, **kwargs)
 
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1625,9 +1625,11 @@ def remove_linked_tree(path):
             os.unlink(path)
         else:
             if sys.platform == "win32":
-                # Adds support for removing long paths on windows
+                # Adding this prefix allows shutil to remove long paths on windows
                 # https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
-                path = "\\\\?\\" + path
+                long_path_pfx = "\\\\?\\"
+                if not path.startswith(long_path_pfx):
+                    path = long_path_pfx + path
             shutil.rmtree(path, **kwargs)
 
 


### PR DESCRIPTION
This fixes the issue with the boost staging area not getting fully cleaned up after running `spack clean -s boost` .

The issue came from some really long path names in the boost source code that were longer than the default 260 character limit on Windows.


