### PR TITLE
Docs: remove reference to pyspack

### DIFF
--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -12,10 +12,6 @@
 Spack
 ===================
 
-.. epigraph::
-
-   `These are docs for the Spack package manager. For sphere packing, see` `pyspack <https://pyspack.readthedocs.io>`_.
-
 Spack is a package management tool designed to support multiple
 versions and configurations of software on a wide variety of platforms
 and environments.  It was designed for large supercomputing centers,


### PR DESCRIPTION
[The other spack](https://github.com/wackywendell/spack) has 10 stars and hasn't had a single commit in 8 years. In fact, the most recent commit was when the docs site was renamed. I don't think anyone viewing our docs is still looking for the other spack.