### PR TITLE
vmd: add LD_LIBRARY_PATH prepends

### DIFF
--- a/var/spack/repos/builtin/packages/vmd/package.py
+++ b/var/spack/repos/builtin/packages/vmd/package.py
@@ -60,3 +60,5 @@ class Vmd(Package):
 
     def setup_run_environment(self, env):
         env.set("PLUGINDIR", self.spec.prefix.lib64.plugins)
+        env.prepend_path('LD_LIBRARY_PATH', '/lib64')
+        env.prepend_path('LD_LIBRARY_PATH', self.prefix.lib64)


### PR DESCRIPTION
To run vmd we need to link the these two shared library locations.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
