### PR TITLE
sst-dumpi: fix homepage

### DIFF
--- a/var/spack/repos/builtin/packages/sst-dumpi/package.py
+++ b/var/spack/repos/builtin/packages/sst-dumpi/package.py
@@ -14,7 +14,7 @@ class SstDumpi(AutotoolsPackage):
     information, and PAPI counters.
     """
 
-    homepage = "http://sst.sandia.gov/about_dumpi.html"
+    homepage = "https://github.com/sstsimulator/sst-dumpi"
     url = "https://github.com/sstsimulator/sst-dumpi/archive/refs/tags/v13.0.0_Final.tar.gz"
     git = "https://github.com/sstsimulator/sst-dumpi.git"
 


### PR DESCRIPTION
This PR fixes the `sst-dumpi` homepage to not point to a dead link.