### PR TITLE
Build wrf%oneapi in aws-pcluster-x86_64_v4 stack

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
@@ -9,7 +9,6 @@ spack:
     # - mpas-model %oneapi
     - openfoam %gcc
     - palace %oneapi ^superlu-dist%oneapi # hack: force fortran-rt provider through superlu-dist
-    # Latest version quantum-espresso@7.3.1 does not build with oneapi, see https://github.com/spack/spack/pull/46456#issuecomment-236315951=> WORKS NOW.
     # TODO: Find out how to make +ipo cmake flag work.
     # - quantum-espresso %oneapi
     - openmpi %oneapi

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
@@ -9,12 +9,11 @@ spack:
     # - mpas-model %oneapi
     - openfoam %gcc
     - palace %oneapi ^superlu-dist%oneapi # hack: force fortran-rt provider through superlu-dist
-    # Latest version qunatum-espresso@7.3.1 does not build with oneapi, see https://github.com/spack/spack/pull/46456#issuecomment-2363159511
+    # Latest version quantum-espresso@7.3.1 does not build with oneapi, see https://github.com/spack/spack/pull/46456#issuecomment-236315951=> WORKS NOW.
+    # TODO: Find out how to make +ipo cmake flag work.
     # - quantum-espresso %oneapi
     - openmpi %oneapi
-    # TODO: oneapi patch in WRF is broken. It uses link time optimization but the gnu linker. Need to check whether the WRF recipe (in later releases) is better.
-    # WRf can only run if https://github.com/spack/spack/pull/46589 is merged.
-    # - wrf %oneapi
+    - wrf %oneapi
 
   - targets:
       - 'target=x86_64_v4'


### PR DESCRIPTION
-------
Since #47040 is merged this should build now.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->