### PR TITLE
ipopt: add 3.14.12 to 3.14.14, improve mumps integration

### DIFF
--- a/var/spack/repos/builtin/packages/ipopt/ipopt_mumps_mpi_comm_option.patch
+++ b/var/spack/repos/builtin/packages/ipopt/ipopt_mumps_mpi_comm_option.patch
@@ -1,0 +1,56 @@
+diff --git a/src/Algorithm/LinearSolvers/IpMumpsSolverInterface.cpp b/src/Algorithm/LinearSolvers/IpMumpsSolverInterface.cpp
+index 62089361..306966b4 100644
+--- a/src/Algorithm/LinearSolvers/IpMumpsSolverInterface.cpp
++++ b/src/Algorithm/LinearSolvers/IpMumpsSolverInterface.cpp
+@@ -97,13 +97,11 @@ MumpsSolverInterface::MumpsSolverInterface()
+    mumps_->job = -1; //initialize mumps
+    mumps_->par = 1; //working host for sequential version
+    mumps_->sym = 2; //general symmetric matrix
+-   mumps_->comm_fortran = USE_COMM_WORLD;
+ 
+ #ifndef IPOPT_MUMPS_NOMUTEX
+    const std::lock_guard<std::mutex> lock(mumps_call_mutex);
+ #endif
+ 
+-   mumps_c(mumps_);
+    mumps_->icntl[2] = 0;  // global info stream
+    mumps_->icntl[3] = 0;  // print level
+    mumps_ptr_ = (void*) mumps_;
+@@ -180,6 +178,11 @@ void MumpsSolverInterface::RegisterOptions(
+       "Threshold to consider a pivot at zero in detection of linearly dependent constraints with MUMPS.",
+       0.0,
+       "This is CNTL(3) in MUMPS.", true);
++   roptions->AddIntegerOption(
++      "mumps_mpi_communicator",
++      "MPI communicator used for matrix operations",
++      USE_COMM_WORLD,
++      "This sets the MPI communicator. MPI_COMM_WORLD is the default. Any other value should be the return value from MPI_Comm_c2f");
+ }
+ 
+ /// give name of MUMPS with version info
+@@ -217,13 +220,24 @@ bool MumpsSolverInterface::InitializeImpl(
+    options.GetIntegerValue("mumps_scaling", mumps_scaling_, prefix);
+    options.GetNumericValue("mumps_dep_tol", mumps_dep_tol_, prefix);
+ 
++   MUMPS_STRUC_C* mumps_ = static_cast<MUMPS_STRUC_C*>(mumps_ptr_);
++
++#ifndef IPOPT_MUMPS_NOMUTEX
++   const std::lock_guard<std::mutex> lock(mumps_call_mutex);
++#endif
++
++   Index mpi_comm;
++   options.GetIntegerValue("mumps_mpi_communicator", mpi_comm, prefix);
++   mumps_->comm_fortran = static_cast<int>(mpi_comm);
++
++   mumps_c(mumps_);
++
+    // Reset all private data
+    initialized_ = false;
+    pivtol_changed_ = false;
+    refactorize_ = false;
+    have_symbolic_factorization_ = false;
+ 
+-   MUMPS_STRUC_C* mumps_ = static_cast<MUMPS_STRUC_C*>(mumps_ptr_);
+    if( !warm_start_same_structure_ )
+    {
+       mumps_->n = 0;

--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -72,7 +72,7 @@ class Ipopt(AutotoolsPackage):
     build_directory = "spack-build"
 
     # IPOPT does not build correctly in parallel on OS X
-    parallel = False    def configure_args(self):
+    parallel = False
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -12,10 +12,13 @@ class Ipopt(AutotoolsPackage):
 
     homepage = "https://github.com/coin-or/Ipopt"
     url = "https://github.com/coin-or/Ipopt/archive/refs/tags/releases/3.13.2.tar.gz"
-    maintainers("goxberry")
+    maintainers("chapman39", "tepperly, goxberry")
 
     license("EPL-2.0")
 
+    version("3.14.14", sha256="264d2d3291cd1cd2d0fa0ad583e0a18199e3b1378c3cb015b6c5600083f1e036")
+    version("3.14.13", sha256="2afcb057e7cf8ed7e07f50ee0a4a06d2e4d39e0f964777e9dd55fe56199a5e0a")
+    version("3.14.12", sha256="6b06cd6280d5ca52fc97ca95adaaddd43529e6e8637c274e21ee1072c3b4577f")
     version("3.14.9", sha256="e12eba451269ec30f4cf6e2acb8b35399f0d029c97dff10465416f5739c8cf7a")
     version("3.14.5", sha256="9ebbbbf14a64e998e3fba5d2662a8f9bd03f97b1406017e78ae54e5d105ae932")
     version("3.14.4", sha256="60865150b6fad19c5968395b57ff4a0892380125646c3afa2a714926f5ac9487")
@@ -43,19 +46,19 @@ class Ipopt(AutotoolsPackage):
     version("3.12.1", sha256="bde8c415136bb38d5a3c5935757399760c6cabf67e9362702e59ab6027f030ec")
     version("3.12.0", sha256="b42f44eb53540205ede4584cced5d88a7b3ec2f1fac6e173a105496307e273a0")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     variant("coinhsl", default=False, description="Build with Coin Harwell Subroutine Libraries")
     variant("metis", default=False, description="Build with METIS partitioning support")
     variant("debug", default=False, description="Build debug instead of optimized version")
     variant("mumps", default=True, description="Build with support for linear solver MUMPS")
+    variant("java", default=False, description="Include Java support")
 
     depends_on("blas")
     depends_on("lapack")
     depends_on("pkgconfig", type="build")
-    depends_on("mumps+double~mpi", when="+mumps")
+    depends_on("mumps+double", when="+mumps")
     depends_on("coinhsl", when="+coinhsl")
     depends_on("metis@4.0:", when="+metis")
 
@@ -63,12 +66,13 @@ class Ipopt(AutotoolsPackage):
     conflicts("~mumps", when="~coinhsl")
 
     patch("ipopt_ppc_build.patch", when="arch=ppc64le")
+    patch("ipopt_mumps_mpi_comm_option.patch", when="+mumps")
 
     flag_handler = build_system_flags
     build_directory = "spack-build"
 
     # IPOPT does not build correctly in parallel on OS X
-    parallel = False
+    parallel = False    def configure_args(self):
 
     def configure_args(self):
         spec = self.spec
@@ -93,9 +97,11 @@ class Ipopt(AutotoolsPackage):
         else:
             args.extend(["--with-lapack-lflags={0} {1}".format(lapack_lib, blas_lib)])
 
-        if spec.satisfies("+mumps"):
+        if "+mumps" in spec:
             mumps_dir = spec["mumps"].prefix
-            mumps_flags = "-ldmumps -lmumps_common -lpord -lmpiseq"
+            mumps_flags = "-ldmumps -lmumps_common -lpord"
+            if "^mumps~mpi" in spec:
+                mumps_flags = mumps_flags + "-lmpiseq"
             mumps_libcmd = "-L%s " % mumps_dir.lib + mumps_flags
             if spec.satisfies("@:3.12.13"):
                 args.extend(
@@ -112,8 +118,11 @@ class Ipopt(AutotoolsPackage):
                         "--with-mumps-cflags=%s" % mumps_dir.include,
                     ]
                 )
+                if "^mumps+mpi" in spec:
+                    args.extend(["--disable-mpiinit"])
 
-        if spec.satisfies("^coinhsl"):
+
+        if spec.satisfies("+coinhsl"):
             hsl_ld_flags = "-ldl {0}".format(spec["coinhsl"].libs.ld_flags)
 
             if spec.satisfies("^coinhsl+blas"):
@@ -134,8 +143,12 @@ class Ipopt(AutotoolsPackage):
                         "--with-hsl-cflags=%s" % spec["coinhsl"].prefix.include,
                     ]
                 )
