### PR TITLE
Remove spurious warning, introduced in #46992

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1061,8 +1061,8 @@ class SetupContext:
                 pkg.setup_dependent_package(dependent_module, spec)
                 dependent_module.propagate_changes_to_mro()
 
-        pkg = self.specs[0].package
         if self.context == Context.BUILD:
+            pkg = self.specs[0].package
             module = ModuleChangePropagator(pkg)
             # std_cmake_args is not sufficiently static to be defined
             # in set_package_py_globals and is deprecated so its handled


### PR DESCRIPTION
fixes #47135

Retrieving the package must be protected by:
```python
if self.context == Context.BUILD:
```
since in that case we are ensured by construction that one and only one spec is in the list:

https://github.com/spack/spack/blob/50aa5a7b249da2105d7601a3af4fb6e8a6de6844/lib/spack/spack/build_environment.py#L1004-L1005
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
