### PR TITLE
libvips: add v8.15.3 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/libvips/package.py
+++ b/var/spack/repos/builtin/packages/libvips/package.py
@@ -12,15 +12,22 @@ class Libvips(AutotoolsPackage):
     little memory."""
 
     homepage = "https://libvips.github.io/libvips/"
-    url = "https://github.com/libvips/libvips/releases/download/v8.9.0/vips-8.9.0.tar.gz"
+    url = "https://github.com/libvips/libvips/releases/download/v8.15.3/vips-8.15.3.tar.xz"
     git = "https://github.com/libvips/libvips.git"
 
-    license("LGPL-2.1-or-later")
+    license("LGPL-2.1-or-later", checked_by="wdconinc")
 
+    version("8.15.3", sha256="3e27d9f536eafad64013958fe9e8a1964c90b564c731d49db7c1a1c11b1052a0")
     version("8.13.3", sha256="4eff5cdc8dbe1a05a926290a99014e20ba386f5dcca38d9774bef61413435d4c")
     version("8.10.5", sha256="a4eef2f5334ab6dbf133cd3c6d6394d5bdb3e76d5ea4d578b02e1bc3d9e1cfd8")
     version("8.9.1", sha256="45633798877839005016c9d3494e98dee065f5cb9e20f4552d3b315b8e8bce91")
     version("8.9.0", sha256="97334a5e70aff343d2587f23cb8068fc846a58cd937c89a446142ccf00ea0349")
+
+    build_system(
+        conditional("autotools", when="@:8.13"),
+        conditional("meson", when="@8.13:"),
+        default="meson",
+    )
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
@@ -46,3 +53,7 @@ class Libvips(AutotoolsPackage):
     depends_on("libtiff", when="+tiff")
     depends_on("libpng", when="+png")
     depends_on("poppler", when="+poppler")
+
+    def url_for_version(self, version):
+        ext = "xz" if version >= Version("8.14") else "gz"
+        return f"https://github.com/libvips/libvips/releases/download/v{version}/vips-{version}.tar.{ext}"

--- a/var/spack/repos/builtin/packages/libvips/package.py
+++ b/var/spack/repos/builtin/packages/libvips/package.py
@@ -52,7 +52,7 @@ class Libvips(AutotoolsPackage):
     depends_on("libjpeg", when="+jpeg")
     depends_on("libtiff", when="+tiff")
     depends_on("libpng", when="+png")
-    depends_on("poppler", when="+poppler")
+    depends_on("poppler +glib", when="+poppler")
 
     def url_for_version(self, version):
         ext = "xz" if version >= Version("8.14") else "gz"


### PR DESCRIPTION
This PR adds `libvips`, v8.15.3, which fixes CVE-2023-40032. This requires a new build system since the package now only supports meson. This also now requires `poppler +glib` which has always been required (as far back as the oldest version, https://github.com/libvips/libvips/blob/v8.9.2/configure.ac#L988).

Test build (with default variants, i.e. only `+fftw`):
```
==> Installing libvips-8.15.3-nthk36hrtrsa4rp7rtznklcivjdejxeo [45/45]
==> No binary for libvips-8.15.3-nthk36hrtrsa4rp7rtznklcivjdejxeo found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/3e/3e27d9f536eafad64013958fe9e8a1964c90b564c731d49db7c1a1c11b1052a0.tar.xz
==> No patches needed for libvips
==> libvips: Executing phase: 'meson'
==> libvips: Executing phase: 'build'
==> libvips: Executing phase: 'install'
==> libvips: Successfully installed libvips-8.15.3-nthk36hrtrsa4rp7rtznklcivjdejxeo
  Stage: 1.29s.  Meson: 3.38s.  Build: 1m 29.48s.  Install: 0.30s.  Post-install: 0.20s.  Total: 1m 34.82s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/libvips-8.15.3-nthk36hrtrsa4rp7rtznklcivjdejxeo
```

Test build (with all variants enabled):
```
==> Installing libvips-8.15.3-hiowlniznr575jlyhqp2ri2xxowmwnav [58/58]
==> No binary for libvips-8.15.3-hiowlniznr575jlyhqp2ri2xxowmwnav found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/3e/3e27d9f536eafad64013958fe9e8a1964c90b564c731d49db7c1a1c11b1052a0.tar.xz
==> No patches needed for libvips
==> libvips: Executing phase: 'meson'
==> libvips: Executing phase: 'build'
==> libvips: Executing phase: 'install'
==> libvips: Successfully installed libvips-8.15.3-hiowlniznr575jlyhqp2ri2xxowmwnav
  Stage: 0.93s.  Meson: 3.31s.  Build: 22.61s.  Install: 0.32s.  Post-install: 0.18s.  Total: 27.51s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/libvips-8.15.3-hiowlniznr575jlyhqp2ri2xxowmwnav
```