### PR TITLE
spherepack: fix url, checksum, add fflags

### DIFF
--- a/var/spack/repos/builtin/packages/spherepack/package.py
+++ b/var/spack/repos/builtin/packages/spherepack/package.py
@@ -10,14 +10,16 @@ from spack.package import *
 class Spherepack(Package):
     """SPHEREPACK - A Package for Modeling Geophysical Processes"""
 
-    homepage = "https://www2.cisl.ucar.edu/resources/legacy/spherepack"
-    url = "https://www2.cisl.ucar.edu/sites/default/files/spherepack3.2.tar"
+    homepage = "https://github.com/NCAR/NCAR-Classic-Libraries-for-Geophysics"
+    url = "https://github.com/NCAR/NCAR-Classic-Libraries-for-Geophysics/raw/refs/heads/main/SpherePack/spherepack3.2.tar.gz"
 
-    version("3.2", sha256="d58ef8cbc45cf2ad24f73a9f73f5f9d4fbe03cd9e2e7722e526fffb68be581ba")
+    version("3.2", sha256="7f5497e77101a4423cee887294f873048f6ff6bc8d0e908c8a89ece677ee19ea")
+
+    depends_on("fortran", type="build")
 
     def install(self, spec, prefix):
         if self.compiler.fc is None:
             raise InstallError("SPHEREPACK requires a Fortran 90 compiler")
-        make("MAKE=make", "F90=f90 -O2", "AR=ar", "libspherepack")
-        make("MAKE=make", "F90=f90 -O2", "AR=ar", "testspherepack")
+        make("MAKE=make", "F90=f90 -O2 -fallow-argument-mismatch", "AR=ar", "libspherepack")
+        make("MAKE=make", "F90=f90 -O2 -fallow-argument-mismatch", "AR=ar", "testspherepack")
         install_tree("lib", prefix.lib)


### PR DESCRIPTION
This PR fixes the url for `spherepack` which is now distributed via GitHub (but not the canonical way...). This also adjusts the checksum but since no previous version is available no attempt was made to compare one by one. The package requires an additional fflag on modern gcc.

Test build:
```
==> Installing spherepack-3.2-cqklcird7oocxpw63h5ky6ihchlci5k2 [3/3]
==> No binary for spherepack-3.2-cqklcird7oocxpw63h5ky6ihchlci5k2 found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/7f/7f5497e77101a4423cee887294f873048f6ff6bc8d0e908c8a89ece677ee19ea.tar.gz
==> No patches needed for spherepack
==> spherepack: Executing phase: 'install'
==> spherepack: Successfully installed spherepack-3.2-cqklcird7oocxpw63h5ky6ihchlci5k2
  Stage: 0.02s.  Install: 8.20s.  Post-install: 0.07s.  Total: 8.30s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/spherepack-3.2-cqklcird7oocxpw63h5ky6ihchlci5k2
```