### PR TITLE
GoPackage: fix attributes to allow for custom build_directory values

### DIFF
--- a/lib/spack/spack/build_systems/go.py
+++ b/lib/spack/spack/build_systems/go.py
@@ -44,15 +44,26 @@ class GoBuilder(BaseBuilder):
         +-----------------------------------------------+--------------------+
         | **Method**                                    | **Purpose**        |
         +===============================================+====================+
-        | :py:meth:`~.GoBuilder.build_args`             | Specify arguments  |
+        | :py:attr:`~.GoBuilder.build_args`             | Specify arguments  |
         |                                               | to ``go build``    |
         +-----------------------------------------------+--------------------+
-        | :py:meth:`~.GoBuilder.check_args`             | Specify arguments  |
+        | :py:attr:`~.GoBuilder.check_args`             | Specify arguments  |
         |                                               | to ``go test``     |
         +-----------------------------------------------+--------------------+
     """
 
     phases = ("build", "install")
+
+    #: Names associated with package methods in the old build-system format
+    legacy_methods = ("check", "installcheck")
+
+    #: Names associated with package attributes in the old build-system format
+    legacy_attributes = (
+        "build_args",
+        "check_args",
+        "build_directory",
+        "install_time_test_callbacks",
+    )
 
     #: Callback names for install-time test
     install_time_test_callbacks = ["check"]

--- a/var/spack/repos/builtin/packages/glab/package.py
+++ b/var/spack/repos/builtin/packages/glab/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Glab(Package):
+class Glab(GoPackage):
     """GitLab's official command line tool."""
 
     homepage = "https://gitlab.com/gitlab-org/cli"
@@ -41,15 +41,20 @@ class Glab(Package):
     depends_on("go@1.22.5:", type="build", when="@1.44:")
     depends_on("go@1.23:", type="build", when="@1.46:")
 
-    phases = ["build", "install"]
+    build_directory = "cmd/glab"
 
-    def setup_build_environment(self, env):
-        # Point GOPATH at the top of the staging dir for the build step.
-        env.prepend_path("GOPATH", self.stage.path)
+    @run_after("install")
+    def install_completions(self):
+        glab = Executable(self.prefix.bin.glab)
 
-    def build(self, spec, prefix):
-        make()
+        mkdirp(bash_completion_path(self.prefix))
+        with open(bash_completion_path(self.prefix) / "glab", "w") as file:
+            glab("completion", "-s", "bash", output=file)
 
-    def install(self, spec, prefix):
-        mkdirp(prefix.bin)
-        install("bin/glab", prefix.bin)
+        mkdirp(fish_completion_path(self.prefix))
+        with open(fish_completion_path(self.prefix) / "glab.fish", "w") as file:
+            glab("completion", "-s", "fish", output=file)
+
+        mkdirp(zsh_completion_path(self.prefix))
+        with open(zsh_completion_path(self.prefix) / "_glab", "w") as file:
+            glab("completion", "-s", "zsh", output=file)


### PR DESCRIPTION
`GoPackage` previously didn't allow users to modify attributes of the base class without modifying the GoBuilder class.

This PR fixes that bug allowing legacy attributes to be overwritten as is present in other build system classes.

Show the possibilities of the modifications by updating `glab` to be a `GoPackage`.