### PR TITLE
Installer: queue only link/run deps unless building from source

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1991,8 +1991,14 @@ class PackageInstaller:
                 dep_pkg = dep.package
                 dep_id = package_id(dep)
 
+                # Add a new task if we need one
                 if dep_id not in self.build_tasks and dep_id not in self.installed:
                     self._add_init_task(dep_pkg, task.request, False, self.all_dependencies)
+                # Add edges for an existing task if it exists
+                elif dep_id in self.build_tasks:
+                    for parent in dep.dependents():
+                        parent_id = package_id(parent)
+                        self.build_tasks[dep_id].add_dependent(parent_id)
 
                 # Clear any persistent failure markings _unless_ they
                 # are associated with another process in this parallel build

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2075,7 +2075,7 @@ class PackageInstaller:
         fail_fast = bool(request.install_args.get("fail_fast"))
         self.fail_fast = self.fail_fast or fail_fast
 
-    def _complete_task(self, task: Task, install_status: InstallStatus) -> None:
+    def _complete_task(self, task: Task, install_status: InstallStatus) -> ExecuteResult:
         """
         Complete the installation of the requested spec and/or dependency
         represented by the task.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -144,8 +144,7 @@ SPEC_FORMAT_RE = re.compile(
     r"(})?"  # finish format string with non-escaped close brace }, or missing if not present
     r"|"
     # OPTION 3: mismatched close brace (option 2 would consume a matched open brace)
-    r"(})"  # brace
-    r")",
+    r"(})" r")",  # brace
     re.IGNORECASE,
 )
 
@@ -5446,6 +5445,21 @@ def eval_conditional(string):
     valid_variables = get_host_environment()
     valid_variables.update({"re": re, "env": os.environ})
     return eval(string, valid_variables)
+
+
+class DagCountVisitor:
+    """Class for counting the number of specs encountered during traversal."""
+
+    def __init__(self, depflag: int):
+        self.depflag: int = depflag
+        self.number: int = 0
+
+    def accept(self, item: spack.traverse.EdgeAndDepth) -> bool:
+        self.number += 1
+        return True
+
+    def neighbors(self, item: spack.traverse.EdgeAndDepth):
+        return item.edge.spec.edges_to_dependencies(depflag=self.depflag)
 
 
 class InvalidVariantForSpecError(spack.error.SpecError):

--- a/lib/spack/spack/test/buildrequest.py
+++ b/lib/spack/spack/test/buildrequest.py
@@ -56,33 +56,14 @@ def test_build_request_strings(install_mockery):
 
 
 @pytest.mark.parametrize(
-    "package_cache_only,dependencies_cache_only,package_deptypes,dependencies_deptypes",
-    [
-        (False, False, dt.BUILD | dt.LINK | dt.RUN, dt.BUILD | dt.LINK | dt.RUN),
-        (True, False, dt.LINK | dt.RUN, dt.BUILD | dt.LINK | dt.RUN),
-        (False, True, dt.BUILD | dt.LINK | dt.RUN, dt.LINK | dt.RUN),
-        (True, True, dt.LINK | dt.RUN, dt.LINK | dt.RUN),
-    ],
+    "include_build_deps,deptypes", [(True, dt.BUILD | dt.LINK | dt.RUN), (False, dt.LINK | dt.RUN)]
 )
-def test_build_request_deptypes(
-    install_mockery,
-    package_cache_only,
-    dependencies_cache_only,
-    package_deptypes,
-    dependencies_deptypes,
-):
+def test_build_request_deptypes(install_mockery, include_build_deps, deptypes):
     s = spack.concretize.concretize_one("dependent-install")
 
-    build_request = inst.BuildRequest(
-        s.package,
-        {
-            "package_cache_only": package_cache_only,
-            "dependencies_cache_only": dependencies_cache_only,
-        },
-    )
+    build_request = inst.BuildRequest(s.package, {"include_build_deps": include_build_deps})
 
-    actual_package_deptypes = build_request.get_depflags(s.package)
-    actual_dependency_deptypes = build_request.get_depflags(s["dependency-install"].package)
+    package_deptypes = build_request.get_depflags(s.package)
+    dependency_deptypes = build_request.get_depflags(s["dependency-install"].package)
 
-    assert actual_package_deptypes == package_deptypes
-    assert actual_dependency_deptypes == dependencies_deptypes
+    assert package_deptypes == dependency_deptypes == deptypes

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -79,7 +79,7 @@ def create_build_task(
 
 def create_install_task(
     pkg: spack.package_base.PackageBase, install_args: Optional[dict] = None
-) -> inst.BuildTask:
+) -> inst.InstallTask:
     request = inst.BuildRequest(pkg, {} if install_args is None else install_args)
     return inst.InstallTask(pkg, request, False, 0, 0, inst.STATUS_ADDED, set())
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -81,7 +81,7 @@ def create_install_task(
     pkg: spack.package_base.PackageBase, install_args: Optional[dict] = None
 ) -> inst.InstallTask:
     request = inst.BuildRequest(pkg, {} if install_args is None else install_args)
-    return inst.InstallTask(pkg, request, False, 0, 0, inst.STATUS_ADDED, set())
+    return inst.InstallTask(pkg, request=request, status=inst.BuildStatus.QUEUED)
 
 
 def create_installer(

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -52,6 +52,7 @@ repo:
 
 def _noop(*args, **kwargs):
     """Generic monkeypatch no-op routine."""
+    pass
 
 
 def _none(*args, **kwargs):
@@ -75,7 +76,7 @@ def create_build_task(
 ) -> inst.BuildTask:
     request = inst.BuildRequest(pkg, {} if install_args is None else install_args)
     return inst.BuildTask(
-        pkg, request=request, progress=MockInstallerProgress, status=inst.BuildStatus.QUEUED
+        pkg, request=request, progress=MockInstallerProgress(), status=inst.BuildStatus.QUEUED
     )
 
 
@@ -84,7 +85,7 @@ def create_install_task(
 ) -> inst.InstallTask:
     request = inst.BuildRequest(pkg, {} if install_args is None else install_args)
     return inst.InstallTask(
-        pkg, request=request, progress=MockInstallerProgress, status=inst.BuildStatus.QUEUED
+        pkg, request=request, progress=MockInstallerProgress(), status=inst.BuildStatus.QUEUED
     )
 
 
@@ -685,7 +686,10 @@ def test_install_splice_root_from_binary(
     assert len(spack.store.STORE.db.query()) == len(list(out.traverse()))
 
 
-class MockInstallerProgress:
+class MockInstallerProgress(inst.InstallerProgress):
+    def __init__(self, *args, **kwargs):
+        pass
+
     def set_installed(self, *args, **kwargs):
         pass
 
@@ -711,7 +715,7 @@ def test_installing_task_use_cache(install_mockery, monkeypatch):
     term_status = MockTermStatusLine()
 
     monkeypatch.setattr(inst, "_install_from_cache", _true)
-    installer.progress = MockInstallerProgress
+    installer.progress = MockInstallerProgress()
     installer.start_task(task, term_status)
     installer.complete_task(task)
     assert request.pkg_id in installer.installed
@@ -1212,7 +1216,6 @@ def test_overwrite_install_backup_success(
     installer.progress = MockInstallerProgress()
     installer._init_queue()
     task = installer._pop_task()
-    term_status = MockTermStatusLine()
 
     # Make sure the install prefix exists with some trivial file
     installed_file = os.path.join(task.pkg.prefix, "some_file")
@@ -1254,10 +1257,9 @@ def test_overwrite_install_backup_failure(
     """
     # Get a build task. TODO: refactor this to avoid calling internal methods
     installer = create_installer(["pkg-c"])
