### PR TITLE
ddt: add v23.0.4 -> v24.0.3

### DIFF
--- a/var/spack/repos/builtin/packages/ddt/package.py
+++ b/var/spack/repos/builtin/packages/ddt/package.py
@@ -37,7 +37,9 @@ class Ddt(Package):
         if version < Version("22.1.3"):
             return f"https://downloads.linaroforge.com/{version}/arm-forge-{version}-linux-x86_64.tar"
         else:
-            return f"https://downloads.linaroforge.com/{version}/linaro-forge-{version}-linux-x86_64.tar"
+            return (
+                f"https://downloads.linaroforge.com/{version}/linaro-forge-{version}-linux-x86_64.tar"
+            )
 
     def setup_run_environment(self, env):
         env.prepend_path("PATH", join_path(self.prefix, "bin"))

--- a/var/spack/repos/builtin/packages/ddt/package.py
+++ b/var/spack/repos/builtin/packages/ddt/package.py
@@ -34,7 +34,7 @@ class Ddt(Package):
     )
 
     def url_for_version(self, version):
-        if version < Version("22.1.3"):
+        if version <= Version("22.1.3"):
             return (
                 f"https://downloads.linaroforge.com/{version}/arm-forge-{version}-linux-x86_64.tar"
             )

--- a/var/spack/repos/builtin/packages/ddt/package.py
+++ b/var/spack/repos/builtin/packages/ddt/package.py
@@ -14,7 +14,8 @@ class Ddt(Package):
     behavior to achieve lightning-fast performance at all scales."""
 
     homepage = "https://arm.com"
-    url = "https://downloads.linaroforge.com/22.1.3/arm-forge-22.1.3-linux-x86_64.tar"
+    url = "https://downloads.linaroforge.com/22.1.3/linaro-forge-22.1.3-linux-x86_64.tar"
+    list_url = "https://www.linaroforge.com/download-documentation"
 
     maintainers("robgics")
 
@@ -22,12 +23,21 @@ class Ddt(Package):
     license_files = ["./licences/ddt.lic"]
 
     # Versions before 22.0 have a security vulnerability. Do not install them.
+    version("24.0.3", sha256="1796559fb86220d5e17777215d3820f4b04aba271782276b81601d5065284526")
+    version("23.1.2", sha256="675d2d8e4510afefa0405eecb46ac8bf440ff35a5a40d5507dc12d29678a22bf")
+    version("23.0.4", sha256="41a81840a273ea9a232efb4f031149867c5eff7a6381d787e18195f1171caac4")
     version("22.1.3", sha256="4f8a8b1df6ad712e89c82eedf4bd85b93b57b3c8d5b37d13480ff058fa8f4467")
     version(
         "22.0.2",
         sha256="3db0c3993d1db617f850c48d25c9239f06a018c895ea305786a7ad836a44496d",
         deprecated=True,
     )
+
+    def url_for_version(self, version):
+        if version < Version("22.1.3"):
+            return f"https://downloads.linaroforge.com/{version}/arm-forge-{version}-linux-x86_64.tar"
+        else:
+            return f"https://downloads.linaroforge.com/{version}/linaro-forge-{version}-linux-x86_64.tar"
 
     def setup_run_environment(self, env):
         env.prepend_path("PATH", join_path(self.prefix, "bin"))

--- a/var/spack/repos/builtin/packages/ddt/package.py
+++ b/var/spack/repos/builtin/packages/ddt/package.py
@@ -35,11 +35,11 @@ class Ddt(Package):
 
     def url_for_version(self, version):
         if version < Version("22.1.3"):
-            return f"https://downloads.linaroforge.com/{version}/arm-forge-{version}-linux-x86_64.tar"
-        else:
             return (
-                f"https://downloads.linaroforge.com/{version}/linaro-forge-{version}-linux-x86_64.tar"
+                f"https://downloads.linaroforge.com/{version}/arm-forge-{version}-linux-x86_64.tar"
             )
+        else:
+            return f"https://downloads.linaroforge.com/{version}/linaro-forge-{version}-linux-x86_64.tar"
 
     def setup_run_environment(self, env):
         env.prepend_path("PATH", join_path(self.prefix, "bin"))


### PR DESCRIPTION
This PR adds v23.0.4, v23.1.2, and v24.0.3 of Linaro Arm DDT. Due to Linaro's purchase of arm Forge, there is now a `url_for_version`.

Test build (though it's just a script):
```console
root@codespaces-d21ee8:/workspaces/spack# spack install ddt 
[+] /usr (external glibc-2.31-ifnzkwqkv2256i3slipur7kcfvgv6bki)
==> Installing gcc-runtime-11.4.0-2mu665nmsxc5u2ktoggqycuukifognbc [2/3]
==> No binary for gcc-runtime-11.4.0-2mu665nmsxc5u2ktoggqycuukifognbc found: installing from source
==> No patches needed for gcc-runtime
==> gcc-runtime: Executing phase: 'install'
==> gcc-runtime: Successfully installed gcc-runtime-11.4.0-2mu665nmsxc5u2ktoggqycuukifognbc
  Stage: 0.00s.  Install: 0.36s.  Post-install: 0.03s.  Total: 0.49s
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-x86_64_v3/gcc-11.4.0/gcc-runtime-11.4.0-2mu665nmsxc5u2ktoggqycuukifognbc
==> Installing ddt-24.0.3-mvmgivqjope3fkylnfen6eazey43bdfq [3/3]
==> No binary for ddt-24.0.3-mvmgivqjope3fkylnfen6eazey43bdfq found: installing from source
==> Fetching https://downloads.linaroforge.com/24.0.3/linaro-forge-24.0.3-linux-x86_64.tar
==> No patches needed for ddt
==> ddt: Executing phase: 'install'
==> Added local symlink /workspaces/spack/opt/spack/linux-ubuntu20.04-x86_64_v3/gcc-11.4.0/ddt-24.0.3-mvmgivqjope3fkylnfen6eazey43bdfq/licences/ddt.lic to global license file
==> ddt: Successfully installed ddt-24.0.3-mvmgivqjope3fkylnfen6eazey43bdfq
  Stage: 2.08s.  Install: 3.43s.  Post-install: 1.00s.  Total: 3m 12.69s
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-x86_64_v3/gcc-11.4.0/ddt-24.0.3-mvmgivqjope3fkylnfen6eazey43bdfq
```