### PR TITLE
Reduce the load on clingo-cffi CI job

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -154,7 +154,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
       with:
-        python-version: '3.12'
+        python-version: '3.13'
     - name: Install System packages
       run: |
           sudo apt-get -y update

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -169,12 +169,13 @@ jobs:
           COVERAGE_FILE: coverage/.coverage-clingo-cffi
       run: |
         . share/spack/setup-env.sh
-        $(which spack) bootstrap disable spack-install
-        $(which spack) bootstrap disable github-actions-v0.4
-        $(which spack) bootstrap status
-        $(which spack) solve zlib
+        spack bootstrap disable spack-install
+        spack bootstrap disable github-actions-v0.4
+        spack bootstrap disable github-actions-v0.5
+        spack bootstrap status
+        spack solve zlib
         common_args=(--dist loadfile --tx '4*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python' -x)
-        $(which spack) unit-test --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml "${common_args[@]}" lib/spack/spack/test/concretize.py
+        spack unit-test --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml "${common_args[@]}" lib/spack/spack/test/concretize.py
     - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
         name: coverage-clingo-cffi

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -154,26 +154,24 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install System packages
       run: |
           sudo apt-get -y update
-          sudo apt-get -y install coreutils cvs gfortran graphviz gnupg2 mercurial ninja-build kcov
+          sudo apt-get -y install coreutils gfortran graphviz gnupg2
     - name: Install Python packages
       run: |
           pip install --upgrade pip setuptools pytest coverage[toml] pytest-cov clingo pytest-xdist
-          pip install --upgrade flake8 "isort>=4.3.5" "mypy>=0.900" "click" "black"
-    - name: Setup git configuration
-      run: |
-          # Need this for the git tests to succeed.
-          git --version
-          . .github/workflows/bin/setup_git.sh
     - name: Run unit tests (full suite with coverage)
       env:
           COVERAGE: true
           COVERAGE_FILE: coverage/.coverage-clingo-cffi
       run: |
-          share/spack/qa/run-unit-tests
+        . share/spack/setup-env.sh
+        $(which spack) bootstrap disable
+        $(which spack) solve zlib
+        common_args=(--dist loadfile --tx '4*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python' -x)
+        $(which spack) unit-test --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml "${common_args[@]}" lib/spack/spack/test/concretize.py
     - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
         name: coverage-clingo-cffi

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -161,7 +161,7 @@ jobs:
           sudo apt-get -y install coreutils gfortran graphviz gnupg2
     - name: Install Python packages
       run: |
-          pip install --upgrade pip setuptools pytest coverage[toml] pytest-cov clingo pytest-xdist
+          pip install --upgrade pip setuptools pytest coverage[toml] pytest-cov clingo
           pip install --upgrade flake8 "isort>=4.3.5" "mypy>=0.900" "click" "black"
     - name: Run unit tests (full suite with coverage)
       env:
@@ -174,8 +174,7 @@ jobs:
         spack bootstrap disable github-actions-v0.5
         spack bootstrap status
         spack solve zlib
-        common_args=(--dist loadfile --tx '4*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python' -x)
-        spack unit-test --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml "${common_args[@]}" lib/spack/spack/test/concretize.py
+        spack unit-test --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml lib/spack/spack/test/concretize.py
     - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
         name: coverage-clingo-cffi

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -170,6 +170,7 @@ jobs:
       run: |
         . share/spack/setup-env.sh
         $(which spack) bootstrap disable
+        $(which spack) bootstrap status
         $(which spack) solve zlib
         common_args=(--dist loadfile --tx '4*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python' -x)
         $(which spack) unit-test --verbose --cov --cov-config=pyproject.toml --cov-report=xml:coverage.xml "${common_args[@]}" lib/spack/spack/test/concretize.py

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -169,7 +169,8 @@ jobs:
           COVERAGE_FILE: coverage/.coverage-clingo-cffi
       run: |
         . share/spack/setup-env.sh
-        $(which spack) bootstrap disable
+        $(which spack) bootstrap disable spack-install
+        $(which spack) bootstrap disable github-actions-v0.4
         $(which spack) bootstrap status
         $(which spack) solve zlib
         common_args=(--dist loadfile --tx '4*popen//python=./bin/spack-tmpconfig python -u ./bin/spack python' -x)

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -162,6 +162,7 @@ jobs:
     - name: Install Python packages
       run: |
           pip install --upgrade pip setuptools pytest coverage[toml] pytest-cov clingo pytest-xdist
+          pip install --upgrade flake8 "isort>=4.3.5" "mypy>=0.900" "click" "black"
     - name: Run unit tests (full suite with coverage)
       env:
           COVERAGE: true


### PR DESCRIPTION
The purpose of this CI job is to ensure that we can use a modern clingo to concretize specs, if e.g. it was installed in a virtual environment with pip.

Since there is no need to re-test unrelated parts of Spack, reduce the number of tests we run to just concretize.py

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
