### PR TITLE
Fix broken `spack find -u`

### DIFF
--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -174,9 +174,9 @@ def query_arguments(args):
     if (args.missing or args.only_missing) and not args.only_deprecated:
         installed.append(InstallStatuses.MISSING)
 
-    selection_fn = None
+    predicate_fn = None
     if args.unknown:
-        selection_fn = lambda x: not spack.repo.PATH.exists(x.spec.name)
+        predicate_fn = lambda x: not spack.repo.PATH.exists(x.spec.name)
 
     explicit = any
     if args.explicit:
@@ -184,7 +184,7 @@ def query_arguments(args):
     if args.implicit:
         explicit = False
 
-    q_args = {"installed": installed, "selection_fn": selection_fn, "explicit": explicit}
+    q_args = {"installed": installed, "predicate_fn": predicate_fn, "explicit": explicit}
 
     install_tree = args.install_tree
     upstreams = spack.config.get("upstreams", {})

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -174,9 +174,9 @@ def query_arguments(args):
     if (args.missing or args.only_missing) and not args.only_deprecated:
         installed.append(InstallStatuses.MISSING)
 
-    known = any
+    selection_fn = None
     if args.unknown:
-        known = False
+        selection_fn = lambda x: not spack.repo.PATH.exists(x.spec.name)
 
     explicit = any
     if args.explicit:
@@ -184,7 +184,7 @@ def query_arguments(args):
     if args.implicit:
         explicit = False
 
-    q_args = {"installed": installed, "known": known, "explicit": explicit}
+    q_args = {"installed": installed, "selection_fn": selection_fn, "explicit": explicit}
 
     install_tree = args.install_tree
     upstreams = spack.config.get("upstreams", {})

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -380,7 +380,7 @@ def modules_cmd(parser, args, module_type, callbacks=callbacks):
     constraint_qualifiers = {
         "refresh": {
             "installed": True,
-            "selection_fn": lambda x: spack.repo.PATH.exists(x.spec.name),
+            "predicate_fn": lambda x: spack.repo.PATH.exists(x.spec.name),
         }
     }
     query_args = constraint_qualifiers.get(args.subparser_name, {})

--- a/lib/spack/spack/cmd/modules/__init__.py
+++ b/lib/spack/spack/cmd/modules/__init__.py
@@ -378,7 +378,10 @@ callbacks = {"refresh": refresh, "rm": rm, "find": find, "loads": loads}
 def modules_cmd(parser, args, module_type, callbacks=callbacks):
     # Qualifiers to be used when querying the db for specs
     constraint_qualifiers = {
-        "refresh": {"installed": True, "known": lambda x: not spack.repo.PATH.exists(x)}
+        "refresh": {
+            "installed": True,
+            "selection_fn": lambda x: spack.repo.PATH.exists(x.spec.name),
+        }
     }
     query_args = constraint_qualifiers.get(args.subparser_name, {})
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -299,7 +299,7 @@ _QUERY_DOCSTRING = """
                 database.  If it is a spec, we'll evaluate
                 ``spec.satisfies(query_spec)``
 
-            selection_fn: optional predicate taking an InstallRecord as argument, and returning
+            predicate_fn: optional predicate taking an InstallRecord as argument, and returning
                 whether that record is selected for the query. It can be used to craft criteria
                 that need some data for selection not provided by the Database itself.
 
@@ -1526,7 +1526,7 @@ class Database:
     def _query(
         self,
         query_spec=any,
-        selection_fn: Optional[SelectType] = None,
+        predicate_fn: Optional[SelectType] = None,
         installed=True,
         explicit=any,
         start_date=None,
@@ -1580,7 +1580,7 @@ class Database:
             if explicit is not any and rec.explicit != explicit:
                 continue
 
-            if selection_fn is not None and not selection_fn(rec):
+            if predicate_fn is not None and not predicate_fn(rec):
                 continue
 
             if start_date or end_date:
@@ -1665,14 +1665,14 @@ class Database:
         query.__doc__ = ""
     query.__doc__ += _QUERY_DOCSTRING
 
-    def query_one(self, query_spec, selection_fn=None, installed=True):
+    def query_one(self, query_spec, predicate_fn=None, installed=True):
         """Query for exactly one spec that matches the query spec.
 
         Raises an assertion error if more than one spec matches the
         query. Returns None if no installed package matches.
 
         """
-        concrete_specs = self.query(query_spec, selection_fn=selection_fn, installed=installed)
+        concrete_specs = self.query(query_spec, predicate_fn=predicate_fn, installed=installed)
         assert len(concrete_specs) <= 1
         return concrete_specs[0] if concrete_specs else None
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -601,7 +601,7 @@ class FailureTracker:
         return self.dir / f"{spec.name}-{spec.dag_hash()}"
 
 
-SelectType = Optional[Callable[[InstallRecord], bool]]
+SelectType = Callable[[InstallRecord], bool]
 
 
 class Database:
@@ -1526,7 +1526,7 @@ class Database:
     def _query(
         self,
         query_spec=any,
-        selection_fn: SelectType = None,
+        selection_fn: Optional[SelectType] = None,
         installed=True,
         explicit=any,
         start_date=None,

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -299,12 +299,9 @@ _QUERY_DOCSTRING = """
                 database.  If it is a spec, we'll evaluate
                 ``spec.satisfies(query_spec)``
 
-            known (bool or None): Specs that are "known" are those
-                for which Spack can locate a ``package.py`` file -- i.e.,
-                Spack "knows" how to install them.  Specs that are unknown may
-                represent packages that existed in a previous version of
-                Spack, but have since either changed their name or
-                been removed
+            selection_fn: optional predicate taking an InstallRecord as argument, and returning
+                whether that record is selected for the query. It can be used to craft criteria
+                that need some data for selection not provided by the Database itself.
 
             installed (bool or InstallStatus or typing.Iterable or None):
                 if ``True``, includes only installed
