### PR TITLE
py-pytest-allclose: new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-pytest-allclose/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-allclose/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPytestAllclose(PythonPackage):
+    """Pytest fixture extending Numpy's allclose function."""
+
+    pypi = "pytest-allclose/pytest-allclose-1.0.0.tar.gz"
+
+    maintainers("paugier")
+
+    license("MIT", checked_by="paugier")
+
+    version("1.0.0", sha256="b2f0c521fa652281400d4a105c84454db3c50b993bcfee9861380be69cc6b041")
+
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-setuptools@:63", type="build")
+
+    depends_on("py-pytest", type="run")
+    depends_on("py-numpy@1.11:", type="run")


### PR DESCRIPTION
This PR adds the package py-pytest-allclose (https://pypi.org/project/pytest-allclose/).

I'm very new to Spack so I hope it's not too wrong. It works as expected for other Spack packages I'm working on  (https://foss.heptapod.net/fluiddyn/fluiddyn/-/merge_requests/128).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
