### PR TITLE
py-pycryptodome: add v3.20.0 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/py-pycryptodome/package.py
+++ b/var/spack/repos/builtin/packages/py-pycryptodome/package.py
@@ -13,8 +13,11 @@ class PyPycryptodome(PythonPackage):
     homepage = "https://www.pycryptodome.org"
     pypi = "pycryptodome/pycryptodome-3.16.0.tar.gz"
 
+    license("Unlicense AND BSD-2-Clause", checked_by="wdconinc")
+
+    version("3.20.0", sha256="09609209ed7de61c2b560cc5c8c4fbf892f8b15b1faf7e4cbffac97db1fffda7")
     version("3.16.0", sha256="0e45d2d852a66ecfb904f090c3f87dc0dfb89a499570abad8590f10d9cffb350")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
This PR adds `py-pycryptodome`, v3.20.0, which fixes CVE-2018-15560, CVE-2023-52323. Added license.

Test build:
```
==> Installing py-pycryptodome-3.20.0-zpnsjdvevuapgexukmf2fww22fvgmvfq [38/38]
==> No binary for py-pycryptodome-3.20.0-zpnsjdvevuapgexukmf2fww22fvgmvfq found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/p/pycryptodome/pycryptodome-3.20.0.tar.gz
==> No patches needed for py-pycryptodome
==> py-pycryptodome: Executing phase: 'install'
==> py-pycryptodome: Successfully installed py-pycryptodome-3.20.0-zpnsjdvevuapgexukmf2fww22fvgmvfq
  Stage: 1.22s.  Install: 20.72s.  Post-install: 0.43s.  Total: 22.44s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/py-pycryptodome-3.20.0-zpnsjdvevuapgexukmf2fww22fvgmvfq
```