### PR TITLE
Fix view creation on macOS (case-insensitive file system)

### DIFF
--- a/lib/spack/llnl/util/link_tree.py
+++ b/lib/spack/llnl/util/link_tree.py
@@ -94,7 +94,7 @@ class SourceMergeVisitor(BaseDirectoryVisitor):
 
     def _in_directories(self, proj_rel_path: str) -> bool:
         """
-        Check if a path is already in the direcrtory list
+        Check if a path is already in the directory list
         """
         return self._normalize_path(proj_rel_path) in self.directories_normalized
 

--- a/lib/spack/llnl/util/link_tree.py
+++ b/lib/spack/llnl/util/link_tree.py
@@ -76,7 +76,7 @@ class SourceMergeVisitor(BaseDirectoryVisitor):
         # and can run mkdir in order.
         self.directories: Dict[str, Tuple[str, str]] = {}
 
-        # If the visitor is configure to normalize paths, keep a map of
+        # If the visitor is configured to normalize paths, keep a map of
         # normalized path to: original path, root directory + relative path
         self._directories_normalized: Dict[str, Tuple[str, str, str]] = {}
 
@@ -84,7 +84,7 @@ class SourceMergeVisitor(BaseDirectoryVisitor):
         # are guaranteed to be grouped by src_root in the order they were visited.
         self.files: Dict[str, Tuple[str, str]] = {}
 
-        # If the visitor is configure to normalize paths, keep a map of
+        # If the visitor is configured to normalize paths, keep a map of
         # normalized path to: original path, root directory + relative path
         self._files_normalized: Dict[str, Tuple[str, str, str]] = {}
 

--- a/lib/spack/llnl/util/link_tree.py
+++ b/lib/spack/llnl/util/link_tree.py
@@ -7,7 +7,7 @@
 import filecmp
 import os
 import shutil
-from typing import Callable, Dict, List, Optional, Set, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import BaseDirectoryVisitor, mkdirp, touch, traverse_tree

--- a/lib/spack/llnl/util/link_tree.py
+++ b/lib/spack/llnl/util/link_tree.py
@@ -6,8 +6,8 @@
 
 import filecmp
 import os
-import sys
 import shutil
+import sys
 from typing import Callable, Dict, List, Optional, Set, Tuple
 
 import llnl.util.tty as tty

