### PR TITLE
(py-)onnx: add v1.16.2; onnx: enable testing

### DIFF
--- a/var/spack/repos/builtin/packages/onnx/package.py
+++ b/var/spack/repos/builtin/packages/onnx/package.py
@@ -17,9 +17,10 @@ class Onnx(CMakePackage):
     url = "https://github.com/onnx/onnx/archive/refs/tags/v1.9.0.tar.gz"
     git = "https://github.com/onnx/onnx.git"
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked_by="wdconinc")
 
     version("master", branch="master")
+    version("1.16.2", sha256="84fc1c3d6133417f8a13af6643ed50983c91dacde5ffba16cc8bb39b22c2acbb")
     version("1.16.1", sha256="0e6aa2c0a59bb2d90858ad0040ea1807117cc2f05b97702170f18e6cd6b66fb3")
     version("1.16.0", sha256="0ce153e26ce2c00afca01c331a447d86fbf21b166b640551fe04258b4acfc6a4")
     version("1.15.0", sha256="c757132e018dd0dd171499ef74fca88b74c5430a20781ec53da19eb7f937ef68")
@@ -61,7 +62,7 @@ class Onnx(CMakePackage):
         "1.1.0_2018-04-19", commit="7e1bed51cc508a25b22130de459830b5d5063c41"
     )  # py-torch@0.4.0
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     generator("ninja")
     depends_on("cmake@3.1:", type="build")
@@ -73,6 +74,9 @@ class Onnx(CMakePackage):
             filter_file("CMAKE_CXX_STANDARD 11", "CMAKE_CXX_STANDARD 14", "CMakeLists.txt")
 
     def cmake_args(self):
-        # Try to get ONNX to use the same version of python as the spec is using
-        args = ["-DPY_VERSION={0}".format(self.spec["python"].version.up_to(2))]
+        args = [
+            # Try to get ONNX to use the same version of python as the spec is using
+            self.define("PY_VERSION", self.spec["python"].version.up_to(2)),
+            self.define("ONNX_BUILD_TESTS", self.run_tests),
+        ]
         return args

--- a/var/spack/repos/builtin/packages/py-onnx/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx/package.py
@@ -21,6 +21,7 @@ class PyOnnx(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.16.2", sha256="b33a282b038813c4b69e73ea65c2909768e8dd6cc10619b70632335daf094646")
     version("1.16.1", sha256="8299193f0f2a3849bfc069641aa8e4f93696602da8d165632af8ee48ec7556b6")
     version("1.16.0", sha256="237c6987c6c59d9f44b6136f5819af79574f8d96a760a1fa843bede11f3822f7")
     version("1.15.0", sha256="b18461a7d38f286618ca2a6e78062a2a9c634ce498e631e708a8041b00094825")
@@ -59,6 +60,8 @@ class PyOnnx(PythonPackage):
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-numpy@1.16.6:", type=("build", "run"), when="@1.8.1:1.13")
     depends_on("py-numpy@1.20:", type=("build", "run"), when="@1.16.0:")
+    depends_on("py-numpy@1.21:", type=("build", "run"), when="@1.16.2:")
+    depends_on("py-numpy@:1", type=("build", "run"), when="@:1.16")
 
     # Historical dependencies
     depends_on("py-six", type=("build", "run"), when="@:1.8.1")

--- a/var/spack/repos/builtin/packages/py-onnx/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx/package.py
@@ -19,7 +19,7 @@ class PyOnnx(PythonPackage):
     homepage = "https://github.com/onnx/onnx"
     pypi = "Onnx/onnx-1.6.0.tar.gz"
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked_by="wdconinc")
 
     version("1.16.2", sha256="b33a282b038813c4b69e73ea65c2909768e8dd6cc10619b70632335daf094646")
     version("1.16.1", sha256="8299193f0f2a3849bfc069641aa8e4f93696602da8d165632af8ee48ec7556b6")


### PR DESCRIPTION
This PR adds `onnx` and `py-onnx` v1.16.2.  Diff at https://github.com/onnx/onnx/compare/v1.16.1...v1.16.2. Numpy>=2 support will be in onnx 1.17, but isn't there yet; see https://github.com/onnx/onnx/pull/6257.

Test builds:
```
==> Installing onnx-1.16.2-k5k2ptrp424ajex2s2ko3ca7rfbuajkp [32/32]
==> No binary for onnx-1.16.2-k5k2ptrp424ajex2s2ko3ca7rfbuajkp found: installing from source
==> Already patched onnx
==> onnx: Executing phase: 'cmake'
==> onnx: Executing phase: 'build'
==> onnx: Executing phase: 'install'
==> onnx: Successfully installed onnx-1.16.2-k5k2ptrp424ajex2s2ko3ca7rfbuajkp
  Stage: 0.00s.  Cmake: 0.29s.  Build: 0.08s.  Install: 0.04s.  Post-install: 0.22s.  Total: 0.79s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/onnx-1.16.2-k5k2ptrp424ajex2s2ko3ca7rfbuajkp
==> Installing py-onnx-1.16.2-fulowylcy6qx3qdk2oydt2ph2h7ddd4g [37/37]
==> No binary for py-onnx-1.16.2-fulowylcy6qx3qdk2oydt2ph2h7ddd4g found: installing from source
==> Already patched py-onnx
==> py-onnx: Executing phase: 'install'
==> py-onnx: Successfully installed py-onnx-1.16.2-fulowylcy6qx3qdk2oydt2ph2h7ddd4g
  Stage: 0.00s.  Install: 1m 34.71s.  Post-install: 2.41s.  Total: 1m 37.40s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/py-onnx-1.16.2-fulowylcy6qx3qdk2oydt2ph2h7ddd4g
```
with `onnx` tests:
```
$ cat /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/onnx-1.16.2-k5k2ptrp424ajex2s2ko3ca7rfbuajkp/.spack/install-time-test-log.txt 
==> Testing package onnx-1.16.2-k5k2ptr
==> [2024-09-07-17:57:39.074627] Running build-time tests
==> [2024-09-07-17:57:39.074691] RUN-TESTS: build-time tests [check]
==> [2024-09-07-17:57:39.075620] 'ninja' '-j8' '-t' 'targets' 'all'
==> [2024-09-07-17:57:39.078758] 'ninja' '-j8' 'test'
[0/1] Running tests...
Test project /opt/spack/stage/wdconinc/spack-stage-onnx-1.16.2-k5k2ptrp424ajex2s2ko3ca7rfbuajkp/spack-build-k5k2ptr
    Start 1: onnx_gtests
1/1 Test #1: onnx_gtests ......................   Passed    0.04 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.05 sec
==> [2024-09-07-17:57:39.130704] 'ninja' '-j8' '-t' 'targets' 'all'
==> [2024-09-07-17:57:39.133133] Target 'check' not found in build.ninja
```