### PR TITLE
kafka: add v2.13-3.7.1, v2.13-3.8.0, remove v2.13-3.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/kafka/package.py
+++ b/var/spack/repos/builtin/packages/kafka/package.py
@@ -21,7 +21,10 @@ class Kafka(Package):
     license("EPL-2.0")
 
     version(
-        "2.13-3.7.0", sha256="65f26e5937bbb76dfe78dfb416730dfa7e3378b27e13fd1e204f1a1099bfaf9c"
+        "2.13-3.8.0", sha256="e0297cc6fdb09ef9d9905751b25d2b629c17528f8629b60561eeff87ce29099c"
+    )
+    version(
+        "2.13-3.7.1", sha256="62acae4a143dd983dc7eb4804d5744ba0c50b199b508f599ef001020e2558fc9"
     )
     version(
         "2.13-3.5.1", sha256="f7b74d544023f2c0ec52a179de59975cb64e34ea03650d829328b407b560e4da"

--- a/var/spack/repos/builtin/packages/kafka/package.py
+++ b/var/spack/repos/builtin/packages/kafka/package.py
@@ -27,6 +27,11 @@ class Kafka(Package):
         "2.13-3.7.1", sha256="62acae4a143dd983dc7eb4804d5744ba0c50b199b508f599ef001020e2558fc9"
     )
     version(
+        "2.13-3.7.0",
+        sha256="65f26e5937bbb76dfe78dfb416730dfa7e3378b27e13fd1e204f1a1099bfaf9c",
+        deprecated=True
+    )
+    version(
         "2.13-3.5.1", sha256="f7b74d544023f2c0ec52a179de59975cb64e34ea03650d829328b407b560e4da"
     )
     version(

--- a/var/spack/repos/builtin/packages/kafka/package.py
+++ b/var/spack/repos/builtin/packages/kafka/package.py
@@ -29,7 +29,7 @@ class Kafka(Package):
     version(
         "2.13-3.7.0",
         sha256="65f26e5937bbb76dfe78dfb416730dfa7e3378b27e13fd1e204f1a1099bfaf9c",
-        deprecated=True
+        deprecated=True,
     )
     version(
         "2.13-3.5.1", sha256="f7b74d544023f2c0ec52a179de59975cb64e34ea03650d829328b407b560e4da"


### PR DESCRIPTION
This PR adds versions 2.13-3.8.0 and 2.13-3.7.1. It also removes 2.13-3.7.0, which can no longer be downloaded.

Note that Apache seems to be removing versions from https://downloads.apache.org/kafka/ as they publish new ones or as they patch older versions. Most of the versions listed in the spack package cannot be downloaded anymore from this address, they are instead downloaded from spack's source cache right now. It looks like 2.13-3.7.0 wasn't in the source cache and is therefore lost.