### PR TITLE
libcgroup: add v3.1.0 (fixes CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/libcgroup/package.py
+++ b/var/spack/repos/builtin/packages/libcgroup/package.py
@@ -9,17 +9,18 @@ from spack.package import *
 class Libcgroup(AutotoolsPackage):
     """Library of control groups."""
 
-    homepage = "https://sourceforge.net/projects/libcg/"
-    url = "https://sourceforge.net/projects/libcg/files/libcgroup/v0.41/libcgroup-0.41.tar.bz2"
+    homepage = "https://github.com/libcgroup/libcgroup/"
+    url = "https://github.com/libcgroup/libcgroup/releases/download/v3.1.0/libcgroup-3.1.0.tar.gz"
 
     license("LGPL-2.1-only")
 
+    version("3.1.0", sha256="976ec4b1e03c0498308cfd28f1b256b40858f636abc8d1f9db24f0a7ea9e1258")
     version("0.41", sha256="e4e38bdc7ef70645ce33740ddcca051248d56b53283c0dc6d404e17706f6fb51")
     version("0.37", sha256="15c8f3febb546530d3495af4e4904b3189c273277ca2d8553dec882cde1cd0f6")
     version("0.36", sha256="8dcd2ae220435b3de736d3efb0023fdf1192d7a7f4032b439f3cf5342cff7b4c")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("m4", type="build")
     depends_on("autoconf", type="build")
@@ -28,3 +29,10 @@ class Libcgroup(AutotoolsPackage):
     depends_on("bison", type="build")
     depends_on("flex", type="build")
     depends_on("linux-pam")
+    depends_on("systemd", when="@3.1:")
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@2.0.1:"):
+            return f"https://github.com/libcgroup/libcgroup/releases/download/v{version}/libcgroup-{version}.tar.gz"
+        else:
+            return f"https://github.com/libcgroup/libcgroup/releases/download/v{version}/libcgroup-{version}.tar.bz2"

--- a/var/spack/repos/builtin/packages/libcgroup/package.py
+++ b/var/spack/repos/builtin/packages/libcgroup/package.py
@@ -15,9 +15,11 @@ class Libcgroup(AutotoolsPackage):
     license("LGPL-2.1-only")
 
     version("3.1.0", sha256="976ec4b1e03c0498308cfd28f1b256b40858f636abc8d1f9db24f0a7ea9e1258")
-    version("0.41", sha256="e4e38bdc7ef70645ce33740ddcca051248d56b53283c0dc6d404e17706f6fb51")
-    version("0.37", sha256="15c8f3febb546530d3495af4e4904b3189c273277ca2d8553dec882cde1cd0f6")
-    version("0.36", sha256="8dcd2ae220435b3de736d3efb0023fdf1192d7a7f4032b439f3cf5342cff7b4c")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2018-14348
+        version("0.41", sha256="e4e38bdc7ef70645ce33740ddcca051248d56b53283c0dc6d404e17706f6fb51")
+        version("0.37", sha256="15c8f3febb546530d3495af4e4904b3189c273277ca2d8553dec882cde1cd0f6")
+        version("0.36", sha256="8dcd2ae220435b3de736d3efb0023fdf1192d7a7f4032b439f3cf5342cff7b4c")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/var/spack/repos/builtin/packages/linux-pam/package.py
+++ b/var/spack/repos/builtin/packages/linux-pam/package.py
@@ -31,6 +31,7 @@ class LinuxPam(AutotoolsPackage):
     variant("lastlog", default=False, description="Build pam_lastlog model")
     variant("regenerate-docu", default=False, description="Regenerate docs")
 
+    depends_on("pkgconfig", type="build")
     depends_on("libtirpc")
     depends_on("libxcrypt")
     depends_on("xauth", when="+xauth")


### PR DESCRIPTION
This PR adds `libcgroup`, v3.1.0, [diff](https://github.com/libcgroup/libcgroup/compare/v0.41...v3.1.0), which fixes CVE-2018-14348. The project is now on GitHub and releases as tar.gz files. The tar.bz2 files from sourceforge have been copied over and checksums are unchanged. This release (3.1.0) adds systemd as a dependency (can be turned off but enabled by default so included by default here since the package has no feature variants yet). Since the CVE is scored high, the previous versions were deprecated.

Test build:
```
==> Installing libcgroup-3.1.0-6x3y4gdf4g55nx4wugn7xsy3dwioyypj [51/51]
==> No binary for libcgroup-3.1.0-6x3y4gdf4g55nx4wugn7xsy3dwioyypj found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/97/976ec4b1e03c0498308cfd28f1b256b40858f636abc8d1f9db24f0a7ea9e1258.tar.gz
==> No patches needed for libcgroup
==> libcgroup: Executing phase: 'autoreconf'
==> libcgroup: Executing phase: 'configure'
==> libcgroup: Executing phase: 'build'
==> libcgroup: Executing phase: 'install'
==> libcgroup: Successfully installed libcgroup-3.1.0-6x3y4gdf4g55nx4wugn7xsy3dwioyypj
  Stage: 0.03s.  Autoreconf: 0.00s.  Configure: 5.15s.  Build: 7.00s.  Install: 0.78s.  Post-install: 0.16s.  Total: 13.28s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libcgroup-3.1.0-6x3y4gdf4g55nx4wugn7xsy3dwioyypj
```