### PR TITLE
py-onnx: Fix builds with GCC 14

### DIFF
--- a/var/spack/repos/builtin/packages/py-onnx/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx/package.py
@@ -56,7 +56,11 @@ class PyOnnx(PythonPackage):
     # https://github.com/protocolbuffers/protobuf/pull/8794, fixed in
     # https://github.com/onnx/onnx/pull/3112
     depends_on("py-protobuf@:3.17", type=("build", "run"), when="@:1.8")
-    depends_on("py-protobuf+cpp", type=("build", "run"))
+
+    depends_on("py-protobuf+cpp", type=("build", "run"), when="%gcc@:13")
+    depends_on("py-protobuf+cpp", type=("build", "run"), when="%clang")
+    depends_on("protobuf", type=("build", "run"), when="%gcc@14:")
+
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-numpy@1.16.6:", type=("build", "run"), when="@1.8.1:1.13")
     depends_on("py-numpy@1.20:", type=("build", "run"), when="@1.16.0:")

--- a/var/spack/repos/builtin/packages/py-onnx/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx/package.py
@@ -59,6 +59,8 @@ class PyOnnx(PythonPackage):
 
     depends_on("py-protobuf+cpp", type=("build", "run"), when="%gcc@:13")
     depends_on("py-protobuf+cpp", type=("build", "run"), when="%clang")
+    # Depending on protobuf is necessary to avoid compilation of the
+    # vendored protobuf sources
     depends_on("protobuf", type=("build", "run"), when="%gcc@14:")
 
     depends_on("py-numpy", type=("build", "run"))


### PR DESCRIPTION
Right now it is impossible to build with GCC 14 because
- `py-onnx` deponds on `py-protobuf+cpp`
- `py-protobuf` has a conflict with GCC 14 with `+cpp`

so I added some ranges not to use `+cpp` with GCC 14 and onwards.

Then, there is a second change in the PR that is not needed for the above: the `protobuf` dependency is needed because `py-onnx` tries to find the `protoc` compiler and if it doesn't find it will try to download and compile a version of protobuf that doesn't compile with GCC 14. With these changes I can compile 1.16.2 with GCC 14. 

I'm not sure if we should also pin the versions of py-protobuf and protobuf since this allows different versions to live together.