### PR TITLE
verilator: fix builds when using gcc on newer versions

### DIFF
--- a/var/spack/repos/builtin/packages/verilator/fix_compile_gch.patch
+++ b/var/spack/repos/builtin/packages/verilator/fix_compile_gch.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Makefile_obj.in b/src/Makefile_obj.in
+index 18947923a..d29baa840 100644
+--- a/src/Makefile_obj.in
++++ b/src/Makefile_obj.in
+@@ -363,7 +363,7 @@ $(TGT): $(PREDEP_H) $(OBJS)
+ .SECONDARY:
+ 
+ %.gch: %
+-	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSWALL} ${CFG_CXXFLAGS_PCH} $< -o $@
++	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSWALL} ${CFG_CXXFLAGS_PCH} -c $< -o $@
+ %.o: %.cpp
+ 	$(OBJCACHE) ${CXX} ${CXXFLAGS} ${CPPFLAGSWALL} -c $< -o $@
+ %.o: %.c

--- a/var/spack/repos/builtin/packages/verilator/package.py
+++ b/var/spack/repos/builtin/packages/verilator/package.py
@@ -87,6 +87,8 @@ class Verilator(AutotoolsPackage):
 
     conflicts("%gcc@:6", msg="C++14 support required")
 
+    patch("fix_compile_gch.patch", level=1, when="@5.0.18:")
+
     # we need to fix the CXX and LINK paths, as they point to the spack
     # wrapper scripts which aren't usable without spack
     filter_compiler_wrappers("verilated.mk", relative_root="include")

--- a/var/spack/repos/builtin/packages/verilator/package.py
+++ b/var/spack/repos/builtin/packages/verilator/package.py
@@ -42,6 +42,7 @@ class Verilator(AutotoolsPackage):
 
     version("master", branch="master")
 
+    version("5.028", sha256="02d4b6f34754b46a97cfd70f5fcbc9b730bd1f0a24c3fc37223397778fcb142c")
     version("5.026", sha256="87fdecf3967007d9ee8c30191ff2476f2a33635d0e0c6e3dbf345cc2f0c50b78")
     version("5.024", sha256="88b04c953e7165c670d6a700f202cef99c746a0867b4e2efe1d7ea789dee35f3")
     version("5.022", sha256="3c2f5338f4b6ce7e2f47a142401acdd18cbf4c5da06092618d6d036c0afef12d")


### PR DESCRIPTION
We hit issue #8640 when trying to build `verilator` (adding the current version and introducing variants is unrelated to the build error → I can split it out); adapting the solution proposed in PR #8853 helped for this case.