### PR TITLE
dire: Update Boost dependency

### DIFF
--- a/var/spack/repos/builtin/packages/dire/package.py
+++ b/var/spack/repos/builtin/packages/dire/package.py
@@ -27,10 +27,6 @@ class Dire(Package):
 
     depends_on("zlib-api")
 
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
     depends_on("lhapdf")
     depends_on("hepmc")
     depends_on("pythia8@8.226:")

--- a/var/spack/repos/builtin/packages/dire/package.py
+++ b/var/spack/repos/builtin/packages/dire/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Dire(Package):


### PR DESCRIPTION
The only version currently available is 2.004, and it does not use Boost.