### PR TITLE
Rework `spack.database.InstallStatuses` into a flag

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -252,7 +252,7 @@ class BinaryCacheIndex:
 
             spec_list = [
                 s
-                for s in db.query_local(installed=any)
+                for s in db.query_local(installed=spack_db.ANY_STATUS)
                 if s.external or db.query_local_by_spec_hash(s.dag_hash()).in_buildcache
             ]
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -87,6 +87,8 @@ from spack.spec import Spec
 from spack.stage import Stage
 from spack.util.executable import which
 
+from .enums import ANY_STATUS
+
 BUILD_CACHE_RELATIVE_PATH = "build_cache"
 BUILD_CACHE_KEYS_RELATIVE_PATH = "_pgp"
 
@@ -252,7 +254,7 @@ class BinaryCacheIndex:
 
             spec_list = [
                 s
-                for s in db.query_local(installed=spack_db.ANY_STATUS)
+                for s in db.query_local(installed=ANY_STATUS)
                 if s.external or db.query_local_by_spec_hash(s.dag_hash()).in_buildcache
             ]
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -87,7 +87,7 @@ from spack.spec import Spec
 from spack.stage import Stage
 from spack.util.executable import which
 
-from .enums import ANY_STATUS
+from .enums import InstallRecordStatus
 
 BUILD_CACHE_RELATIVE_PATH = "build_cache"
 BUILD_CACHE_KEYS_RELATIVE_PATH = "_pgp"
@@ -254,7 +254,7 @@ class BinaryCacheIndex:
 
             spec_list = [
                 s
-                for s in db.query_local(installed=ANY_STATUS)
+                for s in db.query_local(installed=InstallRecordStatus.ANY)
                 if s.external or db.query_local_by_spec_hash(s.dag_hash()).in_buildcache
             ]
 

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -33,7 +33,7 @@ import spack.user_environment as uenv
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 
-from ..enums import DBStatus
+from ..enums import InstallRecordStatus
 
 # cmd has a submodule called "list" so preserve the python list module
 python_list = list
@@ -273,7 +273,7 @@ def disambiguate_spec(
     spec: "spack.spec.Spec",
     env: Optional["ev.Environment"],
     local: bool = False,
-    installed: Union[bool, DBStatus] = True,
+    installed: Union[bool, InstallRecordStatus] = True,
     first: bool = False,
 ) -> "spack.spec.Spec":
     """Given a spec, figure out which installed package it refers to.
@@ -293,7 +293,7 @@ def disambiguate_spec_from_hashes(
     spec: "spack.spec.Spec",
     hashes: List[str],
     local: bool = False,
-    installed: Union[bool, DBStatus] = True,
+    installed: Union[bool, InstallRecordStatus] = True,
     first: bool = False,
 ) -> "spack.spec.Spec":
     """Given a spec and a list of hashes, get concrete spec the spec refers to.

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -33,7 +33,7 @@ import spack.user_environment as uenv
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 
-from ..enums import DBStatusQuery
+from ..enums import DBStatus
 
 # cmd has a submodule called "list" so preserve the python list module
 python_list = list
@@ -273,7 +273,7 @@ def disambiguate_spec(
     spec: "spack.spec.Spec",
     env: Optional["ev.Environment"],
     local: bool = False,
-    installed: Union[bool, DBStatusQuery] = True,
+    installed: Union[bool, DBStatus] = True,
     first: bool = False,
 ) -> "spack.spec.Spec":
     """Given a spec, figure out which installed package it refers to.
@@ -293,7 +293,7 @@ def disambiguate_spec_from_hashes(
     spec: "spack.spec.Spec",
     hashes: List[str],
     local: bool = False,
-    installed: Union[bool, DBStatusQuery] = True,
+    installed: Union[bool, DBStatus] = True,
     first: bool = False,
 ) -> "spack.spec.Spec":
     """Given a spec and a list of hashes, get concrete spec the spec refers to.

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -9,7 +9,7 @@ import os
 import re
 import sys
 from collections import Counter
-from typing import List, Union
+from typing import List, Optional, Union
 
 import llnl.string
 import llnl.util.tty as tty
@@ -32,6 +32,7 @@ import spack.traverse as traverse
 import spack.user_environment as uenv
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
+from spack.database import StatusQuery
 
 # cmd has a submodule called "list" so preserve the python list module
 python_list = list
@@ -267,39 +268,48 @@ def matching_specs_from_env(specs):
     return _concretize_spec_pairs(spec_pairs + additional_concrete_specs)[: len(spec_pairs)]
 
 
-def disambiguate_spec(spec, env, local=False, installed=True, first=False):
+def disambiguate_spec(
+    spec: "spack.spec.Spec",
+    env: Optional["ev.Environment"],
+    local: bool = False,
+    installed: Union[bool, StatusQuery] = True,
+    first: bool = False,
+) -> "spack.spec.Spec":
     """Given a spec, figure out which installed package it refers to.
 
-    Arguments:
-        spec (spack.spec.Spec): a spec to disambiguate
-        env (spack.environment.Environment): a spack environment,
-            if one is active, or None if no environment is active
-        local (bool): do not search chained spack instances
-        installed (bool or spack.database.InstallStatus or typing.Iterable):
-            install status argument passed to database query.
-            See ``spack.database.Database._query`` for details.
+    Args:
+        spec: a spec to disambiguate
+        env: a spack environment, if one is active, or None if no environment is active
+        local: do not search chained spack instances
+        installed: install status argument passed to database query.
+        first: returns the first matching spec, even if more than one match is found
     """
     hashes = env.all_hashes() if env else None
     return disambiguate_spec_from_hashes(spec, hashes, local, installed, first)
 
 
-def disambiguate_spec_from_hashes(spec, hashes, local=False, installed=True, first=False):
+def disambiguate_spec_from_hashes(
+    spec: "spack.spec.Spec",
+    hashes: List[str],
+    local: bool = False,
+    installed: Union[bool, StatusQuery] = True,
+    first: bool = False,
+) -> "spack.spec.Spec":
     """Given a spec and a list of hashes, get concrete spec the spec refers to.
 
     Arguments:
-        spec (spack.spec.Spec): a spec to disambiguate
-        hashes (typing.Iterable): a set of hashes of specs among which to disambiguate
-        local (bool): do not search chained spack instances
-        installed (bool or spack.database.InstallStatus or typing.Iterable):
-            install status argument passed to database query.
-            See ``spack.database.Database._query`` for details.
+        spec: a spec to disambiguate
+        hashes: a set of hashes of specs among which to disambiguate
+        local: if True, do not search chained spack instances
+        installed: install status argument passed to database query.
+        first: returns the first matching spec, even if more than one match is found
     """
     if local:
         matching_specs = spack.store.STORE.db.query_local(spec, hashes=hashes, installed=installed)
     else:
         matching_specs = spack.store.STORE.db.query(spec, hashes=hashes, installed=installed)
     if not matching_specs:
-        tty.die("Spec '%s' matches no installed packages." % spec)
+        tty.die(f"Spec '{spec}' matches no installed packages.")
 
     elif first:
         return matching_specs[0]

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -271,7 +271,7 @@ def matching_specs_from_env(specs):
 
 def disambiguate_spec(
     spec: spack.spec.Spec,
-    env: Optional["ev.Environment"],
+    env: Optional[ev.Environment],
     local: bool = False,
     installed: Union[bool, InstallRecordStatus] = True,
     first: bool = False,

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -270,12 +270,12 @@ def matching_specs_from_env(specs):
 
 
 def disambiguate_spec(
-    spec: "spack.spec.Spec",
+    spec: spack.spec.Spec,
     env: Optional["ev.Environment"],
     local: bool = False,
     installed: Union[bool, InstallRecordStatus] = True,
     first: bool = False,
-) -> "spack.spec.Spec":
+) -> spack.spec.Spec:
     """Given a spec, figure out which installed package it refers to.
 
     Args:
@@ -290,12 +290,12 @@ def disambiguate_spec(
 
 
 def disambiguate_spec_from_hashes(
-    spec: "spack.spec.Spec",
+    spec: spack.spec.Spec,
     hashes: List[str],
     local: bool = False,
     installed: Union[bool, InstallRecordStatus] = True,
     first: bool = False,
-) -> "spack.spec.Spec":
+) -> spack.spec.Spec:
     """Given a spec and a list of hashes, get concrete spec the spec refers to.
 
     Arguments:

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -32,7 +32,8 @@ import spack.traverse as traverse
 import spack.user_environment as uenv
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
-from spack.database import StatusQuery
+
+from ..enums import DBStatusQuery
 
 # cmd has a submodule called "list" so preserve the python list module
 python_list = list
@@ -272,7 +273,7 @@ def disambiguate_spec(
     spec: "spack.spec.Spec",
     env: Optional["ev.Environment"],
     local: bool = False,
-    installed: Union[bool, StatusQuery] = True,
+    installed: Union[bool, DBStatusQuery] = True,
     first: bool = False,
 ) -> "spack.spec.Spec":
     """Given a spec, figure out which installed package it refers to.
@@ -292,7 +293,7 @@ def disambiguate_spec_from_hashes(
     spec: "spack.spec.Spec",
     hashes: List[str],
     local: bool = False,
-    installed: Union[bool, StatusQuery] = True,
+    installed: Union[bool, DBStatusQuery] = True,
     first: bool = False,
 ) -> "spack.spec.Spec":
     """Given a spec and a list of hashes, get concrete spec the spec refers to.

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -32,8 +32,9 @@ import spack.util.web as web_util
 from spack import traverse
 from spack.cmd import display_specs
 from spack.cmd.common import arguments
-from spack.database import ANY_STATUS
 from spack.spec import Spec, save_dependency_specfiles
+
+from ..enums import ANY_STATUS
 
 description = "create, download and install binary packages"
 section = "packaging"

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -34,7 +34,7 @@ from spack.cmd import display_specs
 from spack.cmd.common import arguments
 from spack.spec import Spec, save_dependency_specfiles
 
-from ..enums import ANY_STATUS
+from ..enums import InstallRecordStatus
 
 description = "create, download and install binary packages"
 section = "packaging"
@@ -311,7 +311,7 @@ def setup_parser(subparser: argparse.ArgumentParser):
 def _matching_specs(specs: List[Spec]) -> List[Spec]:
     """Disambiguate specs and return a list of matching specs"""
     return [
-        spack.cmd.disambiguate_spec(s, ev.active_environment(), installed=ANY_STATUS)
+        spack.cmd.disambiguate_spec(s, ev.active_environment(), installed=InstallRecordStatus.ANY)
         for s in specs
     ]
 

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -32,6 +32,7 @@ import spack.util.web as web_util
 from spack import traverse
 from spack.cmd import display_specs
 from spack.cmd.common import arguments
+from spack.database import ANY_STATUS
 from spack.spec import Spec, save_dependency_specfiles
 
 description = "create, download and install binary packages"
@@ -308,7 +309,10 @@ def setup_parser(subparser: argparse.ArgumentParser):
 
 def _matching_specs(specs: List[Spec]) -> List[Spec]:
     """Disambiguate specs and return a list of matching specs"""
-    return [spack.cmd.disambiguate_spec(s, ev.active_environment(), installed=any) for s in specs]
+    return [
+        spack.cmd.disambiguate_spec(s, ev.active_environment(), installed=ANY_STATUS)
+        for s in specs
+    ]
 
 
 def _format_spec(spec: Spec) -> str:

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -25,7 +25,7 @@ import spack.store
 from spack.cmd.common import arguments
 from spack.error import SpackError
 
-from ..enums import DBStatus
+from ..enums import InstallRecordStatus
 
 description = "replace one package with another via symlinks"
 section = "admin"
@@ -97,7 +97,10 @@ def deprecate(parser, args):
         raise SpackError("spack deprecate requires exactly two specs")
 
     deprecate = spack.cmd.disambiguate_spec(
-        specs[0], env, local=True, installed=(DBStatus.INSTALLED | DBStatus.DEPRECATED)
+        specs[0],
+        env,
+        local=True,
+        installed=(InstallRecordStatus.INSTALLED | InstallRecordStatus.DEPRECATED),
     )
 
     if args.install:

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -25,7 +25,7 @@ import spack.store
 from spack.cmd.common import arguments
 from spack.error import SpackError
 
