### PR TITLE
ocaml: add v5.0.0 -> v5.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/ocaml/package.py
+++ b/var/spack/repos/builtin/packages/ocaml/package.py
@@ -14,6 +14,10 @@ class Ocaml(Package):
     url = "https://caml.inria.fr/pub/distrib/ocaml-4.06/ocaml-4.06.0.tar.gz"
 
     maintainers("scemama")
+    version("5.2.0", sha256="3a7b5fb6d81bb42bbda84aadf5d84ff8bcbb149988087e7863bf5c2f4b27b187")
+    version("5.1.1", sha256="33b8c1df88700ba1f5123aa4bdbc7a125482feafc77e5081ef1725fddf290be1")
+    version("5.1.0", sha256="5e91492d87b193728a0729122b679039c73e75820dcf2724a31b262390d210c2")
+    version("5.0.0", sha256="969e1f7939736d39f2af533cd12cc64b05f060dbed087d7b760ee2503bfe56de")
     version("4.13.1", sha256="66a5353c5e7b33a8981446e857657aad45a3b82080ea5c67d4baa434eacfcf5f")
     version("4.12.0", sha256="9825e5903b852a7a5edb71a1ed68f5d5d55d6417e2dda514dda602bc6efeed7b")
     version("4.11.0", sha256="b5bd04bf794a676389b167633f01f8275acdd853149b137f7575f2c2ddef1377")


### PR DESCRIPTION
Tested on an x86 machine with gcc 14.2.0.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
