### PR TITLE
dosfstools: add v4.2

### DIFF
--- a/var/spack/repos/builtin/packages/dosfstools/package.py
+++ b/var/spack/repos/builtin/packages/dosfstools/package.py
@@ -25,6 +25,11 @@ class Dosfstools(AutotoolsPackage):
     depends_on("autoconf", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
+    depends_on("gettext", when="@4.2:") # for HAVE_ICONV
+
+    @when("@4.2:")
+    def autoreconf(self, spec, prefix):
+        Executable("./autogen.sh")()
 
     def setup_run_environment(self, env):
         env.prepend_path("PATH", self.prefix.sbin)

--- a/var/spack/repos/builtin/packages/dosfstools/package.py
+++ b/var/spack/repos/builtin/packages/dosfstools/package.py
@@ -25,7 +25,7 @@ class Dosfstools(AutotoolsPackage):
     depends_on("autoconf", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("gettext", when="@4.2:") # for HAVE_ICONV
+    depends_on("gettext", when="@4.2:")  # for HAVE_ICONV
 
     @when("@4.2:")
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/dosfstools/package.py
+++ b/var/spack/repos/builtin/packages/dosfstools/package.py
@@ -15,10 +15,11 @@ class Dosfstools(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
+    version("4.2", sha256="355a6725524b50e64ae94060ed28579e0e004c519fc964f7085188cd87a99ba7")
     version("4.1", sha256="8ff9c2dcc01551fe9de8888cb41eb1051fd58bdf1ab3a93d3d88916f0a4ffd1b")
     version("4.0", sha256="77975e289e695cb8c984a3c0a15a3bbf3af90be83c26983d43abcde9ec48eea5")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("automake", type="build")
     depends_on("autoconf", type="build")


### PR DESCRIPTION
This PR adds `dosfstools`, v4.2, no build system or dependency changes.

Test build:
```
==> Installing dosfstools-4.2-mp5vby2yxcqkpu5oijm4vslqk3x7qjw5 [24/24]
==> No binary for dosfstools-4.2-mp5vby2yxcqkpu5oijm4vslqk3x7qjw5 found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/35/355a6725524b50e64ae94060ed28579e0e004c519fc964f7085188cd87a99ba7.tar.gz
==> No patches needed for dosfstools
==> dosfstools: Executing phase: 'autoreconf'
==> dosfstools: Executing phase: 'configure'
==> dosfstools: Executing phase: 'build'
==> dosfstools: Executing phase: 'install'
==> dosfstools: Successfully installed dosfstools-4.2-mp5vby2yxcqkpu5oijm4vslqk3x7qjw5
  Stage: 0.01s.  Autoreconf: 0.95s.  Configure: 2.46s.  Build: 1.44s.  Install: 0.06s.  Post-install: 0.11s.  Total: 5.11s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/dosfstools-4.2-mp5vby2yxcqkpu5oijm4vslqk3x7qjw5
```