### PR TITLE
[rocm-openmp-extras] - Add support for flang-legacy in 6.1.2

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -257,7 +257,7 @@ class LlvmAmdgpu(CMakePackage, CompilerPackage):
             args.append(self.define("LLVM_ENABLE_PROJECTS", llvm_projects))
             args.append(self.define("LLVM_ENABLE_RUNTIMES", llvm_runtimes))
             args.append(self.define("LLVM_ENABLE_LIBCXX", "OFF"))
-            args.append(self.define("CLANG_LINK_FLANG_LEGACY", False))
+            args.append(self.define("CLANG_LINK_FLANG_LEGACY", True))
             args.append(self.define("CMAKE_CXX_STANDARD", 17))
             args.append(self.define("FLANG_INCLUDE_DOCS", False))
             args.append(self.define("LLVM_BUILD_DOCS", "ON"))

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -480,7 +480,9 @@ class RocmOpenmpExtras(Package):
 
         os.symlink(os.path.join(omp_bin_dir, "flang1"), os.path.join(bin_dir, "flang1"))
         os.symlink(os.path.join(omp_bin_dir, "flang2"), os.path.join(bin_dir, "flang2"))
-        os.symlink(os.path.join(omp_bin_dir, "flang-legacy"), os.path.join(bin_dir, "flang-legacy"))
+        os.symlink(
+            os.path.join(omp_bin_dir, "flang-legacy"), os.path.join(bin_dir, "flang-legacy")
+        )
         os.symlink(os.path.join(omp_lib_dir, "libdevice"), os.path.join(lib_dir, "libdevice"))
         os.symlink(
             os.path.join(openmp_extras_prefix, "lib-debug"), os.path.join(llvm_prefix, "lib-debug")
@@ -587,7 +589,9 @@ class RocmOpenmpExtras(Package):
             "-DLLVM_INCLUDE_DOCS=0",
             "-DLLVM_INCLUDE_UTILS=0",
             "-DCLANG_DEFAULT_PIE_ON_LINUX=0",
-            "../../rocm-openmp-extras/flang/flang-legacy/{0}/llvm-legacy/llvm".format(flang_legacy_version),
+            "../../rocm-openmp-extras/flang/flang-legacy/{0}/llvm-legacy/llvm".format(
+                flang_legacy_version
+            ),
         ]
 
         components["flang-legacy"] = [
@@ -596,7 +600,11 @@ class RocmOpenmpExtras(Package):
             "../rocm-openmp-extras/flang/flang-legacy/{0}".format(flang_legacy_version),
         ]
 
-        if self.compiler.name == "gcc" and self.compiler.version >= Version("7.0.0") and self.compiler.version < Version("9.0.0"):
+        if (
+            self.compiler.name == "gcc"
+            and self.compiler.version >= Version("7.0.0")
+            and self.compiler.version < Version("9.0.0")
+        ):
             components["flang-legacy-llvm"] += ["-DCMAKE_CXX_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0'"]
             components["flang-legacy"] += ["-DCMAKE_CXX_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0'"]
 
@@ -616,7 +624,15 @@ class RocmOpenmpExtras(Package):
         ]
         components["flang-runtime"] += flang_common_args
 
-        build_order = ["aomp-extras", "openmp", "flang-legacy-llvm", "flang-legacy", "pgmath", "flang", "flang-runtime"]
+        build_order = [
+            "aomp-extras",
+            "openmp",
+            "flang-legacy-llvm",
+            "flang-legacy",
+            "pgmath",
+            "flang",
+            "flang-runtime",
+        ]
 
         # Override standard CMAKE_BUILD_TYPE
         for arg in std_cmake_args:

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -644,7 +644,6 @@ class RocmOpenmpExtras(Package):
             cmake_args.extend(std_cmake_args)
             if component == "flang-legacy-llvm":
                 with working_dir("spack-build-{0}/llvm-legacy".format(component), create=True):
-                    flang_legacy_dir = working_dir
                     cmake_args.append("-DCMAKE_BUILD_TYPE=Release")
                     cmake(*cmake_args)
                     make()

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -627,10 +627,7 @@ class RocmOpenmpExtras(Package):
         ]
         components["flang-runtime"] += flang_common_args
 
-        build_order = [
-            "aomp-extras",
-            "openmp",
-        ]
+        build_order = ["aomp-extras", "openmp"]
         if self.spec.version >= Version("6.1.0"):
             build_order += ["flang-legacy-llvm", "flang-legacy"]
 

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -471,8 +471,9 @@ class RocmOpenmpExtras(Package):
             os.unlink(os.path.join(bin_dir, "flang1"))
         if os.path.islink((os.path.join(bin_dir, "flang2"))):
             os.unlink(os.path.join(bin_dir, "flang2"))
-        if os.path.islink((os.path.join(bin_dir, "flang-legacy"))):
-            os.unlink(os.path.join(bin_dir, "flang-legacy"))
+        if self.spec.version >= Version("6.1.0"):
+            if os.path.islink((os.path.join(bin_dir, "flang-legacy"))):
+                os.unlink(os.path.join(bin_dir, "flang-legacy"))
         if os.path.islink((os.path.join(lib_dir, "libdevice"))):
             os.unlink(os.path.join(lib_dir, "libdevice"))
         if os.path.islink((os.path.join(llvm_prefix, "lib-debug"))):
@@ -480,9 +481,11 @@ class RocmOpenmpExtras(Package):
 
         os.symlink(os.path.join(omp_bin_dir, "flang1"), os.path.join(bin_dir, "flang1"))
         os.symlink(os.path.join(omp_bin_dir, "flang2"), os.path.join(bin_dir, "flang2"))
-        os.symlink(
-            os.path.join(omp_bin_dir, "flang-legacy"), os.path.join(bin_dir, "flang-legacy")
-        )
+
+        if self.spec.version >= Version("6.1.0"):
+            os.symlink(
+                os.path.join(omp_bin_dir, "flang-legacy"), os.path.join(bin_dir, "flang-legacy")
+            )
         os.symlink(os.path.join(omp_lib_dir, "libdevice"), os.path.join(lib_dir, "libdevice"))
         os.symlink(
             os.path.join(openmp_extras_prefix, "lib-debug"), os.path.join(llvm_prefix, "lib-debug")
@@ -627,13 +630,11 @@ class RocmOpenmpExtras(Package):
         build_order = [
             "aomp-extras",
             "openmp",
-            "flang-legacy-llvm",
-            "flang-legacy",
-            "pgmath",
-            "flang",
-            "flang-runtime",
         ]
+        if self.spec.version >= Version("6.1.0"):
+            build_order += ["flang-legacy-llvm", "flang-legacy"]
 
+        build_order += ["pgmath", "flang", "flang-runtime"]
         # Override standard CMAKE_BUILD_TYPE
         for arg in std_cmake_args:
             found = re.search("CMAKE_BUILD_TYPE", arg)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
