### PR TITLE
awscli-v2: remove upperbound on cryptography

### DIFF
--- a/var/spack/repos/builtin/packages/awscli-v2/package.py
+++ b/var/spack/repos/builtin/packages/awscli-v2/package.py
@@ -23,7 +23,9 @@ class AwscliV2(PythonPackage):
         depends_on("py-flit-core@3.7.1:3.8.0")
         depends_on("py-colorama@0.2.5:0.4.6")
         depends_on("py-docutils@0.10:0.19")
-        depends_on("py-cryptography@3.3.2:40.0.1")
+        # Remove upper bound to enable Python 3.12 support
+        # depends_on("py-cryptography@3.3.2:40.0.1")
+        depends_on("py-cryptography@3.3.2:")
         depends_on("py-ruamel-yaml@0.15:0.17.21")
         depends_on("py-ruamel-yaml-clib@0.2:0.2.7", when="^python@:3.9")
         depends_on("py-prompt-toolkit@3.0.24:3.0.38")


### PR DESCRIPTION
Older cryptography did not support Python 3.12. I would like to build a single environment containing Python 3.12.

I tested awscli-v2 with cryptography 42.0.8 and it was able to download files without issue. I'm guessing these upper bounds are overzealous.