### PR TITLE
Fix makefile target check when running keep-going depfile make jobserver

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1855,13 +1855,22 @@ class PackageBase(WindowsRPath, PackageViewMixin, RedistributionMixin, metaclass
         #
         # BSD Make:
         #     make: don't know how to make test. Stop
+        #
+        # Note: "Stop." is not printed when running a Make jobserver (spack env depfile) that runs
+        # with `make -k/--keep-going`
         missing_target_msgs = [
-            "No rule to make target `{0}'.  Stop.",
-            "No rule to make target '{0}'.  Stop.",
-            "don't know how to make {0}. Stop",
+            "No rule to make target `{0}'.",
+            "No rule to make target '{0}'.",
+            "don't know how to make {0}.",
         ]
 
-        kwargs = {"fail_on_error": False, "output": os.devnull, "error": str}
+        kwargs = {
+            "fail_on_error": False,
+            "output": os.devnull,
+            "error": str,
+            # Remove MAKEFLAGS to avoid inherited flags from Make jobserver (spack env depfile)
+            "extra_env": {"MAKEFLAGS": ""},
+        }
 
         stderr = make("-n", target, **kwargs)
 


### PR DESCRIPTION
When running a Makefile jobserver from `spack env depfile`, with `make -k`/`make --keep-going` (make's non-fail-fast mode), I encountered the following error:

```console
$ spack env depfile -o my-depfile.mk
$ SPACK_INSTALL_FLAGS=-v make -f my-depfile.mk -j20 --keep-going  # Install as much as possible
...
==> [<date>] 'make' '-n' 'check'
==> [<date>] 'make' 'check'
make[1]: *** No rule to make target 'check'. 
...
```

Spack would erroneously detect the `check` target, and tried to execute it.

This is because `make -k`/`make --keep-going` is forwarded through `MAKEFLAGS`, and `make -k` does not print `Stop` at the end:

```console
$ cat Makefile
a:
	echo a
$ make -n foobar
make: *** No rule to make target 'foobar'.  Stop.
$ make -k -n foobar
make: *** No rule to make target 'foobar'.
```

EDIT: mention `env depfile` and `MAKEFLAGS` for clarity

