### PR TITLE
`spack ci`: Reduce noop job resource requests

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -110,8 +110,8 @@ ci:
       variables:
         GIT_STRATEGY: "none"
         CI_JOB_SIZE: "small"
-        KUBERNETES_CPU_REQUEST: "500m"
-        KUBERNETES_MEMORY_REQUEST: "500M"
+        KUBERNETES_CPU_REQUEST: "100m"
+        KUBERNETES_MEMORY_REQUEST: "5M"
       before_script:: []
       after_script:: []
 


### PR DESCRIPTION
`no-spec-to-rebuild` jobs use far less resources than they request. For example, [this](https://gitlab.spack.io/spack/spack/-/jobs/12944487) job [used](https://prometheus.spack.io/api/v1/query_range?query=container_memory_working_set_bytes{pod=%22runner-dcsgp53u-project-2-concurrent-3-0ubclrr1%22}&start=1728655743&end=1728656543&step=1s) around 3MB.

While this won't lead to any crazy cost savings, k8s requests effectively block other jobs from using the resources, so reducing this to a reasonable number is important.

cc: @alecbcs @kwryankrattiger 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
