### PR TITLE
py-flask-cors: add v4.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-flask-cors/package.py
+++ b/var/spack/repos/builtin/packages/py-flask-cors/package.py
@@ -16,6 +16,7 @@ class PyFlaskCors(PythonPackage):
 
     license("MIT")
 
+    version("4.0.0", sha256="f268522fcb2f73e2ecdde1ef45e2fd5c71cc48fe03cffb4b441c6d1b40684eb0")
     version("3.0.10", sha256="b60839393f3b84a0f3746f6cdca56c1ad7426aa738b70d6c61375857823181de")
 
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
This PR adds `py-flask-cors`, v4.0.0 ([`requirements.txt`](https://github.com/corydolphin/flask-cors/blob/main/requirements.txt)).

Test build:
```
==> Installing py-flask-cors-4.0.0-slwyz4ecc72hwl5bfgv277s4zprwahjk [36/36]
==> No binary for py-flask-cors-4.0.0-slwyz4ecc72hwl5bfgv277s4zprwahjk found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/f2/f268522fcb2f73e2ecdde1ef45e2fd5c71cc48fe03cffb4b441c6d1b40684eb0.tar.gz
==> No patches needed for py-flask-cors
==> py-flask-cors: Executing phase: 'install'
==> py-flask-cors: Successfully installed py-flask-cors-4.0.0-slwyz4ecc72hwl5bfgv277s4zprwahjk
  Stage: 0.04s.  Install: 3.87s.  Post-install: 1.46s.  Total: 5.97s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/py-flask-cors-4.0.0-slwyz4ecc72hwl5bfgv277s4zprwahjk
```
