### PR TITLE
fix unzip%nvhpc

### DIFF
--- a/var/spack/repos/builtin/packages/unzip/package.py
+++ b/var/spack/repos/builtin/packages/unzip/package.py
@@ -28,8 +28,9 @@ class Unzip(MakefilePackage):
         make_args = ["-f", join_path("unix", "Makefile")]
 
         cflags = []
-        cflags.append("-Wno-error=implicit-function-declaration")
-        cflags.append("-Wno-error=implicit-int")
+        if not self.spec.satisfies("%nvhpc"):
+            cflags.append("-Wno-error=implicit-function-declaration")
+            cflags.append("-Wno-error=implicit-int")
         cflags.append("-DLARGE_FILE_SUPPORT")
 
         make_args.append(f"LOC={' '.join(cflags)}")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
fixes the following issue:
```
==> unzip: Executing phase: 'edit'
==> unzip: Executing phase: 'build'
==> [2024-10-21-11:16:29.209670] '/leonardo/prod/spack/5.2/install/0.21/linux-rhel8-icelake/gcc-8.5.0/gmake-4.4.1-ihyrzlce36p5wcnhiqsnrwrlp2ksie7i/bin/make' '-j20' '-f' 'unix/Makefile' 'LOC=-Wno-error=implicit-function-declaration -Wno-error=implicit-int -DLARGE_FILE_SUPPORT' 'generic'
sh unix/configure "cc" "-I. -Ibzip2 -DUNIX -Wno-error=implicit-function-declaration -Wno-error=implicit-int -DLARGE_FILE_SUPPORT" "bzip2"
Check C compiler operation
nvc-Error-Switch -Wno-error=implicit-function-declaration allows no arguments

nvc-Error-Switch -Wno-error=implicit-int allows no arguments


C compiler "cc" does not work as expected.
Failing command was: cc -I. -Ibzip2 -DUNIX -Wno-error=implicit-function-declaration -Wno-error=implicit-int -DLARGE_FILE_SUPPORT -I. -DUNIX -c conftest.c
make: *** [unix/Makefile:470: flags] Error 1
```