### PR TITLE
Backports v0.21.3

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -176,7 +176,7 @@ jobs:
     runs-on: ${{ matrix.macos-version }}
     strategy:
       matrix:
-        macos-version: ['macos-11', 'macos-12']
+        macos-version: ['macos-12']
     steps:
       - name: Install dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v0.21.3 (2024-10-02)
+
+## Bugfixes
+- Forward compatibility with Spack 0.23 packages with language dependencies (#45205, #45191)
+- Forward compatibility with `urllib` from Python 3.12.6+ (#46453, #46483)
+- Bump `archspec` to 0.2.5-dev for better aarch64 and Windows support (#42854, #44005,
+  #45721, #46445)
+- Support macOS Sequoia (#45018, #45127, #43862)
+- CI and test maintenance (#42909, #42728, #46711, #41943, #43363)
+
 # v0.21.2 (2024-03-01)
 
 ## Bugfixes

--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -18,7 +18,7 @@ archspec
 
 * Homepage: https://pypi.python.org/pypi/archspec
 * Usage: Labeling, comparison and detection of microarchitectures
-* Version: 0.2.2 (commit 1dc58a5776dd77e6fc6e4ba5626af5b1fb24996e)
+* Version: 0.2.3 (commit 7b8fe60b69e2861e7dac104bc1c183decfcd3daf)
 
 astunparse
 ----------------

--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -18,7 +18,7 @@ archspec
 
 * Homepage: https://pypi.python.org/pypi/archspec
 * Usage: Labeling, comparison and detection of microarchitectures
-* Version: 0.2.3 (commit 7b8fe60b69e2861e7dac104bc1c183decfcd3daf)
+* Version: 0.2.4 (commit 48b92512b9ce203ded0ebd1ac41b42593e931f7c)
 
 astunparse
 ----------------

--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -18,7 +18,7 @@ archspec
 
 * Homepage: https://pypi.python.org/pypi/archspec
 * Usage: Labeling, comparison and detection of microarchitectures
-* Version: 0.2.4 (commit 48b92512b9ce203ded0ebd1ac41b42593e931f7c)
+* Version: 0.2.5-dev (commit 7e6740012b897ae4a950f0bba7e9726b767e921f)
 
 astunparse
 ----------------

--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -18,7 +18,7 @@ archspec
 
 * Homepage: https://pypi.python.org/pypi/archspec
 * Usage: Labeling, comparison and detection of microarchitectures
-* Version: 0.2.5-dev (commit 7e6740012b897ae4a950f0bba7e9726b767e921f)
+* Version: 0.2.5-dev (commit cbb1fd5eb397a70d466e5160b393b87b0dbcc78f)
 
 astunparse
 ----------------

--- a/lib/spack/external/archspec/__init__.py
+++ b/lib/spack/external/archspec/__init__.py
@@ -1,3 +1,3 @@
 """Init file to avoid namespace packages"""
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/lib/spack/external/archspec/__init__.py
+++ b/lib/spack/external/archspec/__init__.py
@@ -1,2 +1,3 @@
 """Init file to avoid namespace packages"""
-__version__ = "0.2.2"
+
+__version__ = "0.2.3"

--- a/lib/spack/external/archspec/__main__.py
+++ b/lib/spack/external/archspec/__main__.py
@@ -3,6 +3,7 @@ Run the `archspec` CLI as a module.
 """
 
 import sys
+
 from .cli import main
 
 sys.exit(main())

--- a/lib/spack/external/archspec/cli.py
+++ b/lib/spack/external/archspec/cli.py
@@ -46,7 +46,11 @@ def _make_parser() -> argparse.ArgumentParser:
 
 def cpu() -> int:
     """Run the `archspec cpu` subcommand."""
-    print(archspec.cpu.host())
+    try:
+        print(archspec.cpu.host())
+    except FileNotFoundError as exc:
+        print(exc)
+        return 1
     return 0
 
 

--- a/lib/spack/external/archspec/cpu/__init__.py
+++ b/lib/spack/external/archspec/cpu/__init__.py
@@ -5,10 +5,14 @@
 """The "cpu" package permits to query and compare different
 CPU microarchitectures.
 """
-from .microarchitecture import Microarchitecture, UnsupportedMicroarchitecture
-from .microarchitecture import TARGETS, generic_microarchitecture
-from .microarchitecture import version_components
 from .detect import host
+from .microarchitecture import (
+    TARGETS,
+    Microarchitecture,
+    UnsupportedMicroarchitecture,
+    generic_microarchitecture,
+    version_components,
+)
 
 __all__ = [
     "Microarchitecture",

--- a/lib/spack/external/archspec/cpu/__init__.py
+++ b/lib/spack/external/archspec/cpu/__init__.py
@@ -5,9 +5,10 @@
 """The "cpu" package permits to query and compare different
 CPU microarchitectures.
 """
-from .detect import host
+from .detect import brand_string, host
 from .microarchitecture import (
     TARGETS,
+    InvalidCompilerVersion,
     Microarchitecture,
     UnsupportedMicroarchitecture,
     generic_microarchitecture,
@@ -15,10 +16,12 @@ from .microarchitecture import (
 )
 
 __all__ = [
+    "brand_string",
+    "host",
+    "TARGETS",
+    "InvalidCompilerVersion",
     "Microarchitecture",
     "UnsupportedMicroarchitecture",
-    "TARGETS",
     "generic_microarchitecture",
-    "host",
     "version_components",
 ]

--- a/lib/spack/external/archspec/cpu/__init__.py
+++ b/lib/spack/external/archspec/cpu/__init__.py
@@ -8,7 +8,6 @@ CPU microarchitectures.
 from .detect import brand_string, host
 from .microarchitecture import (
     TARGETS,
-    InvalidCompilerVersion,
     Microarchitecture,
     UnsupportedMicroarchitecture,
     generic_microarchitecture,
@@ -16,12 +15,11 @@ from .microarchitecture import (
 )
 
 __all__ = [
-    "brand_string",
-    "host",
-    "TARGETS",
-    "InvalidCompilerVersion",
     "Microarchitecture",
     "UnsupportedMicroarchitecture",
+    "TARGETS",
     "generic_microarchitecture",
+    "host",
     "version_components",
+    "brand_string",
 ]

--- a/lib/spack/external/archspec/cpu/detect.py
+++ b/lib/spack/external/archspec/cpu/detect.py
@@ -4,15 +4,17 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Detection of CPU microarchitectures"""
 import collections
-import functools
 import os
 import platform
 import re
+import struct
 import subprocess
 import warnings
+from typing import Dict, List, Optional, Set, Tuple, Union
 
-from .microarchitecture import generic_microarchitecture, TARGETS
-from .schema import TARGETS_JSON
+from ..vendor.cpuid.cpuid import CPUID
+from .microarchitecture import TARGETS, Microarchitecture, generic_microarchitecture
+from .schema import CPUID_JSON, TARGETS_JSON
 
 #: Mapping from operating systems to chain of commands
 #: to obtain a dictionary of raw info on the current cpu
@@ -22,43 +24,46 @@ INFO_FACTORY = collections.defaultdict(list)
 #: functions checking the compatibility of the host with a given target
 COMPATIBILITY_CHECKS = {}
 
+# Constants for commonly used architectures
+X86_64 = "x86_64"
+AARCH64 = "aarch64"
+PPC64LE = "ppc64le"
+PPC64 = "ppc64"
+RISCV64 = "riscv64"
 
-def info_dict(operating_system):
-    """Decorator to mark functions that are meant to return raw info on
-    the current cpu.
+
+def detection(operating_system: str):
+    """Decorator to mark functions that are meant to return partial information on the current cpu.
 
     Args:
-        operating_system (str or tuple): operating system for which the marked
-            function is a viable factory of raw info dictionaries.
+        operating_system: operating system where this function can be used.
     """
 
     def decorator(factory):
         INFO_FACTORY[operating_system].append(factory)
-
-        @functools.wraps(factory)
-        def _impl():
-            info = factory()
-
-            # Check that info contains a few mandatory fields
-            msg = 'field "{0}" is missing from raw info dictionary'
-            assert "vendor_id" in info, msg.format("vendor_id")
-            assert "flags" in info, msg.format("flags")
-            assert "model" in info, msg.format("model")
-            assert "model_name" in info, msg.format("model_name")
-
-            return info
-
-        return _impl
+        return factory
 
     return decorator
 
 
-@info_dict(operating_system="Linux")
-def proc_cpuinfo():
-    """Returns a raw info dictionary by parsing the first entry of
-    ``/proc/cpuinfo``
-    """
-    info = {}
+def partial_uarch(
+    name: str = "", vendor: str = "", features: Optional[Set[str]] = None, generation: int = 0
+) -> Microarchitecture:
+    """Construct a partial microarchitecture, from information gathered during system scan."""
+    return Microarchitecture(
+        name=name,
+        parents=[],
+        vendor=vendor,
+        features=features or set(),
+        compilers={},
+        generation=generation,
+    )
+
+
+@detection(operating_system="Linux")
+def proc_cpuinfo() -> Microarchitecture:
+    """Returns a partial Microarchitecture, obtained from scanning ``/proc/cpuinfo``"""
+    data = {}
     with open("/proc/cpuinfo") as file:  # pylint: disable=unspecified-encoding
         for line in file:
             key, separator, value = line.partition(":")
@@ -70,11 +75,96 @@ def proc_cpuinfo():
             #
             # we are on a blank line separating two cpus. Exit early as
             # we want to read just the first entry in /proc/cpuinfo
-            if separator != ":" and info:
+            if separator != ":" and data:
                 break
 
-            info[key.strip()] = value.strip()
-    return info
+            data[key.strip()] = value.strip()
+
+    architecture = _machine()
+    if architecture == X86_64:
+        return partial_uarch(
+            vendor=data.get("vendor_id", "generic"), features=_feature_set(data, key="flags")
+        )
+
+    if architecture == AARCH64:
+        return partial_uarch(
+            vendor=_canonicalize_aarch64_vendor(data),
+            features=_feature_set(data, key="Features"),
+        )
+
+    if architecture in (PPC64LE, PPC64):
+        generation_match = re.search(r"POWER(\d+)", data.get("cpu", ""))
+        try:
+            generation = int(generation_match.group(1))
+        except AttributeError:
+            # There might be no match under emulated environments. For instance
+            # emulating a ppc64le with QEMU and Docker still reports the host
+            # /proc/cpuinfo and not a Power
+            generation = 0
+        return partial_uarch(generation=generation)
+
+    if architecture == RISCV64:
+        if data.get("uarch") == "sifive,u74-mc":
+            data["uarch"] = "u74mc"
+        return partial_uarch(name=data.get("uarch", RISCV64))
+
+    return generic_microarchitecture(architecture)
+
+
+class CpuidInfoCollector:
+    """Collects the information we need on the host CPU from cpuid"""
+
+    # pylint: disable=too-few-public-methods
+    def __init__(self):
+        self.cpuid = CPUID()
+
+        registers = self.cpuid.registers_for(**CPUID_JSON["vendor"]["input"])
+        self.highest_basic_support = registers.eax
+        self.vendor = struct.pack("III", registers.ebx, registers.edx, registers.ecx).decode(
+            "utf-8"
+        )
+
+        registers = self.cpuid.registers_for(**CPUID_JSON["highest_extension_support"]["input"])
+        self.highest_extension_support = registers.eax
+
+        self.features = self._features()
+
+    def _features(self):
+        result = set()
+
+        def check_features(data):
+            registers = self.cpuid.registers_for(**data["input"])
+            for feature_check in data["bits"]:
+                current = getattr(registers, feature_check["register"])
+                if self._is_bit_set(current, feature_check["bit"]):
+                    result.add(feature_check["name"])
+
+        for call_data in CPUID_JSON["flags"]:
+            if call_data["input"]["eax"] > self.highest_basic_support:
+                continue
+            check_features(call_data)
+
+        for call_data in CPUID_JSON["extension-flags"]:
+            if call_data["input"]["eax"] > self.highest_extension_support:
+                continue
+            check_features(call_data)
+
+        return result
+
+    def _is_bit_set(self, register: int, bit: int) -> bool:
+        mask = 1 << bit
+        return register & mask > 0
+
+
+@detection(operating_system="Windows")
+def cpuid_info():
+    """Returns a partial Microarchitecture, obtained from running the cpuid instruction"""
+    architecture = _machine()
+    if architecture == X86_64:
+        data = CpuidInfoCollector()
+        return partial_uarch(vendor=data.vendor, features=data.features)
+
+    return generic_microarchitecture(architecture)
 
 
 def _check_output(args, env):
@@ -83,13 +173,24 @@ def _check_output(args, env):
     return str(output.decode("utf-8"))
 
 
+WINDOWS_MAPPING = {
+    "AMD64": "x86_64",
+    "ARM64": "aarch64",
+}
+
+
 def _machine():
-    """ "Return the machine architecture we are on"""
+    """Return the machine architecture we are on"""
     operating_system = platform.system()
 
-    # If we are not on Darwin, trust what Python tells us
-    if operating_system != "Darwin":
+    # If we are not on Darwin or Windows, trust what Python tells us
+    if operating_system not in ("Darwin", "Windows"):
         return platform.machine()
+
+    # Normalize windows specific names
+    if operating_system == "Windows":
+        platform_machine = platform.machine()
+        return WINDOWS_MAPPING.get(platform_machine, platform_machine)
 
     # On Darwin it might happen that we are on M1, but using an interpreter
     # built for x86_64. In that case "platform.machine() == 'x86_64'", so we
@@ -103,54 +204,47 @@ def _machine():
     if "Apple" in output:
         # Note that a native Python interpreter on Apple M1 would return
         # "arm64" instead of "aarch64". Here we normalize to the latter.
-        return "aarch64"
+        return AARCH64
 
-    return "x86_64"
+    return X86_64
 
 
-@info_dict(operating_system="Darwin")
-def sysctl_info_dict():
+@detection(operating_system="Darwin")
+def sysctl_info() -> Microarchitecture:
     """Returns a raw info dictionary parsing the output of sysctl."""
     child_environment = _ensure_bin_usrbin_in_path()
 
-    def sysctl(*args):
+    def sysctl(*args: str) -> str:
         return _check_output(["sysctl"] + list(args), env=child_environment).strip()
 
-    if _machine() == "x86_64":
-        flags = (
-            sysctl("-n", "machdep.cpu.features").lower()
-            + " "
-            + sysctl("-n", "machdep.cpu.leaf7_features").lower()
+    if _machine() == X86_64:
+        features = (
+            f'{sysctl("-n", "machdep.cpu.features").lower()} '
+            f'{sysctl("-n", "machdep.cpu.leaf7_features").lower()}'
         )
-        info = {
-            "vendor_id": sysctl("-n", "machdep.cpu.vendor"),
-            "flags": flags,
-            "model": sysctl("-n", "machdep.cpu.model"),
-            "model name": sysctl("-n", "machdep.cpu.brand_string"),
-        }
-    else:
-        model = "unknown"
-        model_str = sysctl("-n", "machdep.cpu.brand_string").lower()
-        if "m2" in model_str:
-            model = "m2"
-        elif "m1" in model_str:
-            model = "m1"
-        elif "apple" in model_str:
-            model = "m1"
+        features = set(features.split())
 
-        info = {
-            "vendor_id": "Apple",
-            "flags": [],
-            "model": model,
-            "CPU implementer": "Apple",
-            "model name": sysctl("-n", "machdep.cpu.brand_string"),
-        }
-    return info
+        # Flags detected on Darwin turned to their linux counterpart
+        for darwin_flag, linux_flag in TARGETS_JSON["conversions"]["darwin_flags"].items():
+            if darwin_flag in features:
+                features.update(linux_flag.split())
+
+        return partial_uarch(vendor=sysctl("-n", "machdep.cpu.vendor"), features=features)
+
+    model = "unknown"
+    model_str = sysctl("-n", "machdep.cpu.brand_string").lower()
+    if "m2" in model_str:
+        model = "m2"
+    elif "m1" in model_str:
+        model = "m1"
+    elif "apple" in model_str:
+        model = "m1"
+
+    return partial_uarch(name=model, vendor="Apple")
 
 
 def _ensure_bin_usrbin_in_path():
-    # Make sure that /sbin and /usr/sbin are in PATH as sysctl is
-    # usually found there
+    # Make sure that /sbin and /usr/sbin are in PATH as sysctl is usually found there
     child_environment = dict(os.environ.items())
     search_paths = child_environment.get("PATH", "").split(os.pathsep)
     for additional_path in ("/sbin", "/usr/sbin"):
@@ -160,22 +254,10 @@ def _ensure_bin_usrbin_in_path():
     return child_environment
 
 
-def adjust_raw_flags(info):
-    """Adjust the flags detected on the system to homogenize
-    slightly different representations.
-    """
-    # Flags detected on Darwin turned to their linux counterpart
-    flags = info.get("flags", [])
-    d2l = TARGETS_JSON["conversions"]["darwin_flags"]
-    for darwin_flag, linux_flag in d2l.items():
-        if darwin_flag in flags:
-            info["flags"] += " " + linux_flag
-
-
-def adjust_raw_vendor(info):
-    """Adjust the vendor field to make it human readable"""
-    if "CPU implementer" not in info:
-        return
+def _canonicalize_aarch64_vendor(data: Dict[str, str]) -> str:
+    """Adjust the vendor field to make it human-readable"""
+    if "CPU implementer" not in data:
+        return "generic"
 
     # Mapping numeric codes to vendor (ARM). This list is a merge from
     # different sources:
@@ -185,43 +267,37 @@ def adjust_raw_vendor(info):
     # https://github.com/gcc-mirror/gcc/blob/master/gcc/config/aarch64/aarch64-cores.def
     # https://patchwork.kernel.org/patch/10524949/
     arm_vendors = TARGETS_JSON["conversions"]["arm_vendors"]
-    arm_code = info["CPU implementer"]
-    if arm_code in arm_vendors:
-        info["CPU implementer"] = arm_vendors[arm_code]
+    arm_code = data["CPU implementer"]
+    return arm_vendors.get(arm_code, arm_code)
 
 
-def raw_info_dictionary():
-    """Returns a dictionary with information on the cpu of the current host.
+def _feature_set(data: Dict[str, str], key: str) -> Set[str]:
+    return set(data.get(key, "").split())
 
-    This function calls all the viable factories one after the other until
-    there's one that is able to produce the requested information.
+
+def detected_info() -> Microarchitecture:
+    """Returns a partial Microarchitecture with information on the CPU of the current host.
+
+    This function calls all the viable factories one after the other until there's one that is
+    able to produce the requested information. Falls-back to a generic microarchitecture, if none
+    of the calls succeed.
     """
     # pylint: disable=broad-except
-    info = {}
     for factory in INFO_FACTORY[platform.system()]:
         try:
-            info = factory()
+            return factory()
         except Exception as exc:
             warnings.warn(str(exc))
 
-        if info:
-            adjust_raw_flags(info)
-            adjust_raw_vendor(info)
-            break
-
-    return info
+    return generic_microarchitecture(_machine())
 
 
-def compatible_microarchitectures(info):
-    """Returns an unordered list of known micro-architectures that are
-    compatible with the info dictionary passed as argument.
-
-    Args:
-        info (dict): dictionary containing information on the host cpu
+def compatible_microarchitectures(info: Microarchitecture) -> List[Microarchitecture]:
+    """Returns an unordered list of known micro-architectures that are compatible with the
+    partial Microarchitecture passed as input.
     """
     architecture_family = _machine()
-    # If a tester is not registered, be conservative and assume no known
-    # target is compatible with the host
+    # If a tester is not registered, assume no known target is compatible with the host
     tester = COMPATIBILITY_CHECKS.get(architecture_family, lambda x, y: False)
     return [x for x in TARGETS.values() if tester(info, x)] or [
         generic_microarchitecture(architecture_family)
@@ -230,8 +306,8 @@ def compatible_microarchitectures(info):
 
 def host():
     """Detects the host micro-architecture and returns it."""
-    # Retrieve a dictionary with raw information on the host's cpu
-    info = raw_info_dictionary()
+    # Retrieve information on the host's cpu
+    info = detected_info()
 
     # Get a list of possible candidates for this micro-architecture
     candidates = compatible_microarchitectures(info)
@@ -258,16 +334,15 @@ def host():
     return max(candidates, key=sorting_fn)
 
 
-def compatibility_check(architecture_family):
+def compatibility_check(architecture_family: Union[str, Tuple[str, ...]]):
     """Decorator to register a function as a proper compatibility check.
 
-    A compatibility check function takes the raw info dictionary as a first
-    argument and an arbitrary target as the second argument. It returns True
-    if the target is compatible with the info dictionary, False otherwise.
+    A compatibility check function takes a partial Microarchitecture object as a first argument,
+    and an arbitrary target Microarchitecture as the second argument. It returns True if the
+    target is compatible with first argument, False otherwise.
 
     Args:
-        architecture_family (str or tuple): architecture family for which
-            this test can be used, e.g. x86_64 or ppc64le etc.
+        architecture_family: architecture family for which this test can be used
     """
     # Turn the argument into something iterable
     if isinstance(architecture_family, str):
@@ -280,86 +355,57 @@ def compatibility_check(architecture_family):
     return decorator
 
 
-@compatibility_check(architecture_family=("ppc64le", "ppc64"))
+@compatibility_check(architecture_family=(PPC64LE, PPC64))
 def compatibility_check_for_power(info, target):
     """Compatibility check for PPC64 and PPC64LE architectures."""
-    basename = platform.machine()
-    generation_match = re.search(r"POWER(\d+)", info.get("cpu", ""))
-    try:
-        generation = int(generation_match.group(1))
-    except AttributeError:
-        # There might be no match under emulated environments. For instance
-        # emulating a ppc64le with QEMU and Docker still reports the host
-        # /proc/cpuinfo and not a Power
-        generation = 0
-
     # We can use a target if it descends from our machine type and our
     # generation (9 for POWER9, etc) is at least its generation.
-    arch_root = TARGETS[basename]
+    arch_root = TARGETS[_machine()]
     return (
         target == arch_root or arch_root in target.ancestors
-    ) and target.generation <= generation
+    ) and target.generation <= info.generation
 
 
-@compatibility_check(architecture_family="x86_64")
+@compatibility_check(architecture_family=X86_64)
 def compatibility_check_for_x86_64(info, target):
     """Compatibility check for x86_64 architectures."""
-    basename = "x86_64"
-    vendor = info.get("vendor_id", "generic")
-    features = set(info.get("flags", "").split())
-
     # We can use a target if it descends from our machine type, is from our
     # vendor, and we have all of its features
-    arch_root = TARGETS[basename]
+    arch_root = TARGETS[X86_64]
     return (
         (target == arch_root or arch_root in target.ancestors)
-        and target.vendor in (vendor, "generic")
-        and target.features.issubset(features)
+        and target.vendor in (info.vendor, "generic")
+        and target.features.issubset(info.features)
     )
 
 
-@compatibility_check(architecture_family="aarch64")
+@compatibility_check(architecture_family=AARCH64)
 def compatibility_check_for_aarch64(info, target):
     """Compatibility check for AARCH64 architectures."""
-    basename = "aarch64"
-    features = set(info.get("Features", "").split())
-    vendor = info.get("CPU implementer", "generic")
-
-    # At the moment it's not clear how to detect compatibility with
+    # At the moment, it's not clear how to detect compatibility with
     # a specific version of the architecture
-    if target.vendor == "generic" and target.name != "aarch64":
+    if target.vendor == "generic" and target.name != AARCH64:
         return False
 
-    arch_root = TARGETS[basename]
+    arch_root = TARGETS[AARCH64]
     arch_root_and_vendor = arch_root == target.family and target.vendor in (
-        vendor,
+        info.vendor,
         "generic",
     )
 
     # On macOS it seems impossible to get all the CPU features
     # with syctl info, but for ARM we can get the exact model
     if platform.system() == "Darwin":
-        model_key = info.get("model", basename)
-        model = TARGETS[model_key]
+        model = TARGETS[info.name]
         return arch_root_and_vendor and (target == model or target in model.ancestors)
 
-    return arch_root_and_vendor and target.features.issubset(features)
+    return arch_root_and_vendor and target.features.issubset(info.features)
 
 
-@compatibility_check(architecture_family="riscv64")
+@compatibility_check(architecture_family=RISCV64)
 def compatibility_check_for_riscv64(info, target):
     """Compatibility check for riscv64 architectures."""
-    basename = "riscv64"
-    uarch = info.get("uarch")
-
-    # sifive unmatched board
-    if uarch == "sifive,u74-mc":
-        uarch = "u74mc"
-    # catch-all for unknown uarchs
-    else:
-        uarch = "riscv64"
-
-    arch_root = TARGETS[basename]
+    arch_root = TARGETS[RISCV64]
     return (target == arch_root or arch_root in target.ancestors) and (
-        target == uarch or target.vendor == "generic"
+        target.name == info.name or target.vendor == "generic"
     )

--- a/lib/spack/external/archspec/cpu/microarchitecture.py
+++ b/lib/spack/external/archspec/cpu/microarchitecture.py
@@ -208,6 +208,8 @@ class Microarchitecture:
         """Returns a string containing the optimization flags that needs
         to be used to produce code optimized for this micro-architecture.
 
+        The version is expected to be a string of dot separated digits.
+
         If there is no information on the compiler passed as argument the
         function returns an empty string. If it is known that the compiler
         version we want to use does not support this architecture the function
@@ -216,6 +218,11 @@ class Microarchitecture:
         Args:
             compiler (str): name of the compiler to be used
             version (str): version of the compiler to be used
+
+        Raises:
+            UnsupportedMicroarchitecture: if the requested compiler does not support
+                this micro-architecture.
+            ValueError: if the version doesn't match the expected format
         """
         # If we don't have information on compiler at all return an empty string
         if compiler not in self.family.compilers:
@@ -231,6 +238,14 @@ class Microarchitecture:
             )
             msg = msg.format(compiler, best_target, best_target.family)
             raise UnsupportedMicroarchitecture(msg)
+
+        # Check that the version matches the expected format
+        if not re.match(r"^(?:\d+\.)*\d+$", version):
+            msg = (
+                "invalid format for the compiler version argument. "
+                "Only dot separated digits are allowed."
+            )
+            raise InvalidCompilerVersion(msg)
 
         # If we have information on this compiler we need to check the
         # version being used
@@ -292,7 +307,7 @@ def generic_microarchitecture(name):
     Args:
         name (str): name of the micro-architecture
     """
-    return Microarchitecture(name, parents=[], vendor="generic", features=[], compilers={})
+    return Microarchitecture(name, parents=[], vendor="generic", features=set(), compilers={})
 
 
 def version_components(version):
@@ -367,7 +382,15 @@ def _known_microarchitectures():
 TARGETS = LazyDictionary(_known_microarchitectures)
 
 
-class UnsupportedMicroarchitecture(ValueError):
+class ArchspecError(Exception):
+    """Base class for errors within archspec"""
+
+
+class UnsupportedMicroarchitecture(ArchspecError, ValueError):
     """Raised if a compiler version does not support optimization for a given
     micro-architecture.
     """
+
+
+class InvalidCompilerVersion(ArchspecError, ValueError):
+    """Raised when an invalid format is used for compiler versions in archspec."""

--- a/lib/spack/external/archspec/cpu/microarchitecture.py
+++ b/lib/spack/external/archspec/cpu/microarchitecture.py
@@ -213,8 +213,6 @@ class Microarchitecture:
         """Returns a string containing the optimization flags that needs
         to be used to produce code optimized for this micro-architecture.
 
-        The version is expected to be a string of dot separated digits.
-
         If there is no information on the compiler passed as argument the
         function returns an empty string. If it is known that the compiler
         version we want to use does not support this architecture the function
@@ -223,11 +221,6 @@ class Microarchitecture:
         Args:
             compiler (str): name of the compiler to be used
             version (str): version of the compiler to be used
-
-        Raises:
-            UnsupportedMicroarchitecture: if the requested compiler does not support
-                this micro-architecture.
-            ValueError: if the version doesn't match the expected format
         """
         # If we don't have information on compiler at all return an empty string
         if compiler not in self.family.compilers:
@@ -243,14 +236,6 @@ class Microarchitecture:
             )
             msg = msg.format(compiler, best_target, best_target.family)
             raise UnsupportedMicroarchitecture(msg)
-
-        # Check that the version matches the expected format
-        if not re.match(r"^(?:\d+\.)*\d+$", version):
-            msg = (
-                "invalid format for the compiler version argument. "
-                "Only dot separated digits are allowed."
-            )
-            raise InvalidCompilerVersion(msg)
 
         # If we have information on this compiler we need to check the
         # version being used
@@ -390,15 +375,7 @@ def _known_microarchitectures():
 TARGETS = LazyDictionary(_known_microarchitectures)
 
 
-class ArchspecError(Exception):
-    """Base class for errors within archspec"""
-
-
-class UnsupportedMicroarchitecture(ArchspecError, ValueError):
+class UnsupportedMicroarchitecture(ValueError):
     """Raised if a compiler version does not support optimization for a given
     micro-architecture.
     """
-
-
-class InvalidCompilerVersion(ArchspecError, ValueError):
-    """Raised when an invalid format is used for compiler versions in archspec."""

--- a/lib/spack/external/archspec/cpu/schema.py
+++ b/lib/spack/external/archspec/cpu/schema.py
@@ -7,7 +7,9 @@ JSON file and its schema
 """
 import collections.abc
 import json
-import os.path
+import os
+import pathlib
+from typing import Tuple
 
 
 class LazyDictionary(collections.abc.MutableMapping):
@@ -46,21 +48,65 @@ class LazyDictionary(collections.abc.MutableMapping):
         return len(self.data)
 
 
-def _load_json_file(json_file):
-    json_dir = os.path.join(os.path.dirname(__file__), "..", "json", "cpu")
-    json_dir = os.path.abspath(json_dir)
+#: Environment variable that might point to a directory with a user defined JSON file
+DIR_FROM_ENVIRONMENT = "ARCHSPEC_CPU_DIR"
 
-    def _factory():
-        filename = os.path.join(json_dir, json_file)
-        with open(filename, "r", encoding="utf-8") as file:
-            return json.load(file)
+#: Environment variable that might point to a directory with extensions to JSON files
+EXTENSION_DIR_FROM_ENVIRONMENT = "ARCHSPEC_EXTENSION_CPU_DIR"
 
-    return _factory
+
+def _json_file(filename: str, allow_custom: bool = False) -> Tuple[pathlib.Path, pathlib.Path]:
+    """Given a filename, returns the absolute path for the main JSON file, and an
+    optional absolute path for an extension JSON file.
+
+    Args:
+        filename: filename for the JSON file
+        allow_custom: if True, allows overriding the location  where the file resides
+    """
+    json_dir = pathlib.Path(__file__).parent / ".." / "json" / "cpu"
+    if allow_custom and DIR_FROM_ENVIRONMENT in os.environ:
+        json_dir = pathlib.Path(os.environ[DIR_FROM_ENVIRONMENT])
+    json_dir = json_dir.absolute()
+    json_file = json_dir / filename
+
+    extension_file = None
+    if allow_custom and EXTENSION_DIR_FROM_ENVIRONMENT in os.environ:
+        extension_dir = pathlib.Path(os.environ[EXTENSION_DIR_FROM_ENVIRONMENT])
+        extension_dir.absolute()
+        extension_file = extension_dir / filename
+
+    return json_file, extension_file
+
+
+def _load(json_file: pathlib.Path, extension_file: pathlib.Path):
+    with open(json_file, "r", encoding="utf-8") as file:
+        data = json.load(file)
+
+    if not extension_file or not extension_file.exists():
+        return data
+
+    with open(extension_file, "r", encoding="utf-8") as file:
+        extension_data = json.load(file)
+
+    top_level_sections = list(data.keys())
+    for key in top_level_sections:
+        if key not in extension_data:
+            continue
+
+        data[key].update(extension_data[key])
+
+    return data
 
 
 #: In memory representation of the data in microarchitectures.json,
 #: loaded on first access
-TARGETS_JSON = LazyDictionary(_load_json_file("microarchitectures.json"))
+TARGETS_JSON = LazyDictionary(_load, *_json_file("microarchitectures.json", allow_custom=True))
 
 #: JSON schema for microarchitectures.json, loaded on first access
-SCHEMA = LazyDictionary(_load_json_file("microarchitectures_schema.json"))
+TARGETS_JSON_SCHEMA = LazyDictionary(_load, *_json_file("microarchitectures_schema.json"))
+
+#: Information on how to call 'cpuid' to get information on the HOST CPU
+CPUID_JSON = LazyDictionary(_load, *_json_file("cpuid.json", allow_custom=True))
+
+#: JSON schema for cpuid.json, loaded on first access
+CPUID_JSON_SCHEMA = LazyDictionary(_load, *_json_file("cpuid_schema.json"))

--- a/lib/spack/external/archspec/json/README.md
+++ b/lib/spack/external/archspec/json/README.md
@@ -9,11 +9,11 @@ language specific APIs.
 
 Currently the repository contains the following JSON files:
 ```console
-.
-├── COPYRIGHT
-└── cpu
-    ├── microarchitectures.json         # Contains information on CPU microarchitectures
-    └── microarchitectures_schema.json  # Schema for the file above
+cpu/
+├── cpuid.json                     # Contains information on CPUID calls to retrieve vendor and features on x86_64
+├── cpuid_schema.json              # Schema for the file above
+├── microarchitectures.json        # Contains information on CPU microarchitectures
+└── microarchitectures_schema.json # Schema for the file above
  ```
 
 

--- a/lib/spack/external/archspec/json/cpu/cpuid.json
+++ b/lib/spack/external/archspec/json/cpu/cpuid.json
@@ -1,0 +1,1050 @@
+{
+  "vendor": {
+    "description": "https://en.wikipedia.org/wiki/CPUID#EAX=0:_Highest_Function_Parameter_and_Manufacturer_ID",
+    "input": {
+      "eax": 0,
+      "ecx": 0
+    }
+  },
+  "highest_extension_support": {
+    "description": "https://en.wikipedia.org/wiki/CPUID#EAX=80000000h:_Get_Highest_Extended_Function_Implemented",
+    "input": {
+      "eax": 2147483648,
+      "ecx": 0
+    }
+  },
+  "flags": [
+    {
+      "description": "https://en.wikipedia.org/wiki/CPUID#EAX=1:_Processor_Info_and_Feature_Bits",
+      "input": {
+        "eax": 1,
+        "ecx": 0
+      },
+      "bits": [
+        {
+          "name": "fpu",
+          "register": "edx",
+          "bit": 0
+        },
+        {
+          "name": "vme",
+          "register": "edx",
+          "bit": 1
+        },
+        {
+          "name": "de",
+          "register": "edx",
+          "bit": 2
+        },
+        {
+          "name": "pse",
+          "register": "edx",
+          "bit": 3
+        },
+        {
+          "name": "tsc",
+          "register": "edx",
+          "bit": 4
+        },
+        {
+          "name": "msr",
+          "register": "edx",
+          "bit": 5
+        },
+        {
+          "name": "pae",
+          "register": "edx",
+          "bit": 6
+        },
+        {
+          "name": "mce",
+          "register": "edx",
+          "bit": 7
+        },
+        {
+          "name": "cx8",
+          "register": "edx",
+          "bit": 8
+        },
+        {
+          "name": "apic",
+          "register": "edx",
+          "bit": 9
+        },
+        {
+          "name": "sep",
+          "register": "edx",
+          "bit": 11
+        },
+        {
+          "name": "mtrr",
+          "register": "edx",
+          "bit": 12
+        },
+        {
+          "name": "pge",
+          "register": "edx",
+          "bit": 13
+        },
+        {
+          "name": "mca",
+          "register": "edx",
+          "bit": 14
+        },
+        {
+          "name": "cmov",
+          "register": "edx",
+          "bit": 15
+        },
+        {
+          "name": "pat",
+          "register": "edx",
+          "bit": 16
+        },
+        {
+          "name": "pse36",
+          "register": "edx",
+          "bit": 17
+        },
+        {
+          "name": "pn",
+          "register": "edx",
+          "bit": 18
+        },
+        {
+          "name": "clflush",
+          "register": "edx",
+          "bit": 19
+        },
+        {
+          "name": "dts",
+          "register": "edx",
+          "bit": 21
+        },
+        {
+          "name": "acpi",
+          "register": "edx",
+          "bit": 22
+        },
+        {
+          "name": "mmx",
+          "register": "edx",
+          "bit": 23
+        },
+        {
+          "name": "fxsr",
+          "register": "edx",
+          "bit": 24
+        },
+        {
+          "name": "sse",
+          "register": "edx",
+          "bit": 25
+        },
+        {
+          "name": "sse2",
+          "register": "edx",
+          "bit": 26
+        },
+        {
+          "name": "ss",
+          "register": "edx",
+          "bit": 27
+        },
+        {
+          "name": "ht",
+          "register": "edx",
+          "bit": 28
+        },
+        {
+          "name": "tm",
+          "register": "edx",
+          "bit": 29
+        },
+        {
+          "name": "ia64",
+          "register": "edx",
+          "bit": 30
+        },
+        {
+          "name": "pbe",
+          "register": "edx",
+          "bit": 31
+        },
+        {
+          "name": "pni",
+          "register": "ecx",
+          "bit": 0
+        },
+        {
+          "name": "pclmulqdq",
+          "register": "ecx",
+          "bit": 1
+        },
+        {
+          "name": "dtes64",
+          "register": "ecx",
+          "bit": 2
+        },
+        {
+          "name": "monitor",
+          "register": "ecx",
+          "bit": 3
+        },
+        {
+          "name": "ds_cpl",
+          "register": "ecx",
+          "bit": 4
+        },
+        {
+          "name": "vmx",
+          "register": "ecx",
+          "bit": 5
+        },
+        {
+          "name": "smx",
+          "register": "ecx",
+          "bit": 6
+        },
+        {
+          "name": "est",
+          "register": "ecx",
+          "bit": 7
+        },
+        {
+          "name": "tm2",
+          "register": "ecx",
+          "bit": 8
+        },
+        {
+          "name": "ssse3",
+          "register": "ecx",
+          "bit": 9
+        },
+        {
+          "name": "cid",
+          "register": "ecx",
+          "bit": 10
+        },
+        {
+          "name": "fma",
+          "register": "ecx",
+          "bit": 12
+        },
+        {
+          "name": "cx16",
+          "register": "ecx",
+          "bit": 13
+        },
+        {
+          "name": "xtpr",
+          "register": "ecx",
+          "bit": 14
+        },
+        {
+          "name": "pdcm",
+          "register": "ecx",
+          "bit": 15
+        },
+        {
+          "name": "pcid",
+          "register": "ecx",
+          "bit": 17
+        },
+        {
+          "name": "dca",
+          "register": "ecx",
+          "bit": 18
+        },
+        {
+          "name": "sse4_1",
+          "register": "ecx",
+          "bit": 19
+        },
+        {
+          "name": "sse4_2",
+          "register": "ecx",
+          "bit": 20
+        },
+        {
+          "name": "x2apic",
+          "register": "ecx",
+          "bit": 21
+        },
+        {
+          "name": "movbe",
+          "register": "ecx",
+          "bit": 22
+        },
+        {
+          "name": "popcnt",
+          "register": "ecx",
+          "bit": 23
+        },
+        {
+          "name": "tscdeadline",
+          "register": "ecx",
+          "bit": 24
+        },
+        {
+          "name": "aes",
+          "register": "ecx",
+          "bit": 25
+        },
+        {
+          "name": "xsave",
+          "register": "ecx",
+          "bit": 26
+        },
+        {
+          "name": "osxsave",
+          "register": "ecx",
+          "bit": 27
+        },
+        {
+          "name": "avx",
+          "register": "ecx",
+          "bit": 28
+        },
+        {
+          "name": "f16c",
+          "register": "ecx",
+          "bit": 29
+        },
+        {
+          "name": "rdrand",
+          "register": "ecx",
+          "bit": 30
+        },
+        {
+          "name": "hypervisor",
+          "register": "ecx",
+          "bit": 31
+        }
+      ]
+    },
+    {
+      "description": "https://en.wikipedia.org/wiki/CPUID#EAX=7,_ECX=0:_Extended_Features",
+      "input": {
+        "eax": 7,
+        "ecx": 0
+      },
+      "bits": [
+        {
+          "name": "fsgsbase",
+          "register": "ebx",
+          "bit": 0
+        },
+        {
+          "name": "sgx",
+          "register": "ebx",
+          "bit": 2
+        },
+        {
+          "name": "bmi1",
+          "register": "ebx",
+          "bit": 3
+        },
+        {
+          "name": "hle",
+          "register": "ebx",
+          "bit": 4
+        },
+        {
+          "name": "avx2",
+          "register": "ebx",
+          "bit": 5
+        },
+        {
+          "name": "fdp-excptn-only",
+          "register": "ebx",
+          "bit": 6
+        },
+        {
+          "name": "smep",
+          "register": "ebx",
+          "bit": 7
+        },
+        {
+          "name": "bmi2",
+          "register": "ebx",
+          "bit": 8
+        },
+        {
+          "name": "erms",
+          "register": "ebx",
+          "bit": 9
+        },
+        {
+          "name": "invpcid",
+          "register": "ebx",
+          "bit": 10
+        },
+        {
+          "name": "rtm",
+          "register": "ebx",
+          "bit": 11
+        },
+        {
+          "name": "pqm",
+          "register": "ebx",
+          "bit": 12
+        },
+        {
+          "name": "mpx",
+          "register": "ebx",
+          "bit": 14
+        },
+        {
+          "name": "pqe",
+          "register": "ebx",
+          "bit": 15
+        },
+        {
+          "name": "avx512f",
+          "register": "ebx",
+          "bit": 16
+        },
+        {
+          "name": "avx512dq",
+          "register": "ebx",
+          "bit": 17
+        },
+        {
+          "name": "rdseed",
+          "register": "ebx",
+          "bit": 18
+        },
+        {
+          "name": "adx",
+          "register": "ebx",
+          "bit": 19
+        },
+        {
+          "name": "smap",
+          "register": "ebx",
+          "bit": 20
+        },
+        {
+          "name": "avx512ifma",
+          "register": "ebx",
+          "bit": 21
+        },
+        {
+          "name": "pcommit",
+          "register": "ebx",
+          "bit": 22
+        },
+        {
+          "name": "clflushopt",
+          "register": "ebx",
+          "bit": 23
+        },
+        {
+          "name": "clwb",
+          "register": "ebx",
+          "bit": 24
+        },
+        {
+          "name": "intel_pt",
+          "register": "ebx",
+          "bit": 25
+        },
+        {
+          "name": "avx512pf",
+          "register": "ebx",
+          "bit": 26
+        },
+        {
+          "name": "avx512er",
+          "register": "ebx",
+          "bit": 27
+        },
+        {
+          "name": "avx512cd",
+          "register": "ebx",
+          "bit": 28
+        },
+        {
+          "name": "sha_ni",
+          "register": "ebx",
+          "bit": 29
+        },
+        {
+          "name": "avx512bw",
+          "register": "ebx",
+          "bit": 30
+        },
+        {
+          "name": "avx512vl",
+          "register": "ebx",
+          "bit": 31
+        },
+        {
+          "name": "prefetchwt1",
+          "register": "ecx",
+          "bit": 0
+        },
+        {
+          "name": "avx512vbmi",
+          "register": "ecx",
+          "bit": 1
+        },
+        {
+          "name": "umip",
+          "register": "ecx",
+          "bit": 2
+        },
+        {
+          "name": "pku",
+          "register": "ecx",
+          "bit": 3
+        },
+        {
+          "name": "ospke",
+          "register": "ecx",
+          "bit": 4
+        },
+        {
+          "name": "waitpkg",
+          "register": "ecx",
+          "bit": 5
+        },
+        {
+          "name": "avx512_vbmi2",
+          "register": "ecx",
+          "bit": 6
+        },
+        {
+          "name": "cet_ss",
+          "register": "ecx",
+          "bit": 7
+        },
+        {
+          "name": "gfni",
+          "register": "ecx",
+          "bit": 8
+        },
+        {
+          "name": "vaes",
+          "register": "ecx",
+          "bit": 9
+        },
+        {
+          "name": "vpclmulqdq",
+          "register": "ecx",
+          "bit": 10
+        },
+        {
+          "name": "avx512_vnni",
+          "register": "ecx",
+          "bit": 11
+        },
+        {
+          "name": "avx512_bitalg",
+          "register": "ecx",
+          "bit": 12
+        },
+        {
+          "name": "tme",
+          "register": "ecx",
+          "bit": 13
+        },
+        {
+          "name": "avx512_vpopcntdq",
+          "register": "ecx",
+          "bit": 14
+        },
+        {
+          "name": "rdpid",
+          "register": "ecx",
+          "bit": 22
+        },
+        {
+          "name": "cldemote",
+          "register": "ecx",
+          "bit": 25
+        },
+        {
+          "name": "movdiri",
+          "register": "ecx",
+          "bit": 27
+        },
+        {
+          "name": "movdir64b",
+          "register": "ecx",
+          "bit": 28
+        },
+        {
+          "name": "enqcmd",
+          "register": "ecx",
+          "bit": 29
+        },
+        {
+          "name": "sgx_lc",
+          "register": "ecx",
+          "bit": 30
+        },
+        {
+          "name": "pks",
+          "register": "ecx",
+          "bit": 31
+        },
+        {
+          "name": "fsrm",
+          "register": "edx",
+          "bit": 4
+        },
+        {
+          "name": "avx512_vp2intersect",
+          "register": "edx",
+          "bit": 8
+        },
+        {
+          "name": "md_clear",
+          "register": "edx",
+          "bit": 10
+        },
+        {
+          "name": "serialize",
+          "register": "edx",
+          "bit": 14
+        },
+        {
+          "name": "tsxldtrk",
+          "register": "edx",
+          "bit": 16
+        },
+        {
+          "name": "amx_bf16",
+          "register": "edx",
+          "bit": 22
+        },
+        {
+          "name": "avx512_fp16",
+          "register": "edx",
+          "bit": 23
+        },
+        {
+          "name": "amx_tile",
+          "register": "edx",
+          "bit": 24
+        },
+        {
+          "name": "amx_int8",
+          "register": "edx",
+          "bit": 25
+        },
+        {
+          "name": "ssbd",
+          "register": "edx",
+          "bit": 31
+        }
+      ]
+    },
+    {
+      "description": "https://en.wikipedia.org/wiki/CPUID#EAX=7,_ECX=0:_Extended_Features",
+      "input": {
+        "eax": 7,
+        "ecx": 1
+      },
+      "bits": [
+        {
+          "name": "sha512",
+          "register": "eax",
+          "bit": 0
+        },
+        {
+          "name": "sm3",
+          "register": "eax",
+          "bit": 1
+        },
+        {
+          "name": "sm4",
+          "register": "eax",
+          "bit": 2
+        },
+        {
+          "name": "rao_int",
+          "register": "eax",
+          "bit": 3
+        },
+        {
+          "name": "avx_vnni",
+          "register": "eax",
+          "bit": 4
+        },
+        {
+          "name": "avx512_bf16",
+          "register": "eax",
+          "bit": 5
+        },
+        {
+          "name": "cmpccxadd",
+          "register": "eax",
+          "bit": 7
+        },
+        {
+          "name": "arch_perfmon_ext",
+          "register": "eax",
+          "bit": 8
+        },
+        {
+          "name": "fzrm",
+          "register": "eax",
+          "bit": 10
+        },
+        {
+          "name": "fsrs",
+          "register": "eax",
+          "bit": 11
+        },
+        {
+          "name": "fsrc",
+          "register": "eax",
+          "bit": 12
+        },
+        {
+          "name": "lkgs",
+          "register": "eax",
+          "bit": 18
+        },
+        {
+          "name": "amx_fp16",
+          "register": "eax",
+          "bit": 21
+        },
+        {
+          "name": "avx_ifma",
+          "register": "eax",
+          "bit": 23
+        },
+        {
+          "name": "lam",
+          "register": "eax",
+          "bit": 26
+        }
+      ]
+    },
+    {
+      "description": "https://en.wikipedia.org/wiki/CPUID#EAX=0Dh:_XSAVE_features_and_state-components",
+      "input": {
+        "eax": 13,
+        "ecx": 1
+      },
+      "bits": [
+        {
+          "name": "xsaveopt",
+          "register": "eax",
+          "bit": 0
+        },
+        {
+          "name": "xsavec",
+          "register": "eax",
+          "bit": 1
+        },
+        {
+          "name": "xgetbv1",
+          "register": "eax",
+          "bit": 2
+        },
+        {
+          "name": "xsaves",
+          "register": "eax",
+          "bit": 3
+        },
+        {
+          "name": "xfd",
+          "register": "eax",
+          "bit": 4
+        }
+      ]
+    }
+  ],
+  "extension-flags": [
+    {
+      "description": "https://en.wikipedia.org/wiki/CPUID#EAX=0Dh:_XSAVE_features_and_state-components",
+      "input": {
+        "eax": 2147483649,
+        "ecx": 0
+      },
+      "bits": [
+        {
+          "name": "fpu",
+          "register": "edx",
+          "bit": 0
+        },
+        {
+          "name": "vme",
+          "register": "edx",
+          "bit": 1
+        },
+        {
+          "name": "de",
+          "register": "edx",
+          "bit": 2
+        },
+        {
+          "name": "pse",
+          "register": "edx",
+          "bit": 3
+        },
+        {
+          "name": "tsc",
+          "register": "edx",
+          "bit": 4
+        },
+        {
+          "name": "msr",
+          "register": "edx",
+          "bit": 5
+        },
+        {
+          "name": "pae",
+          "register": "edx",
+          "bit": 6
+        },
+        {
+          "name": "mce",
+          "register": "edx",
+          "bit": 7
+        },
+        {
+          "name": "cx8",
+          "register": "edx",
+          "bit": 8
+        },
+        {
+          "name": "apic",
+          "register": "edx",
+          "bit": 9
+        },
+        {
+          "name": "syscall",
+          "register": "edx",
+          "bit": 10
+        },
+        {
+          "name": "syscall",
+          "register": "edx",
+          "bit": 11
+        },
+        {
+          "name": "mtrr",
+          "register": "edx",
+          "bit": 12
+        },
+        {
+          "name": "pge",
+          "register": "edx",
+          "bit": 13
+        },
+        {
+          "name": "mca",
+          "register": "edx",
+          "bit": 14
+        },
+        {
+          "name": "cmov",
+          "register": "edx",
+          "bit": 15
+        },
+        {
+          "name": "pat",
+          "register": "edx",
+          "bit": 16
+        },
+        {
+          "name": "pse36",
+          "register": "edx",
+          "bit": 17
+        },
+        {
+          "name": "mp",
+          "register": "edx",
+          "bit": 19
+        },
+        {
+          "name": "nx",
+          "register": "edx",
+          "bit": 20
+        },
+        {
+          "name": "mmxext",
+          "register": "edx",
+          "bit": 22
+        },
+        {
+          "name": "mmx",
+          "register": "edx",
+          "bit": 23
+        },
+        {
+          "name": "fxsr",
+          "register": "edx",
+          "bit": 24
+        },
+        {
+          "name": "fxsr_opt",
+          "register": "edx",
+          "bit": 25
+        },
+        {
+          "name": "pdpe1gp",
+          "register": "edx",
+          "bit": 26
+        },
+        {
+          "name": "rdtscp",
+          "register": "edx",
+          "bit": 27
+        },
+        {
+          "name": "lm",
+          "register": "edx",
+          "bit": 29
+        },
+        {
+          "name": "3dnowext",
+          "register": "edx",
+          "bit": 30
+        },
+        {
+          "name": "3dnow",
+          "register": "edx",
+          "bit": 31
+        },
+        {
+          "name": "lahf_lm",
+          "register": "ecx",
+          "bit": 0
+        },
+        {
+          "name": "cmp_legacy",
+          "register": "ecx",
+          "bit": 1
+        },
+        {
+          "name": "svm",
+          "register": "ecx",
+          "bit": 2
+        },
+        {
+          "name": "extapic",
+          "register": "ecx",
+          "bit": 3
+        },
+        {
+          "name": "cr8_legacy",
+          "register": "ecx",
+          "bit": 4
+        },
+        {
+          "name": "abm",
+          "register": "ecx",
+          "bit": 5
+        },
+        {
+          "name": "sse4a",
+          "register": "ecx",
+          "bit": 6
+        },
+        {
+          "name": "misalignsse",
+          "register": "ecx",
+          "bit": 7
+        },
+        {
+          "name": "3dnowprefetch",
+          "register": "ecx",
+          "bit": 8
+        },
+        {
+          "name": "osvw",
+          "register": "ecx",
+          "bit": 9
+        },
+        {
+          "name": "ibs",
+          "register": "ecx",
+          "bit": 10
+        },
+        {
+          "name": "xop",
+          "register": "ecx",
+          "bit": 11
+        },
+        {
+          "name": "skinit",
+          "register": "ecx",
+          "bit": 12
+        },
+        {
+          "name": "wdt",
+          "register": "ecx",
+          "bit": 13
+        },
+        {
+          "name": "lwp",
+          "register": "ecx",
+          "bit": 15
+        },
+        {
+          "name": "fma4",
+          "register": "ecx",
+          "bit": 16
+        },
+        {
+          "name": "tce",
+          "register": "ecx",
+          "bit": 17
+        },
+        {
+          "name": "nodeid_msr",
+          "register": "ecx",
+          "bit": 19
+        },
+        {
+          "name": "tbm",
+          "register": "ecx",
+          "bit": 21
+        },
+        {
+          "name": "topoext",
+          "register": "ecx",
+          "bit": 22
+        },
+        {
+          "name": "perfctr_core",
+          "register": "ecx",
+          "bit": 23
+        },
+        {
+          "name": "perfctr_nb",
+          "register": "ecx",
+          "bit": 24
+        },
+        {
+          "name": "dbx",
+          "register": "ecx",
+          "bit": 26
+        },
+        {
+          "name": "perftsc",
+          "register": "ecx",
+          "bit": 27
+        },
+        {
+          "name": "pci_l2i",
+          "register": "ecx",
+          "bit": 28
+        },
+        {
+          "name": "mwaitx",
+          "register": "ecx",
+          "bit": 29
+        }
+      ]
+    }
+  ]
+}

--- a/lib/spack/external/archspec/json/cpu/cpuid_schema.json
+++ b/lib/spack/external/archspec/json/cpu/cpuid_schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Schema for microarchitecture definitions and feature aliases",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "vendor": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "input": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "eax": {
+              "type": "integer"
+            },
+            "ecx": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    },
+    "highest_extension_support": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "input": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "eax": {
+              "type": "integer"
+            },
+            "ecx": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    },
+    "flags": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "input": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "eax": {
+                "type": "integer"
+              },
+              "ecx": {
+                "type": "integer"
+              }
+            }
+          },
+          "bits": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "register": {
+                  "type": "string"
+                },
+                "bit": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "extension-flags": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "input": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "eax": {
+                "type": "integer"
+              },
+              "ecx": {
+                "type": "integer"
+              }
+            }
+          },
+          "bits": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "register": {
+                  "type": "string"
+                },
+                "bit": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/spack/external/archspec/json/cpu/microarchitectures.json
+++ b/lib/spack/external/archspec/json/cpu/microarchitectures.json
@@ -2937,8 +2937,6 @@
           "ilrcpc",
           "flagm",
           "ssbs",
