### PR TITLE
packages/*: http -> https where permanent redirect

### DIFF
--- a/var/spack/repos/builtin/packages/ape/package.py
+++ b/var/spack/repos/builtin/packages/ape/package.py
@@ -11,9 +11,9 @@ class Ape(Package):
     Theory framework"""
 
     homepage = "https://www.tddft.org/programs/APE/"
-    url = "https://www.tddft.org/programs/APE/sites/default/files/ape-2.2.1.tar.gz"
+    url = "https://gitlab.com/ape/ape/-/archive/2.2.1/ape-2.2.1.tar.gz"
 
-    version("2.2.1", sha256="1bdb7f987fde81f8a5f335da6b59fa884e6d185d4a0995c90fde7c04376ce9e3")
+    version("2.2.1", sha256="3f5125182e308ab49338cad791e175ce158526a56c6ca88ac6582c1e5d7435d4")
 
     depends_on("gsl")
     depends_on("libxc@:4", when="@2.3.0:")

--- a/var/spack/repos/builtin/packages/ape/package.py
+++ b/var/spack/repos/builtin/packages/ape/package.py
@@ -11,7 +11,7 @@ class Ape(Package):
     Theory framework"""
 
     homepage = "https://www.tddft.org/programs/APE/"
-    url = "http://www.tddft.org/programs/APE/sites/default/files/ape-2.2.1.tar.gz"
+    url = "https://www.tddft.org/programs/APE/sites/default/files/ape-2.2.1.tar.gz"
 
     version("2.2.1", sha256="1bdb7f987fde81f8a5f335da6b59fa884e6d185d4a0995c90fde7c04376ce9e3")
 

--- a/var/spack/repos/builtin/packages/aperture-photometry/package.py
+++ b/var/spack/repos/builtin/packages/aperture-photometry/package.py
@@ -11,7 +11,7 @@ from spack.package import *
 class AperturePhotometry(Package):
     """Aperture Photometry Tool APT is software for astronomical research"""
 
-    homepage = "http://www.aperturephotometry.org/"
+    homepage = "https://www.aperturephotometry.org/"
     url = "https://web.ipac.caltech.edu/staff/laher/apt/APT_v2.8.4.tar.gz"
     maintainers("snehring")
 

--- a/var/spack/repos/builtin/packages/camx/package.py
+++ b/var/spack/repos/builtin/packages/camx/package.py
@@ -18,13 +18,13 @@ class Camx(MakefilePackage):
 
     version(
         "6.50",
-        url="http://www.camx.com/getmedia/caaf7983-616b-4207-bd10-c2b404bda78d/CAMx_v6-50-src-180430.tgz",
+        url="https://www.camx.com/getmedia/caaf7983-616b-4207-bd10-c2b404bda78d/CAMx_v6-50-src-180430.tgz",
         sha256="4a53f78e0722d85a9c7d8ed6732aff55163a4ce06f69b6bbc9e00a3bf36a756c",
     )
     resource(
         when="@6.50",
         name="user_manual",
-        url="http://www.camx.com/files/camxusersguide_v6-50.pdf",
+        url="https://www.camx.com/files/camxusersguide_v6-50.pdf",
         sha256="b02d9826d59f22f9daa5955bb7b9fd3e0ca86eb73017c5845896d40391c64588",
         expand=False,
         placement="doc",
@@ -32,7 +32,7 @@ class Camx(MakefilePackage):
     resource(
         when="@6.50",
         name="input_data",
-        url="http://www.camx.com/getmedia/77ad8028-9388-4f5d-bcab-a418e15dde68/v6-50-specific-inputs-180430.tgz",
+        url="https://www.camx.com/getmedia/77ad8028-9388-4f5d-bcab-a418e15dde68/v6-50-specific-inputs-180430.tgz",
         sha256="89b58283e37b8e2bd550a8ec62208f241be72c78dc26da9c42ad63c34f54ebfb",
         placement="data",
     )

--- a/var/spack/repos/builtin/packages/cdd/package.py
+++ b/var/spack/repos/builtin/packages/cdd/package.py
@@ -28,7 +28,7 @@ class Cdd(Package):
     patch("Makefile.spack.patch")
 
     def url_for_version(self, version):
-        url = "http://www.cs.mcgill.ca/~fukuda/download/cdd/cdd-{0}.tar.gz"
+        url = "https://www.cs.mcgill.ca/~fukuda/download/cdd/cdd-{0}.tar.gz"
         return url.format(version.joined)
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/cram/package.py
+++ b/var/spack/repos/builtin/packages/cram/package.py
@@ -10,7 +10,7 @@ class Cram(CMakePackage):
     """Cram runs many small MPI jobs inside one large MPI job."""
 
     homepage = "https://github.com/llnl/cram"
-    url = "http://github.com/llnl/cram/archive/v1.0.1.tar.gz"
+    url = "https://github.com/llnl/cram/archive/v1.0.1.tar.gz"
 
     version("1.0.1", sha256="985888018f6481c3e9ab4f1d1788e25725d8b92a1cf52b1366ee93793614709a")
 

--- a/var/spack/repos/builtin/packages/ddt/package.py
+++ b/var/spack/repos/builtin/packages/ddt/package.py
@@ -14,7 +14,7 @@ class Ddt(Package):
     behavior to achieve lightning-fast performance at all scales."""
 
     homepage = "https://arm.com"
-    url = "https://content.allinea.com/downloads/arm-forge-22.0.2-linux-x86_64.tar"
+    url = "https://downloads.linaroforge.com/22.1.3/arm-forge-22.1.3-linux-x86_64.tar"
 
     maintainers("robgics")
 
@@ -22,7 +22,12 @@ class Ddt(Package):
     license_files = ["./licences/ddt.lic"]
 
     # Versions before 22.0 have a security vulnerability. Do not install them.
-    version("22.0.2", sha256="3db0c3993d1db617f850c48d25c9239f06a018c895ea305786a7ad836a44496d")
+    version("22.1.3", sha256="4f8a8b1df6ad712e89c82eedf4bd85b93b57b3c8d5b37d13480ff058fa8f4467")
+    version(
+        "22.0.2",
+        sha256="3db0c3993d1db617f850c48d25c9239f06a018c895ea305786a7ad836a44496d",
+        deprecated=True,
+    )
 
     def setup_run_environment(self, env):
         env.prepend_path("PATH", join_path(self.prefix, "bin"))

--- a/var/spack/repos/builtin/packages/ddt/package.py
+++ b/var/spack/repos/builtin/packages/ddt/package.py
@@ -14,7 +14,7 @@ class Ddt(Package):
     behavior to achieve lightning-fast performance at all scales."""
 
     homepage = "https://arm.com"
-    url = "http://content.allinea.com/downloads/arm-forge-22.0.2-linux-x86_64.tar"
+    url = "https://content.allinea.com/downloads/arm-forge-22.0.2-linux-x86_64.tar"
 
     maintainers("robgics")
 

--- a/var/spack/repos/builtin/packages/flink/package.py
+++ b/var/spack/repos/builtin/packages/flink/package.py
@@ -26,7 +26,7 @@ class Flink(Package):
     depends_on("java@8:", type="run")
 
     def url_for_version(self, version):
-        url = "http://archive.apache.org/dist/flink/flink-{0}/flink-{0}-bin-scala_2.11.tgz"
+        url = "https://archive.apache.org/dist/flink/flink-{0}/flink-{0}-bin-scala_2.11.tgz"
         return url.format(version)
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/geoip/package.py
+++ b/var/spack/repos/builtin/packages/geoip/package.py
@@ -10,7 +10,7 @@ class Geoip(AutotoolsPackage):
     """Library for country/city/organization to IP address
     or hostname mapping."""
 
-    homepage = "http://www.maxmind.com/app/c"
+    homepage = "https://www.maxmind.com/app/c"
     url = "https://github.com/maxmind/geoip-api-c/releases/download/v1.6.12/GeoIP-1.6.12.tar.gz"
 
     license("LGPL-2.1-or-later")

--- a/var/spack/repos/builtin/packages/gffread/package.py
+++ b/var/spack/repos/builtin/packages/gffread/package.py
@@ -10,7 +10,7 @@ class Gffread(MakefilePackage):
     """gffread: GFF/GTF utility providing format conversions, region filtering,
     FASTA sequence extraction and more"""
 
-    homepage = "http://ccb.jhu.edu/software/stringtie/gff.shtml#gffread"
+    homepage = "https://ccb.jhu.edu/software/stringtie/gff.shtml#gffread"
     url = "https://github.com/gpertea/gffread/releases/download/v0.12.7/gffread-0.12.7.tar.gz"
 
     license("MIT")

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -16,7 +16,7 @@ class Git(AutotoolsPackage):
     projects with speed and efficiency.
     """
 
-    homepage = "http://git-scm.com"
+    homepage = "https://git-scm.com"
     url = "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.12.0.tar.gz"
     maintainers("jennfshr")
 

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -15,7 +15,7 @@ MACOS_VERSION = macos_version() if sys.platform == "darwin" else None
 class Graphviz(AutotoolsPackage):
     """Graph Visualization Software"""
 
-    homepage = "http://www.graphviz.org"
+    homepage = "https://www.graphviz.org"
     git = "https://gitlab.com/graphviz/graphviz.git"
     url = "https://gitlab.com/graphviz/graphviz/-/archive/2.46.0/graphviz-2.46.0.tar.bz2"
 

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -20,7 +20,7 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
     measurements of a program's work, resource consumption, and inefficiency
     and attributes them to the full calling context in which they occur."""
 
-    homepage = "http://hpctoolkit.org"
+    homepage = "https://hpctoolkit.org"
     git = "https://gitlab.com/hpctoolkit/hpctoolkit.git"
     maintainers("mwkrentel")
 

--- a/var/spack/repos/builtin/packages/hto4l/package.py
+++ b/var/spack/repos/builtin/packages/hto4l/package.py
@@ -11,7 +11,7 @@ class Hto4l(MakefilePackage):
     up to NLOPS electroweak accuracy and in presence of dimension-6 operators."""
 
     homepage = "https://www2.pv.infn.it/~hepcomplex/hto4l.html"
-    url = "http://www2.pv.infn.it/~hepcomplex/releases/hto4l/Hto4l-v2.02.tar.bz2"
+    url = "https://www2.pv.infn.it/~hepcomplex/releases/hto4l/Hto4l-v2.02.tar.bz2"
 
     maintainers("haralmha")
 

--- a/var/spack/repos/builtin/packages/hto4l/package.py
+++ b/var/spack/repos/builtin/packages/hto4l/package.py
@@ -11,7 +11,7 @@ class Hto4l(MakefilePackage):
     up to NLOPS electroweak accuracy and in presence of dimension-6 operators."""
 
     homepage = "https://www2.pv.infn.it/~hepcomplex/hto4l.html"
-    url = "https://www2.pv.infn.it/~hepcomplex/releases/hto4l/Hto4l-v2.02.tar.bz2"
+    url = "https://www2.pv.infn.it/hepcomplex/releases/hto4l/Hto4l-v2.02.tar.bz2"
 
     maintainers("haralmha")
 

--- a/var/spack/repos/builtin/packages/hypre-cmake/package.py
+++ b/var/spack/repos/builtin/packages/hypre-cmake/package.py
@@ -13,7 +13,7 @@ class HypreCmake(CMakePackage, CudaPackage):
     features parallel multigrid methods for both structured and
     unstructured grid problems."""
 
-    homepage = "http://computing.llnl.gov/project/linear_solvers/software.php"
+    homepage = "https://computing.llnl.gov/project/linear_solvers/software.php"
     url = "https://github.com/hypre-space/hypre/archive/v2.14.0.tar.gz"
     git = "https://github.com/hypre-space/hypre.git"
 
@@ -59,7 +59,7 @@ class HypreCmake(CMakePackage, CudaPackage):
             url = f"https://github.com/hypre-space/hypre/archive/v{version}.tar.gz"
         else:
             url = (
-                f"http://computing.llnl.gov/project/linear_solvers/download/hypre-{version}.tar.gz"
+                f"https://computing.llnl.gov/project/linear_solvers/download/hypre-{version}.tar.gz"
             )
 
         return url

--- a/var/spack/repos/builtin/packages/hypre-cmake/package.py
+++ b/var/spack/repos/builtin/packages/hypre-cmake/package.py
@@ -58,9 +58,7 @@ class HypreCmake(CMakePackage, CudaPackage):
         if version >= Version("2.12.0"):
             url = f"https://github.com/hypre-space/hypre/archive/v{version}.tar.gz"
         else:
-            url = (
-                f"https://computing.llnl.gov/project/linear_solvers/download/hypre-{version}.tar.gz"
-            )
+            url = f"https://computing.llnl.gov/project/linear_solvers/download/hypre-{version}.tar.gz"
 
         return url
 

--- a/var/spack/repos/builtin/packages/itstool/package.py
+++ b/var/spack/repos/builtin/packages/itstool/package.py
@@ -11,8 +11,8 @@ class Itstool(AutotoolsPackage):
     rules from the W3C Internationalization Tag Set (ITS) to determine what
     to translate and how to separate it into PO file messages."""
 
-    homepage = "http://itstool.org/"
-    url = "http://files.itstool.org/itstool/itstool-2.0.2.tar.bz2"
+    homepage = "https://itstool.org/"
+    url = "https://files.itstool.org/itstool/itstool-2.0.2.tar.bz2"
 
     maintainers("agoodLANL")
 

--- a/var/spack/repos/builtin/packages/ldsc/package.py
+++ b/var/spack/repos/builtin/packages/ldsc/package.py
@@ -10,7 +10,7 @@ class Ldsc(PythonPackage):
     """ldsc is a command line tool for estimating heritability and genetic correlation from
     GWAS summary statistics. ldsc also computes LD scores"""
 
-    homepage = "http://github.com/bulik/ldsc"
+    homepage = "https://github.com/bulik/ldsc"
     pypi = "ldsc/ldsc-2.0.1.tar.gz"
 
     license("GPL-3.0-only", checked_by="A-N-Other")

--- a/var/spack/repos/builtin/packages/libnftnl/package.py
+++ b/var/spack/repos/builtin/packages/libnftnl/package.py
@@ -11,7 +11,7 @@ class Libnftnl(AutotoolsPackage):
     over libmnl."""
 
     homepage = "https://git.netfilter.org/libnftnl/"
-    url = "http://ftp.netfilter.org/pub/libnftnl/libnftnl-1.1.5.tar.bz2"
+    url = "https://ftp.netfilter.org/pub/libnftnl/libnftnl-1.1.5.tar.bz2"
 
     license("GPL-2.0-or-later")
 

--- a/var/spack/repos/builtin/packages/libtheora/package.py
+++ b/var/spack/repos/builtin/packages/libtheora/package.py
@@ -16,7 +16,7 @@ class Libtheora(AutotoolsPackage, MSBuildPackage):
     """Theora Video Compression."""
 
     homepage = "https://www.theora.org"
-    url = "http://downloads.xiph.org/releases/theora/libtheora-1.1.1.tar.xz"
+    url = "https://downloads.xiph.org/releases/theora/libtheora-1.1.1.tar.xz"
     git = "https://gitlab.xiph.org/xiph/theora.git"
 
     license("BSD-3-Clause")

--- a/var/spack/repos/builtin/packages/lua-bitlib/package.py
+++ b/var/spack/repos/builtin/packages/lua-bitlib/package.py
@@ -10,7 +10,7 @@ from spack.package import *
 class LuaBitlib(LuaPackage):
     """Lua-jit-like bitwise operations for lua"""
 
-    homepage = "http://luaforge.net/projects/bitlib"
+    homepage = "https://luaforge.net/projects/bitlib"
     url = "https://luarocks.org/manifests/luarocks/bitlib-23-2.src.rock"
 
     version(

--- a/var/spack/repos/builtin/packages/lua-lpeg/package.py
+++ b/var/spack/repos/builtin/packages/lua-lpeg/package.py
@@ -10,7 +10,7 @@ from spack.package import *
 class LuaLpeg(LuaPackage):
     """pattern-matching for lua"""
 
-    homepage = "http://www.inf.puc-rio.br/~roberto/lpeg/"
+    homepage = "https://www.inf.puc-rio.br/~roberto/lpeg/"
     url = "https://luarocks.org/manifests/gvvaughan/lpeg-1.0.2-1.src.rock"
 
     license("MIT")

--- a/var/spack/repos/builtin/packages/minigmg/package.py
+++ b/var/spack/repos/builtin/packages/minigmg/package.py
@@ -23,7 +23,7 @@ class Minigmg(Package):
     Note, miniGMG code has been supersceded by HPGMG."""
 
     homepage = (
-        "http://crd.lbl.gov/departments/computer-science/PAR/research/previous-projects/miniGMG/"
+        "https://crd.lbl.gov/departments/computer-science/PAR/research/previous-projects/miniGMG/"
     )
     url = "https://crd.lbl.gov/assets/Uploads/FTG/Projects/miniGMG/miniGMG.tar.gz"
 

--- a/var/spack/repos/builtin/packages/ocaml/package.py
+++ b/var/spack/repos/builtin/packages/ocaml/package.py
@@ -46,7 +46,7 @@ class Ocaml(Package):
     variant("force-safe-string", default=True, description="Enforce safe (immutable) strings")
 
     def url_for_version(self, version):
-        url = "http://caml.inria.fr/pub/distrib/ocaml-{0}/ocaml-{1}.tar.gz"
+        url = "https://caml.inria.fr/pub/distrib/ocaml-{0}/ocaml-{1}.tar.gz"
         return url.format(str(version)[:-2], version)
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/ompt-openmp/package.py
+++ b/var/spack/repos/builtin/packages/ompt-openmp/package.py
@@ -15,7 +15,7 @@ class OmptOpenmp(CMakePackage):
     """
 
     homepage = "https://github.com/OpenMPToolsInterface/LLVM-openmp"
-    url = "http://github.com/khuck/LLVM-openmp/archive/v0.1.tar.gz"
+    url = "https://github.com/khuck/LLVM-openmp/archive/v0.1.tar.gz"
 
     license("MIT")
 

--- a/var/spack/repos/builtin/packages/open3d/package.py
+++ b/var/spack/repos/builtin/packages/open3d/package.py
@@ -11,7 +11,7 @@ from spack.package import *
 class Open3d(CMakePackage, CudaPackage):
     """Open3D: A Modern Library for 3D Data Processing."""
 
-    homepage = "http://www.open3d.org/"
+    homepage = "https://www.open3d.org/"
     url = "https://github.com/isl-org/Open3D/archive/refs/tags/v0.13.0.tar.gz"
     git = "https://github.com/isl-org/Open3D.git"
 

--- a/var/spack/repos/builtin/packages/openfst/package.py
+++ b/var/spack/repos/builtin/packages/openfst/package.py
@@ -12,9 +12,9 @@ class Openfst(AutotoolsPackage):
     finite-state transducers are automata where each transition has
     an input label, an output label, and a weight."""
 
-    homepage = "http://www.openfst.org"
-    url = "http://www.openfst.org/twiki/pub/FST/FstDownload/openfst-1.6.1.tar.gz"
-    list_url = "http://www.openfst.org/twiki/bin/view/FST/FstDownload"
+    homepage = "https://www.openfst.org"
+    url = "https://www.openfst.org/twiki/pub/FST/FstDownload/openfst-1.6.1.tar.gz"
+    list_url = "https://www.openfst.org/twiki/bin/view/FST/FstDownload"
 
     license("Apache-2.0")
 
@@ -33,7 +33,7 @@ class Openfst(AutotoolsPackage):
     version(
         "1.4.1-patch",
         sha256="e671bf6bd4425a1fed4e7543a024201b74869bfdd029bdf9d10c53a3c2818277",
-        url="http://www.openfst.org/twiki/pub/FST/FstDownload/openfst-1.4.1.tar.gz",
+        url="https://www.openfst.org/twiki/pub/FST/FstDownload/openfst-1.4.1.tar.gz",
     )
     version("1.4.1", sha256="e671bf6bd4425a1fed4e7543a024201b74869bfdd029bdf9d10c53a3c2818277")
     version("1.4.0", sha256="eb557f37560438f03912b4e43335c4c9e72aa486d4f2046127131185eb88f17a")

--- a/var/spack/repos/builtin/packages/perl-alien-svn/package.py
+++ b/var/spack/repos/builtin/packages/perl-alien-svn/package.py
@@ -11,7 +11,7 @@ from spack.package import *
 class PerlAlienSvn(PerlPackage):
     """Perl SVN extension."""
 
-    homepage = "http://metacpan.org/source/MSCHWERN/Alien-SVN-v1.8.11.0"
+    homepage = "https://metacpan.org/source/MSCHWERN/Alien-SVN-v1.8.11.0"
     url = "https://cpan.metacpan.org/authors/id/M/MS/MSCHWERN/Alien-SVN-v1.8.11.0.tar.gz"
 
     version("1.8.11.0", sha256="acf8ebce1cb6958ef24611a453abee32b8e4dfe767563834362891ef3f30fc68")

--- a/var/spack/repos/builtin/packages/pism/package.py
+++ b/var/spack/repos/builtin/packages/pism/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class Pism(CMakePackage):
     """Parallel Ice Sheet Model"""
 
-    homepage = "http://pism-docs.org/wiki/doku.php:="
+    homepage = "https://pism-docs.org/wiki/doku.php:="
     url = "https://github.com/pism/pism/archive/v1.1.4.tar.gz"
     git = "https://github.com/pism/pism.git"
 

--- a/var/spack/repos/builtin/packages/pixman/package.py
+++ b/var/spack/repos/builtin/packages/pixman/package.py
@@ -13,7 +13,7 @@ class Pixman(AutotoolsPackage):
     pixel manipulation features such as image compositing and
     trapezoid rasterization."""
 
-    homepage = "http://www.pixman.org"
+    homepage = "https://www.pixman.org"
     url = "https://cairographics.org/releases/pixman-0.32.6.tar.gz"
 
     license("MIT")

--- a/var/spack/repos/builtin/packages/pocl/package.py
+++ b/var/spack/repos/builtin/packages/pocl/package.py
@@ -15,7 +15,7 @@ class Pocl(CMakePackage):
     and devices, both for homogeneous CPU and heterogeneous
     GPUs/accelerators."""
 
-    homepage = "http://portablecl.org"
+    homepage = "https://portablecl.org"
     url = "https://github.com/pocl/pocl/archive/v1.1.tar.gz"
     git = "https://github.com/pocl/pocl.git"
 
@@ -80,7 +80,7 @@ class Pocl(CMakePackage):
         if version >= Version("1.0"):
             url = "https://github.com/pocl/pocl/archive/v{0}.tar.gz"
         else:
-            url = "http://portablecl.org/downloads/pocl-{0}.tar.gz"
+            url = "https://portablecl.org/downloads/pocl-{0}.tar.gz"
 
         return url.format(version.up_to(2))
 

--- a/var/spack/repos/builtin/packages/py-croniter/package.py
+++ b/var/spack/repos/builtin/packages/py-croniter/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyCroniter(PythonPackage):
     """croniter provides iteration for datetime object with cron like format."""
 
-    homepage = "http://github.com/kiorky/croniter"
+    homepage = "https://github.com/kiorky/croniter"
     pypi = "croniter/croniter-1.3.8.tar.gz"
 
     license("MIT")

--- a/var/spack/repos/builtin/packages/py-doit/package.py
+++ b/var/spack/repos/builtin/packages/py-doit/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyDoit(PythonPackage):
     """doit - Automation Tool."""
 
-    homepage = "http://pydoit.org/"
+    homepage = "https://pydoit.org/"
     pypi = "doit/doit-0.36.0.tar.gz"
 
     license("MIT")

--- a/var/spack/repos/builtin/packages/py-downhill/package.py
+++ b/var/spack/repos/builtin/packages/py-downhill/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyDownhill(PythonPackage):
     """Stochastic optimization routines for Theano"""
 
-    homepage = "http://github.com/lmjohns3/downhill"
+    homepage = "https://github.com/lmjohns3/downhill"
     pypi = "downhill/downhill-0.4.0.tar.gz"
 
     license("MIT")

--- a/var/spack/repos/builtin/packages/py-fastcluster/package.py
+++ b/var/spack/repos/builtin/packages/py-fastcluster/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyFastcluster(PythonPackage):
     """Fast hierarchical clustering routines for R and Python."""
 
-    homepage = "http://danifold.net/"
+    homepage = "https://danifold.net/"
     pypi = "fastcluster/fastcluster-1.1.26.tar.gz"
 
     license("BSD-2-Clause")

--- a/var/spack/repos/builtin/packages/py-flawfinder/package.py
+++ b/var/spack/repos/builtin/packages/py-flawfinder/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyFlawfinder(PythonPackage, SourceforgePackage):
     """a program that examines source code looking for security weaknesses"""
 
-    homepage = "http://dwheeler.com/flawfinder/"
+    homepage = "https://dwheeler.com/flawfinder/"
     sourceforge_mirror_path = "project/flawfinder/flawfinder-2.0.19.tar.gz"
 
     license("GPL-2.0+")

--- a/var/spack/repos/builtin/packages/py-glob2/package.py
+++ b/var/spack/repos/builtin/packages/py-glob2/package.py
@@ -10,7 +10,7 @@ class PyGlob2(PythonPackage):
     """Version of the glob module that can capture patterns
     and supports recursive wildcards."""
 
-    homepage = "http://github.com/miracle2k/python-glob2/"
+    homepage = "https://github.com/miracle2k/python-glob2/"
     pypi = "glob2/glob2-0.7.tar.gz"
 
     version("0.7", sha256="85c3dbd07c8aa26d63d7aacee34fa86e9a91a3873bc30bf62ec46e531f92ab8c")

--- a/var/spack/repos/builtin/packages/py-jupyter-server-mathjax/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-server-mathjax/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyJupyterServerMathjax(PythonPackage):
     """MathJax resources as a Jupyter Server Extension."""
 
-    homepage = "http://jupyter.org/"
+    homepage = "https://jupyter.org/"
     pypi = "jupyter_server_mathjax/jupyter_server_mathjax-0.2.3.tar.gz"
 
     license("BSD-3-Clause")

--- a/var/spack/repos/builtin/packages/py-lhsmdu/package.py
+++ b/var/spack/repos/builtin/packages/py-lhsmdu/package.py
@@ -13,7 +13,7 @@ class PyLhsmdu(PythonPackage):
     from Deutsch and Deutsch, Latin hypercube sampling with multidimensional
     uniformity."""
 
-    homepage = "http://github.com/sahilm89/lhsmdu"
+    homepage = "https://github.com/sahilm89/lhsmdu"
     pypi = "lhsmdu/lhsmdu-1.1.tar.gz"
     maintainers("liuyangzhuan")
 

--- a/var/spack/repos/builtin/packages/py-mne/package.py
+++ b/var/spack/repos/builtin/packages/py-mne/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyMne(PythonPackage):
     """MNE python project for MEG and EEG data analysis."""
 
-    homepage = "http://mne.tools/"
+    homepage = "https://mne.tools/"
     pypi = "mne/mne-0.23.4.tar.gz"
     git = "https://github.com/mne-tools/mne-python.git"
 

--- a/var/spack/repos/builtin/packages/py-myhdl/package.py
+++ b/var/spack/repos/builtin/packages/py-myhdl/package.py
@@ -10,7 +10,7 @@ from spack.package import *
 class PyMyhdl(PythonPackage):
     """Python as a Hardware Description Language"""
 
-    homepage = "http://www.myhdl.org"
+    homepage = "https://www.myhdl.org"
     pypi = "myhdl/myhdl-0.9.0.tar.gz"
 
     license("LGPL-2.1-or-later")

--- a/var/spack/repos/builtin/packages/py-mypy/package.py
+++ b/var/spack/repos/builtin/packages/py-mypy/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyMypy(PythonPackage):
     """Optional static typing for Python."""
 
-    homepage = "http://www.mypy-lang.org/"
+    homepage = "https://www.mypy-lang.org/"
     pypi = "mypy/mypy-0.740.tar.gz"
     git = "https://github.com/python/mypy.git"
 

--- a/var/spack/repos/builtin/packages/py-netpyne/package.py
+++ b/var/spack/repos/builtin/packages/py-netpyne/package.py
@@ -11,7 +11,7 @@ class PyNetpyne(PythonPackage):
     parallel simulation, optimization and analysis of multiscale
     biological neuronal networks in NEURON."""
 
-    homepage = "http://www.netpyne.org/"
+    homepage = "https://www.netpyne.org/"
     url = "https://github.com/suny-downstate-medical-center/netpyne/archive/refs/tags/v1.0.3.1.tar.gz"
     git = "https://github.com/suny-downstate-medical-center/netpyne.git"
 

--- a/var/spack/repos/builtin/packages/py-opentuner/package.py
+++ b/var/spack/repos/builtin/packages/py-opentuner/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyOpentuner(PythonPackage):
     """An extensible framework for program autotuning."""
 
-    homepage = "http://opentuner.org/"
+    homepage = "https://opentuner.org/"
     git = "https://github.com/jansel/opentuner.git"
 
     maintainers("matthiasdiener")

--- a/var/spack/repos/builtin/packages/py-orbax-checkpoint/package.py
+++ b/var/spack/repos/builtin/packages/py-orbax-checkpoint/package.py
@@ -13,7 +13,7 @@ class PyOrbaxCheckpoint(PythonPackage):
     composable API which maximizes flexibility for diverse use cases.
     """
 
-    homepage = "http://github.com/google/orbax"
+    homepage = "https://github.com/google/orbax"
     pypi = "orbax_checkpoint/orbax_checkpoint-0.5.3.tar.gz"
 
     license("Apache-2.0")

--- a/var/spack/repos/builtin/packages/py-outdated/package.py
+++ b/var/spack/repos/builtin/packages/py-outdated/package.py
@@ -10,7 +10,7 @@ class PyOutdated(PythonPackage):
     """This is a mini-library which, given a package name and a version, checks if
     it's the latest version available on PyPI."""
 
-    homepage = "http://github.com/alexmojaki/outdated"
+    homepage = "https://github.com/alexmojaki/outdated"
     pypi = "outdated/outdated-0.2.2.tar.gz"
 
     maintainers("meyersbs")

--- a/var/spack/repos/builtin/packages/py-panel/package.py
+++ b/var/spack/repos/builtin/packages/py-panel/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyPanel(PythonPackage):
     """A high level app and dashboarding solution for Python."""
 
-    homepage = "http://panel.holoviz.org/"
+    homepage = "https://panel.holoviz.org/"
     pypi = "panel/panel-0.14.4.tar.gz"
 
     license("BSD-3-Clause")

--- a/var/spack/repos/builtin/packages/py-pyfr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfr/package.py
@@ -12,7 +12,7 @@ class PyPyfr(PythonPackage, CudaPackage, ROCmPackage):
     advection-diffusion type problems on streaming architectures
     using the Flux Reconstruction approach of Huynh."""
 
-    homepage = "http://www.pyfr.org/"
+    homepage = "https://www.pyfr.org/"
     pypi = "pyfr/pyfr-1.13.0.tar.gz"
     git = "https://github.com/PyFR/PyFR/"
     maintainers("MichaelLaufer")

--- a/var/spack/repos/builtin/packages/py-pygresql/package.py
+++ b/var/spack/repos/builtin/packages/py-pygresql/package.py
@@ -10,8 +10,8 @@ class PyPygresql(PythonPackage):
     """PyGreSQL is an open-source Python module that interfaces to a
     PostgreSQL database"""
 
-    homepage = "http://www.pygresql.org"
-    url = "http://www.pygresql.org/files/PyGreSQL-5.0.5.tar.gz"
+    homepage = "https://www.pygresql.org"
+    url = "https://www.pygresql.org/files/PyGreSQL-5.0.5.tar.gz"
 
     version("5.0.5", sha256="ff5e76b840600d4912b79daf347b44274a1c0368663e7b57529c406f8426479c")
 

--- a/var/spack/repos/builtin/packages/py-pylev/package.py
+++ b/var/spack/repos/builtin/packages/py-pylev/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyPylev(PythonPackage):
     """A pure Python Levenshtein implementation that's not freaking GPL'd."""
 
-    homepage = "http://github.com/toastdriven/pylev"
+    homepage = "https://github.com/toastdriven/pylev"
     pypi = "pylev/pylev-1.4.0.tar.gz"
 
     license("BSD-3-Clause")

--- a/var/spack/repos/builtin/packages/py-pymorph/package.py
+++ b/var/spack/repos/builtin/packages/py-pymorph/package.py
@@ -11,7 +11,7 @@ class PyPymorph(PythonPackage):
     morphology functions.
     """
 
-    homepage = "http://luispedro.org/software/pymorph/"
+    homepage = "https://luispedro.org/software/pymorph/"
     pypi = "pymorph/pymorph-0.96.tar.gz"
 
     version("0.96", sha256="5dd648e4cb4c3495ee6031bc8020ed8216f3d6cb8c0dcd0427b215b75d7d29ad")

--- a/var/spack/repos/builtin/packages/py-pyqtgraph/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqtgraph/package.py
@@ -10,7 +10,7 @@ class PyPyqtgraph(PythonPackage):
     """PyQtGraph is a pure-python graphics and GUI library intended for use in mathematics,
     scientific, and engineering applications"""
 
-    homepage = "http://www.pyqtgraph.org/"
+    homepage = "https://www.pyqtgraph.org/"
     pypi = "pyqtgraph/pyqtgraph-0.13.3.tar.gz"
 
     license("MIT", checked_by="A-N-Other")

--- a/var/spack/repos/builtin/packages/py-pysimdjson/package.py
+++ b/var/spack/repos/builtin/packages/py-pysimdjson/package.py
@@ -11,7 +11,7 @@ class PyPysimdjson(PythonPackage):
     JSON parser. If SIMD instructions are unavailable a fallback parser
     is used, making pysimdjson safe to use anywhere."""
 
-    homepage = "http://github.com/TkTech/pysimdjson"
+    homepage = "https://github.com/TkTech/pysimdjson"
     pypi = "pysimdjson/pysimdjson-4.0.3.tar.gz"
 
     maintainers("haralmha")

--- a/var/spack/repos/builtin/packages/py-python-jose/package.py
+++ b/var/spack/repos/builtin/packages/py-python-jose/package.py
@@ -10,7 +10,7 @@ from spack.package import *
 class PyPythonJose(PythonPackage):
     """JOSE implementation in Python"""
 
-    homepage = "http://github.com/mpdavis/python-jose"
+    homepage = "https://github.com/mpdavis/python-jose"
     pypi = "python-jose/python-jose-3.3.0.tar.gz"
 
     license("MIT")

--- a/var/spack/repos/builtin/packages/py-python-pptx/package.py
+++ b/var/spack/repos/builtin/packages/py-python-pptx/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyPythonPptx(PythonPackage):
     """Generate and manipulate Open XML PowerPoint (.pptx) files."""
 
-    homepage = "http://github.com/scanny/python-pptx"
+    homepage = "https://github.com/scanny/python-pptx"
     pypi = "python-pptx/python-pptx-0.6.21.tar.gz"
 
     maintainers("LydDeb")

--- a/var/spack/repos/builtin/packages/py-requests-file/package.py
+++ b/var/spack/repos/builtin/packages/py-requests-file/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyRequestsFile(PythonPackage):
     """File transport adapter for Requests."""
 
-    homepage = "http://github.com/dashea/requests-file"
+    homepage = "https://github.com/dashea/requests-file"
     pypi = "requests-file/requests-file-1.5.1.tar.gz"
 
     maintainers("LydDeb")

--- a/var/spack/repos/builtin/packages/py-rx/package.py
+++ b/var/spack/repos/builtin/packages/py-rx/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyRx(PythonPackage):
     """Reactive Extensions (Rx) for Python"""
 
-    homepage = "http://reactivex.io/"
+    homepage = "https://reactivex.io/"
     pypi = "Rx/Rx-3.2.0.tar.gz"
 
     maintainers("dorton21")

--- a/var/spack/repos/builtin/packages/py-seekpath/package.py
+++ b/var/spack/repos/builtin/packages/py-seekpath/package.py
@@ -10,7 +10,7 @@ class PySeekpath(PythonPackage):
     """SeeK-path is a python module to obtain band paths in the Brillouin zone of crystal
     structures."""
 
-    homepage = "http://github.com/giovannipizzi/seekpath"
+    homepage = "https://github.com/giovannipizzi/seekpath"
     pypi = "seekpath/seekpath-2.0.1.tar.gz"
 
     maintainers("meyersbs")

--- a/var/spack/repos/builtin/packages/py-sqlalchemy-migrate/package.py
+++ b/var/spack/repos/builtin/packages/py-sqlalchemy-migrate/package.py
@@ -10,7 +10,7 @@ from spack.package import *
 class PySqlalchemyMigrate(PythonPackage):
     """Database schema migration for SQLAlchemy"""
 
-    homepage = "http://www.openstack.org/"
+    homepage = "https://www.openstack.org/"
     pypi = "sqlalchemy-migrate/sqlalchemy-migrate-0.13.0.tar.gz"
 
     license("MIT")

--- a/var/spack/repos/builtin/packages/py-stack-data/package.py
+++ b/var/spack/repos/builtin/packages/py-stack-data/package.py
@@ -10,7 +10,7 @@ class PyStackData(PythonPackage):
     """Extract data from python stack frames and tracebacks for informative
     displays."""
 
-    homepage = "http://github.com/alexmojaki/stack_data"
+    homepage = "https://github.com/alexmojaki/stack_data"
     pypi = "stack_data/stack_data-0.2.0.tar.gz"
 
     license("MIT")

--- a/var/spack/repos/builtin/packages/py-tuspy/package.py
+++ b/var/spack/repos/builtin/packages/py-tuspy/package.py
@@ -10,7 +10,7 @@ from spack.package import *
 class PyTuspy(PythonPackage):
     """A Python client for the tus resumable upload protocol -> http://tus.io"""
 
-    homepage = "http://github.com/tus/tus-py-client/"
+    homepage = "https://github.com/tus/tus-py-client/"
     pypi = "tuspy/tuspy-1.0.0.tar.gz"
 
     license("MIT")

--- a/var/spack/repos/builtin/packages/py-xrootdpyfs/package.py
+++ b/var/spack/repos/builtin/packages/py-xrootdpyfs/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyXrootdpyfs(PythonPackage):
     """XRootDPyFS is a PyFilesystem interface to XRootD."""
 
-    homepage = "http://github.com/inveniosoftware/xrootdpyfs/"
+    homepage = "https://github.com/inveniosoftware/xrootdpyfs/"
     pypi = "xrootdpyfs/xrootdpyfs-0.2.2.tar.gz"
 
     version("0.2.2", sha256="43698c260f3ec52320c6bfac8dd3e7c2be7d28e9e9f58edf4f916578114e82bf")

--- a/var/spack/repos/builtin/packages/rabbitmq/package.py
+++ b/var/spack/repos/builtin/packages/rabbitmq/package.py
@@ -15,7 +15,7 @@ class Rabbitmq(Package):
     """
 
     homepage = "https://www.rabbitmq.com/"
-    url = "http://www.rabbitmq.com/releases/rabbitmq-server/v3.6.15/rabbitmq-server-generic-unix-3.6.15.tar.xz"
+    url = "https://www.rabbitmq.com/releases/rabbitmq-server/v3.6.15/rabbitmq-server-generic-unix-3.6.15.tar.xz"
 
     license("BSD-2-Clause")
 

--- a/var/spack/repos/builtin/packages/repeatmasker/package.py
+++ b/var/spack/repos/builtin/packages/repeatmasker/package.py
@@ -37,10 +37,10 @@ class Repeatmasker(Package):
 
     def url_for_version(self, version):
         if version >= Version("4.1.0"):
-            url = "http://www.repeatmasker.org/RepeatMasker/RepeatMasker-{0}.tar.gz"
+            url = "https://www.repeatmasker.org/RepeatMasker/RepeatMasker-{0}.tar.gz"
             return url.format(version)
         else:
-            url = "http://www.repeatmasker.org/RepeatMasker/RepeatMasker-open-{0}.tar.gz"
+            url = "https://www.repeatmasker.org/RepeatMasker/RepeatMasker-open-{0}.tar.gz"
             return url.format(version.dashed)
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/rrdtool/package.py
+++ b/var/spack/repos/builtin/packages/rrdtool/package.py
@@ -10,7 +10,7 @@ class Rrdtool(AutotoolsPackage):
     """RA tool for data logging and analysis."""
 
     homepage = "https://oss.oetiker.ch/rrdtool"
-    url = "http://oss.oetiker.ch/rrdtool/pub/rrdtool-1.7.0.tar.gz"
+    url = "https://oss.oetiker.ch/rrdtool/pub/rrdtool-1.7.0.tar.gz"
 
     license("GPL-2.0-or-later")
 

--- a/var/spack/repos/builtin/packages/survey/package.py
+++ b/var/spack/repos/builtin/packages/survey/package.py
@@ -27,7 +27,7 @@ class Survey(CMakePackage):
                      jeg@trenzasynergy.com
     """
 
-    homepage = "http://www.trenzasynergy.com"
+    homepage = "https://www.trenzasynergy.com"
     git = "ssh://git@gitlab.com/trenza/survey.git"
 
     maintainers("jgalarowicz")

--- a/var/spack/repos/builtin/packages/swig/package.py
+++ b/var/spack/repos/builtin/packages/swig/package.py
@@ -19,7 +19,7 @@ class Swig(AutotoolsPackage, SourceforgePackage):
     features that let you tailor the wrapping process to suit your
     application."""
 
-    homepage = "http://www.swig.org"
+    homepage = "https://www.swig.org"
     sourceforge_mirror_path = "swig/swig-3.0.12.tar.gz"
     maintainers("sethrj")
 

--- a/var/spack/repos/builtin/packages/thrift/package.py
+++ b/var/spack/repos/builtin/packages/thrift/package.py
@@ -18,8 +18,8 @@ class Thrift(Package):
     """
 
     homepage = "https://thrift.apache.org"
-    url = "http://archive.apache.org/dist/thrift/0.16.0/thrift-0.16.0.tar.gz"
-    list_url = "http://archive.apache.org/dist/thrift/"
+    url = "https://archive.apache.org/dist/thrift/0.16.0/thrift-0.16.0.tar.gz"
+    list_url = "https://archive.apache.org/dist/thrift/"
     list_depth = 1
 
     maintainers("thomas-bouvier")

--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -11,7 +11,7 @@ class Ucx(AutotoolsPackage, CudaPackage):
     """a communication library implementing high-performance messaging for
     MPI/PGAS frameworks"""
 
-    homepage = "http://www.openucx.org"
+    homepage = "https://www.openucx.org"
     url = "https://github.com/openucx/ucx/releases/download/v1.3.1/ucx-1.3.1.tar.gz"
     git = "https://github.com/openucx/ucx.git"
 

--- a/var/spack/repos/builtin/packages/unixodbc/package.py
+++ b/var/spack/repos/builtin/packages/unixodbc/package.py
@@ -11,8 +11,8 @@ class Unixodbc(AutotoolsPackage):
     a predictable API with which to access Data Sources. Data Sources include
     SQL Servers and any Data Source with an ODBC Driver."""
 
-    homepage = "http://www.unixodbc.org/"
-    url = "http://www.unixodbc.org/unixODBC-2.3.4.tar.gz"
+    homepage = "https://www.unixodbc.org/"
+    url = "https://www.unixodbc.org/unixODBC-2.3.4.tar.gz"
 
     license("LGPL-2.0-or-later")
 

--- a/var/spack/repos/builtin/packages/voropp/package.py
+++ b/var/spack/repos/builtin/packages/voropp/package.py
@@ -11,8 +11,8 @@ class Voropp(MakefilePackage):
     Voronoi diagram, a widely-used tessellation that has applications in many
     scientific fields."""
 
-    homepage = "http://math.lbl.gov/voro++/about.html"
-    url = "http://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz"
+    homepage = "https://math.lbl.gov/voro++/about.html"
+    url = "https://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz"
 
     variant("pic", default=True, description="Position independent code")
 

--- a/var/spack/repos/builtin/packages/wannier90/package.py
+++ b/var/spack/repos/builtin/packages/wannier90/package.py
@@ -15,7 +15,7 @@ class Wannier90(MakefilePackage):
     Wannier90 is released under the GNU General Public License.
     """
 
-    homepage = "http://wannier.org"
+    homepage = "https://wannier.org"
     url = "https://github.com/wannier-developers/wannier90/archive/v3.1.0.tar.gz"
     git = "https://github.com/wannier-developers/wannier90.git"
 
@@ -54,7 +54,7 @@ class Wannier90(MakefilePackage):
         if version > Version("2"):
             url = "https://github.com/wannier-developers/wannier90/archive/v{0}.tar.gz"
         else:
-            url = "http://wannier.org/code/wannier90-{0}.tar.gz"
+            url = "https://wannier.org/code/wannier90-{0}.tar.gz"
         return url.format(version)
 
     @property

--- a/var/spack/repos/builtin/packages/xsdk-examples/package.py
+++ b/var/spack/repos/builtin/packages/xsdk-examples/package.py
@@ -10,7 +10,7 @@ from spack.package import *
 class XsdkExamples(CMakePackage, CudaPackage, ROCmPackage):
     """xSDK Examples show usage of libraries in the xSDK package."""
 
-    homepage = "http://xsdk.info"
+    homepage = "https://xsdk.info"
     url = "https://github.com/xsdk-project/xsdk-examples/archive/v0.1.0.tar.gz"
     git = "https://github.com/xsdk-project/xsdk-examples"
 

--- a/var/spack/repos/builtin/packages/yambo/package.py
+++ b/var/spack/repos/builtin/packages/yambo/package.py
@@ -17,7 +17,7 @@ class Yambo(AutotoolsPackage):
     to its release under the GPL license, yambo was known as SELF.
     """
 
-    homepage = "http://www.yambo-code.org/index.php"
+    homepage = "https://www.yambo-code.org/index.php"
     url = "https://github.com/yambo-code/yambo/archive/4.2.2.tar.gz"
 
     license("GPL-2.0-or-later")


### PR DESCRIPTION
Repology marks many packages are [problematic](https://repology.org/repository/spack/problems) because of permanent redirects from http to https for either homepage or download urls. These problems overwhelm other, potentially worse, problems such as dead links.

This PR updates (only) those packages marked as problematic due to permanent redirects from http to https.