### PR TITLE
Make `oci.py::test_buildcache_tag` resistant to changes in the mock specs

### DIFF
--- a/lib/spack/spack/test/oci/integration_test.py
+++ b/lib/spack/spack/test/oci/integration_test.py
@@ -69,8 +69,8 @@ def test_buildcache_tag(install_mockery, mock_fetch, mutable_mock_env_path):
     """Tests whether we can create an OCI image from a full environment with multiple roots."""
     env("create", "test")
     with ev.read("test"):
-        install("--add", "libelf")
-        install("--add", "trivial-install-test-package")
+        install("--fake", "--add", "libelf")
+        install("--fake", "--add", "trivial-install-test-package")
 
     registry = InMemoryOCIRegistry("example.com")
 
@@ -83,7 +83,7 @@ def test_buildcache_tag(install_mockery, mock_fetch, mutable_mock_env_path):
         name = ImageReference.from_string("example.com/image:full_env")
 
         with ev.read("test") as e:
-            specs = e.all_specs()
+            specs = [x for x in e.all_specs() if not x.external]
 
         manifest, config = get_manifest_and_config(name)
 
@@ -100,7 +100,7 @@ def test_buildcache_tag(install_mockery, mock_fetch, mutable_mock_env_path):
 
         name = ImageReference.from_string("example.com/image:single_spec")
         manifest, config = get_manifest_and_config(name)
-        assert len(manifest["layers"]) == 1
+        assert len(manifest["layers"]) == len([x for x in libelf.traverse() if not x.external])
 
 
 def test_buildcache_push_with_base_image_command(mutable_database, tmpdir):
@@ -347,6 +347,10 @@ def test_best_effort_upload(mutable_database: spack.database.Database, monkeypat
         for s in mpileaks.traverse():
             if s.name in without_manifest:
                 continue
+
+            if s.external:
+                continue
+
             # This should not raise a 404.
             manifest, _ = get_manifest_and_config(image.with_tag(default_tag(s)))
 
@@ -358,6 +362,10 @@ def test_best_effort_upload(mutable_database: spack.database.Database, monkeypat
         for s in mpileaks.traverse():
             if s.name in without_manifest:
                 continue
+
+            if s.external:
+                continue
+
             expected_digests = {
                 pkg_to_own_digest[t.name]
                 for t in s.traverse(deptype=("link", "run"), root=True)


### PR DESCRIPTION
Extracted from #45189 

This just makes `test_buildcache_tag` resilient to changes in the structure of the mock specs it installs. In particular, it allows for them to have external dependencies.

It also allows people to review the change with a much smaller scope :slightly_smiling_face: 
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
