### PR TITLE
paraview: add forward compat bound with cuda

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -325,6 +325,9 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8474
     depends_on("proj@8.1.0", when="@5.11:")
 
+    # Patches to vendored VTK-m are needed for forward compat with CUDA 12 (mr 2972 and 3259)
+    depends_on("cuda@:11", when="+cuda")
+
     patch("stl-reader-pv440.patch", when="@4.4.0")
 
     # Broken gcc-detection - improved in 5.1.0, redundant later


### PR DESCRIPTION
For the Paraview maintainers: feel free to unvendor VTK-m or if that is not possible repeat the patches in Paraview.

This PR is just to fix build failures on develop, even if it is "too strict".