### PR TITLE
dd4hep: mark conflict with root@6.31.1:

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -140,6 +140,9 @@ class Dd4hep(CMakePackage):
     # See https://github.com/AIDASoft/DD4hep/pull/1191
     conflicts("^geant4 cxxstd=11", when="+ddg4")
 
+    # See https://github.com/AIDASoft/DD4hep/issues/1210
+    conflicts("^root@6.31.1:", when="@:1.27")
+
     @property
     def libs(self):
         # We need to override libs here, because we don't build a libdd4hep so


### PR DESCRIPTION
dd4hep versions up to and including 1.27 had a conflict with root versions starting from 6.31.1, as shown in
https://github.com/AIDASoft/DD4hep/issues/1210. This PR explicitly adds that conflict to the spec.