### PR TITLE
hive: add v3.1.3 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/hive/package.py
+++ b/var/spack/repos/builtin/packages/hive/package.py
@@ -17,8 +17,9 @@ class Hive(Package):
     homepage = "https://hive.apache.org/"
     url = "https://www.apache.org/dist/hive/hive-3.1.2/apache-hive-3.1.2-bin.tar.gz"
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked_by="wdconinc")
 
+    version("3.1.3", sha256="0c9b6a6359a7341b6029cc9347435ee7b379f93846f779d710b13f795b54bb16")
     version("3.1.2", sha256="d75dcf36908b4e7b9b0ec9aec57a46a6628b97b276c233cb2c2f1a3e89b13462")
     version("2.3.6", sha256="0b3736edc8d15f01ed649bfce7d74346c35fd57567411e9d0c3f48578f76610d")
     version("1.2.2", sha256="763b246a1a1ceeb815493d1e5e1d71836b0c5b9be1c4cd9c8d685565113771d1")


### PR DESCRIPTION
This PR adds `hive`, v3.1.3, which fixes CVE-2018-21234, CVE-2021-34538. 

Test build:
```
==> Installing hive-3.1.3-uhpw3yuk2jbfttxebprwzaayqauhbipc [6/6]
==> No binary for hive-3.1.3-uhpw3yuk2jbfttxebprwzaayqauhbipc found: installing from source
==> Fetching https://www.apache.org/dist/hive/hive-3.1.3/apache-hive-3.1.3-bin.tar.gz
==> No patches needed for hive
==> hive: Executing phase: 'install'
==> hive: Successfully installed hive-3.1.3-uhpw3yuk2jbfttxebprwzaayqauhbipc
  Stage: 1m 6.31s.  Install: 0.44s.  Post-install: 1.06s.  Total: 1m 7.89s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/hive-3.1.3-uhpw3yuk2jbfttxebprwzaayqauhbipc
```