### PR TITLE
py-mgmetis: Fails to build with mpi4py @4: depend on @3

### DIFF
--- a/var/spack/repos/builtin/packages/py-mgmetis/package.py
+++ b/var/spack/repos/builtin/packages/py-mgmetis/package.py
@@ -21,6 +21,6 @@ class PyMgmetis(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-numpy@1.20.0:1.26.4", type=("build", "run"))
     depends_on("py-cython", type=("build"))
-    depends_on("py-mpi4py@3.0.3:", type=("build", "run"))
+    depends_on("py-mpi4py@3.0.3:3", type=("build", "run"))
     depends_on("py-pytest")
     depends_on("metis+shared", type="all")


### PR DESCRIPTION
@tech-91: When trying to build your PR #47121,
I noticed that py-mgmetis (your package) does not build with mpi4py@4

`spack install py-mgmetis ^py-mpi4py@4` fais with:
```
 os.environ["CC"] = mpi4py.get_config()["mpicc"]
  KeyError: 'mpicc'       
```
Therefore restrict it to the v3 versions of `py-mpi4py`:
```py
-    depends_on("py-mpi4py@3.0.3:", type=("build", "run"))
+    depends_on("py-mpi4py@3.0.3:3", type=("build", "run"))
```

Full log:
```py
Processing /home/bkaindl/spack.5/.stage/spack-stage-py-mgmetis-master-iarvxdd26qum3ggsgubbteule367x4ss/spack-src
  Added file:///home/bkaindl/spack.5/.stage/spack-stage-py-mgmetis-master-iarvxdd26qum3ggsgubbteule367x4ss/spack-src to build tracker '/tmp/pip-build-tracker-glmi894s'                                                                                                                                       Running setup.py (path:/home/bkaindl/spack.5/.stage/spack-stage-py-mgmetis-master-iarvxdd26qum3ggsgubbteule367x4ss/spack-src/setup.py) egg_info for package from file:///home/bkaindl/spack.5/.stage/spack-stage-py-mgmetis-master-iarvxdd26qum3ggsgubbteule367x4ss/spack-src
  Created temporary directory: /tmp/pip-pip-egg-info-0xummfxb
  Preparing metadata (setup.py): started                                                                                                                Running command python setup.py egg_info
  Traceback (most recent call last):
    File "<string>", line 2, in <module>
    File "<pip-setuptools-caller>", line 34, in <module>
    File "/home/bkaindl/spack.5/.stage/spack-stage-py-mgmetis-master-iarvxdd26qum3ggsgubbteule367x4ss/spack-src/setup.py", line 5, in <module>
      import conf                                                                                                                                         File "/home/bkaindl/spack.5/.stage/spack-stage-py-mgmetis-master-iarvxdd26qum3ggsgubbteule367x4ss/spack-src/conf.py", line 74, in <module>
      os.environ["CC"] = mpi4py.get_config()["mpicc"]
  KeyError: 'mpicc'                                                                                                                                     error: subprocess-exited-with-error                                                                                                                                                                                                                                                                         × python setup.py egg_info did not run successfully.
  │ exit code: 1                                                                                                                                        ╰─> See above for output. 
```