### PR TITLE
Fix wrong use of 'command -v' in setup-env.csh

### DIFF
--- a/share/spack/setup-env.csh
+++ b/share/spack/setup-env.csh
@@ -62,9 +62,9 @@ if (! $?SPACK_PYTHON) then
     setenv SPACK_PYTHON ""
 endif
 foreach cmd ("$SPACK_PYTHON" python3 python python2)
-    command -v "$cmd" >& /dev/null
+    set status=`which "$cmd" >& /dev/null; echo $?`
     if ($status == 0) then
-        setenv SPACK_PYTHON `command -v "$cmd"`
+        setenv SPACK_PYTHON `which "$cmd"`
         break
     endif
 end


### PR DESCRIPTION
fixes #29510

`which` is a shell-builtin command in csh just like `command` is one in bash. So I use `which` to replace original `command -v`，and the original `$status` seems not to be set. I also fixed it.

This version still shows `Exit 1` when `$SPACK_PYTHON` is empty, but after that loop, it can still be set correctly.
