### PR TITLE
remove concrete spec constraint from `spack develop`

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -425,9 +425,13 @@ Developing Packages in a Spack Environment
 
 The ``spack develop`` command allows one to develop Spack packages in
 an environment. It requires a spec containing a concrete version, and
-will configure Spack to install the package from local source. By
-default, it will also clone the package to a subdirectory in the
-environment. This package will have a special variant ``dev_path``
+will configure Spack to install the package from local source. 
+If a version is not provided from teh command line interface then spack 
+will automatically pick the highest version the package has defined.
+This means any infinity versions (``develop``, ``main``, ``stable``) will be
+preferred in this selection process.
+By default, ``spack develop`` will also clone the package to a subdirectory in the
+environment for the local source. This package will have a special variant ``dev_path``
 set, and Spack will ensure the package and its dependents are rebuilt
 any time the environment is installed if the package's local source
 code has been modified. Spack's native implementation to check for modifications

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -426,7 +426,7 @@ Developing Packages in a Spack Environment
 The ``spack develop`` command allows one to develop Spack packages in
 an environment. It requires a spec containing a concrete version, and
 will configure Spack to install the package from local source. 
-If a version is not provided from teh command line interface then spack 
+If a version is not provided from the command line interface then spack 
 will automatically pick the highest version the package has defined.
 This means any infinity versions (``develop``, ``main``, ``stable``) will be
 preferred in this selection process.

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 import shutil
-from copy import copy
 
 import llnl.util.tty as tty
 
@@ -46,13 +45,6 @@ def setup_parser(subparser):
 
     subparser.add_argument(
         "-f", "--force", help="remove any files or directories that block cloning source code"
-    )
-
-    subparser.add_argument(
-        "-r",
-        "--recursive",
-        action="store_true",
-        help="traverse edges of the graph to mark everything up to the root as a develop spec",
     )
 
     arguments.add_common_arguments(subparser, ["spec"])
@@ -124,21 +116,6 @@ def develop(parser, args):
         raise SpackError("spack develop requires at most one named spec")
 
     spec = specs[0]
-    if args.recursive:
-        concrete_specs = env.all_matching_specs(spec)
-        if not concrete_specs:
-            tty.msg(
-                "No matching specs found in the environment. "
-                "Recursive develop requires a concretized environment"
-            )
-        else:
-            for cspec in concrete_specs:
-                for parent in cspec.traverse_edges(direction="parents", root=True):
-                    parent_args = copy(args)
-                    parent_args.spec = parent.spec.format("{name}@{version}")
-                    parent_args.recursive = False
-                    tty.debug(f"Recursive develop for {parent_args.spec}")
-                    develop(parser, parent_args)
 
     version = spec.versions.concrete_range_as_version
     if not version:

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -121,9 +121,8 @@ def develop(parser, args):
     if not version:
         # look up the maximum version so infintiy versions are preferred for develop
         version = max(spec.package_class.versions.keys())
-        tty.warn(
-            f"{spec.name} was not given a version to develop with. "
-            f"Defaulting to the maximal version: {spec.name}@{version}"
+        tty.msg(
+            f"Defaulting to highest version: {spec.name}@{version}"
         )
     spec.versions = spack.version.VersionList([version])
 

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -85,6 +85,12 @@ def _retrieve_develop_source(spec: spack.spec.Spec, abspath: str) -> None:
 
 
 def develop(parser, args):
+    # Note: we could put develop specs in any scope, but I assume
+    # users would only ever want to do this for either (a) an active
+    # env or (b) a specified config file (e.g. that is included by
+    # an environment)
+    # TODO: when https://github.com/spack/spack/pull/35307 is merged,
+    # an active env is not required if a scope is specified
     env = spack.cmd.require_active_env(cmd_name="develop")
     if not args.spec:
         if args.clone is False:
@@ -130,7 +136,6 @@ def develop(parser, args):
     # active environment's directory, named after the spec
     path = args.path or spec.name
     if not os.path.isabs(path):
-        env = spack.cmd.require_active_env(cmd_name="develop")
         abspath = spack.util.path.canonicalize_path(path, default_wd=env.path)
     else:
         abspath = path
@@ -154,13 +159,6 @@ def develop(parser, args):
 
         _retrieve_develop_source(spec, abspath)
 
-    # Note: we could put develop specs in any scope, but I assume
-    # users would only ever want to do this for either (a) an active
-    # env or (b) a specified config file (e.g. that is included by
-    # an environment)
-    # TODO: when https://github.com/spack/spack/pull/35307 is merged,
-    # an active env is not required if a scope is specified
-    env = spack.cmd.require_active_env(cmd_name="develop")
     tty.debug("Updating develop config for {0} transactionally".format(env.name))
     with env.write_transaction():
         if args.build_directory is not None:

--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -127,9 +127,7 @@ def develop(parser, args):
     if not version:
         # look up the maximum version so infintiy versions are preferred for develop
         version = max(spec.package_class.versions.keys())
-        tty.msg(
-            f"Defaulting to highest version: {spec.name}@{version}"
-        )
+        tty.msg(f"Defaulting to highest version: {spec.name}@{version}")
     spec.versions = spack.version.VersionList([version])
 
     # If user does not specify --path, we choose to create a directory in the

--- a/lib/spack/spack/test/cmd/develop.py
+++ b/lib/spack/spack/test/cmd/develop.py
@@ -65,6 +65,12 @@ class TestDevelop:
             develop("--no-clone", "-p", str(tmpdir), "mpich@1.0")
             self.check_develop(e, spack.spec.Spec("mpich@=1.0"), str(tmpdir))
 
+    def test_develop_no_version(self, tmpdir):
+        env("create", "test")
+        with ev.read("test") as e:
+            develop("--no-clone", "-p", str(tmpdir), "mpich")
+            self.check_develop(e, spack.spec.Spec("mpich@=main"), str(tmpdir))
+
     def test_develop(self):
         env("create", "test")
         with ev.read("test") as e:

--- a/var/spack/repos/builtin.mock/packages/mpich/package.py
+++ b/var/spack/repos/builtin.mock/packages/mpich/package.py
@@ -16,6 +16,7 @@ class Mpich(Package):
 
     variant("debug", default=False, description="Compile MPICH with debug flags.")
 
+    version("main", branch="main", git="https://github.com/pmodels/mpich")
     version("3.0.4", md5="9c5d5d4fe1e17dd12153f40bc5b6dbc0")
     version("3.0.3", md5="0123456789abcdef0123456789abcdef")
     version("3.0.2", md5="0123456789abcdef0123456789abcdef")


### PR DESCRIPTION
Remove the constraint for concrete specs and simply take the max(version) if a version is not given. This should default to the highest infinity version which is also the logical best guess for doing development.

Precursor to #46885

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
