### PR TITLE
builtin repo: remove some uses of spec.compiler

### DIFF
--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -87,9 +87,9 @@ class ClingoBootstrap(Clingo):
 
     @run_before("cmake", when="+optimized")
     def pgo_train(self):
-        if self.spec.compiler.name == "clang":
+        if self.spec.satisfies("%clang"):
             llvm_profdata = which("llvm-profdata", required=True)
-        elif self.spec.compiler.name == "apple-clang":
+        elif self.spec.satisfies("%apple-clang"):
             llvm_profdata = Executable(
                 Executable("xcrun")("-find", "llvm-profdata", output=str).strip()
             )
@@ -125,7 +125,7 @@ class ClingoBootstrap(Clingo):
         # Clean the build dir.
         rmtree(self.build_directory, ignore_errors=True)
 
-        if self.spec.compiler.name in ("clang", "apple-clang"):
+        if self.spec.satisfies("%clang") or self.spec.satisfies("apple-clang"):
             # merge reports
             use_report = join_path(reports, "merged.prof")
             raw_files = glob.glob(join_path(reports, "*.profraw"))
@@ -142,5 +142,7 @@ class ClingoBootstrap(Clingo):
         cmake.add_default_envmod(use_mods)
 
     def setup_build_environment(self, env):
-        if self.spec.compiler.name in ("gcc", "clang") and "+static_libstdcpp" in self.spec:
+        if (
+            self.spec.satisfies("%gcc") or self.spec.satisfies("%clang")
+        ) and "+static_libstdcpp" in self.spec:
             env.append_flags("LDFLAGS", "-static-libstdc++ -static-libgcc -Wl,--exclude-libs,ALL")

--- a/var/spack/repos/builtin/packages/cloverleaf-ref/package.py
+++ b/var/spack/repos/builtin/packages/cloverleaf-ref/package.py
@@ -103,9 +103,6 @@ class CloverleafRef(MakefilePackage):
         elif self.spec.satisfies("%xl"):
             targets.append("COMPILER=XLF")
 
-        else:
-            raise ValueError("Compiler {} not supported".format(self.spec.compiler.name))
-
         return targets
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/cmdstan/package.py
+++ b/var/spack/repos/builtin/packages/cmdstan/package.py
@@ -32,7 +32,7 @@ class Cmdstan(MakefilePackage):
     filter_compiler_wrappers("local", relative_root="make")
 
     def edit(self, spec, prefix):
-        if spec.compiler.name == "intel":
+        if spec.satisfies("%intel"):
             cxx_type = "icc"
         else:
             cxx_type = spec.compiler.name

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -180,7 +180,8 @@ class Curl(NMakePackage, AutotoolsPackage):
 
     def flag_handler(self, name, flags):
         build_system_flags = []
-        if name == "cflags" and self.spec.compiler.name in ["intel", "oneapi"]:
+        spec = self.spec
+        if name == "cflags" and (spec.satisfies("%intel") or spec.satisfies("%oneapi")):
             build_system_flags = ["-we147"]
         return flags, None, build_system_flags
 

--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -6,7 +6,6 @@
 import os
 
 from spack.package import *
-from spack.spec import UnsupportedCompilerError
 
 
 class Elemental(CMakePackage):
@@ -94,6 +93,8 @@ class Elemental(CMakePackage):
     patch("elemental_cublas.patch", when="+cublas")
     patch("cmake_0.87.7.patch", when="@0.87.7")
 
+    conflicts("%intel@:17.0.2", when="@:0.87.7")
+
     @property
     def libs(self):
         shared = True if "+shared" in self.spec else False
