### PR TITLE
asp.py: fix type hinting for mypy-1.13

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3083,13 +3083,9 @@ class CompilerParser:
                 )
                 continue
 
-            target = c.target if c.target != "any" else None
+            target = str(c.target) if c.target != "any" else ""
             candidate = KnownCompiler(
-                spec=c.spec,
-                os=c.operating_system,
-                target=str(target),
-                available=True,
-                compiler_obj=c,
+                spec=c.spec, os=c.operating_system, target=target, available=True, compiler_obj=c
             )
             if candidate in self.compilers:
                 warnings.warn(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3085,7 +3085,7 @@ class CompilerParser:
 
             target = c.target if c.target != "any" else None
             candidate = KnownCompiler(
-                spec=c.spec, os=c.operating_system, target=target, available=True, compiler_obj=c
+                spec=c.spec, os=c.operating_system, target=str(target), available=True, compiler_obj=c
             )
             if candidate in self.compilers:
                 warnings.warn(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3085,7 +3085,11 @@ class CompilerParser:
 
             target = c.target if c.target != "any" else None
             candidate = KnownCompiler(
-                spec=c.spec, os=c.operating_system, target=str(target), available=True, compiler_obj=c
+                spec=c.spec,
+                os=c.operating_system,
+                target=str(target),
+                available=True,
+                compiler_obj=c,
             )
             if candidate in self.compilers:
                 warnings.warn(


### PR DESCRIPTION
This PR adds an explicit conversion of `compiler.target` to string before passing into `KnownCompiler` which expects target to be string.

This PR fixes the mypy upgrade in https://github.com/spack/spack/pull/47173, where these two commits have been cherry-picked from.