### PR TITLE
spack.modules: move get_module up

### DIFF
--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -173,7 +173,7 @@ def loads(module_type, specs, args, out=None):
     modules = list(
         (
             spec,
-            spack.modules.common.get_module(
+            spack.modules.get_module(
                 module_type,
                 spec,
                 get_full_path=False,
@@ -222,7 +222,7 @@ def find(module_type, specs, args):
 
     try:
         modules = [
-            spack.modules.common.get_module(
+            spack.modules.get_module(
                 module_type,
                 spec,
                 args.full_path,
@@ -233,7 +233,7 @@ def find(module_type, specs, args):
         ]
 
         modules.append(
-            spack.modules.common.get_module(
+            spack.modules.get_module(
                 module_type,
                 single_spec,
                 args.full_path,

--- a/lib/spack/spack/modules/__init__.py
+++ b/lib/spack/spack/modules/__init__.py
@@ -16,12 +16,8 @@ import spack.repo
 import spack.spec
 import spack.store
 
-from .common import (
-    BaseModuleFileWriter,
-    ModuleNotFoundError,
-    disable_modules,
-    upstream_module_index,
-)
+from . import common
+from .common import BaseModuleFileWriter, disable_modules
 from .lmod import LmodModulefileWriter
 from .tcl import TclModulefileWriter
 
@@ -63,7 +59,7 @@ def get_module(
     except spack.repo.UnknownPackageError:
         upstream, record = spack.store.STORE.db.query_by_spec_hash(spec.dag_hash())
     if upstream:
-        module = upstream_module_index.upstream_module(spec, module_type)
+        module = common.upstream_module_index.upstream_module(spec, module_type)
         if not module:
             return None
 
@@ -76,7 +72,7 @@ def get_module(
         if not os.path.isfile(writer.layout.filename):
             fmt_str = "{name}{@version}{/hash:7}"
             if not writer.conf.excluded:
-                raise ModuleNotFoundError(
+                raise common.ModuleNotFoundError(
                     "The module for package {} should be at {}, but it does not exist".format(
                         spec.format(fmt_str), writer.layout.filename
                     )

--- a/lib/spack/spack/modules/__init__.py
+++ b/lib/spack/spack/modules/__init__.py
@@ -7,9 +7,21 @@
 include Tcl non-hierarchical modules, Lua hierarchical modules, and others.
 """
 
+import os
 from typing import Dict, Type
 
-from .common import BaseModuleFileWriter, disable_modules
+import llnl.util.tty as tty
+
+import spack.repo
+import spack.spec
+import spack.store
+
+from .common import (
+    BaseModuleFileWriter,
+    ModuleNotFoundError,
+    disable_modules,
+    upstream_module_index,
+)
 from .lmod import LmodModulefileWriter
 from .tcl import TclModulefileWriter
 
@@ -19,3 +31,66 @@ module_types: Dict[str, Type[BaseModuleFileWriter]] = {
     "tcl": TclModulefileWriter,
     "lmod": LmodModulefileWriter,
 }
+
+
+def get_module(
+    module_type, spec: spack.spec.Spec, get_full_path, module_set_name="default", required=True
+):
+    """Retrieve the module file for a given spec and module type.
+
+    Retrieve the module file for the given spec if it is available. If the
+    module is not available, this will raise an exception unless the module
+    is excluded or if the spec is installed upstream.
+
+    Args:
+        module_type: the type of module we want to retrieve (e.g. lmod)
+        spec: refers to the installed package that we want to retrieve a module
+            for
+        required: if the module is required but excluded, this function will
+            print a debug message. If a module is missing but not excluded,
+            then an exception is raised (regardless of whether it is required)
+        get_full_path: if ``True``, this returns the full path to the module.
+            Otherwise, this returns the module name.
+        module_set_name: the named module configuration set from modules.yaml
+            for which to retrieve the module.
+
+    Returns:
+        The module name or path. May return ``None`` if the module is not
+        available.
+    """
+    try:
+        upstream = spec.installed_upstream
+    except spack.repo.UnknownPackageError:
+        upstream, record = spack.store.STORE.db.query_by_spec_hash(spec.dag_hash())
+    if upstream:
+        module = upstream_module_index.upstream_module(spec, module_type)
+        if not module:
+            return None
+
+        if get_full_path:
+            return module.path
+        else:
+            return module.use_name
+    else:
+        writer = module_types[module_type](spec, module_set_name)
+        if not os.path.isfile(writer.layout.filename):
+            fmt_str = "{name}{@version}{/hash:7}"
+            if not writer.conf.excluded:
+                raise ModuleNotFoundError(
+                    "The module for package {} should be at {}, but it does not exist".format(
+                        spec.format(fmt_str), writer.layout.filename
+                    )
+                )
+            elif required:
+                tty.debug(
+                    "The module configuration has excluded {}: omitting it".format(
+                        spec.format(fmt_str)
+                    )
+                )
+            else:
+                return None
+
+        if get_full_path:
+            return writer.layout.filename
+        else:
+            return writer.layout.use_name

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -46,7 +46,6 @@ import spack.config
 import spack.deptypes as dt
 import spack.environment
 import spack.error
-import spack.modules
 import spack.paths
 import spack.projections as proj
 import spack.repo
@@ -322,67 +321,6 @@ class UpstreamModuleIndex:
         else:
             tty.debug(f"No module is available for upstream package {spec}")
             return None
-
-
-def get_module(module_type, spec, get_full_path, module_set_name="default", required=True):
-    """Retrieve the module file for a given spec and module type.
-
-    Retrieve the module file for the given spec if it is available. If the
-    module is not available, this will raise an exception unless the module
-    is excluded or if the spec is installed upstream.
-
-    Args:
-        module_type: the type of module we want to retrieve (e.g. lmod)
-        spec: refers to the installed package that we want to retrieve a module
-            for
-        required: if the module is required but excluded, this function will
-            print a debug message. If a module is missing but not excluded,
-            then an exception is raised (regardless of whether it is required)
-        get_full_path: if ``True``, this returns the full path to the module.
-            Otherwise, this returns the module name.
-        module_set_name: the named module configuration set from modules.yaml
-            for which to retrieve the module.
-
-    Returns:
-        The module name or path. May return ``None`` if the module is not
-        available.
-    """
-    try:
-        upstream = spec.installed_upstream
-    except spack.repo.UnknownPackageError:
-        upstream, record = spack.store.STORE.db.query_by_spec_hash(spec.dag_hash())
-    if upstream:
-        module = upstream_module_index.upstream_module(spec, module_type)
-        if not module:
-            return None
-
-        if get_full_path:
-            return module.path
-        else:
-            return module.use_name
-    else:
-        writer = spack.modules.module_types[module_type](spec, module_set_name)
-        if not os.path.isfile(writer.layout.filename):
-            fmt_str = "{name}{@version}{/hash:7}"
-            if not writer.conf.excluded:
-                raise ModuleNotFoundError(
-                    "The module for package {} should be at {}, but it does not exist".format(
-                        spec.format(fmt_str), writer.layout.filename
-                    )
-                )
-            elif required:
-                tty.debug(
-                    "The module configuration has excluded {}: omitting it".format(
-                        spec.format(fmt_str)
-                    )
-                )
-            else:
-                return None
-
-        if get_full_path:
-            return writer.layout.filename
-        else:
-            return writer.layout.use_name
 
 
 class BaseConfiguration:

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -170,7 +170,7 @@ module_index:
         old_index = spack.modules.common.upstream_module_index
         spack.modules.common.upstream_module_index = upstream_index
 
-        m1_path = spack.modules.common.get_module("tcl", s1, True)
+        m1_path = spack.modules.get_module("tcl", s1, True)
         assert m1_path == "/path/to/a"
     finally:
         spack.modules.common.upstream_module_index = old_index
@@ -192,7 +192,7 @@ def test_load_installed_package_not_in_repo(install_mockery, mock_fetch, monkeyp
     with pytest.raises(spack.repo.UnknownPackageError):
         spec.package
 
-    module_path = spack.modules.common.get_module("tcl", spec, True)
+    module_path = spack.modules.get_module("tcl", spec, True)
     assert module_path
 
     spack.package_base.PackageBase.uninstall_by_spec(spec)


### PR DESCRIPTION
Breaks the cycle between spack.modules and spack.modules.common