### PR TITLE
charliecloud: fix libsquashfuse dependency

### DIFF
--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -150,9 +150,9 @@ class Charliecloud(AutotoolsPackage):
     with when("+squashfuse"):
         depends_on("libfuse@3:", type=("build", "run", "link"), when="@0.32:")
         depends_on("pkgconfig", type="build", when="@0.37:")
-        depends_on("squashfuse@0.1.105:0.2.0,0.4.0:", type="build", when="@0.36:")
-        depends_on("squashfuse@0.1.105:0.2.0,0.4.0", type="build", when="@0.35")
-        depends_on("squashfuse@0.1.105", type="build", when="@0.32:0.34")
+        depends_on("squashfuse@0.1.105:0.2.0,0.4.0:", type="link", when="@0.36:")
+        depends_on("squashfuse@0.1.105:0.2.0,0.4.0", type="link", when="@0.35")
+        depends_on("squashfuse@0.1.105", type="link", when="@0.32:0.34")
 
     def autoreconf(self, spec, prefix):
         which("bash")("autogen.sh")


### PR DESCRIPTION
Should have been a link dependency, not a build dependency.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
