### PR TITLE
systemd: add v256.7

### DIFF
--- a/var/spack/repos/builtin/packages/systemd/package.py
+++ b/var/spack/repos/builtin/packages/systemd/package.py
@@ -17,6 +17,7 @@ class Systemd(MesonPackage):
     url = "https://github.com/systemd/systemd/archive/refs/tags/v255.tar.gz"
     license("GPL-2.0-only")
 
+    version("256.7", sha256="896d76ff65c88f5fd9e42f90d152b0579049158a163431dd77cdc57748b1d7b0")
     version("255", sha256="28854ffb2cb5f9e07fcbdbaf1e03a80b3462a12edeef84893ca2f37b22e4491e")
 
     depends_on("c", type="build")  # generated


### PR DESCRIPTION
This PR adds `systemd`, v256.7, [diff](https://github.com/systemd/systemd/compare/v255...v256.7). This adds support for bcachefs and pidfs in the magics, so they don't result in a compilation error on newer kernels (see e.g. https://github.com/systemd/systemd/pull/33108).

Test build:
```
==> Installing systemd-256.7-j22baz7ezk4yvgbo7xhc6dfx4ozrmxpe [50/51]
==> No binary for systemd-256.7-j22baz7ezk4yvgbo7xhc6dfx4ozrmxpe found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/89/896d76ff65c88f5fd9e42f90d152b0579049158a163431dd77cdc57748b1d7b0.tar.gz
==> No patches needed for systemd
==> systemd: Executing phase: 'meson'
==> systemd: Executing phase: 'build'
==> systemd: Executing phase: 'install'
==> systemd: Successfully installed systemd-256.7-j22baz7ezk4yvgbo7xhc6dfx4ozrmxpe
  Stage: 0.24s.  Meson: 11.91s.  Build: 2m 3.25s.  Install: 0.54s.  Post-install: 0.28s.  Total: 2m 16.50s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/systemd-256.7-j22baz7ezk4yvgbo7xhc6dfx4ozrmxpe
```