### PR TITLE
mivisionx, migraphx and rocal: add and fix tests

### DIFF
--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -136,6 +136,9 @@ class Migraphx(CMakePackage):
             env.set("CXXFLAGS", "-fsanitize=address -shared-libasan")
             env.set("LDFLAGS", "-fuse-ld=lld")
 
+    def setup_run_environment(self,env):
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["roctracer-dev"].prefix.lib)
+
     def cmake_args(self):
         spec = self.spec
         abspath = spec["abseil-cpp"].prefix.include
@@ -159,6 +162,7 @@ class Migraphx(CMakePackage):
                     "CMAKE_CXX_FLAGS", "-fsanitize=address -shared-libasan -I{0}".format(abspath)
                 )
             )
+        args.append(self.define("BUILD_TESTING", self.run_tests))
         return args
 
     def test_unit_tests(self):

--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -136,7 +136,7 @@ class Migraphx(CMakePackage):
             env.set("CXXFLAGS", "-fsanitize=address -shared-libasan")
             env.set("LDFLAGS", "-fuse-ld=lld")
 
-    def setup_run_environment(self,env):
+    def setup_run_environment(self, env):
         env.prepend_path("LD_LIBRARY_PATH", self.spec["roctracer-dev"].prefix.lib)
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -136,9 +136,6 @@ class Migraphx(CMakePackage):
             env.set("CXXFLAGS", "-fsanitize=address -shared-libasan")
             env.set("LDFLAGS", "-fuse-ld=lld")
 
-    def setup_run_environment(self, env):
-        env.prepend_path("LD_LIBRARY_PATH", self.spec["roctracer-dev"].prefix.lib)
-
     def cmake_args(self):
         spec = self.spec
         abspath = spec["abseil-cpp"].prefix.include

--- a/var/spack/repos/builtin/packages/miopen-hip/0001-link-with-roctracer-when-building-miopendriver-6.1.0.patch
+++ b/var/spack/repos/builtin/packages/miopen-hip/0001-link-with-roctracer-when-building-miopendriver-6.1.0.patch
@@ -1,26 +1,42 @@
-From bbfc08e034b80d8b8c6895cb74c38544ffa9a9b4 Mon Sep 17 00:00:00 2001
-From: sreenivasa murthy kolam <sreenivasamurthy.kolam@amd.com>
-Date: Thu, 24 Oct 2024 14:01:27 +0000
+From ea1ff66e448c977da9c5cff74e201850d6b9b04c Mon Sep 17 00:00:00 2001
+From: Afzal Patel <Afzal.Patel@amd.com>
+Date: Thu, 7 Nov 2024 22:08:17 +0000
 Subject: [PATCH] link with roctracer when building miopendriver for 6.1.0
 
 ---
- driver/CMakeLists.txt | 3 +++
- 1 file changed, 3 insertions(+)
+ driver/CMakeLists.txt | 4 ++++
+ src/CMakeLists.txt    | 3 ++-
+ 2 files changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/driver/CMakeLists.txt b/driver/CMakeLists.txt
-index 7d4fdbb..31de1ba 100644
+index 7d4fdbb..9e5ede5 100644
 --- a/driver/CMakeLists.txt
 +++ b/driver/CMakeLists.txt
-@@ -34,6 +34,9 @@ endif()
+@@ -34,6 +34,10 @@ endif()
  add_dependencies(MIOpenDriver generate_kernels)
  target_include_directories(MIOpenDriver PRIVATE ../src/kernels)
  target_link_libraries(MIOpenDriver MIOpen Threads::Threads)
 +if(MIOPEN_USE_ROCTRACER)
++    target_include_directories(MIOpenDriver PRIVATE ${ROCTRACER_INCLUDE_DIR})
 +    target_link_libraries(MIOpenDriver ${rocTracer})
 +endif()
  if(NOT MIOPEN_EMBED_DB STREQUAL "")
  target_link_libraries(MIOpenDriver $<BUILD_INTERFACE:miopen_data> )
  endif()
