### PR TITLE
ucx: fix --with-rocm argument to prevent runtime error: "undefined symbol: hsa_init"'

### DIFF
--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -251,16 +251,23 @@ class Ucx(AutotoolsPackage, CudaPackage):
             args.append("LDFLAGS=-fuse-ld=bfd")
 
         if "+rocm" in spec:
-            rocm_flags = " ".join(
-                [
-                    "-I" + self.spec["hip"].prefix.include,
-                    "-I" + self.spec["hip"].prefix.include.hip,
-                    "-I" + self.spec["hsa-rocr-dev"].prefix.include.hsa,
-                    "-L" + self.spec["hip"].prefix.lib,
-                    "-L" + self.spec["hsa-rocr-dev"].prefix.lib,
-                ]
+            cppflags = " ".join(
+                "-I" + include_dir
+                for include_dir in (
+                    self.spec["hip"].prefix.include,
+                    self.spec["hip"].prefix.include.hip,
+                    self.spec["hsa-rocr-dev"].prefix.include.hsa,
+                )
             )
-            args.append("--with-rocm=" + rocm_flags)
+            ldflags = " ".join(
+                "-L" + library_dir
+                for library_dir in (
+                    self.spec["hip"].prefix.lib,
+                    self.spec["hsa-rocr-dev"].prefix.lib,
+                )
+            )
+            args.extend(["CPPFLAGS=" + cppflags, "LDFLAGS=" + ldflags])
+            args.append("--with-rocm=" + self.spec["hip"].prefix)
         else:
             args.append("--without-rocm")
 


### PR DESCRIPTION
I successfully compiled `ucx+rocm` using *spack*, also compiling all the *ROCm* packages. However, I got the following error at runtime: 
```
$ ucx_info
Usage: ucx_info [options]
At least one of the following options must be set:
  -v                   Show version information
  -d                   Show devices and transports
  -b                   Show build configuration
  -y                   Show type and structures information
  -s                   Show system information
  -c                   Show UCX configuration
  -C                   Comment-out default configuration values
  -a                   Show also hidden configuration
  -f                   Display fully decorated output

UCP information (-u is required):
  -p                   Show UCP context information
  -w                   Show UCP worker information
  -e                   Show UCP endpoint configuration
  -m <size>[,<type>]   Show UCP memory allocation info for a given size and type
ucx_info: symbol lookup error: spack-ucx/opt/spack/linux-fedora40-zen3/gcc-14.2.1/ucx-1.17.0-lacb3axi23mtspcjgmkpvmsuf7jnxrdx/lib/ucx/libuct_rocm.so.0: undefined symbol: hsa_init
```

With the current recipe, the configure `--with-rocm` flag is empty and it is used to pass the include and library folders of `hip` and  `hsa-rocr-dev` packages. However, in this way `ROCM_LIBS` remains unset instead of being `ROCM_LIBS='-lhsa-runtime64 -lhsakmt'`, as checked from the `config.log` files.

I suggest passing the `hip` prefix as `ROCM_ROOT` and passing the extra include and library directories as `CPPFLAGS` and `LDFLAGS`, respectively (a similar approach is used in the `python` recipe).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
