### PR TITLE
py-rucio-clients: new package (and dependencies)

### DIFF
--- a/var/spack/repos/builtin/packages/py-argcomplete/package.py
+++ b/var/spack/repos/builtin/packages/py-argcomplete/package.py
@@ -12,6 +12,8 @@ class PyArgcomplete(PythonPackage):
     homepage = "https://github.com/kislyuk/argcomplete"
     pypi = "argcomplete/argcomplete-1.12.0.tar.gz"
 
+    version("3.5.0", sha256="4349400469dccfb7950bb60334a680c58d88699bff6159df61251878dc6bf74b")
+    version("3.1.6", sha256="3b1f07d133332547a53c79437527c00be48cca3807b1d4ca5cab1b26313386a6")
     version("3.1.2", sha256="d5d1e5efd41435260b8f85673b74ea2e883affcbec9f4230c582689e8e78251b")
     version("3.0.8", sha256="b9ca96448e14fa459d7450a4ab5a22bbf9cee4ba7adddf03e65c398b5daeea28")
     version("2.0.0", sha256="6372ad78c89d662035101418ae253668445b391755cfe94ea52f1b9d22425b20")

--- a/var/spack/repos/builtin/packages/py-dogpile-cache/package.py
+++ b/var/spack/repos/builtin/packages/py-dogpile-cache/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyDogpileCache(PythonPackage):
+    """dogpile.cache is a Python caching API which provides a generic
+    interface to caching backends of any variety."""
+
+    homepage = "https://dogpilecache.sqlalchemy.org/en/latest/"
+    pypi = "dogpile.cache/dogpile.cache-1.3.3.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("MIT", checked_by="wdconinc")
+
+    version("1.3.3", sha256="f84b8ed0b0fb297d151055447fa8dcaf7bae566d4dbdefecdcc1f37662ab588b")
+
+    depends_on("py-setuptools@61.2:", type="build")
+    depends_on("py-decorator@4.0.0:", type=("build", "run"))
+    depends_on("py-stevedore@3.0.0:", type=("build", "run"))
+    depends_on("py-typing-extensions@4.0.1:", type=("build", "run"), when="^python@:3.10")

--- a/var/spack/repos/builtin/packages/py-invoke/package.py
+++ b/var/spack/repos/builtin/packages/py-invoke/package.py
@@ -14,8 +14,10 @@ class PyInvoke(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("2.2.0", sha256="ee6cbb101af1a859c7fe84f2a264c059020b0cb7fe3535f9424300ab568f6bd5")
     version("1.4.1", sha256="de3f23bfe669e3db1085789fd859eb8ca8e0c5d9c20811e2407fa042e8a5e15d")
     version("1.2.0", sha256="dc492f8f17a0746e92081aec3f86ae0b4750bf41607ea2ad87e5a7b5705121b7")
 
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
+    depends_on("python@3.6:", type=("build", "run"), when="@2:")
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-jsonschema-specifications/package.py
+++ b/var/spack/repos/builtin/packages/py-jsonschema-specifications/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyJsonschemaSpecifications(PythonPackage):
+    """The JSON Schema meta-schemas and vocabularies, exposed as a Registry."""
+
+    homepage = "https://jsonschema-specifications.readthedocs.io/"
+    pypi = "jsonschema_specifications/jsonschema_specifications-2023.12.1.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("MIT", checked_by="wdconinc")
+
+    version("2023.12.1", sha256="48a76787b3e70f5ed53f1160d2b81f586e4ca6d1548c5de7085d1682674764cc")
+
+    depends_on("py-hatchling", type="build")
+    depends_on("py-hatch-vcs", type="build")
+
+    depends_on("py-referencing@0.31.0:", type=("build", "run"))
+    depends_on("py-importlib-resources@1.4.0:", type=("build", "run"), when="^python@:3.8")

--- a/var/spack/repos/builtin/packages/py-jsonschema/package.py
+++ b/var/spack/repos/builtin/packages/py-jsonschema/package.py
@@ -9,11 +9,16 @@ from spack.package import *
 class PyJsonschema(PythonPackage):
     """Jsonschema: An(other) implementation of JSON Schema for Python."""
 
-    homepage = "https://github.com/Julian/jsonschema"
+    homepage = "https://github.com/python-jsonschema/jsonschema"
     pypi = "jsonschema/jsonschema-3.2.0.tar.gz"
 
-    license("MIT")
+    license("MIT", checked_by="wdconinc")
 
+    version("4.22.0", sha256="5b22d434a45935119af990552c862e5d6d564e8f6601206b305a61fdf661a2b7")
+    version("4.21.1", sha256="85727c00279f5fa6bedbe6238d2aa6403bedd8b4864ab11207d07df3cc1b2ee5")
+    version("4.20.0", sha256="4f614fd46d8d61258610998997743ec5492a648b33cf478c1ddc23ed4598a5fa")
+    version("4.19.2", sha256="c9ff4d7447eed9592c23a12ccee508baf0dd0d59650615e847feb6cdca74f392")
+    version("4.18.6", sha256="ce71d2f8c7983ef75a756e568317bf54bc531dc3ad7e66a128eae0d51623d8a3")
     version("4.17.3", sha256="0f864437ab8b6076ba6707453ef8f98a6a0d512a80e93f8abdb676f737ecb60d")
     version("4.16.0", sha256="165059f076eff6971bae5b742fc029a7b4ef3f9bcf04c14e4776a7605de14b23")
     version("4.10.0", sha256="8ff7b44c6a99c6bfd55ca9ac45261c649cefd40aaba1124c29aaef1bcb378d84")
@@ -33,14 +38,17 @@ class PyJsonschema(PythonPackage):
         description="Enable format-nongpl functionality",
     )
 
