### PR TITLE
omega-h: fix versioning and cuda compat

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse_v1/spack.yaml
@@ -225,7 +225,7 @@ spack:
   - magma +cuda cuda_arch=75
   - mfem +cuda cuda_arch=75
   - mgard +serial +openmp +timing +unstructured +cuda cuda_arch=75
-  - omega-h +cuda cuda_arch=75
+  - "omega-h@:9 +cuda cuda_arch=75"  # https://github.com/SCOREC/omega_h/issues/116
   - parsec +cuda cuda_arch=75
   - petsc +cuda cuda_arch=75
   - py-torch +cuda cuda_arch=75
@@ -274,7 +274,7 @@ spack:
   - magma +cuda cuda_arch=80
   - mfem +cuda cuda_arch=80
   - mgard +serial +openmp +timing +unstructured +cuda cuda_arch=80
-  - omega-h +cuda cuda_arch=80
+  - "omega-h@:9 +cuda cuda_arch=80"  # https://github.com/SCOREC/omega_h/issues/116
   - parsec +cuda cuda_arch=80
   - petsc +cuda cuda_arch=80
   - py-torch +cuda cuda_arch=80

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
@@ -233,7 +233,7 @@ spack:
   - magma +cuda cuda_arch=70
   - mfem +cuda cuda_arch=70
   - mgard +serial +openmp +timing +unstructured +cuda cuda_arch=70
-  - omega-h +cuda cuda_arch=70
+  - "omega-h@:9 +cuda cuda_arch=70"  # https://github.com/SCOREC/omega_h/issues/116
   - parsec +cuda cuda_arch=70
   - petsc +cuda cuda_arch=70
   - raja +cuda cuda_arch=70

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -239,7 +239,7 @@ spack:
   - libpressio +bitgrooming +bzip2 +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp +json +remote +netcdf +cusz +mgard +cuda cuda_arch=80 ^cusz +cuda cuda_arch=80
   - magma +cuda cuda_arch=80
   - mfem +cuda cuda_arch=80
-  - omega-h +cuda cuda_arch=80
+  - "omega-h@:9 +cuda cuda_arch=80"  # https://github.com/SCOREC/omega_h/issues/116
   - parsec +cuda cuda_arch=80
   - petsc +cuda cuda_arch=80
   - py-torch +cuda cuda_arch=80

--- a/var/spack/repos/builtin/packages/ceed/package.py
+++ b/var/spack/repos/builtin/packages/ceed/package.py
@@ -240,7 +240,7 @@ class Ceed(BundlePackage, CudaPackage, ROCmPackage):
 
     # Omega_h
     # ceed-5.0
-    depends_on("omega-h@scorec.10.1.0", when="@5.0.0+omega-h")
+    depends_on("omega-h@10.1.0", when="@5.0.0+omega-h")
     depends_on("omega-h~trilinos", when="@5.0.0+omega-h+quickbuild")
 
     # MFEM, Laghos, Remhos

--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -20,22 +20,22 @@ class OmegaH(CMakePackage, CudaPackage):
     tags = ["e4s"]
     version("main", branch="main")
     version(
-        "scorec.10.8.5",
+        "10.8.5-scorec",
         commit="62026fc305356abb5e02a9fce3fead9cf5077fbe",
         git="https://github.com/SCOREC/omega_h.git",
     )
     version(
-        "scorec.10.7.0",
+        "10.7.0-scorec",
         commit="0e5de8618c3370f702e08c1b1af476dbbc118892",
         git="https://github.com/SCOREC/omega_h.git",
     )
     version(
-        "scorec.10.6.0",
+        "10.6.0-scorec",
         commit="f376fad4741b55a4b2482218eb3437d719b7c72e",
         git="https://github.com/SCOREC/omega_h.git",
     )
     version(
-        "scorec.10.1.0",
+        "10.1.0-scorec",
         commit="e88912368e101d940f006019585701a704295ab0",
         git="https://github.com/SCOREC/omega_h.git",
     )
@@ -73,26 +73,16 @@ class OmegaH(CMakePackage, CudaPackage):
     depends_on("trilinos +kokkos", when="+trilinos")
     depends_on("kokkos", when="+kokkos")
     depends_on("zlib-api", when="+zlib")
