### PR TITLE
CMake: Improve incremental build speed.

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -544,7 +544,7 @@ class CMakeBuilder(BaseBuilder):
 
         # skip cmake phase if it is an incremental develop build
         if spec.is_develop and os.path.isfile(
-            os.path.join(spec.build_directory, "CMakeCache.txt")
+            os.path.join(self.build_directory, "CMakeCache.txt")
         ):
             return
 

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -541,6 +541,11 @@ class CMakeBuilder(BaseBuilder):
 
     def cmake(self, pkg, spec, prefix):
         """Runs ``cmake`` in the build directory"""
+
+        # skip cmake phase if it is an incremental develop build
+        if spec.is_develop and os.path.isfile(os.path.join(spec.build_directory, "CMakeCache.txt"):
+            return
+            
         options = self.std_cmake_args
         options += self.cmake_args()
         options.append(os.path.abspath(self.root_cmakelists_dir))

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -543,9 +543,11 @@ class CMakeBuilder(BaseBuilder):
         """Runs ``cmake`` in the build directory"""
 
         # skip cmake phase if it is an incremental develop build
-        if spec.is_develop and os.path.isfile(os.path.join(spec.build_directory, "CMakeCache.txt")):
+        if spec.is_develop and os.path.isfile(
+            os.path.join(spec.build_directory, "CMakeCache.txt")
+        ):
             return
-            
+
         options = self.std_cmake_args
         options += self.cmake_args()
         options.append(os.path.abspath(self.root_cmakelists_dir))

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -543,7 +543,7 @@ class CMakeBuilder(BaseBuilder):
         """Runs ``cmake`` in the build directory"""
 
         # skip cmake phase if it is an incremental develop build
-        if spec.is_develop and os.path.isfile(os.path.join(spec.build_directory, "CMakeCache.txt"):
+        if spec.is_develop and os.path.isfile(os.path.join(spec.build_directory, "CMakeCache.txt")):
             return
             
         options = self.std_cmake_args


### PR DESCRIPTION
CMake automatically embeds an updated configure step into make/ninja that will be called at the start of the build phase.  By default if a `CMakeCache.txt` file exists in the build directory CMake will use it and this existence  combined with `spec.is_develop` is sufficient evidence of an incremental build.

This PR removes duplicate work/expense from CMake packages when using `spack develop`.  If developers want to have a fresh build they can run `spack clean` to wipe the build directory similar to removing a `CMakeCache.txt` in a non-spack workflow.

@scheibelp @zackgalbreath @johnwparent 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
