### PR TITLE
Improve behavior of `spack deprecate`

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2498,6 +2498,15 @@ def deprecate(spec: "spack.spec.Spec", deprecator: "spack.spec.Spec", link_fn) -
     if not spack.store.STORE.db.query(deprecator):
         PackageInstaller([deprecator.package], explicit=True).install()
 
+    # Here we assume we don't deprecate across different stores, and that same hash
+    # means same binary artifacts
+    if spec.dag_hash() == deprecator.dag_hash():
+        return
+
+    # We can't really have control over external specs, and cannot link anything in their place
+    if spec.external:
+        return
+
     old_deprecator = spack.store.STORE.db.deprecator(spec)
     if old_deprecator:
         # Find this spec file from its old deprecation

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2494,10 +2494,6 @@ def build_process(pkg: "spack.package_base.PackageBase", install_args: dict) -> 
 
 def deprecate(spec: "spack.spec.Spec", deprecator: "spack.spec.Spec", link_fn) -> None:
     """Deprecate this package in favor of deprecator spec"""
-    # Install deprecator if it isn't installed already
-    if not spack.store.STORE.db.query(deprecator):
-        PackageInstaller([deprecator.package], explicit=True).install()
-
     # Here we assume we don't deprecate across different stores, and that same hash
     # means same binary artifacts
     if spec.dag_hash() == deprecator.dag_hash():
@@ -2506,6 +2502,10 @@ def deprecate(spec: "spack.spec.Spec", deprecator: "spack.spec.Spec", link_fn) -
     # We can't really have control over external specs, and cannot link anything in their place
     if spec.external:
         return
+
+    # Install deprecator if it isn't installed already
+    if not spack.store.STORE.db.query(deprecator):
+        PackageInstaller([deprecator.package], explicit=True).install()
 
     old_deprecator = spack.store.STORE.db.deprecator(spec)
     if old_deprecator:


### PR DESCRIPTION
fixes #46915 
extracted from #45189

The `deprecate` functions now exits early:
1. When we deprecate a spec for another with the same hash
2. When we deprecate an external spec

In the second case, the issue is that we don't have any control, nor we can make any assumption, over the prefix where the external is installed

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
