### PR TITLE
spec.py: fix comparison with multivalued variants

### DIFF
--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1975,3 +1975,7 @@ def test_equality_discriminate_on_propagation(lhs, rhs):
     s, t = Spec(lhs), Spec(rhs)
     assert s != t
     assert len({s, t}) == 2
+
+
+def test_comparison_multivalued_variants():
+    assert Spec("x=a") < Spec("x=a,b") < Spec("x==a,b") < Spec("x==a,b,c")

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -378,8 +378,8 @@ class AbstractVariant:
 
     def _cmp_iter(self) -> Iterable:
         yield self.name
-        yield from (str(v) for v in self.value_as_tuple)
         yield self.propagate
+        yield from (str(v) for v in self.value_as_tuple)
 
     def copy(self) -> "AbstractVariant":
         """Returns an instance of a variant equivalent to self


### PR DESCRIPTION
Closes #47446

Fix a regression introduced in #47376, the issue is that the `yield from` bit is variable length, so at some point a variant value string may be compared to a propagate bool.