### PR TITLE
run-unit-tests: no xdist if coverage

### DIFF
--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -47,7 +47,7 @@ $coverage_run $(which spack) python -c "import spack.pkg.builtin.mpileaks; repr(
 # Run unit tests with code coverage
 #-----------------------------------------------------------
 # Check if xdist is available
-if python -m pytest -VV 2>&1 | grep xdist; then
+if [[ "$UNIT_TEST_COVERAGE" != "true" ]] && python -m pytest -VV 2>&1 | grep xdist; then
   export PYTEST_ADDOPTS="$PYTEST_ADDOPTS --dist loadfile --tx '${SPACK_TEST_PARALLEL:=3}*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python'"
 fi
 
@@ -61,9 +61,9 @@ fi
 # where it seems that otherwise the configuration file might not be located by subprocesses
 # in some, not better specified, cases.
 if [[ "$UNIT_TEST_COVERAGE" == "true" ]]; then
-  $(which spack) unit-test -x --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml
+  "$(which spack)" unit-test -x --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml
 else
-  $(which spack) unit-test -x --verbose
+  "$(which spack)" unit-test -x --verbose
 fi
 
 


### PR DESCRIPTION
looks like xdist only slows down unit tests under coverage

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
