### PR TITLE
Enable 'compiler add/find' for /bin/gcc

### DIFF
--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -169,7 +169,7 @@ def executable_prefix(executable_dir: str) -> str:
         return executable_dir
     idx = lowered_components.index("bin")
     # Do not return an empty string if "bin" is found in the root directory
-    return os.sep.join(components[:idx]) if idx >1 else os.path.abspath(os.sep)
+    return os.sep.join(components[:idx]) if idx > 1 else os.path.abspath(os.sep)
 
 
 def library_prefix(library_dir: str) -> str:
@@ -190,13 +190,13 @@ def library_prefix(library_dir: str) -> str:
     if "lib64" in lowered_components:
         idx = lowered_components.index("lib64")
         # Do not return an empty string if "lib64" is found in the root directory
-        return os.sep.join(components[:idx]) if idx >1 else os.path.abspath(os.sep)
+        return os.sep.join(components[:idx]) if idx > 1 else os.path.abspath(os.sep)
     elif "lib" in lowered_components:
         idx = lowered_components.index("lib")
-        return os.sep.join(components[:idx]) if idx >1 else os.path.abspath(os.sep)
+        return os.sep.join(components[:idx]) if idx > 1 else os.path.abspath(os.sep)
     elif sys.platform == "win32" and "bin" in lowered_components:
         idx = lowered_components.index("bin")
-        return os.sep.join(components[:idx]) if idx >1 else os.path.abspath(os.sep)
+        return os.sep.join(components[:idx]) if idx > 1 else os.path.abspath(os.sep)
     else:
         return library_dir
 

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -168,7 +168,8 @@ def executable_prefix(executable_dir: str) -> str:
     if "bin" not in lowered_components:
         return executable_dir
     idx = lowered_components.index("bin")
-    return os.sep.join(components[:idx])
+    # Do not return an empty string if "bin" is found in the root directory
+    return os.sep.join(components[:idx]) if idx >1 else os.path.abspath(os.sep)
 
 
 def library_prefix(library_dir: str) -> str:
@@ -188,13 +189,14 @@ def library_prefix(library_dir: str) -> str:
     lowered_components = library_dir.lower().split(os.sep)
     if "lib64" in lowered_components:
         idx = lowered_components.index("lib64")
-        return os.sep.join(components[:idx])
+        # Do not return an empty string if "lib64" is found in the root directory
+        return os.sep.join(components[:idx]) if idx >1 else os.path.abspath(os.sep)
     elif "lib" in lowered_components:
         idx = lowered_components.index("lib")
-        return os.sep.join(components[:idx])
+        return os.sep.join(components[:idx]) if idx >1 else os.path.abspath(os.sep)
     elif sys.platform == "win32" and "bin" in lowered_components:
         idx = lowered_components.index("bin")
-        return os.sep.join(components[:idx])
+        return os.sep.join(components[:idx]) if idx >1 else os.path.abspath(os.sep)
     else:
         return library_dir
 

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -158,7 +158,7 @@ def components_to_path(components: List[str], idx: int) -> str:
         idx: Integer number of component entries to use.
     """
     assert idx >= 0
-    return os.sep.join(components[:idx]) if idx > 1 else os.path.abspath(os.sep)
+    return os.sep.join(components[:idx]) if idx > 0 else os.path.abspath(os.sep)
 
 
 def executable_prefix(executable_dir: str) -> str:

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -150,6 +150,17 @@ def _convert_to_iterable(single_val_or_multiple):
         return [x]
 
 
+def components_to_path(components: List[str], idx: int) -> str:
+    """Given a list of path components return the path using up to `idx` entries of `components`.
+    This functions makes sure to return the file system root instead of empty string if idx==0.
+    Args:
+        components: List of directory components
+        idx: Integer number of component entries to use.
+    """
+    assert idx >= 0
+    return os.sep.join(components[:idx]) if idx > 1 else os.path.abspath(os.sep)
+
+
 def executable_prefix(executable_dir: str) -> str:
     """Given a directory where an executable is found, guess the prefix
     (i.e. the "root" directory of that installation) and return it.
