### PR TITLE
env depfile: generate Makefile with absolute script path

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -807,6 +807,13 @@ def env_depfile_setup_parser(subparser):
         "used. can be set to an empty string --make-prefix ''",
     )
     subparser.add_argument(
+        "--make-absolute-path",
+        default=False,
+        action="store_true",
+        dest="absolute_path",
+        help="use an absolute path to the spack executable in the Makefile",
+    )
+    subparser.add_argument(
         "--make-disable-jobserver",
         default=True,
         action="store_false",
@@ -862,6 +869,7 @@ def env_depfile(args):
         dep_buildcache=depfile.UseBuildCache.from_string(args.use_buildcache[1]),
         make_prefix=args.make_prefix,
         jobserver=args.jobserver,
+        absolute_path=args.absolute_path,
     )
 
     # Warn in case we're generating a depfile for an empty environment. We don't automatically

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -807,13 +807,6 @@ def env_depfile_setup_parser(subparser):
         "used. can be set to an empty string --make-prefix ''",
     )
     subparser.add_argument(
-        "--make-absolute-path",
-        default=False,
-        action="store_true",
-        dest="absolute_path",
-        help="use an absolute path to the spack executable in the Makefile",
-    )
-    subparser.add_argument(
         "--make-disable-jobserver",
         default=True,
         action="store_false",
@@ -869,7 +862,6 @@ def env_depfile(args):
         dep_buildcache=depfile.UseBuildCache.from_string(args.use_buildcache[1]),
         make_prefix=args.make_prefix,
         jobserver=args.jobserver,
-        absolute_path=args.absolute_path,
     )
 
     # Warn in case we're generating a depfile for an empty environment. We don't automatically

--- a/lib/spack/spack/environment/depfile.py
+++ b/lib/spack/spack/environment/depfile.py
@@ -9,15 +9,15 @@ depfiles from an environment.
 
 import os
 import re
-from enum import Enum
 import shlex
+from enum import Enum
 from typing import List, Optional
 
 import spack.deptypes as dt
 import spack.environment.environment as ev
+import spack.paths
 import spack.spec
 import spack.traverse as traverse
-import spack.paths
 
 
 class UseBuildCache(Enum):

--- a/lib/spack/spack/environment/depfile.py
+++ b/lib/spack/spack/environment/depfile.py
@@ -10,6 +10,7 @@ depfiles from an environment.
 import os
 import re
 from enum import Enum
+import shlex
 from typing import List, Optional
 
 import spack.deptypes as dt
@@ -130,7 +131,6 @@ class MakefileModel:
         adjacency_list: List[DepfileNode],
         make_prefix: Optional[str],
         jobserver: bool,
-        absolute_paths: bool,
     ):
         """
         Args:
@@ -140,7 +140,6 @@ class MakefileModel:
             make_prefix: prefix for makefile targets
             jobserver: when enabled, make will invoke Spack with jobserver support. For
                 dry-run this should be disabled.
-            absolute_paths: when enabled, uses an absolute path for `spack` in the Makefile
         """
         # Currently we can only use depfile with an environment since Spack needs to
         # find the concrete specs somewhere.
@@ -179,8 +178,6 @@ class MakefileModel:
         self.root_install_targets = [self._install_target(s.safe_name()) for s in self.roots]
 
         self.jobserver_support = "+" if jobserver else ""
-
-        self.spack_script = spack.paths.spack_script if absolute_paths else "spack"
 
         # All package identifiers, used to generate the SPACK_PACKAGE_IDS variable
         self.all_pkg_identifiers: List[str] = []
@@ -231,7 +228,7 @@ class MakefileModel:
             "install_deps_target": self._target("install-deps"),
             "any_hash_target": self._target("%"),
             "jobserver_support": self.jobserver_support,
-            "spack_script": self.spack_script,
+            "spack_script": shlex.quote(spack.paths.spack_script),
             "adjacency_list": self.make_adjacency_list,
             "phony_convenience_targets": " ".join(self.phony_convenience_targets),
             "pkg_ids_variable": self.pkg_identifier_variable,
@@ -251,7 +248,6 @@ class MakefileModel:
         dep_buildcache: UseBuildCache = UseBuildCache.AUTO,
         make_prefix: Optional[str] = None,
         jobserver: bool = True,
