### PR TITLE
boost: remove Compiler.cxx_names

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -462,24 +462,24 @@ class Boost(Package):
 
     def determine_toolset(self, spec):
         toolsets = {
-            "g++": "gcc",
-            "icpc": "intel",
-            "icpx": "intel",
-            "clang++": "clang",
-            "armclang++": "clang",
-            "xlc++": "xlcpp",
-            "xlc++_r": "xlcpp",
-            "pgc++": "pgi",
-            "nvc++": "pgi",
-            "FCC": "clang",
+            "%gcc": "gcc",
+            "%intel": "intel",
+            "%oneapi": "intel",
+            "%clang": "clang",
+            "%arm": "clang",
+            "%xl": "xlcpp",
+            "%xl_r": "xlcpp",
+            "%pgi": "pgi",
+            "%nvhpc": "pgi",
+            "%fj": "clang",
         }
 
         if spec.satisfies("@1.47:"):
-            toolsets["icpc"] += "-linux"
-            toolsets["icpx"] += "-linux"
+            toolsets["%intel"] += "-linux"
+            toolsets["%oneapi"] += "-linux"
 
         for cc, toolset in toolsets.items():
-            if cc in self.compiler.cxx_names:
+            if self.spec.satisfies(cc):
                 return toolset
 
         # fallback to gcc if no toolset found


### PR DESCRIPTION
Extracted from #45982

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
