### PR TITLE
kokkos: minor fix for kokkos+rocm standalone test

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -414,7 +414,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         cmake = self.spec["cmake"].command
         cmake_args = ["-DEXECUTABLE_OUTPUT_PATH=" + cmake_path]
         if self.spec.satisfies("+rocm"):
-            prefix_paths = ";".join(spack.build_environment.get_cmake_prefix_path(self))
+            prefix_paths = ";".join(spack.build_systems.cmake.get_cmake_prefix_path(self))
             cmake_args.append("-DCMAKE_PREFIX_PATH={0}".format(prefix_paths))
 
         cmake(cmake_path, *cmake_args)


### PR DESCRIPTION
I added `spack.build_environment.get_cmake_prefix_path` for the +rocm test in: https://github.com/spack/spack/pull/46779. 
The location of get_cmake_prefix_path was changed to `spack.build_systems.cmake.get_cmake_prefix_path` after https://github.com/spack/spack/pull/46685
