### PR TITLE
Environment.clear: ensure clearing is passed through to manifest

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1159,6 +1159,8 @@ class Environment:
             # things that cannot be recreated from file
             self.new_specs = []  # write packages for these on write()
 
+        self.manifest.clear()
+
     @property
     def active(self):
         """True if this environment is currently active."""
@@ -2787,6 +2789,11 @@ class EnvironmentManifestFile(collections.abc.Mapping):
         except ValueError as e:
             msg = f"cannot remove {user_spec} from {self}, no such spec exists"
             raise SpackEnvironmentError(msg) from e
+        self.changed = True
+
+    def clear(self) -> None:
+        """Clear all user specs from the list of root specs"""
+        self.configuration["specs"] = []
         self.changed = True
 
     def override_user_spec(self, user_spec: str, idx: int) -> None:

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -574,36 +574,48 @@ def test_remove_command():
 
     with ev.read("test"):
         add("mpileaks")
+
+    with ev.read("test"):
         assert "mpileaks" in find()
         assert "mpileaks@" not in find()
         assert "mpileaks@" not in find("--show-concretized")
 
     with ev.read("test"):
         remove("mpileaks")
+
+    with ev.read("test"):
         assert "mpileaks" not in find()
         assert "mpileaks@" not in find()
         assert "mpileaks@" not in find("--show-concretized")
 
     with ev.read("test"):
         add("mpileaks")
+
+    with ev.read("test"):
         assert "mpileaks" in find()
         assert "mpileaks@" not in find()
         assert "mpileaks@" not in find("--show-concretized")
 
     with ev.read("test"):
         concretize()
+
+    with ev.read("test"):
         assert "mpileaks" in find()
         assert "mpileaks@" not in find()
         assert "mpileaks@" in find("--show-concretized")
 
     with ev.read("test"):
         remove("mpileaks")
+
+    with ev.read("test"):
         assert "mpileaks" not in find()
         # removed but still in last concretized specs
         assert "mpileaks@" in find("--show-concretized")
 
     with ev.read("test"):
         concretize()
+
+    with ev.read("test"):
         assert "mpileaks" not in find()
         assert "mpileaks@" not in find()
         # now the lockfile is regenerated and it's gone.

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -610,6 +610,28 @@ def test_remove_command():
         assert "mpileaks@" not in find("--show-concretized")
 
 
+def test_remove_command_all():
+    # Need separate ev.read calls for each command to ensure we test round-trip to disk
+    env("create", "test")
+    test_pkgs = ("mpileaks", "zlib")
+
+    with ev.read("test") as e:
+        for name in test_pkgs:
+            add(name)
+
+    with ev.read("test") as e:
+        for name in test_pkgs:
+            assert name in find()
+            assert f"{name}@" not in find()
+
+    with ev.read("test"):
+        remove("-a")
+
+    with ev.read("test"):
+        for name in test_pkgs:
+            assert name not in find()
+
+
 def test_bad_remove_included_env():
     env("create", "test")
     test = ev.read("test")

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -627,11 +627,11 @@ def test_remove_command_all():
     env("create", "test")
     test_pkgs = ("mpileaks", "zlib")
 
-    with ev.read("test") as e:
+    with ev.read("test"):
         for name in test_pkgs:
             add(name)
 
-    with ev.read("test") as e:
+    with ev.read("test"):
         for name in test_pkgs:
             assert name in find()
             assert f"{name}@" not in find()


### PR DESCRIPTION
@white238 reported a bug that `spack remove -a` silently failed to remove any specs.

This PR resolves the bug and adds a regression test.

@tldahlgren FYI
