### PR TITLE
qt-*: add v6.8.0, v6.8.1

### DIFF
--- a/var/spack/repos/builtin/packages/qt-5compat/package.py
+++ b/var/spack/repos/builtin/packages/qt-5compat/package.py
@@ -18,6 +18,7 @@ class Qt5compat(QtPackage):
 
     license("LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only")
 
+    version("6.8.0", sha256="0ea312a2d7e7033857712273e5ea42e61d1f485d23420307f7bbf0b8ca701453")
     version("6.7.3", sha256="959634d1a6a53f9a483882e81da87ec182ff44d7747a0cc771c786b0f2cf52e0")
     version("6.7.2", sha256="331a1e617952217868beeef7964828500388abeeb502ea3436f16eec816426c4")
 

--- a/var/spack/repos/builtin/packages/qt-5compat/package.py
+++ b/var/spack/repos/builtin/packages/qt-5compat/package.py
@@ -18,6 +18,7 @@ class Qt5compat(QtPackage):
 
     license("LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only")
 
+    version("6.8.1", sha256="5e51feb8d9362d860017ae72f63daa5caeddf3ec3396e73a4b27c672536fd774")
     version("6.8.0", sha256="0ea312a2d7e7033857712273e5ea42e61d1f485d23420307f7bbf0b8ca701453")
     version("6.7.3", sha256="959634d1a6a53f9a483882e81da87ec182ff44d7747a0cc771c786b0f2cf52e0")
     version("6.7.2", sha256="331a1e617952217868beeef7964828500388abeeb502ea3436f16eec816426c4")

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -144,6 +144,7 @@ class QtBase(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.1", sha256="9b81b83e4079d2f79ae057902973fc0ebb10d566ec022f483e7c0f2294acb19c")
     version("6.8.0", sha256="3e526ceaaf615005bc89a98ee8a52b87db6fefe7155595bf75c40fd82cd1a7ce")
     version("6.7.3", sha256="65771d1618cab08ec5e9bbfdc265b5d2ce2ccf0373143d7d9d139647a7196aec")
     version("6.7.2", sha256="96b96e4fd0fc306502ed8b94a34cfa0bacc8a25d43c2e958dd6772b28f6b0e42")

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -144,6 +144,7 @@ class QtBase(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.0", sha256="3e526ceaaf615005bc89a98ee8a52b87db6fefe7155595bf75c40fd82cd1a7ce")
     version("6.7.3", sha256="65771d1618cab08ec5e9bbfdc265b5d2ce2ccf0373143d7d9d139647a7196aec")
     version("6.7.2", sha256="96b96e4fd0fc306502ed8b94a34cfa0bacc8a25d43c2e958dd6772b28f6b0e42")
     version("6.7.1", sha256="d6950597ce1fc2e1cf374c3aa70c2d72532bb74150e9853d7127af86a8a6c7b4")

--- a/var/spack/repos/builtin/packages/qt-declarative/package.py
+++ b/var/spack/repos/builtin/packages/qt-declarative/package.py
@@ -16,6 +16,7 @@ class QtDeclarative(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.0", sha256="d28e15cec7754ee16588deace17ee83d75e2613f4751a79dd60c277721f7480f")
     version("6.7.3", sha256="f39fa4e7e3b4011e52fc55fbde5f41e61815bffea432869abc9b90aa4de07613")
     version("6.7.2", sha256="3b91d1b75f22221f39b93647d73c9fe7fc4b9c8d45ff0cec402626eab15d8dd8")
     version("6.7.1", sha256="fdf4099cbced3ce56e5151122ae1eb924886492f9fc2eb6a353d60a23e8fde14")

--- a/var/spack/repos/builtin/packages/qt-declarative/package.py
+++ b/var/spack/repos/builtin/packages/qt-declarative/package.py
@@ -16,6 +16,7 @@ class QtDeclarative(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.1", sha256="c3f41f5de5b2f02aa31bc5668f617f65d9adb3fb1939679b2a57a73a98c36ed6")
     version("6.8.0", sha256="d28e15cec7754ee16588deace17ee83d75e2613f4751a79dd60c277721f7480f")
     version("6.7.3", sha256="f39fa4e7e3b4011e52fc55fbde5f41e61815bffea432869abc9b90aa4de07613")
     version("6.7.2", sha256="3b91d1b75f22221f39b93647d73c9fe7fc4b9c8d45ff0cec402626eab15d8dd8")

--- a/var/spack/repos/builtin/packages/qt-quick3d/package.py
+++ b/var/spack/repos/builtin/packages/qt-quick3d/package.py
@@ -16,6 +16,7 @@ class QtQuick3d(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.0", sha256="3fc965c7c867e21d894e5394ec1c3f7626ecb895e335115661133ac499a14408")
     version("6.7.3", sha256="3e68f3a9a330e7b9a92ddf5b8d7a0874a107ea77636c788f598de65e327eb4a0")
     version("6.7.2", sha256="67021658cb10bfa6d969c4219d599ab2f4775d08fb4ae56da17fbec305088b55")
     version("6.7.1", sha256="c889b70305da7595df87c3bd062474787b722ab216bc2e6226e33fae3ec3459d")

--- a/var/spack/repos/builtin/packages/qt-quick3d/package.py
+++ b/var/spack/repos/builtin/packages/qt-quick3d/package.py
@@ -16,6 +16,7 @@ class QtQuick3d(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.1", sha256="67878e0ecb9e8b760567364afd3c1b90d8c65087d8f676e9df51cad95df1bf21")
     version("6.8.0", sha256="3fc965c7c867e21d894e5394ec1c3f7626ecb895e335115661133ac499a14408")
     version("6.7.3", sha256="3e68f3a9a330e7b9a92ddf5b8d7a0874a107ea77636c788f598de65e327eb4a0")
     version("6.7.2", sha256="67021658cb10bfa6d969c4219d599ab2f4775d08fb4ae56da17fbec305088b55")

--- a/var/spack/repos/builtin/packages/qt-quicktimeline/package.py
+++ b/var/spack/repos/builtin/packages/qt-quicktimeline/package.py
@@ -16,6 +16,7 @@ class QtQuicktimeline(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.1", sha256="29d79b17c0de962ce5dc9f2984eb89b701946522537cf5c90ca803c75148de19")
     version("6.8.0", sha256="3128c0f1a9e944c52ac8d080ecab7e7ed2a37e67cd06ab573dc178b3f8832fb4")
     version("6.7.3", sha256="81ce374a22bf00d53d0a9d5293d6495a224137e9427e4d4913d87f2f0adc5a58")
     version("6.7.2", sha256="ad5370a3b193c5d30a824a1def0608e12fb735c4ff20ae55161a6f6e202e091d")

--- a/var/spack/repos/builtin/packages/qt-quicktimeline/package.py
+++ b/var/spack/repos/builtin/packages/qt-quicktimeline/package.py
@@ -16,6 +16,7 @@ class QtQuicktimeline(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.0", sha256="3128c0f1a9e944c52ac8d080ecab7e7ed2a37e67cd06ab573dc178b3f8832fb4")
     version("6.7.3", sha256="81ce374a22bf00d53d0a9d5293d6495a224137e9427e4d4913d87f2f0adc5a58")
     version("6.7.2", sha256="ad5370a3b193c5d30a824a1def0608e12fb735c4ff20ae55161a6f6e202e091d")
     version("6.7.1", sha256="98766368b4650eef583f76d257573e6785938b89c9eb2fc57577f4c199b12a1f")

--- a/var/spack/repos/builtin/packages/qt-shadertools/package.py
+++ b/var/spack/repos/builtin/packages/qt-shadertools/package.py
@@ -18,6 +18,7 @@ class QtShadertools(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.1", sha256="b780ae2746d98fa3fc896c8ea8cd5c17ea360bedb33948e7343946bd9b115c24")
     version("6.8.0", sha256="19a6fce3e958d8e8d6cb2c13501a4a8fa61ad9e5bc0cd0496901b34012f2362e")
     version("6.7.3", sha256="8ec6a48c41d49b6f9595659169b2c69aecd46e96a88131f19f6a4cda394fa3f4")
     version("6.7.2", sha256="256ff8199d9f6e97bef57f602c5fa7a32e3c7588bf7efe39e412b810c7ed4ffc")

--- a/var/spack/repos/builtin/packages/qt-shadertools/package.py
+++ b/var/spack/repos/builtin/packages/qt-shadertools/package.py
@@ -18,6 +18,7 @@ class QtShadertools(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.0", sha256="19a6fce3e958d8e8d6cb2c13501a4a8fa61ad9e5bc0cd0496901b34012f2362e")
     version("6.7.3", sha256="8ec6a48c41d49b6f9595659169b2c69aecd46e96a88131f19f6a4cda394fa3f4")
     version("6.7.2", sha256="256ff8199d9f6e97bef57f602c5fa7a32e3c7588bf7efe39e412b810c7ed4ffc")
     version("6.7.1", sha256="56cfba20c7e8f7a218cac68d237a63ea342ac9a67211ecdf3c7152572632448b")

--- a/var/spack/repos/builtin/packages/qt-svg/package.py
+++ b/var/spack/repos/builtin/packages/qt-svg/package.py
@@ -18,6 +18,7 @@ class QtSvg(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.0", sha256="19a6fce3e958d8e8d6cb2c13501a4a8fa61ad9e5bc0cd0496901b34012f2362e")
     version("6.7.3", sha256="2852d8f1f52b60f0624ca5edf479125e4b32d579b1177d8b76d8e28fac98a701")
     version("6.7.2", sha256="c0e140bbba4157cdbbe0e84ddbb4e238b87aa0ca7b870bad283d8cf2a7fa74b6")
     version("6.7.1", sha256="55134e1242305e554610bf1a77e71d3d15104ee819a3c87def1f8b736d5ecf0e")

--- a/var/spack/repos/builtin/packages/qt-svg/package.py
+++ b/var/spack/repos/builtin/packages/qt-svg/package.py
@@ -18,6 +18,7 @@ class QtSvg(QtPackage):
 
     license("BSD-3-Clause")
 
+    version("6.8.1", sha256="288f233991686bc411a11cc331fb1be5f12ed43be03e29639158e545685ce7c9")
     version("6.8.0", sha256="ec3112668b7b8cfd1790bf4f936268dd6d32251ea81bb20d3aa4c4bac2031866")
     version("6.7.3", sha256="2852d8f1f52b60f0624ca5edf479125e4b32d579b1177d8b76d8e28fac98a701")
     version("6.7.2", sha256="c0e140bbba4157cdbbe0e84ddbb4e238b87aa0ca7b870bad283d8cf2a7fa74b6")

--- a/var/spack/repos/builtin/packages/qt-svg/package.py
+++ b/var/spack/repos/builtin/packages/qt-svg/package.py
@@ -18,7 +18,7 @@ class QtSvg(QtPackage):
 
     license("BSD-3-Clause")
 
-    version("6.8.0", sha256="19a6fce3e958d8e8d6cb2c13501a4a8fa61ad9e5bc0cd0496901b34012f2362e")
+    version("6.8.0", sha256="ec3112668b7b8cfd1790bf4f936268dd6d32251ea81bb20d3aa4c4bac2031866")
     version("6.7.3", sha256="2852d8f1f52b60f0624ca5edf479125e4b32d579b1177d8b76d8e28fac98a701")
     version("6.7.2", sha256="c0e140bbba4157cdbbe0e84ddbb4e238b87aa0ca7b870bad283d8cf2a7fa74b6")
     version("6.7.1", sha256="55134e1242305e554610bf1a77e71d3d15104ee819a3c87def1f8b736d5ecf0e")

--- a/var/spack/repos/builtin/packages/qt-tools/package.py
+++ b/var/spack/repos/builtin/packages/qt-tools/package.py
@@ -20,6 +20,7 @@ class QtTools(QtPackage):
     license("BSD-3-Clause")
 
     # src/assistant/qlitehtml is a submodule that is not in the git archive
+    version("6.8.1", commit="b0d66c51cbda17b213bed73d379f0900c77f457c", submodules=True)
     version("6.8.0", commit="3dd2b6ad0dd1a0480628b4cc74cb7b89a89e4a61", submodules=True)
     version("6.7.3", commit="ec4747e62a837a0262212a5f4fb03734660c7360", submodules=True)
     version("6.7.2", commit="46ffaed90df8c14d67b4b16fdf5e0b87ab227c88", submodules=True)

--- a/var/spack/repos/builtin/packages/qt-tools/package.py
+++ b/var/spack/repos/builtin/packages/qt-tools/package.py
@@ -20,6 +20,7 @@ class QtTools(QtPackage):
     license("BSD-3-Clause")
 
     # src/assistant/qlitehtml is a submodule that is not in the git archive
+    version("6.8.0", commit="3dd2b6ad0dd1a0480628b4cc74cb7b89a89e4a61", submodules=True)
     version("6.7.3", commit="ec4747e62a837a0262212a5f4fb03734660c7360", submodules=True)
     version("6.7.2", commit="46ffaed90df8c14d67b4b16fdf5e0b87ab227c88", submodules=True)
 


### PR DESCRIPTION
This PR updates Qt packages to v6.8.0 and v68.1, which includes the packages `qt-base`, `qt-5compat`, `qt-quick3d`, `qt-declarative`, `qt-quicktimeline`, `qt-shadertools`, `qt-svg`, and `qt-tools`.

Test builds:
```
==> Installing qt-base-6.8.0-72lfe4zrogbh6v3dfj7v4pyemrurovcv [110/110]
==> No binary for qt-base-6.8.0-72lfe4zrogbh6v3dfj7v4pyemrurovcv found: installing from source
==> Fetching https://github.com/qt/qtbase/archive/refs/tags/v6.8.0.tar.gz
==> No patches needed for qt-base
==> qt-base: Executing phase: 'cmake'
==> qt-base: Executing phase: 'build'
==> qt-base: Executing phase: 'install'
==> qt-base: Successfully installed qt-base-6.8.0-72lfe4zrogbh6v3dfj7v4pyemrurovcv
  Stage: 9.05s.  Cmake: 2m 14.32s.  Build: 27m 54.43s.  Install: 4.35s.  Post-install: 3.59s.  Total: 30m 28.55s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-base-6.8.0-72lfe4zrogbh6v3dfj7v4pyemrurovcv
```