### PR TITLE
perl-*: add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/perl-alien-libxml2/package.py
+++ b/var/spack/repos/builtin/packages/perl-alien-libxml2/package.py
@@ -14,8 +14,10 @@ class PerlAlienLibxml2(PerlPackage):
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("0.19", sha256="f4a674099bbd5747c0c3b75ead841f3b244935d9ef42ba35368024bd611174c9")
     version("0.10_01", sha256="2f45b308b33503292f48bf46a75fe1e653d6b209ba5caf0628d8cc103f8d61ac")
 
     depends_on("libxml2")
     depends_on("perl-alien-build", type=("build", "run"))
+    depends_on("perl-alien-build-plugin-download-gitlab", type=("build", "run"), when="@0.18:")
     depends_on("pkgconfig", type=("build"))

--- a/var/spack/repos/builtin/packages/perl-carp-clan/package.py
+++ b/var/spack/repos/builtin/packages/perl-carp-clan/package.py
@@ -10,11 +10,18 @@ class PerlCarpClan(PerlPackage):
     """Report errors from perspective of caller of a "clan" of modules"""
 
     homepage = "https://metacpan.org/pod/Carp::Clan"
-    url = "http://search.cpan.org/CPAN/authors/id/K/KE/KENTNL/Carp-Clan-6.06.tar.gz"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Carp-Clan-6.08.tar.gz"
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("6.08", sha256="c75f92e34422cc5a65ab05d155842b701452434e9aefb649d6e2289c47ef6708")
     version("6.06", sha256="ea4ac8f611354756d43cb369880032901e9cc4cc7e0bebb7b647186dac00c9d4")
 
     depends_on("perl-test-exception", type=("build", "run"))
     depends_on("perl-sub-uplevel", type=("build", "run"))
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@6.08:"):
+            return f"https://cpan.metacpan.org/authors/id/E/ET/ETHER/Carp-Clan-{version}.tar.gz"
+        else:
+            return f"https://cpan.metacpan.org/authors/id/K/KE/KENTNL/Carp-Clan-{version}.tar.gz"

--- a/var/spack/repos/builtin/packages/perl-class-data-inheritable/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-data-inheritable/package.py
@@ -10,8 +10,15 @@ class PerlClassDataInheritable(PerlPackage):
     """For creating accessor/mutators to class data."""
 
     homepage = "https://metacpan.org/pod/Class::Data::Inheritable"
-    url = "http://search.cpan.org/CPAN/authors/id/T/TM/TMTM/Class-Data-Inheritable-0.08.tar.gz"
+    url = "https://cpan.metacpan.org/authors/id/R/RS/RSHERER/Class-Data-Inheritable-0.09.tar.gz"
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("0.09", sha256="44088d6e90712e187b8a5b050ca5b1c70efe2baa32ae123e9bd8f59f29f06e4d")
     version("0.08", sha256="9967feceea15227e442ec818723163eb6d73b8947e31f16ab806f6e2391af14a")
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@0.09:"):
+            return f"https://cpan.metacpan.org/authors/id/R/RS/RSHERER/Class-Data-Inheritable-{version}.tar.gz"
+        else:
+            return f"https://cpan.metacpan.org/authors/id/T/TM/TMTM/Class-Data-Inheritable-{version}.tar.gz"

--- a/var/spack/repos/builtin/packages/perl-cpan-meta-check/package.py
+++ b/var/spack/repos/builtin/packages/perl-cpan-meta-check/package.py
@@ -15,6 +15,7 @@ class PerlCpanMetaCheck(PerlPackage):
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("0.018", sha256="f619d2df5ea0fd91c8cf83eb54acccb5e43d9e6ec1a3f727b3d0ac15d0cf378a")
     version("0.017", sha256="0454ab93f12780b1d579df15b5f939e09702e954be82028fadd40e8bc9b0f091")
     version("0.014", sha256="28a0572bfc1c0678d9ce7da48cf521097ada230f96eb3d063fcbae1cfe6a351f")
 

