### PR TITLE
emacs: add v29.4

### DIFF
--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -20,7 +20,7 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
 
     maintainers("alecbcs")
 
-    license("GPL-3.0-or-later")
+    license("GPL-3.0-or-later", checked_by="wdconinc")
 
     version("master", branch="master")
     version("29.4", sha256="1adb1b9a2c6cdb316609b3e86b0ba1ceb523f8de540cfdda2aec95b6a5343abf")

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -15,12 +15,15 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     homepage = "https://www.gnu.org/software/emacs"
     git = "git://git.savannah.gnu.org/emacs.git"
     gnu_mirror_path = "emacs/emacs-24.5.tar.gz"
+    list_url = " https://ftpmirror.gnu.org/emacs/"
+    list_depth = 0
 
     maintainers("alecbcs")
 
     license("GPL-3.0-or-later")
 
     version("master", branch="master")
+    version("29.4", sha256="1adb1b9a2c6cdb316609b3e86b0ba1ceb523f8de540cfdda2aec95b6a5343abf")
     version("29.3", sha256="2de8df5cab8ac697c69a1c46690772b0cf58fe7529f1d1999582c67d927d22e4")
     version("29.2", sha256="ac8773eb17d8b3c0c4a3bccbb478f7c359266b458563f9a5e2c23c53c05e4e59")
     version("29.1", sha256="5b80e0475b0e619d2ad395ef5bc481b7cb9f13894ed23c301210572040e4b5b1")
@@ -36,10 +39,11 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     version("25.1", sha256="763344b90db4d40e9fe90c5d14748a9dbd201ce544e2cf0835ab48a0aa4a1c67")
     version("24.5", sha256="2737a6622fb2d9982e9c47fb6f2fb297bda42674e09db40fc9bcc0db4297c3b6")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
-
+    variant("gui", default=False, description="Enable GUI build on Mac")
+    variant("json", default=False, when="@27:", description="Build with json support")
+    variant("native", default=False, when="@28:", description="enable native compilation of elisp")
+    variant("tls", default=True, description="Build Emacs with gnutls")
+    variant("treesitter", default=False, when="@29:", description="Build with tree-sitter support")
     variant("X", default=False, description="Enable an X toolkit")
     variant(
         "toolkit",
@@ -47,12 +51,8 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
         values=("gtk", "athena"),
         description="Select an X toolkit (gtk, athena)",
     )
-    variant("gui", default=False, description="Enable GUI build on Mac")
-    variant("tls", default=True, description="Build Emacs with gnutls")
-    variant("native", default=False, when="@28:", description="enable native compilation of elisp")
-    variant("treesitter", default=False, when="@29:", description="Build with tree-sitter support")
-    variant("json", default=False, when="@27:", description="Build with json support")
 
+    depends_on("c", type="build")
     depends_on("pkgconfig", type="build")
     depends_on("gzip", type="build")
 

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -13,7 +13,7 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     """The Emacs programmable text editor."""
 
     homepage = "https://www.gnu.org/software/emacs"
-    git = "git://git.savannah.gnu.org/emacs.git"
+    git = "https://git.savannah.gnu.org/git/emacs.git"
     gnu_mirror_path = "emacs/emacs-24.5.tar.gz"
     list_url = " https://ftpmirror.gnu.org/emacs/"
     list_depth = 0


### PR DESCRIPTION
Add emacs v29.4.

**Changelog:**
https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS?h=emacs-29