-        absolute_path: bool = True,
     ) -> "MakefileModel":
         """Produces a MakefileModel from an environment and a list of specs.
 
@@ -264,7 +260,6 @@ class MakefileModel:
             make_prefix: the prefix for the makefile targets
             jobserver: when enabled, make will invoke Spack with jobserver support. For
                 dry-run this should be disabled.
-            absolute_path: when enabled, uses an absolute path for `spack` in the Makefile
         """
         roots = env.all_matching_specs(*filter_specs) if filter_specs else env.concrete_roots()
         visitor = DepfileSpecVisitor(pkg_buildcache, dep_buildcache)
@@ -272,6 +267,4 @@ class MakefileModel:
             roots, traverse.CoverNodesVisitor(visitor, key=lambda s: s.dag_hash())
         )
 
-        return MakefileModel(
-            env, roots, visitor.adjacency_list, make_prefix, jobserver, absolute_path
-        )
+        return MakefileModel(env, roots, visitor.adjacency_list, make_prefix, jobserver)

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -3953,7 +3953,7 @@ def test_environment_depfile_makefile(depfile_flags, expected_installs, tmpdir, 
         )
 
     # Do make dry run.
-    out = make("-n", "-f", makefile, output=str)
+    out = make("-n", "-f", makefile, "SPACK=spack", output=str)
 
     specs_that_make_would_install = _parse_dry_run_package_installs(out)
 
@@ -3991,7 +3991,7 @@ def test_depfile_works_with_gitversions(tmpdir, mock_packages, monkeypatch):
         env("depfile", "-o", makefile, "--make-disable-jobserver", "--make-prefix=prefix")
 
     # Do a dry run on the generated depfile
-    out = make("-n", "-f", makefile, output=str)
+    out = make("-n", "-f", makefile, "SPACK=spack", output=str)
 
     # Check that all specs are there (without duplicates)
     specs_that_make_would_install = _parse_dry_run_package_installs(out)
@@ -4053,7 +4053,12 @@ def test_depfile_phony_convenience_targets(
 
         # Phony install/* target should install picked package and all its deps
         specs_that_make_would_install = _parse_dry_run_package_installs(
-            make("-n", picked_spec.format("install/{name}-{version}-{hash}"), output=str)
+            make(
+                "-n",
+                picked_spec.format("install/{name}-{version}-{hash}"),
+                "SPACK=spack",
+                output=str,
+            )
         )
 
         assert set(specs_that_make_would_install) == set(expected_installs)
@@ -4061,7 +4066,12 @@ def test_depfile_phony_convenience_targets(
 
         # Phony install-deps/* target shouldn't install picked package
         specs_that_make_would_install = _parse_dry_run_package_installs(
-            make("-n", picked_spec.format("install-deps/{name}-{version}-{hash}"), output=str)
+            make(
+                "-n",
+                picked_spec.format("install-deps/{name}-{version}-{hash}"),
+                "SPACK=spack",
+                output=str,
+            )
         )
 
         assert set(specs_that_make_would_install) == set(expected_installs) - {picked_package}
@@ -4121,7 +4131,7 @@ post-install: $(addprefix example/post-install/,$(example/SPACK_PACKAGE_IDS))
     make = Executable("make")
 
     # Do dry run.
-    out = make("-n", "-C", str(tmpdir), output=str)
+    out = make("-n", "-C", str(tmpdir), "SPACK=spack", output=str)
 
     # post-install: <hash> should've been executed
     with ev.read("test") as test:

--- a/share/spack/templates/depfile/Makefile
+++ b/share/spack/templates/depfile/Makefile
@@ -1,4 +1,4 @@
-SPACK ?= spack -c config:install_status:false
+SPACK ?= {{ spack_script }} -c config:install_status:false
 SPACK_INSTALL_FLAGS ?=
 
 # This variable can be used to add post install hooks


### PR DESCRIPTION
In scripting concepts, it is useful if we don't need to tightly control the PATH between multiple spack installations, but instead rely on absolute paths, like
```bash
/path/to/spack -e environment env depfile --make-absolute-path
```