### PR TITLE
libsndfile: add v1.2.2 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/libsndfile/package.py
+++ b/var/spack/repos/builtin/packages/libsndfile/package.py
@@ -12,12 +12,18 @@ class Libsndfile(AutotoolsPackage):
     through one standard library interface. It is released in source code
     format under the Gnu Lesser General Public License."""
 
-    homepage = "http://www.mega-nerd.com/libsndfile/"
-    url = "http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.28.tar.gz"
+    homepage = "https://github.com/libsndfile/libsndfile"
+    url = "https://github.com/libsndfile/libsndfile/releases/download/1.2.2/libsndfile-1.2.2.tar.xz"
 
     license("LGPL-2.1-or-later")
 
-    version("1.0.28", sha256="1ff33929f042fa333aed1e8923aa628c3ee9e1eb85512686c55092d1e5a9dfa9")
+    version("1.2.2", sha256="3799ca9924d3125038880367bf1468e53a1b7e3686a934f098b7e1d286cdb80e")
+    # https://nvd.nist.gov/vuln/detail/CVE-2022-33064
+    version(
+        "1.0.28", 
+        sha256="1ff33929f042fa333aed1e8923aa628c3ee9e1eb85512686c55092d1e5a9dfa9",
+        deprecated=True,
+    )
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
@@ -32,8 +38,17 @@ class Libsndfile(AutotoolsPackage):
     depends_on("alsa-lib", when="+alsa")
     depends_on("flac@1.3.1:", when="+external-libs")
     depends_on("libogg@1.1.3:", when="+external-libs")
+    depends_on("libogg@1.3.0:", when="@1.0.31: +external-libs")
     depends_on("libvorbis@1.2.3:", when="+external-libs")
     depends_on("sqlite@3.2:", when="+sqlite")
+
+    def url_for_version(self, version):
+        if self.spec.satisfies("@1.1:"):
+            return f"https://github.com/libsndfile/libsndfile/releases/download/{version}/libsndfile-{version}.tar.xz"
+        elif self.spec.satisfies("@1.0.29:"):
+            return f"https://github.com/libsndfile/libsndfile/releases/download/v{version}/libsndfile-{version}.tar.bz2"
+        else:
+            return f"http://www.mega-nerd.com/libsndfile/files/libsndfile-{version}.tar.gz"
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/libsndfile/package.py
+++ b/var/spack/repos/builtin/packages/libsndfile/package.py
@@ -13,14 +13,16 @@ class Libsndfile(AutotoolsPackage):
     format under the Gnu Lesser General Public License."""
 
     homepage = "https://github.com/libsndfile/libsndfile"
-    url = "https://github.com/libsndfile/libsndfile/releases/download/1.2.2/libsndfile-1.2.2.tar.xz"
+    url = (
+        "https://github.com/libsndfile/libsndfile/releases/download/1.2.2/libsndfile-1.2.2.tar.xz"
+    )
 
     license("LGPL-2.1-or-later")
 
     version("1.2.2", sha256="3799ca9924d3125038880367bf1468e53a1b7e3686a934f098b7e1d286cdb80e")
     # https://nvd.nist.gov/vuln/detail/CVE-2022-33064
     version(
-        "1.0.28", 
+        "1.0.28",
         sha256="1ff33929f042fa333aed1e8923aa628c3ee9e1eb85512686c55092d1e5a9dfa9",
         deprecated=True,
     )


### PR DESCRIPTION
This PR adds `libsndfile`, v1.2.2, which fixes CVE-2018-13139, CVE-2018-13419, CVE-2018-19432, CVE-2018-19661, CVE-2018-19662, CVE-2018-19758, CVE-2019-3832, CVE-2021-3246, CVE-2021-4156, CVE-2022-33064. At least one is marked as high severity so older versions deprecated.

Test build:
```
==> Installing libsndfile-1.2.2-xqfl34vu7si5hc3yzzsbds3ukugzsvei [5/5]
==> No binary for libsndfile-1.2.2-xqfl34vu7si5hc3yzzsbds3ukugzsvei found: installing from source
==> Fetching https://github.com/libsndfile/libsndfile/releases/download/1.2.2/libsndfile-1.2.2.tar.xz
==> No patches needed for libsndfile
==> libsndfile: Executing phase: 'autoreconf'
==> libsndfile: Executing phase: 'configure'
==> libsndfile: Executing phase: 'build'
==> libsndfile: Executing phase: 'install'
==> libsndfile: Successfully installed libsndfile-1.2.2-xqfl34vu7si5hc3yzzsbds3ukugzsvei
  Stage: 1.47s.  Autoreconf: 0.00s.  Configure: 9.64s.  Build: 17.25s.  Install: 0.38s.  Post-install: 0.10s.  Total: 29.00s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libsndfile-1.2.2-xqfl34vu7si5hc3yzzsbds3ukugzsvei
```
