### PR TITLE
py-asdf: add 3.5.0, and update py-asdf-standard to match

### DIFF
--- a/var/spack/repos/builtin/packages/py-asdf-standard/package.py
+++ b/var/spack/repos/builtin/packages/py-asdf-standard/package.py
@@ -16,11 +16,17 @@ class PyAsdfStandard(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("1.1.1", sha256="01535bc2b15bfc09ec8a62d4999f9cf32dc49dc71660c8425640228fd8776102")
     version("1.0.3", sha256="afd8ff9a70e7b17f6bcc64eb92a544867d5d4fe1f0076719142fdf62b96cfd44")
+
+    with when("@1.1.1:"):
+        depends_on("python@3.9:", type=("build", "run"))
+
+        depends_on("py-setuptools@61:", type="build")
 
     depends_on("python@3.8:", type=("build", "run"))
 
     depends_on("py-setuptools@42:", type="build")
     depends_on("py-setuptools-scm@3.4: +toml", type="build")
 
-    depends_on("py-importlib-resources@3:", type=("build", "run"), when="^python@:3.8")
+    depends_on("py-importlib-resources@3:", type=("build", "run"), when="@1.0.3 ^python@:3.8")

--- a/var/spack/repos/builtin/packages/py-asdf/package.py
+++ b/var/spack/repos/builtin/packages/py-asdf/package.py
@@ -48,7 +48,7 @@ class PyAsdf(PythonPackage):
         depends_on("py-pyyaml@5.4.1:", type=("build", "run"))
         depends_on("py-semantic-version@2.8:", type=("build", "run"))
 
-    with when('@2.15.0'):
+    with when("@2.15.0"):
         depends_on("py-asdf-unit-schemas@0.1:", type=("build", "run"))
         depends_on("py-importlib-metadata@4.11.4:", type=("build", "run"))
         depends_on("py-importlib-resources@3:", type=("build", "run"), when="^python@:3.8")

--- a/var/spack/repos/builtin/packages/py-asdf/package.py
+++ b/var/spack/repos/builtin/packages/py-asdf/package.py
@@ -18,6 +18,7 @@ class PyAsdf(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("3.5.0", sha256="047ad7bdd8f40b04b8625abfd119a35d18b344301c60ea9ddf63964e7ce19669")
     version("2.15.0", sha256="686f1c91ebf987d41f915cfb6aa70940d7ad17f87ede0be70463147ad2314587")
     version("2.4.2", sha256="6ff3557190c6a33781dae3fd635a8edf0fa0c24c6aca27d8679af36408ea8ff2")
 
@@ -25,7 +26,15 @@ class PyAsdf(PythonPackage):
 
     depends_on("py-lz4@0.10:", when="+lz4", type=("build", "run"))
 
-    with when("@2.15:"):
+    with when("@3.5.0:"):
+        depends_on("python@3.9:", type=("build", "run"))
+
+        depends_on("py-asdf-standard@1.1.0:", type=("build", "run"))
+        depends_on("py-importlib-metadata@4.11.4:", type=("build", "run"), when="^python@:3.11")
+        depends_on("py-numpy@1.22:", type=("build", "run"))
+        depends_on("py-attrs@22.2.0:", type=("build", "run"))
+
+    with when("@2.15.0:"):
         depends_on("python@3.8:", type=("build", "run"))
 
         depends_on("py-setuptools@60:", type="build")
@@ -33,16 +42,18 @@ class PyAsdf(PythonPackage):
 
         depends_on("py-asdf-standard@1.0.1:", type=("build", "run"))
         depends_on("py-asdf-transform-schemas@0.3:", type=("build", "run"))
-        depends_on("py-asdf-unit-schemas@0.1:", type=("build", "run"))
-        depends_on("py-importlib-metadata@4.11.4:", type=("build", "run"))
-        depends_on("py-importlib-resources@3:", type=("build", "run"), when="^python@:3.8")
         depends_on("py-jmespath@0.6.2:", type=("build", "run"))
-        depends_on("py-jsonschema@4.0.1:4.17", type=("build", "run"))
         depends_on("py-numpy@1.20:", type=("build", "run"))
-        depends_on("py-numpy@1.20:1.24", type=("build", "run"), when="^python@:3.8")
         depends_on("py-packaging@19:", type=("build", "run"))
         depends_on("py-pyyaml@5.4.1:", type=("build", "run"))
         depends_on("py-semantic-version@2.8:", type=("build", "run"))
+
+    with when('@2.15.0'):
+        depends_on("py-asdf-unit-schemas@0.1:", type=("build", "run"))
+        depends_on("py-importlib-metadata@4.11.4:", type=("build", "run"))
+        depends_on("py-importlib-resources@3:", type=("build", "run"), when="^python@:3.8")
+        depends_on("py-jsonschema@4.0.1:4.17", type=("build", "run"))
+        depends_on("py-numpy@1.20:1.24", type=("build", "run"), when="^python@:3.8")
 
     with when("@2.4.2"):
         depends_on("python@3.3:", type=("build", "run"))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This is a relatively straightforward update that adds the latest version of `asdf` and updates the dependencies according to the `pyproject.toml`. The helper `asdf-standard` package is also updated.