### PR TITLE
mlpack: add v4.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/hermes-shm/package.py
+++ b/var/spack/repos/builtin/packages/hermes-shm/package.py
@@ -37,6 +37,7 @@ class HermesShm(CMakePackage):
     variant("adios", default=False, description="Build Adios support")
 
     # Required deps
+    depends_on("pkgconfig", type="build")
     depends_on("catch2@3.0.1")
     depends_on("yaml-cpp")
     depends_on("doxygen@1.9.3", type="build")

--- a/var/spack/repos/builtin/packages/mlpack/package.py
+++ b/var/spack/repos/builtin/packages/mlpack/package.py
@@ -20,6 +20,7 @@ class Mlpack(CMakePackage):
 
     license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("4.5.0", sha256="aab70aee10c134ef3fe568843fe4b3bb5e8901af30ea666f57462ad950682317")
     version("4.4.0", sha256="61c604026d05af26c244b0e47024698bbf150dfcc9d77b64057941d7d64d6cf6")
     version("4.3.0", sha256="08cd54f711fde66fc3b6c9db89dc26776f9abf1a6256c77cfa3556e2a56f1a3d")
     version("4.2.1", sha256="2d2b8d61dc2e3179e0b6fefd5c217c57aa168c4d0b9c6868ddb94f6395a80dd5")
@@ -39,6 +40,7 @@ class Mlpack(CMakePackage):
     # CMakeLists.txt
     depends_on("cmake@3.6:", type="build")
     depends_on("armadillo@9.800:")
+    depends_on("armadillo@10.8:", when="@4.5:")
     depends_on("ensmallen@2.10.0:")
     depends_on("cereal@1.1.2:")
 
@@ -58,6 +60,7 @@ class Mlpack(CMakePackage):
         # ref: src/mlpack/bindings/python/CMakeLists.txt
         depends_on("py-cython@0.24:")
         depends_on("py-numpy")
+        depends_on("py-numpy@:1", when="@:4.4.0")
         depends_on("py-pandas@0.15.0:")
         # ref: src/mlpack/bindings/python/PythonInstall.cmake
         depends_on("py-pip")


### PR DESCRIPTION
This PR adds `mlpack`, v4.5.0. As outlined in the [release notes](https://github.com/mlpack/mlpack/releases/tag/4.5.0) (and verified by going through the diff), this requires newer armadillo and can now also support numpy-2. Also 4.4.1 will have support for numpy-2, so the range of the numpy-1 dependency is limited to 4.4.0.

Test build (defaults):
```
==> Installing mlpack-4.5.0-kvrgze6e7rcckneqsqjrygxzaoofq3a5 [34/34]
==> No binary for mlpack-4.5.0-kvrgze6e7rcckneqsqjrygxzaoofq3a5 found: installing from source
==> Fetching https://github.com/mlpack/mlpack/archive/refs/tags/4.5.0.tar.gz
==> No patches needed for mlpack
==> mlpack: Executing phase: 'cmake'
==> mlpack: Executing phase: 'build'
==> mlpack: Executing phase: 'install'
==> mlpack: Successfully installed mlpack-4.5.0-kvrgze6e7rcckneqsqjrygxzaoofq3a5
  Stage: 2.51s.  Cmake: 23.14s.  Build: 21m 33.32s.  Install: 1.00s.  Post-install: 0.80s.  Total: 22m 2.83s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/mlpack-4.5.0-kvrgze6e7rcckneqsqjrygxzaoofq3a5
```

Test build with `+python`:
```
==> Installing mlpack-4.5.0-5hpobtylwsndb6nfawregumq5mgfn6ak [57/57]
==> No binary for mlpack-4.5.0-5hpobtylwsndb6nfawregumq5mgfn6ak found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/aa/aab70aee10c134ef3fe568843fe4b3bb5e8901af30ea666f57462ad950682317.tar.gz
==> No patches needed for mlpack
==> mlpack: Executing phase: 'cmake'
==> mlpack: Executing phase: 'build'
==> mlpack: Executing phase: 'install'
==> mlpack: Successfully installed mlpack-4.5.0-5hpobtylwsndb6nfawregumq5mgfn6ak
  Stage: 0.19s.  Cmake: 3m 13.88s.  Build: 1h 1m 4.90s.  Install: 1h 5m 23.99s.  Post-install: 1.44s.  Total: 2h 9m 45.61s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/mlpack-4.5.0-5hpobtylwsndb6nfawregumq5mgfn6ak
```