### PR TITLE
spack.concretize: add type-hints, remove kwargs

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -214,6 +214,7 @@ nitpick_ignore = [
     # Spack classes that intersphinx is unable to resolve
     ("py:class", "spack.version.StandardVersion"),
     ("py:class", "spack.spec.DependencySpec"),
+    ("py:class", "spack.spec.ArchSpec"),
     ("py:class", "spack.spec.InstallStatus"),
     ("py:class", "spack.spec.SpecfileReaderBase"),
     ("py:class", "spack.install_test.Pb"),

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -194,7 +194,7 @@ def _concretize_spec_pairs(to_concretize, tests=False):
     elif unify == "when_possible":
         concretize_method = spack.concretize.concretize_together_when_possible
 
-    concretized = concretize_method(*to_concretize, tests=tests)
+    concretized = concretize_method(to_concretize, tests=tests)
     return [concrete for _, concrete in concretized]
 
 

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -8,7 +8,6 @@
 import sys
 import time
 from contextlib import contextmanager
-from itertools import chain
 from typing import Tuple
 
 import llnl.util.tty as tty
@@ -34,37 +33,6 @@ def enable_compiler_existence_check():
     CHECK_COMPILER_EXISTENCE, saved = True, CHECK_COMPILER_EXISTENCE
     yield
     CHECK_COMPILER_EXISTENCE = saved
-
-
-def find_spec(spec, condition, default=None):
-    """Searches the dag from spec in an intelligent order and looks
-    for a spec that matches a condition"""
-    # First search parents, then search children
-    deptype = ("build", "link")
-    dagiter = chain(
-        spec.traverse(direction="parents", deptype=deptype, root=False),
-        spec.traverse(direction="children", deptype=deptype, root=False),
-    )
-    visited = set()
-    for relative in dagiter:
-        if condition(relative):
-            return relative
-        visited.add(id(relative))
-
-    # Then search all other relatives in the DAG *except* spec
-    for relative in spec.root.traverse(deptype="all"):
-        if relative is spec:
-            continue
-        if id(relative) in visited:
-            continue
-        if condition(relative):
-            return relative
-
-    # Finally search spec itself.
-    if condition(spec):
-        return spec
-
-    return default  # Nothing matched the condition; return default.
 
 
 def concretize_specs_together(*abstract_specs, **kwargs):

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -44,7 +44,7 @@ def concretize_specs_together(
     """Given a number of specs as input, tries to concretize them together.
 
     Args:
-        *abstract_specs: abstract specs to be concretized
+        abstract_specs: abstract specs to be concretized
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
     """
@@ -62,7 +62,7 @@ def concretize_together(
     """Given a number of specs as input, tries to concretize them together.
 
     Args:
-        *spec_list: list of tuples to concretize. First entry is abstract spec, second entry is
+        spec_list: list of tuples to concretize. First entry is abstract spec, second entry is
             already concrete spec or None if not yet concretized
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
@@ -82,7 +82,7 @@ def concretize_together_when_possible(
     "to the extent possible".
 
     Args:
-        *spec_list: list of tuples to concretize. First entry is abstract spec, second entry is
+        spec_list: list of tuples to concretize. First entry is abstract spec, second entry is
             already concrete spec or None if not yet concretized
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
@@ -114,7 +114,7 @@ def concretize_separately(
     """Concretizes the input specs separately from each other.
 
     Args:
-        *spec_list: list of tuples to concretize. First entry is abstract spec, second entry is
+        spec_list: list of tuples to concretize. First entry is abstract spec, second entry is
             already concrete spec or None if not yet concretized
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -2,9 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-"""
-(DEPRECATED) Used to contain the code for the original concretizer
-"""
+"""High-level functions to concretize list of specs"""
 import sys
 import time
 from contextlib import contextmanager

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -6,7 +6,7 @@
 import sys
 import time
 from contextlib import contextmanager
-from typing import Iterable, List, Optional, Tuple, Union
+from typing import Iterable, Optional, Sequence, Tuple, Union
 
 import llnl.util.tty as tty
 
@@ -38,7 +38,9 @@ SpecLike = Union[Spec, str]
 TestsType = Union[bool, Iterable[str]]
 
 
-def concretize_specs_together(*abstract_specs: SpecLike, tests: TestsType = False) -> List[Spec]:
+def concretize_specs_together(
+    abstract_specs: Sequence[SpecLike], tests: TestsType = False
+) -> Sequence[Spec]:
     """Given a number of specs as input, tries to concretize them together.
 
     Args:
@@ -54,7 +56,9 @@ def concretize_specs_together(*abstract_specs: SpecLike, tests: TestsType = Fals
     return [s.copy() for s in result.specs]
 
 
-def concretize_together(*spec_list: SpecPair, tests: TestsType = False) -> List[SpecPair]:
+def concretize_together(
+    spec_list: Sequence[SpecPair], tests: TestsType = False
+) -> Sequence[SpecPair]:
     """Given a number of specs as input, tries to concretize them together.
 
     Args:
@@ -65,13 +69,13 @@ def concretize_together(*spec_list: SpecPair, tests: TestsType = False) -> List[
     """
     to_concretize = [concrete if concrete else abstract for abstract, concrete in spec_list]
     abstract_specs = [abstract for abstract, _ in spec_list]
-    concrete_specs = concretize_specs_together(*to_concretize, tests=tests)
+    concrete_specs = concretize_specs_together(to_concretize, tests=tests)
     return list(zip(abstract_specs, concrete_specs))
 
 
 def concretize_together_when_possible(
-    *spec_list: SpecPair, tests: TestsType = False
-) -> List[SpecPair]:
+    spec_list: Sequence[SpecPair], tests: TestsType = False
+) -> Sequence[SpecPair]:
     """Given a number of specs as input, tries to concretize them together to the extent possible.
 
     See documentation for ``unify: when_possible`` concretization for the precise definition of
@@ -104,7 +108,9 @@ def concretize_together_when_possible(
     ]
 
 
-def concretize_separately(*spec_list: SpecPair, tests: TestsType = False) -> List[SpecPair]:
+def concretize_separately(
+    spec_list: Sequence[SpecPair], tests: TestsType = False
+) -> Sequence[SpecPair]:
     """Concretizes the input specs separately from each other.
 
     Args:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -14,7 +14,7 @@ import stat
 import urllib.parse
 import urllib.request
 import warnings
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
@@ -1535,7 +1535,7 @@ class Environment:
 
     def _concretize_together_where_possible(
         self, tests: bool = False
-    ) -> List[Tuple[spack.spec.Spec, spack.spec.Spec]]:
+    ) -> Sequence[Tuple[spack.spec.Spec, spack.spec.Spec]]:
         # Avoid cyclic dependency
         import spack.solver.asp
 
@@ -1550,7 +1550,7 @@ class Environment:
 
         ret = []
         result = spack.concretize.concretize_together_when_possible(
-            *specs_to_concretize, tests=tests
+            specs_to_concretize, tests=tests
         )
         for abstract, concrete in result:
             # Only add to the environment if it's from this environment (not included in)
@@ -1563,7 +1563,7 @@ class Environment:
 
         return ret
 
-    def _concretize_together(self, tests: bool = False) -> List[SpecPair]:
+    def _concretize_together(self, tests: bool = False) -> Sequence[SpecPair]:
         """Concretization strategy that concretizes all the specs
         in the same DAG.
         """
@@ -1577,8 +1577,8 @@ class Environment:
         self.specs_by_hash = {}
 
         try:
-            concretized_specs: List[SpecPair] = spack.concretize.concretize_together(
-                *specs_to_concretize, tests=tests
+            concretized_specs = spack.concretize.concretize_together(
+                specs_to_concretize, tests=tests
             )
         except spack.error.UnsatisfiableSpecError as e:
             # "Enhance" the error message for multiple root specs, suggest a less strict
@@ -1627,7 +1627,7 @@ class Environment:
         to_concretize = [
             (root, None) for root in self.user_specs if root not in old_concretized_user_specs
         ]
-        concretized_specs = spack.concretize.concretize_separately(*to_concretize, tests=tests)
+        concretized_specs = spack.concretize.concretize_separately(to_concretize, tests=tests)
 
         by_hash = {}
         for abstract, concrete in concretized_specs:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -55,7 +55,7 @@ from spack.spec import Spec
 from spack.spec_list import SpecList
 from spack.util.path import substitute_path_variables
 
-SpecPair = Tuple[spack.spec.Spec, spack.spec.Spec]
+SpecPair = spack.concretize.SpecPair
 
 #: environment variable used to indicate the active environment
 spack_env_var = "SPACK_ENV"
@@ -1533,9 +1533,7 @@ class Environment:
         ]
         return new_user_specs, kept_user_specs, specs_to_concretize
 
-    def _concretize_together_where_possible(
-        self, tests: bool = False
-    ) -> Sequence[Tuple[spack.spec.Spec, spack.spec.Spec]]:
+    def _concretize_together_where_possible(self, tests: bool = False) -> Sequence[SpecPair]:
         # Avoid cyclic dependency
         import spack.solver.asp
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -781,7 +781,7 @@ class TestConcretize:
     )
     def test_simultaneous_concretization_of_specs(self, abstract_specs):
         abstract_specs = [Spec(x) for x in abstract_specs]
-        concrete_specs = spack.concretize.concretize_specs_together(*abstract_specs)
+        concrete_specs = spack.concretize.concretize_specs_together(abstract_specs)
 
         # Check there's only one configuration of each package in the DAG
         names = set(dep.name for spec in concrete_specs for dep in spec.traverse())
@@ -2103,7 +2103,7 @@ class TestConcretize:
         spack.config.set("packages", external_conf)
 
         abstract_specs = [Spec(s) for s in ["py-extension1", "python"]]
-        specs = spack.concretize.concretize_specs_together(*abstract_specs)
+        specs = spack.concretize.concretize_specs_together(abstract_specs)
         assert specs[0]["python"] == specs[1]["python"]
 
     @pytest.mark.regression("36190")

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -33,7 +33,6 @@ import spack.spec
 import spack.store
 import spack.util.file_cache
 import spack.variant as vt
-from spack.concretize import find_spec
 from spack.installer import PackageInstaller
 from spack.spec import CompilerSpec, Spec
 from spack.version import Version, VersionList, ver
@@ -673,39 +672,6 @@ class TestConcretize:
         )
         assert spec["externaltool"].compiler.satisfies("gcc")
         assert spec["stuff"].compiler.satisfies("gcc")
-
-    def test_find_spec_parents(self):
-        """Tests the spec finding logic used by concretization."""
-        s = Spec.from_literal({"a +foo": {"b +foo": {"c": None, "d+foo": None}, "e +foo": None}})
-
-        assert "a" == find_spec(s["b"], lambda s: "+foo" in s).name
-
-    def test_find_spec_children(self):
-        s = Spec.from_literal({"a": {"b +foo": {"c": None, "d+foo": None}, "e +foo": None}})
-
-        assert "d" == find_spec(s["b"], lambda s: "+foo" in s).name
-
-        s = Spec.from_literal({"a": {"b +foo": {"c+foo": None, "d": None}, "e +foo": None}})
-
-        assert "c" == find_spec(s["b"], lambda s: "+foo" in s).name
-
-    def test_find_spec_sibling(self):
-        s = Spec.from_literal({"a": {"b +foo": {"c": None, "d": None}, "e +foo": None}})
-
-        assert "e" == find_spec(s["b"], lambda s: "+foo" in s).name
-        assert "b" == find_spec(s["e"], lambda s: "+foo" in s).name
-
-        s = Spec.from_literal({"a": {"b +foo": {"c": None, "d": None}, "e": {"f +foo": None}}})
-
-        assert "f" == find_spec(s["b"], lambda s: "+foo" in s).name
-
-    def test_find_spec_self(self):
-        s = Spec.from_literal({"a": {"b +foo": {"c": None, "d": None}, "e": None}})
-        assert "b" == find_spec(s["b"], lambda s: "+foo" in s).name
-
-    def test_find_spec_none(self):
-        s = Spec.from_literal({"a": {"b": {"c": None, "d": None}, "e": None}})
-        assert find_spec(s["b"], lambda s: "+foo" in s) is None
 
     def test_compiler_child(self):
         s = Spec("mpileaks%clang target=x86_64 ^dyninst%gcc")


### PR DESCRIPTION
Modifications:
- [x] Add type-hints to functions in `spack.concretize`
- [x] Remove `**kwargs` in favor of explicit keywords
- [x] Change the module docstring (this module is not deprecated anymore)
- [x] Don't use `*args` for list of pair of specs
- [x] Remove an unused function in the `spack.concretize` module

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
