### PR TITLE
whizard: add a patch when using hepmc3 3.3.0 or newer

### DIFF
--- a/var/spack/repos/builtin/packages/whizard/hepmc3.3.0.patch
+++ b/var/spack/repos/builtin/packages/whizard/hepmc3.3.0.patch
@@ -1,0 +1,25 @@
+--- a/src/hepmc/HepMC3Wrap.cpp	2024-08-21 20:16:15.770305323 +0200
++++ b/src/hepmc/HepMC3Wrap.cpp	2024-08-21 20:16:28.463638884 +0200
+@@ -161,7 +162,7 @@
+ }
+ 
+ extern "C" void gen_event_add_vertex( GenEvent* evt, GenVertex* v ) {
+-  evt->add_vertex( v );
++  evt->add_vertex( GenVertexPtr(v) );
+ }
+ 
+ extern "C" void gen_event_set_signal_process_vertex
+@@ -237,11 +238,11 @@
+ }
+ 
+ extern "C" void gen_vertex_add_particle_in( GenVertex* v, GenParticle* p ) {
+-  v->add_particle_in( p );
++  v->add_particle_in( GenParticlePtr(p) );
+ }
+ 
+ extern "C" void gen_vertex_add_particle_out( GenVertex* v, GenParticle* p ) {
+-  v->add_particle_out( p );
++  v->add_particle_out( GenParticlePtr(p) );
+ }
+ 
+ extern "C" bool gen_vertex_is_valid( GenVertex* v ) {

--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -92,6 +92,7 @@ class Whizard(AutotoolsPackage):
     # that happens, this needs to be adapted with a when clause
     patch("parallel_build_fix.patch", when="@3:3.1.3")
     patch("parallel_build_fix_2.8.patch", when="@2.8")
+    patch("hepmc3.3.0.patch", when="@3:3.1.4^hepmc3@3.3.0:")
     # Make sure that the patch actually has an effect by running autoreconf
     force_autoreconf = True
     # Which then requires the following build dependencies

--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -92,6 +92,8 @@ class Whizard(AutotoolsPackage):
     # that happens, this needs to be adapted with a when clause
     patch("parallel_build_fix.patch", when="@3:3.1.3")
     patch("parallel_build_fix_2.8.patch", when="@2.8")
+
+    # Subset of https://gitlab.tp.nt.uni-siegen.de/whizard/public/-/commit/f6048e4
     patch("hepmc3.3.0.patch", when="@3:3.1.4^hepmc3@3.3.0:")
     # Make sure that the patch actually has an effect by running autoreconf
     force_autoreconf = True


### PR DESCRIPTION
After https://gitlab.cern.ch/hepmc/HepMC3/-/merge_requests/247 and https://gitlab.cern.ch/hepmc/HepMC3/-/merge_requests/342 some functions do not accept raw pointers anymore. The changes are already in the whizard repository but happened in a bigger merge than just the minimal changes in this PR (https://gitlab.tp.nt.uni-siegen.de/whizard/public/-/commit/f6048e4457fc4531315685a25590b58432093af5).