### PR TITLE
tomcat: add v9.0.96, v10.1.31, v11.0.0 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/tomcat/package.py
+++ b/var/spack/repos/builtin/packages/tomcat/package.py
@@ -14,7 +14,9 @@ class Tomcat(Package):
     """
 
     homepage = "https://tomcat.apache.org/"
-    url = "https://archive.apache.org/dist/tomcat/tomcat-11/v11.0.0/bin/apache-tomcat-11.0.0.tar.gz"
+    url = (
+        "https://archive.apache.org/dist/tomcat/tomcat-11/v11.0.0/bin/apache-tomcat-11.0.0.tar.gz"
+    )
 
     license("Apache-2.0")
 
@@ -27,11 +29,21 @@ class Tomcat(Package):
     )
     with default_args(deprecated=True):
         # https://nvd.nist.gov/vuln/detail/CVE-2023-46589
-        version("9.0.30", sha256="43a9b268671bbd3aace427637fbf577e742b521901e111342321ae901478100b")
-        version("9.0.29", sha256="1bf634413326ec96972fc1c3ac6666e8e4cab49ad3fc9f5e3228b85208d9c4b0")
-        version("9.0.27", sha256="6616a150e1593ef1a622298aaef9b889db70c8ee5122d35ad52adfcda1084d10")
-        version("9.0.26", sha256="b5430890d3b986d6b7ec6a6ef611f9451cbfa933b0a1a3dd48e2cd1f46a63381")
-        version("9.0.24", sha256="22064138e25f7ab899802804775259a156c06770535b8ce93856beba13dfcf6d")
+        version(
+            "9.0.30", sha256="43a9b268671bbd3aace427637fbf577e742b521901e111342321ae901478100b"
+        )
+        version(
+            "9.0.29", sha256="1bf634413326ec96972fc1c3ac6666e8e4cab49ad3fc9f5e3228b85208d9c4b0"
+        )
+        version(
+            "9.0.27", sha256="6616a150e1593ef1a622298aaef9b889db70c8ee5122d35ad52adfcda1084d10"
+        )
+        version(
+            "9.0.26", sha256="b5430890d3b986d6b7ec6a6ef611f9451cbfa933b0a1a3dd48e2cd1f46a63381"
+        )
+        version(
+            "9.0.24", sha256="22064138e25f7ab899802804775259a156c06770535b8ce93856beba13dfcf6d"
+        )
 
     # https://tomcat.apache.org/whichversion.html
     depends_on("java@8:", type="run", when="@9:")

--- a/var/spack/repos/builtin/packages/tomcat/package.py
+++ b/var/spack/repos/builtin/packages/tomcat/package.py
@@ -14,19 +14,32 @@ class Tomcat(Package):
     """
 
     homepage = "https://tomcat.apache.org/"
-    url = "https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.30/bin/apache-tomcat-9.0.30.tar.gz"
+    url = "https://archive.apache.org/dist/tomcat/tomcat-11/v11.0.0/bin/apache-tomcat-11.0.0.tar.gz"
 
     license("Apache-2.0")
 
-    version("9.0.30", sha256="43a9b268671bbd3aace427637fbf577e742b521901e111342321ae901478100b")
-    version("9.0.29", sha256="1bf634413326ec96972fc1c3ac6666e8e4cab49ad3fc9f5e3228b85208d9c4b0")
-    version("9.0.27", sha256="6616a150e1593ef1a622298aaef9b889db70c8ee5122d35ad52adfcda1084d10")
-    version("9.0.26", sha256="b5430890d3b986d6b7ec6a6ef611f9451cbfa933b0a1a3dd48e2cd1f46a63381")
-    version("9.0.24", sha256="22064138e25f7ab899802804775259a156c06770535b8ce93856beba13dfcf6d")
+    version("11.0.0", sha256="d0ca319af349838f59009a9c5ed3709f02344201059dbc26dce4313ee969cd20")
+    version("10.1.31", sha256="06f6e2e11ef5afb435a4b27e1e264ebcdbafd95389f5ee37e425dc135ed325d4")
+    version(
+        "9.0.96",
+        sha256="bf4ad04955457ad663157876461015437a7479546aec9a38840d736b3d70151f",
+        preferred=True,
+    )
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2023-46589
+        version("9.0.30", sha256="43a9b268671bbd3aace427637fbf577e742b521901e111342321ae901478100b")
+        version("9.0.29", sha256="1bf634413326ec96972fc1c3ac6666e8e4cab49ad3fc9f5e3228b85208d9c4b0")
+        version("9.0.27", sha256="6616a150e1593ef1a622298aaef9b889db70c8ee5122d35ad52adfcda1084d10")
+        version("9.0.26", sha256="b5430890d3b986d6b7ec6a6ef611f9451cbfa933b0a1a3dd48e2cd1f46a63381")
+        version("9.0.24", sha256="22064138e25f7ab899802804775259a156c06770535b8ce93856beba13dfcf6d")
+
+    # https://tomcat.apache.org/whichversion.html
+    depends_on("java@8:", type="run", when="@9:")
+    depends_on("java@11:", type="run", when="@10:")
+    depends_on("java@17:", type="run", when="@11:")
 
     def url_for_version(self, version):
