### PR TITLE
py-cfgrib: add v0.9.14.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-cfgrib/package.py
+++ b/var/spack/repos/builtin/packages/py-cfgrib/package.py
@@ -15,6 +15,7 @@ class PyCfgrib(PythonPackage):
 
     license("Apache-2.0")
 
+    version("0.9.14.1", sha256="a6e66e8a3d8f9823d3eef0c2c6ebca602d5bcc324f0baf4f3d13f68b0b40501e")
     version("0.9.10.4", sha256="b490078192aa13ec89c77296110355521442325866b16a996f4b3cf421542909")
     version("0.9.9.0", sha256="6ff0227df9c5ee34aa7d6ab1f7af3fbe6838523a8a9891c74040b419b03ad289")
     version("0.9.8.5", sha256="07c224d7ac823a1df5738b96b9d3621515538f51f67e55044f9cc8ec1668e1bd")
@@ -31,6 +32,10 @@ class PyCfgrib(PythonPackage):
 
     depends_on("py-xarray@0.15:", when="@0.9.10:+xarray", type=("build", "run"))
     depends_on("py-xarray@0.12:", when="+xarray", type=("build", "run"))
+
+    # 0.9.14.1 enables support for xarray 2024.09.0
+    # https://github.com/ecmwf/cfgrib/commit/46a79025146b3847e81629748fc3fe16e56097cf
+    depends_on("py-xarray@:2024.08.0", when="+xarray @:0.9.14.0", type=("build", "run"))
 
     # Historical dependencies
     depends_on("py-pytest-runner", when="@0.9.8.5", type="build")

--- a/var/spack/repos/builtin/packages/py-cfgrib/package.py
+++ b/var/spack/repos/builtin/packages/py-cfgrib/package.py
@@ -30,12 +30,11 @@ class PyCfgrib(PythonPackage):
     depends_on("py-eccodes", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
 
-    depends_on("py-xarray@0.15:", when="@0.9.10:+xarray", type=("build", "run"))
-    depends_on("py-xarray@0.12:", when="+xarray", type=("build", "run"))
-
-    # 0.9.14.1 enables support for xarray 2024.09.0
+    # 0.9.14.1 enables support for xarray @2024.09.0:
     # https://github.com/ecmwf/cfgrib/commit/46a79025146b3847e81629748fc3fe16e56097cf
-    depends_on("py-xarray@:2024.08.0", when="+xarray @:0.9.14.0", type=("build", "run"))
+    depends_on("py-xarray@0.15:", when="@0.9.14.1:+xarray", type=("build", "run"))
+    depends_on("py-xarray@0.15:2024.08.0", when="@0.9.10:0.9.14.0+xarray", type=("build", "run"))
+    depends_on("py-xarray@0.12:2024.08.0", when="@:0.9.14.0+xarray", type=("build", "run"))
 
     # Historical dependencies
     depends_on("py-pytest-runner", when="@0.9.8.5", type="build")


### PR DESCRIPTION
Add the newest version of `py-cfgrib` and ensure pre 0.9.14.1 versions use a compatible xarray

as per https://github.com/ecmwf/cfgrib/commit/46a79025146b3847e81629748fc3fe16e56097cf

/cc @adamjstewart for review based on git blame