### PR TITLE
unixodbc: add v2.3.12 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/unixodbc/package.py
+++ b/var/spack/repos/builtin/packages/unixodbc/package.py
@@ -16,6 +16,7 @@ class Unixodbc(AutotoolsPackage):
 
     license("LGPL-2.0-or-later")
 
+    version("2.3.12", sha256="f210501445ce21bf607ba51ef8c125e10e22dffdffec377646462df5f01915ec")
     version("2.3.4", sha256="2e1509a96bb18d248bf08ead0d74804957304ff7c6f8b2e5965309c632421e39")
 
     depends_on("c", type="build")


### PR DESCRIPTION
This PR adds `unixodbc`, v2.3.12, which fixes CVE-2018-7409, CVE-2018-7485.

Test build:
```
==> Installing unixodbc-2.3.12-syrh5htw7a3bdlsvteuhxhzzgayd44fy [5/5]
==> No binary for unixodbc-2.3.12-syrh5htw7a3bdlsvteuhxhzzgayd44fy found: installing from source
==> Fetching https://www.unixodbc.org/unixODBC-2.3.12.tar.gz
==> No patches needed for unixodbc
==> unixodbc: Executing phase: 'autoreconf'
==> unixodbc: Executing phase: 'configure'
==> unixodbc: Executing phase: 'build'
==> unixodbc: Executing phase: 'install'
==> unixodbc: Successfully installed unixodbc-2.3.12-syrh5htw7a3bdlsvteuhxhzzgayd44fy
  Stage: 1.85s.  Autoreconf: 0.00s.  Configure: 11.47s.  Build: 16.36s.  Install: 0.69s.  Post-install: 0.19s.  Total: 30.63s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/unixodbc-2.3.12-syrh5htw7a3bdlsvteuhxhzzgayd44fy
```
