### PR TITLE
su2 fixes and improvements: AD, scipy/numpy, and Mutationpp setup, environment variable

### DIFF
--- a/var/spack/repos/builtin/packages/medipack/package.py
+++ b/var/spack/repos/builtin/packages/medipack/package.py
@@ -13,12 +13,14 @@ class Medipack(CMakePackage):
     homepage = "https://github.com/SciCompKL/MeDiPack"
     url = "https://github.com/SciCompKL/MeDiPack/archive/refs/tags/v1.2.2.tar.gz"
 
+    version("1.3.0", sha256="81daf8391ca00286a1276408badc7f1c9f76af889eb16940601c0ffb5f229e1d")
     version("1.2.2", sha256="8937fa1025c6fb12f516cacf38a7f776221e7e818b30f17ce334c63f78513aa7")
     version("1.2.1", sha256="c746196b98cfe24a212584cdb88bd12ebb14f4a54728070d605e0c6d0e75db8a")
 
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@3.12:", type="build", when="@1.2.2:")
+    depends_on("mpi")
 
     build_system(
         conditional("cmake", when="@1.2.2:"),
@@ -27,7 +29,7 @@ class Medipack(CMakePackage):
     )
 
     def install(self, spec, prefix):
-        mkdirp(join_path(prefix, "include"))
-        install_tree(join_path(self.stage.source_path, "include"), join_path(prefix, "include"))
-        mkdirp(join_path(prefix, "src"))
-        install_tree(join_path(self.stage.source_path, "src"), join_path(prefix, "src"))
+        mkdirp(self.prefix.include)
+        install_tree(join_path(self.stage.source_path, "include"), self.prefix.include)
+        mkdirp(self.prefix.src)
+        install_tree(join_path(self.stage.source_path, "src"), self.prefix.src)

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -136,7 +136,8 @@ class PyScipy(PythonPackage):
 
     # meson.build
     # https://docs.scipy.org/doc/scipy/dev/toolchain.html#compilers
-    conflicts("%gcc@:7", when="@1.10:", msg="SciPy requires GCC >= 8.0")
+    conflicts("%gcc@:7", when="@1.10:", msg="SciPy 1.10-1.13 requires GCC >= 8.0")
+    conflicts("%gcc@:9.0", when="@1.14:", msg="SciPy 1.14: requires GCC >= 9.1")
     conflicts("%gcc@:4.7", when="@:1.9", msg="SciPy requires GCC >= 4.8")
     conflicts("%apple-clang@:9", when="@1.10:", msg="SciPy requires Apple Clang >= 10")
     conflicts(

--- a/var/spack/repos/builtin/packages/su2/package.py
+++ b/var/spack/repos/builtin/packages/su2/package.py
@@ -38,6 +38,9 @@ class Su2(MesonPackage):
     version("7.0.0", sha256="6207dcca15eaebc11ce12b2866c937b4ad9b93274edf6f23d0487948ac3963b8")
     version("6.2.0", sha256="ffc953326e8432a1a6534556a5f6cf086046d3149cfcec6b4e7390eebe30ce2e")
 
+    # @:7 is missing few <cstdint> includes, causing a few files to fail with %gcc@13:
+    conflicts("%gcc@13:", when="@:7")
+
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
@@ -126,9 +129,10 @@ class Su2(MesonPackage):
             "-Denable-pywrapper={}".format("+pywrapper" in self.spec),
             "-Denable-mkl={}".format("+mkl" in self.spec),
             "-Denable-openblas={}".format("+openblas" in self.spec),
-            "-Denable-mpp={}".format("+mpp" in self.spec),
             "-Denable-mixedprec={}".format("+midexprec" in self.spec),
         ]
+        if self.spec.version >= Version("7.1.0"):
+            args.append("-Denable-mpp={}".format("+mpp" in self.spec))
 
         if "+mkl" in self.spec:
             args.append("-Dmkl_root=" + self.spec["intel-oneapi-mkl"].prefix)


### PR DESCRIPTION
This is not a new feature addition but a fix for existing issues.

* Added scipy and numpy:

  These packages are required for Python scripts in addition to the main executable.

* AD (Algorithmic Differentiation) Package

  Different versions of codipack are required depending on the version.
  opdilib is only needed for the +autodiff variant.
  A new version has been added to medipack, and it now requires the mpi option.
  When using AD with OpenMP, opdilib is available, so codipack@openmp is not required.
  
* Mutationpp (+mpp) Installation and Environment Variable Setup:

* Environment Variables Required for Runtime: SU2_RUN, SU2_HOME..

* mpi option(Dwith-mpi=auto) 
   There was a bug preventing installation with Intel-oneapi MPI, which has been fixed.
   (https://www.cfd-online.com/Forums/su2/257600-build-issue-intel-oneapi-2021-a.html)
    > I was using "enabled" and apparently this was the root of the issue. I switched to "auto" and everything proceeded.