### PR TITLE
parallel-netcdf: Adds a new static variant

### DIFF
--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -153,7 +153,7 @@ class ParallelNetcdf(AutotoolsPackage):
 
         if self.version >= Version("1.9"):
             args += self.enable_or_disable("shared")
-            args.extent(["--disable-silent-rules"])
+            args.append("--disable-silent-rules")
 
         if self.spec.satisfies("%nag+fortran+shared"):
             args.extend(["ac_cv_prog_fc_v=-Wl,-v", "ac_cv_prog_f77_v=-Wl,-v"])


### PR DESCRIPTION
When building a static library, the spack `-rpath` is passed to the linker which is not accepted by the macos linker. This is detailed in issue #45919.

By default, the parallel-netcdf package is building a static library. This makes it unbuildable on macos.

This PR adds a static variant (enabled by default to mimic existing behaviour) to allow turning off the problematic library gen. Further, it explicitly conflicts on `+static` to avoid unclear compilation errors when on darwin. 

