### PR TITLE
Require a newer version of cudnn for cupy

### DIFF
--- a/var/spack/repos/builtin/packages/py-cupy/package.py
+++ b/var/spack/repos/builtin/packages/py-cupy/package.py
@@ -53,7 +53,8 @@ class PyCupy(PythonPackage, CudaPackage, ROCmPackage):
     for a in CudaPackage.cuda_arch_values:
         depends_on("nccl +cuda cuda_arch={0}".format(a), when="+cuda cuda_arch={0}".format(a))
 
-    depends_on("cudnn", when="+cuda")
+    depends_on("cudnn@8.8", when="@12.0.0: +cuda")
+    depends_on("cudnn@8.5", when="@11.2.0:11.6.0 +cuda")
     depends_on("cutensor", when="@:12.1.0 +cuda")
     depends_on("cutensor@2.0.1.2", when="@13.1: +cuda")
 


### PR DESCRIPTION
cupy 12 needs a newer version of cudnn as documented [here](https://github.com/cupy/cupy/releases/tag/v12.0.0).  Supercedes #46128

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
