### PR TITLE
gaudi: remove redundant dependency on cppgsl

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -109,7 +109,6 @@ class Gaudi(CMakePackage):
         depends_on(pv[0], when=pv[1] + " +examples")
 
     # Adding these dependencies triggers the build of most optional components
-    depends_on("cppgsl", when="+cppunit")
     depends_on("cppunit", when="+cppunit")
     depends_on("doxygen +graphviz", when="+docs")
     depends_on("gperftools", when="+gperftools")


### PR DESCRIPTION
It appears twice in the recipe and it's a mandatory dependency: https://gitlab.cern.ch/gaudi/Gaudi/-/blob/master/cmake/GaudiDependencies.cmake#L128