### PR TITLE
MSVC: Restore amalgamated compiler functionality

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -265,7 +265,7 @@ def find_compilers(
     if sys.platform == "win32":
         default_paths.extend(windows_os.WindowsOs().compiler_search_paths)
     compiler_pkgs = spack.repo.PATH.packages_with_tags(COMPILER_TAG, full=True)
-    import pdb; pdb.set_trace()
+
     detected_packages = spack.detection.by_path(
         compiler_pkgs, path_hints=default_paths, max_workers=max_workers
     )

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -265,7 +265,7 @@ def find_compilers(
     if sys.platform == "win32":
         default_paths.extend(windows_os.WindowsOs().compiler_search_paths)
     compiler_pkgs = spack.repo.PATH.packages_with_tags(COMPILER_TAG, full=True)
-
+    import pdb; pdb.set_trace()
     detected_packages = spack.detection.by_path(
         compiler_pkgs, path_hints=default_paths, max_workers=max_workers
     )

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -87,7 +87,7 @@ def dedupe_paths(paths: List[str]) -> List[str]:
         #         etc
         # checking if latest/bin is a symlink will return false because the bin directory
         # is not a symlink, and will cause the "latest/bin" dir to override the "2025.0/bin"
-        # checking for all parent paths of our detected binaries will prevent this case 
+        # checking for all parent paths of our detected binaries will prevent this case
         elif not any([llnl.util.symlink.islink(str(x)) for x in pathlib.Path(path).parents]):
             seen[identifier] = path
     return list(seen.values())

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -353,8 +353,6 @@ class Finder:
         if initial_guess is None:
             initial_guess = self.default_path_hints()
             initial_guess.extend(common_windows_package_paths(pkg_cls))
-        if pkg_name == "builtin.msvc":
-            import pdb; pdb.set_trace()
         candidates = self.candidate_files(patterns=patterns, paths=initial_guess)
         result = self.detect_specs(pkg=pkg_cls, paths=candidates)
         return result
@@ -444,20 +442,20 @@ def by_path(
     repository = spack.repo.PATH.ensure_unwrapped()
     with spack.util.parallel.make_concurrent_executor(max_workers, require_fork=False) as executor:
         for pkg in packages_to_search:
-            # executable_future = executor.submit(
-            #     executables_finder.find,
-            #     pkg_name=pkg,
-            #     initial_guess=path_hints,
-            #     repository=repository,
-            # )
-            # library_future = executor.submit(
-            #     libraries_finder.find,
-            #     pkg_name=pkg,
-            #     initial_guess=path_hints,
-            #     repository=repository,
-            # )
-            # detected_specs_by_package[pkg] = executable_future, library_future
-            executables_finder.find(pkg_name=pkg, initial_guess=path_hints, repository=repository)
+            executable_future = executor.submit(
+                executables_finder.find,
+                pkg_name=pkg,
+                initial_guess=path_hints,
+                repository=repository,
+            )
+            library_future = executor.submit(
+                libraries_finder.find,
+                pkg_name=pkg,
+                initial_guess=path_hints,
+                repository=repository,
+            )
+            detected_specs_by_package[pkg] = executable_future, library_future
+            # executables_finder.find(pkg_name=pkg, initial_guess=path_hints, repository=repository)
 
         for pkg_name, futures in detected_specs_by_package.items():
             for future in futures:

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -272,8 +272,7 @@ class Finder:
             return []
 
         result = []
-        # we cannot group by prefix here, not all the paths for a given package are in the same prefix
-        # oneAPI + MSVC integration
+
         for candidate_path, items_in_prefix in _group_by_prefix(
             llnl.util.lang.dedupe(paths)
         ).items():
@@ -455,7 +454,6 @@ def by_path(
                 repository=repository,
             )
             detected_specs_by_package[pkg] = executable_future, library_future
-            # executables_finder.find(pkg_name=pkg, initial_guess=path_hints, repository=repository)
 
         for pkg_name, futures in detected_specs_by_package.items():
             for future in futures:

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -74,6 +74,9 @@ def dedupe_paths(paths: List[str]) -> List[str]:
     This ensures that we pick for example ``/usr/bin`` over ``/bin`` if the latter is a symlink to
     the former."""
     seen: Dict[Tuple[int, int], str] = {}
+
+    linked_parent_check = lambda x: any([llnl.util.symlink.islink(str(y)) for y in pathlib.Path(x).parents])
+
     for path in paths:
         identifier = file_identifier(path)
         if identifier not in seen:
@@ -88,7 +91,7 @@ def dedupe_paths(paths: List[str]) -> List[str]:
         # checking if latest/bin is a symlink will return false because the bin directory
         # is not a symlink, and will cause the "latest/bin" dir to override the "2025.0/bin"
         # checking for all parent paths of our detected binaries will prevent this case
-        elif not any([llnl.util.symlink.islink(str(x)) for x in pathlib.Path(path).parents]):
+        elif not (llnl.util.symlink.islink(path) or linked_parent_check(path)):
             seen[identifier] = path
     return list(seen.values())
 

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -75,7 +75,9 @@ def dedupe_paths(paths: List[str]) -> List[str]:
     the former."""
     seen: Dict[Tuple[int, int], str] = {}
 
-    linked_parent_check = lambda x: any([llnl.util.symlink.islink(str(y)) for y in pathlib.Path(x).parents])
+    linked_parent_check = lambda x: any(
+        [llnl.util.symlink.islink(str(y)) for y in pathlib.Path(x).parents]
+    )
 
     for path in paths:
         identifier = file_identifier(path)

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -83,16 +83,9 @@ def dedupe_paths(paths: List[str]) -> List[str]:
         identifier = file_identifier(path)
         if identifier not in seen:
             seen[identifier] = path
-        # OneAPI symlinks a "latest" directory to a versioned directory
-        # where the layout is something like:
-        # latest -> 2025.0
-        # 2025.0  /
-        #         | - bin
-        #         | - lib
-        #         etc
-        # checking if latest/bin is a symlink will return false because the bin directory
-        # is not a symlink, and will cause the "latest/bin" dir to override the "2025.0/bin"
-        # checking for all parent paths of our detected binaries will prevent this case
+        # we also want to deprioritize paths if they contain a symlink in any parent 
+        # (not just the basedir): e.g. oneapi has "latest/bin",
+        # where "latest" is a symlink to 2025.0"
         elif not (llnl.util.symlink.islink(path) or linked_parent_check(path)):
             seen[identifier] = path
     return list(seen.values())
@@ -277,7 +270,6 @@ class Finder:
             return []
 
         result = []
-
         for candidate_path, items_in_prefix in _group_by_prefix(
             llnl.util.lang.dedupe(paths)
         ).items():

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -83,7 +83,7 @@ def dedupe_paths(paths: List[str]) -> List[str]:
         identifier = file_identifier(path)
         if identifier not in seen:
             seen[identifier] = path
-        # we also want to deprioritize paths if they contain a symlink in any parent 
+        # we also want to deprioritize paths if they contain a symlink in any parent
         # (not just the basedir): e.g. oneapi has "latest/bin",
         # where "latest" is a symlink to 2025.0"
         elif not (llnl.util.symlink.islink(path) or linked_parent_check(path)):

--- a/var/spack/repos/builtin/packages/msvc/package.py
+++ b/var/spack/repos/builtin/packages/msvc/package.py
@@ -31,7 +31,7 @@ class Msvc(Package, CompilerPackage):
             "detected on a system where they are externally installed"
         )
 
-    compiler_languages = ["c", "cxx"]
+    compiler_languages = ["c", "cxx", "fortran"]
     c_names = ["cl"]
     cxx_names = ["cl"]
     fortran_names = ["ifx", "ifort"]

--- a/var/spack/repos/builtin/packages/msvc/package.py
+++ b/var/spack/repos/builtin/packages/msvc/package.py
@@ -6,8 +6,8 @@ import re
 import spack.compiler
 from spack.package import *
 
-
 FC_PATH: Dict[str, str] = dict()
+
 
 def get_valid_fortran_pth():
     """Assign maximum available fortran compiler version"""

--- a/var/spack/repos/builtin/packages/msvc/package.py
+++ b/var/spack/repos/builtin/packages/msvc/package.py
@@ -7,6 +7,17 @@ import spack.compiler
 from spack.package import *
 
 
+FC_PATH: Dict[str, str] = dict()
+
+def get_valid_fortran_pth():
+    """Assign maximum available fortran compiler version"""
+    # TODO (johnwparent): validate compatibility w/ try compiler
+    # functionality when added
+    sort_fn = lambda fc_ver: Version(fc_ver)
+    sort_fc_ver = sorted(list(FC_PATH.keys()), key=sort_fn)
+    return FC_PATH[sort_fc_ver[-1]] if sort_fc_ver else None
+
+
 class Msvc(Package, CompilerPackage):
     """
     Microsoft Visual C++ is a compiler for the C, C++, C++/CLI and C++/CX programming languages.
@@ -23,6 +34,8 @@ class Msvc(Package, CompilerPackage):
     compiler_languages = ["c", "cxx"]
     c_names = ["cl"]
     cxx_names = ["cl"]
+    fortran_names = ["ifx", "ifort"]
+
     compiler_version_argument = ""
     compiler_version_regex = r"([1-9][0-9]*\.[0-9]*\.[0-9]*)"
 
@@ -30,6 +43,7 @@ class Msvc(Package, CompilerPackage):
     def determine_version(cls, exe):
         # MSVC compiler does not have a proper version argument
         # Errors out and prints version info with no args
+        # We need to support amalgamated MSVC/ONEAPI compilers
         match = re.search(
             cls.compiler_version_regex,
             spack.compiler.get_compiler_version_output(exe, version_arg=None, ignore_errors=True),

--- a/var/spack/repos/builtin/packages/msvc/package.py
+++ b/var/spack/repos/builtin/packages/msvc/package.py
@@ -58,15 +58,15 @@ class Msvc(Package, CompilerPackage):
         # MSVC uses same executable for both languages
         spec, extras = super().determine_variants(exes, version_str)
         extras["compilers"]["c"] = extras["compilers"]["cxx"]
-        # manually populate intel compilers stored from previous
-        # attempt to detect the intel compilers
-        # compiler detection sorts the detected paths, so oneAPI
-        # will always be interrogated as msvc before MSVC is
-        # this means we can store the oneAPI detections, and
-        # then use them to manually populate the MSVC compiler entries
-        # TODO: remove this once compilers as nodes lands
+        # This depends on oneapi being processed before msvc
+        # which is guarunteed from detection behavior.
+        # Processing oneAPI tracks oneAPI installations within
+        # this module, which are then used to populate compatible
+        # MSVC version's fortran compiler spots
+
+        # TODO: remove this once #45189 lands
         # TODO: interrogate intel and msvc for compatibility after
-        # compilers as nodes lands
+        # #45189 lands
         extras["compilers"]["fortran"] = get_latest_valid_fortran_pth()
         return spec, extras
 


### PR DESCRIPTION
At some point the compiler refactors broke the ability of MSVC to detect OneAPI as part of its amalgamated compiler modeling. This PR attempts to restore that.

* Adds Intel Fortran detection existing in the previous compiler classes to the MSVC object to allow for assignment of detected fortran executables to appropriate C/C++ compilers

* Allows OneAPIs installation structure to be appropriately evaluated during detection

OneAPI's install layout symlinks a "latest" directory to a versioned directory where the layout is something like:
```
 latest -> 2025.0
 2025.0  - | - bin - | 
                     | - ifx.exe
                | - include
                | - lib
               etc
```
Previous behavior evaluated the direct parent of a detected executable to ensure symlinks were replaced by the resolved path referenced by the symlink, however, in the case above, this is insufficient to ensure that "latest" would be replaced by corresponding versioned options. Failing to do this results in an ifx detection associated with a static version in Spack, but in reality, that version can change as the latest symlink is updated by subsequent OneAPI updates.
This PR instead iterates up the parents of a detected executable, checking if a symlink is present in any parents, and if so, preferring a non symlinked path.