### PR TITLE
pika: Add conflict between HIP and GCC (libstdc++) >= 13

### DIFF
--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -139,6 +139,8 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("apex", when="+apex")
     depends_on("cuda@11:", when="+cuda")
     depends_on("hip@5.2:", when="@0.8: +rocm")
+    # https://github.com/pika-org/pika/issues/1238
+    conflicts("%gcc@13:", when="+rocm")
     depends_on("hipblas", when="@:0.8 +rocm")
     depends_on("mpi", when="+mpi")
     depends_on("stdexec", when="+stdexec")


### PR DESCRIPTION
The conflict is really with libstdc++ >= 13, not GCC. This is a case where it'd be really handy to be able to talk about C++ standard libraries as virtuals.

Just conflicting on GCC is not entirely accurate since most other compilers will use libstdc++ as well, but I don't want to overconstrain builds either. I suppose this acts more as a hint than a fully accurate conflict.

There's no upper bound on the pika/HIP version since we don't currently have a workaround.