### PR TITLE
genie: add v3.4.2

### DIFF
--- a/var/spack/repos/builtin/packages/genie/package.py
+++ b/var/spack/repos/builtin/packages/genie/package.py
@@ -22,6 +22,7 @@ class Genie(Package):
     maintainers("davehadley")
 
     version("master", branch="master")
+    version("3.4.2", sha256="c5935aea86d2ba9897ab55bb581622c561575957d19e572691d3bc0833ed9512")
     version("3.0.6", sha256="ab56ea85d0c1d09029254365bfe75a1427effa717389753b9e0c1b6c2eaa5eaf")
     version("3.0.4", sha256="53f034618fef9f7f0e17d1c4ed72743e4bba590e824b795177a1a8a8486c861e")
     version("3.0.2", sha256="34d6c37017b2387c781aea7bc727a0aac0ef45d6b3f3982cc6f3fc82493f65c3")
@@ -60,7 +61,9 @@ class Genie(Package):
     # GENIE Makefile's think that the spack compiler is invalid.
     # Disables this check.
     patch("genie_disable_gopt_with_compiler_check.patch", level=0, when="@2.11:")
-
+    patch("https://patch-diff.githubusercontent.com/raw/GENIE-MC/Generator/pull/376.patch?full_index=1",
+          sha256="7eca9bf44251cd99edd962483ca24c5072f8e2eee688f1e95b076425f2dc59f6",
+          when="@3.4.2")
     # Flags for GENIE"s optional but disabled by default features
     variant(
         "atmo", default=False, description="Enable GENIE Atmospheric neutrino event generation app"

--- a/var/spack/repos/builtin/packages/genie/package.py
+++ b/var/spack/repos/builtin/packages/genie/package.py
@@ -61,9 +61,11 @@ class Genie(Package):
     # GENIE Makefile's think that the spack compiler is invalid.
     # Disables this check.
     patch("genie_disable_gopt_with_compiler_check.patch", level=0, when="@2.11:")
-    patch("https://patch-diff.githubusercontent.com/raw/GENIE-MC/Generator/pull/376.patch?full_index=1",
-          sha256="7eca9bf44251cd99edd962483ca24c5072f8e2eee688f1e95b076425f2dc59f6",
-          when="@3.4.2")
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/GENIE-MC/Generator/pull/376.patch?full_index=1",
+        sha256="7eca9bf44251cd99edd962483ca24c5072f8e2eee688f1e95b076425f2dc59f6",
+        when="@3.4.2",
+    )
     # Flags for GENIE"s optional but disabled by default features
     variant(
         "atmo", default=False, description="Enable GENIE Atmospheric neutrino event generation app"


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Add Genie v3.4.2 to the build script. The build requests the [this patch](https://github.com/GENIE-MC/Generator/pull/376) to correctly identify that root has the `mathmore` feature flag turned on. 

Build successfully tested on Ubuntu 22.04. 