### PR TITLE
url join: fix oci scheme

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2698,6 +2698,9 @@ def get_keys(install=False, trust=False, force=False, mirrors=None):
 
     for mirror in mirror_collection.values():
         fetch_url = mirror.fetch_url
+        # TODO: oci:// does not support signing.
+        if fetch_url.startswith("oci://"):
+            continue
         keys_url = url_util.join(
             fetch_url, BUILD_CACHE_RELATIVE_PATH, BUILD_CACHE_KEYS_RELATIVE_PATH
         )

--- a/lib/spack/spack/test/util/util_url.py
+++ b/lib/spack/spack/test/util/util_url.py
@@ -48,7 +48,7 @@ def test_relative_path_to_file_url(tmpdir):
 
 
 @pytest.mark.parametrize("resolve_href", [True, False])
-@pytest.mark.parametrize("scheme", ["http", "s3", "gs", "file"])
+@pytest.mark.parametrize("scheme", ["http", "s3", "gs", "file", "oci"])
 def test_url_join_absolute(scheme, resolve_href):
     """Test that joining a URL with an absolute path works the same for schemes we care about, and
     whether we work in web browser mode or not."""

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -73,7 +73,7 @@ def join(base: str, *components: str, resolve_href: bool = False, **kwargs) -> s
     1. By default resolve_href=False, which makes the function like os.path.join: for example
     https://example.com/a/b + c/d = https://example.com/a/b/c/d. If resolve_href=True, the
     behavior is how a browser would resolve the URL: https://example.com/a/c/d.
-    2. s3:// and gs:// URLs are joined like http:// URLs.
+    2. s3://, gs://, oci:// URLs are joined like http:// URLs.
     3. It accepts multiple components for convenience. Note that components[1:] are treated as
     literal path components and appended to components[0] separated by slashes."""
     # Ensure a trailing slash in the path component of the base URL to get os.path.join-like
@@ -87,8 +87,8 @@ def join(base: str, *components: str, resolve_href: bool = False, **kwargs) -> s
     try:
         # NOTE: we temporarily modify urllib internals so s3 and gs schemes are treated like http.
         # This is non-portable, and may be forward incompatible with future cpython versions.
-        urllib.parse.uses_netloc = [*uses_netloc, "s3", "gs"]
-        urllib.parse.uses_relative = [*uses_relative, "s3", "gs"]
+        urllib.parse.uses_netloc = [*uses_netloc, "s3", "gs", "oci"]
+        urllib.parse.uses_relative = [*uses_relative, "s3", "gs", "oci"]
         return urllib.parse.urljoin(base, "/".join(components), **kwargs)
     finally:
         urllib.parse.uses_netloc = uses_netloc


### PR DESCRIPTION
Fix an issue where spack.util.url.join(...) was used on oci:// urls.

The fact that that happened was a bug by itself, so also fix it on the call site.