### PR TITLE
py-fluidfft and co: add new packages

### DIFF
--- a/var/spack/repos/builtin/packages/py-fluidfft-builder/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidfft-builder/package.py
@@ -17,4 +17,4 @@ class PyFluidfftBuilder(PythonPackage):
     version("0.0.2", sha256="c0af9ceca27ae3a00ccf2f160703be9e394d8b886b8a02653b6c0a12a4f54a90")
 
     depends_on("python@3.9:", type=("build", "run"))
-    depends_on("py-flit-core", type="build")
+    depends_on("py-flit-core@3.2:3", type="build")

--- a/var/spack/repos/builtin/packages/py-fluidfft-builder/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidfft-builder/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyFluidfftBuilder(PythonPackage):
+    """Fluidfft plugin dependencies"""
+
+    pypi = "fluidfft-builder/fluidfft_builder-0.0.2.tar.gz"
+
+    maintainers("paugier")
+    license("MIT", checked_by="paugier")
+
+    version("0.0.2", sha256="c0af9ceca27ae3a00ccf2f160703be9e394d8b886b8a02653b6c0a12a4f54a90")
+
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-flit-core", type="build")

--- a/var/spack/repos/builtin/packages/py-fluidfft-fftw/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidfft-fftw/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyFluidfftFftw(PythonPackage):
+    """Fluidfft plugin using fftw."""
+
+    pypi = "fluidfft_fftw/fluidfft_fftw-0.0.1.tar.gz"
+
+    maintainers("paugier")
+    license("CECILL-B", checked_by="paugier")
+
+    version("0.0.1", sha256="59967846e1d976508db30ff65987e9c1e6c024ec9c095849608ee8913b96d3ff")
+
+    with default_args(type=("build", "run")):
+        depends_on("python@3.9:")
+
+    with default_args(type="link"):
+        depends_on("fftw")
+
+    with default_args(type="build"):
+        depends_on("py-meson-python")
+        depends_on("py-transonic@0.6.4:")
+        depends_on("py-fluidfft-builder")
+
+    depends_on("py-fluidfft", type="run")

--- a/var/spack/repos/builtin/packages/py-fluidfft-fftwmpi/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidfft-fftwmpi/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyFluidfftFftwmpi(PythonPackage):
+    """Fluidfft plugin using fftwmpi."""
+
+    pypi = "fluidfft-fftwmpi/fluidfft_fftwmpi-0.0.1.tar.gz"
+
+    maintainers("paugier")
+    license("CECILL-B", checked_by="paugier")
+
+    version("0.0.1", sha256="af3c606852e991c2c1b3ea4f7558c69ab9138b713a7166a6eedf48ef1af660d3")
+
+    with default_args(type=("build", "run")):
+        extends("python@3.9:")
+        depends_on("py-mpi4py")
+
+    with default_args(type="link"):
+        depends_on("fftw")
+
+    with default_args(type="build"):
+        depends_on("py-meson-python")
+        depends_on("py-transonic@0.6.4:")
+        depends_on("py-fluidfft-builder")
+
+    depends_on("py-fluidfft", type="run")

--- a/var/spack/repos/builtin/packages/py-fluidfft-mpi-with-fftw/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidfft-mpi-with-fftw/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyFluidfftMpiWithFftw(PythonPackage):
+    """Fluidfft MPI plugin using fftw."""
+
+    pypi = "fluidfft-mpi_with_fftw/fluidfft_mpi_with_fftw-0.0.1.tar.gz"
+
+    maintainers("paugier")
+    license("CECILL-B", checked_by="paugier")
+
+    version("0.0.1", sha256="ab8c1867e745715892f8d30c9409e9509467a610f5a702ac7b5cfa003787f6ce")
+
+    with default_args(type=("build", "run")):
+        depends_on("python@3.9:")
+        depends_on("py-mpi4py")
+
+    with default_args(type="link"):
+        depends_on("fftw")
+
+    with default_args(type="build"):
+        depends_on("py-meson-python")
+        depends_on("py-transonic@0.6.4:")
+        depends_on("py-fluidfft-builder")
+
+    depends_on("py-fluidfft", type="run")

--- a/var/spack/repos/builtin/packages/py-fluidfft-p3dfft/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidfft-p3dfft/package.py
@@ -26,7 +26,7 @@ class PyFluidfftP3dfft(PythonPackage):
 
     with default_args(type="build"):
         depends_on("py-meson-python")
-        depends_on("py-transonic")
+        depends_on("py-transonic@0.6.4:")
         depends_on("py-fluidfft-builder")
 
     depends_on("py-fluidfft", type="run")

