### PR TITLE
orca: add v6.0.1, avx2-6.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/orca/package.py
+++ b/var/spack/repos/builtin/packages/orca/package.py
@@ -23,7 +23,9 @@ class Orca(Package):
 
     license("LGPL-2.1-or-later")
 
-    version("avx2-6.0.1", sha256="bdb14a0b6b49064531eb6cf3811b5b95b628ce88a576b8b842b201b9c37e6779")
+    version(
+        "avx2-6.0.1", sha256="bdb14a0b6b49064531eb6cf3811b5b95b628ce88a576b8b842b201b9c37e6779"
+    )
     version("6.0.1", sha256="5aadad86f323dd2fa9dc00c94ff3aa7fe6e006d740aad8a410c5090ce26ea98c")
     version(
         "avx2-6.0.0", sha256="02c21294efe7b1b721e26cb90f98ee15ad682d02807201b7d217dfe67905a2fd"

--- a/var/spack/repos/builtin/packages/orca/package.py
+++ b/var/spack/repos/builtin/packages/orca/package.py
@@ -24,7 +24,7 @@ class Orca(Package):
     license("LGPL-2.1-or-later")
 
     version(
-        "avx2-6.0.1", sha256="bdb14a0b6b49064531eb6cf3811b5b95b628ce88a576b8b842b201b9c37e6779"
+        "avx2-6.0.1", sha256="f31f98256a0c6727b6ddfe50aa3ac64c45549981138d670a57e90114b4b9c9d2"
     )
     version("6.0.1", sha256="5aadad86f323dd2fa9dc00c94ff3aa7fe6e006d740aad8a410c5090ce26ea98c")
     version(

--- a/var/spack/repos/builtin/packages/orca/package.py
+++ b/var/spack/repos/builtin/packages/orca/package.py
@@ -60,11 +60,17 @@ class Orca(Package):
         openmpi_version = self.openmpi_versions[version.string].replace(".", "")
         if openmpi_version == "412":
             openmpi_version = "411"
+
         ver_parts = version.string.split("-")
         ver_underscored = ver_parts[-1].replace(".", "_")
         features = ver_parts[:-1] + ["shared"]
         feature_text = "_".join(features)
-        return f"file://{os.getcwd()}/orca_{ver_underscored}_linux_x86-64_{feature_text}_openmpi{openmpi_version}.tar.xz"
+
+        url = f"file://{os.getcwd()}/orca_{ver_underscored}_linux_x86-64_{feature_text}_openmpi{openmpi_version}.tar.xz"
+        if self.spec.satisfies("@=avx2-6.0.1"):
+            url = f"file://{os.getcwd()}/orca_{ver_underscored}_linux_x86-64_shared_openmpi{openmpi_version}_avx2.tar.xz"
+
+        return url
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/orca/package.py
+++ b/var/spack/repos/builtin/packages/orca/package.py
@@ -23,6 +23,8 @@ class Orca(Package):
 
     license("LGPL-2.1-or-later")
 
+    version("avx2-6.0.1", sha256="bdb14a0b6b49064531eb6cf3811b5b95b628ce88a576b8b842b201b9c37e6779")
+    version("6.0.1", sha256="5aadad86f323dd2fa9dc00c94ff3aa7fe6e006d740aad8a410c5090ce26ea98c")
     version(
         "avx2-6.0.0", sha256="02c21294efe7b1b721e26cb90f98ee15ad682d02807201b7d217dfe67905a2fd"
     )
@@ -43,7 +45,9 @@ class Orca(Package):
         "5.0.3": "4.1.2",
         "5.0.4": "4.1.2",
         "6.0.0": "4.1.6",
+        "6.0.1": "4.1.6",
         "avx2-6.0.0": "4.1.6",
+        "avx2-6.0.1": "4.1.6",
     }
     for orca_version, openmpi_version in openmpi_versions.items():
         depends_on(

--- a/var/spack/repos/builtin/packages/orca/package.py
+++ b/var/spack/repos/builtin/packages/orca/package.py
@@ -26,7 +26,7 @@ class Orca(Package):
     version(
         "avx2-6.0.1", sha256="f31f98256a0c6727b6ddfe50aa3ac64c45549981138d670a57e90114b4b9c9d2"
     )
-    version("6.0.1", sha256="5aadad86f323dd2fa9dc00c94ff3aa7fe6e006d740aad8a410c5090ce26ea98c")
+    version("6.0.1", sha256="5e9b49588375e0ce5bc32767127cc725f5425917804042cdecdfd5c6b965ef61")
     version(
         "avx2-6.0.0", sha256="02c21294efe7b1b721e26cb90f98ee15ad682d02807201b7d217dfe67905a2fd"
     )


### PR DESCRIPTION
Add the latest released version `6.0.1` and `avx2-6.0.1`.

I didn't look too far into it but the MPI dictionary is getting too many entries mapped to the same version, maybe something more appropriate could be done.

Also for the `avx2` versions the generated link differs from the default from the orca forum after the changes from #45824 i.e.
- `orca_6_0_1_linux_x86-64_avx2_shared_openmpi416.tar.xz` < generated link
- `orca_6_0_1_linux_x86-64_shared_openmpi416_avx2.tar.xz` < original file name

It's not a big deal to change the file name, but I'd rather it worked out of the box, maybe I should open a discussion about this.