### PR TITLE
umoci: fix url; add v0.4.7 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/umoci/package.py
+++ b/var/spack/repos/builtin/packages/umoci/package.py
@@ -12,24 +12,23 @@ class Umoci(MakefilePackage):
     complete manipulation tool for OCI images."""
 
     homepage = "https://umo.ci/"
-    url = "https://github.com/openSUSE/umoci/archive/v0.4.4.tar.gz"
+    url = "https://github.com/opencontainers/umoci/archive/v0.4.4.tar.gz"
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked_by="wdconinck")
 
+    version("0.4.7", sha256="c01b36de6fdc513eb65add57bc882d72f94fc3b4b65a8f9ef59826fb754af93e")
     version("0.4.4", sha256="bc5c53812e0076d026aa275b197b878857cf7ba7a4f048fd13433de6107b9aed")
     version("0.4.3", sha256="b7d537fec84d4327b1bbfe27118f69df5591143a74a7a1b66cc9904d85c30226")
     version("0.4.2", sha256="fbc397dd39bda2570155dc3b1be0835809a36fccc342e2545b3edb9f0f9dc6f5")
     version("0.4.1", sha256="0d83e01167383f529d726e9fd455660d4837371d5f0d82fad405f3ae6ae52486")
     version("0.4.0", sha256="66997e270dee8abc9796385b162a1e8e32dd2ee2359e5200af4e6671cc1e76a0")
 
-    depends_on("c", type="build")  # generated
-
     depends_on("go")
     depends_on("go-md2man", type="build")
 
     def build(self, spec, prefix):
         provider = "github.com"
-        project = "openSUSE"
+        project = "opencontainers"
         repo = "umoci"
 
         mkdirp(join_path(self.stage.source_path, "src", provider, project))


### PR DESCRIPTION
This PR adds `umoci`, v0.4.7, which fixes CVE-2021-29136. This also updates the github organization from openSUSE to opencontainers, where the project is now managed. The previous versions are available there, and the checksums are verified to be unchanged.

Test build:
```
==> Installing umoci-0.4.7-73jn43zde7x7c27qyhbqtsohmxg4xrhb [21/21]
==> No binary for umoci-0.4.7-73jn43zde7x7c27qyhbqtsohmxg4xrhb found: installing from source
==> Fetching https://github.com/opencontainers/umoci/archive/v0.4.7.tar.gz
==> No patches needed for umoci
==> umoci: Executing phase: 'edit'
==> umoci: Executing phase: 'build'
==> umoci: Executing phase: 'install'
==> umoci: Successfully installed umoci-0.4.7-73jn43zde7x7c27qyhbqtsohmxg4xrhb
  Stage: 1.88s.  Edit: 0.00s.  Build: 14.33s.  Install: 1.14s.  Post-install: 0.39s.  Total: 18.41s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.2.0/umoci-0.4.7-73jn43zde7x7c27qyhbqtsohmxg4xrhb
```