-    installer.progress = MockInstallerProgress
+    installer.progress = MockInstallerProgress()
     installer._init_queue()
     task = installer._pop_task()
-    term_status = MockTermStatusLine()
 
     # Make sure the install prefix exists
     installed_file = os.path.join(task.pkg.prefix, "some_file")

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -77,6 +77,13 @@ def create_build_task(
     return inst.BuildTask(pkg, request=request, status=inst.BuildStatus.QUEUED)
 
 
+def create_install_task(
+    pkg: spack.package_base.PackageBase, install_args: Optional[dict] = None
+) -> inst.BuildTask:
+    request = inst.BuildRequest(pkg, {} if install_args is None else install_args)
+    return inst.InstallTask(pkg, request, False, 0, 0, inst.STATUS_ADDED, set())
+
+
 def create_installer(
     specs: Union[List[str], List[spack.spec.Spec]], install_args: Optional[dict] = None
 ) -> inst.PackageInstaller:
@@ -219,54 +226,6 @@ def test_installer_str(install_mockery):
     assert "#tasks=0" in istr
     assert "installed (0)" in istr
     assert "failed (0)" in istr
-
-
-def test_installer_prune_built_build_deps(install_mockery, monkeypatch, tmpdir):
-    r"""
-    Ensure that build dependencies of installed deps are pruned
-    from installer package queues.
-
-               (a)
-              /   \
-             /     \
-           (b)     (c) <--- is installed already so we should
-              \   / | \     prune (f) from this install since
-               \ /  |  \    it is *only* needed to build (b)
-               (d) (e) (f)
-
-    Thus since (c) is already installed our build_pq dag should
-    only include four packages. [(a), (b), (c), (d), (e)]
-    """
-
-    @property
-    def _mock_installed(self):
-        return self.name == "pkg-c"
-
-    # Mock the installed property to say that (b) is installed
-    monkeypatch.setattr(spack.spec.Spec, "installed", _mock_installed)
-
-    # Create mock repository with packages (a), (b), (c), (d), and (e)
-    builder = spack.repo.MockRepositoryBuilder(tmpdir.mkdir("mock-repo"))
-
-    builder.add_package("pkg-a", dependencies=[("pkg-b", "build", None), ("pkg-c", "build", None)])
-    builder.add_package("pkg-b", dependencies=[("pkg-d", "build", None)])
-    builder.add_package(
-        "pkg-c",
-        dependencies=[("pkg-d", "build", None), ("pkg-e", "all", None), ("pkg-f", "build", None)],
-    )
-    builder.add_package("pkg-d")
-    builder.add_package("pkg-e")
-    builder.add_package("pkg-f")
-
-    with spack.repo.use_repositories(builder.root):
-        installer = create_installer(["pkg-a"])
-
-        installer._init_queue()
-
-        # Assert that (c) is not in the build_pq
-        result = {task.pkg_id[:5] for _, task in installer.build_pq}
-        expected = {"pkg-a", "pkg-b", "pkg-c", "pkg-d", "pkg-e"}
-        assert result == expected
 
 
 def test_check_before_phase_error(install_mockery):
@@ -605,7 +564,7 @@ def test_check_deps_status_external(install_mockery, monkeypatch):
     monkeypatch.setattr(spack.spec.Spec, "external", True)
     installer._check_deps_status(request)
 
-    for dep in request.spec.traverse(root=False):
+    for dep in request.spec.traverse(root=False, deptype=request.get_depflags(request.spec)):
         assert inst.package_id(dep) in installer.installed
 
 
@@ -617,7 +576,7 @@ def test_check_deps_status_upstream(install_mockery, monkeypatch):
     monkeypatch.setattr(spack.spec.Spec, "installed_upstream", True)
     installer._check_deps_status(request)
 
-    for dep in request.spec.traverse(root=False):
+    for dep in request.spec.traverse(root=False, deptype=request.get_depflags(request.spec)):
         assert inst.package_id(dep) in installer.installed
 
 
@@ -673,7 +632,8 @@ def test_install_spliced_build_spec_installed(install_mockery, capfd, mock_fetch
     installer = create_installer([out], {"verbose": True, "fail_fast": True})
     installer._init_queue()
     for _, task in installer.build_pq:
-        assert isinstance(task, inst.RewireTask if task.pkg.spec.spliced else inst.BuildTask)
+        assert isinstance(task, inst.RewireTask if task.pkg.spec.spliced else inst.InstallTask)
+
     installer.install()
     for node in out.traverse():
         assert node.installed
@@ -743,7 +703,7 @@ class MockTermStatusLine:
 def test_installing_task_use_cache(install_mockery, monkeypatch):
     installer = create_installer(["trivial-install-test-package"], {})
     request = installer.build_requests[0]
-    task = create_build_task(request.pkg)
+    task = create_install_task(request.pkg)
     install_status = MockInstallStatus()
     term_status = MockTermStatusLine()
 


### PR DESCRIPTION
Depends on #39136 (commits up-to/including 39ff are from that PR)

- Refactors BuildTask into separate classes BuildTask and InstallTask
- Queues all packages as InstallTask, with link/run deps only
- If an InstallTask fails to install from binary, a BuildTask is generated
- The BuildTask is queued with dependencies on the new InstallTasks for its build deps and their link/run dependencies.
- The Tasks telescope open to include all build deps of build deps ad-hoc

TODO:
- [ ] Docs
- [x] Fix InstallStatus to track/report new dependencies properly