### PR TITLE
clinfo: add v3.0.23.01.25

### DIFF
--- a/var/spack/repos/builtin/packages/clinfo/package.py
+++ b/var/spack/repos/builtin/packages/clinfo/package.py
@@ -19,6 +19,9 @@ class Clinfo(MakefilePackage):
     license("CC0-1.0")
 
     version(
+        "3.0.23.01.25", sha256="6dcdada6c115873db78c7ffc62b9fc1ee7a2d08854a3bccea396df312e7331e3"
+    )
+    version(
         "3.0.21.02.21", sha256="e52f5c374a10364999d57a1be30219b47fb0b4f090e418f2ca19a0c037c1e694"
     )
     version(


### PR DESCRIPTION
This PR adds `clinfo`, v3.0.23.01.25, [diff](https://github.com/Oblomov/clinfo/compare/3.0.21.02.21...3.0.23.01.25), minimal upstream changes only.

Test builds:
```
==> Installing clinfo-3.0.23.01.25-3qiq2asao5vxxok7oxw2hza2ug7zx2dh [47/47]
==> No binary for clinfo-3.0.23.01.25-3qiq2asao5vxxok7oxw2hza2ug7zx2dh found: installing from source
==> Fetching https://github.com/Oblomov/clinfo/archive/refs/tags/3.0.23.01.25.tar.gz
==> No patches needed for clinfo
==> clinfo: Executing phase: 'edit'
==> clinfo: Executing phase: 'build'
==> clinfo: Executing phase: 'install'
==> clinfo: Successfully installed clinfo-3.0.23.01.25-3qiq2asao5vxxok7oxw2hza2ug7zx2dh
  Stage: 0.98s.  Edit: 0.00s.  Build: 0.88s.  Install: 0.02s.  Post-install: 0.19s.  Total: 2.27s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/clinfo-3.0.23.01.25-3qiq2asao5vxxok7oxw2hza2ug7zx2dh
```