### PR TITLE
Fix regression in spec format string for indiviual variants

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3894,9 +3894,12 @@ class Spec:
                 if part.startswith("_"):
                     raise SpecFormatStringError("Attempted to format private attribute")
                 else:
-                    if part == "variants" and isinstance(current, VariantMap):
+                    if isinstance(current, VariantMap):
                         # subscript instead of getattr for variant names
-                        current = current[part]
+                        try:
+                            current = current[part]
+                        except KeyError:
+                            raise SpecFormatStringError(f"Variant '{part}' does not exist")
                     else:
                         # aliases
                         if part == "arch":

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3891,42 +3891,45 @@ class Spec:
             for idx, part in enumerate(parts):
                 if not part:
                     raise SpecFormatStringError("Format string attributes must be non-empty")
-                elif part.startswith("_"):
+                if part.startswith("_"):
                     raise SpecFormatStringError("Attempted to format private attribute")
-                elif isinstance(current, VariantMap):
-                    # subscript instead of getattr for variant names
-                    try:
-                        current = current[part]
-                    except KeyError:
-                        raise SpecFormatStringError(f"Variant '{part}' does not exist")
                 else:
-                    # aliases
-                    if part == "arch":
-                        part = "architecture"
-                    elif part == "version" and not current.versions.concrete:
-                        # version (singular) requires a concrete versions list. Avoid
-                        # pedantic errors by using versions (plural) when not concrete.
-                        # These two are not entirely equivalent for pkg@=1.2.3:
-                        # - version prints '1.2.3'
-                        # - versions prints '=1.2.3'
-                        part = "versions"
-                    try:
-                        current = getattr(current, part)
-                    except AttributeError:
-                        raise SpecFormatStringError(
-                            f"Attempted to format attribute {attribute}. "
-                            f"Spec {'.'.join(parts[:idx])} has no attribute {part}"
-                        )
-                    if isinstance(current, vn.VersionList) and current == vn.any_version:
-                        # don't print empty version lists
+                    if isinstance(current, VariantMap):
+                        # subscript instead of getattr for variant names
+                        try:
+                            current = current[part]
+                        except KeyError:
+                            raise SpecFormatStringError(f"Variant '{part}' does not exist")
+                    else:
+                        # aliases
+                        if part == "arch":
+                            part = "architecture"
+                        elif part == "version":
+                            # version (singular) requires a concrete versions list. Avoid
+                            # pedantic errors by using versions (plural) when not concrete.
+                            # These two are not entirely equivalent for pkg@=1.2.3:
+                            # - version prints '1.2.3'
+                            # - versions prints '=1.2.3'
+                            if not current.versions.concrete:
+                                part = "versions"
+                        try:
+                            current = getattr(current, part)
+                        except AttributeError:
+                            parent = ".".join(parts[:idx])
+                            m = "Attempted to format attribute %s." % attribute
+                            m += "Spec %s has no attribute %s" % (parent, part)
+                            raise SpecFormatStringError(m)
+                        if isinstance(current, vn.VersionList):
+                            if current == vn.any_version:
+                                # don't print empty version lists
+                                return ""
+
+                    if callable(current):
+                        raise SpecFormatStringError("Attempted to format callable object")
+
+                    if current is None:
+                        # not printing anything
                         return ""
-
-                if callable(current):
-                    raise SpecFormatStringError("Attempted to format callable object")
-
-                if current is None:
-                    # not printing anything
-                    return ""
 
             # Set color codes for various attributes
             color = None

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3891,45 +3891,42 @@ class Spec:
             for idx, part in enumerate(parts):
                 if not part:
                     raise SpecFormatStringError("Format string attributes must be non-empty")
-                if part.startswith("_"):
+                elif part.startswith("_"):
                     raise SpecFormatStringError("Attempted to format private attribute")
+                elif isinstance(current, VariantMap):
+                    # subscript instead of getattr for variant names
+                    try:
+                        current = current[part]
+                    except KeyError:
+                        raise SpecFormatStringError(f"Variant '{part}' does not exist")
                 else:
