### PR TITLE
shc: fix url

### DIFF
--- a/var/spack/repos/builtin/packages/shc/package.py
+++ b/var/spack/repos/builtin/packages/shc/package.py
@@ -13,7 +13,7 @@ class Shc(AutotoolsPackage):
     and linked to produce a stripped binary executable."""
 
     homepage = "https://neurobin.org/projects/softwares/unix/shc/"
-    url = "https://github.com/neurobin/shc/archive/4.0.3.tar.gz"
+    url = "https://github.com/neurobin/shc/archive/refs/tags/4.0.3.tar.gz"
 
     license("GPL-3.0-or-later")
 


### PR DESCRIPTION
The old url for `shc` is broken with:
```console
curl -L https://github.com/neurobin/shc/archive/4.0.3.tar.gz
the given path has multiple possibilities: #<Git::Ref:0x00007fa482365dc0>, #<Git::Ref:0x00007fa482365280>
```

This PR adjusts the url. Verified that all checksums remain unchanged.