### PR TITLE
mypy: work around typing issues with `functools.partial`

### DIFF
--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -51,7 +51,7 @@ __all__ = ["FilesystemView", "YamlFilesystemView"]
 _projections_path = ".spack/projections.yaml"
 
 
-LinkCallbackType = Callable[[str, str, "FilesystemView", Optional["spack.spec.Spec"]], None]
+LinkCallbackType = Callable[[str, str, "FilesystemView", Optional[spack.spec.Spec]], None]
 
 
 def view_symlink(src: str, dst: str, *args, **kwargs) -> None:
@@ -63,7 +63,7 @@ def view_hardlink(src: str, dst: str, *args, **kwargs) -> None:
 
 
 def view_copy(
-    src: str, dst: str, view: "FilesystemView", spec: Optional["spack.spec.Spec"] = None
+    src: str, dst: str, view: "FilesystemView", spec: Optional[spack.spec.Spec] = None
 ) -> None:
     """
     Copy a file from src to dst.
@@ -185,7 +185,7 @@ class FilesystemView:
         self.link_type = link_type
         self._link = function_for_link_type(link_type)
 
-    def link(self, src: str, dst: str, spec: Optional["spack.spec.Spec"] = None) -> None:
+    def link(self, src: str, dst: str, spec: Optional[spack.spec.Spec] = None) -> None:
         self._link(src, dst, self, spec)
 
     def add_specs(self, *specs, **kwargs):

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -33,6 +33,7 @@ from llnl.util.symlink import symlink
 from llnl.util.tty.color import colorize
 
 import spack.config
+import spack.directory_layout
 import spack.paths
 import spack.projections
 import spack.relocate
@@ -156,15 +157,6 @@ class FilesystemView:
     This can be circumvented by loading all needed modules into a common
     directory structure.
     """
-
-    layout: "spack.directory_layout.DirectoryLayout"
-    projections: Dict
-    ignore_conflicts: bool
-    verbose: bool
-    link_type: str
-
-    _root: str
-    _link: LinkCallbackType
 
     def __init__(
         self,

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -157,6 +157,15 @@ class FilesystemView:
     directory structure.
     """
 
+    layout: "spack.directory_layout.DirectoryLayout"
+    projections: Dict
+    ignore_conflicts: bool
+    verbose: bool
+    link_type: str
+
+    _root: str
+    _link: LinkCallbackType
+
     def __init__(
         self,
         root: str,
@@ -182,7 +191,10 @@ class FilesystemView:
 
         # Setup link function to include view
         self.link_type = link_type
-        self.link = ft.partial(function_for_link_type(link_type), view=self)
+        self._link = function_for_link_type(link_type)
+
+    def link(self, src: str, dst: str, spec: Optional["spack.spec.Spec"] = None) -> None:
+        self._link(src, dst, self, spec)
 
     def add_specs(self, *specs, **kwargs):
         """

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -161,7 +161,7 @@ class FilesystemView:
     def __init__(
         self,
         root: str,
-        layout: "spack.directory_layout.DirectoryLayout",
+        layout: spack.directory_layout.DirectoryLayout,
         *,
         projections: Optional[Dict] = None,
         ignore_conflicts: bool = False,
@@ -287,7 +287,7 @@ class YamlFilesystemView(FilesystemView):
     def __init__(
         self,
         root: str,
-        layout: "spack.directory_layout.DirectoryLayout",
+        layout: spack.directory_layout.DirectoryLayout,
         *,
         projections: Optional[Dict] = None,
         ignore_conflicts: bool = False,


### PR DESCRIPTION
Typing for link functions is weird, and `mypy` has issues with the typing of `functools.partial`. Combine the two and we get weird errors like this with newer versions of mypy:

```
lib/spack/spack/filesystem_view.py:183: error: Unexpected keyword argument "view"  [call-arg]
```

This works around the issue by replacing the problematic partial call with a wrapper instance method on `FileSystemView`.

This will enable us to merge #45533 and #45534.