### PR TITLE
Fix missing string_view include in ROOT v6.22.08

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -108,6 +108,12 @@ class Root(CMakePackage):
     # 6.16.00 fails to handle particular build option combinations, _cf_
     # https://github.com/root-project/ROOT/commit/e0ae0483985d90a71a6cabd10d3622dfd1c15611.
     patch("root7-webgui.patch", level=1, when="@6.16.00")
+    # Missing includes in libcpp_string_view.h
+    patch(
+        "https://github.com/root-project/root/pull/8289.patch?full_index=1",
+        sha256="5d91d78bcecd4fdbce9c829554a563234a9cb99eaf91dbc14fb85c3de33bac34",
+        when="@6.22:6.22.08",
+    )
     # 6.26.00:6.26.06 can fail with empty string COMPILE_DEFINITIONS, which this patch
     # protects against
     patch(


### PR DESCRIPTION
Patch root v6.22.08 per https://github.com/root-project/root/pull/8289. A header is missing in the string_view header file, causing compile to fail on C++11. 

This patch is required to build ROOT v6.22.08 on Ubuntu 22.04.