### PR TITLE
don't concretize in CI if changed packages are not in stacks

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1413,6 +1413,10 @@ class Environment:
         """Returns true when the spec is built from local sources"""
         return spec.name in self.dev_specs
 
+    def possible_dependencies(self):
+        """Get a set of names of possible dependencies for all roots."""
+        return set(spack.package_base.possible_dependencies(self.user_specs))
+
     def concretize(self, force=False, tests=False):
         """Concretize user_specs in this environment.
 


### PR DESCRIPTION
This is a draft -- it's not done yet but the goal is to skip re-concretization in `generate` jobs if the modified packages couldn't possibly be a dependency of the environment being concretized.