### PR TITLE
spec: shorten string formatting for concrete specs

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4016,8 +4016,12 @@ class Spec:
         return str(path_ctor(*output_path_components))
 
     def __str__(self):
+        if self._concrete:
+            return self.format("{name}{@version}{/hash:7}")
+
         if not self._dependencies:
             return self.format()
+
         root_str = [self.format()]
         sorted_dependencies = sorted(
             self.traverse(root=False), key=lambda x: (x.name, x.abstract_hash)

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -676,11 +676,13 @@ def test_build_manifest_visitor(tmpdir):
         assert all(os.path.islink(f) for f in visitor.symlinks)
 
 
-def test_text_relocate_if_needed(install_mockery, mock_fetch, monkeypatch, capfd):
-    spec = Spec("needs-text-relocation").concretized()
-    install_cmd(str(spec))
+def test_text_relocate_if_needed(install_mockery, temporary_store, mock_fetch, monkeypatch, capfd):
+    install_cmd("needs-text-relocation")
 
-    manifest = get_buildfile_manifest(spec)
+    specs = temporary_store.db.query("needs-text-relocation")
+    assert len(specs) == 1
+    manifest = get_buildfile_manifest(specs[0])
+
     assert join_path("bin", "exe") in manifest["text_to_relocate"]
     assert join_path("bin", "otherexe") not in manifest["text_to_relocate"]
     assert join_path("bin", "secretexe") not in manifest["text_to_relocate"]

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -933,14 +933,15 @@ spack:
 """
             )
         env_cmd("create", "test", "./spack.yaml")
-        with ev.read("test"):
-            concrete_spec = Spec("patchelf").concretized()
+        with ev.read("test") as current_env:
+            current_env.concretize()
+            install_cmd("--keep-stage")
+
+            concrete_spec = list(current_env.roots())[0]
             spec_json = concrete_spec.to_json(hash=ht.dag_hash)
             json_path = str(tmp_path / "spec.json")
             with open(json_path, "w") as ypfd:
                 ypfd.write(spec_json)
-
-            install_cmd("--add", "--keep-stage", json_path)
 
             for s in concrete_spec.traverse():
                 ci.push_to_build_cache(s, mirror_url, True)

--- a/lib/spack/spack/test/modules/conftest.py
+++ b/lib/spack/spack/test/modules/conftest.py
@@ -16,8 +16,10 @@ def modulefile_content(request):
     """Returns a function that generates the content of a module file as a list of lines."""
     writer_cls = getattr(request.module, "writer_cls")
 
-    def _impl(spec_str, module_set_name="default", explicit=True):
-        spec = spack.spec.Spec(spec_str).concretized()
+    def _impl(spec_like, module_set_name="default", explicit=True):
+        if isinstance(spec_like, str):
+            spec_like = spack.spec.Spec(spec_like)
+        spec = spec_like.concretized()
         generator = writer_cls(spec, module_set_name, explicit)
         generator.write(overwrite=True)
         written_module = pathlib.Path(generator.layout.filename)

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -388,7 +388,7 @@ class TestTcl:
 
         spec = spack.spec.Spec("mpileaks")
         spec.concretize()
-        content = modulefile_content(str(spec["callpath"]))
+        content = modulefile_content(spec["callpath"])
 
         assert len([x for x in content if "setenv FOOBAR" in x]) == 1
         assert len([x for x in content if "setenv FOOBAR {callpath}" in x]) == 1

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -715,13 +715,6 @@ class TestSpecSemantics:
     def test_spec_formatting(self, default_mock_concretization):
         spec = default_mock_concretization("multivalue-variant cflags=-O2")
 
-        # Since the default is the full spec see if the string rep of
-        # spec is the same as the output of spec.format()
-        # ignoring whitespace (though should we?) and ignoring dependencies
-        spec_string = str(spec)
-        idx = spec_string.index(" ^")
-        assert spec_string[:idx] == spec.format().strip()
-
         # Testing named strings ie {string} and whether we get
         # the correct component
         # Mixed case intentional to test both


### PR DESCRIPTION
This PR shorten the string representation for concrete specs, in order to make it more legible.

**Before**
```python
Spack version 0.23.0.dev0
Python 3.11.5, Linux x86_64
>>> from spack.spec import Spec
>>> str(Spec("hdf5").concretized())
'hdf5@=1.14.3%gcc@=10.5.0~cxx~fortran~hl~ipo~java~map+mpi+shared~subfiling~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches=82088c8 arch=linux-ubuntu20.04-icelake ^[deptypes=build] autoconf@=2.72%gcc@=10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build] automake@=1.16.5%gcc@=10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] berkeley-db@=18.1.40%gcc@=10.5.0+cxx~docs+stl build_system=autotools patches=26090f4,b231fcc arch=linux-ubuntu20.04-icelake ^[deptypes=build] bison@=3.8.2%gcc@=10.5.0~color build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build,link,run] bzip2@=1.0.8%gcc@=10.5.0~debug~pic+shared build_system=generic arch=linux-ubuntu20.04-icelake ^[deptypes=build] ca-certificates-mozilla@=2023-05-30%gcc@=10.5.0 build_system=generic arch=linux-ubuntu20.04-icelake ^[deptypes=build] cmake@=3.30.2%gcc@=10.5.0~doc+ncurses+ownlibs build_system=generic build_type=Release patches=dbc3892 arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] curl@=8.8.0%gcc@=10.5.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-ubuntu20.04-icelake ^[deptypes=build] diffutils@=3.10%gcc@=10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build,run] findutils@=4.9.0%gcc@=10.5.0 build_system=autotools patches=440b954 arch=linux-ubuntu20.04-icelake ^[deptypes=link virtuals=fortran-rt,libgfortran] gcc-runtime@=10.5.0%gcc@=10.5.0 build_system=generic arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] gdbm@=1.23%gcc@=10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] gettext@=0.22.5%gcc@=10.5.0+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=link virtuals=libc] glibc@=2.31%gcc@=10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] gmake@=4.4.1%gcc@=10.5.0~guile build_system=generic arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] hwloc@=2.11.1%gcc@=10.5.0~cairo~cuda~gl~libudev+libxml2~nvml~oneapi-level-zero~opencl+pci~rocm build_system=autotools libs=shared,static arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] krb5@=1.21.2%gcc@=10.5.0+shared build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] libedit@=3.1-20240808%gcc@=10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] libevent@=2.1.12%gcc@=10.5.0+openssl build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build,link virtuals=iconv] libiconv@=1.17%gcc@=10.5.0 build_system=autotools libs=shared,static arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] libpciaccess@=0.17%gcc@=10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] libsigsegv@=2.14%gcc@=10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build] libtool@=2.4.7%gcc@=10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=link] libxcrypt@=4.4.35%gcc@=10.5.0~obsolete_api build_system=autotools patches=4885da3 arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] libxml2@=2.10.3%gcc@=10.5.0+pic~python+shared build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build,run] m4@=1.4.19%gcc@=10.5.0+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] ncurses@=6.5%gcc@=10.5.0~symlinks+termlib abi=none build_system=autotools patches=7a351bc arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] nghttp2@=1.63.0%gcc@=10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] numactl@=2.0.18%gcc@=10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build,link virtuals=mpi] openmpi@=5.0.5%gcc@=10.5.0+atomics~cuda~debug~gpfs~internal-hwloc~internal-libevent~internal-pmix~java~lustre~memchecker~openshmem~romio+rsh~static+vt+wrapper-rpath build_system=autotools fabrics=none romio-filesystem=none schedulers=none arch=linux-ubuntu20.04-icelake ^[deptypes=run] openssh@=9.8p1%gcc@=10.5.0+gssapi build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] openssl@=3.3.1%gcc@=10.5.0~docs+shared build_system=generic certs=mozilla arch=linux-ubuntu20.04-icelake ^[deptypes=build,run] perl@=5.40.0%gcc@=10.5.0+cpanm+opcode+open+shared+threads build_system=generic arch=linux-ubuntu20.04-icelake ^[deptypes=run] pigz@=2.8%gcc@=10.5.0 build_system=makefile arch=linux-ubuntu20.04-icelake ^[deptypes=build,run virtuals=pkgconfig] pkgconf@=2.2.0%gcc@=10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] pmix@=5.0.3%gcc@=10.5.0~munge~python~restful build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build,link] readline@=8.2%gcc@=10.5.0 build_system=autotools patches=bbf97f1 arch=linux-ubuntu20.04-icelake ^[deptypes=run] tar@=1.34%gcc@=10.5.0 build_system=autotools zip=pigz arch=linux-ubuntu20.04-icelake ^[deptypes=build] util-macros@=1.20.1%gcc@=10.5.0 build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=build,link,run] xz@=5.4.6%gcc@=10.5.0~pic build_system=autotools libs=shared,static arch=linux-ubuntu20.04-icelake ^[deptypes=build,link virtuals=zlib-api] zlib-ng@=2.2.1%gcc@=10.5.0+compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-ubuntu20.04-icelake ^[deptypes=run] zstd@=1.5.6%gcc@=10.5.0+programs build_system=makefile compression=none libs=shared,static arch=linux-ubuntu20.04-icelake'
```

**After**
```python
Python 3.11.5, Linux x86_64
>>> from spack.spec import Spec
>>> str(Spec("hdf5").concretized())
'hdf5@1.14.3/s7xubt6'
```
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
