### PR TITLE
rocm-validation-suite: update patch file for 6.2 and 6.2.1 and remove unwanted environment variable to add library paths into RUNPATH

### DIFF
--- a/var/spack/repos/builtin/packages/rocm-validation-suite/009-replacing-rocm-path-with-package-path-6.2.1.patch
+++ b/var/spack/repos/builtin/packages/rocm-validation-suite/009-replacing-rocm-path-with-package-path-6.2.1.patch
@@ -1,0 +1,686 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7867e3a..7268387 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -74,14 +74,18 @@ endif(rocblas_FOUND)
+ # Making ROCM_PATH, CMAKE_INSTALL_PREFIX, CPACK_PACKAGING_INSTALL_PREFIX as CACHE
+ # variables since we will pass them as cmake params appropriately, and 
+ # all find_packages relevant to this build will be in ROCM path hence appending it to CMAKE_PREFIX_PATH 
+-set(ROCM_PATH "/opt/rocm" CACHE PATH "ROCM install path")
+-set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "CMAKE installation directory")
+-set(CPACK_PACKAGING_INSTALL_PREFIX "/opt/rocm" CACHE PATH "Prefix used in built packages")
++set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
++set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
++set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+ list(APPEND CMAKE_PREFIX_PATH "${ROCM_PATH}")
+-set(ROCR_INC_DIR "${ROCM_PATH}/include" CACHE PATH "Contains header files exported by ROC Runtime" FORCE)
+-set(ROCR_LIB_DIR "${ROCM_PATH}/lib" CACHE PATH "Contains library files exported by ROC Runtime" FORCE)
+-set(HIP_INC_DIR "${ROCM_PATH}" CACHE PATH "Contains header files exported by ROC Runtime")
+-set(ROCT_INC_DIR "${ROCM_PATH}/include" CACHE PATH "Contains header files exported by ROC Trunk" FORCE)
++set(ROCR_INC_DIR "${HSA_PATH}/include" CACHE PATH "Contains header files exported by ROC Runtime")
++set(ROCR_LIB_DIR "${HSA_PATH}/lib" CACHE PATH "Contains library files exported by ROC Runtime")
++set(HIP_INC_DIR "${HIP_PATH}" CACHE PATH "Contains header files exported by ROC Runtime")
++set(ROCT_INC_DIR "${ROCM_PATH}/include" CACHE PATH "Contains header files exported by ROC Trunk")
++set(HIPRAND_INC_DIR "${HIPRAND_DIR}/include" CACHE PATH "Contains header files exported by ROC Trunk")
++set(HIPRAND_LIB_DIR "${HIPRAND_DIR}/lib" CACHE PATH "Contains header files exported by ROC Trunk")
++set(ROCRAND_INC_DIR "${ROCRAND_DIR}/include" CACHE PATH "Contains header files exported by ROC Trunk")
++set(ROCRAND_LIB_DIR "${ROCRAND_DIR}/lib" CACHE PATH "Contains header files exported by ROC Trunk")
+ 
+ add_definitions(-DROCM_PATH="${ROCM_PATH}")
+ if(FETCH_ROCMPATH_FROM_ROCMCORE)
+@@ -443,15 +447,18 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/rvs_smi-build/librocm_smi64.so
+ 
+ endif()  # if (RVS_ROCMSMI EQUAL 1)
+ 
+-set(HIPRAND_INC_DIR "${ROCM_PATH}/include")
+-set(HIPRAND_LIB_DIR "${ROCM_PATH}/lib")
++set(HIPRAND_INC_DIR "${HIPRAND_DIR}/include")
++set(HIPRAND_LIB_DIR "${HIPRAND_DIR}/lib")
++
++set(ROCRAND_INC_DIR "${ROCRAND_DIR}/include")
++set(ROCRAND_LIB_DIR "${ROCRAND_DIR}/lib")
+ 
+ if (RVS_ROCBLAS EQUAL 1)
+   set(ROCBLAS_INC_DIR "${CMAKE_BINARY_DIR}/rvs_rblas-src/build/release/rocblas-install")
+   set(ROCBLAS_LIB_DIR "${CMAKE_BINARY_DIR}/rvs_rblas-src/build/release/rocblas-install/lib/")
+ else()
+-  set(ROCBLAS_INC_DIR "${ROCM_PATH}/include")
+-  set(ROCBLAS_LIB_DIR "${ROCM_PATH}/lib")
++  set(ROCBLAS_INC_DIR "${ROCBLAS_DIR}/include")
++  set(ROCBLAS_LIB_DIR "${ROCBLAS_DIR}/lib")
+ endif()
+ 
+ if (RVS_ROCMSMI EQUAL 1)
+@@ -466,8 +473,8 @@ else()
+     set(ROCM_SMI_LIB_DIR "${ROCM_PATH}/rocm_smi/lib")
+   else()
+     message( STATUS "ROCBLAS REORG Enabled Version: ${RVS_ROCBLAS_VERSION_FLAT}" )
+-    set(ROCM_SMI_INC_DIR "${ROCM_PATH}/include")
+-    set(ROCM_SMI_LIB_DIR "${ROCM_PATH}/lib")
++    set(ROCM_SMI_INC_DIR "${ROCM_SMI_DIR}/include")
++    set(ROCM_SMI_LIB_DIR "${ROCM_SMI_DIR}/lib")
+   endif()
+ endif()
+ set(ROCM_SMI_LIB "rocm_smi64" CACHE STRING "rocm_smi library name")
+diff --git a/babel.so/CMakeLists.txt b/babel.so/CMakeLists.txt
+index 54a0e3a..c9ddeaa 100644
+--- a/babel.so/CMakeLists.txt
++++ b/babel.so/CMakeLists.txt
+@@ -109,13 +109,13 @@ set(HIP_HCC_LIB "amdhip64")
+ add_compile_options(-DRVS_ROCBLAS_VERSION_FLAT=${RVS_ROCBLAS_VERSION_FLAT})
+ 
+ # Determine Roc Runtime header files are accessible
+-if(NOT EXISTS ${HIP_INC_DIR}/include/hip/hip_runtime.h)
+-  message("ERROR: ROC Runtime headers can't be found under specified path. Please set HIP_INC_DIR path. Current value is : " ${HIP_INC_DIR})
++if(NOT EXISTS ${HIP_PATH}/include/hip/hip_runtime.h)
++  message("ERROR: ROC Runtime headers can't be found under specified path. Please set HIP_PATH path. Current value is : " ${HIP_PATH})
+   RETURN()
+ endif()
+ 
+-if(NOT EXISTS ${HIP_INC_DIR}/include/hip/hip_runtime_api.h)
+-  message("ERROR: ROC Runtime headers can't be found under specified path. Please set HIP_INC_DIR path. Current value is : " ${HIP_INC_DIR})
++if(NOT EXISTS ${HIP_PATH}/include/hip/hip_runtime_api.h)
++  message("ERROR: ROC Runtime headers can't be found under specified path. Please set HIP_PATH path. Current value is : " ${HIP_PATH})
+   RETURN()
+ endif()
+ 
+@@ -135,16 +135,16 @@ if(DEFINED RVS_ROCMSMI)
+ endif()
+ 
+ 
+-if(NOT EXISTS "${ROCR_LIB_DIR}/lib${HIP_HCC_LIB}.so")
+-  message("ERROR: ROC Runtime libraries can't be found under specified path. Please set ROCR_LIB_DIR path. Current value is : " ${ROCR_LIB_DIR})
++if(NOT EXISTS "${HIP_PATH}/lib/lib${HIP_HCC_LIB}.so")
++  message("ERROR: ROC Runtime libraries can't be found under specified path. Please set HIP_PATH path. Current value is : " ${HIP_PATH})
+   RETURN()
+ endif()
+ 
+ ## define include directories
+-include_directories(./ ../ ${ROCR_INC_DIR} ${HIP_INC_DIR})
++include_directories(./ ../ ${HIP_PATH})
+ 
+ # Add directories to look for library files to link
+-link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ASAN_LIB_PATH})
++link_directories(${RVS_LIB_DIR} ${HIP_PATH}/lib/ ${ROCBLAS_LIB_DIR} ${ASAN_LIB_PATH} ${ROCM_SMI_LIB_DIR} ${HIPRAND_LIB_DIR} ${ROCRAND_LIB_DIR})
+ ## additional libraries
+ set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so)
+ 
+@@ -156,7 +156,7 @@ add_library( ${RVS_TARGET} SHARED ${SOURCES})
+ set_target_properties(${RVS_TARGET} PROPERTIES
+         SUFFIX .so.${LIB_VERSION_STRING}
+         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+-target_link_libraries(${RVS_TARGET} ${PROJECT_LINK_LIBS} ${HIP_HCC_LIB} ${ROCBLAS_LIB})
++target_link_libraries(${RVS_TARGET} ${PROJECT_LINK_LIBS} ${HIP_HCC_LIB} ${ROCBLAS_LIB} ${ROCBLAS_LIB_DIR}/librocblas.so ${HSAKMT_LIB_DIR}/libhsakmt.a ${HSA_PATH}/lib/libhsa-runtime64.so ${HIPRAND_LIB_DIR}/libhiprand.so ${ROCRAND_LIB_DIR}/librocrand.so)
+ add_dependencies(${RVS_TARGET} rvslib)
+ 
+ add_custom_command(TARGET ${RVS_TARGET} POST_BUILD
+diff --git a/cmake_modules/tests_unit.cmake b/cmake_modules/tests_unit.cmake
+index 9760b72..d585f8b 100644
+--- a/cmake_modules/tests_unit.cmake
++++ b/cmake_modules/tests_unit.cmake
+@@ -27,7 +27,7 @@
+ ## define additional unit testing include directories
+ include_directories(${UT_INC})
+ ## define additional unit testing lib directories
+-link_directories(${UT_LIB} ${RVS_LIB_DIR})
++link_directories(${UT_LIB} ${RVS_LIB_DIR} ${ROCM_SMI_LIB_DIR} ${HIPRAND_LIB_DIR} ${ROCRAND_LIB_DIR})
+ 
+ file(GLOB TESTSOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} test/test*.cpp )
+ #message ( "TESTSOURCES: ${TESTSOURCES}" )
+@@ -46,6 +46,7 @@ FOREACH(SINGLE_TEST ${TESTSOURCES})
+   add_dependencies(${TEST_NAME} rvs_gtest_target) 
+   target_link_libraries(${TEST_NAME}
+     ${UT_LINK_LIBS}  rvslibut rvslib gtest_main gtest pthread pci
++    ${ROCBLAS_LIB_DIR}/librocblas.so ${HSAKMT_LIB_DIR}/libhsakmt.a ${HSA_PATH}/lib/libhsa-runtime64.so ${HIPRAND_LIB_DIR}/libhiprand.so ${ROCRAND_LIB_DIR}/librocrand.so
+   )
+   target_compile_definitions(${TEST_NAME} PUBLIC RVS_UNIT_TEST)
+   if(DEFINED tcd.${TEST_NAME})
+diff --git a/edp.so/CMakeLists.txt b/edp.so/CMakeLists.txt
+index 7dd34ea..41c8493 100644
+--- a/edp.so/CMakeLists.txt
++++ b/edp.so/CMakeLists.txt
+@@ -128,17 +128,17 @@ if(DEFINED RVS_ROCMSMI)
+ endif()
+ 
+ 
+-if(NOT EXISTS "${ROCR_LIB_DIR}/lib${HIP_HCC_LIB}.so")
++if(NOT EXISTS "${HIP_INC_DIR}/lib/lib${HIP_HCC_LIB}.so")
+   message("ERROR: ROC Runtime libraries can't be found under specified path. Please set ROCR_LIB_DIR path. Current value is : " ${ROCR_LIB_DIR})
+   RETURN()
+ endif()
+ 
+ ## define include directories
+-include_directories(./ ../ ${ROCR_INC_DIR} ${ROCBLAS_INC_DIR} ${HIP_INC_DIR})
++include_directories(./ ../ ${ROCR_INC_DIR} ${ROCBLAS_INC_DIR} ${HIP_INC_DIR} ${YAML_CPP_INCLUDE_DIRS} ${HIPRAND_INC_DIR} ${ROCRAND_INC_DIR})
+ # Add directories to look for library files to link
+-link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${ROCBLAS_LIB_DIR})
++link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ROCM_SMI_LIB_DIR} ${HIPRAND_LIB_DIR} ${ROCRAND_LIB_DIR})
+ ## additional libraries
+-set (PROJECT_LINK_LIBS rvslib libpthread.so libpciaccess.so libpci.so libm.so)
++set (PROJECT_LINK_LIBS rvslib libpthread.so libpciaccess.so libpci.so libm.so ${ROCBLAS_LIB_DIR}/librocblas.so ${HSAKMT_LIB_DIR}/libhsakmt.a ${HSA_PATH}/lib/libhsa-runtime64.so ${HIPRAND_LIB_DIR}/libhiprand.so ${ROCRAND_LIB_DIR}/librocrand.so)
+ 
+ ## define source files
+ set (SOURCES src/rvs_module.cpp src/action.cpp src/edp_worker.cpp )
+@@ -148,7 +148,7 @@ add_library( ${RVS_TARGET} SHARED ${SOURCES})
+ set_target_properties(${RVS_TARGET} PROPERTIES
+         SUFFIX .so.${LIB_VERSION_STRING}
+         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+-target_link_libraries(${RVS_TARGET} ${PROJECT_LINK_LIBS} ${HIP_HCC_LIB} ${ROCBLAS_LIB})
++target_link_libraries(${RVS_TARGET} ${PROJECT_LINK_LIBS} ${HIP_HCC_LIB} ${ROCBLAS_LIB} ${HIPRAND_LIB} ${ROCRAND_LIB})
+ add_dependencies(${RVS_TARGET} rvslib)
+ 
+ add_custom_command(TARGET ${RVS_TARGET} POST_BUILD
+diff --git a/gm.so/CMakeLists.txt b/gm.so/CMakeLists.txt
+index d3caa84..94a06be 100644
+--- a/gm.so/CMakeLists.txt
++++ b/gm.so/CMakeLists.txt
+@@ -118,11 +118,11 @@ if(DEFINED RVS_ROCMSMI)
+ endif()
+ 
+ ## define include directories
+-include_directories(./ ../ ${ROCM_SMI_INC_DIR})
++include_directories(./ ../ ${ROCM_SMI_INC_DIR} ${YAML_CPP_INCLUDE_DIRS})
+ # Add directories to look for library files to link
+-link_directories(${RVS_LIB_DIR} ${ROCM_SMI_LIB_DIR} ${ASAN_LIB_PATH})
++link_directories(${RVS_LIB_DIR} ${ROCM_SMI_LIB_DIR} ${ASAN_LIB_PATH} ${ROCM_SMI_LIB} ${HIPRAND_LIB_DIR} ${ROCRAND_LIB_DIR})
+ ## additional libraries
+-set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so)
++set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so librocm_smi64.so ${ROCBLAS_LIB_DIR}/librocblas.so ${HSAKMT_LIB_DIR}/libhsakmt.a ${HSA_PATH}/lib/libhsa-runtime64.so ${HIPRAND_LIB_DIR}/libhiprand.so ${ROCRAND_LIB_DIR}/librocrand.so)
+ 
+ ## define source files
+ set(SOURCES  src/rvs_module.cpp src/action.cpp src/worker.cpp)
+@@ -133,7 +133,7 @@ add_library( ${RVS_TARGET} SHARED ${SOURCES})
+ set_target_properties(${RVS_TARGET} PROPERTIES
+         SUFFIX .so.${LIB_VERSION_STRING}
+         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+-target_link_libraries(${RVS_TARGET} ${PROJECT_LINK_LIBS} ${ROCM_SMI_LIB})
++target_link_libraries(${RVS_TARGET} ${PROJECT_LINK_LIBS})
+ add_dependencies(${RVS_TARGET} rvslib)
+ 
+ add_custom_command(TARGET ${RVS_TARGET} POST_BUILD
+@@ -149,7 +149,7 @@ install(FILES "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/lib${RVS}.so"
+ 
+ # TEST SECTION
+ if (RVS_BUILD_TESTS)
+-  add_custom_command(TARGET ${RVS_TARGET} POST_BUILD
++  B_add_custom_command(TARGET ${RVS_TARGET} POST_BUILD
+   COMMAND ln -fs ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/lib${RVS}.so.${VERSION_MAJOR} ${RVS_BINTEST_FOLDER}/lib${RVS}.so WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+   )
+   include(${CMAKE_CURRENT_SOURCE_DIR}/tests.cmake)
+diff --git a/gm.so/tests.cmake b/gm.so/tests.cmake
+index b360065..172e97c 100644
+--- a/gm.so/tests.cmake
++++ b/gm.so/tests.cmake
+@@ -30,11 +30,11 @@ set(CORE_RUNTIME_NAME "hsa-runtime")
+ set(CORE_RUNTIME_TARGET "${CORE_RUNTIME_NAME}64")
+ 
+ set(UT_LINK_LIBS  libpthread.so libpci.so libm.so libdl.so "lib${ROCM_SMI_LIB}.so"
+-  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${YAML_CPP_LIBRARIES} ${HIPRAND_LIB}
++  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${YAML_CPP_LIBRARIES} "lib${HIPRAND_LIB}.so" "lib${ROCRAND_LIB}.so"
+ )
+ 
+ # Add directories to look for library files to link
+-link_directories(${ROCM_SMI_LIB_DIR} ${ROCT_LIB_DIR} ${ROCBLAS_LIB_DIR})
++link_directories(${ROCM_SMI_LIB_DIR} ${ROCT_LIB_DIR} ${ROCBLAS_LIB_DIR} ${HIPRAND_LIB_DIR} ${ROCRAND_LIB_DIR})
+ 
+ set (UT_SOURCES src/action.cpp src/worker.cpp
+ )
+diff --git a/gpup.so/CMakeLists.txt b/gpup.so/CMakeLists.txt
+index 43d337a..c92d8ba 100644
+--- a/gpup.so/CMakeLists.txt
++++ b/gpup.so/CMakeLists.txt
+@@ -109,11 +109,11 @@ else()
+ endif()
+ 
+ ## define include directories
+-include_directories(./ ../ include ../include)
++include_directories(./ ../ include ../include ${YAML_CPP_INCLUDE_DIRS})
+ # Add directories to look for library files to link
+-link_directories(${RVS_LIB_DIR} ${ASAN_LIB_PATH})
++link_directories(${RVS_LIB_DIR} ${ASAN_LIB_PATH} ${ROCM_SMI_LIB_DIR} ${HIPRAND_LIB_DIR} ${ROCRAND_LIB_DIR})
+ ## additional libraries
+-set (PROJECT_LINK_LIBS rvslib libpci.so libm.so)
++set (PROJECT_LINK_LIBS rvslib libpci.so libm.so ${ROCBLAS_LIB_DIR}/librocblas.so ${HSAKMT_LIB_DIR}/libhsakmt.a ${HSA_PATH}/lib/libhsa-runtime64.so ${HIPRAND_LIB_DIR}/libhiprand.so ${ROCRAND_LIB_DIR}/librocrand.so)
+ 
+ ## define source files
+ set(SOURCES src/rvs_module.cpp src/action.cpp)
+diff --git a/gpup.so/tests.cmake b/gpup.so/tests.cmake
+index 9a1f7ed..3649ae4 100644
+--- a/gpup.so/tests.cmake
++++ b/gpup.so/tests.cmake
+@@ -25,12 +25,13 @@
+ 
+ set(ROCBLAS_LIB "rocblas")
+ set(HIPRAND_LIB "hiprand")
++set(ROCRAND_LIB "rocrand")
+ set(ROC_THUNK_NAME "hsakmt")
+ set(CORE_RUNTIME_NAME "hsa-runtime")
+ set(CORE_RUNTIME_TARGET "${CORE_RUNTIME_NAME}64")
+ 
+ set(UT_LINK_LIBS libpthread.so libm.so libdl.so ${ROCM_SMI_LIB}
+-  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${YAML_CPP_LIBRARIES} ${HIPRAND_LIB})
++  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${YAML_CPP_LIBRARIES} ${HIPRAND_LIB} ${ROCRAND_LIB})
+ 
+ # Add directories to look for library files to link
+ link_directories(${RVS_LIB_DIR} ${ROCM_SMI_LIB_DIR} ${ROCT_LIB_DIR} ${ROCBLAS_LIB_DIR})
+diff --git a/gst.so/CMakeLists.txt b/gst.so/CMakeLists.txt
+index fd346ce..7e17a68 100644
+--- a/gst.so/CMakeLists.txt
++++ b/gst.so/CMakeLists.txt
+@@ -137,17 +137,17 @@ if(DEFINED RVS_ROCMSMI)
+ endif()
+ 
+ 
+-if(NOT EXISTS "${ROCR_LIB_DIR}/lib${HIP_HCC_LIB}.so")
++if(NOT EXISTS "${HIP_INC_DIR}/lib/lib${HIP_HCC_LIB}.so")
+   message("ERROR: ROC Runtime libraries can't be found under specified path. Please set ROCR_LIB_DIR path. Current value is : " ${ROCR_LIB_DIR})
+   RETURN()
+ endif()
+ 
+ ## define include directories
+-include_directories(./ ../ ${ROCR_INC_DIR} ${ROCBLAS_INC_DIR} ${HIP_INC_DIR})
++include_directories(./ ../ ${ROCR_INC_DIR} ${ROCBLAS_INC_DIR} ${HIP_INC_DIR} ${YAML_CPP_INCLUDE_DIRS} ${HIPRAND_INC_DIR} ${ROCRAND_INC_DIR})
+ # Add directories to look for library files to link
+-link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ASAN_LIB_PATH})
++link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${HIP_INC_DIR}/lib/ ${ROCBLAS_LIB_DIR} ${ASAN_LIB_PATH} ${ROCM_SMI_LIB_DIR} ${HIPRAND_DIR} ${ROCRAND_DIR})
+ ## additional libraries
+-set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so)
++set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so ${ROCBLAS_LIB_DIR}/librocblas.so ${HSAKMT_LIB_DIR}/libhsakmt.a ${HSA_PATH}/lib/libhsa-runtime64.so ${HIPRAND_LIB_DIR}/libhiprand.so ${ROCRAND_LIB_DIR}/librocrand.so)
+ 
+ ## define source files
+ set(SOURCES src/rvs_module.cpp src/action.cpp src/gst_worker.cpp)
+diff --git a/iet.so/CMakeLists.txt b/iet.so/CMakeLists.txt
+index 002c03c..604b86b 100644
+--- a/iet.so/CMakeLists.txt
++++ b/iet.so/CMakeLists.txt
+@@ -145,7 +145,7 @@ if(DEFINED RVS_ROCMSMI)
+   endif()
+ endif()
+ 
+-if(NOT EXISTS "${ROCR_LIB_DIR}/lib${HIP_HCC_LIB}.so")
++if(NOT EXISTS "${HIP_INC_DIR}/lib/lib${HIP_HCC_LIB}.so")
+   message("ERROR: ROC Runtime libraries can't be found under specified path. Please set ROCR_LIB_DIR path. Current value is : " ${ROCR_LIB_DIR})
+   RETURN()
+ endif()
+@@ -160,11 +160,11 @@ if(DEFINED RVS_ROCMSMI)
+ endif()
+ 
+ ## define include directories
+-include_directories(./ ../ ${ROCM_SMI_INC_DIR} ${ROCBLAS_INC_DIR} ${ROCR_INC_DIR} ${HIP_INC_DIR})
++include_directories(./ ../ ${ROCM_SMI_INC_DIR} ${ROCBLAS_INC_DIR} ${ROCR_INC_DIR} ${HIP_INC_DIR} ${HIPRAND_INC_DIR} ${ROCRAND_INC_DIR})
+ # Add directories to look for library files to link
+-link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ROCM_SMI_LIB_DIR} ${ASAN_LIB_PATH})
++link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ROCM_SMI_LIB_DIR} ${ASAN_LIB_PATH} ${HIPRAND_LIB_DIR} ${ROCRAND_LIB_DIR})
+ ## additional libraries
+-set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so)
++set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so librocm_smi64.so ${ROCBLAS_LIB_DIR}/librocblas.so ${HSAKMT_LIB_DIR}/libhsakmt.a ${HSA_PATH}/lib/libhsa-runtime64.so ${HIPRAND_LIB_DIR}/libhiprand.so ${ROCRAND_LIB_DIR}/librocrand.so )
+ 
+ set(SOURCES src/rvs_module.cpp src/action.cpp src/iet_worker.cpp )
+ 
+@@ -173,7 +173,7 @@ add_library( ${RVS_TARGET} SHARED ${SOURCES})
+ set_target_properties(${RVS_TARGET} PROPERTIES
+         SUFFIX .so.${LIB_VERSION_STRING}
+         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+-target_link_libraries(${RVS_TARGET} ${PROJECT_LINK_LIBS} ${HIP_HCC_LIB} ${ROCBLAS_LIB} ${ROCM_SMI_LIB})
++target_link_libraries(${RVS_TARGET} ${PROJECT_LINK_LIBS} ${HIP_INC_DIR}/lib/ ${HIP_HCC_LIB} ${ROCBLAS_LIB})
+ add_dependencies(${RVS_TARGET} rvslib)
+ 
+ add_custom_command(TARGET ${RVS_TARGET} POST_BUILD
+diff --git a/mem.so/CMakeLists.txt b/mem.so/CMakeLists.txt
+index 5133337..3ba941f 100644
+--- a/mem.so/CMakeLists.txt
++++ b/mem.so/CMakeLists.txt
+@@ -134,18 +134,18 @@ if(DEFINED RVS_ROCMSMI)
+ endif()
+ 
+ 
+-if(NOT EXISTS "${ROCR_LIB_DIR}/lib${HIP_HCC_LIB}.so")
++if(NOT EXISTS "${HIP_INC_DIR}/lib/lib${HIP_HCC_LIB}.so")
+   message("ERROR: ROC Runtime libraries can't be found under specified path. Please set ROCR_LIB_DIR path. Current value is : " ${ROCR_LIB_DIR})
+   RETURN()
+ endif()
+ 
+ ## define include directories
+-include_directories(./ ../ ${ROCR_INC_DIR} ${HIP_INC_DIR})
++include_directories(./ ../ ${ROCR_INC_DIR} ${HIP_INC_DIR} ${HIPRAND_INC_DIR} ${ROCRAND_INC_DIR})
+ 
+ # Add directories to look for library files to link
+-link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ASAN_LIB_PATH})
++link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${HIP_INC_DIR}/lib ${ROCBLAS_LIB_DIR} ${ASAN_LIB_PATH} ${ROCM_SMI_LIB_DIR} ${HIPRAND_LIB_DIR} ${ROCRAND_LIB_DIR})
+ ## additional libraries
+-set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so)
++set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so ${ROCBLAS_LIB_DIR}/librocblas.so ${HSAKMT_LIB_DIR}/libhsakmt.a ${HSA_PATH}/lib/libhsa-runtime64.so ${HIPRAND_LIB_DIR}/libhiprand.so ${ROCRAND_LIB_DIR}/librocrand.so)
+ 
+ ## define source files
+ set(SOURCES src/rvs_module.cpp src/action.cpp src/rvs_memtest.cpp src/rvs_memworker.cpp)
+diff --git a/pbqt.so/CMakeLists.txt b/pbqt.so/CMakeLists.txt
+index 5ae675a..873a1e8 100644
+--- a/pbqt.so/CMakeLists.txt
++++ b/pbqt.so/CMakeLists.txt
+@@ -136,11 +136,11 @@ if(NOT EXISTS ${ROCR_LIB_DIR}/${CORE_RUNTIME_LIBRARY}.so)
+ endif()
+ 
+ ## define include directories
+-include_directories(./ ../ pci ${ROCR_INC_DIR})
++include_directories(./ ../ pci ${ROCR_INC_DIR} ${YAML_CPP_INCLUDE_DIRS} ${HIPRAND_INC_DIR} ${ROCRAND_INC_DIR})
+ # Add directories to look for library files to link
+-link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${ROCT_LIB_DIR} ${ASAN_LIB_PATH})
++link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${HSAKMT_LIB_DIR} ${ROCT_LIB_DIR} ${ASAN_LIB_PATH} ${ROCM_SMI_LIB_DIR} ${HIPRAND_LIB_DIR} ${ROCRAND_LIB_DIR})
+ ## additional libraries
+-set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so)
++set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so ${ROCBLAS_LIB_DIR}/librocblas.so ${HSAKMT_LIB_DIR}/libhsakmt.a ${HSA_PATH}/lib/libhsa-runtime64.so ${HIPRAND_LIB_DIR}/libhiprand.so ${ROCRAND_LIB_DIR}/librocrand.so)
+ 
+ ## define source files
+ set(SOURCES src/rvs_module.cpp src/action.cpp src/action_run.cpp
+diff --git a/pebb.so/CMakeLists.txt b/pebb.so/CMakeLists.txt
+index c4e2964..41a45f5 100644
+--- a/pebb.so/CMakeLists.txt
++++ b/pebb.so/CMakeLists.txt
+@@ -137,11 +137,11 @@ if(NOT EXISTS ${ROCR_LIB_DIR}/${CORE_RUNTIME_LIBRARY}.so)
+ endif()
+ 
+ ## define include directories
+-include_directories(./ ../ pci ${ROCR_INC_DIR})
++include_directories(./ ../ pci ${ROCR_INC_DIR} ${HIPRAND_INC_DIR} ${ROCRAND_INC_DIR})
+ # Add directories to look for library files to link
+-link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${ROCT_LIB_DIR} ${ASAN_LIB_PATH})
++link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${HSAKMT_LIB_DIR} ${ROCT_LIB_DIR} ${ASAN_LIB_PATH} ${ROCM_SMI_LIB_DIR} ${HIPRAND_LIB_DIR}/.. ${ROCRAND_LIB_DIR}/..)
+ ## additional libraries
+-set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so)
++set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so ${ROCBLAS_LIB_DIR}/librocblas.so ${HSAKMT_LIB_DIR}/libhsakmt.a ${HSA_PATH}/lib/libhsa-runtime64.so ${HIPRAND_LIB_DIR}/libhiprand.so ${ROCRAND_LIB_DIR}/librocrand.so)
+ 
+ ## define source files
+ set(SOURCES src/rvs_module.cpp src/action.cpp src/action_run.cpp
+diff --git a/peqt.so/CMakeLists.txt b/peqt.so/CMakeLists.txt
+index ead507d..d83c9e5 100644
+--- a/peqt.so/CMakeLists.txt
++++ b/peqt.so/CMakeLists.txt
+@@ -107,11 +107,11 @@ else()
+ endif()
+ 
+ ## define include directories
+-include_directories(./ ../)
++include_directories(./ ../ ${HSA_PATH})
+ # Add directories to look for library files to link
+-link_directories(${RVS_LIB_DIR} ${ASAN_LIB_PATH})
++link_directories(${RVS_LIB_DIR} ${HSA_PATH}/lib/ ${HSAKMT_LIB_DIR} ${ASAN_LIB_PATH} ${ROCM_SMI_LIB_DIR} ${HIPRAND_LIB_DIR} ${ROCRAND_LIB_DIR})
+ ## additional libraries
+-set (PROJECT_LINK_LIBS rvslib libpci.so libm.so)
++set (PROJECT_LINK_LIBS rvslib libpci.so libm.so ${HIPRAND_LIB_DIR}/libhiprand.so ${ROCRAND_LIB_DIR}/librocrand.so)
+ 
+ ## define source files
+ set(SOURCES src/rvs_module.cpp src/action.cpp)
+@@ -121,7 +121,7 @@ add_library( ${RVS_TARGET} SHARED ${SOURCES})
+ set_target_properties(${RVS_TARGET} PROPERTIES
+         SUFFIX .so.${LIB_VERSION_STRING}
+         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+-target_link_libraries(${RVS_TARGET} ${PROJECT_LINK_LIBS} )
++target_link_libraries(${RVS_TARGET} ${PROJECT_LINK_LIBS} ${ROCBLAS_LIB_DIR}/librocblas.so ${HSAKMT_LIB_DIR}/libhsakmt.a ${HSA_PATH}/lib/libhsa-runtime64.so ${HIPRAND_LIB_DIR}/libhiprand.so ${ROCRAND_LIB_DIR}/librocrand.so)
+ add_dependencies(${RVS_TARGET} rvslib)
+ 
+ add_custom_command(TARGET ${RVS_TARGET} POST_BUILD
+diff --git a/perf.so/CMakeLists.txt b/perf.so/CMakeLists.txt
+index 518dac9..dfe05f5 100644
+--- a/perf.so/CMakeLists.txt
++++ b/perf.so/CMakeLists.txt
+@@ -137,17 +137,17 @@ if(DEFINED RVS_ROCMSMI)
+ endif()
+ 
+ 
+-if(NOT EXISTS "${ROCR_LIB_DIR}/lib${HIP_HCC_LIB}.so")
++if(NOT EXISTS "${HIP_INC_DIR}/lib/lib${HIP_HCC_LIB}.so")
+   message("ERROR: ROC Runtime libraries can't be found under specified path. Please set ROCR_LIB_DIR path. Current value is : " ${ROCR_LIB_DIR})
+   RETURN()
+ endif()
+ 
+ ## define include directories
+-include_directories(./ ../ ${ROCR_INC_DIR} ${ROCBLAS_INC_DIR} ${HIP_INC_DIR})
++include_directories(./ ../ ${ROCR_INC_DIR} ${ROCBLAS_INC_DIR} ${HIP_INC_DIR} ${HIPRAND_INC_DIR} ${ROCRAND_INC_DIR})
+ # Add directories to look for library files to link
+-link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ASAN_LIB_PATH})
++link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${HIP_INC_DIR}/lib ${ROCBLAS_LIB_DIR} ${ASAN_LIB_PATH} ${ROCM_SMI_LIB_DIR} ${HIPRAND_LIB_DIR} ${ROCRAND_LIB_DIR})
+ ## additional libraries
+-set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so)
++set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so ${ROCBLAS_LIB_DIR}/librocblas.so ${HSAKMT_LIB_DIR}/libhsakmt.a ${HSA_PATH}/lib/libhsa-runtime64.so ${HIPRAND_LIB_DIR}/libhiprand.so ${ROCRAND_LIB_DIR}/librocrand.so)
+ 
+ ## define source files
+ set(SOURCES src/rvs_module.cpp src/action.cpp src/perf_worker.cpp)
+@@ -157,7 +157,7 @@ add_library( ${RVS_TARGET} SHARED ${SOURCES})
+ set_target_properties(${RVS_TARGET} PROPERTIES
+         SUFFIX .so.${LIB_VERSION_STRING}
+         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+-target_link_libraries(${RVS_TARGET} ${PROJECT_LINK_LIBS} ${HIP_HCC_LIB} ${ROCBLAS_LIB})
++target_link_libraries(${RVS_TARGET} ${PROJECT_LINK_LIBS})
+ add_dependencies(${RVS_TARGET} rvslib)
+ 
+ add_custom_command(TARGET ${RVS_TARGET} POST_BUILD
+diff --git a/pesm.so/CMakeLists.txt b/pesm.so/CMakeLists.txt
+index 1f27f34..502c1c8 100644
+--- a/pesm.so/CMakeLists.txt
++++ b/pesm.so/CMakeLists.txt
+@@ -107,11 +107,11 @@ else()
+ endif()
+ 
+ ## define include directories
+-include_directories(./ ../ pci)
++include_directories(./ ../ pci ${YAML_CPP_INCLUDE_DIRS})
+ # Add directories to look for library files to link
+-link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ASAN_LIB_PATH})
++link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ASAN_LIB_PATH} ${ROCM_SMI_LIB_DIR} ${HIPRAND_DIR} ${ROCRAND_DIR})
+ ## additional libraries
+-set (PROJECT_LINK_LIBS libpthread.so libpci.so libm.so)
++set (PROJECT_LINK_LIBS libpthread.so libpci.so libm.so ${PROJECT_LINK_LIBS} ${ROCBLAS_LIB_DIR}/librocblas.so ${HSAKMT_LIB_DIR}/libhsakmt.a ${HSA_PATH}/lib/libhsa-runtime64.so ${HIPRAND_LIB_DIR}/libhiprand.so ${ROCRAND_LIB_DIR}/librocrand.so)
+ 
+ ## define source files
+ set(SOURCES  src/rvs_module.cpp src/action.cpp src/worker.cpp)
+diff --git a/pesm.so/tests.cmake b/pesm.so/tests.cmake
+index 2c72658..c6acbf4 100644
+--- a/pesm.so/tests.cmake
++++ b/pesm.so/tests.cmake
+@@ -30,11 +30,11 @@ set(CORE_RUNTIME_NAME "hsa-runtime")
+ set(CORE_RUNTIME_TARGET "${CORE_RUNTIME_NAME}64")
+ 
+ set(UT_LINK_LIBS  libpthread.so libpci.so libm.so libdl.so "lib${ROCM_SMI_LIB}.so"
+-  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${YAML_CPP_LIBRARIES} ${HIPRAND_LIB}
++  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${YAML_CPP_LIBRARIES} "lib${HIPRAND_LIB}.so" "lib${ROCRAND_LIB}.so"
+ )
+ 
+ # Add directories to look for library files to link
+-link_directories(${ROCM_SMI_LIB_DIR} ${ROCT_LIB_DIR} ${ROCBLAS_LIB_DIR} ${HIPRAND_LIB_DIR})
++link_directories(${ROCM_SMI_LIB_DIR} ${ROCT_LIB_DIR} ${ROCBLAS_LIB_DIR} ${HIPRAND_LIB_DIR} ${ROCRAND_LIB_DIR})
+ 
+ set (UT_SOURCES test/unitactionbase.cpp
+ )
+diff --git a/rcqt.so/CMakeLists.txt b/rcqt.so/CMakeLists.txt
+index c0099ab..fcc82f3 100644
+--- a/rcqt.so/CMakeLists.txt
++++ b/rcqt.so/CMakeLists.txt
+@@ -108,11 +108,11 @@ else()
+ endif()
+ 
+ ## define include directories
+-include_directories(./ ../)
++include_directories(./ ../ ${YAML_CPP_INCLUDE_DIRS})
+ # Add directories to look for library files to link
+-link_directories(${RVS_LIB_DIR} ${ASAN_LIB_PATH})
++link_directories(${RVS_LIB_DIR} ${ASAN_LIB_PATH} ${ASAN_LIB_PATH} ${HSAKMT_LIB_DIR} ${ROCM_SMI_LIB_DIR})
+ ## additional libraries
+-set (PROJECT_LINK_LIBS rvslib)
++set (PROJECT_LINK_LIBS rvslib ${ROCBLAS_LIB_DIR}/librocblas.so ${HSAKMT_LIB_DIR}/libhsakmt.a ${HSA_PATH}/lib/libhsa-runtime64.so ${HIPRAND_LIB_DIR}/libhiprand.so ${ROCRAND_LIB_DIR}/librocrand.so)
+ 
+ ## define source files
+ set(SOURCES 
+diff --git a/rvs/CMakeLists.txt b/rvs/CMakeLists.txt
+index fc0118e..04c9abf 100644
+--- a/rvs/CMakeLists.txt
++++ b/rvs/CMakeLists.txt
+@@ -34,6 +34,7 @@ set ( RVS "rvs" )
+ set ( RVS_PACKAGE "rvs-roct" )
+ set ( RVS_COMPONENT "lib${RVS}" )
+ set ( RVS_TARGET "${RVS}" )
++set ( YAML_CPP_LIBRARIES "${YAML_CPP_LIB_PATH}")
+ 
+ project ( ${RVS_TARGET} )
+ 
+@@ -115,20 +116,22 @@ endif()
+ ## define include directories
+ include_directories(./ ../ ${YAML_CPP_INCLUDE_DIRS})
+ ## define lib directories
+-link_directories(${CMAKE_CURRENT_BINARY_DIR} ${RVS_LIB_DIR} ${ROCT_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ROCM_SMI_LIB_DIR} ${ASAN_LIB_PATH} ${HIPRAND_LIB_PATH})
++link_directories(${CMAKE_CURRENT_BINARY_DIR} ${RVS_LIB_DIR} ${ROCT_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ROCM_SMI_LIB_DIR} ${ASAN_LIB_PATH} ${HIPRAND_LIB_DIR} ${ROCRAND_LIB_DIR} ${RVS_LIB_DIR}/.. ${YAML_CPP_LIBRARIES})
+ 
+ ## additional libraries
+-set(ROCBLAS_LIB "rocblas")
+-set(ROC_THUNK_NAME "hsakmt")
+-set(CORE_RUNTIME_NAME "hsa-runtime")
+-set(HIPRAND_LIB "hiprand")
+-set(CORE_RUNTIME_TARGET "${CORE_RUNTIME_NAME}64")
+-set(PROJECT_LINK_LIBS libdl.so libpthread.so libpci.so ${YAML_CPP_LIBRARIES})
++set(ROCBLAS_LIB "${ROCBLAS_LIB_DIR}/librocblas.so")
++set(ROC_THUNK_NAME "${HSAKMT_LIB_DIR}/libhsakmt.a")
++set(CORE_RUNTIME_NAME "${HSA_PATH}/lib/libhsa-runtime64.so")
++set(YAML_CPP_LIB "${YAML_CPP_LIBRARIES}/libyaml-cpp.a")
++set(CORE_RUNTIME_TARGET "${CORE_RUNTIME_NAME}")
++set(PROJECT_LINK_LIBS libdl.so libpthread.so libpci.so)
++set(HIPRAND_LIB "${HIPRAND_LIB_DIR}/libhiprand.so")
++set(ROCRAND_LIB "${ROCRAND_LIB_DIR}/librocrand.so")
+ 
+ ## define target
+ add_executable(${RVS_TARGET} src/rvs.cpp)
+ target_link_libraries(${RVS_TARGET} rvslib
+-  ${ROCBLAS_LIB} ${ROCM_SMI_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${PROJECT_LINK_LIBS} ${HIPRAND_LIB})
++  ${ROCBLAS_LIB} ${ROCM_SMI_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${PROJECT_LINK_LIBS} ${HIPRAND_LIB} ${YAML_CPP_LIB} ${ROCRAND_LIB})
+ add_dependencies(${RVS_TARGET} rvslib)
+ 
+ install(TARGETS ${RVS_TARGET}
+diff --git a/rvs/tests.cmake b/rvs/tests.cmake
+index c519482..64a4ad0 100644
+--- a/rvs/tests.cmake
++++ b/rvs/tests.cmake
+@@ -32,17 +32,18 @@
+ 
+ set(ROCBLAS_LIB "rocblas")
+ set(HIPRAND_LIB "hiprand")
++set(ROCRAND_LIB "rocrand")
+ set(ROC_THUNK_NAME "hsakmt")
+ set(CORE_RUNTIME_NAME "hsa-runtime")
+ set(CORE_RUNTIME_TARGET "${CORE_RUNTIME_NAME}64")
+ 
+ ## define lib directories
+-link_directories(${RVS_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ROCM_SMI_LIB_DIR} ${ROCT_LIB_DIR} ${HIPRAND_LIB_DIR})
++link_directories(${RVS_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ROCM_SMI_LIB_DIR} ${ROCT_LIB_DIR} ${HIPRAND_LIB_DIR} ${ROCRAND_LIB_DIR})
+ 
+ ## define target for "test-to-fail"
+ add_executable(${RVS_TARGET}fail src/rvs.cpp)
+ target_link_libraries(${RVS_TARGET}fail rvslib rvslibut ${PROJECT_LINK_LIBS}
+-  ${ROCM_SMI_LIB} ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${ROCM_CORE} ${CORE_RUNTIME_TARGET} ${HIPRAND_LIB})
++  ${ROCM_SMI_LIB} ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${ROCM_CORE} ${CORE_RUNTIME_TARGET} ${HIPRAND_LIB} ${ROCRAND_LIB})
+ 
+ target_compile_definitions(${RVS_TARGET}fail PRIVATE RVS_INVERT_RETURN_STATUS)
+ set_target_properties(${RVS_TARGET}fail PROPERTIES
+@@ -211,7 +212,7 @@ FOREACH(SINGLE_TEST ${TESTSOURCES})
+     ${PROJECT_LINK_LIBS}
+     ${PROJECT_TEST_LINK_LIBS}
+     rvslib rvslibut gtest_main gtest pthread
+-    ${ROCM_SMI_LIB} ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${HIPRAND_LIB}
++    ${ROCM_SMI_LIB} ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${HIPRAND_LIB} ${ROCRAND_LIB}
+   )
+   add_dependencies(${TEST_NAME} rvs_gtest_target)
+ 
+diff --git a/rvslib/CMakeLists.txt b/rvslib/CMakeLists.txt
+index 8d29590..18eb9f4 100644
+--- a/rvslib/CMakeLists.txt
++++ b/rvslib/CMakeLists.txt
+@@ -116,7 +116,7 @@ endif()
+ 
+ ## define include directories
+ include_directories(./ ../ ../rvs
+-  ${ROCM_SMI_INC_DIR} ${ROCR_INC_DIR} ${ROCBLAS_INC_DIR} ${HIP_INC_DIR})
++  ${ROCM_SMI_INC_DIR} ${ROCR_INC_DIR} ${ROCBLAS_INC_DIR} ${HIP_PATH} ${YAML_CPP_INCLUDE_DIRS} ${HIPRAND_INC_DIR} ${ROCRAND_INC_DIR})
+ 
+ link_directories(${ASAN_LIB_PATH} ${ROCM_SMI_LIB_DIR})
+ 
+diff --git a/smqt.so/CMakeLists.txt b/smqt.so/CMakeLists.txt
+index 042586f..285cb17 100644
+--- a/smqt.so/CMakeLists.txt
++++ b/smqt.so/CMakeLists.txt
+@@ -106,11 +106,11 @@ else()
+ endif()
+ 
+ ## define include directories
+-include_directories(./ ../ pci)
++include_directories(./ ../ pci ${YAML_CPP_INCLUDE_DIRS})
+ # Add directories to look for library files to link
+-link_directories(${RVS_LIB_DIR} ${ASAN_LIB_PATH})
++link_directories(${RVS_LIB_DIR} ${ASAN_LIB_PATH} ${ROCM_SMI_LIB_DIR})
+ ## additional libraries
+-set (PROJECT_LINK_LIBS rvslib libpci.so libm.so)
++set (PROJECT_LINK_LIBS rvslib libpci.so libm.so ${ROCBLAS_LIB_DIR}/librocblas.so ${HSAKMT_LIB_DIR}/libhsakmt.a ${HSA_PATH}/lib/libhsa-runtime64.so ${HIPRAND_LIB_DIR}/libhiprand.so ${ROCRAND_LIB_DIR}/librocrand.so)
+ 
+ ## define source files
+ set(SOURCES src/rvs_module.cpp src/action.cpp)
+diff --git a/smqt.so/tests.cmake b/smqt.so/tests.cmake
+index 76766de..804441a 100644
+--- a/smqt.so/tests.cmake
++++ b/smqt.so/tests.cmake
+@@ -30,11 +30,11 @@ set(CORE_RUNTIME_NAME "hsa-runtime")
+ set(CORE_RUNTIME_TARGET "${CORE_RUNTIME_NAME}64")
+ 
+ set(UT_LINK_LIBS  libpthread.so libpci.so libm.so libdl.so "lib${ROCM_SMI_LIB}.so"
+-  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${YAML_CPP_LIBRARIES} ${HIPRAND_LIB}
++  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${YAML_CPP_LIBRARIES} "lib${HIPRAND_LIB}.so" "lib${HIPRAND_LIB}.so"
+ )
+ 
+ # Add directories to look for library files to link
+-link_directories(${ROCM_SMI_LIB_DIR} ${ROCT_LIB_DIR} ${ROCBLAS_LIB_DIR} ${HIPRAND_LIB_DIR})
++link_directories(${ROCM_SMI_LIB_DIR} ${ROCT_LIB_DIR} ${ROCBLAS_LIB_DIR} ${HIPRAND_LIB_DIR} ${ROCRAND_LIB_DIR})
+ 
+ set (UT_SOURCES src/action.cpp test/unitsmqt.cpp
+ )
+diff --git a/testif.so/CMakeLists.txt b/testif.so/CMakeLists.txt
+index 4cba0f9..691534a 100644
+--- a/testif.so/CMakeLists.txt
++++ b/testif.so/CMakeLists.txt
+@@ -108,11 +108,11 @@ endif()
+ 
+ 
+ ## define include directories
+-include_directories(./ ../ pci)
++include_directories(./ ../ pci ${YAML_CPP_INCLUDE_DIRS})
+ # Add directories to look for library files to link
+-link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ASAN_LIB_PATH})
++link_directories(${RVS_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ASAN_LIB_PATH} ${ROCM_SMI_LIB_DIR})
+ ## additional libraries
+-set (PROJECT_LINK_LIBS libpthread.so libpci.so libm.so)
++set (PROJECT_LINK_LIBS libpthread.so libpci.so libm.so ${ROCBLAS_LIB_DIR}/librocblas.so ${HSAKMT_LIB_DIR}/libhsakmt.a ${HSA_PATH}/lib/libhsa-runtime64.so)
+ 
+ ## define source files
+ ## set(SOURCES  src/rvs_module.cpp src/action.cpp src/worker.cpp)
+diff --git a/tst.so/CMakeLists.txt b/tst.so/CMakeLists.txt
+index 1a1a8b0..c6e46da 100644
+--- a/tst.so/CMakeLists.txt
++++ b/tst.so/CMakeLists.txt
+@@ -140,7 +140,7 @@ if(DEFINED RVS_ROCMSMI)
+   endif()
+ endif()
+ 
+-if(NOT EXISTS "${ROCR_LIB_DIR}/lib${HIP_HCC_LIB}.so")
++if(NOT EXISTS "${HIP_INC_DIR}/lib/lib${HIP_HCC_LIB}.so")
+   message("ERROR: ROC Runtime libraries can't be found under specified path. Please set ROCR_LIB_DIR path. Current value is : " ${ROCR_LIB_DIR})
+   RETURN()
+ endif()
+@@ -155,11 +155,11 @@ if(DEFINED RVS_ROCMSMI)
+ endif()
+ 
+ ## define include directories
+-include_directories(./ ../ ${ROCM_SMI_INC_DIR} ${ROCBLAS_INC_DIR} ${ROCR_INC_DIR} ${HIP_INC_DIR})
++include_directories(./ ../ ${ROCM_SMI_INC_DIR} ${ROCBLAS_INC_DIR} ${ROCR_INC_DIR} ${HIP_INC_DIR} ${HIPRAND_INC_DIR} ${ROCRAND_INC_DIR})
+ # Add directories to look for library files to link
+-link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ROCM_SMI_LIB_DIR} ${ASAN_LIB_PATH})
++link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ROCM_SMI_LIB_DIR} ${ASAN_LIB_PATH} ${HIPRAND_LIB_DIR}/.. ${ROCRAND_LIB_DIR}/..)
+ ## additional libraries
+-set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so)
++set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so ${HIPRAND_LIB_DIR}/libhiprand.so ${ROCRAND_LIB_DIR}/librocrand.so)
+ 
+ set(SOURCES src/rvs_module.cpp src/action.cpp src/tst_worker.cpp )
+ 

