### PR TITLE
[do not merge] env-view command based on 0.22.1

### DIFF
--- a/lib/spack/spack/cmd/env_view.py
+++ b/lib/spack/spack/cmd/env_view.py
@@ -58,7 +58,15 @@ def _specs_for_view(env):
         concrete_roots, order="topo", deptype=deptype, key=traverse.by_dag_hash
     )
 
-    return [x for x in specs if x.installed]
+    selected = list()
+    for x in specs:
+        if not x.installed:
+            continue
+        if hasattr(x.package, "tags") and "runtime" in x.package.tags:
+            continue
+        selected.append(x)
+
+    return selected
 
 
 def env_view(parser, args):

--- a/lib/spack/spack/cmd/env_view.py
+++ b/lib/spack/spack/cmd/env_view.py
@@ -1,0 +1,97 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import llnl.util.tty as tty
+from llnl.util.link_tree import MergeConflictError
+
+import spack.cmd
+import spack.environment as ev
+import spack.schema.projections
+import spack.store
+from spack import traverse
+from spack.config import validate
+from spack.filesystem_view import YamlFilesystemView
+from spack.util import spack_yaml as s_yaml
+
+description = "Create a view based on all specs in an environment"
+section = "environments"
+level = "short"
+
+
+def setup_parser(sp):
+    setup_parser.parser = sp
+
+    sp.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="if not verbose only warnings/errors will be printed",
+    )
+    sp.add_argument(
+        "-e",
+        "--exclude",
+        action="append",
+        default=[],
+        help="exclude packages with names matching the given regex pattern",
+    )
+
+    sp.add_argument(
+        "--projection-file",
+        dest="projection_file",
+        type=spack.cmd.extant_file,
+        help="initialize view using projections from file",
+    )
+    sp.add_argument("-i", "--ignore-conflicts", action="store_true")
+
+    sp.add_argument("path", nargs=1, help="path to file system view directory")
+
+
+def _specs_for_view(env):
+    deptype = ("link", "run")
+
+    concrete_roots = env.concrete_roots()
+
+    specs = traverse.traverse_nodes(
+        concrete_roots, order="topo", deptype=deptype, key=traverse.by_dag_hash
+    )
+
+    return [x for x in specs if x.installed]
+
+
+def env_view(parser, args):
+    path = args.path[0]
+
+    if args.projection_file:
+        with open(args.projection_file, "r") as f:
+            projections_data = s_yaml.load(f)
+            validate(projections_data, spack.schema.projections.schema)
+            ordered_projections = projections_data["projections"]
+    else:
+        ordered_projections = {}
+
+    view = YamlFilesystemView(
+        path,
+        spack.store.STORE.layout,
+        projections=ordered_projections,
+        ignore_conflicts=getattr(args, "ignore_conflicts", False),
+        link_type="symlink",
+        verbose=args.verbose,
+    )
+
+    env = ev.active_environment()
+    if not env:
+        tty.die("View creation requires specs unless you are in an environment")
+    specs = _specs_for_view(env)
+
+    try:
+        view.add_specs(*specs, with_dependencies=False, exclude=args.exclude)
+    except MergeConflictError:
+        tty.info(
+            "Some file blocked the merge, adding the '-i' flag will "
+            "ignore this conflict. For more information see e.g. "
+            "https://github.com/spack/spack/issues/9029"
+        )
+        raise

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -241,10 +241,22 @@ class FilesystemView:
         raise NotImplementedError
 
     def get_all_specs(self):
-        """
-        Get all specs currently active in this view.
-        """
-        raise NotImplementedError
+        md_dirs = []
+        for root, dirs, files in os.walk(self._root):
+            if spack.store.STORE.layout.metadata_dir in dirs:
+                md_dirs.append(os.path.join(root, spack.store.STORE.layout.metadata_dir))
+
+        specs = []
+        for md_dir in md_dirs:
+            if os.path.exists(md_dir):
+                for name_dir in os.listdir(md_dir):
+                    filename = os.path.join(
+                        md_dir, name_dir, spack.store.STORE.layout.spec_file_name
+                    )
+                    spec = get_spec_from_file(filename)
+                    if spec:
+                        specs.append(spec)
+        return specs
 
     def get_spec(self, spec):
         """
@@ -543,24 +555,6 @@ class YamlFilesystemView(FilesystemView):
         if proj:
             return os.path.join(self._root, locator_spec.format_path(proj))
         return self._root
-
-    def get_all_specs(self):
-        md_dirs = []
-        for root, dirs, files in os.walk(self._root):
-            if spack.store.STORE.layout.metadata_dir in dirs:
-                md_dirs.append(os.path.join(root, spack.store.STORE.layout.metadata_dir))
-
-        specs = []
-        for md_dir in md_dirs:
-            if os.path.exists(md_dir):
-                for name_dir in os.listdir(md_dir):
-                    filename = os.path.join(
-                        md_dir, name_dir, spack.store.STORE.layout.spec_file_name
-                    )
-                    spec = get_spec_from_file(filename)
-                    if spec:
-                        specs.append(spec)
-        return specs
 
     def get_conflicts(self, *specs):
         """

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -313,6 +313,9 @@ class NameValueModifier:
         """Apply the modification to the mapping passed as input"""
         raise NotImplementedError("must be implemented by derived classes")
 
