### PR TITLE
fish: use shlex.quote instead of custom quote

### DIFF
--- a/lib/spack/spack/cmd/commands.py
+++ b/lib/spack/spack/cmd/commands.py
@@ -584,7 +584,7 @@ class FishCompletionWriter(ArgparseWriter):
                 if value is not None:
                     commands.append(f"{head} {value}")
 
-        return f"{'\n'.join(commands)}\n"
+        return "\n".join(commands) + "\n"
 
     def prog_comment(self, prog: str) -> str:
         """Return a comment line for the command."""
@@ -654,7 +654,7 @@ class FishCompletionWriter(ArgparseWriter):
             if help:
                 commands.append(f"{prefix} -d {shlex.quote(help)}")
 
-        return f"{'\n'.join(commands)}\n"
+        return "\n".join(commands) + "\n"
 
     def subcommands(self, prog: str, subcommands: List[Tuple[ArgumentParser, str, str]]) -> str:
         """Return the completion for subcommands.
@@ -678,7 +678,7 @@ class FishCompletionWriter(ArgparseWriter):
 
             commands.append(command)
 
-        return f"{'\n'.join(commands)}\n"
+        return "\n".join(commands) + "\n"
 
 
 @formatter

--- a/lib/spack/spack/cmd/commands.py
+++ b/lib/spack/spack/cmd/commands.py
@@ -7,6 +7,7 @@ import argparse
 import copy
 import os
 import re
+import shlex
 import sys
 from argparse import ArgumentParser, Namespace
 from typing import IO, Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
@@ -436,14 +437,7 @@ class FishCompletionWriter(ArgparseWriter):
         Returns:
             Quoted string.
         """
