### PR TITLE
[WIP] py-cffi package family: Support Python 3.12

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/packages.yaml
@@ -1,0 +1,4 @@
+spack:
+  packages:
+    python:
+      require: '@3.12:'

--- a/share/spack/gitlab/cloud_pipelines/configs/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/packages.yaml
@@ -1,4 +1,3 @@
-spack:
-  packages:
-    python:
-      require: '@3.12:'
+packages:
+  python:
+    require: '@3.12:'

--- a/share/spack/gitlab/cloud_pipelines/configs/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/packages.yaml
@@ -1,3 +1,0 @@
-packages:
-  python:
-    require: '@3.12:'

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -94,6 +94,7 @@ class FluxCore(AutotoolsPackage):
     # Use of distutils in configure script dropped in v0.55
     depends_on("python@:3.11", when="@:0.54", type=("build", "link", "run"))
     depends_on("py-cffi@1.1:", type=("build", "run"))
+    depends_on("py-cffi@1.16:", type=("build", "run"), when="^python@3.12:")
     depends_on("py-pyyaml@3.10:", type=("build", "run"))
     depends_on("py-jsonschema@2.3:", type=("build", "run"), when="@:0.58.0")
     depends_on("py-ply", type=("build", "run"), when="@0.46.1:")
@@ -117,6 +118,8 @@ class FluxCore(AutotoolsPackage):
     depends_on("automake", type="build", when="@master")
     depends_on("libtool", type="build", when="@master")
 
+    depends_on("py-setuptools", type="build", when="^python@3.12:")
+
     # Testing Dependencies
     depends_on("mpich pmi=pmi", type="test")
     depends_on("valgrind", type="test")
@@ -127,9 +130,7 @@ class FluxCore(AutotoolsPackage):
 
     def patch(self):
         with when("^python@3.12:"):
-            filter_file(
-                "import sys", r"import sys\n import setuptools", "config/am_check_pymod.m4"
-            )
+            filter_file("^import sys", "import sys;import setuptools", "configure")
 
     def url_for_version(self, version):
         """

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -125,12 +125,13 @@ class FluxCore(AutotoolsPackage):
     # Patch 0.27-0.30 for build errors when czmq built with "draft APIs":
     patch("0001-build-fix-build-errors-with-side-installed-0MQ.patch", when="@0.27.0:0.30.0")
 
-    filter_file(
-        "import sys",
-        r"import sys\n import setuptools",
-        "config/am_check_pymod.m4",
-        when="^python@3.12"
-    )
+    def patch(self):
+        with when("^python@3.12"):
+            filter_file(
+                "import sys",
+                r"import sys\n import setuptools",
+                "config/am_check_pymod.m4",
+            )
 
     def url_for_version(self, version):
         """

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -125,6 +125,13 @@ class FluxCore(AutotoolsPackage):
     # Patch 0.27-0.30 for build errors when czmq built with "draft APIs":
     patch("0001-build-fix-build-errors-with-side-installed-0MQ.patch", when="@0.27.0:0.30.0")
 
