### PR TITLE
gfsio: add v1.4.2

### DIFF
--- a/var/spack/repos/builtin/packages/gfsio/package.py
+++ b/var/spack/repos/builtin/packages/gfsio/package.py
@@ -19,11 +19,14 @@ class Gfsio(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
     version("develop", branch="develop")
+    version("1.4.2", sha256="1e92ba60c603a8d3019b2aa8134fb3a69e078b2d9398990638576d6c5aea4beb")
     version("1.4.1", sha256="eab106302f520600decc4f9665d7c6a55e7b4901fab6d9ef40f29702b89b69b1")
 
     depends_on("fortran", type="build")
 
     depends_on("pfunit", type="test")
+
+    conflicts("%oneapi", when="@:1.4.1", msg="Requires @1.4.2: for Intel oneAPI")
 
     def cmake_args(self):
         args = [self.define("ENABLE_TESTS", self.run_tests)]


### PR DESCRIPTION
This PR adds v1.4.2 of gfsio, which adds Intel oneAPI support. No other variant changes etc.