### PR TITLE
DO NOT MERGE: Another Windows CI GL test

### DIFF
--- a/var/spack/repos/builtin/packages/zlib-ng/package.py
+++ b/var/spack/repos/builtin/packages/zlib-ng/package.py
@@ -37,7 +37,7 @@ class ZlibNg(AutotoolsPackage, CMakePackage):
     conflicts("+shared~pic")
 
     variant("new_strategies", default=True, description="Enable new deflate strategies")
-
+    variant("fake-variant", default=True, description="REMOVE ME")
     provides("zlib-api", when="+compat")
 
     # Default to autotools, since cmake would result in circular dependencies if it's not


### PR DESCRIPTION
Windows pipelines were failing consistently from 9/22 - 9/25 due to an apparent change in the gpg signature style, preventing the installation of any binaries from develop buildcaches. We are still investigating the cause, but #46567 allowed us to determine that specs that were regenerated during a build were able to be installed from the buildcache. This indicated intermediately signed binaries functioned, meaning we had a need to purge the buildcache, which was performed in the evening of 9/25. Initial develop pipelines are passing, however these delt with regenerated specs, so we have yet to see a case of using the reputationally signed binaries. 

This PR attempts to get ahead of any develop/other PR failures by forcing the use of the reputationally signed binaries.


**DO NOT MERGE THIS PR**
There should also be no need to review it, as, assuming GL passes, it will be closed.