### PR TITLE
Libmng: Restore Autotools system

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -164,7 +164,7 @@ class Cmake(Package):
     depends_on("qt", when="+qtgui")
     for plat in ["linux", "darwin", "freebsd"]:
         with when(f"platform={plat}"):
-            depends_on("qt ^libmng build_system=autotools", when="+qtgui")
+            depends_on("libmng build_system=autotools", when="+qtgui")
 
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/21135
     conflicts(

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -161,7 +161,10 @@ class Cmake(Package):
     depends_on("gmake", when="platform=darwin")
     depends_on("gmake", when="platform=freebsd")
 
-    depends_on("qt ^libmng build_system=autotools", when="+qtgui")
+    depends_on("qt", when="+qtgui platform=windows")
+    for plat in ["linux", "darwin", "freebsd"]:
+        with when(f"+qtgui platform={plat}"):
+            depends_on("qt ^libmng build_system=autotools")
 
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/21135
     conflicts(

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -161,10 +161,10 @@ class Cmake(Package):
     depends_on("gmake", when="platform=darwin")
     depends_on("gmake", when="platform=freebsd")
 
-    depends_on("qt", when="+qtgui platform=windows")
+    depends_on("qt", when="+qtgui")
     for plat in ["linux", "darwin", "freebsd"]:
-        with when(f"+qtgui platform={plat}"):
-            depends_on("qt ^libmng build_system=autotools")
+        with when(f"platform={plat}"):
+            depends_on("^libmng build_system=autotools", when="+qtgui")
 
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/21135
     conflicts(

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -161,7 +161,7 @@ class Cmake(Package):
     depends_on("gmake", when="platform=darwin")
     depends_on("gmake", when="platform=freebsd")
 
-    depends_on("qt", when="+qtgui")
+    depends_on("qt ^libmng build_system=autotools", when="+qtgui")
 
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/21135
     conflicts(

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -162,6 +162,9 @@ class Cmake(Package):
     depends_on("gmake", when="platform=freebsd")
 
     depends_on("qt", when="+qtgui")
+    # Qt depends on libmng, which is a CMake package;
+    # ensure we build using a non CMake build system
+    # when libmng is build as a transitive dependency of CMake
     for plat in ["linux", "darwin", "freebsd"]:
         with when(f"platform={plat}"):
             depends_on("libmng build_system=autotools", when="+qtgui")

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -164,7 +164,7 @@ class Cmake(Package):
     depends_on("qt", when="+qtgui")
     for plat in ["linux", "darwin", "freebsd"]:
         with when(f"platform={plat}"):
-            depends_on("^libmng build_system=autotools", when="+qtgui")
+            depends_on("qt ^libmng build_system=autotools", when="+qtgui")
 
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/21135
     conflicts(

--- a/var/spack/repos/builtin/packages/libmng/package.py
+++ b/var/spack/repos/builtin/packages/libmng/package.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import spack.build_systems
-import spack.build_systems.cmake
 import spack.build_systems.autotools
+import spack.build_systems.cmake
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/libmng/package.py
+++ b/var/spack/repos/builtin/packages/libmng/package.py
@@ -3,10 +3,13 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems
+import spack.build_systems.cmake
+import spack.build_systems.autotools
 from spack.package import *
 
 
-class Libmng(CMakePackage):
+class Libmng(CMakePackage, AutotoolsPackage):
     """THE reference library for reading, displaying, writing
     and examining Multiple-Image Network Graphics.  MNG is the animation
     extension to the popular PNG image format."""
@@ -26,9 +29,24 @@ class Libmng(CMakePackage):
     depends_on("zlib-api")
     depends_on("lcms")
 
+    build_system("cmake", "autotools", default="cmake")
+
     def patch(self):
         # jpeg requires stdio to be included before its headers.
         filter_file(r"^(\#include \<jpeglib\.h\>)", "#include<stdio.h>\n\\1", "libmng_types.h")
 
+
+class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):
         return ["-DWITH_LCMS2:BOOL=ON", "-DWITH_LCMS1:BOOL=OFF"]
+
+
+class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
+    @run_before("configure")
+    def clean_preconf(self):
+        """Required, otherwise configure will crash as subdirectories have
+        already been configured"""
+        make("distclean")
+
+    def configure_args(self):
+        return ["--with-lcms2", "--without-lcms1"]


### PR DESCRIPTION
CMake, when building its Qt gui, depends on Qt, which in turn, depends on libmng, a CMake based build. To avoid this obvious cyclic dependency, we re-introduce libmng's autotools build into Spack and require when building Qt as a CMake dependency, libmng is built with autotools

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
