### PR TITLE
rocal and rocm-openmp-extras: fix build failures

### DIFF
--- a/var/spack/repos/builtin/packages/mivisionx/package.py
+++ b/var/spack/repos/builtin/packages/mivisionx/package.py
@@ -15,7 +15,7 @@ class Mivisionx(CMakePackage):
     git = "https://github.com/GPUOpen-ProfessionalCompute-Libraries/MIVisionX.git"
     url = "https://github.com/GPUOpen-ProfessionalCompute-Libraries/MIVisionX/archive/rocm-6.1.2.tar.gz"
 
-    maintainers("srekolam", "renjithravindrankannath")
+    maintainers("srekolam", "renjithravindrankannath", "afzpatel")
     tags = ["rocm"]
 
     def url_for_version(self, version):
@@ -211,7 +211,7 @@ class Mivisionx(CMakePackage):
         when="@5.3:",
     )
     depends_on("openssl")
-    depends_on("libjpeg-turbo@2.0.6+partial_decoder", type="build")
+    depends_on("libjpeg-turbo@2.0.6+partial_decoder", type="build", when="@:6.2.0")
     depends_on("rpp@1.2.0", when="@5.5:5.6")
     depends_on("lmdb", when="@5.5:")
     depends_on("py-setuptools", when="@5.6:")

--- a/var/spack/repos/builtin/packages/rocal/package.py
+++ b/var/spack/repos/builtin/packages/rocal/package.py
@@ -20,7 +20,8 @@ class Rocal(CMakePackage):
     version("6.2.1", sha256="77d3e63e02afaee6f1ee1d877d88b48c6ea66a0afca96a1313d0f1c4f8e86b2a")
     version("6.2.0", sha256="c7c265375a40d4478a628258378726c252caac424f974456d488fce43890e157")
 
-    depends_on("libjpeg-turbo@2.0.6+partial_decoder")
+    depends_on("libjpeg-turbo@2.0.6+partial_decoder", when="@6.2.0")
+    depends_on("libjpeg-turbo@3.0.2:", when="@6.2.1:")
     depends_on("rapidjson")
     depends_on("ffmpeg@4.4:")
 

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -155,7 +155,7 @@ class RocmOpenmpExtras(Package):
 
     license("Apache-2.0")
 
-    maintainers("srekolam", "renjithravindrankannath", "estewart08")
+    maintainers("srekolam", "renjithravindrankannath", "estewart08", "afzpatel")
     version("6.2.1", sha256=versions_dict["6.2.1"]["aomp"])
     version("6.2.0", sha256=versions_dict["6.2.0"]["aomp"])
     version("6.1.2", sha256=versions_dict["6.1.2"]["aomp"])
@@ -189,6 +189,7 @@ class RocmOpenmpExtras(Package):
     depends_on("libffi", type=("build", "link"))
     depends_on("libdrm", when="@5.7:6.0")
     depends_on("numactl", when="@5.7:6.0")
+    depends_on("zlib", when="@6.2:")
 
     for ver in [
         "5.5.0",
@@ -489,6 +490,7 @@ class RocmOpenmpExtras(Package):
         ffi_inc = spec["libffi"].prefix.include
         if self.spec.satisfies("@6.2:"):
             ncurses_lib_dir = self.spec["ncurses"].prefix.lib
+            zlib_lib_dir = self.spec["zlib"].prefix.lib
 
         # flang1 and flang2 symlink needed for build of flang-runtime
         # libdevice symlink to rocm-openmp-extras for runtime
@@ -638,11 +640,12 @@ class RocmOpenmpExtras(Package):
             flang_legacy_flags.append("-D_GLIBCXX_USE_CXX11_ABI=0")
         if self.spec.satisfies("@6.2:"):
             flang_legacy_flags.append("-L{0}".format(ncurses_lib_dir))
+            flang_legacy_flags.append("-L{0}".format(zlib_lib_dir))
         components["flang-legacy-llvm"] += [
-            "-DCMAKE_CXX_FLAGS={0}".format(",".join(flang_legacy_flags))
+            "-DCMAKE_CXX_FLAGS={0}".format(" ".join(flang_legacy_flags))
         ]
         components["flang-legacy"] += [
-            "-DCMAKE_CXX_FLAGS={0}".format(",".join(flang_legacy_flags))
+            "-DCMAKE_CXX_FLAGS={0}".format(" ".join(flang_legacy_flags))
         ]
 
         components["flang"] = [


### PR DESCRIPTION
**rocm-openmp-extras:** The following error is seen when building flang-legacy:
`ld.lld: error: unable to find library -lz
`
Added zlib lib path in the CMAKE_CXX_FLAGS and now the build is succesful

**rocal:**  The following error is seen when building rocal@6.2.1:
`error: 'tj3GetScalingFactors' was not declared in this scope;`
The build was succesful after updating libjpeg-turbo dependency
