### PR TITLE
cyrus-sasl: patch v2.1.27:2.1.28 for gcc-14

### DIFF
--- a/var/spack/repos/builtin/packages/cyrus-sasl/package.py
+++ b/var/spack/repos/builtin/packages/cyrus-sasl/package.py
@@ -23,6 +23,14 @@ class CyrusSasl(AutotoolsPackage):
     version("2.1.24", sha256="1df15c492f7ecb90be49531a347b3df21b041c2e0325dcc4fc5a6e98384c40dd")
     version("2.1.23", sha256="b1ec43f62d68446a6a5879925c63d94e26089c5a46cd83e061dd685d014c7d1f")
 
+    # ensure include time.h, https://github.com/cyrusimap/cyrus-sasl/pull/709
+    patch(
+        "https://github.com/cyrusimap/cyrus-sasl/commit/266f0acf7f5e029afbb3e263437039e50cd6c262.patch?full_index=1",
+        sha256="819342fe68475ac1690136ff4ce9b73c028f433ae150898add36f724a8e2274b",
+        when="@2.1.27:2.1.28",
+    )
+    conflicts("%gcc@14:", when="@:2.1.26")
+
     depends_on("c", type="build")  # generated
 
     depends_on("m4", type="build")


### PR DESCRIPTION
This PR patches `cyrus-sasl` to compile with gcc-14. The patch has been applied into master, and will be in v2.2 releases. No more v2.1 releases forthcoming, but I still closed the range at v2.1.28 instead of v2.1. The patch does not apply to v2.1.26 and older, so a conflict with gcc-14 was added. See https://github.com/cyrusimap/cyrus-sasl/pull/709.

```
==> Installing cyrus-sasl-2.1.28-utquawfqnwinshxidwtxn26gfff2oitu [20/20]
==> No binary for cyrus-sasl-2.1.28-utquawfqnwinshxidwtxn26gfff2oitu found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/3e/3e38933a30b9ce183a5488b4f6a5937a702549cde0d3287903d80968ad4ec341.tar.gz
==> Fetching https://github.com/cyrusimap/cyrus-sasl/commit/266f0acf7f5e029afbb3e263437039e50cd6c262.patch?full_index=1
==> Applied patch https://github.com/cyrusimap/cyrus-sasl/commit/266f0acf7f5e029afbb3e263437039e50cd6c262.patch?full_index=1
==> cyrus-sasl: Executing phase: 'autoreconf'
==> cyrus-sasl: Executing phase: 'configure'
==> cyrus-sasl: Executing phase: 'build'
==> cyrus-sasl: Executing phase: 'install'
==> cyrus-sasl: Successfully installed cyrus-sasl-2.1.28-utquawfqnwinshxidwtxn26gfff2oitu
  Stage: 0.47s.  Autoreconf: 7.85s.  Configure: 7.84s.  Build: 8.28s.  Install: 0.66s.  Post-install: 0.30s.  Total: 25.60s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/cyrus-sasl-2.1.28-utquawfqnwinshxidwtxn26gfff2oitu
```