### PR TITLE
hudi: fix url

### DIFF
--- a/var/spack/repos/builtin/packages/hudi/package.py
+++ b/var/spack/repos/builtin/packages/hudi/package.py
@@ -12,7 +12,7 @@ class Hudi(MavenPackage):
     Hudi manages the storage of large analytical datasets on DFS."""
 
     homepage = "https://hudi.apache.org/"
-    url = "https://github.com/apache/hudi/archive/release-0.5.3.tar.gz"
+    url = "https://github.com/apache/hudi/archive/refs/tags/release-0.5.3.tar.gz"
 
     license("Apache-2.0")
 


### PR DESCRIPTION
This PR fixes the url of `hudi` which errors with:
```console
$ curl -L https://github.com/apache/hudi/archive/release-0.5.3.tar.gz 
the given path has multiple possibilities: #<Git::Ref:0x00007f06717c8980>, #<Git::Ref:0x00007f06717c5be0>
```
Checksum verified and unchanged. 