### PR TITLE
siesta: remove missing library

### DIFF
--- a/var/spack/repos/builtin/packages/siesta/package.py
+++ b/var/spack/repos/builtin/packages/siesta/package.py
@@ -190,9 +190,7 @@ class Siesta(MakefilePackage, CMakePackage):
                                         spec["netcdf-fortran"].prefix
                                     )
                                 )
-                                libs_arg.append(
-                                    "-L{0}/lib -lhdf5".format(spec["hdf5"].prefix)
-                                )
+                                libs_arg.append("-L{0}/lib -lhdf5".format(spec["hdf5"].prefix))
 
                         if "+metis" in spec:
                             libs_arg.append("-L{0} -lmetis".format(self.spec["metis"].prefix.lib))

--- a/var/spack/repos/builtin/packages/siesta/package.py
+++ b/var/spack/repos/builtin/packages/siesta/package.py
@@ -190,7 +190,6 @@ class Siesta(MakefilePackage, CMakePackage):
                                         spec["netcdf-fortran"].prefix
                                     )
                                 )
-                                libs_arg.append("-L{0}/lib -lhdf5".format(spec["hdf5"].prefix))
 
                         if "+metis" in spec:
                             libs_arg.append("-L{0} -lmetis".format(self.spec["metis"].prefix.lib))

--- a/var/spack/repos/builtin/packages/siesta/package.py
+++ b/var/spack/repos/builtin/packages/siesta/package.py
@@ -191,7 +191,7 @@ class Siesta(MakefilePackage, CMakePackage):
                                     )
                                 )
                                 libs_arg.append(
-                                    "-L{0}/lib -lhdf5_fortran -lhdf5".format(spec["hdf5"].prefix)
+                                    "-L{0}/lib -lhdf5".format(spec["hdf5"].prefix)
                                 )
 
                         if "+metis" in spec:


### PR DESCRIPTION
Siesta (netcdf-fortran/-c in fact) does not have a hdf5+fortran dependency. Thus spack will not produce libhdf5_fortran and trying to use it will fail (unless you have an external hdf5/reuse of a fdf5+fortran).