### PR TITLE
Revert "allow failure for cray-sles"

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -905,7 +905,6 @@ e4s-cray-rhel-build:
     SPACK_CI_STACK_NAME: e4s-cray-sles
 
 e4s-cray-sles-generate:
-  allow_failure: true  # no machines available
   extends: [ ".generate-cray-sles", ".e4s-cray-sles" ]
 
 e4s-cray-sles-build:


### PR DESCRIPTION
Reverts spack/spack#46411

Added CI variable `SPACK_CI_DISABLE_STACKS=/^(e4s-cray-sles)$/` to disable this stack while runners are down.