### PR TITLE
cppunit: add v1.15.1; deprecate custom commit version

### DIFF
--- a/var/spack/repos/builtin/packages/cppunit/package.py
+++ b/var/spack/repos/builtin/packages/cppunit/package.py
@@ -16,18 +16,16 @@ class Cppunit(AutotoolsPackage):
     license("LGPL-2.1-or-later")
 
     version("master", branch="master")
-    version("1.15_20220904", commit="78e64f0edb4f3271a6ddbcdf9cba05138597bfca")
-    version(
-        "1.14.0",
-        sha256="3d569869d27b48860210c758c4f313082103a5e58219a7669b52bfd29d674780",
-        preferred=True,
-    )
+    version("1.15.1", sha256="89c5c6665337f56fd2db36bc3805a5619709d51fb136e51937072f63fcc717a7")
+    version("1.15_20220904", commit="78e64f0edb4f3271a6ddbcdf9cba05138597bfca", deprecated=True)
+    version("1.14.0", sha256="3d569869d27b48860210c758c4f313082103a5e58219a7669b52bfd29d674780")
     version("1.13.2", sha256="3f47d246e3346f2ba4d7c9e882db3ad9ebd3fcbd2e8b732f946e0e3eeb9f429f")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     # https://github.com/cms-sw/cmsdist/blob/IB/CMSSW_12_6_X/master/cppunit-1.14-defaulted-function-deleted.patch
-    patch("cppunit-1.14-defaulted-function-deleted.patch", when="@1.15:")
+    # https://cgit.freedesktop.org/libreoffice/cppunit/commit/?h=cppunit-1.15.1&id=834f3a287387bd6230c98b0c5375aff568c75e02
+    patch("cppunit-1.14-defaulted-function-deleted.patch", when="@1.15_20220904")
 
     variant(
         "cxxstd",
@@ -45,9 +43,9 @@ class Cppunit(AutotoolsPackage):
         description="Build shared libs, static libs or both",
     )
 
-    depends_on("autoconf", type="build", when="@1.15_20220904")
-    depends_on("automake", type="build", when="@1.15_20220904")
-    depends_on("libtool", type="build", when="@1.15_20220904")
+    depends_on("autoconf", type="build", when="@master,1.15_20220904")
+    depends_on("automake", type="build", when="@master,1.15_20220904")
+    depends_on("libtool", type="build", when="@master,1.15_20220904")
 
     def setup_build_environment(self, env):
         cxxstd = self.spec.variants["cxxstd"].value


### PR DESCRIPTION
This PR adds `cppunit` v1.15.1. Only bug fixes, including one that means the patch for the previous version is not needed anymore. This PR also removes the preferred status for 1.14, and deprecates the custom commit which uses a problematic version number that otherwise ranks before v1.15.1. Finally, this PR ensures that the master version also gets autoconf build dependencies.

Test build:
```
==> cppunit: Executing phase: 'install'
==> cppunit: Successfully installed cppunit-1.15.1-hrn4trc6lzwlayfzea3izncraozngr35
  Stage: 0.16s.  Autoreconf: 0.00s.  Configure: 24.74s.  Build: 42.38s.  Install: 1.94s.  Post-install: 0.57s.  Total: 1m 9.95s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/cppunit-1.15.1-hrn4trc6lzwlayfzea3izncraozngr35
```