### PR TITLE
Add missing & remove redundant imports

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -53,7 +53,6 @@ import llnl.util.lang
 
 import spack.config
 import spack.patch
-import spack.paths
 import spack.repo
 import spack.spec
 import spack.util.crypto

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -33,7 +33,6 @@ from llnl.util.filesystem import BaseDirectoryVisitor, mkdirp, visit_directory_t
 from llnl.util.symlink import readlink
 
 import spack.caches
-import spack.cmd
 import spack.config as config
 import spack.database as spack_db
 import spack.error
@@ -47,7 +46,6 @@ import spack.oci.opener
 import spack.paths
 import spack.platforms
 import spack.relocate as relocate
-import spack.repo
 import spack.spec
 import spack.stage
 import spack.store

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -37,16 +37,10 @@ from llnl.util.lang import GroupedExceptionHandler
 import spack.binary_distribution
 import spack.config
 import spack.detection
-import spack.environment
-import spack.modules
-import spack.paths
 import spack.platforms
-import spack.platforms.linux
-import spack.repo
 import spack.spec
 import spack.store
 import spack.user_environment
-import spack.util.environment
 import spack.util.executable
 import spack.util.path
 import spack.util.spack_yaml

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -15,8 +15,6 @@ from llnl.util import tty
 
 import spack.environment
 import spack.tengine
-import spack.util.cpus
-import spack.util.executable
 
 from ._common import _root_spec
 from .config import root_path, spec_for_current_python, store_path

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -65,16 +65,12 @@ import spack.main
 import spack.package_base
 import spack.paths
 import spack.platforms
-import spack.repo
 import spack.schema.environment
 import spack.spec
 import spack.stage
 import spack.store
 import spack.subprocess_context
-import spack.user_environment
 import spack.util.executable
-import spack.util.path
-import spack.util.pattern
 from spack import traverse
 from spack.context import Context
 from spack.error import NoHeadersError, NoLibrariesError

--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -11,7 +11,6 @@ import llnl.util.lang
 from llnl.util.filesystem import mkdirp
 
 import spack.config
-import spack.error
 import spack.fetch_strategy
 import spack.paths
 import spack.util.file_cache

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -38,7 +38,6 @@ import spack.mirror
 import spack.paths
 import spack.repo
 import spack.spec
-import spack.stage
 import spack.util.git
 import spack.util.gpg as gpg_util
 import spack.util.spack_yaml as syaml

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -16,7 +16,6 @@ import spack.bootstrap
 import spack.bootstrap.config
 import spack.bootstrap.core
 import spack.config
-import spack.main
 import spack.mirror
 import spack.spec
 import spack.stage

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -23,14 +23,9 @@ import spack.environment as ev
 import spack.error
 import spack.mirror
 import spack.oci.oci
-import spack.oci.opener
-import spack.relocate
-import spack.repo
 import spack.spec
 import spack.stage
 import spack.store
-import spack.user_environment
-import spack.util.crypto
 import spack.util.parallel
 import spack.util.url as url_util
 import spack.util.web as web_util

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -15,7 +15,6 @@ import spack.cmd
 import spack.repo
 import spack.spec
 import spack.stage
