### PR TITLE
elasticsearch, kibana, logstash: add v8.15.2 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/elasticsearch/package.py
+++ b/var/spack/repos/builtin/packages/elasticsearch/package.py
@@ -24,6 +24,12 @@ class Elasticsearch(Package):
 
     depends_on("java", type="run")
 
+    def url_for_version(self, version):
+        if self.spec.satisfies("@:6"):
+            return f"https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.tar.gz"
+        else:
+            return f"https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}-linux-x86_64.tar.gz"
+
     def install(self, spec, prefix):
         dirs = ["bin", "config", "lib", "modules", "plugins"]
 

--- a/var/spack/repos/builtin/packages/elasticsearch/package.py
+++ b/var/spack/repos/builtin/packages/elasticsearch/package.py
@@ -13,11 +13,14 @@ class Elasticsearch(Package):
     """
 
     homepage = "https://www.elastic.co/"
-    url = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.4.tar.gz"
+    url = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.15.2-linux-x86_64.tar.gz"
 
-    version("6.4.0", sha256="e9786efb5cecd12adee2807c7640ba9a1ab3b484d2e87497bb8d0b6df0e24f01")
-    version("6.3.0", sha256="0464127140820d82b24bd2830232131ea85bcd49267a8bc7365e4fa391dee2a3")
-    version("6.2.4", sha256="91e6f1ea1e1dd39011e7a703d2751ca46ee374665b08b0bfe17e0c0c27000e8e")
+    version("8.15.2", sha256="0b6905ede457be9d1d73d0b6be1c3a7c7c6220829846b532f2604ad30ba7308f")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2018-3831
+        version("6.4.0", sha256="e9786efb5cecd12adee2807c7640ba9a1ab3b484d2e87497bb8d0b6df0e24f01")
+        version("6.3.0", sha256="0464127140820d82b24bd2830232131ea85bcd49267a8bc7365e4fa391dee2a3")
+        version("6.2.4", sha256="91e6f1ea1e1dd39011e7a703d2751ca46ee374665b08b0bfe17e0c0c27000e8e")
 
     depends_on("java", type="run")
 

--- a/var/spack/repos/builtin/packages/kibana/package.py
+++ b/var/spack/repos/builtin/packages/kibana/package.py
@@ -13,9 +13,10 @@ class Kibana(Package):
     homepage = "https://www.elastic.co/products/kibana"
     url = "https://artifacts.elastic.co/downloads/kibana/kibana-6.4.0-linux-x86_64.tar.gz"
 
-    version("6.4.0", sha256="df2056105a08c206a1adf9caed09a152a53429a0f1efc1ba3ccd616092d78aee")
-
-    depends_on("cxx", type="build")  # generated
+    version("8.15.2", sha256="b1f8082a4200867078170e92ad299e293ee514f5fdbb96b7a0d1de17a880d1eb")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2019-7609
+        version("6.4.0", sha256="df2056105a08c206a1adf9caed09a152a53429a0f1efc1ba3ccd616092d78aee")
 
     depends_on("java", type="run")
 

--- a/var/spack/repos/builtin/packages/logstash/package.py
+++ b/var/spack/repos/builtin/packages/logstash/package.py
@@ -15,12 +15,21 @@ class Logstash(Package):
     """
 
     homepage = "https://artifacts.elastic.co"
-    url = "https://artifacts.elastic.co/downloads/logstash/logstash-6.6.0.tar.gz"
+    url = "https://artifacts.elastic.co/downloads/logstash/logstash-8.15.2-linux-x86_64.tar.gz"
 
-    version("6.6.0", sha256="5a9a8b9942631e9d4c3dfb8d47075276e8c2cff343841145550cc0c1cfe7bba7")
+    version("8.15.2", sha256="fc75c8cad1016b07f7aeeeeb7ea23f4195ab1beee2ced282f11ff6d0e84f7e51")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2019-7612
+        version("6.6.0", sha256="5a9a8b9942631e9d4c3dfb8d47075276e8c2cff343841145550cc0c1cfe7bba7")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@:6"):
+            return f"https://artifacts.elastic.co/downloads/logstash/logstash-{version}.tar.gz"
+        else:
+            return f"https://artifacts.elastic.co/downloads/logstash/logstash-{version}-linux-x86_64.tar.gz"
 
     def install(self, spec, prefix):
         install_tree(".", prefix)

