### PR TITLE
Concretizer: put build->run deps in parent unification set (fixes #46034)

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -95,11 +95,18 @@ unify(SetID, PackageName) :- unification_set(SetID, node(_, PackageName)).
 unification_set("root", PackageNode) :- attr("root", PackageNode).
 unification_set(SetID, ChildNode) :- attr("depends_on", ParentNode, ChildNode, Type), Type != "build", unification_set(SetID, ParentNode).
 
-unification_set(("build", node(X, Child)), node(X, Child))
+unification_set(("build", ParentNode), node(X, Child))
   :- attr("depends_on", ParentNode, node(X, Child), Type),
      Type == "build",
      multiple_unification_sets(Child),
      unification_set(SetID, ParentNode).
+
+unification_set(("build", ParentNode), node(X, Child))
+  :- attr("depends_on", ParentNode, NonDupeNode, "build"),
+     not multiple_unification_sets(NonDupeNode),
+     attr("depends_on", NonDupeNode, node(X, Child), "run"),
+     multiple_unification_sets(Child),
+     unification_set(_, ParentNode).
 
 unification_set("generic_build", node(X, Child))
   :- attr("depends_on", ParentNode, node(X, Child), Type),

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2668,6 +2668,13 @@ class TestConcretizeSeparately:
         gmake = s["python"].dependencies(name="gmake", deptype="build")
         assert len(gmake) == 1 and gmake[0].satisfies("@=3.0")
 
+    @pytest.mark.parametrize("strategy", ["none", "minimal", "full"])
+    def test_two_setuptools_with_run(self, strategy):
+        """Tests that concretization fails for mixed build/run dependencies on build tools."""
+        spack.config.CONFIG.set("concretizer:duplicates:strategy", strategy)
+        with pytest.raises((spack.error.UnsatisfiableSpecError, vt.InvalidVariantForSpecError)):
+            _ = Spec("py-shapely ^py-numpy+rundep").concretized()
+
     def test_solution_without_cycles(self):
         """Tests that when we concretize a spec with cycles, a fallback kicks in to recompute
         a solution without cycles.

--- a/var/spack/repos/duplicates.test/packages/py-numpy/package.py
+++ b/var/spack/repos/duplicates.test/packages/py-numpy/package.py
@@ -15,6 +15,9 @@ class PyNumpy(Package):
 
     version("1.25.0", md5="0123456789abcdef0123456789abcdef")
 
+    variant("rundep", default=False, description="activate run dependency on py-setuptools")
+
     extends("python")
-    depends_on("py-setuptools@=59", type=("build", "run"))
+    depends_on("py-setuptools@=59", type=("build"))
+    depends_on("py-setuptools@=59", type=("build", "run"), when="+rundep")
     depends_on("gmake@4.1", type="build")


### PR DESCRIPTION
In #46034, a package X build-depends on a `build-tools`-tagged package, e.g., `py-setuptools`, as well as another package Y that itself depends (build+run) on the same `build-tools` tagged package. In this case, the concretizer puts the possibly two versions of the build tool into separate unification sets, but the run-type dependency requires the
build environment of X to have both versions in its environment — which is illegal.
With this fix, the concretizer puts the two build tool nodes into a new common unification set if there is a build→run-type dependency chain on the build tool ⇒ spack now reports the expected error about not being able to find a common concretization of the build tool.