### PR TITLE
troubleshoot trilinos issue

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -297,7 +297,10 @@ class CMakeBuilder(BaseBuilder):
     @property
     def archive_files(self):
         """Files to archive for packages based on CMake"""
-        files = [os.path.join(self.build_directory, "CMakeCache.txt")]
+        files = [
+            os.path.join(self.build_directory, "CMakeCache.txt"),
+            os.path.join(self.build_directory, "CMakeFiles", "CMakeConfigureLog.yaml"),
+        ]
         if _supports_compilation_databases(self):
             files.append(os.path.join(self.build_directory, "compile_commands.json"))
         return files

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -851,6 +851,8 @@ aws-pcluster-build-neoverse_v1:
 .generate-cray:
   extends: [ ".generate-common", ".base-job" ]
   before_script:
+    - env -i ldd /opt/cray/pe/libsci/23.02.1.1/CRAY/9.0/x86_64/lib/libsci_cray.so
+    - nm --undefined-only --dynamic /opt/cray/pe/libsci/23.02.1.1/CRAY/9.0/x86_64/lib/libsci_cray.so
     - echo $PATH
     - module avail
     - module list

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -885,6 +885,7 @@ e4s-cray-rhel-generate:
   extends: [ ".generate-cray-rhel", ".e4s-cray-rhel" ]
 
 e4s-cray-rhel-build:
+  allow_failure: true
   extends: [ ".build", ".e4s-cray-rhel" ]
   trigger:
     include:
@@ -907,6 +908,7 @@ e4s-cray-sles-generate:
   extends: [ ".generate-cray-sles", ".e4s-cray-sles" ]
 
 e4s-cray-sles-build:
+  allow_failure: true
   extends: [ ".build", ".e4s-cray-sles" ]
   trigger:
     include:

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -108,6 +108,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     variant("shared", default=True, description="Enables the build of shared libraries")
     variant("uvm", default=False, when="@13.2: +cuda", description="Turn on UVM for CUDA build")
     variant("wrapper", default=False, description="Use nvcc-wrapper for CUDA build")
+    variant("remove_me", default=True, description="Remove me")
 
     # Makes the Teuchos Memory Management classes (Teuchos::RCP, Teuchos::Ptr, Teuchos::Array,
     # Teuchos::ArrayView, and Teuchos::ArrayRCP) thread-safe. Requires at least the OMP kokkos


### PR DESCRIPTION
The issue seems to be that `/opt/cray/pe/libsci/23.02.1.1/CRAY/9.0/x86_64/lib/libsci_cray.so` does not list `libdl.so` in DT_NEEDED.

It's just that a dependency pulls it in, which is maybe enough to make the runtime linker happy, but `ld.lld` does not like it and errors out:

```
ld.lld: error: undefined reference due to --no-allow-shlib-undefined: dlclose
>>> referenced by /opt/cray/pe/libsci/23.02.1.1/CRAY/9.0/x86_64/lib/libsci_cray.so
```

```
$ libtree -vv /opt/cray/pe/libsci/23.02.1.1/CRAY/9.0/x86_64/lib/libsci_cray.so
libsci_cray.so.5
├── libquadmath.so.0 [ld.so.conf]
│   ├── libm.so.6 [default path]
│   │   ├── libc.so.6 [default path]
│   │   │   └── ld-linux-x86-64.so.2 [default path]
│   │   └── ld-linux-x86-64.so.2 [default path]
│   └── libc.so.6 [default path]
├── libf.so.1 [ld.so.conf]
│   ├── libu.so.1 [runpath]
│   │   ├── libcsup.so.1 [runpath]
│   │   │   ├── librt.so.1 [default path]
│   │   │   │   ├── libpthread.so.0 [default path]
│   │   │   │   │   ├── libc.so.6 [default path]
│   │   │   │   │   └── ld-linux-x86-64.so.2 [default path]
│   │   │   │   └── libc.so.6 [default path]
│   │   │   └── libc.so.6 [default path]
│   │   ├── libquadmath.so.0 [runpath]
│   │   │   ├── libm.so.6 [default path]
│   │   │   └── libc.so.6 [default path]
│   │   ├── libstdc++.so.6 [runpath]
│   │   │   ├── libgcc_s.so.1 [ld.so.conf]
│   │   │   │   └── libc.so.6 [default path]
│   │   │   ├── libm.so.6 [default path]
│   │   │   ├── ld-linux-x86-64.so.2 [default path]
│   │   │   └── libc.so.6 [default path]
│   │   ├── libgcc_s.so.1 [runpath]
│   │   ├── librt.so.1 [default path]
│   │   ├── libm.so.6 [default path]
│   │   ├── libc.so.6 [default path]
│   │   ├── libpthread.so.0 [default path]
│   │   ├── libdl.so.2 [default path]
│   │   │   ├── libc.so.6 [default path]
│   │   │   └── ld-linux-x86-64.so.2 [default path]
│   │   └── ld-linux-x86-64.so.2 [default path]
│   ├── libcsup.so.1 [runpath]
│   ├── librt.so.1 [default path]
│   ├── libpthread.so.0 [default path]
│   ├── libc.so.6 [default path]
│   ├── ld-linux-x86-64.so.2 [default path]
│   └── libm.so.6 [default path]
├── libfi.so.1 [ld.so.conf]
│   ├── libmodules.so.1 [runpath]
│   │   ├── libfi.so.1 [runpath]
│   │   ├── libf.so.1 [runpath]
│   │   ├── libquadmath.so.0 [runpath]
│   │   ├── libu.so.1 [runpath]
│   │   ├── librt.so.1 [default path]
│   │   ├── libc.so.6 [default path]
│   │   └── libm.so.6 [default path]
│   ├── libf.so.1 [runpath]
│   ├── libquadmath.so.0 [runpath]
│   ├── libcraymath.so.1 [runpath]
│   │   ├── libquadmath.so.0 [runpath]
│   │   ├── libu.so.1 [runpath]
│   │   ├── libgfortran.so.5 [runpath]
│   │   │   ├── libquadmath.so.0 [rpath]
│   │   │   ├── libgcc_s.so.1 [rpath]
│   │   │   ├── ld-linux-x86-64.so.2 [default path]
│   │   │   ├── libc.so.6 [default path]
│   │   │   └── libm.so.6 [default path]
│   │   ├── libm.so.6 [default path]
│   │   ├── libc.so.6 [default path]
│   │   └── librt.so.1 [default path]
│   ├── libu.so.1 [runpath]
│   ├── librt.so.1 [default path]
│   ├── libc.so.6 [default path]
│   └── libm.so.6 [default path]
├── libcsup.so.1 [ld.so.conf]
├── libu.so.1 [ld.so.conf]
├── libcraymath.so.1 [ld.so.conf]
├── libmodules.so.1 [ld.so.conf]
├── libc.so.6 [default path]
├── libpthread.so.0 [default path]
├── libm.so.6 [default path]
└── ld-linux-x86-64.so.2 [default path]
```