### PR TITLE
sysstat: add v12.7.6 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/sysstat/package.py
+++ b/var/spack/repos/builtin/packages/sysstat/package.py
@@ -17,8 +17,12 @@ class Sysstat(AutotoolsPackage):
 
     license("GPL-2.0-or-later")
 
-    version("12.4.5", sha256="4e35abdd9eaf766ecdab55786f459093f3e1c350db23e57a15561afda417ff0d")
-    version("12.2.0", sha256="614ab9fe8e7937a3edb7b2b6760792a3764ea3a7310ac540292dd0e3dfac86a6")
+    version("12.7.6", sha256="dc77a08871f8e8813448ea31048833d4acbab7276dd9a456cd2526c008bd5301")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2023-33204
+        # https://nvd.nist.gov/vuln/detail/CVE-2022-39377
+        version("12.4.5", sha256="4e35abdd9eaf766ecdab55786f459093f3e1c350db23e57a15561afda417ff0d")
+        version("12.2.0", sha256="614ab9fe8e7937a3edb7b2b6760792a3764ea3a7310ac540292dd0e3dfac86a6")
 
     depends_on("c", type="build")  # generated
 

--- a/var/spack/repos/builtin/packages/sysstat/package.py
+++ b/var/spack/repos/builtin/packages/sysstat/package.py
@@ -21,8 +21,12 @@ class Sysstat(AutotoolsPackage):
     with default_args(deprecated=True):
         # https://nvd.nist.gov/vuln/detail/CVE-2023-33204
         # https://nvd.nist.gov/vuln/detail/CVE-2022-39377
-        version("12.4.5", sha256="4e35abdd9eaf766ecdab55786f459093f3e1c350db23e57a15561afda417ff0d")
-        version("12.2.0", sha256="614ab9fe8e7937a3edb7b2b6760792a3764ea3a7310ac540292dd0e3dfac86a6")
+        version(
+            "12.4.5", sha256="4e35abdd9eaf766ecdab55786f459093f3e1c350db23e57a15561afda417ff0d"
+        )
+        version(
+            "12.2.0", sha256="614ab9fe8e7937a3edb7b2b6760792a3764ea3a7310ac540292dd0e3dfac86a6"
+        )
 
     depends_on("c", type="build")  # generated
 


### PR DESCRIPTION
This PR adds `sysstat`, v12.7.6, which fixes CVE-2022-39377, CVE-2023-33204, [release notes](https://sysstat.github.io/2024/07/03/sysstat-12.7.6.html), [diff](https://github.com/sysstat/sysstat/compare/v12.4.5...v12.7.6). No changes to dependencies based on the diff. Both CVEs are marked as high, so I marked the previous versions as deprecated.

Test build:
```
-- linux-ubuntu24.04-skylake / gcc@13.3.0 -----------------------
pwhnd5h sysstat@12.7.6 build_system=autotools
==> 1 installed package
```