### PR TITLE
Sqlite: force utf-8 for cross locale support

### DIFF
--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -294,6 +294,15 @@ class NMakeBuilder(spack.build_systems.nmake.NMakeBuilder):
     def makefile_name(self):
         return "Makefile.msc"
 
+    def setup_build_environment(self, env):
+        # setting CL does not override the compiler
+        # in MSVC, it allows for the specification
+        # of extra/common arguments
+        # here we use it to inject options for the compiler
+        # rather than patching sqlite's build
+        env.set("CL", "/utf-8")
+
+
     def nmake_args(self):
         enable_fts = "1" if "+fts" in self.spec else "0"
         enable_rtree = "1" if "+rtree" in self.spec else "0"

--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -302,7 +302,6 @@ class NMakeBuilder(spack.build_systems.nmake.NMakeBuilder):
         # rather than patching sqlite's build
         env.set("CL", "/utf-8")
 
-
     def nmake_args(self):
         enable_fts = "1" if "+fts" in self.spec else "0"
         enable_rtree = "1" if "+rtree" in self.spec else "0"


### PR DESCRIPTION
Sqlite's source has some unicode characters that are breaking MSVC based builds in some locales. This PR is an attempt to allow for better cross locale support (alternative approach is for Spack to start mucking about w/ locale settings, which is a bit more involved on Windows).

Fixes https://github.com/spack/spack/issues/46241
(I hope)