### PR TITLE
py-mechanize: add v0.4.10 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/py-mechanize/package.py
+++ b/var/spack/repos/builtin/packages/py-mechanize/package.py
@@ -12,8 +12,9 @@ class PyMechanize(PythonPackage):
     homepage = "https://github.com/python-mechanize/mechanize"
     pypi = "mechanize/mechanize-0.4.3.tar.gz"
 
-    license("BSD-3-Clause")
+    license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("0.4.10", sha256="1dea947f9be7ea0ab610f7bbc4a4e36b45d6bfdfceea29ad3d389a88a1957ddf")
     version("0.4.3", sha256="d7d7068be5e1b3069575c98c870aaa96dd26603fe8c8697b470e2f65259fddbf")
     version("0.2.5", sha256="2e67b20d107b30c00ad814891a095048c35d9d8cb9541801cebe85684cc84766")
 


### PR DESCRIPTION
This PR adds `py-mechanize`, v0.4.10, which fixes CVE-2021-32837.

Test build:
```
==> Installing py-mechanize-0.4.10-mug4lwzleb7tjgzgk266vepr3je3hfnz [41/41]
==> No binary for py-mechanize-0.4.10-mug4lwzleb7tjgzgk266vepr3je3hfnz found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/m/mechanize/mechanize-0.4.10.tar.gz
==> No patches needed for py-mechanize
==> py-mechanize: Executing phase: 'install'
==> py-mechanize: Successfully installed py-mechanize-0.4.10-mug4lwzleb7tjgzgk266vepr3je3hfnz
  Stage: 0.71s.  Install: 1.21s.  Post-install: 0.37s.  Total: 2.39s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/py-mechanize-0.4.10-mug4lwzleb7tjgzgk266vepr3je3hfnz
```