### PR TITLE
extrae: fix typo

### DIFF
--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -128,7 +128,7 @@ class Extrae(AutotoolsPackage):
 
         args += (
             ["--with-cuda=%s" % spec["cuda"].prefix]
-            if spec.satisifes("+cuda")
+            if spec.satisfies("+cuda")
             else ["--without-cuda"]
         )
 


### PR DESCRIPTION
#47343 broke building extrae:
```
==> Installing extrae-4.1.2-3m2zqwnb5yl3fubfyt5jhkcq5otlqmnp
==> No binary for extrae-4.1.2-3m2zqwnb5yl3fubfyt5jhkcq5otlqmnp found: installing from source
==> Using cached archive: /home/mose/repo/spack/var/spack/cache/_source-cache/archive/ad/adbc1d3aefde7649262426d471237dc96f070b93be850a6f15280ed86fd0b952.tar.bz2
==> No patches needed for extrae
==> extrae: Executing phase: 'autoreconf'
==> extrae: Executing phase: 'configure'
==> Error: AttributeError: 'Spec' object has no attribute 'satisifes'

The 'extrae' package cannot find an attribute while trying to build from sources. This might be due to a change in Spack's package format to support multiple build-systems for a single package. You can fix this by updating the build recipe, and you can also report the issue as a bug. More information at https://spack.readthedocs.io/en/latest/packaging_guide.html#installation-procedure

/home/mose/repo/spack/var/spack/repos/builtin/packages/extrae/package.py:131, in configure_args:
        128
        129        args += (
        130            ["--with-cuda=%s" % spec["cuda"].prefix]
  >>    131            if spec.satisifes("+cuda")
        132            else ["--without-cuda"]
        133        )
        134

See build log for details:
  /tmp/mose/spack-stage/spack-stage-extrae-4.1.2-3m2zqwnb5yl3fubfyt5jhkcq5otlqmnp/spack-build-out.txt
```
CC: @hainest.