### PR TITLE
database: don't call `socket.getfqdn()` on every write

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -50,6 +50,7 @@ except ImportError:
     pass
 
 import llnl.util.filesystem as fs
+import llnl.util.lang
 import llnl.util.tty as tty
 
 import spack.deptypes as dt
@@ -119,6 +120,17 @@ DEFAULT_INSTALL_RECORD_FIELDS = (
     "installation_time",
     "deprecated_for",
 )
+
+
+@llnl.util.lang.memoized
+def _getfqdn():
+    """Memoized version of `getfqdn()`.
+
+    If we call `getfqdn()` too many times, DNS can be very slow. We only need to call it
+    one time per process, so we cache it here.
+
+    """
+    return socket.getfqdn()
 
 
 def reader(version: vn.StandardVersion) -> Type["spack.spec.SpecfileReaderBase"]:
@@ -1084,7 +1096,7 @@ class Database:
             self._state_is_inconsistent = True
             return
 
-        temp_file = self._index_path + (".%s.%s.temp" % (socket.getfqdn(), os.getpid()))
+        temp_file = self._index_path + (".%s.%s.temp" % (_getfqdn(), os.getpid()))
 
         # Write a temporary database file them move it into place
         try:


### PR DESCRIPTION
We've seen `getfqdn()` cause [slowdowns on macOS in CI](https://github.com/spack/spack/pull/46478#issuecomment-2361003637) when added elsewhere. It's also called by database.py every time we write the DB file.

- [x] replace the call with a memoized version so that it is only called once per process.
