### PR TITLE
gtkplus: swap to at-spi2-core

### DIFF
--- a/var/spack/repos/builtin/packages/at-spi2-atk/package.py
+++ b/var/spack/repos/builtin/packages/at-spi2-atk/package.py
@@ -25,7 +25,7 @@ class AtSpi2Atk(MesonPackage):
     depends_on("c", type="build")  # generated
 
     depends_on("pkgconfig", type="build")
-    depends_on("at-spi2-core@2.28.0:")
+    depends_on("at-spi2-core@2.28.0:2.45.1")
     depends_on("atk@2.28.1:")
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -61,8 +61,10 @@ class Gtkplus(AutotoolsPackage, MesonPackage):
     depends_on("glib@2.57.2:")
     depends_on("pango@1.41.0:+X")
     depends_on("fribidi@0.19.7:")
-    depends_on("atk@2.35.1:")
-    depends_on("at-spi2-atk@2.15.1:", when="@3:")
+    # atk was also merged into at-spi2-core, but gtk3 doesn't want to build without it
+    depends_on("atk@2.35.1:", when="@:3")
+    # at-spi2-atk was merged into at-spi2-core, but gtk3 is picky
+    depends_on("at-spi2-core@2.46:2.48", when="@:3")
     depends_on("cairo@1.14.0:+X+pdf+gobject")
     depends_on("gdk-pixbuf@2.30.0:")
     depends_on("gobject-introspection@1.39.0:")


### PR DESCRIPTION
at-spi2-atk and atk are now archived projects, with that functionality now in at-spi2-core. However it seems gtk3 is picky and still needs atk (for the non deprecated versions we have) and specific version ranges of at-spi2-core.

I've also bound the requirements on at-spi2-atk (although I don't think anything else uses it) since building against the latest at-spi2-core with that results in issues later down the line when other programs try to use gtkplus (wxwidgets was failing in the configure phase while testing for gtk) which is what lead me down this path.

