### PR TITLE
qt-base: fix rpath for dependents

### DIFF
--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -65,8 +65,11 @@ class QtPackage(CMakePackage):
             if re_qt.match(dep.name):
                 qt_prefix_path.append(self.spec[dep.name].prefix)
 
-        # Now append all qt-* dependency prefixex into a prefix path
+        # Now append all qt-* dependency prefixes into a prefix path
         args.append(self.define("QT_ADDITIONAL_PACKAGES_PREFIX_PATH", ":".join(qt_prefix_path)))
+
+        # Add all dependency prefix/lib directories to RPATH
+        args.append(self.define("QT_EXTRA_RPATHS", ":".join(p.lib for p in qt_prefix_path)))
 
         return args
 

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -70,9 +70,9 @@ class QtPackage(CMakePackage):
 
         # Make our CMAKE_INSTALL_RPATH redundant:
         # for prefix of current package ($ORIGIN/../lib type of rpaths),
-        define("QT_DISABLE_RPATH", True)
+        self.define("QT_DISABLE_RPATH", True)
         # for prefixes of dependencies
-        define("QT_NO_DISABLE_CMAKE_INSTALL_RPATH_USE_LINK_PATH", True)
+        self.define("QT_NO_DISABLE_CMAKE_INSTALL_RPATH_USE_LINK_PATH", True)
 
         return args
 

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -68,9 +68,11 @@ class QtPackage(CMakePackage):
         # Now append all qt-* dependency prefixes into a prefix path
         args.append(self.define("QT_ADDITIONAL_PACKAGES_PREFIX_PATH", ":".join(qt_prefix_path)))
 
-        # Add all dependency prefix/lib directories to RPATH
-        qt_extra_rpaths = [p.lib for p in qt_prefix_path] + [p.lib64 for p in qt_prefix_path]
-        args.append(self.define("QT_EXTRA_RPATHS", qt_extra_rpaths))
+        # Make our CMAKE_INSTALL_RPATH redundant:
+        # for prefix of current package ($ORIGIN/../lib type of rpaths), 
+        define("QT_DISABLE_RPATH", True)
+        # for prefixes of dependencies
+        define("QT_NO_DISABLE_CMAKE_INSTALL_RPATH_USE_LINK_PATH", True)
 
         return args
 

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -69,7 +69,7 @@ class QtPackage(CMakePackage):
         args.append(self.define("QT_ADDITIONAL_PACKAGES_PREFIX_PATH", ":".join(qt_prefix_path)))
 
         # Make our CMAKE_INSTALL_RPATH redundant:
-        # for prefix of current package ($ORIGIN/../lib type of rpaths), 
+        # for prefix of current package ($ORIGIN/../lib type of rpaths),
         define("QT_DISABLE_RPATH", True)
         # for prefixes of dependencies
         define("QT_NO_DISABLE_CMAKE_INSTALL_RPATH_USE_LINK_PATH", True)

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -69,7 +69,7 @@ class QtPackage(CMakePackage):
         args.append(self.define("QT_ADDITIONAL_PACKAGES_PREFIX_PATH", ":".join(qt_prefix_path)))
 
         # Add all dependency prefix/lib directories to RPATH
-        args.append(self.define("QT_EXTRA_RPATHS", ":".join(p.lib for p in qt_prefix_path)))
+        args.append(self.define("QT_EXTRA_RPATHS", ":".join(p + "/lib" for p in qt_prefix_path)))
 
         return args
 

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -70,9 +70,9 @@ class QtPackage(CMakePackage):
 
         # Make our CMAKE_INSTALL_RPATH redundant:
         # for prefix of current package ($ORIGIN/../lib type of rpaths),
-        self.define("QT_DISABLE_RPATH", True)
+        args.append(self.define("QT_DISABLE_RPATH", True))
         # for prefixes of dependencies
-        self.define("QT_NO_DISABLE_CMAKE_INSTALL_RPATH_USE_LINK_PATH", True)
+        args.append(self.define("QT_NO_DISABLE_CMAKE_INSTALL_RPATH_USE_LINK_PATH", True))
 
         return args
 

--- a/var/spack/repos/builtin/packages/qt-base/package.py
+++ b/var/spack/repos/builtin/packages/qt-base/package.py
@@ -69,7 +69,8 @@ class QtPackage(CMakePackage):
         args.append(self.define("QT_ADDITIONAL_PACKAGES_PREFIX_PATH", ":".join(qt_prefix_path)))
 
         # Add all dependency prefix/lib directories to RPATH
-        args.append(self.define("QT_EXTRA_RPATHS", ":".join(p + "/lib" for p in qt_prefix_path)))
+        qt_extra_rpaths = [p.lib for p in qt_prefix_path] + [p.lib64 for p in qt_prefix_path]
+        args.append(self.define("QT_EXTRA_RPATHS", qt_extra_rpaths))
 
         return args
 


### PR DESCRIPTION
This PR fixes the linking (rpath handling) of qt-base dependents. This fixes a regression introduced in #46685 (which was the right thing to do).

