### PR TITLE
rocketmq: add v5.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/rocketmq/package.py
+++ b/var/spack/repos/builtin/packages/rocketmq/package.py
@@ -30,5 +30,9 @@ class Rocketmq(Package):
 
     depends_on("java@8:", type="run")
 
+    # UseBiasedLocking deprecated in java@15:, removed in java@21:
+    # https://openjdk.org/jeps/374, https://github.com/apache/rocketmq/pull/8809
+    depends_on("java@:20", type="run")
+
     def install(self, spec, prefix):
         install_tree(".", prefix)

--- a/var/spack/repos/builtin/packages/rocketmq/package.py
+++ b/var/spack/repos/builtin/packages/rocketmq/package.py
@@ -16,14 +16,17 @@ class Rocketmq(Package):
     homepage = "https://rocketmq.apache.org/"
     url = "https://archive.apache.org/dist/rocketmq/4.5.2/rocketmq-all-4.5.2-bin-release.zip"
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked_by="wdconinc")
 
-    version("4.6.0", sha256="584910d50639297808dd0b86fcdfaf431efd9607009a44c6258d9a0e227748fe")
-    version("4.5.2", sha256="f7711ef9c203d7133e70e0e1e887025d7dd80d29f6d5283ca6022b12576b8aba")
-    version("4.5.1", sha256="0c46e4b652b007d07e9c456eb2e275126b9210c27cd56bee518809f33c8ed437")
-    version("4.5.0", sha256="d75dc26291b47413f7c565bc65499501e3499f01beb713246586f72844e31042")
-    version("4.4.0", sha256="8a948e240e8d2ebbf4c40c180105d088a937f82a594cd1f2ae527b20349f1d34")
-    version("4.3.2", sha256="e31210a86266ee218eb6ff4f8ca6e211439895459c3bdad162067b573d9e3415")
+    version("5.3.1", sha256="251d7261fa26d35eaffef6a2fce30880054af7a5883d578dd31574bf908a8b97")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2023-37582
+        version("4.6.0", sha256="584910d50639297808dd0b86fcdfaf431efd9607009a44c6258d9a0e227748fe")
+        version("4.5.2", sha256="f7711ef9c203d7133e70e0e1e887025d7dd80d29f6d5283ca6022b12576b8aba")
+        version("4.5.1", sha256="0c46e4b652b007d07e9c456eb2e275126b9210c27cd56bee518809f33c8ed437")
+        version("4.5.0", sha256="d75dc26291b47413f7c565bc65499501e3499f01beb713246586f72844e31042")
+        version("4.4.0", sha256="8a948e240e8d2ebbf4c40c180105d088a937f82a594cd1f2ae527b20349f1d34")
+        version("4.3.2", sha256="e31210a86266ee218eb6ff4f8ca6e211439895459c3bdad162067b573d9e3415")
 
     depends_on("java@8:", type="run")
 


### PR DESCRIPTION
This PR adds `rocketmq`, v5.3.1, which fixes CVE-2019-17572, CVE-2023-33246, CVE-2023-37582, CVE-2024-23321. Since one of these CVEs is marked critical, the older versions are deprecated. License checked.

Test build:
```
==> Installing rocketmq-5.3.1-jryeeatpye6l36gapeekuztfd6hirmm7 [4/4]
==> No binary for rocketmq-5.3.1-jryeeatpye6l36gapeekuztfd6hirmm7 found: installing from source
==> Fetching https://archive.apache.org/dist/rocketmq/5.3.1/rocketmq-all-5.3.1-bin-release.zip
==> No patches needed for rocketmq
==> rocketmq: Executing phase: 'install'
==> rocketmq: Successfully installed rocketmq-5.3.1-jryeeatpye6l36gapeekuztfd6hirmm7
  Stage: 33.28s.  Install: 0.06s.  Post-install: 0.19s.  Total: 33.57s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/rocketmq-5.3.1-jryeeatpye6l36gapeekuztfd6hirmm7
```

Test run per https://rocketmq.apache.org/docs/quickStart/01quickstart:
```
/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/rocketmq-5.3.1-jryeeatpye6l36gapeekuztfd6hirmm7/bin/mqnamesrv 
The Name Server boot success. serializeType=JSON, address 0.0.0.0:9876
```

Starting with openjdk 21 affected by https://github.com/apache/rocketmq/pull/8809, so restricting to version 20 at the latest.