### PR TITLE
yajl: fix url

### DIFF
--- a/var/spack/repos/builtin/packages/yajl/package.py
+++ b/var/spack/repos/builtin/packages/yajl/package.py
@@ -10,7 +10,7 @@ class Yajl(CMakePackage):
     """Yet Another JSON Library (YAJL)"""
 
     homepage = "https://lloyd.github.io/yajl/"
-    url = "https://github.com/lloyd/yajl/archive/2.1.0.zip"
+    url = "https://github.com/lloyd/yajl/archive/refs/tags/2.1.0.zip"
     git = "https://github.com/lloyd/yajl.git"
 
     license("MIT")


### PR DESCRIPTION
This PR fixes a broken url for `yajl`:
```console
$ curl -L https://github.com/lloyd/yajl/archive/2.1.0.zip
the given path has multiple possibilities: #<Git::Ref:0x00007f4c1c4c2e48>, #<Git::Ref:0x00007f4c1c4c21c8>
```
Existing checksums unchanged.

This happens when a branch and tag with identical names exist, i.e. both of the following exist:
```
curl -L https://github.com/lloyd/yajl/archive/refs/tags/2.1.0.zip
curl -L https://github.com/lloyd/yajl/archive/refs/heads/2.1.0.zip
```
Maybe an audit rule should prevent these kind of ambiguous urls from being used. @alalazo what do you think?