### PR TITLE
Replace if ... in spec with spec.satisfies in k* packages and l* packages

### DIFF
--- a/var/spack/repos/builtin/packages/kaldi/package.py
+++ b/var/spack/repos/builtin/packages/kaldi/package.py
@@ -58,28 +58,30 @@ class Kaldi(Package):  # Does not use Autotools
         configure_args.append("--speex-root=" + spec["speex"].prefix)
         configure_args.append("--cub-root=" + spec["cuda"].prefix.include)
 
-        if "~shared" in spec:
+        if spec.satisfies("~shared"):
             configure_args.append("--static")
         else:
             configure_args.append("--shared")
 
-        if "^openblas" in spec:
+        if spec.satisfies("^[virtuals=blas] openblas"):
             configure_args.append("--mathlib=OPENBLAS")
             configure_args.append("--openblas-root=" + spec["blas"].prefix)
             if "+openmp" in spec["blas"].variants:
                 configure_args.append("--threaded-math=yes")
-        elif "^atlas" in spec:
+        elif spec.satisfies("^[virtuals=blas] atlas"):
             configure_args.append("--mathlib=ATLAS")
             configure_args.append("--atlas-root=" + spec["blas"].prefix)
             if "+pthread" in spec["blas"].variants:
                 configure_args.append("--threaded-atlas")
-        elif "^intel-parallel-studio" in spec or "^intel-mkl" in spec:
+        elif spec.satisfies("^[virtuals=blas] intel-parallel-studio") or spec.satisfies(
+            "^[virtuals=blas] intel-mkl"
+        ):
             configure_args.append("--mathlib=MKL")
             configure_args.append("--mkl-root=" + spec["blas"].prefix.mkl)
             if "+openmp" in spec["blas"].variants:
                 configure_args.append("--mkl-threading=iomp")
 
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             configure_args.append("--use-cuda=yes")
             configure_args.append("--cudatk-dir=" + spec["cuda"].prefix)
 

--- a/var/spack/repos/builtin/packages/kassiopeia/package.py
+++ b/var/spack/repos/builtin/packages/kassiopeia/package.py
@@ -63,7 +63,7 @@ class Kassiopeia(CMakePackage):
         )
 
     def cmake_args(self):
-        if "+root" in self.spec:
+        if self.spec.satisfies("+root"):
             cxxstd = self.spec["root"].variants["cxxstd"].value
         else:
             if self.spec.satisfies("@:3.8.1"):

--- a/var/spack/repos/builtin/packages/kokkos-kernels/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/package.py
@@ -175,7 +175,7 @@ class KokkosKernels(CMakePackage, CudaPackage):
         spec = self.spec
         options = []
 
-        isdiy = "+diy" in spec
+        isdiy = spec.satisfies("+diy")
         if isdiy:
             options.append("-DSpack_WORKAROUND=On")
 

--- a/var/spack/repos/builtin/packages/kokkos-legacy/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-legacy/package.py
@@ -246,7 +246,7 @@ class KokkosLegacy(Package):
             cuda_options_args = []
 
             # PIC
-            if "+pic" in spec:
+            if spec.satisfies("+pic"):
                 g_args.append("--cxxflags=-fPIC")
 
             # C++ standard
@@ -255,19 +255,19 @@ class KokkosLegacy(Package):
                 g_args.append(f"--cxxstandard={cxxstandard}")
 
             # Build Debug
-            if "+debug" in spec:
+            if spec.satisfies("+debug"):
                 g_args.append("--debug")
 
             # Backends
-            if "+serial" in spec:
+            if spec.satisfies("+serial"):
                 g_args.append("--with-serial")
-            if "+openmp" in spec:
+            if spec.satisfies("+openmp"):
                 g_args.append("--with-openmp")
-            if "+pthreads" in spec:
+            if spec.satisfies("+pthreads"):
                 g_args.append("--with-pthread")
-            if "+qthreads" in spec:
+            if spec.satisfies("+qthreads"):
                 g_args.append(f"--with-qthreads={spec['qthreads'].prefix}")
-            if "+cuda" in spec:
+            if spec.satisfies("+cuda"):
                 g_args.append(f"--with-cuda={spec['cuda'].prefix}")
             # Host architectures
             host_arch = spec.variants["host_arch"].value
@@ -282,31 +282,31 @@ class KokkosLegacy(Package):
                 g_args.append(f"--arch={','.join(arch_args)}")
 
             # CUDA options
-            if "+force_uvm" in spec:
+            if spec.satisfies("+force_uvm"):
                 cuda_options_args.append("force_uvm")
-            if "+use_ldg" in spec:
+            if spec.satisfies("+use_ldg"):
                 cuda_options_args.append("use_ldg")
-            if "+rdc" in spec:
+            if spec.satisfies("+rdc"):
                 cuda_options_args.append("rdc")
-            if "+enable_lambda" in spec:
+            if spec.satisfies("+enable_lambda"):
                 cuda_options_args.append("enable_lambda")
             if cuda_options_args:
                 g_args.append(f"--with-cuda-options={','.join(cuda_options_args)}")
 
             # Kokkos options
-            if "+aggressive_vectorization" in spec:
+            if spec.satisfies("+aggressive_vectorization"):
                 kokkos_options_args.append("aggressive_vectorization")
-            if "+disable_profiling" in spec:
+            if spec.satisfies("+disable_profiling"):
                 kokkos_options_args.append("disable_profiling")
-            if "+disable_dualview_modify_check" in spec:
+            if spec.satisfies("+disable_dualview_modify_check"):
                 kokkos_options_args.append("disable_dualview_modify_check")
-            if "+enable_profile_load_print" in spec:
+            if spec.satisfies("+enable_profile_load_print"):
                 kokkos_options_args.append("enable_profile_load_print")
-            if "+compiler_warnings" in spec:
+            if spec.satisfies("+compiler_warnings"):
                 kokkos_options_args.append("compiler_warnings")
-            if "+disable_deprecated_code" in spec:
+            if spec.satisfies("+disable_deprecated_code"):
                 kokkos_options_args.append("disable_deprecated_code")
-            if "+enable_eti" in spec:
+            if spec.satisfies("+enable_eti"):
                 kokkos_options_args.append("enable_eti")
             if kokkos_options_args:
                 g_args.append(f"--with-options={','.join(kokkos_options_args)}")

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -320,7 +320,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         ]
 
         spack_microarches = []
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             if isinstance(spec.variants["cuda_arch"].value, str):
                 cuda_arch = spec.variants["cuda_arch"].value
             else:
@@ -336,7 +336,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         if kokkos_microarch_name:
             spack_microarches.append(kokkos_microarch_name)
 
-        if "+rocm" in spec:
+        if spec.satisfies("+rocm"):
             for amdgpu_target in spec.variants["amdgpu_target"].value:
                 if amdgpu_target != "none":
                     if amdgpu_target in self.amdgpu_arch_map:
@@ -360,10 +360,10 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
             if spec.variants[tpl].value:
                 options.append(self.define(tpl + "_DIR", spec[tpl].prefix))
 
-        if "+rocm" in self.spec:
+        if self.spec.satisfies("+rocm"):
             options.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
             options.append(self.define("Kokkos_ENABLE_ROCTHRUST", True))
-        elif "+wrapper" in self.spec:
+        elif self.spec.satisfies("+wrapper"):
             options.append(
                 self.define("CMAKE_CXX_COMPILER", self.spec["kokkos-nvcc-wrapper"].kokkos_cxx)
             )
@@ -375,11 +375,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         # which breaks GPU-aware with Cray-MPICH
         # See https://github.com/kokkos/kokkos/pull/6402
         # TODO: disable this once Cray-MPICH is fixed
-        if (
-            self.spec.satisfies("@4.2.00:")
-            and "mpi" in self.spec
-            and self.spec["mpi"].name == "cray-mpich"
-        ):
+        if self.spec.satisfies("@4.2.00:") and self.spec.satisfies("^[virtuals=mpi] cray-mpich"):
             options.append(self.define("Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC", False))
 
         # Remove duplicate options

--- a/var/spack/repos/builtin/packages/krakenuniq/package.py
+++ b/var/spack/repos/builtin/packages/krakenuniq/package.py
@@ -35,7 +35,7 @@ class Krakenuniq(Package):
 
     def install(self, spec, prefix):
         local_script = which("./install_krakenuniq.sh")
-        if "+jellyfish" in self.spec:
+        if self.spec.satisfies("+jellyfish"):
             local_script("-j", prefix.bin)
         else:
             local_script(prefix.bin)

--- a/var/spack/repos/builtin/packages/krims/package.py
+++ b/var/spack/repos/builtin/packages/krims/package.py
@@ -68,10 +68,10 @@ class Krims(CMakePackage):
         args = [
             "-DAUTOCHECKOUT_MISSING_REPOS=OFF",
             #
-            "-DBUILD_SHARED_LIBS=" + str("+shared" in spec),
+            "-DBUILD_SHARED_LIBS=" + str(spec.satisfies("+shared")),
             # TODO Hard-disable tests for now, since rapidcheck not in Spack
             "-DKRIMS_ENABLE_TESTS=OFF",
-            "-DKRIMS_ENABLE_EXAMPLES=" + str("+examples" in spec),
+            "-DKRIMS_ENABLE_EXAMPLES=" + str(spec.satisfies("+examples")),
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/kripke/package.py
+++ b/var/spack/repos/builtin/packages/kripke/package.py
@@ -103,14 +103,14 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
             ]
         )
 
-        if "+caliper" in spec:
+        if spec.satisfies("+caliper"):
             args.append("-DENABLE_CALIPER=ON")
 
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             args.append("-DENABLE_MPI=ON")
             args.append(self.define("CMAKE_CXX_COMPILER", self.spec["mpi"].mpicxx))
 
-        if "+rocm" in spec:
+        if spec.satisfies("+rocm"):
             # Set up the hip macros needed by the build
             args.append("-DENABLE_HIP=ON")
             args.append("-DHIP_ROOT_DIR={0}".format(spec["hip"].prefix))
@@ -123,7 +123,7 @@ class Kripke(CMakePackage, CudaPackage, ROCmPackage):
             # Ensure build with hip is disabled
             args.append("-DENABLE_HIP=OFF")
 
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             args.append("-DENABLE_CUDA=ON")
             args.append(self.define("CMAKE_CUDA_HOST_COMPILER", self.spec["mpi"].mpicxx))
             if not spec.satisfies("cuda_arch=none"):

--- a/var/spack/repos/builtin/packages/kvtree/package.py
+++ b/var/spack/repos/builtin/packages/kvtree/package.py
@@ -55,7 +55,7 @@ class Kvtree(CMakePackage):
         spec = self.spec
         args = []
         args.append(self.define_from_variant("MPI"))
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             args.append(self.define("MPI_C_COMPILER", spec["mpi"].mpicc))
 
         args.append(self.define_from_variant("KVTREE_FILE_LOCK", "file_lock"))

--- a/var/spack/repos/builtin/packages/laghos/package.py
+++ b/var/spack/repos/builtin/packages/laghos/package.py
@@ -63,7 +63,7 @@ class Laghos(MakefilePackage):
         targets.append("TEST_MK=%s" % spec["mfem"].package.test_mk)
         if spec.satisfies("@:2.0"):
             targets.append("CXX=%s" % spec["mpi"].mpicxx)
-        if "+ofast %gcc" in self.spec:
+        if self.spec.satisfies("+ofast %gcc"):
             targets.append("CXXFLAGS = -Ofast -finline-functions")
         return targets
 

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -844,12 +844,12 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
             self.define("ENABLE_TESTING", self.run_tests),
             self.define("DOWNLOAD_POTENTIALS", False),
         ]
-        if "~kokkos" in spec:
+        if spec.satisfies("~kokkos"):
             # LAMMPS can be build with the GPU package OR the KOKKOS package
             # Using both in a single build is discouraged.
             # +cuda only implies that one of the two is used
             # by default it will use the GPU package if kokkos wasn't enabled
-            if "+cuda" in spec:
+            if spec.satisfies("+cuda"):
                 args.append(self.define("PKG_GPU", True))
                 args.append(self.define("GPU_API", "cuda"))
                 args.append(self.define_from_variant("GPU_PREC", "gpu_precision"))
@@ -857,13 +857,13 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
                 if cuda_arch != "none":
                     args.append(self.define("GPU_ARCH", "sm_{0}".format(cuda_arch[0])))
                 args.append(self.define_from_variant("CUDA_MPS_SUPPORT", "cuda_mps"))
