### PR TITLE
AOCL: add v5.0

### DIFF
--- a/var/spack/repos/builtin/packages/amd-aocl/package.py
+++ b/var/spack/repos/builtin/packages/amd-aocl/package.py
@@ -24,7 +24,8 @@ class AmdAocl(BundlePackage):
 
     maintainers("amd-toolchain-support")
 
-    version("4.2", preferred=True)
+    version("5.0", preferred=True)
+    version("4.2")
     version("4.1")
     version("4.0")
     version("3.2")
@@ -38,21 +39,31 @@ class AmdAocl(BundlePackage):
         depends_on("amdblis threads=openmp")
         depends_on("amdfftw +openmp")
         depends_on("amdlibflame threads=openmp")
+        depends_on("aocl-sparse +openmp")
+        depends_on("aocl-da +openmp")
+        depends_on("aocl-compression +openmp")
 
     with when("~openmp"):
         depends_on("amdblis threads=none")
         depends_on("amdfftw ~openmp")
         depends_on("amdlibflame threads=none")
+        depends_on("aocl-sparse ~openmp")
+        depends_on("aocl-da ~openmp")
+        depends_on("aocl-compression ~openmp")
 
-    for vers in ["2.2", "3.0", "3.1", "3.2", "4.0", "4.1", "4.2"]:
+    for vers in ["2.2", "3.0", "3.1", "3.2", "4.0", "4.1", "4.2", "5.0"]:
         with when(f"@={vers}"):
             depends_on(f"amdblis@={vers}")
             depends_on(f"amdfftw@={vers}")
-            depends_on(f"amdlibflame@={vers}")
+            depends_on(f"amdlibflame@={vers} ^[virtuals=blas] amdblis")
             depends_on(f"amdlibm@={vers}")
-            depends_on(f"amdscalapack@={vers}")
+            depends_on(
+                f"amdscalapack@={vers} ^[virtuals=blas] amdblis ^[virtuals=lapack] amdlibflame"
+            )
             depends_on(f"aocl-sparse@={vers}")
             if Version(vers) >= Version("4.2"):
                 depends_on(f"aocl-compression@={vers}")
                 depends_on(f"aocl-crypto@={vers}")
                 depends_on(f"aocl-libmem@={vers}")
+            if Version(vers) >= Version("5.0"):
+                depends_on(f"aocl-da@={vers}")

--- a/var/spack/repos/builtin/packages/amd-aocl/package.py
+++ b/var/spack/repos/builtin/packages/amd-aocl/package.py
@@ -55,11 +55,12 @@ class AmdAocl(BundlePackage):
         with when(f"@={vers}"):
             depends_on(f"amdblis@={vers}")
             depends_on(f"amdfftw@={vers}")
-            depends_on(f"amdlibflame@={vers} ^[virtuals=blas] amdblis")
+            depends_on(f"amdlibflame@={vers}")
+            depends_on("amdlibflame ^[virtuals=blas] amdblis")
             depends_on(f"amdlibm@={vers}")
-            depends_on(
-                f"amdscalapack@={vers} ^[virtuals=blas] amdblis ^[virtuals=lapack] amdlibflame"
-            )
+            depends_on(f"amdscalapack@={vers}")
+            depends_on("amdscalapack ^[virtuals=blas] amdblis")
+            depends_on("amdscalapack ^[virtuals=lapack] amdlibflame")
             depends_on(f"aocl-sparse@={vers}")
             if Version(vers) >= Version("4.2"):
                 depends_on(f"aocl-compression@={vers}")

--- a/var/spack/repos/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/builtin/packages/amdblis/package.py
@@ -5,8 +5,6 @@
 
 import os
 
-from llnl.util import tty
-
 from spack.package import *
 from spack.pkg.builtin.blis import BlisBase
 
@@ -39,10 +37,11 @@ class Amdblis(BlisBase):
     license("BSD-3-Clause")
 
     version(
-        "4.2",
-        sha256="0e1baf850ba0e6f99e79f64bbb0a59fcb838ddb5028e24527f52b407c3c62963",
+        "5.0",
+        sha256="5abb34972b88b2839709d0af8785662bc651c7806ccfa41d386d93c900169bc2",
         preferred=True,
     )
+    version("4.2", sha256="0e1baf850ba0e6f99e79f64bbb0a59fcb838ddb5028e24527f52b407c3c62963")
     version("4.1", sha256="a05c6c7d359232580d1d599696053ad0beeedf50f3b88d5d22ee7d34375ab577")
     version("4.0", sha256="cddd31176834a932753ac0fc4c76332868feab3e9ac607fa197d8b44c1e74a41")
     version("3.2", sha256="5a400ee4fc324e224e12f73cc37b915a00f92b400443b15ce3350278ad46fff6")
@@ -65,18 +64,6 @@ class Amdblis(BlisBase):
     def configure_args(self):
         spec = self.spec
         args = super().configure_args()
-
-        if not (
-            spec.satisfies(r"%aocc@3.2:4.2")
-            or spec.satisfies(r"%gcc@12.2:13.1")
-            or spec.satisfies(r"%clang@15:17")
-        ):
-            tty.warn(
-                "AOCL has been tested to work with the following compilers "
-                "versions - gcc@12.2:13.1, aocc@3.2:4.2, and clang@15:17 "
-                "see the following aocl userguide for details: "
-                "https://www.amd.com/content/dam/amd/en/documents/developer/version-4-2-documents/aocl/aocl-4-2-user-guide.pdf"
-            )
 
         if spec.satisfies("+ilp64"):
             args.append("--blas-int-size=64")
