### PR TITLE
gcc: improve detection

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/gcc/detection_test.yaml
@@ -52,27 +52,6 @@ paths:
         cxx: ".*/bin/g[+][+]-5$"
         fortran: ".*/bin/gfortran-5$"
 
-# Multiple compilers present at the same time
-- layout:
-  - executables:
-    - "bin/x86_64-linux-gnu-gcc-6"
-    script: 'echo 6.5.0'
-  - executables:
-    - "bin/x86_64-linux-gnu-gcc-10"
-    - "bin/x86_64-linux-gnu-g++-10"
-    script: "echo 10.1.0"
-  platforms: [linux]
-  results:
-  - spec: "gcc@6.5.0 languages=c"
-    extra_attributes:
-      compilers:
-        c: ".*/bin/x86_64-linux-gnu-gcc-6$"
-  - spec: "gcc@10.1.0 languages=c,c++"
-    extra_attributes:
-      compilers:
-        c: ".*/bin/x86_64-linux-gnu-gcc-10$"
-        cxx: ".*/bin/x86_64-linux-gnu-g[+][+]-10$"
-
 # Apple clang under disguise as gcc should not be detected
 - layout:
   - executables:

--- a/var/spack/repos/builtin/packages/gcc/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/gcc/detection_test.yaml
@@ -94,3 +94,25 @@ paths:
       fi
   platforms: ["darwin"]
   results: []
+
+# Mingw cross compiler on linux should not be detected
+- layout:
+  - executables:
+    - "bin/i686-w64-mingw32-gcc"
+    script: |
+      if [ "$1" = "-dumpversion" ] ; then
+        echo "9.3-win32"
+      elif [ "$1" = "-dumpfullversion" ] ; then
+        echo "9.3-win32" >&2
+        exit 1
+      elif [ "$1" = "--version" ] ; then
+        echo "i686-w64-mingw32-gcc (GCC) 9.3-win32 20200320"
+        echo "Copyright (C) 2019 Free Software Foundation, Inc."
+        echo "This is free software; see the source for copying conditions.  There is NO"
+        echo "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
+      else
+        echo "mock executable got an unexpected flag: $1"
+        exit 1
+      fi
+  platforms: [linux]
+  results: []

--- a/var/spack/repos/builtin/packages/gcc/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/gcc/detection_test.yaml
@@ -61,7 +61,7 @@ paths:
     - "bin/x86_64-linux-gnu-gcc-10"
     - "bin/x86_64-linux-gnu-g++-10"
     script: "echo 10.1.0"
-  platforms: [darwin, linux]
+  platforms: [linux]
   results:
   - spec: "gcc@6.5.0 languages=c"
     extra_attributes:

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -10,7 +10,6 @@ import sys
 import archspec.cpu
 
 import llnl.util.tty as tty
-from llnl.util.lang import classproperty
 from llnl.util.symlink import readlink
 
 import spack.platforms

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -540,14 +540,6 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     compiler_version_regex = r"(?<!clang version)\s?([0-9.]+)"
     compiler_version_argument = ("-dumpfullversion", "-dumpversion")
 
-    @classproperty
-    def compiler_prefixes(cls):
-        host = spack.platforms.host()
-        if str(host) == "linux":
-            target = archspec.cpu.host().family
-            return [rf"{target}-{host}-\w+-"]
-        return []
-
     @classmethod
     def filter_detected_exes(cls, prefix, exes_in_prefix):
         # Apple's gcc is actually apple clang, so skip it.


### PR DESCRIPTION
Modifications:
- [x] Do not detect mingw cross-compilers on Ubuntu.
- [x] Avoid calling --version on all executables, if not on darwin.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
