### PR TITLE
*: no loop over files with filter_file(*files)

### DIFF
--- a/var/spack/repos/builtin/packages/augustus/package.py
+++ b/var/spack/repos/builtin/packages/augustus/package.py
@@ -168,13 +168,11 @@ class Augustus(MakefilePackage):
             pattern = "^#!.*"
             repl = f"#!{self.spec['perl'].command.path}"
             files = glob.glob("*.pl")
-            for file in files:
-                filter_file(pattern, repl, *files, backup=False)
+            filter_file(pattern, repl, *files, backup=False)
 
             repl = f"#!{self.spec['python'].command.path}"
             files = glob.glob("*.py")
-            for file in files:
-                filter_file(pattern, repl, *files, backup=False)
+            filter_file(pattern, repl, *files, backup=False)
 
     def setup_build_environment(self, env):
         htslib = self.spec["htslib"].prefix

--- a/var/spack/repos/builtin/packages/braker/package.py
+++ b/var/spack/repos/builtin/packages/braker/package.py
@@ -63,8 +63,7 @@ class Braker(Package):
             pattern = "^#!.*/usr/bin/env perl"
             repl = "#!{0}".format(self.spec["perl"].command.path)
             files = glob.iglob("*.pl")
-            for file in files:
-                filter_file(pattern, repl, *files, backup=False)
+            filter_file(pattern, repl, *files, backup=False)
 
     def setup_run_environment(self, env):
         env.prepend_path("PERL5LIB", self.prefix.lib)

--- a/var/spack/repos/builtin/packages/fplo/package.py
+++ b/var/spack/repos/builtin/packages/fplo/package.py
@@ -136,5 +136,4 @@ class Fplo(MakefilePackage):
             pattern = "^#!.*/usr/bin/perl"
             repl = "#!{0}".format(self.spec["perl"].command.path)
             files = ["fconv2", "fconvdens2", "fdowngrad.pl", "fout2in", "grBhfat", "grpop"]
-            for file in files:
-                filter_file(pattern, repl, *files, backup=False)
+            filter_file(pattern, repl, *files, backup=False)

--- a/var/spack/repos/builtin/packages/genemark-et/package.py
+++ b/var/spack/repos/builtin/packages/genemark-et/package.py
@@ -62,8 +62,7 @@ class GenemarkEt(Package):
             pattern = "^#!.*/usr/bin/perl"
             repl = "#!{0}".format(self.spec["perl"].command.path)
             files = glob.iglob("*.pl")
-            for file in files:
-                filter_file(pattern, repl, *files, backup=False)
+            filter_file(pattern, repl, *files, backup=False)
 
     def setup_run_environment(self, env):
         env.prepend_path("PERL5LIB", self.prefix.lib)

--- a/var/spack/repos/builtin/packages/hisat2/package.py
+++ b/var/spack/repos/builtin/packages/hisat2/package.py
@@ -89,24 +89,20 @@ class Hisat2(MakefilePackage):
             pattern = "^#!.*/usr/bin/env python"
             repl = f"#!{self.spec['python'].command.path}"
             files = ["hisat2-build", "hisat2-inspect"]
-            for file in files:
-                filter_file(pattern, repl, *files, backup=False)
+            filter_file(pattern, repl, *files, backup=False)
 
             pattern = "^#!.*/usr/bin/env perl"
             repl = f"#!{self.spec['perl'].command.path}"
             files = ["hisat2"]
-            for file in files:
-                filter_file(pattern, repl, *files, backup=False)
+            filter_file(pattern, repl, *files, backup=False)
 
             pattern = "^#!.*/usr/bin/env python3"
             repl = f"#!{self.spec['python'].command.path}"
             files = glob.glob("*.py")
-            for file in files:
-                filter_file(pattern, repl, *files, backup=False)
+            filter_file(pattern, repl, *files, backup=False)
 
         with working_dir(self.prefix.scripts):
             pattern = "^#!.*/usr/bin/perl"
             repl = f"#!{self.spec['perl'].command.path}"
             files = glob.glob("*.pl")
-            for file in files:
-                filter_file(pattern, repl, *files, backup=False)
+            filter_file(pattern, repl, *files, backup=False)

--- a/var/spack/repos/builtin/packages/scalpel/package.py
+++ b/var/spack/repos/builtin/packages/scalpel/package.py
@@ -47,7 +47,7 @@ class Scalpel(MakefilePackage, SourceforgePackage):
                 "FindVariants.pl",
                 "FindSomatic.pl",
             ]
-            filter_file(match, substitute, *files, **kwargs)
+            too(match, substitute, *files, **kwargs)
 
     # Scalpel doesn't actually *have* an install step.  The authors
     # expect you to unpack the tarball, build it in the resulting

--- a/var/spack/repos/builtin/packages/scalpel/package.py
+++ b/var/spack/repos/builtin/packages/scalpel/package.py
@@ -47,7 +47,7 @@ class Scalpel(MakefilePackage, SourceforgePackage):
                 "FindVariants.pl",
                 "FindSomatic.pl",
             ]
-            too(match, substitute, *files, **kwargs)
+            filter_file(match, substitute, *files, **kwargs)
 
     # Scalpel doesn't actually *have* an install step.  The authors
     # expect you to unpack the tarball, build it in the resulting


### PR DESCRIPTION
This PR changes redundant code that had gotten copied to a few different packages by now:
```py
            for file in files:
                filter_file(pattern, repl, *files, backup=False)
```
Because `filter_file` accepts `*files`, we don't need the loop.