### PR TITLE
Bugfix/Installer: properly track task queueing

### DIFF
--- a/lib/spack/llnl/string.py
+++ b/lib/spack/llnl/string.py
@@ -42,16 +42,16 @@ def comma_and(sequence: List[str]) -> str:
 
 
 def ordinal(number: int) -> str:
-    """Return the ordinal number representation of the provided number.
+    """Return the ordinal representation (1st, 2nd, 3rd, etc.) for the provided number.
 
     Args:
-        number: value to convert to ordinal number
+        number: int to convert to ordinal number
 
-    Returns: ordinal number (representation) of the number
+    Returns: number's corresponding ordinal
     """
-    suffixes = {"1": "st", "2": "nd", "3": "rd"}
-    d = str(number)[-1]
-    suffix = suffixes[d] if d in suffixes and number % 100 not in [11, 12, 13] else "th"
+    idx = (number % 10) << 1
+    tens = number % 100 // 10
+    suffix = "th" if tens == 1 else "thstndrdththththththth"[idx : idx + 2]
     return f"{number}{suffix}"
 
 

--- a/lib/spack/llnl/string.py
+++ b/lib/spack/llnl/string.py
@@ -51,7 +51,7 @@ def ordinal(number: int) -> str:
     """
     idx = (number % 10) << 1
     tens = number % 100 // 10
-    suffix = "th" if tens == 1 else "thstndrdththththththth"[idx : idx + 2]
+    suffix = "th" if tens == 1 or idx > 6 else "thstndrd"[idx : idx + 2]
     return f"{number}{suffix}"
 
 

--- a/lib/spack/llnl/string.py
+++ b/lib/spack/llnl/string.py
@@ -41,6 +41,20 @@ def comma_and(sequence: List[str]) -> str:
     return comma_list(sequence, "and")
 
 
+def ordinal(number: int) -> str:
+    """Return the ordinal number representation of the provided number.
+
+    Args:
+        number: value to convert to ordinal number
+
+    Returns: ordinal number (representation) of the number
+    """
+    suffixes = {"1": "st", "2": "nd", "3": "rd"}
+    d = str(number)[-1]
+    suffix = suffixes[d] if d in suffixes and number % 100 not in [11, 12, 13] else "th"
+    return f"{number}{suffix}"
+
+
 def quote(sequence: List[str], q: str = "'") -> List[str]:
     """Quotes each item in the input list with the quote character passed as second argument."""
     return [f"{q}{e}{q}" for e in sequence]

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1249,7 +1249,7 @@ class PackageInstaller:
     def _add_init_task(
         self,
         pkg: "spack.package_base.PackageBase",
-        request: Optional[BuildRequest],
+        request: BuildRequest,
         is_compiler: bool,
         all_deps: Dict[str, Set[str]],
     ) -> None:
@@ -1258,8 +1258,7 @@ class PackageInstaller:
 
         Args:
             pkg: the package to be built and installed
