### PR TITLE
Patch fftw cmake

### DIFF
--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+spack # Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -244,6 +244,9 @@ class Fftw(FftwBase):
     provides("fftw-api@3", when="@3:")
 
     patch("pfft-3.3.9.patch", when="@3.3.9:+pfft_patches", level=0)
+    patch("https://github.com/FFTW/fftw3/commit/f69fef7aa546d4477a2a3fd7f13fa8b2f6c54af7.patch?full_index=1",
+          sha256="872cff9a7d346e91a108ffd3540bfcebeb8cf86c7f40f6b31fd07a80267cbf53",
+          when="@3.3.7:")
     patch("pfft-3.3.5.patch", when="@3.3.5:3.3.8+pfft_patches", level=0)
     patch("pfft-3.3.4.patch", when="@3.3.4+pfft_patches", level=0)
     patch("pgi-3.3.6-pl2.patch", when="@3.3.6-pl2%pgi", level=0)

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -1,4 +1,4 @@
-spack # Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -244,9 +244,11 @@ class Fftw(FftwBase):
     provides("fftw-api@3", when="@3:")
 
     patch("pfft-3.3.9.patch", when="@3.3.9:+pfft_patches", level=0)
-    patch("https://github.com/FFTW/fftw3/commit/f69fef7aa546d4477a2a3fd7f13fa8b2f6c54af7.patch?full_index=1",
-          sha256="872cff9a7d346e91a108ffd3540bfcebeb8cf86c7f40f6b31fd07a80267cbf53",
-          when="@3.3.7:")
+    patch(
+        "https://github.com/FFTW/fftw3/commit/f69fef7aa546d4477a2a3fd7f13fa8b2f6c54af7.patch?full_index=1",
+        sha256="872cff9a7d346e91a108ffd3540bfcebeb8cf86c7f40f6b31fd07a80267cbf53",
+        when="@3.3.7:",
+    )
     patch("pfft-3.3.5.patch", when="@3.3.5:3.3.8+pfft_patches", level=0)
     patch("pfft-3.3.4.patch", when="@3.3.4+pfft_patches", level=0)
     patch("pgi-3.3.6-pl2.patch", when="@3.3.6-pl2%pgi", level=0)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This patches https://github.com/FFTW/fftw3/issues/130 in FFTW from 3.3.7. The patch is in the FFTW development but there's no released version with it. Presumably this won't be needed if/when they release 3.3.11. 