### PR TITLE
hipcc: fix rocm_agent_enumerator path

### DIFF
--- a/var/spack/repos/builtin/packages/hipcc/0001-fix-rocm-agent-enumerator-path.patch
+++ b/var/spack/repos/builtin/packages/hipcc/0001-fix-rocm-agent-enumerator-path.patch
@@ -1,0 +1,25 @@
+From 9478adea1d98175c1b2d75a73bd1616e2f0ce845 Mon Sep 17 00:00:00 2001
+From: Afzal Patel <Afzal.Patel@amd.com>
+Date: Mon, 23 Sep 2024 11:25:43 +0000
+Subject: [PATCH] fix rocm-agent-numerator path
+
+---
+ amd/hipcc/src/hipBin_amd.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/amd/hipcc/src/hipBin_amd.h b/amd/hipcc/src/hipBin_amd.h
+index 57d009804..d53d08123 100644
+--- a/amd/hipcc/src/hipBin_amd.h
++++ b/amd/hipcc/src/hipBin_amd.h
+@@ -752,7 +752,7 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
+     } else if (os != windows) {
+       // Else try using rocm_agent_enumerator
+       string ROCM_AGENT_ENUM;
+-      ROCM_AGENT_ENUM = roccmPath + "/bin/rocm_agent_enumerator";
++      ROCM_AGENT_ENUM = string(getenv("ROCMINFO_PATH")) + "/bin/rocm_agent_enumerator";
+       targetsStr = ROCM_AGENT_ENUM +" -t GPU";
+       SystemCmdOut sysOut = hipBinUtilPtr_->exec(targetsStr.c_str());
+       regex toReplace("\n+");
+--
+2.27.0
+

--- a/var/spack/repos/builtin/packages/hipcc/package.py
+++ b/var/spack/repos/builtin/packages/hipcc/package.py
@@ -41,6 +41,9 @@ class Hipcc(CMakePackage):
 
     patch("0014-remove-compiler-rt-linkage-for-host.6.0.patch", when="@6.0")
     patch("0014-remove-compiler-rt-linkage-for-host.6.1.patch", when="@6.1:")
+    # hipcc is assuming rocm-agent-numerator is in ROCM_PATH.
+    # This patch fixes the path by using ROCMINFO_PATH
+    patch("0001-fix-rocm-agent-enumerator-path.patch", when="@6.2:")
 
     @property
     def root_cmakelists_dir(self):


### PR DESCRIPTION
hipcc is displaying this message anytime it is used:
`/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/hip-6.2.0-wkmbgxgoierxxbjdy2vrhcn6xqa2574g/bin/rocm_agent_enumerator: No such file or directory`

This pr adds a patch will set the correct path of rocm_agent_enumerator using ROCMINFO_PATH.