### PR TITLE
Add a custom hook for dev_path changes

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -416,7 +416,7 @@ set, and Spack will ensure the package and its dependents are rebuilt
 any time the environment is installed if the package's local source
 code has been modified. Spack's native implementation to check for modifications
 is to check if ``mtime`` is newer than the installation.
-A custom check can be created by defining a ``detect_dev_src_change`` attribute 
+A custom check can be created by overriding the ``detect_dev_src_change`` method 
 in your package class. This is particularly useful for projects using custom spack repo's 
 to drive development and want to optimize performance. 
 

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -414,7 +414,13 @@ default, it will also clone the package to a subdirectory in the
 environment. This package will have a special variant ``dev_path``
 set, and Spack will ensure the package and its dependents are rebuilt
 any time the environment is installed if the package's local source
-code has been modified. Spack ensures that all instances of a
+code has been modified. Spack's native implementation to check for modifications
+is to check if ``mtime`` is newer than the installation.
+A custom check can be created by defining a ``detect_dev_src_change`` attribute 
+in your package class. This is particularly useful for projects using custom spack repo's 
+to drive development and want to optimize performance. 
+
+Spack ensures that all instances of a
 developed package in the environment are concretized to match the
 version (and other constraints) passed as the spec argument to the
 ``spack develop`` command.

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -559,7 +559,7 @@ def _is_dev_spec_and_has_changed(spec):
     # hook so packages can use to write their own method for checking the dev_path
     # use package so attributes about concretization such as variant state can be
     # utilized
-    if hasattr(spec.package, "detect_dev_src_change", None):
+    if hasattr(spec.package, "detect_dev_src_change"):
         return spec.package.detect_dev_src_change()
     else:
         _, record = spack.store.STORE.db.query_by_spec_hash(spec.dag_hash())

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -547,8 +547,7 @@ def _is_dev_spec_and_has_changed(spec):
     last installation"""
     # First check if this is a dev build and in the process already try to get
     # the dev_path
-    dev_path_var = spec.variants.get("dev_path", None)
-    if not dev_path_var:
+    if not spec.variants.get("dev_path", None):
         return False
 
     # Now we can check whether the code changed since the last installation

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -559,10 +559,8 @@ def _is_dev_spec_and_has_changed(spec):
     # hook so packages can use to write their own method for checking the dev_path
     # use package so attributes about concretization such as variant state can be
     # utilized
-    custom_check = getattr(spec.package, "detect_dev_src_change", None)
-
-    if custom_check:
-        return custom_check()
+    if hasattr(spec.package, "detect_dev_src_change", None):
+        return spec.package.detect_dev_src_change()
     else:
         _, record = spack.store.STORE.db.query_by_spec_hash(spec.dag_hash())
         mtime = fs.last_modification_time_recursive(dev_path_var.value)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -559,12 +559,7 @@ def _is_dev_spec_and_has_changed(spec):
     # hook so packages can use to write their own method for checking the dev_path
     # use package so attributes about concretization such as variant state can be
     # utilized
-    if hasattr(spec.package, "detect_dev_src_change"):
-        return spec.package.detect_dev_src_change()
-    else:
-        _, record = spack.store.STORE.db.query_by_spec_hash(spec.dag_hash())
-        mtime = fs.last_modification_time_recursive(dev_path_var.value)
-        return mtime > record.installation_time
+    return spec.package.detect_dev_src_change()
 
 
 def _error_on_nonempty_view_dir(new_root):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1107,7 +1107,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
         """
         dev_path_var = self.spec.variants.get("dev_path", None)
         _, record = spack.store.STORE.db.query_by_spec_hash(self.spec.dag_hash())
-        mtime = fs.last_modification_time_recursive(dev_path_var.value)
+        mtime = fsys.last_modification_time_recursive(dev_path_var.value)
         return mtime > record.installation_time
 
     def all_urls_for_version(self, version: StandardVersion) -> List[str]:

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1101,6 +1101,14 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
         """
         pass
 
+    def detect_dev_src_change(self):
+        """
+        Method for checking for source code changes to trigger rebuild/reinstall
+        """
+        _, record = spack.store.STORE.db.query_by_spec_hash(self.spec.dag_hash())
+        mtime = fs.last_modification_time_recursive(dev_path_var.value)
+        return mtime > record.installation_time
+
     def all_urls_for_version(self, version: StandardVersion) -> List[str]:
         """Return all URLs derived from version_urls(), url, urls, and
         list_url (if it contains a version) in a package in that order.

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1105,6 +1105,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
         """
         Method for checking for source code changes to trigger rebuild/reinstall
         """
+        dev_path_var = self.spec.variants.get("dev_path", None)
         _, record = spack.store.STORE.db.query_by_spec_hash(self.spec.dag_hash())
         mtime = fs.last_modification_time_recursive(dev_path_var.value)
         return mtime > record.installation_time


### PR DESCRIPTION
Using the recent addition of `git_sparse_paths` in #45473 shows yet another way that our current develop change detection breaks down. In this case if you try to develop with `spack develop --p` pointing to the full source then any change to the code triggers a rebuild of everything.

There have also been filesytem performance issues as noted in #41976 and #41013

This PR proposes to add a package hook to allow custom overriding of the standard filesystem behavior. I think I can also put in something that resolves the sparse-paths issue more directly, but since there are limited users of that feature (my team at SNL) I think a custom hook is sufficient until more users adopt that feature or a longer term trajectory for base implementation  of detecting changes is settled on.

The current form as implemented is probably the "safest" form for all package types so I think it makes sense to leave it as a default.

Pinging @scheibelp @tgamblin 
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
