### PR TITLE
py-pydantic: add v2.7.4 with dep py-annotated-types

### DIFF
--- a/var/spack/repos/builtin/packages/py-annotated-types/package.py
+++ b/var/spack/repos/builtin/packages/py-annotated-types/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyAnnotatedTypes(PythonPackage):
+    """Reusable constraint types to use with typing.Annotated."""
+
+    homepage = "https://github.com/annotated-types/annotated-types"
+    pypi = "annotated_types/annotated_types-0.7.0.tar.gz"
+
+    license("MIT", checked_by="wdconinc")
+
+    version("0.7.0", sha256="aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89")
+
+    depends_on("py-hatchling", type="build")
+    depends_on("py-typing-extensions@4.0.0:", when="^python@:3.8", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pydantic/package.py
+++ b/var/spack/repos/builtin/packages/py-pydantic/package.py
@@ -14,6 +14,7 @@ class PyPydantic(PythonPackage):
 
     license("MIT")
 
+    version("2.7.4", sha256="0c84efd9548d545f63ac0060c1e4d39bb9b14db8b3c0652338aecc07b5adec52")
     version("1.10.9", sha256="95c70da2cd3b6ddf3b9645ecaa8d98f3d80c606624b6d245558d202cd23ea3be")
     version("1.10.2", sha256="91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410")
     version("1.9.2", sha256="8cb0bc509bfb71305d7a59d00163d5f9fc4530f0881ea32c74ff4f74c85f3d3d")
@@ -21,9 +22,15 @@ class PyPydantic(PythonPackage):
 
     variant("dotenv", default=False, description="Install requirements for pydantic.dotenv")
 
-    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools", type="build", when="@1")
+    depends_on("py-hatchling", type="build", when="@2")
+    depends_on("py-hatch-fancy-pypi-readme@22.5.0:", type="build", when="@2")
+    depends_on("py-typing-extensions@4.6.1:", when="@2.7.1:", type=("build", "run"))
     depends_on("py-typing-extensions@4.2:", when="@1.10.9:", type=("build", "run"))
     depends_on("py-typing-extensions@4.1:", when="@1.10:", type=("build", "run"))
     depends_on("py-typing-extensions@3.7.4.3:", type=("build", "run"))
 
-    depends_on("py-python-dotenv@0.10.4:", when="+dotenv", type=("build", "run"))
+    depends_on("py-annotated-types@0.4.0:", type=("build", "run"), when="@2.7.4:")
+    depends_on("py-pydantic-core@2.18.4", type=("build", "run"), when="@2.7.4")
+
+    depends_on("py-python-dotenv@0.10.4:", when="@1 +dotenv", type=("build", "run"))


### PR DESCRIPTION
Depends on `py-annotated-types`, which is added as well.