### PR TITLE
Less boost in pipelines

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -16,6 +16,12 @@ spack:
       variants: +mpi
     gl:
       require: osmesa
+    boost:
+      require:
+      - "%oneapi target=x86_64v3"
+      - "+atomic +chrono +date_time +exception +filesystem +graph +iostreams"
+      - "+locale +log +math +random +regex"
+      - "+serialization +signals +system +thread +timer +wave"
     elfutils:
       variants: ~nls
     gcc-runtime:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -17,8 +17,7 @@ spack:
     gl:
       require: osmesa
     boost:
-      require:
-      - "%oneapi target=x86_64v3"
+      prefer:
       - "+atomic +chrono +date_time +exception +filesystem +graph +iostreams"
       - "+locale +log +math +random +regex"
       - "+serialization +signals +system +thread +timer +wave"

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -18,9 +18,24 @@ spack:
       require: osmesa
     boost:
       prefer:
-      - "+atomic +chrono +date_time +exception +filesystem +graph +iostreams"
-      - "+locale +log +math +random +regex"
-      - "+serialization +signals +system +thread +timer +wave"
+      - "+atomic"
+      - "+chrono"
+      - "+date_time"
+      - "+exception"
+      - "+filesystem"
+      - "+graph"
+      - "+iostreams"
+      - "+locale"
+      - "+log"
+      - "+math"
+      - "+random"
+      - "+regex"
+      - "+serialization"
+      - "+signals"
+      - "+system"
+      - "+thread"
+      - "+timer"
+      - "+wave"
     elfutils:
       variants: ~nls
     gcc-runtime:


### PR DESCRIPTION
This is an attempt at building less flavors of `boost` in pipelines, if compared to `develop`:

![Screenshot from 2024-08-30 11-00-13](https://github.com/user-attachments/assets/eed972ff-6520-4f37-9f06-78eb9321d15b)


Modified pipelines:
- [ ] e4s-oneapi