### PR TITLE
blast-plus: add +openmp variant (with support for %apple-clang)

### DIFF
--- a/var/spack/repos/builtin/packages/blast-plus/package.py
+++ b/var/spack/repos/builtin/packages/blast-plus/package.py
@@ -68,6 +68,7 @@ class BlastPlus(AutotoolsPackage):
     variant("pcre", default=True, description="Build with pcre support")
     variant("perl", default=True, description="Build with perl support")
     variant("python", default=True, description="Build with python support")
+    variant("openmp", default=True, description="Build with openMP support")
 
     depends_on("jpeg", when="+jpeg")
     depends_on("libpng", when="+png")
@@ -79,6 +80,7 @@ class BlastPlus(AutotoolsPackage):
     depends_on("bzip2", when="+bzip2")
     depends_on("lzo", when="+lzo")
     depends_on("pcre", when="+pcre")
+    depends_on("llvm-openmp", when="%apple-clang")
 
     depends_on("python", when="+python")
     depends_on("perl", when="+perl")
@@ -166,4 +168,15 @@ class BlastPlus(AutotoolsPackage):
         else:
             config_args.append("--without-python")
 
+        if spec.satisfies("-openmp"):
+            config_args.append("--without-openmp")
+
         return config_args
+
+    def setup_build_environment(self, env):
+
+        if self.spec.satisfies("%apple-clang") and self.spec.satisfies("+openmp"):
+            env.append_flags("CPPFLAGS", self.compiler.openmp_flag)
+            env.append_flags("CFLAGS", self.spec["llvm-openmp"].headers.include_flags)
+            env.append_flags("CXXFLAGS", self.spec["llvm-openmp"].headers.include_flags)
+            env.append_flags("LDFLAGS", self.spec["llvm-openmp"].libs.ld_flags)


### PR DESCRIPTION
fixed bug where openmp would not allow build with apple-clang

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