Consider the installation of `qt-shadertools ^qt-base`. When the executable `qsb` is installed, it links against `libQt6ShaderTools.so`, which links against `libQt6Core.so`.

Before #46685 (qt-base and many other things in rpath):
```
-- Installing: /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-w4u4za2oq377w73afgj4gahlazkgbepi/bin/qsb
-- Set non-toolchain portion of runtime path of "/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-w4u4za2oq377w73afgj4gahlazkgbepi/bin/qsb" to "/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-w4u4za2oq377w73afgj4gahlazkgbepi/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-w4u4za2oq377w73afgj4gahlazkgbepi/lib64:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/gcc-runtime-14.2.0-oxp4lkxjn6l6jmfini7eo3phwurr7sox/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-base-6.8.0-wu2we3wf6uvgj5hnna3mtgf3qhkz5kn7/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/double-conversion-3.3.0-hwqt5pgidlumimfuufyzwyfm5tvco533/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/fontconfig-2.15.0-diitizwjtwr4gf2dpts6eusdpt2qfdde/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/font-util-1.4.1-alhczhf7kvecqnzy3v3yrcbxwvprgeho/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/freetype-2.13.2-iichvd4j52gdkgvkpictimyhkknig6je/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/bzip2-1.0.8-dmfzprl5vwyrsn7nclsgqx53qxpk37yu/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libpng-1.6.39-lkidhk6l7z62koopwbaje43yzlvwvb6b/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/zlib-ng-2.2.1-qm5ncziecfqsmhqluqhzv3s75y3xpdv5/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libxml2-2.13.4-rigsdfwace7pwbqes7uwbtwc35ox22hf/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libiconv-1.17-ztwikj6tb4qtniesdfwqyzzh7v2o5wou/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/xz-5.4.6-2jtw3ayrd3eyhw63vwxomug22l3znaem/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/util-linux-uuid-2.40.2-nxoqirxu33364r5e6v6zpaz2gy5gigqf/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/harfbuzz-10.0.1-qodlkub4j7ba2ga4u7hyho5bbz5gqajj/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/cairo-1.18.0-76athrymm4oncxx3hrpwho2a4oibgcw6/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/glib-2.80.3-xkc4b3kkiuqqneveffnkpxnln5ycvtms/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/elfutils-0.191-izq2lph4cwejar6liuuoh7p66afscdkz/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/gettext-0.22.5-oh3inx5nvrlks3tzw2s6iofyfcbdxf3a/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/ncurses-6.5-u75heumlr3tu2lghbpy53s6dij5fhj4k/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/pkgconf-2.3.0-ordb2yizgftekkx6lw5bwwlfxlc2kmqq/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/zstd-1.5.6-x5axsbrc7tgpvf7pjd26ffm7qusni6ed/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libffi-3.4.6-yn7pttd3psicv5apaelqfewdj6s4xngd/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/pcre2-10.44-jpzaxxwnfy7tvkbbe5ajf2u6p5ermkzc/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/meson-1.6.0-vwkncngizwjfryzpy3xtvgxotnipalef/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/pixman-0.42.2-focphl7ofemgpmblb2d26km3yw73q7pg/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/zlib-1.3.1-b6mwv32whj7uimtg5wyf4ysx6eve2rs4/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/gobject-introspection-1.78.1-qhqruo6dj6qt2jak5utgvia2ppkh5cbp/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/python-3.11.9-5mg3uwkarq34i7za3peqmc5txm5ibks6/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/expat-2.6.3-mwdxvvlwcoy7rtmu5nfksdnxcwlydvel/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libbsd-0.12.2-dhjpzijh4hpzfwmpsts5huhaexpmoon5/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libmd-1.1.0-th37bkyj5mwvhtvssrsweng65m34hu6h/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/gdbm-1.23-53nwimp5agn6lukvynricfyvvp7rmhcw/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/readline-8.2-yk7clyqkvzoxvjz3daqm4qlizrfcqvp5/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libxcrypt-4.4.36-ch33phr6zezfbekbwjnnm2kejbdugxpm/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/sqlite-3.46.0-uefq7querbnikgx3y2tbxyr3ey32lzvi/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/icu4c-74.2-f4x24jskuopwb3vus5fbrxa3kbhy4ned/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libdrm-2.4.123-jszrdonedovchlxyojeqzifkqbfd2xau/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libpciaccess-0.17-6ipuk6rq2hj744zxlhlp2kxoh36jur3l/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libpthread-stubs-0.5-kiruvlsp3pfwuu2jqh7572tkbfrxeyu7/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libjpeg-turbo-3.0.3-3bevhon6xmqrt3j2uibkaaoqma2u3j6s/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libproxy-0.4.17-yco3iujet3c7aybkrhqrh3deukjpc2qi/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libx11-1.8.10-k6dq4oryqs6slsj27alpj6szzcbziojp/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/kbproto-1.0.7-tzlsvyqnsfurdowqb3m2ip6nidoyw42p/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libxcb-1.17.0-wlxckrz73nndzcxlj3qcfdf3v5dt37p7/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libxau-1.0.11-kmokhksbtow55lyrajmjhymr6suinbbu/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/xproto-7.0.31-3p2gxigc7bosemxu5mn5atm43wsjkyis/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libxdmcp-1.1.5-u3ozsdgvg5sigzfs3dvuitarnqpohlqu/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libxkbcommon-1.7.0-bjqi4qgnys2itjmbfm5ri6sujrxgutst/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/wayland-1.23.0-o4mucqibb7pvni7brf744wix7ixtpbsw/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/libxrender-0.9.11-xzcfd4zgvhebmbwv4fh2mfroupreac2x/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/renderproto-0.11.1-26eefht36wzjbppzowack75ulkelhjyw/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/xcb-util-0.4.1-cc2jomia2ecxtljnuqq5z3t4hbij46ou/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/xcb-util-cursor-0.1.4-x2362i75rn4py7wfyirjfoispkzuifzl/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/xcb-util-image-0.4.1-t2sud63nexbf4sxzgtj67xbmznku4uxk/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/xcb-util-renderutil-0.3.10-cra3xvahkedwuonv456pstmpolzffbho/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/xcb-util-keysyms-0.4.1-d44hcqowvk465oltrfyq2fy3hczr36he/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/xcb-util-wm-0.4.2-6u7fgdcmlkgmdyknkxi4g6phzripjdab/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/openssl-3.4.0-p7dr2wthxmafzozbvj57k6mdalcadkno/lib64:$ORIGIN/../lib"
```

