### PR TITLE
Windows Rpath: Allow package test rpaths

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2493,8 +2493,7 @@ class WindowsSimulatedRPath:
         self._additional_library_dependents = set()
         if not self.link_install_prefix:
             tty.debug(
-                f"Generating rpath for non install context, {self.pkg.prefix} \
-install prefixes will be omitted as rpath targets"
+                f"Generating rpath for non install context: {base_modification_prefix}"
             )
 
     @property
@@ -2523,13 +2522,9 @@ install prefixes will be omitted as rpath targets"
             else:
                 new_pth = pathlib.Path(pth)
             path_is_in_prefix = new_pth.is_relative_to(self.base_modification_prefix)
-            add_lib = False
-            if path_is_in_prefix:
-                add_lib = True
-            else:
+            if not path_is_in_prefix:
                 raise RuntimeError(f"Attempting to generate rpath symlink out of rpath context: {str(self.base_modification_prefix)}")
-            if add_lib:
-                self._additional_library_dependents.add(new_pth)
+            self._additional_library_dependents.add(new_pth)
 
     @property
     def rpaths(self):

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2476,7 +2476,8 @@ class WindowsSimulatedRPath:
         base_pths = set()
         if self.link_install_prefix:
             base_pths.add(pathlib.Path(self.pkg.prefix.bin))
-        return base_pths | self._additional_library_dependents
+            base_pths |= self._additional_library_dependents
+        return base_pths
 
     def add_library_dependent(self, *dest):
         """
@@ -2581,9 +2582,11 @@ class WindowsSimulatedRPath:
 
 
 def make_package_test_rpath(pkg, test_dir):
-    """Establishes a temp rpath for the pkg in the testing directory
+    """Establishes a temp Windows simulated rpath for the pkg in the testing directory
     so an executable can test the libraries/executables with proper access
     to dependent dlls
+
+    Note: this is a no-op on all other platforms besides Windows
 
     Args:
         pkg (spack.package_base.PackageBase): the package for which the rpath should be computed

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2485,21 +2485,31 @@ class WindowsSimulatedRPath:
         self._addl_rpaths: set[str] = set()
         if link_install_prefix and base_modification_prefix:
             raise RuntimeError(
-                "Invalid combination of arguments given to WindowsSimulated RPath. \n"
+                "Invalid combination of arguments given to WindowsSimulated RPath.\n"
                 "Select either `link_install_prefix` to create an install prefix rpath"
                 " or specify a `base_modification_prefix` for any other link type. "
                 "Specifying both arguments is invalid."
             )
+        if not (link_install_prefix or base_modification_prefix):
+            raise RuntimeError(
+                "Insufficient arguments given to WindowsSimulatedRpath.\n"
+                "WindowsSimulatedRPath requires one of link_install_prefix"
+                " or base_modification_prefix to be specified."
+                " Neither was provided."
+            )
 
         self.link_install_prefix = link_install_prefix
-        self.base_modification_prefix = (
-            pathlib.Path(base_modification_prefix)
-            if base_modification_prefix
-            else pathlib.Path(self.pkg.prefix)
-        )
-        self._additional_library_dependents: set[str] = set()
+        if base_modification_prefix:
+            self._base_modification_prefix = pathlib.Path(base_modification_prefix)
+        self._additional_library_dependents: set[pathlib.Path] = set()
         if not self.link_install_prefix:
             tty.debug(f"Generating rpath for non install context: {base_modification_prefix}")
+
+    @property
+    def base_modification_prefix(self) -> pathlib.Path:
+        if self.link_install_prefix:
+            self._base_modification_prefix = pathlib.Path(self.pkg.prefix)
+        return self._base_modification_prefix
 
     @property
     def library_dependents(self):

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2467,6 +2467,11 @@ class WindowsSimulatedRPath:
         self._addl_rpaths = set()
         self.link_install_prefix = link_install_prefix
         self._additional_library_dependents = set()
+        if not self.link_install_prefix:
+            tty.debug(
+                "Generating rpath for non install context, \
+install prefixes will be omitted as rpath targets"
+            )
 
     @property
     def library_dependents(self):
@@ -2476,7 +2481,7 @@ class WindowsSimulatedRPath:
         base_pths = set()
         if self.link_install_prefix:
             base_pths.add(pathlib.Path(self.pkg.prefix.bin))
-            base_pths |= self._additional_library_dependents
+        base_pths |= self._additional_library_dependents
         return base_pths
 
     def add_library_dependent(self, *dest):
@@ -2493,7 +2498,23 @@ class WindowsSimulatedRPath:
                 new_pth = pathlib.Path(pth).parent
             else:
                 new_pth = pathlib.Path(pth)
-            self._additional_library_dependents.add(new_pth)
+            path_is_in_prefix = new_pth.is_relative_to(self.pkg.prefix)
+            add_lib = False
+            if self.link_install_prefix:
+                # We're creating RPath's post install, accept rpath targets anywhere but warn if
+                # out of install prefix
+                if not path_is_in_prefix:
+                    tty.warn(
+                        f"Generating rpath in {new_pth} which is \
+not rooted in target package ({self.pkg}) prefix"
+                    )
+                add_lib = True
+            elif not path_is_in_prefix:
+                # We're creating an RPath for anywhere not in the install prefix, only add rpath
+                # target if it's not in the install prefix
+                add_lib = True
+            if add_lib:
+                self._additional_library_dependents.add(new_pth)
 
     @property
     def rpaths(self):

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2473,7 +2473,10 @@ class WindowsSimulatedRPath:
         """
         Set of directories where package binaries/libraries are located.
         """
-        return set([pathlib.Path(self.pkg.prefix.bin)]) | self._additional_library_dependents
+        base_pths = set()
+        if self.link_install_prefix:
+            base_pths.add(pathlib.Path(self.pkg.prefix.bin))
+        return base_pths | self._additional_library_dependents
 
     def add_library_dependent(self, *dest):
         """
