### PR TITLE
Add py-trio and py-outcome

### DIFF
--- a/var/spack/repos/builtin/packages/py-attrs/package.py
+++ b/var/spack/repos/builtin/packages/py-attrs/package.py
@@ -15,6 +15,9 @@ class PyAttrs(PythonPackage):
 
     license("MIT")
 
+    version("24.2.0", sha256="5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346")
+    version("24.1.0", sha256="adbdec84af72d38be7628e353a09b6a6790d15cd71819f6e9d7b0faa8a125745")
+    version("23.2.0", sha256="935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30")
     version("23.1.0", sha256="6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015")
     version("22.2.0", sha256="c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99")
     version("22.1.0", sha256="29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6")

--- a/var/spack/repos/builtin/packages/py-outcome/package.py
+++ b/var/spack/repos/builtin/packages/py-outcome/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyOutcome(PythonPackage):
+    """Capture the outcome of Python function calls. Extracted from the Trio project."""
+
+    pypi = "outcome/outcome-1.3.0.tar.gz"
+
+    maintainers("paugier")
+    license("MIT", checked_by="paugier")
+
+    version(
+        "1.3.0.post0", sha256="9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8"
+    )
+    version("1.2.0", sha256="6f82bd3de45da303cf1f771ecafa1633750a358436a8bb60e06a1ceb745d2672")
+
+    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-attrs@19.2.0:", type="run")

--- a/var/spack/repos/builtin/packages/py-trio/package.py
+++ b/var/spack/repos/builtin/packages/py-trio/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyTrio(PythonPackage):
+    """Trio - a friendly Python library for async concurrency and I/O."""
+
+    pypi = "trio/trio-0.26.2.tar.gz"
+
+    maintainers("paugier")
+    license("MIT", checked_by="paugier")
+
+    version("0.26.2", sha256="0346c3852c15e5c7d40ea15972c4805689ef2cb8b5206f794c9c19450119f3a4")
+    version("0.26.1", sha256="6d2fe7ee656146d598ec75128ff4a2386576801b42b691f4a91cc2c18508544a")
+    version("0.26.0", sha256="67c5ec3265dd4abc7b1d1ab9ca4fe4c25b896f9c93dac73713778adab487f9c4")
+
+    with default_args(type=("build", "run")):
+        depends_on("python@3.8:")
+
+    depends_on("py-setuptools", type="build")
+
+    with default_args(type="run"):
+        depends_on("py-attrs@23.2.0:")
+        depends_on("py-sortedcontainers")
+        depends_on("py-idna")
+        depends_on("py-outcome")
+        depends_on("py-sniffio@1.3.0:")
+        depends_on("py-cffi@1.14:", when="platform=windows")
+        depends_on("py-exceptiongroup", when="^python@:3.10")


### PR DESCRIPTION
This adds Trio (https://pypi.org/project/trio/) and a related project (outcome, https://pypi.org/project/outcome/).

It works as expected for other Spack packages I'm working on (https://foss.heptapod.net/fluiddyn/fluiddyn/-/merge_requests/128).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
