### PR TITLE
py-flask-compress: add v1.14

### DIFF
--- a/var/spack/repos/builtin/packages/py-flask-compress/package.py
+++ b/var/spack/repos/builtin/packages/py-flask-compress/package.py
@@ -15,7 +15,11 @@ class PyFlaskCompress(PythonPackage):
 
     license("MIT")
 
+    version("1.14", sha256="e46528f37b91857012be38e24e65db1a248662c3dc32ee7808b5986bf1d123ee")
     version("1.4.0", sha256="468693f4ddd11ac6a41bca4eb5f94b071b763256d54136f77957cfee635badb3")
 
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@0.42:", type="build", when="@1.10:")
+    depends_on("py-setuptools-scm@3.4: +toml", type="build", when="@1.10:")
     depends_on("py-flask@0.9:", type=("build", "run"))
+    depends_on("py-brotli", type="run", when="@1.5:")


### PR DESCRIPTION
This PR adds `py-flask-compress`, v1.14 ([`pyproject.toml`](https://github.com/colour-science/flask-compress/commits/v1.14/pyproject.toml)). This adds brotli support and now uses setuptools-scm. No zstd support added here. No attempt to pick up 1.17 yet (not automatically added and likely requires a url_for_version to handle some dash/underscore switch again).

Test build:
```
==> Installing py-flask-compress-1.14-eafykwjpfvmrb7h3jkcx6sdfzqygx3pz [52/52]
==> No binary for py-flask-compress-1.14-eafykwjpfvmrb7h3jkcx6sdfzqygx3pz found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/e4/e46528f37b91857012be38e24e65db1a248662c3dc32ee7808b5986bf1d123ee.tar.gz
==> No patches needed for py-flask-compress
==> py-flask-compress: Executing phase: 'install'
==> py-flask-compress: Successfully installed py-flask-compress-1.14-eafykwjpfvmrb7h3jkcx6sdfzqygx3pz
  Stage: 0.03s.  Install: 3.52s.  Post-install: 1.25s.  Total: 5.24s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/py-flask-compress-1.14-eafykwjpfvmrb7h3jkcx6sdfzqygx3pz
```