### PR TITLE
gh: add v2.58.0, drop GoBuilder

### DIFF
--- a/var/spack/repos/builtin/packages/gh/package.py
+++ b/var/spack/repos/builtin/packages/gh/package.py
@@ -16,6 +16,7 @@ class Gh(GoPackage):
 
     license("MIT")
 
+    version("2.58.0", sha256="90894536c797147586db775d06ec2040c45cd7eef941f7ccbea46f4e5997c81c")
     version("2.50.0", sha256="683d0dee90e1d24a6673d13680e0d41963ddc6dd88580ab5119acec790d1b4d7")
     version("2.49.2", sha256="e839ea302ad99b70ce3efcb903f938ecbbb919798e49bc2f2034ad506ae0b0f5")
     version("2.43.1", sha256="1ea3f451fb7002c1fb95a7fab21e9ab16591058492628fe264c5878e79ec7c90")

--- a/var/spack/repos/builtin/packages/gh/package.py
+++ b/var/spack/repos/builtin/packages/gh/package.py
@@ -43,8 +43,6 @@ class Gh(GoPackage):
     depends_on("go@1.21:", type="build", when="@2.33.0:")
     depends_on("go@1.22:", type="build", when="@2.47.0:")
 
-
-class GoBuilder(spack.build_systems.go.GoBuilder):
     @property
     def build_args(self):
         args = super().build_args


### PR DESCRIPTION
Now that `GoBuilder` properly supports legacy attributes on `GoPackage` we can drop the explicit call on the builder.