### PR TITLE
llvm based compilers: filter more executables in detection

### DIFF
--- a/var/spack/repos/builtin/packages/aocc/package.py
+++ b/var/spack/repos/builtin/packages/aocc/package.py
@@ -6,10 +6,10 @@
 from llnl.util import tty
 
 from spack.package import *
-from spack.pkg.builtin.llvm import LlvmBasedCompiler
+from spack.pkg.builtin.llvm import LlvmDetection
 
 
-class Aocc(Package, LlvmBasedCompiler):
+class Aocc(Package, LlvmDetection, CompilerPackage):
     """
     The AOCC compiler system is a high performance, production quality code
     generation tool.  The AOCC environment provides various options to developers

--- a/var/spack/repos/builtin/packages/aocc/package.py
+++ b/var/spack/repos/builtin/packages/aocc/package.py
@@ -6,9 +6,10 @@
 from llnl.util import tty
 
 from spack.package import *
+from spack.pkg.builtin.llvm import LlvmBasedCompiler
 
 
-class Aocc(Package, CompilerPackage):
+class Aocc(Package, LlvmBasedCompiler):
     """
     The AOCC compiler system is a high performance, production quality code
     generation tool.  The AOCC environment provides various options to developers
@@ -107,8 +108,5 @@ class Aocc(Package, CompilerPackage):
                 with open(join_path(self.prefix.bin, "{}.cfg".format(compiler)), "w") as f:
                     f.write(compiler_options)
 
-    compiler_version_argument = "--version"
     compiler_version_regex = r"AOCC_(\d+[._]\d+[._]\d+)"
-    c_names = ["clang"]
-    cxx_names = ["clang++"]
     fortran_names = ["flang"]

--- a/var/spack/repos/builtin/packages/apple-clang/package.py
+++ b/var/spack/repos/builtin/packages/apple-clang/package.py
@@ -3,10 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack.package import *
-from spack.pkg.builtin.llvm import LlvmBasedCompiler
+from spack.pkg.builtin.llvm import LlvmDetection
 
 
-class AppleClang(BundlePackage, LlvmBasedCompiler):
+class AppleClang(BundlePackage, LlvmDetection, CompilerPackage):
     """Apple's Clang compiler"""
 
     homepage = "https://developer.apple.com/videos/developer-tools/compiler-and-llvm"

--- a/var/spack/repos/builtin/packages/apple-clang/package.py
+++ b/var/spack/repos/builtin/packages/apple-clang/package.py
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack.package import *
+from spack.pkg.builtin.llvm import LlvmBasedCompiler
 
 
-class AppleClang(BundlePackage, CompilerPackage):
+class AppleClang(BundlePackage, LlvmBasedCompiler):
     """Apple's Clang compiler"""
 
     homepage = "https://developer.apple.com/videos/developer-tools/compiler-and-llvm"

--- a/var/spack/repos/builtin/packages/apple-clang/package.py
+++ b/var/spack/repos/builtin/packages/apple-clang/package.py
@@ -15,11 +15,7 @@ class AppleClang(BundlePackage, LlvmDetection, CompilerPackage):
     maintainers("alalazo")
 
     compiler_languages = ["c", "cxx"]
-    c_names = ["clang"]
-    cxx_names = ["clang++"]
-
     compiler_version_regex = r"^Apple (?:LLVM|clang) version ([^ )]+)"
-    compiler_version_argument = "--version"
 
     @classmethod
     def validate_detected_spec(cls, spec, extra_attributes):

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -13,9 +13,10 @@ from llnl.util.lang import classproperty
 import spack.build_environment
 import spack.util.executable
 from spack.package import *
+from spack.package_base import PackageBase
 
 
-class LlvmBasedCompiler(CompilerPackage):
+class LlvmDetection(PackageBase):
     """Base class to detect LLVM based compilers"""
 
     compiler_version_argument = "--version"
@@ -34,7 +35,7 @@ class LlvmBasedCompiler(CompilerPackage):
         return [x for x in exes_in_prefix if not reject.search(x)]
 
 
-class Llvm(CMakePackage, CudaPackage, LlvmBasedCompiler):
+class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
     """The LLVM Project is a collection of modular and reusable compiler and
     toolchain technologies. Despite its name, LLVM has little to do
     with traditional virtual machines, though it does provide helpful

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -636,16 +636,14 @@ class Llvm(CMakePackage, CudaPackage, CompilerPackage):
 
     @classmethod
     def filter_detected_exes(cls, prefix, exes_in_prefix):
-        result = []
-        for exe in exes_in_prefix:
-            # Executables like lldb-vscode-X are daemon listening
-            # on some port and would hang Spack during detection.
-            # clang-cl and clang-cpp are dev tools that we don't
-            # need to test
-            if any(x in exe for x in ("vscode", "cpp", "-cl", "-gpu")):
-                continue
-            result.append(exe)
-        return result
+        # Executables like lldb-vscode-X are daemon listening on some port and would hang Spack
+        # during detection. clang-cl, clang-cpp, etc. are dev tools that we don't need to test
+        reject = re.compile(
+            r"-(vscode|cpp|cl|gpu|tidy|rename|scan-deps|format|refactor|offload|"
+            r"check|query|doc|move|extdef|apply|reorder|change-namespace|"
+            r"include-fixer|import-test)"
+        )
+        return [x for x in exes_in_prefix if not reject.search(x)]
 
     @classmethod
     def determine_version(cls, exe):


### PR DESCRIPTION
Extracted from #45784
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
