### PR TITLE
pika: remove git dependency

### DIFF
--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -106,7 +106,6 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     )
 
     # Build dependencies
-    depends_on("git", type="build")
     depends_on("cmake@3.18:", type="build")
     depends_on("cmake@3.22:", when="@0.8:", type="build")
 


### PR DESCRIPTION
The git dependency is optional, and is only used to get the commit hash for pika's CMake configuration. When building releases the source directory is anyway from a tarball, not a git repository, so the hash will be `"unknown"` and when building from a specific git commit the git commit will be embedded in the spec/version/install directory in case one needs it. This optimizes for the common case of installing a released version of pika by removing the `git` dependency entirely.

If it were possible to detect when the version comes from a git repo and make the `git` dependency conditional on that that could be an alternative but I could not find a way to do that. Alternatively, one could tell pika's CMake what the git hash is at configure time, but again I couldn't find a way to extract that from the spec. If either of these are actually possible they could be an alternative, but I think removing the dependency outright is also ok.