### PR TITLE
nano: add v8.1, v8.2 (and v6.4)

### DIFF
--- a/var/spack/repos/builtin/packages/nano/package.py
+++ b/var/spack/repos/builtin/packages/nano/package.py
@@ -87,6 +87,8 @@ class Nano(AutotoolsPackage):
     depends_on("c", type="build")
 
     depends_on("pkgconfig", type="build")
+    depends_on("gettext@0.18.3:")
+    depends_on("gettext@0.20:", when="@8.1:")
     depends_on("ncurses")
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/nano/package.py
+++ b/var/spack/repos/builtin/packages/nano/package.py
@@ -23,6 +23,7 @@ class Nano(AutotoolsPackage):
     # 7.x
     version("7.2", sha256="86f3442768bd2873cec693f83cdf80b4b444ad3cc14760b74361474fc87a4526")
     # 6.x
+    version("6.4", sha256="4199ae8ca78a7796de56de1a41b821dc47912c0307e9816b56cc317df34661c0")
     version("6.3", sha256="eb532da4985672730b500f685dbaab885a466d08fbbf7415832b95805e6f8687")
     version("6.2", sha256="2bca1804bead6aaf4ad791f756e4749bb55ed860eec105a97fba864bc6a77cb3")
     version("6.1", sha256="3d57ec893fbfded12665b7f0d563d74431fc43abeaccacedea23b66af704db40")

--- a/var/spack/repos/builtin/packages/nano/package.py
+++ b/var/spack/repos/builtin/packages/nano/package.py
@@ -14,9 +14,11 @@ class Nano(AutotoolsPackage):
     list_url = "https://www.nano-editor.org/dist/"
     list_depth = 1
 
-    license("GPL-3.0-or-later")
+    license("GPL-3.0-or-later", checked_by="wdconinc")
 
     # 8.x
+    version("8.2", sha256="d5ad07dd862facae03051c54c6535e54c7ed7407318783fcad1ad2d7076fffeb")
+    version("8.1", sha256="93b3e3e9155ae389fe9ccf9cb7ab380eac29602835ba3077b22f64d0f0cbe8cb")
     version("8.0", sha256="c17f43fc0e37336b33ee50a209c701d5beb808adc2d9f089ca831b40539c9ac4")
     # 7.x
     version("7.2", sha256="86f3442768bd2873cec693f83cdf80b4b444ad3cc14760b74361474fc87a4526")
@@ -82,7 +84,7 @@ class Nano(AutotoolsPackage):
     version("2.6.2", sha256="22f79cc635458e0c0d110d211576f1edc03b112a62d73b914826a46547a6ac27")
     version("2.6.1", sha256="45721fa6d6128068895ad71a6967ff7398d11b064b3f888e5073c97a2b6e9a81")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("pkgconfig", type="build")
     depends_on("ncurses")


### PR DESCRIPTION
This PR adds `nano`, v8.1 and v8.2. License and language checked. For completeness, I also added v6.4 as the final bugfix release of the 6.x series.

There appears to be a dependency on gettext that was not yet included, and which was changed from min 0.18.3 to min 0.20 with v8.1 (https://git.savannah.gnu.org/cgit/nano.git/tree/configure.ac?h=v8.2#n51). With this change, the configure step does indeed picks e.g. msgfmt from the correct prefix instead of from the system:
```
checking for msgfmt... /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/gettext-0.22.5-flgrqsz2mgzlbusqvxbnbfq4kbj63btt/bin/msgfmt
checking for gmsgfmt... /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/gettext-0.22.5-flgrqsz2mgzlbusqvxbnbfq4kbj63btt/bin/msgfmt
checking for xgettext... /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/gettext-0.22.5-flgrqsz2mgzlbusqvxbnbfq4kbj63btt/bin/xgettext
checking for msgmerge... /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/gettext-0.22.5-flgrqsz2mgzlbusqvxbnbfq4kbj63btt/bin/msgmerge
```

Test builds:
```
==> Installing nano-6.4-pi2ergrjluzmdcnjbx5b3imkotyimqfx [16/17]
==> No binary for nano-6.4-pi2ergrjluzmdcnjbx5b3imkotyimqfx found: installing from source
==> Fetching https://www.nano-editor.org/dist/v6/nano-6.4.tar.xz
==> No patches needed for nano
==> nano: Executing phase: 'autoreconf'
==> nano: Executing phase: 'configure'
==> nano: Executing phase: 'build'
==> nano: Executing phase: 'install'
==> nano: Successfully installed nano-6.4-pi2ergrjluzmdcnjbx5b3imkotyimqfx
  Stage: 2.07s.  Autoreconf: 0.00s.  Configure: 21.76s.  Build: 4.30s.  Install: 0.38s.  Post-install: 0.16s.  Total: 28.75s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/nano-6.4-pi2ergrjluzmdcnjbx5b3imkotyimqfx
==> Installing nano-8.1-szhpt2zgfju4hvlh4xbh7k2wywkdltv5 [15/16]
==> No binary for nano-8.1-szhpt2zgfju4hvlh4xbh7k2wywkdltv5 found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/93/93b3e3e9155ae389fe9ccf9cb7ab380eac29602835ba3077b22f64d0f0cbe8cb.tar.xz
==> No patches needed for nano
==> nano: Executing phase: 'autoreconf'
==> nano: Executing phase: 'configure'
==> nano: Executing phase: 'build'
==> nano: Executing phase: 'install'
==> nano: Successfully installed nano-8.1-szhpt2zgfju4hvlh4xbh7k2wywkdltv5
  Stage: 0.22s.  Autoreconf: 0.00s.  Configure: 23.74s.  Build: 4.21s.  Install: 0.42s.  Post-install: 0.12s.  Total: 28.79s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/nano-8.1-szhpt2zgfju4hvlh4xbh7k2wywkdltv5
==> Installing nano-8.2-3o5oqmreiezpsiq4csc4nbgbzk7sj4kl [16/16]
==> No binary for nano-8.2-3o5oqmreiezpsiq4csc4nbgbzk7sj4kl found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/d5/d5ad07dd862facae03051c54c6535e54c7ed7407318783fcad1ad2d7076fffeb.tar.xz
==> No patches needed for nano
==> nano: Executing phase: 'autoreconf'
==> nano: Executing phase: 'configure'
==> nano: Executing phase: 'build'
==> nano: Executing phase: 'install'
==> nano: Successfully installed nano-8.2-3o5oqmreiezpsiq4csc4nbgbzk7sj4kl
  Stage: 0.14s.  Autoreconf: 0.00s.  Configure: 23.72s.  Build: 4.17s.  Install: 0.44s.  Post-install: 0.13s.  Total: 28.65s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/nano-8.2-3o5oqmreiezpsiq4csc4nbgbzk7sj4kl
```