### PR TITLE
cans: update homepage and url

### DIFF
--- a/var/spack/repos/builtin/packages/cans/package.py
+++ b/var/spack/repos/builtin/packages/cans/package.py
@@ -15,8 +15,8 @@ class Cans(MakefilePackage):
     finite-difference Poisson equation
     in a 3D Cartesian grid."""
 
-    homepage = "https://github.com/p-costa/CaNS"
-    url = "https://github.com/p-costa/CaNS/archive/refs/tags/v1.1.4.tar.gz"
+    homepage = "https://github.com/CaNS-World/CaNS"
+    url = "https://github.com/CaNS-World/CaNS/archive/refs/tags/v1.1.4.tar.gz"
 
     maintainers("lhxone", "p-costa", "nscapin", "GabrieleBoga")
 


### PR DESCRIPTION
This PR updates the homepage and url of `cans` which is redirecting to a different github organization now. Checked checksums and they are unchanged with the new url.