-          "paca",
-          "pacg",
           "dcpodp",
           "svei8mm",
           "svebf16",
@@ -3066,8 +3064,6 @@
 	  "flagm",
 	  "ssbs",
 	  "sb",
-	  "paca",
-	  "pacg",
 	  "dcpodp",
 	  "sve2",
 	  "sveaes",
@@ -3081,8 +3077,7 @@
 	  "svebf16",
 	  "i8mm",
 	  "bf16",
-	  "dgh",
-	  "bti"
+	  "dgh"
       ],
       "compilers" : {
           "gcc": [

--- a/lib/spack/external/archspec/json/cpu/microarchitectures.json
+++ b/lib/spack/external/archspec/json/cpu/microarchitectures.json
@@ -2844,8 +2844,7 @@
           "asimdrdm",
           "lrcpc",
           "dcpop",
-          "asimddp",
-          "ssbs"
+          "asimddp"
       ],
       "compilers" : {
           "gcc": [
@@ -2942,7 +2941,6 @@
           "uscat",
           "ilrcpc",
           "flagm",
-          "ssbs",
           "dcpodp",
           "svei8mm",
           "svebf16",
@@ -3010,7 +3008,7 @@
               },
               {
                   "versions": "11:",
-                  "flags" : "-march=armv8.4-a+sve+ssbs+fp16+bf16+crypto+i8mm+rng"
+                  "flags" : "-march=armv8.4-a+sve+fp16+bf16+crypto+i8mm+rng"
               },
               {
                   "versions": "12:",
@@ -3066,7 +3064,6 @@
 	  "uscat",
 	  "ilrcpc",
 	  "flagm",
-	  "ssbs",
 	  "sb",
 	  "dcpodp",
 	  "sve2",
@@ -3179,7 +3176,6 @@
 	  "uscat",
 	  "ilrcpc",
 	  "flagm",
-	  "ssbs",
 	  "sb",
 	  "dcpodp",
 	  "sve2",

--- a/lib/spack/external/archspec/json/cpu/microarchitectures.json
+++ b/lib/spack/external/archspec/json/cpu/microarchitectures.json
@@ -2225,10 +2225,14 @@
         ],
         "nvhpc": [
           {
-            "versions": "21.11:",
+            "versions": "21.11:23.8",
 	    "name": "zen3",
             "flags": "-tp {name}",
-	    "warnings": "zen4 is not fully supported by nvhpc yet, falling back to zen3"
+	    "warnings": "zen4 is not fully supported by nvhpc versions < 23.9, falling back to zen3"
+          },
+          {
+            "versions": "23.9:",
+            "flags": "-tp {name}"
           }
 	]
       }
@@ -2711,7 +2715,8 @@
             "flags": "-mcpu=thunderx2t99"
           }
         ]
-      }
+      },
+      "cpupart": "0x0af"
     },
     "a64fx": {
       "from": ["armv8.2a"],
@@ -2779,7 +2784,8 @@
             "flags": "-march=armv8.2-a+crc+crypto+fp16+sve"
           }
         ]
-      }
+      },
+      "cpupart": "0x001"
     },
     "cortex_a72": {
       "from": ["aarch64"],
@@ -2816,7 +2822,8 @@
                   "flags" : "-mcpu=cortex-a72"
               }
           ]
-      }
+      },
+      "cpupart": "0xd08"
     },
     "neoverse_n1": {
       "from": ["cortex_a72", "armv8.2a"],
@@ -2902,7 +2909,8 @@
                   "flags": "-tp {name}"
               }
           ]
-      }
+      },
+      "cpupart": "0xd0c"
     },
     "neoverse_v1": {
       "from": ["neoverse_n1", "armv8.4a"],
@@ -2926,8 +2934,6 @@
           "lrcpc",
           "dcpop",
           "sha3",
-          "sm3",
-          "sm4",
           "asimddp",
           "sha512",
           "sve",
@@ -3028,7 +3034,8 @@
                   "flags": "-tp {name}"
               }
           ]
-      }
+      },
+      "cpupart": "0xd40"
     },
     "neoverse_v2": {
       "from": ["neoverse_n1", "armv9.0a"],
@@ -3052,13 +3059,10 @@
 	  "lrcpc",
 	  "dcpop",
 	  "sha3",
-	  "sm3",
-	  "sm4",
 	  "asimddp",
 	  "sha512",
 	  "sve",
 	  "asimdfhm",
-	  "dit",
 	  "uscat",
 	  "ilrcpc",
 	  "flagm",
@@ -3066,18 +3070,12 @@
 	  "sb",
 	  "dcpodp",
 	  "sve2",
-	  "sveaes",
-	  "svepmull",
-	  "svebitperm",
-	  "svesha3",
-	  "svesm4",
 	  "flagm2",
 	  "frint",
 	  "svei8mm",
 	  "svebf16",
 	  "i8mm",
-	  "bf16",
-	  "dgh"
+	  "bf16"
       ],
       "compilers" : {
           "gcc": [
@@ -3102,15 +3100,19 @@
                   "flags" : "-march=armv8.5-a+sve -mtune=cortex-a76"
               },
               {
-                  "versions": "10.0:11.99",
+                  "versions": "10.0:11.3.99",
                   "flags" : "-march=armv8.5-a+sve+sve2+i8mm+bf16 -mtune=cortex-a77"
               },
+	      {
+                  "versions": "11.4:11.99",
+                  "flags" : "-mcpu=neoverse-v2"
+              },
               {
-                  "versions": "12.0:12.99",
+                  "versions": "12.0:12.2.99",
                   "flags" : "-march=armv9-a+i8mm+bf16 -mtune=cortex-a710"
               },
 	      {
-                  "versions": "13.0:",
+                  "versions": "12.3:",
                   "flags" : "-mcpu=neoverse-v2"
               }
           ],
@@ -3145,7 +3147,113 @@
                   "flags": "-tp {name}"
               }
           ]
-      }
+      },
+      "cpupart": "0xd4f"
+    },
+    "neoverse_n2": {
+      "from": ["neoverse_n1", "armv9.0a"],
+      "vendor": "ARM",
+      "features": [
+          "fp",
+	  "asimd",
+	  "evtstrm",
+	  "aes",
+	  "pmull",
+	  "sha1",
+	  "sha2",
+	  "crc32",
+	  "atomics",
+	  "fphp",
+	  "asimdhp",
+	  "cpuid",
+	  "asimdrdm",
+	  "jscvt",
+	  "fcma",
+	  "lrcpc",
+	  "dcpop",
+	  "sha3",
+	  "asimddp",
+	  "sha512",
+	  "sve",
+	  "asimdfhm",
+	  "uscat",
+	  "ilrcpc",
+	  "flagm",
+	  "ssbs",
+	  "sb",
+	  "dcpodp",
+	  "sve2",
+	  "flagm2",
+	  "frint",
+	  "svei8mm",
+	  "svebf16",
+	  "i8mm",
+	  "bf16"
+      ],
+      "compilers" : {
+          "gcc": [
+              {
+                  "versions": "4.8:5.99",
+                  "flags": "-march=armv8-a"
+              },
+              {
+                  "versions": "6:6.99",
+                  "flags" : "-march=armv8.1-a"
+              },
+              {
+                  "versions": "7.0:7.99",
+                  "flags" : "-march=armv8.2-a -mtune=cortex-a72"
+              },
+              {
+                  "versions": "8.0:8.99",
+                  "flags" : "-march=armv8.4-a+sve -mtune=cortex-a72"
+              },
+              {
+                  "versions": "9.0:9.99",
+                  "flags" : "-march=armv8.5-a+sve -mtune=cortex-a76"
+              },
+              {
+                  "versions": "10.0:10.99",
+                  "flags" : "-march=armv8.5-a+sve+sve2+i8mm+bf16 -mtune=cortex-a77"
+              },
+              {
+                  "versions": "11.0:",
+                  "flags" : "-mcpu=neoverse-n2"
+              }
+          ],
+          "clang" : [
+              {
+                  "versions": "9.0:10.99",
+                  "flags" : "-march=armv8.5-a+sve"
+              },
+              {
+                  "versions": "11.0:13.99",
+                  "flags" : "-march=armv8.5-a+sve+sve2+i8mm+bf16"
+              },
+              {
+                  "versions": "14.0:15.99",
+                  "flags" : "-march=armv9-a+i8mm+bf16"
+              },
+              {
+                  "versions": "16.0:",
+                  "flags" : "-mcpu=neoverse-n2"
+              }
+          ],
+          "arm" : [
+              {
+                  "versions": "23.04.0:",
+                  "flags" : "-mcpu=neoverse-n2"
+              }
+          ],
+          "nvhpc" : [
+              {
+                  "versions": "23.3:",
+                  "name": "neoverse-n1",
+                  "flags": "-tp {name}"
+              }
+          ]
+      },
+      "cpupart": "0xd49"
     },
     "m1": {
       "from": ["armv8.4a"],
@@ -3211,7 +3319,8 @@
             "flags" : "-mcpu=apple-m1"
           }
         ]
-      }
+      },
+      "cpupart": "0x022"
     },
     "m2": {
       "from": ["m1", "armv8.5a"],
@@ -3289,7 +3398,8 @@
             "flags" : "-mcpu=apple-m2"
           }
         ]
-      }
+      },
+      "cpupart": "0x032"
     },
     "arm": {
       "from": [],

--- a/lib/spack/external/archspec/json/cpu/microarchitectures_schema.json
+++ b/lib/spack/external/archspec/json/cpu/microarchitectures_schema.json
@@ -52,6 +52,9 @@
                   }
                 }
               }
