### PR TITLE
nvhpc: add 'compiler' tag to the override

### DIFF
--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -406,7 +406,7 @@ class Nvhpc(Package, CompilerPackage):
     homepage = "https://developer.nvidia.com/hpc-sdk"
 
     maintainers("samcmill")
-    tags = ["e4s"]
+    tags = ["e4s", "compiler"]
 
     skip_version_audit = ["platform=darwin", "platform=windows"]
 


### PR DESCRIPTION
fixes #46295

A proper solution would be a tag directive that accumulates tags with the ones defined in base classes. For the time being, rewrite them explicitly.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
