### PR TITLE
solr: add v8.11.4, v9.7.0 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/solr/package.py
+++ b/var/spack/repos/builtin/packages/solr/package.py
@@ -19,12 +19,16 @@ class Solr(Package):
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("9.7.0", sha256="38548b86fa4e3c87883875952da124bf7d742cb8f7b25d37a1176833588e8552") 
+    version("9.7.0", sha256="38548b86fa4e3c87883875952da124bf7d742cb8f7b25d37a1176833588e8552")
     version("8.11.4", sha256="163fbdf246bbd78910bc36c3257ad50cdf31ccc3329a5ef885c23c9ef69e0ebe")
     with default_args(deprecated=True):
         # https://nvd.nist.gov/vuln/detail/CVE-2024-45216
-        version("8.11.3", sha256="178300ae095094c2060a1060cf475aa935f1202addfb5bacb38e8712ccb56455")
-        version("8.11.2", sha256="54d6ebd392942f0798a60d50a910e26794b2c344ee97c2d9b50e678a7066d3a6")
+        version(
+            "8.11.3", sha256="178300ae095094c2060a1060cf475aa935f1202addfb5bacb38e8712ccb56455"
+        )
+        version(
+            "8.11.2", sha256="54d6ebd392942f0798a60d50a910e26794b2c344ee97c2d9b50e678a7066d3a6"
+        )
         version("8.6.0", sha256="4519ccdb531619df770f1065db6adcedc052c7aa94b42806d541966550956aa5")
         version("8.5.2", sha256="c457d6c7243241cad141e1df34c6f669d58a6c60e537f4217d032616dd066dcf")
         version("8.5.1", sha256="47b68073b37bbcc0517a355ef722f20827c3f1416537ebbccf5239dda8064a0b")

--- a/var/spack/repos/builtin/packages/solr/package.py
+++ b/var/spack/repos/builtin/packages/solr/package.py
@@ -12,23 +12,33 @@ class Solr(Package):
     recovery,centralized configuration and more. Solr powers the search and
     navigation features of many of the world's largest internet sites."""
 
-    homepage = "https://lucene.apache.org/"
-    url = "https://archive.apache.org/dist/lucene/solr/7.7.3/solr-7.7.3.tgz"
-    list_url = "https://archive.apache.org/dist/lucene/solr"
+    homepage = "https://solr.apache.org/"
+    url = "https://archive.apache.org/dist/solr/solr/7.7.3/solr-7.7.3.tgz"
+    list_url = "https://archive.apache.org/dist/solr/solr"
     list_depth = 1
+
+    license("Apache-2.0", checked_by="wdconinc")
+
+    version("9.7.0", sha256="38548b86fa4e3c87883875952da124bf7d742cb8f7b25d37a1176833588e8552") 
+    version("8.11.4", sha256="163fbdf246bbd78910bc36c3257ad50cdf31ccc3329a5ef885c23c9ef69e0ebe")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2024-45216
+        version("8.11.3", sha256="178300ae095094c2060a1060cf475aa935f1202addfb5bacb38e8712ccb56455")
+        version("8.11.2", sha256="54d6ebd392942f0798a60d50a910e26794b2c344ee97c2d9b50e678a7066d3a6")
+        version("8.6.0", sha256="4519ccdb531619df770f1065db6adcedc052c7aa94b42806d541966550956aa5")
+        version("8.5.2", sha256="c457d6c7243241cad141e1df34c6f669d58a6c60e537f4217d032616dd066dcf")
+        version("8.5.1", sha256="47b68073b37bbcc0517a355ef722f20827c3f1416537ebbccf5239dda8064a0b")
+        version("8.5.0", sha256="9e54711ad0aa60e9723d2cdeb20cf0d21ee2ab9fa0048ec59dcb5f9d94dc61dd")
+        version("8.4.1", sha256="ec39e1e024b2e37405149de41e39e875a39bf11a53f506d07d96b47b8d2a4301")
+        version("7.7.3", sha256="3ec67fa430afa5b5eb43bb1cd4a659e56ee9f8541e0116d6080c0d783870baee")
 
     depends_on("java", type="run")
 
