### PR TITLE
less: add v661, v668

### DIFF
--- a/var/spack/repos/builtin/packages/less/package.py
+++ b/var/spack/repos/builtin/packages/less/package.py
@@ -17,9 +17,13 @@ class Less(AutotoolsPackage):
 
     depends_on("ncurses")
 
-    license("GPL-3.0-or-later OR BSD-2-Clause")
+    license("GPL-3.0-or-later OR BSD-2-Clause", checked_by="wdconinc")
 
+    version("668", sha256="dbc0de59ea9c50e1e8927e6b077858db3a84954e767909bc599e6e6f602c5717")
+    version("661", sha256="a900e3916738bf8c1a0a2a059810f1c59b8271ac8bb46898c6e921ea6aefd757")
     version("643", sha256="3bb417c4b909dfcb0adafc371ab87f0b22e8b15f463ec299d156c495fc9aa196")
-    version("590", sha256="69056021c365b16504cf5bd3864436a5e50cb2f98b76cd68b99b457064139375")
-    version("551", sha256="2630db16ef188e88b513b3cc24daa9a798c45643cc7da06e549c9c00cfd84244")
-    version("530", sha256="8c1652ba88a726314aa2616d1c896ca8fe9a30253a5a67bc21d444e79a6c6bc3")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2022-46663
+        version("590", sha256="69056021c365b16504cf5bd3864436a5e50cb2f98b76cd68b99b457064139375")
+        version("551", sha256="2630db16ef188e88b513b3cc24daa9a798c45643cc7da06e549c9c00cfd84244")
+        version("530", sha256="8c1652ba88a726314aa2616d1c896ca8fe9a30253a5a67bc21d444e79a6c6bc3")


### PR DESCRIPTION
This PR adds `less`, v661 and v668. CVE-2022-46663 (severity high) affects versions before 609, so they have been marked as deprecated.

Test builds:
```
==> Installing less-661-a56frqezk5m4du45p3a66acpu55pmawb [5/6]
==> No binary for less-661-a56frqezk5m4du45p3a66acpu55pmawb found: installing from source
==> Fetching https://www.greenwoodsoftware.com/less/less-661.zip
==> No patches needed for less
==> less: Executing phase: 'autoreconf'
==> less: Executing phase: 'configure'
==> less: Executing phase: 'build'
==> less: Executing phase: 'install'
==> less: Successfully installed less-661-a56frqezk5m4du45p3a66acpu55pmawb
  Stage: 0.94s.  Autoreconf: 0.00s.  Configure: 3.87s.  Build: 2.37s.  Install: 0.02s.  Post-install: 0.09s.  Total: 7.33s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/less-661-a56frqezk5m4du45p3a66acpu55pmawb
==> Installing less-668-2kgv7amoohsyzyonryvucb3kwksbzznb [6/6]
==> No binary for less-668-2kgv7amoohsyzyonryvucb3kwksbzznb found: installing from source
==> Fetching https://www.greenwoodsoftware.com/less/less-668.zip
==> No patches needed for less
==> less: Executing phase: 'autoreconf'
==> less: Executing phase: 'configure'
==> less: Executing phase: 'build'
==> less: Executing phase: 'install'
==> less: Successfully installed less-668-2kgv7amoohsyzyonryvucb3kwksbzznb
  Stage: 0.87s.  Autoreconf: 0.00s.  Configure: 3.22s.  Build: 2.92s.  Install: 0.02s.  Post-install: 0.18s.  Total: 7.26s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/less-668-2kgv7amoohsyzyonryvucb3kwksbzznb
```