### PR TITLE
litestream: drop GoBuilder now that GoPackage is fixed

### DIFF
--- a/var/spack/repos/builtin/packages/litestream/package.py
+++ b/var/spack/repos/builtin/packages/litestream/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack.package import *
 
 
@@ -14,12 +12,12 @@ class Litestream(GoPackage):
     homepage = "https://github.com/benbjohnson/litestream"
     url = "https://github.com/benbjohnson/litestream/archive/refs/tags/v0.3.13.tar.gz"
 
+    maintainers("alecbcs")
+
     license("Apache-2.0", checked_by="cmelone")
 
     version("0.3.13", sha256="92cb22323b8168f6efdfcad270772fea9e78c709a7149b1bf35d81fcb88bdaf9")
 
+    depends_on("go@1.21:", type="build", when="@0.3.12:")
 
-class GoBuilder(spack.build_systems.go.GoBuilder):
-    @property
-    def build_directory(self):
-        return os.path.join(self.pkg.stage.source_path, "cmd", "litestream")
+    build_directory = "cmd/litestream"


### PR DESCRIPTION
Drop `GoBuilder` now that we properly handle `build_directory`.