### PR TITLE
gtkplus: depends_on libxfixes when @:2

### DIFF
--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -70,6 +70,7 @@ class Gtkplus(MesonPackage):
     depends_on("fixesproto", when="@3:")
     depends_on("gettext", when="@3:")
     depends_on("cups", when="+cups")
+    depends_on("libxfixes", when="@:2")
 
     patch("no-demos.patch", when="@2.0:2")
 


### PR DESCRIPTION
This PR adds a dependency on `libxfixes` to `gtkplus` for all versions 2.x. This fixes the compilation error which affects all versions 2.x in spack (e.g. reproduced on codespaces):
```
gtksocket-x11.c:44:10: fatal error: X11/extensions/Xfixes.h: No such file or directory
   44 | #include <X11/extensions/Xfixes.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```
With this fix, all version 2.x in spack compile correctly.

The origin of this issue is that `libxfixes` is found by configure.ac through a pc file that is transitively accessible. The information is correctly propagated to the gdk/x11/ source files, but not to the gtk/gtksocket-x11.c file (the only file that includes an X11/extensions/ header). Adding the `libxfixes` dependency explicitly allows also that file to find the correct header.

There is probably a better fix for this by patching one of the Makefile.am files, but I'm balancing that with the fact that this only affects deprecated versions and that I don't really see that better fix despite some (too much?) time spent on this already.

For versions 3.x, there is no problem and no need to fix anything.

Test build after this change (e.g. oldest version):
```
==> Installing gtkplus-2.24.25-ciidv7dliejgaepgewqigq63ok7umtqo [153/157]
==> No binary for gtkplus-2.24.25-ciidv7dliejgaepgewqigq63ok7umtqo found: installing from source
==> Using cached archive: /workspaces/spack/var/spack/cache/_source-cache/archive/38/38af1020cb8ff3d10dda2c8807f11e92af9d2fa4045de61c62eedb7fbc7ea5b3.tar.xz
==> Applied patch /workspaces/spack/var/spack/repos/builtin/packages/gtkplus/no-demos.patch
==> Ran patch() for gtkplus
==> gtkplus: Executing phase: 'meson'
==> gtkplus: Executing phase: 'build'
==> gtkplus: Executing phase: 'install'
==> gtkplus: Successfully installed gtkplus-2.24.25-ciidv7dliejgaepgewqigq63ok7umtqo
  Stage: 0.83s.  Meson: 15.39s.  Build: 47.59s.  Install: 12.75s.  Post-install: 0.56s.  Total: 1m 17.51s
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/gtkplus-2.24.25-ciidv7dliejgaepgewqigq63ok7umtqo
```