### PR TITLE
qt-*: add v6.7.3 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/qt-5compat/package.py
+++ b/var/spack/repos/builtin/packages/qt-5compat/package.py
@@ -18,6 +18,7 @@ class Qt5compat(QtPackage):
 
     license("LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only")
 
+    version("6.7.3", sha256="959634d1a6a53f9a483882e81da87ec182ff44d7747a0cc771c786b0f2cf52e0")
     version("6.7.2", sha256="331a1e617952217868beeef7964828500388abeeb502ea3436f16eec816426c4")
 
     depends_on("cxx", type="build")

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -133,6 +133,7 @@ class QtBase(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.7.3", sha256="65771d1618cab08ec5e9bbfdc265b5d2ce2ccf0373143d7d9d139647a7196aec")
     version("6.7.2", sha256="96b96e4fd0fc306502ed8b94a34cfa0bacc8a25d43c2e958dd6772b28f6b0e42")
     version("6.7.1", sha256="d6950597ce1fc2e1cf374c3aa70c2d72532bb74150e9853d7127af86a8a6c7b4")
     version("6.7.0", sha256="e17f016ec987092423e86d732c0f9786124598877fa00970fd806da113c02ca5")

--- a/var/spack/repos/builtin/packages/qt-declarative/package.py
+++ b/var/spack/repos/builtin/packages/qt-declarative/package.py
@@ -16,6 +16,7 @@ class QtDeclarative(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.7.3", sha256="f39fa4e7e3b4011e52fc55fbde5f41e61815bffea432869abc9b90aa4de07613")
     version("6.7.2", sha256="3b91d1b75f22221f39b93647d73c9fe7fc4b9c8d45ff0cec402626eab15d8dd8")
     version("6.7.1", sha256="fdf4099cbced3ce56e5151122ae1eb924886492f9fc2eb6a353d60a23e8fde14")
     version("6.7.0", sha256="dc3fec16cbe0f706b2b6114e5dbb884269543f2d679a0a3a63b4f686156adf73")

--- a/var/spack/repos/builtin/packages/qt-quick3d/package.py
+++ b/var/spack/repos/builtin/packages/qt-quick3d/package.py
@@ -16,6 +16,7 @@ class QtQuick3d(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.7.3", sha256="3e68f3a9a330e7b9a92ddf5b8d7a0874a107ea77636c788f598de65e327eb4a0")
     version("6.7.2", sha256="67021658cb10bfa6d969c4219d599ab2f4775d08fb4ae56da17fbec305088b55")
     version("6.7.1", sha256="c889b70305da7595df87c3bd062474787b722ab216bc2e6226e33fae3ec3459d")
     version("6.7.0", sha256="3adb7cc458c21a4642e7138cc0ca12934cd7075633d06c46c689f65718c8ba73")

--- a/var/spack/repos/builtin/packages/qt-quicktimeline/package.py
+++ b/var/spack/repos/builtin/packages/qt-quicktimeline/package.py
@@ -16,6 +16,7 @@ class QtQuicktimeline(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.7.3", sha256="81ce374a22bf00d53d0a9d5293d6495a224137e9427e4d4913d87f2f0adc5a58")
     version("6.7.2", sha256="ad5370a3b193c5d30a824a1def0608e12fb735c4ff20ae55161a6f6e202e091d")
     version("6.7.1", sha256="98766368b4650eef583f76d257573e6785938b89c9eb2fc57577f4c199b12a1f")
     version("6.7.0", sha256="9c8d953d4dfbe2a42dbbd88c26b4b01f6caab4d525ec01eb66edc71e9ee39172")

--- a/var/spack/repos/builtin/packages/qt-shadertools/package.py
+++ b/var/spack/repos/builtin/packages/qt-shadertools/package.py
@@ -18,6 +18,7 @@ class QtShadertools(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.7.3", sha256="8ec6a48c41d49b6f9595659169b2c69aecd46e96a88131f19f6a4cda394fa3f4")
     version("6.7.2", sha256="256ff8199d9f6e97bef57f602c5fa7a32e3c7588bf7efe39e412b810c7ed4ffc")
     version("6.7.1", sha256="56cfba20c7e8f7a218cac68d237a63ea342ac9a67211ecdf3c7152572632448b")
     version("6.7.0", sha256="82d9ef04a470db30e90253ddc72fcbc8fea2ecad419a735ecf64bb965560197f")

--- a/var/spack/repos/builtin/packages/qt-svg/package.py
+++ b/var/spack/repos/builtin/packages/qt-svg/package.py
@@ -18,6 +18,7 @@ class QtSvg(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.7.3", sha256="2852d8f1f52b60f0624ca5edf479125e4b32d579b1177d8b76d8e28fac98a701")
     version("6.7.2", sha256="c0e140bbba4157cdbbe0e84ddbb4e238b87aa0ca7b870bad283d8cf2a7fa74b6")
     version("6.7.1", sha256="55134e1242305e554610bf1a77e71d3d15104ee819a3c87def1f8b736d5ecf0e")
     version("6.7.0", sha256="ea023d11c710145786833649c3dc79dd099110fc3a9756a8a88699eeaac949f1")


### PR DESCRIPTION
This PR adds `qt-*`, v6.7.3, which fixes CVE-2024-39936.

Test build (with `qt-quick3d ^embree ~ispc`, due to build error in `ispc` for me):
```
==> Installing qt-base-6.7.3-qmbnewn3no52gaxdurla3irlnn6wtkne [87/94]
==> No binary for qt-base-6.7.3-qmbnewn3no52gaxdurla3irlnn6wtkne found: installing from source
==> Fetching https://github.com/qt/qtbase/archive/refs/tags/v6.7.3.tar.gz
==> No patches needed for qt-base
==> qt-base: Executing phase: 'cmake'
==> qt-base: Executing phase: 'build'
==> qt-base: Executing phase: 'install'
==> qt-base: Successfully installed qt-base-6.7.3-qmbnewn3no52gaxdurla3irlnn6wtkne
  Stage: 8.75s.  Cmake: 36.63s.  Build: 15m 32.56s.  Install: 0.96s.  Post-install: 1.47s.  Total: 16m 21.48s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/qt-base-6.7.3-qmbnewn3no52gaxdurla3irlnn6wtkne
==> Installing qt-shadertools-6.7.3-jiedpnkssh3nixktirizycuta7224tje [88/94]
==> No binary for qt-shadertools-6.7.3-jiedpnkssh3nixktirizycuta7224tje found: installing from source
==> Fetching https://github.com/qt/qtshadertools/archive/refs/tags/v6.7.3.tar.gz
==> No patches needed for qt-shadertools
==> qt-shadertools: Executing phase: 'cmake'
==> qt-shadertools: Executing phase: 'build'
==> qt-shadertools: Executing phase: 'install'
==> qt-shadertools: Successfully installed qt-shadertools-6.7.3-jiedpnkssh3nixktirizycuta7224tje
  Stage: 1.22s.  Cmake: 1.59s.  Build: 1m 26.96s.  Install: 0.02s.  Post-install: 0.22s.  Total: 1m 30.21s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/qt-shadertools-6.7.3-jiedpnkssh3nixktirizycuta7224tje
==> Installing qt-svg-6.7.3-f5m6yncwbxhy4bepjwdcmw5ltk5tiztt [89/94]
==> No binary for qt-svg-6.7.3-f5m6yncwbxhy4bepjwdcmw5ltk5tiztt found: installing from source
==> Fetching https://github.com/qt/qtsvg/archive/refs/tags/v6.7.3.tar.gz
==> No patches needed for qt-svg
==> qt-svg: Executing phase: 'cmake'
==> qt-svg: Executing phase: 'build'
==> qt-svg: Executing phase: 'install'
==> qt-svg: Successfully installed qt-svg-6.7.3-f5m6yncwbxhy4bepjwdcmw5ltk5tiztt
  Stage: 1.33s.  Cmake: 1.58s.  Build: 32.21s.  Install: 0.02s.  Post-install: 0.21s.  Total: 35.60s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/qt-svg-6.7.3-f5m6yncwbxhy4bepjwdcmw5ltk5tiztt
==> Installing qt-5compat-6.7.3-5h2nghtnimra73hm3hnh6wnfskdxvnkh [90/94]
==> No binary for qt-5compat-6.7.3-5h2nghtnimra73hm3hnh6wnfskdxvnkh found: installing from source
==> Fetching https://github.com/qt/qt5compat/archive/refs/tags/v6.7.3.tar.gz
==> No patches needed for qt-5compat
==> qt-5compat: Executing phase: 'cmake'
==> qt-5compat: Executing phase: 'build'
==> qt-5compat: Executing phase: 'install'
==> qt-5compat: Successfully installed qt-5compat-6.7.3-5h2nghtnimra73hm3hnh6wnfskdxvnkh
  Stage: 2.61s.  Cmake: 2.19s.  Build: 16.29s.  Install: 0.02s.  Post-install: 0.21s.  Total: 21.53s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/qt-5compat-6.7.3-5h2nghtnimra73hm3hnh6wnfskdxvnkh
==> Installing qt-declarative-6.7.3-djxzbogdcvsf66mfpmlq3exzdczbrbrp [84/87]
==> No binary for qt-declarative-6.7.3-djxzbogdcvsf66mfpmlq3exzdczbrbrp found: installing from source
==> Fetching https://github.com/qt/qtdeclarative/archive/refs/tags/v6.7.3.tar.gz
==> No patches needed for qt-declarative
==> qt-declarative: Executing phase: 'cmake'
==> qt-declarative: Executing phase: 'build'
==> qt-declarative: Executing phase: 'install'
==> qt-declarative: Successfully installed qt-declarative-6.7.3-djxzbogdcvsf66mfpmlq3exzdczbrbrp
  Stage: 4.41s.  Cmake: 7.10s.  Build: 25m 36.25s.  Install: 1.18s.  Post-install: 0.98s.  Total: 25m 51.54s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/qt-declarative-6.7.3-djxzbogdcvsf66mfpmlq3exzdczbrbrp
==> Installing qt-quicktimeline-6.7.3-4itmmvfcrqonslne6owjpq5xnwneiqft [85/87]
==> No binary for qt-quicktimeline-6.7.3-4itmmvfcrqonslne6owjpq5xnwneiqft found: installing from source
==> Fetching https://github.com/qt/qtquicktimeline/archive/refs/tags/v6.7.3.tar.gz
==> No patches needed for qt-quicktimeline
==> qt-quicktimeline: Executing phase: 'cmake'
==> qt-quicktimeline: Executing phase: 'build'
==> qt-quicktimeline: Executing phase: 'install'
==> qt-quicktimeline: Successfully installed qt-quicktimeline-6.7.3-4itmmvfcrqonslne6owjpq5xnwneiqft
  Stage: 1.04s.  Cmake: 2.07s.  Build: 27.45s.  Install: 0.03s.  Post-install: 0.32s.  Total: 31.15s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/qt-quicktimeline-6.7.3-4itmmvfcrqonslne6owjpq5xnwneiqft
==> Installing qt-quick3d-6.7.3-jafco3i5s5lourbz3ta7spmpedxyfe6x [82/82]
==> No binary for qt-quick3d-6.7.3-jafco3i5s5lourbz3ta7spmpedxyfe6x found: installing from source
==> Fetching https://github.com/qt/qtquick3d/archive/refs/tags/v6.7.3.tar.gz
==> No patches needed for qt-quick3d
==> qt-quick3d: Executing phase: 'cmake'
==> qt-quick3d: Executing phase: 'build'
==> qt-quick3d: Executing phase: 'install'
==> qt-quick3d: Successfully installed qt-quick3d-6.7.3-jafco3i5s5lourbz3ta7spmpedxyfe6x
  Stage: 7.34s.  Cmake: 5.04s.  Build: 6m 45.97s.  Install: 0.28s.  Post-install: 0.74s.  Total: 6m 59.90s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/qt-quick3d-6.7.3-jafco3i5s5lourbz3ta7spmpedxyfe6x
```