### PR TITLE
ddt: deprecate all versions in favor of linaro-forge

### DIFF
--- a/var/spack/repos/builtin/packages/ddt/package.py
+++ b/var/spack/repos/builtin/packages/ddt/package.py
@@ -22,16 +22,14 @@ class Ddt(Package):
     license_required = True
     license_files = ["./licences/ddt.lic"]
 
-    # Versions before 22.0 have a security vulnerability. Do not install them.
-    version("24.0.3", sha256="1796559fb86220d5e17777215d3820f4b04aba271782276b81601d5065284526")
-    version("23.1.2", sha256="675d2d8e4510afefa0405eecb46ac8bf440ff35a5a40d5507dc12d29678a22bf")
-    version("23.0.4", sha256="41a81840a273ea9a232efb4f031149867c5eff7a6381d787e18195f1171caac4")
-    version("22.1.3", sha256="4f8a8b1df6ad712e89c82eedf4bd85b93b57b3c8d5b37d13480ff058fa8f4467")
-    version(
-        "22.0.2",
-        sha256="3db0c3993d1db617f850c48d25c9239f06a018c895ea305786a7ad836a44496d",
-        deprecated=True,
-    )
+    with default_args(deprecated=True):
+        # All versions are deprecated; the package linaro-forge is preferred
+        version("24.0.3", sha256="1796559fb86220d5e17777215d3820f4b04aba271782276b81601d5065284526")
+        version("23.1.2", sha256="675d2d8e4510afefa0405eecb46ac8bf440ff35a5a40d5507dc12d29678a22bf")
+        version("23.0.4", sha256="41a81840a273ea9a232efb4f031149867c5eff7a6381d787e18195f1171caac4")
+        version("22.1.3", sha256="4f8a8b1df6ad712e89c82eedf4bd85b93b57b3c8d5b37d13480ff058fa8f4467")
+        version("22.0.2", sha256="3db0c3993d1db617f850c48d25c9239f06a018c895ea305786a7ad836a44496d")
+        # Versions before 22.0 have a security vulnerability. Do not install them.
 
     def url_for_version(self, version):
         if version <= Version("22.1.3"):

--- a/var/spack/repos/builtin/packages/ddt/package.py
+++ b/var/spack/repos/builtin/packages/ddt/package.py
@@ -24,11 +24,21 @@ class Ddt(Package):
 
     with default_args(deprecated=True):
         # All versions are deprecated; the package linaro-forge is preferred
-        version("24.0.3", sha256="1796559fb86220d5e17777215d3820f4b04aba271782276b81601d5065284526")
-        version("23.1.2", sha256="675d2d8e4510afefa0405eecb46ac8bf440ff35a5a40d5507dc12d29678a22bf")
-        version("23.0.4", sha256="41a81840a273ea9a232efb4f031149867c5eff7a6381d787e18195f1171caac4")
-        version("22.1.3", sha256="4f8a8b1df6ad712e89c82eedf4bd85b93b57b3c8d5b37d13480ff058fa8f4467")
-        version("22.0.2", sha256="3db0c3993d1db617f850c48d25c9239f06a018c895ea305786a7ad836a44496d")
+        version(
+            "24.0.3", sha256="1796559fb86220d5e17777215d3820f4b04aba271782276b81601d5065284526"
+        )
+        version(
+            "23.1.2", sha256="675d2d8e4510afefa0405eecb46ac8bf440ff35a5a40d5507dc12d29678a22bf"
+        )
+        version(
+            "23.0.4", sha256="41a81840a273ea9a232efb4f031149867c5eff7a6381d787e18195f1171caac4"
+        )
+        version(
+            "22.1.3", sha256="4f8a8b1df6ad712e89c82eedf4bd85b93b57b3c8d5b37d13480ff058fa8f4467"
+        )
+        version(
+            "22.0.2", sha256="3db0c3993d1db617f850c48d25c9239f06a018c895ea305786a7ad836a44496d"
+        )
         # Versions before 22.0 have a security vulnerability. Do not install them.
 
     def url_for_version(self, version):


### PR DESCRIPTION
This PR deprecates all versions of `ddt` in preparation of removal at some later time (after v0.23 release). This package is identical to `linaro-forge` which is maintained by staff at Linaro. Ref: https://github.com/spack/spack/pull/46112#issuecomment-2317706215.
