### PR TITLE
mbedtls: add v2.28.9, v3.6.2 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/mbedtls/package.py
+++ b/var/spack/repos/builtin/packages/mbedtls/package.py
@@ -18,13 +18,15 @@ class Mbedtls(MakefilePackage):
 
     maintainers("haampie")
 
-    license("Apache-2.0 OR GPL-2.0-or-later")
+    license("Apache-2.0 OR GPL-2.0-or-later", checked_by="wdconinc")
 
     # version 3.x
+    version("3.6.1", sha256="fc8bef0991b43629b7e5319de6f34f13359011105e08e3e16eed3a9fe6ffd3a3")
     version("3.6.0", sha256="3ecf94fcfdaacafb757786a01b7538a61750ebd85c4b024f56ff8ba1490fcd38")
     version("3.3.0", sha256="a22ff38512697b9cd8472faa2ea2d35e320657f6d268def3a64765548b81c3ec")
 
     # version 2.x
+    version("2.28.9", sha256="e85ea97aaf78dd6c0a5ba2e54dd5932ffa15f39abfc189c26beef7684630c02b")
     version("2.28.8", sha256="241c68402cef653e586be3ce28d57da24598eb0df13fcdea9d99bfce58717132")
     version("2.28.2", sha256="1db6d4196178fa9f8264bef5940611cd9febcd5d54ec05f52f1e8400f792b5a4")
     version("2.7.19", sha256="3da12b1cebe1a25da8365d5349f67db514aefcaa75e26082d7cb2fa3ce9608aa")
@@ -79,7 +81,10 @@ class Mbedtls(MakefilePackage):
     def url_for_version(self, version):
         if self.spec.satisfies("@:2.28.7,3:3.5"):
             return f"https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v{version}.tar.gz"
-        return f"https://github.com/Mbed-TLS/mbedtls/releases/download/v{version}/mbedtls-{version}.tar.bz2"
+        if self.spec.satisfies("@2.28.8,3.6.0"):
+            return f"https://github.com/Mbed-TLS/mbedtls/releases/download/v{version}/mbedtls-{version}.tar.bz2"
+        # release tags for @2.28.9:2,3.6.1:
+        return f"https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-{version}/mbedtls-{version}.tar.bz2"
 
     def flag_handler(self, name, flags):
         # Compile with PIC, if requested.

--- a/var/spack/repos/builtin/packages/mbedtls/package.py
+++ b/var/spack/repos/builtin/packages/mbedtls/package.py
@@ -21,9 +21,12 @@ class Mbedtls(MakefilePackage):
     license("Apache-2.0 OR GPL-2.0-or-later", checked_by="wdconinc")
 
     # version 3.x
-    version("3.6.1", sha256="fc8bef0991b43629b7e5319de6f34f13359011105e08e3e16eed3a9fe6ffd3a3")
-    version("3.6.0", sha256="3ecf94fcfdaacafb757786a01b7538a61750ebd85c4b024f56ff8ba1490fcd38")
-    version("3.3.0", sha256="a22ff38512697b9cd8472faa2ea2d35e320657f6d268def3a64765548b81c3ec")
+    version("3.6.2", sha256="8b54fb9bcf4d5a7078028e0520acddefb7900b3e66fec7f7175bb5b7d85ccdca")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2024-45159
+        version("3.6.1", sha256="fc8bef0991b43629b7e5319de6f34f13359011105e08e3e16eed3a9fe6ffd3a3")
+        version("3.6.0", sha256="3ecf94fcfdaacafb757786a01b7538a61750ebd85c4b024f56ff8ba1490fcd38")
+        version("3.3.0", sha256="a22ff38512697b9cd8472faa2ea2d35e320657f6d268def3a64765548b81c3ec")
 
     # version 2.x
     version("2.28.9", sha256="e85ea97aaf78dd6c0a5ba2e54dd5932ffa15f39abfc189c26beef7684630c02b")


### PR DESCRIPTION
This PR adds `mbedtls`, v2.28.9 and v3.6.1, both of which fix CVE-2024-45157, CVE-2024-45159. The name of the release branch that we download from has changed again.

Test build 2.28.9:
```
==> Installing mbedtls-2.28.9-mppaikgrcvabya3yrqgdlidq255xegtp [5/6]
==> No binary for mbedtls-2.28.9-mppaikgrcvabya3yrqgdlidq255xegtp found: installing from source
==> Fetching https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-2.28.9/mbedtls-2.28.9.tar.bz2
==> No patches needed for mbedtls
==> mbedtls: Executing phase: 'edit'
==> mbedtls: Executing phase: 'build'
==> mbedtls: Executing phase: 'install'
==> mbedtls: Successfully installed mbedtls-2.28.9-mppaikgrcvabya3yrqgdlidq255xegtp
  Stage: 1.86s.  Edit: 0.00s.  Build: 7.87s.  Install: 0.12s.  Post-install: 0.13s.  Total: 10.00s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/mbedtls-2.28.9-mppaikgrcvabya3yrqgdlidq255xegtp
```

Test build 3.6.2:
```
==> Installing mbedtls-3.6.2-gkxwpqdfyo5tr2p2yqzzuhqq32vchf2h [6/6]
==> No binary for mbedtls-3.6.2-gkxwpqdfyo5tr2p2yqzzuhqq32vchf2h found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/8b/8b54fb9bcf4d5a7078028e0520acddefb7900b3e66fec7f7175bb5b7d85ccdca.tar.bz2
==> No patches needed for mbedtls
==> mbedtls: Executing phase: 'edit'
==> mbedtls: Executing phase: 'build'
==> mbedtls: Executing phase: 'install'
==> mbedtls: Successfully installed mbedtls-3.6.2-gkxwpqdfyo5tr2p2yqzzuhqq32vchf2h
  Stage: 0.96s.  Edit: 0.00s.  Build: 3.84s.  Install: 0.47s.  Post-install: 0.28s.  Total: 5.57s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/mbedtls-3.6.2-gkxwpqdfyo5tr2p2yqzzuhqq32vchf2h
```