### PR TITLE
[WIP] trigger py-torchaudio build

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchaudio/package.py
+++ b/var/spack/repos/builtin/packages/py-torchaudio/package.py
@@ -52,6 +52,8 @@ class PyTorchaudio(PythonPackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
+    variant("noop", default=False, description="This variant is for triggering a rebuild")
+
     with default_args(type=("build", "link", "run")):
         # Based on PyPI wheel availability
         depends_on("python@3.8:3.12", when="@2.2:")


### PR DESCRIPTION
I'm seeing a CI failure in https://github.com/spack/spack/pull/45427 related to `py-torchaudio` that seems repeatable (even after the branch was synced with develop yesterday). I suspect a different PR was merged that broke `py-torchaudio`, so I opened this PR to force a CI rebuild of it.

If the CI build fails, then some change to `python`/`py-torchaudio`/other in develop is to blame.
