### PR TITLE
`gc`: restrict to specific specs

### DIFF
--- a/lib/spack/spack/cmd/gc.py
+++ b/lib/spack/spack/cmd/gc.py
@@ -41,7 +41,7 @@ def setup_parser(subparser):
         help="do not remove installed build-only dependencies of roots\n"
         "(default is to keep only link & run dependencies)",
     )
-    spack.cmd.common.arguments.add_common_arguments(subparser, ["yes_to_all"])
+    spack.cmd.common.arguments.add_common_arguments(subparser, ["yes_to_all", "constraint"])
 
 
 def roots_from_environments(args, active_env):
@@ -97,6 +97,12 @@ def gc(parser, args):
             root_hashes = None
 
         specs = spack.store.STORE.db.unused_specs(root_hashes=root_hashes, deptype=deptype)
+
+        # limit search to constraint specs if provided
+        if args.constraint:
+            hashes = set(spec.dag_hash() for spec in args.specs())
+            specs = [spec for spec in specs if spec.dag_hash() in hashes]
+
         if not specs:
             tty.msg("There are no unused specs. Spack's store is clean.")
             return

--- a/lib/spack/spack/test/cmd/gc.py
+++ b/lib/spack/spack/test/cmd/gc.py
@@ -36,6 +36,22 @@ def test_gc_with_build_dependency(mutable_database):
 
 
 @pytest.mark.db
+def test_gc_with_constraints(mutable_database):
+    s_cmake1 = spack.spec.Spec("simple-inheritance ^cmake@3.4.3").concretized()
+    s_cmake2 = spack.spec.Spec("simple-inheritance ^cmake@3.23.1").concretized()
+    PackageInstaller([s_cmake1.package], explicit=True, fake=True).install()
+    PackageInstaller([s_cmake2.package], explicit=True, fake=True).install()
+
+    assert "There are no unused specs." in gc("python")
+
+    assert "Successfully uninstalled cmake@3.4.3" in gc("-y", "cmake@3.4.3")
+    assert "There are no unused specs." in gc("-y", "cmake@3.4.3")
+
+    assert "Successfully uninstalled cmake" in gc("-y", "cmake@3.23.1")
+    assert "There are no unused specs." in gc("-y", "cmake")
+
+
+@pytest.mark.db
 def test_gc_with_environment(mutable_database, mutable_mock_env_path):
     s = spack.spec.Spec("simple-inheritance")
     s.concretize()

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1195,7 +1195,12 @@ _spack_find() {
 }
 
 _spack_gc() {
-    SPACK_COMPREPLY="-h --help -E --except-any-environment -e --except-environment -b --keep-build-dependencies -y --yes-to-all"
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -E --except-any-environment -e --except-environment -b --keep-build-dependencies -y --yes-to-all"
+    else
+        _installed_packages
+    fi
 }
 
 _spack_gpg() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1817,6 +1817,7 @@ complete -c spack -n '__fish_spack_using_command find' -l end-date -r -d 'latest
 
 # spack gc
 set -g __fish_spack_optspecs_spack_gc h/help E/except-any-environment e/except-environment= b/keep-build-dependencies y/yes-to-all
+complete -c spack -n '__fish_spack_using_command_pos_remainder 0 gc' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command gc' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command gc' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command gc' -s E -l except-any-environment -f -a except_any_environment


### PR DESCRIPTION
`spack gc` has so far been a global or environment-specific thing. This adds the ability to restrict garbage collection to specific specs, e.g. if you *just* want to get rid of all your unused python installations, you could write:

```console
spack gc python
```

- [x] add `constraint` arg to `spack gc`
- [x] add a simple test

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
