### PR TITLE
opam: Add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/opam/package.py
+++ b/var/spack/repos/builtin/packages/opam/package.py
@@ -18,6 +18,11 @@ class Opam(AutotoolsPackage):
 
     maintainers("scemama")
 
+    version("2.2.1", sha256="07ad3887f61e0bc61a0923faae16fcc141285ece5b248a9e2cd4f902523cc121")
+    version("2.2.0", sha256="39334f36adbe280683487cf204b7b0642080fc5965747f7d6f7cc7b83cd7a192")
+    version("2.1.6", sha256="d2af5edc85f552e0cf5ec0ddcc949d94f2dc550dc5df595174a06a4eaf8af628")
+    version("2.1.5", sha256="09f8d9e410b2f5723c2bfedbf7970e3b305f5017895fcd91759f05e753ddcea5")
+    version("2.1.4", sha256="1643609f4eea758eb899dc8df57b88438e525d91592056f135e6e045d0d916cb")
     version("2.1.3", sha256="cb2ab00661566178318939918085aa4b5c35c727df83751fd92d114fdd2fa001")
     version("2.0.6", sha256="7c4bff5e5f3628ad00c53ee1b044ced8128ffdcfbb7582f8773fb433e12e07f4")
     version("2.0.5", sha256="776c7e64d6e24c2ef1efd1e6a71d36e007645efae94eaf860c05c1929effc76f")
@@ -36,9 +41,17 @@ class Opam(AutotoolsPackage):
     depends_on("ocaml@:4.09.0", type="build", when="@:1.2.2")
     depends_on("ocaml", type="build", when="@2.0.0:")
 
-    parallel = False
+    # TODO: Is this really the correct constraint? I can't find any issues with
+    # building newer opams in parallel, and the constraint was added in the
+    # package's first commit with no message.
+    with when("@:2.0.0"):
+        parallel = False
 
     sanity_check_is_file = ["bin/opam"]
+
+    @property
+    def build_directory(self):
+        return self.stage.source_path
 
     @when("@:1.2.2")
     def setup_build_environment(self, env):
@@ -52,8 +65,26 @@ class Opam(AutotoolsPackage):
         # https://github.com/Homebrew/homebrew-core/blob/master/Formula/opam.rb
         env.set("OCAMLPARAM", "safe-string=0,_")  # OCaml 4.06.0 compat
 
+    def configure(self, spec, prefix):
+        args = ["--prefix={0}".format(prefix)]
+
+        with when("@:2.2"):
+            # NOTE: The config script really wants the vendored third party
+            # libraries to live in the <source prefix>/src_ext directory, not
+            # in the build directory when this flag is enabled. This is why the
+            # build directory must be set to the source path above.
+            args.append("--with-vendored-deps")
+
+        return configure(*args)
+
     def build(self, spec, prefix):
-        make("lib-ext")
+        if spec.satisfies("@:2.0.0"):
+            make("lib-ext")
+
         make()
+
         if spec.satisfies("@:1.2.2"):
             make("man")
+
+    def install(self, spec, prefix):
+        make("install")

--- a/var/spack/repos/builtin/packages/opam/package.py
+++ b/var/spack/repos/builtin/packages/opam/package.py
@@ -41,11 +41,11 @@ class Opam(AutotoolsPackage):
     depends_on("ocaml@:4.09.0", type="build", when="@:1.2.2")
     depends_on("ocaml", type="build", when="@2.0.0:")
 
-    # TODO: Is this really the correct constraint? I can't find any issues with
-    # building newer opams in parallel, and the constraint was added in the
-    # package's first commit with no message.
-    with when("@:2.0.0"):
-        parallel = False
+    # While this package is a makefile package, 'make' is really only used to
+    # call the locally built copy of dune, which is itself parallel, so there's
+    # no sense in calling make with >1 job.
+    # See: ocaml/opam#3585 spack/spack#46535
+    parallel = False
 
     sanity_check_is_file = ["bin/opam"]
 

--- a/var/spack/repos/builtin/packages/opam/package.py
+++ b/var/spack/repos/builtin/packages/opam/package.py
@@ -78,7 +78,8 @@ class Opam(AutotoolsPackage):
         return configure(*args)
 
     def build(self, spec, prefix):
-        if spec.satisfies("@:2.0.0"):
+        # https://github.com/dbuenzli/cmdliner/issues/34#issuecomment-145236209
+        if spec.satisfies("@:2.1"):
             make("lib-ext")
 
         make()


### PR DESCRIPTION
Also: set the build and install directories to the source directory because the build system unfortunately expects the `src_ext` directory to be under the current working directory when building the bundled third-party libraries, even when the configure script is run from another directory.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