--- a/var/spack/repos/builtin/packages/logstash/package.py
+++ b/var/spack/repos/builtin/packages/logstash/package.py
@@ -22,7 +22,7 @@ class Logstash(Package):
         # https://nvd.nist.gov/vuln/detail/CVE-2019-7612
         version("6.6.0", sha256="5a9a8b9942631e9d4c3dfb8d47075276e8c2cff343841145550cc0c1cfe7bba7")
 
-    depends_on("java@11:", type="build")
+    depends_on("java@11:")
 
     def url_for_version(self, version):
         if self.spec.satisfies("@:6"):

--- a/var/spack/repos/builtin/packages/logstash/package.py
+++ b/var/spack/repos/builtin/packages/logstash/package.py
@@ -22,14 +22,17 @@ class Logstash(Package):
         # https://nvd.nist.gov/vuln/detail/CVE-2019-7612
         version("6.6.0", sha256="5a9a8b9942631e9d4c3dfb8d47075276e8c2cff343841145550cc0c1cfe7bba7")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("java@11:", type="build")
 
     def url_for_version(self, version):
         if self.spec.satisfies("@:6"):
-            return f"https://artifacts.elastic.co/downloads/logstash/logstash-{version}.tar.gz"
+            return automatically added to the packagef"https://artifacts.elastic.co/downloads/logstash/logstash-{version}.tar.gz"
         else:
             return f"https://artifacts.elastic.co/downloads/logstash/logstash-{version}-linux-x86_64.tar.gz"
 
     def install(self, spec, prefix):
         install_tree(".", prefix)
+
+    def setup_run_environment(self, env):
+        # do not use the bundled jdk
+        env.set("LS_JAVA_HOME", self.spec["java"].home)

--- a/var/spack/repos/builtin/packages/logstash/package.py
+++ b/var/spack/repos/builtin/packages/logstash/package.py
@@ -26,7 +26,7 @@ class Logstash(Package):
 
     def url_for_version(self, version):
         if self.spec.satisfies("@:6"):
-            return automatically added to the packagef"https://artifacts.elastic.co/downloads/logstash/logstash-{version}.tar.gz"
+            return f"https://artifacts.elastic.co/downloads/logstash/logstash-{version}.tar.gz"
         else:
             return f"https://artifacts.elastic.co/downloads/logstash/logstash-{version}-linux-x86_64.tar.gz"
 


### PR DESCRIPTION
This PR adds `elasticsearch`, `kibana` and `logstash`, v8.15.2, which fixes CVE-2023-46674, CVE-2023-31418, CVE-2019-7611, CVE-2018-3831, CVE-2020-7013, CVE-2019-7610, CVE-2019-7609, CVE-2018-17246, CVE-2018-17245, CVE-2019-7612, CVE-2019-7620, CVE-2023-46672 (and a bunch more medium or low CVEs)

