### PR TITLE
rpm: add v4.18.2 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/rpm/package.py
+++ b/var/spack/repos/builtin/packages/rpm/package.py
@@ -24,6 +24,7 @@ class Rpm(AutotoolsPackage):
     maintainers("haampie")
 
     version("master", branch="master")
+    version("4.18.2", sha256="8be0a812b2e707c72ae486b54db18ae211dd4158ad35e32b308d662c59a75e85")
     version("4.16.1.2", sha256="3d2807807a8ccaa92a8ced74e09b5bf5b2417a5bbf9bee4abc7c6aa497547bf3")
     version("4.16.0", sha256="a62b744e3404b107e8467e1a36ff0f2bf9e5c1b748dbfeb36db54bbb859446ea")
 
@@ -94,13 +95,16 @@ class Rpm(AutotoolsPackage):
     depends_on("gzip")
     depends_on("xz")
     depends_on("lzma")
-    depends_on("zstd", when="+zstd")
+    with when("+zstd"):
+        depends_on("zstd")
+        depends_on("zstd@1.3.8:", when="@4.17:")
 
     # java jar dependency analysis (already requirement for lua)
     depends_on("unzip", type="run")
 
     # Build dependencies
     depends_on("doxygen", type="build")
+    depends_on("pandoc", type="build", when="@4.17:")
     depends_on("pkgconfig", type="build")
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")


### PR DESCRIPTION
This PR adds `rpm`, v4.18.2, which fixes CVE-2021-35937, CVE-2021-35938, CVE-2021-35939. This is the last version before the swtich from Autotools to CMake (will be for a separate PR). The [diff of `configure.ac`](https://github.com/rpm-software-management/rpm/compare/rpm-4.16.1.2-release...rpm-4.18.2-release) indicates an updated `zstd` version requirement and a new (optional) `pandoc` requirement (which is included here since `doxygen` is already included).

Test build (note: this is with `spack install rpm@=4.18.2 ^lua@=5.3.6` since `lua@5.4` fails on patch)
```
==> Installing rpm-4.18.2-mtd5q3bcj67uyqmksrqpmag7abcud5y3 [44/44]
==> No binary for rpm-4.18.2-mtd5q3bcj67uyqmksrqpmag7abcud5y3 found: installing from source
==> Using cached archive: /workspaces/spack/var/spack/cache/_source-cache/archive/8b/8be0a812b2e707c72ae486b54db18ae211dd4158ad35e32b308d662c59a75e85.tar.gz
==> No patches needed for rpm
==> rpm: Executing phase: 'autoreconf'
==> rpm: Executing phase: 'configure'
==> rpm: Executing phase: 'build'
==> rpm: Executing phase: 'install'
==> rpm: Successfully installed rpm-4.18.2-mtd5q3bcj67uyqmksrqpmag7abcud5y3
  Stage: 0.04s.  Autoreconf: 7.99s.  Configure: 30.58s.  Build: 32.48s.  Install: 4.98s.  Post-install: 0.16s.  Total: 1m 16.47s
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/rpm-4.18.2-mtd5q3bcj67uyqmksrqpmag7abcud5y3
```

Issue with `lua@5.4` is fixed in https://github.com/spack/spack/pull/39403.