@@ -2575,6 +2578,26 @@ class WindowsSimulatedRPath:
         if "windows-system" not in getattr(self.pkg, "tags", []):
             for library, lib_dir in itertools.product(self.rpaths, self.library_dependents):
                 self._link(library, lib_dir)
+
+
+def make_package_test_rpath(pkg, test_dir):
+    """Establishes a temp rpath for the pkg in the testing directory
+    so an executable can test the libraries/executables with proper access
+    to dependent dlls
+
+    Args:
+        pkg (spack.package_base.PackageBase): the package for which the rpath should be computed
+        test_dir (StrPath): the testing directory in which we should construct an rpath
+    """
+    # link_install_prefix as false ensures we're not linking into the install prefix
+    mini_rpath = WindowsSimulatedRPath(pkg, link_install_prefix=False)
+    # add the testing directory as a location to install rpath symlinks
+    mini_rpath.add_library_dependent(test_dir)
+    # add the build dir & build dir bin
+    mini_rpath.add_rpath(os.path.join(pkg.build_directory, "bin"))
+    mini_rpath.add_rpath(os.path.join(pkg.build_directory))
+    # construct rpath
+    mini_rpath.establish_link()
 
 
 @system_path_filter

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2454,9 +2454,12 @@ class WindowsSimulatedRPath:
     and vis versa.
     """
 
-    def __init__(self, package:"spack.package_base.PackageBase", 
-                 base_modification_prefix:Optional[Union[str, pathlib.Path]]=None, 
-                 link_install_prefix:bool=True):
+    def __init__(
+        self,
+        package,
+        base_modification_prefix: Optional[Union[str, pathlib.Path]] = None,
+        link_install_prefix: bool = True,
+    ):
         """
         Args:
             package (spack.package_base.PackageBase): Package requiring links
