### PR TITLE
acts: add version 36.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -41,6 +41,7 @@ class Acts(CMakePackage, CudaPackage):
     # Supported Acts versions
     version("main", branch="main")
     version("master", branch="main", deprecated=True)  # For compatibility
+    version("36.2.0", commit="e2fb53da911dc481969e56d635898a46b8d78df9", submodules=True)
     version("36.1.0", commit="3f19d1a0eec1d11937d66d0ef603f0b25b9b4e96", submodules=True)
     version("36.0.0", commit="6eca77c45b136861272694edbb61bb77200948a5", submodules=True)
     version("35.2.0", commit="b3b09f46d064c43050dd3d21cdf51d7a412134fc", submodules=True)


### PR DESCRIPTION
This commit adds version 36.2.0 of ACTS. As far as I can tell, there are no dependency changes.