### PR TITLE
foldseek: updated specs

### DIFF
--- a/var/spack/repos/builtin/packages/foldseek/package.py
+++ b/var/spack/repos/builtin/packages/foldseek/package.py
@@ -14,13 +14,12 @@ class Foldseek(CMakePackage):
 
     license("GPL-3.0-only", checked_by="A-N-Other")
 
+    version("9-427df8a", sha256="b17d2d85b49a8508f79ffd8b15e54afc5feef5f3fb0276a291141ca5dbbbe8bc")
     version("8-ef4e960", sha256="c74d02c4924d20275cc567783b56fff10e76ed67f3d642f53c283f67c4180a1e")
     version("7-04e0ec8", sha256="009d722d600248a680b9e1e9dcb3bf799f8be8de41e80a598b7f39a5ced54191")
-
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
 
     depends_on("zlib-api")
     depends_on("bzip2")
     depends_on("openmpi")
     depends_on("rust", type="build")
+    depends_on("rust@1.78.0", when="@:9", type="build")


### PR DESCRIPTION
- updated specs for rust version; breaks with and after 1.79.0 due to renaming of functions
- removed redundant c and cxx dependencies for the cmakepackage
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
