### PR TITLE
tl-expected: add v1.1.0; deprecated custom calver version

### DIFF
--- a/var/spack/repos/builtin/packages/tl-expected/package.py
+++ b/var/spack/repos/builtin/packages/tl-expected/package.py
@@ -15,13 +15,15 @@ class TlExpected(CMakePackage):
 
     maintainers("charmoniumQ")
 
-    license("CC0-1.0")
+    license("CC0-1.0", checked_by="wdconinc")
 
-    # Note that the 1.0.0 has this issue:
-    # https://github.com/TartanLlama/expected/issues/114
-    # But no new patch version has been released,
-    # so I will use the latest commit at the time of writing:
-    version("2022-11-24", commit="b74fecd4448a1a5549402d17ddc51e39faa5020c")
+    version("1.1.0", sha256="1db357f46dd2b24447156aaf970c4c40a793ef12a8a9c2ad9e096d9801368df6")
+    with default_args(deprecated=True):
+        # Note that the 1.0.0 has this issue:
+        # https://github.com/TartanLlama/expected/issues/114
+        # But no new patch version has been released,
+        # so I will use the latest commit at the time of writing:
+        version("2022-11-24", commit="b74fecd4448a1a5549402d17ddc51e39faa5020c")
     version("1.0.0", sha256="8f5124085a124113e75e3890b4e923e3a4de5b26a973b891b3deb40e19c03cee")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")

--- a/var/spack/repos/builtin/packages/tl-expected/package.py
+++ b/var/spack/repos/builtin/packages/tl-expected/package.py
@@ -10,7 +10,7 @@ class TlExpected(CMakePackage):
     """C++11/14/17 std::expected with functional-style extensions."""
 
     homepage = "https://tl.tartanllama.xyz/en/latest/"
-    url = "https://github.com/TartanLlama/expected/archive/1.0.0.tar.gz"
+    url = "https://github.com/TartanLlama/expected/archive/refs/tags/v1.0.0.tar.gz"
     git = "https://github.com/TartanLlama/expected.git"
 
     maintainers("charmoniumQ")


### PR DESCRIPTION
This PR adds `tl-expected`, v1.1.0. This is a header-only library which includes tests (not supported by the spack recipe), so I kept the cxx build dependency.

This PR removes our custom calver version `2022-11-24` which is always going to be more recent than 1.1.0. In these cases, other distributions uses e.g. `1.0.0.git20221124`.
