### PR TITLE
py-cookiecutter: add v2.6.0 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/py-cookiecutter/package.py
+++ b/var/spack/repos/builtin/packages/py-cookiecutter/package.py
@@ -16,14 +16,32 @@ class PyCookiecutter(PythonPackage):
 
     license("BSD-3-Clause")
 
-    version("1.6.0", sha256="0c9018699b556b83d7c37b27fe0cc17485b90b6e1f47365b3cdddf77f6ca9d36")
+    version("2.6.0", sha256="da014a94d85c1b1be14be214662982c8c90d860834cbf9ddb2391a37ad7d08be")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2022-24065
+        version("1.7.3", sha256="5c16f9e33875f49bb091ef836b71ced63372aadc49799d78315db1d91d17d76d")
+        version("1.6.0", sha256="0c9018699b556b83d7c37b27fe0cc17485b90b6e1f47365b3cdddf77f6ca9d36")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-future@0.15.2:", type=("build", "run"))
     depends_on("py-binaryornot@0.2.0:", type=("build", "run"))
-    depends_on("py-jinja2@2.7:", type=("build", "run"))
+    depends_on("py-binaryornot@0.4.4:", type=("build", "run"), when="@1.7.1:")
+    depends_on("py-jinja2@2.7:3", type=("build", "run"))
     depends_on("py-click@5.0:", type=("build", "run"))
-    depends_on("py-whichcraft@0.4.0:", type=("build", "run"))
-    depends_on("py-poyo@0.1.0:", type=("build", "run"))
-    depends_on("py-jinja2-time@0.1.0:", type=("build", "run"))
+    depends_on("py-click@7.0:", type=("build", "run"), when="@1.7:")
+    depends_on("py-click@:7", type=("build", "run"), when="@:2.0")
+    depends_on("py-click@:8", type=("build", "run"), when="@2.1:")
+    depends_on("py-pyyaml@5.3.1:", type=("build", "run"), when="@2:")
+    depends_on("py-python-slugify@4:", type=("build", "run"), when="@1.7.1:")
     depends_on("py-requests@2.18.0:", type=("build", "run"))
+    depends_on("py-requests@2.23.0:", type=("build", "run"), when="@1.7.1:")
+    depends_on("py-arrow", type=("build", "run"), when="@2.2:")
+    depends_on("py-rich", type=("build", "run"), when="@2.3:")
+
+    # Historical dependencies
+    depends_on("py-future@0.15.2:", type=("build", "run"), when="@:1.7.0")
+    depends_on("py-whichcraft@0.4.0:", type=("build", "run"), when="@:1")
+    depends_on("py-poyo@0.1.0:", type=("build", "run"), when="@:1")
+    depends_on("py-poyo@0.5.0:", type=("build", "run"), when="@1.7.1:1")
+    depends_on("py-jinja2-time@0.1.0:", type=("build", "run"), when="@:2.1")
+    depends_on("py-jinja2-time@0.2.0:", type=("build", "run"), when="@1.7.1:2.1")
+    depends_on("py-six@1.10:", type=("build", "run"), when="@1.7.2:1")

--- a/var/spack/repos/builtin/packages/py-poyo/package.py
+++ b/var/spack/repos/builtin/packages/py-poyo/package.py
@@ -14,6 +14,7 @@ class PyPoyo(PythonPackage):
 
     license("MIT")
 
+    version("0.5.0", sha256="cf75b237ff3efdde8a573512d7356c428033c77a6ccee50a89496b2654cf9420") 
     version("0.4.1", sha256="9f069dc9c8ee359abc8ef9e7304cb1b1c23556d1f4ae64f4247c1e45de43c1f1")
 
     depends_on("py-setuptools", type="build")

--- a/var/spack/repos/builtin/packages/py-poyo/package.py
+++ b/var/spack/repos/builtin/packages/py-poyo/package.py
@@ -14,7 +14,7 @@ class PyPoyo(PythonPackage):
 
     license("MIT")
 
-    version("0.5.0", sha256="cf75b237ff3efdde8a573512d7356c428033c77a6ccee50a89496b2654cf9420") 
+    version("0.5.0", sha256="cf75b237ff3efdde8a573512d7356c428033c77a6ccee50a89496b2654cf9420")
     version("0.4.1", sha256="9f069dc9c8ee359abc8ef9e7304cb1b1c23556d1f4ae64f4247c1e45de43c1f1")
 
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
This PR adds `py-cookiecutter`, v2.6.0, which fixes CVE-2022-24065. Previous versions (all before 2.1.1) are marked as deprecated since the CVE is rated critical, NVD score 9.8 (@alecbcs).

Test build:
```
==> Installing py-poyo-0.5.0-ylmudqlbwohf6mjoree6fvnojwmdjd7u [28/28]
==> No binary for py-poyo-0.5.0-ylmudqlbwohf6mjoree6fvnojwmdjd7u found: installing from source
==> Fetching https://github.com/hackebrot/poyo/archive/0.5.0.tar.gz
==> No patches needed for py-poyo
==> py-poyo: Executing phase: 'install'
==> py-poyo: Successfully installed py-poyo-0.5.0-ylmudqlbwohf6mjoree6fvnojwmdjd7u
  Stage: 0.88s.  Install: 0.92s.  Post-install: 0.18s.  Total: 2.07s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-poyo-0.5.0-ylmudqlbwohf6mjoree6fvnojwmdjd7u
==> Installing py-cookiecutter-2.6.0-noeklgga6pzblx4quw5ujc36ii6bn7b3 [52/52]
==> No binary for py-cookiecutter-2.6.0-noeklgga6pzblx4quw5ujc36ii6bn7b3 found: installing from source
==> Fetching https://github.com/audreyr/cookiecutter/archive/2.6.0.tar.gz
==> No patches needed for py-cookiecutter
==> py-cookiecutter: Executing phase: 'install'
==> py-cookiecutter: Successfully installed py-cookiecutter-2.6.0-noeklgga6pzblx4quw5ujc36ii6bn7b3
  Stage: 1.33s.  Install: 1.27s.  Post-install: 1.11s.  Total: 3.98s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-cookiecutter-2.6.0-noeklgga6pzblx4quw5ujc36ii6bn7b3
```