### PR TITLE
compilers: avoid redundant fs operations and cache

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -178,7 +178,7 @@ def list_modules(directory, **kwargs):
             ):
                 yield entry.name
 
-            elif entry.is_file() and entry.name.endswith(".py") and not ignore.match(entry.name):
+            elif entry.is_file() and entry.name.endswith(".py") and not ignore.search(entry.name):
                 yield entry.name[:-3]  # strip .py
 
 

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -178,7 +178,7 @@ def list_modules(directory, **kwargs):
             ):
                 yield entry.name
 
-            elif entry.is_file() and entry.name.endswith(".py") and not ignore.search(entry.name):
+            elif entry.name.endswith(".py") and entry.is_file() and not ignore.search(entry.name):
                 yield entry.name[:-3]  # strip .py
 
 

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta
 from typing import Any, Callable, Iterable, List, Tuple
 
 # Ignore emacs backups when listing modules
-ignore_modules = [r"^\.#", "~$"]
+ignore_modules = r"^\.#|~$"
 
 
 def index_by(objects, *funcs):
@@ -164,19 +164,22 @@ def list_modules(directory, **kwargs):
     order."""
     list_directories = kwargs.setdefault("directories", True)
 
-    for name in os.listdir(directory):
-        if name == "__init__.py":
-            continue
+    ignore = re.compile(ignore_modules)
 
-        path = os.path.join(directory, name)
-        if list_directories and os.path.isdir(path):
-            init_py = os.path.join(path, "__init__.py")
-            if os.path.isfile(init_py):
-                yield name
+    with os.scandir(directory) as it:
+        for entry in it:
+            if entry.name == "__init__.py" or entry.name == "__pycache__":
+                continue
 
-        elif name.endswith(".py"):
-            if not any(re.search(pattern, name) for pattern in ignore_modules):
-                yield re.sub(".py$", "", name)
+            if (
+                list_directories
+                and entry.is_dir()
+                and os.path.isfile(os.path.join(entry.path, "__init__.py"))
+            ):
+                yield entry.name
+
+            elif entry.is_file() and entry.name.endswith(".py") and not ignore.match(entry.name):
+                yield entry.name[:-3]  # strip .py
 
 
 def decorator_with_or_without_args(decorator):

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -394,8 +394,9 @@ def all_compiler_names() -> List[str]:
     return [replace_apple_clang(name) for name in all_compiler_module_names()]
 
 
+@llnl.util.lang.memoized
 def all_compiler_module_names() -> List[str]:
-    return [name for name in llnl.util.lang.list_modules(spack.paths.compilers_path)]
+    return list(llnl.util.lang.list_modules(spack.paths.compilers_path))
 
 
 @_auto_compiler_spec


### PR DESCRIPTION
avoids 360 stat calls for me when `spack spec zlib`.