### PR TITLE
openblas: add v0.3.28 with patch

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/openblas-0.3.28-thread-buffer.patch
+++ b/var/spack/repos/builtin/packages/openblas/openblas-0.3.28-thread-buffer.patch
@@ -1,0 +1,14 @@
+--- a/driver/others/blas_server.c	2024-09-18 17:09:48.362101394 -0700
++++ b/driver/others/blas_server.c	2024-09-18 17:12:59.690940586 -0700
+@@ -1076,6 +1076,11 @@
+       main_status[cpu] = MAIN_RUNNING1;
+ #endif
+
++if (buffer == NULL) {
++	blas_thread_buffer[cpu] = blas_memory_alloc(2);
++	buffer = blas_thread_buffer[cpu];
++}
++
+ //For target LOONGSON3R5, applying an offset to the buffer is essential
+ //for minimizing cache conflicts and optimizing performance.
+ #if defined(ARCH_LOONGARCH64) && !defined(NO_AFFINITY)

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -26,6 +26,7 @@ class Openblas(CMakePackage, MakefilePackage):
     license("BSD-3-Clause")
 
     version("develop", branch="develop")
+    version("0.3.28", sha256="f1003466ad074e9b0c8d421a204121100b0751c96fc6fcf3d1456bd12f8a00a1")
     version("0.3.27", sha256="aa2d68b1564fe2b13bc292672608e9cdeeeb6dc34995512e65c3b10f4599e897")
     version("0.3.26", sha256="4e6e4f5cb14c209262e33e6816d70221a2fe49eb69eaf0a06f065598ac602c68")
     version("0.3.25", sha256="4c25cb30c4bb23eddca05d7d0a85997b8db6144f5464ba7f8c09ce91e2f35543")
@@ -60,10 +61,6 @@ class Openblas(CMakePackage, MakefilePackage):
     version("0.2.17", sha256="0fe836dfee219ff4cadcc3567fb2223d9e0da5f60c7382711fb9e2c35ecf0dbf")
     version("0.2.16", sha256="766f350d0a4be614812d535cead8c816fc3ad3b9afcd93167ea5e4df9d61869b")
     version("0.2.15", sha256="73c40ace5978282224e5e122a41c8388c5a19e65a6f2329c2b7c0b61bacc9044")
-
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
 
     variant(
         "fortran",
@@ -105,6 +102,14 @@ class Openblas(CMakePackage, MakefilePackage):
     provides("blas", "lapack")
     provides("lapack@3.9.1:", when="@0.3.15:")
     provides("lapack@3.7.0", when="@0.2.20")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+    depends_on("perl", when="@:0.3.20", type="build")
+
+    # https://github.com/OpenMathLib/OpenBLAS/pull/4879
+    patch("openblas-0.3.28-thread-buffer.patch", when="@0.3.28")
 
     # https://github.com/OpenMathLib/OpenBLAS/pull/4328
     patch("xcode15-fortran.patch", when="@0.3.25 %apple-clang@15:")
@@ -265,8 +270,6 @@ class Openblas(CMakePackage, MakefilePackage):
     )
 
     conflicts("target=x86_64_v4:", when="%intel@2021")
-
-    depends_on("perl", type="build")
 
     build_system("makefile", "cmake", default="makefile")
 


### PR DESCRIPTION
Following up on https://github.com/spack/spack/pull/45782, adding the latest openblas release v0.3.28 with a patch based on https://github.com/OpenMathLib/OpenBLAS/pull/4879.

The build dependency perl is no longer required as of v0.3.21, so also adding a constraint for that. For reference: https://github.com/OpenMathLib/OpenBLAS/blob/develop/Changelog.txt#L524