### PR TITLE
pythia8: Include patch for C++20 / Clang

### DIFF
--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -137,12 +137,16 @@ class Pythia8(AutotoolsPackage):
             r"-std=c\+\+[0-9][0-9]", f"-std=c++{self.spec.variants['cxxstd'].value}", "configure"
         )
 
-    # Fix for https://gitlab.com/Pythia8/releases/-/issues/428
-    @when("@:8.311")
-    def patch(self):
-        filter_file(
-            r"[/]examples[/]Makefile[.]inc\|;n' \\", "/examples/Makefile.inc|' \\", "configure"
-        )
+        # Fix for https://gitlab.com/Pythia8/releases/-/issues/428
+        with when("@:8.311"):
+            print("Patching")
+            filter_file(
+                r"[/]examples[/]Makefile[.]inc\|;n' \\", "/examples/Makefile.inc|' \\", "configure"
+            )
+
+    with when("@:8.312 cxxstd=20"):
+        patch("pythia8-cpp20-fjcore-forward-decl.patch", when="%apple-clang")
+        patch("pythia8-cpp20-fjcore-forward-decl.patch", when="%clang")
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -144,9 +144,8 @@ class Pythia8(AutotoolsPackage):
             )
 
     # Fix for https://gitlab.com/Pythia8/releases/-/issues/523
-    with when("@:8.312 cxxstd=20"):
-        patch("pythia8-cpp20-fjcore-forward-decl.patch", when="%apple-clang")
-        patch("pythia8-cpp20-fjcore-forward-decl.patch", when="%clang")
+    with when("@8.307:8.312 cxxstd=20"):
+        patch("pythia8-cpp20-fjcore-forward-decl.patch")
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -144,6 +144,7 @@ class Pythia8(AutotoolsPackage):
                 r"[/]examples[/]Makefile[.]inc\|;n' \\", "/examples/Makefile.inc|' \\", "configure"
             )
 
+    # Fix for https://gitlab.com/Pythia8/releases/-/issues/523
     with when("@:8.312 cxxstd=20"):
         patch("pythia8-cpp20-fjcore-forward-decl.patch", when="%apple-clang")
         patch("pythia8-cpp20-fjcore-forward-decl.patch", when="%clang")

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -139,7 +139,6 @@ class Pythia8(AutotoolsPackage):
 
         # Fix for https://gitlab.com/Pythia8/releases/-/issues/428
         with when("@:8.311"):
-            print("Patching")
             filter_file(
                 r"[/]examples[/]Makefile[.]inc\|;n' \\", "/examples/Makefile.inc|' \\", "configure"
             )

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -132,7 +132,7 @@ class Pythia8(AutotoolsPackage):
     filter_compiler_wrappers("Makefile.inc", relative_root="share/Pythia8/examples")
 
     @run_before("configure")
-    def setup_cxxstd(self):
+    def setup_configure(self):
         filter_file(
             r"-std=c\+\+[0-9][0-9]", f"-std=c++{self.spec.variants['cxxstd'].value}", "configure"
         )

