### PR TITLE
geant4-data: symlink only specific data dirs

### DIFF
--- a/var/spack/repos/builtin/packages/g4abla/package.py
+++ b/var/spack/repos/builtin/packages/g4abla/package.py
@@ -24,13 +24,18 @@ class G4abla(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))
-        install_path = join_path(prefix.share, "data", "G4ABLA{0}".format(self.version))
+        install_path = join_path(prefix.share, "data", self.g4datasetname)
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(self.prefix.share, "data", "G4ABLA{0}".format(self.version))
+        install_path = join_path(self.prefix.share, "data", self.g4datasetname)
         env.set("G4ABLADATA", install_path)
 
     def url_for_version(self, version):
         """Handle version string."""
         return "http://geant4-data.web.cern.ch/geant4-data/datasets/G4ABLA.%s.tar.gz" % version
+
+    @property
+    def g4datasetname(self):
+        spec = self.spec
+        return "G4ABLA{0}".format(spec.version)

--- a/var/spack/repos/builtin/packages/g4emlow/package.py
+++ b/var/spack/repos/builtin/packages/g4emlow/package.py
@@ -35,13 +35,18 @@ class G4emlow(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))
-        install_path = join_path(prefix.share, "data", "G4EMLOW{0}".format(self.version))
+        install_path = join_path(prefix.share, "data", self.g4datasetname)
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(self.prefix.share, "data", "G4EMLOW{0}".format(self.version))
+        install_path = join_path(self.prefix.share, "data", self.g4datasetname)
         env.set("G4LEDATA", install_path)
 
     def url_for_version(self, version):
         """Handle version string."""
         return "https://geant4-data.web.cern.ch/geant4-data/datasets/G4EMLOW.%s.tar.gz" % version
+
+    @property
+    def g4datasetname(self):
+        spec = self.spec
+        return "G4EMLOW{0}".format(spec.version)

--- a/var/spack/repos/builtin/packages/g4ensdfstate/package.py
+++ b/var/spack/repos/builtin/packages/g4ensdfstate/package.py
@@ -25,11 +25,11 @@ class G4ensdfstate(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))
-        install_path = join_path(prefix.share, "data", "G4ENSDFSTATE{0}".format(self.version))
+        install_path = join_path(prefix.share, "data", self.g4datasetname)
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(self.prefix.share, "data", "G4ENSDFSTATE{0}".format(self.version))
+        install_path = join_path(self.prefix.share, "data", self.g4datasetname)
         env.set("G4ENSDFSTATEDATA", install_path)
 
     def url_for_version(self, version):
@@ -37,3 +37,8 @@ class G4ensdfstate(Package):
         return (
             "http://geant4-data.web.cern.ch/geant4-data/datasets/G4ENSDFSTATE.%s.tar.gz" % version
         )
+
+    @property
+    def g4datasetname(self):
+        spec = self.spec
+        return "G4ENSDFSTATE{0}".format(spec.version)

--- a/var/spack/repos/builtin/packages/g4incl/package.py
+++ b/var/spack/repos/builtin/packages/g4incl/package.py
@@ -25,13 +25,18 @@ class G4incl(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))
-        install_path = join_path(prefix.share, "data", "G4INCL{0}".format(self.version))
+        install_path = join_path(prefix.share, "data", self.g4datasetname)
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(self.prefix.share, "data", "G4INCL{0}".format(self.version))
+        install_path = join_path(self.prefix.share, "data", self.g4datasetname)
         env.set("G4INCLDATA", install_path)
 
     def url_for_version(self, version):
         """Handle version string."""
         return "http://geant4-data.web.cern.ch/geant4-data/datasets/G4INCL.%s.tar.gz" % version
+
+    @property
+    def g4datasetname(self):
+        spec = self.spec
+        return "G4INCL{0}".format(spec.version)

