### PR TITLE
magma: Updating git repo location

### DIFF
--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -14,7 +14,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
     """
 
     homepage = "https://icl.utk.edu/magma/"
-    git = "https://bitbucket.org/icl/magma"
+    git = "https://github.com/icl-utk-edu/magma"
     url = "https://icl.utk.edu/projectsfiles/magma/downloads/magma-2.2.0.tar.gz"
     maintainers("stomov", "luszczek", "G-Ragghianti")
 


### PR DESCRIPTION
The git repo for MAGMA has moved to github.
