### PR TITLE
py-lxml: add 5.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -15,6 +15,11 @@ class PyCython(PythonPackage):
 
     license("Apache-2.0")
 
+    version(
+        "3.0.11",
+        sha256="7146dd2af8682b4ca61331851e6aebce9fe5158e75300343f80c07ca80b1faff",
+        url="https://files.pythonhosted.org/packages/source/cython/cython-3.0.11.tar.gz",
+    )
     version("3.0.10", sha256="dcc96739331fb854dcf503f94607576cfe8488066c61ca50dfd55836f132de99")
     version("3.0.8", sha256="8333423d8fd5765e7cceea3a9985dd1e0a5dfeb2734629e1a2ed2d6233d39de6")
     version("3.0.7", sha256="fb299acf3a578573c190c858d49e0cf9d75f4bc49c3f24c5a63804997ef09213")

--- a/var/spack/repos/builtin/packages/py-lxml/package.py
+++ b/var/spack/repos/builtin/packages/py-lxml/package.py
@@ -16,6 +16,7 @@ class PyLxml(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("5.3.0", sha256="4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f")
     version("5.2.2", sha256="bb2dc4898180bea79863d5487e5f9c7c34297414bad54bcd0f0852aee9cfdb87")
     version("4.9.2", sha256="2455cfaeb7ac70338b3257f41e21f0724f4b5b0c0e7702da67ee6c3640835b67")
     version("4.9.1", sha256="fe749b052bb7233fe5d072fcb549221a8cb1a16725c47c37e42b0b9cb3ff2c3f")
@@ -45,6 +46,7 @@ class PyLxml(PythonPackage):
     depends_on("py-html5lib", when="+html5", type=("build", "run"))
     depends_on("py-beautifulsoup4", when="+htmlsoup", type=("build", "run"))
     depends_on("py-cssselect@0.7:", when="+cssselect", type=("build", "run"))
+    depends_on("py-cython@3.0.11:", type="build", when="@5.3:")
     depends_on("py-cython@3.0.10:", type="build", when="@5.2:")
     depends_on("py-cython@3.0.9:", type="build", when="@5.1.1:")
     depends_on("py-cython@3.0.8:", type="build", when="@5:")


### PR DESCRIPTION
Depends on #46772 

Only cython is in `requirements.txt`, and the new version is added here: https://github.com/spack/spack/pull/46772
I've managed to build this version with cython 3.0.10, but I guess we may want to respect whatever it says in `requirements.txt`.