### PR TITLE
py-torchgeo: zipfile-deflate64 no longer required

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchgeo/package.py
+++ b/var/spack/repos/builtin/packages/py-torchgeo/package.py
@@ -162,7 +162,7 @@ class PyTorchgeo(PythonPackage):
         depends_on("py-radiant-mlhub@0.2.1:0.4", when="@:0.4.0")
         depends_on("py-rarfile@4:", when="@0.5")
         depends_on("py-rarfile@3:", when="@:0.4")
-        depends_on("py-zipfile-deflate64@0.2:", when="@0.2.1:")
+        depends_on("py-zipfile-deflate64@0.2:", when="@0.2.1:0.5")
 
     with when("+docs"), default_args(type="run"):
         depends_on("py-ipywidgets@7:")


### PR DESCRIPTION
Fixes a typo in my previous PR. I moved zipfile-deflate64 to the historical dependencies section, but I forgot to add an upper bound.