### PR TITLE
gromacs: add conflict between NVSHMEM and cuFFTMp

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -167,7 +167,8 @@ class Gromacs(CMakePackage, CudaPackage):
     conflicts(
         "+nvshmem",
         when="+cufftmp",
-        msg="The GROMACS suport for NVSHMEM does not work with the GROMACS support for cuFFTMp (even though cuFFTMp uses NVSHMEM in its implementation)",
+        msg=("The GROMACS suport for NVSHMEM does not work with the GROMACS support "
+             "for cuFFTMp (even though cuFFTMp uses NVSHMEM in its implementation)",
     )
 
     variant("openmp", default=True, description="Enables OpenMP at configure time")

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -168,7 +168,7 @@ class Gromacs(CMakePackage, CudaPackage):
         "+nvshmem",
         when="+cufftmp",
         msg=("The GROMACS support for NVSHMEM does not work with the GROMACS support "
-             "for cuFFTMp (even though cuFFTMp uses NVSHMEM in its implementation)",
+             "for cuFFTMp (even though cuFFTMp uses NVSHMEM in its implementation)"),
     )
 
     variant("openmp", default=True, description="Enables OpenMP at configure time")

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -161,7 +161,7 @@ class Gromacs(CMakePackage, CudaPackage):
     variant(
         "nvshmem",
         default=False,
-        when="@2023:+mpi+cuda",
+        when="@2024:+mpi+cuda",
         description="Enable NVSHMEM support for Nvidia GPUs",
         when="+cuda+mpi",
     )

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -162,7 +162,7 @@ class Gromacs(CMakePackage, CudaPackage):
         "nvshmem",
         default=False,
         when="@2024:+mpi+cuda",
-        description="Enable NVSHMEM support for Nvidia GPUs"
+        description="Enable NVSHMEM support for Nvidia GPUs",
     )
     conflicts(
         "+nvshmem",

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -161,7 +161,8 @@ class Gromacs(CMakePackage, CudaPackage):
     variant(
         "nvshmem",
         default=False,
-        description="Enable nvshmem support for nvidia gpus",
+        when="@2023:+mpi+cuda",
+        description="Enable NVSHMEM support for Nvidia GPUs",
         when="+cuda+mpi",
     )
     conflicts(

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -164,7 +164,11 @@ class Gromacs(CMakePackage, CudaPackage):
         description="Enable nvshmem support for nvidia gpus",
         when="+cuda+mpi",
     )
-    conflicts("+nvshmem", when="+cufftmp", msg="The GROMACS suport for NVSHMEM does not work with the GROMACS support for cuFFTMp (even though cuFFTMp uses NVSHMEM in its implementation)")
+    conflicts(
+        "+nvshmem",
+        when="+cufftmp",
+        msg="The GROMACS suport for NVSHMEM does not work with the GROMACS support for cuFFTMp (even though cuFFTMp uses NVSHMEM in its implementation)",
+    )
 
     variant("openmp", default=True, description="Enables OpenMP at configure time")
     variant("openmp_max_threads", default="none", description="Max number of OpenMP threads")

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -162,8 +162,7 @@ class Gromacs(CMakePackage, CudaPackage):
         "nvshmem",
         default=False,
         when="@2024:+mpi+cuda",
-        description="Enable NVSHMEM support for Nvidia GPUs",
-        when="+cuda+mpi",
+        description="Enable NVSHMEM support for Nvidia GPUs"
     )
     conflicts(
         "+nvshmem",

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -167,8 +167,10 @@ class Gromacs(CMakePackage, CudaPackage):
     conflicts(
         "+nvshmem",
         when="+cufftmp",
-        msg=("The GROMACS support for NVSHMEM does not work with the GROMACS support "
-             "for cuFFTMp (even though cuFFTMp uses NVSHMEM in its implementation)"),
+        msg=(
+            "The GROMACS support for NVSHMEM does not work with the GROMACS support "
+            "for cuFFTMp (even though cuFFTMp uses NVSHMEM in its implementation)"
+        ),
     )
 
     variant("openmp", default=True, description="Enables OpenMP at configure time")

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -167,7 +167,7 @@ class Gromacs(CMakePackage, CudaPackage):
     conflicts(
         "+nvshmem",
         when="+cufftmp",
-        msg=("The GROMACS suport for NVSHMEM does not work with the GROMACS support "
+        msg=("The GROMACS support for NVSHMEM does not work with the GROMACS support "
              "for cuFFTMp (even though cuFFTMp uses NVSHMEM in its implementation)",
     )
 

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -164,6 +164,8 @@ class Gromacs(CMakePackage, CudaPackage):
         description="Enable nvshmem support for nvidia gpus",
         when="+cuda+mpi",
     )
+    conflicts("+nvshmem", when="+cufftmp", msg="The GROMACS suport for NVSHMEM does not work with the GROMACS support for cuFFTMp (even though cuFFTMp uses NVSHMEM in its implementation)")
+
     variant("openmp", default=True, description="Enables OpenMP at configure time")
     variant("openmp_max_threads", default="none", description="Max number of OpenMP threads")
     conflicts(


### PR DESCRIPTION
These don't work in the same build configuration.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