+            },
+            "cpupart": {
+              "type": "string"
             }
           },
           "required": [

--- a/lib/spack/external/archspec/vendor/cpuid/LICENSE
+++ b/lib/spack/external/archspec/vendor/cpuid/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Anders Høst
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/spack/external/archspec/vendor/cpuid/README.md
+++ b/lib/spack/external/archspec/vendor/cpuid/README.md
@@ -1,0 +1,76 @@
+cpuid.py
+========
+
+Now, this is silly!
+
+Pure Python library for accessing information about x86 processors
+by querying the [CPUID](http://en.wikipedia.org/wiki/CPUID)
+instruction. Well, not exactly pure Python...
+
+It works by allocating a small piece of virtual memory, copying
+a raw x86 function to that memory, giving the memory execute
+permissions and then calling the memory as a function. The injected
+function executes the CPUID instruction and copies the result back
+to a ctypes.Structure where is can be read by Python.
+
+It should work fine on both 32 and 64 bit versions of Windows and Linux
+running x86 processors. Apple OS X and other BSD systems should also work,
+not tested though...
+
+
+Why?
+----
+For poops and giggles. Plus, having access to a low-level feature
+without having to compile a C wrapper is pretty neat.
+
+
+Examples
+--------
+Getting info with eax=0:
+
+    import cpuid
+
+    q = cpuid.CPUID()
+    eax, ebx, ecx, edx = q(0)
+
+Running the files:
+
+    $ python example.py 
+    Vendor ID : GenuineIntel
+    CPU name  : Intel(R) Xeon(R) CPU           W3550  @ 3.07GHz
+    
+    Vector instructions supported:
+    SSE       : Yes
+    SSE2      : Yes
+    SSE3      : Yes
+    SSSE3     : Yes
+    SSE4.1    : Yes
+    SSE4.2    : Yes
+    SSE4a     : --
+    AVX       : --
+    AVX2      : --
+    
+    $ python cpuid.py
+    CPUID    A        B        C        D
+    00000000 0000000b 756e6547 6c65746e 49656e69
+    00000001 000106a5 00100800 009ce3bd bfebfbff
+    00000002 55035a01 00f0b2e4 00000000 09ca212c
+    00000003 00000000 00000000 00000000 00000000
+    00000004 00000000 00000000 00000000 00000000
+    00000005 00000040 00000040 00000003 00001120
+    00000006 00000003 00000002 00000001 00000000
+    00000007 00000000 00000000 00000000 00000000
+    00000008 00000000 00000000 00000000 00000000
+    00000009 00000000 00000000 00000000 00000000
+    0000000a 07300403 00000044 00000000 00000603
+    0000000b 00000000 00000000 00000095 00000000
+    80000000 80000008 00000000 00000000 00000000
+    80000001 00000000 00000000 00000001 28100800
+    80000002 65746e49 2952286c 6f655820 2952286e
+    80000003 55504320 20202020 20202020 57202020
+    80000004 30353533 20402020 37302e33 007a4847
+    80000005 00000000 00000000 00000000 00000000
+    80000006 00000000 00000000 01006040 00000000
+    80000007 00000000 00000000 00000000 00000100
+    80000008 00003024 00000000 00000000 00000000
+

--- a/lib/spack/external/archspec/vendor/cpuid/cpuid.py
+++ b/lib/spack/external/archspec/vendor/cpuid/cpuid.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+#
+#     Copyright (c) 2024 Anders Høst
+#
+
+from __future__ import print_function
+
+import platform
+import os
+import ctypes
+from ctypes import c_uint32, c_long, c_ulong, c_size_t, c_void_p, POINTER, CFUNCTYPE
+
+# Posix x86_64:
+# Three first call registers : RDI, RSI, RDX
+# Volatile registers         : RAX, RCX, RDX, RSI, RDI, R8-11
+
+# Windows x86_64:
+# Three first call registers : RCX, RDX, R8
+# Volatile registers         : RAX, RCX, RDX, R8-11
+
+# cdecl 32 bit:
+# Three first call registers : Stack (%esp)
+# Volatile registers         : EAX, ECX, EDX
+
+_POSIX_64_OPC = [
+        0x53,                    # push   %rbx
+        0x89, 0xf0,              # mov    %esi,%eax
+        0x89, 0xd1,              # mov    %edx,%ecx
+        0x0f, 0xa2,              # cpuid
+        0x89, 0x07,              # mov    %eax,(%rdi)
+        0x89, 0x5f, 0x04,        # mov    %ebx,0x4(%rdi)
+        0x89, 0x4f, 0x08,        # mov    %ecx,0x8(%rdi)
+        0x89, 0x57, 0x0c,        # mov    %edx,0xc(%rdi)
+        0x5b,                    # pop    %rbx
+        0xc3                     # retq
+]
+
+_WINDOWS_64_OPC = [
+        0x53,                    # push   %rbx
+        0x89, 0xd0,              # mov    %edx,%eax
+        0x49, 0x89, 0xc9,        # mov    %rcx,%r9
+        0x44, 0x89, 0xc1,        # mov    %r8d,%ecx
+        0x0f, 0xa2,              # cpuid
+        0x41, 0x89, 0x01,        # mov    %eax,(%r9)
+        0x41, 0x89, 0x59, 0x04,  # mov    %ebx,0x4(%r9)
+        0x41, 0x89, 0x49, 0x08,  # mov    %ecx,0x8(%r9)
+        0x41, 0x89, 0x51, 0x0c,  # mov    %edx,0xc(%r9)
+        0x5b,                    # pop    %rbx
+        0xc3                     # retq
+]
+
+_CDECL_32_OPC = [
+        0x53,                    # push   %ebx
+        0x57,                    # push   %edi
+        0x8b, 0x7c, 0x24, 0x0c,  # mov    0xc(%esp),%edi
+        0x8b, 0x44, 0x24, 0x10,  # mov    0x10(%esp),%eax
+        0x8b, 0x4c, 0x24, 0x14,  # mov    0x14(%esp),%ecx
+        0x0f, 0xa2,              # cpuid
+        0x89, 0x07,              # mov    %eax,(%edi)
+        0x89, 0x5f, 0x04,        # mov    %ebx,0x4(%edi)
+        0x89, 0x4f, 0x08,        # mov    %ecx,0x8(%edi)
+        0x89, 0x57, 0x0c,        # mov    %edx,0xc(%edi)
+        0x5f,                    # pop    %edi
+        0x5b,                    # pop    %ebx
+        0xc3                     # ret
+]
+
+is_windows = os.name == "nt"
+is_64bit = ctypes.sizeof(ctypes.c_voidp) == 8
+
+
+class CPUID_struct(ctypes.Structure):
+    _register_names = ("eax", "ebx", "ecx", "edx")
+    _fields_ = [(r, c_uint32) for r in _register_names]
+
+    def __getitem__(self, item):
+        if item not in self._register_names:
+            raise KeyError(item)
+        return getattr(self, item)
+
+    def __repr__(self):
+        return "eax=0x{:x}, ebx=0x{:x}, ecx=0x{:x}, edx=0x{:x}".format(self.eax, self.ebx, self.ecx, self.edx)
+
+
+class CPUID(object):
+    def __init__(self):
+        if platform.machine() not in ("AMD64", "x86_64", "x86", "i686"):
+            raise SystemError("Only available for x86")
+
+        if is_windows:
+            if is_64bit:
+                # VirtualAlloc seems to fail under some weird
+                # circumstances when ctypes.windll.kernel32 is
+                # used under 64 bit Python. CDLL fixes this.
+                self.win = ctypes.CDLL("kernel32.dll")
+                opc = _WINDOWS_64_OPC
+            else:
+                # Here ctypes.windll.kernel32 is needed to get the
+                # right DLL. Otherwise it will fail when running
+                # 32 bit Python on 64 bit Windows.
+                self.win = ctypes.windll.kernel32
+                opc = _CDECL_32_OPC
+        else:
+            opc = _POSIX_64_OPC if is_64bit else _CDECL_32_OPC
+
+        size = len(opc)
+        code = (ctypes.c_ubyte * size)(*opc)
+
+        if is_windows:
+            self.win.VirtualAlloc.restype = c_void_p
+            self.win.VirtualAlloc.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_ulong, ctypes.c_ulong]
+            self.addr = self.win.VirtualAlloc(None, size, 0x1000, 0x40)
+            if not self.addr:
+                raise MemoryError("Could not allocate RWX memory")
+            ctypes.memmove(self.addr, code, size)
+        else:
+            from mmap import (
+                mmap,
+                MAP_PRIVATE,
+                MAP_ANONYMOUS,
+                PROT_WRITE,
+                PROT_READ,
+                PROT_EXEC,
+            )
+            self.mm = mmap(
+                -1,
+                size,
+                flags=MAP_PRIVATE | MAP_ANONYMOUS,
+                prot=PROT_WRITE | PROT_READ | PROT_EXEC,
+            )
+            self.mm.write(code)
+            self.addr = ctypes.addressof(ctypes.c_int.from_buffer(self.mm))
+
+        func_type = CFUNCTYPE(None, POINTER(CPUID_struct), c_uint32, c_uint32)
+        self.func_ptr = func_type(self.addr)
+
+    def __call__(self, eax, ecx=0):
+        struct = self.registers_for(eax=eax, ecx=ecx)
+        return struct.eax, struct.ebx, struct.ecx, struct.edx
+
+    def registers_for(self, eax, ecx=0):
+        """Calls cpuid with eax and ecx set as the input arguments, and returns a structure
+        containing eax, ebx, ecx, and edx.
+        """
+        struct = CPUID_struct()
+        self.func_ptr(struct, eax, ecx)
+        return struct
+
+    def __del__(self):
+        if is_windows:
+            self.win.VirtualFree.restype = c_long
+            self.win.VirtualFree.argtypes = [c_void_p, c_size_t, c_ulong]
+            self.win.VirtualFree(self.addr, 0, 0x8000)
+        else:
+            self.mm.close()
+
+
+
+if __name__ == "__main__":
+    def valid_inputs():
+        cpuid = CPUID()
+        for eax in (0x0, 0x80000000):
+            highest, _, _, _ = cpuid(eax)
+            while eax <= highest:
+                regs = cpuid(eax)
+                yield (eax, regs)
+                eax += 1
+
+
+    print(" ".join(x.ljust(8) for x in ("CPUID", "A", "B", "C", "D")).strip())
+    for eax, regs in valid_inputs():
+        print("%08x" % eax, " ".join("%08x" % reg for reg in regs))

--- a/lib/spack/external/archspec/vendor/cpuid/example.py
+++ b/lib/spack/external/archspec/vendor/cpuid/example.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+#     Copyright (c) 2024 Anders Høst
+#
+
+from __future__ import print_function
+
+import struct
+import cpuid
+
+
+def cpu_vendor(cpu):
+    _, b, c, d = cpu(0)
+    return struct.pack("III", b, d, c).decode("utf-8")
+
+
+def cpu_name(cpu):
+    name = "".join((struct.pack("IIII", *cpu(0x80000000 + i)).decode("utf-8")
+                    for i in range(2, 5)))
+
+    return name.split('\x00', 1)[0]
+
+
+def is_set(cpu, leaf, subleaf, reg_idx, bit):
+    """
+    @param {leaf} %eax
+    @param {sublead} %ecx, 0 in most cases
+    @param {reg_idx} idx of [%eax, %ebx, %ecx, %edx], 0-based
+    @param {bit} bit of reg selected by {reg_idx}, 0-based
+    """
+
+    regs = cpu(leaf, subleaf)
+
+    if (1 << bit) & regs[reg_idx]:
+        return "Yes"
+    else:
+        return "--"
+
+
+if __name__ == "__main__":
+    cpu = cpuid.CPUID()
+
+    print("Vendor ID : %s" % cpu_vendor(cpu))
+    print("CPU name  : %s" % cpu_name(cpu))
+    print()
+    print("Vector instructions supported:")
+    print("SSE       : %s" % is_set(cpu, 1, 0, 3, 25))
+    print("SSE2      : %s" % is_set(cpu, 1, 0, 3, 26))
+    print("SSE3      : %s" % is_set(cpu, 1, 0, 2, 0))
+    print("SSSE3     : %s" % is_set(cpu, 1, 0, 2, 9))
+    print("SSE4.1    : %s" % is_set(cpu, 1, 0, 2, 19))
+    print("SSE4.2    : %s" % is_set(cpu, 1, 0, 2, 20))
+    print("SSE4a     : %s" % is_set(cpu, 0x80000001, 0, 2, 6))
+    print("AVX       : %s" % is_set(cpu, 1, 0, 2, 28))
+    print("AVX2      : %s" % is_set(cpu, 7, 0, 1, 5))
+    print("BMI1      : %s" % is_set(cpu, 7, 0, 1, 3))
+    print("BMI2      : %s" % is_set(cpu, 7, 0, 1, 8))
+    # Intel RDT CMT/MBM
+    print("L3 Monitoring : %s" % is_set(cpu, 0xf, 0, 3, 1))
+    print("L3 Occupancy  : %s" % is_set(cpu, 0xf, 1, 3, 0))
+    print("L3 Total BW   : %s" % is_set(cpu, 0xf, 1, 3, 1))
+    print("L3 Local BW   : %s" % is_set(cpu, 0xf, 1, 3, 2))

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-__version__ = "0.21.3.dev0"
+__version__ = "0.21.3"
 spack_version = __version__
 
 

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 #: PEP440 canonical <major>.<minor>.<micro>.<devN> string
-__version__ = "0.21.2"
+__version__ = "0.21.3.dev0"
 spack_version = __version__
 
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2380,6 +2380,9 @@ def get_keys(install=False, trust=False, force=False, mirrors=None):
 
     for mirror in mirror_collection.values():
         fetch_url = mirror.fetch_url
+        # TODO: oci:// does not support signing.
+        if fetch_url.startswith("oci://"):
+            continue
         keys_url = url_util.join(
             fetch_url, BUILD_CACHE_RELATIVE_PATH, BUILD_CACHE_KEYS_RELATIVE_PATH
         )

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -789,7 +789,7 @@ def setup_package(pkg, dirty, context: Context = Context.BUILD):
         for mod in ["cray-mpich", "cray-libsci"]:
             module("unload", mod)
 
-    if target.module_name:
+    if target and target.module_name:
         load_module(target.module_name)
 
     load_external_modules(pkg)

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -112,16 +112,16 @@ def _to_dict(compiler):
 def get_compiler_config(scope=None, init_config=True):
     """Return the compiler configuration for the specified architecture."""
 
-    config = spack.config.get("compilers", scope=scope) or []
+    config = spack.config.CONFIG.get("compilers", scope=scope) or []
     if config or not init_config:
         return config
 
-    merged_config = spack.config.get("compilers")
+    merged_config = spack.config.CONFIG.get("compilers")
     if merged_config:
         return config
 
     _init_compiler_config(scope=scope)
-    config = spack.config.get("compilers", scope=scope)
+    config = spack.config.CONFIG.get("compilers", scope=scope)
     return config
 
 

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 from typing import Dict, List, Set
 
+import archspec.cpu
+
 import spack.compiler
 import spack.operating_systems.windows_os
 import spack.platforms
@@ -185,6 +187,9 @@ class Msvc(Compiler):
         # get current platform architecture and format for vcvars argument
         arch = spack.platforms.real_host().default.lower()
         arch = arch.replace("-", "_")
+        if str(archspec.cpu.host().family) == "x86_64":
+            arch = "amd64"
+
         self.vcvars_call = VCVarsInvocation(vcvars_script_path, arch, self.msvc_version)
         env_cmds.append(self.vcvars_call)
         # Below is a check for a valid fortran path

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -463,6 +463,8 @@ def _depends_on(pkg, spec, when=None, type=dt.DEFAULT_TYPES, patches=None):
     dep_spec = spack.spec.Spec(spec)
     if not dep_spec.name:
         raise DependencyError("Invalid dependency specification in package '%s':" % pkg.name, spec)
+    elif dep_spec.name in ("c", "cxx", "fortran"):  # forward compat for language deps
+        return
     if pkg.name == dep_spec.name:
         raise CircularReferenceError("Package '%s' cannot depend on itself." % pkg.name)
 

--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -143,6 +143,7 @@ class MacOs(OperatingSystem):
             "12": "monterey",
             "13": "ventura",
             "14": "sonoma",
+            "15": "sequoia",
         }
 
         version = macos_version()

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2185,7 +2185,7 @@ class SpackSolverSetup:
             try:
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
-                    target.optimization_flags(compiler_name, compiler_version)
+                    target.optimization_flags(compiler_name, str(compiler_version))
                 supported.append(target)
             except archspec.cpu.UnsupportedMicroarchitecture:
                 continue

--- a/lib/spack/spack/solver/os_compatibility.lp
+++ b/lib/spack/spack/solver/os_compatibility.lp
@@ -10,6 +10,7 @@
 %=============================================================================
 
 % macOS
+os_compatible("sequoia", "sonoma").
 os_compatible("sonoma", "ventura").
 os_compatible("ventura", "monterey").
 os_compatible("monterey", "bigsur").

--- a/lib/spack/spack/solver/os_compatibility.lp
+++ b/lib/spack/spack/solver/os_compatibility.lp
@@ -10,6 +10,8 @@
 %=============================================================================
 
 % macOS
+os_compatible("sonoma", "ventura").
+os_compatible("ventura", "monterey").
 os_compatible("monterey", "bigsur").
 os_compatible("bigsur", "catalina").
 

--- a/lib/spack/spack/target.py
+++ b/lib/spack/spack/target.py
@@ -102,7 +102,10 @@ class Target:
         if self.microarchitecture.vendor == "generic":
             return str(self)
 
-        return syaml.syaml_dict(self.microarchitecture.to_dict(return_list_of_items=True))
+        # Get rid of compiler flag information before turning the uarch into a dict
+        uarch_dict = self.microarchitecture.to_dict()
+        uarch_dict.pop("compilers", None)
+        return syaml.syaml_dict(uarch_dict.items())
 
     def __repr__(self):
         cls_name = self.__class__.__name__

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -8,13 +8,16 @@ import sys
 
 import pytest
 
+import archspec.cpu
+
 import llnl.util.filesystem as fs
 
+import spack.compilers
 import spack.concretize
 import spack.operating_systems
 import spack.platforms
 import spack.target
-from spack.spec import ArchSpec, CompilerSpec, Spec
+from spack.spec import ArchSpec, Spec
 
 
 @pytest.fixture(scope="module")
@@ -121,52 +124,60 @@ def test_arch_spec_container_semantic(item, architecture_str):
 @pytest.mark.parametrize(
     "compiler_spec,target_name,expected_flags",
     [
-        # Check compilers with version numbers from a single toolchain
+        # Homogeneous compilers
         ("gcc@4.7.2", "ivybridge", "-march=core-avx-i -mtune=core-avx-i"),
-        # Check mixed toolchains
-        ("clang@8.0.0", "broadwell", ""),
         ("clang@3.5", "x86_64", "-march=x86-64 -mtune=generic"),
-        # Check Apple's Clang compilers
         ("apple-clang@9.1.0", "x86_64", "-march=x86-64"),
+        # Mixed toolchain
+        ("clang@8.0.0", "broadwell", ""),
     ],
 )
 @pytest.mark.filterwarnings("ignore:microarchitecture specific")
-def test_optimization_flags(compiler_spec, target_name, expected_flags, config):
+def test_optimization_flags(compiler_spec, target_name, expected_flags, compiler_factory):
     target = spack.target.Target(target_name)
-    compiler = spack.compilers.compilers_for_spec(compiler_spec).pop()
+    compiler_dict = compiler_factory(spec=compiler_spec, operating_system="")["compiler"]
+    if compiler_spec == "clang@8.0.0":
+        compiler_dict["paths"] = {
+            "cc": "/path/to/clang-8",
+            "cxx": "/path/to/clang++-8",
+            "f77": "/path/to/gfortran-9",
+            "fc": "/path/to/gfortran-9",
+        }
+    compiler = spack.compilers.compiler_from_dict(compiler_dict)
+
     opt_flags = target.optimization_flags(compiler)
     assert opt_flags == expected_flags
 
 
 @pytest.mark.parametrize(
-    "compiler,real_version,target_str,expected_flags",
+    "compiler_str,real_version,target_str,expected_flags",
     [
-        (CompilerSpec("gcc@=9.2.0"), None, "haswell", "-march=haswell -mtune=haswell"),
+        ("gcc@=9.2.0", None, "haswell", "-march=haswell -mtune=haswell"),
         # Check that custom string versions are accepted
-        (
-            CompilerSpec("gcc@=10foo"),
-            "9.2.0",
-            "icelake",
-            "-march=icelake-client -mtune=icelake-client",
-        ),
+        ("gcc@=10foo", "9.2.0", "icelake", "-march=icelake-client -mtune=icelake-client"),
         # Check that we run version detection (4.4.0 doesn't support icelake)
-        (
-            CompilerSpec("gcc@=4.4.0-special"),
-            "9.2.0",
-            "icelake",
-            "-march=icelake-client -mtune=icelake-client",
-        ),
+        ("gcc@=4.4.0-special", "9.2.0", "icelake", "-march=icelake-client -mtune=icelake-client"),
         # Check that the special case for Apple's clang is treated correctly
         # i.e. it won't try to detect the version again
-        (CompilerSpec("apple-clang@=9.1.0"), None, "x86_64", "-march=x86-64"),
+        ("apple-clang@=9.1.0", None, "x86_64", "-march=x86-64"),
     ],
 )
 def test_optimization_flags_with_custom_versions(
-    compiler, real_version, target_str, expected_flags, monkeypatch, config
+    compiler_str,
+    real_version,
+    target_str,
+    expected_flags,
+    monkeypatch,
+    mutable_config,
+    compiler_factory,
 ):
     target = spack.target.Target(target_str)
+    compiler_dict = compiler_factory(spec=compiler_str, operating_system="redhat6")
+    mutable_config.set("compilers", [compiler_dict])
     if real_version:
         monkeypatch.setattr(spack.compiler.Compiler, "get_real_version", lambda x: real_version)
+    compiler = spack.compilers.compiler_from_dict(compiler_dict["compiler"])
+
     opt_flags = target.optimization_flags(compiler)
     assert opt_flags == expected_flags
 
@@ -201,9 +212,10 @@ def test_satisfy_strict_constraint_when_not_concrete(architecture_tuple, constra
 )
 @pytest.mark.usefixtures("mock_packages", "config")
 @pytest.mark.only_clingo("Fixing the parser broke this test for the original concretizer.")
+@pytest.mark.skipif(
+    str(archspec.cpu.host().family) != "x86_64", reason="tests are for x86_64 uarch ranges"
+)
 def test_concretize_target_ranges(root_target_range, dep_target_range, result, monkeypatch):
-    # Monkeypatch so that all concretization is done as if the machine is core2
-    monkeypatch.setattr(spack.platforms.test.Test, "default", "core2")
     spec = Spec(f"a %gcc@10 foobar=bar target={root_target_range} ^b target={dep_target_range}")
     with spack.concretize.disable_compiler_existence_check():
         spec.concretize()

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -216,10 +216,12 @@ def test_satisfy_strict_constraint_when_not_concrete(architecture_tuple, constra
     str(archspec.cpu.host().family) != "x86_64", reason="tests are for x86_64 uarch ranges"
 )
 def test_concretize_target_ranges(root_target_range, dep_target_range, result, monkeypatch):
-    spec = Spec(f"a %gcc@10 foobar=bar target={root_target_range} ^b target={dep_target_range}")
+    spec = Spec(
+        f"pkg-a %gcc@10 foobar=bar target={root_target_range} ^pkg-b target={dep_target_range}"
+    )
     with spack.concretize.disable_compiler_existence_check():
         spec.concretize()
-    assert spec.target == spec["b"].target == result
+    assert spec.target == spec["pkg-b"].target == result
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -19,6 +19,8 @@ from pathlib import PurePath
 import py
 import pytest
 
+import archspec.cpu
+
 from llnl.util.filesystem import join_path, visit_directory_tree
 
 import spack.binary_distribution as bindist
@@ -573,11 +575,20 @@ def test_update_sbang(tmpdir, test_mirror):
         uninstall_cmd("-y", "/%s" % new_spec.dag_hash())
 
 
-def test_install_legacy_buildcache_layout(install_mockery_mutable_config):
+@pytest.mark.skipif(
+    str(archspec.cpu.host().family) != "x86_64",
+    reason="test data uses gcc 4.5.0 which does not support aarch64",
+)
+def test_install_legacy_buildcache_layout(
+    mutable_config, compiler_factory, install_mockery_mutable_config
+):
     """Legacy buildcache layout involved a nested archive structure
     where the .spack file contained a repeated spec.json and another
     compressed archive file containing the install tree.  This test
     makes sure we can still read that layout."""
