### PR TITLE
netfilter pkgs: avoid 3rd party urls, add latest official version

### DIFF
--- a/var/spack/repos/builtin/packages/libmnl/package.py
+++ b/var/spack/repos/builtin/packages/libmnl/package.py
@@ -8,19 +8,35 @@ from spack.package import *
 
 class Libmnl(AutotoolsPackage):
     """libmnl is a minimalistic user-space library oriented to Netlink
-    developers.There are a lot of common tasks in parsing, validating,
+    developers. There are a lot of common tasks in parsing, validating,
     constructing of both the Netlink header and TLVs that are repetitive
-    and easy to get wrong.This library aims to provide simple helpers
+    and easy to get wrong. This library aims to provide simple helpers
     that allows you to re-use code and to avoid re-inventing the wheel."""
 
-    homepage = "https://github.com/threatstack/libmnl"
-    url = "https://github.com/threatstack/libmnl/archive/libmnl-1.0.3.tar.gz"
+    homepage = "https://netfilter.org/projects/libmnl/"
+    url = "https://netfilter.org/projects/libmnl/files/libmnl-1.0.5.tar.bz2"
 
-    license("LGPL-2.1-or-later")
+    license("LGPL-2.1-or-later", checked_by="wdconinc")
 
-    version("1.0.3", sha256="14405da1bb3a679c24e0fe1f2845d47359ed2de8055e588df4b6b19cab68e901")
-    version("1.0.2", sha256="2caec4716aceb245130f4e42f8c118b92618e37db8bb94e2799aff42b95c269f")
-    version("1.0.1", sha256="60fe2a6ce59f6118b75b598dc11fc89b97e20ff8633fbea26fc568c45bbb672b")
+    version("1.0.5", sha256="274b9b919ef3152bfb3da3a13c950dd60d6e2bcd54230ffeca298d03b40d0525")
+
+    # Versions that were initially sourced at a third party are now deprecated
+    with default_args(deprecated=True):
+        version(
+            "1.0.3",
+            sha256="14405da1bb3a679c24e0fe1f2845d47359ed2de8055e588df4b6b19cab68e901",
+            url="https://github.com/threatstack/libmnl/archive/libmnl-1.0.3.tar.gz",
+        )
+        version(
+            "1.0.2",
+            sha256="2caec4716aceb245130f4e42f8c118b92618e37db8bb94e2799aff42b95c269f",
+            url="https://github.com/threatstack/libmnl/archive/libmnl-1.0.2.tar.gz",
+        )
+        version(
+            "1.0.1",
+            sha256="60fe2a6ce59f6118b75b598dc11fc89b97e20ff8633fbea26fc568c45bbb672b",
+            url="https://github.com/threatstack/libmnl/archive/libmnl-1.0.1.tar.gz",
+        )
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")

--- a/var/spack/repos/builtin/packages/libnetfilter-conntrack/package.py
+++ b/var/spack/repos/builtin/packages/libnetfilter-conntrack/package.py
@@ -10,14 +10,34 @@ class LibnetfilterConntrack(AutotoolsPackage):
     """libnetfilter_conntrack is a userspace library providing a programming
     interface (API) to the in-kernel connection tracking state table."""
 
-    homepage = "https://netfilter.org"
-    url = "https://github.com/Distrotech/libnetfilter_conntrack/archive/libnetfilter_conntrack-1.0.4.tar.gz"
+    homepage = "https://netfilter.org/projects/libnetfilter_conntrack/"
+    url = "https://www.netfilter.org/projects/libnetfilter_conntrack/files/libnetfilter_conntrack-1.0.5.tar.bz2"
 
-    license("GPL-2.0-or-later")
+    license("GPL-2.0-or-later", checked_by="wdconinc")
 
