### PR TITLE
GCC: add rpath for non-static builds only

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -962,7 +962,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
 
             # rpath
             if rpath_dir:
-                f.write(f"*link_libgcc:\n+ -rpath {rpath_dir}\n\n")
+                f.write(f"*link_libgcc:\n+ %{{!static:-rpath {rpath_dir}}}\n\n")
 
             # programs search path
             if self.spec.satisfies("+binutils"):


### PR DESCRIPTION
Some pure-static linked program requires an empty `rpath`, for example `ld.so` from `glibc`. 
This PR limits gcc's rpath-adding to only non-static builds, to give statically linked programs an empty `rpath`.

@alalazo @michaelkuhn

----
Update by @bernhardkaindl:

@yizeyi18 mentioned this PR as a fix needed for
- #46663
> spack-built gcc breaks glibc's ld.so for adding rpath to it. Fixing in https://github.com/spack/spack/pull/46843.

```py
-                f.write(f"*link_libgcc:\n+ -rpath {rpath_dir}\n\n")
+                f.write(f"*link_libgcc:\n+ %{{!static:-rpath {rpath_dir}}}\n\n")
```
@haampie?