### PR TITLE
py-krb5: add v0.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-krb5/package.py
+++ b/var/spack/repos/builtin/packages/py-krb5/package.py
@@ -16,8 +16,10 @@ class PyKrb5(PythonPackage):
 
     license("MIT", checked_by="wdconinc")
 
+    version("0.7.0", sha256="6a308f2e17d151c395b24e6aec7bdff6a56fe3627a32042fc86d412398a92ddd") 
     version("0.6.0", sha256="712ba092fbe3a28ec18820bb1b1ed2cc1037b75c5c7033f970c6a8c97bbd1209")
 
+    depends_on("python@3.8:", type=("build", "run"), when="@0.7.0:")
     depends_on("py-setuptools@42:", type="build")
     depends_on("py-cython@0.29.32:3", type=("build", "run"))
     depends_on("krb5", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-krb5/package.py
+++ b/var/spack/repos/builtin/packages/py-krb5/package.py
@@ -16,7 +16,7 @@ class PyKrb5(PythonPackage):
 
     license("MIT", checked_by="wdconinc")
 
-    version("0.7.0", sha256="6a308f2e17d151c395b24e6aec7bdff6a56fe3627a32042fc86d412398a92ddd") 
+    version("0.7.0", sha256="6a308f2e17d151c395b24e6aec7bdff6a56fe3627a32042fc86d412398a92ddd")
     version("0.6.0", sha256="712ba092fbe3a28ec18820bb1b1ed2cc1037b75c5c7033f970c6a8c97bbd1209")
 
     depends_on("python@3.8:", type=("build", "run"), when="@0.7.0:")


### PR DESCRIPTION
This PR adds `py-krb5`, v0.7.0, [diff](https://github.com/jborean93/pykrb5/compare/v0.6.0...v0.7.0). Requires python@3.8 now.

Test build:
```
==> Installing py-krb5-0.7.0-bwi4nim7ukdr4ew74hmtmvjumznmeelf [30/30]
==> No binary for py-krb5-0.7.0-bwi4nim7ukdr4ew74hmtmvjumznmeelf found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/k/krb5/krb5-0.7.0.tar.gz
==> No patches needed for py-krb5
==> py-krb5: Executing phase: 'install'
==> py-krb5: Successfully installed py-krb5-0.7.0-bwi4nim7ukdr4ew74hmtmvjumznmeelf
  Stage: 0.98s.  Install: 5m 59.49s.  Post-install: 0.67s.  Total: 6m 1.55s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-krb5-0.7.0-bwi4nim7ukdr4ew74hmtmvjumznmeelf
```