### PR TITLE
doxygen: add v1.12.0

### DIFF
--- a/var/spack/repos/builtin/packages/doxygen/package.py
+++ b/var/spack/repos/builtin/packages/doxygen/package.py
@@ -20,6 +20,7 @@ class Doxygen(CMakePackage):
 
     license("GPL-2.0-or-later")
 
+    version("1.12.0", sha256="5ca35e1258020df5fe8b21c3656aed156c317def4a81b7fe52f452edc9f35768")
     version("1.11.0", sha256="1fea49c69e51fec3dd2599947f6d48d9b1268bd5115b1bb08dffefc1fd5d19ee")
     version("1.10.0", sha256="795692a53136ca9bb9a6cd72656968af7858a78be7d6d011e12ab1dce6b9533c")
     version("1.9.8", sha256="77371e8a58d22d5e03c52729844d1043e9cbf8d0005ec5112ffa4c8f509ddde8")
@@ -136,16 +137,18 @@ class Doxygen(CMakePackage):
     def patch(self):
         if self.spec["iconv"].name != "libiconv":
             return
-        # On Linux systems, iconv is provided by libc. Since CMake finds the
-        # symbol in libc, it does not look for libiconv, which leads to linker
-        # errors. This makes sure that CMake always looks for the external
-        # libconv instead.
-        filter_file(
-            "check_function_exists(iconv_open ICONV_IN_GLIBC)",
-            "set(ICONV_IN_GLIBC FALSE)",
-            join_path("cmake", "FindIconv.cmake"),
-            string=True,
-        )
+
+        if self.spec.satisfies("@:1.11"):
+            # On Linux systems, iconv is provided by libc. Since CMake finds the
+            # symbol in libc, it does not look for libiconv, which leads to linker
+            # errors. This makes sure that CMake always looks for the external
+            # libconv instead.
+            filter_file(
+                "check_function_exists(iconv_open ICONV_IN_GLIBC)",
+                "set(ICONV_IN_GLIBC FALSE)",
+                join_path("cmake", "FindIconv.cmake"),
+                string=True,
+            )
 
     def cmake_args(self):
         return [


### PR DESCRIPTION
This PR adds `doxygen`, v1.12.0, [diff](https://github.com/doxygen/doxygen/compare/Release_1_11_0...Release_1_12_0), [release notes](https://www.doxygen.nl/manual/changelog.html#log_1_12_0).

This release removes the FindIconv.cmake in cmake/, and the version bundled with CMake is now use. That version has been included sincde CMake 3.11, and 3.14 is required. No changes necessary, except for disabling our patch of FindIconv.cmake.

Test build:
```
==> Installing doxygen-1.12.0-msuqcqh4uijbovyif73qkceyn4ydvvuu [34/34]
==> No binary for doxygen-1.12.0-msuqcqh4uijbovyif73qkceyn4ydvvuu found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/5c/5ca35e1258020df5fe8b21c3656aed156c317def4a81b7fe52f452edc9f35768.tar.gz
==> Ran patch() for doxygen
==> doxygen: Executing phase: 'cmake'
==> doxygen: Executing phase: 'build'
==> doxygen: Executing phase: 'install'
==> doxygen: Successfully installed doxygen-1.12.0-msuqcqh4uijbovyif73qkceyn4ydvvuu
  Stage: 0.13s.  Cmake: 0.75s.  Build: 5m 21.49s.  Install: 0.30s.  Post-install: 0.33s.  Total: 5m 23.19s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/doxygen-1.12.0-msuqcqh4uijbovyif73qkceyn4ydvvuu
```
