### PR TITLE
amduprof: Add v5.0

### DIFF
--- a/var/spack/repos/builtin/packages/amduprof/package.py
+++ b/var/spack/repos/builtin/packages/amduprof/package.py
@@ -16,15 +16,28 @@ class Amduprof(Package):
     understand the limiters of application performance and evaluate
     improvements."""
 
-    homepage = "https://developer.amd.com/amd-uprof/"
-    url = f"file://{os.getcwd()}/AMDuProf_Linux_x64_4.2.850.tar.bz2"
+    homepage = "https://www.amd.com/en/developer/uprof.html"
     manual_download = True
 
     maintainers("amd-toolchain-support")
 
-    version("4.2.850", sha256="f2d7c4eb9ec9c32845ff8f19874c1e6bcb0fa8ab2c12e73addcbf23a6d1bd623")
+    version(
+        "5.0.1479",
+        sha256="065d24d9b84d2ef94ae8a360bf55c74a0f3fe9250b01cc7fb2642495028130d5",
+        url="file://{0}/AMDuProf_Linux_x64_5.0.1479.tar.bz2".format(os.getcwd()),
+        preferred=True,
+    )
+    version(
+        "4.2.850",
+        sha256="f2d7c4eb9ec9c32845ff8f19874c1e6bcb0fa8ab2c12e73addcbf23a6d1bd623",
+        url="file://{0}/AMDuProf_Linux_x64_4.2.850.tar.bz2".format(os.getcwd()),
+    )
 
     depends_on("binutils@2.27:", type="run")
+
+    # Licensing
+    license_required = True
+    license_url = "https://www.amd.com/en/developer/uprof/uprof-eula.html"
 
     conflicts("platform=darwin")
     requires("target=x86_64:", msg="AMD uProf available only on x86_64")


### PR DESCRIPTION
1. Support for new Zen5 processors and MI300A in all AMDuProf tools. 
   - Refer uProf Release Notes for the complete feature list.
2. Virtualization support – AWS, Hyper-V 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
