### PR TITLE
cups: fix url; add v2.4.10 (fixes CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/cups/package.py
+++ b/var/spack/repos/builtin/packages/cups/package.py
@@ -14,7 +14,9 @@ class Cups(AutotoolsPackage):
     install."""
 
     homepage = "https://www.cups.org/"
-    url = "https://github.com/OpenPrinting/cups/releases/download/v2.4.10/cups-2.4.10-source.tar.gz"
+    url = (
+        "https://github.com/OpenPrinting/cups/releases/download/v2.4.10/cups-2.4.10-source.tar.gz"
+    )
 
     license("Apache-2.0", checked_by="wdconinc")
 

--- a/var/spack/repos/builtin/packages/cups/package.py
+++ b/var/spack/repos/builtin/packages/cups/package.py
@@ -14,18 +14,23 @@ class Cups(AutotoolsPackage):
     install."""
 
     homepage = "https://www.cups.org/"
-    url = "https://github.com/apple/cups/releases/download/v2.2.3/cups-2.2.3-source.tar.gz"
+    url = "https://github.com/OpenPrinting/cups/releases/download/v2.4.10/cups-2.4.10-source.tar.gz"
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked_by="wdconinc")
 
+    version("2.4.10", sha256="d75757c2bc0f7a28b02ee4d52ca9e4b1aa1ba2affe16b985854f5336940e5ad7")
     version("2.3.3", sha256="261fd948bce8647b6d5cb2a1784f0c24cc52b5c4e827b71d726020bcc502f3ee")
     version("2.2.3", sha256="66701fe15838f2c892052c913bde1ba106bbee2e0a953c955a62ecacce76885f")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("pkgconfig", type="build")
 
     depends_on("gnutls")
-    depends_on("pkgconfig", type="build")
+
+    def url_for_version(self, version):
+        org = "apple" if version < Version("2.4") else "OpenPrinting"
+        return f"https://github.com/{org}/cups/releases/download/v{version}/cups-{version}-source.tar.gz"
 
     def configure_args(self):
         args = ["--enable-gnutls", "--with-components=core"]


### PR DESCRIPTION
This PR fixes the url for for CUPS, now distributed under OpenPrinting on GitHub, so we can more easily pick up the versions that fix CVE-2022-26691, CVE-2022-26691, CVE-2023-4504, CVE-2023-32324,  CVE-2023-34241.

Test build:
```
==> Installing cups-2.4.10-ebvvebdjhzb27rmc4p5igb3wz6q3zhhx [30/30]
==> No binary for cups-2.4.10-ebvvebdjhzb27rmc4p5igb3wz6q3zhhx found: installing from source
==> Fetching https://github.com/OpenPrinting/cups/releases/download/v2.4.10/cups-2.4.10-source.tar.gz
==> No patches needed for cups
==> cups: Executing phase: 'autoreconf'
==> cups: Executing phase: 'configure'
==> cups: Executing phase: 'build'
==> cups: Executing phase: 'install'
==> cups: Successfully installed cups-2.4.10-ebvvebdjhzb27rmc4p5igb3wz6q3zhhx
  Stage: 1.80s.  Autoreconf: 0.00s.  Configure: 6.56s.  Build: 10.85s.  Install: 1.28s.  Post-install: 0.15s.  Total: 20.72s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/cups-2.4.10-ebvvebdjhzb27rmc4p5igb3wz6q3zhhx
```