### PR TITLE
codespaces: add ubuntu22.04

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,0 @@
-{
-  "image": "ghcr.io/spack/ubuntu20.04-runner-amd64-gcc-11.4:2023.08.01",
-  "postCreateCommand": "./.devcontainer/postCreateCommand.sh"
-}

--- a/.devcontainer/ubuntu20.04/devcontainer.json
+++ b/.devcontainer/ubuntu20.04/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ubuntu 20.04",
+  "image": "ghcr.io/spack/ubuntu20.04-runner-amd64-gcc-11.4:2023.08.01",
+  "postCreateCommand": "./.devcontainer/postCreateCommand.sh"
+}

--- a/.devcontainer/ubuntu22.04/devcontainer.json
+++ b/.devcontainer/ubuntu22.04/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ubuntu 22.04",
+  "image": "ghcr.io/spack/ubuntu-22.04:v2024-05-07",
+  "postCreateCommand": "./.devcontainer/postCreateCommand.sh"
+}


### PR DESCRIPTION
This PR adds a codespaces config for ubuntu22.04 (while keeping ubuntu20.04 as well). Both options are supported with about 1k binary packages in the CI pipelines.

![image](https://github.com/user-attachments/assets/17f841e1-160a-448c-9524-85119e4ba1b3)
