### PR TITLE
edm4hep: fix concretization by adding a when inside the conditional

### DIFF
--- a/var/spack/repos/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/builtin/packages/edm4hep/package.py
@@ -52,7 +52,7 @@ class Edm4hep(CMakePackage):
 
     depends_on("cxx", type="build")  # generated
 
-    _cxxstd_values = (conditional("17", when="@:0.99.0"), conditional("20"))
+    _cxxstd_values = (conditional("17", when="@:0.99.0"), conditional("20", when="@0.10:"))
     variant(
         "cxxstd",
         default="20",


### PR DESCRIPTION
otherwise it will error since conditional requires `when`. I picked the oldest version available in the recipe but support for C++20 should be there since 0.3.1 or so.