### PR TITLE
drill: fix url, add non-log4j-affected v1.20.3, v1.21.2

### DIFF
--- a/var/spack/repos/builtin/packages/drill/package.py
+++ b/var/spack/repos/builtin/packages/drill/package.py
@@ -23,11 +23,21 @@ class Drill(Package):
     version("1.20.3", sha256="1520cd2524cf8e0ce45fcf02e8e5e3e044465c6dacad853f9fadf9c918863cad")
     with default_args(deprecated=True):
         # Log4Shell vulnerability (CVE-2021-44228) affects all versions before 1.20.0
-        version("1.17.0", sha256="a3d2d544bcc32b915fb53fced0f982670bd6fe2abd764423e566a5f6b54debf1")
-        version("1.16.0", sha256="fd195d2b38f393459b37d8f13ac1f36cdbe38495eabb08252da38e3544e87839")
-        version("1.15.0", sha256="188c1d0df28e50f0265f4bc3c5871b4e7abc9450a4e5a7dbe7f0b23146bec76b")
-        version("1.14.0", sha256="1145bdbb723119f271d32daf4cdd77cdeebe88ddcb7d04facd585b715bb5723b")
-        version("1.13.0", sha256="8da6d56f75ae01e0bee6176095d32760e7183dd0200f10ee68b8cd3f882def6a")
+        version(
+            "1.17.0", sha256="a3d2d544bcc32b915fb53fced0f982670bd6fe2abd764423e566a5f6b54debf1"
+        )
+        version(
+            "1.16.0", sha256="fd195d2b38f393459b37d8f13ac1f36cdbe38495eabb08252da38e3544e87839"
+        )
+        version(
+            "1.15.0", sha256="188c1d0df28e50f0265f4bc3c5871b4e7abc9450a4e5a7dbe7f0b23146bec76b"
+        )
+        version(
+            "1.14.0", sha256="1145bdbb723119f271d32daf4cdd77cdeebe88ddcb7d04facd585b715bb5723b"
+        )
+        version(
+            "1.13.0", sha256="8da6d56f75ae01e0bee6176095d32760e7183dd0200f10ee68b8cd3f882def6a"
+        )
 
     # pom.xml, requireJavaVersion
     depends_on("java@7:", type="run")

--- a/var/spack/repos/builtin/packages/drill/package.py
+++ b/var/spack/repos/builtin/packages/drill/package.py
@@ -14,17 +14,24 @@ class Drill(Package):
     """
 
     homepage = "https://drill.apache.org/"
-    url = "https://www-eu.apache.org/dist/drill/drill-1.17.0/apache-drill-1.17.0.tar.gz"
+    url = "https://dist.apache.org/repos/dist/release/drill/1.17.0/apache-drill-1.17.0.tar.gz"
+    git = "https://github.com/apache/drill.git"
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked_by="wdconinc")
 
-    version("1.17.0", sha256="a3d2d544bcc32b915fb53fced0f982670bd6fe2abd764423e566a5f6b54debf1")
-    version("1.16.0", sha256="fd195d2b38f393459b37d8f13ac1f36cdbe38495eabb08252da38e3544e87839")
-    version("1.15.0", sha256="188c1d0df28e50f0265f4bc3c5871b4e7abc9450a4e5a7dbe7f0b23146bec76b")
-    version("1.14.0", sha256="1145bdbb723119f271d32daf4cdd77cdeebe88ddcb7d04facd585b715bb5723b")
-    version("1.13.0", sha256="8da6d56f75ae01e0bee6176095d32760e7183dd0200f10ee68b8cd3f882def6a")
+    version("1.21.2", sha256="77e2e7438f1b4605409828eaa86690f1e84b038465778a04585bd8fb21d68e3b")
+    version("1.20.3", sha256="1520cd2524cf8e0ce45fcf02e8e5e3e044465c6dacad853f9fadf9c918863cad")
+    with default_args(deprecated=True):
+        # Log4Shell vulnerability (CVE-2021-44228) affects all versions before 1.20.0
+        version("1.17.0", sha256="a3d2d544bcc32b915fb53fced0f982670bd6fe2abd764423e566a5f6b54debf1")
+        version("1.16.0", sha256="fd195d2b38f393459b37d8f13ac1f36cdbe38495eabb08252da38e3544e87839")
+        version("1.15.0", sha256="188c1d0df28e50f0265f4bc3c5871b4e7abc9450a4e5a7dbe7f0b23146bec76b")
+        version("1.14.0", sha256="1145bdbb723119f271d32daf4cdd77cdeebe88ddcb7d04facd585b715bb5723b")
+        version("1.13.0", sha256="8da6d56f75ae01e0bee6176095d32760e7183dd0200f10ee68b8cd3f882def6a")
 
+    # pom.xml, requireJavaVersion
     depends_on("java@7:", type="run")
+    depends_on("java@8:", type="run", when="@1.14:")
 
     def install(self, spec, prefix):
         install_tree(".", prefix)


### PR DESCRIPTION
This PR adds Apache's `drill` with two non-log4j (LogShell) vulnerable versions, and fixes the url to a working url. The new url (rightfully) does not distribute the vulnerable versions (see https://dist.apache.org/repos/dist/release/drill/), so the vulnerable versions are marked as deprecated but kept with the same checksum since then they can still be found on the source mirror. Checked license. Updated required java version.

Old url is broken even for newest version:
```
$ curl -L https://www-eu.apache.org/dist/drill/drill-1.21.2/apache-drill-1.21.2.tar.gz
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL was not found on this server.</p>
</body></html>
```

Test builds:
```
==> Installing drill-1.21.2-khlojg4oh2nan5dg3dvi65obo4uuk6mi [4/4]
==> No binary for drill-1.21.2-khlojg4oh2nan5dg3dvi65obo4uuk6mi found: installing from source
==> Fetching https://dist.apache.org/repos/dist/release/drill/1.21.2/apache-drill-1.21.2.tar.gz
==> No patches needed for drill
==> drill: Executing phase: 'install'
==> drill: Successfully installed drill-1.21.2-khlojg4oh2nan5dg3dvi65obo4uuk6mi
  Stage: 1m 32.39s.  Install: 0.41s.  Post-install: 0.73s.  Total: 1m 33.57s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/drill-1.21.2-khlojg4oh2nan5dg3dvi65obo4uuk6mi
```