### PR TITLE
libvpx: add v1.14.1 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/libvpx/package.py
+++ b/var/spack/repos/builtin/packages/libvpx/package.py
@@ -19,7 +19,15 @@ class Libvpx(AutotoolsPackage):
 
     license("BSD-3-Clause")
 
-    version("1.10.0", sha256="85803ccbdbdd7a3b03d930187cb055f1353596969c1f92ebec2db839fa4f834a")
+    version("1.14.1", sha256="901747254d80a7937c933d03bd7c5d41e8e6c883e0665fadcb172542167c7977")
+
+    # Deprecated versions
+    # https://nvd.nist.gov/vuln/detail/CVE-2023-44488
+    version(
+        "1.10.0",
+        sha256="85803ccbdbdd7a3b03d930187cb055f1353596969c1f92ebec2db839fa4f834a",
+        deprecated=True,
+    )
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated


### PR DESCRIPTION
This PR adds `libvpx`, v1.14.1, which fixes CVE-2023-44488. Since that CVE is scored as high, previous versions are marked as deprecated.

Test build:
```
==> Waiting for libvpx-1.14.1-zacko2pigfb32g7uwubddxomnbq34pev
==> Installing libvpx-1.14.1-zacko2pigfb32g7uwubddxomnbq34pev [7/7]
==> No binary for libvpx-1.14.1-zacko2pigfb32g7uwubddxomnbq34pev found: installing from source
==> Fetching https://github.com/webmproject/libvpx/archive/refs/tags/v1.14.1.tar.gz
==> No patches needed for libvpx
==> libvpx: Executing phase: 'autoreconf'
==> libvpx: Executing phase: 'configure'
==> libvpx: Executing phase: 'build'
==> libvpx: Executing phase: 'install'
==> libvpx: Successfully installed libvpx-1.14.1-zacko2pigfb32g7uwubddxomnbq34pev
  Stage: 1.91s.  Autoreconf: 0.00s.  Configure: 4.67s.  Build: 3m 50.54s.  Install: 0.46s.  Post-install: 0.32s.  Total: 3m 58.52s[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libvpx-1.14.1-zacko2pigfb32g7uwubddxomnbq34pev
```