### PR TITLE
py-gssapi: add v1.9.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-gssapi/package.py
+++ b/var/spack/repos/builtin/packages/py-gssapi/package.py
@@ -15,11 +15,13 @@ class PyGssapi(PythonPackage):
 
     maintainers("wdconinc")
 
+    version("1.9.0", sha256="f468fac8f3f5fca8f4d1ca19e3cd4d2e10bd91074e7285464b22715d13548afe")
     version("1.8.3", sha256="aa3c8d0b1526f52559552bb2c9d2d6be013d76a8e5db00b39a1db5727e93b0b0")
     version("1.8.2", sha256="b78e0a021cc91158660e4c5cc9263e07c719346c35a9c0f66725e914b235c89a")
 
     depends_on("py-cython@0.29.29:2", type="build", when="@:1.8.2")
     depends_on("py-cython@0.29.29:3", type="build", when="@1.8.3:")
+    depends_on("py-cython@3.0.3:3", type="build", when="@1.9.0:")
     depends_on("py-setuptools@40.6.0:", type="build")
 
     depends_on("py-decorator", type=("build", "run"))


### PR DESCRIPTION
This PR adds `py-gssapi`, v1.9.0, [diff](https://github.com/pythongssapi/python-gssapi/compare/v1.8.3...v1.9.0). Updated `py-cython` requirement to v3.

Test build:
```
==> Installing py-gssapi-1.9.0-xbdrb73rmk2jgebg4qmk6oknpdkk3vav [31/31]
==> No binary for py-gssapi-1.9.0-xbdrb73rmk2jgebg4qmk6oknpdkk3vav found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/g/gssapi/gssapi-1.9.0.tar.gz
==> No patches needed for py-gssapi
==> py-gssapi: Executing phase: 'install'
==> py-gssapi: Successfully installed py-gssapi-1.9.0-xbdrb73rmk2jgebg4qmk6oknpdkk3vav
  Stage: 1.23s.  Install: 4m 27.01s.  Post-install: 1.11s.  Total: 4m 30.41s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-gssapi-1.9.0-xbdrb73rmk2jgebg4qmk6oknpdkk3vav
```