### PR TITLE
Win:port adios2 2

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -11,6 +11,7 @@ from spack.package import *
 
 IS_WINDOWS = sys.platform == "win32"
 
+
 class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     """The Adaptable Input Output System version 2,
     developed in the Exascale Computing Program"""

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -3,11 +3,13 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import sys
 import tempfile
 
 from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
 
+IS_WINDOWS = sys.platform == "win32"
 
 class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     """The Adaptable Input Output System version 2,
@@ -77,7 +79,7 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     variant("zfp", default=True, description="Enable ZFP compression")
     variant("png", default=True, when="@2.4:", description="Enable PNG compression")
     variant("sz", default=True, when="@2.6:", description="Enable SZ compression")
-    variant("mgard", default=True, when="@2.8:", description="Enable MGARD compression")
+    variant("mgard", default=not IS_WINDOWS, when="@2.8:", description="Enable MGARD compression")
 
     # Rransport engines
     variant("sst", default=True, description="Enable the SST staging engine")
@@ -99,7 +101,7 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     )
     variant(
         "libcatalyst",
-        default=True,
+        default=not IS_WINDOWS,
         when="@2.9:",
         description="Enable support for in situ visualization plugin using ParaView Catalyst",
     )


### PR DESCRIPTION
Adios2 was ported in 2023 but seems to have regressed via new variants and associated deps in the last year. Conflcit with those deps for now until they can be ported