-from ..enums import DBStatusQuery
+from ..enums import DBStatus
 
 description = "replace one package with another via symlinks"
 section = "admin"
@@ -97,7 +97,7 @@ def deprecate(parser, args):
         raise SpackError("spack deprecate requires exactly two specs")
 
     deprecate = spack.cmd.disambiguate_spec(
-        specs[0], env, local=True, installed=(DBStatusQuery.INSTALLED | DBStatusQuery.DEPRECATED)
+        specs[0], env, local=True, installed=(DBStatus.INSTALLED | DBStatus.DEPRECATED)
     )
 
     if args.install:

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -23,8 +23,9 @@ import spack.environment as ev
 import spack.installer
 import spack.store
 from spack.cmd.common import arguments
-from spack.database import StatusQuery
 from spack.error import SpackError
+
+from ..enums import DBStatusQuery
 
 description = "replace one package with another via symlinks"
 section = "admin"
@@ -96,7 +97,7 @@ def deprecate(parser, args):
         raise SpackError("spack deprecate requires exactly two specs")
 
     deprecate = spack.cmd.disambiguate_spec(
-        specs[0], env, local=True, installed=(StatusQuery.INSTALLED | StatusQuery.DEPRECATED)
+        specs[0], env, local=True, installed=(DBStatusQuery.INSTALLED | DBStatusQuery.DEPRECATED)
     )
 
     if args.install:

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -23,7 +23,7 @@ import spack.environment as ev
 import spack.installer
 import spack.store
 from spack.cmd.common import arguments
-from spack.database import InstallStatuses
+from spack.database import StatusQuery
 from spack.error import SpackError
 
 description = "replace one package with another via symlinks"
@@ -95,8 +95,9 @@ def deprecate(parser, args):
     if len(specs) != 2:
         raise SpackError("spack deprecate requires exactly two specs")
 
-    install_query = [InstallStatuses.INSTALLED, InstallStatuses.DEPRECATED]
-    deprecate = spack.cmd.disambiguate_spec(specs[0], env, local=True, installed=install_query)
+    deprecate = spack.cmd.disambiguate_spec(
+        specs[0], env, local=True, installed=(StatusQuery.INSTALLED | StatusQuery.DEPRECATED)
+    )
 
     if args.install:
         deprecator = specs[1].concretized()

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -166,11 +166,11 @@ def setup_parser(subparser):
 
 
 def query_arguments(args):
-    if args.only_missing and args.deprecated:
-        raise RuntimeError("cannot use --only-missing with --deprecated")
+    if args.only_missing and (args.deprecated or args.missing):
+        raise RuntimeError("cannot use --only-missing with --deprecated, or --missing")
 
-    if args.only_deprecated and args.missing:
-        raise RuntimeError("cannot use --only-deprecated with --missing")
+    if args.only_deprecated and (args.deprecated or args.missing):
+        raise RuntimeError("cannot use --only-deprecated with --deprecated, or --missing")
 
     installed = StatusQuery.INSTALLED
     if args.only_missing:

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -17,7 +17,7 @@ import spack.repo
 import spack.spec
 import spack.store
 from spack.cmd.common import arguments
-from spack.database import InstallStatuses
+from spack.database import StatusQuery
 
 description = "list and search installed packages"
 section = "basic"
@@ -137,20 +137,21 @@ def setup_parser(subparser):
     subparser.add_argument(
         "--loaded", action="store_true", help="show only packages loaded in the user environment"
     )
