### PR TITLE
py-falcon: fix url

### DIFF
--- a/var/spack/repos/builtin/packages/py-falcon/package.py
+++ b/var/spack/repos/builtin/packages/py-falcon/package.py
@@ -11,7 +11,7 @@ class PyFalcon(PythonPackage):
     building large-scale app backends and microservices."""
 
     homepage = "https://github.com/falconry/falcon"
-    url = "https://github.com/falconry/falcon/archive/3.0.0a2.tar.gz"
+    url = "https://github.com/falconry/falcon/archive/refs/tags/3.0.0a2.tar.gz"
 
     license("Apache-2.0")
 


### PR DESCRIPTION
This PR fixes the url of py-falcon, which fails with
```console
$ curl https://github.com/falconry/falcon/archive/3.0.0a2.tar.gz
the given path has multiple possibilities: #<Git::Ref:0x00007ff140cf49d0>, #<Git::Ref:0x00007ff140cf2630>
```

Checksums verified and unchanged.