### PR TITLE
Add repositories for "requirements" and "flag mixing" unit tests 

### DIFF
--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -522,13 +522,11 @@ packages:
 
 @pytest.mark.parametrize("mpi_requirement", ["mpich", "mpich2", "zmpi"])
 def test_requirements_on_virtual(mpi_requirement, concretize_scope, mock_packages):
-    conf_str = """\
+    conf_str = f"""\
 packages:
   mpi:
-    require: "{}"
-""".format(
-        mpi_requirement
-    )
+    require: "{mpi_requirement}"
+"""
     update_packages_config(conf_str)
 
     spec = Spec("callpath").concretized()

--- a/lib/spack/spack/test/concretize_requirements.py
+++ b/lib/spack/spack/test/concretize_requirements.py
@@ -15,7 +15,6 @@ import spack.util.spack_yaml as syaml
 import spack.version
 from spack.solver.asp import InternalConcretizerError, UnsatisfiableSpecError
 from spack.spec import Spec
-from spack.test.conftest import create_test_repo
 from spack.util.url import path_to_file_url
 
 
@@ -24,76 +23,10 @@ def update_packages_config(conf_str):
     spack.config.set("packages", conf["packages"], scope="concretize")
 
 
-_pkgx = (
-    "x",
-    """\
-class X(Package):
-    version("1.1")
-    version("1.0")
-    version("0.9")
-
-    variant("shared", default=True,
-            description="Build shared libraries")
-
-    depends_on("y")
-""",
-)
-
-
-_pkgy = (
-    "y",
-    """\
-class Y(Package):
-    version("2.5")
-    version("2.4")
-    version("2.3", deprecated=True)
-
-    variant("shared", default=True,
-            description="Build shared libraries")
-""",
-)
-
-
-_pkgv = (
-    "v",
-    """\
-class V(Package):
-    version("2.1")
-    version("2.0")
-""",
-)
-
-
-_pkgt = (
-    "t",
-    """\
-class T(Package):
-    version('2.1')
-    version('2.0')
-
-    depends_on('u', when='@2.1:')
-""",
-)
-
-
-_pkgu = (
-    "u",
-    """\
-class U(Package):
-    version('1.1')
-    version('1.0')
-""",
-)
-
-
 @pytest.fixture
-def _create_test_repo(tmpdir, mutable_config):
-    yield create_test_repo(tmpdir, [_pkgx, _pkgy, _pkgv, _pkgt, _pkgu])
-
-
-@pytest.fixture
-def test_repo(_create_test_repo, monkeypatch, mock_stage):
-    with spack.repo.use_repositories(_create_test_repo) as mock_repo_path:
+def test_repo(mutable_config, monkeypatch, mock_stage):
+    repo_dir = pathlib.Path(spack.paths.repos_path) / "requirements.test"
+    with spack.repo.use_repositories(str(repo_dir)) as mock_repo_path:
         yield mock_repo_path
 
 
@@ -491,23 +424,24 @@ packages:
     assert s2.satisfies("@2.5")
 
 
-def test_reuse_oneof(concretize_scope, _create_test_repo, mutable_database, mock_fetch):
+def test_reuse_oneof(concretize_scope, test_repo, tmp_path, mock_fetch):
     conf_str = """\
 packages:
   y:
     require:
-    - one_of: ["@2.5", "%gcc"]
+    - one_of: ["@2.5", "~shared"]
 """
 
-    with spack.repo.use_repositories(_create_test_repo):
-        s1 = Spec("y@2.5%gcc").concretized()
+    store_dir = tmp_path / "store"
+    with spack.store.use_store(str(store_dir)):
+        s1 = Spec("y@2.5 ~shared").concretized()
         s1.package.do_install(fake=True, explicit=True)
 
         update_packages_config(conf_str)
 
         with spack.config.override("concretizer:reuse", True):
             s2 = Spec("y").concretized()
