### PR TITLE
Chapel 2.2 update

### DIFF
--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -442,9 +442,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     variant("cuda", default=False, sticky=True, description="Enable Nvidia CUDA GPU support")
 
     conflicts("+rocm", when="+cuda", msg="Chapel must be built with either CUDA or ROCm, not both")
-    conflicts(
-        "+rocm", when="@:1", msg="ROCm support in spack requires Chapel 2.0.0 or later"
-    )
+    conflicts("+rocm", when="@:1", msg="ROCm support in spack requires Chapel 2.0.0 or later")
     # Chapel restricts the allowable ROCm versions
     with when("@2:2.1 +rocm"):
         depends_on("hsa-rocr-dev@4:5.4")
@@ -576,7 +574,11 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     def setup_chpl_compilers(self, env):
         env.set("CHPL_HOST_COMPILER", self.compiler_map[self.spec.compiler.name])
-        if self.spec.satisfies("+rocm") or self.spec.satisfies("+cuda") or self.spec.satisfies("llvm=spack"):
+        if (
+            self.spec.satisfies("+rocm")
+            or self.spec.satisfies("+cuda")
+            or self.spec.satisfies("llvm=spack")
+        ):
             env.set("CHPL_TARGET_COMPILER", "llvm")
         else:
             env.set("CHPL_TARGET_COMPILER", self.compiler_map[self.spec.compiler.name])

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -618,7 +618,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         if not is_system_path(prefix):
             env.prepend_path("CPATH", prefix.include)
 
-    def set_lib_path(self, env, prefix):
+    def update_lib_path(self, env, prefix):
         if not is_system_path(prefix):
             env.prepend_path("LD_LIBRARY_PATH", prefix.lib)
             env.prepend_path("LIBRARY_PATH", prefix.lib)
@@ -657,10 +657,10 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             # TODO: why must we add to CPATH to find gmp.h
             # TODO: why must we add to LIBRARY_PATH to find lgmp
             self.prepend_cpath_include(env, self.spec["gmp"].prefix)
-            self.set_lib_path(env, self.spec["gmp"].prefix)
+            self.update_lib_path(env, self.spec["gmp"].prefix)
 
         if self.spec.variants["hwloc"].value == "spack":
-            self.set_lib_path(env, self.spec["hwloc"].prefix)
+            self.update_lib_path(env, self.spec["hwloc"].prefix)
             # Need this for the test env, where it does not appear automatic:
             env.prepend_path("PKG_CONFIG_PATH", self.spec["libpciaccess"].prefix.lib.pkgconfig)
 
@@ -673,18 +673,18 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         if self.spec.satisfies("+yaml"):
             self.prepend_cpath_include(env, self.spec["libyaml"].prefix)
             # could not compile test/library/packages/Yaml/writeAndParse.chpl without this
-            self.set_lib_path(env, self.spec["libyaml"].prefix)
+            self.update_lib_path(env, self.spec["libyaml"].prefix)
 
         if self.spec.satisfies("+zmq"):
             self.prepend_cpath_include(env, self.spec["libzmq"].prefix)
             # could not compile test/library/packages/ZMQ/hello.chpl without this
-            self.set_lib_path(env, self.spec["libzmq"].prefix)
+            self.update_lib_path(env, self.spec["libzmq"].prefix)
             env.prepend_path("PKG_CONFIG_PATH", self.spec["libsodium"].prefix.lib.pkgconfig)
 
         if self.spec.satisfies("+curl"):
             self.prepend_cpath_include(env, self.spec["curl"].prefix)
             # could not compile test/library/packages/Curl/check-http.chpl without this
-            self.set_lib_path(env, self.spec["curl"].prefix)
+            self.update_lib_path(env, self.spec["curl"].prefix)
 
         if self.spec.satisfies("+cuda"):
             # TODO: why must we add to LD_LIBRARY_PATH to find libcudart?
@@ -698,8 +698,8 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             env.set("CHPL_GPU_ARCH", self.spec.variants["amdgpu_target"].value[0])
             self.prepend_cpath_include(env, self.spec["hip"].prefix)
             env.set("CHPL_ROCM_PATH", self.spec["llvm-amdgpu"].prefix)
-            self.set_lib_path(env, self.spec["hip"].prefix)
-            self.set_lib_path(env, self.spec["hsa-rocr-dev"].prefix)
+            self.update_lib_path(env, self.spec["hip"].prefix)
+            self.update_lib_path(env, self.spec["hsa-rocr-dev"].prefix)
         self.setup_chpl_comm(env, self.spec)
 
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -442,10 +442,14 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         "+rocm", when="@:1", msg="ROCm support in spack requires Chapel 2.0.0 or later"
     )
     # Chapel restricts the allowable ROCm versions
-    with when("+rocm"):
+    with when("@2:2.1 +rocm"):
         depends_on("hsa-rocr-dev@4:5.4")
         depends_on("hip@4:5.4")
         depends_on("llvm-amdgpu@4:5.4")
