### PR TITLE
rapidjson: 1.2.0-2024-08-16 and fix for gcc14

### DIFF
--- a/var/spack/repos/builtin/packages/rapidjson/no_march-1.2-2024.patch
+++ b/var/spack/repos/builtin/packages/rapidjson/no_march-1.2-2024.patch
@@ -1,0 +1,38 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1b3a79de..2d165f45 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -70,15 +70,7 @@ endif(CCACHE_FOUND)
+ find_program(VALGRIND_FOUND valgrind)
+ 
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+-    if(RAPIDJSON_ENABLE_INSTRUMENTATION_OPT AND NOT CMAKE_CROSSCOMPILING)
+-        if(CMAKE_SYSTEM_PROCESSOR STREQUAL "powerpc" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le")
+-          set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=native")
+-        else()
+-          #FIXME: x86 is -march=native, but doesn't mean every arch is this option. To keep original project's compatibility, I leave this except POWER.
+-          set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+-        endif()
+-    endif()
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+     set(EXTRA_CXX_FLAGS -Weffc++ -Wswitch-default -Wfloat-equal -Wconversion -Wsign-conversion)
+     if (RAPIDJSON_BUILD_CXX11 AND CMAKE_VERSION VERSION_LESS 3.1)
+         if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7.0")
+@@ -106,15 +98,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+         endif()
+     endif()
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-    if(NOT CMAKE_CROSSCOMPILING)
+-      if(CMAKE_SYSTEM_PROCESSOR STREQUAL "powerpc" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le")
+-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=native")
+-      else()
+-        #FIXME: x86 is -march=native, but doesn't mean every arch is this option. To keep original project's compatibility, I leave this except POWER.
+-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+-      endif()
+-    endif()
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Wno-missing-field-initializers")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-missing-field-initializers")
+     set(EXTRA_CXX_FLAGS -Weffc++ -Wswitch-default -Wfloat-equal -Wconversion -Wimplicit-fallthrough)
+     if (RAPIDJSON_BUILD_CXX11 AND CMAKE_VERSION VERSION_LESS 3.1)
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")

--- a/var/spack/repos/builtin/packages/rapidjson/package.py
+++ b/var/spack/repos/builtin/packages/rapidjson/package.py
@@ -15,6 +15,7 @@ class Rapidjson(CMakePackage):
 
     license("MIT")
 
+    version("1.2.0-2024-08-16", commit="7c73dd7de7c4f14379b781418c6e947ad464c818")
     version("1.2.0-2022-03-09", commit="8261c1ddf43f10de00fd8c9a67811d1486b2c784")
     version("1.2.0-2021-08-13", commit="00dbcf2c6e03c47d6c399338b6de060c71356464")
     version("1.1.0", sha256="bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e")
@@ -31,9 +32,12 @@ class Rapidjson(CMakePackage):
     # -march=native causes issues on ARM, with older GCC, and with Fujitsu
     # Spack injects the appropriate optimization flags anyway
     # https://github.com/Tencent/rapidjson/issues/1816
-    patch("no_march-1.2.patch", when="@1.2")
+    patch("no_march-1.2-2024.patch", when="@1.2.0-2024-08-16:")
+    patch("no_march-1.2.patch", when="@1.2:1.2.0-2022-03-09")
     patch("no_march-1.1.patch", when="@1.1")
     patch("no_march-1.0.patch", when="@1.0")
+
+    conflicts("%gcc@14", when="@:1.2.0-2022-03-09")
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION
This updates rapidjson to the latest version in github which contains fixes
to allow for compile with gcc14