### PR TITLE
add lima package, update qemu to make it usable

### DIFF
--- a/var/spack/repos/builtin/packages/lima/package.py
+++ b/var/spack/repos/builtin/packages/lima/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Lima(Package):
+    """Linux virtual machines, with a focus on running containers"""
+
+    homepage = "https://lima-vm.io"
+    url = "https://github.com/lima-vm/lima/archive/refs/tags/v0.23.2.tar.gz"
+
+    maintainers("trws")
+
+    license("Apache-2.0", checked_by="trws")
+
+    version("0.23.2", sha256="fc21295f78d717efc921f8f6d1ec22f64da82bfe685d0d2d505aee76c53da1ff")
+
+    depends_on("qemu@9:")
+    depends_on("go@1.22.0:")
+
+    # NOTE: in truth this is a go build, it fetches many go packages during this build
+    # process, but at least uses the built qemu and local vz on macos
+    def install(self, spec, prefix):
+        make()
+        make("install", f"DESTDIR={prefix}", "PREFIX=")

--- a/var/spack/repos/builtin/packages/qemu/package.py
+++ b/var/spack/repos/builtin/packages/qemu/package.py
@@ -18,6 +18,7 @@ class Qemu(AutotoolsPackage):
     # Docs say TCG is "under a BSD license" but all the headers for TCG have the MIT license.
     license("GPL-2.0-only AND LGPL-2.1-only AND MIT", checked_by="tgamblin")
 
+    version("9.1.0", sha256="816b7022a8ba7c2ac30e2e0cf973e826f6bcc8505339603212c5ede8e94d7834")
     version("4.1.1", sha256="ed6fdbbdd272611446ff8036991e9b9f04a2ab2e3ffa9e79f3bab0eb9a95a1d2")
     version("4.1.0", sha256="656e60218689bdeec69903087fd7582d5d3e72238d02f4481d8dc6d79fd909c6")
     version("4.0.1", sha256="f2674dd6053ef1d48593aa1f0a50c5ac9039f7a059ecb6f9b8307f3fb2fcedad")
@@ -107,6 +108,50 @@ class Qemu(AutotoolsPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("glib@2.40:")
-    depends_on("pixman@0.21.8:")
     depends_on("pkgconfig", type="build")
+    depends_on("py-tomli", when="@9:", type="build")
+    depends_on("meson@1.1.0:", when="@9:", type="build")
+
+    depends_on("bison", when="@9:")
+    depends_on("bzip2", when="@9:")
+    depends_on("capstone", when="@9:")
+    depends_on("dtc", when="@9:")
+    depends_on("flex", when="@9:")
+    depends_on("glib@2.40:")
+    depends_on("gnutls", when="@9:")
+    depends_on("libslirp", when="@9:")
+    depends_on("libssh", when="@9:")
+    depends_on("libusb", when="@9:")
+    depends_on("lzo", when="@9:")
+    depends_on("ncurses", when="@9:")
+    depends_on("nettle", when="@9:")
+    depends_on("pixman@0.21.8:")
+    depends_on("snappy", when="@9:")
+    depends_on("vde", when="@9:")
+    depends_on("zlib", when="@9:")
+    depends_on("zstd", when="@9:")
+
+    # linux deps not needed on darwin
+    depends_on("elfutils", when="@9: platform=linux")
+    depends_on("libcap-ng", when="@9: platform=linux")
+
+    build_directory = "build"
+
+    @when("@9:")
+    def configure_args(self):
+        return [
+            "--disable-bsd-user",
+            "--disable-guest-agent",
+            "--disable-sdl",
+            "--disable-bsd-user",
+            "--disable-guest-agent",
+            "--enable-slirp",
+            "--enable-capstone",
+            "--enable-curses",
+            "--enable-fdt=system",
+            "--enable-libssh",
+            "--enable-vde",
+            "--enable-virtfs",
+            "--enable-zstd",
+            "--disable-docs",
+        ]

--- a/var/spack/repos/builtin/packages/vde/package.py
+++ b/var/spack/repos/builtin/packages/vde/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Vde(AutotoolsPackage):
+    """Ethernet compliant virtual network"""
+
+    homepage = "https://github.com/virtualsquare/vde-2"
+    url = "https://github.com/virtualsquare/vde-2/archive/refs/tags/v2.3.3.tar.gz"
+
+    license("GPL-2.0-or-later AND LGPL-2.1-or-later", checked_by="trws")
+
+    version("2.3.3", sha256="a7d2cc4c3d0c0ffe6aff7eb0029212f2b098313029126dcd12dc542723972379")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
+
+    def autoreconf(self, spec, prefix):
+        autoreconf("--install", "--verbose")


### PR DESCRIPTION
adds the lima-vm project, in order to make that useful adds a newer version of qemu so qemu VMs can work, and builds qemu with flags that allow it to do things like give the VMs networking and virtfs filesystems.

Also adds vde as a dependency of qemu.