### PR TITLE
flink: add v1.20.0 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/flink/package.py
+++ b/var/spack/repos/builtin/packages/flink/package.py
@@ -13,10 +13,11 @@ class Flink(Package):
     """
 
     homepage = "https://flink.apache.org/"
-    url = "https://archive.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.11.tgz"
+    url = "https://archive.apache.org/dist/flink/flink-1.20.0/flink-1.20.0-bin-scala_2.12.tgz"
 
-    license("BSD-2-Clause")
+    license("Apache-2.0", checked_by="wdconinc")
 
+    version("1.20.0", sha256="708fd544ccf9ddc0d4b192fe035797ce16de2c26f1d764c55907305efe140af0")
     version("1.9.1", sha256="f69de344cd593e92f8261e19ae8a47b3910e9a70a7cd1ccfb1ecd1ff000b93ea")
     version("1.9.0", sha256="a2245f68309e94ed54d86a680232a518aed9c5ea030bcc0b298bc8f27165eeb7")
     version("1.8.3", sha256="1ba90e99f70ad7e2583d48d1404d1c09e327e8fb8fa716b1823e427464cc8dc0")
@@ -26,8 +27,8 @@ class Flink(Package):
     depends_on("java@8:", type="run")
 
     def url_for_version(self, version):
-        url = "https://archive.apache.org/dist/flink/flink-{0}/flink-{0}-bin-scala_2.11.tgz"
-        return url.format(version)
+        scala = "2.12" if version >= Version("1.15") else "2.11"
+        return f"https://archive.apache.org/dist/flink/flink-{version}/flink-{version}-bin-scala_{scala}.tgz"
 
     def install(self, spec, prefix):
         install_tree(".", prefix)


### PR DESCRIPTION
This PR adds `flink`, v1.20.0, which fixes CVE-2020-1960, CVE-2020-17518, CVE-2020-17519. To ensure `spack checksum` picks up newer version, the url was updated since this (binary) download has the scala version as part of the url, and is now released for scala 2.12 (next releases likely 2.13). License updated.

Test build:
```
==> Installing flink-1.20.0-lagc5c4wt3zm4hl2hquqqyitl726j6nq [5/5]
==> No binary for flink-1.20.0-lagc5c4wt3zm4hl2hquqqyitl726j6nq found: installing from source
==> Fetching https://archive.apache.org/dist/flink/flink-1.20.0/flink-1.20.0-bin-scala_2.12.tgz
==> No patches needed for flink
==> flink: Executing phase: 'install'
==> flink: Successfully installed flink-1.20.0-lagc5c4wt3zm4hl2hquqqyitl726j6nq
  Stage: 1m 16.61s.  Install: 0.26s.  Post-install: 1.66s.  Total: 1m 18.59s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/flink-1.20.0-lagc5c4wt3zm4hl2hquqqyitl726j6nq
```