### PR TITLE
goblin-hmc-sim: fix url

### DIFF
--- a/var/spack/repos/builtin/packages/goblin-hmc-sim/package.py
+++ b/var/spack/repos/builtin/packages/goblin-hmc-sim/package.py
@@ -15,7 +15,7 @@ class GoblinHmcSim(MakefilePackage):
     homepage = "https://github.com/tactcomplabs/gc64-hmcsim"
     git = "https://github.com/tactcomplabs/gc64-hmcsim"
     # The version numbers track the SST they were released with
-    url = "https://github.com/tactcomplabs/gc64-hmcsim/archive/sst-8.0.0-release.tar.gz"
+    url = "https://github.com/tactcomplabs/gc64-hmcsim/archive/refs/tags/sst-8.0.0-release.tar.gz"
     # This works with parallel builds outside Spack
     # For some reason .o files get thrashed inside Spack
     parallel = False


### PR DESCRIPTION
This PR fixes the url for `goblin-hmc-sim` since the old archive-only github link is deprecated and may not work.
```console
$ curl https://github.com/tactcomplabs/gc64-hmcsim/archive/sst-8.0.0-release.tar.gz
the given path has multiple possibilities: #<Git::Ref:0x00007fba1e3e99c0>, #<Git::Ref:0x00007fba1e3e9880>
```