### PR TITLE
Implement prefix property for OneAPI compiler

### DIFF
--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -7,7 +7,9 @@ import os
 from os.path import dirname, join
 
 from llnl.util import tty
+from llnl.util.filesystem import ancestor
 
+import spack.util.executable
 from spack.compiler import Compiler
 from spack.version import Version
 
@@ -115,6 +117,24 @@ class Oneapi(Compiler):
     @property
     def stdcxx_libs(self):
         return ("-cxxlib",)
+
+    @property
+    def prefix(self):
+        # OneAPI reports its install prefix when running ``--version``
+        # on the line ``InstalledDir: <prefix>/bin/compiler``.
+        cc = spack.util.executable.Executable(self.cc)
+        with self.compiler_environment():
+            oneapi_output = cc("--version", output=str, error=str)
+
+            for line in oneapi_output.splitlines():
+                if line.startswith("InstalledDir:"):
+                    oneapi_prefix = line.split(":")[1].strip()
+                    # Go from <prefix>/bin/compiler to <prefix>
+                    return ancestor(oneapi_prefix, 2)
+
+            raise RuntimeError(
+                "could not find install prefix of OneAPI from output:\n\t{}".format(oneapi_output)
+            )
 
     def setup_custom_environment(self, pkg, env):
         # workaround bug in icpx driver where it requires sycl-post-link is on the PATH


### PR DESCRIPTION
Uses `icx --version` output to determine installation prefix. I've verified this with the following versions built with Spack:
```
intel-oneapi-compilers@2021.4.0  intel-oneapi-compilers@2023.2.4
intel-oneapi-compilers@2022.2.1  intel-oneapi-compilers@2024.1.0
```
as well as with a couple external system installations of OneAPI.

The prefix will be `<oneapi_install_dir>/compiler/<oneapi_version>` regardless of which OneAPI version is installed; I think this is the best one can do given the idiosyncratic directory layout of OneAPI. This means compiler binaries like `icx` will be found in `{compiler.prefix}/linux/bin` for older versions (2021 -- 2023) and `{compiler.prefix}/bin` for newer versions (2024).

@rscohn2 would appreciate your eyes on this.