### PR TITLE
RPackage: parse description for incomplete dependencies during test

### DIFF
--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -65,7 +65,7 @@ class RBuilder(GenericBuilder):
                 p = re.search(r"^[\w_-]+", r_dep)  # first word, incl. underscore or dash
                 v = re.search("(?<=[(]).*(?=[)])", r_dep)  # everything between parentheses
                 # require valid package
-                assert(p, f"Unable to find package name in {r_dep}")
+                assert p, f"Unable to find package name in {r_dep}"
                 r_spec = f"r-{p[0].strip().lower()}" if p[0].lower() != "r" else "r"
                 # allow minimum or pinned versions
                 if v:

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -55,9 +55,9 @@ class RBuilder(GenericBuilder):
             with open(fs.join_path(self.stage.source_path, 'DESCRIPTION')) as file:
                 for desc in pycran.parse(file.read()):
                     if "Imports" in desc:
-                        r_deps.extend([d.strip() for d in desc["Imports"].split(",")])
+                        r_deps.extend([d.strip() for d in desc["Imports"].split(",") if d != ""])
                     if "Depends" in desc:
-                        r_deps.extend([d.strip() for d in desc["Depends"].split(",")])
+                        r_deps.extend([d.strip() for d in desc["Depends"].split(",") if d != ""])
 
             # Convert to spack dependencies format for comparison
             deps = {}

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -54,8 +54,10 @@ class RBuilder(GenericBuilder):
             r_deps = []
             with open(fs.join_path(self.stage.source_path, 'DESCRIPTION')) as file:
                 for desc in pycran.parse(file.read()):
-                    r_deps.extend([d.strip() for d in desc.get("Imports", None).split(",")])
-                    r_deps.extend([d.strip() for d in desc.get("Depends", None).split(",")])
+                    if "Imports" in desc:
+                        r_deps.extend([d.strip() for d in desc["Imports"].split(",")])
+                    if "Depends" in desc:
+                        r_deps.extend([d.strip() for d in desc["Depends"].split(",")])
 
             # Convert to spack dependencies format for comparison
             deps = {}

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -12,6 +12,7 @@ from llnl.util.lang import ClassProperty, classproperty
 
 import spack.builder
 import spack.deptypes as dt
+import spack.phase_callbacks
 from spack.dependency import Dependency
 from spack.directives import extends
 from spack.error import SpackError
@@ -106,7 +107,8 @@ class RBuilder(GenericBuilder):
         if package:
             yield package
 
-    def verify_package(self):
+    @spack.phase_callbacks.run_before("install")
+    def _verify_package(self):
         if not self.pkg.run_tests:
             return
 
@@ -204,8 +206,6 @@ class RBuilder(GenericBuilder):
                 "This package requires stricter dependencies than specified:\n\n"
                 + "\n".join(missing_deps)
             )
-
-    spack.builder.run_before("install")(verify_package)
 
     def install(self, pkg, spec, prefix):
         """Installs an R package."""

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -179,13 +179,17 @@ class RBuilder(GenericBuilder):
                 # Spack dependency must satisfy R dependency
                 if not merged_dependencies[dep].spec.satisfies(deps[dep].spec):
                     missing_deps.append(
-                        f'    depends_on("{deps[dep].spec}", type=("build", "run"), when="@{self.pkg.version}:")'
+                        f'    depends_on("{deps[dep].spec}",'
+                        + f' type=("build", "run"),'
+                        + f' when="@{self.pkg.version}:")'
                     )
                 # Remove from dict
                 del merged_dependencies[dep]
             else:
                 missing_deps.append(
-                    f'    depends_on("{deps[dep].spec}", type=("build", "run"), when="@{self.pkg.version}:")'
+                    f'    depends_on("{deps[dep].spec}",'
+                    + f' type=("build", "run"),'
+                    + f' when="@{self.pkg.version}:")'
                 )
         for dep in merged_dependencies:
             if re.match("^r-.*", dep):

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -7,11 +7,11 @@ from typing import Dict, Generator, Optional, Set, Tuple, Union
 import llnl.util.filesystem as fs
 import llnl.util.lang as lang
 import llnl.util.tty as tty
