### PR TITLE
restic: convert to GoPackage

### DIFF
--- a/var/spack/repos/builtin/packages/restic/package.py
+++ b/var/spack/repos/builtin/packages/restic/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Restic(Package):
+class Restic(GoPackage):
     """Fast, secure, efficient backup program."""
 
     homepage = "https://restic.net"
@@ -27,23 +27,11 @@ class Restic(Package):
     version("0.14.0", sha256="78cdd8994908ebe7923188395734bb3cdc9101477e4163c67e7cc3b8fd3b4bd6")
     version("0.12.1", sha256="a9c88d5288ce04a6cc78afcda7590d3124966dab3daa9908de9b3e492e2925fb")
 
-    depends_on("go", type="build")
     depends_on("go@1.15:", type="build", when="@0.14.0:")
     depends_on("go@1.18:", type="build", when="@0.15.0:")
     depends_on("go@1.19:", type="build", when="@1.16.1:")
 
-    phases = ["build", "install"]
-
-    def setup_build_environment(self, env):
-        # Point GOPATH at the top of the staging dir for the build step.
-        env.prepend_path("GOPATH", self.stage.path)
-
-    def build(self, spec, prefix):
-        go("run", "build.go")
-
-    def install(self, spec, prefix):
-        mkdirp(prefix.bin)
-        install("restic", prefix.bin)
+    build_directory = "cmd/restic"
 
     @run_after("install")
     def install_completions(self):


### PR DESCRIPTION
Convert `restic` to a `GoPackage` now that we support custom build_directories.