### PR TITLE
libressl: add v3.7.3, v3.8.4, v3.9.2 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/libressl/package.py
+++ b/var/spack/repos/builtin/packages/libressl/package.py
@@ -18,11 +18,14 @@ class Libressl(AutotoolsPackage):
 
     license("custom")
 
+    version("3.9.2", sha256="7b031dac64a59eb6ee3304f7ffb75dad33ab8c9d279c847f92c89fb846068f97")
+    version("3.8.4", sha256="c0cef9cfe174ac366ce482f542fddb07721e7fa0caface34b49a8720fa37fe7d")
+    version("3.7.3", sha256="7948c856a90c825bd7268b6f85674a8dcd254bae42e221781b24e3f8dc335db3")
     version("3.7.2", sha256="b06aa538fefc9c6b33c4db4931a09a5f52d9d2357219afcbff7d93fe12ebf6f7")
     version("3.6.3", sha256="87b1bbe36e9eec8d0ae5f04c83d36b2c5b0e581784c7eb0817025ed29eadea37")
     version("3.6.1", sha256="acfac61316e93b919c28d62d53037ca734de85c46b4d703f19fd8395cf006774")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     variant("shared", default=True, description="Build shared libraries")
     variant("static", default=False, description="Build static libraries")


### PR DESCRIPTION
This PR adds `libressl`, v3.7.3, v3.8.4, v3.9.2, which fix CVE-2023-35784.

Test build (of latest version):
```
==> Installing libressl-3.9.2-2mmvprgujrxvnnucv6zjtftm5ywwwd7i [4/4]
==> No binary for libressl-3.9.2-2mmvprgujrxvnnucv6zjtftm5ywwwd7i found: installing from source
==> Fetching https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.9.2.tar.gz
==> No patches needed for libressl
==> libressl: Executing phase: 'autoreconf'
==> libressl: Executing phase: 'configure'
==> libressl: Executing phase: 'build'
==> libressl: Executing phase: 'install'
==> libressl: Successfully installed libressl-3.9.2-2mmvprgujrxvnnucv6zjtftm5ywwwd7i
  Stage: 1.71s.  Autoreconf: 0.00s.  Configure: 7.86s.  Build: 49.93s.  Install: 6.19s.  Post-install: 0.40s.  Total: 1m 6.18s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/libressl-3.9.2-2mmvprgujrxvnnucv6zjtftm5ywwwd7i
```