### PR TITLE
Fix missing #include <cstdint> when compiling Trilinos 13.4.0 with GCC13

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/cstdint_gcc13.patch
+++ b/var/spack/repos/builtin/packages/trilinos/cstdint_gcc13.patch
@@ -1,0 +1,33 @@
+diff -Naur spack-src.orig/packages/kokkos/core/src/impl/Kokkos_MemoryPool.cpp spack-src/packages/kokkos/core/src/impl/Kokkos_MemoryPool.cpp
+--- spack-src.orig/packages/kokkos/core/src/impl/Kokkos_MemoryPool.cpp	2024-09-02 10:53:10.022724683 +0200
++++ spack-src/packages/kokkos/core/src/impl/Kokkos_MemoryPool.cpp	2024-09-02 10:57:03.312228742 +0200
+@@ -44,6 +44,7 @@
+ 
+ #include <impl/Kokkos_Error.hpp>
+ 
++#include <cstdint>
+ #include <ostream>
+ #include <sstream>
+ 
+diff -Naur spack-src.orig/packages/teuchos/core/src/Teuchos_BigUIntDecl.hpp spack-src/packages/teuchos/core/src/Teuchos_BigUIntDecl.hpp
+--- spack-src.orig/packages/teuchos/core/src/Teuchos_BigUIntDecl.hpp	2024-09-02 10:53:50.098010896 +0200
++++ spack-src/packages/teuchos/core/src/Teuchos_BigUIntDecl.hpp	2024-09-02 10:51:17.777157344 +0200
+@@ -42,6 +42,7 @@
+ #ifndef TEUCHOS_BIG_UINT_DECL_HPP
+ #define TEUCHOS_BIG_UINT_DECL_HPP
+ 
++#include <cstdint>
+ #include <iosfwd>
+ 
+ /*! \file Teuchos_BigUIntDecl.hpp
+diff -Naur spack-src.orig/packages/teuchos/core/src/Teuchos_PrintDouble.cpp spack-src/packages/teuchos/core/src/Teuchos_PrintDouble.cpp
+--- spack-src.orig/packages/teuchos/core/src/Teuchos_PrintDouble.cpp	2024-09-02 10:54:02.240401775 +0200
++++ spack-src/packages/teuchos/core/src/Teuchos_PrintDouble.cpp	2024-09-02 10:51:34.110672927 +0200
+@@ -42,6 +42,7 @@
+ #include "Teuchos_PrintDouble.hpp"
+ #include "Teuchos_BigUInt.hpp"
+ 
++#include <cstdint>
+ #include <cstring>
+ 
+ namespace Teuchos {

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -514,6 +514,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         "0001-use-the-gcnArchName-inplace-of-gcnArch-as-gcnArch-is.patch",
         when="@15.0.0 ^hip@6.0 +rocm",
     )
+    patch("cstdint_gcc13.patch", when="@13.4.0:13.4.1 %gcc@13.0.0:")
 
     # Allow building with +teko gotype=long
     patch(


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
