### PR TITLE
`cc`: refactor `ld` and path list logic

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -238,6 +238,36 @@ esac
 }
 "
 
+# path_list functions. Path_lists have 3 parts: spack_store_<list>, <list> and system_<list>,
+# which are used to prioritize paths when assembling the final command line.
+
+# init_path_lists LISTNAME
+# Set <LISTNAME>, spack_store_<LISTNAME>, and system_<LISTNAME> to "".
+init_path_lists() {
+    eval "spack_store_$1=\"\""
+    eval "$1=\"\""
+    eval "system_$1=\"\""
+}
+
+# assign_path_lists LISTNAME1 LISTNAME2
+# Copy contents of LISTNAME2 into LISTNAME1, for each path_list prefix.
+assign_path_lists() {
+    eval "spack_store_$1=\"\${spack_store_$2}\""
+    eval "$1=\"\${$2}\""
+    eval "system_$1=\"\${system_$2}\""
+}
+
+# append_path_lists LISTNAME ELT
+# Append the provided ELT to the appropriate list, based on the result of path_order().
+append_path_lists() {
+    path_order "$2"
+    case $? in
+        0) eval "append spack_store_$1 \"\$2\"" ;;
+        1) eval "append $1 \"\$2\"" ;;
+        2) eval "append system_$1 \"\$2\"" ;;
+    esac
+}
+
 # Check if optional parameters are defined
 # If we aren't asking for debug flags, don't add them
 if [ -z "${SPACK_ADD_DEBUG_FLAGS:-}" ]; then
@@ -470,12 +500,7 @@ input_command="$*"
 parse_Wl() {
     while [ $# -ne 0 ]; do
     if [ "$wl_expect_rpath" = yes ]; then
-        path_order "$1"
-        case $? in
-            0) append return_spack_store_rpath_dirs_list "$1" ;;
-            1) append return_rpath_dirs_list "$1" ;;
-            2) append return_system_rpath_dirs_list "$1" ;;
-        esac
+        append_path_lists return_rpath_dirs_list "$1"
         wl_expect_rpath=no
     else
         case "$1" in
@@ -484,24 +509,14 @@ parse_Wl() {
                 if [ -z "$arg" ]; then
                     shift; continue
                 fi
-                path_order "$arg"
-                case $? in
-                    0) append return_spack_store_rpath_dirs_list "$arg" ;;
-                    1) append return_rpath_dirs_list "$arg" ;;
-                    2) append return_system_rpath_dirs_list "$arg" ;;
-                esac
+                append_path_lists return_rpath_dirs_list "$arg"
                 ;;
             --rpath=*)
                 arg="${1#--rpath=}"
                 if [ -z "$arg" ]; then
                     shift; continue
                 fi
-                path_order "$arg"
-                case $? in
-                    0) append return_spack_store_rpath_dirs_list "$arg" ;;
-                    1) append return_rpath_dirs_list "$arg" ;;
-                    2) append return_system_rpath_dirs_list "$arg" ;;
-                esac
+                append_path_lists return_rpath_dirs_list "$arg"
                 ;;
             -rpath|--rpath)
                 wl_expect_rpath=yes
@@ -509,8 +524,7 @@ parse_Wl() {
             "$dtags_to_strip")
                 ;;
             -Wl)
-                # Nested -Wl,-Wl means we're in NAG compiler territory, we don't support
-                # it.
+                # Nested -Wl,-Wl means we're in NAG compiler territory. We don't support it.
                 return 1
                 ;;
             *)
@@ -529,21 +543,10 @@ categorize_arguments() {
     return_other_args_list=""
     return_isystem_was_used=""
 
-    return_isystem_spack_store_include_dirs_list=""
-    return_isystem_system_include_dirs_list=""
-    return_isystem_include_dirs_list=""
-
-    return_spack_store_include_dirs_list=""
-    return_system_include_dirs_list=""
-    return_include_dirs_list=""
-
-    return_spack_store_lib_dirs_list=""
-    return_system_lib_dirs_list=""
-    return_lib_dirs_list=""
-
-    return_spack_store_rpath_dirs_list=""
-    return_system_rpath_dirs_list=""
-    return_rpath_dirs_list=""
+    init_path_lists return_isystem_include_dirs_list
+    init_path_lists return_include_dirs_list
+    init_path_lists return_lib_dirs_list
+    init_path_lists return_rpath_dirs_list
 
     # Global state for keeping track of -Wl,-rpath -Wl,/path
     wl_expect_rpath=no
@@ -609,32 +612,17 @@ categorize_arguments() {
                 arg="${1#-isystem}"
                 return_isystem_was_used=true
                 if [ -z "$arg" ]; then shift; arg="$1"; fi
-                path_order "$arg"
-                case $? in
-                    0) append return_isystem_spack_store_include_dirs_list "$arg" ;;
-                    1) append return_isystem_include_dirs_list "$arg" ;;
-                    2) append return_isystem_system_include_dirs_list "$arg" ;;
-                esac
+                append_path_lists return_isystem_include_dirs_list "$arg"
                 ;;
             -I*)
                 arg="${1#-I}"
                 if [ -z "$arg" ]; then shift; arg="$1"; fi
