### PR TITLE
gdk-pixbuf/atk: delete old versions, make mesonpackage

### DIFF
--- a/var/spack/repos/builtin/packages/atk/package.py
+++ b/var/spack/repos/builtin/packages/atk/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Atk(Package):
+class Atk(MesonPackage):
     """ATK provides the set of accessibility interfaces that are
     implemented by other toolkits and applications. Using the ATK
     interfaces, accessibility tools have full access to view and
@@ -23,20 +23,10 @@ class Atk(Package):
     version("2.36.0", sha256="fb76247e369402be23f1f5c65d38a9639c1164d934e40f6a9cf3c9e96b652788")
     version("2.30.0", sha256="dd4d90d4217f2a0c1fee708a555596c2c19d26fef0952e1ead1938ab632c027b")
     version("2.28.1", sha256="cd3a1ea6ecc268a2497f0cd018e970860de24a6d42086919d6bf6c8e8d53f4fc")
-    version(
-        "2.20.0",
-        sha256="493a50f6c4a025f588d380a551ec277e070b28a82e63ef8e3c06b3ee7c1238f0",
-        deprecated=True,
-    )
-    version(
-        "2.14.0",
-        sha256="2875cc0b32bfb173c066c22a337f79793e0c99d2cc5e81c4dac0d5a523b8fbad",
-        deprecated=True,
-    )
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
-    depends_on("meson@0.40.1:", type="build", when="@2.28:")
+    depends_on("meson@0.40.1:", type="build")
     depends_on("meson@0.46.0:", type="build", when="@2.29:")
     depends_on("glib")
     depends_on("gettext")
@@ -45,33 +35,15 @@ class Atk(Package):
     depends_on("libffi")
 
     def url_for_version(self, version):
-        """Handle gnome's version-based custom URLs."""
-        url = "http://ftp.gnome.org/pub/gnome/sources/atk"
-        return url + f"/{version.up_to(2)}/atk-{version}.tar.xz"
+        return (
+            f"http://ftp.gnome.org/pub/gnome/sources/atk/"
+            f"{version.up_to(2)}/atk-{version}.tar.xz"
+        )
 
     def setup_run_environment(self, env):
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
         env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
         env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
-
-    def setup_dependent_run_environment(self, env, dependent_spec):
-        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
-        env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
-
-    def install(self, spec, prefix):
-        with working_dir("spack-build", create=True):
-            meson("..", *std_meson_args)
-            ninja("-v")
-            ninja("install")
-
-    @when("@:2.27")
-    def install(self, spec, prefix):
-        configure(f"--prefix={prefix}")
-        make()
-        if self.run_tests:
-            make("check")
-        make("install")
-        if self.run_tests:
-            make("installcheck")

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -6,12 +6,10 @@
 from spack.package import *
 
 
-class GdkPixbuf(Package):
-    """The Gdk Pixbuf is a toolkit for image loading and pixel buffer
-    manipulation. It is used by GTK+ 2 and GTK+ 3 to load and
-    manipulate images. In the past it was distributed as part of
-    GTK+ 2 but it was split off into a separate package in
-    preparation for the change to GTK+ 3."""
+class GdkPixbuf(MesonPackage):
+    """The Gdk Pixbuf is a toolkit for image loading and pixel buffer manipulation. It is used by
+    GTK+ 2 and GTK+ 3 to load and manipulate images. In the past it was distributed as part of
+    GTK+ 2 but it was split off into a separate package in preparation for the change to GTK+ 3."""
 
     homepage = "https://gitlab.gnome.org/GNOME/gdk-pixbuf"
     url = "https://ftp.acc.umu.se/pub/gnome/sources/gdk-pixbuf/2.40/gdk-pixbuf-2.40.0.tar.xz"
@@ -43,44 +41,20 @@ class GdkPixbuf(Package):
         sha256="83c66a1cfd591d7680c144d2922c5955d38b4db336d7cd3ee109f7bcf9afef15",
         deprecated=True,
     )
-    # https://nvd.nist.gov/vuln/detail/CVE-2021-20240
-    version(
-        "2.40.0",
-        sha256="1582595099537ca8ff3b99c6804350b4c058bb8ad67411bbaae024ee7cead4e6",
-        deprecated=True,
-    )
-    version(
-        "2.38.2",
-        sha256="73fa651ec0d89d73dd3070b129ce2203a66171dfc0bd2caa3570a9c93d2d0781",
-        deprecated=True,
-    )
-    version(
-        "2.38.0",
-        sha256="dd50973c7757bcde15de6bcd3a6d462a445efd552604ae6435a0532fbbadae47",
-        deprecated=True,
-    )
-    version(
-        "2.31.2",
-        sha256="9e467ed09894c802499fb2399cd9a89ed21c81700ce8f27f970a833efb1e47aa",
-        deprecated=True,
-    )
 
     depends_on("c", type="build")
 
-    variant("x11", default=False, description="Enable X11 support", when="@:2.41")
     variant("tiff", default=False, description="Enable TIFF support(partially broken)")
     # Man page creation was getting docbook errors, see issue #18853
     variant("man", default=False, description="Enable man page creation")
 
