### PR TITLE
`ftgl`: Handle char/unsigned char API change with the update to freetype@2.13.3

### DIFF
--- a/var/spack/repos/builtin/packages/ftgl/package.py
+++ b/var/spack/repos/builtin/packages/ftgl/package.py
@@ -38,7 +38,7 @@ class Ftgl(CMakePackage):
     patch(
         "https://patch-diff.githubusercontent.com/raw/frankheckenbach/ftgl/pull/20.patch?full_index=1",
         sha256="e2a0810fbf68403931bef4fbfda22e010e01421c92eeaa45f62e4e47f2381ebd",
-        when="@2.4.0",
+        when="@2.4.0 %gcc@14:",
     )
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/ftgl/package.py
+++ b/var/spack/repos/builtin/packages/ftgl/package.py
@@ -18,15 +18,12 @@ class Ftgl(CMakePackage):
     version("2.4.0", commit="483639219095ad080538e07ceb5996de901d4e74")
     version("2.3.1", commit="3c0fdf367824b6381f29df3d8b4590240db62ab7")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
-    # FIXME: Doc generation is broken in upstream build system
-    # variant('doc', default=False, description='Build the documentation')
     variant("shared", default=True, description="Build as a shared library")
 
     depends_on("cmake@2.8:", type="build")
-    # depends_on('doxygen', type='build', when='+doc')  -- FIXME, see above
     depends_on("pkgconfig", type="build")
     depends_on("gl")
     depends_on("glu")
@@ -34,16 +31,24 @@ class Ftgl(CMakePackage):
 
     # Fix oversight in CMakeLists
     patch("remove-ftlibrary-from-sources.diff", when="@:2.4.0")
-    # Fix gcc14 compilation error due to type mismatch in FTContour
+
+    # As reported by Khem Raj in
+    # https://github.com/kraj/ftgl/commit/37ed7d606a0dfecdcb4ab0c26d1b0132cd96d5fa
+    # freetype 2.13.3 changed the type of many external chars to unsigned char!
     patch(
         "https://patch-diff.githubusercontent.com/raw/frankheckenbach/ftgl/pull/20.patch?full_index=1",
         sha256="e2a0810fbf68403931bef4fbfda22e010e01421c92eeaa45f62e4e47f2381ebd",
-        when="@2.4.0 %gcc@14:",
+        when="^freetype@2.13.3:",
     )
 
     def cmake_args(self):
         spec = self.spec
         args = ["-DBUILD_SHARED_LIBS={0}".format(spec.satisfies("+shared"))]
+
+        # To not fail the build for 'char/unsigned char' conversion errors,
+        # downgrade them to warnings in general to not fail the build:
+        args.append("-DCMAKE_CXX_FLAGS=-fpermissive")
+
         if "darwin" in self.spec.architecture:
             args.append("-DCMAKE_MACOSX_RPATH=ON")
         return args


### PR DESCRIPTION
The patch added by #46927 should only be applied where it is needed: with GCC 11 it causes a compilation failure where none previously existed.
