### PR TITLE
Fix generate on change check

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -739,6 +739,9 @@ def generate_gitlab_ci_yaml(
             for p in possible_builds.values():
                 if a in p:
                     changed = True
+                    break
+            if changed:
+                break
 
         if not changed:
             spack_ci = SpackCI(ci_config)

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -733,8 +733,12 @@ def generate_gitlab_ci_yaml(
         else:
             tty.debug("  no affected packages...")
 
+        changed = False
         possible_builds = spack.package_base.possible_dependencies(*env.user_specs)
-        changed = any((spec in p for p in possible_builds.values()) for spec in affected_pkgs)
+        for a in affected_pkgs:
+            for p in possible_builds.values():
+                if a in p:
+                    changed = True
 
         if not changed:
             spack_ci = SpackCI(ci_config)

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1652,7 +1652,7 @@ def test_ci_dynamic_mapping_full(
                 assert "unallowed_field" not in job
 
 
-@pytest.mark.parametrize("affected_packages", [None, "trivial-pkg-with-valid-hash"])
+@pytest.mark.parametrize("affected_packages", [[], ["trivial-pkg-with-valid-hash"]])
 def test_ci_generate_noop_no_concretize(
     tmpdir,
     working_env,
@@ -1679,10 +1679,7 @@ spack:
         )
 
     def fake_compute_affected(r1=None, r2=None):
-        if affected_packages:
-            return [affected_packages]
-        else:
-            return []
+        return affected_packages
 
     monkeypatch.setattr(ci, "compute_affected_packages", fake_compute_affected)
     monkeypatch.setenv("SPACK_PRUNE_UNTOUCHED", "TRUE")  # enables pruning of untouched specs

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1652,6 +1652,7 @@ def test_ci_dynamic_mapping_full(
                 assert "unallowed_field" not in job
 
 
+@pytest.mark.parametrize("affected_packages", [None, "trivial-pkg-with-valid-hash"])
 def test_ci_generate_noop_no_concretize(
     tmpdir,
     working_env,
@@ -1660,6 +1661,7 @@ def test_ci_generate_noop_no_concretize(
     mock_packages,
     monkeypatch,
     ci_base_environment,
+    affected_packages,
 ):
     # Write the enviroment file
     filename = str(tmpdir.join("spack.yaml"))
@@ -1677,7 +1679,10 @@ spack:
         )
 
     def fake_compute_affected(r1=None, r2=None):
-        return []
+        if affected_packages:
+            return [affected_packages]
+        else:
+            return []
 
     monkeypatch.setattr(ci, "compute_affected_packages", fake_compute_affected)
     monkeypatch.setenv("SPACK_PRUNE_UNTOUCHED", "TRUE")  # enables pruning of untouched specs


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This feature worked great in the case where there was no change to any package. However, if there was a change in any package, it was evaluating erroneously that there was a change to a possible package.

The use of nested loops in the `any` check for changed would always report true if there were any affected packages even if they were not possible packages. The reason for this is the nested inline loop created a list of generator expressions which any would evaluate to True.

To fix this, the nested loop was expanded and the usage of `any` dropped. As an added bonus, early exit on first matching package name since this check can be potentially expensive when there are many possible packages in the environment.

A unit test to capture this missing case was also added.

CC: @tgamblin 