### PR TITLE
Bugfix: csh setup on darwin to use full, not relative, path

### DIFF
--- a/share/spack/setup-env.csh
+++ b/share/spack/setup-env.csh
@@ -42,6 +42,9 @@ if ($?_sp_source_file) then
     set _sp_share_spack = `dirname "$_sp_source_file"`
     set _sp_share = `dirname "$_sp_share_spack"`
     setenv SPACK_ROOT `dirname "$_sp_share"`
+    if ( "$SPACK_ROOT" == "." ) then
+        setenv SPACK_ROOT `$PWD`
+    endif
 endif
 
 if (! $?SPACK_ROOT) then


### PR DESCRIPTION
Make sure `SPACK_ROOT` is an absolute, not relative, path on `darwin-sonoma-m1`.  Once added, I was able to set up a clone.