@@ -101,14 +102,6 @@ class Elemental(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
-
-        if spec.satisfies("@:0.87.7") and spec.satisfies("%intel@:17.0.2"):
-            raise UnsupportedCompilerError(
-                "Elemental {0} has a known bug with compiler: {1} {2}".format(
-                    spec.version, spec.compiler.name, spec.compiler.version
-                )
-            )
-
         args = [
             "-DCMAKE_INSTALL_MESSAGE:STRING=LAZY",
             "-DCMAKE_C_COMPILER=%s" % spec["mpi"].mpicc,

--- a/var/spack/repos/builtin/packages/fds/package.py
+++ b/var/spack/repos/builtin/packages/fds/package.py
@@ -77,7 +77,7 @@ class Fds(MakefilePackage):
 
     def edit(self, spec, prefix):
         env["MKL_ROOT"] = self.spec["mkl"].prefix
-        if spec.compiler.name == "oneapi":
+        if spec.satisfies("%oneapi"):
             env["INTEL_IFORT"] = "ifx"
         makefile = FileFilter("Build/makefile")
         makefile.filter(r"\.\./Scripts", "./Scripts")

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -331,7 +331,12 @@ class Hdf5(CMakePackage):
         cmake_flags = []
 
         if name == "cflags":
-            if spec.compiler.name in ["gcc", "clang", "apple-clang", "oneapi"]:
+            if (
+                spec.satisfies("%gcc")
+                or spec.satisfies("%clang")
+                or spec.satisfies("%apple-clang")
+                or spec.satisfies("%oneapi")
+            ):
                 # Quiet warnings/errors about implicit declaration of functions
                 # in C99:
                 cmake_flags.append("-Wno-error=implicit-function-declaration")

--- a/var/spack/repos/builtin/packages/lz4/package.py
+++ b/var/spack/repos/builtin/packages/lz4/package.py
@@ -94,7 +94,7 @@ class MakefileBuilder(MakefileBuilder):
 
     def build(self, pkg, spec, prefix):
         par = True
-        if spec.compiler.name == "nvhpc":
+        if spec.satisfies("%nvhpc"):
             # relocation error when building shared and dynamic libs in
             # parallel
             par = False

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -168,7 +168,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
 
         if "@2.5.0" in spec:
             options.append(define("MAGMA_SPARSE", False))
-            if spec.compiler.name in ["xl", "xl_r"]:
+            if spec.satisfies("%xl") or spec.satisfies("%xl_r"):
                 options.append(define("CMAKE_DISABLE_FIND_PACKAGE_OpenMP", True))
 
         if "+rocm" in spec:

--- a/var/spack/repos/builtin/packages/mgcfd-op2/package.py
+++ b/var/spack/repos/builtin/packages/mgcfd-op2/package.py
@@ -43,21 +43,21 @@ class MgcfdOp2(MakefilePackage):
             env.set("COMPILER", self.spec.compiler.name)
 
         # Set Fortran compiler to GCC if using Arm.
-        if self.spec.compiler.name == "arm":
+        if self.spec.satisfies("%arm"):
             env.set("OP2_F_COMPILER", "gnu")
 
         # This overrides a flag issue in downstream OP2.
-        if self.spec.compiler.name == "nvhpc":
+        if self.spec.satisfies("%nvhpc"):
             env.set("CFLAGS", "-O3 -DOMPI_SKIP_MPICXX -DMPICH_IGNORE_CXX_SEEK -DMPIPP_H")
 
     def edit(self, spec, prefix):
         # Makefile tweaks to ensure the correct compiler commands are called.
         makefile = FileFilter("Makefile")
-        if self.spec.compiler.name == "arm":
+        if self.spec.satisfies("%arm"):
             makefile.filter(r"CPP := clang", r"CPP := armclang")
             makefile.filter(r"-cxx=clang.*", "")
 
-        if self.spec.compiler.name == "nvhpc":
+        if self.spec.satisfies("%nvhpc"):
             makefile.filter("pgc", "nvc")
 
     @property

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -156,7 +156,7 @@ class NetcdfFortran(AutotoolsPackage):
         # To avoid warning messages when compiler user applications in both
         # cases, we create copies of all '*.mod' files in the prefix/include
         # with names in upper- and lowercase.
-        if self.spec.compiler.name != "cce":
+        if not self.spec.satisfies("%cce"):
             return
 
         with working_dir(self.spec.prefix.include):

--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -61,6 +61,6 @@ class PyGevent(PythonPackage):
         if name == "cflags":
             if self.spec.satisfies("%oneapi@2023:"):
                 flags.append("-Wno-error=incompatible-function-pointer-types")
-            if self.spec.compiler.name in ["intel", "oneapi"]:
+            if self.spec.satisfies("%oneapi") or self.spec.satisfies("%intel"):
                 flags.append("-we147")
         return (flags, None, None)

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -459,7 +459,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
             name == "ldflags"
             and spec.target.family == "aarch64"
             and "ubuntu" in spec.os
-            and spec.compiler.name == "gcc"
+            and spec.satisfies("%gcc")
             and "cortex_a53" not in spec.target.name
         ):
             flags.append("-mno-fix-cortex-a53-843419")

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -147,7 +147,7 @@ class Silo(AutotoolsPackage):
                     min_apiver = int(min_ver / 2) * 2
                     flags.append("-DH5_USE_{0}{1}_API".format(maj_ver, min_apiver))
 
-            if spec.compiler.name in ["clang", "apple-clang"]:
+            if spec.satisfies("%clang") or spec.satisfies("%apple-clang"):
                 flags.append("-Wno-implicit-function-declaration")
         return (flags, None, None)
 

--- a/var/spack/repos/builtin/packages/sw4/package.py
+++ b/var/spack/repos/builtin/packages/sw4/package.py
@@ -63,7 +63,7 @@ class Sw4(MakefilePackage):
                 os.environ["EXTRA_LINK_FLAGS"] += spec["llvm-openmp"].libs.ld_flags + " "
 
         # From spack/trilinos
-        if spec.compiler.name in ["clang", "apple-clang", "gcc"]:
+        if spec.satisfies("%gcc") or spec.satisfies("%clang") or spec.satisfies("%apple-clang"):
             fc = Executable(self.compiler.fc)
             libgfortran = fc("--print-file-name", "libgfortran." + dso_suffix, output=str).strip()
             if libgfortran == "libgfortran." + dso_suffix:

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -553,7 +553,11 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
                 flags.append("-Wl,-undefined,dynamic_lookup")
 
             # Fortran lib (assumes clang is built with gfortran!)
-            if "+fortran" in spec and spec.compiler.name in ["gcc", "clang", "apple-clang"]:
+            if spec.satisfies("+fortran") and (
+                spec.satisfies("%gcc")
+                or spec.satisfies("%clang")
+                or spec.satisfies("%apple-clang")
+            ):
                 fc = Executable(self.compiler.fc)
                 libgfortran = fc(
                     "--print-file-name", "libgfortran." + dso_suffix, output=str

--- a/var/spack/repos/builtin/packages/wgrib2/package.py
+++ b/var/spack/repos/builtin/packages/wgrib2/package.py
@@ -116,13 +116,14 @@ class Wgrib2(MakefilePackage):
 
     # Use Spack compiler wrapper flags
     def inject_flags(self, name, flags):
+        spec = self.spec
         if name == "cflags":
-            if self.spec.compiler.name == "apple-clang":
+            if spec.satisfies("%apple-clang"):
                 flags.append("-Wno-error=implicit-function-declaration")
 
             # When mixing Clang/gfortran need to link to -lgfortran
             # Find this by searching for gfortran/../lib
-            if self.spec.compiler.name in ["apple-clang", "clang"]:
+            if spec.satisfies("%apple-clang") or spec.satisfies("%clang"):
                 if "gfortran" in self.compiler.fc:
                     output = Executable(self.compiler.fc)("-###", output=str, error=str)
                     libdir = re.search("--libdir=(.+?) ", output).group(1)
@@ -153,9 +154,10 @@ class Wgrib2(MakefilePackage):
             makefile.filter(r"^%s=.*" % makefile_option, "{}={}".format(makefile_option, value))
 
     def setup_build_environment(self, env):
-        if self.spec.compiler.name in ["oneapi", "intel"]:
+        spec = self.spec
+        if spec.satisfies("%oneapi") or spec.satisfies("%intel"):
             comp_sys = "intel_linux"
-        elif self.spec.compiler.name in ["gcc", "clang", "apple-clang"]:
+        elif spec.satisfies("%gcc") or spec.satisfies("%clang") or spec.satisfies("%apple-clang"):
             comp_sys = "gnu_linux"
 
         env.set("COMP_SYS", comp_sys)

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -260,6 +260,16 @@ class Wrf(Package):
     depends_on("libtool", type="build")
     depends_on("adios2", when="@4.5: +adios2")
 
+    requires(
+        "%gcc",
+        "%intel",
+        "%arm",
+        "%aocc",
+        "%fj",
+        "%oneapi",
+        policy="one_of",
+        msg="WRF supports only the GCC, Intel, AMD of Fujitsu compilers",
+    )
     conflicts(
         "%oneapi", when="@:4.3", msg="Intel oneapi compiler patch only added for version 4.4"
     )
@@ -417,11 +427,6 @@ class Wrf(Package):
     def configure(self, spec, prefix):
         # Remove broken default options...
         self.do_configure_fixup()
-
-        if self.spec.compiler.name not in ["intel", "gcc", "arm", "aocc", "fj", "oneapi"]:
-            raise InstallError(
-                "Compiler %s not currently supported for WRF build." % self.spec.compiler.name
-            )
 
         p = Popen("./configure", stdin=PIPE, stdout=PIPE, stderr=PIPE)
         if sys.platform != "win32":

--- a/var/spack/repos/builtin/packages/xyce/package.py
+++ b/var/spack/repos/builtin/packages/xyce/package.py
@@ -227,7 +227,11 @@ class Xyce(CMakePackage):
             flags.append("-DXyce_INTRUSIVE_PCE -Wreorder")
         elif name == "ldflags":
             # Fortran lib (assumes clang is built with gfortran!)
-            if spec.compiler.name in ["gcc", "clang", "apple-clang"]:
+            if (
+                spec.satisfies("%gcc")
+                or spec.satisfies("%clang")
+                or spec.satisfies("%apple-clang")
+            ):
                 fc = Executable(self.compiler.fc)
                 libgfortran = fc(
                     "--print-file-name", "libgfortran." + dso_suffix, output=str

--- a/var/spack/repos/builtin/packages/zlib-ng/package.py
+++ b/var/spack/repos/builtin/packages/zlib-ng/package.py
@@ -79,7 +79,7 @@ class AutotoolsBuilder(autotools.AutotoolsBuilder):
     def pretend_gcc(self):
         # All nice things (PIC flags, symbol versioning) that happen to the compilers that are
         # recognized as gcc (%gcc, %clang, %intel, %oneapi) we want for some other compilers too:
-        if self.spec.compiler.name in ["nvhpc"]:
+        if self.spec.satisfies("%nvhpc"):
             filter_file(r"^gcc=0$", "gcc=1", join_path(self.configure_directory, "configure"))
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -115,7 +115,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder, SetupEnviron
             # script but patch the makefile for all the aforementioned compilers, given the
             # importance of the package, we try to be conservative for now and do the patching only
             # for compilers that will not produce a correct shared library otherwise.
-            if self.spec.compiler.name in ["nvhpc"]:
+            if self.spec.satisfies("%nvhpc"):
                 if "~pic" in self.spec:
                     # In this case, we should build the static library without PIC, therefore we
                     # don't append the respective compiler flag to CFLAGS in the build environment.


### PR DESCRIPTION
This PR removes the uses of `spec.compiler` that can be easily substituted by a more idiomatic approach, e.g. using `spec.satisfies` or directives.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