--- a/var/spack/repos/builtin/packages/g4ndl/package.py
+++ b/var/spack/repos/builtin/packages/g4ndl/package.py
@@ -25,13 +25,18 @@ class G4ndl(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))
-        install_path = join_path(prefix.share, "data", "G4NDL{0}".format(self.version))
+        install_path = join_path(prefix.share, "data", self.g4datasetname)
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(self.prefix.share, "data", "G4NDL{0}".format(self.version))
+        install_path = join_path(self.prefix.share, "data", self.g4datasetname)
         env.set("G4NEUTRONHPDATA", install_path)
 
     def url_for_version(self, version):
         """Handle version string."""
         return "http://geant4-data.web.cern.ch/geant4-data/datasets/G4NDL.%s.tar.gz" % version
+
+    @property
+    def g4datasetname(self):
+        spec = self.spec
+        return "G4NDL{0}".format(spec.version)

--- a/var/spack/repos/builtin/packages/g4neutronxs/package.py
+++ b/var/spack/repos/builtin/packages/g4neutronxs/package.py
@@ -24,11 +24,11 @@ class G4neutronxs(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))
-        install_path = join_path(prefix.share, "data", "G4NEUTRONXS{0}".format(self.version))
+        install_path = join_path(prefix.share, "data", self.g4datasetname)
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(self.prefix.share, "data", "G4NEUTRONXS{0}".format(self.version))
+        install_path = join_path(self.prefix.share, "data", self.g4datasetname)
         env.set("G4NEUTRONXSDATA", install_path)
 
     def url_for_version(self, version):
@@ -36,3 +36,8 @@ class G4neutronxs(Package):
         return (
             "http://geant4-data.web.cern.ch/geant4-data/datasets/G4NEUTRONXS.%s.tar.gz" % version
         )
+
+    @property
+    def g4datasetname(self):
+        spec = self.spec
+        return "G4NEUTRONXS{0}".format(spec.version)

--- a/var/spack/repos/builtin/packages/g4nudexlib/package.py
+++ b/var/spack/repos/builtin/packages/g4nudexlib/package.py
@@ -23,13 +23,18 @@ class G4nudexlib(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))
-        install_path = join_path(prefix.share, "data", "G4NUDEXLIB{0}".format(self.version))
+        install_path = join_path(prefix.share, "data", self.g4datasetname)
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(self.prefix.share, "data", "G4NUDEXLIB{0}".format(self.version))
+        install_path = join_path(self.prefix.share, "data", self.g4datasetname)
         env.set("G4NUDEXLIBDATA", install_path)
 
     def url_for_version(self, version):
         """Handle version string."""
         return "http://geant4-data.web.cern.ch/geant4-data/datasets/G4NUDEXLIB.%s.tar.gz" % version
+
+    @property
+    def g4datasetname(self):
+        spec = self.spec
+        return "G4NUDEXLIB{0}".format(spec.version)

--- a/var/spack/repos/builtin/packages/g4particlexs/package.py
+++ b/var/spack/repos/builtin/packages/g4particlexs/package.py
@@ -28,11 +28,11 @@ class G4particlexs(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))
-        install_path = join_path(prefix.share, "data", "G4PARTICLEXS{0}".format(self.version))
+        install_path = join_path(prefix.share, "data", self.g4datasetname)
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(self.prefix.share, "data", "G4PARTICLEXS{0}".format(self.version))
+        install_path = join_path(self.prefix.share, "data", self.g4datasetname)
         env.set("G4PARTICLEXSDATA", install_path)
 
     def url_for_version(self, version):
@@ -40,3 +40,8 @@ class G4particlexs(Package):
         return (
             "http://geant4-data.web.cern.ch/geant4-data/datasets/G4PARTICLEXS.%s.tar.gz" % version
         )
+
+    @property
+    def g4datasetname(self):
+        spec = self.spec
+        return "G4PARTICLEXS{0}".format(spec.version)

