### PR TITLE
Dynamic Resource Allocation for AWS Builds

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -5,6 +5,15 @@ ci:
       # Test package relocation on linux using a modified prefix
       # This is not well supported on MacOS (https://github.com/spack/spack/issues/37162)
       - - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+  - dynamic-mapping:
+    endpoint: spack-gantry.spack.svc.cluster.local/v1/allocation
+    timeout: 1
+    verify_ssl: True
+    attributes:
+      allow:
+      - variables
+      require:
+      - variables
   - match_behavior: first
     submapping:
     - match:

--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -6,6 +6,7 @@ ci:
       # This is not well supported on MacOS (https://github.com/spack/spack/issues/37162)
       - - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
   - dynamic-mapping:
+    name: spack-gantry
     endpoint: spack-gantry.spack.svc.cluster.local/v1/allocation
     timeout: 1
     verify_ssl: True


### PR DESCRIPTION
**Do not merge until I confirm the service is ready for production.**

----

**Overview**
CI jobs require varying amounts of resources depending on the spec. For builds in the K8s cluster on AWS, resource requests attached to jobs are used to decide where to allocate jobs, which influences the instance types that will be provisioned. We can keep our costs low and ensure responsible use of the CI by only requesting the resources necessary to perform builds.

Currently, requests are manually defined on a per-spec basis at [`share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml`](https://github.com/spack/spack/blob/develop/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml). This is not a sustainable solution, as it requires someone to continuously monitor the resource usage of each spec, and make modifications as needed. This has not been feasible so far.

We are hoping to optimize jobs for their average resource utilization ratio, which can be defined as:

```math
\text{UR}_{\text{CPU}} = \frac{\text{CPU}_{\text{usage avg}}}{\text{CPU}_{\text{request}}}
```

```math
\text{UR}_{\text{RAM}} = \frac{\text{RAM}_{\text{usage avg}}}{\text{RAM}_{\text{request}}}
```

<br>

Under the fixed allocations, $`\text{UR}_\text{CPU} = 0.65`$ and $`\text{UR}_{RAM} = 0.17`$. In Kubernetes, requests are meant to represent the average load of an application, while limits should approximate maximum usage. However, $`\frac{\text{RAM}_{\text{usage max}}}{\text{RAM}_{\text{request}}} = 0.42`$ across all the builds in our dataset ($n = 171540$), which is somehow even more surprising. We are leaving time and money on the table with these wildly inaccurate allocations.

To rectify this, @alecbcs and I have developed a web app ([spack-gantry](https://github.com/spack/spack-gantry)) that exposes an endpoint to predict the resource usage of a spec using a relatively simple model and past data for jobs in AWS. Using these dynamic allocations, we improve the utilization ratios to:

```math
\text{UR}_{\text{CPU}} = 0.85
```

```math
\text{UR}_{\text{RAM}} = 0.87
```

<br>

An added benefit of this model is that predictions will be conditioned on the complexity of enabled variants. For instance, if your package with `~cuda` consumes an average of 10MB of memory, but with `+cuda` it quadruples, the model is be aware of these differences and will only use appropriate samples to predict usage for this package.

**What does this PR actually do?**
The changes create an additional step to the CI generate process. For each spec, a request will be made to an API endpoint, which will return a response similar to:

```json
{
	"KUBERNETES_CPU_REQUEST": "2000m",
	"KUBERNETES_MEMORY_REQUEST": "2000M"
}
```

I've done some performance testing and each response averaged 1.5 milliseconds. Assuming there are 60,000 daily requests, this would add approximately 1.5-3 minutes of overhead per day.

Spack will apply these variables to the CI job environment if the job is on AWS. On UO runners, these variables will be ignored.

**Safeguards**
Our main goals are to improve the accuracy of the utilization ratio and be maximally efficient with our cloud consumption.

As this PR is the first step, we want to minimize any detrimental effects. We've ensured that any resource requests will not be lower than current levels (on a per-spec basis). 

Like the current setup, we are not enforcing resource limits that would result in unnecessary OOM kills or slowdowns. In the future, we will remove these safeguards to improve prediction accuracy after extensive testing and validation.

If there is a failure reaching Gantry's HTTP endpoint, Spack will default to the current allocations, resulting in minimal interruptions to the CI generate step.

depends on #41622 