### PR TITLE
otf-cpt: add new package for OTF-CPT

### DIFF
--- a/var/spack/repos/builtin/packages/otf-cpt/package.py
+++ b/var/spack/repos/builtin/packages/otf-cpt/package.py
@@ -20,7 +20,7 @@ class OtfCpt(CMakePackage):
 
     version("0.9", tag="v0.9")
 
-    depends_on("cxx")
+    depends_on("cxx", type="build")
     depends_on("mpi")
     conflicts(
         "%gcc",

--- a/var/spack/repos/builtin/packages/otf-cpt/package.py
+++ b/var/spack/repos/builtin/packages/otf-cpt/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class OtfCpt(CMakePackage):
+    """Tool to collect and report model factors (aka. fundamental performance factors)
+    for hybrid MPI + OpenMP applications on-the-fly."""
+
+    # Add a proper url for your package's homepage here.
+    homepage = (
+        "https://github.com/RWTH-HPC/OTF-CPT?tab=readme-ov-file#on-the-fly-critical-path-tool"
+    )
+    git = "https://github.com/RWTH-HPC/OTF-CPT.git"
+
+    maintainers("jgraciahlrs", "jprotze")
+
+    license("Apache-2.0", checked_by="jgracia")
+
+    version("0.9", tag="v0.9")
+
+    depends_on("cxx")
+    depends_on("mpi")
+    conflicts(
+        "%gcc",
+        msg="GCC compilers currently do not support OMPT, please use a clang-like compiler.",
+    )
+
+    patch(
+        "https://github.com/RWTH-HPC/OTF-CPT/commit/b58f83588a4c231b71ca48dcddd909e1ab318cc6.diff",
+        sha256="1c8e1c4b5bf4cd1c6e4ed9a9d8c5ef47abe2aad5402ec466db0df4f96cbd3407",
+        when="@0.9",
+    )

--- a/var/spack/repos/builtin/packages/otf-cpt/package.py
+++ b/var/spack/repos/builtin/packages/otf-cpt/package.py
@@ -26,7 +26,8 @@ class OtfCpt(CMakePackage):
     depends_on("mpi")
     conflicts(
         "%gcc",
-        msg="GCC compilers currently do not support OMPT, please use a clang-like compiler.",
+        # Use a clang compiler with a matching libomp, e.g. 'sudo apt install libomp-14-dev':
+        msg="gcc currently does not support OMPT, please use a clang-like compiler with libomp",
     )
 
     patch(

--- a/var/spack/repos/builtin/packages/otf-cpt/package.py
+++ b/var/spack/repos/builtin/packages/otf-cpt/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 
 class OtfCpt(CMakePackage):
     """Tool to collect and report model factors (aka. fundamental performance factors)
@@ -16,7 +18,7 @@ class OtfCpt(CMakePackage):
 
     maintainers("jgraciahlrs", "jprotze")
 
-    license("Apache-2.0", checked_by="jgracia")
+    license("Apache-2.0", checked_by="jgraciahlrs")
 
     version("0.9", tag="v0.9")
 
@@ -28,7 +30,7 @@ class OtfCpt(CMakePackage):
     )
 
     patch(
-        "https://github.com/RWTH-HPC/OTF-CPT/commit/b58f83588a4c231b71ca48dcddd909e1ab318cc6.diff",
+        "https://github.com/RWTH-HPC/OTF-CPT/commit/b58f83588a4c231b71ca48dcddd909e1ab318cc6.diff?full_index=1",
         sha256="1c8e1c4b5bf4cd1c6e4ed9a9d8c5ef47abe2aad5402ec466db0df4f96cbd3407",
         when="@0.9",
     )

--- a/var/spack/repos/builtin/packages/otf-cpt/package.py
+++ b/var/spack/repos/builtin/packages/otf-cpt/package.py
@@ -31,6 +31,6 @@ class OtfCpt(CMakePackage):
 
     patch(
         "https://github.com/RWTH-HPC/OTF-CPT/commit/b58f83588a4c231b71ca48dcddd909e1ab318cc6.diff?full_index=1",
-        sha256="1c8e1c4b5bf4cd1c6e4ed9a9d8c5ef47abe2aad5402ec466db0df4f96cbd3407",
+        sha256="35fadc3e61e5b7aa3a68272f701af3a242e30a435f1ddd679577ba35c7496565",
         when="@0.9",
     )


### PR DESCRIPTION
Adds package "OTF-CPT" to builtin repo. 

OTF-CPT is a tool for performance analysis in HPC, in particular for mixed MPI + OpenMP applications.

Homepage [here](https://github.com/RWTH-HPC/OTF-CPT?tab=readme-ov-file#on-the-fly-critical-path-tool).
