### PR TITLE
Update ExaCA backend handling and add version 2.0

### DIFF
--- a/var/spack/repos/builtin/packages/exaca/package.py
+++ b/var/spack/repos/builtin/packages/exaca/package.py
@@ -12,7 +12,7 @@ class Exaca(CMakePackage):
 
     homepage = "https://github.com/LLNL/ExaCA"
     git = "https://github.com/LLNL/ExaCA.git"
-    url = "https://github.com/LLNL/ExaCA/archive/1.2.0.tar.gz"
+    url = "https://github.com/LLNL/ExaCA/archive/2.0.0.tar.gz"
 
     maintainers("streeve", "MattRolchigo")
 
@@ -21,6 +21,8 @@ class Exaca(CMakePackage):
     license("MIT")
 
     version("master", branch="master")
+    version("2.0.0", sha256="a33cc65a6e79bed37a644f5bfc9dd5fe356239f78c5b82830c6354acc43e016b")
+    version("1.3.0", sha256="637215d3c64e8007b55d68bea6003b51671029d9045af847534e0e59c4271a94")
     version("1.2.0", sha256="5038d63de96c6142ddea956998e1f4ebffbc4a5723caa4da0e73eb185e6623e4")
     version("1.1.0", sha256="10106fb1836964a19bc5bab3f374baa24188ba786c768e554442ab896b31ff24")
     version("1.0.0", sha256="48556233360a5e15e1fc20849e57dd60739c1991c7dfc7e6b2956af06688b96a")
@@ -40,6 +42,7 @@ class Exaca(CMakePackage):
     depends_on("googletest@1.10:", type="test", when="@1.1:+testing")
     depends_on("kokkos@3.0:", when="@:1.1")
     depends_on("kokkos@3.2:", when="@1.2:")
+    depends_on("kokkos@4.0:", when="@1.3:")
     depends_on("mpi")
     depends_on("nlohmann-json", when="@1.2:")
 
@@ -48,5 +51,8 @@ class Exaca(CMakePackage):
 
         if self.spec.satisfies("@1.1:"):
             options += [self.define_from_variant("ExaCA_ENABLE_TESTING", "testing")]
+        # Only release with optional json
+        if self.spec.satisfies("@1.2"):
+            options += [self.define_from_variant("ExaCA_ENABLE_JSON", "ON")]
 
         return options


### PR DESCRIPTION
- Add new releases
- Kokkos/cuda/rocm backend handling updated to match other Kokkos packages