### PR TITLE
`spack ci`: Don't require OIDC initialization for noop

### DIFF
--- a/lib/spack/spack/schema/ci.py
+++ b/lib/spack/spack/schema/ci.py
@@ -47,7 +47,7 @@ attributes_schema = {
         "tags": {"type": "array", "items": {"type": "string"}},
         "variables": {
             "type": "object",
-            "patternProperties": {r"[\w\d\-_\.]+": {"type": "string"}},
+            "patternProperties": {r"[\w\d\-_\.]+": {"type": ["string", "number"]}},
         },
         "before_script": script_schema,
         "script": script_schema,

--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -108,6 +108,7 @@ ci:
       tags: ["service"]
       image: busybox:latest
       variables:
+        CI_OIDC_REQUIRED: 0
         GIT_STRATEGY: "none"
         CI_JOB_SIZE: "small"
         KUBERNETES_CPU_REQUEST: "500m"


### PR DESCRIPTION
ref. https://github.com/spack/spack-infrastructure/pull/957

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
