### PR TITLE
Remove code from Compiler that is not used anymore

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -608,10 +608,6 @@ class Compiler:
         return cls.default_version(cc)
 
     @classmethod
-    def cxx_version(cls, cxx):
-        return cls.default_version(cxx)
-
-    @classmethod
     def search_regexps(cls, language):
         # Compile all the regular expressions used for files beforehand.
         # This searches for any combination of <prefix><name><suffix>

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -202,9 +202,6 @@ class Compiler:
     support for specific compilers, their possible names, arguments,
     and how to identify the particular type of compiler."""
 
-    # Subclasses use possible names of C compiler
-    cc_names: List[str] = []
-
     # Subclasses use possible names of C++ compiler
     cxx_names: List[str] = []
 

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -612,10 +612,6 @@ class Compiler:
         return cls.default_version(cxx)
 
     @classmethod
-    def fc_version(cls, fc):
-        return cls.default_version(fc)
-
-    @classmethod
     def search_regexps(cls, language):
         # Compile all the regular expressions used for files beforehand.
         # This searches for any combination of <prefix><name><suffix>

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -205,9 +205,6 @@ class Compiler:
     # Subclasses use possible names of Fortran 77 compiler
     f77_names: List[str] = []
 
-    # Subclasses use possible names of Fortran 90 compiler
-    fc_names: List[str] = []
-
     # Optional prefix regexes for searching for this type of compiler.
     # Prefixes are sometimes used for toolchains
     prefixes: List[str] = []

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -202,9 +202,6 @@ class Compiler:
     support for specific compilers, their possible names, arguments,
     and how to identify the particular type of compiler."""
 
-    # Subclasses use possible names of Fortran 77 compiler
-    f77_names: List[str] = []
-
     # Optional prefix regexes for searching for this type of compiler.
     # Prefixes are sometimes used for toolchains
     prefixes: List[str] = []

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -202,9 +202,6 @@ class Compiler:
     support for specific compilers, their possible names, arguments,
     and how to identify the particular type of compiler."""
 
-    # Subclasses use possible names of C++ compiler
-    cxx_names: List[str] = []
-
     # Subclasses use possible names of Fortran 77 compiler
     f77_names: List[str] = []
 

--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -612,10 +612,6 @@ class Compiler:
         return cls.default_version(cxx)
 
     @classmethod
-    def f77_version(cls, f77):
-        return cls.default_version(f77)
-
-    @classmethod
     def fc_version(cls, fc):
         return cls.default_version(fc)
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -8,6 +8,7 @@ system and configuring Spack to use multiple compilers.
 """
 import importlib
 import os
+import re
 import sys
 import warnings
 from typing import Dict, List, Optional
