### PR TITLE
voropp: swich to cmake

### DIFF
--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -661,7 +661,7 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
     depends_on("hipfft", when="+kokkos+kspace+rocm fft_kokkos=hipfft")
     depends_on("fftw-api@3", when="+kokkos+kspace fft_kokkos=fftw3")
     depends_on("mkl", when="+kokkos+kspace fft_kokkos=mkl")
-    depends_on("voropp+pic", when="+voronoi")
+    depends_on("voropp", when="+voronoi")
     depends_on("netcdf-c+mpi", when="+user-netcdf")
     depends_on("netcdf-c+mpi", when="+netcdf")
     depends_on("blas", when="+user-atc")

--- a/var/spack/repos/builtin/packages/voropp/package.py
+++ b/var/spack/repos/builtin/packages/voropp/package.py
@@ -24,7 +24,7 @@ class Voropp(CMakePackage):
 
     depends_on("cxx", type="build")  # generated
 
-    patch("voro++-0.4.6_cmake.patch", when="@0.4.6")
+    patch("voro++-0.4.6-cmake.patch", when="@0.4.6")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/voropp/package.py
+++ b/var/spack/repos/builtin/packages/voropp/package.py
@@ -6,28 +6,29 @@
 from spack.package import *
 
 
-class Voropp(MakefilePackage):
+class Voropp(CMakePackage):
     """Voro++ is a open source software library for the computation of the
     Voronoi diagram, a widely-used tessellation that has applications in many
     scientific fields."""
 
     homepage = "https://math.lbl.gov/voro++/about.html"
     url = "https://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz"
+    git = "https://github.com/chr1shr/voro"
 
-    variant("pic", default=True, description="Position independent code")
+    variant("shared", default=True, description="Build shared libraries")
 
     license("BSD-3-Clause-LBNL")
 
+    version("master", branch="master")
     version("0.4.6", sha256="ef7970071ee2ce3800daa8723649ca069dc4c71cc25f0f7d22552387f3ea437e")
 
     depends_on("cxx", type="build")  # generated
 
-    def edit(self, spec, prefix):
-        filter_file(r"CC=g\+\+", "CC={0}".format(self.compiler.cxx), "config.mk")
-        filter_file(r"PREFIX=/usr/local", "PREFIX={0}".format(self.prefix), "config.mk")
-        # We can safely replace the default CFLAGS which are:
-        # CFLAGS=-Wall -ansi -pedantic -O3
-        cflags = ""
-        if "+pic" in spec:
-            cflags += self.compiler.cc_pic_flag
-        filter_file(r"CFLAGS=.*", "CFLAGS={0}".format(cflags), "config.mk")
+    patch("voro++-0.4.6_cmake.patch", when="@0.4.6")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+        ]
+
+        return args

--- a/var/spack/repos/builtin/packages/voropp/package.py
+++ b/var/spack/repos/builtin/packages/voropp/package.py
@@ -27,8 +27,6 @@ class Voropp(CMakePackage):
     patch("voro++-0.4.6-cmake.patch", when="@0.4.6")
 
     def cmake_args(self):
-        args = [
-            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
-        ]
+        args = [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]
 
         return args

--- a/var/spack/repos/builtin/packages/voropp/voro++-0.4.6-cmake.patch
+++ b/var/spack/repos/builtin/packages/voropp/voro++-0.4.6-cmake.patch
@@ -1,0 +1,29 @@
+diff -Naur voro++-0.4.6.orig/CMakeLists.txt voro++-0.4.6/CMakeLists.txt
+--- voro++-0.4.6.orig/CMakeLists.txt	1969-12-31 17:00:00.000000000 -0700
++++ voro++-0.4.6/CMakeLists.txt	2024-10-16 20:51:05.636348019 -0600
+@@ -0,0 +1,25 @@
++# Set  the minimum  required version  of cmake  for a  project.
++cmake_minimum_required(VERSION 2.6)
++
++add_library(voro++ SHARED
++	cell.cc
++	common.cc
++	container.cc
++	unitcell.cc
++	v_compute.cc
++	c_loops.cc
++	v_base.cc wall.cc
++	pre_container.cc
++	container_prd.cc
++)
++set_target_properties(voro++ PROPERTIES VERSION 0.0.0 SOVERSION 0)
++
++add_executable(voro++-bin cmd_line.cc)
++set_target_properties(voro++-bin PROPERTIES OUTPUT_NAME voro++)
++target_link_libraries(voro++-bin voro++)
++
++file(GLOB_RECURSE HDR RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.hh)
++
++install(TARGETS voro++ LIBRARY DESTINATION lib${LIB_SUFFIX})
++install(FILES ${HDR} DESTINATION include)
++install(TARGETS voro++-bin DESTINATION bin)

--- a/var/spack/repos/builtin/packages/voropp/voro++-0.4.6-cmake.patch
+++ b/var/spack/repos/builtin/packages/voropp/voro++-0.4.6-cmake.patch
@@ -1,10 +1,14 @@
 diff -Naur voro++-0.4.6.orig/CMakeLists.txt voro++-0.4.6/CMakeLists.txt
 --- voro++-0.4.6.orig/CMakeLists.txt	1969-12-31 17:00:00.000000000 -0700
-+++ voro++-0.4.6/CMakeLists.txt	2024-10-16 20:51:05.636348019 -0600
-@@ -0,0 +1,25 @@
++++ voro++-0.4.6/CMakeLists.txt	2024-10-16 21:14:06.755336366 -0600
+@@ -0,0 +1,3 @@
 +# Set  the minimum  required version  of cmake  for a  project.
 +cmake_minimum_required(VERSION 2.6)
-+
++add_subdirectory(src)
+diff -Naur voro++-0.4.6.orig/src/CMakeLists.txt voro++-0.4.6/src/CMakeLists.txt
+--- voro++-0.4.6.orig/src/CMakeLists.txt	1969-12-31 17:00:00.000000000 -0700
++++ voro++-0.4.6/src/CMakeLists.txt	2024-10-16 21:14:07.639351723 -0600
+@@ -0,0 +1,22 @@
 +add_library(voro++ SHARED
 +	cell.cc
 +	common.cc


### PR DESCRIPTION
The patch for v0.4.6 is adapted from Fedora (https://src.fedoraproject.org/rpms/voro++/blob/rawhide/f/CMakeLists.txt) and got later merged into upstream's `master`.

CMake is always `+pic` or I dropped that variant and added a `shared` one instead.
