### PR TITLE
AMBER: Adds conflict clause to avoid using X11 on  Cray

### DIFF
--- a/var/spack/repos/builtin/packages/amber/package.py
+++ b/var/spack/repos/builtin/packages/amber/package.py
@@ -143,6 +143,7 @@ class Amber(Package, CudaPackage):
     depends_on("cuda@7.5.18", when="@:16+cuda")
 
     # conflicts
+    conflicts("+x11", when="platform=cray", msg="x11 amber applications not available for cray")
     conflicts("+openmp", when="%clang", msg="OpenMP not available for the clang compiler")
     conflicts(
         "+openmp", when="%apple-clang", msg="OpenMP not available for the Apple clang compiler"


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