-                path_order "$arg"
-                case $? in
-                    0) append return_spack_store_include_dirs_list "$arg" ;;
-                    1) append return_include_dirs_list "$arg" ;;
-                    2) append return_system_include_dirs_list "$arg" ;;
-                esac
+                append_path_lists return_include_dirs_list "$arg"
                 ;;
             -L*)
                 arg="${1#-L}"
                 if [ -z "$arg" ]; then shift; arg="$1"; fi
-                path_order "$arg"
-                case $? in
-                    0) append return_spack_store_lib_dirs_list "$arg" ;;
-                    1) append return_lib_dirs_list "$arg" ;;
-                    2) append return_system_lib_dirs_list "$arg" ;;
-                esac
+                append_path_lists return_lib_dirs_list "$arg"
                 ;;
             -l*)
                 # -loopopt=0 is generated erroneously in autoconf <= 2.69,
@@ -667,32 +655,17 @@ categorize_arguments() {
                     break
                 elif [ "$xlinker_expect_rpath" = yes ]; then
                     # Register the path of -Xlinker -rpath <other args> -Xlinker <path>
-                    path_order "$1"
-                    case $? in
-                        0) append return_spack_store_rpath_dirs_list "$1" ;;
-                        1) append return_rpath_dirs_list "$1" ;;
-                        2) append return_system_rpath_dirs_list "$1" ;;
-                    esac
+                    append_path_lists return_rpath_dirs_list "$1"
                     xlinker_expect_rpath=no
                 else
                     case "$1" in
                         -rpath=*)
                             arg="${1#-rpath=}"
-                            path_order "$arg"
-                            case $? in
-                                0) append return_spack_store_rpath_dirs_list "$arg" ;;
-                                1) append return_rpath_dirs_list "$arg" ;;
-                                2) append return_system_rpath_dirs_list "$arg" ;;
-                            esac
+                            append_path_lists return_rpath_dirs_list "$arg"
                             ;;
                         --rpath=*)
                             arg="${1#--rpath=}"
-                            path_order "$arg"
-                            case $? in
-                                0) append return_spack_store_rpath_dirs_list "$arg" ;;
-                                1) append return_rpath_dirs_list "$arg" ;;
-                                2) append return_system_rpath_dirs_list "$arg" ;;
-                            esac
+                            append_path_lists return_rpath_dirs_list "$arg"
                             ;;
                         -rpath|--rpath)
                             xlinker_expect_rpath=yes
