### PR TITLE
Added a missing python dependency (gffutils)

### DIFF
--- a/var/spack/repos/builtin/packages/bcftools/package.py
+++ b/var/spack/repos/builtin/packages/bcftools/package.py
@@ -55,6 +55,7 @@ class Bcftools(AutotoolsPackage):
 
     depends_on("gsl", when="+libgsl")
     depends_on("py-matplotlib", when="@1.6:", type="run")
+    depends_on("py-gffutils", when="@1.9:", type="run")
     depends_on("perl", when="@1.8:~perl-filters", type="run")
     depends_on("perl", when="@1.8:+perl-filters", type=("build", "run"))
 


### PR DESCRIPTION
bcftools comes with a script [gff2gff](https://samtools.github.io/bcftools/bcftools.html#gff2gff) but this fails in the spack build as it's missing a dependency on gffutils.

```(module load bcftools-1.19/python-3.11.6 && gff2gff.py)
Loading bcftools-1.19/python-3.11.6
  Loading requirement: python-3.11.6/perl-5.38.0
Traceback (most recent call last):
  File "/x/y/z/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-13.1.0/bcftools-1.19-it7i34mcvtotomowem6q3l3cr6xk7i5n/bin/gff2gff.py", line 13, in <module>
    import gffutils
ModuleNotFoundError: No module named 'gffutils'
```

I have only tested this on version 1.19 (it may well be a requirement for earlier versions); however 1.19 is over a year old.