### PR TITLE
fix various bootstrap/concretizer import issues

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -17,6 +17,7 @@ from llnl.util.lang import attr_setdefault, index_by
 from llnl.util.tty.colify import colify
 from llnl.util.tty.color import colorize
 
+import spack.concretize
 import spack.config  # breaks a cycle.
 import spack.environment as ev
 import spack.error

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -10,8 +10,11 @@ from typing import Iterable, Optional, Sequence, Tuple, Union
 
 import llnl.util.tty as tty
 
+import spack.compilers
 import spack.config
 import spack.error
+import spack.repo
+import spack.util.parallel
 from spack.spec import ArchSpec, CompilerSpec, Spec
 
 CHECK_COMPILER_EXISTENCE = True
@@ -87,6 +90,8 @@ def concretize_together_when_possible(
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
     """
+    import spack.solver.asp
+
     to_concretize = [concrete if concrete else abstract for abstract, concrete in spec_list]
     old_concrete_to_abstract = {
         concrete: abstract for (abstract, concrete) in spec_list if concrete
@@ -119,6 +124,8 @@ def concretize_separately(
         tests: list of package names for which to consider tests dependencies. If True, all nodes
             will have test dependencies. If False, test dependencies will be disregarded.
     """
+    import spack.bootstrap
+
     to_concretize = [abstract for abstract, concrete in spec_list if not concrete]
     args = [
         (i, str(abstract), tests)
@@ -155,11 +162,7 @@ def concretize_separately(
 
     for j, (i, concrete, duration) in enumerate(
         spack.util.parallel.imap_unordered(
-            spack.concretize._concretize_task,
-            args,
-            processes=num_procs,
-            debug=tty.is_debug(),
-            maxtaskperchild=1,
+            _concretize_task, args, processes=num_procs, debug=tty.is_debug(), maxtaskperchild=1
         )
     ):
         ret.append((i, concrete))

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -24,7 +24,6 @@ from llnl.util.symlink import readlink, symlink
 
 import spack
 import spack.caches
-import spack.compilers
 import spack.concretize
 import spack.config
 import spack.deptypes as dt
@@ -43,7 +42,6 @@ import spack.user_environment as uenv
 import spack.util.environment
 import spack.util.hash
 import spack.util.lock as lk
-import spack.util.parallel
 import spack.util.path
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -27,7 +27,6 @@ from llnl.util.lang import elide_list
 
 import spack
 import spack.binary_distribution
-import spack.bootstrap.core
 import spack.compilers
 import spack.concretize
 import spack.config
@@ -816,7 +815,7 @@ class PyclingoDriver:
             solve, and the internal statistics from clingo.
         """
         # avoid circular import
-        import spack.bootstrap
+        import spack.bootstrap.core
 
         output = output or DEFAULT_OUTPUT_CONFIGURATION
         timer = spack.util.timer.Timer()


### PR DESCRIPTION
Closes #47432

Those modules really need to be untangled, but for now add some inline imports.

This cannot be tested really because tests themselves do various imports, hiding the problem.