@@ -731,21 +704,10 @@ categorize_arguments() {
 
 categorize_arguments "$@"
 
-spack_store_include_dirs_list="$return_spack_store_include_dirs_list"
-system_include_dirs_list="$return_system_include_dirs_list"
-include_dirs_list="$return_include_dirs_list"
-
-spack_store_lib_dirs_list="$return_spack_store_lib_dirs_list"
-system_lib_dirs_list="$return_system_lib_dirs_list"
-lib_dirs_list="$return_lib_dirs_list"
-
-spack_store_rpath_dirs_list="$return_spack_store_rpath_dirs_list"
-system_rpath_dirs_list="$return_system_rpath_dirs_list"
-rpath_dirs_list="$return_rpath_dirs_list"
-
-isystem_spack_store_include_dirs_list="$return_isystem_spack_store_include_dirs_list"
-isystem_system_include_dirs_list="$return_isystem_system_include_dirs_list"
-isystem_include_dirs_list="$return_isystem_include_dirs_list"
+assign_path_lists isystem_include_dirs_list return_isystem_include_dirs_list
+assign_path_lists include_dirs_list return_include_dirs_list
+assign_path_lists lib_dirs_list return_lib_dirs_list
+assign_path_lists rpath_dirs_list return_rpath_dirs_list
 
 isystem_was_used="$return_isystem_was_used"
 other_args_list="$return_other_args_list"
@@ -821,21 +783,10 @@ IFS="$lsep"
     categorize_arguments $spack_flags_list
 unset IFS
 
-spack_flags_isystem_spack_store_include_dirs_list="$return_isystem_spack_store_include_dirs_list"
-spack_flags_isystem_system_include_dirs_list="$return_isystem_system_include_dirs_list"
-spack_flags_isystem_include_dirs_list="$return_isystem_include_dirs_list"
-
-spack_flags_spack_store_include_dirs_list="$return_spack_store_include_dirs_list"
-spack_flags_system_include_dirs_list="$return_system_include_dirs_list"
-spack_flags_include_dirs_list="$return_include_dirs_list"
-
-spack_flags_spack_store_lib_dirs_list="$return_spack_store_lib_dirs_list"
-spack_flags_system_lib_dirs_list="$return_system_lib_dirs_list"
-spack_flags_lib_dirs_list="$return_lib_dirs_list"
-
-spack_flags_spack_store_rpath_dirs_list="$return_spack_store_rpath_dirs_list"
-spack_flags_system_rpath_dirs_list="$return_system_rpath_dirs_list"
-spack_flags_rpath_dirs_list="$return_rpath_dirs_list"
+assign_path_lists spack_flags_isystem_include_dirs_list return_isystem_include_dirs_list
+assign_path_lists spack_flags_include_dirs_list return_include_dirs_list
+assign_path_lists spack_flags_lib_dirs_list return_lib_dirs_list
+assign_path_lists spack_flags_rpath_dirs_list return_rpath_dirs_list
 
 spack_flags_isystem_was_used="$return_isystem_was_used"
 spack_flags_other_args_list="$return_other_args_list"
@@ -894,7 +845,7 @@ esac
 case "$mode" in
     cpp|cc|as|ccld)
         if [ "$spack_flags_isystem_was_used" = "true" ] || [ "$isystem_was_used" = "true" ]; then
-            extend isystem_spack_store_include_dirs_list SPACK_STORE_INCLUDE_DIRS
+            extend spack_store_isystem_include_dirs_list SPACK_STORE_INCLUDE_DIRS
             extend isystem_include_dirs_list SPACK_INCLUDE_DIRS
         else
             extend spack_store_include_dirs_list SPACK_STORE_INCLUDE_DIRS
@@ -910,32 +861,32 @@ args_list="$flags_list"
 
 # Include search paths partitioned by (in store, non-sytem, system)
 # NOTE: adding ${lsep} to the prefix here turns every added element into two
-extend args_list spack_flags_spack_store_include_dirs_list -I
+extend args_list spack_store_spack_flags_include_dirs_list -I
 extend args_list spack_store_include_dirs_list -I
 
 extend args_list spack_flags_include_dirs_list -I
 extend args_list include_dirs_list -I
 
-extend args_list spack_flags_isystem_spack_store_include_dirs_list "-isystem${lsep}"
-extend args_list isystem_spack_store_include_dirs_list "-isystem${lsep}"
+extend args_list spack_store_spack_flags_isystem_include_dirs_list "-isystem${lsep}"
+extend args_list spack_store_isystem_include_dirs_list "-isystem${lsep}"
 
 extend args_list spack_flags_isystem_include_dirs_list "-isystem${lsep}"
 extend args_list isystem_include_dirs_list "-isystem${lsep}"
 
-extend args_list spack_flags_system_include_dirs_list -I
+extend args_list system_spack_flags_include_dirs_list -I
 extend args_list system_include_dirs_list -I
 
-extend args_list spack_flags_isystem_system_include_dirs_list "-isystem${lsep}"
-extend args_list isystem_system_include_dirs_list "-isystem${lsep}"
+extend args_list system_spack_flags_isystem_include_dirs_list "-isystem${lsep}"
+extend args_list system_isystem_include_dirs_list "-isystem${lsep}"
 
 # Library search paths partitioned by (in store, non-sytem, system)
-extend args_list spack_flags_spack_store_lib_dirs_list "-L"
+extend args_list spack_store_spack_flags_lib_dirs_list "-L"
 extend args_list spack_store_lib_dirs_list "-L"
 
 extend args_list spack_flags_lib_dirs_list "-L"
 extend args_list lib_dirs_list "-L"
 
