### PR TITLE
ftgl: Add patch to tolerate char/unsigned char API change with update to freetype@2.13.3

### DIFF
--- a/var/spack/repos/builtin/packages/ftgl/package.py
+++ b/var/spack/repos/builtin/packages/ftgl/package.py
@@ -34,6 +34,11 @@ class Ftgl(CMakePackage):
 
     # Fix oversight in CMakeLists
     patch("remove-ftlibrary-from-sources.diff", when="@:2.4.0")
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/frankheckenbach/ftgl/pull/20.patch?full_index=1",
+        sha256="e2a0810fbf68403931bef4fbfda22e010e01421c92eeaa45f62e4e47f2381ebd",
+        when="@2.4.0"
+    )
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/ftgl/package.py
+++ b/var/spack/repos/builtin/packages/ftgl/package.py
@@ -37,7 +37,7 @@ class Ftgl(CMakePackage):
     patch(
         "https://patch-diff.githubusercontent.com/raw/frankheckenbach/ftgl/pull/20.patch?full_index=1",
         sha256="e2a0810fbf68403931bef4fbfda22e010e01421c92eeaa45f62e4e47f2381ebd",
-        when="@2.4.0"
+        when="@2.4.0",
     )
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/ftgl/package.py
+++ b/var/spack/repos/builtin/packages/ftgl/package.py
@@ -34,6 +34,7 @@ class Ftgl(CMakePackage):
 
     # Fix oversight in CMakeLists
     patch("remove-ftlibrary-from-sources.diff", when="@:2.4.0")
+    # Fix gcc14 compilation error due to type mismatch in FTContour
     patch(
         "https://patch-diff.githubusercontent.com/raw/frankheckenbach/ftgl/pull/20.patch?full_index=1",
         sha256="e2a0810fbf68403931bef4fbfda22e010e01421c92eeaa45f62e4e47f2381ebd",


### PR DESCRIPTION
@joequant
> add patch to all for compile with stricter type checks

Update by @bernhardkaindl:
- These unsigned char/char conversion errors have nothing to do with gcc-14
- They break compilation with most/all gcc/C++ compilers unless `-fpermissive` is used.
- The trigger for this error was an API change in freetype-2.13.3 that we added with #46751
- Khem Raj patched this instead using a `cast` in his fork of `ftgl:
https://github.com/kraj/ftgl/commit/37ed7d606a0dfecdcb4ab0c26d1b0132cd96d5fa

I updated #47003 to handle this now correctly.

@wdconinc Should freetype@2.13.3 stay to be the default freetype for the spack-0.23 release?

I've nothing against that, but I just wanted to update this here.