### PR TITLE
llvm: Add conflict related to Python `distutils` removal

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -277,6 +277,8 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
     conflicts("+z3", when="~clang")
     conflicts("+lua", when="@:10")
     conflicts("+lua", when="~lldb")
+    # Python distutils were removed with 3.12 and are required to build LLVM <= 14
+    conflicts("^python@3.12:", when="@:14")
 
     variant(
         "zstd",


### PR DESCRIPTION
Python 3.12 removed the `distutils` module, which is being used in the build process for LLVM <= 14.
I encountered build failures with Python 3.12 and LLVM 6 up to 14 related to the module being absent. Specifying `^python@3.11` explicitly fixed them.