### PR TITLE
cryptopp: fix url

### DIFF
--- a/var/spack/repos/builtin/packages/cryptopp/package.py
+++ b/var/spack/repos/builtin/packages/cryptopp/package.py
@@ -13,8 +13,8 @@ class Cryptopp(MakefilePackage):
     public-key encryption (RSA, DSA), and a few obsolete/historical encryption
     algorithms (MD5, Panama)."""
 
-    homepage = "https://www.cryptopp.com"
-    url = "https://www.cryptopp.com/cryptopp700.zip"
+    homepage = "https://github.com/weidai11/cryptopp"
+    url = "https://github.com/weidai11/cryptopp/releases/download/CRYPTOPP_8_9_0/cryptopp890.zip"
 
     license("BSL-1.0")
 

--- a/var/spack/repos/builtin/packages/cryptopp/package.py
+++ b/var/spack/repos/builtin/packages/cryptopp/package.py
@@ -37,8 +37,7 @@ class Cryptopp(MakefilePackage):
     depends_on("gmake", type="build")
 
     def url_for_version(self, version):
-        url = "{0}/{1}{2}.zip"
-        return url.format(self.homepage, self.name, version.joined)
+        return f"https://github.com/weidai11/cryptopp/releases/download/CRYPTOPP_{version.underscored}/cryptopp{version.joined}.zip"
 
     def build(self, spec, prefix):
         cxx_flags = []

--- a/var/spack/repos/builtin/packages/cryptopp/package.py
+++ b/var/spack/repos/builtin/packages/cryptopp/package.py
@@ -14,7 +14,10 @@ class Cryptopp(MakefilePackage):
     algorithms (MD5, Panama)."""
 
     homepage = "https://github.com/weidai11/cryptopp"
-    url = "https://github.com/weidai11/cryptopp/releases/download/CRYPTOPP_8_9_0/cryptopp890.zip"
+    urls = [
+        "https://github.com/weidai11/cryptopp/releases/download/CRYPTOPP_8_9_0/cryptopp890.zip",
+        "https://www.cryptopp.com/cryptopp700.zip",
+    ]
 
     license("BSL-1.0")
 


### PR DESCRIPTION
The `cryptopp` homepage and download url have been offline for two months now. This PR adds the corresponding github project download url. I didn't go through and verified all versions, but I did verify that the last two are unchanged. Versions 7.0.0 and earlier are not uploaded as downloadable assets on github, so are not downloadable right now. 

We're not the only package managers affected, https://github.com/gentoo/gentoo/commit/bbde0bfe9453b81a8ba0abefd102bab7c3da8828.