### PR TITLE
Revert "msmpi tries to access dependent package hdf5 spack_cc"

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1003,6 +1003,7 @@ class SetupContext:
         """Set the globals in modules of package.py files."""
         for dspec, flag in chain(self.external, self.nonexternal):
             pkg = dspec.package
+
             if self.should_set_package_py_globals & flag:
                 if self.context == Context.BUILD and self.needs_build_context & flag:
                     set_package_py_globals(pkg, context=Context.BUILD)
@@ -1010,12 +1011,6 @@ class SetupContext:
                     # This includes runtime dependencies, also runtime deps of direct build deps.
                     set_package_py_globals(pkg, context=Context.RUN)
 
-        # Looping over the set of packages a second time
-        # ensures all globals are loaded into the module space prior to
-        # any package setup. This guarantees package setup methods have
-        # access to expected module level definitions such as "spack_cc"
-        for dspec, flag in chain(self.external, self.nonexternal):
-            pkg = dspec.package
             for spec in dspec.dependents():
                 # Note: some specs have dependents that are unreachable from the root, so avoid
                 # setting globals for those.

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -513,30 +513,6 @@ def test_setting_dtags_based_on_config(config_setting, expected_flag, config, mo
         assert dtags_to_add.value == expected_flag
 
 
-def test_module_globals_available_at_setup_dependent_time(
-    monkeypatch, mutable_config, mock_packages, working_env
-):
-    """Spack built package externaltest depends on an external package
-    externaltool. Externaltool's setup_dependent_package needs to be able to
-    access globals on the dependent"""
-
-    def setup_dependent_package(module, dependent_spec):
-        # Make sure set_package_py_globals was already called on
-        # dependents
-        # ninja is always set by the setup context and is not None
-        dependent_module = dependent_spec.package.module
-        assert hasattr(dependent_module, "ninja")
-        assert dependent_module.ninja is not None
-        dependent_spec.package.test_attr = True
-
-    externaltool = spack.spec.Spec("externaltest").concretized()
-    monkeypatch.setattr(
-        externaltool["externaltool"].package, "setup_dependent_package", setup_dependent_package
-    )
-    spack.build_environment.setup_package(externaltool.package, False)
-    assert externaltool.package.test_attr
-
-
 def test_build_jobs_sequential_is_sequential():
     assert (
         determine_number_of_jobs(


### PR DESCRIPTION
Reverts spack/spack#44327

This is a whac a mole thing. Reverting this commit seems the better choice because it unbreaks `develop`, whereas only windows is helped by keeping it, and we're not testing mpi on windows anyways.

`set_package_py_globals(...)` calls `CMakeBuilder.std_args(...)` calls `get_cmake_prefix_path(...)` which calls `cmake_prefix_paths(...)` on dependencies, which rely on globals. For example pytorch's `cmake_prefix_paths` needs the `python_platlib` global.
