### PR TITLE
New version for openCARP packages, vtest

### DIFF
--- a/var/spack/repos/builtin/packages/meshtool/package.py
+++ b/var/spack/repos/builtin/packages/meshtool/package.py
@@ -18,6 +18,7 @@ class Meshtool(MakefilePackage):
     # Version to use with openCARP releases
     # It is possible that different openCARP releases rely on the same
     # meshtool version
+    version("octest", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc15.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc13.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")
     version("oc12.0", commit="867431d6bde35ad41104f611aa57130ef58cfb79")

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -49,6 +49,7 @@ class Opencarp(CMakePackage):
     version(
         "7.0", commit="78da91952738b45760bcbc34610814a83c8c6299", submodules=False, no_cache=True
     )
+    version("test", commit="6a8e1c09d34ffc1abf418e2148a10e5b12a88213", submodules=False, no_cache=True, preferred=True)
     version("master", branch="master", submodules=False, no_cache=True)
 
     depends_on("c", type="build")  # generated
@@ -72,7 +73,7 @@ class Opencarp(CMakePackage):
     depends_on("py-carputils", when="+carputils", type=("build", "run"))
     depends_on("meshtool", when="+meshtool", type=("build", "run"))
     # Use specific versions of carputils and meshtool for releases
-    for ver in ["15.0", "13.0", "12.0", "11.0", "10.0", "9.0", "8.2", "8.1", "7.0"]:
+    for ver in ["test", "15.0", "13.0", "12.0", "11.0", "10.0", "9.0", "8.2", "8.1", "7.0"]:
         depends_on("py-carputils@oc" + ver, when="@" + ver + " +carputils")
         depends_on("meshtool@oc" + ver, when="@" + ver + " +meshtool")
 

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -19,6 +19,7 @@ class PyCarputils(PythonPackage):
 
     version("master", branch="master")
     # Version to use with openCARP releases
+    version("octest", commit="c40783d884de5ad8ae1b5102b68013b28e14cbe4")
     version("oc15.0", commit="50e2580b3f75711388eb55982a9b43871c3201f3")
     version("oc13.0", commit="216c3802c2ac2d14c739164dcd57f2e59aa2ede3")
     version("oc12.0", commit="4d7a1f0c604a2ad232e70cf9aa3a8daff5ffb195")


### PR DESCRIPTION
Add a new version for the packages of the openCARP ecosystem, opencarp, meshtool and py-carputils.