+    with when("@2.2: +rocm"):
+        depends_on("hsa-rocr-dev@4:5.4,6.0:6.2")
+        depends_on("hip@4:5.4,6.0:6.2")
+        depends_on("llvm-amdgpu@4:5.4,6.0:6.2")
 
     conflicts(
         "comm_substrate=unset",

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -618,7 +618,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         symlink(self.spec["gasnet"].prefix.src, dst)
 
     def setup_if_not_unset(self, env, var, value):
-        if value != "unset":
+        if value != "unset" and var in self.chpl_env_vars:
             if value == "spack":
                 value = "system"
             env.set(var, value)

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -437,6 +437,10 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     conflicts("platform=windows")  # Support for windows is through WSL only
 
+    # Ensure GPU support is Sticky: never allow the concretizer to choose this
+    variant("rocm", default=False, sticky=True, description="Enable AMD ROCm GPU support")
+    variant("cuda", default=False, sticky=True, description="Enable Nvidia CUDA GPU support")
+
     conflicts("+rocm", when="+cuda", msg="Chapel must be built with either CUDA or ROCm, not both")
     conflicts(
         "+rocm", when="@:1", msg="ROCm support in spack requires Chapel 2.0.0 or later"

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -707,7 +707,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
             env.set("CHPL_GPU", "amd")
             env.set("CHPL_GPU_ARCH", self.spec.variants["amdgpu_target"].value[0])
             self.prepend_cpath_include(env, self.spec["hip"].prefix)
-            env.set("CHPL_ROCM_PATH", self.spec["llvm-amdgpu"].prefix)
+            env.set("CHPL_ROCM_PATH", self.spec["hip"].prefix)
             self.update_lib_path(env, self.spec["hip"].prefix)
             self.update_lib_path(env, self.spec["hsa-rocr-dev"].prefix)
         self.setup_chpl_comm(env, self.spec)

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -631,7 +631,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         # variants that appear unused by Spack typically correspond directly to
         # a CHPL_<variant> variable which will be used by the Chapel build system
         for v in self.spec.variants.keys():
-            self.setup_if_not_unset(env, "CHPL_" + v.upper(), self.spec.variants[v].value)
+            self.setup_if_not_unset(env, "CHPL_" + v.upper(), str(self.spec.variants[v].value))
         self.setup_chpl_compilers(env)
         self.setup_chpl_platform(env)
 

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -437,7 +437,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     conflicts("+rocm", when="+cuda", msg="Chapel must be built with either CUDA or ROCm, not both")
     conflicts(
-        "+rocm", when="@:1.99.99", msg="ROCm support in spack requires Chapel 2.0.0 or later"
+        "+rocm", when="@:1", msg="ROCm support in spack requires Chapel 2.0.0 or later"
     )
     # Chapel restricts the allowable ROCm versions
     with when("+rocm"):
@@ -463,7 +463,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     conflicts(
         "^python@3.12:",
-        when="@:2.0.99",
+        when="@:2.0",
         msg="Chapel versions prior to 2.1.0 may produce SyntaxWarnings with Python >= 3.12",
     )
 

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -36,7 +36,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     homepage = "https://chapel-lang.org/"
 
-    url = "https://github.com/chapel-lang/chapel/archive/refs/tags/2.1.0.tar.gz"
+    url = "https://github.com/chapel-lang/chapel/archive/refs/tags/2.2.0.tar.gz"
     git = "https://github.com/chapel-lang/chapel.git"
 
     test_requires_compiler = True
@@ -55,6 +55,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     version("main", branch="main")
 
+    version("2.2.0", sha256="9b0ce16ed0b1c777647c3aa852d8d8cacea2c3d8a952548a238f07c0f357a0f9")
     version("2.1.0", sha256="8e164d9a9e705e6b816857e84833b0922ce0bde6a36a9f3a29734830aac168ef")
     version("2.0.1", sha256="47e1f3789478ea870bd4ecdf52acbe469d171b89b663309325431f3da7c75008")
     version("2.0.0", sha256="a8cab99fd034c7b7229be8d4626ec95cf02072646fb148c74b4f48c460c6059c")
@@ -732,7 +733,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     @llnl.util.lang.memoized
     def _output_version_long(self):
         if str(self.spec.version).lower() == "main":
-            return "2.2.0"
+            return "2.3.0"
         spec_vers_str = str(self.spec.version.up_to(3))
         return spec_vers_str
 
@@ -740,7 +741,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     @llnl.util.lang.memoized
     def _output_version_short(self):
         if str(self.spec.version).lower() == "main":
-            return "2.2"
+            return "2.3"
         spec_vers_str = str(self.spec.version.up_to(2))
         return spec_vers_str
 

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -514,7 +514,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     # with an error about missing plugin-api.h
     depends_on("binutils+gold+ld+plugins+headers", when="llvm=bundled")
 
-    depends_on("m4")
+    depends_on("m4", when="gmp=bundled")
 
     # Runtime dependencies:
     # Note here "run" is run of the Chapel compiler built by this package,

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -691,6 +691,7 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
         if self.spec.satisfies("+cuda"):
             # TODO: why must we add to LD_LIBRARY_PATH to find libcudart?
             env.prepend_path("LD_LIBRARY_PATH", self.spec["cuda"].prefix.lib64)
+            env.set("CHPL_CUDA_PATH", self.spec["cuda"].prefix)
             env.set("CHPL_LOCALE_MODEL", "gpu")
             env.set("CHPL_GPU", "nvidia")
 

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -48,6 +48,8 @@ class Chapel(AutotoolsPackage, CudaPackage, ROCmPackage):
     # TODO: add chapel-project github account
     maintainers("arezaii", "bonachea")
 
+    tags = ["e4s"]
+
     # See https://spdx.org/licenses/ for a list.
     license("Apache-2.0")
 


### PR DESCRIPTION
This updates Chapel to version 2.2, released 9/26/2024. 

Changes in this PR include:
- add support for ROCm 6 
- add 'E4S' tag
- make GPU variant (cuda or rocm) sticky
- rename some functions based on previous reviewer feedback
- narrow 'm4' dep to gmp=bundled variant
- fix bug when generating module
- restrict env vars set by variant names to list of known chapel env var names