### PR TITLE
py-sqlparse: add v0.5.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-sqlparse/package.py
+++ b/var/spack/repos/builtin/packages/py-sqlparse/package.py
@@ -14,6 +14,7 @@ class PySqlparse(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("0.5.1", sha256="a9f1a42ca749a019aa98d996b58e917f4c9e1b9ff164610355f35248733767bb")
     version("0.4.1", sha256="f75cdec98a4cc8296890279d744e1ae8618bb14dbad77e3d0637f0d7bb5d6535")
     version("0.3.1", sha256="344b539482b75c244ac69fbb160d0f4d63a288a392475c8418ca692c594561f9")
     version("0.3.0", sha256="a75fddae009fba1d66786203c9dd3a842aa4415475c466d15484139117108474")
@@ -21,4 +22,6 @@ class PySqlparse(PythonPackage):
     version("0.2.3", sha256="12470ab41df1a7003a2957a79c6da9cd4ded180c8a193aa112fe0899b935ef30")
 
     depends_on("py-setuptools", type="build")
+    depends_on("py-hatchling", when="@0.5.1:", type="build")
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
+    depends_on("python@3.8:", when="@0.5.1:", type=("build", "run"))


### PR DESCRIPTION
drops support for python <3.8 and adds hatchling build dep. [ref](https://github.com/andialbrecht/sqlparse/commit/0cd062018fb1a1c296417435a10be1910a9ea657)

let me know if any of the ordering needs to be fixed

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
