### PR TITLE
Add `+freethreading` variant to python (disables the GIL)

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -648,9 +648,6 @@ class Python(Package):
         else:
             config_args.append("--without-system-expat")
 
-        if "+gil" not in spec:
-            config_args.append("--disable-gil")
-
         if self.version < Version("3.12.0"):
             if "+ctypes" in spec:
                 config_args.append("--with-system-ffi")
@@ -672,6 +669,9 @@ class Python(Package):
         # https://docs.python.org/3.8/library/sqlite3.html#f1
         if spec.satisfies("+sqlite3 ^sqlite+dynamic_extensions"):
             config_args.append("--enable-loadable-sqlite-extensions")
+
+        if "+gil" not in spec:
+            config_args.append("--disable-gil")
 
         if spec.satisfies("%oneapi"):
             cflags.append("-fp-model=strict")

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -439,6 +439,12 @@ class Python(Package):
                 variants += "+crypt"
             except ProcessError:
                 variants += "~crypt"
+        try:
+            python("-c", "import sys; assert sys._is_gil_enabled()")
+        except ProcessError:
+            variants += "~freethreading"
+        else:
+            variants += "+freethreading"
 
         return variants
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -251,9 +251,9 @@ class Python(Package):
     # free-threaded (no-GIL) builds are experimental as of Python 3.13
     # https://docs.python.org/3/howto/free-threading-python.html
     variant(
-        "gil",
-        default=True,
-        description="Build with the Global Interpreter Lock enabled",
+        "freethreading",
+        default=False,
+        description="Build with the Global Interpreter Lock disabled",
         when="@3.13:",
     )
 
@@ -670,7 +670,7 @@ class Python(Package):
         if spec.satisfies("+sqlite3 ^sqlite+dynamic_extensions"):
             config_args.append("--enable-loadable-sqlite-extensions")
 
-        if "+gil" not in spec:
+        if "+freethreading" in spec:
             config_args.append("--disable-gil")
 
         if spec.satisfies("%oneapi"):

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -248,6 +248,15 @@ class Python(Package):
         description="Symlink 'python3' executable to 'python' (not PEP 394 compliant)",
     )
 
+    # free-threaded (no-GIL) builds are experimental as of Python 3.13
+    # https://docs.python.org/3/howto/free-threading-python.html
+    variant(
+        "gil",
+        default=True,
+        description="Build with the Global Interpreter Lock enabled",
+        when="@3.13:",
+    )
+
     # Optional Python modules
     variant("readline", default=sys.platform != "win32", description="Build readline module")
     variant("ssl", default=True, description="Build ssl module")
@@ -638,6 +647,9 @@ class Python(Package):
             config_args.append("--with-system-expat")
         else:
             config_args.append("--without-system-expat")
+
+        if "+gil" not in spec:
+            config_args.append("--disable-gil")
 
         if self.version < Version("3.12.0"):
             if "+ctypes" in spec:


### PR DESCRIPTION
Python 3.13 adds a new configure argument `--disable-gil`, which builds Python [without the Global Interpreter Lock](https://docs.python.org/3/howto/free-threading-python.html). This option is currently experimental, and comes with performance tradeoffs for single-threaded tasks, but can cause big speedups for multithreaded workloads.

This adds a new variant `+freethreading`, which defaults to False but adds the `--disable-gil` argument when set to True.
The other way this could be done would be with a `+gil` variant with the default set to True (and install `python~gil` instead), but the official [recommendation](https://github.com/python/steering-council/issues/221#issuecomment-1841593283) from the Python steering council to packagers is that the term for this type of Python should be "freethreading" when exposed to users, and that references to internal implementation details like the GIL should stay internal.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
