### PR TITLE
yara: add v4.5.2 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/yara/package.py
+++ b/var/spack/repos/builtin/packages/yara/package.py
@@ -15,6 +15,7 @@ class Yara(AutotoolsPackage):
 
     license("BSD-3-Clause")
 
+    version("4.5.2", sha256="1f87056fcb10ee361936ee7b0548444f7974612ebb0e681734d8de7df055d1ec")
     version("3.9.0", sha256="ebe7fab0abadb90449a62afbd24e196e18b177efe71ffd8bf22df95c5386f64d")
 
     depends_on("c", type="build")  # generated
@@ -24,3 +25,4 @@ class Yara(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
+    depends_on("pkgconfig", type="build", when="@4:")

--- a/var/spack/repos/builtin/packages/yara/package.py
+++ b/var/spack/repos/builtin/packages/yara/package.py
@@ -16,7 +16,9 @@ class Yara(AutotoolsPackage):
     license("BSD-3-Clause")
 
     version("4.5.2", sha256="1f87056fcb10ee361936ee7b0548444f7974612ebb0e681734d8de7df055d1ec")
-    version("3.9.0", sha256="ebe7fab0abadb90449a62afbd24e196e18b177efe71ffd8bf22df95c5386f64d")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2021-3402
+        version("3.9.0", sha256="ebe7fab0abadb90449a62afbd24e196e18b177efe71ffd8bf22df95c5386f64d")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated


### PR DESCRIPTION
This PR adds `yara`, v4.5.2, which fixes CVE-2021-3402. Since this CVE is critical, the older version has been deprecated.

Test build:
```
==> Installing yara-4.5.2-cqu7qcx3rhubc3hpei5yd4mwsofpfj7a [18/18]
==> No binary for yara-4.5.2-cqu7qcx3rhubc3hpei5yd4mwsofpfj7a found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/1f/1f87056fcb10ee361936ee7b0548444f7974612ebb0e681734d8de7df055d1ec.tar.gz
==> No patches needed for yara
==> yara: Executing phase: 'autoreconf'
==> yara: Executing phase: 'configure'
==> yara: Executing phase: 'build'
==> yara: Executing phase: 'install'
==> yara: Successfully installed yara-4.5.2-cqu7qcx3rhubc3hpei5yd4mwsofpfj7a
  Stage: 0.08s.  Autoreconf: 4.65s.  Configure: 4.03s.  Build: 2.79s.  Install: 0.38s.  Post-install: 0.16s.  Total: 12.19s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/yara-4.5.2-cqu7qcx3rhubc3hpei5yd4mwsofpfj7a
```

Test run:
```
$ yara --version
4.5.2
```