### PR TITLE
lammps: use the Cray GTL

### DIFF
--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -792,6 +792,22 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
 
     root_cmakelists_dir = "cmake"
 
+    def flag_handler(self, name, flags):
+        wrapper_flags = []
+        build_system_flags = []
+
+        if self.spec.satisfies("+rocm"):
+            if self.spec.satisfies("^cray-mpich"):
+                gtl_lib = self.spec["cray-mpich"].package.gtl_lib
+                build_system_flags.extend(gtl_lib.get(name) or [])
+            # hipcc is not wrapped, we need to pass the flags via the build
+            # system.
+            build_system_flags.extend(flags)
+        else:
+            wrapper_flags.extend(flags)
+
+        return (wrapper_flags, [], build_system_flags)
+
     def cmake_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -796,8 +796,8 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
         wrapper_flags = []
         build_system_flags = []
 
-        if self.spec.satisfies("+rocm"):
-            if self.spec.satisfies("^cray-mpich"):
+        if self.spec.satisfies("+mpi+cuda") or self.spec.satisfies("+mpi+rocm"):
+            if self.spec.satisfies("^[virtuals=mpi] cray-mpich"):
                 gtl_lib = self.spec["cray-mpich"].package.gtl_lib
                 build_system_flags.extend(gtl_lib.get(name) or [])
             # hipcc is not wrapped, we need to pass the flags via the build


### PR DESCRIPTION
When using Cray's MPICH and wanting GPU awareness one should make sure that the GPU Transport Layer (GTL) is linked.

This GTL generally manifest itself through the Cray compiler wrappers (cc/CC/ftn) and is automatically linked when the module like `craype-accel-amd-gfx90a` (for MI250X) are loaded.

If one does not use the Cray wrappers, a manual GTL link step must be done.

I prepared a fix for the cray-mpich package that adds the facility to get the GTL's path and library name (https://github.com/spack/spack/pull/45830). So this PR is dependent on #45830.

Then, using a classical flag handler, we can inject the library flags into the build. (note that this added flag handler also fixes the issue where hipcc does not get forwarded its ldflag/ldlibs spec flags because it is NOT wrapped by spack https://github.com/spack/spack/issues/45690)

@rbberger