### PR TITLE
Adds variant to PAPI to toggle use of rdpmc due to topdown counter issues on Intel CPUs

### DIFF
--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -59,6 +59,12 @@ class Papi(AutotoolsPackage, ROCmPackage):
     variant("cuda", default=False, description="Enable CUDA support")
     variant("nvml", default=False, description="Enable NVML support")
     variant("rocm_smi", default=False, description="Enable ROCm SMI support")
+    variant(
+        "rdpmc",
+        default=True,
+        when="@6.0.0:",
+        description="Enable use of rdpmc for reading counters, when possible",
+    )
 
     variant("shared", default=True, description="Build shared libraries")
     # PAPI requires building static libraries, so there is no "static" variant
@@ -158,6 +164,9 @@ class Papi(AutotoolsPackage, ROCmPackage):
 
         build_shared = "yes" if "+shared" in spec else "no"
         options.append("--with-shared-lib=" + build_shared)
+
+        build_rdpmc_support = "yes" if "+rdpmc" in spec else "no"
+        options.append("--enable-perfevent-rdpmc=" + build_rdpmc_support)
 
         if "+static_tools" in spec:
             options.append("--with-static-tools")


### PR DESCRIPTION
Due to the topdown issues described in icl-utk-edu/papi#207 and icl-utk-edu/papi#238, some tools (e.g., Caliper) might need counter reads with `rdpmc` disabled on certain architectures (e.g., Sapphire Rapids) in very specific circumstances (e.g., topdown calculations). To help those users, this PR adds a new `rdpmc` variant. When enabled (which it is by default), this variant passes `--enable-perfevent-rdpmc=yes` to `configure` so that `rdpmc` is used for counter reads. When disabled, this variant passes `--enable-perfevent-rdpmc=no` to `configure` so that POSIX `read` is used for counter reads.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
