### PR TITLE
imports: automate missing imports

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -51,7 +51,9 @@ from urllib.request import urlopen
 
 import llnl.util.lang
 
+import spack.builder
 import spack.config
+import spack.fetch_strategy
 import spack.patch
 import spack.repo
 import spack.spec

--- a/lib/spack/spack/bootstrap/config.py
+++ b/lib/spack/spack/bootstrap/config.py
@@ -14,6 +14,7 @@ from llnl.util import tty
 import spack.compilers
 import spack.config
 import spack.environment
+import spack.modules
 import spack.paths
 import spack.platforms
 import spack.repo

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -14,7 +14,9 @@ import archspec.cpu
 from llnl.util import tty
 
 import spack.environment
+import spack.spec
 import spack.tengine
+import spack.util.path
 
 from ._common import _root_spec
 from .config import root_path, spec_for_current_python, store_path

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1136,7 +1136,7 @@ def _setup_pkg_and_run(
         return_value = function(pkg, kwargs)
         write_pipe.send(return_value)
 
-    except StopPhase as e:
+    except spack.error.StopPhase as e:
         # Do not create a full ChildError from this, it's not an error
         # it's a control statement.
         write_pipe.send(e)
@@ -1297,7 +1297,7 @@ def start_build_process(pkg, function, kwargs):
     p.join()
 
     # If returns a StopPhase, raise it
-    if isinstance(child_result, StopPhase):
+    if isinstance(child_result, spack.error.StopPhase):
         # do not print
         raise child_result
 
@@ -1504,17 +1504,6 @@ class ChildError(InstallError):
 def _make_child_error(msg, module, name, traceback, log, log_type, context):
     """Used by __reduce__ in ChildError to reconstruct pickled errors."""
     return ChildError(msg, module, name, traceback, log, log_type, context)
-
-
-class StopPhase(spack.error.SpackError):
-    """Pickle-able exception to control stopped builds."""
-
-    def __reduce__(self):
-        return _make_stop_phase, (self.message, self.long_message)
-
-
-def _make_stop_phase(msg, long_msg):
-    return StopPhase(msg, long_msg)
 
 
 def write_log_summary(out, log_type, log, last=None):

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -75,9 +75,8 @@ import spack.subprocess_context
 import spack.util.executable
 from spack import traverse
 from spack.context import Context
-from spack.error import NoHeadersError, NoLibrariesError
+from spack.error import InstallError, NoHeadersError, NoLibrariesError
 from spack.install_test import spack_install_test_log
-from spack.installer import InstallError
 from spack.util.cpus import determine_number_of_jobs
 from spack.util.environment import (
     SYSTEM_DIR_CASE_ENTRY,

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -53,6 +53,7 @@ from llnl.util.symlink import symlink
 from llnl.util.tty.color import cescape, colorize
 from llnl.util.tty.log import MultiProcessFd
 
+import spack.build_systems._checks
 import spack.build_systems.cmake
 import spack.build_systems.meson
 import spack.build_systems.python
@@ -62,6 +63,7 @@ import spack.config
 import spack.deptypes as dt
 import spack.error
 import spack.main
+import spack.multimethod
 import spack.package_base
 import spack.paths
 import spack.platforms

--- a/lib/spack/spack/build_systems/_checks.py
+++ b/lib/spack/spack/build_systems/_checks.py
@@ -8,7 +8,7 @@ from typing import List
 import llnl.util.lang
 
 import spack.builder
-import spack.installer
+import spack.error
 import spack.relocate
 import spack.spec
 import spack.store
@@ -34,7 +34,7 @@ def sanity_check_prefix(builder: spack.builder.Builder):
             if not predicate(abs_path):
                 msg = "Install failed for {0}. No such {1} in prefix: {2}"
                 msg = msg.format(pkg.name, filetype, path)
-                raise spack.installer.InstallError(msg)
+                raise spack.error.InstallError(msg)
 
     check_paths(pkg.sanity_check_is_file, "file", os.path.isfile)
     check_paths(pkg.sanity_check_is_dir, "directory", os.path.isdir)
@@ -42,7 +42,7 @@ def sanity_check_prefix(builder: spack.builder.Builder):
     ignore_file = llnl.util.lang.match_predicate(spack.store.STORE.layout.hidden_file_regexes)
     if all(map(ignore_file, os.listdir(pkg.prefix))):
         msg = "Install failed for {0}.  Nothing was installed!"
-        raise spack.installer.InstallError(msg.format(pkg.name))
+        raise spack.error.InstallError(msg.format(pkg.name))
 
 
 def apply_macos_rpath_fixups(builder: spack.builder.Builder):

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -13,6 +13,7 @@ import llnl.util.tty as tty
 
 import spack.build_environment
 import spack.builder
+import spack.error
 import spack.package_base
 from spack.directives import build_system, conflicts, depends_on
 from spack.multimethod import when
@@ -248,7 +249,7 @@ class AutotoolsBuilder(BaseBuilder):
 
         # An external gnuconfig may not not have a prefix.
         if gnuconfig_dir is None:
-            raise spack.build_environment.InstallError(
+            raise spack.error.InstallError(
                 "Spack could not find substitutes for GNU config files because no "
                 "prefix is available for the `gnuconfig` package. Make sure you set a "
                 "prefix path instead of modules for external `gnuconfig`."
@@ -268,7 +269,7 @@ class AutotoolsBuilder(BaseBuilder):
                 msg += (
                     " or the `gnuconfig` package prefix is misconfigured as" " an external package"
                 )
-            raise spack.build_environment.InstallError(msg)
+            raise spack.error.InstallError(msg)
 
         # Filter working substitutes
         candidates = [f for f in candidates if runs_ok(f)]
@@ -293,9 +294,7 @@ To resolve this problem, please try the following:
    and set the prefix to the directory containing the `config.guess` and
    `config.sub` files.
 """
-            raise spack.build_environment.InstallError(
-                msg.format(", ".join(to_be_found), self.name)
-            )
+            raise spack.error.InstallError(msg.format(", ".join(to_be_found), self.name))
 
         # Copy the good files over the bad ones
         for abs_path in to_be_patched:

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -15,6 +15,7 @@ import llnl.util.filesystem as fs
 import spack.build_environment
 import spack.builder
 import spack.deptypes as dt
+import spack.error
 import spack.package_base
 from spack.directives import build_system, conflicts, depends_on, variant
 from spack.multimethod import when
@@ -344,7 +345,7 @@ class CMakeBuilder(BaseBuilder):
             msg = "Invalid CMake generator: '{0}'\n".format(generator)
             msg += "CMakePackage currently supports the following "
             msg += "primary generators: '{0}'".format("', '".join(valid_primary_generators))
-            raise spack.package_base.InstallError(msg)
+            raise spack.error.InstallError(msg)
 
         try:
             build_type = pkg.spec.variants["build_type"].value

--- a/lib/spack/spack/build_systems/compiler.py
+++ b/lib/spack/spack/build_systems/compiler.py
@@ -14,6 +14,7 @@ from llnl.util.lang import classproperty
 
 import spack.compiler
 import spack.package_base
+import spack.util.executable
 
 # Local "type" for type hints
 Path = Union[str, pathlib.Path]

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -25,7 +25,7 @@ from llnl.util.filesystem import (
 import spack.builder
 import spack.error
 from spack.build_environment import dso_suffix
-from spack.package_base import InstallError
+from spack.error import InstallError
 from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable
 from spack.util.prefix import Prefix

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -22,6 +22,7 @@ from llnl.util.filesystem import (
     install,
 )
 
+import spack.builder
 import spack.error
 from spack.build_environment import dso_suffix
 from spack.package_base import InstallError

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -15,7 +15,7 @@ from llnl.util.link_tree import LinkTree
 import spack.util.path
 from spack.build_environment import dso_suffix
 from spack.directives import conflicts, license, redistribute, variant
-from spack.package_base import InstallError
+from spack.error import InstallError
 from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable
 

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -24,6 +24,8 @@ import spack.deptypes as dt
 import spack.detection
 import spack.multimethod
 import spack.package_base
+import spack.platforms
+import spack.repo
 import spack.spec
 import spack.store
 from spack.directives import build_system, depends_on, extends

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -10,7 +10,7 @@ from typing import List, Optional, Tuple
 
 from llnl.util import lang
 
-import spack.build_environment
+import spack.error
 import spack.multimethod
 
 #: Builder classes, as registered by the "builder" decorator
@@ -461,15 +461,13 @@ class InstallationPhase:
         # If a phase has a matching stop_before_phase attribute,
         # stop the installation process raising a StopPhase
         if getattr(instance, "stop_before_phase", None) == self.name:
-            raise spack.build_environment.StopPhase(
-                "Stopping before '{0}' phase".format(self.name)
-            )
+            raise spack.error.StopPhase("Stopping before '{0}' phase".format(self.name))
 
     def _on_phase_exit(self, instance):
         # If a phase has a matching last_phase attribute,
         # stop the installation process raising a StopPhase
         if getattr(instance, "last_phase", None) == self.name:
-            raise spack.build_environment.StopPhase("Stopping at '{0}' phase".format(self.name))
+            raise spack.error.StopPhase("Stopping at '{0}' phase".format(self.name))
 
     def copy(self):
         return copy.deepcopy(self)

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -31,6 +31,7 @@ from llnl.util.tty.color import cescape, colorize
 
 import spack
 import spack.binary_distribution as bindist
+import spack.concretize
 import spack.config as cfg
 import spack.environment as ev
 import spack.main

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -17,7 +17,7 @@ from llnl.util.lang import attr_setdefault, index_by
 from llnl.util.tty.colify import colify
 from llnl.util.tty.color import colorize
 
-import spack.config
+import spack.config  # breaks a cycle.
 import spack.environment as ev
 import spack.error
 import spack.extensions

--- a/lib/spack/spack/cmd/arch.py
+++ b/lib/spack/spack/cmd/arch.py
@@ -11,6 +11,7 @@ import llnl.util.tty.colify as colify
 import llnl.util.tty.color as color
 
 import spack.platforms
+import spack.spec
 
 description = "print architecture information about this machine"
 section = "system"

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -20,6 +20,7 @@ import spack.mirror
 import spack.spec
 import spack.stage
 import spack.util.path
+import spack.util.spack_yaml
 from spack.cmd.common import arguments
 
 description = "manage bootstrap configuration"

--- a/lib/spack/spack/cmd/change.py
+++ b/lib/spack/spack/cmd/change.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import spack.cmd
+import spack.spec
 from spack.cmd.common import arguments
 
 description = "change an existing spec in an environment"

--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -11,6 +11,7 @@ import llnl.util.filesystem
 import llnl.util.tty as tty
 
 import spack.caches
+import spack.cmd
 import spack.config
 import spack.stage
 import spack.store

--- a/lib/spack/spack/cmd/commands.py
+++ b/lib/spack/spack/cmd/commands.py
@@ -17,6 +17,7 @@ from llnl.util.argparsewriter import ArgparseRstWriter, ArgparseWriter, Command
 from llnl.util.tty.colify import colify
 
 import spack.cmd
+import spack.config
 import spack.main
 import spack.paths
 import spack.platforms

--- a/lib/spack/spack/cmd/common/confirmation.py
+++ b/lib/spack/spack/cmd/common/confirmation.py
@@ -9,6 +9,7 @@ from typing import List
 import llnl.util.tty as tty
 
 import spack.cmd
+import spack.spec
 
 display_args = {"long": True, "show_flags": False, "variants": False, "indent": 4}
 

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -14,6 +14,7 @@ import llnl.util.tty as tty
 import spack.config
 import spack.environment as ev
 import spack.schema.env
+import spack.spec
 import spack.store
 import spack.util.spack_yaml as syaml
 from spack.cmd.common import arguments

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -13,6 +13,7 @@ import llnl.util.tty as tty
 
 import spack.config
 import spack.environment as ev
+import spack.error
 import spack.schema.env
 import spack.spec
 import spack.store
@@ -255,7 +256,7 @@ def config_remove(args):
         existing.pop(value, None)
     else:
         # This should be impossible to reach
-        raise spack.config.ConfigError("Config has nested non-dict values")
+        raise spack.error.ConfigError("Config has nested non-dict values")
 
     spack.config.set(path, existing, scope)
 
@@ -339,7 +340,7 @@ def _config_change(config_path, match_spec_str=None):
         if not changed:
             existing_requirements = spack.config.get(key_path)
             if isinstance(existing_requirements, str):
-                raise spack.config.ConfigError(
+                raise spack.error.ConfigError(
                     "'config change' needs to append a requirement,"
                     " but existing require: config is not a list"
                 )

--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -16,6 +16,8 @@ from llnl.util.filesystem import working_dir
 import spack
 import spack.paths
 import spack.platforms
+import spack.spec
+import spack.store
 import spack.util.git
 from spack.util.executable import which
 

--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -8,7 +8,9 @@ import sys
 
 import llnl.util.tty as tty
 
+import spack.build_environment
 import spack.cmd
+import spack.cmd.common.arguments
 import spack.config
 import spack.repo
 from spack.cmd.common import arguments

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -25,6 +25,7 @@ import spack.cmd.modules
 import spack.config
 import spack.environment as ev
 import spack.environment.depfile as depfile
+import spack.environment.environment
 import spack.environment.shell
 import spack.tengine
 from spack.cmd.common import arguments

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -18,6 +18,7 @@ import spack.config
 import spack.cray_manifest as cray_manifest
 import spack.detection
 import spack.error
+import spack.package_base
 import spack.repo
 import spack.spec
 from spack.cmd.common import arguments

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -11,8 +11,10 @@ import llnl.util.tty as tty
 import llnl.util.tty.color as color
 
 import spack.cmd as cmd
+import spack.config
 import spack.environment as ev
 import spack.repo
+import spack.spec
 import spack.store
 from spack.cmd.common import arguments
 from spack.database import InstallStatuses

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -16,6 +16,7 @@ import spack.fetch_strategy as fs
 import spack.install_test
 import spack.repo
 import spack.spec
+import spack.variant
 import spack.version
 from spack.cmd.common import arguments
 from spack.package_base import preferred_version

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -13,7 +13,6 @@ import llnl.util.filesystem as fs
 from llnl.string import plural
 from llnl.util import lang, tty
 
-import spack.build_environment
 import spack.cmd
 import spack.config
 import spack.environment as ev
@@ -22,7 +21,7 @@ import spack.report
 import spack.spec
 import spack.store
 from spack.cmd.common import arguments
-from spack.error import SpackError
+from spack.error import InstallError, SpackError
 from spack.installer import PackageInstaller
 
 description = "build and install packages"
@@ -285,7 +284,7 @@ def require_user_confirmation_for_overwrite(concrete_specs, args):
         tty.die("Reinstallation aborted.")
 
 
-def _dump_log_on_error(e: spack.build_environment.InstallError):
+def _dump_log_on_error(e: InstallError):
     e.print_context()
     assert e.pkg, "Expected InstallError to include the associated package"
     if not os.path.exists(e.pkg.log_path):
@@ -350,7 +349,7 @@ def install(parser, args):
             install_with_active_env(env, args, install_kwargs, reporter_factory)
         else:
             install_without_active_env(args, install_kwargs, reporter_factory)
-    except spack.build_environment.InstallError as e:
+    except InstallError as e:
         if args.show_log_on_error:
             _dump_log_on_error(e)
         raise

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -6,6 +6,7 @@
 import sys
 
 import spack.cmd
+import spack.cmd.common
 import spack.environment as ev
 import spack.store
 import spack.user_environment as uenv

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -125,13 +125,13 @@ def check_module_set_name(name):
     names = [k for k in modules if k != "prefix_inspections"]
 
     if not names:
-        raise spack.config.ConfigError(
+        raise spack.error.ConfigError(
             f"Module set configuration is missing. Cannot use module set '{name}'"
         )
 
     pretty_names = "', '".join(names)
 
-    raise spack.config.ConfigError(
+    raise spack.error.ConfigError(
         f"Cannot use invalid module set '{name}'.",
         f"Valid module set names are: '{pretty_names}'.",
     )

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -15,6 +15,7 @@ from llnl.util.tty import color
 
 import spack.cmd
 import spack.config
+import spack.error
 import spack.modules
 import spack.modules.common
 import spack.repo

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -13,7 +13,6 @@ import sys
 import llnl.util.tty as tty
 
 import spack
-import spack.cmd.python
 
 description = "launch an interpreter as spack would launch a command"
 section = "developer"
@@ -79,8 +78,8 @@ def python(parser, args, unknown_args):
 
     # Run user choice of interpreter
     if args.python_interpreter == "ipython":
-        return spack.cmd.python.ipython_interpreter(args)
-    return spack.cmd.python.python_interpreter(args)
+        return ipython_interpreter(args)
+    return python_interpreter(args)
 
 
 def ipython_interpreter(args):

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -13,6 +13,7 @@ import sys
 import llnl.util.tty as tty
 
 import spack
+import spack.cmd.python
 
 description = "launch an interpreter as spack would launch a command"
 section = "developer"

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -12,10 +12,12 @@ import llnl.util.tty.color as color
 
 import spack
 import spack.cmd
+import spack.cmd.common.arguments
 import spack.config
 import spack.environment
 import spack.hash_types as ht
 import spack.solver.asp as asp
+import spack.spec
 from spack.cmd.common import arguments
 
 description = "concretize a specs using an ASP solver"

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -14,6 +14,7 @@ import spack.environment as ev
 import spack.hash_types as ht
 import spack.spec
 import spack.store
+import spack.traverse
 from spack.cmd.common import arguments
 
 description = "show what would be installed, given a spec"

--- a/lib/spack/spack/cmd/tags.py
+++ b/lib/spack/spack/cmd/tags.py
@@ -9,6 +9,7 @@ import llnl.string
 import llnl.util.tty as tty
 import llnl.util.tty.colify as colify
 
+import spack.environment
 import spack.repo
 import spack.tag
 

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -15,10 +15,12 @@ from llnl.util import lang, tty
 from llnl.util.tty import colify
 
 import spack.cmd
+import spack.config
 import spack.environment as ev
 import spack.install_test
 import spack.repo
 import spack.report
+import spack.store
 from spack.cmd.common import arguments
 
 description = "run spack's tests for an install"

--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -10,6 +10,7 @@ import llnl.util.tty as tty
 from llnl.util.filesystem import working_dir
 
 import spack
+import spack.cmd
 import spack.config
 import spack.paths
 import spack.util.git

--- a/lib/spack/spack/cmd/undevelop.py
+++ b/lib/spack/spack/cmd/undevelop.py
@@ -6,6 +6,7 @@
 import llnl.util.tty as tty
 
 import spack.cmd
+import spack.config
 from spack.cmd.common import arguments
 
 description = "remove specs from an environment"

--- a/lib/spack/spack/cmd/unit_test.py
+++ b/lib/spack/spack/cmd/unit_test.py
@@ -10,6 +10,8 @@ import os.path
 import re
 import sys
 
+import spack.extensions
+
 try:
     import pytest
 except ImportError:

--- a/lib/spack/spack/cmd/unload.py
+++ b/lib/spack/spack/cmd/unload.py
@@ -7,7 +7,9 @@ import os
 import sys
 
 import spack.cmd
+import spack.cmd.common
 import spack.error
+import spack.store
 import spack.user_environment as uenv
 from spack.cmd.common import arguments
 

--- a/lib/spack/spack/cmd/verify.py
+++ b/lib/spack/spack/cmd/verify.py
@@ -6,6 +6,7 @@ import argparse
 
 import llnl.util.tty as tty
 
+import spack.cmd
 import spack.environment as ev
 import spack.store
 import spack.verify

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -39,6 +39,7 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 
 from llnl.util import filesystem, lang, tty
 
+import spack.error
 import spack.paths
 import spack.platforms
 import spack.schema

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -50,8 +50,6 @@ import spack.schema.compilers
 import spack.schema.concretizer
 import spack.schema.config
 import spack.schema.definitions
-
-# import spack.spec
 import spack.schema.develop
 import spack.schema.env
 import spack.schema.mirrors
@@ -1026,7 +1024,7 @@ def change_or_add(
 
     if found:
         update_fn(section)
-        set(section_name, section, scope=scope)
+        CONFIG.set(section_name, section, scope=scope)
         return
 
     # If no scope meets the criteria specified by ``find_fn``,
@@ -1039,14 +1037,14 @@ def change_or_add(
             break
 
     if found:
-        set(section_name, section, scope=scope)
+        CONFIG.set(section_name, section, scope=scope)
         return
 
     # If no scopes define any config for the named section, then
     # modify the highest-priority scope.
     scope, section = configs_by_section[0]
     update_fn(section)
-    set(section_name, section, scope=scope)
+    CONFIG.set(section_name, section, scope=scope)
 
 
 def update_all(section_name: str, change_fn: Callable[[str], bool]) -> None:
@@ -1058,7 +1056,7 @@ def update_all(section_name: str, change_fn: Callable[[str], bool]) -> None:
     for scope, section in configs_by_section:
         modified = change_fn(section)
         if modified:
-            set(section_name, section, scope=scope)
+            CONFIG.set(section_name, section, scope=scope)
 
 
 def _validate_section_name(section: str) -> None:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -65,7 +65,7 @@ import spack.spec
 # Hacked yaml for configuration files preserves line numbers.
 import spack.util.spack_yaml as syaml
 import spack.util.web as web_util
-from spack.error import SpackError, SpecSyntaxError
+from spack.error import SpecSyntaxError
 from spack.util.cpus import cpus_available
 
 #: Dict from section names -> schema for that section
@@ -172,7 +172,7 @@ class DirectoryConfigScope(ConfigScope):
 
     def _write_section(self, section: str) -> None:
         if not self.writable:
-            raise ConfigError(f"Cannot write to immutable scope {self}")
+            raise spack.error.ConfigError(f"Cannot write to immutable scope {self}")
 
         filename = self.get_section_filename(section)
         data = self.get_section(section)
@@ -284,7 +284,7 @@ class SingleFileScope(ConfigScope):
 
     def _write_section(self, section: str) -> None:
         if not self.writable:
-            raise ConfigError(f"Cannot write to immutable scope {self}")
+            raise spack.error.ConfigError(f"Cannot write to immutable scope {self}")
         data_to_write: Optional[YamlConfigDict] = self._raw_data
 
         # If there is no existing data, this section SingleFileScope has never
@@ -712,7 +712,7 @@ class Configuration:
             data[section] = self.get_config(section, scope=scope)
             syaml.dump_config(data, stream=sys.stdout, default_flow_style=False, blame=blame)
         except (syaml.SpackYAMLError, OSError) as e:
-            raise ConfigError(f"cannot read '{section}' configuration") from e
+            raise spack.error.ConfigError(f"cannot read '{section}' configuration") from e
 
 
 @contextlib.contextmanager
@@ -814,7 +814,7 @@ def _add_command_line_scopes(
             _add_platform_scope(cfg, name, path, writable=False)
             continue
         else:
-            raise ConfigError(f"Invalid configuration scope: {path}")
+            raise spack.error.ConfigError(f"Invalid configuration scope: {path}")
 
         for scope in manifest.env_config_scopes:
             scope.name = f"{name}:{scope.name}"
@@ -1232,7 +1232,7 @@ def get_valid_type(path):
                     return types[schema_type]()
     else:
         return type(None)
-    raise ConfigError(f"Cannot determine valid type for path '{path}'.")
+    raise spack.error.ConfigError(f"Cannot determine valid type for path '{path}'.")
 
 
 def remove_yaml(dest, source):
@@ -1733,19 +1733,15 @@ def parse_spec_from_yaml_string(string: str) -> "spack.spec.Spec":
         raise e
 
 
-class ConfigError(SpackError):
-    """Superclass for all Spack config related errors."""
-
-
-class ConfigSectionError(ConfigError):
+class ConfigSectionError(spack.error.ConfigError):
     """Error for referring to a bad config section name in a configuration."""
 
 
-class ConfigFileError(ConfigError):
+class ConfigFileError(spack.error.ConfigError):
     """Issue reading or accessing a configuration file."""
 
 
-class ConfigFormatError(ConfigError):
+class ConfigFormatError(spack.error.ConfigError):
     """Raised when a configuration format does not match its schema."""
 
     def __init__(

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -25,8 +25,10 @@ from typing import Dict, List, Optional, Set, Tuple, Union
 import llnl.util.tty
 
 import spack.config
+import spack.error
 import spack.operating_systems.windows_os as winOs
 import spack.spec
+import spack.util.environment
 import spack.util.spack_yaml
 import spack.util.windows_registry
 

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -18,6 +18,7 @@ import llnl.util.filesystem
 import llnl.util.lang
 import llnl.util.tty
 
+import spack.spec
 import spack.util.elf as elf_utils
 import spack.util.environment
 import spack.util.environment as environment

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -16,7 +16,9 @@ from llnl.util.symlink import readlink
 
 import spack.config
 import spack.hash_types as ht
+import spack.projections
 import spack.spec
+import spack.store
 import spack.util.spack_json as sjson
 from spack.error import SpackError
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -30,13 +30,16 @@ import spack.compilers
 import spack.concretize
 import spack.config
 import spack.deptypes as dt
+import spack.environment
 import spack.error
 import spack.filesystem_view as fsv
 import spack.hash_types as ht
 import spack.paths
 import spack.repo
 import spack.schema.env
+import spack.schema.merged
 import spack.spec
+import spack.spec_list
 import spack.store
 import spack.user_environment as uenv
 import spack.util.cpus

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -174,3 +174,7 @@ class InstallError(SpackError):
     def __init__(self, message, long_msg=None, pkg=None):
         super().__init__(message, long_msg)
         self.pkg = pkg
+
+
+class ConfigError(SpackError):
+    """Superclass for all Spack config related errors."""

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -178,3 +178,14 @@ class InstallError(SpackError):
 
 class ConfigError(SpackError):
     """Superclass for all Spack config related errors."""
+
+
+class StopPhase(SpackError):
+    """Pickle-able exception to control stopped builds."""
+
+    def __reduce__(self):
+        return _make_stop_phase, (self.message, self.long_message)
+
+
+def _make_stop_phase(msg, long_msg):
+    return StopPhase(msg, long_msg)

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -144,3 +144,33 @@ class PatchDirectiveError(SpackError):
 
 class PatchLookupError(NoSuchPatchError):
     """Raised when a patch file cannot be located from sha256."""
+
+
+class SpecSyntaxError(Exception):
+    """Base class for Spec syntax errors"""
+
+
+class PackageError(SpackError):
+    """Raised when something is wrong with a package definition."""
+
+    def __init__(self, message, long_msg=None):
+        super().__init__(message, long_msg)
+
+
+class NoURLError(PackageError):
+    """Raised when someone tries to build a URL for a package with no URLs."""
+
+    def __init__(self, cls):
+        super().__init__("Package %s has no version with a URL." % cls.__name__)
+
+
+class InstallError(SpackError):
+    """Raised when something goes wrong during install or uninstall.
+
+    The error can be annotated with a ``pkg`` attribute to allow the
+    caller to get the package for which the exception was raised.
+    """
+
+    def __init__(self, message, long_msg=None, pkg=None):
+        super().__init__(message, long_msg)
+        self.pkg = pkg

--- a/lib/spack/spack/extensions.py
+++ b/lib/spack/spack/extensions.py
@@ -17,6 +17,7 @@ from typing import List
 
 import llnl.util.lang
 
+import spack.cmd
 import spack.config
 import spack.error
 import spack.util.path

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1541,7 +1541,7 @@ def _extrapolate(pkg, version):
     """Create a fetcher from an extrapolated URL for this version."""
     try:
         return URLFetchStrategy(url=pkg.url_for_version(version), fetch_options=pkg.fetch_options)
-    except spack.package_base.NoURLError:
+    except spack.error.NoURLError:
         raise ExtrapolationError(
             f"Can't extrapolate a URL for version {version} because "
             f"package {pkg.name} defines no URLs"

--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -46,6 +46,7 @@ import spack.deptypes as dt
 import spack.repo
 import spack.spec
 import spack.tengine
+import spack.traverse
 
 
 def find(seq, predicate):

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -33,7 +33,7 @@ import spack.spec
 import spack.util.executable
 import spack.util.path
 import spack.util.spack_json as sjson
-from spack.installer import InstallError
+from spack.error import InstallError
 from spack.spec import Spec
 from spack.util.prefix import Prefix
 
@@ -119,7 +119,7 @@ def cache_extra_test_sources(pkg: Pb, srcs: ListOrStringType):
             location(s) under the install testing directory.
 
     Raises:
-        spack.installer.InstallError: if any of the source paths are absolute
+        spack.error.InstallError: if any of the source paths are absolute
             or do not exist
             under the build stage
     """

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1517,7 +1517,7 @@ class PackageInstaller:
             # the database, so that we don't need to re-read from file.
             spack.store.STORE.db.add(pkg.spec, explicit=explicit)
 
-        except spack.build_environment.StopPhase as e:
+        except spack.error.StopPhase as e:
             # A StopPhase exception means that do_install was asked to
             # stop early from clients, and is not an error at this point
             pid = f"{self.pid}: " if tty.show_pid() else ""

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -9,6 +9,8 @@ In a normal Spack installation, this is invoked from the bin/spack script
 after the system path is set up.
 """
 import argparse
+
+# import spack.modules.common
 import inspect
 import io
 import operator
@@ -36,6 +38,7 @@ import spack
 import spack.cmd
 import spack.config
 import spack.environment as ev
+import spack.error
 import spack.modules
 import spack.paths
 import spack.platforms
@@ -44,6 +47,7 @@ import spack.spec
 import spack.store
 import spack.util.debug
 import spack.util.environment
+import spack.util.lock
 from spack.error import SpackError
 
 #: names of profile statistics
@@ -763,6 +767,8 @@ def print_setup_info(*info):
     This is in ``main.py`` to make it fast; the setup scripts need to
     invoke spack in login scripts, and it needs to be quick.
     """
+    import spack.modules.common
+
     shell = "csh" if "csh" in info else "sh"
 
     def shell_set(var, value):

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -29,6 +29,7 @@ import spack.caches
 import spack.config
 import spack.error
 import spack.fetch_strategy
+import spack.mirror
 import spack.oci.image
 import spack.repo
 import spack.spec

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -46,6 +46,7 @@ import spack.config
 import spack.deptypes as dt
 import spack.environment
 import spack.error
+import spack.modules
 import spack.paths
 import spack.projections as proj
 import spack.repo

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -11,6 +11,8 @@ Everything in this module is automatically imported into Spack package files.
 from os import chdir, environ, getcwd, makedirs, mkdir, remove, removedirs
 from shutil import move, rmtree
 
+from spack.error import InstallError
+
 # Emulate some shell commands for convenience
 env = environ
 cd = chdir
@@ -84,12 +86,7 @@ from spack.install_test import (
     install_test_root,
     test_part,
 )
-from spack.installer import (
-    ExternalPackageError,
-    InstallError,
-    InstallLockError,
-    UpstreamPackageError,
-)
+from spack.installer import ExternalPackageError, InstallLockError, UpstreamPackageError
 from spack.mixins import filter_compiler_wrappers
 from spack.multimethod import default_args, when
 from spack.package_base import (

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -33,6 +33,8 @@ import llnl.util.tty as tty
 from llnl.util.lang import classproperty, memoized
 from llnl.util.link_tree import LinkTree
 
+import spack.build_environment
+import spack.builder
 import spack.compilers
 import spack.config
 import spack.dependency
@@ -50,6 +52,7 @@ import spack.spec
 import spack.store
 import spack.url
 import spack.util.environment
+import spack.util.executable
 import spack.util.path
 import spack.util.web
 from spack.filesystem_view import YamlFilesystemView

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -55,6 +55,7 @@ import spack.util.environment
 import spack.util.executable
 import spack.util.path
 import spack.util.web
+from spack.error import InstallError, NoURLError, PackageError
 from spack.filesystem_view import YamlFilesystemView
 from spack.install_test import (
     PackageTest,
@@ -64,7 +65,7 @@ from spack.install_test import (
     cache_extra_test_sources,
     install_test_root,
 )
-from spack.installer import InstallError, PackageInstaller
+from spack.installer import PackageInstaller
 from spack.solver.version_order import concretization_version_order
 from spack.stage import DevelopStage, ResourceStage, Stage, StageComposite, compute_stage_name
 from spack.util.executable import ProcessError, which
@@ -2582,20 +2583,6 @@ class PackageStillNeededError(InstallError):
         )
         self.spec = spec
         self.dependents = dependents
-
-
-class PackageError(spack.error.SpackError):
-    """Raised when something is wrong with a package definition."""
-
-    def __init__(self, message, long_msg=None):
-        super().__init__(message, long_msg)
-
-
-class NoURLError(PackageError):
-    """Raised when someone tries to build a URL for a package with no URLs."""
-
-    def __init__(self, cls):
-        super().__init__("Package %s has no version with a URL." % cls.__name__)
 
 
 class InvalidPackageOpError(PackageError):

--- a/lib/spack/spack/package_prefs.py
+++ b/lib/spack/spack/package_prefs.py
@@ -9,7 +9,7 @@ import spack.config
 import spack.error
 import spack.repo
 import spack.spec
-from spack.config import ConfigError
+from spack.error import ConfigError
 from spack.version import Version
 
 _lesser_spec_types = {"compiler": spack.spec.CompilerSpec, "version": Version}

--- a/lib/spack/spack/parser.py
+++ b/lib/spack/spack/parser.py
@@ -70,6 +70,7 @@ import spack.deptypes
 import spack.error
 import spack.spec
 import spack.version
+from spack.error import SpecSyntaxError
 
 IS_WINDOWS = sys.platform == "win32"
 #: Valid name for specs and variants. Here we are not using
@@ -598,10 +599,6 @@ def parse_one_or_raise(
         raise ValueError(message)
 
     return result
-
-
-class SpecSyntaxError(Exception):
-    """Base class for Spec syntax errors"""
 
 
 class SpecTokenizationError(SpecSyntaxError):

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -6,6 +6,7 @@ import collections
 import itertools
 import os
 import re
+import sys
 from collections import OrderedDict
 from typing import List, Optional
 
@@ -18,15 +19,12 @@ from llnl.util.lang import memoized
 from llnl.util.symlink import readlink, symlink
 
 import spack.error
-import spack.platforms
 import spack.store
 import spack.util.elf as elf
 import spack.util.executable as executable
 import spack.util.filesystem as ssys
 
 from .relocate_text import BinaryFilePrefixReplacer, TextFilePrefixReplacer
-
-is_macos = str(spack.platforms.real_host()) == "darwin"  # type: ignore
 
 
 class InstallRootStringError(spack.error.SpackError):
@@ -50,7 +48,7 @@ def _patchelf() -> Optional[executable.Executable]:
     """Return the full path to the patchelf binary, if available, else None."""
     import spack.bootstrap
 
-    if is_macos:
+    if sys.platform == "darwin":
         return None
 
     with spack.bootstrap.ensure_bootstrap_configuration():
@@ -417,7 +415,7 @@ def relocate_macho_binaries(
             # normalized paths
             rel_to_orig = macho_make_paths_normal(orig_path_name, rpaths, deps, idpath)
             # replace the relativized paths with normalized paths
-            if is_macos:
+            if sys.platform == "darwin":
                 modify_macho_object(path_name, rpaths, deps, idpath, rel_to_orig)
             else:
                 modify_object_macholib(path_name, rel_to_orig)
@@ -428,7 +426,7 @@ def relocate_macho_binaries(
                 rpaths, deps, idpath, old_layout_root, prefix_to_prefix
             )
             # replace the old paths with new paths
-            if is_macos:
+            if sys.platform == "darwin":
                 modify_macho_object(path_name, rpaths, deps, idpath, paths_to_paths)
             else:
                 modify_object_macholib(path_name, paths_to_paths)
@@ -439,7 +437,7 @@ def relocate_macho_binaries(
                 path_name, new_layout_root, rpaths, deps, idpath
             )
             # replace the new paths with relativized paths in the new prefix
-            if is_macos:
+            if sys.platform == "darwin":
                 modify_macho_object(path_name, rpaths, deps, idpath, paths_to_paths)
             else:
                 modify_object_macholib(path_name, paths_to_paths)
@@ -451,7 +449,7 @@ def relocate_macho_binaries(
                 rpaths, deps, idpath, old_layout_root, prefix_to_prefix
             )
             # replace the old paths with new paths
-            if is_macos:
+            if sys.platform == "darwin":
                 modify_macho_object(path_name, rpaths, deps, idpath, paths_to_paths)
             else:
                 modify_object_macholib(path_name, paths_to_paths)
@@ -573,7 +571,7 @@ def make_macho_binaries_relative(cur_path_names, orig_path_names, old_layout_roo
     """
     Replace old RPATHs with paths relative to old_dir in binary files
     """
-    if not is_macos:
+    if not sys.platform == "darwin":
         return
 
     for cur_path, orig_path in zip(cur_path_names, orig_path_names):

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -17,6 +17,7 @@ import llnl.util.tty as tty
 from llnl.util.lang import memoized
 from llnl.util.symlink import readlink, symlink
 
+import spack.error
 import spack.platforms
 import spack.store
 import spack.util.elf as elf
@@ -25,7 +26,7 @@ import spack.util.filesystem as ssys
 
 from .relocate_text import BinaryFilePrefixReplacer, TextFilePrefixReplacer
 
-is_macos = str(spack.platforms.real_host()) == "darwin"
+is_macos = str(spack.platforms.real_host()) == "darwin"  # type: ignore
 
 
 class InstallRootStringError(spack.error.SpackError):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -1525,7 +1525,7 @@ class MockRepositoryBuilder:
                 ``spack.dependency.default_deptype`` and ``spack.spec.Spec()`` are used.
         """
         dependencies = dependencies or []
-        context = {"cls_name": spack.util.naming.mod_to_class(name), "dependencies": dependencies}
+        context = {"cls_name": nm.mod_to_class(name), "dependencies": dependencies}
         template = spack.tengine.make_environment().get_template("mock-repository/package.pyt")
         text = template.render(context)
         package_py = self.recipe_filename(name)

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -39,8 +39,10 @@ import spack.config
 import spack.error
 import spack.patch
 import spack.provider_index
+import spack.repo
 import spack.spec
 import spack.tag
+import spack.tengine
 import spack.util.git
 import spack.util.naming as nm
 import spack.util.path

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -42,7 +42,6 @@ import spack.provider_index
 import spack.repo
 import spack.spec
 import spack.tag
-import spack.tengine
 import spack.util.git
 import spack.util.naming as nm
 import spack.util.path
@@ -1524,6 +1523,8 @@ class MockRepositoryBuilder:
                 Both "dep_type" and "condition" can default to ``None`` in which case
                 ``spack.dependency.default_deptype`` and ``spack.spec.Spec()`` are used.
         """
+        import spack.tengine  # avoid circular import
+
         dependencies = dependencies or []
         context = {"cls_name": nm.mod_to_class(name), "dependencies": dependencies}
         template = spack.tengine.make_environment().get_template("mock-repository/package.pyt")

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -22,6 +22,8 @@ from llnl.util.filesystem import working_dir
 import spack
 import spack.paths
 import spack.platforms
+import spack.spec
+import spack.tengine
 import spack.util.git
 from spack.error import SpackError
 from spack.util.crypto import checksum

--- a/lib/spack/spack/rewiring.py
+++ b/lib/spack/spack/rewiring.py
@@ -14,6 +14,7 @@ from llnl.util.symlink import readlink, symlink
 import spack.binary_distribution as bindist
 import spack.error
 import spack.hooks
+import spack.platforms
 import spack.relocate as relocate
 import spack.store
 

--- a/lib/spack/spack/schema/__init__.py
+++ b/lib/spack/spack/schema/__init__.py
@@ -8,6 +8,8 @@ import warnings
 
 import llnl.util.lang
 
+from spack.error import SpecSyntaxError
+
 
 class DeprecationMessage(typing.NamedTuple):
     message: str
@@ -31,7 +33,7 @@ def _make_validator():
         for spec_str in instance:
             try:
                 spack.parser.parse(spec_str)
-            except spack.parser.SpecSyntaxError as e:
+            except SpecSyntaxError as e:
                 yield jsonschema.ValidationError(str(e))
 
     def _deprecated_properties(validator, deprecated, instance, schema):

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -11,6 +11,7 @@ from typing import Any, Dict
 
 from llnl.util.lang import union_dicts
 
+import spack.config
 import spack.schema.projections
 
 #: Properties for inclusion in other schemas

--- a/lib/spack/spack/schema/view.py
+++ b/lib/spack/spack/schema/view.py
@@ -11,6 +11,7 @@
 from typing import Any, Dict
 
 import spack.schema
+import spack.schema.projections
 
 projections_scheme = spack.schema.projections.properties["projections"]
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2168,7 +2168,7 @@ class SpackSolverSetup:
                     matches = [x for x in self.possible_versions[pkg_name] if x.satisfies(v)]
                     matches.sort(reverse=True)
                     if not matches:
-                        raise spack.config.ConfigError(
+                        raise spack.error.ConfigError(
                             f"Preference for version {v} does not match any known "
                             f"version of {pkg_name} (in its package.py or any external)"
                         )
@@ -2798,7 +2798,7 @@ class SpackSolverSetup:
                     # not throw an error, which is just so that users know they need to change
                     # their config, instead of getting a hard to decipher concretization error.
                     if not any(x for x in self.possible_versions[name] if x.satisfies(versions)):
-                        raise spack.config.ConfigError(
+                        raise spack.error.ConfigError(
                             f"Version requirement {versions} on {pkg_name} for {name} "
                             f"cannot match any known version from package.py or externals"
                         )

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -27,7 +27,9 @@ from llnl.util.lang import elide_list
 
 import spack
 import spack.binary_distribution
+import spack.bootstrap.core
 import spack.compilers
+import spack.concretize
 import spack.config
 import spack.config as sc
 import spack.deptypes as dt

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2016,6 +2016,7 @@ class Spec:
     def _lookup_hash(self):
         """Lookup just one spec with an abstract hash, returning a spec from the the environment,
         store, or finally, binary caches."""
+        import spack.binary_distribution
         import spack.environment
 
         active_env = spack.environment.active_environment()

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -33,6 +33,7 @@ import spack.directory_layout
 import spack.error
 import spack.paths
 import spack.spec
+import spack.store
 import spack.util.path
 
 #: default installation root, relative to the Spack install path

--- a/lib/spack/spack/tag.py
+++ b/lib/spack/spack/tag.py
@@ -14,6 +14,8 @@ import spack.util.spack_json as sjson
 
 def _get_installed_package_names():
     """Returns names of packages installed in the active environment."""
+    import spack.environment
+
     specs = spack.environment.installed_specs()
     return [spec.name for spec in specs]
 

--- a/lib/spack/spack/tag.py
+++ b/lib/spack/spack/tag.py
@@ -8,6 +8,7 @@ import copy
 from collections.abc import Mapping
 
 import spack.error
+import spack.repo
 import spack.util.spack_json as sjson
 
 

--- a/lib/spack/spack/target.py
+++ b/lib/spack/spack/target.py
@@ -11,6 +11,7 @@ import llnl.util.tty as tty
 import spack.compiler
 import spack.compilers
 import spack.spec
+import spack.util.executable
 import spack.util.spack_yaml as syaml
 
 

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -27,11 +27,15 @@ from llnl.util.symlink import readlink
 
 import spack.binary_distribution as bindist
 import spack.caches
+import spack.compilers
 import spack.config
 import spack.fetch_strategy
 import spack.hooks.sbang as sbang
 import spack.main
 import spack.mirror
+import spack.paths
+import spack.spec
+import spack.stage
 import spack.store
 import spack.util.gpg
 import spack.util.spack_yaml as syaml

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -9,6 +9,7 @@ import spack.bootstrap
 import spack.bootstrap.config
 import spack.bootstrap.core
 import spack.compilers
+import spack.config
 import spack.environment
 import spack.store
 import spack.util.path

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -16,6 +16,7 @@ import spack.build_environment
 import spack.config
 import spack.deptypes as dt
 import spack.package_base
+import spack.paths
 import spack.spec
 import spack.util.spack_yaml as syaml
 from spack.build_environment import UseMode, _static_to_shared_library, dso_suffix

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -16,7 +16,10 @@ import llnl.util.filesystem as fs
 import spack.build_systems.autotools
 import spack.build_systems.cmake
 import spack.environment
+import spack.package_base
+import spack.paths
 import spack.platforms
+import spack.platforms.test
 from spack.build_environment import ChildError, setup_package
 from spack.spec import Spec
 from spack.util.executable import which

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -16,7 +16,7 @@ import llnl.util.filesystem as fs
 import spack.build_systems.autotools
 import spack.build_systems.cmake
 import spack.environment
-import spack.package_base
+import spack.error
 import spack.paths
 import spack.platforms
 import spack.platforms.test
@@ -268,7 +268,7 @@ class TestCMakePackage:
 
     def test_cmake_bad_generator(self, default_mock_concretization):
         s = default_mock_concretization("cmake-client")
-        with pytest.raises(spack.package_base.InstallError):
+        with pytest.raises(spack.error.InstallError):
             spack.build_systems.cmake.CMakeBuilder.std_args(
                 s.package, generator="Yellow Sticky Notes"
             )

--- a/lib/spack/spack/test/builder.py
+++ b/lib/spack/spack/test/builder.py
@@ -8,7 +8,10 @@ import pytest
 
 from llnl.util.filesystem import touch
 
+import spack.builder
 import spack.paths
+import spack.repo
+import spack.spec
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/buildtask.py
+++ b/lib/spack/spack/test/buildtask.py
@@ -5,6 +5,7 @@
 
 import pytest
 
+import spack.error
 import spack.installer as inst
 import spack.repo
 import spack.spec

--- a/lib/spack/spack/test/buildtask.py
+++ b/lib/spack/spack/test/buildtask.py
@@ -26,7 +26,7 @@ def test_build_task_errors(install_mockery):
         inst.BuildTask(spec.package, None, False, 0, 0, 0, set())
 
     request = inst.BuildRequest(spec.package, {})
-    with pytest.raises(inst.InstallError, match="Cannot create a build task"):
+    with pytest.raises(spack.error.InstallError, match="Cannot create a build task"):
         inst.BuildTask(spec.package, request, False, 0, 0, inst.STATUS_REMOVED, set())
 
 

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -13,6 +13,7 @@ import spack.ci as ci
 import spack.environment as ev
 import spack.error
 import spack.paths as spack_paths
+import spack.spec
 import spack.util.git
 
 

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -15,6 +15,7 @@ import spack.config
 import spack.environment as ev
 import spack.main
 import spack.mirror
+import spack.spec
 
 _bootstrap = spack.main.SpackCommand("bootstrap")
 

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -10,7 +10,6 @@ import pytest
 import spack.cmd.checksum
 import spack.error
 import spack.package_base
-import spack.parser
 import spack.repo
 import spack.spec
 import spack.stage

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -8,6 +8,7 @@ import argparse
 import pytest
 
 import spack.cmd.checksum
+import spack.error
 import spack.package_base
 import spack.parser
 import spack.repo
@@ -304,7 +305,7 @@ def test_checksum_deprecated_version(mock_packages, can_fetch_versions):
 
 def test_checksum_url(mock_packages, config):
     pkg_cls = spack.repo.PATH.get_pkg_class("zlib")
-    with pytest.raises(spack.parser.SpecSyntaxError):
+    with pytest.raises(spack.error.SpecSyntaxError):
         spack_checksum(f"{pkg_cls.url}")
 
 

--- a/lib/spack/spack/test/cmd/clean.py
+++ b/lib/spack/spack/test/cmd/clean.py
@@ -14,6 +14,7 @@ import spack.cmd.clean
 import spack.environment as ev
 import spack.main
 import spack.package_base
+import spack.spec
 import spack.stage
 import spack.store
 

--- a/lib/spack/spack/test/cmd/commands.py
+++ b/lib/spack/spack/test/cmd/commands.py
@@ -10,6 +10,7 @@ import shutil
 import pytest
 
 import spack.cmd
+import spack.cmd.commands
 import spack.main
 import spack.paths
 from spack.cmd.commands import _dest_to_fish_complete, _positional_to_subroutine

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -10,6 +10,7 @@ import pytest
 
 import spack.cmd.compiler
 import spack.compilers
+import spack.config
 import spack.main
 import spack.spec
 import spack.util.pattern

--- a/lib/spack/spack/test/cmd/create.py
+++ b/lib/spack/spack/test/cmd/create.py
@@ -9,6 +9,7 @@ import tarfile
 import pytest
 
 import spack.cmd.create
+import spack.url
 from spack.main import SpackCommand
 from spack.url import UndetectableNameError
 from spack.util.executable import which

--- a/lib/spack/spack/test/cmd/debug.py
+++ b/lib/spack/spack/test/cmd/debug.py
@@ -11,6 +11,7 @@ import pytest
 
 import spack
 import spack.platforms
+import spack.spec
 from spack.main import SpackCommand
 from spack.util.executable import which
 

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -5,6 +5,7 @@
 
 import pytest
 
+import spack.spec
 import spack.store
 from spack.database import InstallStatuses
 from spack.main import SpackCommand

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -11,6 +11,7 @@ import llnl.util.filesystem as fs
 
 import spack.environment as ev
 import spack.error
+import spack.repo
 import spack.spec
 import spack.store
 from spack.main import SpackCommand

--- a/lib/spack/spack/test/cmd/develop.py
+++ b/lib/spack/spack/test/cmd/develop.py
@@ -11,7 +11,11 @@ import llnl.util.filesystem as fs
 
 import spack.config
 import spack.environment as ev
+import spack.package_base
 import spack.spec
+import spack.stage
+import spack.util.git
+import spack.util.path
 from spack.main import SpackCommand
 
 add = SpackCommand("add")

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -7,6 +7,8 @@ import pytest
 
 import spack.cmd.diff
 import spack.main
+import spack.repo
+import spack.spec
 import spack.util.spack_json as sjson
 from spack.test.conftest import create_test_repo
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -24,11 +24,17 @@ import spack.environment.depfile as depfile
 import spack.environment.environment
 import spack.environment.shell
 import spack.error
+import spack.main
 import spack.modules
+import spack.modules.tcl
 import spack.package_base
 import spack.paths
 import spack.repo
+import spack.solver.asp
+import spack.spec
+import spack.stage
 import spack.store
+import spack.util.environment
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml
 from spack.cmd.env import _env_create

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1166,7 +1166,7 @@ spack:
     )
     with ev.Environment(tmp_path):
         assert spack.spec.Spec("mpich").concretized().satisfies("@3.0.3")
-        with pytest.raises(spack.config.ConfigError, match="not a list"):
+        with pytest.raises(spack.error.ConfigError, match="not a list"):
             config("change", "packages:mpich:require:~debug")
 
 
@@ -1194,7 +1194,7 @@ def test_env_with_included_config_missing_file(tmpdir, mutable_empty_config):
     with spack_yaml.open("w") as f:
         f.write("spack:\n  include:\n    - {0}\n".format(missing_file.strpath))
 
-    with pytest.raises(spack.config.ConfigError, match="missing include path"):
+    with pytest.raises(spack.error.ConfigError, match="missing include path"):
         ev.Environment(tmpdir.strpath)
 
 

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -12,6 +12,8 @@ from llnl.util.filesystem import getuid, touch
 
 import spack
 import spack.cmd.external
+import spack.config
+import spack.cray_manifest
 import spack.detection
 import spack.detection.path
 import spack.repo

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -14,6 +14,7 @@ import pytest
 import spack.cmd as cmd
 import spack.cmd.find
 import spack.environment as ev
+import spack.store
 import spack.user_environment as uenv
 from spack.main import SpackCommand
 from spack.spec import Spec

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -17,11 +17,13 @@ import pytest
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
+import spack.build_environment
 import spack.cmd.common.arguments
 import spack.cmd.install
 import spack.config
 import spack.environment as ev
 import spack.hash_types as ht
+import spack.installer
 import spack.package_base
 import spack.store
 from spack.error import SpackError

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -22,13 +22,13 @@ import spack.cmd.common.arguments
 import spack.cmd.install
 import spack.config
 import spack.environment as ev
+import spack.error
 import spack.hash_types as ht
 import spack.installer
 import spack.package_base
 import spack.store
-from spack.error import SpackError
+from spack.error import SpackError, SpecSyntaxError
 from spack.main import SpackCommand
-from spack.parser import SpecSyntaxError
 from spack.spec import Spec
 
 install = SpackCommand("install")
@@ -422,7 +422,7 @@ def test_junit_output_with_failures(tmpdir, exc_typename, msg):
 @pytest.mark.parametrize(
     "exc_typename,expected_exc,msg",
     [
-        ("RuntimeError", spack.installer.InstallError, "something weird happened"),
+        ("RuntimeError", spack.error.InstallError, "something weird happened"),
         ("KeyboardInterrupt", KeyboardInterrupt, "Ctrl-C strikes again"),
     ],
 )
@@ -706,7 +706,7 @@ def test_install_only_package(tmpdir, mock_fetch, install_mockery, capfd):
     with capfd.disabled():
         try:
             install("--only", "package", "dependent-install")
-        except spack.installer.InstallError as e:
+        except spack.error.InstallError as e:
             msg = str(e)
 
     assert "Cannot proceed with dependent-install" in msg

--- a/lib/spack/spack/test/cmd/is_git_repo.py
+++ b/lib/spack/spack/test/cmd/is_git_repo.py
@@ -11,6 +11,8 @@ import pytest
 from llnl.util.filesystem import mkdirp, working_dir
 
 import spack
+import spack.cmd
+import spack.fetch_strategy
 from spack.version import ver
 
 

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -7,6 +7,7 @@ import os.path
 import sys
 from textwrap import dedent
 
+import spack.paths
 import spack.repo
 from spack.main import SpackCommand
 

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -11,6 +11,7 @@ from llnl.util.filesystem import mkdirp
 
 import spack.environment as ev
 import spack.paths
+import spack.spec
 import spack.stage
 from spack.main import SpackCommand, SpackCommandError
 

--- a/lib/spack/spack/test/cmd/logs.py
+++ b/lib/spack/spack/test/cmd/logs.py
@@ -13,6 +13,9 @@ from io import BytesIO, TextIOWrapper
 import pytest
 
 import spack
+import spack.cmd.logs
+import spack.main
+import spack.spec
 from spack.main import SpackCommand
 
 logs = SpackCommand("logs")

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -10,8 +10,11 @@ import pytest
 import spack.cmd.mirror
 import spack.config
 import spack.environment as ev
+import spack.error
+import spack.mirror
 import spack.spec
 import spack.util.url as url_util
+import spack.version
 from spack.main import SpackCommand, SpackCommandError
 
 mirror = SpackCommand("mirror")

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -11,6 +11,8 @@ import pytest
 import spack.config
 import spack.main
 import spack.modules
+import spack.modules.lmod
+import spack.repo
 import spack.spec
 import spack.store
 

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -12,6 +12,7 @@ from llnl.util.filesystem import mkdirp, working_dir
 
 import spack.cmd.pkg
 import spack.main
+import spack.paths
 import spack.repo
 import spack.util.file_cache
 

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -142,7 +142,7 @@ def test_spec_returncode():
 
 
 def test_spec_parse_error():
-    with pytest.raises(spack.parser.SpecSyntaxError) as e:
+    with pytest.raises(spack.error.SpecSyntaxError) as e:
         spec("1.15:")
 
     # make sure the error is formatted properly

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -9,7 +9,6 @@ import pytest
 
 import spack.environment as ev
 import spack.error
-import spack.parser
 import spack.spec
 import spack.store
 from spack.main import SpackCommand, SpackCommandError

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -11,6 +11,7 @@ import pytest
 
 from llnl.util.filesystem import FileFilter
 
+import spack.cmd.style
 import spack.main
 import spack.paths
 import spack.repo

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -12,6 +12,7 @@ import llnl.util.filesystem as fs
 
 import spack.compiler
 import spack.compilers
+import spack.config
 import spack.spec
 import spack.util.module_cmd
 from spack.compiler import Compiler

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -22,10 +22,13 @@ import spack.deptypes as dt
 import spack.detection
 import spack.error
 import spack.hash_types as ht
+import spack.paths
 import spack.platforms
+import spack.platforms.test
 import spack.repo
 import spack.solver.asp
 import spack.solver.version_order
+import spack.spec
 import spack.store
 import spack.util.file_cache
 import spack.variant as vt

--- a/lib/spack/spack/test/concretize_errors.py
+++ b/lib/spack/spack/test/concretize_errors.py
@@ -5,6 +5,7 @@
 
 import pytest
 
+import spack.config
 import spack.solver.asp
 import spack.spec
 

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -11,6 +11,8 @@ import pytest
 import spack.config
 import spack.package_prefs
 import spack.repo
+import spack.spec
+import spack.util.module_cmd
 import spack.util.spack_yaml as syaml
 from spack.config import ConfigError
 from spack.spec import CompilerSpec, Spec

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -14,7 +14,7 @@ import spack.repo
 import spack.spec
 import spack.util.module_cmd
 import spack.util.spack_yaml as syaml
-from spack.config import ConfigError
+from spack.error import ConfigError
 from spack.spec import CompilerSpec, Spec
 from spack.version import Version
 
@@ -229,7 +229,7 @@ mpileaks:
         """Preference should not specify an undefined version"""
         update_packages("python", "version", ["3.5.0.1"])
         spec = Spec("python")
-        with pytest.raises(spack.config.ConfigError):
+        with pytest.raises(ConfigError):
             spec.concretize()
 
     def test_preferred_truncated(self):

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -11,6 +11,7 @@ import spack.config
 import spack.error
 import spack.package_base
 import spack.repo
+import spack.solver.asp
 import spack.util.spack_yaml as syaml
 import spack.version
 from spack.solver.asp import InternalConcretizerError, UnsatisfiableSpecError

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -138,7 +138,7 @@ packages:
     require: "@1.2"
 """
     update_packages_config(conf_str)
-    with pytest.raises(spack.config.ConfigError):
+    with pytest.raises(spack.error.ConfigError):
         Spec("x").concretize()
 
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -20,12 +20,14 @@ import spack.directory_layout
 import spack.environment as ev
 import spack.package_base
 import spack.paths
+import spack.platforms
 import spack.repo
 import spack.schema.compilers
 import spack.schema.config
 import spack.schema.env
 import spack.schema.mirrors
 import spack.schema.repos
+import spack.spec
 import spack.store
 import spack.util.path as spack_path
 import spack.util.spack_yaml as syaml

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -18,6 +18,7 @@ from llnl.util.filesystem import join_path, touch, touchp
 import spack.config
 import spack.directory_layout
 import spack.environment as ev
+import spack.error
 import spack.package_base
 import spack.paths
 import spack.platforms
@@ -312,7 +313,7 @@ def test_add_config_path_with_enumerated_type(mutable_config):
     spack.config.add("config:flags:keep_werror:specific")
     assert spack.config.get("config")["flags"]["keep_werror"] == "specific"
 
-    with pytest.raises(spack.config.ConfigError):
+    with pytest.raises(spack.error.ConfigError):
         spack.config.add("config:flags:keep_werror:foo")
 
 
@@ -871,10 +872,10 @@ def test_bad_command_line_scopes(tmp_path, config):
 
     file_path.write_text("")
 
-    with pytest.raises(spack.config.ConfigError):
+    with pytest.raises(spack.error.ConfigError):
         spack.config._add_command_line_scopes(cfg, [str(file_path)])
 
-    with pytest.raises(spack.config.ConfigError):
+    with pytest.raises(spack.error.ConfigError):
         spack.config._add_command_line_scopes(cfg, [str(non_existing_path)])
 
 
@@ -992,7 +993,7 @@ config:
     data = scope.get_section("config")
     assert data["config"]["install_tree"] == {"root": "dummy_tree_value"}
 
-    with pytest.raises(spack.config.ConfigError):
+    with pytest.raises(spack.error.ConfigError):
         scope._write_section("config")
 
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -38,17 +38,21 @@ import spack.caches
 import spack.compiler
 import spack.compilers
 import spack.config
+import spack.directives
 import spack.environment as ev
 import spack.error
+import spack.modules.common
 import spack.package_base
 import spack.paths
 import spack.platforms
 import spack.repo
 import spack.solver.asp
+import spack.spec
 import spack.stage
 import spack.store
 import spack.subprocess_context
 import spack.util.executable
+import spack.util.file_cache
 import spack.util.git
 import spack.util.gpg
 import spack.util.parallel

--- a/lib/spack/spack/test/container/images.py
+++ b/lib/spack/spack/test/container/images.py
@@ -7,6 +7,7 @@ import os.path
 import pytest
 
 import spack.container
+import spack.container.images
 
 
 @pytest.mark.parametrize(

--- a/lib/spack/spack/test/cray_manifest.py
+++ b/lib/spack/spack/test/cray_manifest.py
@@ -19,6 +19,8 @@ import spack.cmd
 import spack.cmd.external
 import spack.compilers
 import spack.cray_manifest as cray_manifest
+import spack.platforms
+import spack.platforms.test
 import spack.solver.asp
 import spack.spec
 import spack.store

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -13,6 +13,8 @@ import sys
 
 import pytest
 
+import spack.subprocess_context
+
 try:
     import uuid
 

--- a/lib/spack/spack/test/detection.py
+++ b/lib/spack/spack/test/detection.py
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import collections
 
+import spack.config
 import spack.detection
+import spack.detection.common
 import spack.spec
 
 

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -14,8 +14,11 @@ import pytest
 
 from llnl.path import path_to_os_path
 
+import spack.hash_types
 import spack.paths
 import spack.repo
+import spack.spec
+import spack.util.file_cache
 from spack.directory_layout import DirectoryLayout, InvalidDirectoryLayoutParametersError
 from spack.spec import Spec
 

--- a/lib/spack/spack/test/env.py
+++ b/lib/spack/spack/test/env.py
@@ -11,7 +11,9 @@ import pytest
 
 import llnl.util.filesystem as fs
 
+import spack.config
 import spack.environment as ev
+import spack.solver.asp
 import spack.spec
 from spack.environment.environment import (
     EnvironmentManifestFile,

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -12,6 +12,9 @@ import pytest
 from llnl.util.filesystem import mkdirp, touch, working_dir
 
 import spack.config
+import spack.error
+import spack.fetch_strategy
+import spack.platforms
 import spack.repo
 from spack.fetch_strategy import GitFetchStrategy
 from spack.spec import Spec

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -23,8 +23,8 @@ import spack.repo
 import spack.store
 import spack.util.spack_json as sjson
 from spack import binary_distribution
+from spack.error import InstallError
 from spack.package_base import (
-    InstallError,
     PackageBase,
     PackageStillNeededError,
     _spack_build_envfile,

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -11,10 +11,13 @@ import pytest
 
 import llnl.util.filesystem as fs
 
+import spack.build_environment
 import spack.config
 import spack.database
 import spack.error
+import spack.installer
 import spack.mirror
+import spack.package_base
 import spack.patch
 import spack.repo
 import spack.store

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -137,7 +137,9 @@ def test_install_from_cache_errors(install_mockery):
     assert spec.concrete
 
     # Check with cache-only
-    with pytest.raises(inst.InstallError, match="No binary found when cache-only was specified"):
+    with pytest.raises(
+        spack.error.InstallError, match="No binary found when cache-only was specified"
+    ):
         spec.package.do_install(package_cache_only=True, dependencies_cache_only=True)
     assert not spec.package.installed_from_binary_cache
 
@@ -583,7 +585,7 @@ def test_check_deps_status_install_failure(install_mockery):
     installer = create_installer(["pkg-a"], {})
     request = installer.build_requests[0]
 
-    with pytest.raises(inst.InstallError, match="install failure"):
+    with pytest.raises(spack.error.InstallError, match="install failure"):
         installer._check_deps_status(request)
 
 
@@ -594,7 +596,7 @@ def test_check_deps_status_write_locked(install_mockery, monkeypatch):
     # Ensure the lock is not acquired
     monkeypatch.setattr(inst.PackageInstaller, "_ensure_locked", _not_locked)
 
-    with pytest.raises(inst.InstallError, match="write locked by another"):
+    with pytest.raises(spack.error.InstallError, match="write locked by another"):
         installer._check_deps_status(request)
 
 
@@ -801,7 +803,7 @@ def test_install_uninstalled_deps(install_mockery, monkeypatch, capsys):
     monkeypatch.setattr(inst.PackageInstaller, "_update_failed", _noop)
 
     msg = "Cannot proceed with dependent-install"
-    with pytest.raises(inst.InstallError, match=msg):
+    with pytest.raises(spack.error.InstallError, match=msg):
         installer.install()
 
     out = str(capsys.readouterr())
@@ -815,7 +817,7 @@ def test_install_failed(install_mockery, monkeypatch, capsys):
     # Make sure the package is identified as failed
     monkeypatch.setattr(spack.database.FailureTracker, "has_failed", _true)
 
-    with pytest.raises(inst.InstallError, match="request failed"):
+    with pytest.raises(spack.error.InstallError, match="request failed"):
         installer.install()
 
     out = str(capsys.readouterr())
@@ -830,7 +832,7 @@ def test_install_failed_not_fast(install_mockery, monkeypatch, capsys):
     # Make sure the package is identified as failed
     monkeypatch.setattr(spack.database.FailureTracker, "has_failed", _true)
 
-    with pytest.raises(inst.InstallError, match="request failed"):
+    with pytest.raises(spack.error.InstallError, match="request failed"):
         installer.install()
 
     out = str(capsys.readouterr())
@@ -906,7 +908,7 @@ def test_install_fail_multi(install_mockery, monkeypatch):
     # Raise a KeyboardInterrupt error to trigger early termination
     monkeypatch.setattr(inst.PackageInstaller, "_install_task", _install)
 
-    with pytest.raises(inst.InstallError, match="Installation request failed"):
+    with pytest.raises(spack.error.InstallError, match="Installation request failed"):
         installer.install()
 
     assert "pkg-a" in installer.installed  # ensure the the second spec installed
@@ -924,7 +926,7 @@ def test_install_fail_fast_on_detect(install_mockery, monkeypatch, capsys):
     # This will prevent b from installing, which will cause the build of c to be skipped.
     monkeypatch.setattr(spack.database.FailureTracker, "has_failed", _true)
 
-    with pytest.raises(inst.InstallError, match="after first install failure"):
+    with pytest.raises(spack.error.InstallError, match="after first install failure"):
         installer.install()
 
     assert b_id in installer.failed, "Expected b to be marked as failed"
@@ -952,7 +954,7 @@ def test_install_fail_fast_on_except(install_mockery, monkeypatch, capsys):
         spack.package_base.PackageBase, "do_patch", _test_install_fail_fast_on_except_patch
     )
 
-    with pytest.raises(inst.InstallError, match="mock patch failure"):
+    with pytest.raises(spack.error.InstallError, match="mock patch failure"):
         installer.install()
 
     out = str(capsys.readouterr())
@@ -973,7 +975,7 @@ def test_install_lock_failures(install_mockery, monkeypatch, capfd):
     # Ensure don't continually requeue the task
     monkeypatch.setattr(inst.PackageInstaller, "_requeue_task", _requeued)
 
-    with pytest.raises(inst.InstallError, match="request failed"):
+    with pytest.raises(spack.error.InstallError, match="request failed"):
         installer.install()
 
     out = capfd.readouterr()[0]
@@ -1004,7 +1006,7 @@ def test_install_lock_installed_requeue(install_mockery, monkeypatch, capfd):
     # Ensure don't continually requeue the task
     monkeypatch.setattr(inst.PackageInstaller, "_requeue_task", _requeued)
 
-    with pytest.raises(inst.InstallError, match="request failed"):
+    with pytest.raises(spack.error.InstallError, match="request failed"):
         installer.install()
 
     assert b_pkg_id not in installer.installed
@@ -1040,7 +1042,7 @@ def test_install_read_locked_requeue(install_mockery, monkeypatch, capfd):
 
     installer = create_installer(["pkg-b"], {})
 
-    with pytest.raises(inst.InstallError, match="request failed"):
+    with pytest.raises(spack.error.InstallError, match="request failed"):
         installer.install()
 
     assert "b" not in installer.installed

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -19,6 +19,8 @@ import llnl.util.tty as tty
 import spack.binary_distribution
 import spack.database
 import spack.deptypes as dt
+import spack.error
+import spack.hooks
 import spack.installer as inst
 import spack.package_base
 import spack.package_prefs as prefs

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -12,8 +12,11 @@ from llnl.util.symlink import readlink
 import spack.cmd.modules
 import spack.config
 import spack.error
+import spack.modules.common
 import spack.modules.tcl
 import spack.package_base
+import spack.package_prefs
+import spack.repo
 import spack.spec
 from spack.modules.common import UpstreamModuleIndex
 from spack.spec import Spec

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -218,8 +218,8 @@ def test_check_module_set_name(mutable_config):
 
     # Invalid module set names
     msg = "Valid module set names are"
-    with pytest.raises(spack.config.ConfigError, match=msg):
+    with pytest.raises(spack.error.ConfigError, match=msg):
         spack.cmd.modules.check_module_set_name("prefix_inspections")
 
-    with pytest.raises(spack.config.ConfigError, match=msg):
+    with pytest.raises(spack.error.ConfigError, match=msg):
         spack.cmd.modules.check_module_set_name("third")

--- a/lib/spack/spack/test/modules/conftest.py
+++ b/lib/spack/spack/test/modules/conftest.py
@@ -6,6 +6,8 @@ import pathlib
 
 import pytest
 
+import spack.modules.lmod
+import spack.modules.tcl
 import spack.spec
 
 

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -9,10 +9,13 @@ import pytest
 
 import archspec.cpu
 
+import spack.config
 import spack.environment as ev
 import spack.main
+import spack.modules.common
 import spack.modules.lmod
 import spack.spec
+import spack.util.environment
 
 mpich_spec_string = "mpich@3.0.4"
 mpileaks_spec_string = "mpileaks"

--- a/lib/spack/spack/test/multimethod.py
+++ b/lib/spack/spack/test/multimethod.py
@@ -7,6 +7,7 @@
 
 import pytest
 
+import spack.config
 import spack.platforms
 import spack.spec
 from spack.multimethod import NoSuchMethodError

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -17,7 +17,10 @@ import pytest
 
 import llnl.util.filesystem as fs
 
+import spack.compilers
+import spack.config
 import spack.deptypes as dt
+import spack.error
 import spack.install_test
 import spack.package_base
 import spack.repo

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -26,7 +26,7 @@ import spack.package_base
 import spack.repo
 import spack.spec
 from spack.build_systems.generic import Package
-from spack.installer import InstallError
+from spack.error import InstallError
 
 
 @pytest.fixture(scope="module")

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -7,8 +7,10 @@ import os
 
 import pytest
 
+import spack.build_environment
 import spack.directives
 import spack.fetch_strategy
+import spack.package_base
 import spack.repo
 from spack.paths import mock_packages_path
 from spack.spec import Spec

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -9,6 +9,7 @@ import pytest
 
 import spack.build_environment
 import spack.directives
+import spack.error
 import spack.fetch_strategy
 import spack.package_base
 import spack.repo
@@ -129,10 +130,10 @@ def test_urls_for_versions(mock_packages, config):
 def test_url_for_version_with_no_urls(mock_packages, config):
     spec = Spec("git-test")
     pkg_cls = spack.repo.PATH.get_pkg_class(spec.name)
-    with pytest.raises(spack.package_base.NoURLError):
+    with pytest.raises(spack.error.NoURLError):
         pkg_cls(spec).url_for_version("1.0")
 
-    with pytest.raises(spack.package_base.NoURLError):
+    with pytest.raises(spack.error.NoURLError):
         pkg_cls(spec).url_for_version("1.1")
 
 

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -21,9 +21,12 @@ from llnl.util.symlink import readlink, symlink
 
 import spack.binary_distribution as bindist
 import spack.cmd.buildcache as buildcache
+import spack.config
 import spack.error
 import spack.fetch_strategy
+import spack.mirror
 import spack.package_base
+import spack.stage
 import spack.util.gpg
 import spack.util.url as url_util
 from spack.fetch_strategy import URLFetchStrategy

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -14,9 +14,12 @@ import pytest
 from llnl.util.filesystem import mkdirp, touch, working_dir
 
 import spack.error
+import spack.fetch_strategy
 import spack.patch
 import spack.paths
 import spack.repo
+import spack.spec
+import spack.stage
 import spack.util.url as url_util
 from spack.spec import Spec
 from spack.stage import Stage

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -12,6 +12,7 @@ import pytest
 import spack.platforms
 import spack.relocate
 import spack.relocate_text as relocate_text
+import spack.repo
 import spack.util.executable
 
 pytestmark = pytest.mark.not_on_windows("Tests fail on Windows")

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -17,6 +17,7 @@ import pytest
 
 import llnl.util.filesystem as fs
 
+import spack.config
 import spack.hooks.sbang as sbang
 import spack.store
 import spack.util.spack_yaml as syaml

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -9,7 +9,6 @@ import pytest
 
 import spack.deptypes as dt
 import spack.error
-import spack.parser
 import spack.repo
 import spack.util.hash as hashutil
 import spack.version

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -12,6 +12,7 @@ import spack.error
 import spack.parser
 import spack.repo
 import spack.util.hash as hashutil
+import spack.version
 from spack.dependency import Dependency
 from spack.spec import Spec
 

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -742,7 +742,7 @@ class TestSpecDag:
 
     def test_invalid_literal_spec(self):
         # Can't give type 'build' to a top-level spec
-        with pytest.raises(spack.parser.SpecSyntaxError):
+        with pytest.raises(spack.error.SpecSyntaxError):
             Spec.from_literal({"foo:build": None})
 
         # Can't use more than one ':' separator

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -9,6 +9,12 @@ import pytest
 
 import spack.directives
 import spack.error
+import spack.parser
+import spack.paths
+import spack.solver.asp
+import spack.spec
+import spack.store
+import spack.variant
 from spack.error import SpecError, UnsatisfiableSpecError
 from spack.spec import (
     ArchSpec,

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -9,8 +9,11 @@ import sys
 
 import pytest
 
+import spack.binary_distribution
 import spack.cmd
+import spack.parser
 import spack.platforms.test
+import spack.repo
 import spack.spec
 from spack.parser import (
     UNIX_FILENAME,

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -17,6 +17,7 @@ import pytest
 from llnl.util.filesystem import getuid, mkdirp, partition_path, touch, working_dir
 from llnl.util.symlink import readlink
 
+import spack.config
 import spack.error
 import spack.fetch_strategy
 import spack.stage

--- a/lib/spack/spack/test/tag.py
+++ b/lib/spack/spack/test/tag.py
@@ -7,6 +7,7 @@ import io
 
 import pytest
 
+import spack.repo
 import spack.tag
 from spack.main import SpackCommand
 

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -10,8 +10,10 @@ import pytest
 
 from llnl.util.filesystem import join_path, mkdirp, touch
 
+import spack.config
 import spack.install_test
 import spack.spec
+import spack.util.executable
 from spack.install_test import TestStatus
 from spack.util.executable import which
 

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -17,9 +17,11 @@ from llnl.util.filesystem import is_exe, working_dir
 import spack.config
 import spack.error
 import spack.fetch_strategy as fs
+import spack.url
 import spack.util.crypto as crypto
 import spack.util.executable
 import spack.util.web as web_util
+import spack.version
 from spack.spec import Spec
 from spack.stage import Stage
 from spack.util.executable import which

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -12,6 +12,7 @@ import pytest
 import llnl.util.filesystem as fs
 
 import spack
+import spack.main
 import spack.util.executable as ex
 from spack.hooks.sbang import filter_shebangs_in_directory
 

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -16,6 +16,7 @@ from llnl.util.filesystem import working_dir
 
 import spack.package_base
 import spack.spec
+import spack.version
 from spack.version import (
     EmptyRangeError,
     GitVersion,


### PR DESCRIPTION
Adds missing `import spack.*` statements.

This makes various implicit circularities explicit. Many issues were solved by moving `spack.installer.InstallError` and `spack.parser.SpecSyntaxError` and other errors into `spack.error`.

First commit is automated, next commits are manual fixes.