### PR TITLE
add retries counter to ci

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -33,11 +33,13 @@ ci:
           --log install_times.json
           ${SPACK_ARTIFACTS_ROOT}/user_data/install_times.json || true
       - - export RETRY_FILE="${SPACK_ARTIFACTS_ROOT}/user_data/retry_count.txt"
-        - [ -f retry_count.txt ] || echo "0" > retry_count.txt
-        - export RETRY_NUMBER=`cat $RETRY_FILE`
-        - export RETRY_NUMBER=$((RETRY_NUMBER+1))
+        - >
+          if [ ! -f $RETRY_FILE ]; then
+            echo "0" > $RETRY_FILE
+          fi
+        - export RETRY_NUMBER=$(cat $RETRY_FILE)
+        - export RETRY_NUMBER=$((RETRY_NUMBER + 1))
         - echo $RETRY_NUMBER > $RETRY_FILE
-
       variables:
         CI_JOB_SIZE: "default"
         CI_GPG_KEY_ROOT: /mnt/key

--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -32,6 +32,12 @@ ci:
           --prefix /home/software/spack:${CI_PROJECT_DIR}/opt/spack
           --log install_times.json
           ${SPACK_ARTIFACTS_ROOT}/user_data/install_times.json || true
+      - - export RETRY_FILE="${SPACK_ARTIFACTS_ROOT}/user_data/retry_count.txt"
+        - [ -f retry_count.txt ] || echo "0" > retry_count.txt
+        - export RETRY_NUMBER=`cat $RETRY_FILE`
+        - export RETRY_NUMBER=$((RETRY_NUMBER+1))
+        - echo $RETRY_NUMBER > $RETRY_FILE
+
       variables:
         CI_JOB_SIZE: "default"
         CI_GPG_KEY_ROOT: /mnt/key


### PR DESCRIPTION
[proof of concept, don't merge]

In anticipation of future changes to CI, we'll need to know how many times a specific job has been retried. Unfortunately, this isn't available as a clean variable in gitlab (see issues [195618](https://gitlab.com/gitlab-org/gitlab/-/issues/195618)/[27589](https://gitlab.com/gitlab-org/gitlab/-/issues/27589)), so we use a [workaround](https://stackoverflow.com/questions/74548131/how-to-identify-retry-pipeline-jobs-in-gitlab) with artifacts.

Basically want to make sure this artifact/variable is available to the `pre_build_script` of the subsequent job.
