### PR TITLE
lua-luaposix: add missing libxcrypt dependency

### DIFF
--- a/var/spack/repos/builtin/packages/lua-luaposix/package.py
+++ b/var/spack/repos/builtin/packages/lua-luaposix/package.py
@@ -23,6 +23,7 @@ class LuaLuaposix(LuaPackage):
     version("33.4.0", sha256="e66262f5b7fe1c32c65f17a5ef5ffb31c4d1877019b4870a5d373e2ab6526a21")
     version("33.2.1", sha256="4fb34dfea67f4cf3194cdecc6614c9aea67edc3c4093d34137669ea869c358e1")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
+    depends_on("libxcrypt", when="platform=linux")
     depends_on("lua-bit32", when="^lua-lang@5.1")


### PR DESCRIPTION
extracted from #47365

libcrypt used to be part of glibc, is now part of libxcrypt.