### PR TITLE
minizip: add v1.3.1 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/minizip/package.py
+++ b/var/spack/repos/builtin/packages/minizip/package.py
@@ -17,7 +17,9 @@ class Minizip(AutotoolsPackage):
     version("1.3.1", sha256="9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23")
     with default_args(deprecated=True):
         # https://nvd.nist.gov/vuln/detail/CVE-2022-37434
-        version("1.2.11", sha256="c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1")
+        version(
+            "1.2.11", sha256="c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
+        )
 
     depends_on("c", type="build")
 

--- a/var/spack/repos/builtin/packages/minizip/package.py
+++ b/var/spack/repos/builtin/packages/minizip/package.py
@@ -14,10 +14,12 @@ class Minizip(AutotoolsPackage):
 
     license("Zlib")
 
-    version("1.2.11", sha256="c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1")
+    version("1.3.1", sha256="9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2022-37434
+        version("1.2.11", sha256="c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
 
     configure_directory = "contrib/minizip"
 
@@ -28,8 +30,9 @@ class Minizip(AutotoolsPackage):
     depends_on("zlib-api")
 
     # error: implicit declaration of function 'mkdir' is invalid in C99
-    patch("implicit.patch", when="%apple-clang@12:")
-    patch("implicit.patch", when="%gcc@7.3.0:")
+    with when("@:1.2.11"):
+        patch("implicit.patch", when="%apple-clang@12:")
+        patch("implicit.patch", when="%gcc@7.3.0:")
 
     # statically link to libz.a
     # https://github.com/Homebrew/homebrew-core/blob/master/Formula/minizip.rb


### PR DESCRIPTION
This PR adds `minizip`, v1.3.1, which fixes CVE-2022-37434 (and some others). Older version deprecated.

This PR does not aim to fix the `minizip` package. The `minizip` package compiles and builds `zlib` all over again, but then still links against the `zlib-api` package that is pulled in as a dependency (i.e. potentially `zlib-ng`).

Test build:
```
==> Installing minizip-1.3.1-q3qiqkflvyyav7cno4pu2ceu2gp5g62x [18/18]
==> No binary for minizip-1.3.1-q3qiqkflvyyav7cno4pu2ceu2gp5g62x found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/9a/9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23.tar.gz
==> No patches needed for minizip
==> minizip: Executing phase: 'autoreconf'
==> minizip: Executing phase: 'configure'
==> minizip: Executing phase: 'build'
==> minizip: Executing phase: 'install'
==> minizip: Successfully installed minizip-1.3.1-q3qiqkflvyyav7cno4pu2ceu2gp5g62x
  Stage: 0.46s.  Autoreconf: 6.73s.  Configure: 1.83s.  Build: 1.79s.  Install: 0.14s.  Post-install: 0.10s.  Total: 11.45s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/minizip-1.3.1-q3qiqkflvyyav7cno4pu2ceu2gp5g62x
```