+    mutable_config.set(
+        "compilers", [compiler_factory(spec="gcc@4.5.0", operating_system="debian6")]
+    )
     legacy_layout_dir = os.path.join(test_path, "data", "mirrors", "legacy_layout")
     mirror_url = "file://{0}".format(legacy_layout_dir)
     filename = (

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -437,14 +437,14 @@ def test_parallel_false_is_not_propagating(default_mock_concretization):
     # a foobar=bar (parallel = False)
     # |
     # b (parallel =True)
-    s = default_mock_concretization("a foobar=bar")
+    s = default_mock_concretization("pkg-a foobar=bar")
 
     spack.build_environment.set_package_py_globals(s.package)
-    assert s["a"].package.module.make_jobs == 1
+    assert s["pkg-a"].package.module.make_jobs == 1
 
-    spack.build_environment.set_package_py_globals(s["b"].package)
-    assert s["b"].package.module.make_jobs == spack.build_environment.determine_number_of_jobs(
-        parallel=s["b"].package.parallel
+    spack.build_environment.set_package_py_globals(s["pkg-b"].package)
+    assert s["pkg-b"].package.module.make_jobs == spack.build_environment.determine_number_of_jobs(
+        parallel=s["pkg-b"].package.parallel
     )
 
 
@@ -540,7 +540,7 @@ def test_dirty_disable_module_unload(config, mock_packages, working_env, mock_mo
     """Test that on CRAY platform 'module unload' is not called if the 'dirty'
     option is on.
     """
-    s = spack.spec.Spec("a").concretized()
+    s = spack.spec.Spec("pkg-a").concretized()
 
     # If called with "dirty" we don't unload modules, so no calls to the
     # `module` function on Cray

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -9,6 +9,8 @@ import os
 import py.path
 import pytest
 
+import archspec.cpu
+
 import llnl.util.filesystem as fs
 
 import spack.build_systems.autotools
@@ -209,6 +211,9 @@ class TestAutotoolsPackage:
             assert "gnuconfig version of config.guess" not in f.read()
 
     @pytest.mark.disable_clean_stage_check
+    @pytest.mark.skipif(
+        str(archspec.cpu.host().family) != "x86_64", reason="test data is specific for x86_64"
+    )
     def test_autotools_gnuconfig_replacement_no_gnuconfig(self, mutable_database, monkeypatch):
         """
         Tests whether a useful error message is shown when patch_config_files is

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -97,7 +97,7 @@ class TestTargets:
 @pytest.mark.usefixtures("config", "mock_packages")
 class TestAutotoolsPackage:
     def test_with_or_without(self, default_mock_concretization):
-        s = default_mock_concretization("a")
+        s = default_mock_concretization("pkg-a")
         options = s.package.with_or_without("foo")
 
         # Ensure that values that are not representing a feature
@@ -129,7 +129,7 @@ class TestAutotoolsPackage:
         assert "--without-lorem-ipsum" in options
 
     def test_none_is_allowed(self, default_mock_concretization):
-        s = default_mock_concretization("a foo=none")
+        s = default_mock_concretization("pkg-a foo=none")
         options = s.package.with_or_without("foo")
 
         # Ensure that values that are not representing a feature

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -102,24 +102,24 @@ and then 'd', 'b', and 'a' to be put in the next three stages, respectively.
 
 """
     builder = repo.MockRepositoryBuilder(tmpdir)
-    builder.add_package("g")
-    builder.add_package("f")
-    builder.add_package("e")
-    builder.add_package("d", dependencies=[("f", None, None), ("g", None, None)])
-    builder.add_package("c")
-    builder.add_package("b", dependencies=[("d", None, None), ("e", None, None)])
-    builder.add_package("a", dependencies=[("b", None, None), ("c", None, None)])
+    builder.add_package("pkg-g")
+    builder.add_package("pkg-f")
+    builder.add_package("pkg-e")
+    builder.add_package("pkg-d", dependencies=[("pkg-f", None, None), ("pkg-g", None, None)])
+    builder.add_package("pkg-c")
+    builder.add_package("pkg-b", dependencies=[("pkg-d", None, None), ("pkg-e", None, None)])
+    builder.add_package("pkg-a", dependencies=[("pkg-b", None, None), ("pkg-c", None, None)])
 
     with repo.use_repositories(builder.root):
-        spec_a = Spec("a").concretized()
+        spec_a = Spec("pkg-a").concretized()
 
         spec_a_label = ci._spec_deps_key(spec_a)
-        spec_b_label = ci._spec_deps_key(spec_a["b"])
-        spec_c_label = ci._spec_deps_key(spec_a["c"])
-        spec_d_label = ci._spec_deps_key(spec_a["d"])
-        spec_e_label = ci._spec_deps_key(spec_a["e"])
-        spec_f_label = ci._spec_deps_key(spec_a["f"])
-        spec_g_label = ci._spec_deps_key(spec_a["g"])
+        spec_b_label = ci._spec_deps_key(spec_a["pkg-b"])
+        spec_c_label = ci._spec_deps_key(spec_a["pkg-c"])
+        spec_d_label = ci._spec_deps_key(spec_a["pkg-d"])
+        spec_e_label = ci._spec_deps_key(spec_a["pkg-e"])
+        spec_f_label = ci._spec_deps_key(spec_a["pkg-f"])
+        spec_g_label = ci._spec_deps_key(spec_a["pkg-g"])
 
         spec_labels, dependencies, stages = ci.stage_spec_jobs([spec_a])
 
@@ -1256,7 +1256,7 @@ def test_ci_generate_override_runner_attrs(
 spack:
   specs:
     - flatten-deps
-    - a
+    - pkg-a
   mirrors:
     some-mirror: https://my.fake.mirror
   ci:
@@ -1273,12 +1273,12 @@ spack:
         - match:
             - dependency-install
         - match:
-            - a
+            - pkg-a
           build-job:
             tags:
               - specific-a-2
         - match:
-            - a
+            - pkg-a
           build-job-remove:
             tags:
               - toplevel2
@@ -1338,8 +1338,8 @@ spack:
             assert global_vars["SPACK_CHECKOUT_VERSION"] == git_version or "v0.20.0.test0"
 
             for ci_key in yaml_contents.keys():
-                if ci_key.startswith("a"):
-                    # Make sure a's attributes override variables, and all the
+                if ci_key.startswith("pkg-a"):
+                    # Make sure pkg-a's attributes override variables, and all the
                     # scripts.  Also, make sure the 'toplevel' tag doesn't
                     # appear twice, but that a's specific extra tag does appear
                     the_elt = yaml_contents[ci_key]
@@ -1798,7 +1798,7 @@ def test_ci_generate_read_broken_specs_url(
     tmpdir, mutable_mock_env_path, install_mockery, mock_packages, monkeypatch, ci_base_environment
 ):
     """Verify that `broken-specs-url` works as intended"""
-    spec_a = Spec("a")
+    spec_a = Spec("pkg-a")
     spec_a.concretize()
     a_dag_hash = spec_a.dag_hash()
 
@@ -1824,7 +1824,7 @@ def test_ci_generate_read_broken_specs_url(
 spack:
   specs:
     - flatten-deps
-    - a
+    - pkg-a
   mirrors:
     some-mirror: https://my.fake.mirror
   ci:
@@ -1832,9 +1832,9 @@ spack:
     pipeline-gen:
     - submapping:
       - match:
-          - a
+          - pkg-a
           - flatten-deps
-          - b
+          - pkg-b
           - dependency-install
         build-job:
           tags:

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -81,14 +81,14 @@ def test_match_spec_env(mock_packages, mutable_mock_env_path):
     """
     # Initial sanity check: we are planning on choosing a non-default
     # value, so make sure that is in fact not the default.
-    check_defaults = spack.cmd.parse_specs(["a"], concretize=True)[0]
+    check_defaults = spack.cmd.parse_specs(["pkg-a"], concretize=True)[0]
     assert not check_defaults.satisfies("foobar=baz")
 
     e = ev.create("test")
-    e.add("a foobar=baz")
+    e.add("pkg-a foobar=baz")
     e.concretize()
     with e:
-        env_spec = spack.cmd.matching_spec_from_env(spack.cmd.parse_specs(["a"])[0])
+        env_spec = spack.cmd.matching_spec_from_env(spack.cmd.parse_specs(["pkg-a"])[0])
         assert env_spec.satisfies("foobar=baz")
         assert env_spec.concrete
 
@@ -96,12 +96,12 @@ def test_match_spec_env(mock_packages, mutable_mock_env_path):
 @pytest.mark.usefixtures("config")
 def test_multiple_env_match_raises_error(mock_packages, mutable_mock_env_path):
     e = ev.create("test")
-    e.add("a foobar=baz")
-    e.add("a foobar=fee")
+    e.add("pkg-a foobar=baz")
+    e.add("pkg-a foobar=fee")
     e.concretize()
     with e:
         with pytest.raises(ev.SpackEnvironmentError) as exc_info:
-            spack.cmd.matching_spec_from_env(spack.cmd.parse_specs(["a"])[0])
+            spack.cmd.matching_spec_from_env(spack.cmd.parse_specs(["pkg-a"])[0])
 
     assert "matches multiple specs" in exc_info.value.message
 
@@ -109,16 +109,16 @@ def test_multiple_env_match_raises_error(mock_packages, mutable_mock_env_path):
 @pytest.mark.usefixtures("config")
 def test_root_and_dep_match_returns_root(mock_packages, mutable_mock_env_path):
     e = ev.create("test")
-    e.add("b@0.9")
-    e.add("a foobar=bar")  # Depends on b, should choose b@1.0
+    e.add("pkg-b@0.9")
+    e.add("pkg-a foobar=bar")  # Depends on b, should choose b@1.0
     e.concretize()
     with e:
         # This query matches the root b and b as a dependency of a. In that
         # case the root instance should be preferred.
-        env_spec1 = spack.cmd.matching_spec_from_env(spack.cmd.parse_specs(["b"])[0])
+        env_spec1 = spack.cmd.matching_spec_from_env(spack.cmd.parse_specs(["pkg-b"])[0])
         assert env_spec1.satisfies("@0.9")
 
-        env_spec2 = spack.cmd.matching_spec_from_env(spack.cmd.parse_specs(["b@1.0"])[0])
+        env_spec2 = spack.cmd.matching_spec_from_env(spack.cmd.parse_specs(["pkg-b@1.0"])[0])
         assert env_spec2
 
 

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -111,10 +111,10 @@ fi
 @pytest.mark.regression("37996")
 def test_compiler_remove(mutable_config, mock_packages):
     """Tests that we can remove a compiler from configuration."""
-    assert spack.spec.CompilerSpec("gcc@=4.5.0") in spack.compilers.all_compiler_specs()
-    args = spack.util.pattern.Bunch(all=True, compiler_spec="gcc@4.5.0", add_paths=[], scope=None)
+    assert spack.spec.CompilerSpec("gcc@=4.8.0") in spack.compilers.all_compiler_specs()
+    args = spack.util.pattern.Bunch(all=True, compiler_spec="gcc@4.8.0", add_paths=[], scope=None)
     spack.cmd.compiler.compiler_remove(args)
-    assert spack.spec.CompilerSpec("gcc@=4.5.0") not in spack.compilers.all_compiler_specs()
+    assert spack.spec.CompilerSpec("gcc@=4.8.0") not in spack.compilers.all_compiler_specs()
 
 
 @pytest.mark.regression("37996")
@@ -123,10 +123,10 @@ def test_removing_compilers_from_multiple_scopes(mutable_config, mock_packages):
     site_config = spack.config.get("compilers", scope="site")
     spack.config.set("compilers", site_config, scope="user")
 
-    assert spack.spec.CompilerSpec("gcc@=4.5.0") in spack.compilers.all_compiler_specs()
-    args = spack.util.pattern.Bunch(all=True, compiler_spec="gcc@4.5.0", add_paths=[], scope=None)
+    assert spack.spec.CompilerSpec("gcc@=4.8.0") in spack.compilers.all_compiler_specs()
+    args = spack.util.pattern.Bunch(all=True, compiler_spec="gcc@4.8.0", add_paths=[], scope=None)
     spack.cmd.compiler.compiler_remove(args)
-    assert spack.spec.CompilerSpec("gcc@=4.5.0") not in spack.compilers.all_compiler_specs()
+    assert spack.spec.CompilerSpec("gcc@=4.8.0") not in spack.compilers.all_compiler_specs()
 
 
 @pytest.mark.not_on_windows("Cannot execute bash script on Windows")

--- a/lib/spack/spack/test/cmd/concretize.py
+++ b/lib/spack/spack/test/cmd/concretize.py
@@ -51,8 +51,8 @@ def test_concretize_root_test_dependencies_are_concretized(unify, mutable_mock_e
 
     with ev.read("test") as e:
         e.unify = unify
-        add("a")
-        add("b")
+        add("pkg-a")
+        add("pkg-b")
         concretize("--test", "root")
         assert e.matching_spec("test-dependency")
 

--- a/lib/spack/spack/test/cmd/deconcretize.py
+++ b/lib/spack/spack/test/cmd/deconcretize.py
@@ -15,26 +15,26 @@ deconcretize = SpackCommand("deconcretize")
 def test_env(mutable_mock_env_path, config, mock_packages):
     ev.create("test")
     with ev.read("test") as e:
-        e.add("a@2.0 foobar=bar ^b@1.0")
-        e.add("a@1.0 foobar=bar ^b@0.9")
+        e.add("pkg-a@2.0 foobar=bar ^pkg-b@1.0")
+        e.add("pkg-a@1.0 foobar=bar ^pkg-b@0.9")
         e.concretize()
         e.write()
 
 
 def test_deconcretize_dep(test_env):
     with ev.read("test") as e:
-        deconcretize("-y", "b@1.0")
+        deconcretize("-y", "pkg-b@1.0")
         specs = [s for s, _ in e.concretized_specs()]
 
     assert len(specs) == 1
-    assert specs[0].satisfies("a@1.0")
+    assert specs[0].satisfies("pkg-a@1.0")
 
 
 def test_deconcretize_all_dep(test_env):
     with ev.read("test") as e:
         with pytest.raises(SpackCommandError):
-            deconcretize("-y", "b")
-        deconcretize("-y", "--all", "b")
+            deconcretize("-y", "pkg-b")
+        deconcretize("-y", "--all", "pkg-b")
         specs = [s for s, _ in e.concretized_specs()]
 
     assert len(specs) == 0
@@ -42,27 +42,27 @@ def test_deconcretize_all_dep(test_env):
 
 def test_deconcretize_root(test_env):
     with ev.read("test") as e:
-        output = deconcretize("-y", "--root", "b@1.0")
+        output = deconcretize("-y", "--root", "pkg-b@1.0")
         assert "No matching specs to deconcretize" in output
         assert len(e.concretized_order) == 2
 
-        deconcretize("-y", "--root", "a@2.0")
+        deconcretize("-y", "--root", "pkg-a@2.0")
         specs = [s for s, _ in e.concretized_specs()]
 
     assert len(specs) == 1
-    assert specs[0].satisfies("a@1.0")
+    assert specs[0].satisfies("pkg-a@1.0")
 
 
 def test_deconcretize_all_root(test_env):
     with ev.read("test") as e:
         with pytest.raises(SpackCommandError):
-            deconcretize("-y", "--root", "a")
+            deconcretize("-y", "--root", "pkg-a")
 
-        output = deconcretize("-y", "--root", "--all", "b")
+        output = deconcretize("-y", "--root", "--all", "pkg-b")
         assert "No matching specs to deconcretize" in output
         assert len(e.concretized_order) == 2
 
-        deconcretize("-y", "--root", "--all", "a")
+        deconcretize("-y", "--root", "--all", "pkg-a")
         specs = [s for s, _ in e.concretized_specs()]
 
     assert len(specs) == 0

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -27,7 +27,9 @@ import spack.modules
 import spack.package_base
 import spack.paths
 import spack.repo
+import spack.store
 import spack.util.spack_json as sjson
+import spack.util.spack_yaml
 from spack.cmd.env import _env_create
 from spack.main import SpackCommand, SpackCommandError
 from spack.spec import Spec
@@ -346,7 +348,7 @@ def test_env_install_two_specs_same_dep(install_mockery, mock_fetch, tmpdir, cap
                 """\
 spack:
   specs:
-  - a
+  - pkg-a
   - depb
 """
             )
@@ -365,8 +367,8 @@ spack:
     depb = spack.store.STORE.db.query_one("depb", installed=True)
     assert depb, "Expected depb to be installed"
 
-    a = spack.store.STORE.db.query_one("a", installed=True)
-    assert a, "Expected a to be installed"
+    a = spack.store.STORE.db.query_one("pkg-a", installed=True)
+    assert a, "Expected pkg-a to be installed"
 
 
 def test_remove_after_concretize():
@@ -635,7 +637,7 @@ def test_env_view_external_prefix(tmp_path, mutable_database, mock_packages):
         """\
 spack:
   specs:
-  - a
+  - pkg-a
   view: true
 """
     )
@@ -643,9 +645,9 @@ spack:
     external_config = io.StringIO(
         """\
 packages:
-  a:
+  pkg-a:
     externals:
-    - spec: a@2.0
+    - spec: pkg-a@2.0
       prefix: {a_prefix}
     buildable: false
 """.format(

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -248,6 +248,7 @@ def test_overriding_prefix(mock_executable, mutable_config, monkeypatch):
     assert gcc.external_path == os.path.sep + os.path.join("opt", "gcc", "bin")
 
 
+@pytest.mark.not_on_windows("Fails spuriously on Windows")
 def test_new_entries_are_reported_correctly(mock_executable, mutable_config, monkeypatch):
     # Prepare an environment to detect a fake gcc
     gcc_exe = mock_executable("gcc", output="echo 4.2.1")

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -88,7 +88,7 @@ def test_install_runtests_all(monkeypatch, mock_packages, install_mockery):
         assert pkg.run_tests
 
     monkeypatch.setattr(spack.package_base.PackageBase, "unit_test_check", check)
-    install("--test=all", "a")
+    install("--test=all", "pkg-a")
 
 
 def test_install_package_already_installed(
@@ -570,61 +570,58 @@ def test_cdash_upload_build_error(tmpdir, mock_fetch, install_mockery, capfd):
 @pytest.mark.disable_clean_stage_check
 def test_cdash_upload_clean_build(tmpdir, mock_fetch, install_mockery, capfd):
     # capfd interferes with Spack's capturing of e.g., Build.xml output
-    with capfd.disabled():
-        with tmpdir.as_cwd():
-            install("--log-file=cdash_reports", "--log-format=cdash", "a")
-            report_dir = tmpdir.join("cdash_reports")
-            assert report_dir in tmpdir.listdir()
-            report_file = report_dir.join("a_Build.xml")
-            assert report_file in report_dir.listdir()
-            content = report_file.open().read()
-            assert "</Build>" in content
-            assert "<Text>" not in content
+    with capfd.disabled(), tmpdir.as_cwd():
+        install("--log-file=cdash_reports", "--log-format=cdash", "pkg-a")
+        report_dir = tmpdir.join("cdash_reports")
+        assert report_dir in tmpdir.listdir()
+        report_file = report_dir.join("pkg-a_Build.xml")
+        assert report_file in report_dir.listdir()
+        content = report_file.open().read()
+        assert "</Build>" in content
+        assert "<Text>" not in content
 
 
 @pytest.mark.disable_clean_stage_check
 def test_cdash_upload_extra_params(tmpdir, mock_fetch, install_mockery, capfd):
     # capfd interferes with Spack's capture of e.g., Build.xml output
-    with capfd.disabled():
-        with tmpdir.as_cwd():
-            install(
-                "--log-file=cdash_reports",
-                "--log-format=cdash",
-                "--cdash-build=my_custom_build",
-                "--cdash-site=my_custom_site",
-                "--cdash-track=my_custom_track",
-                "a",
-            )
-            report_dir = tmpdir.join("cdash_reports")
-            assert report_dir in tmpdir.listdir()
-            report_file = report_dir.join("a_Build.xml")
-            assert report_file in report_dir.listdir()
-            content = report_file.open().read()
-            assert 'Site BuildName="my_custom_build - a"' in content
-            assert 'Name="my_custom_site"' in content
-            assert "-my_custom_track" in content
+    with capfd.disabled(), tmpdir.as_cwd():
+        install(
+            "--log-file=cdash_reports",
+            "--log-format=cdash",
+            "--cdash-build=my_custom_build",
+            "--cdash-site=my_custom_site",
+            "--cdash-track=my_custom_track",
+            "pkg-a",
+        )
+        report_dir = tmpdir.join("cdash_reports")
+        assert report_dir in tmpdir.listdir()
+        report_file = report_dir.join("pkg-a_Build.xml")
+        assert report_file in report_dir.listdir()
+        content = report_file.open().read()
+        assert 'Site BuildName="my_custom_build - pkg-a"' in content
+        assert 'Name="my_custom_site"' in content
+        assert "-my_custom_track" in content
 
 
 @pytest.mark.disable_clean_stage_check
 def test_cdash_buildstamp_param(tmpdir, mock_fetch, install_mockery, capfd):
     # capfd interferes with Spack's capture of e.g., Build.xml output
-    with capfd.disabled():
-        with tmpdir.as_cwd():
-            cdash_track = "some_mocked_track"
-            buildstamp_format = "%Y%m%d-%H%M-{0}".format(cdash_track)
-            buildstamp = time.strftime(buildstamp_format, time.localtime(int(time.time())))
-            install(
-                "--log-file=cdash_reports",
-                "--log-format=cdash",
-                "--cdash-buildstamp={0}".format(buildstamp),
-                "a",
-            )
-            report_dir = tmpdir.join("cdash_reports")
-            assert report_dir in tmpdir.listdir()
-            report_file = report_dir.join("a_Build.xml")
-            assert report_file in report_dir.listdir()
-            content = report_file.open().read()
-            assert buildstamp in content
+    with capfd.disabled(), tmpdir.as_cwd():
+        cdash_track = "some_mocked_track"
+        buildstamp_format = "%Y%m%d-%H%M-{0}".format(cdash_track)
+        buildstamp = time.strftime(buildstamp_format, time.localtime(int(time.time())))
+        install(
+            "--log-file=cdash_reports",
+            "--log-format=cdash",
+            "--cdash-buildstamp={0}".format(buildstamp),
+            "pkg-a",
+        )
+        report_dir = tmpdir.join("cdash_reports")
+        assert report_dir in tmpdir.listdir()
+        report_file = report_dir.join("pkg-a_Build.xml")
+        assert report_file in report_dir.listdir()
+        content = report_file.open().read()
+        assert buildstamp in content
 
 
 @pytest.mark.disable_clean_stage_check
@@ -632,38 +629,37 @@ def test_cdash_install_from_spec_json(
     tmpdir, mock_fetch, install_mockery, capfd, mock_packages, mock_archive, config
 ):
     # capfd interferes with Spack's capturing
-    with capfd.disabled():
-        with tmpdir.as_cwd():
-            spec_json_path = str(tmpdir.join("spec.json"))
+    with capfd.disabled(), tmpdir.as_cwd():
+        spec_json_path = str(tmpdir.join("spec.json"))
 
-            pkg_spec = Spec("a")
-            pkg_spec.concretize()
+        pkg_spec = Spec("pkg-a")
+        pkg_spec.concretize()
 
-            with open(spec_json_path, "w") as fd:
-                fd.write(pkg_spec.to_json(hash=ht.dag_hash))
+        with open(spec_json_path, "w") as fd:
+            fd.write(pkg_spec.to_json(hash=ht.dag_hash))
 
-            install(
-                "--log-format=cdash",
-                "--log-file=cdash_reports",
-                "--cdash-build=my_custom_build",
-                "--cdash-site=my_custom_site",
-                "--cdash-track=my_custom_track",
-                "-f",
-                spec_json_path,
-            )
+        install(
+            "--log-format=cdash",
+            "--log-file=cdash_reports",
+            "--cdash-build=my_custom_build",
+            "--cdash-site=my_custom_site",
+            "--cdash-track=my_custom_track",
+            "-f",
+            spec_json_path,
+        )
 
-            report_dir = tmpdir.join("cdash_reports")
-            assert report_dir in tmpdir.listdir()
-            report_file = report_dir.join("a_Configure.xml")
-            assert report_file in report_dir.listdir()
-            content = report_file.open().read()
-            install_command_regex = re.compile(
-                r"<ConfigureCommand>(.+)</ConfigureCommand>", re.MULTILINE | re.DOTALL
-            )
-            m = install_command_regex.search(content)
-            assert m
-            install_command = m.group(1)
-            assert "a@" in install_command
+        report_dir = tmpdir.join("cdash_reports")
+        assert report_dir in tmpdir.listdir()
+        report_file = report_dir.join("pkg-a_Configure.xml")
+        assert report_file in report_dir.listdir()
+        content = report_file.open().read()
+        install_command_regex = re.compile(
+            r"<ConfigureCommand>(.+)</ConfigureCommand>", re.MULTILINE | re.DOTALL
+        )
+        m = install_command_regex.search(content)
+        assert m
+        install_command = m.group(1)
+        assert "pkg-a@" in install_command
 
 
 @pytest.mark.disable_clean_stage_check
@@ -795,15 +791,15 @@ def test_install_no_add_in_env(tmpdir, mock_fetch, install_mockery, mutable_mock
     #                 ^libdwarf
     #         ^mpich
     #     libelf@0.8.10
-    #     a~bvv
-    #         ^b
-    #     a
-    #         ^b
+    #     pkg-a~bvv
+    #         ^pkg-b
+    #     pkg-a
+    #         ^pkg-b
     e = ev.create("test", with_view=False)
     e.add("mpileaks")
     e.add("libelf@0.8.10")  # so env has both root and dep libelf specs
-    e.add("a")
-    e.add("a ~bvv")
+    e.add("pkg-a")
+    e.add("pkg-a ~bvv")
     e.concretize()
     e.write()
     env_specs = e.all_specs()
@@ -814,9 +810,9 @@ def test_install_no_add_in_env(tmpdir, mock_fetch, install_mockery, mutable_mock
 
     # First find and remember some target concrete specs in the environment
     for e_spec in env_specs:
-        if e_spec.satisfies(Spec("a ~bvv")):
+        if e_spec.satisfies(Spec("pkg-a ~bvv")):
             a_spec = e_spec
-        elif e_spec.name == "b":
+        elif e_spec.name == "pkg-b":
             b_spec = e_spec
         elif e_spec.satisfies(Spec("mpi")):
             mpi_spec = e_spec
@@ -839,8 +835,8 @@ def test_install_no_add_in_env(tmpdir, mock_fetch, install_mockery, mutable_mock
         assert "You can add specs to the environment with 'spack add " in inst_out
 
         # Without --add, ensure that two packages "a" get installed
-        inst_out = install("a", output=str)
-        assert len([x for x in e.all_specs() if x.installed and x.name == "a"]) == 2
+        inst_out = install("pkg-a", output=str)
+        assert len([x for x in e.all_specs() if x.installed and x.name == "pkg-a"]) == 2
 
         # Install an unambiguous dependency spec (that already exists as a dep
         # in the environment) and make sure it gets installed (w/ deps),
@@ -873,7 +869,7 @@ def test_install_no_add_in_env(tmpdir, mock_fetch, install_mockery, mutable_mock
         # root of the environment as well as installed.
         assert b_spec not in e.roots()
 
-        install("--add", "b")
+        install("--add", "pkg-b")
 
         assert b_spec in e.roots()
         assert b_spec not in e.uninstalled_specs()
@@ -908,7 +904,7 @@ def test_cdash_auth_token(tmpdir, mock_fetch, install_mockery, monkeypatch, capf
     # capfd interferes with Spack's capturing
     with tmpdir.as_cwd(), capfd.disabled():
         monkeypatch.setenv("SPACK_CDASH_AUTH_TOKEN", "asdf")
-        out = install("-v", "--log-file=cdash_reports", "--log-format=cdash", "a")
+        out = install("-v", "--log-file=cdash_reports", "--log-format=cdash", "pkg-a")
         assert "Using CDash auth token from environment" in out
 
 
@@ -916,26 +912,25 @@ def test_cdash_auth_token(tmpdir, mock_fetch, install_mockery, monkeypatch, capf
 @pytest.mark.disable_clean_stage_check
 def test_cdash_configure_warning(tmpdir, mock_fetch, install_mockery, capfd):
     # capfd interferes with Spack's capturing of e.g., Build.xml output
-    with capfd.disabled():
-        with tmpdir.as_cwd():
-            # Test would fail if install raised an error.
+    with capfd.disabled(), tmpdir.as_cwd():
+        # Test would fail if install raised an error.
 
-            # Ensure that even on non-x86_64 architectures, there are no
-            # dependencies installed
-            spec = spack.spec.Spec("configure-warning").concretized()
-            spec.clear_dependencies()
-            specfile = "./spec.json"
-            with open(specfile, "w") as f:
-                f.write(spec.to_json())
+        # Ensure that even on non-x86_64 architectures, there are no
+        # dependencies installed
+        spec = Spec("configure-warning").concretized()
+        spec.clear_dependencies()
+        specfile = "./spec.json"
+        with open(specfile, "w") as f:
+            f.write(spec.to_json())
 
-            install("--log-file=cdash_reports", "--log-format=cdash", specfile)
-            # Verify Configure.xml exists with expected contents.
-            report_dir = tmpdir.join("cdash_reports")
-            assert report_dir in tmpdir.listdir()
-            report_file = report_dir.join("Configure.xml")
-            assert report_file in report_dir.listdir()
-            content = report_file.open().read()
-            assert "foo: No such file or directory" in content
+        install("--log-file=cdash_reports", "--log-format=cdash", specfile)
+        # Verify Configure.xml exists with expected contents.
+        report_dir = tmpdir.join("cdash_reports")
+        assert report_dir in tmpdir.listdir()
+        report_file = report_dir.join("Configure.xml")
+        assert report_file in report_dir.listdir()
+        content = report_file.open().read()
+        assert "foo: No such file or directory" in content
 
 
 @pytest.mark.not_on_windows("ArchSpec gives test platform debian rather than windows")
@@ -952,7 +947,7 @@ def test_compiler_bootstrap(
     assert CompilerSpec("gcc@=12.0") not in compilers.all_compiler_specs()
 
     # Test succeeds if it does not raise an error
-    install("a%gcc@=12.0")
+    install("pkg-a%gcc@=12.0")
 
 
 @pytest.mark.not_on_windows("Binary mirrors not supported on windows")
@@ -992,8 +987,8 @@ def test_compiler_bootstrap_from_binary_mirror(
     # Now make sure that when the compiler is installed from binary mirror,
     # it also gets configured as a compiler.  Test succeeds if it does not
     # raise an error
-    install("--no-check-signature", "--cache-only", "--only", "dependencies", "b%gcc@=10.2.0")
-    install("--no-cache", "--only", "package", "b%gcc@10.2.0")
+    install("--no-check-signature", "--cache-only", "--only", "dependencies", "pkg-b%gcc@=10.2.0")
+    install("--no-cache", "--only", "package", "pkg-b%gcc@10.2.0")
 
 
 @pytest.mark.not_on_windows("ArchSpec gives test platform debian rather than windows")
@@ -1013,7 +1008,7 @@ def test_compiler_bootstrap_already_installed(
 
     # Test succeeds if it does not raise an error
     install("gcc@=12.0")
-    install("a%gcc@=12.0")
+    install("pkg-a%gcc@=12.0")
 
 
 def test_install_fails_no_args(tmpdir):
@@ -1195,7 +1190,7 @@ def test_report_filename_for_cdash(install_mockery_mutable_config, mock_fetch):
     parser = argparse.ArgumentParser()
     spack.cmd.install.setup_parser(parser)
     args = parser.parse_args(
-        ["--cdash-upload-url", "https://blahblah/submit.php?project=debugging", "a"]
+        ["--cdash-upload-url", "https://blahblah/submit.php?project=debugging", "pkg-a"]
     )
     specs = spack.cmd.install.concrete_specs_from_cli(args, {})
     filename = spack.cmd.install.report_filename(args, specs)

--- a/lib/spack/spack/test/cmd/maintainers.py
+++ b/lib/spack/spack/test/cmd/maintainers.py
@@ -133,7 +133,7 @@ def test_maintainers_list_packages(mock_packages, capfd):
 
 
 def test_maintainers_list_fails(mock_packages, capfd):
-    out = maintainers("a", fail_on_error=False)
+    out = maintainers("pkg-a", fail_on_error=False)
     assert not out
     assert maintainers.returncode == 1
 

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -11,6 +11,7 @@ import pytest
 import spack.config
 import spack.main
 import spack.modules
+import spack.spec
 import spack.store
 
 module = spack.main.SpackCommand("module")
@@ -178,8 +179,8 @@ def test_setdefault_command(mutable_database, mutable_config):
         }
     }
     spack.config.set("modules", data)
-    # Install two different versions of a package
-    other_spec, preferred = "a@1.0", "a@2.0"
+    # Install two different versions of pkg-a
+    other_spec, preferred = "pkg-a@1.0", "pkg-a@2.0"
 
     spack.spec.Spec(other_spec).concretized().package.do_install(fake=True)
     spack.spec.Spec(preferred).concretized().package.do_install(fake=True)

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -28,8 +28,8 @@ class {name}(Package):
         pass
 """
 
-abc = set(("pkg-a", "pkg-b", "pkg-c"))
-abd = set(("pkg-a", "pkg-b", "pkg-d"))
+abc = {"mockpkg-a", "mockpkg-b", "mockpkg-c"}
+abd = {"mockpkg-a", "mockpkg-b", "mockpkg-d"}
 
 
 # Force all tests to use a git repository *in* the mock packages repo.
@@ -53,27 +53,33 @@ def mock_pkg_git_repo(git, tmpdir_factory):
         git("config", "user.name", "Spack Testing")
         git("-c", "commit.gpgsign=false", "commit", "-m", "initial mock repo commit")
 
-        # add commit with pkg-a, pkg-b, pkg-c packages
-        mkdirp("pkg-a", "pkg-b", "pkg-c")
-        with open("pkg-a/package.py", "w") as f:
+        # add commit with mockpkg-a, mockpkg-b, mockpkg-c packages
+        mkdirp("mockpkg-a", "mockpkg-b", "mockpkg-c")
+        with open("mockpkg-a/package.py", "w") as f:
             f.write(pkg_template.format(name="PkgA"))
-        with open("pkg-b/package.py", "w") as f:
+        with open("mockpkg-b/package.py", "w") as f:
             f.write(pkg_template.format(name="PkgB"))
-        with open("pkg-c/package.py", "w") as f:
+        with open("mockpkg-c/package.py", "w") as f:
             f.write(pkg_template.format(name="PkgC"))
-        git("add", "pkg-a", "pkg-b", "pkg-c")
-        git("-c", "commit.gpgsign=false", "commit", "-m", "add pkg-a, pkg-b, pkg-c")
+        git("add", "mockpkg-a", "mockpkg-b", "mockpkg-c")
+        git("-c", "commit.gpgsign=false", "commit", "-m", "add mockpkg-a, mockpkg-b, mockpkg-c")
 
-        # remove pkg-c, add pkg-d
-        with open("pkg-b/package.py", "a") as f:
-            f.write("\n# change pkg-b")
-        git("add", "pkg-b")
-        mkdirp("pkg-d")
-        with open("pkg-d/package.py", "w") as f:
+        # remove mockpkg-c, add mockpkg-d
+        with open("mockpkg-b/package.py", "a") as f:
+            f.write("\n# change mockpkg-b")
+        git("add", "mockpkg-b")
+        mkdirp("mockpkg-d")
+        with open("mockpkg-d/package.py", "w") as f:
             f.write(pkg_template.format(name="PkgD"))
-        git("add", "pkg-d")
-        git("rm", "-rf", "pkg-c")
-        git("-c", "commit.gpgsign=false", "commit", "-m", "change pkg-b, remove pkg-c, add pkg-d")
+        git("add", "mockpkg-d")
+        git("rm", "-rf", "mockpkg-c")
+        git(
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-m",
+            "change mockpkg-b, remove mockpkg-c, add mockpkg-d",
+        )
 
     with spack.repo.use_repositories(str(repo_path)):
         yield mock_repo_packages
@@ -86,12 +92,11 @@ def mock_pkg_names():
     # Be sure to include virtual packages since packages with stand-alone
     # tests may inherit additional tests from the virtuals they provide,
     # such as packages that implement `mpi`.
-    names = set(
+    return {
         name
         for name in repo.all_package_names(include_virtuals=True)
-        if not name.startswith("pkg-")
-    )
-    return names
+        if not name.startswith("mockpkg-")
+    }
 
 
 def split(output):
@@ -113,17 +118,17 @@ def test_mock_packages_path(mock_packages):
 
 def test_pkg_add(git, mock_pkg_git_repo):
     with working_dir(mock_pkg_git_repo):
-        mkdirp("pkg-e")
-        with open("pkg-e/package.py", "w") as f:
+        mkdirp("mockpkg-e")
+        with open("mockpkg-e/package.py", "w") as f:
             f.write(pkg_template.format(name="PkgE"))
 
-    pkg("add", "pkg-e")
+    pkg("add", "mockpkg-e")
 
     with working_dir(mock_pkg_git_repo):
         try:
-            assert "A  pkg-e/package.py" in git("status", "--short", output=str)
+            assert "A  mockpkg-e/package.py" in git("status", "--short", output=str)
         finally:
-            shutil.rmtree("pkg-e")
+            shutil.rmtree("mockpkg-e")
             # Removing a package mid-run disrupts Spack's caching
             if spack.repo.PATH.repos[0]._fast_package_checker:
                 spack.repo.PATH.repos[0]._fast_package_checker.invalidate()
@@ -138,10 +143,10 @@ def test_pkg_list(mock_pkg_git_repo, mock_pkg_names):
     assert sorted(mock_pkg_names) == sorted(out)
 
     out = split(pkg("list", "HEAD^"))
-    assert sorted(mock_pkg_names.union(["pkg-a", "pkg-b", "pkg-c"])) == sorted(out)
+    assert sorted(mock_pkg_names.union(["mockpkg-a", "mockpkg-b", "mockpkg-c"])) == sorted(out)
 
     out = split(pkg("list", "HEAD"))
-    assert sorted(mock_pkg_names.union(["pkg-a", "pkg-b", "pkg-d"])) == sorted(out)
+    assert sorted(mock_pkg_names.union(["mockpkg-a", "mockpkg-b", "mockpkg-d"])) == sorted(out)
 
     # test with three dots to make sure pkg calls `git merge-base`
     out = split(pkg("list", "HEAD^^..."))
@@ -151,25 +156,25 @@ def test_pkg_list(mock_pkg_git_repo, mock_pkg_names):
 @pytest.mark.not_on_windows("stdout format conflict")
 def test_pkg_diff(mock_pkg_git_repo, mock_pkg_names):
     out = split(pkg("diff", "HEAD^^", "HEAD^"))
-    assert out == ["HEAD^:", "pkg-a", "pkg-b", "pkg-c"]
+    assert out == ["HEAD^:", "mockpkg-a", "mockpkg-b", "mockpkg-c"]
 
     out = split(pkg("diff", "HEAD^^", "HEAD"))
-    assert out == ["HEAD:", "pkg-a", "pkg-b", "pkg-d"]
+    assert out == ["HEAD:", "mockpkg-a", "mockpkg-b", "mockpkg-d"]
 
     out = split(pkg("diff", "HEAD^", "HEAD"))
-    assert out == ["HEAD^:", "pkg-c", "HEAD:", "pkg-d"]
+    assert out == ["HEAD^:", "mockpkg-c", "HEAD:", "mockpkg-d"]
 
 
 @pytest.mark.not_on_windows("stdout format conflict")
 def test_pkg_added(mock_pkg_git_repo):
     out = split(pkg("added", "HEAD^^", "HEAD^"))
-    assert ["pkg-a", "pkg-b", "pkg-c"] == out
+    assert ["mockpkg-a", "mockpkg-b", "mockpkg-c"] == out
 
     out = split(pkg("added", "HEAD^^", "HEAD"))
-    assert ["pkg-a", "pkg-b", "pkg-d"] == out
+    assert ["mockpkg-a", "mockpkg-b", "mockpkg-d"] == out
 
     out = split(pkg("added", "HEAD^", "HEAD"))
-    assert ["pkg-d"] == out
+    assert ["mockpkg-d"] == out
 
     out = split(pkg("added", "HEAD", "HEAD"))
     assert out == []
@@ -184,7 +189,7 @@ def test_pkg_removed(mock_pkg_git_repo):
     assert out == []
 
     out = split(pkg("removed", "HEAD^", "HEAD"))
-    assert out == ["pkg-c"]
+    assert out == ["mockpkg-c"]
 
 
 @pytest.mark.not_on_windows("stdout format conflict")
@@ -196,34 +201,34 @@ def test_pkg_changed(mock_pkg_git_repo):
     assert out == []
 
     out = split(pkg("changed", "--type", "a", "HEAD^^", "HEAD^"))
-    assert out == ["pkg-a", "pkg-b", "pkg-c"]
+    assert out == ["mockpkg-a", "mockpkg-b", "mockpkg-c"]
 
     out = split(pkg("changed", "--type", "r", "HEAD^^", "HEAD^"))
     assert out == []
 
     out = split(pkg("changed", "--type", "ar", "HEAD^^", "HEAD^"))
-    assert out == ["pkg-a", "pkg-b", "pkg-c"]
+    assert out == ["mockpkg-a", "mockpkg-b", "mockpkg-c"]
 
     out = split(pkg("changed", "--type", "arc", "HEAD^^", "HEAD^"))
-    assert out == ["pkg-a", "pkg-b", "pkg-c"]
+    assert out == ["mockpkg-a", "mockpkg-b", "mockpkg-c"]
 
     out = split(pkg("changed", "HEAD^", "HEAD"))
-    assert out == ["pkg-b"]
+    assert out == ["mockpkg-b"]
 
     out = split(pkg("changed", "--type", "c", "HEAD^", "HEAD"))
-    assert out == ["pkg-b"]
+    assert out == ["mockpkg-b"]
 
     out = split(pkg("changed", "--type", "a", "HEAD^", "HEAD"))
-    assert out == ["pkg-d"]
+    assert out == ["mockpkg-d"]
 
     out = split(pkg("changed", "--type", "r", "HEAD^", "HEAD"))
-    assert out == ["pkg-c"]
+    assert out == ["mockpkg-c"]
 
     out = split(pkg("changed", "--type", "ar", "HEAD^", "HEAD"))
-    assert out == ["pkg-c", "pkg-d"]
+    assert out == ["mockpkg-c", "mockpkg-d"]
 
     out = split(pkg("changed", "--type", "arc", "HEAD^", "HEAD"))
-    assert out == ["pkg-b", "pkg-c", "pkg-d"]
+    assert out == ["mockpkg-b", "mockpkg-c", "mockpkg-d"]
 
     # invalid type argument
     with pytest.raises(spack.main.SpackCommandError):
@@ -289,7 +294,7 @@ def test_pkg_canonical_source(mock_packages):
 
 
 def test_pkg_hash(mock_packages):
-    output = pkg("hash", "a", "b").strip().split()
+    output = pkg("hash", "pkg-a", "pkg-b").strip().split()
     assert len(output) == 2 and all(len(elt) == 32 for elt in output)
 
     output = pkg("hash", "multimethod").strip().split()

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -59,7 +59,7 @@ def test_spec_concretizer_args(mutable_config, mutable_database):
 def test_spec_parse_dependency_variant_value():
     """Verify that we can provide multiple key=value variants to multiple separate
     packages within a spec string."""
-    output = spec("multivalue-variant fee=barbaz ^ a foobar=baz")
+    output = spec("multivalue-variant fee=barbaz ^ pkg-a foobar=baz")
 
     assert "fee=barbaz" in output
     assert "foobar=baz" in output

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -10,10 +10,14 @@ import pytest
 
 from llnl.util.filesystem import copy_tree
 
+import spack.cmd.common.arguments
 import spack.cmd.install
+import spack.cmd.test
 import spack.config
+import spack.install_test
 import spack.package_base
 import spack.paths
+import spack.spec
 import spack.store
 from spack.install_test import TestStatus
 from spack.main import SpackCommand

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -62,10 +62,16 @@ def test_multiple_conflicting_compiler_definitions(mutable_config):
     assert cmp.f77 == "f77"
 
 
-def test_get_compiler_duplicates(config):
+def test_get_compiler_duplicates(mutable_config, compiler_factory):
     # In this case there is only one instance of the specified compiler in
     # the test configuration (so it is not actually a duplicate), but the
     # method behaves the same.
+    cnl_compiler = compiler_factory(spec="gcc@4.5.0", operating_system="CNL")
+    # CNL compiler has no target attribute, and this is essential to make detection pass
+    del cnl_compiler["compiler"]["target"]
+    mutable_config.set(
+        "compilers", [compiler_factory(spec="gcc@4.5.0", operating_system="SuSE11"), cnl_compiler]
+    )
     cfg_file_to_duplicates = spack.compilers.get_compiler_duplicates(
         "gcc@4.5.0", spack.spec.ArchSpec("cray-CNL-xeon")
     )
@@ -73,13 +79,6 @@ def test_get_compiler_duplicates(config):
     assert len(cfg_file_to_duplicates) == 1
     cfg_file, duplicates = next(iter(cfg_file_to_duplicates.items()))
     assert len(duplicates) == 1
-
-
-def test_all_compilers(config):
-    all_compilers = spack.compilers.all_compilers()
-    filtered = [x for x in all_compilers if str(x.spec) == "clang@=3.3"]
-    filtered = [x for x in filtered if x.operating_system == "SuSE11"]
-    assert len(filtered) == 1
 
 
 @pytest.mark.parametrize(
@@ -660,7 +659,25 @@ def test_xl_r_flags():
     "compiler_spec,expected_result",
     [("gcc@4.7.2", False), ("clang@3.3", False), ("clang@8.0.0", True)],
 )
-def test_detecting_mixed_toolchains(compiler_spec, expected_result, config):
+def test_detecting_mixed_toolchains(
+    compiler_spec, expected_result, mutable_config, compiler_factory
+):
+    mixed_c = compiler_factory(spec="clang@8.0.0", operating_system="debian6")
+    mixed_c["compiler"]["paths"] = {
+        "cc": "/path/to/clang-8",
+        "cxx": "/path/to/clang++-8",
+        "f77": "/path/to/gfortran-9",
+        "fc": "/path/to/gfortran-9",
+    }
+    mutable_config.set(
+        "compilers",
+        [
+            compiler_factory(spec="gcc@4.7.2", operating_system="debian6"),
+            compiler_factory(spec="clang@3.3", operating_system="debian6"),
+            mixed_c,
+        ],
+    )
+
     compiler = spack.compilers.compilers_for_spec(compiler_spec).pop()
     assert spack.compilers.is_mixed_toolchain(compiler) is expected_result
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1203,10 +1203,11 @@ class TestConcretize:
 
     @pytest.mark.regression("20055")
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")
-    def test_custom_compiler_version(self, mutable_config, compiler_factory):
+    def test_custom_compiler_version(self, mutable_config, compiler_factory, monkeypatch):
         mutable_config.set(
             "compilers", [compiler_factory(spec="gcc@10foo", operating_system="redhat6")]
         )
+        monkeypatch.setattr(spack.compiler.Compiler, "real_version", "10.2.1")
         s = Spec("pkg-a %gcc@10foo os=redhat6").concretized()
         assert "%gcc@10foo" in s
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -224,6 +224,20 @@ class Changing(Package):
         yield _changing_pkg
 
 
+@pytest.fixture()
+def clang12_with_flags(compiler_factory):
+    c = compiler_factory(spec="clang@12.2.0", operating_system="redhat6")
+    c["compiler"]["flags"] = {"cflags": "-O3", "cxxflags": "-O3"}
+    return c
+
+
+@pytest.fixture()
+def gcc11_with_flags(compiler_factory):
+    c = compiler_factory(spec="gcc@11.1.0", operating_system="redhat6")
+    c["compiler"]["flags"] = {"cflags": "-O0 -g", "cxxflags": "-O0 -g", "fflags": "-O0 -g"}
+    return c
+
+
 # This must use the mutable_config fixture because the test
 # adjusting_default_target_based_on_compiler uses the current_host fixture,
 # which changes the config.
@@ -316,18 +330,35 @@ class TestConcretize:
         assert Spec("builtin.mock.multi-provider-mpi@1.10.0") in providers
         assert Spec("builtin.mock.multi-provider-mpi@1.8.8") in providers
 
-    def test_different_compilers_get_different_flags(self):
+    def test_different_compilers_get_different_flags(
+        self, mutable_config, clang12_with_flags, gcc11_with_flags
+    ):
+        """Tests that nodes get the flags of the associated compiler."""
+        mutable_config.set("compilers", [clang12_with_flags, gcc11_with_flags])
         client = Spec(
             "cmake-client %gcc@11.1.0 platform=test os=fe target=fe"
-            + " ^cmake %clang@12.2.0 platform=test os=fe target=fe"
-        )
-        client.concretize()
+            " ^cmake %clang@12.2.0 platform=test os=fe target=fe"
+        ).concretized()
         cmake = client["cmake"]
-        assert set(client.compiler_flags["cflags"]) == set(["-O0", "-g"])
-        assert set(cmake.compiler_flags["cflags"]) == set(["-O3"])
-        assert set(client.compiler_flags["fflags"]) == set(["-O0", "-g"])
+        assert set(client.compiler_flags["cflags"]) == {"-O0", "-g"}
+        assert set(cmake.compiler_flags["cflags"]) == {"-O3"}
+        assert set(client.compiler_flags["fflags"]) == {"-O0", "-g"}
         assert not set(cmake.compiler_flags["fflags"])
 
+    @pytest.mark.regression("9908")
+    def test_spec_flags_maintain_order(self, mutable_config, gcc11_with_flags):
+        """Tests that Spack assembles flags in a consistent way (i.e. with the same ordering),
+        for successive concretizations.
+        """
+        mutable_config.set("compilers", [gcc11_with_flags])
+        spec_str = "libelf %gcc@11.1.0 os=redhat6"
+        for _ in range(3):
+            s = Spec(spec_str).concretized()
+            assert all(
+                s.compiler_flags[x] == ["-O0", "-g"] for x in ("cflags", "cxxflags", "fflags")
+            )
+
+    @pytest.mark.xfail(reason="Broken, needs to be fixed")
     def test_compiler_flags_from_compiler_and_dependent(self):
         client = Spec("cmake-client %clang@12.2.0 platform=test os=fe target=fe cflags==-g")
         client.concretize()
@@ -335,7 +366,8 @@ class TestConcretize:
         for spec in [client, cmake]:
             assert spec.compiler_flags["cflags"] == ["-O3", "-g"]
 
-    def test_compiler_flags_differ_identical_compilers(self):
+    def test_compiler_flags_differ_identical_compilers(self, mutable_config, clang12_with_flags):
+        mutable_config.set("compilers", [clang12_with_flags])
         # Correct arch to use test compiler that has flags
         spec = Spec("a %clang@12.2.0 platform=test os=fe target=fe")
 
@@ -390,25 +422,20 @@ class TestConcretize:
         for dep in spec.traverse():
             assert "%clang" in dep
 
-    def test_architecture_inheritance(self):
-        """test_architecture_inheritance is likely to fail with an
-        UnavailableCompilerVersionError if the architecture is concretized
-        incorrectly.
-        """
-        spec = Spec("cmake-client %gcc@11.1.0 os=fe ^ cmake")
-        spec.concretize()
-        assert spec["cmake"].architecture == spec.architecture
-
     @pytest.mark.only_clingo("Fixing the parser broke this test for the original concretizer")
-    def test_architecture_deep_inheritance(self, mock_targets):
+    def test_architecture_deep_inheritance(self, mock_targets, compiler_factory):
         """Make sure that indirect dependencies receive architecture
         information from the root even when partial architecture information
         is provided by an intermediate dependency.
         """
-        spec_str = "mpileaks %gcc@4.5.0 os=CNL target=nocona" " ^dyninst os=CNL ^callpath os=CNL"
-        spec = Spec(spec_str).concretized()
-        for s in spec.traverse(root=False):
-            assert s.architecture.target == spec.architecture.target
+        cnl_compiler = compiler_factory(spec="gcc@4.5.0", operating_system="CNL")
+        # CNL compiler has no target attribute, and this is essential to make detection pass
+        del cnl_compiler["compiler"]["target"]
+        with spack.config.override("compilers", [cnl_compiler]):
+            spec_str = "mpileaks %gcc@4.5.0 os=CNL target=nocona ^dyninst os=CNL ^callpath os=CNL"
+            spec = Spec(spec_str).concretized()
+            for s in spec.traverse(root=False):
+                assert s.architecture.target == spec.architecture.target
 
     def test_compiler_flags_from_user_are_grouped(self):
         spec = Spec('a%gcc cflags="-O -foo-flag foo-val" platform=test')
@@ -843,9 +870,12 @@ class TestConcretize:
         ],
     )
     @pytest.mark.only_clingo("Original concretizer cannot work around conflicts")
-    def test_compiler_conflicts_in_package_py(self, spec_str, expected_str):
-        s = Spec(spec_str).concretized()
-        assert s.satisfies(expected_str)
+    def test_compiler_conflicts_in_package_py(
+        self, spec_str, expected_str, clang12_with_flags, gcc11_with_flags
+    ):
+        with spack.config.override("compilers", [clang12_with_flags, gcc11_with_flags]):
+            s = Spec(spec_str).concretized()
+            assert s.satisfies(expected_str)
 
     @pytest.mark.parametrize(
         "spec_str,expected,unexpected",
@@ -1135,16 +1165,18 @@ class TestConcretize:
 
     @pytest.mark.regression("20019")
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")
-    def test_compiler_match_is_preferred_to_newer_version(self):
+    def test_compiler_match_is_preferred_to_newer_version(self, compiler_factory):
         # This spec depends on openblas. Openblas has a conflict
         # that doesn't allow newer versions with gcc@4.4.0. Check
         # that an old version of openblas is selected, rather than
         # a different compiler for just that node.
-        spec_str = "simple-inheritance+openblas %gcc@10.1.0 os=redhat6"
-        s = Spec(spec_str).concretized()
-
-        assert "openblas@0.2.15" in s
-        assert s["openblas"].satisfies("%gcc@10.1.0")
+        with spack.config.override(
+            "compilers", [compiler_factory(spec="gcc@10.1.0", operating_system="redhat6")]
+        ):
+            spec_str = "simple-inheritance+openblas %gcc@10.1.0 os=redhat6"
+            s = Spec(spec_str).concretized()
+            assert "openblas@0.2.15" in s
+            assert s["openblas"].satisfies("%gcc@10.1.0")
 
     @pytest.mark.regression("19981")
     def test_target_ranges_in_conflicts(self):
@@ -1169,7 +1201,10 @@ class TestConcretize:
 
     @pytest.mark.regression("20055")
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")
-    def test_custom_compiler_version(self):
+    def test_custom_compiler_version(self, mutable_config, compiler_factory):
+        mutable_config.set(
+            "compilers", [compiler_factory(spec="gcc@10foo", operating_system="redhat6")]
+        )
         s = Spec("a %gcc@10foo os=redhat6").concretized()
         assert "%gcc@10foo" in s
 
@@ -1369,11 +1404,16 @@ class TestConcretize:
             ("mpileaks%gcc@10.2.1 platform=test os=redhat6", "os=redhat6"),
         ],
     )
-    def test_os_selection_when_multiple_choices_are_possible(self, spec_str, expected_os):
-        s = Spec(spec_str).concretized()
-
-        for node in s.traverse():
-            assert node.satisfies(expected_os)
+    def test_os_selection_when_multiple_choices_are_possible(
+        self, spec_str, expected_os, compiler_factory
+    ):
+        # GCC 10.2.1 is defined both for debian and for redhat
+        with spack.config.override(
+            "compilers", [compiler_factory(spec="gcc@10.2.1", operating_system="redhat6")]
+        ):
+            s = Spec(spec_str).concretized()
+            for node in s.traverse():
+                assert node.satisfies(expected_os)
 
     @pytest.mark.regression("22718")
     @pytest.mark.parametrize(

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -23,6 +23,8 @@ import spack.hash_types as ht
 import spack.platforms
 import spack.repo
 import spack.solver.asp
+import spack.store
+import spack.util.file_cache
 import spack.variant as vt
 from spack.concretize import find_spec
 from spack.spec import CompilerSpec, Spec
@@ -369,7 +371,7 @@ class TestConcretize:
     def test_compiler_flags_differ_identical_compilers(self, mutable_config, clang12_with_flags):
         mutable_config.set("compilers", [clang12_with_flags])
         # Correct arch to use test compiler that has flags
-        spec = Spec("a %clang@12.2.0 platform=test os=fe target=fe")
+        spec = Spec("pkg-a %clang@12.2.0 platform=test os=fe target=fe")
 
         # Get the compiler that matches the spec (
         compiler = spack.compilers.compiler_for_spec("clang@=12.2.0", spec.architecture)
@@ -438,7 +440,7 @@ class TestConcretize:
                 assert s.architecture.target == spec.architecture.target
 
     def test_compiler_flags_from_user_are_grouped(self):
-        spec = Spec('a%gcc cflags="-O -foo-flag foo-val" platform=test')
+        spec = Spec('pkg-a%gcc cflags="-O -foo-flag foo-val" platform=test')
         spec.concretize()
         cflags = spec.compiler_flags["cflags"]
         assert any(x == "-foo-flag foo-val" for x in cflags)
@@ -546,20 +548,20 @@ class TestConcretize:
         spec = Spec("multivalue-variant foo==baz,fee")
         spec.concretize()
 
-        assert spec.satisfies("^a foo=baz,fee")
-        assert spec.satisfies("^b foo=baz,fee")
-        assert not spec.satisfies("^a foo=bar")
-        assert not spec.satisfies("^b foo=bar")
+        assert spec.satisfies("^pkg-a foo=baz,fee")
+        assert spec.satisfies("^pkg-b foo=baz,fee")
+        assert not spec.satisfies("^pkg-a foo=bar")
+        assert not spec.satisfies("^pkg-b foo=bar")
 
     def test_no_matching_compiler_specs(self, mock_low_high_config):
         # only relevant when not building compilers as needed
         with spack.concretize.enable_compiler_existence_check():
-            s = Spec("a %gcc@=0.0.0")
+            s = Spec("pkg-a %gcc@=0.0.0")
             with pytest.raises(spack.concretize.UnavailableCompilerVersionError):
                 s.concretize()
 
     def test_no_compilers_for_arch(self):
-        s = Spec("a arch=linux-rhel0-x86_64")
+        s = Spec("pkg-a arch=linux-rhel0-x86_64")
         with pytest.raises(spack.error.SpackError):
             s.concretize()
 
@@ -768,7 +770,7 @@ class TestConcretize:
         # The string representation of a spec containing
         # an explicit multi-valued variant and a dependency
         # might be parsed differently than the originating spec
-        s = Spec("a foobar=bar ^b")
+        s = Spec("pkg-a foobar=bar ^pkg-b")
         t = Spec(str(s))
 
         s.concretize()
@@ -1140,14 +1142,14 @@ class TestConcretize:
         [
             # Check that True is treated correctly and attaches test deps
             # to all nodes in the DAG
-            ("a", True, ["a"], []),
-            ("a foobar=bar", True, ["a", "b"], []),
+            ("pkg-a", True, ["pkg-a"], []),
+            ("pkg-a foobar=bar", True, ["pkg-a", "pkg-b"], []),
             # Check that a list of names activates the dependency only for
             # packages in that list
-            ("a foobar=bar", ["a"], ["a"], ["b"]),
-            ("a foobar=bar", ["b"], ["b"], ["a"]),
+            ("pkg-a foobar=bar", ["pkg-a"], ["pkg-a"], ["pkg-b"]),
+            ("pkg-a foobar=bar", ["pkg-b"], ["pkg-b"], ["pkg-a"]),
             # Check that False disregard test dependencies
-            ("a foobar=bar", False, [], ["a", "b"]),
+            ("pkg-a foobar=bar", False, [], ["pkg-a", "pkg-b"]),
         ],
     )
     def test_activating_test_dependencies(self, spec_str, tests_arg, with_dep, without_dep):
@@ -1205,7 +1207,7 @@ class TestConcretize:
         mutable_config.set(
             "compilers", [compiler_factory(spec="gcc@10foo", operating_system="redhat6")]
         )
-        s = Spec("a %gcc@10foo os=redhat6").concretized()
+        s = Spec("pkg-a %gcc@10foo os=redhat6").concretized()
         assert "%gcc@10foo" in s
 
     def test_all_patches_applied(self):
@@ -1330,10 +1332,10 @@ class TestConcretize:
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_reuse_with_flags(self, mutable_database, mutable_config):
         spack.config.set("concretizer:reuse", True)
-        spec = Spec("a cflags=-g cxxflags=-g").concretized()
+        spec = Spec("pkg-a cflags=-g cxxflags=-g").concretized()
         spack.store.STORE.db.add(spec, None)
 
-        testspec = Spec("a cflags=-g")
+        testspec = Spec("pkg-a cflags=-g")
         testspec.concretize()
         assert testspec == spec
 
@@ -1674,31 +1676,31 @@ class TestConcretize:
         self, temporary_store, mock_custom_repository
     ):
         with spack.repo.use_repositories(mock_custom_repository, override=False):