-import spack.util.crypto
 import spack.util.web as web_util
 from spack.cmd.common import arguments
 from spack.package_base import (

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -19,7 +19,6 @@ import spack.cmd
 import spack.cmd.buildcache as buildcache
 import spack.config as cfg
 import spack.environment as ev
-import spack.environment.depfile
 import spack.hash_types as ht
 import spack.mirror
 import spack.util.gpg as gpg_util

--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -10,11 +10,8 @@ import shutil
 import llnl.util.filesystem
 import llnl.util.tty as tty
 
-import spack.bootstrap
 import spack.caches
-import spack.cmd.test
 import spack.config
-import spack.repo
 import spack.stage
 import spack.store
 import spack.util.path

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -15,7 +15,6 @@ import spack.config
 import spack.deptypes as dt
 import spack.environment as ev
 import spack.mirror
-import spack.modules
 import spack.reporters
 import spack.spec
 import spack.store

--- a/lib/spack/spack/cmd/common/env_utility.py
+++ b/lib/spack/spack/cmd/common/env_utility.py
@@ -10,7 +10,6 @@ import llnl.util.tty as tty
 import spack.cmd
 import spack.deptypes as dt
 import spack.error
-import spack.paths
 import spack.spec
 import spack.store
 from spack import build_environment, traverse

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -13,9 +13,7 @@ import llnl.util.tty as tty
 
 import spack.config
 import spack.environment as ev
-import spack.repo
 import spack.schema.env
-import spack.schema.packages
 import spack.store
 import spack.util.spack_yaml as syaml
 from spack.cmd.common import arguments

--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -13,7 +13,6 @@ from llnl.util.filesystem import mkdirp
 
 import spack.repo
 import spack.stage
-import spack.util.web
 from spack.spec import Spec
 from spack.url import (
     UndetectableNameError,

--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -14,7 +14,6 @@ import llnl.util.tty as tty
 from llnl.util.filesystem import working_dir
 
 import spack
-import spack.config
 import spack.paths
 import spack.platforms
 import spack.util.git

--- a/lib/spack/spack/cmd/dependencies.py
+++ b/lib/spack/spack/cmd/dependencies.py
@@ -11,7 +11,6 @@ from llnl.util.tty.colify import colify
 import spack.cmd
 import spack.environment as ev
 import spack.package_base
-import spack.repo
 import spack.store
 from spack.cmd.common import arguments
 

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -10,7 +10,6 @@ import llnl.util.tty as tty
 import spack.cmd
 import spack.config
 import spack.fetch_strategy
-import spack.package_base
 import spack.repo
 import spack.spec
 import spack.stage

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -12,7 +12,6 @@ from llnl.util.tty.color import cprint, get_color_when
 import spack.cmd
 import spack.environment as ev
 import spack.solver.asp as asp
-import spack.util.environment
 import spack.util.spack_json as sjson
 from spack.cmd.common import arguments
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -21,15 +21,11 @@ from llnl.util.tty.color import cescape, colorize
 import spack.cmd
 import spack.cmd.common
 import spack.cmd.common.arguments
-import spack.cmd.install
 import spack.cmd.modules
-import spack.cmd.uninstall
 import spack.config
 import spack.environment as ev
 import spack.environment.depfile as depfile
 import spack.environment.shell
-import spack.schema.env
-import spack.spec
 import spack.tengine
 from spack.cmd.common import arguments
 from spack.util.environment import EnvironmentModifications

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -20,7 +20,6 @@ import spack.detection
 import spack.error
 import spack.repo
 import spack.spec
-import spack.util.environment
 from spack.cmd.common import arguments
 
 description = "manage external packages in Spack configuration"

--- a/lib/spack/spack/cmd/fetch.py
+++ b/lib/spack/spack/cmd/fetch.py
@@ -8,7 +8,6 @@ import llnl.util.tty as tty
 import spack.cmd
 import spack.config
 import spack.environment as ev
-import spack.repo
 import spack.traverse
 from spack.cmd.common import arguments
 

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -10,7 +10,6 @@ import llnl.util.lang
 import llnl.util.tty as tty
 import llnl.util.tty.color as color
 
-import spack.bootstrap
 import spack.cmd as cmd
 import spack.environment as ev
 import spack.repo

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -17,8 +17,6 @@ import spack.build_environment
 import spack.cmd
 import spack.config
 import spack.environment as ev
-import spack.fetch_strategy
-import spack.package_base
 import spack.paths
 import spack.report
 import spack.spec

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -6,11 +6,9 @@
 import sys
 
 import spack.cmd
-import spack.cmd.find
 import spack.environment as ev
 import spack.store
 import spack.user_environment as uenv
-import spack.util.environment
 from spack.cmd.common import arguments
 
 description = "add package to the user environment"

--- a/lib/spack/spack/cmd/mark.py
+++ b/lib/spack/spack/cmd/mark.py
@@ -8,9 +8,6 @@ import sys
 from llnl.util import tty
 
 import spack.cmd
-import spack.error
-import spack.package_base
-import spack.repo
 import spack.store
 from spack.cmd.common import arguments
 from spack.database import InstallStatuses

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -17,7 +17,6 @@ import spack.environment as ev
 import spack.mirror
 import spack.repo
 import spack.spec
-import spack.util.path
 import spack.util.web as web_util
 from spack.cmd.common import arguments
 from spack.error import SpackError

--- a/lib/spack/spack/cmd/patch.py
+++ b/lib/spack/spack/cmd/patch.py
@@ -9,7 +9,6 @@ import spack.cmd
 import spack.config
 import spack.environment as ev
 import spack.package_base
-import spack.repo
 import spack.traverse
 from spack.cmd.common import arguments
 

--- a/lib/spack/spack/cmd/pkg.py
+++ b/lib/spack/spack/cmd/pkg.py
@@ -12,7 +12,6 @@ import llnl.util.tty as tty
 from llnl.util.tty.colify import colify
 
 import spack.cmd
-import spack.paths
 import spack.repo
 import spack.util.executable as exe
 import spack.util.package_hash as ph

--- a/lib/spack/spack/cmd/restage.py
+++ b/lib/spack/spack/cmd/restage.py
@@ -6,7 +6,6 @@
 import llnl.util.tty as tty
 
 import spack.cmd
-import spack.repo
 from spack.cmd.common import arguments
 
 description = "revert checked out package source code"

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -15,7 +15,6 @@ import spack.cmd
 import spack.config
 import spack.environment
 import spack.hash_types as ht
-import spack.package_base
 import spack.solver.asp as asp
 from spack.cmd.common import arguments
 

--- a/lib/spack/spack/cmd/stage.py
+++ b/lib/spack/spack/cmd/stage.py
@@ -11,8 +11,6 @@ import spack.cmd
 import spack.config
 import spack.environment as ev
 import spack.package_base
-import spack.repo
-import spack.stage
 import spack.traverse
 from spack.cmd.common import arguments
 

--- a/lib/spack/spack/cmd/tags.py
+++ b/lib/spack/spack/cmd/tags.py
@@ -10,7 +10,6 @@ import llnl.util.tty as tty
 import llnl.util.tty.colify as colify
 
 import spack.repo
-import spack.store
 import spack.tag
 
 description = "show package tags and associated packages"

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -17,7 +17,6 @@ from llnl.util.tty import colify
 import spack.cmd
 import spack.environment as ev
 import spack.install_test
-import spack.package_base
 import spack.repo
 import spack.report
 from spack.cmd.common import arguments

--- a/lib/spack/spack/cmd/unload.py
+++ b/lib/spack/spack/cmd/unload.py
@@ -9,7 +9,6 @@ import sys
 import spack.cmd
 import spack.error
 import spack.user_environment as uenv
-import spack.util.environment
 from spack.cmd.common import arguments
 
 description = "remove package from the user environment"

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -25,7 +25,6 @@ import spack.paths
 import spack.platforms
 import spack.repo
 import spack.spec
-import spack.version
 from spack.operating_systems import windows_os
 from spack.util.environment import get_path
 from spack.util.naming import mod_to_class

--- a/lib/spack/spack/compilers/apple_clang.py
+++ b/lib/spack/spack/compilers/apple_clang.py
@@ -8,7 +8,6 @@ import llnl.util.lang
 
 import spack.compiler
 import spack.compilers.clang
-import spack.util.executable
 from spack.version import Version
 
 

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -8,16 +8,8 @@
 from contextlib import contextmanager
 from itertools import chain
 
-import spack.compilers
 import spack.config
-import spack.environment
 import spack.error
-import spack.platforms
-import spack.repo
-import spack.spec
-import spack.target
-import spack.tengine
-import spack.util.path
 
 CHECK_COMPILER_EXISTENCE = True
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -40,10 +40,8 @@ import llnl.util.lang
 import llnl.util.tty.color
 
 import spack.deptypes as dt
-import spack.error
 import spack.patch
 import spack.spec
-import spack.url
 import spack.util.crypto
 import spack.variant
 from spack.dependency import Dependency

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -46,7 +46,6 @@ from llnl.util.symlink import symlink
 import spack.config
 import spack.error
 import spack.oci.opener
-import spack.url
 import spack.util.archive
 import spack.util.crypto as crypto
 import spack.util.git

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -17,12 +17,21 @@ from typing import Callable, List, Optional, Tuple, Type, TypeVar, Union
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
+import llnl.util.tty.log
 from llnl.string import plural
 from llnl.util.lang import nullcontext
 from llnl.util.tty.color import colorize
 
+import spack.build_environment
+import spack.builder
+import spack.config
 import spack.error
+import spack.package_base
 import spack.paths
+import spack.repo
+import spack.spec
+import spack.util.executable
+import spack.util.path
 import spack.util.spack_json as sjson
 from spack.installer import InstallError
 from spack.spec import Spec
@@ -42,7 +51,7 @@ spack_install_test_log = "install-time-test-log.txt"
 
 
 ListOrStringType = Union[str, List[str]]
-LogType = Union["tty.log.nixlog", "tty.log.winlog"]
+LogType = Union[llnl.util.tty.log.nixlog, llnl.util.tty.log.winlog]
 
 Pb = TypeVar("Pb", bound="spack.package_base.PackageBase")
 PackageObjectOrClass = Union[Pb, Type[Pb]]
@@ -280,7 +289,7 @@ class PackageTest:
     def logger(self) -> Optional[LogType]:
         """The current logger or, if none, sets to one."""
         if not self._logger:
-            self._logger = tty.log.log_output(self.test_log_file)
+            self._logger = llnl.util.tty.log.log_output(self.test_log_file)
 
         return self._logger
 
@@ -297,7 +306,7 @@ class PackageTest:
         fs.touch(self.test_log_file)  # Otherwise log_parse complains
         fs.set_install_permissions(self.test_log_file)
 
-        with tty.log.log_output(self.test_log_file, verbose) as self._logger:
+        with llnl.util.tty.log.log_output(self.test_log_file, verbose) as self._logger:
             with self.logger.force_echo():  # type: ignore[union-attr]
                 tty.msg("Testing package " + colorize(r"@*g{" + self.pkg_id + r"}"))
 

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -48,7 +48,6 @@ from llnl.util.tty.log import log_output
 
 import spack.binary_distribution as binary_distribution
 import spack.build_environment
-import spack.compilers
 import spack.config
 import spack.database
 import spack.deptypes as dt

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -40,7 +40,6 @@ import spack.modules
 import spack.paths
 import spack.platforms
 import spack.repo
-import spack.solver.asp
 import spack.spec
 import spack.store
 import spack.util.debug

--- a/lib/spack/spack/oci/oci.py
+++ b/lib/spack/spack/oci/oci.py
@@ -15,16 +15,10 @@ from urllib.request import Request
 
 import llnl.util.tty as tty
 
-import spack.config
-import spack.error
 import spack.fetch_strategy
 import spack.mirror
 import spack.oci.opener
-import spack.repo
-import spack.spec
 import spack.stage
-import spack.traverse
-import spack.util.crypto
 import spack.util.url
 
 from .image import Digest, ImageReference

--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -22,7 +22,6 @@ import llnl.util.lang
 import spack.config
 import spack.mirror
 import spack.parser
-import spack.repo
 import spack.util.web
 
 from .image import ImageReference

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -38,16 +38,13 @@ import spack.config
 import spack.dependency
 import spack.deptypes as dt
 import spack.directives
-import spack.directory_layout
 import spack.environment
 import spack.error
 import spack.fetch_strategy as fs
 import spack.hooks
 import spack.mirror
-import spack.mixins
 import spack.multimethod
 import spack.patch
-import spack.paths
 import spack.repo
 import spack.spec
 import spack.store

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -17,15 +17,11 @@ import llnl.util.tty as tty
 from llnl.util.lang import memoized
 from llnl.util.symlink import readlink, symlink
 
-import spack.paths
 import spack.platforms
-import spack.repo
-import spack.spec
 import spack.store
 import spack.util.elf as elf
 import spack.util.executable as executable
 import spack.util.filesystem as ssys
-import spack.util.path
 
 from .relocate_text import BinaryFilePrefixReplacer, TextFilePrefixReplacer
 

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -41,7 +41,6 @@ import spack.patch
 import spack.provider_index
 import spack.spec
 import spack.tag
-import spack.util.file_cache
 import spack.util.git
 import spack.util.naming as nm
 import spack.util.path

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -15,7 +15,6 @@ from typing import Any, Callable, Dict, List, Type
 import llnl.util.lang
 
 import spack.build_environment
-import spack.fetch_strategy
 import spack.install_test
 import spack.installer
 import spack.package_base

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -20,9 +20,6 @@ import llnl.util.tty as tty
 from llnl.util.filesystem import working_dir
 
 import spack
-import spack.build_environment
-import spack.fetch_strategy
-import spack.package_base
 import spack.paths
 import spack.platforms
 import spack.util.git

--- a/lib/spack/spack/rewiring.py
+++ b/lib/spack/spack/rewiring.py
@@ -14,9 +14,7 @@ from llnl.util.symlink import readlink, symlink
 import spack.binary_distribution as bindist
 import spack.error
 import spack.hooks
-import spack.paths
 import spack.relocate as relocate
-import spack.stage
 import spack.store
 
 

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -14,7 +14,6 @@ from llnl.util.lang import union_dicts
 
 import spack.schema.gitlab_ci  # DEPRECATED
 import spack.schema.merged
-import spack.schema.projections
 
 from .spec_list import spec_list_schema
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -27,7 +27,6 @@ from llnl.util.lang import elide_list
 
 import spack
 import spack.binary_distribution
-import spack.cmd
 import spack.compilers
 import spack.config
 import spack.config as sc
@@ -36,13 +35,11 @@ import spack.environment as ev
 import spack.error
 import spack.package_base
 import spack.package_prefs
-import spack.parser
 import spack.platforms
 import spack.repo
 import spack.spec
 import spack.store
 import spack.util.crypto
-import spack.util.elf
 import spack.util.libc
 import spack.util.path
 import spack.util.timer

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -84,7 +84,6 @@ import spack.solver
 import spack.store
 import spack.target
 import spack.traverse as traverse
-import spack.util.crypto
 import spack.util.executable
 import spack.util.hash
 import spack.util.module_cmd as md

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -36,7 +36,6 @@ import spack.config
 import spack.error
 import spack.fetch_strategy as fs
 import spack.mirror
-import spack.paths
 import spack.resource
 import spack.spec
 import spack.util.crypto

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -32,7 +32,6 @@ import spack.fetch_strategy
 import spack.hooks.sbang as sbang
 import spack.main
 import spack.mirror
-import spack.repo
 import spack.store
 import spack.util.gpg
 import spack.util.spack_yaml as syaml

--- a/lib/spack/spack/test/build_distribution.py
+++ b/lib/spack/spack/test/build_distribution.py
@@ -9,10 +9,8 @@ import os.path
 import pytest
 
 import spack.binary_distribution as bd
-import spack.main
 import spack.mirror
 import spack.spec
-import spack.util.url
 
 pytestmark = pytest.mark.not_on_windows("does not run on windows")
 

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -17,7 +17,6 @@ import spack.build_systems.autotools
 import spack.build_systems.cmake
 import spack.environment
 import spack.platforms
-import spack.repo
 from spack.build_environment import ChildError, setup_package
 from spack.spec import Spec
 from spack.util.executable import which

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -13,7 +13,6 @@ import pytest
 
 import spack.build_environment
 import spack.config
-import spack.spec
 from spack.paths import build_env_path
 from spack.util.environment import SYSTEM_DIR_CASE_ENTRY, set_env
 from spack.util.executable import Executable, ProcessError

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -10,12 +10,10 @@ import pytest
 import llnl.util.filesystem as fs
 
 import spack.ci as ci
-import spack.config
 import spack.environment as ev
 import spack.error
 import spack.paths as spack_paths
 import spack.util.git
-import spack.util.gpg
 
 
 @pytest.fixture

--- a/lib/spack/spack/test/cmd/blame.py
+++ b/lib/spack/spack/test/cmd/blame.py
@@ -9,7 +9,6 @@ import pytest
 
 from llnl.util.filesystem import working_dir
 
-import spack.cmd
 import spack.paths
 import spack.util.spack_json as sjson
 from spack.main import SpackCommand

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -13,7 +13,6 @@ import pytest
 
 import spack.binary_distribution
 import spack.cmd.buildcache
-import spack.deptypes
 import spack.environment as ev
 import spack.error
 import spack.main

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -18,13 +18,11 @@ import spack
 import spack.binary_distribution
 import spack.ci as ci
 import spack.cmd.ci
-import spack.config
 import spack.environment as ev
 import spack.hash_types as ht
 import spack.main
 import spack.paths as spack_paths
 import spack.repo as repo
-import spack.util.gpg
 import spack.util.spack_yaml as syaml
 from spack.cmd.ci import FAILED_CREATE_BUILDCACHE_CODE
 from spack.schema.buildcache_spec import schema as specfile_schema

--- a/lib/spack/spack/test/cmd/create.py
+++ b/lib/spack/spack/test/cmd/create.py
@@ -9,7 +9,6 @@ import tarfile
 import pytest
 
 import spack.cmd.create
-import spack.util.editor
 from spack.main import SpackCommand
 from spack.url import UndetectableNameError
 from spack.util.executable import which

--- a/lib/spack/spack/test/cmd/debug.py
+++ b/lib/spack/spack/test/cmd/debug.py
@@ -10,7 +10,6 @@ import platform
 import pytest
 
 import spack
-import spack.config
 import spack.platforms
 from spack.main import SpackCommand
 from spack.util.executable import which

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -9,7 +9,6 @@ import pytest
 
 import llnl.util.filesystem as fs
 
-import spack.build_environment
 import spack.environment as ev
 import spack.error
 import spack.spec

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -6,9 +6,7 @@
 import pytest
 
 import spack.cmd.diff
-import spack.config
 import spack.main
-import spack.store
 import spack.util.spack_json as sjson
 from spack.test.conftest import create_test_repo
 

--- a/lib/spack/spack/test/cmd/edit.py
+++ b/lib/spack/spack/test/cmd/edit.py
@@ -5,7 +5,6 @@
 
 import os
 
-import spack.paths
 import spack.repo
 import spack.util.editor
 from spack.build_systems import autotools, cmake

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -9,7 +9,6 @@ import pytest
 
 import llnl.util.filesystem as fs
 
-import spack.bootstrap
 import spack.util.executable
 import spack.util.gpg
 from spack.main import SpackCommand

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -24,7 +24,6 @@ import spack.environment as ev
 import spack.hash_types as ht
 import spack.package_base
 import spack.store
-import spack.util.executable
 from spack.error import SpackError
 from spack.main import SpackCommand
 from spack.parser import SpecSyntaxError

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -10,7 +10,6 @@ import pytest
 
 import spack.spec
 import spack.user_environment as uenv
-import spack.util.environment
 from spack.main import SpackCommand
 
 load = SpackCommand("load")

--- a/lib/spack/spack/test/cmd/stage.py
+++ b/lib/spack/spack/test/cmd/stage.py
@@ -10,8 +10,6 @@ import pytest
 import spack.config
 import spack.environment as ev
 import spack.package_base
-import spack.repo
-import spack.stage
 import spack.traverse
 from spack.main import SpackCommand, SpackCommandError
 from spack.version import Version

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -11,14 +11,11 @@ import pytest
 from llnl.util.filesystem import copy_tree
 
 import spack.cmd.common.arguments
-import spack.cmd.install
 import spack.cmd.test
 import spack.config
 import spack.install_test
-import spack.package_base
 import spack.paths
 import spack.spec
-import spack.store
 from spack.install_test import TestStatus
 from spack.main import SpackCommand
 

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -13,7 +13,6 @@ import llnl.util.filesystem as fs
 import spack.compiler
 import spack.compilers
 import spack.spec
-import spack.util.environment
 import spack.util.module_cmd
 from spack.compiler import Compiler
 from spack.util.executable import Executable, ProcessError

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -28,7 +28,6 @@ import spack.solver.asp
 import spack.solver.version_order
 import spack.store
 import spack.util.file_cache
-import spack.util.libc
 import spack.variant as vt
 from spack.concretize import find_spec
 from spack.spec import CompilerSpec, Spec

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -7,7 +7,6 @@ import pathlib
 
 import pytest
 
-import spack.build_systems.generic
 import spack.config
 import spack.error
 import spack.package_base

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -18,8 +18,6 @@ from llnl.util.filesystem import join_path, touch, touchp
 import spack.config
 import spack.directory_layout
 import spack.environment as ev
-import spack.fetch_strategy
-import spack.main
 import spack.package_base
 import spack.paths
 import spack.repo
@@ -27,7 +25,6 @@ import spack.schema.compilers
 import spack.schema.config
 import spack.schema.env
 import spack.schema.mirrors
-import spack.schema.packages
 import spack.schema.repos
 import spack.store
 import spack.util.path as spack_path

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -35,16 +35,12 @@ from llnl.util.filesystem import copy_tree, mkdirp, remove_linked_tree, touchp, 
 import spack.binary_distribution
 import spack.bootstrap.core
 import spack.caches
-import spack.cmd.buildcache
 import spack.compiler
 import spack.compilers
 import spack.config
-import spack.database
-import spack.directory_layout
 import spack.environment as ev
 import spack.error
 import spack.package_base
-import spack.package_prefs
 import spack.paths
 import spack.platforms
 import spack.repo
@@ -52,7 +48,6 @@ import spack.solver.asp
 import spack.stage
 import spack.store
 import spack.subprocess_context
-import spack.test.cray_manifest
 import spack.util.executable
 import spack.util.git
 import spack.util.gpg

--- a/lib/spack/spack/test/container/cli.py
+++ b/lib/spack/spack/test/container/cli.py
@@ -8,7 +8,6 @@ import llnl.util.filesystem as fs
 
 import spack.container.images
 import spack.main
-import spack.platforms
 
 containerize = spack.main.SpackCommand("containerize")
 

--- a/lib/spack/spack/test/cray_manifest.py
+++ b/lib/spack/spack/test/cray_manifest.py
@@ -18,7 +18,6 @@ import spack
 import spack.cmd
 import spack.cmd.external
 import spack.compilers
-import spack.config
 import spack.cray_manifest as cray_manifest
 import spack.solver.asp
 import spack.spec

--- a/lib/spack/spack/test/flag_handlers.py
+++ b/lib/spack/spack/test/flag_handlers.py
@@ -8,7 +8,6 @@ import os
 import pytest
 
 import spack.build_environment
-import spack.repo
 import spack.spec
 from spack.package import build_system_flags, env_flags, inject_flags
 

--- a/lib/spack/spack/test/flag_mixing.py
+++ b/lib/spack/spack/test/flag_mixing.py
@@ -4,14 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import pytest
 
-import spack.build_systems.generic
 import spack.config
 import spack.environment as ev
-import spack.error
-import spack.package_base
 import spack.repo
 import spack.util.spack_yaml as syaml
-import spack.version
 from spack.spec import Spec
 from spack.test.conftest import create_test_repo
 

--- a/lib/spack/spack/test/gcs_fetch.py
+++ b/lib/spack/spack/test/gcs_fetch.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.config
-import spack.error
 import spack.fetch_strategy
 import spack.stage
 

--- a/lib/spack/spack/test/graph.py
+++ b/lib/spack/spack/test/graph.py
@@ -5,7 +5,6 @@
 import io
 
 import spack.graph
-import spack.repo
 import spack.spec
 
 

--- a/lib/spack/spack/test/hg_fetch.py
+++ b/lib/spack/spack/test/hg_fetch.py
@@ -10,7 +10,6 @@ import pytest
 from llnl.util.filesystem import mkdirp, touch, working_dir
 
 import spack.config
-import spack.repo
 from spack.fetch_strategy import HgFetchStrategy
 from spack.spec import Spec
 from spack.stage import Stage

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -17,9 +17,6 @@ import llnl.util.lock as ulk
 import llnl.util.tty as tty
 
 import spack.binary_distribution
-import spack.compilers
-import spack.concretize
-import spack.config
 import spack.database
 import spack.deptypes as dt
 import spack.installer as inst
@@ -29,7 +26,6 @@ import spack.repo
 import spack.spec
 import spack.store
 import spack.util.lock as lk
-import spack.version
 
 
 def _mock_repo(root, namespace):

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -15,7 +15,6 @@ import spack.config
 import spack.fetch_strategy
 import spack.mirror
 import spack.patch
-import spack.repo
 import spack.stage
 import spack.util.executable
 import spack.util.spack_json as sjson

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -14,7 +14,6 @@ import spack.config
 import spack.error
 import spack.modules.tcl
 import spack.package_base
-import spack.schema.modules
 import spack.spec
 from spack.modules.common import UpstreamModuleIndex
 from spack.spec import Spec

--- a/lib/spack/spack/test/modules/conftest.py
+++ b/lib/spack/spack/test/modules/conftest.py
@@ -6,11 +6,7 @@ import pathlib
 
 import pytest
 
-import spack.config
-import spack.modules.common
-import spack.paths
 import spack.spec
-import spack.util.path
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/multimethod.py
+++ b/lib/spack/spack/test/multimethod.py
@@ -8,7 +8,6 @@
 import pytest
 
 import spack.platforms
-import spack.repo
 import spack.spec
 from spack.multimethod import NoSuchMethodError
 

--- a/lib/spack/spack/test/oci/integration_test.py
+++ b/lib/spack/spack/test/oci/integration_test.py
@@ -17,7 +17,6 @@ from contextlib import contextmanager
 import pytest
 
 import spack.binary_distribution
-import spack.cmd.buildcache
 import spack.database
 import spack.environment as ev
 import spack.error

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -24,8 +24,6 @@ import spack.cmd.buildcache as buildcache
 import spack.error
 import spack.fetch_strategy
 import spack.package_base
-import spack.repo
-import spack.store
 import spack.util.gpg
 import spack.util.url as url_util
 from spack.fetch_strategy import URLFetchStrategy

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -17,7 +17,6 @@ import spack.error
 import spack.patch
 import spack.paths
 import spack.repo
-import spack.util.compression
 import spack.util.url as url_util
 from spack.spec import Spec
 from spack.stage import Stage

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -9,14 +9,9 @@ import shutil
 
 import pytest
 
-import spack.concretize
-import spack.paths
 import spack.platforms
 import spack.relocate
 import spack.relocate_text as relocate_text
-import spack.spec
-import spack.store
-import spack.tengine
 import spack.util.executable
 
 pytestmark = pytest.mark.not_on_windows("Tests fail on Windows")

--- a/lib/spack/spack/test/reporters.py
+++ b/lib/spack/spack/test/reporters.py
@@ -10,7 +10,6 @@ import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
 import spack.reporters.extract
-import spack.spec
 from spack.install_test import TestStatus
 from spack.reporters import CDash, CDashConfiguration
 

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -18,7 +18,6 @@ import pytest
 import llnl.util.filesystem as fs
 
 import spack.hooks.sbang as sbang
-import spack.paths
 import spack.store
 import spack.util.spack_yaml as syaml
 from spack.util.executable import which

--- a/lib/spack/spack/test/solver/intermediate.py
+++ b/lib/spack/spack/test/solver/intermediate.py
@@ -6,7 +6,6 @@
 import pytest
 
 import spack.compilers
-import spack.config
 import spack.spec
 from spack.concretize import UnavailableCompilerVersionError
 from spack.solver import asp

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -9,7 +9,6 @@ import pytest
 
 import spack.deptypes as dt
 import spack.error
-import spack.package_base
 import spack.parser
 import spack.repo
 import spack.util.hash as hashutil

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -12,7 +12,6 @@ import pytest
 import spack.cmd
 import spack.platforms.test
 import spack.spec
-import spack.variant
 from spack.parser import (
     UNIX_FILENAME,
     WINDOWS_FILENAME,

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -19,7 +19,6 @@ from llnl.util.symlink import readlink
 
 import spack.error
 import spack.fetch_strategy
-import spack.paths
 import spack.stage
 import spack.util.executable
 import spack.util.url as url_util

--- a/lib/spack/spack/test/svn_fetch.py
+++ b/lib/spack/spack/test/svn_fetch.py
@@ -10,7 +10,6 @@ import pytest
 from llnl.util.filesystem import mkdirp, touch, working_dir
 
 import spack.config
-import spack.repo
 from spack.fetch_strategy import SvnFetchStrategy
 from spack.spec import Spec
 from spack.stage import Stage

--- a/lib/spack/spack/test/tag.py
+++ b/lib/spack/spack/test/tag.py
@@ -7,7 +7,6 @@ import io
 
 import pytest
 
-import spack.cmd.install
 import spack.tag
 from spack.main import SpackCommand
 

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -17,7 +17,6 @@ from llnl.util.filesystem import is_exe, working_dir
 import spack.config
 import spack.error
 import spack.fetch_strategy as fs
-import spack.repo
 import spack.util.crypto as crypto
 import spack.util.executable
 import spack.util.web as web_util

--- a/lib/spack/spack/test/util/spack_lock_wrapper.py
+++ b/lib/spack/spack/test/util/spack_lock_wrapper.py
@@ -10,7 +10,7 @@ import pytest
 
 from llnl.util.filesystem import getuid, group_ids
 
-import spack.config
+import spack.error
 import spack.util.lock as lk
 
 

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -17,7 +17,6 @@ import spack.config
 import spack.mirror
 import spack.paths
 import spack.url
-import spack.util.path
 import spack.util.s3
 import spack.util.url as url_util
 import spack.util.web

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -8,7 +8,6 @@ import sys
 
 import spack.build_environment
 import spack.config
-import spack.error
 import spack.spec
 import spack.util.environment as environment
 from spack import traverse

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -19,7 +19,6 @@ from llnl.util.lock import ReadTransaction  # noqa: F401
 from llnl.util.lock import WriteTransaction  # noqa: F401
 
 import spack.error
-import spack.paths
 
 
 class Lock(llnl.util.lock.Lock):

--- a/lib/spack/spack/util/package_hash.py
+++ b/lib/spack/spack/util/package_hash.py
@@ -7,6 +7,7 @@ import ast
 
 import spack.directives_meta
 import spack.error
+import spack.fetch_strategy
 import spack.package_base
 import spack.repo
 import spack.spec

--- a/lib/spack/spack/util/package_hash.py
+++ b/lib/spack/spack/util/package_hash.py
@@ -12,7 +12,6 @@ import spack.package_base
 import spack.repo
 import spack.spec
 import spack.util.hash
-import spack.util.naming
 from spack.util.unparse import unparse
 
 

--- a/lib/spack/spack/verify.py
+++ b/lib/spack/spack/verify.py
@@ -11,7 +11,6 @@ from typing import Any, Dict
 import llnl.util.tty as tty
 from llnl.util.symlink import readlink
 
-import spack.filesystem_view
 import spack.store
 import spack.util.file_permissions as fp
 import spack.util.spack_json as sjson

--- a/lib/spack/spack/version/git_ref_lookup.py
+++ b/lib/spack/spack/version/git_ref_lookup.py
@@ -17,7 +17,6 @@ import spack.repo
 import spack.util.executable
 import spack.util.hash
 import spack.util.spack_json as sjson
-import spack.version
 
 from .common import VersionLookupError
 from .lookup import AbstractRefLookup


### PR DESCRIPTION
Delete about 185 unused imports. These are not caught by tooling cause these modules likely have side effects on import (defining globals etc)