### PR TITLE
Spec.splice: Allow splices when multiples nodes in the DAG share a name

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4270,7 +4270,7 @@ class Spec:
 
     def _splice_intransitive(self, other):
         """Execute an intransitive splice. See ``Spec.splice`` for details."""
-        spec = self.copy()
+        spec = self.copy(deps=dt.ALL & ~dt.BUILD)
         replacement = other.copy(deps=dt.ALL & ~dt.BUILD)
 
         # Ignore build deps in spec while doing the splice
@@ -4305,7 +4305,7 @@ class Spec:
     def _splice_transitive(self, other):
         """Execute a transitive splice. See ``Spec.splice`` for details"""
         spec = self.copy(deps=dt.ALL & ~dt.BUILD)
-        replacement = other.copy()
+        replacement = other.copy(deps=dt.ALL & ~dt.BUILD)
 
         # Ignore build deps in spec while doing the splice
         # They will be added back in at the end

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4284,7 +4284,9 @@ class Spec:
 
         # Transitively splice any relevant nodes from spec into replacement
         # This handles all shared dependencies between self and other
-        replacement._splice_helper(spec, self_root=spec, other_root=other)
+        # This is basically a reverse transitive splice for all shared dependencies
+        # so self_root and other_root are swapped
+        replacement._splice_helper(spec, self_root=other, other_root=spec)
 
         # Intransitively splice replacement into spec
         # This is very simple now that all shared dependencies have been handled

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4199,7 +4199,6 @@ class Spec:
         for edge in self.edges_from_dependents():
             if edge.parent not in ancestors_in_context:
                 continue
-            index = edge.parent._dependencies[self.name].index(edge)
             build_dep = edge.depflag & dt.BUILD
             other_dep = edge.depflag & ~dt.BUILD
             if build_dep:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4266,6 +4266,7 @@ class Spec:
                 node._add_dependency(dupe, depflag=new_depflag, virtuals=edge.virtuals)
 
     def _splice_intransitive(self, other):
+        """Execute an intransitive splice. See ``Spec.splice`` for details."""
         spec = self.copy()
         replacement = other.copy()
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4265,8 +4265,11 @@ class Spec:
                 # No match, keep searching
                 if not analogs:
                     continue
-                analogs.sort(key=lambda s: s.version)
-                analog = analogs[-1]
+
+                # If there are multiple analogs, this package must satisfy the constraint
+                # that a newer version can always replace a lesser version.
+                analog = max(analogs, key=lambda s: s.version)
+
                 # No splice needed here, keep checking
                 if analog == node:
                     continue

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4160,7 +4160,6 @@ class Spec:
             # Could be using any virtual the package can provide
             return set(self.package.virtuals_provided)
 
