### PR TITLE
neartree: added version 5.1.1, added Makefile patches to fix libtool error

### DIFF
--- a/var/spack/repos/builtin/packages/neartree/Makefile-3.1.patch
+++ b/var/spack/repos/builtin/packages/neartree/Makefile-3.1.patch
@@ -1,0 +1,23 @@
+--- a/Makefile
++++ b/Makefile
+@@ -114,13 +114,13 @@ CPPLIBRARIES = -lm
+ #
+ CLIBRARIES = $(CVECTOR_LIBLOC) -lCVector -lm
+ 
+-COMPILE_COMMAND        =  $(LIBTOOL) --mode=compile $(CC) $(CFLAGS) $(INCLUDES) $(WARNINGS) -c
+-CPPCOMPILE_COMMAND     =  $(LIBTOOL) --mode=compile $(CXX) $(CFLAGS) $(INCLUDES) $(WARNINGS) -c
+-LIBRARY_LINK_COMMAND   =  $(LIBTOOL) --mode=link $(CC) -version-info $(VERSION) -no-undefined -rpath $(INSTALL_PREFIX)/lib
+-BUILD_COMMAND_LOCAL    =  $(LIBTOOL) --mode=link $(CC) $(CFLAGS) $(INCLUDES)
+-CPPBUILD_COMMAND_LOCAL =  $(LIBTOOL) --mode=link $(CXX) -no-undefined $(CFLAGS) $(INCLUDES)
+-BUILD_COMMAND_DYNAMIC  =  $(LIBTOOL) --mode=link $(CC) -no-undefined $(CFLAGS) -shared -I$(INSTALL_PREFIX)/include
+-BUILD_COMMAND_STATIC   =  $(LIBTOOL) --mode=link $(CC) $(CFLAGS) -static-libtool-libs -I$(INSTALL_PREFIX)/include
++COMPILE_COMMAND        =  $(LIBTOOL) --mode=compile --tag=CC $(CC) $(CFLAGS) $(INCLUDES) $(WARNINGS) -c
++CPPCOMPILE_COMMAND     =  $(LIBTOOL) --mode=compile --tag=CXX $(CXX) $(CFLAGS) $(INCLUDES) $(WARNINGS) -c
++LIBRARY_LINK_COMMAND   =  $(LIBTOOL) --mode=link --tag=CC $(CC) -version-info $(VERSION) -no-undefined -rpath $(INSTALL_PREFIX)/lib
++BUILD_COMMAND_LOCAL    =  $(LIBTOOL) --mode=link --tag=CC $(CC) $(CFLAGS) $(INCLUDES)
++CPPBUILD_COMMAND_LOCAL =  $(LIBTOOL) --mode=link --tag=CXX $(CXX) -no-undefined $(CFLAGS) $(INCLUDES)
++BUILD_COMMAND_DYNAMIC  =  $(LIBTOOL) --mode=link --tag=CC $(CC) -no-undefined $(CFLAGS) -shared -I$(INSTALL_PREFIX)/include
++BUILD_COMMAND_STATIC   =  $(LIBTOOL) --mode=link --tag=CC $(CC) $(CFLAGS) -static-libtool-libs -I$(INSTALL_PREFIX)/include
+ INSTALL_COMMAND        =  $(LIBTOOL) --mode=install cp
+ INSTALL_FINISH_COMMAND =  $(LIBTOOL) --mode=finish
+ 

