### PR TITLE
r-diagram: fix dependency on non-existent R version

### DIFF
--- a/var/spack/repos/builtin/packages/r-diagram/package.py
+++ b/var/spack/repos/builtin/packages/r-diagram/package.py
@@ -24,5 +24,5 @@ class RDiagram(RPackage):
 
     version("1.6.5", sha256="e9c03e7712e0282c5d9f2b760bafe2aac9e99a9723578d9e6369d60301f574e4")
 
-    depends_on("r@2.01:", type=("build", "run"))
+    depends_on("r@2.1:", type=("build", "run"))
     depends_on("r-shape", type=("build", "run"))


### PR DESCRIPTION
This PR fixes an issue where `r-prodlim` causes `Cannot satisfy 'r@4.0.0:' and 'r@2.01:` because the version `r@2.01:` follows a different versioning scheme. Since the R version 2.01 is [not something that exists](https://cran.r-project.org/src/base/R-2/) and is not included in Spack, this PR modifies the dependency to apply when `@2.1:`.

Note: the package `diagram` on CRAN does refer to `>= 2.01` in its `DESCRIPTION` file, https://cran.r-project.org/web/packages/diagram/index.html.