### PR TITLE
kokkos: Unconditionally disable `Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC`

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -375,7 +375,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         # which breaks GPU-aware with Cray-MPICH
         # See https://github.com/kokkos/kokkos/pull/6402
         # TODO: disable this once Cray-MPICH is fixed
-        if self.spec.satisfies("@4.2.00:") and self.spec.satisfies("^[virtuals=mpi] cray-mpich"):
+        if self.spec.satisfies("@4.2.00:"):
             options.append(self.define("Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC", False))
 
         # Remove duplicate options


### PR DESCRIPTION
https://github.com/spack/spack/pull/42661 added a conditional disabling of Kokkos' use of cudaMallocAsync with cray-mpich, since it's buggy. However, as far as I can tell this branch will never be taken, because `mpi` is not a dependency of `kokkos`.

I tested with e.g. `arborx +mpi ^cray-mpich`, which ends up having both `kokkos` and `cray-mpich` as dependencies, and the condition for disabling `Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC` is not taken. Especially in a case where kokkos would be separately concretized without MPI first and then concretized together with a package that uses MPI, it makes little sense that the build configuration of kokkos would (or would not) change depending on the other package.

I also tested the condition with and without https://github.com/spack/spack/pull/46388, which changed the condition, but neither of them disable the option.

@rbberger since you opened the original PR, do you think I'm missing something here? Did the condition actually work at some point?

A variant (disabled by default) is also still an option, but considering the CMake flag is an `IMPL` option, I'm not sure the kokkos people want to have that exposed in the spack package?