-        url = "https://archive.apache.org/dist/tomcat/tomcat-9/v{0}/bin/apache-tomcat-{0}.tar.gz"
-        return url.format(version)
+        return f"https://archive.apache.org/dist/tomcat/tomcat-{version.up_to(1)}/v{version}/bin/apache-tomcat-{version}.tar.gz"
 
     def install(self, spec, prefix):
         install_tree(".", prefix)


### PR DESCRIPTION
This PR adds `tomcat`, v9.0.96, v10.1.31, v11.0.0, which fixes numerous CVEs, [`cpe:2.3:a:apache:tomcat:9.0.30:*:*:*:*:*:*:*`](https://nvd.nist.gov/vuln/search/results?adv_search=true&isCpeNameSearch=true&query=cpe%3A2.3%3Aa%3Aapache%3Atomcat%3A9.0.30%3A*%3A*%3A*%3A*%3A*%3A*%3A*), e.g. CVE-2020-1938 is a critical CVE that is a good reason to upgrade. Marked older versions as deprecated since at least one CVE is scored high. Added java runtime dependency based on table in comment. Due to incompatibility when going from 9 to 10 and 10 to 11, marked 9 as continued to be preferred for now. 

Test build:
```
==> Installing tomcat-9.0.96-ut577apv7gwj2b3qmexu7lw2fg3fcivh [4/4]
==> No binary for tomcat-9.0.96-ut577apv7gwj2b3qmexu7lw2fg3fcivh found: installing from source
==> Fetching https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.96/bin/apache-tomcat-9.0.96.tar.gz
==> No patches needed for tomcat
==> tomcat: Executing phase: 'install'
==> tomcat: Successfully installed tomcat-9.0.96-ut577apv7gwj2b3qmexu7lw2fg3fcivh
  Stage: 10.74s.  Install: 0.10s.  Post-install: 0.24s.  Total: 11.11s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/tomcat-9.0.96-ut577apv7gwj2b3qmexu7lw2fg3fcivh
==> Installing tomcat-10.1.31-bi6nxncrudbkzyznl5qu5sd3gcjp34th [4/6]
==> No binary for tomcat-10.1.31-bi6nxncrudbkzyznl5qu5sd3gcjp34th found: installing from source
==> Fetching https://archive.apache.org/dist/tomcat/tomcat-10/v10.1.31/bin/apache-tomcat-10.1.31.tar.gz
==> No patches needed for tomcat
==> tomcat: Executing phase: 'install'
==> tomcat: Successfully installed tomcat-10.1.31-bi6nxncrudbkzyznl5qu5sd3gcjp34th
  Stage: 3.95s.  Install: 0.08s.  Post-install: 0.19s.  Total: 4.24s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/tomcat-10.1.31-bi6nxncrudbkzyznl5qu5sd3gcjp34th
==> Installing tomcat-11.0.0-ivyzmhq5e6obj4jeixgjkqaxijt37jaz [5/6]
==> No binary for tomcat-11.0.0-ivyzmhq5e6obj4jeixgjkqaxijt37jaz found: installing from source
==> Fetching https://archive.apache.org/dist/tomcat/tomcat-11/v11.0.0/bin/apache-tomcat-11.0.0.tar.gz
==> No patches needed for tomcat
==> tomcat: Executing phase: 'install'
==> tomcat: Successfully installed tomcat-11.0.0-ivyzmhq5e6obj4jeixgjkqaxijt37jaz
  Stage: 4.07s.  Install: 0.10s.  Post-install: 0.23s.  Total: 4.42s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/tomcat-11.0.0-ivyzmhq5e6obj4jeixgjkqaxijt37jaz
```