### PR TITLE
zabbix: add v5.0.44, v6.0.34, v7.0.4 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -226,3 +226,12 @@ class Mysql(CMakePackage):
 
         if "python" in self.spec and self.spec.satisfies("@:7"):
             self._fix_dtrace_shebang(env)
+
+    @run_before("install")
+    def fixup_mysqlconfig(self):
+        if not self.spec.satisfies("platform=windows"):
+            # mysql uses spack libz but exports -lzlib to its dependencies. Fix that:
+            with working_dir(self.build_directory):
+                for config in ("scripts/mysql_config", "scripts/mysqlclient.pc"):
+                    if os.path.exists(config):
+                        filter_file(" -lzlib ", " -lz ", config)

--- a/var/spack/repos/builtin/packages/zabbix/package.py
+++ b/var/spack/repos/builtin/packages/zabbix/package.py
@@ -11,16 +11,23 @@ class Zabbix(AutotoolsPackage):
     such as networks, servers, VMs, applications and the cloud."""
 
     homepage = "https://www.zabbix.com"
-    url = "https://github.com/zabbix/zabbix/archive/5.0.3.tar.gz"
+    url = "https://github.com/zabbix/zabbix/archive/refs/tags/5.0.3.tar.gz"
 
-    license("GPL-2.0-or-later")
+    license("AGPL-3.0-only", when="@7:", checked_by="wdconinc")
+    license("GPL-2.0-or-later", when="@:6", checked_by="wdconinc")
 
-    version("5.0.3", sha256="d579c5fa4e9065e8041396ace24d7132521ef5054ce30dfd9d151cbb7f0694ec")
-    version("4.0.24", sha256="c7e4962d745277d67797d90e124555ce27d198822a7e65c55d86aee45d3e93fc")
-    version("4.0.23", sha256="652143614f52411cad47db64e93bf3ba1cd547d6ca9591296223b5f0528b3b61")
+    version("7.0.4", sha256="73aa6b47bd4078587589b30f09671fb30c7743f5b57e81ea8e9bd5a7c5f221c7")
+    version("6.0.34", sha256="e60558911230d27ffad98850e414b46e318c9d41591a6ff65a255c0810cfcb8b")
+    version("5.0.44", sha256="f8ee86fd21f0f57e7fad68387271b995c1e5cc402d517cd7df5d5221fd6129fd")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2023-32724
+        version("5.0.3", sha256="d579c5fa4e9065e8041396ace24d7132521ef5054ce30dfd9d151cbb7f0694ec")
+        # https://nvd.nist.gov/vuln/detail/CVE-2019-17382
+        version("4.0.24", sha256="c7e4962d745277d67797d90e124555ce27d198822a7e65c55d86aee45d3e93fc")
+        version("4.0.23", sha256="652143614f52411cad47db64e93bf3ba1cd547d6ca9591296223b5f0528b3b61")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")

--- a/var/spack/repos/builtin/packages/zabbix/package.py
+++ b/var/spack/repos/builtin/packages/zabbix/package.py
@@ -40,6 +40,8 @@ class Zabbix(AutotoolsPackage):
     depends_on("m4", type="build")
     depends_on("pkgconfig", type="build")
     depends_on("mysql-client")
+    # Older versions of mysql use openssl-1.x, causing build issues:
+    depends_on("mysql@8.0.35:", when="^[virtuals=mysql-client] mysql")
     depends_on("libevent")
     depends_on("pcre")
     depends_on("go")

--- a/var/spack/repos/builtin/packages/zabbix/package.py
+++ b/var/spack/repos/builtin/packages/zabbix/package.py
@@ -34,21 +34,32 @@ class Zabbix(AutotoolsPackage):
     depends_on("cxx", type="build")
 
     depends_on("autoconf", type="build")
+    depends_on("autoconf-archive", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("mysql-client")
     depends_on("libevent")
     depends_on("pcre")
     depends_on("go")
 
+    def autoreconf(self, spec, prefix):
+        Executable("./bootstrap.sh")()
+
     def configure_args(self):
+        mysql_prefix = self.spec["mysql-client"].prefix
+        if self.spec.satisfies("^[virtuals=mysql-client] mysql"):
+            mysql_config = mysql_prefix.bin.mysql_config
+        else:
+            mysql_config = mysql_prefix.bin.mariadb_config
+
         args = [
             "--enable-server",
             "--enable-proxy",
             "--enable-agent",
             "--enable-agent2",
-            "--with-mysql",
+            f"--with-mysql={mysql_config}",
             f"--with-libevent={self.spec['libevent'].prefix}",
             f"--with-libpcre={self.spec['pcre'].prefix}",
         ]

--- a/var/spack/repos/builtin/packages/zabbix/package.py
+++ b/var/spack/repos/builtin/packages/zabbix/package.py
@@ -49,8 +49,8 @@ class Zabbix(AutotoolsPackage):
             "--enable-agent",
             "--enable-agent2",
             "--with-mysql",
-            f"--with-libevent={self.spec["libevent"].prefix}",
-            f"--with-libpcre={self.spec["pcre"].prefix}",
+            f"--with-libevent={self.spec['libevent'].prefix}",
+            f"--with-libpcre={self.spec['pcre'].prefix}",
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/zabbix/package.py
+++ b/var/spack/repos/builtin/packages/zabbix/package.py
@@ -37,7 +37,7 @@ class Zabbix(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("mysql")
+    depends_on("mysql-client")
     depends_on("libevent")
     depends_on("pcre")
     depends_on("go")
@@ -49,8 +49,8 @@ class Zabbix(AutotoolsPackage):
             "--enable-agent",
             "--enable-agent2",
             "--with-mysql",
-            "--with-libevent=%s" % self.spec["libevent"].prefix,
-            "--with-libpcre=%s" % self.spec["pcre"].prefix,
+            f"--with-libevent={self.spec["libevent"].prefix}",
+            f"--with-libpcre={self.spec["pcre"].prefix}",
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/zabbix/package.py
+++ b/var/spack/repos/builtin/packages/zabbix/package.py
@@ -23,8 +23,12 @@ class Zabbix(AutotoolsPackage):
         # https://nvd.nist.gov/vuln/detail/CVE-2023-32724
         version("5.0.3", sha256="d579c5fa4e9065e8041396ace24d7132521ef5054ce30dfd9d151cbb7f0694ec")
         # https://nvd.nist.gov/vuln/detail/CVE-2019-17382
-        version("4.0.24", sha256="c7e4962d745277d67797d90e124555ce27d198822a7e65c55d86aee45d3e93fc")
-        version("4.0.23", sha256="652143614f52411cad47db64e93bf3ba1cd547d6ca9591296223b5f0528b3b61")
+        version(
+            "4.0.24", sha256="c7e4962d745277d67797d90e124555ce27d198822a7e65c55d86aee45d3e93fc"
+        )
+        version(
+            "4.0.23", sha256="652143614f52411cad47db64e93bf3ba1cd547d6ca9591296223b5f0528b3b61"
+        )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")


### PR DESCRIPTION
This PR adds `zabbix`, v5.0.44, v6.0.34, v7.0.4, which are the latest released/maintained versions. This fixes CVE-2023-32721, CVE-2023-29451, CVE-2023-29450, CVE-2023-29449, CVE-2022-35230, CVE-2021-46088, CVE-2022-23132, CVE-2021-27927, CVE-2019-17382, CVE-2019-15132, CVE-2024-22119, CVE-2023-32724, CVE-2023-32721, CVE-2023-29451, CVE-2023-29450, CVE-2023-29449, CVE-2022-35230, CVE-2022-35229, CVE-2021-46088, CVE-2022-23133, CVE-2022-23132, CVE-2021-27927, CVE-2019-15132.

Test environment:
```
  - zabbix@=5.0.44 ^[virtuals=mysql-client] mysql
  - zabbix@=5.0.44 ^[virtuals=mysql-client] mariadb
  - zabbix@=5.0.44 ^[virtuals=mysql-client] mariadb-c-client
  - zabbix@=6.0.34 ^[virtuals=mysql-client] mysql
  - zabbix@=6.0.34 ^[virtuals=mysql-client] mariadb
  - zabbix@=6.0.34 ^[virtuals=mysql-client] mariadb-c-client
  - zabbix@=7.0.4 ^[virtuals=mysql-client] mysql
  - zabbix@=7.0.4 ^[virtuals=mysql-client] mariadb
  - zabbix@=7.0.4 ^[virtuals=mysql-client] mariadb-c-client
```

Test builds:
```
[+] qpax65v zabbix@5.0.44  [+] 7svlhfe zabbix@6.0.34  [+] dcxylpo zabbix@7.0.4
[+] qtv3gbd zabbix@5.0.44  [+] qalyi3l zabbix@6.0.34  [+] 7p3yfzo zabbix@7.0.4
[+] lvxqbth zabbix@5.0.44  [+] sdvgwt6 zabbix@6.0.34  [+] epfg7aj zabbix@7.0.4
```

Test run:
```
19:23:08 wdconinc@menelaos /opt/spack/stage/wdconinc/spack-stage-zabbix-6.0.34-ora7ipfuoy7irz2sourdaboipaqpbpz4/spack-src $ spack load /7p3yfzo
19:23:30 wdconinc@menelaos /opt/spack/stage/wdconinc/spack-stage-zabbix-6.0.34-ora7ipfuoy7irz2sourdaboipaqpbpz4/spack-src $ zabbix_server -V
zabbix_server (Zabbix) 7.0.4
Revision {ZABBIX_REVISION} 24 September 2024, compilation time: Oct 29 2024 19:15:17

Copyright (C) 2024 Zabbix SIA
License AGPLv3: GNU Affero General Public License version 3 <https://www.gnu.org/licenses/>.
This is free software: you are free to change and redistribute it according to
the license. There is NO WARRANTY, to the extent permitted by law.
```