-            s = Spec("c").concretized()
+            s = Spec("pkg-c").concretized()
             assert s.namespace != "builtin.mock"
             s.package.do_install(fake=True, explicit=True)
 
         with spack.config.override("concretizer:reuse", True):
-            s = Spec("c").concretized()
+            s = Spec("pkg-c").concretized()
         assert s.namespace == "builtin.mock"
 
     @pytest.mark.regression("28259")
     def test_reuse_with_unknown_package_dont_raise(self, tmpdir, temporary_store, monkeypatch):
         builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock.repo"), namespace="myrepo")
-        builder.add_package("c")
+        builder.add_package("pkg-c")
         with spack.repo.use_repositories(builder.root, override=False):
-            s = Spec("c").concretized()
+            s = Spec("pkg-c").concretized()
             assert s.namespace == "myrepo"
             s.package.do_install(fake=True, explicit=True)
 
-        del sys.modules["spack.pkg.myrepo.c"]
+        del sys.modules["spack.pkg.myrepo.pkg-c"]
         del sys.modules["spack.pkg.myrepo"]
-        builder.remove("c")
+        builder.remove("pkg-c")
         with spack.repo.use_repositories(builder.root, override=False) as repos:
             # TODO (INJECT CONFIGURATION): unclear why the cache needs to be invalidated explicitly
             repos.repos[0]._pkg_checker.invalidate()
             with spack.config.override("concretizer:reuse", True):
-                s = Spec("c").concretized()
+                s = Spec("pkg-c").concretized()
             assert s.namespace == "builtin.mock"
 
     @pytest.mark.parametrize(
@@ -1810,20 +1812,20 @@ class TestConcretize:
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_version_weight_and_provenance(self):
         """Test package preferences during coconcretization."""
-        reusable_specs = [Spec(spec_str).concretized() for spec_str in ("b@0.9", "b@1.0")]
-        root_spec = Spec("a foobar=bar")
+        reusable_specs = [Spec(spec_str).concretized() for spec_str in ("pkg-b@0.9", "pkg-b@1.0")]
+        root_spec = Spec("pkg-a foobar=bar")
 
         with spack.config.override("concretizer:reuse", True):
             solver = spack.solver.asp.Solver()
             setup = spack.solver.asp.SpackSolverSetup()
             result, _, _ = solver.driver.solve(setup, [root_spec], reuse=reusable_specs)
-            # The result here should have a single spec to build ('a')
-            # and it should be using b@1.0 with a version badness of 2
+            # The result here should have a single spec to build ('pkg-a')
+            # and it should be using pkg-b@1.0 with a version badness of 2
             # The provenance is:
-            # version_declared("b","1.0",0,"package_py").
-            # version_declared("b","0.9",1,"package_py").
-            # version_declared("b","1.0",2,"installed").
-            # version_declared("b","0.9",3,"installed").
+            # version_declared("pkg-b","1.0",0,"package_py").
+            # version_declared("pkg-b","0.9",1,"package_py").
+            # version_declared("pkg-b","1.0",2,"installed").
+            # version_declared("pkg-b","0.9",3,"installed").
             #
             # Depending on the target, it may also use gnuconfig
             result_spec = result.specs[0]
@@ -1836,12 +1838,12 @@ class TestConcretize:
 
             for criterion in criteria:
                 assert criterion in result.criteria
-            assert result_spec.satisfies("^b@1.0")
+            assert result_spec.satisfies("^pkg-b@1.0")
 
     @pytest.mark.regression("31169")
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_not_reusing_incompatible_os_or_compiler(self):
-        root_spec = Spec("b")
+        root_spec = Spec("pkg-b")
         s = root_spec.concretized()
         wrong_compiler, wrong_os = s.copy(), s.copy()
         wrong_compiler.compiler = spack.spec.CompilerSpec("gcc@12.1.0")
@@ -2096,7 +2098,7 @@ class TestConcretize:
         "specs",
         [
             ["mpileaks^ callpath ^dyninst@8.1.1:8 ^mpich2@1.3:1"],
-            ["multivalue-variant ^a@2:2"],
+            ["multivalue-variant ^pkg-a@2:2"],
             ["v1-consumer ^conditional-provider@1:1 +disable-v1"],
         ],
     )
@@ -2146,7 +2148,7 @@ class TestConcretize:
             },
         ]
         spack.config.set("compilers", compiler_configuration)
-        s = Spec("a %gcc@:11").concretized()
+        s = Spec("pkg-a %gcc@:11").concretized()
         assert s.compiler.version == ver("=11.1.0"), s
 
     @pytest.mark.regression("36339")
@@ -2167,7 +2169,7 @@ class TestConcretize:
             }
         ]
         spack.config.set("compilers", compiler_configuration)
-        s = Spec("a %gcc@foo").concretized()
+        s = Spec("pkg-a %gcc@foo").concretized()
         assert s.compiler.version == ver("=foo")
 
     @pytest.mark.regression("36628")
@@ -2193,7 +2195,7 @@ class TestConcretize:
         ]
 
         with spack.config.override("compilers", compiler_configuration):
-            s = spack.spec.Spec("a").concretized()
+            s = Spec("pkg-a").concretized()
         assert s.satisfies("%gcc@12.1.0")
 
     @pytest.mark.parametrize("spec_str", ["mpileaks", "mpileaks ^mpich"])
@@ -2228,7 +2230,7 @@ class TestConcretize:
         with pytest.raises(spack.error.UnsatisfiableSpecError):
             # normally spack concretizes to @=3.0 if it's not defined in package.py, except
             # when checksums are required
-            Spec("a@=3.0").concretized()
+            Spec("pkg-a@=3.0").concretized()
 
     @pytest.mark.regression("39570")
     @pytest.mark.db
@@ -2453,7 +2455,9 @@ def test_drop_moving_targets(v_str, v_opts, checksummed):
 class TestConcreteSpecsByHash:
     """Tests the container of concrete specs"""
 
-    @pytest.mark.parametrize("input_specs", [["a"], ["a foobar=bar", "b"], ["a foobar=baz", "b"]])
+    @pytest.mark.parametrize(
+        "input_specs", [["pkg-a"], ["pkg-a foobar=bar", "pkg-b"], ["pkg-a foobar=baz", "pkg-b"]]
+    )
     def test_adding_specs(self, input_specs, default_mock_concretization):
         """Tests that concrete specs in the container are equivalent, but stored as different
         objects in memory.

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -105,7 +105,7 @@ class TestConcretizePreferences:
 
     @pytest.mark.parametrize(
         "compiler_str,spec_str",
-        [("gcc@=4.5.0", "mpileaks"), ("clang@=12.0.0", "mpileaks"), ("gcc@=4.5.0", "openmpi")],
+        [("gcc@=4.8.0", "mpileaks"), ("clang@=12.0.0", "mpileaks"), ("gcc@=4.8.0", "openmpi")],
     )
     def test_preferred_compilers(self, compiler_str, spec_str):
         """Test preferred compilers are applied correctly"""

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -512,5 +512,5 @@ mpich:
         packages.yaml doesn't fail with an error.
         """
         with spack.config.override("packages:all", {"variants": "+foo"}):
-            s = Spec("a").concretized()
+            s = Spec("pkg-a").concretized()
             assert s.satisfies("foo=bar")

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -872,6 +872,8 @@ def test_skip_requirement_when_default_requirement_condition_cannot_be_met(
 
 def test_requires_directive(concretize_scope, mock_packages):
     compilers_yaml = pathlib.Path(concretize_scope) / "compilers.yaml"
+
+    # NOTE: target is omitted here so that the test works on aarch64, as well.
     compilers_yaml.write_text(
         """
 compilers::
@@ -883,7 +885,6 @@ compilers::
       f77: null
       fc: null
     operating_system: debian6
-    target: x86_64
     modules: []
 """
     )

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1176,13 +1176,13 @@ def test_license_dir_config(mutable_config, mock_packages):
     expected_dir = spack.paths.default_license_dir
     assert spack.config.get("config:license_dir") == expected_dir
     assert spack.package_base.PackageBase.global_license_dir == expected_dir
-    assert spack.repo.PATH.get_pkg_class("a").global_license_dir == expected_dir
+    assert spack.repo.PATH.get_pkg_class("pkg-a").global_license_dir == expected_dir
 
     rel_path = os.path.join(os.path.sep, "foo", "bar", "baz")
     spack.config.set("config:license_dir", rel_path)
     assert spack.config.get("config:license_dir") == rel_path
     assert spack.package_base.PackageBase.global_license_dir == rel_path
-    assert spack.repo.PATH.get_pkg_class("a").global_license_dir == rel_path
+    assert spack.repo.PATH.get_pkg_class("pkg-a").global_license_dir == rel_path
 
 
 @pytest.mark.regression("22547")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -597,7 +597,7 @@ def mutable_mock_repo(mock_repo_path, request):
 def mock_custom_repository(tmpdir, mutable_mock_repo):
     """Create a custom repository with a single package "c" and return its path."""
     builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("myrepo"))
-    builder.add_package("c")
+    builder.add_package("pkg-c")
     return builder.root
 
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -21,6 +21,7 @@ import xml.etree.ElementTree
 import py
 import pytest
 
+import archspec.cpu
 import archspec.cpu.microarchitecture
 import archspec.cpu.schema
 
@@ -708,7 +709,9 @@ def configuration_dir(tmpdir_factory, linux_os):
     t.write(content)
 
     compilers_yaml = test_config.join("compilers.yaml")
-    content = "".join(compilers_yaml.read()).format(linux_os)
+    content = "".join(compilers_yaml.read()).format(
+        linux_os=linux_os, target=str(archspec.cpu.host().family)
+    )
     t = tmpdir.join("site", "compilers.yaml")
     t.write(content)
     yield tmpdir
@@ -1952,3 +1955,48 @@ def pytest_runtest_setup(item):
 def disable_parallel_buildcache_push(monkeypatch):
     """Disable process pools in tests."""
     monkeypatch.setattr(spack.cmd.buildcache, "_make_pool", spack.cmd.buildcache.NoPool)
+
+
+def create_test_repo(tmpdir, pkg_name_content_tuples):
+    repo_path = str(tmpdir)
+    repo_yaml = tmpdir.join("repo.yaml")
+    with open(str(repo_yaml), "w") as f:
+        f.write(
+            """\
+repo:
+  namespace: testcfgrequirements
+"""
+        )
+
+    packages_dir = tmpdir.join("packages")
+    for pkg_name, pkg_str in pkg_name_content_tuples:
+        pkg_dir = packages_dir.ensure(pkg_name, dir=True)
+        pkg_file = pkg_dir.join("package.py")
+        with open(str(pkg_file), "w") as f:
+            f.write(pkg_str)
+
+    return spack.repo.Repo(repo_path)
+
+
+@pytest.fixture()
+def compiler_factory():
+    """Factory for a compiler dict, taking a spec and an OS as arguments."""
+
+    def _factory(*, spec, operating_system):
+        return {
+            "compiler": {
+                "spec": spec,
+                "operating_system": operating_system,
+                "paths": {"cc": "/path/to/cc", "cxx": "/path/to/cxx", "f77": None, "fc": None},
+                "modules": [],
+                "target": str(archspec.cpu.host().family),
+            }
+        }
+
+    return _factory
+
+
+@pytest.fixture()
+def host_architecture_str():
+    """Returns the broad architecture family (x86_64, aarch64, etc.)"""
+    return str(archspec.cpu.host().family)

