### PR TITLE
perl-dbi: add v1.645 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/perl-dbi/package.py
+++ b/var/spack/repos/builtin/packages/perl-dbi/package.py
@@ -12,9 +12,16 @@ class PerlDbi(PerlPackage):
     database interface independent of the actual database being used."""
 
     homepage = "https://dbi.perl.org/"
-    url = "http://search.cpan.org/CPAN/authors/id/T/TI/TIMB/DBI-1.636.tar.gz"
+    url = "https://cpan.metacpan.org/authors/id/H/HM/HMBRAND/DBI-1.645.tgz"
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("1.645", sha256="e38b7a5efee129decda12383cf894963da971ffac303f54cc1b93e40e3cf9921")
     version("1.643", sha256="8a2b993db560a2c373c174ee976a51027dd780ec766ae17620c20393d2e836fa")
     version("1.636", sha256="8f7ddce97c04b4b7a000e65e5d05f679c964d62c8b02c94c1a7d815bb2dd676c")
+
+    def url_for_version(self, version):
+        if version <= Version("1.643"):
+            return f"http://search.cpan.org/CPAN/authors/id/T/TI/TIMB/DBI-{version}.tar.gz"
+        else:
+            return f"https://cpan.metacpan.org/authors/id/H/HM/HMBRAND/DBI-{version}.tgz"


### PR DESCRIPTION
This PR adds `perl-dbi`, v1.645, which fixes CVE-2014-10402. The url has changed. for newer versions.

Test build:
```
==> Installing perl-dbi-1.645-l73t7dh7wwvmlrgnknekrvrapxlbxpmu [11/11]
==> No binary for perl-dbi-1.645-l73t7dh7wwvmlrgnknekrvrapxlbxpmu found: installing from source
==> Fetching https://cpan.metacpan.org/authors/id/H/HM/HMBRAND/DBI-1.645.tgz
==> No patches needed for perl-dbi
==> perl-dbi: Executing phase: 'configure'
==> perl-dbi: Executing phase: 'build'
==> perl-dbi: Executing phase: 'install'
==> perl-dbi: Successfully installed perl-dbi-1.645-l73t7dh7wwvmlrgnknekrvrapxlbxpmu
  Stage: 0.72s.  Configure: 1.16s.  Build: 3.64s.  Install: 0.18s.  Post-install: 0.11s.  Total: 5.85s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/perl-dbi-1.645-l73t7dh7wwvmlrgnknekrvrapxlbxpmu
```