### PR TITLE
drop main dep from build_environment/subprocess_context

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -62,7 +62,6 @@ import spack.compilers
 import spack.config
 import spack.deptypes as dt
 import spack.error
-import spack.main
 import spack.multimethod
 import spack.package_base
 import spack.paths
@@ -452,7 +451,7 @@ def set_wrapper_variables(pkg, env):
         env.set(SPACK_DEBUG, "TRUE")
     env.set(SPACK_SHORT_SPEC, pkg.spec.short_spec)
     env.set(SPACK_DEBUG_LOG_ID, pkg.spec.format("{name}-{hash:7}"))
-    env.set(SPACK_DEBUG_LOG_DIR, spack.main.spack_working_dir)
+    env.set(SPACK_DEBUG_LOG_DIR, spack.paths.spack_working_dir)
 
     if spack.config.get("config:ccache"):
         # Enable ccache in the compiler wrapper

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -100,22 +100,10 @@ section_order = {
 #: Properties that commands are required to set.
 required_command_properties = ["level", "section", "description"]
 
-#: Recorded directory where spack command was originally invoked
-spack_working_dir = None
 spack_ld_library_path = os.environ.get("LD_LIBRARY_PATH", "")
 
 #: Whether to print backtraces on error
 SHOW_BACKTRACE = False
-
-
-def set_working_dir():
-    """Change the working directory to getcwd, or spack prefix if no cwd."""
-    global spack_working_dir
-    try:
-        spack_working_dir = os.getcwd()
-    except OSError:
-        os.chdir(spack.paths.prefix)
-        spack_working_dir = spack.paths.prefix
 
 
 def add_all_commands(parser):
@@ -998,7 +986,7 @@ def finish_parse_and_run(parser, cmd_name, main_args, env_format_error):
             raise env_format_error
 
     # many operations will fail without a working directory.
-    set_working_dir()
+    spack.paths.set_working_dir()
 
     # now we can actually execute the command.
     if main_args.spack_profile or main_args.sorted_profile:

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -136,3 +136,16 @@ user_config_path = _get_user_config_path()
 
 #: System configuration location
 system_config_path = _get_system_config_path()
+
+#: Recorded directory where spack command was originally invoked
+spack_working_dir = None
+
+
+def set_working_dir():
+    """Change the working directory to getcwd, or spack prefix if no cwd."""
+    global spack_working_dir
+    try:
+        spack_working_dir = os.getcwd()
+    except OSError:
+        os.chdir(prefix)
+        spack_working_dir = prefix

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -22,7 +22,7 @@ from types import ModuleType
 
 import spack.config
 import spack.environment
-import spack.main
+import spack.paths
 import spack.platforms
 import spack.repo
 import spack.store
@@ -72,12 +72,12 @@ class PackageInstallContext:
         else:
             self.pkg = pkg
             self.env = spack.environment.active_environment()
-        self.spack_working_dir = spack.main.spack_working_dir
+        self.spack_working_dir = spack.paths.spack_working_dir
         self.test_state = TestState()
 
     def restore(self):
         self.test_state.restore()
-        spack.main.spack_working_dir = self.spack_working_dir
+        spack.paths.spack_working_dir = self.spack_working_dir
         env = pickle.load(self.serialized_env) if _SERIALIZE else self.env
         if env:
             spack.environment.activate(env)


### PR DESCRIPTION
Deletes another import that causes circular deps
