### PR TITLE
openmpi: update dependency wrt mpi standard versions

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -571,9 +571,9 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     variant("openshmem", default=False, description="Enable building OpenSHMEM")
 
     provides("mpi@:2.0", when="@:1.2")
-    provides("mpi@:2.1", when="@1.3.0:")
-    provides("mpi@:2.2", when="@1.7.3:")
-    provides("mpi@:3.0", when="@1.7.5:")
+    provides("mpi@:2.1", when="@1.3:1.7.2")
+    provides("mpi@:2.2", when="@1.7.3:1.7.4")
+    provides("mpi@:3.0", when="@1.7.5:1.10.7")
     provides("mpi@:3.1", when="@2.0.0:")
 
     if sys.platform != "darwin":

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -570,8 +570,9 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     variant("internal-libevent", default=False, description="Use internal libevent")
     variant("openshmem", default=False, description="Enable building OpenSHMEM")
 
-    provides("mpi")
-    provides("mpi@:2.2", when="@1.6.5")
+    provides("mpi@:2.0", when="@:1.2")
+    provides("mpi@:2.1", when="@1.3.0:")
+    provides("mpi@:2.2", when="@1.7.3:")
     provides("mpi@:3.0", when="@1.7.5:")
     provides("mpi@:3.1", when="@2.0.0:")
 


### PR DESCRIPTION
This PR updates  MPI standard version mapping to  OpenMPI versions, and fixes the following issue:

Without this change:
```
$ ./bin/spack spec ginkgo ^openmpi |grep openmpi@
 -       ^openmpi@1.7.4%gcc@14.0.1~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~internal-libevent~internal-pmix~java~lustre~memchecker~openshmem~orterunprefix~romio+rsh~singularity~sqlite3~static~thread_multiple+vt+wrapper-rpath build_system=autotools fabrics=none romio-filesystem=none schedulers=none arch=linux-fedora40-skylake
```
With this change:
```
$ ./bin/spack spec ginkgo ^openmpi |grep openmpi@
 -       ^openmpi@5.0.5%gcc@14.0.1~atomics~cuda~gpfs~internal-hwloc~internal-libevent~internal-pmix~java~lustre~memchecker~openshmem~romio+rsh~static+vt+wrapper-rpath build_system=autotools fabrics=none romio-filesystem=none schedulers=none arch=linux-fedora40-skylake
```
Ref: 2.1 (change in v1.3.0)
```
$ git grep -E '(MPI_VERSION|MPI_SUBVERSION)' v1.2.9 ompi/include/mpi.h.in
v1.2.9:ompi/include/mpi.h.in:#define MPI_VERSION 2
v1.2.9:ompi/include/mpi.h.in:#define MPI_SUBVERSION 0
$ git grep -E '(MPI_VERSION|MPI_SUBVERSION)' v1.3.0 ompi/include/mpi.h.in
v1.3.0:ompi/include/mpi.h.in:#define MPI_VERSION 2
v1.3.0:ompi/include/mpi.h.in:#define MPI_SUBVERSION 1
```
Ref: 2.2: (change in v1.7.3)
```
$ git grep -E '(MPI_VERSION|MPI_SUBVERSION)' v1.7.2 ompi/include/mpi.h.in
v1.7.2:ompi/include/mpi.h.in:#define MPI_VERSION 2
v1.7.2:ompi/include/mpi.h.in:#define MPI_SUBVERSION 1
$ git grep -E '(MPI_VERSION|MPI_SUBVERSION)' v1.7.3 ompi/include/mpi.h.in
v1.7.3:ompi/include/mpi.h.in:#define MPI_VERSION 2
v1.7.3:ompi/include/mpi.h.in:#define MPI_SUBVERSION 2
```
Ref: 3.0 (change in v1.7.5)
```
$ git grep -E '(MPI_VERSION|MPI_SUBVERSION)' v1.7.4 ompi/include/mpi.h.in
v1.7.4:ompi/include/mpi.h.in:#define MPI_VERSION 2
v1.7.4:ompi/include/mpi.h.in:#define MPI_SUBVERSION 2
$ git grep -E '(MPI_VERSION|MPI_SUBVERSION)' v1.7.5 ompi/include/mpi.h.in
v1.7.5:ompi/include/mpi.h.in:#define MPI_VERSION 3
v1.7.5:ompi/include/mpi.h.in:#define MPI_SUBVERSION 0
```
Ref: 3.1 (change` in v2.0.0)
```$ git grep -E '(MPI_VERSION|MPI_SUBVERSION)' v1.10.7 ompi/include/mpi.h.in
v1.10.7:ompi/include/mpi.h.in:#define MPI_VERSION 3
v1.10.7:ompi/include/mpi.h.in:#define MPI_SUBVERSION 0
$ git grep -E '(MPI_VERSION|MPI_SUBVERSION)' v2.0.0 ompi/include/mpi.h.in
v2.0.0:ompi/include/mpi.h.in:#define MPI_VERSION 3
v2.0.0:ompi/include/mpi.h.in:#define MPI_SUBVERSION 1
```
