### PR TITLE
[WIP] py-cffi: remove Python upper bound

### DIFF
--- a/var/spack/repos/builtin/packages/py-cffi/package.py
+++ b/var/spack/repos/builtin/packages/py-cffi/package.py
@@ -34,6 +34,7 @@ class PyCffi(PythonPackage):
     depends_on("pkgconfig", type="build")
     depends_on("py-setuptools@66.1:", type="build", when="@1.17:")
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools", type="run", when="^python@3.12:")
     depends_on("py-pycparser", type=("build", "run"))
     depends_on("libffi")
 

--- a/var/spack/repos/builtin/packages/py-cffi/package.py
+++ b/var/spack/repos/builtin/packages/py-cffi/package.py
@@ -16,6 +16,7 @@ class PyCffi(PythonPackage):
 
     license("MIT")
 
+    version("1.17.1", sha256="1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824")
     version("1.16.0", sha256="bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0")
     version("1.15.1", sha256="d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9")
     version("1.15.0", sha256="920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954")
@@ -29,7 +30,9 @@ class PyCffi(PythonPackage):
 
     depends_on("c", type="build")
 
+    depends_on("python", type=("build", "link", "run"))
     depends_on("pkgconfig", type="build")
+    depends_on("py-setuptools@66.1:", type="build", when="@1.17:")
     depends_on("py-setuptools", type="build")
     depends_on("py-pycparser", type=("build", "run"))
     depends_on("libffi")

--- a/var/spack/repos/builtin/packages/py-cffi/package.py
+++ b/var/spack/repos/builtin/packages/py-cffi/package.py
@@ -27,12 +27,8 @@ class PyCffi(PythonPackage):
     version("1.10.0", sha256="b3b02911eb1f6ada203b0763ba924234629b51586f72a21faacc638269f4ced5")
     version("1.1.2", sha256="390970b602708c91ddc73953bb6929e56291c18a4d80f360afa00fad8b6f3339")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
-    # ./spack-src/cffi/ffiplatform.py has _hack_at_distutils which imports
-    # setuptools before distutils, but only on Windows. This could be made
-    # unconditional to support Python 3.12
-    depends_on("python@:3.11", type=("build", "run"))
     depends_on("pkgconfig", type="build")
     depends_on("py-setuptools", type="build")
     depends_on("py-pycparser", type=("build", "run"))


### PR DESCRIPTION
Trying to relax some of the constraints set on packages by @haampie to get more things to build with Python 3.12.

I was able to build cffi with Python 3.12, now let's see if something else later down the pipeline breaks.