### PR TITLE
CMakePackage: Set policy CMP0042 NEW on macos

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -108,6 +108,11 @@ def _conditional_cmake_defaults(pkg: spack.package_base.PackageBase, args: List[
     if _supports_compilation_databases(pkg):
         args.append(CMakeBuilder.define("CMAKE_EXPORT_COMPILE_COMMANDS", True))
 
+    # Enable MACOSX_RPATH by default
+    # https://cmake.org/cmake/help/latest/policy/CMP0042.html
+    if platform.mac_ver()[0] and cmake.satisfies("@3.0:"):
+        args.append(CMakeBuilder.define("CMAKE_POLICY_DEFAULT_CMP0042", "NEW"))
+
 
 def generator(*names: str, default: Optional[str] = None):
     """The build system generator to use.

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -110,7 +110,7 @@ def _conditional_cmake_defaults(pkg: spack.package_base.PackageBase, args: List[
 
     # Enable MACOSX_RPATH by default
     # https://cmake.org/cmake/help/latest/policy/CMP0042.html
-    if platform.mac_ver()[0] and cmake.satisfies("@3.0:"):
+    if pkg.spec.satisfies("platform=darwin") and cmake.satisfies("@3:"):
         args.append(CMakeBuilder.define("CMAKE_POLICY_DEFAULT_CMP0042", "NEW"))
 
 

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -108,7 +108,7 @@ def _conditional_cmake_defaults(pkg: spack.package_base.PackageBase, args: List[
     if _supports_compilation_databases(pkg):
         args.append(CMakeBuilder.define("CMAKE_EXPORT_COMPILE_COMMANDS", True))
 
-    # Enable MACOSX_RPATH by default
+    # Enable MACOSX_RPATH by default when cmake_minimum_required < 3
     # https://cmake.org/cmake/help/latest/policy/CMP0042.html
     if pkg.spec.satisfies("platform=darwin") and cmake.satisfies("@3:"):
         args.append(CMakeBuilder.define("CMAKE_POLICY_DEFAULT_CMP0042", "NEW"))


### PR DESCRIPTION
By default, set `CMAKE_POLICY_DEFAULT_CMP0042=NEW` which enables setting @rpath in a target's install name