### PR TITLE
poppler: change the URL of the test repository

### DIFF
--- a/var/spack/repos/builtin/packages/poppler/package.py
+++ b/var/spack/repos/builtin/packages/poppler/package.py
@@ -78,7 +78,7 @@ class Poppler(CMakePackage):
     # Only needed to run `make test`
     resource(
         name="test",
-        git="https://anongit.freedesktop.org/git/poppler/test.git",
+        git="git://git.freedesktop.org/git/poppler/test.git",
         placement="testdata",
     )
 

--- a/var/spack/repos/builtin/packages/poppler/package.py
+++ b/var/spack/repos/builtin/packages/poppler/package.py
@@ -77,9 +77,7 @@ class Poppler(CMakePackage):
 
     # Only needed to run `make test`
     resource(
-        name="test",
-        git="git://git.freedesktop.org/git/poppler/test.git",
-        placement="testdata",
+        name="test", git="git://git.freedesktop.org/git/poppler/test.git", placement="testdata"
     )
 
     def cmake_args(self):


### PR DESCRIPTION
The current URL fails with 504 and building fails after fetching. The CMakeLists.txt tells us which URL should be used: https://gitlab.freedesktop.org/poppler/poppler/-/blob/master/CMakeLists.txt#L107