### PR TITLE
acfl, armpl-cc: add v24.10

### DIFF
--- a/var/spack/repos/builtin/packages/acfl/package.py
+++ b/var/spack/repos/builtin/packages/acfl/package.py
@@ -241,10 +241,10 @@ def get_os(ver):
     if ver.startswith("22"):
         return _os_map_before_23.get(spack_os, "")
     if ver.startswith("23") or ver == "24.04":
-        return {**_os_map, "centos7": "RHEL-7", "rhel7": "RHEL-7"}.get(spack_os, "")
+        return {**_os_map, "centos7": "RHEL-7", "rhel7": "RHEL-7"}.get(spack_os, "RHEL-7")
     if ver == "24.10":
-        return _os_map.get(spack_os, "")
-    return "Unknown-OS"
+        return _os_map.get(spack_os, "RHEL-8")
+    return "RHEL-8"
 
 
 def get_armpl_version_to_3(spec):
@@ -297,7 +297,6 @@ class Acfl(Package, CompilerPackage):
     """
 
     homepage = "https://developer.arm.com/Tools%20and%20Software/Arm%20Compiler%20for%20Linux"
-    url = "https://developer.arm.com/-/cdn-downloads/permalink/Arm-Compiler-for-Linux/Version_24.10/arm-compiler-for-linux_24.10_Ubuntu-20.04_aarch64.tar"
 
     maintainers("paolotricerri")
 

--- a/var/spack/repos/builtin/packages/armpl-gcc/package.py
+++ b/var/spack/repos/builtin/packages/armpl-gcc/package.py
@@ -341,8 +341,6 @@ class ArmplGcc(Package):
     high-performance computing applications on Arm processors."""
 
     homepage = "https://developer.arm.com/tools-and-software/server-and-hpc/downloads/arm-performance-libraries"
-    url = "https://developer.arm.com/-/media/Files/downloads/hpc/arm-performance-libraries/24-04/linux/arm-performance-libraries_24.04_deb_gcc.tar"
-
     maintainers("paolotricerri")
 
     for ver, packages in _versions.items():

--- a/var/spack/repos/builtin/packages/armpl-gcc/package.py
+++ b/var/spack/repos/builtin/packages/armpl-gcc/package.py
@@ -54,6 +54,11 @@ _os_pkg_map = {
 }
 
 _versions = {
+    "24.10": {
+        "deb": ("2be772d41c0e8646e24c4f57e188e96f2dd8934966ae560c74fa905cbde5e1bc"),
+        "macOS": ("04e794409867e6042ed0f487bbaf47cc6edd527dc6ddad67160f1dba83906969"),
+        "rpm": ("055d4b3c63d990942d453a8720d029be7e604646218ffc3262321683f51f23aa"),
+    },
     "24.04": {
         "deb": ("a323074cd08af82f4d79988cc66088b18e47dea4b93323b1b8a0f994f769f2f0"),
         "macOS": ("228bf3a2c25dbd45c2f89c78f455ee3c7dfb25e121c20d2765138b5174e688dc"),
@@ -261,7 +266,8 @@ def get_os_or_pkg_manager(ver):
         return _os_pkg_map.get(platform.default_os, "rpm")
 
 
-def get_package_url_before_24(base_url, version):
+def get_package_url_before_24(version):
+    base_url = "https://developer.arm.com/-/media/Files/downloads/hpc/arm-performance-libraries"
     armpl_version = version.split("_")[0]
     armpl_version_dashed = armpl_version.replace(".", "-")
     compiler_version = version.split("_", 1)[1]
@@ -270,7 +276,7 @@ def get_package_url_before_24(base_url, version):
         if armpl_version.startswith("23.06"):
             return (
                 f"{base_url}/{armpl_version_dashed}/"
-                + f"armpl_{armpl_version}_{compiler_version}.dmg"
+                f"armpl_{armpl_version}_{compiler_version}.dmg"
             )
         else:
             filename = f"arm-performance-libraries_{armpl_version}_macOS.dmg"
@@ -286,9 +292,11 @@ def get_package_url_before_24(base_url, version):
     return f"{base_url}/{armpl_version_dashed}/{os_short}/{filename}"
 
 
-def get_package_url_from_24(base, version):
+def get_package_url_from_24(version):
+    base_url = (
+        "https://developer.arm.com/-/cdn-downloads/permalink/Arm-Performance-Libraries/Version"
+    )
     pkg_system = get_os_or_pkg_manager(version)
-    os = "macOS" if pkg_system == "macOS" else "linux"
 
     extension = "tgz" if pkg_system == "macOS" else "tar"
 
@@ -298,17 +306,15 @@ def get_package_url_from_24(base, version):
         full_name_library = f"{full_name_library}_gcc"
     file_name = f"{full_name_library}.{extension}"
 
-    vn = version.replace(".", "-")
-    url_parts = f"{base}/{vn}/{os}/{file_name}"
+    url_parts = f"{base_url}_{version}/{file_name}"
     return url_parts
 
 
 def get_package_url(version):
-    base_url = "https://developer.arm.com/-/media/Files/downloads/hpc/arm-performance-libraries"
     if version[:2] >= "24":
-        return get_package_url_from_24(base_url, version)
+        return get_package_url_from_24(version)
     else:
-        return get_package_url_before_24(base_url, version)
+        return get_package_url_before_24(version)
 
 
 def get_armpl_prefix(spec):
@@ -434,7 +440,7 @@ class ArmplGcc(Package):
 
         exe = Executable(
             f"./arm-performance-libraries_{armpl_version}_"
-            + f"{get_os_or_pkg_manager(armpl_version)}.sh"
+            f"{get_os_or_pkg_manager(armpl_version)}.sh"
         )
         exe("--accept", "--force", "--install-to", prefix)
 


### PR DESCRIPTION
This patch introduces the possibility of installing armpl-gcc and acfl 24.10 through spack. It also addressed one issue observed after PR https://github.com/spack/spack/pull/46594

CC: @dslarm 

@spackbot fix style

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
