### PR TITLE
`.libs` search searches up to maximum depth of 2 by default

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2074,7 +2074,7 @@ class HeaderList(FileList):
         self._macro_definitions.append(macro)
 
 
-def find_headers(headers, root, recursive=False):
+def find_headers(headers, root, recursive=False, max_depth: Optional[int] = None):
     """Returns an iterable object containing a list of full paths to
     headers if found.
 
@@ -2126,7 +2126,7 @@ def find_headers(headers, root, recursive=False):
     # List of headers we are searching with suffixes
     headers = ["{0}.{1}".format(header, suffix) for header in headers for suffix in suffixes]
 
-    return HeaderList(find(root, headers, recursive))
+    return HeaderList(find(root, headers, recursive, max_depth=max_depth))
 
 
 @system_path_filter

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1158,9 +1158,12 @@ def _libs_default_handler(spec: "Spec"):
     )
 
     for shared in search_shared:
-        # Since we are searching for link libraries, on Windows search only for
-        # ".Lib" extensions by default as those represent import libraries for implicit links.
-        libs = fs.find_libraries(name, home, shared=shared, recursive=True, runtime=False)
+        # Set runtime=False: we want find libraries used for linking by default
+        # Set max_depth=2: we default to searching the root directory and two levels
+        #     of directories underneath it, but we don't recurse beyond that by default
+        libs = fs.find_libraries(
+            name, home, shared=shared, recursive=True, runtime=False, max_depth=2
+        )
         if libs:
             return libs
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1110,7 +1110,7 @@ def _headers_default_handler(spec: "Spec"):
         NoHeadersError: If no headers are found
     """
     home = getattr(spec.package, "home")
-    headers = fs.find_headers("*", root=home.include, recursive=True)
+    headers = fs.find_headers("*", root=home.include, recursive=True, max_depth=1)
 
     if headers:
         return headers


### PR DESCRIPTION
Follow up to https://github.com/spack/spack/pull/41945

Partial fix to https://github.com/spack/spack/issues/24418

#41945 updated Spack's `find()` functionality to offer more control over recursive searches (and also follow symlinks, but it's primary purpose was to allow the user to apply a depth limit to recursive searches).

This makes use of #41945 so that for a given package, if you invoke `.libs` on it to search for its associated libraries, it will only search up to depth 2 (i.e. will find something in `root/x/y/` but not `root/x/y/z/`)