--- 
-2.39.3
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 0741a60..47573d4 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -861,7 +861,8 @@ if(NOT WIN32 AND NOT APPLE)
+ endif()
+
+ if(MIOPEN_USE_ROCTRACER)
+-    target_link_libraries(MIOpen PRIVATE roctx64)
++    target_include_directories(MIOpen PRIVATE ${ROCTRACER_INCLUDE_DIR})
++    target_link_libraries(MIOpen PRIVATE ${rocTracer})
+ endif()
+
+ ############################################################
+--
+2.43.5
 

--- a/var/spack/repos/builtin/packages/miopen-hip/0001-link-with-roctracer-when-building-miopendriver-6.2.0.patch
+++ b/var/spack/repos/builtin/packages/miopen-hip/0001-link-with-roctracer-when-building-miopendriver-6.2.0.patch
@@ -1,26 +1,41 @@
-From 5565f0bf0a8e7b8217ed1a943a4210fec303ec42 Mon Sep 17 00:00:00 2001
-From: sreenivasa murthy kolam <sreenivasamurthy.kolam@amd.com>
-Date: Thu, 24 Oct 2024 13:55:01 +0000
+From 3cb81598fd66aab0fa5b0c6aac654a91ed90e872 Mon Sep 17 00:00:00 2001
+From: Afzal Patel <Afzal.Patel@amd.com>
+Date: Thu, 7 Nov 2024 21:42:15 +0000
 Subject: [PATCH] link with roctracer when building miopendriver
 
 ---
- driver/CMakeLists.txt | 3 +++
- 1 file changed, 3 insertions(+)
+ driver/CMakeLists.txt | 4 ++++
+ src/CMakeLists.txt    | 3 ++-
+ 2 files changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/driver/CMakeLists.txt b/driver/CMakeLists.txt
-index 8f19a90..6c701d6 100644
+index 8f19a90..6d32b83 100644
 --- a/driver/CMakeLists.txt
 +++ b/driver/CMakeLists.txt
-@@ -64,6 +64,9 @@ endif()
+@@ -64,6 +64,10 @@ endif()
  add_dependencies(MIOpenDriver generate_kernels)
  target_include_directories(MIOpenDriver PRIVATE ../src/kernels)
  target_link_libraries(MIOpenDriver MIOpen Threads::Threads roc::rocrand)
 +if(MIOPEN_USE_ROCTRACER)
++    target_include_directories(MIOpenDriver PRIVATE ${ROCTRACER_INCLUDE_DIR})
 +    target_link_libraries(MIOpenDriver ${rocTracer})
 +endif()
  if(NOT MIOPEN_EMBED_DB STREQUAL "")
  target_link_libraries(MIOpenDriver $<BUILD_INTERFACE:miopen_data> )
  endif()
--- 
-2.39.3
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 66ac75f..69da1b9 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -917,7 +917,8 @@ if(NOT WIN32 AND NOT APPLE)
+ endif()
 
+ if(MIOPEN_USE_ROCTRACER)
+-    target_link_libraries(MIOpen PRIVATE roctx64)
++    target_include_directories(MIOpen PRIVATE ${ROCTRACER_INCLUDE_DIR})
++    target_link_libraries(MIOpen PRIVATE ${rocTracer})
+ endif()
+
+ ############################################################
+--
+2.43.5

--- a/var/spack/repos/builtin/packages/miopen-hip/package.py
+++ b/var/spack/repos/builtin/packages/miopen-hip/package.py
@@ -208,12 +208,13 @@ class MiopenHip(CMakePackage):
             args.append("-DROCTRACER_LIB_DIR={0}".format(self.spec["roctracer-dev"].prefix.lib))
             args.append("-DSQLITE_INCLUDE_DIR={0}".format(self.spec["sqlite"].prefix.include))
         if self.spec.satisfies("@6.1:"):
