### PR TITLE
unzip: use more generic strip flag for cce

### DIFF
--- a/var/spack/repos/builtin/packages/unzip/package.py
+++ b/var/spack/repos/builtin/packages/unzip/package.py
@@ -22,7 +22,7 @@ class Unzip(MakefilePackage):
     # clang and oneapi need this patch, likely others
     # There is no problem with it on gcc, so make it a catch all
     patch("configure-cflags.patch")
-    patch("strip.patch", when="%cce@:18.0.1")
+    patch("strip.patch")
 
     def get_make_args(self):
         make_args = ["-f", join_path("unix", "Makefile")]

--- a/var/spack/repos/builtin/packages/unzip/package.py
+++ b/var/spack/repos/builtin/packages/unzip/package.py
@@ -14,7 +14,9 @@ class Unzip(MakefilePackage):
 
     license("custom")
 
-    version("6.0", sha256="036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37")
+    version(
+        "6.0", sha256="036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37"
+    )
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
@@ -22,6 +24,7 @@ class Unzip(MakefilePackage):
     # clang and oneapi need this patch, likely others
     # There is no problem with it on gcc, so make it a catch all
     patch("configure-cflags.patch")
+    patch("strip.patch", when="%cce@:18.0.1")
 
     def get_make_args(self):
         make_args = ["-f", join_path("unix", "Makefile")]
@@ -31,7 +34,7 @@ class Unzip(MakefilePackage):
         cflags.append("-Wno-error=implicit-int")
         cflags.append("-DLARGE_FILE_SUPPORT")
 
-        make_args.append(f"LOC=\"{' '.join(cflags)}\"")
+        make_args.append(f"LOC={' '.join(cflags)}")
         return make_args
 
     @property

--- a/var/spack/repos/builtin/packages/unzip/package.py
+++ b/var/spack/repos/builtin/packages/unzip/package.py
@@ -14,9 +14,7 @@ class Unzip(MakefilePackage):
 
     license("custom")
 
-    version(
-        "6.0", sha256="036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37"
-    )
+    version("6.0", sha256="036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated

--- a/var/spack/repos/builtin/packages/unzip/strip.patch
+++ b/var/spack/repos/builtin/packages/unzip/strip.patch
@@ -1,0 +1,11 @@
+--- spack-src/unix/configure	2024-08-23 14:21:34.822163922 +0200
++++ spack-src/unix/configure.patched	2024-08-23 14:27:24.862640828 +0200
+@@ -17,7 +17,7 @@
+ IZ_BZIP2=${3}
+ CFLAGS="${CFLAGS} -I. -DUNIX"
+ LFLAGS1=""
+-LFLAGS2="-s"
++LFLAGS2="-Wl,-s"
+ LN="ln -s"
+ 
+ CFLAGS_OPT=''


### PR DESCRIPTION
No quotes around the flags, its already going to be passed as one argument. If we use quotes, we'll call `make` like so:
```
$ make ... 'LOC="-Wno-error=implicit-function-declaration -Wno-error=implicit-int -DLARGE_FILE_SUPPORT"'
```
Which will execute target `flags:  unix/configure` giving:
```
$ sh unix/configure "cc" "-I. -Ibzip2 -DUNIX "-Wno-error=implicit-function-declaration -Wno-error=implicit-int -DLARGE_FILE_SUPPORT"" "bzip2"
```
Notice how the double quoting is broken. This misleads the script into promoting `-Wno-error=implicit-int` as the directory containing the bzip2 libraries. For instance:
```
$ cc -o unzip -L-Wno-error=implicit-int unzip.o ... unshrink.o zipinfo.o unix.o -s
```
Now that issue in itself is not that bad, it wont change the build process and most compiler will ignore that weird `-L`.

The next issue is that the "-s" flag that gcc takes in and passes automatically to the linker is not well supported by the cray compiler (crashes cray's crayclang..). One can instead use `-Wl,-s`. And this should be fixed with cce 18.0.1.

@wdconinc @alecbcs 