### PR TITLE
activemq: add v5.18.6, v6.1.3 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/activemq/package.py
+++ b/var/spack/repos/builtin/packages/activemq/package.py
@@ -17,8 +17,15 @@ class Activemq(Package):
 
     license("Apache-2.0")
 
-    version("5.17.3", sha256="a4cc4c3a2f136707c2c696f3bb3ee2a86dbeff1b9eb5e237b14edc0c5e5a328f")
+    version("6.1.3", sha256="cad14e816e990f1312709ebfc228f42895d8c54c652d3cd56f0b5145635dc794")
+    version("5.18.6", sha256="b1363696e4e014423f6ab22f1ece4bf14ee32b80bfa5bdbae7dd4026a47ff03a")
 
+    # https://nvd.nist.gov/vuln/detail/CVE-2023-46604
+    version(
+        "5.17.3",
+        sha256="a4cc4c3a2f136707c2c696f3bb3ee2a86dbeff1b9eb5e237b14edc0c5e5a328f",
+        deprecated=True,
+    )
     # https://nvd.nist.gov/vuln/detail/CVE-2018-11775
     version(
         "5.14.0",
@@ -29,6 +36,9 @@ class Activemq(Package):
     depends_on("cxx", type="build")  # generated
 
     depends_on("java")
+    depends_on("java@8:", when="@5.15:")
+    depends_on("java@11:", when="@5.17:")
+    depends_on("java@17:", when="@6:")
 
     def install(self, spec, prefix):
         install_tree(".", prefix)


### PR DESCRIPTION
This PR adds `activemq`, v5.18.6 and v6.1.3, which fixes CVE-2022-41678, CVE-2023-46604. Since CVE-2023-46604 is critical, previous versions are marked as deprecated.

Test builds:
```
==> Installing activemq-5.18.6-kjciibx4zboecoeaknpfwp4ijhhcmqyg [4/5]
==> No binary for activemq-5.18.6-kjciibx4zboecoeaknpfwp4ijhhcmqyg found: installing from source
==> Fetching https://archive.apache.org/dist/activemq/5.18.6/apache-activemq-5.18.6-bin.tar.gz
==> No patches needed for activemq
==> activemq: Executing phase: 'install'
==> activemq: Successfully installed activemq-5.18.6-kjciibx4zboecoeaknpfwp4ijhhcmqyg
  Stage: 9.00s.  Install: 0.30s.  Post-install: 0.73s.  Total: 10.07s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/activemq-5.18.6-kjciibx4zboecoeaknpfwp4ijhhcmqyg
==> Waiting for activemq-6.1.3-nkjkhyi27pqikg24ljjlrvgysz77otvm
==> Installing activemq-6.1.3-nkjkhyi27pqikg24ljjlrvgysz77otvm [5/5]
==> No binary for activemq-6.1.3-nkjkhyi27pqikg24ljjlrvgysz77otvm found: installing from source
==> Fetching https://archive.apache.org/dist/activemq/6.1.3/apache-activemq-6.1.3-bin.tar.gz
==> No patches needed for activemq
==> activemq: Executing phase: 'install'
==> activemq: Successfully installed activemq-6.1.3-nkjkhyi27pqikg24ljjlrvgysz77otvm
  Stage: 10.99s.  Install: 0.28s.  Post-install: 0.79s.  Total: 12.11s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/activemq-6.1.3-nkjkhyi27pqikg24ljjlrvgysz77otvm
```