### PR TITLE
fzf: add v0.55.0

### DIFF
--- a/var/spack/repos/builtin/packages/fzf/package.py
+++ b/var/spack/repos/builtin/packages/fzf/package.py
@@ -19,6 +19,7 @@ class Fzf(MakefilePackage):
 
     license("MIT")
 
+    version("0.55.0", sha256="805383f71bca7f8fb271ecd716852aea88fd898d5027d58add9e43df6ea766da")
     version("0.54.3", sha256="6413f3916f8058b396820f9078b1336d94c72cbae39c593b1d16b83fcc4fdf74")
     version("0.53.0", sha256="d45abbfb64f21913c633d46818d9d3eb3d7ebc7e94bd16f45941958aa5480e1d")
     version("0.52.1", sha256="96848746ca78249c1fdd16f170776ce2f667097b60e4ffbd5ecdbd7dfac72ef9")


### PR DESCRIPTION
Add v0.55.0 to fzf. 

**Changelog:**
https://junegunn.github.io/fzf/releases/0.55.0/ 