### PR TITLE
cray ci: dont use cray-libsci

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-rhel/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-rhel/spack.yaml
@@ -14,8 +14,6 @@ spack:
       - "%cce"
       compiler: [cce]
       providers:
-        blas: [cray-libsci]
-        lapack: [cray-libsci]
         mpi: [cray-mpich]
         tbb: [intel-tbb]
         scalapack: [netlib-scalapack]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-sles/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-cray-sles/spack.yaml
@@ -12,8 +12,6 @@ spack:
     all:
       require: '%gcc'
       providers:
-        blas: [cray-libsci]
-        lapack: [cray-libsci]
         mpi: [cray-mpich]
         tbb: [intel-tbb]
         scalapack: [netlib-scalapack]


### PR DESCRIPTION
cray-libsci fails to specify its dependency on libdl.so, which causes
issues when linking to it with ld.lld, which by defaults wants all
symbols to be resolvable.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
