### PR TITLE
wayland-protocols: add v1.37

### DIFF
--- a/var/spack/repos/builtin/packages/wayland-protocols/package.py
+++ b/var/spack/repos/builtin/packages/wayland-protocols/package.py
@@ -28,6 +28,7 @@ class WaylandProtocols(MesonPackage, AutotoolsPackage):
 
     license("MIT")
 
+    version("1.37", sha256="c3b215084eb4cf318415533554c2c2714e58ed75847d7c3a8e50923215ffbbf3")
     version("1.36", sha256="c839dd4325565fd59a93d6cde17335357328f66983c2e1fb03c33e92d6918b17")
     version("1.35", sha256="6e62dfa92ce82487d107b76064cfe2d7ca107c87c239ea9036a763d79c09105a")
     version("1.34", sha256="cd3cc9dedb838e6fc8f55bbeb688e8569ffac7df53bc59dbfac8acbb39267f05")


### PR DESCRIPTION
This PR adds `wayland-protocols`, v1.37. No build system changes needed (https://gitlab.freedesktop.org/wayland/wayland-protocols/-/compare/1.36...1.37?from_project_id=2891&straight=false).

Test build:
```
==> Installing wayland-protocols-1.37-y64vfb7icmgpak7klfyabg2r253jtaht [35/35]
==> No binary for wayland-protocols-1.37-y64vfb7icmgpak7klfyabg2r253jtaht found: installing from source
==> Fetching https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.37/wayland-protocols-1.37.tar.gz
==> No patches needed for wayland-protocols
==> wayland-protocols: Executing phase: 'meson'
==> wayland-protocols: Executing phase: 'build'
==> wayland-protocols: Executing phase: 'install'
==> wayland-protocols: Successfully installed wayland-protocols-1.37-y64vfb7icmgpak7klfyabg2r253jtaht
  Stage: 1.86s.  Meson: 0.41s.  Build: 0.00s.  Install: 0.24s.  Post-install: 0.17s.  Total: 2.83s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/wayland-protocols-1.37-y64vfb7icmgpak7klfyabg2r253jtaht
```