### PR TITLE
krb5: disable missing keyutils dependency

### DIFF
--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -103,7 +103,7 @@ class Krb5(AutotoolsPackage):
 
     def configure_args(self):
         spec = self.spec
-        args = ["--without-system-verto"]
+        args = ["--without-system-verto", "--without-keyutils"]
 
         if spec.satisfies("~shared"):
             args.append("--enable-static")


### PR DESCRIPTION
extracted from #47365

otherwise it may be picked up from the system.