### PR TITLE
sherpa: add v3.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/sherpa/package.py
+++ b/var/spack/repos/builtin/packages/sherpa/package.py
@@ -22,6 +22,7 @@ class Sherpa(CMakePackage, AutotoolsPackage):
 
     license("GPL-3.0-only")
 
+    version("3.0.1", sha256="ff5f43e79a9a10919391242307a771eca0c57b0462c11bfb99ee4a0fe8c48c58")
     version("3.0.0", sha256="e460d8798b323c4ef663293a2c918b1463e9641b35703a54d70d25c852c67d36")
     version("2.2.15", sha256="0300fd719bf6a089b7dc5441f720e669ac1cb030045d87034a4733bee98e7bbc")
     version("2.2.14", sha256="f17d88d7f3bc4234a9db3872e8a3c1f3ef99e1e2dc881ada5ddf848715dc82da")
@@ -88,6 +89,7 @@ class Sherpa(CMakePackage, AutotoolsPackage):
 
     depends_on("mpi", when="+mpi")
     depends_on("python", when="+python")
+    depends_on("py-setuptools", when="+python", type="build")
     depends_on("swig", when="+python", type="build")
     depends_on("hepmc", when="+hepmc2")
     depends_on("hepmc3", when="+hepmc3")

--- a/var/spack/repos/builtin/packages/sherpa/package.py
+++ b/var/spack/repos/builtin/packages/sherpa/package.py
@@ -89,7 +89,6 @@ class Sherpa(CMakePackage, AutotoolsPackage):
 
     depends_on("mpi", when="+mpi")
     depends_on("python", when="+python")
-    depends_on("py-setuptools", when="+python", type="build")
     depends_on("swig", when="+python", type="build")
     depends_on("hepmc", when="+hepmc2")
     depends_on("hepmc3", when="+hepmc3")


### PR DESCRIPTION
This PR adds `sherpa`, v3.0.1. (Note that sherpa@3 still supports both rivet@3 and rivet@4.)

Test build:
```
==> Installing sherpa-3.0.1-xaesxbsiijqichyr75q5mlbmdbtsyij2 [114/114]
==> No binary for sherpa-3.0.1-xaesxbsiijqichyr75q5mlbmdbtsyij2 found: installing from source
==> Fetching https://gitlab.com/sherpa-team/sherpa/-/archive/v3.0.1/sherpa-v3.0.1.tar.gz
==> Ran patch() for sherpa
==> sherpa: Executing phase: 'cmake'
==> sherpa: Executing phase: 'build'
==> sherpa: Executing phase: 'install'
==> sherpa: Successfully installed sherpa-3.0.1-xaesxbsiijqichyr75q5mlbmdbtsyij2
  Stage: 1.28s.  Cmake: 2.42s.  Build: 12m 11.30s.  Install: 1.23s.  Post-install: 1.13s.  Total: 12m 17.80s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/sherpa-3.0.1-xaesxbsiijqichyr75q5mlbmdbtsyij2
```