### PR TITLE
ocl-icd: add v2.3.2

### DIFF
--- a/var/spack/repos/builtin/packages/ocl-icd/package.py
+++ b/var/spack/repos/builtin/packages/ocl-icd/package.py
@@ -16,6 +16,7 @@ class OclIcd(AutotoolsPackage):
 
     license("BSD-2-Clause")
 
+    version("2.3.2", sha256="ec47d7dcd961ea06695b067e8b7edb82e420ddce03e0081a908c62fd0b8535c5")
     version("2.3.1", sha256="a32b67c2d52ffbaf490be9fc18b46428ab807ab11eff7664d7ff75e06cfafd6d")
     version("2.3.0", sha256="469f592ccd9b0547fb7212b17e1553b203d178634c20d3416640c0209e3ddd50")
     version("2.2.14", sha256="46df23608605ad548e80b11f4ba0e590cef6397a079d2f19adf707a7c2fbfe1b")


### PR DESCRIPTION
This PR adds `ocl-icd`, v2.3.2, [diff](https://github.com/OCL-dev/ocl-icd/compare/v2.3.1...v2.3.2). A new build option has been added to support custom layer directories, but that support is not added here.

Test builds:
```
==> Installing ocl-icd-2.3.2-xkk2aikp2jhyqpm2ejotdjvfklmctujc [46/47]
==> No binary for ocl-icd-2.3.2-xkk2aikp2jhyqpm2ejotdjvfklmctujc found: installing from source
==> Fetching https://github.com/OCL-dev/ocl-icd/archive/v2.3.2.tar.gz
==> No patches needed for ocl-icd
==> ocl-icd: Executing phase: 'autoreconf'
==> ocl-icd: Executing phase: 'configure'
==> ocl-icd: Executing phase: 'build'
==> ocl-icd: Executing phase: 'install'
==> ocl-icd: Successfully installed ocl-icd-2.3.2-xkk2aikp2jhyqpm2ejotdjvfklmctujc
  Stage: 1.03s.  Autoreconf: 4.93s.  Configure: 3.00s.  Build: 6.01s.  Install: 0.31s.  Post-install: 0.13s.  Total: 15.68s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/ocl-icd-2.3.2-xkk2aikp2jhyqpm2ejotdjvfklmctujc
```