### PR TITLE
casacore-measures: new package

### DIFF
--- a/var/spack/repos/builtin/packages/casacore-measures/package.py
+++ b/var/spack/repos/builtin/packages/casacore-measures/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class CasacoreMeasures(Package):
+    """Install casacore measures tables, and a tool to maintain them."""
+
+    homepage = "https://gitlab.com/dsa-2000/rcp/casacore-measures"
+    url = "https://gitlab.com/dsa-2000/rcp/casacore-measures/-/archive/v1.0.0/casacore-measures-v1.0.0.tar.gz"
+    git = "https://gitlab.com/dsa-2000/rcp/casacore-measures.git"
+
+    maintainers("mpokorny")
+
+    license("AGPL-3.0-or-later", checked_by="mpokorny")
+
+    version("main", branch="main")
+    version("1.0.0", sha256="2bcd891bc0bd67749d93ec5b0fe92d8c1cbb73253465dd0410a3ab5493b3cee5")
+
+    depends_on("wget", type=("build", "run"))
+
+    def install(self, spec, prefix):
+        mkdirp(self.prefix.bin)
+        install("bin/update_measures", self.prefix.bin)
+        mkdirp(self.prefix.share.data)
+        update = Executable(self.prefix.bin.update_measures)
+        update()

--- a/var/spack/repos/builtin/packages/wget/package.py
+++ b/var/spack/repos/builtin/packages/wget/package.py
@@ -40,6 +40,8 @@ class Wget(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on("gnutls", when="ssl=gnutls")
     depends_on("openssl", when="ssl=openssl")
+    # OpenSSL 3.0 is not supported by wget, openssl@3.1: works:
+    conflicts("openssl@3.0", when="ssl=openssl")
 
     depends_on("gettext", type="build")
     depends_on("python@3:", type="build", when="+python")


### PR DESCRIPTION
This package is used to install and maintain measures data that can be used by the `casacore` package. It is not a resource file because the measures must be periodically updated to be useful.