--- a/var/spack/repos/builtin/packages/pythia8/pythia8-cpp20-fjcore-forward-decl.patch
+++ b/var/spack/repos/builtin/packages/pythia8/pythia8-cpp20-fjcore-forward-decl.patch
@@ -1,0 +1,37 @@
+diff --git a/src/FJcore.cc b/src/FJcore.cc
+index c60108e2..afd32eee 100644
+--- a/src/FJcore.cc
++++ b/src/FJcore.cc
+@@ -730,14 +730,10 @@ FJCORE_BEGIN_NAMESPACE      // defined in fastjet/internal/base.hh
+ class ClosestPair2D : public ClosestPair2DBase {
+ public:
+   ClosestPair2D(const std::vector<Coord2D> & positions, 
+-		const Coord2D & left_corner, const Coord2D & right_corner) {
+-    _initialize(positions, left_corner, right_corner, positions.size());
+-  };
++		const Coord2D & left_corner, const Coord2D & right_corner);
+   ClosestPair2D(const std::vector<Coord2D> & positions, 
+ 		const Coord2D & left_corner, const Coord2D & right_corner,
+-		const unsigned int max_size) {
+-    _initialize(positions, left_corner, right_corner, max_size);
+-  };
++		const unsigned int max_size);
+   void closest_pair(unsigned int & ID1, unsigned int & ID2, 
+ 		    double & distance2) const;
+   void remove(unsigned int ID);
+@@ -808,6 +804,15 @@ public:
+     return coord.distance2(other.coord);
+   };
+ };
++inline ClosestPair2D::ClosestPair2D(const std::vector<Coord2D> & positions, 
++  const Coord2D & left_corner, const Coord2D & right_corner) {
++  _initialize(positions, left_corner, right_corner, positions.size());
++};
++inline ClosestPair2D::ClosestPair2D(const std::vector<Coord2D> & positions, 
++  const Coord2D & left_corner, const Coord2D & right_corner,
++  const unsigned int max_size) {
++  _initialize(positions, left_corner, right_corner, max_size);
++};
+ inline bool floor_ln2_less(unsigned x, unsigned y) {
+   if (x>y) return false;
+   return (x < (x^y)); // beware of operator precedence...


### PR DESCRIPTION
Pythia8 vendors some FJCore sources that are as of Pythia8 312 incompatible with C++20 on clang. This adds a patch that makes it compatible in these scenarios.
Related issue on the Pythia repository: https://gitlab.com/Pythia8/releases/-/issues/523

This PR:

- Moves the existing modification of `configure` to generate a modified `Makefile` from a `patch` function to the already existing function being run before the *configure* step
  - This is needed because defining a `patch` function prevents using `patch()` in the class (as far as I can tell)
- Adds patches for `%clang` and `%appleclang` when `cxxstd=20` and `@:8312

---

Compilation on linux:
```
$ spack install pythia8@8.312%clang cxxstd=20
==> Installing pythia8-8.312-zxo6h4jqqw4yjgzzythtyehp2yyzjvws [14/14]
==> No binary for pythia8-8.312-zxo6h4jqqw4yjgzzythtyehp2yyzjvws found: installing from source
==> Using cached archive: /scratch/pagessin/spack-test/spack/var/spack/cache/_source-cache/archive/ba/bad98e2967b687046c4568c9091d630a0c31b628745c021a994aba4d1d50f8ea.tgz
==> Applied patch /scratch/pagessin/spack-test/spack/var/spack/repos/builtin/packages/pythia8/pythia8-cpp20-fjcore-forward-decl.patch
==> pythia8: Executing phase: 'autoreconf'
==> pythia8: Executing phase: 'configure'
==> pythia8: Executing phase: 'build'
==> pythia8: Executing phase: 'install'
==> pythia8: Successfully installed pythia8-8.312-zxo6h4jqqw4yjgzzythtyehp2yyzjvws
  Stage: 0.48s.  Autoreconf: 0.00s.  Configure: 1.52s.  Build: 30.28s.  Install: 0.60s.  Post-install: 0.29s.  Total: 33.33s
[+] /scratch/pagessin/spack-test/spack/opt/spack/linux-almalinux9-zen2/clang-17.0.6/pythia8-8.312-zxo6h4jqqw4yjgzzythtyehp2yyzjvws
```

Compilation on macOS:
```
$ spack install pythia8@8.312 cxxstd=20
==> Installing pythia8-8.312-otexj543luj3kaglxp2hlxx3ojiz2wfh [13/13]
==> No binary for pythia8-8.312-otexj543luj3kaglxp2hlxx3ojiz2wfh found: installing from source
==> Using cached archive: /Users/pagessin/spack/var/spack/cache/_source-cache/archive/ba/bad98e2967b687046c4568c9091d630a0c31b628745c021a994aba4d1d50f8ea.tgz
==> Applied patch /Users/pagessin/spack/var/spack/repos/builtin/packages/pythia8/pythia8-cpp20-fjcore-forward-decl.patch
==> pythia8: Executing phase: 'autoreconf'
==> pythia8: Executing phase: 'configure'
==> pythia8: Executing phase: 'build'
==> pythia8: Executing phase: 'install'
==> pythia8: Successfully installed pythia8-8.312-otexj543luj3kaglxp2hlxx3ojiz2wfh
  Stage: 0.40s.  Autoreconf: 0.00s.  Configure: 2.90s.  Build: 48.19s.  Install: 1.22s.  Post-install: 0.19s.  Total: 53.05s
[+] /Users/pagessin/spack/opt/spack/darwin-sequoia-m1/apple-clang-15.0.0/pythia8-8.312-otexj543luj3kaglxp2hlxx3ojiz2wfh
```