### PR TITLE
R: external detection

### DIFF
--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -20,6 +20,8 @@ class R(AutotoolsPackage):
 
     extendable = True
 
+    executables = ["^R$"]
+
     license("GPL-2.0-or-later")
 
     version("4.4.1", sha256="b4cb675deaaeb7299d3b265d218cde43f192951ce5b89b7bb1a5148a36b2d94d")
@@ -126,6 +128,24 @@ class R(AutotoolsPackage):
     )
 
     build_directory = "spack-build"
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("--version", output=str, error=str)
+        # R version 4.3.3 (2024-02-29) -- "Angel Food Cake"
+        match = re.search(r"^R version ([^\s]+)", output)
+        return match.group(1) if match else None
+    
+    @classmethod
+    def determine_variants(cls, exes, version):
+        variants = []
+        for exe in exes:
+            output = Executable(exe)("CMD", "config", "--all", output=str, error=str)
+    
+            if "-lX11" in output:
+                variants.append("+X")
+    
+        return variants
 
     # R custom URL version
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -135,16 +135,16 @@ class R(AutotoolsPackage):
         # R version 4.3.3 (2024-02-29) -- "Angel Food Cake"
         match = re.search(r"^R version ([^\s]+)", output)
         return match.group(1) if match else None
-    
+
     @classmethod
     def determine_variants(cls, exes, version):
         variants = []
         for exe in exes:
             output = Executable(exe)("CMD", "config", "--all", output=str, error=str)
-    
+
             if "-lX11" in output:
                 variants.append("+X")
-    
+
         return variants
 
     # R custom URL version


### PR DESCRIPTION
This PR adds external detection of R, based on the (capital) `R` executable. Version info is obtained from `R --version` based on `^R version ([^\s]+)`, and variant info from `R CMD config --all` and looking for a X11 linking option.

Test (ubuntu 24.04 with `r-base` installed):
```console
$ spack -d external find r
<snip>
==> [2024-08-25-11:28:45.422475] Reading config from file /home/wdconinc/git/spack/etc/spack/packages.yaml
==> [2024-08-25-11:28:45.585228] '/usr/bin/R' '--version'
==> [2024-08-25-11:28:45.592158] '/usr/bin/R' 'CMD' 'config' '--all'
==> [2024-08-25-11:28:45.858781] The following specs have been detected on this system and added to /home/wdconinc/git/spack/var/spack/environments/default/spack.yaml
r@4.3.3
```
which correctly detects
```yaml
spack:
  packages:
    r:
      externals:
      - spec: r@4.3.3+X
        prefix: /usr
```