### PR TITLE
quantum-espresso: Restrict oneapi compiler to supported versions

### DIFF
--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -307,8 +307,8 @@ class QuantumEspresso(CMakePackage, Package):
     )
     # Fixed in https://github.com/libmbd/libmbd/pull/60, which will be part of the next release
     conflicts(
-        "@7.3.1 %oneapi@2024.1:",
-        when="build_system=cmake",
+        "@7.3.1",
+        when="%oneapi@2024.1:",
         msg="ifx added f_c_string in the ISO_C_BINDING module since version 2024.1 which conflicts"
         + "with the libmbd provided one.",
     )

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -300,7 +300,11 @@ class QuantumEspresso(CMakePackage, Package):
 
     conflicts("@6.5:", when="+environ", msg="6.4.x is the latest QE series supported by Environ")
 
-    conflicts("@:7.3.0", when="%oneapi", msg="Support for ifx has been added in release 7.3.1")
+    conflicts(
+        "@:7.3.0",
+        when="build_system=generic %oneapi",
+        msg="Support for ifx has been added to configure in release 7.3.1",
+    )
 
     # 7.3 - a compile-time problem fixed in 7.3.1
     patch_url = "https://gitlab.com/QEF/q-e/-/commit/b98ff7539e5731728d2d49ac01021a57f2594027.diff"

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -305,6 +305,13 @@ class QuantumEspresso(CMakePackage, Package):
         when="build_system=generic %oneapi",
         msg="Support for ifx has been added to configure in release 7.3.1",
     )
+    # TODO: When adding the next version make sure https://github.com/libmbd/libmbd/pull/60 is
+    # merged into the libmbd version used. Otherwise extend the conflict to the new version.
+    conflicts(
+        "@7.3.1 %oneapi@2024.1:",
+        when="build_system=cmake",
+        msg="ifx added intrinsic module ISO_C_BINDING in version 2024.1 which conflicts with the libmbd provided one.",
+    )
 
     # 7.3 - a compile-time problem fixed in 7.3.1
     patch_url = "https://gitlab.com/QEF/q-e/-/commit/b98ff7539e5731728d2d49ac01021a57f2594027.diff"

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -300,6 +300,8 @@ class QuantumEspresso(CMakePackage, Package):
 
     conflicts("@6.5:", when="+environ", msg="6.4.x is the latest QE series supported by Environ")
 
+    conflicts("@:7.3.0", when="%oneapi", msg="Support for ifx has been added in release 7.3.1")
+
     # 7.3 - a compile-time problem fixed in 7.3.1
     patch_url = "https://gitlab.com/QEF/q-e/-/commit/b98ff7539e5731728d2d49ac01021a57f2594027.diff"
     patch_checksum = "04c125d249d1f076abe04bc4de39bd3b44a41a78d6233b638a17bd96f91443d5"

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -305,12 +305,12 @@ class QuantumEspresso(CMakePackage, Package):
         when="build_system=generic %oneapi",
         msg="Support for ifx has been added to configure in release 7.3.1",
     )
-    # TODO: When adding the next version make sure https://github.com/libmbd/libmbd/pull/60 is
-    # merged into the libmbd version used. Otherwise extend the conflict to the new version.
+    # Fixed in https://github.com/libmbd/libmbd/pull/60, which will be part of the next release
     conflicts(
         "@7.3.1 %oneapi@2024.1:",
         when="build_system=cmake",
-        msg="ifx added intrinsic module ISO_C_BINDING in version 2024.1 which conflicts with the libmbd provided one.",
+        msg="ifx added f_c_string in the ISO_C_BINDING module since version 2024.1 which conflicts"
+        + "with the libmbd provided one.",
     )
 
     # 7.3 - a compile-time problem fixed in 7.3.1


### PR DESCRIPTION
Support for `ifx` has been added in release 7.3.1