### PR TITLE
Revert "Add full_hostname host variable"

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -893,9 +893,8 @@ The valid variables for a ``when`` clause are:
 
 #. ``env``. The user environment (usually ``os.environ`` in Python).
 
-#. ``hostname``. The hostname of the system.
-
-#. ``full_hostname``. The fully qualified hostname of the system.
+#. ``hostname``. The hostname of the system (if ``hostname`` is an
+   executable in the user's PATH).
 
 ^^^^^^^^^^^^^^^^^^^^^^^^
 SpecLists as Constraints

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4908,7 +4908,6 @@ def get_host_environment() -> Dict[str, Any]:
         "architecture": arch_spec,
         "arch_str": str(arch_spec),
         "hostname": socket.gethostname(),
-        "full_hostname": socket.getfqdn(),
     }
 
 


### PR DESCRIPTION
It looks like this commit causes a major performance penalty in unit test time on macOS. Fine with the feature in principle, but has to be redone.

Reverts spack/spack#45522