### PR TITLE
bigdft-futile: fix compilation for @1.9.5~mpi

### DIFF
--- a/var/spack/repos/builtin/packages/bigdft-futile/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-futile/package.py
@@ -49,6 +49,14 @@ class BigdftFutile(AutotoolsPackage, CudaPackage):
 
     configure_directory = "futile"
 
+    # missing MPI_BOTTOM in fake mpif.h (generated when compiling without MPI support)
+    # similar issue (maybe others) also in 1.9.4 but this patch does not work for 1.9.4
+    patch(
+        "https://gitlab.com/l_sim/bigdft-suite/-/commit/ec7419011fa9fd815de77bfca8642973091fb64b.diff",
+        sha256="66c493e37fe7f7f9800ae7f49bb0172a5b2372a2ce0ee4c3bcb7ff5c59a3925c",
+        when="@1.9.5~mpi",
+    )
+
     def configure_args(self):
         spec = self.spec
         prefix = self.prefix


### PR DESCRIPTION
When compiled without MPI support, a fake mpi header is autogenerated during configure/build. The header is missing one symbol in version 1.9.5. The problem has since been fixed upstream.

A similar problem does also occur for 1.9.4. Unfortunately, the patch does not work for 1.9.4 and I also don't know if further fixes would be required for 1.9.4. Therefore, only the newest version 1.9.5 is patched.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
