### PR TITLE
 postgresql: Add icu4c dependency for versions 16+

### DIFF
--- a/var/spack/repos/builtin/packages/postgresql/package.py
+++ b/var/spack/repos/builtin/packages/postgresql/package.py
@@ -105,7 +105,7 @@ class Postgresql(AutotoolsPackage):
         if spec.satisfies("+xml"):
             args.append("--with-libxml")
 
-        if not spec.satisfies("+icu"):
+        if spec.satisfies("~icu"):
             args.append("--without-icu")
 
         return args

--- a/var/spack/repos/builtin/packages/postgresql/package.py
+++ b/var/spack/repos/builtin/packages/postgresql/package.py
@@ -64,7 +64,7 @@ class Postgresql(AutotoolsPackage):
     variant("tcl", default=False, description="Enable Tcl bindings.")
     variant("gssapi", default=False, description="Build with GSSAPI functionality.")
     variant("xml", default=False, description="Build with XML support.")
-    variant("icu", default=True, description="Build with ICU support.")
+    variant("icu", default=True, description="Build with ICU support.", when="@16:")
 
     depends_on("icu4c", when="@16: +icu")
     depends_on("readline", when="lineedit=readline")

--- a/var/spack/repos/builtin/packages/postgresql/package.py
+++ b/var/spack/repos/builtin/packages/postgresql/package.py
@@ -64,8 +64,9 @@ class Postgresql(AutotoolsPackage):
     variant("tcl", default=False, description="Enable Tcl bindings.")
     variant("gssapi", default=False, description="Build with GSSAPI functionality.")
     variant("xml", default=False, description="Build with XML support.")
+    variant("icu", default=True, description="Build with ICU support.")
 
-    depends_on("icu4c", when="@16:")
+    depends_on("icu4c", when="@16: +icu")
     depends_on("readline", when="lineedit=readline")
     depends_on("libedit", when="lineedit=libedit")
     depends_on("openssl")
@@ -103,6 +104,9 @@ class Postgresql(AutotoolsPackage):
 
         if spec.satisfies("+xml"):
             args.append("--with-libxml")
+
+        if not spec.satisfies("+icu"):
+            args.append("--without-icu")
 
         return args
 

--- a/var/spack/repos/builtin/packages/postgresql/package.py
+++ b/var/spack/repos/builtin/packages/postgresql/package.py
@@ -65,6 +65,7 @@ class Postgresql(AutotoolsPackage):
     variant("gssapi", default=False, description="Build with GSSAPI functionality.")
     variant("xml", default=False, description="Build with XML support.")
 
+    depends_on("icu4c", when="@16:")
     depends_on("readline", when="lineedit=readline")
     depends_on("libedit", when="lineedit=libedit")
     depends_on("openssl")


### PR DESCRIPTION
The dependency for icu4c was missing. It is needed for versions 16+ unless explicitly excluded when configuring.
Should address #46287.

I checked:
"postgresql +client_only" - will come with ICU (icu4c) now.
"postgresql -icu" - no ICU

Both seem to work for me.