### PR TITLE
docs: do not promote build_systems/* at all

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -37,5 +37,3 @@ search:
     chain.html: 5
     pipelines.html: 5
     packaging_guide.html: 5
-    build_systems.html: 4
-    build_systems/*: 4


### PR DESCRIPTION
They still interfere with very basic search queries