### PR TITLE
pika: Add minimum CMake version requirement when using CUDA and C++20

### DIFF
--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -117,6 +117,8 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("%clang@:8", when="@0.2:")
     conflicts("+stdexec", when="cxxstd=17")
     conflicts("cxxstd=23", when="^cmake@:3.20.2")
+    conflicts("cxxstd=20", when="+cuda ^cmake@:3.25.1")
+    conflicts("cxxstd=23", when="+cuda")
     # nvcc version <= 11 does not support C++20 and newer
     for cxxstd in filter(lambda x: x != "17", cxxstds):
         requires("%nvhpc", when=f"cxxstd={cxxstd} ^cuda@:11")


### PR DESCRIPTION
Also add an unconditional conflict for CUDA and C++23, since that isn't supported at all. CMake 3.25.2 added C++20 support for CUDA (https://cmake.org/cmake/help/latest/release/3.25.html#id2).