### PR TITLE
style: fix black configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,17 +70,8 @@ features = [
 [tool.black]
 line-length = 99
 target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
-include = '''
-    \.pyi?$
-'''
-extend-exclude = '''
-/(
-    \.git
-  | \.mypy_cache
-  | ^lib/spack/external/
-  | ^opt/
-)/
-'''
+include = '(lib/spack|var/spack/repos)/.*\.pyi?$|bin/spack$'
+extend-exclude = 'lib/spack/external'
 skip_magic_trailing_comma = true
 
 [tool.isort]


### PR DESCRIPTION
We mostly use `spack style` and `spack style --fix`, but it's nice to also be able to run plain old `black .` in the repo.

- [x] Fix includes and excludes `pyproject.toml` so that we *only* cover files we expect to be blackened.

Note that `spack style` is still likely the better way to go, because it looks at `git status` and tells black to only check files that changed from `develop`. `black` with `pyproject.toml` won't do that. Of course, you can always manually specify which files you want blackened.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
