### PR TITLE
podio: Add the new datasource variant once it is available

### DIFF
--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -80,6 +80,12 @@ class Podio(CMakePackage):
     )
     variant("sio", default=False, description="Build the SIO I/O backend")
     variant("rntuple", default=False, description="Build the RNTuple backend")
+    variant(
+        "datasource",
+        default=False,
+        description="Build the RDataSource for reading podio collections",
+        when="@1.0.2:",
+    )
 
     depends_on("root@6.08.06: cxxstd=17", when="cxxstd=17")
     depends_on("root@6.28.04: +root7", when="+rntuple")
@@ -106,6 +112,7 @@ class Podio(CMakePackage):
         args = [
             self.define_from_variant("ENABLE_SIO", "sio"),
             self.define_from_variant("ENABLE_RNTUPLE", "rntuple"),
+            self.define_from_variant("ENABLE_DATASOURCE", "datasource"),
             self.define("CMAKE_CXX_STANDARD", self.spec.variants["cxxstd"].value),
             self.define("BUILD_TESTING", self.run_tests),
         ]

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -88,6 +88,7 @@ class Podio(CMakePackage):
     )
 
     depends_on("root@6.08.06: cxxstd=17", when="cxxstd=17")
+    depends_on("root@6.14:", when="+datasource")
     depends_on("root@6.28.04: +root7", when="+rntuple")
     depends_on("root@6.28:", when="@0.17:")
     for cxxstd in ("17", "20"):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Add a variant `datasource` that allows to toggle the newly added `ENABLE_DATASOURCE` cmake flag, see https://github.com/AIDASoft/podio/pull/593