### PR TITLE
Update Spack's unparser from cpython, fix package hash instabilities

### DIFF
--- a/lib/spack/spack/test/util/package_hash.py
+++ b/lib/spack/spack/test/util/package_hash.py
@@ -174,6 +174,9 @@ class ManyDocstrings:
     def method2():
         """ELEVEN"""
         return "TWELVE"
+
+def empty_func():
+    """THIRTEEN"""
 '''
 
 many_strings_no_docstrings = """\
@@ -189,6 +192,9 @@ class ManyDocstrings:
 
     def method2():
         return 'TWELVE'
+
+def empty_func():
+    pass
 """
 
 

--- a/lib/spack/spack/test/util/package_hash.py
+++ b/lib/spack/spack/test/util/package_hash.py
@@ -345,7 +345,7 @@ def test_remove_complex_package_logic_filtered():
         # has @when("@4.1.0") and raw unicode literals
         ("mfem", "slf5qyyyhuj66mo5lpuhkrs35akh2zck"),
         ("mfem@4.0.0", "slf5qyyyhuj66mo5lpuhkrs35akh2zck"),
-        ("mfem@4.1.0", "yo3ymaulytctas67zjn663ixw5cfyh5u"),
+        ("mfem@4.1.0", "6tjbezoh2aquz6gmvoz7jf6j6lib65m2"),
         # has @when("@1.5.0:")
         ("py-torch", "m3ucsddqr7hjevtgx4cad34nrtqgyjfg"),
         ("py-torch@1.0", "m3ucsddqr7hjevtgx4cad34nrtqgyjfg"),

--- a/lib/spack/spack/test/util/unparse/unparse.py
+++ b/lib/spack/spack/test/util/unparse/unparse.py
@@ -569,3 +569,7 @@ def test_subscript_without_tuple():
     """Test change in visit_Subscript/visit_Index is_non_empty_tuple."""
     check_ast_roundtrip("a[*b]")
     check_ast_roundtrip("a[1, *b]")
+
+
+def test_attribute_on_int():
+    check_ast_roundtrip("1 .__abs__()")

--- a/lib/spack/spack/test/util/unparse/unparse.py
+++ b/lib/spack/spack/test/util/unparse/unparse.py
@@ -553,3 +553,19 @@ def test_async_with_as():
 )
 def test_match_literal(literal):
     check_ast_roundtrip(literal)
+
+
+def test_subscript_with_tuple():
+    """Test change in visit_Subscript/visit_Index is_non_empty_tuple."""
+    check_ast_roundtrip("a[()]")
+    check_ast_roundtrip("a[b]")
+    check_ast_roundtrip("a[(*b,)]")
+    check_ast_roundtrip("a[(1, 2)]")
+    check_ast_roundtrip("a[(1, *b)]")
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="Not supported < 3.11")
+def test_subscript_without_tuple():
+    """Test change in visit_Subscript/visit_Index is_non_empty_tuple."""
+    check_ast_roundtrip("a[*b]")
+    check_ast_roundtrip("a[1, *b]")

--- a/lib/spack/spack/util/package_hash.py
+++ b/lib/spack/spack/util/package_hash.py
@@ -43,6 +43,8 @@ class RemoveDocstrings(ast.NodeTransformer):
     def remove_docstring(self, node):
         if node.body:
             node.body = [child for child in node.body if not unused_string(child)]
+        if not node.body:
+            node.body = [ast.Pass()]
 
         self.generic_visit(node)
         return node

--- a/lib/spack/spack/util/unparse/__init__.py
+++ b/lib/spack/spack/util/unparse/__init__.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2014-2021, Simon Percivall and Spack Project Developers.
 #
 # SPDX-License-Identifier: Python-2.0
-import io
 
 from .unparser import Unparser
 
@@ -9,6 +8,5 @@ __version__ = "1.6.3"
 
 
 def unparse(tree, py_ver_consistent=False):
-    v = io.StringIO()
-    Unparser(py_ver_consistent=py_ver_consistent).visit(tree, v)
-    return v.getvalue().strip() + "\n"
+    unparser = Unparser(py_ver_consistent=py_ver_consistent)
+    return unparser.visit(tree) + "\n"

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -72,8 +72,6 @@ class NodeVisitor(object):
             elif isinstance(value, AST):
                 self.visit(value)
 
-    # def visit_Constant removed compared to cpython because overridden below anyway
-
 
 # Large float and imaginary literals get turned into infinities in the AST.
 # We unparse those infinities to INFSTR.

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -619,10 +619,6 @@ class Unparser(NodeVisitor):
     # Python < 3.8. Num, Str, Bytes, NameConstant, Ellipsis replaced with Constant
     # https://github.com/python/cpython/commit/3f22811fef73aec848d961593d95fa877f77ecbf
     def visit_Str(self, node):
-        # Python 3.5, 3.6, and 3.7 can't tell if something was written as a
-        # unicode constant. Try to make that consistent with 'u' for '\u- literals
-        if self._py_ver_consistent and repr(node.s).startswith("'\\u"):
-            self.write("u")
         self._write_constant(node.s)
 
     def visit_JoinedStr(self, node):
@@ -733,7 +729,8 @@ class Unparser(NodeVisitor):
 
     def _write_docstring(self, node):
         self.fill()
-        if node.kind == "u":
+        # Don't emit `u""` because it's not avail in python AST <= 3.7
+        if not self._py_ver_consistent and node.kind == "u":
             self.write("u")
         self._write_str_avoiding_backslashes(node.value, quote_types=_MULTI_QUOTES)
 
@@ -763,7 +760,8 @@ class Unparser(NodeVisitor):
         elif value is ...:
             self.write("...")
         else:
-            if node.kind == "u":
+            # Don't emit `u""` because it's not avail in python AST <= 3.7
+            if not self._py_ver_consistent and node.kind == "u":
                 self.write("u")
             self._write_constant(node.value)
 

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -836,7 +836,7 @@ class Unparser(NodeVisitor):
                 self.traverse(gen)
 
     def visit_comprehension(self, node):
-        if getattr(node, "is_async", False):
+        if node.is_async:
             self.write(" async for ")
         else:
             self.write(" for ")

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -709,6 +709,11 @@ class Unparser(NodeVisitor):
 
         with self.delimit("{", "}"):
             expr = unparse_inner(node.value)
+            # Python <= 3.11 does not support backslash in formats part
+            if "\\" in expr:
+                raise ValueError(
+                    "Unable to avoid backslash in f-string expression part (python 3.11)"
+                )
             if expr.startswith("{"):
                 # Separate pair of opening brackets as "{ {"
                 self.write(" ")

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -724,13 +724,6 @@ class Unparser(NodeVisitor):
             self.write(
                 repr(value).replace("inf", _INFSTR).replace("nan", f"({_INFSTR}-{_INFSTR})")
             )
-        elif isinstance(value, str) and self._py_ver_consistent:
-            # emulate a python 2 repr with raw unicode escapes
-            # see _Str for python 2 counterpart
-            raw = repr(value.encode("raw_unicode_escape")).lstrip("b")
-            if raw.startswith(r"'\\u"):
-                raw = "'\\" + raw[3:]
-            self.write(raw)
         elif self._avoid_backslashes and isinstance(value, str):
             self._write_str_avoiding_backslashes(value)
         else:

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -238,8 +238,11 @@ class Unparser(NodeVisitor):
             return node
 
     def get_type_comment(self, node):
-        # We don't care about type comments for spack package hash.
-        return None
+        # Python 3.8 introduced type_comment
+        # (enabled on compile(... ast.PyCF_TYPE_COMMENTS))
+        comment = self._type_ignores.get(node.lineno) or getattr(node, "type_comment", None)
+        if comment is not None:
+            return f" # type: {comment}"
 
     def traverse(self, node):
         if isinstance(node, list):

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -490,23 +490,17 @@ class Unparser:
             with self.block():
                 self.traverse(node.orelse)
 
-    def _generic_With(self, node, async_=False):
-        self.fill("async with " if async_ else "with ")
-        if hasattr(node, "items"):
-            self.interleave(lambda: self.write(", "), self.traverse, node.items)
-        else:
-            self.traverse(node.context_expr)
-            if node.optional_vars:
-                self.write(" as ")
-                self.traverse(node.optional_vars)
+    def visit_With(self, node):
+        self.fill("with ")
+        self.interleave(lambda: self.write(", "), self.traverse, node.items)
         with self.block():
             self.traverse(node.body)
 
-    def visit_With(self, node):
-        self._generic_With(node)
-
     def visit_AsyncWith(self, node):
-        self._generic_With(node, async_=True)
+        self.fill("async with ")
+        self.interleave(lambda: self.write(", "), self.traverse, node.items)
+        with self.block():
+            self.traverse(node.body)
 
     def _str_literal_helper(
         self, string, *, quote_types=_ALL_QUOTES, escape_special_whitespace=False

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -127,23 +127,19 @@ class Unparser:
         """Add new source parts"""
         self._source.extend(text)
 
-    class _Block:
+    @contextmanager
+    def block(self, *, extra=None):
         """A context manager for preparing the source for blocks. It adds
-        the character ':', increases the indentation on enter and decreases
-        the indentation on exit."""
-
-        def __init__(self, unparser):
-            self.unparser = unparser
-
-        def __enter__(self):
-            self.unparser.write(":")
-            self.unparser._indent += 1
-
-        def __exit__(self, exc_type, exc_value, traceback):
-            self.unparser._indent -= 1
-
-    def block(self):
-        return self._Block(self)
+        the character':', increases the indentation on enter and decreases
+        the indentation on exit. If *extra* is given, it will be directly
+        appended after the colon character.
+        """
+        self.write(":")
+        if extra:
+            self.write(extra)
+        self._indent += 1
+        yield
+        self._indent -= 1
 
     @contextmanager
     def delimit(self, start, end):

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -16,7 +16,7 @@ def nullcontext():
 
 # Large float and imaginary literals get turned into infinities in the AST.
 # We unparse those infinities to INFSTR.
-INFSTR = "1e" + repr(sys.float_info.max_10_exp + 1)
+_INFSTR = "1e" + repr(sys.float_info.max_10_exp + 1)
 
 
 class _Precedence:
@@ -61,7 +61,7 @@ def interleave(inter, f, seq):
 
 _SINGLE_QUOTES = ("'", '"')
 _MULTI_QUOTES = ('"""', "'''")
-_ALL_QUOTES = _SINGLE_QUOTES + _MULTI_QUOTES
+_ALL_QUOTES = (*_SINGLE_QUOTES, *_MULTI_QUOTES)
 
 
 def is_simple_tuple(slice_value):
@@ -599,7 +599,7 @@ class Unparser:
     def _write_constant(self, value):
         if isinstance(value, (float, complex)):
             # Substitute overflowing decimal literal for AST infinities.
-            self.write(repr(value).replace("inf", INFSTR))
+            self.write(repr(value).replace("inf", _INFSTR))
         elif isinstance(value, str) and self._py_ver_consistent:
             # emulate a python 2 repr with raw unicode escapes
             # see _Str for python 2 counterpart
@@ -626,7 +626,7 @@ class Unparser:
 
     def visit_Num(self, node):
         repr_n = repr(node.n)
-        self.write(repr_n.replace("inf", INFSTR))
+        self.write(repr_n.replace("inf", _INFSTR))
 
     def visit_List(self, node):
         with self.delimit("[", "]"):

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -760,7 +760,8 @@ class Unparser(NodeVisitor):
     def _write_docstring(self, node):
         self.fill()
         # Don't emit `u""` because it's not avail in python AST <= 3.7
-        if not self._py_ver_consistent and node.kind == "u":
+        # Ubuntu 18's Python 3.6 doesn't have "kind"
+        if not self._py_ver_consistent and getattr(node, "kind", None) == "u":
             self.write("u")
         # Python 3.8 changed Str to Constant
         value = node.s if type(node).__name__ == "Str" else node.value
