### PR TITLE
py-vector: add v1.4.2, v1.5.0; variant awkward

### DIFF
--- a/var/spack/repos/builtin/packages/py-vector/package.py
+++ b/var/spack/repos/builtin/packages/py-vector/package.py
@@ -18,6 +18,8 @@ class PyVector(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.5.0", sha256="77e48bd40b7e7d30a17bf79bb6ed0f2d6985d915fcb9bf0879836276a619a0a9")
+    version("1.4.2", sha256="3805848eb9e53e9c60aa24dd5be88c842a6cd3d241e22984bfe12629b08536a9")
     version("1.4.1", sha256="15aef8911560db1ea3ffa9dbd5414d0ec575a504a2c3f23ea45170a18994466e")
     version("1.3.1", sha256="1a94210c21a5d38d36d0fa36c1afb92c2857ba1d09c824b0d4b8615d51f4f2e5")
     version("1.2.0", sha256="23b7ac5bdab273b4f9306167fd86666a3777a52804d0282a556d989130cb57a4")
@@ -29,6 +31,8 @@ class PyVector(PythonPackage):
     version("0.8.5", sha256="2c7c8b228168b89da5d30d50dbd05452348920559ebe0eb94cfdafa15cdc8378")
     version("0.8.4", sha256="ef97bfec0263766edbb74c290401f89921f8d11ae9e4a0ffd904ae40674f1239")
 
+    variant("awkward", default=True, description="Build with awkward support", when="@0.9:")
+
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("python@3.7:", type=("build", "run"), when="@0.10:")
     depends_on("python@3.8:", type=("build", "run"), when="@1.1:")
@@ -39,7 +43,11 @@ class PyVector(PythonPackage):
         depends_on("py-setuptools@42:", type="build")
         depends_on("py-setuptools-scm@3.4: +toml", type="build")
         depends_on("py-wheel", type="build")
-    depends_on("py-numpy@1.13.3:", type=("build", "run"))
+    depends_on("py-numpy@1.13.3:2.0", type=("build", "run"))
     depends_on("py-packaging@19.0:", type=("build", "run"))
     depends_on("py-importlib-metadata@0.22:", type=("build", "run"), when="@:1.0 ^python@:3.7")
     depends_on("py-typing-extensions", type=("build", "run"), when="@:1.0 ^python@:3.7")
+
+    with when("+awkward"):
+        depends_on("py-awkward@1.2:", type=("build", "run"))
+        depends_on("py-awkward@2:", type=("build", "run"), when="@1.5:")


### PR DESCRIPTION
This PR adds python package `vector` v1.4.2 and v1.5.0 (which removes awkward v1 support). This PR also enables the variant awkward by default, and applies the numpy upper limit retroactively since it would also have applied to older versions even if not included in the pyproject.toml files for those releases.

```
==> Installing py-vector-1.5.0-4b4zza2gbal3wqqqsz4mzuwf4mv2cezp [59/59]
==> No binary for py-vector-1.5.0-4b4zza2gbal3wqqqsz4mzuwf4mv2cezp found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/v/vector/vector-1.5.0.tar.gz
==> No patches needed for py-vector
==> py-vector: Executing phase: 'install'
==> py-vector: Successfully installed py-vector-1.5.0-4b4zza2gbal3wqqqsz4mzuwf4mv2cezp
  Stage: 0.87s.  Install: 1.34s.  Post-install: 0.64s.  Total: 3.05s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-vector-1.5.0-4b4zza2gbal3wqqqsz4mzuwf4mv2cezp
```
and
```
$ python
Python 3.10.14 (main, Aug 24 2024, 14:13:54) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import vector
>>> print(vector.__version__)
1.5.0
```