### PR TITLE
rivet: add through v4.0.2 (incl yoda: add through v2.0.2)

### DIFF
--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -60,7 +60,7 @@ class Hepmc3(CMakePackage):
 
     @property
     def libs(self):
-       return find_libraries(["libHepMC3", "libHepMC3Search"], root=self.prefix, recursive=True)
+        return find_libraries(["libHepMC3", "libHepMC3Search"], root=self.prefix, recursive=True)
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -58,6 +58,10 @@ class Hepmc3(CMakePackage):
     conflicts("%gcc@9.3.0", when="@:3.1.1")
     patch("ba38f14d8f56c16cc4105d98f6d4540c928c6150.patch", when="@3.1.2:3.2.1 %gcc@9.3.0")
 
+    @property
+    def libs(self):
+       return find_libraries(["libHepMC3", "libHepMC3Search"], root=self.prefix, recursive=True)
+
     def cmake_args(self):
         spec = self.spec
         from_variant = self.define_from_variant

--- a/var/spack/repos/builtin/packages/rivet/package.py
+++ b/var/spack/repos/builtin/packages/rivet/package.py
@@ -58,6 +58,7 @@ class Rivet(AutotoolsPackage):
     depends_on("yoda@1.9.8:", when="@3.1.8:")
     depends_on("yoda@1.9.9:", when="@3.1.9:")
     depends_on("yoda@1.9.10:", when="@3.1.10:")
+    depends_on("yoda@:1", when="@:3")
     depends_on("yoda@2.0.1:", when="@4.0.0:")
 
     # The following versions were not a part of LCG stack
@@ -66,6 +67,7 @@ class Rivet(AutotoolsPackage):
 
     depends_on("hepmc", when="hepmc=2")
     depends_on("hepmc3", when="hepmc=3")
+    conflicts("hepmc@3.3.0", when="@:4.0.0 hepmc=3", msg="patch-level zero requires at least 4.0.1")
     depends_on("fastjet plugins=cxx")
     depends_on("fastjet@3.4.0:", when="@3.1.7:")
     depends_on("fjcontrib")