@@ -793,7 +794,8 @@ class Unparser(NodeVisitor):
             self.write("...")
         else:
             # Don't emit `u""` because it's not avail in python AST <= 3.7
-            if not self._py_ver_consistent and node.kind == "u":
+            # Ubuntu 18's Python 3.6 doesn't have "kind"
+            if not self._py_ver_consistent and getattr(node, "kind", None) == "u":
                 self.write("u")
             self._write_constant(node.value)
 

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -243,6 +243,13 @@ class Unparser(NodeVisitor):
         for stmt in node.body:
             self.traverse(stmt)
 
+    def visit_FunctionType(self, node):
+        with self.delimit("(", ")"):
+            self.interleave(lambda: self.write(", "), self.traverse, node.argtypes)
+
+        self.write(" -> ")
+        self.traverse(node.returns)
+
     def visit_Expr(self, node):
         self.fill()
         self.set_precedence(_Precedence.YIELD, node.value)

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -506,12 +506,24 @@ class Unparser(NodeVisitor):
         if node.bound:
             self.write(": ")
             self.traverse(node.bound)
+        # Python 3.13 introduced default_value
+        if getattr(node, "default_value", False):
+            self.write(" = ")
+            self.traverse(node.default_value)
 
     def visit_TypeVarTuple(self, node):
         self.write("*" + node.name)
+        # Python 3.13 introduced default_value
+        if getattr(node, "default_value", False):
+            self.write(" = ")
+            self.traverse(node.default_value)
 
     def visit_ParamSpec(self, node):
         self.write("**" + node.name)
+        # Python 3.13 introduced default_value
+        if getattr(node, "default_value", False):
+            self.write(" = ")
+            self.traverse(node.default_value)
 
     def visit_TypeAlias(self, node):
         self.fill("type ")

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -746,9 +746,10 @@ class Unparser:
             self.interleave(lambda: self.write(", "), write_item, zip(node.keys, node.values))
 
     def visit_Tuple(self, node):
-        with self.delimit_if(
-            "(", ")", len(node.elts) == 0 or self.get_precedence(node) > _Precedence.TUPLE
-        ):
+        # with self.delimit_if(
+        #     "(", ")", len(node.elts) == 0 or self.get_precedence(node) > _Precedence.TUPLE
+        # ):
+        with self.delimit("(", ")"):  # don't change spack package hash
             self.items_view(self.traverse, node.elts)
 
     unop = {"Invert": "~", "Not": "not", "UAdd": "+", "USub": "-"}

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -482,7 +482,7 @@ class Unparser(NodeVisitor):
             self._type_params_helper(node.type_params)
         with self.delimit("(", ")"):
             self.traverse(node.args)
-        if getattr(node, "returns", False):
+        if node.returns:
             self.write(" -> ")
             self.traverse(node.returns)
         with self.block(extra=self.get_type_comment(node)):

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -127,7 +127,6 @@ class Unparser(NodeVisitor):
         self._type_ignores = {}
         self._indent = 0
         self._in_try_star = False
-        self.future_imports = []
         self._py_ver_consistent = py_ver_consistent
         self._avoid_backslashes = _avoid_backslashes
 
@@ -284,10 +283,6 @@ class Unparser(NodeVisitor):
         self.interleave(lambda: self.write(", "), self.traverse, node.names)
 
     def visit_ImportFrom(self, node):
-        # A from __future__ import may affect unparsing, so record it.
-        if node.module and node.module == "__future__":
-            self.future_imports.extend(n.name for n in node.names)
-
         self.fill("from ")
         self.write("." * (node.level or 0))
         if node.module:

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -389,7 +389,7 @@ class Unparser(NodeVisitor):
         self.fill("raise")
         if not node.exc:
             if node.cause:
-                raise ValueError(f"Node can't use cause without an exception.")
+                raise ValueError("Node can't use cause without an exception.")
             return
         self.write(" ")
         self.traverse(node.exc)

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -64,6 +64,8 @@ def is_simple_tuple(slice_value):
     return (
         isinstance(slice_value, ast.Tuple)
         and slice_value.elts
+        # Python < 3.11. Grammar change.
+        # https://github.com/python/cpython/commit/e8e737bcf6d22927caebc30c5d57ac4634063219
         and not any(isinstance(elt, ast.Starred) for elt in slice_value.elts)
     )
 
@@ -547,10 +549,13 @@ class Unparser:
         quote_type = quote_types[0]
         self.write(f"{quote_type}{string}{quote_type}")
 
-    # expr
+    # Python < 3.8. Num, Str, Bytes, NameConstant, Ellipsis replaced with Constant
+    # https://github.com/python/cpython/commit/3f22811fef73aec848d961593d95fa877f77ecbf
     def visit_Bytes(self, node):
         self.write(repr(node.s))
 
+    # Python < 3.8. Num, Str, Bytes, NameConstant, Ellipsis replaced with Constant
+    # https://github.com/python/cpython/commit/3f22811fef73aec848d961593d95fa877f77ecbf
     def visit_Str(self, node):
         # Python 3.5, 3.6, and 3.7 can't tell if something was written as a
         # unicode constant. Try to make that consistent with 'u' for '\u- literals
@@ -638,6 +643,8 @@ class Unparser:
     def visit_Name(self, node):
         self.write(node.id)
 
+    # Python < 3.8. Num, Str, Bytes, NameConstant, Ellipsis replaced with Constant
+    # https://github.com/python/cpython/commit/3f22811fef73aec848d961593d95fa877f77ecbf
     def visit_NameConstant(self, node):
         self.write(repr(node.value))
 
@@ -669,6 +676,8 @@ class Unparser:
                 self.write("u")
             self._write_constant(node.value)
 
+    # Python < 3.8. Num, Str, Bytes, NameConstant, Ellipsis replaced with Constant
+    # https://github.com/python/cpython/commit/3f22811fef73aec848d961593d95fa877f77ecbf
     def visit_Num(self, node):
         repr_n = repr(node.n)
         self.write(repr_n.replace("inf", _INFSTR))
@@ -916,7 +925,8 @@ class Unparser:
         self.set_precedence(_Precedence.EXPR, node.value)
         self.traverse(node.value)
 
-    # slice
+    # Python < 3.8. Num, Str, Bytes, NameConstant, Ellipsis replaced with Constant
+    # https://github.com/python/cpython/commit/3f22811fef73aec848d961593d95fa877f77ecbf
     def visit_Ellipsis(self, node):
         self.write("...")
 
@@ -946,6 +956,7 @@ class Unparser:
             for case in node.cases:
                 self.traverse(case)
 
+    # Python < 3.9. ExtSlice(slices) replaced with Tuple(slices, Load()).
     def visit_ExtSlice(self, node):
         self.interleave(lambda: self.write(", "), self.traverse, node.dims)
 
@@ -960,6 +971,7 @@ class Unparser:
     def visit_arguments(self, node):
         first = True
         # normal arguments
+        # Python < 3.8. Position-only arguments
         all_args = getattr(node, "posonlyargs", []) + node.args
         defaults = [None] * (len(all_args) - len(node.defaults)) + node.defaults
         for index, elements in enumerate(zip(all_args, defaults), 1):
@@ -972,6 +984,7 @@ class Unparser:
             if d:
                 self.write("=")
                 self.traverse(d)
+                # Python < 3.8. Position-only arguments
             if index == len(getattr(node, "posonlyargs", ())):
                 self.write(", /")
 
@@ -1074,7 +1087,10 @@ class Unparser:
         with self.delimit("{", "}"):
             keys = node.keys
             self.interleave(
-                lambda: self.write(", "), write_key_pattern_pair, zip(keys, node.patterns)
+                lambda: self.write(", "),
+                write_key_pattern_pair,
+                # (zip strict is >= Python 3.10)
+                zip(keys, node.patterns),
             )
             rest = node.rest
             if rest is not None:
@@ -1099,7 +1115,10 @@ class Unparser:
                 if patterns:
                     self.write(", ")
                 self.interleave(
-                    lambda: self.write(", "), write_attr_pattern, zip(attrs, node.kwd_patterns)
+                    lambda: self.write(", "),
+                    write_attr_pattern,
+                    # (zip strict is >= Python 3.10)
+                    zip(attrs, node.kwd_patterns),
                 )
 
     def visit_MatchAs(self, node):

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -4,9 +4,10 @@
 "Usage: unparse.py <path to source file>"
 import ast
 import sys
-from ast import AST, Constant, FormattedValue, If, JoinedStr, Name, Tuple
+from ast import AST, FormattedValue, If, JoinedStr, Name, Tuple
 from contextlib import contextmanager
 from enum import IntEnum, auto
+from typing import Optional
 
 
 # TODO: if we require Python 3.7, use its `nullcontext()`
@@ -229,10 +230,7 @@ class Unparser(NodeVisitor):
         if not isinstance(node, ast.Expr):
             return None
         node = node.value
-        if isinstance(node, Constant) and isinstance(node.value, str):
-            return node
-        # Python 3.8 changed Str to Constant
-        elif type(node).__name__ == "Str" and node.s:
+        if _is_str_literal(node):
             return node
 
     def get_type_comment(self, node):
@@ -636,13 +634,23 @@ class Unparser(NodeVisitor):
 
     # Python < 3.8. Num, Str, Bytes, NameConstant, Ellipsis replaced with Constant
     # https://github.com/python/cpython/commit/3f22811fef73aec848d961593d95fa877f77ecbf
-    def visit_Bytes(self, node):
-        self.write(repr(node.s))
+    if sys.version_info < (3, 8):
 
-    # Python < 3.8. Num, Str, Bytes, NameConstant, Ellipsis replaced with Constant
-    # https://github.com/python/cpython/commit/3f22811fef73aec848d961593d95fa877f77ecbf
-    def visit_Str(self, node):
-        self._write_constant(node.s)
+        def visit_Num(self, node):
+            repr_n = repr(node.n)
+            self.write(repr_n.replace("inf", _INFSTR))
+
+        def visit_Str(self, node):
+            self._write_constant(node.s)
+
+        def visit_Bytes(self, node):
+            self.write(repr(node.s))
+
+        def visit_NameConstant(self, node):
+            self.write(repr(node.value))
+
+        def visit_Ellipsis(self, node):
+            self.write("...")
 
     def visit_JoinedStr(self, node):
         self.write("f")
@@ -657,10 +665,7 @@ class Unparser(NodeVisitor):
         for value in node.values:
             with self.buffered() as buffer:
                 self._write_fstring_inner(value)
-            # Python 3.8 replaced Str with Constant
-            fstring_parts.append(
-                ("".join(buffer), isinstance(value, Constant) or type(value).__name__ == "Str")
-            )
+            fstring_parts.append(("".join(buffer), _is_str_literal(value)))
 
         new_fstring_parts = []
         quote_types = list(_ALL_QUOTES)
@@ -705,29 +710,21 @@ class Unparser(NodeVisitor):
             # for both the f-string itself, and format_spec
             for value in node.values:
                 self._write_fstring_inner(value, is_format_spec=is_format_spec)
-        # Python 3.8 replaced Str with Constant
-        elif type(node).__name__ == "Str":
-            value = node.s.replace("{", "{{").replace("}", "}}")
-
-            if is_format_spec:
-                value = value.replace("\\", "\\\\")
-                value = value.replace("'", "\\'")
-                value = value.replace('"', '\\"')
-                value = value.replace("\n", "\\n")
-            self.write(value)
-        elif isinstance(node, Constant) and isinstance(node.value, str):
-            value = node.value.replace("{", "{{").replace("}", "}}")
-
-            if is_format_spec:
-                value = value.replace("\\", "\\\\")
-                value = value.replace("'", "\\'")
-                value = value.replace('"', '\\"')
-                value = value.replace("\n", "\\n")
-            self.write(value)
         elif isinstance(node, FormattedValue):
             self.visit_FormattedValue(node)
