### PR TITLE
imagemagick: add v7.1.1-39

### DIFF
--- a/var/spack/repos/builtin/packages/imagemagick/package.py
+++ b/var/spack/repos/builtin/packages/imagemagick/package.py
@@ -15,17 +15,20 @@ class Imagemagick(AutotoolsPackage):
 
     license("ImageMagick")
 
+    version("7.1.1-39", sha256="b2eb652d9221bdeb65772503891d8bfcfc36b3b1a2c9bb35b9d247a08965fd5d")
     version("7.1.1-29", sha256="27bd25f945efdd7e38f6f9845a7c0a391fdb732f652dda140b743769c5f106e8")
     version("7.1.1-11", sha256="98bb2783da7d5b06e7543529bd07b50d034fba611ff15e8817a0f4f73957d934")
-    version("7.1.0-62", sha256="d282117bc6d0e91ad1ad685d096623b96ed8e229f911c891d83277b350ef884a")
-    version("7.1.0-60", sha256="94424cc13c5ba18e0e5d5badb834ce74eab11207b00ea32c1f533a5e34c85887")
-    version("7.0.11-14", sha256="dfa5aa3f7f289f12c2f9ee6c7c19b02ae857b4eec02f40298f60f5c11048a016")
-    version("7.0.10-62", sha256="84442158aea070095efa832cfe868fd99d6befdf609444f0c9e9f1b4f25480cd")
-    version("7.0.9-27", sha256="aeea7768bf330d87efa80fa89f03c5acc2382eae32d1d871acb813e5b116395a")
-    version("7.0.8-7", sha256="fadb36b59f310e9eee5249ecb2326b323a64da6cc716dd6d08ece8ea2c780b81")
-    version("7.0.5-9", sha256="b85b269e0ed1628e88e840053823f8a33c314b2271f04762f43d33e9d0b4d264")
-    version("7.0.2-7", sha256="f2f18a97f861c1668befdaff0cc3aaafb2111847aab028a88b4c2cb017acfbaa")
-    version("7.0.2-6", sha256="7d49ca8030f895c683cae69c52d8edfc4876de651f5b8bfdbea907e222480bd3")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2023-34153
+        version("7.1.0-62", sha256="d282117bc6d0e91ad1ad685d096623b96ed8e229f911c891d83277b350ef884a")
+        version("7.1.0-60", sha256="94424cc13c5ba18e0e5d5badb834ce74eab11207b00ea32c1f533a5e34c85887")
+        version("7.0.11-14", sha256="dfa5aa3f7f289f12c2f9ee6c7c19b02ae857b4eec02f40298f60f5c11048a016")
+        version("7.0.10-62", sha256="84442158aea070095efa832cfe868fd99d6befdf609444f0c9e9f1b4f25480cd")
+        version("7.0.9-27", sha256="aeea7768bf330d87efa80fa89f03c5acc2382eae32d1d871acb813e5b116395a")
+        version("7.0.8-7", sha256="fadb36b59f310e9eee5249ecb2326b323a64da6cc716dd6d08ece8ea2c780b81")
+        version("7.0.5-9", sha256="b85b269e0ed1628e88e840053823f8a33c314b2271f04762f43d33e9d0b4d264")
+        version("7.0.2-7", sha256="f2f18a97f861c1668befdaff0cc3aaafb2111847aab028a88b4c2cb017acfbaa")
+        version("7.0.2-6", sha256="7d49ca8030f895c683cae69c52d8edfc4876de651f5b8bfdbea907e222480bd3")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated

--- a/var/spack/repos/builtin/packages/imagemagick/package.py
+++ b/var/spack/repos/builtin/packages/imagemagick/package.py
@@ -20,15 +20,33 @@ class Imagemagick(AutotoolsPackage):
     version("7.1.1-11", sha256="98bb2783da7d5b06e7543529bd07b50d034fba611ff15e8817a0f4f73957d934")
     with default_args(deprecated=True):
         # https://nvd.nist.gov/vuln/detail/CVE-2023-34153
