### PR TITLE
modules/common.py: format_path instead of format

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -527,9 +527,7 @@ class BaseFileLayout:
         parts = name.split("/")
         name = os.path.join(*parts)
         # Add optional suffixes based on constraints
-        path_elements = [name]
-        path_elements.extend(map(self.spec.format, self.conf.suffixes))
-        return "-".join(path_elements)
+        return "-".join([name, *map(self.spec.format_path, self.conf.suffixes)])
 
     @property
     def filename(self):


### PR DESCRIPTION
`format_path` ensures that `/` is mapped to `_` which can happen in `{version}`
format strings.

