### PR TITLE
python: Fix setup.py for split libtinfo when building the curses module

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -445,6 +445,13 @@ class Python(Package):
         ff.filter(
             r"^(.*)setup\.py(.*)((build)|(install))(.*)$", r"\1setup.py\2 --no-user-cfg \3\6"
         )
+        # NOTE: Python<=3.11's setup.py uses ldd to find the terminfo/cap library
+        # that its libreadline uses. In the case of a split libtinfo, this fails.
+        # To solve this, we add the tinfo library to the list of libraries that
+        # setup.py searches for when looking for a curses terminal library.
+        # This fixes using external and internal curses builds with split libtinfo:
+        if os.path.exists("setup.py"):  # 3.12.0+ replaced setup.py:
+            filter_file(r"(n\?curses)", r"(\1|tinfo)", "setup.py")
 
     def setup_build_environment(self, env):
         spec = self.spec


### PR DESCRIPTION
Fix missing `_curses` module when `libtinfo` is split from `libncurses`:

In such cases, the default build of `python` in `spack` succeeds, but 'import curses' fails due to missing the `_curses` module.

This is triggered when `libreadline` is built using a separate `libtinfow` library (e.g. from `ncurses+termlib`, which is the default in `spack`.

Fix building the `_curses` module in such cases.

Implementation: The `detect_modules` function of Python's `setup.py` uses `ldd` to find the curses library that its `libreadline` uses in order to use the same library also for the `_curses` module.

The detection function expects to have a `libreadline` that is linked to a library matching `libn?cursesw?` or `libtinfo`, but it does not expect a `libtinfow` library.

This was fixed in Python 3.12, but older Python versions are affected.

Support `libreadline` libraries linked against `libtinfow` by extending the regular expression in the code path that supports `libncursesw` to also support `libtinfow`.

This helps to build `firefox` in #45083 using `spack`. For details, see https://github.com/spack/spack/pull/45083#pullrequestreview-2335033403

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
