### PR TITLE
Disable automatic repo cache updates with an environment variable

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -2559,7 +2559,9 @@ def _concretize_task(packed_arguments) -> Tuple[int, Spec, float]:
 
 def make_repo_path(root):
     """Make a RepoPath from the repo subdirectories in an environment."""
-    path = spack.repo.RepoPath(cache=spack.caches.MISC_CACHE)
+    path = spack.repo.RepoPath(
+        index_factory=spack.repo.IndexFactory(cache=spack.caches.MISC_CACHE)
+    )
 
     if os.path.isdir(root):
         for repo_root in os.listdir(root):

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -92,10 +92,6 @@ class ProviderIndex(_IndexBase):
 
             restrict: "restricts" values to the verbatim input specs; do not
                 pre-apply package's constraints.
-
-        TODO: rename this.  It is intended to keep things as broad
-        TODO: as possible without overly restricting results, so it is
-        TODO: not the best name.
         """
         self.repository = repository
         self.restrict = restrict

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -584,7 +584,8 @@ class RepoIndex:
     defined by ``Indexer``, so that the ``RepoIndex`` can read, generate,
     and update stored indices.
 
-    Generated indexes are accessed by name via ``__getitem__()``."""
+    Generated indexes are accessed by name via ``__getitem__()``.
+    """
 
     def __init__(
         self,
@@ -628,7 +629,8 @@ class RepoIndex:
         because the main bottleneck here is loading all the packages.  It
         can take tens of seconds to regenerate sequentially, and we'd
         rather only pay that cost once rather than on several
-        invocations."""
+        invocations.
+        """
         for name, indexer in self.indexers.items():
             self.indexes[name] = self._build_index(name, indexer)
 
@@ -1230,9 +1232,6 @@ class Repo:
 
     def exists(self, pkg_name: str) -> bool:
         """Whether a package with the supplied name exists."""
-        if pkg_name is None:
-            return False
-
         # if the FastPackageChecker is already constructed, use it
         if self._fast_package_checker:
             return pkg_name in self._pkg_checker

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -668,6 +668,10 @@ class RepoIndex:
 
         return indexer.index
 
+    def all_package_names(self) -> List[str]:
+        """Returns the list of all package names in the repository"""
+        return sorted(self.checker.keys())
+
 
 class RepoPath:
     """A RepoPath is a list of repos that function as one.
@@ -1204,7 +1208,7 @@ class Repo:
 
     def all_package_names(self, include_virtuals: bool = False) -> List[str]:
         """Returns a sorted list of all package names in the Repo."""
-        names = sorted(self._pkg_checker.keys())
+        names = self.index.all_package_names()
         if include_virtuals:
             return names
         return [x for x in names if not self.is_virtual(x)]

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -604,21 +604,15 @@ class RepoIndex(Index):
     Generated indexes are accessed by name via ``__getitem__()``.
     """
 
-    def __init__(
-        self,
-        package_checker: FastPackageChecker,
-        namespace: str,
-        cache: "spack.caches.FileCacheType",
-    ):
-        self.checker = package_checker
-        self.packages_path = self.checker.packages_path
+    def __init__(self, packages_path: str, namespace: str, cache: "spack.caches.FileCacheType"):
+        self.packages_path = packages_path
         if sys.platform == "win32":
             self.packages_path = llnl.path.convert_to_posix_path(self.packages_path)
         self.namespace = namespace
-
         self.indexers: Dict[str, Indexer] = {}
         self.indexes: Dict[str, Any] = {}
         self.cache = cache
+        self.checker = FastPackageChecker(self.packages_path)
 
     def add_indexer(self, name: str, indexer: Indexer):
         """Add an indexer to the repo index.
@@ -703,9 +697,7 @@ class IndexFactory:
         self.cache = cache
 
     def get(self, *, repository: "Repo") -> "Index":
-        result = RepoIndex(
-            FastPackageChecker(repository.packages_path), repository.namespace, cache=self.cache
-        )
+        result = RepoIndex(repository.packages_path, repository.namespace, cache=self.cache)
         result.add_indexer("providers", ProviderIndexer(repository))
         result.add_indexer("tags", TagIndexer(repository))
         result.add_indexer("patches", PatchIndexer(repository))

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -132,8 +132,8 @@ def test_pkg_add(git, mock_pkg_git_repo):
         finally:
             shutil.rmtree("mockpkg-e")
             # Removing a package mid-run disrupts Spack's caching