-            elif "+opencl" in spec:
+            elif spec.satisfies("+opencl"):
                 # LAMMPS downloads and bundles its own OpenCL ICD Loader by default
                 args.append(self.define("USE_STATIC_OPENCL_LOADER", False))
                 args.append(self.define("PKG_GPU", True))
                 args.append(self.define("GPU_API", "opencl"))
                 args.append(self.define_from_variant("GPU_PREC", "gpu_precision"))
-            elif "+rocm" in spec:
+            elif spec.satisfies("+rocm"):
                 args.append(self.define("PKG_GPU", True))
                 args.append(self.define("GPU_API", "hip"))
                 args.append(self.define_from_variant("GPU_PREC", "gpu_precision"))
@@ -926,27 +926,27 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
             # for transposing 3d FFT data.
             args.append(self.define("FFT_SINGLE", spec.satisfies("fftw_precision=single")))
 
-        if "+user-adios" in spec or "+adios" in spec:
+        if spec.satisfies("+user-adios") or spec.satisfies("+adios"):
             args.append(self.define("ADIOS2_DIR", self.spec["adios2"].prefix))
-        if "+user-plumed" in spec or "+plumed" in spec:
+        if spec.satisfies("+user-plumed") or spec.satisfies("+plumed"):
             args.append(self.define("DOWNLOAD_PLUMED", False))
             if "+shared" in self.spec["plumed"]:
                 args.append(self.define("PLUMED_MODE", "shared"))
             else:
                 args.append(self.define("PLUMED_MODE", "static"))
-        if "+user-smd" in spec or "+machdyn" in spec:
+        if spec.satisfies("+user-smd") or spec.satisfies("+machdyn"):
             args.append(self.define("DOWNLOAD_EIGEN3", False))
             args.append(self.define("EIGEN3_INCLUDE_DIR", self.spec["eigen"].prefix.include))
-        if "+user-hdnnp" in spec or "+ml-hdnnp" in spec:
+        if spec.satisfies("+user-hdnnp") or spec.satisfies("+ml-hdnnp"):
             args.append(self.define("DOWNLOAD_N2P2", False))
             args.append(self.define("N2P2_DIR", self.spec["n2p2"].prefix))
 
-        if "+rocm" in spec:
+        if spec.satisfies("+rocm"):
             args.append(self.define("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
-            if "@:20231121" in spec:
-                if "^hip@:5.4" in spec:
+            if spec.satisfies("@:20231121"):
+                if spec.satisfies("^hip@:5.4"):
                     args.append(self.define("HIP_PATH", f"{spec['hip'].prefix}/hip"))
-                elif "^hip@5.5:" in spec:
+                elif spec.satisfies("^hip@5.5:"):
                     args.append(self.define("HIP_PATH", spec["hip"].prefix))
 
         return args
@@ -957,14 +957,14 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
 
     def setup_run_environment(self, env):
         env.set("LAMMPS_POTENTIALS", self.prefix.share.lammps.potentials)
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             if self.spec.platform == "darwin":
                 env.prepend_path("DYLD_FALLBACK_LIBRARY_PATH", self.prefix.lib)
                 env.prepend_path("DYLD_FALLBACK_LIBRARY_PATH", self.prefix.lib64)
             else:
                 env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
                 env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib64)
-        if "+plugin" in self.spec:
+        if self.spec.satisfies("+plugin"):
             env.prepend_path("LAMMPS_PLUGIN_PATH", self.prefix.lib.lammps.plugins)
             env.prepend_path("LAMMPS_PLUGIN_PATH", self.prefix.lib64.lammps.plugins)
 

--- a/var/spack/repos/builtin/packages/lapackpp/package.py
+++ b/var/spack/repos/builtin/packages/lapackpp/package.py
@@ -104,15 +104,15 @@ class Lapackpp(CMakePackage, CudaPackage, ROCmPackage):
 
         backend = "none"
         if self.version >= Version("2022.07.00"):
-            if "+cuda" in spec:
+            if spec.satisfies("+cuda"):
                 backend = "cuda"
-            if "+rocm" in spec:
+            if spec.satisfies("+rocm"):
                 backend = "hip"
-            if "+sycl" in spec:
+            if spec.satisfies("+sycl"):
                 backend = "sycl"
 
         args = [
-            "-DBUILD_SHARED_LIBS=%s" % ("+shared" in spec),
+            "-DBUILD_SHARED_LIBS=%s" % spec.satisfies("+shared"),
             "-Dbuild_tests=%s" % self.run_tests,
             "-DLAPACK_LIBRARIES=%s" % spec["lapack"].libs.joined(";"),
             "-Dgpu_backend=%s" % backend,

--- a/var/spack/repos/builtin/packages/latex2html/package.py
+++ b/var/spack/repos/builtin/packages/latex2html/package.py
@@ -119,7 +119,7 @@ class Latex2html(AutotoolsPackage):
                 exe = which(p)
                 if exe:
                     args.append("--with-{0}={1}".format(p, str(exe)))
-        if "+svg" in spec:
+        if spec.satisfies("+svg"):
             p = "pdftocairo"
             exe = join_path(spec["poppler"].prefix.bin, p)
             if os.path.exists(exe):

--- a/var/spack/repos/builtin/packages/latte/package.py
+++ b/var/spack/repos/builtin/packages/latte/package.py
@@ -40,13 +40,13 @@ class Latte(CMakePackage):
 
     def cmake_args(self):
         options = []
-        if "+shared" in self.spec:
+        if self.spec.satisfies("+shared"):
             options.append("-DBUILD_SHARED_LIBS=ON")
         else:
             options.append("-DBUILD_SHARED_LIBS=OFF")
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             options.append("-DO_MPI=yes")
-        if "+progress" in self.spec:
+        if self.spec.satisfies("+progress"):
             options.append("-DPROGRESS=yes")
 
         blas_list = ";".join(self.spec["blas"].libs)

--- a/var/spack/repos/builtin/packages/lazyten/package.py
+++ b/var/spack/repos/builtin/packages/lazyten/package.py
@@ -75,10 +75,10 @@ class Lazyten(CMakePackage):
         args = [
             "-DAUTOCHECKOUT_MISSING_REPOS=OFF",
             #
-            "-DBUILD_SHARED_LIBS=" + str("+shared" in spec),
+            "-DBUILD_SHARED_LIBS=" + str(spec.satisfies("+shared")),
             # TODO Hard-disable tests for now, since rapidcheck not in Spack
             "-DLAZYTEN_ENABLE_TESTS=OFF",
-            "-DLAZYTEN_ENABLE_EXAMPLES=" + str("+examples" in spec),
+            "-DLAZYTEN_ENABLE_EXAMPLES=" + str(spec.satisfies("+examples")),
         ]
 
         # Tell lazyten where to look for the krims cmake config
@@ -98,7 +98,7 @@ class Lazyten(CMakePackage):
             ]
         )
 
-        if "+arpack" in spec:
+        if spec.satisfies("+arpack"):
             args.append("-DARPACK_DIR=" + spec["arpack-ng"].prefix)
             args.append("-DARPACK_LIBRARY=" + ";".join(spec["arpack-ng"].libs))
 

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -266,7 +266,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     @property
     def libs(self):
-        shared = True if "+shared" in self.spec else False
+        shared = True if self.spec.satisfies("+shared") else False
         return find_libraries("liblbann", root=self.prefix, shared=shared, recursive=True)
 
     @property
@@ -286,7 +286,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         spec = self.spec
         entries = super().initconfig_compiler_entries()
         entries.append(cmake_cache_string("CMAKE_CXX_STANDARD", "17"))
-        entries.append(cmake_cache_option("BUILD_SHARED_LIBS", "+shared" in spec))
+        entries.append(cmake_cache_option("BUILD_SHARED_LIBS", spec.satisfies("+shared")))
         if not spec.satisfies("^cmake@3.23.0"):
             # There is a bug with using Ninja generator in this version
             # of CMake
@@ -298,7 +298,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         entries.append(cmake_cache_string("CMAKE_SHARED_LINKER_FLAGS", linker_flags))
 
         # Use lld high performance linker