--- a/lib/spack/spack/test/data/config/compilers.yaml
+++ b/lib/spack/spack/test/data/config/compilers.yaml
@@ -1,353 +1,41 @@
 compilers:
 - compiler:
-    spec: clang@3.3
-    operating_system: {0.name}{0.version}
+    spec: gcc@=4.8.0
+    operating_system: {linux_os.name}{linux_os.version}
+    paths:
+      cc: /path/to/gcc
+      cxx: /path/to/g++
+      f77: None
+      fc: None
+    modules: []
+    target: {target}
+- compiler:
+    spec: gcc@=4.8.0
+    operating_system: redhat6
+    paths:
+      cc: /path/to/gcc
+      cxx: /path/to/g++
+      f77: None
+      fc: None
+    modules: []
+    target: {target}
+- compiler:
+    spec: clang@=12.0.0
+    operating_system: {linux_os.name}{linux_os.version}
     paths:
       cc: /path/to/clang
       cxx: /path/to/clang++
       f77: None
       fc: None
-    modules: 'None'
-    target: x86_64
+    modules: []
+    target: {target}
 - compiler:
-    spec: gcc@4.5.0
-    operating_system: {0.name}{0.version}
+    spec: gcc@=10.2.1
+    operating_system: {linux_os.name}{linux_os.version}
     paths:
       cc: /path/to/gcc
       cxx: /path/to/g++
       f77: None
       fc: None
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: gcc@4.5.0
-    operating_system: redhat6
-    paths:
-      cc: /path/to/gcc
-      cxx: /path/to/g++
-      f77: None
-      fc: None
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: clang@3.3
-    operating_system: CNL
-    paths:
-      cc: /path/to/clang
-      cxx: /path/to/clang++
-      f77: None
-      fc: None
-    modules: 'None'
-- compiler:
-    spec: clang@3.3
-    operating_system: SuSE11
-    paths:
-      cc: /path/to/clang
-      cxx: /path/to/clang++
-      f77: None
-      fc: None
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: clang@3.3
-    operating_system: yosemite
-    paths:
-      cc: /path/to/clang
-      cxx: /path/to/clang++
-      f77: None
-      fc: None
-    modules: 'None'
-    target: x86_64
-- compiler:
-    paths:
-      cc: /path/to/gcc
-      cxx: /path/to/g++
-      f77: /path/to/gfortran
-      fc: /path/to/gfortran
-    operating_system: CNL
-    spec: gcc@4.5.0
-    modules: 'None'
-- compiler:
-    paths:
-      cc: /path/to/gcc
-      cxx: /path/to/g++
-      f77: /path/to/gfortran
-      fc: /path/to/gfortran
-    operating_system: SuSE11
-    spec: gcc@4.5.0
-    modules: 'None'
-    target: x86_64
-- compiler:
-    paths:
-      cc: /path/to/gcc
-      cxx: /path/to/g++
-      f77: /path/to/gfortran
-      fc: /path/to/gfortran
-    operating_system: yosemite
-    spec: gcc@4.5.0
-    modules: 'None'
-    target: x86_64
-- compiler:
-    paths:
-      cc: /path/to/gcc
-      cxx: /path/to/g++
-      f77: /path/to/gfortran
-      fc: /path/to/gfortran
-    operating_system: elcapitan
-    spec: gcc@4.5.0
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: clang@3.3
-    operating_system: elcapitan
-    paths:
-      cc: /path/to/clang
-      cxx: /path/to/clang++
-      f77: None
-      fc: None
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: gcc@4.7.2
-    operating_system: redhat6
-    paths:
-      cc: /path/to/gcc472
-      cxx: /path/to/g++472
-      f77: /path/to/gfortran472
-      fc: /path/to/gfortran472
-    flags:
-      cflags: -O0 -g
-      cxxflags: -O0 -g
-      fflags: -O0 -g
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: gcc@4.4.0
-    operating_system: redhat6
-    paths:
-      cc: /path/to/gcc440
-      cxx: /path/to/g++440
-      f77: /path/to/gfortran440
-      fc: /path/to/gfortran440
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: clang@3.5
-    operating_system: redhat6
-    paths:
-      cc: /path/to/clang35
-      cxx: /path/to/clang++35
-      f77: None
-      fc: None
-    flags:
-      cflags: -O3
-      cxxflags: -O3
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: clang@8.0.0
-    operating_system: redhat7
-    paths:
-      cc: /path/to/clang-8
-      cxx: /path/to/clang++-8
-      f77: /path/to/gfortran-9
-      fc: /path/to/gfortran-9
-    flags:
-      cflags: -O3
-      cxxflags: -O3
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: apple-clang@9.1.0
-    operating_system: elcapitan
-    paths:
-      cc: /path/to/clang
-      cxx: /path/to/clang++
-      f77: None
-      fc: None
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: gcc@10foo
-    operating_system: redhat6
-    paths:
-      cc: /path/to/gcc
-      cxx: /path/to/g++
-      f77: /path/to/gfortran
-      fc: /path/to/gfortran
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: gcc@4.4.0-special
-    operating_system: redhat6
-    paths:
-      cc: /path/to/gcc
-      cxx: /path/to/g++
-      f77: /path/to/gfortran
-      fc: /path/to/gfortran
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: clang@12.0.0
-    operating_system: {0.name}{0.version}
-    paths:
-      cc: /path/to/clang
-      cxx: /path/to/clang++
-      f77: None
-      fc: None
-    modules: 'None'
-    target: aarch64
-- compiler:
-    spec: gcc@10.2.1
-    operating_system: {0.name}{0.version}
-    paths:
-      cc: /path/to/gcc
-      cxx: /path/to/g++
-      f77: None
-      fc: None
-    modules: 'None'
-    target: aarch64
-- compiler:
-    spec: clang@12.0.0
-    operating_system: redhat6
-    paths:
-      cc: /path/to/clang
-      cxx: /path/to/clang++
-      f77: None
-      fc: None
-    modules: 'None'
-    target: aarch64
-- compiler:
-    spec: gcc@10.2.1
-    operating_system: redhat6
-    paths:
-      cc: /path/to/gcc
-      cxx: /path/to/g++
-      f77: None
-      fc: None
-    modules: 'None'
-    target: aarch64
-- compiler:
-    spec: gcc@10.1.0
-    operating_system: redhat6
-    paths:
-      cc: /path/to/gcc
-      cxx: /path/to/g++
-      f77: None
-      fc: None
-    modules: 'None'
-    target: aarch64
-- compiler:
-    spec: gcc@11.1.0
-    operating_system: redhat6
-    paths:
-      cc: /path/to/gcc
-      cxx: /path/to/g++
-      f77: None
-      fc: None
-    flags:
-      cflags: -O0 -g
-      cxxflags: -O0 -g
-      fflags: -O0 -g
-    modules: 'None'
-    target: aarch64
-- compiler:
-    spec: clang@12.2.0
-    operating_system: redhat6
-    paths:
-      cc: /path/to/clang35
-      cxx: /path/to/clang++35
-      f77: None
-      fc: None
-    flags:
-      cflags: -O3
-      cxxflags: -O3
-    modules: 'None'
-    target: aarch64
-- compiler:
-    spec: gcc@10foo
-    operating_system: redhat6
-    paths:
-      cc: /path/to/gcc
-      cxx: /path/to/g++
-      f77: /path/to/gfortran
-      fc: /path/to/gfortran
-    modules: 'None'
-    target: aarch64
-- compiler:
-    spec: clang@12.0.0
-    operating_system: {0.name}{0.version}
-    paths:
-      cc: /path/to/clang
-      cxx: /path/to/clang++
-      f77: None
-      fc: None
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: gcc@10.2.1
-    operating_system: {0.name}{0.version}
-    paths:
-      cc: /path/to/gcc
-      cxx: /path/to/g++
-      f77: None
-      fc: None
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: clang@12.0.0
-    operating_system: redhat6
-    paths:
-      cc: /path/to/clang
-      cxx: /path/to/clang++
-      f77: None
-      fc: None
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: gcc@10.2.1
-    operating_system: redhat6
-    paths:
-      cc: /path/to/gcc
-      cxx: /path/to/g++
-      f77: None
-      fc: None
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: gcc@10.1.0
-    operating_system: redhat6
-    paths:
-      cc: /path/to/gcc
-      cxx: /path/to/g++
-      f77: None
-      fc: None
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: gcc@11.1.0
-    operating_system: redhat6
-    paths:
-      cc: /path/to/gcc
-      cxx: /path/to/g++
-      f77: None
-      fc: None
-    flags:
-      cflags: -O0 -g
-      cxxflags: -O0 -g
-      fflags: -O0 -g
-    modules: 'None'
-    target: x86_64
-- compiler:
-    spec: clang@12.2.0
-    operating_system: redhat6
-    paths:
-      cc: /path/to/clang35
-      cxx: /path/to/clang++35
-      f77: None
-      fc: None
-    flags:
-      cflags: -O3
-      cxxflags: -O3
-    modules: 'None'
-    target: x86_64
+    modules: []
+    target: {target}

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -30,7 +30,7 @@ def test_true_directives_exist(mock_packages):
 
     assert cls.dependencies
     assert spack.spec.Spec() in cls.dependencies["extendee"]
-    assert spack.spec.Spec() in cls.dependencies["b"]
+    assert spack.spec.Spec() in cls.dependencies["pkg-b"]
 
     assert cls.resources
     assert spack.spec.Spec() in cls.resources
@@ -43,7 +43,7 @@ def test_constraints_from_context(mock_packages):
     pkg_cls = spack.repo.PATH.get_pkg_class("with-constraint-met")
 
     assert pkg_cls.dependencies
-    assert spack.spec.Spec("@1.0") in pkg_cls.dependencies["b"]
+    assert spack.spec.Spec("@1.0") in pkg_cls.dependencies["pkg-b"]
 
     assert pkg_cls.conflicts
     assert (spack.spec.Spec("+foo@1.0"), None) in pkg_cls.conflicts["%gcc"]
@@ -54,7 +54,7 @@ def test_constraints_from_context_are_merged(mock_packages):
     pkg_cls = spack.repo.PATH.get_pkg_class("with-constraint-met")
 
     assert pkg_cls.dependencies
-    assert spack.spec.Spec("@0.14:15 ^b@3.8:4.0") in pkg_cls.dependencies["c"]
+    assert spack.spec.Spec("@0.14:15 ^pkg-b@3.8:4.0") in pkg_cls.dependencies["pkg-c"]
 
 
 @pytest.mark.regression("27754")
@@ -68,7 +68,7 @@ def test_extends_spec(config, mock_packages):
 
 @pytest.mark.regression("34368")
 def test_error_on_anonymous_dependency(config, mock_packages):
-    pkg = spack.repo.PATH.get_pkg_class("a")
+    pkg = spack.repo.PATH.get_pkg_class("pkg-a")
     with pytest.raises(spack.directives.DependencyError):
         spack.directives._depends_on(pkg, "@4.5")
 

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -377,10 +377,10 @@ spack:
     """
     )
     env = ev.Environment(tmp_path)
-    env.add("a")
+    env.add("pkg-a")
 
     assert len(env.user_specs) == 1
-    assert env.manifest.pristine_yaml_content["spack"]["specs"] == ["a"]
+    assert env.manifest.pristine_yaml_content["spack"]["specs"] == ["pkg-a"]
 
 
 @pytest.mark.parametrize(
@@ -578,7 +578,7 @@ def test_conflicts_with_packages_that_are_not_dependencies(
 spack:
   specs:
   - {spec_str}
-  - b
+  - pkg-b
   concretizer:
     unify: true
 """
@@ -706,7 +706,7 @@ def test_variant_propagation_with_unify_false(tmp_path, mock_packages, config):
     spack:
       specs:
       - parent-foo ++foo
-      - c
+      - pkg-c
       concretizer:
         unify: false
     """
@@ -791,10 +791,10 @@ def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path, mock
         """spack:
       specs:
       # These two specs concretize to the same hash
-      - c
-      - c@1.0
+      - pkg-c
+      - pkg-c@1.0
       # Spec used to trigger the bug
-      - a
+      - pkg-a
       concretizer:
         unify: true
     """
@@ -802,8 +802,8 @@ def test_deconcretize_then_concretize_does_not_error(mutable_mock_env_path, mock
     e = ev.Environment(mutable_mock_env_path)
     with e:
         e.concretize()
-        e.deconcretize(spack.spec.Spec("a"), concrete=False)
+        e.deconcretize(spack.spec.Spec("pkg-a"), concrete=False)
         e.concretize()
     assert len(e.concrete_roots()) == 3
-    all_root_hashes = set(x.dag_hash() for x in e.concrete_roots())
+    all_root_hashes = {x.dag_hash() for x in e.concrete_roots()}
     assert len(all_root_hashes) == 2

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -141,6 +141,7 @@ def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch, wo
     assert s.package.spec.installed
 
 
+@pytest.mark.not_on_windows("Fails spuriously on Windows")
 @pytest.mark.disable_clean_stage_check
 def test_failing_overwrite_install_should_keep_previous_installation(
     mock_fetch, install_mockery, working_env

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -11,6 +11,8 @@ import sys
 import py
 import pytest
 
+import archspec.cpu
+
 import llnl.util.filesystem as fs
 import llnl.util.lock as ulk
 import llnl.util.tty as tty
@@ -528,6 +530,10 @@ def test_update_tasks_for_compiler_packages_as_compiler(mock_packages, config, m
     assert installer.build_pq[0][1].compiler
 
 
+@pytest.mark.skipif(
+    str(archspec.cpu.host().family) != "x86_64",
+    reason="OneAPI compiler is not supported on other architectures",
+)
 def test_bootstrapping_compilers_with_different_names_from_spec(
     install_mockery, mutable_config, mock_fetch, archspec_host_is_spack_test_host
 ):

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -132,7 +132,7 @@ def test_hms(sec, result):
 
 def test_get_dependent_ids(install_mockery, mock_packages):
     # Concretize the parent package, which handle dependency too
-    spec = spack.spec.Spec("a")
+    spec = spack.spec.Spec("pkg-a")
     spec.concretize()
     assert spec.concrete
 
@@ -223,11 +223,11 @@ def test_process_binary_cache_tarball_tar(install_mockery, monkeypatch, capfd):
     # Skip database updates
     monkeypatch.setattr(spack.database.Database, "add", _noop)
 
-    spec = spack.spec.Spec("a").concretized()
+    spec = spack.spec.Spec("pkg-a").concretized()
     assert inst._process_binary_cache_tarball(spec.package, explicit=False, unsigned=False)
 
     out = capfd.readouterr()[0]
-    assert "Extracting a" in out
+    assert "Extracting pkg-a" in out
     assert "from binary cache" in out
 
 
@@ -278,7 +278,7 @@ def test_installer_prune_built_build_deps(install_mockery, monkeypatch, tmpdir):
 
     @property
     def _mock_installed(self):
-        return self.name in ["c"]
+        return self.name == "pkg-c"
 
     # Mock the installed property to say that (b) is installed
     monkeypatch.setattr(spack.spec.Spec, "installed", _mock_installed)
@@ -286,24 +286,25 @@ def test_installer_prune_built_build_deps(install_mockery, monkeypatch, tmpdir):
     # Create mock repository with packages (a), (b), (c), (d), and (e)
     builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock-repo"))
 
-    builder.add_package("a", dependencies=[("b", "build", None), ("c", "build", None)])
-    builder.add_package("b", dependencies=[("d", "build", None)])
+    builder.add_package("pkg-a", dependencies=[("pkg-b", "build", None), ("pkg-c", "build", None)])
+    builder.add_package("pkg-b", dependencies=[("pkg-d", "build", None)])
     builder.add_package(
-        "c", dependencies=[("d", "build", None), ("e", "all", None), ("f", "build", None)]
+        "pkg-c",
+        dependencies=[("pkg-d", "build", None), ("pkg-e", "all", None), ("pkg-f", "build", None)],
     )
-    builder.add_package("d")
-    builder.add_package("e")
-    builder.add_package("f")
+    builder.add_package("pkg-d")
+    builder.add_package("pkg-e")
+    builder.add_package("pkg-f")
 
     with spack.repo.use_repositories(builder.root):
-        const_arg = installer_args(["a"], {})
+        const_arg = installer_args(["pkg-a"], {})
         installer = create_installer(const_arg)
 
         installer._init_queue()
 
         # Assert that (c) is not in the build_pq
-        result = set([task.pkg_id[0] for _, task in installer.build_pq])
-        expected = set(["a", "b", "c", "d", "e"])
+        result = {task.pkg_id[:5] for _, task in installer.build_pq}
+        expected = {"pkg-a", "pkg-b", "pkg-c", "pkg-d", "pkg-e"}
         assert result == expected
 
 
@@ -418,8 +419,7 @@ def test_ensure_locked_have(install_mockery, tmpdir, capsys):
 
 @pytest.mark.parametrize("lock_type,reads,writes", [("read", 1, 0), ("write", 0, 1)])
 def test_ensure_locked_new_lock(install_mockery, tmpdir, lock_type, reads, writes):
-    pkg_id = "a"
-    const_arg = installer_args([pkg_id], {})
+    const_arg = installer_args(["pkg-a"], {})
     installer = create_installer(const_arg)
     spec = installer.build_requests[0].pkg.spec
     with tmpdir.as_cwd():
@@ -438,8 +438,7 @@ def test_ensure_locked_new_warn(install_mockery, monkeypatch, tmpdir, capsys):
         lock.default_timeout = 1e-9 if timeout is None else None
         return lock
 
-    pkg_id = "a"
-    const_arg = installer_args([pkg_id], {})
+    const_arg = installer_args(["pkg-a"], {})
     installer = create_installer(const_arg)
     spec = installer.build_requests[0].pkg.spec
 
@@ -496,7 +495,7 @@ def test_packages_needed_to_bootstrap_compiler_packages(install_mockery, monkeyp
     spec.concretize()
 
     def _conc_spec(compiler):
-        return spack.spec.Spec("a").concretized()
+        return spack.spec.Spec("pkg-a").concretized()
 
     # Ensure we can get past functions that are precluding obtaining
     # packages.
@@ -604,7 +603,7 @@ def test_clear_failures_success(tmpdir):
     """Test the clear_failures happy path."""
     failures = spack.database.FailureTracker(str(tmpdir), default_timeout=0.1)
 
-    spec = spack.spec.Spec("a")
+    spec = spack.spec.Spec("pkg-a")
     spec._mark_concrete()
 
     # Set up a test prefix failure lock
@@ -630,7 +629,7 @@ def test_clear_failures_success(tmpdir):
 def test_clear_failures_errs(tmpdir, capsys):
     """Test the clear_failures exception paths."""
     failures = spack.database.FailureTracker(str(tmpdir), default_timeout=0.1)
-    spec = spack.spec.Spec("a")
+    spec = spack.spec.Spec("pkg-a")
     spec._mark_concrete()
     failures.mark(spec)
 
@@ -692,11 +691,11 @@ def test_check_deps_status_install_failure(install_mockery):
     """Tests that checking the dependency status on a request to install
     'a' fails, if we mark the dependency as failed.
     """
-    s = spack.spec.Spec("a").concretized()
+    s = spack.spec.Spec("pkg-a").concretized()
     for dep in s.traverse(root=False):
         spack.store.STORE.failure_tracker.mark(dep)
 
-    const_arg = installer_args(["a"], {})
+    const_arg = installer_args(["pkg-a"], {})
     installer = create_installer(const_arg)
     request = installer.build_requests[0]
 
@@ -705,7 +704,7 @@ def test_check_deps_status_install_failure(install_mockery):
 
 
 def test_check_deps_status_write_locked(install_mockery, monkeypatch):
-    const_arg = installer_args(["a"], {})
+    const_arg = installer_args(["pkg-a"], {})
     installer = create_installer(const_arg)
     request = installer.build_requests[0]
 
@@ -717,7 +716,7 @@ def test_check_deps_status_write_locked(install_mockery, monkeypatch):
 
 
 def test_check_deps_status_external(install_mockery, monkeypatch):
-    const_arg = installer_args(["a"], {})
+    const_arg = installer_args(["pkg-a"], {})
     installer = create_installer(const_arg)
     request = installer.build_requests[0]
 
@@ -730,7 +729,7 @@ def test_check_deps_status_external(install_mockery, monkeypatch):
 
 
 def test_check_deps_status_upstream(install_mockery, monkeypatch):
-    const_arg = installer_args(["a"], {})
+    const_arg = installer_args(["pkg-a"], {})
     installer = create_installer(const_arg)
     request = installer.build_requests[0]
 
@@ -807,7 +806,7 @@ def test_install_task_add_compiler(install_mockery, monkeypatch, capfd):
     def _add(_compilers):
         tty.msg(config_msg)
 
-    const_arg = installer_args(["a"], {})
+    const_arg = installer_args(["pkg-a"], {})
     installer = create_installer(const_arg)
     task = create_build_task(installer.build_requests[0].pkg)
     task.compiler = True
@@ -845,7 +844,7 @@ def test_release_lock_write_n_exception(install_mockery, tmpdir, capsys):
 @pytest.mark.parametrize("installed", [True, False])
 def test_push_task_skip_processed(install_mockery, installed):
     """Test to ensure skip re-queueing a processed package."""
-    const_arg = installer_args(["a"], {})
+    const_arg = installer_args(["pkg-a"], {})
     installer = create_installer(const_arg)
     assert len(list(installer.build_tasks)) == 0
 
@@ -863,7 +862,7 @@ def test_push_task_skip_processed(install_mockery, installed):
 
 def test_requeue_task(install_mockery, capfd):
     """Test to ensure cover _requeue_task."""
-    const_arg = installer_args(["a"], {})
+    const_arg = installer_args(["pkg-a"], {})
     installer = create_installer(const_arg)
     task = create_build_task(installer.build_requests[0].pkg)
 
@@ -881,7 +880,7 @@ def test_requeue_task(install_mockery, capfd):
     assert qtask.attempts == task.attempts + 1
 
     out = capfd.readouterr()[1]
-    assert "Installing a" in out
+    assert "Installing pkg-a" in out
     assert " in progress by another process" in out
 
 
@@ -894,17 +893,17 @@ def test_cleanup_all_tasks(install_mockery, monkeypatch):
     def _rmtask(installer, pkg_id):
         raise RuntimeError("Raise an exception to test except path")
 
-    const_arg = installer_args(["a"], {})
+    const_arg = installer_args(["pkg-a"], {})
     installer = create_installer(const_arg)
     spec = installer.build_requests[0].pkg.spec
 
     # Cover task removal happy path
-    installer.build_tasks["a"] = _mktask(spec.package)
+    installer.build_tasks["pkg-a"] = _mktask(spec.package)
     installer._cleanup_all_tasks()
     assert len(installer.build_tasks) == 0
 
     # Cover task removal exception path
-    installer.build_tasks["a"] = _mktask(spec.package)
+    installer.build_tasks["pkg-a"] = _mktask(spec.package)
     monkeypatch.setattr(inst.PackageInstaller, "_remove_task", _rmtask)
     installer._cleanup_all_tasks()
     assert len(installer.build_tasks) == 1
@@ -998,7 +997,7 @@ def test_install_uninstalled_deps(install_mockery, monkeypatch, capsys):
 
 def test_install_failed(install_mockery, monkeypatch, capsys):
     """Test install with failed install."""
-    const_arg = installer_args(["b"], {})
+    const_arg = installer_args(["pkg-b"], {})
     installer = create_installer(const_arg)
 
     # Make sure the package is identified as failed
@@ -1014,7 +1013,7 @@ def test_install_failed(install_mockery, monkeypatch, capsys):
 
 def test_install_failed_not_fast(install_mockery, monkeypatch, capsys):
     """Test install with failed install."""
-    const_arg = installer_args(["a"], {"fail_fast": False})
+    const_arg = installer_args(["pkg-a"], {"fail_fast": False})
     installer = create_installer(const_arg)
 
     # Make sure the package is identified as failed
@@ -1025,12 +1024,12 @@ def test_install_failed_not_fast(install_mockery, monkeypatch, capsys):
 
     out = str(capsys.readouterr())
     assert "failed to install" in out
-    assert "Skipping build of a" in out
+    assert "Skipping build of pkg-a" in out
 
 
 def test_install_fail_on_interrupt(install_mockery, monkeypatch):
     """Test ctrl-c interrupted install."""
-    spec_name = "a"
+    spec_name = "pkg-a"
     err_msg = "mock keyboard interrupt for {0}".format(spec_name)
 
     def _interrupt(installer, task, install_status, **kwargs):
@@ -1048,13 +1047,13 @@ def test_install_fail_on_interrupt(install_mockery, monkeypatch):
     with pytest.raises(KeyboardInterrupt, match=err_msg):
         installer.install()
 
-    assert "b" in installer.installed  # ensure dependency of a is 'installed'
+    assert "pkg-b" in installer.installed  # ensure dependency of pkg-a is 'installed'
     assert spec_name not in installer.installed
 
 
 def test_install_fail_single(install_mockery, monkeypatch):
     """Test expected results for failure of single package."""
-    spec_name = "a"
+    spec_name = "pkg-a"
     err_msg = "mock internal package build error for {0}".format(spec_name)
 
     class MyBuildException(Exception):
@@ -1075,13 +1074,13 @@ def test_install_fail_single(install_mockery, monkeypatch):
     with pytest.raises(MyBuildException, match=err_msg):
         installer.install()
 
-    assert "b" in installer.installed  # ensure dependency of a is 'installed'
+    assert "pkg-b" in installer.installed  # ensure dependency of a is 'installed'
     assert spec_name not in installer.installed
 
 
 def test_install_fail_multi(install_mockery, monkeypatch):
     """Test expected results for failure of multiple packages."""
-    spec_name = "c"
+    spec_name = "pkg-c"
     err_msg = "mock internal package build error"
 
     class MyBuildException(Exception):
@@ -1093,7 +1092,7 @@ def test_install_fail_multi(install_mockery, monkeypatch):
         else:
             installer.installed.add(task.pkg.name)
 
-    const_arg = installer_args([spec_name, "a"], {})
+    const_arg = installer_args([spec_name, "pkg-a"], {})
     installer = create_installer(const_arg)
 
     # Raise a KeyboardInterrupt error to trigger early termination
@@ -1102,14 +1101,14 @@ def test_install_fail_multi(install_mockery, monkeypatch):
     with pytest.raises(inst.InstallError, match="Installation request failed"):
         installer.install()
 
-    assert "a" in installer.installed  # ensure the the second spec installed
+    assert "pkg-a" in installer.installed  # ensure the the second spec installed
     assert spec_name not in installer.installed
 
 
 def test_install_fail_fast_on_detect(install_mockery, monkeypatch, capsys):
     """Test fail_fast install when an install failure is detected."""
-    const_arg = installer_args(["b"], {"fail_fast": False})
-    const_arg.extend(installer_args(["c"], {"fail_fast": True}))
+    const_arg = installer_args(["pkg-b"], {"fail_fast": False})
+    const_arg.extend(installer_args(["pkg-c"], {"fail_fast": True}))
     installer = create_installer(const_arg)
     pkg_ids = [inst.package_id(spec.package) for spec, _ in const_arg]
 
@@ -1139,7 +1138,7 @@ def _test_install_fail_fast_on_except_patch(installer, **kwargs):
 @pytest.mark.disable_clean_stage_check
 def test_install_fail_fast_on_except(install_mockery, monkeypatch, capsys):
     """Test fail_fast install when an install failure results from an error."""
-    const_arg = installer_args(["a"], {"fail_fast": True})
+    const_arg = installer_args(["pkg-a"], {"fail_fast": True})
     installer = create_installer(const_arg)
 
     # Raise a non-KeyboardInterrupt exception to trigger fast failure.
@@ -1154,7 +1153,7 @@ def test_install_fail_fast_on_except(install_mockery, monkeypatch, capsys):
         installer.install()
 
     out = str(capsys.readouterr())
-    assert "Skipping build of a" in out
+    assert "Skipping build of pkg-a" in out
 
 
 def test_install_lock_failures(install_mockery, monkeypatch, capfd):
@@ -1163,7 +1162,7 @@ def test_install_lock_failures(install_mockery, monkeypatch, capfd):
     def _requeued(installer, task, install_status):
         tty.msg("requeued {0}".format(task.pkg.spec.name))
 
-    const_arg = installer_args(["b"], {})
+    const_arg = installer_args(["pkg-b"], {})
     installer = create_installer(const_arg)
 
     # Ensure never acquire a lock
@@ -1183,7 +1182,7 @@ def test_install_lock_failures(install_mockery, monkeypatch, capfd):
 
 def test_install_lock_installed_requeue(install_mockery, monkeypatch, capfd):
     """Cover basic install handling for installed package."""
-    const_arg = installer_args(["b"], {})
+    const_arg = installer_args(["pkg-b"], {})
     b, _ = const_arg[0]
     installer = create_installer(const_arg)
     b_pkg_id = inst.package_id(b.package)
@@ -1239,7 +1238,7 @@ def test_install_read_locked_requeue(install_mockery, monkeypatch, capfd):
     # Ensure don't continually requeue the task
     monkeypatch.setattr(inst.PackageInstaller, "_requeue_task", _requeued)
 
-    const_arg = installer_args(["b"], {})
+    const_arg = installer_args(["pkg-b"], {})
     installer = create_installer(const_arg)
 
     with pytest.raises(inst.InstallError, match="request failed"):
@@ -1255,7 +1254,7 @@ def test_install_read_locked_requeue(install_mockery, monkeypatch, capfd):
 
 def test_install_skip_patch(install_mockery, mock_fetch):
     """Test the path skip_patch install path."""
-    spec_name = "b"
+    spec_name = "pkg-b"
     const_arg = installer_args([spec_name], {"fake": False, "skip_patch": True})
     installer = create_installer(const_arg)
 
@@ -1282,7 +1281,7 @@ def test_overwrite_install_backup_success(temporary_store, config, mock_packages
     of the original prefix, and leave the original spec marked installed.
     """
     # Get a build task. TODO: refactor this to avoid calling internal methods
-    const_arg = installer_args(["b"])
+    const_arg = installer_args(["pkg-b"], {})
     installer = create_installer(const_arg)
     installer._init_queue()
     task = installer._pop_task()