@@ -125,3 +112,12 @@ class Amdblis(BlisBase):
                 os.symlink("libblis-mt.a", "libblis.a")
             if os.path.isfile("libblis-mt.so"):
                 os.symlink("libblis-mt.so", "libblis.so")
+
+    @property
+    def libs(self):
+        return find_libraries(
+            ["libblis"] if self.spec.satisfies("threads=none") else ["libblis-mt"],
+            root=self.prefix,
+            shared=self.spec.satisfies("libs=shared"),
+            recursive=True,
+        )

--- a/var/spack/repos/builtin/packages/amdfftw/package.py
+++ b/var/spack/repos/builtin/packages/amdfftw/package.py
@@ -5,8 +5,6 @@
 
 import os
 
-from llnl.util import tty
-
 from spack.build_environment import optimization_flags
 from spack.package import *
 from spack.pkg.builtin.fftw import FftwBase
@@ -43,10 +41,11 @@ class Amdfftw(FftwBase):
     license("GPL-2.0-only")
 
     version(
-        "4.2",
-        sha256="391ef7d933e696762e3547a35b58ab18d22a6cf3e199c74889bcf25a1d1fc89b",
+        "5.0",
+        sha256="bead6c08309a206f8a6258971272affcca07f11eb57b5ecd8496e2e7e3ead877",
         preferred=True,
     )
+    version("4.2", sha256="391ef7d933e696762e3547a35b58ab18d22a6cf3e199c74889bcf25a1d1fc89b")
     version("4.1", sha256="f1cfecfcc0729f96a5bd61c6b26f3fa43bb0662d3fff370d4f73490c60cf4e59")
     version("4.0", sha256="5f02cb05f224bd86bd88ec6272b294c26dba3b1d22c7fb298745fd7b9d2271c0")
     version("3.2", sha256="31cab17a93e03b5b606e88dd6116a1055b8f49542d7d0890dbfcca057087b8d0")
@@ -158,6 +157,13 @@ class Amdfftw(FftwBase):
 
     requires("target=x86_64:", msg="AMD FFTW available only on x86_64")
 
+    def flag_handler(self, name, flags):
+        (flags, _, _) = super().flag_handler(name, flags)
+        if name == "cflags":
+            if self.spec.satisfies("%gcc@14:"):
+                flags.append("-Wno-incompatible-pointer-types")
+        return (flags, None, None)
+
     def configure(self, spec, prefix):
         """Configure function"""
         # Base options
@@ -174,18 +180,6 @@ class Amdfftw(FftwBase):
             options.append("CC={0}".format(os.path.basename(spack_cc)))
             options.append("FC={0}".format(os.path.basename(spack_fc)))
             options.append("F77={0}".format(os.path.basename(spack_fc)))
-
-        if not (
-            spec.satisfies(r"%aocc@3.2:4.2")
-            or spec.satisfies(r"%gcc@12.2:13.1")
-            or spec.satisfies(r"%clang@15:17")
-        ):
-            tty.warn(
-                "AOCL has been tested to work with the following compilers "
-                "versions - gcc@12.2:13.1, aocc@3.2:4.2, and clang@15:17 "
-                "see the following aocl userguide for details: "
-                "https://www.amd.com/content/dam/amd/en/documents/developer/version-4-2-documents/aocl/aocl-4-2-user-guide.pdf"
-            )
 
         if spec.satisfies("+debug"):
             options.append("--enable-debug")

--- a/var/spack/repos/builtin/packages/amdlibflame/libflame-pkgconfig.patch
+++ b/var/spack/repos/builtin/packages/amdlibflame/libflame-pkgconfig.patch
@@ -1,0 +1,29 @@
+diff -Naru a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2024-02-26 18:26:37.000000000 +0000
++++ b/CMakeLists.txt	2024-03-19 20:48:44.099094687 +0000
+@@ -1197,3 +1197,12 @@
+         PROPERTY ADDITIONAL_CLEAN_FILES 
+ 		${CMAKE_SOURCE_DIR}/build/FLA_config.h ${CMAKE_SOURCE_DIR}/include/
+ )
++
++# pkgconfig file
++set (prefix ${CMAKE_INSTALL_PREFIX})
++set (VERSION 4.2)
++configure_file (flame.pc.in flame.pc @ONLY)
++install (FILES
++         ${CMAKE_CURRENT_BINARY_DIR}/flame.pc
++         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig
++         COMPONENT Development)
+diff -Naru a/flame.pc.in b/flame.pc.in
+--- a/flame.pc.in	1970-01-01 00:00:00.000000000 +0000
++++ b/flame.pc.in	2024-03-19 20:48:51.112058421 +0000
+@@ -0,0 +1,9 @@
++prefix=@prefix@
++libdir=${prefix}/lib
++includedir=${prefix}/include
++
++Name: libFLAME
++Description: AMD-optimized libFLAME library
++Version: @VERSION@
++Libs: -L${libdir} -lflame
++Cflags: -I${includedir}

