### PR TITLE
py-jupyter-server: add v2.14.2 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/py-jupyter-events/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-events/package.py
@@ -12,10 +12,13 @@ class PyJupyterEvents(PythonPackage):
     homepage = "https://github.com/jupyter/jupyter_events"
     pypi = "jupyter_events/jupyter_events-0.6.3.tar.gz"
 
+    version("0.10.0", sha256="670b8229d3cc882ec782144ed22e0d29e1c2d639263f92ca8383e66682845e22")
     version("0.6.3", sha256="9a6e9995f75d1b7146b436ea24d696ce3a35bfa8bfe45e0c33c334c79464d0b3")
 
     depends_on("py-hatchling@1.5:", type="build")
 
+    depends_on("py-referencing", type=("build", "run"), when="@0.7:")
+    depends_on("py-jsonschema+format-nongpl@4.18:", type=("build", "run"), when="@0.7:")
     depends_on("py-jsonschema+format-nongpl@3.2:", type=("build", "run"))
     depends_on("py-python-json-logger@2.0.4:", type=("build", "run"))
     depends_on("py-pyyaml@5.3:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-jupyter-server/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-server/package.py
@@ -22,12 +22,24 @@ class PyJupyterServer(PythonPackage):
     version("1.18.1", sha256="2b72fc595bccae292260aad8157a0ead8da2c703ec6ae1bb7b36dbad0e267ea7")
     with default_args(deprecated=True):
         # https://nvd.nist.gov/vuln/detail/CVE-2022-29241
-        version("1.17.0", sha256="7b3aa524790ab0da64f06dfe0b2af149d0a3f59aad71fdedcf1d8bae6508018c")
-        version("1.13.5", sha256="9e3e9717eea3bffab8cfb2ff330011be6c8bbd9cdae5b71cef169fcece2f19d3")
-        version("1.11.2", sha256="c1f32e0c1807ab2de37bf70af97a36b4436db0bc8af3124632b1f4441038bf95")
-        version("1.11.1", sha256="ab7ab1cc38512f15026cbcbb96300fb46ec8b24aa162263d9edd00e0a749b1e8")
-        version("1.11.0", sha256="8ab4f484a4a2698f757cff0769d27b5d991e0232a666d54f4d6ada4e6a61330b")
-        version("1.10.2", sha256="d3a3b68ebc6d7bfee1097f1712cf7709ee39c92379da2cc08724515bb85e72bf")
+        version(
+            "1.17.0", sha256="7b3aa524790ab0da64f06dfe0b2af149d0a3f59aad71fdedcf1d8bae6508018c"
+        )
+        version(
+            "1.13.5", sha256="9e3e9717eea3bffab8cfb2ff330011be6c8bbd9cdae5b71cef169fcece2f19d3"
+        )
+        version(
+            "1.11.2", sha256="c1f32e0c1807ab2de37bf70af97a36b4436db0bc8af3124632b1f4441038bf95"
+        )
+        version(
+            "1.11.1", sha256="ab7ab1cc38512f15026cbcbb96300fb46ec8b24aa162263d9edd00e0a749b1e8"
+        )
+        version(
+            "1.11.0", sha256="8ab4f484a4a2698f757cff0769d27b5d991e0232a666d54f4d6ada4e6a61330b"
+        )
+        version(
+            "1.10.2", sha256="d3a3b68ebc6d7bfee1097f1712cf7709ee39c92379da2cc08724515bb85e72bf"
+        )
         version("1.9.0", sha256="7d19006380f6217458a9db309b54e3dab87ced6c06329c61823907bef2a6f51b")
         version("1.6.1", sha256="242ddd0b644f10e030f917019b47c381e0f2d2b950164af45cbd791d572198ac")
 

--- a/var/spack/repos/builtin/packages/py-jupyter-server/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-server/package.py
@@ -16,17 +16,20 @@ class PyJupyterServer(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2.14.2", sha256="66095021aa9638ced276c248b1d81862e4c50f292d575920bbe960de1c56b12b")
     version("2.6.0", sha256="ae4af349f030ed08dd78cb7ac1a03a92d886000380c9ea6283f3c542a81f4b06")
     version("1.21.0", sha256="d0adca19913a3763359be7f0b8c2ea8bfde356f4b8edd8e3149d7d0fbfaa248b")
     version("1.18.1", sha256="2b72fc595bccae292260aad8157a0ead8da2c703ec6ae1bb7b36dbad0e267ea7")
-    version("1.17.0", sha256="7b3aa524790ab0da64f06dfe0b2af149d0a3f59aad71fdedcf1d8bae6508018c")
-    version("1.13.5", sha256="9e3e9717eea3bffab8cfb2ff330011be6c8bbd9cdae5b71cef169fcece2f19d3")
-    version("1.11.2", sha256="c1f32e0c1807ab2de37bf70af97a36b4436db0bc8af3124632b1f4441038bf95")
-    version("1.11.1", sha256="ab7ab1cc38512f15026cbcbb96300fb46ec8b24aa162263d9edd00e0a749b1e8")
-    version("1.11.0", sha256="8ab4f484a4a2698f757cff0769d27b5d991e0232a666d54f4d6ada4e6a61330b")
-    version("1.10.2", sha256="d3a3b68ebc6d7bfee1097f1712cf7709ee39c92379da2cc08724515bb85e72bf")
-    version("1.9.0", sha256="7d19006380f6217458a9db309b54e3dab87ced6c06329c61823907bef2a6f51b")
-    version("1.6.1", sha256="242ddd0b644f10e030f917019b47c381e0f2d2b950164af45cbd791d572198ac")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2022-29241
+        version("1.17.0", sha256="7b3aa524790ab0da64f06dfe0b2af149d0a3f59aad71fdedcf1d8bae6508018c")
+        version("1.13.5", sha256="9e3e9717eea3bffab8cfb2ff330011be6c8bbd9cdae5b71cef169fcece2f19d3")
+        version("1.11.2", sha256="c1f32e0c1807ab2de37bf70af97a36b4436db0bc8af3124632b1f4441038bf95")
+        version("1.11.1", sha256="ab7ab1cc38512f15026cbcbb96300fb46ec8b24aa162263d9edd00e0a749b1e8")
+        version("1.11.0", sha256="8ab4f484a4a2698f757cff0769d27b5d991e0232a666d54f4d6ada4e6a61330b")
+        version("1.10.2", sha256="d3a3b68ebc6d7bfee1097f1712cf7709ee39c92379da2cc08724515bb85e72bf")
+        version("1.9.0", sha256="7d19006380f6217458a9db309b54e3dab87ced6c06329c61823907bef2a6f51b")
+        version("1.6.1", sha256="242ddd0b644f10e030f917019b47c381e0f2d2b950164af45cbd791d572198ac")
 
     variant("typescript", default=False, description="Build the typescript code", when="@1.10.2:1")
 
@@ -46,7 +49,9 @@ class PyJupyterServer(PythonPackage):
     depends_on("npm", type="build", when="+typescript")
     depends_on("py-anyio@3.1.0:", when="@2.2.1:", type=("build", "run"))
     depends_on("py-anyio@3.1.0:3", when="@:2.2.0", type=("build", "run"))
+    depends_on("py-argon2-cffi@21.1:", when="@2.14:", type=("build", "run"))
     depends_on("py-argon2-cffi", type=("build", "run"))
+    depends_on("py-jinja2@3.0.3:", when="@2.14:", type=("build", "run"))
     depends_on("py-jinja2", type=("build", "run"))
     depends_on("py-jupyter-client@7.4.4:", when="@2:", type=("build", "run"))
     depends_on("py-jupyter-client@6.1.12:", when="@1.16:", type=("build", "run"))
@@ -54,18 +59,23 @@ class PyJupyterServer(PythonPackage):
     depends_on("py-jupyter-core@4.12:4,5.1:", when="@1.23.5:", type=("build", "run"))
     depends_on("py-jupyter-core@4.7:", when="@1.16:", type=("build", "run"))
     depends_on("py-jupyter-core@4.6:", type=("build", "run"))
+    depends_on("py-jupyter-server-terminals@0.4.4:", when="@2.14:", type=("build", "run"))
     depends_on("py-jupyter-server-terminals", when="@2:", type=("build", "run"))
     depends_on("py-nbconvert@6.4.4:", when="@1.16:", type=("build", "run"))
     depends_on("py-nbconvert", type=("build", "run"))
     depends_on("py-nbformat@5.3:", when="@2:", type=("build", "run"))
     depends_on("py-nbformat@5.2:", when="@1.15:", type=("build", "run"))
     depends_on("py-nbformat", type=("build", "run"))
+    depends_on("py-packaging@22.0:", when="@2.14:", type=("build", "run"))
     depends_on("py-packaging", when="@1.13.2:", type=("build", "run"))
+    depends_on("py-prometheus-client@0.9:", when="@2.14:", type=("build", "run"))
     depends_on("py-prometheus-client", type=("build", "run"))
+    # for windows depends_on pywinpty@2.0.1:, when='@2.14:'
     # for windows depends_on pywinpty, when='@1.13.2:'
     # py-pywinpty is not in spack and requires the build system maturin
     depends_on("py-pyzmq@24:", when="@2:", type=("build", "run"))
     depends_on("py-pyzmq@17:", type=("build", "run"))
+    depends_on("py-send2trash@1.8.2:", when="@2.7.1:", type=("build", "run"))
     depends_on("py-send2trash", type=("build", "run"))
     depends_on("py-terminado@0.8.3:", type=("build", "run"))
     depends_on("py-tornado@6.2:", when="@2:", type=("build", "run"))
@@ -74,8 +84,11 @@ class PyJupyterServer(PythonPackage):
     depends_on("py-traitlets@5.1:", when="@1.16:", type=("build", "run"))
     depends_on("py-traitlets@5:", when="@1.13.3:", type=("build", "run"))
     depends_on("py-traitlets@4.2.1:", type=("build", "run"))
+    depends_on("py-websocket-client@1.7:", when="@2.14:", type=("build", "run"))
     depends_on("py-websocket-client", type=("build", "run"))
+    depends_on("py-jupyter-events@0.9:", when="@2.10.1:", type=("build", "run"))
     depends_on("py-jupyter-events@0.6:", when="@2.6:", type=("build", "run"))
+    depends_on("py-overrides@5.0:", when="@2.14:", type=("build", "run"))
     depends_on("py-overrides", when="@2.6:", type=("build", "run"))
 
     # old

--- a/var/spack/repos/builtin/packages/py-send2trash/package.py
+++ b/var/spack/repos/builtin/packages/py-send2trash/package.py
@@ -14,6 +14,7 @@ class PySend2trash(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.8.3", sha256="90bcdf2ed2a18b687040c0f58bfccd6ad2e1b7ec495a9903119dc3c47c615052")
     version("1.8.0", sha256="937b038abd9f1e7b8c5d7a116be5dc4663beb71df74dcccffe56cacf992c7a9c")
     version("1.5.0", sha256="7cebc0ffc8b6d6e553bce9c6bb915614610ba2dec17c2f0643b1b97251da2a41")
 

--- a/var/spack/repos/builtin/packages/py-websocket-client/package.py
+++ b/var/spack/repos/builtin/packages/py-websocket-client/package.py
@@ -34,7 +34,7 @@ class PyWebsocketClient(PythonPackage):
 
     def url_for_version(self, version):
         url = "https://files.pythonhosted.org/packages/source/w/{0}/{0}-{1}.tar.gz"
-        if version >= Version("0.59.0"):
+        if self.spec.satisfies("@0.59.0:1.7"):
             letter = "websocket-client"
         else:
             letter = "websocket_client"

--- a/var/spack/repos/builtin/packages/py-websocket-client/package.py
+++ b/var/spack/repos/builtin/packages/py-websocket-client/package.py
@@ -15,6 +15,9 @@ class PyWebsocketClient(PythonPackage):
 
     license("Apache-2.0")
 
+    version("1.8.0", sha256="3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da")
+    version("1.7.0", sha256="10e511ea3a8c744631d3bd77e61eb17ed09304c413ad42cf6ddfa4c7787e8fe6")
+    version("1.6.4", sha256="b3324019b3c28572086c4a319f91d1dcd44e6e11cd340232978c684a7650d0df")
     version("1.6.3", sha256="3aad25d31284266bcfcfd1fd8a743f63282305a364b8d0948a43bd606acc652f")
     version("1.5.1", sha256="3f09e6d8230892547132177f575a4e3e73cfdf06526e20cc02aa1c3b47184d40")
     version("1.4.1", sha256="f9611eb65c8241a67fb373bef040b3cf8ad377a9f6546a12b620b6511e8ea9ef")


### PR DESCRIPTION
This PR adds `py-jupyter-server`, v2.14.2, which fixes CVE-2023-39968, CVE-2023-40170, CVE-2023-49080 (all of which are medium or less severe). Versions before CVE-2022-29241 (high severity) are marked as deprecated.

Test build:
```
==> Installing py-jupyter-server-2.14.2-ecxgj7jqdvhmw6pnvmmme5ehudrjhalf [118/118]
==> No binary for py-jupyter-server-2.14.2-ecxgj7jqdvhmw6pnvmmme5ehudrjhalf found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/j/jupyter_server/jupyter_server-2.14.2.tar.gz
==> No patches needed for py-jupyter-server
==> py-jupyter-server: Executing phase: 'install'
==> py-jupyter-server: Successfully installed py-jupyter-server-2.14.2-ecxgj7jqdvhmw6pnvmmme5ehudrjhalf
  Stage: 0.76s.  Install: 1.06s.  Post-install: 1.85s.  Total: 3.93s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/py-jupyter-server-2.14.2-ecxgj7jqdvhmw6pnvmmme5ehudrjhalf
```

Test run:
```
$ jupyter-server 
[I 2024-10-14 12:57:39.053 ServerApp] jupyter_server_terminals | extension was successfully linked.
[I 2024-10-14 12:57:39.068 ServerApp] jupyter_server_terminals | extension was successfully loaded.
[I 2024-10-14 12:57:39.072 ServerApp] Serving notebooks from local directory: /opt/spack/stage/wdconinc
[I 2024-10-14 12:57:39.072 ServerApp] Jupyter Server 2.14.2 is running at:
[I 2024-10-14 12:57:39.072 ServerApp] http://localhost:8888/?token=XX
[I 2024-10-14 12:57:39.073 ServerApp]     http://127.0.0.1:8888/?token=XX
[I 2024-10-14 12:57:39.073 ServerApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
[C 2024-10-14 12:57:39.075 ServerApp] 
    
    To access the server, open this file in a browser:
        file:///home/wdconinc/.local/share/jupyter/runtime/jpserver-714884-open.html
```