### PR TITLE
Fix variant expressions that will never match

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -399,7 +399,10 @@ class Acts(CMakePackage, CudaPackage):
     # ACTS imposes requirements on the C++ standard values used by ROOT
     for _cxxstd in _cxxstd_values:
         for _v in _cxxstd:
-            depends_on(f"geant4 cxxstd={_v.value}", when=f"cxxstd={_v.value} {_v.when} +geant4")
+            if Spec(_v.when).satisfies("@0.23:"):  # geant4 variant only exists at 0.23 or higher
+                depends_on(
+                    f"geant4 cxxstd={_v.value}", when=f"cxxstd={_v.value} {_v.when} +geant4"
+                )
             depends_on(
                 f"geant4 cxxstd={_v.value}", when=f"cxxstd={_v.value} {_v.when} +fatras_geant4"
             )

--- a/var/spack/repos/builtin/packages/aluminum/package.py
+++ b/var/spack/repos/builtin/packages/aluminum/package.py
@@ -88,7 +88,6 @@ class Aluminum(CachedCMakePackage, CudaPackage, ROCmPackage):
     # FIXME: Do we want to expose tuning parameters to the Spack
     # recipe? Some are numeric values, some are on/off switches.
 
-    conflicts("~cuda", when="+cuda_rma", msg="CUDA RMA support requires CUDA")
     conflicts("+cuda", when="+rocm", msg="CUDA and ROCm support are mutually exclusive")
 
     depends_on("mpi")

--- a/var/spack/repos/builtin/packages/ceed/package.py
+++ b/var/spack/repos/builtin/packages/ceed/package.py
@@ -201,10 +201,6 @@ class Ceed(BundlePackage, CudaPackage, ROCmPackage):
     # and +mumps:
     depends_on("petsc@3.11.1+mpi+hypre+suite-sparse+mumps+double~int64", when="@2.0.0+petsc+mfem")
     depends_on("hpgmg@0.4+fe", when="@2.0.0+petsc")
-    # ceed-1.0
-    # The mfem petsc examples need the petsc variants +hypre, +suite-sparse,
-    # and +mumps:
-    depends_on("hpgmg@a0a5510df23b+fe", when="@1.0.0+petsc")
 
     # MAGMA
     # ceed 5.0
@@ -313,8 +309,8 @@ class Ceed(BundlePackage, CudaPackage, ROCmPackage):
     depends_on("suite-sparse@:5.1.0", when="@2.0.0%gcc@:4.8+mfem+petsc")
 
     # ceed-1.0
-    depends_on("mfem@3.3.2+mpi+examples+miniapps", when="@1.0.0+mfem~petsc")
-    depends_on("mfem@3.3.2+mpi+petsc+examples+miniapps", when="@1.0.0+mfem+petsc")
+    depends_on("mfem@3.3.2+mpi+examples+miniapps", when="@1.0.0+mfem")
+    depends_on("mfem@3.3.2+mpi+petsc+examples+miniapps", when="@1.0.0+mfem")
     depends_on("laghos@1.0", when="@1.0.0+mfem")
     # The next line seems to be necessary because the concretizer somehow
     # decides that mfem requires 'hypre+internal-superlu' even though the mfem
@@ -324,4 +320,4 @@ class Ceed(BundlePackage, CudaPackage, ROCmPackage):
     depends_on("hypre~internal-superlu", when="@1.0.0+mfem")
 
     # If using gcc version <= 4.8 build suite-sparse version <= 5.1.0
-    depends_on("suite-sparse@:5.1.0", when="@1.0.0%gcc@:4.8+mfem+petsc")
+    depends_on("suite-sparse@:5.1.0", when="@1.0.0%gcc@:4.8+mfem")

--- a/var/spack/repos/builtin/packages/cosmoflow-benchmark/package.py
+++ b/var/spack/repos/builtin/packages/cosmoflow-benchmark/package.py
@@ -30,7 +30,7 @@ class CosmoflowBenchmark(Package, CudaPackage):
     depends_on("py-tensorflow+cuda", when="+cuda", type=("build", "run"))
     depends_on("py-tensorflow~cuda~nccl", when="~cuda", type=("build", "run"))
     depends_on("py-torch+cuda", when="+cuda", type=("build", "run"))
-    depends_on("py-torch~cuda~cudnn~nccl", when="~cuda", type=("build", "run"))
+    depends_on("py-torch~cuda~nccl", when="~cuda", type=("build", "run"))
     depends_on("py-horovod tensor_ops=mpi", when="~cuda", type=("build", "run"))
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -271,8 +271,6 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("sirius+rocm", when="+rocm")
         depends_on("sirius+openmp", when="+openmp")
         depends_on("sirius~openmp", when="~openmp")
-        depends_on("sirius@7.0.0:7.0", when="@8:8.2")
-        depends_on("sirius@7.2", when="@8.3:8.9")
         depends_on("sirius@7.3:", when="@9.1")
         depends_on("sirius@7.4:7.5", when="@2023.2")
         depends_on("sirius@7.5:", when="@2024.1:")

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -358,16 +358,6 @@ class Dealii(CMakePackage, CudaPackage):
             "via ~{0}".format(_package),
         )
 
