### PR TITLE
cp2k: protect 2024.3 against newer libxc

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -200,7 +200,7 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("libxc@5.1.3:5.1", when="@8.2:8")
         depends_on("libxc@5.1.7:5.1", when="@9:2022.2")
         depends_on("libxc@6.1:", when="@2023.1:")
-        depends_on("libxc@6.2:", when="@2023.2:")
+        depends_on("libxc@6.2:6.2.2", when="@2023.2:2024.3")
 
     with when("+spla"):
         depends_on("spla+cuda+fortran", when="+cuda")

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -200,7 +200,8 @@ class Cp2k(MakefilePackage, CMakePackage, CudaPackage, ROCmPackage):
         depends_on("libxc@5.1.3:5.1", when="@8.2:8")
         depends_on("libxc@5.1.7:5.1", when="@9:2022.2")
         depends_on("libxc@6.1:", when="@2023.1:")
-        depends_on("libxc@6.2:6.2.2", when="@2023.2:2024.3")
+        depends_on("libxc@6.2:", when="@2023.2:")
+        depends_on("libxc@:6", when="@:2024.3")
 
     with when("+spla"):
         depends_on("spla+cuda+fortran", when="+cuda")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Protect last releases of cp2k from libxc>6.2.2, i.e. 7.0.0

Needed for https://github.com/spack/spack/pull/47263

Note that this problem is fixed on CP2K master by https://github.com/cp2k/cp2k/pull/3722 ; verified this builds with 7.0.0.
