### PR TITLE
shadow: Add 4.16 and fix build wthout libbsd

### DIFF
--- a/var/spack/repos/builtin/packages/shadow/package.py
+++ b/var/spack/repos/builtin/packages/shadow/package.py
@@ -16,10 +16,15 @@ class Shadow(AutotoolsPackage):
 
     license("BSD-3-Clause")
 
+    version("4.16.0", sha256="1744f339e07a2b41056347ddd612839762ff565d7e9494fb049428002fa2e7e0")
     version("4.15.1", sha256="b34686b89b279887ffbf1f33128902ccc0fa1a998a3add44213bb12d7385b218")
     version("4.13", sha256="813057047499c7fe81108adcf0cffa3ad4ec75e19a80151f9cbaa458ff2e86cd")
     version("4.8.1", sha256="3ee3081fbbcbcfea5c8916419e46bc724807bab271072104f23e7a29e9668f3a")
     version("4.7", sha256="5135b0ca2a361a218fab59e63d9c1720d2a8fc1faa520c819a654b638017286f")
     version("4.6", sha256="4668f99bd087399c4a586084dc3b046b75f560720d83e92fd23bf7a89dda4d31")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
+
+    def configure_args(self):
+        # Fix build when libbsd is not installed on the host:
+        return ["--without-libbsd"]

--- a/var/spack/repos/builtin/packages/singularityce/package.py
+++ b/var/spack/repos/builtin/packages/singularityce/package.py
@@ -219,4 +219,4 @@ class Singularityce(SingularityBase):
     version("3.9.1", sha256="1ba3bb1719a420f48e9b0a6afdb5011f6c786d0f107ef272528c632fff9fd153")
     version("3.8.0", sha256="5fa2c0e7ef2b814d8aa170826b833f91e5031a85d85cd1292a234e6c55da1be1")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")


### PR DESCRIPTION
`shadow`: Add 4.16, fix build when `libbsd` is not installed on the host.

`shadow` is a dependency of `Singularity`,
so this fixes the build of `Singularity` without `libbsd` installed on the host.

Also confirm the dependeny on the `C` compiler for `shadow` and `singularityce` recipes.