### PR TITLE
Concretizer: fix duplicate count when strategy=full

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -95,10 +95,9 @@ unify(SetID, PackageName) :- unification_set(SetID, node(_, PackageName)).
 unification_set("root", PackageNode) :- attr("root", PackageNode).
 unification_set(SetID, ChildNode) :- attr("depends_on", ParentNode, ChildNode, Type), Type != "build", unification_set(SetID, ParentNode).
 
-unification_set(("build", node(X, Child)), node(X, Child))
+unification_set(("build", ParentNode), node(X, Child))
   :- attr("depends_on", ParentNode, node(X, Child), Type),
      Type == "build",
-     multiple_unification_sets(Child),
      unification_set(SetID, ParentNode).
 
 unification_set("generic_build", node(X, Child))

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2668,6 +2668,13 @@ class TestConcretizeSeparately:
         gmake = s["python"].dependencies(name="gmake", deptype="build")
         assert len(gmake) == 1 and gmake[0].satisfies("@=3.0")
 
+    @pytest.mark.parametrize("strategy", ["none", "minimal", "full"])
+    def test_two_setuptools_with_run(self, strategy):
+        """Tests that concretization fails for mixed build/run dependencies on build tools."""
+        spack.config.CONFIG.set("concretizer:duplicates:strategy", strategy)
+        with pytest.raises((spack.error.UnsatisfiableSpecError, vt.InvalidVariantForSpecError)):
+            _ = Spec("py-shapely ^py-numpy+rundep").concretized()
+
     def test_solution_without_cycles(self):
         """Tests that when we concretize a spec with cycles, a fallback kicks in to recompute
         a solution without cycles.

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2675,10 +2675,7 @@ class TestConcretizeSeparately:
         with pytest.raises((spack.error.UnsatisfiableSpecError, vt.InvalidVariantForSpecError)):
             _ = Spec("py-shapely ^py-numpy+rundep").concretized()
 
-    @pytest.mark.parametrize("strategy", [
-        "minimal",
-        pytest.param("full", marks=pytest.mark.xfail(reason="Broken, needs to be fixed")),
-    ])
+    @pytest.mark.parametrize("strategy", ["minimal", "full"])
     def test_two_cmake_with_dep_gmake(self, strategy):
         """Tests that we can concretize separate build dependencies, when we
         are dealing with nested build tools.
@@ -2707,10 +2704,7 @@ class TestConcretizeSeparately:
         gmake = seemake[0].dependencies(name="gmake")
         assert len(gmake) == 1 and gmake[0].satisfies("@=3.0")
 
-    @pytest.mark.parametrize(
-        "strategy",
-        [pytest.param("full", marks=pytest.mark.xfail(reason="Broken, needs to be fixed"))],
-    )
+    @pytest.mark.parametrize("strategy", ["full"])
     def test_two_cmake_with_run_dep(self, strategy):
         """Tests that we can concretize separate build dependencies with conflicting
         (non-build-tool) dependencies in the build-tool stack.
@@ -2739,10 +2733,7 @@ class TestConcretizeSeparately:
         curl = seemake[0].dependencies(name="curl")
         assert len(curl) == 1 and curl[0].satisfies("@=3.0")
 
-    @pytest.mark.parametrize(
-        "strategy",
-        [pytest.param("full", marks=pytest.mark.xfail(reason="Broken, needs to be fixed"))],
-    )
+    @pytest.mark.parametrize("strategy", ["full"])
     def test_two_cmake_with_transient_run_dep(self, strategy):
         """Tests that we can concretize separate build dependencies with conflicting
         (non-build-tool) dependencies of nested build dependencies in the build-tool stack.

--- a/var/spack/repos/duplicates.test/packages/buildtool/package.py
+++ b/var/spack/repos/duplicates.test/packages/buildtool/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class Buildtool(Package):
+    """A build tool with a run-time dependency."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/tdep-1.0.tar.gz"
+
+    tags = ["build-tools"]
+
+    version("4.0", md5="0123456789abcdef0123456789abcdef")
+    version("3.0", md5="0123456789abcdef0123456789abcdef")
+
+    depends_on("curl@4", when="@4", type=("build", "link", "run"))
+    depends_on("curl@3", when="@3", type=("build", "link", "run"))

--- a/var/spack/repos/duplicates.test/packages/compiled-intermediate-tool/package.py
+++ b/var/spack/repos/duplicates.test/packages/compiled-intermediate-tool/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class CompiledIntermediateTool(Package):
+    """A cmake-built intermediate tool."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/tdep-1.0.tar.gz"
+
+    version("4.0", md5="0123456789abcdef0123456789abcdef")
+    version("3.0", md5="0123456789abcdef0123456789abcdef")
+
+    depends_on("seemake@4", when="@4", type="build")
+    depends_on("seemake@3", when="@3", type="build")

