### PR TITLE
PETSC: Detect Cray wrapper and not cray compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/crape.diff
+++ b/var/spack/repos/builtin/packages/petsc/crape.diff
@@ -1,0 +1,20 @@
+--- spack-src/config/BuildSystem/config/setCompilers.py	2024-08-26 16:33:45.394302234 +0200
++++ spack-src/config/BuildSystem/config/setCompilers.py.patched	2024-08-26 16:33:39.483376156 +0200
+@@ -519,7 +519,7 @@
+     '''Returns true if the compiler is a Cray Programming Environment (PE) wrapper compiler'''
+     # Note with Cray module PrgEnv-gnu, cc is a Cray PE wrapper around gcc, but not a Cray compiler on its own.
+     try:
+-      (output, error, status) = config.base.Configure.executeShellCommand(compiler+' --help', log = log)
++      (output, error, status) = config.base.Configure.executeShellCommand(compiler+' --cray-print-opts', log = log)
+       output = output + error
+       # On OLCF Spock, with PrgEnv-cray
+       #     $ cc --help |& grep "\-craype\-"
+@@ -527,7 +527,7 @@
+       # with PrgEnv-gnu, the output is
+       #     -craype-verbose    Print the command which is forwarded
+       #     ...
+-      if output.find('-craype-') >= 0:
++      if status:
+         if log: log.write('Detected Cray PE wrapper compiler\n')
+         return 1
+     except RuntimeError:

--- a/var/spack/repos/builtin/packages/petsc/crape.diff
+++ b/var/spack/repos/builtin/packages/petsc/crape.diff
@@ -1,20 +1,33 @@
---- spack-src/config/BuildSystem/config/setCompilers.py	2024-08-26 16:33:45.394302234 +0200
-+++ spack-src/config/BuildSystem/config/setCompilers.py.patched	2024-08-26 16:33:39.483376156 +0200
-@@ -519,7 +519,7 @@
-     '''Returns true if the compiler is a Cray Programming Environment (PE) wrapper compiler'''
-     # Note with Cray module PrgEnv-gnu, cc is a Cray PE wrapper around gcc, but not a Cray compiler on its own.
+--- spack-src/config/BuildSystem/config/setCompilers.py	2024-08-29 14:52:04.889517604 +0200
++++ spack-src/config/BuildSystem/config/setCompilers.py.patched	2024-08-29 14:52:33.554153906 +0200
+@@ -516,19 +516,19 @@
+ 
+   @staticmethod
+   def isCrayPEWrapper(compiler, log):
+-    '''Returns true if the compiler is a Cray Programming Environment (PE) wrapper compiler'''
+-    # Note with Cray module PrgEnv-gnu, cc is a Cray PE wrapper around gcc, but not a Cray compiler on its own.
++    '''Returns true if the compiler is a Cray Programming Environment (PE) wrapped compiler'''
++    # NOTE: details on this method in: https://github.com/spack/spack/pull/46086
      try:
 -      (output, error, status) = config.base.Configure.executeShellCommand(compiler+' --help', log = log)
-+      (output, error, status) = config.base.Configure.executeShellCommand(compiler+' --cray-print-opts', log = log)
++      canary_value = '5dde31d2'
++      (output, error, status) = config.base.Configure.executeShellCommand(
++        f'CRAY_CPU_TARGET="{canary_value}" {compiler} --version',
++        checkCommand=config.base.Configure.passCheckCommand,
++        log=log,
++      )
        output = output + error
-       # On OLCF Spock, with PrgEnv-cray
-       #     $ cc --help |& grep "\-craype\-"
-@@ -527,7 +527,7 @@
-       # with PrgEnv-gnu, the output is
-       #     -craype-verbose    Print the command which is forwarded
-       #     ...
+-      # On OLCF Spock, with PrgEnv-cray
+-      #     $ cc --help |& grep "\-craype\-"
+-      #     Use --craype-help for CrayPE specific options.
+-      # with PrgEnv-gnu, the output is
+-      #     -craype-verbose    Print the command which is forwarded
+-      #     ...
 -      if output.find('-craype-') >= 0:
