### PR TITLE
Fix errors found by running `spack audit externals`

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/gcc/detection_test.yaml
@@ -26,7 +26,7 @@ paths:
     extra_attributes:
       compilers:
         c: ".*/bin/gcc"
-        cxx: ".*/bin/g++"
+        cxx: ".*/bin/g\\+\\+"
 
 # Mock a version < 7 of GCC that requires -dumpversion and
 # errors with -dumpfullversion

--- a/var/spack/repos/builtin/packages/nvhpc/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/nvhpc/detection_test.yaml
@@ -24,7 +24,7 @@ paths:
     extra_attributes:
       compilers:
         c: ".*/bin/nvc"
-        cxx: ".*/bin/nvc++"
+        cxx: ".*/bin/nvc\\+\\+"
         fortran: ".*/bin/nvfortran"
 - layout:
   - executables:
@@ -51,7 +51,7 @@ paths:
     extra_attributes:
       compilers:
         c: ".*/bin/nvc"
-        cxx: ".*/bin/nvc++"
+        cxx: ".*/bin/nvc\\+\\+"
         fortran: ".*/bin/nvfortran"
 - layout:
   - executables:
@@ -78,5 +78,5 @@ paths:
     extra_attributes:
       compilers:
         c: ".*/bin/nvc"
-        cxx: ".*/bin/nvc++"
+        cxx: ".*/bin/nvc\\+\\+"
         fortran: ".*/bin/nvfortran"


### PR DESCRIPTION
I got the following errors when I ran the command with my cluster's Spack installation:

```console
$ spack audit externals
PKG-EXTERNALS: 4 issues found
1. builtin.gcc: illegal regex in "gcc@9.4.0 languages='c,c++'" extra attributes
    .*/bin/g++ is not a valid regex
2. builtin.nvhpc: illegal regex in "nvhpc@20.9~blas~lapack~mpi" extra attributes
    .*/bin/nvc++ is not a valid regex
3. builtin.nvhpc: illegal regex in "nvhpc@20.9~blas~lapack~mpi" extra attributes
    .*/bin/nvc++ is not a valid regex
4. builtin.nvhpc: illegal regex in "nvhpc@20.9~blas~lapack~mpi" extra attributes
    .*/bin/nvc++ is not a valid regex
```

The problem was that `+` is part of the regex grammar, so it needs to be escaped. I'm not sure why this isn't detected as part of global testing, but it should still be fixed.

I'm not a fan of needing to write `".*/bin/g\\+\\+"` instead of `'.*/bin/g\+\+'`, but neither of the YAML files I modified use single-quoted strings at all, so I kept using double-quoted strings for consistency.