### PR TITLE
New urls for Kokkos and Kokkos-Kernels

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos-kernels/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/package.py
@@ -11,7 +11,7 @@ class KokkosKernels(CMakePackage, CudaPackage):
 
     homepage = "https://github.com/kokkos/kokkos-kernels"
     git = "https://github.com/kokkos/kokkos-kernels.git"
-    url = "https://github.com/kokkos/kokkos-kernels/archive/4.0.00.tar.gz"
+    url = "https://github.com/kokkos/kokkos-kernels/releases/download/4.4.01/kokkos-kernels-4.4.01.tar.gz"
 
     tags = ["e4s"]
 
@@ -21,32 +21,111 @@ class KokkosKernels(CMakePackage, CudaPackage):
 
     license("Apache-2.0 WITH LLVM-exception")
 
-    # generate checksum for each release tarball with the following command
-    # openssl sha256 kokkos-kernels-x.y.z.tar.gz
     version("develop", branch="develop")
     version("master", branch="master")
-    version("4.4.01", sha256="9f741449f5ace5a7d8a5a81194ff2108e5525d16f08fcd9bb6c9bb4853d7720d")
-    version("4.4.00", sha256="6559871c091eb5bcff53bae5a0f04f2298971d1aa1b2c135bd5a2dae3f9376a2")
-    version("4.3.01", sha256="749553a6ea715ba1e56fa0b13b42866bb9880dba7a94e343eadf40d08c68fab8")
-    version("4.3.00", sha256="03c3226ee97dbca4fa56fe69bc4eefa0673e23c37f2741943d9362424a63950e")
-    version("4.2.01", sha256="058052b3a40f5d4e447b7ded5c480f1b0d4aa78373b0bc7e43804d0447c34ca8")
-    version("4.2.00", sha256="c65df9a101dbbef2d8fd43c60c9ea85f2046bb3535fa1ad16e7c661ddd60401e")
-    version("4.1.00", sha256="d6a4108444ea226e43bf6a9c0dfc557f223a72b1142bf81aa78dd60e16ac2d56")
-    version("4.0.01", sha256="3f493fcb0244b26858ceb911be64092fbf7785616ad62c81abde0ea1ce86688a")
-    version("4.0.00", sha256="750079d0be1282d18ecd280e130ca303044ac399f1e5864488284b92f5ce0a86")
-    version("3.7.01", sha256="b2060f5894bdaf7f7d4793b90444fac260460cfa80595afcbcb955518864b446")
-    version("3.7.00", sha256="51bc6db3995392065656848e2b152cfd1c3a95a951ab18a3934278113d59f32b")
-    version("3.6.01", sha256="f000b156c8c0b80e85d38587907c11d9479aaf362408b812effeda5e22b24d0d")
-    version("3.6.00", sha256="2753643fd643b9eed9f7d370e0ff5fa957211d08a91aa75398e31cbc9e5eb0a5")
-    version("3.5.00", sha256="a03a41a047d95f9f07cd1e1d30692afdb75b5c705ef524e19c1d02fe60ccf8d1")
-    version("3.4.01", sha256="f504aa4afbffb58fa7c4430d0fdb8fd5690a268823fa15eb0b7d58dab9d351e6")
-    version("3.4.00", sha256="07ba11869e686cb0d47272d1ef494ccfbcdef3f93ff1c8b64ab9e136a53a227a")
-    version("3.3.01", sha256="0f21fe6b5a8b6ae7738290e293aa990719aefe88b32f84617436bfd6074a8f77")
-    version("3.3.00", sha256="8d7f78815301afb90ddba7914dce5b718cea792ac0c7350d2f8d00bd2ef1cece")
-    version("3.2.01", sha256="c486e5cac19e354a517498c362838619435734d64b44f44ce909b0531c21d95c")
-    version("3.2.00", sha256="8ac20ee28ae7813ce1bda461918800ad57fdbac2af86ef5d1ba74e83e10956de")
-    version("3.1.00", sha256="27fea241ae92f41bd5b070b1a590ba3a56a06aca750207a98bea2f64a4a40c89")
-    version("3.0.00", sha256="e4b832aed3f8e785de24298f312af71217a26067aea2de51531e8c1e597ef0e6")
+    version("4.4.01", sha256="4a32bc8330e0113856bdf181df94cc4f9902e3cebb5dc7cea5948f30df03bfa1")
+    version("4.4.00", sha256="66d5c3f728a8c7689159c97006996164ea00fd39702476220e3dbf2a05c49e8f")
+
+    version(
+        "4.3.01",
+        sha256="749553a6ea715ba1e56fa0b13b42866bb9880dba7a94e343eadf40d08c68fab8",
+        url="https://github.com/kokkos/kokkos-kernels/archive/4.3.01.tar.gz",
+    )
+    version(
+        "4.3.00",
+        sha256="03c3226ee97dbca4fa56fe69bc4eefa0673e23c37f2741943d9362424a63950e",
+        url="https://github.com/kokkos/kokkos-kernels/archive/4.3.00.tar.gz",
+    )
+    version(
+        "4.2.01",
+        sha256="058052b3a40f5d4e447b7ded5c480f1b0d4aa78373b0bc7e43804d0447c34ca8",
+        url="https://github.com/kokkos/kokkos-kernels/archive/4.2.01.tar.gz",
+    )
+    version(
+        "4.2.00",
+        sha256="c65df9a101dbbef2d8fd43c60c9ea85f2046bb3535fa1ad16e7c661ddd60401e",
+        url="https://github.com/kokkos/kokkos-kernels/archive/4.2.00.tar.gz",
+    )
+    version(
+        "4.1.00",
+        sha256="d6a4108444ea226e43bf6a9c0dfc557f223a72b1142bf81aa78dd60e16ac2d56",
+        url="https://github.com/kokkos/kokkos-kernels/archive/4.1.00.tar.gz",
+    )
+    version(
+        "4.0.01",
+        sha256="3f493fcb0244b26858ceb911be64092fbf7785616ad62c81abde0ea1ce86688a",
+        url="https://github.com/kokkos/kokkos-kernels/archive/4.0.01.tar.gz",
+    )
+    version(
+        "4.0.00",
+        sha256="750079d0be1282d18ecd280e130ca303044ac399f1e5864488284b92f5ce0a86",
+        url="https://github.com/kokkos/kokkos-kernels/archive/4.0.00.tar.gz",
+    )
+    version(
+        "3.7.01",
+        sha256="b2060f5894bdaf7f7d4793b90444fac260460cfa80595afcbcb955518864b446",
+        url="https://github.com/kokkos/kokkos-kernels/archive/3.7.01.tar.gz",
+    )
+    version(
+        "3.7.00",
+        sha256="51bc6db3995392065656848e2b152cfd1c3a95a951ab18a3934278113d59f32b",
+        url="https://github.com/kokkos/kokkos-kernels/archive/3.7.00.tar.gz",
+    )
+    version(
+        "3.6.01",
+        sha256="f000b156c8c0b80e85d38587907c11d9479aaf362408b812effeda5e22b24d0d",
+        url="https://github.com/kokkos/kokkos-kernels/archive/3.6.01.tar.gz",
+    )
+    version(
+        "3.6.00",
+        sha256="2753643fd643b9eed9f7d370e0ff5fa957211d08a91aa75398e31cbc9e5eb0a5",
+        url="https://github.com/kokkos/kokkos-kernels/archive/3.6.00.tar.gz",
+    )
+    version(
+        "3.5.00",
+        sha256="a03a41a047d95f9f07cd1e1d30692afdb75b5c705ef524e19c1d02fe60ccf8d1",
+        url="https://github.com/kokkos/kokkos-kernels/archive/3.5.00.tar.gz",
+    )
+    version(
+        "3.4.01",
+        sha256="f504aa4afbffb58fa7c4430d0fdb8fd5690a268823fa15eb0b7d58dab9d351e6",
+        url="https://github.com/kokkos/kokkos-kernels/archive/3.4.01.tar.gz",
+    )
+    version(
+        "3.4.00",
+        sha256="07ba11869e686cb0d47272d1ef494ccfbcdef3f93ff1c8b64ab9e136a53a227a",
+        url="https://github.com/kokkos/kokkos-kernels/archive/3.4.00.tar.gz",
+    )
+    version(
+        "3.3.01",
+        sha256="0f21fe6b5a8b6ae7738290e293aa990719aefe88b32f84617436bfd6074a8f77",
+        url="https://github.com/kokkos/kokkos-kernels/archive/3.3.01.tar.gz",
+    )
+    version(
+        "3.3.00",
+        sha256="8d7f78815301afb90ddba7914dce5b718cea792ac0c7350d2f8d00bd2ef1cece",
+        url="https://github.com/kokkos/kokkos-kernels/archive/3.3.00.tar.gz",
+    )
+    version(
+        "3.2.01",
+        sha256="c486e5cac19e354a517498c362838619435734d64b44f44ce909b0531c21d95c",
+        url="https://github.com/kokkos/kokkos-kernels/archive/3.2.01.tar.gz",
+    )
+    version(
+        "3.2.00",
+        sha256="8ac20ee28ae7813ce1bda461918800ad57fdbac2af86ef5d1ba74e83e10956de",
+        url="https://github.com/kokkos/kokkos-kernels/archive/3.2.00.tar.gz",
+    )
+    version(
+        "3.1.00",
+        sha256="27fea241ae92f41bd5b070b1a590ba3a56a06aca750207a98bea2f64a4a40c89",
+        url="https://github.com/kokkos/kokkos-kernels/archive/3.1.00.tar.gz",
+    )
+    version(
+        "3.0.00",
+        sha256="e4b832aed3f8e785de24298f312af71217a26067aea2de51531e8c1e597ef0e6",
+        url="https://github.com/kokkos/kokkos-kernels/archive/3.0.00.tar.gz",
+    )
 
     depends_on("cxx", type="build")  # generated
 

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -15,7 +15,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
     homepage = "https://github.com/kokkos/kokkos"
     git = "https://github.com/kokkos/kokkos.git"
