### PR TITLE
iproute2: add v5.15.0 -> v6.11.0

### DIFF
--- a/var/spack/repos/builtin/packages/iproute2/package.py
+++ b/var/spack/repos/builtin/packages/iproute2/package.py
@@ -9,8 +9,8 @@ from spack.package import *
 class Iproute2(AutotoolsPackage):
     """This is a set of utilities for Linux networking."""
 
-    homepage = "https://github.com/shemminger/iproute2"
-    url = "https://github.com/shemminger/iproute2/archive/v5.9.0.tar.gz"
+    homepage = "https://wiki.linuxfoundation.org/networking/iproute2"
+    url = "https://github.com/iproute2/iproute2/archive/v5.9.0.tar.gz"
 
     depends_on("bison", type="build")
     depends_on("flex", type="build")
@@ -18,6 +18,13 @@ class Iproute2(AutotoolsPackage):
 
     license("GPL-2.0-or-later")
 
+    version("6.11.0", sha256="e5ad1c86aa788a979ba1b68cd6ee948b37983d99efabf6a0bf556b061569cc4d")
+    version("6.10.0", sha256="060ee42dfcdf8b9daf9f986eee26d16ac5bdf39c8784702957b13bebec538541")
+    version("6.2.0", sha256="813d41443d4ee0b189531e0d63f955ce94367ef80b184bcd27a30be86ae715e0")
+    version("6.1.0", sha256="63b6057041be86fee8af3468d86fdc1eb2afe1d56500f298413baf89575eff1e")
+    version("6.0.0", sha256="0a92b8d04710ab4e649ec25eb919768ba44d3047f26e80621368689d0f3c5a59")
+    version("5.17.0", sha256="ab5ed83d901d42a8dd5ec539ab8de35c65f921f002331fc7adfd359def33158d")
+    version("5.15.0", sha256="e10161fabe68714b34d565b6efff41b987ffec077f79beec497688c155881ea6")
     version("5.11.0", sha256="16b79e6ce65d4d5fd425cef2fd92a58c403a93faeeed0e0a3202b36a8e857d1f")
     version("5.10.0", sha256="164f1de457eefbdadb98d82c309a0977542b34e7a2dfe81e497a0b93675cb3d2")
     version("5.9.0", sha256="1afde56d416f136b1236ac2f8276e4edbe114ca3c2ab12f11af11b84cf0992e4")


### PR DESCRIPTION
Test builds of 6.11 and 5.17 worked correctly.

For a quick functionality test, ran

    devlink dev paramt set … name enable_roce value false cmode driverinit 
    devlink dev reload …
    devlink dev paramt set … name enable_roce value true cmode driverinit 
    devlink dev reload …

and the Nvidia/Mellanox ConnectX-6 toggled RoCE functionality properly for both 5.17 and 6.11.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
