### PR TITLE
apr: add v1.7.5, deprecate older due to CVE

### DIFF
--- a/var/spack/repos/builtin/packages/apr/package.py
+++ b/var/spack/repos/builtin/packages/apr/package.py
@@ -12,16 +12,20 @@ class Apr(AutotoolsPackage):
     homepage = "https://apr.apache.org/"
     url = "https://archive.apache.org/dist/apr/apr-1.7.0.tar.gz"
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked_by="wdconinc")
 
-    version("1.7.4", sha256="a4137dd82a185076fa50ba54232d920a17c6469c30b0876569e1c2a05ff311d9")
-    version("1.7.3", sha256="af9bfd5b8a04425d6b419673f3e0a7656fade226aae78180d93f8a6f2d3d1c09")
-    version("1.7.2", sha256="3d8999b216f7b6235343a4e3d456ce9379aa9a380ffb308512f133f0c5eb2db9")
-    version("1.7.0", sha256="48e9dbf45ae3fdc7b491259ffb6ccf7d63049ffacbc1c0977cced095e4c2d5a2")
-    version("1.6.2", sha256="4fc24506c968c5faf57614f5d0aebe0e9d0b90afa47a883e1a1ca94f15f4a42e")
-    version("1.5.2", sha256="1af06e1720a58851d90694a984af18355b65bb0d047be03ec7d659c746d6dbdb")
+    version("1.7.5", sha256="3375fa365d67bcf945e52b52cba07abea57ef530f40b281ffbe977a9251361db")
 
-    depends_on("c", type="build")  # generated
+    # https://nvd.nist.gov/vuln/detail/CVE-2023-49582
+    with default_args(deprecated=True):
+        version("1.7.4", sha256="a4137dd82a185076fa50ba54232d920a17c6469c30b0876569e1c2a05ff311d9")
+        version("1.7.3", sha256="af9bfd5b8a04425d6b419673f3e0a7656fade226aae78180d93f8a6f2d3d1c09")
+        version("1.7.2", sha256="3d8999b216f7b6235343a4e3d456ce9379aa9a380ffb308512f133f0c5eb2db9")
+        version("1.7.0", sha256="48e9dbf45ae3fdc7b491259ffb6ccf7d63049ffacbc1c0977cced095e4c2d5a2")
+        version("1.6.2", sha256="4fc24506c968c5faf57614f5d0aebe0e9d0b90afa47a883e1a1ca94f15f4a42e")
+        version("1.5.2", sha256="1af06e1720a58851d90694a984af18355b65bb0d047be03ec7d659c746d6dbdb")
+
+    depends_on("c", type="build")
 
     patch("missing_includes.patch", when="@1.7.0")
 


### PR DESCRIPTION
This PR adds Apache's `apr`, v1.7.5, which fixes a CVE https://nvd.nist.gov/vuln/detail/CVE-2023-49582. Checked license.

Test build:
```
==> Installing apr-1.7.5-otl5mngtrq5zpgiibtfan2dpxmooefyd [17/29]
==> No binary for apr-1.7.5-otl5mngtrq5zpgiibtfan2dpxmooefyd found: installing from source
==> Fetching https://archive.apache.org/dist/apr/apr-1.7.5.tar.gz
==> No patches needed for apr
==> apr: Executing phase: 'autoreconf'
==> apr: Executing phase: 'configure'
==> apr: Executing phase: 'build'
==> apr: Executing phase: 'install'
==> apr: Successfully installed apr-1.7.5-otl5mngtrq5zpgiibtfan2dpxmooefyd
  Stage: 1.79s.  Autoreconf: 0.00s.  Configure: 17.08s.  Build: 9.16s.  Install: 0.20s.  Post-install: 0.03s.  Total: 28.29s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/apr-1.7.5-otl5mngtrq5zpgiibtfan2dpxmooefyd
```