### PR TITLE
Put some more constraint on a few mpi providers

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -72,3 +72,13 @@ packages:
     permissions:
       read: world
       write: user
+  cray-mpich:
+    buildable: false
+  cray-mvapich2:
+    buildable: false
+  fujitsu-mpi:
+    buildable: false
+  hpcx-mpi:
+    buildable: false
+  spectrum-mpi:
+    buildable: false

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -32,6 +32,8 @@ class CrayMpich(Package):
     depends_on("cray-pmi")
     depends_on("libfabric")
 
+    requires("platform=linux", msg="Cray MPICH is only available on Cray")
+
     # cray-mpich 8.1.7: features MPI compiler wrappers
     variant("wrappers", default=True, when="@8.1.7:", description="enable MPI wrappers")
 

--- a/var/spack/repos/builtin/packages/cray-mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/cray-mvapich2/package.py
@@ -26,6 +26,8 @@ class CrayMvapich2(Package):
 
     provides("mpi@3")
 
+    requires("platform=linux", msg="Cray MVAPICH2 is only available on Cray")
+
     def setup_run_environment(self, env):
         if spack_cc is None:
             return

--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -22,6 +22,8 @@ class FujitsuMpi(Package):
         msg="currently only supports Fujitsu, Clang, or GCC compilers",
     )
 
+    requires("platform=linux")
+
     def install(self, spec, prefix):
         raise InstallError("Fujitsu MPI is not installable; it is vendor supplied")
 

--- a/var/spack/repos/builtin/packages/hpcx-mpi/package.py
+++ b/var/spack/repos/builtin/packages/hpcx-mpi/package.py
@@ -19,8 +19,10 @@ class HpcxMpi(Package):
 
     provides("mpi")
 
+    requires("platform=linux")
+
     def install(self, spec, prefix):
-        raise InstallError("HPC-X MPI is not buildable, it is for external " "specs only.")
+        raise InstallError("HPC-X MPI is not buildable, it is for external specs only.")
 
     def setup_dependent_package(self, module, dependent_spec):
         # This works for AOCC (AMD), Intel and GNU.

--- a/var/spack/repos/builtin/packages/msmpi/package.py
+++ b/var/spack/repos/builtin/packages/msmpi/package.py
@@ -33,6 +33,8 @@ class Msmpi(Package):
 
     patch("ifort_compat.patch")
 
+    requires("platform=windows")
+
     @classmethod
     def determine_version(cls, exe):
         # MSMPI is typically MS only, don't detect on other platforms

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -20,7 +20,7 @@ class SpectrumMpi(BundlePackage):
 
     provides("mpi")
 
-    conflicts("platform=windows")
+    requires("platform=linux")
 
     executables = ["^ompi_info$"]
 


### PR DESCRIPTION
This should help not selecting, by default, some niche implementation that are supposed to be externals. We can probably slightly optimize concretization based on providers which are `buildable: false` and not available, in a following PR.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