-        if "+lld" in spec:
+        if spec.satisfies("+lld"):
             entries.append(
                 cmake_cache_string(
                     "CMAKE_EXE_LINKER_FLAGS", "{0} -fuse-ld=lld".format(linker_flags)
@@ -311,7 +311,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
             )
 
         # Use gold high performance linker
-        if "+gold" in spec:
+        if spec.satisfies("+gold"):
             entries.append(
                 cmake_cache_string(
                     "CMAKE_EXE_LINKER_FLAGS", "{0} -fuse-ld=gold".format(linker_flags)
@@ -340,7 +340,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         spec = self.spec
         entries = super().initconfig_hardware_entries()
 
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             if self.spec.satisfies("%clang"):
                 for flag in self.spec.compiler_flags["cxxflags"]:
                     if "gcc-toolchain" in flag:
@@ -393,7 +393,9 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
         entries.append(cmake_cache_option("LBANN_WITH_ALUMINUM", True))
         entries.append(cmake_cache_option("LBANN_WITH_CONDUIT", True))
         entries.append(cmake_cache_option("LBANN_WITH_HWLOC", True))
-        entries.append(cmake_cache_option("LBANN_WITH_ROCTRACER", "+rocm +distconv" in spec))
+        entries.append(
+            cmake_cache_option("LBANN_WITH_ROCTRACER", spec.satisfies("+rocm +distconv"))
+        )
         entries.append(cmake_cache_option("LBANN_WITH_TBINF", False))
         entries.append(
             cmake_cache_string("LBANN_DATATYPE", "{0}".format(spec.variants["dtype"].value))

--- a/var/spack/repos/builtin/packages/lc-framework/package.py
+++ b/var/spack/repos/builtin/packages/lc-framework/package.py
@@ -43,7 +43,7 @@ class LcFramework(CMakePackage, CudaPackage):
 
     def cmake_args(self):
         args = [self.define_from_variant("LC_BUILD_LIBPRESSIO_PLUGIN", "libpressio")]
-        if "+cuda" in self.spec:
+        if self.spec.satisfies("+cuda"):
             args.append(self.define_from_variant("LC_BUILD_CUDA", "cuda"))
             args.append(self.builder.define_cuda_architectures(self))
 

--- a/var/spack/repos/builtin/packages/ldc/package.py
+++ b/var/spack/repos/builtin/packages/ldc/package.py
@@ -43,7 +43,9 @@ class Ldc(CMakePackage):
 
         args = [
             "-DD_COMPILER:STRING={0}".format(ldmd2),
-            "-DBUILD_SHARED_LIBS:BOOL={0}".format("ON" if "+shared" in self.spec else "OFF"),
+            "-DBUILD_SHARED_LIBS:BOOL={0}".format(
+                "ON" if self.spec.satisfies("+shared") else "OFF"
+            ),
             "-DLDC_INSTALL_LTOPLUGIN:BOOL=ON",
             "-DLDC_BUILD_WITH_LTO:BOOL=OFF",
         ]

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -93,7 +93,9 @@ class Legion(CMakePackage, ROCmPackage):
     patch("hip-offload-arch.patch", when="@23.03.0 +rocm")
 
     def patch(self):
-        if "network=gasnet conduit=ofi-slingshot11 ^cray-mpich+wrappers" in self.spec:
+        if self.spec.satisfies(
+            "network=gasnet conduit=ofi-slingshot11 ^[virtuals=mpi] cray-mpich+wrappers"
+        ):
             filter_file(
                 r"--with-mpi-cc=cc",
                 f"--with-mpi-cc={self.spec['mpi'].mpicc}",

--- a/var/spack/repos/builtin/packages/lesstif/package.py
+++ b/var/spack/repos/builtin/packages/lesstif/package.py
@@ -42,8 +42,8 @@ class Lesstif(AutotoolsPackage):
             "--disable-debug",
             "--enable-production",
             "--disable-dependency-tracking",
-            "--enable-shared" if "+shared" in spec else "--disable-shared",
-            "--enable-static" if "+static" in spec else "--disable-static",
+            "--enable-shared" if spec.satisfies("+shared") else "--disable-shared",
+            "--enable-static" if spec.satisfies("+static") else "--disable-static",
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/leveldb/package.py
+++ b/var/spack/repos/builtin/packages/leveldb/package.py
@@ -70,7 +70,7 @@ class Leveldb(CMakePackage):
     def cmake_args(self):
         args = []
 
-        if "+shared" in self.spec:
+        if self.spec.satisfies("+shared"):
             args.append("-DBUILD_SHARED_LIBS=ON")
         else:
             args.append("-DBUILD_SHARED_LIBS=OFF")

--- a/var/spack/repos/builtin/packages/lhapdf/package.py
+++ b/var/spack/repos/builtin/packages/lhapdf/package.py
@@ -50,7 +50,7 @@ class Lhapdf(AutotoolsPackage):
         # Add -lintl if provided by gettext, otherwise libintl is provided by the system's glibc:
         if (
             self.spec.satisfies("+python")
-            and "gettext" in self.spec
+            and self.spec.satisfies("^gettext")
             and "intl" in self.spec["gettext"].libs.names
         ):
             env.append_flags("LDFLAGS", "-L" + self.spec["gettext"].prefix.lib)

--- a/var/spack/repos/builtin/packages/libarchive/package.py
+++ b/var/spack/repos/builtin/packages/libarchive/package.py
@@ -136,7 +136,7 @@ class Libarchive(AutotoolsPackage):
         args += self.with_or_without("xar")
         args += self.enable_or_disable("programs")
 
-        if "+iconv" in spec:
+        if spec.satisfies("+iconv"):
             if spec["iconv"].name == "libiconv":
                 args.append(f"--with-libiconv-prefix={spec['iconv'].prefix}")
             else:

--- a/var/spack/repos/builtin/packages/libbeagle/package.py
+++ b/var/spack/repos/builtin/packages/libbeagle/package.py
@@ -48,7 +48,7 @@ class Libbeagle(AutotoolsPackage, CudaPackage):
 
     def patch(self):
         # update cuda architecture if necessary
-        if "+cuda" in self.spec:
+        if self.spec.satisfies("+cuda"):
             cuda_arch = self.spec.variants["cuda_arch"].value
             archflag = "-arch=compute_{0}".format(cuda_arch)
 
@@ -73,12 +73,12 @@ class Libbeagle(AutotoolsPackage, CudaPackage):
             "--disable-march-native"
         ]
 
-        if "+cuda" in self.spec:
+        if self.spec.satisfies("+cuda"):
             args.append("--with-cuda={0}".format(self.spec["cuda"].prefix))
         else:
             args.append("--without-cuda")
 
-        if "+opencl" in self.spec:
+        if self.spec.satisfies("+opencl"):
             args.append("--with-opencl={0}".format(self.spec["opencl"].prefix))
         else:
             args.append("--without-opencl")

--- a/var/spack/repos/builtin/packages/libcanberra/package.py
+++ b/var/spack/repos/builtin/packages/libcanberra/package.py
@@ -46,7 +46,7 @@ class Libcanberra(AutotoolsPackage):
     def configure_args(self):
         args = ["--enable-static"]
 
-        if "+gtk" in self.spec:
+        if self.spec.satisfies("+gtk"):
             args.append("--enable-gtk")
         else:
             args.append("--disable-gtk")

--- a/var/spack/repos/builtin/packages/libceed/package.py
+++ b/var/spack/repos/builtin/packages/libceed/package.py
@@ -76,12 +76,12 @@ class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
         # Use verbose building output
         makeopts = ["V=1"]
 
-        if "@:0.2" in spec:
-            makeopts += ["NDEBUG=%s" % ("" if "+debug" in spec else "1")]
+        if spec.satisfies("@:0.2"):
+            makeopts += ["NDEBUG=%s" % ("" if spec.satisfies("+debug") else "1")]
 
-        elif "@0.4:" in spec:
+        elif spec.satisfies("@0.4:"):
             # Determine options based on the compiler:
-            if "+debug" in spec:
+            if spec.satisfies("+debug"):
                 opt = "-g"
             elif compiler.name == "gcc":
                 opt = "-O3 -g -ffp-contract=fast"
@@ -114,7 +114,7 @@ class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
             if spec.satisfies("@:0.7") and "avx" in self.spec.target:
                 makeopts.append("AVX=1")
 
-            if "+cuda" in spec:
+            if spec.satisfies("+cuda"):
                 makeopts += ["CUDA_DIR=%s" % spec["cuda"].prefix]
                 makeopts += ["CUDA_ARCH=sm_%s" % spec.variants["cuda_arch"].value]
                 if spec.satisfies("@:0.4"):
@@ -128,17 +128,17 @@ class Libceed(MakefilePackage, CudaPackage, ROCmPackage):
                 # Disable CUDA auto-detection:
                 makeopts += ["CUDA_DIR=/disable-cuda"]
 
-            if "+rocm" in spec:
+            if spec.satisfies("+rocm"):
                 makeopts += ["HIP_DIR=%s" % spec["hip"].prefix]
                 amdgpu_target = ",".join(spec.variants["amdgpu_target"].value)
                 makeopts += ["HIP_ARCH=%s" % amdgpu_target]
                 if spec.satisfies("@0.8"):
                     makeopts += ["HIPBLAS_DIR=%s" % spec["hipblas"].prefix]
 
-            if "+libxsmm" in spec:
+            if spec.satisfies("+libxsmm"):
                 makeopts += ["XSMM_DIR=%s" % spec["libxsmm"].prefix]
 
-            if "+magma" in spec:
+            if spec.satisfies("+magma"):
                 makeopts += ["MAGMA_DIR=%s" % spec["magma"].prefix]
 
         return makeopts

--- a/var/spack/repos/builtin/packages/libcint/package.py
+++ b/var/spack/repos/builtin/packages/libcint/package.py
@@ -68,11 +68,11 @@ class Libcint(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         args = [
-            "-DWITH_RANGE_COULOMB=" + str("+coulomb_erf" in spec),
-            "-DPYPZPX=" + str("+pypzpx" in spec),
-            "-DWITH_F12=" + str("+f12" in spec),
-            "-DBUILD_SHARED_LIBS=" + str("+shared" in spec),
-            "-DENABLE_TEST=" + str("+test" in spec),
+            "-DWITH_RANGE_COULOMB=" + str(spec.satisfies("+coulomb_erf")),
+            "-DPYPZPX=" + str(spec.satisfies("+pypzpx")),
+            "-DWITH_F12=" + str(spec.satisfies("+f12")),
+            "-DBUILD_SHARED_LIBS=" + str(spec.satisfies("+shared")),
+            "-DENABLE_TEST=" + str(spec.satisfies("+test")),
             "-DENABLE_EXAMPLE=OFF",  # Requires fortran compiler
         ]
         return args

--- a/var/spack/repos/builtin/packages/libcroco/package.py
+++ b/var/spack/repos/builtin/packages/libcroco/package.py
@@ -32,7 +32,7 @@ class Libcroco(AutotoolsPackage):
 
     def configure_args(self):
         config_args = []
-        if "+doc" in self.spec:
+        if self.spec.satisfies("+doc"):
             config_args.extend(
                 [
                     "--enable-gtk-doc",

--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -99,6 +99,6 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
 class MesonBuilder(spack.build_systems.meson.MesonBuilder):
     def meson_args(self):
         if self.spec.satisfies("@:2.4.112"):
-            return ["-Dman-pages=" + ("true" if "+docs" in self.spec else "false")]
+            return ["-Dman-pages=" + ("true" if self.spec.satisfies("+docs") else "false")]
         else:
-            return ["-Dman-pages=" + ("enabled" if "+docs" in self.spec else "disabled")]
+            return ["-Dman-pages=" + ("enabled" if self.spec.satisfies("+docs") else "disabled")]

--- a/var/spack/repos/builtin/packages/libepoxy/package.py
+++ b/var/spack/repos/builtin/packages/libepoxy/package.py
@@ -35,7 +35,7 @@ class Libepoxy(AutotoolsPackage):
         # --enable-glx defaults to auto and was failing on PPC64LE systems
         # because libx11 was missing from the dependences. This explicitly
         # enables/disables glx support.
-        if "+glx" in self.spec:
+        if self.spec.satisfies("+glx"):
             args.append("--enable-glx=yes")
         else:
             args.append("--enable-glx=no")

--- a/var/spack/repos/builtin/packages/libevent/package.py
+++ b/var/spack/repos/builtin/packages/libevent/package.py
@@ -61,7 +61,7 @@ class Libevent(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
         configure_args = []
-        if "+openssl" in spec:
+        if spec.satisfies("+openssl"):
             configure_args.append("--enable-openssl")
         else:
             configure_args.append("--disable-openssl")

--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -199,7 +199,7 @@ class Libfabric(AutotoolsPackage, CudaPackage):
 
         args.extend(self.enable_or_disable("debug"))
 
-        if "+kdreg" in self.spec:
+        if self.spec.satisfies("+kdreg"):
             args.append("--with-kdreg=yes")
         else:
             args.append("--with-kdreg=no")

--- a/var/spack/repos/builtin/packages/libflame/package.py
+++ b/var/spack/repos/builtin/packages/libflame/package.py
@@ -72,22 +72,22 @@ class LibflameBase(AutotoolsPackage):
         # https://github.com/flame/libflame/issues/24
         config_args = ["LIBS=" + self.spec["blas"].libs.ld_flags]
 
-        if "+lapack2flame" in self.spec:
+        if self.spec.satisfies("+lapack2flame"):
             config_args.append("--enable-lapack2flame")
         else:
             config_args.append("--disable-lapack2flame")
 
-        if "+static" in self.spec:
+        if self.spec.satisfies("+static"):
             config_args.append("--enable-static-build")
         else:
             config_args.append("--disable-static-build")
 
-        if "+shared" in self.spec:
+        if self.spec.satisfies("+shared"):
             config_args.append("--enable-dynamic-build")
         else:
             config_args.append("--disable-dynamic-build")
 
-        if "+debug" in self.spec:
+        if self.spec.satisfies("+debug"):
             config_args.append("--enable-debug")
         else:
             config_args.append("--disable-debug")

--- a/var/spack/repos/builtin/packages/libfms/package.py
+++ b/var/spack/repos/builtin/packages/libfms/package.py
@@ -33,7 +33,7 @@ class Libfms(CMakePackage):
     def cmake_args(self):
         args = []
         args.extend([self.define_from_variant("BUILD_SHARED_LIBS", "shared")])
-        if "+conduit" in self.spec:
+        if self.spec.satisfies("+conduit"):
             args.extend([self.define("CONDUIT_DIR", self.spec["conduit"].prefix)])
 
         return args
@@ -52,6 +52,6 @@ class Libfms(CMakePackage):
         """Export the FMS library.
         Sample usage: spec['libfms'].libs.ld_flags
         """
-        is_shared = "+shared" in self.spec
+        is_shared = self.spec.satisfies("+shared")
         libs = find_libraries("libfms", root=self.prefix, shared=is_shared, recursive=True)
         return libs or None  # Raise an error if no libs are found

--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -106,19 +106,19 @@ class Libfuse(MesonPackage):
     def meson_args(self):
         args = []
 
-        if "+utils" in self.spec:
+        if self.spec.satisfies("+utils"):
             args.append("-Dutils=true")
             args.append("-Dexamples=true")
         else:
             args.append("-Dutils=false")
             args.append("-Dexamples=false")
 
-        if "+useroot" in self.spec:
+        if self.spec.satisfies("+useroot"):
             args.append("-Duseroot=true")
         else:
             args.append("-Duseroot=false")
 
-        if "~system_install" in self.spec:
+        if self.spec.satisfies("~system_install"):
             # Fix meson's setup if meson does not have the host system's udev package:
             args.append("-Dudevrulesdir={0}".format(self.prefix.etc.rules.d))
 
@@ -147,10 +147,14 @@ class Libfuse(MesonPackage):
         ]
 
         args.append(
-            "--enable-static" if "default_library=static" in self.spec else "--disable-static"
+            "--enable-static"
+            if self.spec.satisfies("default_library=static")
+            else "--disable-static"
         )
         args.append(
-            "--enable-shared" if "default_library=shared" in self.spec else "--disable-shared"
+            "--enable-shared"
+            if self.spec.satisfies("default_library=shared")
+            else "--disable-shared"
         )
 
         configure(*args)

--- a/var/spack/repos/builtin/packages/libgain/package.py
+++ b/var/spack/repos/builtin/packages/libgain/package.py
@@ -30,5 +30,5 @@ class Libgain(AutotoolsPackage):
 
     @property
     def libs(self):
-        shared = "+shared" in self.spec
+        shared = self.spec.satisfies("+shared")
         return find_libraries("libGaIn", root=self.prefix, shared=shared, recursive=True)

--- a/var/spack/repos/builtin/packages/libgeotiff/package.py
+++ b/var/spack/repos/builtin/packages/libgeotiff/package.py
@@ -63,17 +63,17 @@ class Libgeotiff(AutotoolsPackage):
 
         args = ["--with-libtiff={0}".format(spec["libtiff"].prefix)]
 
-        if "+zlib" in spec:
+        if spec.satisfies("+zlib"):
             args.append("--with-zlib={0}".format(spec["zlib-api"].prefix))
         else:
             args.append("--with-zlib=no")
 
-        if "+jpeg" in spec:
+        if spec.satisfies("+jpeg"):
             args.append("--with-jpeg={0}".format(spec["jpeg"].prefix))
         else:
             args.append("--with-jpeg=no")
 
-        if "+proj" in spec:
+        if spec.satisfies("+proj"):
             args.append("--with-proj={0}".format(spec["proj"].prefix))
         else:
             args.append("--with-proj=no")

--- a/var/spack/repos/builtin/packages/libgit2/package.py
+++ b/var/spack/repos/builtin/packages/libgit2/package.py
@@ -105,16 +105,16 @@ class Libgit2(CMakePackage):
 
     def cmake_args(self):
         args = []
-        if "https=system" in self.spec:
-            if "platform=linux" in self.spec:
+        if self.spec.satisfies("https=system"):
+            if self.spec.satisfies("platform=linux"):
                 args.append("-DUSE_HTTPS=OpenSSL")
-            elif "platform=darwin" in self.spec:
+            elif self.spec.satisfies("platform=darwin"):
                 args.append("-DUSE_HTTPS=SecureTransport")
             else:
                 # Let CMake try to find an HTTPS implementation. Mileage on
                 # your platform may vary
                 args.append("-DUSE_HTTPS=ON")
-        elif "https=openssl" in self.spec:
+        elif self.spec.satisfies("https=openssl"):
             args.append("-DUSE_HTTPS=OpenSSL")
         else:
             args.append("-DUSE_HTTPS=OFF")
@@ -122,7 +122,7 @@ class Libgit2(CMakePackage):
         args.append(f"-DUSE_SSH={'ON' if '+ssh' in self.spec else 'OFF'}")
 
         # The curl backed is not supported after 0.27.x
-        if "@:0.27 +curl" in self.spec:
+        if self.spec.satisfies("@:0.27 +curl"):
             args.append(f"-DCURL={'ON' if '+curl' in self.spec else 'OFF'}")
 
         # Control tests

--- a/var/spack/repos/builtin/packages/libhio/package.py
+++ b/var/spack/repos/builtin/packages/libhio/package.py
@@ -62,7 +62,7 @@ class Libhio(AutotoolsPackage):
         args = []
 
         args.append("--with-external_bz2={0}".format(spec["bzip2"].prefix))
-        if "+hdf5" in spec:
+        if spec.satisfies("+hdf5"):
             args.append("--with-hdf5={0}".format(spec["hdf5"].prefix))
 
         args.append("--with-external-json={0}".format(spec["json-c"].prefix))

--- a/var/spack/repos/builtin/packages/libiberty/package.py
+++ b/var/spack/repos/builtin/packages/libiberty/package.py
@@ -60,7 +60,7 @@ class Libiberty(AutotoolsPackage, GNUMirrorPackage):
         else:
             flags.append("-O2")
 
-        if "+pic" in self.spec:
+        if self.spec.satisfies("+pic"):
             flags.append(self.compiler.cc_pic_flag)
 
         return (None, None, flags)

--- a/var/spack/repos/builtin/packages/libiconv/package.py
+++ b/var/spack/repos/builtin/packages/libiconv/package.py
@@ -60,5 +60,5 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
 
     @property
     def libs(self):
-        shared = "libs=shared" in self.spec
+        shared = self.spec.satisfies("libs=shared")
         return find_libraries(["libiconv"], root=self.prefix, recursive=True, shared=shared)

--- a/var/spack/repos/builtin/packages/libint/package.py
+++ b/var/spack/repos/builtin/packages/libint/package.py
@@ -128,7 +128,7 @@ class Libint(AutotoolsPackage):
 
         # Change AR to xiar if we compile with Intel and we
         # find the executable
-        if "%intel" in self.spec and which("xiar"):
+        if self.spec.satisfies("%intel") and which("xiar"):
             env.set("AR", "xiar")
 
     def configure_args(self):
@@ -158,7 +158,7 @@ class Libint(AutotoolsPackage):
         if self.version < Version("2.0.0"):
             config_args.extend(["--with-libint-max-am=5", "--with-libderiv-max-am1=4"])
 
-        if "@2.6.0:" in self.spec:
+        if self.spec.satisfies("@2.6.0:"):
             config_args += ["--with-libint-exportdir=generated"]
             config_args += self.enable_or_disable("debug", activation_value=lambda x: "opt")
             config_args += self.enable_or_disable("fma")
@@ -204,7 +204,7 @@ class Libint(AutotoolsPackage):
 
     @property
     def build_targets(self):
-        if "@2.6.0:" in self.spec:
+        if self.spec.satisfies("@2.6.0:"):
             return ["export"]
 
         return []
@@ -244,9 +244,9 @@ class Libint(AutotoolsPackage):
                     f"-DCMAKE_INSTALL_PREFIX={prefix}",
                     "-DLIBINT2_BUILD_SHARED_AND_STATIC_LIBS=ON",
                 ]
-                if "+fortran" in spec:
+                if spec.satisfies("+fortran"):
                     cmake_args.append("-DENABLE_FORTRAN=ON")
-                if "+debug" in spec:
+                if spec.satisfies("+debug"):
                     cmake_args.append("CMAKE_BUILD_TYPE=Debug")
                 cmake = Executable("cmake")
                 mkdirp("build")
@@ -274,7 +274,7 @@ class Libint(AutotoolsPackage):
     def patch(self):
         # Use Fortran compiler to link the Fortran example, not the C++
         # compiler
-        if "+fortran" in self.spec:
+        if self.spec.satisfies("+fortran"):
             if not self.spec.satisfies("%fj"):
                 filter_file(
                     "$(CXX) $(CXXFLAGS)",

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -131,5 +131,5 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     @run_after("install")
     def darwin_fix(self):
         # The shared library is not installed correctly on Darwin; fix this
-        if self.spec.satisfies("platform=darwin") and ("+shared" in self.spec):
+        if self.spec.satisfies("platform=darwin") and self.spec.satisfies("+shared"):
             fix_darwin_install_name(self.prefix.lib)

--- a/var/spack/repos/builtin/packages/libkml/package.py
+++ b/var/spack/repos/builtin/packages/libkml/package.py
@@ -52,12 +52,12 @@ class Libkml(CMakePackage):
 
         args = []
 
-        if "+java" in spec:
+        if spec.satisfies("+java"):
             args.append("-DWITH_JAVA:BOOL=ON")
         else:
             args.append("-DWITH_JAVA:BOOL=OFF")
 
-        if "+python" in spec:
+        if spec.satisfies("+python"):
             args.append("-DWITH_PYTHON:BOOL=ON")
         else:
             args.append("-DWITH_PYTHON:BOOL=OFF")

--- a/var/spack/repos/builtin/packages/liblas/package.py
+++ b/var/spack/repos/builtin/packages/liblas/package.py
@@ -37,22 +37,22 @@ class Liblas(CMakePackage):
 
     def cmake_args(self):
         args = []
-        if "+endian" in self.spec:
+        if self.spec.satisfies("+endian"):
             args.append("-DWITH_ENDIANAWARE=ON")
         else:
             args.append("-DWITH_ENDIANAWARE=OFF")
 
-        if "+gdal" in self.spec:
+        if self.spec.satisfies("+gdal"):
             args.append("-DWITH_GDAL=ON")
         else:
             args.append("-DWITH_GDAL=OFF")
 
-        if "+geotiff" in self.spec:
+        if self.spec.satisfies("+geotiff"):
             args.append("-DWITH_GEOTIFF=ON")
         else:
             args.append("-DWITH_GEOTIFF=OFF")
 
-        if "+laszip" in self.spec:
+        if self.spec.satisfies("+laszip"):
             args.append("-DWITH_LASZIP=ON")
         else:
             args.append("-DWITH_LASZIP=OFF")

--- a/var/spack/repos/builtin/packages/libmesh/package.py
+++ b/var/spack/repos/builtin/packages/libmesh/package.py
@@ -152,7 +152,7 @@ class Libmesh(AutotoolsPackage):
     def configure_args(self):
         options = []
 
-        if "+shared" in self.spec:
+        if self.spec.satisfies("+shared"):
             options.extend(["--enable-shared", "--disable-static"])
         else:
             options.extend(["--disable-shared", "--enable-static"])
@@ -209,44 +209,44 @@ class Libmesh(AutotoolsPackage):
                 options.append("--enable-" + bundled_library + "=no")
 
         # and the ones which are dependencies of other bundled libraries:
-        if "+exodusii" in self.spec or "+netcdf" in self.spec:
+        if self.spec.satisfies("+exodusii") or self.spec.satisfies("+netcdf"):
             options.append("--enable-netcdf=yes")
         else:
             options.append("--enable-netcdf=no")
 
-        if "+vtk" in self.spec:
+        if self.spec.satisfies("+vtk"):
             options.append("--enable-vtk")
             options.append("--with-vtk=%s" % self.spec["vtk"].prefix)
         else:
             options.append("--disable-vtk")
 
         # handle external library dependencies:
-        if "+boost" in self.spec:
+        if self.spec.satisfies("+boost"):
             options.append("--with-boost=%s" % self.spec["boost"].prefix)
         else:
             options.append("--enable-boost=no")
 
-        if "+eigen" in self.spec:
+        if self.spec.satisfies("+eigen"):
             options.append("--with-eigen=%s" % self.spec["eigen"].prefix)
         else:
             options.append("--enable-eigen=no")
 
-        if "+metaphysicl" in self.spec:
+        if self.spec.satisfies("+metaphysicl"):
             options.append("--enable-metaphysicl")
         else:
             options.append("--disable-metaphysicl")
 
-        if "+perflog" in self.spec:
+        if self.spec.satisfies("+perflog"):
             options.append("--enable-perflog")
         else:
             options.append("--disable-perflog")
 
-        if "+blocked" in self.spec:
+        if self.spec.satisfies("+blocked"):
             options.append("--enable-blocked-storage")
         else:
             options.append("--disable-blocked-storage")
 
-        if "+hdf5" in self.spec:
+        if self.spec.satisfies("+hdf5"):
             options.append("--with-hdf5=%s" % self.spec["hdf5"].prefix)
         else:
             options.append("--enable-hdf5=no")
@@ -255,34 +255,34 @@ class Libmesh(AutotoolsPackage):
             if "+netcdf" not in self.spec:
                 options.append("--disable-netcdf-4")
 
-        if "+metis" in self.spec:
+        if self.spec.satisfies("+metis"):
             options.append("--enable-metis")
             options.append("--enable-parmetis")
-            if "+petsc" in self.spec:
+            if self.spec.satisfies("+petsc"):
                 options.append("--with-metis=PETSc")
                 options.append("--with-parmetis=PETSc")
         else:
             options.append("--disable-metis")
 
-        if "+petsc" in self.spec or "+slepc" in self.spec:
+        if self.spec.satisfies("+petsc") or self.spec.satisfies("+slepc"):
             options.append("--enable-petsc=yes")
             options.append("PETSC_DIR=%s" % self.spec["petsc"].prefix)
         else:
             options.append("--enable-petsc=no")
 
-        if "+slepc" in self.spec:
+        if self.spec.satisfies("+slepc"):
             options.append("--enable-slepc=yes")
             options.append("SLEPC_DIR=%s" % self.spec["slepc"].prefix)
         else:
             options.append("--enable-slepc=no")
 
         # and, finally, other things:
-        if "+debug" in self.spec:
+        if self.spec.satisfies("+debug"):
             options.append("--with-methods=dbg")
         else:
             options.append("--with-methods=opt")
 
-        if "+mpi" in self.spec:
+        if self.spec.satisfies("+mpi"):
             options.append("CC=%s" % self.spec["mpi"].mpicc)
             options.append("CXX=%s" % self.spec["mpi"].mpicxx)
             options.append("--with-mpi=%s" % self.spec["mpi"].prefix)
@@ -293,7 +293,7 @@ class Libmesh(AutotoolsPackage):
             options.append("CC=%s" % self.compiler.cc)
             options.append("CXX=%s" % self.compiler.cxx)
 
-        if "threads=openmp" in self.spec:
+        if self.spec.satisfies("threads=openmp"):
             # OpenMP cannot be used if pthreads is not available: see
             # parallel/threads_pthread.h and parallel/threads.h
             options.append("--enable-openmp=yes")
@@ -302,14 +302,14 @@ class Libmesh(AutotoolsPackage):
         else:
             options.append("--enable-openmp=no")
 
-        if "threads=pthreads" in self.spec:
+        if self.spec.satisfies("threads=pthreads"):
             options.append("--with-thread-model=pthread")
             options.append("--enable-pthreads=yes")
         else:
             if "threads=openmp" not in self.spec:
                 options.append("--enable-pthreads=no")
 
-        if "threads=tbb" in self.spec:
+        if self.spec.satisfies("threads=tbb"):
             options.append("--with-thread-model=tbb")
             options.append("--enable-tbb=yes")
             options.append("--with-tbb=%s" % self.spec["tbb"].prefix)

--- a/var/spack/repos/builtin/packages/libmonitor/package.py
+++ b/var/spack/repos/builtin/packages/libmonitor/package.py
@@ -64,10 +64,10 @@ class Libmonitor(AutotoolsPackage):
     def configure_args(self):
         args = []
 
-        if "+hpctoolkit" in self.spec:
+        if self.spec.satisfies("+hpctoolkit"):
             args.append("--enable-client-signals=%s" % self.signals)
 
-        if "+dlopen" in self.spec:
+        if self.spec.satisfies("+dlopen"):
             args.append("--enable-dlfcn")
         else:
             args.append("--disable-dlfcn")

--- a/var/spack/repos/builtin/packages/libmypaint/package.py
+++ b/var/spack/repos/builtin/packages/libmypaint/package.py
@@ -41,10 +41,10 @@ class Libmypaint(AutotoolsPackage):
     def configure_args(self):
         args = []
 
-        if "+gegl" in self.spec:
+        if self.spec.satisfies("+gegl"):
             args.append("--enable-gegl=yes")
 
-        if "+introspection" in self.spec:
+        if self.spec.satisfies("+introspection"):
             args.extend(
                 ["--enable-introspection=yes", "--with-glib={0}".format(self.spec["glib"].prefix)]
             )

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -48,7 +48,7 @@ class Libpng(CMakePackage):
     def libs(self):
         # v1.2 does not have a version-less symlink
         libraries = f"libpng{self.version.up_to(2).joined}"
-        shared = "libs=shared" in self.spec
+        shared = self.spec.satisfies("libs=shared")
         return find_libraries(
             libraries, root=self.prefix, shared=shared, recursive=True, runtime=False
         )

--- a/var/spack/repos/builtin/packages/libpressio/package.py
+++ b/var/spack/repos/builtin/packages/libpressio/package.py
@@ -374,11 +374,14 @@ class Libpressio(CMakePackage, CudaPackage):
             self.define_from_variant("LIBPRESSIO_INSTALL_DOCS", "docs"),
             self.define_from_variant("BUILD_PYTHON_WRAPPER", "python"),
             self.define("LIBPRESSIO_HAS_MPI4PY", self.spec.satisfies("+python +mpi")),
-            self.define("LIBPRESSIO_BUILD_MODE", "FULL" if "+core" in self.spec else "CORE"),
+            self.define(
+                "LIBPRESSIO_BUILD_MODE", "FULL" if self.spec.satisfies("+core") else "CORE"
+            ),
             self.define("BUILD_TESTING", self.run_tests),
             # this flag was removed in 0.52.0, we should deprecate and remove this
             self.define(
-                "LIBPRESSIO_CXX_VERSION", "11" if "+boost" in self.spec else self.lp_cxx_version()
+                "LIBPRESSIO_CXX_VERSION",
+                "11" if self.spec.satisfies("+boost") else self.lp_cxx_version(),
             ),
         ]
         # if cuda is backed by the shim, we need to set these linker flags to
@@ -386,15 +389,15 @@ class Libpressio(CMakePackage, CudaPackage):
         if self.spec.satisfies("+cusz +cuda"):
             args.append("-DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined")
         # libpressio needs to know where to install the python libraries
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             args.append(f"-DLIBPRESSIO_PYTHON_SITELIB={python_platlib}")
         # help ensure that libpressio finds the correct HDF5 package
-        if "+hdf5" in self.spec:
+        if self.spec.satisfies("+hdf5"):
             args.append("-DHDF5_ROOT=" + self.spec["hdf5"].prefix)
         return args
 
     def setup_run_environment(self, env):
-        if "+hdf5" in self.spec and "+json" in self.spec:
+        if self.spec.satisfies("+hdf5") and self.spec.satisfies("+json"):
             env.prepend_path("HDF5_PLUGIN_PATH", self.prefix.lib64)
 
     @run_after("build")
@@ -404,7 +407,7 @@ class Libpressio(CMakePackage, CudaPackage):
 
     @run_after("build")
     def install_docs(self):
-        if "+docs" in self.spec:
+        if self.spec.satisfies("+docs"):
             with working_dir(self.build_directory):
                 make("docs")
 

--- a/var/spack/repos/builtin/packages/libproxy/package.py
+++ b/var/spack/repos/builtin/packages/libproxy/package.py
@@ -40,12 +40,12 @@ class Libproxy(CMakePackage):
             self.define("WITH_PYTHON2", False),
             self.define("WITH_VALA", False),
         ]
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             args.append(self.define("PYTHON3_SITEPKG_DIR", python_platlib))
         return args
 
     def setup_run_environment(self, env):
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             libs = self.spec["libproxy"].libs.directories[0]
             if self.spec.satisfies("platform=darwin"):
                 env.prepend_path("DYLD_FALLBACK_LIBRARY_PATH", libs)

--- a/var/spack/repos/builtin/packages/libpsm3/package.py
+++ b/var/spack/repos/builtin/packages/libpsm3/package.py
@@ -56,8 +56,8 @@ class Libpsm3(AutotoolsPackage):
         env.prepend_path("FI_PROVIDER_PATH", self.prefix.lib)
         env.set("FI_PROVIDER", "psm3")
         env.set("PSM3_ALLOW_ROUTERS", "1")
-        if "+sockets" in self.spec and "~verbs" in self.spec:
+        if self.spec.satisfies("+sockets ~verbs"):
             env.set("PSM3_HAL", "sockets")
         env.set("FI_PSM3_NAME_SERVER", "1")
-        if "+debug" in self.spec:
+        if self.spec.satisfies("+debug"):
             env.set("PSM3_IDENTIFY", "1")

--- a/var/spack/repos/builtin/packages/libquo/package.py
+++ b/var/spack/repos/builtin/packages/libquo/package.py
@@ -47,7 +47,7 @@ class Libquo(AutotoolsPackage):
             "CC={0}".format(self.spec["mpi"].mpicc),
             "FC={0}".format(self.spec["mpi"].mpifc),
         ]
-        if "%pgi" in self.spec:
+        if self.spec.satisfies("%pgi"):
             config_args.append("CFLAGS={0}".format(self.compiler.cc_pic_flag))
             config_args.append("FCFLAGS={0}".format(self.compiler.fc_pic_flag))
         return config_args

--- a/var/spack/repos/builtin/packages/librsb/package.py
+++ b/var/spack/repos/builtin/packages/librsb/package.py
@@ -44,7 +44,7 @@ class Librsb(AutotoolsPackage):
     variant("verbose", default=False, description="Extra Library Verbosity. Good for learning.")
 
     def setup_build_environment(self, spack_env):
-        if "+asan" in self.spec:
+        if self.spec.satisfies("+asan"):
             spack_env.set("LSAN_OPTIONS", "verbosity=1:log_threads=1")
             spack_env.set("ASAN_OPTS", "detect_leaks=0")
 
@@ -56,25 +56,25 @@ class Librsb(AutotoolsPackage):
             f"CPPFLAGS={self.spec['zlib-api'].headers.include_flags}",
             f"LDFLAGS={self.spec['zlib-api'].libs.search_flags}",
         ]
-        if "+asan" in self.spec:
+        if self.spec.satisfies("+asan"):
             args.append("CFLAGS=-O0 -ggdb -fsanitize=address -fno-omit-frame-pointer")
             args.append("CXXFLAGS=-O0 -ggdb -fsanitize=address -fno-omit-frame-pointer")
             args.append("LIBS=-lasan")
             args.append("FCLIBS=-lasan")
             args.append("--disable-shared")
             args.append("--enable-fortran-linker")
-        if "+debug" in self.spec:
+        if self.spec.satisfies("+debug"):
             args.append("--enable-allocator-wrapper")
             args.append("--enable-debug")
-        if "+native" in self.spec:
+        if self.spec.satisfies("+native"):
             args.append("CFLAGS=-O3 -march=native")
             args.append("CXXFLAGS=-O3 -march=native")
             args.append("FCFLAGS=-O3 -march=native")
-        if "+nospblas" in self.spec:
+        if self.spec.satisfies("+nospblas"):
             args.append("--disable-sparse-blas-interface")
-        if "+serial" in self.spec:
+        if self.spec.satisfies("+serial"):
             args.append("--disable-openmp")
-        if "+verbose" in self.spec:
+        if self.spec.satisfies("+verbose"):
             args.append("--enable-internals-error-verbosity=1")
             args.append("--enable-interface-error-verbosity=1")
         return args

--- a/var/spack/repos/builtin/packages/librsvg/package.py
+++ b/var/spack/repos/builtin/packages/librsvg/package.py
@@ -75,7 +75,7 @@ class Librsvg(AutotoolsPackage):
 
     def configure_args(self):
         args = []
-        if "+doc" in self.spec:
+        if self.spec.satisfies("+doc"):
             args.append("--enable-gtk-doc")
         else:
             args.extend(

--- a/var/spack/repos/builtin/packages/libseccomp/package.py
+++ b/var/spack/repos/builtin/packages/libseccomp/package.py
@@ -27,6 +27,6 @@ class Libseccomp(AutotoolsPackage):
 
     def configure_args(self):
         args = []
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             args.append("--enable-python")
         return args

--- a/var/spack/repos/builtin/packages/libsharp/package.py
+++ b/var/spack/repos/builtin/packages/libsharp/package.py
@@ -43,7 +43,7 @@ class Libsharp(AutotoolsPackage):
             args.append("--disable-openmp")
         if "+mpi" not in self.spec:
             args.append("--disable-mpi")
-        if "+pic" in self.spec:
+        if self.spec.satisfies("+pic"):
             args.append("--enable-pic")
         return args
 

--- a/var/spack/repos/builtin/packages/libsolv/package.py
+++ b/var/spack/repos/builtin/packages/libsolv/package.py
@@ -29,7 +29,7 @@ class Libsolv(CMakePackage):
 
     def cmake_args(self):
         return [
-            self.define("ENABLE_STATIC", "~shared" in self.spec),
-            self.define("DISABLE_DYNAMIC", "~shared" in self.spec),
+            self.define("ENABLE_STATIC", self.spec.satisfies("~shared")),
+            self.define("DISABLE_DYNAMIC", self.spec.satisfies("~shared")),
             self.define_from_variant("ENABLE_CONDA", "conda"),
         ]

--- a/var/spack/repos/builtin/packages/libstdcompat/package.py
+++ b/var/spack/repos/builtin/packages/libstdcompat/package.py
@@ -90,7 +90,7 @@ class Libstdcompat(CMakePackage):
         args = []
         cpp_compat = self.spec.variants["cpp_compat"].value
 
-        if "cpp_unstable" in self.spec:
+        if self.spec.satisfies("+cpp_unstable"):
             args.append("-DSTDCOMPAT_CXX_UNSTABLE=ON")
 
         if cpp_compat == "auto":

--- a/var/spack/repos/builtin/packages/libtraceevent/package.py
+++ b/var/spack/repos/builtin/packages/libtraceevent/package.py
@@ -38,13 +38,13 @@ class Libtraceevent(MakefilePackage):
     @property
     def build_targets(self):
         result = self.common_targets + ["all"]
-        if "+doc" in self.spec:
+        if self.spec.satisfies("+doc"):
             result.append("doc")
         return result
 
     @property
     def install_targets(self):
         result = self.common_targets + ["install"]
-        if "+doc" in self.spec:
+        if self.spec.satisfies("+doc"):
             result.append("doc-install")
         return result

--- a/var/spack/repos/builtin/packages/libunwind/package.py
+++ b/var/spack/repos/builtin/packages/libunwind/package.py
@@ -108,7 +108,7 @@ class Libunwind(AutotoolsPackage):
             ):
                 wrapper_flags.append("-fcommon")
 
-            if "+pic" in self.spec:
+            if self.spec.satisfies("+pic"):
                 wrapper_flags.append(self.compiler.cc_pic_flag)
 
         return (wrapper_flags, None, flags)

--- a/var/spack/repos/builtin/packages/libvpx/package.py
+++ b/var/spack/repos/builtin/packages/libvpx/package.py
@@ -30,6 +30,6 @@ class Libvpx(AutotoolsPackage):
 
     def configure_args(self):
         extra_args = []
-        if "+pic" in self.spec:
+        if self.spec.satisfies("+pic"):
             extra_args.append("--enable-pic")
         return extra_args

--- a/var/spack/repos/builtin/packages/libxc/package.py
+++ b/var/spack/repos/builtin/packages/libxc/package.py
@@ -95,14 +95,14 @@ class Libxc(AutotoolsPackage, CudaPackage):
         # https://gitlab.com/libxc/libxc/-/issues/430 (configure script does not ensure C99)
         # TODO: Switch to cmake since this is better supported
         env.append_flags("CFLAGS", self.compiler.c99_flag)
-        if "%intel" in self.spec:
+        if self.spec.satisfies("%intel"):
             if which("xiar"):
                 env.set("AR", "xiar")
 
-        if "%aocc" in self.spec:
+        if self.spec.satisfies("%aocc"):
             env.append_flags("FCFLAGS", "-fPIC")
 
-        if "+cuda" in self.spec:
+        if self.spec.satisfies("+cuda"):
             nvcc = self.spec["cuda"].prefix.bin.nvcc
             env.set("CCLD", "{0} -ccbin {1}".format(nvcc, spack_cc))
             env.set("CC", "{0} -x cu -ccbin {1}".format(nvcc, spack_cc))
@@ -116,16 +116,16 @@ class Libxc(AutotoolsPackage, CudaPackage):
         args = []
         args += self.enable_or_disable("shared")
         args += self.enable_or_disable("cuda")
-        if "+kxc" in self.spec:
+        if self.spec.satisfies("+kxc"):
             args.append("--enable-kxc")
-        if "+lxc" in self.spec:
+        if self.spec.satisfies("+lxc"):
             args.append("--enable-lxc")
         return args
 
     @run_after("configure")
     def patch_libtool(self):
         """AOCC support for LIBXC"""
-        if "%aocc" in self.spec:
+        if self.spec.satisfies("%aocc"):
             filter_file(
                 r"\$wl-soname \$wl\$soname",
                 r"-fuse-ld=ld -Wl,-soname,\$soname",

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -208,7 +208,7 @@ class BaseBuilder(metaclass=spack.builder.PhaseCallbacksMeta):
     @run_after("install")
     @on_package_attributes(run_tests=True)
     def import_module_test(self):
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             with working_dir("spack-test", create=True):
                 python("-c", "import libxml2")
 
@@ -222,7 +222,7 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
             "--with-iconv={0}".format(spec["iconv"].prefix),
         ]
 
-        if "+python" in spec:
+        if spec.satisfies("+python"):
             args.extend(
                 [
                     "--with-python={0}".format(spec["python"].home),
@@ -273,6 +273,6 @@ class NMakeBuilder(BaseBuilder, nmake.NMakeBuilder):
                     )
                 ),
             ]
-            if "+python" in spec:
+            if spec.satisfies("+python"):
                 opts.append("python=yes")
             cscript("configure.js", *opts)

--- a/var/spack/repos/builtin/packages/libxslt/package.py
+++ b/var/spack/repos/builtin/packages/libxslt/package.py
@@ -61,12 +61,12 @@ class Libxslt(AutotoolsPackage):
     def configure_args(self):
         args = []
 
-        if "+crypto" in self.spec:
+        if self.spec.satisfies("+crypto"):
             args.append("--with-crypto")
         else:
             args.append("--without-crypto")
 
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             args.append("--with-python={0}".format(self.spec["python"].home))
         else:
             args.append("--without-python")
@@ -76,7 +76,7 @@ class Libxslt(AutotoolsPackage):
     @run_after("install")
     @on_package_attributes(run_tests=True)
     def import_module_test(self):
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             with working_dir("spack-test", create=True):
                 python("-c", "import libxslt")
 

--- a/var/spack/repos/builtin/packages/libxsmm/package.py
+++ b/var/spack/repos/builtin/packages/libxsmm/package.py
@@ -123,7 +123,7 @@ class Libxsmm(MakefilePackage):
         # make_args += ['MNK=1 4 5 6 8 9 13 16 17 22 23 24 26 32']
 
         # include call trace as the build is already de-optimized
-        if "+debug" in spec:
+        if spec.satisfies("+debug"):
             make_args += ["DBG=1"]
             make_args += ["TRACE=1"]
 
@@ -131,10 +131,10 @@ class Libxsmm(MakefilePackage):
         if blas_val != "default":
             make_args += ["BLAS={0}".format(blas_val)]
 
-        if "+large_jit_buffer" in spec:
+        if spec.satisfies("+large_jit_buffer"):
             make_args += ["CODE_BUF_MAXSIZE=262144"]
 
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             make(*(make_args + ["STATIC=0"]))
 
         # builds static libraries by default
@@ -151,16 +151,16 @@ class Libxsmm(MakefilePackage):
         # always install libraries
         install_tree("lib", prefix.lib)
 
-        if "+header-only" in spec:
+        if spec.satisfies("+header-only"):
             install_tree("src", prefix.src)
 
-        if "+generator" in spec:
+        if spec.satisfies("+generator"):
             install_tree("bin", prefix.bin)
 
         mkdirp(prefix.doc)
         install(join_path("documentation", "*.md"), prefix.doc)
         install(join_path("documentation", "*.pdf"), prefix.doc)
-        if "@1.8.2:" in spec:
+        if spec.satisfies("@1.8.2:"):
             install("LICENSE.md", prefix.doc)
         else:
             install("README.md", prefix.doc)

--- a/var/spack/repos/builtin/packages/liggghts/package.py
+++ b/var/spack/repos/builtin/packages/liggghts/package.py
@@ -67,7 +67,7 @@ class Liggghts(MakefilePackage):
         )
         makefile.filter(r"^#(VTK_LIB_USR=-L).*", r"\1{0}".format(vtk.prefix.lib))
 
-        if "+mpi" in spec:
+        if spec.satisfies("+mpi"):
             mpi = spec["mpi"]
             makefile.filter(r"^#(MPICXX_USR=).*", r"\1{0}".format(mpi.mpicxx))
             makefile.filter(r"^#(MPI_INC_USR=).*", r"\1{0}".format(mpi.prefix.include))
@@ -81,19 +81,19 @@ class Liggghts(MakefilePackage):
             # builds using its own target!
             makefile_auto.filter(r"^(.+)(EXTRA_ADDLIBS.*mpi_stubs.*)", r"\1#\2")
 
-        if "+jpeg" in spec:
+        if spec.satisfies("+jpeg"):
             jpeg = spec["jpeg"]
             makefile.filter(r"^(USE_JPG = ).*", r'\1"ON"')
             makefile.filter(r"^#(JPG_INC_USR=-I).*", r"\1{0}".format(jpeg.prefix.include))
             makefile.filter(r"^#(JPG_LIB_USR=-L).*", r"\1{0}".format(jpeg.prefix.lib))
 
-        if "+gzip" in spec:
+        if spec.satisfies("+gzip"):
             makefile.filter(r"^(USE_GZIP = ).*", r'\1"ON"')
 
-        if "+debug" in spec:
+        if spec.satisfies("+debug"):
             makefile.filter(r"^(USE_DEBUG = ).*", r'\1"ON"')
 
-        if "+profile" in spec:
+        if spec.satisfies("+profile"):
             makefile.filter(r"^(USE_PROFILE = ).*", r'\1"ON"')
 
         # Enable debug output of Makefile.auto in the log file

--- a/var/spack/repos/builtin/packages/ligra/package.py
+++ b/var/spack/repos/builtin/packages/ligra/package.py
@@ -30,7 +30,7 @@ class Ligra(MakefilePackage):
     depends_on("mkl", when="+mkl")
 
     def setup_build_environment(self, env):
-        if "+openmp" in self.spec:
+        if self.spec.satisfies("+openmp"):
             env.set("OPENMP", "1")
         # when +mkl, MKLROOT will be defined by intel-mkl package,
         # triggering a build with mkl support

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -108,13 +108,13 @@ class Likwid(Package):
         filter_file("^#!/usr/bin/perl", "#!/usr/bin/env perl", *files)
 
     def setup_run_environment(self, env):
-        if "+cuda" in self.spec:
+        if self.spec.satisfies("+cuda"):
             libs = find_libraries(
                 "libcupti", root=self.spec["cuda"].prefix, shared=True, recursive=True
             )
             for lib in libs.directories:
                 env.append_path("LD_LIBRARY_PATH", lib)
-        if "+rocm" in self.spec:
+        if self.spec.satisfies("+rocm"):
             libs = find_libraries(
                 "librocprofiler64.so.1",
                 root=self.spec["rocprofiler-dev"].prefix,
@@ -176,14 +176,14 @@ class Likwid(Package):
             "ACCESSMODE = {}".format(spec.variants["accessmode"].value),
             "config.mk",
         )
-        if "accessmode=accessdaemon" in spec:
+        if spec.satisfies("accessmode=accessdaemon"):
             # Disable the chown, see the `spack_perms_fix` template and script
             filter_file("^INSTALL_CHOWN .*", "INSTALL_CHOWN =", "config.mk")
         else:
             filter_file("^BUILDFREQ .*", "BUILDFREQ = false", "config.mk")
             filter_file("^BUILDDAEMON .*", "BUILDDAEMON = false", "config.mk")
 
-        if "+fortran" in self.spec:
+        if self.spec.satisfies("+fortran"):
             filter_file("^FORTRAN_INTERFACE .*", "FORTRAN_INTERFACE = true", "config.mk")
             if self.compiler.name == "gcc":
                 makepath = join_path("make", "include_GCC.mk")
@@ -192,7 +192,7 @@ class Likwid(Package):
         else:
             filter_file("^FORTRAN_INTERFACE .*", "FORTRAN_INTERFACE = false", "config.mk")
 
-        if "+cuda" in self.spec:
+        if self.spec.satisfies("+cuda"):
             filter_file("^NVIDIA_INTERFACE.*", "NVIDIA_INTERFACE = true", "config.mk")
             filter_file("^BUILDAPPDAEMON.*", "BUILDAPPDAEMON = true", "config.mk")
             cudainc = spec["cuda"].prefix.include
@@ -206,7 +206,7 @@ class Likwid(Package):
         else:
             filter_file("^NVIDIA_INTERFACE.*", "NVIDIA_INTERFACE = false", "config.mk")
 
-        if "+rocm" in self.spec:
+        if self.spec.satisfies("+rocm"):
             env["ROCM_HOME"] = spec["rocm-core"].prefix
             filter_file("^ROCM_INTERFACE.*", "ROCM_INTERFACE = true", "config.mk")
             filter_file("^BUILDAPPDAEMON.*", "BUILDAPPDAEMON = true", "config.mk")
@@ -256,7 +256,7 @@ class Likwid(Package):
     # the build log.  See https://github.com/spack/spack/pull/10412.
     @run_after("install")
     def caveats(self):
-        if "accessmode=accessdaemon" in self.spec:
+        if self.spec.satisfies("accessmode=accessdaemon"):
             perm_script = "spack_perms_fix.sh"
             perm_script_path = join_path(self.spec.prefix, perm_script)
             daemons = glob.glob(join_path(self.spec.prefix, "sbin", "*"))

--- a/var/spack/repos/builtin/packages/linux-perf/package.py
+++ b/var/spack/repos/builtin/packages/linux-perf/package.py
@@ -137,20 +137,20 @@ class LinuxPerf(Package):
         if version >= Version("6.4"):
             args.append("BUILD_NONDISTRO=1")
 
-        if "+libaudit" in spec:
+        if spec.satisfies("+libaudit"):
             checks.add("libaudit")
             args.append("NO_SYSCALL_TABLE=1")  # will look for libaudit
         else:
             checks.add("syscall_table")
             args.append("NO_LIBAUDIT=1")
 
-        if "+debuginfod" in spec:
+        if spec.satisfies("+debuginfod"):
             if version >= Version("5.19"):  # Not in --build-options before that
                 checks.add("debuginfod")
         else:
             args.append("NO_LIBDEBUGINFOD=1")
 
-        if "+python" in spec:
+        if spec.satisfies("+python"):
             checks.add("libpython")
             args.extend(
                 [
@@ -161,22 +161,22 @@ class LinuxPerf(Package):
         else:
             args.append("NO_LIBPYTHON=1")
 
-        if "+perl" in spec:
+        if spec.satisfies("+perl"):
             checks.add("libperl")
         else:
             args.append("NO_LIBPERL=1")
 
-        if "+openssl" in spec:
+        if spec.satisfies("+openssl"):
             checks.add("libcrypto")
         else:
             args.append("NO_LIBCRYPTO=1")
 
-        if "+slang" in spec:
+        if spec.satisfies("+slang"):
             checks.add("libslang")
         else:
             args.append("NO_SLANG=1")
 
-        if "+libpfm4" in spec:
+        if spec.satisfies("+libpfm4"):
             checks.add("libpfm4")
             if version < Version("6.4"):
                 args.append("LIBPFM4=1")
@@ -184,35 +184,35 @@ class LinuxPerf(Package):
             if version >= Version("6.4"):
                 args.append("NO_LIBPFM4=1")
 
-        if "+babeltrace" in spec:
+        if spec.satisfies("+babeltrace"):
             # checks.add("babeltrace")  # Not in --build-options ?
             args.append("LIBBABELTRACE_DIR={}".format(spec["babeltrace"].prefix))
         else:
             args.append("NO_LIBBABELTRACE=1")
 
-        if "+libcap" in spec:
+        if spec.satisfies("+libcap"):
             # checks.add("libcap")  # Not in --build-options ?
             pass
         else:
             args.append("NO_LIBCAP=1")
 
-        if "+numactl" in spec:
+        if spec.satisfies("+numactl"):
             checks.add("libnuma")
         else:
             args.append("NO_LIBNUMA=1")
 
-        if "+xz" in spec:
+        if spec.satisfies("+xz"):
             checks.add("lzma")
         else:
             args.append("NO_LZMA=1")
 
-        if "+zstd" in spec:
+        if spec.satisfies("+zstd"):
             checks.add("zstd")
             args.append("LIBZSTD_DIR={}".format(spec["zstd"].prefix))
         else:
             args.append("NO_LIBZSTD=1")
 
-        if "+libtraceevent" in spec:
+        if spec.satisfies("+libtraceevent"):
             if version >= Version("6.2"):  # Not in --build-options before that
                 checks.add("libtraceevent")
             if version >= Version("6.10"):
@@ -223,7 +223,7 @@ class LinuxPerf(Package):
             if version >= Version("6.2"):
                 args.append("NO_LIBTRACEEVENT=1")
 
-        if "+jvmti" in spec:
+        if spec.satisfies("+jvmti"):
             # checks.add("jvmti")  # Not in --build-options ?
             args.append("JDIR={}".format(spec["java"].prefix))
         else:

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -229,7 +229,7 @@ class LlvmAmdgpu(CMakePackage, CompilerPackage):
         ]
 
         # Enable rocm-device-libs as a external project
-        if "+rocm-device-libs" in self.spec:
+        if self.spec.satisfies("+rocm-device-libs"):
             if self.spec.satisfies("@:6.0"):
                 dir = os.path.join(self.stage.source_path, "rocm-device-libs")
             elif self.spec.satisfies("@6.1:"):
@@ -242,10 +242,10 @@ class LlvmAmdgpu(CMakePackage, CompilerPackage):
                 ]
             )
 