-        else:
-            raise ValueError(f"Unexpected node inside JoinedStr, {node!r}")
+        else:  # str literal
+            maybe_string = _get_str_literal_value(node)
+            if maybe_string is None:
+                raise ValueError(f"Unexpected node inside JoinedStr, {node!r}")
+
+            value = maybe_string.replace("{", "{{").replace("}", "}}")
+
+            if is_format_spec:
+                value = value.replace("\\", "\\\\")
+                value = value.replace("'", "\\'")
+                value = value.replace('"', '\\"')
+                value = value.replace("\n", "\\n")
+            self.write(value)
 
     def visit_FormattedValue(self, node):
         def unparse_inner(inner):
@@ -763,13 +760,10 @@ class Unparser(NodeVisitor):
         if not self._py_ver_consistent and getattr(node, "kind", None) == "u":
             self.write("u")
         # Python 3.8 replaced Str with Constant
-        value = node.s if type(node).__name__ == "Str" else node.value
+        value = _get_str_literal_value(node)
+        if value is None:
+            raise ValueError(f"Node {node!r} is not a string literal.")
         self._write_str_avoiding_backslashes(value, quote_types=_MULTI_QUOTES)
-
-    # Python < 3.8. Num, Str, Bytes, NameConstant, Ellipsis replaced with Constant
-    # https://github.com/python/cpython/commit/3f22811fef73aec848d961593d95fa877f77ecbf
-    def visit_NameConstant(self, node):
-        self.write(repr(node.value))
 
     def _write_constant(self, value):
         if isinstance(value, (float, complex)):
@@ -797,12 +791,6 @@ class Unparser(NodeVisitor):
             if not self._py_ver_consistent and getattr(node, "kind", None) == "u":
                 self.write("u")
             self._write_constant(node.value)
-
-    # Python < 3.8. Num, Str, Bytes, NameConstant, Ellipsis replaced with Constant
-    # https://github.com/python/cpython/commit/3f22811fef73aec848d961593d95fa877f77ecbf
-    def visit_Num(self, node):
-        repr_n = repr(node.n)
-        self.write(repr_n.replace("inf", _INFSTR))
 
     def visit_List(self, node):
         with self.delimit("[", "]"):
@@ -1056,11 +1044,6 @@ class Unparser(NodeVisitor):
         self.set_precedence(_Precedence.EXPR, node.value)
         self.traverse(node.value)
 
-    # Python < 3.8. Num, Str, Bytes, NameConstant, Ellipsis replaced with Constant
-    # https://github.com/python/cpython/commit/3f22811fef73aec848d961593d95fa877f77ecbf
-    def visit_Ellipsis(self, node):
-        self.write("...")
-
     # Python 3.9 simplified Subscript(Index(value)) to Subscript(value)
     # https://github.com/python/cpython/commit/13d52c268699f199a8e917a0f1dc4c51e5346c42
     def visit_Index(self, node):
@@ -1276,8 +1259,26 @@ if sys.version_info >= (3, 8):
         """Check if a node represents a literal int."""
         return isinstance(node, ast.Constant) and isinstance(node.value, int)
 
+    def _is_str_literal(node: ast.AST) -> bool:
+        """Check if a node represents a literal str."""
+        return isinstance(node, ast.Constant) and isinstance(node.value, str)
+
+    def _get_str_literal_value(node: ast.AST) -> Optional[str]:
+        """Get the string value of a literal str node."""
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        return None
+
 else:
 
     def _is_int_literal(node: ast.AST) -> bool:
         """Check if a node represents a literal int."""
         return isinstance(node, ast.Num) and isinstance(node.n, int)
+
+    def _is_str_literal(node: ast.AST) -> bool:
+        """Check if a node represents a literal str."""
+        return isinstance(node, ast.Str)
+
+    def _get_str_literal_value(node: ast.AST) -> Optional[str]:
+        """Get the string value of a literal str node."""
+        return node.s if isinstance(node, ast.Str) else None

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -1048,7 +1048,7 @@ class Unparser(NodeVisitor):
                 self.write(", /")
 
         # varargs, or bare '*' if no varargs but keyword-only arguments present
-        if node.vararg or getattr(node, "kwonlyargs", False):
+        if node.vararg or node.kwonlyargs:
             if first:
                 first = False
             else:
@@ -1061,12 +1061,9 @@ class Unparser(NodeVisitor):
                     self.traverse(node.vararg.annotation)
 
         # keyword-only arguments
-        if getattr(node, "kwonlyargs", False):
+        if node.kwonlyargs:
             for a, d in zip(node.kwonlyargs, node.kw_defaults):
-                if first:
-                    first = False
-                else:
-                    self.write(", ")
+                self.write(", ")
                 self.traverse(a)
                 if d:
                     self.write("=")
@@ -1085,7 +1082,6 @@ class Unparser(NodeVisitor):
 
     def visit_keyword(self, node):
         if node.arg is None:
