### PR TITLE
opendatadetector: Add an env variable pointing to the share directory

### DIFF
--- a/var/spack/repos/builtin/packages/opendatadetector/package.py
+++ b/var/spack/repos/builtin/packages/opendatadetector/package.py
@@ -36,6 +36,6 @@ class Opendatadetector(CMakePackage):
         return args
 
     def setup_run_environment(self, env):
-        env.set("OPENDATADETECTOR", self.prefix.share + "/OpenDataDetector")
+        env.set("OPENDATADETECTOR_DATA", join_path(self.prefix.share, "OpenDataDetector"))
         env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
         env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib64)

--- a/var/spack/repos/builtin/packages/opendatadetector/package.py
+++ b/var/spack/repos/builtin/packages/opendatadetector/package.py
@@ -32,10 +32,10 @@ class Opendatadetector(CMakePackage):
 
     def cmake_args(self):
         args = []
-        # C++ Standard
         args.append("-DCMAKE_CXX_STANDARD=%s" % self.spec["root"].variants["cxxstd"].value)
         return args
 
     def setup_run_environment(self, env):
+        env.set("OPENDATADETECTOR", self.prefix.share + "/OpenDataDetector")
         env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
         env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib64)


### PR DESCRIPTION
This was a request from one of our users (see https://github.com/key4hep/key4hep-spack/issues/526) and it's useful to point to
the xml files provided by OpenDataDetector. These files can be found in `<prefix>/share/OpenDataDetector/xml/`.