### PR TITLE
wrf: Enable oneapi on more platforms

### DIFF
--- a/var/spack/repos/builtin/packages/wrf/patches/4.4/ifx.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/4.4/ifx.patch
@@ -26,7 +26,7 @@ index 6aa210d7..a3224d34 100644
 +PROMOTION       =       -real-size `expr 8 \* $(RWORDSIZE)` -i4
 +ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_FUNC -DRPC_TYPES=2 -DXEON_SIMD
 +CFLAGS_LOCAL    =       -w -flto -O3 -Wno-implicit-function-declaration -Wno-implicit-int
-+LDFLAGS_LOCAL   =       -flto -fuse-ld=lld
++LDFLAGS_LOCAL   =       -flto -fuse-ld=lld -i_use-path
 +CPLUSPLUSLIB    =       
 +ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
 +FCOPTIM         =       -O3
@@ -38,7 +38,7 @@ index 6aa210d7..a3224d34 100644
 +FCSUFFIX        =
 +BYTESWAPIO      =       -convert big_endian
 +RECORDLENGTH    =       -assume byterecl
-+FCBASEOPTS_NO_G =       -O3 -flto -w -ftz -align array64byte -fno-alias $(FORMAT_FREE) $(BYTESWAPIO) -fp-model fast=2 -fimf-use-svml=true -vec-threshold0 -xCORE-AVX512
++FCBASEOPTS_NO_G =       -O3 -flto -w -ftz -align array64byte -fno-alias $(FORMAT_FREE) $(BYTESWAPIO) -fp-model fast=2 -fimf-use-svml=true -vec-threshold0
 +FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 +MODULE_SRCH_FLAG =     
 +TRADFLAG        =      -traditional-cpp


### PR DESCRIPTION
* Remove the implicit CORE-AVX512 since the CPU specific flags are added by the
compiler wrappers.
* Add `-i_use-path` to help `ifx` find `lld` even if `-gcc-name` is set in
`ifx.cfg`. This file is written by `intel-oneapi-compilers` package to find the
correct `gcc`. Not being able to find `ldd` is a bug in `ifx`. @rscohn2 found
this workaround.

-------

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->