### PR TITLE
py-pybind11 fix

### DIFF
--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -101,7 +101,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):
         return [
             self.define("PYBIND11_TEST", self.pkg.run_tests),
-            self.define("prefix_for_pc_file", self.prefix)
+            self.define("prefix_for_pc_file", self.prefix),
         ]
 
     def install(self, pkg, spec, prefix):

--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -99,7 +99,10 @@ class PyPybind11(CMakePackage, PythonExtension):
 
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):
-        return [self.define("PYBIND11_TEST", self.pkg.run_tests)]
+        return [
+            self.define("PYBIND11_TEST", self.pkg.run_tests),
+            self.define("prefix_for_pc_file", self.prefix)
+        ]
 
     def install(self, pkg, spec, prefix):
         super().install(pkg, spec, prefix)


### PR DESCRIPTION
The detection logic for the prefix used in py-bind11's pkgconfig PC file if broken for spack resulting in an empty prefix in the PC file.  However, the package provides an escape hatch in the form of prefix_for_pc_file variable in cmake. Use this escape hatch to provide the correct path; spack will always know better than pybind11's CMake.