### PR TITLE
raja-perf: Fix support for SYCL

### DIFF
--- a/var/spack/repos/builtin/packages/raja-perf/package.py
+++ b/var/spack/repos/builtin/packages/raja-perf/package.py
@@ -321,7 +321,7 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
         entries.append(cmake_cache_option("BUILD_SHARED_LIBS", "+shared" in spec))
         entries.append(cmake_cache_option("ENABLE_OPENMP", "+openmp" in spec))
         entries.append(cmake_cache_option("RAJA_ENABLE_OPENMP_TASK", "+omptask" in spec))
-        entries.append(cmake_cache_option("RAJA_ENABLE_SYCL", spec.satisfies("+sycl")))
+        entries.append(cmake_cache_option("ENABLE_SYCL", spec.satisfies("+sycl")))
 
         # C++17
         if spec.satisfies("@2024.07.0:") and spec.satisfies("+sycl"):


### PR DESCRIPTION
Fixed: The variable set in the package did not match the one used in the build system.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
