### PR TITLE
Replace `if ... in spec` with `spec.satisfies` in f* and g* packages

### DIFF
--- a/var/spack/repos/builtin/packages/faiss/package.py
+++ b/var/spack/repos/builtin/packages/faiss/package.py
@@ -79,7 +79,7 @@ class Faiss(AutotoolsPackage, CMakePackage, CudaPackage):
     patch("fixes-in-v1.7.2.patch", when="@1.7.2")
 
     def setup_run_environment(self, env):
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             env.prepend_path("PYTHONPATH", python_platlib)
             if self.spec.satisfies("platform=darwin"):
                 env.append_path(
@@ -100,7 +100,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             self.define("FAISS_OPT_LEVEL", "generic"),
         ]
 
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             key = "CMAKE_CUDA_ARCHITECTURES"
             args.append(self.define_from_variant(key, "cuda_arch"))
             # args.append(self.define_from_variant(
@@ -109,7 +109,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
 
     def install(self, pkg, spec, prefix):
         super().install(pkg, spec, prefix)
-        if "+python" in spec:
+        if spec.satisfies("+python"):
 
             class CustomPythonPipBuilder(spack.build_systems.python.PythonPipBuilder):
                 def __init__(self, pkg, build_dirname):
@@ -133,17 +133,17 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
     def build(self, pkg, spec, prefix):
         make()
 
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             make("-C", "python")
 
         # CPU tests
-        if "+tests" in self.spec:
+        if self.spec.satisfies("+tests"):
             with working_dir("tests"):
                 make("gtest")
                 make("tests")
 
         # GPU tests
-        if "+tests+cuda" in self.spec:
+        if self.spec.satisfies("+tests+cuda"):
             with working_dir(os.path.join("gpu", "test")):
                 make("gtest")
                 make("build")  # target added by the patch
@@ -152,7 +152,7 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
     def install(self, pkg, spec, prefix):
         make("install")
 
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             with working_dir("python"):
                 args = std_pip_args + ["--prefix=" + prefix, "."]
                 pip(*args)
@@ -174,7 +174,7 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
             _prefix_and_install("TestCpu")
 
         # GPU tests
-        if "+cuda" in self.spec:
+        if self.spec.satisfies("+cuda"):
             with working_dir(os.path.join("gpu", "test")):
                 _prefix_and_install("TestGpuIndexFlat")
                 _prefix_and_install("TestGpuIndexBinaryFlat")

--- a/var/spack/repos/builtin/packages/fasttransforms/package.py
+++ b/var/spack/repos/builtin/packages/fasttransforms/package.py
@@ -32,9 +32,9 @@ class Fasttransforms(MakefilePackage):
 
     def build(self, spec, prefix):
         makeargs = ["CC=cc"]
-        if "openblas" in spec:
+        if spec.satisfies("openblas"):
             makeargs += ["FT_BLAS=openblas"]
-        if "quadmath" in spec:
+        if spec.satisfies("quadmath"):
             makeargs += ["FT_QUADMATH=1"]
         make("assembly", *makeargs)
         make("lib", *makeargs)

--- a/var/spack/repos/builtin/packages/fasttree/package.py
+++ b/var/spack/repos/builtin/packages/fasttree/package.py
@@ -34,7 +34,7 @@ class Fasttree(Package):
 
     def install(self, spec, prefix):
         cc = Executable(spack_cc)
-        if "+openmp" in self.spec:
+        if self.spec.satisfies("+openmp"):
             cc(
                 "-O3",
                 self.compiler.openmp_flag,
@@ -63,5 +63,5 @@ class Fasttree(Package):
     @run_after("install")
     def create_fasttree_mp_symlink(self):
         with working_dir(prefix.bin):
-            if "+openmp" in self.spec:
+            if self.spec.satisfies("+openmp"):
                 symlink("FastTree", "FastTreeMP")

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -68,7 +68,7 @@ class Fckit(CMakePackage):
             "-DFYPP_NO_LINE_NUMBERING=ON",
         ]
 
-        if "~shared" in self.spec:
+        if self.spec.satisfies("~shared"):
             args.append("-DBUILD_SHARED_LIBS=OFF")
 
         if "finalize_ddts=auto" not in self.spec:

--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -192,7 +192,7 @@ class Fenics(CMakePackage):
     # build python interface of dolfin
     @run_after("install")
     def install_python_interface(self):
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             with working_dir("python"):
                 args = std_pip_args + ["--prefix=" + self.prefix, "."]
                 pip(*args)

--- a/var/spack/repos/builtin/packages/ferret/package.py
+++ b/var/spack/repos/builtin/packages/ferret/package.py
@@ -80,7 +80,7 @@ class Ferret(Package):
 
         work_dir = "FERRET" if "@:7.2" in spec else "."
         with working_dir(work_dir, create=False):
-            if "@7.3:" in spec:
+            if spec.satisfies("@7.3:"):
                 copy("site_specific.mk.in", "site_specific.mk")
                 copy(
                     "external_functions/ef_utility/site_specific.mk.in",
@@ -111,7 +111,7 @@ class Ferret(Package):
                 r"^(NETCDF4?_(LIB)?DIR).+", "\\1 = %s" % netcdff_prefix, "site_specific.mk"
             )
 
-            if "@:7.3" in spec:
+            if spec.satisfies("@:7.3"):
                 # Don't force using the static version of libz
                 filter_file(
                     r"\$\(LIBZ_DIR\)/lib64/libz.a", "-lz", "platform_specific.mk.x86_64-linux"
@@ -137,7 +137,7 @@ class Ferret(Package):
                 # Don't force using the static version of libgfortran
                 filter_file(r"-static-libgfortran", "", "platform_specific.mk.x86_64-linux")
 
-            if "@:7.4" in spec:
+            if spec.satisfies("@:7.4"):
                 compilers_spec_file = "platform_specific.mk.x86_64-linux"
             else:
                 compilers_spec_file = "site_specific.mk"
@@ -182,7 +182,7 @@ class Ferret(Package):
             make(parallel=False)
             make("install")
 
-        if "+datasets" in self.spec:
+        if self.spec.satisfies("+datasets"):
             mkdir(self.prefix.fer_dsets)
             install_tree("fer_dsets", self.prefix.fer_dsets)
 
@@ -199,7 +199,7 @@ class Ferret(Package):
         fer_descr = ["."]
         fer_grids = ["."]
 
-        if "+datasets" in self.spec:
+        if self.spec.satisfies("+datasets"):
             env.set("FER_DSETS", self.prefix.fer_dsets)
 
             fer_data.append(self.prefix.fer_dsets.data)

--- a/var/spack/repos/builtin/packages/ffte/package.py
+++ b/var/spack/repos/builtin/packages/ffte/package.py
@@ -87,7 +87,7 @@ class Ffte(Package):
 
     def install(self, spec, prefix):
         self.edit(spec, prefix)
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             env["CC"] = spec["mpi"].mpicc
             env["F77"] = spec["mpi"].mpif77
             env["FC"] = spec["mpi"].mpifc
@@ -103,5 +103,5 @@ class Ffte(Package):
         make()
         mkdirp(prefix.lib)
         install("libffte.a", prefix.lib)
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             install("mpi/libfftempi.a", prefix.lib)

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -79,7 +79,7 @@ class FftwBase(AutotoolsPackage):
             os.rename("fftw/config.h", "fftw/config.h.SPACK_RENAMED")
 
     def autoreconf(self, spec, prefix):
-        if "+pfft_patches" in spec:
+        if spec.satisfies("+pfft_patches"):
             autoreconf = which("autoreconf")
             autoreconf("-ifv")
 
@@ -114,13 +114,13 @@ class FftwBase(AutotoolsPackage):
             options.append("--enable-type-prefix")
 
         # Variants that affect every precision
-        if "+openmp" in spec:
+        if spec.satisfies("+openmp"):
             options.append("--enable-openmp")
             if spec.satisfies("@:2"):
                 # TODO: libtool strips CFLAGS, so 2.x libxfftw_threads
                 #       isn't linked to the openmp library. Patch Makefile?
                 options.insert(0, "CFLAGS=" + self.compiler.openmp_flag)
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             options.append("--enable-mpi")
 
         # Specific SIMD support.

--- a/var/spack/repos/builtin/packages/fftx/package.py
+++ b/var/spack/repos/builtin/packages/fftx/package.py
@@ -43,9 +43,9 @@ class Fftx(CMakePackage, CudaPackage, ROCmPackage):
         #  What config should be built -- driven by spec
         spec = self.spec
         backend = "CPU"
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             backend = "CUDA"
-        if "+rocm" in spec:
+        if spec.satisfies("+rocm"):
             backend = "HIP"
         self.build_config = "-D_codegen=%s" % backend
 
@@ -58,7 +58,7 @@ class Fftx(CMakePackage, CudaPackage, ROCmPackage):
         spec = self.spec
         args = ["-DSPIRAL_HOME:STRING={0}".format(spec["spiral-software"].prefix)]
         args.append("-DCMAKE_INSTALL_PREFIX:PATH={0}".format(self.prefix))
-        if "+rocm" in spec:
+        if spec.satisfies("+rocm"):
             args.append("-DCMAKE_CXX_COMPILER={0}".format(self.spec["hip"].hipcc))
         args.append(self.build_config)
 

--- a/var/spack/repos/builtin/packages/fio/package.py
+++ b/var/spack/repos/builtin/packages/fio/package.py
@@ -58,6 +58,6 @@ class Fio(AutotoolsPackage):
 
     @run_after("build")
     def build_docs(self):
-        if "+doc" in self.spec:
+        if self.spec.satisfies("+doc"):
             make("-C", "doc", "html")
             make("-C", "doc", "man")

--- a/var/spack/repos/builtin/packages/fish/package.py
+++ b/var/spack/repos/builtin/packages/fish/package.py
@@ -80,7 +80,7 @@ class Fish(CMakePackage):
             "-DPCRE2_INCLUDE_DIR=" + self.spec["pcre2"].headers.directories[0],
         ]
 
-        if "+docs" in self.spec:
+        if self.spec.satisfies("+docs"):
             args.append("-DBUILD_DOCS=ON")
         else:
             args.append("-DBUILD_DOCS=OFF")

--- a/var/spack/repos/builtin/packages/flamemaster/package.py
+++ b/var/spack/repos/builtin/packages/flamemaster/package.py
@@ -242,7 +242,7 @@ class Flamemaster(CMakePackage):
         args.append("-DEIGEN_INTEGRATION:BOOL=%s" % ("ON" if "+eigen" in spec else "OFF"))
         args.append("-DINSTALL_EIGEN:BOOL=%s" % ("ON" if "+eigen" in spec else "OFF"))
 
-        if "^amdlibflame" in spec:
+        if spec.satisfies("^amdlibflame"):
             args.append("-DBLA_VENDOR=FLAME")
 
         args.append("-DFLAMEMASTER_INSTALL_PREFIX:PATH={0}".format(spec.prefix))

--- a/var/spack/repos/builtin/packages/flamemaster/package.py
+++ b/var/spack/repos/builtin/packages/flamemaster/package.py
@@ -242,7 +242,7 @@ class Flamemaster(CMakePackage):
         args.append("-DEIGEN_INTEGRATION:BOOL=%s" % ("ON" if "+eigen" in spec else "OFF"))
         args.append("-DINSTALL_EIGEN:BOOL=%s" % ("ON" if "+eigen" in spec else "OFF"))
 
