### PR TITLE
py-pycifrw: add v4.4.6

### DIFF
--- a/var/spack/repos/builtin/packages/py-pycifrw/package.py
+++ b/var/spack/repos/builtin/packages/py-pycifrw/package.py
@@ -15,6 +15,7 @@ class PyPycifrw(PythonPackage):
 
     license("Python-2.0")
 
+    version("4.4.6", sha256="02bf5975e70ab71540bff62fbef3e8354ac707a0f0ab914a152047962891ef15")
     version("4.4.1", sha256="cef7662f475e0eb78a55c2d55774d474e888c96b0539e5f08550afa902cdc4e1")
 
     depends_on("c", type="build")  # generated


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Add v4.4.6, released 2023-11-01, with various bug fixes. The existing v4.4.1 dates from 2019.
