### PR TITLE
scc: add v3.4.0, drop generated dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/scc/package.py
+++ b/var/spack/repos/builtin/packages/scc/package.py
@@ -19,8 +19,9 @@ class Scc(GoPackage):
 
     license("MIT")
 
+    version("3.4.0", sha256="bdedb6f32d1c3d73ac7e55780021c742bc8ed32f6fb878ee3e419f9acc76bdaa")
     version("3.3.2", sha256="2bbfed4cf34bbe50760217b479331cf256285335556a0597645b7250fb603388")
     version("3.1.0", sha256="bffea99c7f178bc48bfba3c64397d53a20a751dfc78221d347aabdce3422fd20")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("go@1.20:", type="build", when="@3.2.0:")
+    depends_on("go@1.22:", type="build", when="@3.4.0:")


### PR DESCRIPTION
https://github.com/boyter/scc/releases/tag/v3.4.0

```
> spack install scc
...
==> Installing scc-3.4.0-a64q56kdyc22xwncwz2rifaqtirilr3e [2/2]
==> No binary for scc-3.4.0-a64q56kdyc22xwncwz2rifaqtirilr3e found: installing from source
==> Fetching https://github.com/boyter/scc/archive/refs/tags/v3.4.0.tar.gz
==> No patches needed for scc
==> scc: Executing phase: 'build'
==> scc: Executing phase: 'install'
==> scc: Successfully installed scc-3.4.0-a64q56kdyc22xwncwz2rifaqtirilr3e
  Stage: 1.15s.  Build: 0.86s.  Install: 0.00s.  Post-install: 0.02s.  Total: 2.15s
[+] spack/spack/opt/spack/darwin-sequoia-m2/apple-clang-16.0.0/scc-3.4.0-a64q56kdyc22xwncwz2rifaqtirilr3e
```