### PR TITLE
dbus: fix url; add v1.14.10, v1.15.10 (meson); fix CVEs

### DIFF
--- a/var/spack/repos/builtin/packages/dbus/package.py
+++ b/var/spack/repos/builtin/packages/dbus/package.py
@@ -80,8 +80,8 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
 
 class MesonBuilder(spack.build_systems.meson.MesonBuilder):
     def meson_args(self):
-        args = ["-Dsystemd=false", "-Dlaunchd=false"]
-        args += [f"-Dxml_docs={'true' if self.spec.satisfies('+xml_docs') else 'false'}"]
+        args = ["-Dsystemd=disabled", "-Dlaunchd=disabled"]
+        args += [f"-Dxml_docs={'enabled' if self.spec.satisfies('+xml_docs') else 'disabled'}"]
         socket = self.spec.variants["system-socket"].value
         if socket != "default":
             args += [f"-Dsystem_socket={socket}"]

--- a/var/spack/repos/builtin/packages/dbus/package.py
+++ b/var/spack/repos/builtin/packages/dbus/package.py
@@ -70,7 +70,7 @@ class Dbus(AutotoolsPackage, MesonPackage):
 
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
     def configure_args(self):
-        args = ["--disable-systemd", "--disable-launchd"]
+        args = ["--disable-systemd", "--disable-launchd", "--disable-qt-help"]
         args += self.enable_or_disable("xml-docs", variant="xml_docs")
         socket = self.spec.variants["system-socket"].value
         if socket != "default":
@@ -80,7 +80,7 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
 
 class MesonBuilder(spack.build_systems.meson.MesonBuilder):
     def meson_args(self):
-        args = ["-Dsystemd=disabled", "-Dlaunchd=disabled"]
+        args = ["-Dsystemd=disabled", "-Dlaunchd=disabled", "-Dqt_help=disabled"]
         args += [f"-Dxml_docs={'enabled' if self.spec.satisfies('+xml_docs') else 'disabled'}"]
         socket = self.spec.variants["system-socket"].value
         if socket != "default":

--- a/var/spack/repos/builtin/packages/dbus/package.py
+++ b/var/spack/repos/builtin/packages/dbus/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Dbus(AutotoolsPackage):
+class Dbus(AutotoolsPackage, MesonPackage):
     """D-Bus is a message bus system, a simple way for applications to
     talk to one another. D-Bus supplies both a system daemon (for
     events such new hardware device printer queue ) and a
@@ -17,10 +17,24 @@ class Dbus(AutotoolsPackage):
     through the message bus daemon)."""
 
     homepage = "https://dbus.freedesktop.org/"
-    url = "https://dbus.freedesktop.org/releases/dbus/dbus-1.8.8.tar.gz"
+    url = "https://dbus.freedesktop.org/releases/dbus/dbus-1.14.10.tar.xz"
+    git = "https://gitlab.freedesktop.org/dbus/dbus"
 
-    license("AFL-2.1 OR GPL-2.0-or-later")
+    license("AFL-2.1 OR GPL-2.0-or-later", checked_by="wdconinc")
 
+    build_system(
+        conditional("autotools", when="@:1.15.8"),
+        conditional("meson", when="@1.15:"),
+        default="meson"
+    )
+
+    # Note: odd minor versions are unstable, keep last stable version preferred
+    version("1.15.10", sha256="f700f2f1d0473f11e52f3f3e179f577f31b85419f9ae1972af8c3db0bcfde178")
+    version(
+        "1.14.10",
+        sha256="ba1f21d2bd9d339da2d4aa8780c09df32fea87998b73da24f49ab9df1e36a50f",
+        preferred=True,
+    )
     version("1.13.6", sha256="b533693232d36d608a09f70c15440c1816319bac3055433300d88019166c1ae4")
     version("1.12.8", sha256="e2dc99e7338303393b6663a98320aba6a63421bcdaaf571c8022f815e5896eb3")
     version("1.11.2", sha256="5abc4c57686fa82669ad0039830788f9b03fdc4fff487f0ccf6c9d56ba2645c9")
