### PR TITLE
curl: mbedtls 3.6.0 bound should be forward not backward compat

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -118,6 +118,7 @@ class Curl(NMakePackage, AutotoolsPackage):
         depends_on("mbedtls@:2", when="@:7.78")
         depends_on("mbedtls@:3.5", when="@:8.7")
         depends_on("mbedtls@2:", when="@7.79:")
+        depends_on("mbedtls@3.2:", when="@8.8")  # https://github.com/curl/curl/issues/13748
 
     depends_on("nss", when="tls=nss")
 

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -114,9 +114,10 @@ class Curl(NMakePackage, AutotoolsPackage):
     depends_on("gnutls", when="tls=gnutls")
 
     with when("tls=mbedtls"):
-        depends_on("mbedtls@:2 +pic", when="@:7.78")
-        depends_on("mbedtls@2: +pic", when="@7.79:")
-        depends_on("mbedtls@3.6.0: +pic", when="@8.8.0:")
+        depends_on("mbedtls +pic")
+        depends_on("mbedtls@:2", when="@:7.78")
+        depends_on("mbedtls@:3.5", when="@:8.7")
+        depends_on("mbedtls@2:", when="@7.79:")
 
     depends_on("nss", when="tls=nss")
 


### PR DESCRIPTION
It was a backward compat bound before because curl bumped mbedtls in their CI,
so the older versions were untested, which was interpreted as "not supported".

But they bumped it because they just added compat for it, meaning that old
mbedtls works fine, and we should be adding a forward not backward compat
bound.

Tested curl@8.10.1 with mbedtls@2.28.2, and https works fine.