-    url = "https://github.com/kokkos/kokkos/archive/3.6.00.tar.gz"
+    url = "https://github.com/kokkos/kokkos/releases/download/4.4.01/kokkos-4.4.01.tar.gz"
 
     tags = ["e4s"]
 
@@ -27,30 +27,120 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version("develop", branch="develop")
-    version("4.4.01", sha256="3f7096d17eaaa4004c7497ac082bf1ae3ff47b5104149e54af021a89414c3682")
-    version("4.4.00", sha256="c638980cb62c34969b8c85b73e68327a2cb64f763dd33e5241f5fd437170205a")
-    version("4.3.01", sha256="5998b7c732664d6b5e219ccc445cd3077f0e3968b4be480c29cd194b4f45ec70")
-    version("4.3.00", sha256="53cf30d3b44dade51d48efefdaee7a6cf109a091b702a443a2eda63992e5fe0d")
-    version("4.2.01", sha256="cbabbabba021d00923fb357d2e1b905dda3838bd03c885a6752062fe03c67964")
-    version("4.2.00", sha256="ac08765848a0a6ac584a0a46cd12803f66dd2a2c2db99bb17c06ffc589bf5be8")
-    version("4.1.00", sha256="cf725ea34ba766fdaf29c884cfe2daacfdc6dc2d6af84042d1c78d0f16866275")
-    version("4.0.01", sha256="bb942de8afdd519fd6d5d3974706bfc22b6585a62dd565c12e53bdb82cd154f0")
-    version("4.0.00", sha256="1829a423883d4b44223c7c3a53d3c51671145aad57d7d23e6a1a4bebf710dcf6")
-    version("3.7.02", sha256="5024979f06bc8da2fb696252a66297f3e0e67098595a0cc7345312b3b4aa0f54")
-    version("3.7.01", sha256="0481b24893d1bcc808ec68af1d56ef09b82a1138a1226d6be27c3b3c3da65ceb")
-    version("3.7.00", sha256="62e3f9f51c798998f6493ed36463f66e49723966286ef70a9dcba329b8443040")
-    version("3.6.01", sha256="1b80a70c5d641da9fefbbb652e857d7c7a76a0ebad1f477c253853e209deb8db")
-    version("3.6.00", sha256="53b11fffb53c5d48da5418893ac7bc814ca2fde9c86074bdfeaa967598c918f4")
-    version("3.5.00", sha256="748f06aed63b1e77e3653cd2f896ef0d2c64cb2e2d896d9e5a57fec3ff0244ff")
-    version("3.4.01", sha256="146d5e233228e75ef59ca497e8f5872d9b272cb93e8e9cdfe05ad34a23f483d1")
-    version("3.4.00", sha256="2e4438f9e4767442d8a55e65d000cc9cde92277d415ab4913a96cd3ad901d317")
-    version("3.3.01", sha256="4919b00bb7b6eb80f6c335a32f98ebe262229d82e72d3bae6dd91aaf3d234c37")
-    version("3.3.00", sha256="170b9deaa1943185e928f8fcb812cd4593a07ed7d220607467e8f0419e147295")
-    version("3.2.01", sha256="9e27a3d8f81559845e190d60f277d84d6f558412a3df3301d9545e91373bcaf1")
-    version("3.2.00", sha256="05e1b4dd1ef383ca56fe577913e1ff31614764e65de6d6f2a163b2bddb60b3e9")
-    version("3.1.01", sha256="ff5024ebe8570887d00246e2793667e0d796b08c77a8227fe271127d36eec9dd")
-    version("3.1.00", sha256="b935c9b780e7330bcb80809992caa2b66fd387e3a1c261c955d622dae857d878")
-    version("3.0.00", sha256="c00613d0194a4fbd0726719bbed8b0404ed06275f310189b3493f5739042a92b")
+
+    version("4.4.01", sha256="3413f0cb39912128d91424ebd92e8832009e7eeaf6fa8da58e99b0d37860d972")
+    version("4.4.00", sha256="0b46372f38c48aa088411ac1b7c173a5c90f0fdb69ab40271827688fc134f58b")
+
+    version(
+        "4.3.01",
+        sha256="5998b7c732664d6b5e219ccc445cd3077f0e3968b4be480c29cd194b4f45ec70",
+        url="https://github.com/kokkos/kokkos/archive/4.3.01.tar.gz",
+    )
+    version(
+        "4.3.00",
+        sha256="53cf30d3b44dade51d48efefdaee7a6cf109a091b702a443a2eda63992e5fe0d",
+        url="https://github.com/kokkos/kokkos/archive/4.3.00.tar.gz",
+    )
+    version(
+        "4.2.01",
+        sha256="cbabbabba021d00923fb357d2e1b905dda3838bd03c885a6752062fe03c67964",
+        url="https://github.com/kokkos/kokkos/archive/4.2.01.tar.gz",
+    )
+    version(
+        "4.2.00",
+        sha256="ac08765848a0a6ac584a0a46cd12803f66dd2a2c2db99bb17c06ffc589bf5be8",
+        url="https://github.com/kokkos/kokkos/archive/4.2.00.tar.gz",
+    )
+    version(
+        "4.1.00",
+        sha256="cf725ea34ba766fdaf29c884cfe2daacfdc6dc2d6af84042d1c78d0f16866275",
+        url="https://github.com/kokkos/kokkos/archive/4.1.00.tar.gz",
+    )
+    version(
+        "4.0.01",
+        sha256="bb942de8afdd519fd6d5d3974706bfc22b6585a62dd565c12e53bdb82cd154f0",
+        url="https://github.com/kokkos/kokkos/archive/4.0.01.tar.gz",
+    )
+    version(
+        "4.0.00",
+        sha256="1829a423883d4b44223c7c3a53d3c51671145aad57d7d23e6a1a4bebf710dcf6",
+        url="https://github.com/kokkos/kokkos/archive/4.0.00.tar.gz",
+    )
+    version(
+        "3.7.02",
+        sha256="5024979f06bc8da2fb696252a66297f3e0e67098595a0cc7345312b3b4aa0f54",
+        url="https://github.com/kokkos/kokkos/archive/3.7.02.tar.gz",
+    )
+    version(
+        "3.7.01",
+        sha256="0481b24893d1bcc808ec68af1d56ef09b82a1138a1226d6be27c3b3c3da65ceb",
+        url="https://github.com/kokkos/kokkos/archive/3.7.01.tar.gz",
+    )
+    version(
+        "3.7.00",
+        sha256="62e3f9f51c798998f6493ed36463f66e49723966286ef70a9dcba329b8443040",
+        url="https://github.com/kokkos/kokkos/archive/3.7.00.tar.gz",
+    )
+    version(
+        "3.6.01",
+        sha256="1b80a70c5d641da9fefbbb652e857d7c7a76a0ebad1f477c253853e209deb8db",
+        url="https://github.com/kokkos/kokkos/archive/3.6.01.tar.gz",
+    )
+    version(
+        "3.6.00",
+        sha256="53b11fffb53c5d48da5418893ac7bc814ca2fde9c86074bdfeaa967598c918f4",
+        url="https://github.com/kokkos/kokkos/archive/3.6.00.tar.gz",
+    )
+    version(
+        "3.5.00",
+        sha256="748f06aed63b1e77e3653cd2f896ef0d2c64cb2e2d896d9e5a57fec3ff0244ff",
+        url="https://github.com/kokkos/kokkos/archive/3.5.00.tar.gz",
+    )
+    version(
+        "3.4.01",
+        sha256="146d5e233228e75ef59ca497e8f5872d9b272cb93e8e9cdfe05ad34a23f483d1",
+        url="https://github.com/kokkos/kokkos/archive/3.4.01.tar.gz",
+    )
+    version(
+        "3.4.00",
+        sha256="2e4438f9e4767442d8a55e65d000cc9cde92277d415ab4913a96cd3ad901d317",
+        url="https://github.com/kokkos/kokkos/archive/3.4.00.tar.gz",
+    )
+    version(
+        "3.3.01",
+        sha256="4919b00bb7b6eb80f6c335a32f98ebe262229d82e72d3bae6dd91aaf3d234c37",
+        url="https://github.com/kokkos/kokkos/archive/3.3.01.tar.gz",
+    )
+    version(
+        "3.3.00",
+        sha256="170b9deaa1943185e928f8fcb812cd4593a07ed7d220607467e8f0419e147295",
+        url="https://github.com/kokkos/kokkos/archive/3.3.00.tar.gz",
+    )
+    version(
+        "3.2.01",
+        sha256="9e27a3d8f81559845e190d60f277d84d6f558412a3df3301d9545e91373bcaf1",
+        url="https://github.com/kokkos/kokkos/archive/3.2.01.tar.gz",
+    )
+    version(
+        "3.2.00",
+        sha256="05e1b4dd1ef383ca56fe577913e1ff31614764e65de6d6f2a163b2bddb60b3e9",
+        url="https://github.com/kokkos/kokkos/archive/3.2.00.tar.gz",
+    )
+    version(
+        "3.1.01",
+        sha256="ff5024ebe8570887d00246e2793667e0d796b08c77a8227fe271127d36eec9dd",
+        url="https://github.com/kokkos/kokkos/archive/3.1.01.tar.gz",
+    )
+    version(
+        "3.1.00",
+        sha256="b935c9b780e7330bcb80809992caa2b66fd387e3a1c261c955d622dae857d878",
+        url="https://github.com/kokkos/kokkos/archive/3.1.00.tar.gz",
+    )
+    version(
+        "3.0.00",
+        sha256="c00613d0194a4fbd0726719bbed8b0404ed06275f310189b3493f5739042a92b",
+        url="https://github.com/kokkos/kokkos/archive/3.0.00.tar.gz",
+    )
 
     depends_on("cxx", type="build")  # Kokkos requires a C++ compiler
 


### PR DESCRIPTION
Since version 4.4, Kokkos and Kokkos-Kernels have released signed tarballs. 
This PR makes Spack use them instead of standard Github-generated artifacts.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
