### PR TITLE
adios2: fix mgard variant

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -271,6 +271,7 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
             from_variant("ADIOS2_USE_DataSpaces", "dataspaces"),
             from_variant("ADIOS2_USE_Fortran", "fortran"),
             from_variant("ADIOS2_USE_HDF5", "hdf5"),
+            from_variant("ADIOS2_USE_MGARD", "mgard"),
             from_variant("ADIOS2_USE_MPI", "mpi"),
             from_variant("ADIOS2_USE_PNG", "png"),
             from_variant("ADIOS2_USE_Python", "python"),
@@ -289,7 +290,6 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
             self.define("ADIOS2_BUILD_EXAMPLES", False),
             self.define("ADIOS2_USE_Endian_Reverse", True),
             self.define("ADIOS2_USE_IME", False),
-            self.define("ADIOS2_USE_MGARD", False),
         ]
 
         if spec.satisfies("+sst"):

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -188,7 +188,8 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("libpng@1.6:", when="+png")
     depends_on("zfp@0.5.1:0.5", when="+zfp")
     depends_on("sz@2.0.2.0:", when="+sz")
-    depends_on("mgard", when="+mgard")
+    depends_on("mgard@2022-11-18:", when="+mgard")
+    depends_on("mgard@2023-01-10:", when="@2.9: +mgard")
 
     extends("python", when="+python")
     depends_on("python@2.7:2.8,3.5:", when="@:2.4.0 +python", type=("build", "run"))


### PR DESCRIPTION
Specifying mgard in adios2 never worked because mgard was always turned off in the build. This fix sets the CMake flag to mirror that of the variant setting.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
