### PR TITLE
gfal2: new package (and dependencies)

### DIFF
--- a/var/spack/repos/builtin/packages/cgsi-gsoap/package.py
+++ b/var/spack/repos/builtin/packages/cgsi-gsoap/package.py
@@ -29,4 +29,4 @@ class CgsiGsoap(CMakePackage):
     depends_on("globus-gss-assist")
     depends_on("globus-gsi-cert-utils")
     depends_on("globus-gsi-credential")
-    depends_on("globus-openssl")
+    depends_on("globus-openssl-module")

--- a/var/spack/repos/builtin/packages/cgsi-gsoap/package.py
+++ b/var/spack/repos/builtin/packages/cgsi-gsoap/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class CgsiGsoap(CMakePackage):
+    """Client and server side library to secure gSOAP
+    using the Globus Security Infrastructure."""
+
+    homepage = "https://github.com/cern-fts/cgsi-gsoap"
+    url = "https://github.com/cern-fts/cgsi-gsoap/archive/refs/tags/v1.3.12.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("1.3.12", sha256="ebb141ea7fe6d883ebeca031b4f2e3697895efb8fde55ee214128d5ca37e13e4")
+
+    depends_on("c", type="build")
+
+    depends_on("pkg-config", type="build")
+    depends_on("gsoap")
+    depends_on("voms")
+    depends_on("globus-common")
+    depends_on("globus-gssapi-gsi")
+    depends_on("globus-gss-assist")
+    depends_on("globus-gsi-cert-utils")
+    depends_on("globus-gsi-credential")
+    depends_on("globus-openssl")

--- a/var/spack/repos/builtin/packages/gfal2-util/package.py
+++ b/var/spack/repos/builtin/packages/gfal2-util/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 
 
 class Gfal2Util(PythonPackage):
-    """FIXME: Put a proper description of your package here."""
+    """CLI for gfal2."""
 
     homepage = "https://dmc-docs.web.cern.ch/dmc-docs/gfal2-util.html"
     url = "https://github.com/cern-fts/gfal2-util/archive/refs/tags/v1.9.0.tar.gz"

--- a/var/spack/repos/builtin/packages/gfal2-util/package.py
+++ b/var/spack/repos/builtin/packages/gfal2-util/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Gfal2Util(PythonPackage):
+    """FIXME: Put a proper description of your package here."""
+
+    homepage = "https://dmc-docs.web.cern.ch/dmc-docs/gfal2-util.html"
+    url = "https://github.com/cern-fts/gfal2-util/archive/refs/tags/v1.9.0.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("1.9.0", sha256="9a5194b7ac80381c0787ec7c2405cc3e060fc03bb99e80bbeb388ec3675cb13d")
+
+    depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/gfal2/package.py
+++ b/var/spack/repos/builtin/packages/gfal2/package.py
@@ -67,5 +67,6 @@ class Gfal2(CMakePackage):
             self.define_from_variant("PLUGIN_HTTP", "http"),
             self.define_from_variant("PLUGIN_SFTP", "sftp"),
             self.define_from_variant("PLUGIN_SRM", "srm"),
+            self.define_from_variant("PLUGIN_XROOTD", "xrootd"),
         ]
         return args

--- a/var/spack/repos/builtin/packages/gfal2/package.py
+++ b/var/spack/repos/builtin/packages/gfal2/package.py
@@ -63,14 +63,13 @@ class Gfal2(CMakePackage):
         filter_file(
             r"find_library\(CRYPTOPP_LIBRARIES",
             "find_library(CRYPTOPP_LIBRARIES PATH_SUFFIXES lib lib64",
-            "cmake/modules/FindCryptopp.cmake"
+            "cmake/modules/FindCryptopp.cmake",
         )
         filter_file(
             r"find_path\(CRYPTOPP_INCLUDE_DIRS",
             "find_path(CRYPTOPP_INCLUDE_DIRS PATH_SUFFIXES include/cryptopp",
-            "cmake/modules/FindCryptopp.cmake"
+            "cmake/modules/FindCryptopp.cmake",
         )
-
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/gfal2/package.py
+++ b/var/spack/repos/builtin/packages/gfal2/package.py
@@ -10,7 +10,7 @@ class Gfal2(CMakePackage):
     """Multi-protocol data management library."""
 
     homepage = "https://dmc-docs.web.cern.ch/dmc-docs/"
-    url = "https://github.com/cern-fts/gfal2/archive/refs/tags/v2.16.4.tar.gz"
+    url = "https://github.com/cern-fts/gfal2/archive/refs/tags/v2.23.0.tar.gz"
 
     maintainers("wdconinc")
 