-        if spec.satisfies("^amdlibflame"):
+        if spec.satisfies("[virtuals=lapack] ^amdlibflame"):
             args.append("-DBLA_VENDOR=FLAME")
 
         args.append("-DFLAMEMASTER_INSTALL_PREFIX:PATH={0}".format(spec.prefix))

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -94,7 +94,7 @@ class Flann(CMakePackage):
             "src/python/CMakeLists.txt",
         )
         # Fix the install location so that spack activate works
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             filter_file("share/flann/python", python_platlib, "src/python/CMakeLists.txt")
         # Hack. Don't install setup.py
         filter_file("install( FILES", "# install( FILES", "src/python/CMakeLists.txt", string=True)

--- a/var/spack/repos/builtin/packages/flatbuffers/package.py
+++ b/var/spack/repos/builtin/packages/flatbuffers/package.py
@@ -56,7 +56,7 @@ class Flatbuffers(CMakePackage):
 
     @run_after("install")
     def python_install(self):
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             pydir = join_path(self.stage.source_path, "python")
             with working_dir(pydir):
                 args = std_pip_args + ["--prefix=" + self.prefix, "."]

--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -131,13 +131,13 @@ class Flecsi(CMakePackage, CudaPackage, ROCmPackage):
                 self.define_from_variant("ENABLE_DOCUMENTATION", "doc"),
             ]
 
-            if "+rocm" in self.spec:
+            if self.spec.satisfies("+rocm"):
                 options.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
                 options.append(self.define("CMAKE_C_COMPILER", self.spec["hip"].hipcc))
-                if "backend=legion" in self.spec:
+                if self.spec.satisfies("backend=legion"):
                     # CMake pulled in via find_package(Legion) won't work without this
                     options.append(self.define("HIP_PATH", "{0}/hip".format(spec["hip"].prefix)))
-            elif "+kokkos" in self.spec:
+            elif self.spec.satisfies("+kokkos"):
                 options.append(self.define("CMAKE_CXX_COMPILER", self.spec["kokkos"].kokkos_cxx))
         else:
             # kept for supporing version prior to 2.2

--- a/var/spack/repos/builtin/packages/fleur/package.py
+++ b/var/spack/repos/builtin/packages/fleur/package.py
@@ -82,7 +82,7 @@ class Fleur(Package):
     def setup_build_environment(self, env):
         spec = self.spec
 
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             env.set("CC", spec["mpi"].mpicc, force=True)
             env.set("FC", spec["mpi"].mpifc, force=True)
             env.set("CXX", spec["mpi"].mpicxx, force=True)
@@ -112,43 +112,43 @@ class Fleur(Package):
         options["-includedir"].append(spec["libxml2"].prefix.include)
         options["-includedir"].append(join_path(spec["libxml2"].prefix.include, "libxml2"))
 
-        if "fft=mkl" in spec:
+        if spec.satisfies("fft=mkl"):
             options["-link"].append(spec["intel-mkl"].libs.link_flags)
             options["-libdir"].append(spec["intel-mkl"].prefix.lib)
             options["-includedir"].append(spec["intel-mkl"].prefix.include)
-        if "fft=fftw" in spec:
+        if spec.satisfies("fft=fftw"):
             options["-link"].append(spec["fftw-api"].libs.link_flags)
             options["-libdir"].append(spec["fftw-api"].prefix.lib)
             options["-includedir"].append(spec["fftw-api"].prefix.include)
-        if "+scalapack" in spec:
+        if spec.satisfies("+scalapack"):
             options["-link"].append(spec["scalapack"].libs.link_flags)
             options["-libdir"].append(spec["scalapack"].prefix.lib)
-        if "+external_libxc" in spec:
+        if spec.satisfies("+external_libxc"):
             # Workaround: The fortran library is called libxcf90.a/so
             #    but spec['wannier90'].libs.link_flags return -lxc
             options["-link"].append("-lxcf90")
             options["-libdir"].append(spec["libxc"].prefix.lib)
             options["-includedir"].append(spec["libxc"].prefix.include)
-        if "+hdf5" in spec:
+        if spec.satisfies("+hdf5"):
             options["-link"].append(spec["hdf5"].libs.link_flags)
             options["-libdir"].append(spec["hdf5"].prefix.lib)
             options["-includedir"].append(spec["hdf5"].prefix.include)
-        if "+magma" in spec:
+        if spec.satisfies("+magma"):
             options["-link"].append(spec["magma"].libs.link_flags)
             options["-libdir"].append(spec["magma"].prefix.lib)
             options["-includedir"].append(spec["magma"].prefix.include)
-        if "+wannier90" in spec:
+        if spec.satisfies("+wannier90"):
             # Workaround: The library is not called wannier90.a/so
             #    for this reason spec['wannier90'].libs.link_flags fails!
             options["-link"].append("-lwannier")
             options["-libdir"].append(spec["wannier90"].prefix.lib)
-        if "+spfft" in spec:
+        if spec.satisfies("+spfft"):
             options["-link"].append(spec["spfft"].libs.link_flags)
             # Workaround: The library is installed in /lib64 not /lib
             options["-libdir"].append(spec["spfft"].prefix.lib + "64")
             # Workaround: The library needs spfft.mod in include/spfft path
             options["-includedir"].append(join_path(spec["spfft"].prefix.include, "spfft"))
-        if "+elpa" in spec:
+        if spec.satisfies("+elpa"):
             options["-link"].append(spec["elpa"].libs.link_flags)
             options["-libdir"].append(spec["elpa"].prefix.lib)
             # Workaround: The library needs elpa.mod in include/elpa_%VERS/modules
@@ -172,7 +172,7 @@ class Fleur(Package):
         with working_dir("build"):
             make()
             mkdirp(prefix.bin)
-            if "+mpi" in spec:
+            if spec.satisfies("+mpi"):
                 install("fleur_MPI", prefix.bin)
             else:
                 install("fleur", prefix.bin)

--- a/var/spack/repos/builtin/packages/fltk/package.py
+++ b/var/spack/repos/builtin/packages/fltk/package.py
@@ -61,16 +61,16 @@ class Fltk(Package):
             "--enable-localzlib",
         ]
 
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             options.append("--enable-shared")
 
-        if "+xft" in spec:
+        if spec.satisfies("+xft"):
             # https://www.fltk.org/articles.php?L374+I0+TFAQ+P1+Q
             options.append("--enable-xft")
         else:
             options.append("--disable-xft")
 
-        if "~gl" in spec:
+        if spec.satisfies("~gl"):
             options.append("--disable-gl")
 
         # FLTK needs to be built in-source

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -209,7 +209,7 @@ class FluxCore(AutotoolsPackage):
         args = ["--enable-pylint=no"]
         if "+docs" not in self.spec:
             args.append("--disable-docs")
-        if "+security" in self.spec:
+        if self.spec.satisfies("+security"):
             args.append("--with-flux-security")
         return args
 

--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -114,7 +114,7 @@ class Fmt(CMakePackage):
         if self.spec.satisfies("+shared"):
             args.append("-DBUILD_SHARED_LIBS=ON")
 
-        if "+pic" in spec:
+        if spec.satisfies("+pic"):
             args.extend(
                 [
                     "-DCMAKE_C_FLAGS={0}".format(self.compiler.cc_pic_flag),
@@ -128,7 +128,7 @@ class Fmt(CMakePackage):
         args.append("-DCMAKE_CXX_STANDARD_REQUIRED=ON")
 
         # When cxxstd is 98, must disable FMT_USE_CPP11
-        if "cxxstd=98" in spec:
+        if spec.satisfies("cxxstd=98"):
             args.append("-DFMT_USE_CPP11=OFF")
 
         # Can't build docs without doxygen+python+virtualenv

--- a/var/spack/repos/builtin/packages/foam-extend/package.py
+++ b/var/spack/repos/builtin/packages/foam-extend/package.py
@@ -298,7 +298,7 @@ class FoamExtend(Package):
         # Adjust configuration via prefs - sort second
         self.etc_prefs["001"].update(self.foam_arch.foam_dict())
 
-        if "+scotch" in spec or "+ptscotch" in spec:
+        if spec.satisfies("+scotch") or spec.satisfies("+ptscotch"):
             pkg = spec["scotch"].prefix
             self.etc_prefs["scotch"] = {
                 "SCOTCH_SYSTEM": 1,
@@ -308,7 +308,7 @@ class FoamExtend(Package):
                 "SCOTCH_INCLUDE_DIR": pkg.include,
             }
 
-        if "+metis" in spec:
+        if spec.satisfies("+metis"):
             pkg = spec["metis"].prefix
             self.etc_prefs["metis"] = {
                 "METIS_SYSTEM": 1,
@@ -318,7 +318,7 @@ class FoamExtend(Package):
                 "METIS_INCLUDE_DIR": pkg.include,
             }
 
-        if "+parmetis" in spec:
+        if spec.satisfies("+parmetis"):
             pkg = spec["parmetis"].prefix
             self.etc_prefs["parametis"] = {
                 "PARMETIS_SYSTEM": 1,
@@ -328,7 +328,7 @@ class FoamExtend(Package):
                 "PARMETIS_INCLUDE_DIR": pkg.include,
             }
 
-        if "+parmgridgen" in spec:
+        if spec.satisfies("+parmgridgen"):
             pkg = spec["parmgridgen"].prefix
             self.etc_prefs["parmgridgen"] = {
                 "PARMGRIDGEN_SYSTEM": 1,
@@ -338,7 +338,7 @@ class FoamExtend(Package):
                 "PARMGRIDGEN_INCLUDE_DIR": pkg.include,
             }
 
-        if "+paraview" in self.spec:
+        if self.spec.satisfies("+paraview"):
             self.etc_prefs["paraview"] = {
                 "PARAVIEW_SYSTEM": 1,
                 "PARAVIEW_DIR": spec["paraview"].prefix,
@@ -386,7 +386,7 @@ class FoamExtend(Package):
         }
 
         # All top-level files, except spack build info and possibly Allwmake
-        if "+source" in spec:
+        if spec.satisfies("+source"):
             ignored = re.compile(r"^spack-.*")
         else:
             ignored = re.compile(r"^(Allclean|Allwmake|spack-).*")
@@ -400,7 +400,7 @@ class FoamExtend(Package):
         for d in ["etc", "bin", "wmake", "lib", join_path(appdir, "bin")]:
             install_tree(d, join_path(self.projectdir, d), symlinks=True)
 
-        if "+source" in spec:
+        if spec.satisfies("+source"):
             subitem = join_path(appdir, "Allwmake")
             install(subitem, join_path(self.projectdir, subitem))
 

--- a/var/spack/repos/builtin/packages/form/package.py
+++ b/var/spack/repos/builtin/packages/form/package.py
@@ -40,7 +40,7 @@ class Form(AutotoolsPackage):
     def configure_args(self):
         args = []
         args += self.with_or_without("gmp", "prefix")
-        if "+zlib" in self.spec:
+        if self.spec.satisfies("+zlib"):
             args.append("--with-zlib=%s" % self.spec["zlib-api"].prefix)
         else:
             args.append("--without-zlib")

--- a/var/spack/repos/builtin/packages/formetis/package.py
+++ b/var/spack/repos/builtin/packages/formetis/package.py
@@ -67,7 +67,7 @@ class Formetis(CMakePackage):
             self.define("CMAKE_Fortran_COMPILER", self.compiler.fc),
             self.define("METIS_ROOT", self.spec["metis"].prefix),
         ]
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             cmake_args.append(self.define("ParMETIS_ROOT", self.spec["parmetis"].prefix))
         cmake_args.append(self.cached_tests_work_dir)
         cmake = which(self.spec["cmake"].prefix.bin.cmake)

--- a/var/spack/repos/builtin/packages/fpm/package.py
+++ b/var/spack/repos/builtin/packages/fpm/package.py
@@ -42,13 +42,13 @@ class Fpm(Package):
     depends_on("git@1.8.5:", type="build")
 
     def setup_build_environment(self, env):
-        if "@0.4.0" in self.spec:
+        if self.spec.satisfies("@0.4.0"):
             env.set("FPM_C_COMPILER", self.compiler.cc)
 
         env.set("FPM_CC", self.compiler.cc)
 
         fflags = "-O3"
-        if "+openmp" in self.spec:
+        if self.spec.satisfies("+openmp"):
             fflags += " " + self.compiler.openmp_flag
         env.set("FFLAGS", fflags)
 

--- a/var/spack/repos/builtin/packages/freefem/package.py
+++ b/var/spack/repos/builtin/packages/freefem/package.py
@@ -75,7 +75,7 @@ class Freefem(AutotoolsPackage):
             "CXXFLAGS=%s" % " ".join(spec.compiler_flags["cxxflags"]),
         ]
 