-    subparser.add_argument(
+    only_missing_or_deprecated = subparser.add_mutually_exclusive_group()
+    only_missing_or_deprecated.add_argument(
         "-M",
         "--only-missing",
         action="store_true",
         dest="only_missing",
         help="show only missing dependencies",
     )
+    only_missing_or_deprecated.add_argument(
+        "--only-deprecated", action="store_true", help="show only deprecated packages"
+    )
     subparser.add_argument(
         "--deprecated",
         action="store_true",
         help="show deprecated packages as well as installed specs",
-    )
-    subparser.add_argument(
-        "--only-deprecated", action="store_true", help="show only deprecated packages"
     )
     subparser.add_argument(
         "--install-tree",
@@ -165,14 +166,23 @@ def setup_parser(subparser):
 
 
 def query_arguments(args):
-    # Set up query arguments.
-    installed = []
-    if not (args.only_missing or args.only_deprecated):
-        installed.append(InstallStatuses.INSTALLED)
-    if (args.deprecated or args.only_deprecated) and not args.only_missing:
-        installed.append(InstallStatuses.DEPRECATED)
-    if (args.missing or args.only_missing) and not args.only_deprecated:
-        installed.append(InstallStatuses.MISSING)
+    if args.only_missing and args.deprecated:
+        raise RuntimeError("cannot use --only-missing with --deprecated")
+
+    if args.only_deprecated and args.missing:
+        raise RuntimeError("cannot use --only-deprecated with --missing")
+
+    installed = StatusQuery.INSTALLED
+    if args.only_missing:
+        installed = StatusQuery.MISSING
+    elif args.only_deprecated:
+        installed = StatusQuery.DEPRECATED
+
+    if args.missing:
+        installed |= StatusQuery.MISSING
+
+    if args.deprecated:
+        installed |= StatusQuery.DEPRECATED
 
     predicate_fn = None
     if args.unknown:

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -17,7 +17,8 @@ import spack.repo
 import spack.spec
 import spack.store
 from spack.cmd.common import arguments
-from spack.database import StatusQuery
+
+from ..enums import DBStatusQuery
 
 description = "list and search installed packages"
 section = "basic"
@@ -172,17 +173,17 @@ def query_arguments(args):
     if args.only_deprecated and (args.deprecated or args.missing):
         raise RuntimeError("cannot use --only-deprecated with --deprecated, or --missing")
 
-    installed = StatusQuery.INSTALLED
+    installed = DBStatusQuery.INSTALLED
     if args.only_missing:
-        installed = StatusQuery.MISSING
+        installed = DBStatusQuery.MISSING
     elif args.only_deprecated:
-        installed = StatusQuery.DEPRECATED
+        installed = DBStatusQuery.DEPRECATED
 
     if args.missing:
-        installed |= StatusQuery.MISSING
+        installed |= DBStatusQuery.MISSING
 
     if args.deprecated:
-        installed |= StatusQuery.DEPRECATED
+        installed |= DBStatusQuery.DEPRECATED
 
     predicate_fn = None
     if args.unknown:

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -18,7 +18,7 @@ import spack.spec
 import spack.store
 from spack.cmd.common import arguments
 
-from ..enums import DBStatusQuery
+from ..enums import DBStatus
 
 description = "list and search installed packages"
 section = "basic"
@@ -173,17 +173,17 @@ def query_arguments(args):
     if args.only_deprecated and (args.deprecated or args.missing):
         raise RuntimeError("cannot use --only-deprecated with --deprecated, or --missing")
 
-    installed = DBStatusQuery.INSTALLED
+    installed = DBStatus.INSTALLED
     if args.only_missing:
-        installed = DBStatusQuery.MISSING
+        installed = DBStatus.MISSING
     elif args.only_deprecated:
-        installed = DBStatusQuery.DEPRECATED
+        installed = DBStatus.DEPRECATED
 
     if args.missing:
-        installed |= DBStatusQuery.MISSING
+        installed |= DBStatus.MISSING
 
     if args.deprecated:
-        installed |= DBStatusQuery.DEPRECATED
+        installed |= DBStatus.DEPRECATED
 
     predicate_fn = None
     if args.unknown:

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -18,7 +18,7 @@ import spack.spec
 import spack.store
 from spack.cmd.common import arguments
 
-from ..enums import DBStatus
+from ..enums import InstallRecordStatus
 
 description = "list and search installed packages"
 section = "basic"
@@ -173,17 +173,17 @@ def query_arguments(args):
     if args.only_deprecated and (args.deprecated or args.missing):
         raise RuntimeError("cannot use --only-deprecated with --deprecated, or --missing")
 
-    installed = DBStatus.INSTALLED
+    installed = InstallRecordStatus.INSTALLED
     if args.only_missing:
-        installed = DBStatus.MISSING
+        installed = InstallRecordStatus.MISSING
     elif args.only_deprecated:
-        installed = DBStatus.DEPRECATED
+        installed = InstallRecordStatus.DEPRECATED
 
     if args.missing:
-        installed |= DBStatus.MISSING
+        installed |= InstallRecordStatus.MISSING
 
     if args.deprecated:
-        installed |= DBStatus.DEPRECATED
+        installed |= InstallRecordStatus.DEPRECATED
 
     predicate_fn = None
     if args.unknown:

--- a/lib/spack/spack/cmd/mark.py
+++ b/lib/spack/spack/cmd/mark.py
@@ -10,7 +10,8 @@ from llnl.util import tty
 import spack.cmd
 import spack.store
 from spack.cmd.common import arguments
-from spack.database import StatusQuery
+
+from ..enums import DBStatusQuery
 
 description = "mark packages as explicitly or implicitly installed"
 section = "admin"
@@ -67,7 +68,7 @@ def find_matching_specs(specs, allow_multiple_matches=False):
     has_errors = False
 
     for spec in specs:
-        matching = spack.store.STORE.db.query_local(spec, installed=StatusQuery.INSTALLED)
+        matching = spack.store.STORE.db.query_local(spec, installed=DBStatusQuery.INSTALLED)
         # For each spec provided, make sure it refers to only one package.
         # Fail and ask user to be unambiguous if it doesn't
         if not allow_multiple_matches and len(matching) > 1:

--- a/lib/spack/spack/cmd/mark.py
+++ b/lib/spack/spack/cmd/mark.py
@@ -11,7 +11,7 @@ import spack.cmd
 import spack.store
 from spack.cmd.common import arguments
 
-from ..enums import DBStatus
+from ..enums import InstallRecordStatus
 
 description = "mark packages as explicitly or implicitly installed"
 section = "admin"
@@ -68,7 +68,7 @@ def find_matching_specs(specs, allow_multiple_matches=False):
     has_errors = False
 
     for spec in specs:
-        matching = spack.store.STORE.db.query_local(spec, installed=DBStatus.INSTALLED)
+        matching = spack.store.STORE.db.query_local(spec, installed=InstallRecordStatus.INSTALLED)
         # For each spec provided, make sure it refers to only one package.
         # Fail and ask user to be unambiguous if it doesn't
         if not allow_multiple_matches and len(matching) > 1:

--- a/lib/spack/spack/cmd/mark.py
+++ b/lib/spack/spack/cmd/mark.py
@@ -10,7 +10,7 @@ from llnl.util import tty
 import spack.cmd
 import spack.store
 from spack.cmd.common import arguments
-from spack.database import InstallStatuses
+from spack.database import StatusQuery
 
 description = "mark packages as explicitly or implicitly installed"
 section = "admin"
@@ -67,8 +67,7 @@ def find_matching_specs(specs, allow_multiple_matches=False):
     has_errors = False
 
     for spec in specs:
-        install_query = [InstallStatuses.INSTALLED]
-        matching = spack.store.STORE.db.query_local(spec, installed=install_query)
+        matching = spack.store.STORE.db.query_local(spec, installed=StatusQuery.INSTALLED)
         # For each spec provided, make sure it refers to only one package.
         # Fail and ask user to be unambiguous if it doesn't
         if not allow_multiple_matches and len(matching) > 1:

--- a/lib/spack/spack/cmd/mark.py
+++ b/lib/spack/spack/cmd/mark.py
@@ -11,7 +11,7 @@ import spack.cmd
 import spack.store
 from spack.cmd.common import arguments
 
-from ..enums import DBStatusQuery
+from ..enums import DBStatus
 
 description = "mark packages as explicitly or implicitly installed"
 section = "admin"
@@ -68,7 +68,7 @@ def find_matching_specs(specs, allow_multiple_matches=False):
     has_errors = False
 
     for spec in specs:
-        matching = spack.store.STORE.db.query_local(spec, installed=DBStatusQuery.INSTALLED)
+        matching = spack.store.STORE.db.query_local(spec, installed=DBStatus.INSTALLED)
         # For each spec provided, make sure it refers to only one package.
         # Fail and ask user to be unambiguous if it doesn't
         if not allow_multiple_matches and len(matching) > 1:

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -100,7 +100,7 @@ def find_matching_specs(
     hashes = env.all_hashes() if env else None
 
     # List of specs that match expressions given via command line
-    specs_from_cli: List["spack.spec.Spec"] = []
+    specs_from_cli: List[spack.spec.Spec] = []
     has_errors = False
     for spec in specs:
         matching = spack.store.STORE.db.query_local(

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -18,7 +18,7 @@ import spack.store
 import spack.traverse as traverse
 from spack.cmd.common import arguments
 
-from ..enums import DBStatusQuery
+from ..enums import DBStatus
 
 description = "remove installed packages"
 section = "build"
@@ -106,7 +106,7 @@ def find_matching_specs(
         matching = spack.store.STORE.db.query_local(
             spec,
             hashes=hashes,
-            installed=(DBStatusQuery.INSTALLED | DBStatusQuery.DEPRECATED),
+            installed=(DBStatus.INSTALLED | DBStatus.DEPRECATED),
             origin=origin,
         )
         # For each spec provided, make sure it refers to only one package.

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -17,7 +17,7 @@ import spack.spec
 import spack.store
 import spack.traverse as traverse
 from spack.cmd.common import arguments
-from spack.database import InstallStatuses
+from spack.database import StatusQuery
 
 description = "remove installed packages"
 section = "build"
@@ -102,9 +102,11 @@ def find_matching_specs(
     specs_from_cli: List["spack.spec.Spec"] = []
     has_errors = False
     for spec in specs:
-        install_query = [InstallStatuses.INSTALLED, InstallStatuses.DEPRECATED]
         matching = spack.store.STORE.db.query_local(
-            spec, hashes=hashes, installed=install_query, origin=origin
+            spec,
+            hashes=hashes,
+            installed=(StatusQuery.INSTALLED | StatusQuery.DEPRECATED),
+            origin=origin,
         )
         # For each spec provided, make sure it refers to only one package.
         # Fail and ask user to be unambiguous if it doesn't

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -18,7 +18,7 @@ import spack.store
 import spack.traverse as traverse
 from spack.cmd.common import arguments
 
-from ..enums import DBStatus
+from ..enums import InstallRecordStatus
 
 description = "remove installed packages"
 section = "build"
@@ -106,7 +106,7 @@ def find_matching_specs(
         matching = spack.store.STORE.db.query_local(
             spec,
             hashes=hashes,
-            installed=(DBStatus.INSTALLED | DBStatus.DEPRECATED),
+            installed=(InstallRecordStatus.INSTALLED | InstallRecordStatus.DEPRECATED),
             origin=origin,
         )
         # For each spec provided, make sure it refers to only one package.

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -17,7 +17,8 @@ import spack.spec
 import spack.store
 import spack.traverse as traverse
 from spack.cmd.common import arguments
-from spack.database import StatusQuery
+
+from ..enums import DBStatusQuery
 
 description = "remove installed packages"
 section = "build"
@@ -105,7 +106,7 @@ def find_matching_specs(
         matching = spack.store.STORE.db.query_local(
             spec,
             hashes=hashes,
-            installed=(StatusQuery.INSTALLED | StatusQuery.DEPRECATED),
+            installed=(DBStatusQuery.INSTALLED | DBStatusQuery.DEPRECATED),
             origin=origin,
         )
         # For each spec provided, make sure it refers to only one package.

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -69,7 +69,7 @@ from spack.directory_layout import (
 from spack.error import SpackError
 from spack.util.crypto import bit_length
 
-from .enums import ANY_STATUS, DBStatusQuery
+from .enums import ANY_STATUS, DBStatus
 
 # TODO: Provide an API automatically retyring a build after detecting and
 # TODO: clearing a failure.
@@ -162,11 +162,11 @@ def _autospec(function):
     return converter
 
 
-def normalize_query(installed: Union[bool, DBStatusQuery]) -> DBStatusQuery:
+def normalize_query(installed: Union[bool, DBStatus]) -> DBStatus:
     if installed is True:
-        installed = DBStatusQuery.INSTALLED
+        installed = DBStatus.INSTALLED
     elif installed is False:
-        installed = DBStatusQuery.MISSING
+        installed = DBStatus.MISSING
     return installed
 
 
@@ -217,12 +217,12 @@ class InstallRecord:
         self.in_buildcache = in_buildcache
         self.origin = origin
 
-    def install_type_matches(self, installed: DBStatusQuery) -> bool:
+    def install_type_matches(self, installed: DBStatus) -> bool:
         if self.installed:
-            return DBStatusQuery.INSTALLED in installed
+            return DBStatus.INSTALLED in installed
         elif self.deprecated_for:
-            return DBStatusQuery.DEPRECATED in installed
-        return DBStatusQuery.MISSING in installed
+            return DBStatus.DEPRECATED in installed
+        return DBStatus.MISSING in installed
 
     def to_dict(self, include_fields=DEFAULT_INSTALL_RECORD_FIELDS):
         rec_dict = {}
@@ -1376,7 +1376,7 @@ class Database:
         self,
         dag_hash: str,
         default: Optional[List["spack.spec.Spec"]] = None,
-        installed: Union[bool, DBStatusQuery] = ANY_STATUS,
+        installed: Union[bool, DBStatus] = ANY_STATUS,
     ) -> Optional[List["spack.spec.Spec"]]:
         installed = normalize_query(installed)
         # hash is a full hash and is in the data somewhere
@@ -1403,7 +1403,7 @@ class Database:
         self,
         dag_hash: str,
         default: Optional[List["spack.spec.Spec"]] = None,
-        installed: Union[bool, DBStatusQuery] = ANY_STATUS,
+        installed: Union[bool, DBStatus] = ANY_STATUS,
     ) -> Optional[List["spack.spec.Spec"]]:
         """Look up a spec in *this DB* by DAG hash, or by a DAG hash prefix.
 
@@ -1411,7 +1411,7 @@ class Database:
             dag_hash: hash (or hash prefix) to look up
             default: default value to return if dag_hash is not in the DB
             installed: if ``True``, includes only installed specs in the search; if ``False``
-                only missing specs. Otherwise, a DBStatusQuery flag.
+                only missing specs. Otherwise, a DBStatus flag.
 
         ``installed`` defaults to ``ANY_STATUS`` so we can refer to any known hash. Note that
         ``query()`` and ``query_one()`` differ in that they only return installed specs by default.
@@ -1424,7 +1424,7 @@ class Database:
         self,
         dag_hash: str,
         default: Optional[List["spack.spec.Spec"]] = None,
-        installed: Union[bool, DBStatusQuery] = ANY_STATUS,
+        installed: Union[bool, DBStatus] = ANY_STATUS,
     ) -> Optional[List["spack.spec.Spec"]]:
         """Look up a spec by DAG hash, or by a DAG hash prefix.
 
@@ -1432,7 +1432,7 @@ class Database:
             dag_hash: hash (or hash prefix) to look up
             default: default value to return if dag_hash is not in the DB
             installed: if ``True``, includes only installed specs in the search; if ``False``
-                only missing specs. Otherwise, a DBStatusQuery flag.
+                only missing specs. Otherwise, a DBStatus flag.
 
         ``installed`` defaults to ``ANY_STATUS`` so we can refer to any known hash. Note that
         ``query()`` and ``query_one()`` differ in that they only return installed specs by default.
@@ -1455,7 +1455,7 @@ class Database:
         query_spec: Optional[Union[str, "spack.spec.Spec"]] = None,
         *,
         predicate_fn: Optional[SelectType] = None,
-        installed: Union[bool, DBStatusQuery] = True,
+        installed: Union[bool, DBStatus] = True,
         explicit: Optional[bool] = None,
         start_date: Optional[datetime.datetime] = None,
         end_date: Optional[datetime.datetime] = None,
@@ -1533,7 +1533,7 @@ class Database:
         query_spec: Optional[Union[str, "spack.spec.Spec"]] = None,
         *,
         predicate_fn: Optional[SelectType] = None,
-        installed: Union[bool, DBStatusQuery] = True,
+        installed: Union[bool, DBStatus] = True,
         explicit: Optional[bool] = None,
         start_date: Optional[datetime.datetime] = None,
         end_date: Optional[datetime.datetime] = None,
@@ -1593,7 +1593,7 @@ class Database:
         query_spec: Optional[Union[str, "spack.spec.Spec"]] = None,
         *,
         predicate_fn: Optional[SelectType] = None,
-        installed: Union[bool, DBStatusQuery] = True,
+        installed: Union[bool, DBStatus] = True,
         explicit: Optional[bool] = None,
         start_date: Optional[datetime.datetime] = None,
         end_date: Optional[datetime.datetime] = None,
@@ -1689,7 +1689,7 @@ class Database:
         self,
         query_spec: Optional[Union[str, "spack.spec.Spec"]],
         predicate_fn: Optional[SelectType] = None,
-        installed: Union[bool, DBStatusQuery] = True,
+        installed: Union[bool, DBStatus] = True,
     ) -> Optional["spack.spec.Spec"]:
         """Query for exactly one spec that matches the query spec.
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -20,7 +20,6 @@ filesystem.
 """
 import contextlib
 import datetime
-import enum
 import os
 import pathlib
 import socket
@@ -69,6 +68,8 @@ from spack.directory_layout import (
 )
 from spack.error import SpackError
 from spack.util.crypto import bit_length
+
+from .enums import ANY_STATUS, StatusQuery
 
 # TODO: Provide an API automatically retyring a build after detecting and
 # TODO: clearing a failure.
@@ -159,17 +160,6 @@ def _autospec(function):
         return function(self, spec_like, *args, **kwargs)
 
     return converter
-
-
-class StatusQuery(enum.Flag):
-    """Enum flag to facilitate querying status from the DB"""
-
-    INSTALLED = enum.auto()
-    DEPRECATED = enum.auto()
-    MISSING = enum.auto()
-
-
-ANY_STATUS = StatusQuery.INSTALLED | StatusQuery.DEPRECATED | StatusQuery.MISSING
 
 
 def normalize_query(installed: Union[bool, StatusQuery]) -> StatusQuery:

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -69,7 +69,7 @@ from spack.directory_layout import (
 from spack.error import SpackError
 from spack.util.crypto import bit_length
 
-from .enums import ANY_STATUS, InstallRecordStatus
+from .enums import InstallRecordStatus
 
 # TODO: Provide an API automatically retyring a build after detecting and
 # TODO: clearing a failure.
@@ -1376,7 +1376,7 @@ class Database:
         self,
         dag_hash: str,
         default: Optional[List["spack.spec.Spec"]] = None,
-        installed: Union[bool, InstallRecordStatus] = ANY_STATUS,
+        installed: Union[bool, InstallRecordStatus] = InstallRecordStatus.ANY,
     ) -> Optional[List["spack.spec.Spec"]]:
         installed = normalize_query(installed)
         # hash is a full hash and is in the data somewhere
@@ -1403,7 +1403,7 @@ class Database:
         self,
         dag_hash: str,
         default: Optional[List["spack.spec.Spec"]] = None,
-        installed: Union[bool, InstallRecordStatus] = ANY_STATUS,
+        installed: Union[bool, InstallRecordStatus] = InstallRecordStatus.ANY,
     ) -> Optional[List["spack.spec.Spec"]]:
         """Look up a spec in *this DB* by DAG hash, or by a DAG hash prefix.
 
@@ -1413,9 +1413,9 @@ class Database:
             installed: if ``True``, includes only installed specs in the search; if ``False``
                 only missing specs. Otherwise, a InstallRecordStatus flag.
 
-        ``installed`` defaults to ``ANY_STATUS`` so we can refer to any known hash. Note that
-        ``query()`` and ``query_one()`` differ in that they only return installed specs by default.
+        ``installed`` defaults to ``InstallRecordStatus.ANY`` so we can refer to any known hash.
 
+        ``query()`` and ``query_one()`` differ in that they only return installed specs by default.
         """
         with self.read_transaction():
             return self._get_by_hash_local(dag_hash, default=default, installed=installed)
@@ -1424,7 +1424,7 @@ class Database:
         self,
         dag_hash: str,
         default: Optional[List["spack.spec.Spec"]] = None,
-        installed: Union[bool, InstallRecordStatus] = ANY_STATUS,
+        installed: Union[bool, InstallRecordStatus] = InstallRecordStatus.ANY,
     ) -> Optional[List["spack.spec.Spec"]]:
         """Look up a spec by DAG hash, or by a DAG hash prefix.
 
@@ -1434,7 +1434,7 @@ class Database:
             installed: if ``True``, includes only installed specs in the search; if ``False``
                 only missing specs. Otherwise, a InstallRecordStatus flag.
 
-        ``installed`` defaults to ``ANY_STATUS`` so we can refer to any known hash. Note that
+        ``installed`` defaults to ``InstallRecordStatus.ANY`` so we can refer to any known hash.
         ``query()`` and ``query_one()`` differ in that they only return installed specs by default.
 
         """

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -20,6 +20,7 @@ filesystem.
 """
 import contextlib
 import datetime
+import enum
 import os
 import pathlib
 import socket
@@ -160,36 +161,23 @@ def _autospec(function):
     return converter
 
 
-class InstallStatus(str):
-    pass
+class StatusQuery(enum.Flag):
+    """Enum flag to facilitate querying status from the DB"""
+
+    INSTALLED = enum.auto()
+    DEPRECATED = enum.auto()
+    MISSING = enum.auto()
 
 
-class InstallStatuses:
-    INSTALLED = InstallStatus("installed")
-    DEPRECATED = InstallStatus("deprecated")
-    MISSING = InstallStatus("missing")
+ANY_STATUS = StatusQuery.INSTALLED | StatusQuery.DEPRECATED | StatusQuery.MISSING
 
-    @classmethod
-    def canonicalize(cls, query_arg):
-        if query_arg is True:
-            return [cls.INSTALLED]
-        if query_arg is False:
-            return [cls.MISSING]
-        if query_arg is any:
-            return [cls.INSTALLED, cls.DEPRECATED, cls.MISSING]
-        if isinstance(query_arg, InstallStatus):
-            return [query_arg]
-        try:
-            statuses = list(query_arg)
-            if all(isinstance(x, InstallStatus) for x in statuses):
-                return statuses
-        except TypeError:
-            pass
 
-        raise TypeError(
-            "installation query must be `any`, boolean, "
-            "InstallStatus, or iterable of InstallStatus"
-        )
+def normalize_query(installed: Union[bool, StatusQuery]) -> StatusQuery:
+    if installed is True:
+        installed = StatusQuery.INSTALLED
+    elif installed is False:
+        installed = StatusQuery.MISSING
+    return installed
 
 
 class InstallRecord:
@@ -227,8 +215,8 @@ class InstallRecord:
         installation_time: Optional[float] = None,
         deprecated_for: Optional[str] = None,
         in_buildcache: bool = False,
-        origin=None,
-    ):
+        origin: Optional[str] = None,
+    ) -> None:
         self.spec = spec
         self.path = str(path) if path else None
         self.installed = bool(installed)
@@ -239,14 +227,12 @@ class InstallRecord:
         self.in_buildcache = in_buildcache
         self.origin = origin
 
-    def install_type_matches(self, installed):
-        installed = InstallStatuses.canonicalize(installed)
+    def install_type_matches(self, installed: StatusQuery) -> bool:
         if self.installed:
-            return InstallStatuses.INSTALLED in installed
+            return StatusQuery.INSTALLED in installed
         elif self.deprecated_for:
-            return InstallStatuses.DEPRECATED in installed
-        else:
-            return InstallStatuses.MISSING in installed
+            return StatusQuery.DEPRECATED in installed
+        return StatusQuery.MISSING in installed
 
     def to_dict(self, include_fields=DEFAULT_INSTALL_RECORD_FIELDS):
         rec_dict = {}
@@ -1396,7 +1382,13 @@ class Database:
             if spec.package.extends(extendee_spec):
                 yield spec.package
 
-    def _get_by_hash_local(self, dag_hash, default=None, installed=any):
+    def _get_by_hash_local(
+        self,
+        dag_hash: str,
+        default: Optional[List["spack.spec.Spec"]] = None,
+        installed: Union[bool, StatusQuery] = ANY_STATUS,
+    ) -> Optional[List["spack.spec.Spec"]]:
+        installed = normalize_query(installed)
         # hash is a full hash and is in the data somewhere
         if dag_hash in self._data:
             rec = self._data[dag_hash]
@@ -1405,8 +1397,7 @@ class Database:
             else:
                 return default
 
-        # check if hash is a prefix of some installed (or previously
-        # installed) spec.
+        # check if hash is a prefix of some installed (or previously installed) spec.
         matches = [
             record.spec
             for h, record in self._data.items()
@@ -1418,52 +1409,43 @@ class Database:
         # nothing found
         return default
 
-    def get_by_hash_local(self, dag_hash, default=None, installed=any):
+    def get_by_hash_local(
+        self,
+        dag_hash: str,
+        default: Optional[List["spack.spec.Spec"]] = None,
+        installed: Union[bool, StatusQuery] = ANY_STATUS,
+    ) -> Optional[List["spack.spec.Spec"]]:
         """Look up a spec in *this DB* by DAG hash, or by a DAG hash prefix.
 
-        Arguments:
-            dag_hash (str): hash (or hash prefix) to look up
-            default (object or None): default value to return if dag_hash is
-                not in the DB (default: None)
-            installed (bool or InstallStatus or typing.Iterable or None):
-                if ``True``, includes only installed
-                specs in the search; if ``False`` only missing specs, and if
-                ``any``, all specs in database. If an InstallStatus or iterable
-                of InstallStatus, returns specs whose install status
-                (installed, deprecated, or missing) matches (one of) the
-                InstallStatus. (default: any)
+        Args:
+            dag_hash: hash (or hash prefix) to look up
+            default: default value to return if dag_hash is not in the DB
+            installed: if ``True``, includes only installed specs in the search; if ``False``
+                only missing specs. Otherwise, a StatusQuery flag.
 
-        ``installed`` defaults to ``any`` so that we can refer to any
-        known hash.  Note that ``query()`` and ``query_one()`` differ in
-        that they only return installed specs by default.
-
-        Returns:
-            (list): a list of specs matching the hash or hash prefix
+        ``installed`` defaults to ``ANY_STATUS`` so we can refer to any known hash. Note that
+        ``query()`` and ``query_one()`` differ in that they only return installed specs by default.
 
         """
         with self.read_transaction():
             return self._get_by_hash_local(dag_hash, default=default, installed=installed)
 
-    def get_by_hash(self, dag_hash, default=None, installed=any):
+    def get_by_hash(
+        self,
+        dag_hash: str,
+        default: Optional[List["spack.spec.Spec"]] = None,
+        installed: Union[bool, StatusQuery] = ANY_STATUS,
+    ) -> Optional[List["spack.spec.Spec"]]:
         """Look up a spec by DAG hash, or by a DAG hash prefix.
 
-        Arguments:
-            dag_hash (str): hash (or hash prefix) to look up
-            default (object or None): default value to return if dag_hash is
-                not in the DB (default: None)
-            installed (bool or InstallStatus or typing.Iterable or None):
-                if ``True``, includes only installed specs in the search; if ``False``
-                only missing specs, and if ``any``, all specs in database. If an
-                InstallStatus or iterable of InstallStatus, returns specs whose install
-                status (installed, deprecated, or missing) matches (one of) the
-                InstallStatus. (default: any)
+        Args:
+            dag_hash: hash (or hash prefix) to look up
+            default: default value to return if dag_hash is not in the DB
+            installed: if ``True``, includes only installed specs in the search; if ``False``
+                only missing specs. Otherwise, a StatusQuery flag.
 
-        ``installed`` defaults to ``any`` so that we can refer to any
-        known hash.  Note that ``query()`` and ``query_one()`` differ in
-        that they only return installed specs by default.
-
-        Returns:
-            (list): a list of specs matching the hash or hash prefix
+        ``installed`` defaults to ``ANY_STATUS`` so we can refer to any known hash. Note that
+        ``query()`` and ``query_one()`` differ in that they only return installed specs by default.
 
         """
 
@@ -1483,7 +1465,7 @@ class Database:
         query_spec: Optional[Union[str, "spack.spec.Spec"]] = None,
         *,
         predicate_fn: Optional[SelectType] = None,
-        installed: Union[bool, InstallStatus, List[InstallStatus]] = True,
+        installed: Union[bool, StatusQuery] = True,
         explicit: Optional[bool] = None,
         start_date: Optional[datetime.datetime] = None,
         end_date: Optional[datetime.datetime] = None,
@@ -1491,6 +1473,7 @@ class Database:
         in_buildcache: Optional[bool] = None,
         origin: Optional[str] = None,
     ) -> List["spack.spec.Spec"]:
+        installed = normalize_query(installed)
 
         # Restrict the set of records over which we iterate first
         matching_hashes = self._data
@@ -1560,7 +1543,7 @@ class Database:
         query_spec: Optional[Union[str, "spack.spec.Spec"]] = None,
         *,
         predicate_fn: Optional[SelectType] = None,
-        installed: Union[bool, InstallStatus, List[InstallStatus]] = True,
+        installed: Union[bool, StatusQuery] = True,
         explicit: Optional[bool] = None,
         start_date: Optional[datetime.datetime] = None,
         end_date: Optional[datetime.datetime] = None,
@@ -1620,7 +1603,7 @@ class Database:
         query_spec: Optional[Union[str, "spack.spec.Spec"]] = None,
         *,
         predicate_fn: Optional[SelectType] = None,
-        installed: Union[bool, InstallStatus, List[InstallStatus]] = True,
+        installed: Union[bool, StatusQuery] = True,
         explicit: Optional[bool] = None,
         start_date: Optional[datetime.datetime] = None,
         end_date: Optional[datetime.datetime] = None,
@@ -1716,7 +1699,7 @@ class Database:
         self,
         query_spec: Optional[Union[str, "spack.spec.Spec"]],
         predicate_fn: Optional[SelectType] = None,
-        installed: Union[bool, InstallStatus, List[InstallStatus]] = True,
+        installed: Union[bool, StatusQuery] = True,
     ) -> Optional["spack.spec.Spec"]:
         """Query for exactly one spec that matches the query spec.
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -69,7 +69,7 @@ from spack.directory_layout import (
 from spack.error import SpackError
 from spack.util.crypto import bit_length
 
-from .enums import ANY_STATUS, StatusQuery
+from .enums import ANY_STATUS, DBStatusQuery
 
 # TODO: Provide an API automatically retyring a build after detecting and
 # TODO: clearing a failure.
@@ -162,11 +162,11 @@ def _autospec(function):
     return converter
 
 
-def normalize_query(installed: Union[bool, StatusQuery]) -> StatusQuery:
+def normalize_query(installed: Union[bool, DBStatusQuery]) -> DBStatusQuery:
     if installed is True:
-        installed = StatusQuery.INSTALLED
+        installed = DBStatusQuery.INSTALLED
     elif installed is False:
-        installed = StatusQuery.MISSING
+        installed = DBStatusQuery.MISSING
     return installed
 
 
@@ -217,12 +217,12 @@ class InstallRecord:
         self.in_buildcache = in_buildcache
         self.origin = origin
 
-    def install_type_matches(self, installed: StatusQuery) -> bool:
+    def install_type_matches(self, installed: DBStatusQuery) -> bool:
         if self.installed:
-            return StatusQuery.INSTALLED in installed
+            return DBStatusQuery.INSTALLED in installed
         elif self.deprecated_for:
-            return StatusQuery.DEPRECATED in installed
-        return StatusQuery.MISSING in installed
+            return DBStatusQuery.DEPRECATED in installed
+        return DBStatusQuery.MISSING in installed
 
     def to_dict(self, include_fields=DEFAULT_INSTALL_RECORD_FIELDS):
         rec_dict = {}
@@ -1376,7 +1376,7 @@ class Database:
         self,
         dag_hash: str,
         default: Optional[List["spack.spec.Spec"]] = None,
-        installed: Union[bool, StatusQuery] = ANY_STATUS,
+        installed: Union[bool, DBStatusQuery] = ANY_STATUS,
     ) -> Optional[List["spack.spec.Spec"]]:
         installed = normalize_query(installed)
         # hash is a full hash and is in the data somewhere
@@ -1403,7 +1403,7 @@ class Database:
         self,
         dag_hash: str,
         default: Optional[List["spack.spec.Spec"]] = None,
-        installed: Union[bool, StatusQuery] = ANY_STATUS,
+        installed: Union[bool, DBStatusQuery] = ANY_STATUS,
     ) -> Optional[List["spack.spec.Spec"]]:
         """Look up a spec in *this DB* by DAG hash, or by a DAG hash prefix.
 
@@ -1411,7 +1411,7 @@ class Database:
             dag_hash: hash (or hash prefix) to look up
             default: default value to return if dag_hash is not in the DB
             installed: if ``True``, includes only installed specs in the search; if ``False``
-                only missing specs. Otherwise, a StatusQuery flag.
+                only missing specs. Otherwise, a DBStatusQuery flag.
 
         ``installed`` defaults to ``ANY_STATUS`` so we can refer to any known hash. Note that
         ``query()`` and ``query_one()`` differ in that they only return installed specs by default.
@@ -1424,7 +1424,7 @@ class Database:
         self,
         dag_hash: str,
         default: Optional[List["spack.spec.Spec"]] = None,
-        installed: Union[bool, StatusQuery] = ANY_STATUS,
+        installed: Union[bool, DBStatusQuery] = ANY_STATUS,
     ) -> Optional[List["spack.spec.Spec"]]:
         """Look up a spec by DAG hash, or by a DAG hash prefix.
 
@@ -1432,7 +1432,7 @@ class Database:
             dag_hash: hash (or hash prefix) to look up
             default: default value to return if dag_hash is not in the DB
             installed: if ``True``, includes only installed specs in the search; if ``False``
-                only missing specs. Otherwise, a StatusQuery flag.
+                only missing specs. Otherwise, a DBStatusQuery flag.
 
         ``installed`` defaults to ``ANY_STATUS`` so we can refer to any known hash. Note that
         ``query()`` and ``query_one()`` differ in that they only return installed specs by default.
@@ -1455,7 +1455,7 @@ class Database:
         query_spec: Optional[Union[str, "spack.spec.Spec"]] = None,
         *,
         predicate_fn: Optional[SelectType] = None,
-        installed: Union[bool, StatusQuery] = True,
+        installed: Union[bool, DBStatusQuery] = True,
         explicit: Optional[bool] = None,
         start_date: Optional[datetime.datetime] = None,
         end_date: Optional[datetime.datetime] = None,
@@ -1533,7 +1533,7 @@ class Database:
         query_spec: Optional[Union[str, "spack.spec.Spec"]] = None,
         *,
         predicate_fn: Optional[SelectType] = None,
-        installed: Union[bool, StatusQuery] = True,
+        installed: Union[bool, DBStatusQuery] = True,
         explicit: Optional[bool] = None,
         start_date: Optional[datetime.datetime] = None,
         end_date: Optional[datetime.datetime] = None,
@@ -1593,7 +1593,7 @@ class Database:
         query_spec: Optional[Union[str, "spack.spec.Spec"]] = None,
         *,
         predicate_fn: Optional[SelectType] = None,
-        installed: Union[bool, StatusQuery] = True,
+        installed: Union[bool, DBStatusQuery] = True,
         explicit: Optional[bool] = None,
         start_date: Optional[datetime.datetime] = None,
         end_date: Optional[datetime.datetime] = None,
@@ -1689,7 +1689,7 @@ class Database:
         self,
         query_spec: Optional[Union[str, "spack.spec.Spec"]],
         predicate_fn: Optional[SelectType] = None,
-        installed: Union[bool, StatusQuery] = True,
+        installed: Union[bool, DBStatusQuery] = True,
     ) -> Optional["spack.spec.Spec"]:
         """Query for exactly one spec that matches the query spec.
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -69,7 +69,7 @@ from spack.directory_layout import (
 from spack.error import SpackError
 from spack.util.crypto import bit_length
 
-from .enums import ANY_STATUS, DBStatus
+from .enums import ANY_STATUS, InstallRecordStatus
 
 # TODO: Provide an API automatically retyring a build after detecting and
 # TODO: clearing a failure.
@@ -162,11 +162,11 @@ def _autospec(function):
     return converter
 
 
-def normalize_query(installed: Union[bool, DBStatus]) -> DBStatus:
+def normalize_query(installed: Union[bool, InstallRecordStatus]) -> InstallRecordStatus:
     if installed is True:
-        installed = DBStatus.INSTALLED
+        installed = InstallRecordStatus.INSTALLED
     elif installed is False:
-        installed = DBStatus.MISSING
+        installed = InstallRecordStatus.MISSING
     return installed
 
 
@@ -217,12 +217,12 @@ class InstallRecord:
         self.in_buildcache = in_buildcache
         self.origin = origin
 
-    def install_type_matches(self, installed: DBStatus) -> bool:
+    def install_type_matches(self, installed: InstallRecordStatus) -> bool:
         if self.installed:
-            return DBStatus.INSTALLED in installed
+            return InstallRecordStatus.INSTALLED in installed
         elif self.deprecated_for:
-            return DBStatus.DEPRECATED in installed
-        return DBStatus.MISSING in installed
+            return InstallRecordStatus.DEPRECATED in installed
+        return InstallRecordStatus.MISSING in installed
 
     def to_dict(self, include_fields=DEFAULT_INSTALL_RECORD_FIELDS):
         rec_dict = {}
@@ -1376,7 +1376,7 @@ class Database:
         self,
         dag_hash: str,
         default: Optional[List["spack.spec.Spec"]] = None,
-        installed: Union[bool, DBStatus] = ANY_STATUS,
+        installed: Union[bool, InstallRecordStatus] = ANY_STATUS,
     ) -> Optional[List["spack.spec.Spec"]]:
         installed = normalize_query(installed)
         # hash is a full hash and is in the data somewhere
@@ -1403,7 +1403,7 @@ class Database:
         self,
         dag_hash: str,
         default: Optional[List["spack.spec.Spec"]] = None,
-        installed: Union[bool, DBStatus] = ANY_STATUS,
+        installed: Union[bool, InstallRecordStatus] = ANY_STATUS,
     ) -> Optional[List["spack.spec.Spec"]]:
         """Look up a spec in *this DB* by DAG hash, or by a DAG hash prefix.
 
@@ -1411,7 +1411,7 @@ class Database:
             dag_hash: hash (or hash prefix) to look up
             default: default value to return if dag_hash is not in the DB
             installed: if ``True``, includes only installed specs in the search; if ``False``
-                only missing specs. Otherwise, a DBStatus flag.
+                only missing specs. Otherwise, a InstallRecordStatus flag.
 
         ``installed`` defaults to ``ANY_STATUS`` so we can refer to any known hash. Note that
         ``query()`` and ``query_one()`` differ in that they only return installed specs by default.
@@ -1424,7 +1424,7 @@ class Database:
         self,
         dag_hash: str,
         default: Optional[List["spack.spec.Spec"]] = None,
-        installed: Union[bool, DBStatus] = ANY_STATUS,
+        installed: Union[bool, InstallRecordStatus] = ANY_STATUS,
     ) -> Optional[List["spack.spec.Spec"]]:
         """Look up a spec by DAG hash, or by a DAG hash prefix.
 
@@ -1432,7 +1432,7 @@ class Database:
             dag_hash: hash (or hash prefix) to look up
             default: default value to return if dag_hash is not in the DB
             installed: if ``True``, includes only installed specs in the search; if ``False``
-                only missing specs. Otherwise, a DBStatus flag.
+                only missing specs. Otherwise, a InstallRecordStatus flag.
 
         ``installed`` defaults to ``ANY_STATUS`` so we can refer to any known hash. Note that
         ``query()`` and ``query_one()`` differ in that they only return installed specs by default.
@@ -1455,7 +1455,7 @@ class Database:
         query_spec: Optional[Union[str, "spack.spec.Spec"]] = None,
         *,
         predicate_fn: Optional[SelectType] = None,
-        installed: Union[bool, DBStatus] = True,
+        installed: Union[bool, InstallRecordStatus] = True,
         explicit: Optional[bool] = None,
         start_date: Optional[datetime.datetime] = None,
         end_date: Optional[datetime.datetime] = None,
@@ -1533,7 +1533,7 @@ class Database:
         query_spec: Optional[Union[str, "spack.spec.Spec"]] = None,
         *,
         predicate_fn: Optional[SelectType] = None,
-        installed: Union[bool, DBStatus] = True,
+        installed: Union[bool, InstallRecordStatus] = True,
         explicit: Optional[bool] = None,
         start_date: Optional[datetime.datetime] = None,
         end_date: Optional[datetime.datetime] = None,
@@ -1593,7 +1593,7 @@ class Database:
         query_spec: Optional[Union[str, "spack.spec.Spec"]] = None,
         *,
         predicate_fn: Optional[SelectType] = None,
-        installed: Union[bool, DBStatus] = True,
+        installed: Union[bool, InstallRecordStatus] = True,
         explicit: Optional[bool] = None,
         start_date: Optional[datetime.datetime] = None,
         end_date: Optional[datetime.datetime] = None,
@@ -1689,7 +1689,7 @@ class Database:
         self,
         query_spec: Optional[Union[str, "spack.spec.Spec"]],
         predicate_fn: Optional[SelectType] = None,
-        installed: Union[bool, DBStatus] = True,
+        installed: Union[bool, InstallRecordStatus] = True,
     ) -> Optional["spack.spec.Spec"]:
         """Query for exactly one spec that matches the query spec.
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1628,7 +1628,7 @@ class Database:
         hashes: Optional[List[str]] = None,
         origin: Optional[str] = None,
         install_tree: str = "all",
-    ):
+    ) -> List["spack.spec.Spec"]:
         """Queries the Spack database including all upstream databases.
 
         Args:
@@ -1709,7 +1709,8 @@ class Database:
             )
 
         results = list(local_results) + list(x for x in upstream_results if x not in local_results)
-        return sorted(results)
+        results.sort()
+        return results
 
     def query_one(
         self,

--- a/lib/spack/spack/enums.py
+++ b/lib/spack/spack/enums.py
@@ -6,7 +6,7 @@
 import enum
 
 
-class StatusQuery(enum.Flag):
+class DBStatusQuery(enum.Flag):
     """Enum flag to facilitate querying status from the DB"""
 
     INSTALLED = enum.auto()
@@ -14,4 +14,4 @@ class StatusQuery(enum.Flag):
     MISSING = enum.auto()
 
 
-ANY_STATUS = StatusQuery.INSTALLED | StatusQuery.DEPRECATED | StatusQuery.MISSING
+ANY_STATUS = DBStatusQuery.INSTALLED | DBStatusQuery.DEPRECATED | DBStatusQuery.MISSING

--- a/lib/spack/spack/enums.py
+++ b/lib/spack/spack/enums.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Enumerations used throughout Spack"""
+import enum
+
+
+class StatusQuery(enum.Flag):
+    """Enum flag to facilitate querying status from the DB"""
+
+    INSTALLED = enum.auto()
+    DEPRECATED = enum.auto()
+    MISSING = enum.auto()
+
+
+ANY_STATUS = StatusQuery.INSTALLED | StatusQuery.DEPRECATED | StatusQuery.MISSING

