### PR TITLE
log4cxx: add v1.2.0 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/log4cxx/package.py
+++ b/var/spack/repos/builtin/packages/log4cxx/package.py
@@ -14,18 +14,41 @@ class Log4cxx(CMakePackage):
 
     maintainers("nicmcd")
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked_by="wdconinc")
 
-    version("0.12.1", sha256="7bea5cb477f0e31c838f0e1f4f498cc3b30c2eae74703ddda923e7e8c2268d22")
-    version("0.12.0", sha256="bd5b5009ca914c8fa7944b92ea6b4ca6fb7d146f65d526f21bf8b3c6a0520e44")
+    version("1.2.0", sha256="09f4748aa5675ef5c0770bedbf5e00488668933c5a935a43ac5b85be2436c48a")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2023-31038
+        version(
+            "0.12.1", sha256="7bea5cb477f0e31c838f0e1f4f498cc3b30c2eae74703ddda923e7e8c2268d22"
+        )
+        version(
+            "0.12.0", sha256="bd5b5009ca914c8fa7944b92ea6b4ca6fb7d146f65d526f21bf8b3c6a0520e44"
+        )
 
-    variant("cxxstd", default="17", description="C++ standard", values=("11", "17"), multi=False)
+    variant(
+        "cxxstd",
+        default="17",
+        description="C++ standard",
+        values=("11", "17"),
+        multi=False,
+        when="@:1.1",
+    )
+    variant(
+        "cxxstd",
+        default="20",
+        description="C++ standard",
+        values=("11", "17", "20"),
+        multi=False,
+        when="@1.2:",
+    )
 
     depends_on("cmake@3.13:", type="build")
 
     depends_on("apr-util")
     depends_on("apr")
     depends_on("boost+thread+system", when="cxxstd=11")
+    depends_on("expat")
     depends_on("zlib-api")
     depends_on("zip")
 


### PR DESCRIPTION
This PR adds `log4cxx`, v1.2.0, which fixes CVE-2023-31038. Since that CVE is of high severity, older versions are deprecated. The new default upstream is to use C++20, so this has been updated in the `cxxstd` variant here. A dependency on `expat` appears to have always been needed and may have been satisfied transitively.

Test build:
```
==> Installing log4cxx-1.2.0-rnhsdzwnt4lac5jtjs2pkr4v3xhslxj2 [19/19]
==> No binary for log4cxx-1.2.0-rnhsdzwnt4lac5jtjs2pkr4v3xhslxj2 found: installing from source
==> Fetching https://dlcdn.apache.org/logging/log4cxx/1.2.0/apache-log4cxx-1.2.0.tar.gz
==> No patches needed for log4cxx
==> log4cxx: Executing phase: 'cmake'
==> log4cxx: Executing phase: 'build'
==> log4cxx: Executing phase: 'install'
==> log4cxx: Successfully installed log4cxx-1.2.0-rnhsdzwnt4lac5jtjs2pkr4v3xhslxj2
  Stage: 0.70s.  Cmake: 4.70s.  Build: 1m 12.78s.  Install: 0.24s.  Post-install: 0.20s.  Total: 1m 18.80s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/log4cxx-1.2.0-rnhsdzwnt4lac5jtjs2pkr4v3xhslxj2
```