@@ -168,8 +179,7 @@ def executable_prefix(executable_dir: str) -> str:
     if "bin" not in lowered_components:
         return executable_dir
     idx = lowered_components.index("bin")
-    # Do not return an empty string if "bin" is found in the root directory
-    return os.sep.join(components[:idx]) if idx > 1 else os.path.abspath(os.sep)
+    return components_to_path(components, idx)
 
 
 def library_prefix(library_dir: str) -> str:
@@ -190,13 +200,13 @@ def library_prefix(library_dir: str) -> str:
     if "lib64" in lowered_components:
         idx = lowered_components.index("lib64")
         # Do not return an empty string if "lib64" is found in the root directory
-        return os.sep.join(components[:idx]) if idx > 1 else os.path.abspath(os.sep)
+        return components_to_path(components, idx)
     elif "lib" in lowered_components:
         idx = lowered_components.index("lib")
-        return os.sep.join(components[:idx]) if idx > 1 else os.path.abspath(os.sep)
+        return components_to_path(components, idx)
     elif sys.platform == "win32" and "bin" in lowered_components:
         idx = lowered_components.index("bin")
-        return os.sep.join(components[:idx]) if idx > 1 else os.path.abspath(os.sep)
+        return components_to_path(components, idx)
     else:
         return library_dir
 

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -158,7 +158,7 @@ def components_to_path(components: List[str], idx: int) -> str:
         idx: Integer number of component entries to use.
     """
     assert idx >= 0
-    return os.sep.join(components[:idx]) if idx > 0 else os.path.abspath(os.sep)
+    return os.sep.join(components[:idx]) if idx > 1 else os.path.abspath(os.sep)
 
 
 def executable_prefix(executable_dir: str) -> str:

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -150,17 +150,6 @@ def _convert_to_iterable(single_val_or_multiple):
         return [x]
 
 
-def components_to_path(components: List[str], idx: int) -> str:
-    """Given a list of path components return the path using up to `idx` entries of `components`.
-    This functions makes sure to return the file system root instead of empty string if idx==0.
-    Args:
-        components: List of directory components
-        idx: Integer number of component entries to use.
-    """
-    assert idx >= 0
-    return os.sep.join(components[:idx]) if idx > 1 else os.path.abspath(os.sep)
-
-
 def executable_prefix(executable_dir: str) -> str:
     """Given a directory where an executable is found, guess the prefix
     (i.e. the "root" directory of that installation) and return it.
@@ -179,7 +168,8 @@ def executable_prefix(executable_dir: str) -> str:
     if "bin" not in lowered_components:
         return executable_dir
     idx = lowered_components.index("bin")
-    return components_to_path(components, idx)
+    # Do not return an empty string if "bin" is found in the root directory
+    return os.sep.join(components[:idx]) if idx > 1 else os.path.abspath(os.sep)
 
 
 def library_prefix(library_dir: str) -> str:
@@ -200,13 +190,13 @@ def library_prefix(library_dir: str) -> str:
     if "lib64" in lowered_components:
         idx = lowered_components.index("lib64")
         # Do not return an empty string if "lib64" is found in the root directory
-        return components_to_path(components, idx)
+        return os.sep.join(components[:idx]) if idx > 1 else os.path.abspath(os.sep)
     elif "lib" in lowered_components:
         idx = lowered_components.index("lib")
-        return components_to_path(components, idx)
+        return os.sep.join(components[:idx]) if idx > 1 else os.path.abspath(os.sep)
     elif sys.platform == "win32" and "bin" in lowered_components:
         idx = lowered_components.index("bin")
-        return components_to_path(components, idx)
+        return os.sep.join(components[:idx]) if idx > 1 else os.path.abspath(os.sep)
     else:
         return library_dir
 

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -17,7 +17,6 @@ import spack.cray_manifest
 import spack.detection
 import spack.detection.path
 import spack.repo
