### PR TITLE
clingo: fix build with Python 3.13+

### DIFF
--- a/var/spack/repos/builtin/packages/clingo/PyEval_InitThreads.patch
+++ b/var/spack/repos/builtin/packages/clingo/PyEval_InitThreads.patch
@@ -1,0 +1,12 @@
+diff --git a/libpyclingo/pyclingo.cc b/libpyclingo/pyclingo.cc
+index ec4a33c6..ee903cd0 100644
+--- a/libpyclingo/pyclingo.cc
++++ b/libpyclingo/pyclingo.cc
+@@ -10463,7 +10463,6 @@ void addEmptyClass(Reference module, char const *name) {
+ 
+ PyObject *initclingo_() {
+     PY_TRY {
+-        if (!PyEval_ThreadsInitialized()) { PyEval_InitThreads(); }
+ #if PY_MAJOR_VERSION >= 3
+         Object m = PyModule_Create(&clingoModule);
+ #else

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -74,6 +74,7 @@ class Clingo(CMakePackage):
     patch("size-t.patch", when="%msvc")
     patch("vs2022.patch", when="%msvc@19.30:")
     patch("clingo_msc_1938_native_handle.patch", when="@:5.7.0 %msvc@19.38:")
+    patch("PyEval_InitThreads.patch", when="@spack,5.3:5.4 ^python@3.9:")
 
     def patch(self):
         # Doxygen is optional but can't be disabled with a -D, so patch


### PR DESCRIPTION
Closes #46754

Python 3.9 deprecated `PyEval_InitThreads` and kept it as a no-op, and
Python 3.13 deleted the function.

The patch removes calls to it.