### PR TITLE
hdf5: disable _Float16 support for aocc

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -578,7 +578,7 @@ class Hdf5(CMakePackage):
 
         # AOCC does not support _Float16
         if spec.satisfies("@1.14.4: %aocc"):
-            args.append(self.define("HDF5_ENABLE_NONSTANDARD_FEATURE_FLOAT16", "OFF"))
+            args.append(self.define("HDF5_ENABLE_NONSTANDARD_FEATURE_FLOAT16", False))
 
         return args
 

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -576,6 +576,10 @@ class Hdf5(CMakePackage):
         if spec.satisfies("@1.10.8,1.13.0"):
             args.append(self.define("HDF5_INSTALL_CMAKE_DIR", "share/cmake/hdf5"))
 
+        # AOCC does not support _Float16
+        if spec.satisfies("@1.14.4: %aocc"):
+            args.append(self.define("HDF5_ENABLE_NONSTANDARD_FEATURE_FLOAT16", "OFF"))
+
         return args
 
     @run_after("install")


### PR DESCRIPTION
This PR disables the `CMake` option `HDF5_ENABLE_NONSTANDARD_FEATURE_FLOAT16` for `AOCC` (introduced in `HDF5-1.14.4`) from the Spack recipe. This change is required since `AOCC` currently does not fully support the `_Float16` type, leaving this option on (the default behavior) may generate library files with unresolved symbols, breaking other packages depending on `HDF5`.
