### PR TITLE
lshw: add v02.20

### DIFF
--- a/var/spack/repos/builtin/packages/lshw/package.py
+++ b/var/spack/repos/builtin/packages/lshw/package.py
@@ -30,6 +30,8 @@ class Lshw(MakefilePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
-    def install(self, spec, prefix):
-        make("install")
-        install_tree(".", prefix)
+    def setup_build_environment(self, env):
+        env.set("PREFIX", self.prefix)
+
+    def setup_run_environment(self, env):
+        env.prepend_path("PATH", self.prefix.sbin)

--- a/var/spack/repos/builtin/packages/lshw/package.py
+++ b/var/spack/repos/builtin/packages/lshw/package.py
@@ -17,16 +17,18 @@ class Lshw(MakefilePackage):
 
     homepage = "https://github.com/lyonel/lshw"
     url = "https://github.com/lyonel/lshw/archive/B.02.18.tar.gz"
+    list_url = "https://github.com/lyonel/lshw/tags"
 
-    license("GPL-3.0-or-later")
+    license("GPL-2.0-only", checked_by="wdconinc")
 
+    version("02.20", sha256="6b8346a89fb0f0f1798e66f6a707a881d38b9b3a67256b30fc4628dac09f291a")
     version("02.18", sha256="aa8cb2eebf36e9e46dfc227f24784aa8c87181ec96e57ee6c455da8a0ce4fa77")
     version("02.17", sha256="0bb76c7df7733dc9b80d5d35f9d9752409ddb506e190453a2cc960461de5ddeb")
     version("02.16", sha256="58a7731d204791dd33db5eb3fde9808d1235283e069e6c33a193637ccec27b3e")
     version("02.15", sha256="33c51ba0554d4bcd8ff9a67e5971a63b9ddd58213e2901a09000815376bc61b9")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     def install(self, spec, prefix):
         make("install")


### PR DESCRIPTION
This PR adds `lshw` v02.20. The license was incorrect. There is indeed both C and C++ code in the archive. Without the list_url, spack seems unable to find the version. It might get tripped up by the first part in `B.02.20`. 

It turns out there were some issues with the package: with `make install` it always (even oldest version) defers to installing under `/usr` (or whatever `PREFIX` is set to). We now set this and also add the `sbin/` directory to the `PATH`.

Test build:
```console
==> Installing lshw-02.20-yqtf6cvviuelvil5rscyknmxvril35il [4/4]
==> No binary for lshw-02.20-yqtf6cvviuelvil5rscyknmxvril35il found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/6b/6b8346a89fb0f0f1798e66f6a707a881d38b9b3a67256b30fc4628dac09f291a.tar.gz
==> No patches needed for lshw
==> lshw: Executing phase: 'edit'
==> lshw: Executing phase: 'build'
==> lshw: Executing phase: 'install'
==> lshw: Successfully installed lshw-02.20-yqtf6cvviuelvil5rscyknmxvril35il
  Stage: 0.07s.  Edit: 0.00s.  Build: 1.61s.  Install: 0.14s.  Post-install: 0.10s.  Total: 1.95s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/lshw-02.20-yqtf6cvviuelvil5rscyknmxvril35il
==> Updating view at /tmp/spack-j9c0t3ms/.spack-env/view
19:02:18 wdconinc@menelaos ~/git/spack (develop *$%>) $ spack load lshw
19:02:22 wdconinc@menelaos ~/git/spack (develop *$%>) $ which lshw
/opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/lshw-02.20-yqtf6cvviuelvil5rscyknmxvril35il/sbin/lshw
19:02:24 wdconinc@menelaos ~/git/spack (develop *$%>) $ lshw
WARNING: you should run this program as super-user.
menelaos                    
    description: Computer
    width: 64 bits
    capabilities: smp vsyscall32
  *-core
       description: Motherboard
       physical id: 0
```