### PR TITLE
py-contourpy: add missing dependency on py-pybind

### DIFF
--- a/var/spack/repos/builtin/packages/py-contourpy/package.py
+++ b/var/spack/repos/builtin/packages/py-contourpy/package.py
@@ -35,6 +35,8 @@ class PyContourpy(PythonPackage):
         depends_on("python@3.8:", when="@1.0.7:")
         depends_on("python@3.7:")
 
+        depends_on("py-pybind11@2.13.1:", when="@1.3:")
+
     with default_args(type=("build", "run")):
         depends_on("py-numpy@1.23:", when="@1.3:")
         depends_on("py-numpy@1.16:")


### PR DESCRIPTION
I get the following errors on AlmaLinux 9 with GCC 14:

```
  >> 142    ../src/common.h:4:10: fatal error: pybind11/pybind11.h: No such file or directory
     143          4 | #include <pybind11/pybind11.h>
```

I have installations with the previous version 1.0.7 and don't remember this so it has to be something that happens for 1.3.0. Even though the matplotlib dependency states it's build and run, I have double checked I need to add it to the build, link and run, and not to the build and run part below.