### PR TITLE
lucene: add v9.12.0, v10.0.0 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/lucene/package.py
+++ b/var/spack/repos/builtin/packages/lucene/package.py
@@ -27,7 +27,9 @@ class Lucene(Package):
     )
     with default_args(deprecated=True):
         # https://nvd.nist.gov/vuln/detail/CVE-2024-45772
-        version("9.10.0", sha256="c57b75ee0ea12b54337967b7854ebd12af3d7bad27245c1dc12a167ce2b1f8a7")
+        version(
+            "9.10.0", sha256="c57b75ee0ea12b54337967b7854ebd12af3d7bad27245c1dc12a167ce2b1f8a7"
+        )
         version("9.5.0", sha256="547277a2b6ce283422eccd14e9ee7ffb28b1af3975936959716c9b4d85843555")
         version("8.3.1", sha256="acd61ad458d16f3c98b9dd4653c6a34dd666a965842e461f7cdf8947fa041e1a")
         version("8.3.0", sha256="67c4f8081f24ff9f4eb4f2b999ac19f7a639b416e5b6f1c1c74e0524a481fc7e")

--- a/var/spack/repos/builtin/packages/lucene/package.py
+++ b/var/spack/repos/builtin/packages/lucene/package.py
@@ -17,16 +17,27 @@ class Lucene(Package):
     list_url = "https://archive.apache.org/dist/lucene/java/"
     list_depth = 1
 
-    license("BSD-2-Clause")
+    license("Apache-2.0", checked_by="wdconinc")
 
-    version("9.10.0", sha256="c57b75ee0ea12b54337967b7854ebd12af3d7bad27245c1dc12a167ce2b1f8a7")
-    version("9.5.0", sha256="547277a2b6ce283422eccd14e9ee7ffb28b1af3975936959716c9b4d85843555")
-    version("8.3.1", sha256="acd61ad458d16f3c98b9dd4653c6a34dd666a965842e461f7cdf8947fa041e1a")
-    version("8.3.0", sha256="67c4f8081f24ff9f4eb4f2b999ac19f7a639b416e5b6f1c1c74e0524a481fc7e")
-    version("8.2.0", sha256="505cad34698b217fd6ceee581a8215223a47df5af820c94ca70a6bdbba9d5d7c")
-    version("8.1.1", sha256="d62b0acdf2b1ed7a25ccdb593ad8584caeaa20cc9870e22790d3ec7fa6240a8c")
+    version("10.0.0", sha256="b40c29039c363a9479947acfbc41efb381af7868233446412d625a197436a243")
+    version(
+        "9.12.0",
+        sha256="8d7c698e7bdee7580950c4323f091b996afb1b14c91d6d6e4e150ccff883c6c5",
+        preferred=True,
+    )
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2024-45772
+        version("9.10.0", sha256="c57b75ee0ea12b54337967b7854ebd12af3d7bad27245c1dc12a167ce2b1f8a7")
+        version("9.5.0", sha256="547277a2b6ce283422eccd14e9ee7ffb28b1af3975936959716c9b4d85843555")
+        version("8.3.1", sha256="acd61ad458d16f3c98b9dd4653c6a34dd666a965842e461f7cdf8947fa041e1a")
+        version("8.3.0", sha256="67c4f8081f24ff9f4eb4f2b999ac19f7a639b416e5b6f1c1c74e0524a481fc7e")
+        version("8.2.0", sha256="505cad34698b217fd6ceee581a8215223a47df5af820c94ca70a6bdbba9d5d7c")
+        version("8.1.1", sha256="d62b0acdf2b1ed7a25ccdb593ad8584caeaa20cc9870e22790d3ec7fa6240a8c")
 
-    depends_on("java", type="run")
+    # build.gradle minJavaVersion or versions.toml minJava
+    depends_on("java@8:", type="run")
+    depends_on("java@11:", type="run", when="@9:")
+    depends_on("java@21:", type="run", when="@10:")
 
     def install(self, spec, prefix):
         install_tree(".", prefix)


### PR DESCRIPTION
This PR adds `lucene`, v9.12.0, v10.0.0, which fixes CVE-2024-45772. Since that CVE is scored as high, the older versions are deprecated. Since v10.0.0 was just released today and is a major upgrade, I'm marking v9.12.0 as preferred for now. The required java versions were updated. The license was updated.

Test build:
```
==> Installing lucene-10.0.0-xut273goezlalt4bgqieg66wnztkiees [5/6]
==> No binary for lucene-10.0.0-xut273goezlalt4bgqieg66wnztkiees found: installing from source
==> Fetching https://archive.apache.org/dist/lucene/java/10.0.0/lucene-10.0.0.tgz
==> No patches needed for lucene
==> lucene: Executing phase: 'install'
==> lucene: Successfully installed lucene-10.0.0-xut273goezlalt4bgqieg66wnztkiees
  Stage: 22.89s.  Install: 1.09s.  Post-install: 1.83s.  Total: 25.82s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/lucene-10.0.0-xut273goezlalt4bgqieg66wnztkiees
==> Installing lucene-9.12.0-geq4islkcdrotd5ahhexgry6aqtespx4 [6/6]
==> No binary for lucene-9.12.0-geq4islkcdrotd5ahhexgry6aqtespx4 found: installing from source
==> Fetching https://archive.apache.org/dist/lucene/java/9.12.0/lucene-9.12.0.tgz
==> No patches needed for lucene
==> lucene: Executing phase: 'install'
==> lucene: Successfully installed lucene-9.12.0-geq4islkcdrotd5ahhexgry6aqtespx4
  Stage: 15.31s.  Install: 1.48s.  Post-install: 1.91s.  Total: 18.73s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/lucene-9.12.0-geq4islkcdrotd5ahhexgry6aqtespx4
```

Test runs:
```
17:15:36 wdconinc@menelaos /opt/spack/stage/wdconinc $ spack load /geq4islkcdrotd5ahhexgry6aqtespx4
17:15:48 wdconinc@menelaos /opt/spack/stage/wdconinc $ /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/lucene-9.12.0-geq4islkcdrotd5ahhexgry6aqtespx4/bin/luke.sh 
Oct 14, 2024 5:16:21 PM org.apache.lucene.luke.app.desktop.LukeMain lambda$main$2
INFO: Elapsed time for initializing GUI: -196123708 ms
17:16:22 wdconinc@menelaos /opt/spack/stage/wdconinc $ spack load /xut
17:18:20 wdconinc@menelaos /opt/spack/stage/wdconinc $ /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/lucene-10.0.0-xut273goezlalt4bgqieg66wnztkiees/bin/luke.sh 
Oct 14, 2024 5:18:34 PM org.apache.lucene.luke.app.desktop.LukeMain lambda$main$2
INFO: Elapsed time for initializing GUI: -196255810 ms
```
In both cases a window popped up.