### PR TITLE
Fix #44560 - remove gcc oriented PATH / LD_LIBRARY_PATH additions from acfl package

### DIFF
--- a/var/spack/repos/builtin/packages/acfl/package.py
+++ b/var/spack/repos/builtin/packages/acfl/package.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os
 
 from spack.package import *
 
@@ -245,7 +244,6 @@ def get_acfl_prefix(spec):
         return join_path(spec.prefix, f"arm-linux-compiler-{spec.version}_{os}")
 
 
-
 def get_armpl_suffix(spec):
     suffix = ""
     if spec.satisfies("@24:"):
@@ -399,7 +397,6 @@ class Acfl(Package, CompilerPackage):
         env.append_path("LD_LIBRARY_PATH", join_path(armpl_dir, "lib"))
         env.prepend_path("LIBRARY_PATH", join_path(arm_dir, "lib"))
         env.prepend_path("MANPATH", join_path(arm_dir, "share", "man"))
-
 
     @run_after("install")
     def check_install(self):

--- a/var/spack/repos/builtin/packages/acfl/package.py
+++ b/var/spack/repos/builtin/packages/acfl/package.py
@@ -245,10 +245,6 @@ def get_acfl_prefix(spec):
         return join_path(spec.prefix, f"arm-linux-compiler-{spec.version}_{os}")
 
 
-def get_gcc_prefix(spec):
-    dirlist = next(os.walk(spec.prefix))[1]
-    return join_path(spec.prefix, next(dir for dir in dirlist if dir.startswith("gcc")))
-
 
 def get_armpl_suffix(spec):
     suffix = ""
@@ -393,7 +389,6 @@ class Acfl(Package, CompilerPackage):
     def setup_run_environment(self, env):
         arm_dir = get_acfl_prefix(self.spec)
         armpl_dir = get_armpl_prefix(self.spec)
-        gcc_dir = get_gcc_prefix(self.spec)
 
         env.set("ARM_LINUX_COMPILER_DIR", arm_dir)
         env.set("ARM_LINUX_COMPILER_INCLUDES", join_path(arm_dir, "includes"))
@@ -405,25 +400,12 @@ class Acfl(Package, CompilerPackage):
         env.prepend_path("LIBRARY_PATH", join_path(arm_dir, "lib"))
         env.prepend_path("MANPATH", join_path(arm_dir, "share", "man"))
 
-        env.set("GCC_DIR", gcc_dir)
-        env.set("GCC_INCLUDES", join_path(gcc_dir, "include"))
-        env.append_path("GCC_LIBRARIES", join_path(gcc_dir, "lib"))
-        env.append_path("GCC_LIBRARIES", join_path(gcc_dir, "lib64"))
-        env.set("COMPILER_PATH", gcc_dir)
-        env.prepend_path("PATH", join_path(gcc_dir, "binutils_bin"))
-        env.prepend_path("CPATH", join_path(gcc_dir, "include"))
-        env.prepend_path("LD_LIBRARY_PATH", join_path(gcc_dir, "lib"))
-        env.prepend_path("LD_LIBRARY_PATH", join_path(gcc_dir, "lib64"))
-        env.prepend_path("LIBRARY_PATH", join_path(gcc_dir, "lib"))
-        env.prepend_path("LIBRARY_PATH", join_path(gcc_dir, "lib64"))
-        env.prepend_path("MANPATH", join_path(gcc_dir, "share", "man"))
 
     @run_after("install")
     def check_install(self):
         arm_dir = get_acfl_prefix(self.spec)
         armpl_dir = get_armpl_prefix(self.spec)
         suffix = get_armpl_suffix(self.spec)
-        gcc_dir = get_gcc_prefix(self.spec)
         armpl_example_dir = join_path(armpl_dir, f"examples{suffix}")
         # run example makefile
         make(
@@ -432,7 +414,6 @@ class Acfl(Package, CompilerPackage):
             "CC=" + self.cc,
             "F90=" + self.fortran,
             "CPATH=" + join_path(arm_dir, "include"),
-            "COMPILER_PATH=" + gcc_dir,
             "ARMPL_DIR=" + armpl_dir,
         )
         # clean up


### PR DESCRIPTION
fixes #44560

@paolotricerri  

The acfl package has two roles: one is to install the Arm Compiler for Linux (ACfL) as a package that can be used by a 'spack compiler add', and the other is to link the co-bundled ArmPL library that is built for that ACfL and provides BLAS, LAPACK and FFTW virtuals.

The PATH/LD_LIBRARY_PATH is modified when using this spack acfl package to link in ArmPL to use a new GCC that is provided by ACfL rather than the system GCC and libstdc++.   When used on C++ codes that leads to the system libstdc++ being hard-rpath'd in, whereas the libstdc++ it built with is actually from the new GCC.  This leads to ABI issues as seen in #44560.  This was on GROMACS but also a handful of other C++ packages that use ArmPL (ie. acfl as the provider).

The fix here is to not set those PATH/LD_LIBRARY_PATH - using/linking the library does not need them.

Potentially when using the ACfL compiler those paths should be set - to avoid older distros with old 'ld' - but that is something the compiler should be wrapped in, not the library.

@spackbot fix style