### PR TITLE
py-torchmetrics: add v1.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchmetrics/package.py
+++ b/var/spack/repos/builtin/packages/py-torchmetrics/package.py
@@ -15,6 +15,7 @@ class PyTorchmetrics(PythonPackage):
     license("Apache-2.0")
     maintainers("adamjstewart")
 
+    version("1.5.0", sha256="c18e68bab4104ad7d2285af601ddc6dc04f9f3b7cafaa8ad13fa1dcc539e33b6")
     version("1.4.3", sha256="5554a19167e91f543afe82ff58a01059c8eec854359ad22896449c2c8fb0ad89")
     version("1.4.2", sha256="7a40cbec85e5645090812b87601696b4adf158294ec8c407ae58a71710938b87")
     version("1.4.0", sha256="0b1e5acdcc9beb05bfe369d3d56cfa5b143f060ebfd6079d19ccc59ba46465b3")
@@ -71,8 +72,9 @@ class PyTorchmetrics(PythonPackage):
         depends_on("py-scipy@1.0.1:", when="+image")
         depends_on("py-torchvision@0.8:", when="+image")
         depends_on("py-torch-fidelity", when="+image")
-        depends_on("py-lpips", when="@:1.2.0+image")
 
         # Historical dependencies
         depends_on("py-pretty-errors@1.2.25", when="@1.4.0")
         depends_on("py-pydeprecate@0.3", when="@0.7:0.8")
+
+        depends_on("py-lpips", when="@:1.2.0+image")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
https://github.com/Lightning-AI/torchmetrics/releases/tag/v1.5.0

Technically an upper bound to prevent numpy 2 was added, but this is only needed because of incompatibilities in the PESQ dependency, which is only used for audio support. The upper bound should instead be added to the PESQ package, which Spack doesn't currently have anyway.