### PR TITLE
LAMMPS update for AOCC-5 compiler and zen5 target

### DIFF
--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -884,11 +884,16 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
                     "-O3 -fno-math-errno -fno-unroll-loops "
                     "-fveclib=AMDLIBM -muse-unaligned-vector-move"
                 )
-                if spec.satisfies("%aocc@4.1:"):
+                if spec.satisfies("%aocc@4.1:4.2"):
                     cxx_flags += (
                         " -mllvm -force-gather-overhead-cost=50"
                         " -mllvm -enable-masked-gather-sequence=false"
                     )
+                elif spec.satisfies("%aocc@5.0:"):
+                    cxx_flags += " -mllvm -enable-aggressive-gather"
+                    if spec.target >= "zen5":
+                        cxx_flags += " -fenable-restrict-based-lv"
+
                 # add -fopenmp-simd if OpenMP not already turned on
                 if spec.satisfies("~openmp"):
                     cxx_flags += " -fopenmp-simd"


### PR DESCRIPTION
Changes include updates in `LAMMPS` recipe for `AOCC` compiler and `zen5` target specific flags
- Restrict the existing flags to apply up to AOCC version 4.2.
- Introduced compiler flags available with AOCC version 5.0 to accommodate architecture-specific changes in the newer compiler versions.


