### PR TITLE
hipfft: update @master dependency wrt rocfft

### DIFF
--- a/var/spack/repos/builtin/packages/hipfft/package.py
+++ b/var/spack/repos/builtin/packages/hipfft/package.py
@@ -83,6 +83,7 @@ class Hipfft(CMakePackage, CudaPackage, ROCmPackage):
         "6.1.1",
         "6.1.2",
         "6.2.0",
+        "master",
     ]:
         depends_on(f"rocm-cmake@{ver}:", type="build", when=f"@{ver}")
         depends_on(f"rocfft@{ver}", when=f"+rocm @{ver}")

--- a/var/spack/repos/builtin/packages/rocfft/package.py
+++ b/var/spack/repos/builtin/packages/rocfft/package.py
@@ -20,6 +20,7 @@ class Rocfft(CMakePackage):
     libraries = ["librocfft"]
 
     license("MIT")
+    version("master", branch="master")
     version("6.2.0", sha256="c9886ec2c713c502dcde4f5fed3d6e1a7dd019023fb07e82d3b622e66c6f2c36")
     version("6.1.2", sha256="6f54609b0ecb8ceae8b7acd4c8692514c2c2dbaf0f8b199fe990fd4711428193")
     version("6.1.1", sha256="d517a931d49a1e59df4e494ab2b68e301fe7ebf39723863985567467f111111c")
@@ -88,6 +89,7 @@ class Rocfft(CMakePackage):
         "6.1.1",
         "6.1.2",
         "6.2.0",
+        "master",
     ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"rocm-cmake@{ver}:", type="build", when=f"@{ver}")


### PR DESCRIPTION
Without this fix:
```
$ ./bin/spack spec ginkgo+rocm amdgpu_target=gfx90a ^hip@5.7.1 |egrep '(hip|hipfft)@'
 -       ^hip@5.7.1
 -       ^hip@5.7.1%gcc@11.4.0~asan~cuda~ipo+rocm build_system=cmake build_type=Release generator=make patches=5bb9b0e,7668b2a,aee7249,b589a02,c2ee21c arch=linux-ubuntu22.04-x86_64
 -       ^hipfft@master%gcc@11.4.0~asan~cuda~ipo+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-ubuntu22.04-x86_64
```
With this fix:
```
$ ./bin/spack spec ginkgo+rocm amdgpu_target=gfx90a ^hip@5.7.1 |egrep '(hip|hipfft)@'
 -       ^hip@5.7.1
 -       ^hip@5.7.1%gcc@11.4.0~asan~cuda~ipo+rocm build_system=cmake build_type=Release generator=make patches=5bb9b0e,7668b2a,aee7249,b589a02,c2ee21c arch=linux-ubuntu22.04-x86_64
 -       ^hipfft@5.7.1%gcc@11.4.0~asan~cuda~ipo+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-ubuntu22.04-x86_64
```
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