After #46685 (qt-base not included in rpath):
```
-- Installing: /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-xmqfv3ajscpuuc2i6wbko7w5sbvuznzo/bin/qsb
-- Set non-toolchain portion of runtime path of "/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-xmqfv3ajscpuuc2i6wbko7w5sbvuznzo/bin/qsb" to "/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-xmqfv3ajscpuuc2i6wbko7w5sbvuznzo/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-xmqfv3ajscpuuc2i6wbko7w5sbvuznzo/lib64:$ORIGIN/../lib"
```
resulting in
```
$ ldd /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-xmqfv3ajscpuuc2i6wbko7w5sbvuznzo/bin/qsb
/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-xmqfv3ajscpuuc2i6wbko7w5sbvuznzo/bin/qsb: /lib/x86_64-linux-gnu/libQt6Core.so.6: version `Qt_6.8' not found (required by /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-xmqfv3ajscpuuc2i6wbko7w5sbvuznzo/bin/qsb)
/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-xmqfv3ajscpuuc2i6wbko7w5sbvuznzo/bin/qsb: /lib/x86_64-linux-gnu/libQt6Core.so.6: version `Qt_6.8' not found (required by /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-xmqfv3ajscpuuc2i6wbko7w5sbvuznzo/lib/libQt6ShaderTools.so.6)
        linux-vdso.so.1 (0x00007cb7aab2f000)
        libQt6ShaderTools.so.6 => /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-xmqfv3ajscpuuc2i6wbko7w5sbvuznzo/lib/libQt6ShaderTools.so.6 (0x00007cb7a9e00000)
        libQt6Gui.so.6 => /lib/x86_64-linux-gnu/libQt6Gui.so.6 (0x00007cb7a9600000)
        libQt6Core.so.6 => /lib/x86_64-linux-gnu/libQt6Core.so.6 (0x00007cb7a9000000)
        libstdc++.so.6 => /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/gcc-runtime-14.2.0-oxp4lkxjn6l6jmfini7eo3phwurr7sox/lib/libstdc++.so.6 (0x00007cb7a8c00000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007cb7a8800000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007cb7a8f13000)
        libgcc_s.so.1 => /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/gcc-runtime-14.2.0-oxp4lkxjn6l6jmfini7eo3phwurr7sox/lib/libgcc_s.so.1 (0x00007cb7aaab8000)
```

After this PR, where we inject the dependency lib dir into `QT_EXTRA_RPATHS` (qt-base included in rpath again, and nothing else much):
```
-- Installing: /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-w4u4za2oq377w73afgj4gahlazkgbepi/bin/qsb
-- Set non-toolchain portion of runtime path of "/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-w4u4za2oq377w73afgj4gahlazkgbepi/bin/qsb" to "/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-w4u4za2oq377w73afgj4gahlazkgbepi/lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-shadertools-6.8.0-w4u4za2oq377w73afgj4gahlazkgbepi/lib64:$ORIGIN/../lib:/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/qt-base-6.8.0-wu2we3wf6uvgj5hnna3mtgf3qhkz5kn7/lib"
```
and proper rpath linking is done to the actual dependents.

In my opinion, this seems to be a bug 'somewhere' in the Qt6 build system, which tries to install all packages into the same prefix as `qt-base`. In that case there is no difference between the rpath for qt-shadertools and for qt-base.