### PR TITLE
r-sf: deprecate unconcretizable 0.5-5

### DIFF
--- a/var/spack/repos/builtin/packages/r-sf/package.py
+++ b/var/spack/repos/builtin/packages/r-sf/package.py
@@ -27,7 +27,9 @@ class RSf(RPackage):
     version("0.9-7", sha256="4acac2f78badf9d252da5bf377975f984927c14a56a72d9f83d285c0adadae9c")
     version("0.7-7", sha256="d1780cb46a285b30c7cc41cae30af523fbc883733344e53f7291e2d045e150a4")
     version("0.7-5", sha256="53ed0567f502216a116c4848f5a9262ca232810f82642df7b98e0541a2524868")
-    version("0.5-5", sha256="82ad31f98243b6982302fe245ee6e0d8d0546e5ff213ccc00ec3025dfec62229")
+    with default_args(deprecated=True):
+        # deprecated @:0.7-3 as gdal@:2 is deprecated, and gdal@3: requires proj@6:
+        version("0.5-5", sha256="82ad31f98243b6982302fe245ee6e0d8d0546e5ff213ccc00ec3025dfec62229")
 
     depends_on("r@3.3.0:", type=("build", "run"))
     depends_on("r-classint@0.2-1:", type=("build", "run"))


### PR DESCRIPTION
`r-sf` is not concretizable and fails with:
```
root@codespaces-2f6b79:/workspaces/spack# spack spec --fresh r-sf@=0.5-5
==> Error: failed to concretize `r-sf@=0.5-5` for the following reasons:
     1. Cannot select a single "version" for package "proj"
     2. Cannot satisfy 'proj@:5'
     3. Cannot satisfy 'proj@6:'
     4. Cannot satisfy 'proj@5'
     5. Cannot satisfy 'proj@4.8.0:5'
     6. Cannot satisfy 'proj@6:'
        required because libgeotiff depends on proj@6: when @1.5:+proj 
          required because gdal depends on libgeotiff@1.5: when @3: 
            required because r-sf depends on gdal@2.0.1: 
              required because r-sf@=0.5-5 requested explicitly 
```
(etc to `14.`)

The reason is that `gdal@:2` is deprecated, and `gdal@3:` requires `proj@6:` which is explictly excluded for `r-sf@:0.7-3`.

This PR deprecates `r-sf@=0.5-5`.