### PR TITLE
python: add 3.13.0

### DIFF
--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -83,10 +83,14 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
     depends_on("texinfo", type="build")
 
     # Optional dependencies
-    depends_on("python", when="+python", type=("build", "link", "run"))
-    # gdb@9.2 will segmentation fault if it builds with python@3.9.
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1829702
-    depends_on("python@:3.8", when="@:9.2+python", type=("build", "link", "run"))
+    with when("+python"), default_args(type=("build", "link", "run")):
+        depends_on("python")
+        # gdb@9.2 will segmentation fault if it builds with python@3.9.
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1829702
+        depends_on("python@:3.8", when="@:9.2")
+        # pyOS_ReadlineTState became private API in cpython commit
+        # d228825e08883fc13f35eb91435f95d32524931c
+        depends_on("python@:3.12", when="@:14.2")
     depends_on("xz", when="+xz")
     depends_on("zlib-api")
     depends_on("zstd", when="@13.1:")

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -276,10 +276,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
         depends_on("rocthrust")
         depends_on("rocprim")
 
-    # Build dependencies
-    depends_on("python@2.6:2.8,3.4:3.8", when="@:3.13", type="build")
-    depends_on("python@2.6:2.8,3.4:", when="@3.14:3.17", type="build")
-    depends_on("python@3.4:", when="@3.18:", type="build")
+    with default_args(type="build"):
+        depends_on("python@2.6:2.8,3.4:")
+        depends_on("python@3.4:", when="@3.18:")
+        depends_on("python@:3.8", when="@:3.13")
+        depends_on("python@:3.12", when="@:3.21")  # import xdrlib
 
     # Other dependencies
     depends_on("metis@5:~int64+real64", when="@:3.7+metis~int64+double")

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -59,7 +59,11 @@ class Python(Package):
 
     license("0BSD")
 
-    version("3.13.0rc3", sha256="e5e8611d1bfbfda4accf8fab868712252a9c5f6aa5f13f6a5093878a9ef38412")
+    version(
+        "3.13.0rc3",
+        sha256="e5e8611d1bfbfda4accf8fab868712252a9c5f6aa5f13f6a5093878a9ef38412",
+        preferred=True,
+    )
     version("3.12.5", sha256="38dc4e2c261d49c661196066edbfb70fdb16be4a79cc8220c224dfeb5636d405")
     version("3.12.4", sha256="01b3c1c082196f3b33168d344a9c85fb07bfe0e7ecfe77fee4443420d1ce2ad9")
     version("3.12.3", sha256="a6b9459f45a6ebbbc1af44f5762623fa355a0c87208ed417628b379d762dddb0")

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -59,11 +59,7 @@ class Python(Package):
 
     license("0BSD")
 
-    version(
-        "3.13.0rc3",
-        sha256="e5e8611d1bfbfda4accf8fab868712252a9c5f6aa5f13f6a5093878a9ef38412",
-        preferred=True,
-    )
+    version("3.13.0rc3", sha256="e5e8611d1bfbfda4accf8fab868712252a9c5f6aa5f13f6a5093878a9ef38412")
     version("3.12.5", sha256="38dc4e2c261d49c661196066edbfb70fdb16be4a79cc8220c224dfeb5636d405")
     version("3.12.4", sha256="01b3c1c082196f3b33168d344a9c85fb07bfe0e7ecfe77fee4443420d1ce2ad9")
     version("3.12.3", sha256="a6b9459f45a6ebbbc1af44f5762623fa355a0c87208ed417628b379d762dddb0")

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -59,6 +59,7 @@ class Python(Package):
 
     license("0BSD")
 
+    version("3.13.0rc3", sha256="e5e8611d1bfbfda4accf8fab868712252a9c5f6aa5f13f6a5093878a9ef38412")
     version("3.12.5", sha256="38dc4e2c261d49c661196066edbfb70fdb16be4a79cc8220c224dfeb5636d405")
     version("3.12.4", sha256="01b3c1c082196f3b33168d344a9c85fb07bfe0e7ecfe77fee4443420d1ce2ad9")
     version("3.12.3", sha256="a6b9459f45a6ebbbc1af44f5762623fa355a0c87208ed417628b379d762dddb0")

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -59,7 +59,7 @@ class Python(Package):
 
     license("0BSD")
 
-    version("3.13.0rc3", sha256="e5e8611d1bfbfda4accf8fab868712252a9c5f6aa5f13f6a5093878a9ef38412")
+    version("3.13.0", sha256="12445c7b3db3126c41190bfdc1c8239c39c719404e844babbd015a1bc3fafcd4")
     version("3.12.5", sha256="38dc4e2c261d49c661196066edbfb70fdb16be4a79cc8220c224dfeb5636d405")
     version("3.12.4", sha256="01b3c1c082196f3b33168d344a9c85fb07bfe0e7ecfe77fee4443420d1ce2ad9")
     version("3.12.3", sha256="a6b9459f45a6ebbbc1af44f5762623fa355a0c87208ed417628b379d762dddb0")


### PR DESCRIPTION
and a few missing upperbounds caught in CI.

python 3.13 does not look like a very big change so lets not prefer 3.12