--- a/var/spack/repos/duplicates.test/packages/compiled-tool/package.py
+++ b/var/spack/repos/duplicates.test/packages/compiled-tool/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class CompiledTool(Package):
+    """A cmake-built tool."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/tdep-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    depends_on("seemake@4", type="build")
+    depends_on("compiled-intermediate-tool@3", type=("build"))

--- a/var/spack/repos/duplicates.test/packages/curl/package.py
+++ b/var/spack/repos/duplicates.test/packages/curl/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class Curl(Package):
+    """Simple tool, used as a run-time dependency"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/tdep-1.0.tar.gz"
+
+    version("4.0", md5="0123456789abcdef0123456789abcdef")
+    version("3.0", md5="0123456789abcdef0123456789abcdef")

--- a/var/spack/repos/duplicates.test/packages/py-numpy/package.py
+++ b/var/spack/repos/duplicates.test/packages/py-numpy/package.py
@@ -15,6 +15,9 @@ class PyNumpy(Package):
 
     version("1.25.0", md5="0123456789abcdef0123456789abcdef")
 
+    variant("rundep", default=False, description="activate run dependency on py-setuptools")
+
     extends("python")
-    depends_on("py-setuptools@=59", type=("build", "run"))
+    depends_on("py-setuptools@=59", type=("build"))
+    depends_on("py-setuptools@=59", type=("build", "run"), when="+rundep")
     depends_on("gmake@4.1", type="build")

--- a/var/spack/repos/duplicates.test/packages/py-shapely/package.py
+++ b/var/spack/repos/duplicates.test/packages/py-shapely/package.py
@@ -15,4 +15,4 @@ class PyShapely(Package):
 
     extends("python")
     depends_on("py-numpy", type=("build", "link", "run"))
-    depends_on("py-setuptools@=60", type="build")
+    depends_on("py-setuptools@=60", type=("build", "run"))

--- a/var/spack/repos/duplicates.test/packages/seemake/package.py
+++ b/var/spack/repos/duplicates.test/packages/seemake/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class Seemake(Package):
+    """A build tool."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/tdep-1.0.tar.gz"
+
+    tags = ["build-tools"]
+
+    version("4.0", md5="0123456789abcdef0123456789abcdef")
+    version("3.0", md5="0123456789abcdef0123456789abcdef")
+
+    depends_on("gmake@4", when="@4", type=("build"))
+    depends_on("gmake@3", when="@3", type=("build"))

--- a/var/spack/repos/duplicates.test/packages/seemake/package.py
+++ b/var/spack/repos/duplicates.test/packages/seemake/package.py
@@ -13,8 +13,17 @@ class Seemake(Package):
 
     tags = ["build-tools"]
 
+    variant("rundep", default=False, description="activate run-time dependency")
+    variant("nestedrundep", default=False, description="activate nested run-time dependency")
+
     version("4.0", md5="0123456789abcdef0123456789abcdef")
     version("3.0", md5="0123456789abcdef0123456789abcdef")
 
     depends_on("gmake@4", when="@4", type=("build"))
     depends_on("gmake@3", when="@3", type=("build"))
+
+    depends_on("curl@4", when="@4+rundep", type=("build", "link", "run"))
+    depends_on("curl@3", when="@3+rundep", type=("build", "link", "run"))
+
+    depends_on("buildtool@4", when="@4+nestedrundep", type=("build"))
+    depends_on("buildtool@3", when="@3+nestedrundep", type=("build"))


### PR DESCRIPTION
Depends on #46106 

This PR resolves the error reported by @muffgaga in https://github.com/spack/spack/pull/46106#issuecomment-2320393133 when using the "full" concretization strategy.

The previous implementation did not always correctly handle the selection of packages that were allowed to have multiple nodes in the DAG, because `self._total_build` is a set, so packages that appeared multiple times in the build subgraph were not counted correctly.

With this PR, the `FullDuplicatesCounter` instead:
- counts the number of dependents (incoming edges) of each package in the DAG
- selects all the packages tagged build-tool that have more than 1 incoming edge
- the subGraphs of those packages are allowed to have multiple possible nodes

Additionally, this adds 3 tests (that would fail before the PR):
- a test that covers concretization of nested build-tool dependencies (initially written by @muffgaga to test #46106)
-  two tests for scenarios where packages can only be concretized using the "full" concretization strategy, because two different versions of a build-tool are needed, but have conflicting dependencies