### PR TITLE
py-django: add v5.0.9, v5.1.1 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/py-asgiref/package.py
+++ b/var/spack/repos/builtin/packages/py-asgiref/package.py
@@ -14,6 +14,7 @@ class PyAsgiref(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.8.1", sha256="c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590")
     version("3.7.2", sha256="9e0ce3aa93a819ba5b45120216b23878cf6e8525eb3848653452b4192b92afed")
     version("3.5.2", sha256="4a29362a6acebe09bf1d6640db38c1dc3d9217c68e6f9f6204d72667fc19a424")
     version("3.5.0", sha256="2f8abc20f7248433085eda803936d98992f1343ddb022065779f37c5da0181d0")

--- a/var/spack/repos/builtin/packages/py-django/package.py
+++ b/var/spack/repos/builtin/packages/py-django/package.py
@@ -12,8 +12,10 @@ class PyDjango(PythonPackage):
     homepage = "https://www.djangoproject.com/"
     pypi = "Django/Django-5.0.1.tar.gz"
 
-    license("BSD-3-Clause")
+    license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("5.1.1", sha256="021ffb7fdab3d2d388bc8c7c2434eb9c1f6f4d09e6119010bbb1694dda286bc2")
+    version("5.0.9", sha256="6333870d342329b60174da3a60dbd302e533f3b0bb0971516750e974a99b5a39")
     version("5.0.1", sha256="8c8659665bc6e3a44fefe1ab0a291e5a3fb3979f9a8230be29de975e57e8f854")
     version("3.0.5", sha256="d4666c2edefa38c5ede0ec1655424c56dc47ceb04b6d8d62a7eac09db89545c1")
     version("3.0.4", sha256="50b781f6cbeb98f673aa76ed8e572a019a45e52bdd4ad09001072dfd91ab07c8")
@@ -25,8 +27,10 @@ class PyDjango(PythonPackage):
     version("2.2.10", sha256="1226168be1b1c7efd0e66ee79b0e0b58b2caa7ed87717909cd8a57bb13a7079a")
 
     depends_on("python@3.10:", when="@5:", type=("build", "run"))
-    depends_on("py-setuptools@40.8:", when="@5:", type="build")
+    depends_on("py-setuptools@61:69.2", when="@5.1:", type="build")
+    depends_on("py-setuptools@40.8:", when="@5:5.0", type="build")
     depends_on("py-setuptools", type="build")
+    depends_on("py-asgiref@3.8.1:3", when="@5.1:", type=("build", "run"))
     depends_on("py-asgiref@3.7:3", when="@5:", type=("build", "run"))
     depends_on("py-asgiref", type=("build", "run"))
     depends_on("py-sqlparse@0.3.1:", when="@5:", type=("build", "run"))


### PR DESCRIPTION
This PR adds `py-django`, v5.0.9 and v5.1.1, both of which fix CVE-2024-24680, CVE-2024-41989, CVE-2024-41990, CVE-2024-41991, CVE-2024-42005. Checked license. Updated dependencies.

Test builds:
```
==> Installing py-django-5.1.1-ih4bp6ut6ld6ign4mkcbfnzi7eju5hj4 [30/30]
==> No binary for py-django-5.1.1-ih4bp6ut6ld6ign4mkcbfnzi7eju5hj4 found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/D/Django/Django-5.1.1.tar.gz
==> No patches needed for py-django
==> py-django: Executing phase: 'install'
==> py-django: Successfully installed py-django-5.1.1-ih4bp6ut6ld6ign4mkcbfnzi7eju5hj4
  Stage: 1.71s.  Install: 8.65s.  Post-install: 1.94s.  Total: 12.43s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-django-5.1.1-ih4bp6ut6ld6ign4mkcbfnzi7eju5hj4
==> Installing py-django-5.0.9-sd5irc33iob3o5mythcsgqgtu4mebijy [31/31]
==> No binary for py-django-5.0.9-sd5irc33iob3o5mythcsgqgtu4mebijy found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/D/Django/Django-5.0.9.tar.gz
==> No patches needed for py-django
==> py-django: Executing phase: 'install'
==> py-django: Successfully installed py-django-5.0.9-sd5irc33iob3o5mythcsgqgtu4mebijy
  Stage: 3.30s.  Install: 57.47s.  Post-install: 7.15s.  Total: 1m 8.64s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-django-5.0.9-sd5irc33iob3o5mythcsgqgtu4mebijy
```