-            # starting from Python 3.5 this denotes a kwargs part of the invocation
             self.write("**")
         else:
             self.write(node.arg)

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -127,16 +127,6 @@ class Unparser(NodeVisitor):
     is disregarded."""
 
     def __init__(self, py_ver_consistent=False, _avoid_backslashes=False):
-        """Traverse an AST and generate its source.
-
-        Arguments:
-            py_ver_consistent (bool): if True, generate unparsed code that is
-                consistent between Python versions 3.5-3.11.
-
-        For legacy reasons, consistency is achieved by unparsing Python3 unicode literals
-        the way Python 2 would. This preserved Spack package hash consistency during the
-        python2/3 transition
-        """
         self._source = []
         self._precedences = {}
         self._indent = 0
@@ -952,11 +942,6 @@ class Unparser(NodeVisitor):
         self.traverse(node.func)
         with self.delimit("(", ")"):
             comma = False
-
-            # NOTE: this code is no longer compatible with python versions 2.7:3.4
-            # If you run on python@:3.4, you will see instability in package hashes
-            # across python versions
-
             for e in node.args:
                 if comma:
                     self.write(", ")
@@ -1019,14 +1004,12 @@ class Unparser(NodeVisitor):
     def visit_ExtSlice(self, node):
         self.interleave(lambda: self.write(", "), self.traverse, node.dims)
 
-    # argument
     def visit_arg(self, node):
         self.write(node.arg)
         if node.annotation:
             self.write(": ")
             self.traverse(node.annotation)
 
-    # others
     def visit_arguments(self, node):
         first = True
         # normal arguments

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -111,12 +111,6 @@ class Unparser:
         else:
             self.interleave(lambda: self.write(", "), traverser, items)
 
-    def visit(self, tree, output_file):
-        """Traverse tree and write source code to output_file."""
-        self.f = output_file
-        self.dispatch(tree)
-        self.f.flush()
-
     def fill(self, text=""):
         "Indent a piece of text, according to the current indentation level"
         self.f.write("\n" + "    " * self._indent + text)
@@ -169,14 +163,20 @@ class Unparser:
         for node in nodes:
             self._precedences[node] = precedence
 
-    def dispatch(self, tree):
+    def traverse(self, tree):
         "Dispatcher function, dispatching tree type T to method _T."
         if isinstance(tree, list):
             for node in tree:
-                self.dispatch(node)
+                self.traverse(node)
             return
         meth = getattr(self, "visit_" + tree.__class__.__name__)
         meth(tree)
+
+    def visit(self, tree, output_file):
+        """Traverse tree and write source code to output_file."""
+        self.f = output_file
+        self.traverse(tree)
+        self.f.flush()
 
     #
     # Unparsing methods
@@ -187,31 +187,31 @@ class Unparser:
 
     def visit_Module(self, tree):
         for stmt in tree.body:
-            self.dispatch(stmt)
+            self.traverse(stmt)
 
     def visit_Interactive(self, tree):
         for stmt in tree.body:
-            self.dispatch(stmt)
+            self.traverse(stmt)
 
     def visit_Expression(self, tree):
-        self.dispatch(tree.body)
+        self.traverse(tree.body)
 
     # stmt
     def visit_Expr(self, tree):
         self.fill()
         self.set_precedence(_Precedence.YIELD, tree.value)
-        self.dispatch(tree.value)
+        self.traverse(tree.value)
 
     def visit_NamedExpr(self, tree):
         with self.require_parens(_Precedence.TUPLE, tree):
             self.set_precedence(_Precedence.ATOM, tree.target, tree.value)
-            self.dispatch(tree.target)
+            self.traverse(tree.target)
             self.write(" := ")
-            self.dispatch(tree.value)
+            self.traverse(tree.value)
 
     def visit_Import(self, node):
         self.fill("import ")
-        self.interleave(lambda: self.write(", "), self.dispatch, node.names)
+        self.interleave(lambda: self.write(", "), self.traverse, node.names)
 
     def visit_ImportFrom(self, node):
         # A from __future__ import may affect unparsing, so record it.
@@ -223,36 +223,36 @@ class Unparser:
         if node.module:
             self.write(node.module)
         self.write(" import ")
-        self.interleave(lambda: self.write(", "), self.dispatch, node.names)
+        self.interleave(lambda: self.write(", "), self.traverse, node.names)
 
     def visit_Assign(self, node):
         self.fill()
         for target in node.targets:
-            self.dispatch(target)
+            self.traverse(target)
             self.write(" = ")
-        self.dispatch(node.value)
+        self.traverse(node.value)
 
     def visit_AugAssign(self, node):
         self.fill()
-        self.dispatch(node.target)
+        self.traverse(node.target)
         self.write(" " + self.binop[node.op.__class__.__name__] + "= ")
-        self.dispatch(node.value)
+        self.traverse(node.value)
 
     def visit_AnnAssign(self, node):
         self.fill()
         with self.delimit_if("(", ")", not node.simple and isinstance(node.target, ast.Name)):
-            self.dispatch(node.target)
+            self.traverse(node.target)
         self.write(": ")
-        self.dispatch(node.annotation)
+        self.traverse(node.annotation)
         if node.value:
             self.write(" = ")
-            self.dispatch(node.value)
+            self.traverse(node.value)
 
     def visit_Return(self, node):
         self.fill("return")
         if node.value:
             self.write(" ")
-            self.dispatch(node.value)
+            self.traverse(node.value)
 
     def visit_Pass(self, node):
         self.fill("pass")
@@ -265,14 +265,14 @@ class Unparser:
 
     def visit_Delete(self, node):
         self.fill("del ")
-        self.interleave(lambda: self.write(", "), self.dispatch, node.targets)
+        self.interleave(lambda: self.write(", "), self.traverse, node.targets)
 
     def visit_Assert(self, node):
         self.fill("assert ")
-        self.dispatch(node.test)
+        self.traverse(node.test)
         if node.msg:
             self.write(", ")
-            self.dispatch(node.msg)
+            self.traverse(node.msg)
 
     def visit_Global(self, node):
         self.fill("global ")
@@ -288,7 +288,7 @@ class Unparser:
             if node.value:
                 self.write(" ")
                 self.set_precedence(_Precedence.ATOM, node.value)
-                self.dispatch(node.value)
+                self.traverse(node.value)
 
     def visit_Yield(self, node):
         with self.require_parens(_Precedence.YIELD, node):
@@ -296,7 +296,7 @@ class Unparser:
             if node.value:
                 self.write(" ")
                 self.set_precedence(_Precedence.ATOM, node.value)
-                self.dispatch(node.value)
+                self.traverse(node.value)
 
     def visit_YieldFrom(self, node):
         with self.require_parens(_Precedence.YIELD, node):
@@ -304,7 +304,7 @@ class Unparser:
             if node.value:
                 self.write(" ")
                 self.set_precedence(_Precedence.ATOM, node.value)
-                self.dispatch(node.value)
+                self.traverse(node.value)
 
     def visit_Raise(self, node):
         self.fill("raise")
@@ -312,46 +312,46 @@ class Unparser:
             assert not node.cause
             return
         self.write(" ")
-        self.dispatch(node.exc)
+        self.traverse(node.exc)
         if node.cause:
             self.write(" from ")
-            self.dispatch(node.cause)
+            self.traverse(node.cause)
 
     def visit_Try(self, node):
         self.fill("try")
         with self.block():
-            self.dispatch(node.body)
+            self.traverse(node.body)
         for ex in node.handlers:
-            self.dispatch(ex)
+            self.traverse(ex)
         if node.orelse:
             self.fill("else")
             with self.block():
-                self.dispatch(node.orelse)
+                self.traverse(node.orelse)
         if node.finalbody:
             self.fill("finally")
             with self.block():
-                self.dispatch(node.finalbody)
+                self.traverse(node.finalbody)
 
     def visit_ExceptHandler(self, node):
         self.fill("except")
         if node.type:
             self.write(" ")
-            self.dispatch(node.type)
+            self.traverse(node.type)
         if node.name:
             self.write(" as ")
             self.write(node.name)
         with self.block():
-            self.dispatch(node.body)
+            self.traverse(node.body)
 
     def visit_ClassDef(self, node):
         self.write("\n")
         for deco in node.decorator_list:
             self.fill("@")
-            self.dispatch(deco)
+            self.traverse(deco)
         self.fill("class " + node.name)
         if getattr(node, "type_params", False):
             self.write("[")
-            self.interleave(lambda: self.write(", "), self.dispatch, node.type_params)
+            self.interleave(lambda: self.write(", "), self.traverse, node.type_params)
             self.write("]")
         with self.delimit_if("(", ")", condition=node.bases or node.keywords):
             comma = False
@@ -360,15 +360,15 @@ class Unparser:
                     self.write(", ")
                 else:
                     comma = True
-                self.dispatch(e)
+                self.traverse(e)
             for e in node.keywords:
                 if comma:
                     self.write(", ")
                 else:
                     comma = True
-                self.dispatch(e)
+                self.traverse(e)
         with self.block():
-            self.dispatch(node.body)
+            self.traverse(node.body)
 
     def visit_FunctionDef(self, node):
         self.__FunctionDef_helper(node, "def")
@@ -380,20 +380,20 @@ class Unparser:
         self.write("\n")
         for deco in node.decorator_list:
             self.fill("@")
-            self.dispatch(deco)
+            self.traverse(deco)
         def_str = fill_suffix + " " + node.name
         self.fill(def_str)
         if getattr(node, "type_params", False):
             self.write("[")
-            self.interleave(lambda: self.write(", "), self.dispatch, node.type_params)
+            self.interleave(lambda: self.write(", "), self.traverse, node.type_params)
             self.write("]")
         with self.delimit("(", ")"):
-            self.dispatch(node.args)
+            self.traverse(node.args)
         if getattr(node, "returns", False):
             self.write(" -> ")
-            self.dispatch(node.returns)
+            self.traverse(node.returns)
         with self.block():
-            self.dispatch(node.body)
+            self.traverse(node.body)
 
     def visit_For(self, node):
         self.__For_helper("for ", node)
@@ -403,55 +403,55 @@ class Unparser:
 
     def __For_helper(self, fill, node):
         self.fill(fill)
-        self.dispatch(node.target)
+        self.traverse(node.target)
         self.write(" in ")
-        self.dispatch(node.iter)
+        self.traverse(node.iter)
         with self.block():
-            self.dispatch(node.body)
+            self.traverse(node.body)
         if node.orelse:
             self.fill("else")
             with self.block():
-                self.dispatch(node.orelse)
+                self.traverse(node.orelse)
 
     def visit_If(self, node):
         self.fill("if ")
-        self.dispatch(node.test)
+        self.traverse(node.test)
         with self.block():
-            self.dispatch(node.body)
+            self.traverse(node.body)
         # collapse nested ifs into equivalent elifs.
         while node.orelse and len(node.orelse) == 1 and isinstance(node.orelse[0], ast.If):
             node = node.orelse[0]
             self.fill("elif ")
-            self.dispatch(node.test)
+            self.traverse(node.test)
             with self.block():
-                self.dispatch(node.body)
+                self.traverse(node.body)
         # final else
         if node.orelse:
             self.fill("else")
             with self.block():
-                self.dispatch(node.orelse)
+                self.traverse(node.orelse)
 
     def visit_While(self, node):
         self.fill("while ")
-        self.dispatch(node.test)
+        self.traverse(node.test)
         with self.block():
-            self.dispatch(node.body)
+            self.traverse(node.body)
         if node.orelse:
             self.fill("else")
             with self.block():
-                self.dispatch(node.orelse)
+                self.traverse(node.orelse)
 
     def _generic_With(self, node, async_=False):
         self.fill("async with " if async_ else "with ")
         if hasattr(node, "items"):
-            self.interleave(lambda: self.write(", "), self.dispatch, node.items)
+            self.interleave(lambda: self.write(", "), self.traverse, node.items)
         else:
-            self.dispatch(node.context_expr)
+            self.traverse(node.context_expr)
             if node.optional_vars:
                 self.write(" as ")
-                self.dispatch(node.optional_vars)
+                self.traverse(node.optional_vars)
         with self.block():
-            self.dispatch(node.body)
+            self.traverse(node.body)
 
     def visit_With(self, node):
         self._generic_With(node)
@@ -634,33 +634,33 @@ class Unparser:
 
     def visit_List(self, node):
         with self.delimit("[", "]"):
-            self.interleave(lambda: self.write(", "), self.dispatch, node.elts)
+            self.interleave(lambda: self.write(", "), self.traverse, node.elts)
 
     def visit_ListComp(self, node):
         with self.delimit("[", "]"):
-            self.dispatch(node.elt)
+            self.traverse(node.elt)
             for gen in node.generators:
-                self.dispatch(gen)
+                self.traverse(gen)
 
     def visit_GeneratorExp(self, node):
         with self.delimit("(", ")"):
-            self.dispatch(node.elt)
+            self.traverse(node.elt)
             for gen in node.generators:
-                self.dispatch(gen)
+                self.traverse(gen)
 
     def visit_SetComp(self, node):
         with self.delimit("{", "}"):
-            self.dispatch(node.elt)
+            self.traverse(node.elt)
             for gen in node.generators:
-                self.dispatch(gen)
+                self.traverse(gen)
 
     def visit_DictComp(self, node):
         with self.delimit("{", "}"):
-            self.dispatch(node.key)
+            self.traverse(node.key)
             self.write(": ")
-            self.dispatch(node.value)
+            self.traverse(node.value)
             for gen in node.generators:
-                self.dispatch(gen)
+                self.traverse(gen)
 
     def visit_comprehension(self, node):
         if getattr(node, "is_async", False):
@@ -668,34 +668,34 @@ class Unparser:
         else:
             self.write(" for ")
         self.set_precedence(_Precedence.TUPLE, node.target)
-        self.dispatch(node.target)
+        self.traverse(node.target)
         self.write(" in ")
         self.set_precedence(_Precedence.TEST.next(), node.iter, *node.ifs)
-        self.dispatch(node.iter)
+        self.traverse(node.iter)
         for if_clause in node.ifs:
             self.write(" if ")
-            self.dispatch(if_clause)
+            self.traverse(if_clause)
 
     def visit_IfExp(self, node):
         with self.require_parens(_Precedence.TEST, node):
             self.set_precedence(_Precedence.TEST.next(), node.body, node.test)
-            self.dispatch(node.body)
+            self.traverse(node.body)
             self.write(" if ")
-            self.dispatch(node.test)
+            self.traverse(node.test)
             self.write(" else ")
             self.set_precedence(_Precedence.TEST, node.orelse)
-            self.dispatch(node.orelse)
+            self.traverse(node.orelse)
 
     def visit_Set(self, node):
         assert node.elts  # should be at least one element
         with self.delimit("{", "}"):
-            self.interleave(lambda: self.write(", "), self.dispatch, node.elts)
+            self.interleave(lambda: self.write(", "), self.traverse, node.elts)
 
     def visit_Dict(self, node):
         def write_key_value_pair(k, v):
-            self.dispatch(k)
+            self.traverse(k)
             self.write(": ")
-            self.dispatch(v)
+            self.traverse(v)
 
         def write_item(item):
             k, v = item
@@ -704,7 +704,7 @@ class Unparser:
                 # see PEP 448 for details
                 self.write("**")
                 self.set_precedence(_Precedence.EXPR, v)
-                self.dispatch(v)
+                self.traverse(v)
             else:
                 write_key_value_pair(k, v)
 
@@ -713,7 +713,7 @@ class Unparser:
 
     def visit_Tuple(self, node):
         with self.delimit("(", ")"):
-            self.items_view(self.dispatch, node.elts)
+            self.items_view(self.traverse, node.elts)
 
     unop = {"Invert": "~", "Not": "not", "UAdd": "+", "USub": "-"}
 
@@ -734,7 +734,7 @@ class Unparser:
             if operator_precedence != _Precedence.FACTOR:
                 self.write(" ")
             self.set_precedence(operator_precedence, node.operand)
-            self.dispatch(node.operand)
+            self.traverse(node.operand)
 
     binop = {
         "Add": "+",
@@ -782,10 +782,10 @@ class Unparser:
                 right_precedence = operator_precedence.next()
 
             self.set_precedence(left_precedence, node.left)
-            self.dispatch(node.left)
+            self.traverse(node.left)
             self.write(" %s " % operator)
             self.set_precedence(right_precedence, node.right)
-            self.dispatch(node.right)
+            self.traverse(node.right)
 
     cmpops = {
         "Eq": "==",
@@ -803,10 +803,10 @@ class Unparser:
     def visit_Compare(self, node):
         with self.require_parens(_Precedence.CMP, node):
             self.set_precedence(_Precedence.CMP.next(), node.left, *node.comparators)
-            self.dispatch(node.left)
+            self.traverse(node.left)
             for o, e in zip(node.ops, node.comparators):
                 self.write(" " + self.cmpops[o.__class__.__name__] + " ")
-                self.dispatch(e)
+                self.traverse(e)
 
     boolops = {"And": "and", "Or": "or"}
 
@@ -821,7 +821,7 @@ class Unparser:
         def increasing_level_dispatch(node):
             op["precedence"] = op["precedence"].next()
             self.set_precedence(op["precedence"], node)
-            self.dispatch(node)
+            self.traverse(node)
 
         with self.require_parens(op["precedence"], node):
             s = " %s " % operator
@@ -829,7 +829,7 @@ class Unparser:
 
     def visit_Attribute(self, node: ast.Attribute):
         self.set_precedence(_Precedence.ATOM, node.value)
-        self.dispatch(node.value)
+        self.traverse(node.value)
         # Special case: 3.__abs__() is a syntax error, so if node.value
         # is an integer literal then we need to either parenthesize
         # it or add an extra space to get 3 .__abs__().
@@ -842,7 +842,7 @@ class Unparser:
         self.set_precedence(_Precedence.ATOM, node.func)
 
         args = node.args
-        self.dispatch(node.func)
+        self.traverse(node.func)
 
         with self.delimit("(", ")"):
             comma = False
@@ -856,28 +856,28 @@ class Unparser:
                     self.write(", ")
                 else:
                     comma = True
-                self.dispatch(e)
+                self.traverse(e)
 
             for e in node.keywords:
                 if comma:
                     self.write(", ")
                 else:
                     comma = True
-                self.dispatch(e)
+                self.traverse(e)
 
     def visit_Subscript(self, node):
         self.set_precedence(_Precedence.ATOM, node.value)
-        self.dispatch(node.value)
+        self.traverse(node.value)
         with self.delimit("[", "]"):
             if is_simple_tuple(node.slice):
-                self.items_view(self.dispatch, node.slice.elts)
+                self.items_view(self.traverse, node.slice.elts)
             else:
-                self.dispatch(node.slice)
+                self.traverse(node.slice)
 
     def visit_Starred(self, node):
         self.write("*")
         self.set_precedence(_Precedence.EXPR, node.value)
-        self.dispatch(node.value)
+        self.traverse(node.value)
 
     # slice
     def visit_Ellipsis(self, node):
@@ -887,30 +887,30 @@ class Unparser:
     def visit_Index(self, node):
         if is_simple_tuple(node.value):
             self.set_precedence(_Precedence.ATOM, node.value)
-            self.items_view(self.dispatch, node.value.elts)
+            self.items_view(self.traverse, node.value.elts)
         else:
             self.set_precedence(_Precedence.TUPLE, node.value)
-            self.dispatch(node.value)
+            self.traverse(node.value)
 
     def visit_Slice(self, node):
         if node.lower:
-            self.dispatch(node.lower)
+            self.traverse(node.lower)
         self.write(":")
         if node.upper:
-            self.dispatch(node.upper)
+            self.traverse(node.upper)
         if node.step:
             self.write(":")
-            self.dispatch(node.step)
+            self.traverse(node.step)
 
     def visit_ExtSlice(self, node):
-        self.interleave(lambda: self.write(", "), self.dispatch, node.dims)
+        self.interleave(lambda: self.write(", "), self.traverse, node.dims)
 
     # argument
     def visit_arg(self, node):
         self.write(node.arg)
         if node.annotation:
             self.write(": ")
-            self.dispatch(node.annotation)
+            self.traverse(node.annotation)
 
     # others
     def visit_arguments(self, node):
@@ -924,10 +924,10 @@ class Unparser:
                 first = False
             else:
                 self.write(", ")
-            self.dispatch(a)
+            self.traverse(a)
             if d:
                 self.write("=")
-                self.dispatch(d)
+                self.traverse(d)
             if index == len(getattr(node, "posonlyargs", ())):
                 self.write(", /")
 
@@ -942,7 +942,7 @@ class Unparser:
                 self.write(node.vararg.arg)
                 if node.vararg.annotation:
                     self.write(": ")
-                    self.dispatch(node.vararg.annotation)
+                    self.traverse(node.vararg.annotation)
 
         # keyword-only arguments
         if getattr(node, "kwonlyargs", False):
@@ -951,10 +951,10 @@ class Unparser:
                     first = False
                 else:
                     self.write(", ")
-                self.dispatch(a),
+                self.traverse(a),
                 if d:
                     self.write("=")
-                    self.dispatch(d)
+                    self.traverse(d)
 
         # kwargs
         if node.kwarg:
@@ -965,7 +965,7 @@ class Unparser:
             self.write("**" + node.kwarg.arg)
             if node.kwarg.annotation:
                 self.write(": ")
-                self.dispatch(node.kwarg.annotation)
+                self.traverse(node.kwarg.annotation)
 
     def visit_keyword(self, node):
         if node.arg is None:
@@ -974,15 +974,15 @@ class Unparser:
         else:
             self.write(node.arg)
             self.write("=")
-        self.dispatch(node.value)
+        self.traverse(node.value)
 
     def visit_Lambda(self, node):
         with self.require_parens(_Precedence.TEST, node):
             self.write("lambda ")
-            self.dispatch(node.args)
+            self.traverse(node.args)
             self.write(": ")
             self.set_precedence(_Precedence.TEST, node.body)
-            self.dispatch(node.body)
+            self.traverse(node.body)
 
     def visit_alias(self, node):
         self.write(node.name)
@@ -990,36 +990,36 @@ class Unparser:
             self.write(" as " + node.asname)
 
     def visit_withitem(self, node):
-        self.dispatch(node.context_expr)
+        self.traverse(node.context_expr)
         if node.optional_vars:
             self.write(" as ")
-            self.dispatch(node.optional_vars)
+            self.traverse(node.optional_vars)
 
     def visit_Match(self, node):
         self.fill("match ")
-        self.dispatch(node.subject)
+        self.traverse(node.subject)
         with self.block():
             for case in node.cases:
-                self.dispatch(case)
+                self.traverse(case)
 
     def visit_match_case(self, node):
         self.fill("case ")
-        self.dispatch(node.pattern)
+        self.traverse(node.pattern)
         if node.guard:
             self.write(" if ")
-            self.dispatch(node.guard)
+            self.traverse(node.guard)
         with self.block():
-            self.dispatch(node.body)
+            self.traverse(node.body)
 
     def visit_MatchValue(self, node):
-        self.dispatch(node.value)
+        self.traverse(node.value)
 
     def visit_MatchSingleton(self, node):
         self._write_constant(node.value)
 
     def visit_MatchSequence(self, node):
         with self.delimit("[", "]"):
-            self.interleave(lambda: self.write(", "), self.dispatch, node.patterns)
+            self.interleave(lambda: self.write(", "), self.traverse, node.patterns)
 
     def visit_MatchStar(self, node):
         name = node.name
@@ -1030,9 +1030,9 @@ class Unparser:
     def visit_MatchMapping(self, node):
         def write_key_pattern_pair(pair):
             k, p = pair
-            self.dispatch(k)
+            self.traverse(k)
             self.write(": ")
-            self.dispatch(p)
+            self.traverse(p)
 
         with self.delimit("{", "}"):
             keys = node.keys
@@ -1047,17 +1047,17 @@ class Unparser:
 
     def visit_MatchClass(self, node):
         self.set_precedence(_Precedence.ATOM, node.cls)
-        self.dispatch(node.cls)
+        self.traverse(node.cls)
         with self.delimit("(", ")"):
             patterns = node.patterns
-            self.interleave(lambda: self.write(", "), self.dispatch, patterns)
+            self.interleave(lambda: self.write(", "), self.traverse, patterns)
             attrs = node.kwd_attrs
             if attrs:
 
                 def write_attr_pattern(pair):
                     attr, pattern = pair
                     self.write("{}=".format(attr))
-                    self.dispatch(pattern)
+                    self.traverse(pattern)
 
                 if patterns:
                     self.write(", ")
@@ -1075,29 +1075,29 @@ class Unparser:
         else:
             with self.require_parens(_Precedence.TEST, node):
                 self.set_precedence(_Precedence.BOR, node.pattern)
-                self.dispatch(node.pattern)
+                self.traverse(node.pattern)
                 self.write(" as {}".format(node.name))
 
     def visit_MatchOr(self, node):
         with self.require_parens(_Precedence.BOR, node):
             self.set_precedence(_Precedence.BOR.next(), *node.patterns)
-            self.interleave(lambda: self.write(" | "), self.dispatch, node.patterns)
+            self.interleave(lambda: self.write(" | "), self.traverse, node.patterns)
 
     def visit_TypeAlias(self, node):
         self.fill("type ")
-        self.dispatch(node.name)
+        self.traverse(node.name)
         if node.type_params:
             self.write("[")
-            self.interleave(lambda: self.write(", "), self.dispatch, node.type_params)
+            self.interleave(lambda: self.write(", "), self.traverse, node.type_params)
             self.write("]")
         self.write(" = ")
-        self.dispatch(node.value)
+        self.traverse(node.value)
 
     def visit_TypeVar(self, node):
         self.write(node.name)
         if node.bound:
             self.write(": ")
-            self.dispatch(node.bound)
+            self.traverse(node.bound)
 
     def visit_TypeVarTuple(self, node):
         self.write("*")

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -850,10 +850,9 @@ class Unparser(NodeVisitor):
             self.interleave(lambda: self.write(", "), write_item, zip(node.keys, node.values))
 
     def visit_Tuple(self, node):
-        # with self.delimit_if(
-        #     "(", ")", len(node.elts) == 0 or self.get_precedence(node) > _Precedence.TUPLE
-        # ):
-        with self.delimit("(", ")"):  # don't change spack package hash
+        with self.delimit_if(
+            "(", ")", len(node.elts) == 0 or self.get_precedence(node) > _Precedence.TUPLE
+        ):
             self.items_view(self.traverse, node.elts)
 
     unop = {"Invert": "~", "Not": "not", "UAdd": "+", "USub": "-"}
@@ -1022,10 +1021,8 @@ class Unparser(NodeVisitor):
     # used in Python <= 3.8 -- see _Subscript for 3.9+
     def visit_Index(self, node):
         if is_non_empty_non_star_tuple(node.value):
-            self.set_precedence(_Precedence.ATOM, node.value)
             self.items_view(self.traverse, node.value.elts)
         else:
-            self.set_precedence(_Precedence.TUPLE, node.value)
             self.traverse(node.value)
 
     def visit_Slice(self, node):
@@ -1121,8 +1118,8 @@ class Unparser(NodeVisitor):
             self.write("lambda")
             with self.buffered() as buffer:
                 self.traverse(node.args)
-            # if buffer: # don't change spack package hash change
-            self.write(" ", *buffer)
+            if buffer:
+                self.write(" ", *buffer)
             self.write(": ")
             self.set_precedence(_Precedence.TEST, node.body)
             self.traverse(node.body)

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -183,6 +183,16 @@ class Unparser(NodeVisitor):
         self._source.extend(text)
 
     @contextmanager
+    def buffered(self, buffer=None):
+        if buffer is None:
+            buffer = []
+
+        original_source = self._source
+        self._source = buffer
+        yield buffer
+        self._source = original_source
+
+    @contextmanager
     def block(self, *, extra=None):
         """A context manager for preparing the source for blocks. It adds
         the character':', increases the indentation on enter and decreases