--- a/lib/spack/llnl/util/link_tree.py
+++ b/lib/spack/llnl/util/link_tree.py
@@ -337,22 +337,8 @@ class DestinationMergeVisitor(BaseDirectoryVisitor):
         be seen as files; we should not accidentally merge
         source dir with a symlinked dest dir.
         """
-        # Always conflict
-        if self.src._in_directories(rel_path):
-            _, src_a_root, src_a_relpath = self.src._directory(rel_path)
-            self.src.fatal_conflicts.append(
-                MergeConflict(
-                    rel_path, os.path.join(src_a_root, src_a_relpath), os.path.join(root, rel_path)
-                )
-            )
 
-        if self.src._in_files(rel_path):
-            _, src_a_root, src_a_relpath = self.src._file(rel_path)
-            self.src.fatal_conflicts.append(
-                MergeConflict(
-                    rel_path, os.path.join(src_a_root, src_a_relpath), os.path.join(root, rel_path)
-                )
-            )
+        self.visit_file(root, rel_path, depth)
 
         # Never descend into symlinked target dirs.
         return False

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -708,7 +708,13 @@ class SimpleFilesystemView(FilesystemView):
         def skip_list(file):
             return os.path.basename(file) == spack.store.STORE.layout.metadata_dir
 
-        visitor = SourceMergeVisitor(ignore=skip_list)
+        # Determine if the root is on a case-insensitive filesystem
+        sentinel_name = ".sentinel"
+        with open(os.path.join(self._root, sentinel_name), "w") as f:
+            f.write("sentinel")
+        normalize_paths = os.path.exists(os.path.join(self._root, sentinel_name.upper()))
+
+        visitor = SourceMergeVisitor(ignore=skip_list, normalize_paths=normalize_paths)
 
         # Gather all the directories to be made and files to be linked
         for spec in specs:

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -892,6 +892,4 @@ class ConflictingProjectionsError(SpackError):
 
 def is_folder_on_case_insensitive_filesystem(path: str) -> bool:
     with tempfile.NamedTemporaryFile(dir=path, prefix=".sentinel") as sentinel:
-        return os.path.exists(
-            os.path.join(path, os.path.join(path, os.path.basename(sentinel.name).upper()))
-        )
+        return os.path.exists(os.path.join(path, os.path.basename(sentinel.name).upper()))

--- a/lib/spack/spack/test/llnl/util/link_tree.py
+++ b/lib/spack/spack/test/llnl/util/link_tree.py
@@ -13,8 +13,8 @@ from llnl.util.filesystem import mkdirp, touchp, visit_directory_tree, working_d
 from llnl.util.link_tree import DestinationMergeVisitor, LinkTree, SourceMergeVisitor
 from llnl.util.symlink import _windows_can_symlink, islink, readlink, symlink
 
-from spack.stage import Stage
 from spack.filesystem_view import is_folder_on_case_insensitive_filesystem
+from spack.stage import Stage
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/llnl/util/link_tree.py
+++ b/lib/spack/spack/test/llnl/util/link_tree.py
@@ -403,6 +403,7 @@ def test_source_merge_visitor_does_deals_with_dangling_symlinks(tmp_path: pathli
 # tailor too much to the implementaion of
 # is_folder_on_case_insensitive_filesystem (should be a detail)
 def _iter_path_components(path: str):
+    drive, path = os.path.splitdrive(path)
     if path.startswith(os.sep):
         root = os.sep
         path = path[len(os.sep) :]
@@ -410,7 +411,7 @@ def _iter_path_components(path: str):
         root = ""
     parts = path.split(os.sep)
     for i in range(len(parts)):
-        yield os.path.split(root + os.path.join(*parts[: i + 1]))
+        yield os.path.split(drive + root + os.path.join(*parts[: i + 1]))
 
 
 def _mock_exists_case_insensitive(path: str):

--- a/lib/spack/spack/test/llnl/util/link_tree.py
+++ b/lib/spack/spack/test/llnl/util/link_tree.py
@@ -450,10 +450,10 @@ def test_source_visitor_path_normalization(tmp_path: pathlib.Path, monkeypatch):
     file = os.path.join(src_a, "file")
     FILE = os.path.join(src_b, "FILE")
 
-    with open(file, "w") as f:
+    with open(file, "wb"):
         pass
 
-    with open(FILE, "w") as f:
+    with open(FILE, "wb"):
         pass
 
     assert os.path.exists(file)

--- a/lib/spack/spack/test/llnl/util/link_tree.py
+++ b/lib/spack/spack/test/llnl/util/link_tree.py
@@ -486,9 +486,7 @@ def test_source_visitor_path_normalization(tmp_path: pathlib.Path, monkeypatch):
     # file conflict with os.path.samefile reporting it's NOT the same file
     a = SourceMergeVisitor(normalize_paths=True)
     a.visit_file(src, "file", 0)
-    with monkeypatch.context() as m:
-        # m.setattr(os.path, "samefile", lambda a, b: True)
-        a.visit_file(src, "FILE", 0)
+    a.visit_file(src, "FILE", 0)
     assert a.files
     assert len(a.files) == 1
     # first file wins

--- a/lib/spack/spack/test/llnl/util/link_tree.py
+++ b/lib/spack/spack/test/llnl/util/link_tree.py
@@ -397,6 +397,8 @@ def test_source_merge_visitor_does_deals_with_dangling_symlinks(tmp_path: pathli
 
     # The first file encountered should be listed.
     assert visitor.files == {str(tmp_path / "view" / "file"): (str(tmp_path / "dir_a"), "file")}
+
+
 # Mocks for the os.path.exists function. Implemented fairly generically to not
 # tailor too much to the implementaion of
 # is_folder_on_case_insensitive_filesystem (should be a detail)

--- a/lib/spack/spack/test/llnl/util/link_tree.py
+++ b/lib/spack/spack/test/llnl/util/link_tree.py
@@ -403,10 +403,14 @@ def test_source_merge_visitor_does_deals_with_dangling_symlinks(tmp_path: pathli
 # tailor too much to the implementaion of
 # is_folder_on_case_insensitive_filesystem (should be a detail)
 def _iter_path_components(path: str):
-    drive, root, path = os.path.splitroot(path)
+    if path.startswith(os.sep):
+        root = os.sep
+        path = path[len(os.sep) :]
+    else:
+        root = ""
     parts = path.split(os.sep)
     for i in range(len(parts)):
-        yield os.path.split(drive + root + os.path.join(*parts[: i + 1]))
+        yield os.path.split(root + os.path.join(*parts[: i + 1]))
 
 
 def _mock_exists_case_insensitive(path: str):

--- a/lib/spack/spack/test/llnl/util/link_tree.py
+++ b/lib/spack/spack/test/llnl/util/link_tree.py
@@ -583,7 +583,6 @@ def test_destination_visitor_path_normalization(tmp_path: pathlib.Path):
 
     dest_visitor = DestinationMergeVisitor(src_visitor)
     dest_visitor.visit_file(dest, "FILE", 0)
-    # not a conflict, since normalization is off
     assert len(dest_visitor.src.files) == 1
     assert len(dest_visitor.src.directories) == 0
     assert "file" in dest_visitor.src.files


### PR DESCRIPTION
I've noticed that Spack does not correctly handle the fact that on macOS, filesystems are (usually) case-insensitive (but case-preserving).
During view creation, Spack walks the source directories of all specs and collects and deduplicates folders and files to be combined into a view. However, on macOS this can currently fail, if a folder shows up multiple times with different cases. Spack will then issue an unconditional `os.mkdir` which fails with an `OSErrror.`

I've encountered this error with the combination of the `dd4hep` and the `root` packages.

- `dd4hep` will arrange for a folder `include/ROOT` to be installed
- `root` will arrange for a folder `include/root` to be installed.

The `os.mkdir` for the second directory will fail.

I see two solutions to this:

1. Make the `os.mkdir` call conditional on whether the target folder already exists. On non-macOS platforms, in the above scenario, that would cause both `include/ROOT` and `include/root` to be created.
2. Teach the `SourceMergeVisitor` visitor to (optionally) *normalize* the paths that it checks to see if a directory (or file for. that matter) already exists.

This PR implements option 2.

The logic in this PR originally used

```python
sys.platform == "darwin"
```

to determine whether to do this or not. However, this is not correct. The case-sensitivity is a filesystem property, which is on by default in APFS, but can be turned off, for example in a separate logical volume, which people have been known to do.

This was changed to empirically check if the root of the view is on a case-insensitive filesystem, by writing to a lower case file and then seeing if it exists when asking for the upper case name.

---

Note: I think it's out-of-scope for this PR whether or not these two folders should be installed by their respective packages and only differ by case. If I build these packages using plain CMake, I will end up with a merged folder on macOS, where the actual case of the directory depends on the order they get installed. I believe Spack should reproduce this.