### PR TITLE
`gimp`: Fix missing pkgconfig and gettext dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/babl/package.py
+++ b/var/spack/repos/builtin/packages/babl/package.py
@@ -15,12 +15,13 @@ class Babl(MesonPackage):
     component permutations."""
 
     homepage = "https://gegl.org/babl"
-    url = "https://download.gimp.org/babl/0.1/babl-0.1.98.tar.xz"
+    url = "https://download.gimp.org/babl/0.1/babl-0.1.108.tar.xz"
 
     maintainers("benkirk")
 
     license("LGPL-3.0-or-later")
 
+    version("0.1.108", sha256="26defe9deaab7ac4d0e076cab49c2a0d6ebd0df0c31fd209925a5f07edee1475")
     version("0.1.106", sha256="d325135d3304f088c134cc620013acf035de2e5d125a50a2d91054e7377c415f")
     version("0.1.102", sha256="a88bb28506575f95158c8c89df6e23686e50c8b9fea412bf49fe8b80002d84f0")
     version("0.1.98", sha256="f3b222f84e462735de63fa9c3651942f2b78fd314c73a22e05ff7c73afd23af1")
@@ -29,9 +30,10 @@ class Babl(MesonPackage):
     version("0.1.92", sha256="f667735028944b6375ad18f160a64ceb93f5c7dccaa9d8751de359777488a2c1")
     version("0.1.90", sha256="6e2ebb636f37581588e3d02499b3d2f69f9ac73e34a262f42911d7f5906a9243")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("cmake@3.4:", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("lcms")
     depends_on("gobject-introspection")
 

--- a/var/spack/repos/builtin/packages/gimp/package.py
+++ b/var/spack/repos/builtin/packages/gimp/package.py
@@ -32,8 +32,8 @@ class Gimp(AutotoolsPackage):
     version("2.10.26", sha256="5ddbccf1db462a41df9a26197fcb0d24c7152753a36b3c8b8a9506b4136395f7")
     version("2.10.24", sha256="bd1bb762368c0dd3175cf05006812dd676949c3707e21f4e6857435cb435989e")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     variant("doc", default=True, description="Build documentation with gtk-doc")
     variant("ghostscript", default=True, description="Build with ghostscript support")
@@ -56,6 +56,7 @@ class Gimp(AutotoolsPackage):
     # variant("python",      default=False, description="Build with Python bindings")
 
     # ref. https://www.gimp.org/source/
+    depends_on("gettext", type="build")
     depends_on("pkgconfig", type="build")
     depends_on("babl")
     depends_on("fontconfig@2.12.4:")
@@ -71,6 +72,7 @@ class Gimp(AutotoolsPackage):
     depends_on("libexif")
     # depends_on("libheif+libde265", when="+libheif")
     depends_on("libjxl", when="+jpegxl")
+    depends_on("libjxl@:0.7", when="+jpegxl@:2.10.32")
     depends_on("libmng", when="+libmng")
     depends_on("libmypaint@1.4")
     depends_on("libpng")
@@ -93,6 +95,10 @@ class Gimp(AutotoolsPackage):
         # ref: https://download.gimp.org/gimp/v2.10/gimp-2.10.32.tar.bz2"
         url = "https://download.gimp.org/gimp/v{0}/gimp-{1}.tar.bz2"
         return url.format(version.up_to(2), version)
+
+    @when("@:2.10.32")
+    def patch(self):
+        filter_file("babl ", "babl-0.1 ", "configure")
 
     def configure_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/gimp/package.py
+++ b/var/spack/repos/builtin/packages/gimp/package.py
@@ -26,11 +26,22 @@ class Gimp(AutotoolsPackage):
     license("GPL-3.0-or-later")
 
     version("2.10.38", sha256="50a845eec11c8831fe8661707950f5b8446e35f30edfb9acf98f85c1133f856e")
-    version("2.10.32", sha256="3f15c70554af5dcc1b46e6dc68f3d8f0a6cc9fe56b6d78ac08c0fd859ab89a25")
-    version("2.10.30", sha256="88815daa76ed7d4277eeb353358bafa116cd2fcd2c861d95b95135c1d52b67dc")
-    version("2.10.28", sha256="4f4dc22cff1ab5f026feaa2ab55e05775b3a11e198186b47bdab79cbfa078826")
-    version("2.10.26", sha256="5ddbccf1db462a41df9a26197fcb0d24c7152753a36b3c8b8a9506b4136395f7")
-    version("2.10.24", sha256="bd1bb762368c0dd3175cf05006812dd676949c3707e21f4e6857435cb435989e")
+    with default_args(deprecated=True):
+        version(
+            "2.10.32", sha256="3f15c70554af5dcc1b46e6dc68f3d8f0a6cc9fe56b6d78ac08c0fd859ab89a25"
+        )
+        version(
+            "2.10.30", sha256="88815daa76ed7d4277eeb353358bafa116cd2fcd2c861d95b95135c1d52b67dc"
+        )
+        version(
+            "2.10.28", sha256="4f4dc22cff1ab5f026feaa2ab55e05775b3a11e198186b47bdab79cbfa078826"
+        )
+        version(
+            "2.10.26", sha256="5ddbccf1db462a41df9a26197fcb0d24c7152753a36b3c8b8a9506b4136395f7"
+        )
+        version(
+            "2.10.24", sha256="bd1bb762368c0dd3175cf05006812dd676949c3707e21f4e6857435cb435989e"
+        )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/var/spack/repos/builtin/packages/glib-networking/package.py
+++ b/var/spack/repos/builtin/packages/glib-networking/package.py
@@ -18,9 +18,10 @@ class GlibNetworking(MesonPackage):
     version("2.65.90", sha256="91b35c5d7472d10229b0b01c0631ac171903e96f84a6fb22c4126a40528c09e2")
     version("2.65.1", sha256="d06311004f7dda4561c210f286a3678b631fb7187cb3b90616c5ba39307cc91f")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("gettext", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("glib")
     depends_on("gnutls")
     depends_on("gsettings-desktop-schemas")

--- a/var/spack/repos/builtin/packages/gsettings-desktop-schemas/package.py
+++ b/var/spack/repos/builtin/packages/gsettings-desktop-schemas/package.py
@@ -24,6 +24,7 @@ class GsettingsDesktopSchemas(MesonPackage):
     depends_on("glib")
     depends_on("gobject-introspection", type="build")
     depends_on("gettext", type="build")
+    depends_on("pkgconfig", type="build")
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.prepend_path("XDG_DATA_DIRS", self.prefix.share)

--- a/var/spack/repos/builtin/packages/libjxl/package.py
+++ b/var/spack/repos/builtin/packages/libjxl/package.py
@@ -30,6 +30,7 @@ class Libjxl(CMakePackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("cmake@3.10:", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("brotli")
     depends_on("highway")
 

--- a/var/spack/repos/builtin/packages/libmypaint/package.py
+++ b/var/spack/repos/builtin/packages/libmypaint/package.py
@@ -24,7 +24,9 @@ class Libmypaint(AutotoolsPackage):
     version("1.4.0", sha256="59d13b14c6aca0497095f29ee7228ca2499a923ba8e1dd718a2f2ecb45a9cbff")
     version("1.3.0", sha256="6a07d9d57fea60f68d218a953ce91b168975a003db24de6ac01ad69dcc94a671")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("gettext", type="build")
+    depends_on("pkgconfig", type="build")
 
     variant("gegl", default=False, description="Enable GEGL based code in build")
     variant("introspection", default=True, description="Enable introspection for this build")


### PR DESCRIPTION
This fixes the build issue reported in https://github.com/spack/spack/pull/46816#pullrequestreview-2353325989 that I ran into when I attempted to build `gimp` without `pkgconfig` and `gettext` installed on the host os:

- Many gimp dependencies were missing `depends_on("gettext", type="build")` and/or `depends_on("pkgconfig", type="build")` (more common).
- Fix an issue where `libwmf` is missing `include limits.h` in some files that shows up when using newer compilers (gcc-13+)



