### PR TITLE
Optionally output package namespace

### DIFF
--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -48,6 +48,7 @@ def setup_parser(subparser):
     options = [
         ("--detectable", print_detectable.__doc__),
         ("--maintainers", print_maintainers.__doc__),
+        ("--namespace", print_namespace.__doc__),
         ("--no-dependencies", "do not " + print_dependencies.__doc__),
         ("--no-variants", "do not " + print_variants.__doc__),
         ("--no-versions", "do not " + print_versions.__doc__),
@@ -187,6 +188,15 @@ def print_maintainers(pkg, args):
         mnt = " ".join(["@@" + m for m in pkg.maintainers])
         color.cprint("")
         color.cprint(section_title("Maintainers: ") + mnt)
+
+
+def print_namespace(pkg, args):
+    """output package namespace"""
+
+    repo = spack.repo.PATH.get_repo(pkg.namespace)
+    color.cprint("")
+    color.cprint(section_title("Namespace:"))
+    color.cprint(f"    @c{{{repo.namespace}}} at {repo.root}")
 
 
 def print_phases(pkg, args):
@@ -522,6 +532,7 @@ def info(parser, args):
     # Now output optional information in expected order
     sections = [
         (args.all or args.maintainers, print_maintainers),
+        (args.all or args.namespace, print_namespace),
         (args.all or args.detectable, print_detectable),
         (args.all or args.tags, print_tags),
         (args.all or not args.no_versions, print_versions),

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1299,7 +1299,7 @@ _spack_help() {
 _spack_info() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -a --all --detectable --maintainers --no-dependencies --no-variants --no-versions --phases --tags --tests --virtuals --variants-by-name"
+        SPACK_COMPREPLY="-h --help -a --all --detectable --maintainers --namespace --no-dependencies --no-variants --no-versions --phases --tags --tests --virtuals --variants-by-name"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1954,7 +1954,7 @@ complete -c spack -n '__fish_spack_using_command help' -l spec -f -a guide
 complete -c spack -n '__fish_spack_using_command help' -l spec -d 'help on the package specification syntax'
 
 # spack info
-set -g __fish_spack_optspecs_spack_info h/help a/all detectable maintainers no-dependencies no-variants no-versions phases tags tests virtuals variants-by-name
+set -g __fish_spack_optspecs_spack_info h/help a/all detectable maintainers namespace no-dependencies no-variants no-versions phases tags tests virtuals variants-by-name
 complete -c spack -n '__fish_spack_using_command_pos 0 info' -f -a '(__fish_spack_packages)'
 complete -c spack -n '__fish_spack_using_command info' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command info' -s h -l help -d 'show this help message and exit'
@@ -1964,6 +1964,8 @@ complete -c spack -n '__fish_spack_using_command info' -l detectable -f -a detec
 complete -c spack -n '__fish_spack_using_command info' -l detectable -d 'output information on external detection'
 complete -c spack -n '__fish_spack_using_command info' -l maintainers -f -a maintainers
 complete -c spack -n '__fish_spack_using_command info' -l maintainers -d 'output package maintainers'
+complete -c spack -n '__fish_spack_using_command info' -l namespace -f -a namespace
+complete -c spack -n '__fish_spack_using_command info' -l namespace -d 'output package namespace'
 complete -c spack -n '__fish_spack_using_command info' -l no-dependencies -f -a no_dependencies
 complete -c spack -n '__fish_spack_using_command info' -l no-dependencies -d 'do not output build, link, and run package dependencies'
 complete -c spack -n '__fish_spack_using_command info' -l no-variants -f -a no_variants


### PR DESCRIPTION
When we have multiple package repositories, it is helpful to easily identify the namespace of a package from the command line.  This PR adds the `spack info --namespace` option, which prints out the namespace underneath the "Homepage" section:

![image](https://github.com/user-attachments/assets/85c1114f-86d3-48d2-8939-cdd904f5939a)

This information is also provided whenever `spack info -a` is used.