### PR TITLE
r-textshaping,r-ragg: Add dep on pkgconfig, type="build" and handle freetype@2.13.3

### DIFF
--- a/var/spack/repos/builtin/packages/r-ragg/package.py
+++ b/var/spack/repos/builtin/packages/r-ragg/package.py
@@ -28,3 +28,9 @@ class RRagg(RPackage):
     depends_on("libpng")
     depends_on("libtiff")
     depends_on("jpeg")
+
+    def flag_handler(self, name, flags):
+        # Freetype 2.13.3 broke the public interface by switching char/unsigned char:
+        if name == "cxxflags" and self.spec["freetype"].version >= Version("2.13.3"):
+            flags.append("-fpermissive")
+        return (flags, None, None)

--- a/var/spack/repos/builtin/packages/r-textshaping/package.py
+++ b/var/spack/repos/builtin/packages/r-textshaping/package.py
@@ -23,6 +23,7 @@ class RTextshaping(RPackage):
     depends_on("r@3.2.0:", type=("build", "run"))
     depends_on("r-systemfonts@1.0.0:", type=("build", "run"))
     depends_on("r-cpp11@0.2.1:", type=("build", "run"))
+    depends_on("pkgconfig", type="build")
     depends_on("freetype")
     depends_on("harfbuzz")
     depends_on("fribidi")


### PR DESCRIPTION
Fix two issues uncovered by a build test of #47008:
- `r-textshaping` needs `pkgconfig` as also shown in two reports about it [here](https://github.com/r-lib/textshaping/issues/41) and [here](https://github.com/r-lib/textshaping/issues/21).
- `r-ragg` is affected by the API change of `freetype` like `ftgl`(#47003), see also #47021