--- a/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
+++ b/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
@@ -58,7 +58,8 @@ class RocmValidationSuite(CMakePackage):
     # It expects rocm components headers and libraries in /opt/rocm
     # It doesn't find package to include the library and include path without this patch.
     patch("009-replacing-rocm-path-with-package-path.patch", when="@6.0")
-    patch("009-replacing-rocm-path-with-package-path-6.1.patch", when="@6.1")
+    patch("009-replacing-rocm-path-with-package-path-6.1.patch", when="@6.1:6.2.0")
+    patch("009-replacing-rocm-path-with-package-path-6.2.1.patch", when="@6.2.1")
     depends_on("cmake@3.5:", type="build")
     depends_on("zlib-api", type="link")
     depends_on("yaml-cpp~shared")
@@ -94,6 +95,9 @@ class RocmValidationSuite(CMakePackage):
         depends_on(f"rocm-smi-lib@{ver}", when=f"@{ver}")
         depends_on(f"hsa-rocr-dev@{ver}", when=f"@{ver}")
         depends_on(f"hsakmt-roct@{ver}", when=f"@{ver}")
+    for ver in ["6.2.1"]:
+        depends_on(f"hiprand@{ver}", when=f"@{ver}")
+        depends_on(f"rocrand@{ver}", when=f"@{ver}")
 
     def patch(self):
         if self.spec.satisfies("@5.2:5.4"):