--- a/lib/spack/spack/enums.py
+++ b/lib/spack/spack/enums.py
@@ -12,8 +12,4 @@ class InstallRecordStatus(enum.Flag):
     INSTALLED = enum.auto()
     DEPRECATED = enum.auto()
     MISSING = enum.auto()
-
-
-ANY_STATUS = (
-    InstallRecordStatus.INSTALLED | InstallRecordStatus.DEPRECATED | InstallRecordStatus.MISSING
-)
+    ANY = INSTALLED | DEPRECATED | MISSING

--- a/lib/spack/spack/enums.py
+++ b/lib/spack/spack/enums.py
@@ -6,7 +6,7 @@
 import enum
 
 
-class DBStatusQuery(enum.Flag):
+class DBStatus(enum.Flag):
     """Enum flag to facilitate querying status from the DB"""
 
     INSTALLED = enum.auto()
@@ -14,4 +14,4 @@ class DBStatusQuery(enum.Flag):
     MISSING = enum.auto()
 
 
-ANY_STATUS = DBStatusQuery.INSTALLED | DBStatusQuery.DEPRECATED | DBStatusQuery.MISSING
+ANY_STATUS = DBStatus.INSTALLED | DBStatus.DEPRECATED | DBStatus.MISSING

--- a/lib/spack/spack/enums.py
+++ b/lib/spack/spack/enums.py
@@ -6,7 +6,7 @@
 import enum
 
 
