### PR TITLE
root: remove +webgui~http conflict version clause

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -422,7 +422,7 @@ class Root(CMakePackage):
     conflicts("+tmva-gpu", when="~cuda", msg="root+tmva-gpu requires CUDA")
     conflicts("+tmva-pymva", when="~tmva", msg="root+tmva-pymva requires TMVA")
     conflicts("+tmva-sofie", when="~tmva", msg="root+tmva-sofie requires TMVA")
-    conflicts("~http", when="@6.29.00: +webgui", msg="root+webgui requires HTTP")
+    conflicts("~http", when="@6.28.12: +webgui", msg="root+webgui requires HTTP")
     conflicts("cxxstd=11", when="+root7", msg="root7 requires at least C++14")
     conflicts("cxxstd=11", when="@6.25.02:", msg="This version of root requires at least C++14")
     conflicts("cxxstd=14", when="@6.30.00:", msg="This version of root requires at least C++17")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -422,7 +422,7 @@ class Root(CMakePackage):
     conflicts("+tmva-gpu", when="~cuda", msg="root+tmva-gpu requires CUDA")
     conflicts("+tmva-pymva", when="~tmva", msg="root+tmva-pymva requires TMVA")
     conflicts("+tmva-sofie", when="~tmva", msg="root+tmva-sofie requires TMVA")
-    conflicts("~http", when="@6.28.12: +webgui", msg="root+webgui requires HTTP")
+    conflicts("~http", msg="root+webgui requires HTTP")
     conflicts("cxxstd=11", when="+root7", msg="root7 requires at least C++14")
     conflicts("cxxstd=11", when="@6.25.02:", msg="This version of root requires at least C++14")
     conflicts("cxxstd=14", when="@6.30.00:", msg="This version of root requires at least C++17")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -422,7 +422,7 @@ class Root(CMakePackage):
     conflicts("+tmva-gpu", when="~cuda", msg="root+tmva-gpu requires CUDA")
     conflicts("+tmva-pymva", when="~tmva", msg="root+tmva-pymva requires TMVA")
     conflicts("+tmva-sofie", when="~tmva", msg="root+tmva-sofie requires TMVA")
-    conflicts("~http", msg="root+webgui requires HTTP")
+    conflicts("~http", when="+webgui", msg="root+webgui requires HTTP")
     conflicts("cxxstd=11", when="+root7", msg="root7 requires at least C++14")
     conflicts("cxxstd=11", when="@6.25.02:", msg="This version of root requires at least C++14")
     conflicts("cxxstd=14", when="@6.30.00:", msg="This version of root requires at least C++17")


### PR DESCRIPTION
Currently, the ROOT spec correctly identifies a conflict between +webgui and ~http, but this conflict is marked as affecting @6.29.00: only. As a matter of fact, ROOT 6.28.12 is also affected. This commit, therefore, updates the when clause on the conflict to @6.28.12:.

See https://github.com/root-project/root/blob/v6-28-12/cmake/modules/RootBuildOptions.cmake#L408.