--- a/var/spack/repos/builtin/packages/neartree/Makefile.patch
+++ b/var/spack/repos/builtin/packages/neartree/Makefile.patch
@@ -1,0 +1,23 @@
+--- a/Makefile
++++ b/Makefile
+@@ -117,13 +117,13 @@ CPPLIBRARIES = -lm
+ #
+ CLIBRARIES = $(CVECTOR_LIBLOC) -lCVector -lm
+ 
+-COMPILE_COMMAND        =  $(LIBTOOL) --mode=compile $(CC) $(CFLAGS) $(INCLUDES) $(WARNINGS) -c
+-CPPCOMPILE_COMMAND     =  $(LIBTOOL) --mode=compile $(CXX) $(CFLAGS) $(INCLUDES) $(WARNINGS) -c
+-LIBRARY_LINK_COMMAND   =  $(LIBTOOL) --mode=link $(CC) -version-info $(VERSION) -no-undefined -rpath $(INSTALL_PREFIX)/lib
+-BUILD_COMMAND_LOCAL    =  $(LIBTOOL) --mode=link $(CC) $(CFLAGS) $(INCLUDES)
+-CPPBUILD_COMMAND_LOCAL =  $(LIBTOOL) --mode=link $(CXX) -no-undefined $(CFLAGS) $(INCLUDES)
+-BUILD_COMMAND_DYNAMIC  =  $(LIBTOOL) --mode=link $(CC) -no-undefined $(CFLAGS) -shared -I$(INSTALL_PREFIX)/include
+-BUILD_COMMAND_STATIC   =  $(LIBTOOL) --mode=link $(CC) $(CFLAGS) -static-libtool-libs -I$(INSTALL_PREFIX)/include
++COMPILE_COMMAND        =  $(LIBTOOL) --mode=compile --tag=CC $(CC) $(CFLAGS) $(INCLUDES) $(WARNINGS) -c
++CPPCOMPILE_COMMAND     =  $(LIBTOOL) --mode=compile --tag=CXX $(CXX) $(CFLAGS) $(INCLUDES) $(WARNINGS) -c
++LIBRARY_LINK_COMMAND   =  $(LIBTOOL) --mode=link --tag=CC $(CC) -version-info $(VERSION) -no-undefined -rpath $(INSTALL_PREFIX)/lib
++BUILD_COMMAND_LOCAL    =  $(LIBTOOL) --mode=link --tag=CC $(CC) $(CFLAGS) $(INCLUDES)
++CPPBUILD_COMMAND_LOCAL =  $(LIBTOOL) --mode=link --tag=CXX $(CXX) -no-undefined $(CFLAGS) $(INCLUDES)
++BUILD_COMMAND_DYNAMIC  =  $(LIBTOOL) --mode=link --tag=CC $(CC) -no-undefined $(CFLAGS) -shared -I$(INSTALL_PREFIX)/include
++BUILD_COMMAND_STATIC   =  $(LIBTOOL) --mode=link --tag=CC $(CC) $(CFLAGS) -static-libtool-libs -I$(INSTALL_PREFIX)/include
+ INSTALL_COMMAND        =  $(LIBTOOL) --mode=install cp
+ INSTALL_FINISH_COMMAND =  $(LIBTOOL) --mode=finish
+ 

--- a/var/spack/repos/builtin/packages/neartree/package.py
+++ b/var/spack/repos/builtin/packages/neartree/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 from spack.package import *
 
 
@@ -11,10 +13,10 @@ class Neartree(MakefilePackage):
     points in spaces of arbitrary dimensions."""
 
     homepage = "https://neartree.sourceforge.net/"
-    url = "https://downloads.sourceforge.net/project/neartree/neartree/NearTree-3.1/NearTree-3.1.tar.gz"
 
     license("LGPL-2.1-or-later")
 
+    version("5.1.1", sha256="b951eb23bb4235ada82cef85b9f129bf74a14e45d992097431e7bfb6bdca6642")
     version("3.1", sha256="07b668516f15a7c13c219fd005b14e73bced5dc6b23857edcc24d3e5cf0d3be3")
 
     depends_on("c", type="build")  # generated
@@ -22,6 +24,15 @@ class Neartree(MakefilePackage):
 
     depends_on("libtool", type="build")
     depends_on("cvector")
+
+    patch("Makefile.patch", when="@5.1.1")
+    patch("Makefile-3.1.patch", when="@3.1")
+
+    def url_for_version(self, version):
+        pattern = re.compile(r"^[0-9]+\.[0-9]+")
+        full_vers = str(version)
+        cropped_vers = pattern.search(full_vers).group()
+        return f"https://downloads.sourceforge.net/project/neartree/neartree/NearTree-{cropped_vers}/NearTree-{full_vers}.tar.gz"
 
     def edit(self, spec, prefix):
         mf = FileFilter("Makefile")


### PR DESCRIPTION
PR #47154 should be merged first, as cvector is a dependency.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
