### PR TITLE
Windows: Port SZ

### DIFF
--- a/var/spack/repos/builtin/packages/sz/package.py
+++ b/var/spack/repos/builtin/packages/sz/package.py
@@ -90,7 +90,6 @@ class Sz(CMakePackage, AutotoolsPackage):
     # Windows requires numerous commits that only exist on master at the moment
     conflicts("platform=windows", when="@:2.1.12.5")
 
-
     def flag_handler(self, name, flags):
         if name == "cflags":
             if self.spec.satisfies("%oneapi"):

--- a/var/spack/repos/builtin/packages/sz/package.py
+++ b/var/spack/repos/builtin/packages/sz/package.py
@@ -87,6 +87,10 @@ class Sz(CMakePackage, AutotoolsPackage):
 
     patch("ctags-only-if-requested.patch", when="@2.1.8.1:2.1.8.3")
 
+    # Windows requires numerous commits that only exist on master at the moment
+    conflicts("platform=windows", when="@:2.1.12.5")
+
+
     def flag_handler(self, name, flags):
         if name == "cflags":
             if self.spec.satisfies("%oneapi"):


### PR DESCRIPTION
Basically just only lets Windows build sz master as that's the only sz that builds on Windows

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
