### PR TITLE
[intel-oneapi-compilers] use llvm flags for ifx

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -446,7 +446,11 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
             llvm_flags.append("-Wno-unused-command-line-argument")
 
         self.write_config_file(common_flags + llvm_flags, self._llvm_bin, ["icx", "icpx"])
-        self.write_config_file(common_flags + classic_flags, self._llvm_bin, ["ifx"])
+        self.write_config_file(
+            common_flags + (llvm_flags if self.spec.satisfies("@2022.1.0:") else classic_flags),
+            self._llvm_bin,
+            ["ifx"],
+        )
         self.write_config_file(common_flags + classic_flags, self._classic_bin, ["ifort"])
         self.write_config_file(common_flags + classic_flags, self._classic_bin, ["icc", "icpc"])
 


### PR DESCRIPTION
@stephenmsachs noted that `ifx -fuse-ld=lld` was using `ld` when `intel-oneapi-compilers%gcc` and `gcc` not the system compiler. However `icx -fuse-ld=lld` does use `lld`. When generating the `ifx.cfg`, we were using `-gcc-name` while `icx` used `--gcc-toolchain`. I think that is because earlier versions of `ifx` did not support `--gcc-toolchain`. Switch `ifx.cfg` to `--gcc-toolchain` for 2022.1.0 and later.
