### PR TITLE
py-xgboost: add v2.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-xgboost/package.py
+++ b/var/spack/repos/builtin/packages/py-xgboost/package.py
@@ -70,8 +70,8 @@ class PyXgboost(PythonPackage):
             depends_on("py-matplotlib")
 
     def patch(self):
+        # Hard-coded to search for system libxgboost in the Python installation prefix
         # https://github.com/dmlc/xgboost/issues/6706
-        # Library is hard-coded to search in Python installation prefix at build and run time
         files = [os.path.join("xgboost", "libpath.py")]
         if self.spec.satisfies("@2:"):
             regex = "sys.base_prefix"

--- a/var/spack/repos/builtin/packages/py-xgboost/package.py
+++ b/var/spack/repos/builtin/packages/py-xgboost/package.py
@@ -14,18 +14,18 @@ class PyXgboost(PythonPackage):
 
     homepage = "https://xgboost.ai/"
     pypi = "xgboost/xgboost-1.3.3.tar.gz"
-
-    maintainers("adamjstewart")
     import_modules = ["xgboost"]
 
     license("Apache-2.0")
+    maintainers("adamjstewart")
 
+    version("2.1.1", sha256="4b1729837f9f1ba88a32ef1be3f8efb860fee6454a68719b196dc88032c23d97")
+    version("2.1.0", sha256="7144980923e76ce741c7b03a14d3bd7514db6de5c7cabe96ba95b229d274f5ca")
+    version("1.7.6", sha256="1c527554a400445e0c38186039ba1a00425dcdb4e40b37eed0e74cb39a159c47")
     version("1.6.2", sha256="e1f5c91ba88cf8edb409d7fd2ca150dcd80b6f2115587d87365f0c10b2d4f009")
     version("1.6.1", sha256="24072028656f3428e7b8aabf77340ece057f273e41f7f85d67ccaefb7454bb18")
     version("1.5.2", sha256="404dc09dca887ef5a9bc0268f882c54b33bfc16ac365a859a11e7b24d49da387")
     version("1.3.3", sha256="397051647bb837915f3ff24afc7d49f7fca57630ffd00fb5ef66ae2a0881fb43")