--- a/var/spack/repos/builtin/packages/perl-data-optlist/package.py
+++ b/var/spack/repos/builtin/packages/perl-data-optlist/package.py
@@ -14,6 +14,7 @@ class PerlDataOptlist(PerlPackage):
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("0.114", sha256="9fd1093b917a21fb79ae1607db53d113b4e0ad8fe0ae776cb077a7e50044fdf3")
     version("0.113", sha256="36aebc5817b7d4686b649434c2ee41f45c8bf97d4ca5a99f607cc40f695a4285")
     version("0.110", sha256="366117cb2966473f2559f2f4575ff6ae69e84c69a0f30a0773e1b51a457ef5c3")
 

--- a/var/spack/repos/builtin/packages/perl-extutils-config/package.py
+++ b/var/spack/repos/builtin/packages/perl-extutils-config/package.py
@@ -14,5 +14,6 @@ class PerlExtutilsConfig(PerlPackage):
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("0.010", sha256="82e7e4e90cbe380e152f5de6e3e403746982d502dd30197a123652e46610c66d")
     version("0.009", sha256="4ef84e73aad50a3be332885d2a3b12f3cab1b1e0bad24e88297a123b4f39f3ce")
     version("0.008", sha256="ae5104f634650dce8a79b7ed13fb59d67a39c213a6776cfdaa3ee749e62f1a8c")

--- a/var/spack/repos/builtin/packages/perl-file-listing/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-listing/package.py
@@ -10,10 +10,17 @@ class PerlFileListing(PerlPackage):
     """Parse directory listing"""
 
     homepage = "https://metacpan.org/pod/File::Listing"
-    url = "http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/File-Listing-6.04.tar.gz"
+    url = "https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/File-Listing-6.16.tar.gz"
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("6.16", sha256="189b3a13fc0a1ba412b9d9ec5901e9e5e444cc746b9f0156d4399370d33655c6")
     version("6.04", sha256="1e0050fcd6789a2179ec0db282bf1e90fb92be35d1171588bd9c47d52d959cf5")
 
     depends_on("perl-http-date", type=("build", "run"))
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@6.05:"):
+            return f"https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/File-Listing-{version}.tar.gz"
+        else:
+            return f"http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/File-Listing-{version}.tar.gz"

--- a/var/spack/repos/builtin/packages/perl-file-listing/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-listing/package.py
@@ -21,6 +21,10 @@ class PerlFileListing(PerlPackage):
 
     def url_for_version(self, version):
         if self.spec.satisfies("@6.05:"):
-            return f"https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/File-Listing-{version}.tar.gz"
+            return (
+                f"https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/File-Listing-{version}.tar.gz"
+            )
         else:
-            return f"http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/File-Listing-{version}.tar.gz"
+            return (
+                f"http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/File-Listing-{version}.tar.gz"
+            )

--- a/var/spack/repos/builtin/packages/perl-http-cookies/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-cookies/package.py
@@ -14,6 +14,7 @@ class PerlHttpCookies(PerlPackage):
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("6.11", sha256="8c9a541a4a39f6c0c7e3d0b700b05dfdb830bd490a1b1942a7dedd1b50d9a8c8")
     version("6.10", sha256="e36f36633c5ce6b5e4b876ffcf74787cc5efe0736dd7f487bdd73c14f0bd7007")
     version("6.04", sha256="0cc7f079079dcad8293fea36875ef58dd1bfd75ce1a6c244cd73ed9523eb13d4")
 

--- a/var/spack/repos/builtin/packages/perl-http-daemon/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-daemon/package.py
@@ -24,7 +24,9 @@ class PerlHttpDaemon(PerlPackage):
 
     def url_for_version(self, version):
         if self.spec.satisfies("@6.02:"):
-            return f"https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Daemon-{version}.tar.gz"
+            return (
+                f"https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Daemon-{version}.tar.gz"
+            )
         elif self.spec.satisfies("@6.05"):
             return f"https://cpan.metacpan.org/authors/id/E/ET/ETHER/HTTP-Daemon-{version}.tar.gz"
         else:

--- a/var/spack/repos/builtin/packages/perl-http-daemon/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-daemon/package.py
@@ -10,13 +10,22 @@ class PerlHttpDaemon(PerlPackage):
     """A simple http server class"""
 
     homepage = "https://metacpan.org/pod/HTTP::Daemon"
