### PR TITLE
acts: add v36.0.0, v36.1.0 and fixes

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -479,13 +479,13 @@ class Acts(CMakePackage, CudaPackage):
             plugin_cmake_variant("PODIO", "podio"),
             example_cmake_variant("PYTHIA8", "pythia8"),
             example_cmake_variant("PYTHON_BINDINGS", "python"),
+            self.define_from_variant("ACTS_CUSTOM_SCALARTYPE", "scalar"),
             plugin_cmake_variant("ACTSVG", "svg"),
             plugin_cmake_variant("SYCL", "sycl"),
             plugin_cmake_variant("TGEO", "tgeo"),
             example_cmake_variant("TBB", "tbb", "USE"),
-            cmake_variant(unit_tests_label, "unit_tests"),
             plugin_cmake_variant("TRACCC", "traccc"),
-            self.define_from_variant("ACTS_CUSTOM_SCALARTYPE", "scalar"),
+            cmake_variant(unit_tests_label, "unit_tests"),
         ]
 
         log_failure_threshold = spec.variants["log_failure_threshold"].value


### PR DESCRIPTION
This commit makes several changes to the Acts repository, namely:

1. It adds versions 36.0.0 and 36.1.0.
2. It adds the traccc plugin and related dependencies.
3. It updates the version requirements of some dependencies.
4. It adds the Geant4 module of GeoModel.
5. It updates the C++ standard requirement.
6. It adds a new variant determining the scalar type to use.

This commit supersedes #45851. Thanks @jmcarcell for the version updates; I have added you as co-author.
