### PR TITLE
Restore bold uncolored font face

### DIFF
--- a/lib/spack/llnl/util/tty/color.py
+++ b/lib/spack/llnl/util/tty/color.py
@@ -263,11 +263,9 @@ def colorize(
                 f"Incomplete color format: '{match.group(0)}' in '{match.string}'"
             )
 
-        color_number_str = ""
-        color_number = colors.get(color_code)
-        if color_number:
-            color_number_str = f";{color_number}"
-        ansi_code = _escape(f"{styles[style]}{color_number_str}", color, enclose, zsh)
+        color_number = colors.get(color_code, "")
+        semi = ";" if color_number else ""
+        ansi_code = _escape(f"{styles[style]}{semi}{color_number}", color, enclose, zsh)
         if text:
             return f"{ansi_code}{text}{_escape(0, color, enclose, zsh)}"
         else:

--- a/lib/spack/llnl/util/tty/color.py
+++ b/lib/spack/llnl/util/tty/color.py
@@ -263,7 +263,11 @@ def colorize(
                 f"Incomplete color format: '{match.group(0)}' in '{match.string}'"
             )
 
-        ansi_code = _escape(f"{styles[style]};{colors.get(color_code, '')}", color, enclose, zsh)
+        color_number_str = ""
+        color_number = colors.get(color_code)
+        if color_number:
+            color_number_str = f";{color_number}"
+        ansi_code = _escape(f"{styles[style]}{color_number_str}", color, enclose, zsh)
         if text:
             return f"{ansi_code}{text}{_escape(0, color, enclose, zsh)}"
         else:


### PR DESCRIPTION
Commit https://github.com/spack/spack/commit/aa0825d642cfa285f5f62761a0e23dc1e511d056 accidentally added a semicolon to the ANSI escape sequence even if the color code was `None` or unknown, breaking the bold, uncolored font-face.  This PR restores the old behavior.