### PR TITLE
seacas: fix build with Apple Clang 16

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -304,6 +304,12 @@ class Seacas(CMakePackage):
         when="@:2023-10-24",
     )
 
+    def flag_handler(self, name, flags):
+        if name == "ldflags":
+            if self.spec.satisfies("%apple-clang@15:"):
+                flags.append("-Wl,-ld_classic")
+        return (flags, None, None)
+
     def setup_run_environment(self, env):
         env.prepend_path("PYTHONPATH", self.prefix.lib)
 


### PR DESCRIPTION
Without this I see:
```
ld: warning: duplicate -rpath '/Users/Adam/spack/opt/spack/darwin-sequoia-m2/apple-clang-16.0.0/cgns-4.4.0-hyx7mtf6mxo7h7gz5rx4lthyrypp4u7h/lib' ignored
ld: warning: duplicate -rpath '/Users/Adam/spack/opt/spack/darwin-sequoia-m2/apple-clang-16.0.0/hdf5-1.14.3-emur2bgnslki3qnnmeqoo5ehaeyeseq5/lib' ignored
ld: duplicate LC_RPATH '/Users/Adam/spack/opt/spack/darwin-sequoia-m2/apple-clang-16.0.0/hdf5-1.14.3-emur2bgnslki3qnnmeqoo5ehaeyeseq5/lib' in '/Users/Adam/spack/opt/spack/darwin-sequoia-m2/apple-clang-16.0.0/cgns-4.4.0-hyx7mtf6mxo7h7gz5rx4lthyrypp4u7h/lib/libcgns.4.4.dylib' 
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```