### PR TITLE
Fix pip bootstrap on Windows for Python 3.12+

### DIFF
--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -48,8 +48,17 @@ class PyPip(Package, PythonExtension):
         name="pip-bootstrap",
         url="https://bootstrap.pypa.io/pip/zipapp/pip-22.3.1.pyz",
         checksum="c9363c70ad91d463f9492a8a2c89f60068f86b0239bd2a6aa77367aab5fefb3e",
-        when="platform=windows",
+        when="platform=windows ^python@:3.11",
         placement={"pip-22.3.1.pyz": "pip.pyz"},
+        expand=False,
+    )
+
+    resource(
+        name="pip-bootstrap",
+        url="https://bootstrap.pypa.io/pip/zipapp/pip-23.1.pyz",
+        checksum="d9f2fe58c472f9107964df35954f8b74e68c307497a12364b00dc28f36f96816",
+        when="platform=windows ^python@3.12:",
+        placement={"pip-23.1.pyz": "pip.pyz"},
         expand=False,
     )
 


### PR DESCRIPTION
Python 3.12 removed several deprecated functions which caused the pip bootstrapping process to fail on Windows. Upgrading the version of pip used to bootstrap when using Python 3.12+ solved the issue.

Pip 23.1 was the oldest version that worked for 3.12.