### PR TITLE
boost: Conditionally include/exclude Boost.Json depending on Boost version

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -690,6 +690,9 @@ class Boost(Package):
         remove_if_in_list = lambda lib, libs: libs.remove(lib) if lib in libs else None
 
         # Remove libraries that the release version does not support
+        if not spec.satisfies("@1.75.0:"):
+            remove_if_in_list("json", with_libs)
+            remove_if_in_list("json", without_libs)
         if spec.satisfies("@1.69.0:"):
             remove_if_in_list("signals", with_libs)
             remove_if_in_list("signals", without_libs)


### PR DESCRIPTION
Boost.Json was added in 1.75.0 (https://www.boost.org/users/history/version_1_75_0.html).