### PR TITLE
qpdf: add v11.9.1 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/qpdf/package.py
+++ b/var/spack/repos/builtin/packages/qpdf/package.py
@@ -20,6 +20,7 @@ class Qpdf(CMakePackage):
 
     license("Apache-2.0", checked_by="taliaferro")
 
+    version("11.9.1", sha256="2ba4d248f9567a27c146b9772ef5dc93bd9622317978455ffe91b259340d13d1")
     version("11.9.0", sha256="9f5d6335bb7292cc24a7194d281fc77be2bbf86873e8807b85aeccfbff66082f")
 
     depends_on("c", type="build")  # generated


### PR DESCRIPTION
This PR adds `qpdf`, v11.9.1, which fixes CVE-2024-24246.

Test build:
```
==> Installing qpdf-11.9.1-bog2c6bs472r5ex7ffa6xzzpgwo4igwk [15/15]
==> No binary for qpdf-11.9.1-bog2c6bs472r5ex7ffa6xzzpgwo4igwk found: installing from source
==> Fetching https://github.com/qpdf/qpdf/releases/download/v11.9.1/qpdf-11.9.1.tar.gz
==> No patches needed for qpdf
==> qpdf: Executing phase: 'cmake'
==> qpdf: Executing phase: 'build'
==> qpdf: Executing phase: 'install'
==> qpdf: Successfully installed qpdf-11.9.1-bog2c6bs472r5ex7ffa6xzzpgwo4igwk
  Stage: 2.61s.  Cmake: 2.26s.  Build: 2m 20.56s.  Install: 0.41s.  Post-install: 0.14s.  Total: 2m 26.07s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/qpdf-11.9.1-bog2c6bs472r5ex7ffa6xzzpgwo4igwk
```