### PR TITLE
docs: add --depth=2 to reduce download size

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ for examples and highlights.
 To install spack and your first package, make sure you have Python.
 Then:
 
-    $ git clone -c feature.manyFiles=true https://github.com/spack/spack.git
+    $ git clone -c feature.manyFiles=true --depth=2 https://github.com/spack/spack.git
     $ cd spack/bin
     $ ./spack install zlib
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,17 @@ See the
 [Feature Overview](https://spack.readthedocs.io/en/latest/features.html)
 for examples and highlights.
 
-To install spack and your first package, make sure you have Python.
+To install spack and your first package, make sure you have Python & Git.
 Then:
 
     $ git clone -c feature.manyFiles=true --depth=2 https://github.com/spack/spack.git
     $ cd spack/bin
     $ ./spack install zlib
+
+> [!TIP]
+> `-c feature.manyFiles=true` improves git's performance on repositories with 1,000+ files.
+>
+> `--depth=2` prunes the git history to reduce the size of the Spack installation.
 
 Documentation
 ----------------

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -61,7 +61,7 @@ Getting Spack is easy.  You can clone it from the `github repository
 
 .. code-block:: console
 
-   $ git clone -c feature.manyFiles=true https://github.com/spack/spack.git
+   $ git clone -c feature.manyFiles=true --depth=2 https://github.com/spack/spack.git
 
 This will create a directory called ``spack``.
 
@@ -1576,4 +1576,3 @@ The intent is to provide a Windows installer that will automatically set up
 Python, Git, and Spack, instead of requiring the user to do so manually.
 Instructions for creating the installer are at
 https://github.com/spack/spack/blob/develop/lib/spack/spack/cmd/installer/README.md
-

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -66,9 +66,9 @@ Getting Spack is easy.  You can clone it from the `github repository
 This will create a directory called ``spack``.
 
 .. note::
-   `-c feature.manyFiles=true` improves git's performance on repositories with 1,000+ files.
+   ``-c feature.manyFiles=true`` improves git's performance on repositories with 1,000+ files.
 
-   `--depth=2` prunes the git history to reduce the size of the Spack installation.
+   ``--depth=2`` prunes the git history to reduce the size of the Spack installation.
 
 .. _shell-support:
 

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -65,6 +65,11 @@ Getting Spack is easy.  You can clone it from the `github repository
 
 This will create a directory called ``spack``.
 
+.. note::
+   `-c feature.manyFiles=true` improves git's performance on repositories with 1,000+ files.
+
+   `--depth=2` prunes the git history to reduce the size of the Spack installation.
+
 .. _shell-support:
 
 ^^^^^^^^^^^^^

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -39,7 +39,7 @@ package:
 
 .. code-block:: console
 
-   $ git clone -c feature.manyFiles=true https://github.com/spack/spack.git
+   $ git clone -c feature.manyFiles=true --depth=2 https://github.com/spack/spack.git
    $ cd spack/bin
    $ ./spack install libelf
 

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -44,9 +44,9 @@ package:
    $ ./spack install libelf
 
 .. note::
-   `-c feature.manyFiles=true` improves git's performance on repositories with 1,000+ files.
+   ``-c feature.manyFiles=true`` improves git's performance on repositories with 1,000+ files.
 
-   `--depth=2` prunes the git history to reduce the size of the Spack installation.
+   ``--depth=2`` prunes the git history to reduce the size of the Spack installation.
 
 If you're new to spack and want to start using it, see :doc:`getting_started`,
 or refer to the full manual below.

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -43,6 +43,11 @@ package:
    $ cd spack/bin
    $ ./spack install libelf
 
+.. note::
+   `-c feature.manyFiles=true` improves git's performance on repositories with 1,000+ files.
+
+   `--depth=2` prunes the git history to reduce the size of the Spack installation.
+
 If you're new to spack and want to start using it, see :doc:`getting_started`,
 or refer to the full manual below.
 


### PR DESCRIPTION
Suggest that users download Spack with `--depth=2` to reduce download size and disk utilization.

In addition `--depth=2` implies,
- only download the develop branch
- setup lazy loading of objects in the case someone wants to checkout another branch

**Current:**
```
> git clone -c features.manyFiles=true https://github.com/spack/spack.git
Cloning into 'spack'...
remote: Enumerating objects: 581050, done.
remote: Counting objects: 100% (2645/2645), done.
remote: Compressing objects: 100% (1285/1285), done.
remote: Total 581050 (delta 1320), reused 2057 (delta 919), pack-reused 578405 (from 1)
Receiving objects: 100% (581050/581050), 197.57 MiB | 35.95 MiB/s, done.
Resolving deltas: 100% (272529/272529), done.
Updating files: 100% (11885/11885), done.
```

**Optimized:**
```
> git clone --depth=2 -c features.manyFiles=true https://github.com/spack/spack.git
Cloning into 'spack'...
remote: Enumerating objects: 20600, done.
remote: Counting objects: 100% (20600/20600), done.
remote: Compressing objects: 100% (11278/11278), done.
remote: Total 20600 (delta 1735), reused 14201 (delta 1460), pack-reused 0 (from 0)
Receiving objects: 100% (20600/20600), 14.27 MiB | 877.00 KiB/s, done.
Resolving deltas: 100% (1735/1735), done.
Updating files: 100% (11885/11885), done.
```