-        if "+llvm_dylib" in self.spec:
+        if self.spec.satisfies("+llvm_dylib"):
             args.append(self.define("LLVM_BUILD_LLVM_DYLIB", True))
 
-        if "+link_llvm_dylib" in self.spec:
+        if self.spec.satisfies("+link_llvm_dylib"):
             args.append(self.define("LLVM_LINK_LLVM_DYLIB", True))
             args.append(self.define("CLANG_LINK_CLANG_DYLIB", True))
 

--- a/var/spack/repos/builtin/packages/llvm-doe/package.py
+++ b/var/spack/repos/builtin/packages/llvm-doe/package.py
@@ -309,7 +309,7 @@ class LlvmDoe(CMakePackage, CudaPackage):
         if self.spec.external:
             return self.spec.extra_attributes["compilers"].get("c", None)
         result = None
-        if "+clang" in self.spec:
+        if self.spec.satisfies("+clang"):
             result = os.path.join(self.spec.prefix.bin, "clang")
         return result
 
@@ -320,7 +320,7 @@ class LlvmDoe(CMakePackage, CudaPackage):
         if self.spec.external:
             return self.spec.extra_attributes["compilers"].get("cxx", None)
         result = None
-        if "+clang" in self.spec:
+        if self.spec.satisfies("+clang"):
             result = os.path.join(self.spec.prefix.bin, "clang++")
         return result
 