--- a/var/spack/repos/builtin/packages/rivet/package.py
+++ b/var/spack/repos/builtin/packages/rivet/package.py
@@ -39,7 +39,12 @@ class Rivet(AutotoolsPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    variant("hepmc", default="2", values=("2", "3"), description="HepMC version to link against")
+    variant(
+        "hepmc",
+        default="2",
+        values=(conditional("2", when="@:3"), "3"),
+        description="HepMC version to link against",
+    )
 
     # According to A. Buckley (main Rivet developer):
     # "typically a given Rivet version will work with
@@ -118,7 +123,7 @@ class Rivet(AutotoolsPackage):
             args += ["--with-hepmc=" + self.spec["hepmc"].prefix]
         else:
             args += ["--with-hepmc3=" + self.spec["hepmc3"].prefix]
-            args += ["--with-hepmc3-libpath=" + self.spec["hepmc3"].prefix.lib]
+            args += ["--with-hepmc3-libpath=" + self.spec["hepmc3"].libs.directories[0]]
 
         args += ["--with-fastjet=" + self.spec["fastjet"].prefix]
         args += ["--with-yoda=" + self.spec["yoda"].prefix]

--- a/var/spack/repos/builtin/packages/rivet/package.py
+++ b/var/spack/repos/builtin/packages/rivet/package.py
@@ -19,6 +19,11 @@ class Rivet(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
+    version("4.0.2", sha256="65a3b36f42bff782ed2767930e669e09b140899605d7972fc8f77785b4a882c0")
+    version("4.0.1", sha256="4e8692d6e8a53961c77983eb6ba4893c3765cf23f705789e4d865be4892eff79")
+    version("4.0.0", sha256="d3c42d9b83ede3e7f4b534535345c2e06e6dafb851454c2b0a5d2331ab0f04d0")
+    version("3.1.10", sha256="458b8e0df1de738e9972d24b260eaa087df12c99d4fe9dee5377d47ea6a49919")
+    version("3.1.9", sha256="f6532045da61eeb2adc20a9abc4166b4b2d41ab2c1ca5b500cd616bb1b92e7b1")
     version("3.1.8", sha256="75b3f3d419ca6388d1fd2ec0eda7e1f90f324b996ccf0591f48a5d2e28dccc13")
     version("3.1.7", sha256="27c7dbbcb5fd7ee81caf136daf4e960bca0ec255d9fa1abe602f4d430861b27a")
     version("3.1.6", sha256="1cf6ebb6a79d181c441d1d0c7c6d623c423817c61093f36f21adaae23e679090")
@@ -48,8 +53,12 @@ class Rivet(AutotoolsPackage):
     depends_on("yoda@1.8.2", when="@3.1.1")
     depends_on("yoda@1.8.3", when="@3.1.2")
     depends_on("yoda@1.8.5:", when="@3.1.3:")
-    depends_on("yoda@1.9.5:", when="@3.1.6:")
+    depends_on("yoda@1.9.6:", when="@3.1.6:")
     depends_on("yoda@1.9.7:", when="@3.1.7:")
+    depends_on("yoda@1.9.8:", when="@3.1.8:")
+    depends_on("yoda@1.9.9:", when="@3.1.9:")
+    depends_on("yoda@1.9.10:", when="@3.1.10:")
+    depends_on("yoda@2.0.1:", when="@4.0.0:")
 
     # The following versions were not a part of LCG stack
     # and thus the exact version of YODA is unknown
@@ -60,6 +69,7 @@ class Rivet(AutotoolsPackage):
     depends_on("fastjet plugins=cxx")
     depends_on("fastjet@3.4.0:", when="@3.1.7:")
     depends_on("fjcontrib")
+    depends_on("highfive", when="@4:")
     depends_on("python", type=("build", "run"))
     depends_on("py-cython@0.24.0:", type="build")
     depends_on("swig", type="build")
@@ -104,11 +114,15 @@ class Rivet(AutotoolsPackage):
             args += ["--with-hepmc=" + self.spec["hepmc"].prefix]
         else:
             args += ["--with-hepmc3=" + self.spec["hepmc3"].prefix]
+            args += ["--with-hepmc3-libpath=" + self.spec["hepmc3"].prefix.lib]
 
         args += ["--with-fastjet=" + self.spec["fastjet"].prefix]
         args += ["--with-yoda=" + self.spec["yoda"].prefix]
 
         args += ["--with-fjcontrib=" + self.spec["fjcontrib"].prefix]
+
+        if self.spec.satisfies("^highfive"):
+            args += ["--with-highfive=" + self.spec["highfive"].prefix]
 
         args += ["--disable-pdfmanual"]
 

--- a/var/spack/repos/builtin/packages/rivet/package.py
+++ b/var/spack/repos/builtin/packages/rivet/package.py
@@ -67,7 +67,9 @@ class Rivet(AutotoolsPackage):
 
     depends_on("hepmc", when="hepmc=2")
     depends_on("hepmc3", when="hepmc=3")
-    conflicts("hepmc@3.3.0", when="@:4.0.0 hepmc=3", msg="patch-level zero requires at least 4.0.1")
+    conflicts(
+        "hepmc@3.3.0", when="@:4.0.0 hepmc=3", msg="patch-level zero requires at least 4.0.1"
+    )
     depends_on("fastjet plugins=cxx")
     depends_on("fastjet@3.4.0:", when="@3.1.7:")
     depends_on("fjcontrib")

--- a/var/spack/repos/builtin/packages/yoda/package.py
+++ b/var/spack/repos/builtin/packages/yoda/package.py
@@ -17,12 +17,10 @@ class Yoda(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
+    version("2.0.2", sha256="31a41413641189814ff3c6bbb96ac5d17d2b68734fe327d06794cdbd3a540399")
+    version("2.0.1", sha256="ae5a78eaae5574a5159d4058839d0983c9923558bfc88fbce21d251fd925d260")
     version("2.0.0", sha256="680f43dabebb3167ce1c5dee72d1c2c285c3190751245aa51e3260a005a99575")
-    version(
-        "1.9.10",
-        sha256="0a708ee9d704945d3387cc437b15ffddf382c70fe5bab39ed2bdbf83c2c28c6f",
-        preferred=True,
-    )
+    version("1.9.10", sha256="0a708ee9d704945d3387cc437b15ffddf382c70fe5bab39ed2bdbf83c2c28c6f")
     version("1.9.9", sha256="ebcad55369a1cedcee3a2de059407c851652ba44495113f5c09d8c2e57f516aa")
     version("1.9.8", sha256="7bc3062468abba50aff3ecb8b22ce677196036009890688ef4533aaa7f92e6e4")
     version("1.9.7", sha256="8d07bb04dcb79364858718a18203452d8d9fa00029fa94239eafa8529032b8ff")


### PR DESCRIPTION
This PR adds `rivet`, through v4.0.2. This completes the v3 series and adds the v4 series (which changes the API, uses yoda@2, and adds hdf5 support through `highfive`). Note that the rivet configure.ac requirements for yoda are not always  strict enough: rivet-4 uses `Estimate::rmErrs()` which was only added in yoda-2.0.1.

Test build (v4):
```
==> Installing yoda-2.0.2-zjwri2wpwht7vmtwfxr3rxcty2zvy7na [117/118]
==> No binary for yoda-2.0.2-zjwri2wpwht7vmtwfxr3rxcty2zvy7na found: installing from source
==> Fetching https://yoda.hepforge.org/downloads/?f=YODA-2.0.2.tar.bz2
==> No patches needed for yoda
==> yoda: Executing phase: 'autoreconf'
==> yoda: Executing phase: 'configure'
==> yoda: Executing phase: 'build'
==> yoda: Executing phase: 'install'
==> yoda: Successfully installed yoda-2.0.2-zjwri2wpwht7vmtwfxr3rxcty2zvy7na
  Stage: 5.41s.  Autoreconf: 0.00s.  Configure: 6.82s.  Build: 11m 7.14s.  Install: 0.60s.  Post-install: 0.75s.  Total: 11m 21.21s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/yoda-2.0.2-zjwri2wpwht7vmtwfxr3rxcty2zvy7na
==> Installing rivet-4.0.2-tnblwot3wyad7cogsjfu75vjhq3qlmw5 [118/118]
==> No binary for rivet-4.0.2-tnblwot3wyad7cogsjfu75vjhq3qlmw5 found: installing from source
==> Fetching https://rivet.hepforge.org/downloads/?f=Rivet-4.0.2.tar.bz2
==> No patches needed for rivet
==> rivet: Executing phase: 'autoreconf'
==> rivet: Executing phase: 'configure'
==> rivet: Executing phase: 'build'
==> rivet: Executing phase: 'install'
==> rivet: Successfully installed rivet-4.0.2-tnblwot3wyad7cogsjfu75vjhq3qlmw5
  Stage: 1m 16.16s.  Autoreconf: 8.40s.  Configure: 8.58s.  Build: 18m 34.79s.  Install: 8.97s.  Post-install: 2.45s.  Total: 20m 19.81s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/rivet-4.0.2-tnblwot3wyad7cogsjfu75vjhq3qlmw5
```

Test build (v3):
```
==> Installing yoda-1.9.10-k6xa5shw5nwthdur4wqavdofqibszn4v [105/106]
==> No binary for yoda-1.9.10-k6xa5shw5nwthdur4wqavdofqibszn4v found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/0a/0a708ee9d704945d3387cc437b15ffddf382c70fe5bab39ed2bdbf83c2c28c6f.tar.bz2
==> No patches needed for yoda
==> yoda: Executing phase: 'autoreconf'
==> yoda: Executing phase: 'configure'
==> yoda: Executing phase: 'build'
==> yoda: Executing phase: 'install'
==> yoda: Successfully installed yoda-1.9.10-k6xa5shw5nwthdur4wqavdofqibszn4v
  Stage: 1.08s.  Autoreconf: 0.00s.  Configure: 5.97s.  Build: 1m 57.24s.  Install: 0.26s.  Post-install: 0.70s.  Total: 2m 5.64s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/yoda-1.9.10-k6xa5shw5nwthdur4wqavdofqibszn4v
==> Installing rivet-3.1.10-2k56b6fuitz6ypugaeqawcrzbd7ers3u [106/106]
==> No binary for rivet-3.1.10-2k56b6fuitz6ypugaeqawcrzbd7ers3u found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/45/458b8e0df1de738e9972d24b260eaa087df12c99d4fe9dee5377d47ea6a49919.tar.bz2
==> No patches needed for rivet
==> rivet: Executing phase: 'autoreconf'
==> rivet: Executing phase: 'configure'
==> rivet: Executing phase: 'build'
==> rivet: Executing phase: 'install'
==> rivet: Successfully installed rivet-3.1.10-2k56b6fuitz6ypugaeqawcrzbd7ers3u
  Stage: 4.94s.  Autoreconf: 9.37s.  Configure: 8.40s.  Build: 12m 10.58s.  Install: 9.20s.  Post-install: 2.44s.  Total: 12m 45.41s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/rivet-3.1.10-2k56b6fuitz6ypugaeqawcrzbd7ers3u
```