### PR TITLE
py-validators: add v0.34.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-validators/package.py
+++ b/var/spack/repos/builtin/packages/py-validators/package.py
@@ -14,7 +14,8 @@ class PyValidators(PythonPackage):
 
     license("MIT")
 
+    version("0.34.0", sha256="647fe407b45af9a74d245b943b18e6a816acf4926974278f6dd617778e1e781f")
     version("0.20.0", sha256="24148ce4e64100a2d5e267233e23e7afeb55316b47d30faae7eb6e7292bc226a")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-decorator@3.4:", type=("build", "run"))
+    depends_on("py-decorator@3.4:", type=("build", "run"), when="@:0.20.7")


### PR DESCRIPTION
This PR adds `py-validators`, v0.34.0. Various changes to the build-system and dependencies between 0.20 and 0.34, but the dust has settled and it's back to setuptools and no other dependencies... Perfect time for a version sync here :-)

Test build:
```
==> Installing py-validators-0.34.0-t53uchw7ffysqtc7zk7m27fdcxsnfvdk [28/28]
==> No binary for py-validators-0.34.0-t53uchw7ffysqtc7zk7m27fdcxsnfvdk found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/v/validators/validators-0.34.0.tar.gz
==> No patches needed for py-validators
==> py-validators: Executing phase: 'install'
==> py-validators: Successfully installed py-validators-0.34.0-t53uchw7ffysqtc7zk7m27fdcxsnfvdk
  Stage: 0.80s.  Install: 1.12s.  Post-install: 0.16s.  Total: 2.16s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-validators-0.34.0-t53uchw7ffysqtc7zk7m27fdcxsnfvdk
```