### PR TITLE
RPackage: ensure CRAN packages are found for older versions

### DIFF
--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -85,20 +85,21 @@ class RPackage(Package):
             return "https://bioconductor.org/packages/" + cls.bioc
 
     @lang.classproperty
-    def url(cls):
+    def urls(cls):
         if cls.cran:
-            return (
+            return [
                 "https://cloud.r-project.org/src/contrib/"
-                + cls.cran
-                + "_"
-                + str(list(cls.versions)[0])
-                + ".tar.gz"
-            )
+                + f"{cls.cran}_{str(list(cls.versions)[0])}.tar.gz",
+                "https://cloud.r-project.org/src/contrib/Archive/{cls.cran}/"
+                + f"{cls.cran}_{str(list(cls.versions)[0])}.tar.gz",
+            ]
+        else:
+            return [cls.url]
 
     @lang.classproperty
     def list_url(cls):
         if cls.cran:
-            return "https://cloud.r-project.org/src/contrib/Archive/" + cls.cran + "/"
+            return "https://cloud.r-project.org/src/contrib/"
 
     @property
     def git(self):

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -93,6 +93,13 @@ class RPackage(Package):
                 "https://cloud.r-project.org/src/contrib/Archive/{cls.cran}/"
                 + f"{cls.cran}_{str(list(cls.versions)[0])}.tar.gz",
             ]
+        elif cls.bioc:
+            return [
+                "https://bioconductor.org/packages/release/bioc/src/contrib/"
+                + f"{cls.bioc}_{str(list(cls.versions)[0])}.tar.gz",
+                "https://bioconductor.org/packages/release/data/annotation/src/contrib/"
+                + f"{cls.bioc}_{str(list(cls.versions)[0])}.tar.gz",
+            ]
         else:
             return [cls.url]
 

--- a/var/spack/repos/builtin/packages/bioconductor-dupradar/package.py
+++ b/var/spack/repos/builtin/packages/bioconductor-dupradar/package.py
@@ -9,8 +9,6 @@ from spack.package import *
 class BioconductorDupradar(RPackage):
     """Assessment of duplication rates in RNA-Seq datasets"""
 
-    homepage = "https://bioconductor.org/packages/3.16/bioc/html/dupRadar.html"
-    url = "https://bioconductor.org/packages/release/bioc/src/contrib/dupRadar_1.30.0.tar.gz"
     maintainers("pabloaledo")
 
     bioc = "dupradar"

--- a/var/spack/repos/builtin/packages/bioconductor-ebseq/package.py
+++ b/var/spack/repos/builtin/packages/bioconductor-ebseq/package.py
@@ -18,10 +18,9 @@ class BioconductorEbseq(RPackage):
     are the same as those required for gene-level analysis)."""
 
     homepage = "https://www.biostat.wisc.edu/~kendzior/EBSEQ/"
-    url = "https://bioconductor.org/packages/release/bioc/src/contrib/EBSeq_1.40.0.tar.gz"
     maintainers("pabloaledo")
 
-    bioc = "ebseq"
+    bioc = "EBSeq"
 
     version(
         "1.40.0",

--- a/var/spack/repos/builtin/packages/bioconductor-rsubread/package.py
+++ b/var/spack/repos/builtin/packages/bioconductor-rsubread/package.py
@@ -9,10 +9,7 @@ from spack.package import *
 class BioconductorRsubread(RPackage):
     """Mapping, quantification and variant analysis of sequencing data"""
 
-    homepage = "https://bioconductor.org/packages/3.16/bioc/html/Rsubread.html"
-    url = "https://bioconductor.org/packages/release/bioc/src/contrib/Rsubread_2.14.2.tar.gz"
-
-    bioc = "rsubread"
+    bioc = "Rsubread"
 
     depends_on("r-matrix")
     depends_on("zlib-api")

--- a/var/spack/repos/builtin/packages/bioconductor-tximeta/package.py
+++ b/var/spack/repos/builtin/packages/bioconductor-tximeta/package.py
@@ -14,9 +14,6 @@ class BioconductorTximeta(RPackage):
     metadata. De novo transcriptomes can be linked to the appropriate sources with
     linkedTxomes and shared for computational reproducibility."""
 
