### PR TITLE
py-cftime: fix url

### DIFF
--- a/var/spack/repos/builtin/packages/py-cftime/package.py
+++ b/var/spack/repos/builtin/packages/py-cftime/package.py
@@ -12,7 +12,7 @@ class PyCftime(PythonPackage):
     netCDF conventions"""
 
     homepage = "https://unidata.github.io/cftime/"
-    url = "https://github.com/Unidata/cftime/archive/v1.0.3.4rel.tar.gz"
+    url = "https://github.com/Unidata/cftime/archive/refs/tags/v1.0.3.4rel.tar.gz"
 
     version("1.0.3.4", sha256="f261ff8c65ceef4799784cd999b256d608c177d4c90b083553aceec3b6c23fd3")
 


### PR DESCRIPTION
This PR fixes the url of `py-cftime` to avoid the error
```console
$ curl -L https://github.com/Unidata/cftime/archive/v1.0.3.4rel.tar.gz
the given path has multiple possibilities: #<Git::Ref:0x00007f11db24b320>, #<Git::Ref:0x00007f11db24a470>
```
Checksum verified and unchanged.