### PR TITLE
store projections: drop references to compiler and os

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -19,7 +19,7 @@ config:
   install_tree:
     root: $spack/opt/spack
     projections:
-      all: "{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}"
+      all: "{platform}-{target}/{name}-{version}-{hash}"
     # install_tree can include an optional padded length (int or boolean)
     # default is False (do not pad)
     # if padded_length is True, Spack will pad as close to the system max path

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -24,12 +24,12 @@ import spack.package_base
 import spack.paths
 import spack.repo
 import spack.schema.compilers
-import spack.spec
 import spack.schema.config
 import spack.schema.env
 import spack.schema.mirrors
 import spack.schema.packages
 import spack.schema.repos
+import spack.spec
 import spack.store
 import spack.util.path as spack_path
 import spack.util.spack_yaml as syaml

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -24,6 +24,7 @@ import spack.package_base
 import spack.paths
 import spack.repo
 import spack.schema.compilers
+import spack.spec
 import spack.schema.config
 import spack.schema.env
 import spack.schema.mirrors
@@ -1311,7 +1312,7 @@ def test_default_install_tree(monkeypatch, default_config):
     s = spack.spec.Spec("nonexistent@x.y.z %none@a.b.c arch=foo-bar-baz")
     monkeypatch.setattr(s, "dag_hash", lambda length: "abc123")
     _, _, projections = spack.store.parse_install_tree(spack.config.get("config"))
-    assert s.format(projections["all"]) == "foo-bar-baz/none-a.b.c/nonexistent-x.y.z-abc123"
+    assert s.format(projections["all"]) == "foo-baz/nonexistent-x.y.z-abc123"
 
 
 def test_local_config_can_be_disabled(working_env):


### PR DESCRIPTION
Removes:
    
1. the second path component `{compiler.name}-{compiler.version}`
2. `{os}` from the first path component
    
in default store projections.
    
The reason is that a) not all packages will have compilers associated
going forward, and b) reuse of packages through build caches makes the
`os` bit somewhat meaningless on Linux, as it refers to the distro the
package was built on, instead of the distro it was installed on (you might
see centos7 directories on ubuntu24.04 for example)
