### PR TITLE
gdbm: add v1.24

### DIFF
--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -17,6 +17,7 @@ class Gdbm(AutotoolsPackage, GNUMirrorPackage):
 
     license("GPL-3.0-or-later")
 
+    version("1.24", sha256="695e9827fdf763513f133910bc7e6cfdb9187943a4fec943e57449723d2b8dbf")
     version("1.23", sha256="74b1081d21fff13ae4bd7c16e5d6e504a4c26f7cde1dca0d963a484174bbcacd")
     version("1.22", sha256="f366c823a6724af313b6bbe975b2809f9a157e5f6a43612a72949138d161d762")
     version("1.21", sha256="b0b7dbdefd798de7ddccdd8edf6693a30494f7789777838042991ef107339cc2")


### PR DESCRIPTION
This PR adds `gdbm`, v1.24, [release notes](https://puszcza.gnu.org.ua/forum/forum.php?forum_id=1343), no relevant changes to [configure.ac](https://git.gnu.org.ua/gdbm.git/log/configure.ac?h=v1.24).

Test build:
```
==> Installing gdbm-1.24-6cpwshwh6vqbvbui7mdpg6shw6bp62xw [6/6]
==> No binary for gdbm-1.24-6cpwshwh6vqbvbui7mdpg6shw6bp62xw found: installing from source
==> Fetching https://ftpmirror.gnu.org/gdbm/gdbm-1.24.tar.gz
==> No patches needed for gdbm
==> gdbm: Executing phase: 'autoreconf'
==> gdbm: Executing phase: 'configure'
==> gdbm: Executing phase: 'build'
==> gdbm: Executing phase: 'install'
==> gdbm: Successfully installed gdbm-1.24-6cpwshwh6vqbvbui7mdpg6shw6bp62xw
  Stage: 4.01s.  Autoreconf: 0.00s.  Configure: 4.45s.  Build: 6.70s.  Install: 0.55s.  Post-install: 0.13s.  Total: 15.93s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/gdbm-1.24-6cpwshwh6vqbvbui7mdpg6shw6bp62xw
```