### PR TITLE
Replace `if ... in spec` with `spec.satisfies` in d* and e* packages

### DIFF
--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -94,7 +94,7 @@ class Dakota(CMakePackage):
             self.define_from_variant("DAKOTA_PYTHON", "python"),
         ]
 
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             args.extend(
                 [
                     "-DDAKOTA_HAVE_MPI:BOOL=ON",

--- a/var/spack/repos/builtin/packages/dalton/package.py
+++ b/var/spack/repos/builtin/packages/dalton/package.py
@@ -79,7 +79,7 @@ class Dalton(CMakePackage):
 
     def cmake_args(self):
         math_libs = self.spec["lapack"].libs + self.spec["blas"].libs
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             env["CC"] = self.spec["mpi"].mpicc
             env["CXX"] = self.spec["mpi"].mpicxx
             env["F77"] = self.spec["mpi"].mpif77

--- a/var/spack/repos/builtin/packages/daos/package.py
+++ b/var/spack/repos/builtin/packages/daos/package.py
@@ -55,7 +55,7 @@ class Daos(SConsPackage):
     def build_args(self, spec, prefix):
         args = ["PREFIX={0}".format(prefix), "USE_INSTALLED=all"]
 
-        if "+debug" in spec:
+        if spec.satisfies("+debug"):
             args.append("--debug=explain,findlibs,includes")
 
         # Construct ALT_PREFIX and make sure that '/usr' is last.

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -101,27 +101,27 @@ class DarshanRuntime(AutotoolsPackage):
         extra_args = []
 
         job_id = "NONE"
-        if "+slurm" in spec:
+        if spec.satisfies("+slurm"):
             job_id = "SLURM_JOBID"
-        if "+cobalt" in spec:
+        if spec.satisfies("+cobalt"):
             job_id = "COBALT_JOBID"
-        if "+pbs" in spec:
+        if spec.satisfies("+pbs"):
             job_id = "PBS_JOBID"
-        if "+sge" in spec:
+        if spec.satisfies("+sge"):
             job_id = "JOB_ID"
 
-        if "+hdf5" in spec:
+        if spec.satisfies("+hdf5"):
             if self.version < Version("3.3.2"):
                 extra_args.append("--enable-hdf5-mod=%s" % spec["hdf5"].prefix)
             else:
                 extra_args.append("--enable-hdf5-mod")
-        if "+parallel-netcdf" in spec:
+        if spec.satisfies("+parallel-netcdf"):
             extra_args.append("--enable-pnetcdf-mod")
-        if "+apmpi" in spec:
+        if spec.satisfies("+apmpi"):
             extra_args.append("--enable-apmpi-mod")
-        if "+apmpi_sync" in spec:
+        if spec.satisfies("+apmpi_sync"):
             extra_args.extend(["--enable-apmpi-mod", "--enable-apmpi-coll-sync"])
-        if "+apxc" in spec:
+        if spec.satisfies("+apxc"):
             extra_args.append("--enable-apxc-mod")
 
         extra_args.append("--with-mem-align=8")
@@ -129,7 +129,7 @@ class DarshanRuntime(AutotoolsPackage):
         extra_args.append("--with-jobid-env=%s" % job_id)
         extra_args.append("--with-zlib=%s" % spec["zlib-api"].prefix)
 
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             extra_args.append("CC=%s" % self.spec["mpi"].mpicc)
         else:
             extra_args.append("CC=%s" % self.compiler.cc)

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -84,12 +84,12 @@ class DarshanUtil(AutotoolsPackage):
 
         extra_args.append("CC=%s" % self.compiler.cc)
         extra_args.append("--with-zlib=%s" % spec["zlib-api"].prefix)
-        if "+apmpi" in spec:
+        if spec.satisfies("+apmpi"):
             if self.version < Version("3.3.2"):
                 extra_args.append("--enable-autoperf-apmpi")
             else:
                 extra_args.append("--enable-apmpi-mod")
-        if "+apxc" in spec:
+        if spec.satisfies("+apxc"):
             if self.version < Version("3.3.2"):
                 extra_args.append("--enable-autoperf-apxc")
             else:

--- a/var/spack/repos/builtin/packages/dataspaces/package.py
+++ b/var/spack/repos/builtin/packages/dataspaces/package.py
@@ -52,7 +52,7 @@ class Dataspaces(AutotoolsPackage):
 
         env.set("CFLAGS", self.compiler.cc_pic_flag)
 
-        if "%gcc@10:" in self.spec:
+        if self.spec.satisfies("%gcc@10:"):
             env.set("FCFLAGS", "-fallow-argument-mismatch")
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/datatransferkit/package.py
+++ b/var/spack/repos/builtin/packages/datatransferkit/package.py
@@ -67,7 +67,7 @@ class Datatransferkit(CMakePackage):
             "-DMPI_BASE_DIR=" + spec["mpi"].prefix,
         ]
 
-        if "+openmp" in spec:
+        if spec.satisfies("+openmp"):
             options.append("-DDataTransferKit_ENABLE_OpenMP=ON")
 
         return options

--- a/var/spack/repos/builtin/packages/dbcsr/package.py
+++ b/var/spack/repos/builtin/packages/dbcsr/package.py
@@ -151,7 +151,7 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
         ]
 
         # Switch necessary as a result of a bug.
-        if "@2.1:2.2" in spec:
+        if spec.satisfies("@2.1:2.2"):
             args += ["-DBUILD_TESTING=ON"]
 
         if self.spec.satisfies("+cuda"):

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -504,7 +504,7 @@ class Dealii(CMakePackage, CudaPackage):
 
         # CUDA
         options.append(self.define_from_variant("DEAL_II_WITH_CUDA", "cuda"))
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             if not spec.satisfies("^cuda@9:"):
                 options.append("-DDEAL_II_WITH_CXX14=OFF")
             cuda_arch = spec.variants["cuda_arch"].value
