### PR TITLE
Remove -ld_classic from all packages

### DIFF
--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -48,14 +48,6 @@ class Armadillo(CMakePackage):
     # platform's compiler is adding `#define linux 1`.
     patch("undef_linux.patch", when="platform=linux")
 
-    def flag_handler(self, name, flags):
-        spec = self.spec
-        if name == "ldflags":
-            if spec.satisfies("%apple-clang@15:"):
-                flags.append("-Wl,-ld_classic")
-
-        return (flags, None, None)
-
     def patch(self):
         # Do not include Find{BLAS_type} because we are specifying the
         # BLAS/LAPACK libraries explicitly.

--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -181,7 +181,6 @@ class Ffmpeg(AutotoolsPackage):
 
     @when("@:6.0 %apple-clang@15:")
     def setup_build_environment(self, env):
-        env.append_flags("LDFLAGS", "-Wl,-ld_classic")
         if self.spec.satisfies("@:3"):
             env.append_flags("CFLAGS", "-Wno-error=incompatible-function-pointer-types")
 

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -309,13 +309,9 @@ class Hdf5(CMakePackage):
                 cmake_flags.append(self.compiler.cc_pic_flag)
             if spec.satisfies("@1.8.21 %oneapi@2023.0.0"):
                 cmake_flags.append("-Wno-error=int-conversion")
-            if spec.satisfies("%apple-clang@15:"):
-                cmake_flags.append("-Wl,-ld_classic")
         elif name == "cxxflags":
             if spec.satisfies("@:1.8.12+cxx~shared"):
                 cmake_flags.append(self.compiler.cxx_pic_flag)
-            if spec.satisfies("%apple-clang@15:"):
-                cmake_flags.append("-Wl,-ld_classic")
         elif name == "fflags":
             if spec.satisfies("%cce+fortran"):
                 # Cray compiler generates module files with uppercase names by

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -1003,7 +1003,7 @@ class Openmpi(AutotoolsPackage, CudaPackage):
 
         # Work around incompatibility with new apple-clang linker
         # https://github.com/open-mpi/ompi/issues/12427
-        if spec.satisfies("@5: %apple-clang@15:"):
+        if spec.satisfies("@:4.1.6,5.0.0:5.0.3 %apple-clang@15:"):
             config_args.append("--with-wrapper-fcflags=-Wl,-ld_classic")
 
         # All rpath flags should be appended with self.compiler.cc_rpath_arg.

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -413,10 +413,7 @@ class PyNumpy(PythonPackage):
 
     @when("@1.26:")
     def setup_build_environment(self, env):
-        if self.spec.satisfies("%apple-clang@15:"):
-            # https://github.com/scipy/scipy/issues/19357
-            env.append_flags("LDFLAGS", "-Wl,-ld_classic")
-        elif self.spec.satisfies("%msvc"):
+        if self.spec.satisfies("%msvc"):
             # For meson build system, compiler paths must be in quotes
             # to prevent paths from being split by spaces.
             env.set("CC", f'"{self.compiler.cc}"')

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -218,10 +218,6 @@ class PyScipy(PythonPackage):
         if self.spec.satisfies("@:1.8"):
             self.spec["py-numpy"].package.setup_build_environment(env)
 
-        # https://github.com/scipy/scipy/issues/19357
-        if self.spec.satisfies("%apple-clang@15:"):
-            env.append_flags("LDFLAGS", "-Wl,-ld_classic")
-
     @when("@1.9:")
     def config_settings(self, spec, prefix):
         blas, lapack = self.spec["py-numpy"].package.blas_lapack_pkg_config()

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -679,10 +679,6 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
         else:
             env.set("BUILD_CUSTOM_PROTOBUF", "OFF")
 
-        # https://github.com/pytorch/pytorch/issues/111086
-        if self.spec.satisfies("%apple-clang@15:"):
-            env.append_flags("LDFLAGS", "-Wl,-ld_classic")
-
     def setup_run_environment(self, env):
         self.torch_cuda_arch_list(env)
 


### PR DESCRIPTION
Now that #46536 has been merged, the `-Wl,-ld_classic` hack is no longer needed. All packages have been tested and build successfully on macOS 15.0 with Apple Clang 16.0.0. The only exception is #46462, which still needs this treatment.