### PR TITLE
vtk-m %oneapi@2025: cxxflags add -Wno-error=missing-template-arg-list…

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -187,7 +187,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
 
     def flag_handler(self, name, flags):
         if name == "cxxflags":
-            if self.spec.satisfies("%oneapi@2025:"):
+            if self.spec.satisfies("@:2.2.0 %oneapi@2025:"):
                 flags.append("-Wno-error=missing-template-arg-list-after-template-kw")
         return (flags, None, None)
 

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -185,6 +185,12 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
         when="@1.6.0:2.1 +cuda ^cuda@12.5:",
     )
 
+    def flag_handler(self, name, flags):
+        if name == "cxxflags":
+            if self.spec.satisfies("%oneapi@2025:"):
+                flags.append("-Wno-error=missing-template-arg-list-after-template-kw")
+        return (flags, None, None)
+
     def cmake_args(self):
         spec = self.spec
         options = []


### PR DESCRIPTION
1. Fix build error
```
  >> 151    /tmp/root/spack-stage/spack-stage-vtk-m-2.2.0-k4fq455x2o3ewbx5oljkj
            pfwoq6fa6b7/spack-src/vtkm/internal/VariantImplDetail.h:734:53: err
            or: a template argument list is expected after a name prefixed by t
            he template keyword [-Wmissing-template-arg-list-after-template-kw]
```

2. Needed to merge PR:
* https://github.com/spack/spack/pull/47317

CC @rscohn2 