### PR TITLE
do_install: post #46423 cleanup

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2221,7 +2221,7 @@ class BuildProcessInstaller:
                 f"{self.pre} Building {self.pkg_id} [{self.pkg.build_system_class}]"  # type: ignore[attr-defined] # noqa: E501
             )
 
-            # get verbosity from do_install() parameter or saved value
+            # get verbosity from install parameter or saved value
             self.echo = self.verbose
             if spack.package_base.PackageBase._verbose is not None:
                 self.echo = spack.package_base.PackageBase._verbose

--- a/lib/spack/spack/rewiring.py
+++ b/lib/spack/spack/rewiring.py
@@ -39,7 +39,8 @@ def rewire(spliced_spec):
     for spec in spliced_spec.traverse(order="post", root=True):
         if not spec.build_spec.installed:
             # TODO: May want to change this at least for the root spec...
-            # spec.build_spec.package.do_install(force=True)
+            # TODO: Also remember to import PackageInstaller
+            # PackageInstaller([spec.build_spec.package]).install()
             raise PackageNotInstalledError(spliced_spec, spec.build_spec, spec)
         if spec.build_spec is not spec and not spec.installed:
             explicit = spec is spliced_spec

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -725,8 +725,8 @@ def test_external_entries_in_db(mutable_database):
 def test_regression_issue_8036(mutable_database, usr_folder_exists):
     # The test ensures that the external package prefix is treated as
     # existing. Even when the package prefix exists, the package should
-    # not be considered installed until it is added to the database with
-    # do_install.
+    # not be considered installed until it is added to the database by
+    # the installer with install().
     s = spack.spec.Spec("externaltool@0.9")
     s.concretize()
     assert not s.installed


### PR DESCRIPTION
Removal of `do_install()` (#46423) left a few references to the method in comments.  This PR cleans those up.