--- a/var/spack/repos/builtin/packages/amdlibm/package.py
+++ b/var/spack/repos/builtin/packages/amdlibm/package.py
@@ -5,8 +5,6 @@
 
 import os
 
-from llnl.util import tty
-
 from spack.package import *
 
 
@@ -28,16 +26,17 @@ class Amdlibm(SConsPackage):
     _name = "amdlibm"
     homepage = "https://www.amd.com/en/developer/aocl/libm.html"
     git = "https://github.com/amd/aocl-libm-ose.git"
-    url = "https://github.com/amd/aocl-libm-ose/archive/refs/tags/3.0.tar.gz"
+    url = "https://github.com/amd/aocl-libm-ose/archive/3.0.tar.gz"
     maintainers("amd-toolchain-support")
 
     license("BSD-3-Clause")
 
     version(
-        "4.2",
-        sha256="58847b942e998b3f52eb41ae26403c7392d244fcafa707cbf23165aac24edd9e",
+        "5.0",
+        sha256="ba1d50c068938c9a927e37e5630f683b6149d7d5a95efffeb76e7c9a8bcb2b5e",
         preferred=True,
     )
+    version("4.2", sha256="58847b942e998b3f52eb41ae26403c7392d244fcafa707cbf23165aac24edd9e")
     version("4.1", sha256="5bbbbc6bc721d9a775822eab60fbc11eb245e77d9f105b4fcb26a54d01456122")
     version("4.0", sha256="038c1eab544be77598eccda791b26553d3b9e2ee4ab3f5ad85fdd2a77d015a7d")
     version("3.2", sha256="c75b287c38a3ce997066af1f5c8d2b19fc460d5e56678ea81f3ac33eb79ec890")
@@ -54,7 +53,7 @@ class Amdlibm(SConsPackage):
     depends_on("python@3.6.1:", type=("build", "run"))
     depends_on("scons@3.1.2:", type=("build"))
     depends_on("mpfr", type=("link"))
-    for vers in ["4.1", "4.2"]:
+    for vers in ["4.1", "4.2", "5.0"]:
         with when(f"@{vers}"):
             depends_on(f"aocl-utils@{vers}")
 
@@ -66,9 +65,13 @@ class Amdlibm(SConsPackage):
     patch("libm-ose-SconsSpack.patch", when="@3.1:4.2")
 
     conflicts("%gcc@:9.1.0", msg="Minimum supported GCC version is 9.2.0")
-    conflicts("%gcc@13.2.0:", msg="Maximum supported GCC version is 13.1.0")
-    conflicts("%clang@9.0:16.0", msg="supported Clang version is from 9 to 16")
+    conflicts("%clang@:9.0", msg="Minimum supported Clang version is 9")
+    conflicts("%clang@17.0.0:", msg="Maximum supported Clang version is 17.0.0")
+    conflicts("%gcc@14.3.0:", msg="Maximum supported GCC version is 14.2.0")
     conflicts("%aocc@3.2.0", msg="dependency on python@3.6.2")
+
+    def patch(self):
+        filter_file("14.1", "14.2", "scripts/site_scons/alm/check.py")
 
     def build_args(self, spec, prefix):
         """Setting build arguments for amdlibm"""
@@ -76,18 +79,6 @@ class Amdlibm(SConsPackage):
 
         if self.spec.satisfies("@4.1: "):
             args.append("--aocl_utils_install_path={0}".format(self.spec["aocl-utils"].prefix))
-
-        if not (
-            self.spec.satisfies(r"%aocc@3.2:4.2")
-            or self.spec.satisfies(r"%gcc@12.2:13.1")
-            or self.spec.satisfies(r"%clang@15:16")
-        ):
-            tty.warn(
-                "AOCL has been tested to work with the following compilers\
-                    versions - gcc@12.2:13.1, aocc@3.2:4.2, and clang@15:16\
-                    see the following aocl userguide for details: \
-                    https://www.amd.com/content/dam/amd/en/documents/developer/version-4-2-documents/aocl/aocl-4-2-user-guide.pdf"
-            )
 
         # we are circumventing the use of
         # Spacks compiler wrappers because

