### PR TITLE
bash: use libc malloc on musl instead of internal malloc

### DIFF
--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -203,6 +203,8 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
             args.append(f"--with-libiconv-prefix={spec['iconv'].prefix}")
         else:
             args.append("--without-libiconv-prefix")
+        if spec.satisfies("^[virtuals=libc] musl"):
+            options.append("--without-bash-malloc")
         return args
 
     def check(self):

--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -203,6 +203,7 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
             args.append(f"--with-libiconv-prefix={spec['iconv'].prefix}")
         else:
             args.append("--without-libiconv-prefix")
+        # bash malloc relies on sbrk which fails intentionally in musl
         if spec.satisfies("^[virtuals=libc] musl"):
             options.append("--without-bash-malloc")
         return args


### PR DESCRIPTION
It appears that the current bash recipe does not work on musl libc. Upon startup, I see the following:
```
bash: xmalloc: locale.c:84: cannot allocate 2 bytes
```

In short, it appears to come from using bash's internal malloc, as opposed to using the libc-provided one. Adding `--without-bash-malloc` to the configure options resolves the issue.