### PR TITLE
Namd variant update

### DIFF
--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -112,6 +112,11 @@ class Namd(MakefilePackage, CudaPackage, ROCmPackage):
     conflicts("+single_node_gpu", when="~cuda~rocm")
     conflicts("+avxtiles", when="@:2.14", msg="AVXTiles algorithm requires NAMD 2.15+")
     conflicts("+memopt", when="@:2.8", msg="memopt mode requires NAMD 2.8+")
+    conflicts(
+        "+memopt",
+        when="+single_node_gpu",
+        msg="memopt mode is not compatible with GPU-resident builds",
+    )
 
     # https://www.ks.uiuc.edu/Research/namd/2.12/features.html
     # https://www.ks.uiuc.edu/Research/namd/2.13/features.html

--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -75,13 +75,23 @@ class Namd(MakefilePackage, CudaPackage, ROCmPackage):
         description="Enables Tcl and/or python interface",
     )
 
-    variant("avxtiles", when="target=x86_64_v4:", default=False, description="Enable avxtiles")
+    variant(
+        "avxtiles",
+        when="target=x86_64_v4: @2.15:",
+        default=False,
+        description="Enable avxtiles supported with NAMD 2.15+",
+    )
     variant("single_node_gpu", default=False, description="Single node GPU")
 
     # Adding memopt variant to build memory-optimized mode that utilizes a compressed
     # version of the molecular structure and also supports parallel I/O.
     # Refer: https://www.ks.uiuc.edu/Research/namd/wiki/index.cgi?NamdMemoryReduction
-    variant("memopt", default=False, description="Enable memory-optimized build")
+    variant(
+        "memopt",
+        when="@2.8:",
+        default=False,
+        description="Enable memory-optimized build supported with NAMD 2.8+",
+    )
 
     # init_tcl_pointers() declaration and implementation are inconsistent
     # "src/colvarproxy_namd.C", line 482: error: inherited member is not
@@ -110,8 +120,6 @@ class Namd(MakefilePackage, CudaPackage, ROCmPackage):
 
     conflicts("+rocm", when="+cuda", msg="NAMD supports only one GPU backend at a time")
     conflicts("+single_node_gpu", when="~cuda~rocm")
-    conflicts("+avxtiles", when="@:2.14", msg="AVXTiles algorithm requires NAMD 2.15+")
-    conflicts("+memopt", when="@:2.8", msg="memopt mode requires NAMD 2.8+")
     conflicts(
         "+memopt",
         when="+single_node_gpu",
@@ -315,7 +323,7 @@ class Namd(MakefilePackage, CudaPackage, ROCmPackage):
             if "+single_node_gpu" in spec:
                 opts.extend(["--with-single-node-hip"])
 
-        if "+memopt" in spec:
+        if spec.satisfies("+memopt"):
             opts.append("--with-memopt")
 
         config = Executable("./config")

--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -103,9 +103,10 @@ class Namd(MakefilePackage, CudaPackage, ROCmPackage):
     depends_on("tcl", when="interface=python")
     depends_on("python", when="interface=python")
 
-    conflicts("+avxtiles", when="@:2.14,3:", msg="AVXTiles algorithm requires NAMD 2.15")
     conflicts("+rocm", when="+cuda", msg="NAMD supports only one GPU backend at a time")
     conflicts("+single_node_gpu", when="~cuda~rocm")
+    conflicts("+avxtiles", when="@:2.14", msg="AVXTiles algorithm requires NAMD 2.15+")
+    conflicts("+memopt", when="@:2.8", msg="memopt mode requires NAMD 2.8+")
 
     # https://www.ks.uiuc.edu/Research/namd/2.12/features.html
     # https://www.ks.uiuc.edu/Research/namd/2.13/features.html

--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -78,6 +78,11 @@ class Namd(MakefilePackage, CudaPackage, ROCmPackage):
     variant("avxtiles", when="target=x86_64_v4:", default=False, description="Enable avxtiles")
     variant("single_node_gpu", default=False, description="Single node GPU")
 
+    # Adding memopt variant to build memory-optimized mode that utilizes a compressed
+    # version of the molecular structure and also supports parallel I/O.
+    # Refer: https://www.ks.uiuc.edu/Research/namd/wiki/index.cgi?NamdMemoryReduction
+    variant("memopt", default=False, description="Enable memory-optimized build")
+
     # init_tcl_pointers() declaration and implementation are inconsistent
     # "src/colvarproxy_namd.C", line 482: error: inherited member is not
     # allowed
@@ -106,7 +111,7 @@ class Namd(MakefilePackage, CudaPackage, ROCmPackage):
     conflicts("+rocm", when="+cuda", msg="NAMD supports only one GPU backend at a time")
     conflicts("+single_node_gpu", when="~cuda~rocm")
     conflicts("+avxtiles", when="@:2.14", msg="AVXTiles algorithm requires NAMD 2.15+")
-    conflicts("+memopt", when="@:2.8", msg="NAMD 2.8+ supports memopt mode")
+    conflicts("+memopt", when="@:2.8", msg="memopt mode requires NAMD 2.8+")
 
     # https://www.ks.uiuc.edu/Research/namd/2.12/features.html
     # https://www.ks.uiuc.edu/Research/namd/2.13/features.html
@@ -304,6 +309,9 @@ class Namd(MakefilePackage, CudaPackage, ROCmPackage):
 
             if "+single_node_gpu" in spec:
                 opts.extend(["--with-single-node-hip"])
+
+        if "+memopt" in spec:
+            opts.append("--with-memopt")
 
         config = Executable("./config")
 

--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -106,7 +106,7 @@ class Namd(MakefilePackage, CudaPackage, ROCmPackage):
     conflicts("+rocm", when="+cuda", msg="NAMD supports only one GPU backend at a time")
     conflicts("+single_node_gpu", when="~cuda~rocm")
     conflicts("+avxtiles", when="@:2.14", msg="AVXTiles algorithm requires NAMD 2.15+")
-    conflicts("+memopt", when="@:2.8", msg="memopt mode requires NAMD 2.8+")
+    conflicts("+memopt", when="@:2.8", msg="NAMD 2.8+ supports memopt mode")
 
     # https://www.ks.uiuc.edu/Research/namd/2.12/features.html
     # https://www.ks.uiuc.edu/Research/namd/2.13/features.html


### PR DESCRIPTION
This PR update the NAMD recipe with below changes:

- Add a new variant `memopt` to build NAMD in memory-optimized mode. Refer https://www.ks.uiuc.edu/Research/namd/wiki/index.cgi?NamdMemoryReduction

- Update conflict for `avxtiles` variant, as it is supported in `version 3.x`