@@ -1084,8 +1094,11 @@ class Unparser(NodeVisitor):
 
     def visit_Lambda(self, node):
         with self.require_parens(_Precedence.TEST, node):
-            self.write("lambda ")
-            self.traverse(node.args)
+            self.write("lambda")
+            with self.buffered() as buffer:
+                self.traverse(node.args)
+            if buffer:
+                self.write(" ", *buffer)
             self.write(": ")
             self.set_precedence(_Precedence.TEST, node.body)
             self.traverse(node.body)

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -888,7 +888,12 @@ class Unparser(NodeVisitor):
 
     def visit_Tuple(self, node):
         with self.delimit_if(
-            "(", ")", len(node.elts) == 0 or self.get_precedence(node) > _Precedence.TUPLE
+            "(",
+            ")",
+            # Don't drop redundant parenthesis to mimic python <= 3.10
+            self._py_ver_consistent
+            or len(node.elts) == 0
+            or self.get_precedence(node) > _Precedence.TUPLE,
         ):
             self.items_view(self.traverse, node.elts)
 
@@ -1155,7 +1160,8 @@ class Unparser(NodeVisitor):
             self.write("lambda")
             with self.buffered() as buffer:
                 self.traverse(node.args)
-            if buffer:
+            # Don't omit extra space to mimic python <= 3.10
+            if buffer or self._py_ver_consistent:
                 self.write(" ", *buffer)
             self.write(": ")
             self.set_precedence(_Precedence.TEST, node.body)

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -4,7 +4,7 @@
 "Usage: unparse.py <path to source file>"
 import ast
 import sys
-from ast import AST, If, Name
+from ast import AST, If, Name, Tuple
 from contextlib import contextmanager
 from enum import IntEnum, auto
 from io import StringIO
@@ -14,6 +14,15 @@ from io import StringIO
 @contextmanager
 def nullcontext():
     yield
+
+
+def is_non_empty_non_star_tuple(slice_value):
+    """True for `(1, 2)`, False for `()` and `(1, *b)`"""
+    return (
+        isinstance(slice_value, Tuple)
+        and slice_value.elts
+        and not any(isinstance(elt, ast.Starred) for elt in slice_value.elts)
+    )
 
 
 def iter_fields(node):
@@ -106,19 +115,6 @@ class _Precedence(IntEnum):
 _SINGLE_QUOTES = ("'", '"')
 _MULTI_QUOTES = ('"""', "'''")
 _ALL_QUOTES = (*_SINGLE_QUOTES, *_MULTI_QUOTES)