-        if "+petsc" in spec:
+        if spec.satisfies("+petsc"):
             options.append("--with-petsc=%s" % spec["petsc"].prefix.lib.petsc.conf.petscvariables)
             options.append("--with-slepc-ldflags=%s" % spec["slepc"].libs.ld_flags)
             options.append("--with-slepc-include=%s" % spec["slepc"].headers.include_flags)

--- a/var/spack/repos/builtin/packages/fsl/package.py
+++ b/var/spack/repos/builtin/packages/fsl/package.py
@@ -111,7 +111,7 @@ class Fsl(Package, CudaPackage):
         vtk_settings.filter(r"(^VTKDIR_LIB)\s*=.*", r"\1 = {0}".format(vtk_lib_dir))
         vtk_settings.filter(r"(^VTKSUFFIX)\s*=.*", r"\1 = -{0}".format(vtk_suffix))
 
-        if "+cuda" in self.spec:
+        if self.spec.satisfies("+cuda"):
             cuda_arch = self.spec.variants["cuda_arch"].value
             cuda_gencode = " ".join(self.cuda_flags(cuda_arch))
             cuda_installation = self.spec["cuda"].prefix

--- a/var/spack/repos/builtin/packages/fstrack/package.py
+++ b/var/spack/repos/builtin/packages/fstrack/package.py
@@ -43,7 +43,7 @@ class Fstrack(MakefilePackage):
         env.set("F90FLAGS_DEBUG", "-g -x f95-cpp-input")
         env.set("LDFLAGS", "-lm")
 
-        if "+flow" in self.spec:
+        if self.spec.satisfies("+flow"):
             env.set("GMTHOME", self.spec["gmt"].prefix)
             env.set("NETCDFDIR", self.spec["netcdf-c"].prefix)
 
@@ -55,7 +55,7 @@ class Fstrack(MakefilePackage):
             make()
 
         with working_dir("fstrack"):
-            if "+flow" in spec:
+            if spec.satisfies("+flow"):
                 make("really_all")
             else:
                 make()

--- a/var/spack/repos/builtin/packages/fujitsu-fftw/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-fftw/package.py
@@ -78,23 +78,23 @@ class FujitsuFftw(FftwBase):
             "ac_cv_prog_f77_v=-###",
         ]
 
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             options.append("--enable-shared")
         else:
             options.append("--disable-shared")
 
-        if "+openmp" in spec:
+        if spec.satisfies("+openmp"):
             options.append("--enable-openmp")
             options.append("OPENMP_CFLAGS=-Kopenmp")
         else:
             options.append("--disable-openmp")
 
-        if "+threads" in spec:
+        if spec.satisfies("+threads"):
             options.append("--enable-threads")
         else:
             options.append("--disable-threads")
 
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             options.append("--enable-mpi")
         else:
             options.append("--disable-mpi")

--- a/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py
@@ -35,25 +35,25 @@ class FujitsuSsl2(Package):
         spec = self.spec
         libslist = []
         if spec.target == "a64fx":  # Build with SVE support
-            if "+parallel" in spec:  # parallel
+            if spec.satisfies("+parallel"):  # parallel
                 libslist.append("libfjlapackexsve.so")
             else:
                 libslist.append("libfjlapacksve.so")
         else:
-            if "+parallel" in spec:  # parallel
+            if spec.satisfies("+parallel"):  # parallel
                 libslist.append("libfjlapackex.so")
             else:
                 libslist.append("libfjlapack.so")
 
-        if "+parallel" in spec:  # parallel
+        if spec.satisfies("+parallel"):  # parallel
             libslist.extend(["libfjomphk.so", "libfjomp.so"])
 
         if spec.target == "a64fx":  # Build with SVE support
-            if "+parallel" in spec:  # parallel
+            if spec.satisfies("+parallel"):  # parallel
                 libslist.append("libssl2mtexsve.a")
             libslist.append("libssl2mtsve.a")
         else:
-            if "+parallel" in spec:  # parallel
+            if spec.satisfies("+parallel"):  # parallel
                 libslist.append("libssl2mtex.a")
             libslist.append("libssl2mt.a")
 
@@ -81,7 +81,7 @@ class FujitsuSsl2(Package):
         libslist = []
         if spec.target == "a64fx":  # Build with SVE support
             libslist.append("libfjscalapacksve.so")
-            if "+parallel" in spec:  # parallel
+            if spec.satisfies("+parallel"):  # parallel
                 libslist.append("libfjlapackexsve.so")
             else:
                 libslist.append("libfjlapacksve.so")
@@ -89,7 +89,7 @@ class FujitsuSsl2(Package):
 
         else:
             libslist.append("libfjscalapack.so")
-            if "+parallel" in spec:  # parallel
+            if spec.satisfies("+parallel"):  # parallel
                 libslist.append("libfjlapackex.so")
             else:
                 libslist.append("libfjlapack.so")
@@ -97,15 +97,15 @@ class FujitsuSsl2(Package):
 
         libslist.extend(["libmpi_usempi_ignore_tkr.so", "libmpi_mpifh.so"])
 
-        if "+parallel" in spec:  # parallel
+        if spec.satisfies("+parallel"):  # parallel
             libslist.extend(["libfjomphk.so", "libfjomp.so"])
 
         if spec.target == "a64fx":  # Build with SVE support
-            if "+parallel" in spec:  # parallel
+            if spec.satisfies("+parallel"):  # parallel
                 libslist.append("libssl2mtexsve.a")
             libslist.append("libssl2mtsve.a")
         else:
-            if "+parallel" in spec:  # parallel
+            if spec.satisfies("+parallel"):  # parallel
                 libslist.append("libssl2mtex.a")
             libslist.append("libssl2mt.a")
 

--- a/var/spack/repos/builtin/packages/funhpc/package.py
+++ b/var/spack/repos/builtin/packages/funhpc/package.py
@@ -31,7 +31,7 @@ class Funhpc(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         options = ["-DGTEST_ROOT=%s" % spec["googletest"].prefix]
-        if "+pic" in spec:
+        if spec.satisfies("+pic"):
             options += ["-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true"]
         return options
 

--- a/var/spack/repos/builtin/packages/fxt/package.py
+++ b/var/spack/repos/builtin/packages/fxt/package.py
@@ -48,7 +48,7 @@ class Fxt(AutotoolsPackage):
 
     def patch(self):
         # Increase the value of FXT_MAX_PARAMS (to allow longer task names)
-        if "+moreparams" in self.spec:
+        if self.spec.satisfies("+moreparams"):
             filter_file("#define FXT_MAX_PARAMS.*", "#define FXT_MAX_PARAMS 16", "tools/fxt.h")
 
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/gapbs/package.py
+++ b/var/spack/repos/builtin/packages/gapbs/package.py
@@ -32,7 +32,7 @@ class Gapbs(MakefilePackage):
     def build(self, spec, prefix):
         cxx_flags = ["-O3", self.compiler.cxx11_flag]
 
-        if "-serial" in spec:
+        if spec.satisfies("-serial"):
             cxx_flags.append(self.compiler.openmp_flag)
 
         make("CXX_FLAGS=" + " ".join(cxx_flags))

--- a/var/spack/repos/builtin/packages/gasnet/package.py
+++ b/var/spack/repos/builtin/packages/gasnet/package.py
@@ -163,22 +163,22 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
         if "conduits=none" not in spec:
             options = ["--prefix=%s" % prefix]
 
-            if "+debug" in spec:
+            if spec.satisfies("+debug"):
                 options.append("--enable-debug")
 
-            if "+cuda" in spec:
+            if spec.satisfies("+cuda"):
                 options.append("--enable-kind-cuda-uva")
                 options.append("--with-cuda-home=" + spec["cuda"].prefix)
 
-            if "+rocm" in spec:
+            if spec.satisfies("+rocm"):
                 options.append("--enable-kind-hip")
                 options.append("--with-hip-home=" + spec["hip"].prefix)
 
-            if "+level_zero" in spec:
+            if spec.satisfies("+level_zero"):
                 options.append("--enable-kind-ze")
                 options.append("--with-ze-home=" + spec["oneapi-level-zero"].prefix)
 
-            if "conduits=mpi" in spec:
+            if spec.satisfies("conduits=mpi"):
                 options.append("--enable-mpi-compat")
             else:
                 options.append("--disable-mpi-compat")
@@ -204,7 +204,7 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
     @run_after("install")
     @on_package_attributes(run_tests=True)
     def check_install(self):
-        if "conduits=smp" in self.spec:
+        if self.spec.satisfies("conduits=smp"):
             make("-C", "smp-conduit", "run-tests")
         self.test_testtools()
 
@@ -219,7 +219,7 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
 
     def test_testtools(self):
         """run testtools and check output"""
-        if "conduits=none" in self.spec:
+        if self.spec.satisfies("conduits=none"):
             raise SkipTest("Test requires conduit libraries")
 
         testtools_path = join_path(self.prefix.tests, "testtools")
@@ -232,7 +232,7 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
 
     def test_testgasnet(self):
         """run testgasnet and check output"""
-        if "conduits=none" in self.spec:
+        if self.spec.satisfies("conduits=none"):
             raise SkipTest("Test requires conduit libraries")
 
         self._setup_test_env()

--- a/var/spack/repos/builtin/packages/gate/package.py
+++ b/var/spack/repos/builtin/packages/gate/package.py
@@ -55,7 +55,7 @@ class Gate(CMakePackage):
     def cmake_args(self):
         args = []
 
-        if "+rtk" in self.spec:
+        if self.spec.satisfies("+rtk"):
             args.extend(["-DGATE_USE_ITK=ON", "-DGATE_USE_RTK=ON"])
         else:
             args.extend(["-DGATE_USE_ITK=OFF", "-DGATE_USE_RTK=OFF"])

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -593,7 +593,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         if self.spec.external:
             return self.spec.extra_attributes["compilers"].get("c", None)
         result = None
-        if "languages=c" in self.spec:
+        if self.spec.satisfies("languages=c"):
             result = str(self.spec.prefix.bin.gcc)
         return result
 
@@ -604,7 +604,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         if self.spec.external:
             return self.spec.extra_attributes["compilers"].get("cxx", None)
         result = None
-        if "languages=c++" in self.spec:
+        if self.spec.satisfies("languages=c++"):
             result = os.path.join(self.spec.prefix.bin, "g++")
         return result
 
@@ -615,7 +615,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         if self.spec.external:
             return self.spec.extra_attributes["compilers"].get("fortran", None)
         result = None
-        if "languages=fortran" in self.spec:
+        if self.spec.satisfies("languages=fortran"):
             result = str(self.spec.prefix.bin.gfortran)
         return result
 
@@ -711,7 +711,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         if "+bootstrap %gcc" in self.spec and self.spec.target.family != "aarch64":
             flags += " " + self.get_common_target_flags(self.spec)
 
-        if "+bootstrap" in self.spec:
+        if self.spec.satisfies("+bootstrap"):
             variables = ["BOOT_CFLAGS", "CFLAGS_FOR_TARGET", "CXXFLAGS_FOR_TARGET"]
         else:
             variables = ["CFLAGS", "CXXFLAGS"]
@@ -752,12 +752,12 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         if self.version >= Version("6"):
             options.append("--with-system-zlib")
 
-        if "zstd" in spec:
+        if spec.satisfies("^zstd"):
             options.append("--with-zstd-include={0}".format(spec["zstd"].headers.directories[0]))
             options.append("--with-zstd-lib={0}".format(spec["zstd"].libs.directories[0]))
 
         # Enabling language "jit" requires --enable-host-shared.
-        if "languages=jit" in spec:
+        if spec.satisfies("languages=jit"):
             options.append("--enable-host-shared")
 
         # Binutils
@@ -832,7 +832,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         options.append("--with-boot-ldflags=" + boot_ldflags)
         options.append("--with-build-config=spack")
 
-        if "languages=d" in spec:
+        if spec.satisfies("languages=d"):
             # Phobos is the standard library for the D Programming Language. The documentation says
             # that on some targets, 'libphobos' is not enabled by default, but compiles and works
             # if '--enable-libphobos' is used. Specifics are documented for affected targets.
@@ -919,13 +919,13 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
 
     @property
     def build_targets(self):
-        if "+profiled" in self.spec:
+        if self.spec.satisfies("+profiled"):
             return ["profiledbootstrap"]
         return []
 
     @property
     def install_targets(self):
-        if "+strip" in self.spec:
+        if self.spec.satisfies("+strip"):
             return ["install-strip"]
         return ["install"]
 

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -506,7 +506,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
         return Executable(exe)("--version", output=str, error=str).rstrip()
 
     def setup_run_environment(self, env):
-        if "+java" in self.spec:
+        if self.spec.satisfies("+java"):
             class_paths = find(self.prefix, "*.jar")
             classpath = os.pathsep.join(class_paths)
             env.prepend_path("CLASSPATH", classpath)
@@ -523,7 +523,7 @@ class Gdal(CMakePackage, AutotoolsPackage, PythonExtension):
             env.prepend_path("LD_LIBRARY_PATH", ":".join(libs))
 
     def patch(self):
-        if "+java platform=darwin" in self.spec:
+        if self.spec.satisfies("+java platform=darwin"):
             filter_file("linux", "darwin", "swig/java/java.opt", string=True)
             filter_file("-lazy-ljvm", "-ljvm", "configure", string=True)
 
@@ -751,7 +751,7 @@ class AutotoolsBuilder(AutotoolsBuilder):
             self.with_or_without("perl"),
             self.with_or_without("php"),
         ]
