### PR TITLE
Add spack_short_version variable in path substitutions

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -511,6 +511,7 @@ Spack understands over a dozen special variables. These are:
 * ``$target_family``. The target family for the current host, as
   detected by ArchSpec. E.g. ``x86_64`` or ``aarch64``.
 * ``$date``: the current date in the format YYYY-MM-DD
+* ``$spack_short_version``: the Spack version truncated to the first components.
 
 
 Note that, as with shell variables, you can write these as ``$varname``

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -69,4 +69,15 @@ def get_version() -> str:
     return spack_version
 
 
-__all__ = ["spack_version_info", "spack_version", "get_version", "get_spack_commit"]
+def get_short_version() -> str:
+    """Short Spack version."""
+    return f"{spack_version_info[0]}.{spack_version_info[1]}"
+
+
+__all__ = [
+    "spack_version_info",
+    "spack_version",
+    "get_version",
+    "get_spack_commit",
+    "get_short_version",
+]

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -472,6 +472,13 @@ def test_substitute_date(mock_low_high_config):
     assert date.today().strftime("%Y-%m-%d") in new_path
 
 
+def test_substitute_spack_version():
+    version = spack.spack_version_info
+    assert spack_path.canonicalize_path(
+        "spack$spack_short_version/test"
+    ) == spack_path.canonicalize_path(f"spack{version[0]}.{version[1]}/test")
+
+
 PAD_STRING = spack_path.SPACK_PATH_PADDING_CHARS
 MAX_PATH_LEN = spack_path.get_system_path_max()
 MAX_PADDED_LEN = MAX_PATH_LEN - spack_path.SPACK_MAX_INSTALL_PATH_LENGTH

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -74,6 +74,7 @@ def replacements():
         "target_family": lambda: arch.target.family,
         "date": lambda: date.today().strftime("%Y-%m-%d"),
         "env": lambda: ev.active_environment().path if ev.active_environment() else NOMATCH,
+        "spack_short_version": lambda: spack.get_short_version(),
     }
 
 
@@ -154,19 +155,20 @@ def substitute_config_variables(path):
 
     Spack allows paths in configs to have some placeholders, as follows:
 
-    - $env               The active Spack environment.
-    - $spack             The Spack instance's prefix
-    - $tempdir           Default temporary directory returned by tempfile.gettempdir()
-    - $user              The current user's username
-    - $user_cache_path   The user cache directory (~/.spack, unless overridden)
-    - $architecture      The spack architecture triple for the current system
-    - $arch              The spack architecture triple for the current system
-    - $platform          The spack platform for the current system
-    - $os                The OS of the current system
-    - $operating_system  The OS of the current system
-    - $target            The ISA target detected for the system
-    - $target_family     The family of the target detected for the system
-    - $date              The current date (YYYY-MM-DD)
+    - $env                 The active Spack environment.
+    - $spack               The Spack instance's prefix
+    - $tempdir             Default temporary directory returned by tempfile.gettempdir()
+    - $user                The current user's username
+    - $user_cache_path     The user cache directory (~/.spack, unless overridden)
+    - $architecture        The spack architecture triple for the current system
+    - $arch                The spack architecture triple for the current system
+    - $platform            The spack platform for the current system
+    - $os                  The OS of the current system
+    - $operating_system    The OS of the current system
+    - $target              The ISA target detected for the system
+    - $target_family       The family of the target detected for the system
+    - $date                The current date (YYYY-MM-DD)
+    - $spack_short_version The spack short version
 
     These are substituted case-insensitively into the path, and users can
     use either ``$var`` or ``${var}`` syntax for the variables. $env is only


### PR DESCRIPTION
Add `$spack_short_version` variable in Spack's path variable substitutions.

I am using these variables because I actively work with multiple Spack instances of different versions simultaneously. I have found that isolating some Spack directories can be very helpful:

```yaml
config:
  # Facilitate the use of multiple Spack versions:
  # - Avoid systematically rebuilding recipe/provider cache
  misc_cache: $user_cache_path/cache$spack_short_version
  # - Avoid unnecessary contention on build stage
  build_stage: [$tempdir/$user/spack$spack_short_version-stage]
```
```yaml
bootstrap:
  # Facilitate the use of multiple Spack versions:
  # - Isolate bootstrap to avoid store db upgrades and re-indexing on downgrades
  root: $user_cache_path/bootstrap$spack_short_version
```

(I also add `$os-$target_family` on infrastructures with overly shared FS)
