### PR TITLE
geode: add v1.13.8, v1.14.3, v1.15.1 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/geode/package.py
+++ b/var/spack/repos/builtin/packages/geode/package.py
@@ -15,14 +15,21 @@ class Geode(Package):
 
     homepage = "https://geode.apache.org/"
     url = "https://archive.apache.org/dist/geode/1.9.2/apache-geode-1.9.2.tgz"
+    list_url = "https://archive.apache.org/dist/geode/"
+    list_depth = 1
 
     license("Apache-2.0")
 
-    version("1.9.2", sha256="4b8118114ef43166f6bf73af56b93aadbf9108fcab06d1fbbb8e27f7d559d7e0")
-    version("1.9.0", sha256="8794808ebc89bc855f0b989b32e91e890d446cfd058e123f6ccb9e12597c1c4f")
-    version("1.8.0", sha256="58edc41edac4eabd899322b73a24727eac41f6253274c2ce7d0a82227121ae3e")
-    version("1.7.0", sha256="91eec04420f46e949d32104479c4a4b5b34a4e5570dca7b98ca067a30d5a783d")
-    version("1.6.0", sha256="79e8d81d058b1c4edd5fb414ff30ac530f7913b978f5abc899c353fcb06e5ef3")
+    version("1.15.1", sha256="2668970982d373ef42cff5076e7073b03e82c8e2fcd7757d5799b2506e265d57")
+    version("1.14.3", sha256="5efb1c71db34ba3b7ce1004579f8b9b7a43eae30f42c37837d5abd68c6d778bd")
+    version("1.13.8", sha256="b5fc105ce0a16aaf7ba341668e022d458b18d6d2c44705a8c79c42077c6d8229")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2022-37021
+        version("1.9.2", sha256="4b8118114ef43166f6bf73af56b93aadbf9108fcab06d1fbbb8e27f7d559d7e0")
+        version("1.9.0", sha256="8794808ebc89bc855f0b989b32e91e890d446cfd058e123f6ccb9e12597c1c4f")
+        version("1.8.0", sha256="58edc41edac4eabd899322b73a24727eac41f6253274c2ce7d0a82227121ae3e")
+        version("1.7.0", sha256="91eec04420f46e949d32104479c4a4b5b34a4e5570dca7b98ca067a30d5a783d")
+        version("1.6.0", sha256="79e8d81d058b1c4edd5fb414ff30ac530f7913b978f5abc899c353fcb06e5ef3")
 
     depends_on("java", type="run")
 


### PR DESCRIPTION
This PR adds `geode`, v1.13.8, v1.14.3, v1.15.1, which fixes a bunch of CVEs, CVE-2019-14892, CVE-2019-15752, CVE-2020-1938, CVE-2021-34797, CVE-2022-34870, CVE-2022-37021, CVE-2022-37022, CVE-2022-37023. Several have a high or critical severity, so affected versions are marked as deprecated.

Test build and run:
```
==> Installing geode-1.14.3-m7s5jtqmzcsidk6eekuana5ywhfpooko [4/6]
==> No binary for geode-1.14.3-m7s5jtqmzcsidk6eekuana5ywhfpooko found: installing from source
==> Fetching https://archive.apache.org/dist/geode/1.14.3/apache-geode-1.14.3.tgz
==> No patches needed for geode
==> geode: Executing phase: 'install'
==> geode: Successfully installed geode-1.14.3-m7s5jtqmzcsidk6eekuana5ywhfpooko
  Stage: 29.08s.  Install: 0.24s.  Post-install: 0.49s.  Total: 29.84s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/geode-1.14.3-m7s5jtqmzcsidk6eekuana5ywhfpooko
==> Installing geode-1.15.1-o7vk3j4zxzozni4urh6uhrr3663awqav [5/6]
==> No binary for geode-1.15.1-o7vk3j4zxzozni4urh6uhrr3663awqav found: installing from source
==> Fetching https://archive.apache.org/dist/geode/1.15.1/apache-geode-1.15.1.tgz
==> No patches needed for geode
==> geode: Executing phase: 'install'
==> geode: Successfully installed geode-1.15.1-o7vk3j4zxzozni4urh6uhrr3663awqav
  Stage: 35.97s.  Install: 0.19s.  Post-install: 0.47s.  Total: 36.65s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/geode-1.15.1-o7vk3j4zxzozni4urh6uhrr3663awqav
==> Installing geode-1.13.8-7zn2thocyxbvi75tfcnedjs5nhkfjiqh [6/6]
==> No binary for geode-1.13.8-7zn2thocyxbvi75tfcnedjs5nhkfjiqh found: installing from source
==> Fetching https://archive.apache.org/dist/geode/1.13.8/apache-geode-1.13.8.tgz
==> No patches needed for geode
==> geode: Executing phase: 'install'
==> geode: Successfully installed geode-1.13.8-7zn2thocyxbvi75tfcnedjs5nhkfjiqh
  Stage: 1m 25.52s.  Install: 0.20s.  Post-install: 0.47s.  Total: 1m 26.21s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/geode-1.13.8-7zn2thocyxbvi75tfcnedjs5nhkfjiqh
19:35:23 wdconinc@menelaos ~ $ spack load /o7vk3j4zxzozni4urh6uhrr3663awqav
19:50:52 wdconinc@menelaos ~ $ /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/geode-1.15.1-o7vk3j4zxzozni4urh6uhrr3663awqav/bin/gfsh
    _________________________     __
   / _____/ ______/ ______/ /____/ /
  / /  __/ /___  /_____  / _____  / 
 / /__/ / ____/  _____/ / /    / /  
/______/_/      /______/_/    /_/    1.15.1

Monitor and Manage Apache Geode
gfsh>
```