### PR TITLE
Fix regular expressions wrt. llvm executables

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -30,7 +30,7 @@ class LlvmDetection(PackageBase):
         reject = re.compile(
             r"-(vscode|cpp|cl|gpu|tidy|rename|scan-deps|format|refactor|offload|"
             r"check|query|doc|move|extdef|apply|reorder|change-namespace|"
-            r"include-fixer|import-test|dab|server)"
+            r"include-fixer|import-test|dap|server)"
         )
         return [x for x in exes_in_prefix if not reject.search(x)]
 
@@ -652,7 +652,7 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
 
     @classproperty
     def executables(cls):
-        return super().executables + [r"^ld.lld(-[\d][\d]*)?$", r"^lldb(-[\d][\d]*)?$"]
+        return super().executables + [r"^ld\.lld(-\d+)?$", r"^lldb(-\d+)?$"]
 
     @classmethod
     def determine_version(cls, exe):


### PR DESCRIPTION
PR #46179 is aimed at fixing issue #46177.  It introduces a couple typos, though (e.g. `dab` instead of `dap`).  This PR addresses those.