### PR TITLE
py-werkzeug: add v3.0.4 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/py-werkzeug/package.py
+++ b/var/spack/repos/builtin/packages/py-werkzeug/package.py
@@ -13,8 +13,9 @@ class PyWerkzeug(PythonPackage):
     pypi = "werkzeug/werkzeug-3.0.0.tar.gz"
     git = "https://github.com/pallets/werkzeug.git"
 
-    license("BSD-3-Clause")
+    license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("3.0.4", sha256="34f2371506b250df4d4f84bfe7b0921e4762525762bbd936614909fe25cd7306")
     version("3.0.0", sha256="3ffff4dcc32db52ef3cc94dff3000a3c2846890f3a5a51800a27b909c5e770f0")
     version("2.3.7", sha256="2b8c0e447b4b9dbcc85dd97b6eeb4dcbaf6c8b6c3be0bd654e25553e0a2157d8")
     version("2.3.4", sha256="1d5a58e0377d1fe39d061a5de4469e414e78ccb1e1e59c0f5ad6fa1c36c52b76")


### PR DESCRIPTION
This PR adds `py-werkzeug`, v3.0.4, which fixes CVE-2023-46136.

Test build:
```
==> Installing py-werkzeug-3.0.4-otfp6okhz6rkjipwegxkrytazyit3wh2 [40/40]
==> No binary for py-werkzeug-3.0.4-otfp6okhz6rkjipwegxkrytazyit3wh2 found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/w/werkzeug/werkzeug-3.0.4.tar.gz
==> No patches needed for py-werkzeug
==> py-werkzeug: Executing phase: 'install'
==> py-werkzeug: Successfully installed py-werkzeug-3.0.4-otfp6okhz6rkjipwegxkrytazyit3wh2
  Stage: 0.81s.  Install: 0.98s.  Post-install: 0.56s.  Total: 2.48s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/py-werkzeug-3.0.4-otfp6okhz6rkjipwegxkrytazyit3wh2
```