### PR TITLE
py-autograd: mark numpy 2 compatibility

### DIFF
--- a/var/spack/repos/builtin/packages/py-autograd/package.py
+++ b/var/spack/repos/builtin/packages/py-autograd/package.py
@@ -36,3 +36,5 @@ class PyAutograd(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-future@0.15.2:", type=("build", "run"))
     depends_on("py-numpy@1.12:", type=("build", "run"))
+    # https://github.com/HIPS/autograd/releases/tag/v1.7.0
+    depends_on("py-numpy@:1", when="@:1.6", type=("build", "run")

--- a/var/spack/repos/builtin/packages/py-autograd/package.py
+++ b/var/spack/repos/builtin/packages/py-autograd/package.py
@@ -37,4 +37,4 @@ class PyAutograd(PythonPackage):
     depends_on("py-future@0.15.2:", type=("build", "run"))
     depends_on("py-numpy@1.12:", type=("build", "run"))
     # https://github.com/HIPS/autograd/releases/tag/v1.7.0
-    depends_on("py-numpy@:1", when="@:1.6", type=("build", "run")
+    depends_on("py-numpy@:1", when="@:1.6", type=("build", "run"))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
https://github.com/HIPS/autograd/releases/tag/v1.7.0