### PR TITLE
geomodel: Fix dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/builtin/packages/geomodel/package.py
@@ -65,10 +65,11 @@ class Geomodel(CMakePackage):
 
     depends_on("geant4", when="+geomodelg4")
     depends_on("geant4", when="+fullsimlight")
+    depends_on("hdf5+cxx", when="+fullsimlight")
     depends_on("hepmc3", when="+hepmc3")
     depends_on("pythia8", when="+pythia")
     with when("+visualization"):
-        depends_on("hdf5")
+        depends_on("hdf5+cxx")
         depends_on("qt-base +gui +opengl +sql +widgets")
         depends_on("opengl")
 

--- a/var/spack/repos/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/builtin/packages/geomodel/package.py
@@ -70,7 +70,8 @@ class Geomodel(CMakePackage):
     depends_on("pythia8", when="+pythia")
     with when("+visualization"):
         depends_on("hdf5+cxx")
-        depends_on("qt-base +gui +opengl +sql +widgets")
+        depends_on("qt +gui +opengl +sql")
+        depends_on("coin3d")
         depends_on("opengl")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/builtin/packages/geomodel/package.py
@@ -72,7 +72,7 @@ class Geomodel(CMakePackage):
         depends_on("hdf5+cxx")
         depends_on("qt +gui +opengl +sql")
         depends_on("coin3d")
-        depends_on("soqt qt=5")
+        depends_on("soqt")
         depends_on("opengl")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/builtin/packages/geomodel/package.py
@@ -72,6 +72,7 @@ class Geomodel(CMakePackage):
         depends_on("hdf5+cxx")
         depends_on("qt +gui +opengl +sql")
         depends_on("coin3d")
+        depends_on("soqt qt=5")
         depends_on("opengl")
 
     def cmake_args(self):


### PR DESCRIPTION
This PRs makes the following changes

- Change existing dependency on `hdf5` to `hdf5+cxx`
- Add dependency on `hdf5` when building `+fullsimlight`
- GeoModel can build with Qt6 **if it ships with the Qt5 compatibility layer**. The Qt6 spec (`qt-base`) does not have this ability, and there is a Qt5 spec (`qt`), so I'm switching this spec over to just use Qt5 for now. `qt` doesn't have the `+widgets` variant, but the build seems to build without.
- GeoModel visualization requires `coin3d` to build