### PR TITLE
Reorder global module population

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -625,6 +625,9 @@ def set_package_py_globals(pkg, context: Context = Context.BUILD):
     jobs = determine_number_of_jobs(parallel=pkg.parallel)
     module.make_jobs = jobs
 
+    module.std_meson_args = spack.build_systems.meson.MesonBuilder.std_args(pkg)
+    module.std_pip_args = spack.build_systems.python.PythonPipBuilder.std_args(pkg)
+
     # TODO: make these build deps that can be installed if not found.
     module.make = MakeExecutable("make", jobs)
     module.gmake = MakeExecutable("gmake", jobs)
@@ -1082,9 +1085,10 @@ class SetupContext:
             pkg = dspec.pkg
             if self.context == Context.BUILD:
                 module = ModuleChangePropagator(pkg)
+                # std_cmake_args is not sufficiently static to be defined
+                # in set_package_py_globals and is deprecated so its handled
+                # here as a special case
                 module.std_cmake_args = spack.build_systems.cmake.CMakeBuilder.std_args(pkg)
-                module.std_meson_args = spack.build_systems.meson.MesonBuilder.std_args(pkg)
-                module.std_pip_args = spack.build_systems.python.PythonPipBuilder.std_args(pkg)
                 module.propegate_changes_to_mro()
 
     def get_env_modifications(self) -> EnvironmentModifications:

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -617,11 +617,6 @@ def set_package_py_globals(pkg, context: Context = Context.BUILD):
     """
     module = ModuleChangePropagator(pkg)
 
-    if context == Context.BUILD:
-        module.std_cmake_args = spack.build_systems.cmake.CMakeBuilder.std_args(pkg)
-        module.std_meson_args = spack.build_systems.meson.MesonBuilder.std_args(pkg)
-        module.std_pip_args = spack.build_systems.python.PythonPipBuilder.std_args(pkg)
-
     jobs = spack.config.determine_number_of_jobs(parallel=pkg.parallel)
     module.make_jobs = jobs
     if context == Context.BUILD:

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -624,9 +624,9 @@ def set_package_py_globals(pkg, context: Context = Context.BUILD):
 
     jobs = determine_number_of_jobs(parallel=pkg.parallel)
     module.make_jobs = jobs
-
-    module.std_meson_args = spack.build_systems.meson.MesonBuilder.std_args(pkg)
-    module.std_pip_args = spack.build_systems.python.PythonPipBuilder.std_args(pkg)
+    if context == Context.BUILD:
+        module.std_meson_args = spack.build_systems.meson.MesonBuilder.std_args(pkg)
+        module.std_pip_args = spack.build_systems.python.PythonPipBuilder.std_args(pkg)
 
     # TODO: make these build deps that can be installed if not found.
     module.make = MakeExecutable("make", jobs)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1081,15 +1081,14 @@ class SetupContext:
                 pkg.setup_dependent_package(dependent_module, spec)
                 dependent_module.propagate_changes_to_mro()
 
-        for dspec, flag in chain(self.external, self.nonexternal):
-            pkg = dspec.pkg
-            if self.context == Context.BUILD:
-                module = ModuleChangePropagator(pkg)
-                # std_cmake_args is not sufficiently static to be defined
-                # in set_package_py_globals and is deprecated so its handled
-                # here as a special case
-                module.std_cmake_args = spack.build_systems.cmake.CMakeBuilder.std_args(pkg)
-                module.propegate_changes_to_mro()
+        pkg = self.specs[0].pkg
+        if self.context == Context.BUILD:
+            module = ModuleChangePropagator(pkg)
+            # std_cmake_args is not sufficiently static to be defined
+            # in set_package_py_globals and is deprecated so its handled
+            # here as a special case
+            module.std_cmake_args = spack.build_systems.cmake.CMakeBuilder.std_args(pkg)
+            module.propegate_changes_to_mro()
 
     def get_env_modifications(self) -> EnvironmentModifications:
         """Returns the environment variable modifications for the given input specs and context.

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -622,7 +622,7 @@ def set_package_py_globals(pkg, context: Context = Context.BUILD):
         module.std_meson_args = spack.build_systems.meson.MesonBuilder.std_args(pkg)
         module.std_pip_args = spack.build_systems.python.PythonPipBuilder.std_args(pkg)
 
-    jobs = determine_number_of_jobs(parallel=pkg.parallel)
+    jobs = spack.config.determine_number_of_jobs(parallel=pkg.parallel)
     module.make_jobs = jobs
     if context == Context.BUILD:
         module.std_meson_args = spack.build_systems.meson.MesonBuilder.std_args(pkg)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1081,14 +1081,14 @@ class SetupContext:
                 pkg.setup_dependent_package(dependent_module, spec)
                 dependent_module.propagate_changes_to_mro()
 
-        pkg = self.specs[0].pkg
+        pkg = self.specs[0].package
         if self.context == Context.BUILD:
             module = ModuleChangePropagator(pkg)
             # std_cmake_args is not sufficiently static to be defined
             # in set_package_py_globals and is deprecated so its handled
             # here as a special case
             module.std_cmake_args = spack.build_systems.cmake.CMakeBuilder.std_args(pkg)
-            module.propegate_changes_to_mro()
+            module.propagate_changes_to_mro()
 
     def get_env_modifications(self) -> EnvironmentModifications:
         """Returns the environment variable modifications for the given input specs and context.


### PR DESCRIPTION
Resubmit of https://github.com/spack/spack/pull/46356 to avoid weird pipeline behavior

From #46356:

An alternative https://github.com/spack/spack/pull/44327 to after https://github.com/spack/spack/pull/46283 reverted that change due to https://github.com/spack/spack/pull/44327 breaking develop.

https://github.com/spack/spack/pull/44327 breaks down the global python module for packages setup into two loops, this first setting the python globals, and the second setting up dependent modules for a given package. As @haampie pointed out in https://github.com/spack/spack/pull/46283 this causes an issue as :

set_package_py_globals(...) calls CMakeBuilder.std_args(...) 
calls get_cmake_prefix_path(...) which calls cmake_prefix_paths(...) on dependencies,
which rely on globals. For example pytorch's cmake_prefix_paths needs the python_platlib global.
(thanks @haampie for tracing that out).

This PR, based on https://github.com/spack/spack/pull/46283#issuecomment-2342361550 from @scheibelp implements a third loop, pulling the std_*_args module setup outside of the general set_package_py_globals and into a loop of its own after both the global python and packages have already been setup.
