### PR TITLE
Using ["hip"].hipcc instead of rocm.

### DIFF
--- a/var/spack/repos/builtin/packages/babelstream/package.py
+++ b/var/spack/repos/builtin/packages/babelstream/package.py
@@ -293,8 +293,10 @@ class Babelstream(CMakePackage, CudaPackage, ROCmPackage):
             args.append("-DCMAKE_CXX_COMPILER=" + hip_comp)
             args.append(
                 "-DCXX_EXTRA_FLAGS= --offload-arch="
-                + self.spec.variants["amdgpu_target"].value
+                + ",".join(self.spec.variants["amdgpu_target"].value)
                 + " "
+                # This evaluate to "none" which is at least very weird, at 
+                # worst, a bug.
                 + self.spec.variants["flags"].value
                 + " -O3"
             )

--- a/var/spack/repos/builtin/packages/babelstream/package.py
+++ b/var/spack/repos/builtin/packages/babelstream/package.py
@@ -296,8 +296,9 @@ class Babelstream(CMakePackage, CudaPackage, ROCmPackage):
                 "-DCXX_EXTRA_FLAGS= --offload-arch="
                 + ",".join(self.spec.variants["amdgpu_target"].value)
                 + " "
-                + extra_flags if extra_flags != "none" else ""
-                + " -O3"
+                + extra_flags
+                if extra_flags != "none"
+                else "" + " -O3"
             )
 
         # ===================================

--- a/var/spack/repos/builtin/packages/babelstream/package.py
+++ b/var/spack/repos/builtin/packages/babelstream/package.py
@@ -289,7 +289,7 @@ class Babelstream(CMakePackage, CudaPackage, ROCmPackage):
         # ===================================
 
         if self.spec.satisfies("+rocm"):
-            hip_comp = self.spec["rocm"].prefix + "/bin/hipcc"
+            hip_comp = self.spec["hip"].hipcc
             args.append("-DCMAKE_CXX_COMPILER=" + hip_comp)
             args.append(
                 "-DCXX_EXTRA_FLAGS= --offload-arch="

--- a/var/spack/repos/builtin/packages/babelstream/package.py
+++ b/var/spack/repos/builtin/packages/babelstream/package.py
@@ -295,9 +295,7 @@ class Babelstream(CMakePackage, CudaPackage, ROCmPackage):
                 "-DCXX_EXTRA_FLAGS= --offload-arch="
                 + ",".join(self.spec.variants["amdgpu_target"].value)
                 + " "
-                # This evaluate to "none" which is at least very weird, at 
-                # worst, a bug.
-                + self.spec.variants["flags"].value
+                + self.spec.variants["flags"].value if self.spec.variants["flags"].value != "none" else ""
                 + " -O3"
             )
 

--- a/var/spack/repos/builtin/packages/babelstream/package.py
+++ b/var/spack/repos/builtin/packages/babelstream/package.py
@@ -291,11 +291,12 @@ class Babelstream(CMakePackage, CudaPackage, ROCmPackage):
         if self.spec.satisfies("+rocm"):
             hip_comp = self.spec["hip"].hipcc
             args.append("-DCMAKE_CXX_COMPILER=" + hip_comp)
+            extra_flags = self.spec.variants["flags"].value
             args.append(
                 "-DCXX_EXTRA_FLAGS= --offload-arch="
                 + ",".join(self.spec.variants["amdgpu_target"].value)
                 + " "
-                + self.spec.variants["flags"].value if self.spec.variants["flags"].value != "none" else ""
+                + extra_flags if extra_flags != "none" else ""
                 + " -O3"
             )
 


### PR DESCRIPTION
Babel stream is the only one using this scheme to get to hipcc.
