### PR TITLE
npb: fix mpi rank mismatch errors

### DIFF
--- a/var/spack/repos/builtin/packages/npb/package.py
+++ b/var/spack/repos/builtin/packages/npb/package.py
@@ -122,6 +122,10 @@ class Npb(MakefilePackage):
         nprocs = spec.variants["nprocs"].value
 
         if "implementation=mpi" in spec:
+            fflags = fflags = ["-O3"]
+            if spec.satisfies("%gcc@10:"):
+                fflags.append("-fallow-argument-mismatch")
+
             definitions = {
                 # Parallel Fortran
                 "MPIFC": spec["mpi"].mpifc,
@@ -129,7 +133,7 @@ class Npb(MakefilePackage):
                 "FLINK": spec["mpi"].mpif77,
                 "FMPI_LIB": spec["mpi"].libs.ld_flags,
                 "FMPI_INC": "-I" + spec["mpi"].prefix.include,
-                "FFLAGS": "-O3",
+                "FFLAGS": " ".join(fflags),
                 "FLINKFLAGS": "-O3",
                 # Parallel C
                 "MPICC": spec["mpi"].mpicc,


### PR DESCRIPTION
MPI variant has several rank mismatch errors, which are silently ignored. This downgrades the errors to warnings.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
