### PR TITLE
py-jupyter: add v1.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-jupyter/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter/package.py
@@ -14,13 +14,20 @@ class PyJupyter(PythonPackage):
 
     license("BSD-3-Clause")
 
-    version("1.0.0", sha256="d9dc4b3318f310e34c82951ea5d6683f67bed7def4b259fafbfe4f1beb1d8e5f")
+    version("1.1.1", sha256="d55467bceabdea49d7e3624af7e33d59c37fff53ed3a350e1ac957bed731de7a")
+    version(
+        "1.0.0",
+        sha256="d9dc4b3318f310e34c82951ea5d6683f67bed7def4b259fafbfe4f1beb1d8e5f",
+        deprecated=True,
+    )
 
-    # pip silently replaces distutils with setuptools
     depends_on("py-setuptools", type="build")
-    depends_on("py-notebook", type=("build", "run"))
-    depends_on("py-qtconsole", type=("build", "run"))
-    depends_on("py-jupyter-console", type=("build", "run"))
-    depends_on("py-nbconvert", type=("build", "run"))
-    depends_on("py-ipykernel", type=("build", "run"))
-    depends_on("py-ipywidgets", type=("build", "run"))
+
+    with default_args(type=("build", "run")):
+        depends_on("py-notebook")
+        depends_on("py-qtconsole", when="@:1.0")
+        depends_on("py-jupyter-console")
+        depends_on("py-nbconvert")
+        depends_on("py-ipykernel")
+        depends_on("py-ipywidgets")
+        depends_on("py-jupyterlab", when="@1.1:")


### PR DESCRIPTION
This package had a new release for the first time in almost a decade. Let's deprecate the old one and get the new one working.