--- a/var/spack/repos/builtin/packages/g4photonevaporation/package.py
+++ b/var/spack/repos/builtin/packages/g4photonevaporation/package.py
@@ -27,13 +27,11 @@ class G4photonevaporation(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))
-        install_path = join_path(prefix.share, "data", "PhotonEvaporation{0}".format(self.version))
+        install_path = join_path(prefix.share, "data", self.g4datasetname)
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(
-            self.prefix.share, "data", "PhotonEvaporation{0}".format(self.version)
-        )
+        install_path = join_path(self.prefix.share, "data", self.g4datasetname)
         env.set("G4LEVELGAMMADATA", install_path)
 
     def url_for_version(self, version):
@@ -42,3 +40,8 @@ class G4photonevaporation(Package):
             "http://geant4-data.web.cern.ch/geant4-data/datasets/G4PhotonEvaporation.%s.tar.gz"
             % version
         )
+
+    @property
+    def g4datasetname(self):
+        spec = self.spec
+        return "PhotonEvaporation{0}".format(spec.version)

--- a/var/spack/repos/builtin/packages/g4pii/package.py
+++ b/var/spack/repos/builtin/packages/g4pii/package.py
@@ -22,13 +22,18 @@ class G4pii(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))
-        install_path = join_path(prefix.share, "data", "G4PII{0}".format(self.version))
+        install_path = join_path(prefix.share, "data", self.g4datasetname)
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(self.prefix.share, "data", "G4PII{0}".format(self.version))
+        install_path = join_path(self.prefix.share, "data", self.g4datasetname)
         env.set("G4PIIDATA", install_path)
 
     def url_for_version(self, version):
         """Handle version string."""
         return "https://geant4-data.web.cern.ch/geant4-data/datasets/G4PII.1.3.tar.gz" % version
+
+    @property
+    def g4datasetname(self):
+        spec = self.spec
+        return "G4PII{0}".format(spec.version)

--- a/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
+++ b/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
@@ -27,13 +27,11 @@ class G4radioactivedecay(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))
-        install_path = join_path(prefix.share, "data", "RadioactiveDecay{0}".format(self.version))
+        install_path = join_path(prefix.share, "data", self.g4datasetname)
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(
-            self.prefix.share, "data", "RadioactiveDecay{0}".format(self.version)
-        )
+        install_path = join_path(self.prefix.share, "data", self.g4datasetname)
         env.set("G4RADIOACTIVEDATA", install_path)
 
     def url_for_version(self, version):
@@ -42,3 +40,8 @@ class G4radioactivedecay(Package):
             "http://geant4-data.web.cern.ch/geant4-data/datasets/G4RadioactiveDecay.%s.tar.gz"
             % version
         )
+
+    @property
+    def g4datasetname(self):
+        spec = self.spec
+        return "RadioactiveDecay{0}".format(spec.version)

--- a/var/spack/repos/builtin/packages/g4realsurface/package.py
+++ b/var/spack/repos/builtin/packages/g4realsurface/package.py
@@ -25,11 +25,11 @@ class G4realsurface(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))
-        install_path = join_path(prefix.share, "data", "RealSurface{0}".format(self.version))
+        install_path = join_path(prefix.share, "data", self.g4datasetname)
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(self.prefix.share, "data", "RealSurface{0}".format(self.version))
+        install_path = join_path(self.prefix.share, "data", self.g4datasetname)
         env.set("G4REALSURFACEDATA", install_path)
 
     def url_for_version(self, version):
@@ -39,3 +39,8 @@ class G4realsurface(Package):
                 "G4" if version > Version("1.0") else "", version
             )
         )
+
+    @property
+    def g4datasetname(self):
+        spec = self.spec
+        return "RealSurface{0}".format(spec.version)

