### PR TITLE
fix GCC bugzilla 106310 (lookup after this-> seems wrong for dependent lookup)

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -51,6 +51,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
     version("12.2.0", sha256="e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff")
     version("12.1.0", sha256="62fd634889f31c02b64af2c468f064b47ad1ca78411c45abe6ac4b5f8dd19c7b")
 
+    version("11.5.0", sha256="a6e21868ead545cf87f0c01f84276e4b5281d672098591c1c896241f09363478")
     version("11.4.0", sha256="3f2db222b007e8a4a23cd5ba56726ef08e8b1f1eb2055ee72c1402cea73a8dd9")
     version("11.3.0", sha256="b47cf2818691f5b1e21df2bb38c795fac2cfbd640ede2d0a5e1c89e338a3ac39")
     version("11.2.0", sha256="d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b")


### PR DESCRIPTION
I ran into the behavior reported in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106310 on Spack v0.22.1 (building https://github.com/prisms-center/plasticity), and saw that only some of the GCC versions in develop were new enough to have the bug fix in place.

This commit adds a version of GCC 11 to match the newer versions of 12 and 13.