### PR TITLE
spack external find: show backtrace on error when --backtrace

### DIFF
--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -11,6 +11,7 @@ import os
 import os.path
 import re
 import sys
+import traceback
 import warnings
 from typing import Dict, Iterable, List, Optional, Set, Tuple, Type
 
@@ -18,6 +19,7 @@ import llnl.util.filesystem
 import llnl.util.lang
 import llnl.util.tty
 
+import spack.error
 import spack.spec
 import spack.util.elf as elf_utils
 import spack.util.environment
@@ -274,8 +276,12 @@ class Finder:
                 )
             except Exception as e:
                 specs = []
+                if spack.error.SHOW_BACKTRACE:
+                    details = traceback.format_exc()
+                else:
+                    details = f"[{e.__class__.__name__}: {e}]"
                 warnings.warn(
-                    f'error detecting "{pkg.name}" from prefix {candidate_path} [{str(e)}]'
+                    f'error detecting "{pkg.name}" from prefix {candidate_path}: {details}'
                 )
 
             if not specs:
@@ -449,9 +455,9 @@ def by_path(
                     llnl.util.tty.debug(
                         f"[EXTERNAL DETECTION] Skipping {pkg_name}: timeout reached"
                     )
-                except Exception as e:
+                except Exception:
                     llnl.util.tty.debug(
-                        f"[EXTERNAL DETECTION] Skipping {pkg_name}: exception occured {e}"
+                        f"[EXTERNAL DETECTION] Skipping {pkg_name}: {traceback.format_exc()}"
                     )
 
     return result

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -12,6 +12,9 @@ import llnl.util.tty as tty
 #: this is module-scoped because it needs to be set very early
 debug = 0
 
+#: whether to show a backtrace when an error is printed, enabled with --backtrace.
+SHOW_BACKTRACE = False
+
 
 class SpackError(Exception):
     """This is the superclass for all Spack errors.

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -102,9 +102,6 @@ required_command_properties = ["level", "section", "description"]
 
 spack_ld_library_path = os.environ.get("LD_LIBRARY_PATH", "")
 
-#: Whether to print backtraces on error
-SHOW_BACKTRACE = False
-
 
 def add_all_commands(parser):
     """Add all spack subcommands to the parser."""
@@ -527,8 +524,7 @@ def setup_main_options(args):
 
     if args.debug or args.backtrace:
         spack.error.debug = True
-        global SHOW_BACKTRACE
-        SHOW_BACKTRACE = True
+        spack.error.SHOW_BACKTRACE = True
 
     if args.debug:
         spack.util.debug.register_interrupt_handler()
@@ -1021,19 +1017,19 @@ def main(argv=None):
         e.die()  # gracefully die on any SpackErrors
 
     except KeyboardInterrupt:
-        if spack.config.get("config:debug") or SHOW_BACKTRACE:
+        if spack.config.get("config:debug") or spack.error.SHOW_BACKTRACE:
             raise
         sys.stderr.write("\n")
         tty.error("Keyboard interrupt.")
         return signal.SIGINT.value
 
     except SystemExit as e:
-        if spack.config.get("config:debug") or SHOW_BACKTRACE:
+        if spack.config.get("config:debug") or spack.error.SHOW_BACKTRACE:
             traceback.print_exc()
         return e.code
 
     except Exception as e:
-        if spack.config.get("config:debug") or SHOW_BACKTRACE:
+        if spack.config.get("config:debug") or spack.error.SHOW_BACKTRACE:
             raise
         tty.error(e)
         return 3


### PR DESCRIPTION
Sometimes there are bugs in the implementation of a package's detection methods. Currently that's hard to troubleshoot:

```
$ spack [--backtrace] -e . external find python
==> Warning: error detecting "python" from prefix /usr/bin ['example']
==> No new external packages detected
```

With this PR you at least get a backtrace (also with --debug):

```
$ spack -e . external find python
==> Warning: error detecting "python" from prefix /usr/bin: [KeyError: 'example']

$ spack --backtrace -e . external find python
==> Warning: error detecting "python" from prefix /usr/bin: Traceback (most recent call last):
  File "/home/harmen/spack/lib/spack/spack/detection/path.py", line 275, in detect_specs
    pkg.determine_spec_details(candidate_path, items_in_prefix)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/harmen/spack/lib/spack/spack/package_base.py", line 241, in determine_spec_details
    variants = cls.determine_variants(objs, version_str)
  File "/home/harmen/spack/var/spack/repos/builtin/packages/python/package.py", line 386, in determine_variants
KeyError: 'example'
```

The line is still off by one, but hopefully one day it'll correct itself ;)