### PR TITLE
Introduce offload variant for llvm >= 19.

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -145,8 +145,12 @@ class Llvm(CMakePackage, CudaPackage, CompilerPackage):
         "or as a project (with the compiler in use)",
     )
 
+    variant("offload", default=True, when="@19:", description="Build the Offload subproject")
+    conflicts("+offload", when="~clang")
+
     variant("libomptarget", default=True, description="Build the OpenMP offloading library")
     conflicts("+libomptarget", when="~clang")
+    conflicts("+libomptarget", when="~offload @19:")
     for _p in ["darwin", "windows"]:
         conflicts("+libomptarget", when="platform={0}".format(_p))
     del _p
@@ -908,6 +912,9 @@ class Llvm(CMakePackage, CudaPackage, CompilerPackage):
                 runtimes.append("openmp")
             elif "openmp=project" in spec:
                 projects.append("openmp")
+
+            if "+offload" in spec:
+                runtimes.append("offload")
 
             if "+libomptarget" in spec:
                 cmake_args.append(define("OPENMP_ENABLE_LIBOMPTARGET", True))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Needed for OpenMP offload to function without missing runtime libraries.