--- a/var/spack/repos/builtin/packages/gfal2/package.py
+++ b/var/spack/repos/builtin/packages/gfal2/package.py
@@ -16,7 +16,7 @@ class Gfal2(CMakePackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("2.16.4", sha256="977c808b3d6bdd60bd996909ea8d63af8b1e26a13f4fa0c1d935dd851dab136f")
+    version("2.23.0", sha256="e3fc9c2ccb2f54b1d0d460545e1b6c581470d2a2968928a8973045089892e509")
 
     variant("dcap", default=False, description="Enable dcap plugin")
     variant("file", default=False, description="Enable file plugin")

--- a/var/spack/repos/builtin/packages/gfal2/package.py
+++ b/var/spack/repos/builtin/packages/gfal2/package.py
@@ -32,6 +32,7 @@ class Gfal2(CMakePackage):
 
     depends_on("glib")
     depends_on("json-c")
+    depends_on("openldap")
 
     depends_on("dcap", when="+dcap")
     depends_on("zlib", when="+file")

--- a/var/spack/repos/builtin/packages/gfal2/package.py
+++ b/var/spack/repos/builtin/packages/gfal2/package.py
@@ -36,7 +36,7 @@ class Gfal2(CMakePackage):
 
     depends_on("dcap", when="+dcap")
     depends_on("zlib", when="+file")
-    depends_on("davix", when="+http")
+    depends_on("davix +thirdparty", when="+http")
     depends_on("cryptopp", when="+http")
     depends_on("libssh2", when="+sftp")
     depends_on("xrootd", when="+xrootd")

--- a/var/spack/repos/builtin/packages/gfal2/package.py
+++ b/var/spack/repos/builtin/packages/gfal2/package.py
@@ -57,6 +57,21 @@ class Gfal2(CMakePackage):
 
     depends_on("googletest", type="test")
 
+    def patch(self):
+        # FindCryptopp.cmake looks in user-specified ${CRYPTOPP_LOCATION}
+        # for both library and headers
+        filter_file(
+            r"find_library\(CRYPTOPP_LIBRARIES",
+            "find_library(CRYPTOPP_LIBRARIES PATH_SUFFIXES lib lib64",
+            "cmake/modules/FindCryptopp.cmake"
+        )
+        filter_file(
+            r"find_path\(CRYPTOPP_INCLUDE_DIRS",
+            "find_path(CRYPTOPP_INCLUDE_DIRS PATH_SUFFIXES include/cryptopp",
+            "cmake/modules/FindCryptopp.cmake"
+        )
+
+
     def cmake_args(self):
         args = [
             self.define("MAIN_CORE", True),
@@ -70,4 +85,8 @@ class Gfal2(CMakePackage):
             self.define_from_variant("PLUGIN_SRM", "srm"),
             self.define_from_variant("PLUGIN_XROOTD", "xrootd"),
         ]
+        if self.spec.satisfies("+http"):
+            args.append(self.define("CRYPTOPP_LOCATION", self.spec["cryptopp"].prefix))
+        if self.spec.satisfies("+xrootd"):
+            args.append(self.define("XROOTD_LOCATION", self.spec["xrootd"].prefix))
         return args

--- a/var/spack/repos/builtin/packages/globus-callout/package.py
+++ b/var/spack/repos/builtin/packages/globus-callout/package.py
@@ -6,23 +6,26 @@
 from spack.package import *
 
 
-class GlobusCommon(AutotoolsPackage):
+class GlobusCallout(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the Common Library Programs.
+    This package contains the Globus Callout Library - provides a
+    platform independent way of dealing with runtime loadable functions.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/common/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_common-18.14.tar.gz"
+    homepage = "https://github.com/gridcf/gct/tree/master/callout/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_callout-4.3.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("18.14", sha256="22368942a78e608d8fe6d9f7379abc628e2bd7af54a98c7d2bddc265d6f0ba45")
+    version("4.3", sha256="367e3fda18c3c3eb2b12496abc504186d0bfa0dadc666f626f580a443bba3000")
 
     depends_on("c", type="build")
+
+    depends_on("globus-common@15:")

--- a/var/spack/repos/builtin/packages/globus-common/package.py
+++ b/var/spack/repos/builtin/packages/globus-common/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class GlobusCommon(AutotoolsPackage):
+    """Common aspects of the Grid Community Toolkit, based on a fork
+    of the Globus Toolkit."""
+
+    homepage = "https://github.com/gridcf/gct/tree/master/common/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_common-18.14.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("18.14", sha256="22368942a78e608d8fe6d9f7379abc628e2bd7af54a98c7d2bddc265d6f0ba45")
+
+    depends_on("c", type="build")

--- a/var/spack/repos/builtin/packages/globus-ftp-client/package.py
+++ b/var/spack/repos/builtin/packages/globus-ftp-client/package.py
@@ -6,24 +6,24 @@
 from spack.package import *
 
 
-class GlobusGssapiGsi(AutotoolsPackage):
+class GlobusFtpClient(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the GSSAPI library.
+    This package contains the GridFTP Client Library.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/gsi/gssapi/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_gssapi_gsi-14.20.tar.gz"
+    homepage = "https://github.com/gridcf/gct/tree/master/gridftp/client/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_ftp_client-9.8.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("14.20", sha256="2ba4e905f1dbbbee8ade01a6d0d59a9b5e816620fe5b080de0524b5331614236")
+    version("9.8", sha256="aa83229f70352e106fc29f28cef4fc8fdab37c794603e7b425f193d947e5926c")
 
     depends_on("c", type="build")
 
@@ -31,15 +31,13 @@ class GlobusGssapiGsi(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("awk", type="build")
 
     depends_on("openssl")
-
-    depends_on("globus-common@14:")
-    depends_on("globus-openssl-module@3:")
-    depends_on("globus-gsi-openssl-error@2:")
-    depends_on("globus-gsi-cert-utils@8:")
-    depends_on("globus-gsi-credential@5:")
+    depends_on("globus-common@15:")
+    depends_on("globus-ftp-control@4:")
     depends_on("globus-gsi-callback@4:")
-    depends_on("globus-gsi-proxy-core@8:")
-    depends_on("globus-gsi-sysconfig@8:")
+    depends_on("globus-gsi-credential@5:")
+    depends_on("globus-gsi-sysconfig@5:")
+    depends_on("globus-gssapi-gsi@10:")
+    depends_on("globus-xio@3:")
+    depends_on("globus-xio-popen-driver@2:")

--- a/var/spack/repos/builtin/packages/globus-ftp-control/package.py
+++ b/var/spack/repos/builtin/packages/globus-ftp-control/package.py
@@ -6,24 +6,24 @@
 from spack.package import *
 
 
-class GlobusGssapiGsi(AutotoolsPackage):
+class GlobusFtpControl(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the GSSAPI library.
+    This package contains the GridFTP Control Library.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/gsi/gssapi/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_gssapi_gsi-14.20.tar.gz"
+    homepage = "https://github.com/gridcf/gct/tree/master/gridftp/control/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_ftp_control-9.7.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("14.20", sha256="2ba4e905f1dbbbee8ade01a6d0d59a9b5e816620fe5b080de0524b5331614236")
+    version("9.10", sha256="86677b4aef54b32bcdc11bb48d63f0a30ee520c8aa60e1f0f51d6cd671ee4010")
 
     depends_on("c", type="build")
 
@@ -31,15 +31,10 @@ class GlobusGssapiGsi(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("awk", type="build")
-
-    depends_on("openssl")
 
     depends_on("globus-common@14:")
-    depends_on("globus-openssl-module@3:")
-    depends_on("globus-gsi-openssl-error@2:")
-    depends_on("globus-gsi-cert-utils@8:")
-    depends_on("globus-gsi-credential@5:")
-    depends_on("globus-gsi-callback@4:")
-    depends_on("globus-gsi-proxy-core@8:")
-    depends_on("globus-gsi-sysconfig@8:")
+    depends_on("globus-gss-assist@11:")
+    depends_on("globus-gssapi-gsi@13:")
+    depends_on("globus-io@11:")
+    depends_on("globus-xio@3:")
+    depends_on("globus-gssapi-error@4:")

--- a/var/spack/repos/builtin/packages/globus-gass-copy/package.py
+++ b/var/spack/repos/builtin/packages/globus-gass-copy/package.py
@@ -6,23 +6,32 @@
 from spack.package import *
 
 
-class GlobusCommon(AutotoolsPackage):
+class GlobusGassCopy(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the Common Library Programs.
+    This package contains the Globus Gass Copy Programs.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/common/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_common-18.14.tar.gz"
+    homepage = "https://github.com/gridcf/gct/tree/master/gass/copy/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_gass_copy-10.13.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("18.14", sha256="22368942a78e608d8fe6d9f7379abc628e2bd7af54a98c7d2bddc265d6f0ba45")
+    version("10.13", sha256="f8b301b99de8f236733486767409d952024e16ff44ccfa8627063eefcbc8fe45")
 
     depends_on("c", type="build")
+
+    depends_on("globus-common@15:")
+    depends_on("globus-ftp-client@7:")
+    depends_on("globus-ftp-control@4:")
+    depends_on("globus-gsi-sysconfig@4:")
+    depends_on("globus-gass-transfer@7:")
+    depends_on("globus-io@8:")
+    depends_on("globus-gssapi-gsi@9:")
+    depends_on("globus-gssapi-error@4:")

--- a/var/spack/repos/builtin/packages/globus-gass-transfer/package.py
+++ b/var/spack/repos/builtin/packages/globus-gass-transfer/package.py
@@ -6,23 +6,33 @@
 from spack.package import *
 
 
-class GlobusCommon(AutotoolsPackage):
+class GlobusGassTransfer(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the Common Library Programs.
+    This package contains the  Globus Gass Transfer.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/common/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_common-18.14.tar.gz"
+    homepage = "https://github.com/gridcf/gct/blob/master/gass/transfer/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_gass_transfer-9.4.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("18.14", sha256="22368942a78e608d8fe6d9f7379abc628e2bd7af54a98c7d2bddc265d6f0ba45")
+    version("9.4", sha256="c5ad54d0e4959f7dc4131918ad9d40d49db2823b84aec8229127826a9601fbf9")
 
     depends_on("c", type="build")
+
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
+
+    depends_on("globus-common@14:")
+    depends_on("globus-gssapi-gsi@10:")
+    depends_on("globus-gss-assist@8:")
+    depends_on("globus-io@8:")

--- a/var/spack/repos/builtin/packages/globus-gsi-callback/package.py
+++ b/var/spack/repos/builtin/packages/globus-gsi-callback/package.py
@@ -6,23 +6,29 @@
 from spack.package import *
 
 
-class GlobusCommon(AutotoolsPackage):
+class GlobusGsiCallback(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the Common Library Programs.
+    This package contains the Globus GSI Callback Library.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/common/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_common-18.14.tar.gz"
+    homepage = "https://github.com/gridcf/gct/tree/master/gsi/callback/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_gsi_callback-6.2.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("18.14", sha256="22368942a78e608d8fe6d9f7379abc628e2bd7af54a98c7d2bddc265d6f0ba45")
+    version("6.2", sha256="ffac5435b7d3a78db3c1f856fbe41e7951d5f7d60df3af4ce8cf5b9e303a6f68")
 
     depends_on("c", type="build")
+
+    depends_on("globus-common@14:")
+    depends_on("globus-openssl-module@3:")
+    depends_on("globus-gsi-openssl-error@2:")
+    depends_on("globus-gsi-cert-utils@8:")
+    depends_on("globus-gsi-sysconfig@5:")

--- a/var/spack/repos/builtin/packages/globus-gsi-cert-utils/package.py
+++ b/var/spack/repos/builtin/packages/globus-gsi-cert-utils/package.py
@@ -6,23 +6,27 @@
 from spack.package import *
 
 
-class GlobusCommon(AutotoolsPackage):
+class GlobusGsiCertUtils(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the Common Library Programs.
+    This package contains the Globus GSI Cert Utils Library Programs.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/common/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_common-18.14.tar.gz"
+    homepage = "https://github.com/gridcf/gct/blob/master/gsi/cert_utils/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_gsi_cert_utils-10.11.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("18.14", sha256="22368942a78e608d8fe6d9f7379abc628e2bd7af54a98c7d2bddc265d6f0ba45")
+    version("10.11", sha256="0bcbef5e04feda1900407970e52e81ad94f68bceef35313f82c810ddb5bff6ba")
 
     depends_on("c", type="build")
+    depends_on("openssl@1:")
+    depends_on("globus-common@14:")
+    depends_on("globus-openssl-module@3:")
+    depends_on("globus-gsi-openssl-error@2:")

--- a/var/spack/repos/builtin/packages/globus-gsi-credential/package.py
+++ b/var/spack/repos/builtin/packages/globus-gsi-credential/package.py
@@ -6,23 +6,28 @@
 from spack.package import *
 
 
-class GlobusCommon(AutotoolsPackage):
+class GlobusGsiCredential(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the Common Library Programs.
+    This package contains the Globus GSI Credential Library.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/common/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_common-18.14.tar.gz"
+    homepage = "https://github.com/gridcf/gct/tree/master/gsi/credential/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_gsi_credential-8.4.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("18.14", sha256="22368942a78e608d8fe6d9f7379abc628e2bd7af54a98c7d2bddc265d6f0ba45")
+    version("8.4", sha256="19e8fde9d4b335d60a021ac58c7559e5c34981e9332a8e574eda0b44ec160fa7")
 
     depends_on("c", type="build")
+    depends_on("globus-common@14:")
+    depends_on("globus-gsi-openssl-error@2:")
+    depends_on("globus-gsi-cert-utils@8:")
+    depends_on("globus-gsi-sysconfig@5:")
+    depends_on("globus-gsi-callback@4:")

--- a/var/spack/repos/builtin/packages/globus-gsi-openssl-error/package.py
+++ b/var/spack/repos/builtin/packages/globus-gsi-openssl-error/package.py
@@ -6,23 +6,31 @@
 from spack.package import *
 
 
-class GlobusCommon(AutotoolsPackage):
+class GlobusGsiOpensslError(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the Common Library Programs.
+    This package contains the Globus OpenSSL Error Handling.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/common/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_common-18.14.tar.gz"
+    homepage = "https://github.com/gridcf/gct/blob/master/gsi/openssl_error/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_gsi_openssl_error-4.4.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("18.14", sha256="22368942a78e608d8fe6d9f7379abc628e2bd7af54a98c7d2bddc265d6f0ba45")
+    version("4.4", sha256="1879ff269154431700ed158a75acc6e10ca0c96af95d92bc2fa63b7fe998fa6e")
 
     depends_on("c", type="build")
+
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
+
+    depends_on("openssl@1:")
+    depends_on("globus-common@14:")

--- a/var/spack/repos/builtin/packages/globus-gsi-proxy-core/package.py
+++ b/var/spack/repos/builtin/packages/globus-gsi-proxy-core/package.py
@@ -6,24 +6,24 @@
 from spack.package import *
 
 
-class GlobusGssapiGsi(AutotoolsPackage):
+class GlobusGsiProxyCore(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the GSSAPI library.
+    This package contains the Globus GSI Proxy Core Library.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/gsi/gssapi/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_gssapi_gsi-14.20.tar.gz"
+    homepage = "https://github.com/gridcf/gct/blob/master/gsi/proxy/proxy_core/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_gsi_proxy_core-9.8.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("14.20", sha256="2ba4e905f1dbbbee8ade01a6d0d59a9b5e816620fe5b080de0524b5331614236")
+    version("9.8", sha256="b0865b298d96ffbf6963c0fcb14eb7fd311de67fb25890a677bd6ace13475da3")
 
     depends_on("c", type="build")
 
@@ -31,15 +31,12 @@ class GlobusGssapiGsi(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("awk", type="build")
 
-    depends_on("openssl")
-
+    depends_on("openssl@1:")
     depends_on("globus-common@14:")
     depends_on("globus-openssl-module@3:")
     depends_on("globus-gsi-openssl-error@2:")
     depends_on("globus-gsi-cert-utils@8:")
+    depends_on("globus-gsi-sysconfig@5:")
+    depends_on("globus-gsi-proxy-ssl@4:")
     depends_on("globus-gsi-credential@5:")
-    depends_on("globus-gsi-callback@4:")
-    depends_on("globus-gsi-proxy-core@8:")
-    depends_on("globus-gsi-sysconfig@8:")

--- a/var/spack/repos/builtin/packages/globus-gsi-proxy-ssl/package.py
+++ b/var/spack/repos/builtin/packages/globus-gsi-proxy-ssl/package.py
@@ -6,23 +6,25 @@
 from spack.package import *
 
 
-class GlobusCommon(AutotoolsPackage):
+class GlobusGsiProxySsl(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the Common Library Programs.
+    This package contains the Globus GSI Proxy SSL Library.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/common/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_common-18.14.tar.gz"
+    homepage = "https://github.com/gridcf/gct/tree/master/gsi/proxy/proxy_ssl/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_gsi_proxy_ssl-6.5.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("18.14", sha256="22368942a78e608d8fe6d9f7379abc628e2bd7af54a98c7d2bddc265d6f0ba45")
+    version("6.5", sha256="4f20042d80a1fe28b40d9f7f4a1fc9f2790645e9b3f426a659b0c3f01eb04259")
 
     depends_on("c", type="build")
+
+    depends_on("openssl@1:")

--- a/var/spack/repos/builtin/packages/globus-gsi-sysconfig/package.py
+++ b/var/spack/repos/builtin/packages/globus-gsi-sysconfig/package.py
@@ -6,23 +6,27 @@
 from spack.package import *
 
 
-class GlobusCommon(AutotoolsPackage):
+class GlobusGsiSysconfig(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the Common Library Programs.
+    This package contains the Globus GSI System Config Library.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/common/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_common-18.14.tar.gz"
+    homepage = "https://github.com/gridcf/gct/blob/master/gsi/sysconfig/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_gsi_sysconfig-9.6.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("18.14", sha256="22368942a78e608d8fe6d9f7379abc628e2bd7af54a98c7d2bddc265d6f0ba45")
+    version("9.6", sha256="7d843374eb64605dda206b84cad2a5c39a1bc9b18e9bfd93591c8fcb6d5a1a7a")
 
     depends_on("c", type="build")
+
+    depends_on("globus-common@15:")
+    depends_on("globus-openssl-module@e3:")
+    depends_on("globus-gsi-openssl-error@2:")

--- a/var/spack/repos/builtin/packages/globus-gss-assist/package.py
+++ b/var/spack/repos/builtin/packages/globus-gss-assist/package.py
@@ -6,24 +6,24 @@
 from spack.package import *
 
 
-class GlobusGssapiGsi(AutotoolsPackage):
+class GlobusGssAssist(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the GSSAPI library.
+    This package contains the GSSAPI Assist library Programs.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/gsi/gssapi/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_gssapi_gsi-14.20.tar.gz"
+    homepage = "https://github.com/gridcf/gct/blob/master/gsi/gss_assist/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_gss_assist-12.7.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("14.20", sha256="2ba4e905f1dbbbee8ade01a6d0d59a9b5e816620fe5b080de0524b5331614236")
+    version("12.7", sha256="5184e0f1a09a64651472f19b79101fc6d966056fd9e1ee29512e41f694eae759")
 
     depends_on("c", type="build")
 
@@ -31,15 +31,10 @@ class GlobusGssapiGsi(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("awk", type="build")
-
-    depends_on("openssl")
 
     depends_on("globus-common@14:")
-    depends_on("globus-openssl-module@3:")
-    depends_on("globus-gsi-openssl-error@2:")
+    depends_on("globus-gsi-sysconfig@7:")
     depends_on("globus-gsi-cert-utils@8:")
-    depends_on("globus-gsi-credential@5:")
-    depends_on("globus-gsi-callback@4:")
-    depends_on("globus-gsi-proxy-core@8:")
-    depends_on("globus-gsi-sysconfig@8:")
+    depends_on("globus-gssapi-gsi@13:")
+    depends_on("globus-callout@2:")
+    depends_on("globus-gsi-credential@6:")

--- a/var/spack/repos/builtin/packages/globus-gssapi-error/package.py
+++ b/var/spack/repos/builtin/packages/globus-gssapi-error/package.py
@@ -6,23 +6,32 @@
 from spack.package import *
 
 
-class GlobusCommon(AutotoolsPackage):
+class GlobusGssapiError(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the Common Library Programs.
+    This package contains the GSSAPI Error Library.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/common/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_common-18.14.tar.gz"
+    homepage = "https://github.com/gridcf/gct/blob/master/gsi/gssapi_error/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_gssapi_error-6.3.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("18.14", sha256="22368942a78e608d8fe6d9f7379abc628e2bd7af54a98c7d2bddc265d6f0ba45")
+    version("6.3", sha256="943261f337ca5547f0e4fed47c8beac14cb125837b265f152c216f9b068dabc4")
 
     depends_on("c", type="build")
+
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
+
+    depends_on("globus-common@14:")
+    depends_on("globus-gss-assist@8:")
+    depends_on("globus-gssapi-gsi@9:")

--- a/var/spack/repos/builtin/packages/globus-gssapi-gsi/package.py
+++ b/var/spack/repos/builtin/packages/globus-gssapi-gsi/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class GlobusGssapiGsi(AutotoolsPackage):
+    """The Grid Security Infrastructure, an implementation of an authentication
+    and authorization infrastructure based upon the concept of X509 proxy
+    certificates. The GSI packages include client and server code necessary
+    to create and verify proxies."""
+
+    homepage = "https://github.com/gridcf/gct/tree/master/gsi/gssapi/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_gssapi_gsi-14.20.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("14.20", sha256="2ba4e905f1dbbbee8ade01a6d0d59a9b5e816620fe5b080de0524b5331614236")
+
+    depends_on("c", type="build")
+
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
+    depends_on("awk", type="build")
+
+    depends_on("openssl")
+
+    depends_on("globus-common")

--- a/var/spack/repos/builtin/packages/globus-io/package.py
+++ b/var/spack/repos/builtin/packages/globus-io/package.py
@@ -17,7 +17,7 @@ class GlobusIo(AutotoolsPackage):
     datagram style communications.
     """
 
-    homepage = "https://www.example.com"
+    homepage = "https://github.com/gridcf/gct/tree/master/io/compat"
     url = "https://repo.gridcf.org/gct6/sources/globus_io-12.4.tar.gz"
 
     maintainers("wdconinc")

--- a/var/spack/repos/builtin/packages/globus-io/package.py
+++ b/var/spack/repos/builtin/packages/globus-io/package.py
@@ -6,24 +6,25 @@
 from spack.package import *
 
 
-class GlobusGssapiGsi(AutotoolsPackage):
+class GlobusIo(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the GSSAPI library.
+    This package contains the uniform I/O interface to stream and
+    datagram style communications.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/gsi/gssapi/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_gssapi_gsi-14.20.tar.gz"
+    homepage = "https://www.example.com"
+    url = "https://repo.gridcf.org/gct6/sources/globus_io-12.4.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("14.20", sha256="2ba4e905f1dbbbee8ade01a6d0d59a9b5e816620fe5b080de0524b5331614236")
+    version("12.4", sha256="992de8d1d6c1a0c4edccd798084b6a7f8b93155ba7ae110d836dc248a2f7005a")
 
     depends_on("c", type="build")
 
@@ -31,15 +32,10 @@ class GlobusGssapiGsi(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("awk", type="build")
-
-    depends_on("openssl")
 
     depends_on("globus-common@14:")
-    depends_on("globus-openssl-module@3:")
-    depends_on("globus-gsi-openssl-error@2:")
-    depends_on("globus-gsi-cert-utils@8:")
-    depends_on("globus-gsi-credential@5:")
-    depends_on("globus-gsi-callback@4:")
-    depends_on("globus-gsi-proxy-core@8:")
-    depends_on("globus-gsi-sysconfig@8:")
+    depends_on("globus-xio@3:")
+    depends_on("globus-gss-assist@8:")
+    depends_on("globus-gssapi-gsi@10:")
+    depends_on("globus-xio-gsi-driver@2:")
+    depends_on("globus-gssapi-error@4:")

--- a/var/spack/repos/builtin/packages/globus-openssl-module/package.py
+++ b/var/spack/repos/builtin/packages/globus-openssl-module/package.py
@@ -6,23 +6,27 @@
 from spack.package import *
 
 
-class GlobusCommon(AutotoolsPackage):
+class GlobusOpensslModule(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the Common Library Programs.
+    This package contains the Globus OpenSSL Module Wrapper.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/common/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_common-18.14.tar.gz"
+    homepage = "https://github.com/gridcf/gct/blob/master/gsi/openssl_module"
+    url = "https://repo.gridcf.org/gct6/sources/globus_openssl_module-5.2.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("18.14", sha256="22368942a78e608d8fe6d9f7379abc628e2bd7af54a98c7d2bddc265d6f0ba45")
+    version("5.2", sha256="6dfcbe4af7a23d16745946131da938181cee3adfe08504df4bb4ab3160c23467")
 
     depends_on("c", type="build")
+
+    depends_on("globus-common@14:")
+    depends_on("globus-gsi-proxy-ssl@4:")
+    depends_on("globus-gsi-openssl-error@2:")

--- a/var/spack/repos/builtin/packages/globus-xio-gsi-driver/package.py
+++ b/var/spack/repos/builtin/packages/globus-xio-gsi-driver/package.py
@@ -6,23 +6,34 @@
 from spack.package import *
 
 
-class GlobusCommon(AutotoolsPackage):
+class GlobusXioGsiDriver(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the Common Library Programs.
+    This package contains the Globus XIO GSI Driver.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/common/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_common-18.14.tar.gz"
+    homepage = "https://github.com/gridcf/gct/blob/master/xio/drivers/gsi"
+    url = "https://repo.gridcf.org/gct6/sources/globus_xio_gsi_driver-5.4.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("18.14", sha256="22368942a78e608d8fe6d9f7379abc628e2bd7af54a98c7d2bddc265d6f0ba45")
+    version("5.4", sha256="9a28f8da77efbd8560bcfacdd514f81f5653d1c612d7fe3c479e52a4c8c1ed76")
 
     depends_on("c", type="build")
+
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
+
+    depends_on("globus-common@14:")
+    depends_on("globus-gssapi-gsi@13:")
+    depends_on("globus-gssapi-error@4:")
+    depends_on("globus-gss-assist@11:")
+    depends_on("globus-xio@3:")

--- a/var/spack/repos/builtin/packages/globus-xio-pipe-driver/package.py
+++ b/var/spack/repos/builtin/packages/globus-xio-pipe-driver/package.py
@@ -6,23 +6,26 @@
 from spack.package import *
 
 
-class GlobusCommon(AutotoolsPackage):
+class GlobusXioPipeDriver(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the Common Library Programs.
+    This package contains the Globus Pipe Driver.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/common/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_common-18.14.tar.gz"
+    homepage = "https://github.com/gridcf/gct/blob/master/xio/drivers/pipe/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_xio_pipe_driver-4.1.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("18.14", sha256="22368942a78e608d8fe6d9f7379abc628e2bd7af54a98c7d2bddc265d6f0ba45")
+    version("4.1", sha256="90860e3bf7c66791f873f488b3b31892d386ac9d73dd4bb366ae8d39fd16ba66")
 
     depends_on("c", type="build")
+
+    depends_on("globus-common@14:")
+    depends_on("globus-xio@3:")

--- a/var/spack/repos/builtin/packages/globus-xio-popen-driver/package.py
+++ b/var/spack/repos/builtin/packages/globus-xio-popen-driver/package.py
@@ -6,23 +6,28 @@
 from spack.package import *
 
 
-class GlobusCommon(AutotoolsPackage):
+class GlobusXioPopenDriver(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the Common Library Programs.
+    This package contains the Globus XIO Pipe Open Driver, which allows
+    a user to execute a program and treat it as a transport driver by
+    routing data through pipes.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/common/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_common-18.14.tar.gz"
+    homepage = "https://github.com/gridcf/gct/blob/master/xio/drivers/popen/source"
+    url = "https://repo.gridcf.org/gct6/sources/globus_xio_popen_driver-4.1.tar.gz"
 
-    maintainers("wdconinc")
+    maintainers("github_user1", "github_user2")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("18.14", sha256="22368942a78e608d8fe6d9f7379abc628e2bd7af54a98c7d2bddc265d6f0ba45")
+    version("4.1", sha256="6e9875c0d279511d8c476f71a46346712512284ade0623cd780c4e504908c110")
 
     depends_on("c", type="build")
+
+    depends_on("globus-common@14:")
+    depends_on("globus-xio@3:")

--- a/var/spack/repos/builtin/packages/globus-xio/package.py
+++ b/var/spack/repos/builtin/packages/globus-xio/package.py
@@ -6,23 +6,30 @@
 from spack.package import *
 
 
-class GlobusCommon(AutotoolsPackage):
+class GlobusXio(AutotoolsPackage):
     """The Grid Community Toolkit (GCT) is an open source software
     toolkit used for building grid systems and applications. It is a fork
     of the Globus Toolkit originally created by the Globus Alliance.
     It is supported by the Grid Community Forum (GridCF) that provides
     community-based support for core software packages in grid computing.
 
-    This package contains the Common Library Programs.
+    This package contains the Globus XIO Framework.
     """
 
-    homepage = "https://github.com/gridcf/gct/tree/master/common/source"
-    url = "https://repo.gridcf.org/gct6/sources/globus_common-18.14.tar.gz"
+    homepage = "https://github.com/gridcf/gct/blob/master/xio/src"
+    url = "https://repo.gridcf.org/gct6/sources/globus_xio-6.6.tar.gz"
 
     maintainers("wdconinc")
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("18.14", sha256="22368942a78e608d8fe6d9f7379abc628e2bd7af54a98c7d2bddc265d6f0ba45")
+    version("6.6", sha256="2ea379df7c2f918a05902bf3e9347667bb172c4893e819913f7975e9e89205fc")
 
     depends_on("c", type="build")
+
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
+
+    depends_on("globus-common@14:")

--- a/var/spack/repos/builtin/packages/srm-ifce/package.py
+++ b/var/spack/repos/builtin/packages/srm-ifce/package.py
@@ -34,5 +34,6 @@ class SrmIfce(CMakePackage):
     def cmake_args(self):
         args = [
             self.define("UNIT_TESTS", self.run_tests),
+            self.define("CGSI_GSOAP_LOCATION", self.spec["cgsi-gsoap"].prefix.lib64),
         ]
         return args

--- a/var/spack/repos/builtin/packages/srm-ifce/package.py
+++ b/var/spack/repos/builtin/packages/srm-ifce/package.py
@@ -1,0 +1,38 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class SrmIfce(CMakePackage):
+    """Client side implementation of the SRMv2 specification."""
+
+    homepage = "https://dmc-docs.web.cern.ch/dmc-docs/srm-ifce.html"
+    url = "https://github.com/cern-fts/srm-ifce/archive/refs/tags/v1.24.4.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("1.24.4", sha256="1a4b937e4ecf04e34106eb4652e18beb3e6fc81ba9c815f6d9b21e07a8a12b1e")
+
+    depends_on("c", type="build")
+
+    depends_on("glib")
+    depends_on("gsoap")
+    depends_on("cgsi-gsoap")
+    depends_on("globus-cmmon")
+    depends_on("globus-gsi-cert-utils")
+    depends_on("globus-gsi-credential")
+    depends_on("globus-gss-assist")
+    depends_on("globus-gssapi-gsi")
+    depends_on("globus-openssl")
+    depends_on("openssl")
+
+    def cmake_args(self):
+        args = [
+            self.define("UNIT_TESTS", self.run_tests),
+        ]
+        return args

--- a/var/spack/repos/builtin/packages/srm-ifce/package.py
+++ b/var/spack/repos/builtin/packages/srm-ifce/package.py
@@ -23,12 +23,12 @@ class SrmIfce(CMakePackage):
     depends_on("glib")
     depends_on("gsoap")
     depends_on("cgsi-gsoap")
-    depends_on("globus-cmmon")
+    depends_on("globus-common")
     depends_on("globus-gsi-cert-utils")
     depends_on("globus-gsi-credential")
     depends_on("globus-gss-assist")
     depends_on("globus-gssapi-gsi")
-    depends_on("globus-openssl")
+    depends_on("globus-openssl-module")
     depends_on("openssl")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/voms/package.py
+++ b/var/spack/repos/builtin/packages/voms/package.py
@@ -36,9 +36,7 @@ class Voms(AutotoolsPackage):
 
     def patch(self):
         filter_file(
-            r"/usr/bin/soapcpp2",
-            f"{self.spec['gsoap'].prefix.bin.soapcpp2}",
-            "m4/wsdl2h.m4"
+            r"/usr/bin/soapcpp2", f"{self.spec['gsoap'].prefix.bin.soapcpp2}", "m4/wsdl2h.m4"
         )
 
     def setup_build_environment(self, env):
@@ -52,7 +50,5 @@ class Voms(AutotoolsPackage):
         autogen()
 
     def configure_args(self):
-        args = [
-            f"--with-gsoap-wsdl2h={self.spec['gsoap'].prefix.bin.wsdl2h}"
-        ]
+        args = [f"--with-gsoap-wsdl2h={self.spec['gsoap'].prefix.bin.wsdl2h}"]
         return args

--- a/var/spack/repos/builtin/packages/voms/package.py
+++ b/var/spack/repos/builtin/packages/voms/package.py
@@ -1,0 +1,58 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Voms(AutotoolsPackage):
+    """The VOMS native service and APIs."""
+
+    homepage = "https://github.com/italiangrid/voms"
+    url = "https://github.com/italiangrid/voms/archive/refs/tags/v2.1.0.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("2.1.0", sha256="2fd2468620af531c02e9ac495aaaf2a8d5b8cfbe24d4904f2e8fa7f64cdeeeec")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
+    depends_on("pkgconfig", type="build")
+
+    depends_on("openssl")
+    depends_on("gsoap@2.7:")
+    depends_on("expat")
+    depends_on("zlib-api")
+
+    force_autoreconf = True
+
+    def patch(self):
+        filter_file(
+            r"/usr/bin/soapcpp2",
+            f"{self.spec['gsoap'].prefix.bin.soapcpp2}",
+            "m4/wsdl2h.m4"
+        )
+
+    def setup_build_environment(self, env):
+        # https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=voms
+        pkgconfig = Executable(join_path(self.spec["pkgconfig"].prefix.bin, "pkg-config"))
+        env.set("GSOAP_SSL_PP_CFLAGS", pkgconfig("--cflags", "gsoapssl++", "zlib", output=str))
+        env.set("GSOAP_SSL_PP_LIBS", pkgconfig("--libs", "gsoapssl++", "zlib", output=str))
+
+    def autoreconf(self, spec, prefix):
+        autogen = Executable("./autogen.sh")
+        autogen()
+
+    def configure_args(self):
+        args = [
+            f"--with-gsoap-wsdl2h={self.spec['gsoap'].prefix.bin.wsdl2h}"
+        ]
+        return args

--- a/var/spack/repos/builtin/packagesg/gfal2/package.py
+++ b/var/spack/repos/builtin/packagesg/gfal2/package.py
@@ -1,0 +1,71 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Gfal2(CMakePackage):
+    """Multi-protocol data management library."""
+
+    homepage = "https://dmc-docs.web.cern.ch/dmc-docs/"
+    url = "https://github.com/cern-fts/gfal2/archive/refs/tags/v2.16.4.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("2.16.4", sha256="977c808b3d6bdd60bd996909ea8d63af8b1e26a13f4fa0c1d935dd851dab136f")
+
+    variant("dcap", default=False, description="Enable dcap plugin")
+    variant("file", default=False, description="Enable file plugin")
+    variant("gridftp", default=False, description="Enable gridftp plugin")
+    variant("http", default=False, description="Enable http plugin")
+    variant("sftp", default=False, description="Enable sftp plugin")
+    variant("sftp", default=False, description="Enable sftp plugin")
+    variant("srm", default=False, description="Enable srm plugin")
+    variant("xrootd", default=False, description="Enable xrootd plugin")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    depends_on("glib")
+    depends_on("json-c")
+
+    depends_on("dcap", when="+dcap")
+    depends_on("zlib", when="+file")
+    depends_on("davix", when="+http")
+    depends_on("cryptopp", when="+http")
+    depends_on("libssh2", when="+sftp")
+    depends_on("xrootd", when="+xrootd")
+
+    with when("+gridftp"):
+        depends_on("globus-common")
+        depends_on("globus-ftp-client")
+        depends_on("globus-ftp-control")
+        depends_on("globus-gass-copy")
+        depends_on("globus-gss-assist")
+        depends_on("globus-gssapi-gsi")
+
+    with when("+srm"):
+        depends_on("globus-common")
+        depends_on("globus-gss-assist")
+        depends_on("globus-gssapi-gsi")
+        depends_on("srm-ifce")
+
+    depends_on("googletest", type="test")
+
+    def cmake_args(self):
+        args = [
+            self.define("MAIN_CORE", True),
+            self.define("MAIN_TRANSFER", True),
+            self.define("SKIP_TESTS", not self.run_tests),
+            self.define_from_variant("PLUGIN_DCAP", "dcap"),
+            self.define_from_variant("PLUGIN_FILE", "file"),
+            self.define_from_variant("PLUGIN_GRIDFTP", "gridftp"),
+            self.define_from_variant("PLUGIN_HTTP", "http"),
+            self.define_from_variant("PLUGIN_SFTP", "sftp"),
+            self.define_from_variant("PLUGIN_SRM", "srm"),
+        ]
+        return args


### PR DESCRIPTION
GFAL2 is a multi-protocol data management library developed by CERN and used for grid and cloud data transfers using a number of common protocols.

Test build for `gfal2 +dcap+file+gridftp+http+ipo+sftp+srm+xrootd`:
```
==> Installing gfal2-2.23.0-ia3yo46szjskrja3dixj6zsp3eauitoa [89/89]
==> No binary for gfal2-2.23.0-ia3yo46szjskrja3dixj6zsp3eauitoa found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/e3/e3fc9c2ccb2f54b1d0d460545e1b6c581470d2a2968928a8973045089892e509.tar.gz
==> Ran patch() for gfal2
==> gfal2: Executing phase: 'cmake'
==> gfal2: Executing phase: 'build'
==> gfal2: Executing phase: 'install'
==> gfal2: Successfully installed gfal2-2.23.0-ia3yo46szjskrja3dixj6zsp3eauitoa
  Stage: 0.02s.  Cmake: 1.65s.  Build: 26.78s.  Install: 0.15s.  Post-install: 0.23s.  Total: 29.04s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/gfal2-2.23.0-ia3yo46szjskrja3dixj6zsp3eauitoa
```