@@ -331,7 +331,7 @@ class LlvmDoe(CMakePackage, CudaPackage):
         if self.spec.external:
             return self.spec.extra_attributes["compilers"].get("fc", None)
         result = None
-        if "+flang" in self.spec:
+        if self.spec.satisfies("+flang"):
             result = os.path.join(self.spec.prefix.bin, "flang")
         return result
 
@@ -342,7 +342,7 @@ class LlvmDoe(CMakePackage, CudaPackage):
         if self.spec.external:
             return self.spec.extra_attributes["compilers"].get("f77", None)
         result = None
-        if "+flang" in self.spec:
+        if self.spec.satisfies("+flang"):
             result = os.path.join(self.spec.prefix.bin, "flang")
         return result
 
@@ -392,10 +392,10 @@ class LlvmDoe(CMakePackage, CudaPackage):
             env.prepend_path("PATH", self.stage.path)
 
     def setup_run_environment(self, env):
-        if "+clang" in self.spec:
+        if self.spec.satisfies("+clang"):
             env.set("CC", join_path(self.spec.prefix.bin, "clang"))
             env.set("CXX", join_path(self.spec.prefix.bin, "clang++"))
-        if "+flang" in self.spec:
+        if self.spec.satisfies("+flang"):
             env.set("FC", join_path(self.spec.prefix.bin, "flang"))
             env.set("F77", join_path(self.spec.prefix.bin, "flang"))
 
