### PR TITLE
libexif: add v0.6.24 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/libexif/package.py
+++ b/var/spack/repos/builtin/packages/libexif/package.py
@@ -22,7 +22,7 @@ class Libexif(AutotoolsPackage, SourceforgePackage):
     depends_on("glib")
 
     def url_for_version(self, version):
-        if version <= Version("0.6.21"):
+        if self.spec.satisfies("@:0.6.21"):
             return f"https://downloads.sourceforge.net/project/libexif/libexif/{version}/libexif-{version}.tar.bz2"
         else:
             return f"https://github.com/libexif/libexif/releases/download/v{version}/libexif-{version}.tar.bz2"

--- a/var/spack/repos/builtin/packages/libexif/package.py
+++ b/var/spack/repos/builtin/packages/libexif/package.py
@@ -8,14 +8,21 @@ from spack.package import *
 class Libexif(AutotoolsPackage, SourceforgePackage):
     """A library to parse an EXIF file and read the data from those tags"""
 
-    homepage = "https://sourceforge.net/projects/libexif/"
-    sourceforge_mirror_path = "libexif/libexif-0.6.21.tar.bz2"
+    homepage = "https://libexif.github.io/"
+    url = "https://github.com/libexif/libexif/releases/download/v0.6.24/libexif-0.6.24.tar.bz2"
 
     maintainers("TheQueasle")
 
-    license("LGPL-2.0-or-later")
+    license("LGPL-2.1-or-later", checked_by="wdconinc")
 
+    version("0.6.24", sha256="d47564c433b733d83b6704c70477e0a4067811d184ec565258ac563d8223f6ae")
     version("0.6.21", sha256="16cdaeb62eb3e6dfab2435f7d7bccd2f37438d21c5218ec4e58efa9157d4d41a")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
     depends_on("glib")
+
+    def url_for_version(self, version):
+        if version <= Version("0.6.21"):
+            return f"https://downloads.sourceforge.net/project/libexif/libexif/{version}/libexif-{version}.tar.bz2"
+        else:
+            return f"https://github.com/libexif/libexif/releases/download/v{version}/libexif-{version}.tar.bz2"


### PR DESCRIPTION
This PR adds `libexif`, v0.6.24, which fixes CVE-2016-6328, CVE-2017-7544, CVE-2018-20030, CVE-2020-0093, CVE-2020-0181, CVE-2020-0198, CVE-2020-12767, CVE-2020-13112, CVE-2020-13113, CVE-2020-13114. The libexif project has moved to GitHub, so updated homepage and url. Added url_for_version for older versions which are not on GitHub. Checked license which has always been LGPL-2.1.

Test build:
```
==> Installing libexif-0.6.24-d3z76qdeyz3ipi547hhysxkfbtcl2yy2 [33/33]
==> No binary for libexif-0.6.24-d3z76qdeyz3ipi547hhysxkfbtcl2yy2 found: installing from source
==> Fetching https://github.com/libexif/libexif/releases/download/v0.6.24/libexif-0.6.24.tar.bz2
==> No patches needed for libexif
==> libexif: Executing phase: 'autoreconf'
==> libexif: Executing phase: 'configure'
==> libexif: Executing phase: 'build'
==> libexif: Executing phase: 'install'
==> libexif: Successfully installed libexif-0.6.24-d3z76qdeyz3ipi547hhysxkfbtcl2yy2
  Stage: 1.59s.  Autoreconf: 0.00s.  Configure: 3.88s.  Build: 5.95s.  Install: 0.52s.  Post-install: 0.35s.  Total: 12.51s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/libexif-0.6.24-d3z76qdeyz3ipi547hhysxkfbtcl2yy2
```