-        if "+iconv" in self.spec:
+        if self.spec.satisfies("+iconv"):
             if self.spec["iconv"].name == "libiconv":
                 args.append(f"--with-libiconv-prefix={self.spec['iconv'].prefix}")
             else:
@@ -787,7 +787,7 @@ class AutotoolsBuilder(AutotoolsBuilder):
         else:
             args.append(self.with_or_without("dwgdirect", variant="teigha", package="teigha"))
 
-        if "+hdf4" in self.spec:
+        if self.spec.satisfies("+hdf4"):
             hdf4 = self.spec["hdf"]
             if "+external-xdr" in hdf4 and hdf4["rpc"].name == "libtirpc":
                 args.append("LIBS=" + hdf4["rpc"].libs.link_flags)
@@ -800,19 +800,19 @@ class AutotoolsBuilder(AutotoolsBuilder):
     def build(self, pkg, spec, prefix):
         # https://trac.osgeo.org/gdal/wiki/GdalOgrInJavaBuildInstructionsUnix
         make()
-        if "+java" in spec:
+        if spec.satisfies("+java"):
             with working_dir("swig/java"):
                 make()
 
     def check(self):
         # no top-level test target
-        if "+java" in self.spec:
+        if self.spec.satisfies("+java"):
             with working_dir("swig/java"):
                 make("test")
 
     def install(self, pkg, spec, prefix):
         make("install")
-        if "+java" in spec:
+        if spec.satisfies("+java"):
             with working_dir("swig/java"):
                 make("install")
                 install("*.jar", prefix)

--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -117,7 +117,7 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
         if self.spec.version >= Version("11.1"):
             args.append("--with-gmp={}".format(self.spec["gmp"].prefix))
 
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             args.append("--with-python={}".format(self.spec["python"].command))
             args.append("LDFLAGS={}".format(self.spec["python"].libs.ld_flags))
 
@@ -125,7 +125,7 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
 
     @run_after("install")
     def gdbinit(self):
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             tool = self.spec["python"].command.path + "-gdb.py"
             if os.path.exists(tool):
                 mkdir(self.prefix.etc)

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -100,7 +100,7 @@ class GdkPixbuf(Package):
                 meson_args += ["-Dtests={0}".format(self.run_tests)]
             # Based on suggestion by luigi-calori and the fixup shown by lee218llnl:
             # https://github.com/spack/spack/pull/27254#issuecomment-974464174
-            if "+x11" in spec:
+            if spec.satisfies("+x11"):
                 if self.version >= Version("2.42"):
                     raise InstallError("+x11 is not valid for {0}".format(self.version))
                 meson_args += ["-Dx11=true"]

--- a/var/spack/repos/builtin/packages/gdl/package.py
+++ b/var/spack/repos/builtin/packages/gdl/package.py
@@ -87,42 +87,42 @@ class Gdl(CMakePackage):
         # only version 6 of ImageMagick is supported (version 7 is packaged)
         args += ["-DMAGICK=OFF"]
 
-        if "+graphicsmagick" in self.spec:
+        if self.spec.satisfies("+graphicsmagick"):
             args += ["-DGRAPHICSMAGICK=ON"]
         else:
             args += ["-DGRAPHICSMAGICK=OFF"]
 
-        if "+hdf4" in self.spec:
+        if self.spec.satisfies("+hdf4"):
             args += ["-DHDF=ON"]
         else:
             args += ["-DHDF=OFF"]
 
-        if "+hdf5" in self.spec:
+        if self.spec.satisfies("+hdf5"):
             args += ["-DHDF5=ON"]
         else:
             args += ["-DHDF5=OFF"]
 
-        if "+openmp" in self.spec:
+        if self.spec.satisfies("+openmp"):
             args += ["-DOPENMP=ON"]
         else:
             args += ["-DOPENMP=OFF"]
 
-        if "+proj" in self.spec:
+        if self.spec.satisfies("+proj"):
             args += ["-DLIBPROJ4=ON", "-DLIBPROJ4DIR={0}".format(self.spec["proj"].prefix)]
         else:
             args += ["-DLIBPROJ4=OFF"]
 
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             args += ["-DPYTHON_MODULE=ON"]
         else:
             args += ["-DPYTHON_MODULE=OFF"]
 
-        if "+wx" in self.spec:
+        if self.spec.satisfies("+wx"):
             args += ["-DWXWIDGETS=ON"]
         else:
             args += ["-DWXWIDGETS=OFF"]
 
-        if "+x11" in self.spec:
+        if self.spec.satisfies("+x11"):
             args += ["-DX11=ON"]
         else:
             args += ["-DX11=OFF"]
@@ -131,7 +131,7 @@ class Gdl(CMakePackage):
 
     @run_after("install")
     def post_install(self):
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             # gdl installs the python module into prefix/lib/site-python
             # move it to the standard location
             src = os.path.join(self.spec.prefix.lib, "site-python")

--- a/var/spack/repos/builtin/packages/geant3/package.py
+++ b/var/spack/repos/builtin/packages/geant3/package.py
@@ -43,5 +43,5 @@ class Geant3(CMakePackage):
         return args
 
     def setup_build_environment(self, env):
-        if "platform=darwin" in self.spec:
+        if self.spec.satisfies("platform=darwin"):
             env.unset("MACOSX_DEPLOYMENT_TARGET")

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -282,7 +282,7 @@ class Geant4(CMakePackage):
         options.append(self.define_from_variant("GEANT4_BUILD_MULTITHREADED", "threads"))
         options.append(self.define_from_variant("GEANT4_USE_TBB", "tbb"))
 
-        if "+threads" in spec:
+        if spec.satisfies("+threads"):
             # Locked at global-dynamic to allow use cases that load the
             # geant4 libs at application runtime
             options.append(self.define("GEANT4_BUILD_TLS_MODEL", "global-dynamic"))
@@ -297,22 +297,22 @@ class Geant4(CMakePackage):
         options.append(self.define("GEANT4_INSTALL_DATADIR", self.datadir))
 
         # Vecgeom
-        if "+vecgeom" in spec:
+        if spec.satisfies("+vecgeom"):
             options.append(self.define("GEANT4_USE_USOLIDS", True))
             options.append(self.define("USolids_DIR", spec["vecgeom"].prefix.lib.CMake.USolids))
 
         # Visualization options
         if "platform=darwin" not in spec:
-            if "+x11 +opengl" in spec:
+            if spec.satisfies("+x11 +opengl"):
                 options.append(self.define("GEANT4_USE_OPENGL_X11", True))
-            if "+motif +opengl" in spec:
+            if spec.satisfies("+motif +opengl"):
                 options.append(self.define("GEANT4_USE_XM", True))
-            if "+x11" in spec:
+            if spec.satisfies("+x11"):
                 options.append(self.define("GEANT4_USE_RAYTRACER_X11", True))
 
-        if "+qt" in spec:
+        if spec.satisfies("+qt"):
             options.append(self.define("GEANT4_USE_QT", True))
-            if "^[virtuals=qmake] qt-base" in spec:
+            if spec.satisfies("^[virtuals=qmake] qt-base"):
                 options.append(self.define("GEANT4_USE_QT_QT6", True))
             options.append(self.define("QT_QMAKE_EXECUTABLE", spec["qmake"].prefix.bin.qmake))
 

--- a/var/spack/repos/builtin/packages/genesis/package.py
+++ b/var/spack/repos/builtin/packages/genesis/package.py
@@ -84,7 +84,7 @@ class Genesis(AutotoolsPackage, CudaPackage):
         options.extend(self.enable_or_disable("openmp"))
         options.extend(self.enable_or_disable("single"))
         options.extend(self.enable_or_disable("hmdisk"))
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             options.append("--enable-gpu")
             options.append("--with-cuda=%s" % spec["cuda"].prefix)
         else:
@@ -99,7 +99,7 @@ class Genesis(AutotoolsPackage, CudaPackage):
         env.set("CC", self.spec["mpi"].mpicc, force=True)
         env.set("CXX", self.spec["mpi"].mpicxx, force=True)
         env.set("LAPACK_LIBS", self.spec["lapack"].libs.ld_flags)
-        if "+cuda" in self.spec:
+        if self.spec.satisfies("+cuda"):
             cuda_arch = self.spec.variants["cuda_arch"].value
             cuda_gencode = " ".join(self.cuda_flags(cuda_arch))
             env.set("NVCCFLAGS", cuda_gencode)

--- a/var/spack/repos/builtin/packages/genie/package.py
+++ b/var/spack/repos/builtin/packages/genie/package.py
@@ -132,17 +132,17 @@ class Genie(Package):
                 "--with-lhapdf6-inc=" + spec["lhapdf"].prefix.include,
                 "--with-lhapdf6-lib=" + spec["lhapdf"].prefix.lib,
             ]
