### PR TITLE
tests: fix wrong install name

### DIFF
--- a/var/spack/repos/builtin.mock/packages/quux/package.py
+++ b/var/spack/repos/builtin.mock/packages/quux/package.py
@@ -142,7 +142,7 @@ const int quux_version_minor = %s;
                 "-o",
                 "libquux.dylib",
                 "-install_name",
-                "@rpath/libcorge.dylib",
+                "@rpath/libquux.dylib",
                 "quux.cc.o",
                 "-Wl,-rpath,%s" % prefix.lib64,
                 "-Wl,-rpath,%s" % spec["garply"].prefix.lib64,


### PR DESCRIPTION
xcode's linker

```
@(#)PROGRAM:ld PROJECT:ld-1115.7.3
BUILD 13:29:00 Aug  9 2024
```

errors when linking a shared library with the same install name as the library being created.

This happens in spack tests due to a copy and paste issue.