### PR TITLE
add libirc to intel-oneapi-runtime

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-runtime/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-runtime/package.py
@@ -29,6 +29,7 @@ class IntelOneapiRuntime(Package):
     LIBRARIES = [
         "imf",
         "intlc",
+        "irc",
         "irng",
         "svml",
         "ifcore",  # Fortran


### PR DESCRIPTION
Addresses issue noted by @stephenmsachs 