-        if "+vleextension" in self.spec:
+        if self.spec.satisfies("+vleextension"):
             args += ["--enable-vle-extension"]
-        if "+t2k" in self.spec:
+        if self.spec.satisfies("+t2k"):
             args += ["--enable-t2k"]
-        if "+fnal" in self.spec:
+        if self.spec.satisfies("+fnal"):
             args += ["--enable-fnal"]
-        if "+atmo" in self.spec:
+        if self.spec.satisfies("+atmo"):
             args += ["--enable-atmo"]
-        if "+nucleondecay" in self.spec:
+        if self.spec.satisfies("+nucleondecay"):
             args += ["--enable-nucleon-decay"]
-        if "+masterclass" in self.spec:
+        if self.spec.satisfies("+masterclass"):
             args += ["--enable-masterclass"]
         return args
 

--- a/var/spack/repos/builtin/packages/genomeworks/package.py
+++ b/var/spack/repos/builtin/packages/genomeworks/package.py
@@ -59,7 +59,7 @@ class Genomeworks(CMakePackage, CudaPackage):
     def cmake_args(self):
         args = []
         spec = self.spec
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             args.append("-DWITH_CUDA=ON")
             args.append("-Dgw_cuda_gen_all_arch=ON")
             args.append("-DTHRUST_IGNORE_CUB_VERSION_CHECK=ON")

--- a/var/spack/repos/builtin/packages/geopm-runtime/package.py
+++ b/var/spack/repos/builtin/packages/geopm-runtime/package.py
@@ -113,7 +113,7 @@ class GeopmRuntime(AutotoolsPackage):
     @property
     def install_targets(self):
         target = ["install"]
-        if "+checkprogs" in self.spec:
+        if self.spec.satisfies("+checkprogs"):
             target += ["checkprogs"]
         return target
 
@@ -161,7 +161,7 @@ class GeopmRuntime(AutotoolsPackage):
             lib_dir = self.prefix.lib
         env.prepend_path("LD_LIBRARY_PATH", lib_dir)
 
-        if "+checkprogs" in self.spec:
+        if self.spec.satisfies("+checkprogs"):
             env.set("GEOPM_SOURCE", self.stage.source_path)
             env.prepend_path("PYTHONPATH", self.stage.source_path)
         env.set("GEOPM_INSTALL", self.prefix)

--- a/var/spack/repos/builtin/packages/geopm-service/package.py
+++ b/var/spack/repos/builtin/packages/geopm-service/package.py
@@ -141,7 +141,7 @@ class GeopmService(AutotoolsPackage):
 
         args += self.enable_or_disable("levelzero")
         args += self.enable_or_disable("nvml")
-        if "+nvml" in self.spec:
+        if self.spec.satisfies("+nvml"):
             args += [
                 "--with-nvml="
                 + join_path(

--- a/var/spack/repos/builtin/packages/geos/package.py
+++ b/var/spack/repos/builtin/packages/geos/package.py
@@ -89,7 +89,7 @@ class Geos(CMakePackage):
         args = []
 
         # https://github.com/libgeos/geos/issues/460
-        if "%intel" in self.spec:
+        if self.spec.satisfies("%intel"):
             args.append(self.define("BUILD_ASTYLE", False))
 
         args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))

--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -125,12 +125,12 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
         else:
             config_args.append("--without-libiconv-prefix")
 
-        if "+curses" in spec:
+        if spec.satisfies("+curses"):
             config_args.append("--with-ncurses-prefix={0}".format(spec["ncurses"].prefix))
         else:
             config_args.append("--disable-curses")
 
-        if "+libxml2" in spec:
+        if spec.satisfies("+libxml2"):
             config_args.append("--with-libxml2-prefix={0}".format(spec["libxml2"].prefix))
         else:
             config_args.append("--with-included-libxml")
@@ -141,7 +141,7 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
         if "+xz" not in spec:
             config_args.append("--without-xz")
 
-        if "+libunistring" in spec:
+        if spec.satisfies("+libunistring"):
             config_args.append(
                 "--with-libunistring-prefix={0}".format(spec["libunistring"].prefix)
             )

--- a/var/spack/repos/builtin/packages/gimp/package.py
+++ b/var/spack/repos/builtin/packages/gimp/package.py
@@ -100,7 +100,7 @@ class Gimp(AutotoolsPackage):
             "GIO_USE_TLS=gnutls",
             "GIO_EXTRA_MODULES={0}/lib/gio/modules".format(self.spec["glib-networking"].prefix),
         ]
-        if "+libxpm" in self.spec:
+        if self.spec.satisfies("+libxpm"):
             args.append("--with-libxpm={0}".format(self.spec["libxpm"].prefix))
         return args
 

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -129,7 +129,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
 
     def setup_build_environment(self, env):
         spec = self.spec
-        if "+sycl" in spec:
+        if spec.satisfies("+sycl"):
             env.set("MKLROOT", join_path(spec["intel-oneapi-mkl"].prefix, "mkl", "latest"))
             env.set("DPL_ROOT", join_path(spec["intel-oneapi-dpl"].prefix, "dpl", "latest"))
             # The `IntelSYCLConfig.cmake` is broken with spack. By default, it
@@ -189,13 +189,13 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
         if self.run_tests:
             args.append("-DGINKGO_USE_EXTERNAL_GTEST=ON")
 
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             archs = spec.variants["cuda_arch"].value
             if archs != "none":
                 arch_str = ";".join(archs)
                 args.append("-DGINKGO_CUDA_ARCHITECTURES={0}".format(arch_str))
 
-        if "+rocm" in spec:
+        if spec.satisfies("+rocm"):
             args.append("-DHIP_PATH={0}".format(spec["hip"].prefix))
             args.append("-DHIP_CLANG_PATH={0}/bin".format(spec["llvm-amdgpu"].prefix))
             args.append("-DHIP_CLANG_INCLUDE_PATH={0}/include".format(spec["llvm-amdgpu"].prefix))
@@ -213,7 +213,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
                     self.define("CMAKE_MODULE_PATH", self.spec["hip"].prefix.lib.cmake.hip)
                 )
 
-        if "+sycl" in self.spec:
+        if self.spec.satisfies("+sycl"):
             sycl_compatible_compilers = ["icpx"]
             if not (os.path.basename(self.compiler.cxx) in sycl_compatible_compilers):
                 raise InstallError("ginkgo +sycl requires icpx compiler.")
@@ -243,7 +243,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
         ]
 
         # Fix: For HIP tests, add the ARCH compilation flags when not present
-        if "+rocm" in self.spec:
+        if self.spec.satisfies("+rocm"):
             src_path = join_path(src_dir, "CMakeLists.txt")
             cmakelists = open(src_path, "rt")
             data = cmakelists.read()

--- a/var/spack/repos/builtin/packages/git-annex/package.py
+++ b/var/spack/repos/builtin/packages/git-annex/package.py
@@ -124,7 +124,7 @@ class GitAnnex(Package):
     def install(self, spec, prefix):
         install_tree(".", prefix.bin)
 
-        if "~standalone" in spec:
+        if spec.satisfies("~standalone"):
             # use git provided by spack instead of the one in the package
             git_files = ["git", "git-receive-pack", "git-shell", "git-upload-pack"]
             for i in git_files:

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -185,7 +185,7 @@ class Git(AutotoolsPackage):
         # In that case the node in the DAG gets truncated and git DOES NOT
         # have a gettext dependency.
         spec = self.spec
-        if "+nls" in spec:
+        if spec.satisfies("+nls"):
             if "intl" in spec["gettext"].libs.names:
                 extlib_bits = []
                 if not is_system_path(spec["gettext"].prefix):
@@ -200,7 +200,7 @@ class Git(AutotoolsPackage):
             # For build step:
             env.append_flags("EXTLIBS", curlconfig("--static-libs", output=str).strip())
 
-        if "~perl" in self.spec:
+        if self.spec.satisfies("~perl"):
             env.append_flags("NO_PERL", "1")
 
     def configure_args(self):
@@ -216,14 +216,14 @@ class Git(AutotoolsPackage):
         if self.spec["iconv"].name == "libiconv":
             configure_args.append(f"--with-iconv={self.spec['iconv'].prefix}")
 
-        if "+perl" in self.spec:
+        if self.spec.satisfies("+perl"):
             configure_args.append("--with-perl={0}".format(spec["perl"].command.path))
 
-        if "^pcre" in self.spec:
+        if self.spec.satisfies("^pcre"):
             configure_args.append("--with-libpcre={0}".format(spec["pcre"].prefix))
-        if "^pcre2" in self.spec:
+        if self.spec.satisfies("^pcre2"):
             configure_args.append("--with-libpcre2={0}".format(spec["pcre2"].prefix))
-        if "+tcltk" in self.spec:
+        if self.spec.satisfies("+tcltk"):
             configure_args.append("--with-tcltk={0}".format(self.spec["tk"].prefix.bin.wish))
         else:
             configure_args.append("--without-tcltk")
@@ -241,7 +241,7 @@ class Git(AutotoolsPackage):
 
     def build(self, spec, prefix):
         args = []
-        if "~nls" in self.spec:
+        if self.spec.satisfies("~nls"):
             args.append("NO_GETTEXT=1")
         make(*args)
 
@@ -251,7 +251,7 @@ class Git(AutotoolsPackage):
 
     def install(self, spec, prefix):
         args = ["install"]
-        if "~nls" in self.spec:
+        if self.spec.satisfies("~nls"):
             args.append("NO_GETTEXT=1")
         make(*args)
 
@@ -267,7 +267,7 @@ class Git(AutotoolsPackage):
 
     @run_after("install")
     def install_manpages(self):
-        if "~man" in self.spec:
+        if self.spec.satisfies("~man"):
             return
 
         prefix = self.prefix
@@ -279,7 +279,7 @@ class Git(AutotoolsPackage):
 
     @run_after("install")
     def install_subtree(self):
-        if "+subtree" in self.spec:
+        if self.spec.satisfies("+subtree"):
             with working_dir("contrib/subtree"):
                 make_args = ["V=1", "prefix={}".format(self.prefix.bin)]
                 make(" ".join(make_args))
@@ -292,7 +292,7 @@ class Git(AutotoolsPackage):
         # Libs from perl-alien-svn and apr-util are required in
         # LD_LIBRARY_PATH
         # TODO: extend to other platforms
