### PR TITLE
Proj package pulls googletest from web by default

### DIFF
--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -165,15 +165,16 @@ class CMakeBuilder(BaseBuilder, cmake.CMakeBuilder):
             self.define_from_variant("BUILD_PROJSYNC", "curl"),
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
         ]
-        if self.spec.satisfies("@6:") and self.pkg.run_tests:
-            args.append(self.define("USE_EXTERNAL_GTEST", True))
-        if self.spec.satisfies("@7:"):
-            test_flag = "BUILD_TESTING"
-        elif self.spec.satisfies("@5.1:"):
-            test_flag = "PROJ_TESTS"
-        else:
-            test_flag = "PROJ4_TESTS"
-        args.append(self.define(test_flag, self.pkg.run_tests))
+        if self.pkg.run_tests:
+            if self.spec.satisfies("@6:"):
+                args.append(self.define("USE_EXTERNAL_GTEST", True))
+            if self.spec.satisfies("@7:"):
+                test_flag = "BUILD_TESTING"
+            elif self.spec.satisfies("@5.1:"):
+                test_flag = "PROJ_TESTS"
+            else:
+                test_flag = "PROJ4_TESTS"
+            args.append(self.define(test_flag, self.pkg.run_tests))
         return args
 
 


### PR DESCRIPTION
It should only do that if in testing mode, but somebody broke the logic such that for most versions it always adds the cmake args that force the download.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
