### PR TITLE
httpd: add v2.4.62, deprecate versions due to CVE, remove old deprecated versions

### DIFF
--- a/var/spack/repos/builtin/packages/httpd/package.py
+++ b/var/spack/repos/builtin/packages/httpd/package.py
@@ -13,35 +13,23 @@ class Httpd(AutotoolsPackage):
     homepage = "https://httpd.apache.org/"
     url = "https://archive.apache.org/dist/httpd/httpd-2.4.43.tar.bz2"
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked_by="wdconinc")
 
-    version("2.4.59", sha256="ec51501ec480284ff52f637258135d333230a7d229c3afa6f6c2f9040e321323")
-    version("2.4.55", sha256="11d6ba19e36c0b93ca62e47e6ffc2d2f2884942694bce0f23f39c71bdc5f69ac")
+    version("2.4.62", sha256="674188e7bf44ced82da8db522da946849e22080d73d16c93f7f4df89e25729ec")
 
-    # https://nvd.nist.gov/vuln/detail/CVE-2022-31813
+    # https://nvd.nist.gov/vuln/detail/CVE-2024-38477
     version(
-        "2.4.43",
-        sha256="a497652ab3fc81318cdc2a203090a999150d86461acff97c1065dc910fe10f43",
+        "2.4.59", 
+        sha256="ec51501ec480284ff52f637258135d333230a7d229c3afa6f6c2f9040e321323",
         deprecated=True,
     )
     version(
-        "2.4.41",
-        sha256="133d48298fe5315ae9366a0ec66282fa4040efa5d566174481077ade7d18ea40",
-        deprecated=True,
-    )
-    version(
-        "2.4.39",
-        sha256="b4ca9d05773aa59b54d66cd8f4744b945289f084d3be17d7981d1783a5decfa2",
-        deprecated=True,
-    )
-    version(
-        "2.4.38",
-        sha256="7dc65857a994c98370dc4334b260101a7a04be60e6e74a5c57a6dee1bc8f394a",
+        "2.4.55", 
+        sha256="11d6ba19e36c0b93ca62e47e6ffc2d2f2884942694bce0f23f39c71bdc5f69ac",
         deprecated=True,
     )
 
-    depends_on("c", type="build")  # generated
-
+    depends_on("c", type="build")
     depends_on("m4", type="build")
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")

--- a/var/spack/repos/builtin/packages/httpd/package.py
+++ b/var/spack/repos/builtin/packages/httpd/package.py
@@ -19,12 +19,12 @@ class Httpd(AutotoolsPackage):
 
     # https://nvd.nist.gov/vuln/detail/CVE-2024-38477
     version(
-        "2.4.59", 
+        "2.4.59",
         sha256="ec51501ec480284ff52f637258135d333230a7d229c3afa6f6c2f9040e321323",
         deprecated=True,
     )
     version(
-        "2.4.55", 
+        "2.4.55",
         sha256="11d6ba19e36c0b93ca62e47e6ffc2d2f2884942694bce0f23f39c71bdc5f69ac",
         deprecated=True,
     )


### PR DESCRIPTION
This PR adds the lastest Apache `httpd`, v2.4.62, with previous versions deprecated due to CVEs. This also removes the old versions that have been deprecated since 0.20.0. Checked license.

Test build:
```
==> Installing httpd-2.4.62-u6ag5zhcl65fhckr5clkh4psg74fj2qm [28/28]
==> No binary for httpd-2.4.62-u6ag5zhcl65fhckr5clkh4psg74fj2qm found: installing from source
==> Fetching https://archive.apache.org/dist/httpd/httpd-2.4.62.tar.bz2
==> No patches needed for httpd
==> httpd: Executing phase: 'autoreconf'
==> httpd: Executing phase: 'configure'
==> httpd: Executing phase: 'build'
==> httpd: Executing phase: 'install'
==> httpd: Successfully installed httpd-2.4.62-u6ag5zhcl65fhckr5clkh4psg74fj2qm
  Stage: 3.38s.  Autoreconf: 0.00s.  Configure: 6.54s.  Build: 37.20s.  Install: 12.34s.  Post-install: 0.65s.  Total: 1m 0.31s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/httpd-2.4.62-u6ag5zhcl65fhckr5clkh4psg74fj2qm
```