### PR TITLE
`umpire`: Reinstate lost depends on `~camp~rocm` when umpire itself has `~rocm` part 2

### DIFF
--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -243,6 +243,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on("camp")
     depends_on("camp+openmp", when="+openmp")
     depends_on("camp~cuda", when="~cuda")
+    depends_on("camp~rocm", when="~rocm")
     depends_on("camp@main", when="@develop")
     depends_on("camp@2024.07.0:", when="@2024.07.0:")
     depends_on("camp@2024.02.1", when="@2024.02.1")


### PR DESCRIPTION
Repeats https://github.com/spack/spack/pull/42701. https://github.com/spack/spack/pull/41375 reverted the change after #42701 was merged, I presume unintentionally.