### PR TITLE
sfcio: add v1.4.2

### DIFF
--- a/var/spack/repos/builtin/packages/sfcio/package.py
+++ b/var/spack/repos/builtin/packages/sfcio/package.py
@@ -19,12 +19,15 @@ class Sfcio(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
     version("develop", branch="develop")
+    version("1.4.2", sha256="bfde52320b836886a766ff8d0d6707b8a533c903b947f8b49250c544aaccaaac")
     version("1.4.1", sha256="d9f900cf18ec1a839b4128c069b1336317ffc682086283443354896746b89c59")
 
     depends_on("fortran", type="build")
 
     depends_on("pfunit", type="test")
 
+    conflicts("%oneapi", when="@:1.4.1", msg="Requires @1.4.2: for Intel oneAPI")
+    
     def cmake_args(self):
         args = [self.define("ENABLE_TESTS", self.run_tests)]
         return args

--- a/var/spack/repos/builtin/packages/sfcio/package.py
+++ b/var/spack/repos/builtin/packages/sfcio/package.py
@@ -27,7 +27,7 @@ class Sfcio(CMakePackage):
     depends_on("pfunit", type="test")
 
     conflicts("%oneapi", when="@:1.4.1", msg="Requires @1.4.2: for Intel oneAPI")
-    
+
     def cmake_args(self):
         args = [self.define("ENABLE_TESTS", self.run_tests)]
         return args


### PR DESCRIPTION
Add v1.4.2 for sfcio, which adds Intel oneAPI support. No other variant changes etc.