### PR TITLE
e4s ci stacks: add nwchem

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse-v2/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse-v2/spack.yaml
@@ -113,6 +113,7 @@ spack:
   - netlib-scalapack
   - nrm
   # - nvhpc
+  - nwchem 
   - omega-h
   - openfoam
   # - openmpi

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse_v1/spack.yaml
@@ -114,6 +114,7 @@ spack:
   - netlib-scalapack
   - nrm
   - nvhpc
+  - nwchem
   - omega-h
   - openfoam
   - openmpi

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -128,6 +128,7 @@ spack:
   - nco
   - netlib-scalapack
   - nrm
+  - nwchem
   - omega-h
   - openfoam
   - openmpi

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
@@ -117,6 +117,7 @@ spack:
   - netlib-scalapack
   - nrm
   - nvhpc
+  - nwchem
   - omega-h
   - openfoam
   - openmpi

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -128,6 +128,7 @@ spack:
   - netlib-scalapack
   - nrm
   - nvhpc
+  - nwchem
   - omega-h
   - openfoam
   - openmpi


### PR DESCRIPTION
E4S CI stacks: add `nwchem` package

@jeffhammond are there any non-default variants you would advise us to turn on here?