### PR TITLE
bigdft-psolver: fix build failure

### DIFF
--- a/var/spack/repos/builtin/packages/bigdft-psolver/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-psolver/package.py
@@ -97,7 +97,7 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
         else:
             args.append("--without-openmp")
 
-        args.append(f"--with-atlab-libs={spec['bigdft-atlab'].prefix.lib}")
+        args.append(f"--with-atlab-libs={spec['bigdft-atlab'].libs.ld_flags}")
 
         if spec.satisfies("+cuda"):
             args.append("--enable-cuda-gpu")

--- a/var/spack/repos/builtin/packages/bigdft-psolver/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-psolver/package.py
@@ -12,7 +12,7 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
     of BigDFT code, and it can also be used separately and linked to other codes."""
 
     homepage = "https://bigdft.org/"
-    url = "https://gitlab.com/l_sim/bigdft-suite/-/archive/1.9.2/bigdft-suite-1.9.2.tar.gz"
+    url = "https://gitlab.com/l_sim/bigdft-suite/-/archive/1.9.5/bigdft-suite-1.9.5.tar.gz"
     git = "https://gitlab.com/l_sim/bigdft-suite.git"
 
     version("develop", branch="devel")
@@ -23,16 +23,15 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
     version("1.9.1", sha256="3c334da26d2a201b572579fc1a7f8caad1cbf971e848a3e10d83bc4dc8c82e41")
     version("1.9.0", sha256="4500e505f5a29d213f678a91d00a10fef9dc00860ea4b3edf9280f33ed0d1ac8")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
 
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("scalapack", default=True, description="Enable SCALAPACK support")
-    variant(
-        "shared", default=True, description="Build shared libraries"
-    )  # Not default in bigdft, but is typically the default expectation
+    # Not default in bigdft, but is typically the default expectation:
+    variant("shared", default=True, description="Build shared libraries")
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")


### PR DESCRIPTION
Configure was unable to link against bigdft-atlab, because the provided variable only contained the directory containing the libs itself, not the ldflags.

    checking for ATLAB (PKG_CONFIG)... checking for atlab modules... yes
    checking for atlab library... no
    checking for ATLAB LIBS... "LIB_ATLAB_LIBS=  (provided /spack-environments-releases-24a/spack/opt/spack/linux-debian11-skylake/gcc-12.3.0/bigdft-atlab-1.9.3-lnx5zchasb34m4e6yvgh7xygor7thmvh/lib -L/spack-environments-releases-24a/spack/opt/spack/linux-debian11-skylake/gcc-12.3.0/bigdft-futile-1.9.3-lj55nh2nzatqi5cfrdhdn4tabpof67yq/lib -lfutile-1 -L/spack-environments-releases-24a/spack/opt/spack/linux-debian11-skylake/gcc-12.3.0/netlib-scalapack-2.2.0-4pfcpzux2hckiuuvdkvhxrxpapv4w6kv/lib -lscalapack -L/spack-environments-releases-24a/spack/opt/spack/linux-debian11-skylake/gcc-12.3.0/openblas-0.3.23-g2u45zrh4z3h3g5tnoey5k2jptr6xa2k/lib -lopenblas -L/spack-environments-releases-24a/spack/opt/spack/linux-debian11-skylake/gcc-12.3.0/openblas-0.3.23-g2u45zrh4z3h3g5tnoey5k2jptr6xa2k/lib -lopenblas)"
    checking for ATLAB CFLAGS... "LIB_ATLAB_CFLAGS=  (provided  -I/spack-environments-releases-24a/spack/opt/spack/linux-debian11-skylake/gcc-12.3.0/bigdft-futile-1.9.3-lj55nh2nzatqi5cfrdhdn4tabpof67yq/include)"
    configure: error: Atlab library not found, cannot proceed.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
