### PR TITLE
Replace `if ... in spec` with `spec.satisfies` in h* and i* packages

### DIFF
--- a/var/spack/repos/builtin/packages/h5hut/package.py
+++ b/var/spack/repos/builtin/packages/h5hut/package.py
@@ -43,7 +43,7 @@ class H5hut(AutotoolsPackage):
     def validate(self):
         """Checks if Fortran compiler is available."""
 
-        if "+fortran" in self.spec and not self.compiler.fc:
+        if self.spec.satisfies("+fortran") and not self.compiler.fc:
             raise RuntimeError("Cannot build Fortran variant without a Fortran compiler.")
 
     def flag_handler(self, name, flags):
@@ -59,10 +59,10 @@ class H5hut(AutotoolsPackage):
         spec = self.spec
         config_args = ["--enable-shared"]
 
-        if "+fortran" in spec:
+        if spec.satisfies("+fortran"):
             config_args.append("--enable-fortran")
 
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             config_args.extend(
                 [
                     "--enable-parallel",
@@ -71,7 +71,7 @@ class H5hut(AutotoolsPackage):
                 ]
             )
 
-            if "+fortran" in spec:
+            if spec.satisfies("+fortran"):
                 config_args.append("FC={0}".format(spec["mpi"].mpifc))
 
         return config_args

--- a/var/spack/repos/builtin/packages/h5utils/package.py
+++ b/var/spack/repos/builtin/packages/h5utils/package.py
@@ -47,17 +47,17 @@ class H5utils(AutotoolsPackage):
         spec = self.spec
         args = []
 
-        if "+vis5d" in spec:
+        if spec.satisfies("+vis5d"):
             args.append(f"--with-v5d={spec['vis5d'].prefix}")
         else:
             args.append("--without-v5d")
 
-        if "+octave" in spec:
+        if spec.satisfies("+octave"):
             args.append("--with-octave")
         else:
             args.append("--without-octave")
 
-        if "+hdf" in spec:
+        if spec.satisfies("+hdf"):
             args.append("--with-hdf4")
         else:
             args.append("--without-hdf4")

--- a/var/spack/repos/builtin/packages/h5z-zfp/package.py
+++ b/var/spack/repos/builtin/packages/h5z-zfp/package.py
@@ -34,7 +34,7 @@ class H5zZfp(CMakePackage):
     def make_defs(self):
         cc = spack_cc
         fc = spack_fc
-        if "^hdf5+mpi" in self.spec:
+        if self.spec.satisfies("^hdf5+mpi"):
             cc = self.spec["mpi"].mpicc
             fc = self.spec["mpi"].mpifc
         make_defs = [
@@ -44,7 +44,7 @@ class H5zZfp(CMakePackage):
             "ZFP_HOME=%s" % self.spec["zfp"].prefix,
         ]
 
-        if "+fortran" in self.spec and fc:
+        if self.spec.satisfies("+fortran") and fc:
             make_defs += ["FC=%s" % fc]
         else:
             make_defs += ["FC="]

--- a/var/spack/repos/builtin/packages/halide/package.py
+++ b/var/spack/repos/builtin/packages/halide/package.py
@@ -118,7 +118,7 @@ class Halide(CMakePackage, PythonExtension):
         for target in llvm_targets:
             args += [self.define("TARGET_{0}".format(target[0]), target[1])]
 
