### PR TITLE
mcpp: add v2.7.2-25-g619046f with CVE patches

### DIFF
--- a/var/spack/repos/builtin/packages/mcpp/package.py
+++ b/var/spack/repos/builtin/packages/mcpp/package.py
@@ -12,11 +12,13 @@ class Mcpp(AutotoolsPackage, SourceforgePackage):
 
     homepage = "https://sourceforge.net/projects/mcpp/"
     sourceforge_mirror_path = "mcpp/mcpp/V.2.7.2/mcpp-2.7.2.tar.gz"
+    git = "https://github.com/jbrandwood/mcpp.git"
 
+    # Versions from `git describe --tags`
+    version("2.7.2-25-g619046f", commit="619046fa0debac3f86ff173098aeb59b8f051d19")
     version("2.7.2", sha256="3b9b4421888519876c4fc68ade324a3bbd81ceeb7092ecdbbc2055099fcb8864")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
 
     def configure_args(self):
         config_args = ["--enable-mcpplib", "--disable-static"]


### PR DESCRIPTION
This PR adds `mcpp`, v2.7.2-25-g619046f, which includes patches from debian and gentoo patches to fix CVE-2019-14274. No c++ code here, but lots of cpp in filenames since it's a preprocessor. Version numbering scheme to allow for future commits (unlikely since project appears unmaintained and patches are on a fork).

Test build:
```
==> Installing mcpp-2.7.2-25-g619046f-3ggu7dyfxx22ep5bxp5zpev5hvz5dwpd [4/4]
==> No binary for mcpp-2.7.2-25-g619046f-3ggu7dyfxx22ep5bxp5zpev5hvz5dwpd found: installing from source
==> No patches needed for mcpp
==> mcpp: Executing phase: 'autoreconf'
==> mcpp: Executing phase: 'configure'
==> mcpp: Executing phase: 'build'
==> mcpp: Executing phase: 'install'
==> mcpp: Successfully installed mcpp-2.7.2-25-g619046f-3ggu7dyfxx22ep5bxp5zpev5hvz5dwpd
  Stage: 4.62s.  Autoreconf: 0.00s.  Configure: 14.69s.  Build: 26.66s.  Install: 0.96s.  Post-install: 0.75s.  Total: 48.30s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/mcpp-2.7.2-25-g619046f-3ggu7dyfxx22ep5bxp5zpev5hvz5dwpd
```