### PR TITLE
openldap: add v2.6.8; conflict gcc@14: for older

### DIFF
--- a/var/spack/repos/builtin/packages/openldap/package.py
+++ b/var/spack/repos/builtin/packages/openldap/package.py
@@ -21,6 +21,7 @@ class Openldap(AutotoolsPackage):
 
     license("OLDAP-2.8")
 
+    version("2.6.8", sha256="48969323e94e3be3b03c6a132942dcba7ef8d545f2ad35401709019f696c3c4e")
     version("2.6.4", sha256="d51704e50178430c06cf3d8aa174da66badf559747a47d920bb54b2d4aa40991")
     version("2.6.0", sha256="b71c580eac573e9aba15d95f33dd4dd08f2ed4f0d7fc09e08ad4be7ed1e41a4f")
     version("2.4.49", sha256="e3b117944b4180f23befe87d0dcf47f29de775befbc469dcf4ac3dab3311e56e")
@@ -66,6 +67,9 @@ class Openldap(AutotoolsPackage):
     depends_on("wiredtiger", when="@2.6.0:")
     depends_on("findutils", type="build")
     # see https://github.com/openldap/openldap/blob/OPENLDAP_REL_ENG_2_4_48/libraries/liblunicode/Makefile.in
+
+    # Newer C compilers (>= Clang 16 and >= GCC 14) reject some constructs removed in C99
+    conflicts("%gcc@14:", when="@:2.6.4", msg="Newer C compilers required 2.6.5 or newer")
 
     # Ref: https://www.linuxfromscratch.org/blfs/view/svn/server/openldap.html
     @when("+client_only")


### PR DESCRIPTION
This PR adds `openldap`, v2.6.8, which fixes compilation with `gcc@14:` (and maybe `clang@16:` as well, though I am not sure it fails with the same `broken POSIX regex` configure error). No changes to [`configure.ac`](https://git.openldap.org/openldap/openldap/-/compare/OPENLDAP_REL_ENG_2_6_4...OPENLDAP_REL_ENG_2_6_8?from_project_id=1&page=3&straight=false) that would need to be adapted to here.

Test build:
```
==> Installing openldap-2.6.8-rmunmvoamoqgebmvykfrmeyctxr6nt7h [11/11]
==> No binary for openldap-2.6.8-rmunmvoamoqgebmvykfrmeyctxr6nt7h found: installing from source
==> Fetching https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.6.8.tgz
==> No patches needed for openldap
==> openldap: Executing phase: 'autoreconf'
==> openldap: Executing phase: 'configure'
==> openldap: Executing phase: 'build'
==> openldap: Executing phase: 'install'
==> openldap: Successfully installed openldap-2.6.8-rmunmvoamoqgebmvykfrmeyctxr6nt7h
  Stage: 2.56s.  Autoreconf: 0.00s.  Configure: 22.25s.  Build: 22.73s.  Install: 8.43s.  Post-install: 0.37s.  Total: 56.53s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/openldap-2.6.8-rmunmvoamoqgebmvykfrmeyctxr6nt7h
```