### PR TITLE
rtd: bump sphinx-rtd-theme to 3.0.1

### DIFF
--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -1,7 +1,7 @@
 sphinx==7.4.7
 sphinxcontrib-programoutput==0.17
 sphinx_design==0.6.1
-sphinx-rtd-theme==2.0.0
+sphinx-rtd-theme==3.0.1
 python-levenshtein==0.25.1
 docutils==0.20.1
 pygments==2.18.0


### PR DESCRIPTION
This PR updates the `sphinx-rtd-theme` to v3.0.1. This enables sphinx-8 compatibility.

Test docs page: https://spack--47002.org.readthedocs.build/en/47002/

This will get https://github.com/spack/spack/pull/45509 unstuck.