### PR TITLE
py-uwsgi: add v2.0.27 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/py-uwsgi/package.py
+++ b/var/spack/repos/builtin/packages/py-uwsgi/package.py
@@ -15,6 +15,7 @@ class PyUwsgi(PythonPackage):
 
     license("GPL-2.0-only")
 
+    version("2.0.27", sha256="3ee5bfb7e6e9c93478c22aa8183eef35b95a2d5b14cca16172e67f135565c458")
     version("2.0.18", sha256="4972ac538800fb2d421027f49b4a1869b66048839507ccf0aa2fda792d99f583")
 
     depends_on("c", type="build")  # generated


### PR DESCRIPTION
This PR adds `py-uwsgi`, v2.0.27, which fixes CVE-2023-27522.

Test build
```
==> Installing py-uwsgi-2.0.27-fgzy2n2ofxdnpbg5ovahejavs5mgfqws [28/28]
==> No binary for py-uwsgi-2.0.27-fgzy2n2ofxdnpbg5ovahejavs5mgfqws found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/u/uwsgi/uwsgi-2.0.27.tar.gz
==> No patches needed for py-uwsgi
==> py-uwsgi: Executing phase: 'install'
==> py-uwsgi: Successfully installed py-uwsgi-2.0.27-fgzy2n2ofxdnpbg5ovahejavs5mgfqws
  Stage: 0.93s.  Install: 40.44s.  Post-install: 0.72s.  Total: 42.99s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-uwsgi-2.0.27-fgzy2n2ofxdnpbg5ovahejavs5mgfqws
```