+            args.append(
+                "-DROCTRACER_INCLUDE_DIR={0}".format(self.spec["roctracer-dev"].prefix.include)
+            )
             args.append(self.define("MIOPEN_USE_ROCTRACER", "ON"))
             args.append(
                 self.define(
                     "CMAKE_CXX_FLAGS",
-                    f"-I{self.spec['roctracer-dev'].prefix.include} "
-                    f"-L{self.spec['roctracer-dev'].prefix.roctracer.lib} "
                     f"-I{self.spec['nlohmann-json'].prefix.include} "
                     f"-I{self.spec['sqlite'].prefix.include} ",
                 )

--- a/var/spack/repos/builtin/packages/mivisionx/0002-add-half-include-path-for-tests-6.2.0.patch
+++ b/var/spack/repos/builtin/packages/mivisionx/0002-add-half-include-path-for-tests-6.2.0.patch
@@ -1,0 +1,62 @@
+diff --git a/model_compiler/python/nnir_to_clib.py b/model_compiler/python/nnir_to_clib.py
+index b688094..26fcfe3 100644
+--- a/model_compiler/python/nnir_to_clib.py
++++ b/model_compiler/python/nnir_to_clib.py
+@@ -151,6 +151,10 @@ if (OPENVX_BACKEND_OPENCL_FOUND)
+     include_directories (${OpenCL_INCLUDE_DIRS} ${OpenCL_INCLUDE_DIRS}/Headers )
+ endif()
+
++find_path(HALF_INCLUDE_DIR half.hpp)
++message(STATUS "HALF_INCLUDE_DIR: ${HALF_INCLUDE_DIR}")
++include_directories(${HALF_INCLUDE_DIR})
++
+ find_package(OpenCV QUIET)
+ include_directories (/opt/rocm/include/mivisionx)
+ include_directories (${PROJECT_SOURCE_DIR}/lib)
+diff --git a/samples/inference/mv_objdetect/CMakeLists.txt b/samples/inference/mv_objdetect/CMakeLists.txt
+index 9b92b84..d82b71e 100644
+--- a/samples/inference/mv_objdetect/CMakeLists.txt
++++ b/samples/inference/mv_objdetect/CMakeLists.txt
+@@ -50,7 +50,10 @@ if (OPENVX_BACKEND_OPENCL_FOUND)
+     include_directories (${OpenCL_INCLUDE_DIRS} ${OpenCL_INCLUDE_DIRS}/Headers )
+ endif()
+
+-include_directories (${ROCM_PATH}/include/mivisionx ${PROJECT_SOURCE_DIR} )
++find_path(HALF_INCLUDE_DIR half.hpp)
++message(STATUS "HALF_INCLUDE_DIR: ${HALF_INCLUDE_DIR}")
++
++include_directories (${ROCM_PATH}/include/mivisionx ${PROJECT_SOURCE_DIR} ${HALF_INCLUDE_DIR} )
+ link_directories    (${ROCM_PATH}/lib ${PROJECT_SOURCE_DIR}/lib)
+ option (USE_POSTPROC  "Use postprocessing module implementation" ON)
+ set(SOURCES mvobjdetect.cpp mvdeploy_api.cpp visualize.cpp)
+diff --git a/utilities/rocAL/rocAL_unittests/CMakeLists.txt b/utilities/rocAL/rocAL_unittests/CMakeLists.txt
+index 6500003..20de035 100644
+--- a/utilities/rocAL/rocAL_unittests/CMakeLists.txt
++++ b/utilities/rocAL/rocAL_unittests/CMakeLists.txt
+@@ -43,9 +43,10 @@ include(GNUInstallDirs)
+
+ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../amd_openvx/cmake)
+
++find_path(HALF_INCLUDE_DIR half.hpp)
+ find_package(OpenCV QUIET)
+ find_package(AMDRPP QUIET)
+-include_directories(${ROCM_PATH}/${CMAKE_INSTALL_INCLUDEDIR}/mivisionx/rocal)
++include_directories(${ROCM_PATH}/${CMAKE_INSTALL_INCLUDEDIR}/mivisionx/rocal ${HALF_INCLUDE_DIR})
+ link_directories(${ROCM_PATH}/lib/)
+ file(GLOB My_Source_Files ./*.cpp)
+ add_executable(${PROJECT_NAME} ${My_Source_Files})
+diff --git a/utilities/rocAL/rocAL_video_unittests/CMakeLists.txt b/utilities/rocAL/rocAL_video_unittests/CMakeLists.txt
+index bd64a5b..3aa6172 100644
+--- a/utilities/rocAL/rocAL_video_unittests/CMakeLists.txt
++++ b/utilities/rocAL/rocAL_video_unittests/CMakeLists.txt
+@@ -46,8 +46,8 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../amd_openvx/cmake)
+
+ find_package(OpenCV QUIET)
+ find_package(AMDRPP QUIET)
+-
+-include_directories(${ROCM_PATH}/${CMAKE_INSTALL_INCLUDEDIR}/mivisionx/rocal)
++find_path(HALF_INCLUDE_DIR half.hpp)
++include_directories(${ROCM_PATH}/${CMAKE_INSTALL_INCLUDEDIR}/mivisionx/rocal ${HALF_INCLUDE_DIR})
+ link_directories(${ROCM_PATH}/lib/)
+ file(GLOB My_Source_Files ./*.cpp)
+ add_executable(${PROJECT_NAME} ${My_Source_Files})

--- a/var/spack/repos/builtin/packages/mivisionx/0002-add-half-include-path-for-tests-6.2.0.patch
+++ b/var/spack/repos/builtin/packages/mivisionx/0002-add-half-include-path-for-tests-6.2.0.patch
@@ -1,8 +1,20 @@
+From 19f084566394c6556cacf1b812a9a64e1fe0610e Mon Sep 17 00:00:00 2001
+From: Renjith Ravindran <Renjith.RavindranKannath@amd.com>
+Date: Wed, 12 Jun 2024 23:33:53 +0000
+Subject: [PATCH] add half include path for tests in 6.1
+
+---
+ model_compiler/python/nnir_to_clib.py                | 4 ++++
+ samples/mv_objdetect/CMakeLists.txt                  | 6 +++++-
+ utilities/rocAL/rocAL_unittests/CMakeLists.txt       | 3 ++-
+ utilities/rocAL/rocAL_video_unittests/CMakeLists.txt | 3 ++-
+ 4 files changed, 13 insertions(+), 3 deletions(-)
+
 diff --git a/model_compiler/python/nnir_to_clib.py b/model_compiler/python/nnir_to_clib.py
-index b688094..26fcfe3 100644
+index 623bf43..544ed31 100644
 --- a/model_compiler/python/nnir_to_clib.py
 +++ b/model_compiler/python/nnir_to_clib.py
-@@ -151,6 +151,10 @@ if (OPENVX_BACKEND_OPENCL_FOUND)
+@@ -160,6 +160,10 @@ if (OPENVX_BACKEND_OPENCL_FOUND)
      include_directories (${OpenCL_INCLUDE_DIRS} ${OpenCL_INCLUDE_DIRS}/Headers )
  endif()
 
@@ -11,17 +23,25 @@ index b688094..26fcfe3 100644
 +include_directories(${HALF_INCLUDE_DIR})
 +
  find_package(OpenCV QUIET)
- include_directories (/opt/rocm/include/mivisionx)
+ include_directories (${ROCM_PATH}/include ${ROCM_PATH}/include/mivisionx)
  include_directories (${PROJECT_SOURCE_DIR}/lib)
-diff --git a/samples/inference/mv_objdetect/CMakeLists.txt b/samples/inference/mv_objdetect/CMakeLists.txt
-index 9b92b84..d82b71e 100644
---- a/samples/inference/mv_objdetect/CMakeLists.txt
-+++ b/samples/inference/mv_objdetect/CMakeLists.txt
-@@ -50,7 +50,10 @@ if (OPENVX_BACKEND_OPENCL_FOUND)
+diff --git a/samples/mv_objdetect/CMakeLists.txt b/samples/mv_objdetect/CMakeLists.txt
+index 54d527b..c334ae4 100644
+--- a/samples/mv_objdetect/CMakeLists.txt
++++ b/samples/mv_objdetect/CMakeLists.txt
+@@ -29,6 +29,7 @@ project (mvobjdetect)
+ set (CMAKE_CXX_STANDARD 14)
+
+ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
++find_path(HALF_INCLUDE_DIR half.hpp)
+ find_package(OpenCV QUIET)
+
+ set(ROCM_PATH /opt/rocm CACHE PATH "ROCm Installation Path")
+@@ -50,7 +51,10 @@ if (OPENVX_BACKEND_OPENCL_FOUND)
      include_directories (${OpenCL_INCLUDE_DIRS} ${OpenCL_INCLUDE_DIRS}/Headers )
  endif()
 
--include_directories (${ROCM_PATH}/include/mivisionx ${PROJECT_SOURCE_DIR} )
+-include_directories (${ROCM_PATH}/include ${ROCM_PATH}/include/mivisionx ${PROJECT_SOURCE_DIR} )
 +find_path(HALF_INCLUDE_DIR half.hpp)
 +message(STATUS "HALF_INCLUDE_DIR: ${HALF_INCLUDE_DIR}")
 +
@@ -29,34 +49,4 @@ index 9b92b84..d82b71e 100644
  link_directories    (${ROCM_PATH}/lib ${PROJECT_SOURCE_DIR}/lib)
  option (USE_POSTPROC  "Use postprocessing module implementation" ON)
  set(SOURCES mvobjdetect.cpp mvdeploy_api.cpp visualize.cpp)
-diff --git a/utilities/rocAL/rocAL_unittests/CMakeLists.txt b/utilities/rocAL/rocAL_unittests/CMakeLists.txt
-index 6500003..20de035 100644
---- a/utilities/rocAL/rocAL_unittests/CMakeLists.txt
-+++ b/utilities/rocAL/rocAL_unittests/CMakeLists.txt
-@@ -43,9 +43,10 @@ include(GNUInstallDirs)
-
- list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../amd_openvx/cmake)
-
-+find_path(HALF_INCLUDE_DIR half.hpp)
- find_package(OpenCV QUIET)
- find_package(AMDRPP QUIET)
--include_directories(${ROCM_PATH}/${CMAKE_INSTALL_INCLUDEDIR}/mivisionx/rocal)
-+include_directories(${ROCM_PATH}/${CMAKE_INSTALL_INCLUDEDIR}/mivisionx/rocal ${HALF_INCLUDE_DIR})
- link_directories(${ROCM_PATH}/lib/)
- file(GLOB My_Source_Files ./*.cpp)
- add_executable(${PROJECT_NAME} ${My_Source_Files})
-diff --git a/utilities/rocAL/rocAL_video_unittests/CMakeLists.txt b/utilities/rocAL/rocAL_video_unittests/CMakeLists.txt
-index bd64a5b..3aa6172 100644
---- a/utilities/rocAL/rocAL_video_unittests/CMakeLists.txt
-+++ b/utilities/rocAL/rocAL_video_unittests/CMakeLists.txt
-@@ -46,8 +46,8 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../amd_openvx/cmake)
-
- find_package(OpenCV QUIET)
- find_package(AMDRPP QUIET)
--
--include_directories(${ROCM_PATH}/${CMAKE_INSTALL_INCLUDEDIR}/mivisionx/rocal)
-+find_path(HALF_INCLUDE_DIR half.hpp)
-+include_directories(${ROCM_PATH}/${CMAKE_INSTALL_INCLUDEDIR}/mivisionx/rocal ${HALF_INCLUDE_DIR})
- link_directories(${ROCM_PATH}/lib/)
- file(GLOB My_Source_Files ./*.cpp)
- add_executable(${PROJECT_NAME} ${My_Source_Files})
+2.27.0

--- a/var/spack/repos/builtin/packages/mivisionx/package.py
+++ b/var/spack/repos/builtin/packages/mivisionx/package.py
@@ -64,7 +64,8 @@ class Mivisionx(CMakePackage):
     patch("0001-add-half-include-path.patch", when="@5.5")
     patch("0001-add-half-include-path-5.6.patch", when="@5.6:6.1")
     patch("0002-add-half-include-path-for-tests.patch", when="@5.5:6.0 +add_tests")
-    patch("0002-add-half-include-path-for-tests-6.1.0.patch", when="@6.1.0: +add_tests")
+    patch("0002-add-half-include-path-for-tests-6.1.0.patch", when="@6.1 +add_tests")
+    patch("0002-add-half-include-path-for-tests-6.2.0.patch", when="@6.2.0: +add_tests")
 
     patch(
         "https://github.com/GPUOpen-ProfessionalCompute-Libraries/MIVisionX/commit/da24882438b91a0ae1feee23206b75c1a1256887.patch?full_index=1",
@@ -95,11 +96,6 @@ class Mivisionx(CMakePackage):
                 r"${ROCM_PATH}/llvm/bin/clang++",
                 "{0}/bin/clang++".format(self.spec["llvm-amdgpu"].prefix),
                 "amd_openvx/openvx/hipvx/CMakeLists.txt",
-                string=True,
-            )
-            filter_file(
-                r"${ROCM_PATH}/llvm/bin/clang++",
-                "{0}/bin/clang++".format(self.spec["llvm-amdgpu"].prefix),
                 "amd_openvx_extensions/amd_nn/nn_hip/CMakeLists.txt",
                 string=True,
             )
@@ -137,65 +133,41 @@ class Mivisionx(CMakePackage):
                 string=True,
             )
 
+        if self.spec.satisfies("@:6.1 +add_tests"):
+            filter_file(
+                r"${ROCM_PATH}/${CMAKE_INSTALL_INCLUDEDIR}/mivisionx/rocal",
+                "{0}/include/mivisionx/rocal".format(self.spec.prefix),
+                "utilities/rocAL/rocAL_unittests/CMakeLists.txt",
+                "utilities/rocAL/rocAL_video_unittests/CMakeLists.txt",
+                string=True,
+            )
+            filter_file(
+                r"${ROCM_PATH}/lib",
+                "{0}/lib".format(self.spec.prefix),
+                "utilities/rocAL/rocAL_unittests/CMakeLists.txt",
+                "utilities/rocAL/rocAL_video_unittests/CMakeLists.txt",
+                string=True,
+            )
         if self.spec.satisfies("+add_tests"):
             filter_file(
                 r"${ROCM_PATH}/include/mivisionx",
                 "{0}/include/mivisionx".format(self.spec.prefix),
                 "tests/amd_migraphx_tests/mnist/CMakeLists.txt",
+                "tests/amd_migraphx_tests/resnet50/CMakeLists.txt",
+                "model_compiler/python/nnir_to_clib.py",
                 string=True,
             )
             filter_file(
                 r"${ROCM_PATH}/lib",
                 "{0}/lib".format(self.spec.prefix),
                 "tests/amd_migraphx_tests/mnist/CMakeLists.txt",
-                string=True,
-            )
-            filter_file(
-                r"${ROCM_PATH}/include/mivisionx",
-                "{0}/include/mivisionx".format(self.spec.prefix),
                 "tests/amd_migraphx_tests/resnet50/CMakeLists.txt",
-                string=True,
-            )
-            filter_file(
-                r"${ROCM_PATH}/lib",
-                "{0}/lib".format(self.spec.prefix),
-                "tests/amd_migraphx_tests/resnet50/CMakeLists.txt",
-                string=True,
-            )
-            filter_file(
-                r"${ROCM_PATH}/include/mivisionx",
-                "{0}/include/mivisionx".format(self.spec.prefix),
-                "model_compiler/python/nnir_to_clib.py",
                 string=True,
             )
             filter_file(
                 r"/opt/rocm",
                 "{0}".format(self.spec.prefix),
                 "model_compiler/python/nnir_to_clib.py",
-                string=True,
-            )
-            filter_file(
-                r"${ROCM_PATH}/${CMAKE_INSTALL_INCLUDEDIR}/mivisionx/rocal",
-                "{0}/include/mivisionx/rocal".format(self.spec.prefix),
-                "utilities/rocAL/rocAL_unittests/CMakeLists.txt",
-                string=True,
-            )
-            filter_file(
-                r"${ROCM_PATH}/lib",
-                "{0}/lib".format(self.spec.prefix),
-                "utilities/rocAL/rocAL_unittests/CMakeLists.txt",
-                string=True,
-            )
-            filter_file(
-                r"${ROCM_PATH}/${CMAKE_INSTALL_INCLUDEDIR}/mivisionx/rocal",
-                "{0}/include/mivisionx/rocal".format(self.spec.prefix),
-                "utilities/rocAL/rocAL_video_unittests/CMakeLists.txt",
-                string=True,
-            )
-            filter_file(
-                r"${ROCM_PATH}/lib",
-                "{0}/lib".format(self.spec.prefix),
-                "utilities/rocAL/rocAL_video_unittests/CMakeLists.txt",
                 string=True,
             )
 
@@ -337,12 +309,13 @@ class Mivisionx(CMakePackage):
             args.append(
                 self.define("AMDRPP_INCLUDE_DIRS", "{0}/include/rpp".format(spec["rpp"].prefix))
             )
+            args.append(self.define("CMAKE_INSTALL_PREFIX_PYTHON", spec.prefix))
+        if self.spec.satisfies("@5.5:6.2.0"):
             args.append(
                 self.define(
                     "TurboJpeg_LIBRARIES_DIRS", "{0}/lib64".format(spec["libjpeg-turbo"].prefix)
                 )
             )
-            args.append(self.define("CMAKE_INSTALL_PREFIX_PYTHON", spec.prefix))
         return args
 
     @run_after("install")

--- a/var/spack/repos/builtin/packages/rocal/package.py
+++ b/var/spack/repos/builtin/packages/rocal/package.py
@@ -37,6 +37,56 @@ class Rocal(CMakePackage):
             "rocAL/rocAL_hip/CMakeLists.txt",
             string=True,
         )
+        filter_file(
+            r"${ROCM_PATH}/include/rocal",
+            "{0}/include/rocal".format(self.spec.prefix),
+            "tests/cpp_api/CMakeLists.txt",
+            string=True,
+        )
+        filter_file(
+            r"${ROCM_PATH}/${CMAKE_INSTALL_INCLUDEDIR}/rocal",
+            "{0}/include/rocal".format(self.spec.prefix),
+            "tests/cpp_api/audio_tests/CMakeLists.txt",
+            "tests/cpp_api/image_augmentation/CMakeLists.txt",
+            "tests/cpp_api/basic_test/CMakeLists.txt",
+            "tests/cpp_api/performance_tests/CMakeLists.txt",
+            "tests/cpp_api/dataloader/CMakeLists.txt",
+            "tests/cpp_api/performance_tests_with_depth/CMakeLists.txt",
+            "tests/cpp_api/dataloader_multithread/CMakeLists.txt",
+            "tests/cpp_api/unit_tests/CMakeLists.txt",
+            "tests/cpp_api/dataloader_tf/CMakeLists.txt",
+            "tests/cpp_api/video_tests/CMakeLists.txt",
+            "tests/cpp_api/external_source/CMakeLists.txt",
+            string=True,
+        )
+        filter_file(
+            r"${ROCM_PATH}/lib",
+            "{0}/lib".format(self.spec.prefix),
+            "tests/cpp_api/audio_tests/CMakeLists.txt",
+            "tests/cpp_api/image_augmentation/CMakeLists.txt",
+            "tests/cpp_api/basic_test/CMakeLists.txt",
+            "tests/cpp_api/performance_tests/CMakeLists.txt",
+            "tests/cpp_api/dataloader/CMakeLists.txt",
+            "tests/cpp_api/performance_tests_with_depth/CMakeLists.txt",
+            "tests/cpp_api/dataloader_multithread/CMakeLists.txt",
+            "tests/cpp_api/unit_tests/CMakeLists.txt",
+            "tests/cpp_api/dataloader_tf/CMakeLists.txt",
+            "tests/cpp_api/video_tests/CMakeLists.txt",
+            "tests/cpp_api/external_source/CMakeLists.txt",
+            string=True,
+        )
+        filter_file(
+            r"${ROCM_PATH}/lib",
+            "{0}/lib".format(self.spec.prefix),
+            "tests/cpp_api/CMakeLists.txt",
+            string=True,
+        )
+        filter_file(
+            r"${ROCM_PATH}/share/rocal",
+            "{0}/share/rocal".format(self.spec.prefix),
+            "tests/cpp_api/CMakeLists.txt",
+            string=True,
+        )
 
     def cmake_args(self):
         args = [
@@ -46,3 +96,12 @@ class Rocal(CMakePackage):
             self.define("CMAKE_INSTALL_PREFIX_PYTHON", self.spec.prefix),
         ]
         return args
+
+    def check(self):
+        print("test will run after install")
+
+    @run_after("install")
+    @on_package_attributes(run_tests=True)
+    def check_install(self):
+        with working_dir(self.build_directory, create=True):
+            make("test")


### PR DESCRIPTION
Add rocAL unit which run after install.
Add migraphx build-time test.
Fix patch for mivisionx +add_tests
fix libroctx64.so not found error with libMIOpen.so