### PR TITLE
extrae: actually make `papi` an optional dependency

### DIFF
--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -68,7 +68,6 @@ class Extrae(AutotoolsPackage):
     # See https://github.com/spack/spack/pull/22303 for reference
     depends_on(Boost.with_default_variants)
     depends_on("libdwarf")
-    depends_on("papi")
     depends_on("elf", type="link")
     depends_on("libxml2")
     depends_on("numactl")


### PR DESCRIPTION
`papi` was added as an optional dependency and a variant in #11978: https://github.com/spack/spack/blob/f33912d707ba63a9d4596b1b4a491a6b17d5b0b1/var/spack/repos/builtin/packages/extrae/package.py#L85-L86 but it was retained as a (duplicate) mandatory dependency as well.