### PR TITLE
miniforge3: wrong sbang replacement

### DIFF
--- a/var/spack/repos/builtin/packages/miniforge3/package.py
+++ b/var/spack/repos/builtin/packages/miniforge3/package.py
@@ -56,6 +56,16 @@ class Miniforge3(Package):
         bash = which("bash")
         bash(script, "-b", "-f", "-p", self.prefix)
 
+    @run_after("install")
+    def patch_sbang(self):
+        # Conda replaces the full path to the Python executable with `/usr/bin/env python` if the full path exceeds
+        # 127 characters. This does however break `conda deactivate` because the wrong Python interpreter is used
+        # after activating an environment. The 127 character limit is not relevant in Spack as Spack will automatically
+        # use the `sbang` script to deal with the overly long sbang line.
+        filter_file(r"#!/usr/bin/env python", rf"#!{self.prefix.bin.python}", self.prefix.bin.conda)
+        if "+mamba" in self.spec:
+            filter_file(r"#!/usr/bin/env python", rf"#!{self.prefix.bin.python}", self.prefix.bin.mamba)
+
     def setup_run_environment(self, env):
         filename = self.prefix.etc.join("profile.d").join("conda.sh")
         env.extend(EnvironmentModifications.from_sourcing_file(filename))

--- a/var/spack/repos/builtin/packages/miniforge3/package.py
+++ b/var/spack/repos/builtin/packages/miniforge3/package.py
@@ -58,13 +58,18 @@ class Miniforge3(Package):
 
     @run_after("install")
     def patch_sbang(self):
-        # Conda replaces the full path to the Python executable with `/usr/bin/env python` if the full path exceeds
-        # 127 characters. This does however break `conda deactivate` because the wrong Python interpreter is used
-        # after activating an environment. The 127 character limit is not relevant in Spack as Spack will automatically
+        # Conda replaces the full path to the Python executable with `/usr/bin/env python`
+        # if the full path exceeds 127 characters. This does however break `conda deactivate`
+        # because the wrong Python interpreter is used after activating an environment.
+        # The 127 character limit is not relevant in Spack as Spack will automatically
         # use the `sbang` script to deal with the overly long sbang line.
-        filter_file(r"#!/usr/bin/env python", rf"#!{self.prefix.bin.python}", self.prefix.bin.conda)
+        filter_file(
+            r"#!/usr/bin/env python", rf"#!{self.prefix.bin.python}", self.prefix.bin.conda
+        )
         if "+mamba" in self.spec:
-            filter_file(r"#!/usr/bin/env python", rf"#!{self.prefix.bin.python}", self.prefix.bin.mamba)
+            filter_file(
+                r"#!/usr/bin/env python", rf"#!{self.prefix.bin.python}", self.prefix.bin.mamba
+            )
 
     def setup_run_environment(self, env):
         filename = self.prefix.etc.join("profile.d").join("conda.sh")


### PR DESCRIPTION
In the sbang line conda replaces the full path to the Python executable with `/usr/bin/env python` if the full path exceeds 127 characters. This does however break `conda deactivate` because the wrong Python interpreter is used after activating an environment. The 127 character limit is not relevant in Spack as Spack will automatically use the `sbang` script to deal with the overly long sbang line.

There is no option to disable this replacement when running the miniforge installer, so the lines have to be changed after running the installer.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
