### PR TITLE
gsoap: add v2.8.135

### DIFF
--- a/var/spack/repos/builtin/packages/gsoap/package.py
+++ b/var/spack/repos/builtin/packages/gsoap/package.py
@@ -17,13 +17,16 @@ class Gsoap(AutotoolsPackage, SourceforgePackage):
 
     maintainers("greenc-FNAL", "gartung", "marcmengel", "vitodb")
 
-    version("2.8.127", sha256="25ecad1bbc363494eb7ea95a68508e4c93cc20596fad9ebc196c6572bbbd3c08")
-    version("2.8.124", sha256="4b798780989338f665ef8e171bbcc422a271004d62d5852666d5eeca33a6a636")
-    version("2.8.119", sha256="8997c43b599a2bfe4a788e303a5dd24bbf5992fd06d56f606ca680ca5b0070cf")
-    version("2.8.114", sha256="aa70a999258100c170a3f8750c1f91318a477d440f6a28117f68bc1ded32327f")
-    version("2.8.113", sha256="e73782b618303cf55ea6a45751b75ba96797a7a12967ed9d02e6d5761977e73a")
-    version("2.8.112", sha256="05345312e0bb4d81c98ae63b97cff9eb097f38dafe09356189f9d8e235c54095")
-    version("2.8.111", sha256="f1670c7e3aeaa66bc5658539fbd162e5099f022666855ef2b2c2bac07fec4bd3")
+    version("2.8.135", sha256="b11757e405d55d4674dfbf88c4fa6d7e24155cf64ed8ed578ccad2f2b555e98d")
+    with default_args(deprecated=True):
+        # Unavailable for direct download anymore
+        version("2.8.127", sha256="25ecad1bbc363494eb7ea95a68508e4c93cc20596fad9ebc196c6572bbbd3c08")
+        version("2.8.124", sha256="4b798780989338f665ef8e171bbcc422a271004d62d5852666d5eeca33a6a636")
+        version("2.8.119", sha256="8997c43b599a2bfe4a788e303a5dd24bbf5992fd06d56f606ca680ca5b0070cf")
+        version("2.8.114", sha256="aa70a999258100c170a3f8750c1f91318a477d440f6a28117f68bc1ded32327f")
+        version("2.8.113", sha256="e73782b618303cf55ea6a45751b75ba96797a7a12967ed9d02e6d5761977e73a")
+        version("2.8.112", sha256="05345312e0bb4d81c98ae63b97cff9eb097f38dafe09356189f9d8e235c54095")
+        version("2.8.111", sha256="f1670c7e3aeaa66bc5658539fbd162e5099f022666855ef2b2c2bac07fec4bd3")
 
     depends_on("openssl")
     depends_on("pkgconfig", type="build")

--- a/var/spack/repos/builtin/packages/gsoap/package.py
+++ b/var/spack/repos/builtin/packages/gsoap/package.py
@@ -20,13 +20,27 @@ class Gsoap(AutotoolsPackage, SourceforgePackage):
     version("2.8.135", sha256="b11757e405d55d4674dfbf88c4fa6d7e24155cf64ed8ed578ccad2f2b555e98d")
     with default_args(deprecated=True):
         # Unavailable for direct download anymore
-        version("2.8.127", sha256="25ecad1bbc363494eb7ea95a68508e4c93cc20596fad9ebc196c6572bbbd3c08")
-        version("2.8.124", sha256="4b798780989338f665ef8e171bbcc422a271004d62d5852666d5eeca33a6a636")
-        version("2.8.119", sha256="8997c43b599a2bfe4a788e303a5dd24bbf5992fd06d56f606ca680ca5b0070cf")
-        version("2.8.114", sha256="aa70a999258100c170a3f8750c1f91318a477d440f6a28117f68bc1ded32327f")
-        version("2.8.113", sha256="e73782b618303cf55ea6a45751b75ba96797a7a12967ed9d02e6d5761977e73a")
-        version("2.8.112", sha256="05345312e0bb4d81c98ae63b97cff9eb097f38dafe09356189f9d8e235c54095")
-        version("2.8.111", sha256="f1670c7e3aeaa66bc5658539fbd162e5099f022666855ef2b2c2bac07fec4bd3")
+        version(
+            "2.8.127", sha256="25ecad1bbc363494eb7ea95a68508e4c93cc20596fad9ebc196c6572bbbd3c08"
+        )
+        version(
+            "2.8.124", sha256="4b798780989338f665ef8e171bbcc422a271004d62d5852666d5eeca33a6a636"
+        )
+        version(
+            "2.8.119", sha256="8997c43b599a2bfe4a788e303a5dd24bbf5992fd06d56f606ca680ca5b0070cf"
+        )
+        version(
+            "2.8.114", sha256="aa70a999258100c170a3f8750c1f91318a477d440f6a28117f68bc1ded32327f"
+        )
+        version(
+            "2.8.113", sha256="e73782b618303cf55ea6a45751b75ba96797a7a12967ed9d02e6d5761977e73a"
+        )
+        version(
+            "2.8.112", sha256="05345312e0bb4d81c98ae63b97cff9eb097f38dafe09356189f9d8e235c54095"
+        )
+        version(
+            "2.8.111", sha256="f1670c7e3aeaa66bc5658539fbd162e5099f022666855ef2b2c2bac07fec4bd3"
+        )
 
     depends_on("openssl")
     depends_on("pkgconfig", type="build")


### PR DESCRIPTION
This PR adds `gsoap`, v2.8.135. Older versions deprecated since not available for direct download anymore at https://sourceforge.net/projects/gsoap2/files/ (I assume users pick them up from the cache.)

Test build:
```
==> Installing gsoap-2.8.135-fuwx5yzns56mvxhgbv4s3m54uzsunw4d [11/11]
==> No binary for gsoap-2.8.135-fuwx5yzns56mvxhgbv4s3m54uzsunw4d found: installing from source
==> Fetching https://prdownloads.sourceforge.net/gsoap2/gsoap_2.8.135.zip
==> No patches needed for gsoap
==> gsoap: Executing phase: 'autoreconf'
==> gsoap: Executing phase: 'configure'
==> gsoap: Executing phase: 'build'
==> gsoap: Executing phase: 'install'
==> gsoap: Successfully installed gsoap-2.8.135-fuwx5yzns56mvxhgbv4s3m54uzsunw4d
  Stage: 6.94s.  Autoreconf: 0.00s.  Configure: 10.28s.  Build: 46.76s.  Install: 0.51s.  Post-install: 0.30s.  Total: 1m 5.19s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/gsoap-2.8.135-fuwx5yzns56mvxhgbv4s3m54uzsunw4d
```
