### PR TITLE
expat: Add 2.6.3 with security fixes + deprecate vulnerable 2.6.2

### DIFF
--- a/var/spack/repos/builtin/packages/expat/package.py
+++ b/var/spack/repos/builtin/packages/expat/package.py
@@ -17,8 +17,16 @@ class Expat(AutotoolsPackage, CMakePackage):
 
     license("MIT")
 
-    version("2.6.2", sha256="9c7c1b5dcbc3c237c500a8fb1493e14d9582146dd9b42aa8d3ffb856a3b927e0")
-    # deprecate all releases before 2.6.2 because of security issues
+    version("2.6.3", sha256="b8baef92f328eebcf731f4d18103951c61fa8c8ec21d5ff4202fb6f2198aeb2d")
+    # deprecate all releases before 2.6.3 because of security issues
+    # CVE-2024-45490 (fixed in 2.6.3)
+    # CVE-2024-45491 (fixed in 2.6.3)
+    # CVE-2024-45492 (fixed in 2.6.3)
+    version(
+        "2.6.2",
+        sha256="9c7c1b5dcbc3c237c500a8fb1493e14d9582146dd9b42aa8d3ffb856a3b927e0",
+        deprecated=True,
+    )
     # CVE-2024-28757 (fixed in 2.6.2)
     version(
         "2.6.1",


### PR DESCRIPTION
```console
# wget https://github.com/libexpat/libexpat/releases/download/R_2_6_3/expat-2.6.3.tar.bz2
# sha256sum expat-2.6.3.tar.bz2
b8baef92f328eebcf731f4d18103951c61fa8c8ec21d5ff4202fb6f2198aeb2d  expat-2.6.3.tar.bz2
```

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