-        if "+svn platform=linux" in self.spec:
+        if self.spec.satisfies("+svn platform=linux"):
             perl_svn = self.spec["perl-alien-svn"]
             env.prepend_path(
                 "LD_LIBRARY_PATH",

--- a/var/spack/repos/builtin/packages/gl2ps/package.py
+++ b/var/spack/repos/builtin/packages/gl2ps/package.py
@@ -63,7 +63,7 @@ class Gl2ps(CMakePackage):
         if spec.satisfies("platform=windows"):
             options.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
 
-        if "~doc" in spec:
+        if spec.satisfies("~doc"):
             # Make sure we don't look.
             options.append(self.define("CMAKE_DISABLE_FIND_PACKAGE_LATEX", True))
 

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -292,20 +292,20 @@ class MesonBuilder(BaseBuilder, spack.build_systems.meson.MesonBuilder):
     def meson_args(self):
         args = []
         if self.spec.satisfies("@2.63.5:"):
-            if "+libmount" in self.spec:
+            if self.spec.satisfies("+libmount"):
                 args.append("-Dlibmount=enabled")
             else:
                 args.append("-Dlibmount=disabled")
         else:
-            if "+libmount" in self.spec:
+            if self.spec.satisfies("+libmount"):
                 args.append("-Dlibmount=true")
             else:
                 args.append("-Dlibmount=false")
-        if "tracing=dtrace" in self.spec:
+        if self.spec.satisfies("tracing=dtrace"):
             args.append("-Ddtrace=true")
         else:
             args.append("-Ddtrace=false")
-        if "tracing=systemtap" in self.spec:
+        if self.spec.satisfies("tracing=systemtap"):
             args.append("-Dsystemtap=true")
         else:
             args.append("-Dsystemtap=false")
@@ -333,7 +333,7 @@ class MesonBuilder(BaseBuilder, spack.build_systems.meson.MesonBuilder):
 class AutotoolsBuilder(BaseBuilder, spack.build_systems.autotools.AutotoolsBuilder):
     def configure_args(self):
         args = []
-        if "+libmount" in self.spec:
+        if self.spec.satisfies("+libmount"):
             args.append("--enable-libmount")
         else:
             args.append("--disable-libmount")
@@ -352,7 +352,7 @@ class AutotoolsBuilder(BaseBuilder, spack.build_systems.autotools.AutotoolsBuild
                 else:
                     args.append("--disable-" + value)
         else:
-            if "tracing=dtrace" in self.spec or "tracing=systemtap" in self.spec:
+            if self.spec.satisfies("tracing=dtrace") or self.spec.satisfies("tracing=systemtap"):
                 args.append("--enable-tracing")
             else:
                 args.append("--disable-tracing")

--- a/var/spack/repos/builtin/packages/globalarrays/package.py
+++ b/var/spack/repos/builtin/packages/globalarrays/package.py
@@ -75,7 +75,7 @@ class Globalarrays(AutotoolsPackage):
             "--with-lapack={0}".format(lapack_libs),
         ]
 
-        if "+scalapack" in self.spec:
+        if self.spec.satisfies("+scalapack"):
             scalapack_libs = self.spec["scalapack"].libs.ld_flags
             args.append("--with-scalapack={0}".format(scalapack_libs))
 

--- a/var/spack/repos/builtin/packages/glpk/package.py
+++ b/var/spack/repos/builtin/packages/glpk/package.py
@@ -33,7 +33,7 @@ class Glpk(AutotoolsPackage, GNUMirrorPackage):
     def configure_args(self):
         options = []
 
-        if "+gmp" in self.spec:
+        if self.spec.satisfies("+gmp"):
             options.append("--with-gmp")
 
         return options

--- a/var/spack/repos/builtin/packages/gmp/package.py
+++ b/var/spack/repos/builtin/packages/gmp/package.py
@@ -65,6 +65,6 @@ class Gmp(AutotoolsPackage, GNUMirrorPackage):
     def configure_args(self):
         args = self.enable_or_disable("cxx")
         args += self.enable_or_disable("libs")
-        if "libs=static" in self.spec:
+        if self.spec.satisfies("libs=static"):
             args.append("--with-pic")
         return args

--- a/var/spack/repos/builtin/packages/gmt/package.py
+++ b/var/spack/repos/builtin/packages/gmt/package.py
@@ -130,16 +130,16 @@ class CMakeBuilder(CMakeBuilder):
             self.define("DCW_PATH", "dcw"),
         ]
 
-        if "+ghostscript" in spec:
+        if spec.satisfies("+ghostscript"):
             args.append(self.define("GS", spec["ghostscript"].prefix.bin.gs))
 
-        if "+geos" in spec:
+        if spec.satisfies("+geos"):
             args.append(self.define("GEOS_CONFIG", spec["geos"].prefix.bin.join("geos-config")))
 
-        if "+pcre" in spec:
+        if spec.satisfies("+pcre"):
             args.append(self.define("PCRE2_CONFIG", spec["pcre2"].prefix.bin.join("pcre2-config")))
 
-        if "+fftw" in spec:
+        if spec.satisfies("+fftw"):
             args.extend(
                 [
                     self.define("FFTW3_INCLUDE_DIR", spec["fftw"].headers.directories[0]),
@@ -147,7 +147,7 @@ class CMakeBuilder(CMakeBuilder):
                 ]
             )
 
-        if "+glib" in spec:
+        if spec.satisfies("+glib"):
             args.extend(
                 [
                     self.define("GLIB_INCLUDE_DIR", spec["glib"].headers.directories[0]),
@@ -155,7 +155,7 @@ class CMakeBuilder(CMakeBuilder):
                 ]
             )
 
-        if "graphicsmagick" in spec:
+        if spec.satisfies("graphicsmagick"):
             args.extend(
                 [
                     self.define("GM", spec["graphicsmagick"].prefix.bin.gm),
@@ -163,7 +163,7 @@ class CMakeBuilder(CMakeBuilder):
                 ]
             )
 
-        if "+ffmpeg" in spec:
+        if spec.satisfies("+ffmpeg"):
             args.append(self.define("FFMPEG", spec["ffmpeg"].prefix.bin.ffmpeg))
 
         return args

--- a/var/spack/repos/builtin/packages/gnina/package.py
+++ b/var/spack/repos/builtin/packages/gnina/package.py
@@ -74,7 +74,7 @@ class Gnina(CMakePackage, CudaPackage):
     def cmake_args(self):
         args = ["-DBLAS=Open"]  # Use OpenBLAS instead of Atlas' BLAS
 
-        if "+gninavis" in self.spec:
+        if self.spec.satisfies("+gninavis"):
             args.append(f"-DRDKIT_INCLUDE_DIR={self.spec['rdkit'].prefix.include.rdkit}")
 
         return args

--- a/var/spack/repos/builtin/packages/gnuplot/package.py
+++ b/var/spack/repos/builtin/packages/gnuplot/package.py
@@ -91,12 +91,12 @@ class Gnuplot(AutotoolsPackage):
 
         options += self.with_or_without("readline", "prefix")
 
-        if "+pbm" in spec:
+        if spec.satisfies("+pbm"):
             options.append("--with-bitmap-terminals")
         else:
             options.append("--without-bitmap-terminals")
 
-        if "+X" in spec:
+        if spec.satisfies("+X"):
             # It seems there's an open bug for wxWidgets support
             # See : http://sourceforge.net/p/gnuplot/bugs/1694/
             os.environ["TERMLIBS"] = "-lX11"
@@ -104,7 +104,7 @@ class Gnuplot(AutotoolsPackage):
         else:
             options.append("--without-x")
 
-        if "+qt" in spec:
+        if spec.satisfies("+qt"):
             options.append("--with-qt=qt5")
             # QT needs C++11 compiler:
             os.environ["CXXFLAGS"] = "{0}".format(self.compiler.cxx11_flag)
@@ -134,22 +134,22 @@ class Gnuplot(AutotoolsPackage):
         else:
             options.append("--with-qt=no")
 
-        if "+wx" in spec:
+        if spec.satisfies("+wx"):
             options.append("--with-wx=%s" % spec["wxwidgets"].prefix)
         else:
             options.append("--disable-wxwidgets")
 
-        if "+gd" in spec:
+        if spec.satisfies("+gd"):
             options.append("--with-gd=%s" % spec["libgd"].prefix)
         else:
             options.append("--without-gd")
 
-        if "+cairo" in spec:
+        if spec.satisfies("+cairo"):
             options.append("--with-cairo")
         else:
             options.append("--without-cairo")
 
-        if "+libcerf" in spec:
+        if spec.satisfies("+libcerf"):
             options.append("--with-libcerf")
         else:
             options.append("--without-libcerf")

--- a/var/spack/repos/builtin/packages/gnutls/package.py
+++ b/var/spack/repos/builtin/packages/gnutls/package.py
@@ -66,7 +66,7 @@ class Gnutls(AutotoolsPackage):
 
     def setup_build_environment(self, env):
         spec = self.spec
-        if "+guile" in spec:
+        if spec.satisfies("+guile"):
             env.set("GUILE", spec["guile"].prefix.bin.guile)
 
     def configure_args(self):
@@ -79,12 +79,12 @@ class Gnutls(AutotoolsPackage):
             args.append("--with-included-unistring")
             args.append("--without-p11-kit")  # p11-kit@0.23.1: ...
 
-        if "+zlib" in spec:
+        if spec.satisfies("+zlib"):
             args.append("--with-zlib")
         else:
             args.append("--without-zlib")
 
-        if "+guile" in spec:
+        if spec.satisfies("+guile"):
             args.append("--enable-guile")
         else:
             args.append("--disable-guile")

--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -66,7 +66,7 @@ class Googletest(CMakePackage):
             install_tree(join_path(self.stage.source_path, "include"), prefix.include)
 
             mkdirp(prefix.lib)
-            if "+shared" in spec:
+            if spec.satisfies("+shared"):
                 install("libgtest.{0}".format(dso_suffix), prefix.lib)
                 install("libgtest_main.{0}".format(dso_suffix), prefix.lib)
             else:

--- a/var/spack/repos/builtin/packages/gosam-contrib/package.py
+++ b/var/spack/repos/builtin/packages/gosam-contrib/package.py
@@ -39,14 +39,14 @@ class GosamContrib(AutotoolsPackage):
 
     def flag_handler(self, name, flags):
         if name in ["cflags", "cxxflags", "cppflags"]:
-            if "+pic" in self.spec:
+            if self.spec.satisfies("+pic"):
                 flags.append(self.compiler.cc_pic_flag)
 
         if name == "fflags":
             if "gfortran" in self.compiler.fc:
                 flags.append("-std=legacy")
 
-            if "+pic" in self.spec:
+            if self.spec.satisfies("+pic"):
                 flags.append(self.compiler.fc_pic_flag)
 
         return (None, flags, None)

--- a/var/spack/repos/builtin/packages/gpi-2/package.py
+++ b/var/spack/repos/builtin/packages/gpi-2/package.py
@@ -105,17 +105,17 @@ class Gpi2(AutotoolsPackage):
         self.set_specific_cflags(spec)
 
         config_args = ["-p {0}".format(prefix)]
-        if "fabrics=ethernet" in spec:
+        if spec.satisfies("fabrics=ethernet"):
             config_args += ["--with-ethernet"]
-        elif "fabrics=infiniband" in spec:
+        elif spec.satisfies("fabrics=infiniband"):
             config_args += ["--with-infiniband={0}".format(spec["rdma-core"].prefix)]
-        if "schedulers=loadleveler" in spec:
+        if spec.satisfies("schedulers=loadleveler"):
             config_args += ["--with-ll"]
-        if "+fortran" in spec:
+        if spec.satisfies("+fortran"):
             config_args += ["--with-fortran=true"]
         else:
             config_args += ["--with-fortran=false"]
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             config_args += ["--with-mpi={0}".format(spec["mpi"].prefix)]
 
         with working_dir(self.build_directory):
@@ -147,7 +147,7 @@ class Gpi2(AutotoolsPackage):
 
         config_args.extend(self.with_or_without("fortran"))
         # Mpi
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             config_args += ["--with-mpi={0}".format(spec["mpi"].prefix)]
         # Fabrics
         if "fabrics=none" not in spec:

--- a/var/spack/repos/builtin/packages/gptl/package.py
+++ b/var/spack/repos/builtin/packages/gptl/package.py
@@ -35,7 +35,7 @@ class Gptl(AutotoolsPackage):
     def configure_args(self):
         args = []
 
-        if "+pmpi" in self.spec:
+        if self.spec.satisfies("+pmpi"):
             args.append("--enable-pmpi")
             args.append("CC=" + self.spec["mpi"].mpicc)
             args.append("CXX=" + self.spec["mpi"].mpicxx)
