### PR TITLE
py-eventlet: fix url

### DIFF
--- a/var/spack/repos/builtin/packages/py-eventlet/package.py
+++ b/var/spack/repos/builtin/packages/py-eventlet/package.py
@@ -10,7 +10,7 @@ class PyEventlet(PythonPackage):
     """Concurrent networking library for Python"""
 
     homepage = "https://github.com/eventlet/eventlet"
-    url = "https://github.com/eventlet/eventlet/releases/download/v0.22.0/eventlet-0.22.0.tar.gz"
+    url = "https://github.com/eventlet/eventlet/archive/refs/tags/v0.22.0.tar.gz"
 
     license("MIT")
 

--- a/var/spack/repos/builtin/packages/py-eventlet/package.py
+++ b/var/spack/repos/builtin/packages/py-eventlet/package.py
@@ -14,7 +14,7 @@ class PyEventlet(PythonPackage):
 
     license("MIT")
 
-    version("0.22.0", sha256="6d22464f448fdf144a9d566c157299d686bbe324554dd7729df9ccd05ca66439")
+    version("0.22.0", sha256="c4cc92268b82eb94d5e0de0592159157d68122d394f480e3f9a9d6ddb695655e")
 
     depends_on("py-setuptools", type="build")
     depends_on("py-greenlet@0.3:")


### PR DESCRIPTION
This PR fixes the `py-eventlet` url, since the old url is dead. Updated checksum.