-    depends_on("meson@0.55.3:", type="build", when="@2.42.2:")
-    depends_on("meson@0.46.0:", type="build", when="@2.37.92:")
-    depends_on("meson@0.45.0:", type="build", when="@2.37.0:")
-    depends_on("ninja", type="build", when="@2.37.0:")
-    depends_on("shared-mime-info", when="@2.36.8: platform=linux")
-    depends_on("pkgconfig", type="build")
-    # Building the man pages requires libxslt and the Docbook stylesheets
-    depends_on("libxslt", type="build", when="+man")
-    depends_on("docbook-xsl@1.79.2:", type="build", when="+man")
+    with default_args(type="build"):
+        depends_on("meson@0.55.3:")
+        depends_on("pkgconfig")
+        depends_on("libxslt", when="+man")
+        depends_on("docbook-xsl@1.79.2:", when="+man")
+
+    depends_on("shared-mime-info", when="platform=linux")
     depends_on("gettext")
     depends_on("glib@2.38.0:")
     depends_on("jpeg")
@@ -88,67 +62,27 @@ class GdkPixbuf(Package):
     depends_on("zlib-api")
     depends_on("libtiff", when="+tiff")
     depends_on("gobject-introspection")
-    depends_on("libx11", when="+x11")
 
-    # Replace the docbook stylesheet URL with the one that our
-    # docbook-xsl package uses/recognizes.
-    # Pach modifies meson build files, so it only applies to versions that
-    # depend on meson.
-    patch("docbook-cdn.patch", when="@2.37.0:+man")
+    # Replace the docbook stylesheet URL with the one that our docbook-xsl package uses/recognizes.
+    patch("docbook-cdn.patch", when="+man")
 
     def url_for_version(self, version):
         url = "https://ftp.acc.umu.se/pub/gnome/sources/gdk-pixbuf/{0}/gdk-pixbuf-{1}.tar.xz"
         return url.format(version.up_to(2), version)
 
     def setup_run_environment(self, env):
+        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
         env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
         env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
 
-    def setup_dependent_run_environment(self, env, dependent_spec):
-        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
-        env.prepend_path("GI_TYPELIB_PATH", join_path(self.prefix.lib, "girepository-1.0"))
-
-    def install(self, spec, prefix):
-        with working_dir("spack-build", create=True):
-            meson_args = std_meson_args + ["-Dman={0}".format("+man" in spec)]
-            # Only build tests when requested
-            if self.version >= Version("2.42.9"):
-                meson_args += ["-Dtests={0}".format(self.run_tests)]
-            # Based on suggestion by luigi-calori and the fixup shown by lee218llnl:
-            # https://github.com/spack/spack/pull/27254#issuecomment-974464174
-            if spec.satisfies("+x11"):
-                if self.version >= Version("2.42"):
-                    raise InstallError("+x11 is not valid for {0}".format(self.version))
-                meson_args += ["-Dx11=true"]
-            meson("..", *meson_args)
-            ninja("-v")
-            if self.run_tests:
-                ninja("test")
-            ninja("install")
-
-    def configure_args(self):
-        args = []
-        # disable building of gtk-doc files following #9771
-        args.append("--disable-gtk-doc-html")
-        true = which("true")
-        args.append("GTKDOC_CHECK={0}".format(true))
-        args.append("GTKDOC_CHECK_PATH={0}".format(true))
-        args.append("GTKDOC_MKPDF={0}".format(true))
-        args.append("GTKDOC_REBASE={0}".format(true))
+    def meson_args(self):
+        args = [f"-Dman={'true' if self.spec.satisfies('+man') else 'false'}"]
+        if self.spec.satisfies("@2.42.9:"):
+            args.append(f"-Dtests={'true' if self.run_tests else 'false'}")
         return args
-
-    @when("@:2.36")
-    def install(self, spec, prefix):
-        configure("--prefix={0}".format(prefix), *self.configure_args())
-        make()
-        if self.run_tests:
-            make("check")
-        make("install")
-        if self.run_tests:
-            make("installcheck")
 
     def setup_build_environment(self, env):
         # The "post-install.sh" script uses gdk-pixbuf-query-loaders,

--- a/var/spack/repos/builtin/packages/w3m/package.py
+++ b/var/spack/repos/builtin/packages/w3m/package.py
@@ -68,7 +68,7 @@ class W3m(AutotoolsPackage):
         values=("gdk-pixbuf", "imlib2"),
         multi=False,
     )
-    depends_on("gdk-pixbuf@2:+x11", when="imagelib=gdk-pixbuf +image")
+    depends_on("gdk-pixbuf@2:", when="imagelib=gdk-pixbuf +image")
     depends_on("imlib2@1.0.5:", when="imagelib=imlib2 +image")
 
     # fix for modern libraries


### PR DESCRIPTION
goal is to get rid of `std_meson_args` global, but clean up package
while at it.

`setup_dependent_run_environment` was removed because it did not depend
on the dependent spec, and would result in repeated env variable
changes for each in-edge.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