+    filter_file(
+        "import sys",
+        r"import sys\n import setuptools",
+        "config/am_check_pymod.m4",
+        when="^python@3.12"
+    )
+
     def url_for_version(self, version):
         """
         Flux uses a fork of ZeroMQ's Collective Code Construction Contract

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -126,11 +126,8 @@ class FluxCore(AutotoolsPackage):
     patch("0001-build-fix-build-errors-with-side-installed-0MQ.patch", when="@0.27.0:0.30.0")
 
     def patch(self):
-        with when("^python@3.12"):
-            filter_file(
-                "import sys",
-                r"import sys\n import setuptools",
-                "config/am_check_pymod.m4",
+        with when("^python@3.12:"):
+            filter_file("import sys", r"import sys\n import setuptools", "config/am_check_pymod.m4"
             )
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -127,7 +127,8 @@ class FluxCore(AutotoolsPackage):
 
     def patch(self):
         with when("^python@3.12:"):
-            filter_file("import sys", r"import sys\n import setuptools", "config/am_check_pymod.m4"
+            filter_file(
+                "import sys", r"import sys\n import setuptools", "config/am_check_pymod.m4"
             )
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/py-cffi/package.py
+++ b/var/spack/repos/builtin/packages/py-cffi/package.py
@@ -33,15 +33,8 @@ class PyCffi(PythonPackage):
     # ./spack-src/cffi/ffiplatform.py has _hack_at_distutils which imports
     # setuptools before distutils, but only on Windows. This could be made
     # unconditional to support Python 3.12
-    depends_on("python@:3.11", type=("build", "run"))
-
-    # python 3.12 support was released in @1.16:, however the removal
-    # in python3.12 of distutils has resulted in an imperfect fix for prefix-based
-    # tools like spack, see:
-    # https://github.com/spack/spack/pull/46224
-    # https://github.com/cython/cython/pull/5754#issuecomment-1752102480
-    # until this is correctly fixed, do not enable 3.12 support
-    # depends_on("python@:3.12", type=("build", "run"), when="@1.16:")
+    depends_on("python@:3.11", type=("build", "run"), when="@:1.15")
+    depends_on("python@:3.12", type=("build", "run"), when="@1.16:")
 
     depends_on("pkgconfig", type="build")
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -57,7 +57,7 @@ class PyCython(PythonPackage):
     depends_on("cxx", type="build")  # generated
 
     # https://github.com/cython/cython/issues/5751 (distutils not yet dropped)
-    depends_on("python@:3.11", type=("build", "link", "run"))
+    depends_on("python@:3.12", type=("build", "link", "run"))
 
     # https://github.com/cython/cython/commit/1cd24026e9cf6d63d539b359f8ba5155fd48ae21
     # collections.Iterable was removed in Python 3.10

--- a/var/spack/repos/builtin/packages/py-expandvars/package.py
+++ b/var/spack/repos/builtin/packages/py-expandvars/package.py
@@ -3,25 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install py-expandvars
-#
-# You can edit this file again by typing:
-#
-#     spack edit py-expandvars
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack.package import *
-
 
 class PyExpandvars(PythonPackage):
     """Expand system variables Unix style"""
@@ -35,6 +17,5 @@ class PyExpandvars(PythonPackage):
 
     version("0.12.0", sha256="7d1adfa55728cf4b5d812ece3d087703faea953e0c0a1a78415de9df5024d844")
 
-    # FIXME: Add dependencies if required.
     depends_on("py-hatchling")
 

--- a/var/spack/repos/builtin/packages/py-expandvars/package.py
+++ b/var/spack/repos/builtin/packages/py-expandvars/package.py
@@ -5,6 +5,7 @@
 
 from spack.package import *
 
+
 class PyExpandvars(PythonPackage):
     """Expand system variables Unix style"""
 
@@ -18,4 +19,3 @@ class PyExpandvars(PythonPackage):
     version("0.12.0", sha256="7d1adfa55728cf4b5d812ece3d087703faea953e0c0a1a78415de9df5024d844")
 
     depends_on("py-hatchling")
-

--- a/var/spack/repos/builtin/packages/py-expandvars/package.py
+++ b/var/spack/repos/builtin/packages/py-expandvars/package.py
@@ -1,0 +1,40 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install py-expandvars
+#
+# You can edit this file again by typing:
+#
+#     spack edit py-expandvars
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack.package import *
+
+
+class PyExpandvars(PythonPackage):
+    """Expand system variables Unix style"""
+
+    homepage = "https://github.com/sayanarijit/expandvars"
+    pypi = "expandvars/expandvars-0.12.0.tar.gz"
+
+    maintainers("Chrismarsh")
+
+    license("MIT", checked_by="Chrismarsh")
+
+    version("0.12.0", sha256="7d1adfa55728cf4b5d812ece3d087703faea953e0c0a1a78415de9df5024d844")
+
+    # FIXME: Add dependencies if required.
+    depends_on("py-hatchling")
+

--- a/var/spack/repos/builtin/packages/py-frozenlist/package.py
+++ b/var/spack/repos/builtin/packages/py-frozenlist/package.py
@@ -28,7 +28,7 @@ class PyFrozenlist(PythonPackage):
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("python@3.7:", when="@1.3.1:", type=("build", "run"))
-    depends_on("py-cython@3.0.4:", when="^python@3.12:")
+    depends_on("py-cython@3.0.4:", when="@1.4.1:")
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@46.4.0:", when="@1.3.1:", type="build")
     depends_on("py-setuptools@47:", when="@1.4.1:", type="build")

--- a/var/spack/repos/builtin/packages/py-frozenlist/package.py
+++ b/var/spack/repos/builtin/packages/py-frozenlist/package.py
@@ -24,10 +24,7 @@ class PyFrozenlist(PythonPackage):
 
     # 1.4.0 is the first version to support python 3.12
     # https://github.com/aio-libs/frozenlist/issues/433#issuecomment-1633197557
-    conflicts(
-        "^python@3.12:",
-        when="@:1.4.0",
-    )
+    conflicts("^python@3.12:", when="@:1.4.0")
 
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("python@3.7:", when="@1.3.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-frozenlist/package.py
+++ b/var/spack/repos/builtin/packages/py-frozenlist/package.py
@@ -15,14 +15,25 @@ class PyFrozenlist(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.4.1", sha256="c037a86e8513059a2613aaba4d817bb90b9d9b6b69aace3ce9c877e8c8ed402b")
     version("1.3.1", sha256="3a735e4211a04ccfa3f4833547acdf5d2f863bfeb01cfd3edaffbc251f15cec8")
     version("1.3.0", sha256="ce6f2ba0edb7b0c1d8976565298ad2deba6f8064d2bebb6ffce2ca896eb35b0b")
     version("1.2.0", sha256="68201be60ac56aff972dc18085800b6ee07973c49103a8aba669dee3d71079de")
 
     depends_on("c", type="build")  # generated
 
+    # 1.4.0 is the first version to support python 3.12
+    # https://github.com/aio-libs/frozenlist/issues/433#issuecomment-1633197557
+    conflicts(
+        "^python@3.12:",
+        when="@:1.4.0",
+    )
+
     depends_on("python@3.6:", type=("build", "run"))
     depends_on("python@3.7:", when="@1.3.1:", type=("build", "run"))
+    depends_on("py-cython@3.0.4:", when="^python@3.12:")
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@46.4.0:", when="@1.3.1:", type="build")
+    depends_on("py-setuptools@47:", when="@1.4.1:", type="build")
     depends_on("py-wheel@0.37.0:", when="@1.3.1:", type="build")
+    depends_on("py-expandvars", when="@1.4.1:", type="build")

--- a/var/spack/repos/builtin/packages/py-multidict/package.py
+++ b/var/spack/repos/builtin/packages/py-multidict/package.py
@@ -15,6 +15,7 @@ class PyMultidict(PythonPackage):
 
     license("Apache-2.0")
 
+    version("6.1.0", sha256="22ae2ebf9b0c69d206c003e2f6a914ea33f0a932d4aa16f236afc049d9958f4a")
     version("6.0.4", sha256="3666906492efb76453c0e7b97f2cf459b0682e7402c0489a95484965dbc1da49")
     version("6.0.2", sha256="5ff3bd75f38e4c43f1f470f2df7a4d430b821c4ce22be384e1459cb57d6bb013")
     version("5.2.0", sha256="0dd1c93edb444b33ba2274b66f63def8a327d607c6c790772f448a53b6ea59ce")
@@ -24,6 +25,10 @@ class PyMultidict(PythonPackage):
     depends_on("c", type="build")  # generated
 
     depends_on("py-setuptools@40:", type="build")
+
+    depends_on("python@:3.11", when="@:6.0.4")
+    # python :3.7 dropped in 6.1.0
+    depends_on("python@3.8:3.13", when="@6.1.0:")
 
     # Historical dependencies
     depends_on("py-pip@18:", when="@:4", type="build")

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -99,6 +99,7 @@ class PyNumpy(PythonPackage):
 
         # Build dependencies (do not include upper bound unless known issues)
         depends_on("py-cython@3.0.6:", when="@2:")
+        depends_on("py-cython@3.0.4:", when="^python@3.12:")
         depends_on("py-cython@0.29.34:", when="@1.26:")
         depends_on("py-cython@0.29.34:2", when="@1.25")
         depends_on("py-cython@0.29.30:2", when="@1.22.4:1.24")

--- a/var/spack/repos/builtin/packages/py-opt-einsum/package.py
+++ b/var/spack/repos/builtin/packages/py-opt-einsum/package.py
@@ -22,3 +22,12 @@ class PyOptEinsum(PythonPackage):
     depends_on("python@3.5:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy@1.7:", type=("build", "run"))
+
+    # until a new 3.4.0 release https://github.com/dgasmith/opt_einsum/issues/221
+    # requires this patch for python 3.12
+    # https://github.com/dgasmith/opt_einsum/pull/208
+    patch(
+        "https://github.com/dgasmith/opt_einsum/commit/0beacf96923bbb2dd1939a9c59398a38ce7a11b1.patch",
+        sha256="8e27da491ab363d7413671b16c48d06481a50c014fe0fcf28f7ef01c8368400c",
+        when="^python@3.12:"
+    )

--- a/var/spack/repos/builtin/packages/py-opt-einsum/package.py
+++ b/var/spack/repos/builtin/packages/py-opt-einsum/package.py
@@ -28,6 +28,6 @@ class PyOptEinsum(PythonPackage):
     # https://github.com/dgasmith/opt_einsum/pull/208
     patch(
         "https://github.com/dgasmith/opt_einsum/commit/0beacf96923bbb2dd1939a9c59398a38ce7a11b1.patch?full_index=1",
-        sha256="8e27da491ab363d7413671b16c48d06481a50c014fe0fcf28f7ef01c8368400c",
+        sha256="3ecf03ec60b3fc8ab256596320fa72d2ded4b7f00a437133ea4266c31ac32894",
         when="^python@3.12:",
     )

--- a/var/spack/repos/builtin/packages/py-opt-einsum/package.py
+++ b/var/spack/repos/builtin/packages/py-opt-einsum/package.py
@@ -27,7 +27,7 @@ class PyOptEinsum(PythonPackage):
     # requires this patch for python 3.12
     # https://github.com/dgasmith/opt_einsum/pull/208
     patch(
-        "https://github.com/dgasmith/opt_einsum/commit/0beacf96923bbb2dd1939a9c59398a38ce7a11b1.patch",
+        "https://github.com/dgasmith/opt_einsum/commit/0beacf96923bbb2dd1939a9c59398a38ce7a11b1.patch?full_index=1",
         sha256="8e27da491ab363d7413671b16c48d06481a50c014fe0fcf28f7ef01c8368400c",
         when="^python@3.12:",
     )

--- a/var/spack/repos/builtin/packages/py-opt-einsum/package.py
+++ b/var/spack/repos/builtin/packages/py-opt-einsum/package.py
@@ -29,5 +29,5 @@ class PyOptEinsum(PythonPackage):
     patch(
         "https://github.com/dgasmith/opt_einsum/commit/0beacf96923bbb2dd1939a9c59398a38ce7a11b1.patch",
         sha256="8e27da491ab363d7413671b16c48d06481a50c014fe0fcf28f7ef01c8368400c",
-        when="^python@3.12:"
+        when="^python@3.12:",
     )


### PR DESCRIPTION
This is a WIP PR to see what breaks with Python 3.12 following up from 

https://github.com/spack/spack/pull/46224 (@adamjstewart )
https://github.com/spack/spack/pull/46484

Some of the core python libraries, such as `py-cython` and `py-cffi`, require the now-removed `disutils`. `setuptools` needs to be imported before `distutils` to ensure prefix tools such as spack can correctly find things, as per @haampie 's comment https://github.com/cython/cython/pull/5754#issuecomment-1752102480

However, both `cython` and `cffi` look to have made this update:

`cython@3.0.4:`
https://github.com/cython/cython/blob/3.0.4/Cython/Build/Cythonize.py#L103
via:
https://github.com/cython/cython/commit/0000fb4c319ef8f7e8eabcc99677f99a8c503cc3

`py-cffi@1.16:`:
https://github.com/python-cffi/cffi/blob/release-1.16/src/cffi/_shimmed_dist_utils.py  


The CI runs in https://github.com/spack/spack/pull/46484 suggested `flux-core` was failing to find `py-cffi` when updated to `python@3.12`. Tagging @grondo if they have ideas on the cffi detection mechanism and why it might not be working?