### PR TITLE
testdfsio: fix url

### DIFF
--- a/var/spack/repos/builtin/packages/testdfsio/package.py
+++ b/var/spack/repos/builtin/packages/testdfsio/package.py
@@ -10,9 +10,9 @@ from spack.package import *
 class Testdfsio(MavenPackage):
     """A corrected and enhanced version of Apache Hadoop TestDFSIO"""
 
-    homepage = "https://github.com/tthx/testdfsio"
-    url = "https://github.com/tthx/testdfsio/archive/0.0.1.tar.gz"
+    homepage = "https://github.com/asotirov0/testdfsio"
+    url = "https://github.com/asotirov0/testdfsio/archive/0.0.1.tar.gz"
 
-    version("0.0.1", sha256="fe8cc47260ffb3e3ac90e0796ebfe73eb4dac64964ab77671e5d32435339dd09")
+    version("0.0.1", sha256="fe8cc47260ffb3e3ac90e0796ebfe73eb4dac64964ab77671e5d32435339dd09", deprecated=True)
 
     depends_on("hadoop@3.2.1:", type="run")

--- a/var/spack/repos/builtin/packages/testdfsio/package.py
+++ b/var/spack/repos/builtin/packages/testdfsio/package.py
@@ -13,6 +13,10 @@ class Testdfsio(MavenPackage):
     homepage = "https://github.com/asotirov0/testdfsio"
     url = "https://github.com/asotirov0/testdfsio/archive/0.0.1.tar.gz"
 
-    version("0.0.1", sha256="fe8cc47260ffb3e3ac90e0796ebfe73eb4dac64964ab77671e5d32435339dd09", deprecated=True)
+    version(
+        "0.0.1",
+        sha256="fe8cc47260ffb3e3ac90e0796ebfe73eb4dac64964ab77671e5d32435339dd09",
+        deprecated=True,
+    )
 
     depends_on("hadoop@3.2.1:", type="run")


### PR DESCRIPTION
This PR fixes the defunct url for testdfsio to another version on GitHub. The checksum is unchanged.

Based on https://github.com/search?q=TestDFSIO&type=repositories this is the only other version on GitHub. It is hardly a sustainable game of whack-a-mole to pick random repositories online, so I've also marked this as deprecated so it can be removed at some point after the next release.