@@ -519,7 +519,7 @@ class Dealii(CMakePackage, CudaPackage):
 
         # MPI
         options.append(self.define_from_variant("DEAL_II_WITH_MPI", "mpi"))
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             options.extend(
                 [
                     self.define("MPI_C_COMPILER", spec["mpi"].mpicc),
@@ -529,9 +529,9 @@ class Dealii(CMakePackage, CudaPackage):
             )
             # FIXME: Fix issues with undefined references in MPI. e.g,
             # libmpi.so: undefined reference to `opal_memchecker_base_isaddressable'
-            if "^openmpi" in spec:
+            if spec.satisfies("^openmpi"):
                 options.extend([self.define("MPI_CXX_LINK_FLAGS", "-lopen-pal")])
-            if "+cuda" in spec:
+            if spec.satisfies("+cuda"):
                 options.extend(
                     [
                         self.define(
@@ -541,7 +541,7 @@ class Dealii(CMakePackage, CudaPackage):
                     ]
                 )
             # Make sure we use the same compiler that Trilinos uses
-            if "+trilinos" in spec:
+            if spec.satisfies("+trilinos"):
                 options.extend([self.define("CMAKE_CXX_COMPILER", spec["trilinos"].kokkos_cxx)])
 
         # Python bindings
@@ -557,7 +557,7 @@ class Dealii(CMakePackage, CudaPackage):
             options.append(self.define_from_variant("DEAL_II_WITH_TBB", "threads"))
         else:
             options.append(self.define_from_variant("DEAL_II_WITH_THREADS", "threads"))
-        if "+threads" in spec:
+        if spec.satisfies("+threads"):
             if spec.satisfies("^intel-parallel-studio+tbb"):
                 # deal.II/cmake will have hard time picking up TBB from Intel.
                 tbb_ver = ".".join(("%s" % spec["tbb"].version).split(".")[1:])
@@ -605,12 +605,12 @@ class Dealii(CMakePackage, CudaPackage):
         # Optional dependencies that do not fit the above pattern:
         # ADOL-C
         options.append(self.define_from_variant("DEAL_II_WITH_ADOLC", "adol-c"))
-        if "+adol-c" in spec:
+        if spec.satisfies("+adol-c"):
             options.append(self.define("ADOLC_DIR", spec["adol-c"].prefix))
 
         # ARPACK
         options.append(self.define_from_variant("DEAL_II_WITH_ARPACK", "arpack"))
-        if "+arpack" in spec and "+mpi" in spec:
+        if spec.satisfies("+arpack") and spec.satisfies("+mpi"):
             options.extend(
                 [
                     self.define("ARPACK_DIR", spec["arpack-ng"].prefix),
@@ -620,7 +620,7 @@ class Dealii(CMakePackage, CudaPackage):
 
         # NetCDF
         # since Netcdf is spread among two, need to do it by hand:
-        if "+netcdf" in spec and "+mpi" in spec:
+        if spec.satisfies("+netcdf") and spec.satisfies("+mpi"):
             netcdf_libs = spec["netcdf-cxx"].libs + spec["netcdf-c"].libs
             options.extend(
                 [
@@ -639,7 +639,7 @@ class Dealii(CMakePackage, CudaPackage):
 
         # ScaLAPACK
         options.append(self.define_from_variant("DEAL_II_WITH_SCALAPACK", "scalapack"))
-        if "+scalapack" in spec:
+        if spec.satisfies("+scalapack"):
             scalapack_libs = spec["scalapack"].libs
             options.extend(
                 [
@@ -654,7 +654,7 @@ class Dealii(CMakePackage, CudaPackage):
 
         # Open Cascade
         options.append(self.define_from_variant("DEAL_II_WITH_OPENCASCADE", "oce"))
-        if "+oce" in spec:
+        if spec.satisfies("+oce"):
             options.append(self.define("OPENCASCADE_DIR", spec["oce"].prefix))
 
         # As a final step, collect CXX flags that may have been
@@ -670,7 +670,7 @@ class Dealii(CMakePackage, CudaPackage):
         options.append(self.define("DEAL_II_CXX_FLAGS", os.environ["SPACK_TARGET_ARGS"]))
 
         # platform introspection - needs to be disabled in some environments
-        if "+platform-introspection" in spec:
+        if spec.satisfies("+platform-introspection"):
             options.append(self.define("DEAL_II_ALLOW_PLATFORM_INTROSPECTION", True))
         else:
             options.append(self.define("DEAL_II_ALLOW_PLATFORM_INTROSPECTION", False))
@@ -682,5 +682,5 @@ class Dealii(CMakePackage, CudaPackage):
 
     def setup_build_environment(self, env):
         spec = self.spec
-        if "+cuda" in spec and "+mpi" in spec:
+        if spec.satisfies("+cuda") and spec.satisfies("+mpi"):
             env.set("CUDAHOSTCXX", spec["mpi"].mpicxx)

--- a/var/spack/repos/builtin/packages/delly2/package.py
+++ b/var/spack/repos/builtin/packages/delly2/package.py
@@ -43,7 +43,7 @@ class Delly2(MakefilePackage):
     depends_on("bcftools", type="run")
 
     def edit(self, spec, prefix):
-        if "+openmp" in self.spec:
+        if self.spec.satisfies("+openmp"):
             env["PARALLEL"] = "1"
         # Only want to build delly source, not submodules. Build fails
         # using provided submodules, succeeds with existing spack recipes.

--- a/var/spack/repos/builtin/packages/dftbplus/package.py
+++ b/var/spack/repos/builtin/packages/dftbplus/package.py
@@ -182,12 +182,12 @@ class Dftbplus(CMakePackage, MakefilePackage):
 
         mconfig.filter("INSTALLDIR := .*", "INSTALLDIR := {0}".format(prefix))
 
-        if "+gpu" in self.spec:
+        if self.spec.satisfies("+gpu"):
             march.filter("MAGMADIR = .*", "MAGMADIR = {0}".format(spec["magma"].prefix))
 
             mconfig.filter("WITH_GPU := .*", "WITH_GPU := 1")
 
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             march.filter(
                 "SCALAPACKDIR = .*", "SCALAPACKDIR = {0}".format(spec["scalapack"].prefix)
             )
@@ -200,7 +200,7 @@ class Dftbplus(CMakePackage, MakefilePackage):
 
             mconfig.filter("WITH_MPI := .*", "WITH_MPI := 1")
 
-            if "+elsi" in self.spec:
+            if self.spec.satisfies("+elsi"):
                 mconfig.filter("WITH_ELSI := .*", "WITH_ELSI := 1")
 
                 has_pexsi = "+enable_pexsi" in spec["elsi"]
@@ -221,20 +221,20 @@ class Dftbplus(CMakePackage, MakefilePackage):
                 "LIB_LAPACK += -l.*", "LIB_LAPACK += {0}".format(spec["blas"].libs.ld_flags)
             )
 
-        if "+sockets" in self.spec:
+        if self.spec.satisfies("+sockets"):
             mconfig.filter("WITH_SOCKETS := .*", "WITH_SOCKETS := 1")
 
-        if "+transport" in self.spec:
+        if self.spec.satisfies("+transport"):
             mconfig.filter("WITH_TRANSPORT := .*", "WITH_TRANSPORT := 1")
 
-        if "+arpack" in self.spec:
+        if self.spec.satisfies("+arpack"):
             march.filter(
                 "ARPACK_LIBS = .*", "ARPACK_LIBS = {0}".format(spec["arpack-ng"].libs.ld_flags)
             )
 
             mconfig.filter("WITH_ARPACK := .*", "WITH_ARPACK := 1")
 
-        if "+dftd3" in self.spec:
+        if self.spec.satisfies("+dftd3"):
             march.filter("COMPILE_DFTD3 = .*", "COMPILE_DFTD3 = 0")
             march.filter(
                 "DFTD3_INCS = .*", "DFTD3_INCS = -I{0}".format(spec["dftd3-lib"].prefix.include)
@@ -272,7 +272,7 @@ class Dftbplus(CMakePackage, MakefilePackage):
         #       (e.g. -DSCALAPACK_LIBRARY)
         # and plural form is ignored.
         # We set both inorder to be compatible with all versions.
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             # we use scalapack for linear algebra
             args.extend(
                 [
@@ -298,7 +298,7 @@ class Dftbplus(CMakePackage, MakefilePackage):
                     self.define("BLAS_LIBRARY", blas_libs),
                 ]
             )
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             args.append(self.define("BUILD_SHARED_LIBS", True))
         if self.run_tests:
             args.append("-DWITH_UNIT_TESTS=ON")

--- a/var/spack/repos/builtin/packages/digitrounding/package.py
+++ b/var/spack/repos/builtin/packages/digitrounding/package.py
@@ -27,7 +27,7 @@ class Digitrounding(CMakePackage):
 
     def cmake_args(self):
         args = []
-        if "+shared" in self.spec:
+        if self.spec.satisfies("+shared"):
             args.append("-DBUILD_SHARED_LIBS=ON")
         else:
             args.append("-DBUILD_SHARED_LIBS=OFF")

--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -12,7 +12,7 @@ from spack.package import *
 def get_blas_entries(inspec):
     entries = []
     spec = inspec["hydrogen"]
-    if "blas=openblas" in spec:
+    if spec.satisfies("blas=openblas"):
         entries.append(cmake_cache_option("DiHydrogen_USE_OpenBLAS", True))
     elif "blas=mkl" in spec or spec.satisfies("^intel-mkl"):
         entries.append(cmake_cache_option("DiHydrogen_USE_MKL", True))
@@ -33,7 +33,7 @@ def get_blas_entries(inspec):
                 % ";".join("-l{0}".format(lib) for lib in self.spec["essl"].libs.names),
             )
         )
-    elif "blas=accelerate" in spec:
+    elif spec.satisfies("blas=accelerate"):
         entries.append(cmake_cache_option("DiHydrogen_USE_ACCELERATE", True))
     elif spec.satisfies("^netlib-lapack"):
         entries.append(cmake_cache_string("BLA_VENDOR", "Generic"))
@@ -332,18 +332,18 @@ class Dihydrogen(CachedCMakePackage, CudaPackage, ROCmPackage):
         # all this, but this shouldn't hurt to have.
         entries.append(cmake_cache_path("spdlog_ROOT", spec["spdlog"].prefix))
 
-        if "+developer" in spec:
+        if spec.satisfies("+developer"):
             entries.append(cmake_cache_path("Catch2_ROOT", spec["catch2"].prefix))
 
-        if "+coverage" in spec:
+        if spec.satisfies("+coverage"):
             entries.append(cmake_cache_path("lcov_ROOT", spec["lcov"].prefix))
             entries.append(cmake_cache_path("genhtml_ROOT", spec["lcov"].prefix))
-            if "+ci" in spec:
+            if spec.satisfies("+ci"):
                 entries.append(cmake_cache_path("gcovr_ROOT", spec["py-gcovr"].prefix))
 
-        if "+distconv" in spec:
+        if spec.satisfies("+distconv"):
             entries.append(cmake_cache_path("Aluminum_ROOT", spec["aluminum"].prefix))
-            if "+cuda" in spec:
+            if spec.satisfies("+cuda"):
                 entries.append(cmake_cache_path("cuDNN_ROOT", spec["cudnn"].prefix))
 
         # Currently this is a hack for all Hydrogen versions. WIP to

--- a/var/spack/repos/builtin/packages/discotec/package.py
+++ b/var/spack/repos/builtin/packages/discotec/package.py
@@ -54,7 +54,7 @@ class Discotec(CMakePackage):
             self.define_from_variant("DISCOTEC_USE_VTK", "vtk"),
             self.define_from_variant("DISCOTEC_WITH_SELALIB", "selalib"),
         ]
-        if "+selalib" in self.spec:
+        if self.spec.satisfies("+selalib"):
             args.append(self.define("SELALIB_DIR", self.spec["selalib"].prefix.cmake))
 
         return args

--- a/var/spack/repos/builtin/packages/dla-future/package.py
+++ b/var/spack/repos/builtin/packages/dla-future/package.py
@@ -198,7 +198,7 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
                     self.define("MKL_LAPACK_TARGET", f"mkl::mkl_intel_32bit_{mkl_threads}_dyn"),
                 ]
 
-            if "+scalapack" in spec:
+            if spec.satisfies("+scalapack"):
                 try:
                     mpi_provider = spec["mpi"].name
                     if mpi_provider in ["mpich", "cray-mpich", "mvapich", "mvapich2"]:
@@ -228,7 +228,7 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
                     " ".join([spec[dep].libs.ld_flags for dep in ["blas", "lapack"]]),
                 )
             )
-            if "+scalapack" in spec:
+            if spec.satisfies("+scalapack"):
                 args.append(self.define("SCALAPACK_LIBRARY", spec["scalapack"].libs.ld_flags))
 
         args.append(self.define_from_variant("DLAF_WITH_SCALAPACK", "scalapack"))
@@ -243,12 +243,12 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
         # CUDA/HIP
         args.append(self.define_from_variant("DLAF_WITH_CUDA", "cuda"))
         args.append(self.define_from_variant("DLAF_WITH_HIP", "rocm"))
-        if "+rocm" in spec:
+        if spec.satisfies("+rocm"):
             archs = spec.variants["amdgpu_target"].value
             if "none" not in archs:
                 arch_str = ";".join(archs)
                 args.append(self.define("CMAKE_HIP_ARCHITECTURES", arch_str))
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             archs = spec.variants["cuda_arch"].value
             if "none" not in archs:
                 arch_str = ";".join(archs)

--- a/var/spack/repos/builtin/packages/dock/package.py
+++ b/var/spack/repos/builtin/packages/dock/package.py
@@ -29,7 +29,7 @@ class Dock(Package):
     depends_on("mpi", when="+mpi")
 
     def setup_build_environment(self, env):
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             env.set("MPICH_HOME", self.spec["mpi"].prefix)
 
     def install(self, spec, prefix):
@@ -48,7 +48,7 @@ class Dock(Package):
             sh_args = ["./configure", compiler_targets[self.compiler.name]]
             config_source = compiler_targets[self.compiler.name]
 
-            if "+mpi" in spec:
+            if spec.satisfies("+mpi"):
                 sh_args.append("parallel")
                 config_source = config_source + ".parallel"
 

--- a/var/spack/repos/builtin/packages/dotnet-core-sdk/package.py
+++ b/var/spack/repos/builtin/packages/dotnet-core-sdk/package.py
@@ -87,7 +87,7 @@ class DotnetCoreSdk(Package):
     variant("telemetry", default=False, description="allow collection of telemetry data")
 
     def setup_run_environment(self, env):
-        if "~telemetry" in self.spec:
+        if self.spec.satisfies("~telemetry"):
             env.set("DOTNET_CLI_TELEMETRY_OPTOUT", "1")
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/draco/package.py
+++ b/var/spack/repos/builtin/packages/draco/package.py
@@ -109,7 +109,7 @@ class Draco(CMakePackage):
                 "-DUSE_QT={0}".format("ON" if "+qt" in self.spec else "OFF"),
             ]
         )
