### PR TITLE
Rework the schema for reusing environments

### DIFF
--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -40,7 +40,7 @@ properties: Dict[str, Any] = {
                                                 "environment",
                                             ],
                                         },
-                                        "ref": {"type": "string"},
+                                        "path": {"type": "string"},
                                         "include": LIST_OF_SPECS,
                                         "exclude": LIST_OF_SPECS,
                                     },

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -32,24 +32,15 @@ properties: Dict[str, Any] = {
                                     "type": "object",
                                     "properties": {
                                         "type": {
-                                            "oneOf": [
-                                                {
-                                                    "type": "string",
-                                                    "enum": [
-                                                        "local",
-                                                        "buildcache",
-                                                        "environment",
-                                                        "external",
-                                                    ],
-                                                },
-                                                {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "environment": {"type": "string"}
-                                                    },
-                                                },
-                                            ]
+                                            "type": "string",
+                                            "enum": [
+                                                "local",
+                                                "buildcache",
+                                                "external",
+                                                "environment",
+                                            ],
                                         },
+                                        "ref": {"type": "string"},
                                         "include": LIST_OF_SPECS,
                                         "exclude": LIST_OF_SPECS,
                                     },

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -4101,8 +4101,8 @@ class ReusableSpecsSelector:
             for source in reuse_yaml.get("from", default_sources):
                 include = source.get("include", default_include)
                 exclude = source.get("exclude", default_exclude)
-                if isinstance(source["type"], dict):
-                    env_dir = ev.as_env_dir(source["type"].get("environment"))
+                if source["type"] == "environment" and "ref" in source:
+                    env_dir = ev.as_env_dir(source["ref"])
                     active_env = ev.active_environment()
                     if active_env and env_dir in active_env.included_concrete_envs:
                         # If environment is included as a concrete environment, use the local copy

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -4101,8 +4101,8 @@ class ReusableSpecsSelector:
             for source in reuse_yaml.get("from", default_sources):
                 include = source.get("include", default_include)
                 exclude = source.get("exclude", default_exclude)
-                if source["type"] == "environment" and "ref" in source:
-                    env_dir = ev.as_env_dir(source["ref"])
+                if source["type"] == "environment" and "path" in source:
+                    env_dir = ev.as_env_dir(source["path"])
                     active_env = ev.active_environment()
                     if active_env and env_dir in active_env.included_concrete_envs:
                         # If environment is included as a concrete environment, use the local copy

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1941,7 +1941,7 @@ def configure_reuse(reuse_mode, combined_env) -> Optional[ev.Environment]:
     elif reuse_mode == "from_environment":
         _config = {"concretizer": {"reuse": {"from": [{"type": "environment"}]}}}
     elif reuse_mode == "from_environment_test1":
-        _config = {"concretizer": {"reuse": {"from": [{"type": {"environment": "test1"}}]}}}
+        _config = {"concretizer": {"reuse": {"from": [{"type": "environment", "ref": "test1"}]}}}
     elif reuse_mode == "from_environment_external_test":
         # Create a new environment called external_test that enables the "debug"
         # The default is "~debug"
@@ -1957,12 +1957,12 @@ def configure_reuse(reuse_mode, combined_env) -> Optional[ev.Environment]:
         # mpich@3.0 but with include concrete the mpich@1.0 +debug version from the
         # "external_test" environment will be used.
         _config = {
-            "concretizer": {"reuse": {"from": [{"type": {"environment": "external_test"}}]}},
+            "concretizer": {"reuse": {"from": [{"type": "environment", "ref": "external_test"}]}},
             "packages": {"mpich": {"require": ["+debug"]}},
         }
     elif reuse_mode == "from_environment_raise":
         _config = {
-            "concretizer": {"reuse": {"from": [{"type": {"environment": "not-a-real-env"}}]}}
+            "concretizer": {"reuse": {"from": [{"type": "environment", "ref": "not-a-real-env"}]}}
         }
     # Disable unification in these tests to avoid confusing reuse due to unification using an
     # include concrete spec vs reuse due to the reuse configuration

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1941,7 +1941,7 @@ def configure_reuse(reuse_mode, combined_env) -> Optional[ev.Environment]:
     elif reuse_mode == "from_environment":
         _config = {"concretizer": {"reuse": {"from": [{"type": "environment"}]}}}
     elif reuse_mode == "from_environment_test1":
-        _config = {"concretizer": {"reuse": {"from": [{"type": "environment", "ref": "test1"}]}}}
+        _config = {"concretizer": {"reuse": {"from": [{"type": "environment", "path": "test1"}]}}}
     elif reuse_mode == "from_environment_external_test":
         # Create a new environment called external_test that enables the "debug"
         # The default is "~debug"
@@ -1957,12 +1957,12 @@ def configure_reuse(reuse_mode, combined_env) -> Optional[ev.Environment]:
         # mpich@3.0 but with include concrete the mpich@1.0 +debug version from the
         # "external_test" environment will be used.
         _config = {
-            "concretizer": {"reuse": {"from": [{"type": "environment", "ref": "external_test"}]}},
+            "concretizer": {"reuse": {"from": [{"type": "environment", "path": "external_test"}]}},
             "packages": {"mpich": {"require": ["+debug"]}},
         }
     elif reuse_mode == "from_environment_raise":
         _config = {
-            "concretizer": {"reuse": {"from": [{"type": "environment", "ref": "not-a-real-env"}]}}
+            "concretizer": {"reuse": {"from": [{"type": "environment", "path": "not-a-real-env"}]}}
         }
     # Disable unification in these tests to avoid confusing reuse due to unification using an
     # include concrete spec vs reuse due to the reuse configuration


### PR DESCRIPTION
Refers to https://github.com/spack/spack/pull/45139#issuecomment-2450843931

Currently, the schema reads:
```yaml
  from:
    - type: 
        environment: path_or_name
```
but this can't be extended easily to other types, e.g. to buildcaches, without duplicating the extension keys. Use instead:
```yaml
  from:
    - type: environment 
      path: path_or_name
```
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
