### PR TITLE
slate %oneapi@2025: cxxflags: add -Wno-error=missing-template-arg-lis…

### DIFF
--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -127,6 +127,12 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+sycl", when="@:2022.07.00", msg="SYCL support requires SLATE version 2023.08.25")
     conflicts("^hip@5.6.0:", when="@:2023.08.25", msg="Incompatible version of HIP/ROCm")
 
+    def flag_handler(self, name, flags):
+        if name == "cxxflags":
+            if self.spec.satisfies("%oneapi@2025:"):
+                flags.append("-Wno-error=missing-template-arg-list-after-template-kw")
+        return (flags, None, None)
+
     def cmake_args(self):
         spec = self.spec
         backend_config = "-Duse_cuda=%s" % ("+cuda" in spec)


### PR DESCRIPTION
Needed to fix error and to merge this PR:
* https://github.com/spack/spack/pull/47317
* [slate@2024.05.31 /iioypgh %oneapi@2025.0.0 arch=linux-ubuntu22.04-x86_64_v3 E4S OneAPI ](https://gitlab.spack.io/spack/spack/-/jobs/13177727)
```
  >> 125    /tmp/root/spack-stage/spack-stage-slate-2024.05.31-iioypghb3amolopp
            7urpai3pdo47pkrk/spack-src/src/gelqf.cc:241:42: error: a template a
            rgument list is expected after a name prefixed by the template keyw
            ord [-Wmissing-template-arg-list-after-template-kw]
     126      241 |                         Treduce.template listBcast(bcast_li
            st_T, layout);
```

There is also an internal compiler error with `slate%oneapi@2025` but that is separate.

CC @rscohn2 
