### PR TITLE
`hepmc3`: fix typo in cmake arg for the `+protobuf` variant

### DIFF
--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -84,8 +84,7 @@ class Hepmc3(CMakePackage):
                 args.append(
                     self.define("HEPMC3_CXX_STANDARD", spec["root"].variants["cxxstd"].value)
                 )
-
-        if spec.satisfies("+protobuf"):
+        elif spec.satisfies("+protobuf"):
             args.append(self.define("HEPMC3_CXX_STANDARD", "14"))
 
         return args

--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -62,7 +62,7 @@ class Hepmc3(CMakePackage):
         spec = self.spec
         from_variant = self.define_from_variant
         args = [
-            from_variant("HEPMC3_ENABLE_PROTOBUF", "protobuf"),
+            from_variant("HEPMC3_ENABLE_PROTOBUFIO", "protobuf"),
             from_variant("HEPMC3_ENABLE_PYTHON", "python"),
             from_variant("HEPMC3_ENABLE_ROOTIO", "rootio"),
             from_variant("HEPMC3_INSTALL_INTERFACES", "interfaces"),

--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -16,7 +16,7 @@ class Hepmc3(CMakePackage):
 
     tags = ["hep"]
 
-    maintainers("vvolkl")
+    maintainers("vvolkl", "luketpickering")
 
     license("LGPL-3.0-or-later")
 

--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -85,4 +85,7 @@ class Hepmc3(CMakePackage):
                     self.define("HEPMC3_CXX_STANDARD", spec["root"].variants["cxxstd"].value)
                 )
 
+        if "+protobuf" in spec:
+            args.append(self.define("HEPMC3_CXX_STANDARD", "14"))
+
         return args

--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -85,7 +85,7 @@ class Hepmc3(CMakePackage):
                     self.define("HEPMC3_CXX_STANDARD", spec["root"].variants["cxxstd"].value)
                 )
 
-        if "+protobuf" in spec:
+        if spec.satisfies("+protobuf"):
             args.append(self.define("HEPMC3_CXX_STANDARD", "14"))
 
         return args


### PR DESCRIPTION
c.f. https://gitlab.cern.ch/hepmc/HepMC3/-/blob/master/CMakeLists.txt?ref_type=heads#L32