### PR TITLE
freetype: prefer 2.13.2 due to interface change in 2.13.3

### DIFF
--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -23,7 +23,14 @@ class Freetype(AutotoolsPackage, CMakePackage):
     license("FTL OR GPL-2.0-or-later")
 
     version("2.13.3", sha256="5c3a8e78f7b24c20b25b54ee575d6daa40007a5f4eea2845861c3409b3021747")
-    version("2.13.2", sha256="1ac27e16c134a7f2ccea177faba19801131116fd682efc1f5737037c5db224b5")
+    # Freetype 2.13.3 broke the public interface, so marking 2.13.2 as preferred in spack 0.23
+    # Once spack 0.23 has been released, this preference can be removed again.
+    # https://gitlab.freedesktop.org/freetype/freetype/-/merge_requests/330
+    version(
+        "2.13.2",
+        sha256="1ac27e16c134a7f2ccea177faba19801131116fd682efc1f5737037c5db224b5",
+        preferred=True,
+    )
     version("2.13.1", sha256="0b109c59914f25b4411a8de2a506fdd18fa8457eb86eca6c7b15c19110a92fa5")
     version("2.13.0", sha256="a7aca0e532a276ea8d85bd31149f0a74c33d19c8d287116ef8f5f8357b4f1f80")
     version("2.12.1", sha256="efe71fd4b8246f1b0b1b9bfca13cfff1c9ad85930340c27df469733bbb620938")


### PR DESCRIPTION
This PR marks `freetype`, v2.13.2, as preferred due to interface changes (`char*` to `unsigned char*`) which cause downstream compilation failures.

See https://gitlab.freedesktop.org/freetype/freetype/-/merge_requests/330 as well as https://github.com/spack/spack/pull/46751.