-extend args_list spack_flags_system_lib_dirs_list "-L"
+extend args_list system_spack_flags_lib_dirs_list "-L"
 extend args_list system_lib_dirs_list "-L"
 
 # RPATHs arguments
@@ -944,26 +895,26 @@ case "$mode" in
         if [ -n "$dtags_to_add" ] ; then
             append args_list "$linker_arg$dtags_to_add"
         fi
-        extend args_list spack_flags_spack_store_rpath_dirs_list "$rpath"
+        extend args_list spack_store_spack_flags_rpath_dirs_list "$rpath"
         extend args_list spack_store_rpath_dirs_list "$rpath"
 
         extend args_list spack_flags_rpath_dirs_list "$rpath"
         extend args_list rpath_dirs_list "$rpath"
 
-        extend args_list spack_flags_system_rpath_dirs_list "$rpath"
+        extend args_list system_spack_flags_rpath_dirs_list "$rpath"
         extend args_list system_rpath_dirs_list "$rpath"
         ;;
     ld)
         if [ -n "$dtags_to_add" ] ; then
             append args_list "$dtags_to_add"
         fi
-        extend args_list spack_flags_spack_store_rpath_dirs_list "-rpath${lsep}"
+        extend args_list spack_store_spack_flags_rpath_dirs_list "-rpath${lsep}"
         extend args_list spack_store_rpath_dirs_list "-rpath${lsep}"
 
         extend args_list spack_flags_rpath_dirs_list "-rpath${lsep}"
         extend args_list rpath_dirs_list "-rpath${lsep}"
 
-        extend args_list spack_flags_system_rpath_dirs_list "-rpath${lsep}"
+        extend args_list system_spack_flags_rpath_dirs_list "-rpath${lsep}"
         extend args_list system_rpath_dirs_list "-rpath${lsep}"
         ;;
 esac

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -101,10 +101,9 @@ setsep() {
     esac
 }
 
-# prepend LISTNAME ELEMENT [SEP]
+# prepend LISTNAME ELEMENT
 #
-# Prepend ELEMENT to the list stored in the variable LISTNAME,
-# assuming the list is separated by SEP.
+# Prepend ELEMENT to the list stored in the variable LISTNAME.
 # Handles empty lists and single-element lists.
 prepend() {
     varname="$1"
@@ -682,7 +681,36 @@ categorize_arguments() {
             "$dtags_to_strip")
                 ;;
             *)
-                append return_other_args_list "$1"
+                # if mode is not ld, we can just add to other args
+                if [ "$mode" != "ld" ]; then
+                    append return_other_args_list "$1"
+                    shift
+                    continue
+                fi
+
+                # if we're in linker mode, we need to parse raw RPATH args
+                case "$1" in
+                    -rpath=*)
+                        arg="${1#-rpath=}"
+                        append_path_lists return_rpath_dirs_list "$arg"
+                        ;;
+                    --rpath=*)
+                        arg="${1#--rpath=}"
+                        append_path_lists return_rpath_dirs_list "$arg"
+                        ;;
+                    -rpath|--rpath)
+                        if [ $# -eq 1 ]; then
+                            # -rpath without value: let the linker raise an error.
+                            append return_other_args_list "$1"
+                            break
+                        fi
+                        shift
+                        append_path_lists return_rpath_dirs_list "$1"
+                        ;;
+                    *)
+                        append return_other_args_list "$1"
+                        ;;
+                esac
                 ;;
         esac
         shift
@@ -890,34 +918,33 @@ extend args_list system_spack_flags_lib_dirs_list "-L"
 extend args_list system_lib_dirs_list "-L"
 
 # RPATHs arguments
+rpath_prefix=""
 case "$mode" in
     ccld)
         if [ -n "$dtags_to_add" ] ; then
             append args_list "$linker_arg$dtags_to_add"
         fi
-        extend args_list spack_store_spack_flags_rpath_dirs_list "$rpath"
-        extend args_list spack_store_rpath_dirs_list "$rpath"
-
-        extend args_list spack_flags_rpath_dirs_list "$rpath"
-        extend args_list rpath_dirs_list "$rpath"
-
-        extend args_list system_spack_flags_rpath_dirs_list "$rpath"
-        extend args_list system_rpath_dirs_list "$rpath"
+        rpath_prefix="$rpath"
         ;;
     ld)
         if [ -n "$dtags_to_add" ] ; then
             append args_list "$dtags_to_add"
         fi