@@ -104,7 +108,7 @@ class RocmValidationSuite(CMakePackage):
             filter_file(
                 r"@ROCM_PATH@/rvs", self.spec.prefix.rvs, "rvs/conf/deviceid.sh.in", string=True
             )
-        elif self.spec.satisfies("@6.0:"):
+        elif self.spec.satisfies("@6.0:6.1"):
             filter_file(
                 "@ROCM_PATH@/rvs", self.spec.prefix.bin, "rvs/conf/deviceid.sh.in", string=True
             )
@@ -119,6 +123,9 @@ class RocmValidationSuite(CMakePackage):
             self.define("YAML_CPP_INCLUDE_DIRS", self.spec["yaml-cpp"].prefix.include),
             self.define("UT_INC", self.spec["googletest"].prefix.include),
         ]
+        if self.spec.satisfies("@6.2.1:"):
+            args.append(self.define("HIPRAND_DIR", self.spec["hiprand"].prefix)),
+            args.append(self.define("ROCRAND_DIR", self.spec["rocrand"].prefix)),
         libloc = self.spec["googletest"].prefix.lib64
         if not os.path.isdir(libloc):
             libloc = self.spec["googletest"].prefix.lib
@@ -131,20 +138,5 @@ class RocmValidationSuite(CMakePackage):
         if not os.path.isdir(libloc):
             libloc = self.spec["yaml-cpp"].prefix.lib
         args.append(self.define("YAML_CPP_LIB_PATH", libloc))
-        if self.spec.satisfies("@6.2:"):
-            args.append(
-                self.define(
-                    "CMAKE_CXX_FLAGS",
-                    f"-I{self.spec['rocm-smi-lib'].prefix.include} "
-                    f"-I{self.spec['rocblas'].prefix.include} "
-                    f"-I{self.spec['yaml-cpp'].prefix.include} "
-                    f"-L{self.spec['hip'].prefix.lib} "
-                    f"-L{self.spec['hsa-rocr-dev'].prefix.lib} "
-                    f"-L{self.spec['hsakmt-roct'].prefix.lib} "
-                    f"-L{self.spec['rocm-smi-lib'].prefix.lib} "
-                    f"-L{self.spec['rocblas'].prefix.lib} "
-                    f"{libloc}/libyaml-cpp.a ",
-                )
-            )
-            args.append(self.define("CPACK_PACKAGING_INSTALL_PREFIX", self.spec.prefix))
+
         return args


### PR DESCRIPTION
Updating patch file for 6.2.1 and removing unwanted arguments to add library paths into RUNPATH
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
