### PR TITLE
hwloc: Disable levelzero explicitly if not requested

### DIFF
--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -198,5 +198,7 @@ class Hwloc(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         if self.spec.satisfies("+oneapi-level-zero"):
             args.append("--enable-levelzero")
+        else:
+            args.append("--disable-levelzero")
 
         return args

--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -26,7 +26,7 @@ class Hwloc(AutotoolsPackage, CudaPackage, ROCmPackage):
     """
 
     homepage = "https://www.open-mpi.org/projects/hwloc/"
-    url = "https://download.open-mpi.org/release/hwloc/v2.0/hwloc-2.0.2.tar.gz"
+    url = "https://download.open-mpi.org/release/hwloc/v2.11/hwloc-2.11.1.tar.bz2"
     git = "https://github.com/open-mpi/hwloc.git"
 
     maintainers("bgoglin")


### PR DESCRIPTION
The configure script will otherwise pick up external levelzero libraries and may potentially break depending libraries like pmix

<details>
<summary>Example spec</summary>

```
spack spec -U openmpi target=x86_64_v3                                                  
Input spec                                
--------------------------------
 -   openmpi arch=None-None-x86_64_v3

Concretized                   
--------------------------------                   
 -   openmpi@5.0.5%gcc@11.4.1~atomics~cuda~debug~gpfs~internal-hwloc~internal-libevent~internal-pmix~java~lustre~memchecker~openshmem~romio+rsh~static+vt+wrapper-rpath build_system=autotools fabrics=none romio-filesystem=none schedulers=none arch=linux-rocky9-x86_64_v3                   
[+]      ^autoconf@2.72%gcc@11.4.1 build_system=autotools arch=linux-rocky9-x86_64_v3                              
[+]          ^m4@1.4.19%gcc@11.4.1+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-rocky9-x86_64_v3                                                                                                                  
[+]              ^diffutils@3.10%gcc@11.4.1 build_system=autotools arch=linux-rocky9-x86_64_v3                     
[+]              ^libsigsegv@2.14%gcc@11.4.1 build_system=autotools arch=linux-rocky9-x86_64_v3
[+]      ^automake@1.16.5%gcc@11.4.1 build_system=autotools arch=linux-rocky9-x86_64_v3
[+]      ^gcc-runtime@11.4.1%gcc@11.4.1 build_system=generic arch=linux-rocky9-x86_64_v3                           
[e]      ^glibc@2.34%gcc@11.4.1 build_system=autotools arch=linux-rocky9-x86_64_v3
[+]      ^gmake@4.4.1%gcc@11.4.1~guile build_system=generic arch=linux-rocky9-x86_64_v3                            
[+]      ^hwloc@2.11.1%gcc@11.4.1~cairo~cuda~gl~libudev+libxml2~nvml~oneapi-level-zero~opencl+pci~rocm build_system=autotools libs=shared,static arch=linux-rocky9-x86_64_v3                                                           
[+]          ^libpciaccess@0.17%gcc@11.4.1 build_system=autotools arch=linux-rocky9-x86_64_v3                      
[+]              ^util-macros@1.20.1%gcc@11.4.1 build_system=autotools arch=linux-rocky9-x86_64_v3
[+]          ^libxml2@2.10.3%gcc@11.4.1+pic~python+shared build_system=autotools arch=linux-rocky9-x86_64_v3       
[+]              ^libiconv@1.17%gcc@11.4.1 build_system=autotools libs=shared,static arch=linux-rocky9-x86_64_v3
[+]              ^xz@5.4.6%gcc@11.4.1~pic build_system=autotools libs=shared,static arch=linux-rocky9-x86_64_v3
[+]          ^ncurses@6.5%gcc@11.4.1~symlinks+termlib abi=none build_system=autotools patches=7a351bc arch=linux-rocky9-x86_64_v3                                                                                                      
[+]      ^libevent@2.1.12%gcc@11.4.1+openssl build_system=autotools arch=linux-rocky9-x86_64_v3                                                                                                                                        
[+]          ^openssl@3.3.1%gcc@11.4.1~docs+shared build_system=generic certs=mozilla arch=linux-rocky9-x86_64_v3                                                                                                                      
[+]              ^ca-certificates-mozilla@2023-05-30%gcc@11.4.1 build_system=generic arch=linux-rocky9-x86_64_v3   
[+]      ^libtool@2.4.7%gcc@11.4.1 build_system=autotools arch=linux-rocky9-x86_64_v3                              
[+]          ^findutils@4.9.0%gcc@11.4.1 build_system=autotools patches=440b954 arch=linux-rocky9-x86_64_v3        
[+]      ^numactl@2.0.18%gcc@11.4.1 build_system=autotools arch=linux-rocky9-x86_64_v3                             
[+]      ^openssh@9.8p1%gcc@11.4.1+gssapi build_system=autotools arch=linux-rocky9-x86_64_v3                       
[+]          ^krb5@1.21.2%gcc@11.4.1+shared build_system=autotools arch=linux-rocky9-x86_64_v3                     
[+]              ^bison@3.8.2%gcc@11.4.1~color build_system=autotools arch=linux-rocky9-x86_64_v3                  
[+]              ^gettext@0.22.5%gcc@11.4.1+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-rocky9-x86_64_v3                                                                                 
[+]                  ^tar@1.34%gcc@11.4.1 build_system=autotools zip=pigz arch=linux-rocky9-x86_64_v3
[+]                      ^pigz@2.8%gcc@11.4.1 build_system=makefile arch=linux-rocky9-x86_64_v3                    
[+]                      ^zstd@1.5.6%gcc@11.4.1+programs build_system=makefile compression=none libs=shared,static arch=linux-rocky9-x86_64_v3                                                                                         
[+]          ^libedit@3.1-20240808%gcc@11.4.1 build_system=autotools arch=linux-rocky9-x86_64_v3
[+]          ^libxcrypt@4.4.35%gcc@11.4.1~obsolete_api build_system=autotools patches=4885da3 arch=linux-rocky9-x86_64_v3                                                                                                              
[+]      ^perl@5.40.0%gcc@11.4.1+cpanm+opcode+open+shared+threads build_system=generic arch=linux-rocky9-x86_64_v3
[+]          ^berkeley-db@18.1.40%gcc@11.4.1+cxx~docs+stl build_system=autotools patches=26090f4,b231fcc arch=linux-rocky9-x86_64_v3                                                                                                   
[+]          ^bzip2@1.0.8%gcc@11.4.1~debug~pic+shared build_system=generic arch=linux-rocky9-x86_64_v3
[+]          ^gdbm@1.23%gcc@11.4.1 build_system=autotools arch=linux-rocky9-x86_64_v3                              
[+]              ^readline@8.2%gcc@11.4.1 build_system=autotools patches=bbf97f1 arch=linux-rocky9-x86_64_v3       
[+]      ^pkgconf@2.2.0%gcc@11.4.1 build_system=autotools arch=linux-rocky9-x86_64_v3
 -       ^pmix@5.0.3%gcc@11.4.1~munge~python~restful build_system=autotools arch=linux-rocky9-x86_64_v3            
[+]      ^zlib-ng@2.2.1%gcc@11.4.1+compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-rocky9-x86_64_v3
```
</details>

<details>
<summary>Failing config.log</summary>

```
configure:4108: === HWLOC                                                                                                                                                                                                              
configure:32231: checking for hwloc pkg-config name                                                                
configure:32262: result: /scratch/root/spack/opt/spack/linux-rocky9-x86_64_v3/gcc-11.4.1/hwloc-2.11.1-jkhsz34zpoa7tlfj4os6sfqp2e737lfg/lib/pkgconfig/hwloc.pc                                                                          
configure:32270: checking if hwloc pkg-config module exists                                                        
configure:32300: check_package_pkgconfig_run_results=                                                                                                                                                                                  
configure:32303: $? = 0                                                                                                                                                                                                                
configure:32310: pkg-config output:                                                                                                                                                                                                    
configure:32308: result: yes                                                                                                                                                                                                           
configure:32316: checking for hwloc pkg-config cflags                                                                                                                                                                                  
configure:32346: check_package_pkgconfig_run_results=Package libze_loader was not found in the pkg-config search path.                                                                                                                 
Perhaps you should add the directory containing `libze_loader.pc'                                                  
to the PKG_CONFIG_PATH environment variable                                                                                                                                                                                            
Package 'libze_loader', required by 'hwloc', not found
configure:32349: $? = 1
configure:32356: pkg-config output: Package libze_loader was not found in the pkg-config search path.
Perhaps you should add the directory containing `libze_loader.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libze_loader', required by 'hwloc', not found
configure:32346: result: error
configure:32348: error: An error occurred retrieving hwloc cppflags from pkg-config
```
</details>