### PR TITLE
loki%oneapi@2025: -Wno-error=missing-template-arg-list-after-template-kw

### DIFF
--- a/var/spack/repos/builtin/packages/loki/package.py
+++ b/var/spack/repos/builtin/packages/loki/package.py
@@ -24,6 +24,8 @@ class Loki(MakefilePackage):
 
     def flag_handler(self, name, flags):
         if name == "cxxflags":
+            if self.spec.satisfies("%oneapi@2025:"):
+                flags.append("-Wno-error=missing-template-arg-list-after-template-kw")
             if self.spec.satisfies("%oneapi@2023.0.0:"):
                 flags.append("-Wno-error=dynamic-exception-spec")
             if self.spec.satisfies("@0.1.7 %gcc@11:"):


### PR DESCRIPTION
Needed to fix `%oneapi@2025` build and to merge:
* https://github.com/spack/spack/pull/47317
* [loki@0.1.7 /cmwefw7 %oneapi@2025.0.0 arch=linux-ubuntu22.04-x86_64_v3 E4S OneAPI ](https://gitlab.spack.io/spack/spack/-/jobs/13177476)
```
...
     90     In file included from StrongPtr.cpp:16:
     91     In file included from ../include/loki/StrongPtr.h:20:
  >> 92     ../include/loki/SmartPtr.h:1323:33: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
     93      1323 |             return OP::template Merge( rhs );
...
```

CC @rscohn2 