### PR TITLE
py-netifaces: add v0.10.9, v0.11.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-netifaces/package.py
+++ b/var/spack/repos/builtin/packages/py-netifaces/package.py
@@ -14,7 +14,7 @@ class PyNetifaces(PythonPackage):
 
     license("MIT", checked_by="wdconinc")
 
-    version("0.11.0", sha256="043a79146eb2907edf439899f262b3dfe41717d34124298ed281139a8b93ca32") 
+    version("0.11.0", sha256="043a79146eb2907edf439899f262b3dfe41717d34124298ed281139a8b93ca32")
     version("0.10.9", sha256="2dee9ffdd16292878336a58d04a20f0ffe95555465fee7c9bd23b3490ef2abf3")
     version("0.10.5", sha256="59d8ad52dd3116fcb6635e175751b250dc783fb011adba539558bd764e5d628b")
 

--- a/var/spack/repos/builtin/packages/py-netifaces/package.py
+++ b/var/spack/repos/builtin/packages/py-netifaces/package.py
@@ -9,15 +9,15 @@ from spack.package import *
 class PyNetifaces(PythonPackage):
     """Portable network interface information"""
 
-    homepage = (
-        "https://0xbharath.github.io/python-network-programming/libraries/netifaces/index.html"
-    )
+    homepage = "https://github.com/al45tair/netifaces"
     pypi = "netifaces/netifaces-0.10.5.tar.gz"
 
-    license("Unlicense")
+    license("MIT", checked_by="wdconinc")
 
+    version("0.11.0", sha256="043a79146eb2907edf439899f262b3dfe41717d34124298ed281139a8b93ca32") 
+    version("0.10.9", sha256="2dee9ffdd16292878336a58d04a20f0ffe95555465fee7c9bd23b3490ef2abf3")
     version("0.10.5", sha256="59d8ad52dd3116fcb6635e175751b250dc783fb011adba539558bd764e5d628b")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
This PR adds `py-netifaces`, v0.11.0. No build system changes. Fixed homepage. Fixed license.

Test build:
```
==> Installing py-netifaces-0.11.0-va4ptzrgpnhagtzypsmekxj65m3qnzue [28/28]
==> No binary for py-netifaces-0.11.0-va4ptzrgpnhagtzypsmekxj65m3qnzue found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/n/netifaces/netifaces-0.11.0.tar.gz
==> No patches needed for py-netifaces
==> py-netifaces: Executing phase: 'install'
==> py-netifaces: Successfully installed py-netifaces-0.11.0-va4ptzrgpnhagtzypsmekxj65m3qnzue
  Stage: 1.74s.  Install: 4.13s.  Post-install: 0.28s.  Total: 6.29s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/py-netifaces-0.11.0-va4ptzrgpnhagtzypsmekxj65m3qnzue
```