### PR TITLE
xrootd: add v5.7.1

### DIFF
--- a/var/spack/repos/builtin/packages/xrootd/package.py
+++ b/var/spack/repos/builtin/packages/xrootd/package.py
@@ -23,6 +23,7 @@ class Xrootd(CMakePackage):
 
     license("LGPL-3.0-only")
 
+    version("5.7.1", sha256="c28c9dc0a2f5d0134e803981be8b1e8b1c9a6ec13b49f5fa3040889b439f4041")
     version("5.7.0", sha256="214599bba98bc69875b82ac74f2d4b9ac8a554a1024119d8a9802b3d8b9986f8")
     version("5.6.9", sha256="44196167fbcf030d113e3749dfdecab934c43ec15e38e77481e29aac191ca3a8")
     version("5.6.8", sha256="19268fd9f0307d936da3598a5eb8471328e059c58f60d91d1ce7305ca0d57528")


### PR DESCRIPTION
This PR adds `xrootd` v5.7.1. Based on [diff](https://github.com/xrootd/xrootd/compare/v5.7.0...v5.7.1), there are no changes that need to be propagated to the spack package recipe. The release note "Update CMake minimum requirement and supported versions" refers to the policy settings upper limit, https://github.com/xrootd/xrootd/commit/7c51f3a38c5d5e5bde744ca52abf20c51f6856cf.

Test build:
```
==> Installing xrootd-5.7.1-bds6ntfadxlknlbjkocymvskberkkklx [32/32]
==> No binary for xrootd-5.7.1-bds6ntfadxlknlbjkocymvskberkkklx found: installing from source
==> Fetching https://xrootd.web.cern.ch/download/v5.7.1/xrootd-5.7.1.tar.gz
==> Applied patch /home/wdconinc/git/spack/var/spack/repos/builtin/packages/xrootd/no-systemd-5.5.2.patch
==> Ran patch() for xrootd
==> xrootd: Executing phase: 'cmake'
==> xrootd: Executing phase: 'build'
==> xrootd: Executing phase: 'install'
==> xrootd: Successfully installed xrootd-5.7.1-bds6ntfadxlknlbjkocymvskberkkklx
  Stage: 2.86s.  Cmake: 3.75s.  Build: 3m 39.58s.  Install: 0.48s.  Post-install: 0.24s.  Total: 3m 47.31s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/xrootd-5.7.1-bds6ntfadxlknlbjkocymvskberkkklx
```