### PR TITLE
bugfix: unit test broken everywhere by package change

### DIFF
--- a/lib/spack/spack/test/cmd/providers.py
+++ b/lib/spack/spack/test/cmd/providers.py
@@ -31,7 +31,6 @@ def test_it_just_runs(pkg):
                 "mpilander",
                 "mvapich2",
                 "openmpi",
-                "openmpi@1.6.5",
                 "openmpi@1.7.5:",
                 "openmpi@2.0.0:",
                 "spectrum-mpi",


### PR DESCRIPTION
Openmpi providers statements were changed. Which is fine in and of itself, but apparently one of our tests depends on the precise constraints used in those statements.

(the unit tests aren't run for package changes, so this made it through without being caught)

See: https://github.com/spack/spack/pull/46102 (that is the "cause", although as I say, not its fault)