-    url = "http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/HTTP-Daemon-6.01.tar.gz"
+    url = "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Daemon-6.16.tar.gz"
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("6.16", sha256="b38d092725e6fa4e0c4dc2a47e157070491bafa0dbe16c78a358e806aa7e173d")
     version("6.01", sha256="43fd867742701a3f9fcc7bd59838ab72c6490c0ebaf66901068ec6997514adc2")
 
     depends_on("perl-lwp-mediatypes", type=("build", "run"))
     depends_on("perl-http-message", type=("build", "run"))
     depends_on("perl-http-date", type=("build", "run"))
     depends_on("perl-module-build-tiny", type="build")
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@6.02:"):
+            return f"https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Daemon-{version}.tar.gz"
+        elif self.spec.satisfies("@6.05"):
+            return f"https://cpan.metacpan.org/authors/id/E/ET/ETHER/HTTP-Daemon-{version}.tar.gz"
+        else:
+            return f"http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/HTTP-Daemon-{version}.tar.gz"

--- a/var/spack/repos/builtin/packages/perl-http-date/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-date/package.py
@@ -10,8 +10,15 @@ class PerlHttpDate(PerlPackage):
     """Date conversion routines"""
 
     homepage = "https://metacpan.org/pod/HTTP::Date"
-    url = "http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/HTTP-Date-6.02.tar.gz"
+    url = "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Date-6.06.tar.gz"
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("6.06", sha256="7b685191c6acc3e773d1fc02c95ee1f9fae94f77783175f5e78c181cc92d2b52")
     version("6.02", sha256="e8b9941da0f9f0c9c01068401a5e81341f0e3707d1c754f8e11f42a7e629e333")
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@6.03:"):
+            return f"https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Date-{version}.tar.gz"
+        else:
+            return f"http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/HTTP-Date-{version}.tar.gz"

--- a/var/spack/repos/builtin/packages/perl-io-socket-ssl/package.py
+++ b/var/spack/repos/builtin/packages/perl-io-socket-ssl/package.py
@@ -14,6 +14,7 @@ class PerlIoSocketSsl(PerlPackage):
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("2.089", sha256="f683112c1642967e9149f51ad553eccd017833b2f22eb23a9055609d2e3a14d1")
     version("2.085", sha256="95b2f7c0628a7e246a159665fbf0620d0d7835e3a940f22d3fdd47c3aa799c2e")
     version("2.052", sha256="e4897a9b17cb18a3c44aa683980d52cef534cdfcb8063d6877c879bfa2f26673")
 

