### PR TITLE
libdwarf: add v0.11.0

### DIFF
--- a/var/spack/repos/builtin/packages/libdwarf/package.py
+++ b/var/spack/repos/builtin/packages/libdwarf/package.py
@@ -30,6 +30,7 @@ class Libdwarf(CMakePackage, Package):
 
     license("LGPL-2.1-only")
 
+    version("0.11.0", sha256="846071fb220ac1952f9f15ebbac6c7831ef50d0369b772c07a8a8139a42e07d2")
     version("0.10.1", sha256="b511a2dc78b98786064889deaa2c1bc48a0c70115c187900dd838474ded1cc19")
     with default_args(deprecated=True):
         version(


### PR DESCRIPTION
This PR adds `libdwarf`, v0.11.0, [diff](https://github.com/davea42/libdwarf-code/compare/v0.10.1...v0.11.0). No build system changes.

Test build:
```
==> Installing libdwarf-0.11.0-4fiunojrqqsbhccmmwln5dwopsc4ffqy [11/11]
==> No binary for libdwarf-0.11.0-4fiunojrqqsbhccmmwln5dwopsc4ffqy found: installing from source
==> Fetching https://www.prevanders.net/libdwarf-0.11.0.tar.xz
==> No patches needed for libdwarf
==> libdwarf: Executing phase: 'cmake'
==> libdwarf: Executing phase: 'build'
==> libdwarf: Executing phase: 'install'
==> libdwarf: Successfully installed libdwarf-0.11.0-4fiunojrqqsbhccmmwln5dwopsc4ffqy
  Stage: 1.72s.  Cmake: 0.95s.  Build: 21.93s.  Install: 0.08s.  Post-install: 0.18s.  Total: 24.94s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/libdwarf-0.11.0-4fiunojrqqsbhccmmwln5dwopsc4ffqy
```