### PR TITLE
lazygit: add v0.44.1

### DIFF
--- a/var/spack/repos/builtin/packages/lazygit/package.py
+++ b/var/spack/repos/builtin/packages/lazygit/package.py
@@ -17,7 +17,10 @@ class Lazygit(GoPackage):
 
     license("MIT")
 
+    version("0.44.1", sha256="02b67d38e07ae89b0ddd3b4917bd0cfcdfb5e158ed771566d3eb81f97f78cc26")
     version("0.41.0", sha256="f2176fa253588fe4b7118bf83f4316ae3ecb914ae1e99aad8c474e23cea49fb8")
     version("0.40.2", sha256="146bd63995fcf2f2373bbc2143b3565b7a2be49a1d4e385496265ac0f69e4128")
 
-    depends_on("c", type="build")  # generated
+    depends_on("go@1.20:", type="build", when="@0.40:")
+    depends_on("go@1.21:", type="build", when="@0.41:")
+    depends_on("go@1.22:", type="build", when="@0.42:")


### PR DESCRIPTION
https://github.com/jesseduffield/lazygit/releases/tag/v0.44.1

```
> spack install lazygit
...
==> Installing lazygit-0.44.1-etopva5ddywulqifsomfehowyakdk4o5 [2/2]
==> No binary for lazygit-0.44.1-etopva5ddywulqifsomfehowyakdk4o5 found: installing from source
==> Fetching https://github.com/jesseduffield/lazygit/archive/refs/tags/v0.44.1.tar.gz
==> No patches needed for lazygit
==> lazygit: Executing phase: 'build'
==> lazygit: Executing phase: 'install'
==> lazygit: Successfully installed lazygit-0.44.1-etopva5ddywulqifsomfehowyakdk4o5
  Stage: 1.42s.  Build: 5.39s.  Install: 0.01s.  Post-install: 0.04s.  Total: 6.98s
[+] ../spack/opt/spack/darwin-sequoia-m2/apple-clang-16.0.0/lazygit-0.44.1-etopva5ddywulqifsomfehowyakdk4o5
```