### PR TITLE
Change URLs from http to https in curl and openssl

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -22,8 +22,7 @@ class Curl(NMakePackage, AutotoolsPackage):
     transferring data with URL syntax"""
 
     homepage = "https://curl.se/"
-    # URL must remain http:// so Spack can bootstrap curl
-    url = "http://curl.haxx.se/download/curl-7.78.0.tar.bz2"
+    url = "https://curl.haxx.se/download/curl-7.78.0.tar.bz2"
 
     executables = ["^curl$"]
     tags = ["build-tools", "windows"]

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -18,8 +18,7 @@ class Openssl(Package):  # Uses Fake Autotools, should subclass Package
 
     homepage = "https://www.openssl.org"
 
-    # URL must remain http:// so Spack can bootstrap curl
-    url = "http://www.openssl.org/source/openssl-1.1.1d.tar.gz"
+    url = "https://www.openssl.org/source/openssl-1.1.1d.tar.gz"
     list_url = "https://www.openssl.org/source/old/"
     list_depth = 1
 


### PR DESCRIPTION
Using http for these two URLs is a problem for computing sites that require https. The http URL redirects to https anyway. Not sure if there is anything I am missing that this would need to stay as http at this point.