### PR TITLE
kubectl: add v1.31.1, convert to a GoPackage

### DIFF
--- a/var/spack/repos/builtin/packages/kubectl/package.py
+++ b/var/spack/repos/builtin/packages/kubectl/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Kubectl(Package):
+class Kubectl(GoPackage):
     """
     Kubectl is a command-line interface for Kubernetes clusters.
     """
@@ -18,18 +18,12 @@ class Kubectl(Package):
 
     license("Apache-2.0")
 
+    version("1.31.1", sha256="83094915698a9c24f93d1ffda3f17804a4024d3b65eabf681e77a62b35137208")
     version("1.31.0", sha256="6679eb90815cc4c3bef6c1b93f7a8451bf3f40d003f45ab57fdc9f8c4e8d4b4f")
     version("1.27.1", sha256="3a3f7c6b8cf1d9f03aa67ba2f04669772b1205b89826859f1636062d5f8bec3f")
     version("1.27.0", sha256="536025dba2714ee5e940bb0a6b1df9ca97c244fa5b00236e012776a69121c323")
 
     depends_on("bash", type="build")
-    depends_on("go", type="build")
     depends_on("go@1.22:", type="build", when="@1.30:")
 
-    phases = ["build", "install"]
-
-    def build(self, spec, prefix):
-        make("-f", "build/root/Makefile", "WHAT=cmd/kubectl")
-
-    def install(self, spec, prefix):
-        install_tree("_output/bin", prefix.bin)
+    build_directory = "cmd/kubectl"


### PR DESCRIPTION
Convert `kubectl` to a GoPackage now that we properly support `build_directory`.

```
> spack install --fresh-roots kubectl
...
==> Installing kubectl-1.31.1-nij2wuxqstjvarxdjrikyqe2f733yptu [14/14]
==> No binary for kubectl-1.31.1-nij2wuxqstjvarxdjrikyqe2f733yptu found: installing from source
==> Fetching https://github.com/kubernetes/kubernetes/archive/refs/tags/v1.31.1.tar.gz
==> No patches needed for kubectl
==> kubectl: Executing phase: 'build'
==> kubectl: Executing phase: 'install'
==> kubectl: Successfully installed kubectl-1.31.1-nij2wuxqstjvarxdjrikyqe2f733yptu
  Stage: 9.93s.  Build: 12.51s.  Install: 0.01s.  Post-install: 0.08s.  Total: 22.63s
[+] /home/alec/src/spack/spack/opt/spack/darwin-sequoia-m2/apple-clang-16.0.0/kubectl-1.31.1-nij2wuxqstjvarxdjrikyqe2f733yptu
```