### PR TITLE
autopush: run after install manifest is written

### DIFF
--- a/lib/spack/spack/hooks/__init__.py
+++ b/lib/spack/spack/hooks/__init__.py
@@ -42,8 +42,9 @@ class _HookRunner:
 
         relative_names = list(list_modules(spack.paths.hooks_path))
 
-        # Ensure that write_install_manifest comes last
-        ensure_last(relative_names, "absolutify_elf_sonames", "write_install_manifest")
+        # write_install_manifest should come after any mutation of the install prefix, and
+        # autopush should include the install manifest.
+        ensure_last(relative_names, "absolutify_elf_sonames", "write_install_manifest", "autopush")
 
         for name in relative_names:
             module_name = __name__ + "." + name


### PR DESCRIPTION
Spack v0.22 introduced the autopush hook, which pushes to a buildcache directly after install.

This hook should run after all mutations to the install prefix have been made.

Right now autopushed tarballs are missing the `.spack/install_manifest.json` file from the
`write_install_manifest` hook.