-
-
-def is_simple_tuple(slice_value):
-    # when unparsing a non-empty tuple, the parantheses can be safely
-    # omitted if there aren't any elements that explicitly requires
-    # parantheses (such as starred expressions).
-    return (
-        isinstance(slice_value, ast.Tuple)
-        and slice_value.elts
-        # Python < 3.11. Grammar change.
-        # https://github.com/python/cpython/commit/e8e737bcf6d22927caebc30c5d57ac4634063219
-        and not any(isinstance(elt, ast.Starred) for elt in slice_value.elts)
-    )
 
 
 class Unparser(NodeVisitor):
@@ -987,10 +983,16 @@ class Unparser(NodeVisitor):
                 self.traverse(e)
 
     def visit_Subscript(self, node):
+        def is_non_empty_tuple(slice_value):
+            return isinstance(slice_value, Tuple) and slice_value.elts
+
         self.set_precedence(_Precedence.ATOM, node.value)
         self.traverse(node.value)
         with self.delimit("[", "]"):
-            if is_simple_tuple(node.slice):
+            # Python >= 3.11 supports `a[42, *b]` (same AST as a[(42, *b)]),
+            # but this is syntax error in 3.10.
+            # So, always emit parenthesis `a[(42, *b)]`
+            if is_non_empty_non_star_tuple(node.slice):
                 self.items_view(self.traverse, node.slice.elts)
             else:
                 self.traverse(node.slice)
@@ -1007,7 +1009,7 @@ class Unparser(NodeVisitor):
 
     # used in Python <= 3.8 -- see _Subscript for 3.9+
     def visit_Index(self, node):
-        if is_simple_tuple(node.value):
+        if is_non_empty_non_star_tuple(node.value):
             self.set_precedence(_Precedence.ATOM, node.value)
             self.items_view(self.traverse, node.value.elts)
         else:

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -46,19 +46,6 @@ def pnext(precedence):
     return min(precedence + 1, _Precedence.ATOM)
 
 
-def interleave(inter, f, seq):
-    """Call f on each item in seq, calling inter() in between."""
-    seq = iter(seq)
-    try:
-        f(next(seq))
-    except StopIteration:
-        pass
-    else:
-        for x in seq:
-            inter()
-            f(x)
-
-
 _SINGLE_QUOTES = ("'", '"')
 _MULTI_QUOTES = ('"""', "'''")
 _ALL_QUOTES = (*_SINGLE_QUOTES, *_MULTI_QUOTES)
@@ -97,6 +84,18 @@ class Unparser:
         self._precedences = {}
         self._avoid_backslashes = _avoid_backslashes
 
+    def interleave(self, inter, f, seq):
+        """Call f on each item in seq, calling inter() in between."""
+        seq = iter(seq)
+        try:
+            f(next(seq))
+        except StopIteration:
+            pass
+        else:
+            for x in seq:
+                inter()
+                f(x)
+
     def items_view(self, traverser, items):
         """Traverse and separate the given *items* with a comma and append it to
         the buffer. If *items* is a single item sequence, a trailing comma
@@ -105,7 +104,7 @@ class Unparser:
             traverser(items[0])
             self.write(",")
         else:
-            interleave(lambda: self.write(", "), traverser, items)
+            self.interleave(lambda: self.write(", "), traverser, items)
 
     def visit(self, tree, output_file):
         """Traverse tree and write source code to output_file."""
@@ -207,7 +206,7 @@ class Unparser:
 
     def visit_Import(self, node):
         self.fill("import ")
-        interleave(lambda: self.write(", "), self.dispatch, node.names)
+        self.interleave(lambda: self.write(", "), self.dispatch, node.names)
 
     def visit_ImportFrom(self, node):
         # A from __future__ import may affect unparsing, so record it.
@@ -219,7 +218,7 @@ class Unparser:
         if node.module:
             self.write(node.module)
         self.write(" import ")
-        interleave(lambda: self.write(", "), self.dispatch, node.names)
+        self.interleave(lambda: self.write(", "), self.dispatch, node.names)
 
     def visit_Assign(self, node):
         self.fill()
@@ -261,7 +260,7 @@ class Unparser:
 
     def visit_Delete(self, node):
         self.fill("del ")
-        interleave(lambda: self.write(", "), self.dispatch, node.targets)
+        self.interleave(lambda: self.write(", "), self.dispatch, node.targets)
 
     def visit_Assert(self, node):
         self.fill("assert ")
@@ -272,11 +271,11 @@ class Unparser:
 
     def visit_Global(self, node):
         self.fill("global ")
-        interleave(lambda: self.write(", "), self.write, node.names)
+        self.interleave(lambda: self.write(", "), self.write, node.names)
 
     def visit_Nonlocal(self, node):
         self.fill("nonlocal ")
-        interleave(lambda: self.write(", "), self.write, node.names)
+        self.interleave(lambda: self.write(", "), self.write, node.names)
 
     def visit_Await(self, node):
         with self.require_parens(_Precedence.AWAIT, node):
@@ -347,7 +346,7 @@ class Unparser:
         self.fill("class " + node.name)
         if getattr(node, "type_params", False):
             self.write("[")
-            interleave(lambda: self.write(", "), self.dispatch, node.type_params)
+            self.interleave(lambda: self.write(", "), self.dispatch, node.type_params)
             self.write("]")
         with self.delimit_if("(", ")", condition=node.bases or node.keywords):
             comma = False
@@ -381,7 +380,7 @@ class Unparser:
         self.fill(def_str)
         if getattr(node, "type_params", False):
             self.write("[")
-            interleave(lambda: self.write(", "), self.dispatch, node.type_params)
+            self.interleave(lambda: self.write(", "), self.dispatch, node.type_params)
             self.write("]")
         with self.delimit("(", ")"):
             self.dispatch(node.args)
@@ -440,7 +439,7 @@ class Unparser:
     def _generic_With(self, node, async_=False):
         self.fill("async with " if async_ else "with ")
         if hasattr(node, "items"):
-            interleave(lambda: self.write(", "), self.dispatch, node.items)
+            self.interleave(lambda: self.write(", "), self.dispatch, node.items)
         else:
             self.dispatch(node.context_expr)
             if node.optional_vars:
@@ -630,7 +629,7 @@ class Unparser:
 
     def visit_List(self, node):
         with self.delimit("[", "]"):
-            interleave(lambda: self.write(", "), self.dispatch, node.elts)
+            self.interleave(lambda: self.write(", "), self.dispatch, node.elts)
 
     def visit_ListComp(self, node):
         with self.delimit("[", "]"):
@@ -685,7 +684,7 @@ class Unparser:
     def visit_Set(self, node):
         assert node.elts  # should be at least one element
         with self.delimit("{", "}"):
-            interleave(lambda: self.write(", "), self.dispatch, node.elts)
+            self.interleave(lambda: self.write(", "), self.dispatch, node.elts)
 
     def visit_Dict(self, node):
         def write_key_value_pair(k, v):
@@ -705,7 +704,7 @@ class Unparser:
                 write_key_value_pair(k, v)
 
         with self.delimit("{", "}"):
-            interleave(lambda: self.write(", "), write_item, zip(node.keys, node.values))
+            self.interleave(lambda: self.write(", "), write_item, zip(node.keys, node.values))
 
     def visit_Tuple(self, node):
         with self.delimit("(", ")"):
@@ -821,7 +820,7 @@ class Unparser:
 
         with self.require_parens(op["precedence"], node):
             s = " %s " % operator
-            interleave(lambda: self.write(s), increasing_level_dispatch, node.values)
+            self.interleave(lambda: self.write(s), increasing_level_dispatch, node.values)
 
     def visit_Attribute(self, node: ast.Attribute):
         self.set_precedence(_Precedence.ATOM, node.value)
@@ -899,7 +898,7 @@ class Unparser:
             self.dispatch(node.step)
 
     def visit_ExtSlice(self, node):
-        interleave(lambda: self.write(", "), self.dispatch, node.dims)
+        self.interleave(lambda: self.write(", "), self.dispatch, node.dims)
 
     # argument
     def visit_arg(self, node):
@@ -1015,7 +1014,7 @@ class Unparser:
 
     def visit_MatchSequence(self, node):
         with self.delimit("[", "]"):
-            interleave(lambda: self.write(", "), self.dispatch, node.patterns)
+            self.interleave(lambda: self.write(", "), self.dispatch, node.patterns)
 
     def visit_MatchStar(self, node):
         name = node.name
@@ -1032,7 +1031,9 @@ class Unparser:
 
         with self.delimit("{", "}"):
             keys = node.keys
-            interleave(lambda: self.write(", "), write_key_pattern_pair, zip(keys, node.patterns))
+            self.interleave(
+                lambda: self.write(", "), write_key_pattern_pair, zip(keys, node.patterns)
+            )
             rest = node.rest
             if rest is not None:
                 if keys:
@@ -1044,7 +1045,7 @@ class Unparser:
         self.dispatch(node.cls)
         with self.delimit("(", ")"):
             patterns = node.patterns
-            interleave(lambda: self.write(", "), self.dispatch, patterns)
+            self.interleave(lambda: self.write(", "), self.dispatch, patterns)
             attrs = node.kwd_attrs
             if attrs:
 
@@ -1055,7 +1056,7 @@ class Unparser:
 
                 if patterns:
                     self.write(", ")
-                interleave(
+                self.interleave(
                     lambda: self.write(", "), write_attr_pattern, zip(attrs, node.kwd_patterns)
                 )
 
@@ -1075,14 +1076,14 @@ class Unparser:
     def visit_MatchOr(self, node):
         with self.require_parens(_Precedence.BOR, node):
             self.set_precedence(pnext(_Precedence.BOR), *node.patterns)
-            interleave(lambda: self.write(" | "), self.dispatch, node.patterns)
+            self.interleave(lambda: self.write(" | "), self.dispatch, node.patterns)
 
     def visit_TypeAlias(self, node):
         self.fill("type ")
         self.dispatch(node.name)
         if node.type_params:
             self.write("[")
-            interleave(lambda: self.write(", "), self.dispatch, node.type_params)
+            self.interleave(lambda: self.write(", "), self.dispatch, node.type_params)
             self.write("]")
         self.write(" = ")
         self.dispatch(node.value)

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -268,7 +268,7 @@ class Unparser(NodeVisitor):
             self.traverse(node.body)
 
     def visit_Module(self, node):
-        # Python < 3.8. Types
+        # Python 3.8 introduced types
         self._type_ignores = {
             ignore.lineno: f"ignore{ignore.tag}" for ignore in getattr(node, "type_ignores", ())
         }
@@ -646,7 +646,8 @@ class Unparser(NodeVisitor):
 
     def visit_JoinedStr(self, node):
         self.write("f")
-        # Python <= 3.11 does not support backslashes inside format parts
+        # Python 3.12 added support for backslashes inside format parts.
+        # We need to keep adding backslashes for python < 3.11 compat.
         if self._avoid_backslashes:
             with self.buffered() as buffer:
                 self._write_fstring_inner(node)
@@ -656,7 +657,7 @@ class Unparser(NodeVisitor):
         for value in node.values:
             with self.buffered() as buffer:
                 self._write_fstring_inner(value)
-            # Python 3.8 changed Str to Constant
+            # Python 3.8 replaced Str with Constant
             fstring_parts.append(
                 ("".join(buffer), isinstance(value, Constant) or type(value).__name__ == "Str")
             )
@@ -704,7 +705,7 @@ class Unparser(NodeVisitor):
             # for both the f-string itself, and format_spec
             for value in node.values:
                 self._write_fstring_inner(value, is_format_spec=is_format_spec)
-        # Python 3.8 changed Str to Constant
+        # Python 3.8 replaced Str with Constant
         elif type(node).__name__ == "Str":
             value = node.s.replace("{", "{{").replace("}", "}}")
 
@@ -761,7 +762,7 @@ class Unparser(NodeVisitor):
         # Ubuntu 18's Python 3.6 doesn't have "kind"
         if not self._py_ver_consistent and getattr(node, "kind", None) == "u":
             self.write("u")
-        # Python 3.8 changed Str to Constant
+        # Python 3.8 replaced Str with Constant
         value = node.s if type(node).__name__ == "Str" else node.value
         self._write_str_avoiding_backslashes(value, quote_types=_MULTI_QUOTES)
 
@@ -1060,7 +1061,8 @@ class Unparser(NodeVisitor):
     def visit_Ellipsis(self, node):
         self.write("...")
 
-    # used in Python <= 3.8 -- see _Subscript for 3.9+
+    # Python 3.9 simplified Subscript(Index(value)) to Subscript(value)
+    # https://github.com/python/cpython/commit/13d52c268699f199a8e917a0f1dc4c51e5346c42
     def visit_Index(self, node):
         if is_non_empty_non_star_tuple(node.value):
             self.items_view(self.traverse, node.value.elts)
@@ -1084,7 +1086,8 @@ class Unparser(NodeVisitor):
             for case in node.cases:
                 self.traverse(case)
 
-    # Python < 3.9. ExtSlice(slices) replaced with Tuple(slices, Load()).
+    # Python 3.9 replaced ExtSlice(slices) with Tuple(slices, Load())
+    # https://github.com/python/cpython/commit/13d52c268699f199a8e917a0f1dc4c51e5346c42
     def visit_ExtSlice(self, node):
         self.interleave(lambda: self.write(", "), self.traverse, node.dims)
 
@@ -1097,7 +1100,7 @@ class Unparser(NodeVisitor):
     def visit_arguments(self, node):
         first = True
         # normal arguments
-        # Python < 3.8. Position-only arguments
+        # Python 3.8 introduced position-only arguments (PEP 570)
         all_args = getattr(node, "posonlyargs", []) + node.args
         defaults = [None] * (len(all_args) - len(node.defaults)) + node.defaults
         for index, elements in enumerate(zip(all_args, defaults), 1):
@@ -1110,7 +1113,7 @@ class Unparser(NodeVisitor):
             if d:
                 self.write("=")
                 self.traverse(d)
-                # Python < 3.8. Position-only arguments
+                # Python 3.8 introduced position-only arguments (PEP 570)
             if index == len(getattr(node, "posonlyargs", ())):
                 self.write(", /")
 
@@ -1160,7 +1163,8 @@ class Unparser(NodeVisitor):
             self.write("lambda")
             with self.buffered() as buffer:
                 self.traverse(node.args)
-            # Don't omit extra space to mimic python <= 3.10
+            # Don't omit extra space to keep old package hash
+            # (extra space was removed in python 3.11)
             if buffer or self._py_ver_consistent:
                 self.write(" ", *buffer)
             self.write(": ")

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -1097,8 +1097,8 @@ class Unparser(NodeVisitor):
             self.write("lambda")
             with self.buffered() as buffer:
                 self.traverse(node.args)
-            if buffer:
-                self.write(" ", *buffer)
+            # if buffer: # don't change spack package hash change
+            self.write(" ", *buffer)
             self.write(": ")
             self.set_precedence(_Precedence.TEST, node.body)
             self.traverse(node.body)

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -4,6 +4,7 @@
 "Usage: unparse.py <path to source file>"
 import ast
 import sys
+from ast import If, Name
 from contextlib import contextmanager
 from enum import IntEnum, auto
 from io import StringIO
@@ -83,11 +84,11 @@ class Unparser:
         the way Python 2 would. This preserved Spack package hash consistency during the
         python2/3 transition
         """
