### PR TITLE
Adding a flag_handler to include "-Wno-error=implicit-function-declar…

### DIFF
--- a/var/spack/repos/builtin/packages/feh/package.py
+++ b/var/spack/repos/builtin/packages/feh/package.py
@@ -38,3 +38,10 @@ class Feh(MakefilePackage):
 
     def install(self, spec, prefix):
         make("install", "PREFIX={0}".format(prefix))
+
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            if self.spec.satisfies("%cce"):
+                flags.append("-Wno-error=implicit-function-declaration")
+        return (flags, None, None)
+


### PR DESCRIPTION
Adding a flag_handler to include "-Wno-error=implicit-function-declaration" for cce compiler. Without that flag 'feh' fails to install with "cce/16.0.1" compiler.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
