### PR TITLE
ffmpeg: add v7.0.2 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -16,7 +16,8 @@ class Ffmpeg(AutotoolsPackage):
 
     maintainers("xjrc")
 
-    license("GPL-2.0-or-later AND LGPL-2.1-or-later", checked_by="wdconinc")
+    license("LGPL-2.1-or-later", when="~gpl", checked_by="wdconinc")
+    license("LGPL-2.1-or-later AND GPL-2.0-or-later", when="+gpl", checked_by="wdconinc")
 
     version("master", branch="master")
     version("7.0.2", sha256="1ed250407ea8f955cca2f1139da3229fbc13032a0802e4b744be195865ff1541")
@@ -48,7 +49,7 @@ class Ffmpeg(AutotoolsPackage):
     variant(
         "gpl",
         default=True,
-        description="allow use of GPL code, the resulting libs " "and binaries will be under GPL",
+        description="allow use of GPL code, the resulting libs and binaries will be under GPL",
     )
     variant("version3", default=True, description="upgrade (L)GPL to version 3")
     variant(

--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -16,15 +16,12 @@ class Ffmpeg(AutotoolsPackage):
 
     maintainers("xjrc")
 
-    license("GPL-2.0-or-later AND LGPL-2.1-or-later")
+    license("GPL-2.0-or-later AND LGPL-2.1-or-later", checked_by="wdconinc")
 
     version("master", branch="master")
+    version("7.0.2", sha256="1ed250407ea8f955cca2f1139da3229fbc13032a0802e4b744be195865ff1541")
     version("7.0", sha256="a24d9074bf5523a65aaa9e7bd02afe4109ce79d69bd77d104fed3dab4b934d7a")
-    version(
-        "6.1.1",
-        sha256="5e3133939a61ef64ac9b47ffd29a5ea6e337a4023ef0ad972094b4da844e3a20",
-        preferred=True,
-    )
+    version("6.1.1", sha256="5e3133939a61ef64ac9b47ffd29a5ea6e337a4023ef0ad972094b4da844e3a20")
     version("6.0", sha256="47d062731c9f66a78380e35a19aac77cebceccd1c7cc309b9c82343ffc430c3d")
     version("5.1.4", sha256="c3c1e316bf91468738dd0aff6eb1faab409f1edcd34fd1a4213626439bc5d743")
     version("5.1.3", sha256="5d5bef6a11f0c500588f9870ec965a30acc0d54d8b1e535da6554a32902d236d")


### PR DESCRIPTION
This PR adds `ffmpeg`, v7.0.2, which fixes CVE-2024-32230. The release series 7.* has now been out for nearly half a year, so removing the preferred on the previous version.

Test build:
```
==> Installing ffmpeg-7.0.2-odg5jisnjrxwb5lqp5cvgczgjoodmq5q [11/11]
==> No binary for ffmpeg-7.0.2-odg5jisnjrxwb5lqp5cvgczgjoodmq5q found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/1e/1ed250407ea8f955cca2f1139da3229fbc13032a0802e4b744be195865ff1541.tar.bz2
==> No patches needed for ffmpeg
==> ffmpeg: Executing phase: 'autoreconf'
==> ffmpeg: Executing phase: 'configure'
==> ffmpeg: Executing phase: 'build'
==> ffmpeg: Executing phase: 'install'
==> ffmpeg: Successfully installed ffmpeg-7.0.2-odg5jisnjrxwb5lqp5cvgczgjoodmq5q
  Stage: 2.15s.  Autoreconf: 0.00s.  Configure: 13.34s.  Build: 43.82s.  Install: 0.91s.  Post-install: 0.55s.  Total: 1m 1.06s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/ffmpeg-7.0.2-odg5jisnjrxwb5lqp5cvgczgjoodmq5q
```