### PR TITLE
Ci generate dynamic

### DIFF
--- a/lib/spack/spack/ci/__init__.py
+++ b/lib/spack/spack/ci/__init__.py
@@ -374,6 +374,8 @@ def collect_pipeline_options(env: ev.Environment, args) -> PipelineOptions:
     if "rebuild-index" in ci_config and ci_config["rebuild-index"] is False:
         options.rebuild_index = False
 
+    options.dynamic_stack = ci_config.get("dynamic", False)
+
     return options
 
 
@@ -388,17 +390,29 @@ def generate_pipeline(env: ev.Environment, args) -> None:
         args: (spack.main.SpackArgumentParser): Parsed arguments from the command
             line.
     """
-    with spack.concretize.disable_compiler_existence_check():
-        with env.write_transaction():
-            env.concretize()
-            env.write()
-
-    options = collect_pipeline_options(env, args)
-
     # Get the joined "ci" config with all of the current scopes resolved
     ci_config = cfg.get("ci")
     if not ci_config:
         raise SpackCIError("Environment does not have a `ci` configuration")
+
+    options = collect_pipeline_options(env, args)
+
+    # Generate a dynamic stack spec list
+    if options.dynamic_stack:
+        rev1, rev2 = get_change_revisions()
+        affected_pkgs = compute_affected_packages(rev1, rev2)
+        for pkg_name in affected_pkgs:
+            pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
+            if pkg_cls.dynamic_specs:
+                for spec in pkg_cls.dynamic_specs:
+                    env.add(spec)
+            else:
+                env.add(pkg_name)
+
+    with spack.concretize.disable_compiler_existence_check():
+        with env.write_transaction():
+            env.concretize()
+            env.write()
 
     # Get the target platform we should generate a pipeline for
     ci_target = ci_config.get("target", "gitlab")

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -391,6 +391,7 @@ class PipelineOptions:
         pipeline_type: Optional[PipelineType] = None,
         require_signing: bool = False,
         cdash_handler: Optional["CDashHandler"] = None,
+        dynamic_stack: bool = False,
     ):
         """
         Args:
@@ -410,6 +411,7 @@ class PipelineOptions:
             pipeline_type: Type of pipeline running (optional)
             require_signing: Require buildcache to be signed (fail w/out signing key)
             cdash_handler: Object for communicating build information with CDash
+            dynamic_stack: Generate the specs in the environment dynamically
         """
         self.env = env
         self.buildcache_destination = buildcache_destination
@@ -427,6 +429,7 @@ class PipelineOptions:
         self.pipeline_type = pipeline_type
         self.require_signing = require_signing
         self.cdash_handler = cdash_handler
+        self.dynamic_stack = dynamic_stack
 
 
 class PipelineNode:

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -719,6 +719,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     #: TestSuite instance used to manage stand-alone tests for 1+ specs.
     test_suite: Optional[Any] = None
 
+    dynamic_specs: Optional[List[str]] = None
+
     def __init__(self, spec):
         # this determines how the package should be built.
         self.spec: spack.spec.Spec = spec

--- a/lib/spack/spack/schema/ci.py
+++ b/lib/spack/spack/schema/ci.py
@@ -127,6 +127,19 @@ pipeline_gen_schema = {
 
 core_shared_properties = union_dicts(
     {
+        "dynamic": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["strategy"],
+            "properties": {
+                "strategy": {"type": "string", "enum": ["changed"]},
+                "refs": {
+                    "type": "array",
+                    "items": {"type": "string", "minItems": 2, "maxItems": 2},
+                    "default": ["HEAD^", "HEAD"],
+                },
+            },
+        },
         "pipeline-gen": pipeline_gen_schema,
         "rebuild-index": {"type": "boolean"},
         "broken-specs-url": {"type": "string"},

--- a/lib/spack/spack/schema/ci.py
+++ b/lib/spack/spack/schema/ci.py
@@ -127,19 +127,7 @@ pipeline_gen_schema = {
 
 core_shared_properties = union_dicts(
     {
-        "dynamic": {
-            "type": "object",
-            "additionalProperties": False,
-            "required": ["strategy"],
-            "properties": {
-                "strategy": {"type": "string", "enum": ["changed"]},
-                "refs": {
-                    "type": "array",
-                    "items": {"type": "string", "minItems": 2, "maxItems": 2},
-                    "default": ["HEAD^", "HEAD"],
-                },
-            },
-        },
+        "dynamic": {"type": "boolean"},
         "pipeline-gen": pipeline_gen_schema,
         "rebuild-index": {"type": "boolean"},
         "broken-specs-url": {"type": "string"},

--- a/share/spack/gitlab/cloud_pipelines/stacks/dynamic-x86_64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/dynamic-x86_64/spack.yaml
@@ -1,0 +1,34 @@
+spack:
+  view: false
+  packages:
+    all:
+      require: target=x86_64_v3
+
+  compilers:
+  - compiler:
+      spec: gcc@=10.2.1
+      paths:
+        cc: /opt/rh/devtoolset-10/root/usr/bin/gcc
+        cxx: /opt/rh/devtoolset-10/root/usr/bin/g++
+        f77: /opt/rh/devtoolset-10/root/usr/bin/gfortran
+        fc: /opt/rh/devtoolset-10/root/usr/bin/gfortran
+      flags: {}
+      operating_system: centos7
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+
+  ci:
+    # This stack has no specs by default
+    # the ci:dynamic field uses a strategy to determine which
+    # if any specs should be added to the stack based on which
+    # packages have been detected as changed.
+    dynamic:
+      strategy: changed
+    pipeline-gen:
+    - build-job:
+        image: ghcr.io/spack/spack/manylinux2014:2024.03.28
+
+  cdash:
+    build-group: Affected Specs

--- a/share/spack/gitlab/cloud_pipelines/stacks/dynamic-x86_64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/dynamic-x86_64/spack.yaml
@@ -24,8 +24,7 @@ spack:
     # the ci:dynamic field uses a strategy to determine which
     # if any specs should be added to the stack based on which
     # packages have been detected as changed.
-    dynamic:
-      strategy: changed
+    dynamic: true
     pipeline-gen:
     - build-job:
         image: ghcr.io/spack/spack/manylinux2014:2024.03.28


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Add a configuration option to dynamically add specs to a CI environment based on a strategy.  The only strategy implement here is for adding changed or affected specs based on a revision range.

This is waiting on additional refactors to CI and the Common CI stacks work to be merged.