### PR TITLE
py-uv: add v0.4.27

### DIFF
--- a/var/spack/repos/builtin/packages/py-uv/package.py
+++ b/var/spack/repos/builtin/packages/py-uv/package.py
@@ -14,6 +14,7 @@ class PyUv(PythonPackage):
 
     license("APACHE 2.0 or MIT")
 
+    version("0.4.27", sha256="c13eea45257362ecfa2a2b31de9b62fbd0542e211a573562d98ab7c8fc50d8fc")
     version("0.4.17", sha256="01564bd760eff885ad61f44173647a569732934d1a4a558839c8088fbf75e53f")
     version("0.4.16", sha256="2144995a87b161d063bd4ef8294b1e948677bd90d01f8394d0e3fca037bb847f")
     version("0.4.15", sha256="8e36b8e07595fc6216d01e729c81a0b4ff029a93cc2ef987a73d3b650d6d559c")
@@ -21,5 +22,9 @@ class PyUv(PythonPackage):
     depends_on("rust", type=("build", "run"))
     depends_on("python@3.8:", type=("build", "run"))
     depends_on("py-maturin@1:1", type="build")
+    depends_on("cmake", type="build")
+
+    def setup_build_environment(self, env):
+        env.set("CMAKE", self.spec["cmake"].prefix.bin.cmake)
 
     executables = ["^uv$"]


### PR DESCRIPTION
This adds the current latest version of py-uv. While working on this, I also found that uv (including older versions) has a build dependency on cmake which was not specified in the package, so I added it as a dependency.

I also found that on my machine, the build process had trouble finding cmake, so I set the path to it explicitly as an environment variable.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
