### PR TITLE
Raise an error if a develop package is not used in the environment

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2611,6 +2611,13 @@ class SpackSolverSetup:
                 )
                 for name, info in env.dev_specs.items()
             )
+            unused_dev_specs = [ds for ds in dev_specs if ds.name not in self.pkgs]
+            if unused_dev_specs:
+                raise spack.error.SpackError(
+                    "Environment has develop packages that are not part of the dependency tree: "
+                    f"{[ds.name for ds in unused_dev_specs]}"
+                )
+
         specs = tuple(specs)  # ensure compatible types to add
 
         self.gen.h1("Reusable concrete specs")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This one way to fix #46546 

As described in #46546 if a `develop` package in an environment that is not part of any of the dependency tree(s) in the environment defines non-default variant values the lookup in `define_variant_values` will fail. This pull request, just checks earlier if any of the packages marked as `develop` is unused by the environment and issues an error with a bit more information earlier.

This is most likely not the very best solution, but it at least gives a better error message, rather than just `==> Error <id>`. I am not sure if it should be an error if a `develop` package in an environment is unused, prior to #44425 it wasn't one and these packages were effectively silently ignored during concretization. 