### PR TITLE
omega-h: new version and cuda conflicts for prior versions

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-neoverse_v1/spack.yaml
@@ -225,7 +225,7 @@ spack:
   - magma +cuda cuda_arch=75
   - mfem +cuda cuda_arch=75
   - mgard +serial +openmp +timing +unstructured +cuda cuda_arch=75
-  - "omega-h@:9 +cuda cuda_arch=75"  # https://github.com/SCOREC/omega_h/issues/116
+  - omega-h +cuda cuda_arch=75
   - parsec +cuda cuda_arch=75
   - petsc +cuda cuda_arch=75
   - py-torch +cuda cuda_arch=75
@@ -274,7 +274,7 @@ spack:
   - magma +cuda cuda_arch=80
   - mfem +cuda cuda_arch=80
   - mgard +serial +openmp +timing +unstructured +cuda cuda_arch=80
-  - "omega-h@:9 +cuda cuda_arch=80"  # https://github.com/SCOREC/omega_h/issues/116
+  - omega-h +cuda cuda_arch=80
   - parsec +cuda cuda_arch=80
   - petsc +cuda cuda_arch=80
   - py-torch +cuda cuda_arch=80

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-power/spack.yaml
@@ -233,7 +233,7 @@ spack:
   - magma +cuda cuda_arch=70
   - mfem +cuda cuda_arch=70
   - mgard +serial +openmp +timing +unstructured +cuda cuda_arch=70
-  - "omega-h@:9 +cuda cuda_arch=70"  # https://github.com/SCOREC/omega_h/issues/116
+  - omega-h +cuda cuda_arch=70
   - parsec +cuda cuda_arch=70
   - petsc +cuda cuda_arch=70
   - raja +cuda cuda_arch=70

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -239,7 +239,7 @@ spack:
   - libpressio +bitgrooming +bzip2 +fpzip +hdf5 +libdistributed +lua +openmp +python +sz +sz3 +unix +zfp +json +remote +netcdf +cusz +mgard +cuda cuda_arch=80 ^cusz +cuda cuda_arch=80
   - magma +cuda cuda_arch=80
   - mfem +cuda cuda_arch=80
-  - "omega-h@:9 +cuda cuda_arch=80"  # https://github.com/SCOREC/omega_h/issues/116
+  - omega-h +cuda cuda_arch=80
   - parsec +cuda cuda_arch=80
   - petsc +cuda cuda_arch=80
   - py-torch +cuda cuda_arch=80

--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -20,6 +20,11 @@ class OmegaH(CMakePackage, CudaPackage):
     tags = ["e4s"]
     version("main", branch="main")
     version(
+        "10.8.6-scorec",
+        commit="a730c78e516d7f6cca4f8b4e4e0a5eb8020f9ad9",
+        git="https://github.com/SCOREC/omega_h.git",
+    )
+    version(
         "10.8.5-scorec",
         commit="62026fc305356abb5e02a9fce3fead9cf5077fbe",
         git="https://github.com/SCOREC/omega_h.git",

--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -89,6 +89,9 @@ class OmegaH(CMakePackage, CudaPackage):
         # Single, broken CUDA version.
         conflicts("^cuda@11.2", msg="See https://github.com/sandialabs/omega_h/issues/366")
 
+    # https://github.com/SCOREC/omega_h/pull/118
+    conflicts("@10.5:10.8.5 +cuda~kokkos")
+
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86610
     conflicts("%gcc@8:8.2", when="@:9.22.1")
 


### PR DESCRIPTION
This PR adds a new version `10.8.6-scorec` that resolves the CUDA issue discussed in https://github.com/SCOREC/omega_h/issues/116 and adds conflicts to avoid the CUDA build error for prior versions.