-    # Note: '+cuda' and 'cuda_arch' variants are added by the CudaPackage
-    depends_on("cuda", when="+cuda")
-    conflicts(
-        "^cuda@11.2",
-        when="@scorec.10.1.0:",
-        msg="Thrust is broken in CUDA = 11.2.* see https://github.com/sandialabs/omega_h/issues/366",
-    )
-    conflicts(
-        "^cuda@:11.3",
-        when="@scorec.10.8.5:",
-        msg="see https://github.com/SCOREC/omega_h/issues/66",
-    )
 
-    # the sandia repo has a fix for cuda > 11.2 support
-    #  see github.com/sandialabs/omega_h/pull/373
-    conflicts(
-        "^cuda@11.2",
-        when="@:9.34.4",
-        msg="Thrust is broken in CUDA = 11.2.* see https://github.com/sandialabs/omega_h/issues/366",
-    )
+    with when("+cuda"):
+        # https://github.com/SCOREC/omega_h/commit/40a2d36d0b747a7147aeed238a0323f40b227cb2
+        depends_on("cuda@11.4:", when="@10.8.3:")
+
+        # https://github.com/SCOREC/omega_h/commit/c2109d2900696974ee66c3fbe6a1ec0e93b66cb6
+        depends_on("cuda@:11", when="@:10.6")
+
+        # Single, broken CUDA version.
+        conflicts("^cuda@11.2", msg="See https://github.com/sandialabs/omega_h/issues/366")
 
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86610
     conflicts("%gcc@8:8.2", when="@:9.22.1")
@@ -120,9 +110,8 @@ class OmegaH(CMakePackage, CudaPackage):
             args.append("-DBUILD_SHARED_LIBS:BOOL=OFF")
         if "+mpi" in self.spec:
             args.append("-DOmega_h_USE_MPI:BOOL=ON")
-            ver = self.spec.version
             # old versions don't call find_package(MPI)
-            if ver < Version("9.33.2") and "scorec" not in str(ver):
+            if self.spec.satisfies("@:9.33.1"):
                 args.append("-DCMAKE_CXX_COMPILER:FILEPATH={0}".format(self.spec["mpi"].mpicxx))
         else:
             args.append("-DOmega_h_USE_MPI:BOOL=OFF")
@@ -131,7 +120,7 @@ class OmegaH(CMakePackage, CudaPackage):
             cuda_arch_list = self.spec.variants["cuda_arch"].value
             cuda_arch = cuda_arch_list[0]
             if cuda_arch != "none":
-                if "scorec" in str(self.spec.version):
+                if self.spec.satisfies("@10:"):
                     args.append("-DOmega_h_CUDA_ARCH={0}".format(cuda_arch))
                 else:
                     args.append("-DCMAKE_CUDA_FLAGS=-arch=sm_{0}".format(cuda_arch))
@@ -174,7 +163,7 @@ class OmegaH(CMakePackage, CudaPackage):
 
     def test_mesh(self):
         """test construction, adaptation, and conversion of a mesh"""
-        if self.spec.satisfies("@:9.34.0") and not self.spec.satisfies("@:scorec"):
+        if self.spec.satisfies("@:9.34.0"):
             raise SkipTest("Package must be installed as version 9.34.1 or later")
 
         with test_part(self, "test_mesh_create", purpose="mesh construction"):

--- a/var/spack/repos/builtin/packages/xsdk/package.py
+++ b/var/spack/repos/builtin/packages/xsdk/package.py
@@ -216,7 +216,7 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
 
     xsdk_depends_on("omega-h +trilinos", when="+trilinos +omega-h")
     xsdk_depends_on("omega-h ~trilinos", when="~trilinos +omega-h")
-    xsdk_depends_on("omega-h@scorec.10.6.0", when="@1.0.0 +omega-h")
+    xsdk_depends_on("omega-h@10.6.0", when="@1.0.0 +omega-h")
     xsdk_depends_on("omega-h@9.34.13", when="@0.8.0 +omega-h")
 
     xsdk_depends_on("strumpack ~cuda", when="~cuda +strumpack")


### PR DESCRIPTION
This fixes among other things broken develop.

The scorec version prefix messes with order, so use a suffix instead (which might as well be dropped given there is no development in the original repo).

Also add cuda forward compat bound to deal with current build failure on develop.

Stick to omega-h@:9 because of build failures reported upstream.