### PR TITLE
spack bootstrap status --dev: function call for new interface

### DIFF
--- a/lib/spack/spack/bootstrap/status.py
+++ b/lib/spack/spack/bootstrap/status.py
@@ -124,7 +124,7 @@ def _development_requirements() -> List[RequiredResponseType]:
     # Ensure we trigger environment modifications if we have an environment
     if BootstrapEnvironment.spack_yaml().exists():
         with BootstrapEnvironment() as env:
-            env.update_syspath_and_environ()
+            env.load()
 
     return [
         _required_executable(


### PR DESCRIPTION
Since the method was renamed in `lib/spack/spack/bootstrap/environment.py` this has been broken. Just discovered now.
