### PR TITLE
pythia8: add v8.312

### DIFF
--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -12,7 +12,7 @@ class Pythia8(AutotoolsPackage):
     the evolution from a few-body hard process to a complex multiparticle
     final state."""
 
-    homepage = "http://home.thep.lu.se/Pythia/"
+    homepage = "https://pythia.org/"
     url = "https://pythia.org/download/pythia83/pythia8306.tgz"
     list_url = "https://pythia.org/releases/"
 

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -22,6 +22,7 @@ class Pythia8(AutotoolsPackage):
 
     license("GPL-2.0-only")
 
+    version("8.312", sha256="bad98e2967b687046c4568c9091d630a0c31b628745c021a994aba4d1d50f8ea")
     version("8.311", sha256="2782d5e429c1543c67375afe547fd4c4ca0720309deb008f7db78626dc7d1464")
     version("8.310", sha256="90c811abe7a3d2ffdbf9b4aeab51cf6e0a5a8befb4e3efa806f3d5b9c311e227")
     version("8.309", sha256="5bdafd9f2c4a1c47fd8a4e82fb9f0d8fcfba4de1003b8e14be4e0347436d6c33")


### PR DESCRIPTION
This PR adds `pythia8`, v8.312 (release notes at https://pythia.org/history/).

Test build:
```
==> Installing pythia8-8.312-tl3aammhh2uesuai2ahjnwip4sp6osf7 [102/104]
==> No binary for pythia8-8.312-tl3aammhh2uesuai2ahjnwip4sp6osf7 found: installing from source
==> Fetching https://pythia.org/download/pythia83/pythia8312.tgz
==> No patches needed for pythia8
==> pythia8: Executing phase: 'autoreconf'
==> pythia8: Executing phase: 'configure'
==> pythia8: Executing phase: 'build'
==> pythia8: Executing phase: 'install'
==> pythia8: Successfully installed pythia8-8.312-tl3aammhh2uesuai2ahjnwip4sp6osf7
  Stage: 17.07s.  Autoreconf: 0.00s.  Configure: 2.13s.  Build: 3m 4.27s.  Install: 0.48s.  Post-install: 0.48s.  Total: 3m 24.65s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/pythia8-8.312-tl3aammhh2uesuai2ahjnwip4sp6osf7
```