-    homepage = "https://bioconductor.org/packages/release/bioc/html/tximeta.html"
-    url = "https://bioconductor.org/packages/release/bioc/src/contrib/tximeta_1.18.1.tar.gz"
-
     bioc = "tximeta"
 
     version(

--- a/var/spack/repos/builtin/packages/phantompeakqualtools/package.py
+++ b/var/spack/repos/builtin/packages/phantompeakqualtools/package.py
@@ -11,7 +11,7 @@ class Phantompeakqualtools(RPackage):
     ChIP-seq/DNase-seq/FAIRE-seq/MNase-seq data."""
 
     homepage = "https://github.com/kundajelab/phantompeakqualtools"
-    url = "https://github.com/kundajelab/phantompeakqualtools/archive/1.2.tar.gz"
+    urls = ["https://github.com/kundajelab/phantompeakqualtools/archive/1.2.tar.gz"]
 
     version("1.2", sha256="86cbcca80b65f150b1cdbea673d8a47caba88c2db6b3b567a80f2c797c9a1668")
 

--- a/var/spack/repos/builtin/packages/qorts/package.py
+++ b/var/spack/repos/builtin/packages/qorts/package.py
@@ -17,7 +17,7 @@ class Qorts(RPackage):
     technology."""
 
     homepage = "https://github.com/hartleys/QoRTs"
-    url = "https://github.com/hartleys/QoRTs/releases/download/v1.2.42/QoRTs_1.2.42.tar.gz"
+    urls = ["https://github.com/hartleys/QoRTs/releases/download/v1.2.42/QoRTs_1.2.42.tar.gz"]
 
     version("1.2.42", sha256="c9f73ce8d5aac1036d13c50475458a61a24cbe5c0baf7ac65b87a7118c51ec08")
 

--- a/var/spack/repos/builtin/packages/r-bfastspatial/package.py
+++ b/var/spack/repos/builtin/packages/r-bfastspatial/package.py
@@ -13,7 +13,7 @@ class RBfastspatial(RPackage):
     post-process the results."""
 
     homepage = "https://github.com/loicdtx/bfastSpatial"
-    url = "https://github.com/loicdtx/bfastSpatial/archive/0.6.2.tar.gz"
+    urls = ["https://github.com/loicdtx/bfastSpatial/archive/0.6.2.tar.gz"]
 
     version("0.6.2", sha256="2c6220a5d04d6e4531b0b022a015651e630433f8d6864fa8b820aed5af5c1897")
 

--- a/var/spack/repos/builtin/packages/r-bsgenome-hsapiens-ucsc-hg19/package.py
+++ b/var/spack/repos/builtin/packages/r-bsgenome-hsapiens-ucsc-hg19/package.py
@@ -15,7 +15,6 @@ class RBsgenomeHsapiensUcscHg19(RPackage):
 
     # This is a bioconductor package but there is no available git repo.
     bioc = "BSgenome.Hsapiens.UCSC.hg19"
-    url = "http://www.bioconductor.org/packages/release/data/annotation/src/contrib/BSgenome.Hsapiens.UCSC.hg19_1.4.0.tar.gz"
 
     version(
         "1.4.3",

--- a/var/spack/repos/builtin/packages/r-cmdstanr/package.py
+++ b/var/spack/repos/builtin/packages/r-cmdstanr/package.py
@@ -17,7 +17,7 @@ class RCmdstanr(RPackage):
     fewer unexpected crashes in RStudio, and a more permissive license."""
 
     homepage = "https://mc-stan.org/cmdstanr/"
-    url = "https://github.com/stan-dev/cmdstanr/archive/refs/tags/v0.5.3.tar.gz"
+    urls = ["https://github.com/stan-dev/cmdstanr/archive/refs/tags/v0.5.3.tar.gz"]
 
     license("BSD-3-Clause")
 

--- a/var/spack/repos/builtin/packages/r-dada2/package.py
+++ b/var/spack/repos/builtin/packages/r-dada2/package.py
@@ -11,7 +11,7 @@ class RDada2(RPackage):
     resolution"""
 
     homepage = "https://benjjneb.github.io/dada2/"
-    url = "https://github.com/benjjneb/dada2/archive/v1.14.tar.gz"
+    urls = ["https://github.com/benjjneb/dada2/archive/v1.14.tar.gz"]
 
     license("LGPL-3.0-only")
 

--- a/var/spack/repos/builtin/packages/r-deseq2/package.py
+++ b/var/spack/repos/builtin/packages/r-deseq2/package.py
@@ -14,7 +14,7 @@ class RDeseq2(RPackage):
     sequencing assays and test for differential expression based on a model
     using the negative binomial distribution."""
 
-    homepage = "https://bioconductor.org/packages/DESeq2"
+    bioc = "DESeq2"
     git = "https://git.bioconductor.org/packages/DESeq2.git"
 
     version("1.40.0", commit="c4962c3b16546e552fbc1a712258e4e21ff44241")

--- a/var/spack/repos/builtin/packages/r-do-db/package.py
+++ b/var/spack/repos/builtin/packages/r-do-db/package.py
@@ -14,7 +14,6 @@ class RDoDb(RPackage):
 
     # There is no git repository for this package.
     bioc = "DO.db"
-    url = "https://www.bioconductor.org/packages/3.5/data/annotation/src/contrib/DO.db_2.9.tar.gz"
 
     version("2.9", sha256="762bcb9b5188274fd81d82f785cf2846a5acc61fad55e2ff8ec1502282c27881")
 

--- a/var/spack/repos/builtin/packages/r-fdb-infiniummethylation-hg18/package.py
+++ b/var/spack/repos/builtin/packages/r-fdb-infiniummethylation-hg18/package.py
@@ -13,7 +13,6 @@ class RFdbInfiniummethylationHg18(RPackage):
 
     # This is a bioconductor package but there is no available git repository
     bioc = "FDb.InfiniumMethylation.hg18"
-    url = "https://bioconductor.org/packages/release/data/annotation/src/contrib/FDb.InfiniumMethylation.hg18_2.2.0.tar.gz"
 
     version("2.2.0", sha256="4a9028ac03c11fffbab731ea750bc7f9b0884fc43c6a8dac6eb2c644e4c79f6f")
 

--- a/var/spack/repos/builtin/packages/r-fdb-infiniummethylation-hg19/package.py
+++ b/var/spack/repos/builtin/packages/r-fdb-infiniummethylation-hg19/package.py
@@ -13,7 +13,6 @@ class RFdbInfiniummethylationHg19(RPackage):
 
     # No available git repository
     bioc = "FDb.InfiniumMethylation.hg19"
-    url = "https://bioconductor.org/packages/release/data/annotation/src/contrib/FDb.InfiniumMethylation.hg19_2.2.0.tar.gz"
 
     version("2.2.0", sha256="605aa3643588a2f40a942fa760b92662060a0dfedb26b4e4cd6f1a78b703093f")
 

--- a/var/spack/repos/builtin/packages/r-genomeinfodbdata/package.py
+++ b/var/spack/repos/builtin/packages/r-genomeinfodbdata/package.py
@@ -11,7 +11,6 @@ class RGenomeinfodbdata(RPackage):
     in the GenomeInfoDb package."""
 
     bioc = "GenomeInfoDbData"
-    url = "https://bioconductor.org/packages/release/data/annotation/src/contrib/GenomeInfoDbData_0.99.0.tar.gz"
 
     version(
         "1.2.10",

--- a/var/spack/repos/builtin/packages/r-go-db/package.py
+++ b/var/spack/repos/builtin/packages/r-go-db/package.py
@@ -13,7 +13,6 @@ class RGoDb(RPackage):
     Ontology assembled using data from GO."""
 
     bioc = "GO.db"
-    url = "https://www.bioconductor.org/packages/release/data/annotation/src/contrib/GO.db_3.4.1.tar.gz"
 
     version(
         "3.17.0",

--- a/var/spack/repos/builtin/packages/r-hdo-db/package.py
+++ b/var/spack/repos/builtin/packages/r-hdo-db/package.py
@@ -13,7 +13,6 @@ class RHdoDb(RPackage):
     assembled using data from DO.  Its annotation data comes from
     https://github.com/DiseaseOntology/HumanDiseaseOntology/tree/main/src/ontology."""
 
-    url = "https://bioconductor.org/packages/release/data/annotation/src/contrib/HDO.db_0.99.1.tar.gz"
     bioc = "HDO.db"
 
     version("0.99.1", sha256="c17cf28d06621d91148a64d47fdeaa906d8621aba7a688715fb9571a55f7cf92")

--- a/var/spack/repos/builtin/packages/r-ieugwasr/package.py
+++ b/var/spack/repos/builtin/packages/r-ieugwasr/package.py
@@ -14,7 +14,7 @@ class RIeugwasr(RPackage):
     specific queries."""
 
     homepage = "https://github.com/MRCIEU/ieugwasr"
-    url = "https://github.com/MRCIEU/ieugwasr/archive/refs/tags/0.1.5.tar.gz"
+    urls = ["https://github.com/MRCIEU/ieugwasr/archive/refs/tags/0.1.5.tar.gz"]
 
     license("MIT")
 

--- a/var/spack/repos/builtin/packages/r-illuminahumanmethylation450kanno-ilmn12-hg19/package.py
+++ b/var/spack/repos/builtin/packages/r-illuminahumanmethylation450kanno-ilmn12-hg19/package.py
@@ -14,7 +14,6 @@ class RIlluminahumanmethylation450kannoIlmn12Hg19(RPackage):
     # This package is available via bioconductor but there is no available git
     # repository.
     bioc = "IlluminaHumanMethylation450kanno.ilmn12.hg19"
-    url = "https://bioconductor.org/packages/release/data/annotation/src/contrib/IlluminaHumanMethylation450kanno.ilmn12.hg19_0.6.0.tar.gz"
 
     version(
         "0.6.1",

--- a/var/spack/repos/builtin/packages/r-illuminahumanmethylation450kmanifest/package.py
+++ b/var/spack/repos/builtin/packages/r-illuminahumanmethylation450kmanifest/package.py
@@ -10,7 +10,6 @@ class RIlluminahumanmethylation450kmanifest(RPackage):
     """Annotation for Illumina's 450k methylation arrays."""
 
     bioc = "IlluminaHumanMethylation450kmanifest"
-    url = "https://bioconductor.org/packages/release/data/annotation/src/contrib/IlluminaHumanMethylation450kmanifest_0.4.0.tar.gz"
 
     version("0.4.0", sha256="41b2e54bac3feafc7646fe40bce3aa2b92c10871b0a13657c5736517792fa763")
 

--- a/var/spack/repos/builtin/packages/r-illuminahumanmethylationepicanno-ilm10b4-hg19/package.py
+++ b/var/spack/repos/builtin/packages/r-illuminahumanmethylationepicanno-ilm10b4-hg19/package.py
@@ -10,7 +10,6 @@ class RIlluminahumanmethylationepicannoIlm10b4Hg19(RPackage):
     """Annotation for Illumina's EPIC methylation arrays."""
 
     bioc = "IlluminaHumanMethylationEPICanno.ilm10b4.hg19"
-    url = "https://bioconductor.org/packages/release/data/annotation/src/contrib/IlluminaHumanMethylationEPICanno.ilm10b4.hg19_0.6.0.tar.gz"
 
     version("0.6.0", sha256="2c8128126b63e7fa805a5f3b02449367dca9c3be3eb5f6300acc718826590719")
 

--- a/var/spack/repos/builtin/packages/r-illuminahumanmethylationepicmanifest/package.py
+++ b/var/spack/repos/builtin/packages/r-illuminahumanmethylationepicmanifest/package.py
@@ -10,7 +10,6 @@ class RIlluminahumanmethylationepicmanifest(RPackage):
     """Manifest for Illumina's EPIC methylation arrays."""
 
     bioc = "IlluminaHumanMethylationEPICmanifest"
-    url = "https://bioconductor.org/packages/release/data/annotation/src/contrib/IlluminaHumanMethylationEPICmanifest_0.3.0.tar.gz"
 
     version("0.3.0", sha256="e39a69d98486cec981e97c56f45bbe47d2ccb5bbb66a1b16fa0685575493902a")
 

--- a/var/spack/repos/builtin/packages/r-kegg-db/package.py
+++ b/var/spack/repos/builtin/packages/r-kegg-db/package.py
@@ -14,7 +14,6 @@ class RKeggDb(RPackage):
     # NOTE: The KEGG.db package was removed in Bioconductor-3.13
 
     bioc = "KEGG.db"
-    url = "https://www.bioconductor.org/packages/release/data/annotation/src/contrib/KEGG.db_3.2.3.tar.gz"
 
     version(
         "3.2.4",

--- a/var/spack/repos/builtin/packages/r-libpressio/package.py
+++ b/var/spack/repos/builtin/packages/r-libpressio/package.py
@@ -10,7 +10,7 @@ class RLibpressio(RPackage):
     """R package for libpressio"""
 
     homepage = "https://github.com/robertu94/libpressio-r"
-    url = "https://github.com/robertu94/libpressio-r/archive/0.0.1.tar.gz"
+    urls = ["https://github.com/robertu94/libpressio-r/archive/0.0.1.tar.gz"]
 
     maintainers("robertu94")
 

--- a/var/spack/repos/builtin/packages/r-mrinstruments/package.py
+++ b/var/spack/repos/builtin/packages/r-mrinstruments/package.py
@@ -12,7 +12,7 @@ class RMrinstruments(RPackage):
     Datasets of eQTLs, GWAS catalogs, etc."""
 
     homepage = "https://github.com/MRCIEU/MRInstruments"
-    url = "https://github.com/MRCIEU/MRInstruments/archive/refs/tags/0.3.3.tar.gz"
+    urls = ["https://github.com/MRCIEU/MRInstruments/archive/refs/tags/0.3.3.tar.gz"]
 
     version("0.3.3", sha256="4ddbaf6335133e8f7baef469d6bc1f89212462b9f4062c9e4ddda37b12eb3486")
 

--- a/var/spack/repos/builtin/packages/r-org-hs-eg-db/package.py
+++ b/var/spack/repos/builtin/packages/r-org-hs-eg-db/package.py
@@ -13,7 +13,6 @@ class ROrgHsEgDb(RPackage):
     Gene identifiers."""
 
     bioc = "org.Hs.eg.db"
-    url = "https://www.bioconductor.org/packages/release/data/annotation/src/contrib/org.Hs.eg.db_3.4.1.tar.gz"
 
     version(
         "3.17.0",

--- a/var/spack/repos/builtin/packages/r-pfam-db/package.py
+++ b/var/spack/repos/builtin/packages/r-pfam-db/package.py
@@ -13,7 +13,6 @@ class RPfamDb(RPackage):
     public repositories."""
 
     bioc = "PFAM.db"
-    url = "https://www.bioconductor.org/packages/release/data/annotation/src/contrib/PFAM.db_3.4.1.tar.gz"
 
     version(
         "3.17.0",

--- a/var/spack/repos/builtin/packages/r-phantompeakqualtools/package.py
+++ b/var/spack/repos/builtin/packages/r-phantompeakqualtools/package.py
@@ -14,7 +14,7 @@ class RPhantompeakqualtools(RPackage):
     package."""
 
     homepage = "https://github.com/kundajelab/phantompeakqualtools"
-    url = "https://github.com/kundajelab/phantompeakqualtools/raw/master/spp_1.14.tar.gz"
+    urls = ["https://github.com/kundajelab/phantompeakqualtools/raw/master/spp_1.14.tar.gz"]
 
     version("1.14", sha256="d03be6163e82aed72298e54a92c181570f9975a395f57a69b21ac02b1001520b")
 

--- a/var/spack/repos/builtin/packages/r-twosamplemr/package.py
+++ b/var/spack/repos/builtin/packages/r-twosamplemr/package.py
@@ -16,7 +16,7 @@ class RTwosamplemr(RPackage):
     serious work we strongly recommend using this R package."""
 
     homepage = "https://mrcieu.github.io/TwoSampleMR/"
-    url = "https://github.com/MRCIEU/TwoSampleMR/archive/refs/tags/v0.5.6.tar.gz"
+    urls = ["https://github.com/MRCIEU/TwoSampleMR/archive/refs/tags/v0.5.6.tar.gz"]
 
     license("MIT")
 

--- a/var/spack/repos/builtin/packages/r-txdb-hsapiens-ucsc-hg18-knowngene/package.py
+++ b/var/spack/repos/builtin/packages/r-txdb-hsapiens-ucsc-hg18-knowngene/package.py
@@ -14,7 +14,6 @@ class RTxdbHsapiensUcscHg18Knowngene(RPackage):
 
     # This is a bioconductor package but ther is no available git repo
     bioc = "TxDb.Hsapiens.UCSC.hg18.knownGene"
-    url = "https://bioconductor.org/packages/release/data/annotation/src/contrib/TxDb.Hsapiens.UCSC.hg18.knownGene_3.2.2.tar.gz"
 
     version("3.2.2", sha256="bc9ca40b4eab87f5ca64a4b876d42502b9b8e9f5983d745bfe0ee349d97b69fa")
 

--- a/var/spack/repos/builtin/packages/r-txdb-hsapiens-ucsc-hg19-knowngene/package.py
+++ b/var/spack/repos/builtin/packages/r-txdb-hsapiens-ucsc-hg19-knowngene/package.py
@@ -14,7 +14,6 @@ class RTxdbHsapiensUcscHg19Knowngene(RPackage):
 
     # This is a bioconductor package but there is no available git repo.
     bioc = "TxDb.Hsapiens.UCSC.hg19.knownGene"
-    url = "https://bioconductor.org/packages/release/data/annotation/src/contrib/TxDb.Hsapiens.UCSC.hg19.knownGene_3.2.2.tar.gz"
 
     version("3.2.2", sha256="063de2b1174782a0b2b8ab7f04a0bdf3c43252cb67c685a9f8ef2b8e318352e9")
 


### PR DESCRIPTION
A large number of CRAN packages are not downloadable anymore: when a new R version is released, package in https://cloud.r-project.org/src/contrib/ are updated, and older versions moved to https://cran.r-project.org/src/contrib/Archive/. For example, https://cloud.r-project.org/src/contrib/vcd_1.4-12.tar.gz but https://cran.r-project.org/src/contrib/Archive/vcd/vcd_1.4-11.tar.gz

Unfortunately, the Archive directories don't also contain the latest version.

This means that:
- we need to allow for packages moving from https://cloud.r-project.org/src/contrib to https://cloud.r-project.org/src/contrib/Archive (`urls`),
- we need to look in https://cloud.r-project.org/src/contrib for new versions (`list_url`).

With the changes in this PR, `urls` will most likely find the first entry (with the most recent version in spack, which hopefully is the most recent version on CRAN), but will also still find the older version if it gets moved.

So far so good. Minimal `RPackage` update, you say...

However:
- we cannot define both `urls` and `url` in the same package, and defining a `urls` property in base class, even if it returns `[cls.url]`, leads to problems for non-CRAN packages that define their own `url`,

So, in addition:
- Bioconductor packages are given similar treatment as CRAN packages, for both software and annotation data packages,
- the handful of remaining non-CRAN, non-Bioconductor packages receive a conversion from `url` to `urls=[url]`.

Finally, this doesn't address the fact that most of these older Bioconductor package links are equally dead, and for similar reasons, as the CRAN links: older version are not accessible under the same URL, but require a Bionductor release version in the URL, e.g. https://bioconductor.org/packages/release/bioc/src/contrib/scran_1.32.0.tar.gz, but https://bioconductor.org/packages/3.18/bioc/src/contrib/scran_1.30.2.tar.gz. Only a few packages explicitly address this, e.g. `r-pfam-db` (which happens to be in this PR's change set as well).  This PR does not aim to fix that, and only aims to fix the CRAN packages.