### PR TITLE
bootstrap: handle a new edge case of binary python packages with missing python-venv

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2580,6 +2580,7 @@ def install_root_node(
         unsigned: if True allows installing unsigned binaries
         force: force installation if the spec is already present in the local store
         sha256: optional sha256 of the binary package, to be checked before installation
+        allow_missing: when true, allows installing a node with missing dependencies
     """
     # Early termination
     if spec.external or spec.virtual:

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2562,7 +2562,13 @@ def _ensure_common_prefix(tar: tarfile.TarFile) -> str:
     return pkg_prefix
 
 
-def install_root_node(spec, unsigned=False, force=False, sha256=None):
+def install_root_node(
+    spec: spack.spec.Spec,
+    unsigned=False,
+    force: bool = False,
+    sha256: Optional[str] = None,
+    allow_missing: bool = False,
+) -> None:
     """Install the root node of a concrete spec from a buildcache.
 
     Checking the sha256 sum of a node before installation is usually needed only
@@ -2571,11 +2577,9 @@ def install_root_node(spec, unsigned=False, force=False, sha256=None):
 
     Args:
         spec: spec to be installed (note that only the root node will be installed)
-        unsigned (bool): if True allows installing unsigned binaries
-        force (bool): force installation if the spec is already present in the
-            local store
-        sha256 (str): optional sha256 of the binary package, to be checked
-            before installation
+        unsigned: if True allows installing unsigned binaries
+        force: force installation if the spec is already present in the local store
+        sha256: optional sha256 of the binary package, to be checked before installation
     """
     # Early termination
     if spec.external or spec.virtual:
@@ -2613,7 +2617,7 @@ def install_root_node(spec, unsigned=False, force=False, sha256=None):
                 spec, spack.store.STORE.layout.spec_file_path(spec)
             )
         spack.hooks.post_install(spec, False)
-        spack.store.STORE.db.add(spec)
+        spack.store.STORE.db.add(spec, allow_missing=allow_missing)
 
 
 def install_single_spec(spec, unsigned=False, force=False):

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -68,7 +68,8 @@ def _try_import_from_store(
                 os.path.join(candidate_spec.prefix, python.package.purelib),
                 os.path.join(candidate_spec.prefix, python.package.platlib),
             ]
-        # otherwise search for the site-packages directory (assuming bootstapped from binaries)
+        # otherwise search for the site-packages directory
+        # (clingo from binaries with truncated python-venv runtime)
         else:
             module_paths = glob.glob(
                 os.path.join(candidate_spec.prefix, "lib", "python*", "site-packages")

--- a/lib/spack/spack/bootstrap/_common.py
+++ b/lib/spack/spack/bootstrap/_common.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Common basic functions used through the spack.bootstrap package"""
 import fnmatch
+import glob
 import importlib
 import os.path
 import re
@@ -60,10 +61,18 @@ def _try_import_from_store(
             python, *_ = candidate_spec.dependencies("python-venv")
         else:
             python, *_ = candidate_spec.dependencies("python")
-        module_paths = [
-            os.path.join(candidate_spec.prefix, python.package.purelib),
-            os.path.join(candidate_spec.prefix, python.package.platlib),
-        ]
+
+        # if python is installed, ask it for the layout
+        if python.installed:
+            module_paths = [
+                os.path.join(candidate_spec.prefix, python.package.purelib),
+                os.path.join(candidate_spec.prefix, python.package.platlib),
+            ]
+        # otherwise search for the site-packages directory (assuming bootstapped from binaries)
+        else:
+            module_paths = glob.glob(
+                os.path.join(candidate_spec.prefix, "lib", "python*", "site-packages")
+            )
         path_before = list(sys.path)
 
         # NOTE: try module_paths first and last, last allows an existing version in path

--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -175,7 +175,15 @@ class BuildcacheBootstrapper(Bootstrapper):
             query = spack.binary_distribution.BinaryCacheQuery(all_architectures=True)
             for match in spack.store.find([f"/{pkg_hash}"], multiple=False, query_fn=query):
                 spack.binary_distribution.install_root_node(
-                    match, unsigned=True, force=True, sha256=pkg_sha256
+                    # allow_missing is true since when bootstrapping clingo we truncate runtime
+                    # deps such as gcc-runtime, since we link libstdc++ statically, and the other
+                    # further runtime deps are loaded by the Python interpreter. This just silences
+                    # warnings about missing dependencies.
+                    match,
+                    unsigned=True,
+                    force=True,
+                    sha256=pkg_sha256,
+                    allow_missing=True,
                 )
 
     def _install_and_test(

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1245,7 +1245,7 @@ class Database:
         self._data[key].explicit = explicit
 
     @_autospec
-    def add(self, spec: "spack.spec.Spec", *, explicit: bool = False) -> None:
+    def add(self, spec: "spack.spec.Spec", *, explicit: bool = False, allow_missing=False) -> None:
         """Add spec at path to database, locking and reading DB to sync.
 
         ``add()`` will lock and read from the DB on disk.
@@ -1254,7 +1254,7 @@ class Database:
         # TODO: ensure that spec is concrete?
         # Entire add is transactional.
         with self.write_transaction():
-            self._add(spec, explicit=explicit)
+            self._add(spec, explicit=explicit, allow_missing=allow_missing)
 
     def _get_matching_spec_key(self, spec: "spack.spec.Spec", **kwargs) -> str:
         """Get the exact spec OR get a single spec that matches."""


### PR DESCRIPTION
Up till now we had the following cases:

1. from source and binary clingo installs without python-venv: ask external
   python where site-packages is (sometimes broken)
2. from source clingo with python-venv: ask python-venv where site-packages is
   (always correct)

but now we also have:

3. from binary clingo with python-venv

where we cannot ask python-venv about layout cause (a) it is not installed, and
(b) even if we would install it, we would not relocate the reference to the
python interpreter, because we don't relocate external prefixes.

So, solution is to just glob for `site-packages` in case python-venv is not
installed.

Further, silence warnings from the database about missing dependencies
`python-venv` / `gcc-runtime` upon install of `clingo-bootstrap`, which is
by design (libstdc++ is statically linked on linux, and other gcc runtime libs
are already loaded by the python interpreter).
