### PR TITLE
mpas-model: Enable oneapi compiler

### DIFF
--- a/var/spack/repos/builtin/packages/mpas-model/package.py
+++ b/var/spack/repos/builtin/packages/mpas-model/package.py
@@ -69,8 +69,7 @@ class MpasModel(MakefilePackage):
     depends_on("mpi")
     depends_on("parallelio")
 
-    # `ifx` internal compiler error triggered by maps-model fixed in oneapi@2024.2
-    conflicts("%oneapi@:2024.1")
+    conflicts("%oneapi@:2024.1", msg="ifx internal compiler error triggered by maps-model fixed in oneapi@2024.2")
 
     patch("makefile.patch", when="@7.0")
 

--- a/var/spack/repos/builtin/packages/mpas-model/package.py
+++ b/var/spack/repos/builtin/packages/mpas-model/package.py
@@ -69,6 +69,9 @@ class MpasModel(MakefilePackage):
     depends_on("mpi")
     depends_on("parallelio")
 
+    # `ifx` internal compiler error triggered by maps-model fixed in oneapi@2024.2
+    conflicts("%oneapi@:2024.1")
+
     patch("makefile.patch", when="@7.0")
 
     parallel = False
@@ -114,7 +117,7 @@ class MpasModel(MakefilePackage):
             cppflags.append("-DUNDERSCORE")
         elif satisfies("%fj"):
             fflags.extend(["-Free", "-Fwide", "-CcdRR8"])
-        elif satisfies("%intel"):
+        elif satisfies("%intel") or satisfies("%oneapi"):
             fflags.extend(["-convert big_endian", "-FR"])
             if satisfies("precision=double"):
                 fflags.extend(["-r8"])

--- a/var/spack/repos/builtin/packages/mpas-model/package.py
+++ b/var/spack/repos/builtin/packages/mpas-model/package.py
@@ -69,7 +69,10 @@ class MpasModel(MakefilePackage):
     depends_on("mpi")
     depends_on("parallelio")
 
-    conflicts("%oneapi@:2024.1", msg="ifx internal compiler error triggered by maps-model fixed in oneapi@2024.2")
+    conflicts(
+        "%oneapi@:2024.1",
+        msg="ifx internal compiler error triggered by maps-model fixed in oneapi@2024.2",
+    )
 
     patch("makefile.patch", when="@7.0")
 


### PR DESCRIPTION
There is an internal compiler error in `ifx` which gets triggered when building maps-model, but this has been fixed in oneapi@2024.2.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