-+      if status:
-         if log: log.write('Detected Cray PE wrapper compiler\n')
+-        if log: log.write('Detected Cray PE wrapper compiler\n')
++      if output.find(canary_value) >= 0:
++        if log:
++          log.write('Detected Cray PE compiler wrapper\n')
          return 1
      except RuntimeError:
+       pass

--- a/var/spack/repos/builtin/packages/petsc/craype.diff
+++ b/var/spack/repos/builtin/packages/petsc/craype.diff
@@ -1,18 +1,18 @@
---- spack-src/config/BuildSystem/config/setCompilers.py	2024-08-29 14:52:04.889517604 +0200
-+++ spack-src/config/BuildSystem/config/setCompilers.py.patched	2024-08-29 14:52:33.554153906 +0200
+--- spack-src/config/BuildSystem/config/setCompilers.py	2024-07-30 18:45:24.000000000 +0200
++++ spack-src/config/BuildSystem/config/setCompilers.py.patched	2024-09-05 10:02:11.471106573 +0200
 @@ -516,19 +516,19 @@
  
    @staticmethod
    def isCrayPEWrapper(compiler, log):
 -    '''Returns true if the compiler is a Cray Programming Environment (PE) wrapper compiler'''
 -    # Note with Cray module PrgEnv-gnu, cc is a Cray PE wrapper around gcc, but not a Cray compiler on its own.
-+    '''Returns true if the compiler is a Cray Programming Environment (PE) wrapped compiler'''
-+    # NOTE: details on this method in: https://github.com/spack/spack/pull/46086
++    '''Returns true if the compiler is a Cray Programming Environment (PE) compiler wrapper'''
      try:
 -      (output, error, status) = config.base.Configure.executeShellCommand(compiler+' --help', log = log)
++      # Cray PE compiler wrappers (e.g., cc) when invoked with --version option will complain when CRAY_CPU_TARGET is set to erroneous value, but Cray raw compilers (e.g., craycc) won't. So use this behavior to differentiate cc from craycc.
 +      canary_value = '5dde31d2'
 +      (output, error, status) = config.base.Configure.executeShellCommand(
-+        f'CRAY_CPU_TARGET="{canary_value}" {compiler} --version',
++        'CRAY_CPU_TARGET="%s" %s --version' % (canary_value, compiler),
 +        checkCommand=config.base.Configure.passCheckCommand,
 +        log=log,
 +      )

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -231,6 +231,8 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     patch("disable-DEPRECATED_ENUM.diff", when="@3.14.1 +cuda")
     patch("revert-3.18.0-ver-format-for-dealii.patch", when="@3.18.0")
 
+    patch("crape.diff", when="@3.16:")
+
     depends_on("diffutils", type="build")
     # not listed as a "build" dependency - so that slepc build gets the same dependency
     depends_on("gmake")

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -231,7 +231,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     patch("disable-DEPRECATED_ENUM.diff", when="@3.14.1 +cuda")
     patch("revert-3.18.0-ver-format-for-dealii.patch", when="@3.18.0")
 
-    patch("crape.diff", when="@3.16:")
+    patch("craype.diff", when="@3.16:")
 
     depends_on("diffutils", type="build")
     # not listed as a "build" dependency - so that slepc build gets the same dependency


### PR DESCRIPTION
Since v3.16, petsc detect the cray wrappers like using the `--help` flag and parsing the output looking for the string `-craype-`.
See: https://github.com/petsc/petsc/commit/a97d815f5d70aea1b0a428861d8a029fac1f1468#diff-8060c7ad6c99476835f06c0be63735c99b5f466a58b22243b8dcec6939fa104f

The --help flag returns the help of the crayclang compiler and not something related to the wrappers. It is absolutely possible that someone use craycc,crayCC,crayftn without the wrappers (for good reasons). 

The petsc detection machinery does not account for the above.

I propose instead something relying on the presence or not of a flag which is exclusive to the cray wrapper: `--cray-print-opts` if the command fails, we do not use a cray wrapper, else we should assume we do.

@balay @barrysmith @jedbrown