### PR TITLE
builder.py: builder_cls should be associated to spack.pkg module

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -722,9 +722,8 @@ def _ensure_env_methods_are_ported_to_builders(pkgs, error_cls):
         )
         builder_cls_names = [spack.builder.BUILDER_CLS[x].__name__ for x in build_system_names]
 
-        module = pkg_cls.module
         has_builders_in_package_py = any(
-            getattr(module, name, False) for name in builder_cls_names
+            spack.builder.get_builder_class(pkg_cls, name) for name in builder_cls_names
         )
         if not has_builders_in_package_py:
             continue

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -75,6 +75,14 @@ class _PhaseAdapter:
         return self.phase_fn(self.builder.pkg, spec, prefix)
 
 
+def get_builder_class(pkg, name: str) -> Optional[type]:
+    """Return the builder class if a package module defines it."""
+    cls = getattr(pkg.module, name, None)
+    if cls and cls.__module__.startswith(spack.repo.ROOT_PYTHON_NAMESPACE):
+        return cls
+    return None
+
+
 def _create(pkg):
     """Return a new builder object for the package object being passed as argument.
 
@@ -100,9 +108,10 @@ def _create(pkg):
     package_buildsystem = buildsystem_name(pkg)
     default_builder_cls = BUILDER_CLS[package_buildsystem]
     builder_cls_name = default_builder_cls.__name__
-    builder_cls = getattr(pkg.module, builder_cls_name, None)
-    if builder_cls and builder_cls.__module__.startswith(spack.repo.ROOT_PYTHON_NAMESPACE):
-        return builder_cls(pkg)
+    builder_class = get_builder_class(pkg, builder_cls_name)
+
+    if builder_class:
+        return builder_class(pkg)
 
     # Specialized version of a given buildsystem can subclass some
     # base classes and specialize certain phases or methods or attributes.

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -12,6 +12,7 @@ from llnl.util import lang
 
 import spack.error
 import spack.multimethod
+import spack.repo
 
 #: Builder classes, as registered by the "builder" decorator
 BUILDER_CLS = {}
@@ -100,7 +101,7 @@ def _create(pkg):
     default_builder_cls = BUILDER_CLS[package_buildsystem]
     builder_cls_name = default_builder_cls.__name__
     builder_cls = getattr(pkg.module, builder_cls_name, None)
-    if builder_cls:
+    if builder_cls and builder_cls.__module__.startswith(spack.repo.ROOT_PYTHON_NAMESPACE):
         return builder_cls(pkg)
 
     # Specialized version of a given buildsystem can subclass some


### PR DESCRIPTION
Having say a `CMakeBuilder` attribute at the module level is insufficient to determine whether a package.py defines separate builders.

It may be that it's merely imported: `from spack.build_systems.cmake import CMakeBuilder` to use some property or method of it in a package class.

Instead check that its associated module is `spack.pkg.*`