### PR TITLE
cups: add v2.4.11

### DIFF
--- a/var/spack/repos/builtin/packages/cups/package.py
+++ b/var/spack/repos/builtin/packages/cups/package.py
@@ -20,9 +20,12 @@ class Cups(AutotoolsPackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("2.4.11", sha256="9a88fe1da3a29a917c3fc67ce6eb3178399d68e1a548c6d86c70d9b13651fd71")
     version("2.4.10", sha256="d75757c2bc0f7a28b02ee4d52ca9e4b1aa1ba2affe16b985854f5336940e5ad7")
-    version("2.3.3", sha256="261fd948bce8647b6d5cb2a1784f0c24cc52b5c4e827b71d726020bcc502f3ee")
-    version("2.2.3", sha256="66701fe15838f2c892052c913bde1ba106bbee2e0a953c955a62ecacce76885f")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2023-4504
+        version("2.3.3", sha256="261fd948bce8647b6d5cb2a1784f0c24cc52b5c4e827b71d726020bcc502f3ee")
+        version("2.2.3", sha256="66701fe15838f2c892052c913bde1ba106bbee2e0a953c955a62ecacce76885f")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")


### PR DESCRIPTION
This PR adds `cups`, v2.4.11, a bugfix release ([diff](https://github.com/OpenPrinting/cups/compare/v2.4.10...v2.4.11)). Older versions before CVE-2023-4504 marked as deprecated.

Test build:
```
==> Installing cups-2.4.11-g3imbmfaza7qtzpaxs45tquuarpfdfun [27/27]
==> No binary for cups-2.4.11-g3imbmfaza7qtzpaxs45tquuarpfdfun found: installing from source
==> Fetching https://github.com/OpenPrinting/cups/releases/download/v2.4.11/cups-2.4.11-source.tar.gz
==> No patches needed for cups
==> cups: Executing phase: 'autoreconf'
==> cups: Executing phase: 'configure'
==> cups: Executing phase: 'build'
==> cups: Executing phase: 'install'
==> cups: Successfully installed cups-2.4.11-g3imbmfaza7qtzpaxs45tquuarpfdfun
  Stage: 1.56s.  Autoreconf: 0.00s.  Configure: 6.85s.  Build: 12.73s.  Install: 1.36s.  Post-install: 0.16s.  Total: 23.33s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/cups-2.4.11-g3imbmfaza7qtzpaxs45tquuarpfdfun
```