### PR TITLE
gtkplus: build_system={autotools,meson}

### DIFF
--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -102,12 +102,15 @@ class Gtkplus(AutotoolsPackage, MesonPackage):
         env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
         env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
 
+
+class BuildEnvironment:
+
     def setup_dependent_run_environment(self, env, dependent_spec):
         env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
         env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
 
 
-class MesonBuilder(spack.build_systems.meson.MesonBuilder):
+class MesonBuilder(BuildEnvironment, spack.build_systems.meson.MesonBuilder):
 
     def meson_args(self):
         args = []
@@ -128,7 +131,7 @@ class MesonBuilder(spack.build_systems.meson.MesonBuilder):
         pass
 
 
-class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
+class AutotoolsBuilder(BuildEnvironment, spack.build_systems.autotools.AutotoolsBuilder):
 
     def configure_args(self):
         true = which("true")

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -16,7 +16,7 @@ class Gtkplus(AutotoolsPackage, MesonPackage):
     license("LGPL-2.0-or-later")
 
     build_system(
-        condational("autotools", when="@:3.24.35"),
+        conditional("autotools", when="@:3.24.35"),
         conditional("meson", when="@3.24.9:"),
         default="autotools",
     )
@@ -148,4 +148,3 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
     def check(self):
         """All build time checks open windows in the X server, don't do that"""
         pass
-

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -98,14 +98,14 @@ class Gtkplus(AutotoolsPackage, MesonPackage):
     def setup_run_environment(self, env):
         env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
 
-    def setup_dependent_build_environment(self, env, dependent_spec):
+    def setup_dependent_run_environment(self, env, dependent_spec):
         env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
         env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
 
 
 class BuildEnvironment:
 
-    def setup_dependent_run_environment(self, env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
         env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
 


### PR DESCRIPTION
This PR adds multiple build system support to `gtkplus`, with a few overlapping versions. As requested in https://github.com/spack/spack/pull/40310#issuecomment-2396662868.

Test build of `gtkplus@=3.24.26 build_system=autotools` and `gtkplus@=3.24.26 build_system=meson`:
```
==> Installing gtkplus-3.24.26-pwcooaudhwpbq4wb7ko725s5k6n6tyhx [93/94]
==> No binary for gtkplus-3.24.26-pwcooaudhwpbq4wb7ko725s5k6n6tyhx found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/2c/2cc1b2dc5cad15d25b6abd115c55ffd8331e8d4677745dd3ce6db725b4fff1e9.tar.xz
==> Ran patch() for gtkplus
==> gtkplus: Executing phase: 'meson'
==> gtkplus: Executing phase: 'build'
==> gtkplus: Executing phase: 'install'
==> gtkplus: Successfully installed gtkplus-3.24.26-pwcooaudhwpbq4wb7ko725s5k6n6tyhx
  Stage: 3.70s.  Meson: 7.83s.  Build: 3m 34.17s.  Install: 0.59s.  Post-install: 0.62s.  Total: 3m 47.25s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/gtkplus-3.24.26-pwcooaudhwpbq4wb7ko725s5k6n6tyhx
==> Installing gtkplus-3.24.26-gvwfjtit56okgq7xtysrtdyio3zzeznl [94/94]
==> No binary for gtkplus-3.24.26-gvwfjtit56okgq7xtysrtdyio3zzeznl found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/2c/2cc1b2dc5cad15d25b6abd115c55ffd8331e8d4677745dd3ce6db725b4fff1e9.tar.xz
==> Ran patch() for gtkplus
==> gtkplus: Executing phase: 'autoreconf'
==> gtkplus: Executing phase: 'configure'
==> gtkplus: Executing phase: 'build'
==> gtkplus: Executing phase: 'install'
==> gtkplus: Successfully installed gtkplus-3.24.26-gvwfjtit56okgq7xtysrtdyio3zzeznl
  Stage: 1.33s.  Autoreconf: 0.00s.  Configure: 15.47s.  Build: 5m 44.94s.  Install: 14.06s.  Post-install: 0.94s.  Total: 6m 17.28s
[+] /opt/software/linux-ubuntu24.04-skylake/gcc-13.3.0/gtkplus-3.24.26-gvwfjtit56okgq7xtysrtdyio3zzeznl
```
