### PR TITLE
PLUMED: Using a C compiler variable

### DIFF
--- a/var/spack/repos/builtin/packages/plumed/package.py
+++ b/var/spack/repos/builtin/packages/plumed/package.py
@@ -260,8 +260,8 @@ class Plumed(AutotoolsPackage):
     def patch(self):
         # Ensure Spack's wrappers are used to compile the Python interface
         env = (
-            'CXX="{0}" LDSHARED="{0} -pthread -shared" '
-            'CC="{1}" LDCXXSHARED="{0} -pthread -shared"'.format(spack_cxx, spack_cc)
+            'CC="{0}" LDSHARED="{0} -pthread -shared" '
+            'CXX="{1}" LDCXXSHARED="{1} -pthread -shared"'.format(spack_cc, spack_cxx)
         )
         filter_file(
             "plumed_program_name=plumed",

--- a/var/spack/repos/builtin/packages/plumed/package.py
+++ b/var/spack/repos/builtin/packages/plumed/package.py
@@ -260,8 +260,8 @@ class Plumed(AutotoolsPackage):
     def patch(self):
         # Ensure Spack's wrappers are used to compile the Python interface
         env = (
-            'CXX={0} LDSHARED="{0} -pthread -shared" '
-            'LDCXXSHARED="{0} -pthread -shared"'.format(spack_cxx)
+            'CXX="{0}" LDSHARED="{0} -pthread -shared" '
+            'CC="{1}" LDCXXSHARED="{0} -pthread -shared"'.format(spack_cxx, spack_cc)
         )
         filter_file(
             "plumed_program_name=plumed",


### PR DESCRIPTION
During the cython build step, we want to give python's setup tool which c compiler it should sue. Currently it falls out of confinement (does not use the spack wrappers) because we give it a cpp compiler instead. 

For fear of breaking stuff I just added the CC variable but I think what was meant initially was only `CC=.. LDSHARED=`.

@marcodelapierre 
