### PR TITLE
nghttp2: add v1.62.1, v1.63.0

### DIFF
--- a/var/spack/repos/builtin/packages/nghttp2/package.py
+++ b/var/spack/repos/builtin/packages/nghttp2/package.py
@@ -15,6 +15,8 @@ class Nghttp2(AutotoolsPackage):
 
     license("MIT")
 
+    version("1.63.0", sha256="9318a2cc00238f5dd6546212109fb833f977661321a2087f03034e25444d3dbb")
+    version("1.62.1", sha256="d0b0b9d00500ee4aa3bfcac00145d3b1ef372fd301c35bff96cf019c739db1b4")
     version("1.62.0", sha256="482e41a46381d10adbdfdd44c1942ed5fd1a419e0ab6f4a5ff5b61468fe6f00d")
     version("1.61.0", sha256="aa7594c846e56a22fbf3d6e260e472268808d3b49d5e0ed339f589e9cc9d484c")
     version("1.57.0", sha256="1e3258453784d3b7e6cc48d0be087b168f8360b5d588c66bfeda05d07ad39ffd")
@@ -48,4 +50,5 @@ class Nghttp2(AutotoolsPackage):
             "--with-mruby=no",
             "--with-neverbleed=no",
             "--with-boost=no",
+            "--with-wolfssl=no",
         ]


### PR DESCRIPTION
This PR adds `nghttp2`, v1.62.1 and v1.63.0.

wolfSSL support was added in v1.63.0 but explictly disabled here to avoid picking up system libraries (default=check). The earlier versions ignore the unknown `--with-wolfssl=no` (and some others, `configure: WARNING: unrecognized options: --with-cunit, --with-boost, --with-wolfssl`).

Test builds:
```
==> Installing nghttp2-1.62.1-irp7ohti4p4fxruectyw475ku4g5ooog [7/7]
==> No binary for nghttp2-1.62.1-irp7ohti4p4fxruectyw475ku4g5ooog found: installing from source
==> Fetching https://github.com/nghttp2/nghttp2/releases/download/v1.62.1/nghttp2-1.62.1.tar.gz
==> No patches needed for nghttp2
==> nghttp2: Executing phase: 'autoreconf'
==> nghttp2: Executing phase: 'configure'
==> nghttp2: Executing phase: 'build'
==> nghttp2: Executing phase: 'install'
==> nghttp2: Successfully installed nghttp2-1.62.1-irp7ohti4p4fxruectyw475ku4g5ooog
  Stage: 0.66s.  Autoreconf: 0.00s.  Configure: 10.22s.  Build: 7.06s.  Install: 0.26s.  Post-install: 0.03s.  Total: 18.30s
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/nghttp2-1.62.1-irp7ohti4p4fxruectyw475ku4g5ooog
==> Installing nghttp2-1.63.0-b46jv2remhofcv335snf2zpxthgcsc6a [7/7]
==> No binary for nghttp2-1.63.0-b46jv2remhofcv335snf2zpxthgcsc6a found: installing from source
==> Fetching https://github.com/nghttp2/nghttp2/releases/download/v1.63.0/nghttp2-1.63.0.tar.gz
==> No patches needed for nghttp2
==> nghttp2: Executing phase: 'autoreconf'
==> nghttp2: Executing phase: 'configure'
==> nghttp2: Executing phase: 'build'
==> nghttp2: Executing phase: 'install'
==> nghttp2: Successfully installed nghttp2-1.63.0-b46jv2remhofcv335snf2zpxthgcsc6a
  Stage: 0.65s.  Autoreconf: 0.00s.  Configure: 10.11s.  Build: 7.01s.  Install: 0.28s.  Post-install: 0.03s.  Total: 18.14s
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/nghttp2-1.63.0-b46jv2remhofcv335snf2zpxthgcsc6a
```