### PR TITLE
eospac: add v6.5.10, v6.5.11

### DIFF
--- a/var/spack/repos/builtin/packages/eospac/package.py
+++ b/var/spack/repos/builtin/packages/eospac/package.py
@@ -23,8 +23,17 @@ class Eospac(Package):
     # - alpha and beta versions are marked with 'deprecated=True' to help
     #   spack's version comparison.
     version(
+        "6.5.11",
+        sha256="ed821b5a1bf45df1443d5f72d86190317ed9f5bad6a7c73e23bb4365bd76e24c",
+        url="https://laws.lanl.gov/projects/data/eos/get_file.php?package=eospac&filename=eospac_v6.5.11_e87627a204786491b3316d7fe3bda14dd9b52ce7.tgz",
+    )
+    version(
+        "6.5.10",
+        sha256="ddf8475ec41df1102ac9d85404a1954e39d8e410f0f2babafabd218cba9812eb",
+        url="https://laws.lanl.gov/projects/data/eos/get_file.php?package=eospac&filename=eospac_v6.5.10_3bf1ad6aab64ad0c665a48978315ba2383ab294f.tgz",
+    )
+    version(
         "6.5.9",
-        preferred=True,
         sha256="54df29b1dc3b35c654ef2ebfbfa42d960a230cfb2d3c04a75ba93d3a789a312a",
         url="https://laws.lanl.gov/projects/data/eos/get_file.php?package=eospac&filename=eospac_v6.5.9_4c633156bacc7b721bdd2735e40e09984a4d60a3.tgz",
     )


### PR DESCRIPTION
This PR adds versions `eospac@6.5.10` and `eospac@6.5.11` to the recipe.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
