### PR TITLE
py-rpds-py: add v0.18.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-rpds-py/package.py
+++ b/var/spack/repos/builtin/packages/py-rpds-py/package.py
@@ -17,5 +17,8 @@ class PyRpdsPy(PythonPackage):
     license("MIT", checked_by="wdconinc")
 
     version("0.20.0", sha256="d72a210824facfdaf8768cf2d7ca25a042c30320b3020de2fa04640920d4e121")
+    version("0.18.1", sha256="dc48b479d540770c811fbd1eb9ba2bb66951863e448efec2e2c102625328e92f")
 
-    depends_on("py-maturin@1.2:1", type="build")
+    depends_on("rust@1.76:", when="@0.19:")
+    depends_on("py-maturin@1.0:1", type="build")
+    depends_on("py-maturin@1.2:", type="build", when="@0.20:")


### PR DESCRIPTION
This PR adds `py-rpds-py`, v0.18.1. This older version is the last one compatible with `rust@1.75` (through archery and triomphe), which is available as an external on operating systems we use a lot.

Test build:
```
==> Installing py-rpds-py-0.18.1-gjqheki46rkyteeu43ue6hsnusswsui7 [113/123]
==> No binary for py-rpds-py-0.18.1-gjqheki46rkyteeu43ue6hsnusswsui7 found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/r/rpds_py/rpds_py-0.18.1.tar.gz
==> No patches needed for py-rpds-py
==> py-rpds-py: Executing phase: 'install'
==> py-rpds-py: Successfully installed py-rpds-py-0.18.1-gjqheki46rkyteeu43ue6hsnusswsui7
  Stage: 0.62s.  Install: 1m 28.01s.  Post-install: 0.25s.  Total: 1m 29.13s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-rpds-py-0.18.1-gjqheki46rkyteeu43ue6hsnusswsui7
```