### PR TITLE
ruby: add v3.3.5

### DIFF
--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -47,6 +47,7 @@ class Ruby(AutotoolsPackage, NMakePackage):
         with when(_platform_condition):
             variant("openssl", default=True, description="Enable OpenSSL support")
             variant("readline", default=False, description="Enable Readline support")
+            variant("yjit", default=False, description="Enable Rust JIT", when="@3.2:")
             depends_on("pkgconfig", type="build")
             depends_on("libffi")
             depends_on("libx11", when="@:2.3")
@@ -58,6 +59,8 @@ class Ruby(AutotoolsPackage, NMakePackage):
             with when("+openssl"):
                 depends_on("openssl@:1")
                 depends_on("openssl@:1.0", when="@:2.3")
+            with when("+yjit"):
+                depends_on("rust@1.58:")
 
     extendable = True
 
@@ -133,6 +136,7 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder, SetupEnvi
             args.append("--with-tk=%s" % self.spec["tk"].prefix)
         if self.spec.satisfies("%fj"):
             args.append("--disable-dtrace")
+        args.extend(self.enable_or_disable("yjit"))
         return args
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -24,6 +24,7 @@ class Ruby(AutotoolsPackage, NMakePackage):
 
     license("Ruby AND BSD-2-Clause AND MIT", checked_by="tgamblin")
 
+    version("3.3.5", sha256="3781a3504222c2f26cb4b9eb9c1a12dbf4944d366ce24a9ff8cf99ecbce75196")
     version("3.3.4", sha256="fe6a30f97d54e029768f2ddf4923699c416cdbc3a6e96db3e2d5716c7db96a34")
     version("3.3.2", sha256="3be1d100ebf2a0ce60c2cd8d22cd9db4d64b3e04a1943be2c4ff7b520f2bcb5b")
     version("3.3.0", sha256="96518814d9832bece92a85415a819d4893b307db5921ae1f0f751a9a89a56b7d")


### PR DESCRIPTION
This PR adds `ruby`, v3.3.5, [release notes](https://github.com/ruby/ruby/releases/tag/v3_3_5), [diff](https://github.com/ruby/ruby/compare/v3_3_4...v3_3_5). No changes to configure.ac.

New variant `+yjit` controls the rust-based JIT that's in ruby since 3.2 on macOS and Linux (https://docs.ruby-lang.org/en/master/yjit/yjit_md.html). It is explicitly disabled when the variant is unset to avoid picking up `/usr/bin/rustc`.

Test build (`~yjit`):
```
==> Installing ruby-3.3.5-74d2s2j6ug6u7l75npp3n4h76nbeakf3 [33/48]
==> No binary for ruby-3.3.5-74d2s2j6ug6u7l75npp3n4h76nbeakf3 found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/37/3781a3504222c2f26cb4b9eb9c1a12dbf4944d366ce24a9ff8cf99ecbce75196.tar.gz
==> No patches needed for ruby
==> ruby: Executing phase: 'autoreconf'
==> ruby: Executing phase: 'configure'
==> ruby: Executing phase: 'build'
==> ruby: Executing phase: 'install'
==> ruby: Successfully installed ruby-3.3.5-74d2s2j6ug6u7l75npp3n4h76nbeakf3
  Stage: 2.43s.  Autoreconf: 0.00s.  Configure: 1m 17.22s.  Build: 7m 25.33s.  Install: 1m 34.86s.  Post-install: 11.41s.  Total: 10m 31.39s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/ruby-3.3.5-74d2s2j6ug6u7l75npp3n4h76nbeakf3
```

With `+yjit` and an external rust on ubuntu24.04, I am getting an `LLVM ERROR: Invalid encoding` error which the new variant allows to circumvent. It is going to take me a while to build rust in spack to see if the same issue is present there.
```
1 error found in build log:
     866    make[1]: Entering directory '/opt/spack/stage/wdconinc/spack-stage-ruby-3.3.5-7m24ndkserxqdscfoywwl3h4qhb7yfop/spack-src'
     867    make[1]: Nothing to be done for 'srcs'.
     868    make[1]: Leaving directory '/opt/spack/stage/wdconinc/spack-stage-ruby-3.3.5-7m24ndkserxqdscfoywwl3h4qhb7yfop/spack-src'
     869    ./miniruby -I./lib -I. -I.ext/common  ./tool/generic_erb.rb -c -o transdb.h ./template/transdb.h.tmpl ./enc/trans enc/trans
     870    LLVM ERROR: Invalid encoding
     871    transdb.h updated
  >> 872    make: *** [Makefile:318: libruby-static.a] Aborted (core dumped)
     873    make: *** Deleting file 'libruby-static.a'
```

Test build (`+yjit`), with a spack-built rust (1.81, in ths case):
```
==> Installing ruby-3.3.5-q4k55hioz6xnb5p7z5tcjodxordtibke [40/40]
==> No binary for ruby-3.3.5-q4k55hioz6xnb5p7z5tcjodxordtibke found: installing from source
==> Fetching https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.5.tar.gz
==> No patches needed for ruby
==> ruby: Executing phase: 'autoreconf'
==> ruby: Executing phase: 'configure'
==> ruby: Executing phase: 'build'
==> ruby: Executing phase: 'install'
==> ruby: Successfully installed ruby-3.3.5-q4k55hioz6xnb5p7z5tcjodxordtibke
  Stage: 1.30s.  Autoreconf: 0.00s.  Configure: 34.50s.  Build: 1m 21.26s.  Install: 30.94s.  Post-install: 4.71s.  Total: 2m 32.86s
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/ruby-3.3.5-q4k55hioz6xnb5p7z5tcjodxordtibke
```