### PR TITLE
libwebsockets: add v4.3.3

### DIFF
--- a/var/spack/repos/builtin/packages/libwebsockets/package.py
+++ b/var/spack/repos/builtin/packages/libwebsockets/package.py
@@ -29,7 +29,4 @@ class Libwebsockets(CMakePackage):
     depends_on("openssl")
 
     def cmake_args(self):
-        args = []
-        if self.spec.platform == "darwin":
-            args = ["-DLWS_WITHOUT_TESTAPPS=ON"]
-        return args
+        return ["-DLWS_WITHOUT_TESTAPPS=ON"]

--- a/var/spack/repos/builtin/packages/libwebsockets/package.py
+++ b/var/spack/repos/builtin/packages/libwebsockets/package.py
@@ -15,6 +15,7 @@ class Libwebsockets(CMakePackage):
 
     license("MIT")
 
+    version("4.3.3", sha256="6fd33527b410a37ebc91bb64ca51bdabab12b076bc99d153d7c5dd405e4bdf90")
     version("2.2.1", sha256="e7f9eaef258e003c9ada0803a9a5636757a5bc0a58927858834fb38a87d18ad2")
     version("2.1.1", sha256="96183cbdfcd6e6a3d9465e854a924b7bfde6c8c6d3384d6159ad797c2e823b4d")
     version("2.1.0", sha256="bcc96aaa609daae4d3f7ab1ee480126709ef4f6a8bf9c85de40aae48e38cce66")
@@ -26,3 +27,9 @@ class Libwebsockets(CMakePackage):
 
     depends_on("zlib-api")
     depends_on("openssl")
+
+    def cmake_args(self):
+        args = []
+        if self.spec.platform == "darwin":
+            args = ["-DLWS_WITHOUT_TESTAPPS=ON"]
+        return args


### PR DESCRIPTION
Errors when building tests on macos:
```
...
error: /Library/Developer/CommandLineTools/usr/bin/install_name_tool: for: /Users/username/Documents/packages/spack/opt/spack/darwin-sonoma-m1/apple-clang-15.0.0/li
            bwebsockets-4.3.3-c6ycpajsexi6jdlbas7xkvrw6wxobkyq/bin/libwebsockets-test-client (for architecture arm64) option "-add_rpath /Users/username/Documents/packages/spac
            k/opt/spack/darwin-sonoma-m1/apple-clang-15.0.0/zlib-ng-2.2.1-z4esolp7gw6gbtwutr2wjcqofeztnnii/lib" would duplicate path, file already has LC_RPATH for: /Users/username
           /Documents/packages/spack/opt/spack/darwin-sonoma-m1/apple-clang-15.0.0/zlib-ng-2.2.1-z4esolp7gw6gbtwutr2wjcqofeztnnii/lib
...
```
