### PR TITLE
compilers.yaml: require list of strings for modules

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -275,7 +275,7 @@ class Compiler:
         operating_system,
         target,
         paths,
-        modules=None,
+        modules: Optional[List[str]] = None,
         alias=None,
         environment=None,
         extra_rpaths=None,

--- a/lib/spack/spack/schema/compilers.py
+++ b/lib/spack/spack/schema/compilers.py
@@ -61,7 +61,10 @@ properties: Dict[str, Any] = {
                         "target": {"type": "string"},
                         "alias": {"anyOf": [{"type": "string"}, {"type": "null"}]},
                         "modules": {
-                            "anyOf": [{"type": "string"}, {"type": "null"}, {"type": "array"}]
+                            "anyOf": [
+                                {"type": "null"},
+                                {"type": "array", "items": {"type": "string"}},
+                            ]
                         },
                         "implicit_rpaths": implicit_rpaths,
                         "environment": spack.schema.environment.definition,


### PR DESCRIPTION
Currently this typo does not error:

```yaml
compilers:
  - spec: gcc@10.3.0
    modules:
      gcc/10.3.0
```

The modules attribute is a string, and Spack will happily treat it as an
iterator and module load its items:

```
module load g
module load c
module load c
```

This commit makes the schema more strict. Only lists of strings are accepted now:

```yaml
compilers:
  - spec: gcc@10.3.0
    modules:
    - gcc/10.3.0
```