@@ -422,7 +422,7 @@ class LlvmDoe(CMakePackage, CudaPackage):
         projects = []
         runtimes = []
 
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             cmake_args.extend(
                 [
                     define("CUDA_TOOLKIT_ROOT_DIR", spec["cuda"].prefix),
@@ -436,7 +436,7 @@ class LlvmDoe(CMakePackage, CudaPackage):
                     ),
                 ]
             )
-            if "+omp_as_runtime" in spec:
+            if spec.satisfies("+omp_as_runtime"):
                 cmake_args.extend(
                     [
                         define("LIBOMPTARGET_NVPTX_ENABLE_BCLIB", True),
@@ -459,21 +459,21 @@ class LlvmDoe(CMakePackage, CudaPackage):
 
         cmake_args.append(from_variant("LIBOMPTARGET_ENABLE_DEBUG", "omp_debug"))
 
-        if "+lldb" in spec:
+        if spec.satisfies("+lldb"):
             if spec.version >= Version("10"):
                 cmake_args.append(from_variant("LLDB_ENABLE_PYTHON", "python"))
             else:
-                cmake_args.append(define("LLDB_DISABLE_PYTHON", "~python" in spec))
+                cmake_args.append(define("LLDB_DISABLE_PYTHON", spec.satisfies("~python")))
             if spec.satisfies("@5.0.0: +python"):
                 cmake_args.append(define("LLDB_USE_SYSTEM_SIX", True))
 
-        if "+gold" in spec:
+        if spec.satisfies("+gold"):
             cmake_args.append(define("LLVM_BINUTILS_INCDIR", spec["binutils"].prefix.include))
 
-        if "+clang" in spec:
+        if spec.satisfies("+clang"):
             projects.append("clang")
             projects.append("clang-tools-extra")
-            if "+omp_as_runtime" in spec:
+            if spec.satisfies("+omp_as_runtime"):
                 runtimes.append("openmp")
             else:
                 projects.append("openmp")
@@ -485,22 +485,22 @@ class LlvmDoe(CMakePackage, CudaPackage):
             if self.spec.satisfies("@9:"):
                 cmake_args.append(define("LLVM_ENABLE_Z3_SOLVER", self.spec.satisfies("@9:+z3")))
 
-        if "+flang" in spec:
+        if spec.satisfies("+flang"):
             projects.append("flang")
-        if "+lldb" in spec:
+        if spec.satisfies("+lldb"):
             projects.append("lldb")
-        if "+lld" in spec:
+        if spec.satisfies("+lld"):
             projects.append("lld")
-        if "+compiler-rt" in spec:
+        if spec.satisfies("+compiler-rt"):
             projects.append("compiler-rt")
-        if "+libcxx" in spec:
+        if spec.satisfies("+libcxx"):
             projects.append("libcxx")
             projects.append("libcxxabi")
-        if "+mlir" in spec:
+        if spec.satisfies("+mlir"):
             projects.append("mlir")
-        if "+internal_unwind" in spec:
+        if spec.satisfies("+internal_unwind"):
             projects.append("libunwind")
-        if "+polly" in spec:
+        if spec.satisfies("+polly"):
             projects.append("polly")
             cmake_args.append(define("LINK_POLLY_INTO_TOOLS", True))
 
@@ -544,7 +544,7 @@ class LlvmDoe(CMakePackage, CudaPackage):
             projects.remove("openmp")
             projects.append("bolt")
             cmake_args.append("-DLIBOMP_USE_BOLT_DEFAULT=ON")
-            if "+argobots" in spec and spec.satisfies("@bolt"):
+            if spec.satisfies("+argobots") and spec.satisfies("@bolt"):
                 cmake_args.append("-DLIBOMP_USE_ARGOBOTS=ON")
 
         if self.compiler.name == "gcc":
@@ -571,7 +571,7 @@ class LlvmDoe(CMakePackage, CudaPackage):
         define = self.define
 
         # unnecessary if we build openmp via LLVM_ENABLE_RUNTIMES
-        if "+cuda ~omp_as_runtime" in self.spec:
+        if self.spec.satisfies("+cuda ~omp_as_runtime"):
             ompdir = "build-bootstrapped-omp"
             prefix_paths = spack.build_environment.get_cmake_prefix_path(self)
             prefix_paths.append(str(spec.prefix))
@@ -600,10 +600,10 @@ class LlvmDoe(CMakePackage, CudaPackage):
                 cmake(*cmake_args)
                 ninja()
                 ninja("install")
-        if "+python" in self.spec:
+        if self.spec.satisfies("+python"):
             install_tree("llvm/bindings/python", python_platlib)
 
-            if "+clang" in self.spec:
+            if self.spec.satisfies("+clang"):
                 install_tree("clang/bindings/python", python_platlib)
 
         with working_dir(self.build_directory):

--- a/var/spack/repos/builtin/packages/llvm-openmp-ompt/package.py
+++ b/var/spack/repos/builtin/packages/llvm-openmp-ompt/package.py
@@ -61,7 +61,7 @@ class LlvmOpenmpOmpt(CMakePackage):
         # Build llvm-openmp-ompt as a stand alone library
         # CMAKE rpath variable prevents standalone error
         # where this package wants the llvm tools path
-        if "+standalone" in self.spec:
+        if self.spec.satisfies("+standalone"):
             cmake_args.extend(
                 [
                     "-DLIBOMP_STANDALONE_BUILD=true",
@@ -72,11 +72,11 @@ class LlvmOpenmpOmpt(CMakePackage):
 
         # Build llvm-openmp-ompt using the tr6_forwards branch
         # This requires the version to be 5.0 (50)
-        if "@tr6_forwards" in self.spec:
+        if self.spec.satisfies("@tr6_forwards"):
             cmake_args.extend(["-DLIBOMP_OMP_VERSION=50"])
 
         # Disable support for libomptarget
-        if "~libomptarget" in self.spec:
+        if self.spec.satisfies("~libomptarget"):
             cmake_args.extend(["-DOPENMP_ENABLE_LIBOMPTARGET=OFF"])
 
         return cmake_args

--- a/var/spack/repos/builtin/packages/loki/package.py
+++ b/var/spack/repos/builtin/packages/loki/package.py
@@ -31,14 +31,14 @@ class Loki(MakefilePackage):
         return (flags, None, None)
 
     def build(self, spec, prefix):
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             make("-C", "src", "build-shared")
         else:
             make("-C", "src", "build-static")
 
     def install(self, spec, prefix):
         make("-C", "include", "install", "prefix={0}".format(prefix))
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             make("-C", "src", "install-shared", "prefix={0}".format(prefix))
         else:
             make("-C", "src", "install-static", "prefix={0}".format(prefix))

--- a/var/spack/repos/builtin/packages/lorene/package.py
+++ b/var/spack/repos/builtin/packages/lorene/package.py
@@ -41,8 +41,8 @@ class Lorene(MakefilePackage):
 
     def edit(self, spec, prefix):
         blas_libs = spec["blas"].libs.link_flags
-        fftw_incdirs = "-I" + spec["fftw"].prefix.include if "+fftw" in spec else ""
-        fftw_libdirs = "-L" + spec["fftw"].prefix.lib if "+fftw" in spec else ""
+        fftw_incdirs = "-I" + spec["fftw"].prefix.include if spec.satisfies("+fftw") else ""
+        fftw_libdirs = "-L" + spec["fftw"].prefix.lib if spec.satisfies("+fftw") else ""
         fftw_libs = spec["fftw"].libs.link_flags
         gsl_incdirs = "-I" + spec["gsl"].prefix.include
         gsl_libdirs = "-L" + spec["gsl"].prefix.lib
@@ -91,7 +91,7 @@ class Lorene(MakefilePackage):
         # (We could circumvent the build system and simply compile all
         # source files, and do so in parallel.)
         make("cpp", "fortran", "export", *args)
-        if "+bin_star" in spec:
+        if spec.satisfies("+bin_star"):
             with working_dir(join_path("Codes", "Bin_star")):
                 make(
                     "-f",
@@ -111,7 +111,7 @@ class Lorene(MakefilePackage):
         install_tree("Export/C++/Include", prefix.include)
         install_tree("C++/Include", prefix.include)
         mkdirp(prefix.bin)
-        if "+bin_star" in spec:
+        if spec.satisfies("+bin_star"):
             for exe in [
                 "coal",
                 "lit_bin",
@@ -125,5 +125,5 @@ class Lorene(MakefilePackage):
 
     @property
     def libs(self):
-        shared = "+shared" in self.spec
+        shared = self.spec.satisfies("+shared")
         return find_libraries("liblorene*", root=self.prefix, shared=shared, recursive=True)

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -259,7 +259,7 @@ class Lua(LuaImplPackage):
     def install(self, spec, prefix):
         make("INSTALL_TOP=%s" % prefix, "install")
 
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             static_to_shared_library(
                 join_path(prefix.lib, "liblua.a"),
                 arguments=["-lm", "-ldl"],
@@ -269,7 +269,7 @@ class Lua(LuaImplPackage):
 
         # compatibility with ax_lua.m4 from autoconf-archive
         # https://www.gnu.org/software/autoconf-archive/ax_lua.html
-        if "+shared" in spec:
+        if spec.satisfies("+shared"):
             with working_dir(prefix.lib):
                 # e.g., liblua.so.5.1.5
                 src_path = "liblua.{0}.{1}".format(dso_suffix, str(self.version.up_to(3)))
@@ -290,7 +290,7 @@ class Lua(LuaImplPackage):
 
     @run_after("install")
     def link_pkg_config(self):
-        if "+pcfile" in self.spec:
+        if self.spec.satisfies("+pcfile"):
             versioned_pc_file_name = "lua{0}.pc".format(self.version.up_to(2))
             symlink(
                 join_path(self.prefix.lib, "pkgconfig", versioned_pc_file_name),

--- a/var/spack/repos/builtin/packages/lulesh/package.py
+++ b/var/spack/repos/builtin/packages/lulesh/package.py
@@ -33,19 +33,19 @@ class Lulesh(MakefilePackage):
         targets = []
         cxxflag = " -g -O3 -I. "
         ldflags = " -g -O3 "
-        if "~mpi" in self.spec:
+        if self.spec.satisfies("~mpi"):
             targets.append("CXX = {0} {1}".format(spack_cxx, " -DUSE_MPI=0 "))
         else:
             targets.append("CXX = {0} {1}".format(self.spec["mpi"].mpicxx, " -DUSE_MPI=1"))
             targets.append("MPI_INC = {0}".format(self.spec["mpi"].prefix.include))
             targets.append("MPI_LIB = {0}".format(self.spec["mpi"].prefix.lib))
-        if "+visual" in self.spec:
+        if self.spec.satisfies("+visual"):
             targets.append("SILO_INCDIR = {0}".format(self.spec["silo"].prefix.include))
             targets.append("SILO_LIBDIR = {0}".format(self.spec["silo"].prefix.lib))
             cxxflag = " -g -DVIZ_MESH -I${SILO_INCDIR} "
             ldflags = " -g -L${SILO_LIBDIR} -Wl,-rpath=${SILO_LIBDIR} -lsiloh5 -lhdf5 "
 
-        if "+openmp" in self.spec:
+        if self.spec.satisfies("+openmp"):
             cxxflag += self.compiler.openmp_flag
             ldflags += self.compiler.openmp_flag
 

--- a/var/spack/repos/builtin/packages/lvarray/package.py
+++ b/var/spack/repos/builtin/packages/lvarray/package.py
@@ -105,7 +105,7 @@ class Lvarray(CMakePackage, CudaPackage):
 
     @run_after("build")
     def build_docs(self):
-        if "+docs" in self.spec:
+        if self.spec.satisfies("+docs"):
             with working_dir(self.build_directory):
                 make("docs")
 
@@ -118,7 +118,7 @@ class Lvarray(CMakePackage, CudaPackage):
 
     def _get_host_config_path(self, spec):
         var = ""
-        if "+cuda" in spec:
+        if spec.satisfies("+cuda"):
             var = "-".join([var, "cuda"])
 
         hostname = socket.gethostname().rstrip("1234567890")
@@ -182,7 +182,7 @@ class Lvarray(CMakePackage, CudaPackage):
             cfg.write("# CMake executable path: %s\n" % cmake_exe)
             cfg.write("#{0}\n\n".format("-" * 80))
 
-            if "blt" in spec:
+            if spec.satisfies("^blt"):
                 cfg.write(cmake_cache_entry("BLT_SOURCE_DIR", spec["blt"].prefix))
 
             #######################
@@ -199,7 +199,7 @@ class Lvarray(CMakePackage, CudaPackage):
             cflags = " ".join(spec.compiler_flags["cflags"])
             cxxflags = " ".join(spec.compiler_flags["cxxflags"])
 
-            if "%intel" in spec:
+            if spec.satisfies("%intel"):
                 cflags += " -qoverride-limits"
                 cxxflags += " -qoverride-limits"
 
@@ -216,10 +216,10 @@ class Lvarray(CMakePackage, CudaPackage):
             debug_flags = "-O0 -g"
             cfg.write(cmake_cache_string("CMAKE_CXX_FLAGS_DEBUG", debug_flags))
 
-            if "%clang arch=linux-rhel7-ppc64le" in spec:
+            if spec.satisfies("%clang arch=linux-rhel7-ppc64le"):
                 cfg.write(cmake_cache_entry("CMAKE_EXE_LINKER_FLAGS", "-Wl,--no-toc-optimize"))
 
-            if "+cuda" in spec:
+            if spec.satisfies("+cuda"):
                 cfg.write("#{0}\n".format("-" * 80))
                 cfg.write("# Cuda\n")
                 cfg.write("#{0}\n\n".format("-" * 80))
@@ -279,7 +279,7 @@ class Lvarray(CMakePackage, CudaPackage):
             cfg.write("# Umpire\n")
             cfg.write("#{0}\n\n".format("-" * 80))
 
-            if "+umpire" in spec:
+            if spec.satisfies("+umpire"):
                 cfg.write(cmake_cache_option("ENABLE_UMPIRE", True))
                 cfg.write(cmake_cache_entry("UMPIRE_DIR", spec["umpire"].prefix))
             else:
@@ -289,7 +289,7 @@ class Lvarray(CMakePackage, CudaPackage):
             cfg.write("# CHAI\n")
             cfg.write("#{0}\n\n".format("-" * 80))
 
-            if "+chai" in spec:
+            if spec.satisfies("+chai"):
                 cfg.write(cmake_cache_option("ENABLE_CHAI", True))
                 cfg.write(cmake_cache_entry("CHAI_DIR", spec["chai"].prefix))
             else:
@@ -299,7 +299,7 @@ class Lvarray(CMakePackage, CudaPackage):
             cfg.write("# Caliper\n")
             cfg.write("#{0}\n\n".format("-" * 80))
 
-            if "+caliper" in spec:
+            if spec.satisfies("+caliper"):
                 cfg.write("#{0}\n".format("-" * 80))
                 cfg.write("# Caliper\n")
                 cfg.write("#{0}\n\n".format("-" * 80))
@@ -312,7 +312,7 @@ class Lvarray(CMakePackage, CudaPackage):
             cfg.write("#{0}\n".format("-" * 80))
             cfg.write("# Python\n")
             cfg.write("#{0}\n\n".format("-" * 80))
-            if "+pylvarray" in spec:
+            if spec.satisfies("+pylvarray"):
                 cfg.write(cmake_cache_option("ENABLE_PYLVARRAY", True))
                 python_exe = os.path.join(spec["python"].prefix.bin, "python3")
                 cfg.write(cmake_cache_entry("Python3_EXECUTABLE", python_exe))
@@ -322,7 +322,7 @@ class Lvarray(CMakePackage, CudaPackage):
             cfg.write("#{0}\n".format("-" * 80))
             cfg.write("# Documentation\n")
             cfg.write("#{0}\n\n".format("-" * 80))
-            if "+docs" in spec:
+            if spec.satisfies("+docs"):
                 cfg.write(cmake_cache_option("ENABLE_DOCS", True))
                 sphinx_dir = spec["py-sphinx"].prefix
                 cfg.write(
@@ -343,7 +343,7 @@ class Lvarray(CMakePackage, CudaPackage):
             cfg.write("#{0}\n".format("-" * 80))
             cfg.write("# addr2line\n")
             cfg.write("#{0}\n\n".format("-" * 80))
-            cfg.write(cmake_cache_option("ENABLE_ADDR2LINE", "+addr2line" in spec))
+            cfg.write(cmake_cache_option("ENABLE_ADDR2LINE", spec.satisfies("+addr2line")))
 
             cfg.write("#{0}\n".format("-" * 80))
             cfg.write("# Other\n")
@@ -359,14 +359,14 @@ class Lvarray(CMakePackage, CudaPackage):
         # Shared libs
         options.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
 
-        if "~tests~examples~benchmarks" in spec:
+        if spec.satisfies("~tests~examples~benchmarks"):
             options.append("-DENABLE_TESTS=OFF")
         else:
             options.append("-DENABLE_TESTS=ON")
 
-        if "~test" in spec:
+        if spec.satisfies("~test"):
             options.append("-DDISABLE_UNIT_TESTS=ON")
-        elif "+tests" in spec and ("%intel" in spec or "%xl" in spec):
+        elif spec.satisfies("+tests") and (spec.satisfies("%intel") or spec.satisfies("%xl")):
             warnings.warn(
                 "The LvArray unit tests take an excessive amount of"
                 " time to build with the Intel or IBM compilers."

--- a/var/spack/repos/builtin/packages/lz4/package.py
+++ b/var/spack/repos/builtin/packages/lz4/package.py
@@ -74,13 +74,13 @@ class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
         args = [self.define("CMAKE_POLICY_DEFAULT_CMP0042", "NEW")]
         # # no pic on windows
-        if "platform=windows" in self.spec:
+        if self.spec.satisfies("platform=windows"):
             args.append(self.define("LZ4_POSITION_INDEPENDENT_LIB", False))
         args.append(
-            self.define("BUILD_SHARED_LIBS", True if "libs=shared" in self.spec else False)
+            self.define("BUILD_SHARED_LIBS", True if self.spec.satisfies("libs=shared") else False)
         )
         args.append(
-            self.define("BUILD_STATIC_LIBS", True if "libs=static" in self.spec else False)
+            self.define("BUILD_STATIC_LIBS", True if self.spec.satisfies("libs=static") else False)
         )
         args.append(self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"))
         return args
@@ -107,8 +107,8 @@ class MakefileBuilder(MakefileBuilder):
         make(
             "install",
             "PREFIX={0}".format(prefix),
-            "BUILD_SHARED={0}".format("yes" if "libs=shared" in self.spec else "no"),
-            "BUILD_STATIC={0}".format("yes" if "libs=static" in self.spec else "no"),
+            "BUILD_SHARED={0}".format("yes" if self.spec.satisfies("libs=shared") else "no"),
+            "BUILD_STATIC={0}".format("yes" if self.spec.satisfies("libs=static") else "no"),
         )
 
     @run_after("install", when="platform=darwin")


### PR DESCRIPTION
with the structure` if "+variant" in spec:`, checks like `if "mpi" in spec:` would be valid whereas it could be `~mpi` or `+mpi`. `satisfies` adds additional checks to avoid mistakes from the user.