### PR TITLE
gettext: Fix ~libxml2: Skip patch for external libxml

### DIFF
--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -31,8 +31,8 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
     version("0.19.8.1", sha256="105556dbc5c3fbbc2aa0edb46d22d055748b6f5c7cd7a8d99f8e7eb84e938be4")
     version("0.19.7", sha256="378fa86a091cec3acdece3c961bb8d8c0689906287809a8daa79dc0c6398d934")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     # Recommended variants
     variant("curses", default=True, description="Use libncurses")
@@ -83,7 +83,7 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
         # From the configure script: "we don't want to use an external libxml, because its
         # dependencies and their dynamic relocations have an impact on the startup time", well,
         # *we* do.
-        if self.spec.satisfies("@0.20:"):  # libtextstyle/configure not present prior
+        if self.spec.satisfies("@0.20:+libxml2"):  # libtextstyle/configure not present prior
             filter_file(
                 "gl_cv_libxml_force_included=yes",
                 "gl_cv_libxml_force_included=no",
@@ -93,7 +93,7 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
 
     def flag_handler(self, name, flags):
         # this goes together with gl_cv_libxml_force_included=no
-        if name == "ldflags":
+        if name == "ldflags" and self.spec.satisfies("+libxml2"):
             flags.append("-lxml2")
         return (flags, None, None)
 


### PR DESCRIPTION
CC: @etiennemlb, @yizeyi18, @wdconinc: Thix fixes the `gettext~libxml2` installation issue:

Ensure that the code to use the internal `libxml` stays intact when it shall be active using `~libxml2`:

This is a regression fix for a new installation issue in gettext:

## Fixes a new issue, which has been independently reported two times now:
- Fixes: #46815
- Fixes: #46863

### Cause:

The `gettext` recipe of `spack` patches configure to not use the internal libxml, but it must not do so when `~libxml2` is selected:

### Fix:

Ensure that the code to use the internal `libxml` stays intact when it has to be used by `~libxml2`.

It looks like this was triggered as a side effect of a seemingly good change, which requires the patching to be done correctly now.