### PR TITLE
minio: add v2024-10-13T13-34-11Z (fix CVEs)

### DIFF
--- a/var/spack/repos/builtin/packages/minio/package.py
+++ b/var/spack/repos/builtin/packages/minio/package.py
@@ -18,17 +18,23 @@ class Minio(MakefilePackage):
     license("AGPL-3.0-or-later")
 
     version(
-        "2020-07-13T18-09-56Z",
-        sha256="147fca3930389162cc7306a0fa5cf478ee2deba4b31a9317f3d35e82aa58d41e",
+        "2024-10-13T13-34-11Z",
+        sha256="53301a6822f8466da88e3b24252d2551c37e7f96e9d37a36121d0616a69af1dd",
     )
-    version(
-        "2020-07-12T19-14-17Z",
-        sha256="bb8ba5d93215ab37788171d8b9ce68e78d64e7b7c74aea508c15958158d85b03",
-    )
-    version(
-        "2020-07-02T00-15-09Z",
-        sha256="4255c4d95a3e010f16a3f1e974768dc68509075403a97a9b9882f7d9e89fedc5",
-    )
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2024-24747
+        version(
+            "2020-07-13T18-09-56Z",
+            sha256="147fca3930389162cc7306a0fa5cf478ee2deba4b31a9317f3d35e82aa58d41e",
+        )
+        version(
+            "2020-07-12T19-14-17Z",
+            sha256="bb8ba5d93215ab37788171d8b9ce68e78d64e7b7c74aea508c15958158d85b03",
+        )
+        version(
+            "2020-07-02T00-15-09Z",
+            sha256="4255c4d95a3e010f16a3f1e974768dc68509075403a97a9b9882f7d9e89fedc5",
+        )
 
     depends_on("go", type="build")
 


### PR DESCRIPTION
This PR adds `minio`, v2024-10-13T13-34-11Z. This fixes a number of CVEs in minio since 2020, CVE-2020-11012, CVE-2021-21287, CVE-2021-21362, CVE-2021-21390, CVE-2021-41137, CVE-2021-43858, CVE-2022-24842, CVE-2022-31028, CVE-2022-35919, CVE-2023-25812, CVE-2023-27589, CVE-2023-28432, CVE-2023-28433, CVE-2023-28434, CVE-2024-24747. Several of these are of high severity, so older versions are marked as deprecated.

Test build:
```
==> Installing minio-2024-10-13T13-34-11Z-yxsrrqlfzoinq2btwtyfdan7swxncsnq [5/5]
==> No binary for minio-2024-10-13T13-34-11Z-yxsrrqlfzoinq2btwtyfdan7swxncsnq found: installing from source
==> Fetching https://github.com/minio/minio/archive/RELEASE.2024-10-13T13-34-11Z.tar.gz
==> No patches needed for minio
==> minio: Executing phase: 'edit'
==> minio: Executing phase: 'build'
==> minio: Executing phase: 'install'
==> minio: Successfully installed minio-2024-10-13T13-34-11Z-yxsrrqlfzoinq2btwtyfdan7swxncsnq
  Stage: 3.29s.  Edit: 0.00s.  Build: 3m 25.21s.  Install: 0.07s.  Post-install: 10.23s.  Total: 3m 39.04s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/minio-2024-10-13T13-34-11Z-yxsrrqlfzoinq2btwtyfdan7swxncsnq
```

Test run:
```
11:46:53 wdconinc@menelaos /opt/spack/stage/wdconinc $ minio server . 
MinIO Object Storage Server
Copyright: 2015-2024 MinIO, Inc.
License: GNU AGPLv3 - https://www.gnu.org/licenses/agpl-3.0.html
Version: DEVELOPMENT.GOGET (go1.23.1 linux/amd64)

API: http://130.179.72.171:9000  http://127.0.0.1:9000 
   RootUser: minioadmin 
   RootPass: minioadmin 

WebUI: http://130.179.72.171:33573 http://127.0.0.1:33573   
   RootUser: minioadmin 
   RootPass: minioadmin 

CLI: https://min.io/docs/minio/linux/reference/minio-mc.html#quickstart
   $ mc alias set 'myminio' 'http://130.179.72.171:9000' 'minioadmin' 'minioadmin'

Docs: https://docs.min.io
WARN: Detected default credentials 'minioadmin:minioadmin', we recommend that you change these values with 'MINIO_ROOT_USER' and 'MINIO_ROOT_PASSWORD' environment variables
```