### PR TITLE
py-zope-*: add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-zope-event/package.py
+++ b/var/spack/repos/builtin/packages/py-zope-event/package.py
@@ -12,10 +12,13 @@ class PyZopeEvent(PythonPackage):
     homepage = "https://github.com/zopefoundation/zope.event"
     pypi = "zope.event/zope.event-4.3.0.tar.gz"
 
-    license("ZPL-2.1")
+    license("ZPL-2.1", checked_by="wdconinc")
 
+    version("5.0", sha256="bac440d8d9891b4068e2b5a2c5e2c9765a9df762944bda6955f96bb9b91e67cd")
     version("4.6", sha256="81d98813046fc86cc4136e3698fee628a3282f9c320db18658c21749235fce80")
+    version("4.5.1", sha256="4ab47faac13163ca3c5d6d8a5595212e14770322e95c338d955e3688ba19082a")
     version("4.5.0", sha256="5e76517f5b9b119acf37ca8819781db6c16ea433f7e2062c4afc2b6fbedb1330")
     version("4.3.0", sha256="e0ecea24247a837c71c106b0341a7a997e3653da820d21ef6c08b32548f733e7")
 
+    depends_on("python@3.7:", type=("build", "run"), when="@5:")
     depends_on("py-setuptools", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-zope-interface/package.py
+++ b/var/spack/repos/builtin/packages/py-zope-interface/package.py
@@ -15,16 +15,27 @@ class PyZopeInterface(PythonPackage):
     homepage = "https://github.com/zopefoundation/zope.interface"
     pypi = "zope.interface/zope.interface-4.5.0.tar.gz"
 
-    license("ZPL-2.1")
+    license("ZPL-2.1", checked_by="wdconinc")
 
+    version("7.0.3", sha256="cd2690d4b08ec9eaf47a85914fe513062b20da78d10d6d789a792c0b20307fb1")
+    version("7.0.2", sha256="f1146bb27a411d0d40cc0e88182a6b0e979d68ab526c8e5ae9e27c06506ed017")
+    version("7.0.1", sha256="f0f5fda7cbf890371a59ab1d06512da4f2c89a6ea194e595808123c863c38eff")
+    version("7.0", sha256="a6699621e2e9565fb34e40677fba6eb0974afc400063b3110d8a14d5b0c7a916")
+    version("6.3", sha256="f83d6b4b22262d9a826c3bd4b2fbfafe1d0000f085ef8e44cd1328eea274ae6a")
+    version("6.2", sha256="3b6c62813c63c543a06394a636978b22dffa8c5410affc9331ce6cdb5bfa8565")
+    version("6.1", sha256="2fdc7ccbd6eb6b7df5353012fbed6c3c5d04ceaca0038f75e601060e95345309")
+    version("6.0", sha256="aab584725afd10c710b8f1e6e208dbee2d0ad009f57d674cb9d1b3964037275d")
+    version("5.5.2", sha256="bfee1f3ff62143819499e348f5b8a7f3aa0259f9aca5e0ddae7391d059dce671")
+    version("5.5.1", sha256="6d678475fdeb11394dc9aaa5c564213a1567cc663082e0ee85d52f78d1fbaab2")
+    version("5.5.0", sha256="700ebf9662cf8df70e2f0cb4988e078c53f65ee3eefd5c9d80cf988c4175c8e3")
     version("5.4.0", sha256="5dba5f530fec3f0988d83b78cc591b58c0b6eb8431a85edd1569a0539a8a5a0e")
     version("5.1.0", sha256="40e4c42bd27ed3c11b2c983fecfb03356fae1209de10686d03c02c8696a1d90e")
     version("4.5.0", sha256="57c38470d9f57e37afb460c399eb254e7193ac7fb8042bd09bdc001981a9c74c")
 
-    depends_on("c", type="build")  # generated
-
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"), when="@4.5.0")
     depends_on("python@2.7:2.8,3.5:", type=("build", "run"), when="@5.1.0:")
+    depends_on("python@3.7:", type=("build", "run"), when="@6:")
+    depends_on("python@3.8:", type=("build", "run"), when="@7:")
 
     depends_on("py-setuptools", type=("build", "run"))
     depends_on("py-setuptools@:45", type=("build", "run"), when="@4.5.0")


### PR DESCRIPTION
This PR adds py-zope-event v4.5.1 and v5.0, and py-zope-interface v5.5.0 to v7.0.3.

Also checked license and removed unnecessary c language dependency in py-zope-interface.