### PR TITLE
Executable: make the timeout message readable

### DIFF
--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -275,9 +275,9 @@ class Executable:
             long_msg = cmd_line_string + f"\n{result}"
             if fail_on_error:
                 raise ProcessTimeoutError(
-                    f"\nProcess timed out after {timeout}s"
-                    f"We expected the following command to run quickly but\
-it did not, please report this as an issue: {long_msg}",
+                    f"\nProcess timed out after {timeout}s. "
+                    "We expected the following command to run quickly but it did not, "
+                    f"please report this as an issue: {long_msg}",
                     long_message=long_msg,
                 ) from te
 


### PR DESCRIPTION
I had to do a double take reading the message after adding a timeout to an executable.  The message before the change:
```
Process timed out after 2sWe expected the following command to run quickly butit did not, please report this as an issue: ...
```

And after:
```
Process timed out after 2s. We expected the following command to run quickly but it did not, please report this as an issue: ...
```

Note: The change was manually tested within #45383 (though is not included in that PR).