### PR TITLE
py-tifffile: add v2024

### DIFF
--- a/var/spack/repos/builtin/packages/py-tifffile/package.py
+++ b/var/spack/repos/builtin/packages/py-tifffile/package.py
@@ -14,6 +14,7 @@ class PyTifffile(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2024.8.30", sha256="2c9508fe768962e30f87def61819183fb07692c258cb175b3c114828368485a4")
     version("2023.8.30", sha256="6a8c53b012a286b75d09a1498ab32f202f24cc6270a105b5d5911dc4426f162a")
     version(
         "2022.10.10", sha256="50b61ba943b866d191295bc38a00191c9fdab23ece063544c7f1a264e3f6aa8e"


### PR DESCRIPTION
Adds a version compatible with numpy 2