### PR TITLE
py-onnx: Make sure to build with c++17 if necessary

### DIFF
--- a/var/spack/repos/builtin/packages/py-onnx/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx/package.py
@@ -70,3 +70,16 @@ class PyOnnx(PythonPackage):
 
     # 'python_out' does not recognize dllexport_decl.
     patch("remove_dllexport_decl.patch", when="@:1.6.0")
+
+    # Switch the CMAKE_CXX_STANDARD to 17 if abseil-cpp has been built with
+    # either of those. (abseil-cpp is pulled in via protobuf)
+    patch(
+        "https://github.com/onnx/onnx/commit/1f6e43cb4d7366b2dffa7f70ae88198306e12c6c.patch?full_index=1",
+        sha256="be12f589bc4113982e4162efcdbd95835a6c161a9a7e10cd1dde026cadedf8aa",
+        when="@1.15.0 ^abseil-cpp cxxstd=17",
+    )
+    patch(
+        "https://github.com/onnx/onnx/commit/1f6e43cb4d7366b2dffa7f70ae88198306e12c6c.patch?full_index=1",
+        sha256="be12f589bc4113982e4162efcdbd95835a6c161a9a7e10cd1dde026cadedf8aa",
+        when="@1.15.0 ^abseil-cpp cxxstd=20",
+    )


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This patch is lifted (with small alterations from) #46390 and seems to have become necessary after #46434. Without this patch `py-onnx@1.15.0` can not be installed if `abseil-cpp` has been built with `cxxstd=17`.

Is there a way to specify the `when` clause only once?

