### PR TITLE
nekrs: add v23.0, add new build system

### DIFF
--- a/var/spack/repos/builtin/packages/nekrs/package.py
+++ b/var/spack/repos/builtin/packages/nekrs/package.py
@@ -8,13 +8,14 @@ import os
 from spack.package import *
 
 
-class Nekrs(Package, CudaPackage, ROCmPackage):
+class Nekrs(Package, CMakePackage, CudaPackage, ROCmPackage):
     """nekRS is an open-source Navier Stokes solver based on the spectral
     element method targeting classical processors and hardware accelerators
     like GPUs"""
 
     homepage = "https://github.com/Nek5000/nekRS"
     git = "https://github.com/Nek5000/nekRS.git"
+    url = "https://github.com/Nek5000/nekRS/archive/refs/tags/v23.0.tar.gz"
 
     tags = [
         "cfd",
@@ -32,6 +33,11 @@ class Nekrs(Package, CudaPackage, ROCmPackage):
 
     license("BSD-3-Clause")
 
+    build_system(
+        conditional("cmake", when="@23.0:"), conditional("generic", when="@=21.0"), default="cmake"
+    )
+
+    version("23.0", sha256="2cb4ded69551b9614036e1a9d5ac54c8535826eae8f8b6a00ddb89043b2c392a")
     version("21.0", tag="v21.0", commit="bcd890bf3f9fb4d91224c83aeda75c33570f1eaa")
 
     depends_on("c", type="build")  # generated
@@ -52,17 +58,35 @@ class Nekrs(Package, CudaPackage, ROCmPackage):
     depends_on("git")
     depends_on("cmake")
 
-    @run_before("install")
-    def fortran_check(self):
-        if not self.compiler.f77:
-            msg = "Cannot build NekRS without a Fortran 77 compiler."
-            raise RuntimeError(msg)
+    def patch(self):
+        with working_dir("scripts"):
+            # Make sure nekmpi wrapper uses srun when we know OpenMPI
+            # is not built with mpiexec
+            if self.spec.satisfies("^openmpi~legacylaunchers"):
+                filter_file(r"mpirun -np", "srun -n", "nrsmpi")
+                filter_file(r"mpirun -np", "srun -n", "nrspre")
+                filter_file(r"mpirun -np", "srun -n", "nrsbmpi")
 
-    # Following 4 methods are stolen from OCCA since we are using OCCA
-    # shipped with nekRS.
+    def setup_run_environment(self, env):
+        # The 'env' is included in the Spack generated module files.
+        spec = self.spec
+        env.set("OCCA_CXX", self.compiler.cxx)
+
+        cxxflags = spec.compiler_flags["cxxflags"]
+        if cxxflags:
+            # Run-time compiler flags:
+            env.set("OCCA_CXXFLAGS", " ".join(cxxflags))
+
+        if "+cuda" in spec:
+            cuda_dir = spec["cuda"].prefix
+            # Run-time CUDA compiler:
+            env.set("OCCA_CUDA_COMPILER", join_path(cuda_dir, "bin", "nvcc"))
+
+
+class SetupEnvironment:
     def _setup_runtime_flags(self, s_env):
         spec = self.spec
-        s_env.set("OCCA_CXX", self.compiler.cxx)
+        s_env.set("OCCA_CXX", self.pkg.compiler.cxx)
 
         cxxflags = spec.compiler_flags["cxxflags"]
         if cxxflags:
@@ -111,26 +135,14 @@ class Nekrs(Package, CudaPackage, ROCmPackage):
         env.set("OCCA_VERBOSE", "1")
         self._setup_runtime_flags(env)
 
-    def setup_run_environment(self, env):
-        # The 'env' is included in the Spack generated module files.
-        self._setup_runtime_flags(env)
-
     def setup_dependent_build_environment(self, env, dependent_spec):
         # Export OCCA_* variables for everyone using this package from within
         # Spack.
         self._setup_runtime_flags(env)
 
-    def install(self, spec, prefix):
-        script_dir = "scripts"
 
-        with working_dir(script_dir):
-            # Make sure nekmpi wrapper uses srun when we know OpenMPI
-            # is not built with mpiexec
-            if "^openmpi~legacylaunchers" in spec:
-                filter_file(r"mpirun -np", "srun -n", "nrsmpi")
-                filter_file(r"mpirun -np", "srun -n", "nrspre")
-                filter_file(r"mpirun -np", "srun -n", "nrsbmpi")
-
+class GenericBuilder(spack.build_systems.generic.GenericBuilder):
+    def install(self, pkg, spec, prefix):
         makenrs = Executable(os.path.join(os.getcwd(), "makenrs"))
 
         makenrs.add_default_env("NEKRS_INSTALL_DIR", prefix)
@@ -140,3 +152,17 @@ class Nekrs(Package, CudaPackage, ROCmPackage):
         makenrs.add_default_env("TRAVIS", "true")
 
         makenrs(output=str, error=str, fail_on_error=True)
+
+
+class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+    def cmake_args(self):
+        cxxflags = self.spec.compiler_flags["cxxflags"]
+        args = [
+            self.define("CMAKE_CXX_COMPILER", self.spec["mpi"].mpicxx),
+            self.define("NEKRS_COMPILER_FLAGS", cxxflags),
+            self.define("OCCA_CXXFLAGS", cxxflags),
+            self.define_from_variant("ENABLE_CUDA", "cuda"),
+            self.define_from_variant("ENABLE_OPENCL", "opencl"),
+            self.define_from_variant("ENABLE_HIP", "rocm"),
+        ]
+        return args

--- a/var/spack/repos/builtin/packages/nekrs/package.py
+++ b/var/spack/repos/builtin/packages/nekrs/package.py
@@ -5,6 +5,8 @@
 
 import os
 
+import spack.build_systems.cmake
+import spack.build_systems.generic
 from spack.package import *
 
 


### PR DESCRIPTION
They've switched to cmake.

I'm not actually able to successfully test the old version as it won't even compile for me with the original package recipe, but I believe we should be in the same place there with this change.