### PR TITLE
pthreadpool: add the PIC flag

### DIFF
--- a/var/spack/repos/builtin/packages/pthreadpool/package.py
+++ b/var/spack/repos/builtin/packages/pthreadpool/package.py
@@ -52,10 +52,6 @@ class Pthreadpool(CMakePackage):
         placement="googlebenchmark",
     )
 
-    def setup_build_environment(self, env):
-        cflags = [self.compiler.cc_pic_flag]
-        env.set("CFLAGS", " ".join(cflags))
-
     def cmake_args(self):
         return [
             self.define("FXDIV_SOURCE_DIR", join_path(self.stage.source_path, "deps", "fxdiv")),
@@ -71,4 +67,5 @@ class Pthreadpool(CMakePackage):
             self.define("PTHREADPOOL_BUILD_BENCHMARKS", False),
             self.define("PTHREADPOOL_LIBRARY_TYPE", "static"),
             self.define("PTHREADPOOL_ALLOW_DEPRECATED_API", True),
+            self.define("CMAKE_POSITION_INDEPENDENT_CODE", True),
         ]

--- a/var/spack/repos/builtin/packages/pthreadpool/package.py
+++ b/var/spack/repos/builtin/packages/pthreadpool/package.py
@@ -52,6 +52,10 @@ class Pthreadpool(CMakePackage):
         placement="googlebenchmark",
     )
 
+    def setup_build_environment(self, env):
+        cflags = [self.compiler.cc_pic_flag]
+        env.set("CFLAGS", " ".join(cflags))
+
     def cmake_args(self):
         return [
             self.define("FXDIV_SOURCE_DIR", join_path(self.stage.source_path, "deps", "fxdiv")),


### PR DESCRIPTION
`pthreadpool` is a dependency of `py-torch`. On AlmaLinux9, compiling with the system compiler (GCC 11.4.1) it seems the PIC flag is needed, when compiling `py-torch` I get the following:
```
     4253      /usr/bin/ld: /pthreadpool/2023-08-29-t3vmkg/lib64/libpthreadpool.a(legacy-api.c.o): relocation R_X86_64_32 against `.text' can not be used when making a shared object; recompile with -fPIC
     4254      /usr/bin/ld: /pthreadpool/2023-08-29-t3vmkg/lib64/libpthreadpool.a(portable-api.c.o): relocation R_X86_64_32 against `.text' can not be used when making a shared object; recompile with -fPIC
     4255      /usr/bin/ld: /pthreadpool/2023-08-29-t3vmkg/lib64/libpthreadpool.a(pthreads.c.o): relocation R_X86_64_32 against `.text' can not be used when making a shared object; recompile with -fPIC
  >> 4256      collect2: error: ld returned 1 exit status
```

And adding this flag like I did in this PR fixes it. Building on Ubuntu 22.04 with GCC 11.4.0 I don't get this. This is also something new since I have been compiling `py-torch` for a while on AlmaLinux 9 and didn't have these issues. It seems it's happening with `py-torch` 2.4.0, since I have builds with 2.3.1 and I didn't have this issue with the same version of `pthreadpool`.

For this PR I can leave as it is and apply it always or we could apply it only if the version of `py-torch` is 2.4.0 or above.