### PR TITLE
cached_cmake: mpifc is not always defined

### DIFF
--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -193,7 +193,10 @@ class CachedCMakeBuilder(CMakeBuilder):
 
         entries.append(cmake_cache_path("MPI_C_COMPILER", spec["mpi"].mpicc))
         entries.append(cmake_cache_path("MPI_CXX_COMPILER", spec["mpi"].mpicxx))
-        entries.append(cmake_cache_path("MPI_Fortran_COMPILER", spec["mpi"].mpifc))
+
+        # not all MPIs have Fortran wrappers
+        if hasattr(spec["mpi"], "mpifc"):
+            entries.append(cmake_cache_path("MPI_Fortran_COMPILER", spec["mpi"].mpifc))
 
         # Check for slurm
         using_slurm = False

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -59,7 +59,7 @@ class Mpich(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("fortran", type="build", when="+fortran")
 
     variant("hwloc", default=True, description="Use external hwloc package")
     variant("hydra", default=True, description="Build the hydra process manager")


### PR DESCRIPTION
Packages like `caliper` that have optional fortran support will still try to access `mpifc` via `CachedCMakePackage` even if the underlying MPI doesn't provide them (e.g. `mpich~fortran`). This PR makes that configuration optional.

It also makes`mpich` only depend on `fortran` when `+fortran`.