### PR TITLE
rocblas and miopen-hip: fix for miopen-hip@6.2.1 build and rocblas build test

### DIFF
--- a/var/spack/repos/builtin/packages/miopen-hip/package.py
+++ b/var/spack/repos/builtin/packages/miopen-hip/package.py
@@ -134,7 +134,7 @@ class MiopenHip(CMakePackage):
     for ver in ["5.4.0", "5.4.3", "5.5.0"]:
         depends_on("nlohmann-json", type="link")
         depends_on(f"rocmlir@{ver}", when=f"@{ver}")
-    for ver in ["6.0.0", "6.0.2", "6.1.0", "6.1.1", "6.1.2", "6.2.0"]:
+    for ver in ["6.0.0", "6.0.2", "6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1"]:
         depends_on("roctracer-dev@" + ver, when="@" + ver)
     for ver in ["6.1.0", "6.1.1", "6.1.2"]:
         depends_on("googletest")

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -86,6 +86,9 @@ class Rocblas(CMakePackage):
     ]:
         depends_on(f"rocm-openmp-extras@{ver}", type="test", when=f"@{ver}")
 
+    for ver in ["6.2.0", "6.2.1"]:
+        depends_on(f"rocm-smi-lib@{ver}", type="test", when=f"@{ver}")
+
     depends_on("rocm-cmake@master", type="build", when="@master:")
 
     for ver in [


### PR DESCRIPTION
ROCm-smi dependecy was added in 6.2 for client test and miopen-hip is missing a roctracer-dev dependency for 6.2.1