### PR TITLE
Add environment variable expansion option for mirrors.yaml

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1182,6 +1182,9 @@ class Uploader:
         self.tmpdir: str
         self.executor: concurrent.futures.Executor
 
+        # Verify if the mirror meets the requirements to push
+        self.mirror.validate("push")
+
     def __enter__(self):
         self._tmpdir = tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root())
         self._executor = spack.util.parallel.make_concurrent_executor()

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1183,7 +1183,7 @@ class Uploader:
         self.executor: concurrent.futures.Executor
 
         # Verify if the mirror meets the requirements to push
-        self.mirror.validate("push")
+        self.mirror.ensure_mirror_usable("push")
 
     def __enter__(self):
         self._tmpdir = tempfile.TemporaryDirectory(dir=spack.stage.get_stage_root())

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -581,23 +581,51 @@ def add_concretizer_args(subparser):
 
 
 def add_connection_args(subparser, add_help):
-    subparser.add_argument(
-        "--s3-access-key-id", help="ID string to use to connect to this S3 mirror"
+    def add_argument_string_or_variable(parser, arg: str, *, deprecate_str: bool = True, **kwargs):
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(arg, **kwargs)
+        # Update help string
+        if "help" in kwargs:
+            kwargs["help"] = "environment variable containing " + kwargs["help"]
+        group.add_argument(arg + "-variable", **kwargs)
+
+    s3_connection_parser = subparser.add_argument_group("S3 Connection")
+
+    add_argument_string_or_variable(
+        s3_connection_parser,
+        "--s3-access-key-id",
+        help="ID string to use to connect to this S3 mirror",
     )
-    subparser.add_argument(
-        "--s3-access-key-secret", help="secret string to use to connect to this S3 mirror"
+    add_argument_string_or_variable(
+        s3_connection_parser,
+        "--s3-access-key-secret",
+        help="secret string to use to connect to this S3 mirror",
     )
-    subparser.add_argument(
-        "--s3-access-token", help="access token to use to connect to this S3 mirror"
+    add_argument_string_or_variable(
+        s3_connection_parser,
+        "--s3-access-token",
+        help="access token to use to connect to this S3 mirror",
     )
-    subparser.add_argument(
+    s3_connection_parser.add_argument(
         "--s3-profile", help="S3 profile name to use to connect to this S3 mirror", default=None
     )
-    subparser.add_argument(
+    s3_connection_parser.add_argument(
         "--s3-endpoint-url", help="endpoint URL to use to connect to this S3 mirror"
     )
-    subparser.add_argument("--oci-username", help="username to use to connect to this OCI mirror")
-    subparser.add_argument("--oci-password", help="password to use to connect to this OCI mirror")
+
+    oci_connection_parser = subparser.add_argument_group("OCI Connection")
+
+    add_argument_string_or_variable(
+        oci_connection_parser,
+        "--oci-username",
+        deprecate_str=False,
+        help="username to use to connect to this OCI mirror",
+    )
+    add_argument_string_or_variable(
+        oci_connection_parser,
+        "--oci-password",
+        help="password to use to connect to this OCI mirror",
+    )
 
 
 def use_buildcache(cli_arg_value):

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -292,8 +292,8 @@ def _configure_access_pair(
             id_arg_tok = id_tok.replace("_", "-")
             secret_arg_tok = secret_tok.replace("_", "-")
             tty.warn(
-                "Exepected both parts of the access pair to be specified. "
-                f"(ie. --{id_arg_tok} and {secret_arg_tok})"
+                "Expected both parts of the access pair to be specified. "
+                f"(i.e. --{id_arg_tok} and --{secret_arg_tok})"
             )
 
         return None

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -238,11 +238,11 @@ def _configure_access_pair(
 
     # Check if any of the arguments are set to update this access_pair.
     # If none are set, then skip computing the new access pair
-    id_ = getattr(args, id_tok)
-    id_variable = getattr(args, id_variable_tok)
-    secret = getattr(args, secret_tok)
-    secret_variable = getattr(args, secret_variable_tok)
-    if not any([id_, id_variable, secret, secret_variable]):
+    args_id = getattr(args, id_tok)
+    args_id_variable = getattr(args, id_variable_tok)
+    args_secret = getattr(args, secret_tok)
+    args_secret_variable = getattr(args, secret_variable_tok)
+    if not any([args_id, args_id_variable, args_secret, args_secret_variable]):
         return None
 
     def _default_value(id_):
@@ -259,10 +259,20 @@ def _configure_access_pair(
         else:
             return None
 
-    id_ = getattr(args, id_tok) or _default_value("id")
-    id_variable = getattr(args, id_variable_tok) or _default_variable("id")
-    secret = getattr(args, secret_tok) or _default_value("secret")
-    secret_variable = getattr(args, secret_variable_tok) or _default_variable("secret")
+    id_ = None
+    id_variable = None
+    secret = None
+    secret_variable = None
+
+    # Get the value/default value if the argument of the inverse
+    if not args_id_variable:
+        id_ = getattr(args, id_tok) or _default_value("id")
+    if not args_id:
+        id_variable = getattr(args, id_variable_tok) or _default_variable("id")
+    if not args_secret_variable:
+        secret = getattr(args, secret_tok) or _default_value("secret")
+    if not args_secret:
+        secret_variable = getattr(args, secret_variable_tok) or _default_variable("secret")
 
     if (id_ or id_variable) and (secret or secret_variable):
         if secret:

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -320,6 +320,16 @@ def mirror_add(args):
     ):
         connection = {"url": args.url}
         # S3 Connection
+        if args.s3_access_key_secret:
+            tty.warn(
+                "Configuring mirror secrets as plain text with --s3-access-key-secret is "
+                "deprecated. Use --s3-access-key-secret-variable instead"
+            )
+        if args.oci_password:
+            tty.warn(
+                "Configuring mirror secrets as plain text with --oci-password is deprecated. "
+                "Use --oci-password-variable instead"
+            )
         access_pair = _configure_access_pair(
             args,
             "s3_access_key_id",

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -162,6 +162,7 @@ class Mirror:
             current_data.pop("access_token_variable")
 
         # If updating to a new access_pair that is the deprecated list, warn
+        warn_deprecated_access_pair = False
         if "access_pair" in new_data:
             warn_deprecated_access_pair = isinstance(new_data["access_pair"], list)
         # If the not updating the current access_pair, and it is the deprecated list, warn

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -332,7 +332,7 @@ class Mirror:
         elif isinstance(pair, dict):
             id_ = os.environ.get(pair["id_variable"]) if "id_variable" in pair else pair["id"]
             secret = os.environ.get(pair["secret_variable"])
-            return (str(id_), str(secret)) if id_ and secret else None
+            return (id_, secret) if id_ and secret else None
         else:
             return None
 

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -171,7 +171,7 @@ class Mirror:
 
         if warn_deprecated_access_pair:
             tty.warn(
-                f"In mirror {self.name}: Using access_pair with a list is "
+                f"In mirror {self.name}: Using access_pair with a pain text secret is "
                 "deprecated, prefer id/secret_variable keys"
             )
 

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -161,6 +161,19 @@ class Mirror:
         elif "access_token_variable" in current_data and "access_token" in new_data:
             current_data.pop("access_token_variable")
 
+        # If updating to a new access_pair that is the deprecated list, warn
+        if "access_pair" in new_data:
+            warn_deprecated_access_pair = isinstance(new_data["access_pair"], list)
+        # If the not updating the current access_pair, and it is the deprecated list, warn
+        elif "access_pair" in current_data:
+            warn_deprecated_access_pair = isinstance(current_data["access_pair"], list)
+
+        if warn_deprecated_access_pair:
+            tty.warn(
+                f"In mirror {self.name}: Using access_pair with a list is "
+                "deprecated, prefer id/secret_variable keys"
+            )
+
         keys = [
             "url",
             "access_pair",

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -157,14 +157,8 @@ class Mirror:
     def validate(self, direction="push"):
         access_pair = self._get_value("access_pair", direction)
         access_token_variable = self._get_value("access_token_variable", direction)
-        url = self.get_url(direction)
 
         errors = []
-
-        # OCI requires an access pair
-        if url.startswith("oci://"):
-            if access_pair is None:
-                errors.append("OCI mirror requires an access_pair")
 
         # Verify that the credentials that are variables expand
         if access_pair and isinstance(access_pair, dict):

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -167,18 +167,19 @@ class Mirror:
             if "secret_variable" in access_pair:
                 if access_pair["secret_variable"] not in os.environ:
                     errors.append(
-                        f"secret_variable {access_pair['secret_variable']} not set in environment"
+                        f"environment variable `{access_pair['secret_variable']}` "
+                        "(secret_variable) not set"
                     )
 
         if access_token_variable:
             if access_token_variable not in os.environ:
                 errors.append(
-                    f"access_token_variable {access_pair['access_token_variable']}"
-                    " not set in environment"
+                    f"environment variable `{access_pair['access_token_variable']}` "
+                    "(access_token_variable) not set"
                 )
 
         if errors:
-            msg = f"Could not validate {direction} configuruation for mirror {self.name}:\n\t"
+            msg = f"invalid {direction} configuration for mirror {self.name}: "
             msg += "\n    ".join(errors)
             raise spack.mirror.MirrorError(msg)
 
@@ -199,8 +200,10 @@ class Mirror:
 
         if warn_deprecated_access_pair:
             tty.warn(
-                f"In mirror {self.name}: Using access_pair with a pain text secret is "
-                "deprecated, prefer id/secret_variable keys"
+                f"in mirror {self.name}: support for plain text secrets in config files "
+                "(access_pair: [id, secret]) is deprecated and will be removed in a future Spack "
+                "version. Use environment variables instead (access_pair: "
+                "{id: ..., secret_variable: ...})"
             )
 
         keys = [

--- a/lib/spack/spack/oci/opener.py
+++ b/lib/spack/spack/oci/opener.py
@@ -377,9 +377,10 @@ def credentials_from_mirrors(
         # Prefer push credentials over fetch. Unlikely that those are different
         # but our config format allows it.
         for direction in ("push", "fetch"):
-            pair = mirror.get_access_pair(direction)
-            if pair is None:
+            pair = mirror.get_credentials(direction).get("access_pair")
+            if not pair:
                 continue
+
             url = mirror.get_url(direction)
             if not url.startswith("oci://"):
                 continue

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -10,19 +10,6 @@
 """
 from typing import Any, Dict
 
-string_or_variable = {
-    "oneOf": [
-        {
-            "type": "object",
-            "required": ["variable"],
-            "additionalProperties": False,
-            "properties": {"variable": {"type": "string"}},
-        },
-        {"type": "string"},
-    ]
-}
-
-
 #: Common properties for connection specification
 connection = {
     "url": {"type": "string"},
@@ -31,7 +18,7 @@ connection = {
         "oneOf": [
             {
                 "type": "array",
-                "items": {"minItems": 2, "maxItems": 2, **string_or_variable},
+                "items": {"minItems": 2, "maxItems": 2, "type": ["string", "null"]},
             },  # deprecated
             {
                 "type": "object",

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -102,8 +102,6 @@ schema = {
 
 
 def update(data):
-    import warnings
-
     import jsonschema
 
     errors = []
@@ -111,13 +109,6 @@ def update(data):
     def check_access_pair(name, section):
         if not section or not isinstance(section, dict):
             return
-
-        access_pair = section.get("access_pair")
-        if access_pair and isinstance(access_pair, list):
-            warnings.warn(
-                f"{name}: Using access_pair with a list is "
-                "deprecated, prefer id/secret_variable keys"
-            )
 
         if set(["access_token", "access_token_variable"]).issubset(set(section.keys())):
             errors.append(

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -10,18 +10,58 @@
 """
 from typing import Any, Dict
 
+string_or_variable = {
+    "oneOf": [
+        {
+            "type": "object",
+            "required": ["variable"],
+            "additionalProperties": False,
+            "properties": {"variable": {"type": "string"}},
+        },
+        {"type": "string"},
+    ]
+}
+
+
 #: Common properties for connection specification
 connection = {
     "url": {"type": "string"},
     # todo: replace this with named keys "username" / "password" or "id" / "secret"
     "access_pair": {
-        "type": "array",
-        "items": {"type": ["string", "null"], "minItems": 2, "maxItems": 2},
+        "oneOf": [
+            {
+                "type": "array",
+                "items": {"minItems": 2, "maxItems": 2, **string_or_variable},
+            },  # deprecated
+            {
+                "type": "object",
+                "required": ["secret_variable"],
+                # Only allow id or id_variable to be set, not both
+                "oneOf": [{"required": ["id"]}, {"required": ["id_variable"]}],
+                "properties": {
+                    "id": {"type": "string"},
+                    "id_variable": {"type": "string"},
+                    "secret_variable": {"type": "string"},
+                },
+            },
+        ]
     },
-    "access_token": {"type": ["string", "null"]},
     "profile": {"type": ["string", "null"]},
     "endpoint_url": {"type": ["string", "null"]},
+    "access_token": {"type": ["string", "null"]},  # deprecated
+    "access_token_variable": {"type": ["string", "null"]},
 }
+
+connection_ext = {
+    "deprecatedProperties": [
+        {
+            "names": ["access_token"],
+            "message": "Spack no longer supportes plain text access_token in mirror configs",
+            "error": False,
+        }
+    ]
+}
+
 
 #: Mirror connection inside pull/push keys
 fetch_and_push = {
@@ -31,6 +71,7 @@ fetch_and_push = {
             "type": "object",
             "additionalProperties": False,
             "properties": {**connection},  # type: ignore
+            **connection_ext,  # type: ignore
         },
     ]
 }
@@ -49,6 +90,7 @@ mirror_entry = {
         "autopush": {"type": "boolean"},
         **connection,  # type: ignore
     },
+    **connection_ext,  # type: ignore
 }
 
 #: Properties for inclusion in other schemas
@@ -70,3 +112,39 @@ schema = {
     "additionalProperties": False,
     "properties": properties,
 }
+
+
+def update(data):
+    import warnings
+
+    import jsonschema
+
+    errors = []
+
+    def check_access_pair(name, section):
+        if not section or not isinstance(section, dict):
+            return
+
+        access_pair = section.get("access_pair")
+        if access_pair and isinstance(access_pair, list):
+            warnings.warn(
+                f"{name}: Using access_pair with a list is "
+                "deprecated, prefer id/secret_variable keys"
+            )
+            if not isinstance(access_pair[1], dict):
+                warnings.warn(f"{name}: Secret part of access pair should be a variable")
+
+        if set(["access_token", "access_token_variable"]).issubset(set(section.keys())):
+            errors.append(
+                f'{name}: mirror credential "access_token" conflicts with "access_token_variable"'
+            )
+
+    # Check all of the sections
+    for name, section in data.items():
+        check_access_pair(name, section)
+        if isinstance(section, dict):
+            check_access_pair(name, section.get("fetch"))
+            check_access_pair(name, section.get("push"))
+
+    if errors:
+        raise jsonschema.ValidationError("\n".join(errors))

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -43,7 +43,8 @@ connection_ext = {
     "deprecatedProperties": [
         {
             "names": ["access_token"],
-            "message": "Spack no longer supportes plain text access_token in mirror configs",
+            "message": "Use of plain text `access_token` in mirror config is deprecated, use "
+            "environment variables instead (access_token_variable)",
             "error": False,
         }
     ]
@@ -110,7 +111,7 @@ def update(data):
         if not section or not isinstance(section, dict):
             return
 
-        if set(["access_token", "access_token_variable"]).issubset(set(section.keys())):
+        if "access_token" in section and "access_token_variable" in section:
             errors.append(
                 f'{name}: mirror credential "access_token" conflicts with "access_token_variable"'
             )

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -118,8 +118,6 @@ def update(data):
                 f"{name}: Using access_pair with a list is "
                 "deprecated, prefer id/secret_variable keys"
             )
-            if not isinstance(access_pair[1], dict):
-                warnings.warn(f"{name}: Secret part of access pair should be a variable")
 
         if set(["access_token", "access_token_variable"]).issubset(set(section.keys())):
             errors.append(

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -17,6 +17,7 @@ import spack.util.url as url_util
 import spack.version
 from spack.main import SpackCommand, SpackCommandError
 
+config = SpackCommand("config")
 mirror = SpackCommand("mirror")
 env = SpackCommand("env")
 add = SpackCommand("add")
@@ -192,25 +193,42 @@ def test_mirror_crud(mutable_config, capsys):
         ):
             # Test S3 connection info id/key
             mirror("add", id_arg, "foo", secret_arg, "bar", mirror_name, mirror_url)
-            mirror(
+            output = config("blame", "mirrors")
+            assert all([x in output for x in ("foo", "bar", mirror_name, mirror_url)])
+
+            output = mirror("set", id_arg, "foo_set", secret_arg, "bar_set", mirror_name)
+            output = config("blame", "mirrors")
+            assert all([x in output for x in ("foo_set", "bar_set", mirror_name, mirror_url)])
+
+            output = mirror(
                 "set-url",
                 id_arg,
                 "foo_set_url",
                 secret_arg,
                 "bar_set_url",
+                "--push",
                 mirror_name,
-                mirror_url,
+                mirror_url + "-push",
             )
-            mirror("set", id_arg, "foo_set", secret_arg, "bar_set", mirror_name)
+            output = config("blame", "mirrors")
+            assert all(
+                [
+                    x in output
+                    for x in ("foo_set_url", "bar_set_url", mirror_name, mirror_url + "-push")
+                ]
+            )
 
-            output = mirror("set", id_arg, "cat", mirror_name)
-            assert "Exepected both parts of the access pair to be specified. " in output
-            output = mirror("set", secret_arg, "cat", mirror_name)
-            assert "Exepected both parts of the access pair to be specified. " in output
+            output = mirror("set", id_arg, "a", mirror_name)
+            assert "No changes made to mirror" not in output
 
-            output = mirror("set-url", id_arg, "cat", mirror_name, mirror_url)
-            output = mirror("set-url", secret_arg, "cat", mirror_name, mirror_url)
-            assert "Exepected both parts of the access pair to be specified. " in output
+            output = mirror("set", secret_arg, "b", mirror_name)
+            assert "No changes made to mirror" not in output
+
+            output = mirror("set-url", id_arg, "c", mirror_name, mirror_url)
+            assert "No changes made to mirror" not in output
+
+            output = mirror("set-url", secret_arg, "d", mirror_name, mirror_url)
+            assert "No changes made to mirror" not in output
 
             output = mirror("remove", mirror_name)
             assert "Removed mirror" in output
@@ -218,10 +236,22 @@ def test_mirror_crud(mutable_config, capsys):
             output = mirror("add", id_arg, "foo", mirror_name, mirror_url)
             assert "Exepected both parts of the access pair to be specified. " in output
 
+            output = mirror("set-url", id_arg, "bar", mirror_name, mirror_url)
+            assert "Exepected both parts of the access pair to be specified. " in output
+
+            output = mirror("set", id_arg, "bar", mirror_name)
+            assert "Exepected both parts of the access pair to be specified. " in output
+
             output = mirror("remove", mirror_name)
             assert "Removed mirror" in output
 
             output = mirror("add", secret_arg, "bar", mirror_name, mirror_url)
+            assert "Exepected both parts of the access pair to be specified. " in output
+
+            output = mirror("set-url", secret_arg, "bar", mirror_name, mirror_url)
+            assert "Exepected both parts of the access pair to be specified. " in output
+
+            output = mirror("set", secret_arg, "bar", mirror_name)
             assert "Exepected both parts of the access pair to be specified. " in output
 
             output = mirror("remove", mirror_name)

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -202,18 +202,18 @@ def test_mirror_crud(mutable_config, capsys):
             output = config("blame", "mirrors")
             assert all([x in output for x in ("foo", "bar", mirror_name, mirror_url)])
             # Mirror access_pair deprecation warning should not be in blame output
-            assert "Using access_pair with a list is deprecated" not in output
+            assert "Using access_pair with a pain text secret is deprecated" not in output
 
             output = mirror("set", id_arg, "foo_set", secret_arg, "bar_set", mirror_name)
             if "variable" not in secret_arg:
-                assert "Using access_pair with a list is deprecated" in output
+                assert "Using access_pair with a pain text secret is deprecated" in output
             output = config("blame", "mirrors")
             assert all([x in output for x in ("foo_set", "bar_set", mirror_name, mirror_url)])
             if "variable" not in secret_arg:
                 output = mirror(
                     "set", id_arg, "foo_set", secret_arg + "-variable", "bar_set_var", mirror_name
                 )
-                assert "Using access_pair with a list is deprecated" not in output
+                assert "Using access_pair with a pain text secret is deprecated" not in output
                 output = config("blame", "mirrors")
                 assert all(
                     [x in output for x in ("foo_set", "bar_set_var", mirror_name, mirror_url)]

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -202,18 +202,18 @@ def test_mirror_crud(mutable_config, capsys):
             output = config("blame", "mirrors")
             assert all([x in output for x in ("foo", "bar", mirror_name, mirror_url)])
             # Mirror access_pair deprecation warning should not be in blame output
-            assert "Using access_pair with a pain text secret is deprecated" not in output
+            assert "support for plain text secrets" not in output
 
             output = mirror("set", id_arg, "foo_set", secret_arg, "bar_set", mirror_name)
             if "variable" not in secret_arg:
-                assert "Using access_pair with a pain text secret is deprecated" in output
+                assert "support for plain text secrets" in output
             output = config("blame", "mirrors")
             assert all([x in output for x in ("foo_set", "bar_set", mirror_name, mirror_url)])
             if "variable" not in secret_arg:
                 output = mirror(
                     "set", id_arg, "foo_set", secret_arg + "-variable", "bar_set_var", mirror_name
                 )
-                assert "Using access_pair with a pain text secret is deprecated" not in output
+                assert "support for plain text secrets" not in output
                 output = config("blame", "mirrors")
                 assert all(
                     [x in output for x in ("foo_set", "bar_set_var", mirror_name, mirror_url)]
@@ -253,25 +253,25 @@ def test_mirror_crud(mutable_config, capsys):
             assert "Removed mirror" in output
 
             output = mirror("add", id_arg, "foo", mirror_name, mirror_url)
-            assert "Exepected both parts of the access pair to be specified. " in output
+            assert "Expected both parts of the access pair to be specified. " in output
 
             output = mirror("set-url", id_arg, "bar", mirror_name, mirror_url)
-            assert "Exepected both parts of the access pair to be specified. " in output
+            assert "Expected both parts of the access pair to be specified. " in output
 
             output = mirror("set", id_arg, "bar", mirror_name)
-            assert "Exepected both parts of the access pair to be specified. " in output
+            assert "Expected both parts of the access pair to be specified. " in output
 
             output = mirror("remove", mirror_name)
             assert "Removed mirror" in output
 
             output = mirror("add", secret_arg, "bar", mirror_name, mirror_url)
-            assert "Exepected both parts of the access pair to be specified. " in output
+            assert "Expected both parts of the access pair to be specified. " in output
 
             output = mirror("set-url", secret_arg, "bar", mirror_name, mirror_url)
-            assert "Exepected both parts of the access pair to be specified. " in output
+            assert "Expected both parts of the access pair to be specified. " in output
 
             output = mirror("set", secret_arg, "bar", mirror_name)
-            assert "Exepected both parts of the access pair to be specified. " in output
+            assert "Expected both parts of the access pair to be specified. " in output
 
             output = mirror("remove", mirror_name)
             assert "Removed mirror" in output

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -360,35 +360,9 @@ def test_update_connection_params(direction, tmpdir, monkeypatch):
     assert m.get_endpoint_url(direction) == "https://example.com"
 
     # Expand environment variables
-    assert m.update(
-        {
-            "access_pair": [
-                {"variable": "_SPACK_TEST_PAIR_USERNAME"},
-                {"variable": "_SPACK_TEST_PAIR_PASSWORD"},
-            ]
-        },
-        direction,
-    )
-
-    assert m.to_dict() == {
-        "url": "https://example.com",
-        direction: {
-            "url": "http://example.org",
-            "access_pair": [
-                {"variable": "_SPACK_TEST_PAIR_USERNAME"},
-                {"variable": "_SPACK_TEST_PAIR_PASSWORD"},
-            ],
-            "access_token": "token",
-            "profile": "profile",
-            "endpoint_url": "https://example.com",
-        },
-    }
-
     os.environ["_SPACK_TEST_PAIR_USERNAME"] = "expanded_username"
     os.environ["_SPACK_TEST_PAIR_PASSWORD"] = "expanded_password"
     os.environ["_SPACK_TEST_TOKEN"] = "expanded_token"
-
-    assert m.get_access_pair(direction) == ("expanded_username", "expanded_password")
 
     assert m.update(
         {

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -94,20 +94,17 @@ def get_mirror_s3_connection_info(mirror, method):
 
     # access token
     if isinstance(mirror, Mirror):
-        access_token = mirror.get_access_token(method)
-        if access_token:
-            s3_connection["aws_session_token"] = access_token
+        credentials = mirror.get_credentials(method)
+        if credentials:
+            if "access_token" in credentials:
+                s3_connection["aws_session_token"] = credentials["access_token"]
 
-        # access pair
-        access_pair = mirror.get_access_pair(method)
-        if access_pair and access_pair[0] and access_pair[1]:
-            s3_connection["aws_access_key_id"] = access_pair[0]
-            s3_connection["aws_secret_access_key"] = access_pair[1]
+            if "access_pair" in credentials:
+                s3_connection["aws_access_key_id"] = credentials["access_pair"][0]
+                s3_connection["aws_secret_access_key"] = credentials["access_pair"][1]
 
-        # profile
-        profile = mirror.get_profile(method)
-        if profile:
-            s3_connection["profile_name"] = profile
+            if "profile" in credentials:
+                s3_connection["profile_name"] = credentials["profile"]
 
         # endpoint url
         endpoint_url = mirror.get_endpoint_url(method) or os.environ.get("S3_ENDPOINT_URL")

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1437,7 +1437,7 @@ _spack_mirror_destroy() {
 _spack_mirror_add() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope --type --autopush --unsigned --signed --s3-access-key-id --s3-access-key-secret --s3-access-token --s3-profile --s3-endpoint-url --oci-username --oci-password"
+        SPACK_COMPREPLY="-h --help --scope --type --autopush --unsigned --signed --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret --s3-access-key-secret-variable --s3-access-token --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password --oci-password-variable"
     else
         _mirrors
     fi
@@ -1464,7 +1464,7 @@ _spack_mirror_rm() {
 _spack_mirror_set_url() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --push --fetch --scope --s3-access-key-id --s3-access-key-secret --s3-access-token --s3-profile --s3-endpoint-url --oci-username --oci-password"
+        SPACK_COMPREPLY="-h --help --push --fetch --scope --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret --s3-access-key-secret-variable --s3-access-token --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password --oci-password-variable"
     else
         _mirrors
     fi
@@ -1473,7 +1473,7 @@ _spack_mirror_set_url() {
 _spack_mirror_set() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --push --fetch --type --url --autopush --no-autopush --unsigned --signed --scope --s3-access-key-id --s3-access-key-secret --s3-access-token --s3-profile --s3-endpoint-url --oci-username --oci-password"
+        SPACK_COMPREPLY="-h --help --push --fetch --type --url --autopush --no-autopush --unsigned --signed --scope --s3-access-key-id --s3-access-key-id-variable --s3-access-key-secret --s3-access-key-secret-variable --s3-access-token --s3-access-token-variable --s3-profile --s3-endpoint-url --oci-username --oci-username-variable --oci-password --oci-password-variable"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2273,7 +2273,7 @@ complete -c spack -n '__fish_spack_using_command mirror destroy' -l mirror-url -
 complete -c spack -n '__fish_spack_using_command mirror destroy' -l mirror-url -r -d 'find mirror to destroy by url'
 
 # spack mirror add
-set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsigned signed s3-access-key-id= s3-access-key-secret= s3-access-token= s3-profile= s3-endpoint-url= oci-username= oci-password=
+set -g __fish_spack_optspecs_spack_mirror_add h/help scope= type= autopush unsigned signed s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret= s3-access-key-secret-variable= s3-access-token= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password= oci-password-variable=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror add' -f
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror add' -s h -l help -d 'show this help message and exit'
@@ -2289,18 +2289,28 @@ complete -c spack -n '__fish_spack_using_command mirror add' -l signed -f -a sig
 complete -c spack -n '__fish_spack_using_command mirror add' -l signed -d 'require signing and signature verification when pushing and installing from this build cache'
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
+complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id-variable -r -f -a s3_access_key_id_variable
+complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-id-variable -r -d 'environment variable containing ID string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-secret -r -f -a s3_access_key_secret
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-secret -r -d 'secret string to use to connect to this S3 mirror'
+complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-secret-variable -r -f -a s3_access_key_secret_variable
+complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-key-secret-variable -r -d 'environment variable containing secret string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-token -r -f -a s3_access_token
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-token -r -d 'access token to use to connect to this S3 mirror'
+complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-token-variable -r -f -a s3_access_token_variable
+complete -c spack -n '__fish_spack_using_command mirror add' -l s3-access-token-variable -r -d 'environment variable containing access token to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-profile -r -f -a s3_profile
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-profile -r -d 'S3 profile name to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-endpoint-url -r -f -a s3_endpoint_url
 complete -c spack -n '__fish_spack_using_command mirror add' -l s3-endpoint-url -r -d 'endpoint URL to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l oci-username -r -f -a oci_username
 complete -c spack -n '__fish_spack_using_command mirror add' -l oci-username -r -d 'username to use to connect to this OCI mirror'
+complete -c spack -n '__fish_spack_using_command mirror add' -l oci-username-variable -r -f -a oci_username_variable
+complete -c spack -n '__fish_spack_using_command mirror add' -l oci-username-variable -r -d 'environment variable containing username to use to connect to this OCI mirror'
 complete -c spack -n '__fish_spack_using_command mirror add' -l oci-password -r -f -a oci_password
 complete -c spack -n '__fish_spack_using_command mirror add' -l oci-password -r -d 'password to use to connect to this OCI mirror'
+complete -c spack -n '__fish_spack_using_command mirror add' -l oci-password-variable -r -f -a oci_password_variable
+complete -c spack -n '__fish_spack_using_command mirror add' -l oci-password-variable -r -d 'environment variable containing password to use to connect to this OCI mirror'
 
 # spack mirror remove
 set -g __fish_spack_optspecs_spack_mirror_remove h/help scope=
@@ -2319,7 +2329,7 @@ complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -f -a '_
 complete -c spack -n '__fish_spack_using_command mirror rm' -l scope -r -d 'configuration scope to modify'
 
 # spack mirror set-url
-set -g __fish_spack_optspecs_spack_mirror_set_url h/help push fetch scope= s3-access-key-id= s3-access-key-secret= s3-access-token= s3-profile= s3-endpoint-url= oci-username= oci-password=
+set -g __fish_spack_optspecs_spack_mirror_set_url h/help push fetch scope= s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret= s3-access-key-secret-variable= s3-access-token= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password= oci-password-variable=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror set-url' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror set-url' -s h -l help -d 'show this help message and exit'
@@ -2331,21 +2341,31 @@ complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -f 
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id-variable -r -f -a s3_access_key_id_variable
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-id-variable -r -d 'environment variable containing ID string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-secret -r -f -a s3_access_key_secret
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-secret -r -d 'secret string to use to connect to this S3 mirror'
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-secret-variable -r -f -a s3_access_key_secret_variable
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-key-secret-variable -r -d 'environment variable containing secret string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-token -r -f -a s3_access_token
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-token -r -d 'access token to use to connect to this S3 mirror'
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-token-variable -r -f -a s3_access_token_variable
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-access-token-variable -r -d 'environment variable containing access token to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-profile -r -f -a s3_profile
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-profile -r -d 'S3 profile name to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-endpoint-url -r -f -a s3_endpoint_url
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l s3-endpoint-url -r -d 'endpoint URL to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-username -r -f -a oci_username
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-username -r -d 'username to use to connect to this OCI mirror'
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-username-variable -r -f -a oci_username_variable
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-username-variable -r -d 'environment variable containing username to use to connect to this OCI mirror'
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-password -r -f -a oci_password
 complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-password -r -d 'password to use to connect to this OCI mirror'
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-password-variable -r -f -a oci_password_variable
+complete -c spack -n '__fish_spack_using_command mirror set-url' -l oci-password-variable -r -d 'environment variable containing password to use to connect to this OCI mirror'
 
 # spack mirror set
-set -g __fish_spack_optspecs_spack_mirror_set h/help push fetch type= url= autopush no-autopush unsigned signed scope= s3-access-key-id= s3-access-key-secret= s3-access-token= s3-profile= s3-endpoint-url= oci-username= oci-password=
+set -g __fish_spack_optspecs_spack_mirror_set h/help push fetch type= url= autopush no-autopush unsigned signed scope= s3-access-key-id= s3-access-key-id-variable= s3-access-key-secret= s3-access-key-secret-variable= s3-access-token= s3-access-token-variable= s3-profile= s3-endpoint-url= oci-username= oci-username-variable= oci-password= oci-password-variable=
 complete -c spack -n '__fish_spack_using_command_pos 0 mirror set' -f -a '(__fish_spack_mirrors)'
 complete -c spack -n '__fish_spack_using_command mirror set' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command mirror set' -s h -l help -d 'show this help message and exit'
@@ -2369,18 +2389,28 @@ complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -f -a '
 complete -c spack -n '__fish_spack_using_command mirror set' -l scope -r -d 'configuration scope to modify'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -f -a s3_access_key_id
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id -r -d 'ID string to use to connect to this S3 mirror'
+complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id-variable -r -f -a s3_access_key_id_variable
+complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-id-variable -r -d 'environment variable containing ID string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-secret -r -f -a s3_access_key_secret
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-secret -r -d 'secret string to use to connect to this S3 mirror'
+complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-secret-variable -r -f -a s3_access_key_secret_variable
+complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-key-secret-variable -r -d 'environment variable containing secret string to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-token -r -f -a s3_access_token
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-token -r -d 'access token to use to connect to this S3 mirror'
+complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-token-variable -r -f -a s3_access_token_variable
+complete -c spack -n '__fish_spack_using_command mirror set' -l s3-access-token-variable -r -d 'environment variable containing access token to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-profile -r -f -a s3_profile
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-profile -r -d 'S3 profile name to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-endpoint-url -r -f -a s3_endpoint_url
 complete -c spack -n '__fish_spack_using_command mirror set' -l s3-endpoint-url -r -d 'endpoint URL to use to connect to this S3 mirror'
 complete -c spack -n '__fish_spack_using_command mirror set' -l oci-username -r -f -a oci_username
 complete -c spack -n '__fish_spack_using_command mirror set' -l oci-username -r -d 'username to use to connect to this OCI mirror'
+complete -c spack -n '__fish_spack_using_command mirror set' -l oci-username-variable -r -f -a oci_username_variable
+complete -c spack -n '__fish_spack_using_command mirror set' -l oci-username-variable -r -d 'environment variable containing username to use to connect to this OCI mirror'
 complete -c spack -n '__fish_spack_using_command mirror set' -l oci-password -r -f -a oci_password
 complete -c spack -n '__fish_spack_using_command mirror set' -l oci-password -r -d 'password to use to connect to this OCI mirror'
+complete -c spack -n '__fish_spack_using_command mirror set' -l oci-password-variable -r -f -a oci_password_variable
+complete -c spack -n '__fish_spack_using_command mirror set' -l oci-password-variable -r -d 'environment variable containing password to use to connect to this OCI mirror'
 
 # spack mirror list
 set -g __fish_spack_optspecs_spack_mirror_list h/help scope=


### PR DESCRIPTION
Currently Spack expects either global mirror environment (S3) configuration to authenticate mirror access or injecting secrets into configs making them unshareable. To improve this a new user credentials file is introduced as well as environment variable expansion. This should make it easier for users to share configurations without risking about mixing in secrets.
