### PR TITLE
py-jaxlib: add GCC 13 support

### DIFF
--- a/var/spack/repos/builtin/packages/py-jaxlib/package.py
+++ b/var/spack/repos/builtin/packages/py-jaxlib/package.py
@@ -99,6 +99,12 @@ class PyJaxlib(PythonPackage, CudaPackage):
         depends_on("py-numpy@:1", when="@:0.4.25")
         depends_on("py-ml-dtypes@0.4:", when="@0.4.29")
 
+    patch(
+        "https://github.com/google/jax/pull/20101.patch?full_index=1",
+        sha256="4dfb9f32d4eeb0a0fb3a6f4124c4170e3fe49511f1b768cd634c78d489962275",
+        when="@:0.4.25",
+    )
+
     conflicts(
         "cuda_arch=none",
         when="+cuda",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Extracted from #45644