### PR TITLE
py-braceexpand: new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-braceexpand/package.py
+++ b/var/spack/repos/builtin/packages/py-braceexpand/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class PyBraceexpand(PythonPackage):
+    """Bash-style brace expansion"""
+
+    homepage = "https://github.com/trendels/braceexpand"
+    url = "https://github.com/trendels/braceexpand/archive/refs/tags/v0.1.7.tar.gz"
+
+    license("MIT")
+
+    version("0.1.7", sha256="72eb91b62b2fa2dd7f6044b7a4b46a3761ac61fe5945a2a86a4538447ab47e05")
+
+    # Requires py-typing with python@:3.4 but Spack's minimum python is higher
+    depends_on("py-setuptools")
+
+    @run_after("install")
+    def copy_test_files(self):
+        cache_extra_test_sources(self, "test_braceexpand.py")
+
+    def test_unittests(self):
+        """run the unit tests"""
+        with working_dir(self.test_suite.current_test_cache_dir):
+            python("test_braceexpand.py")


### PR DESCRIPTION
Adding the package.

```
$ spack install py-braceexpand
...
==> Installing py-braceexpand-0.1.7-qkovnkxmlvyhkpy4ojwj25vldmabruyy [9/9]
==> No binary for py-braceexpand-0.1.7-qkovnkxmlvyhkpy4ojwj25vldmabruyy found: installing from source
==> Using cached archive: $spack/var/spack/cache/_source-cache/archive/72/72eb91b62b2fa2dd7f6044b7a4b46a3761ac61fe5945a2a86a4538447ab47e05.tar.gz
==> No patches needed for py-braceexpand
==> py-braceexpand: Executing phase: 'install'
==> py-braceexpand: Successfully installed py-braceexpand-0.1.7-qkovnkxmlvyhkpy4ojwj25vldmabruyy
  Stage: 0.01s.  Install: 1.86s.  Post-install: 0.20s.  Total: 2.26s
[+] $spack/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/py-braceexpand-0.1.7-qkovnkxmlvyhkpy4ojwj25vldmabruyy
41.050u 2.595s 0:46.94 92.9%	0+0k 5360+5592io 0pf+0w
```

```
$ spack -v test run py-braceexpand
==> Spack test m5bpvpmvut54gqweuunxnxam23s5saec
==> Testing package py-braceexpand-0.1.7-qkovnkx
...
==> [2024-10-23-18:28:19.866302] test: test_imports: Attempts to import modules of the installed package.
...
==> [2024-10-23-18:28:19.867883] Detected the following modules: []
PASSED: PyBraceexpand::test_imports
==> [2024-10-23-18:28:19.868098] test: test_unittests: run the unit tests
==> [2024-10-23-18:28:19.868583] '$spack/opt/spack/linux-rhel8-x86_64_v3/gcc-12.1.1/python-venv-1.0-pr6rh6ezcslqp2sscmh4fn2jelr6dsqi/bin/python3' 'test_braceexpand.py'
.......
----------------------------------------------------------------------
Ran 7 tests in 0.003s

OK
PASSED: PyBraceexpand::test_unittests
==> [2024-10-23-18:28:19.938412] Completed testing
==> [2024-10-23-18:28:19.938526] 
==================== SUMMARY: py-braceexpand-0.1.7-qkovnkx =====================
PyBraceexpand::test_imports .. PASSED
PyBraceexpand::test_unittests .. PASSED
============================= 2 passed of 2 parts ==============================
```