### PR TITLE
various package fixes for illumine

### DIFF
--- a/var/spack/repos/builtin/packages/libpressio-opt/package.py
+++ b/var/spack/repos/builtin/packages/libpressio-opt/package.py
@@ -10,7 +10,7 @@ class LibpressioOpt(CMakePackage):
     """Metacompressor which preforms optimization of compressor settings for LibPressio"""
 
     homepage = "https://github.com/robertu94/libpressio_opt"
-    git = "git@github.com:robertu94/libpressio_opt"
+    git = "https://github.com/robertu94/libpressio_opt.git"
     url = "https://github.com/robertu94/libpressio_opt/archive/refs/tags/0.11.0.tar.gz"
 
     maintainers("robertu94")

--- a/var/spack/repos/builtin/packages/libpressio-tools/package.py
+++ b/var/spack/repos/builtin/packages/libpressio-tools/package.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 from spack.package import *
 
 
@@ -94,6 +93,10 @@ class LibpressioTools(CMakePackage):
     variant("predict", default=False, description="depend on libpressio-predict", when="@0.4.6:")
     variant("jit", default=False, description="depend on libpressio-jit", when="@0.4.6:")
     conflicts("+opt", when="~mpi", msg="opt support requires MPI")
+
+    def setup_run_environment(self, env):
+        libraries = find_libraries(["liblibpressio_meta"], root=self.prefix, recursive=True)
+        env.set("LIBPRESSIO_PLUGINS", libraries)
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -395,7 +395,7 @@ class Libpressio(CMakePackage, CudaPackage):
 
     def setup_run_environment(self, env):
         if "+hdf5" in self.spec and "+json" in self.spec:
-            env.prepend_path("HDF5_PLUGIN_PATH", self.prefix.lib64)
+            env.prepend_path("HDF5_PLUGIN_PATH", self.prefix.hdf5.lib.plugin)
 
     @run_after("build")
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -486,6 +486,7 @@ class Opencv(CMakePackage, CudaPackage):
 
     with when("+hdf"):
         depends_on("hdf5")
+        depends_on("mpi", when="^hdf5+mpi")
 
     with when("+hfs"):
         with when("+cuda"):

--- a/var/spack/repos/builtin/packages/py-cupy/package.py
+++ b/var/spack/repos/builtin/packages/py-cupy/package.py
@@ -53,7 +53,8 @@ class PyCupy(PythonPackage, CudaPackage, ROCmPackage):
     for a in CudaPackage.cuda_arch_values:
         depends_on("nccl +cuda cuda_arch={0}".format(a), when="+cuda cuda_arch={0}".format(a))
 
-    depends_on("cudnn", when="+cuda")
+    depends_on("cudnn@8.8", when="@12.0.0: +cuda")
+    depends_on("cudnn@8.5", when="@11.2.0:11.6.0 +cuda")
     depends_on("cutensor", when="@:12.1.0 +cuda")
     depends_on("cutensor@2.0.1.2", when="@13.1: +cuda")
 

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -525,6 +525,7 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
 
         enable_or_disable("cuda")
         if "+cuda" in self.spec:
+            env.set("CUDA_TOOLKIT_ROOT_DIR", self.spec["cuda"].prefix)  # Linux/macOS
             env.set("CUDA_HOME", self.spec["cuda"].prefix)  # Linux/macOS
             env.set("CUDA_PATH", self.spec["cuda"].prefix)  # Windows
             self.torch_cuda_arch_list(env)

--- a/var/spack/repos/builtin/packages/sz3/package.py
+++ b/var/spack/repos/builtin/packages/sz3/package.py
@@ -16,6 +16,7 @@ class Sz3(CMakePackage):
     tags = ["e4s"]
 
     version("master")
+    version("3.2.0", commit="b3dab4018425803a55d8073dc55dade7fa46b7b4")
     version("3.1.8", commit="e308ebf8528c233286874b920c72c0a6c0218fb2")
     version("3.1.7", commit="c49fd17f2d908835c41000c1286c510046c0480e")
     version("3.1.5.4", commit="4c6ddf628f27d36b28d1bbda02174359cd05573d")


### PR DESCRIPTION
Various fixes for libpressio and related packages needed for the Illumine project on Polaris at Argonne.

+ Switch to an HTTPS git endpoint for libpressio-opt instead of a git endpoint
+ use LIBPRESSIO_PLUGINS features in libpressio to automatically load the libpressio-meta.so extensions
+ with libpressio+hdf, use the correct plugin path so that ONLY the HDF5 plugin is found instead of other libraries that happen to have the "trigger" function that HDF5 looks for
+ with opencv, require the MPI compilers when HDF5 requires them because otherwise this dependency is not correctly propagated for the HDF5 compiler wrappers used by this package.
+ cupy 12 needs a newer version of cudnn as [documented here](https://github.com/cupy/cupy/releases/tag/v12.0.0)
+ py-torch also looks for the CUDA toolkit with the  CUDA_TOOLKIT_ROOT_DIR in addition to CUDA_HOME.  We need to set both.
+ new version of SZ3
