### PR TITLE
developer-tools-ci: remove version constraint on Emacs

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/developer-tools-manylinux2014/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/developer-tools-manylinux2014/spack.yaml
@@ -10,7 +10,7 @@ spack:
       # editors
     - neovim~no_luajit
     - py-pynvim
-    - emacs@29.1+json+native+treesitter   # note, pulls in gcc
+    - emacs+json+native+treesitter   # note, pulls in gcc
       # - tree-sitter is a dep, should also have cli but no package
     - nano   # just in case
       # tags and scope search helpers


### PR DESCRIPTION
Remove the version constraint we had pinning an older version of `emacs` in the developer tools CI.

This will prevent future PRs like https://github.com/spack/spack/pull/46419.
