### PR TITLE
unrar: add v7.0.9 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/unrar/package.py
+++ b/var/spack/repos/builtin/packages/unrar/package.py
@@ -13,9 +13,12 @@ class Unrar(MakefilePackage):
     homepage = "https://www.rarlab.com"
     url = "https://www.rarlab.com/rar/unrarsrc-5.9.4.tar.gz"
 
-    version("5.9.4", sha256="3d010d14223e0c7a385ed740e8f046edcbe885e5c22c5ad5733d009596865300")
-    version("5.8.2", sha256="33386623fd3fb153b56292df4a6a69b457e69e1803b6d07b614e5fd22fb33dda")
-    version("5.8.1", sha256="035f1f436f0dc2aea09aec146b9cc3e47ca2442f2c62b4ad9374c7c9cc20e632")
+    version("7.0.9", sha256="505c13f9e4c54c01546f2e29b2fcc2d7fabc856a060b81e5cdfe6012a9198326")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2022-48579
+        version("5.9.4", sha256="3d010d14223e0c7a385ed740e8f046edcbe885e5c22c5ad5733d009596865300")
+        version("5.8.2", sha256="33386623fd3fb153b56292df4a6a69b457e69e1803b6d07b614e5fd22fb33dda")
+        version("5.8.1", sha256="035f1f436f0dc2aea09aec146b9cc3e47ca2442f2c62b4ad9374c7c9cc20e632")
 
     depends_on("cxx", type="build")  # generated
 


### PR DESCRIPTION
This PR adds `unrar`, v7.0.9, which fixes CVE-2022-48579. Since that CVE is scored high, the previous versions are marked as deprecated.

Test build:
```
==> Installing unrar-7.0.9-xtro6lmvjzkxlckzjlylw4tyvfuyumjr [4/4]
==> No binary for unrar-7.0.9-xtro6lmvjzkxlckzjlylw4tyvfuyumjr found: installing from source
==> Fetching https://www.rarlab.com/rar/unrarsrc-7.0.9.tar.gz
==> No patches needed for unrar
==> unrar: Executing phase: 'edit'
==> unrar: Executing phase: 'build'
==> unrar: Executing phase: 'install'
==> unrar: Successfully installed unrar-7.0.9-xtro6lmvjzkxlckzjlylw4tyvfuyumjr
  Stage: 2.26s.  Edit: 0.00s.  Build: 20.19s.  Install: 0.00s.  Post-install: 0.13s.  Total: 22.73s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/unrar-7.0.9-xtro6lmvjzkxlckzjlylw4tyvfuyumjr
```

Test run (not sure what's up with the version number):
```
$ unrar -version | head

UNRAR 7.01 freeware      Copyright (c) 1993-2024 Alexander Roshal

Usage:     unrar <command> -<switch 1> -<switch N> <archive> <files...>
               <@listfiles...> <path_to_extract/>

<Commands>
  e             Extract files without archived paths
  l[t[a],b]     List archive contents [technical[all], bare]
  p             Print file to stdout
```