### PR TITLE
actsvg: new variant +python

### DIFF
--- a/var/spack/repos/builtin/packages/actsvg/package.py
+++ b/var/spack/repos/builtin/packages/actsvg/package.py
@@ -41,6 +41,7 @@ class Actsvg(CMakePackage):
 
     variant("examples", default=False, description="Build the example applications")
     variant("meta", default=True, description="Build the meta level interface")
+    variant("python", default=True, when="@0.4.39:", description="Build the python bindings")
     variant(
         "web", default=True, when="@0.4.36:", description="Build the webpage builder interface"
     )
@@ -48,11 +49,13 @@ class Actsvg(CMakePackage):
     depends_on("boost +program_options", type="test")
     depends_on("boost +program_options", when="+examples")
     depends_on("googletest", when="+examples")
+    depends_on("python@3.8:", when="+python")
 
     def cmake_args(self):
         args = [
             self.define_from_variant("ACTSVG_BUILD_EXAMPLES", "examples"),
             self.define_from_variant("ACTSVG_BUILD_META", "meta"),
+            self.define_from_variant("ACTSVG_BUILD_PYTHON_BINDINGS", "python"),
             self.define_from_variant("ACTSVG_BUILD_WEB", "web"),
             self.define("ACTSVG_BUILD_TESTING", self.run_tests),
         ]


### PR DESCRIPTION
This PR adds the variant `+python` to `actsvg` to enable the Python bindings. True by default. Added in https://github.com/acts-project/actsvg/commit/cdef4a2f415baa13c0f51539f2528a3712cf3a9d, which was first included in 0.4.39. Still requires 3.8 or newer.

Test build:
```
==> Installing actsvg-0.4.50-uvgbmojmo6kqktezpb3y2uhfv5r63voq [30/30]
==> No binary for actsvg-0.4.50-uvgbmojmo6kqktezpb3y2uhfv5r63voq found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/c9/c97fb1cc75cbf23caebd3c6fb8716354bdbd0a77ad39dc43dae963692f3256e1.zip
==> No patches needed for actsvg
==> actsvg: Executing phase: 'cmake'
==> actsvg: Executing phase: 'build'
==> actsvg: Executing phase: 'install'
==> actsvg: Successfully installed actsvg-0.4.50-uvgbmojmo6kqktezpb3y2uhfv5r63voq
  Stage: 0.04s.  Cmake: 4.58s.  Build: 39.72s.  Install: 0.10s.  Post-install: 0.17s.  Total: 44.84s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/actsvg-0.4.50-uvgbmojmo6kqktezpb3y2uhfv5r63voq
```

Fixes:
```
     45    -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
     46    -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
     47    -- Found Threads: TRUE
  >> 48    CMake Error at /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/cmake-3.30.2-43womxnbbulx2r267f37xylba4lbslle/share/cmake-3.30/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
     49      Could NOT find Python (missing: Python_INCLUDE_DIRS Python_LIBRARIES
     50      Development Development.Module Development.Embed) (found suitable version
     51      "3.13.0", minimum required is "3.8")
     52    Call Stack (most recent call first):
     53      /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/cmake-3.30.2-43womxnbbulx2r267f37xylba4lbslle/share/cmake-3.30/Modules/FindPackageHandleStandardArgs.cmake:603 (_FPHSA_FAILURE_MESSAGE)
     54      /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/cmake-3.30.2-43womxnbbulx2r267f37xylba4lbslle/share/cmake-3.30/Modules/FindPython/Support.cmake:4002 (find_package_handle_standard_args)
```