### PR TITLE
py-parso: new version and fix forward compat bounds

### DIFF
--- a/var/spack/repos/builtin/packages/py-parso/package.py
+++ b/var/spack/repos/builtin/packages/py-parso/package.py
@@ -16,6 +16,7 @@ class PyParso(PythonPackage):
 
     license("MIT")
 
+    version("0.8.4", sha256="eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d")
     version("0.8.3", sha256="8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0")
     version("0.8.2", sha256="12b83492c6239ce32ff5eed6d3639d6a536170723c6f3f1506869f1ace413398")
     version("0.8.1", sha256="8519430ad07087d4c997fda3a7918f7cfa27cb58972a8c89c2a0295a1c940e9e")
@@ -23,7 +24,10 @@ class PyParso(PythonPackage):
     version("0.6.1", sha256="56b2105a80e9c4df49de85e125feb6be69f49920e121406f15e7acde6c9dfc57")
     version("0.4.0", sha256="2e9574cb12e7112a87253e14e2c380ce312060269d04bd018478a3c92ea9a376")
 
-    depends_on("python@3.6:", type=("build", "run"), when="@0.8.1:")
-    depends_on("python@2.7:2.8,3.4:", type=("build", "run"), when="@0.6.1:")
-    depends_on("python@2.6:2.8,3.3:", type=("build", "run"), when="@0.4.0:")
+    with default_args(type=("build", "run")):
+        depends_on("python@:3.13", when="@:0.8.4")
+        # https://github.com/davidhalter/parso/commit/f7bea28bcc3a1862075e5b61a08d703d72be94aa
+        depends_on("python@:3.12", when="@:0.8.3")
+        # https://github.com/davidhalter/parso/commit/285492f4ed25f145859630ee6c5625e60aff6e2e
+        depends_on("python@:3.11", when="@:0.8.2")
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
Fixes tab completion in ipython on python 3.13.

py-parso needs grammar files for each python version, meaning that
every future release needs a forward compat bound.
