### PR TITLE
llnl.util.lang: add classes to help with deprecations

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -914,6 +914,21 @@ def ensure_last(lst, *elements):
         lst.append(lst.pop(lst.index(elt)))
 
 
+class Const:
+    """Class level constant, raises when trying to set the attribute"""
+
+    __slots__ = ["value"]
+
+    def __init__(self, value):
+        self.value = value
+
+    def __get__(self, instance, owner):
+        return self.value
+
+    def __set__(self, instance, value):
+        raise TypeError(f"Const value does not support assignment [value={self.value}]")
+
+
 class TypedMutableSequence(collections.abc.MutableSequence):
     """Base class that behaves like a list, just with a different type.
 

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -1050,9 +1050,6 @@ class DeprecatedProperty:
     #: 2 - Error
     error_lvl = 0
 
-    #: Whether to add tracebacks to warnings and errors
-    traceback = False
-
     def __init__(self, name: str) -> None:
         self.name = name
 
@@ -1063,12 +1060,8 @@ class DeprecatedProperty:
         if self.error_lvl == 1:
             msg = f"accessing the '{self.name}' property of '{instance}', which is deprecated"
             warnings.warn(msg)
-            if self.traceback:
-                traceback.print_stack()
         elif self.error_lvl == 2:
             msg = f"cannot access the '{self.name}' attribute of '{instance}'"
-            if self.traceback:
-                traceback.print_stack()
             raise AttributeError(msg)
 
         return self.factory(instance, owner)

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -11,6 +11,7 @@ import os
 import re
 import sys
 import traceback
+import warnings
 from datetime import datetime, timedelta
 from typing import Callable, Iterable, List, Tuple, TypeVar
 
@@ -1033,3 +1034,49 @@ class classproperty:
 
     def __get__(self, instance, owner):
         return self.callback(owner)
+
+
+class DeprecatedProperty:
+    """Data descriptor to error or warn when a deprecated property is accessed.
+
+    Derived classes must define a factory method to return an adaptor for the deprecated
+    property, if the descriptor is not set to error.
+    """
+
+    __slots__ = ["name"]
+
+    #: 0 - Nothing
+    #: 1 - Warning
+    #: 2 - Error
+    error_lvl = 0
+
+    #: Whether to add tracebacks to warnings and errors
+    traceback = False
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+
+        if self.error_lvl == 1:
+            msg = f"accessing the '{self.name}' property of '{instance}', which is deprecated"
+            warnings.warn(msg)
+            if self.traceback:
+                traceback.print_stack()
+        elif self.error_lvl == 2:
+            msg = f"cannot access the '{self.name}' attribute of '{instance}'"
+            if self.traceback:
+                traceback.print_stack()
+            raise AttributeError(msg)
+
+        return self.factory(instance, owner)
+
+    def __set__(self, instance, value):
+        raise TypeError(
+            f"the deprecated property '{self.name}' of '{instance}' does not support assignment"
+        )
+
+    def factory(self, instance, owner):
+        raise NotImplementedError("must be implemented by derived classes")

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -1058,11 +1058,11 @@ class DeprecatedProperty:
             return self
 
         if self.error_lvl == 1:
-            msg = f"accessing the '{self.name}' property of '{instance}', which is deprecated"
-            warnings.warn(msg)
+            warnings.warn(
+                f"accessing the '{self.name}' property of '{instance}', which is deprecated"
+            )
         elif self.error_lvl == 2:
-            msg = f"cannot access the '{self.name}' attribute of '{instance}'"
-            raise AttributeError(msg)
+            raise AttributeError(f"cannot access the '{self.name}' attribute of '{instance}'")
 
         return self.factory(instance, owner)
 

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -340,6 +340,7 @@ def test_grouped_exception_base_type():
 
 def test_class_level_constant_value():
     """Tests that the Const descriptor does not allow overwriting the value from an instance"""
+
     class _SomeClass:
         CONST_VALUE = llnl.util.lang.Const(10)
 
@@ -347,3 +348,28 @@ def test_class_level_constant_value():
         _SomeClass().CONST_VALUE = 11
 
 
+def test_deprecated_property():
+    """Tests the behavior of the DeprecatedProperty descriptor, which is can be used when
+    deprecating an attribute.
+    """
+
+    class _Deprecated(llnl.util.lang.DeprecatedProperty):
+        def factory(self, instance, owner):
+            return 46
+
+    class _SomeClass:
+        deprecated = _Deprecated("deprecated")
+
+    # Default behavior is to just return the deprecated value
+    s = _SomeClass()
+    assert s.deprecated == 46
+
+    # When setting error_level to 1 the attribute warns
+    _SomeClass.deprecated.error_lvl = 1
+    with pytest.warns(UserWarning):
+        assert s.deprecated == 46
+
+    # When setting error_level to 2 an exception is raised
+    _SomeClass.deprecated.error_lvl = 2
+    with pytest.raises(AttributeError):
+        _ = s.deprecated

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -336,3 +336,14 @@ def test_grouped_exception_base_type():
     message = h.grouped_message(with_tracebacks=False)
     assert "catch-runtime-error" in message
     assert "catch-value-error" not in message
+
+
+def test_class_level_constant_value():
+    """Tests that the Const descriptor does not allow overwriting the value from an instance"""
+    class _SomeClass:
+        CONST_VALUE = llnl.util.lang.Const(10)
+
+    with pytest.raises(TypeError, match="not support assignment"):
+        _SomeClass().CONST_VALUE = 11
+
+


### PR DESCRIPTION
Extracted from #45189 

This PR adds a couple of classes to `llnl.util.lang`, which could help when deprecating attributes/properties of an object:
- `Const` raises an exception whenever an attribute is set on the instance, when it was supposed to be a constant defined by the class
- `DeprecatedProperty` allows to inject an adaptor to a deprecated attribute API, and either warn or error when usage is detected.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
