### PR TITLE
root: fix variant detection for spack external find

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -539,7 +539,6 @@ class Root(CMakePackage):
         _add_variant(v, f, "http", "+http")
         _add_variant(v, f, ("imt", "tbb"), "+tbb")
         if Version(version_str) <= Version("6.28"):
-            print(version_str)
             _add_variant(v, f, "jemalloc", "+jemalloc")
         if Version(version_str) <= Version("6.17"):
             _add_variant(v, f, "memstat", "+memstat")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -538,21 +538,27 @@ class Root(CMakePackage):
         _add_variant(v, f, "gviz", "+graphviz")
         _add_variant(v, f, "http", "+http")
         _add_variant(v, f, ("imt", "tbb"), "+tbb")
-        _add_variant(v, f, "jemalloc", "+jemalloc")
-        _add_variant(v, f, "memstat", "+memstat")
+        if Version(version_str) <= Version("6.28"):
+            print(version_str)
+            _add_variant(v, f, "jemalloc", "+jemalloc")
+        if Version(version_str) <= Version("6.17"):
+            _add_variant(v, f, "memstat", "+memstat")
         _add_variant(v, f, ("minuit", "minuit2"), "+minuit")
         _add_variant(v, f, "mlp", "+mlp")
         _add_variant(v, f, "mysql", "+mysql")
-        _add_variant(v, f, "oracle", "+oracle")
+        if Version(version_str) <= Version("6.30"):
+            _add_variant(v, f, "oracle", "+oracle")
         _add_variant(v, f, "pgsql", "+postgres")
-        _add_variant(v, f, "pythia6", "+pythia6")
+        if Version(version_str) <= Version("6.30"):
+            _add_variant(v, f, "pythia6", "+pythia6")
         _add_variant(v, f, "pythia8", "+pythia8")
         _add_variant(v, f, "pyroot", "+python")
-        _add_variant(v, f, ("qt", "qtgsi"), "+qt4")
+        if Version(version_str) <= Version("6.17"):
+            _add_variant(v, f, ("qt", "qtgsi"), "+qt4")
         _add_variant(v, f, "r", "+r")
         _add_variant(v, f, "roofit", "+roofit")
         # webui feature renamed to webgui in 6.18
-        if Version(version_str).satisfies("@6.18:"):
+        if Version(version_str) >= Version("6.18"):
             _add_variant(v, f, ("root7", "webgui"), "+webgui")
         else:
             _add_variant(v, f, ("root7", "webui"), "+webgui")
@@ -561,7 +567,8 @@ class Root(CMakePackage):
         _add_variant(v, f, "spectrum", "+spectrum")
         _add_variant(v, f, "sqlite", "+sqlite")
         _add_variant(v, f, "ssl", "+ssl")
-        _add_variant(v, f, "table", "+table")
+        if Version(version_str) <= Version("6.17"):
+            _add_variant(v, f, "table", "+table")
         _add_variant(v, f, "thread", "+threads")
         _add_variant(v, f, "tmva", "+tmva")
         _add_variant(v, f, "tmva-cpu", "+tmva-cpu")
@@ -572,7 +579,8 @@ class Root(CMakePackage):
         _add_variant(v, f, "vc", "+vc")
         _add_variant(v, f, "vdt", "+vdt")
         _add_variant(v, f, "veccore", "+veccore")
-        _add_variant(v, f, "vmc", "+vmc")
+        if Version(version_str) <= Version("6.25"):
+            _add_variant(v, f, "vmc", "+vmc")
         _add_variant(v, f, ("x11", "xft"), "+x")
         _add_variant(v, f, "xml", "+xml")
         _add_variant(v, f, "xrootd", "+xrootd")


### PR DESCRIPTION
A few fixes (possibly non-exhaustive) to `spack external find root` Several variants have had `when=` clauses added that need to be propagated to determine_variants. The previously used Version.satifies("") method also has been removed, it seems. It's slightly cumbersome that there is no self.spec to use in determine_variants, but comparisons using Version(version_str) work at least

