### PR TITLE
rabbitmq-c: add v0.14.0 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/rabbitmq-c/package.py
+++ b/var/spack/repos/builtin/packages/rabbitmq-c/package.py
@@ -16,12 +16,13 @@ class RabbitmqC(CMakePackage):
 
     maintainers("lpottier")
 
-    license("MIT")
+    license("MIT", checked_by="wdconinc")
 
+    version("0.14.0", sha256="839b28eae20075ac58f45925fe991d16a3138cbde015db0ee11df1acb1c493df")
     version("0.13.0", sha256="8b224e41bba504fc52b02f918d8df7e4bf5359d493cbbff36c06078655c676e6")
     version("0.11.0", sha256="437d45e0e35c18cf3e59bcfe5dfe37566547eb121e69fca64b98f5d2c1c2d424")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     variant("ssl", default=True, description="Required to connect to RabbitMQ using SSL/TLS")
     variant("shared", default=True, description="Build shared library")
@@ -30,6 +31,7 @@ class RabbitmqC(CMakePackage):
     variant("tools", default=False, description="Build the tools")
 
     depends_on("cmake@3.12:", type="build")
+    depends_on("cmake@3.22:", type="build", when="@0.14:")
     depends_on("openssl@1.1.1:", when="+ssl", type=("build", "link", "run"))
     depends_on("doxygen", when="+doc", type="build")
     depends_on("popt@1.14:", when="+tools", type=("build", "link", "run"))


### PR DESCRIPTION
This PR adds `rabbitmq-c`, v0.14.0, which fixes CVE-2023-35789. Checked license and updated required cmake minimum version (no other changes in CMakeLists.txt that need to be adapted to here).

Test build:
```
==> Installing rabbitmq-c-0.14.0-neezkyk5anvrlg6l4ky4md7bpgne67lo [11/11]
==> No binary for rabbitmq-c-0.14.0-neezkyk5anvrlg6l4ky4md7bpgne67lo found: installing from source
==> Fetching https://github.com/alanxz/rabbitmq-c/archive/refs/tags/v0.14.0.tar.gz
==> No patches needed for rabbitmq-c
==> rabbitmq-c: Executing phase: 'cmake'
==> rabbitmq-c: Executing phase: 'build'
==> rabbitmq-c: Executing phase: 'install'
==> rabbitmq-c: Successfully installed rabbitmq-c-0.14.0-neezkyk5anvrlg6l4ky4md7bpgne67lo
  Stage: 1.41s.  Cmake: 5.57s.  Build: 6.06s.  Install: 0.36s.  Post-install: 0.49s.  Total: 14.30s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/rabbitmq-c-0.14.0-neezkyk5anvrlg6l4ky4md7bpgne67lo
```