### PR TITLE
acts: further simplify `cxxstd` handling

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -400,14 +400,9 @@ class Acts(CMakePackage, CudaPackage):
     # ACTS imposes requirements on the C++ standard values used by ROOT
     for _cxxstd in _cxxstd_values:
         for _v in _cxxstd:
-            if Spec(_v.when).satisfies("@0.23:"):  # geant4 variant only exists at 0.23 or higher
-                depends_on(
-                    f"geant4 cxxstd={_v.value}", when=f"cxxstd={_v.value} {_v.when} +geant4"
-                )
-            depends_on(
-                f"geant4 cxxstd={_v.value}", when=f"cxxstd={_v.value} {_v.when} +fatras_geant4"
-            )
-            depends_on(f"root cxxstd={_v.value}", when=f"cxxstd={_v.value} {_v.when} +tgeo")
+            depends_on(f"geant4 cxxstd={_v.value}", when=f"cxxstd={_v.value} +geant4")
+            depends_on(f"geant4 cxxstd={_v.value}", when=f"cxxstd={_v.value} +fatras_geant4")
+            depends_on(f"root cxxstd={_v.value}", when=f"cxxstd={_v.value} +tgeo")
 
     # When the traccc plugin is enabled, detray should match the Acts scalars
     with when("+traccc"):


### PR DESCRIPTION
See https://github.com/spack/spack/pull/46314#discussion_r1752940332.

This further simplifies `cxxstd` variant handling in `acts` by removing superfluous version constraints from dependencies for `geant4` and `root`.

The version constraints in the loop are redundant with the conditional variant values here:

```python
    _cxxstd_values = (
        conditional("14", when="@:0.8.1"),
        conditional("17", when="@:35"),
        conditional("20", when="@24:"),
    )
    _cxxstd_common = {
        "values": _cxxstd_values,
        "multi": False,
        "description": "Use the specified C++ standard when building.",
    }
    variant("cxxstd", default="17", when="@:35", **_cxxstd_common)
    variant("cxxstd", default="20", when="@36:", **_cxxstd_common)
```

So we can simplify the dependencies in the loop to:

```python
    for _cxxstd in _cxxstd_values:
        for _v in _cxxstd:
            depends_on(f"geant4 cxxstd={_v.value}", when=f"cxxstd={_v.value} +geant4")
            depends_on(f"geant4 cxxstd={_v.value}", when=f"cxxstd={_v.value} +fatras_geant4")
            depends_on(f"root cxxstd={_v.value}", when=f"cxxstd={_v.value} +tgeo")
```

And avoid the potential for impossible variant expressions.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
