### PR TITLE
docs search: rank api lowest and generated commands low

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,3 +14,9 @@ sphinx:
 python:
   install:
     - requirements: lib/spack/docs/requirements.txt
+
+search:
+  ranking:
+    spack.html: -10
+    llnl.html: -10
+    command_index.html: -9


### PR DESCRIPTION
The content of spack.html/llnl.html makes search on read the docs almost useless