### PR TITLE
Ensure spack_store_rpath_dirs_list is empty when add_rpaths is false

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -839,6 +839,11 @@ if [ "$mode" = ccld ] || [ "$mode" = ld ]; then
         # it is assumed that paths have already been confirmed.
         extend spack_store_rpath_dirs_list SPACK_STORE_RPATH_DIRS
         extend rpath_dirs_list SPACK_RPATH_DIRS
+    else 
+        # If a compiler is configured with extra_rpaths, these are passed in as `-Wl,-rpath`
+        # which are ultimately stored in spack_store_rpath_dirs_list via parse_Wl. These
+        # are added even when $add_rpaths=false, causing issues.
+        spack_store_rpath_dirs_list=""
     fi
 fi
 


### PR DESCRIPTION
Fixes #45919

If a compiler is defined to have `extra_rpaths` these are passed in as `-Wl,-rpath`. Thus, this arg gets stored into `return_spack_store_rpath_dirs_list`, via `parse_Wl`, and ultimately into `spack_store_rpath_dirs_list`. The rpath then is added [unconditionally](https://github.com/spack/spack/blob/develop/lib/spack/env/cc#L948) to `args_list` in `ccld` mode even if `$add_rpaths=false`. Not adding rpaths is required on darwin when using the -r flag. The existing rpath protection on darwin does not consider this edge case, so this PR adds it by ensuring any `-Wl,-rpath` detected rpaths are cleared out.
