### PR TITLE
libxml2: add v2.11.9, v2.12.9, v2.13.4 (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -30,19 +30,24 @@ class Libxml2(AutotoolsPackage, NMakePackage):
 
     license("MIT")
 
-    version("2.10.3", sha256="5d2cc3d78bec3dbe212a9d7fa629ada25a7da928af432c93060ff5c17ee28a9c")
-    version("2.10.2", sha256="d240abe6da9c65cb1900dd9bf3a3501ccf88b3c2a1cb98317d03f272dda5b265")
-    version("2.10.1", sha256="21a9e13cc7c4717a6c36268d0924f92c3f67a1ece6b7ff9d588958a6db9fb9d8")
-    version("2.9.14", sha256="60d74a257d1ccec0475e749cba2f21559e48139efba6ff28224357c7c798dfee")
-    version("2.9.13", sha256="276130602d12fe484ecc03447ee5e759d0465558fbc9d6bd144e3745306ebf0e")
-    version("2.9.12", sha256="c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92")
-    version("2.9.11", sha256="886f696d5d5b45d780b2880645edf9e0c62a4fd6841b853e824ada4e02b4d331")
-    version("2.9.10", sha256="aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f")
-    version("2.9.9", sha256="94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871")
-    version("2.9.8", sha256="0b74e51595654f958148759cfef0993114ddccccbb6f31aee018f3558e8e2732")
-    version("2.9.4", sha256="ffb911191e509b966deb55de705387f14156e1a56b21824357cdf0053233633c")
-    version("2.9.2", sha256="5178c30b151d044aefb1b08bf54c3003a0ac55c59c866763997529d60770d5bc")
-    version("2.7.8", sha256="cda23bc9ebd26474ca8f3d67e7d1c4a1f1e7106364b690d822e009fdc3c417ec")
+    version("2.13.4", sha256="65d042e1c8010243e617efb02afda20b85c2160acdbfbcb5b26b80cec6515650")
+    version("2.12.9", sha256="59912db536ab56a3996489ea0299768c7bcffe57169f0235e7f962a91f483590")
+    version("2.11.9", sha256="780157a1efdb57188ec474dca87acaee67a3a839c2525b2214d318228451809f")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2024-25062
+        version("2.10.3", sha256="5d2cc3d78bec3dbe212a9d7fa629ada25a7da928af432c93060ff5c17ee28a9c")
+        version("2.10.2", sha256="d240abe6da9c65cb1900dd9bf3a3501ccf88b3c2a1cb98317d03f272dda5b265")
+        version("2.10.1", sha256="21a9e13cc7c4717a6c36268d0924f92c3f67a1ece6b7ff9d588958a6db9fb9d8")
+        version("2.9.14", sha256="60d74a257d1ccec0475e749cba2f21559e48139efba6ff28224357c7c798dfee")
+        version("2.9.13", sha256="276130602d12fe484ecc03447ee5e759d0465558fbc9d6bd144e3745306ebf0e")
+        version("2.9.12", sha256="c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92")
+        version("2.9.11", sha256="886f696d5d5b45d780b2880645edf9e0c62a4fd6841b853e824ada4e02b4d331")
+        version("2.9.10", sha256="aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f")
+        version("2.9.9", sha256="94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871")
+        version("2.9.8", sha256="0b74e51595654f958148759cfef0993114ddccccbb6f31aee018f3558e8e2732")
+        version("2.9.4", sha256="ffb911191e509b966deb55de705387f14156e1a56b21824357cdf0053233633c")
+        version("2.9.2", sha256="5178c30b151d044aefb1b08bf54c3003a0ac55c59c866763997529d60770d5bc")
+        version("2.7.8", sha256="cda23bc9ebd26474ca8f3d67e7d1c4a1f1e7106364b690d822e009fdc3c417ec")
 
     depends_on("c", type="build")  # generated
 

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -35,14 +35,30 @@ class Libxml2(AutotoolsPackage, NMakePackage):
     version("2.11.9", sha256="780157a1efdb57188ec474dca87acaee67a3a839c2525b2214d318228451809f")
     with default_args(deprecated=True):
         # https://nvd.nist.gov/vuln/detail/CVE-2024-25062
-        version("2.10.3", sha256="5d2cc3d78bec3dbe212a9d7fa629ada25a7da928af432c93060ff5c17ee28a9c")
-        version("2.10.2", sha256="d240abe6da9c65cb1900dd9bf3a3501ccf88b3c2a1cb98317d03f272dda5b265")
-        version("2.10.1", sha256="21a9e13cc7c4717a6c36268d0924f92c3f67a1ece6b7ff9d588958a6db9fb9d8")
-        version("2.9.14", sha256="60d74a257d1ccec0475e749cba2f21559e48139efba6ff28224357c7c798dfee")
-        version("2.9.13", sha256="276130602d12fe484ecc03447ee5e759d0465558fbc9d6bd144e3745306ebf0e")
-        version("2.9.12", sha256="c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92")
-        version("2.9.11", sha256="886f696d5d5b45d780b2880645edf9e0c62a4fd6841b853e824ada4e02b4d331")
-        version("2.9.10", sha256="aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f")
+        version(
+            "2.10.3", sha256="5d2cc3d78bec3dbe212a9d7fa629ada25a7da928af432c93060ff5c17ee28a9c"
+        )
+        version(
+            "2.10.2", sha256="d240abe6da9c65cb1900dd9bf3a3501ccf88b3c2a1cb98317d03f272dda5b265"
+        )
+        version(
+            "2.10.1", sha256="21a9e13cc7c4717a6c36268d0924f92c3f67a1ece6b7ff9d588958a6db9fb9d8"
+        )
+        version(
+            "2.9.14", sha256="60d74a257d1ccec0475e749cba2f21559e48139efba6ff28224357c7c798dfee"
+        )
+        version(
+            "2.9.13", sha256="276130602d12fe484ecc03447ee5e759d0465558fbc9d6bd144e3745306ebf0e"
+        )
+        version(
+            "2.9.12", sha256="c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92"
+        )
+        version(
+            "2.9.11", sha256="886f696d5d5b45d780b2880645edf9e0c62a4fd6841b853e824ada4e02b4d331"
+        )
+        version(
+            "2.9.10", sha256="aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f"
+        )
         version("2.9.9", sha256="94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871")
         version("2.9.8", sha256="0b74e51595654f958148759cfef0993114ddccccbb6f31aee018f3558e8e2732")
         version("2.9.4", sha256="ffb911191e509b966deb55de705387f14156e1a56b21824357cdf0053233633c")


### PR DESCRIPTION
This PR adds `libxml2`, v2.11.9, v2.12.9, v2.13.4. These fix, among others, CVE-2024-25062 and CVE-2024-40896 (that one is only mentioned in the release notes but not on NVD). Since the first CVE is rated high, older versions are deprecated. Since the fixes to 2.11 and 2.12 were released when the 2.13 release series was already available, I'm adding them in case a downstream package prefers them. Some changes to the [`configure.ac`](https://gitlab.gnome.org/GNOME/libxml2/-/compare/v2.10.4...v2.13.4?from_project_id=1665&page=2&straight=false#87db583be5c13c1f7b3c958b10e03d67b6a2ca06), but none that need addressing here.

Option change in defaults with 2.13 is in the [release notes](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.0): "Support for HTTP POST was removed. Support for zlib, liblzma and HTTP is now disabled by default." We already explicitly enable/disable for zlib and lzma, but no dedicated variant for http was added.

Test builds:
```
==> Installing libxml2-2.12.9-eup5brjtd3kumqrw5gl4sdmh2wgy3x3v [8/10]
==> No binary for libxml2-2.12.9-eup5brjtd3kumqrw5gl4sdmh2wgy3x3v found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/59/59912db536ab56a3996489ea0299768c7bcffe57169f0235e7f962a91f483590.tar.xz
==> Using cached archive: /opt/spack/cache/_source-cache/archive/96/96151685cec997e1f9f3387e3626d61e6284d4d6e66e0e440c209286c03e9cc7.tar.gz
==> Moving resource stage
        source: /opt/spack/stage/wdconinc/resource-xmlts-eup5brjtd3kumqrw5gl4sdmh2wgy3x3v/spack-src/
        destination: /opt/spack/stage/wdconinc/spack-stage-libxml2-2.12.9-eup5brjtd3kumqrw5gl4sdmh2wgy3x3v/spack-src/xmlconf
==> Ran patch() for libxml2
==> libxml2: Executing phase: 'autoreconf'
==> libxml2: Executing phase: 'configure'
==> libxml2: Executing phase: 'build'
==> libxml2: Executing phase: 'install'
==> libxml2: Successfully installed libxml2-2.12.9-eup5brjtd3kumqrw5gl4sdmh2wgy3x3v
  Stage: 0.66s.  Autoreconf: 0.00s.  Configure: 3.91s.  Build: 43.47s.  Install: 0.35s.  Post-install: 0.14s.  Total: 48.58s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libxml2-2.12.9-eup5brjtd3kumqrw5gl4sdmh2wgy3x3v
==> Installing libxml2-2.13.4-ofh62bf6pusjpl5poc6kd7tsgwspf645 [9/10]
==> No binary for libxml2-2.13.4-ofh62bf6pusjpl5poc6kd7tsgwspf645 found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/65/65d042e1c8010243e617efb02afda20b85c2160acdbfbcb5b26b80cec6515650.tar.xz
==> Using cached archive: /opt/spack/cache/_source-cache/archive/96/96151685cec997e1f9f3387e3626d61e6284d4d6e66e0e440c209286c03e9cc7.tar.gz
==> Moving resource stage
        source: /opt/spack/stage/wdconinc/resource-xmlts-ofh62bf6pusjpl5poc6kd7tsgwspf645/spack-src/
        destination: /opt/spack/stage/wdconinc/spack-stage-libxml2-2.13.4-ofh62bf6pusjpl5poc6kd7tsgwspf645/spack-src/xmlconf
==> Ran patch() for libxml2
==> libxml2: Executing phase: 'autoreconf'
==> libxml2: Executing phase: 'configure'
==> libxml2: Executing phase: 'build'
==> libxml2: Executing phase: 'install'
==> libxml2: Successfully installed libxml2-2.13.4-ofh62bf6pusjpl5poc6kd7tsgwspf645
  Stage: 0.77s.  Autoreconf: 0.00s.  Configure: 3.16s.  Build: 32.41s.  Install: 0.45s.  Post-install: 0.18s.  Total: 37.04s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libxml2-2.13.4-ofh62bf6pusjpl5poc6kd7tsgwspf645
==> Installing libxml2-2.11.9-turuxvzad4l3kkdfttt4sipkv7exkwwm [10/10]
==> No binary for libxml2-2.11.9-turuxvzad4l3kkdfttt4sipkv7exkwwm found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/78/780157a1efdb57188ec474dca87acaee67a3a839c2525b2214d318228451809f.tar.xz
==> Using cached archive: /opt/spack/cache/_source-cache/archive/96/96151685cec997e1f9f3387e3626d61e6284d4d6e66e0e440c209286c03e9cc7.tar.gz
==> Moving resource stage
        source: /opt/spack/stage/wdconinc/resource-xmlts-turuxvzad4l3kkdfttt4sipkv7exkwwm/spack-src/
        destination: /opt/spack/stage/wdconinc/spack-stage-libxml2-2.11.9-turuxvzad4l3kkdfttt4sipkv7exkwwm/spack-src/xmlconf
==> Ran patch() for libxml2
==> libxml2: Executing phase: 'autoreconf'
==> libxml2: Executing phase: 'configure'
==> libxml2: Executing phase: 'build'
==> libxml2: Executing phase: 'install'
==> libxml2: Successfully installed libxml2-2.11.9-turuxvzad4l3kkdfttt4sipkv7exkwwm
  Stage: 1.16s.  Autoreconf: 0.00s.  Configure: 4.39s.  Build: 52.99s.  Install: 0.53s.  Post-install: 0.18s.  Total: 59.52s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libxml2-2.11.9-turuxvzad4l3kkdfttt4sipkv7exkwwm
```