### PR TITLE
fds: add v6.9.0, v6.9.1 and openmp

### DIFF
--- a/var/spack/repos/builtin/packages/fds/package.py
+++ b/var/spack/repos/builtin/packages/fds/package.py
@@ -21,7 +21,13 @@ class Fds(MakefilePackage):
     url = "https://github.com/firemodels/fds/archive/refs/tags/FDS-6.8.0.tar.gz"
     git = "https://github.com/firemodels/fds.git"
 
+    version("6.9.1", commit="889da6ae08d08dae680f7c0d8de66a3ad1c65375")
+    version("6.9.0", commit="63395692607884566fdedb5db4b5b4d98d3bcafb")
     version("6.8.0", commit="886e0096535519b7358a3c4393c91da3caee5072")
+
+    variant("openmp", default=False, description="Enable OpenMP support")
+
+    conflicts('%gcc', when='+openmp', msg="GCC already provides OpenMP supporti")
 
     depends_on("fortran", type="build")  # generated
 
@@ -86,11 +92,12 @@ class Fds(MakefilePackage):
         mpi_prefix = mpi_mapping[spec["mpi"].name]
         compiler_prefix = compiler_mapping[spec.compiler.name]
         platform_prefix = platform_mapping[spec.architecture.platform]
-        return ["{}_{}_{}".format(mpi_prefix, compiler_prefix, platform_prefix)]
+        openmp_prefix = '_openmp' if '+openmp' in spec else ''
+        return [f"{mpi_prefix}_{compiler_prefix}_{platform_prefix}{openmp_prefix}"]
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         with working_dir(self.build_directory):
             install("*.mod", prefix.bin)
             install("*.o", prefix.bin)
-            install("fds_" + self.build_targets[0], prefix.bin + "/fds")
+            install("fds_" + self.build_targets[0], join_path(prefix.bin, "fds"))

--- a/var/spack/repos/builtin/packages/fds/package.py
+++ b/var/spack/repos/builtin/packages/fds/package.py
@@ -27,7 +27,7 @@ class Fds(MakefilePackage):
 
     variant("openmp", default=False, description="Enable OpenMP support")
 
-    conflicts('%gcc', when='+openmp', msg="GCC already provides OpenMP supporti")
+    conflicts("%gcc", when="+openmp", msg="GCC already provides OpenMP support")
 
     depends_on("fortran", type="build")  # generated
 
@@ -92,7 +92,7 @@ class Fds(MakefilePackage):
         mpi_prefix = mpi_mapping[spec["mpi"].name]
         compiler_prefix = compiler_mapping[spec.compiler.name]
         platform_prefix = platform_mapping[spec.architecture.platform]
-        openmp_prefix = '_openmp' if '+openmp' in spec else ''
+        openmp_prefix = "_openmp" if "+openmp" in spec else ""
         return [f"{mpi_prefix}_{compiler_prefix}_{platform_prefix}{openmp_prefix}"]
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Added a new version and enabled OpenMP support for the oneAPI compiler.
While OpenMP support was already available in previous installations, it had not yet been fully incorporated into Spack. This update addresses that gap by adding OpenMP support for builds using the oneAPI compiler.

I have tested this in the following environment. I have tested on a Linux Ubuntu 20.04 environment with Cascade Lake architecture.
- fds@6.9.0 %gcc@13
- fds@6.9.1 %gcc@13
- fds@6.9.0+openmp %oneapi@2024.2.1
- fds@6.9.1+openmp %oneapi@2024.2.1