### PR TITLE
root: fix macos build

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -634,7 +634,7 @@ class Root(CMakePackage):
             define("builtin_freetype", False),
             define("builtin_ftgl", False),
             define("builtin_gl2ps", False),
-            define("builtin_glew", self.spec.satisfies("platform=darwin")),
+            define("builtin_glew", False),
             define("builtin_gsl", False),
             define("builtin_llvm", True),
             define("builtin_lz4", self.spec.satisfies("@6.12.02:6.12")),


### PR DESCRIPTION
No ROOT `builtin` should ever be set to true, because that vendors an existing library that spack doesn't know about.

Worse, using `builtin_glew` forces the package to be on, even when not building x/gl/aqua on macos, which causes build failures. This PR fixes that problem.

Caused by https://github.com/spack/spack/pull/45632#issuecomment-2276311748 . Perhaps @stephenswat you can post the build error and we can see if there's an alternate solution that works for both cases?