### PR TITLE
mfem, pflotran, alquimia: remove old versions with xsdk string (in version)

### DIFF
--- a/var/spack/repos/builtin/packages/alquimia/package.py
+++ b/var/spack/repos/builtin/packages/alquimia/package.py
@@ -21,8 +21,6 @@ class Alquimia(CMakePackage):
     version("1.1.0", commit="211931c3e76b1ae7cdb48c46885b248412d6fe3d")  # tag v1.1.0
     version("1.0.10", commit="b2c11b6cde321f4a495ef9fcf267cb4c7a9858a0")  # tag v.1.0.10
     version("1.0.9", commit="2ee3bcfacc63f685864bcac2b6868b48ad235225")  # tag v.1.0.9
-    version("xsdk-0.6.0", commit="9a0aedd3a927d4d5e837f8fd18b74ad5a78c3821")
-    version("xsdk-0.5.0", commit="8397c3b00a09534c5473ff3ab21f0e32bb159380")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
@@ -35,8 +33,6 @@ class Alquimia(CMakePackage):
     depends_on("pflotran@5.0.0", when="@1.1.0")
     depends_on("pflotran@4.0.1", when="@1.0.10")
     depends_on("pflotran@3.0.2", when="@1.0.9")
-    depends_on("pflotran@xsdk-0.6.0", when="@xsdk-0.6.0")
-    depends_on("pflotran@xsdk-0.5.0", when="@xsdk-0.5.0")
     depends_on("pflotran@develop", when="@develop")
     depends_on("petsc@3.10:", when="@develop")
 

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -106,9 +106,6 @@ class Mfem(Package, CudaPackage, ROCmPackage):
         extension="tar.gz",
     )
 
-    # Tagged development version used by xSDK
-    version("4.0.1-xsdk", commit="c55c80d17b82d80de04b849dd526e17044f8c99a")
-
     version(
         "4.0.0",
         sha256="df5bdac798ea84a263979f6fbf79de9013e1c55562f95f98644c3edcacfbc727",
@@ -309,8 +306,8 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     depends_on("sundials@2.7.0+mpi+hypre", when="@:3.3.0+sundials+mpi")
     depends_on("sundials@2.7.0:", when="@3.3.2:+sundials~mpi")
     depends_on("sundials@2.7.0:+mpi+hypre", when="@3.3.2:+sundials+mpi")
-    depends_on("sundials@5.0.0:5", when="@4.0.1-xsdk:4.4+sundials~mpi")
-    depends_on("sundials@5.0.0:5+mpi+hypre", when="@4.0.1-xsdk:4.4+sundials+mpi")
+    depends_on("sundials@5.0.0:5", when="@4.1.0:4.4+sundials~mpi")
+    depends_on("sundials@5.0.0:5+mpi+hypre", when="@4.1.0:4.4+sundials+mpi")
     depends_on("sundials@5.0.0:6.7.0", when="@4.5.0:+sundials~mpi")
     depends_on("sundials@5.0.0:6.7.0+mpi+hypre", when="@4.5.0:+sundials+mpi")
     conflicts("cxxstd=11", when="^sundials@6.4.0:")

--- a/var/spack/repos/builtin/packages/pflotran/package.py
+++ b/var/spack/repos/builtin/packages/pflotran/package.py
@@ -23,10 +23,6 @@ class Pflotran(AutotoolsPackage):
     version("5.0.0", commit="f0fe931c72c03580e489724afeb8c5451406b942")  # tag v5.0.0
     version("4.0.1", commit="fd351a49b687e27f46eae92e9259156eea74897d")  # tag v4.0.1
     version("3.0.2", commit="9e07f416a66b0ad304c720b61aa41cba9a0929d5")  # tag v3.0.2
-    version("xsdk-0.6.0", commit="46e14355c1827c057f2e1b3e3ae934119ab023b2")
-    version("xsdk-0.5.0", commit="98a959c591b72f73373febf5f9735d2c523b4c20")
-    version("xsdk-0.4.0", commit="c851cbc94fc56a32cfdb0678f3c24b9936a5584e")
-    version("xsdk-0.3.0", branch="release/xsdk-0.3.0")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
@@ -40,10 +36,6 @@ class Pflotran(AutotoolsPackage):
     depends_on("petsc@3.20:+hdf5+metis", when="@5.0.0")
     depends_on("petsc@3.18:+hdf5+metis", when="@4.0.1")
     depends_on("petsc@3.16:+hdf5+metis", when="@3.0.2")
-    depends_on("petsc@3.14:+hdf5+metis", when="@xsdk-0.6.0")
-    depends_on("petsc@3.12:+hdf5+metis", when="@xsdk-0.5.0")
-    depends_on("petsc@3.10:+hdf5+metis", when="@xsdk-0.4.0")
-    depends_on("petsc@3.8.0:+hdf5+metis", when="@xsdk-0.3.0")
 
     # https://github.com/spack/spack/pull/37579#issuecomment-1545998141
     conflicts("^hdf5@1.14.1", when="%oneapi")
@@ -54,10 +46,6 @@ class Pflotran(AutotoolsPackage):
                 make("pflotran_rxn")
         else:
             make("all")
-
-    @property
-    def parallel(self):
-        return self.spec.satisfies("@xsdk-0.4.0:")
 
     def flag_handler(self, name, flags):
         if "%gcc@10:" in self.spec and name == "fflags":


### PR DESCRIPTION
These old pkg versions were used in older xsdk releases - that are already removed from spack.