### PR TITLE
python: rework how we compute the "command" property

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -47,6 +47,7 @@ __all__ = [
     "copy_mode",
     "filter_file",
     "find",
+    "find_first",
     "find_headers",
     "find_all_headers",
     "find_libraries",

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -857,14 +857,14 @@ class Python(Package):
         # * python
         #
         # in that order if using python@3.11.0, for example.
-        version = self.spec.version
-        for ver in [version.up_to(2), version.up_to(1), ""]:
-            if sys.platform != "win32":
-                path = os.path.join(self.prefix.bin, "python{0}".format(ver))
-            else:
-                path = os.path.join(self.prefix, "python{0}.exe".format(ver))
-            if os.path.exists(path):
-                return Executable(path)
+        suffixes = [self.spec.version.up_to(2), self.spec.version.up_to(1), ""]
+        file_extension = "" if sys.platform != "win32" else ".exe"
+        patterns = [f"python{ver}{file_extension}" for ver in suffixes]
+        root = self.prefix.bin if sys.platform != "win32" else self.prefix
+        path = find_first(root, files=patterns)
+
+        if path is not None:
+            return Executable(path)
 
         else:
             # Give a last try at rhel8 platform python
@@ -873,8 +873,7 @@ class Python(Package):
                 if os.path.exists(path):
                     return Executable(path)
 
-            msg = "Unable to locate {0} command in {1}"
-            raise RuntimeError(msg.format(self.name, self.prefix.bin))
+        raise RuntimeError(f"Unable to locate {self.name} command in {self.prefix.bin}")
 
     @property
     def config_vars(self):

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -873,7 +873,9 @@ class Python(Package):
                 if os.path.exists(path):
                     return Executable(path)
 
-        raise RuntimeError(f"Unable to locate {self.name} command in {self.prefix.bin}")
+        raise RuntimeError(
+            f"cannot to locate the '{self.name}' command in {root} or its subdirectories"
+        )
 
     @property
     def config_vars(self):


### PR DESCRIPTION
On Windows 10 the layout of virtual environments is something like:

```
Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d-----        05/10/2024     12:17                Include
d-----        05/10/2024     12:17                Lib
d-----        05/10/2024     12:20                Scripts
-a----        05/10/2024     12:17            339 pyvenv.cfg
```
and the executables we search for are in the Scripts directory. The current search mechanism fails with that.

Here we rework the search logic to use the "find_first" function, that does a bfs with depth 2 by default. That covers for the case of the virtual environment above.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
