### PR TITLE
geomodel: Rename v7.0.0 to v6.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/builtin/packages/geomodel/package.py
@@ -18,7 +18,7 @@ class Geomodel(CMakePackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("7.0.0", sha256="9ad86e9f3e2d67b9056b70550d347db8017f4d5acf829804afc61e4fe7b6a527")
+    version("6.6.0", sha256="3cefeaa409177d45d3fa63e069b6496ca062991b0d7d71275b1748487659e91b")
     version("6.5.0", sha256="8a2f71493e54ea4d393f4c0075f3ca13df132f172c891825f3ab949cda052c5f")
     version("6.4.0", sha256="369f91f021be83d294ba6a9bdbe00077625e9fe798a396aceece8970e7dd5838")
     version("6.3.0", sha256="d2b101e06d20a8a3b638e6021f517a939f49ea6d8347ce40c927c27efe66b28c")


### PR DESCRIPTION
The GeoModel devs decided to delete the v7.0.0 release and re-release it as v6.6.0 (see
https://gitlab.cern.ch/GeoModelDev/GeoModel/-/merge_requests/357).