### PR TITLE
Increase min version for sparse_checkout

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -930,7 +930,9 @@ class GitFetchStrategy(VCSFetchStrategy):
         dest = self.stage.source_path
         git = self.git
 
-        if self.git_version < spack.version.Version("2.25.0.0"):
+        if self.git_version < spack.version.Version("2.26.0"):
+            # technically this should be supported for 2.25, but bumping for OS issues 
+            # see https://github.com/spack/spack/issues/45771
             # code paths exist where the package is not set.  Assure some indentifier for the
             # package that was configured  for sparse checkout exists in the error message
             identifier = str(self.url)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -931,7 +931,7 @@ class GitFetchStrategy(VCSFetchStrategy):
         git = self.git
 
         if self.git_version < spack.version.Version("2.26.0"):
-            # technically this should be supported for 2.25, but bumping for OS issues 
+            # technically this should be supported for 2.25, but bumping for OS issues
             # see https://github.com/spack/spack/issues/45771
             # code paths exist where the package is not set.  Assure some indentifier for the
             # package that was configured  for sparse checkout exists in the error message

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -415,7 +415,7 @@ def test_git_sparse_paths_partial_clone(
         for p in sparse_paths:
             assert os.path.isdir(p)
 
-        if git_version < Version("2.25.0.0"):
+        if git_version < Version("2.26.0.0"):
             # older versions of git should fall back to a full clone
             for p in omitted_paths:
                 assert os.path.isdir(p)


### PR DESCRIPTION
Closes #45771 by updating sparse checkout to require `git@2.26` as a min version
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
