### PR TITLE
highway: remove HWY_CMAKE_ARM7 option

### DIFF
--- a/var/spack/repos/builtin/packages/highway/package.py
+++ b/var/spack/repos/builtin/packages/highway/package.py
@@ -36,7 +36,6 @@ class Highway(CMakePackage):
     depends_on("googletest", type="test")
 
     def cmake_args(self):
-        spec = self.spec
         define = self.define
         from_variant = self.define_from_variant
 
@@ -46,9 +45,6 @@ class Highway(CMakePackage):
             define("HWY_ENABLE_TESTS", self.run_tests),
             define("BUILD_TESTING", self.run_tests),
             define("HWY_SYSTEM_GTEST", self.run_tests),
-            define(
-                "HWY_CMAKE_ARM7", spec.satisfies("%gcc@:6.1.0") or spec.satisfies("%clang@:16")
-            ),
         ]
 
         return args


### PR DESCRIPTION
Spack currently does not detect armv7 architectures so remove this option.

Edit: Also I should have not addded this option in the first place without an arch check.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
