### PR TITLE
Update arch.satisfies documentation for conditional defintions

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -863,7 +863,7 @@ named list ``compilers`` is ``['%gcc', '%clang', '%intel']`` on
    spack:
      definitions:
        - compilers: ['%gcc', '%clang']
-       - when: arch.satisfies('x86_64:')
+       - when: arch.satisfies('target=x86_64:')
          compilers: ['%intel']
 
 .. note::


### PR DESCRIPTION
closes #38838

This is an extremely minor documentation update. When attempting to use the conditional definition `when` directive with `arch.satisfies('x86_64:')` as outlined in the documentation, I receive the following error: 

```
spack.parser.SpecTokenizationError: unexpected tokens in the spec string
x86_64:
```

First, I tried just removing the `:` to fix. However, this appears to always evaluate to true and didn't filter out the correct definitions when I was building an `aarch64` stack on our ARM nodes. After some trial and error, it looks like the correct instructions for Spack's current API is `arch.satisfies('target=x86_64:')`. This PR is just updating the documentation to reflect that and doesn't affect the Spack code. 