### PR TITLE
root: require +opengl when +aqua is on

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -429,6 +429,8 @@ class Root(CMakePackage):
     # Incompatible variants
     if sys.platform == "darwin":
         conflicts("+opengl", when="~x ~aqua", msg="root+opengl requires X or Aqua")
+        # https://github.com/root-project/root/issues/7160
+        conflicts("+aqua", when="~opengl", msg="+aqua requires OpenGL to be enabled")
     else:
         conflicts("+opengl", when="~x", msg="root+opengl requires X")
     conflicts("+math", when="~gsl", msg="root+math requires GSL")


### PR DESCRIPTION
According to https://github.com/root-project/root/issues/7160, if `-Dcocoa=ON` ROOT must also be configured with `-Dopengl=ON`, since otherwise the build encounters missing includes. This is/was a silent failure in ROOT CMake, but I believe has been made an explicit failure some time this year.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
