### PR TITLE
geomodel: add v5.1.0 -> v6.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/builtin/packages/geomodel/package.py
@@ -71,13 +71,16 @@ class Geomodel(CMakePackage):
         depends_on("opengl")
 
     def cmake_args(self):
-        args = [
-            self.define_from_variant("GEOMODEL_BUILD_VISUALIZATION", "visualization"),
-            self.define_from_variant("GEOMODEL_BUILD_GEOMODELG4", "geomodelg4"),
-            self.define_from_variant("GEOMODEL_BUILD_FULLSIMLIGHT", "fullsimlight"),
-            self.define_from_variant("GEOMODEL_BUILD_FSL", "fsl"),
-            self.define_from_variant("GEOMODEL_BUILD_EXAMPLES", "examples"),
-            self.define_from_variant("GEOMODEL_BUILD_TOOLS", "tools"),
-        ]
+        def cmake_variant(cmake_label, spack_variant):
+            enabled = spec.satisfies("+" + spack_variant)
+            return f"-DGEOMODEL_BUILD_{cmake_label}={enabled}"
 
+        args = [
+            cmake_variant("VISUALIZATION", "visualization"),
+            cmake_variant("GEOMODELG4", "geomodelg4"),
+            cmake_variant("FULLSIMLIGHT", "fullsimlight"),
+            cmake_variant("FSL", "fsl"),
+            cmake_variant("EXAMPLES", "examples"),
+            cmake_variant("TOOLS", "tools"),
+        ]
         return args

--- a/var/spack/repos/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/builtin/packages/geomodel/package.py
@@ -14,10 +14,19 @@ class Geomodel(CMakePackage):
     url = "https://gitlab.cern.ch/GeoModelDev/GeoModel/-/archive/4.6.0/GeoModel-4.6.0.tar.bz2"
     git = "https://gitlab.cern.ch/GeoModelDev/GeoModel"
 
-    maintainers("wdconinc")
+    maintainers("wdconinc", "stephenswat")
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("6.4.0", sha256="369f91f021be83d294ba6a9bdbe00077625e9fe798a396aceece8970e7dd5838")
+    version("6.3.0", sha256="d2b101e06d20a8a3b638e6021f517a939f49ea6d8347ce40c927c27efe66b28c")
+    version("6.2.0", sha256="99bb3908bf710ce5ba0bcdd192942705a183a9f2886079df091dc69423b7bdf1")
+    version("6.1.0", sha256="2974f0e35e07cd44170d29ef106ec1ee50cb3fa3ba88382bea7394eb341dcd32")
+    version("6.0.0", sha256="7263d44ae2b99da9bc45cf0bbda64b2d8bdce1b350328fe41fce001d5266c3a1")
+    version("5.6.0", sha256="51e6570e119c2d3037b594779bb78d78b524c41132fac38d83ae162b5b6ffe54")
+    version("5.4.0", sha256="82cd08bea5791d862244211f8367cd6f5698b311e4862b2eb5584f835d551821")
+    version("5.3.0", sha256="d30c31f387716415542f3424a7f64ab62ef640a4e6f832243944918f7daca080")
+    version("5.1.0", sha256="bbe7d6ea46fe750d9421fb741b2340d16afcddbf5d6aeafab09d60577d55f93d")
     version("4.6.0", sha256="d827dc79a5555fd7b09d1b670fc6f01f91476d0edf98ccd644c624f18fb729ca")
 
     depends_on("cxx", type="build")  # generated
@@ -62,16 +71,13 @@ class Geomodel(CMakePackage):
         depends_on("opengl")
 
     def cmake_args(self):
-        def cmake_variant(cmake_label, spack_variant):
-            enabled = spec.satisfies("+" + spack_variant)
-            return f"-DGEOMODEL_BUILD_{cmake_label}={enabled}"
-
         args = [
-            cmake_variant("VISUALIZATION", "visualization"),
-            cmake_variant("GEOMODELG4", "geomodelg4"),
-            cmake_variant("FULLSIMLIGHT", "fullsimlight"),
-            cmake_variant("FSL", "fsl"),
-            cmake_variant("EXAMPLES", "examples"),
-            cmake_variant("TOOLS", "tools"),
+            self.define_from_variant("GEOMODEL_BUILD_VISUALIZATION", "visualization"),
+            self.define_from_variant("GEOMODEL_BUILD_GEOMODELG4", "geomodelg4"),
+            self.define_from_variant("GEOMODEL_BUILD_FULLSIMLIGHT", "fullsimlight"),
+            self.define_from_variant("GEOMODEL_BUILD_FSL", "fsl"),
+            self.define_from_variant("GEOMODEL_BUILD_EXAMPLES", "examples"),
+            self.define_from_variant("GEOMODEL_BUILD_TOOLS", "tools"),
         ]
+
         return args


### PR DESCRIPTION
This PR adds new versions 5.1.0 through 6.4.0 of the geomodel package. It also adds me as a maintainer.