### PR TITLE
sbcl: new package

### DIFF
--- a/var/spack/repos/builtin/packages/sbcl-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/sbcl-bootstrap/package.py
@@ -36,25 +36,45 @@ class SbclBootstrap(Package):
     # By checking objdump -T of the sbcl binary in each prebuilt tarball, I
     # found the latest reference to glibc for each version.
     sbcl_releases = {
-        "2.3.11": {
-            "x86_64": "98784b04f68882b887984242eef73dbb092ec5c778dd536b2c60846715e03f3c",
-            "min_glibc": "2.34",
+        "2.4.0": {
+            "darwin": {"arm64": "1d01fac2d9748f769c9246a0a11a2c011d7843337f8f06ca144f5a500e10c117"}
         },
+        "2.3.11": {
+            "linux": {
+                "x86_64": "98784b04f68882b887984242eef73dbb092ec5c778dd536b2c60846715e03f3c",
+                "min_glibc": "2.34",
+            }
+        },
+        # TODO(ashermancinelli): I don't have a machine to test this on, but the binaries are
+        #                        available.
+        # "2.2.9": {
+        #     "darwin": {
+        #         "x86_64": "0000000000000000000000000000000000000000000000000000000000000000"
+        #     }
+        # },
         "2.0.11": {
-            "x86_64": "b7e61bc6b8d238f8878e660bc0635e99c2ea1255bfd6153d702fe9a00f8138fd",
-            "min_glibc": "2.28",
+            "linux": {
+                "x86_64": "b7e61bc6b8d238f8878e660bc0635e99c2ea1255bfd6153d702fe9a00f8138fd",
+                "min_glibc": "2.28",
+            }
         },
         "1.4.16": {
-            "x86_64": "df3d905d37656a7eeeba72d703577afc94a21d756a4dde0949310200f82ce575",
-            "min_glibc": "2.14",
+            "linux": {
+                "x86_64": "df3d905d37656a7eeeba72d703577afc94a21d756a4dde0949310200f82ce575",
+                "min_glibc": "2.14",
+            }
         },
         "1.4.2": {
-            "aarch64": "ddac6499f36c18ecbce9822a53ef3914c0def5276a457446a456c62999b16d36",
-            "min_glibc": "2.17",
+            "linux": {
+                "aarch64": "ddac6499f36c18ecbce9822a53ef3914c0def5276a457446a456c62999b16d36",
+                "min_glibc": "2.17",
+            }
         },
         "1.3.21": {
-            "x86_64": "c1c3e17e1857fb1c22af575941be5cd1d5444b462397b1b3c9f3877aee2e814b",
-            "min_glibc": "2.3",
+            "linux": {
+                "x86_64": "c1c3e17e1857fb1c22af575941be5cd1d5444b462397b1b3c9f3877aee2e814b",
+                "min_glibc": "2.3",
+            }
         },
     }
 
@@ -62,26 +82,29 @@ class SbclBootstrap(Package):
     target = platform.machine().lower()
 
     for ver in sbcl_releases:
-        if target in sbcl_releases[ver]:
-            version(ver, sha256=sbcl_releases[ver][target])
-            if "min_glibc" in sbcl_releases[ver]:
-                conflicts(
-                    "glibc@:{0}".format(sbcl_releases[ver]["min_glibc"]), when="@{0}".format(ver)
-                )
+        if os in sbcl_releases[ver]:
+            if target in sbcl_releases[ver][os]:
+                version(ver, sha256=sbcl_releases[ver][os][target])
+                if "min_glibc" in sbcl_releases[ver][os]:
+                    conflicts(
+                        "glibc@:{0}".format(sbcl_releases[ver][os]["min_glibc"]),
+                        when="@{0}".format(ver),
+                    )
 
-    supported_sysinfo_msg = "linux x86_64 is the only supported platform"
-    for sysinfo in ["platform=darwin", "platform=windows", "target=ppc64le"]:
+    supported_sysinfo_msg = (
+        "Not a supported platform. See https://www.sbcl.org/platform-table.html"
+    )
+    for sysinfo in ["platform=windows", "target=ppc64le"]:
         conflicts(sysinfo, msg=supported_sysinfo_msg)
 
     def url_for_version(self, version):
-        if self.os != "linux":
-            return None
         target = platform.machine().lower()
-        sbcl_targets = {"aarch64": "arm64", "x86_64": "x86-64"}
+        os = platform.system().lower()
+        sbcl_targets = {"arm64": "arm64", "aarch64": "arm64", "x86_64": "x86-64"}
         if target not in sbcl_targets:
             return None
-        sbcl_url = "https://sourceforge.net/projects/sbcl/files/sbcl/{version}/sbcl-{version}-{target}-linux-binary.tar.bz2"
-        return sbcl_url.format(version=version, target=sbcl_targets[target])
+        sbcl_url = "https://sourceforge.net/projects/sbcl/files/sbcl/{version}/sbcl-{version}-{target}-{os}-binary.tar.bz2"
+        return sbcl_url.format(version=version, target=sbcl_targets[target], os=os)
 
     def install(self, spec, prefix):
         sh = which("sh")

--- a/var/spack/repos/builtin/packages/sbcl-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/sbcl-bootstrap/package.py
@@ -21,6 +21,9 @@ class SbclBootstrap(Package):
 
     maintainers("ashermancinelli")
 
+    # sbcl-bootstrap is not available on Windows, but is depended on by sbcl:
+    skip_version_audit = ["platform=windows"]
+
     # NOTE: The sbcl homepage lists
     # while the sourceforge repo lists "Public Domain, MIT License", the
     # COPYING file distributed with the source code contains this message:

--- a/var/spack/repos/builtin/packages/sbcl/package.py
+++ b/var/spack/repos/builtin/packages/sbcl/package.py
@@ -1,0 +1,82 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+from spack.util.environment import set_env
+
+
+class Sbcl(MakefilePackage):
+    """Steel Bank Common Lisp (SBCL) is a high performance Common Lisp compiler.
+    It is open source / free software, with a permissive license. In addition
+    to the compiler and runtime system for ANSI Common Lisp, it provides an
+    interactive environment including a debugger, a statistical profiler, a
+    code coverage tool, and many other extensions.
+    """
+
+    homepage = "https://www.sbcl.org/"
+    url = "https://sourceforge.net/projects/sbcl/files/sbcl/2.4.8/sbcl-2.4.8-source.tar.bz2"
+    git = "git://git.code.sf.net/p/sbcl/sbcl"
+
+    maintainers("ashermancinelli")
+
+    # NOTE: The sbcl homepage lists
+    # while the sourceforge repo lists "Public Domain, MIT License", the
+    # COPYING file distributed with the source code contains this message:
+    #
+    # > Thus, there are no known obstacles to copying, using, and modifying
+    # > SBCL freely, as long as copyright notices of MIT, Symbolics, Xerox and
+    # > Gerd Moellmann are retained.
+    #
+    # MIT seems the most appropriate, but if we can add more context to this
+    # license message, then we should.
+    license("MIT", checked_by="ashermancinelli")
+
+    version("master", branch="master")
+    version("2.4.8", sha256="fc6ecdcc538e80a14a998d530ccc384a41790f4f4fc6cd7ffe8cb126a677694c")
+
+    depends_on("c", type="build")
+    depends_on("sbcl-bootstrap", type="build")
+    depends_on("zstd", when="platform=darwin")
+
+    variant(
+        "fancy", default=True, description="Enable extra features like compression and threading."
+    )
+
+    # TODO(ashermancinelli): there's nothing on the platform support page that
+    #                        makes me think this shouldn't build, but I can't
+    #                        get the sbcl binary to link with gcc on darwin.
+    conflicts(
+        "+fancy%gcc",
+        when="platform=darwin",
+        msg="Cannot build with gcc on darwin because pthreads will fail to link",
+    )
+
+    phases = ["build", "install"]
+
+    def build(self, spec, prefix):
+        sh = which("sh")
+
+        version_str = str(spec.version)
+
+        # NOTE: add any other git versions here.
+        # When installing from git, the build system expects a dummy version
+        # to be provided as a lisp expression.
+        if version_str in ("master",):
+            with open("version.lisp-expr", "w") as f:
+                f.write(f'"{version_str}"')
+
+        build_args = []
+        build_args.append("--prefix={0}".format(prefix))
+
+        if "+fancy" in self.spec:
+            build_args.append("--fancy")
+
+        sbcl_bootstrap_prefix = self.spec["sbcl-bootstrap"].prefix.lib.sbcl
+        with set_env(SBCL_HOME=sbcl_bootstrap_prefix):
+            sh("make.sh", *build_args)
+
+    def install(self, spec, prefix):
+        sh = which("sh")
+        sh("install.sh")


### PR DESCRIPTION
Now that #46582 has been merged for the binary sbcl-bootstrap, we can build the actual sbcl package from source. I tested on x86 64 and arm64 systems, building the master branch from source with `sbcl@master+fancy`.