### PR TITLE
hiop: Fix how ReSolve option is passed

### DIFF
--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -203,6 +203,9 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
                 ]
             )
 
+        with when("+cuda @:0.7.1"):
+            args.extend(self.define_from_variant("HIOP_USE_RESOLVE", "cusolver_lu"))
+
         args.extend(
             [
                 self.define("HIOP_BUILD_STATIC", True),
@@ -223,7 +226,6 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
                 self.define_from_variant("HIOP_USE_COINHSL", "sparse"),
                 self.define_from_variant("HIOP_TEST_WITH_BSUB", "jsrun"),
                 self.define_from_variant("HIOP_USE_GINKGO", "ginkgo"),
-                self.define_from_variant("HIOP_USE_RESOLVE", "cusolver_lu"),
             ]
         )
 

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -203,7 +203,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
                 ]
             )
 
-        with when("+cuda @:0.7.1"):
+        with when("+cuda @0.7.1:"):
             args.extend(self.define_from_variant("HIOP_USE_RESOLVE", "cusolver_lu"))
 
         args.extend(

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -204,7 +204,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
             )
 
         with when("+cuda @0.7.1:"):
-            args.extend(self.define_from_variant("HIOP_USE_RESOLVE", "cusolver_lu"))
+            args.extend([self.define_from_variant("HIOP_USE_RESOLVE", "cusolver_lu")])
 
         args.extend(
             [

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -90,7 +90,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "deepchecking",
         default=False,
-        description="Ultra safety checks - " "used for increased robustness and self-diagnostics",
+        description="Ultra safety checks - used for increased robustness and self-diagnostics",
     )
     variant("ginkgo", default=False, description="Enable/disable ginkgo solver")
     variant(
@@ -203,9 +203,6 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
                 ]
             )
 
-        with when("+cuda @0.7.1:"):
-            args.extend([self.define_from_variant("HIOP_USE_RESOLVE", "cusolver_lu")])
-
         args.extend(
             [
                 self.define("HIOP_BUILD_STATIC", True),
@@ -226,6 +223,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
                 self.define_from_variant("HIOP_USE_COINHSL", "sparse"),
                 self.define_from_variant("HIOP_TEST_WITH_BSUB", "jsrun"),
                 self.define_from_variant("HIOP_USE_GINKGO", "ginkgo"),
+                self.define_from_variant("HIOP_USE_RESOLVE", "cusolver_lu"),
             ]
         )
 
@@ -316,7 +314,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         exe = which(exe)
 
         for i, args in enumerate(options):
-            with test_part(self, f"test_{exName}_{i+1}", purpose=" ".join(args)):
+            with test_part(self, f"test_{exName}_{i + 1}", purpose=" ".join(args)):
                 exe(*args)
 
     def test_NlpMdsEx1(self):


### PR DESCRIPTION
Was getting some cryptic errors building hiop~cuda and it looked like some extra whitespace was being added to the CMake line due to a stray CLI argument from an undefined `args.extend` input.

This should fix that issue - see error [pipeline](https://github.com/LLNL/hiop/actions/runs/10741214413/job/29791072221)
