### PR TITLE
guacamole-{client,server}: add v1.5.5 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/guacamole-client/package.py
+++ b/var/spack/repos/builtin/packages/guacamole-client/package.py
@@ -18,13 +18,15 @@ class GuacamoleClient(MavenPackage):
     version("1.5.5", sha256="ebbd3c0b73ddafbf6656d11324163f5b8d410f94b472791e6fa75fca13a5d30b")
     version("1.2.0", sha256="2327368a32e61cf82032311be79ded4e5eefbc59ac9fb6e0a054b4f49168843e")
 
+    # remove usage of deprecated AccessController class, deprecated in java 17
     patch(
         "https://github.com/apache/guacamole-client/commit/b315e6aac84550948763a2bc99f12ceb2a28dca1.patch?full_index=1",
         sha256="3529eb8bfd3d025682463cbce3f5a58bdbcacfa58c915c5471e00913c89f7474",
-        when="@:1.5.5",
+        when="@1.5:1.5.5",
     )
 
     depends_on("java@8:", type=("build", "run"))
+    depends_on("java@:16", type=("build", "run"), when="@:1.4")
 
     def build_args(self):
         # The file .spack_patched is flagged as an unapproved license

--- a/var/spack/repos/builtin/packages/guacamole-client/package.py
+++ b/var/spack/repos/builtin/packages/guacamole-client/package.py
@@ -18,4 +18,14 @@ class GuacamoleClient(MavenPackage):
     version("1.5.5", sha256="ebbd3c0b73ddafbf6656d11324163f5b8d410f94b472791e6fa75fca13a5d30b")
     version("1.2.0", sha256="2327368a32e61cf82032311be79ded4e5eefbc59ac9fb6e0a054b4f49168843e")
 
+    patch(
+        "https://github.com/apache/guacamole-client/commit/b315e6aac84550948763a2bc99f12ceb2a28dca1.patch?full_index=1",
+        sha256="3529eb8bfd3d025682463cbce3f5a58bdbcacfa58c915c5471e00913c89f7474",
+        when="@:1.5.5",
+    )
+
     depends_on("java@8:", type=("build", "run"))
+
+    def build_args(self):
+        # The file .spack_patched is flagged as an unapproved license
+        return ["-Drat.numUnapprovedLicenses=1"]

--- a/var/spack/repos/builtin/packages/guacamole-client/package.py
+++ b/var/spack/repos/builtin/packages/guacamole-client/package.py
@@ -15,6 +15,7 @@ class GuacamoleClient(MavenPackage):
 
     license("Apache-2.0")
 
+    version("1.5.5", sha256="ebbd3c0b73ddafbf6656d11324163f5b8d410f94b472791e6fa75fca13a5d30b")
     version("1.2.0", sha256="2327368a32e61cf82032311be79ded4e5eefbc59ac9fb6e0a054b4f49168843e")
 
-    depends_on("java@8", type=("build", "run"))
+    depends_on("java@8:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/guacamole-server/package.py
+++ b/var/spack/repos/builtin/packages/guacamole-server/package.py
@@ -16,15 +16,18 @@ class GuacamoleServer(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
-    version("1.1.0", sha256="d0f0c66ebfa7a4fd6689ae5240f21797b5177945a042388b691b15b8bd5c81a8")
+    version("1.5.5", sha256="50430c0f0f3b92f2cd3e60436fab0cedee8c1a9f762696a666016347039c731e")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2023-43826
+        version("1.1.0", sha256="d0f0c66ebfa7a4fd6689ae5240f21797b5177945a042388b691b15b8bd5c81a8")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("cairo")
+    depends_on("cairo +pdf +png")  # pdf enables zlib support required for CairoScript
     depends_on("libjpeg")
     depends_on("libpng")
     depends_on("uuid")


### PR DESCRIPTION
This PR adds guacamole, v1.5.5, for both server and client. This fixes (for the server) CVE-2019-19603, CVE-2020-9497, CVE-2020-9498, CVE-2020-11997, CVE-2021-41767, CVE-2021-43999, CVE-2023-30575, CVE-2023-30576, CVE-2023-43826. The older server versions have been marked as deprecated since several of the CVEs are scored high.

- The server (also previously) requires `cairo +png` explicitly for image exports to png, and it uses CairoScript which is only enabled in cairo when zlib support is found. That is not an individual variant, but enabled when `+pdf`, so the dependency here is on `cairo +pdf`.

- The client specifies java 1.8 as minimum in pom.xml. For more recent versions, the deprecation of the AccessController class and the use of `-Werror` cause a build failure on newer java versions, so a patch that has been merged into `main` is added.

Test build server:
```
==> Installing guacamole-server-1.5.5-rpz3kcav2q7a52vd3cfcnuccrdj2raum [48/48]
==> No binary for guacamole-server-1.5.5-rpz3kcav2q7a52vd3cfcnuccrdj2raum found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/50/50430c0f0f3b92f2cd3e60436fab0cedee8c1a9f762696a666016347039c731e.tar.gz
==> No patches needed for guacamole-server
==> guacamole-server: Executing phase: 'autoreconf'
==> guacamole-server: Executing phase: 'configure'
==> guacamole-server: Executing phase: 'build'
==> guacamole-server: Executing phase: 'install'
==> guacamole-server: Successfully installed guacamole-server-1.5.5-rpz3kcav2q7a52vd3cfcnuccrdj2raum
  Stage: 0.11s.  Autoreconf: 25.57s.  Configure: 32.89s.  Build: 23.94s.  Install: 1.98s.  Post-install: 1.63s.  Total: 1m 26.93s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/guacamole-server-1.5.5-rpz3kcav2q7a52vd3cfcnuccrdj2raum
```

Test build client:
```
==> Installing guacamole-client-1.5.5-btnd76lurptgtxh3qazti4icgcocx56h [5/5]
==> No binary for guacamole-client-1.5.5-btnd76lurptgtxh3qazti4icgcocx56h found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/eb/ebbd3c0b73ddafbf6656d11324163f5b8d410f94b472791e6fa75fca13a5d30b.tar.gz
==> Using cached archive: /opt/spack/cache/_source-cache/archive/35/3529eb8bfd3d025682463cbce3f5a58bdbcacfa58c915c5471e00913c89f7474
==> Applied patch https://github.com/apache/guacamole-client/commit/b315e6aac84550948763a2bc99f12ceb2a28dca1.patch?full_index=1
==> guacamole-client: Executing phase: 'build'
==> guacamole-client: Executing phase: 'install'
==> guacamole-client: Successfully installed guacamole-client-1.5.5-btnd76lurptgtxh3qazti4icgcocx56h
  Stage: 0.57s.  Build: 2m 46.31s.  Install: 4.36s.  Post-install: 6.31s.  Total: 2m 57.88s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/guacamole-client-1.5.5-btnd76lurptgtxh3qazti4icgcocx56h
```