### PR TITLE
xorg-server: add variants dri and glx

### DIFF
--- a/var/spack/repos/builtin/packages/xorg-server/package.py
+++ b/var/spack/repos/builtin/packages/xorg-server/package.py
@@ -16,6 +16,9 @@ class XorgServer(AutotoolsPackage, XorgPackage):
     license("MIT")
 
     version(
+        "1.18.99.902", sha256="fe5a312f7bdc6762c97f01b7a1d3c7a8691997255be6fbf7598c180abf384ea3"
+    )
+    version(
         "1.18.99.901", sha256="c8425163b588de2ee7e5c8e65b0749f2710f55a7e02a8d1dc83b3630868ceb21"
     )
 

--- a/var/spack/repos/builtin/packages/xorg-server/package.py
+++ b/var/spack/repos/builtin/packages/xorg-server/package.py
@@ -41,7 +41,7 @@ class XorgServer(AutotoolsPackage, XorgPackage):
     depends_on("pixman@0.27.2:")
     depends_on("font-util")
     depends_on("libxshmfence@1.1:")
-    depends_on("libdrm@2.3.0:")
+    depends_on("libdrm@2.3.0:", when="+dri")
     depends_on("libx11")
 
     depends_on("gl", when="+dri")

--- a/var/spack/repos/builtin/packages/xorg-server/package.py
+++ b/var/spack/repos/builtin/packages/xorg-server/package.py
@@ -103,7 +103,7 @@ class XorgServer(AutotoolsPackage, XorgPackage):
             args.append("--disable-glx")
 
         if self.spec.satisfies("+dri"):
-            args.append("--enable-dri")
+            args.append("--disable-dri")  # dri requires libdri, not libdrm
             args.append("--enable-dri2")
             args.append("--enable-dri3")
             args.append("--enable-drm")

--- a/var/spack/repos/builtin/packages/xorg-server/package.py
+++ b/var/spack/repos/builtin/packages/xorg-server/package.py
@@ -75,7 +75,6 @@ class XorgServer(AutotoolsPackage, XorgPackage):
     depends_on("recordproto@1.13.99.1:", type="build")
     depends_on("scrnsaverproto@1.1:", type="build")
     depends_on("resourceproto@1.2.0:", type="build")
-    depends_on("glproto@1.4.17:", type="build")
     depends_on("presentproto@1.0:", type="build")
     depends_on("xineramaproto", type="build")
     depends_on("libxkbfile")
@@ -84,6 +83,7 @@ class XorgServer(AutotoolsPackage, XorgPackage):
     depends_on("libxdamage")
     depends_on("libxfixes")
     depends_on("libepoxy")
+    depends_on("libpciaccess")
 
     @when("@:1.19")
     def setup_build_environment(self, env):
@@ -106,10 +106,12 @@ class XorgServer(AutotoolsPackage, XorgPackage):
             args.append("--enable-dri")
             args.append("--enable-dri2")
             args.append("--enable-dri3")
+            args.append("--enable-drm")
         else:
             args.append("--disable-dri")
             args.append("--disable-dri2")
             args.append("--disable-dri3")
+            args.append("--disable-drm")
 
         if self.spec.satisfies("^[virtuals=gl] osmesa"):
             args.append("--enable-glx")
@@ -118,7 +120,6 @@ class XorgServer(AutotoolsPackage, XorgPackage):
 
         args.extend(
             [
-                "--disable-dri",  # dri >= 7.8.0
                 "--disable-glamor",  # Glamor for Xorg requires gbm >= 10.2.0
             ]
         )

--- a/var/spack/repos/builtin/packages/xorg-server/package.py
+++ b/var/spack/repos/builtin/packages/xorg-server/package.py
@@ -101,7 +101,7 @@ class XorgServer(AutotoolsPackage, XorgPackage):
             args.append("--enable-glx")
         else:
             args.append("--disable-glx")
-            
+
         if self.spec.satisfies("+dri"):
             args.append("--enable-dri")
             args.append("--enable-dri2")
@@ -118,10 +118,6 @@ class XorgServer(AutotoolsPackage, XorgPackage):
         else:
             args.append("--disable-glx")
 
-        args.extend(
-            [
-                "--disable-glamor",  # Glamor for Xorg requires gbm >= 10.2.0
-            ]
-        )
+        args.extend(["--disable-glamor"])  # Glamor for Xorg requires gbm >= 10.2.0
 
         return args


### PR DESCRIPTION
Per user request on slack, who wanted a way to install Xvfb without dri or glx, this PR adds two variants to turn off dri and glx.

Test build of `xorg-server ~dri ~glx`:
```
==> Installing xorg-server-1.18.99.902-olkmhceibclbfgnxons7vd3h32o3bcyn [76/76]
==> No binary for xorg-server-1.18.99.902-olkmhceibclbfgnxons7vd3h32o3bcyn found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/fe/fe5a312f7bdc6762c97f01b7a1d3c7a8691997255be6fbf7598c180abf384ea3.tar.gz
==> Applied patch /home/wdconinc/git/spack/var/spack/repos/builtin/packages/xorg-server/sysmacros.patch
==> Ran patch() for xorg-server
==> xorg-server: Executing phase: 'autoreconf'
==> xorg-server: Executing phase: 'configure'
==> xorg-server: Executing phase: 'build'
==> xorg-server: Executing phase: 'install'
==> xorg-server: Successfully installed xorg-server-1.18.99.902-olkmhceibclbfgnxons7vd3h32o3bcyn
  Stage: 0.17s.  Autoreconf: 0.00s.  Configure: 12.97s.  Build: 52.33s.  Install: 1.79s.  Post-install: 0.32s.  Total: 1m 7.80s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/xorg-server-1.18.99.902-olkmhceibclbfgnxons7vd3h32o3bcyn
```