### PR TITLE
py-gevent: add patch for Cython 3.0.10 and 3.0.11

### DIFF
--- a/var/spack/repos/builtin/packages/py-gevent/cython.patch
+++ b/var/spack/repos/builtin/packages/py-gevent/cython.patch
@@ -1,0 +1,9 @@
+--- a/src/gevent/_gevent_cqueue.pxd
++++ b/src/gevent/_gevent_cqueue.pxd
+@@ -75,7 +75,6 @@ cdef class ItemWaiter(Waiter):
+     cdef readonly Queue queue
+ 
+ 
+-@cython.final
+ cdef class UnboundQueue(Queue):
+     pass

--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -41,15 +41,12 @@ class PyGevent(PythonPackage):
 
     # https://github.com/gevent/gevent/issues/1599
     conflicts("^py-cython@3:", when="@:20.5.0")
-    # https://github.com/gevent/gevent/issues/2031
-    conflicts(
-        "^py-cython@3.0.10",
-        when="@:23.9.0",
-        msg="py-gevent fails to build when using cython@3.0.10",
-    )
 
     # Deprecated compiler options. upstream PR: https://github.com/gevent/gevent/pull/1896
     patch("icc.patch", when="@:21.12.0 %intel")
+
+    # https://github.com/gevent/gevent/issues/2031
+    patch("cython.patch", when="@:24.2.1^py-cython@3.0.10:3.0.11")
 
     @run_before("install")
     def recythonize(self):


### PR DESCRIPTION
Same issue as in https://github.com/spack/spack/pull/45295 with `py-cython` 3.0.11. A conflict can be added but there is a patch that fixes the builds (only tried with `py-cython` 3.0.11) in https://github.com/gevent/gevent/issues/2031#issuecomment-2108204975. This patch has not been added upstream, but it looks simple enough and probably fine from what I understand (`UnboundQueue` possibly missing some optimizations because it's not marked as `final`). Alternatively, a conflict can be added.