### PR TITLE
acts: allow version 1 of podio for gcc14 and add dfelibs dependency

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -377,9 +377,9 @@ class Acts(CMakePackage, CudaPackage):
     depends_on("nlohmann-json @3.9.1:", when="@0.14: +json")
     depends_on("podio @0.6:", when="@25: +edm4hep")
     depends_on("podio @0.16:", when="@30.3: +edm4hep")
-    depends_on("podio @:0", when="@:35 +edm4hep")
+    depends_on("podio", when="@:35 +edm4hep")
     depends_on("podio @0.16:", when="+podio")
-    depends_on("podio @:0", when="@:35 +podio")
+    depends_on("podio", when="@:35 +podio")
     depends_on("pythia8", when="+pythia8")
     depends_on("python", when="+python")
     depends_on("python@3.8:", when="+python @19.11:19")
@@ -389,6 +389,7 @@ class Acts(CMakePackage, CudaPackage):
     depends_on("py-pybind11 @2.6.2:", when="+python @18:")
     depends_on("py-pybind11 @2.13.1:", when="+python @36:")
     depends_on("py-pytest", when="+python +unit_tests")
+    depends_on("dfelibs")
 
     with when("+tgeo"):
         depends_on("root @6.10:")


### PR DESCRIPTION
This allows acts to use version 1 of podio which has gcc14 compilation fixes, and adds a dependency on dfelibs which is necessary for compile
