### PR TITLE
fio: disable native build

### DIFF
--- a/var/spack/repos/builtin/packages/fio/package.py
+++ b/var/spack/repos/builtin/packages/fio/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
 from spack.package import *
 
 
@@ -31,27 +30,26 @@ class Fio(AutotoolsPackage):
     version("3.16", sha256="c7731a9e831581bab7104da9ea60c9f44e594438dbe95dff26726ca0285e7b93")
     version("2.19", sha256="61fb03a18703269b781aaf195cb0d7931493bbb5bfcc8eb746d5d66d04ed77f7")
 
-    depends_on("c", type="build")  # generated
-
     variant("gui", default=False, description="Enable building of gtk gfio")
     variant("doc", default=False, description="Generate documentation")
     variant("libaio", default=False, description="Enable libaio engine")
 
+    depends_on("c", type="build")
+    depends_on("pkgconfig", type="build")
+    depends_on("zlib-api")
     depends_on("gtkplus@2.18:", when="+gui")
     depends_on("cairo", when="+gui")
     depends_on("libaio", when="+libaio")
-
     depends_on("py-sphinx", type="build", when="+doc")
 
     conflicts("+libaio", when="platform=darwin", msg="libaio does not support Darwin")
-
+    conflicts("+libaio", when="platform=windows", msg="libaio does not support Windows")
     conflicts("@:3.18", when="%gcc@10:", msg="gcc@10: sets -fno-common by default")
 
     def configure_args(self):
-        config_args = []
-        spec = self.spec
+        config_args = ["--disable-native"]
 
-        if spec.satisfies("+gui"):
+        if self.spec.satisfies("+gui"):
             config_args.append("--enable-gfio")
 
         return config_args


### PR DESCRIPTION
By default, the fio configure script enables a native build, which overrides the given Spack architecture target and can then cause segfaults if the fio build is run on a non-native architecture. This change disables the native build to ensure that the given Spack architecture target is used.

For reference: https://github.com/axboe/fio/blob/master/configure#L186

Also adding missing dependencies for pkgconfig and zlib-api and another conflict for libaio when platform=windows.

Closes https://github.com/spack/spack/issues/20303.