### PR TITLE
tinker: add v8.7.2

### DIFF
--- a/var/spack/repos/builtin/packages/tinker/package.py
+++ b/var/spack/repos/builtin/packages/tinker/package.py
@@ -16,7 +16,13 @@ class Tinker(CMakePackage):
     homepage = "https://dasher.wustl.edu/tinker/"
     url = "https://dasher.wustl.edu/tinker/downloads/tinker-8.7.1.tar.gz"
 
-    version("8.7.1", sha256="0d6eff8bbc9be0b37d62b6fd3da35bb5499958eafe67aa9c014c4648c8b46d0f")
+    version("8.7.2", sha256="f9e94ae0684d527cd2772a4a7a05c41864ce6246f1194f6c1c402a94598151c2")
+    version(
+        "8.7.1",
+        sha256="0d6eff8bbc9be0b37d62b6fd3da35bb5499958eafe67aa9c014c4648c8b46d0f",
+        deprecated=True,
+    )
+
     patch("tinker-8.7.1-cmake.patch")
 
     depends_on("fftw")


### PR DESCRIPTION
This PR adds `tinker`, v8.7.2. This makes the package installable again from upstream sources since the 8.7.1 archive is not available anymore (one of those projects that removes archives when a newer bugfix release is available). I didn't add newer versions beyond the 8.7 series.

Test build:
```
==> Installing tinker-8.7.2-x2l6zop2tgexdlrae572bzhivjmm3ooo [29/29]
==> No binary for tinker-8.7.2-x2l6zop2tgexdlrae572bzhivjmm3ooo found: installing from source
==> Fetching https://dasher.wustl.edu/tinker/downloads/tinker-8.7.2.tar.gz
==> Applied patch /home/wdconinc/git/spack/var/spack/repos/builtin/packages/tinker/tinker-8.7.1-cmake.patch
==> tinker: Executing phase: 'cmake'
==> tinker: Executing phase: 'build'
==> tinker: Executing phase: 'install'
==> tinker: Successfully installed tinker-8.7.2-x2l6zop2tgexdlrae572bzhivjmm3ooo
  Stage: 8.67s.  Cmake: 0.36s.  Build: 1m 23.97s.  Install: 0.33s.  Post-install: 0.33s.  Total: 1m 33.84s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/tinker-8.7.2-x2l6zop2tgexdlrae572bzhivjmm3ooo
```