### PR TITLE
Add GHA for circular imports regressions

### DIFF
--- a/.github/workflows/valid-style.yml
+++ b/.github/workflows/valid-style.yml
@@ -87,3 +87,48 @@ jobs:
           spack -d bootstrap now --dev
           spack style -t black
           spack unit-test -V
+  import-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: julia-actions/setup-julia@v2
+      with:
+        version: '1.10'
+    - uses: julia-actions/cache@v2
+    - name: Checkout base branch
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+        path: old
+    - name: Checkout PR branch
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      with:
+        path: new
+    - name: Install circular import checker
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      with:
+        repository: haampie/circular-import-fighter
+        path: circular-import-fighter
+    - name: Install dependencies
+      working-directory: circular-import-fighter
+      run: make -j dependencies
+    - name: Import cycles before
+      working-directory: circular-import-fighter
+      run: make SPACK_ROOT=../old && cp solution solution.old
+    - name: Import cycles after
+      working-directory: circular-import-fighter
+      run: make clean-graph && make SPACK_ROOT=../new && cp solution solution.new
+    - name: Compare import cycles
+      working-directory: circular-import-fighter
+      run: |
+        edges_before="$(grep -oP 'edges to delete: \K\d+' solution.old)"
+        edges_after="$(grep -oP 'edges to delete: \K\d+' solution.new)"
+        if [ "$edges_after" -gt "$edges_before" ]; then
+          printf '\033[1;31mImport check failed: %s imports need to be deleted, ' "$edges_after"
+          printf 'previously this was %s\033[0m\n'  "$edges_before"
+          printf 'Compare \033[1;97m"Import cycles before"\033[0m and '
+          printf '\033[1;97m"Import cycles after"\033[0m to see problematic imports.\n'
+          exit 1
+        else
+          printf '\033[1;32mImport check passed: %s <= %s\033[0m\n' "$edges_after" "$edges_before"
+        fi

--- a/.github/workflows/valid-style.yml
+++ b/.github/workflows/valid-style.yml
@@ -88,19 +88,32 @@ jobs:
           spack style -t black
           spack unit-test -V
   import-check:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - uses: julia-actions/setup-julia@v2
       with:
         version: '1.10'
     - uses: julia-actions/cache@v2
-    - name: Checkout base branch
+
+    # PR: use the base of the PR as the old commit
+    - name: Checkout old commit
+      if: github.event_name == 'pull_request'
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       with:
         ref: ${{ github.event.pull_request.base.sha }}
         path: old
-    - name: Checkout PR branch
+    # not a PR: use the previous commit as the old commit
+    - name: Checkout old commit
+      if: github.event_name != 'pull_request'
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      with:
+        fetch-depth: 2
+        path: old
+    - name: Checkout old commit
+      if: github.event_name != 'pull_request'
+      run: git -C old reset --hard HEAD^
+
+    - name: Checkout new commit
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       with:
         path: new

--- a/.github/workflows/valid-style.yml
+++ b/.github/workflows/valid-style.yml
@@ -96,20 +96,20 @@ jobs:
     - uses: julia-actions/cache@v2
 
     # PR: use the base of the PR as the old commit
-    - name: Checkout old commit
+    - name: Checkout PR base commit
       if: github.event_name == 'pull_request'
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       with:
         ref: ${{ github.event.pull_request.base.sha }}
         path: old
     # not a PR: use the previous commit as the old commit
-    - name: Checkout old commit
+    - name: Checkout previous commit
       if: github.event_name != 'pull_request'
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       with:
         fetch-depth: 2
         path: old
-    - name: Checkout old commit
+    - name: Checkout previous commit
       if: github.event_name != 'pull_request'
       run: git -C old reset --hard HEAD^
 

--- a/.github/workflows/valid-style.yml
+++ b/.github/workflows/valid-style.yml
@@ -108,6 +108,7 @@ jobs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       with:
         repository: haampie/circular-import-fighter
+        ref: 555519c6fd5564fd2eb844e7b87e84f4d12602e2
         path: circular-import-fighter
     - name: Install dependencies
       working-directory: circular-import-fighter


### PR DESCRIPTION
This GitHub action checks out the repo before and after the PR/commit, and computes the minimal set of import statements to remove so that the spack.* module graph is acyclic. If this number increases as a result of the PR, the action fails.

The tooling is a julia package, which solves this NP-hard problem exactly in a few seconds. The julia binaries are cached so that the whole action runs in ~45s.