+    depends_on("python@3.8:", when="@4.18:", type="build")
+
     depends_on("py-hatchling", when="@4.10:", type="build")
     depends_on("py-hatch-vcs", when="@4.10:", type="build")
     depends_on("py-hatch-fancy-pypi-readme", when="@4.11:", type="build")
 
     depends_on("py-attrs@17.4:", when="@3:", type=("build", "run"))
-    depends_on("py-pyrsistent@0.14:", when="@3:", type=("build", "run"))
-    depends_on("py-importlib-metadata", when="@3.1.1: ^python@:3.7", type=("build", "run"))
-    depends_on("py-typing-extensions", when="@4.3: ^python@:3.7", type=("build", "run"))
+    depends_on("py-attrs@22.2:", when="@4.18:", type=("build", "run"))
+    depends_on("py-jsonschema-specifications@2023.03.6:", when="@4.18:", type=("build", "run"))
+    depends_on("py-referencing@0.28.4:", when="@4.18:", type=("build", "run"))
+    depends_on("py-rpds-py@0.7.1:", when="@4.18:", type=("build", "run"))
     depends_on("py-importlib-resources@1.4:", when="@4.2.1: ^python@:3.8", type=("build", "run"))
     depends_on("py-importlib-resources", when="@4.2.0 ^python@:3.8", type=("build", "run"))
     depends_on("py-pkgutil-resolve-name@1.3.10:", when="@4.10.0: ^python@:3.8")
@@ -53,6 +61,9 @@ class PyJsonschema(PythonPackage):
     depends_on("py-setuptools-scm+toml@3.4:", when="@4.4.0", type="build")
     depends_on("py-setuptools-scm", when="@3", type="build")
     depends_on("py-six@1.11:", when="@3", type=("build", "run"))
+    depends_on("py-pyrsistent@0.14:", when="@3:4.17", type=("build", "run"))
+    depends_on("py-importlib-metadata", when="@3.1.1:4.17 ^python@:3.7", type=("build", "run"))
+    depends_on("py-typing-extensions", when="@4.3:4.17 ^python@:3.7", type=("build", "run"))
 
     conflicts("^py-pyrsistent@0.17.0:0.17.2")
 

--- a/var/spack/repos/builtin/packages/py-kerberos/package.py
+++ b/var/spack/repos/builtin/packages/py-kerberos/package.py
@@ -18,6 +18,7 @@ class PyKerberos(PythonPackage):
     homepage = "https://github.com/apple/ccs-pykerberos"
     pypi = "kerberos/kerberos-1.3.0.tar.gz"
 
+    version("1.3.1", sha256="cdd046142a4e0060f96a00eb13d82a5d9ebc0f2d7934393ed559bac773460a2c")
     version("1.3.0", sha256="f039b7dd4746df56f6102097b3dc250fe0078be75130b9dc4211a85a3b1ec6a4")
 
     depends_on("c", type="build")  # generated

