### PR TITLE
darshan-runtime: add new variants

### DIFF
--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -77,11 +77,7 @@ class DarshanRuntime(AutotoolsPackage):
         description="Compile with Parallel NetCDF module",
         when="@3.4.1:",
     )
-    variant(
-        "lustre",
-        default=False,
-        description="Compile with Lustre module",
-        when="@3.1:")
+    variant("lustre", default=False, description="Compile with Lustre module", when="@3.1:")
     variant("apmpi", default=False, description="Compile with AutoPerf MPI module", when="@3.3:")
     variant(
         "apmpi_sync",

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -58,6 +58,7 @@ class DarshanRuntime(AutotoolsPackage):
     depends_on("zlib-api")
     depends_on("hdf5", when="+hdf5")
     depends_on("parallel-netcdf", when="+parallel-netcdf")
+    depends_on("lustre", when="+lustre")
     depends_on("papi", when="+apxc")
     depends_on("autoconf", type="build", when="@main")
     depends_on("automake", type="build", when="@main")
@@ -76,6 +77,11 @@ class DarshanRuntime(AutotoolsPackage):
         description="Compile with Parallel NetCDF module",
         when="@3.4.1:",
     )
+    variant(
+        "lustre",
+        default=False,
+        description="Compile with Lustre module",
+        when="@3.1:")
     variant("apmpi", default=False, description="Compile with AutoPerf MPI module", when="@3.3:")
     variant(
         "apmpi_sync",
@@ -87,10 +93,17 @@ class DarshanRuntime(AutotoolsPackage):
     variant(
         "scheduler",
         default="NONE",
-        description="queue system scheduler JOB ID",
+        description="Queue system scheduler JOB ID",
         values=("NONE", "cobalt", "pbs", "sge", "slurm"),
         multi=False,
     )
+    variant(
+        "log_path",
+        values=str,
+        default="none",
+        description="Path to centralized, formatted Darshan log directory",
+    )
+    variant("group_readable_logs", default=False, description="Build with group readable logs option")
 
     @property
     def configure_directory(self):
@@ -117,15 +130,25 @@ class DarshanRuntime(AutotoolsPackage):
                 extra_args.append("--enable-hdf5-mod")
         if spec.satisfies("+parallel-netcdf"):
             extra_args.append("--enable-pnetcdf-mod")
+        if spec.satisfies("+lustre"):
+            extra_args.append("--enable-lustre-mod")
+        else:
+            extra_args.append("--disable-lustre-mod")
         if spec.satisfies("+apmpi"):
             extra_args.append("--enable-apmpi-mod")
         if spec.satisfies("+apmpi_sync"):
             extra_args.extend(["--enable-apmpi-mod", "--enable-apmpi-coll-sync"])
         if spec.satisfies("+apxc"):
             extra_args.append("--enable-apxc-mod")
+        if spec.satisfies("+group_readable_logs"):
+            extra_args.append("--enable-group-readable-logs")
+        log_path = self.spec.variants["log_path"].value
+        if log_path != "none":
+            extra_args.append("--with-log-path=" + log_path)
+        else:
+            extra_args.append("--with-log-path-by-env=DARSHAN_LOG_DIR_PATH")
 
         extra_args.append("--with-mem-align=8")
-        extra_args.append("--with-log-path-by-env=DARSHAN_LOG_DIR_PATH")
         extra_args.append("--with-jobid-env=%s" % job_id)
         extra_args.append("--with-zlib=%s" % spec["zlib-api"].prefix)
 
@@ -138,9 +161,10 @@ class DarshanRuntime(AutotoolsPackage):
         return extra_args
 
     def setup_run_environment(self, env):
-        # default path for log file, could be user or site specific setting
-        darshan_log_dir = os.environ["HOME"]
-        env.set("DARSHAN_LOG_DIR_PATH", darshan_log_dir)
+        if self.spec.variants["log_path"].value == "none":
+            # set a default path for log file that can be overrode by user
+            darshan_log_dir = os.environ["HOME"]
+            env.set("DARSHAN_LOG_DIR_PATH", darshan_log_dir)
 
     @property
     def basepath(self):

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -103,7 +103,8 @@ class DarshanRuntime(AutotoolsPackage):
         default="none",
         description="Path to centralized, formatted Darshan log directory",
     )
-    variant("group_readable_logs", default=False, description="Build with group readable logs option")
+    variant("mmap_logs", default=False, description="Use mmap to store Darshan log data")
+    variant("group_readable_logs", default=False, description="Write group-readable logs")
 
     @property
     def configure_directory(self):
@@ -142,6 +143,8 @@ class DarshanRuntime(AutotoolsPackage):
             extra_args.append("--enable-apxc-mod")
         if spec.satisfies("+group_readable_logs"):
             extra_args.append("--enable-group-readable-logs")
+        if spec.satisfies("+mmap_logs"):
+            extra_args.append("--enable-mmap-logs")
         log_path = self.spec.variants["log_path"].value
         if log_path != "none":
             extra_args.append("--with-log-path=" + log_path)


### PR DESCRIPTION
- `lustre` variant enables instrumentation of Lustre files
  - requires Lustre headers, so Lustre is a proper dependency for this variant
- `log_path` variant allows setting of a centralized log directory for Darshan logs (commonly used for facility deployments)
  - when this variant is used, the `DARSHAN_LOG_DIR_PATH` env var is no longer used to set the log file path (and the setting of this env var is skipped in the `setup_run_environment()` function)
- `group_readable_logs` variant sets Darshan log permissions to allow reads from users in the same UNIX group
- `mmap_logs` variant enables Darshan's mechanism for storing log files in memory at runtime using `mmap()`