-import spack.builder
-import spack.deptypes as dt
 from llnl.util.filesystem import mkdirp
 from llnl.util.lang import ClassProperty, classproperty
 
+import spack.builder
+import spack.deptypes as dt
 from spack.dependency import Dependency
 from spack.directives import extends
 from spack.error import SpackError
@@ -70,7 +70,6 @@ class RBuilder(GenericBuilder):
         # in our dictionary we have a single package
         # metadata parsed so we yield and repeat again.
         for line in data.splitlines():
-
             if not line.strip():
                 continue
 
@@ -105,7 +104,6 @@ class RBuilder(GenericBuilder):
         # the last parsed package.
         if package:
             yield package
-
 
     def verify_package(self):
         if not self.pkg.run_tests:

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -43,6 +43,7 @@ class RBuilder(GenericBuilder):
         """Arguments to pass to install via ``--configure-vars``."""
         return []
 
+    @staticmethod
     def parse_description(data: str) -> Generator:
         """Parses CRAN package metadata from
         https://cran.r-project.org/src/contrib/PACKAGES
@@ -180,7 +181,7 @@ class RBuilder(GenericBuilder):
                 if not merged_dependencies[dep].spec.satisfies(deps[dep].spec):
                     missing_deps.append(
                         f'    depends_on("{deps[dep].spec}",'
-                        + f' type=("build", "run"),'
+                        + ' type=("build", "run"),'
                         + f' when="@{self.pkg.version}:")'
                     )
                 # Remove from dict
@@ -188,7 +189,7 @@ class RBuilder(GenericBuilder):
             else:
                 missing_deps.append(
                     f'    depends_on("{deps[dep].spec}",'
-                    + f' type=("build", "run"),'
+                    + ' type=("build", "run"),'
                     + f' when="@{self.pkg.version}:")'
                 )
         for dep in merged_dependencies:

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import re
-from typing import Optional, Tuple
+from typing import Dict, Generator, Optional, Set, Tuple, Union
 
 import llnl.util.filesystem as fs
 import llnl.util.lang as lang
@@ -41,6 +41,68 @@ class RBuilder(GenericBuilder):
         """Arguments to pass to install via ``--configure-vars``."""
         return []
 
+    def parse_description(data: str) -> Generator:
+        """Parses CRAN package metadata from
+        https://cran.r-project.org/src/contrib/PACKAGES
+        and returns the list of dictionaries.
+
+        Args:
+            data (str): raw text from the package list
+
+        Returns:
+            (Generator): each entry from packages as dictionary
+
+        Note: based on PyPI pycran v0.2.0 under Apache-2.0 license.
+        """
+        fields: Set = set()
+        package: Dict = {}
+
+        def append(field_value: Union[bytes, str]):
+            pairs = list(package.items())
+            if pairs:
+                last_field = pairs[-1][0]
+                package[last_field] += field_value
+
+        # We want to iterate over each line and accumulate
+        # keys in dictionary, once we meet the same key
+        # in our dictionary we have a single package
+        # metadata parsed so we yield and repeat again.
+        for line in data.splitlines():
+
+            if not line.strip():
+                continue
+
+            if ":" in line:
+                parts = line.split(":", maxsplit=1)
+                field = parts[0].strip()
+                value = str("".join(parts[1:]).strip())
+
+                if not field[0].isalpha():
+                    field = ""
+                    value = line
+
+                if field and field in fields:
+                    fields = {field}
+                    result = {**package}
+                    package = {field: value}
+                    if result:
+                        yield result
+                else:
+                    # Here we want to parse dangling lines
+                    # like the ones with long dependency
+                    # list, `R (>= 2.15.0), xtable, pbapply ... \n    and more`
+                    if field:
+                        package[field] = value.strip()
+                        fields.add(field)
+                    else:
+                        append(f" {value.strip()}")
+            else:
+                append(f" {line.strip()}")
+
+        # We also need to return the metadata for
+        # the last parsed package.
+        if package:
+            yield package
     def install(self, pkg, spec, prefix):
         """Installs an R package."""
         mkdirp(pkg.module.r_lib_dir)

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -7,12 +7,14 @@ from typing import Dict, Generator, Optional, Set, Tuple, Union
 import llnl.util.filesystem as fs
 import llnl.util.lang as lang
 import llnl.util.tty as tty
+import spack.builder
 import spack.deptypes as dt
 from llnl.util.filesystem import mkdirp
 from llnl.util.lang import ClassProperty, classproperty
 
 from spack.dependency import Dependency
 from spack.directives import extends
+from spack.error import SpackError
 from spack.spec import Spec
 
 from .generic import GenericBuilder, Package
@@ -103,64 +105,108 @@ class RBuilder(GenericBuilder):
         # the last parsed package.
         if package:
             yield package
+
+
+    def verify_package(self):
+        if not self.pkg.run_tests:
+            return
+
+        # Read DESCRIPTION file with dependency information
+        r_deps = []
+        with open(fs.join_path(self.stage.source_path, "DESCRIPTION")) as file:
+            for desc in RBuilder.parse_description(file.read()):
+                for field in [f for f in ["Depends", "Imports", "LinkingTo"] if f in desc]:
+                    r_deps.extend([d.strip() for d in desc[field].split(",") if d != ""])
+        tty.debug(f"DESCRIPTION: {r_deps}")
+
+        # Convert to spack dependencies format for comparison
+        deps = {}
+        r_core = [
+            "r-compiler",
+            "r-graphics",
+            "r-grdevices",
+            "r-grid",
+            "r-methods",
+            "r-parallel",
+            "r-splines",
+            "r-stats",
+            "r-stats4",
+            "r-tcltk",
+            "r-tools",
+            "r-utils",
+        ]
+        for r_dep in r_deps:
+            p = re.search(r"^[\w_.-]+", r_dep)  # first word, incl. underscore, dot, or dash
+            v = re.search("(?<=[(]).*(?=[)])", r_dep)  # everything between parentheses
+            # require valid package
+            assert p, f"Unable to find package name in {r_dep}"
+            r_spec = f"r-{p[0].strip().lower()}" if p[0].lower() != "r" else "r"
+            r_spec = re.sub(r"\.", "-", r_spec)  # dot to dash
+            # filter R core packages
+            if r_spec in r_core:
+                r_spec = "r"
+            # allow minimum or pinned versions
+            if v:
+                v = re.sub(r">=\s([\d.-]+)", r"@\1:", v[0])  # >=
+                v = re.sub(r">\s([\d.-]+)", r"@\1.1:", v)  # >
+                v = re.sub(r"==\s([\d.-]+)", r"@\1", v)  # ==
+            else:
+                v = ""
+            # merge dependencies as they are added
+            if r_spec in deps:
+                deps[r_spec].merge(Dependency(self.pkg, Spec(r_spec + v), dt.BUILD | dt.RUN))
+            else:
+                deps[r_spec] = Dependency(self.pkg, Spec(r_spec + v), dt.BUILD | dt.RUN)
+        tty.debug(f"Converted: {deps}")
+
+        # Retrieve dependencies for current spack package and version
+        spack_dependencies = []
+        for when, dep in self.pkg.dependencies.items():
+            if self.spec.satisfies(when):
+                spack_dependencies.append(dep)
+        tty.debug(f"Spack as read: {spack_dependencies}")
+        merged_dependencies = {}
+        for dep in spack_dependencies:
+            for n, d in dep.items():
+                if n in merged_dependencies:
+                    merged_dependencies[n].merge(d)
+                else:
+                    merged_dependencies[n] = d
+        tty.debug(f"Spack merged: {merged_dependencies}")
+
+        # For each R dependency, ensure Spack dependency is at least as strong
+        missing_deps = []
+        for dep in sorted(deps.keys()):
+            if dep in list(merged_dependencies.keys()):
+                # Spack dependency must satisfy R dependency
+                if not merged_dependencies[dep].spec.satisfies(deps[dep].spec):
+                    missing_deps.append(
+                        f'    depends_on("{deps[dep].spec}", type=("build", "run"), when="@{self.pkg.version}:")'
+                    )
+                # Remove from dict
+                del merged_dependencies[dep]
+            else:
+                missing_deps.append(
+                    f'    depends_on("{deps[dep].spec}", type=("build", "run"), when="@{self.pkg.version}:")'
+                )
+        for dep in merged_dependencies:
+            if re.match("^r-.*", dep):
+                missing_deps.append(
+                    f'    #depends_on("{merged_dependencies[dep].spec}") not needed anymore'
+                )
+
+        # Raise exception
+        if len(missing_deps) > 0:
+            raise SpackError(
+                "This package requires stricter dependencies than specified:\n\n"
+                + "\n".join(missing_deps)
+            )
+
+    spack.builder.run_before("install")(verify_package)
+
     def install(self, pkg, spec, prefix):
         """Installs an R package."""
         mkdirp(pkg.module.r_lib_dir)
-
-        try:
-            # TODO: use a more sustainable dcf parser
-            import pycran
-
-            # Read DESCRIPTION file with dependency information
-            # https://r-pkgs.org/description.html
-            r_deps = []
-            with open(fs.join_path(self.stage.source_path, 'DESCRIPTION')) as file:
-                for desc in pycran.parse(file.read()):
-                    if "Imports" in desc:
-                        r_deps.extend([d.strip() for d in desc["Imports"].split(",") if d != ""])
-                    if "Depends" in desc:
-                        r_deps.extend([d.strip() for d in desc["Depends"].split(",") if d != ""])
-
-            # Convert to spack dependencies format for comparison
-            deps = {}
-            for r_dep in r_deps:
-                p = re.search(r"^[\w_-]+", r_dep)  # first word, incl. underscore or dash
-                v = re.search("(?<=[(]).*(?=[)])", r_dep)  # everything between parentheses
-                # require valid package
-                assert p, f"Unable to find package name in {r_dep}"
-                r_spec = f"r-{p[0].strip().lower()}" if p[0].lower() != "r" else "r"
-                # allow minimum or pinned versions
-                if v:
-                    v = re.sub(r">=\s([\d.-]+)", r"@\1:", v[0])  # >=
-                    v = re.sub(r"==\s([\d.-]+)", r"@\1", v)  # ==
-                    deps[r_spec] = Dependency(pkg, Spec(r_spec + v), dt.BUILD | dt.RUN)
-                else:
-                    deps[r_spec] = Dependency(pkg, Spec(r_spec), dt.BUILD | dt.RUN)
-
-            # Retrieve dependencies for current spack package and version
-            spack_dependencies = []
-            for when, dep in pkg.dependencies.items():
-                if spec.satisfies(when):
-                    spack_dependencies.append(dep)
-            merged_dependencies = {}
-            for dep in spack_dependencies:
-                for n, d in dep.items():
-                    if d in merged_dependencies:
-                        merged_dependencies[n].merge(d)
-                    else:
-                        merged_dependencies[n] = d
-
-            # For each R dependency, ensure Spack dependency is at least as strong
-            for dep in sorted(deps.keys()):
-                if dep in merged_dependencies:
-                    if not merged_dependencies[dep].spec.satisfies(deps[dep].spec):
-                        tty.debug(f'    depends_on("{deps[dep].spec}", when="@{pkg.version}:", type=("build", "run"))')
-                else:
-                    tty.debug(f'    depends_on("{deps[dep].spec}", when="@{pkg.version}:", type=("build", "run"))')
-
-        except ImportError:
-            tty.debug("R package dependency verification requires pycran")
-            pass
 
         config_args = self.configure_args()
         config_vars = self.configure_vars()

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -1,12 +1,19 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import re
 from typing import Optional, Tuple
 
+import llnl.util.filesystem as fs
+import llnl.util.lang as lang
+import llnl.util.tty as tty
+import spack.deptypes as dt
 from llnl.util.filesystem import mkdirp
 from llnl.util.lang import ClassProperty, classproperty
 
+from spack.dependency import Dependency
 from spack.directives import extends
+from spack.spec import Spec
 
 from .generic import GenericBuilder, Package
 
@@ -37,6 +44,59 @@ class RBuilder(GenericBuilder):
     def install(self, pkg, spec, prefix):
         """Installs an R package."""
         mkdirp(pkg.module.r_lib_dir)
+
+        try:
+            # TODO: use a more sustainable dcf parser
+            import pycran
+
+            # Read DESCRIPTION file with dependency information
+            # https://r-pkgs.org/description.html
+            r_deps = []
+            with open(fs.join_path(self.stage.source_path, 'DESCRIPTION')) as file:
+                for desc in pycran.parse(file.read()):
+                    r_deps.extend([d.strip() for d in desc.get("Imports", None).split(",")])
+                    r_deps.extend([d.strip() for d in desc.get("Depends", None).split(",")])
+
+            # Convert to spack dependencies format for comparison
+            deps = {}
+            for r_dep in r_deps:
+                p = re.search(r"^[\w_-]+", r_dep)  # first word, incl. underscore or dash
+                v = re.search("(?<=[(]).*(?=[)])", r_dep)  # everything between parentheses
+                # require valid package
+                assert(p, f"Unable to find package name in {r_dep}")
+                r_spec = f"r-{p[0].strip().lower()}" if p[0].lower() != "r" else "r"
+                # allow minimum or pinned versions
+                if v:
+                    v = re.sub(r">=\s([\d.-]+)", r"@\1:", v[0])  # >=
+                    v = re.sub(r"==\s([\d.-]+)", r"@\1", v)  # ==
+                    deps[r_spec] = Dependency(pkg, Spec(r_spec + v), dt.BUILD | dt.RUN)
+                else:
+                    deps[r_spec] = Dependency(pkg, Spec(r_spec), dt.BUILD | dt.RUN)
+
+            # Retrieve dependencies for current spack package and version
+            spack_dependencies = []
+            for when, dep in pkg.dependencies.items():
+                if spec.satisfies(when):
+                    spack_dependencies.append(dep)
+            merged_dependencies = {}
+            for dep in spack_dependencies:
+                for n, d in dep.items():
+                    if d in merged_dependencies:
+                        merged_dependencies[n].merge(d)
+                    else:
+                        merged_dependencies[n] = d
+
+            # For each R dependency, ensure Spack dependency is at least as strong
+            for dep in sorted(deps.keys()):
+                if dep in merged_dependencies:
+                    if not merged_dependencies[dep].spec.satisfies(deps[dep].spec):
+                        tty.debug(f'    depends_on("{deps[dep].spec}", when="@{pkg.version}:", type=("build", "run"))')
+                else:
+                    tty.debug(f'    depends_on("{deps[dep].spec}", when="@{pkg.version}:", type=("build", "run"))')
+
+        except ImportError:
+            tty.debug("R package dependency verification requires pycran")
+            pass
 
         config_args = self.configure_args()
         config_vars = self.configure_vars()


### PR DESCRIPTION
R packages bundle a `DESCRIPTION` file which includes the required dependencies for an install to even succeed at all.

This PR parses the `DESCRIPTION` file and determines whether spack 'got it right' (or at least sufficiently right), and it generates an exception and prints required depends_on lines.

This feature is at this point mostly a useful crutch to help with updating package versions. But it would be more powerful if this could be used to inject dependencies when `spack checksum` does its thing, or when `spack create` is used. I am not sure we have the necessary hooks for this.