### PR TITLE
directory_layout: delete dead code

### DIFF
--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -14,7 +14,6 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import llnl.util.filesystem as fs
-import llnl.util.tty as tty
 from llnl.util.symlink import readlink
 
 import spack.config
@@ -152,20 +151,9 @@ class DirectoryLayout:
     def spec_file_path(self, spec):
         """Gets full path to spec file"""
         _check_concrete(spec)
-        # Attempts to convert to JSON if possible.
-        # Otherwise just returns the YAML.
         yaml_path = os.path.join(self.metadata_path(spec), self._spec_file_name_yaml)
         json_path = os.path.join(self.metadata_path(spec), self.spec_file_name)
-        if os.path.exists(yaml_path) and fs.can_write_to_dir(yaml_path):
-            self.write_spec(spec, json_path)
-            try:
-                os.remove(yaml_path)
-            except OSError as err:
-                tty.debug("Could not remove deprecated {0}".format(yaml_path))
-                tty.debug(err)
-        elif os.path.exists(yaml_path):
-            return yaml_path
-        return json_path
+        return yaml_path if os.path.exists(yaml_path) else json_path
 
     def deprecated_file_path(self, deprecated_spec, deprecator_spec=None):
         """Gets full path to spec file for deprecated spec
@@ -199,17 +187,7 @@ class DirectoryLayout:
             deprecated_spec.dag_hash() + "_" + self.spec_file_name,
         )
 
-        if os.path.exists(yaml_path) and fs.can_write_to_dir(yaml_path):
-            self.write_spec(deprecated_spec, json_path)
-            try:
-                os.remove(yaml_path)
-            except (IOError, OSError) as err:
-                tty.debug("Could not remove deprecated {0}".format(yaml_path))
-                tty.debug(err)
-        elif os.path.exists(yaml_path):
-            return yaml_path
-
-        return json_path
+        return yaml_path if os.path.exists(yaml_path) else json_path
 
     @contextmanager
     def disable_upstream_check(self):


### PR DESCRIPTION
There was an attempt to turn spec.yaml into spec.json, but the branch was
always false due to `isdir(path/to/spec.yaml)`.

Probably better to leave prefixes immutable anyways, and it's unexpected to
have a getter mutate the file system.

