### PR TITLE
Denote  default behavior for CLI options in `--help` output

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -82,15 +82,17 @@ def setup_parser(subparser):
         action="store_true",
         dest="prune_dag",
         default=True,
-        help="skip up-to-date specs\n\n"
-        "do not generate jobs for specs that are up-to-date on the mirror",
+        help="skip up-to-date specs\n"
+        "(Default behavior)\n\n"
+        "do not generate jobs for specs that are up-to-date on the mirror\n",
     )
     prune_group.add_argument(
         "--no-prune-dag",
         action="store_false",
         dest="prune_dag",
         default=True,
-        help="process up-to-date specs\n\n"
+        help="process up-to-date specs\n"
+        "(Default behavior)\n\n"
         "generate jobs for specs even when they are up-to-date on the mirror",
     )
     generate.add_argument(

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -388,6 +388,7 @@ def install_status():
             "show install status of packages\n"
             "[+] installed       [^] installed in an upstream\n"
             " -  not installed   [-] missing dep of installed package\n"
+            "(Default behavior)\n"
         ),
     )
 

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -400,7 +400,7 @@ def no_install_status():
         dest="install_status",
         action="store_false",
         default=True,
-        help="do not show install status annotations",
+        help="do not show install status annotations (Default behavior)",
     )
 
 

--- a/lib/spack/spack/cmd/dependencies.py
+++ b/lib/spack/spack/cmd/dependencies.py
@@ -42,8 +42,7 @@ def setup_parser(subparser):
         action="store_false",
         default=True,
         dest="expand_virtuals",
-        help="do not expand virtual dependencies"
-        "(Default behavior)\n",
+        help="do not expand virtual dependencies" "(Default behavior)\n",
     )
     arguments.add_common_arguments(subparser, ["spec"])
 

--- a/lib/spack/spack/cmd/dependencies.py
+++ b/lib/spack/spack/cmd/dependencies.py
@@ -42,7 +42,8 @@ def setup_parser(subparser):
         action="store_false",
         default=True,
         dest="expand_virtuals",
-        help="do not expand virtual dependencies",
+        help="do not expand virtual dependencies"
+        "(Default behavior)\n",
     )
     arguments.add_common_arguments(subparser, ["spec"])
 

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -54,7 +54,8 @@ def setup_parser(sp):
         action="store_false",
         default=True,
         dest="dependencies",
-        help="do not deprecate dependencies",
+        help="do not deprecate dependencies"
+        "(Default behavior)\n",
     )
 
     install = sp.add_mutually_exclusive_group()

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -54,8 +54,7 @@ def setup_parser(sp):
         action="store_false",
         default=True,
         dest="dependencies",
-        help="do not deprecate dependencies"
-        "(Default behavior)\n",
+        help="do not deprecate dependencies" "(Default behavior)\n",
     )
 
     install = sp.add_mutually_exclusive_group()

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -841,7 +841,8 @@ def env_depfile_setup_parser(subparser):
         default=True,
         action="store_false",
         dest="jobserver",
