### PR TITLE
Add unsetting of common Makefile variables

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -216,6 +216,10 @@ def clean_environment():
     env.unset("R_HOME")
     env.unset("R_ENVIRON")
 
+    # Common Makefile variables
+    env.unset("BUILD_DIR")
+    env.unset("INSTALL_DIR")
+
     env.unset("LUA_PATH")
     env.unset("LUA_CPATH")
 


### PR DESCRIPTION


Modify files to unset common Makefile variables: BUILD_DIR and INSTALL_DIR.

The command `./bin/spack install lz4@1.9.4` results in an error due to the INSTALL_DIR variable when it is already in use.