@@ -1343,7 +1342,7 @@ def test_overwrite_install_backup_failure(temporary_store, config, mock_packages
             self.called = True
 
     # Get a build task. TODO: refactor this to avoid calling internal methods
-    const_arg = installer_args(["b"])
+    const_arg = installer_args(["pkg-b"], {})
     installer = create_installer(const_arg)
     installer._init_queue()
     task = installer._pop_task()
@@ -1372,8 +1371,8 @@ def test_term_status_line():
     # accept that. `with log_output(buf)` doesn't really work because it trims output
     # and we actually want to test for escape sequences etc.
     x = inst.TermStatusLine(enabled=True)
-    x.add("a")
-    x.add("b")
+    x.add("pkg-a")
+    x.add("pkg-b")
     x.clear()
 
 

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -289,8 +289,8 @@ def test_mirror_cache_symlinks(tmpdir):
 @pytest.mark.parametrize(
     "specs,expected_specs",
     [
-        (["a"], ["a@=1.0", "a@=2.0"]),
-        (["a", "brillig"], ["a@=1.0", "a@=2.0", "brillig@=1.0.0", "brillig@=2.0.0"]),
+        (["pkg-a"], ["pkg-a@=1.0", "pkg-a@=2.0"]),
+        (["pkg-a", "brillig"], ["pkg-a@=1.0", "pkg-a@=2.0", "brillig@=1.0.0", "brillig@=2.0.0"]),
     ],
 )
 def test_get_all_versions(specs, expected_specs):

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -7,6 +7,8 @@ import os
 
 import pytest
 
+import archspec.cpu
+
 import spack.environment as ev
 import spack.main
 import spack.modules.lmod
@@ -100,14 +102,19 @@ class TestLmod:
         else:
             assert repetitions == 1
 
-    def test_compilers_provided_different_name(self, factory, module_configuration):
-        module_configuration("complex_hierarchy")
-        module, spec = factory("intel-oneapi-compilers%clang@3.3")
+    def test_compilers_provided_different_name(
+        self, factory, module_configuration, compiler_factory
+    ):
+        with spack.config.override(
+            "compilers", [compiler_factory(spec="clang@3.3", operating_system="debian6")]
+        ):
+            module_configuration("complex_hierarchy")
+            module, spec = factory("intel-oneapi-compilers%clang@3.3")
 
-        provides = module.conf.provides
+            provides = module.conf.provides
 
-        assert "compiler" in provides
-        assert provides["compiler"] == spack.spec.CompilerSpec("oneapi@=3.0")
+            assert "compiler" in provides
+            assert provides["compiler"] == spack.spec.CompilerSpec("oneapi@=3.0")
 
     def test_simple_case(self, modulefile_content, module_configuration):
         """Tests the generation of a simple Lua module file."""
@@ -136,6 +143,9 @@ class TestLmod:
 
         assert len([x for x in content if "depends_on(" in x]) == 5
 
+    @pytest.mark.skipif(
+        str(archspec.cpu.host().family) != "x86_64", reason="test data is specific for x86_64"
+    )
     def test_alter_environment(self, modulefile_content, module_configuration):
         """Tests modifications to run-time environment."""
 
@@ -207,6 +217,9 @@ class TestLmod:
 
         assert len([x for x in content if 'setenv("FOO", "{{name}}, {name}, {{}}, {}")' in x]) == 1
 
+    @pytest.mark.skipif(
+        str(archspec.cpu.host().family) != "x86_64", reason="test data is specific for x86_64"
+    )
     def test_help_message(self, modulefile_content, module_configuration):
         """Tests the generation of module help message."""
 
@@ -330,14 +343,16 @@ class TestLmod:
 
         assert "Override successful!" in content
 
-    def test_override_template_in_modules_yaml(self, modulefile_content, module_configuration):
+    def test_override_template_in_modules_yaml(
+        self, modulefile_content, module_configuration, host_architecture_str
+    ):
         """Tests overriding a template from `modules.yaml`"""
         module_configuration("override_template")
 
         content = modulefile_content("override-module-templates")
         assert "Override even better!" in content
 
-        content = modulefile_content("mpileaks target=x86_64")
+        content = modulefile_content(f"mpileaks target={host_architecture_str}")
         assert "Override even better!" in content
 
     @pytest.mark.usefixtures("config")

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -7,6 +7,8 @@ import os
 
 import pytest
 
+import archspec.cpu
+
 import spack.modules.common
 import spack.modules.tcl
 import spack.spec
@@ -89,22 +91,29 @@ class TestTcl:
         assert len([x for x in content if "depends-on " in x]) == 2
         assert len([x for x in content if "module load " in x]) == 2
 
-    def test_prerequisites_direct(self, modulefile_content, module_configuration):
+    def test_prerequisites_direct(
+        self, modulefile_content, module_configuration, host_architecture_str
+    ):
         """Tests asking direct dependencies as prerequisites."""
 
         module_configuration("prerequisites_direct")
-        content = modulefile_content("mpileaks target=x86_64")
+        content = modulefile_content(f"mpileaks target={host_architecture_str}")
 
         assert len([x for x in content if "prereq" in x]) == 2
 
-    def test_prerequisites_all(self, modulefile_content, module_configuration):
+    def test_prerequisites_all(
+        self, modulefile_content, module_configuration, host_architecture_str
+    ):
         """Tests asking all dependencies as prerequisites."""
 
         module_configuration("prerequisites_all")
-        content = modulefile_content("mpileaks target=x86_64")
+        content = modulefile_content(f"mpileaks target={host_architecture_str}")
 
         assert len([x for x in content if "prereq" in x]) == 5
 
+    @pytest.mark.skipif(
+        str(archspec.cpu.host().family) != "x86_64", reason="test data is specific for x86_64"
+    )
     def test_alter_environment(self, modulefile_content, module_configuration):
         """Tests modifications to run-time environment."""
 
@@ -177,6 +186,9 @@ class TestTcl:
 
         assert len([x for x in content if "setenv FOO {{{name}}, {name}, {{}}, {}}" in x]) == 1
 
+    @pytest.mark.skipif(
+        str(archspec.cpu.host().family) != "x86_64", reason="test data is specific for x86_64"
+    )
     def test_help_message(self, modulefile_content, module_configuration):
         """Tests the generation of module help message."""
 
@@ -219,7 +231,7 @@ class TestTcl:
         )
         assert help_msg in "".join(content)
 
-    def test_exclude(self, modulefile_content, module_configuration):
+    def test_exclude(self, modulefile_content, module_configuration, host_architecture_str):
         """Tests excluding the generation of selected modules."""
 
         module_configuration("exclude")
@@ -231,9 +243,9 @@ class TestTcl:
         # and IOError on Python 2 or common bases like EnvironmentError
         # which are not officially documented
         with pytest.raises(Exception):
-            modulefile_content("callpath target=x86_64")
+            modulefile_content(f"callpath target={host_architecture_str}")
 
-        content = modulefile_content("zmpi target=x86_64")
+        content = modulefile_content(f"zmpi target={host_architecture_str}")
 
         assert len([x for x in content if "module load " in x]) == 1
 
@@ -403,14 +415,16 @@ class TestTcl:
 
         assert "Override successful!" in content
 
-    def test_override_template_in_modules_yaml(self, modulefile_content, module_configuration):
+    def test_override_template_in_modules_yaml(
+        self, modulefile_content, module_configuration, host_architecture_str
+    ):
         """Tests overriding a template from `modules.yaml`"""
         module_configuration("override_template")
 
         content = modulefile_content("override-module-templates")
         assert "Override even better!" in content
 
-        content = modulefile_content("mpileaks target=x86_64")
+        content = modulefile_content(f"mpileaks target={host_architecture_str}")
         assert "Override even better!" in content
 
     def test_extend_context(self, modulefile_content, module_configuration):

--- a/lib/spack/spack/test/multimethod.py
+++ b/lib/spack/spack/test/multimethod.py
@@ -69,9 +69,15 @@ def test_no_version_match(pkg_name):
         ("", "boolean_false_first", "True"),
     ],
 )
-def test_multimethod_calls(pkg_name, constraint_str, method_name, expected_result):
-    s = spack.spec.Spec(pkg_name + constraint_str).concretized()
-    msg = "Method {0} from {1} is giving a wrong result".format(method_name, s)
+def test_multimethod_calls(
+    pkg_name, constraint_str, method_name, expected_result, compiler_factory
+):
+    # Add apple-clang, as it is required by one of the tests
+    with spack.config.override(
+        "compilers", [compiler_factory(spec="apple-clang@9.1.0", operating_system="elcapitan")]
+    ):
+        s = spack.spec.Spec(pkg_name + constraint_str).concretized()
+    msg = f"Method {method_name} from {s} is giving a wrong result"
     assert getattr(s.package, method_name)() == expected_result, msg
 
 

--- a/lib/spack/spack/test/optional_deps.py
+++ b/lib/spack/spack/test/optional_deps.py
@@ -13,28 +13,44 @@ from spack.spec import Spec
         # Normalize simple conditionals
         ("optional-dep-test", {"optional-dep-test": None}),
         ("optional-dep-test~a", {"optional-dep-test~a": None}),
-        ("optional-dep-test+a", {"optional-dep-test+a": {"a": None}}),
-        ("optional-dep-test a=true", {"optional-dep-test a=true": {"a": None}}),
-        ("optional-dep-test a=true", {"optional-dep-test+a": {"a": None}}),
-        ("optional-dep-test@1.1", {"optional-dep-test@1.1": {"b": None}}),
-        ("optional-dep-test%intel", {"optional-dep-test%intel": {"c": None}}),
-        ("optional-dep-test%intel@64.1", {"optional-dep-test%intel@64.1": {"c": None, "d": None}}),
+        ("optional-dep-test+a", {"optional-dep-test+a": {"pkg-a": None}}),
+        ("optional-dep-test a=true", {"optional-dep-test a=true": {"pkg-a": None}}),
+        ("optional-dep-test a=true", {"optional-dep-test+a": {"pkg-a": None}}),
+        ("optional-dep-test@1.1", {"optional-dep-test@1.1": {"pkg-b": None}}),
+        ("optional-dep-test%intel", {"optional-dep-test%intel": {"pkg-c": None}}),
+        (
+            "optional-dep-test%intel@64.1",
+            {"optional-dep-test%intel@64.1": {"pkg-c": None, "pkg-d": None}},
+        ),
         (
             "optional-dep-test%intel@64.1.2",
-            {"optional-dep-test%intel@64.1.2": {"c": None, "d": None}},
+            {"optional-dep-test%intel@64.1.2": {"pkg-c": None, "pkg-d": None}},
         ),
-        ("optional-dep-test%clang@35", {"optional-dep-test%clang@35": {"e": None}}),
+        ("optional-dep-test%clang@35", {"optional-dep-test%clang@35": {"pkg-e": None}}),
         # Normalize multiple conditionals
-        ("optional-dep-test+a@1.1", {"optional-dep-test+a@1.1": {"a": None, "b": None}}),
-        ("optional-dep-test+a%intel", {"optional-dep-test+a%intel": {"a": None, "c": None}}),
-        ("optional-dep-test@1.1%intel", {"optional-dep-test@1.1%intel": {"b": None, "c": None}}),
+        ("optional-dep-test+a@1.1", {"optional-dep-test+a@1.1": {"pkg-a": None, "pkg-b": None}}),
+        (
+            "optional-dep-test+a%intel",
+            {"optional-dep-test+a%intel": {"pkg-a": None, "pkg-c": None}},
+        ),
+        (
+            "optional-dep-test@1.1%intel",
+            {"optional-dep-test@1.1%intel": {"pkg-b": None, "pkg-c": None}},
+        ),
         (
             "optional-dep-test@1.1%intel@64.1.2+a",
-            {"optional-dep-test@1.1%intel@64.1.2+a": {"a": None, "b": None, "c": None, "d": None}},
+            {
+                "optional-dep-test@1.1%intel@64.1.2+a": {
+                    "pkg-a": None,
+                    "pkg-b": None,
+                    "pkg-c": None,
+                    "pkg-d": None,
+                }
+            },
         ),
         (
             "optional-dep-test@1.1%clang@36.5+a",
-            {"optional-dep-test@1.1%clang@36.5+a": {"b": None, "a": None, "e": None}},
+            {"optional-dep-test@1.1%clang@36.5+a": {"pkg-b": None, "pkg-a": None, "pkg-e": None}},
         ),
         # Chained MPI
         (
@@ -44,7 +60,10 @@ from spack.spec import Spec
         # Each of these dependencies comes from a conditional
         # dependency on another.  This requires iterating to evaluate
         # the whole chain.
-        ("optional-dep-test+f", {"optional-dep-test+f": {"f": None, "g": None, "mpi": None}}),
+        (
+            "optional-dep-test+f",
+            {"optional-dep-test+f": {"pkg-f": None, "pkg-g": None, "mpi": None}},
+        ),
     ]
 )
 def spec_and_expected(request):
@@ -63,12 +82,12 @@ def test_normalize(spec_and_expected, config, mock_packages):
 def test_default_variant(config, mock_packages):
     spec = Spec("optional-dep-test-3")
     spec.concretize()
-    assert "a" in spec
+    assert "pkg-a" in spec
 
     spec = Spec("optional-dep-test-3~var")
     spec.concretize()
-    assert "a" in spec
+    assert "pkg-a" in spec
 
     spec = Spec("optional-dep-test-3+var")
     spec.concretize()
-    assert "b" in spec
+    assert "pkg-b" in spec

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -21,6 +21,7 @@ import spack.deptypes as dt
 import spack.install_test
 import spack.package_base
 import spack.repo
+import spack.spec
 from spack.build_systems.generic import Package
 from spack.installer import InstallError
 