--- a/var/spack/repos/builtin/packages/py-fluidfft-p3dfft/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidfft-p3dfft/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyFluidfftP3dfft(PythonPackage):
+    """Fluidfft MPI plugin using p3dfft."""
+
+    pypi = "fluidfft-p3dfft/fluidfft_p3dfft-0.0.1.tar.gz"
+
+    maintainers("paugier")
+    license("CECILL-B", checked_by="paugier")
+
+    version("0.0.1", sha256="1c291236a43045b9f8b9725e568277c5f405d2e2d9f811ba1bc9c5e1d9f2f827")
+
+    with default_args(type=("build", "run")):
+        depends_on("python@3.9:")
+        depends_on("py-mpi4py")
+
+    with default_args(type="link"):
+        depends_on("p3dfft3")
+        depends_on("fftw")
+
+    with default_args(type="build"):
+        depends_on("py-meson-python")
+        depends_on("py-transonic")
+        depends_on("py-fluidfft-builder")
+
+    depends_on("py-fluidfft", type="run")

--- a/var/spack/repos/builtin/packages/py-fluidfft-pfft/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidfft-pfft/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyFluidfftPfft(PythonPackage):
+    """Fluidfft MPI plugin using pfft."""
+
+    pypi = "fluidfft-pfft/fluidfft_pfft-0.0.1.tar.gz"
+
+    maintainers("paugier")
+    license("CECILL-B", checked_by="paugier")
+
+    version("0.0.1", sha256="ef8255bd78c9d2dbfb11715542b221d457eedfa0a5b0bbdd1b95e8fbe64043c5")
+
+    with default_args(type=("build", "run")):
+        depends_on("python@3.9:")
+        depends_on("py-mpi4py")
+
+    with default_args(type="link"):
+        depends_on("fftw")
+        depends_on("pfft")
+
+    with default_args(type="build"):
+        depends_on("py-meson-python")
+        depends_on("py-transonic@0.6.4:")
+        depends_on("py-fluidfft-builder")
+
+    depends_on("py-fluidfft", type="run")

--- a/var/spack/repos/builtin/packages/py-fluidfft/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidfft/package.py
@@ -26,11 +26,11 @@ class PyFluidfft(PythonPackage):
 
     with default_args(type="build"):
         depends_on("py-meson-python")
-        depends_on("py-pythran")
+        depends_on("py-pythran@0.9.7:")
 
     with default_args(type="run"):
         depends_on("py-fluiddyn@0.2.3:")
-        depends_on("py-pyfftw")
+        depends_on("py-pyfftw@0.10.4:")
         depends_on("py-importlib_metadata", when="^python@:3.10")
 
     def config_settings(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/py-fluidfft/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidfft/package.py
@@ -1,0 +1,38 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyFluidfft(PythonPackage):
+    """Efficient and easy Fast Fourier Transform (FFT) for Python."""
+
+    pypi = "fluidfft/fluidfft-0.4.2.tar.gz"
+
+    maintainers("paugier")
+
+    license("CECILL-B", checked_by="paugier")
+
+    version("0.4.2", sha256="5e35f1fb647da2fa65c116bb0d598fc9cb975cd95c41022644c27dc726c36073")
+    version("0.4.1", sha256="b17e64c7b2be47c61d6ac7b713e0e8992cf900d2367381288c93a56090e6c0c1")
+
+    variant("native", default=False, description="Compile with -march=native and -Ofast.")
+
+    with default_args(type=("build", "run")):
+        depends_on("python@3.9:")
+        depends_on("py-transonic@0.6.4:")
+
+    with default_args(type="build"):
+        depends_on("py-meson-python")
+        depends_on("py-pythran")
+
+    with default_args(type="run"):
+        depends_on("py-fluiddyn@0.2.3:")
+        depends_on("py-pyfftw")
+        depends_on("py-importlib_metadata", when="^python@:3.10")
+
+    def config_settings(self, spec, prefix):
+        settings = {"setup-args": {"-Dnative": spec.variants["native"].value}}
+        return settings


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds Fluidfft https://pypi.org/project/fluidfft and related packages.

It works as expected for other Spack packages I'm working on (https://foss.heptapod.net/fluiddyn/fluiddyn/-/merge_requests/128).

It depends on https://github.com/spack/spack/pull/46234 and https://github.com/spack/spack/pull/46235.

I have a question related to build options. One can build Fluidfft with Meson options

```
pip install fluidfft -C setup-args=-Dnative=true
```

I guess this can be used with `config_settings`, but I don't know how to do it.