-            assert not s2.satisfies("@2.5 %gcc")
+            assert not s2.satisfies("@2.5 ~shared")
 
 
 @pytest.mark.parametrize(
@@ -546,13 +480,11 @@ packages:
 @pytest.mark.parametrize("spec_str,requirement_str", [("x", "%gcc"), ("x", "%clang")])
 def test_default_requirements_with_all(spec_str, requirement_str, concretize_scope, test_repo):
     """Test that default requirements are applied to all packages."""
-    conf_str = """\
+    conf_str = f"""\
 packages:
   all:
-    require: "{}"
-""".format(
-        requirement_str
-    )
+    require: "{requirement_str}"
+"""
     update_packages_config(conf_str)
 
     spec = Spec(spec_str).concretized()
@@ -573,15 +505,13 @@ def test_default_and_package_specific_requirements(
     """Test that specific package requirements override default package requirements."""
     generic_req, specific_req = requirements
     generic_exp, specific_exp = expectations
-    conf_str = """\
+    conf_str = f"""\
 packages:
   all:
-    require: "{}"
+    require: "{generic_req}"
   x:
-    require: "{}"
-""".format(
-        generic_req, specific_req
-    )
+    require: "{specific_req}"
+"""
     update_packages_config(conf_str)
 
     spec = Spec("x").concretized()
@@ -613,15 +543,13 @@ packages:
 def test_requirements_on_virtual_and_on_package(
     mpi_requirement, specific_requirement, concretize_scope, mock_packages
 ):
-    conf_str = """\
+    conf_str = f"""\
 packages:
   mpi:
-    require: "{0}"
-  {0}:
-    require: "{1}"
-""".format(
-        mpi_requirement, specific_requirement
-    )
+    require: "{mpi_requirement}"
+  {mpi_requirement}:
+    require: "{specific_requirement}"
+"""
     update_packages_config(conf_str)
 
     spec = Spec("callpath").concretized()

--- a/lib/spack/spack/test/flag_mixing.py
+++ b/lib/spack/spack/test/flag_mixing.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import pathlib
+
 import pytest
 
 import spack.config
@@ -9,7 +11,6 @@ import spack.environment as ev
 import spack.repo
 import spack.util.spack_yaml as syaml
 from spack.spec import Spec
-from spack.test.conftest import create_test_repo
 
 """
 These tests include the following package DAGs:
@@ -40,90 +41,11 @@ u x
 y
 """
 
-_pkgx = (
-    "x",
-    """\
-class X(Package):
-    version("1.1")
-    version("1.0")
-
-    variant("activatemultiflag", default=False)
-    depends_on('y cflags="-d1"', when="~activatemultiflag")
-    depends_on('y cflags="-d1 -d2"', when="+activatemultiflag")
-""",
-)
-
-
-_pkgy = (
-    "y",
-    """\
-class Y(Package):
-    version("2.1")
-    version("2.0")
-""",
-)
-
-
-_pkgw = (
-    "w",
-    """\
-class W(Package):
-    version("3.1")
-    version("3.0")
-
-    variant("moveflaglater", default=False)
-
-    depends_on('x +activatemultiflag')
-    depends_on('y cflags="-d0"', when="~moveflaglater")
-    depends_on('y cflags="-d3"', when="+moveflaglater")
-""",
-)
-
-
-_pkgv = (
-    "v",
-    """\
-class V(Package):
-    version("4.1")
-    version("4.0")
-
-    depends_on("y")
-""",
-)
-
-
-_pkgt = (
-    "t",
-    """\
-class T(Package):
-    version("5.0")
-
-    depends_on("u")
-    depends_on("x+activatemultiflag")
-    depends_on("y cflags='-c1 -c2'")
-""",
-)
-
-
-_pkgu = (
-    "u",
-    """\
-class U(Package):
-    version("6.0")
-
-    depends_on("y cflags='-e1 -e2'")
-""",
-)
-
 
 @pytest.fixture
-def _create_test_repo(tmpdir, mutable_config):
-    yield create_test_repo(tmpdir, [_pkgt, _pkgu, _pkgv, _pkgw, _pkgx, _pkgy])
-
-
-@pytest.fixture
-def test_repo(_create_test_repo, monkeypatch, mock_stage):
-    with spack.repo.use_repositories(_create_test_repo) as mock_repo_path:
+def test_repo(mutable_config, monkeypatch, mock_stage):
+    repo_dir = pathlib.Path(spack.paths.repos_path) / "flags.test"
+    with spack.repo.use_repositories(str(repo_dir)) as mock_repo_path:
         yield mock_repo_path
 
 

--- a/var/spack/repos/flags.test/packages/t/package.py
+++ b/var/spack/repos/flags.test/packages/t/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class T(Package):
+    version("5.0")
+
+    depends_on("u")
+    depends_on("x+activatemultiflag")
+    depends_on("y cflags='-c1 -c2'")
+
+    depends_on("c", type="build")

--- a/var/spack/repos/flags.test/packages/u/package.py
+++ b/var/spack/repos/flags.test/packages/u/package.py
@@ -1,0 +1,11 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class U(Package):
+    version("6.0")
+
+    depends_on("y cflags='-e1 -e2'")

--- a/var/spack/repos/flags.test/packages/v/package.py
+++ b/var/spack/repos/flags.test/packages/v/package.py
@@ -1,0 +1,14 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class V(Package):
+    version("4.1")
+    version("4.0")
+
+    depends_on("y")
+
+    depends_on("c", type="build")

--- a/var/spack/repos/flags.test/packages/w/package.py
+++ b/var/spack/repos/flags.test/packages/w/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class W(Package):
+    version("3.1")
+    version("3.0")
+
+    variant("moveflaglater", default=False)
+
+    depends_on("x +activatemultiflag")
+    depends_on('y cflags="-d0"', when="~moveflaglater")
+    depends_on('y cflags="-d3"', when="+moveflaglater")
+
+    depends_on("c", type="build")

--- a/var/spack/repos/flags.test/packages/x/package.py
+++ b/var/spack/repos/flags.test/packages/x/package.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class X(Package):
+    version("1.1")
+    version("1.0")
+
+    variant("activatemultiflag", default=False)
+    depends_on('y cflags="-d1"', when="~activatemultiflag")
+    depends_on('y cflags="-d1 -d2"', when="+activatemultiflag")
+
+    depends_on("c", type="build")

--- a/var/spack/repos/flags.test/packages/y/package.py
+++ b/var/spack/repos/flags.test/packages/y/package.py
@@ -1,0 +1,12 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class Y(Package):
+    version("2.1")
+    version("2.0")
+
+    depends_on("c", type="build")

--- a/var/spack/repos/flags.test/repo.yaml
+++ b/var/spack/repos/flags.test/repo.yaml
@@ -1,0 +1,2 @@
+repo:
+  namespace: flags.test

--- a/var/spack/repos/requirements.test/packages/t/package.py
+++ b/var/spack/repos/requirements.test/packages/t/package.py
@@ -5,9 +5,10 @@
 from spack.package import *
 
 
-class U(Package):
-    version("6.0")
+class T(Package):
+    version("2.1")
+    version("2.0")
 
-    depends_on("y cflags='-e1 -e2'")
+    depends_on("u", when="@2.1:")
 
     depends_on("c", type="build")

--- a/var/spack/repos/requirements.test/packages/u/package.py
+++ b/var/spack/repos/requirements.test/packages/u/package.py
@@ -6,8 +6,7 @@ from spack.package import *
 
 
 class U(Package):
-    version("6.0")
-
-    depends_on("y cflags='-e1 -e2'")
+    version("1.1")
+    version("1.0")
 
     depends_on("c", type="build")

--- a/var/spack/repos/requirements.test/packages/v/package.py
+++ b/var/spack/repos/requirements.test/packages/v/package.py
@@ -5,9 +5,8 @@
 from spack.package import *
 
 
-class U(Package):
-    version("6.0")
-
-    depends_on("y cflags='-e1 -e2'")
+class V(Package):
+    version("2.1")
+    version("2.0")
 
     depends_on("c", type="build")

--- a/var/spack/repos/requirements.test/packages/x/package.py
+++ b/var/spack/repos/requirements.test/packages/x/package.py
@@ -5,9 +5,12 @@
 from spack.package import *
 
 
-class U(Package):
-    version("6.0")
+class X(Package):
+    version("1.1")
+    version("1.0")
+    version("0.9")
 
-    depends_on("y cflags='-e1 -e2'")
+    variant("shared", default=True, description="Build shared libraries")
 
+    depends_on("y")
     depends_on("c", type="build")

--- a/var/spack/repos/requirements.test/packages/y/package.py
+++ b/var/spack/repos/requirements.test/packages/y/package.py
@@ -5,9 +5,11 @@
 from spack.package import *
 
 
-class U(Package):
-    version("6.0")
+class Y(Package):
+    version("2.5")
+    version("2.4")
+    version("2.3", deprecated=True)
 
-    depends_on("y cflags='-e1 -e2'")
+    variant("shared", default=True, description="Build shared libraries")
 
     depends_on("c", type="build")

--- a/var/spack/repos/requirements.test/repo.yaml
+++ b/var/spack/repos/requirements.test/repo.yaml
@@ -1,0 +1,2 @@
+repo:
+  namespace: requirements.test


### PR DESCRIPTION
Extracted from #45189 

Unit tests for requirements and flag mixing use small custom repositories, where packages are defined as strings within the test file. This prevents sharing packages among test repositories with the use of links, which is needed in #45189 to avoid duplication for mock compilers / runtimes. The refactor is extracted in a standalone PR to reduce the size of #45189.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
