### PR TITLE
yaml-cpp: Add 0.8.0

### DIFF
--- a/var/spack/repos/builtin/packages/yaml-cpp/package.py
+++ b/var/spack/repos/builtin/packages/yaml-cpp/package.py
@@ -14,13 +14,14 @@ class YamlCpp(CMakePackage):
     """A YAML parser and emitter in C++"""
 
     homepage = "https://github.com/jbeder/yaml-cpp"
-    url = "https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.5.3.tar.gz"
+    url = "https://github.com/jbeder/yaml-cpp/archive/0.8.0.tar.gz"
     git = "https://github.com/jbeder/yaml-cpp.git"
     maintainers("eschnett")
 
     license("MIT")
 
     version("develop", branch="master")
+    version("0.8.0", sha256="fbe74bbdcee21d656715688706da3c8becfd946d92cd44705cc6098bb23b3a16")
     version("0.7.0", sha256="43e6a9fcb146ad871515f0d0873947e5d497a1c9c60c58cb102a97b47208b7c3")
     version("0.6.3", sha256="77ea1b90b3718aa0c324207cb29418f5bced2354c2e483a9523d98c3460af1ed")
     version("0.6.2", sha256="e4d8560e163c3d875fd5d9e5542b5fd5bec810febdcba61481fe5fc4e6b1fd05")
@@ -86,8 +87,10 @@ class YamlCpp(CMakePackage):
         return options
 
     def url_for_version(self, version):
-        url = "https://github.com/jbeder/yaml-cpp/archive/{0}-{1}.tar.gz"
+        url = "https://github.com/jbeder/yaml-cpp/archive/{0}.tar.gz"
         if version < Version("0.5.3"):
-            return url.format("release", version)
+            return url.format(f"release-{version}")
+        elif version < Version("0.8.0"):
+            return url.format(f"yaml-cpp-{version}")
         else:
-            return url.format("yaml-cpp", version)
+            return url.format(version)


### PR DESCRIPTION
Adds `yaml-cpp@0.8.0` and updates the URL logic to grab the new URL format while maintaining backwards compatibility. 
