### PR TITLE
harfbuzz: add v10.0.0, v10.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -20,6 +20,8 @@ class Harfbuzz(MesonPackage, AutotoolsPackage):
 
     license("MIT")
 
+    version("10.0.1", sha256="b2cb13bd351904cb9038f907dc0dee0ae07127061242fe3556b2795c4e9748fc")
+    version("10.0.0", sha256="c2dfe016ad833a5043ecc6579043f04e8e6d50064e02ad449bb466e6431e3e04")
     version("9.0.0", sha256="a41b272ceeb920c57263ec851604542d9ec85ee3030506d94662067c7b6ab89e")
     version("8.5.0", sha256="77e4f7f98f3d86bf8788b53e6832fb96279956e1c3961988ea3d4b7ca41ddc27")
     version("8.4.0", sha256="af4ea73e25ab748c8c063b78c2f88e48833db9b2ac369e29bd115702e789755e")


### PR DESCRIPTION
This PR adds `harfbuzz`, v10.0.0 and v10.0.1, [diff](https://github.com/harfbuzz/harfbuzz/compare/9.0.0...10.0.1). No changes to dependencies or build system.

Test build:
```
-- linux-ubuntu24.04-skylake / gcc@13.3.0 ----------------------
oprn7yi harfbuzz@10.0.1~graphite2~strip build_system=meson buildtype=release default_library=shared
==> 1 installed package
```