### PR TITLE
git: fix zsh shell completions

### DIFF
--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -270,6 +270,11 @@ class Git(AutotoolsPackage):
         )
 
         mkdirp(zsh_completion_path(self.prefix))
+        filter_file(
+            r"\$bash_completion\/git",
+            join_path(bash_completion_path(self.prefix), "git"),
+            "contrib/completion/git-completion.zsh",
+        )
         install(
             "contrib/completion/git-completion.zsh",
             join_path(zsh_completion_path(self.prefix), "_git"),


### PR DESCRIPTION
Git's `zsh` shell completions are really just a wrapper for the bash completions and need to know the location of the bash completion script.