### PR TITLE
mvapich: hydra process manager requires pmi_version simple

### DIFF
--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -121,6 +121,10 @@ class Mvapich(AutotoolsPackage):
     with when("process_managers=auto"):
         conflicts("pmi_version=pmi2")
 
+    with when("process_managers=hydra"):
+        conflicts("pmi_version=pmi2")
+        conflicts("pmi_version=pmix")
+
     filter_compiler_wrappers("mpicc", "mpicxx", "mpif77", "mpif90", "mpifort", relative_root="bin")
 
     @classmethod


### PR DESCRIPTION
When I tried to install `mvapich@3` with `process_managers=hydra` and `pmi_version=pmi2`, I got an error during `spack install` in the `configure` step of `mvapich`. It complained that `hydra` requires `pmi_version=simple`. I don't see this conflict in the package.

Hopefully the package maintainers can tell me if I am doing something wrong or if the changes in this PR are ok.