### PR TITLE
net-snmp: add v5.9.4 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/net-snmp/package.py
+++ b/var/spack/repos/builtin/packages/net-snmp/package.py
@@ -14,10 +14,11 @@ class NetSnmp(AutotoolsPackage):
 
     license("Net-SNMP")
 
+    version("5.9.4", sha256="8b4de01391e74e3c7014beb43961a2d6d6fa03acc34280b9585f4930745b0544")
     version("5.9.1", sha256="eb7fd4a44de6cddbffd9a92a85ad1309e5c1054fb9d5a7dd93079c8953f48c3f")
     version("5.9", sha256="04303a66f85d6d8b16d3cc53bde50428877c82ab524e17591dfceaeb94df6071")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("perl-extutils-makemaker")
     depends_on("ncurses")


### PR DESCRIPTION
This PR updates `net-snmp` to v5.9.4, which fixes CVE-2022-44792, CVE-2022-44793. 

Test build:
```
==> Installing net-snmp-5.9.4-ydmenvsdewcyty62rgte4ocowriet4gp [13/13]
==> No binary for net-snmp-5.9.4-ydmenvsdewcyty62rgte4ocowriet4gp found: installing from source
==> Fetching https://sourceforge.net/projects/net-snmp/files/net-snmp/5.9.4/net-snmp-5.9.4.tar.gz/download
==> No patches needed for net-snmp
==> net-snmp: Executing phase: 'autoreconf'
==> net-snmp: Executing phase: 'configure'
==> net-snmp: Executing phase: 'build'
==> net-snmp: Executing phase: 'install'
==> net-snmp: Successfully installed net-snmp-5.9.4-ydmenvsdewcyty62rgte4ocowriet4gp
  Stage: 2.04s.  Autoreconf: 0.00s.  Configure: 1m 3.57s.  Build: 1m 4.59s.  Install: 15.13s.  Post-install: 0.23s.  Total: 2m 25.65s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/net-snmp-5.9.4-ydmenvsdewcyty62rgte4ocowriet4gp
```