### PR TITLE
nwchem: add f90allocatable variant

### DIFF
--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -46,6 +46,7 @@ class Nwchem(Package):
     depends_on("fortran", type="build")  # generated
 
     variant("openmp", default=False, description="Enables OpenMP support")
+    variant("f90allocatable", default=False, description="Use F90 allocatable instead of MA")
     variant(
         "armci",
         values=("mpi-ts", "mpi-pr", "armcimpi", "mpi3", "openib", "ofi"),
@@ -157,6 +158,9 @@ class Nwchem(Package):
 
         if spec.satisfies("+openmp"):
             args.extend(["USE_OPENMP=y"])
+
+        if spec.satisfies("+f90allocatable"):
+            args.extend(["USE_F90_ALLOCATABLE=1"])
 
         if self.spec.variants["armci"].value == "armcimpi":
             armcimpi = spec["armci"]


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This is a very small change to enable the F90 allocatable option, which is a dependency of some GPU stuff that is coming later.