-from spack.detection.common import components_to_path
 from spack.main import SpackCommand
 from spack.spec import Spec
 
@@ -71,13 +70,6 @@ def test_find_external_two_instances_same_package(mock_executable):
     assert spec_to_path[Spec("cmake@3.17.2")] == (
         spack.detection.executable_prefix(str(cmake2.parent))
     )
-
-
-def test_components_to_path(mock_executable):
-    components = ["foo", "bar"]
-    assert components_to_path(components, 2) == os.sep.join(["foo", "bar"])
-    assert components_to_path(components, 1) == os.sep.join(["foo"])
-    assert components_to_path(components, 0) == os.path.abspath(os.sep)
 
 
 def test_find_external_update_config(mutable_config):

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -17,6 +17,7 @@ import spack.cray_manifest
 import spack.detection
 import spack.detection.path
 import spack.repo
+from spack.detection.common import components_to_path
 from spack.main import SpackCommand
 from spack.spec import Spec
 
@@ -70,6 +71,13 @@ def test_find_external_two_instances_same_package(mock_executable):
     assert spec_to_path[Spec("cmake@3.17.2")] == (
         spack.detection.executable_prefix(str(cmake2.parent))
     )
+
+
+def test_components_to_path(mock_executable):
+    components = ["foo", "bar"]
+    assert components_to_path(components, 2) == os.sep.join(["foo", "bar"])
+    assert components_to_path(components, 1) == os.sep.join(["foo"])
+    assert components_to_path(components, 0) == os.path.abspath(os.sep)
 
 
 def test_find_external_update_config(mutable_config):

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -6,6 +6,7 @@
 """Tests for ``llnl/util/filesystem.py``"""
 import filecmp
 import os
+import pathlib
 import shutil
 import stat
 import sys
@@ -1054,4 +1055,5 @@ def test_windows_sfn(tmpdir):
 def test_truncate_path(input_path, input_args, expected, expected_truncated):
     result, truncated = fs.truncate_path(input_path, **input_args)
     assert truncated is expected_truncated
-    assert str(result) == expected
+    # Roundtrip to get the correct path separator on Windows
+    assert str(result) == str(pathlib.Path(expected))

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -1035,3 +1035,23 @@ def test_windows_sfn(tmpdir):
     assert "d\\LONGER~1" in fs.windows_sfn(d)
     assert "d\\LONGER~2" in fs.windows_sfn(e)
     shutil.rmtree(tmpdir.join("d"))
+
+
+@pytest.mark.parametrize(
+    "input_path,input_args,expected,expected_truncated",
+    [
+        ("/usr/bin", {"subdirs": ["bin"]}, "/usr", True),
+        ("/bin", {"subdirs": ["bin"]}, "/", True),
+        ("/bin", {"subdirs": ["lib"]}, "/bin", False),
+        # Test the case where more subdirs could match. We always pick the first match
+        ("/usr/bin/lib", {"subdirs": ["lib", "bin"]}, "/usr/bin", True),
+        ("/usr/bin/lib", {"subdirs": ["bin", "lib"]}, "/usr", True),
+        # Test case sensitivity
+        ("/usr/bin", {"subdirs": ["BIN"]}, "/usr", True),
+        ("/usr/bin", {"subdirs": ["BIN"], "case_insensitive": False}, "/usr/bin", False),
+    ],
+)
+def test_truncate_path(input_path, input_args, expected, expected_truncated):
+    result, truncated = fs.truncate_path(input_path, **input_args)
+    assert truncated is expected_truncated
+    assert str(result) == expected


### PR DESCRIPTION
`executable_prefix()` should not return an empty string if `bin` directory is found at the system root, e.g. `/bin` since `prefix_from_path()` uses that results in an `if` statement.

Fixes https://github.com/spack/spack/issues/46574
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
