### PR TITLE
libvdwxc: fix broken patch

### DIFF
--- a/var/spack/repos/builtin/packages/libvdwxc/package.py
+++ b/var/spack/repos/builtin/packages/libvdwxc/package.py
@@ -56,10 +56,8 @@ class Libvdwxc(AutotoolsPackage):
         return args
 
     # misuse of fftw_plan in m4 for fftw detection (configure fails with gcc 14)
-    # two patches for (1) m4 macro from upstream and (2) pre-generated configure in tarball
-    patch(
-        "https://gitlab.com/libvdwxc/libvdwxc/-/commit/9340f857515c4a2e56d2aa7cf3a21c41ba8559c3.diff",
-        sha256="b9ad695e54a25d7ffa92f783bb0a31d3b421225f97958972e32ba42893844b80",
-        when="@:0.4.0",
-    )
+    # Only the configure script is patched, NOT the m4 macro (to avoid depending on aclocal),
+    # so running autoreconf is not supported.
+    # The relevant upstream fix for the m4 would be:
+    # https://gitlab.com/libvdwxc/libvdwxc/-/commit/9340f857515c4a2e56d2aa7cf3a21c41ba8559c3.diff
     patch("fftw-detection.patch", when="@:0.4.0")


### PR DESCRIPTION
This MR is a follow-up of #45093, which introduced fixes for the FFTW m4 macro (wrong datatype, incompatilbe with GCC 14). The MR introduced two patches: one for the configure script (required) and one for the m4 macro (optional, because Spack skips autoreconf if the configure script is present).

The optional patch of the m4 macro does however break the configure step: the changes in the macro are detected and configure fails with the following message:

```
/TMP/stage/spack-stage-libvdwxc-0.4.0-ss5roq4262uoyn3hz4hiyedziowj3vqy/spack-src/config/gnu/missing: line 81: aclocal-1.15: command no
t found
>> 177    WARNING: 'aclocal-1.15' is missing on your system.
178             You should only need it if you modified 'acinclude.m4' or
179             'configure.ac' or m4 files included by 'configure.ac'.
180             The 'aclocal' program is part of the GNU Automake package:
181             <http://www.gnu.org/software/automake>
182             It also requires GNU Autoconf, GNU m4 and Perl in order to run:
183             <http://www.gnu.org/software/autoconf>
184             <http://www.gnu.org/software/m4/>
185             <http://www.perl.org/>
>> 186    make: *** [Makefile:486: aclocal.m4] Error 127
```

This MR removes the optional patch of the m4 macro.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