--- a/var/spack/repos/builtin/packages/perl-io-stringy/package.py
+++ b/var/spack/repos/builtin/packages/perl-io-stringy/package.py
@@ -21,6 +21,13 @@ class PerlIoStringy(PerlPackage):
     globref, or a FileHandle."""
 
     homepage = "https://metacpan.org/pod/IO::Stringy"
-    url = "https://cpan.metacpan.org/authors/id/D/DS/DSKOLL/IO-stringy-2.111.tar.gz"
+    url = "https://cpan.metacpan.org/authors/id/C/CA/CAPOEIRAB/IO-Stringy-2.112.tar.gz"
 
+    version("2.113", sha256="51220fcaf9f66a639b69d251d7b0757bf4202f4f9debd45bdd341a6aca62fe4e")
     version("2.111", sha256="8c67fd6608c3c4e74f7324f1404a856c331dbf48d9deda6aaa8296ea41bf199d")
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@2.112:"):
+            return f"https://cpan.metacpan.org/authors/id/C/CA/CAPOEIRAB/IO-Stringy-{version}.tar.gz"
+        else:
+            return f"https://cpan.metacpan.org/authors/id/D/DS/DSKOLL/IO-stringy-{version}.tar.gz"

--- a/var/spack/repos/builtin/packages/perl-io-stringy/package.py
+++ b/var/spack/repos/builtin/packages/perl-io-stringy/package.py
@@ -28,6 +28,8 @@ class PerlIoStringy(PerlPackage):
 
     def url_for_version(self, version):
         if self.spec.satisfies("@2.112:"):
-            return f"https://cpan.metacpan.org/authors/id/C/CA/CAPOEIRAB/IO-Stringy-{version}.tar.gz"
+            return (
+                f"https://cpan.metacpan.org/authors/id/C/CA/CAPOEIRAB/IO-Stringy-{version}.tar.gz"
+            )
         else:
             return f"https://cpan.metacpan.org/authors/id/D/DS/DSKOLL/IO-stringy-{version}.tar.gz"

--- a/var/spack/repos/builtin/packages/perl-ipc-run3/package.py
+++ b/var/spack/repos/builtin/packages/perl-ipc-run3/package.py
@@ -14,4 +14,5 @@ class PerlIpcRun3(PerlPackage):
 
     maintainers("EbiArnie")
 
+    version("0.049", sha256="9d048ae7b9ae63871bae976ba01e081d887392d904e5d48b04e22d35ed22011a")
     version("0.048", sha256="3d81c3cc1b5cff69cca9361e2c6e38df0352251ae7b41e2ff3febc850e463565")

--- a/var/spack/repos/builtin/packages/perl-lwp-mediatypes/package.py
+++ b/var/spack/repos/builtin/packages/perl-lwp-mediatypes/package.py
@@ -10,8 +10,15 @@ class PerlLwpMediatypes(PerlPackage):
     """Guess media type for a file or a URL"""
 
     homepage = "https://metacpan.org/pod/LWP::MediaTypes"
-    url = "http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/LWP-MediaTypes-6.02.tar.gz"
+    url = "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/LWP-MediaTypes-6.04.tar.gz"
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("6.04", sha256="8f1bca12dab16a1c2a7c03a49c5e58cce41a6fec9519f0aadfba8dad997919d9")
     version("6.02", sha256="18790b0cc5f0a51468495c3847b16738f785a2d460403595001e0b932e5db676")
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@6.03:"):
+            return f"https://cpan.metacpan.org/authors/id/O/OA/OALDERS/LWP-MediaTypes-{version}.tar.gz"
+        else:
+            return f"http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/LWP-MediaTypes-{version}.tar.gz"

--- a/var/spack/repos/builtin/packages/perl-lwp-mediatypes/package.py
+++ b/var/spack/repos/builtin/packages/perl-lwp-mediatypes/package.py
@@ -21,4 +21,6 @@ class PerlLwpMediatypes(PerlPackage):
         if self.spec.satisfies("@6.03:"):
             return f"https://cpan.metacpan.org/authors/id/O/OA/OALDERS/LWP-MediaTypes-{version}.tar.gz"
         else:
-            return f"http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/LWP-MediaTypes-{version}.tar.gz"
+            return (
+                f"http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/LWP-MediaTypes-{version}.tar.gz"
+            )

--- a/var/spack/repos/builtin/packages/perl-lwp-protocol-https/package.py
+++ b/var/spack/repos/builtin/packages/perl-lwp-protocol-https/package.py
@@ -10,10 +10,11 @@ class PerlLwpProtocolHttps(PerlPackage):
     """Provide https support for LWP::UserAgent"""
 
     homepage = "https://metacpan.org/pod/LWP::Protocol::https"
-    url = "http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/LWP-Protocol-https-6.04.tar.gz"
+    url = "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/LWP-Protocol-https-6.14.tar.gz"
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("6.14", sha256="59cdeabf26950d4f1bef70f096b0d77c5b1c5a7b5ad1b66d71b681ba279cbb2a")
     version("6.04", sha256="1ef67750ee363525cf729b59afde805ac4dc80eaf8d36ca01082a4d78a7af629")
 
     depends_on("perl-test-requiresinternet", type=("build", "run"))
@@ -21,3 +22,9 @@ class PerlLwpProtocolHttps(PerlPackage):
     depends_on("perl-net-http", type=("build", "run"))
     depends_on("perl-mozilla-ca", type=("build", "run"))
     depends_on("perl-libwww-perl", type=("build", "run"))
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@6.07:"):
+            return f"https://cpan.metacpan.org/authors/id/O/OA/OALDERS/LWP-Protocol-https-{version}.tar.gz"
+        else:
+            return f"http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/LWP-Protocol-https-{version}.tar.gz"

--- a/var/spack/repos/builtin/packages/perl-net-ssleay/package.py
+++ b/var/spack/repos/builtin/packages/perl-net-ssleay/package.py
@@ -10,10 +10,11 @@ class PerlNetSsleay(PerlPackage):
     """Perl extension for using OpenSSL"""
 
     homepage = "https://metacpan.org/pod/Net::SSLeay"
-    url = "http://search.cpan.org/CPAN/authors/id/M/MI/MIKEM/Net-SSLeay-1.82.tar.gz"
+    url = "https://cpan.metacpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.94.tar.gz"
 
     license("Artistic-2.0")
 
+    version("1.94", sha256="9d7be8a56d1bedda05c425306cc504ba134307e0c09bda4a788c98744ebcd95d")
     version("1.85", sha256="9d8188b9fb1cae3bd791979c20554925d5e94a138d00414f1a6814549927b0c8")
     version("1.82", sha256="5895c519c9986a5e5af88e3b8884bbdc70e709ee829dc6abb9f53155c347c7e5")
 
@@ -34,3 +35,9 @@ class PerlNetSsleay(PerlPackage):
         with open(config_answers_filename, "r") as f:
             env["OPENSSL_PREFIX"] = self.spec["openssl"].prefix
             perl("Makefile.PL", "INSTALL_BASE={0}".format(prefix), input=f)
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@1.86:"):
+            return f"https://cpan.metacpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-{version}.tar.gz"
+        else:
+            return f"http://search.cpan.org/CPAN/authors/id/M/MI/MIKEM/Net-SSLeay-{version}.tar.gz"

--- a/var/spack/repos/builtin/packages/perl-package-stash-xs/package.py
+++ b/var/spack/repos/builtin/packages/perl-package-stash-xs/package.py
@@ -10,8 +10,15 @@ class PerlPackageStashXs(PerlPackage):
     """Faster and more correct implementation of the Package::Stash API"""
 
     homepage = "https://metacpan.org/pod/Package::Stash::XS"
-    url = "http://search.cpan.org/CPAN/authors/id/D/DO/DOY/Package-Stash-XS-0.28.tar.gz"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Package-Stash-XS-0.30.tar.gz"
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("0.30", sha256="26bad65c1959c57379b3e139dc776fbec5f702906617ef27cdc293ddf1239231")
     version("0.28", sha256="23d8c5c25768ef1dc0ce53b975796762df0d6e244445d06e48d794886c32d486")
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@0.29:"):
+            return f"https://cpan.metacpan.org/authors/id/E/ET/ETHER/Package-Stash-XS-{version}.tar.gz"
+        else:
+            return f"http://search.cpan.org/CPAN/authors/id/D/DO/DOY/Package-Stash-XS-{version}.tar.gz"

--- a/var/spack/repos/builtin/packages/perl-package-stash/package.py
+++ b/var/spack/repos/builtin/packages/perl-package-stash/package.py
@@ -24,6 +24,10 @@ class PerlPackageStash(PerlPackage):
 
     def url_for_version(self, version):
         if self.spec.satisfies("@0.38:"):
-            return f"https://cpan.metacpan.org/authors/id/E/ET/ETHER/Package-Stash-{version}.tar.gz"
+            return (
+                f"https://cpan.metacpan.org/authors/id/E/ET/ETHER/Package-Stash-{version}.tar.gz"
+            )
         else:
-            return f"http://search.cpan.org/CPAN/authors/id/D/DO/DOY/Package-Stash-{version}.tar.gz"
+            return (
+                f"http://search.cpan.org/CPAN/authors/id/D/DO/DOY/Package-Stash-{version}.tar.gz"
+            )

--- a/var/spack/repos/builtin/packages/perl-package-stash/package.py
+++ b/var/spack/repos/builtin/packages/perl-package-stash/package.py
@@ -10,13 +10,20 @@ class PerlPackageStash(PerlPackage):
     """Routines for manipulating stashes"""
 
     homepage = "https://metacpan.org/pod/Package::Stash"
-    url = "http://search.cpan.org/CPAN/authors/id/D/DO/DOY/Package-Stash-0.37.tar.gz"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Package-Stash-0.40.tar.gz"
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("0.40", sha256="5a9722c6d9cb29ee133e5f7b08a5362762a0b5633ff5170642a5b0686e95e066")
     version("0.37", sha256="06ab05388f9130cd377c0e1d3e3bafeed6ef6a1e22104571a9e1d7bfac787b2c")
 
     depends_on("perl-test-requires", type=("build", "run"))
     depends_on("perl-test-fatal", type=("build", "run"))
     depends_on("perl-module-implementation", type=("build", "run"))
     depends_on("perl-dist-checkconflicts", type=("build", "run"))
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@0.38:"):
+            return f"https://cpan.metacpan.org/authors/id/E/ET/ETHER/Package-Stash-{version}.tar.gz"
+        else:
+            return f"http://search.cpan.org/CPAN/authors/id/D/DO/DOY/Package-Stash-{version}.tar.gz"

--- a/var/spack/repos/builtin/packages/perl-params-util/package.py
+++ b/var/spack/repos/builtin/packages/perl-params-util/package.py
@@ -19,6 +19,10 @@ class PerlParamsUtil(PerlPackage):
 
     def url_for_version(self, version):
         if self.spec.satisfies("@1.099:"):
-            return f"https://cpan.metacpan.org/authors/id/R/RE/REHSACK/Params-Util-{version}.tar.gz"
+            return (
+                f"https://cpan.metacpan.org/authors/id/R/RE/REHSACK/Params-Util-{version}.tar.gz"
+            )
         else:
-            return f"http://search.cpan.org/CPAN/authors/id/A/AD/ADAMK/Params-Util-{version}.tar.gz"
+            return (
+                f"http://search.cpan.org/CPAN/authors/id/A/AD/ADAMK/Params-Util-{version}.tar.gz"
+            )

--- a/var/spack/repos/builtin/packages/perl-params-util/package.py
+++ b/var/spack/repos/builtin/packages/perl-params-util/package.py
@@ -10,8 +10,15 @@ class PerlParamsUtil(PerlPackage):
     """Simple, compact and correct param-checking functions"""
 
     homepage = "https://metacpan.org/pod/Params::Util"
-    url = "http://search.cpan.org/CPAN/authors/id/A/AD/ADAMK/Params-Util-1.07.tar.gz"
+    url = "https://cpan.metacpan.org/authors/id/R/RE/REHSACK/Params-Util-1.102.tar.gz"
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("1.102", sha256="499bb1b482db24fda277a51525596ad092c2bd51dd508fa8fec2e9f849097402")
     version("1.07", sha256="30f1ec3f2cf9ff66ae96f973333f23c5f558915bb6266881eac7423f52d7c76c")
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@1.099:"):
+            return f"https://cpan.metacpan.org/authors/id/R/RE/REHSACK/Params-Util-{version}.tar.gz"
+        else:
+            return f"http://search.cpan.org/CPAN/authors/id/A/AD/ADAMK/Params-Util-{version}.tar.gz"

--- a/var/spack/repos/builtin/packages/perl-task-weaken/package.py
+++ b/var/spack/repos/builtin/packages/perl-task-weaken/package.py
@@ -21,4 +21,6 @@ class PerlTaskWeaken(PerlPackage):
         if self.spec.satisfies("@1.05:"):
             return f"https://cpan.metacpan.org/authors/id/E/ET/ETHER/Task-Weaken-{version}.tar.gz"
         else:
-            return f"http://search.cpan.org/CPAN/authors/id/A/AD/ADAMK/Task-Weaken-{version}.tar.gz"
+            return (
+                f"http://search.cpan.org/CPAN/authors/id/A/AD/ADAMK/Task-Weaken-{version}.tar.gz"
+            )

--- a/var/spack/repos/builtin/packages/perl-task-weaken/package.py
+++ b/var/spack/repos/builtin/packages/perl-task-weaken/package.py
@@ -10,8 +10,15 @@ class PerlTaskWeaken(PerlPackage):
     """Ensure that a platform has weaken support"""
 
     homepage = "https://metacpan.org/pod/Task::Weaken"
-    url = "http://search.cpan.org/CPAN/authors/id/A/AD/ADAMK/Task-Weaken-1.04.tar.gz"
+    url = "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Task-Weaken-1.06.tar.gz"
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("1.06", sha256="2383fedb9dbaef646468ea824afbf7c801076720cfba0df2a7a074726dcd66be")
     version("1.04", sha256="67e271c55900fe7889584f911daa946e177bb60c8af44c32f4584b87766af3c4")
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@1.05:"):
+            return f"https://cpan.metacpan.org/authors/id/E/ET/ETHER/Task-Weaken-{version}.tar.gz"
+        else:
+            return f"http://search.cpan.org/CPAN/authors/id/A/AD/ADAMK/Task-Weaken-{version}.tar.gz"

--- a/var/spack/repos/builtin/packages/perl-task-weaken/package.py
+++ b/var/spack/repos/builtin/packages/perl-task-weaken/package.py
@@ -17,6 +17,8 @@ class PerlTaskWeaken(PerlPackage):
     version("1.06", sha256="2383fedb9dbaef646468ea824afbf7c801076720cfba0df2a7a074726dcd66be")
     version("1.04", sha256="67e271c55900fe7889584f911daa946e177bb60c8af44c32f4584b87766af3c4")
 
+    depends_on("perl-module-install", type="build", when="@:1.04")
+
     def url_for_version(self, version):
         if self.spec.satisfies("@1.05:"):
             return f"https://cpan.metacpan.org/authors/id/E/ET/ETHER/Task-Weaken-{version}.tar.gz"

--- a/var/spack/repos/builtin/packages/perl-test-output/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-output/package.py
@@ -13,6 +13,7 @@ class PerlTestOutput(PerlPackage):
     url = "https://github.com/briandfoy/test-output/archive/release-1.033.tar.gz"
     license("Artistic-2.0")
 
+    version("1.034", sha256="cc016f9c89d3a22f461cb88318f53b03645eaec4025d483ae3bd52a166af5f72")
     version("1.033", sha256="35f0a4ef2449fc78886b4c99e1c1d23f432c2fae98538a4489439eb17223bfc2")
     version("1.032", sha256="8b87e16b40199c9d62f07a821e1ff17a2701e42adffb281a649ed631823d5771")
     version("1.031", sha256="1bb5847f26bee90e71b0af2a9d3a5eec4e17a63aacaf18ce5215f350961c5bf7")

--- a/var/spack/repos/builtin/packages/perl-timedate/package.py
+++ b/var/spack/repos/builtin/packages/perl-timedate/package.py
@@ -12,8 +12,15 @@ class PerlTimedate(PerlPackage):
     modules by David Muir on CPAN."""
 
     homepage = "https://metacpan.org/release/TimeDate"
