### PR TITLE
pacparser: add v1.4.5 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/pacparser/package.py
+++ b/var/spack/repos/builtin/packages/pacparser/package.py
@@ -10,11 +10,12 @@ class Pacparser(MakefilePackage):
     """pacparser is a library to parse proxy auto-config (PAC) files."""
 
     homepage = "https://pacparser.github.io/"
-    url = "https://github.com/manugarg/pacparser/releases/download/v1.4.0/pacparser-v1.4.0.tar.gz"
+    url = "https://github.com/manugarg/pacparser/archive/refs/tags/v1.4.5.tar.gz"
     git = "https://github.com/manugarg/pacparser.git"
 
     license("LGPL-3.0-or-later")
 
+    version("1.4.5", sha256="fac205f41d000e245519244dc3e730e649a0ac1c61b5f2d1d0660056e1680b2d")
     version("1.4.0", sha256="2e66c5fe635cd5dcb9bccca4aced925eca712632b81bada3b63682159c0f910e")
     version("1.3.9", commit="4bbfb15c96ea0b2aede2f7371e59f66e15722d41")
     version("1.3.8", sha256="4e2872de565b2b64ffc81ba503e0eba35b3f7ef4a023ddd4a328c7b9d2cac266")
@@ -32,6 +33,12 @@ class Pacparser(MakefilePackage):
     extends("python", when="+python")
 
     variant("python", default=False, description="Build and install python bindings")
+
+    def url_for_version(self, version):
+        if version <= Version("1.4.0"):
+            return f"https://github.com/manugarg/pacparser/releases/download/v{version}/pacparser-v{version}.tar.gz"
+        else:
+            return f"https://github.com/manugarg/pacparser/archive/refs/tags/v{version}.tar.gz"
 
     def build(self, spec, prefix):
         make('CC="%s"' % self.compiler.cc, 'CXX="%s"' % self.compiler.cxx, "-C", "src")


### PR DESCRIPTION
This PR adds `pacparser`, v1.4.5, which fixes CVE-2019-25078, CVE-2023-37360.

Test build:
```
==> Installing pacparser-1.4.5-oec2rvem43fmiingkrrm6ta2dvrdpkxy [5/5]
==> No binary for pacparser-1.4.5-oec2rvem43fmiingkrrm6ta2dvrdpkxy found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/fa/fac205f41d000e245519244dc3e730e649a0ac1c61b5f2d1d0660056e1680b2d.tar.gz
==> No patches needed for pacparser
==> pacparser: Executing phase: 'edit'
==> pacparser: Executing phase: 'build'
==> pacparser: Executing phase: 'install'
==> pacparser: Successfully installed pacparser-1.4.5-oec2rvem43fmiingkrrm6ta2dvrdpkxy
  Stage: 0.03s.  Edit: 0.00s.  Build: 3.78s.  Install: 0.09s.  Post-install: 0.09s.  Total: 4.02s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/pacparser-1.4.5-oec2rvem43fmiingkrrm6ta2dvrdpkxy
```
(Note to reviewer: I also had a failing build before it succeeded... but I couldn't reproduce the failure. Might have been a transient but please try to build before approving.)