### PR TITLE
Don't ask about checksums on spack-develop packages

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1467,6 +1467,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
             checksum
             and (self.version not in self.versions)
             and (not isinstance(self.version, GitVersion))
+            and ("dev_path" not in self.spec.variants)
         ):
             tty.warn(
                 "There is no checksum on file to fetch %s safely."


### PR DESCRIPTION
Fix regression introduced in spack 0.22.1 #44950 where Spack would ask about checksums on spack-develop packages.

For example, before this PR:

```console
$ spack stage -p zlib zlib
$ spack install zlib@=1.3.1-test2 dev_path=$PWD/zlib/spack-src
[+] /usr (external glibc-2.35-cnh4togub6zgwj654ijdifcqektau4q3)
[+] /.../github.com/spack/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/gcc-runtime-12.3.0-3v6mo2xn55wd7bbla2bp53ynsuaxziu7
[+] /.../github.com/spack/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/gmake-4.4.1-d47qevmiioeufwd6l2yym263uyzgtyfy
==> Installing zlib-1.3.1-test2-p5awpz7dpkqpjkxig5ay2xihwoqpgs2v
==> No binary for zlib-1.3.1-test2-p5awpz7dpkqpjkxig5ay2xihwoqpgs2v found: installing from source
==> Warning: There is no checksum on file to fetch zlib@1.3.1-test2 safely.
==>   Fetch anyway? [y/N]
```

Now, it installs without compaints.
