### PR TITLE
Fix neovim on Darwin

### DIFF
--- a/var/spack/repos/builtin/packages/lua-lpeg/package.py
+++ b/var/spack/repos/builtin/packages/lua-lpeg/package.py
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+import os
+
+import spack.build_systems.lua
 from spack.package import *
 
 
@@ -32,3 +35,36 @@ class LuaLpeg(LuaPackage):
     )
 
     depends_on("lua-lang@:5.1.9", when="@:0.12.1 ^[virtuals=lua-lang] lua")
+
+
+class LuaBuilder(spack.build_systems.lua.LuaBuilder):
+    # without this, the resulting library cannot be linked by a normal link phase, the
+    # way neovim expects to link it, works fine with lua loads though,
+    # * replaces `-bundle` from the default flags with `-shared`
+    @when("platform=darwin")
+    def generate_luarocks_config(self, pkg, spec, prefix):
+        path = super().generate_luarocks_config(pkg, spec, prefix)
+
+        with open(path, "a") as cfg:
+            cfg.write(
+                """
+
+            variables = {
+                LIBFLAG = "-shared -fPIC -undefined dynamic_lookup -all_load"
+            }
+            """
+            )
+
+        return path
+
+    # Builds searching for lpeg with darwin conventions can't find it without a dylib
+    # symlink, neovim is an example
+    @run_after("install", when="platform=darwin")
+    def create_dylib_link_and_fix_id(self):
+        lpeg_so = find(self.prefix, "lpeg.so")
+        assert len(lpeg_so) >= 1
+        dylib_path = os.path.join(self.prefix.lib, "liblpeg.dylib")
+        symlink(lpeg_so[0], dylib_path)
+        # can't use spack.filesystem.fix_darwin_install_name for this, doesn't work
+        install_name_tool = which("install_name_tool", required=True)
+        install_name_tool("-id", dylib_path, dylib_path)

--- a/var/spack/repos/builtin/packages/lua-luajit-openresty/package.py
+++ b/var/spack/repos/builtin/packages/lua-luajit-openresty/package.py
@@ -18,13 +18,13 @@ class LuaLuajitOpenresty(LuaImplPackage):
     license("MIT")
 
     version(
+        "2.1-20240626", sha256="1e53822a1105df216b9657ccb0293a152ac5afd875abc848453bfa353ca8181b"
+    )
+    version(
         "2.1-20230410", sha256="77bbcbb24c3c78f51560017288f3118d995fe71240aa379f5818ff6b166712ff"
     )
     version(
         "2.1-20220111", sha256="1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
-    )
-    version(
-        "2.1-20230410", sha256="77bbcbb24c3c78f51560017288f3118d995fe71240aa379f5818ff6b166712ff"
     )
 
     depends_on("c", type="build")  # generated
@@ -64,3 +64,11 @@ class LuaLuajitOpenresty(LuaImplPackage):
         # that unwinding symbols are not included by libc, this is necessary
         # on some platforms for the final link stage to work
         src_makefile.filter("^TARGET_LD = .*", f"TARGET_LD = {spack_cxx}")
+
+    def setup_run_environment(self, env):
+        env.prepend_path(
+            "LUA_PATH",
+            os.path.join(self.spec.prefix, "share", f"luajit-{self.version[0:2]}", "?.lua"),
+            separator=";",
+        )
+        super().setup_run_environment(env)

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -64,8 +64,8 @@ class LuaImplPackage(MakefilePackage):
 
     resource(
         name="luarocks",
-        url="https://luarocks.github.io/luarocks/releases/" "luarocks-3.8.0.tar.gz",
-        sha256="56ab9b90f5acbc42eb7a94cf482e6c058a63e8a1effdf572b8b2a6323a06d923",
+        url="https://luarocks.github.io/luarocks/releases/luarocks-3.11.1.tar.gz",
+        sha256="c3fb3d960dffb2b2fe9de7e3cb004dc4d0b34bb3d342578af84f84325c669102",
         destination="luarocks",
         placement="luarocks",
     )


### PR DESCRIPTION
This is a pile of updates to make it so that Neovim can build and work on macOS again in Sonoma.  Oddly it actually doesn't touch the Neovim package at all, but fixes up luarocks, lua-lpeg, and openresty luajit such that the Neovim build can succeed.  (The lpeg flag modification is based on what home-brew does, though not quite the same)