### PR TITLE
hazelcast: add v5.5.0 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/hazelcast/package.py
+++ b/var/spack/repos/builtin/packages/hazelcast/package.py
@@ -15,15 +15,14 @@ class Hazelcast(MavenPackage):
     homepage = "http://www.hazelcast.com/"
     url = "https://github.com/hazelcast/hazelcast/archive/v3.12.8.tar.gz"
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked_by="wdconinc")
 
+    version("5.5.0", sha256="bbf0c9b9de89512a41d698c02477c88c4955600f34741ee42e26838409e2e526")
     version("5.2.3", sha256="026c213d3bb520b6c44587ae2a67eca50b9a5a0fc56d2cdedfb2c09c7858a11f")
     version("4.0.2", sha256="4f01682583ae6603365ac7a24c568d7598cc3c1cbd736e5c6ed98bd75e39ffa3")
     version("4.0.1", sha256="c9c7d5cbcf70c5e1eb72890df2b4104639f7543f11c6ac5d3e80cd2d4a0d2181")
     version("3.12.8", sha256="65d0e131fc993f9517e8ce9ae5af9515f1b8038304abaaf9da535bdef1d71726")
     version("3.12.7", sha256="0747de968082bc50202f825b4010be28a3885b3dbcee4b83cbe21b2f8b26a7e0")
     version("3.11.7", sha256="c9f636b8813027d4cc24459bd27740549f89b4f11f62a868079bcb5b41d9b2bb")
-
-    depends_on("c", type="build")  # generated
 
     depends_on("java@8:", type=("build", "run"))


### PR DESCRIPTION
This PR adds `hazelcast`, v5.5.0, which fixes CVE-2023-33264, CVE-2023-33265, CVE-2023-33265. The package has 2 c files in https://github.com/hazelcast/hazelcast/tree/master/hazelcast/src/main/resources which is not included in the build.

Test build:
```
==> Installing hazelcast-5.5.0-vujyx6ndgjnkkgrvt3r6pai7jly2ufwe [5/5]
==> No binary for hazelcast-5.5.0-vujyx6ndgjnkkgrvt3r6pai7jly2ufwe found: installing from source
==> Fetching https://github.com/hazelcast/hazelcast/archive/v5.5.0.tar.gz
==> No patches needed for hazelcast
==> hazelcast: Executing phase: 'build'
==> hazelcast: Executing phase: 'install'
==> hazelcast: Successfully installed hazelcast-5.5.0-vujyx6ndgjnkkgrvt3r6pai7jly2ufwe
  Stage: 6.66s.  Build: 23m 16.24s.  Install: 17.94s.  Post-install: 15.95s.  Total: 23m 57.05s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/hazelcast-5.5.0-vujyx6ndgjnkkgrvt3r6pai7jly2ufwe
```