### PR TITLE
ginkgo: revert mpi@3.1 dependency:

### DIFF
--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -62,7 +62,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cuda@9:", when="+cuda @:1.4.0")
     depends_on("cuda@9.2:", when="+cuda @1.5.0:")
     depends_on("cuda@10.1:", when="+cuda @1.7.0:")
-    depends_on("mpi@3.1:", when="+mpi")
+    depends_on("mpi", when="+mpi")
 
     depends_on("rocthrust", when="+rocm")
     depends_on("hipsparse", when="+rocm")


### PR DESCRIPTION
Currently this breaks builds with OpenMPI - as spack is resolving this to `openmpi@1.7.4`

This change is from https://github.com/spack/spack/pull/45791

Related: https://github.com/spack/spack/pull/46102



<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
