### PR TITLE
codecov: increase project threshold to 2%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     project:
       default:
-        threshold: 0.2%
+        threshold: 2.0%
 
 ignore:
   - lib/spack/spack/test/.*


### PR DESCRIPTION
We run tests for more python versions on `develop` than we do for PRs, so codecov project status is nearly always failing. There is about a 1% difference in max coverage between `develop` tests and PR tests, so we should increase the project threshold to 2% to allow for this difference.

The purpose of the project test on PRs is just to make sure that nothing done on the PR massively affects coverage of code not covered by the PR. This is valuable, but rare. It only really affects PRs that deal with test or coverage configuration.

- [x] change project coverage threshold from .2% to 2%

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
