### PR TITLE
Kokkos async malloc

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -377,7 +377,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
         if "+cuda" in self.spec:
             options.append(
-                self.define_from_variant(Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC, "alloc_async")
+                self.define_from_variant("Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC", "alloc_async")
             )
 
         # Remove duplicate options

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -375,7 +375,9 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         if self.spec.satisfies("%oneapi") or self.spec.satisfies("%intel"):
             options.append(self.define("CMAKE_CXX_FLAGS", "-fp-model=precise"))
 
-        options.append(self.define_from_variant("Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC", "alloc_async"))
+        options.append(
+            self.define_from_variant("Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC", "alloc_async")
+        )
 
         # Remove duplicate options
         return lang.dedupe(options)

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -229,7 +229,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
     # Expose a way to disable CudaMallocAsync that can cause problems
     # with some MPI such as cray-mpich
-    variant("alloc_async", default=True, description="Use CudaMallocAsync", when="@4.2: +cuda")
+    variant("alloc_async", default=False, description="Use CudaMallocAsync", when="@4.2: +cuda")
 
     # SYCL and OpenMPTarget require C++17 or higher
     for cxxstdver in cxxstds[: cxxstds.index("17")]:

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -227,8 +227,13 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+cuda", when="cxxstd=17 ^cuda@:10")
     conflicts("+cuda", when="cxxstd=20 ^cuda@:11")
 
-    variant("async_malloc", default=True, description="Use CudaMallocAsync or HipMallocAsync", when="@4.2:")
-    conflicts("+async_malloc", when="~cuda ~rocm")
+    variant(
+        "alloc_async",
+        default=True,
+        description="Use CudaMallocAsync or HipMallocAsync",
+        when="@4.2:",
+    )
+    conflicts("+alloc_async", when="~cuda ~rocm")
 
     # SYCL and OpenMPTarget require C++17 or higher
     for cxxstdver in cxxstds[: cxxstds.index("17")]:
@@ -375,7 +380,9 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
             options.append(self.define("CMAKE_CXX_FLAGS", "-fp-model=precise"))
 
         if "+cuda" in self.spec:
-            options.append(self.define_from_variant(Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC, "async_malloc"))
+            options.append(
+                self.define_from_variant(Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC, "alloc_async")
+            )
 
         # Remove duplicate options
         return lang.dedupe(options)

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -227,7 +227,8 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+cuda", when="cxxstd=17 ^cuda@:10")
     conflicts("+cuda", when="cxxstd=20 ^cuda@:11")
 
-    # Expose a way to disable CudaMallocAsync that can cause problems with some MPI such as cray-mpich
+    # Expose a way to disable CudaMallocAsync that can cause problems
+    # with some MPI such as cray-mpich
     variant("alloc_async", default=True, description="Use CudaMallocAsync", when="@4.2: +cuda")
 
     # SYCL and OpenMPTarget require C++17 or higher

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -375,7 +375,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         if self.spec.satisfies("%oneapi") or self.spec.satisfies("%intel"):
             options.append(self.define("CMAKE_CXX_FLAGS", "-fp-model=precise"))
 
-        if "+cuda" in self.spec:
+        if self.spec.satisfies("+cuda"):
             options.append(
                 self.define_from_variant("Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC", "alloc_async")
             )

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -227,13 +227,8 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+cuda", when="cxxstd=17 ^cuda@:10")
     conflicts("+cuda", when="cxxstd=20 ^cuda@:11")
 
-    variant(
-        "alloc_async",
-        default=True,
-        description="Use CudaMallocAsync or HipMallocAsync",
-        when="@4.2:",
-    )
-    conflicts("+alloc_async", when="~cuda ~rocm")
+    # Expose a way to disable CudaMallocAsync that can cause problems with some MPI such as cray-mpich
+    variant("alloc_async", default=True, description="Use CudaMallocAsync", when="@4.2: +cuda")
 
     # SYCL and OpenMPTarget require C++17 or higher
     for cxxstdver in cxxstds[: cxxstds.index("17")]:

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -375,10 +375,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         if self.spec.satisfies("%oneapi") or self.spec.satisfies("%intel"):
             options.append(self.define("CMAKE_CXX_FLAGS", "-fp-model=precise"))
 
-        if self.spec.satisfies("+cuda"):
-            options.append(
-                self.define_from_variant("Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC", "alloc_async")
-            )
+        options.append(self.define_from_variant("Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC", "alloc_async"))
 
         # Remove duplicate options
         return lang.dedupe(options)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Add a variant `alloc_async` to enable/disable the use of `cudaMallocAsync`.

It is disabled by default (unlike previous behavior, but it follows the new policy in Kokkos kokkos/kokkos#7353).

Related to kokkos/kokkos#7294 and #46090.