### PR TITLE
py-jupyter-core: set environment variables for extensions

### DIFF
--- a/var/spack/repos/builtin/packages/py-jupyter-core/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-core/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/py-jupyter-core/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-core/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 from spack.package import *
 
 
@@ -45,3 +46,10 @@ class PyJupyterCore(PythonPackage):
 
     # Historical dependencies
     depends_on("py-setuptools", when="@:4.9.2", type=("build", "run"))
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        # https://docs.jupyter.org/en/stable/use/jupyter-directories.html
+        if os.path.exists(dependent_spec.prefix.etc.jupyter):
+            env.prepend_path("JUPYTER_CONFIG_PATH", dependent_spec.prefix.etc.jupyter)
+        if os.path.exists(dependent_spec.prefix.share.jupyter):
+            env.prepend_path("JUPYTER_PATH", dependent_spec.prefix.share.jupyter)


### PR DESCRIPTION
This is an attempt to get Jupyter Extensions working properly. A few remaining issues:

* This only works if the package has a direct dependency on py-jupyter-core, I wish transitive dependencies were supported
* I'm not 100% convinced I got py-ipympl working with this change, but it at least no longer has errors
* It would be interesting to make this extendable, but Spack does not support packages that extend multiple things (python, py-jupyter-core)

I'm out of ideas (and time), so these can be saved for future daring developers to solve.