### PR TITLE
parallel: add v20240822

### DIFF
--- a/var/spack/repos/builtin/packages/parallel/package.py
+++ b/var/spack/repos/builtin/packages/parallel/package.py
@@ -15,8 +15,9 @@ class Parallel(AutotoolsPackage, GNUMirrorPackage):
     homepage = "https://www.gnu.org/software/parallel/"
     gnu_mirror_path = "parallel/parallel-20220522.tar.bz2"
 
-    license("GPL-3.0-or-later")
+    license("GPL-3.0-or-later", checked_by="wdconinc")
 
+    version("20240822", sha256="d7bbd95b7631980b172be04cbd2138d5f7d8c063d6da5ad8f9f70dfd88c8309d")
     version("20220522", sha256="bb6395f8d964e68f3bdb26a764d3c48b69bc5b759a92ac3ab2bd1895c7fa8c1f")
     version("20220422", sha256="96e4b73fff1302fc141a889ae43ab2e93f6c9e86ac60ef62ced02dbe70b73ca7")
     version("20220322", sha256="df93ccf6a9f529ad2126b7042aef0486603e938c77b405939c41702d38a4e6d8")

--- a/var/spack/repos/builtin/packages/parallel/package.py
+++ b/var/spack/repos/builtin/packages/parallel/package.py
@@ -41,8 +41,7 @@ class Parallel(AutotoolsPackage, GNUMirrorPackage):
     @run_before("install")
     def filter_sbang(self):
         """Run before install so that the standard Spack sbang install hook
-        can fix up the path to the perl binary. Note that the `parallel` script
-        is run during installation to 
+        can fix up the path to the perl binary.
         """
         perl = self.spec["perl"].command
         kwargs = {"ignore_absent": False, "backup": False, "string": False}

--- a/var/spack/repos/builtin/packages/parallel/package.py
+++ b/var/spack/repos/builtin/packages/parallel/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.hooks.sbang import filter_shebang
 from spack.package import *
 
 
@@ -40,7 +41,8 @@ class Parallel(AutotoolsPackage, GNUMirrorPackage):
     @run_before("install")
     def filter_sbang(self):
         """Run before install so that the standard Spack sbang install hook
-        can fix up the path to the perl binary.
+        can fix up the path to the perl binary. Note that the `parallel` script
+        is run during installation to 
         """
         perl = self.spec["perl"].command
         kwargs = {"ignore_absent": False, "backup": False, "string": False}
@@ -50,3 +52,6 @@ class Parallel(AutotoolsPackage, GNUMirrorPackage):
             substitute = f"#!{perl}"
             files = ["parallel", "niceload", "parcat", "sql"]
             filter_file(match, substitute, *files, **kwargs)
+            # Since scripts are run during installation, we need to add sbang
+            for file in files:
+                filter_shebang(file)


### PR DESCRIPTION
This PR adds parallel, v20240822. No build system changes. License checked.

Test build:
```
==> Installing parallel-20240822-sj6fmuvfrgtrkpy4xjwvhnwvrpfuoioe [14/14]
==> No binary for parallel-20240822-sj6fmuvfrgtrkpy4xjwvhnwvrpfuoioe found: installing from source
==> Fetching https://ftpmirror.gnu.org/parallel/parallel-20240822.tar.bz2
==> No patches needed for parallel
==> parallel: Executing phase: 'autoreconf'
==> parallel: Executing phase: 'configure'
==> parallel: Executing phase: 'build'
==> parallel: Executing phase: 'install'
==> parallel: Successfully installed parallel-20240822-sj6fmuvfrgtrkpy4xjwvhnwvrpfuoioe
  Stage: 2.51s.  Autoreconf: 0.00s.  Configure: 1.37s.  Build: 0.03s.  Install: 0.65s.  Post-install: 0.04s.  Total: 4.82s
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/parallel-20240822-sj6fmuvfrgtrkpy4xjwvhnwvrpfuoioe
```