### PR TITLE
py-codespell: add v2.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-codespell/package.py
+++ b/var/spack/repos/builtin/packages/py-codespell/package.py
@@ -15,6 +15,7 @@ class PyCodespell(PythonPackage):
 
     license("GPL-2.0", checked_by="cmelone")
 
+    version("2.3.0", sha256="360c7d10f75e65f67bad720af7007e1060a5d395670ec11a7ed1fed9dd17471f")
     version("2.2.6", sha256="a8c65d8eb3faa03deabab6b3bbe798bea72e1799c7e9e955d57eca4096abcff9")
 
     depends_on("py-setuptools@64.0:", type="build")


### PR DESCRIPTION
This PR adds `py-codespell`, 2.3.0, [diff](https://github.com/codespell-project/codespell/compare/v2.2.6...v2.3.0), no changes to pyproject.toml that need to be considered here.

Test build:
```
==> Installing py-codespell-2.3.0-fzyuh755reoi32qstbkh66rc63p3ixpf [43/43]
==> No binary for py-codespell-2.3.0-fzyuh755reoi32qstbkh66rc63p3ixpf found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/c/codespell/codespell-2.3.0.tar.gz
==> No patches needed for py-codespell
==> py-codespell: Executing phase: 'install'
==> py-codespell: Successfully installed py-codespell-2.3.0-fzyuh755reoi32qstbkh66rc63p3ixpf
  Stage: 0.92s.  Install: 11.46s.  Post-install: 1.50s.  Total: 15.27s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-codespell-2.3.0-fzyuh755reoi32qstbkh66rc63p3ixpf
```