### PR TITLE
py-twisted: add v22.10.0, v24.7.0; deprecate older versions (fixes CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/py-incremental/package.py
+++ b/var/spack/repos/builtin/packages/py-incremental/package.py
@@ -14,6 +14,9 @@ class PyIncremental(PythonPackage):
 
     license("MIT")
 
+    version("24.7.2", sha256="fb4f1d47ee60efe87d4f6f0ebb5f70b9760db2b2574c59c8e8912be4ebd464c9")
     version("21.3.0", sha256="02f5de5aff48f6b9f665d99d48bfc7ec03b6e3943210de7cfc88856d755d6f57")
 
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@61.0:", type="build", when="@24.7:")
+    depends_on("py-tomli", type=("build", "run"), when="@24.7: ^python@:3.10")

--- a/var/spack/repos/builtin/packages/py-twisted/package.py
+++ b/var/spack/repos/builtin/packages/py-twisted/package.py
@@ -10,36 +10,52 @@ class PyTwisted(PythonPackage):
     """An asynchronous networking framework written in Python"""
 
     homepage = "https://twistedmatrix.com/"
-    pypi = "Twisted/Twisted-21.7.0.tar.gz"
+    pypi = "Twisted/twisted-21.7.0.tar.gz"
 
     license("Unlicense")
 
-    version("21.7.0", sha256="2cd652542463277378b0d349f47c62f20d9306e57d1247baabd6d1d38a109006")
-    version("15.4.0", sha256="78862662fa9ae29654bc2b9d349c3f1d887e6b2ed978512c4442d53ea861f05c")
-    version("15.3.0", sha256="025729751cf898842262375a40f70ae1d246daea88369eab9f6bb96e528bf285")
+    version("24.7.0", sha256="5a60147f044187a127ec7da96d170d49bcce50c6fd36f594e60f4587eff4d394")
+    version("22.10.0", sha256="32acbd40a94f5f46e7b42c109bfae2b302250945561783a8b7a059048f2d4d31")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2022-24801
+        version("21.7.0", sha256="2cd652542463277378b0d349f47c62f20d9306e57d1247baabd6d1d38a109006")
+        version("15.4.0", sha256="78862662fa9ae29654bc2b9d349c3f1d887e6b2ed978512c4442d53ea861f05c")
+        version("15.3.0", sha256="025729751cf898842262375a40f70ae1d246daea88369eab9f6bb96e528bf285")
 
     depends_on("python@3.6.7:", type=("build", "run"), when="@21.7.0:")
+    depends_on("python@3.7.1:", type=("build", "run"), when="@22.8.0:")
 
-    depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools@35.0.2:", type="build", when="@21.7.0:")
+    with when("@:22.10"):
+        depends_on("py-setuptools", type="build")
+        depends_on("py-setuptools@35.0.2:", type="build", when="@21.7.0:")
+    with when("@23.8.0:"):
+        depends_on("py-hatchling@1.10.0:", type="build")
+        depends_on("py-hatch-fancy-pypi-readme@22.5.0:", type="build")
+        depends_on("py-incremental@22.10.0:", type="build")
 
     depends_on("py-zope-interface@4.0.2:", type=("build", "run"))
     depends_on("py-zope-interface@4.4.2:", type=("build", "run"), when="@21.7.0:")
+    depends_on("py-zope-interface@5:", type=("build", "run"), when="@23.8.0:")
 
     depends_on("py-incremental@21.3.0:", type=("build", "run"), when="@21.7.0:")
+    depends_on("py-incremental@22.10.0:", type=("build", "run"), when="@23.8.0:")
     depends_on("py-constantly@15.1:", type=("build", "run"), when="@21.7.0:")
     depends_on("py-automat@0.8.0:", type=("build", "run"), when="@21.7.0:")
     depends_on("py-hyperlink@17.1.1:", type=("build", "run"), when="@21.7.0:")
     depends_on("py-attrs@19.2.0:", type=("build", "run"), when="@21.7.0:")
+    depends_on("py-attrs@21.3.0:", type=("build", "run"), when="@23.8.0:")
     depends_on("py-typing-extensions@3.6.5:", type=("build", "run"), when="@21.7.0:")
+    depends_on("py-typing-extensions@3.10.0:", type=("build", "run"), when="@23.8.0:")
 
     def url_for_version(self, version):
         url = "https://pypi.io/packages/source/T/Twisted/"
 
         if version <= Version("20.3.0"):
             url += "Twisted-{0}.tar.bz2"
-        else:
+        elif version <= Version("22.10.0"):
             url += "Twisted-{0}.tar.gz"
+        else:
+            url += "twisted-{0}.tar.gz"
 
         url = url.format(version)
         return url

--- a/var/spack/repos/builtin/packages/py-twisted/package.py
+++ b/var/spack/repos/builtin/packages/py-twisted/package.py
@@ -18,9 +18,15 @@ class PyTwisted(PythonPackage):
     version("22.10.0", sha256="32acbd40a94f5f46e7b42c109bfae2b302250945561783a8b7a059048f2d4d31")
     with default_args(deprecated=True):
         # https://nvd.nist.gov/vuln/detail/CVE-2022-24801
-        version("21.7.0", sha256="2cd652542463277378b0d349f47c62f20d9306e57d1247baabd6d1d38a109006")
-        version("15.4.0", sha256="78862662fa9ae29654bc2b9d349c3f1d887e6b2ed978512c4442d53ea861f05c")
-        version("15.3.0", sha256="025729751cf898842262375a40f70ae1d246daea88369eab9f6bb96e528bf285")
+        version(
+            "21.7.0", sha256="2cd652542463277378b0d349f47c62f20d9306e57d1247baabd6d1d38a109006"
+        )
+        version(
+            "15.4.0", sha256="78862662fa9ae29654bc2b9d349c3f1d887e6b2ed978512c4442d53ea861f05c"
+        )
+        version(
+            "15.3.0", sha256="025729751cf898842262375a40f70ae1d246daea88369eab9f6bb96e528bf285"
+        )
 
     depends_on("python@3.6.7:", type=("build", "run"), when="@21.7.0:")
     depends_on("python@3.7.1:", type=("build", "run"), when="@22.8.0:")


### PR DESCRIPTION
This PR adds `py-twisted`, v22.10.0 (last setuptools) and v24.7.0 (hatchling), which fixes CVE-2016-1000111, CVE-2019-12387, CVE-2019-12855, CVE-2020-10108, CVE-2020-10109, CVE-2022-21712, CVE-2022-21716, CVE-2022-24801, CVE-2022-39348, CVE-2023-46137. Deprecated versions that are affected by CVEs scored high or critical. Url has changed and now uses lowercase files (but directories are case-insensitive).

Test builds:
```
==> Installing py-twisted-21.7.0-l2wqdat5onu52li7oowklum4nx3wmcr6 [60/62]
==> No binary for py-twisted-21.7.0-l2wqdat5onu52li7oowklum4nx3wmcr6 found: installing from source
==> Warning: py-twisted@21.7.0 is deprecated and may be removed in a future Spack release.
==>   Fetch anyway? [y/N] y
==> Fetching https://mirror.spack.io/_source-cache/archive/2c/2cd652542463277378b0d349f47c62f20d9306e57d1247baabd6d1d38a109006.tar.gz
==> No patches needed for py-twisted
==> py-twisted: Executing phase: 'install'
==> py-twisted: Successfully installed py-twisted-21.7.0-l2wqdat5onu52li7oowklum4nx3wmcr6
  Stage: 5.54s.  Install: 4.54s.  Post-install: 0.82s.  Total: 11.03s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-twisted-21.7.0-l2wqdat5onu52li7oowklum4nx3wmcr6
==> Installing py-twisted-22.10.0-n5qpbggpg3evnszz23vycwkimtgzlzun [61/62]
==> No binary for py-twisted-22.10.0-n5qpbggpg3evnszz23vycwkimtgzlzun found: installing from source
==> Fetching https://pypi.io/packages/source/T/Twisted/Twisted-22.10.0.tar.gz
==> No patches needed for py-twisted
==> py-twisted: Executing phase: 'install'
==> py-twisted: Successfully installed py-twisted-22.10.0-n5qpbggpg3evnszz23vycwkimtgzlzun
  Stage: 1.26s.  Install: 4.82s.  Post-install: 0.76s.  Total: 6.98s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-twisted-22.10.0-n5qpbggpg3evnszz23vycwkimtgzlzun
==> Installing py-twisted-24.7.0-g5xa6cdfj2uijegmwrhwqg37swltrsoj [62/62]
==> No binary for py-twisted-24.7.0-g5xa6cdfj2uijegmwrhwqg37swltrsoj found: installing from source
==> Fetching https://pypi.io/packages/source/T/Twisted/twisted-24.7.0.tar.gz
==> No patches needed for py-twisted
==> py-twisted: Executing phase: 'install'
==> py-twisted: Successfully installed py-twisted-24.7.0-g5xa6cdfj2uijegmwrhwqg37swltrsoj
  Stage: 1.50s.  Install: 3.32s.  Post-install: 0.93s.  Total: 5.90s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/py-twisted-24.7.0-g5xa6cdfj2uijegmwrhwqg37swltrsoj
```