### PR TITLE
flux-sched: Use the spack-provided python interpreter/env

### DIFF
--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -19,7 +19,7 @@ class FluxSched(CMakePackage, AutotoolsPackage):
     git = "https://github.com/flux-framework/flux-sched.git"
     tags = ["radiuss", "e4s"]
 
-    maintainers("grondo")
+    maintainers("trws", "jameshcorbett")
 
     license("LGPL-3.0-only")
 

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -171,6 +171,9 @@ class FluxSched(CMakePackage, AutotoolsPackage):
     def lua_lib_dir(self):
         return os.path.join("lib", "lua", str(self.lua_version))
 
+    def setup_build_environment(self, env):
+        env.prepend_path("PYTHON", os.path.join(self.spec["python"].prefix.bin, "python3"))
+
     def setup_run_environment(self, env):
         # If this package is external, we expect the external provider to set
         # things like LUA paths. So, we early return. If the package is not
@@ -192,7 +195,6 @@ class FluxSched(CMakePackage, AutotoolsPackage):
         env.prepend_path("FLUX_MODULE_PATH", self.prefix.lib64.flux.modules.sched)
         env.prepend_path("FLUX_EXEC_PATH", self.prefix.libexec.flux.cmd)
         env.prepend_path("FLUX_RC_EXTRA", self.prefix.etc.flux)
-        env.prepend_path("PYTHON", os.path.join(self.spec["python"].prefix.bin, "python3"))
 
 
 class CMakeBuilder(CMakeBuilder):

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -64,6 +64,7 @@ class FluxSched(CMakePackage, AutotoolsPackage):
     depends_on(
         "boost+exception+filesystem+system+serialization+graph+container+regex@1.53.0,1.59.0: "
     )
+    depends_on("python@3.6:", type=("build", "run"))
     depends_on("py-pyyaml@3.10:", type=("build", "run"))
     depends_on("py-jsonschema@2.3:", type=("build", "run"))
     depends_on("libedit")
@@ -191,6 +192,7 @@ class FluxSched(CMakePackage, AutotoolsPackage):
         env.prepend_path("FLUX_MODULE_PATH", self.prefix.lib64.flux.modules.sched)
         env.prepend_path("FLUX_EXEC_PATH", self.prefix.libexec.flux.cmd)
         env.prepend_path("FLUX_RC_EXTRA", self.prefix.etc.flux)
+        env.prepend_path("PYTHON", os.path.join(self.spec["python"].prefix.bin, "python3"))
 
 
 class CMakeBuilder(CMakeBuilder):

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -172,7 +172,7 @@ class FluxSched(CMakePackage, AutotoolsPackage):
         return os.path.join("lib", "lua", str(self.lua_version))
 
     def setup_build_environment(self, env):
-        env.prepend_path("PYTHON", os.path.join(self.spec["python"].prefix.bin, "python3"))
+        env.set("PYTHON", self.spec["python"].command.path)
 
     def setup_run_environment(self, env):
         # If this package is external, we expect the external provider to set


### PR DESCRIPTION
`flux-sched` package will pick up the system python if not explicitly pointed towards a dependency.  An alternative method could be to pass it to CMake explicitly instead of using an environment variable, but I don't have the means to test it.  This issue was also not consistent, as it appeared on one of our machines, but not another just like it.
