### PR TITLE
py-protobuf: drop +cpp, always require protobuf

### DIFF
--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -226,7 +226,7 @@ class Lbann(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("python@3: +shared", type=("build", "run"), when="+pfe")
     extends("python", when="+pfe")
     depends_on("py-setuptools", type="build", when="+pfe")
-    depends_on("py-protobuf+cpp@3.10.0:4.21.12", type=("build", "run"), when="+pfe")
+    depends_on("py-protobuf@3.10.0:4.21.12", type=("build", "run"), when="+pfe")
 
     depends_on("protobuf@3.10.0:3.21.12")
     depends_on("zlib-api", when="^protobuf@3.11.0:")

--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -16,6 +16,9 @@ class Protobuf(CMakePackage):
 
     license("BSD-3-Clause")
 
+    version("3.28.2", sha256="1b6b6a7a7894f509f099c4469b5d4df525c2f3c9e4009e5b2db5b0f66cb8ee0e")
+    version("3.27.5", sha256="a4aa92d0a207298149bf553d9a3192f3562eb91740086f50fa52331e60fa480c")
+    version("3.26.1", sha256="f3c0830339eaa5036eba8ff8ce7fca5aa3088f7d616f7c3713d946f611ae92bf")
     version("3.25.3", sha256="da82be8acc5347c7918ef806ebbb621b24988f7e1a19b32cd7fc73bc29b59186")
     version("3.24.3", sha256="2c23dee0bdbc36bd43ee457083f8f5560265d0815cc1c56033de3932843262fe")
     version("3.23.3", sha256="5e4b555f72a7e3f143a7aff7262292500bb02c49b174351684bb70fc7f2a6d33")
@@ -77,8 +80,8 @@ class Protobuf(CMakePackage):
     version("3.1.0", sha256="fb2a314f4be897491bb2446697be693d489af645cb0e165a85e7e64e07eb134d")
     version("3.0.2", sha256="a0a265bcc9d4e98c87416e59c33afc37cede9fb277292523739417e449b18c1e")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     variant("shared", default=True, description="Enables the build of shared libraries")
     variant(

--- a/var/spack/repos/builtin/packages/py-onnx/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx/package.py
@@ -56,7 +56,6 @@ class PyOnnx(PythonPackage):
     # https://github.com/protocolbuffers/protobuf/pull/8794, fixed in
     # https://github.com/onnx/onnx/pull/3112
     depends_on("py-protobuf@:3.17", type=("build", "run"), when="@:1.8")
-    depends_on("py-protobuf+cpp", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-numpy@1.16.6:", type=("build", "run"), when="@1.8.1:1.13")
     depends_on("py-numpy@1.20:", type=("build", "run"), when="@1.16.0:")

--- a/var/spack/repos/builtin/packages/py-protobuf/package.py
+++ b/var/spack/repos/builtin/packages/py-protobuf/package.py
@@ -17,6 +17,8 @@ class PyProtobuf(PythonPackage):
     homepage = "https://developers.google.com/protocol-buffers/"
     pypi = "protobuf/protobuf-3.11.0.tar.gz"
 
+    version("5.28.2", sha256="59379674ff119717404f7454647913787034f03fe7049cbef1d74a97bb4593f0")
+    version("5.27.5", sha256="7fa81bc550201144a32f4478659da06e0b2ebe4d5303aacce9a202a1c3d5178d")
     version("5.26.1", sha256="8ca2a1d97c290ec7b16e4e5dff2e5ae150cc1582f55b5ab300d45cb0dfa90e51")
     version("4.25.3", sha256="25b5d0b42fd000320bd7830b349e3b696435f3b329810427a6bcce6a5492cc5c")
     version("4.24.3", sha256="12e9ad2ec079b833176d2921be2cb24281fa591f0b119b208b788adc48c2561d")
@@ -62,38 +64,18 @@ class PyProtobuf(PythonPackage):
     version("3.3.0", sha256="1cbcee2c45773f57cb6de7ee0eceb97f92b9b69c0178305509b162c0160c1f04")
     version("3.0.0", sha256="ecc40bc30f1183b418fe0ec0c90bc3b53fa1707c4205ee278c6b90479e5b6ff5")
 
-    depends_on("c", type="build")  # generated
-
-    variant("cpp", default=False, when="@:4.21", description="Enable the cpp implementation")
+    depends_on("c", type="build")
 
     depends_on("python", type=("build", "link", "run"))
     depends_on("py-setuptools", type=("build", "run"))
-    # in newer pip versions --install-option does not exist
-    depends_on("py-pip@:23.0", when="+cpp", type=("build", "run"))
     depends_on("py-six@1.9:", when="@3.0:3.17", type=("build", "run"))
 
-    # Setup dependencies for protobuf to use the same minor version as py-protobuf
-    # Handle mapping the 4.x release to the protobuf 3.x releases
-    depends_on("protobuf@3.21", when="+cpp @4.21")
-    # Handle the 3.x series releases
-    for ver in list(range(0, 21)):
-        depends_on(f"protobuf@3.{ver}", when=f"@3.{ver}+cpp")
+    # Minor version must match protobuf
+    for ver in range(26, 29):
+        depends_on(f"protobuf@3.{ver}", when=f"@5.{ver}")
+    for ver in range(21, 26):
+        depends_on(f"protobuf@3.{ver}", when=f"@4.{ver}")
+    for ver in range(0, 21):
+        depends_on(f"protobuf@3.{ver}", when=f"@3.{ver}")
 
-    conflicts("+cpp", when="^python@3.11:")
-    conflicts("%gcc@14", when="@:4.24.3")
-
-    @property
-    def build_directory(self):
-        if self.spec.satisfies("@3.1.0"):
-            return "python"
-        else:
-            return "."
-
-    @when("+cpp")
-    def setup_build_environment(self, env):
-        protobuf_dir = self.spec["protobuf"].libs.directories[0]
-        env.prepend_path("LIBRARY_PATH", protobuf_dir)
-
-    @when("+cpp")
-    def install_options(self, spec, prefix):
-        return ["--cpp_implementation"]
+    conflicts("%gcc@14:", when="@:4.24.3")

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -377,8 +377,6 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     conflicts("+rocm", when="@:2.7.4-a,2.7.4.0:2.11.0-a,2.11.0.0:2.14-a,2.14-z:2.16.1-a,2.16.1-z:")
     # wheel 0.40 upgrades vendored packaging, trips over tensorflow-io-gcs-filesystem identifier
     conflicts("^py-wheel@0.40:", when="@2.11:2.13")
-    # Must be matching versions of py-protobuf and protobuf
-    conflicts("^py-protobuf~cpp")
 
     # https://www.tensorflow.org/install/source#tested_build_configurations
     # https://github.com/tensorflow/tensorflow/issues/70199


### PR DESCRIPTION
Many packages depend on protobuf. Many others depend on py-protobuf. Very few depend on both. But, if both end up in the DAG and do not have matching minor versions, everything breaks.

This PR adds a dependency on protobuf to py-protobuf. While this is not strictly necessary, it does prevent the above issue.

I'm less certain about dropping `+cpp`. py-protobuf has a number of optional [implementation backends](https://github.com/protocolbuffers/protobuf/tree/main/python#implementation-backends). `cpp` is deprecated, but maybe we need it for some legacy packages. I'm hoping CI will tell us whether or not that is the case.

Fixes #14528 @rblake-llnl 