### PR TITLE
legion%oneapi@2025: cxxflags add -Wno-error=missing-template-arg-list…

### DIFF
--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -310,6 +310,12 @@ class Legion(CMakePackage, ROCmPackage):
         "sysomp", default=False, description="Use system OpenMP implementation instead of Realm's"
     )
 
+    def flag_handler(self, name, flags):
+        if name == "cxxflags":
+            if self.spec.satisfies("%oneapi@2025:"):
+                flags.append("-Wno-error=missing-template-arg-list-after-template-kw")
+        return (flags, None, None)
+
     def cmake_args(self):
         spec = self.spec
         from_variant = self.define_from_variant


### PR DESCRIPTION
1. Fix build error:
* [ legion@24.09.0 /4z6owc7 %oneapi@2025.0.0 arch=linux-ubuntu22.04-x86_64_v3 E4S OneAPI ](https://gitlab.spack.io/spack/spack/-/jobs/13177684)
```
     230    In file included from /tmp/root/spack-stage/spack-stage-legion-24.0
            9.0-4z6owc72vfsjza3f6fh2ailto2us5776/spack-src/runtime/legion/legio
            n_utilities.h:25:
  >> 231    /tmp/root/spack-stage/spack-stage-legion-24.09.0-4z6owc72vfsjza3f6f
            h2ailto2us5776/spack-src/runtime/legion/bitmask.h:2884:20: error: a
             template argument list is expected after a name prefixed by the te
            mplate keyword [-Wmissing-template-arg-list-after-template-kw]
     232     2884 |       rez.template serialize(sum_mask);
     233          |                  
```

2. Need this fix to merge following PR:
* https://github.com/spack/spack/pull/47317

CC @rscohn2 