-    version("1.0.4", sha256="68168697b9d6430b7797ddd579e13a2cef06ea15c154dfd14e18be64e035ea6e")
-    version("1.0.3", sha256="e2129d7c0346c7140355d643da8e3409cbd755689ea889bc0d6dbd557f1b5671")
-    version("1.0.2", sha256="97f641a2e47053bd87bc817292519d6661e8f84a22d3314724b83b9f5eaddbff")
+    version("1.0.9", sha256="67bd9df49fe34e8b82144f6dfb93b320f384a8ea59727e92ff8d18b5f4b579a8")
+    version("1.0.8", sha256="0cd13be008923528687af6c6b860f35392d49251c04ee0648282d36b1faec1cf")
+    version("1.0.7", sha256="33685351e29dff93cc21f5344b6e628e41e32b9f9e567f4bec0478eb41f989b6")
+    version("1.0.6", sha256="efcc08021284e75f4d96d3581c5155a11f08fd63316b1938cbcb269c87f37feb")
+    version("1.0.5", sha256="fc9d7daf43605a73045de203bbfc0bca3e07f72d4ac61bcf656868f48692d73a")
+
+    # Versions that were initially sourced at a third party are now deprecated
+    with default_args(deprecated=True):
+        version(
+            "1.0.4",
+            sha256="68168697b9d6430b7797ddd579e13a2cef06ea15c154dfd14e18be64e035ea6e",
+            url="https://github.com/Distrotech/libnetfilter_conntrack/archive/libnetfilter_conntrack-1.0.4.tar.gz",
+        )
+        version(
+            "1.0.3",
+            sha256="e2129d7c0346c7140355d643da8e3409cbd755689ea889bc0d6dbd557f1b5671",
+            url="https://github.com/Distrotech/libnetfilter_conntrack/archive/libnetfilter_conntrack-1.0.3.tar.gz",
+        )
+        version(
+            "1.0.2",
+            sha256="97f641a2e47053bd87bc817292519d6661e8f84a22d3314724b83b9f5eaddbff",
+            url="https://github.com/Distrotech/libnetfilter_conntrack/archive/libnetfilter_conntrack-1.0.2.tar.gz",
+        )
 
     depends_on("c", type="build")  # generated
 
