### PR TITLE
spectrum-mpi: no windows

### DIFF
--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -20,6 +20,8 @@ class SpectrumMpi(BundlePackage):
 
     provides("mpi")
 
+    conflicts("platform=windows")
+
     executables = ["^ompi_info$"]
 
     @classmethod


### PR DESCRIPTION
bit of a mystery why the concretizer picks up spectrum-mpi on windows instead of its favorite provider.