--- a/var/spack/repos/builtin/packages/py-krb5/package.py
+++ b/var/spack/repos/builtin/packages/py-krb5/package.py
@@ -20,3 +20,4 @@ class PyKrb5(PythonPackage):
 
     depends_on("py-setuptools@42:", type="build")
     depends_on("py-cython@0.29.32:3", type=("build", "run"))
+    depends_on("krb5", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-krb5/package.py
+++ b/var/spack/repos/builtin/packages/py-krb5/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyKrb5(PythonPackage):
+    """Kerberos API bindings for Python."""
+
+    homepage = "https://github.com/jborean93/pykrb5"
+    pypi = "krb5/krb5-0.6.0.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("MIT", checked_by="wdconinc")
+
+    version("0.6.0", sha256="712ba092fbe3a28ec18820bb1b1ed2cc1037b75c5c7033f970c6a8c97bbd1209")
+
+    depends_on("py-setuptools@42:", type="build")
+    depends_on("py-cython@0.29.32:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-paramiko/package.py
+++ b/var/spack/repos/builtin/packages/py-paramiko/package.py
@@ -14,6 +14,12 @@ class PyParamiko(PythonPackage):
 
     license("LGPL-2.1-or-later")
 
+    version("3.4.0", sha256="aac08f26a31dc4dffd92821527d1682d99d52f9ef6851968114a8728f3c274d3")
+    version("3.3.1", sha256="6a3777a961ac86dbef375c5f5b8d50014a1a96d0fd7f054a43bc880134b0ff77")
+    version("3.3.0", sha256="ef639f5b97cf7bde57b6e1706e85b7e3f5561f632e180c6c155f53560ff1701b")
+    version("3.2.0", sha256="93cdce625a8a1dc12204439d45033f3261bdb2c201648cfcdc06f9fd0f94ec29")
+    version("3.1.0", sha256="6950faca6819acd3219d4ae694a23c7a87ee38d084f70c1724b0c0dbb8b75769")
+    version("3.0.0", sha256="fedc9b1dd43bc1d45f67f1ceca10bc336605427a46dcdf8dec6bfea3edf57965")
     version("2.12.0", sha256="376885c05c5d6aa6e1f4608aac2a6b5b0548b1add40274477324605903d9cd49")
     version("2.9.2", sha256="944a9e5dbdd413ab6c7951ea46b0ab40713235a9c4c5ca81cfe45c6f14fa677b")
     version("2.7.1", sha256="920492895db8013f6cc0179293147f830b8c7b21fdfc839b6bad760c27459d9f")
@@ -23,11 +29,15 @@ class PyParamiko(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     depends_on("py-bcrypt@3.1.3:", when="@2.7:", type=("build", "run"))
+    depends_on("py-bcrypt@3.2:", when="@3:", type=("build", "run"))
     depends_on("py-cryptography@1.1:", type=("build", "run"))
     depends_on("py-cryptography@2.5:", when="@2.7:", type=("build", "run"))
+    depends_on("py-cryptography@3.3:", when="@3:", type=("build", "run"))
     depends_on("py-pyasn1@0.1.7:", when="@:2.1", type=("build", "run"))
     depends_on("py-pynacl@1.0.1:", when="@2.7:", type=("build", "run"))
-    depends_on("py-six", when="@2.9.3:", type=("build", "run"))
+    depends_on("py-pynacl@1.5:", when="@3:", type=("build", "run"))
+    depends_on("py-six", when="@2.9.3:2", type=("build", "run"))
 
     depends_on("py-invoke@1.3:", when="+invoke", type=("build", "run"))
+    depends_on("py-invoke@2:", when="@3: +invoke", type=("build", "run"))
     conflicts("+invoke", when="@2.1.2")

--- a/var/spack/repos/builtin/packages/py-pyspnego/package.py
+++ b/var/spack/repos/builtin/packages/py-pyspnego/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPyspnego(PythonPackage):
+    """FIXME: Put a proper description of your package here."""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://www.example.com"
+    pypi = "pyspnego/pyspnego-0.11.1.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("UNKNOWN", checked_by="github_user1")
+
+    version("0.11.1", sha256="e92ed8b0a62765b9d6abbb86a48cf871228ddb97678598dc01c9c39a626823f6")
+
+    variant("kerberos", default=False, description="")
+
+    depends_on("py-setuptools@61:", type="build")
+    depends_on("py-cryptography", type=("build", "run"))
+    depends_on("py-sspilib", type=("build", "run"), when="platform=windows")
+
+    with when("+kerberos"):
+        depends_on("py-gssapi@1.6.0:", type=("build", "run"))
+        depends_on("py-krb5@0.3.0:", type=("build", "run"))
+    conflicts("+kerberos", when="platform=windows", msg="kerberos support unavailable on windows")

--- a/var/spack/repos/builtin/packages/py-pyspnego/package.py
+++ b/var/spack/repos/builtin/packages/py-pyspnego/package.py
@@ -7,19 +7,18 @@ from spack.package import *
 
 
 class PyPyspnego(PythonPackage):
-    """FIXME: Put a proper description of your package here."""
+    """Python SPNEGO authentication library."""
 
-    # FIXME: Add a proper url for your package's homepage here.
-    homepage = "https://www.example.com"
+    homepage = "https://github.com/jborean93/pyspnego"
     pypi = "pyspnego/pyspnego-0.11.1.tar.gz"
 
     maintainers("wdconinc")
 
-    license("UNKNOWN", checked_by="github_user1")
+    license("MIT", checked_by="wdconinc")
 
     version("0.11.1", sha256="e92ed8b0a62765b9d6abbb86a48cf871228ddb97678598dc01c9c39a626823f6")
 
-    variant("kerberos", default=False, description="")
+    variant("kerberos", default=False, description="Enable Kerberos authentication on Linux")
 
     depends_on("py-setuptools@61:", type="build")
     depends_on("py-cryptography", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-python-magic/package.py
+++ b/var/spack/repos/builtin/packages/py-python-magic/package.py
@@ -18,6 +18,7 @@ class PyPythonMagic(PythonPackage):
 
     license("MIT")
 
+    version("0.4.27", sha256="c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b")
     version("0.4.24", sha256="de800df9fb50f8ec5974761054a708af6e4246b03b4bdaee993f948947b0ebcf")
     version("0.4.15", sha256="f3765c0f582d2dfc72c15f3b5a82aecfae9498bd29ca840d72f37d7bd38bfcd5")
 

--- a/var/spack/repos/builtin/packages/py-python-swiftclient/package.py
+++ b/var/spack/repos/builtin/packages/py-python-swiftclient/package.py
@@ -14,6 +14,7 @@ class PyPythonSwiftclient(PythonPackage):
 
     maintainers("ajkotobi")
 
+    version("4.6.0", sha256="d4d18540413893fc16ad87791d740f823f763435e8212e68eb53d60da2638233")
     version("3.12.0", sha256="313b444a14d0f9b628cbf3e8c52f2c4271658f9e8a33d4222851c2e4f0f7b7a0")
     version("3.11.1", sha256="06919d59676d3e215f4da4f3f930d71880dda3528289842b25199509df712411")
     version("3.10.0", sha256="66227eaf29a691c70675fb9982022980b92797c273dd5e6dc7e680425e9a3634")
@@ -25,10 +26,13 @@ class PyPythonSwiftclient(PythonPackage):
     variant("keystone", default=False, description="Enable keystone authentication")
 
     depends_on("python@2.7:", type=("build", "run"))
+    depends_on("python@3.6:", type=("build", "run"), when="@4:")
     depends_on("py-setuptools", type="build")
     depends_on("py-pbr", type="build")
 
     depends_on("py-requests@1.1.0:", type=("build", "run"))
-    depends_on("py-six@1.9:", type=("build", "run"))
+    depends_on("py-requests@2.4.0:", type=("build", "run"), when="@4:")
 
     depends_on("py-python-keystoneclient@0.7.0:", when="+keystone", type=("build", "run"))
+
+    depends_on("py-six@1.9:", type=("build", "run"), when="@:3")

--- a/var/spack/repos/builtin/packages/py-referencing/package.py
+++ b/var/spack/repos/builtin/packages/py-referencing/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyReferencing(PythonPackage):
+    """JSON Referencing + Python."""
+
+    homepage = "https://referencing.readthedocs.io/"
+    pypi = "referencing/referencing-0.35.1.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("MIT", checked_by="wdconinc")
+
+    version("0.35.1", sha256="25b42124a6c8b632a425174f24087783efb348a6f1e0008e63cd4466fedf703c")
+
+    depends_on("py-hatchling", type="build")
+    depends_on("py-hatch-vcs", type="build")
+
+    depends_on("py-attrs@22.2.0:", type=("build", "run"))
+    depends_on("py-rpds-py@0.7.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-requests-kerberos/package.py
+++ b/var/spack/repos/builtin/packages/py-requests-kerberos/package.py
@@ -7,14 +7,14 @@ from spack.package import *
 
 
 class PyRequestsKerberos(PythonPackage):
-    """FIXME: Put a proper description of your package here."""
+    """An authentication handler for using Kerberos with Python Requests."""
 
-    homepage = "https://www.example.com"
+    homepage = "https://github.com/requests/requests-kerberos"
     pypi = "requests_kerberos/requests_kerberos-0.15.0.tar.gz"
 
     maintainers("wdconinc")
 
-    license("UNKNOWN", checked_by="github_user1")
+    license("ISC", checked_by="wdconinc")
 
     version("0.15.0", sha256="437512e424413d8113181d696e56694ffa4259eb9a5fc4e803926963864eaf4e")
 

--- a/var/spack/repos/builtin/packages/py-requests-kerberos/package.py
+++ b/var/spack/repos/builtin/packages/py-requests-kerberos/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyRequestsKerberos(PythonPackage):
+    """FIXME: Put a proper description of your package here."""
+
+    homepage = "https://www.example.com"
+    pypi = "requests_kerberos/requests_kerberos-0.15.0.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("UNKNOWN", checked_by="github_user1")
+
+    version("0.15.0", sha256="437512e424413d8113181d696e56694ffa4259eb9a5fc4e803926963864eaf4e")
+
+    depends_on("py-setuptools@61:", type="build")
+    depends_on("py-requests@1.1.0:", type=("build", "run"))
+    depends_on("py-cryptography@1.3:", type=("build", "run"))
+    depends_on("py-pyspnego +kerberos", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-rpds-py/package.py
+++ b/var/spack/repos/builtin/packages/py-rpds-py/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyRpdsPy(PythonPackage):
+    """Python bindings to the Rust rpds crate for persistent data structures."""
+
+    homepage = "https://rpds.readthedocs.io/"
+    pypi = "rpds_py/rpds_py-0.20.0.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("MIT", checked_by="wdconinc")
+
+    version("0.20.0", sha256="d72a210824facfdaf8768cf2d7ca25a042c30320b3020de2fa04640920d4e121")
+
+    depends_on("py-maturin@1.2:1", type="build")

--- a/var/spack/repos/builtin/packages/py-rucio-clients/package.py
+++ b/var/spack/repos/builtin/packages/py-rucio-clients/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyRucioClients(PythonPackage):
+    """Rucio Client Lite Package"""
+
+    homepage = "https://rucio.cern.ch/"
+    pypi = "rucio_clients/rucio_clients-35.4.0.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("35.4.0", sha256="f8771ee39d0d496109586ddbb4000ce006a193fd33cdac8a654661ae0b7346c0")
+
+    # requirements/requirements.client.txt
+    depends_on("python@3.9:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-requests@2.32.2:", type=("build", "run"))
+    depends_on("py-urllib3@1.26.18:", type=("build", "run"))
+    depends_on("py-dogpile-cache@1.2.2:", type=("build", "run"))
+    depends_on("py-tabulate@0.9.0:", type=("build", "run"))
+    depends_on("py-jsonschema@4.20.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-rucio-clients/package.py
+++ b/var/spack/repos/builtin/packages/py-rucio-clients/package.py
@@ -17,7 +17,7 @@ class PyRucioClients(PythonPackage):
     license("Apache-2.0", checked_by="wdconinc")
 
     version("35.4.0", sha256="f8771ee39d0d496109586ddbb4000ce006a193fd33cdac8a654661ae0b7346c0")
-    
+
     variant("ssh", default=False, description="Enable SSH2 protocol library")
     variant("kerberos", default=False, description="Enable kerberos authentication")
     variant("swift", default=False, description="Enable support for swift service")

--- a/var/spack/repos/builtin/packages/py-rucio-clients/package.py
+++ b/var/spack/repos/builtin/packages/py-rucio-clients/package.py
@@ -17,6 +17,12 @@ class PyRucioClients(PythonPackage):
     license("Apache-2.0", checked_by="wdconinc")
 
     version("35.4.0", sha256="f8771ee39d0d496109586ddbb4000ce006a193fd33cdac8a654661ae0b7346c0")
+    
+    variant("ssh", default=False, description="Enable SSH2 protocol library")
+    variant("kerberos", default=False, description="Enable kerberos authentication")
+    variant("swift", default=False, description="Enable support for swift service")
+    variant("argcomplete", default=False, description="Enable bash tab completion for argparse")
+    variant("dumper", default=False, description="Enable file type identification using libmagic")
 
     # requirements/requirements.client.txt
     depends_on("python@3.9:", type=("build", "run"))
@@ -26,3 +32,16 @@ class PyRucioClients(PythonPackage):
     depends_on("py-dogpile-cache@1.2.2:", type=("build", "run"))
     depends_on("py-tabulate@0.9.0:", type=("build", "run"))
     depends_on("py-jsonschema@4.20.0:", type=("build", "run"))
+
+    with when("+ssh"):
+        depends_on("py-paramiko@3.4.0:")
+    with when("+kerberos"):
+        depends_on("py-kerberos@1.3.1:")
+        depends_on("py-pykerberos@1.2.4:")
+        depends_on("py-requests-kerberos@0.14.0:")
+    with when("+swift"):
+        depends_on("py-python-swiftclient@4.4.0:")
+    with when("+argcomplete"):
+        depends_on("py-argcomplete@3.1.6:")
+    with when("+dumper"):
+        depends_on("py-python-magic@0.4.27:")

--- a/var/spack/repos/builtin/packages/py-sspilib/package.py
+++ b/var/spack/repos/builtin/packages/py-sspilib/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySspilib(PythonPackage):
+    """SSPI API bindings for Python."""
+
+    homepage = "https://github.com/jborean93/sspilibi"
+    pypi = "sspilib/sspilib-0.1.0.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("MIT", checked_by="wdconinc")
+
+    version("0.1.0", sha256="58b5291553cf6220549c0f855e0e6973f4977375d8236ce47bb581efb3e9b1cf")
+
+    depends_on("py-setuptools@61:", type="build")
+    depends_on("py-cython@3", type=("build", "run"))


### PR DESCRIPTION
This PR adds `py-rucio-client` which has a CLI to access Rucio data management servers (https://rucio.cern.ch/documentation/user/setting_up_the_rucio_client/).

Test builds (no variants):
```
==> Installing py-dogpile-cache-1.3.3-phru65kndwxiohlmdk6giyvrj44tjlwy [50/53]
==> No binary for py-dogpile-cache-1.3.3-phru65kndwxiohlmdk6giyvrj44tjlwy found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/d/dogpile.cache/dogpile.cache-1.3.3.tar.gz
==> No patches needed for py-dogpile-cache
==> py-dogpile-cache: Executing phase: 'install'
==> py-dogpile-cache: Successfully installed py-dogpile-cache-1.3.3-phru65kndwxiohlmdk6giyvrj44tjlwy
  Stage: 0.65s.  Install: 1.11s.  Post-install: 0.29s.  Total: 2.13s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-dogpile-cache-1.3.3-phru65kndwxiohlmdk6giyvrj44tjlwy
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-isoduration-20.11.0-rawtggb7iucpqt2zdr4w2iu3p2wcu5he
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-jsonschema-4.22.0-zmycuh26t2forijvxteovco6zhqjtec7
==> Installing py-rucio-clients-35.4.0-wbp4wze3eeedr42muvppfrjdgi5raj2k [53/53]
==> No binary for py-rucio-clients-35.4.0-wbp4wze3eeedr42muvppfrjdgi5raj2k found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/r/rucio_clients/rucio_clients-35.4.0.tar.gz
==> No patches needed for py-rucio-clients
==> py-rucio-clients: Executing phase: 'install'
==> py-rucio-clients: Successfully installed py-rucio-clients-35.4.0-wbp4wze3eeedr42muvppfrjdgi5raj2k
  Stage: 0.58s.  Install: 1.46s.  Post-install: 1.06s.  Total: 3.30s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-rucio-clients-35.4.0-wbp4wze3eeedr42muvppfrjdgi5raj2k
```