-    url = "https://cpan.metacpan.org/authors/id/G/GB/GBARR/TimeDate-2.30.tar.gz"
+    url = "https://cpan.metacpan.org/authors/id/A/AT/ATOOMIC/TimeDate-2.33.tar.gz"
 
     license("GPL-1.0-or-later OR Artistic-1.0-Perl")
 
+    version("2.33", sha256="c0b69c4b039de6f501b0d9f13ec58c86b040c1f7e9b27ef249651c143d605eb2")
     version("2.30", sha256="75bd254871cb5853a6aa0403ac0be270cdd75c9d1b6639f18ecba63c15298e86")
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@2.31:"):
+            return f"https://cpan.metacpan.org/authors/id/A/AT/ATOOMIC/TimeDate-{version}.tar.gz"
+        else:
+            return f"https://cpan.metacpan.org/authors/id/G/GB/GBARR/TimeDate-{version}.tar.gz"


### PR DESCRIPTION
This PR adds new versions of a number of perl packages ([outdated in spack, but up-to-date in at least 20 other package repositories](https://repology.org/projects/?search=perl%3A&maintainer=&category=&inrepo=spack&notinrepo=&repos=&families=&repos_newest=&families_newest=20-&outdated=on)). In serveral cases this has meant adding an `url_for_version` function since a new maintainer has taken over on metacpan.org.

Test build:
```
whrl74h perl@5.40.0+cpanm+opcode+open+shared+threads build_system=generic
idjblty perl-alien-build@2.78 build_system=perl
t4eztpi perl-alien-build-plugin-download-gitlab@0.01 build_system=perl
lpkiklz perl-alien-libxml2@0.19 build_system=perl
vexi74a perl-capture-tiny@0.48 build_system=perl
mz5zadr perl-carp-clan@6.08 build_system=perl
lkrkqpm perl-class-data-inheritable@0.09 build_system=perl
uozi4xl perl-clone@0.46 build_system=perl
3mca2ds perl-cpan-meta-check@0.018 build_system=perl
7nz7yn2 perl-data-optlist@0.114 build_system=perl
ntuh5ul perl-dist-checkconflicts@0.11 build_system=perl
5xyvkbu perl-encode-locale@1.05 build_system=perl
k6a6s6z perl-extutils-config@0.010 build_system=perl
qoyfgys perl-extutils-helpers@0.026 build_system=perl
aqnrbo3 perl-extutils-installpaths@0.013 build_system=perl
3ci275c perl-extutils-makemaker@7.70 build_system=perl
2gydlbh perl-ffi-checklib@0.31 build_system=perl
ccibm4u perl-file-chdir@0.1011 build_system=perl
prmdhq7 perl-file-listing@6.16 build_system=perl
s6ts4qd perl-file-which@1.27 build_system=perl
pm2toll perl-html-parser@3.72 build_system=perl
i5pxf5z perl-html-tagset@3.24 build_system=perl
ujv5g3y perl-http-cookies@6.11 build_system=perl
euytk4i perl-http-daemon@6.16 build_system=perl
exdf53k perl-http-date@6.06 build_system=perl
bkiivnu perl-http-message@6.45 build_system=perl
jelfu4c perl-http-negotiate@6.01 build_system=perl
qxxylyh perl-io-html@1.004 build_system=perl
boconko perl-io-socket-ssl@2.089 build_system=perl
3nvyk6k perl-io-stringy@2.113 build_system=perl
2ifn2dq perl-ipc-run3@0.049 build_system=perl
s4quop7 perl-libwww-perl@6.68 build_system=perl
llkcj6w perl-lwp-mediatypes@6.04 build_system=perl
3qzsww7 perl-lwp-protocol-https@6.14 build_system=perl
7c3xnwi perl-module-build@0.4234 build_system=perl
l5cyhyt perl-module-build-tiny@0.048 build_system=perl
w475z6l perl-module-implementation@0.09 build_system=perl
y3cgfzk perl-module-runtime@0.016 build_system=perl
vpbedtk perl-mozilla-ca@20160104 build_system=perl
dqox4n5 perl-net-http@6.23 build_system=perl
3vs7dnf perl-net-ssleay@1.94 build_system=perl
ur2pkoy perl-package-stash@0.40 build_system=perl
y3omhbr perl-package-stash-xs@0.30 build_system=perl
hzrsudt perl-params-util@1.102 build_system=perl
kix4vai perl-path-tiny@0.146 build_system=perl
oqnm3bm perl-sub-install@0.929 build_system=perl
p3tnkbr perl-sub-uplevel@0.2800 build_system=perl
kwcfhxn perl-task-weaken@1.06 build_system=perl
ryodajs perl-term-table@0.018 build_system=perl
zqnyajt perl-test-deep@1.204 build_system=perl
j5ofblu perl-test-exception@0.43 build_system=perl
nphv5vd perl-test-fatal@0.017 build_system=perl
gcmxnkb perl-test-needs@0.002010 build_system=perl
whdoqij perl-test-requires@0.11 build_system=perl
dmvo2zf perl-test-requiresinternet@0.05 build_system=perl
u5kck55 perl-test2-suite@0.000159 build_system=perl
vlwag75 perl-timedate@2.33 build_system=perl
vg6qcbj perl-try-tiny@0.31 build_system=perl
nlqaovi perl-uri@5.08 build_system=perl
3mvuhwl perl-www-robotrules@6.02 build_system=perl
```