-        extend args_list spack_store_spack_flags_rpath_dirs_list "-rpath${lsep}"
-        extend args_list spack_store_rpath_dirs_list "-rpath${lsep}"
-
-        extend args_list spack_flags_rpath_dirs_list "-rpath${lsep}"
-        extend args_list rpath_dirs_list "-rpath${lsep}"
-
-        extend args_list system_spack_flags_rpath_dirs_list "-rpath${lsep}"
-        extend args_list system_rpath_dirs_list "-rpath${lsep}"
+        rpath_prefix="-rpath${lsep}"
         ;;
 esac
+
+# if mode is ccld or ld, extend RPATH lists with the prefix determined above
+if [ -n "$rpath_prefix" ]; then
+    extend args_list spack_store_spack_flags_rpath_dirs_list "$rpath_prefix"
+    extend args_list spack_store_rpath_dirs_list "$rpath_prefix"
+
+    extend args_list spack_flags_rpath_dirs_list "$rpath_prefix"
+    extend args_list rpath_dirs_list "$rpath_prefix"
+
+    extend args_list system_spack_flags_rpath_dirs_list "$rpath_prefix"
+    extend args_list system_rpath_dirs_list "$rpath_prefix"
+fi
 
 # Other arguments from the input command
 extend args_list other_args_list

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -199,7 +199,7 @@ def check_args(cc, args, expected):
     """
     with set_env(SPACK_TEST_COMMAND="dump-args"):
         cc_modified_args = cc(*args, output=str).strip().split("\n")
-        assert expected == cc_modified_args
+        assert cc_modified_args == expected
 
 
 def check_args_contents(cc, args, must_contain, must_not_contain):
@@ -270,6 +270,43 @@ def test_ccld_mode(wrapper_environment):
 def test_ld_mode(wrapper_environment):
     assert dump_mode(ld, []) == "ld"
     assert dump_mode(ld, ["foo.o", "bar.o", "baz.o", "-o", "foo", "-Wl,-rpath,foo"]) == "ld"
+
+
+def test_ld_unterminated_rpath(wrapper_environment):
+    check_args(
+        ld,
+        ["foo.o", "bar.o", "baz.o", "-o", "foo", "-rpath"],
+        ["ld", "--disable-new-dtags", "foo.o", "bar.o", "baz.o", "-o", "foo", "-rpath"],
+    )
+
+
+def test_xlinker_unterminated_rpath(wrapper_environment):
+    check_args(
+        cc,
+        ["foo.o", "bar.o", "baz.o", "-o", "foo", "-Xlinker", "-rpath"],
+        [real_cc]
+        + target_args
+        + [
+            "-Wl,--disable-new-dtags",
+            "foo.o",
+            "bar.o",
+            "baz.o",
+            "-o",
+            "foo",
+            "-Xlinker",
+            "-rpath",
+        ],
+    )
+
+
+def test_wl_unterminated_rpath(wrapper_environment):
+    check_args(
+        cc,
+        ["foo.o", "bar.o", "baz.o", "-o", "foo", "-Wl,-rpath"],
+        [real_cc]
+        + target_args
+        + ["-Wl,--disable-new-dtags", "foo.o", "bar.o", "baz.o", "-o", "foo", "-Wl,-rpath"],
+    )
 
 
 def test_ld_flags(wrapper_environment, wrapper_flags):


### PR DESCRIPTION
NOTE: this should probably be rebased as 2 commits.

All the `cc` refactors from #46536, except the slow `contains` function and unique `RPATH` tracking.

1. In the pure `ld` case, we weren't actually parsing `RPATH` arguments separately as we do for `ccld`. Fix this by adding *another* nested case statement for raw `RPATH` parsing. There are now 3 places where we deal with `-rpath` and friends, but I don't see a great way to unify them, as `-Wl,`, `-Xlinker`, and raw `-rpath` arguments are all ever so slightly different.

2. Clean up all the 3-way list inits, assignments, and appends to make `cc`, a bit more readable and less repetitious. Related path lists for system, store, and other paths were treated as 3 lists before -- now they're named consistently and handled with a few functions that encapsulate the named list logic.

3. Fix ordering of assertions to make `pytest` diffs more intelligible. The meaning of `+` and `-` in diffs changed in `pytest` 6.0 and the "preferred" order for assertions became `assert actual == expected` instead of the other way around.