@@ -631,37 +632,34 @@ def is_mixed_toolchain(compiler):
     Args:
         compiler (spack.compiler.Compiler): a valid compiler object
     """
-    cc = os.path.basename(compiler.cc or "")
-    cxx = os.path.basename(compiler.cxx or "")
-    f77 = os.path.basename(compiler.f77 or "")
-    fc = os.path.basename(compiler.fc or "")
+    import spack.detection.path
+
+    executables = [
+        os.path.basename(compiler.cc or ""),
+        os.path.basename(compiler.cxx or ""),
+        os.path.basename(compiler.f77 or ""),
+        os.path.basename(compiler.fc or ""),
+    ]
 
     toolchains = set()
-    for compiler_cls in all_compiler_types():
-        # Inspect all the compiler toolchain we know. If a compiler is the
-        # only compiler supported there it belongs to that toolchain.
-        def name_matches(name, name_list):
-            # This is such that 'gcc' matches variations
-            # like 'ggc-9' etc that are found in distros
-            name, _, _ = name.partition("-")
-            return len(name_list) == 1 and name and name in name_list
+    finder = spack.detection.path.ExecutablesFinder()
 
-        if any(
-            [
-                name_matches(cc, compiler_cls.cc_names),
-                name_matches(cxx, compiler_cls.cxx_names),
-                name_matches(f77, compiler_cls.f77_names),
-                name_matches(fc, compiler_cls.fc_names),
-            ]
-        ):
-            tty.debug("[TOOLCHAIN] MATCH {0}".format(compiler_cls.__name__))
-            toolchains.add(compiler_cls.__name__)
+    for pkg_name in spack.repo.PATH.packages_with_tags(COMPILER_TAG):
+        pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+        patterns = finder.search_patterns(pkg=pkg_cls)
+        if not patterns:
+            continue
+        joined_pattern = re.compile(r"|".join(patterns))
+
+        if any(joined_pattern.search(exe) for exe in executables):
+            tty.debug(f"[TOOLCHAIN] MATCH {pkg_name}")
+            toolchains.add(pkg_name)
 
     if len(toolchains) > 1:
         if (
-            toolchains == set(["Clang", "AppleClang", "Aocc"])
+            toolchains == {"llvm", "apple-clang", "aocc"}
             # Msvc toolchain uses Intel ifx
-            or toolchains == set(["Msvc", "Dpcpp", "Oneapi"])
+            or toolchains == {"msvc", "intel-oneapi-compilers"}
         ):
             return False
         tty.debug("[TOOLCHAINS] {0}".format(toolchains))

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -13,9 +13,6 @@ from spack.version import ver
 
 
 class Aocc(Compiler):
-    # Subclasses use possible names of C compiler
-    cc_names = ["clang"]
-
     # Subclasses use possible names of C++ compiler
     cxx_names = ["clang++"]
 

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -13,9 +13,6 @@ from spack.version import ver
 
 
 class Aocc(Compiler):
-    # Subclasses use possible names of C++ compiler
-    cxx_names = ["clang++"]
-
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["flang"]
 

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -13,9 +13,6 @@ from spack.version import ver
 
 
 class Aocc(Compiler):
-    # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ["flang"]
-
     version_argument = "--version"
 
     @property

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -16,9 +16,6 @@ class Aocc(Compiler):
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["flang"]
 
-    # Subclasses use possible names of Fortran 90 compiler
-    fc_names = ["flang"]
-
     version_argument = "--version"
 
     @property

--- a/lib/spack/spack/compilers/arm.py
+++ b/lib/spack/spack/compilers/arm.py
@@ -9,9 +9,6 @@ import spack.compiler
 
 
 class Arm(spack.compiler.Compiler):
-    # Subclasses use possible names of C compiler
-    cc_names = ["armclang"]
-
     # Subclasses use possible names of C++ compiler
     cxx_names = ["armclang++"]
 

--- a/lib/spack/spack/compilers/arm.py
+++ b/lib/spack/spack/compilers/arm.py
@@ -9,9 +9,6 @@ import spack.compiler
 
 
 class Arm(spack.compiler.Compiler):
-    # Subclasses use possible names of C++ compiler
-    cxx_names = ["armclang++"]
-
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["armflang"]
 

--- a/lib/spack/spack/compilers/arm.py
+++ b/lib/spack/spack/compilers/arm.py
@@ -82,7 +82,3 @@ class Arm(spack.compiler.Compiler):
     @classmethod
     def fc_version(cls, fc):
         return cls.default_version(fc)
-
-    @classmethod
-    def f77_version(cls, f77):
-        return cls.fc_version(f77)

--- a/lib/spack/spack/compilers/arm.py
+++ b/lib/spack/spack/compilers/arm.py
@@ -12,9 +12,6 @@ class Arm(spack.compiler.Compiler):
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["armflang"]
 
-    # Subclasses use possible names of Fortran 90 compiler
-    fc_names = ["armflang"]
-
     # Named wrapper links within lib/spack/env
     link_paths = {
         "cc": os.path.join("arm", "armclang"),

--- a/lib/spack/spack/compilers/arm.py
+++ b/lib/spack/spack/compilers/arm.py
@@ -9,9 +9,6 @@ import spack.compiler
 
 
 class Arm(spack.compiler.Compiler):
-    # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ["armflang"]
-
     # Named wrapper links within lib/spack/env
     link_paths = {
         "cc": os.path.join("arm", "armclang"),

--- a/lib/spack/spack/compilers/arm.py
+++ b/lib/spack/spack/compilers/arm.py
@@ -78,7 +78,3 @@ class Arm(spack.compiler.Compiler):
         return "-fPIC"
 
     required_libs = ["libclang", "libflang"]
-
-    @classmethod
-    def fc_version(cls, fc):
-        return cls.default_version(fc)

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -19,9 +19,6 @@ class Cce(Compiler):
         if not self.is_clang_based:
             self.version_argument = "-V"
 
-    # Subclasses use possible names of C++ compiler
-    cxx_names = ["crayCC"]
-
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["crayftn"]
 

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -19,9 +19,6 @@ class Cce(Compiler):
         if not self.is_clang_based:
             self.version_argument = "-V"
 
-    # Subclasses use possible names of C compiler
-    cc_names = ["craycc"]
-
     # Subclasses use possible names of C++ compiler
     cxx_names = ["crayCC"]
 

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -22,9 +22,6 @@ class Cce(Compiler):
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["crayftn"]
 
-    # Subclasses use possible names of Fortran 90 compiler
-    fc_names = ["crayftn"]
-
     # MacPorts builds gcc versions with prefixes and -mp-X.Y suffixes.
     suffixes = [r"-mp-\d\.\d"]
 

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -19,9 +19,6 @@ class Cce(Compiler):
         if not self.is_clang_based:
             self.version_argument = "-V"
 
-    # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ["crayftn"]
-
     # MacPorts builds gcc versions with prefixes and -mp-X.Y suffixes.
     suffixes = [r"-mp-\d\.\d"]
 

--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -31,9 +31,6 @@ fc_mapping = [
 
 
 class Clang(Compiler):
-    # Subclasses use possible names of C compiler
-    cc_names = ["clang"]
-
     # Subclasses use possible names of C++ compiler
     cxx_names = ["clang++"]
 

--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -34,9 +34,6 @@ class Clang(Compiler):
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["flang-new", "flang"]
 
-    # Subclasses use possible names of Fortran 90 compiler
-    fc_names = ["flang-new", "flang"]
-
     version_argument = "--version"
 
     @property

--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -31,9 +31,6 @@ fc_mapping = [
 
 
 class Clang(Compiler):
-    # Subclasses use possible names of C++ compiler
-    cxx_names = ["clang++"]
-
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["flang-new", "flang"]
 

--- a/lib/spack/spack/compilers/clang.py
+++ b/lib/spack/spack/compilers/clang.py
@@ -31,9 +31,6 @@ fc_mapping = [
 
 
 class Clang(Compiler):
-    # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ["flang-new", "flang"]
-
     version_argument = "--version"
 
     @property

--- a/lib/spack/spack/compilers/fj.py
+++ b/lib/spack/spack/compilers/fj.py
@@ -9,9 +9,6 @@ import spack.compiler
 
 
 class Fj(spack.compiler.Compiler):
-    # Subclasses use possible names of C compiler
-    cc_names = ["fcc"]
-
     # Subclasses use possible names of C++ compiler
     cxx_names = ["FCC"]
 

--- a/lib/spack/spack/compilers/fj.py
+++ b/lib/spack/spack/compilers/fj.py
@@ -9,9 +9,6 @@ import spack.compiler
 
 
 class Fj(spack.compiler.Compiler):
-    # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ["frt"]
-
     # Named wrapper links within build_env_path
     link_paths = {
         "cc": os.path.join("fj", "fcc"),

--- a/lib/spack/spack/compilers/fj.py
+++ b/lib/spack/spack/compilers/fj.py
@@ -12,9 +12,6 @@ class Fj(spack.compiler.Compiler):
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["frt"]
 
-    # Subclasses use possible names of Fortran 90 compiler
-    fc_names = ["frt"]
-
     # Named wrapper links within build_env_path
     link_paths = {
         "cc": os.path.join("fj", "fcc"),

--- a/lib/spack/spack/compilers/fj.py
+++ b/lib/spack/spack/compilers/fj.py
@@ -9,9 +9,6 @@ import spack.compiler
 
 
 class Fj(spack.compiler.Compiler):
-    # Subclasses use possible names of C++ compiler
-    cxx_names = ["FCC"]
-
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["frt"]
 

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -199,10 +199,6 @@ class Gcc(spack.compiler.Compiler):
             version = cls.extract_version_from_output(output)
         return version
 
-    @classmethod
-    def f77_version(cls, f77):
-        return cls.fc_version(f77)
-
     @property
     def stdcxx_libs(self):
         return ("-lstdc++",)

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -15,9 +15,6 @@ from spack.version import Version
 
 
 class Gcc(spack.compiler.Compiler):
-    # Subclasses use possible names of C++ compiler
-    cxx_names = ["g++"]
-
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["gfortran"]
 

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import re
 
 from llnl.util.filesystem import ancestor
 
@@ -166,36 +165,6 @@ class Gcc(spack.compiler.Compiler):
         version = super(Gcc, cls).default_version(cc)
         if Version(version) >= Version("7"):
             output = spack.compiler.get_compiler_version_output(cc, "-dumpfullversion")
-            version = cls.extract_version_from_output(output)
-        return version
-
-    @classmethod
-    def fc_version(cls, fc):
-        """Older versions of gfortran use the ``-dumpversion`` option.
-        Output looks like this::
-
-            GNU Fortran (GCC) 4.4.7 20120313 (Red Hat 4.4.7-18)
-            Copyright (C) 2010 Free Software Foundation, Inc.
-
-        or::
-
-            4.8.5
-
-        In GCC 7, this option was changed to only return the major
-        version of the compiler::
-
-            7
-
-        A new ``-dumpfullversion`` option was added that gives us
-        what we want::
-
-            7.2.0
-        """
-        output = spack.compiler.get_compiler_version_output(fc, "-dumpversion")
-        match = re.search(r"(?:GNU Fortran \(GCC\) )?([\d.]+)", output)
-        version = match.group(match.lastindex) if match else "unknown"
-        if Version(version) >= Version("7"):
-            output = spack.compiler.get_compiler_version_output(fc, "-dumpfullversion")
             version = cls.extract_version_from_output(output)
         return version
 

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -15,9 +15,6 @@ from spack.version import Version
 
 
 class Gcc(spack.compiler.Compiler):
-    # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ["gfortran"]
-
     # MacPorts builds gcc versions with prefixes and -mp-X or -mp-X.Y suffixes.
     # Homebrew and Linuxbrew may build gcc with -X, -X.Y suffixes.
     # Old compatibility versions may contain XY suffixes.

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -15,9 +15,6 @@ from spack.version import Version
 
 
 class Gcc(spack.compiler.Compiler):
-    # Subclasses use possible names of C compiler
-    cc_names = ["gcc"]
-
     # Subclasses use possible names of C++ compiler
     cxx_names = ["g++"]
 

--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -18,9 +18,6 @@ class Gcc(spack.compiler.Compiler):
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["gfortran"]
 
-    # Subclasses use possible names of Fortran 90 compiler
-    fc_names = ["gfortran"]
-
     # MacPorts builds gcc versions with prefixes and -mp-X or -mp-X.Y suffixes.
     # Homebrew and Linuxbrew may build gcc with -X, -X.Y suffixes.
     # Old compatibility versions may contain XY suffixes.

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -11,9 +11,6 @@ from spack.version import Version
 
 
 class Intel(Compiler):
-    # Subclasses use possible names of C compiler
-    cc_names = ["icc"]
-
     # Subclasses use possible names of C++ compiler
     cxx_names = ["icpc"]
 

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -11,9 +11,6 @@ from spack.version import Version
 
 
 class Intel(Compiler):
-    # Subclasses use possible names of C++ compiler
-    cxx_names = ["icpc"]
-
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["ifort"]
 

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -14,9 +14,6 @@ class Intel(Compiler):
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["ifort"]
 
-    # Subclasses use possible names of Fortran 90 compiler
-    fc_names = ["ifort"]
-
     # Named wrapper links within build_env_path
     link_paths = {
         "cc": os.path.join("intel", "icc"),

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -11,9 +11,6 @@ from spack.version import Version
 
 
 class Intel(Compiler):
-    # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ["ifort"]
-
     # Named wrapper links within build_env_path
     link_paths = {
         "cc": os.path.join("intel", "icc"),

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -117,9 +117,6 @@ def get_valid_fortran_pth():
 
 
 class Msvc(Compiler):
-    # Subclasses use possible names of C++ compiler
-    cxx_names: List[str] = ["cl"]
-
     # Subclasses use possible names of Fortran 77 compiler
     f77_names: List[str] = ["ifx"]
 

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -8,7 +8,7 @@ import re
 import subprocess
 import sys
 import tempfile
-from typing import Dict, List
+from typing import Dict
 
 import archspec.cpu
 
@@ -117,9 +117,6 @@ def get_valid_fortran_pth():
 
 
 class Msvc(Compiler):
-    # Subclasses use possible names of Fortran 77 compiler
-    f77_names: List[str] = ["ifx"]
-
     # Named wrapper links within build_env_path
     # Due to the challenges of supporting compiler wrappers
     # in Windows, we leave these blank, and dynamically compute

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -117,9 +117,6 @@ def get_valid_fortran_pth():
 
 
 class Msvc(Compiler):
-    # Subclasses use possible names of C compiler
-    cc_names: List[str] = ["cl"]
-
     # Subclasses use possible names of C++ compiler
     cxx_names: List[str] = ["cl"]
 

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -381,7 +381,3 @@ class Msvc(Compiler):
             )
         clp = spack.util.executable.which_string("cl", path=sps)
         return cls.default_version(clp) if clp else fc_ver
-
-    @classmethod
-    def f77_version(cls, f77):
-        return cls.fc_version(f77)

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -120,9 +120,6 @@ class Msvc(Compiler):
     # Subclasses use possible names of Fortran 77 compiler
     f77_names: List[str] = ["ifx"]
 
-    # Subclasses use possible names of Fortran 90 compiler
-    fc_names: List[str] = ["ifx"]
-
     # Named wrapper links within build_env_path
     # Due to the challenges of supporting compiler wrappers
     # in Windows, we leave these blank, and dynamically compute

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -5,7 +5,6 @@
 
 import os
 import re
-from typing import List
 
 import llnl.util.lang
 
@@ -13,9 +12,6 @@ import spack.compiler
 
 
 class Nag(spack.compiler.Compiler):
-    # Subclasses use possible names of C++ compiler
-    cxx_names: List[str] = []
-
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["nagfor"]
 

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -13,9 +13,6 @@ import spack.compiler
 
 
 class Nag(spack.compiler.Compiler):
-    # Subclasses use possible names of C compiler
-    cc_names: List[str] = []
-
     # Subclasses use possible names of C++ compiler
     cxx_names: List[str] = []
 

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -12,9 +12,6 @@ import spack.compiler
 
 
 class Nag(spack.compiler.Compiler):
-    # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ["nagfor"]
-
     # Named wrapper links within build_env_path
     # Use default wrappers for C and C++, in case provided in compilers.yaml
     link_paths = {

--- a/lib/spack/spack/compilers/nag.py
+++ b/lib/spack/spack/compilers/nag.py
@@ -15,9 +15,6 @@ class Nag(spack.compiler.Compiler):
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["nagfor"]
 
-    # Subclasses use possible names of Fortran 90 compiler
-    fc_names = ["nagfor"]
-
     # Named wrapper links within build_env_path
     # Use default wrappers for C and C++, in case provided in compilers.yaml
     link_paths = {

--- a/lib/spack/spack/compilers/nvhpc.py
+++ b/lib/spack/spack/compilers/nvhpc.py
@@ -9,9 +9,6 @@ from spack.compiler import Compiler
 
 
 class Nvhpc(Compiler):
-    # Subclasses use possible names of C++ compiler
-    cxx_names = ["nvc++"]
-
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["nvfortran"]
 

--- a/lib/spack/spack/compilers/nvhpc.py
+++ b/lib/spack/spack/compilers/nvhpc.py
@@ -12,9 +12,6 @@ class Nvhpc(Compiler):
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["nvfortran"]
 
-    # Subclasses use possible names of Fortran 90 compiler
-    fc_names = ["nvfortran"]
-
     # Named wrapper links within build_env_path
     link_paths = {
         "cc": os.path.join("nvhpc", "nvc"),

--- a/lib/spack/spack/compilers/nvhpc.py
+++ b/lib/spack/spack/compilers/nvhpc.py
@@ -9,9 +9,6 @@ from spack.compiler import Compiler
 
 
 class Nvhpc(Compiler):
-    # Subclasses use possible names of C compiler
-    cc_names = ["nvc"]
-
     # Subclasses use possible names of C++ compiler
     cxx_names = ["nvc++"]
 

--- a/lib/spack/spack/compilers/nvhpc.py
+++ b/lib/spack/spack/compilers/nvhpc.py
@@ -9,9 +9,6 @@ from spack.compiler import Compiler
 
 
 class Nvhpc(Compiler):
-    # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ["nvfortran"]
-
     # Named wrapper links within build_env_path
     link_paths = {
         "cc": os.path.join("nvhpc", "nvc"),

--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -13,9 +13,6 @@ from spack.version import Version
 
 
 class Oneapi(Compiler):
-    # Subclasses use possible names of C compiler
-    cc_names = ["icx"]
-
     # Subclasses use possible names of C++ compiler
     cxx_names = ["icpx"]
 

--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -13,9 +13,6 @@ from spack.version import Version
 
 
 class Oneapi(Compiler):
-    # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ["ifx"]
-
     # Named wrapper links within build_env_path
     link_paths = {
         "cc": os.path.join("oneapi", "icx"),

--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -16,9 +16,6 @@ class Oneapi(Compiler):
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["ifx"]
 
-    # Subclasses use possible names of Fortran 90 compiler
-    fc_names = ["ifx"]
-
     # Named wrapper links within build_env_path
     link_paths = {
         "cc": os.path.join("oneapi", "icx"),

--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -13,9 +13,6 @@ from spack.version import Version
 
 
 class Oneapi(Compiler):
-    # Subclasses use possible names of C++ compiler
-    cxx_names = ["icpx"]
-
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["ifx"]
 

--- a/lib/spack/spack/compilers/pgi.py
+++ b/lib/spack/spack/compilers/pgi.py
@@ -10,9 +10,6 @@ from spack.version import Version
 
 
 class Pgi(Compiler):
-    # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ["pgfortran", "pgf77"]
-
     # Named wrapper links within build_env_path
     link_paths = {
         "cc": os.path.join("pgi", "pgcc"),

--- a/lib/spack/spack/compilers/pgi.py
+++ b/lib/spack/spack/compilers/pgi.py
@@ -13,9 +13,6 @@ class Pgi(Compiler):
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["pgfortran", "pgf77"]
 
-    # Subclasses use possible names of Fortran 90 compiler
-    fc_names = ["pgfortran", "pgf95", "pgf90"]
-
     # Named wrapper links within build_env_path
     link_paths = {
         "cc": os.path.join("pgi", "pgcc"),

--- a/lib/spack/spack/compilers/pgi.py
+++ b/lib/spack/spack/compilers/pgi.py
@@ -10,9 +10,6 @@ from spack.version import Version
 
 
 class Pgi(Compiler):
-    # Subclasses use possible names of C++ compiler
-    cxx_names = ["pgc++", "pgCC"]
-
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["pgfortran", "pgf77"]
 

--- a/lib/spack/spack/compilers/pgi.py
+++ b/lib/spack/spack/compilers/pgi.py
@@ -10,9 +10,6 @@ from spack.version import Version
 
 
 class Pgi(Compiler):
-    # Subclasses use possible names of C compiler
-    cc_names = ["pgcc"]
-
     # Subclasses use possible names of C++ compiler
     cxx_names = ["pgc++", "pgCC"]
 

--- a/lib/spack/spack/compilers/rocmcc.py
+++ b/lib/spack/spack/compilers/rocmcc.py
@@ -53,10 +53,6 @@ class Rocmcc(spack.compilers.clang.Clang):
     def fc_version(cls, fortran_compiler):
         return cls.default_version(fortran_compiler)
 
-    @classmethod
-    def f77_version(cls, f77):
-        return cls.fc_version(f77)
-
     @property
     def stdcxx_libs(self):
         return ("-lstdc++",)

--- a/lib/spack/spack/compilers/rocmcc.py
+++ b/lib/spack/spack/compilers/rocmcc.py
@@ -11,9 +11,6 @@ import spack.compilers.clang
 
 
 class Rocmcc(spack.compilers.clang.Clang):
-    # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ["amdflang"]
-
     @property
     def link_paths(self):
         link_paths = {

--- a/lib/spack/spack/compilers/rocmcc.py
+++ b/lib/spack/spack/compilers/rocmcc.py
@@ -11,9 +11,6 @@ import spack.compilers.clang
 
 
 class Rocmcc(spack.compilers.clang.Clang):
-    # Subclasses use possible names of C compiler
-    cc_names = ["amdclang"]
-
     # Subclasses use possible names of C++ compiler
     cxx_names = ["amdclang++"]
 

--- a/lib/spack/spack/compilers/rocmcc.py
+++ b/lib/spack/spack/compilers/rocmcc.py
@@ -49,10 +49,6 @@ class Rocmcc(spack.compilers.clang.Clang):
         if match:
             return ".".join(match.groups())
 
-    @classmethod
-    def fc_version(cls, fortran_compiler):
-        return cls.default_version(fortran_compiler)
-
     @property
     def stdcxx_libs(self):
         return ("-lstdc++",)

--- a/lib/spack/spack/compilers/rocmcc.py
+++ b/lib/spack/spack/compilers/rocmcc.py
@@ -11,9 +11,6 @@ import spack.compilers.clang
 
 
 class Rocmcc(spack.compilers.clang.Clang):
-    # Subclasses use possible names of C++ compiler
-    cxx_names = ["amdclang++"]
-
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["amdflang"]
 

--- a/lib/spack/spack/compilers/rocmcc.py
+++ b/lib/spack/spack/compilers/rocmcc.py
@@ -14,9 +14,6 @@ class Rocmcc(spack.compilers.clang.Clang):
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["amdflang"]
 
-    # Subclasses use possible names of Fortran 90 compiler
-    fc_names = ["amdflang"]
-
     @property
     def link_paths(self):
         link_paths = {

--- a/lib/spack/spack/compilers/xl.py
+++ b/lib/spack/spack/compilers/xl.py
@@ -13,9 +13,6 @@ class Xl(Compiler):
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["xlf"]
 
-    # Subclasses use possible names of Fortran 90 compiler
-    fc_names = ["xlf90", "xlf95", "xlf2003", "xlf2008"]
-
     # Named wrapper links within build_env_path
     link_paths = {
         "cc": os.path.join("xl", "xlc"),

--- a/lib/spack/spack/compilers/xl.py
+++ b/lib/spack/spack/compilers/xl.py
@@ -115,7 +115,3 @@ class Xl(Compiler):
         if c_version < 10:
             c_version = c_version - 0.1
         return str(c_version)
-
-    @classmethod
-    def f77_version(cls, f77):
-        return cls.fc_version(f77)

--- a/lib/spack/spack/compilers/xl.py
+++ b/lib/spack/spack/compilers/xl.py
@@ -10,9 +10,6 @@ from spack.version import Version
 
 
 class Xl(Compiler):
-    # Subclasses use possible names of C compiler
-    cc_names = ["xlc"]
-
     # Subclasses use possible names of C++ compiler
     cxx_names = ["xlC", "xlc++"]
 

--- a/lib/spack/spack/compilers/xl.py
+++ b/lib/spack/spack/compilers/xl.py
@@ -10,9 +10,6 @@ from spack.version import Version
 
 
 class Xl(Compiler):
-    # Subclasses use possible names of C++ compiler
-    cxx_names = ["xlC", "xlc++"]
-
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["xlf"]
 

--- a/lib/spack/spack/compilers/xl.py
+++ b/lib/spack/spack/compilers/xl.py
@@ -10,9 +10,6 @@ from spack.version import Version
 
 
 class Xl(Compiler):
-    # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ["xlf"]
-
     # Named wrapper links within build_env_path
     link_paths = {
         "cc": os.path.join("xl", "xlc"),

--- a/lib/spack/spack/compilers/xl.py
+++ b/lib/spack/spack/compilers/xl.py
@@ -91,27 +91,3 @@ class Xl(Compiler):
         # For Fortran 90 and beyond, it is set by default and has not impact.
         # Its use has no negative side effects.
         return "-qzerosize"
-
-    @classmethod
-    def fc_version(cls, fc):
-        # The fortran and C/C++ versions of the XL compiler are always
-        # two units apart.  By this we mean that the fortran release that
-        # goes with XL C/C++ 11.1 is 13.1.  Having such a difference in
-        # version number is confusing spack quite a lot.  Most notably
-        # if you keep the versions as is the default xl compiler will
-        # only have fortran and no C/C++.  So we associate the Fortran
-        # compiler with the version associated to the C/C++ compiler.
-        # One last stumble. Version numbers over 10 have at least a .1
-        # those under 10 a .0. There is no xlf 9.x or under currently
-        # available. BG/P and BG/L can such a compiler mix and possibly
-        # older version of AIX and linux on power.
-        fortran_version = cls.default_version(fc)
-        if fortran_version >= 16:
-            # Starting with version 16.1, the XL C and Fortran compilers
-            # have the same version.  So no need to downgrade the Fortran
-            # compiler version to match that of the C compiler version.
-            return str(fortran_version)
-        c_version = float(fortran_version) - 2
-        if c_version < 10:
-            c_version = c_version - 0.1
-        return str(c_version)

--- a/lib/spack/spack/compilers/xl_r.py
+++ b/lib/spack/spack/compilers/xl_r.py
@@ -9,9 +9,6 @@ import spack.compilers.xl
 
 
 class XlR(spack.compilers.xl.Xl):
-    # Subclasses use possible names of C++ compiler
-    cxx_names = ["xlC_r", "xlc++_r"]
-
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["xlf_r"]
 

--- a/lib/spack/spack/compilers/xl_r.py
+++ b/lib/spack/spack/compilers/xl_r.py
@@ -12,9 +12,6 @@ class XlR(spack.compilers.xl.Xl):
     # Subclasses use possible names of Fortran 77 compiler
     f77_names = ["xlf_r"]
 
-    # Subclasses use possible names of Fortran 90 compiler
-    fc_names = ["xlf90_r", "xlf95_r", "xlf2003_r", "xlf2008_r"]
-
     # Named wrapper links within build_env_path
     link_paths = {
         "cc": os.path.join("xl_r", "xlc_r"),

--- a/lib/spack/spack/compilers/xl_r.py
+++ b/lib/spack/spack/compilers/xl_r.py
@@ -9,9 +9,6 @@ import spack.compilers.xl
 
 
 class XlR(spack.compilers.xl.Xl):
-    # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ["xlf_r"]
-
     # Named wrapper links within build_env_path
     link_paths = {
         "cc": os.path.join("xl_r", "xlc_r"),

--- a/lib/spack/spack/compilers/xl_r.py
+++ b/lib/spack/spack/compilers/xl_r.py
@@ -9,9 +9,6 @@ import spack.compilers.xl
 
 
 class XlR(spack.compilers.xl.Xl):
-    # Subclasses use possible names of C compiler
-    cc_names = ["xlc_r"]
-
     # Subclasses use possible names of C++ compiler
     cxx_names = ["xlC_r", "xlc++_r"]
 

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -130,6 +130,7 @@ def test_arch_spec_container_semantic(item, architecture_str):
     ],
 )
 @pytest.mark.filterwarnings("ignore:microarchitecture specific")
+@pytest.mark.not_on_windows("Windows doesn't support the compiler wrapper")
 def test_optimization_flags(compiler_spec, target_name, expected_flags, compiler_factory):
     target = spack.target.Target(target_name)
     compiler_dict = compiler_factory(spec=compiler_spec, operating_system="")["compiler"]

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -589,6 +589,7 @@ def test_xl_r_flags():
     "compiler_spec,expected_result",
     [("gcc@4.7.2", False), ("clang@3.3", False), ("clang@8.0.0", True)],
 )
+@pytest.mark.not_on_windows("GCC and LLVM currently not supported on the platform")
 def test_detecting_mixed_toolchains(
     compiler_spec, expected_result, mutable_config, compiler_factory
 ):

--- a/var/spack/repos/builtin/packages/molgw/package.py
+++ b/var/spack/repos/builtin/packages/molgw/package.py
@@ -101,7 +101,7 @@ class Molgw(MakefilePackage):
         if "+scalapack" in spec:
             flags["FC"] = "{0}".format(spec["mpi"].mpifc)
         else:
-            flags["FC"] = self.compiler.fc_names[0]
+            flags["FC"] = self.compiler.fc
 
         # Set FCFLAGS
         if self.compiler.flags.get("fflags") is not None:


### PR DESCRIPTION
#45784 unified the search mechanism of `spack compiler find` and `spack external find`. This PR removes attributes from `Compiler` classes that were mainly used in the old search mechanism.

**Prerequisites**

- [x] #46037
- [x] #46038

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