@@ -26,5 +46,6 @@ class LibnetfilterConntrack(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
     depends_on("pkgconfig", type="build")
+
     depends_on("libmnl@1.0.3:")
     depends_on("libnfnetlink@1.0.0:")

--- a/var/spack/repos/builtin/packages/libnetfilter-conntrack/package.py
+++ b/var/spack/repos/builtin/packages/libnetfilter-conntrack/package.py
@@ -10,14 +10,35 @@ class LibnetfilterConntrack(AutotoolsPackage):
     """libnetfilter_conntrack is a userspace library providing a programming
     interface (API) to the in-kernel connection tracking state table."""
 
-    homepage = "https://netfilter.org"
-    url = "https://github.com/Distrotech/libnetfilter_conntrack/archive/libnetfilter_conntrack-1.0.4.tar.gz"
+    homepage = "https://netfilter.org/projects/libnetfilter_conntrack/"
+    url = "https://www.netfilter.org/projects/libnetfilter_conntrack/files/libnetfilter_conntrack-1.0.5.tar.bz2"
 
-    license("GPL-2.0-or-later")
+    license("GPL-2.0-only", when="@:0.9.0", checked_by="wdconinc")
+    license("GPL-2.0-or-later", when="@0.9.1:", checked_by="wdconinc")
 
-    version("1.0.4", sha256="68168697b9d6430b7797ddd579e13a2cef06ea15c154dfd14e18be64e035ea6e")
-    version("1.0.3", sha256="e2129d7c0346c7140355d643da8e3409cbd755689ea889bc0d6dbd557f1b5671")
-    version("1.0.2", sha256="97f641a2e47053bd87bc817292519d6661e8f84a22d3314724b83b9f5eaddbff")
+    version("1.0.9", sha256="67bd9df49fe34e8b82144f6dfb93b320f384a8ea59727e92ff8d18b5f4b579a8")
+    version("1.0.8", sha256="0cd13be008923528687af6c6b860f35392d49251c04ee0648282d36b1faec1cf")
+    version("1.0.7", sha256="33685351e29dff93cc21f5344b6e628e41e32b9f9e567f4bec0478eb41f989b6")
+    version("1.0.6", sha256="efcc08021284e75f4d96d3581c5155a11f08fd63316b1938cbcb269c87f37feb")
+    version("1.0.5", sha256="fc9d7daf43605a73045de203bbfc0bca3e07f72d4ac61bcf656868f48692d73a")
+
+    # Versions that were initially sourced at a third party are now deprecated
+    with default_args(deprecated=True):
+        version(
+            "1.0.4",
+            sha256="68168697b9d6430b7797ddd579e13a2cef06ea15c154dfd14e18be64e035ea6e",
+            url="https://github.com/Distrotech/libnetfilter_conntrack/archive/libnetfilter_conntrack-1.0.4.tar.gz",
+        )
+        version(
+            "1.0.3",
+            sha256="e2129d7c0346c7140355d643da8e3409cbd755689ea889bc0d6dbd557f1b5671",
+            url="https://github.com/Distrotech/libnetfilter_conntrack/archive/libnetfilter_conntrack-1.0.3.tar.gz",
+        )
+        version(
+            "1.0.2",
+            sha256="97f641a2e47053bd87bc817292519d6661e8f84a22d3314724b83b9f5eaddbff",
+            url="https://github.com/Distrotech/libnetfilter_conntrack/archive/libnetfilter_conntrack-1.0.2.tar.gz",
+        )
 
     depends_on("c", type="build")  # generated
 

--- a/var/spack/repos/builtin/packages/libnetfilter-cthelper/package.py
+++ b/var/spack/repos/builtin/packages/libnetfilter-cthelper/package.py
@@ -9,14 +9,21 @@ from spack.package import *
 class LibnetfilterCthelper(AutotoolsPackage):
     """Libnetfilter-cthelper library for user space helpers / ALGs"""
 
-    homepage = "https://github.com/vyos/libnetfilter-cthelper/"
-    url = "https://github.com/vyos/libnetfilter-cthelper/archive/VyOS_1.2-2019Q4.tar.gz"
+    homepage = "https://netfilter.org/projects/libnetfilter_cthelper/"
+    url = "https://www.netfilter.org/projects/libnetfilter_cthelper/files/libnetfilter_cthelper-1.0.5.tar.bz2"
 
     license("GPL-2.0-or-later")
 
-    version(
-        "1.2-2019Q4", sha256="15a7b13999d1428d75e720c8116318cd51bec1d365852ae1778d3c85b93a9777"
-    )
+    version("1.0.1", sha256="14073d5487233897355d3ff04ddc1c8d03cc5ba8d2356236aa88161a9f2dc912")
+    
+    # Versions that were initially sourced at a third party are now deprecated
+    with default_args(deprecated=True):
+        # This appears to be version 1.0.0
+        version(
+            "1.2-2019Q4",
+            sha256="15a7b13999d1428d75e720c8116318cd51bec1d365852ae1778d3c85b93a9777",
+            url="https://github.com/vyos/libnetfilter-cthelper/archive/VyOS_1.2-2019Q4.tar.gz",
+        )
 
     depends_on("c", type="build")  # generated
 
@@ -24,4 +31,6 @@ class LibnetfilterCthelper(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("libmnl")
+    depends_on("pkgconfig", type="build")
+
+    depends_on("libmnl@1.0:")

--- a/var/spack/repos/builtin/packages/libnetfilter-cthelper/package.py
+++ b/var/spack/repos/builtin/packages/libnetfilter-cthelper/package.py
@@ -9,14 +9,20 @@ from spack.package import *
 class LibnetfilterCthelper(AutotoolsPackage):
     """Libnetfilter-cthelper library for user space helpers / ALGs"""
 
-    homepage = "https://github.com/vyos/libnetfilter-cthelper/"
-    url = "https://github.com/vyos/libnetfilter-cthelper/archive/VyOS_1.2-2019Q4.tar.gz"
+    homepage = "https://netfilter.org/projects/libnetfilter_cthelper/"
+    url = "https://www.netfilter.org/projects/libnetfilter_cthelper/files/libnetfilter_cthelper-1.0.5.tar.bz2"
 
     license("GPL-2.0-or-later")
 
-    version(
-        "1.2-2019Q4", sha256="15a7b13999d1428d75e720c8116318cd51bec1d365852ae1778d3c85b93a9777"
-    )
+    version("1.0.1", sha256="14073d5487233897355d3ff04ddc1c8d03cc5ba8d2356236aa88161a9f2dc912")
+    
+    # Versions that were initially sourced at a third party are now deprecated
+    with default_args(deprecated=True):
+        version(
+            "1.2-2019Q4",
+            sha256="15a7b13999d1428d75e720c8116318cd51bec1d365852ae1778d3c85b93a9777",
+            url="https://github.com/vyos/libnetfilter-cthelper/archive/VyOS_1.2-2019Q4.tar.gz",
+        )
 
     depends_on("c", type="build")  # generated
 

--- a/var/spack/repos/builtin/packages/libnetfilter-cthelper/package.py
+++ b/var/spack/repos/builtin/packages/libnetfilter-cthelper/package.py
@@ -15,7 +15,7 @@ class LibnetfilterCthelper(AutotoolsPackage):
     license("GPL-2.0-or-later")
 
     version("1.0.1", sha256="14073d5487233897355d3ff04ddc1c8d03cc5ba8d2356236aa88161a9f2dc912")
-    
+
     # Versions that were initially sourced at a third party are now deprecated
     with default_args(deprecated=True):
         # This appears to be version 1.0.0

--- a/var/spack/repos/builtin/packages/libnetfilter-cttimeout/package.py
+++ b/var/spack/repos/builtin/packages/libnetfilter-cttimeout/package.py
@@ -9,14 +9,21 @@ from spack.package import *
 class LibnetfilterCttimeout(AutotoolsPackage):
     """Conntrack timeout policy library."""
 
-    homepage = "https://github.com/vyos/libnetfilter-cttimeout/"
-    url = "https://github.com/vyos/libnetfilter-cttimeout/archive/VyOS_1.2-2019Q4.tar.gz"
+    homepage = "https://netfilter.org/projects/libnetfilter_cttimeout/"
+    url = "https://www.netfilter.org/projects/libnetfilter_cttimeout/files/libnetfilter_cttimeout-1.0.1.tar.bz2"
 
-    license("GPL-2.0-only")
+    license("GPL-2.0-only", checked_by="wdconinc")
 
-    version(
-        "1.2-2019Q4", sha256="71cebdf07a578901b160a54199062a4b4cd445e14742e2c7badc0900d8ae56b6"
-    )
+    version("1.0.1", sha256="0b59da2f3204e1c80cb85d1f6d72285fc07b01a2f5678abf5dccfbbefd650325")
+
+    # Versions that were initially sourced at a third party are now deprecated
+    with default_args(deprecated=True):
+        # This appears to be version 1.0.0
+        version(
+            "1.2-2019Q4",
+            sha256="71cebdf07a578901b160a54199062a4b4cd445e14742e2c7badc0900d8ae56b6",
+            url="https://github.com/vyos/libnetfilter-cttimeout/archive/VyOS_1.2-2019Q4.tar.gz",
+        )
 
     depends_on("c", type="build")  # generated
 
@@ -24,5 +31,6 @@ class LibnetfilterCttimeout(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
+    depends_on("pkgconfig", type="build")
 
     depends_on("libmnl")

--- a/var/spack/repos/builtin/packages/libnetfilter-cttimeout/package.py
+++ b/var/spack/repos/builtin/packages/libnetfilter-cttimeout/package.py
@@ -9,14 +9,20 @@ from spack.package import *
 class LibnetfilterCttimeout(AutotoolsPackage):
     """Conntrack timeout policy library."""
 
-    homepage = "https://github.com/vyos/libnetfilter-cttimeout/"
-    url = "https://github.com/vyos/libnetfilter-cttimeout/archive/VyOS_1.2-2019Q4.tar.gz"
+    homepage = "https://netfilter.org/projects/libnetfilter_cttimeout/"
+    url = "https://www.netfilter.org/projects/libnetfilter_cttimeout/files/libnetfilter_cttimeout-1.0.1.tar.bz2"
 
-    license("GPL-2.0-only")
+    license("GPL-2.0-only", checked_by="wdconinc")
 
-    version(
-        "1.2-2019Q4", sha256="71cebdf07a578901b160a54199062a4b4cd445e14742e2c7badc0900d8ae56b6"
-    )
+    version("1.0.1", sha256="0b59da2f3204e1c80cb85d1f6d72285fc07b01a2f5678abf5dccfbbefd650325")
+
+    # Versions that were initially sourced at a third party are now deprecated
+    with default_args(deprecated=True):
+        version(
+            "1.2-2019Q4",
+            sha256="71cebdf07a578901b160a54199062a4b4cd445e14742e2c7badc0900d8ae56b6",
+            url="https://github.com/vyos/libnetfilter-cttimeout/archive/VyOS_1.2-2019Q4.tar.gz",
+        )
 
     depends_on("c", type="build")  # generated
 

--- a/var/spack/repos/builtin/packages/libnetfilter-queue/package.py
+++ b/var/spack/repos/builtin/packages/libnetfilter-queue/package.py
@@ -9,14 +9,21 @@ from spack.package import *
 class LibnetfilterQueue(AutotoolsPackage):
     """Libnetfilter-queue libnetfilter queue library."""
 
-    homepage = "https://github.com/vyos/libnetfilter-queue/"
-    url = "https://github.com/vyos/libnetfilter-queue/archive/VyOS_1.2-2019Q4.tar.gz"
+    homepage = "https://netfilter.org/projects/libnetfilter_queue/"
+    url = "https://www.netfilter.org/projects/libnetfilter_queue/files/libnetfilter_queue-1.0.5.tar.bz2"
 
     license("GPL-2.0-only")
 
-    version(
-        "1.2-2019Q4", sha256="73b87e600b492cf9e3aa8fb6e9855e1ccc523a7bc466c1fd1a0e6ffa424d746e"
-    )
+    version("1.0.5", sha256="f9ff3c11305d6e03d81405957bdc11aea18e0d315c3e3f48da53a24ba251b9f5")
+
+    # Versions that were initially sourced at a third party are now deprecated
+    with default_args(deprecated=True):
+        # This appears to be version 1.0.2
+        version(
+            "1.2-2019Q4",
+            sha256="73b87e600b492cf9e3aa8fb6e9855e1ccc523a7bc466c1fd1a0e6ffa424d746e",
+            url="https://github.com/vyos/libnetfilter-queue/archive/VyOS_1.2-2019Q4.tar.gz",
+        )
 
     depends_on("c", type="build")  # generated
 
@@ -24,6 +31,7 @@ class LibnetfilterQueue(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
+    depends_on("pkgconfig", type="build")
 
     depends_on("libnfnetlink")
-    depends_on("libmnl")
+    depends_on("libmnl@1.0.3:")

--- a/var/spack/repos/builtin/packages/libnetfilter-queue/package.py
+++ b/var/spack/repos/builtin/packages/libnetfilter-queue/package.py
@@ -9,13 +9,19 @@ from spack.package import *
 class LibnetfilterQueue(AutotoolsPackage):
     """Libnetfilter-queue libnetfilter queue library."""
 
-    homepage = "https://github.com/vyos/libnetfilter-queue/"
-    url = "https://github.com/vyos/libnetfilter-queue/archive/VyOS_1.2-2019Q4.tar.gz"
+    homepage = "https://netfilter.org/projects/libnetfilter_queue/"
+    url = "https://www.netfilter.org/projects/libnetfilter_queue/files/libnetfilter_queue-1.0.5.tar.bz2"
 
     license("GPL-2.0-only")
 
+    version("1.0.5", sha256="f9ff3c11305d6e03d81405957bdc11aea18e0d315c3e3f48da53a24ba251b9f5")
+
+    # Versions that were initially sourced at a third party are now deprecated
     version(
-        "1.2-2019Q4", sha256="73b87e600b492cf9e3aa8fb6e9855e1ccc523a7bc466c1fd1a0e6ffa424d746e"
+        "1.2-2019Q4",
+        sha256="73b87e600b492cf9e3aa8fb6e9855e1ccc523a7bc466c1fd1a0e6ffa424d746e",
+        url="https://github.com/vyos/libnetfilter-queue/archive/VyOS_1.2-2019Q4.tar.gz",
+        deprecated=True,
     )
 
     depends_on("c", type="build")  # generated

--- a/var/spack/repos/builtin/packages/libnfnetlink/package.py
+++ b/var/spack/repos/builtin/packages/libnfnetlink/package.py
@@ -12,14 +12,30 @@ class Libnfnetlink(AutotoolsPackage):
     netfilter subsystem specific libraries such as libnfnetlink_conntrack,
     libnfnetlink_log and libnfnetlink_queue."""
 
-    homepage = "https://netfilter.org"
-    url = "https://github.com/Distrotech/libnfnetlink/archive/libnfnetlink-1.0.1.tar.gz"
+    homepage = "https://netfilter.org/projects/libnfnetlink/"
+    url = "https://netfilter.org/projects/libnfnetlink/files/libnfnetlink-1.0.2.tar.bz2"
 
     license("GPL-2.0-only")
 
-    version("1.0.1", sha256="11dd8a1045b03d47c878535eeb6b9eb34db295d21903a4dfd2c2cc63f45e675b")
-    version("1.0.0", sha256="1d43456e51d5ff2e8bc84b68d8acad3bb15603cfaa806ba9693eea4f2aa1abeb")
-    version("0.0.41", sha256="84381ad3aec4fc4884c020c7774a241160d92ed50c9f93a2660db94e212cbb72")
+    version("1.0.2", sha256="b064c7c3d426efb4786e60a8e6859b82ee2f2c5e49ffeea640cfe4fe33cbc376")
+    
+    # Versions that were initially sourced at a third party are now deprecated
+    with default_args(deprecated=True):
+        version(
+            "1.0.1",
+            sha256="11dd8a1045b03d47c878535eeb6b9eb34db295d21903a4dfd2c2cc63f45e675b",
+            url="https://github.com/Distrotech/libnfnetlink/archive/libnfnetlink-1.0.1.tar.gz",
+        )
+        version(
+            "1.0.0",
+            sha256="1d43456e51d5ff2e8bc84b68d8acad3bb15603cfaa806ba9693eea4f2aa1abeb",
+            url="https://github.com/Distrotech/libnfnetlink/archive/libnfnetlink-1.0.0.tar.gz",
+        )
+        version(
+            "0.0.41",
+            sha256="84381ad3aec4fc4884c020c7774a241160d92ed50c9f93a2660db94e212cbb72",
+            url="https://github.com/Distrotech/libnfnetlink/archive/libnfnetlink-0.0.41.tar.gz",
+        )
 
     depends_on("c", type="build")  # generated
 

--- a/var/spack/repos/builtin/packages/libnfnetlink/package.py
+++ b/var/spack/repos/builtin/packages/libnfnetlink/package.py
@@ -18,7 +18,7 @@ class Libnfnetlink(AutotoolsPackage):
     license("GPL-2.0-only")
 
     version("1.0.2", sha256="b064c7c3d426efb4786e60a8e6859b82ee2f2c5e49ffeea640cfe4fe33cbc376")
-    
+
     # Versions that were initially sourced at a third party are now deprecated
     with default_args(deprecated=True):
         version(

--- a/var/spack/repos/builtin/packages/libnftnl/package.py
+++ b/var/spack/repos/builtin/packages/libnftnl/package.py
@@ -10,11 +10,12 @@ class Libnftnl(AutotoolsPackage):
     """A library for low-level interaction with nftables Netlink's API
     over libmnl."""
 
-    homepage = "https://git.netfilter.org/libnftnl/"
-    url = "https://ftp.netfilter.org/pub/libnftnl/libnftnl-1.1.5.tar.bz2"
+    homepage = "https://netfilter.org/projects/libmnl/"
+    url = "https://netfilter.org/projects/libnftnl/files/libnftnl-1.2.7.tar.xz"
 
-    license("GPL-2.0-or-later")
+    license("GPL-2.0-or-later", checked_by="wdconinc")
 
+    version("1.2.7", sha256="9122774f968093d5c0bacddd67de480f31fa4073405a7fc058a34b0f387aecb3")
     version("1.1.6", sha256="c1eb5a696fc1d4b3b412770586017bc01af93da3ddd25233d34a62979dee1eca")
     version("1.1.5", sha256="66de4d05227c0a1a731c369b193010d18a05b1185c2735211e0ecf658eeb14f3")
     version("1.1.4", sha256="c8c7988347adf261efac5bba59f8e5f995ffb65f247a88cc144e69620573ed20")
@@ -22,4 +23,12 @@ class Libnftnl(AutotoolsPackage):
     depends_on("c", type="build")  # generated
 
     depends_on("pkgconfig", type="build")
-    depends_on("libmnl@1.0.3:")
+    depends_on("libmnl@1.0.0:")
+    depends_on("libmnl@1.0.3:", when="@1.1.1:")
+    depends_on("libmnl@1.0.4:", when="@1.1.7:")
+
+    def url_for_version(self, version):
+        if version >= Version("1.2.5"):
+            return f"https://netfilter.org/projects/libnftnl/files/libnftnl-{version}.tar.xz"
+        else:
+            return f"https://netfilter.org/projects/libnftnl/files/libnftnl-{version}.tar.bz2"

--- a/var/spack/repos/builtin/packages/libnftnl/package.py
+++ b/var/spack/repos/builtin/packages/libnftnl/package.py
@@ -10,11 +10,12 @@ class Libnftnl(AutotoolsPackage):
     """A library for low-level interaction with nftables Netlink's API
     over libmnl."""
 
-    homepage = "https://git.netfilter.org/libnftnl/"
-    url = "https://ftp.netfilter.org/pub/libnftnl/libnftnl-1.1.5.tar.bz2"
+    homepage = "https://netfilter.org/projects/libmnl/"
+    url = "https://netfilter.org/projects/libnftnl/files/libnftnl-1.2.7.tar.xz"
 
-    license("GPL-2.0-or-later")
+    license("GPL-2.0-or-later", checked_by="wdconinc")
 
+    version("1.2.7", sha256="9122774f968093d5c0bacddd67de480f31fa4073405a7fc058a34b0f387aecb3")
     version("1.1.6", sha256="c1eb5a696fc1d4b3b412770586017bc01af93da3ddd25233d34a62979dee1eca")
     version("1.1.5", sha256="66de4d05227c0a1a731c369b193010d18a05b1185c2735211e0ecf658eeb14f3")
     version("1.1.4", sha256="c8c7988347adf261efac5bba59f8e5f995ffb65f247a88cc144e69620573ed20")
@@ -23,3 +24,9 @@ class Libnftnl(AutotoolsPackage):
 
     depends_on("pkgconfig", type="build")
     depends_on("libmnl@1.0.3:")
+
+    def url_for_version(self, version):
+        if version >= Version("1.2.5"):
+            return f"https://netfilter.org/projects/libnftnl/files/libnftnl-{version}.tar.xz"
+        else:
+            return f"https://netfilter.org/projects/libnftnl/files/libnftnl-{version}.tar.bz2"


### PR DESCRIPTION
For various netfilter packages (now?) distributed at https://netfilter.org/projects/, we were using URLs at unmaintained third-party locations (DistroTech, VyOS).

In some cases, the version numbers of the third-party locations were using different version numbers for the same code (https://github.com/vyos-legacy/libnetfilter-cthelper/tags uses the same commit for VyOS_1.2-2019Q4 and debian/1.0.0-5+vyos2+lithium4 from 2015, while a version 1.0.1 from netfilter was released in 2022 at https://netfilter.org/projects/libnetfilter_cthelper/downloads.html).

This PR 'fixes' this for all netfilter packages. The versions at third-party locations were all marked as deprecated (since one could consider this problematic provenance) and the latest version distributed at netfilter.org was added.

Test builds:
```console
root@codespaces-bb8e02:/workspaces/spack# spack spec 
[+]  libmnl@1.0.5%gcc@11.4.0 build_system=autotools arch=linux-ubuntu20.04-x86_64_v3
[+]      ^autoconf@2.72%gcc@11.4.0 build_system=autotools arch=linux-ubuntu20.04-x86_64_v3
[+]          ^perl@5.40.0%gcc@11.4.0+cpanm+opcode+open+shared+threads build_system=generic arch=linux-ubuntu20.04-x86_64_v3
[+]              ^berkeley-db@18.1.40%gcc@11.4.0+cxx~docs+stl build_system=autotools patches=26090f4,b231fcc arch=linux-ubuntu20.04-x86_64_v3
[+]              ^bzip2@1.0.8%gcc@11.4.0~debug~pic+shared build_system=generic arch=linux-ubuntu20.04-x86_64_v3
[+]              ^gdbm@1.23%gcc@11.4.0 build_system=autotools arch=linux-ubuntu20.04-x86_64_v3
[+]                  ^readline@8.2%gcc@11.4.0 build_system=autotools patches=bbf97f1 arch=linux-ubuntu20.04-x86_64_v3
[+]                      ^ncurses@6.5%gcc@11.4.0~symlinks+termlib abi=none build_system=autotools patches=7a351bc arch=linux-ubuntu20.04-x86_64_v3
[+]              ^zlib-ng@2.2.1%gcc@11.4.0+compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-ubuntu20.04-x86_64_v3
[+]      ^automake@1.16.5%gcc@11.4.0 build_system=autotools arch=linux-ubuntu20.04-x86_64_v3
[+]      ^gcc-runtime@11.4.0%gcc@11.4.0 build_system=generic arch=linux-ubuntu20.04-x86_64_v3
[e]      ^glibc@2.31%gcc@11.4.0 build_system=autotools arch=linux-ubuntu20.04-x86_64_v3
[+]      ^gmake@4.4.1%gcc@11.4.0~guile build_system=generic arch=linux-ubuntu20.04-x86_64_v3
[+]      ^libtool@2.4.7%gcc@11.4.0 build_system=autotools arch=linux-ubuntu20.04-x86_64_v3
[+]          ^findutils@4.9.0%gcc@11.4.0 build_system=autotools patches=440b954 arch=linux-ubuntu20.04-x86_64_v3
[+]      ^m4@1.4.19%gcc@11.4.0+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-ubuntu20.04-x86_64_v3
[+]          ^diffutils@3.10%gcc@11.4.0 build_system=autotools arch=linux-ubuntu20.04-x86_64_v3
[+]              ^libiconv@1.17%gcc@11.4.0 build_system=autotools libs=shared,static arch=linux-ubuntu20.04-x86_64_v3
[+]          ^libsigsegv@2.14%gcc@11.4.0 build_system=autotools arch=linux-ubuntu20.04-x86_64_v3
[+]  libnetfilter-conntrack@1.0.9%gcc@11.4.0 build_system=autotools arch=linux-ubuntu20.04-x86_64_v3
[+]      ^pkgconf@2.2.0%gcc@11.4.0 build_system=autotools arch=linux-ubuntu20.04-x86_64_v3
[+]  libnetfilter-cthelper@1.0.1%gcc@11.4.0 build_system=autotools arch=linux-ubuntu20.04-x86_64_v3
[+]  libnetfilter-cttimeout@1.0.1%gcc@11.4.0 build_system=autotools arch=linux-ubuntu20.04-x86_64_v3
[+]  libnetfilter-queue@1.0.5%gcc@11.4.0 build_system=autotools arch=linux-ubuntu20.04-x86_64_v3
[+]  libnfnetlink@1.0.2%gcc@11.4.0 build_system=autotools arch=linux-ubuntu20.04-x86_64_v3
[+]  libnftnl@1.2.7%gcc@11.4.0 build_system=autotools arch=linux-ubuntu20.04-x86_64_v3
```