### PR TITLE
e4s external rocm ci: upgrade to v6.2.1

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -377,7 +377,7 @@ e4s-neoverse_v1-build:
 
 e4s-rocm-external-generate:
   extends: [ ".e4s-rocm-external", ".generate-x86_64"]
-  image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.2.0:2024.09.11
+  image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.2.1:2024.09.11
 
 e4s-rocm-external-build:
   extends: [ ".e4s-rocm-external", ".build" ]

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -377,7 +377,7 @@ e4s-neoverse_v1-build:
 
 e4s-rocm-external-generate:
   extends: [ ".e4s-rocm-external", ".generate-x86_64"]
-  image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.2.1:2024.09.11
+  image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.2.1:2024.10.08
 
 e4s-rocm-external-build:
   extends: [ ".e4s-rocm-external", ".build" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -302,7 +302,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.2.1:2024.09.11
+        image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.2.1:2024.10.08
 
   cdash:
     build-group: E4S ROCm External

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -27,186 +27,186 @@ spack:
     comgr:
       buildable: false
       externals:
-      - spec: comgr@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: comgr@6.2.1
+        prefix: /opt/rocm-6.2.1/
     hip-rocclr:
       buildable: false
       externals:
-      - spec: hip-rocclr@6.2.0
-        prefix: /opt/rocm-6.2.0/hip
+      - spec: hip-rocclr@6.2.1
+        prefix: /opt/rocm-6.2.1/hip
     hipblas:
       buildable: false
       externals:
-      - spec: hipblas@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: hipblas@6.2.1
+        prefix: /opt/rocm-6.2.1/
     hipcub:
       buildable: false
       externals:
-      - spec: hipcub@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: hipcub@6.2.1
+        prefix: /opt/rocm-6.2.1/
     hipfft:
       buildable: false
       externals:
-      - spec: hipfft@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: hipfft@6.2.1
+        prefix: /opt/rocm-6.2.1/
     hipsparse:
       buildable: false
       externals:
-      - spec: hipsparse@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: hipsparse@6.2.1
+        prefix: /opt/rocm-6.2.1/
     miopen-hip:
       buildable: false
       externals:
-      - spec: miopen-hip@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: miopen-hip@6.2.1
+        prefix: /opt/rocm-6.2.1/
     miopengemm:
       buildable: false
       externals:
-      - spec: miopengemm@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: miopengemm@6.2.1
+        prefix: /opt/rocm-6.2.1/
     rccl:
       buildable: false
       externals:
-      - spec: rccl@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: rccl@6.2.1
+        prefix: /opt/rocm-6.2.1/
     rocblas:
       buildable: false
       externals:
-      - spec: rocblas@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: rocblas@6.2.1
+        prefix: /opt/rocm-6.2.1/
     rocfft:
       buildable: false
       externals:
-      - spec: rocfft@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: rocfft@6.2.1
+        prefix: /opt/rocm-6.2.1/
     rocm-clang-ocl:
       buildable: false
       externals:
-      - spec: rocm-clang-ocl@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: rocm-clang-ocl@6.2.1
+        prefix: /opt/rocm-6.2.1/
     rocm-cmake:
       buildable: false
       externals:
-      - spec: rocm-cmake@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: rocm-cmake@6.2.1
+        prefix: /opt/rocm-6.2.1/
     rocm-dbgapi:
       buildable: false
       externals:
-      - spec: rocm-dbgapi@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: rocm-dbgapi@6.2.1
+        prefix: /opt/rocm-6.2.1/
     rocm-debug-agent:
       buildable: false
       externals:
-      - spec: rocm-debug-agent@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: rocm-debug-agent@6.2.1
+        prefix: /opt/rocm-6.2.1/
     rocm-device-libs:
       buildable: false
       externals:
-      - spec: rocm-device-libs@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: rocm-device-libs@6.2.1
+        prefix: /opt/rocm-6.2.1/
     rocm-gdb:
       buildable: false
       externals:
-      - spec: rocm-gdb@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: rocm-gdb@6.2.1
+        prefix: /opt/rocm-6.2.1/
     rocm-opencl:
       buildable: false
       externals:
-      - spec: rocm-opencl@6.2.0
-        prefix: /opt/rocm-6.2.0/opencl
+      - spec: rocm-opencl@6.2.1
+        prefix: /opt/rocm-6.2.1/opencl
     rocm-smi-lib:
       buildable: false
       externals:
-      - spec: rocm-smi-lib@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: rocm-smi-lib@6.2.1
+        prefix: /opt/rocm-6.2.1/
     hip:
       buildable: false
       externals:
-      - spec: hip@6.2.0
-        prefix: /opt/rocm-6.2.0
+      - spec: hip@6.2.1
+        prefix: /opt/rocm-6.2.1
         extra_attributes:
           compilers:
-            c: /opt/rocm-6.2.0/llvm/bin/clang++
-            c++: /opt/rocm-6.2.0/llvm/bin/clang++
-            hip: /opt/rocm-6.2.0/hip/bin/hipcc
+            c: /opt/rocm-6.2.1/llvm/bin/clang++
+            c++: /opt/rocm-6.2.1/llvm/bin/clang++
+            hip: /opt/rocm-6.2.1/hip/bin/hipcc
     hipify-clang:
       buildable: false
       externals:
-      - spec: hipify-clang@6.2.0
-        prefix: /opt/rocm-6.2.0
+      - spec: hipify-clang@6.2.1
+        prefix: /opt/rocm-6.2.1
     llvm-amdgpu:
       buildable: false
       externals:
-      - spec: llvm-amdgpu@6.2.0
-        prefix: /opt/rocm-6.2.0/llvm
+      - spec: llvm-amdgpu@6.2.1
+        prefix: /opt/rocm-6.2.1/llvm
         extra_attributes:
           compilers:
-            c: /opt/rocm-6.2.0/llvm/bin/clang++
-            cxx: /opt/rocm-6.2.0/llvm/bin/clang++
+            c: /opt/rocm-6.2.1/llvm/bin/clang++
+            cxx: /opt/rocm-6.2.1/llvm/bin/clang++
     hsakmt-roct:
       buildable: false
       externals:
-      - spec: hsakmt-roct@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: hsakmt-roct@6.2.1
+        prefix: /opt/rocm-6.2.1/
     hsa-rocr-dev:
       buildable: false
       externals:
-      - spec: hsa-rocr-dev@6.2.0
-        prefix: /opt/rocm-6.2.0/
+      - spec: hsa-rocr-dev@6.2.1
+        prefix: /opt/rocm-6.2.1/
         extra_atributes:
           compilers:
-            c: /opt/rocm-6.2.0/llvm/bin/clang++
-            cxx: /opt/rocm-6.2.0/llvm/bin/clang++
+            c: /opt/rocm-6.2.1/llvm/bin/clang++
+            cxx: /opt/rocm-6.2.1/llvm/bin/clang++
     roctracer-dev-api:
       buildable: false
       externals:
-      - spec: roctracer-dev-api@6.2.0
-        prefix: /opt/rocm-6.2.0
+      - spec: roctracer-dev-api@6.2.1
+        prefix: /opt/rocm-6.2.1
     roctracer-dev:
       buildable: false
       externals:
       - spec: roctracer-dev@4.5.3
-        prefix: /opt/rocm-6.2.0
+        prefix: /opt/rocm-6.2.1
     rocprim:
       buildable: false
       externals:
-      - spec: rocprim@6.2.0
-        prefix: /opt/rocm-6.2.0
+      - spec: rocprim@6.2.1
+        prefix: /opt/rocm-6.2.1
     rocrand:
       buildable: false
       externals:
-      - spec: rocrand@6.2.0
-        prefix: /opt/rocm-6.2.0
+      - spec: rocrand@6.2.1
+        prefix: /opt/rocm-6.2.1
     hipsolver:
       buildable: false
       externals:
-      - spec: hipsolver@6.2.0
-        prefix: /opt/rocm-6.2.0
+      - spec: hipsolver@6.2.1
+        prefix: /opt/rocm-6.2.1
     rocsolver:
       buildable: false
       externals:
-      - spec: rocsolver@6.2.0
-        prefix: /opt/rocm-6.2.0
+      - spec: rocsolver@6.2.1
+        prefix: /opt/rocm-6.2.1
     rocsparse:
       buildable: false
       externals:
-      - spec: rocsparse@6.2.0
-        prefix: /opt/rocm-6.2.0
+      - spec: rocsparse@6.2.1
+        prefix: /opt/rocm-6.2.1
     rocthrust:
       buildable: false
       externals:
-      - spec: rocthrust@6.2.0
-        prefix: /opt/rocm-6.2.0
+      - spec: rocthrust@6.2.1
+        prefix: /opt/rocm-6.2.1
     rocprofiler-dev:
       buildable: false
       externals:
-      - spec: rocprofiler-dev@6.2.0
-        prefix: /opt/rocm-6.2.0
+      - spec: rocprofiler-dev@6.2.1
+        prefix: /opt/rocm-6.2.1
     rocm-core:
       buildable: false
       externals:
-      - spec: rocm-core@6.2.0
-        prefix: /opt/rocm-6.2.0
+      - spec: rocm-core@6.2.1
+        prefix: /opt/rocm-6.2.1
 
   specs:
   # ROCM NOARCH
@@ -302,7 +302,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.2.0:2024.09.11
+        image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4-rocm6.2.1:2024.09.11
 
   cdash:
     build-group: E4S ROCm External

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -67,6 +67,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
         "6.1.1",
         "6.1.2",
         "6.2.0",
+        "6.2.1",
     ]:
         depends_on(f"rocm-core@{ver}", when=f"@2.8.0: +rocm ^hip@{ver}")
     depends_on("python", when="@master", type="build")


### PR DESCRIPTION
E4S External ROCm CI stack: Upgrade ROCm components to v6.2.1