### PR TITLE
MGARD: Add more compiler leniency

### DIFF
--- a/var/spack/repos/builtin/packages/mgard/package.py
+++ b/var/spack/repos/builtin/packages/mgard/package.py
@@ -74,10 +74,15 @@ class Mgard(CMakePackage, CudaPackage):
 
     def flag_handler(self, name, flags):
         if name == "cxxflags":
-            if self.spec.satisfies("@2020-10-01 %oneapi@2023:"):
-                flags.append("-Wno-error=c++11-narrowing")
-            if self.spec.satisfies("@2020-10-01 %apple-clang@15:"):
-                flags.append("-Wno-error=c++11-narrowing")
+            for a_spec in [
+                "@2020-10-01 %oneapi@2023:",
+                "@2020-10-01 %apple-clang@15:",
+                "@2020-10-01 %aocc@3:",
+                "@2020-10-01 %cce@15:",
+                "@2020-10-01 %rocmcc@4:",
+            ]:
+                if self.spec.satisfies(a_spec):
+                    flags.append("-Wno-error=c++11-narrowing")
         return (flags, None, None)
 
     def cmake_args(self):


### PR DESCRIPTION
Add more compiler leniency so that more compiler can be used to build this package.

Note that the lower bound of the compiler version below are approximate has I do not have all of them available for testing.

@robertu94
