### PR TITLE
e4s ci stacks: add geopm-runtime

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -94,7 +94,6 @@ spack:
   - flux-core
   - fortrilinos
   - gasnet
-  - geopm-runtime
   - ginkgo
   - globalarrays
   - glvis ^llvm
@@ -193,6 +192,7 @@ spack:
   # --
   # - chapel ~cuda ~rocm                                    # llvm: closures.c:(.text+0x305e): undefined reference to `_intel_fast_memset'
   # - cp2k +mpi                                             # dbcsr: dbcsr_api.F(973): #error: incomplete macro call DBCSR_ABORT.
+  # - geopm-runtime                                         # libelf: configure: error: installation or configuration problem: C compiler cannot create executables.
   # - hpctoolkit                                            # dyninst@13.0.0%gcc: libiberty/./d-demangle.c:142: undefined reference to `_intel_fast_memcpy'
   # - lbann                                                 # 2024.2 internal compiler error
   # - plasma                                                # 2024.2 internal compiler error

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -94,7 +94,7 @@ spack:
   - flux-core
   - fortrilinos
   - gasnet
-  - geopm-service
+  - geopm-runtime
   - ginkgo
   - globalarrays
   - glvis ^llvm
@@ -193,7 +193,6 @@ spack:
   # --
   # - chapel ~cuda ~rocm                                    # llvm: closures.c:(.text+0x305e): undefined reference to `_intel_fast_memset'
   # - cp2k +mpi                                             # dbcsr: dbcsr_api.F(973): #error: incomplete macro call DBCSR_ABORT.
-  # - geopm-runtime                                         # libelf: configure: error: installation or configuration problem: C compiler cannot create executables.
   # - hpctoolkit                                            # dyninst@13.0.0%gcc: libiberty/./d-demangle.c:142: undefined reference to `_intel_fast_memcpy'
   # - lbann                                                 # 2024.2 internal compiler error
   # - plasma                                                # 2024.2 internal compiler error

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
@@ -82,7 +82,6 @@ spack:
   - flux-core
   - fortrilinos
   - gasnet
-  - geopm-runtime
   - ginkgo
   - globalarrays
   - gmp
@@ -183,6 +182,7 @@ spack:
   # - ecp-data-vis-sdk ~cuda ~rocm +adios2 +ascent +cinema +darshan +faodel +hdf5 ~paraview +pnetcdf +sz +unifyfs +veloc ~visit +vtkm +zfp # +visit: libext, libxkbfile, libxrender, libxt, silo (https://github.com/spack/spack/issues/39538), cairo
   # --
   # - dealii                                # fltk: https://github.com/spack/spack/issues/38791
+  # - geopm-runtime                         # cairo: *** No autoreconf found, please install it ***
   # - glvis                                 # glvis: https://github.com/spack/spack/issues/42839
   # - libpressio +bitgrooming +bzip2 ~cuda ~cusz +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp # py-numcodecs: gcc: error: unrecognized command line option '-mno-sse2'; did you mean '-mno-isel'? gcc: error: unrecognized command line option '-mno-avx2'
   # - phist +mpi                            # ghost@develop: gcc-9: error: unrecognized command line option '-march=native'; did you mean '-mcpu=native'?

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
@@ -82,6 +82,7 @@ spack:
   - flux-core
   - fortrilinos
   - gasnet
+  - geopm-runtime
   - ginkgo
   - globalarrays
   - gmp
@@ -182,7 +183,6 @@ spack:
   # - ecp-data-vis-sdk ~cuda ~rocm +adios2 +ascent +cinema +darshan +faodel +hdf5 ~paraview +pnetcdf +sz +unifyfs +veloc ~visit +vtkm +zfp # +visit: libext, libxkbfile, libxrender, libxt, silo (https://github.com/spack/spack/issues/39538), cairo
   # --
   # - dealii                                # fltk: https://github.com/spack/spack/issues/38791
-  # - geopm                                 # geopm: https://github.com/spack/spack/issues/38798
   # - glvis                                 # glvis: https://github.com/spack/spack/issues/42839
   # - libpressio +bitgrooming +bzip2 ~cuda ~cusz +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp # py-numcodecs: gcc: error: unrecognized command line option '-mno-sse2'; did you mean '-mno-isel'? gcc: error: unrecognized command line option '-mno-avx2'
   # - phist +mpi                            # ghost@develop: gcc-9: error: unrecognized command line option '-march=native'; did you mean '-mcpu=native'?

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -88,6 +88,7 @@ spack:
   - fortrilinos
   - fpm
   - gasnet
+  - geopm-runtime
   - ginkgo
   - globalarrays
   - gmp
@@ -192,7 +193,6 @@ spack:
   - warpx +python
   - zfp
   # --
-  # - geopm                           # geopm: https://github.com/spack/spack/issues/38795
   - glvis                           # glvis: https://github.com/spack/spack/issues/42839
   # - nek5000 +mpi +visit             # nek5000:  Error: AttributeError: 'str' object has no attribute 'propagate': 'VISIT_INSTALL="' + spec["visit"].prefix.bin + '"',
 


### PR DESCRIPTION
Add `geopm-runtime` to E4S CI stacks

@bgeltz @cmcantalupo Are there any non-default variants you would recommend be turned on/off here?