-        virtuals = set()
         hashes = [s.dag_hash() for s in root.traverse()]
         in_edges = set(
             [edge for edge in self.edges_from_dependents() if edge.parent.dag_hash() in hashes]
@@ -4274,7 +4273,7 @@ class Spec:
                     for virtual in node._virtuals_provided(root=self):
                         analogs += [
                             r
-                            for r in replacements_by_name[getattr(virtual, name, virtual)]
+                            for r in replacements_by_name[getattr(virtual, "name", virtual)]
                             if r._splice_match(node, self_root=self_root, other_root=other_root)
                         ]
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4162,10 +4162,7 @@ class Spec:
         in_edges = set(
             [edge for edge in self.edges_from_dependents() if edge.parent.dag_hash() in hashes]
         )
-        for edge in in_edges:
-            virtuals |= set(edge.virtuals)
-
-        return virtuals
+        return set().union(*[edge.virtuals for edge in in_edges])
 
     def _splice_match(self, other, self_root, other_root):
         """Return True if other is a match for self in a splice of other_root into self_root"""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1765,7 +1765,10 @@ class Spec:
         for edge in selected:
             has_errors, details = False, []
             msg = f"cannot update the edge from {edge.parent.name} to {edge.spec.name}"
-            if not dt.compatible(edge.depflag, depflag):
+
+            # If the dependency is to an existing spec, we can update dependency
+            # types. If it is to a new object, check deptype compatibility.
+            if id(edge.spec) != id(dependency_spec) and not dt.compatible(edge.depflag, depflag):
                 has_errors = True
                 details.append(
                     (

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4180,7 +4180,8 @@ class Spec:
     def _splice_detach_and_add_dependents(self, replacement, context):
         """Helper method for Spec._intransitive_splice.
 
-        replacement is a copy of other with all deps cleared. Other is the argument from splice."""
+        replacement is a node to splice in, context is the scope of dependents to consider relevant
+        to this splice."""
         # Update build_spec attributes for all transitive dependents
         # before we start changing their dependencies
         ancestors_in_context = [

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4178,7 +4178,7 @@ class Spec:
         )
 
     def _splice_detach_and_add_dependents(self, replacement, context):
-        """Helper method for Spec._intransitive_splice.
+        """Helper method for Spec._splice_helper.
 
         replacement is a node to splice in, context is the scope of dependents to consider relevant
         to this splice."""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4194,7 +4194,7 @@ class Spec:
         for edge in self.edges_from_dependents():
             index = edge.parent._dependencies[self.name].index(edge)
             build_dep = edge.depflag & dt.BUILD
-            other_dep = edge.depflag & dt.LINK | dt.RUN | dt.TEST
+            other_dep = edge.depflag & ~dt.BUILD
             if build_dep:
                 parent_edge = [e for e in edge.parent._dependencies[self.name] if e.spec is self]
                 assert len(parent_edge) == 1

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4239,10 +4239,22 @@ class Spec:
     def _splice_helper(self, replacement, self_root, other_root):
         """Main loop of a transitive splice.
 
-        Topo traversal of self ensures that if a node is unreachable in the end result, we will
-        never consider it.
-        For each node, find any analog in replacement and swap it in.
-        We assume only build deps are handled outside of this method
+        The while loop around a traversal of self ensures that changes to self from previous
+        iterations are reflected in the traversal. This avoids evaluating irrelevant nodes
+        using topological traversal (all incoming edges traversed before any outgoing edge).
+        If any node will not be in the end result, its parent will be spliced and it will not
+        ever be considered.
+        For each node in self, find any analogous node in replacement and swap it in.
+        We assume all build deps are handled outside of this method
+
+        Arguments:
+            replacement: The node that will replace any equivalent node in self
+            self_root: The root of the spec that self comes from. This provides the context for
+                evaluating whether ``replacement`` is a match for each node of ``self``. See
+                ``Spec._splice_match`` and ``Spec._virtuals_provided`` for details.
+            other_root: The root of the spec that replacement comes from. This provides the context
+                for evaluating whether ``replacement`` is a match for each node of ``self``. See
+                ``Spec._splice_match`` and ``Spec._virtuals_provided`` for details.
         """
         ids = set(id(s) for s in replacement.traverse())
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4221,27 +4221,27 @@ class Spec:
             if other_dep:
                 edge.parent._add_dependency(replacement, depflag=other_dep, virtuals=edge.virtuals)
 
-    def get_analogues(self, candidates_generator, self_root, other_root):
+    def get_analogs(self, candidates_generator, self_root, other_root):
         """Find all specs in candidate_generator that are splice matches for self
 
         self_root and other_root are passed as arguments to ``self._splie_match``."""
-        analogues = [
+        analogs = [
             dep
             for dep in candidates_generator
             if self._splice_match(dep, self_root=self_root, other_root=other_root)
         ]
-        if not analogues:
+        if not analogs:
             return []
 
-        name_analogues = [a for a in analogues if a.name == self.name]
-        return name_analogues or analogues
+        name_analogs = [a for a in analogs if a.name == self.name]
+        return name_analogs or analogs
 
     def _splice_helper(self, replacement, self_root, other_root):
         """Main loop of a transitive splice.
 
         Topo traversal of self ensures that if a node is unreachable in the end result, we will
         never consider it.
-        For each node, find any analogue in replacement and swap it in.
+        For each node, find any analog in replacement and swap it in.
         We assume only build deps are handled outside of this method
         """
         ids = [id(s) for s in replacement.traverse()]
@@ -4257,20 +4257,20 @@ class Spec:
                 # If this node has already been swapped in, don't consider it again
                 if id(node) in ids:
                     continue
-                analogues = node.get_analogues(
+                analogs = node.get_analogs(
                     replacement.traverse(deptype=dt.ALL & ~dt.BUILD),
                     self_root=self_root,
                     other_root=other_root,
                 )
                 # No match, keep searching
-                if not analogues:
+                if not analogs:
                     continue
-                analogues.sort(key=lambda s: s.version)
-                analogue = analogues[-1]
+                analogs.sort(key=lambda s: s.version)
+                analog = analogs[-1]
                 # No splice needed here, keep checking
-                if analogue == node:
+                if analog == node:
                     continue
-                node._splice_detach_and_add_dependents(analogue, context=self)
+                node._splice_detach_and_add_dependents(analog, context=self)
                 changed = True
                 break
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4244,7 +4244,7 @@ class Spec:
         For each node, find any analog in replacement and swap it in.
         We assume only build deps are handled outside of this method
         """
-        ids = [id(s) for s in replacement.traverse()]
+        ids = set(id(s) for s in replacement.traverse())
 
         changed = True
         while changed:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4165,7 +4165,16 @@ class Spec:
         return set().union(*[edge.virtuals for edge in in_edges])
 
     def _splice_match(self, other, self_root, other_root):
-        """Return True if other is a match for self in a splice of other_root into self_root"""
+        """Return True if other is a match for self in a splice of other_root into self_root
+
+        Other is a splice match for self if it shares a name, or if self is a virtual provider
+        and other provides a superset of the virtuals provided by self. Virtuals provided are
+        evaluated in the context of a root spec (self_root for self, other_root for other).
+
+        This is a slight oversimplification. Other could be a match for self in the context of
+        one edge in self_root and not in the context of another edge. This method could be
+        expanded in the future to account for these cases.
+        """
         if other.name == self.name:
             return True
 

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -311,7 +311,7 @@ def test_pkg_grep(mock_packages, capfd):
     output, _ = capfd.readouterr()
     assert output.strip() == "\n".join(
         spack.repo.PATH.get_pkg_class(name).module.__file__
-        for name in ["splice-a", "splice-h", "splice-t", "splice-vh", "splice-z"]
+        for name in ["splice-a", "splice-h", "splice-t", "splice-vh", "splice-vt", "splice-z"]
     )
 
     # ensure that this string isn't fouhnd

--- a/lib/spack/spack/test/rewiring.py
+++ b/lib/spack/spack/test/rewiring.py
@@ -102,6 +102,8 @@ def test_rewire_writes_new_metadata(mock_fetch, install_mockery):
         )
         assert os.path.exists(manifest_file_path)
         orig_node = spec[node.name]
+        if node == orig_node:
+            continue
         orig_manifest_file_path = os.path.join(
             orig_node.prefix,
             spack.store.STORE.layout.metadata_dir,

--- a/lib/spack/spack/test/rewiring.py
+++ b/lib/spack/spack/test/rewiring.py
@@ -47,7 +47,7 @@ def test_rewire_db(mock_fetch, install_mockery, transitive):
         text_file_path = os.path.join(node.prefix, node.name)
         with open(text_file_path, "r") as f:
             text = f.read()
-            for modded_spec in node.traverse(root=True):
+            for modded_spec in node.traverse(root=True, deptype=("link", "run")):
                 assert modded_spec.prefix in text
 
 
@@ -60,6 +60,7 @@ def test_rewire_bin(mock_fetch, install_mockery, transitive):
     spec.package.do_install()
     dep.package.do_install()
     spliced_spec = spec.splice(dep, transitive=transitive)
+
     assert spec.dag_hash() != spliced_spec.dag_hash()
 
     spack.rewiring.rewire(spliced_spec)

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1108,7 +1108,7 @@ class TestSpecSemantics:
     def test_splice_swap_names_mismatch_virtuals(self, default_mock_concretization, transitive):
         spec = default_mock_concretization("splice-t")
         dep = default_mock_concretization("splice-vh+foo")
-        with pytest.raises(spack.spec.SpliceError, match="will not provide the same virtuals."):
+        with pytest.raises(spack.spec.SpliceError, match="virtual"):
             spec.splice(dep, transitive)
 
     def test_spec_override(self):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1104,17 +1104,15 @@ class TestSpecSemantics:
         assert set(spliced["f"].dependents()) == {spliced["c"]}
 
         # spliced["g"] is g3, but spliced["b"]["g"] is g1
-        assert spliced["g"] == c_blue["g"]
+        assert spliced["g"] == a_red["g"]
         assert spliced["g"]._build_spec is None
         assert set(spliced["g"].dependents(deptype=dt.LINK)) == {
             spliced,
             spliced["c"],
             spliced["f"],
+            a_red["c"],
         }
-        # Because a copy of g3 is used, it does not have dependents in the original specs
-        # It has build dependents on these spliced specs because it is an unchanged dependency
-        # for them
-        assert set(spliced["g"].dependents(deptype=dt.BUILD)) == {spliced["c"], spliced["f"]}
+        assert set(spliced["g"].dependents(deptype=dt.BUILD)) == {spliced, a_red["c"]}
 
         assert spliced["b"]["g"] == a_red["b"]["g"]
         assert spliced["b"]["g"]._build_spec is None
@@ -1128,7 +1126,9 @@ class TestSpecSemantics:
                     ("a", "c"),  # These are the spliced edges
                     ("c", "d"),
                     ("f", "e"),
-                    ("a", "g"),
+                    ("c", "g"),
+                    ("f", "g"),
+                    ("c", "f"),  # ancestor to spliced edge
                 ]:
                     depflag |= dt.BUILD
                 assert edge.depflag == depflag

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -66,7 +66,11 @@ def setup_complex_splice(monkeypatch):
     def splice_match(self, other, self_root, other_root):
         return self.name == other.name
 
+    def virtuals_provided(self, root):
+        return []
+
     monkeypatch.setattr(Spec, "_splice_match", splice_match)
+    monkeypatch.setattr(Spec, "_virtuals_provided", virtuals_provided)
 
     g1_red = Spec("g color=red")
     g1_red.versions = vn.VersionList([vn.Version("1")])

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1098,7 +1098,7 @@ class TestSpecSemantics:
 
     @pytest.mark.parametrize("transitive", [True, False])
     def test_splice_swap_names(self, default_mock_concretization, transitive):
-        spec = default_mock_concretization("splice-t")
+        spec = default_mock_concretization("splice-vt")
         dep = default_mock_concretization("splice-a+foo")
         out = spec.splice(dep, transitive)
         assert dep.name in out

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1061,6 +1061,9 @@ class TestSpecSemantics:
             "a color=red ^b color=red ^c color=blue "
             "^d color=red ^e color=red ^f color=blue ^g@3 color=blue"
         )
+        assert set(spliced.dependencies(deptype=dt.BUILD)) == set(
+            a_red.dependencies(deptype=dt.BUILD)
+        )
         assert spliced.build_spec == a_red
         # We cannot check spliced["b"].build_spec is spliced["b"] because Spec.__getitem__ creates
         # a new wrapper object on each invocation. So we select once and check on that object
@@ -1072,6 +1075,9 @@ class TestSpecSemantics:
 
         assert spliced["c"].satisfies(
             "c color=blue ^d color=red ^e color=red ^f color=blue ^g@3 color=blue"
+        )
+        assert set(spliced["c"].dependencies(deptype=dt.BUILD)) == set(
+            c_blue.dependencies(deptype=dt.BUILD)
         )
         assert spliced["c"].build_spec == c_blue
         assert set(spliced["c"].dependents()) == {spliced}
@@ -1091,6 +1097,9 @@ class TestSpecSemantics:
         assert set(spliced["e"].dependents(deptype=dt.BUILD)) == {spliced["b"]}
 
         assert spliced["f"].satisfies("f color=blue ^e color=red ^g@3 color=blue")
+        assert set(spliced["f"].dependencies(deptype=dt.BUILD)) == set(
+            c_blue["f"].dependencies(deptype=dt.BUILD)
+        )
         assert spliced["f"].build_spec == c_blue["f"]
         assert set(spliced["f"].dependents()) == {spliced["c"]}
 
@@ -1132,9 +1141,15 @@ class TestSpecSemantics:
             "a color=red ^b color=red"
             "^c color=blue ^d color=blue ^e color=blue ^f color=blue ^g@3 color=blue"
         )
+        assert set(spliced.dependencies(deptype=dt.BUILD)) == set(
+            a_red.dependencies(deptype=dt.BUILD)
+        )
         assert spliced.build_spec == a_red
 
         assert spliced["b"].satisfies("b color=red ^d color=blue ^e color=blue ^g@2 color=blue")
+        assert set(spliced["b"].dependencies(deptype=dt.BUILD)) == set(
+            a_red["b"].dependencies(deptype=dt.BUILD)
+        )
         assert spliced["b"].build_spec == a_red["b"]
         assert set(spliced["b"].dependents()) == {spliced}
 
@@ -1191,6 +1206,7 @@ class TestSpecSemantics:
                     ("b", "d"),
                     ("b", "e"),
                     ("b", "g"),
+                    ("a", "b"),  # This edge not spliced, but b was spliced invalidating edge
                 ]:
                     depflag |= dt.BUILD
                 assert edge.depflag == depflag

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -7,6 +7,7 @@ import pathlib
 
 import pytest
 
+import spack.deptypes as dt
 import spack.directives
 import spack.error
 import spack.parser
@@ -15,6 +16,7 @@ import spack.solver.asp
 import spack.spec
 import spack.store
 import spack.variant
+import spack.version as vn
 from spack.error import SpecError, UnsatisfiableSpecError
 from spack.spec import (
     ArchSpec,
@@ -965,6 +967,129 @@ class TestSpecSemantics:
 
         # Finally, the spec should know it's been spliced:
         assert out.spliced
+
+    def test_splice_intransitive_complex(self, monkeypatch):
+        def splice_match(self, other, self_root, other_root):
+            return self.name == other.name
+
+        monkeypatch.setattr(Spec, "_validate_version", lambda s: None)
+        monkeypatch.setattr(Spec, "_splice_match", splice_match)
+
+        g1_red = Spec("g color=red")
+        g1_red.versions = vn.VersionList([vn.Version("1")])
+        g2_red = Spec("g color=red")
+        g2_red.versions = vn.VersionList([vn.Version("2")])
+        g2_blue = Spec("g color=blue")
+        g2_blue.versions = vn.VersionList([vn.Version("2")])
+        g3_blue = Spec("g color=blue")
+        g3_blue.versions = vn.VersionList([vn.Version("3")])
+
+        depflag = dt.LINK | dt.BUILD
+        e_red = Spec("e color=red")
+        e_red._add_dependency(g1_red, depflag=depflag, virtuals=())
+        e_blue = Spec("e color=blue")
+        e_blue._add_dependency(g3_blue, depflag=depflag, virtuals=())
+
+        d_red = Spec("d color=red")
+        d_red._add_dependency(g1_red, depflag=depflag, virtuals=())
+        d_blue = Spec("d color=blue")
+        d_blue._add_dependency(g2_blue, depflag=depflag, virtuals=())
+
+        b_red = Spec("b color=red")
+        b_red._add_dependency(e_red, depflag=depflag, virtuals=())
+        b_red._add_dependency(d_red, depflag=depflag, virtuals=())
+        b_red._add_dependency(g1_red, depflag=depflag, virtuals=())
+
+        f_blue = Spec("f color=blue")
+        f_blue._add_dependency(e_blue, depflag=depflag, virtuals=())
+        f_blue._add_dependency(g3_blue, depflag=depflag, virtuals=())
+
+        c_red = Spec("c color=red")
+        c_red._add_dependency(d_red, depflag=depflag, virtuals=())
+        c_red._add_dependency(g2_red, depflag=depflag, virtuals=())
+        c_blue = Spec("c color=blue")
+        c_blue._add_dependency(d_blue, depflag=depflag, virtuals=())
+        c_blue._add_dependency(f_blue, depflag=depflag, virtuals=())
+        c_blue._add_dependency(g3_blue, depflag=depflag, virtuals=())
+
+        a_red = Spec("a color=red")
+        a_red._add_dependency(b_red, depflag=depflag, virtuals=())
+        a_red._add_dependency(c_red, depflag=depflag, virtuals=())
+        a_red._add_dependency(g2_red, depflag=depflag, virtuals=())
+
+        for spec in [e_red, e_blue, d_red, d_blue, b_red, f_blue, c_red, c_blue, a_red]:
+            spec.versions = vn.VersionList([vn.Version("1")])
+
+            a_red._mark_concrete()
+            c_blue._mark_concrete()
+
+        spliced = a_red.splice(c_blue, transitive=False)
+        assert spliced.satisfies(
+            "a color=red ^b color=red ^c color=blue ^d color=red ^e color=red ^f color=blue ^g@3 color=blue"
+        )
+        assert spliced.build_spec == a_red
+        # We cannot check spliced["b"].build_spec is spliced["b"] because Spec.__getitem__ creates
+        # a new wrapper object on each invocation. So we select once and check on that object
+        # For the rest of the unchanged specs we will just check the s._build_spec is None.
+        b = spliced["b"]
+        assert b == b_red
+        assert b.build_spec is b
+        assert set(b.dependents()) == {spliced}
+
+        assert spliced["c"].satisfies(
+            "c color=blue ^d color=red ^e color=red ^f color=blue ^g@3 color=blue"
+        )
+        assert spliced["c"].build_spec == c_blue
+        assert set(spliced["c"].dependents()) == {spliced}
+
+        assert spliced["d"] == d_red
+        assert spliced["d"]._build_spec is None
+        # Since D had a parent changed, it has a split edge for link vs build dependent
+        # note: spliced["b"] == b_red, referenced differently to preserve logic
+        assert set(spliced["d"].dependents()) == {spliced["b"], spliced["c"], c_red}
+        assert set(spliced["d"].dependents(deptype=dt.BUILD)) == {b_red, c_red}
+
+        assert spliced["e"] == e_red
+        assert spliced["e"]._build_spec is None
+        assert set(spliced["e"].dependents()) == {spliced["b"], spliced["f"]}
+
+        assert spliced["f"].satisfies("f color=blue ^e color=red ^g@3 color=blue")
+        assert spliced["f"].build_spec == f_blue
+        assert set(spliced["f"].dependents()) == {spliced["c"]}
+
+        # spliced["g"] is g3, but spliced["b"]["g"] is g1
+        assert spliced["g"] == g3_blue
+        assert spliced["g"]._build_spec is None
+        for edge in spliced["g"].edges_from_dependents():
+            print(edge)
+        print(spliced["c"]["g"])
+        assert set(spliced["g"].dependents(deptype=dt.LINK)) == {
+            spliced,
+            spliced["c"],
+            spliced["f"],
+        }
+        assert set(spliced["g"].dependents(deptype=dt.BUILD)) == {c_blue, f_blue, e_blue}
+
+        assert spliced["b"]["g"] == g1_red
+        assert spliced["b"]["g"]._build_spec is None
+        assert set(spliced["b"]["g"].dependents()) == {spliced["b"], spliced["d"], spliced["e"]}
+
+        for edge in spliced.traverse_edges(cover="edges", deptype=dt.LINK | dt.RUN):
+            # traverse_edges creates a synthetic edge with no deptypes to the root
+            if edge.depflag:
+                depflag = dt.LINK
+                if (edge.parent.name, edge.spec.name) not in [
+                    ("a", "c"),  # These are the spliced edges
+                    ("c", "d"),
+                    ("f", "e"),
+                    ("a", "g"),
+                ]:
+                    depflag |= dt.BUILD
+                print(edge)
+                assert edge.depflag == depflag
+
+        print(spliced)
+        assert False
 
     @pytest.mark.parametrize("transitive", [True, False])
     def test_splice_with_cached_hashes(self, default_mock_concretization, transitive):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -36,7 +36,7 @@ from spack.variant import (
 
 @pytest.fixture()
 def setup_complex_splice(monkeypatch):
-    """Fixture to set up splicing for two complex specs.
+    r"""Fixture to set up splicing for two complex specs.
 
     a_red is a spec in which every node has the variant color=red
     c_blue is a spec in which every node has the variant color=blue
@@ -1058,7 +1058,8 @@ class TestSpecSemantics:
 
         spliced = a_red.splice(c_blue, transitive=False)
         assert spliced.satisfies(
-            "a color=red ^b color=red ^c color=blue ^d color=red ^e color=red ^f color=blue ^g@3 color=blue"
+            "a color=red ^b color=red ^c color=blue "
+            "^d color=red ^e color=red ^f color=blue ^g@3 color=blue"
         )
         assert spliced.build_spec == a_red
         # We cannot check spliced["b"].build_spec is spliced["b"] because Spec.__getitem__ creates
@@ -1128,7 +1129,8 @@ class TestSpecSemantics:
 
         spliced = a_red.splice(c_blue, transitive=True)
         assert spliced.satisfies(
-            "a color=red ^b color=red ^c color=blue ^d color=blue ^e color=blue ^f color=blue ^g@3 color=blue"
+            "a color=red ^b color=red"
+            "^c color=blue ^d color=blue ^e color=blue ^f color=blue ^g@3 color=blue"
         )
         assert spliced.build_spec == a_red
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -552,6 +552,20 @@ def specfile_for(default_mock_concretization):
             "^[deptypes=build,link] zlib",
         ),
         (
+            "^[deptypes=link] zlib ^[deptypes=build] zlib",
+            [
+                Token(TokenType.START_EDGE_PROPERTIES, value="^["),
+                Token(TokenType.KEY_VALUE_PAIR, value="deptypes=link"),
+                Token(TokenType.END_EDGE_PROPERTIES, value="]"),
+                Token(TokenType.UNQUALIFIED_PACKAGE_NAME, value="zlib"),
+                Token(TokenType.START_EDGE_PROPERTIES, value="^["),
+                Token(TokenType.KEY_VALUE_PAIR, value="deptypes=build"),
+                Token(TokenType.END_EDGE_PROPERTIES, value="]"),
+                Token(TokenType.UNQUALIFIED_PACKAGE_NAME, value="zlib"),
+            ],
+            "^[deptypes=link] zlib ^[deptypes=build] zlib",
+        ),
+        (
             "git-test@git.foo/bar",
             [
                 Token(TokenType.UNQUALIFIED_PACKAGE_NAME, "git-test"),
@@ -992,6 +1006,8 @@ def test_disambiguate_hash_by_spec(spec1, spec2, constraint, mock_packages, monk
         ("x target=be platform=test os=be os=fe", "'platform'"),
         # Dependencies
         ("^[@foo] zlib", "edge attributes"),
+        ("x ^[deptypes=link]foo ^[deptypes=run]foo", "conflicting dependency types"),
+        ("x ^[deptypes=build,link]foo ^[deptypes=link]foo", "conflicting dependency types"),
         # TODO: Remove this as soon as use variants are added and we can parse custom attributes
         ("^[foo=bar] zlib", "edge attributes"),
         # Propagating reserved names generates a parse error

--- a/var/spack/repos/builtin.mock/packages/splice-vt/package.py
+++ b/var/spack/repos/builtin.mock/packages/splice-vt/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class SpliceVt(Package):
+    """Simple package with one optional dependency"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/splice-t-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    depends_on("somethingelse")
+    depends_on("splice-z")
+
+    def install(self, spec, prefix):
+        with open(prefix.join("splice-vt"), "w") as f:
+            f.write("splice-vt: {0}".format(prefix))
+            f.write("splice-h: {0}".format(spec["somethingelse"].prefix))
+            f.write("splice-z: {0}".format(spec["splice-z"].prefix))


### PR DESCRIPTION
The current `Spec.splice` model is very limited by the inability to splice specs that contain multiple nodes with the same name.  This is an artifact of the original algorithm design predating the separate concretization of build dependencies, which was the first feature to allow multiple specs in a DAG to share a name.

This PR provides a complete reimplementation of `Spec.splice` to avoid that limitation. At the same time, the new algorithm ensures that build dependencies for spliced specs are not changed, since the splice by definition cannot change the build-time information of the spec. This is handled by splitting the dependency edges and link/run edges into separate dependencies as needed.

The attached image shows a pair of splices between two specs, with the transitive splice on the lower-left and the intransitive splice on the lower-right. In both cases, only the link/run DAG is considered.

![splice](https://github.com/user-attachments/assets/c7737f82-d3c2-41a4-8a14-1a43b22aff2a)

This PR includes tests for these cases to augment the less complex splicing tests that predate it.

@tldahlgren and @tgamblin this follows the algorithm we discussed on 9/10
