### PR TITLE
AOCC: add v5.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/aocc/package.py
+++ b/var/spack/repos/builtin/packages/aocc/package.py
@@ -34,6 +34,12 @@ class Aocc(Package, LlvmDetection, CompilerPackage):
     maintainers("amd-toolchain-support")
 
     version(
+        ver="5.0.0",
+        sha256="966fac2d2c759e9de6e969c10ada7a7b306c113f7f1e07ea376829ec86380daa",
+        url="https://download.amd.com/developer/eula/aocc/aocc-5-0/aocc-compiler-5.0.0.tar",
+        preferred=True,
+    )
+    version(
         ver="4.2.0",
         sha256="ed5a560ec745b24dc0685ccdcbde914843fb2f2dfbfce1ba592de4ffbce1ccab",
         url="https://download.amd.com/developer/eula/aocc/aocc-4-2/aocc-compiler-4.2.0.tar",


### PR DESCRIPTION
What’s new in AOCC 5.0:

- Based on LLVM 17.0.6 release (llvm.org, Nov 2023)
- Optimized support for AMD “Zen5” architecture
- Improved SLP and loop vectorization
- Improved LICM and loop optimizations
- Enhanced control/data flow optimizations
- Zen5 tuned AOCL-LibM 5.0 ([AMD Math Library](https://www.amd.com/en/developer/aocl/libm.html))