### PR TITLE
Deprecate `config:install_missing_compilers`

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -115,12 +115,6 @@ config:
   suppress_gpg_warnings: false
 
 
-  # If set to true, Spack will attempt to build any compiler on the spec
-  # that is not already available. If set to False, Spack will only use
-  # compilers already configured in compilers.yaml
-  install_missing_compilers: false
-
-
   # If set to true, Spack will always check checksums after downloading
   # archives. If false, Spack skips the checksum step.
   checksum: true

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -181,10 +181,6 @@ Spec-related modules
 :mod:`spack.parser`
   Contains :class:`~spack.parser.SpecParser` and functions related to parsing specs.
 
-:mod:`spack.concretize`
-  Contains :class:`~spack.concretize.Concretizer` implementation,
-  which allows site administrators to change Spack's :ref:`concretization-policies`.
-
 :mod:`spack.version`
   Implements a simple :class:`~spack.version.Version` class with simple
   comparison semantics.  Also implements :class:`~spack.version.VersionRange`

--- a/lib/spack/docs/pipelines.rst
+++ b/lib/spack/docs/pipelines.rst
@@ -663,11 +663,7 @@ build the package.
 
 When including a bootstrapping phase as in the example above, the result is that
 the bootstrapped compiler packages will be pushed to the binary mirror (and the
-local artifacts mirror) before the actual release specs are built. In this case,
-the jobs corresponding to subsequent release specs are configured to
-``install_missing_compilers``, so that if spack is asked to install a package
-with a compiler it doesn't know about, it can be quickly installed from the
-binary mirror first.
+local artifacts mirror) before the actual release specs are built.
 
 Since bootstrapping compilers is optional, those items can be left out of the
 environment/stack file, and in that case no bootstrapping will be done (only the

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -25,13 +25,7 @@ class Concretizer:
 
     #: Controls whether we check that compiler versions actually exist
     #: during concretization. Used for testing and for mirror creation
-    check_for_compiler_existence = None
-
-    def __init__(self):
-        if Concretizer.check_for_compiler_existence is None:
-            Concretizer.check_for_compiler_existence = not spack.config.get(
-                "config:install_missing_compilers", False
-            )
+    check_for_compiler_existence = True
 
 
 @contextmanager

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -19,29 +19,23 @@ import spack.target
 import spack.tengine
 import spack.util.path
 
-
-class Concretizer:
-    """(DEPRECATED) Only contains logic to enable/disable compiler existence checks."""
-
-    #: Controls whether we check that compiler versions actually exist
-    #: during concretization. Used for testing and for mirror creation
-    check_for_compiler_existence = True
+CHECK_COMPILER_EXISTENCE = True
 
 
 @contextmanager
 def disable_compiler_existence_check():
-    saved = Concretizer.check_for_compiler_existence
-    Concretizer.check_for_compiler_existence = False
+    global CHECK_COMPILER_EXISTENCE
+    CHECK_COMPILER_EXISTENCE, saved = False, CHECK_COMPILER_EXISTENCE
     yield
-    Concretizer.check_for_compiler_existence = saved
+    CHECK_COMPILER_EXISTENCE = saved
 
 
 @contextmanager
 def enable_compiler_existence_check():
-    saved = Concretizer.check_for_compiler_existence
-    Concretizer.check_for_compiler_existence = True
+    global CHECK_COMPILER_EXISTENCE
+    CHECK_COMPILER_EXISTENCE, saved = True, CHECK_COMPILER_EXISTENCE
     yield
-    Concretizer.check_for_compiler_existence = saved
+    CHECK_COMPILER_EXISTENCE = saved
 
 
 def find_spec(spec, condition, default=None):

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1099,25 +1099,6 @@ class PackageInstaller:
         installed = f"installed ({len(self.installed)}) = {self.installed}"
         return f"{self.pid}: {requests}; {tasks}; {installed}; {failed}"
 
-    def _modify_existing_task(self, pkgid: str, attr, value) -> None:
-        """
-        Update a task in-place to modify its behavior.
-
-        Currently used to update the ``compiler`` field on tasks
-        that were originally created as a dependency of a compiler,
-        but are compilers in their own right.
-
-        For example, ``intel-oneapi-compilers-classic`` depends on
-        ``intel-oneapi-compilers``, which can cause the latter to be
-        queued first as a non-compiler, and only later as a compiler.
-        """
-        for i, tup in enumerate(self.build_pq):
-            key, task = tup
-            if task.pkg_id == pkgid:
-                tty.debug(f"Modifying task for {pkgid} to treat it as a compiler", level=2)
-                setattr(task, attr, value)
-                self.build_pq[i] = (key, task)
-
     def _add_init_task(
         self,
         pkg: "spack.package_base.PackageBase",

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1479,10 +1479,6 @@ class PackageInstaller:
         fail_fast = bool(request.install_args.get("fail_fast"))
         self.fail_fast = self.fail_fast or fail_fast
 
-    def _add_compiler_package_to_config(self, pkg: "spack.package_base.PackageBase") -> None:
-        compiler_search_prefix = getattr(pkg, "compiler_search_prefix", pkg.spec.prefix)
-        spack.compilers.find_compilers([compiler_search_prefix])
-
     def _install_task(self, task: BuildTask, install_status: InstallStatus) -> None:
         """
         Perform the installation of the requested spec and/or dependency
@@ -1510,8 +1506,6 @@ class PackageInstaller:
         if use_cache:
             if _install_from_cache(pkg, explicit, unsigned):
                 self._update_installed(task)
-                if task.compiler:
-                    self._add_compiler_package_to_config(pkg)
                 return
             elif cache_only:
                 raise InstallError("No binary found when cache-only was specified", pkg=pkg)
@@ -1541,9 +1535,6 @@ class PackageInstaller:
             # the database, so that we don't need to re-read from file.
             spack.store.STORE.db.add(pkg.spec, explicit=explicit)
 
-            # If a compiler, ensure it is added to the configuration
-            if task.compiler:
-                self._add_compiler_package_to_config(pkg)
         except spack.build_environment.StopPhase as e:
             # A StopPhase exception means that do_install was asked to
             # stop early from clients, and is not an error at this point
@@ -1943,10 +1934,6 @@ class PackageInstaller:
                     self._update_installed(task)
                     path = spack.util.path.debug_padded_filter(pkg.prefix)
                     _print_installed_pkg(path)
-
-                    # It's an already installed compiler, add it to the config
-                    if task.compiler:
-                        self._add_compiler_package_to_config(pkg)
 
                 else:
                     # At this point we've failed to get a write or a read

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -75,7 +75,6 @@ properties: Dict[str, Any] = {
             "verify_ssl": {"type": "boolean"},
             "ssl_certs": {"type": "string"},
             "suppress_gpg_warnings": {"type": "boolean"},
-            "install_missing_compilers": {"type": "boolean"},
             "debug": {"type": "boolean"},
             "checksum": {"type": "boolean"},
             "deprecated": {"type": "boolean"},
@@ -102,7 +101,14 @@ properties: Dict[str, Any] = {
                 "message": "Spack supports only clingo as a concretizer from v0.23. "
                 "The config:concretizer config option is ignored.",
                 "error": False,
-            }
+            },
+            {
+                "names": ["install_missing_compilers"],
+                "message": "The config:install_missing_compilers option has been deprecated in "
+                "Spack v0.23, and is currently ignored. It will be removed from config in "
+                "Spack v0.25.",
+                "error": False,
+            },
         ],
     }
 }

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2613,9 +2613,6 @@ class SpackSolverSetup:
                 continue
 
             current_libc = compiler.compiler_obj.default_libc
-            # If this is a compiler yet to be built infer libc from the Python process
-            if not current_libc and compiler.compiler_obj.cc is None:
-                current_libc = spack.util.libc.libc_from_current_python_process()
 
             if using_libc_compatibility() and current_libc:
                 recorder("*").depends_on(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2613,8 +2613,7 @@ class SpackSolverSetup:
                 continue
 
             current_libc = compiler.compiler_obj.default_libc
-            # If this is a compiler yet to be built (config:install_missing_compilers:true)
-            # infer libc from the Python process
+            # If this is a compiler yet to be built infer libc from the Python process
             if not current_libc and compiler.compiler_obj.cc is None:
                 current_libc = spack.util.libc.libc_from_current_python_process()
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3035,7 +3035,7 @@ class CompilerParser:
         Args:
             input_specs: specs to be concretized
         """
-        strict = spack.concretize.Concretizer().check_for_compiler_existence
+        strict = spack.concretize.CHECK_COMPILER_EXISTENCE
         default_os = str(spack.platforms.host().default_os)
         default_target = str(archspec.cpu.host().family)
         for s in traverse.traverse_nodes(input_specs):

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1340,7 +1340,7 @@ node_compiler_weight(node(ID, Package), 100)
     not compiler_weight(CompilerID, _).
 
 % For the time being, be strict and reuse only if the compiler match one we have on the system
-error(100, "Compiler {1}@{2} requested for {0} cannot be found. Set install_missing_compilers:true if intended.", Package, Compiler, Version)
+error(100, "Compiler {1}@{2} requested for {0} cannot be found.", Package, Compiler, Version)
  :- attr("node_compiler_version", node(ID, Package), Compiler, Version),
     not node_compiler(node(ID, Package), _).
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -19,7 +19,6 @@ import llnl.util.tty as tty
 
 import spack.cmd.common.arguments
 import spack.cmd.install
-import spack.compilers as compilers
 import spack.config
 import spack.environment as ev
 import spack.hash_types as ht
@@ -29,7 +28,7 @@ import spack.util.executable
 from spack.error import SpackError
 from spack.main import SpackCommand
 from spack.parser import SpecSyntaxError
-from spack.spec import CompilerSpec, Spec
+from spack.spec import Spec
 
 install = SpackCommand("install")
 env = SpackCommand("env")
@@ -914,68 +913,6 @@ def test_cdash_configure_warning(tmpdir, mock_fetch, install_mockery, capfd):
         assert report_file in report_dir.listdir()
         content = report_file.open().read()
         assert "foo: No such file or directory" in content
-
-
-@pytest.mark.not_on_windows("ArchSpec gives test platform debian rather than windows")
-def test_compiler_bootstrap(
-    install_mockery, mock_packages, mock_fetch, mock_archive, mutable_config, monkeypatch
-):
-    monkeypatch.setattr(spack.concretize.Concretizer, "check_for_compiler_existence", False)
-    spack.config.set("config:install_missing_compilers", True)
-    assert CompilerSpec("gcc@=12.0") not in compilers.all_compiler_specs()
-
-    # Test succeeds if it does not raise an error
-    install("pkg-a%gcc@=12.0")
-
-
-@pytest.mark.not_on_windows("Binary mirrors not supported on windows")
-def test_compiler_bootstrap_from_binary_mirror(
-    install_mockery, mock_packages, mock_fetch, mock_archive, mutable_config, monkeypatch, tmpdir
-):
-    """
-    Make sure installing compiler from buildcache registers compiler
-    """
-
-    # Create a temp mirror directory for buildcache usage
-    mirror_dir = tmpdir.join("mirror_dir")
-    mirror_url = "file://{0}".format(mirror_dir.strpath)
-
-    # Install a compiler, because we want to put it in a buildcache
-    install("gcc@=10.2.0")
-
-    # Put installed compiler in the buildcache
-    buildcache("push", "-u", "-f", mirror_dir.strpath, "gcc@10.2.0")
-
-    # Now uninstall the compiler
-    uninstall("-y", "gcc@10.2.0")
-
-    monkeypatch.setattr(spack.concretize.Concretizer, "check_for_compiler_existence", False)
-    spack.config.set("config:install_missing_compilers", True)
-    assert CompilerSpec("gcc@=10.2.0") not in compilers.all_compiler_specs()
-
-    # Configure the mirror where we put that buildcache w/ the compiler
-    mirror("add", "test-mirror", mirror_url)
-
-    # Now make sure that when the compiler is installed from binary mirror,
-    # it also gets configured as a compiler.  Test succeeds if it does not
-    # raise an error
-    install("--no-check-signature", "--cache-only", "--only", "dependencies", "pkg-b%gcc@=10.2.0")
-    install("--no-cache", "--only", "package", "pkg-b%gcc@10.2.0")
-
-
-@pytest.mark.not_on_windows("ArchSpec gives test platform debian rather than windows")
-@pytest.mark.regression("16221")
-def test_compiler_bootstrap_already_installed(
-    install_mockery, mock_packages, mock_fetch, mock_archive, mutable_config, monkeypatch
-):
-    monkeypatch.setattr(spack.concretize.Concretizer, "check_for_compiler_existence", False)
-    spack.config.set("config:install_missing_compilers", True)
-
-    assert CompilerSpec("gcc@=12.0") not in compilers.all_compiler_specs()
-
-    # Test succeeds if it does not raise an error
-    install("gcc@=12.0")
-    install("pkg-a%gcc@=12.0")
 
 
 def test_install_fails_no_args(tmpdir):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2376,26 +2376,6 @@ class TestConcretize:
         s = Spec("mpich").concretized()
         assert s.external
 
-    @pytest.mark.regression("43875")
-    def test_concretize_missing_compiler(self, mutable_config, monkeypatch):
-        """Tests that Spack can concretize a spec with a missing compiler when the
-        option is active.
-        """
-
-        def _default_libc(self):
-            if self.cc is None:
-                return None
-            return Spec("glibc@=2.28")
-
-        monkeypatch.setattr(spack.concretize.Concretizer, "check_for_compiler_existence", False)
-        monkeypatch.setattr(spack.compiler.Compiler, "default_libc", property(_default_libc))
-        monkeypatch.setattr(
-            spack.util.libc, "libc_from_current_python_process", lambda: Spec("glibc@=2.28")
-        )
-        mutable_config.set("config:install_missing_compilers", True)
-        s = Spec("pkg-a %gcc@=13.2.0").concretized()
-        assert s.satisfies("%gcc@13.2.0")
-
     @pytest.mark.regression("43267")
     def test_spec_with_build_dep_from_json(self, tmp_path):
         """Tests that we can correctly concretize a spec, when we express its dependency as a


### PR DESCRIPTION
depends on https://github.com/spack/spack/pull/46221

The option `config:install_missing_compilers` is currently buggy, and has been for a while. Remove it, since it won't be needed when compilers are treated as dependencies.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
