### PR TITLE
py-ipython: add v8.28.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -22,6 +22,7 @@ class PyIpython(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("8.28.0", sha256="0d0d15ca1e01faeb868ef56bc7ee5a0de5bd66885735682e8a322ae289a13d1a")
     version("8.27.0", sha256="0b99a2dc9f15fd68692e898e5568725c6d49c527d36a9fb5960ffbdeaa82ff7e")
     version("8.26.0", sha256="1cec0fbba8404af13facebe83d04436a7434c7400e59f47acf467c64abd0956c")
     version("8.25.0", sha256="c6ed726a140b6e725b911528f80439c534fac915246af3efc39440a6b0f9d716")


### PR DESCRIPTION
This PR adds `py-ipython`, v8.28.0, [diff](https://github.com/ipython/ipython/compare/8.27.0...8.28.0). No changes to the package recipe needed as far as I can tell.

Test build:
```
==> Installing py-ipython-8.28.0-e6wcv5ingb5q4d5ioketktdw2orx4jbz [60/60]
==> No binary for py-ipython-8.28.0-e6wcv5ingb5q4d5ioketktdw2orx4jbz found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/i/ipython/ipython-8.28.0.tar.gz
==> No patches needed for py-ipython
==> py-ipython: Executing phase: 'install'
==> py-ipython: Successfully installed py-ipython-8.28.0-e6wcv5ingb5q4d5ioketktdw2orx4jbz
  Stage: 1.27s.  Install: 1.55s.  Post-install: 1.09s.  Total: 4.11s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-ipython-8.28.0-e6wcv5ingb5q4d5ioketktdw2orx4jbz
```