### PR TITLE
boost: Refactor header-only install and add missing compiled libraries

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -116,7 +116,9 @@ class Boost(Package):
     # support. The header-only library is installed when no variant is given.
     all_libs = [
         "atomic",
+        "charconv",
         "chrono",
+        "cobalt",
         "container",
         "context",
         "contract",
@@ -146,6 +148,7 @@ class Boost(Package):
         "thread",
         "timer",
         "type_erasure",
+        "url",
         "wave",
     ]
 
@@ -687,6 +690,12 @@ class Boost(Package):
         remove_if_in_list = lambda lib, libs: libs.remove(lib) if lib in libs else None
 
         # Remove libraries that the release version does not support
+        if not spec.satisfies("@1.85.0:"):
+            remove_if_in_list("charconv", with_libs)
+        if not spec.satisfies("@1.84.0:"):
+            remove_if_in_list("cobalt", with_libs)
+        if not spec.satisfies("@1.81.0:"):
+            remove_if_in_list("url", with_libs)
         if not spec.satisfies("@1.75.0:"):
             remove_if_in_list("json", with_libs)
         if spec.satisfies("@1.69.0:"):

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -509,7 +509,7 @@ class Boost(Package):
         else:
             options.append("--with-toolset=%s" % boost_toolset_id)
         if with_libs:
-            options.append("--with-libraries=%s" % ",".join(with_libs))
+            options.append("--with-libraries=%s" % ",".join(sorted(with_libs)))
         else:
             options.append("--with-libraries=headers")
 
@@ -682,38 +682,33 @@ class Boost(Package):
             force_symlink("/usr/bin/libtool", join_path(newdir, "libtool"))
             env["PATH"] = newdir + ":" + env["PATH"]
 
-        with_libs = list()
-        for lib in Boost.all_libs:
-            if "+{0}".format(lib) in spec:
-                with_libs.append(lib)
-
-        remove_if_in_list = lambda lib, libs: libs.remove(lib) if lib in libs else None
+        with_libs = {f"{lib}" for lib in Boost.all_libs if f"+{lib}" in spec}
 
         # Remove libraries that the release version does not support
         if not spec.satisfies("@1.85.0:"):
-            remove_if_in_list("charconv", with_libs)
+            with_libs.discard("charconv")
         if not spec.satisfies("@1.84.0:"):
-            remove_if_in_list("cobalt", with_libs)
+            with_libs.discard("cobalt")
         if not spec.satisfies("@1.81.0:"):
-            remove_if_in_list("url", with_libs)
+            with_libs.discard("url")
         if not spec.satisfies("@1.75.0:"):
-            remove_if_in_list("json", with_libs)
+            with_libs.discard("json")
         if spec.satisfies("@1.69.0:"):
-            remove_if_in_list("signals", with_libs)
+            with_libs.discard("signals")
         if not spec.satisfies("@1.54.0:"):
-            remove_if_in_list("log", with_libs)
+            with_libs.discard("log")
         if not spec.satisfies("@1.53.0:"):
-            remove_if_in_list("atomic", with_libs)
+            with_libs.discard("atomic")
         if not spec.satisfies("@1.48.0:"):
-            remove_if_in_list("locale", with_libs)
+            with_libs.discard("locale")
         if not spec.satisfies("@1.47.0:"):
-            remove_if_in_list("chrono", with_libs)
+            with_libs.discard("chrono")
         if not spec.satisfies("@1.43.0:"):
-            remove_if_in_list("random", with_libs)
+            with_libs.discard("random")
         if not spec.satisfies("@1.39.0:"):
-            remove_if_in_list("exception", with_libs)
+            with_libs.discard("exception")
         if spec.satisfies("+graph") and spec.satisfies("+mpi"):
-            with_libs.append("graph_parallel")
+            with_libs.add("graph_parallel")
 
         # to make Boost find the user-config.jam
         env["BOOST_BUILD_PATH"] = self.stage.source_path

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -497,7 +497,7 @@ class Boost(Package):
             spec["python"].libs[0],
         )
 
-    def determine_bootstrap_options(self, spec, with_libs, without_libs, options):
+    def determine_bootstrap_options(self, spec, with_libs, options):
         boost_toolset_id = self.determine_toolset(spec)
 
         # Arm compiler bootstraps with 'gcc' (but builds as 'clang')
@@ -508,7 +508,7 @@ class Boost(Package):
         if with_libs:
             options.append("--with-libraries=%s" % ",".join(with_libs))
         else:
-            options.append("--without-libraries=%s" % ",".join(without_libs))
+            options.append("--with-libraries=headers")
 
         if spec.satisfies("+python"):
             options.append("--with-python=%s" % spec["python"].command.path)
@@ -680,49 +680,37 @@ class Boost(Package):
             env["PATH"] = newdir + ":" + env["PATH"]
 
         with_libs = list()
-        without_libs = list()
         for lib in Boost.all_libs:
             if "+{0}".format(lib) in spec:
                 with_libs.append(lib)
-            else:
-                without_libs.append(lib)
 
         remove_if_in_list = lambda lib, libs: libs.remove(lib) if lib in libs else None
 
         # Remove libraries that the release version does not support
         if not spec.satisfies("@1.75.0:"):
             remove_if_in_list("json", with_libs)
-            remove_if_in_list("json", without_libs)
         if spec.satisfies("@1.69.0:"):
             remove_if_in_list("signals", with_libs)
-            remove_if_in_list("signals", without_libs)
         if not spec.satisfies("@1.54.0:"):
             remove_if_in_list("log", with_libs)
-            remove_if_in_list("log", without_libs)
         if not spec.satisfies("@1.53.0:"):
             remove_if_in_list("atomic", with_libs)
-            remove_if_in_list("atomic", without_libs)
         if not spec.satisfies("@1.48.0:"):
             remove_if_in_list("locale", with_libs)
-            remove_if_in_list("locale", without_libs)
         if not spec.satisfies("@1.47.0:"):
             remove_if_in_list("chrono", with_libs)
-            remove_if_in_list("chrono", without_libs)
         if not spec.satisfies("@1.43.0:"):
             remove_if_in_list("random", with_libs)
-            remove_if_in_list("random", without_libs)
         if not spec.satisfies("@1.39.0:"):
             remove_if_in_list("exception", with_libs)
-            remove_if_in_list("exception", without_libs)
         if spec.satisfies("+graph") and spec.satisfies("+mpi"):
             with_libs.append("graph_parallel")
-            remove_if_in_list("graph_parallel", without_libs)
 
         # to make Boost find the user-config.jam
         env["BOOST_BUILD_PATH"] = self.stage.source_path
 
         bootstrap_options = ["--prefix=%s" % prefix]
-        self.determine_bootstrap_options(spec, with_libs, without_libs, bootstrap_options)
+        self.determine_bootstrap_options(spec, with_libs, bootstrap_options)
 
         if self.spec.satisfies("platform=windows"):
             bootstrap = Executable("cmd.exe")


### PR DESCRIPTION
- In #46062 I added a somewhat clunky way of installing header-only boost while going through `b2` etc. I discovered there's a much simpler way: `--with-libraries=headers`. This changes the boost package to use that instead when no compiled libraries are requested and avoids the awkward dance of with/without-libraries.
- This also adds three compiled libraries that were added since 1.81.0: charconv, cobalt, and url.