### PR TITLE
duckdb: version 1.1.2 + install headers and libraries

### DIFF
--- a/var/spack/repos/builtin/packages/duckdb/package.py
+++ b/var/spack/repos/builtin/packages/duckdb/package.py
@@ -18,6 +18,7 @@ class Duckdb(MakefilePackage):
     maintainers("glentner", "teaguesterling")
 
     version("master", branch="master")
+    version("1.1.2", sha256="a3319a64c390ed0454c869b2e4fc0af2413cd49f55cd0f1400aaed9069cdbc4c")
     version("1.1.1", sha256="a764cef80287ccfd8555884d8facbe962154e7c747043c0842cd07873b4d6752")
     version("1.1.0", sha256="d9be2c6d3a5ebe2b3d33044fb2cb535bb0bd972a27ae38c4de5e1b4caa4bf68d")
     version("1.0.0", sha256="04e472e646f5cadd0a3f877a143610674b0d2bcf9f4102203ac3c3d02f1c5f26")
@@ -186,5 +187,10 @@ class Duckdb(MakefilePackage):
 
     def install(self, spec, prefix):
         mkdir(prefix.bin)
+        mkdirp(prefix.lib)
+        mkdir(prefix.include)
         build_dir = join_path("build", "release")
         install(join_path(build_dir, "duckdb"), prefix.bin)
+        install(join_path(build_dir, "src", "libduckdb.so"), prefix.lib)
+        install(join_path(build_dir, "src", "libduckdb_static.a"), prefix.lib)
+        install_tree(join_path("src", "include"), prefix.include)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This PR does the following:

- Add version 1.1.2
- Install the headers and libraries (previously, only the duckdb executable was installed)

I have tested the installation with all the non-deprecated versions.