### PR TITLE
libssh2: fix crypto

### DIFF
--- a/var/spack/repos/builtin/packages/libssh2/package.py
+++ b/var/spack/repos/builtin/packages/libssh2/package.py
@@ -14,6 +14,7 @@ class Libssh2(AutotoolsPackage, CMakePackage):
 
     license("BSD-3-Clause")
 
+    version("1.11.1", sha256="d9ec76cbe34db98eec3539fe2c899d26b0c837cb3eb466a56b0f109cabf658f7")
     version("1.11.0", sha256="3736161e41e2693324deb38c26cfdc3efe6209d634ba4258db1cecff6a5ad461")
     version("1.10.0", sha256="2d64e90f3ded394b91d3a2e774ca203a4179f69aebee03003e5a6fa621e41d51")
     version("1.9.0", sha256="d5fb8bd563305fd1074dda90bd053fb2d29fc4bce048d182f96eaa466dfadafd")
@@ -23,8 +24,7 @@ class Libssh2(AutotoolsPackage, CMakePackage):
         "1.4.3", sha256="eac6f85f9df9db2e6386906a6227eb2cd7b3245739561cad7d6dc1d5d021b96d"
     )  # CentOS7
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
 
     build_system("autotools", "cmake", default="autotools")
 
@@ -53,7 +53,7 @@ class Libssh2(AutotoolsPackage, CMakePackage):
     # and fails to prepend the -L flags, which is causing issues in libgit2, as
     # it tries to locate e.g. libssl in the dirs of the pc file's -L flags, and
     # cannot find the lib.
-    patch("pr-1114.patch", when="@1.7:")
+    patch("pr-1114.patch", when="@1.7:1.11.0")
 
 
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
@@ -77,14 +77,27 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
 
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
     def configure_args(self):
-        args = ["--disable-tests", "--disable-docker-tests", "--disable-examples-build"]
-        args += self.enable_or_disable("shared")
+        args = [
+            "--disable-tests",
+            "--disable-docker-tests",
+            "--disable-examples-build",
+            "--without-libgcrypt",
+            "--without-wincng",
+            *self.enable_or_disable("shared"),
+        ]
 
         crypto = self.spec.variants["crypto"].value
 
-        if crypto == "openssl":
-            args.append(f"--with-libssl-prefix={self.spec['openssl'].prefix}")
-        elif crypto == "mbedtls":
-            args.append(f"--with-libmbedcrypto-prefix={self.spec['mbedtls'].prefix}")
+        if self.spec.satisfies("@1.9:"):
+            # single flag for all crypto backends
+            args.append(f"--with-crypto={crypto}")
+        else:
+            # one flag per crypto backend
+            if crypto == "openssl":
+                args.append(f"--with-libssl-prefix={self.spec['openssl'].prefix}")
+                args.append("--without-mbedtls")
+            elif crypto == "mbedtls":
+                args.append(f"--with-libmbedcrypto-prefix={self.spec['mbedtls'].prefix}")
+                args.append("--without-openssl")
 
         return args


### PR DESCRIPTION
extracted from #47365

Flags changed; without it always picks openssl if available.