-            request: the associated install request where ``None`` can be used
-                 to indicate the package was explicitly requested by the user
+            request: the associated install request
             is_compiler: whether task is for a bootstrap compiler
             all_deps: dictionary of all dependencies and associated dependents
         """

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -908,7 +908,7 @@ class BuildTask:
 
         # The initial build task cannot have status "removed".
         if attempts == 0 and status == BuildStatus.REMOVED:
-            raise InstallError(
+            raise spack.error.InstallError(
                 f"Cannot create a build task for {self.pkg_id} with status '{status}'", pkg=pkg
             )
         self.status = status

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -920,7 +920,10 @@ class BuildTask:
         self.start = start
 
         if not isinstance(installed, set):
-            raise TypeError(f"BuildTask constructor requires 'installed' be a 'set', not '{installed.__class__.__name__}'.")
+            raise TypeError(
+                f"BuildTask constructor requires 'installed' be a 'set', "
+                f"not '{installed.__class__.__name__}'."
+            )
 
         # Set of dependents, which needs to include the requesting package
         # to support tracking of parallel, multi-spec, environment installs.

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -906,7 +906,8 @@ class BuildTask:
         if not isinstance(status, BuildStatus):
             raise TypeError(f"{status} is not a valid build status")
 
-        if status == BuildStatus.REMOVED:
+        # The initial build task cannot have status "removed".
+        if attempts == 0 and status == BuildStatus.REMOVED:
             raise InstallError(
                 f"Cannot create a build task for {self.pkg_id} with status '{status}'", pkg=pkg
             )

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -919,12 +919,8 @@ class BuildTask:
         # The initial start time for processing the spec
         self.start = start
 
-        # Make sure installed is an expected type
-        if isinstance(installed, (tuple, list)):
-            installed = set(installed)
-
         if not isinstance(installed, set):
-            raise TypeError(f"{installed} is not a valid installed type")
+            raise TypeError(f"BuildTask constructor requires 'installed' be a 'set', not '{installed.__class__.__name__}'.")
 
         # Set of dependents, which needs to include the requesting package
         # to support tracking of parallel, multi-spec, environment installs.

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -76,8 +76,8 @@ _counter = itertools.count(0)
 class BuildStatus(enum.Enum):
     """Different build (task) states."""
 
-    #: Build status indicating task has been added.
-    ADDED = enum.auto()
+    #: Build status indicating task has been added/queued.
+    QUEUED = enum.auto()
 
     #: Build status indicating the spec failed to install
     FAILED = enum.auto()
@@ -97,7 +97,7 @@ class BuildStatus(enum.Enum):
     REMOVED = enum.auto()
 
     def __str__(self):
-        return "queued" if self == BuildStatus.ADDED else f"{self.name.lower()}"
+        return f"{self.name.lower()}"
 
 
 def _write_timer_json(pkg, timer, cache):
@@ -860,7 +860,7 @@ class BuildTask:
         compiler: bool = False,
         start: float = 0.0,
         attempts: int = 0,
-        status: BuildStatus = BuildStatus.ADDED,
+        status: BuildStatus = BuildStatus.QUEUED,
         installed: Set[str] = set(),
     ):
         """
@@ -870,7 +870,7 @@ class BuildTask:
             pkg: the package to be built and installed and whose spec is
                 concrete
             request: the associated install request
-            compiler:  whether task is for a bootstrap compiler
+            compiler: whether task is for a bootstrap compiler
             start: the initial start time for the package, in seconds
             attempts: the number of attempts to install the package, which
                 should be 0 when the task is initially instantiated
@@ -1221,7 +1221,7 @@ class PackageInstaller:
             pkg,
             request=request,
             compiler=is_compiler,
-            status=BuildStatus.ADDED,
+            status=BuildStatus.QUEUED,
             installed=self.installed,
         )
         for dep_id in task.dependencies:

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -42,6 +42,7 @@ from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
 import llnl.util.filesystem as fs
 import llnl.util.lock as lk
 import llnl.util.tty as tty
+from llnl.string import ordinal
 from llnl.util.lang import pretty_seconds
 from llnl.util.tty.color import colorize
 from llnl.util.tty.log import log_output
@@ -1707,14 +1708,10 @@ class PackageInstaller:
             return
 
         # Remove any associated build task since its sequence will change
-        def ord(num):
-            suffixes = {"1": "st", "2": "nd", "3": "rd"}
-            d = str(num)[-1]
-            suffix = suffixes[d] if d in suffixes and num % 100 not in [11, 12, 13] else "th"
-            return f"{num}{suffix}"
-
         self._remove_task(task.pkg_id)
-        desc = "Queueing" if task.attempts <= 1 else f"Requeueing ({ord(task.attempts)} time)"
+        desc = (
+            "Queueing" if task.attempts <= 1 else f"Requeueing ({ordinal(task.attempts)} attempt)"
+        )
         tty.debug(msg.format(desc, task.pkg_id, task.status))
 
         # Now add the new task to the queue with a new sequence number to

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1682,7 +1682,7 @@ class PackageInstaller:
         # Remove any associated build task since its sequence will change
         self._remove_task(task.pkg_id)
         desc = (
-            "Queueing" if task.attempts <= 1 else f"Requeueing ({ordinal(task.attempts)} attempt)"
+            "Queueing" if task.attempts == 1 else f"Requeueing ({ordinal(task.attempts)} attempt)"
         )
         tty.debug(msg.format(desc, task.pkg_id, task.status))
 

--- a/lib/spack/spack/test/buildtask.py
+++ b/lib/spack/spack/test/buildtask.py
@@ -41,7 +41,7 @@ def test_build_task_errors(install_mockery):
         inst.BuildTask(spec.package, request, status=inst.BuildStatus.REMOVED)
 
     # Also make sure to not accept an incompatible installed argument value.