+    def __hash__(self):
+        return hash((self.name, self.value, self.separator))
+
 
 class SetEnv(NameValueModifier):
     __slots__ = ("force", "raw")

--- a/scripts/whole-env-module.py
+++ b/scripts/whole-env-module.py
@@ -1,0 +1,101 @@
+import argparse
+import os
+
+from llnl.util.lang import dedupe
+
+import spack.environment as ev
+import spack.environment.shell
+import spack.paths
+import spack.user_environment as uenv
+from spack.util.environment import EnvironmentModifications
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate sourcing script")
+    parser.add_argument("path", type=str, help="Where to generate the file")
+    parser.add_argument(
+        "--view-input",
+        dest="view_input",
+        type=str,
+        help="If provided, designate a view to create the module for",
+    )
+    args = parser.parse_args()
+    generate_module(args)
+
+
+def generate_module(args):
+    env_mods = EnvironmentModifications()
+
+    if args.view_input:
+        if not os.path.isdir(args.view_input):
+            raise Exception(
+                f"Specified --view-input {args.view_input} does not exist as a directory"
+            )
+
+        descriptor = ev.environment.ViewDescriptor(base_path=args.view_input, root=args.view_input)
+
+        env_mods.extend(uenv.unconditional_environment_modifications(descriptor))
+        view = descriptor.view()
+        env_mods.extend(
+            uenv.environment_modifications_for_specs(*list(view.get_all_specs()), view=view)
+        )
+
+        # Note: you cannot encode PruneDuplicatePaths into a direct lmod action
+        # so instead, I run dedupe on the environment modifications.
+        # This would be incorrect if for example you had an action sequence like
+        # [x, undo(x), x]; you could sidestep that particular issue by reversing
+        # de-duping, and then re-reversing. Not sure if other effects might be
+        # more subtle
+        env_mods.env_modifications = list(dedupe(env_mods.env_modifications))
+    else:
+        active_env = ev.active_environment()
+        if not active_env:
+            raise Exception("An active env is required unless --view-input is specified")
+
+        view_id = None
+        if active_env.has_view(ev.default_view_name):
+            view_id = ev.default_view_name
+        else:
+            raise Exception(f"{active_env.name} does not have a default view")
+
+        env_mods.extend(spack.environment.shell.activate(env=active_env, view=view_id))
+
+    context = {"environment_modifications": [(type(x).__name__, x) for x in env_mods]}
+
+    import jinja2
+
+    template = jinja2.Template(lmod_template())
+    text = template.render(context)
+
+    if os.path.exists(args.path):
+        raise Exception(f"Already exists {args.path}")
+    with open(args.path, "w") as f:
+        f.write(text)
+
+
+def lmod_template():
+    return """\
+{% block environment %}
+{% for command_name, cmd in environment_modifications %}
+{% if command_name == 'PrependPath' %}
+prepend_path("{{ cmd.name }}", "{{ cmd.value }}", "{{ cmd.separator }}")
+{% elif command_name in ('AppendPath', 'AppendFlagsEnv') %}
+append_path("{{ cmd.name }}", "{{ cmd.value }}", "{{ cmd.separator }}")
+{% elif command_name in ('RemovePath', 'RemoveFlagsEnv') %}
+remove_path("{{ cmd.name }}", "{{ cmd.value }}", "{{ cmd.separator }}")
+{% elif command_name == 'SetEnv' %}
+setenv("{{ cmd.name }}", "{{ cmd.value }}")
+{% elif command_name == 'UnsetEnv' %}
+unsetenv("{{ cmd.name }}")
+{% endif %}
+{% endfor %}
+{# Make sure system man pages are enabled by appending trailing delimiter to MANPATH #}
+{% if has_manpath_modifications %}
+append_path("MANPATH", "", ":")
+{% endif %}
+{% endblock %}
+"""
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/whole-env-module.py
+++ b/scripts/whole-env-module.py
@@ -38,7 +38,7 @@ def generate_module(args):
         env_mods.extend(uenv.unconditional_environment_modifications(descriptor))
         view = descriptor.view(new=view_input)
         specs_to_consider = list(view.get_all_specs())
-        specs_to_consider.sort(key=lambda s: len(s.traverse()))
+        specs_to_consider.sort(key=lambda s: len(list(s.traverse())))
         env_mods.extend(
             uenv.environment_modifications_for_specs(*specs_to_consider, view=view)
         )

