### PR TITLE
feat: Add OpenColorIO option to OpenImageIO

### DIFF
--- a/var/spack/repos/builtin/packages/opencolorio/package.py
+++ b/var/spack/repos/builtin/packages/opencolorio/package.py
@@ -12,8 +12,9 @@ class Opencolorio(CMakePackage):
 
     homepage = "https://opencolorio.readthedocs.io"
     git = "https://github.com/AcademySoftwareFoundation/OpenColorIO"
-    url = "https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/refs/tags/v2.4.0.tar.gz"
-
+    url = (
+        "https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/refs/tags/v2.4.0.tar.gz"
+    )
     license("Apache-2.0")
 
     version("2.4.0", sha256="0ff3966b9214da0941b2b1cbdab3975a00a51fc6f3417fa860f98f5358f2c282")
@@ -24,7 +25,6 @@ class Opencolorio(CMakePackage):
     depends_on("yaml-cpp@0.6.3:")
     depends_on("imath@3.0.5:")
     depends_on("pystring@1.1.3:")
-
 
     # Optional dependencies
     variant("lcms", default=False, description="Little CMS for ociobakelut")

--- a/var/spack/repos/builtin/packages/opencolorio/package.py
+++ b/var/spack/repos/builtin/packages/opencolorio/package.py
@@ -1,0 +1,39 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Opencolorio(CMakePackage):
+    """OpenColorIO (OCIO) is a complete color management solution geared towards motion
+    picture production with an emphasis on visual effects and computer animation."""
+
+    homepage = "https://opencolorio.readthedocs.io"
+    git = "https://github.com/AcademySoftwareFoundation/OpenColorIO"
+    url = "https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/refs/tags/v2.4.0.tar.gz"
+
+    license("Apache-2.0")
+
+    version("2.4.0", sha256="0ff3966b9214da0941b2b1cbdab3975a00a51fc6f3417fa860f98f5358f2c282")
+
+    # Core dependencies
+    depends_on("cmake@3.14:", type="build")
+    depends_on("expat@2.2.8:")
+    depends_on("yaml-cpp@0.6.3:")
+    depends_on("imath@3.0.5:")
+    depends_on("pystring@1.1.3:")
+
+
+    # Optional dependencies
+    variant("lcms", default=False, description="Little CMS for ociobakelut")
+    depends_on("lcms@2.2:", when="+lcms")
+
+    variant("python", default=False, description="Build python bindings")
+    extends("python", when="+python")
+    depends_on("py-pybind11", when="+python", type=("build", "run"))
+
+    def cmake_args(self):
+        args = ["-DOCIO_BUILD_PYTHON={0}".format("ON" if "+python" in self.spec else "OFF")]
+        return args

--- a/var/spack/repos/builtin/packages/openimageio/package.py
+++ b/var/spack/repos/builtin/packages/openimageio/package.py
@@ -42,6 +42,9 @@ class Openimageio(CMakePackage):
     variant("qt", default=False, description="Build qt viewer")
     depends_on("qt@5.6.0:+opengl", when="+qt")
 
+    variant("ocio", default=False, description="Support video frames")
+    depends_on("opencolorio@2.2:", when="+ocio")
+
     def url_for_version(self, version):
         if version >= Version("2"):
             return super().url_for_version(version)

--- a/var/spack/repos/builtin/packages/pystring/package.py
+++ b/var/spack/repos/builtin/packages/pystring/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Pystring(CMakePackage):
+    """Pystring is a collection of C++ functions which match the interface and behavior
+    of python's string class methods using std::string."""
+
+    git = "https://github.com/imageworks/pystring"
+    url = "https://github.com/imageworks/pystring/archive/refs/tags/v1.1.4.tar.gz"
+
+    license("Apache-2.0")
+
+    version("1.1.4", sha256="49da0fe2a049340d3c45cce530df63a2278af936003642330287b68cefd788fb")
+
+    # Core dependencies
+    depends_on("cmake@3.27.9:", type="build")


### PR DESCRIPTION
This adds OpenColorIO as an optional variant using `+ocio` to the OpenImageIO package. Once built, `oiiotool --buildinfo` shows the correct OpenColorIO version, while before it was `NONE`.

I tested it using a Docker container with Rocky Linux 8.9 (gcc 8.5.0):
```Dockerfile
FROM rockylinux:8.9

RUN dnf install -y epel-release && \
    dnf group install -y "Development Tools" && \
    dnf install -y curl findutils gcc-gfortran gnupg2 hostname iproute redhat-lsb-core python3 python3-pip python3-setuptools unzip python3-boto3

RUN dnf install -y patch

RUN git clone -c feature.manyFiles=true --depth=1 https://github.com/spack/spack.git /root/spack
RUN echo "source /root/spack/share/spack/setup-env.sh" >> /root/.bashrc

ADD spack/openimageio/package.py /root/spack/var/spack/repos/builtin/packages/openimageio/package.py
ADD spack/opencolorio/package.py /root/spack/var/spack/repos/builtin/packages/opencolorio/package.py
ADD spack/pystring/package.py /root/spack/var/spack/repos/builtin/packages/pystring/package.py

RUN cd /root/spack && source share/spack/setup-env.sh && \
    spack install openimageio +ocio
```

Let me know if there's other tests I should perform.

Tagging @bernhardkaindl since you handled the last update to OpenImageIO.