-class DBStatus(enum.Flag):
+class InstallRecordStatus(enum.Flag):
     """Enum flag to facilitate querying status from the DB"""
 
     INSTALLED = enum.auto()
@@ -14,4 +14,6 @@ class DBStatus(enum.Flag):
     MISSING = enum.auto()
 
 
-ANY_STATUS = DBStatus.INSTALLED | DBStatus.DEPRECATED | DBStatus.MISSING
+ANY_STATUS = (
+    InstallRecordStatus.INSTALLED | InstallRecordStatus.DEPRECATED | InstallRecordStatus.MISSING
+)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -95,7 +95,7 @@ import spack.variant as vt
 import spack.version as vn
 import spack.version.git_ref_lookup
 
-from .enums import ANY_STATUS
+from .enums import InstallRecordStatus
 
 __all__ = [
     "CompilerSpec",
@@ -2075,7 +2075,7 @@ class Spec:
         # First env, then store, then binary cache
         matches = (
             (active_env.all_matching_specs(self) if active_env else [])
-            or spack.store.STORE.db.query(self, installed=ANY_STATUS)
+            or spack.store.STORE.db.query(self, installed=InstallRecordStatus.ANY)
             or spack.binary_distribution.BinaryCacheQuery(True)(self)
         )
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2066,6 +2066,7 @@ class Spec:
         """Lookup just one spec with an abstract hash, returning a spec from the the environment,
         store, or finally, binary caches."""
         import spack.binary_distribution
+        import spack.database as db
         import spack.environment
 
         active_env = spack.environment.active_environment()
@@ -2073,7 +2074,7 @@ class Spec:
         # First env, then store, then binary cache
         matches = (
             (active_env.all_matching_specs(self) if active_env else [])
-            or spack.store.STORE.db.query(self, installed=any)
+            or spack.store.STORE.db.query(self, installed=db.ANY_STATUS)
             or spack.binary_distribution.BinaryCacheQuery(True)(self)
         )
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -95,6 +95,8 @@ import spack.variant as vt
 import spack.version as vn
 import spack.version.git_ref_lookup
 
+from .enums import ANY_STATUS
+
 __all__ = [
     "CompilerSpec",
     "Spec",
@@ -2066,7 +2068,6 @@ class Spec:
         """Lookup just one spec with an abstract hash, returning a spec from the the environment,
         store, or finally, binary caches."""
         import spack.binary_distribution
-        import spack.database as db
         import spack.environment
 
         active_env = spack.environment.active_environment()
@@ -2074,7 +2075,7 @@ class Spec:
         # First env, then store, then binary cache
         matches = (
             (active_env.all_matching_specs(self) if active_env else [])
-            or spack.store.STORE.db.query(self, installed=db.ANY_STATUS)
+            or spack.store.STORE.db.query(self, installed=ANY_STATUS)
             or spack.binary_distribution.BinaryCacheQuery(True)(self)
         )
 

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -7,7 +7,7 @@ import pytest
 
 import spack.spec
 import spack.store
-from spack.enums import ANY_STATUS, DBStatusQuery
+from spack.enums import ANY_STATUS, DBStatus
 from spack.main import SpackCommand
 
 install = SpackCommand("install")
@@ -56,7 +56,7 @@ def test_deprecate_install(mock_packages, mock_archive, mock_fetch, install_mock
     deprecate("-y", "-i", "libelf@0.8.10", "libelf@0.8.13")
 
     non_deprecated = spack.store.STORE.db.query()
-    deprecated = spack.store.STORE.db.query(installed=DBStatusQuery.DEPRECATED)
+    deprecated = spack.store.STORE.db.query(installed=DBStatus.DEPRECATED)
     assert deprecated == to_deprecate
     assert len(non_deprecated) == 1
     assert non_deprecated[0].satisfies("libelf@0.8.13")
@@ -76,7 +76,7 @@ def test_deprecate_deps(mock_packages, mock_archive, mock_fetch, install_mockery
 
     non_deprecated = spack.store.STORE.db.query()
     all_available = spack.store.STORE.db.query(installed=ANY_STATUS)
-    deprecated = spack.store.STORE.db.query(installed=DBStatusQuery.DEPRECATED)
+    deprecated = spack.store.STORE.db.query(installed=DBStatus.DEPRECATED)
 
     assert all_available == all_installed
     assert sorted(all_available) == sorted(deprecated + non_deprecated)

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -7,7 +7,7 @@ import pytest
 
 import spack.spec
 import spack.store
-from spack.enums import ANY_STATUS, DBStatus
+from spack.enums import ANY_STATUS, InstallRecordStatus
 from spack.main import SpackCommand
 
 install = SpackCommand("install")
@@ -56,7 +56,7 @@ def test_deprecate_install(mock_packages, mock_archive, mock_fetch, install_mock
     deprecate("-y", "-i", "libelf@0.8.10", "libelf@0.8.13")
 
     non_deprecated = spack.store.STORE.db.query()
-    deprecated = spack.store.STORE.db.query(installed=DBStatus.DEPRECATED)
+    deprecated = spack.store.STORE.db.query(installed=InstallRecordStatus.DEPRECATED)
     assert deprecated == to_deprecate
     assert len(non_deprecated) == 1
     assert non_deprecated[0].satisfies("libelf@0.8.13")
@@ -76,7 +76,7 @@ def test_deprecate_deps(mock_packages, mock_archive, mock_fetch, install_mockery
 
     non_deprecated = spack.store.STORE.db.query()
     all_available = spack.store.STORE.db.query(installed=ANY_STATUS)
-    deprecated = spack.store.STORE.db.query(installed=DBStatus.DEPRECATED)
+    deprecated = spack.store.STORE.db.query(installed=InstallRecordStatus.DEPRECATED)
 
     assert all_available == all_installed
     assert sorted(all_available) == sorted(deprecated + non_deprecated)

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -7,7 +7,7 @@ import pytest
 
 import spack.spec
 import spack.store
-from spack.database import ANY_STATUS, StatusQuery
+from spack.enums import ANY_STATUS, DBStatusQuery
 from spack.main import SpackCommand
 
 install = SpackCommand("install")
@@ -56,7 +56,7 @@ def test_deprecate_install(mock_packages, mock_archive, mock_fetch, install_mock
     deprecate("-y", "-i", "libelf@0.8.10", "libelf@0.8.13")
 
     non_deprecated = spack.store.STORE.db.query()
-    deprecated = spack.store.STORE.db.query(installed=StatusQuery.DEPRECATED)
+    deprecated = spack.store.STORE.db.query(installed=DBStatusQuery.DEPRECATED)
     assert deprecated == to_deprecate
     assert len(non_deprecated) == 1
     assert non_deprecated[0].satisfies("libelf@0.8.13")
@@ -76,7 +76,7 @@ def test_deprecate_deps(mock_packages, mock_archive, mock_fetch, install_mockery
 
     non_deprecated = spack.store.STORE.db.query()
     all_available = spack.store.STORE.db.query(installed=ANY_STATUS)
-    deprecated = spack.store.STORE.db.query(installed=StatusQuery.DEPRECATED)
+    deprecated = spack.store.STORE.db.query(installed=DBStatusQuery.DEPRECATED)
 
     assert all_available == all_installed
     assert sorted(all_available) == sorted(deprecated + non_deprecated)

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -7,7 +7,7 @@ import pytest
 
 import spack.spec
 import spack.store
-from spack.database import InstallStatuses
+from spack.database import ANY_STATUS, StatusQuery
 from spack.main import SpackCommand
 
 install = SpackCommand("install")
@@ -26,7 +26,7 @@ def test_deprecate(mock_packages, mock_archive, mock_fetch, install_mockery):
     deprecate("-y", "libelf@0.8.10", "libelf@0.8.13")
 
     non_deprecated = spack.store.STORE.db.query()
-    all_available = spack.store.STORE.db.query(installed=any)
+    all_available = spack.store.STORE.db.query(installed=ANY_STATUS)
     assert all_available == all_installed
     assert non_deprecated == spack.store.STORE.db.query("libelf@0.8.13")
 
@@ -56,7 +56,7 @@ def test_deprecate_install(mock_packages, mock_archive, mock_fetch, install_mock
     deprecate("-y", "-i", "libelf@0.8.10", "libelf@0.8.13")
 
     non_deprecated = spack.store.STORE.db.query()
-    deprecated = spack.store.STORE.db.query(installed=InstallStatuses.DEPRECATED)
+    deprecated = spack.store.STORE.db.query(installed=StatusQuery.DEPRECATED)
     assert deprecated == to_deprecate
     assert len(non_deprecated) == 1
     assert non_deprecated[0].satisfies("libelf@0.8.13")
@@ -75,8 +75,8 @@ def test_deprecate_deps(mock_packages, mock_archive, mock_fetch, install_mockery
     deprecate("-y", "-d", "libdwarf@20130207", "libdwarf@20130729")
 
     non_deprecated = spack.store.STORE.db.query()
-    all_available = spack.store.STORE.db.query(installed=any)
-    deprecated = spack.store.STORE.db.query(installed=InstallStatuses.DEPRECATED)
+    all_available = spack.store.STORE.db.query(installed=ANY_STATUS)
+    deprecated = spack.store.STORE.db.query(installed=StatusQuery.DEPRECATED)
 
     assert all_available == all_installed
     assert sorted(all_available) == sorted(deprecated + non_deprecated)
@@ -96,7 +96,7 @@ def test_uninstall_deprecated(mock_packages, mock_archive, mock_fetch, install_m
 
     uninstall("-y", "libelf@0.8.10")
 
-    assert spack.store.STORE.db.query() == spack.store.STORE.db.query(installed=any)
+    assert spack.store.STORE.db.query() == spack.store.STORE.db.query(installed=ANY_STATUS)
     assert spack.store.STORE.db.query() == non_deprecated
 
 
@@ -116,7 +116,7 @@ def test_deprecate_already_deprecated(mock_packages, mock_archive, mock_fetch, i
     deprecate("-y", "libelf@0.8.10", "libelf@0.8.13")
 
     non_deprecated = spack.store.STORE.db.query()
-    all_available = spack.store.STORE.db.query(installed=any)
+    all_available = spack.store.STORE.db.query(installed=ANY_STATUS)
     assert len(non_deprecated) == 2
     assert len(all_available) == 3
 
@@ -143,7 +143,7 @@ def test_deprecate_deprecator(mock_packages, mock_archive, mock_fetch, install_m
     deprecate("-y", "libelf@0.8.12", "libelf@0.8.13")
 
     non_deprecated = spack.store.STORE.db.query()
-    all_available = spack.store.STORE.db.query(installed=any)
+    all_available = spack.store.STORE.db.query(installed=ANY_STATUS)
     assert len(non_deprecated) == 1
     assert len(all_available) == 3
 

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -7,7 +7,7 @@ import pytest
 
 import spack.spec
 import spack.store
-from spack.enums import ANY_STATUS, InstallRecordStatus
+from spack.enums import InstallRecordStatus
 from spack.main import SpackCommand
 
 install = SpackCommand("install")
@@ -26,7 +26,7 @@ def test_deprecate(mock_packages, mock_archive, mock_fetch, install_mockery):
     deprecate("-y", "libelf@0.8.10", "libelf@0.8.13")
 
     non_deprecated = spack.store.STORE.db.query()
-    all_available = spack.store.STORE.db.query(installed=ANY_STATUS)
+    all_available = spack.store.STORE.db.query(installed=InstallRecordStatus.ANY)
     assert all_available == all_installed
     assert non_deprecated == spack.store.STORE.db.query("libelf@0.8.13")
 
@@ -75,7 +75,7 @@ def test_deprecate_deps(mock_packages, mock_archive, mock_fetch, install_mockery
     deprecate("-y", "-d", "libdwarf@20130207", "libdwarf@20130729")
 
     non_deprecated = spack.store.STORE.db.query()
-    all_available = spack.store.STORE.db.query(installed=ANY_STATUS)
+    all_available = spack.store.STORE.db.query(installed=InstallRecordStatus.ANY)
     deprecated = spack.store.STORE.db.query(installed=InstallRecordStatus.DEPRECATED)
 
     assert all_available == all_installed
@@ -96,7 +96,9 @@ def test_uninstall_deprecated(mock_packages, mock_archive, mock_fetch, install_m
 
     uninstall("-y", "libelf@0.8.10")
 
-    assert spack.store.STORE.db.query() == spack.store.STORE.db.query(installed=ANY_STATUS)
+    assert spack.store.STORE.db.query() == spack.store.STORE.db.query(
+        installed=InstallRecordStatus.ANY
+    )
     assert spack.store.STORE.db.query() == non_deprecated
 
 
@@ -116,7 +118,7 @@ def test_deprecate_already_deprecated(mock_packages, mock_archive, mock_fetch, i
     deprecate("-y", "libelf@0.8.10", "libelf@0.8.13")
 
     non_deprecated = spack.store.STORE.db.query()
-    all_available = spack.store.STORE.db.query(installed=ANY_STATUS)
+    all_available = spack.store.STORE.db.query(installed=InstallRecordStatus.ANY)
     assert len(non_deprecated) == 2
     assert len(all_available) == 3
 
@@ -143,7 +145,7 @@ def test_deprecate_deprecator(mock_packages, mock_archive, mock_fetch, install_m
     deprecate("-y", "libelf@0.8.12", "libelf@0.8.13")
 
     non_deprecated = spack.store.STORE.db.query()
-    all_available = spack.store.STORE.db.query(installed=ANY_STATUS)
+    all_available = spack.store.STORE.db.query(installed=InstallRecordStatus.ANY)
     assert len(non_deprecated) == 1
     assert len(all_available) == 3
 

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -17,6 +17,7 @@ import spack.environment as ev
 import spack.repo
 import spack.store
 import spack.user_environment as uenv
+from spack.database import StatusQuery
 from spack.main import SpackCommand
 from spack.spec import Spec
 from spack.test.conftest import create_test_repo
@@ -75,7 +76,7 @@ def test_query_arguments():
     assert "installed" in q_args
     assert "predicate_fn" in q_args
     assert "explicit" in q_args
-    assert q_args["installed"] == ["installed"]
+    assert q_args["installed"] == StatusQuery.INSTALLED
     assert q_args["predicate_fn"] is None
     assert q_args["explicit"] is None
     assert "start_date" in q_args

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -17,7 +17,7 @@ import spack.environment as ev
 import spack.repo
 import spack.store
 import spack.user_environment as uenv
-from spack.enums import DBStatus
+from spack.enums import InstallRecordStatus
 from spack.main import SpackCommand
 from spack.spec import Spec
 from spack.test.conftest import create_test_repo
@@ -76,7 +76,7 @@ def test_query_arguments():
     assert "installed" in q_args
     assert "predicate_fn" in q_args
     assert "explicit" in q_args
-    assert q_args["installed"] == DBStatus.INSTALLED
+    assert q_args["installed"] == InstallRecordStatus.INSTALLED
     assert q_args["predicate_fn"] is None
     assert q_args["explicit"] is None
     assert "start_date" in q_args

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -17,7 +17,7 @@ import spack.environment as ev
 import spack.repo
 import spack.store
 import spack.user_environment as uenv
-from spack.database import StatusQuery
+from spack.enums import DBStatusQuery
 from spack.main import SpackCommand
 from spack.spec import Spec
 from spack.test.conftest import create_test_repo
@@ -76,7 +76,7 @@ def test_query_arguments():
     assert "installed" in q_args
     assert "predicate_fn" in q_args
     assert "explicit" in q_args
-    assert q_args["installed"] == StatusQuery.INSTALLED
+    assert q_args["installed"] == DBStatusQuery.INSTALLED
     assert q_args["predicate_fn"] is None
     assert q_args["explicit"] is None
     assert "start_date" in q_args

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -17,7 +17,7 @@ import spack.environment as ev
 import spack.repo
 import spack.store
 import spack.user_environment as uenv
-from spack.enums import DBStatusQuery
+from spack.enums import DBStatus
 from spack.main import SpackCommand
 from spack.spec import Spec
 from spack.test.conftest import create_test_repo
@@ -76,7 +76,7 @@ def test_query_arguments():
     assert "installed" in q_args
     assert "predicate_fn" in q_args
     assert "explicit" in q_args
-    assert q_args["installed"] == DBStatusQuery.INSTALLED
+    assert q_args["installed"] == DBStatus.INSTALLED
     assert q_args["predicate_fn"] is None
     assert q_args["explicit"] is None
     assert "start_date" in q_args

--- a/lib/spack/spack/test/cmd/reindex.py
+++ b/lib/spack/spack/test/cmd/reindex.py
@@ -6,7 +6,7 @@ import shutil
 
 import spack.store
 from spack.database import Database
-from spack.enums import ANY_STATUS
+from spack.enums import InstallRecordStatus
 from spack.main import SpackCommand
 
 install = SpackCommand("install")
@@ -58,18 +58,18 @@ def test_reindex_with_deprecated_packages(
 
     db = spack.store.STORE.db
 
-    all_installed = db.query(installed=ANY_STATUS)
+    all_installed = db.query(installed=InstallRecordStatus.ANY)
     non_deprecated = db.query(installed=True)
 
     _clear_db(tmp_path)
 
     reindex()
 
-    assert db.query(installed=ANY_STATUS) == all_installed
+    assert db.query(installed=InstallRecordStatus.ANY) == all_installed
     assert db.query(installed=True) == non_deprecated
 
     old_libelf = db.query_local_by_spec_hash(
-        db.query_local("libelf@0.8.12", installed=ANY_STATUS)[0].dag_hash()
+        db.query_local("libelf@0.8.12", installed=InstallRecordStatus.ANY)[0].dag_hash()
     )
     new_libelf = db.query_local_by_spec_hash(
         db.query_local("libelf@0.8.13", installed=True)[0].dag_hash()

--- a/lib/spack/spack/test/cmd/reindex.py
+++ b/lib/spack/spack/test/cmd/reindex.py
@@ -5,7 +5,7 @@
 import shutil
 
 import spack.store
-from spack.database import Database
+from spack.database import ANY_STATUS, Database
 from spack.main import SpackCommand
 
 install = SpackCommand("install")
@@ -57,18 +57,18 @@ def test_reindex_with_deprecated_packages(
 
     db = spack.store.STORE.db
 
-    all_installed = db.query(installed=any)
+    all_installed = db.query(installed=ANY_STATUS)
     non_deprecated = db.query(installed=True)
 
     _clear_db(tmp_path)
 
     reindex()
 
-    assert db.query(installed=any) == all_installed
+    assert db.query(installed=ANY_STATUS) == all_installed
     assert db.query(installed=True) == non_deprecated
 
     old_libelf = db.query_local_by_spec_hash(
-        db.query_local("libelf@0.8.12", installed=any)[0].dag_hash()
+        db.query_local("libelf@0.8.12", installed=ANY_STATUS)[0].dag_hash()
     )
     new_libelf = db.query_local_by_spec_hash(
         db.query_local("libelf@0.8.13", installed=True)[0].dag_hash()

--- a/lib/spack/spack/test/cmd/reindex.py
+++ b/lib/spack/spack/test/cmd/reindex.py
@@ -5,7 +5,8 @@
 import shutil
 
 import spack.store
-from spack.database import ANY_STATUS, Database
+from spack.database import Database
+from spack.enums import ANY_STATUS
 from spack.main import SpackCommand
 
 install = SpackCommand("install")

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -11,7 +11,7 @@ import llnl.util.tty as tty
 import spack.cmd.uninstall
 import spack.environment
 import spack.store
-from spack.enums import ANY_STATUS
+from spack.enums import InstallRecordStatus
 from spack.main import SpackCommand, SpackCommandError
 
 uninstall = SpackCommand("uninstall")
@@ -130,10 +130,10 @@ def test_force_uninstall_and_reinstall_by_hash(mutable_database):
         specs = spack.store.STORE.db.get_by_hash(dag_hash[:7], installed=installed)
         assert len(specs) == 1 and specs[0] == callpath_spec
 
-        specs = spack.store.STORE.db.get_by_hash(dag_hash, installed=ANY_STATUS)
+        specs = spack.store.STORE.db.get_by_hash(dag_hash, installed=InstallRecordStatus.ANY)
         assert len(specs) == 1 and specs[0] == callpath_spec
 
-        specs = spack.store.STORE.db.get_by_hash(dag_hash[:7], installed=ANY_STATUS)
+        specs = spack.store.STORE.db.get_by_hash(dag_hash[:7], installed=InstallRecordStatus.ANY)
         assert len(specs) == 1 and specs[0] == callpath_spec
 
         specs = spack.store.STORE.db.get_by_hash(dag_hash, installed=not installed)
@@ -148,7 +148,7 @@ def test_force_uninstall_and_reinstall_by_hash(mutable_database):
         spec = spack.store.STORE.db.query_one("callpath ^mpich", installed=installed)
         assert spec == callpath_spec
 
-        spec = spack.store.STORE.db.query_one("callpath ^mpich", installed=ANY_STATUS)
+        spec = spack.store.STORE.db.query_one("callpath ^mpich", installed=InstallRecordStatus.ANY)
         assert spec == callpath_spec
 
         spec = spack.store.STORE.db.query_one("callpath ^mpich", installed=not installed)

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -11,7 +11,7 @@ import llnl.util.tty as tty
 import spack.cmd.uninstall
 import spack.environment
 import spack.store
-from spack.database import ANY_STATUS
+from spack.enums import ANY_STATUS
 from spack.main import SpackCommand, SpackCommandError
 
 uninstall = SpackCommand("uninstall")

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -11,6 +11,7 @@ import llnl.util.tty as tty
 import spack.cmd.uninstall
 import spack.environment
 import spack.store
+from spack.database import ANY_STATUS
 from spack.main import SpackCommand, SpackCommandError
 
 uninstall = SpackCommand("uninstall")
@@ -129,10 +130,10 @@ def test_force_uninstall_and_reinstall_by_hash(mutable_database):
         specs = spack.store.STORE.db.get_by_hash(dag_hash[:7], installed=installed)
         assert len(specs) == 1 and specs[0] == callpath_spec
 
-        specs = spack.store.STORE.db.get_by_hash(dag_hash, installed=any)
+        specs = spack.store.STORE.db.get_by_hash(dag_hash, installed=ANY_STATUS)
         assert len(specs) == 1 and specs[0] == callpath_spec
 
-        specs = spack.store.STORE.db.get_by_hash(dag_hash[:7], installed=any)
+        specs = spack.store.STORE.db.get_by_hash(dag_hash[:7], installed=ANY_STATUS)
         assert len(specs) == 1 and specs[0] == callpath_spec
 
         specs = spack.store.STORE.db.get_by_hash(dag_hash, installed=not installed)
@@ -147,7 +148,7 @@ def test_force_uninstall_and_reinstall_by_hash(mutable_database):
         spec = spack.store.STORE.db.query_one("callpath ^mpich", installed=installed)
         assert spec == callpath_spec
 
-        spec = spack.store.STORE.db.query_one("callpath ^mpich", installed=any)
+        spec = spack.store.STORE.db.query_one("callpath ^mpich", installed=ANY_STATUS)
         assert spec == callpath_spec
 
         spec = spack.store.STORE.db.query_one("callpath ^mpich", installed=not installed)

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -34,7 +34,7 @@ import spack.repo
 import spack.spec
 import spack.store
 import spack.version as vn
-from spack.enums import ANY_STATUS
+from spack.enums import InstallRecordStatus
 from spack.installer import PackageInstaller
 from spack.schema.database_index import schema
 from spack.util.executable import Executable
@@ -293,7 +293,7 @@ def _print_ref_counts():
     recs = []
 
     def add_rec(spec):
-        cspecs = spack.store.STORE.db.query(spec, installed=ANY_STATUS)
+        cspecs = spack.store.STORE.db.query(spec, installed=InstallRecordStatus.ANY)
 
         if not cspecs:
             recs.append("[ %-7s ] %-20s-" % ("", spec))
@@ -325,7 +325,7 @@ def _print_ref_counts():
 
 def _check_merkleiness():
     """Ensure the spack database is a valid merkle graph."""
-    all_specs = spack.store.STORE.db.query(installed=ANY_STATUS)
+    all_specs = spack.store.STORE.db.query(installed=InstallRecordStatus.ANY)
 
     seen = {}
     for spec in all_specs:
@@ -618,7 +618,7 @@ def test_080_root_ref_counts(mutable_database):
     mutable_database.remove("mpileaks ^mpich")
 
     # record no longer in DB
-    assert mutable_database.query("mpileaks ^mpich", installed=ANY_STATUS) == []
+    assert mutable_database.query("mpileaks ^mpich", installed=InstallRecordStatus.ANY) == []
 
     # record's deps have updated ref_counts
     assert mutable_database.get_record("callpath ^mpich").ref_count == 0
@@ -628,7 +628,7 @@ def test_080_root_ref_counts(mutable_database):
     mutable_database.add(rec.spec)
 
     # record is present again
-    assert len(mutable_database.query("mpileaks ^mpich", installed=ANY_STATUS)) == 1
+    assert len(mutable_database.query("mpileaks ^mpich", installed=InstallRecordStatus.ANY)) == 1
 
     # dependencies have ref counts updated
     assert mutable_database.get_record("callpath ^mpich").ref_count == 1
@@ -644,18 +644,21 @@ def test_090_non_root_ref_counts(mutable_database):
 
     # record still in DB but marked uninstalled
     assert mutable_database.query("callpath ^mpich", installed=True) == []
-    assert len(mutable_database.query("callpath ^mpich", installed=ANY_STATUS)) == 1
+    assert len(mutable_database.query("callpath ^mpich", installed=InstallRecordStatus.ANY)) == 1
 
     # record and its deps have same ref_counts
-    assert mutable_database.get_record("callpath ^mpich", installed=ANY_STATUS).ref_count == 1
+    assert (
+        mutable_database.get_record("callpath ^mpich", installed=InstallRecordStatus.ANY).ref_count
+        == 1
+    )
     assert mutable_database.get_record("mpich").ref_count == 2
 
     # remove only dependent of uninstalled callpath record
     mutable_database.remove("mpileaks ^mpich")
 
     # record and parent are completely gone.
-    assert mutable_database.query("mpileaks ^mpich", installed=ANY_STATUS) == []
-    assert mutable_database.query("callpath ^mpich", installed=ANY_STATUS) == []
+    assert mutable_database.query("mpileaks ^mpich", installed=InstallRecordStatus.ANY) == []
+    assert mutable_database.query("callpath ^mpich", installed=InstallRecordStatus.ANY) == []
 
     # mpich ref count updated properly.
     mpich_rec = mutable_database.get_record("mpich")
@@ -669,14 +672,14 @@ def test_100_no_write_with_exception_on_remove(database):
             raise Exception()
 
     with database.read_transaction():
-        assert len(database.query("mpileaks ^zmpi", installed=ANY_STATUS)) == 1
+        assert len(database.query("mpileaks ^zmpi", installed=InstallRecordStatus.ANY)) == 1
 
     with pytest.raises(Exception):
         fail_while_writing()
 
     # reload DB and make sure zmpi is still there.
     with database.read_transaction():
-        assert len(database.query("mpileaks ^zmpi", installed=ANY_STATUS)) == 1
+        assert len(database.query("mpileaks ^zmpi", installed=InstallRecordStatus.ANY)) == 1
 
 
 def test_110_no_write_with_exception_on_install(database):
@@ -686,14 +689,14 @@ def test_110_no_write_with_exception_on_install(database):
             raise Exception()
 
     with database.read_transaction():
-        assert database.query("cmake", installed=ANY_STATUS) == []
+        assert database.query("cmake", installed=InstallRecordStatus.ANY) == []
 
     with pytest.raises(Exception):
         fail_while_writing()
 
     # reload DB and make sure cmake was not written.
     with database.read_transaction():
-        assert database.query("cmake", installed=ANY_STATUS) == []
+        assert database.query("cmake", installed=InstallRecordStatus.ANY) == []
 
 
 def test_115_reindex_with_packages_not_in_repo(mutable_database, tmpdir):

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -34,6 +34,7 @@ import spack.repo
 import spack.spec
 import spack.store
 import spack.version as vn
+from spack.enums import ANY_STATUS
 from spack.installer import PackageInstaller
 from spack.schema.database_index import schema
 from spack.util.executable import Executable
@@ -292,7 +293,7 @@ def _print_ref_counts():
     recs = []
 
     def add_rec(spec):
-        cspecs = spack.store.STORE.db.query(spec, installed=spack.database.ANY_STATUS)
+        cspecs = spack.store.STORE.db.query(spec, installed=ANY_STATUS)
 
         if not cspecs:
             recs.append("[ %-7s ] %-20s-" % ("", spec))
@@ -324,7 +325,7 @@ def _print_ref_counts():
 
 def _check_merkleiness():
     """Ensure the spack database is a valid merkle graph."""
-    all_specs = spack.store.STORE.db.query(installed=spack.database.ANY_STATUS)
+    all_specs = spack.store.STORE.db.query(installed=ANY_STATUS)
 
     seen = {}
     for spec in all_specs:
@@ -617,7 +618,7 @@ def test_080_root_ref_counts(mutable_database):
     mutable_database.remove("mpileaks ^mpich")
 
     # record no longer in DB
-    assert mutable_database.query("mpileaks ^mpich", installed=spack.database.ANY_STATUS) == []
+    assert mutable_database.query("mpileaks ^mpich", installed=ANY_STATUS) == []
 
     # record's deps have updated ref_counts
     assert mutable_database.get_record("callpath ^mpich").ref_count == 0
@@ -627,7 +628,7 @@ def test_080_root_ref_counts(mutable_database):
     mutable_database.add(rec.spec)
 
     # record is present again
-    assert len(mutable_database.query("mpileaks ^mpich", installed=spack.database.ANY_STATUS)) == 1
+    assert len(mutable_database.query("mpileaks ^mpich", installed=ANY_STATUS)) == 1
 
     # dependencies have ref counts updated
     assert mutable_database.get_record("callpath ^mpich").ref_count == 1
@@ -643,23 +644,18 @@ def test_090_non_root_ref_counts(mutable_database):
 
     # record still in DB but marked uninstalled
     assert mutable_database.query("callpath ^mpich", installed=True) == []
-    assert len(mutable_database.query("callpath ^mpich", installed=spack.database.ANY_STATUS)) == 1
+    assert len(mutable_database.query("callpath ^mpich", installed=ANY_STATUS)) == 1
 
     # record and its deps have same ref_counts
-    assert (
-        mutable_database.get_record(
-            "callpath ^mpich", installed=spack.database.ANY_STATUS
-        ).ref_count
-        == 1
-    )
+    assert mutable_database.get_record("callpath ^mpich", installed=ANY_STATUS).ref_count == 1
     assert mutable_database.get_record("mpich").ref_count == 2
 
     # remove only dependent of uninstalled callpath record
     mutable_database.remove("mpileaks ^mpich")
 
     # record and parent are completely gone.
-    assert mutable_database.query("mpileaks ^mpich", installed=spack.database.ANY_STATUS) == []
-    assert mutable_database.query("callpath ^mpich", installed=spack.database.ANY_STATUS) == []
+    assert mutable_database.query("mpileaks ^mpich", installed=ANY_STATUS) == []
+    assert mutable_database.query("callpath ^mpich", installed=ANY_STATUS) == []
 
     # mpich ref count updated properly.
     mpich_rec = mutable_database.get_record("mpich")
@@ -673,14 +669,14 @@ def test_100_no_write_with_exception_on_remove(database):
             raise Exception()
 
     with database.read_transaction():
-        assert len(database.query("mpileaks ^zmpi", installed=spack.database.ANY_STATUS)) == 1
+        assert len(database.query("mpileaks ^zmpi", installed=ANY_STATUS)) == 1
 
     with pytest.raises(Exception):
         fail_while_writing()
 
     # reload DB and make sure zmpi is still there.
     with database.read_transaction():
-        assert len(database.query("mpileaks ^zmpi", installed=spack.database.ANY_STATUS)) == 1
+        assert len(database.query("mpileaks ^zmpi", installed=ANY_STATUS)) == 1
 
 
 def test_110_no_write_with_exception_on_install(database):
@@ -690,14 +686,14 @@ def test_110_no_write_with_exception_on_install(database):
             raise Exception()
 
     with database.read_transaction():
-        assert database.query("cmake", installed=spack.database.ANY_STATUS) == []
+        assert database.query("cmake", installed=ANY_STATUS) == []
 
     with pytest.raises(Exception):
         fail_while_writing()
 
     # reload DB and make sure cmake was not written.
     with database.read_transaction():
-        assert database.query("cmake", installed=spack.database.ANY_STATUS) == []
+        assert database.query("cmake", installed=ANY_STATUS) == []
 
 
 def test_115_reindex_with_packages_not_in_repo(mutable_database, tmpdir):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1206,7 +1206,7 @@ _spack_fetch() {
 _spack_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --format -H --hashes --json -I --install-status -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -r --only-roots -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --deprecated --only-deprecated --install-tree --start-date --end-date"
+        SPACK_COMPREPLY="-h --help --format -H --hashes --json -I --install-status -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -N --namespaces -r --only-roots -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --only-deprecated --deprecated --install-tree --start-date --end-date"
     else
         _installed_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1776,7 +1776,7 @@ complete -c spack -n '__fish_spack_using_command fetch' -l deprecated -f -a conf
 complete -c spack -n '__fish_spack_using_command fetch' -l deprecated -d 'allow concretizer to select deprecated versions'
 
 # spack find
-set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json I/install-status d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces r/only-roots c/show-concretized f/show-flags show-full-compiler x/explicit X/implicit u/unknown m/missing v/variants loaded M/only-missing deprecated only-deprecated install-tree= start-date= end-date=
+set -g __fish_spack_optspecs_spack_find h/help format= H/hashes json I/install-status d/deps p/paths groups no-groups l/long L/very-long t/tag= N/namespaces r/only-roots c/show-concretized f/show-flags show-full-compiler x/explicit X/implicit u/unknown m/missing v/variants loaded M/only-missing only-deprecated deprecated install-tree= start-date= end-date=
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 find' -f -a '(__fish_spack_installed_specs)'
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command find' -s h -l help -d 'show this help message and exit'
@@ -1826,10 +1826,10 @@ complete -c spack -n '__fish_spack_using_command find' -l loaded -f -a loaded
 complete -c spack -n '__fish_spack_using_command find' -l loaded -d 'show only packages loaded in the user environment'
 complete -c spack -n '__fish_spack_using_command find' -s M -l only-missing -f -a only_missing
 complete -c spack -n '__fish_spack_using_command find' -s M -l only-missing -d 'show only missing dependencies'
-complete -c spack -n '__fish_spack_using_command find' -l deprecated -f -a deprecated
-complete -c spack -n '__fish_spack_using_command find' -l deprecated -d 'show deprecated packages as well as installed specs'
 complete -c spack -n '__fish_spack_using_command find' -l only-deprecated -f -a only_deprecated
 complete -c spack -n '__fish_spack_using_command find' -l only-deprecated -d 'show only deprecated packages'
+complete -c spack -n '__fish_spack_using_command find' -l deprecated -f -a deprecated
+complete -c spack -n '__fish_spack_using_command find' -l deprecated -d 'show deprecated packages as well as installed specs'
 complete -c spack -n '__fish_spack_using_command find' -l install-tree -r -f -a install_tree
 complete -c spack -n '__fish_spack_using_command find' -l install-tree -r -d 'Install trees to query: '"'"'all'"'"' (default), '"'"'local'"'"', '"'"'upstream'"'"', upstream name or path'
 complete -c spack -n '__fish_spack_using_command find' -l start-date -r -f -a start_date


### PR DESCRIPTION
In `spack.database` we use a custom enum-like class `InstallStatuses` for legacy reasons[^1]. 

In this PR we turn that class into an `enum.Flag`, which has some small benefits:
- Flags are composable with `|`. That allows us to simplify the signature of a couple of methods
- We can easily define a constant in the enum representing "any" status, and stop using the builtin `any` for that purpose

On top of that:
- More type-hinting is added to query functions.
- In `spack find` the  `--only-missing` option is mutually exclusive with `--only-deprecated`. Both can't be mixed with `--missing` and `--deprecated`.

[^1]: This class was added when Spack still had to support Python 2.6
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
