### PR TITLE
py-mypy: add v1.11.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-mypy/package.py
+++ b/var/spack/repos/builtin/packages/py-mypy/package.py
@@ -17,6 +17,7 @@ class PyMypy(PythonPackage):
 
     license("MIT AND PSF-2.0", checked_by="tgamblin")
 
+    version("1.11.2", sha256="7f9993ad3e0ffdc95c2a14b66dee63729f021968bff8ad911867579c65d13a79")
     version("1.11.1", sha256="f404a0b069709f18bbdb702eb3dcfe51910602995de00bd39cea3050b5772d08")
     version("1.10.1", sha256="1f8f492d7db9e3593ef42d4f115f04e556130f2819ad33ab84551403e97dd4c0")
     version("1.9.0", sha256="3cc5da0127e6a478cddd906068496a97a7618a21ce9b54bde5bf7e539c7af974")


### PR DESCRIPTION
This PR adds py-mypy v1.11.2. No changes needed (https://github.com/python/mypy/compare/v1.11.1...v1.11.2). Still not smart enough for functools.partial:
```
root@codespaces-fb731a:/workspaces/spack# spack style -t mypy
==> Running style checks on spack
  selected: mypy
==> Modified files
  var/spack/repos/builtin/packages/py-mypy/package.py
==> Running mypy checks
/workspaces/spack/pyproject.toml: [mypy]: python_version: Python 3.7 is not supported (must be 3.8 or higher). You may need to put quotes around your Python version
lib/spack/spack/filesystem_view.py:183: error: Unexpected keyword argument "view"  [call-arg]
Found 1 error in 1 file (checked 620 source files)
  mypy found errors
==> Error: spack style found errors
```