-        self.future_imports = []
         self._source = []
-        self._indent = 0
-        self._py_ver_consistent = py_ver_consistent
         self._precedences = {}
+        self._indent = 0
+        self.future_imports = []
+        self._py_ver_consistent = py_ver_consistent
         self._avoid_backslashes = _avoid_backslashes
 
     def interleave(self, inter, f, seq):
@@ -226,7 +227,7 @@ class Unparser:
             self.future_imports.extend(n.name for n in node.names)
 
         self.fill("from ")
-        self.write("." * node.level)
+        self.write("." * (node.level or 0))
         if node.module:
             self.write(node.module)
         self.write(" import ")
@@ -247,7 +248,7 @@ class Unparser:
 
     def visit_AnnAssign(self, node):
         self.fill()
-        with self.delimit_if("(", ")", not node.simple and isinstance(node.target, ast.Name)):
+        with self.delimit_if("(", ")", not node.simple and isinstance(node.target, Name)):
             self.traverse(node.target)
         self.write(": ")
         self.traverse(node.annotation)
@@ -307,16 +308,17 @@ class Unparser:
 
     def visit_YieldFrom(self, node):
         with self.require_parens(_Precedence.YIELD, node):
-            self.write("yield from")
-            if node.value:
-                self.write(" ")
-                self.set_precedence(_Precedence.ATOM, node.value)
-                self.traverse(node.value)
+            self.write("yield from ")
+            if not node.value:
+                raise ValueError("Node can't be used without a value attribute.")
+            self.set_precedence(_Precedence.ATOM, node.value)
+            self.traverse(node.value)
 
     def visit_Raise(self, node):
         self.fill("raise")
         if not node.exc:
-            assert not node.cause
+            if node.cause:
+                raise ValueError(f"Node can't use cause without an exception.")
             return
         self.write(" ")
         self.traverse(node.exc)
@@ -374,16 +376,17 @@ class Unparser:
                 else:
                     comma = True
                 self.traverse(e)
+
         with self.block():
             self.traverse(node.body)
 
     def visit_FunctionDef(self, node):
-        self.__FunctionDef_helper(node, "def")
+        self._function_helper(node, "def")
 
     def visit_AsyncFunctionDef(self, node):
-        self.__FunctionDef_helper(node, "async def")
+        self._function_helper(node, "async def")
 
-    def __FunctionDef_helper(self, node, fill_suffix):
+    def _function_helper(self, node, fill_suffix):
         self.maybe_newline()
         for deco in node.decorator_list:
             self.fill("@")
@@ -402,13 +405,37 @@ class Unparser:
         with self.block():
             self.traverse(node.body)
 
+    def visit_TypeVar(self, node):
+        self.write(node.name)
+        if node.bound:
+            self.write(": ")
+            self.traverse(node.bound)
+
+    def visit_TypeVarTuple(self, node):
+        self.write("*")
+        self.write(node.name)
+
+    def visit_ParamSpec(self, node):
+        self.write("**")
+        self.write(node.name)
+
+    def visit_TypeAlias(self, node):
+        self.fill("type ")
+        self.traverse(node.name)
+        if node.type_params:
+            self.write("[")
+            self.interleave(lambda: self.write(", "), self.traverse, node.type_params)
+            self.write("]")
+        self.write(" = ")
+        self.traverse(node.value)
+
     def visit_For(self, node):
-        self.__For_helper("for ", node)
+        self._for_helper("for ", node)
 
     def visit_AsyncFor(self, node):
-        self.__For_helper("async for ", node)
+        self._for_helper("async for ", node)
 
-    def __For_helper(self, fill, node):
+    def _for_helper(self, fill, node):
         self.fill(fill)
         self.traverse(node.target)
         self.write(" in ")
@@ -426,7 +453,7 @@ class Unparser:
         with self.block():
             self.traverse(node.body)
         # collapse nested ifs into equivalent elifs.
-        while node.orelse and len(node.orelse) == 1 and isinstance(node.orelse[0], ast.If):
+        while node.orelse and len(node.orelse) == 1 and isinstance(node.orelse[0], If):
             node = node.orelse[0]
             self.fill("elif ")
             self.traverse(node.test)
