### PR TITLE
busybox: add v1.37.0

### DIFF
--- a/var/spack/repos/builtin/packages/busybox/package.py
+++ b/var/spack/repos/builtin/packages/busybox/package.py
@@ -16,6 +16,7 @@ class Busybox(MakefilePackage):
 
     license("GPL-2.0-only")
 
+    version("1.37.0", sha256="3311dff32e746499f4df0d5df04d7eb396382d7e108bb9250e7b519b837043a4")
     version("1.36.1", sha256="b8cc24c9574d809e7279c3be349795c5d5ceb6fdf19ca709f80cde50e47de314")
     version("1.36.0", sha256="542750c8af7cb2630e201780b4f99f3dcceeb06f505b479ec68241c1e6af61a5")
     version("1.31.1", sha256="d0f940a72f648943c1f2211e0e3117387c31d765137d92bd8284a3fb9752a998")


### PR DESCRIPTION
This PR adds `busybox`, v1.37.0, no relevant changes in [Makefile](https://git.busybox.net/busybox/log/Makefile?h=1_37_stable).

Test build (codespaces, kernel 6.5):
```
==> Installing busybox-1.37.0-rs3qrvlgm3wbf5v7h6rv4ltjfilfrh3z [4/4]
==> No binary for busybox-1.37.0-rs3qrvlgm3wbf5v7h6rv4ltjfilfrh3z found: installing from source
==> Fetching https://busybox.net/downloads/busybox-1.37.0.tar.bz2
==> No patches needed for busybox
==> busybox: Executing phase: 'edit'
==> busybox: Executing phase: 'build'
==> busybox: Executing phase: 'install'
==> busybox: Successfully installed busybox-1.37.0-rs3qrvlgm3wbf5v7h6rv4ltjfilfrh3z
  Stage: 1.81s.  Edit: 0.00s.  Build: 1m 5.68s.  Install: 4.78s.  Post-install: 1.47s.  Total: 1m 13.93s
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/busybox-1.37.0-rs3qrvlgm3wbf5v7h6rv4ltjfilfrh3z
```

Note: there are potentially issues with newer kernels, see http://lists.busybox.net/pipermail/busybox-cvs/2024-January/041752.html. This affects earlier versions too, so there is nothing that we can really do about it here since we cannot access the kernel version.