### PR TITLE
blast-plus: adding py-setuptools dep

### DIFF
--- a/var/spack/repos/builtin/packages/blast-plus/package.py
+++ b/var/spack/repos/builtin/packages/blast-plus/package.py
@@ -80,6 +80,7 @@ class BlastPlus(AutotoolsPackage):
     depends_on("pcre", when="+pcre")
 
     depends_on("python", when="+python")
+    depends_on("py-setuptools@48:", when="+python ^python@3.12:", type="build")
     depends_on("perl", when="+perl")
 
     depends_on("lmdb", when="@2.7.1:")


### PR DESCRIPTION
distutils was removed in python@3.12. 
