### PR TITLE
catch2: add v3.7.1

### DIFF
--- a/var/spack/repos/builtin/packages/catch2/package.py
+++ b/var/spack/repos/builtin/packages/catch2/package.py
@@ -22,6 +22,7 @@ class Catch2(CMakePackage):
     version("develop", branch="devel")
 
     # Releases
+    version("3.7.1", sha256="c991b247a1a0d7bb9c39aa35faf0fe9e19764213f28ffba3109388e62ee0269c")
     version("3.6.0", sha256="485932259a75c7c6b72d4b874242c489ea5155d17efa345eb8cc72159f49f356")
     version("3.5.4", sha256="b7754b711242c167d8f60b890695347f90a1ebc95949a045385114165d606dbb")
     version("3.4.0", sha256="122928b814b75717316c71af69bd2b43387643ba076a6ec16e7882bfb2dfacbb")


### PR DESCRIPTION
This PR adds `catch2`, v3.7.1, [diff](https://github.com/catchorg/Catch2/compare/v3.6.0...v3.7.1). No changes in CMakeLists.txt.

Test build:
```
==> Installing catch2-3.7.1-d2hupm6v6ltvxhht5fp5t5ob2xps6zg2 [10/10]
==> No binary for catch2-3.7.1-d2hupm6v6ltvxhht5fp5t5ob2xps6zg2 found: installing from source
==> Fetching https://github.com/catchorg/Catch2/archive/refs/tags/v3.7.1.tar.gz
==> Ran patch() for catch2
==> catch2: Executing phase: 'cmake'
==> catch2: Executing phase: 'build'
==> catch2: Executing phase: 'install'
==> catch2: Successfully installed catch2-3.7.1-d2hupm6v6ltvxhht5fp5t5ob2xps6zg2
  Stage: 1.59s.  Cmake: 2.83s.  Build: 1m 40.60s.  Install: 0.42s.  Post-install: 0.38s.  Total: 1m 46.68s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/catch2-3.7.1-d2hupm6v6ltvxhht5fp5t5ob2xps6zg2
```