### PR TITLE
Preserve initial environment for config paths

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -527,7 +527,21 @@ Environment variables
 After Spack-specific variables are evaluated, environment variables are
 expanded. These are formatted like Spack-specific variables, e.g.,
 ``${varname}``. You can use this to insert environment variables in your
-Spack configuration.
+Spack configuration. 
+
+Spack will not replace environment variables that 
+are not set. In addition, if an environment variable is removed during 
+a clean environment install, Spack will sometimes not expand the removed 
+environment variable. For consistency, avoid using environment variables 
+and variable patterns described in the 
+`clean_environment function <https://github.com/spack/spack/blob/develop/lib/spack/spack/build_environment.py>`_.
+
+Environment variables that may be cleaned include:
+
+* common build variables, such as ``LIBRARY_PATH`` and ``CPATH``.
+* common runtime variables, such as ``LD_LIBRARY_PATH``.
+* compiler variables, such as ``CC`` and ``MPICC``.
+* variables that end in ``_ROOT``
 
 ^^^^^^^^^^^^^^^^^^^^^
 User home directories

--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -8,8 +8,8 @@ import os
 from typing import Union
 
 import llnl.util.lang
-from llnl.util.filesystem import mkdirp
 import llnl.util.tty as tty
+from llnl.util.filesystem import mkdirp
 
 import spack.config
 import spack.fetch_strategy

--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -9,6 +9,7 @@ from typing import Union
 
 import llnl.util.lang
 from llnl.util.filesystem import mkdirp
+import llnl.util.tty as tty
 
 import spack.config
 import spack.fetch_strategy
@@ -29,6 +30,7 @@ def misc_cache_location():
 
 def _misc_cache():
     path = misc_cache_location()
+    tty.debug(f"Misc cache location: {path}")
     return spack.util.file_cache.FileCache(path)
 
 
@@ -46,15 +48,13 @@ def fetch_cache_location():
     This prevents Spack from repeatedly fetch the same files when
     building the same package different ways or multiple times.
     """
-    path = spack.config.get("config:source_cache")
-    if not path:
-        path = spack.paths.default_fetch_cache_path
-    path = spack.util.path.canonicalize_path(path)
-    return path
+    path = spack.config.get("config:source_cache", spack.paths.default_fetch_cache_path)
+    return spack.util.path.canonicalize_path(path)
 
 
 def _fetch_cache():
     path = fetch_cache_location()
+    tty.debug(f"Source cache location: {path}")
     return spack.fetch_strategy.FsCache(path)
 
 

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -400,6 +400,24 @@ class PruneDuplicatePaths(NameModifier):
         env[self.name] = self.separator.join(directories)
 
 
+class FrozenEnvironment:
+    """Freezes os.environ at the time of instanciation"""
+
+    def __init__(self):
+        self._frozen_environ = os.environ.copy()
+
+    def __enter__(self):
+        self._current_environ = os.environ.copy()
+        os.environ.update(self._frozen_environ)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        os.environ.clear()
+        os.environ.update(self._current_environ)
+
+
+INITIAL_ENVIRONMENT = FrozenEnvironment()
+
+
 class EnvironmentModifications:
     """Keeps track of requests to modify the current environment."""
 

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -191,6 +191,16 @@ def substitute_path_variables(path):
     path = substitute_config_variables(path)
     path = os.path.expandvars(path)
     path = os.path.expanduser(path)
+    
+    # Check for unexpanded vars which may be the result of a cleaned environment.
+    # Ignore $SSL_CERT_FILE since that's often not set but is in the config files
+    # by default.
+    if "$" in path.replace("$SSL_CERT_FILE", ""):
+        tty.warn((f"Path '{path}' appears to contain unexpanded environment variables. "
+                 "This sometimes occurs if your config file uses variable names that are "
+                 "cleaned before package installation, or if an expected environment "
+                 "variable is not set."))
+
     return path
 
 

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -191,15 +191,19 @@ def substitute_path_variables(path):
     path = substitute_config_variables(path)
     path = os.path.expandvars(path)
     path = os.path.expanduser(path)
-    
+
     # Check for unexpanded vars which may be the result of a cleaned environment.
     # Ignore $SSL_CERT_FILE since that's often not set but is in the config files
     # by default.
     if "$" in path.replace("$SSL_CERT_FILE", ""):
-        tty.warn((f"Path '{path}' appears to contain unexpanded environment variables. "
-                 "This sometimes occurs if your config file uses variable names that are "
-                 "cleaned before package installation, or if an expected environment "
-                 "variable is not set."))
+        tty.warn(
+            (
+                f"Path '{path}' appears to contain unexpanded environment variables. "
+                "This sometimes occurs if your config file uses variable names that are "
+                "cleaned before package installation, or if an expected environment "
+                "variable is not set."
+            )
+        )
 
     return path
 

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -284,10 +284,10 @@ def canonicalize_path(
 
         return os.path.normpath(path)
 
-    try:
+    if env:
         with env:
             return _canonicalize_path(path, default_wd)
-    except TypeError:
+    else:
         return _canonicalize_path(path, default_wd)
 
 


### PR DESCRIPTION
## Problem background

I recently ran into a scope config path issue that took me a while to understand and fix! I created a scope that contained an environment variable ending in `_ROOT` to define some cache and install paths (let's say `SPACK_CUSTOM_LOC_ROOT=<some custom path>`). While the packages and misc cache items in this scope were written to the correct location in `<some custom path>/packages` or `<some custom path>/cache/misc`, the source cache and modulefiles were written to literally `<scope definition path>/${SPACK_CUSTOM_LOC_ROOT}` during `spack install`. 

Ultimately, I decided this probably wasn't intended behavior since `spack clean -d` and `spack module lmod refresh` expanded the two bad paths correctly. I believe what happens is, since the source cache and module setup is done lazily, the `clean_environment` function executed in `install` before those paths were defined by config. I may be the only one boneheaded enough to make this mistake, but I added some debug and warning messages in this PR and also added a note on what environment variables to avoid to the documentation. This PR doesn't change any Spack behavior other than adding a few messages. 

## Changes in this PR

1. Add debug messages to print the source and misc cache paths. 
2. Add a warning message when an expanded config path contains what appears to be an unexpanded environment variable (excluding `$SSL_CERT_FILE`). 
3. Add some info about environment variables to avoid in the docs. 