### PR TITLE
routinator: add v0.14.0 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/routinator/package.py
+++ b/var/spack/repos/builtin/packages/routinator/package.py
@@ -16,6 +16,7 @@ class Routinator(Package):
 
     license("BSD-3-Clause")
 
+    version("0.14.0", sha256="861e90f395344be19880485185df47e8fd258cc583b82be702af660b466955cb")
     version("0.12.1", sha256="8150fe544f89205bb2d65bca46388f055cf13971d3163fe17508bf231f9ab8bc")
     version(
         "0.11.2",
@@ -25,6 +26,7 @@ class Routinator(Package):
 
     depends_on("rust@1.56:", when="@0.11.2")
     depends_on("rust@1.63:", when="@0.12.1")
+    depends_on("rust@1.70:", when="@0.13.0:")
 
     def install(self, spec, prefix):
         cargo = which("cargo")


### PR DESCRIPTION
This PR adds `routinator`, v0.14.0, which fixes CVE-2023-39915, CVE-2023-39916. The version of rust required per Cargo.toml is now 1.70.

Test build:
```
==> Installing routinator-0.14.0-hl5rcg2izlxwhw2v6d67pibckgoa7ol5 [5/5]
==> No binary for routinator-0.14.0-hl5rcg2izlxwhw2v6d67pibckgoa7ol5 found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/86/861e90f395344be19880485185df47e8fd258cc583b82be702af660b466955cb.tar.gz
==> No patches needed for routinator
==> routinator: Executing phase: 'install'
==> routinator: Successfully installed routinator-0.14.0-hl5rcg2izlxwhw2v6d67pibckgoa7ol5
  Stage: 0.47s.  Install: 5m 18.41s.  Post-install: 0.26s.  Total: 5m 19.23s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/routinator-0.14.0-hl5rcg2izlxwhw2v6d67pibckgoa7ol5
```