### PR TITLE
Singularity: set `share loop devices` to `yes`.

### DIFF
--- a/var/spack/repos/builtin/packages/singularityce/package.py
+++ b/var/spack/repos/builtin/packages/singularityce/package.py
@@ -113,6 +113,11 @@ class SingularityBase(MakefilePackage):
             "mksquashfs path = {0}".format(squash_path),
             join_path(prefix.etc, self.singularity_name, self.singularity_name + ".conf"),
         )
+        filter_file(
+             r"^shared loop devices = no",
+             "shared loop devices = yes",
+             join_path(prefix.etc, self.singularity_name, self.singularity_name + ".conf"),
+         )
 
     #
     # Assemble a script that fixes the ownership and permissions of several

--- a/var/spack/repos/builtin/packages/singularityce/package.py
+++ b/var/spack/repos/builtin/packages/singularityce/package.py
@@ -114,10 +114,10 @@ class SingularityBase(MakefilePackage):
             join_path(prefix.etc, self.singularity_name, self.singularity_name + ".conf"),
         )
         filter_file(
-             r"^shared loop devices = no",
-             "shared loop devices = yes",
-             join_path(prefix.etc, self.singularity_name, self.singularity_name + ".conf"),
-         )
+            r"^shared loop devices = no",
+            "shared loop devices = yes",
+            join_path(prefix.etc, self.singularity_name, self.singularity_name + ".conf"),
+        )
 
     #
     # Assemble a script that fixes the ownership and permissions of several


### PR DESCRIPTION
This will allow Singularity to work when used for large MPI jobs. I am not aware of any reason not to have the option set to `yes` by default.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
