### PR TITLE
package_base: sort deprecated versions later in `preferred_version`

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -119,8 +119,14 @@ def preferred_version(pkg: "PackageBase"):
     """
     # Here we sort first on the fact that a version is marked
     # as preferred in the package, then on the fact that the
+    # version is not deprecated, then on the fact that the
     # version is not develop, then lexicographically
-    key_fn = lambda v: (pkg.versions[v].get("preferred", False), not v.isdevelop(), v)
+    key_fn = lambda v: (
+        pkg.versions[v].get("preferred", False),
+        not pkg.versions[v].get("deprecated", False),
+        not v.isdevelop(),
+        v,
+    )
     return max(pkg.versions, key=key_fn)
 
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -66,6 +66,7 @@ from spack.install_test import (
     install_test_root,
 )
 from spack.installer import InstallError, PackageInstaller
+from spack.solver.asp import concretization_version_order
 from spack.stage import DevelopStage, ResourceStage, Stage, StageComposite, compute_stage_name
 from spack.util.executable import ProcessError, which
 from spack.util.package_hash import package_hash
@@ -117,17 +118,8 @@ def preferred_version(pkg: "PackageBase"):
     Arguments:
         pkg: The package whose versions are to be assessed.
     """
-    # Here we sort first on the fact that a version is marked
-    # as preferred in the package, then on the fact that the
-    # version is not deprecated, then on the fact that the
-    # version is not develop, then lexicographically
-    key_fn = lambda v: (
-        pkg.versions[v].get("preferred", False),
-        not pkg.versions[v].get("deprecated", False),
-        not v.isdevelop(),
-        v,
-    )
-    return max(pkg.versions, key=key_fn)
+    version, _ = max(pkg.versions.items(), key=concretization_version_order)
+    return version
 
 
 class WindowsRPath:

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -66,7 +66,6 @@ from spack.install_test import (
     install_test_root,
 )
 from spack.installer import InstallError, PackageInstaller
-from spack.solver.asp import concretization_version_order
 from spack.stage import DevelopStage, ResourceStage, Stage, StageComposite, compute_stage_name
 from spack.util.executable import ProcessError, which
 from spack.util.package_hash import package_hash
@@ -118,6 +117,8 @@ def preferred_version(pkg: "PackageBase"):
     Arguments:
         pkg: The package whose versions are to be assessed.
     """
+    from spack.solver.asp import concretization_version_order
+
     version, _ = max(pkg.versions.items(), key=concretization_version_order)
     return version
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -348,20 +348,6 @@ def check_packages_exist(specs):
                 raise spack.repo.UnknownPackageError(str(s.fullname))
 
 
-def concretization_version_order(version_info: Tuple[GitOrStandardVersion, dict]):
-    """Version order key for concretization, where preferred > not preferred,
-    not deprecated > deprecated, finite > any infinite component; only if all are
-    the same, do we use default version ordering."""
-    version, info = version_info
-    return (
-        info.get("preferred", False),
-        not info.get("deprecated", False),
-        not version.isdevelop(),
-        not version.is_prerelease(),
-        version,
-    )
-
-
 class Result:
     """Result of an ASP solve."""
 
@@ -591,6 +577,20 @@ def _is_checksummed_version(version_info: Tuple[GitOrStandardVersion, dict]):
             return True
         return "commit" in info and len(info["commit"]) == 40
     return _is_checksummed_git_version(version)
+
+
+def concretization_version_order(version_info: Tuple[GitOrStandardVersion, dict]):
+    """Version order key for concretization, where preferred > not preferred,
+    not deprecated > deprecated, finite > any infinite component; only if all are
+    the same, do we use default version ordering."""
+    version, info = version_info
+    return (
+        info.get("preferred", False),
+        not info.get("deprecated", False),
+        not version.isdevelop(),
+        not version.is_prerelease(),
+        version,
+    )
 
 
 def _spec_with_default_name(spec_str, name):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2959,7 +2959,7 @@ def test_concretization_version_order():
     result = [
         v
         for v, _ in sorted(
-            versions, key=spack.solver.asp._concretization_version_order, reverse=True
+            versions, key=spack.solver.asp.concretization_version_order, reverse=True
         )
     ]
     assert result == [


### PR DESCRIPTION
We currently have for `spack info ants` a deprecated version that is the preferred version:
```
Preferred version:  
    20220205    [git] https://github.com/ANTsX/ANTs.git at commit 6f07ac55569d0d085d2adf7888d1c7a2bd563bfe

Safe versions:  
    2.5.1       https://github.com/ANTsX/ANTs/archive/v2.5.1.tar.gz
    2.4.3       https://github.com/ANTsX/ANTs/archive/v2.4.3.tar.gz
    2.4.0       https://github.com/ANTsX/ANTs/archive/v2.4.0.tar.gz
    2.3.5       https://github.com/ANTsX/ANTs/archive/v2.3.5.tar.gz
    2.2.0       https://github.com/ANTsX/ANTs/archive/v2.2.0.tar.gz

Deprecated versions:  
    20220205    [git] https://github.com/ANTsX/ANTs.git at commit 6f07ac55569d0d085d2adf7888d1c7a2bd563bfe
```

This PR sorts deprecated versions further down the list in the `preferred_version` call.

With this PR we get:
```
Preferred version:  
    2.5.1       https://github.com/ANTsX/ANTs/archive/v2.5.1.tar.gz

Safe versions:  
    2.5.1       https://github.com/ANTsX/ANTs/archive/v2.5.1.tar.gz
    2.4.3       https://github.com/ANTsX/ANTs/archive/v2.4.3.tar.gz
    2.4.0       https://github.com/ANTsX/ANTs/archive/v2.4.0.tar.gz
    2.3.5       https://github.com/ANTsX/ANTs/archive/v2.3.5.tar.gz
    2.2.0       https://github.com/ANTsX/ANTs/archive/v2.2.0.tar.gz

Deprecated versions:  
    20220205    [git] https://github.com/ANTsX/ANTs.git at commit 6f07ac55569d0d085d2adf7888d1c7a2bd563bfe
```