### PR TITLE
freetype: add v2.13.3

### DIFF
--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -22,6 +22,7 @@ class Freetype(AutotoolsPackage, CMakePackage):
 
     license("FTL OR GPL-2.0-or-later")
 
+    version("2.13.3", sha256="5c3a8e78f7b24c20b25b54ee575d6daa40007a5f4eea2845861c3409b3021747")
     version("2.13.2", sha256="1ac27e16c134a7f2ccea177faba19801131116fd682efc1f5737037c5db224b5")
     version("2.13.1", sha256="0b109c59914f25b4411a8de2a506fdd18fa8457eb86eca6c7b15c19110a92fa5")
     version("2.13.0", sha256="a7aca0e532a276ea8d85bd31149f0a74c33d19c8d287116ef8f5f8357b4f1f80")


### PR DESCRIPTION
This PR adds `freetype`, v2.13.3 (bugfix release, [diff](https://gitlab.freedesktop.org/freetype/freetype/-/compare/VER-2-13-2...VER-2-13-3?from_project_id=7950&straight=false)).

Test build:
```
==> Installing freetype-2.13.3-qxuqdwuyrpk3ey6d6s2o2ureldrxyp57 [8/8]
==> No binary for freetype-2.13.3-qxuqdwuyrpk3ey6d6s2o2ureldrxyp57 found: installing from source
==> Fetching https://download.savannah.gnu.org/releases/freetype/freetype-2.13.3.tar.gz
==> No patches needed for freetype
==> freetype: Executing phase: 'autoreconf'
==> freetype: Executing phase: 'configure'
==> freetype: Executing phase: 'build'
==> freetype: Executing phase: 'install'
==> freetype: Successfully installed freetype-2.13.3-qxuqdwuyrpk3ey6d6s2o2ureldrxyp57
  Stage: 2.35s.  Autoreconf: 0.00s.  Configure: 12.04s.  Build: 17.36s.  Install: 1.05s.  Post-install: 0.53s.  Total: 33.76s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/freetype-2.13.3-qxuqdwuyrpk3ey6d6s2o2ureldrxyp57
```