-    with pytest.raises(TypeError, match="not a valid installed"):
+    with pytest.raises(TypeError, match="'installed' be a 'set', not 'str'"):
         inst.BuildTask(spec.package, request, installed="mpileaks")
 
 

--- a/lib/spack/spack/test/buildtask.py
+++ b/lib/spack/spack/test/buildtask.py
@@ -41,7 +41,7 @@ def test_build_task_errors(install_mockery):
         inst.BuildTask(spec.package, request, status=inst.BuildStatus.REMOVED)
 
     # Also make sure to not accept an incompatible installed argument value.
-    with pytest.raises(TypeError, match="not a valid installed value"):
+    with pytest.raises(TypeError, match="not a valid installed"):
         inst.BuildTask(spec.package, request, installed="mpileaks")
 
 

--- a/lib/spack/spack/test/buildtask.py
+++ b/lib/spack/spack/test/buildtask.py
@@ -52,7 +52,7 @@ def test_build_task_basics(install_mockery):
 
     # Ensure key properties match expectations
     request = inst.BuildRequest(spec.package, {})
-    task = inst.BuildTask(spec.package, request=request, status=inst.BuildStatus.ADDED)
+    task = inst.BuildTask(spec.package, request=request, status=inst.BuildStatus.QUEUED)
     assert not task.explicit
     assert task.priority == len(task.uninstalled_deps)
     assert task.key == (task.priority, task.sequence)
@@ -74,16 +74,16 @@ def test_build_task_strings(install_mockery):
 
     # Ensure key properties match expectations
     request = inst.BuildRequest(spec.package, {})
-    task = inst.BuildTask(spec.package, request=request, status=inst.BuildStatus.ADDED)
+    task = inst.BuildTask(spec.package, request=request, status=inst.BuildStatus.QUEUED)
 
     # Cover __repr__
     irep = task.__repr__()
     assert irep.startswith(task.__class__.__name__)
-    assert "BuildStatus.ADDED" in irep
+    assert "BuildStatus.QUEUED" in irep
     assert "sequence=" in irep
 
     # Cover __str__
     istr = str(task)
-    assert "status=queued" in istr  # == BuildStatus.ADDED
+    assert "status=queued" in istr  # == BuildStatus.QUEUED
     assert "#dependencies=1" in istr
     assert "priority=" in istr

--- a/lib/spack/spack/test/buildtask.py
+++ b/lib/spack/spack/test/buildtask.py
@@ -37,7 +37,7 @@ def test_build_task_errors(install_mockery):
 
     # Now we can check that build tasks cannot be create when the status
     # indicates the task is/should've been removed.
-    with pytest.raises(inst.InstallError, match="Cannot create a build task"):
+    with pytest.raises(spack.error.InstallError, match="Cannot create a build task"):
         inst.BuildTask(spec.package, request, status=inst.BuildStatus.REMOVED)
 
     # Also make sure to not accept an incompatible installed argument value.

--- a/lib/spack/spack/test/buildtask.py
+++ b/lib/spack/spack/test/buildtask.py
@@ -12,22 +12,57 @@ import spack.spec
 
 
 def test_build_task_errors(install_mockery):
+    kwargs = {
+        "request": None,
+        "compiler": "False",
+        "start": "0",
+        "attempts": "0",
+        "status": "0",
+        "installed": "mpileaks",
+    }
     with pytest.raises(ValueError, match="must be a package"):
-        inst.BuildTask("abc", None, False, 0, 0, 0, set())
+        inst.BuildTask(None, **kwargs)
+
+    with pytest.raises(ValueError, match="must be a package"):
+        inst.BuildTask("abc", **kwargs)
 
     spec = spack.spec.Spec("trivial-install-test-package")
     pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
     with pytest.raises(ValueError, match="must have a concrete spec"):
-        inst.BuildTask(pkg_cls(spec), None, False, 0, 0, 0, set())
+        inst.BuildTask(pkg_cls(spec), **kwargs)
 
     spec.concretize()
     assert spec.concrete
-    with pytest.raises(ValueError, match="must have a build request"):
-        inst.BuildTask(spec.package, None, False, 0, 0, 0, set())
+    with pytest.raises(ValueError, match="must be a BuildRequest"):
+        inst.BuildTask(spec.package, **kwargs)
 
