### PR TITLE
fixesproto: add xextproto dep

### DIFF
--- a/var/spack/repos/builtin/packages/fixesproto/package.py
+++ b/var/spack/repos/builtin/packages/fixesproto/package.py
@@ -20,3 +20,4 @@ class Fixesproto(AutotoolsPackage, XorgPackage):
 
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
+    depends_on("xextproto")


### PR DESCRIPTION
needed according to pc file

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
