### PR TITLE
Add conflict between llvm-amdgpu until version 5 and ninja since version 1.12.0

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -102,6 +102,9 @@ class LlvmAmdgpu(CMakePackage, CompilerPackage):
 
     conflicts("^cmake@3.19.0")
 
+    # https://github.com/spack/spack/issues/45746
+    conflicts("^ninja@1.12:", when="@:5")
+
     root_cmakelists_dir = "llvm"
     install_targets = ["clang-tidy", "install"]
 

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -103,7 +103,7 @@ class LlvmAmdgpu(CMakePackage, CompilerPackage):
     conflicts("^cmake@3.19.0")
 
     # https://github.com/spack/spack/issues/45746
-    conflicts("^ninja@1.12:", when="@:5")
+    conflicts("^ninja@1.12:", when="@:6.0")
 
     root_cmakelists_dir = "llvm"
     install_targets = ["clang-tidy", "install"]


### PR DESCRIPTION
Fixes #45746. Without any further investigation of the root cause of the issue I'm proposing a conflict to fix the linked issue. Since it seems like llvm-amdgpu@6 already builds correctly with the newer ninja I'm not going to investigate further. To summarize, the versions I tried building were:
- llvm-amdgpu@5.5.1 and ninja@1.11.1: success
- llvm-amdgpu@5.5.1 and ninja@1.12.0: fail
- llvm-amdgpu@5.5.1 and ninja@1.12.1: fail
- llvm-amdgpu@5.7.1 and ninja@1.12.0: fail
- llvm-amdgpu@6.1.0 and ninja@1.12.1: success

Edit: tested by @srekolam
- llvm-amdgpu@6.0.2 and ninja@1.12: fail

Based on this I'm capping the conflict to only apply up to and including ~llvm-amdgpu@5~ llvm-amdgpu@6.1.