-    # interfaces added after 9.5.0:
-    for _package in ["vtk", "taskflow"]:
-        conflicts(
-            "+{0}".format(_package),
-            when="@:9.5",
-            msg="The interface to {0} is supported from version 9.6.0 "
-            "onwards. Please explicitly disable this variant "
-            "via ~{0}".format(_package),
-        )
-
     # Interfaces removed in 9.3.0:
     conflicts(
         "+nanoflann",

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -687,7 +687,6 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
     conflicts("+cuda", when="+opencl")
     conflicts("+rocm", when="+opencl")
     conflicts("+body", when="+poems@:20180628")
-    conflicts("+latte", when="@:20170921")
     conflicts("+python", when="~lib")
     conflicts("+qeq", when="~manybody")
     conflicts("+user-atc", when="~manybody")

--- a/var/spack/repos/builtin/packages/mlperf-deepcam/package.py
+++ b/var/spack/repos/builtin/packages/mlperf-deepcam/package.py
@@ -22,7 +22,7 @@ class MlperfDeepcam(Package, CudaPackage):
     depends_on("py-pycuda", type=("build", "run"))
     depends_on("py-mpi4py", type=("build", "run"))
     depends_on("py-torch+cuda", when="+cuda", type=("build", "run"))
-    depends_on("py-torch~cuda~cudnn~nccl", when="~cuda", type=("build", "run"))
+    depends_on("py-torch~cuda~nccl", when="~cuda", type=("build", "run"))
     depends_on("py-matplotlib", type=("build", "run"))
     depends_on("py-basemap", type=("build", "run"))
     depends_on("py-pillow", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -667,11 +667,6 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     conflicts("fabrics=knem", when="@:1.4")
 
     conflicts(
-        "schedulers=slurm ~pmi",
-        when="@1.5.4",
-        msg="+pmi is required for openmpi to work with Slurm.",
-    )
-    conflicts(
         "schedulers=loadleveler",
         when="@3:",
         msg="The loadleveler scheduler is not supported with " "openmpi(>=3).",

--- a/var/spack/repos/builtin/packages/q-e-sirius/package.py
+++ b/var/spack/repos/builtin/packages/q-e-sirius/package.py
@@ -59,8 +59,6 @@ class QESirius(CMakePackage):
     depends_on("git", type="build")
     depends_on("pkgconfig", type="build")
 
-    conflicts("~scalapack", when="+elpa", msg="ELPA requires SCALAPACK support")
-
     variant("scalapack", default=True, description="Enables scalapack support")
 
     with when("+scalapack"):

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -203,7 +203,6 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
 
     # External libraries incompatible with 64-bit indices
     conflicts("+lapack", when="@3.0.0: +int64")
-    conflicts("+hypre", when="+hypre@:2.6.1a +int64")
 
     # External libraries incompatible with single precision
     conflicts("+klu", when="precision=single")

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -383,9 +383,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     # Fix: https://github.com/xiaoyeli/superlu_dist/commit/09cb1430f7be288fd4d75b8ed461aa0b7e68fefe
     # is not tagged yet. See discussion here https://github.com/trilinos/Trilinos/issues/11839
     conflicts("+cuda +stokhos +superlu-dist")
-    # Cuda UVM must be enabled prior to 13.2
-    # See https://github.com/spack/spack/issues/28869
-    conflicts("~uvm", when="@:13.1 +cuda")
 
     # stokhos fails on xl/xl_r
     conflicts("+stokhos", when="%xl")

--- a/var/spack/repos/builtin/packages/w3emc/package.py
+++ b/var/spack/repos/builtin/packages/w3emc/package.py
@@ -56,7 +56,6 @@ class W3emc(CMakePackage):
     )
 
     conflicts("+shared +extradeps", msg="Shared library cannot be built with unknown dependencies")
-    conflicts("+shared ~pic", msg="Shared library requires PIC")
 
     depends_on("bufr", when="@2.10: +bufr")
     depends_on("bacio", when="@2.9.2:")


### PR DESCRIPTION
In #44425, we add stricter variant audits that catch expressions that can never match. (see https://github.com/spack/spack/pull/44425#discussion_r1749627212)

This fixes 13 packages that had this type of issue.

Most packages had lingering spec expressions from before conditional variants with `when=` statements were added. For example:

* Given `conflicts("+a", when="~b")`, if the package has since added `variant("a", when="+b")`, the conflict is no longer needed, because `a` and `b` will never exist together.

* Similarly, two packages that depended on `py-torch` depended on `py-torch~cuda~cudnn`, which can't match because the `cudnn` variant doesn't exist when `cuda` is disabled. Note that neither `+foo` or `~foo` match (intentionally) if the `foo` variant doesn't exist.

* Some packages referred to impossible version/variant combinations, e.g., `ceed@1.0.0+mfem~petsc` when the `petsc` variant only exist at version `2` or higher.

Some of these correct real issues (e.g. the `py-torch` dependencies would have never worked). Others simply declutter old code in packages by making all constraints consistent with version and variant updates.

The only one of these that I think is not all that useful is the one for `acts`, where looping over `cxxstd` versions and package versions ends up adding some constraints that are impossible. The additional dependencies could never have happened and the code is more complicated with the needed extra constriant. I think *probably* the best thing to do in `acts` is to just not to use a loop and to write out the constraints explicitly, but maybe the code is easier to maintain as written.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
