### PR TITLE
aspell: various fixes and updates

### DIFF
--- a/lib/spack/spack/build_systems/aspell_dict.py
+++ b/lib/spack/spack/build_systems/aspell_dict.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+
 import llnl.util.filesystem as fs
 
 import spack.directives
@@ -46,18 +48,12 @@ class AspellDictPackage(AutotoolsPackage):
     #: Override the default autotools builder
     AutotoolsBuilder = AspellBuilder
 
-    def view_destination(self, view):
-        aspell_spec = self.spec["aspell"]
-        if view.get_projection_for_spec(aspell_spec) != aspell_spec.prefix:
-            raise spack.package_base.ExtensionError(
-                "aspell does not support non-global extensions"
-            )
-        aspell = aspell_spec.command
-        return aspell("dump", "config", "dict-dir", output=str).strip()
-
-    def view_source(self):
-        return self.prefix.lib
-
     def patch(self):
-        fs.filter_file(r"^dictdir=.*$", "dictdir=/lib", "configure")
-        fs.filter_file(r"^datadir=.*$", "datadir=/lib", "configure")
+        aspell_spec = self.spec["aspell"]
+        aspell = aspell_spec.command
+        dictdir = aspell("dump", "config", "dict-dir", output=str).strip()
+        datadir = aspell("dump", "config", "data-dir", output=str).strip()
+        dictdir = os.path.relpath(dictdir, aspell_spec.prefix)
+        datadir = os.path.relpath(datadir, aspell_spec.prefix)
+        fs.filter_file(r"^dictdir=.*$", f"dictdir=/{dictdir}", "configure")
+        fs.filter_file(r"^datadir=.*$", f"datadir=/{datadir}", "configure")

--- a/var/spack/repos/builtin/packages/aspell/package.py
+++ b/var/spack/repos/builtin/packages/aspell/package.py
@@ -27,3 +27,9 @@ class Aspell(AutotoolsPackage, GNUMirrorPackage):
 
     patch("fix_cpp.patch")
     patch("issue-519.patch", when="@:0.60.6.1")
+
+    # workaround due to https://github.com/GNUAspell/aspell/issues/591
+    @run_after("configure", when="@0.60.8:")
+    def make_missing_files(self):
+        make("gen/dirs.h")
+        make("gen/static_filters.src.cpp")

--- a/var/spack/repos/builtin/packages/aspell/package.py
+++ b/var/spack/repos/builtin/packages/aspell/package.py
@@ -33,3 +33,6 @@ class Aspell(AutotoolsPackage, GNUMirrorPackage):
     def make_missing_files(self):
         make("gen/dirs.h")
         make("gen/static_filters.src.cpp")
+
+    def setup_run_environment(self, env):
+        env.set("ASPELL_CONF", f"prefix {self.prefix}")

--- a/var/spack/repos/builtin/packages/aspell6-de/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-de/package.py
@@ -15,6 +15,10 @@ class Aspell6De(AspellDictPackage, GNUMirrorPackage):
     license("GPL-2.0-or-later")
 
     version(
+        "6-de-20161207-7-0",
+        sha256="c2125d1fafb1d4effbe6c88d4e9127db59da9ed92639c7cbaeae1b7337655571",
+    )
+    version(
         "6-de-20030222-1",
         sha256="ba6c94e11bc2e0e6e43ce0f7822c5bba5ca5ac77129ef90c190b33632416e906",
     )

--- a/var/spack/repos/builtin/packages/aspell6-en/package.py
+++ b/var/spack/repos/builtin/packages/aspell6-en/package.py
@@ -13,5 +13,8 @@ class Aspell6En(AspellDictPackage, GNUMirrorPackage):
     gnu_mirror_path = "aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2"
 
     version(
+        "2020.12.07-0", sha256="4c8f734a28a088b88bb6481fcf972d0b2c3dc8da944f7673283ce487eac49fb3"
+    )
+    version(
         "2017.01.22-0", sha256="93c73fae3eab5ea3ca6db3cea8770715a820f1b7d6ea2b932dd66a17f8fd55e1"
     )


### PR DESCRIPTION
- fixes aspell install that seems to have been broken since 0.60.8 due to missing files
- adds newer dicts for English and German
- fixes install issue with dictionaries and makes them visible for aspell by updating prefix via `ASPELL_CONF` 