-                    if isinstance(current, VariantMap):
-                        # subscript instead of getattr for variant names
-                        try:
-                            current = current[part]
-                        except KeyError:
-                            raise SpecFormatStringError(f"Variant '{part}' does not exist")
-                    else:
-                        # aliases
-                        if part == "arch":
-                            part = "architecture"
-                        elif part == "version":
-                            # version (singular) requires a concrete versions list. Avoid
-                            # pedantic errors by using versions (plural) when not concrete.
-                            # These two are not entirely equivalent for pkg@=1.2.3:
-                            # - version prints '1.2.3'
-                            # - versions prints '=1.2.3'
-                            if not current.versions.concrete:
-                                part = "versions"
-                        try:
-                            current = getattr(current, part)
-                        except AttributeError:
-                            parent = ".".join(parts[:idx])
-                            m = "Attempted to format attribute %s." % attribute
-                            m += "Spec %s has no attribute %s" % (parent, part)
-                            raise SpecFormatStringError(m)
-                        if isinstance(current, vn.VersionList):
-                            if current == vn.any_version:
-                                # don't print empty version lists
-                                return ""
-
-                    if callable(current):
-                        raise SpecFormatStringError("Attempted to format callable object")
-
-                    if current is None:
-                        # not printing anything
+                    # aliases
+                    if part == "arch":
+                        part = "architecture"
+                    elif part == "version" and not current.versions.concrete:
+                        # version (singular) requires a concrete versions list. Avoid
+                        # pedantic errors by using versions (plural) when not concrete.
+                        # These two are not entirely equivalent for pkg@=1.2.3:
+                        # - version prints '1.2.3'
+                        # - versions prints '=1.2.3'
+                        part = "versions"
+                    try:
+                        current = getattr(current, part)
+                    except AttributeError:
+                        raise SpecFormatStringError(
+                            f"Attempted to format attribute {attribute}. "
+                            f"Spec {'.'.join(parts[:idx])} has no attribute {part}"
+                        )
+                    if isinstance(current, vn.VersionList) and current == vn.any_version:
+                        # don't print empty version lists
                         return ""
+
+                if callable(current):
+                    raise SpecFormatStringError("Attempted to format callable object")
+
+                if current is None:
+                    # not printing anything
+                    return ""
 
             # Set color codes for various attributes
             color = None

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -689,6 +689,13 @@ class TestSpecSemantics:
             ("{/hash}", "/", lambda s: "/" + s.dag_hash()),
         ]
 
+        variants_segments = [
+            ("{variants.debug}", spec, "debug"),
+            ("{variants.foo}", spec, "foo"),
+            ("{^pkg-a.variants.bvv}", spec["pkg-a"], "bvv"),
+            ("{^pkg-a.variants.foo}", spec["pkg-a"], "foo"),
+        ]
+
         other_segments = [
             ("{spack_root}", spack.paths.spack_root),
             ("{spack_install}", spack.store.STORE.layout.root),
@@ -715,6 +722,12 @@ class TestSpecSemantics:
             assert spec.format(named_str) == getter(spec)
             callpath, fmt_str = depify("callpath", named_str, sigil)
             assert spec.format(fmt_str) == getter(callpath)
+
+        for named_str, test_spec, variant_name in variants_segments:
+            assert test_spec.format(named_str) == str(test_spec.variants[variant_name])
+            assert test_spec.format(named_str[:-1] + ".value}") == str(
+                test_spec.variants[variant_name].value
+            )
 
         for named_str, expected in other_segments:
             actual = spec.format(named_str)
@@ -775,6 +788,7 @@ class TestSpecSemantics:
             r"{dag_hash}",
             r"{foo}",
             r"{+variants.debug}",
+            r"{variants.this_variant_does_not_exist}",
         ],
     )
     def test_spec_formatting_bad_formats(self, default_mock_concretization, fmt_str):


### PR DESCRIPTION
Fix a regression in `{variants.X}` and `{variants.X.value}` spec format strings. I think it broke in Spack v0.22 #43712.

I also added some tests.

Before:

```console
$ spack spec --format '{name} {variants.pic}' zlib
==> Error: Attempted to format attribute variants.pic.Spec variants has no attribute pic
Traceback (most recent call last):
  File "/.../spack/lib/spack/spack/spec.py", line 3913, in format_attribute
    current = getattr(current, part)
              ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'VariantMap' object has no attribute 'pic'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/.../spack/lib/spack/spack/main.py", line 1070, in main
    return _main(argv)
           ^^^^^^^^^^^
  File "/.../spack/lib/spack/spack/main.py", line 1023, in _main
    return finish_parse_and_run(parser, cmd_name, args, env_format_error)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../spack/lib/spack/spack/main.py", line 1053, in finish_parse_and_run
    return _invoke_command(command, parser, args, unknown)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../spack/lib/spack/spack/main.py", line 650, in _invoke_command
    return_val = command(parser, args)
                 ^^^^^^^^^^^^^^^^^^^^^
  File "/.../spack/lib/spack/spack/cmd/spec.py", line 128, in spec
    print(output.format(args.format))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../spack/lib/spack/spack/spec.py", line 3949, in format
    return SPEC_FORMAT_RE.sub(format_attribute, format_string).strip()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../spack/lib/spack/spack/spec.py", line 3918, in format_attribute
    raise SpecFormatStringError(m)
spack.spec.SpecFormatStringError: Attempted to format attribute variants.pic.Spec variants has no attribute pic
```

After this fix (and before regression):

```console
$ spack spec --format '{name} {variants.pic}' zlib
zlib +pic
```


