### PR TITLE
NOT A REAL PR: Windows CI Diagnostic (Part 3)

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1871,8 +1871,7 @@ def report_tarball_fetch_verify_exceptions():
     for exc in _tarball_fetch_and_verify_exceptions:
         exc[0].add_note(f"component failure: {exc[1]}")
         except_to_raise.append(exc[0])
-
-    print(ExceptionGroup("Spack buildcache fetch & verify exceptions", except_to_raise))
+        print(exc[0])
 
 
 def _delete_staged_downloads(download_result):

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1869,9 +1869,8 @@ def try_fetch(url_to_fetch):
 def report_tarball_fetch_verify_exceptions():
     except_to_raise = []
     for exc in _tarball_fetch_and_verify_exceptions:
-        exc[0].add_note(f"component failure: {exc[1]}")
         except_to_raise.append(exc[0])
-        print(exc[0])
+        print(f"failed component: {exc[1]} as {exc[0]} ")
 
 
 def _delete_staged_downloads(download_result):

--- a/share/spack/gitlab/cloud_pipelines/configs/win64/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/win64/ci.yaml
@@ -7,12 +7,12 @@ ci:
       before_script::
       - fsutil 8dot3name set C:\ 0
       - . .\share\spack\setup-env.ps1
-      - If (Test-Path -path C:\\key\intermediate_ci_signing_key.gpg) { spack.ps1 gpg trust C:\\key\intermediate_ci_signing_key.gpg }
-      - If (Test-Path -path C:\\key\spack_public_key.gpg) { spack.ps1 gpg trust C:\\key\spack_public_key.gpg }
+      - If (Test-Path -path C:/key/intermediate_ci_signing_key.gpg) { spack.ps1 gpg trust C:/key/intermediate_ci_signing_key.gpg }
+      - If (Test-Path -path C:/key/spack_public_key.gpg) { spack.ps1 gpg trust C:/key/spack_public_key.gpg }
 
       script::
       - spack.ps1 env activate --without-view ${SPACK_CONCRETE_ENV_DIR}
       - spack.ps1 config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{hash}'"
       - mkdir ${SPACK_ARTIFACTS_ROOT}/user_data
-      - spack.ps1 --backtrace ci rebuild | Tee-Object -FilePath "${env:SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt" 2>&1 | Tee-Object -FilePath "${env:SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt"
+      - spack.ps1 --backtrace -dv ci rebuild | Tee-Object -FilePath "${env:SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt" 2>&1 | Tee-Object -FilePath "${env:SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt"
       image: "ghcr.io/johnwparent/windows-server21h2:sha-1c12b61"

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -113,6 +113,7 @@ class Hdf5(CMakePackage):
         values=("default", "v116", "v114", "v112", "v110", "v18", "v16"),
         multi=False,
     )
+    variant("fake", default=True, description="DELETE ME")
 
     depends_on("cmake@3.12:", type="build")
     depends_on("cmake@3.18:", type="build", when="@1.13:")


### PR DESCRIPTION
NOT A REAL PR

Windows CI is behaving oddly again, PR to test

Issue: specs pulled from develop buildcaches are either failing to download or failing to validate signatures and failing semi-silently during one of those processes. Specs from intermediate package rebuild job caches are perfectly fine.

Testing strategy:

Modify package that uses buildcache from develop (hdf5)
Update error reporting in buildcache module

cc @kwryankrattiger @scheibelp 