@@ -43,13 +43,13 @@ class Gptl(AutotoolsPackage):
             args.append("F90=" + self.spec["mpi"].mpifc)
             args.append("F77=" + self.spec["mpi"].mpif77)
 
-        if "+papi" in self.spec:
+        if self.spec.satisfies("+papi"):
             args.append("--enable-papi")
 
-        if "+nestedomp" in self.spec:
+        if self.spec.satisfies("+nestedomp"):
             args.append("--enable-nestedomp")
 
-        if "+disable-unwind" in self.spec:
+        if self.spec.satisfies("+disable-unwind"):
             args.append("--disable-libunwind")
 
         return args

--- a/var/spack/repos/builtin/packages/gptune/package.py
+++ b/var/spack/repos/builtin/packages/gptune/package.py
@@ -112,7 +112,7 @@ class Gptune(CMakePackage):
         comp_version = str(self.compiler.version).replace(".", ",")
         test_dir = join_path(self.test_suite.current_test_cache_dir, self.examples_src_dir)
 
-        if "+superlu" in spec:
+        if spec.satisfies("+superlu"):
             superludriver = join_path(spec["superlu-dist"].prefix.lib, "EXAMPLE/pddrive_spawn")
             op = ["-r", superludriver, "."]
             # copy superlu-dist executables to the correct place
@@ -127,7 +127,7 @@ class Gptune(CMakePackage):
             self.run_test("mkdir", options=["-p", "EXAMPLE"], work_dir=wd + "/superlu_dist/build")
             self.run_test("cp", options=op, work_dir=wd + "/superlu_dist/build/EXAMPLE")
 
-        if "+hypre" in spec:
+        if spec.satisfies("+hypre"):
             hypredriver = join_path(spec["hypre"].prefix.bin, "ij")
             op = ["-r", hypredriver, "."]
             # copy superlu-dist executables to the correct place
@@ -221,14 +221,14 @@ class Gptune(CMakePackage):
         self.run_test("cp", options=op, work_dir=wd)
 
         apps = ["Scalapack-PDGEQRF_RCI"]
-        if "+mpispawn" in spec:
+        if spec.satisfies("+mpispawn"):
             apps = apps + ["GPTune-Demo", "Scalapack-PDGEQRF"]
-        if "+superlu" in spec:
+        if spec.satisfies("+superlu"):
             apps = apps + ["SuperLU_DIST_RCI"]
-            if "+mpispawn" in spec:
+            if spec.satisfies("+mpispawn"):
                 apps = apps + ["SuperLU_DIST"]
-        if "+hypre" in spec:
-            if "+mpispawn" in spec:
+        if spec.satisfies("+hypre"):
+            if spec.satisfies("+mpispawn"):
                 apps = apps + ["Hypre"]
 
         for app in apps:

--- a/var/spack/repos/builtin/packages/gpu-burn/package.py
+++ b/var/spack/repos/builtin/packages/gpu-burn/package.py
@@ -30,7 +30,7 @@ class GpuBurn(MakefilePackage, CudaPackage):
 
     def edit(self, spec, prefix):
         # update cuda architecture if necessary
-        if "+cuda" in self.spec:
+        if self.spec.satisfies("+cuda"):
             cuda_arch = self.spec.variants["cuda_arch"].value
             archflag = " ".join(CudaPackage.cuda_flags(cuda_arch))
             with open("Makefile", "w") as fh:

--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -164,7 +164,7 @@ class Graphviz(AutotoolsPackage):
         # Set MACOSX_DEPLOYMENT_TARGET to 10.x due to old configure
         super().setup_build_environment(env)
 
-        if "+quartz" in self.spec:
+        if self.spec.satisfies("+quartz"):
             env.set("OBJC", self.compiler.cc)
 
     @when("%clang platform=darwin")
@@ -209,7 +209,7 @@ class Graphviz(AutotoolsPackage):
                 args.append("--with-{0}includedir={1}".format(var, spec[var].prefix.include))
                 args.append("--with-{0}libdir={1}".format(var, spec[var].prefix.lib))
 
-        if "+zlib" in spec:
+        if spec.satisfies("+zlib"):
             args.append("--with-zlibincludedir={}".format(spec["zlib-api"].prefix.include))
             args.append("--with-zliblibdir={}".format(spec["zlib-api"].prefix.lib))
 

--- a/var/spack/repos/builtin/packages/grass/package.py
+++ b/var/spack/repos/builtin/packages/grass/package.py
@@ -117,132 +117,132 @@ class Grass(AutotoolsPackage):
             "--with-proj-share={0}".format(spec["proj"].prefix.share.proj),
         ]
 
-        if "+cxx" in spec:
+        if spec.satisfies("+cxx"):
             args.append("--with-cxx")
         else:
             args.append("--without-cxx")
 
-        if "+tiff" in spec:
+        if spec.satisfies("+tiff"):
             args.append("--with-tiff")
         else:
             args.append("--without-tiff")
 
-        if "+png" in spec:
+        if spec.satisfies("+png"):
             args.append("--with-png")
         else:
             args.append("--without-png")
 
-        if "+postgres" in spec:
+        if spec.satisfies("+postgres"):
             args.append("--with-postgres")
         else:
             args.append("--without-postgres")
 
-        if "+mysql" in spec:
+        if spec.satisfies("+mysql"):
             args.append("--with-mysql")
         else:
             args.append("--without-mysql")
 
-        if "+sqlite" in spec:
+        if spec.satisfies("+sqlite"):
             args.append("--with-sqlite")
         else:
             args.append("--without-sqlite")
 
-        if "+opengl" in spec:
+        if spec.satisfies("+opengl"):
             args.append("--with-opengl")
         else:
             args.append("--without-opengl")
 
-        if "+odbc" in spec:
+        if spec.satisfies("+odbc"):
             args.append("--with-odbc")
         else:
             args.append("--without-odbc")
 
-        if "+fftw" in spec:
+        if spec.satisfies("+fftw"):
             args.append("--with-fftw")
         else:
             args.append("--without-fftw")
 
-        if "+blas" in spec:
+        if spec.satisfies("+blas"):
             args.append("--with-blas")
         else:
             args.append("--without-blas")
 
-        if "+lapack" in spec:
+        if spec.satisfies("+lapack"):
             args.append("--with-lapack")
         else:
             args.append("--without-lapack")
 
-        if "+cairo" in spec:
+        if spec.satisfies("+cairo"):
             args.append("--with-cairo")
         else:
             args.append("--without-cairo")
 
-        if "+freetype" in spec:
+        if spec.satisfies("+freetype"):
             args.append("--with-freetype")
         else:
             args.append("--without-freetype")
 
-        if "+readline" in spec:
+        if spec.satisfies("+readline"):
             args.append("--with-readline")
         else:
             args.append("--without-readline")
 
-        if "+regex" in spec:
+        if spec.satisfies("+regex"):
             args.append("--with-regex")
         else:
             args.append("--without-regex")
 
-        if "+pthread" in spec:
+        if spec.satisfies("+pthread"):
             args.append("--with-pthread")
         else:
             args.append("--without-pthread")
 
-        if "+openmp" in spec:
+        if spec.satisfies("+openmp"):
             args.append("--with-openmp")
         else:
             args.append("--without-openmp")
 
-        if "+opencl" in spec:
+        if spec.satisfies("+opencl"):
             args.append("--with-opencl")
         else:
             args.append("--without-opencl")
 
-        if "+bzlib" in spec:
+        if spec.satisfies("+bzlib"):
             args.append("--with-bzlib")
         else:
             args.append("--without-bzlib")
 
-        if "+zstd" in spec:
+        if spec.satisfies("+zstd"):
             args.append("--with-zstd")
         else:
             args.append("--without-zstd")
 
-        if "+gdal" in spec:
+        if spec.satisfies("+gdal"):
             args.append("--with-gdal={0}/gdal-config".format(spec["gdal"].prefix.bin))
         else:
             args.append("--without-gdal")
 
-        if "+liblas" in spec:
+        if spec.satisfies("+liblas"):
             args.append("--with-liblas={0}/liblas-config".format(spec["liblas"].prefix.bin))
         else:
             args.append("--without-liblas")
 
-        if "+wxwidgets" in spec:
+        if spec.satisfies("+wxwidgets"):
             args.append("--with-wxwidgets={0}/wx-config".format(spec["wxwidgets"].prefix.bin))
         else:
             args.append("--without-wxwidgets")
 
-        if "+netcdf" in spec:
+        if spec.satisfies("+netcdf"):
             args.append("--with-netcdf={0}/bin/nc-config".format(spec["netcdf-c"].prefix))
         else:
             args.append("--without-netcdf")
 
-        if "+geos" in spec:
+        if spec.satisfies("+geos"):
             args.append("--with-geos={0}/bin/geos-config".format(spec["geos"].prefix))
         else:
             args.append("--without-geos")
 
-        if "+x" in spec:
+        if spec.satisfies("+x"):
             args.append("--with-x")
         else:
             args.append("--without-x")

--- a/var/spack/repos/builtin/packages/grep/package.py
+++ b/var/spack/repos/builtin/packages/grep/package.py
@@ -32,7 +32,7 @@ class Grep(AutotoolsPackage):
     def configure_args(self):
         args = []
 
-        if "+pcre" in self.spec:
+        if self.spec.satisfies("+pcre"):
             args.append("--enable-perl-regexp")
         else:
             args.append("--disable-perl-regexp")

--- a/var/spack/repos/builtin/packages/grib-api/package.py
+++ b/var/spack/repos/builtin/packages/grib-api/package.py
@@ -105,7 +105,7 @@ class GribApi(CMakePackage):
             for var, opt in var_opt_list
         ]
 