--- a/var/spack/repos/builtin/packages/g4saiddata/package.py
+++ b/var/spack/repos/builtin/packages/g4saiddata/package.py
@@ -23,13 +23,18 @@ class G4saiddata(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))
-        install_path = join_path(prefix.share, "data", "G4SAIDDATA{0}".format(self.version))
+        install_path = join_path(prefix.share, "data", self.g4datasetname)
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(self.prefix.share, "data", "G4SAIDDATA{0}".format(self.version))
+        install_path = join_path(self.prefix.share, "data", self.g4datasetname)
         env.set("G4SAIDXSDATA", install_path)
 
     def url_for_version(self, version):
         """Handle version string."""
         return "http://geant4-data.web.cern.ch/geant4-data/datasets/G4SAIDDATA.%s.tar.gz" % version
+
+    @property
+    def g4datasetname(self):
+        spec = self.spec
+        return "G4SAIDDATA{0}".format(spec.version)

--- a/var/spack/repos/builtin/packages/g4tendl/package.py
+++ b/var/spack/repos/builtin/packages/g4tendl/package.py
@@ -24,13 +24,18 @@ class G4tendl(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))
-        install_path = join_path(prefix.share, "data", "G4TENDL{0}".format(self.version))
+        install_path = join_path(prefix.share, "data", self.g4datasetname)
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(self.prefix.share, "data", "G4TENDL{0}".format(self.version))
+        install_path = join_path(self.prefix.share, "data", self.g4datasetname)
         env.set("G4PARTICLEHPDATA", install_path)
 
     def url_for_version(self, version):
         """Handle version string."""
         return "http://geant4-data.web.cern.ch/geant4-data/datasets/G4TENDL.%s.tar.gz" % version
+
+    @property
+    def g4datasetname(self):
+        spec = self.spec
+        return "G4TENDL{0}".format(spec.version)

--- a/var/spack/repos/builtin/packages/g4urrpt/package.py
+++ b/var/spack/repos/builtin/packages/g4urrpt/package.py
@@ -23,13 +23,18 @@ class G4urrpt(Package):
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, "data"))
-        install_path = join_path(prefix.share, "data", "G4URRPT{0}".format(self.version))
+        install_path = join_path(prefix.share, "data", self.g4datasetname)
         install_tree(self.stage.source_path, install_path)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        install_path = join_path(self.prefix.share, "data", "G4URRPT{0}".format(self.version))
+        install_path = join_path(self.prefix.share, "data", self.g4datasetname)
         env.set("G4URRPTDATA", install_path)
 
     def url_for_version(self, version):
         """Handle version string."""
         return "http://geant4-data.web.cern.ch/geant4-data/datasets/G4URRPT.%s.tar.gz" % version
+
+    @property
+    def g4datasetname(self):
+        spec = self.spec
+        return "G4URRPT{0}".format(spec.version)

--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import glob
 import os
 
 from spack.package import *
@@ -204,5 +203,11 @@ class Geant4Data(BundlePackage):
     def install(self, spec, prefix):
         with working_dir(self.datadir, create=True):
             for s in spec.dependencies():
-                for d in glob.glob("{0}/data/*".format(s.prefix.share)):
-                    os.symlink(d, os.path.basename(d))
+                if not s.name.startswith("g4"):
+                    continue
+
+                if not hasattr(s.package, "g4datasetname"):
+                    raise InstallError(f"Dependency `{s.name}` does not expose `g4datasetname`")
+
+                d = "{0}/data/{1}".format(s.prefix.share, s.package.g4datasetname)
+                os.symlink(d, os.path.basename(d))


### PR DESCRIPTION
Currently, the `geant4-data` spec creates symlink to all of its dependencies, and it does so by globbing their `share/` directories. This works very well for the way Spack installs these, but it doesn't work for anybody wanting to use e.g. the Geant4 data on CVMFS. See pull request #47298. This commit changes the way the `geant4-data` spec works. It no longer blindly globs directories and makes symlinks, but it asks its dependencies specifically for the name of their data directory. This should allow us to use Spack to use the CVMFS installations as externals.