### PR TITLE
root: add v6.32.06

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -34,6 +34,7 @@ class Root(CMakePackage):
     version("develop", branch="master")
 
     # Production version
+    version("6.32.06", sha256="3fc032d93fe848dea5adb1b47d8f0a86279523293fee0aa2b3cd52a1ffab7247")
     version("6.32.04", sha256="132f126aae7d30efbccd7dcd991b7ada1890ae57980ef300c16421f9d4d07ea8")
     version("6.32.02", sha256="3d0f76bf05857e1807ccfb2c9e014f525bcb625f94a2370b455f4b164961602d")
     version("6.32.00", sha256="12f203681a59041c474ce9523761e6f0e8861b3bee78df5f799a8db55189e5d2")
@@ -456,6 +457,10 @@ class Root(CMakePackage):
     # See https://github.com/root-project/root/issues/11714
     if sys.platform == "darwin" and macos_version() >= Version("13"):
         conflicts("@:6.26.09", msg="macOS 13 support was added in root 6.26.10")
+
+    # See https://github.com/root-project/root/issues/16219
+    if sys.platform == "darwin" and macos_version() >= Version("15"):
+        conflicts("@:6.32.05", msg="macOS 15 support was added in root 6.32.06")
 
     # ROOT <6.14 is incompatible with Python >=3.7, which is the minimum supported by spack
     conflicts("+python", when="@:6.13", msg="Spack wants python >=3.7, too new for ROOT <6.14")


### PR DESCRIPTION
This PR adds `root`, v6.32.06, which fixes bugs and adds macOS sequoia support, [release notes](https://root.cern/doc/v632/release-notes.html#release-6.32.06).

Test build (on Linux):
```
==> Installing root-6.32.06-sy7opihfn5brchpxctberyterolpv5ul [76/76]
==> No binary for root-6.32.06-sy7opihfn5brchpxctberyterolpv5ul found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/3f/3fc032d93fe848dea5adb1b47d8f0a86279523293fee0aa2b3cd52a1ffab7247.tar.gz
==> Using cached archive: /opt/spack/cache/_source-cache/archive/99/991905b17d246fb7584309fdeb5720d29a083a1313920562de1de1edb11675a6
==> Applied patch /home/wdconinc/git/spack/var/spack/repos/builtin/packages/root/format-stringbuf-size.patch
==> Applied patch https://github.com/wdconinc/root/commit/06db88c70f602c08c97c401b81afcf6adc2eb25e.diff?full_index=1
==> Ran patch() for root
==> root: Executing phase: 'cmake'
==> root: Executing phase: 'build'
==> root: Executing phase: 'install'
==> root: Successfully installed root-6.32.06-sy7opihfn5brchpxctberyterolpv5ul
  Stage: 2.17s.  Cmake: 33.01s.  Build: 5m 42.11s.  Install: 17.60s.  Post-install: 6.27s.  Total: 6m 42.80s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/root-6.32.06-sy7opihfn5brchpxctberyterolpv5ul
```