### PR TITLE
heffte@develop: Use a new CMake variable to set the install prefix

### DIFF
--- a/var/spack/repos/builtin/packages/heffte/package.py
+++ b/var/spack/repos/builtin/packages/heffte/package.py
@@ -142,7 +142,12 @@ class Heffte(CMakePackage, CudaPackage, ROCmPackage):
         cmake_dir = self.test_suite.current_test_cache_dir.testing
 
         options = [cmake_dir]
-        options.append(self.define("Heffte_DIR", self.spec.prefix.lib.cmake.Heffte))
+        # changing the default install path search to newer cmake convention
+        if self.spec.satisfies("@develop"):
+            options.append(self.define("Heffte_ROOT", self.spec.prefix))
+        else:
+            options.append(self.define("Heffte_DIR", self.spec.prefix.lib.cmake.Heffte))
+
         if self.spec.satisfies("+rocm"):
             # path name is 'hsa-runtime64' but python cannot have '-' in variable name
             hsa_runtime = join_path(self.spec["hsa-rocr-dev"].prefix.lib.cmake, "hsa-runtime64")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Since Heffte is now using newer versions of CMake, we can use the newer convention of `Heffte_ROOT`.

Older versions should keep to the older convention.

This is a follow on to: https://github.com/icl-utk-edu/heffte/pull/57