### PR TITLE
xrootd: change urls to xrootd.web.cern.ch

### DIFF
--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -11,7 +11,7 @@ class Xrootd(CMakePackage):
     """The XROOTD project aims at giving high performance, scalable fault
     tolerant access to data repositories of many kinds."""
 
-    homepage = "https://xrootd.slac.stanford.edu"
+    homepage = "https://xrootd.web.cern.ch"
     urls = [
         "https://xrootd.web.cern.ch/download/v5.7.0/xrootd-5.7.0.tar.gz",
         "https://github.com/xrootd/xrootd/releases/download/v5.7.0/xrootd-5.7.0.tar.gz",

--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -13,10 +13,10 @@ class Xrootd(CMakePackage):
 
     homepage = "https://xrootd.slac.stanford.edu"
     urls = [
-        "https://xrootd.slac.stanford.edu/download/v5.7.0/xrootd-5.7.0.tar.gz",
+        "https://xrootd.web.cern.ch/download/v5.7.0/xrootd-5.7.0.tar.gz",
         "https://github.com/xrootd/xrootd/releases/download/v5.7.0/xrootd-5.7.0.tar.gz",
     ]
-    list_url = "https://xrootd.slac.stanford.edu/dload.html"
+    list_url = "https://xrootd.web.cern.ch/dload.html"
     git = "https://github.com/xrootd/xrootd.git"
 
     maintainers("gartung", "greenc-FNAL", "marcmengel", "vitodb", "wdconinc")


### PR DESCRIPTION
This PR changes the url of `xrootd` to point to the new location on https://xrootd.web.cern.ch (with complete certificate chain). The new location will be used as reference location going forward; see comment by project at https://github.com/xrootd/xrootd/issues/2295#issuecomment-2303978911, "Andy and I decided to make the tarballs on EOS the official location for downloads in the future".