### PR TITLE
Noop jobs should do less work

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -106,10 +106,14 @@ ci:
 
   - noop-job:
       tags: ["service"]
+      image: busybox:latest
       variables:
+        GIT_STRATEGY: "none"
         CI_JOB_SIZE: "small"
         KUBERNETES_CPU_REQUEST: "500m"
         KUBERNETES_MEMORY_REQUEST: "500M"
+      before_script:: []
+      after_script:: []
 
   - any-job:
       tags: ["spack"]


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Follow up to part of discussion with @cmelone who pointed out that noop jobs could really be doing less. This removes the before and after scripts and avoids cloning Spack completely as it is not needed. Also trying out using the `busybox` image which is significantly smaller than the current default image.

ref. https://github.com/spack/spack/pull/46713#discussion_r1784825955

CC: @alecbcs 