Test build:
```
==> Installing kibana-8.15.2-ha7cm7jhpugj5swuc4ucu5quh7ivnsai [4/5]
==> No binary for kibana-8.15.2-ha7cm7jhpugj5swuc4ucu5quh7ivnsai found: installing from source
==> Fetching https://artifacts.elastic.co/downloads/kibana/kibana-8.15.2-linux-x86_64.tar.gz
==> No patches needed for kibana
==> kibana: Executing phase: 'install'
==> kibana: Successfully installed kibana-8.15.2-ha7cm7jhpugj5swuc4ucu5quh7ivnsai
  Stage: 37.66s.  Install: 46.64s.  Post-install: 46.32s.  Total: 2m 10.72s
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/kibana-8.15.2-ha7cm7jhpugj5swuc4ucu5quh7ivnsai
==> Installing elasticsearch-8.15.2-adlhzvvdvcnkh4wso25hw7liwrd2mmpu [5/5]
==> No binary for elasticsearch-8.15.2-adlhzvvdvcnkh4wso25hw7liwrd2mmpu found: installing from source
==> Fetching https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.15.2-linux-x86_64.tar.gz
==> No patches needed for elasticsearch
==> elasticsearch: Executing phase: 'install'
==> elasticsearch: Successfully installed elasticsearch-8.15.2-adlhzvvdvcnkh4wso25hw7liwrd2mmpu
  Stage: 24.28s.  Install: 10.39s.  Post-install: 3.09s.  Total: 38.40s
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/elasticsearch-8.15.2-adlhzvvdvcnkh4wso25hw7liwrd2mmpu
==> Installing logstash-8.15.2-rwkwz64eqwnsko7cmikzovvyemynowwp [3/3]
==> No binary for logstash-8.15.2-rwkwz64eqwnsko7cmikzovvyemynowwp found: installing from source
==> Fetching https://artifacts.elastic.co/downloads/logstash/logstash-8.15.2-linux-x86_64.tar.gz
==> No patches needed for logstash
==> logstash: Executing phase: 'install'
==> logstash: Successfully installed logstash-8.15.2-rwkwz64eqwnsko7cmikzovvyemynowwp
  Stage: 52.68s.  Install: 10.90s.  Post-install: 9.32s.  Total: 1m 12.95s
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/logstash-8.15.2-rwkwz64eqwnsko7cmikzovvyemynowwp
```

Test run of kibana (until killed with Ctrl-C):
```
@wdconinc ➜ /workspaces/spack (packages/elasticsearch-kibana-8.15.2) $ kibana serve
Kibana is currently running with legacy OpenSSL providers enabled! For details and instructions on how to disable see https://www.elastic.co/guide/en/kibana/8.15/production.html#openssl-legacy-provider
{"log.level":"info","@timestamp":"2024-10-08T16:57:07.020Z","log.logger":"elastic-apm-node","ecs.version":"8.10.0","agentVersion":"4.7.0","env":{"pid":10270,"proctitle":"/workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/kibana-8.15.2-ha7cm7jhpugj5swuc4ucu5quh7ivnsai/bin/../node/glibc-217/bin/node","os":"linux 6.5.0-1025-azure","arch":"x64","host":"codespaces-edb9c2","timezone":"UTC+00","runtime":"Node.js v20.15.1"},"config":{"active":{"source":"start","value":true},"breakdownMetrics":{"source":"start","value":false},"captureBody":{"source":"start","value":"off","commonName":"capture_body"},"captureHeaders":{"source":"start","value":false},"centralConfig":{"source":"start","value":false},"contextPropagationOnly":{"source":"start","value":true},"environment":{"source":"start","value":"production"},"globalLabels":{"source":"start","value":[["git_rev","5a522bfe14bc6d06c20bc337477fd53f7c538973"]],"sourceValue":{"git_rev":"5a522bfe14bc6d06c20bc337477fd53f7c538973"}},"logLevel":{"source":"default","value":"info","commonName":"log_level"},"metricsInterval":{"source":"start","value":120,"sourceValue":"120s"},"serverUrl":{"source":"start","value":"https://kibana-cloud-apm.apm.us-east-1.aws.found.io/","commonName":"server_url"},"transactionSampleRate":{"source":"start","value":0.1,"commonName":"transaction_sample_rate"},"captureSpanStackTraces":{"source":"start","sourceValue":false},"secretToken":{"source":"start","value":"[REDACTED]","commonName":"secret_token"},"serviceName":{"source":"start","value":"kibana","commonName":"service_name"},"serviceVersion":{"source":"start","value":"8.15.2","commonName":"service_version"}},"activationMethod":"require","message":"Elastic APM Node.js Agent v4.7.0"}
Native global console methods have been overridden in production environment.
[2024-10-08T16:57:08.499+00:00][INFO ][root] Kibana is starting
[2024-10-08T16:57:08.594+00:00][INFO ][node] Kibana process configured with roles: [background_tasks, ui]
^C^\Quit (core dumped)
```

