### PR TITLE
tau: fix cray compiler names

### DIFF
--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -216,13 +216,23 @@ class Tau(Package):
             if compiler_path:
                 compiler_path = compiler_path + "/bin/"
         os.environ["PATH"] = ":".join([compiler_path, os.environ["PATH"]])
-        compiler_options = [
-            "-c++=%s" % os.path.basename(self.compiler.cxx),
-            "-cc=%s" % os.path.basename(self.compiler.cc),
-        ]
+
+        cc_name = os.path.basename(self.compiler.cc)
+        cxx_name = os.path.basename(self.compiler.cxx)
+
+        # tau does not understand craycc, crayCC, crayftn; cc, c++ and ftn are OK.
+        if cc_name.startswith("cray"):
+            cc_name = cc_name[4:]
+        if cxx_name.startswith("cray"):
+            cxx_name = cxx_name[4:]
+
+        compiler_options = [f"-cc={cc_name}", f"-c++={cxx_name}"]
 
         if "+fortran" in spec and self.compiler.fc:
-            compiler_options.append("-fortran=%s" % os.path.basename(self.compiler.fc))
+            fortran_name = os.path.basename(self.compiler.fc)
+            if fortran_name.startswith("cray"):
+                fortran_name = fortran_name[4:]
+            compiler_options.append(f"-fortran={fortran_name}")
 
         ##########
 

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -204,35 +204,21 @@ class Tau(Package):
         #     ('CC', 'CXX' and 'FC')
         # 4 - if no -cc=<compiler> -cxx=<compiler> is passed tau is built with
         #     system compiler silently
-        # (regardless of what %<compiler> is used in the spec)
-        # 5 - On cray gnu compilers are not provied by self.compilers
-        #     Checking GCC_PATH will work if spack loads the gcc module
-        #
-        # In the following we give TAU what he expects and put compilers into
-        # PATH
-        compiler_path = os.path.dirname(self.compiler.cc)
-        if not compiler_path and self.compiler.cc_names[0] == "gcc":
-            compiler_path = os.environ.get("GCC_PATH", "")
-            if compiler_path:
-                compiler_path = compiler_path + "/bin/"
-        os.environ["PATH"] = ":".join([compiler_path, os.environ["PATH"]])
+        compiler_flags: Dict[str, str] = {
+            flag: os.path.basename(getattr(self.compiler, compiler))
+            for flag, compiler in (("-cc", "cc"), ("-c++", "cxx"), ("-fortran", "fc"))
+            if getattr(self.compiler, compiler)
+        }
 
-        cc_name = os.path.basename(self.compiler.cc)
-        cxx_name = os.path.basename(self.compiler.cxx)
+        if "~fortran" in spec:
+            compiler_flags.pop("-fortran", None)
 
-        # tau does not understand craycc, crayCC, crayftn; cc, c++ and ftn are OK.
-        if cc_name.startswith("cray"):
-            cc_name = cc_name[4:]
-        if cxx_name.startswith("cray"):
-            cxx_name = cxx_name[4:]
+        # tau does not understand `craycc`, `crayCC`, `crayftn`, strip off the `cray` prefix
+        for flag, value in compiler_flags.items():
+            if value.startswith("cray"):
+                compiler_flags[flag] = value[4:]
 
-        compiler_options = [f"-cc={cc_name}", f"-c++={cxx_name}"]
-
-        if "+fortran" in spec and self.compiler.fc:
-            fortran_name = os.path.basename(self.compiler.fc)
-            if fortran_name.startswith("cray"):
-                fortran_name = fortran_name[4:]
-            compiler_options.append(f"-fortran={fortran_name}")
+        compiler_options = [f"{flag}={value}" for flag, value in compiler_flags.items()]
 
         ##########
 


### PR DESCRIPTION
fix a build issue seen on develop ci

1. cray compilers can be `cray{cc,CC,ftn}`, the prefix is not understood by `tau` so drop it.
2. don't depend on `GCC_PATH` (unreproducible builds, misses compiler wrapper)