-        if "+fast_fma" in self.spec:
+        if self.spec.satisfies("+fast_fma"):
             options.extend(
                 [
                     "-DDRACO_ROUNDOFF_MODE={0}".format(

--- a/var/spack/repos/builtin/packages/dray/package.py
+++ b/var/spack/repos/builtin/packages/dray/package.py
@@ -162,7 +162,7 @@ class Dray(Package, CudaPackage):
         # Find and record what CMake is used
         ##############################################
 
-        if "+cmake" in spec:
+        if spec.satisfies("+cmake"):
             cmake_exe = spec["cmake"].command.path
         else:
             cmake_exe = which("cmake")
@@ -199,7 +199,7 @@ class Dray(Package, CudaPackage):
         cfg.write("# cpp compiler used by spack\n")
         cfg.write(cmake_cache_entry("CMAKE_CXX_COMPILER", cpp_compiler))
 
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             mpicc_path = spec["mpi"].mpicc
             mpicxx_path = spec["mpi"].mpicxx
             # if we are using compiler wrappers on cray systems
@@ -212,7 +212,7 @@ class Dray(Package, CudaPackage):
             cfg.write(cmake_cache_entry("ENABLE_MPI", "ON"))
             cfg.write(cmake_cache_entry("MPI_C_COMPILER", mpicc_path))
             cfg.write(cmake_cache_entry("MPI_CXX_COMPILER", mpicxx_path))
-            if "+blt_find_mpi" in spec:
+            if spec.satisfies("+blt_find_mpi"):
                 cfg.write(cmake_cache_entry("ENABLE_FIND_MPI", "ON"))
             else:
                 cfg.write(cmake_cache_entry("ENABLE_FIND_MPI", "OFF"))
@@ -250,7 +250,7 @@ class Dray(Package, CudaPackage):
 
         cfg.write("# CUDA Support\n")
 
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             cfg.write(cmake_cache_entry("ENABLE_CUDA", "ON"))
             if "cuda_arch" in spec.variants:
                 cuda_value = spec.variants["cuda_arch"].value
@@ -259,13 +259,13 @@ class Dray(Package, CudaPackage):
         else:
             cfg.write(cmake_cache_entry("ENABLE_CUDA", "OFF"))
 
-        if "+openmp" in spec:
+        if spec.satisfies("+openmp"):
             cfg.write(cmake_cache_entry("ENABLE_OPENMP", "ON"))
         else:
             cfg.write(cmake_cache_entry("ENABLE_OPENMP", "OFF"))
 
         # shared vs static libs
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             cfg.write(cmake_cache_entry("BUILD_SHARED_LIBS", "ON"))
         else:
             cfg.write(cmake_cache_entry("BUILD_SHARED_LIBS", "OFF"))
@@ -273,7 +273,7 @@ class Dray(Package, CudaPackage):
         #######################
         # Unit Tests
         #######################
-        if "+test" in spec:
+        if spec.satisfies("+test"):
             cfg.write(cmake_cache_entry("DRAY_ENABLE_TESTS", "ON"))
             # we need this to control BLT tests
             cfg.write(cmake_cache_entry("ENABLE_TESTS", "ON"))
@@ -285,7 +285,7 @@ class Dray(Package, CudaPackage):
         #######################
         # Utilities
         #######################
-        if "+utils" in spec:
+        if spec.satisfies("+utils"):
             cfg.write(cmake_cache_entry("DRAY_ENABLE_UTILS", "ON"))
         else:
             cfg.write(cmake_cache_entry("DRAY_ENABLE_UTILS", "OFF"))
@@ -293,7 +293,7 @@ class Dray(Package, CudaPackage):
         #######################
         # Logging
         #######################
-        if "+logging" in spec:
+        if spec.satisfies("+logging"):
             cfg.write(cmake_cache_entry("ENABLE_LOGGING", "ON"))
         else:
             cfg.write(cmake_cache_entry("ENABLE_LOGGING", "OFF"))
@@ -301,7 +301,7 @@ class Dray(Package, CudaPackage):
         #######################
         # Status
         #######################
-        if "+stats" in spec:
+        if spec.satisfies("+stats"):
             cfg.write(cmake_cache_entry("ENABLE_STATS", "ON"))
         else:
             cfg.write(cmake_cache_entry("ENABLE_STATS", "OFF"))

--- a/var/spack/repos/builtin/packages/duckdb/package.py
+++ b/var/spack/repos/builtin/packages/duckdb/package.py
@@ -96,7 +96,7 @@ class Duckdb(MakefilePackage):
     )
 
     def setup_build_environment(self, env):
-        if "+ninjabuild" in self.spec:
+        if self.spec.satisfies("+ninjabuild"):
             env.set("GEN", "ninja")
         variant_flags = [
             "autocomplete",

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -139,12 +139,12 @@ class Dyninst(CMakePackage):
             self.define("LibIberty_LIBRARIES", spec["libiberty"].libs),
         ]
 
-        if "+openmp" in spec:
+        if spec.satisfies("+openmp"):
             args.append("-DUSE_OpenMP=ON")
         else:
             args.append("-DUSE_OpenMP=OFF")
 
-        if "+static" in spec:
+        if spec.satisfies("+static"):
             args.append("-DENABLE_STATIC_LIBS=YES")
         else:
             args.append("-DENABLE_STATIC_LIBS=NO")
@@ -194,14 +194,14 @@ class Dyninst(CMakePackage):
 
         # Openmp applies to version 10.x or later.
         if spec.satisfies("@10.0.0:"):
-            if "+openmp" in spec:
+            if spec.satisfies("+openmp"):
                 args.append("-DUSE_OpenMP=ON")
             else:
                 args.append("-DUSE_OpenMP=OFF")
 
         # Static libs started with version 9.1.0.
         if spec.satisfies("@9.1.0:"):
-            if "+static" in spec:
+            if spec.satisfies("+static"):
                 args.append("-DENABLE_STATIC_LIBS=1")
             else:
                 args.append("-DENABLE_STATIC_LIBS=NO")

--- a/var/spack/repos/builtin/packages/easi/package.py
+++ b/var/spack/repos/builtin/packages/easi/package.py
@@ -63,22 +63,22 @@ class Easi(CMakePackage):
         args.append(self.define_from_variant("PYTHON_BINDINGS", "python"))
         self.define("PYBIND11_USE_FETCHCONTENT", False)
         spec = self.spec
-        if "jit=impalajit" in spec or "jit=impalajit-llvm" in spec:
+        if spec.satisfies("jit=impalajit") or spec.satisfies("jit=impalajit-llvm"):
             args.append(self.define("IMPALAJIT", True))
             backend_type = "llvm" if "jit=impalajit-llvm" in spec else "original"
             args.append(self.define("IMPALAJIT_BACKEND", backend_type))
         else:
             args.append(self.define("IMPALAJIT", False))
 
-        if "jit=lua" in spec:
+        if spec.satisfies("jit=lua"):
             args.append(self.define("LUA", True))
 
-        if "+python" in spec:
+        if spec.satisfies("+python"):
             args += [self.define("easi_INSTALL_PYTHONDIR", python_platlib)]
 
         return args
 
     def setup_run_environment(self, env):
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             full_path = os.path.join(python_platlib, "easilib/cmake/easi/python_wrapper")
             env.prepend_path("PYTHONPATH", full_path)

--- a/var/spack/repos/builtin/packages/ebms/package.py
+++ b/var/spack/repos/builtin/packages/ebms/package.py
@@ -36,7 +36,7 @@ class Ebms(MakefilePackage):
 
         cflags = "-g -O3 -std=gnu99"
 
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             targets.append("CC={0}".format(self.spec["mpi"].mpicc))
 
         targets.append("CFLAGS={0}".format(cflags))

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -337,7 +337,7 @@ class Eccodes(CMakePackage):
             self.define("ENABLE_EXTRA_TESTS", False),
         ]
 
-        if "+netcdf" in self.spec:
+        if self.spec.satisfies("+netcdf"):
             # Prevent possible overriding by environment variables NETCDF_ROOT, NETCDF_DIR, and
             # NETCDF_PATH:
             args.append(self.define("NETCDF_PATH", self.spec["netcdf-c"].prefix))
@@ -350,10 +350,10 @@ class Eccodes(CMakePackage):
         if jp2k == "openjpeg":
             args.append(self.define("OPENJPEG_PATH", self.spec["openjpeg"].prefix))
 
-        if "+png" in self.spec:
+        if self.spec.satisfies("+png"):
             args.append(self.define("ZLIB_ROOT", self.spec["zlib-api"].prefix))
 
-        if "+aec" in self.spec:
+        if self.spec.satisfies("+aec"):
             # Prevent overriding by environment variables AEC_DIR and AEC_PATH:
             args.append(self.define("AEC_DIR", self.spec["libaec"].prefix))
 

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -86,7 +86,7 @@ class EcmwfAtlas(CMakePackage):
         if self.spec.satisfies("@0.35:"):
             args.append(self.define_from_variant("ENABLE_ECTRANS", "trans"))
             args.append(self.define_from_variant("ENABLE_TESSELATION", "tesselation"))
-        if "~shared" in self.spec:
+        if self.spec.satisfies("~shared"):
             args.append("-DBUILD_SHARED_LIBS=OFF")
         return args
 

--- a/var/spack/repos/builtin/packages/eem/package.py
+++ b/var/spack/repos/builtin/packages/eem/package.py
@@ -31,7 +31,7 @@ class Eem(MakefilePackage):
         settings.filter("$(HOME)/local", prefix, string=True)
         settings.filter("mpicxx", self.spec["mpi"].mpicxx, string=True)
 
-        if "+K" in self.spec:
+        if self.spec.satisfies("+K"):
             settings.filter("CXXFLAGS= -Wall -Wno-sign-compare -g", "CXXFLAGS=", string=True)
             settings.filter(
                 "CXXFLAGS+= -std=c++11 -DHAVE_UNORDERED_MAP",

--- a/var/spack/repos/builtin/packages/elbencho/package.py
+++ b/var/spack/repos/builtin/packages/elbencho/package.py
@@ -68,11 +68,11 @@ class Elbencho(MakefilePackage):
     def edit(self, spec, prefix):
         os.mkdir(prefix.bin)
         os.environ["INST_PATH"] = prefix.bin
-        if "+s3" in spec:
+        if spec.satisfies("+s3"):
             os.environ["S3_SUPPORT"] = "1"
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             os.environ["CUDA_SUPPORT"] = "1"
-        if "+cufile" in spec:
+        if spec.satisfies("+cufile"):
             os.environ["CUFILE_SUPPORT"] = "1"
         makefile = FileFilter("Makefile")
         makefile.filter(r"\s+/etc/bash_completion.d/", f" {prefix}/etc/bash_completion.d/")

--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -102,7 +102,7 @@ class Elemental(CMakePackage):
     def cmake_args(self):
         spec = self.spec
 
-        if "@:0.87.7" in spec and "%intel@:17.0.2" in spec:
+        if spec.satisfies("@:0.87.7") and spec.satisfies("%intel@:17.0.2"):
             raise UnsupportedCompilerError(
                 "Elemental {0} has a known bug with compiler: {1} {2}".format(
                     spec.version, spec.compiler.name, spec.compiler.version
@@ -150,7 +150,7 @@ class Elemental(CMakePackage):
 
         # If using 64bit int BLAS libraries, elemental has to build
         # them internally
-        if "+int64_blas" in spec:
+        if spec.satisfies("+int64_blas"):
             args.extend(
                 [
                     "-DEL_BLAS_SUFFIX:STRING={0}".format(
@@ -159,7 +159,7 @@ class Elemental(CMakePackage):
                     "-DCUSTOM_BLAS_SUFFIX:BOOL=TRUE",
                 ]
             ),
-            if "+scalapack" in spec:
+            if spec.satisfies("+scalapack"):
                 args.extend(
                     [
                         "-DEL_LAPACK_SUFFIX:STRING={0}".format(
@@ -171,7 +171,7 @@ class Elemental(CMakePackage):
         else:
             math_libs = spec["lapack"].libs + spec["blas"].libs
 
-            if "+scalapack" in spec:
+            if spec.satisfies("+scalapack"):
                 math_libs = spec["scalapack"].libs + math_libs
 
             args.extend(["-DMATH_LIBS:STRING={0}".format(math_libs.ld_flags)])

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -128,7 +128,7 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
         else:
             args.append("--program-prefix=''")
 
-        if "@0.182:" in spec:
+        if spec.satisfies("@0.182:"):
             args.append("--with-zstd=%s" % spec["zstd"].prefix)
 
         if spec.satisfies("@0.183:"):
@@ -137,7 +137,7 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
             else:
                 args.append("--without-libiconv-prefix")
 
-        if "+nls" in spec:
+        if spec.satisfies("+nls"):
             # Prior to 0.183, only msgfmt is used from gettext.
             if spec.satisfies("@0.183:"):
                 if "intl" not in spec["gettext"].libs.names:
@@ -147,7 +147,7 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
         else:
             args.append("--disable-nls")
 
-        if "+debuginfod" in spec:
+        if spec.satisfies("+debuginfod"):
             args.append("--enable-debuginfod")
             if spec.satisfies("@0.181:"):
                 args.append("--enable-libdebuginfod")

--- a/var/spack/repos/builtin/packages/elk/package.py
+++ b/var/spack/repos/builtin/packages/elk/package.py
@@ -136,7 +136,7 @@ class Elk(MakefilePackage):
         config["F90_OPTS"] = flags
         config["F77_OPTS"] = flags
 
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             config["F90"] = spec["mpi"].mpifc
             config["F77"] = spec["mpi"].mpif77
             config["SRC_MPI"] = " "
@@ -146,7 +146,7 @@ class Elk(MakefilePackage):
             config["SRC_MPI"] = "mpi_stub.f90"
 
         # OpenMP support
-        if "+openmp" in spec:
+        if spec.satisfies("+openmp"):
             config["F90_OPTS"] += " " + self.compiler.openmp_flag
             config["F77_OPTS"] += " " + self.compiler.openmp_flag
             config["SRC_OMP"] = " "
@@ -154,29 +154,29 @@ class Elk(MakefilePackage):
         # BLAS/LAPACK support
         # Note: openblas must be compiled with OpenMP support
         # if the +openmp variant is chosen
-        if "linalg=internal" in spec:
+        if spec.satisfies("linalg=internal"):
             self.build_targets.append("blas")
             self.build_targets.append("lapack")
-        if "linalg=generic" in spec:
+        if spec.satisfies("linalg=generic"):
             blas = spec["blas"].libs.joined()
             lapack = spec["lapack"].libs.joined()
             config["LIB_LPK"] = " ".join([lapack, blas])
-        if "linalg=openblas" in spec:
+        if spec.satisfies("linalg=openblas"):
             config["LIB_LPK"] = spec["openblas"].libs.ld_flags
             config["SRC_OBLAS"] = " "
-        if "linalg=mkl" in spec:
+        if spec.satisfies("linalg=mkl"):
             config["LIB_LPK"] = spec["mkl"].libs.ld_flags
             config["SRC_MKL"] = " "
-        if "linalg=blis" in spec:
+        if spec.satisfies("linalg=blis"):
             config["LIB_LPK"] = " ".join(["lapack.a ", spec["blis"].libs.ld_flags])
             config["SRC_BLIS"] = " "
         # FFT
-        if "fft=internal" in spec:
+        if spec.satisfies("fft=internal"):
             self.build_targets.append("fft")
-        elif "fft=fftw" in spec:
+        elif spec.satisfies("fft=fftw"):
             config["LIB_FFT"] = spec["fftw"].libs.ld_flags
             config["SRC_FFT"] = "zfftifc_fftw.f90"
-        elif "fft=mkl" in spec:
+        elif spec.satisfies("fft=mkl"):
             config["LIB_FFT"] = spec["mkl"].libs.ld_flags
             config["SRC_FFT"] = "mkl_dfti.f90 zfftifc_mkl.f90"
             cp = which("cp")
@@ -192,7 +192,7 @@ class Elk(MakefilePackage):
         self.build_targets.append("elk")
         print(self.build_targets)
         # Libxc support
-        if "+libxc" in spec:
+        if spec.satisfies("+libxc"):
             config["LIB_libxc"] = " ".join(
                 [
                     join_path(spec["libxc"].prefix.lib, "libxcf90.so"),

--- a/var/spack/repos/builtin/packages/elmerfem/package.py
+++ b/var/spack/repos/builtin/packages/elmerfem/package.py
@@ -57,7 +57,7 @@ class Elmerfem(CMakePackage):
 
         args = ["-DWITH_ElmerIce=ON", "-DWITH_CONTRIB=ON"]
 
-        if "+gui" in spec:
+        if spec.satisfies("+gui"):
             args.append("-DWITH_ELMERGUI:BOOL=TRUE")
             args.append("-DWITH_QT5:BOOL=TRUE")
             args.append("-DWITH_QWT:BOOL=TRUE")
@@ -65,7 +65,7 @@ class Elmerfem(CMakePackage):
         else:
             args.append("-DWITH_ELMERGUI:BOOL=FALSE")
 
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             args.append("-DWITH_MPI=ON")
         else:
             args.append("-DWITH_MPI=OFF")
@@ -73,40 +73,40 @@ class Elmerfem(CMakePackage):
         if self.spec.satisfies("^intel-mkl"):
             args.append("-DWITH_MKL:BOOL=TRUE")
 
-        if "+openmp" in spec:
+        if spec.satisfies("+openmp"):
             args.append("-DWITH_OpenMP=ON")
         else:
             args.append("-DWITH_OpenMP=OFF")
 
-        if "+mumps" in spec:
+        if spec.satisfies("+mumps"):
             args.append("-DWITH_Mumps=ON")
         else:
             args.append("-DWITH_Mumps=OFF")
 
-        if "+hypre" in spec:
+        if spec.satisfies("+hypre"):
             args.append("-DWITH_Hypre=ON")
         else:
             args.append("-DWITH_Hypre=OFF")
 
-        if "+trilinos" in spec:
+        if spec.satisfies("+trilinos"):
             args.extend(["-DWITH_Trilinos=ON", "-DCMAKE_CXX_STANDARD=11"])
         else:
             args.append("-DWITH_Trilinos=OFF")
 
-        if "+lua" in spec:
+        if spec.satisfies("+lua"):
             args.extend(["-DWITH_LUA=ON", "-DUSE_SYSTEM_LUA=ON"])
-            if "%gcc" in spec:
+            if spec.satisfies("%gcc"):
                 args.append("-DCMAKE_Fortran_FLAGS=-ffree-line-length-none")
 
         else:
             args.append("-DWITH_LUA=OFF")
 
-        if "+zoltan" in spec:
+        if spec.satisfies("+zoltan"):
             args.extend(["-DWITH_Zoltan=ON", "-DUSE_SYSTEM_ZOLTAN=ON"])
         else:
             args.append("-DWITH_Zoltan=OFF")
 
-        if "+scatt2d" in spec:
+        if spec.satisfies("+scatt2d"):
             args.extend(
                 [
                     "-DWITH_ScatteredDataInterpolator=ON",
@@ -132,5 +132,5 @@ class Elmerfem(CMakePackage):
     def setup_run_environment(self, env):
         env.set("ELMER_HOME", self.prefix)
         env.set("ELMER_Fortran_COMPILER", self.compiler.fc)
-        if "+gui" in self.spec:
+        if self.spec.satisfies("+gui"):
             env.set("ELMERGUI_HOME", self.prefix.share.ElmerGUI)

--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -158,7 +158,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
         if spec.target.family != "x86_64":
             options.append("--disable-sse-assembly")
 
-        if "%aocc" in spec or "%fj" in spec:
+        if spec.satisfies("%aocc") or spec.satisfies("%fj"):
             options.append("--disable-shared")
             options.append("--enable-static")
 
@@ -169,17 +169,17 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
         if self.compiler.name == "gcc":
             options.extend(["CFLAGS=-O3", "FCFLAGS=-O3 -ffree-line-length-none"])
 
-        if "%aocc" in spec:
+        if spec.satisfies("%aocc"):
             options.extend(["FCFLAGS=-O3", "CFLAGS=-O3"])
 
-        if "%fj" in spec:
+        if spec.satisfies("%fj"):
             options.append("--disable-Fortran2008-features")
             options.append("--enable-FUGAKU")
-            if "+openmp" in spec:
+            if spec.satisfies("+openmp"):
                 options.extend(["FCFLAGS=-Kparallel"])
 
         cuda_flag = "nvidia-gpu"
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             prefix = spec["cuda"].prefix
             # Can't yet be changed to the new option --enable-nvidia-gpu-kernels
             # https://github.com/marekandreas/elpa/issues/55
@@ -199,7 +199,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
         else:
             options.append(f"--disable-{cuda_flag}" + kernels)
 
-        if "+rocm" in spec:
+        if spec.satisfies("+rocm"):
             # Can't yet be changed to the new option --enable-amd-gpu-kernels
             # https://github.com/marekandreas/elpa/issues/55
             options.append("--enable-amd-gpu")
@@ -208,7 +208,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
             if spec.satisfies("+gpu_streams"):
                 options.append("--enable-gpu-streams=amd")
 
-        elif "@2021.05.001:" in self.spec:
+        elif self.spec.satisfies("@2021.05.001:"):
             options.append("--disable-amd-gpu" + kernels)
 
         options += self.enable_or_disable("openmp")
@@ -219,7 +219,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         options += [f'LDFLAGS={" ".join(ldflags)}', f'LIBS={" ".join(libs)}']
 
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             options += [
                 "CC={0}".format(spec["mpi"].mpicc),
                 "CXX={0}".format(spec["mpi"].mpicxx),
@@ -227,7 +227,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
                 "SCALAPACK_LDFLAGS={0}".format(spec["scalapack"].libs.joined()),
             ]
 
-        if "+autotune" in self.spec:
+        if self.spec.satisfies("+autotune"):
             options.append("--enable-autotune-redistribute-matrix")
             # --enable-autotune-redistribute-matrix requires --enable-scalapack-tests as well
             options.append("--enable-scalapack-tests")

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -91,7 +91,7 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
         spec = self.spec
 
         toolkit = spec.variants["toolkit"].value
-        if "+X" in spec:
+        if spec.satisfies("+X"):
             args = ["--with-x", "--with-x-toolkit={0}".format(toolkit)]
         else:
             args = ["--without-x"]

--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -92,10 +92,10 @@ class EnvironmentModules(Package):
         if not spec.satisfies("@4.5.2"):
             config_args.extend(["--disable-dependency-tracking", "--disable-silent-rules"])
 
-        if "~X" in spec:
+        if spec.satisfies("~X"):
             config_args = ["--without-x"] + config_args
 
-        if "@4.4.0:4.8" in self.spec:
+        if self.spec.satisfies("@4.4.0:4.8"):
             config_args.extend(
                 [
                     "--with-icase=search",
@@ -104,13 +104,13 @@ class EnvironmentModules(Package):
                 ]
             )
 
-        if "@4.3.0:4.8" in self.spec:
+        if self.spec.satisfies("@4.3.0:4.8"):
             config_args.extend(["--enable-color"])
 
-        if "@4.2.0:4.8" in self.spec:
+        if self.spec.satisfies("@4.2.0:4.8"):
             config_args.extend(["--enable-auto-handling"])
 
-        if "@4.1.0:" in self.spec:
+        if self.spec.satisfies("@4.1.0:"):
             config_args.extend(
                 [
                     # Variables in quarantine are empty during module command
@@ -120,17 +120,17 @@ class EnvironmentModules(Package):
                 ]
             )
 
-        if "@4.0.0:4.8" in self.spec:
+        if self.spec.satisfies("@4.0.0:4.8"):
             config_args.extend(["--disable-compat-version"])
 
-        if "@4.0.0:" in self.spec:
+        if self.spec.satisfies("@4.0.0:"):
             config_args.extend(["--with-tclsh={0}".format(tcl.prefix.bin.tclsh)])
 
-        if "@3.2.10" in self.spec:
+        if self.spec.satisfies("@3.2.10"):
             # See: https://sourceforge.net/p/modules/bugs/62/
             config_args.extend(["--disable-debug", "CPPFLAGS=-DUSE_INTERP_ERRORLINE"])
 
-        if "@:3.2" in self.spec:
+        if self.spec.satisfies("@:3.2"):
             config_args.extend(
                 [
                     "--without-tclx",

--- a/var/spack/repos/builtin/packages/eospac/package.py
+++ b/var/spack/repos/builtin/packages/eospac/package.py
@@ -159,11 +159,11 @@ class Eospac(Package):
             # This looks goofy because eospac does not actually respect the
             # value of DO_OFFLOAD and instead only attempts to check for its
             # existence; a quirk of eospac.
-            if "+offload" in spec:
+            if spec.satisfies("+offload"):
                 compilerArgs.append("DO_OFFLOAD=1")
             # Eospac depends on fcommon behavior
             #   but gcc@10 flipped to default fno-common
-            if "%gcc@10:" in spec:
+            if spec.satisfies("%gcc@10:"):
                 compilerArgs.append("CFLAGS=-fcommon")
             if self.run_tests:
                 make("check", *compilerArgs)

--- a/var/spack/repos/builtin/packages/erne/package.py
+++ b/var/spack/repos/builtin/packages/erne/package.py
@@ -30,7 +30,7 @@ class Erne(AutotoolsPackage):
     depends_on("openmpi", type=("build", "run"), when="+mpi")
 
     def configure_args(self):
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             return ["--enable-openmpi"]
         else:
             return ["--disable-openmpi"]

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -333,24 +333,26 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
         # ESMF_COMM must be set to indicate which MPI implementation
         # is used to build the ESMF library.
         if spec.satisfies("+mpi"):
-            if self.spec.satisfies("^cray-mpich"):
+            if self.spec.satisfies("^[virtuals=mpi] cray-mpich"):
                 env.set("ESMF_COMM", "mpi")
                 # https://github.com/jcsda/spack-stack/issues/517
                 if self.spec.satisfies("@:8.4.1"):
                     env.set("ESMF_CXXLINKLIBS", "-lmpifort -lmpi")
-            elif spec.satisfies("^mvapich2"):
+            elif spec.satisfies("^[virtuals=mpi] mvapich2"):
                 env.set("ESMF_COMM", "mvapich2")
-            elif spec.satisfies("^mpich"):
+            elif spec.satisfies("^[virtuals=mpi] mpich"):
                 if self.spec.satisfies("@:8.2.99"):
                     env.set("ESMF_COMM", "mpich3")
                 else:
                     env.set("ESMF_COMM", "mpich")
-            elif spec.satisfies("^openmpi") or spec.satisfies("^hpcx-mpi"):
+            elif spec.satisfies("^[virtuals=mpi] openmpi") or spec.satisfies(
+                "^[virtuals=mpi] hpcx-mpi"
+            ):
                 env.set("ESMF_COMM", "openmpi")
             elif (
-                "^intel-parallel-studio+mpi" in spec
-                or "^intel-mpi" in spec
-                or "^intel-oneapi-mpi" in spec
+                spec.satisfies("^[virtuals=mpi] intel-parallel-studio+mpi")
+                or spec.satisfies("^[virtuals=mpi] intel-mpi")
+                or spec.satisfies("^[virtuals=mpi] intel-oneapi-mpi")
             ):
                 env.set("ESMF_COMM", "intelmpi")
             elif spec.satisfies("^mpt"):

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -355,7 +355,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
                 or spec.satisfies("^[virtuals=mpi] intel-oneapi-mpi")
             ):
                 env.set("ESMF_COMM", "intelmpi")
-            elif spec.satisfies("^mpt"):
+            elif spec.satisfies("^[virtuals=mpi] mpt"):
                 # MPT is the HPE (SGI) variant of mpich
                 env.set("ESMF_COMM", "mpt")
         else:

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -288,7 +288,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
             msg += '"{0}", is not supported by ESMF.'
             raise InstallError(msg.format(self.pkg.compiler.name))
 
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             env.set("ESMF_CXX", spec["mpi"].mpicxx)
             env.set("ESMF_C", spec["mpi"].mpicc)
             env.set("ESMF_F90", spec["mpi"].mpifc)
@@ -298,7 +298,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
             env.set("ESMF_F90", spack_fc)
 
         # This environment variable controls the build option.
-        if "+debug" in spec:
+        if spec.satisfies("+debug"):
             # Build a debuggable version of the library.
             env.set("ESMF_BOPT", "g")
         else:
@@ -332,20 +332,20 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
 
         # ESMF_COMM must be set to indicate which MPI implementation
         # is used to build the ESMF library.
-        if "+mpi" in spec:
-            if "^cray-mpich" in self.spec:
+        if spec.satisfies("+mpi"):
+            if self.spec.satisfies("^cray-mpich"):
                 env.set("ESMF_COMM", "mpi")
                 # https://github.com/jcsda/spack-stack/issues/517
                 if self.spec.satisfies("@:8.4.1"):
                     env.set("ESMF_CXXLINKLIBS", "-lmpifort -lmpi")
-            elif "^mvapich2" in spec:
+            elif spec.satisfies("^mvapich2"):
                 env.set("ESMF_COMM", "mvapich2")
-            elif "^mpich" in spec:
+            elif spec.satisfies("^mpich"):
                 if self.spec.satisfies("@:8.2.99"):
                     env.set("ESMF_COMM", "mpich3")
                 else:
                     env.set("ESMF_COMM", "mpich")
-            elif "^openmpi" in spec or "^hpcx-mpi" in spec:
+            elif spec.satisfies("^openmpi") or spec.satisfies("^hpcx-mpi"):
                 env.set("ESMF_COMM", "openmpi")
             elif (
                 "^intel-parallel-studio+mpi" in spec
@@ -353,7 +353,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
                 or "^intel-oneapi-mpi" in spec
             ):
                 env.set("ESMF_COMM", "intelmpi")
-            elif "^mpt" in spec:
+            elif spec.satisfies("^mpt"):
                 # MPT is the HPE (SGI) variant of mpich
                 env.set("ESMF_COMM", "mpt")
         else:
@@ -369,7 +369,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
         # LAPACK #
         ##########
 
-        if "+external-lapack" in spec:
+        if spec.satisfies("+external-lapack"):
             # A system-dependent external LAPACK/BLAS installation is used
             # to satisfy the external dependencies of the LAPACK-dependent
             # ESMF code.
@@ -388,7 +388,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
         # NetCDF #
         ##########
 
-        if "+netcdf" in spec:
+        if spec.satisfies("+netcdf"):
             # ESMF provides the ability to read Grid and Mesh data in
             # NetCDF format.
             env.set("ESMF_NETCDF", "nc-config")
@@ -403,7 +403,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
         # Parallel-NetCDF #
         ###################
 
-        if "+pnetcdf" in spec:
+        if spec.satisfies("+pnetcdf"):
             # ESMF provides the ability to write Mesh weights
             # using Parallel-NetCDF.
 
@@ -414,7 +414,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
         ##############
         # ParallelIO #
         ##############
-        if "+external-parallelio" in spec:
+        if spec.satisfies("+external-parallelio"):
             env.set("ESMF_PIO", "external")
             env.set("ESMF_PIO_LIBPATH", spec["parallelio"].prefix.lib)
             env.set("ESMF_PIO_INCLUDE", spec["parallelio"].prefix.include)
@@ -428,7 +428,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
         # XERCES #
         ##########
 
-        if "+xerces" in spec:
+        if spec.satisfies("+xerces"):
             # ESMF provides the ability to read Attribute data in
             # XML file format via the XERCES C++ library.
 
@@ -444,11 +444,11 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
         #########################
 
         # Static-only option:
-        if "~shared" in spec:
+        if spec.satisfies("~shared"):
             env.set("ESMF_SHARED_LIB_BUILD", "OFF")
 
         # https://github.com/JCSDA/spack-stack/issues/956
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             if sys.platform == "darwin":
                 env.set("ESMF_TRACE_LIB_BUILD", "OFF")
 
@@ -474,7 +474,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
     def install(self, pkg, spec, prefix):
         make("install")
 
-        if "+python" in spec:
+        if spec.satisfies("+python"):
             # build the python library
             python_builder = PythonPipBuilder(pkg)
             python_builder.install(pkg, spec, prefix)

--- a/var/spack/repos/builtin/packages/essl/package.py
+++ b/var/spack/repos/builtin/packages/essl/package.py
@@ -45,18 +45,18 @@ class Essl(BundlePackage):
         spec = self.spec
         prefix = self.prefix
 
-        if "+ilp64" in spec:
+        if spec.satisfies("+ilp64"):
             essl_lib = ["libessl6464"]
         else:
             essl_lib = ["libessl"]
 
         if spec.satisfies("threads=openmp"):
             # ESSL SMP support requires XL or Clang OpenMP library
-            if "%xl" in spec or "%xl_r" in spec or "%clang" in spec:
-                if "+ilp64" in spec:
+            if spec.satisfies("%xl") or spec.satisfies("%xl_r") or spec.satisfies("%clang"):
+                if spec.satisfies("+ilp64"):
                     essl_lib = ["libesslsmp6464"]
                 else:
-                    if "+cuda" in spec:
+                    if spec.satisfies("+cuda"):
                         essl_lib = ["libesslsmpcuda"]
                     else:
                         essl_lib = ["libesslsmp"]

--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -104,11 +104,11 @@ class Evtgen(CMakePackage):
         args = []
 
         args.append("--hepmcdir=%s" % self.spec["hepmc"].prefix)
-        if "+pythia8" in self.spec:
+        if self.spec.satisfies("+pythia8"):
             args.append("--pythiadir=%s" % self.spec["pythia8"].prefix)
-        if "+photos" in self.spec:
+        if self.spec.satisfies("+photos"):
             args.append("--photosdir=%s" % self.spec["photos"].prefix)
-        if "+tauola" in self.spec:
+        if self.spec.satisfies("+tauola"):
             args.append("--tauoladir=%s" % self.spec["tauola"].prefix)
 
         return args

--- a/var/spack/repos/builtin/packages/exabayes/package.py
+++ b/var/spack/repos/builtin/packages/exabayes/package.py
@@ -38,7 +38,7 @@ class Exabayes(AutotoolsPackage):
 
     def configure_args(self):
         args = []
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             args.append("--enable-mpi")
         else:
             args.append("--disable-mpi")

--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -199,7 +199,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
         args = []
         spec = self.spec
 
-        if "~mpi" in self.spec:
+        if self.spec.satisfies("~mpi"):
             args.append(self.define("CMAKE_C_COMPILER", os.environ["CC"]))
             args.append(self.define("CMAKE_CXX_COMPILER", os.environ["CXX"]))
         else:
@@ -207,7 +207,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
             args.append(self.define("CMAKE_CXX_COMPILER", spec["mpi"].mpicxx))
             args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
             args.append(self.define("MPI_CXX_COMPILER", spec["mpi"].mpicxx))
-            if "+cuda" in spec:
+            if spec.satisfies("+cuda"):
                 args.append(self.define("MPI_CXX_HEADER_DIR", spec["mpi"].prefix.include))
 
         # NOTE: If building with spack develop on a cluster, you may want to
@@ -233,7 +233,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
             ]
         )
 
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             cuda_arch_list = spec.variants["cuda_arch"].value
             if cuda_arch_list[0] != "none":
                 args.append(self.define("CMAKE_CUDA_ARCHITECTURES", cuda_arch_list))
@@ -246,7 +246,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
         # args.append(
         #     self.define('HIP_CLANG_INCLUDE_PATH',
         #         '/opt/rocm-X.Y.Z/llvm/lib/clang/14.0.0/include/'))
-        if "+rocm" in spec:
+        if spec.satisfies("+rocm"):
             args.append(self.define("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
             rocm_arch_list = spec.variants["amdgpu_target"].value

--- a/var/spack/repos/builtin/packages/examinimd/package.py
+++ b/var/spack/repos/builtin/packages/examinimd/package.py
@@ -43,14 +43,14 @@ class Examinimd(MakefilePackage):
         # Append Kokkos
         targets.append("KOKKOS_PATH={0}".format(self.spec["kokkos-legacy"].prefix))
         # Set kokkos device
-        if "openmp" in self.spec:
+        if self.spec.satisfies("openmp"):
             targets.append("KOKKOS_DEVICES=OpenMP")
-        elif "pthreads" in self.spec:
+        elif self.spec.satisfies("pthreads"):
             targets.append("KOKKOS_DEVICES=Pthread")
         else:
             targets.append("KOKKOS_DEVICES=Serial")
         # Set MPI as needed
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             targets.append("MPI=1")
             targets.append("CXX = {0}".format(self.spec["mpi"].mpicxx))
         else:

--- a/var/spack/repos/builtin/packages/exasp2/package.py
+++ b/var/spack/repos/builtin/packages/exasp2/package.py
@@ -48,7 +48,7 @@ class Exasp2(MakefilePackage):
     def build_targets(self):
         targets = []
         spec = self.spec
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             targets.append("PARALLEL=MPI")
             targets.append("MPICC={0}".format(spec["mpi"].mpicc))
             targets.append("MPI_LIB=-L" + spec["mpi"].prefix.lib + " -lmpi")

--- a/var/spack/repos/builtin/packages/exawind/package.py
+++ b/var/spack/repos/builtin/packages/exawind/package.py
@@ -116,14 +116,14 @@ class Exawind(CMakePackage, CudaPackage, ROCmPackage):
 
     def setup_build_environment(self, env):
         env.append_flags("CXXFLAGS", "-DUSE_STK_SIMD_NONE")
-        if "+rocm+amr_wind_gpu~nalu_wind_gpu" in self.spec:
+        if self.spec.satisfies("+rocm+amr_wind_gpu~nalu_wind_gpu"):
             # Manually turn off device self.defines to solve Kokkos issues in Nalu-Wind headers
             env.append_flags("CXXFLAGS", "-U__HIP_DEVICE_COMPILE__ -DDESUL_HIP_RDC")
-        if "+cuda" in self.spec:
+        if self.spec.satisfies("+cuda"):
             env.set("OMPI_CXX", self.spec["kokkos-nvcc-wrapper"].kokkos_cxx)
             env.set("MPICH_CXX", self.spec["kokkos-nvcc-wrapper"].kokkos_cxx)
             env.set("MPICXX_CXX", self.spec["kokkos-nvcc-wrapper"].kokkos_cxx)
-        if "+rocm" in self.spec:
+        if self.spec.satisfies("+rocm"):
             env.set("OMPI_CXX", self.spec["hip"].hipcc)
             env.set("MPICH_CXX", self.spec["hip"].hipcc)
             env.set("MPICXX_CXX", self.spec["hip"].hipcc)

--- a/var/spack/repos/builtin/packages/exciting/package.py
+++ b/var/spack/repos/builtin/packages/exciting/package.py
@@ -75,18 +75,18 @@ class Exciting(MakefilePackage):
         opts["LIB_ARP"] = "libarpack.a"
         opts["F90"] = spack_fc
         opts["F77"] = spack_f77
-        if "+omp" in spec:
+        if spec.satisfies("+omp"):
             opts["SMPF90_OPTS"] = self.compiler.openmp_flag + " -DUSEOMP"
             opts["SMPF77_OPTS"] = self.compiler.openmp_flag + " -DUSEOMP"
         else:
             opts["BUILDSMP"] = "false"
 
-        if "%intel" in spec:
+        if spec.satisfies("%intel"):
             opts["F90_OPTS"] += " -cpp -ip -unroll -scalar_rep "
             opts["CPP_ON_OPTS"] += " -DIFORT -DFFTW"
-        if "%gcc" in spec:
+        if spec.satisfies("%gcc"):
             opts["F90_OPTS"] += " -march=native -ffree-line-length-0"
-            if "%gcc@10:" in spec:
+            if spec.satisfies("%gcc@10:"):
                 # The INSTALL file says this will fix the GCC@10 issues
                 opts["F90_OPTS"] += " -fallow-argument-mismatch"
                 opts["F77_OPTS"] += " -fallow-argument-mismatch"
@@ -95,7 +95,7 @@ class Exciting(MakefilePackage):
             " ".join(["FCFLAGS = @FCFLAGS@", "-cpp", self.compiler.openmp_flag]),
             "src/libXC/src/Makefile.in",
         )
-        if "+mkl" in spec:
+        if spec.satisfies("+mkl"):
             opts["LIB_LPK"] = "-mkl=parallel"
             opts["INC_MKL"] = spec["mkl"].headers.include_flags
             opts["LIB_MKL"] = spec["mkl"].libs.ld_flags
@@ -109,17 +109,17 @@ class Exciting(MakefilePackage):
                 ]
             )
 
-        if "+omp" in spec:
+        if spec.satisfies("+omp"):
             opts["BUILDSMP"] = "true"
 
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             opts["BUILDMPI"] = "true"
             opts["MPIF90"] = spec["mpi"].mpifc
             opts["MPIF90_CPP_OPTS"] = "-DMPI -DMPIRHO -DMPISEC"
             opts["MPIF90_OPTS"] = " ".join(["$(F90_OPTS)", "$(CPP_ON_OPTS) " "$(MPIF90_CPP_OPTS)"])
             opts["MPIF90MT"] = "$(MPIF90)"
 
-            if "+omp" in spec:
+            if spec.satisfies("+omp"):
                 opts["BUILDMPISMP"] = "true"
                 opts["SMPF90_OPTS"] = self.compiler.openmp_flag + " -DUSEOMP"
                 opts["SMPF77_OPTS"] = opts["SMPF90_OPTS"]
@@ -127,7 +127,7 @@ class Exciting(MakefilePackage):
 
         else:
             opts["BUILDMPI"] = "false"
-        if "+scalapack" in spec:
+        if spec.satisfies("+scalapack"):
             opts["LIB_SCLPK"] = spec["scalapack"].libs.ld_flags
             opts["CPP_SCLPK"] = " -DSCAL "
             opts["MPI_LIBS"] = "$(LIB_SCLPK)"

--- a/var/spack/repos/builtin/packages/exodusii/package.py
+++ b/var/spack/repos/builtin/packages/exodusii/package.py
@@ -183,7 +183,7 @@ class Exodusii(CMakePackage):
                     define("MPI_BASE_DIR", spec["mpi"].prefix),
                 ]
             )
-            if "+fortran" in self.spec:
+            if self.spec.satisfies("+fortran"):
                 options.append(define("CMAKE_Fortran_COMPILER", spec["mpi"].mpifc))
 
         # ##################### Dependencies ##########################

--- a/var/spack/repos/builtin/packages/expat/package.py
+++ b/var/spack/repos/builtin/packages/expat/package.py
@@ -176,7 +176,7 @@ class AutotoolsBuilder(autotools.AutotoolsBuilder):
     def configure_args(self):
         spec = self.spec
         args = ["--without-docbook", "--enable-static"]
-        if "+libbsd" in spec and "@2.2.1:" in spec:
+        if spec.satisfies("+libbsd") and spec.satisfies("@2.2.1:"):
             args.append("--with-libbsd")
         return args
 
@@ -188,7 +188,7 @@ class CMakeBuilder(cmake.CMakeBuilder):
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
         ]
 
-        if "+libbsd" in self.spec and "@2.2.1:" in self.spec:
+        if self.spec.satisfies("+libbsd") and self.spec.satisfies("@2.2.1:"):
             args.append(self.define_from_variant("EXPAT_WITH_LIBBSD", "libbsd"))
 
         return args

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -94,7 +94,7 @@ class Extrae(AutotoolsPackage):
 
     def configure_args(self):
         spec = self.spec
-        if "^intel-oneapi-mpi" in spec:
+        if spec.satisfies("^intel-oneapi-mpi"):
             mpiroot = spec["mpi"].component_prefix
         else:
             mpiroot = spec["mpi"].prefix
@@ -127,7 +127,7 @@ class Extrae(AutotoolsPackage):
             else ["--without-cuda"]
         )
 
-        if "+cupti" in self.spec:
+        if self.spec.satisfies("+cupti"):
             cupti_h = find_headers("cupti", spec["cuda"].prefix, recursive=True)
             cupti_dir = os.path.dirname(os.path.dirname(cupti_h[0]))
 

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -94,7 +94,7 @@ class Extrae(AutotoolsPackage):
 
     def configure_args(self):
         spec = self.spec
-        if spec.satisfies("^intel-oneapi-mpi"):
+        if spec.satisfies("^[virtuals=mpi] intel-oneapi-mpi"):
             mpiroot = spec["mpi"].component_prefix
         else:
             mpiroot = spec["mpi"].prefix

--- a/var/spack/repos/builtin/packages/eztrace/package.py
+++ b/var/spack/repos/builtin/packages/eztrace/package.py
@@ -92,13 +92,13 @@ class CMakeBuilder(cmake.CMakeBuilder):
 
         if spec.satisfies("@2.1: %llvm-openmp-ompt"):
             args.append(self.define("EZTRACE_ENABLE_OMPT", True))
-        if "+starpu" in spec:
+        if spec.satisfies("+starpu"):
             args.append(self.define("EZTRACE_ENABLE_STARPU", True))
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             args.append(self.define("EZTRACE_ENABLE_CUDA", True))
-        if "+netcdf" in spec:
+        if spec.satisfies("+netcdf"):
             args.append(self.define("EZTRACE_ENABLE_NETCDF", True))
-        if "+pnetcdf" in spec:
+        if spec.satisfies("+pnetcdf"):
             args.append(self.define("EZTRACE_ENABLE_PNETCDF", True))
 
         return args


### PR DESCRIPTION
with the structure if "+variant" in spec:, checks like if "mpi" in spec: would be valid whereas it could be ~mpi or +mpi. Satisfies adds additional checks to avoid mistakes from the user.