### PR TITLE
py-fluidsim-core and py-fluidsim: add new packages

### DIFF
--- a/var/spack/repos/builtin/packages/py-fluidfft-builder/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidfft-builder/package.py
@@ -18,3 +18,4 @@ class PyFluidfftBuilder(PythonPackage):
 
     depends_on("python@3.9:", type=("build", "run"))
     depends_on("py-flit-core@3.2:3", type="build")
+    depends_on("py-cython@3.0:", type="run")

--- a/var/spack/repos/builtin/packages/py-fluidfft-fftw/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidfft-fftw/package.py
@@ -26,5 +26,6 @@ class PyFluidfftFftw(PythonPackage):
         depends_on("py-meson-python")
         depends_on("py-transonic@0.6.4:")
         depends_on("py-fluidfft-builder")
+        depends_on("py-cython@3.0:")
 
     depends_on("py-fluidfft", type="run")

--- a/var/spack/repos/builtin/packages/py-fluidfft-fftwmpi/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidfft-fftwmpi/package.py
@@ -27,5 +27,6 @@ class PyFluidfftFftwmpi(PythonPackage):
         depends_on("py-meson-python")
         depends_on("py-transonic@0.6.4:")
         depends_on("py-fluidfft-builder")
+        depends_on("py-cython@3.0:")
 
     depends_on("py-fluidfft", type="run")

--- a/var/spack/repos/builtin/packages/py-fluidfft-mpi-with-fftw/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidfft-mpi-with-fftw/package.py
@@ -27,5 +27,6 @@ class PyFluidfftMpiWithFftw(PythonPackage):
         depends_on("py-meson-python")
         depends_on("py-transonic@0.6.4:")
         depends_on("py-fluidfft-builder")
+        depends_on("py-cython@3.0:")
 
     depends_on("py-fluidfft", type="run")

--- a/var/spack/repos/builtin/packages/py-fluidfft-p3dfft/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidfft-p3dfft/package.py
@@ -28,5 +28,6 @@ class PyFluidfftP3dfft(PythonPackage):
         depends_on("py-meson-python")
         depends_on("py-transonic@0.6.4:")
         depends_on("py-fluidfft-builder")
+        depends_on("py-cython@3.0:")
 
     depends_on("py-fluidfft", type="run")

--- a/var/spack/repos/builtin/packages/py-fluidfft-pfft/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidfft-pfft/package.py
@@ -28,5 +28,6 @@ class PyFluidfftPfft(PythonPackage):
         depends_on("py-meson-python")
         depends_on("py-transonic@0.6.4:")
         depends_on("py-fluidfft-builder")
+        depends_on("py-cython@3.0:")
 
     depends_on("py-fluidfft", type="run")

--- a/var/spack/repos/builtin/packages/py-fluidsim-core/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidsim-core/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyFluidsimCore(PythonPackage):
+    """Pure-Python core library for FluidSim framework."""
+
+    pypi = "fluidsim-core/fluidsim_core-0.8.3.tar.gz"
+
+    maintainers("paugier")
+    license("CECILL", checked_by="paugier")
+
+    version("0.8.3", sha256="2c829486d640f921e42b690b824fe52ce6fcb678a36535f06d76b872e353d211")
+    version("0.8.2", sha256="62a8b43fc7ede8c6efc5cc109ae5caca2c1f54891dff547511c8fe94caf0bd7c")
+    version("0.8.1", sha256="3dfb51d5db1a574089738a4b8e1c76e75da32b25dceb349207dcece73d1b1646")
+    version("0.8.0", sha256="4b7a23649df9d10cde6510280fb8683550549d4cbbc1ebb0bc6adc6e559915f7")
+
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-flit-core@3.2:3", type="build")
+
+    with default_args(type="run"):
+        depends_on("py-fluiddyn")
+        depends_on("py-importlib_metadata", when="^python@:3.9")

--- a/var/spack/repos/builtin/packages/py-fluidsim/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidsim/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
+from spack.pkg.builtin.py_fluidsim_core import PyFluidsimCore
 
 
 class PyFluidsim(PythonPackage):
@@ -19,6 +20,8 @@ class PyFluidsim(PythonPackage):
     version("0.8.1", sha256="44c70f388c429856f5df24705cddb2e024d7d1376d2153e113ef111af90b857b")
     version("0.8.0", sha256="01f6d489ce44fe4dc47357506ba227ae0e87b346758d8f067c13f319d0a9a881")
 
+    variant("native", default=False, description="Compile with -march=native and -Ofast.")
+
     with default_args(type=("build", "run")):
         extends("python@3.9:")
         depends_on("py-transonic@0.6.4:")
@@ -28,7 +31,8 @@ class PyFluidsim(PythonPackage):
         depends_on("py-pythran@0.9.7:")
 
     with default_args(type="run"):
-        depends_on("py-fluidsim-core")
+        for _v in PyFluidsimCore.versions:
+            depends_on(f"py-fluidsim-core@{_v}", when=f"@{_v}")
         depends_on("py-fluidfft@0.4.0:")
         depends_on("py-xarray")
         depends_on("py-rich")

--- a/var/spack/repos/builtin/packages/py-fluidsim/package.py
+++ b/var/spack/repos/builtin/packages/py-fluidsim/package.py
@@ -1,0 +1,39 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyFluidsim(PythonPackage):
+    """Framework for studying fluid dynamics with simulations."""
+
+    pypi = "fluidsim/fluidsim-0.8.3.tar.gz"
+
+    maintainers("paugier")
+    license("CECILL", checked_by="paugier")
+
+    version("0.8.3", sha256="ff3df8c2e8c96a694b5656125e778fc5f6561699bae3b264cbb75e2070b94169")
+    version("0.8.2", sha256="eb36c2d7d588fbb088af026683a12bb14aa126bbbc91b999009130d6cb7920f9")
+    version("0.8.1", sha256="44c70f388c429856f5df24705cddb2e024d7d1376d2153e113ef111af90b857b")
+    version("0.8.0", sha256="01f6d489ce44fe4dc47357506ba227ae0e87b346758d8f067c13f319d0a9a881")
+
+    with default_args(type=("build", "run")):
+        extends("python@3.9:")
+        depends_on("py-transonic@0.6.4:")
+
+    with default_args(type="build"):
+        depends_on("py-meson-python")
+        depends_on("py-pythran@0.9.7:")
+
+    with default_args(type="run"):
+        depends_on("py-fluidsim-core")
+        depends_on("py-fluidfft@0.4.0:")
+        depends_on("py-xarray")
+        depends_on("py-rich")
+        depends_on("py-scipy")
+
+    def config_settings(self, spec, prefix):
+        settings = {"setup-args": {"-Dnative": spec.variants["native"].value}}
+        return settings


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This PR adds fluidsim (https://pypi.org/project/fluidsim/) and fluidsim-core (https://pypi.org/project/fluidsim-core).

It would allow users to run simulations with Fluidsim on clusters only with Spack, which would be great for this research project.

I tried to follow what I learned about Spack. I hope I did it correctly.

One thing that I don't know: how to express that fluidsim 0.8.3 requires fluidsim-core 0.8.3 (and same for other versions)?