-
-    depends_on("cxx", type="build")  # generated
 
     variant("pandas", default=False, description="Enable Pandas extensions for training.")
     variant(
@@ -34,48 +34,57 @@ class PyXgboost(PythonPackage):
     variant("dask", default=False, description="Enables Dask extensions for distributed training.")
     variant("plotting", default=False, description="Enables tree and importance plotting.")
 
-    for ver in ["1.3.3", "1.5.2", "1.6.1", "1.6.2"]:
+    for ver in ["1.3.3", "1.5.2", "1.6.1", "1.6.2", "1.7.6", "2.1.0", "2.1.1"]:
         depends_on("xgboost@" + ver, when="@" + ver)
 
-    depends_on("python@3.7:", when="@1.6:", type=("build", "run"))
-    depends_on("python@3.6:", type=("build", "run"))
-    depends_on("py-setuptools", type=("build"))
-    # in newer pip versions --install-option does not exist
-    depends_on("py-pip@:23.0", type="build")
+    with default_args(type="build"):
+        depends_on("py-hatchling@1.12.1:", type="build", when="@2:")
+        # Required to use --config-settings
+        depends_on("py-pip@22.1:", when="@2:")
 
-    depends_on("py-numpy", type=("build", "run"))
-    # https://github.com/dmlc/xgboost/issues/10221
-    depends_on("py-numpy@:1", when="@:2.0", type=("build", "run"))
-    depends_on("py-scipy", type=("build", "run"))
+        # Historical dependencies
+        depends_on("py-setuptools")
+        # in newer pip versions --install-option does not exist
+        depends_on("py-pip@:23.0")
 
-    depends_on("py-pandas", when="+pandas", type=("build", "run"))
+    with default_args(type=("build", "run")):
+        depends_on("py-numpy", type=("build", "run"))
+        # https://github.com/dmlc/xgboost/issues/10221
+        depends_on("py-numpy@:1", when="@:2.0", type=("build", "run"))
+        depends_on("py-scipy", type=("build", "run"))
 
-    depends_on("py-scikit-learn", when="+scikit-learn", type=("build", "run"))
+        with when("+pandas"):
+            depends_on("py-pandas@1.2:", when="@2:")
+            depends_on("py-pandas")
 
-    depends_on("py-dask", when="+dask", type=("build", "run"))
-    depends_on("py-pandas", when="+dask", type=("build", "run"))
-    depends_on("py-distributed", when="+dask", type=("build", "run"))
+        with when("+scikit-learn"):
+            depends_on("py-scikit-learn")
 
-    depends_on("py-graphviz", when="+plotting", type=("build", "run"))
-    depends_on("py-matplotlib", when="+plotting", type=("build", "run"))
+        with when("+dask"):
+            depends_on("py-dask")
+            depends_on("py-pandas")
+            depends_on("py-distributed")
+
+        with when("+plotting"):
+            depends_on("py-graphviz")
+            depends_on("py-matplotlib")
 
     def patch(self):
         # https://github.com/dmlc/xgboost/issues/6706
-        # 'setup.py' is hard-coded to search in Python installation prefix
-        filter_file(
-            "lib_path = os.path.join(sys.prefix, 'lib')",
-            "lib_path = '{0}'".format(self.spec["xgboost"].libs.directories[0]),
-            "setup.py",
-            string=True,
-        )
+        # Library is hard-coded to search in Python installation prefix at build and run time
+        files = [os.path.join("xgboost", "libpath.py")]
+        if self.spec.satisfies("@2:"):
+            regex = "sys.base_prefix"
+            files.append(os.path.join("packager", "nativelib.py"))
+        else:
+            regex = "sys.prefix"
+            files.append("setup.py")
+        filter_file(regex, repr(self.spec["xgboost"].prefix), *files, string=True)
 
-        # Same for run-time search
-        filter_file(
-            "os.path.join(curr_path, 'lib'),",
-            "'{0}',".format(self.spec["xgboost"].libs.directories[0]),
-            os.path.join("xgboost", "libpath.py"),
-            string=True,
-        )
+    @when("@2:")
+    def config_settings(self, spec, prefix):
+        return {"use_system_libxgboost": True}
 
+    @when("@:1")
     def install_options(self, spec, prefix):
         return ["--use-system-libxgboost"]

--- a/var/spack/repos/builtin/packages/py-xgboost/package.py
+++ b/var/spack/repos/builtin/packages/py-xgboost/package.py
@@ -43,9 +43,9 @@ class PyXgboost(PythonPackage):
         depends_on("py-pip@22.1:", when="@2:")
 
         # Historical dependencies
-        depends_on("py-setuptools")
+        depends_on("py-setuptools", when="@:1")
         # in newer pip versions --install-option does not exist
-        depends_on("py-pip@:23.0")
+        depends_on("py-pip@:23.0", when="@:1")
 
     with default_args(type=("build", "run")):
         depends_on("py-numpy", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/xgboost/package.py
+++ b/var/spack/repos/builtin/packages/xgboost/package.py
@@ -53,7 +53,7 @@ class Xgboost(CMakePackage, CudaPackage):
         # thrust 2.3.1 tuple issues
         depends_on("cuda@:12.3", when="@:1.7")
         # https://github.com/dmlc/xgboost/issues/10555
-        depends_on("cuda@:12.4", when="@:2.1.0")  # assuming fix is backported
+        depends_on("cuda@:12.4", when="@:2.1")
 
     depends_on("nccl", when="+nccl")
     depends_on("llvm-openmp", when="%apple-clang +openmp")

--- a/var/spack/repos/builtin/packages/xgboost/package.py
+++ b/var/spack/repos/builtin/packages/xgboost/package.py
@@ -18,33 +18,22 @@ class Xgboost(CMakePackage, CudaPackage):
 
     homepage = "https://xgboost.ai/"
     git = "https://github.com/dmlc/xgboost.git"
-
-    maintainers("adamjstewart")
+    submodules = True
 
     license("Apache-2.0")
+    maintainers("adamjstewart")
 
-    version("master", branch="master", submodules=True)
-    version(
-        "2.1.0", tag="v2.1.0", commit="213ebf7796b757448dfa2cfba532074696fa1524", submodules=True
-    )
-    version(
-        "1.7.6", tag="v1.7.6", commit="36eb41c960483c8b52b44082663c99e6a0de440a", submodules=True
-    )
-    version(
-        "1.6.2", tag="v1.6.2", commit="b9934246faa9a25e10a12339685dfbe56d56f70b", submodules=True
-    )
-    version(
-        "1.6.1", tag="v1.6.1", commit="5d92a7d936fc3fad4c7ecb6031c3c1c7da882a14", submodules=True
-    )
-    version(
-        "1.5.2", tag="v1.5.2", commit="742c19f3ecf2135b4e008a4f4a10b59add8b1045", submodules=True
-    )
-    version(
-        "1.3.3", tag="v1.3.3", commit="000292ce6d99ed658f6f9aebabc6e9b330696e7e", submodules=True
-    )
+    version("master", branch="master")
+    version("2.1.1", tag="v2.1.1", commit="9c9db1259240bffe9040ed7ca6e3fb2c1bda80e4")
+    version("2.1.0", tag="v2.1.0", commit="213ebf7796b757448dfa2cfba532074696fa1524")
+    version("1.7.6", tag="v1.7.6", commit="36eb41c960483c8b52b44082663c99e6a0de440a")
+    version("1.6.2", tag="v1.6.2", commit="b9934246faa9a25e10a12339685dfbe56d56f70b")
+    version("1.6.1", tag="v1.6.1", commit="5d92a7d936fc3fad4c7ecb6031c3c1c7da882a14")
+    version("1.5.2", tag="v1.5.2", commit="742c19f3ecf2135b4e008a4f4a10b59add8b1045")
+    version("1.3.3", tag="v1.3.3", commit="000292ce6d99ed658f6f9aebabc6e9b330696e7e")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     variant("nccl", default=False, description="Build with NCCL to enable distributed GPU support")
     variant("openmp", default=True, description="Build with OpenMP support")


### PR DESCRIPTION
Extracted out of #45644 so that PR can be simpler.

I successfully built both py-xgboost 1.7.6 and 2.1.1 on macOS arm64. I didn't test Linux, but CI will test that for us.