-        if "+python" in spec:
+        if spec.satisfies("+python"):
             args += [
                 self.define("PYBIND11_USE_FETCHCONTENT", False),
                 self.define("Halide_INSTALL_PYTHONDIR", python_platlib),

--- a/var/spack/repos/builtin/packages/hdf-eos2/package.py
+++ b/var/spack/repos/builtin/packages/hdf-eos2/package.py
@@ -71,7 +71,7 @@ class HdfEos2(AutotoolsPackage):
     # Build dependencies
     depends_on("hdf")
     # Because hdf always depends on zlib and jpeg in spack, the tests below in configure_args
-    # (if "jpeg" in self.spec:) always returns true and hdf-eos2 wants zlib and jpeg, too.
+    # (if self.spec.satisfies("^jpeg"):) always returns true and hdf-eos2 wants zlib and jpeg, too.
     depends_on("zlib-api")
     depends_on("jpeg")
     depends_on("szip", when="^hdf +szip")
@@ -151,15 +151,15 @@ class HdfEos2(AutotoolsPackage):
 
         # Provide config args for dependencies
         extra_args.append("--with-hdf4={0}".format(self.spec["hdf"].prefix))
-        if "jpeg" in self.spec:
+        if self.spec.satisfies("^jpeg"):
             # Allow handling whatever provider of jpeg are using
             tmp = self.spec["jpeg"].libs.directories
             if tmp:
                 tmp = tmp[0]
                 extra_args.append("--with-jpeg={0}".format(tmp))
-        if "szip" in self.spec:
+        if self.spec.satisfies("^szip"):
             extra_args.append("--with-szlib={0}".format(self.spec["szip"].prefix))
-        if "zlib" in self.spec:
+        if self.spec.satisfies("^zlib"):
             extra_args.append("--with-zlib={0}".format(self.spec["zlib-api"].prefix))
 
         return extra_args

--- a/var/spack/repos/builtin/packages/hdf-eos5/package.py
+++ b/var/spack/repos/builtin/packages/hdf-eos5/package.py
@@ -107,9 +107,9 @@ class HdfEos5(AutotoolsPackage):
 
         # Provide config args for dependencies
         extra_args.append("--with-hdf5={0}".format(self.spec["hdf5"].prefix))
-        if "szip" in self.spec:
+        if self.spec.satisfies("^szip"):
             extra_args.append("--with-szlib={0}".format(self.spec["szip"].prefix))
-        if "zlib-api" in self.spec:
+        if self.spec.satisfies("^zlib-api"):
             extra_args.append("--with-zlib={0}".format(self.spec["zlib-api"].prefix))
 
         return extra_args

--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -121,7 +121,7 @@ class Hdf(AutotoolsPackage):
         elif "static" in query_parameters:
             shared = False
         else:
-            shared = "+shared" in self.spec
+            shared = self.spec.satisfies("+shared")
 
         libs = find_libraries(libraries, root=self.prefix, shared=shared, recursive=True)
 
@@ -134,15 +134,15 @@ class Hdf(AutotoolsPackage):
         if not shared and "transitive" in query_parameters:
             libs += self.spec["jpeg:transitive"].libs
             libs += self.spec["zlib:transitive"].libs
-            if "+szip" in self.spec:
+            if self.spec.satisfies("+szip"):
                 libs += self.spec["szip:transitive"].libs
-            if "+external-xdr" in self.spec and self.spec["rpc"].name == "libtirpc":
+            if self.spec.satisfies("+external-xdr") and self.spec["rpc"].name == "libtirpc":
                 libs += self.spec["rpc:transitive"].libs
 
         return libs
 
     def flag_handler(self, name, flags):
-        if "+pic" in self.spec:
+        if self.spec.satisfies("+pic"):
             if name == "cflags":
                 flags.append(self.compiler.cc_pic_flag)
             elif name == "fflags":
@@ -175,12 +175,12 @@ class Hdf(AutotoolsPackage):
         config_args += self.enable_or_disable("fortran")
         config_args += self.enable_or_disable("java")
 
-        if "+szip" in self.spec:
+        if self.spec.satisfies("+szip"):
             config_args.append("--with-szlib=%s" % self.spec["szip"].prefix)
         else:
             config_args.append("--without-szlib")
 
-        if "~external-xdr" in self.spec:
+        if self.spec.satisfies("~external-xdr"):
             config_args.append("--enable-hdf4-xdr")
         elif self.spec["rpc"].name == "libtirpc":
             # We should not specify '--disable-hdf4-xdr' due to a bug in the

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -326,7 +326,7 @@ class Hdf5(CMakePackage):
             if spec.satisfies("@:1.8.12+fortran~shared"):
                 cmake_flags.append(self.compiler.fc_pic_flag)
         elif name == "ldlibs":
-            if "+fortran %fj" in spec:
+            if spec.satisfies("+fortran %fj"):
                 cmake_flags.extend(["-lfj90i", "-lfj90f", "-lfjsrcinfo", "-lelf"])
 
         return flags, None, (cmake_flags or None)
@@ -344,7 +344,7 @@ class Hdf5(CMakePackage):
         """
         query_parameters = self.spec.last_query.extra_parameters
 
-        shared = "+shared" in self.spec
+        shared = self.spec.satisfies("+shared")
 
         # This map contains a translation from query_parameters
         # to the libraries needed
@@ -485,7 +485,7 @@ class Hdf5(CMakePackage):
 
     @run_before("cmake")
     def fortran_check(self):
-        if "+fortran" in self.spec and not self.compiler.fc:
+        if self.spec.satisfies("+fortran") and not self.compiler.fc:
             msg = "cannot build a Fortran variant without a Fortran compiler"
             raise RuntimeError(msg)
 
@@ -532,7 +532,7 @@ class Hdf5(CMakePackage):
         # MSMPI does not provide compiler wrappers
         # and pointing these variables at the MSVC compilers
         # breaks CMake's mpi detection for MSMPI.
-        if "+mpi" in spec and "msmpi" not in spec:
+        if spec.satisfies("+mpi") and "msmpi" not in spec:
             args.extend(
                 [
                     "-DMPI_CXX_COMPILER:PATH=%s" % spec["mpi"].mpicxx,
@@ -540,7 +540,7 @@ class Hdf5(CMakePackage):
                 ]
             )
 
-            if "+fortran" in spec:
+            if spec.satisfies("+fortran"):
                 args.extend(["-DMPI_Fortran_COMPILER:PATH=%s" % spec["mpi"].mpifc])
 
         # work-around for https://github.com/HDFGroup/hdf5/issues/1320
@@ -618,7 +618,7 @@ class Hdf5(CMakePackage):
     def link_debug_libs(self):
         # When build_type is Debug, the hdf5 build appends _debug to all library names.
         # Dependents of hdf5 (netcdf-c etc.) can't handle those, thus make symlinks.
-        if "build_type=Debug" in self.spec:
+        if self.spec.satisfies("build_type=Debug"):
             libs = find(self.prefix.lib, "libhdf5*_debug.*", recursive=False)
             with working_dir(self.prefix.lib):
                 for lib in libs:

--- a/var/spack/repos/builtin/packages/heasoft/package.py
+++ b/var/spack/repos/builtin/packages/heasoft/package.py
@@ -93,7 +93,7 @@ class Heasoft(AutotoolsPackage):
             join_path("tcltk", "BUILD_DIR", "hd_config_info"),
         )
 
-        if "+X" in self.spec:
+        if self.spec.satisfies("+X"):
             filter_file(
                 r"(\s+XDIR => ).*",
                 r"\1'{0}',".format(self.spec["libx11"].libs.directories[0]),
@@ -109,7 +109,7 @@ class Heasoft(AutotoolsPackage):
 
         config_args += self.enable_or_disable("x", variant="X")
 
-        if "+X" in self.spec:
+        if self.spec.satisfies("+X"):
             config_args.extend(
                 [
                     "--x-includes={0}".format(self.spec["libx11"].headers.directories[0]),

--- a/var/spack/repos/builtin/packages/heffte/package.py
+++ b/var/spack/repos/builtin/packages/heffte/package.py
@@ -100,7 +100,7 @@ class Heffte(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant("Heffte_ENABLE_PYTHON", "python"),
         ]
 
-        if "+cuda" in self.spec and self.spec.satisfies("@:2.3.0"):
+        if self.spec.satisfies("+cuda") and self.spec.satisfies("@:2.3.0"):
             cuda_arch = self.spec.variants["cuda_arch"].value
             if len(cuda_arch) > 0 or cuda_arch[0] != "none":
                 nvcc_flags = ""
@@ -111,7 +111,7 @@ class Heffte(CMakePackage, CudaPackage, ROCmPackage):
                 archs = ";".join(cuda_arch)
                 args.append("-DCMAKE_CUDA_ARCHITECTURES=%s" % archs)
 
-        if "+rocm" in self.spec:
+        if self.spec.satisfies("+rocm"):
             args.append("-DCMAKE_CXX_COMPILER={0}".format(self.spec["hip"].hipcc))
 
             rocm_arch = self.spec.variants["amdgpu_target"].value
@@ -143,7 +143,7 @@ class Heffte(CMakePackage, CudaPackage, ROCmPackage):
 
         options = [cmake_dir]
         options.append(self.define("Heffte_DIR", self.spec.prefix.lib.cmake.Heffte))
-        if "+rocm" in self.spec:
+        if self.spec.satisfies("+rocm"):
             # path name is 'hsa-runtime64' but python cannot have '-' in variable name
             hsa_runtime = join_path(self.spec["hsa-rocr-dev"].prefix.lib.cmake, "hsa-runtime64")
             options.extend(

--- a/var/spack/repos/builtin/packages/helics/package.py
+++ b/var/spack/repos/builtin/packages/helics/package.py
@@ -142,7 +142,9 @@ class Helics(CMakePackage):
 
         # HELICS shared library options
         args.append(
-            "-DHELICS_DISABLE_C_SHARED_LIB={0}".format("OFF" if "+c_shared" in spec else "ON")
+            "-DHELICS_DISABLE_C_SHARED_LIB={0}".format(
+                "OFF" if spec.satisfies("+c_shared") else "ON"
+            )
         )
         args.append(from_variant("HELICS_BUILD_CXX_SHARED_LIB", "cxx_shared"))
 
@@ -150,13 +152,17 @@ class Helics(CMakePackage):
         args.append(from_variant("HELICS_BUILD_APP_EXECUTABLES", "apps"))
         args.append(from_variant("HELICS_BUILD_APP_LIBRARY", "apps_lib"))
         args.append(
-            "-DHELICS_DISABLE_WEBSERVER={0}".format("OFF" if "+webserver" in spec else "ON")
+            "-DHELICS_DISABLE_WEBSERVER={0}".format(
+                "OFF" if spec.satisfies("+webserver") else "ON"
+            )
         )
         args.append(from_variant("HELICS_BUILD_BENCHMARKS", "benchmarks"))
 
         # Extra HELICS library dependencies
-        args.append("-DHELICS_DISABLE_BOOST={0}".format("OFF" if "+boost" in spec else "ON"))
-        args.append("-DHELICS_DISABLE_ASIO={0}".format("OFF" if "+asio" in spec else "ON"))
+        args.append(
+            "-DHELICS_DISABLE_BOOST={0}".format("OFF" if spec.satisfies("+boost") else "ON")
+        )
+        args.append("-DHELICS_DISABLE_ASIO={0}".format("OFF" if spec.satisfies("+asio") else "ON"))
 
         # Encryption
         args.append(from_variant("HELICS_ENABLE_ENCRYPTION", "encryption"))
@@ -178,5 +184,5 @@ class Helics(CMakePackage):
 
     def setup_run_environment(self, env):
         spec = self.spec
-        if "+python" in spec:
+        if spec.satisfies("+python"):
             env.prepend_path("PYTHONPATH", self.prefix.python)

--- a/var/spack/repos/builtin/packages/hh-suite/package.py
+++ b/var/spack/repos/builtin/packages/hh-suite/package.py
@@ -37,7 +37,7 @@ class HhSuite(CMakePackage):
 
     def build_args(self, spec, prefix):
         args = []
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             args.append("-DCHECK_MPI=1")
         else:
             args.append("-DCHECK_MPI=0")

--- a/var/spack/repos/builtin/packages/highfive/package.py
+++ b/var/spack/repos/builtin/packages/highfive/package.py
@@ -58,8 +58,8 @@ class Highfive(CMakePackage):
 
     def cmake_args(self):
         args = [
-            "-DUSE_BOOST:Bool={0}".format("+boost" in self.spec),
-            "-DHIGHFIVE_PARALLEL_HDF5:Bool={0}".format("+mpi" in self.spec),
+            "-DUSE_BOOST:Bool={0}".format(self.spec.satisfies("+boost")),
+            "-DHIGHFIVE_PARALLEL_HDF5:Bool={0}".format(self.spec.satisfies("+mpi")),
             "-DHIGHFIVE_UNIT_TESTS:Bool=false",
             "-DHIGHFIVE_EXAMPLES:Bool=false",
         ]

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -178,7 +178,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         args = []
         spec = self.spec
 
-        use_gpu = "+cuda" in spec or "+rocm" in spec
+        use_gpu = spec.satisfies("+cuda") or spec.satisfies("+rocm")
 
         if use_gpu:
             args.extend(
@@ -218,7 +218,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         # args.append(
         #     self.define('HIOP_CTEST_LAUNCH_COMMAND', 'srun -t 10:00'))
 
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             args.extend(
                 [
                     self.define("MPI_HOME", spec["mpi"].prefix),
@@ -237,7 +237,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
             #     self.define('MPI_Fortran_LINK_FLAGS',
             #         '-L/path/to/libfabric/lib64/ -lfabric'))
 
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             cuda_arch_list = spec.variants["cuda_arch"].value
             if cuda_arch_list[0] != "none":
                 args.append(self.define("CMAKE_CUDA_ARCHITECTURES", cuda_arch_list))
@@ -250,7 +250,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         # args.append(
         #     self.define('HIP_CLANG_INCLUDE_PATH',
         #         '/opt/rocm-X.Y.Z/llvm/lib/clang/14.0.0/include/'))
-        if "+rocm" in spec:
+        if spec.satisfies("+rocm"):
             args.append(self.define("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
             rocm_arch_list = spec.variants["amdgpu_target"].value
@@ -258,7 +258,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
                 args.append(self.define("GPU_TARGETS", rocm_arch_list))
                 args.append(self.define("AMDGPU_TARGETS", rocm_arch_list))
 
-        if "+kron" in spec:
+        if spec.satisfies("+kron"):
             args.append(self.define("HIOP_UMFPACK_DIR", spec["suite-sparse"].prefix))
 
         # Unconditionally disable strumpack, even when +sparse. This may be
@@ -266,7 +266,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         # fully supported in spack at the moment.
         args.append(self.define("HIOP_USE_STRUMPACK", False))
 
-        if "+sparse" in spec:
+        if spec.satisfies("+sparse"):
             args.append(self.define("HIOP_COINHSL_DIR", spec["coinhsl"].prefix))
 
         return args

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -577,19 +577,19 @@ class Hip(CMakePackage):
 
         args.append(self.define("HIP_COMMON_DIR", self.stage.source_path))
         args.append(self.define("HIP_CATCH_TEST", "OFF"))
-        if "@:5.5" in self.spec:
+        if self.spec.satisfies("@:5.5"):
             args.append(self.define("ROCCLR_PATH", self.stage.source_path + "rocclr"))
             args.append(self.define("AMD_OPENCL_PATH", self.stage.source_path + "opencl"))
-        if "@5.3.0:" in self.spec:
+        if self.spec.satisfies("@5.3.0:"):
             args.append("-DCMAKE_INSTALL_LIBDIR=lib")
-        if "@5.6.0:" in self.spec:
+        if self.spec.satisfies("@5.6.0:"):
             args.append(self.define("ROCCLR_PATH", self.stage.source_path + "/clr/rocclr"))
             args.append(self.define("AMD_OPENCL_PATH", self.stage.source_path + "/clr/opencl"))
             args.append(self.define("CLR_BUILD_HIP", True)),
             args.append(self.define("CLR_BUILD_OCL", False)),
-        if "@5.6:5.7" in self.spec:
+        if self.spec.satisfies("@5.6:5.7"):
             args.append(self.define("HIPCC_BIN_DIR", self.stage.source_path + "/hipcc/bin")),
-        if "@6.0:" in self.spec:
+        if self.spec.satisfies("@6.0:"):
             args.append(self.define("HIPCC_BIN_DIR", self.spec["hipcc"].prefix.bin)),
         return args
 

--- a/var/spack/repos/builtin/packages/hipsycl/package.py
+++ b/var/spack/repos/builtin/packages/hipsycl/package.py
@@ -77,8 +77,8 @@ class Hipsycl(CMakePackage, ROCmPackage):
         spec = self.spec
         args = [
             "-DWITH_CPU_BACKEND:Bool=TRUE",
-            "-DWITH_ROCM_BACKEND:Bool={0}".format("TRUE" if "+rocm" in spec else "FALSE"),
-            "-DWITH_CUDA_BACKEND:Bool={0}".format("TRUE" if "+cuda" in spec else "FALSE"),
+            "-DWITH_ROCM_BACKEND:Bool={0}".format("TRUE" if spec.satisfies("+rocm") else "FALSE"),
+            "-DWITH_CUDA_BACKEND:Bool={0}".format("TRUE" if spec.satisfies("+cuda") else "FALSE"),
             # prevent hipSYCL's cmake to look for other LLVM installations
             # if the specified one isn't compatible
             "-DDISABLE_LLVM_VERSION_CHECK:Bool=TRUE",
@@ -116,9 +116,9 @@ class Hipsycl(CMakePackage, ROCmPackage):
             )
         args.append("-DCLANG_EXECUTABLE_PATH:String={0}".format(llvm_clang_bin))
         # explicit CUDA toolkit
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             args.append("-DCUDA_TOOLKIT_ROOT_DIR:String={0}".format(spec["cuda"].prefix))
-        if "+rocm" in spec:
+        if spec.satisfies("+rocm"):
             args.append("-DWITH_ACCELERATED_CPU:STRING=OFF")
             args.append("-DROCM_PATH:STRING={0}".format(os.environ.get("ROCM_PATH")))
             if self.spec.satisfies("@24.02.0:"):
@@ -161,7 +161,7 @@ class Hipsycl(CMakePackage, ROCmPackage):
             #    the libc++.so and libc++abi.so dyn linked to the sycl
             #    ptx backend
             rpaths = set()
-            if "~rocm" in spec:
+            if spec.satisfies("~rocm"):
                 so_paths = filesystem.find_libraries(
                     "libc++", self.spec["llvm"].prefix, shared=True, recursive=True
                 )

--- a/var/spack/repos/builtin/packages/hiredis/package.py
+++ b/var/spack/repos/builtin/packages/hiredis/package.py
@@ -46,13 +46,17 @@ class Hiredis(MakefilePackage, CMakePackage):
 class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
     @property
     def build_targets(self):
-        use_ssl = 1 if "+ssl" in self.spec else 0
-        run_test_async = 1 if "+test_async" in self.spec else 0
+        use_ssl = 1 if self.spec.satisfies("+ssl") else 0
+        run_test_async = 1 if self.spec.satisfies("+test_async") else 0
         return ["USE_SSL={0}".format(use_ssl), "TEST_ASYNC={0}".format(run_test_async)]
 
     def install(self, pkg, spec, prefix):
         make("PREFIX={0}".format(prefix), "install")
-        if "+test" in self.spec or "+test_async" in self.spec or "+test_ssl" in self.spec:
+        if (
+            self.spec.satisfies("+test")
+            or self.spec.satisfies("+test_async")
+            or self.spec.satisfies("+test_ssl")
+        ):
             make("PREFIX={0}".format(prefix), "test")
 
     @run_after("install")
@@ -63,9 +67,9 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
 
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):
-        build_test = not ("+test" in self.spec)
-        ssl_test = ("+test_ssl" in self.spec) and ("+test" in self.spec)
-        async_test = ("+test_async" in self.spec) and ("+test" in self.spec)
+        build_test = not self.spec.satisfies("+test")
+        ssl_test = self.spec.satisfies("+test_ssl") and self.spec.satisfies("+test")
+        async_test = self.spec.satisfies("+test_async") and self.spec.satisfies("+test")
 
         args = [
             self.define_from_variant("ENABLE_SSL", "ssl"),

--- a/var/spack/repos/builtin/packages/hmmer/package.py
+++ b/var/spack/repos/builtin/packages/hmmer/package.py
@@ -41,10 +41,10 @@ class Hmmer(Package):
     def install(self, spec, prefix):
         configure_args = ["--prefix={0}".format(prefix)]
 
-        if "+gsl" in self.spec:
+        if self.spec.satisfies("+gsl"):
             configure_args.extend(["--with-gsl", "LIBS=-lgsl -lgslcblas"])
 
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             configure_args.append("--enable-mpi")
 
         configure(*configure_args)

--- a/var/spack/repos/builtin/packages/homer/package.py
+++ b/var/spack/repos/builtin/packages/homer/package.py
@@ -50,5 +50,5 @@ class Homer(Package):
         perl("configureHomer.pl", "-local")
 
         # download extra data if requested
-        if "+data" in spec:
+        if spec.satisfies("+data"):
             perl("configureHomer.pl", "-install", "-all")

--- a/var/spack/repos/builtin/packages/hoomd-blue/package.py
+++ b/var/spack/repos/builtin/packages/hoomd-blue/package.py
@@ -71,14 +71,14 @@ class HoomdBlue(CMakePackage):
         cmake_args = ["-DCMAKE_INSTALL_PREFIX={0}".format(python_platlib)]
 
         # MPI support
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             os.environ["MPI_HOME"] = spec["mpi"].prefix
             cmake_args.append("-DENABLE_MPI=ON")
         else:
             cmake_args.append("-DENABLE_MPI=OFF")
 
         # CUDA support
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             cmake_args.append("-DENABLE_CUDA=ON")
         else:
             cmake_args.append("-DENABLE_CUDA=OFF")
@@ -95,7 +95,7 @@ class HoomdBlue(CMakePackage):
         cmake_args.append("-DENABLE_MPI_CUDA=OFF")
 
         # Documentation
-        if "+doc" in spec:
+        if spec.satisfies("+doc"):
             cmake_args.append("-DENABLE_DOXYGEN=ON")
         else:
             cmake_args.append("-DENABLE_DOXYGEN=OFF")

--- a/var/spack/repos/builtin/packages/hpcc/package.py
+++ b/var/spack/repos/builtin/packages/hpcc/package.py
@@ -85,7 +85,7 @@ class Hpcc(MakefilePackage):
     }
 
     def patch(self):
-        if "fftw" in self.spec:
+        if self.spec.satisfies("^fftw"):
             # spack's fftw2 prefix headers with floating point type
             filter_file(r"^\s*#include <fftw.h>", "#include <sfftw.h>", "FFT/wrapfftw.h")
             filter_file(

--- a/var/spack/repos/builtin/packages/hpccg/package.py
+++ b/var/spack/repos/builtin/packages/hpccg/package.py
@@ -31,7 +31,7 @@ class Hpccg(MakefilePackage):
     def build_targets(self):
         targets = []
 
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             targets.append("CXX={0}".format(self.spec["mpi"].mpicxx))
             targets.append("LINKER={0}".format(self.spec["mpi"].mpicxx))
             targets.append("USE_MPI=-DUSING_MPI")
@@ -39,7 +39,7 @@ class Hpccg(MakefilePackage):
             targets.append("CXX=c++")
             targets.append("LINKER=c++")
 
-        if "+openmp" in self.spec:
+        if self.spec.satisfies("+openmp"):
             targets.append("USE_OMP=-DUSING_OMP")
             targets.append("OMP_FLAGS={0}".format(self.compiler.openmp_flag))
 

--- a/var/spack/repos/builtin/packages/hpcg/package.py
+++ b/var/spack/repos/builtin/packages/hpcg/package.py
@@ -76,7 +76,7 @@ class Hpcg(AutotoolsPackage):
             CXXFLAGS += " -Rpass=loop-vectorize"
             CXXFLAGS += " -Rpass-missed=loop-vectorize"
             CXXFLAGS += " -Rpass-analysis=loop-vectorize "
-        if "+openmp" in self.spec:
+        if self.spec.satisfies("+openmp"):
             CXXFLAGS += self.compiler.openmp_flag
         config = [
             # Shell

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -263,7 +263,7 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
         env.prepend_path("MANPATH", spec.prefix.share.man)
         env.prepend_path("CPATH", spec.prefix.include)
         env.prepend_path("LD_LIBRARY_PATH", spec.prefix.lib.hpctoolkit)
-        if "+viewer" in spec:
+        if spec.satisfies("+viewer"):
             env.prepend_path("PATH", spec["hpcviewer"].prefix.bin)
             env.prepend_path("MANPATH", spec["hpcviewer"].prefix.share.man)
 
@@ -329,18 +329,18 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
         if spec.satisfies("@2022.10:"):
             args.append("--with-yaml-cpp=%s" % spec["yaml-cpp"].prefix)
 
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             args.append("--with-cuda=%s" % spec["cuda"].prefix)
 
-        if "+level_zero" in spec:
+        if spec.satisfies("+level_zero"):
             args.append("--with-level0=%s" % spec["oneapi-level-zero"].prefix)
 
             # gtpin requires level_zero
-            if "+gtpin" in spec:
+            if spec.satisfies("+gtpin"):
                 args.append("--with-gtpin=%s" % spec["intel-gtpin"].prefix)
                 args.append("--with-igc=%s" % spec["oneapi-igc"].prefix)
 
-        if "+opencl" in spec:
+        if spec.satisfies("+opencl"):
             args.append("--with-opencl=%s" % spec["opencl-c-headers"].prefix)
 
         if spec.satisfies("+rocm"):
@@ -399,17 +399,17 @@ class MesonBuilder(spack.build_systems.meson.MesonBuilder):
         spec = self.spec
 
         args = [
-            "-Dhpcprof_mpi=" + ("enabled" if "+mpi" in spec else "disabled"),
-            "-Dpython=" + ("enabled" if "+python" in spec else "disabled"),
-            "-Dpapi=" + ("enabled" if "+papi" in spec else "disabled"),
-            "-Dopencl=" + ("enabled" if "+opencl" in spec else "disabled"),
-            "-Dcuda=" + ("enabled" if "+cuda" in spec else "disabled"),
-            "-Drocm=" + ("enabled" if "+rocm" in spec else "disabled"),
-            "-Dlevel0=" + ("enabled" if "+level_zero" in spec else "disabled"),
-            "-Dgtpin=" + ("enabled" if "+gtpin" in spec else "disabled"),
+            "-Dhpcprof_mpi=" + ("enabled" if spec.satisfies("+mpi") else "disabled"),
+            "-Dpython=" + ("enabled" if spec.satisfies("+python") else "disabled"),
+            "-Dpapi=" + ("enabled" if spec.satisfies("+papi") else "disabled"),
+            "-Dopencl=" + ("enabled" if spec.satisfies("+opencl") else "disabled"),
+            "-Dcuda=" + ("enabled" if spec.satisfies("+cuda") else "disabled"),
+            "-Drocm=" + ("enabled" if spec.satisfies("+rocm") else "disabled"),
+            "-Dlevel0=" + ("enabled" if spec.satisfies("+level_zero") else "disabled"),
+            "-Dgtpin=" + ("enabled" if spec.satisfies("+gtpin") else "disabled"),
         ]
 
-        if "@:2024.01" in spec:
+        if spec.satisfies("@:2024.01"):
             args.append(f"--native-file={self.gen_prefix_file()}")
 
         return args
@@ -444,29 +444,29 @@ class MesonBuilder(spack.build_systems.meson.MesonBuilder):
 
         cfg["properties"]["prefix_yaml_cpp"] = f"'''{spec['yaml-cpp'].prefix}'''"
 
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             cfg["properties"]["prefix_cuda"] = f"'''{spec['cuda'].prefix}'''"
 
-        if "+level_zero" in spec:
+        if spec.satisfies("+level_zero"):
             cfg["properties"]["prefix_level0"] = f"'''{spec['oneapi-level-zero'].prefix}'''"
 
-        if "+gtpin" in spec:
+        if spec.satisfies("+gtpin"):
             cfg["properties"]["prefix_gtpin"] = f"'''{spec['intel-gtpin'].prefix}'''"
             cfg["properties"]["prefix_igc"] = f"'''{spec['oneapi-igc'].prefix}'''"
 
-        if "+opencl" in spec:
+        if spec.satisfies("+opencl"):
             cfg["properties"]["prefix_opencl"] = f"'''{spec['opencl-c-headers'].prefix}'''"
 
-        if "+rocm" in spec:
+        if spec.satisfies("+rocm"):
             cfg["properties"]["prefix_rocm_hip"] = f"'''{spec['hip'].prefix}'''"
             cfg["properties"]["prefix_rocm_hsa"] = f"'''{spec['hsa-rocr-dev'].prefix}'''"
             cfg["properties"]["prefix_rocm_tracer"] = f"'''{spec['roctracer-dev'].prefix}'''"
             cfg["properties"]["prefix_rocm_profiler"] = f"'''{spec['rocprofiler-dev'].prefix}'''"
 
-        if "+python" in spec:
+        if spec.satisfies("+python"):
             cfg["binaries"]["python"] = f"'''{spec['python'].command}'''"
 
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             cfg["binaries"]["mpicxx"] = f"'''{spec['mpi'].mpicxx}'''"
 
         native_fd, native_path = tempfile.mkstemp(

--- a/var/spack/repos/builtin/packages/hpgmg/package.py
+++ b/var/spack/repos/builtin/packages/hpgmg/package.py
@@ -52,24 +52,24 @@ class Hpgmg(MakefilePackage):
 
     def configure_args(self):
         args = []
-        if "+fe" in self.spec and not ("@0.3" in self.spec):
+        if self.spec.satisfies("+fe") and not self.spec.satisfies("@0.3"):
             args.append("--fe")
 
-        if "fv=serial" in self.spec:
+        if self.spec.satisfies("fv=serial"):
             args.append("--no-fv-mpi")
 
-        if "mpi" in self.spec:
+        if self.spec.satisfies("^mpi"):
             args.append("--CC={0}".format(self.spec["mpi"].mpicc))
 
         cflags = []
-        if "fv=none" in self.spec:
+        if self.spec.satisfies("fv=none"):
             args.append("--no-fv")
         else:
             # Apple's Clang doesn't support OpenMP
             if not self.spec.satisfies("%apple-clang"):
                 cflags.append(self.compiler.openmp_flag)
 
-        if "+debug" in self.spec:
+        if self.spec.satisfies("+debug"):
             cflags.append("-g")
         else:
             cflags.append("-O3")

--- a/var/spack/repos/builtin/packages/hpl/package.py
+++ b/var/spack/repos/builtin/packages/hpl/package.py
@@ -50,7 +50,7 @@ class Hpl(AutotoolsPackage):
         config = []
 
         # OpenMP support
-        if "+openmp" in spec:
+        if spec.satisfies("+openmp"):
             config.append("OMP_DEFS     = {0}".format(self.compiler.openmp_flag))
 
         config.extend(
@@ -106,7 +106,7 @@ class Hpl(AutotoolsPackage):
         filter_file(r"^libs10=.*", "libs10=%s" % self.spec["blas"].libs.ld_flags, "configure")
 
         cflags, ldflags = ["-O3"], []
-        if "+openmp" in self.spec:
+        if self.spec.satisfies("+openmp"):
             cflags.append(self.compiler.openmp_flag)
 
         if (
@@ -116,10 +116,10 @@ class Hpl(AutotoolsPackage):
         ):
             ldflags.append(self.spec["blas"].libs.ld_flags)
 
-        if "%aocc" in self.spec:
-            if "%aocc@3:" in self.spec:
+        if self.spec.satisfies("%aocc"):
+            if self.spec.satisfies("%aocc@3:"):
                 ldflags.extend(["-lamdlibm", "-lm"])
-            if "%aocc@4:" in self.spec:
+            if self.spec.satisfies("%aocc@4:"):
                 ldflags.append("-lamdalloc")
 
         if self.spec["blas"].name == "fujitsu-ssl2" and (

--- a/var/spack/repos/builtin/packages/hpx-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/hpx-kokkos/package.py
@@ -81,7 +81,7 @@ class HpxKokkos(CMakePackage, CudaPackage, ROCmPackage):
             self.define("HPX_KOKKOS_ENABLE_BENCHMARKS", self.run_tests),
         ]
 
-        if "+rocm" in self.spec:
+        if self.spec.satisfies("+rocm"):
             args += [self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc)]
 
         return args

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -241,8 +241,8 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant("HPX_WITH_ASYNC_CUDA", "async_cuda"),
             self.define("HPX_WITH_TESTS", self.run_tests),
             self.define("HPX_WITH_NETWORKING", "networking=none" not in spec),
-            self.define("HPX_WITH_PARCELPORT_TCP", "networking=tcp" in spec),
-            self.define("HPX_WITH_PARCELPORT_MPI", "networking=mpi" in spec),
+            self.define("HPX_WITH_PARCELPORT_TCP", spec.satisfies("networking=tcp")),
+            self.define("HPX_WITH_PARCELPORT_MPI", spec.satisfies("networking=mpi")),
             self.define(
                 "HPX_WITH_MAX_CPU_COUNT",
                 format_max_cpu_count(spec.variants["max_cpu_count"].value),
@@ -260,7 +260,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
             args += [self.define("HPX_WITH_UNITY_BUILD", True)]
 
         # HIP support requires compiling with hipcc
-        if "+rocm" in self.spec:
+        if self.spec.satisfies("+rocm"):
             args += [self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc)]
             if self.spec.satisfies("^cmake@3.21.0:3.21.2"):
                 args += [self.define("__skip_rocmclang", True)]
@@ -268,13 +268,13 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
         # Instrumentation
         args += self.instrumentation_args()
 
-        if "instrumentation=thread_debug" in spec:
+        if spec.satisfies("instrumentation=thread_debug"):
             args += [
                 self.define("HPX_WITH_THREAD_DEBUG_INFO", True),
                 self.define("HPX_WITH_LOGGING", True),
             ]
 
-        if "instrumentation=apex" in spec:
+        if spec.satisfies("instrumentation=apex"):
             args += [
                 self.define("APEX_WITH_OTF2", True),
                 self.define("OTF2_ROOT", spec["otf2"].prefix),

--- a/var/spack/repos/builtin/packages/hpx5/package.py
+++ b/var/spack/repos/builtin/packages/hpx5/package.py
@@ -84,24 +84,24 @@ class Hpx5(AutotoolsPackage):
             # '--with-papi=papi',   # currently disabled in HPX
         ]
 
-        if "+cxx11" in spec:
+        if spec.satisfies("+cxx11"):
             args += ["--enable-hpx++"]
 
-        if "+debug" in spec:
+        if spec.satisfies("+debug"):
             args += ["--enable-debug"]
 
-        if "+instrumentation" in spec:
+        if spec.satisfies("+instrumentation"):
             args += ["--enable-instrumentation"]
 
-        if "+mpi" in spec or "+photon" in spec:
+        if spec.satisfies("+mpi") or spec.satisfies("+photon"):
             # photon requires mpi
             args += ["--enable-mpi"]
             # Choose pkg-config name for MPI library
-            if "^openmpi" in spec:
+            if spec.satisfies("^openmpi"):
                 args += ["--with-mpi=ompi-cxx"]
-            elif "^mpich" in spec:
+            elif spec.satisfies("^mpich"):
                 args += ["--with-mpi=mpich"]
-            elif "^mvapich2" in spec:
+            elif spec.satisfies("^mvapich2"):
                 args += ["--with-mpi=mvapich2-cxx"]
             else:
                 args += ["--with-mpi=system"]
@@ -110,17 +110,17 @@ class Hpx5(AutotoolsPackage):
         # if '+metis' in spec:
         #     args += ['--with-metis=???']
 
-        if "+opencl" in spec:
+        if spec.satisfies("+opencl"):
             args += ["--enable-opencl"]
-            if "^pocl" in spec:
+            if spec.satisfies("^pocl"):
                 args += ["--with-opencl=pocl"]
             else:
                 args += ["--with-opencl=system"]
 
-        if "+photon" in spec:
+        if spec.satisfies("+photon"):
             args += ["--enable-photon"]
 
-        if "+pic" in spec:
+        if spec.satisfies("+pic"):
             args += ["--with-pic"]
 
         return args

--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -178,7 +178,7 @@ class Hwloc(AutotoolsPackage, CudaPackage, ROCmPackage):
         if "+rocm" not in self.spec:
             args.append("--disable-rsmi")
 
-        if "+rocm" in self.spec:
+        if self.spec.satisfies("+rocm"):
             args.append("--with-rocm={0}".format(self.spec["hip"].prefix))
             args.append("--with-rocm-version={0}".format(self.spec["hip"].version))
 
@@ -192,11 +192,11 @@ class Hwloc(AutotoolsPackage, CudaPackage, ROCmPackage):
         args.extend(self.enable_or_disable("pci"))
         args.extend(self.enable_or_disable("libs"))
 
-        if "+cuda" in self.spec:
+        if self.spec.satisfies("+cuda"):
             args.append("--with-cuda={0}".format(self.spec["cuda"].prefix))
             args.append("--with-cuda-version={0}".format(self.spec["cuda"].version))
 
-        if "+oneapi-level-zero" in self.spec:
+        if self.spec.satisfies("+oneapi-level-zero"):
             args.append("--enable-levelzero")
 
         return args

--- a/var/spack/repos/builtin/packages/hypar/package.py
+++ b/var/spack/repos/builtin/packages/hypar/package.py
@@ -47,18 +47,18 @@ class Hypar(AutotoolsPackage):
     def configure_args(self):
         args = []
         spec = self.spec
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             args.append("--with-mpi-dir={0}".format(spec["mpi"].prefix))
         else:
             args.append("--enable-serial")
-        if "+openmp" in spec:
+        if spec.satisfies("+openmp"):
             args.append("--enable-omp")
-        if "+scalapack" in spec:
+        if spec.satisfies("+scalapack"):
             args.append("--enable-scalapack")
             args.append("--with-blas-dir={0}".format(spec["blas"].prefix))
             args.append("--with-lapack-dir={0}".format(spec["lapack"].prefix))
             args.append("--with-scalapack-dir={0}".format(spec["scalapack"].prefix))
-        if "+fftw" in spec:
+        if spec.satisfies("+fftw"):
             args.append("--enable-fftw")
             args.append("--with-fftw-dir={0}".format(spec["fftw"].prefix))
         return args

--- a/var/spack/repos/builtin/packages/hypre-cmake/package.py
+++ b/var/spack/repos/builtin/packages/hypre-cmake/package.py
@@ -82,7 +82,7 @@ class HypreCmake(CMakePackage, CudaPackage):
         return args
 
     def setup_build_environment(self, env):
-        if "+cuda" in self.spec:
+        if self.spec.satisfies("+cuda"):
             env.set("CUDA_HOME", self.spec["cuda"].prefix)
             env.set("CUDA_PATH", self.spec["cuda"].prefix)
             cuda_arch = self.spec.variants["cuda_arch"].value
@@ -90,7 +90,7 @@ class HypreCmake(CMakePackage, CudaPackage):
                 arch_sorted = list(sorted(cuda_arch, reverse=True))
                 env.set("HYPRE_CUDA_SM", arch_sorted[0])
             # In CUDA builds hypre currently doesn't handle flags correctly
-            env.append_flags("CXXFLAGS", "-O2" if "~debug" in self.spec else "-g")
+            env.append_flags("CXXFLAGS", "-O2" if self.spec.satisfies("~debug") else "-g")
 
     extra_install_tests = join_path("src", "examples")
 
@@ -152,6 +152,6 @@ class HypreCmake(CMakePackage, CudaPackage):
         """Export the hypre library.
         Sample usage: spec['hypre'].libs.ld_flags
         """
-        is_shared = "+shared" in self.spec
+        is_shared = self.spec.satisfies("+shared")
         libs = find_libraries("libHYPRE", root=self.prefix, shared=is_shared, recursive=True)
         return libs or None

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -329,7 +329,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
             configure_args.append("--with-magma-lib=%s" % spec["magma"].libs)
             configure_args.append("--with-magma")
 
-        if "+gpu-aware-mpi" in spec:
+        if spec.satisfies("+gpu-aware-mpi"):
             configure_args.append("--enable-gpu-aware-mpi")
 
         configure_args.extend(self.enable_or_disable("fortran"))
@@ -348,7 +348,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
             env.set("CUDA_HOME", spec["cuda"].prefix)
             env.set("CUDA_PATH", spec["cuda"].prefix)
             # In CUDA builds hypre currently doesn't handle flags correctly
-            env.append_flags("CXXFLAGS", "-O2" if "~debug" in spec else "-g")
+            env.append_flags("CXXFLAGS", "-O2" if spec.satisfies("~debug") else "-g")
 
         if spec.satisfies("+rocm"):
             # As of 2022/04/05, the following are set by 'llvm-amdgpu' and
@@ -426,6 +426,6 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
         """Export the hypre library.
         Sample usage: spec['hypre'].libs.ld_flags
         """
-        is_shared = "+shared" in self.spec
+        is_shared = self.spec.satisfies("+shared")
         libs = find_libraries("libHYPRE", root=self.prefix, shared=is_shared, recursive=True)
         return libs or None

--- a/var/spack/repos/builtin/packages/ibm-databroker/package.py
+++ b/var/spack/repos/builtin/packages/ibm-databroker/package.py
@@ -47,6 +47,6 @@ class IbmDatabroker(CMakePackage, PythonExtension):
     def cmake_args(self):
         args = []
         args.append("-DDEFAULT_BE=redis")
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             args.append("-DPYDBR=1")
         return args

--- a/var/spack/repos/builtin/packages/icedtea/package.py
+++ b/var/spack/repos/builtin/packages/icedtea/package.py
@@ -158,9 +158,9 @@ class Icedtea(AutotoolsPackage):
         os.environ["POTENTIAL_CC"] = os.environ["CC"]
         os.environ["WGET"] = self.spec["wget"].command.path
         args = []
-        if "~X" in self.spec:
+        if self.spec.satisfies("~X"):
             args.append("--enable-headless")
-        if "+shenandoah" in self.spec:
+        if self.spec.satisfies("+shenandoah"):
             args.append("--with-hotspot-build=shenandoah")
             args.append("--with-hotspot-src-zip=" + self.stage[9].archive_file)
             args.append("--with-hotspot-checksum=no")

--- a/var/spack/repos/builtin/packages/icon/package.py
+++ b/var/spack/repos/builtin/packages/icon/package.py
@@ -144,13 +144,13 @@ class Icon(AutotoolsPackage):
         ]:
             args += self.enable_or_disable(x)
 
-        if "+art" in self.spec:
+        if self.spec.satisfies("+art"):
             args.append("--enable-art")
             libs += self.spec["libxml2"].libs
         else:
             args.append("--disable-art")
 
-        if "+coupling" in self.spec:
+        if self.spec.satisfies("+coupling"):
             args.append("--enable-coupling")
             libs += self.spec["libfyaml"].libs
         else:
@@ -168,7 +168,7 @@ class Icon(AutotoolsPackage):
             )
             libs += self.spec["serialbox:fortran"].libs
 
-        if "+grib2" in self.spec:
+        if self.spec.satisfies("+grib2"):
             args.append("--enable-grib2")
             libs += self.spec["eccodes:c"].libs
         else:
@@ -179,7 +179,7 @@ class Icon(AutotoolsPackage):
         libs += self.spec["netcdf-fortran"].libs
         libs += self.spec["netcdf-c"].libs
 
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             args.extend(
                 [
                     "--enable-mpi",
@@ -214,7 +214,7 @@ class Icon(AutotoolsPackage):
             flags["ICON_BUNDLED_CFLAGS"].append("-O2")
             flags["FCFLAGS"].append("-g")
             flags["ICON_FCFLAGS"].append("-O2")
-            if "+ocean" in self.spec:
+            if self.spec.satisfies("+ocean"):
                 flags["ICON_OCEAN_FCFLAGS"].extend(["-O3", "-fno-tree-loop-vectorize"])
                 args.extend(
                     ["--enable-fcgroup-OCEAN", "ICON_OCEAN_PATH=src/hamocc:src/ocean:src/sea_ice"]
@@ -239,10 +239,10 @@ class Icon(AutotoolsPackage):
                 ]
             )
 
-            if "%oneapi+coupling" in self.spec:
+            if self.spec.satisfies("%oneapi+coupling"):
                 flags["ICON_YAC_CFLAGS"].extend(["-O2", "-fp-model precise"])
 
-            if "+ocean" in self.spec:
+            if self.spec.satisfies("+ocean"):
                 flags["ICON_OCEAN_FCFLAGS"].extend(
                     ["-O3", "-assume norealloc_lhs", "-reentrancy threaded"]
                 )
@@ -250,10 +250,10 @@ class Icon(AutotoolsPackage):
                     ["--enable-fcgroup-OCEAN", "ICON_OCEAN_PATH=src/hamocc:src/ocean:src/sea_ice"]
                 )
 
-                if "+openmp" in self.spec:
+                if self.spec.satisfies("+openmp"):
                     flags["ICON_OCEAN_FCFLAGS"].extend(["-DOCE_SOLVE_OMP"])
 
-            if "+ecrad" in self.spec:
+            if self.spec.satisfies("+ecrad"):
                 flags["ICON_ECRAD_FCFLAGS"].extend(["-qno-opt-dynamic-align", "-no-fma", "-fpe0"])
 
         elif self.compiler.name == "nvhpc":
@@ -267,7 +267,7 @@ class Icon(AutotoolsPackage):
                     ["-acc=gpu", "-gpu=cc{0}".format(self.nvidia_targets[gpu])]
                 )
 
-            if "%nvhpc@:23.9+coupling" in self.spec:
+            if self.spec.satisfies("%nvhpc@:23.9+coupling"):
                 args.append("yac_cv_fc_is_contiguous_works=yes")
 
         else:

--- a/var/spack/repos/builtin/packages/igraph/package.py
+++ b/var/spack/repos/builtin/packages/igraph/package.py
@@ -51,7 +51,7 @@ class Igraph(CMakePackage, AutotoolsPackage):
             "-DBLA_VENDOR=OpenBLAS",
         ]
 
-        if "+shared" in self.spec:
+        if self.spec.satisfies("+shared"):
             args.append("-DBUILD_SHARED_LIBS=ON")
         else:
             args.append("-DBUILD_SHARED_LIBS=OFF")

--- a/var/spack/repos/builtin/packages/igv/package.py
+++ b/var/spack/repos/builtin/packages/igv/package.py
@@ -34,7 +34,7 @@ class Igv(Package):
         mkdirp(prefix.bin)
         install("igv.args", prefix)
         files = ["igv.sh", "igv_hidpi.sh"]
-        if "+igvtools" in spec:
+        if spec.satisfies("+igvtools"):
             files.extend(["igvtools", "igvtools_gui", "igvtools_gui_hidpi"])
         for f in files:
             filter_file("^prefix=.*$", "prefix=" + prefix, f)

--- a/var/spack/repos/builtin/packages/infernal/package.py
+++ b/var/spack/repos/builtin/packages/infernal/package.py
@@ -30,7 +30,7 @@ class Infernal(AutotoolsPackage):
 
     def configure_args(self):
         args = []
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             args.append("--enable-mpi")
         else:
             args.append("--disable-mpi")

--- a/var/spack/repos/builtin/packages/intel-llvm/package.py
+++ b/var/spack/repos/builtin/packages/intel-llvm/package.py
@@ -32,7 +32,7 @@ class IntelLlvm(CMakePackage):
         env.append_flags("CXXFLAGS", self.compiler.cxx11_flag)
 
     def setup_run_environment(self, env):
-        if "+clang" in self.spec:
+        if self.spec.satisfies("+clang"):
             env.set("CC", join_path(self.spec.prefix.bin, "clang"))
             env.set("CXX", join_path(self.spec.prefix.bin, "clang++"))
 

--- a/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi-benchmarks/package.py
@@ -98,25 +98,25 @@ class IntelMpiBenchmarks(MakefilePackage):
     def build_targets(self):
         spec = self.spec
         targets = []
-        if "+mpi1" in spec:
+        if spec.satisfies("+mpi1"):
             targets.append("MPI1")
-        if "+ext" in spec:
+        if spec.satisfies("+ext"):
             targets.append("EXT")
-        if "+io" in spec:
+        if spec.satisfies("+io"):
             targets.append("IO")
-        if "+nbc" in spec:
+        if spec.satisfies("+nbc"):
             targets.append("NBC")
-        if "+p2p" in spec:
+        if spec.satisfies("+p2p"):
             targets.append("P2P")
-        if "+rma" in spec:
+        if spec.satisfies("+rma"):
             targets.append("RMA")
-        if "+mt" in spec:
+        if spec.satisfies("+mt"):
             targets.append("MT")
 
         if spec.satisfies("@2019:"):
             targets = ["TARGET=" + target for target in targets]
 
-        if "+check" in spec:
+        if spec.satisfies("+check"):
             targets.append("CPPFLAGS=-DCHECK")
 
         return targets
@@ -129,17 +129,17 @@ class IntelMpiBenchmarks(MakefilePackage):
         mkdir(prefix.bin)
 
         with working_dir(self.build_directory):
-            if "+mpi1" in spec:
+            if spec.satisfies("+mpi1"):
                 install("IMB-MPI1", prefix.bin)
-            if "+ext" in spec:
+            if spec.satisfies("+ext"):
                 install("IMB-EXT", prefix.bin)
-            if "+io" in spec:
+            if spec.satisfies("+io"):
                 install("IMB-IO", prefix.bin)
-            if "+nbc" in spec:
+            if spec.satisfies("+nbc"):
                 install("IMB-NBC", prefix.bin)
-            if "+p2p" in spec:
+            if spec.satisfies("+p2p"):
                 install("IMB-P2P", prefix.bin)
-            if "+rma" in spec:
+            if spec.satisfies("+rma"):
                 install("IMB-RMA", prefix.bin)
-            if "+mt" in spec:
+            if spec.satisfies("+mt"):
                 install("IMB-MT", prefix.bin)

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -157,15 +157,15 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
 
     @property
     def env_script_args(self):
-        if "+external-libfabric" in self.spec:
+        if self.spec.satisfies("+external-libfabric"):
             return ("-i_mpi_ofi_internal=0",)
         else:
             return ()
 
     def wrapper_names(self):
-        if "+generic-names" in self.spec:
+        if self.spec.satisfies("+generic-names"):
             return ["mpicc", "mpicxx", "mpif77", "mpif90", "mpifc"]
-        elif "+classic-names" in self.spec:
+        elif self.spec.satisfies("+classic-names"):
             return ["mpiicc", "mpiicpc", "mpiifort", "mpiifort", "mpiifort"]
         else:
             return ["mpiicx", "mpiicpx", "mpiifx", "mpiifx", "mpiifx"]
@@ -202,14 +202,14 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
     @property
     def libs(self):
         libs = []
-        if "+ilp64" in self.spec:
+        if self.spec.satisfies("+ilp64"):
             libs += find_libraries("libmpi_ilp64", self.component_prefix.lib.release)
         libs += find_libraries(["libmpicxx", "libmpifort"], self.component_prefix.lib)
         libs += find_libraries("libmpi", self.component_prefix.lib.release)
         libs += find_system_libraries(["libdl", "librt", "libpthread"])
 
         # Find libfabric for libmpi.so
-        if "+external-libfabric" in self.spec:
+        if self.spec.satisfies("+external-libfabric"):
             libs += self.spec["libfabric"].libs
         else:
             libs += find_libraries(["libfabric"], self.component_prefix.libfabric.lib)

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -187,7 +187,7 @@ class IntelTbb(CMakePackage, MakefilePackage):
 
     @property
     def libs(self):
-        shared = True if "+shared" in self.spec else False
+        shared = True if self.spec.satisfies("+shared") else False
         return find_libraries("libtbb*", root=self.prefix, shared=shared, recursive=True)
 
 

--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -124,11 +124,11 @@ class IntelXed(Package):
             "--no-werror",
             f"--prefix={prefix}",
         )
-        if "+optimize" in spec:
+        if spec.satisfies("+optimize"):
             mfile.add_default_arg("--opt=2")
-        if "+debug" in spec:
+        if spec.satisfies("+debug"):
             mfile.add_default_arg("--debug")
-        if "+pic" in spec:
+        if spec.satisfies("+pic"):
             mfile.add_default_arg(
                 f"--extra-ccflags={self.compiler.cc_pic_flag}",
                 f"--extra-cxxflags={self.compiler.cxx_pic_flag}",
@@ -144,11 +144,11 @@ class IntelXed(Package):
         mfile(
             f"--install-dir={shared_kit}",
             "--shared",
-            *(["examples"] if "+examples" in spec else []),
+            *(["examples"] if spec.satisfies("+examples") else []),
             "install",
         )
 
-        if "+examples" in self.spec:
+        if self.spec.satisfies("+examples"):
             # Install the example binaries to share/xed/examples
             install_tree(join_path(shared_kit, "bin"), prefix.share.xed.examples)
 

--- a/var/spack/repos/builtin/packages/ior/package.py
+++ b/var/spack/repos/builtin/packages/ior/package.py
@@ -66,18 +66,18 @@ class Ior(AutotoolsPackage):
 
         env["CC"] = spec["mpi"].mpicc
 
-        if "+hdf5" in spec:
+        if spec.satisfies("+hdf5"):
             config_args.append("--with-hdf5")
             config_args.append("CFLAGS=-D H5_USE_16_API")
         else:
             config_args.append("--without-hdf5")
 
-        if "+ncmpi" in spec:
+        if spec.satisfies("+ncmpi"):
             config_args.append("--with-ncmpi")
         else:
             config_args.append("--without-ncmpi")
 
-        if "+lustre" in spec:
+        if spec.satisfies("+lustre"):
             config_args.append("--with-lustre")
         else:
             config_args.append("--without-lustre")

--- a/var/spack/repos/builtin/packages/ipm/package.py
+++ b/var/spack/repos/builtin/packages/ipm/package.py
@@ -79,25 +79,25 @@ class Ipm(AutotoolsPackage):
     def configure_args(self):
         args = []
         spec = self.spec
-        if "+papi" in spec:
+        if spec.satisfies("+papi"):
             args.append("--with-papi={0}".format(spec["papi"].prefix))
 
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             args.append("--with-cudapath={0}".format(spec["cuda"].prefix))
 
-        if "+libunwind" in spec:
+        if spec.satisfies("+libunwind"):
             args.append("--with-libunwind={0}".format(spec["libunwind"].prefix))
 
-        if "+papi_multiplexing" in spec:
+        if spec.satisfies("+papi_multiplexing"):
             args.append("--enable-papi-multiplexing")
 
-        if "+posixio" in spec:
+        if spec.satisfies("+posixio"):
             args.append("--enable-posixio")
 
-        if "+pmon" in spec:
+        if spec.satisfies("+pmon"):
             args.append("--enable-pmon")
 
-        if "+coll_details" in spec:
+        if spec.satisfies("+coll_details"):
             args.append("--enable-coll-details")
 
         args.extend(

--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -93,7 +93,7 @@ class Ipopt(AutotoolsPackage):
         else:
             args.extend(["--with-lapack-lflags={0} {1}".format(lapack_lib, blas_lib)])
 
-        if "+mumps" in spec:
+        if spec.satisfies("+mumps"):
             mumps_dir = spec["mumps"].prefix
             mumps_flags = "-ldmumps -lmumps_common -lpord -lmpiseq"
             mumps_libcmd = "-L%s " % mumps_dir.lib + mumps_flags
@@ -113,7 +113,7 @@ class Ipopt(AutotoolsPackage):
                     ]
                 )
 
-        if "coinhsl" in spec:
+        if spec.satisfies("^coinhsl"):
             hsl_ld_flags = "-ldl {0}".format(spec["coinhsl"].libs.ld_flags)
 
             if spec.satisfies("^coinhsl+blas"):
@@ -135,7 +135,7 @@ class Ipopt(AutotoolsPackage):
                     ]
                 )
 
-        if "metis" in spec:
+        if spec.satisfies("^metis"):
             if spec.satisfies("@:3.12.13"):
                 args.extend(
                     [
@@ -147,7 +147,7 @@ class Ipopt(AutotoolsPackage):
         # The IPOPT configure file states that '--enable-debug' implies
         # '--disable-shared', but adding '--enable-shared' overrides
         # '--disable-shared' and builds a shared library with debug symbols
-        if "+debug" in spec:
+        if spec.satisfies("+debug"):
             args.append("--enable-debug")
         else:
             args.append("--disable-debug")

--- a/var/spack/repos/builtin/packages/iq-tree/package.py
+++ b/var/spack/repos/builtin/packages/iq-tree/package.py
@@ -57,13 +57,13 @@ class IqTree(CMakePackage):
         args = []
         iqflags = []
 
-        if "+lsd2" in spec:
+        if spec.satisfies("+lsd2"):
             args.append("-DUSE_LSD2=ON")
 
-        if "+openmp" in spec:
+        if spec.satisfies("+openmp"):
             iqflags.append("omp")
 
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             iqflags.append("mpi")
 
         if not iqflags:

--- a/var/spack/repos/builtin/packages/itensor/package.py
+++ b/var/spack/repos/builtin/packages/itensor/package.py
@@ -92,12 +92,12 @@ class Itensor(MakefilePackage):
         filter_file(r"^BLAS_LAPACK_LIBFLAGS.+", vlib, mf)
 
         # 3.HDF5
-        if "+hdf5" in spec:
+        if spec.satisfies("+hdf5"):
             hdf5p = f"HDF5_PREFIX={spec['hdf5'].prefix.lib}"
             filter_file("^#HDF5.+", hdf5p, mf)
 
         # 4.openmp
-        if "+openmp" in spec:
+        if spec.satisfies("+openmp"):
             filter_file("#ITENSOR_USE_OMP", "ITENSOR_USE_OMP", mf)
             filter_file("-fopenmp", self.compiler.openmp_flag, mf)
 
@@ -105,7 +105,7 @@ class Itensor(MakefilePackage):
         filter_file(r"^PREFIX.+", f"PREFIX={os.getcwd()}", mf)
 
         # 5.shared
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             filter_file("ITENSOR_MAKE_DYLIB=0", "ITENSOR_MAKE_DYLIB=1", mf)
 
     def install(self, spec, prefix):


### PR DESCRIPTION
with the structure` if "+variant" in spec:`, checks like `if "mpi" in spec:` would be valid whereas it could be `~mpi` or `+mpi`. `satisfies` adds additional checks to avoid mistakes from the user.