-        help="disable POSIX jobserver support",
+        help="disable POSIX jobserver support"
+        "(Default behavior)\n",
     )
     subparser.add_argument(
         "--use-buildcache",

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -841,8 +841,7 @@ def env_depfile_setup_parser(subparser):
         default=True,
         action="store_false",
         dest="jobserver",
-        help="disable POSIX jobserver support"
-        "(Default behavior)\n",
+        help="disable POSIX jobserver support" "(Default behavior)\n",
     )
     subparser.add_argument(
         "--use-buildcache",

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -75,7 +75,9 @@ def setup_parser(subparser):
     create.set_defaults(func=gpg_create)
 
     list = subparsers.add_parser("list", help=gpg_list.__doc__)
-    list.add_argument("--trusted", action="store_true", default=True, help="list trusted keys (default)")
+    list.add_argument(
+        "--trusted", action="store_true", default=True, help="list trusted keys (default)"
+    )
     list.add_argument(
         "--signing", action="store_true", help="list keys which may be used for signing"
     )

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -75,7 +75,7 @@ def setup_parser(subparser):
     create.set_defaults(func=gpg_create)
 
     list = subparsers.add_parser("list", help=gpg_list.__doc__)
-    list.add_argument("--trusted", action="store_true", default=True, help="list trusted keys")
+    list.add_argument("--trusted", action="store_true", default=True, help="list trusted keys (default)")
     list.add_argument(
         "--signing", action="store_true", help="list keys which may be used for signing"
     )

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -124,7 +124,7 @@ def setup_parser(subparser):
         action="store_false",
         dest="use_cache",
         default=True,
-        help="do not check for pre-built Spack packages in mirrors",
+        help="do not check for pre-built Spack packages in mirrors (default)",
     )
     cache_group.add_argument(
         "--cache-only",

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -158,7 +158,7 @@ def setup_parser(subparser):
         dest="untracked",
         action="store_false",
         default=True,
-        help="exclude untracked files from checks",
+        help="exclude untracked files from checks (default)",
     )
     subparser.add_argument(
         "-f",

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1345,7 +1345,7 @@ complete -c spack -n '__fish_spack_using_command dependencies' -s t -l transitiv
 complete -c spack -n '__fish_spack_using_command dependencies' -l deptype -r -f -a deptype
 complete -c spack -n '__fish_spack_using_command dependencies' -l deptype -r -d 'comma-separated list of deptypes to traverse (default=build,link,run,test)'
 complete -c spack -n '__fish_spack_using_command dependencies' -s V -l no-expand-virtuals -f -a expand_virtuals
-complete -c spack -n '__fish_spack_using_command dependencies' -s V -l no-expand-virtuals -d 'do not expand virtual dependencies'
+complete -c spack -n '__fish_spack_using_command dependencies' -s V -l no-expand-virtuals -d 'do not expand virtual dependencies(Default behavior)'
 
 # spack dependents
 set -g __fish_spack_optspecs_spack_dependents h/help i/installed t/transitive
@@ -1367,7 +1367,7 @@ complete -c spack -n '__fish_spack_using_command deprecate' -s y -l yes-to-all -
 complete -c spack -n '__fish_spack_using_command deprecate' -s d -l dependencies -f -a dependencies
 complete -c spack -n '__fish_spack_using_command deprecate' -s d -l dependencies -d 'deprecate dependencies (default)'
 complete -c spack -n '__fish_spack_using_command deprecate' -s D -l no-dependencies -f -a dependencies
-complete -c spack -n '__fish_spack_using_command deprecate' -s D -l no-dependencies -d 'do not deprecate dependencies'
+complete -c spack -n '__fish_spack_using_command deprecate' -s D -l no-dependencies -d 'do not deprecate dependencies(Default behavior)'
 complete -c spack -n '__fish_spack_using_command deprecate' -s i -l install-deprecator -f -a install
 complete -c spack -n '__fish_spack_using_command deprecate' -s i -l install-deprecator -d 'concretize and install deprecator spec'
 complete -c spack -n '__fish_spack_using_command deprecate' -s I -l no-install-deprecator -f -a install
@@ -1661,7 +1661,7 @@ complete -c spack -n '__fish_spack_using_command env depfile' -s h -l help -d 's
 complete -c spack -n '__fish_spack_using_command env depfile' -l make-prefix -l make-target-prefix -r -f -a make_prefix
 complete -c spack -n '__fish_spack_using_command env depfile' -l make-prefix -l make-target-prefix -r -d 'prefix Makefile targets/variables with <TARGET>/<name>,'
 complete -c spack -n '__fish_spack_using_command env depfile' -l make-disable-jobserver -f -a jobserver
-complete -c spack -n '__fish_spack_using_command env depfile' -l make-disable-jobserver -d 'disable POSIX jobserver support'
+complete -c spack -n '__fish_spack_using_command env depfile' -l make-disable-jobserver -d 'disable POSIX jobserver support(Default behavior)'
 complete -c spack -n '__fish_spack_using_command env depfile' -l use-buildcache -r -f -a use_buildcache
 complete -c spack -n '__fish_spack_using_command env depfile' -l use-buildcache -r -d 'use `only` to prune redundant build dependencies'
 complete -c spack -n '__fish_spack_using_command env depfile' -s o -l output -r -f -a output
@@ -1894,7 +1894,7 @@ set -g __fish_spack_optspecs_spack_gpg_list h/help trusted signing
 complete -c spack -n '__fish_spack_using_command gpg list' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command gpg list' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command gpg list' -l trusted -f -a trusted
-complete -c spack -n '__fish_spack_using_command gpg list' -l trusted -d 'list trusted keys'
+complete -c spack -n '__fish_spack_using_command gpg list' -l trusted -d 'list trusted keys (default)'
 complete -c spack -n '__fish_spack_using_command gpg list' -l signing -f -a signing
 complete -c spack -n '__fish_spack_using_command gpg list' -l signing -d 'list keys which may be used for signing'
 
@@ -2008,7 +2008,7 @@ complete -c spack -n '__fish_spack_using_command install' -l dont-restage -d 'if
 complete -c spack -n '__fish_spack_using_command install' -l use-cache -f -a use_cache
 complete -c spack -n '__fish_spack_using_command install' -l use-cache -d 'check for pre-built Spack packages in mirrors (default)'
 complete -c spack -n '__fish_spack_using_command install' -l no-cache -f -a use_cache
-complete -c spack -n '__fish_spack_using_command install' -l no-cache -d 'do not check for pre-built Spack packages in mirrors'
+complete -c spack -n '__fish_spack_using_command install' -l no-cache -d 'do not check for pre-built Spack packages in mirrors (default)'
 complete -c spack -n '__fish_spack_using_command install' -l cache-only -f -a cache_only
 complete -c spack -n '__fish_spack_using_command install' -l cache-only -d 'only install package from binary mirrors'
 complete -c spack -n '__fish_spack_using_command install' -l use-buildcache -r -f -a use_buildcache
@@ -2766,7 +2766,7 @@ complete -c spack -n '__fish_spack_using_command solve' -s N -l namespaces -d 's
 complete -c spack -n '__fish_spack_using_command solve' -s I -l install-status -f -a install_status
 complete -c spack -n '__fish_spack_using_command solve' -s I -l install-status -d 'show install status of packages'
 complete -c spack -n '__fish_spack_using_command solve' -l no-install-status -f -a install_status
-complete -c spack -n '__fish_spack_using_command solve' -l no-install-status -d 'do not show install status annotations'
+complete -c spack -n '__fish_spack_using_command solve' -l no-install-status -d 'do not show install status annotations (Default behavior)'
 complete -c spack -n '__fish_spack_using_command solve' -s y -l yaml -f -a format
 complete -c spack -n '__fish_spack_using_command solve' -s y -l yaml -d 'print concrete spec as YAML'
 complete -c spack -n '__fish_spack_using_command solve' -s j -l json -f -a format
@@ -2800,7 +2800,7 @@ complete -c spack -n '__fish_spack_using_command spec' -s N -l namespaces -d 'sh
 complete -c spack -n '__fish_spack_using_command spec' -s I -l install-status -f -a install_status
 complete -c spack -n '__fish_spack_using_command spec' -s I -l install-status -d 'show install status of packages'
 complete -c spack -n '__fish_spack_using_command spec' -l no-install-status -f -a install_status
-complete -c spack -n '__fish_spack_using_command spec' -l no-install-status -d 'do not show install status annotations'
+complete -c spack -n '__fish_spack_using_command spec' -l no-install-status -d 'do not show install status annotations (Default behavior)'
 complete -c spack -n '__fish_spack_using_command spec' -s y -l yaml -f -a format
 complete -c spack -n '__fish_spack_using_command spec' -s y -l yaml -d 'print concrete spec as YAML'
 complete -c spack -n '__fish_spack_using_command spec' -s j -l json -f -a format
@@ -2850,7 +2850,7 @@ complete -c spack -n '__fish_spack_using_command style' -s a -l all -d 'check al
 complete -c spack -n '__fish_spack_using_command style' -s r -l root-relative -f -a root_relative
 complete -c spack -n '__fish_spack_using_command style' -s r -l root-relative -d 'print root-relative paths (default: cwd-relative)'
 complete -c spack -n '__fish_spack_using_command style' -s U -l no-untracked -f -a untracked
-complete -c spack -n '__fish_spack_using_command style' -s U -l no-untracked -d 'exclude untracked files from checks'
+complete -c spack -n '__fish_spack_using_command style' -s U -l no-untracked -d 'exclude untracked files from checks (default)'
 complete -c spack -n '__fish_spack_using_command style' -s f -l fix -f -a fix
 complete -c spack -n '__fish_spack_using_command style' -s f -l fix -d 'format automatically if possible (e.g., with isort, black)'
 complete -c spack -n '__fish_spack_using_command style' -l root -r -f -a root


### PR DESCRIPTION
Adds docstrings indicating if a given CLI opt is on by default for each default CLI option.