-    request = inst.BuildRequest(spec.package, {})
-    with pytest.raises(spack.error.InstallError, match="Cannot create a build task"):
-        inst.BuildTask(spec.package, request, False, 0, 0, inst.STATUS_REMOVED, set())
+    kwargs["request"] = inst.BuildRequest(spec.package, {})
+    with pytest.raises(ValueError, match="must be a BuildStatus"):
+        inst.BuildTask(spec.package, **kwargs)
+
+    kwargs["status"] = "queued"
+    with pytest.raises(ValueError, match="must be a BuildStatus"):
+        inst.BuildTask(spec.package, **kwargs)
+
+    kwargs["status"] = inst.BuildStatus.REMOVED
+    with pytest.raises(inst.InstallError, match="Cannot create a build task"):
+        inst.BuildTask(spec.package, **kwargs)
+
+    kwargs["status"] = inst.BuildStatus.INSTALLED
+    with pytest.raises(ValueError, match="must be a bool"):
+        inst.BuildTask(spec.package, **kwargs)
+
+    kwargs["compiler"] = False
+    with pytest.raises(ValueError, match="must be a float"):
+        inst.BuildTask(spec.package, **kwargs)
+
+    kwargs["start"] = 10.0
+    with pytest.raises(ValueError, match="must be a set"):
+        inst.BuildTask(spec.package, **kwargs)
+
+    kwargs["installed"] = ["mpileaks"]
+    with pytest.raises(ValueError, match="must be a set"):
+        inst.BuildTask(spec.package, **kwargs)
 
 
 def test_build_task_basics(install_mockery):
@@ -37,7 +72,7 @@ def test_build_task_basics(install_mockery):
 
     # Ensure key properties match expectations
     request = inst.BuildRequest(spec.package, {})
-    task = inst.BuildTask(spec.package, request, False, 0, 0, inst.STATUS_ADDED, set())
+    task = inst.BuildTask(spec.package, request=request, status=inst.BuildStatus.ADDED)
     assert not task.explicit
     assert task.priority == len(task.uninstalled_deps)
     assert task.key == (task.priority, task.sequence)
@@ -59,16 +94,16 @@ def test_build_task_strings(install_mockery):
 
     # Ensure key properties match expectations
     request = inst.BuildRequest(spec.package, {})
-    task = inst.BuildTask(spec.package, request, False, 0, 0, inst.STATUS_ADDED, set())
+    task = inst.BuildTask(spec.package, request=request, status=inst.BuildStatus.ADDED)
 
     # Cover __repr__
     irep = task.__repr__()
     assert irep.startswith(task.__class__.__name__)
-    assert "status='queued'" in irep  # == STATUS_ADDED
+    assert "BuildStatus.ADDED" in irep
     assert "sequence=" in irep
 
     # Cover __str__
     istr = str(task)
-    assert "status=queued" in istr  # == STATUS_ADDED
+    assert "status=queued" in istr  # == BuildStatus.ADDED
     assert "#dependencies=1" in istr
     assert "priority=" in istr

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -73,7 +73,7 @@ def create_build_task(
     pkg: spack.package_base.PackageBase, install_args: Optional[dict] = None
 ) -> inst.BuildTask:
     request = inst.BuildRequest(pkg, {} if install_args is None else install_args)
