### PR TITLE
quicksilver: fix homepage

### DIFF
--- a/var/spack/repos/builtin/packages/quicksilver/package.py
+++ b/var/spack/repos/builtin/packages/quicksilver/package.py
@@ -13,7 +13,7 @@ class Quicksilver(MakefilePackage):
 
     tags = ["proxy-app"]
 
-    homepage = "https://codesign.llnl.gov/quicksilver.php"
+    homepage = "https://asc.llnl.gov/codes/proxy-apps/quicksilver"
     url = "https://github.com/LLNL/Quicksilver/tarball/V1.0"
     git = "https://github.com/LLNL/Quicksilver.git"
 


### PR DESCRIPTION
This PR fixes the homepage for `quicksilver`, since the previous one is dead.