### PR TITLE
std_pip_args: use PythonPipBuilder.std_args(...) instead

### DIFF
--- a/var/spack/repos/builtin/packages/cmor/package.py
+++ b/var/spack/repos/builtin/packages/cmor/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -76,5 +77,4 @@ class Cmor(AutotoolsPackage):
         make("install")
 
         if spec.satisfies("+python"):
-            args = std_pip_args + ["--prefix=" + prefix, "."]
-            pip(*args)
+            pip(*PythonPipBuilder.std_args(self), f"--prefix={prefix}", ".")

--- a/var/spack/repos/builtin/packages/faiss/package.py
+++ b/var/spack/repos/builtin/packages/faiss/package.py
@@ -5,6 +5,7 @@
 
 import os
 
+from spack.build_systems import autotools, cmake, python
 from spack.package import *
 
 
@@ -91,7 +92,7 @@ class Faiss(AutotoolsPackage, CMakePackage, CudaPackage):
                 env.append_path("LD_LIBRARY_PATH", os.path.join(python_platlib, "faiss"))
 
 
-class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         spec = self.spec
         args = [
@@ -113,20 +114,19 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         super().install(pkg, spec, prefix)
         if spec.satisfies("+python"):
 
-            class CustomPythonPipBuilder(spack.build_systems.python.PythonPipBuilder):
+            class CustomPythonPipBuilder(python.PythonPipBuilder):
                 def __init__(self, pkg, build_dirname):
-                    spack.build_systems.python.PythonPipBuilder.__init__(self, pkg)
+                    python.PythonPipBuilder.__init__(self, pkg)
                     self.build_dirname = build_dirname
 
                 @property
                 def build_directory(self):
                     return os.path.join(self.pkg.stage.path, self.build_dirname, "faiss", "python")
 
-            customPip = CustomPythonPipBuilder(pkg, self.build_dirname)
-            customPip.install(pkg, spec, prefix)
+            CustomPythonPipBuilder(pkg, self.build_dirname).install(pkg, spec, prefix)
 
 
-class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
+class AutotoolsBuilder(autotools.AutotoolsBuilder):
     def configure_args(self):
         args = []
         args.extend(self.with_or_without("cuda", activation_value="prefix"))
@@ -156,8 +156,7 @@ class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
 
         if self.spec.satisfies("+python"):
             with working_dir("python"):
-                args = std_pip_args + ["--prefix=" + prefix, "."]
-                pip(*args)
+                pip(*python.PythonPipBuilder.std_args(pkg), f"--prefix={prefix}", ".")
 
         if "+tests" not in self.spec:
             return

--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 from spack.pkg.builtin.boost import Boost
 
@@ -194,5 +195,4 @@ class Fenics(CMakePackage):
     def install_python_interface(self):
         if self.spec.satisfies("+python"):
             with working_dir("python"):
-                args = std_pip_args + ["--prefix=" + self.prefix, "."]
-                pip(*args)
+                pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")

--- a/var/spack/repos/builtin/packages/flatbuffers/package.py
+++ b/var/spack/repos/builtin/packages/flatbuffers/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -59,8 +60,7 @@ class Flatbuffers(CMakePackage):
         if self.spec.satisfies("+python"):
             pydir = join_path(self.stage.source_path, "python")
             with working_dir(pydir):
-                args = std_pip_args + ["--prefix=" + self.prefix, "."]
-                pip(*args)
+                pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")
 
     def cmake_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/jsonnet/package.py
+++ b/var/spack/repos/builtin/packages/jsonnet/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -40,5 +41,4 @@ class Jsonnet(MakefilePackage):
     @run_after("install")
     def python_install(self):
         if "+python" in self.spec:
-            args = std_pip_args + ["--prefix=" + self.prefix, "."]
-            pip(*args)
+            pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -6,6 +6,7 @@ import datetime as dt
 import os
 
 from spack.build_environment import optimization_flags
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -992,5 +993,4 @@ class Lammps(CMakePackage, CudaPackage, ROCmPackage, PythonExtension):
                 os.environ["LAMMPS_VERSION_FILE"] = join_path(
                     self.stage.source_path, "src", "version.h"
                 )
-                args = std_pip_args + ["--prefix=" + self.prefix, "."]
-                pip(*args)
+                pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")

--- a/var/spack/repos/builtin/packages/mxnet/package.py
+++ b/var/spack/repos/builtin/packages/mxnet/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -126,5 +127,4 @@ class Mxnet(CMakePackage, CudaPackage, PythonExtension):
     def install_python(self):
         if "+python" in self.spec:
             with working_dir("python"):
-                args = std_pip_args + ["--prefix=" + prefix, "."]
-                pip(*args)
+                pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")

--- a/var/spack/repos/builtin/packages/nvtx/package.py
+++ b/var/spack/repos/builtin/packages/nvtx/package.py
@@ -48,6 +48,5 @@ class Nvtx(Package, PythonExtension):
 
         install("./nvtx-config.cmake", prefix)  # added by the patch above
 
-        args = std_pip_args + ["--prefix=" + prefix, "."]
         with working_dir(self.build_directory):
-            pip(*args)
+            pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")

--- a/var/spack/repos/builtin/packages/py-dgl/package.py
+++ b/var/spack/repos/builtin/packages/py-dgl/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -132,8 +133,7 @@ class PyDgl(CMakePackage, PythonExtension, CudaPackage):
 
     def install(self, spec, prefix):
         with working_dir("python"):
-            args = std_pip_args + ["--prefix=" + prefix, "."]
-            pip(*args)
+            pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")
 
         # Older versions do not install correctly
         if self.spec.satisfies("@:0.4.3"):

--- a/var/spack/repos/builtin/packages/py-jaxlib/package.py
+++ b/var/spack/repos/builtin/packages/py-jaxlib/package.py
@@ -5,6 +5,7 @@
 
 import tempfile
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 rocm_dependencies = [
@@ -194,7 +195,6 @@ build --local_cpu_resources={make_jobs}
 
         python(*args)
         with working_dir(self.wrapped_package_object.tmp_path):
-            args = std_pip_args + ["--prefix=" + self.prefix, "."]
-            pip(*args)
+            pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")
         remove_linked_tree(self.wrapped_package_object.tmp_path)
         remove_linked_tree(self.wrapped_package_object.buildtmp)

--- a/var/spack/repos/builtin/packages/py-keras/package.py
+++ b/var/spack/repos/builtin/packages/py-keras/package.py
@@ -5,6 +5,7 @@
 
 import tempfile
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -199,6 +200,5 @@ class PyKeras(PythonPackage):
         build_pip_package("--src", buildpath)
 
         with working_dir(buildpath):
-            args = std_pip_args + ["--prefix=" + prefix, "."]
-            pip(*args)
+            pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")
         remove_linked_tree(self.tmp_path)

--- a/var/spack/repos/builtin/packages/py-meldmd/package.py
+++ b/var/spack/repos/builtin/packages/py-meldmd/package.py
@@ -5,6 +5,7 @@
 
 import os
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -52,11 +53,10 @@ class PyMeldmd(CMakePackage, PythonExtension, CudaPackage):
 
     @run_after("install")
     def install_python(self):
-        args = std_pip_args + ["--prefix=" + prefix, "."]
-        pip(*args)
+        pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")
         with working_dir(join_path(self.build_directory, "python")):
             make("MeldPluginPatch")
-            pip(*args)
+            pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")
         for _, _, files in os.walk(self.spec["openmm"].prefix.lib.plugins):
             for f in files:
                 os.symlink(

--- a/var/spack/repos/builtin/packages/py-onnxruntime/package.py
+++ b/var/spack/repos/builtin/packages/py-onnxruntime/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -211,6 +212,5 @@ class PyOnnxruntime(CMakePackage, PythonExtension, ROCmPackage):
     @run_after("install")
     def install_python(self):
         """Install everything from build directory."""
-        args = std_pip_args + ["--prefix=" + prefix, "."]
         with working_dir(self.build_directory):
-            pip(*args)
+            pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")

--- a/var/spack/repos/builtin/packages/py-or-tools/package.py
+++ b/var/spack/repos/builtin/packages/py-or-tools/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -57,5 +58,4 @@ class PyOrTools(CMakePackage):
         with working_dir(self.build_directory):
             make("install")
         with working_dir(join_path(self.build_directory, "python")):
-            args = std_pip_args + ["--prefix=" + prefix, "."]
-            pip(*args)
+            pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -143,8 +144,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             python("setup.py", "build_ext", *args)
 
     def install(self, pkg, spec, prefix):
-        pip_args = std_pip_args + [f"--prefix={prefix}", "."]
-        pip(*pip_args)
+        pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")
         super().install(pkg, spec, prefix)
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -113,8 +114,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             python("setup.py", "build_ext", *args)
 
     def install(self, pkg, spec, prefix):
-        pip_args = std_pip_args + ["--prefix=" + prefix, "."]
-        pip(*pip_args)
+        pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")
         super().install(pkg, spec, prefix)
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -5,6 +5,7 @@
 import os
 import sys
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -76,15 +77,14 @@ class PyPip(Package, PythonExtension):
         # itself, see:
         # https://discuss.python.org/t/bootstrapping-a-specific-version-of-pip/12306
         whl = self.stage.archive_file
-        args = std_pip_args + ["--prefix=" + prefix, whl]
         if sys.platform == "win32":
             # On Windows for newer versions of pip, you must bootstrap pip first.
             # In order to achieve this, use the pip.pyz zipapp version of pip to
             # bootstrap the pip wheel install.
-            args.insert(0, os.path.join(self.stage.source_path, "pip.pyz"))
+            script = os.path.join(self.stage.source_path, "pip.pyz")
         else:
-            args.insert(0, os.path.join(whl, "pip"))
-        python(*args)
+            script = os.path.join(whl, "pip")
+        python(script, *PythonPipBuilder.std_args(self), f"--prefix={prefix}", whl)
 
     def setup_dependent_package(self, module, dependent_spec: Spec):
         setattr(module, "pip", python.with_default_args("-m", "pip"))

--- a/var/spack/repos/builtin/packages/py-pynucleus/package.py
+++ b/var/spack/repos/builtin/packages/py-pynucleus/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -59,11 +60,9 @@ class PyPynucleus(PythonPackage):
 
     @run_before("install")
     def install_python(self):
-        prefix = self.prefix
         for subpackage in ["packageTools", "base", "metisCy", "fem", "multilevelSolver", "nl"]:
             with working_dir(subpackage):
-                args = std_pip_args + ["--prefix=" + prefix, "."]
-                pip(*args)
+                pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")
 
     @run_after("install")
     def install_additional_files(self):

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -95,5 +96,4 @@ class PySetuptools(Package, PythonExtension):
         #
         # We work around this issue by installing setuptools from wheels
         whl = self.stage.archive_file
-        args = ["-m", "pip"] + std_pip_args + ["--prefix=" + prefix, whl]
-        python(*args)
+        python("-m", "pip", *PythonPipBuilder.std_args(self), f"--prefix={prefix}", whl)

--- a/var/spack/repos/builtin/packages/py-tensorboard-data-server/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorboard-data-server/package.py
@@ -5,6 +5,7 @@
 
 import glob
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -60,5 +61,4 @@ class PyTensorboardDataServer(PythonPackage):
             )
 
         wheel = glob.glob("*.whl")[0]
-        args = std_pip_args + ["--prefix=" + prefix, wheel]
-        pip(*args)
+        pip(*PythonPipBuilder.std_args(self), f"--prefix={prefix}", wheel)

--- a/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
@@ -5,6 +5,7 @@
 
 import tempfile
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -97,6 +98,5 @@ class PyTensorflowEstimator(Package):
         buildpath = join_path(self.stage.source_path, "spack-build")
         build_pip_package("--src", buildpath)
         with working_dir(buildpath):
-            args = std_pip_args + ["--prefix=" + prefix, "."]
-            pip(*args)
+            pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")
         remove_linked_tree(self.tmp_path)

--- a/var/spack/repos/builtin/packages/py-tensorflow-hub/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-hub/package.py
@@ -5,6 +5,7 @@
 
 import tempfile
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -78,8 +79,7 @@ class PyTensorflowHub(Package):
         )
 
         with working_dir(insttmp_path):
-            args = std_pip_args + ["--prefix=" + prefix, "."]
-            pip(*args)
+            pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")
 
         remove_linked_tree(tmp_path)
         remove_linked_tree(insttmp_path)

--- a/var/spack/repos/builtin/packages/py-tensorflow-probability/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-probability/package.py
@@ -5,6 +5,7 @@
 
 import tempfile
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -118,7 +119,6 @@ class PyTensorflowProbability(Package):
         bazel(*args)
 
         with working_dir(join_path("bazel-bin", "pip_pkg.runfiles", "tensorflow_probability")):
-            args = std_pip_args + ["--prefix=" + prefix, "."]
-            pip(*args)
+            pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")
 
         remove_linked_tree(self.tmp_path)

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 
 from spack.build_environment import optimization_flags
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 rocm_dependencies = [
@@ -888,12 +889,10 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
             )
             with working_dir(buildpath):
                 wheel = glob.glob("*.whl")[0]
-                args = std_pip_args + ["--prefix=" + prefix, wheel]
-                pip(*args)
+                pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", wheel)
         else:
             buildpath = join_path(self.stage.source_path, "spack-build")
             with working_dir(buildpath):
-                args = std_pip_args + ["--prefix=" + prefix, "."]
-                pip(*args)
+                pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")
 
         remove_linked_tree(tmp_path)

--- a/var/spack/repos/builtin/packages/py-tfdlpack/package.py
+++ b/var/spack/repos/builtin/packages/py-tfdlpack/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -40,8 +41,7 @@ class PyTfdlpack(CMakePackage, PythonExtension):
 
     def install(self, spec, prefix):
         with working_dir("python"):
-            args = std_pip_args + ["--prefix=" + prefix, "."]
-            pip(*args)
+            pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")
 
     def setup_run_environment(self, env):
         # Prevent TensorFlow from taking over the whole GPU

--- a/var/spack/repos/builtin/packages/py-wheel/package.py
+++ b/var/spack/repos/builtin/packages/py-wheel/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -43,5 +44,4 @@ class PyWheel(Package, PythonExtension):
         # To build wheel from source, you need setuptools and wheel already installed.
         # We get around this by using a pre-built wheel, see:
         # https://discuss.python.org/t/bootstrapping-a-specific-version-of-pip/12306
-        args = std_pip_args + ["--prefix=" + prefix, self.stage.archive_file]
-        pip(*args)
+        pip(*PythonPipBuilder.std_args(self), f"--prefix={prefix}", self.stage.archive_file)

--- a/var/spack/repos/builtin/packages/sgpp/package.py
+++ b/var/spack/repos/builtin/packages/sgpp/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 from spack.pkg.builtin.boost import Boost
 
@@ -190,5 +191,4 @@ class Sgpp(SConsPackage):
     @run_after("install")
     def python_install(self):
         if "+python" in self.spec:
-            args = std_pip_args + ["--prefix=" + self.prefix, "."]
-            pip(*args)
+            pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")

--- a/var/spack/repos/builtin/packages/sourmash/package.py
+++ b/var/spack/repos/builtin/packages/sourmash/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -35,8 +36,7 @@ class Sourmash(PythonPackage):
         cargo = Executable("cargo")
         cargo("build", "--release")
         # install python package
-        args = std_pip_args + ["--prefix=" + prefix, "."]
-        pip(*args)
+        pip(*PythonPipBuilder.std_args(self), f"--prefix={prefix}", ".")
         # move sourmash.so into expected place
         site_packages = join_path(python_platlib, "sourmash")
         lib_ext = "dylib" if spec.platform == "Darwin" else "so"

--- a/var/spack/repos/builtin/packages/tamaas/package.py
+++ b/var/spack/repos/builtin/packages/tamaas/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -101,5 +102,4 @@ class Tamaas(SConsPackage):
         scons("install-lib", *args)
 
         if spec.satisfies("+python"):
-            args = ["-m", "pip"] + std_pip_args + ["--prefix=" + prefix, "build-release/python"]
-            python(*args)
+            pip(*PythonPipBuilder.std_args(self), f"--prefix={prefix}", "build-release/python")

--- a/var/spack/repos/builtin/packages/treelite/package.py
+++ b/var/spack/repos/builtin/packages/treelite/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 
 
@@ -50,5 +51,4 @@ class Treelite(CMakePackage):
     def python_install(self):
         if "+python" in self.spec:
             with working_dir("python"):
-                args = std_pip_args + ["--prefix=" + self.prefix, "."]
-                pip(*args)
+                pip(*PythonPipBuilder.std_args(self), f"--prefix={self.prefix}", ".")


### PR DESCRIPTION
Currently `std_pip_args` is set in `build_environment.py` for any package,
including ones that don't depend on python or pip.

This commit replaces globals with direct calls to `PythonPipBuilder.std_args`,
so (A) the origin is clear, and (B) the dependency on build_environment.py
is effectively removed, which was an input that was not reflected in the package
hash.

