### PR TITLE
RPackage: new variant +suggests for suggested dependencies

### DIFF
--- a/lib/spack/docs/build_systems/rpackage.rst
+++ b/lib/spack/docs/build_systems/rpackage.rst
@@ -257,7 +257,9 @@ These are optional, rarely-used dependencies that a user might find
 useful. You should **NOT** add these dependencies to your package.
 R packages already have enough dependencies as it is, and adding
 optional dependencies can really slow down the concretization
-process. They can also introduce circular dependencies.
+process. They can also introduce circular dependencies. If you really
+consider the installation of suggested packages to be important, then
+you can add these dependencies conditional on the `suggests` variant.
 
 A fifth rarely used section is:
 

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -77,6 +77,15 @@ class RPackage(Package):
 
     extends("r")
 
+    # R packages have a field "Suggests" in their DESCRIPTION file, and
+    # this build system wide variant allows for depending on these packages
+    # conditionally.
+    variant(
+        "suggests",
+        default=False,
+        description="Install suggested dependencies",
+    )
+
     @lang.classproperty
     def homepage(cls):
         if cls.cran:

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -7,7 +7,7 @@ from typing import Optional, Tuple
 
 import llnl.util.lang as lang
 
-from spack.directives import extends
+from spack.directives import extends, variant
 
 from .generic import GenericBuilder, Package
 


### PR DESCRIPTION
This PR adds a new R-package build system-wide variant `suggests` to deal with the `Suggests:` entries in the package `DESCRIPTION` file. See https://r-pkgs.org/description.html#sec-description-imports-suggests for details:
> Packages listed in Suggests are either needed for development tasks or might unlock optional functionality for your users. The lines below indicate that, while your package can take advantage of [the listed packages], they’re not absolutely required.

There are a few cases (e.g. `r-filelock`) where the currently required dependencies can be changed to suggested dependencies.

There are no conflicts with existing variants with this name (anywhere in the builtin repository).