### PR TITLE
require spec in develop entry

### DIFF
--- a/lib/spack/spack/schema/develop.py
+++ b/lib/spack/spack/schema/develop.py
@@ -13,6 +13,7 @@ properties: Dict[str, Any] = {
             r"\w[\w-]*": {
                 "type": "object",
                 "additionalProperties": False,
+                "required": ["spec"],
                 "properties": {"spec": {"type": "string"}, "path": {"type": "string"}},
             }
         },


### PR DESCRIPTION
`entry["spec"]` is expected in code but not required by the schema.