@@ -141,19 +142,19 @@ def setup_install_test(source_paths, test_root):
     "spec,sources,extras,expect",
     [
         (
-            "a",
+            "pkg-a",
             ["example/a.c"],  # Source(s)
             ["example/a.c"],  # Extra test source
             ["example/a.c"],
         ),  # Test install dir source(s)
         (
-            "b",
+            "pkg-b",
             ["test/b.cpp", "test/b.hpp", "example/b.txt"],  # Source(s)
             ["test"],  # Extra test source
             ["test/b.cpp", "test/b.hpp"],
         ),  # Test install dir source
         (
-            "c",
+            "pkg-c",
             ["examples/a.py", "examples/b.py", "examples/c.py", "tests/d.py"],
             ["examples/b.py", "tests"],
             ["examples/b.py", "tests/d.py"],
@@ -201,7 +202,7 @@ def test_cache_extra_sources(install_mockery, spec, sources, extras, expect):
 
 
 def test_cache_extra_sources_fails(install_mockery):
-    s = spack.spec.Spec("a").concretized()
+    s = spack.spec.Spec("pkg-a").concretized()
     s.package.spec.concretize()
 
     with pytest.raises(InstallError) as exc_info:
@@ -225,7 +226,7 @@ def test_package_url_and_urls():
         url = "https://www.example.com/url-package-1.0.tgz"
         urls = ["https://www.example.com/archive"]
 
-    s = spack.spec.Spec("a")
+    s = spack.spec.Spec("pkg-a")
     with pytest.raises(ValueError, match="defines both"):
         URLsPackage(s)
 
@@ -235,7 +236,7 @@ def test_package_license():
         extendees = None  # currently a required attribute for is_extension()
         license_files = None
 
-    s = spack.spec.Spec("a")
+    s = spack.spec.Spec("pkg-a")
     pkg = LicensedPackage(s)
     assert pkg.global_license_file is None
 
@@ -248,21 +249,21 @@ class BaseTestPackage(Package):
 
 
 def test_package_version_fails():
-    s = spack.spec.Spec("a")
+    s = spack.spec.Spec("pkg-a")
     pkg = BaseTestPackage(s)
     with pytest.raises(ValueError, match="does not have a concrete version"):
         pkg.version()
 
 
 def test_package_tester_fails():
-    s = spack.spec.Spec("a")
+    s = spack.spec.Spec("pkg-a")
     pkg = BaseTestPackage(s)
     with pytest.raises(ValueError, match="without concrete version"):
         pkg.tester()
 
 
 def test_package_fetcher_fails():
-    s = spack.spec.Spec("a")
+    s = spack.spec.Spec("pkg-a")
     pkg = BaseTestPackage(s)
     with pytest.raises(ValueError, match="without concrete version"):
         pkg.fetcher
@@ -280,7 +281,7 @@ def test_package_test_no_compilers(mock_packages, monkeypatch, capfd):
 
     monkeypatch.setattr(spack.compilers, "compilers_for_spec", compilers)
 
-    s = spack.spec.Spec("a")
+    s = spack.spec.Spec("pkg-a")
     pkg = BaseTestPackage(s)
     pkg.test_requires_compiler = True
     pkg.do_test()

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -517,7 +517,7 @@ def test_manual_download(
     def _instr(pkg):
         return f"Download instructions for {pkg.spec.name}"
 
-    spec = default_mock_concretization("a")
+    spec = default_mock_concretization("pkg-a")
     spec.package.manual_download = manual
     if instr:
         monkeypatch.setattr(spack.package_base.PackageBase, "download_instr", _instr)
@@ -543,7 +543,7 @@ def test_fetch_without_code_is_noop(
     default_mock_concretization, install_mockery, fetching_not_allowed
 ):
     """do_fetch for packages without code should be a no-op"""
-    pkg = default_mock_concretization("a").package
+    pkg = default_mock_concretization("pkg-a").package
     pkg.has_code = False
     pkg.do_fetch()
 
@@ -552,7 +552,7 @@ def test_fetch_external_package_is_noop(
     default_mock_concretization, install_mockery, fetching_not_allowed
 ):
     """do_fetch for packages without code should be a no-op"""
-    spec = default_mock_concretization("a")
+    spec = default_mock_concretization("pkg-a")
     spec.external_path = "/some/where"
     assert spec.external
     spec.package.do_fetch()

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -9,6 +9,8 @@ import shutil
 
 import pytest
 
+import archspec.cpu
+
 import spack.concretize
 import spack.paths
 import spack.platforms
@@ -290,6 +292,7 @@ def test_relocate_text_bin_raise_if_new_prefix_is_longer(tmpdir):
 
 
 @pytest.mark.requires_executables("install_name_tool", "file", "cc")
+@pytest.mark.skipif(str(archspec.cpu.host().family) != "x86_64", reason="failing on Apple M1/M2")
 def test_fixup_macos_rpaths(make_dylib, make_object_file):
     # For each of these tests except for the "correct" case, the first fixup
     # should make changes, and the second fixup should be a null-op.

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -9,6 +9,8 @@ import pytest
 import spack.package_base
 import spack.paths
 import spack.repo
+import spack.spec
+import spack.util.file_cache
 
 
 @pytest.fixture(params=["packages", "", "foo"])
@@ -30,25 +32,25 @@ repo:
 
 
 def test_repo_getpkg(mutable_mock_repo):
-    mutable_mock_repo.get_pkg_class("a")
-    mutable_mock_repo.get_pkg_class("builtin.mock.a")
+    mutable_mock_repo.get_pkg_class("pkg-a")
+    mutable_mock_repo.get_pkg_class("builtin.mock.pkg-a")
 
 
 def test_repo_multi_getpkg(mutable_mock_repo, extra_repo):
     mutable_mock_repo.put_first(extra_repo[0])
-    mutable_mock_repo.get_pkg_class("a")
-    mutable_mock_repo.get_pkg_class("builtin.mock.a")
+    mutable_mock_repo.get_pkg_class("pkg-a")
+    mutable_mock_repo.get_pkg_class("builtin.mock.pkg-a")
 
 
 def test_repo_multi_getpkgclass(mutable_mock_repo, extra_repo):
     mutable_mock_repo.put_first(extra_repo[0])
-    mutable_mock_repo.get_pkg_class("a")
-    mutable_mock_repo.get_pkg_class("builtin.mock.a")
+    mutable_mock_repo.get_pkg_class("pkg-a")
+    mutable_mock_repo.get_pkg_class("builtin.mock.pkg-a")
 
 
 def test_repo_pkg_with_unknown_namespace(mutable_mock_repo):
     with pytest.raises(spack.repo.UnknownNamespaceError):
-        mutable_mock_repo.get_pkg_class("unknown.a")
+        mutable_mock_repo.get_pkg_class("unknown.pkg-a")
 
 
 def test_repo_unknown_pkg(mutable_mock_repo):
@@ -142,14 +144,14 @@ def test_get_all_mock_packages(mock_packages):
 
 def test_repo_path_handles_package_removal(tmpdir, mock_packages):
     builder = spack.repo.MockRepositoryBuilder(tmpdir, namespace="removal")
-    builder.add_package("c")
+    builder.add_package("pkg-c")
     with spack.repo.use_repositories(builder.root, override=False) as repos:
-        r = repos.repo_for_pkg("c")
+        r = repos.repo_for_pkg("pkg-c")
         assert r.namespace == "removal"
 
-    builder.remove("c")
+    builder.remove("pkg-c")
     with spack.repo.use_repositories(builder.root, override=False) as repos:
-        r = repos.repo_for_pkg("c")
+        r = repos.repo_for_pkg("pkg-c")
         assert r.namespace == "builtin.mock"
 
 

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -138,19 +138,19 @@ def test_specify_preinstalled_dep(tmpdir, monkeypatch):
     transitive dependency that is only supplied by the preinstalled package.
     """
     builder = spack.repo.MockRepositoryBuilder(tmpdir)
-    builder.add_package("c")
-    builder.add_package("b", dependencies=[("c", None, None)])
-    builder.add_package("a", dependencies=[("b", None, None)])
+    builder.add_package("pkg-c")
+    builder.add_package("pkg-b", dependencies=[("pkg-c", None, None)])
+    builder.add_package("pkg-a", dependencies=[("pkg-b", None, None)])
 
     with spack.repo.use_repositories(builder.root):
-        b_spec = Spec("b").concretized()
-        monkeypatch.setattr(Spec, "installed", property(lambda x: x.name != "a"))
+        b_spec = Spec("pkg-b").concretized()
+        monkeypatch.setattr(Spec, "installed", property(lambda x: x.name != "pkg-a"))
 
-        a_spec = Spec("a")
+        a_spec = Spec("pkg-a")
         a_spec._add_dependency(b_spec, depflag=dt.BUILD | dt.LINK, virtuals=())
         a_spec.concretize()
 
-        assert set(x.name for x in a_spec.traverse()) == set(["a", "b", "c"])
+        assert {x.name for x in a_spec.traverse()} == {"pkg-a", "pkg-b", "pkg-c"}
 
 
 @pytest.mark.usefixtures("config")
@@ -982,15 +982,15 @@ def test_synthetic_construction_of_split_dependencies_from_same_package(mock_pac
     # Construct in a synthetic way (i.e. without using the solver)
     # the following spec:
     #
-    #          b
+    #        pkg-b
     #  build /   \ link,run
-    #    c@2.0   c@1.0
+    #  pkg-c@2.0   pkg-c@1.0
     #
     # To demonstrate that a spec can now hold two direct
     # dependencies from the same package
-    root = Spec("b").concretized()
-    link_run_spec = Spec("c@=1.0").concretized()
-    build_spec = Spec("c@=2.0").concretized()
+    root = Spec("pkg-b").concretized()
+    link_run_spec = Spec("pkg-c@=1.0").concretized()
+    build_spec = Spec("pkg-c@=2.0").concretized()
 
     root.add_dependency_edge(link_run_spec, depflag=dt.LINK, virtuals=())
     root.add_dependency_edge(link_run_spec, depflag=dt.RUN, virtuals=())
@@ -998,10 +998,10 @@ def test_synthetic_construction_of_split_dependencies_from_same_package(mock_pac
 
     # Check dependencies from the perspective of root
     assert len(root.dependencies()) == 2
-    assert all(x.name == "c" for x in root.dependencies())
+    assert all(x.name == "pkg-c" for x in root.dependencies())
 
-    assert "@2.0" in root.dependencies(name="c", deptype=dt.BUILD)[0]
-    assert "@1.0" in root.dependencies(name="c", deptype=dt.LINK | dt.RUN)[0]
+    assert "@2.0" in root.dependencies(name="pkg-c", deptype=dt.BUILD)[0]
+    assert "@1.0" in root.dependencies(name="pkg-c", deptype=dt.LINK | dt.RUN)[0]
 
     # Check parent from the perspective of the dependencies
     assert len(build_spec.dependents()) == 1
@@ -1013,30 +1013,30 @@ def test_synthetic_construction_of_split_dependencies_from_same_package(mock_pac
 def test_synthetic_construction_bootstrapping(mock_packages, config):
     # Construct the following spec:
     #
-    #  b@2.0
+    #  pkg-b@2.0
     #    | build
-    #  b@1.0
+    #  pkg-b@1.0
     #
-    root = Spec("b@=2.0").concretized()
-    bootstrap = Spec("b@=1.0").concretized()
+    root = Spec("pkg-b@=2.0").concretized()
+    bootstrap = Spec("pkg-b@=1.0").concretized()
 
     root.add_dependency_edge(bootstrap, depflag=dt.BUILD, virtuals=())
 
     assert len(root.dependencies()) == 1
-    assert root.dependencies()[0].name == "b"
-    assert root.name == "b"
+    assert root.dependencies()[0].name == "pkg-b"
+    assert root.name == "pkg-b"
 
 
 def test_addition_of_different_deptypes_in_multiple_calls(mock_packages, config):
     # Construct the following spec:
     #
-    #  b@2.0
+    #  pkg-b@2.0
     #    | build,link,run
-    #  b@1.0
+    #  pkg-b@1.0
     #
     # with three calls and check we always have a single edge
-    root = Spec("b@=2.0").concretized()
-    bootstrap = Spec("b@=1.0").concretized()
+    root = Spec("pkg-b@=2.0").concretized()
+    bootstrap = Spec("pkg-b@=1.0").concretized()
 
     for current_depflag in (dt.BUILD, dt.LINK, dt.RUN):
         root.add_dependency_edge(bootstrap, depflag=current_depflag, virtuals=())
@@ -1063,9 +1063,9 @@ def test_addition_of_different_deptypes_in_multiple_calls(mock_packages, config)
 def test_adding_same_deptype_with_the_same_name_raises(
     mock_packages, config, c1_depflag, c2_depflag
 ):
-    p = Spec("b@=2.0").concretized()
-    c1 = Spec("b@=1.0").concretized()
-    c2 = Spec("b@=2.0").concretized()
+    p = Spec("pkg-b@=2.0").concretized()
+    c1 = Spec("pkg-b@=1.0").concretized()
+    c2 = Spec("pkg-b@=2.0").concretized()
 
     p.add_dependency_edge(c1, depflag=c1_depflag, virtuals=())
     with pytest.raises(spack.error.SpackError):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -734,18 +734,6 @@ class TestSpecSemantics:
             with pytest.raises(SpecFormatStringError):
                 spec.format(fmt_str)
 
-    @pytest.mark.regression("9908")
-    def test_spec_flags_maintain_order(self):
-        # Spack was assembling flags in a manner that could result in
-        # different orderings for repeated concretizations of the same
-        # spec and config
-        spec_str = "libelf %gcc@11.1.0 os=redhat6"
-        for _ in range(3):
-            s = Spec(spec_str).concretized()
-            assert all(
-                s.compiler_flags[x] == ["-O0", "-g"] for x in ("cflags", "cxxflags", "fflags")
-            )
-
     def test_combination_of_wildcard_or_none(self):
         # Test that using 'none' and another value raises
         with pytest.raises(spack.variant.InvalidVariantValueCombinationError):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -373,7 +373,7 @@ class TestSpecSemantics:
         https://github.com/spack/spack/pull/2386#issuecomment-282147639
         is handled correctly.
         """
-        a = Spec("a foobar=bar")
+        a = Spec("pkg-a foobar=bar")
         a.concretize()
 
         assert a.satisfies("foobar=bar")
@@ -390,21 +390,21 @@ class TestSpecSemantics:
         assert "foo=bar" in a
 
         # Check that conditional dependencies are treated correctly
-        assert "^b" in a
+        assert "^pkg-b" in a
 
     def test_unsatisfied_single_valued_variant(self):
-        a = Spec("a foobar=baz")
+        a = Spec("pkg-a foobar=baz")
         a.concretize()
-        assert "^b" not in a
+        assert "^pkg-b" not in a
 
         mv = Spec("multivalue-variant")
         mv.concretize()
-        assert "a@1.0" not in mv
+        assert "pkg-a@1.0" not in mv
 
     def test_indirect_unsatisfied_single_valued_variant(self):
         spec = Spec("singlevalue-variant-dependent")
         spec.concretize()
-        assert "a@1.0" not in spec
+        assert "pkg-a@1.0" not in spec
 
     def test_unsatisfiable_multi_value_variant(self, default_mock_concretization):
         # Semantics for a multi-valued variant is different
@@ -982,8 +982,8 @@ class TestSpecSemantics:
             spec.splice(dep, transitive)
 
     def test_spec_override(self):
-        init_spec = Spec("a foo=baz foobar=baz cflags=-O3 cxxflags=-O1")
-        change_spec = Spec("a foo=fee cflags=-O2")
+        init_spec = Spec("pkg-a foo=baz foobar=baz cflags=-O3 cxxflags=-O1")
+        change_spec = Spec("pkg-a foo=fee cflags=-O2")
         new_spec = Spec.override(init_spec, change_spec)
         new_spec.concretize()
         assert "foo=fee" in new_spec
@@ -1253,15 +1253,15 @@ def test_spec_installed(default_mock_concretization, database):
     spec = Spec("not-a-real-package")
     assert not spec.installed
 
-    # 'a' is not in the mock DB and is not installed
-    spec = default_mock_concretization("a")
+    # pkg-a is not in the mock DB and is not installed
+    spec = default_mock_concretization("pkg-a")
     assert not spec.installed
 
 
 @pytest.mark.regression("30678")
 def test_call_dag_hash_on_old_dag_hash_spec(mock_packages, default_mock_concretization):
     # create a concrete spec
-    a = default_mock_concretization("a")
+    a = default_mock_concretization("pkg-a")
     dag_hashes = {spec.name: spec.dag_hash() for spec in a.traverse()}
 
     # make it look like an old DAG hash spec with no package hash on the spec.
@@ -1309,8 +1309,8 @@ def test_unsupported_compiler():
 
 
 def test_package_hash_affects_dunder_and_dag_hash(mock_packages, default_mock_concretization):
-    a1 = default_mock_concretization("a")
-    a2 = default_mock_concretization("a")
+    a1 = default_mock_concretization("pkg-a")
+    a2 = default_mock_concretization("pkg-a")
 
     assert hash(a1) == hash(a2)
     assert a1.dag_hash() == a2.dag_hash()
@@ -1334,8 +1334,8 @@ def test_intersects_and_satisfies_on_concretized_spec(default_mock_concretizatio
     """Test that a spec obtained by concretizing an abstract spec, satisfies the abstract spec
     but not vice-versa.
     """
-    a1 = default_mock_concretization("a@1.0")
-    a2 = Spec("a@1.0")
+    a1 = default_mock_concretization("pkg-a@1.0")
+    a2 = Spec("pkg-a@1.0")
 
     assert a1.intersects(a2)
     assert a2.intersects(a1)
@@ -1461,17 +1461,17 @@ def test_constrain(factory, lhs_str, rhs_str, result, constrained_str):
 
 
 def test_abstract_hash_intersects_and_satisfies(default_mock_concretization):
-    concrete: Spec = default_mock_concretization("a")
+    concrete: Spec = default_mock_concretization("pkg-a")
     hash = concrete.dag_hash()
     hash_5 = hash[:5]
     hash_6 = hash[:6]
     # abstract hash that doesn't have a common prefix with the others.
     hash_other = f"{'a' if hash_5[0] == 'b' else 'b'}{hash_5[1:]}"
 
-    abstract_5 = Spec(f"a/{hash_5}")
-    abstract_6 = Spec(f"a/{hash_6}")
-    abstract_none = Spec(f"a/{hash_other}")
-    abstract = Spec("a")
+    abstract_5 = Spec(f"pkg-a/{hash_5}")
+    abstract_6 = Spec(f"pkg-a/{hash_6}")
+    abstract_none = Spec(f"pkg-a/{hash_other}")
+    abstract = Spec("pkg-a")
 
     def assert_subset(a: Spec, b: Spec):
         assert a.intersects(b) and b.intersects(a) and a.satisfies(b) and not b.satisfies(a)
@@ -1508,6 +1508,6 @@ def test_edge_equality_does_not_depend_on_virtual_order():
 
 
 def test_old_format_strings_trigger_error(default_mock_concretization):
-    s = Spec("a").concretized()
+    s = Spec("pkg-a").concretized()
     with pytest.raises(SpecFormatStringError):
         s.format("${PACKAGE}-${VERSION}-${HASH}")

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -699,7 +699,7 @@ def test_spec_by_hash_tokens(text, tokens):
 @pytest.mark.db
 def test_spec_by_hash(database, monkeypatch, config):
     mpileaks = database.query_one("mpileaks ^zmpi")
-    b = spack.spec.Spec("b").concretized()
+    b = spack.spec.Spec("pkg-b").concretized()
     monkeypatch.setattr(spack.binary_distribution, "update_cache_and_get_specs", lambda: [b])
 
     hash_str = f"/{mpileaks.dag_hash()}"
@@ -796,7 +796,7 @@ def test_ambiguous_hash(mutable_database, default_mock_concretization, config):
     In the past this ambiguity error would happen during parse time."""
 
     # This is a very sketchy as manually setting hashes easily breaks invariants
-    x1 = default_mock_concretization("a")
+    x1 = spack.spec.Spec("pkg-a").concretized()
     x2 = x1.copy()
     x1._hash = "xyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
     x1._process_hash = "xyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
@@ -814,7 +814,7 @@ def test_ambiguous_hash(mutable_database, default_mock_concretization, config):
         s1.lookup_hash()
 
     # ambiguity in first hash character AND spec name
-    s2 = SpecParser("a/x").next_spec()
+    s2 = SpecParser("pkg-a/x").next_spec()
     with pytest.raises(spack.spec.AmbiguousHashError):
         s2.lookup_hash()
 

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -314,23 +314,23 @@ def test_save_dependency_spec_jsons_subset(tmpdir, config):
     output_path = str(tmpdir.mkdir("spec_jsons"))
 
     builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock-repo"))
-    builder.add_package("g")
-    builder.add_package("f")
-    builder.add_package("e")
-    builder.add_package("d", dependencies=[("f", None, None), ("g", None, None)])
-    builder.add_package("c")
-    builder.add_package("b", dependencies=[("d", None, None), ("e", None, None)])
-    builder.add_package("a", dependencies=[("b", None, None), ("c", None, None)])
+    builder.add_package("pkg-g")
+    builder.add_package("pkg-f")
+    builder.add_package("pkg-e")
+    builder.add_package("pkg-d", dependencies=[("pkg-f", None, None), ("pkg-g", None, None)])
+    builder.add_package("pkg-c")
+    builder.add_package("pkg-b", dependencies=[("pkg-d", None, None), ("pkg-e", None, None)])
+    builder.add_package("pkg-a", dependencies=[("pkg-b", None, None), ("pkg-c", None, None)])
 
     with spack.repo.use_repositories(builder.root):
-        spec_a = Spec("a").concretized()
-        b_spec = spec_a["b"]
-        c_spec = spec_a["c"]
+        spec_a = Spec("pkg-a").concretized()
+        b_spec = spec_a["pkg-b"]
+        c_spec = spec_a["pkg-c"]
 
-        save_dependency_specfiles(spec_a, output_path, [Spec("b"), Spec("c")])
+        save_dependency_specfiles(spec_a, output_path, [Spec("pkg-b"), Spec("pkg-c")])
 
-        assert check_specs_equal(b_spec, os.path.join(output_path, "b.json"))
-        assert check_specs_equal(c_spec, os.path.join(output_path, "c.json"))
+        assert check_specs_equal(b_spec, os.path.join(output_path, "pkg-b.json"))
+        assert check_specs_equal(c_spec, os.path.join(output_path, "pkg-c.json"))
 
 
 def test_legacy_yaml(tmpdir, install_mockery, mock_packages):

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -519,7 +519,7 @@ def test_find_required_file(tmpdir):
 def test_packagetest_fails(mock_packages):
     MyPackage = collections.namedtuple("MyPackage", ["spec"])
 
-    s = spack.spec.Spec("a")
+    s = spack.spec.Spec("pkg-a")
     pkg = MyPackage(s)
     with pytest.raises(ValueError, match="require a concrete package"):
         spack.install_test.PackageTest(pkg)

--- a/lib/spack/spack/test/util/util_url.py
+++ b/lib/spack/spack/test/util/util_url.py
@@ -48,7 +48,7 @@ def test_relative_path_to_file_url(tmpdir):
 
 
 @pytest.mark.parametrize("resolve_href", [True, False])
-@pytest.mark.parametrize("scheme", ["http", "s3", "gs", "file"])
+@pytest.mark.parametrize("scheme", ["http", "s3", "gs", "file", "oci"])
 def test_url_join_absolute(scheme, resolve_href):
     """Test that joining a URL with an absolute path works the same for schemes we care about, and
     whether we work in web browser mode or not."""

--- a/lib/spack/spack/test/util/util_url.py
+++ b/lib/spack/spack/test/util/util_url.py
@@ -8,6 +8,8 @@ import os
 import os.path
 import urllib.parse
 
+import pytest
+
 import spack.util.path
 import spack.util.url as url_util
 
@@ -45,155 +47,63 @@ def test_relative_path_to_file_url(tmpdir):
         assert os.path.samefile(roundtrip, path)
 
 
-def test_url_join_local_paths():
-    # Resolve local link against page URL
+@pytest.mark.parametrize("resolve_href", [True, False])
+@pytest.mark.parametrize("scheme", ["http", "s3", "gs", "file"])
+def test_url_join_absolute(scheme, resolve_href):
+    """Test that joining a URL with an absolute path works the same for schemes we care about, and
+    whether we work in web browser mode or not."""
+    netloc = "" if scheme == "file" else "example.com"
+    a1 = url_util.join(f"{scheme}://{netloc}/a/b/c", "/d/e/f", resolve_href=resolve_href)
+    a2 = url_util.join(f"{scheme}://{netloc}/a/b/c", "/d", "e", "f", resolve_href=resolve_href)
+    assert a1 == a2 == f"{scheme}://{netloc}/d/e/f"
 
-    # wrong:
-    assert (
-        url_util.join("s3://bucket/index.html", "../other-bucket/document.txt")
-        == "s3://bucket/other-bucket/document.txt"
-    )
-
-    # correct - need to specify resolve_href=True:
-    assert (
-        url_util.join("s3://bucket/index.html", "../other-bucket/document.txt", resolve_href=True)
-        == "s3://other-bucket/document.txt"
-    )
-
-    # same as above: make sure several components are joined together correctly
-    assert (
-        url_util.join(
-            # with resolve_href=True, first arg is the base url; can not be
-            # broken up
-            "s3://bucket/index.html",
-            # with resolve_href=True, remaining arguments are the components of
-            # the local href that needs to be resolved
-            "..",
-            "other-bucket",
-            "document.txt",
-            resolve_href=True,
-        )
-        == "s3://other-bucket/document.txt"
-    )
-
-    # Append local path components to prefix URL
-
-    # wrong:
-    assert (
-        url_util.join("https://mirror.spack.io/build_cache", "my-package", resolve_href=True)
-        == "https://mirror.spack.io/my-package"
-    )
-
-    # correct - Need to specify resolve_href=False:
-    assert (
-        url_util.join("https://mirror.spack.io/build_cache", "my-package", resolve_href=False)
-        == "https://mirror.spack.io/build_cache/my-package"
-    )
-
-    # same as above; make sure resolve_href=False is default
-    assert (
-        url_util.join("https://mirror.spack.io/build_cache", "my-package")
-        == "https://mirror.spack.io/build_cache/my-package"
-    )
-
-    # same as above: make sure several components are joined together correctly
-    assert (
-        url_util.join(
-            # with resolve_href=False, first arg is just a prefix. No
-            # resolution is done.  So, there should be no difference between
-            # join('/a/b/c', 'd/e'),
-            # join('/a/b', 'c', 'd/e'),
-            # join('/a', 'b/c', 'd', 'e'), etc.
-            "https://mirror.spack.io",
-            "build_cache",
-            "my-package",
-        )
-        == "https://mirror.spack.io/build_cache/my-package"
-    )
-
-    # For s3:// URLs, the "netloc" (bucket) is considered part of the path.
-    # Make sure join() can cross bucket boundaries in this case.
-    args = ["s3://bucket/a/b", "new-bucket", "c"]
-    assert url_util.join(*args) == "s3://bucket/a/b/new-bucket/c"
-
-    args.insert(1, "..")
-    assert url_util.join(*args) == "s3://bucket/a/new-bucket/c"
-
-    args.insert(1, "..")
-    assert url_util.join(*args) == "s3://bucket/new-bucket/c"
-
-    # new-bucket is now the "netloc" (bucket name)
-    args.insert(1, "..")
-    assert url_util.join(*args) == "s3://new-bucket/c"
+    b1 = url_util.join(f"{scheme}://{netloc}/a", "https://b.com/b", resolve_href=resolve_href)
+    b2 = url_util.join(f"{scheme}://{netloc}/a", "https://b.com", "b", resolve_href=resolve_href)
+    assert b1 == b2 == "https://b.com/b"
 
 
-def test_url_join_absolute_paths():
-    # Handling absolute path components is a little tricky.  To this end, we
-    # distinguish "absolute path components", from the more-familiar concept of
-    # "absolute paths" as they are understood for local filesystem paths.
-    #
-    # - All absolute paths are absolute path components.  Joining a URL with
-    #   these components has the effect of completely replacing the path of the
-    #   URL with the absolute path.  These components do not specify a URL
-    #   scheme, so the scheme of the URL procuced when joining them depend on
-    #   those provided by components that came before it (file:// assumed if no
-    #   such scheme is provided).
+@pytest.mark.parametrize("scheme", ["http", "s3", "gs"])
+def test_url_join_up(scheme):
+    """Test that the netloc component is preserved when going .. up in the path."""
+    a1 = url_util.join(f"{scheme}://netloc/a/b.html", "c", resolve_href=True)
+    assert a1 == f"{scheme}://netloc/a/c"
+    b1 = url_util.join(f"{scheme}://netloc/a/b.html", "../c", resolve_href=True)
+    b2 = url_util.join(f"{scheme}://netloc/a/b.html", "..", "c", resolve_href=True)
+    assert b1 == b2 == f"{scheme}://netloc/c"
+    c1 = url_util.join(f"{scheme}://netloc/a/b.html", "../../c", resolve_href=True)
+    c2 = url_util.join(f"{scheme}://netloc/a/b.html", "..", "..", "c", resolve_href=True)
+    assert c1 == c2 == f"{scheme}://netloc/c"
 
-    # For eaxmple:
-    p = "/path/to/resource"
-    # ...is an absolute path
+    d1 = url_util.join(f"{scheme}://netloc/a/b", "c", resolve_href=False)
+    assert d1 == f"{scheme}://netloc/a/b/c"
+    d2 = url_util.join(f"{scheme}://netloc/a/b", "../c", resolve_href=False)
+    d3 = url_util.join(f"{scheme}://netloc/a/b", "..", "c", resolve_href=False)
+    assert d2 == d3 == f"{scheme}://netloc/a/c"
+    e1 = url_util.join(f"{scheme}://netloc/a/b", "../../c", resolve_href=False)
+    e2 = url_util.join(f"{scheme}://netloc/a/b", "..", "..", "c", resolve_href=False)
+    assert e1 == e2 == f"{scheme}://netloc/c"
+    f1 = url_util.join(f"{scheme}://netloc/a/b", "../../../c", resolve_href=False)
+    f2 = url_util.join(f"{scheme}://netloc/a/b", "..", "..", "..", "c", resolve_href=False)
+    assert f1 == f2 == f"{scheme}://netloc/c"
 
-    # http:// URL
-    assert url_util.join("http://example.com/a/b/c", p) == "http://example.com/path/to/resource"
 
-    # s3:// URL
-    # also notice how the netloc is treated as part of the path for s3:// URLs
-    assert url_util.join("s3://example.com/a/b/c", p) == "s3://path/to/resource"
+@pytest.mark.parametrize("scheme", ["http", "https", "ftp", "s3", "gs", "file"])
+def test_url_join_resolve_href(scheme):
+    """test that `resolve_href=True` behaves like a web browser at the base page, and
+    `resolve_href=False` behaves like joining paths in a file system at the base directory."""
+    # these are equivalent because of the trailing /
+    netloc = "" if scheme == "file" else "netloc"
+    a1 = url_util.join(f"{scheme}://{netloc}/my/path/", "other/path", resolve_href=True)
+    a2 = url_util.join(f"{scheme}://{netloc}/my/path/", "other", "path", resolve_href=True)
+    assert a1 == a2 == f"{scheme}://{netloc}/my/path/other/path"
+    b1 = url_util.join(f"{scheme}://{netloc}/my/path", "other/path", resolve_href=False)
+    b2 = url_util.join(f"{scheme}://{netloc}/my/path", "other", "path", resolve_href=False)
+    assert b1 == b2 == f"{scheme}://{netloc}/my/path/other/path"
 
-    # - URL components that specify a scheme are always absolute path
-    #   components.  Joining a base URL with these components effectively
-    #   discards the base URL and "resets" the joining logic starting at the
-    #   component in question and using it as the new base URL.
-
-    # For eaxmple:
-    p = "http://example.com/path/to"
-    # ...is an http:// URL
-
-    join_result = url_util.join(p, "resource")
-    assert join_result == "http://example.com/path/to/resource"
-
-    # works as if everything before the http:// URL was left out
-    assert url_util.join("literally", "does", "not", "matter", p, "resource") == join_result
-
-    assert url_util.join("file:///a/b/c", "./d") == "file:///a/b/c/d"
-
-    # Finally, resolve_href should have no effect for how absolute path
-    # components are handled because local hrefs can not be absolute path
-    # components.
-    args = [
-        "s3://does",
-        "not",
-        "matter",
-        "http://example.com",
-        "also",
-        "does",
-        "not",
-        "matter",
-        "/path",
-    ]
-
-    expected = "http://example.com/path"
-    assert url_util.join(*args, resolve_href=True) == expected
-    assert url_util.join(*args, resolve_href=False) == expected
-
-    # resolve_href only matters for the local path components at the end of the
-    # argument list.
-    args[-1] = "/path/to/page"
-    args.extend(("..", "..", "resource"))
-
-    assert url_util.join(*args, resolve_href=True) == "http://example.com/resource"
-
-    assert url_util.join(*args, resolve_href=False) == "http://example.com/path/resource"
+    # this is like a web browser: relative to /my.
+    c1 = url_util.join(f"{scheme}://{netloc}/my/path", "other/path", resolve_href=True)
+    c2 = url_util.join(f"{scheme}://{netloc}/my/path", "other", "path", resolve_href=True)
+    assert c1 == c2 == f"{scheme}://{netloc}/my/other/path"
 
 
 def test_default_download_name():

--- a/lib/spack/spack/test/views.py
+++ b/lib/spack/spack/test/views.py
@@ -33,8 +33,8 @@ def test_view_with_spec_not_contributing_files(mock_packages, tmpdir):
     layout = DirectoryLayout(view_dir)
     view = SimpleFilesystemView(view_dir, layout)
 
-    a = Spec("a")
-    b = Spec("b")
+    a = Spec("pkg-a")
+    b = Spec("pkg-b")
     a.prefix = os.path.join(tmpdir, "a")
     b.prefix = os.path.join(tmpdir, "b")
     a._mark_concrete()

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -79,7 +79,7 @@ def join(base: str, *components: str, resolve_href: bool = False, **kwargs) -> s
     1. By default resolve_href=False, which makes the function like os.path.join: for example
     https://example.com/a/b + c/d = https://example.com/a/b/c/d. If resolve_href=True, the
     behavior is how a browser would resolve the URL: https://example.com/a/c/d.
-    2. s3:// and gs:// URLs are joined like http:// URLs.
+    2. s3://, gs://, oci:// URLs are joined like http:// URLs.
     3. It accepts multiple components for convenience. Note that components[1:] are treated as
     literal path components and appended to components[0] separated by slashes."""
     # Ensure a trailing slash in the path component of the base URL to get os.path.join-like
@@ -93,8 +93,8 @@ def join(base: str, *components: str, resolve_href: bool = False, **kwargs) -> s
     try:
         # NOTE: we temporarily modify urllib internals so s3 and gs schemes are treated like http.
         # This is non-portable, and may be forward incompatible with future cpython versions.
-        urllib.parse.uses_netloc = [*uses_netloc, "s3", "gs"]
-        urllib.parse.uses_relative = [*uses_relative, "s3", "gs"]
+        urllib.parse.uses_netloc = [*uses_netloc, "s3", "gs", "oci"]
+        urllib.parse.uses_relative = [*uses_relative, "s3", "gs", "oci"]
         return urllib.parse.urljoin(base, "/".join(components), **kwargs)
     finally:
         urllib.parse.uses_netloc = uses_netloc

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -7,14 +7,11 @@
 Utility functions for parsing, formatting, and manipulating URLs.
 """
 
-import itertools
 import os
 import posixpath
 import sys
 import urllib.parse
 import urllib.request
-
-from llnl.path import convert_to_posix_path
 
 from spack.util.path import sanitize_filename
 
@@ -25,26 +22,6 @@ def validate_scheme(scheme):
     C:/x/y/z (with backward not forward slash) may parse as a URL with scheme
     C and path /x/y/z."""
     return scheme in ("file", "http", "https", "ftp", "s3", "gs", "ssh", "git")
-
-
-def _split_all(path):
-    """Split path into its atomic components.
-
-    Returns the shortest list, L, of strings such that posixpath.join(*L) ==
-    path and posixpath.split(element) == ('', element) for every element in L
-    except possibly the first.  This first element may possibly have the value
-    of '/'.
-    """
-    result = []
-    a = path
-    old_a = None
-    while a != old_a:
-        (old_a, (a, b)) = a, posixpath.split(a)
-
-        if a or b:
-            result.insert(0, b or "/")
-
-    return result
 
 
 def local_file_path(url):
@@ -97,151 +74,31 @@ def format(parsed_url):
     return parsed_url.geturl()
 
 
-def join(base_url, path, *extra, **kwargs):
-    """Joins a base URL with one or more local URL path components
-
-    If resolve_href is True, treat the base URL as though it where the locator
-    of a web page, and the remaining URL path components as though they formed
-    a relative URL to be resolved against it (i.e.: as in posixpath.join(...)).
-    The result is an absolute URL to the resource to which a user's browser
-    would navigate if they clicked on a link with an "href" attribute equal to
-    the relative URL.
-
-    If resolve_href is False (default), then the URL path components are joined
-    as in posixpath.join().
-
-    Note: file:// URL path components are not canonicalized as part of this
-    operation.  To canonicalize, pass the joined url to format().
-
-    Examples:
-      base_url = 's3://bucket/index.html'
-      body = fetch_body(prefix)
-      link = get_href(body) # link == '../other-bucket/document.txt'
-
-      # wrong - link is a local URL that needs to be resolved against base_url
-      spack.util.url.join(base_url, link)
-      's3://bucket/other_bucket/document.txt'
-
-      # correct - resolve local URL against base_url
-      spack.util.url.join(base_url, link, resolve_href=True)
-      's3://other_bucket/document.txt'
-
-      prefix = 'https://mirror.spack.io/build_cache'
-
-      # wrong - prefix is just a URL prefix
-      spack.util.url.join(prefix, 'my-package', resolve_href=True)
-      'https://mirror.spack.io/my-package'
-
-      # correct - simply append additional URL path components
-      spack.util.url.join(prefix, 'my-package', resolve_href=False) # default
-      'https://mirror.spack.io/build_cache/my-package'
-
-      # For canonicalizing file:// URLs, take care to explicitly differentiate
-      # between absolute and relative join components.
-    """
-    paths = [
-        (x) if isinstance(x, str) else x.geturl() for x in itertools.chain((base_url, path), extra)
-    ]
-
-    paths = [convert_to_posix_path(x) for x in paths]
-    n = len(paths)
-    last_abs_component = None
-    scheme = ""
-    for i in range(n - 1, -1, -1):
-        obj = urllib.parse.urlparse(paths[i], scheme="", allow_fragments=False)
-
-        scheme = obj.scheme
-
-        # in either case the component is absolute
-        if scheme or obj.path.startswith("/"):
-            if not scheme:
-                # Without a scheme, we have to go back looking for the
-                # next-last component that specifies a scheme.
-                for j in range(i - 1, -1, -1):
-                    obj = urllib.parse.urlparse(paths[j], scheme="", allow_fragments=False)
-
-                    if obj.scheme:
-                        paths[i] = "{SM}://{NL}{PATH}".format(
-                            SM=obj.scheme,
-                            NL=((obj.netloc + "/") if obj.scheme != "s3" else ""),
-                            PATH=paths[i][1:],
-                        )
-                        break
-
-            last_abs_component = i
-            break
-
-    if last_abs_component is not None:
-        paths = paths[last_abs_component:]
-        if len(paths) == 1:
-            result = urllib.parse.urlparse(paths[0], scheme="file", allow_fragments=False)
-
-            # another subtlety: If the last argument to join() is an absolute
-            # file:// URL component with a relative path, the relative path
-            # needs to be resolved.
-            if result.scheme == "file" and result.netloc:
-                result = urllib.parse.ParseResult(
-                    scheme=result.scheme,
-                    netloc="",
-                    path=posixpath.abspath(result.netloc + result.path),
-                    params=result.params,
-                    query=result.query,
-                    fragment=None,
-                )
-
-            return result.geturl()
-
-    return _join(*paths, **kwargs)
-
-
-def _join(base_url, path, *extra, **kwargs):
-    base_url = urllib.parse.urlparse(base_url)
-    resolve_href = kwargs.get("resolve_href", False)
-
-    (scheme, netloc, base_path, params, query, _) = base_url
-    scheme = scheme.lower()
-
-    path_tokens = [
-        part
-        for part in itertools.chain(
-            _split_all(path),
-            itertools.chain.from_iterable(_split_all(extra_path) for extra_path in extra),
-        )
-        if part and part != "/"
-    ]
-
-    base_path_args = ["/fake-root"]
-    if scheme == "s3":
-        if netloc:
-            base_path_args.append(netloc)
-
-    if base_path.startswith("/"):
-        base_path = base_path[1:]
-
-    base_path_args.append(base_path)
-
-    if resolve_href:
-        new_base_path, _ = posixpath.split(posixpath.join(*base_path_args))
-        base_path_args = [new_base_path]
-
-    base_path_args.extend(path_tokens)
-    base_path = posixpath.relpath(posixpath.join(*base_path_args), "/fake-root")
-
-    if scheme == "s3":
-        path_tokens = [part for part in _split_all(base_path) if part and part != "/"]
-
-        if path_tokens:
-            netloc = path_tokens.pop(0)
-            base_path = posixpath.join("", *path_tokens)
-
-    if sys.platform == "win32":
-        base_path = convert_to_posix_path(base_path)
-
-    return format(
-        urllib.parse.ParseResult(
-            scheme=scheme, netloc=netloc, path=base_path, params=params, query=query, fragment=None
-        )
-    )
+def join(base: str, *components: str, resolve_href: bool = False, **kwargs) -> str:
+    """Convenience wrapper around ``urllib.parse.urljoin``, with a few differences:
+    1. By default resolve_href=False, which makes the function like os.path.join: for example
+    https://example.com/a/b + c/d = https://example.com/a/b/c/d. If resolve_href=True, the
+    behavior is how a browser would resolve the URL: https://example.com/a/c/d.
+    2. s3:// and gs:// URLs are joined like http:// URLs.
+    3. It accepts multiple components for convenience. Note that components[1:] are treated as
+    literal path components and appended to components[0] separated by slashes."""
+    # Ensure a trailing slash in the path component of the base URL to get os.path.join-like
+    # behavior instead of web browser behavior.
+    if not resolve_href:
+        parsed = urllib.parse.urlparse(base)
+        if not parsed.path.endswith("/"):
+            base = parsed._replace(path=f"{parsed.path}/").geturl()
+    uses_netloc = urllib.parse.uses_netloc
+    uses_relative = urllib.parse.uses_relative
+    try:
+        # NOTE: we temporarily modify urllib internals so s3 and gs schemes are treated like http.
+        # This is non-portable, and may be forward incompatible with future cpython versions.
+        urllib.parse.uses_netloc = [*uses_netloc, "s3", "gs"]
+        urllib.parse.uses_relative = [*uses_relative, "s3", "gs"]
+        return urllib.parse.urljoin(base, "/".join(components), **kwargs)
+    finally:
+        urllib.parse.uses_netloc = uses_netloc
+        urllib.parse.uses_relative = uses_relative
 
 
 def default_download_filename(url: str) -> str:

--- a/var/spack/repos/builtin.mock/packages/depb/package.py
+++ b/var/spack/repos/builtin.mock/packages/depb/package.py
@@ -14,7 +14,7 @@ class Depb(AutotoolsPackage):
 
     version("1.0", md5="0123456789abcdef0123456789abcdef")
 
-    depends_on("b")
+    depends_on("pkg-b")
 
     def install(self, spec, prefix):
         # sanity_check_prefix requires something in the install directory

--- a/var/spack/repos/builtin.mock/packages/external-buildable-with-variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/external-buildable-with-variant/package.py
@@ -15,4 +15,4 @@ class ExternalBuildableWithVariant(Package):
 
     variant("baz", default=False, description="nope")
 
-    depends_on("c@1.0", when="@0.9")
+    depends_on("pkg-c@1.0", when="@0.9")

--- a/var/spack/repos/builtin.mock/packages/missing-dependency/package.py
+++ b/var/spack/repos/builtin.mock/packages/missing-dependency/package.py
@@ -18,4 +18,4 @@ class MissingDependency(Package):
     depends_on("this-is-a-missing-dependency")
 
     # this one is a "real" mock dependency
-    depends_on("a")
+    depends_on("pkg-a")

--- a/var/spack/repos/builtin.mock/packages/multivalue-variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/multivalue-variant/package.py
@@ -40,5 +40,5 @@ class MultivalueVariant(Package):
 
     depends_on("mpi")
     depends_on("callpath")
-    depends_on("a")
-    depends_on("a@1.0", when="fee=barbaz")
+    depends_on("pkg-a")
+    depends_on("pkg-a@1.0", when="fee=barbaz")

--- a/var/spack/repos/builtin.mock/packages/optional-dep-test-3/package.py
+++ b/var/spack/repos/builtin.mock/packages/optional-dep-test-3/package.py
@@ -16,5 +16,5 @@ class OptionalDepTest3(Package):
 
     variant("var", default=False)
 
-    depends_on("a", when="~var")
-    depends_on("b", when="+var")
+    depends_on("pkg-a", when="~var")
+    depends_on("pkg-b", when="+var")

--- a/var/spack/repos/builtin.mock/packages/optional-dep-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/optional-dep-test/package.py
@@ -19,14 +19,14 @@ class OptionalDepTest(Package):
     variant("f", default=False)
     variant("mpi", default=False)
 
-    depends_on("a", when="+a")
-    depends_on("b", when="@1.1")
-    depends_on("c", when="%intel")
-    depends_on("d", when="%intel@64.1")
-    depends_on("e", when="%clang@34:40")
+    depends_on("pkg-a", when="+a")
+    depends_on("pkg-b", when="@1.1")
+    depends_on("pkg-c", when="%intel")
+    depends_on("pkg-d", when="%intel@64.1")
+    depends_on("pkg-e", when="%clang@34:40")
 
-    depends_on("f", when="+f")
-    depends_on("g", when="^f")
-    depends_on("mpi", when="^g")
+    depends_on("pkg-f", when="+f")
+    depends_on("pkg-g", when="^pkg-f")
+    depends_on("mpi", when="^pkg-g")
 
     depends_on("mpi", when="+mpi")

--- a/var/spack/repos/builtin.mock/packages/pkg-a/package.py
+++ b/var/spack/repos/builtin.mock/packages/pkg-a/package.py
@@ -6,7 +6,7 @@ import spack.build_systems.autotools
 from spack.package import *
 
 
-class A(AutotoolsPackage):
+class PkgA(AutotoolsPackage):
     """Simple package with one optional dependency"""
 
     homepage = "http://www.example.com"
@@ -25,7 +25,7 @@ class A(AutotoolsPackage):
 
     variant("bvv", default=True, description="The good old BV variant")
 
-    depends_on("b", when="foobar=bar")
+    depends_on("pkg-b", when="foobar=bar")
     depends_on("test-dependency", type="test")
 
     parallel = False

--- a/var/spack/repos/builtin.mock/packages/pkg-b/package.py
+++ b/var/spack/repos/builtin.mock/packages/pkg-b/package.py
@@ -6,10 +6,17 @@
 from spack.package import *
 
 
-class C(Package):
+class PkgB(Package):
     """Simple package with no dependencies"""
 
     homepage = "http://www.example.com"
-    url = "http://www.example.com/c-1.0.tar.gz"
+    url = "http://www.example.com/b-1.0.tar.gz"
 
     version("1.0", md5="0123456789abcdef0123456789abcdef")
+    version("0.9", md5="abcd456789abcdef0123456789abcdef")
+
+    variant(
+        "foo", description="", values=any_combination_of("bar", "baz", "fee").with_default("bar")
+    )
+
+    depends_on("test-dependency", type="test")

--- a/var/spack/repos/builtin.mock/packages/pkg-c/package.py
+++ b/var/spack/repos/builtin.mock/packages/pkg-c/package.py
@@ -6,17 +6,10 @@
 from spack.package import *
 
 
-class B(Package):
+class PkgC(Package):
     """Simple package with no dependencies"""
 
     homepage = "http://www.example.com"
-    url = "http://www.example.com/b-1.0.tar.gz"
+    url = "http://www.example.com/c-1.0.tar.gz"
 
     version("1.0", md5="0123456789abcdef0123456789abcdef")
-    version("0.9", md5="abcd456789abcdef0123456789abcdef")
-
-    variant(
-        "foo", description="", values=any_combination_of("bar", "baz", "fee").with_default("bar")
-    )
-
-    depends_on("test-dependency", type="test")

--- a/var/spack/repos/builtin.mock/packages/pkg-e/package.py
+++ b/var/spack/repos/builtin.mock/packages/pkg-e/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class E(Package):
+class PkgE(Package):
     """Simple package with no dependencies"""
 
     homepage = "http://www.example.com"

--- a/var/spack/repos/builtin.mock/packages/quux/package.py
+++ b/var/spack/repos/builtin.mock/packages/quux/package.py
@@ -142,7 +142,7 @@ const int quux_version_minor = %s;
                 "-o",
                 "libquux.dylib",
                 "-install_name",
-                "@rpath/libcorge.dylib",
+                "@rpath/libquux.dylib",
                 "quux.cc.o",
                 "-Wl,-rpath,%s" % prefix.lib64,
                 "-Wl,-rpath,%s" % spec["garply"].prefix.lib64,

--- a/var/spack/repos/builtin.mock/packages/test-dep-with-imposed-conditions/package.py
+++ b/var/spack/repos/builtin.mock/packages/test-dep-with-imposed-conditions/package.py
@@ -14,4 +14,4 @@ class TestDepWithImposedConditions(Package):
 
     version("1.0", md5="0123456789abcdef0123456789abcdef")
 
-    depends_on("c@1.0", type="test")
+    depends_on("pkg-c@1.0", type="test")

--- a/var/spack/repos/builtin.mock/packages/vendorsb/package.py
+++ b/var/spack/repos/builtin.mock/packages/vendorsb/package.py
@@ -15,5 +15,5 @@ class Vendorsb(Package):
     version("1.1", md5="0123456789abcdef0123456789abcdef")
     version("1.0", md5="0123456789abcdef0123456789abcdef")
 
-    # b is not a dependency
-    conflicts("b", when="@=1.1")
+    # pkg-b is not a dependency
+    conflicts("pkg-b", when="@=1.1")

--- a/var/spack/repos/builtin.mock/packages/when-directives-false/package.py
+++ b/var/spack/repos/builtin.mock/packages/when-directives-false/package.py
@@ -20,7 +20,7 @@ class WhenDirectivesFalse(Package):
         when=False,
     )
     extends("extendee", when=False)
-    depends_on("b", when=False)
+    depends_on("pkg-b", when=False)
     conflicts("@1.0", when=False)
     resource(
         url="http://www.example.com/example-1.0-resource.tar.gz",

--- a/var/spack/repos/builtin.mock/packages/when-directives-true/package.py
+++ b/var/spack/repos/builtin.mock/packages/when-directives-true/package.py
@@ -20,7 +20,7 @@ class WhenDirectivesTrue(Package):
         when=True,
     )
     extends("extendee", when=True)
-    depends_on("b", when=True)
+    depends_on("pkg-b", when=True)
     conflicts("@1.0", when=True)
     resource(
         url="http://www.example.com/example-1.0-resource.tar.gz",

--- a/var/spack/repos/builtin.mock/packages/with-constraint-met/package.py
+++ b/var/spack/repos/builtin.mock/packages/with-constraint-met/package.py
@@ -16,8 +16,8 @@ class WithConstraintMet(Package):
     version("1.0", md5="0123456789abcdef0123456789abcdef")
 
     with when("@1.0"):
-        depends_on("b")
+        depends_on("pkg-b")
         conflicts("%gcc", when="+foo")
 
-    with when("@0.14: ^b@:4.0"):
-        depends_on("c", when="@:15 ^b@3.8:")
+    with when("@0.14: ^pkg-b@:4.0"):
+        depends_on("pkg-c", when="@:15 ^pkg-b@3.8:")

--- a/var/spack/repos/builtin.mock/packages/wrong-variant-in-depends-on/package.py
+++ b/var/spack/repos/builtin.mock/packages/wrong-variant-in-depends-on/package.py
@@ -13,4 +13,4 @@ class WrongVariantInDependsOn(Package):
 
     version("1.0", md5="0123456789abcdef0123456789abcdef")
 
-    depends_on("b+doesnotexist")
+    depends_on("pkg-b+doesnotexist")


### PR DESCRIPTION
- [x] Set version to v0.21.3.dev0
- [x] #45205
- [x] directives: forward compat for c, cxx, fortran deps
- [x] #45018, #43862, #45127
- [x] #42854 #44005 #45721 #46445 (but revert breaking change https://github.com/archspec/archspec/commit/f2c8cdd1bc532f6e55209ef8112f79c5565f082d)
- [x] #43363
- [x] #46453 
- [x] #46483 
- [x] #41943
- [x] #46711 
- [x] #42728 (just the bit where it disables a test)
- [x] #42909
- [x] Update CHANGELOG.md
- [x] Set version to v0.21.3