### PR TITLE
geoip: deprecate due to duplication

### DIFF
--- a/var/spack/repos/builtin/packages/geoip-api-c/package.py
+++ b/var/spack/repos/builtin/packages/geoip-api-c/package.py
@@ -13,13 +13,13 @@ class GeoipApiC(AutotoolsPackage):
     homepage = "https://github.com/maxmind/geoip-api-c"
     url = "https://github.com/maxmind/geoip-api-c/archive/v1.6.12.tar.gz"
 
-    license("LGPL-2.1-or-later")
+    license("LGPL-2.1-or-later", checked_by="wdconinc")
 
     version("1.6.12", sha256="99b119f8e21e94f1dfd6d49fbeed29a70df1544896e76cd456f25e397b07d476")
-    version("1.6.11", sha256="b0e5a92200b5ab540d118983f7b7191caf4faf1ae879c44afa3ff2a2abcdb0f5")
-    version("1.6.10", sha256="cb44e0d0dbc45efe2e399e695864e58237ce00026fba8a74b31d85888c89c67a")
+    version("1.6.11", sha256="8859cb7c9cb63e77f4aedb40a4622024359b956b251aba46b255acbe190c34e0")
+    version("1.6.10", sha256="de0d6d037d5e0ad9f7110e7f3b82eb20a24616712d29be0019e28ba7364cdc3e")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")

--- a/var/spack/repos/builtin/packages/geoip/package.py
+++ b/var/spack/repos/builtin/packages/geoip/package.py
@@ -8,15 +8,17 @@ from spack.package import *
 
 class Geoip(AutotoolsPackage):
     """Library for country/city/organization to IP address
-    or hostname mapping."""
+    or hostname mapping. This package has been deprecated. Use geoip-api-c instead."""
 
     homepage = "http://www.maxmind.com/app/c"
     url = "https://github.com/maxmind/geoip-api-c/releases/download/v1.6.12/GeoIP-1.6.12.tar.gz"
 
     license("LGPL-2.1-or-later")
 
-    version("1.6.12", sha256="1dfb748003c5e4b7fd56ba8c4cd786633d5d6f409547584f6910398389636f80")
-    version("1.6.11", sha256="b0e5a92200b5ab540d118983f7b7191caf4faf1ae879c44afa3ff2a2abcdb0f5")
-    version("1.6.10", sha256="cb44e0d0dbc45efe2e399e695864e58237ce00026fba8a74b31d85888c89c67a")
+    with default_args(deprecated=True):
+        # Note: use geoip-api-c instead
+        version("1.6.12", sha256="1dfb748003c5e4b7fd56ba8c4cd786633d5d6f409547584f6910398389636f80")
+        version("1.6.11", sha256="b0e5a92200b5ab540d118983f7b7191caf4faf1ae879c44afa3ff2a2abcdb0f5")
+        version("1.6.10", sha256="cb44e0d0dbc45efe2e399e695864e58237ce00026fba8a74b31d85888c89c67a")
 
     depends_on("c", type="build")  # generated

--- a/var/spack/repos/builtin/packages/geoip/package.py
+++ b/var/spack/repos/builtin/packages/geoip/package.py
@@ -17,8 +17,14 @@ class Geoip(AutotoolsPackage):
 
     with default_args(deprecated=True):
         # Note: use geoip-api-c instead
-        version("1.6.12", sha256="1dfb748003c5e4b7fd56ba8c4cd786633d5d6f409547584f6910398389636f80")
-        version("1.6.11", sha256="b0e5a92200b5ab540d118983f7b7191caf4faf1ae879c44afa3ff2a2abcdb0f5")
-        version("1.6.10", sha256="cb44e0d0dbc45efe2e399e695864e58237ce00026fba8a74b31d85888c89c67a")
+        version(
+            "1.6.12", sha256="1dfb748003c5e4b7fd56ba8c4cd786633d5d6f409547584f6910398389636f80"
+        )
+        version(
+            "1.6.11", sha256="b0e5a92200b5ab540d118983f7b7191caf4faf1ae879c44afa3ff2a2abcdb0f5"
+        )
+        version(
+            "1.6.10", sha256="cb44e0d0dbc45efe2e399e695864e58237ce00026fba8a74b31d85888c89c67a"
+        )
 
     depends_on("c", type="build")  # generated


### PR DESCRIPTION
This PR deprecates `geoip` which is duplicated as `geoip-api-c`. Since `geoip-api-c` has dependents and `geoip` does not, and since `geo-api-c` is the name of the github project, it's `geoip` that gets deprecated here.
