### PR TITLE
ELPA: Link against libamdhip64

### DIFF
--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -137,6 +137,20 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
     build_directory = "spack-build"
     parallel = False
 
+    def flag_handler(self, name, flags):
+        if self.spec.satisfies("+rocm"):
+            if name == "ldlibs":
+                # NOTE: hipcc may be used to build some files but the final link
+                # step is not done using hipcc. We must provide the libs.
+                # SPACK_LINK_DIRS already contains the library path.
+                flags.extend(
+                    [
+                        "-l{}".format(library.split("lib")[1])
+                        for library in self.spec["hip"].package.libraries
+                    ]
+                )
+        return flags, None, None
+
     def configure_args(self):
         spec = self.spec
         options = []

--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -143,12 +143,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
                 # NOTE: hipcc may be used to build some files but the final link
                 # step is not done using hipcc. We must provide the libs.
                 # SPACK_LINK_DIRS already contains the library path.
-                flags.extend(
-                    [
-                        "-l{}".format(library.split("lib")[1])
-                        for library in self.spec["hip"].package.libraries
-                    ]
-                )
+                flags.extend(self.spec["hip"].libs.link_flags.split())
         return flags, None, None
 
     def configure_args(self):


### PR DESCRIPTION
When building an elpa with the +rocm variant, Spack will mix compilers. For instance, we may end up with gcc for the fortran part and hipcc for the rest. 

At some point a link step happens, and we do not currently link using hipcc. In practice, hipcc implicitly adds the --hip-link flag to amdclang which makes clang link (among other things) against libamdhip64.so. We do not use hipcc for the final link step, so we need to do it ourselves.