+        else:
+            # Fixes dynamic linking errors relating to failure to find hsllib.so
+            if spec.satisfies("@3.13:"):
+                args.extend(["--without-hsl"])
 
-        if spec.satisfies("^metis"):
+        if spec.satisfies("+metis"):
             if spec.satisfies("@:3.12.13"):
                 args.extend(
                     [
@@ -143,6 +156,11 @@ class Ipopt(AutotoolsPackage):
                         "--with-metis-incdir=%s" % spec["metis"].prefix.include,
                     ]
                 )
+
+        if spec.satisfies("+java"):
+            args.extend([ "--enable-java"])
+        else:
+            args.extend([ "--disable-java"])
 
         # The IPOPT configure file states that '--enable-debug' implies
         # '--disable-shared', but adding '--enable-shared' overrides

--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -12,7 +12,7 @@ class Ipopt(AutotoolsPackage):
 
     homepage = "https://github.com/coin-or/Ipopt"
     url = "https://github.com/coin-or/Ipopt/archive/refs/tags/releases/3.13.2.tar.gz"
-    maintainers("chapman39", "tepperly, goxberry")
+    maintainers("chapman39", "tepperly")
 
     license("EPL-2.0")
 

--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -121,7 +121,6 @@ class Ipopt(AutotoolsPackage):
                 if "^mumps+mpi" in spec:
                     args.extend(["--disable-mpiinit"])
 
-
         if spec.satisfies("+coinhsl"):
             hsl_ld_flags = "-ldl {0}".format(spec["coinhsl"].libs.ld_flags)
 
@@ -158,9 +157,9 @@ class Ipopt(AutotoolsPackage):
                 )
 
         if spec.satisfies("+java"):
-            args.extend([ "--enable-java"])
+            args.extend(["--enable-java"])
         else:
-            args.extend([ "--disable-java"])
+            args.extend(["--disable-java"])
 
         # The IPOPT configure file states that '--enable-debug' implies
         # '--disable-shared', but adding '--enable-shared' overrides

--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -97,7 +97,7 @@ class Ipopt(AutotoolsPackage):
         else:
             args.extend(["--with-lapack-lflags={0} {1}".format(lapack_lib, blas_lib)])
 
-        if "+mumps" in spec:
+        if spec.satisfies("+mumps"):
             mumps_dir = spec["mumps"].prefix
             mumps_flags = "-ldmumps -lmumps_common -lpord"
             if "^mumps~mpi" in spec:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

* Adds new ipopt versions
* Resolves issues using mumps as linear solver in an parallel program
 
Using mumps as ipopt's solver requires building `mumps+mpi` and setting `--disable-mpiinit` in ipopt's configuration. Additional information can be seen in this Ipopt PR https://github.com/coin-or/Ipopt/pull/790