### PR TITLE
Run unit test in parallel again in CI

### DIFF
--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -47,7 +47,7 @@ $coverage_run $(which spack) python -c "import spack.pkg.builtin.mpileaks; repr(
 # Run unit tests with code coverage
 #-----------------------------------------------------------
 # Check if xdist is available
-if python -m pytest --trace-config 2>&1 | grep xdist; then
+if python -m pytest -VV 2>&1 | grep xdist; then
   export PYTEST_ADDOPTS="$PYTEST_ADDOPTS --dist loadfile --tx '${SPACK_TEST_PARALLEL:=3}*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python'"
 fi
 


### PR DESCRIPTION
The --trace-config option was failing for linux unit-tests (cannot import `archspec`), so we were running serial.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
