### PR TITLE
openimageio: add v2.5.15.0, rm old versions (not buildable anymore)

### DIFF
--- a/var/spack/repos/builtin/packages/openimageio/package.py
+++ b/var/spack/repos/builtin/packages/openimageio/package.py
@@ -48,9 +48,9 @@ class Openimageio(CMakePackage):
     conflicts("target=aarch64:", when="@:1.8.15")
 
     def url_for_version(self, version):
-        if version >= Version('2'):
+        if version >= Version("2"):
             return super().url_for_version(version)
-        return f'https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/Release-{version}.tar.gz'
+        return f"https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/Release-{version}.tar.gz"
 
     def cmake_args(self):
         args = ["-DUSE_FFMPEG={0}".format("ON" if "+ffmpeg" in self.spec else "OFF")]

--- a/var/spack/repos/builtin/packages/openimageio/package.py
+++ b/var/spack/repos/builtin/packages/openimageio/package.py
@@ -4,34 +4,30 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Openimageio(CMakePackage):
-    """OpenImageIO is a library for reading and writing images, and a bunch of
-    related classes, utilities, and applications."""
+    """Reading, writing, and processing images in a wide variety of file formats, using
+    a format-agnostic API, aimed at VFX applications."""
 
     homepage = "https://www.openimageio.org"
-    url = "https://github.com/OpenImageIO/oiio/archive/Release-1.8.15.tar.gz"
+    url = "https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/v2.5.14.0.tar.gz"
 
     license("Apache-2.0")
 
-    version("2.2.7.0", sha256="857ac83798d6d2bda5d4d11a90618ff19486da2e5a4c4ff022c5976b5746fe8c")
-    version("1.8.15", sha256="4d5b4ed3f2daaed69989f53c0f9364dd87c82dc0a09807b5b6e9008e2426e86f")
+    version("2.5.14.0", sha256="0e74372c658f083820872311d126867f10d59b526a856672746de7b2c772034d")
+    version("2.2.7.0", sha256="6126fb8b1a8be0106c78056652a249791e43b8741d6db3e9921a29ad823c1590")
+    version("1.8.15", sha256="5cf57027597aeb3934c10739d3eeca9fb10a38606ad722da579772bab0e9cc5e")
 
     depends_on("cxx", type="build")  # generated
 
     # Core dependencies
     depends_on("cmake@3.2.2:", type="build")
-    depends_on("boost@1.53:", type=("build", "link"))
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants, type=("build", "link"))
-    depends_on("libtiff@4.0:", type=("build", "link"))
-    depends_on("openexr@2.3:", type=("build", "link"))
-    depends_on("libpng@1.6:", type=("build", "link"))
+    depends_on("boost+atomic+filesystem+thread@1.53:")
+    depends_on("libtiff@4.0:")
+    depends_on("openexr@2.3:2", when="@1")
+    depends_on("openexr@3.1:", when="@2")
+    depends_on("libpng@1.6:")
 
     # Optional dependencies
     variant("ffmpeg", default=False, description="Support video frames")
@@ -49,6 +45,11 @@ class Openimageio(CMakePackage):
     depends_on("qt@5.6.0:+opengl", when="+qt")
 
     conflicts("target=aarch64:", when="@:1.8.15")
+
+    def url_for_version(self, version):
+        if version >= Version('2'):
+            return super().url_for_version(version)
+        return f'https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/Release-{version}.tar.gz'
 
     def cmake_args(self):
         args = ["-DUSE_FFMPEG={0}".format("ON" if "+ffmpeg" in self.spec else "OFF")]

--- a/var/spack/repos/builtin/packages/openimageio/package.py
+++ b/var/spack/repos/builtin/packages/openimageio/package.py
@@ -10,7 +10,8 @@ class Openimageio(CMakePackage):
     """Reading, writing, and processing images in a wide variety of file formats, using
     a format-agnostic API, aimed at VFX applications."""
 
-    homepage = "https://www.openimageio.org"
+    homepage = "https://openimageio.readthedocs.io"
+    git = "https://github.com/AcademySoftwareFoundation/OpenImageIO"
     url = "https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/v2.5.14.0.tar.gz"
 
     license("Apache-2.0")

--- a/var/spack/repos/builtin/packages/openimageio/package.py
+++ b/var/spack/repos/builtin/packages/openimageio/package.py
@@ -16,18 +16,15 @@ class Openimageio(CMakePackage):
 
     license("Apache-2.0")
 
-    version("2.5.14.0", sha256="0e74372c658f083820872311d126867f10d59b526a856672746de7b2c772034d")
-    version("2.2.7.0", sha256="6126fb8b1a8be0106c78056652a249791e43b8741d6db3e9921a29ad823c1590")
-    version("1.8.15", sha256="5cf57027597aeb3934c10739d3eeca9fb10a38606ad722da579772bab0e9cc5e")
+    version("2.5.15.0", sha256="7779ef2c3d03c5ed95e13ff292de85c3f8cee301cd46baad0d2dc83c93bfe85c")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     # Core dependencies
     depends_on("cmake@3.2.2:", type="build")
-    depends_on("boost+atomic+filesystem+thread@1.53:")
+    depends_on("boost+atomic+filesystem+thread+chrono@1.53:")
     depends_on("libtiff@4.0:")
-    depends_on("openexr@2.3:2", when="@1")
-    depends_on("openexr@3.1:", when="@2")
+    depends_on("openexr@3.1:")
     depends_on("libpng@1.6:")
 
     # Optional dependencies
@@ -44,8 +41,6 @@ class Openimageio(CMakePackage):
 
     variant("qt", default=False, description="Build qt viewer")
     depends_on("qt@5.6.0:+opengl", when="+qt")
-
-    conflicts("target=aarch64:", when="@:1.8.15")
 
     def url_for_version(self, version):
         if version >= Version("2"):


### PR DESCRIPTION
Update OpenImageIO to v2.5.14.0 and update OpenEXR dependency.

Fixes https://github.com/spack/spack/issues/42837
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
