### PR TITLE
assimp: add v5.4.3, enable testing

### DIFF
--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -68,3 +68,12 @@ class Assimp(CMakePackage):
         if name == "cxxflags":
             flags.append(self.compiler.cxx11_flag)
         return (None, None, flags)
+
+    def check(self):
+        unit = Executable(join_path(self.builder.build_directory, "bin", "unit"))
+        skipped_tests = [
+            "AssimpAPITest_aiMatrix3x3.aiMatrix3FromToTest",
+            "AssimpAPITest_aiMatrix4x4.aiMatrix4FromToTest",
+            "AssimpAPITest_aiQuaternion.aiQuaternionFromNormalizedQuaternionTest",
+        ]
+        unit(f"--gtest_filter=-{':'.join(skipped_tests)}")

--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -16,9 +16,10 @@ class Assimp(CMakePackage):
 
     maintainers("wdconinc")
 
-    license("BSD-3-Clause")
+    license("BSD-3-Clause", checked_by="wdconinc")
 
     version("master", branch="master")
+    version("5.4.3", sha256="66dfbaee288f2bc43172440a55d0235dfc7bf885dda6435c038e8000e79582cb")
     version("5.4.2", sha256="7414861a7b038e407b510e8b8c9e58d5bf8ca76c9dfe07a01d20af388ec5086a")
     version("5.4.0", sha256="a90f77b0269addb2f381b00c09ad47710f2aab6b1d904f5e9a29953c30104d3f")
     version("5.3.1", sha256="a07666be71afe1ad4bc008c2336b7c688aca391271188eb9108d0c6db1be53f1")
@@ -32,9 +33,6 @@ class Assimp(CMakePackage):
     version("5.0.1", sha256="11310ec1f2ad2cd46b95ba88faca8f7aaa1efe9aa12605c55e3de2b977b3dbfc")
     version("4.0.1", sha256="60080d8ab4daaab309f65b3cffd99f19eb1af8d05623fff469b9b652818e286e")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-
     patch(
         "https://patch-diff.githubusercontent.com/raw/assimp/assimp/pull/4203.patch?full_index=1",
         sha256="24135e88bcef205e118f7a3f99948851c78d3f3e16684104dc603439dd790d74",
@@ -42,6 +40,9 @@ class Assimp(CMakePackage):
     )
 
     variant("shared", default=True, description="Enables the build of shared libraries")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("cmake@3.10:", type="build", when="@5.1:")
     depends_on("cmake@3.22:", type="build", when="@5.4:")
@@ -54,10 +55,10 @@ class Assimp(CMakePackage):
 
     def cmake_args(self):
         args = [
-            "-DASSIMP_HUNTER_ENABLED=OFF",
-            "-DASSIMP_BUILD_ZLIB=OFF",
-            "-DASSIMP_BUILD_MINIZIP=OFF",
-            "-DASSIMP_BUILD_TESTS=OFF",
+            self.define("ASSIMP_HUNTER_ENABLED", False),
+            self.define("ASSIMP_BUILD_ZLIB", False),
+            self.define("ASSIMP_BUILD_MINIZIP", False),
+            self.define("ASSIMP_BUILD_TESTS", self.run_tests),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
         ]
         return args


### PR DESCRIPTION
This PR adds `assimp`, v5.4.3. This is a bugfix release, https://github.com/assimp/assimp/releases/tag/v5.4.3, with no relevant changes to the build system (https://github.com/assimp/assimp/compare/v5.4.2...v5.4.3).

This PR also adds testing functionality (test dependencies are vendored at https://github.com/assimp/assimp/tree/master/contrib and can only be externally provided when using hunter).

Test build:
```
==> Installing assimp-5.4.3-wvzvc4ojk3vhyo65cbiqiqjlpo7vhxfa [11/11]
==> No binary for assimp-5.4.3-wvzvc4ojk3vhyo65cbiqiqjlpo7vhxfa found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/66/66dfbaee288f2bc43172440a55d0235dfc7bf885dda6435c038e8000e79582cb.tar.gz
==> Ran patch() for assimp
==> assimp: Executing phase: 'cmake'
==> assimp: Executing phase: 'build'
==> assimp: Executing phase: 'install'
==> assimp: Successfully installed assimp-5.4.3-wvzvc4ojk3vhyo65cbiqiqjlpo7vhxfa
  Stage: 0.84s.  Cmake: 0.35s.  Build: 4.02s.  Install: 0.49s.  Post-install: 0.12s.  Total: 5.97s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/assimp-5.4.3-wvzvc4ojk3vhyo65cbiqiqjlpo7vhxfa
```