-        # Goal here is to match fish_indent behavior
-
-        # Strings without spaces (or other special characters) do not need to be escaped
-        if not any([sub in string for sub in [" ", "'", '"']]):
-            return string
-
-        string = string.replace("'", r"\'")
-        return f"'{string}'"
+        return shlex.quote(string)
 
     def optspecs(
         self,

--- a/lib/spack/spack/cmd/commands.py
+++ b/lib/spack/spack/cmd/commands.py
@@ -19,6 +19,7 @@ from llnl.util.tty.colify import colify
 import spack.cmd
 import spack.main
 import spack.paths
+import spack.platforms
 from spack.main import section_descriptions
 
 description = "list available spack commands"
@@ -140,7 +141,7 @@ class SpackArgparseRstWriter(ArgparseRstWriter):
 
         cmd = self.parser.prog.replace(" ", "-")
         if cmd in self.documented:
-            string += "\n:ref:`More documentation <cmd-{0}>`\n".format(cmd)
+            string = f"{string}\n:ref:`More documentation <cmd-{cmd}>`\n"
 
         return string
 
@@ -250,33 +251,27 @@ class BashCompletionWriter(ArgparseWriter):
             Function body.
         """
         if positionals:
-            return """
+            return f"""
     if $list_options
     then
-        {0}
+        {self.optionals(optionals)}
     else
-        {1}
+        {self.positionals(positionals)}
     fi
-""".format(
-                self.optionals(optionals), self.positionals(positionals)
-            )
+"""
         elif subcommands:
-            return """
+            return f"""
     if $list_options
     then
-        {0}
+        {self.optionals(optionals)}
     else
-        {1}
+        {self.subcommands(subcommands)}
     fi
-""".format(
-                self.optionals(optionals), self.subcommands(subcommands)
-            )
+"""
         else:
-            return """
-    {0}
-""".format(
-                self.optionals(optionals)
-            )
+            return f"""
+    {self.optionals(optionals)}
+"""
 
     def positionals(self, positionals: Sequence[str]) -> str:
         """Return the syntax for reporting positional arguments.
@@ -305,7 +300,7 @@ class BashCompletionWriter(ArgparseWriter):
         Returns:
             Syntax for optional flags.
         """
-        return 'SPACK_COMPREPLY="{0}"'.format(" ".join(optionals))
+        return f'SPACK_COMPREPLY="{" ".join(optionals)}"'
 
     def subcommands(self, subcommands: Sequence[str]) -> str:
         """Return the syntax for reporting subcommands.
@@ -316,7 +311,7 @@ class BashCompletionWriter(ArgparseWriter):
         Returns:
             Syntax for subcommand parsers
         """
-        return 'SPACK_COMPREPLY="{0}"'.format(" ".join(subcommands))
+        return f'SPACK_COMPREPLY="{" ".join(subcommands)}"'
 
 
 # Map argument destination names to their complete commands
@@ -396,7 +391,7 @@ def _fish_dest_get_complete(prog: str, dest: str) -> Optional[str]:
     subcmd = s[1] if len(s) == 2 else ""
 
     for (prog_key, pos_key), value in _dest_to_fish_complete.items():
-        if subcmd.startswith(prog_key) and re.match("^" + pos_key + "$", dest):
+        if subcmd.startswith(prog_key) and re.match(f"^{pos_key}$", dest):
             return value
     return None
 
@@ -428,17 +423,6 @@ class FishCompletionWriter(ArgparseWriter):
             + self.complete(cmd.prog, positionals, optionals, subcommands)
         )
 
-    def _quote(self, string: str) -> str:
-        """Quote string and escape special characters if necessary.
-
-        Args:
-            string: Input string.
-
-        Returns:
-            Quoted string.
-        """
-        return shlex.quote(string)
-
     def optspecs(
         self,
         prog: str,
@@ -457,7 +441,7 @@ class FishCompletionWriter(ArgparseWriter):
         optspec_var = "__fish_spack_optspecs_" + prog.replace(" ", "_").replace("-", "_")
 
         if optionals is None:
-            return "set -g %s\n" % optspec_var
+            return f"set -g {optspec_var}\n"
 
         # Build optspec by iterating over options
         args = []
@@ -484,11 +468,11 @@ class FishCompletionWriter(ArgparseWriter):
             long = [f[2:] for f in flags if f.startswith("--")]
 
             while len(short) > 0 and len(long) > 0:
-                arg = "%s/%s%s" % (short.pop(), long.pop(), required)
+                arg = f"{short.pop()}/{long.pop()}{required}"
             while len(short) > 0:
-                arg = "%s/%s" % (short.pop(), required)
+                arg = f"{short.pop()}/{required}"
             while len(long) > 0:
-                arg = "%s%s" % (long.pop(), required)
+                arg = f"{long.pop()}{required}"
 
             args.append(arg)
 
@@ -497,7 +481,7 @@ class FishCompletionWriter(ArgparseWriter):
         # indicate that such subcommand exists.
         args = " ".join(args)
 
-        return "set -g %s %s\n" % (optspec_var, args)
+        return f"set -g {optspec_var} {args}\n"
 
     @staticmethod
     def complete_head(
@@ -518,12 +502,14 @@ class FishCompletionWriter(ArgparseWriter):
         subcmd = s[1] if len(s) == 2 else ""
 
         if index is None:
-            return "complete -c %s -n '__fish_spack_using_command %s'" % (s[0], subcmd)
+            return f"complete -c {s[0]} -n '__fish_spack_using_command {subcmd}'"
         elif nargs in [argparse.ZERO_OR_MORE, argparse.ONE_OR_MORE, argparse.REMAINDER]:
-            head = "complete -c %s -n '__fish_spack_using_command_pos_remainder %d %s'"
+            return (
+                f"complete -c {s[0]} -n '__fish_spack_using_command_pos_remainder "
+                f"{index} {subcmd}'"
+            )
         else:
-            head = "complete -c %s -n '__fish_spack_using_command_pos %d %s'"
-        return head % (s[0], index, subcmd)
+            return f"complete -c {s[0]} -n '__fish_spack_using_command_pos {index} {subcmd}'"
 
     def complete(
         self,
@@ -591,25 +577,18 @@ class FishCompletionWriter(ArgparseWriter):
 
             if choices is not None:
                 # If there are choices, we provide a completion for all possible values.
-                commands.append(head + " -f -a %s" % self._quote(" ".join(choices)))
+                commands.append(f"{head} -f -a {shlex.quote(' '.join(choices))}")
             else:
                 # Otherwise, we try to find a predefined completion for it
                 value = _fish_dest_get_complete(prog, args)
                 if value is not None:
-                    commands.append(head + " " + value)
+                    commands.append(f"{head} {value}")
 
-        return "\n".join(commands) + "\n"
+        return f"{'\n'.join(commands)}\n"
 
     def prog_comment(self, prog: str) -> str:
-        """Return a comment line for the command.
-
-        Args:
-            prog: Program name.
-
-        Returns:
-            Comment line.
-        """
-        return "\n# %s\n" % prog
+        """Return a comment line for the command."""
+        return f"\n# {prog}\n"
 
     def optionals(
         self,
@@ -652,30 +631,30 @@ class FishCompletionWriter(ArgparseWriter):
             for f in flags:
                 if f.startswith("--"):
                     long = f[2:]
-                    prefix += " -l %s" % long
+                    prefix = f"{prefix} -l {long}"
                 elif f.startswith("-"):
                     short = f[1:]
                     assert len(short) == 1
-                    prefix += " -s %s" % short
+                    prefix = f"{prefix} -s {short}"
 
             # Check if option require argument.
             # Currently multi-argument options are not supported, so we treat it like one argument.
             if nargs != 0:
-                prefix += " -r"
+                prefix = f"{prefix} -r"
 
             if dest is not None:
                 # If there are choices, we provide a completion for all possible values.
-                commands.append(prefix + " -f -a %s" % self._quote(" ".join(dest)))
+                commands.append(f"{prefix} -f -a {shlex.quote(' '.join(dest))}")
             else:
                 # Otherwise, we try to find a predefined completion for it
                 value = _fish_dest_get_complete(prog, dest)
                 if value is not None:
-                    commands.append(prefix + " " + value)
+                    commands.append(f"{prefix} {value}")
 
             if help:
-                commands.append(prefix + " -d %s" % self._quote(help))
+                commands.append(f"{prefix} -d {shlex.quote(help)}")
 
-        return "\n".join(commands) + "\n"
+        return f"{'\n'.join(commands)}\n"
 
     def subcommands(self, prog: str, subcommands: List[Tuple[ArgumentParser, str, str]]) -> str:
         """Return the completion for subcommands.
@@ -691,15 +670,15 @@ class FishCompletionWriter(ArgparseWriter):
         head = self.complete_head(prog, 0)
 
         for _, subcommand, help in subcommands:
-            command = head + " -f -a %s" % self._quote(subcommand)
+            command = f"{head} -f -a {shlex.quote(subcommand)}"
 
             if help is not None and len(help) > 0:
                 help = help.split("\n")[0]
-                command += " -d %s" % self._quote(help)
+                command = f"{command} -d {shlex.quote(help)}"
 
             commands.append(command)
 
-        return "\n".join(commands) + "\n"
+        return f"{'\n'.join(commands)}\n"
 
 
 @formatter
@@ -741,7 +720,7 @@ def rst_index(out: IO) -> None:
 
         for i, cmd in enumerate(sorted(commands)):
             description = description.capitalize() if i == 0 else ""
-            ref = ":ref:`%s <spack-%s>`" % (cmd, cmd)
+            ref = f":ref:`{cmd} <spack-{cmd}>`"
             comma = "," if i != len(commands) - 1 else ""
             bar = "| " if i % 8 == 0 else "  "
             out.write(line % (description, bar + ref + comma))
@@ -852,10 +831,10 @@ def _commands(parser: ArgumentParser, args: Namespace) -> None:
 
     # check header first so we don't open out files unnecessarily
     if args.header and not os.path.exists(args.header):
-        tty.die("No such file: '%s'" % args.header)
+        tty.die(f"No such file: '{args.header}'")
 
     if args.update:
-        tty.msg("Updating file: %s" % args.update)
+        tty.msg(f"Updating file: {args.update}")
         with open(args.update, "w") as f:
             prepend_header(args, f)
             formatter(args, f)

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -353,7 +353,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a arch -d 'print ar
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a audit -d 'audit configuration files, packages, etc.'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a blame -d 'show contributors to packages'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a bootstrap -d 'manage bootstrap configuration'
-complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a build-env -d 'run a command in a spec\'s install environment, or dump its environment to screen or file'
+complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a build-env -d 'run a command in a spec'"'"'s install environment, or dump its environment to screen or file'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a buildcache -d 'create, download and install binary packages'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a cd -d 'cd to spack directories in the shell'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a change -d 'change an existing spec in an environment'
@@ -376,7 +376,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a dependencies -d '
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a dependents -d 'show packages that depend on another'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a deprecate -d 'replace one package with another via symlinks'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a dev-build -d 'developer build: build from code in current working directory'
-complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a develop -d 'add a spec to an environment\'s dev-build information'
+complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a develop -d 'add a spec to an environment'"'"'s dev-build information'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a diff -d 'compare two specs'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a docs -d 'open spack documentation in a web browser'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a edit -d 'open package files in $EDITOR'
@@ -407,7 +407,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a pkg -d 'query pac
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a providers -d 'list packages that provide a particular virtual package'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a pydoc -d 'run pydoc from within spack'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a python -d 'launch an interpreter as spack would launch a command'
-complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a reindex -d 'rebuild Spack\'s package database'
+complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a reindex -d 'rebuild Spack'"'"'s package database'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a remove -d 'remove specs from an environment'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a rm -d 'remove specs from an environment'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a repo -d 'manage package source repositories'
@@ -418,12 +418,12 @@ complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a spec -d 'show wha
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a stage -d 'expand downloaded archive in preparation for install'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a style -d 'runs source code style checks on spack'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a tags -d 'show package tags and associated packages'
-complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a test -d 'run spack\'s tests for an install'
-complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a test-env -d 'run a command in a spec\'s test environment, or dump its environment to screen or file'
+complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a test -d 'run spack'"'"'s tests for an install'
+complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a test-env -d 'run a command in a spec'"'"'s test environment, or dump its environment to screen or file'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a tutorial -d 'set up spack for our tutorial (WARNING: modifies config!)'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a undevelop -d 'remove specs from an environment'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a uninstall -d 'remove installed packages'
-complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a unit-test -d 'run spack\'s unit tests (wrapper around pytest)'
+complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a unit-test -d 'run spack'"'"'s unit tests (wrapper around pytest)'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a unload -d 'remove package from the user environment'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a url -d 'debugging tool for url parsing'
 complete -c spack -n '__fish_spack_using_command_pos 0 ' -f -a verify -d 'check that all spack packages are on disk as installed'
@@ -468,7 +468,7 @@ complete -c spack -n '__fish_spack_using_command ' -s p -l profile -d 'profile e
 complete -c spack -n '__fish_spack_using_command ' -l sorted-profile -r -f -a sorted_profile
 complete -c spack -n '__fish_spack_using_command ' -l sorted-profile -r -d 'profile and sort'
 complete -c spack -n '__fish_spack_using_command ' -l lines -r -f -a lines
-complete -c spack -n '__fish_spack_using_command ' -l lines -r -d 'lines of profile output or \'all\' (default: 20)'
+complete -c spack -n '__fish_spack_using_command ' -l lines -r -d 'lines of profile output or '"'"'all'"'"' (default: 20)'
 complete -c spack -n '__fish_spack_using_command ' -s v -l verbose -f -a verbose
 complete -c spack -n '__fish_spack_using_command ' -s v -l verbose -d 'print additional output during builds'
 complete -c spack -n '__fish_spack_using_command ' -l stacktrace -f -a stacktrace
@@ -667,7 +667,7 @@ complete -c spack -n '__fish_spack_using_command build-env' -s h -l help -d 'sho
 complete -c spack -n '__fish_spack_using_command build-env' -l clean -f -a dirty
 complete -c spack -n '__fish_spack_using_command build-env' -l clean -d 'unset harmful variables in the build environment (default)'
 complete -c spack -n '__fish_spack_using_command build-env' -l dirty -f -a dirty
-complete -c spack -n '__fish_spack_using_command build-env' -l dirty -d 'preserve user environment in spack\'s build environment (danger!)'
+complete -c spack -n '__fish_spack_using_command build-env' -l dirty -d 'preserve user environment in spack'"'"'s build environment (danger!)'
 complete -c spack -n '__fish_spack_using_command build-env' -s U -l fresh -f -a concretizer_reuse
 complete -c spack -n '__fish_spack_using_command build-env' -s U -l fresh -d 'do not reuse installed deps; build newest configuration'
 complete -c spack -n '__fish_spack_using_command build-env' -l reuse -f -a concretizer_reuse
@@ -892,7 +892,7 @@ complete -c spack -n '__fish_spack_using_command cd' -s r -l spack-root -d 'spac
 complete -c spack -n '__fish_spack_using_command cd' -s i -l install-dir -f -a install_dir
 complete -c spack -n '__fish_spack_using_command cd' -s i -l install-dir -d 'install prefix for spec (spec need not be installed)'
 complete -c spack -n '__fish_spack_using_command cd' -s p -l package-dir -f -a package_dir
-complete -c spack -n '__fish_spack_using_command cd' -s p -l package-dir -d 'directory enclosing a spec\'s package.py file'
+complete -c spack -n '__fish_spack_using_command cd' -s p -l package-dir -d 'directory enclosing a spec'"'"'s package.py file'
 complete -c spack -n '__fish_spack_using_command cd' -s P -l packages -f -a packages
 complete -c spack -n '__fish_spack_using_command cd' -s P -l packages -d 'top-level packages directory for Spack'
 complete -c spack -n '__fish_spack_using_command cd' -s s -l stage-dir -f -a stage_dir
@@ -927,9 +927,9 @@ complete -c spack -n '__fish_spack_using_command_pos_remainder 1 checksum' -f -a
 complete -c spack -n '__fish_spack_using_command checksum' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command checksum' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command checksum' -l keep-stage -f -a keep_stage
-complete -c spack -n '__fish_spack_using_command checksum' -l keep-stage -d 'don\'t clean up staging area when command completes'
+complete -c spack -n '__fish_spack_using_command checksum' -l keep-stage -d 'don'"'"'t clean up staging area when command completes'
 complete -c spack -n '__fish_spack_using_command checksum' -l batch -s b -f -a batch
-complete -c spack -n '__fish_spack_using_command checksum' -l batch -s b -d 'don\'t ask which versions to checksum'
+complete -c spack -n '__fish_spack_using_command checksum' -l batch -s b -d 'don'"'"'t ask which versions to checksum'
 complete -c spack -n '__fish_spack_using_command checksum' -l latest -s l -f -a latest
 complete -c spack -n '__fish_spack_using_command checksum' -l latest -s l -d 'checksum the latest available version'
 complete -c spack -n '__fish_spack_using_command checksum' -l preferred -s p -f -a preferred
@@ -961,7 +961,7 @@ complete -c spack -n '__fish_spack_using_command ci generate' -l copy-to -r -d '
 complete -c spack -n '__fish_spack_using_command ci generate' -l optimize -f -a optimize
 complete -c spack -n '__fish_spack_using_command ci generate' -l optimize -d '(DEPRECATED) optimize the gitlab yaml file for size'
 complete -c spack -n '__fish_spack_using_command ci generate' -l dependencies -f -a dependencies
-complete -c spack -n '__fish_spack_using_command ci generate' -l dependencies -d '(DEPRECATED) disable DAG scheduling (use \'plain\' dependencies)'
+complete -c spack -n '__fish_spack_using_command ci generate' -l dependencies -d '(DEPRECATED) disable DAG scheduling (use '"'"'plain'"'"' dependencies)'
 complete -c spack -n '__fish_spack_using_command ci generate' -l buildcache-destination -r -f -a buildcache_destination
 complete -c spack -n '__fish_spack_using_command ci generate' -l buildcache-destination -r -d 'override the mirror configured in the environment'
 complete -c spack -n '__fish_spack_using_command ci generate' -l prune-dag -f -a prune_dag
@@ -1037,7 +1037,7 @@ set -g __fish_spack_optspecs_spack_commands h/help update-completion a/aliases f
 complete -c spack -n '__fish_spack_using_command commands' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command commands' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command commands' -l update-completion -f -a update_completion
-complete -c spack -n '__fish_spack_using_command commands' -l update-completion -d 'regenerate spack\'s tab completion scripts'
+complete -c spack -n '__fish_spack_using_command commands' -l update-completion -d 'regenerate spack'"'"'s tab completion scripts'
 complete -c spack -n '__fish_spack_using_command commands' -s a -l aliases -f -a aliases
 complete -c spack -n '__fish_spack_using_command commands' -s a -l aliases -d 'include command aliases'
 complete -c spack -n '__fish_spack_using_command commands' -l format -r -f -a 'subcommands rst names bash fish'
@@ -1137,7 +1137,7 @@ complete -c spack -n '__fish_spack_using_command concretize' -s f -l force -d 'r
 complete -c spack -n '__fish_spack_using_command concretize' -l test -r -f -a 'root all'
 complete -c spack -n '__fish_spack_using_command concretize' -l test -r -d 'concretize with test dependencies of only root packages or all packages'
 complete -c spack -n '__fish_spack_using_command concretize' -s q -l quiet -f -a quiet
-complete -c spack -n '__fish_spack_using_command concretize' -s q -l quiet -d 'don\'t print concretized specs'
+complete -c spack -n '__fish_spack_using_command concretize' -s q -l quiet -d 'don'"'"'t print concretized specs'
 complete -c spack -n '__fish_spack_using_command concretize' -s U -l fresh -f -a concretizer_reuse
 complete -c spack -n '__fish_spack_using_command concretize' -s U -l fresh -d 'do not reuse installed deps; build newest configuration'
 complete -c spack -n '__fish_spack_using_command concretize' -l reuse -f -a concretizer_reuse
@@ -1158,7 +1158,7 @@ complete -c spack -n '__fish_spack_using_command concretise' -s f -l force -d 'r
 complete -c spack -n '__fish_spack_using_command concretise' -l test -r -f -a 'root all'
 complete -c spack -n '__fish_spack_using_command concretise' -l test -r -d 'concretize with test dependencies of only root packages or all packages'
 complete -c spack -n '__fish_spack_using_command concretise' -s q -l quiet -f -a quiet
-complete -c spack -n '__fish_spack_using_command concretise' -s q -l quiet -d 'don\'t print concretized specs'
+complete -c spack -n '__fish_spack_using_command concretise' -s q -l quiet -d 'don'"'"'t print concretized specs'
 complete -c spack -n '__fish_spack_using_command concretise' -s U -l fresh -f -a concretizer_reuse
 complete -c spack -n '__fish_spack_using_command concretise' -s U -l fresh -d 'do not reuse installed deps; build newest configuration'
 complete -c spack -n '__fish_spack_using_command concretise' -l reuse -f -a concretizer_reuse
@@ -1288,7 +1288,7 @@ set -g __fish_spack_optspecs_spack_create h/help keep-stage n/name= t/template= 
 complete -c spack -n '__fish_spack_using_command create' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command create' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command create' -l keep-stage -f -a keep_stage
-complete -c spack -n '__fish_spack_using_command create' -l keep-stage -d 'don\'t clean up staging area when command completes'
+complete -c spack -n '__fish_spack_using_command create' -l keep-stage -d 'don'"'"'t clean up staging area when command completes'
 complete -c spack -n '__fish_spack_using_command create' -s n -l name -r -f -a name
 complete -c spack -n '__fish_spack_using_command create' -s n -l name -r -d 'name of the package to create'
 complete -c spack -n '__fish_spack_using_command create' -s t -l template -r -f -a 'autoreconf autotools bazel bundle cargo cmake generic go intel lua makefile maven meson octave perlbuild perlmake python qmake r racket ruby scons sip waf'
@@ -1302,11 +1302,11 @@ complete -c spack -n '__fish_spack_using_command create' -s f -l force -d 'overw
 complete -c spack -n '__fish_spack_using_command create' -l skip-editor -f -a skip_editor
 complete -c spack -n '__fish_spack_using_command create' -l skip-editor -d 'skip the edit session for the package (e.g., automation)'
 complete -c spack -n '__fish_spack_using_command create' -s b -l batch -f -a batch
-complete -c spack -n '__fish_spack_using_command create' -s b -l batch -d 'don\'t ask which versions to checksum'
+complete -c spack -n '__fish_spack_using_command create' -s b -l batch -d 'don'"'"'t ask which versions to checksum'
 
 # spack debug
 set -g __fish_spack_optspecs_spack_debug h/help
-complete -c spack -n '__fish_spack_using_command_pos 0 debug' -f -a create-db-tarball -d 'create a tarball of Spack\'s installation metadata'
+complete -c spack -n '__fish_spack_using_command_pos 0 debug' -f -a create-db-tarball -d 'create a tarball of Spack'"'"'s installation metadata'
 complete -c spack -n '__fish_spack_using_command_pos 0 debug' -f -a report -d 'print information useful for bug reports'
 complete -c spack -n '__fish_spack_using_command debug' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command debug' -s h -l help -d 'show this help message and exit'
@@ -1373,7 +1373,7 @@ complete -c spack -n '__fish_spack_using_command deprecate' -s i -l install-depr
 complete -c spack -n '__fish_spack_using_command deprecate' -s I -l no-install-deprecator -f -a install
 complete -c spack -n '__fish_spack_using_command deprecate' -s I -l no-install-deprecator -d 'deprecator spec must already be installed (default)'
 complete -c spack -n '__fish_spack_using_command deprecate' -s l -l link-type -r -f -a 'soft hard'
-complete -c spack -n '__fish_spack_using_command deprecate' -s l -l link-type -r -d (deprecated)
+complete -c spack -n '__fish_spack_using_command deprecate' -s l -l link-type -r -d '(deprecated)'
 
 # spack dev-build
 set -g __fish_spack_optspecs_spack_dev_build h/help j/jobs= n/no-checksum d/source-path= i/ignore-dependencies keep-prefix skip-patch q/quiet drop-in= test= b/before= u/until= clean dirty U/fresh reuse fresh-roots deprecated
@@ -1405,7 +1405,7 @@ complete -c spack -n '__fish_spack_using_command dev-build' -s u -l until -r -d 
 complete -c spack -n '__fish_spack_using_command dev-build' -l clean -f -a dirty
 complete -c spack -n '__fish_spack_using_command dev-build' -l clean -d 'unset harmful variables in the build environment (default)'
 complete -c spack -n '__fish_spack_using_command dev-build' -l dirty -f -a dirty
-complete -c spack -n '__fish_spack_using_command dev-build' -l dirty -d 'preserve user environment in spack\'s build environment (danger!)'
+complete -c spack -n '__fish_spack_using_command dev-build' -l dirty -d 'preserve user environment in spack'"'"'s build environment (danger!)'
 complete -c spack -n '__fish_spack_using_command dev-build' -s U -l fresh -f -a concretizer_reuse
 complete -c spack -n '__fish_spack_using_command dev-build' -s U -l fresh -d 'do not reuse installed deps; build newest configuration'
 complete -c spack -n '__fish_spack_using_command dev-build' -l reuse -f -a concretizer_reuse
@@ -1483,7 +1483,7 @@ complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a list -d 'list 
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a ls -d 'list managed environments'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a status -d 'print whether there is an active environment'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a st -d 'print whether there is an active environment'
-complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a loads -d 'list modules for an installed environment \'(see spack module loads)\''
+complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a loads -d 'list modules for an installed environment '"'"'(see spack module loads)'"'"''
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a view -d 'manage a view associated with the environment'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a update -d 'update environments to the latest format'
 complete -c spack -n '__fish_spack_using_command_pos 0 env' -f -a revert -d 'restore environments to their state before update'
@@ -1515,9 +1515,9 @@ complete -c spack -n '__fish_spack_using_command env activate' -s p -l prompt -d
 complete -c spack -n '__fish_spack_using_command env activate' -l temp -f -a temp
 complete -c spack -n '__fish_spack_using_command env activate' -l temp -d 'create and activate an environment in a temporary directory'
 complete -c spack -n '__fish_spack_using_command env activate' -l create -f -a create
-complete -c spack -n '__fish_spack_using_command env activate' -l create -d 'create and activate the environment if it doesn\'t exist'
+complete -c spack -n '__fish_spack_using_command env activate' -l create -d 'create and activate the environment if it doesn'"'"'t exist'
 complete -c spack -n '__fish_spack_using_command env activate' -l envfile -r -f -a envfile
-complete -c spack -n '__fish_spack_using_command env activate' -l envfile -r -d 'either a lockfile (must end with \'.json\' or \'.lock\') or a manifest file'
+complete -c spack -n '__fish_spack_using_command env activate' -l envfile -r -d 'either a lockfile (must end with '"'"'.json'"'"' or '"'"'.lock'"'"') or a manifest file'
 complete -c spack -n '__fish_spack_using_command env activate' -l keep-relative -f -a keep_relative
 complete -c spack -n '__fish_spack_using_command env activate' -l keep-relative -d 'copy relative develop paths verbatim into the new environment when initializing from envfile'
 complete -c spack -n '__fish_spack_using_command env activate' -s d -l dir -f -a dir
@@ -1699,7 +1699,7 @@ set -g __fish_spack_optspecs_spack_external_find h/help not-buildable exclude= p
 complete -c spack -n '__fish_spack_using_command external find' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command external find' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command external find' -l not-buildable -f -a not_buildable
-complete -c spack -n '__fish_spack_using_command external find' -l not-buildable -d 'packages with detected externals won\'t be built with Spack'
+complete -c spack -n '__fish_spack_using_command external find' -l not-buildable -d 'packages with detected externals won'"'"'t be built with Spack'
 complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -f -a exclude
 complete -c spack -n '__fish_spack_using_command external find' -l exclude -r -d 'packages to exclude from search'
 complete -c spack -n '__fish_spack_using_command external find' -s p -l path -r -f -a path
@@ -1729,7 +1729,7 @@ complete -c spack -n '__fish_spack_using_command external read-cray-manifest' -l
 complete -c spack -n '__fish_spack_using_command external read-cray-manifest' -l ignore-default-dir -f -a ignore_default_dir
 complete -c spack -n '__fish_spack_using_command external read-cray-manifest' -l ignore-default-dir -d 'ignore the default directory of manifest files'
 complete -c spack -n '__fish_spack_using_command external read-cray-manifest' -l dry-run -f -a dry_run
-complete -c spack -n '__fish_spack_using_command external read-cray-manifest' -l dry-run -d 'don\'t modify DB with files that are read'
+complete -c spack -n '__fish_spack_using_command external read-cray-manifest' -l dry-run -d 'don'"'"'t modify DB with files that are read'
 complete -c spack -n '__fish_spack_using_command external read-cray-manifest' -l fail-on-error -f -a fail_on_error
 complete -c spack -n '__fish_spack_using_command external read-cray-manifest' -l fail-on-error -d 'if a manifest file cannot be parsed, fail and report the full stack trace'
 
@@ -1761,7 +1761,7 @@ complete -c spack -n '__fish_spack_using_command find' -s h -l help -d 'show thi
 complete -c spack -n '__fish_spack_using_command find' -l format -r -f -a format
 complete -c spack -n '__fish_spack_using_command find' -l format -r -d 'output specs with the specified format string'
 complete -c spack -n '__fish_spack_using_command find' -s H -l hashes -f -a format
-complete -c spack -n '__fish_spack_using_command find' -s H -l hashes -d 'same as \'--format {/hash}\'; use with xargs or $()'
+complete -c spack -n '__fish_spack_using_command find' -s H -l hashes -d 'same as '"'"'--format {/hash}'"'"'; use with xargs or $()'
 complete -c spack -n '__fish_spack_using_command find' -l json -f -a json
 complete -c spack -n '__fish_spack_using_command find' -l json -d 'output specs as machine-readable json records'
 complete -c spack -n '__fish_spack_using_command find' -s I -l install-status -f -a install_status
@@ -1783,7 +1783,7 @@ complete -c spack -n '__fish_spack_using_command find' -s t -l tag -r -d 'filter
 complete -c spack -n '__fish_spack_using_command find' -s N -l namespaces -f -a namespaces
 complete -c spack -n '__fish_spack_using_command find' -s N -l namespaces -d 'show fully qualified package names'
 complete -c spack -n '__fish_spack_using_command find' -s r -l only-roots -f -a only_roots
-complete -c spack -n '__fish_spack_using_command find' -s r -l only-roots -d 'don\'t show full list of installed specs in an environment'
+complete -c spack -n '__fish_spack_using_command find' -s r -l only-roots -d 'don'"'"'t show full list of installed specs in an environment'
 complete -c spack -n '__fish_spack_using_command find' -s c -l show-concretized -f -a show_concretized
 complete -c spack -n '__fish_spack_using_command find' -s c -l show-concretized -d 'show concretized specs in an environment'
 complete -c spack -n '__fish_spack_using_command find' -s f -l show-flags -f -a show_flags
@@ -1809,7 +1809,7 @@ complete -c spack -n '__fish_spack_using_command find' -l deprecated -d 'show de
 complete -c spack -n '__fish_spack_using_command find' -l only-deprecated -f -a only_deprecated
 complete -c spack -n '__fish_spack_using_command find' -l only-deprecated -d 'show only deprecated packages'
 complete -c spack -n '__fish_spack_using_command find' -l install-tree -r -f -a install_tree
-complete -c spack -n '__fish_spack_using_command find' -l install-tree -r -d 'Install trees to query: \'all\' (default), \'local\', \'upstream\', upstream name or path'
+complete -c spack -n '__fish_spack_using_command find' -l install-tree -r -d 'Install trees to query: '"'"'all'"'"' (default), '"'"'local'"'"', '"'"'upstream'"'"', upstream name or path'
 complete -c spack -n '__fish_spack_using_command find' -l start-date -r -f -a start_date
 complete -c spack -n '__fish_spack_using_command find' -l start-date -r -d 'earliest date of installation [YYYY-MM-DD]'
 complete -c spack -n '__fish_spack_using_command find' -l end-date -r -f -a end_date
@@ -1935,7 +1935,7 @@ complete -c spack -n '__fish_spack_using_command graph' -s a -l ascii -d 'draw g
 complete -c spack -n '__fish_spack_using_command graph' -s d -l dot -f -a dot
 complete -c spack -n '__fish_spack_using_command graph' -s d -l dot -d 'generate graph in dot format and print to stdout'
 complete -c spack -n '__fish_spack_using_command graph' -s s -l static -f -a static
-complete -c spack -n '__fish_spack_using_command graph' -s s -l static -d 'graph static (possible) deps, don\'t concretize (implies --dot)'
+complete -c spack -n '__fish_spack_using_command graph' -s s -l static -d 'graph static (possible) deps, don'"'"'t concretize (implies --dot)'
 complete -c spack -n '__fish_spack_using_command graph' -s c -l color -f -a color
 complete -c spack -n '__fish_spack_using_command graph' -s c -l color -d 'use different colors for different dependency types'
 complete -c spack -n '__fish_spack_using_command graph' -s i -l installed -f -a installed
@@ -1979,7 +1979,7 @@ complete -c spack -n '__fish_spack_using_command info' -l tests -d 'output relev
 complete -c spack -n '__fish_spack_using_command info' -l virtuals -f -a virtuals
 complete -c spack -n '__fish_spack_using_command info' -l virtuals -d 'output virtual packages'
 complete -c spack -n '__fish_spack_using_command info' -l variants-by-name -f -a variants_by_name
-complete -c spack -n '__fish_spack_using_command info' -l variants-by-name -d 'list variants in strict name order; don\'t group by condition'
+complete -c spack -n '__fish_spack_using_command info' -l variants-by-name -d 'list variants in strict name order; don'"'"'t group by condition'
 
 # spack install
 set -g __fish_spack_optspecs_spack_install h/help only= u/until= j/jobs= overwrite fail-fast keep-prefix keep-stage dont-restage use-cache no-cache cache-only use-buildcache= include-build-deps no-check-signature show-log-on-error source n/no-checksum v/verbose fake only-concrete add no-add f/file= clean dirty test= log-format= log-file= help-cdash cdash-upload-url= cdash-build= cdash-site= cdash-track= cdash-buildstamp= y/yes-to-all U/fresh reuse fresh-roots deprecated
@@ -1997,11 +1997,11 @@ complete -c spack -n '__fish_spack_using_command install' -l overwrite -d 'reins
 complete -c spack -n '__fish_spack_using_command install' -l fail-fast -f -a fail_fast
 complete -c spack -n '__fish_spack_using_command install' -l fail-fast -d 'stop all builds if any build fails (default is best effort)'
 complete -c spack -n '__fish_spack_using_command install' -l keep-prefix -f -a keep_prefix
-complete -c spack -n '__fish_spack_using_command install' -l keep-prefix -d 'don\'t remove the install prefix if installation fails'
+complete -c spack -n '__fish_spack_using_command install' -l keep-prefix -d 'don'"'"'t remove the install prefix if installation fails'
 complete -c spack -n '__fish_spack_using_command install' -l keep-stage -f -a keep_stage
-complete -c spack -n '__fish_spack_using_command install' -l keep-stage -d 'don\'t remove the build stage if installation succeeds'
+complete -c spack -n '__fish_spack_using_command install' -l keep-stage -d 'don'"'"'t remove the build stage if installation succeeds'
 complete -c spack -n '__fish_spack_using_command install' -l dont-restage -f -a dont_restage
-complete -c spack -n '__fish_spack_using_command install' -l dont-restage -d 'if a partial install is detected, don\'t delete prior state'
+complete -c spack -n '__fish_spack_using_command install' -l dont-restage -d 'if a partial install is detected, don'"'"'t delete prior state'
 complete -c spack -n '__fish_spack_using_command install' -l use-cache -f -a use_cache
 complete -c spack -n '__fish_spack_using_command install' -l use-cache -d 'check for pre-built Spack packages in mirrors (default)'
 complete -c spack -n '__fish_spack_using_command install' -l no-cache -f -a use_cache
@@ -2009,7 +2009,7 @@ complete -c spack -n '__fish_spack_using_command install' -l no-cache -d 'do not
 complete -c spack -n '__fish_spack_using_command install' -l cache-only -f -a cache_only
 complete -c spack -n '__fish_spack_using_command install' -l cache-only -d 'only install package from binary mirrors'
 complete -c spack -n '__fish_spack_using_command install' -l use-buildcache -r -f -a use_buildcache
-complete -c spack -n '__fish_spack_using_command install' -l use-buildcache -r -d 'select the mode of buildcache for the \'package\' and \'dependencies\''
+complete -c spack -n '__fish_spack_using_command install' -l use-buildcache -r -d 'select the mode of buildcache for the '"'"'package'"'"' and '"'"'dependencies'"'"''
 complete -c spack -n '__fish_spack_using_command install' -l include-build-deps -f -a include_build_deps
 complete -c spack -n '__fish_spack_using_command install' -l include-build-deps -d 'include build deps when installing from cache, useful for CI pipeline troubleshooting'
 complete -c spack -n '__fish_spack_using_command install' -l no-check-signature -f -a unsigned
@@ -2035,7 +2035,7 @@ complete -c spack -n '__fish_spack_using_command install' -s f -l file -r -d 're
 complete -c spack -n '__fish_spack_using_command install' -l clean -f -a dirty
 complete -c spack -n '__fish_spack_using_command install' -l clean -d 'unset harmful variables in the build environment (default)'
 complete -c spack -n '__fish_spack_using_command install' -l dirty -f -a dirty
-complete -c spack -n '__fish_spack_using_command install' -l dirty -d 'preserve user environment in spack\'s build environment (danger!)'
+complete -c spack -n '__fish_spack_using_command install' -l dirty -d 'preserve user environment in spack'"'"'s build environment (danger!)'
 complete -c spack -n '__fish_spack_using_command install' -l test -r -f -a 'root all'
 complete -c spack -n '__fish_spack_using_command install' -l test -r -d 'run tests on only root packages or all packages'
 complete -c spack -n '__fish_spack_using_command install' -l log-format -r -f -a 'junit cdash'
@@ -2137,7 +2137,7 @@ complete -c spack -n '__fish_spack_using_command location' -s r -l spack-root -d
 complete -c spack -n '__fish_spack_using_command location' -s i -l install-dir -f -a install_dir
 complete -c spack -n '__fish_spack_using_command location' -s i -l install-dir -d 'install prefix for spec (spec need not be installed)'
 complete -c spack -n '__fish_spack_using_command location' -s p -l package-dir -f -a package_dir
-complete -c spack -n '__fish_spack_using_command location' -s p -l package-dir -d 'directory enclosing a spec\'s package.py file'
+complete -c spack -n '__fish_spack_using_command location' -s p -l package-dir -d 'directory enclosing a spec'"'"'s package.py file'
 complete -c spack -n '__fish_spack_using_command location' -s P -l packages -f -a packages
 complete -c spack -n '__fish_spack_using_command location' -s P -l packages -d 'top-level packages directory for Spack'
 complete -c spack -n '__fish_spack_using_command location' -s s -l stage-dir -f -a stage_dir
@@ -2244,11 +2244,11 @@ complete -c spack -n '__fish_spack_using_command mirror create' -l exclude-file 
 complete -c spack -n '__fish_spack_using_command mirror create' -l exclude-specs -r -f -a exclude_specs
 complete -c spack -n '__fish_spack_using_command mirror create' -l exclude-specs -r -d 'specs which Spack should not try to add to a mirror (specified on command line)'
 complete -c spack -n '__fish_spack_using_command mirror create' -l skip-unstable-versions -f -a skip_unstable_versions
-complete -c spack -n '__fish_spack_using_command mirror create' -l skip-unstable-versions -d 'don\'t cache versions unless they identify a stable (unchanging) source code'
+complete -c spack -n '__fish_spack_using_command mirror create' -l skip-unstable-versions -d 'don'"'"'t cache versions unless they identify a stable (unchanging) source code'
 complete -c spack -n '__fish_spack_using_command mirror create' -s D -l dependencies -f -a dependencies
 complete -c spack -n '__fish_spack_using_command mirror create' -s D -l dependencies -d 'also fetch all dependencies'
 complete -c spack -n '__fish_spack_using_command mirror create' -s n -l versions-per-spec -r -f -a versions_per_spec
-complete -c spack -n '__fish_spack_using_command mirror create' -s n -l versions-per-spec -r -d 'the number of versions to fetch for each spec, choose \'all\' to retrieve all versions of each package'
+complete -c spack -n '__fish_spack_using_command mirror create' -s n -l versions-per-spec -r -d 'the number of versions to fetch for each spec, choose '"'"'all'"'"' to retrieve all versions of each package'
 complete -c spack -n '__fish_spack_using_command mirror create' -l private -f -a private
 complete -c spack -n '__fish_spack_using_command mirror create' -l private -d 'for a private mirror, include non-redistributable packages'
 complete -c spack -n '__fish_spack_using_command mirror create' -s U -l fresh -f -a concretizer_reuse
@@ -2353,7 +2353,7 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l fetch -d 'modify
 complete -c spack -n '__fish_spack_using_command mirror set' -l type -r -f -a 'binary source'
 complete -c spack -n '__fish_spack_using_command mirror set' -l type -r -d 'specify the mirror type: for both binary and source use `--type binary --type source`'
 complete -c spack -n '__fish_spack_using_command mirror set' -l url -r -f -a url
-complete -c spack -n '__fish_spack_using_command mirror set' -l url -r -d 'url of mirror directory from \'spack mirror create\''
+complete -c spack -n '__fish_spack_using_command mirror set' -l url -r -d 'url of mirror directory from '"'"'spack mirror create'"'"''
 complete -c spack -n '__fish_spack_using_command mirror set' -l autopush -f -a autopush
 complete -c spack -n '__fish_spack_using_command mirror set' -l autopush -d 'set mirror to push automatically after installation'
 complete -c spack -n '__fish_spack_using_command mirror set' -l no-autopush -f -a autopush
@@ -2580,7 +2580,7 @@ complete -c spack -n '__fish_spack_using_command_pos 1 pkg changed' -f -a '(__fi
 complete -c spack -n '__fish_spack_using_command pkg changed' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command pkg changed' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command pkg changed' -s t -l type -r -f -a type
-complete -c spack -n '__fish_spack_using_command pkg changed' -s t -l type -r -d 'types of changes to show (A: added, R: removed, C: changed); default is \'C\''
+complete -c spack -n '__fish_spack_using_command pkg changed' -s t -l type -r -d 'types of changes to show (A: added, R: removed, C: changed); default is '"'"'C'"'"''
 
 # spack pkg removed
 set -g __fish_spack_optspecs_spack_pkg_removed h/help
@@ -2672,9 +2672,9 @@ complete -c spack -n '__fish_spack_using_command rm' -s f -l force -d 'remove co
 set -g __fish_spack_optspecs_spack_repo h/help
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a create -d 'create a new package repository'
 complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a list -d 'show registered repositories and their namespaces'
-complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a add -d 'add a package source to Spack\'s configuration'
-complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a remove -d 'remove a repository from Spack\'s configuration'
-complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a rm -d 'remove a repository from Spack\'s configuration'
+complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a add -d 'add a package source to Spack'"'"'s configuration'
+complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a remove -d 'remove a repository from Spack'"'"'s configuration'
+complete -c spack -n '__fish_spack_using_command_pos 0 repo' -f -a rm -d 'remove a repository from Spack'"'"'s configuration'
 complete -c spack -n '__fish_spack_using_command repo' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command repo' -s h -l help -d 'show this help message and exit'
 
@@ -2907,7 +2907,7 @@ complete -c spack -n '__fish_spack_using_command test run' -l help-cdash -d 'sho
 complete -c spack -n '__fish_spack_using_command test run' -l clean -f -a dirty
 complete -c spack -n '__fish_spack_using_command test run' -l clean -d 'unset harmful variables in the build environment (default)'
 complete -c spack -n '__fish_spack_using_command test run' -l dirty -f -a dirty
-complete -c spack -n '__fish_spack_using_command test run' -l dirty -d 'preserve user environment in spack\'s build environment (danger!)'
+complete -c spack -n '__fish_spack_using_command test run' -l dirty -d 'preserve user environment in spack'"'"'s build environment (danger!)'
 
 # spack test list
 set -g __fish_spack_optspecs_spack_test_list h/help a/all
@@ -2955,7 +2955,7 @@ complete -c spack -n '__fish_spack_using_command test-env' -s h -l help -d 'show
 complete -c spack -n '__fish_spack_using_command test-env' -l clean -f -a dirty
 complete -c spack -n '__fish_spack_using_command test-env' -l clean -d 'unset harmful variables in the build environment (default)'
 complete -c spack -n '__fish_spack_using_command test-env' -l dirty -f -a dirty
-complete -c spack -n '__fish_spack_using_command test-env' -l dirty -d 'preserve user environment in spack\'s build environment (danger!)'
+complete -c spack -n '__fish_spack_using_command test-env' -l dirty -d 'preserve user environment in spack'"'"'s build environment (danger!)'
 complete -c spack -n '__fish_spack_using_command test-env' -s U -l fresh -f -a concretizer_reuse
 complete -c spack -n '__fish_spack_using_command test-env' -s U -l fresh -d 'do not reuse installed deps; build newest configuration'
 complete -c spack -n '__fish_spack_using_command test-env' -l reuse -f -a concretizer_reuse


### PR DESCRIPTION
Closes #46250. Fixes a bug where `(xyz)` was not quoted.

shlex prefers `'"'"'` over `\'` in single quoted strings, which is fine by me.