### PR TITLE
sigio: add v2.3.3

### DIFF
--- a/var/spack/repos/builtin/packages/sigio/package.py
+++ b/var/spack/repos/builtin/packages/sigio/package.py
@@ -19,9 +19,12 @@ class Sigio(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
     version("develop", branch="develop")
+    version("2.3.3", sha256="2b4a04be3be10f222d0ff47f973f65a03b8b5521dcad8e8866f3bfe4e8dfafab")
     version("2.3.2", sha256="333f3cf3a97f97103cbafcafc2ad89b24faa55b1332a98adc1637855e8a5b613")
 
     depends_on("fortran", type="build")
+
+    conflicts("%oneapi", when="@:2.3.2", msg="Requires @2.3.3: for Intel OneAPI")
 
     def cmake_args(self):
         args = [self.define("ENABLE_TESTS", self.run_tests)]


### PR DESCRIPTION
This PR adds sigio v2.3.3, which, among other things, adds Intel LLVM support.