### PR TITLE
flume: add v1.11.0 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/flume/package.py
+++ b/var/spack/repos/builtin/packages/flume/package.py
@@ -18,11 +18,12 @@ class Flume(Package):
     application.
     """
 
-    homepage = "https://cwiki.apache.org/FLUME"
+    homepage = "https://flume.apache.org"
     url = "https://www.apache.org/dist/flume/1.9.0/apache-flume-1.9.0-bin.tar.gz"
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked_by="wdconinc")
 
+    version("1.11.0", sha256="6eb7806076bdc3dcadb728275eeee7ba5cb12b63a2d981de3da9063008dba678")
     version("1.9.0", sha256="0373ed5abfd44dc4ab23d9a02251ffd7e3b32c02d83a03546e97ec15a7b23619")
     version("1.8.0", sha256="be1b554a5e23340ecc5e0b044215bf7828ff841f6eabe647b526d31add1ab5fa")
     version("1.7.0", sha256="b97254cf37c36b6e5045f764095d86fc6d9a8043dda169e950547fcae35681ec")


### PR DESCRIPTION
This PR adds `flume`, v1.11.0, which fixes CVE-2022-25167, CVE-2022-34916, CVE-2022-42468. Updated homepage to be more canonical.

Test build:
```
==> Installing flume-1.11.0-vdhtnzdnidohv2yak3rhkyzm3cwwygtu [5/5]
==> No binary for flume-1.11.0-vdhtnzdnidohv2yak3rhkyzm3cwwygtu found: installing from source
==> Fetching https://downloads.apache.org/flume/1.11.0/apache-flume-1.11.0-bin.tar.gz
==> No patches needed for flume
==> flume: Executing phase: 'install'
==> flume: Successfully installed flume-1.11.0-vdhtnzdnidohv2yak3rhkyzm3cwwygtu
  Stage: 1m 52.22s.  Install: 0.26s.  Post-install: 0.72s.  Total: 1m 53.24s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/flume-1.11.0-vdhtnzdnidohv2yak3rhkyzm3cwwygtu
```