### PR TITLE
gl header search: fix issue due to breaking change in find api

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -3298,7 +3298,7 @@ follows:
        # The header provided by the bar virtual package
        @property
        def bar_headers(self):
-           return find_headers("bar/bar.h", root=self.home.include, recursive=False)
+           return find_headers("bar", root=self.home.include, recursive=False)
 
        # The library provided by the bar virtual package
        @property
@@ -3313,7 +3313,7 @@ follows:
        # The header provided by the baz virtual package
        @property
        def baz_headers(self):
-           return find_headers("baz/baz", root=self.baz_home.include, recursive=False)
+           return find_headers("baz", root=self.baz_home.include, recursive=False)
 
        # The library provided by the baz virtual package
        @property

--- a/var/spack/repos/builtin/packages/egl/package.py
+++ b/var/spack/repos/builtin/packages/egl/package.py
@@ -77,10 +77,15 @@ class Egl(BundlePackage):
 
     @property
     def egl_headers(self):
-        header_name = "GL/gl"
+        header_name = "gl"
         gl_header = find_headers(header_name, root=self.prefix, recursive=True)
-        header_name = "EGL/egl"
+        header_name = "egl"
         egl_header = find_headers(header_name, root=self.prefix, recursive=True)
+
+        # Filter the prefix to avoid picking up GL/EGL headers _not_ provided by
+        # OpenGL (ie. hwloc)
+        gl_header = [h for h in gl_header if "GL/" in h]
+        egl_header = [h for h in egl_header if "EGL/" in h]
         return gl_header + egl_header
 
     @property

--- a/var/spack/repos/builtin/packages/glx/package.py
+++ b/var/spack/repos/builtin/packages/glx/package.py
@@ -30,7 +30,7 @@ class Glx(BundlePackage):
 
     @property
     def gl_headers(self):
-        return find_headers("GL/gl", root=self.gl_home, recursive=True)
+        return find_headers("gl", root=self.gl_home, recursive=True)
 
     @property
     def gl_libs(self):

--- a/var/spack/repos/builtin/packages/glx/package.py
+++ b/var/spack/repos/builtin/packages/glx/package.py
@@ -30,7 +30,10 @@ class Glx(BundlePackage):
 
     @property
     def gl_headers(self):
-        return find_headers("gl", root=self.gl_home, recursive=True)
+        header = find_headers("gl", root=self.gl_home, recursive=True)
+        # Filter the prefix to avoid picking up GL headers _not_ provided by
+        # OpenGL (ie. hwloc)
+        return [h for h in header if "GL" in h]
 
     @property
     def gl_libs(self):

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -169,7 +169,7 @@ class Mesa(MesonPackage):
 
     @property
     def libglx_headers(self):
-        return find_headers("GL/glx", root=self.spec.prefix.include, recursive=False)
+        return find_headers("glx", root=self.spec.prefix.include.GL, recursive=False)
 
     @property
     def libglx_libs(self):
@@ -177,7 +177,7 @@ class Mesa(MesonPackage):
 
     @property
     def libosmesa_headers(self):
-        return find_headers("GL/osmesa", root=self.spec.prefix.include, recursive=False)
+        return find_headers("osmesa", root=self.spec.prefix.include.GL, recursive=False)
 
     @property
     def libosmesa_libs(self):

--- a/var/spack/repos/builtin/packages/opengl/package.py
+++ b/var/spack/repos/builtin/packages/opengl/package.py
@@ -92,12 +92,14 @@ class Opengl(BundlePackage):
 
     @property
     def gl_headers(self):
+        headers = find_headers("gl", root=self.prefix, recursive=True)
+        # Filter the prefix to avoid picking up gl.h headers _not_ provided by
+        # OpenGL (ie. hwloc)
         spec = self.spec
+        header_prefix = "GL/"
         if "platform=darwin" in spec:
-            header_name = "OpenGL/gl"
-        else:
-            header_name = "GL/gl"
-        return find_headers(header_name, root=self.prefix, recursive=True)
+            header_prefix = "OpenGL/"
+        return [h for h in headers if header_prefix in h]
 
     @property
     def gl_libs(self):

--- a/var/spack/repos/builtin/packages/osmesa/package.py
+++ b/var/spack/repos/builtin/packages/osmesa/package.py
@@ -30,7 +30,7 @@ class Osmesa(BundlePackage):
 
     @property
     def gl_headers(self):
-        return find_headers("GL/gl", root=self.gl_home, recursive=True)
+        return find_headers("gl", root=self.gl_home, recursive=True)
 
     @property
     def gl_libs(self):


### PR DESCRIPTION
#41945 has a breaking change where `x/y` patterns are no longer allowed to `find`, only `fnmatch` type filename patterns are. So stop using `find_headers("x/y", prefix.include)` and instead use `find_headers("y", prefix.include.x)`. This makes no difference to the return value of `find_headers(...)`, so does not influence `-I` flags.