@@ -30,12 +44,11 @@ class Dbus(AutotoolsPackage):
     version("1.8.4", sha256="3ef63dc8d0111042071ee7f7bafa0650c6ce2d7be957ef0b7ec269495a651ff8")
     version("1.8.2", sha256="5689f7411165adc953f37974e276a3028db94447c76e8dd92efe910c6d3bae08")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-
     variant("xml_docs", default=False, description="Build XML documentation")
     variant("system-socket", default="default", description="Location for the DBus system socket")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build", when="platform=windows")
     depends_on("pkgconfig", type="build")
     depends_on("docbook-xml", type="build")
     depends_on("docbook-xsl", type="build")
@@ -44,6 +57,18 @@ class Dbus(AutotoolsPackage):
     depends_on("libsm")
     depends_on("xmlto", when="+xml_docs", type="build")
 
+    def url_for_version(self, version):
+        ext = "gz" if version < Version("1.15") else "xz"
+        return f"https://dbus.freedesktop.org/releases/dbus/dbus-{version}.tar.{ext}"
+
+    @run_after("install")
+    def generate_uuid(self):
+        # dbus needs a machine id generated after install
+        dbus_uuidgen = Executable(self.prefix.bin.join("dbus-uuidgen"))
+        dbus_uuidgen("--ensure")
+
+
+class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
     def configure_args(self):
         args = ["--disable-systemd", "--disable-launchd"]
         args += self.enable_or_disable("xml-docs", variant="xml_docs")
@@ -52,8 +77,12 @@ class Dbus(AutotoolsPackage):
             args += ["--with-system-socket={0}".format(socket)]
         return args
 
-    @run_after("install")
-    def generate_uuid(self):
-        # dbus needs a machine id generated after install
-        dbus_uuidgen = Executable(self.prefix.bin.join("dbus-uuidgen"))
-        dbus_uuidgen("--ensure")
+
+class MesonBuilder(spack.build_systems.meson.MesonBuilder):
+    def meson_args(self):
+        args = ["-Dsystemd=false", "-Dlaunchd=false"]
+        args += [f"-Dxml_docs={'true' if self.spec.satisfies('+xml_docs') else 'false'}"]
+        socket = self.spec.variants["system-socket"].value
+        if socket != "default":
+            args += [f"-Dsystem_socket={socket}"]
+        return args

--- a/var/spack/repos/builtin/packages/dbus/package.py
+++ b/var/spack/repos/builtin/packages/dbus/package.py
@@ -25,7 +25,7 @@ class Dbus(AutotoolsPackage, MesonPackage):
     build_system(
         conditional("autotools", when="@:1.15.8"),
         conditional("meson", when="@1.15:"),
-        default="meson"
+        default="meson",
     )
 
     # Note: odd minor versions are unstable, keep last stable version preferred


### PR DESCRIPTION
This PR fixes the url for dbus, which is now distributed as an `xz` file. This PR adds v1.14.10, which fixes CVE-2019-12749, CVE-2020-12049, CVE-2022-42010, CVE-2022-42011, CVE-2022-42012, CVE-2023-34969. This PR also adds v1.15.10 (preferred false) since it switches the build system and, well, I might as well.

The generation of qt-help files was [introduced](https://gitlab.freedesktop.org/dbus/dbus/-/commit/6e8d75834eac4c4b9be78a8104993b3b76fb7dca) in dbus-1.13.16, and is explicitly disabled (circular dependency and documentation feature). I included an older version in the test builds below to demonstrate this doesn't have negative effects.

Build is included in gitlab CI stack (https://cache.spack.io/tag/develop/).

Test builds:
```
$ spack find -lv dbus
==> In environment /tmp/spack-r_8tfc7o
==> 3 root specs
[+] 4rcbs3t dbus@1.13.6  [+] 2yvvvln dbus@1.14.10  [+] ojjgafc dbus@1.15.10

-- linux-ubuntu24.04-skylake / gcc@13.3.0 -----------------------
4rcbs3t dbus@1.13.6~xml_docs build_system=autotools system-socket=default
2yvvvln dbus@1.14.10~xml_docs build_system=autotools system-socket=default
ojjgafc dbus@1.15.10~strip~xml_docs build_system=meson buildtype=release default_library=shared system-socket=default
==> 3 installed packages
```