--- a/scripts/whole-env-module.py
+++ b/scripts/whole-env-module.py
@@ -1,8 +1,10 @@
 import argparse
 import os
+import tempfile
 
 from llnl.util.lang import dedupe
 
+import spack.database as db
 import spack.environment as ev
 import spack.environment.shell
 import spack.paths
@@ -23,6 +25,15 @@ def main():
     generate_module(args)
 
 
+def _associate_specs(specs):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        database = db.Database(temp_dir)
+        for spec in specs:
+            database.add(spec, directory_layout=None)
+        database._read()
+        return set(database.query())
+
+
 def generate_module(args):
     env_mods = EnvironmentModifications()
 
@@ -38,15 +49,9 @@ def generate_module(args):
         env_mods.extend(uenv.unconditional_environment_modifications(descriptor))
         view = descriptor.view(new=view_input)
         specs_to_consider = list(view.get_all_specs())
-        specs_to_consider.sort(key=lambda s: len(list(s.traverse())))
-        visited = set()
-        not_contained = list()
-        for spec in reversed(specs_to_consider):
-            if spec in visited:
-                continue
-            not_contained.append(spec)
-            visited.update(spec.traverse())
-        specs_to_consider = not_contained
+
+        specs_to_consider = _associate_specs(specs_to_consider)
+
         env_mods.extend(
             uenv.environment_modifications_for_specs(*specs_to_consider, view=view)
         )

--- a/scripts/whole-env-module.py
+++ b/scripts/whole-env-module.py
@@ -32,10 +32,11 @@ def generate_module(args):
                 f"Specified --view-input {args.view_input} does not exist as a directory"
             )
 
-        descriptor = ev.environment.ViewDescriptor(base_path=args.view_input, root=args.view_input)
+        view_input = os.path.abspath(args.view_input)
+        descriptor = ev.environment.ViewDescriptor(base_path=view_input, root=view_input)
 
         env_mods.extend(uenv.unconditional_environment_modifications(descriptor))
-        view = descriptor.view()
+        view = descriptor.view(new=view_input)
         env_mods.extend(
             uenv.environment_modifications_for_specs(*list(view.get_all_specs()), view=view)
         )

--- a/scripts/whole-env-module.py
+++ b/scripts/whole-env-module.py
@@ -47,8 +47,6 @@ def generate_module(args):
             not_contained.append(spec)
             visited.update(spec.traverse())
         specs_to_consider = not_contained
-        #tmp_map = dict((x.name, x) for x in specs_to_consider)
-        #import pdb; pdb.set_trace()
         env_mods.extend(
             uenv.environment_modifications_for_specs(*specs_to_consider, view=view)
         )

--- a/scripts/whole-env-module.py
+++ b/scripts/whole-env-module.py
@@ -37,8 +37,10 @@ def generate_module(args):
 
         env_mods.extend(uenv.unconditional_environment_modifications(descriptor))
         view = descriptor.view(new=view_input)
+        specs_to_consider = list(view.get_all_specs())
+        specs_to_consider.sort(key=lambda s: len(s.traverse()))
         env_mods.extend(
-            uenv.environment_modifications_for_specs(*list(view.get_all_specs()), view=view)
+            uenv.environment_modifications_for_specs(*specs_to_consider, view=view)
         )
 
         # Note: you cannot encode PruneDuplicatePaths into a direct lmod action

--- a/scripts/whole-env-module.py
+++ b/scripts/whole-env-module.py
@@ -39,6 +39,16 @@ def generate_module(args):
         view = descriptor.view(new=view_input)
         specs_to_consider = list(view.get_all_specs())
         specs_to_consider.sort(key=lambda s: len(list(s.traverse())))
+        visited = set()
+        not_contained = list()
+        for spec in reversed(specs_to_consider):
+            if spec in visited:
+                continue
+            not_contained.append(spec)
+            visited.update(spec.traverse())
+        specs_to_consider = not_contained
+        #tmp_map = dict((x.name, x) for x in specs_to_consider)
+        #import pdb; pdb.set_trace()
         env_mods.extend(
             uenv.environment_modifications_for_specs(*specs_to_consider, view=view)
         )


### PR DESCRIPTION
Replacement for https://github.com/spack/spack/pull/43061 (based on latest v0.22.1)

With an active environment, you can do 

```
spack env-view X
```

to create a view in `X` that would match `spack env view enable <path>`, but is not managed by the Spack environment.

You can then do

```
spack -E python scripts/whole-env-module.py --view-input X Y
```

To generate a simplified module Y that adds the view to the user's shell (and also performs custom env modifications defined by packages in that view).

This is based off of the `releases/v0.22` branch to support a user who needs that branch.