--- a/var/spack/repos/builtin/packages/aocl-crypto/lsb_release.patch
+++ b/var/spack/repos/builtin/packages/aocl-crypto/lsb_release.patch
@@ -1,0 +1,153 @@
+diff --git a/cmake/CompilerLinux.cmake b/cmake/CompilerLinux.cmake
+index f54bea37..8541e343 100644
+--- a/cmake/CompilerLinux.cmake
++++ b/cmake/CompilerLinux.cmake
+@@ -32,22 +32,11 @@ function(alcp_get_build_environment)
+         set (ALCP_BUILD_COMPILER "Clang_v${CMAKE_CXX_COMPILER_VERSION}")
+     endif()
+ 
+-    # uses lsb_release utility on linux, as cmake doesnt have a variable which has the Linux flavor information
+-    find_program(LSB_RELEASE_EXEC lsb_release)
+-    if(NOT LSB_RELEASE_EXEC)
+-        MESSAGE(FATAL_ERROR "LSB Release is missing from the machine, please install lsb_release!")
+-    endif()
+-    execute_process(COMMAND ${LSB_RELEASE_EXEC} -r -s
+-        OUTPUT_VARIABLE OS_VERSION
+-        OUTPUT_STRIP_TRAILING_WHITESPACE
+-    )
+-    execute_process(COMMAND ${LSB_RELEASE_EXEC} -i -s
+-        OUTPUT_VARIABLE OS_VENDOR
+-        OUTPUT_STRIP_TRAILING_WHITESPACE
+-    )
+-    
++    cmake_host_system_information(RESULT OS_VERSION QUERY DISTRIB_PRETTY_NAME)
++    message(STATUS "OS Information: ${OS_VERSION}")
++
+     # final build env string will contain compiler and system environment details where the binary was created
+-    set (ALCP_BUILD_ENV ${ALCP_BUILD_COMPILER}_${OS_VENDOR}_${OS_VERSION} PARENT_SCOPE)
++    set (ALCP_BUILD_ENV ${ALCP_BUILD_COMPILER}_${OS_VERSION} PARENT_SCOPE)
+ endfunction(alcp_get_build_environment)
+ 
+ 
+diff --git a/docs/resources/Quick_Start.md b/docs/resources/Quick_Start.md
+index 17bc025a..278a3d1f 100644
+--- a/docs/resources/Quick_Start.md
++++ b/docs/resources/Quick_Start.md
+@@ -141,47 +141,6 @@ AOCL_CRYPTO_REPO="https://github.com/amd/aocl-crypto.git"
+ AOCL_UTILS_REPO="https://github.com/amd/aocl-utils.git"
+ AOCL_BRANCH="amd-main"
+ 
+-# Function to check if lsb_release is installed
+-ensure_lsb_release(){
+-    if ! type "lsb_release" > /dev/null; then
+-        if type "apt" > /dev/null; then
+-            if type "sudo" > /dev/null; then
+-                sudo apt update
+-                sudo apt install lsb-release
+-            else
+-                echo "lsb-release not found, cannot install! missing \"sudo\" binary"
+-                exit -1; # We cannot do anything anymore
+-            fi
+-        else
+-            echo "lsb-release not found, cannot install! missing \"apt\" binary"
+-        fi
+-    fi
+-
+-    type lsb_release > /dev/null
+-    if [ $? -ne 0 ]; then
+-        echo "lsb_release not found!"
+-        exit -1;
+-    else
+-        echo "lsb_release found"
+-    fi
+-}
+-
+-# Function to check if OS is ubuntu with a specific version
+-detect_ubuntu(){
+-
+-    lsb_release --id | grep "Ubuntu" > /dev/null
+-    if [ $? -eq 0 ]; then
+-        # Detected Ubuntu
+-        echo "Detected Ubuntu"
+-        lsb_release --release | grep $1 > /dev/null
+-        if [ $? -eq 0 ]; then
+-            echo "Detected OS Release Version $1"
+-            return 0
+-        fi
+-    fi
+-    return 1 # Return error
+-}
+-
+ # Function to exit with an error if some execution failed
+ quit_if_status_not_zero(){
+     if [ $1 -ne 0 ]; then
+@@ -338,8 +297,6 @@ run_example_cfb(){
+ 
+ # Make sure we dont destroy anything
+ ensure_no_directory_conflict
+-# Make sure we can detect the OS
+-ensure_lsb_release
+ # Make sure all the needed packages (dependancies) are installed
+ ensure_packages
+ # Clone Utils and Crypto
+diff --git a/scripts/Clone_Build.sh b/scripts/Clone_Build.sh
+index 89a7cd2f..1ed2f3cf 100755
+--- a/scripts/Clone_Build.sh
++++ b/scripts/Clone_Build.sh
+@@ -36,47 +36,6 @@ AOCL_CRYPTO_REPO="git@er.github.amd.com:AOCL/aocl-crypto"
+ AOCL_UTILS_REPO="git@github.amd.com:AOCL/aocl-utils"
+ AOCL_BRANCH="amd-main"
+ 
+-# Function to check if lsb_release is installed
+-ensure_lsb_release(){
+-    if ! type "lsb_release" > /dev/null; then
+-        if type "apt" > /dev/null; then
+-            if type "sudo" > /dev/null; then
+-                sudo apt update
+-                sudo apt install lsb-release
+-            else
+-                echo "lsb-release not found, cannot install! missing \"sudo\" binary"
+-                exit -1; # We cannot do anything anymore
+-            fi
+-        else
+-            echo "lsb-release not found, cannot install! missing \"apt\" binary"
+-        fi
+-    fi
+-
+-    type lsb_release > /dev/null
+-    if [ $? -ne 0 ]; then
+-        echo "lsb_release not found!"
+-        exit -1;
+-    else
+-        echo "lsb_release found"
+-    fi
+-}
+-
+-# Function to check if OS is ubuntu with a specific version
+-detect_ubuntu(){
+-
+-    lsb_release --id | grep "Ubuntu" > /dev/null
+-    if [ $? -eq 0 ]; then
+-        # Detected Ubuntu
+-        echo "Detected Ubuntu"
+-        lsb_release --release | grep $1 > /dev/null
+-        if [ $? -eq 0 ]; then
+-            echo "Detected OS Release Version $1"
+-            return 0
+-        fi
+-    fi
+-    return 1 # Return error
+-}
+-
+ # Function to exit with an error if some execution failed
+ quit_if_status_not_zero(){
+     if [ $1 -ne 0 ]; then
+@@ -233,8 +192,6 @@ run_example_cfb(){
+ 
+ # Make sure we dont destroy anything
+ ensure_no_directory_conflict
+-# Make sure we can detect the OS
+-ensure_lsb_release
+ # Make sure all the needed packages (dependancies) are installed
+ ensure_packages
+ # Clone Utils and Crypto

--- a/var/spack/repos/builtin/packages/aocl-crypto/package.py
+++ b/var/spack/repos/builtin/packages/aocl-crypto/package.py
@@ -53,6 +53,7 @@ class AoclCrypto(CMakePackage):
     patch(
         "lsb_release.patch",
         sha256="b61d6d2518276c56d37e8c64d18488081af70f29a62f315ecbd23664e0e440b9",
+        when="@5.0",
     )
 
     depends_on("cmake@3.22:", type="build")

--- a/var/spack/repos/builtin/packages/aocl-crypto/package.py
+++ b/var/spack/repos/builtin/packages/aocl-crypto/package.py
@@ -2,10 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 # ----------------------------------------------------------------------------
-from llnl.util import tty
-
 from spack.package import *
 
 
@@ -35,24 +32,34 @@ class AoclCrypto(CMakePackage):
 
     _name = "aocl-crypto"
     homepage = "https://www.amd.com/en/developer/aocl/cryptography.html"
-    git = "https://github.com/amd/aocl-crypto"
-    url = "https://github.com/amd/aocl-crypto/archive/refs/tags/4.2.tar.gz"
+    url = "https://github.com/amd/aocl-crypto/archive/4.2.tar.gz"
+    git = "https://github.com/amd/aocl-crypto/"
 
     maintainers("amd-toolchain-support")
+
     version(
-        "4.2",
-        sha256="2bdbedd8ab1b28632cadff237f4abd776e809940ad3633ad90fc52ce225911fe",
+        "5.0",
+        sha256="b15e609943f9977e13f2d5839195bb7411c843839a09f0ad47f78f57e8821c23",
         preferred=True,
     )
+    version("4.2", sha256="2bdbedd8ab1b28632cadff237f4abd776e809940ad3633ad90fc52ce225911fe")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     variant("examples", default=False, description="Build examples")
+    variant("ipp", default=False, description="Build Intel IPP library")
 
-    depends_on("cmake@3.15:", type="build")
-    depends_on("openssl@3.0.0:")
+    # Removed dependency on lsb_release
+    patch(
+        "lsb_release.patch",
+        sha256="b61d6d2518276c56d37e8c64d18488081af70f29a62f315ecbd23664e0e440b9",
+    )
+
+    depends_on("cmake@3.22:", type="build")
+    depends_on("openssl@3.1.5:")
+    depends_on("intel-oneapi-ippcp@2021.12.0:", when="+ipp")
     depends_on("p7zip", type="build")
-    for vers in ["4.2"]:
+    for vers in ["4.2", "5.0"]:
         with when(f"@={vers}"):
             depends_on(f"aocl-utils@={vers}")
 
@@ -75,22 +82,22 @@ class AoclCrypto(CMakePackage):
     def cmake_args(self):
         """Runs ``cmake`` in the build directory"""
         spec = self.spec
-        if not (
-            spec.satisfies(r"%aocc@4.1:4.2")
-            or spec.satisfies(r"%gcc@12.2:13.1")
-            or spec.satisfies(r"%clang@16:17")
-        ):
-            tty.warn(
-                "AOCL has been tested to work with the following compilers "
-                "versions - gcc@12.2:13.1, aocc@4.1:4.2, and clang@16:17 "
-                "see the following aocl userguide for details: "
-                "https://www.amd.com/content/dam/amd/en/documents/developer/version-4-2-documents/aocl/aocl-4-2-user-guide.pdf"
-            )
 
-        args = ["-DCMAKE_C_COMPILER=%s" % spack_cc, "-DCMAKE_CXX_COMPILER=%s" % spack_cxx]
-        args.append(self.define_from_variant("ALCP_ENABLE_EXAMPLES", "examples"))
-        args.append("-DOPENSSL_INSTALL_DIR=" + spec["openssl"].prefix)
-        args.append("-DENABLE_AOCL_UTILS=ON")
-        args.append("-DAOCL_UTILS_INSTALL_DIR=" + spec["aocl-utils"].prefix)
+        args = [
+            self.define_from_variant("ALCP_ENABLE_EXAMPLES", "examples"),
+            self.define("ENABLE_AOCL_UTILS", True),
+            self.define("AOCL_UTILS_INSTALL_DIR", spec["aocl-utils"].prefix),
+            self.define("CMAKE_INSTALL_LIBDIR", "lib"),
+            self.define("ALCP_ENABLE_DYNAMIC_COMPILER_PICK", False),
+        ]
+
+        compat_libs = ["openssl"]
+        args.append(self.define("OPENSSL_INSTALL_DIR", spec["openssl"].prefix))
+
+        if "+ipp" in spec:
+            compat_libs.append("ipp")
+            args.append(self.define("IPP_INSTALL_DIR", spec["intel-oneapi-ippcp"].prefix))
+
+        args.append(self.define("AOCL_COMPAT_LIBS", ",".join(compat_libs)))
 
         return args

--- a/var/spack/repos/builtin/packages/aocl-da/0001-Fix-to-enable-cmake-to-be-configured-with-examples-o.patch
+++ b/var/spack/repos/builtin/packages/aocl-da/0001-Fix-to-enable-cmake-to-be-configured-with-examples-o.patch
@@ -1,0 +1,27 @@
+From 961ce9edbba7e18eca97cf3725515e627bbe39e1 Mon Sep 17 00:00:00 2001
+From: Edvin Hopkins <edvin.hopkins@amd.com>
+Date: Wed, 16 Oct 2024 11:38:28 +0100
+Subject: [PATCH] Fix to enable cmake to be configured with examples off but
+ gtests on
+
+---
+ tests/unit_tests/CMakeLists.txt | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/tests/unit_tests/CMakeLists.txt b/tests/unit_tests/CMakeLists.txt
+index e5e05c6..e479c7d 100644
+--- a/tests/unit_tests/CMakeLists.txt
++++ b/tests/unit_tests/CMakeLists.txt
+@@ -107,9 +107,6 @@ add_executable(kmeans_tests kmeans_tests.cpp)
+ add_executable(nlls_tests nlls_tests.cpp)
+ 
+ add_executable(pca_tests pca_tests.cpp)
+-target_compile_definitions(
+-  pca
+-  PRIVATE DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../data/factorization_data/")
+ target_link_libraries(pca_tests PRIVATE ${BLAS})
+ 
+ add_executable(data data_tests.cpp)
+-- 
+2.34.1
+

--- a/var/spack/repos/builtin/packages/aocl-da/package.py
+++ b/var/spack/repos/builtin/packages/aocl-da/package.py
@@ -1,0 +1,123 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack.package import *
+from spack.util.environment import EnvironmentModifications
+
+
+class AoclDa(CMakePackage):
+    """
+    The AOCL Data Analytics Library (AOCL-DA) is a data analytics library
+    providing optimized building blocks for data analysis. It is written with a
+    C-compatible interface to make it as seamless as possible to integrate
+    with the library from whichever programming language you are using.
+    The intended workflow for using the library is as follows:
+    • load data from memory by reading CSV files or using the in-built
+    da_datastore object
+    • preprocess the data by removing missing values, standardizing, and
+    selecting certain subsets of the data, before extracting contiguous
+    arrays of data from the da_datastore objects
+    • data processing (e.g. principal component analysis, linear model
+    fitting, etc.)
+    C++ example programs can be found in the examples folder of your
+    installation.
+    """
+
+    _name = "aocl-da"
+    homepage = "https://www.amd.com/en/developer/aocl/analytics.html"
+    git = "https://github.com/amd/aocl-data-analytics"
+    url = "https://github.com/amd/aocl-data-analytics/archive/5.0.tar.gz"
+
+    maintainers("amd-toolchain-support")
+
+    version("5.0", sha256="3458adc7be39c78a08232c887f32838633149df0a69ccea024327c3edc5a5c1d")
+
+    variant("examples", default=True, description="Build examples")
+    variant("gtest", default=False, description="Build and install Googletest")
+    variant("ilp64", default=False, description="Build with ILP64 support")
+    variant(
+        "openmp",
+        default=True,
+        description="Build using OpenMP and link to threaded BLAS and LAPACK",
+    )
+    variant("shared", default=True, description="Build shared libraries")
+    variant("python", default=True, description="Build with Python bindings")
+
+    depends_on("cmake@3.22:", type="build")
+    for vers in ["5.0"]:
+        with when(f"@={vers}"):
+            depends_on(f"aocl-utils@={vers} +shared", when="+shared")
+            depends_on(f"aocl-utils@={vers} ~shared", when="~shared")
+            depends_on(f"amdblis@={vers} libs=shared", when="+shared")
+            depends_on(f"amdblis@={vers} libs=static", when="~shared")
+            depends_on(f"amdlibflame@={vers} +shared", when="+shared")
+            depends_on(f"amdlibflame@={vers} ~shared", when="~shared")
+            depends_on(f"aocl-sparse@={vers} +shared", when="+shared")
+            depends_on(f"aocl-sparse@={vers} ~shared", when="~shared")
+
+    depends_on("amdblis threads=openmp", when="+openmp")
+    depends_on("amdlibflame threads=openmp", when="+openmp")
+    depends_on("amdblis threads=none", when="~openmp")
+    depends_on("amdlibflame threads=none", when="~openmp")
+    depends_on("aocl-sparse +openmp", when="+openmp")
+    depends_on("aocl-sparse ~openmp", when="~openmp")
+
+    with when("+python"):
+        depends_on("python", type=("build", "run"))
+        depends_on("py-wheel", type=("build", "run"))
+        depends_on("py-setuptools", type=("build", "run"))
+        depends_on("py-pybind11", type=("build", "link", "run"))
+        depends_on("py-numpy", type=("build", "run"))
+        depends_on("py-pip", type=("build", "run"))
+        depends_on("patchelf", type="build")
+        depends_on("py-pytest", type="test")
+        depends_on("py-scikit-learn", type=("test", "run"))
+
+    def setup_build_environment(self, env):
+        if self.spec.satisfies("%aocc"):
+            cc = self.compiler.cc
+            compiler_install_dir = os.path.dirname(os.path.dirname(cc))
+            env.append_path("LD_LIBRARY_PATH", join_path(compiler_install_dir, "lib"))
+
+    def setup_run_environment(self, env):
+        env.prepend_path("PYTHONPATH", join_path(self.prefix, "python_package"))
+
+    def cmake_args(self):
+        """Runs ``cmake`` in the build directory"""
+        spec = self.spec
+        args = []
+        args.append(f"-DUTILS_LIB={spec['aocl-utils'].libs}")
+        args.append(f"-DUTILS_CPUID_LIB={spec['aocl-utils'].libs}")
+        args.append(f"-DUTILS_CORE_LIB={spec['aocl-utils'].libs}")
+        args.append(f"-DBLAS_LIB={spec['amdblis'].libs}")
+        args.append("-DBLAS_INCLUDE_DIR={0}/blis".format(spec["amdblis"].prefix.include))
+        args.append(f"-DLAPACK_LIB={spec['amdlibflame'].libs}")
+        args.append("-DLAPACK_INCLUDE_DIR={0}".format(spec["amdlibflame"].prefix.include))
+        args.append(f"-DSPARSE_LIB={spec['aocl-sparse'].libs}")
+        args.append("-DSPARSE_INCLUDE_DIR={0}".format(spec["aocl-sparse"].prefix.include))
+        args.append(self.define_from_variant("BUILD_EXAMPLES", "examples"))
+        args.append(self.define_from_variant("BUILD_GTEST", "gtest"))
+        args.append(self.define_from_variant("BUILD_ILP64", "ilp64"))
+        args.append(self.define_from_variant("BUILD_SMP", "openmp"))
+        args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+        args.append(self.define_from_variant("BUILD_PYTHON", "python"))
+
+        return args
+
+    @run_after("install")
+    @on_package_attributes(run_tests=True)
+    def test_python(self):
+        """Perform smoke tests on the installed package."""
+        pytest = which("pytest")
+        envmod = EnvironmentModifications()
+        envmod.append_path("PYTHONPATH", join_path(self.prefix, "python_package"))
+        pytest.add_default_envmod(envmod)
+        pytest(
+            join_path(
+                install_test_root(self), join_path(self.stage.source_path, "python_interface")
+            )
+        )

--- a/var/spack/repos/builtin/packages/aocl-da/package.py
+++ b/var/spack/repos/builtin/packages/aocl-da/package.py
@@ -28,7 +28,7 @@ class AoclDa(CMakePackage):
     """
 
     _name = "aocl-da"
-    homepage = "https://www.amd.com/en/developer/aocl/analytics.html"
+    homepage = "https://www.amd.com/en/developer/aocl/data-analytics.html"
     git = "https://github.com/amd/aocl-data-analytics"
     url = "https://github.com/amd/aocl-data-analytics/archive/5.0.tar.gz"
 
@@ -46,6 +46,13 @@ class AoclDa(CMakePackage):
     )
     variant("shared", default=True, description="Build shared libraries")
     variant("python", default=True, description="Build with Python bindings")
+
+    # Fix to enable cmake to be configured with examples off but gtest on
+    patch(
+        "0001-Fix-to-enable-cmake-to-be-configured-with-examples-o.patch",
+        sha256="65be59e99d52816cb77d3e887cd4816870576b46748b53073658caa9ca07d127",
+        when="@5.0",
+    )
 
     depends_on("cmake@3.22:", type="build")
     for vers in ["5.0"]:

--- a/var/spack/repos/builtin/packages/aocl-libmem/cmake.patch
+++ b/var/spack/repos/builtin/packages/aocl-libmem/cmake.patch
@@ -1,0 +1,46 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 74b7bd8..d787a7d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -32,7 +32,7 @@ endif()
+ # set the project name and version
+ set(LIBMEM_VERSION_STRING 5.0)
+ 
+-project(aocl-libmem VERSION ${LIBMEM_VERSION_STRING} LANGUAGES C DESCRIPTION
++project(aocl-libmem VERSION ${LIBMEM_VERSION_STRING} LANGUAGES C CXX DESCRIPTION
+                         "Library of AMD optimized string/memory functions")
+ 
+ string(TIMESTAMP BUILD_DATE "%Y%m%d")
+@@ -45,7 +45,7 @@ add_definitions(-DLIBMEM_BUILD_VERSION="${LIBMEM_BUILD_VERSION_STR}")
+ set(DEFAULT_BUILD_TYPE "Release")
+ 
+ set(CMAKE_C_STANDARD 99)
+-
++set(CMAKE_CXX_STANDARD 17)
+ option(ENABLE_LOGGING "Enable Logger" OFF)
+ 
+ option(ENABLE_TUNABLES "Enable user input" OFF)
+@@ -100,6 +100,22 @@ endif ()
+ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)
+ 
+ # let the build system know the tools directory
+-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tools)
++include(CheckCXXSourceRuns)
++check_cxx_source_runs("
++#include <cpuid.h>
++int main() {
++  unsigned int eax, ebx, ecx, edx;
++  if (__get_cpuid(0, &eax, &ebx, &ecx, &edx)) {
++    // The 'AuthenticAMD' string is EBX, EDX, ECX after calling cpuid with eax=0
++    if (ebx == 0x68747541 && edx == 0x69746E65 && ecx == 0x444D4163) {
++      return 0; // AMD CPU detected
++    }
++  }
++  return 1; // Non-AMD CPU
++}
++" AMD_Tools)
++if(AMD_Tools)
++    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tools)
++endif()
+ 
+ file(WRITE ${CMAKE_BINARY_DIR}/version.h ${LIBMEM_BUILD_VERSION_STR})

--- a/var/spack/repos/builtin/packages/aocl-libmem/package.py
+++ b/var/spack/repos/builtin/packages/aocl-libmem/package.py
@@ -54,6 +54,13 @@ class AoclLibmem(CMakePackage):
         multi=False,
     )
 
+    # validator needs to be built only for AuthenticAMD targets
+    patch(
+        "cmake.patch",
+        sha256="43453a83f322de7c89264439b2e9cbde855e50f550e13ebc884d13d959002092",
+        when="@5.0",
+    )
+
     depends_on("cmake@3.22:", type="build")
 
     @property

--- a/var/spack/repos/builtin/packages/aocl-libmem/package.py
+++ b/var/spack/repos/builtin/packages/aocl-libmem/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 # ----------------------------------------------------------------------------
-from llnl.util import tty
-
 from spack.package import *
 
 
@@ -31,15 +29,16 @@ class AoclLibmem(CMakePackage):
     _name = "aocl-libmem"
     homepage = "https://www.amd.com/en/developer/aocl/libmem.html"
     git = "https://github.com/amd/aocl-libmem"
-    url = "https://github.com/amd/aocl-libmem/archive/refs/tags/4.2.tar.gz"
+    url = "https://github.com/amd/aocl-libmem/archive/4.2.tar.gz"
 
     maintainers("amd-toolchain-support")
 
     version(
-        "4.2",
-        sha256="4ff5bd8002e94cc2029ef1aeda72e7cf944b797c7f07383656caa93bcb447569",
+        "5.0",
+        sha256="d3148db1a57fec4f3468332c775cade356e8133bf88385991964edd7534b7e22",
         preferred=True,
     )
+    version("4.2", sha256="4ff5bd8002e94cc2029ef1aeda72e7cf944b797c7f07383656caa93bcb447569")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
@@ -55,7 +54,7 @@ class AoclLibmem(CMakePackage):
         multi=False,
     )
 
-    depends_on("cmake@3.15:", type="build")
+    depends_on("cmake@3.22:", type="build")
 
     @property
     def libs(self):
@@ -66,18 +65,6 @@ class AoclLibmem(CMakePackage):
     def cmake_args(self):
         """Runs ``cmake`` in the build directory"""
         spec = self.spec
-
-        if not (
-            spec.satisfies(r"%aocc@4.1:4.2")
-            or spec.satisfies(r"%gcc@12.2:13.1")
-            or spec.satisfies(r"%clang@16:17")
-        ):
-            tty.warn(
-                "AOCL has been tested to work with the following compilers "
-                "versions - gcc@12.2:13.1, aocc@4.1:4.2, and clang@16:17 "
-                "see the following aocl userguide for details: "
-                "https://www.amd.com/content/dam/amd/en/documents/developer/version-4-2-documents/aocl/aocl-4-2-user-guide.pdf"
-            )
 
         args = []
         args.append(self.define_from_variant("ENABLE_LOGGING", "logging"))


### PR DESCRIPTION
What is new in AOCL 5.0:

**AOCL-Data Analytics (aocl-da)**
- New library for optimized data analysis and machine learning.

**AOCL-BLAS(amdblis)**
- Specific tuning for Turin and AVX512 improvements for various APIs.
- Enhanced performance and additional support in aocl_gemm add-on.

**AOCL-Compression(aocl-compression)**
- Improved single-threaded performance for ZLIB and BZIP2.
- Multi-threaded support and performance boosts for LZ4, ZSTD, ZLIB, and Snappy.
- New options for faster compression and decompression.

**AOCL-Cryptography(aocl-crypto)**
- OpenSSL Provider support and fixes for several algorithms.
- New features like Chacha20-Poly1305 Cipher and RSA enhancements.
- Performance improvements for various cryptographic functions.

**AOCL-FFTW(amdfftw)**
- Default support for Wisdom feature with a specific option.

**AOCL-LAPACK(amdlibflame)**
- Enhancements to SVD, Factorization, and Solver APIs.
- New runtime options and improved documentation.

**AOCL-LibM(amdlibm)**
- New vector APIs and variants for mathematical functions.
- Beta version of CMAKE build system for Linux.

**AOCL-LibMem(aocl-libmem)**
- New functions and improved AVX2 performance.

**AOCL-ScaLAPACK(amdscalapack)**
- Build without test framework and enabled tracing/logging for all APIs.

**AOCL-Sparse(aocl-sparse)**
- New APIs and support for various matrix operations.
- Performance improvements and multi-threading support.

**AOCL-Utils(aocl-utils)**
- New APIs for ISA details and CPU feature checks.
- Thread pinning and support for Linux and Windows.

