### PR TITLE
external: list licensing in init summary

### DIFF
--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -11,6 +11,7 @@ altgraph
 * Homepage: https://altgraph.readthedocs.io/en/latest/index.html
 * Usage: dependency of macholib
 * Version: 0.17.3
+* License: MIT
 
 archspec
 --------
@@ -18,6 +19,7 @@ archspec
 * Homepage: https://pypi.python.org/pypi/archspec
 * Usage: Labeling, comparison and detection of microarchitectures
 * Version: 0.2.5 (commit 38ce485258ffc4fc6dd6688f8dc90cb269478c47)
+* License: Apache-2.0
 
 astunparse
 ----------------
@@ -25,6 +27,7 @@ astunparse
 * Homepage: https://github.com/simonpercivall/astunparse
 * Usage: Unparsing Python ASTs for package hashes in Spack
 * Version: 1.6.3 (plus modifications)
+* License: PSF-2.0
 * Note: This is in ``spack.util.unparse`` because it's very heavily
   modified, and we want to track coverage for it.
   Specifically, we have modified this library to generate consistent unparsed ASTs
@@ -41,6 +44,7 @@ attrs
 * Homepage: https://github.com/python-attrs/attrs
 * Usage: Needed by jsonschema.
 * Version: 22.1.0
+* License: MIT
 
 ctest_log_parser
 ----------------
@@ -48,6 +52,7 @@ ctest_log_parser
 * Homepage: https://github.com/Kitware/CMake/blob/master/Source/CTest/cmCTestBuildHandler.cxx
 * Usage: Functions to parse build logs and extract error messages.
 * Version: Unversioned
+* License: BSD-3-Clause
 * Note: This is a homemade port of Kitware's CTest build handler.
 
 distro
@@ -56,6 +61,7 @@ distro
 * Homepage: https://pypi.python.org/pypi/distro
 * Usage: Provides a more stable linux distribution detection.
 * Version: 1.8.0
+* License: Apache-2.0
 
 jinja2
 ------
@@ -63,6 +69,7 @@ jinja2
 * Homepage: https://pypi.python.org/pypi/Jinja2
 * Usage: A modern and designer-friendly templating language for Python.
 * Version: 3.0.3 (last version supporting Python 3.6)
+* License: BSD-3-Clause
 
 jsonschema
 ----------
@@ -70,6 +77,7 @@ jsonschema
 * Homepage: https://pypi.python.org/pypi/jsonschema
 * Usage: An implementation of JSON Schema for Python.
 * Version: 3.2.0 (last version before 2.7 and 3.6 support was dropped)
+* License: MIT
 * Note: We don't include tests or benchmarks; just what Spack needs.
 
 macholib
@@ -78,6 +86,7 @@ macholib
 * Homepage: https://macholib.readthedocs.io/en/latest/index.html#
 * Usage: Manipulation of Mach-o binaries for relocating macOS buildcaches on Linux
 * Version: 1.16.2
+* License: MIT
 
 markupsafe
 ----------
@@ -85,6 +94,7 @@ markupsafe
 * Homepage: https://pypi.python.org/pypi/MarkupSafe
 * Usage: Implements a XML/HTML/XHTML Markup safe string for Python.
 * Version: 2.0.1 (last version supporting Python 3.6)
+* License: BSD-3-Clause
 
 pyrsistent
 ----------
@@ -92,6 +102,7 @@ pyrsistent
 * Homepage: http://github.com/tobgu/pyrsistent/
 * Usage: Needed by `jsonschema`
 * Version: 0.18.0
+* License: MIT
 
 ruamel.yaml
 ------
@@ -101,6 +112,7 @@ ruamel.yaml
   actively maintained and has more features, including round-tripping
   comments read from config files.
 * Version: 0.17.21
+* License: MIT
 
 six
 ---
@@ -108,5 +120,6 @@ six
 * Homepage: https://pypi.python.org/pypi/six
 * Usage: Python 2 and 3 compatibility utilities.
 * Version: 1.16.0
+* License: MIT
 
 """

--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -19,7 +19,7 @@ archspec
 * Homepage: https://pypi.python.org/pypi/archspec
 * Usage: Labeling, comparison and detection of microarchitectures
 * Version: 0.2.5 (commit 38ce485258ffc4fc6dd6688f8dc90cb269478c47)
-* License: Apache-2.0
+* License: Apache-2.0 or MIT
 
 astunparse
 ----------------

--- a/var/spack/repos/builtin/packages/py-archspec/package.py
+++ b/var/spack/repos/builtin/packages/py-archspec/package.py
@@ -14,7 +14,7 @@ class PyArchspec(PythonPackage):
 
     maintainers("alalazo")
 
-    license("Apache-2.0")
+    license("Apache-2.0 AND MIT", checked_by="wdconinc")
 
     version("0.2.4", sha256="eabbae22f315d24cc2ce786a092478ec8e245208c9877fb213c2172a6ecb9302")
     version("0.2.3", sha256="d07deb5b6e2ab3b74861e217523d02e69be8522f6e6565f4cc5d2062eb1a5d2c")


### PR DESCRIPTION
Instead of merely hinting at the different licenses in
```
This module contains the following external, potentially separately licensed, packages that are included in Spack
```
this PR adds them explicitly in the `external/__init__` docstring. Naturally, all listed licenses allow vendoring, which can now be easily assessed.