### PR TITLE
py-datrie: patch to allow gcc-14 compilation

### DIFF
--- a/var/spack/repos/builtin/packages/py-datrie/package.py
+++ b/var/spack/repos/builtin/packages/py-datrie/package.py
@@ -22,3 +22,8 @@ class PyDatrie(PythonPackage):
     depends_on("py-setuptools@40.8:", type=("build"))
     depends_on("py-cython@0.28:", type="build")
     depends_on("py-pytest-runner", type="build")
+
+    @when("@:0.8.2")
+    def patch(self):
+        # fix failure to compile on gcc-14, https://github.com/pytries/datrie/pull/99
+        filter_file(r"(\s*)(struct AlphaMap:)", r"\1ctypedef \2", "src/cdatrie.pxd")


### PR DESCRIPTION
This PR patches `py-datrie` for gcc-14, which fails due to `-Werror=incompatible-pointer-types`. Another approach could have been to disable that error with cflags/cxxflags, but an actual fix seems preferred.

Test build:
```
==> Installing py-datrie-0.8.2-rukglixxxwakkwjho3zyt6uwguiq4yj5 [30/30]
==> No binary for py-datrie-0.8.2-rukglixxxwakkwjho3zyt6uwguiq4yj5 found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/52/525b08f638d5cf6115df6ccd818e5a01298cd230b2dac91c8ff2e6499d18765d.tar.gz
==> Ran patch() for py-datrie
==> py-datrie: Executing phase: 'install'
==> py-datrie: Successfully installed py-datrie-0.8.2-rukglixxxwakkwjho3zyt6uwguiq4yj5
  Stage: 0.01s.  Install: 23.33s.  Post-install: 0.40s.  Total: 23.99s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/py-datrie-0.8.2-rukglixxxwakkwjho3zyt6uwguiq4yj5
```