@@ -467,7 +494,7 @@ class Unparser:
         self._generic_With(node, async_=True)
 
     def _str_literal_helper(
-        self, string, quote_types=_ALL_QUOTES, escape_special_whitespace=False
+        self, string, *, quote_types=_ALL_QUOTES, escape_special_whitespace=False
     ):
         """Helper for writing string literals, minimizing escapes.
         Returns the tuple (string literal to write, possible quote types).
@@ -505,11 +532,11 @@ class Unparser:
                 escaped_string = escaped_string[:-1] + "\\" + escaped_string[-1]
         return escaped_string, possible_quotes
 
-    def _write_str_avoiding_backslashes(self, string, quote_types=_ALL_QUOTES):
-        """Write string literal value w/a best effort attempt to avoid backslashes."""
+    def _write_str_avoiding_backslashes(self, string, *, quote_types=_ALL_QUOTES):
+        """Write string literal value with a best effort attempt to avoid backslashes."""
         string, quote_types = self._str_literal_helper(string, quote_types=quote_types)
         quote_type = quote_types[0]
-        self.write("{quote_type}{string}{quote_type}".format(quote_type=quote_type, string=string))
+        self.write(f"{quote_type}{string}{quote_type}")
 
     # expr
     def visit_Bytes(self, node):
@@ -554,7 +581,7 @@ class Unparser:
             new_buffer.append(value)
         value = "".join(new_buffer)
         quote_type = quote_types[0]
-        self.write("{quote_type}{value}{quote_type}".format(quote_type=quote_type, value=value))
+        self.write(f"{quote_type}{value}{quote_type}")
 
     def visit_FormattedValue(self, node):
         # FormattedValue(expr value, int? conversion, expr? format_spec)
@@ -626,7 +653,7 @@ class Unparser:
         if isinstance(value, tuple):
             with self.delimit("(", ")"):
                 self.items_view(self._write_constant, value)
-        elif value is Ellipsis:  # instead of `...` for Py2 compatibility
+        elif value is ...:
             self.write("...")
         else:
             if node.kind == "u":
@@ -721,10 +748,9 @@ class Unparser:
             self.items_view(self.traverse, node.elts)
 
     unop = {"Invert": "~", "Not": "not", "UAdd": "+", "USub": "-"}
-
     unop_precedence = {
-        "~": _Precedence.FACTOR,
         "not": _Precedence.NOT,
+        "~": _Precedence.FACTOR,
         "+": _Precedence.FACTOR,
         "-": _Precedence.FACTOR,
     }
@@ -736,7 +762,7 @@ class Unparser:
             self.write(operator)
             # factor prefixes (+, -, ~) shouldn't be separated
             # from the value they belong, (e.g: +1 instead of + 1)
-            if operator_precedence != _Precedence.FACTOR:
+            if operator_precedence is not _Precedence.FACTOR:
                 self.write(" ")
             self.set_precedence(operator_precedence, node.operand)
             self.traverse(node.operand)
@@ -788,7 +814,7 @@ class Unparser:
 
             self.set_precedence(left_precedence, node.left)
             self.traverse(node.left)
-            self.write(" %s " % operator)
+            self.write(f" {operator} ")
             self.set_precedence(right_precedence, node.right)
             self.traverse(node.right)
 
@@ -814,23 +840,21 @@ class Unparser:
                 self.traverse(e)
 
     boolops = {"And": "and", "Or": "or"}
-
     boolop_precedence = {"and": _Precedence.AND, "or": _Precedence.OR}
 
     def visit_BoolOp(self, node):
         operator = self.boolops[node.op.__class__.__name__]
+        operator_precedence = self.boolop_precedence[operator]
 
-        # use a dict instead of nonlocal for Python 2 compatibility
-        op = {"precedence": self.boolop_precedence[operator]}
-
-        def increasing_level_dispatch(node):
-            op["precedence"] = op["precedence"].next()
-            self.set_precedence(op["precedence"], node)
+        def increasing_level_traverse(node):
+            nonlocal operator_precedence
+            operator_precedence = operator_precedence.next()
+            self.set_precedence(operator_precedence, node)
             self.traverse(node)
 
-        with self.require_parens(op["precedence"], node):
-            s = " %s " % operator
-            self.interleave(lambda: self.write(s), increasing_level_dispatch, node.values)
+        with self.require_parens(operator_precedence, node):
+            s = f" {operator} "
+            self.interleave(lambda: self.write(s), increasing_level_traverse, node.values)
 
     def visit_Attribute(self, node: ast.Attribute):
         self.set_precedence(_Precedence.ATOM, node.value)
@@ -845,10 +869,7 @@ class Unparser:
 
     def visit_Call(self, node):
         self.set_precedence(_Precedence.ATOM, node.func)
-
-        args = node.args
         self.traverse(node.func)
-
         with self.delimit("(", ")"):
             comma = False
 
@@ -856,13 +877,12 @@ class Unparser:
             # If you run on python@:3.4, you will see instability in package hashes
             # across python versions
 
-            for e in args:
+            for e in node.args:
                 if comma:
                     self.write(", ")
                 else:
                     comma = True
                 self.traverse(e)
-
             for e in node.keywords:
                 if comma:
                     self.write(", ")
@@ -906,6 +926,13 @@ class Unparser:
         if node.step:
             self.write(":")
             self.traverse(node.step)
+
+    def visit_Match(self, node):
+        self.fill("match ")
+        self.traverse(node.subject)
+        with self.block():
+            for case in node.cases:
+                self.traverse(case)
 
     def visit_ExtSlice(self, node):
         self.interleave(lambda: self.write(", "), self.traverse, node.dims)
@@ -956,7 +983,7 @@ class Unparser:
                     first = False
                 else:
                     self.write(", ")
-                self.traverse(a),
+                self.traverse(a)
                 if d:
                     self.write("=")
                     self.traverse(d)
@@ -1000,13 +1027,6 @@ class Unparser:
             self.write(" as ")
             self.traverse(node.optional_vars)
 
-    def visit_Match(self, node):
-        self.fill("match ")
-        self.traverse(node.subject)
-        with self.block():
-            for case in node.cases:
-                self.traverse(case)
-
     def visit_match_case(self, node):
         self.fill("case ")
         self.traverse(node.pattern)
@@ -1030,7 +1050,7 @@ class Unparser:
         name = node.name
         if name is None:
             name = "_"
-        self.write("*{}".format(name))
+        self.write(f"*{name}")
 
     def visit_MatchMapping(self, node):
         def write_key_pattern_pair(pair):
@@ -1048,7 +1068,7 @@ class Unparser:
             if rest is not None:
                 if keys:
                     self.write(", ")
-                self.write("**{}".format(rest))
+                self.write(f"**{rest}")
 
     def visit_MatchClass(self, node):
         self.set_precedence(_Precedence.ATOM, node.cls)
@@ -1061,7 +1081,7 @@ class Unparser:
 
                 def write_attr_pattern(pair):
                     attr, pattern = pair
-                    self.write("{}=".format(attr))
+                    self.write(f"{attr}=")
                     self.traverse(pattern)
 
                 if patterns:
@@ -1081,36 +1101,12 @@ class Unparser:
             with self.require_parens(_Precedence.TEST, node):
                 self.set_precedence(_Precedence.BOR, node.pattern)
                 self.traverse(node.pattern)
-                self.write(" as {}".format(node.name))
+                self.write(f" as {node.name}")
 
     def visit_MatchOr(self, node):
         with self.require_parens(_Precedence.BOR, node):
             self.set_precedence(_Precedence.BOR.next(), *node.patterns)
             self.interleave(lambda: self.write(" | "), self.traverse, node.patterns)
-
-    def visit_TypeAlias(self, node):
-        self.fill("type ")
-        self.traverse(node.name)
-        if node.type_params:
-            self.write("[")
-            self.interleave(lambda: self.write(", "), self.traverse, node.type_params)
-            self.write("]")
-        self.write(" = ")
-        self.traverse(node.value)
-
-    def visit_TypeVar(self, node):
-        self.write(node.name)
-        if node.bound:
-            self.write(": ")
-            self.traverse(node.bound)
-
-    def visit_TypeVarTuple(self, node):
-        self.write("*")
-        self.write(node.name)
-
-    def visit_ParamSpec(self, node):
-        self.write("**")
-        self.write(node.name)
 
 
 if sys.version_info >= (3, 8):

--- a/lib/spack/spack/util/unparse/unparser.py
+++ b/lib/spack/spack/util/unparse/unparser.py
@@ -5,6 +5,7 @@
 import ast
 import sys
 from contextlib import contextmanager
+from enum import IntEnum, auto
 from io import StringIO
 
 
@@ -19,31 +20,35 @@ def nullcontext():
 _INFSTR = "1e" + repr(sys.float_info.max_10_exp + 1)
 
 
-class _Precedence:
+class _Precedence(IntEnum):
     """Precedence table that originated from python grammar."""
 
-    TUPLE = 0
-    YIELD = 1  # 'yield', 'yield from'
-    TEST = 2  # 'if'-'else', 'lambda'
-    OR = 3  # 'or'
-    AND = 4  # 'and'
-    NOT = 5  # 'not'
-    CMP = 6  # '<', '>', '==', '>=', '<=', '!=', 'in', 'not in', 'is', 'is not'
-    EXPR = 7
+    # NAMED_EXPR = auto()  # <target> := <expr1>
+    TUPLE = auto()  # <expr1>, <expr2>
+    YIELD = auto()  # 'yield', 'yield from'
+    TEST = auto()  # 'if'-'else', 'lambda'
+    OR = auto()  # 'or'
+    AND = auto()  # 'and'
+    NOT = auto()  # 'not'
+    CMP = auto()  # '<', '>', '==', '>=', '<=', '!=',
+    # 'in', 'not in', 'is', 'is not'
+    EXPR = auto()
     BOR = EXPR  # '|'
-    BXOR = 8  # '^'
-    BAND = 9  # '&'
-    SHIFT = 10  # '<<', '>>'
-    ARITH = 11  # '+', '-'
-    TERM = 12  # '*', '@', '/', '%', '//'
-    FACTOR = 13  # unary '+', '-', '~'
-    POWER = 14  # '**'
-    AWAIT = 15  # 'await'
-    ATOM = 16
+    BXOR = auto()  # '^'
+    BAND = auto()  # '&'
+    SHIFT = auto()  # '<<', '>>'
+    ARITH = auto()  # '+', '-'
+    TERM = auto()  # '*', '@', '/', '%', '//'
+    FACTOR = auto()  # unary '+', '-', '~'
+    POWER = auto()  # '**'
+    AWAIT = auto()  # 'await'
+    ATOM = auto()
 
-
-def pnext(precedence):
-    return min(precedence + 1, _Precedence.ATOM)
+    def next(self):
+        try:
+            return self.__class__(self + 1)
+        except ValueError:
+            return self
 
 
 _SINGLE_QUOTES = ("'", '"')
@@ -570,7 +575,7 @@ class Unparser:
 
         expr = StringIO()
         unparser = type(self)(py_ver_consistent=self._py_ver_consistent, _avoid_backslashes=True)
-        unparser.set_precedence(pnext(_Precedence.TEST), node.value)
+        unparser.set_precedence(_Precedence.TEST.next(), node.value)
         unparser.visit(node.value, expr)
         expr = expr.getvalue().rstrip("\n")
 
@@ -665,7 +670,7 @@ class Unparser:
         self.set_precedence(_Precedence.TUPLE, node.target)
         self.dispatch(node.target)
         self.write(" in ")
-        self.set_precedence(pnext(_Precedence.TEST), node.iter, *node.ifs)
+        self.set_precedence(_Precedence.TEST.next(), node.iter, *node.ifs)
         self.dispatch(node.iter)
         for if_clause in node.ifs:
             self.write(" if ")
@@ -673,7 +678,7 @@ class Unparser:
 
     def visit_IfExp(self, node):
         with self.require_parens(_Precedence.TEST, node):
-            self.set_precedence(pnext(_Precedence.TEST), node.body, node.test)
+            self.set_precedence(_Precedence.TEST.next(), node.body, node.test)
             self.dispatch(node.body)
             self.write(" if ")
             self.dispatch(node.test)
@@ -770,11 +775,11 @@ class Unparser:
         operator_precedence = self.binop_precedence[operator]
         with self.require_parens(operator_precedence, node):
             if operator in self.binop_rassoc:
-                left_precedence = pnext(operator_precedence)
+                left_precedence = operator_precedence.next()
                 right_precedence = operator_precedence
             else:
                 left_precedence = operator_precedence
-                right_precedence = pnext(operator_precedence)
+                right_precedence = operator_precedence.next()
 
             self.set_precedence(left_precedence, node.left)
             self.dispatch(node.left)
@@ -797,7 +802,7 @@ class Unparser:
 
     def visit_Compare(self, node):
         with self.require_parens(_Precedence.CMP, node):
-            self.set_precedence(pnext(_Precedence.CMP), node.left, *node.comparators)
+            self.set_precedence(_Precedence.CMP.next(), node.left, *node.comparators)
             self.dispatch(node.left)
             for o, e in zip(node.ops, node.comparators):
                 self.write(" " + self.cmpops[o.__class__.__name__] + " ")
@@ -814,7 +819,7 @@ class Unparser:
         op = {"precedence": self.boolop_precedence[operator]}
 
         def increasing_level_dispatch(node):
-            op["precedence"] = pnext(op["precedence"])
+            op["precedence"] = op["precedence"].next()
             self.set_precedence(op["precedence"], node)
             self.dispatch(node)
 
@@ -1075,7 +1080,7 @@ class Unparser:
 
     def visit_MatchOr(self, node):
         with self.require_parens(_Precedence.BOR, node):
-            self.set_precedence(pnext(_Precedence.BOR), *node.patterns)
+            self.set_precedence(_Precedence.BOR.next(), *node.patterns)
             self.interleave(lambda: self.write(" | "), self.dispatch, node.patterns)
 
     def visit_TypeAlias(self, node):


### PR DESCRIPTION
Fix package hash instabilities between python 3.7 and 3.8 https://github.com/spack/spack/issues/45408.

There were 23 builtin packages affected by this. It mostly was AST changes around strings and f-strings. This is important to me because my "fresh" CI/CD is running python 3.11, but my users are running 3.6+.

Package hash for `armcomputelibrary` and `mfem` changed, [see comment](https://github.com/spack/spack/pull/47217#issuecomment-2493473928).

Also, I kind-of went down the rabbit hole of updating Spack's entire unparser.py to mirror `class Unparser` of [`cpython/Lib/ast.py`](https://github.com/python/cpython/blob/main/Lib/ast.py). One can now more easily compare spack's unparser directly to class Unparse of [cpython Lib/ast.py](https://github.com/python/cpython/blob/main/Lib/ast.py): 

```
git clone https://github.com/python/cpython
cp cpython/Lib/ast.py .../spack/lib/spack/spack/util/unparse/cpython-ast.py

cd .../spack/lib/spack/spack/util/unparse
spack style -t black --fix ./cpython-ast.py

your-favorite-diff-tool cpython-ast.py unparser.py  # Skip to the `class Unparse`
```

---

1. Remove differences by backporting one by one cpython ast.py unparser changes to spack's unparser, without breaking python 3.6+ compat, and **no change in current builtin packages hash** with python 3.6 to 3.12:
    - [X] Update style (naming, function order, etc.) to mirror cpython's
    - [X] Update minor code changes
    - [X] Update more sensible changes
    - [X] Drop more Python 2 code and ast nodes
    - [X] Don't change package hash
3. Fix #45408
    - [x] Update major parts of the unparser (might include more that just this fix)
    - [x] Add tests related to those changes
    - [x] Test py 3.6 to 3.13
    - [X] Ideally don't change current package hash -- **Except 2: armcomputelibrary and mfem**