### PR TITLE
qt: add v5.15.15

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -32,6 +32,7 @@ class Qt(Package):
 
     license("LGPL-3.0-only")
 
+    version("5.15.15", sha256="b423c30fe3ace7402e5301afbb464febfb3da33d6282a37a665be1e51502335e")
     version("5.15.14", sha256="fdd3a4f197d2c800ee0085c721f4bef60951cbda9e9c46e525d1412f74264ed7")
     version("5.15.13", sha256="9550ec8fc758d3d8d9090e261329700ddcd712e2dda97e5fcfeabfac22bea2ca")
     version("5.15.12", sha256="93f2c0889ee2e9cdf30c170d353c3f829de5f29ba21c119167dee5995e48ccce")


### PR DESCRIPTION
This PR adds `qt`, v5.15.15. Diff at https://github.com/qt/qtbase/compare/v5.15.14-lts-lgpl...v5.15.15-lts-lgpl; no changes needed. Patch for `@5.15.14: %oneapi` should still apply.

Successfully built in CI at https://gitlab.spack.io/spack/spack/-/jobs/12546880.