@@ -602,6 +599,9 @@ class FailureTracker:
         """Return the path to the spec's failure file, which may not exist."""
         assert spec.concrete, "concrete spec required for failure path"
         return self.dir / f"{spec.name}-{spec.dag_hash()}"
+
+
+SelectType = Optional[Callable[[InstallRecord], bool]]
 
 
 class Database:
@@ -1526,7 +1526,7 @@ class Database:
     def _query(
         self,
         query_spec=any,
-        known=any,
+        selection_fn: SelectType = None,
         installed=True,
         explicit=any,
         start_date=None,
@@ -1534,7 +1534,7 @@ class Database:
         hashes=None,
         in_buildcache=any,
         origin=None,
-    ):
+    ) -> List["spack.spec.Spec"]:
         """Run a query on the database."""
 
         # TODO: Specs are a lot like queries.  Should there be a
@@ -1580,7 +1580,7 @@ class Database:
             if explicit is not any and rec.explicit != explicit:
                 continue
 
-            if known is not any and known(rec.spec.name):
+            if selection_fn is not None and not selection_fn(rec):
                 continue
 
             if start_date or end_date:
@@ -1665,14 +1665,14 @@ class Database:
         query.__doc__ = ""
     query.__doc__ += _QUERY_DOCSTRING
 
-    def query_one(self, query_spec, known=any, installed=True):
+    def query_one(self, query_spec, selection_fn=None, installed=True):
         """Query for exactly one spec that matches the query spec.
 
         Raises an assertion error if more than one spec matches the
         query. Returns None if no installed package matches.
 
         """
-        concrete_specs = self.query(query_spec, known=known, installed=installed)
+        concrete_specs = self.query(query_spec, selection_fn=selection_fn, installed=installed)
         assert len(concrete_specs) <= 1
         return concrete_specs[0] if concrete_specs else None
 

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -70,10 +70,10 @@ def test_query_arguments():
 
     q_args = query_arguments(args)
     assert "installed" in q_args
-    assert "selection_fn" in q_args
+    assert "predicate_fn" in q_args
     assert "explicit" in q_args
     assert q_args["installed"] == ["installed"]
-    assert q_args["selection_fn"] is None
+    assert q_args["predicate_fn"] is None
     assert q_args["explicit"] is any
     assert "start_date" in q_args
     assert "end_date" not in q_args

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -70,10 +70,10 @@ def test_query_arguments():
 
     q_args = query_arguments(args)
     assert "installed" in q_args
-    assert "known" in q_args
+    assert "selection_fn" in q_args
     assert "explicit" in q_args
     assert q_args["installed"] == ["installed"]
-    assert q_args["known"] is any
+    assert q_args["selection_fn"] is None
     assert q_args["explicit"] is any
     assert "start_date" in q_args
     assert "end_date" not in q_args

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -1181,3 +1181,20 @@ def test_reindex_with_upstreams(tmp_path, monkeypatch, mock_packages, config):
     assert not reindexed_local_store.db.query_local("callpath")
     assert reindexed_local_store.db.query("callpath") == [callpath]
     assert reindexed_local_store.db.query_local("mpileaks") == [mpileaks]
+
+
+@pytest.mark.regression("47101")
+def test_query_with_selection_fn(database):
+    all_specs = database.query()
+
+    # Name starts with a string
+    specs = database.query(selection_fn=lambda x: x.spec.name.startswith("mpil"))
+    assert specs and all(x.name.startswith("mpil") for x in specs)
+    assert len(specs) < len(all_specs)
+
+    # Recipe is currently known/unknown
+    specs = database.query(selection_fn=lambda x: spack.repo.PATH.exists(x.spec.name))
+    assert specs == all_specs
+
+    specs = database.query(selection_fn=lambda x: not spack.repo.PATH.exists(x.spec.name))
+    assert not specs

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -1184,17 +1184,17 @@ def test_reindex_with_upstreams(tmp_path, monkeypatch, mock_packages, config):
 
 
 @pytest.mark.regression("47101")
-def test_query_with_selection_fn(database):
+def test_query_with_predicate_fn(database):
     all_specs = database.query()
 
     # Name starts with a string
-    specs = database.query(selection_fn=lambda x: x.spec.name.startswith("mpil"))
+    specs = database.query(predicate_fn=lambda x: x.spec.name.startswith("mpil"))
     assert specs and all(x.name.startswith("mpil") for x in specs)
     assert len(specs) < len(all_specs)
 
     # Recipe is currently known/unknown
-    specs = database.query(selection_fn=lambda x: spack.repo.PATH.exists(x.spec.name))
+    specs = database.query(predicate_fn=lambda x: spack.repo.PATH.exists(x.spec.name))
     assert specs == all_specs
 
-    specs = database.query(selection_fn=lambda x: not spack.repo.PATH.exists(x.spec.name))
+    specs = database.query(predicate_fn=lambda x: not spack.repo.PATH.exists(x.spec.name))
     assert not specs


### PR DESCRIPTION
fixes #47101

The bug was introduced in #33495, where `spack find` was not updated, and wasn't caught by unit tests.

Modifications:
- Now a Database can accept a custom predicate to select the installation records. 
- A unit test is added to prevent regressions. 
- The weird convention of having `any` as a default value has been replaced by the more commonly used `None` value.

We can follow with a PR adding type hints, but would like to keep this fix minimal in terms of LoC changed.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
