### PR TITLE
gimp: add v2.10.38

### DIFF
--- a/var/spack/repos/builtin/packages/gimp/package.py
+++ b/var/spack/repos/builtin/packages/gimp/package.py
@@ -25,6 +25,7 @@ class Gimp(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
+    version("2.10.38", sha256="50a845eec11c8831fe8661707950f5b8446e35f30edfb9acf98f85c1133f856e")
     version("2.10.32", sha256="3f15c70554af5dcc1b46e6dc68f3d8f0a6cc9fe56b6d78ac08c0fd859ab89a25")
     version("2.10.30", sha256="88815daa76ed7d4277eeb353358bafa116cd2fcd2c861d95b95135c1d52b67dc")
     version("2.10.28", sha256="4f4dc22cff1ab5f026feaa2ab55e05775b3a11e198186b47bdab79cbfa078826")


### PR DESCRIPTION
- [x] Needs #46814
- [x] Needs #46822
- [x] Needs #46824

This PR adds `gimp`, v2.10.38, [release notes](https://www.gimp.org/news/2024/05/05/gimp-2-10-38-released/), [diff](https://gitlab.gnome.org/GNOME/gimp/-/compare/GIMP_2_10_32...GIMP_2_10_38?from_project_id=1848&straight=false), [configure.ac](https://gitlab.gnome.org/GNOME/gimp/-/compare/GIMP_2_10_32...GIMP_2_10_38?from_project_id=1848&page=6&straight=false#87db583be5c13c1f7b3c958b10e03d67b6a2ca06).

There were updated requirements for `gegl`, `libjxl`, `babl`, but no dependency versions are specified in the package recipe so I didn't add them. The new required versions are old enough and have been in spack for a while.

Test build on clean codespaces instance (`$ spack install -j20 --add --deprecated gimp@=2.10.38 ^gettext +libxml2` after cherry-picking #46814, #46822, and #46824, and with `+libxml2` because of #46815):
```
==> Installing gimp-2.10.38-3rysavhmzgiqgkzp4rydgqmbmq2xbf4g [133/133]
==> No binary for gimp-2.10.38-3rysavhmzgiqgkzp4rydgqmbmq2xbf4g found: installing from source
==> Using cached archive: /workspaces/spack/var/spack/cache/_source-cache/archive/50/50a845eec11c8831fe8661707950f5b8446e35f30edfb9acf98f85c1133f856e.tar.bz2
==> No patches needed for gimp
==> gimp: Executing phase: 'autoreconf'
==> gimp: Executing phase: 'configure'
==> gimp: Executing phase: 'build'
==> gimp: Executing phase: 'install'
==> gimp: Successfully installed gimp-2.10.38-3rysavhmzgiqgkzp4rydgqmbmq2xbf4g
  Stage: 4.25s.  Autoreconf: 0.00s.  Configure: 34.58s.  Build: 2m 16.45s.  Install: 25.74s.  Post-install: 1.65s.  Total: 3m 23.27s
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/gimp-2.10.38-3rysavhmzgiqgkzp4rydgqmbmq2xbf4g
```