### PR TITLE
VTK: Fixup netcdf spec reference

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -177,7 +177,8 @@ class Vtk(CMakePackage):
     depends_on("lz4")
     depends_on("netcdf-c~mpi", when="~mpi")
     depends_on("netcdf-c+mpi", when="+mpi")
-    depends_on("netcdf-cxx4", when="@:8.1.2")
+    depends_on("netcdf-cxx4", when="@6.3.0:8.1.2")
+    depends_on("netcdf-cxx", when="@:6.1.0")
     depends_on("libpng")
     depends_on("libtiff")
     depends_on("zlib-api")
@@ -322,7 +323,7 @@ class Vtk(CMakePackage):
             cmake_args.extend(
                 [
                     "-DVTK_USE_SYSTEM_LIBPROJ4:BOOL=OFF",
-                    "-DNETCDF_CXX_ROOT={0}".format(spec["netcdf-cxx"].prefix),
+                    "-DNETCDF_CXX_ROOT={0}".format(spec["netcdf-cxx4"].prefix),
                 ]
             )
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Reference the correct netcdf-cxx package in the cmake args setup.
