### PR TITLE
armadillo: add v12.8.4, v14.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -13,9 +13,12 @@ class Armadillo(CMakePackage):
 
     homepage = "https://arma.sourceforge.net/"
     url = "http://sourceforge.net/projects/arma/files/armadillo-8.100.1.tar.xz"
+    git = "https://gitlab.com/conradsnicta/armadillo-code"
 
     license("Apache-2.0")
 
+    version("14.0.2", sha256="248e2535fc092add6cb7dea94fc86ae1c463bda39e46fd82d2a7165c1c197dff")
+    version("12.8.4", sha256="558fe526b990a1663678eff3af6ec93f79ee128c81a4c8aef27ad328fae61138")
     version("12.8.3", sha256="2922589f6387796504b340da6bb954bef3d87574c298515893289edd2d890151")
     version("12.8.2", sha256="03b62f8c09e4f5d74643b478520741b8e27b55e7e4525978fcae2f5d791ac3bf")
     version("12.8.1", sha256="2781dd3a6cc5f9a49c91a4519dde2b1c24335a5bfe0cc1c9881b6363142452b4")
@@ -32,6 +35,7 @@ class Armadillo(CMakePackage):
     variant("hdf5", default=False, description="Include HDF5 support")
 
     depends_on("cmake@2.8.12:", type="build")
+    depends_on("cmake@3.5:", type="build", when="@14:")
     depends_on("arpack-ng")  # old arpack causes undefined symbols
     depends_on("blas")
     depends_on("lapack")

--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -13,7 +13,7 @@ class Armadillo(CMakePackage):
 
     homepage = "https://arma.sourceforge.net/"
     url = "http://sourceforge.net/projects/arma/files/armadillo-8.100.1.tar.xz"
-    git = "https://gitlab.com/conradsnicta/armadillo-code"
+    git = "https://gitlab.com/conradsnicta/armadillo-code.git"
 
     license("Apache-2.0")
 


### PR DESCRIPTION
This PR adds `armadillo`, v12.8.4 (last of 12 series) and v14.0.2. [Diff](https://gitlab.com/conradsnicta/armadillo-code/-/compare/12.8.4...14.0.2?from_project_id=6604173&straight=false) indicates newer CMake required. While there is a different handling of static/shared libs and wrapper/no wrapper installs, the defaults (which we don't modify) result in the same behavior. Installed files are as expected.

Test builds:
```
$ spack find -lv armadillo
==> In environment /tmp/spack-ubcqxtcz
==> 2 root specs
[+] p6pdkhi armadillo@12.8.4  [+] 6lhlyh6 armadillo@14.0.2

-- linux-ubuntu24.04-skylake / gcc@13.3.0 -----------------------
p6pdkhi armadillo@12.8.4~hdf5~ipo build_system=cmake build_type=Release generator=make patches=59207b1
6lhlyh6 armadillo@14.0.2~hdf5~ipo build_system=cmake build_type=Release generator=make patches=59207b1
==> 2 installed packages
```