### PR TITLE
Bugfix/hsakmt-roct@6.1.2: use correct version for rocm-core and llvm-amdgpu

### DIFF
--- a/var/spack/repos/builtin/packages/hsakmt-roct/package.py
+++ b/var/spack/repos/builtin/packages/hsakmt-roct/package.py
@@ -64,7 +64,7 @@ class HsakmtRoct(CMakePackage):
         "6.0.2",
         "6.1.0",
         "6.1.1",
-        "6.1.0",
+        "6.1.2",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@{ver}")
         depends_on(f"llvm-amdgpu@{ver}", type="test", when=f"@{ver}")


### PR DESCRIPTION
Ensure using the corresponding version for the `rocm-core` and `llvm-amdgpu` dependencies.

Looks like I missed this line when I reviewed #44849 .  Without the fix, version `6.1.0` is listed twice in the `for` loop for these dependencies while `6.1.2` not at all.