### PR TITLE
orca: add avx2-6.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/orca/package.py
+++ b/var/spack/repos/builtin/packages/orca/package.py
@@ -23,6 +23,9 @@ class Orca(Package):
 
     license("LGPL-2.1-or-later")
 
+    version(
+        "avx2-6.0.0", sha256="02c21294efe7b1b721e26cb90f98ee15ad682d02807201b7d217dfe67905a2fd"
+    )
     version("6.0.0", sha256="219bd1deb6d64a63cb72471926cb81665cbbcdec19f9c9549761be67d49a29c6")
     version("5.0.4", sha256="c4ea5aea60da7bcb18a6b7042609206fbeb2a765c6fa958c5689d450b588b036")
     version("5.0.3", sha256="b8b9076d1711150a6d6cb3eb30b18e2782fa847c5a86d8404b9339faef105043")
@@ -40,6 +43,7 @@ class Orca(Package):
         "5.0.3": "4.1.2",
         "5.0.4": "4.1.2",
         "6.0.0": "4.1.6",
+        "avx2-6.0.0": "4.1.6",
     }
     for orca_version, openmpi_version in openmpi_versions.items():
         depends_on(
@@ -47,10 +51,14 @@ class Orca(Package):
         )
 
     def url_for_version(self, version):
-        openmpi_version = self.openmpi_versions[str(version.dotted)].replace(".", "")
+        openmpi_version = self.openmpi_versions[version.string].replace(".", "")
         if openmpi_version == "412":
             openmpi_version = "411"
-        return f"file://{os.getcwd()}/orca_{version.underscored}_linux_x86-64_shared_openmpi{openmpi_version}.tar.xz"
+        ver_parts = version.string.split("-")
+        ver_underscored = ver_parts[-1].replace(".", "_")
+        features = ver_parts[:-1] + ["shared"]
+        feature_text = "_".join(features)
+        return f"file://{os.getcwd()}/orca_{ver_underscored}_linux_x86-64_{feature_text}_openmpi{openmpi_version}.tar.xz"
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)


### PR DESCRIPTION
The avx2 version can be downloaded from the ORCA [forum](https://orcaforum.kofo.mpg.de/app.php/dlext/?view=detail&df_id=214#).

The version is named `avx2-6.0.0` (as opposed to the more natural-looking `6.0.0-avx2`) to avoid the avx2 version shadowing the non-avx2 one. Definitely open for better suggestion.

Samle installation session:

```sh
$ sha256sum orca_6_0_0_linux_x86-64_avx2_shared_openmpi416.tar.xz
02c21294efe7b1b721e26cb90f98ee15ad682d02807201b7d217dfe67905a2fd  orca_6_0_0_linux_x86-64_avx2_shared_openmpi416.tar.xz

$ spack install orca@avx2-6.0.0
...
==> Installing orca-avx2-6.0.0-hjznfadyenbmkqw75tckvifs3jbrjiul [24/24]
==> No binary for orca-avx2-6.0.0-hjznfadyenbmkqw75tckvifs3jbrjiul found: installing from source
==> Fetching file:///usr/local/google/home/linsword/contrib/orca_6_0_0_linux_x86-64_avx2_shared_openmpi416.tar.xz
==> No patches needed for orca
==> orca: Executing phase: 'install'
==> orca: Successfully installed orca-avx2-6.0.0-hjznfadyenbmkqw75tckvifs3jbrjiul

$ spack install orca@6.0.0
...
==> Installing orca-6.0.0-6y7wevwuq4ufhod76gk6aqticewbanqf [24/24]
==> No binary for orca-6.0.0-6y7wevwuq4ufhod76gk6aqticewbanqf found: installing from source
==> Fetching file:///usr/local/google/home/linsword/contrib/orca_6_0_0_linux_x86-64_shared_openmpi416.tar.xz
==> No patches needed for orca
==> orca: Executing phase: 'install'
==> orca: Successfully installed orca-6.0.0-6y7wevwuq4ufhod76gk6aqticewbanqf

$ spack find orca
-- linux-debiann-zen2 / gcc@13.2.0 ------------------------------
orca@avx2-6.0.0  orca@6.0.0
==> 2 installed packages
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
