### PR TITLE
tmux: Fix MacOS header guard collison build bug

### DIFF
--- a/var/spack/repos/builtin/packages/tmux/package.py
+++ b/var/spack/repos/builtin/packages/tmux/package.py
@@ -64,6 +64,12 @@ class Tmux(AutotoolsPackage):
 
     conflicts("+static", when="platform=darwin", msg="Static build not supported on MacOS")
 
+    patch(
+        "https://github.com/tmux/tmux/commit/775789fbd5c4f3aa93061480cd64e61daf7fb689.patch?full_index=1",
+        sha256="c1b61a1244f758480578888d3f89cac470271c376ea0879996b81e10b397cad0",
+        when="@2.4:",
+    )
+
     @run_before("autoreconf")
     def autogen(self):
         if self.spec.satisfies("@master"):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Adds fix for tmux issue #4041: https://github.com/tmux/tmux/pull/4041

This allows for tmux to build on MacOS