### PR TITLE
rclone: add v1.68.1, convert to a GoPackage

### DIFF
--- a/var/spack/repos/builtin/packages/rclone/package.py
+++ b/var/spack/repos/builtin/packages/rclone/package.py
@@ -17,6 +17,7 @@ class Rclone(GoPackage):
 
     license("MIT")
 
+    version("1.68.1", sha256="c5d45b83dd008d08a0903eebf1578a11a40a77152226e22ce5e9287b9db05579")
     version("1.65.2", sha256="1305c913ac3684d02ce2bade0a23a2115c1ec03c9447d1562bb6cd9fa2573412")
     version("1.65.1", sha256="904b906cc465dd679a00487497e3891d33fca6b6e25c184400bccfb248344f39")
     version("1.65.0", sha256="45ec732d50b2517dc2c860317a3bf79867634a8143e4a441a3e399434ad6c141")
@@ -40,8 +41,11 @@ class Rclone(GoPackage):
     version("1.55.0", sha256="75accdaedad3b82edc185dc8824a19a59c30dc6392de7074b6cd98d1dc2c9040")
 
     depends_on("go@1.14:", type="build")
-    depends_on("go@1.17:", type="build", when="@1.58.0:")
-    depends_on("go@1.18:", type="build", when="@1.62.0:")
+    depends_on("go@1.17:", type="build", when="@1.58:")
+    depends_on("go@1.18:", type="build", when="@1.62:")
+    depends_on("go@1.19:", type="build", when="@1.63:")
+    depends_on("go@1.20:", type="build", when="@1.66:")
+    depends_on("go@1.21:", type="build", when="@1.68:")
 
     @run_after("install")
     def install_completions(self):

--- a/var/spack/repos/builtin/packages/rclone/package.py
+++ b/var/spack/repos/builtin/packages/rclone/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Rclone(Package):
+class Rclone(GoPackage):
     """Rclone is a command line program to sync files and directories
     to and from various cloud storage providers"""
 
@@ -39,24 +39,9 @@ class Rclone(Package):
     version("1.55.1", sha256="25da7fc5c9269b3897f27b0d946919df595c6dda1b127085fda0fe32aa59d29d")
     version("1.55.0", sha256="75accdaedad3b82edc185dc8824a19a59c30dc6392de7074b6cd98d1dc2c9040")
 
-    depends_on("c", type="build")  # generated
-
     depends_on("go@1.14:", type="build")
     depends_on("go@1.17:", type="build", when="@1.58.0:")
     depends_on("go@1.18:", type="build", when="@1.62.0:")
-
-    phases = ["build", "install"]
-
-    def setup_build_environment(self, env):
-        # Point GOPATH at the top of the staging dir for the build step.
-        env.prepend_path("GOPATH", self.stage.path)
-
-    def build(self, spec, prefix):
-        go("build")
-
-    def install(self, spec, prefix):
-        mkdirp(prefix.bin)
-        install("rclone", prefix.bin)
 
     @run_after("install")
     def install_completions(self):


### PR DESCRIPTION
Covert `rclone` to a `GoPackage` now that we properly support legacy attributes such as `build_directory`.

```
> spack install rclone@=1.68.1
...
==> Installing rclone-1.68.1-hh643rcpoiyk5kk3uhxgr3ssh6ly34uo [2/2]
==> No binary for rclone-1.68.1-hh643rcpoiyk5kk3uhxgr3ssh6ly34uo found: installing from source
==> Fetching https://github.com/rclone/rclone/releases/download/v1.68.1/rclone-v1.68.1.tar.gz
==> No patches needed for rclone
==> rclone: Executing phase: 'build'
==> rclone: Executing phase: 'install'
==> rclone: Successfully installed rclone-1.68.1-hh643rcpoiyk5kk3uhxgr3ssh6ly34uo
  Stage: 1.81s.  Build: 33.85s.  Install: 0.16s.  Post-install: 8.06s.  Total: 43.94s
[+] /.../rclone-1.68.1-hh643rcpoiyk5kk3uhxgr3ssh6ly34uo
```