-        if "+netcdf" in self.spec:
+        if self.spec.satisfies("+netcdf"):
             args.extend(
                 [
                     "-DENABLE_NETCDF=ON",
@@ -128,12 +128,12 @@ class GribApi(CMakePackage):
         if self.spec.variants["jp2k"].value == "openjpeg":
             args.append("-DOPENJPEG_PATH=" + self.spec["openjpeg"].prefix)
 
-        if "+png" in self.spec:
+        if self.spec.satisfies("+png"):
             args.extend(["-DENABLE_PNG=ON", "-DZLIB_ROOT=" + self.spec["zlib-api"].prefix])
         else:
             args.append("-DENABLE_PNG=OFF")
 
-        if "+aec" in self.spec:
+        if self.spec.satisfies("+aec"):
             args.extend(
                 [
                     "-DENABLE_AEC=ON",

--- a/var/spack/repos/builtin/packages/grid/package.py
+++ b/var/spack/repos/builtin/packages/grid/package.py
@@ -77,12 +77,12 @@ class Grid(AutotoolsPackage):
         args = ["--with-gmp", "--with-mpfr"]
 
         if spec.satisfies("^intel-mkl"):
-            if "+fftw" in spec or "+lapack" in spec:
+            if spec.satisfies("+fftw") or spec.satisfies("+lapack"):
                 args.append("--enable-mkl")
         else:
-            if "+fftw" in spec:
+            if spec.satisfies("+fftw"):
                 args.append("--with-fftw={0}".format(self.spec["fftw-api"].prefix))
-            if "+lapack" in spec:
+            if spec.satisfies("+lapack"):
                 args.append("--enable-lapack={0}".format(self.spec["lapack"].prefix))
                 # lapack is searched only as `-llapack`, so anything else
                 # wouldn't be found, causing an error.

--- a/var/spack/repos/builtin/packages/gridlab-d/package.py
+++ b/var/spack/repos/builtin/packages/gridlab-d/package.py
@@ -42,7 +42,7 @@ class GridlabD(AutotoolsPackage):
     def configure_args(self):
         args = []
 
-        if "+helics" in self.spec:
+        if self.spec.satisfies("+helics"):
             # Taken from
             # https://github.com/GMLC-TDC/HELICS-Tutorial/tree/master/setup
             args.append("--with-helics=" + self.spec["helics"].prefix)

--- a/var/spack/repos/builtin/packages/groff/package.py
+++ b/var/spack/repos/builtin/packages/groff/package.py
@@ -82,7 +82,7 @@ class Groff(AutotoolsPackage, GNUMirrorPackage):
     def configure_args(self):
         args = ["--disable-silent-rules"]
         args.extend(self.with_or_without("x"))
-        if "@1.22.4:" in self.spec:
+        if self.spec.satisfies("@1.22.4:"):
             args.extend(self.with_or_without("uchardet"))
         if self.spec["iconv"].name == "libiconv":
             args.append(f"--with-libiconv-prefix={self.spec['iconv'].prefix}")

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -384,14 +384,14 @@ class Gromacs(CMakePackage, CudaPackage):
                 string=True,
             )
 
-        if "+plumed" in self.spec:
+        if self.spec.satisfies("+plumed"):
             self.spec["plumed"].package.apply_patch(self)
 
         if self.spec.satisfies("%nvhpc"):
             # Disable obsolete workaround
             filter_file("ifdef __PGI", "if 0", "src/gromacs/fileio/xdrf.h")
 
-        if "+cuda" in self.spec:
+        if self.spec.satisfies("+cuda"):
             # Upstream supports building of last two major versions of Gromacs.
             # Older versions of Gromacs need to be patched to build with more recent
             # versions of CUDA library.
@@ -486,7 +486,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         # In other words, the mapping between package variants and the
         # GMX CMake variables is often non-trivial.
 
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             options.append("-DGMX_MPI:BOOL=ON")
             if self.pkg.version < Version("2020"):
                 # Ensures gmxapi builds properly
@@ -542,39 +542,39 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             else:
                 options.append("-DGMX_GPLUSPLUS_PATH=%s/g++" % self.spec["gcc"].prefix.bin)
 
-        if "+double" in self.spec:
+        if self.spec.satisfies("+double"):
             options.append("-DGMX_DOUBLE:BOOL=ON")
 
-        if "+nosuffix" in self.spec:
+        if self.spec.satisfies("+nosuffix"):
             options.append("-DGMX_DEFAULT_SUFFIX:BOOL=OFF")
 
-        if "~shared" in self.spec:
+        if self.spec.satisfies("~shared"):
             options.append("-DBUILD_SHARED_LIBS:BOOL=OFF")
             options.append("-DGMXAPI:BOOL=OFF")
 
-        if "+hwloc" in self.spec:
+        if self.spec.satisfies("+hwloc"):
             options.append("-DGMX_HWLOC:BOOL=ON")
         else:
             options.append("-DGMX_HWLOC:BOOL=OFF")
 
         if self.pkg.version >= Version("2021"):
-            if "+cuda" in self.spec:
+            if self.spec.satisfies("+cuda"):
                 options.append("-DGMX_GPU:STRING=CUDA")
-            elif "+opencl" in self.spec:
+            elif self.spec.satisfies("+opencl"):
                 options.append("-DGMX_GPU:STRING=OpenCL")
-            elif "+sycl" in self.spec:
+            elif self.spec.satisfies("+sycl"):
                 options.append("-DGMX_GPU:STRING=SYCL")
             else:
                 options.append("-DGMX_GPU:STRING=OFF")
         else:
-            if "+cuda" in self.spec or "+opencl" in self.spec:
+            if self.spec.satisfies("+cuda") or self.spec.satisfies("+opencl"):
                 options.append("-DGMX_GPU:BOOL=ON")
-                if "+opencl" in self.spec:
+                if self.spec.satisfies("+opencl"):
                     options.append("-DGMX_USE_OPENCL=ON")
             else:
                 options.append("-DGMX_GPU:BOOL=OFF")
 
-        if "+cuda" in self.spec:
+        if self.spec.satisfies("+cuda"):
             options.append("-DCUDA_TOOLKIT_ROOT_DIR:STRING=" + self.spec["cuda"].prefix)
             if not self.spec.satisfies("cuda_arch=none"):
                 cuda_arch = self.spec.variants["cuda_arch"].value
@@ -588,28 +588,28 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         if self.spec["blas"].libs:
             options.append("-DGMX_BLAS_USER={0}".format(self.spec["blas"].libs.joined(";")))
 
-        if "+cp2k" in self.spec:
+        if self.spec.satisfies("+cp2k"):
             options.append("-DGMX_CP2K:BOOL=ON")
             options.append("-DCP2K_DIR:STRING={0}".format(self.spec["cp2k"].prefix))
 
-        if "+cufftmp" in self.spec:
+        if self.spec.satisfies("+cufftmp"):
             options.append("-DGMX_USE_CUFFTMP=ON")
             options.append(
                 f'-DcuFFTMp_ROOT={self.spec["nvhpc"].prefix}/Linux_{self.spec.target.family}'
                 + f'/{self.spec["nvhpc"].version}/math_libs'
             )
 
-        if "+heffte" in self.spec:
+        if self.spec.satisfies("+heffte"):
             options.append("-DGMX_USE_HEFFTE=on")
             options.append(f'-DHeffte_ROOT={self.spec["heffte"].prefix}')
 
-        if "+intel-data-center-gpu-max" in self.spec:
+        if self.spec.satisfies("+intel-data-center-gpu-max"):
             options.append("-DGMX_GPU_NB_CLUSTER_SIZE=8")
             options.append("-DGMX_GPU_NB_NUM_CLUSTER_PER_CELL_X=1")
 
-        if "~nblib" in self.spec:
+        if self.spec.satisfies("~nblib"):
             options.append("-DGMX_INSTALL_NBLIB_API=OFF")
-        if "~gmxapi" in self.spec:
+        if self.spec.satisfies("~gmxapi"):
             options.append("-DGMXAPI=OFF")
 
         # Activate SIMD based on properties of the target
@@ -685,7 +685,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
                 )
             )
 
-        if "+cycle_subcounters" in self.spec:
+        if self.spec.satisfies("+cycle_subcounters"):
             options.append("-DGMX_CYCLE_SUBCOUNTERS:BOOL=ON")
         else:
             options.append("-DGMX_CYCLE_SUBCOUNTERS:BOOL=OFF")
@@ -719,7 +719,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         else:
             # we rely on the fftw-api@3
             options.append("-DGMX_FFT_LIBRARY=fftw3")
-            if "^amdfftw" in self.spec:
+            if self.spec.satisfies("^amdfftw"):
                 options.append("-DGMX_FFT_LIBRARY=fftw3")
                 options.append(
                     "-DFFTWF_INCLUDE_DIRS={0}".format(self.spec["amdfftw"].headers.directories[0])
@@ -727,14 +727,14 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
                 options.append(
                     "-DFFTWF_LIBRARIES={0}".format(self.spec["amdfftw"].libs.joined(";"))
                 )
-            elif "^armpl-gcc" in self.spec:
+            elif self.spec.satisfies("^armpl-gcc"):
                 options.append(
                     "-DFFTWF_INCLUDE_DIR={0}".format(self.spec["armpl-gcc"].headers.directories[0])
                 )
                 options.append(
                     "-DFFTWF_LIBRARY={0}".format(self.spec["armpl-gcc"].libs.joined(";"))
                 )
-            elif "^acfl" in self.spec:
+            elif self.spec.satisfies("^acfl"):
                 options.append(
                     "-DFFTWF_INCLUDE_DIR={0}".format(self.spec["acfl"].headers.directories[0])
                 )
@@ -742,7 +742,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
 
         # Ensure that the GROMACS log files report how the code was patched
         # during the build, so that any problems are easier to diagnose.
-        if "+plumed" in self.spec:
+        if self.spec.satisfies("+plumed"):
             options.append("-DGMX_VERSION_STRING_OF_FORK=PLUMED-spack")
         else:
             options.append("-DGMX_VERSION_STRING_OF_FORK=spack")

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -719,7 +719,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         else:
             # we rely on the fftw-api@3
             options.append("-DGMX_FFT_LIBRARY=fftw3")
-            if self.spec.satisfies("^amdfftw"):
+            if self.spec.satisfies("^[virtuals=fftw-api] amdfftw"):
                 options.append("-DGMX_FFT_LIBRARY=fftw3")
                 options.append(
                     "-DFFTWF_INCLUDE_DIRS={0}".format(self.spec["amdfftw"].headers.directories[0])

--- a/var/spack/repos/builtin/packages/gslib/package.py
+++ b/var/spack/repos/builtin/packages/gslib/package.py
@@ -50,7 +50,7 @@ class Gslib(Package):
         if "+mpiio" not in spec:
             filter_file(r"MPIIO.*?=.*1", "MPIIO = 0", makefile)
 
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             cc = spec["mpi"].mpicc
         else:
             filter_file(r"MPI.*?=.*1", "MPI = 0", makefile)
@@ -58,7 +58,7 @@ class Gslib(Package):
 
         make_cmd = "CC=" + cc
 
-        if "+blas" in spec:
+        if spec.satisfies("+blas"):
             filter_file(r"BLAS.*?=.*0", "BLAS = 1", makefile)
             blas = spec["blas"].libs
             ld_flags = blas.ld_flags

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -124,7 +124,7 @@ class Gtkplus(MesonPackage):
             "GTKDOC_MKPDF={0}".format(true),
             "GTKDOC_REBASE={0}".format(true),
         ]
-        if "~cups" in self.spec:
+        if self.spec.satisfies("~cups"):
             args.append("--disable-cups")
         return args
 

--- a/var/spack/repos/builtin/packages/guile/package.py
+++ b/var/spack/repos/builtin/packages/guile/package.py
@@ -70,12 +70,12 @@ class Guile(AutotoolsPackage, GNUMirrorPackage):
             "--with-libintl-prefix={0}".format(spec["gettext"].prefix),
         ]
 
-        if "threads=none" in spec:
+        if spec.satisfies("threads=none"):
             config_args.append("--without-threads")
         else:
             config_args.append("--with-threads")
 
-        if "+readline" in spec:
+        if spec.satisfies("+readline"):
             config_args.append("--with-libreadline-prefix={0}".format(spec["readline"].prefix))
         else:
             config_args.append("--without-libreadline-prefix")

--- a/var/spack/repos/builtin/packages/gunrock/package.py
+++ b/var/spack/repos/builtin/packages/gunrock/package.py
@@ -163,5 +163,5 @@ See "spack info gunrock"',
         with working_dir(self.build_directory):
             install_tree("lib", prefix.lib)
             # bin dir is created only if tests/examples are built
-            if "+tests" in spec:
+            if spec.satisfies("+tests"):
                 install_tree("bin", prefix.bin)

--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -66,7 +66,7 @@ class Gxsview(QMakePackage):
         )
         # Below to avoid undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
         if self.spec.satisfies("%gcc@8.0:8.9") or self.spec.satisfies("%fj"):
-            if "^vtk@9:" in self.spec:
+            if self.spec.satisfies("^vtk@9:"):
                 fic = "vtk9.pri"
             else:
                 fic = "vtk8.pri"


### PR DESCRIPTION
with the structure `if "+variant" in spec:`, checks like `if "mpi" in spec:` would be valid whereas it could be `~mpi` or `+mpi`. Satisfies adds additional checks to avoid mistakes from the user.