### PR TITLE
Bug fixes for building py-netcdf4 and py-ruamel-yaml-clib with apple-clang@15

### DIFF
--- a/var/spack/repos/builtin/packages/py-netcdf4/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf4/package.py
@@ -59,7 +59,7 @@ class PyNetcdf4(PythonPackage):
 
     def flag_handler(self, name, flags):
         if name == "cflags":
-            if self.spec.satisfies("%oneapi"):
+            if self.spec.satisfies("%oneapi") or self.spec.satisfies("%apple-clang@15:"):
                 flags.append("-Wno-error=int-conversion")
 
         return flags, None, None

--- a/var/spack/repos/builtin/packages/py-ruamel-yaml-clib/package.py
+++ b/var/spack/repos/builtin/packages/py-ruamel-yaml-clib/package.py
@@ -28,6 +28,6 @@ class PyRuamelYamlClib(PythonPackage):
 
     def flag_handler(self, name, flags):
         if name == "cflags":
-            if self.spec.satisfies("%oneapi"):
+            if self.spec.satisfies("%oneapi") or self.spec.satisfies(" %apple-clang@15:"):
                 flags.append("-Wno-error=incompatible-function-pointer-types")
         return (flags, None, None)


### PR DESCRIPTION
The title has it all. These changes are required for building the two packages with `apple-clang@15` (tested on macOS). Credit to @srherbener who identified these changes.