### PR TITLE
llvm: be more strict with detection

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -652,7 +652,7 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
 
     @classproperty
     def executables(cls):
-        return super().executables + ["^ld.lld(-[\d][\d]*)?$", "^lldb(-[\d][\d]*)?$"]
+        return super().executables + [r"^ld.lld(-[\d][\d]*)?$", r"^lldb(-[\d][\d]*)?$"]
 
     @classmethod
     def determine_version(cls, exe):

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -30,7 +30,7 @@ class LlvmDetection(PackageBase):
         reject = re.compile(
             r"-(vscode|cpp|cl|gpu|tidy|rename|scan-deps|format|refactor|offload|"
             r"check|query|doc|move|extdef|apply|reorder|change-namespace|"
-            r"include-fixer|import-test)"
+            r"include-fixer|import-test|dab|server)"
         )
         return [x for x in exes_in_prefix if not reject.search(x)]
 
@@ -652,7 +652,7 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
 
     @classproperty
     def executables(cls):
-        return super().executables + ["ld.lld", "lldb"]
+        return super().executables + ["^ld.lld(-[\d][\d]*)?$", "^lldb(-[\d][\d]*)?$"]
 
     @classmethod
     def determine_version(cls, exe):


### PR DESCRIPTION
fixes #46177

This change prevents issues like the one reported in #46177, where calling an executable might hang the process.
