### PR TITLE
py-dm-tree: support externally-installed pybind11 and abseil-cpp

### DIFF
--- a/var/spack/repos/builtin/packages/py-dm-tree/package.py
+++ b/var/spack/repos/builtin/packages/py-dm-tree/package.py
@@ -36,6 +36,11 @@ class PyDmTree(PythonPackage):
 
     depends_on("cxx", type="build")
 
+    # Based on PyPI wheel availability
+    depends_on("python@:3.12", when="@0.1.8:", type=("build", "run"))
+    depends_on("python@:3.10", when="@0.1.6:0.1.7", type=("build", "run"))
+    depends_on("python@:3.8", when="@0.1.5", type=("build", "run"))
+
     depends_on("py-setuptools", type="build")
     depends_on("cmake@3.12:", when="@0.1.7:", type="build")
     depends_on("py-pybind11@2.10.1:", when="@0.1.8:")

--- a/var/spack/repos/builtin/packages/py-dm-tree/package.py
+++ b/var/spack/repos/builtin/packages/py-dm-tree/package.py
@@ -23,13 +23,32 @@ class PyDmTree(PythonPackage):
 
     version("0.1.8", sha256="0fcaabbb14e7980377439e7140bd05552739ca5e515ecb3119f234acee4b9430")
     version("0.1.7", sha256="30fec8aca5b92823c0e796a2f33b875b4dccd470b57e91e6c542405c5f77fd2a")
-    version("0.1.6", sha256="6776404b23b4522c01012ffb314632aba092c9541577004ab153321e87da439a")
-    version("0.1.5", sha256="a951d2239111dfcc468071bc8ff792c7b1e3192cab5a3c94d33a8b2bda3127fa")
+    version(
+        "0.1.6",
+        sha256="6776404b23b4522c01012ffb314632aba092c9541577004ab153321e87da439a",
+        deprecated=True,
+    )
+    version(
+        "0.1.5",
+        sha256="a951d2239111dfcc468071bc8ff792c7b1e3192cab5a3c94d33a8b2bda3127fa",
+        deprecated=True,
+    )
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("cxx", type="build")
 
     depends_on("py-setuptools", type="build")
-    depends_on("cmake", when="@0.1.7:", type="build")
+    depends_on("cmake@3.12:", when="@0.1.7:", type="build")
+    depends_on("py-pybind11@2.10.1:", when="@0.1.8:")
+    depends_on("abseil-cpp", when="@0.1.8:")
+
+    patch(
+        "https://github.com/google-deepmind/tree/pull/73.patch?full_index=1",
+        sha256="77dbd895611d412da99a5afbf312c3c49984ad02bd0e56ad342b2002a87d789c",
+        when="@0.1.8",
+    )
+    conflicts("%gcc@13:", when="@:0.1.7")
+
+    # Historical dependencies
     depends_on("bazel@:5", when="@:0.1.6", type="build")
     depends_on("py-six@1.12.0:", when="@:0.1.6", type=("build", "run"))
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Extracted from #45644

Deprecated older versions that require bazel.