### PR TITLE
llvm-amdgpu: Updating LD_LIBRARY_PATH w.r.t new prefix path

### DIFF
--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -359,6 +359,9 @@ class Hip(CMakePackage):
 
             if self.spec.satisfies("@5.7:"):
                 paths["hip-path"] = rocm_prefix
+            if self.spec.satisfies("@6.0:"):
+                paths["hsa-rocr-dev"] = rocm_prefix
+
         else:
             paths = {
                 "hip-path": self.spec.prefix,

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -269,12 +269,12 @@ class LlvmAmdgpu(CMakePackage, CompilerPackage):
     # Make sure that the compiler paths are in the LD_LIBRARY_PATH
     def setup_run_environment(self, env):
         llvm_amdgpu_home = self.spec["llvm-amdgpu"].prefix
-        env.prepend_path("LD_LIBRARY_PATH", llvm_amdgpu_home + "/llvm/lib")
+        env.prepend_path("LD_LIBRARY_PATH", llvm_amdgpu_home + "/lib")
 
     # Make sure that the compiler paths are in the LD_LIBRARY_PATH
     def setup_dependent_run_environment(self, env, dependent_spec):
         llvm_amdgpu_home = self.spec["llvm-amdgpu"].prefix
-        env.prepend_path("LD_LIBRARY_PATH", llvm_amdgpu_home + "/llvm/lib")
+        env.prepend_path("LD_LIBRARY_PATH", llvm_amdgpu_home + "/lib")
 
     # Required for enabling asan on dependent packages
     def setup_dependent_build_environment(self, env, dependent_spec):


### PR DESCRIPTION
setting LD_LIBRARY_PATH= <llvm-prefix-path>/lib so that it should work with external path with releases 5.3 to 6.3 which is /opt/rocm-<v.e.r>/llvm/lib where llvm-prefix-path is set as /opt/rocm-<v.e.r>/llvm in the package.yaml and with the spack installed llvm-amdgpu path as well.