### PR TITLE
fix hdf5 dependency for OpenCV

### DIFF
--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -486,6 +486,7 @@ class Opencv(CMakePackage, CudaPackage):
 
     with when("+hdf"):
         depends_on("hdf5")
+        depends_on("mpi", when="^hdf5+mpi")
 
     with when("+hfs"):
         with when("+cuda"):


### PR DESCRIPTION
When OpenCV depends on HDF5+mpi, it needs to the MPI compilers available.  Supercedes #46128

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
