### PR TITLE
bazel: add Apple Clang 16 conflict

### DIFF
--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -140,6 +140,9 @@ class Bazel(Package):
     # Newer versions of grpc and abseil dependencies are needed but are not in bazel-4.0.0
     conflicts("@4.0.0", when="%gcc@11:")
 
+    # https://github.com/bazelbuild/bazel/pull/23667
+    conflicts("%apple-clang@16:", when="@:7.3")
+
     executables = ["^bazel$"]
 
     # Download resources to perform offline build with bazel.


### PR DESCRIPTION
Tried backporting this patch but couldn't get it to work for some reason. For now, it isn't possible to build bazel with the latest Xcode.