### PR TITLE
gnutls: add variant +brotli

### DIFF
--- a/var/spack/repos/builtin/packages/gnutls/package.py
+++ b/var/spack/repos/builtin/packages/gnutls/package.py
@@ -83,20 +83,9 @@ class Gnutls(AutotoolsPackage):
             args.append("--with-included-unistring")
             args.append("--without-p11-kit")  # p11-kit@0.23.1: ...
 
-        if spec.satisfies("+zlib"):
-            args.append("--with-zlib")
-        else:
-            args.append("--without-zlib")
-
-        if spec.satisfies("+brotli"):
-            args.append("--with-brotli")
-        else:
-            args.append("--without-brotli")
-
-        if spec.satisfies("+guile"):
-            args.append("--enable-guile")
-        else:
-            args.append("--disable-guile")
+        args += self.with_or_without("zlib")
+        args += self.with_or_without("brotli")
+        args += self.enable_or_disable("guile")
 
         if self.run_tests:
             args.extend(["--enable-tests", "--enable-valgrind-tests", "--enable-full-test-suite"])

--- a/var/spack/repos/builtin/packages/gnutls/package.py
+++ b/var/spack/repos/builtin/packages/gnutls/package.py
@@ -38,6 +38,7 @@ class Gnutls(AutotoolsPackage):
 
     variant("zlib", default=True, description="Enable zlib compression support")
     variant("guile", default=False, description="Enable Guile bindings")
+    variant("brotli", default=True, description="Enable brotli compression support")
 
     # gnutls+guile is currently broken on MacOS.  See Issue #11668
     conflicts("+guile", when="platform=darwin")
@@ -54,6 +55,7 @@ class Gnutls(AutotoolsPackage):
     depends_on("libidn2@:2.0", when="@:3.5")
     depends_on("libidn2")
     depends_on("zlib-api", when="+zlib")
+    depends_on("brotli", when="+brotli")
     depends_on("gettext")
 
     depends_on("pkgconfig", type="build")
@@ -83,6 +85,11 @@ class Gnutls(AutotoolsPackage):
             args.append("--with-zlib")
         else:
             args.append("--without-zlib")
+
+        if spec.satisfies("+brotli"):
+            args.append("--with-brotli")
+        else:
+            args.append("--without-brotli")
 
         if spec.satisfies("+guile"):
             args.append("--enable-guile")

--- a/var/spack/repos/builtin/packages/gnutls/package.py
+++ b/var/spack/repos/builtin/packages/gnutls/package.py
@@ -38,7 +38,9 @@ class Gnutls(AutotoolsPackage):
 
     variant("zlib", default=True, description="Enable zlib compression support")
     variant("guile", default=False, description="Enable Guile bindings")
-    variant("brotli", default=True, description="Enable brotli compression support", when="@3.7.4:")
+    variant(
+        "brotli", default=True, description="Enable brotli compression support", when="@3.7.4:"
+    )
 
     # gnutls+guile is currently broken on MacOS.  See Issue #11668
     conflicts("+guile", when="platform=darwin")

--- a/var/spack/repos/builtin/packages/gnutls/package.py
+++ b/var/spack/repos/builtin/packages/gnutls/package.py
@@ -38,7 +38,7 @@ class Gnutls(AutotoolsPackage):
 
     variant("zlib", default=True, description="Enable zlib compression support")
     variant("guile", default=False, description="Enable Guile bindings")
-    variant("brotli", default=True, description="Enable brotli compression support")
+    variant("brotli", default=True, description="Enable brotli compression support", when="@3.7.4:")
 
     # gnutls+guile is currently broken on MacOS.  See Issue #11668
     conflicts("+guile", when="platform=darwin")


### PR DESCRIPTION
This PR adds `brotli` variant `+brotli` to explicitly enable/disable brotli support. Otherwise this is picked up transitively but not sufficiently provided as an include path, resulting in:
```
  >> 3680    /opt/spack/stage/wdconinc/spack-stage-gnutls-3.8.3-ofqydkhtdh3m2vd4wsyx7aebzjoriocp/spack-src/lib/compress.c:30:10: fatal error: brotli/decode.h: No such file or directory
     3681       30 | #include <brotli/decode.h>
     3682          |          ^~~~~~~~~~~~~~~~~
     3683    compilation terminated.
  >> 3684    make[4]: *** [Makefile:2882: compress.lo] Error 1
     3685    make[4]: *** Waiting for unfinished jobs....
```

Test build (with `+brotli`):
```
==> Installing gnutls-3.8.3-dcs2rjcprdf3zimoo7sbh4yp645ty5nd [87/149]
==> No binary for gnutls-3.8.3-dcs2rjcprdf3zimoo7sbh4yp645ty5nd found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/f7/f74fc5954b27d4ec6dfbb11dea987888b5b124289a3703afcada0ee520f4173e.tar.xz
==> No patches needed for gnutls
==> gnutls: Executing phase: 'autoreconf'
==> gnutls: Executing phase: 'configure'
==> gnutls: Executing phase: 'build'
==> gnutls: Executing phase: 'install'
==> gnutls: Successfully installed gnutls-3.8.3-dcs2rjcprdf3zimoo7sbh4yp645ty5nd
  Stage: 0.43s.  Autoreconf: 0.00s.  Configure: 35.93s.  Build: 2m 46.68s.  Install: 3.95s.  Post-install: 0.51s.  Total: 3m 27.64s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/gnutls-3.8.3-dcs2rjcprdf3zimoo7sbh4yp645ty5nd
```