-    return inst.BuildTask(pkg, request=request, status=inst.BuildStatus.ADDED)
+    return inst.BuildTask(pkg, request=request, status=inst.BuildStatus.QUEUED)
 
 
 def create_installer(

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -73,7 +73,7 @@ def create_build_task(
     pkg: spack.package_base.PackageBase, install_args: Optional[dict] = None
 ) -> inst.BuildTask:
     request = inst.BuildRequest(pkg, {} if install_args is None else install_args)
-    return inst.BuildTask(pkg, request, False, 0, 0, inst.STATUS_ADDED, set())
+    return inst.BuildTask(pkg, request=request, status=inst.BuildStatus.ADDED)
 
 
 def create_installer(
@@ -698,7 +698,7 @@ def test_requeue_task(install_mockery, capfd):
     ids = list(installer.build_tasks)
     assert len(ids) == 1
     qtask = installer.build_tasks[ids[0]]
-    assert qtask.status == inst.STATUS_INSTALLING
+    assert qtask.status == inst.BuildStatus.INSTALLING
     assert qtask.sequence > task.sequence
     assert qtask.attempts == task.attempts + 1
 


### PR DESCRIPTION
This PR fixes reporting of task queueing.  It restores proper tracking of task queueing/requeueing.  The number of attempts is also reported in the debug message to aid debugging.  In the interest of clarity, it also adds keys for instantiating `BuildTask` and calling `_add_init_task`.

UPDATE: This PR now also changed the arguments to `BuildTask` after `pkg` to be kwargs.  As part of that effort, the build status strings are replaced with an enumeration.

### Motivation

Using `spack -d install` revealed that a build task/spec was being reported as being re-queued but never simply queued.  Digging deeper also revealed that the attempts property was no longer reflecting the numbers of times a spec was being dequeued, which can be numerous even when processing a small number of packages.

### Solution

Clarify the purpose of the property, ensure it is set as intended, and output the number of attempts in debug messages (to aid understanding the build process).

### Outputs

Outputs from a run **before** the change:

```
$ spack -d install clingo
..
==> [2024-09-09-14:55:01.493962] Initializing the build queue from the build requests
==> [2024-09-09-14:55:01.495507] Initializing the build queue for clingo
..
==> [2024-09-09-14:55:02.868780] Pkg id clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b has the following dependents:
==> [2024-09-09-14:55:02.885075] Requeueing a build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b with status 'queued'
..
==> [2024-09-09-14:55:02.919192] Removing build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b from list
==> [2024-09-09-14:55:02.919247] Requeueing a build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b with status 'queued'
..
==> [2024-09-09-14:55:03.005403] Removing build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b from list
==> [2024-09-09-14:55:03.005443] Requeueing a build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b with status 'queued'
..
==> [2024-09-09-14:55:03.433727] Removing build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b from list
==> [2024-09-09-14:55:03.433767] Requeueing a build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b with status 'queued'
..
==> [2024-09-09-14:55:04.279117] Removing build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b from list
==> [2024-09-09-14:55:04.279159] Requeueing a build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b with status 'queued'
..
==> [2024-09-09-14:55:04.327872] Removing build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b from list
==> [2024-09-09-14:55:04.327909] Requeueing a build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b with status 'queued'
..
==> [2024-09-09-14:55:04.390158] Removing build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b from list
==> [2024-09-09-14:55:04.390196] Requeueing a build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b with status 'queued'
..
==> [2024-09-09-14:55:04.499311] Removing build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b from list
==> [2024-09-09-14:55:04.499356] Requeueing a build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b with status 'queued'
..
==> [2024-09-09-14:55:04.509436] Processing clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b: task=priority=0, status=dequeued, start=1725918902.9191785, #dependencies=7
..
==> [2024-09-09-14:55:04.616149] No binary for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b found: installing from source
..
```

versus same outputs **after** the change:

```
$ spack -d install clingo
..
==> [2024-09-09-15:03:17.979669] Initializing the build queue from the build requests
==> [2024-09-09-15:03:17.980480] Initializing the build queue for clingo
..
==> [2024-09-09-15:03:18.861703] Pkg id clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b has the following dependents:
==> [2024-09-09-15:03:18.874243] Queueing a build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b with status 'queued'
..
==> [2024-09-09-15:03:18.892256] Removing build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b from list
==> [2024-09-09-15:03:18.892294] Requeueing (2nd time) a build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b with status 'queued'
..
==> [2024-09-09-15:03:18.961266] Removing build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b from list
==> [2024-09-09-15:03:18.961306] Requeueing (3rd time) a build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b with status 'queued'
..
==> [2024-09-09-15:03:19.147869] Removing build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b from list
==> [2024-09-09-15:03:19.147920] Requeueing (4th time) a build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b with status 'queued'
..
==> [2024-09-09-15:03:19.735383] Removing build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b from list
==> [2024-09-09-15:03:19.735429] Requeueing (5th time) a build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b with status 'queued'
..
==> [2024-09-09-15:03:19.802132] Removing build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b from list
==> [2024-09-09-15:03:19.802177] Requeueing (6th time) a build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b with status 'queued'
..
==> [2024-09-09-15:03:19.837947] Removing build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b from list
==> [2024-09-09-15:03:19.837987] Requeueing (7th time) a build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b with status 'queued'
..
==> [2024-09-09-15:03:19.911192] Removing build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b from list
==> [2024-09-09-15:03:19.911262] Requeueing (8th time) a build task for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b with status 'queued'
..
==> [2024-09-09-15:03:19.918175] Processing clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b: task=priority=0, status=dequeued, start=1725919398.892243, #dependencies=7
..
==> [2024-09-09-15:03:19.965812] No binary for clingo-5.7.1-v5g6aprs7x3nphntlrcf5kt4ve57yk2b found: installing from source
..
```