### PR TITLE
clingo-bootstrap: no need for setting MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -75,10 +75,7 @@ class ClingoBootstrap(Clingo):
         return self.define("CLINGO_BUILD_PY_SHARED", "OFF")
 
     def cmake_args(self):
-        return [
-            *super().cmake_args(),
-            self.define("CLINGO_BUILD_APPS", False)
-        ]
+        return [*super().cmake_args(), self.define("CLINGO_BUILD_APPS", False)]
 
     @run_before("cmake", when="+optimized")
     def pgo_train(self):

--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -75,15 +75,10 @@ class ClingoBootstrap(Clingo):
         return self.define("CLINGO_BUILD_PY_SHARED", "OFF")
 
     def cmake_args(self):
-        args = super().cmake_args()
-        args.append(self.define("CLINGO_BUILD_APPS", False))
-        if self.spec.satisfies("platform=darwin target=aarch64:"):
-            # big sur is first to support darwin-aarch64
-            args.append(self.define("CMAKE_OSX_DEPLOYMENT_TARGET", "11"))
-        elif self.spec.satisfies("platform=darwin target=x86_64:"):
-            # for x86_64 use highsierra
-            args.append(self.define("CMAKE_OSX_DEPLOYMENT_TARGET", "10.13"))
-        return args
+        return [
+            *super().cmake_args(),
+            self.define("CLINGO_BUILD_APPS", False)
+        ]
 
     @run_before("cmake", when="+optimized")
     def pgo_train(self):


### PR DESCRIPTION
Turns out `os=...` of the spec and `MACOSX_DEPLOYMENT_TARGET` are kept
in sync (both ways), and the env variable is used to initialize
`CMAKE_MACOSX_DEPLOYMENT_TARGET`.

In bootstrap code we set the env variable, so these bits are redundant.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
