### PR TITLE
spack arch: add --family --generic flags

### DIFF
--- a/lib/spack/spack/cmd/arch.py
+++ b/lib/spack/spack/cmd/arch.py
@@ -7,7 +7,6 @@ import collections
 
 import archspec.cpu
 
-import llnl.util.tty as tty
 import llnl.util.tty.colify as colify
 import llnl.util.tty.color as color
 

--- a/lib/spack/spack/cmd/arch.py
+++ b/lib/spack/spack/cmd/arch.py
@@ -92,7 +92,7 @@ def display_targets(targets):
 
 def arch(parser, args):
     if args.generic_target:
-        tty.warn("spack arch --generic-target is deprecated in favor of --generic --target")
+        # TODO: add deprecation warning in 0.24
         print(archspec.cpu.host().generic)
         return
 

--- a/lib/spack/spack/cmd/arch.py
+++ b/lib/spack/spack/cmd/arch.py
@@ -7,6 +7,7 @@ import collections
 
 import archspec.cpu
 
+import llnl.util.tty as tty
 import llnl.util.tty.colify as colify
 import llnl.util.tty.color as color
 
@@ -19,11 +20,22 @@ level = "short"
 
 
 def setup_parser(subparser):
+    # DEPRECATED: equivalent to --generic --target
     subparser.add_argument(
-        "-g", "--generic-target", action="store_true", help="show the best generic target"
+        "-g",
+        "--generic-target",
+        action="store_true",
+        help="show the best generic target (deprecated)",
     )
     subparser.add_argument(
         "--known-targets", action="store_true", help="show a list of all known targets and exit"
+    )
+    target_type = subparser.add_mutually_exclusive_group()
+    target_type.add_argument(
+        "--family", action="store_true", help="print generic ISA (x86_64, aarch64, ppc64le, ...)"
+    )
+    target_type.add_argument(
+        "--generic", action="store_true", help="print feature level (x86_64_v3, armv8.4a, ...)"
     )
     parts = subparser.add_mutually_exclusive_group()
     parts2 = subparser.add_mutually_exclusive_group()
@@ -80,6 +92,7 @@ def display_targets(targets):
 
 def arch(parser, args):
     if args.generic_target:
+        tty.warn("spack arch --generic-target is deprecated in favor of --generic --target")
         print(archspec.cpu.host().generic)
         return
 
@@ -96,6 +109,10 @@ def arch(parser, args):
     host_platform = spack.platforms.host()
     host_os = host_platform.operating_system(os_args)
     host_target = host_platform.target(target_args)
+    if args.family:
+        host_target = host_target.family
+    elif args.generic:
+        host_target = host_target.generic
     architecture = spack.spec.ArchSpec((str(host_platform), str(host_os), str(host_target)))
 
     if args.platform:

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -415,7 +415,7 @@ _spack_add() {
 }
 
 _spack_arch() {
-    SPACK_COMPREPLY="-h --help -g --generic-target --known-targets -p --platform -o --operating-system -t --target -f --frontend -b --backend"
+    SPACK_COMPREPLY="-h --help -g --generic-target --known-targets --family --generic -p --platform -o --operating-system -t --target -f --frontend -b --backend"
 }
 
 _spack_audit() {

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -489,13 +489,17 @@ complete -c spack -n '__fish_spack_using_command add' -s l -l list-name -r -f -a
 complete -c spack -n '__fish_spack_using_command add' -s l -l list-name -r -d 'name of the list to add specs to'
 
 # spack arch
-set -g __fish_spack_optspecs_spack_arch h/help g/generic-target known-targets p/platform o/operating-system t/target f/frontend b/backend
+set -g __fish_spack_optspecs_spack_arch h/help g/generic-target known-targets family generic p/platform o/operating-system t/target f/frontend b/backend
 complete -c spack -n '__fish_spack_using_command arch' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command arch' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command arch' -s g -l generic-target -f -a generic_target
-complete -c spack -n '__fish_spack_using_command arch' -s g -l generic-target -d 'show the best generic target'
+complete -c spack -n '__fish_spack_using_command arch' -s g -l generic-target -d 'show the best generic target (deprecated)'
 complete -c spack -n '__fish_spack_using_command arch' -l known-targets -f -a known_targets
 complete -c spack -n '__fish_spack_using_command arch' -l known-targets -d 'show a list of all known targets and exit'
+complete -c spack -n '__fish_spack_using_command arch' -l family -f -a family
+complete -c spack -n '__fish_spack_using_command arch' -l family -d 'print generic ISA (x86_64, aarch64, ppc64le, ...)'
+complete -c spack -n '__fish_spack_using_command arch' -l generic -f -a generic
+complete -c spack -n '__fish_spack_using_command arch' -l generic -d 'print feature level (x86_64_v3, armv8.4a, ...)'
 complete -c spack -n '__fish_spack_using_command arch' -s p -l platform -f -a platform
 complete -c spack -n '__fish_spack_using_command arch' -s p -l platform -d 'print only the platform'
 complete -c spack -n '__fish_spack_using_command arch' -s o -l operating-system -f -a operating_system


### PR DESCRIPTION
With this you can run

```
spack install ... target=$(spack arch --target --family) # most compatible when sharing binaries, useful for bootstrapping
spack install ... arch=$(spack arch --family)

spack install ... target=$(spack arch --target --generic) # reasonably compatible when sharing binaries
spack install ... arch=$(spack arch --generic)
```

Deprecate `--generic-target` in favor of `--generic --target`