### PR TITLE
dakota: add v6.20 and updated boost version requirements

### DIFF
--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -43,6 +43,12 @@ class Dakota(CMakePackage):
     license("LGPL-2.1-or-later")
 
     version(
+        "6.20.0",
+        tag="v6.20.0",
+        commit="494027b37264ec9268f2de8649d071de0232c534",
+        submodules=submodules,
+    )
+    version(
         "6.19.0",
         tag="v6.19.0",
         commit="603f448b916a8f629d258922e26e7e40dcaaf8ce",
@@ -76,7 +82,7 @@ class Dakota(CMakePackage):
     depends_on("python", when="+python")
     depends_on("perl-data-dumper", type="build", when="@6.12:")
     depends_on("boost@:1.68.0", when="@:6.12")
-    depends_on("boost@1.69.0:", when="@6.18:")
+    depends_on("boost@1.69.0:1.84.0", when="@6.18:6.20")
     depends_on("boost +filesystem +program_options +regex +serialization +system")
 
     # TODO: replace this with an explicit list of components of Boost,


### PR DESCRIPTION
builds were failing with:
```
  >> 17135    /var/tmp/testnewm/spack-stage/spack-stage-dakota-6.20.0-34ztuavbk
              dp436veghrqi4qh3vvbtoez/spack-src/src/WorkdirHelper.cpp:55:37: er
              ror: expected unqualified-id before '&' token
     17136       55 |   catch (const bfs::filesystem_error& e) {

```
I am not actually familiar with dakota and and am not on top of boost updates, but I do see changes between https://www.boost.org/doc/libs/1_84_0/boost/filesystem/exception.hpp and https://www.boost.org/doc/libs/1_85_0/boost/filesystem/exception.hpp, which likely contribute to the error. Restricting the boost version allows dakota to build. I also added the latest release since I did some testing with that version as well.