### PR TITLE
add a '+no_warning' variant to METIS to prevent pervasive warning

### DIFF
--- a/var/spack/repos/builtin/packages/draco/package.py
+++ b/var/spack/repos/builtin/packages/draco/package.py
@@ -77,6 +77,7 @@ class Draco(CMakePackage):
     depends_on("lapack", when="+lapack")
     depends_on("libquo@1.3.1:", when="@7.4.0:+libquo")
     depends_on("metis", when="+parmetis")
+    depends_on("metis@5:+no_warning", when="@7.19:+parmetis")
     depends_on("parmetis", when="+parmetis")
     depends_on("qt", when="+qt", type=("build", "link", "run"))
     depends_on("superlu-dist@:5", when="@:7.6+superlu_dist")

--- a/var/spack/repos/builtin/packages/metis/no_warning.patch
+++ b/var/spack/repos/builtin/packages/metis/no_warning.patch
@@ -1,0 +1,13 @@
+diff --git a/libmetis/pmetis.c b/libmetis/pmetis.c
+index 9174aa3..f8ced79 100644
+--- a/libmetis/pmetis.c
++++ b/libmetis/pmetis.c
+@@ -163,8 +163,6 @@ idx_t MlevelRecursiveBisection(ctrl_t *ctrl, graph_t *graph, idx_t nparts,
+   real_t wsum, *tpwgts2;
+ 
+   if ((nvtxs = graph->nvtxs) == 0) {
+-    printf("\t***Cannot bisect a graph with 0 vertices!\n"
+-           "\t***You are trying to partition a graph into too many parts!\n");
+     return 0;
+   }
+ 

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -34,8 +34,8 @@ class Metis(CMakePackage, MakefilePackage):
     depends_on("c", type="build")  # generated
 
     variant(
-        "no_warning", 
-        default=False, 
+        "no_warning",
+        default=False,
         description="Disable failed partition warning print on all ranks",
     )
     patch("no_warning.patch", when="@5:+no_warning")

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -33,6 +33,9 @@ class Metis(CMakePackage, MakefilePackage):
 
     depends_on("c", type="build")  # generated
 
+    variant("no_warning", default=False, description="Disable failed partition warning print on all ranks")
+    patch("no_warning.patch", when="@5:+no_warning")
+
     build_system(
         conditional("cmake", when="@5:"), conditional("makefile", when="@:4"), default="cmake"
     )

--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -33,7 +33,11 @@ class Metis(CMakePackage, MakefilePackage):
 
     depends_on("c", type="build")  # generated
 
-    variant("no_warning", default=False, description="Disable failed partition warning print on all ranks")
+    variant(
+        "no_warning", 
+        default=False, 
+        description="Disable failed partition warning print on all ranks",
+    )
     patch("no_warning.patch", when="@5:+no_warning")
 
     build_system(


### PR DESCRIPTION
There is a pervasive warning in METIS that causes a proliferation of output that can't be controlled via the METIS or ParMETIS interfaces.  This change set creates a +no_warning variant of METIS to optionally remove these warnings. 

- Add patch file to remove print statements
- Add optional +no_warning variant to METIS
- Enable the METIS +no_warning variant for the latest draco dependency