### PR TITLE
mrbayes: readline and mpi variants are mutually exclusive

### DIFF
--- a/var/spack/repos/builtin/packages/mrbayes/package.py
+++ b/var/spack/repos/builtin/packages/mrbayes/package.py
@@ -28,6 +28,8 @@ class Mrbayes(AutotoolsPackage):
         "readline", default=False, description="Enable readline library, not recommended with MPI"
     )
 
+    conflicts("+readline", when="+mpi", msg="MPI and readline support are exclusive")
+
     depends_on("libbeagle", when="+beagle")
     depends_on("mpi", when="+mpi")
     depends_on("readline", when="+readline")


### PR DESCRIPTION
MRBayes [INSTALL](https://github.com/NBISweden/MrBayes/blob/develop/INSTALL) states:

However, it seems as if the Readline library doesn't work well together with common MPI implementations, such as OpenMPI (https://www.open-mpi.org/) and MPICH (https://www.mpich.org/), so if MrBayes is configured with support for MPI parallelization, Readline support will be automatically disabled.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
