### PR TITLE
cbflib: improve syntax for querying %gcc version

### DIFF
--- a/var/spack/repos/builtin/packages/cbflib/package.py
+++ b/var/spack/repos/builtin/packages/cbflib/package.py
@@ -49,8 +49,7 @@ class Cbflib(MakefilePackage):
         mf.filter(r"^C\+\+.+", "C++ = {0}".format(spack_cxx))
         mf.filter("gfortran", spack_fc)
         mf.filter(r"^INSTALLDIR .+", "INSTALLDIR = {0}".format(prefix))
-        real_version = Version(self.compiler.get_real_version())
-        if real_version >= Version("10"):
+        if self.spec.satisfies("%gcc@10:"):
             mf.filter(r"^F90FLAGS[ \t]*=[ \t]*(.+)", "F90FLAGS = \\1 -fallow-invalid-boz")
 
     def build(self, spec, prefix):


### PR DESCRIPTION
Extracted from #45189

The fix in https://github.com/spack/spack/pull/38632 was likely meant for `gfortran`, not for any compiler with version greater than 10.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
