### PR TITLE
Pytest: only windows mark

### DIFF
--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1980,6 +1980,11 @@ def pytest_runtest_setup(item):
     if not_on_windows_marker and sys.platform == "win32":
         pytest.skip(*not_on_windows_marker.args)
 
+    # Skip items marked "only windows" if they're run anywhere but Windows
+    only_windows_marker = item.get_closest_marker(name="only_windows")
+    if only_windows_marker and sys.platform != "win32":
+        pytest.skip(*only_windows_marker.args)
+
 
 @pytest.fixture(autouse=True)
 def disable_parallel_buildcache_push(monkeypatch):

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -1000,7 +1000,7 @@ def test_rename_dest_exists(tmpdir):
         shutil.rmtree(tmpdir.join("f"))
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="No-op on non Windows")
+@pytest.mark.only_windows("Test is for Windows specific behavior")
 def test_windows_sfn(tmpdir):
     # first check some standard Windows locations
     # we know require sfn names

--- a/lib/spack/spack/test/llnl/util/symlink.py
+++ b/lib/spack/spack/test/llnl/util/symlink.py
@@ -37,7 +37,7 @@ def test_symlink_dir(tmpdir):
         assert symlink.islink(link_dir)
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
+@pytest.mark.only_windows("Test is for Windows specific behavior")
 def test_symlink_source_not_exists(tmpdir):
     """Test the symlink.symlink method for the case where a source path does not exist"""
     with tmpdir.as_cwd():
@@ -71,7 +71,7 @@ def test_symlink_src_relative_to_link(tmpdir):
         assert os.path.lexists(link_dir)
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
+@pytest.mark.only_windows("Test is for Windows specific behavior")
 def test_symlink_src_not_relative_to_link(tmpdir):
     """Test the symlink.symlink functionality where the source value does not exist relative to
     the link and not relative to the cwd. NOTE that this symlink api call is EXPECTED to raise
@@ -98,7 +98,7 @@ def test_symlink_src_not_relative_to_link(tmpdir):
         assert not os.path.lexists(link_dir)
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
+@pytest.mark.only_windows("Test is for Windows specific behavior")
 def test_symlink_link_already_exists(tmpdir):
     """Test the symlink.symlink method for the case where a link already exists"""
     with tmpdir.as_cwd():
@@ -113,7 +113,7 @@ def test_symlink_link_already_exists(tmpdir):
 
 
 @pytest.mark.skipif(not symlink._windows_can_symlink(), reason="Test requires elevated privileges")
-@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
+@pytest.mark.only_windows("Test is for Windows specific behavior")
 def test_symlink_win_file(tmpdir):
     """Check that symlink.symlink makes a symlink file when run with elevated permissions"""
     with tmpdir.as_cwd():
@@ -130,7 +130,7 @@ def test_symlink_win_file(tmpdir):
 
 
 @pytest.mark.skipif(not symlink._windows_can_symlink(), reason="Test requires elevated privileges")
-@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
+@pytest.mark.only_windows("Test is for Windows specific behavior")
 def test_symlink_win_dir(tmpdir):
     """Check that symlink.symlink makes a symlink dir when run with elevated permissions"""
     with tmpdir.as_cwd():
@@ -147,7 +147,7 @@ def test_symlink_win_dir(tmpdir):
         assert not symlink._windows_is_junction(link_dir)
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
+@pytest.mark.only_windows("Test is for Windows specific behavior")
 def test_windows_create_junction(tmpdir):
     """Test the symlink._windows_create_junction method"""
     with tmpdir.as_cwd():
@@ -163,7 +163,7 @@ def test_windows_create_junction(tmpdir):
         assert not os.path.islink(junction_link_dir)
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
+@pytest.mark.only_windows("Test is for Windows specific behavior")
 def test_windows_create_hard_link(tmpdir):
     """Test the symlink._windows_create_hard_link method"""
     with tmpdir.as_cwd():
@@ -179,7 +179,7 @@ def test_windows_create_hard_link(tmpdir):
         assert not os.path.islink(link_file)
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
+@pytest.mark.only_windows("Test is for Windows specific behavior")
 def test_windows_create_link_dir(tmpdir):
     """Test the functionality of the windows_create_link method with a directory
     which should result in making a junction.
@@ -198,7 +198,7 @@ def test_windows_create_link_dir(tmpdir):
         assert not os.path.islink(link_dir)
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
+@pytest.mark.only_windows("Test is for Windows specific behavior")
 def test_windows_create_link_file(tmpdir):
     """Test the functionality of the windows_create_link method with a file
     which should result in the creation of a hard link. It also tests the
@@ -215,7 +215,7 @@ def test_windows_create_link_file(tmpdir):
         assert not symlink._windows_is_junction(link_file)
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows")
+@pytest.mark.only_windows("Test is for Windows specific behavior")
 def test_windows_read_link(tmpdir):
     """Makes sure symlink.readlink can read the link source for hard links and
     junctions on windows."""

--- a/lib/spack/spack/test/llnl/util/symlink.py
+++ b/lib/spack/spack/test/llnl/util/symlink.py
@@ -5,7 +5,6 @@
 
 """Tests for ``llnl/util/symlink.py``"""
 import os
-import sys
 import tempfile
 
 import pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,3 +15,4 @@ markers =
   enable_compiler_execution: enable compiler execution to detect link paths and libc
   disable_clean_stage_check: avoid failing tests if there are leftover files in the stage area
   not_on_windows: mark tests that are skipped on Windows
+  only_windows: mark tests that are skipped everywhere but Windows


### PR DESCRIPTION
Adds a convenience feature to pytest allowing a test or test module to be easily designated as "Windows only"

Pulled from: https://github.com/spack/spack/pull/41810