### PR TITLE
perl-graphviz: add graphviz dependency

### DIFF
--- a/var/spack/repos/builtin/packages/perl-graphviz/package.py
+++ b/var/spack/repos/builtin/packages/perl-graphviz/package.py
@@ -18,6 +18,7 @@ class PerlGraphviz(PerlPackage):
 
     version("2.26", sha256="9a5d2520b3262bf30475272dd764a445f8e7f931bef88be0e3d3bff445da7328")
 
+    depends_on("graphviz", type=("build", "run", "test"))
     depends_on("perl-file-which@1.09:", type=("build", "run", "test"))
     depends_on("perl-ipc-run@0.6:", type=("build", "run", "test"))
     depends_on("perl-libwww-perl", type=("build", "run", "test"))


### PR DESCRIPTION
Noticed that `perl-graphviz` did not build while testing #46213 due to a reported missing `dot` executable. Adding a `graphviz` dependency resolved this.