### PR TITLE
bash: use the correct variable in configure() in bash package.py

### DIFF
--- a/var/spack/repos/builtin/packages/bash/package.py
+++ b/var/spack/repos/builtin/packages/bash/package.py
@@ -205,7 +205,7 @@ class Bash(AutotoolsPackage, GNUMirrorPackage):
             args.append("--without-libiconv-prefix")
         # bash malloc relies on sbrk which fails intentionally in musl
         if spec.satisfies("^[virtuals=libc] musl"):
-            options.append("--without-bash-malloc")
+            args.append("--without-bash-malloc")
         return args
 
     def check(self):


### PR DESCRIPTION
I made a silly mistake.

I used the wrong variable name in https://github.com/spack/spack/pull/46370 and ended up testing the wrong repo clone with musl.

Apologies for any inconvenience.