### PR TITLE
py-awkward: add dependency for py-importlib-metadata

### DIFF
--- a/var/spack/repos/builtin/packages/py-awkward/package.py
+++ b/var/spack/repos/builtin/packages/py-awkward/package.py
@@ -82,7 +82,7 @@ class PyAwkward(PythonPackage):
     depends_on("py-numpy@1.17.0:", when="@2.1:", type=("build", "run"))
     depends_on("py-numpy@1.18.0:", when="@2.3:", type=("build", "run"))
     depends_on("py-pybind11", type=("build", "link"))
-    depends_on("py-importlib-resources", when="@2: ^python@:3.8", type=("build", "run"))
+    depends_on("py-importlib-resources", when="@2:2.3 ^python@:3.8", type=("build", "run"))
     depends_on("py-typing-extensions@4.1:", when="@2: ^python@:3.10", type=("build", "run"))
     depends_on("py-packaging", when="@2:", type=("build", "run"))
     depends_on("dlpack", when="@1.0.0:")
@@ -90,7 +90,7 @@ class PyAwkward(PythonPackage):
     depends_on("cmake@3.13:", type="build")
     depends_on("py-wheel@0.36.0:", when="@:1.7.0", type="build")
     depends_on("py-importlib-metadata@4.13.0:", when="@2.4.0:", type=("build", "run"))
-    depends_on("py-fsspec@2022.11.0:", when="@2.6.1:", type=("build", "run"))
+    depends_on("py-fsspec@2022.11.0:", when="@2.6.0:", type=("build", "run"))
 
     @when("@1.9.0:")
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/py-awkward/package.py
+++ b/var/spack/repos/builtin/packages/py-awkward/package.py
@@ -89,6 +89,8 @@ class PyAwkward(PythonPackage):
     depends_on("rapidjson")
     depends_on("cmake@3.13:", type="build")
     depends_on("py-wheel@0.36.0:", when="@:1.7.0", type="build")
+    depends_on("py-importlib-metadata@4.13.0:", when="@2.4.0:", type=("build", "run"))
+    depends_on("py-fsspec@2022.11.0:", when="@2.6.1:", type=("build", "run"))
 
     @when("@1.9.0:")
     def setup_build_environment(self, env):


### PR DESCRIPTION
Present in the [pyproject.toml](https://github.com/scikit-hep/awkward/blob/main/pyproject.toml). See https://github.com/key4hep/key4hep-spack/issues/664 for an example issue when importing without this change.