### PR TITLE
ffmpeg: require libharfbuzz when +drawtext for v7+

### DIFF
--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -108,7 +108,7 @@ class Ffmpeg(AutotoolsPackage):
     depends_on("fontconfig", when="+drawtext")
     depends_on("freetype", when="+drawtext")
     depends_on("fribidi", when="+drawtext")
-    depends_on("harfbuzz", when="+drawtext")
+    depends_on("harfbuzz", when="+drawtext @7:")
     depends_on("lame", when="+libmp3lame")
     depends_on("libssh", when="+libssh")
     depends_on("libvorbis", when="+libvorbis")

--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -108,6 +108,7 @@ class Ffmpeg(AutotoolsPackage):
     depends_on("fontconfig", when="+drawtext")
     depends_on("freetype", when="+drawtext")
     depends_on("fribidi", when="+drawtext")
+    depends_on("harfbuzz", when="+drawtext")
     depends_on("lame", when="+libmp3lame")
     depends_on("libssh", when="+libssh")
     depends_on("libvorbis", when="+libvorbis")
@@ -211,6 +212,9 @@ class Ffmpeg(AutotoolsPackage):
         if spec.satisfies("@2.3:"):
             drawtext_opts.append("libfribidi")
 
+        if spec.satisfies("@7:"):
+            drawtext_opts.append("libharfbuzz")
+            
         config_args += self.enable_or_disable_meta("drawtext", drawtext_opts)
 
         # other variants #

--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -214,7 +214,7 @@ class Ffmpeg(AutotoolsPackage):
 
         if spec.satisfies("@7:"):
             drawtext_opts.append("libharfbuzz")
-            
+
         config_args += self.enable_or_disable_meta("drawtext", drawtext_opts)
 
         # other variants #


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Adds `libharfbuzz` as a dependency for ffmpeg 7.0+ when `+drawtext` is enabled. (Without this PR, drawtext support is silently disabled when building.)

libharfbuzz was added as a required dependency for drawtext by this ffmpeg commit:
```
commit 1eeb59a2099479eeead8cdc0d4586443fb301a8a
Author: yethie <klimklim@tiscali.it>
Date:   Fri May 26 12:11:41 2023 +0200

    avfilter/vf_drawtext: improve glyph shaping and positioning

    - text is now shaped using libharfbuz
    - glyphs position is now accurate to 1/4 pixel in both directions
    - the default line height is now the one defined in the font

    Adds libharfbuzz dependency.
```