### PR TITLE
gmsh: missing dependencies take 2, spack/spack#46326

### DIFF
--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -80,6 +80,9 @@ class Gmsh(CMakePackage):
 
     # https://gmsh.info/doc/texinfo/gmsh.html#Compiling-the-source-code
     # We make changes to the GMSH default, such as external blas.
+    depends_on("libpng", when="+fltk")
+    depends_on("libjpeg-turbo", when="+fltk")
+    depends_on("zlib-api")
     depends_on("blas", when="~eigen")
     depends_on("lapack", when="~eigen")
     depends_on("eigen@3:", when="+eigen+external")


### PR DESCRIPTION
up fix for missing dependencies in gmsh spack/spack#46326 and feelpp/spack#3

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
