### PR TITLE
acts: add GeoModel dependency

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -343,6 +343,7 @@ class Acts(CMakePackage, CudaPackage):
     depends_on("eigen @3.3.7:3.3.99", when="@:15.0")
     depends_on("geant4", when="+fatras_geant4")
     depends_on("geant4", when="+geant4")
+    depends_on("geomodel @4.6.0:", when="+geomodel")
     depends_on("git-lfs", when="@12.0.0:")
     depends_on("gperftools", when="+profilecpu")
     depends_on("gperftools", when="+profilemem")


### PR DESCRIPTION
This commit adds a dependency on GeoModel 4.6.0 when the GeoModel plugin is enabled. Note that the dependency is upgraded to 6.3.0 in Acts 36.1.0, but that will need to be covered in #45851.