### PR TITLE
keepalived: add v2.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/keepalived/package.py
+++ b/var/spack/repos/builtin/packages/keepalived/package.py
@@ -17,6 +17,7 @@ class Keepalived(AutotoolsPackage):
 
     license("GPL-2.0-only")
 
+    version("2.3.1", sha256="92f4b69bfd998e2306d1995ad16fdad1b59e70be694c883385c5f55e02c62aa3")
     version("2.0.19", sha256="0e2f8454765bc6a5fa26758bd9cec18aae42882843cdd24848aff0ae65ce4ca7")
     version("2.0.18", sha256="1423a2b1b8e541211029b9e1e1452e683bbe5f4b0b287eddd609aaf5ff024fd0")
     version("2.0.17", sha256="8965ffa2ffe243014f9c0245daa65f00a9930cf746edf33525d28a86f97497b4")
@@ -27,7 +28,8 @@ class Keepalived(AutotoolsPackage):
     version("2.0.12", sha256="fd50e433d784cfd948de5726752cf89ab7001f587fe10a5110c6c7cbda4b7b5e")
     version("2.0.11", sha256="a298b0c02a20959cfc365b62c14f45abd50d5e0595b2869f5bce10ec2392fa48")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("pkgconfig", type="build")
 
     depends_on("openssl")
 


### PR DESCRIPTION
This PR adds `keepalived`, v2.3.1, which fixes CVE-2021-44225. Since the CVE is scored medium, older versions are not marked as deprecated. The configure.ac indicates an unlisted dependency on pkgconfig.

Test build:
```
==> Installing keepalived-2.3.1-yi555dg7b2hfvahjgihhjsjqnq2euoho [6/6]
==> No binary for keepalived-2.3.1-yi555dg7b2hfvahjgihhjsjqnq2euoho found: installing from source
==> Fetching https://www.keepalived.org/software/keepalived-2.3.1.tar.gz
==> No patches needed for keepalived
==> keepalived: Executing phase: 'autoreconf'
==> keepalived: Executing phase: 'configure'
==> keepalived: Executing phase: 'build'
==> keepalived: Executing phase: 'install'
==> keepalived: Successfully installed keepalived-2.3.1-yi555dg7b2hfvahjgihhjsjqnq2euoho
  Stage: 2.24s.  Autoreconf: 0.00s.  Configure: 12.92s.  Build: 11.81s.  Install: 0.30s.  Post-install: 0.13s.  Total: 27.56s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/keepalived-2.3.1-yi555dg7b2hfvahjgihhjsjqnq2euoho
```