### PR TITLE
zookeeper: add v3.8.4

### DIFF
--- a/var/spack/repos/builtin/packages/zookeeper/package.py
+++ b/var/spack/repos/builtin/packages/zookeeper/package.py
@@ -24,7 +24,9 @@ class Zookeeper(Package):
     with default_args(deprecated=True):
         # 3.6 is EoL since 30th of December, 2022
         # 3.5 is EoL since 1st of June, 2022
-        version("3.4.11", sha256="f6bd68a1c8f7c13ea4c2c99f13082d0d71ac464ffaf3bf7a365879ab6ad10e84")
+        version(
+            "3.4.11", sha256="f6bd68a1c8f7c13ea4c2c99f13082d0d71ac464ffaf3bf7a365879ab6ad10e84"
+        )
 
     depends_on("java")
 

--- a/var/spack/repos/builtin/packages/zookeeper/package.py
+++ b/var/spack/repos/builtin/packages/zookeeper/package.py
@@ -13,14 +13,15 @@ class Zookeeper(Package):
     """
 
     homepage = "https://archive.apache.org"
-    url = "https://archive.apache.org/dist/zookeeper/zookeeper-3.4.11/zookeeper-3.4.11.tar.gz"
+    urls = [
+        "https://archive.apache.org/dist/zookeeper/zookeeper-3.8.4/apache-zookeeper-3.8.4.tar.gz",
+        "https://archive.apache.org/dist/zookeeper/zookeeper-3.4.11/zookeeper-3.4.11.tar.gz",
+    ]
 
     license("Apache-2.0")
 
+    version("3.8.4", sha256="b15bf5b4e4977d04447be0c53743c57df985b6f6786c067b12821a8d79922294")
     version("3.4.11", sha256="f6bd68a1c8f7c13ea4c2c99f13082d0d71ac464ffaf3bf7a365879ab6ad10e84")
-
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
 
     def install(self, spec, prefix):
         install_tree(".", prefix)

--- a/var/spack/repos/builtin/packages/zookeeper/package.py
+++ b/var/spack/repos/builtin/packages/zookeeper/package.py
@@ -14,7 +14,7 @@ class Zookeeper(Package):
 
     homepage = "https://archive.apache.org"
     urls = [
-        "https://archive.apache.org/dist/zookeeper/zookeeper-3.8.4/apache-zookeeper-bin-3.8.4.tar.gz",
+        "https://archive.apache.org/dist/zookeeper/zookeeper-3.8.4/apache-zookeeper-3.8.4-bin.tar.gz",
         "https://archive.apache.org/dist/zookeeper/zookeeper-3.4.11/zookeeper-3.4.11.tar.gz",
     ]
 

--- a/var/spack/repos/builtin/packages/zookeeper/package.py
+++ b/var/spack/repos/builtin/packages/zookeeper/package.py
@@ -14,14 +14,24 @@ class Zookeeper(Package):
 
     homepage = "https://archive.apache.org"
     urls = [
-        "https://archive.apache.org/dist/zookeeper/zookeeper-3.8.4/apache-zookeeper-3.8.4.tar.gz",
+        "https://archive.apache.org/dist/zookeeper/zookeeper-3.8.4/apache-zookeeper-bin-3.8.4.tar.gz",
         "https://archive.apache.org/dist/zookeeper/zookeeper-3.4.11/zookeeper-3.4.11.tar.gz",
     ]
 
     license("Apache-2.0")
 
-    version("3.8.4", sha256="b15bf5b4e4977d04447be0c53743c57df985b6f6786c067b12821a8d79922294")
-    version("3.4.11", sha256="f6bd68a1c8f7c13ea4c2c99f13082d0d71ac464ffaf3bf7a365879ab6ad10e84")
+    version("3.8.4", sha256="284cb4675adb64794c63d95bf202d265cebddc0cda86ac86fb0ede8049de9187")
+    with default_args(deprecated=True):
+        # 3.6 is EoL since 30th of December, 2022
+        # 3.5 is EoL since 1st of June, 2022
+        version("3.4.11", sha256="f6bd68a1c8f7c13ea4c2c99f13082d0d71ac464ffaf3bf7a365879ab6ad10e84")
+
+    depends_on("java")
 
     def install(self, spec, prefix):
         install_tree(".", prefix)
+
+    def setup_run_environment(self, env):
+        env.set("ZOOBINDIR", self.prefix.bin)
+        env.set("ZOOCFGDIR", ".")
+        env.set("ZOO_LOG_DIR", ".")


### PR DESCRIPTION
This PR adds `zookeeper`, v3.8.4, latest stable version.

Test build:
```
==> Installing zookeeper-3.8.4-afdyqflrhxbgqmx2aab2gdajlhf5qdk7 [4/4]
==> No binary for zookeeper-3.8.4-afdyqflrhxbgqmx2aab2gdajlhf5qdk7 found: installing from source
==> Fetching https://archive.apache.org/dist/zookeeper/zookeeper-3.8.4/apache-zookeeper-3.8.4-bin.tar.gz
==> No patches needed for zookeeper
==> zookeeper: Executing phase: 'install'
==> zookeeper: Successfully installed zookeeper-3.8.4-afdyqflrhxbgqmx2aab2gdajlhf5qdk7
  Stage: 2m 6.85s.  Install: 0.36s.  Post-install: 0.40s.  Total: 2m 7.63s
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/zookeeper-3.8.4-afdyqflrhxbgqmx2aab2gdajlhf5qdk7
==> Installing zookeeper-3.4.11-hop5jkexiplqcglm3dzo247re3lesfhm [4/4]
==> No binary for zookeeper-3.4.11-hop5jkexiplqcglm3dzo247re3lesfhm found: installing from source
==> Warning: zookeeper@3.4.11 is deprecated and may be removed in a future Spack release.
==>   Fetch anyway? [y/N] y
==> Fetching https://mirror.spack.io/_source-cache/archive/f6/f6bd68a1c8f7c13ea4c2c99f13082d0d71ac464ffaf3bf7a365879ab6ad10e84.tar.gz
==> No patches needed for zookeeper
==> zookeeper: Executing phase: 'install'
==> zookeeper: Successfully installed zookeeper-3.4.11-hop5jkexiplqcglm3dzo247re3lesfhm
  Stage: 1m 0.87s.  Install: 0.46s.  Post-install: 0.50s.  Total: 1m 1.85s
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/zookeeper-3.4.11-hop5jkexiplqcglm3dzo247re3lesfhm
```

This runs fine (with a basic `zoo.cfg` in the pwd, per https://zookeeper.apache.org/doc/r3.8.2/zookeeperStarted.html#sc_InstallingSingleMode)
```
@wdconinc ➜ /workspaces/spack (packages/zookeeper-3.8.4) $ zkServer.sh start-foreground
ZooKeeper JMX enabled by default
Using config: ./zoo.cfg
16:12:51.103 [main] INFO org.apache.zookeeper.server.quorum.QuorumPeerConfig - Reading configuration from: ./zoo.cfg
16:12:51.106 [main] WARN org.apache.zookeeper.server.quorum.QuorumPeerConfig - var/zookeeper is relative. Prepend ./ to indicate that you're sure!
16:12:51.107 [main] INFO org.apache.zookeeper.server.quorum.QuorumPeerConfig - clientPortAddress is 0.0.0.0:2181
...
```
And older version still works too:
```
$ zkServer.sh start-foreground
ZooKeeper JMX enabled by default
Using config: ./zoo.cfg
log4j:WARN No appenders could be found for logger (org.apache.zookeeper.server.quorum.QuorumPeerConfig).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
...
```
```
