### PR TITLE
libarchive: add v3.7.5, v3.7.6 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/libarchive/package.py
+++ b/var/spack/repos/builtin/packages/libarchive/package.py
@@ -17,14 +17,18 @@ class Libarchive(AutotoolsPackage):
 
     license("BSD-2-Clause AND BSD-3-Clause AND Public-Domain")
 
-    version("3.7.4", sha256="7875d49596286055b52439ed42f044bd8ad426aa4cc5aabd96bfe7abb971d5e8")
-    version("3.7.3", sha256="f27a97bc22ceb996e72502df47dc19f99f9a0f09181ae909f09f3c9eb17b67e2")
-    version("3.7.2", sha256="df404eb7222cf30b4f8f93828677890a2986b66ff8bf39dac32a804e96ddf104")
-    version("3.7.1", sha256="5d24e40819768f74daf846b99837fc53a3a9dcdf3ce1c2003fe0596db850f0f0")
-    version("3.7.0", sha256="d937886a14b48c4287c4d343644feb294a14b31b7926ba9a4f1777123ce7c2cc")
-    version("3.6.2", sha256="ba6d02f15ba04aba9c23fd5f236bb234eab9d5209e95d1c4df85c44d5f19b9b3")
+    version("3.7.6", sha256="b4071807367b15b72777c2eaac80f42c8ea2d20212ab279514a19fe1f6f96ef4")
+    version("3.7.5", sha256="37556113fe44d77a7988f1ef88bf86ab68f53d11e85066ffd3c70157cc5110f1")
 
     # Deprecated versions
+    # https://nvd.nist.gov/vuln/detail/CVE-2024-48957
+    version("3.7.4", sha256="7875d49596286055b52439ed42f044bd8ad426aa4cc5aabd96bfe7abb971d5e8", deprecated=True)
+    version("3.7.3", sha256="f27a97bc22ceb996e72502df47dc19f99f9a0f09181ae909f09f3c9eb17b67e2", deprecated=True)
+    version("3.7.2", sha256="df404eb7222cf30b4f8f93828677890a2986b66ff8bf39dac32a804e96ddf104", deprecated=True)
+    version("3.7.1", sha256="5d24e40819768f74daf846b99837fc53a3a9dcdf3ce1c2003fe0596db850f0f0", deprecated=True)
+    version("3.7.0", sha256="d937886a14b48c4287c4d343644feb294a14b31b7926ba9a4f1777123ce7c2cc", deprecated=True)
+    version("3.6.2", sha256="ba6d02f15ba04aba9c23fd5f236bb234eab9d5209e95d1c4df85c44d5f19b9b3", deprecated=True)
+
     # https://nvd.nist.gov/vuln/detail/CVE-2021-31566
     version(
         "3.5.2",

--- a/var/spack/repos/builtin/packages/libarchive/package.py
+++ b/var/spack/repos/builtin/packages/libarchive/package.py
@@ -22,12 +22,36 @@ class Libarchive(AutotoolsPackage):
 
     # Deprecated versions
     # https://nvd.nist.gov/vuln/detail/CVE-2024-48957
-    version("3.7.4", sha256="7875d49596286055b52439ed42f044bd8ad426aa4cc5aabd96bfe7abb971d5e8", deprecated=True)
-    version("3.7.3", sha256="f27a97bc22ceb996e72502df47dc19f99f9a0f09181ae909f09f3c9eb17b67e2", deprecated=True)
-    version("3.7.2", sha256="df404eb7222cf30b4f8f93828677890a2986b66ff8bf39dac32a804e96ddf104", deprecated=True)
-    version("3.7.1", sha256="5d24e40819768f74daf846b99837fc53a3a9dcdf3ce1c2003fe0596db850f0f0", deprecated=True)
-    version("3.7.0", sha256="d937886a14b48c4287c4d343644feb294a14b31b7926ba9a4f1777123ce7c2cc", deprecated=True)
-    version("3.6.2", sha256="ba6d02f15ba04aba9c23fd5f236bb234eab9d5209e95d1c4df85c44d5f19b9b3", deprecated=True)
+    version(
+        "3.7.4",
+        sha256="7875d49596286055b52439ed42f044bd8ad426aa4cc5aabd96bfe7abb971d5e8",
+        deprecated=True,
+    )
+    version(
+        "3.7.3",
+        sha256="f27a97bc22ceb996e72502df47dc19f99f9a0f09181ae909f09f3c9eb17b67e2",
+        deprecated=True,
+    )
+    version(
+        "3.7.2",
+        sha256="df404eb7222cf30b4f8f93828677890a2986b66ff8bf39dac32a804e96ddf104",
+        deprecated=True,
+    )
+    version(
+        "3.7.1",
+        sha256="5d24e40819768f74daf846b99837fc53a3a9dcdf3ce1c2003fe0596db850f0f0",
+        deprecated=True,
+    )
+    version(
+        "3.7.0",
+        sha256="d937886a14b48c4287c4d343644feb294a14b31b7926ba9a4f1777123ce7c2cc",
+        deprecated=True,
+    )
+    version(
+        "3.6.2",
+        sha256="ba6d02f15ba04aba9c23fd5f236bb234eab9d5209e95d1c4df85c44d5f19b9b3",
+        deprecated=True,
+    )
 
     # https://nvd.nist.gov/vuln/detail/CVE-2021-31566
     version(


### PR DESCRIPTION
This PR adds `libarchive`, v3.7.5 and v3.7.6, which fixes CVE-2024-48957, CVE-2024-48958. Since these CVEs are marked high, older versions deprecated.

Test build:
```
==> No binary for libarchive-3.7.6-ryprre6guk7z5vtzt6cxsvzqj6wvwg2o found: installing from source
==> Fetching https://www.libarchive.org/downloads/libarchive-3.7.6.tar.gz
==> No patches needed for libarchive
==> libarchive: Executing phase: 'autoreconf'
==> libarchive: Executing phase: 'configure'
==> libarchive: Executing phase: 'build'
==> libarchive: Executing phase: 'install'
==> libarchive: Successfully installed libarchive-3.7.6-ryprre6guk7z5vtzt6cxsvzqj6wvwg2o
  Stage: 1.32s.  Autoreconf: 0.00s.  Configure: 30.56s.  Build: 31.67s.  Install: 0.42s.  Post-install: 0.16s.  Total: 1m 4.48s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libarchive-3.7.6-ryprre6guk7z5vtzt6cxsvzqj6wvwg2o
```