-    license("CC-BY-2.5")
-
-    version("8.11.3", sha256="178300ae095094c2060a1060cf475aa935f1202addfb5bacb38e8712ccb56455")
-    version("8.11.2", sha256="54d6ebd392942f0798a60d50a910e26794b2c344ee97c2d9b50e678a7066d3a6")
-    version("8.6.0", sha256="4519ccdb531619df770f1065db6adcedc052c7aa94b42806d541966550956aa5")
-    version("8.5.2", sha256="c457d6c7243241cad141e1df34c6f669d58a6c60e537f4217d032616dd066dcf")
-    version("8.5.1", sha256="47b68073b37bbcc0517a355ef722f20827c3f1416537ebbccf5239dda8064a0b")
-    version("8.5.0", sha256="9e54711ad0aa60e9723d2cdeb20cf0d21ee2ab9fa0048ec59dcb5f9d94dc61dd")
-    version("8.4.1", sha256="ec39e1e024b2e37405149de41e39e875a39bf11a53f506d07d96b47b8d2a4301")
-    version("7.7.3", sha256="3ec67fa430afa5b5eb43bb1cd4a659e56ee9f8541e0116d6080c0d783870baee")
+    def url_for_version(self, version):
+        if self.spec.satisfies("@9:"):
+            return f"https://archive.apache.org/dist/solr/solr/{version}/solr-{version}.tgz"
+        else:
+            return f"https://archive.apache.org/dist/lucene/solr/{version}/solr-{version}.tgz"
 
     def install(self, spec, prefix):
         install_tree(".", prefix)


### PR DESCRIPTION
This PR adds `solr`, v8.11.4, v9.7.0, both of which fix CVE-2024-45216. Since that vulnerability is rated as critical [by Solr itself](https://solr.apache.org/news.html#cve-2024-45216-apache-solr-authentication-bypass-possible-using-a-fake-url-path-ending) (but awaiting analysis on NVD), older versions are marked as deprecated.

Test build and run:
```
==> Installing solr-9.7.0-mii5v2p6dik23m4s45zrnntfib2rhrrw [4/4]
==> No binary for solr-9.7.0-mii5v2p6dik23m4s45zrnntfib2rhrrw found: installing from source
==> Fetching https://archive.apache.org/dist/solr/solr/9.7.0/solr-9.7.0.tgz
==> No patches needed for solr
==> solr: Executing phase: 'install'
==> solr: Successfully installed solr-9.7.0-mii5v2p6dik23m4s45zrnntfib2rhrrw
  Stage: 1m 3.80s.  Install: 0.36s.  Post-install: 0.75s.  Total: 1m 4.96s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/solr-9.7.0-mii5v2p6dik23m4s45zrnntfib2rhrrw
==> Updating view at /tmp/spack-3s2sg9z1/.spack-env/view
20:30:42 wdconinc@menelaos ~ $ solr start -p 8984
*** [WARN] *** Your open file limit is currently 1024.  
 It should be set to 65000 to avoid operational disruption. 
 If you no longer wish to see this warning, set SOLR_ULIMIT_CHECKS to false in your profile or solr.in.sh
*** [WARN] ***  Your Max Processes Limit is currently 62416. 
 It should be set to 65000 to avoid operational disruption. 
 If you no longer wish to see this warning, set SOLR_ULIMIT_CHECKS to false in your profile or solr.in.sh
Java 17 detected. Enabled workaround for SOLR-16463
Waiting up to 180 seconds to see Solr running on port 8984 [|]  
Started Solr server on port 8984 (pid=1932344). Happy searching!

20:30:52 wdconinc@menelaos ~ $ ps
    PID TTY          TIME CMD
1926465 pts/1    00:00:00 bash
1932344 pts/1    00:00:13 java
1932438 pts/1    00:00:00 ps
```

Same thing for v8.11.4:
```
==> Installing solr-8.11.4-vibw3ak6q5g3zdhoqtuvb7ddn4tkr3k2 [4/4]
==> No binary for solr-8.11.4-vibw3ak6q5g3zdhoqtuvb7ddn4tkr3k2 found: installing from source
==> Fetching https://archive.apache.org/dist/lucene/solr/8.11.4/solr-8.11.4.tgz
==> No patches needed for solr
==> solr: Executing phase: 'install'
==> solr: Successfully installed solr-8.11.4-vibw3ak6q5g3zdhoqtuvb7ddn4tkr3k2
  Stage: 29.20s.  Install: 0.33s.  Post-install: 0.69s.  Total: 30.24s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/solr-8.11.4-vibw3ak6q5g3zdhoqtuvb7ddn4tkr3k2
==> Updating view at /tmp/spack-3s2sg9z1/.spack-env/view
20:32:40 wdconinc@menelaos ~ $ solr start -p 8984
*** [WARN] *** Your open file limit is currently 1024.  
 It should be set to 65000 to avoid operational disruption. 
 If you no longer wish to see this warning, set SOLR_ULIMIT_CHECKS to false in your profile or solr.in.sh
*** [WARN] ***  Your Max Processes Limit is currently 62416. 
 It should be set to 65000 to avoid operational disruption. 
 If you no longer wish to see this warning, set SOLR_ULIMIT_CHECKS to false in your profile or solr.in.sh
Warning: Available entropy is low. As a result, use of the UUIDField, SSL, or any other features that require
RNG might not work properly. To check for the amount of available entropy, use 'cat /proc/sys/kernel/random/entropy_avail'.

Waiting up to 180 seconds to see Solr running on port 8984 [|]  
Started Solr server on port 8984 (pid=1932827). Happy searching!

```