### PR TITLE
tcsh: add missing libxcrypt dependency

### DIFF
--- a/var/spack/repos/builtin/packages/tcsh/package.py
+++ b/var/spack/repos/builtin/packages/tcsh/package.py
@@ -108,6 +108,7 @@ class Tcsh(AutotoolsPackage):
     )
 
     depends_on("ncurses+termlib")
+    depends_on("libxcrypt", when="platform=linux")
 
     @run_after("install")
     def link_csh(self):


### PR DESCRIPTION
extracted from #47365

libcrypt used to be part of glibc, is now part of libxcrypt.