### PR TITLE
Correcting yaml-cpp library path since it is lib64 in centos

### DIFF
--- a/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
+++ b/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
@@ -141,7 +141,7 @@ class RocmValidationSuite(CMakePackage):
                     f"-L{self.spec['hsakmt-roct'].prefix.lib} "
                     f"-L{self.spec['rocm-smi-lib'].prefix.lib} "
                     f"-L{self.spec['rocblas'].prefix.lib} "
-                    f"{self.spec['yaml-cpp'].prefix.lib}/libyaml-cpp.a ",
+                    f"{libloc}/libyaml-cpp.a ",
                 )
             )
             args.append(self.define("CPACK_PACKAGING_INSTALL_PREFIX", self.spec.prefix))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
