### PR TITLE
bugfix: `elfutils` has no bzip2 or xz variants

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/gpu-tests/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/gpu-tests/spack.yaml
@@ -16,7 +16,7 @@ spack:
     boost:
       variants: +python +filesystem +iostreams +system
     elfutils:
-      variants: +bzip2 ~nls +xz
+      variants: ~nls
     hdf5:
       variants: +fortran +hl +shared
     libfabric:


### PR DESCRIPTION
Removing unneeded variant tweaks from the `gpu-tests` stack.