-            if spack.repo.PATH.repos[0]._fast_package_checker:
-                spack.repo.PATH.repos[0]._fast_package_checker.invalidate()
+            if spack.repo.PATH.repos[0].index.checker:
+                spack.repo.PATH.repos[0].index.checker.invalidate()
 
     with pytest.raises(spack.main.SpackCommandError):
         pkg("add", "does-not-exist")

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -42,7 +42,9 @@ def mock_pkg_git_repo(git, tmp_path_factory):
     shutil.copytree(spack.paths.mock_packages_path, str(repo_dir))
 
     repo_cache = spack.util.file_cache.FileCache(str(root_dir / "cache"))
-    mock_repo = spack.repo.RepoPath(str(repo_dir), cache=repo_cache)
+    mock_repo = spack.repo.RepoPath(
+        str(repo_dir), index_factory=spack.repo.IndexFactory(cache=repo_cache)
+    )
     mock_repo_packages = mock_repo.repos[0].packages_path
 
     with working_dir(mock_repo_packages):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1734,7 +1734,7 @@ class TestConcretize:
         builder.remove("pkg-c")
         with spack.repo.use_repositories(builder.root, override=False) as repos:
             # TODO (INJECT CONFIGURATION): unclear why the cache needs to be invalidated explicitly
-            repos.repos[0]._pkg_checker.invalidate()
+            repos.repos[0].index.checker.invalidate()
             with spack.config.override("concretizer:reuse", True):
                 s = Spec("pkg-c").concretized()
             assert s.namespace == "builtin.mock"

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -230,7 +230,9 @@ class Changing(Package):
                 self.repo_dir = repo_directory
                 cache_dir = tmp_path_factory.mktemp("cache")
                 self.repo_cache = spack.util.file_cache.FileCache(str(cache_dir))
-                self.repo = spack.repo.Repo(str(repo_directory), cache=self.repo_cache)
+                self.repo = spack.repo.Repo(
+                    str(repo_directory), index_factory=spack.repo.IndexFactory(self.repo_cache)
+                )
 
             def change(self, changes=None):
                 changes = changes or {}
@@ -256,7 +258,9 @@ class Changing(Package):
                 package_py.write_text(changing_pkg_str)
 
                 # Re-add the repository
-                self.repo = spack.repo.Repo(str(self.repo_dir), cache=self.repo_cache)
+                self.repo = spack.repo.Repo(
+                    str(self.repo_dir), index_factory=spack.repo.IndexFactory(self.repo_cache)
+                )
                 repository.put_first(self.repo)
 
         _changing_pkg = _ChangingPackage(repo_dir)

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -2026,7 +2026,7 @@ repo:
             f.write(pkg_str)
 
     repo_cache = spack.util.file_cache.FileCache(str(tmpdir.join("cache")))
-    return spack.repo.Repo(repo_path, cache=repo_cache)
+    return spack.repo.Repo(repo_path, index_factory=spack.repo.IndexFactory(repo_cache))
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -160,7 +160,8 @@ def test_handle_unknown_package(temporary_store, config, mock_packages, tmp_path
     layout = temporary_store.layout
 
     repo_cache = spack.util.file_cache.FileCache(str(tmp_path / "cache"))
-    mock_db = spack.repo.RepoPath(spack.paths.mock_packages_path, cache=repo_cache)
+    factory = spack.repo.IndexFactory(cache=repo_cache)
+    mock_db = spack.repo.RepoPath(spack.paths.mock_packages_path, index_factory=factory)
 
     not_in_mock = set.difference(
         set(spack.repo.all_package_names()), set(mock_db.all_package_names())


### PR DESCRIPTION
depends on #45827

This PR allows a user to disable repo cache updates by setting the env variable:
```console
SPACK_UPDATE_CACHE=0
```
This means that:
1. The user is responsible to know that the repo cache exists and is up to date
2. Spack will avoid 8k stat calls and will never try to update the cache, but will just use the existing one

This can have a noticeable impact on slow filesystems:
```console
$ time SPACK_UPDATE_CACHE=0 spack external find -t compiler
==> The following specs have been detected on this system and added to /home/culpo/.spack/packages.yaml
gcc@11.2.1  gcc@11.2.1

real	0m4.963s
user	0m3.501s
sys	0m0.585s
$ rm ~/.spack/packages.yaml 

$ time spack external find -t compiler
==> The following specs have been detected on this system and added to /home/culpo/.spack/packages.yaml
gcc@11.2.1  gcc@11.2.1

real	0m16.947s
user	0m3.570s
sys	0m1.064s
```


<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