@@ -2479,22 +2482,24 @@ class WindowsSimulatedRPath:
                 both is an error.
         """
         self.pkg = package
-        self._addl_rpaths = set()
+        self._addl_rpaths: set[str] = set()
         if link_install_prefix and base_modification_prefix:
-            raise RuntimeError("Invalid combination of arguments given to WindowsSimulated RPath. \n"
-                               "Select either `link_install_prefix` to create an install prefix rpath"
-                               " or specify a `base_modification_prefix` for any other link type. "
-                               "Specifying both arguments is invalid.")
-        
-        self.link_install_prefix = link_install_prefix
-        self.base_modification_prefix = pathlib.Path(base_modification_prefix) \
-            if base_modification_prefix \
-            else pathlib.Path(self.pkg.prefix)
-        self._additional_library_dependents = set()
-        if not self.link_install_prefix:
-            tty.debug(
-                f"Generating rpath for non install context: {base_modification_prefix}"
+            raise RuntimeError(
+                "Invalid combination of arguments given to WindowsSimulated RPath. \n"
+                "Select either `link_install_prefix` to create an install prefix rpath"
+                " or specify a `base_modification_prefix` for any other link type. "
+                "Specifying both arguments is invalid."
             )
+
+        self.link_install_prefix = link_install_prefix
+        self.base_modification_prefix = (
+            pathlib.Path(base_modification_prefix)
+            if base_modification_prefix
+            else pathlib.Path(self.pkg.prefix)
+        )
+        self._additional_library_dependents: set[str] = set()
+        if not self.link_install_prefix:
+            tty.debug(f"Generating rpath for non install context: {base_modification_prefix}")
 
     @property
     def library_dependents(self):
@@ -2523,7 +2528,10 @@ class WindowsSimulatedRPath:
                 new_pth = pathlib.Path(pth)
             path_is_in_prefix = new_pth.is_relative_to(self.base_modification_prefix)
             if not path_is_in_prefix:
-                raise RuntimeError(f"Attempting to generate rpath symlink out of rpath context: {str(self.base_modification_prefix)}")
+                raise RuntimeError(
+                    f"Attempting to generate rpath symlink out of rpath context:\
+{str(self.base_modification_prefix)}"
+                )
             self._additional_library_dependents.add(new_pth)
 
     @property

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2500,16 +2500,12 @@ class WindowsSimulatedRPath:
 
         self.link_install_prefix = link_install_prefix
         if base_modification_prefix:
-            self._base_modification_prefix = pathlib.Path(base_modification_prefix)
+            self.base_modification_prefix = pathlib.Path(base_modification_prefix)
+        else:
+            self.base_modification_prefix = pathlib.Path(self.pkg.prefix)
         self._additional_library_dependents: set[pathlib.Path] = set()
         if not self.link_install_prefix:
             tty.debug(f"Generating rpath for non install context: {base_modification_prefix}")
-
-    @property
-    def base_modification_prefix(self) -> pathlib.Path:
-        if self.link_install_prefix:
-            self._base_modification_prefix = pathlib.Path(self.pkg.prefix)
-        return self._base_modification_prefix
 
     @property
     def library_dependents(self):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -125,9 +125,10 @@ class WindowsRPath:
         # Spack should in general not modify things it has not installed
         # we can reasonably expect externals to have their link interface properly established
         if sys.platform == "win32" and not self.spec.external:
-            self.win_rpath.add_library_dependent(*self.win_add_library_dependent())
-            self.win_rpath.add_rpath(*self.win_add_rpath())
-            self.win_rpath.establish_link()
+            win_rpath = fsys.WindowsSimulatedRPath(self)
+            win_rpath.add_library_dependent(*self.win_add_library_dependent())
+            win_rpath.add_rpath(*self.win_add_rpath())
+            win_rpath.establish_link()
 
 
 #: Registers which are the detectable packages, by repo and package name
@@ -742,7 +743,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         # Set up timing variables
         self._fetch_time = 0.0
 
-        self.win_rpath = fsys.WindowsSimulatedRPath(self)
         super().__init__()
 
     def __getitem__(self, key: str) -> "PackageBase":

--- a/var/spack/repos/builtin/packages/libcatalyst/package.py
+++ b/var/spack/repos/builtin/packages/libcatalyst/package.py
@@ -70,14 +70,10 @@ class Libcatalyst(CMakePackage):
         ]
         adapter0_test_path = join_path(testdir, "adaptor0/adaptor0_test")
         if sys.platform == "win32":
-            # Default generator on Windows is visual studio, Spack uses
-            # ninja
-            # If visual studio is used the path to the test exe is
-            # adapter0/<CONFIG>/adaptor0_test
-            # due to the nature of VS as a multi-config generator
-            # Use ninja to keep the path/logic the same here
-            # This package is a CMake package so we're already guaranteed to have
-            # ninja in the DAG, so no need to re-depend on it for this purpose
+            # Specify ninja generator for `cmake` call used to generate test artifact
+            # (this differs from the build of `libcatalyst` itself); if unspecified, the
+            # default is to use Visual Studio, which generates a more-complex path
+            # (adapter0/<CONFIG>/adaptor0_test rather than adaptor0/adaptor0_test).
             cmake_args.append("-GNinja")
             # To run the test binary on Windows, we need to construct an rpath
             # for the current package being tested, including the package

--- a/var/spack/repos/builtin/packages/libcatalyst/package.py
+++ b/var/spack/repos/builtin/packages/libcatalyst/package.py
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import subprocess
+import sys
+
+import llnl.util.filesystem as fsys
+import llnl.util.tty as tty
 
 from spack.package import *
 
@@ -57,19 +61,34 @@ class Libcatalyst(CMakePackage):
     @on_package_attributes(run_tests=True)
     @run_after("install")
     def build_test(self):
-        testdir = "smoke_test_build"
+        testdir = join_path(self.stage.source_path, "smoke_test_build")
         cmakeExampleDir = join_path(self.stage.source_path, "examples")
         cmake_args = [
             cmakeExampleDir,
             "-DBUILD_SHARED_LIBS=ON",
             self.define("CMAKE_PREFIX_PATH", self.prefix),
         ]
+        adapter0_test_path = join_path(testdir, "adaptor0/adaptor0_test")
+        if sys.platform == "win32":
+            # Default generator on Windows is visual studio, Spack uses
+            # ninja
+            # If visual studio is used the path to the test exe is
+            # adapter0/<CONFIG>/adaptor0_test
+            # due to the nature of VS as a multi-config generator
+            # Use ninja to keep the path/logic the same here
+            # This package is a CMake package so we're already guaranteed to have
+            # ninja in the DAG, so no need to re-depend on it for this purpose
+            cmake_args.append("-GNinja")
+            # To run the test binary on Windows, we need to construct an rpath
+            # for the current package being tested, including the package
+            # itself
+            fsys.make_package_test_rpath(self, adapter0_test_path)
         cmake = which(self.spec["cmake"].prefix.bin.cmake)
 
         with working_dir(testdir, create=True):
             cmake(*cmake_args)
             cmake(*(["--build", "."]))
             tty.info("Running Catalyst test")
-
-            res = subprocess.run(["adaptor0/adaptor0_test", "catalyst"])
+            if
+            res = subprocess.run([adapter0_test_path, "catalyst"])
             assert res.returncode == 0

--- a/var/spack/repos/builtin/packages/libcatalyst/package.py
+++ b/var/spack/repos/builtin/packages/libcatalyst/package.py
@@ -89,6 +89,5 @@ class Libcatalyst(CMakePackage):
             cmake(*cmake_args)
             cmake(*(["--build", "."]))
             tty.info("Running Catalyst test")
-            if
             res = subprocess.run([adapter0_test_path, "catalyst"])
             assert res.returncode == 0


### PR DESCRIPTION
Windows binaries and dlls need access to their dependent dlls in order to properly run, this is handled in the general case post install, but has yet to be extended to during test time.

This PR adds the during install/test time Windows Simulated RPath functionality, allowing packages to construct ad-hoc rpaths including themselves to provide functional run environments to their testing executables.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
