### PR TITLE
chatterbug: update homepage and git

### DIFF
--- a/var/spack/repos/builtin/packages/chatterbug/package.py
+++ b/var/spack/repos/builtin/packages/chatterbug/package.py
@@ -15,8 +15,8 @@ class Chatterbug(MakefilePackage):
 
     tags = ["proxy-app"]
 
-    homepage = "https://chatterbug.readthedocs.io"
-    git = "https://github.com/LLNL/chatterbug.git"
+    homepage = "https://github.com/hpcgroup/chatterbug"
+    git = "https://github.com/hpcgroup/chatterbug.git"
 
     license("MIT")
 


### PR DESCRIPTION
This PR updates the homepage and git url for `chatterbug` which has moved to a different github organization and does not publish RTD anymore. The tagged commit is still valid on the new repo location.