### PR TITLE
libde265: add v1.0.15 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/libde265/package.py
+++ b/var/spack/repos/builtin/packages/libde265/package.py
@@ -20,7 +20,14 @@ class Libde265(CMakePackage):
     license("LGPL-3.0-or-later")
 
     version("1.0.15", sha256="d4e55706dfc5b2c5c9702940b675ce2d3e7511025c6894eaddcdbaf0b15fd3f3")
-    version("1.0.9", sha256="153554f407718a75f1e0ae197d35b43147ce282118a54f894554dbe27c32163d")
+
+    # Deprecated versions
+    # https://nvd.nist.gov/vuln/detail/CVE-2023-49468
+    version(
+        "1.0.9",
+        sha256="153554f407718a75f1e0ae197d35b43147ce282118a54f894554dbe27c32163d",
+        deprecated=True,
+    )
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated

--- a/var/spack/repos/builtin/packages/libde265/package.py
+++ b/var/spack/repos/builtin/packages/libde265/package.py
@@ -19,6 +19,7 @@ class Libde265(CMakePackage):
 
     license("LGPL-3.0-or-later")
 
+    version("1.0.15", sha256="d4e55706dfc5b2c5c9702940b675ce2d3e7511025c6894eaddcdbaf0b15fd3f3")
     version("1.0.9", sha256="153554f407718a75f1e0ae197d35b43147ce282118a54f894554dbe27c32163d")
 
     depends_on("c", type="build")  # generated

--- a/var/spack/repos/builtin/packages/libde265/package.py
+++ b/var/spack/repos/builtin/packages/libde265/package.py
@@ -21,14 +21,6 @@ class Libde265(CMakePackage):
 
     version("1.0.15", sha256="d4e55706dfc5b2c5c9702940b675ce2d3e7511025c6894eaddcdbaf0b15fd3f3")
 
-    # Deprecated versions
-    # https://nvd.nist.gov/vuln/detail/CVE-2023-49468
-    version(
-        "1.0.9",
-        sha256="153554f407718a75f1e0ae197d35b43147ce282118a54f894554dbe27c32163d",
-        deprecated=True,
-    )
-
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 


### PR DESCRIPTION
This PR adds `libde265`, v1.0.15, which fixes CVE-2022-47655, CVE-2022-47664, CVE-2022-47665, CVE-2023-24751, CVE-2023-24752, CVE-2023-24754, CVE-2023-24755, CVE-2023-24756, CVE-2023-24757, CVE-2023-24758, CVE-2023-25221, CVE-2023-27102, CVE-2023-27103, CVE-2023-43887, CVE-2023-47471, CVE-2023-49465, CVE-2023-49467, CVE-2023-49468. At least one CVE marked as high, so deprecated older versions.

Test build:
```
==> Installing libde265-1.0.15-w3ru5nhx4ogtzs7jwh54dxsevihacpf7 [12/12]
==> No binary for libde265-1.0.15-w3ru5nhx4ogtzs7jwh54dxsevihacpf7 found: installing from source
==> Fetching https://github.com/strukturag/libde265/archive/refs/tags/v1.0.15.tar.gz
==> No patches needed for libde265
==> libde265: Executing phase: 'cmake'
==> libde265: Executing phase: 'build'
==> libde265: Executing phase: 'install'
==> libde265: Successfully installed libde265-1.0.15-w3ru5nhx4ogtzs7jwh54dxsevihacpf7
  Stage: 1.20s.  Cmake: 3.08s.  Build: 45.29s.  Install: 0.28s.  Post-install: 0.25s.  Total: 50.44s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libde265-1.0.15-w3ru5nhx4ogtzs7jwh54dxsevihacpf7
```