### PR TITLE
openpmd-api: add v0.16.0

### DIFF
--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -108,6 +108,13 @@ class OpenpmdApi(CMakePackage):
         when="@0.15.1",
     )
 
+    # fix superbuild control in 0.16.0
+    patch(
+        "https://github.com/openPMD/openPMD-api/pull/1678.patch?full_index=1",
+        sha256="e49fe79691bbb5aae2224d218f29801630d33f3a923c518f6bfb39ec22fd6a72",
+        when="@0.16.0",
+    )
+
     extends("python", when="+python")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -58,7 +58,8 @@ class OpenpmdApi(CMakePackage):
     depends_on("mpi@2.3:", when="+mpi")  # might become MPI 3.0+
     depends_on("nlohmann-json@3.9.1:")
     depends_on("mpark-variant@1.4.0:", when="@:0.14")  # pre C++17 releases
-    depends_on("toml11@3.7.1:3", when="@0.15.0:")
+    depends_on("toml11@3.7.1:3", when="@0.15")
+    depends_on("toml11@3.7.1:", when="@0.16:")
     with when("+hdf5"):
         depends_on("hdf5@1.8.13:")
         depends_on("hdf5@1.8.13: ~mpi", when="~mpi")

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -10,7 +10,7 @@ class OpenpmdApi(CMakePackage):
     """C++ & Python API for Scientific I/O"""
 
     homepage = "https://www.openPMD.org"
-    url = "https://github.com/openPMD/openPMD-api/archive/0.15.2.tar.gz"
+    url = "https://github.com/openPMD/openPMD-api/archive/0.16.0.tar.gz"
     git = "https://github.com/openPMD/openPMD-api.git"
 
     maintainers("ax3l", "franzpoeschel")
@@ -21,6 +21,7 @@ class OpenpmdApi(CMakePackage):
 
     # C++17 up until here
     version("develop", branch="dev")
+    version("0.16.0", sha256="b52222a4ab2511f9e3f6e21af222f57ab4fb6228623024fc5d982066333e104f")
     version("0.15.2", sha256="fbe3b356fe6f4589c659027c8056844692c62382e3ec53b953bed1c87e58ba13")
     version("0.15.1", sha256="0e81652152391ba4d2b62cfac95238b11233a4f89ff45e1fcffcc7bcd79dabe1")
     version("0.15.0", sha256="290e3a3c5814204ea6527d53423bfacf7a8dc490713227c9e0eaa3abf4756177")
@@ -45,18 +46,19 @@ class OpenpmdApi(CMakePackage):
     variant("shared", default=True, description="Build a shared version of the library")
     variant("mpi", default=True, description="Enable parallel I/O")
     variant("hdf5", default=True, description="Enable HDF5 support")
-    variant("adios1", default=False, description="Enable ADIOS1 support")
+    variant("adios1", default=False, description="Enable ADIOS1 support", when="@:0.15")
     variant("adios2", default=True, description="Enable ADIOS2 support")
     variant("python", default=False, description="Enable Python bindings")
 
     depends_on("cmake@3.15.0:", type="build")
+    depends_on("cmake@3.22.0:", type="build", when="@0.16.0:")
     depends_on("catch2@2.6.1:2", type="test")
     depends_on("catch2@2.13.4:2", type="test", when="@0.14.0:")
     depends_on("catch2@2.13.10:2", type="test", when="@0.15.0:")
     depends_on("mpi@2.3:", when="+mpi")  # might become MPI 3.0+
     depends_on("nlohmann-json@3.9.1:")
     depends_on("mpark-variant@1.4.0:", when="@:0.14")  # pre C++17 releases
-    depends_on("toml11@3.7.1:3.8.1", when="@0.15.0:")
+    depends_on("toml11@3.7.1:3", when="@0.15.0:")
     with when("+hdf5"):
         depends_on("hdf5@1.8.13:")
         depends_on("hdf5@1.8.13: ~mpi", when="~mpi")
@@ -73,6 +75,7 @@ class OpenpmdApi(CMakePackage):
         depends_on("adios2@2.5.0: +mpi", when="+mpi")
     with when("+python"):
         depends_on("py-pybind11@2.6.2:", type="link")
+        depends_on("py-pybind11@2.13.0:", type="link", when="@0.16.0:")
         depends_on("py-numpy@1.15.1:", type=["test", "run"])
         depends_on("py-mpi4py@2.1.0:", when="+mpi", type=["test", "run"])
         depends_on("python@3.7:", type=["link", "test", "run"])


### PR DESCRIPTION
Add the latest release of openPMD-api.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
