### PR TITLE
libdrm: add v2.4.123

### DIFF
--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -19,6 +19,7 @@ class Libdrm(AutotoolsPackage, MesonPackage):
 
     license("MIT")
 
+    version("2.4.123", sha256="a2b98567a149a74b0f50e91e825f9c0315d86e7be9b74394dae8b298caadb79e")
     version("2.4.122", sha256="d9f5079b777dffca9300ccc56b10a93588cdfbc9dde2fae111940dfb6292f251")
     version("2.4.121", sha256="909084a505d7638887f590b70791b3bbd9069c710c948f5d1f1ce6d080cdfcab")
     version("2.4.120", sha256="3bf55363f76c7250946441ab51d3a6cc0ae518055c0ff017324ab76cdefb327a")


### PR DESCRIPTION
This PR adds `libdrm`, v2.4.123, [diff](https://gitlab.freedesktop.org/mesa/drm/-/compare/libdrm-2.4.122...libdrm-2.4.123?from_project_id=177&straight=false). No changes to meson.build that need to be adapted.

Test build:
```
==> Installing libdrm-2.4.123-xuikxyfuudetbjbaayijrieewglobts4 [31/31]
==> No binary for libdrm-2.4.123-xuikxyfuudetbjbaayijrieewglobts4 found: installing from source
==> Fetching https://dri.freedesktop.org/libdrm/libdrm-2.4.123.tar.xz
==> No patches needed for libdrm
==> libdrm: Executing phase: 'meson'
==> libdrm: Executing phase: 'build'
==> libdrm: Executing phase: 'install'
==> libdrm: Successfully installed libdrm-2.4.123-xuikxyfuudetbjbaayijrieewglobts4
  Stage: 1.24s.  Meson: 10.25s.  Build: 14.08s.  Install: 1.18s.  Post-install: 0.55s.  Total: 28.08s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/libdrm-2.4.123-xuikxyfuudetbjbaayijrieewglobts4
```
