### PR TITLE
libwmf: add v0.2.13; patch for missing limits.h

### DIFF
--- a/var/spack/repos/builtin/packages/libwmf/package.py
+++ b/var/spack/repos/builtin/packages/libwmf/package.py
@@ -19,8 +19,15 @@ class Libwmf(AutotoolsPackage):
 
     license("LGPL-2.0-or-later")
 
+    version("0.2.13", sha256="18ba69febd2f515d98a2352de284a8051896062ac9728d2ead07bc39ea75a068") 
     version("0.2.12", sha256="464ff63605d7eaf61a4a12dbd420f7a41a4d854675d8caf37729f5bc744820e2")
     version("0.2.11", sha256="e2a2664afd5abc71a42be7ad3c200f64de2b8889bf088eac1d32e205ce843803")
+
+    patch(
+        "https://github.com/caolanm/libwmf/commit/1f87c35bc2a36fdca760a4577761d30d9cc876e2.patch?full_index=1",
+        sha256="80ae84a904baa21e1566e3d2bca1c6aaa0a2a30f684fe50f25e7e5751ef3ec93",
+        when="@:0.2.13",
+    )
 
     depends_on("c", type="build")  # generated
 

--- a/var/spack/repos/builtin/packages/libwmf/package.py
+++ b/var/spack/repos/builtin/packages/libwmf/package.py
@@ -19,7 +19,7 @@ class Libwmf(AutotoolsPackage):
 
     license("LGPL-2.0-or-later")
 
-    version("0.2.13", sha256="18ba69febd2f515d98a2352de284a8051896062ac9728d2ead07bc39ea75a068") 
+    version("0.2.13", sha256="18ba69febd2f515d98a2352de284a8051896062ac9728d2ead07bc39ea75a068")
     version("0.2.12", sha256="464ff63605d7eaf61a4a12dbd420f7a41a4d854675d8caf37729f5bc744820e2")
     version("0.2.11", sha256="e2a2664afd5abc71a42be7ad3c200f64de2b8889bf088eac1d32e205ce843803")
 


### PR DESCRIPTION
This PR adds `libwmf`, v0.2.13, [diff](https://github.com/caolanm/libwmf/compare/v0.2.12...v0.2.13), with minimal changes to configure.ac (limited to switching freetype detection to pkg-config).

This PR also adds an extra patch to address the following compilation error on gcc-9.4.0, and [apparently](https://github.com/caolanm/libwmf/pull/9) macOS:
```
gd.c: In function 'gdImageCreateFromXbm':
gd.c:2216:20: error: 'SHRT_MAX' undeclared (first use in this function)
 2216 |   if (w < 0 || w > SHRT_MAX || h < 0 || h > SHRT_MAX)
      |                    ^~~~~~~~
gd.c:8:1: note: 'SHRT_MAX' is defined in header '<limits.h>'; did you forget to '#include <limits.h>'?
    7 | #include "gdhelpers.h"
  +++ |+#include <limits.h>
    8 | 
gd.c:2216:20: note: each undeclared identifier is reported only once for each function it appears in
 2216 |   if (w < 0 || w > SHRT_MAX || h < 0 || h > SHRT_MAX)
      |                    ^~~~~~~~
```

Test build:
```
==> Installing libwmf-0.2.13-5zz73uqei5wfiwxtk35kiatx32oeq6cu [60/60]
==> No binary for libwmf-0.2.13-5zz73uqei5wfiwxtk35kiatx32oeq6cu found: installing from source
==> Fetching https://github.com/caolanm/libwmf/archive/refs/tags/v0.2.13.tar.gz
==> Using cached archive: /opt/spack/cache/_source-cache/archive/80/80ae84a904baa21e1566e3d2bca1c6aaa0a2a30f684fe50f25e7e5751ef3ec93
==> Applied patch https://github.com/caolanm/libwmf/commit/1f87c35bc2a36fdca760a4577761d30d9cc876e2.patch?full_index=1
==> libwmf: Executing phase: 'autoreconf'
==> libwmf: Executing phase: 'configure'
==> libwmf: Executing phase: 'build'
==> libwmf: Executing phase: 'install'
==> libwmf: Successfully installed libwmf-0.2.13-5zz73uqei5wfiwxtk35kiatx32oeq6cu
  Stage: 1.51s.  Autoreconf: 0.00s.  Configure: 4.65s.  Build: 7.98s.  Install: 0.68s.  Post-install: 0.37s.  Total: 15.44s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/libwmf-0.2.13-5zz73uqei5wfiwxtk35kiatx32oeq6cu
```

Patch applies cleanly to oldest version 0.2.11:
```
==> Installing libwmf-0.2.11-pge7jysr2vupj6vpdlqqecnnq4h22d6e [60/60]
==> No binary for libwmf-0.2.11-pge7jysr2vupj6vpdlqqecnnq4h22d6e found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/e2/e2a2664afd5abc71a42be7ad3c200f64de2b8889bf088eac1d32e205ce843803.tar.gz
==> Fetching https://github.com/caolanm/libwmf/commit/1f87c35bc2a36fdca760a4577761d30d9cc876e2.patch?full_index=1
==> Applied patch https://github.com/caolanm/libwmf/commit/1f87c35bc2a36fdca760a4577761d30d9cc876e2.patch?full_index=1
==> libwmf: Executing phase: 'autoreconf'
==> libwmf: Executing phase: 'configure'
==> libwmf: Executing phase: 'build'
==> libwmf: Executing phase: 'install'
==> libwmf: Successfully installed libwmf-0.2.11-pge7jysr2vupj6vpdlqqecnnq4h22d6e
  Stage: 1.66s.  Autoreconf: 0.00s.  Configure: 5.99s.  Build: 9.66s.  Install: 0.81s.  Post-install: 0.47s.  Total: 18.96s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/libwmf-0.2.11-pge7jysr2vupj6vpdlqqecnnq4h22d6e
```