### PR TITLE
popt: add v1.19; fix url and homepage

### DIFF
--- a/var/spack/repos/builtin/packages/popt/package.py
+++ b/var/spack/repos/builtin/packages/popt/package.py
@@ -9,16 +9,23 @@ from spack.package import *
 class Popt(AutotoolsPackage):
     """The popt library parses command line options."""
 
-    homepage = "https://launchpad.net/popt"
-    url = "https://launchpad.net/popt/head/1.16/+download/popt-1.16.tar.gz"
+    homepage = "https://github.com/rpm-software-management/popt"
+    url = "https://ftp.osuosl.org/pub/rpm/popt/releases/popt-1.x/popt-1.19.tar.gz"
 
     license("MIT")
 
+    version("1.19", sha256="c25a4838fc8e4c1c8aacb8bd620edb3084a3d63bf8987fdad3ca2758c63240f9")
     version("1.16", sha256="e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("iconv")
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@1.18:"):
+            return f"https://ftp.osuosl.org/pub/rpm/popt/releases/popt-{version.up_to(1)}.x/popt-{version}.tar.gz"
+        else:
+            return f"https://launchpad.net/popt/head/{version}/+download/popt-{version}.tar.gz"
 
     def patch(self):
         # Remove flags not recognized by the NVIDIA compilers


### PR DESCRIPTION
This PR adds `popt`, v1.19, and fixes the url. This is now maintained and distributed via OSU, not launchpad. The github master branch has cmake, but 1.19 is still autotools.

Test build:
```
==> Installing popt-1.19-fizbpt7lejelexbubr36wklykm3ttni6 [5/5]
==> No binary for popt-1.19-fizbpt7lejelexbubr36wklykm3ttni6 found: installing from source
==> Fetching https://ftp.osuosl.org/pub/rpm/popt/releases/popt-1.x/popt-1.19.tar.gz
==> Ran patch() for popt
==> popt: Executing phase: 'autoreconf'
==> popt: Executing phase: 'configure'
==> popt: Executing phase: 'build'
==> popt: Executing phase: 'install'
==> popt: Successfully installed popt-1.19-fizbpt7lejelexbubr36wklykm3ttni6
  Stage: 0.84s.  Autoreconf: 0.00s.  Configure: 3.78s.  Build: 2.47s.  Install: 0.27s.  Post-install: 0.12s.  Total: 7.61s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/popt-1.19-fizbpt7lejelexbubr36wklykm3ttni6
```