-        version("7.1.0-62", sha256="d282117bc6d0e91ad1ad685d096623b96ed8e229f911c891d83277b350ef884a")
-        version("7.1.0-60", sha256="94424cc13c5ba18e0e5d5badb834ce74eab11207b00ea32c1f533a5e34c85887")
-        version("7.0.11-14", sha256="dfa5aa3f7f289f12c2f9ee6c7c19b02ae857b4eec02f40298f60f5c11048a016")
-        version("7.0.10-62", sha256="84442158aea070095efa832cfe868fd99d6befdf609444f0c9e9f1b4f25480cd")
-        version("7.0.9-27", sha256="aeea7768bf330d87efa80fa89f03c5acc2382eae32d1d871acb813e5b116395a")
-        version("7.0.8-7", sha256="fadb36b59f310e9eee5249ecb2326b323a64da6cc716dd6d08ece8ea2c780b81")
-        version("7.0.5-9", sha256="b85b269e0ed1628e88e840053823f8a33c314b2271f04762f43d33e9d0b4d264")
-        version("7.0.2-7", sha256="f2f18a97f861c1668befdaff0cc3aaafb2111847aab028a88b4c2cb017acfbaa")
-        version("7.0.2-6", sha256="7d49ca8030f895c683cae69c52d8edfc4876de651f5b8bfdbea907e222480bd3")
+        version(
+            "7.1.0-62", sha256="d282117bc6d0e91ad1ad685d096623b96ed8e229f911c891d83277b350ef884a"
+        )
+        version(
+            "7.1.0-60", sha256="94424cc13c5ba18e0e5d5badb834ce74eab11207b00ea32c1f533a5e34c85887"
+        )
+        version(
+            "7.0.11-14", sha256="dfa5aa3f7f289f12c2f9ee6c7c19b02ae857b4eec02f40298f60f5c11048a016"
+        )
+        version(
+            "7.0.10-62", sha256="84442158aea070095efa832cfe868fd99d6befdf609444f0c9e9f1b4f25480cd"
+        )
+        version(
+            "7.0.9-27", sha256="aeea7768bf330d87efa80fa89f03c5acc2382eae32d1d871acb813e5b116395a"
+        )
+        version(
+            "7.0.8-7", sha256="fadb36b59f310e9eee5249ecb2326b323a64da6cc716dd6d08ece8ea2c780b81"
+        )
+        version(
+            "7.0.5-9", sha256="b85b269e0ed1628e88e840053823f8a33c314b2271f04762f43d33e9d0b4d264"
+        )
+        version(
+            "7.0.2-7", sha256="f2f18a97f861c1668befdaff0cc3aaafb2111847aab028a88b4c2cb017acfbaa"
+        )
+        version(
+            "7.0.2-6", sha256="7d49ca8030f895c683cae69c52d8edfc4876de651f5b8bfdbea907e222480bd3"
+        )
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated


### PR DESCRIPTION
This PR adds `imagemagick`, v7.1.1-39, and marks some older versions before the latest high CVE as deprecated.

Test build:
```
==> Installing imagemagick-7.1.1-39-gfyzrmnxb55ozqix4er4wbawd4n2h4l2 [60/60]
==> No binary for imagemagick-7.1.1-39-gfyzrmnxb55ozqix4er4wbawd4n2h4l2 found: installing from source
==> Fetching https://github.com/ImageMagick/ImageMagick/archive/7.1.1-39.tar.gz
==> No patches needed for imagemagick
==> imagemagick: Executing phase: 'autoreconf'
==> imagemagick: Executing phase: 'configure'
==> imagemagick: Executing phase: 'build'
==> imagemagick: Executing phase: 'install'
==> imagemagick: Successfully installed imagemagick-7.1.1-39-gfyzrmnxb55ozqix4er4wbawd4n2h4l2
  Stage: 2.77s.  Autoreconf: 0.00s.  Configure: 24.90s.  Build: 2m 18.69s.  Install: 1.45s.  Post-install: 0.53s.  Total: 2m 48.58s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/imagemagick-7.1.1-39-gfyzrmnxb55ozqix4er4wbawd4n2h4l2
```