### PR TITLE
hive: add v4.0.1 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/hive/package.py
+++ b/var/spack/repos/builtin/packages/hive/package.py
@@ -19,10 +19,13 @@ class Hive(Package):
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("3.1.3", sha256="0c9b6a6359a7341b6029cc9347435ee7b379f93846f779d710b13f795b54bb16")
-    version("3.1.2", sha256="d75dcf36908b4e7b9b0ec9aec57a46a6628b97b276c233cb2c2f1a3e89b13462")
-    version("2.3.6", sha256="0b3736edc8d15f01ed649bfce7d74346c35fd57567411e9d0c3f48578f76610d")
-    version("1.2.2", sha256="763b246a1a1ceeb815493d1e5e1d71836b0c5b9be1c4cd9c8d685565113771d1")
+    version("4.0.1", sha256="2bf988a1ed17437b1103e367939c25a13f64d36cf6d1c3bef8c3f319f0067619")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2020-13949
+        version("3.1.3", sha256="0c9b6a6359a7341b6029cc9347435ee7b379f93846f779d710b13f795b54bb16")
+        version("3.1.2", sha256="d75dcf36908b4e7b9b0ec9aec57a46a6628b97b276c233cb2c2f1a3e89b13462")
+        version("2.3.6", sha256="0b3736edc8d15f01ed649bfce7d74346c35fd57567411e9d0c3f48578f76610d")
+        version("1.2.2", sha256="763b246a1a1ceeb815493d1e5e1d71836b0c5b9be1c4cd9c8d685565113771d1")
 
     depends_on("hadoop", type="run")
 


### PR DESCRIPTION
This PR adds `hive`, v4.0.1, which fixes CVE-2020-13949. Since that CVE has high severity, previous versions are marked as deprecated.

Test build:
```
==> Installing hive-4.0.1-wcigu4qfwst6o5mxrq2qhj5xgogea272 [5/5]
==> No binary for hive-4.0.1-wcigu4qfwst6o5mxrq2qhj5xgogea272 found: installing from source
==> Fetching https://www.apache.org/dist/hive/hive-4.0.1/apache-hive-4.0.1-bin.tar.gz
==> No patches needed for hive
==> hive: Executing phase: 'install'
==> hive: Successfully installed hive-4.0.1-wcigu4qfwst6o5mxrq2qhj5xgogea272
  Stage: 1m 5.26s.  Install: 0.48s.  Post-install: 1.40s.  Total: 1m 7.28s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/hive-4.0.1-wcigu4qfwst6o5mxrq2qhj5xgogea272
```

Test run:
```
$ hive
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/hive-4.0.1-wcigu4qfwst6o5mxrq2qhj5xgogea272/lib/log4j-slf4j-impl-2.18.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/hadoop-3.4.0-rhl7hfbybtvdc5tjjpgcwqyd6sl6o6ui/share/hadoop/common/lib/slf4j-reload4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/hive-4.0.1-wcigu4qfwst6o5mxrq2qhj5xgogea272/lib/log4j-slf4j-impl-2.18.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/hadoop-3.4.0-rhl7hfbybtvdc5tjjpgcwqyd6sl6o6ui/share/hadoop/common/lib/slf4j-reload4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
Beeline version 4.0.1 by Apache Hive
beeline>
```
