### PR TITLE
apptainer: add v1.3.4

### DIFF
--- a/var/spack/repos/builtin/packages/apptainer/package.py
+++ b/var/spack/repos/builtin/packages/apptainer/package.py
@@ -36,6 +36,7 @@ class Apptainer(SingularityBase):
     )
 
     version("main", branch="main")
+    version("1.3.4", sha256="c6ccfdd7c967e5c36dde8711f369c4ac669a16632b79fa0dcaf7e772b7a47397")
     version("1.3.3", sha256="94a274ab4898cdb131f4e3867c4e15f7e16bc2823303d2afcbafee0242f0838d")
     version("1.3.2", sha256="483910727e1a15843b93d9f2db1fc87e27804de9c74da13cc32cd4bd0d35e079")
     # version "1.3.1" has security vulnerability CVE-2024-3727

--- a/var/spack/repos/builtin/packages/e2fsprogs/package.py
+++ b/var/spack/repos/builtin/packages/e2fsprogs/package.py
@@ -27,6 +27,7 @@ class E2fsprogs(AutotoolsPackage):
 
     depends_on("texinfo", type="build")
     depends_on("fuse", when="+fuse2fs")
+    depends_on("pkgconfig", when="+fuse2fs")
 
     # fuse3 support is in the yet unreleased 1.47.1
     patch(


### PR DESCRIPTION
This PR adds `apptainer`, v1.3.4 ([release notes](https://github.com/apptainer/apptainer/releases/tag/v1.3.4), [diff](https://github.com/apptainer/apptainer/compare/v1.3.3...v1.3.4)).

Test build:
```
==> Installing apptainer-1.3.4-77wuj46cqkmbkdlr6i4nzqz45gvpmhm3 [45/45]
==> No binary for apptainer-1.3.4-77wuj46cqkmbkdlr6i4nzqz45gvpmhm3 found: installing from source
==> Fetching https://github.com/apptainer/apptainer/releases/download/v1.3.4/apptainer-1.3.4.tar.gz
==> No patches needed for apptainer
==> apptainer: Executing phase: 'edit'
==> apptainer: Executing phase: 'build'
==> apptainer: Executing phase: 'install'
==> apptainer: Successfully installed apptainer-1.3.4-77wuj46cqkmbkdlr6i4nzqz45gvpmhm3
  Stage: 8.29s.  Edit: 7.47s.  Build: 11m 18.11s.  Install: 8.42s.  Post-install: 1.81s.  Total: 11m 45.74s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/apptainer-1.3.4-77wuj46cqkmbkdlr6i4nzqz45gvpmhm3
```
