### PR TITLE
llnl.util.filesystem: multiple entrypoints and max_depth

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1673,16 +1673,20 @@ def find_first(root: str, files: Union[Iterable[str], str], bfs_depth: int = 2) 
     return FindFirstFile(root, *files, bfs_depth=bfs_depth).find()
 
 
-def find(root, files, recursive=True):
+def find(root, files, recursive=True, max_depth: Optional[int] = None):
     """Search for ``files`` starting from the ``root`` directory.
 
     Like GNU/BSD find but written entirely in Python.
+
+    Specifically this behaves like `find -type f`: it only returns
+    results that are files. When searching recursively, this behaves
+    as `find` with the `-L` option (follows symlinks).
 
     Examples:
 
     .. code-block:: console
 
-       $ find /usr -name python
+       $ find -L /usr -name python
 
     is equivalent to:
 
@@ -1712,6 +1716,8 @@ def find(root, files, recursive=True):
         files (str or collections.abc.Sequence): Library name(s) to search for
         recursive (bool): if False search only root folder,
             if True descends top-down from the root. Defaults to True.
+        max_depth (int): if set, don't search below this depth. Cannot be set
+            if recursive is False
 
     Returns:
         list: The files that have been found
@@ -1719,59 +1725,135 @@ def find(root, files, recursive=True):
     if isinstance(files, str):
         files = [files]
 
-    if recursive:
-        tty.debug(f"Find (recursive): {root} {str(files)}")
-        result = _find_recursive(root, files)
-    else:
-        tty.debug(f"Find (not recursive): {root} {str(files)}")
-        result = _find_non_recursive(root, files)
+    # If recursive is false, max_depth can only be None or 0
+    if max_depth and not recursive:
+        raise ValueError(f"max_depth ({max_depth}) cannot be set if recursive is False")
+
+    if not recursive:
+        max_depth = 0
+    elif max_depth is None:
+        max_depth = sys.maxsize
+
+    tty.debug(f"Find (max depth = {max_depth}): {root} {str(files)}")
+    result = find_max_depth(root, files, max_depth)
 
     tty.debug(f"Find complete: {root} {str(files)}")
     return result
 
 
-@system_path_filter
-def _find_recursive(root, search_files):
-    # The variable here is **on purpose** a defaultdict. The idea is that
-    # we want to poke the filesystem as little as possible, but still maintain
-    # stability in the order of the answer. Thus we are recording each library
-    # found in a key, and reconstructing the stable order later.
+@system_path_filter(arg_slice=slice(1))
+def find_max_depth(root, globs, max_depth: Optional[int] = None):
+    """Given a set of non-recursive glob file patterns, finds all
+    files matching those patterns up to a maximum specified depth.
+
+    If a directory has a name which matches an input pattern, it will
+    not be included in the results.
+
+    If ``max_depth`` is specified, does not search below that depth.
+
+    If ``globs`` is a list, files matching earlier entries are placed
+    in the return value before files matching later entries.
+    """
+    # If root doesn't exist, then we say we found nothing. If it
+    # exists but is not a dir, we assume the user would want to
+    # know; likewise if it exists but we do not have permission to
+    # access it.
+    try:
+        stat_root = os.stat(root)
+    except OSError as e:
+        if e.errno == errno.ENOENT:
+            return []
+        else:
+            raise
+    if not stat.S_ISDIR(stat_root.st_mode):
+        raise ValueError(f"{root} is not a directory")
+
+    if max_depth is None:
+        max_depth = sys.maxsize
+
+    if isinstance(globs, str):
+        globs = [globs]
+    # Apply normcase to regular expressions and to the filenames:
+    # this respects case-sensitivity semantics of different OSes
+    # (e.g. file search is typically case-insensitive on Windows)
+    regexes = [re.compile(fnmatch.translate(os.path.normcase(x))) for x in globs]
+
+    # Note later calls to os.scandir etc. return abspaths if the
+    # input is absolute, see https://docs.python.org/3/library/os.html#os.DirEntry.path
+    root = os.path.abspath(root)
+
     found_files = collections.defaultdict(list)
 
-    # Make the path absolute to have os.walk also return an absolute path
-    root = os.path.abspath(root)
-    for path, _, list_files in os.walk(root):
-        for search_file in search_files:
-            matches = glob.glob(os.path.join(path, search_file))
-            matches = [os.path.join(path, x) for x in matches]
-            found_files[search_file].extend(matches)
+    def _dir_id(stat_info):
+        # Note: on windows, st_ino is the file index and st_dev
+        # is the volume serial number. See
+        # https://github.com/python/cpython/blob/3.9/Python/fileutils.c
+        return (stat_info.st_ino, stat_info.st_dev)
 
-    answer = []
-    for search_file in search_files:
-        answer.extend(found_files[search_file])
+    def _log_file_access_issue(e):
+        errno_name = errno.errorcode.get(e.errno, "UNKNOWN")
+        tty.debug(f"find must skip {dir_entry.path}: {errno_name} {str(e)}")
 
-    return answer
+    visited_dirs = set([_dir_id(stat_root)])
 
+    # Each queue item stores the depth and path
+    # This achieves a consistent traversal order by iterating through
+    # each directory in alphabetical order.
+    # This also traverses in BFS order to ensure finding the shortest
+    # path to any file (or one of the shortest paths, if there are
+    # several - the one returned will be consistent given the prior
+    # point).
+    dir_queue = collections.deque([(0, root)])
+    while dir_queue:
+        depth, next_dir = dir_queue.pop()
+        try:
+            dir_iter = os.scandir(next_dir)
+        except OSError:
+            # Most commonly, this would be a permissions issue, for
+            # example if we are scanning an external directory like /usr
+            continue
 
-@system_path_filter
-def _find_non_recursive(root, search_files):
-    # The variable here is **on purpose** a defaultdict as os.list_dir
-    # can return files in any order (does not preserve stability)
-    found_files = collections.defaultdict(list)
+        with dir_iter:
+            ordered_entries = sorted(dir_iter, key=lambda x: x.name)
+            for dir_entry in ordered_entries:
+                try:
+                    it_is_a_dir = dir_entry.is_dir(follow_symlinks=True)
+                except OSError as e:
+                    # Possible permission issue, or a symlink that cannot
+                    # be resolved (ELOOP).
+                    _log_file_access_issue(e)
+                    continue
 
-    # Make the path absolute to have absolute path returned
-    root = os.path.abspath(root)
+                if it_is_a_dir and (depth < max_depth):
+                    try:
+                        # The stat should be performed in a try/except block.
+                        # We repeat that here vs. moving to the above block
+                        # because we only want to call `stat` if we haven't
+                        # exceeded our max_depth
+                        if sys.platform == "win32":
+                            # Note: st_ino/st_dev on DirEntry.stat are not set on
+                            # Windows, so we have to call os.stat
+                            stat_info = os.stat(dir_entry.path, follow_symlinks=True)
+                        else:
+                            stat_info = dir_entry.stat(follow_symlinks=True)
+                    except OSError as e:
+                        _log_file_access_issue(e)
+                        continue
 
-    for search_file in search_files:
-        matches = glob.glob(os.path.join(root, search_file))
-        matches = [os.path.join(root, x) for x in matches]
-        found_files[search_file].extend(matches)
+                    dir_id = _dir_id(stat_info)
+                    if dir_id not in visited_dirs:
+                        dir_queue.appendleft((depth + 1, dir_entry.path))
+                        visited_dirs.add(dir_id)
+                else:
+                    fname = os.path.basename(dir_entry.path)
+                    for pattern in regexes:
+                        if pattern.match(os.path.normcase(fname)):
+                            found_files[pattern].append(os.path.join(next_dir, fname))
 
-    answer = []
-    for search_file in search_files:
-        answer.extend(found_files[search_file])
+        # TODO: for fully-recursive searches, we can print a warning after
+        # after having searched everything up to some fixed depth
 
-    return answer
+    return list(itertools.chain(*[found_files[x] for x in regexes]))
 
 
 # Utilities for libraries and headers
@@ -2210,7 +2292,9 @@ def find_system_libraries(libraries, shared=True):
     return libraries_found
 
 
-def find_libraries(libraries, root, shared=True, recursive=False, runtime=True):
+def find_libraries(
+    libraries, root, shared=True, recursive=False, runtime=True, max_depth: Optional[int] = None
+):
     """Returns an iterable of full paths to libraries found in a root dir.
 
     Accepts any glob characters accepted by fnmatch:
@@ -2231,6 +2315,8 @@ def find_libraries(libraries, root, shared=True, recursive=False, runtime=True):
             otherwise for static. Defaults to True.
         recursive (bool): if False search only root folder,
             if True descends top-down from the root. Defaults to False.
+        max_depth (int): if set, don't search below this depth. Cannot be set
+            if recursive is False
         runtime (bool): Windows only option, no-op elsewhere. If true,
             search for runtime shared libs (.DLL), otherwise, search
             for .Lib files. If shared is false, this has no meaning.
@@ -2239,6 +2325,7 @@ def find_libraries(libraries, root, shared=True, recursive=False, runtime=True):
     Returns:
         LibraryList: The libraries that have been found
     """
+
     if isinstance(libraries, str):
         libraries = [libraries]
     elif not isinstance(libraries, collections.abc.Sequence):
@@ -2271,8 +2358,10 @@ def find_libraries(libraries, root, shared=True, recursive=False, runtime=True):
     libraries = ["{0}.{1}".format(lib, suffix) for lib in libraries for suffix in suffixes]
 
     if not recursive:
+        if max_depth:
+            raise ValueError(f"max_depth ({max_depth}) cannot be set if recursive is False")
         # If not recursive, look for the libraries directly in root
-        return LibraryList(find(root, libraries, False))
+        return LibraryList(find(root, libraries, recursive=False))
 
     # To speedup the search for external packages configured e.g. in /usr,
     # perform first non-recursive search in root/lib then in root/lib64 and
@@ -2290,7 +2379,7 @@ def find_libraries(libraries, root, shared=True, recursive=False, runtime=True):
         if found_libs:
             break
     else:
-        found_libs = find(root, libraries, True)
+        found_libs = find(root, libraries, recursive=True, max_depth=max_depth)
 
     return LibraryList(found_libs)
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -20,11 +20,11 @@ import sys
 import tempfile
 from contextlib import contextmanager
 from itertools import accumulate
-from typing import Callable, Iterable, List, Match, Optional, Tuple, Union
+from typing import Callable, Deque, Dict, Iterable, List, Match, Optional, Set, Tuple, Union
 
 import llnl.util.symlink
 from llnl.util import tty
-from llnl.util.lang import dedupe, memoized
+from llnl.util.lang import dedupe, fnmatch_translate_multiple, memoized
 from llnl.util.symlink import islink, readlink, resolve_link_target_relative_to_the_link, symlink
 
 from ..path import path_to_os_path, system_path_filter
@@ -1673,32 +1673,40 @@ def find_first(root: str, files: Union[Iterable[str], str], bfs_depth: int = 2) 
     return FindFirstFile(root, *files, bfs_depth=bfs_depth).find()
 
 
-def find(root, files, recursive=True, max_depth: Optional[int] = None):
-    """Search for ``files`` starting from the ``root`` directory.
-
-    Like GNU/BSD find but written entirely in Python.
-
-    Specifically this behaves like `find -type f`: it only returns
-    results that are files. When searching recursively, this behaves
-    as `find` with the `-L` option (follows symlinks).
+def find(
+    root: Union[str, List[str]],
+    files: Union[str, List[str]],
+    recursive: bool = True,
+    max_depth: Optional[int] = None,
+) -> List[str]:
+    """Finds all non-directory files matching the filename patterns from ``files`` starting from
+    ``root``. This function returns a deterministic result for the same input and directory
+    structure when run multiple times. Symlinked directories are followed, and unique directories
+    are searched only once. Each matching file is returned only once at lowest depth in case
+    multiple paths exist due to symlinked directories. The function has similarities to the Unix
+    ``find`` utility.
 
     Examples:
 
     .. code-block:: console
 
-       $ find -L /usr -name python
+       $ find -L /usr -name python3 -type f
 
-    is equivalent to:
+    is roughly equivalent to
 
-    >>> find('/usr', 'python')
+    >>> find("/usr", "python3")
+
+    with the notable difference that this function only lists a single path to each file in case of
+    symlinked directories.
 
     .. code-block:: console
 
-       $ find /usr/local/bin -maxdepth 1 -name python
+       $ find -L /usr/local/bin /usr/local/sbin -maxdepth 1 '(' -name python3 -o -name getcap \\
+            ')' -type f
 
-    is equivalent to:
+    is roughly equivalent to:
 
-    >>> find('/usr/local/bin', 'python', recursive=False)
+    >>> find(["/usr/local/bin", "/usr/local/sbin"], ["python3", "getcap"], recursive=False)
 
     Accepts any glob characters accepted by fnmatch:
 
@@ -1712,17 +1720,17 @@ def find(root, files, recursive=True, max_depth: Optional[int] = None):
     ==========  ====================================
 
     Parameters:
-        root (str): The root directory to start searching from
-        files (str or collections.abc.Sequence): Library name(s) to search for
-        recursive (bool): if False search only root folder,
-            if True descends top-down from the root. Defaults to True.
-        max_depth (int): if set, don't search below this depth. Cannot be set
-            if recursive is False
+        root: One or more root directories to start searching from
+        files: One or more filename patterns to search for
+        recursive: if False search only root, if True descends from roots. Defaults to True.
+        max_depth: if set, don't search below this depth. Cannot be set if recursive is False
 
-    Returns:
-        list: The files that have been found
+    Returns a list of absolute, matching file paths.
     """
-    if isinstance(files, str):
+    if not isinstance(root, list):
+        root = [root]
+
+    if not isinstance(files, list):
         files = [files]
 
     # If recursive is false, max_depth can only be None or 0
@@ -1734,10 +1742,9 @@ def find(root, files, recursive=True, max_depth: Optional[int] = None):
     elif max_depth is None:
         max_depth = sys.maxsize
 
-    tty.debug(f"Find (max depth = {max_depth}): {root} {str(files)}")
-    result = find_max_depth(root, files, max_depth)
-
-    tty.debug(f"Find complete: {root} {str(files)}")
+    tty.debug(f"Find (max depth = {max_depth}): {root} {files}")
+    result = _find_max_depth(root, files, max_depth)
+    tty.debug(f"Find complete: {root} {files}")
     return result
 
 
@@ -1746,56 +1753,36 @@ def _log_file_access_issue(e: OSError, path: str) -> None:
     tty.debug(f"find must skip {path}: {errno_name} {e}")
 
 
-@system_path_filter(arg_slice=slice(1))
-def find_max_depth(root, globs, max_depth: Optional[int] = None):
-    """Given a set of non-recursive glob file patterns, finds all
-    files matching those patterns up to a maximum specified depth.
+def _dir_id(s: os.stat_result) -> Tuple[int, int]:
+    # Note: on windows, st_ino is the file index and st_dev is the volume serial number. See
+    # https://github.com/python/cpython/blob/3.9/Python/fileutils.c
+    return (s.st_ino, s.st_dev)
 
-    If a directory has a name which matches an input pattern, it will
-    not be included in the results.
 
-    If ``max_depth`` is specified, does not search below that depth.
+def _find_max_depth(roots: List[str], globs: List[str], max_depth: int = sys.maxsize) -> List[str]:
+    """See ``find`` for the public API."""
+    # Apply normcase to file patterns and filenames to respect case insensitive filesystems
+    regex, groups = fnmatch_translate_multiple([os.path.normcase(x) for x in globs])
+    # Ordered dictionary that keeps track of the files found for each pattern
+    capture_group_to_paths: Dict[str, List[str]] = {group: [] for group in groups}
+    # Ensure returned paths are always absolute
+    roots = [os.path.abspath(r) for r in roots]
+    # Breadth-first search queue. Each element is a tuple of (depth, directory)
+    dir_queue: Deque[Tuple[int, str]] = collections.deque()
+    # Set of visited directories. Each element is a tuple of (inode, device)
+    visited_dirs: Set[Tuple[int, int]] = set()
 
-    If ``globs`` is a list, files matching earlier entries are placed
-    in the return value before files matching later entries.
-    """
-    try:
-        stat_root = os.stat(root)
-    except OSError:
-        return []
+    for root in roots:
+        try:
+            stat_root = os.stat(root)
+        except OSError as e:
+            _log_file_access_issue(e, root)
+            continue
+        dir_id = _dir_id(stat_root)
+        if dir_id not in visited_dirs:
+            dir_queue.appendleft((0, root))
+            visited_dirs.add(dir_id)
 
-    if max_depth is None:
-        max_depth = sys.maxsize
-
-    if isinstance(globs, str):
-        globs = [globs]
-    # Apply normcase to regular expressions and to the filenames:
-    # this respects case-sensitivity semantics of different OSes
-    # (e.g. file search is typically case-insensitive on Windows)
-    regexes = [re.compile(fnmatch.translate(os.path.normcase(x))) for x in globs]
-
-    # Note later calls to os.scandir etc. return abspaths if the
-    # input is absolute, see https://docs.python.org/3/library/os.html#os.DirEntry.path
-    root = os.path.abspath(root)
-
-    found_files = collections.defaultdict(list)
-
-    def _dir_id(stat_info):
-        # Note: on windows, st_ino is the file index and st_dev
-        # is the volume serial number. See
-        # https://github.com/python/cpython/blob/3.9/Python/fileutils.c
-        return (stat_info.st_ino, stat_info.st_dev)
-
-    visited_dirs = set([_dir_id(stat_root)])
-
-    # Each queue item stores the depth and path
-    # This achieves a consistent traversal order by iterating through
-    # each directory in alphabetical order.
-    # This also traverses in BFS order to ensure finding the shortest
-    # path to any file (or one of the shortest paths, if there are
-    # several - the one returned will be consistent given the prior
-    # point).
-    dir_queue = collections.deque([(0, root)])
     while dir_queue:
         depth, next_dir = dir_queue.pop()
         try:
@@ -1810,20 +1797,18 @@ def find_max_depth(root, globs, max_depth: Optional[int] = None):
                 try:
                     it_is_a_dir = dir_entry.is_dir(follow_symlinks=True)
                 except OSError as e:
-                    # Possible permission issue, or a symlink that cannot
-                    # be resolved (ELOOP).
+                    # Possible permission issue, or a symlink that cannot be resolved (ELOOP).
                     _log_file_access_issue(e, dir_entry.path)
                     continue
 
-                if it_is_a_dir and (depth < max_depth):
+                if it_is_a_dir and depth < max_depth:
                     try:
-                        # The stat should be performed in a try/except block.
-                        # We repeat that here vs. moving to the above block
-                        # because we only want to call `stat` if we haven't
-                        # exceeded our max_depth
+                        # The stat should be performed in a try/except block. We repeat that here
+                        # vs. moving to the above block because we only want to call `stat` if we
+                        # haven't exceeded our max_depth
                         if sys.platform == "win32":
-                            # Note: st_ino/st_dev on DirEntry.stat are not set on
-                            # Windows, so we have to call os.stat
+                            # Note: st_ino/st_dev on DirEntry.stat are not set on Windows, so we
+                            # have to call os.stat
                             stat_info = os.stat(dir_entry.path, follow_symlinks=True)
                         else:
                             stat_info = dir_entry.stat(follow_symlinks=True)
@@ -1836,15 +1821,15 @@ def find_max_depth(root, globs, max_depth: Optional[int] = None):
                         dir_queue.appendleft((depth + 1, dir_entry.path))
                         visited_dirs.add(dir_id)
                 else:
-                    fname = os.path.basename(dir_entry.path)
-                    for pattern in regexes:
-                        if pattern.match(os.path.normcase(fname)):
-                            found_files[pattern].append(os.path.join(next_dir, fname))
+                    m = regex.match(os.path.normcase(os.path.basename(dir_entry.path)))
+                    if not m:
+                        continue
+                    for group in capture_group_to_paths:
+                        if m.group(group):
+                            capture_group_to_paths[group].append(dir_entry.path)
+                            break
 
-        # TODO: for fully-recursive searches, we can print a warning after
-        # after having searched everything up to some fixed depth
-
-    return list(itertools.chain(*[found_files[x] for x in regexes]))
+    return [path for paths in capture_group_to_paths.values() for path in paths]
 
 
 # Utilities for libraries and headers

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1821,7 +1821,9 @@ def _find_max_depth(
                     _log_file_access_issue(e, dir_entry.path)
                     continue
 
-                if it_is_a_dir and depth < max_depth:
+                if it_is_a_dir:
+                    if depth >= max_depth:
+                        continue
                     try:
                         # The stat should be performed in a try/except block. We repeat that here
                         # vs. moving to the above block because we only want to call `stat` if we

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1748,12 +1748,11 @@ def find(
     if max_depth and not recursive:
         raise ValueError(f"max_depth ({max_depth}) cannot be set if recursive is False")
 
+    tty.debug(f"Find (max depth = {max_depth}): {root} {files}")
     if not recursive:
         max_depth = 0
     elif max_depth is None:
         max_depth = sys.maxsize
-
-    tty.debug(f"Find (max depth = {max_depth}): {root} {files}")
     result = _find_max_depth(root, files, max_depth)
     tty.debug(f"Find complete: {root} {files}")
     return result

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1831,7 +1831,7 @@ def _find_max_depth(
         for pattern_name, pattern in complex_patterns.items():
             matched_paths[pattern_name].extend(
                 path
-                for path in glob.glob(os.path.join(curr_dir, pattern), include_hidden=True)
+                for path in glob.glob(os.path.join(curr_dir, pattern))
                 if not os.path.isdir(path)
             )
 

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -15,7 +15,7 @@ import traceback
 import typing
 import warnings
 from datetime import datetime, timedelta
-from typing import Callable, Iterable, List, Tuple, TypeVar
+from typing import Callable, Dict, Iterable, List, Tuple, TypeVar
 
 # Ignore emacs backups when listing modules
 ignore_modules = r"^\.#|~$"
@@ -867,24 +867,11 @@ else:
     PatternStr = typing.Pattern[str]
 
 
-def fnmatch_translate_multiple(patterns: List[str]) -> Tuple[PatternStr, List[str]]:
-    """Same as fnmatch.translate, but creates a single regex of the form
-    ``(?P<pattern0>...)|(?P<pattern1>...)|...`` for each pattern in the iterable, where
-    ``patternN`` is a named capture group that matches the corresponding pattern translated by
-    ``fnmatch.translate``. This can be used to match multiple patterns in a single pass. No case
-    normalization is performed on the patterns.
-
-    Args:
-        patterns: list of fnmatch patterns
-
-    Returns:
-        Tuple of the combined regex and the list of named capture groups corresponding to each
-        pattern in the input list.
-    """
-    groups = [f"pattern{i}" for i in range(len(patterns))]
-    regexes = (fnmatch.translate(p) for p in patterns)
-    combined = re.compile("|".join(f"(?P<{g}>{r})" for g, r in zip(groups, regexes)))
-    return combined, groups
+def fnmatch_translate_multiple(named_patterns: Dict[str, str]) -> str:
+    """Similar to ``fnmatch.translate``, but takes an ordered dictionary where keys are pattern
+    names, and values are filename patterns. The output is a regex that matches any of the
+    patterns in order, and named capture groups are used to identify which pattern matched."""
+    return "|".join(f"(?P<{n}>{fnmatch.translate(p)})" for n, p in named_patterns.items())
 
 
 @contextlib.contextmanager

--- a/lib/spack/spack/test/llnl/util/file_list.py
+++ b/lib/spack/spack/test/llnl/util/file_list.py
@@ -9,7 +9,7 @@ import sys
 
 import pytest
 
-from llnl.util.filesystem import HeaderList, LibraryList, find, find_headers, find_libraries
+from llnl.util.filesystem import HeaderList, LibraryList, find_headers, find_libraries
 
 import spack.paths
 
@@ -324,33 +324,3 @@ def test_searching_order(search_fn, search_list, root, kwargs):
 
     # List should be empty here
     assert len(rlist) == 0
-
-
-@pytest.mark.parametrize(
-    "root,search_list,kwargs,expected",
-    [
-        (
-            search_dir,
-            "*/*bar.tx?",
-            {"recursive": False},
-            [
-                os.path.join(search_dir, os.path.join("a", "foobar.txt")),
-                os.path.join(search_dir, os.path.join("b", "bar.txp")),
-                os.path.join(search_dir, os.path.join("c", "bar.txt")),
-            ],
-        ),
-        (
-            search_dir,
-            "*/*bar.tx?",
-            {"recursive": True},
-            [
-                os.path.join(search_dir, os.path.join("a", "foobar.txt")),
-                os.path.join(search_dir, os.path.join("b", "bar.txp")),
-                os.path.join(search_dir, os.path.join("c", "bar.txt")),
-            ],
-        ),
-    ],
-)
-def test_find_with_globbing(root, search_list, kwargs, expected):
-    matches = find(root, search_list, **kwargs)
-    assert sorted(matches) == sorted(expected)

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -1072,16 +1072,16 @@ def test_find_max_depth(dir_structure_with_things_to_find):
     # Make sure the paths we use to verify are absolute
     assert os.path.isabs(locations["file_one"])
 
-    assert set(fs.find_max_depth(root, "file_*", 0)) == {locations["file_four"]}
-    assert set(fs.find_max_depth(root, "file_*", 1)) == {
+    assert set(fs.find(root, "file_*", max_depth=0)) == {locations["file_four"]}
+    assert set(fs.find(root, "file_*", max_depth=1)) == {
         locations["file_one"],
         locations["file_three"],
         locations["file_four"],
     }
-    assert set(fs.find_max_depth(root, "file_two", 2)) == {locations["file_two"]}
-    assert not set(fs.find_max_depth(root, "file_two", 1))
-    assert set(fs.find_max_depth(root, "file_two")) == {locations["file_two"]}
-    assert set(fs.find_max_depth(root, "file_*")) == set(locations.values())
+    assert set(fs.find(root, "file_two", max_depth=2)) == {locations["file_two"]}
+    assert not set(fs.find(root, "file_two", max_depth=1))
+    assert set(fs.find(root, "file_two")) == {locations["file_two"]}
+    assert set(fs.find(root, "file_*")) == set(locations.values())
 
 
 def test_find_max_depth_relative(dir_structure_with_things_to_find):
@@ -1090,8 +1090,8 @@ def test_find_max_depth_relative(dir_structure_with_things_to_find):
     """
     root, locations = dir_structure_with_things_to_find
     with fs.working_dir(root):
-        assert set(fs.find_max_depth(".", "file_*", 0)) == {locations["file_four"]}
-        assert set(fs.find_max_depth(".", "file_two", 2)) == {locations["file_two"]}
+        assert set(fs.find(".", "file_*", max_depth=0)) == {locations["file_four"]}
+        assert set(fs.find(".", "file_two", max_depth=2)) == {locations["file_two"]}
 
 
 @pytest.mark.parametrize("recursive,max_depth", [(False, -1), (False, 1)])
@@ -1105,7 +1105,8 @@ def test_max_depth_and_recursive_errors(tmpdir, recursive, max_depth):
         fs.find_libraries(["some_lib"], root, recursive=recursive, max_depth=max_depth)
 
 
-def dir_structure_with_things_to_find_links(tmpdir, use_junctions=False):
+@pytest.fixture(params=[True, False])
+def complex_dir_structure(request, tmpdir):
     """
     "lx-dy" means "level x, directory y"
     "lx-fy" means "level x, file y"
@@ -1128,8 +1129,11 @@ def dir_structure_with_things_to_find_links(tmpdir, use_junctions=False):
         l1-s3 -> l3-d4 # a link that "skips" a directory level
         l1-s4 -> l2-s3 # a link to a link to a dir
     """
-    if sys.platform == "win32" and (not use_junctions) and (not _windows_can_symlink()):
+    use_junctions = request.param
+    if sys.platform == "win32" and not use_junctions and not _windows_can_symlink():
         pytest.skip("This Windows instance is not configured with symlink support")
+    elif sys.platform != "win32" and use_junctions:
+        pytest.skip("Junctions are a Windows-only feature")
 
     l1_d1 = tmpdir.join("l1-d1").ensure(dir=True)
     l2_d1 = l1_d1.join("l2-d1").ensure(dir=True)
@@ -1150,44 +1154,60 @@ def dir_structure_with_things_to_find_links(tmpdir, use_junctions=False):
     link_fn(l2_d2, l2_s3)
     link_fn(l2_s3, pathlib.Path(tmpdir) / "l1-s4")
 
-    locations = {}
-    locations["l4-f1"] = str(l3_d2.join("l4-f1").ensure())
-    locations["l4-f2-full"] = str(l3_d4.join("l4-f2").ensure())
-    locations["l4-f2-link"] = str(pathlib.Path(tmpdir) / "l1-s3" / "l4-f2")
-    locations["l2-f1"] = str(l1_d2.join("l2-f1").ensure())
-    locations["l2-f1-link"] = str(pathlib.Path(tmpdir) / "l1-d1" / "l2-d1" / "l3-s1" / "l2-f1")
-    locations["l3-f3-full"] = str(l2_d2.join("l3-f3").ensure())
-    locations["l3-f3-link-l1"] = str(pathlib.Path(tmpdir) / "l1-s4" / "l3-f3")
+    locations = {
+        "l4-f1": str(l3_d2.join("l4-f1").ensure()),
+        "l4-f2-full": str(l3_d4.join("l4-f2").ensure()),
+        "l4-f2-link": str(pathlib.Path(tmpdir) / "l1-s3" / "l4-f2"),
+        "l2-f1": str(l1_d2.join("l2-f1").ensure()),
+        "l2-f1-link": str(pathlib.Path(tmpdir) / "l1-d1" / "l2-d1" / "l3-s1" / "l2-f1"),
+        "l3-f3-full": str(l2_d2.join("l3-f3").ensure()),
+        "l3-f3-link-l1": str(pathlib.Path(tmpdir) / "l1-s4" / "l3-f3"),
+    }
 
     return str(tmpdir), locations
 
 
-def _check_find_links(root, locations):
+def test_find_max_depth_symlinks(complex_dir_structure):
+    root, locations = complex_dir_structure
     root = pathlib.Path(root)
-    assert set(fs.find_max_depth(root, "l4-f1")) == {locations["l4-f1"]}
-    assert set(fs.find_max_depth(root / "l1-s3", "l4-f2", 0)) == {locations["l4-f2-link"]}
-    assert set(fs.find_max_depth(root / "l1-d1", "l2-f1")) == {locations["l2-f1-link"]}
+    assert set(fs.find(root, "l4-f1")) == {locations["l4-f1"]}
+    assert set(fs.find(root / "l1-s3", "l4-f2", max_depth=0)) == {locations["l4-f2-link"]}
+    assert set(fs.find(root / "l1-d1", "l2-f1")) == {locations["l2-f1-link"]}
     # File is accessible via symlink and subdir, the link path will be
     # searched first, and the directory will not be searched again when
     # it is encountered the second time (via not-link) in the traversal
-    assert set(fs.find_max_depth(root, "l4-f2")) == {locations["l4-f2-link"]}
+    assert set(fs.find(root, "l4-f2")) == {locations["l4-f2-link"]}
     # File is accessible only via the dir, so the full file path should
     # be reported
-    assert set(fs.find_max_depth(root / "l1-d1", "l4-f2")) == {locations["l4-f2-full"]}
+    assert set(fs.find(root / "l1-d1", "l4-f2")) == {locations["l4-f2-full"]}
     # Check following links to links
-    assert set(fs.find_max_depth(root, "l3-f3")) == {locations["l3-f3-link-l1"]}
+    assert set(fs.find(root, "l3-f3")) == {locations["l3-f3-link-l1"]}
 
 
-@pytest.mark.parametrize(
-    "use_junctions",
-    [
-        False,
-        pytest.param(
-            True,
-            marks=pytest.mark.skipif(sys.platform != "win32", reason="Only Windows has junctions"),
-        ),
-    ],
-)
-def test_find_max_depth_symlinks(tmpdir, use_junctions):
-    root, locations = dir_structure_with_things_to_find_links(tmpdir, use_junctions=use_junctions)
-    _check_find_links(root, locations)
+def test_find_max_depth_multiple_and_repeated_entry_points(complex_dir_structure):
+    root, locations = complex_dir_structure
+
+    fst = str(pathlib.Path(root) / "l1-d1" / "l2-d1")
+    snd = str(pathlib.Path(root) / "l1-d2")
+    nonexistent = str(pathlib.Path(root) / "nonexistent")
+
+    assert set(fs.find([fst, snd, fst, snd, nonexistent], ["l*-f*"], max_depth=1)) == {
+        locations["l2-f1"],
+        locations["l4-f1"],
+        locations["l4-f2-full"],
+        locations["l3-f3-full"],
+    }
+
+
+def test_multiple_patterns(complex_dir_structure):
+    root, _ = complex_dir_structure
+    paths = fs.find(root, ["l2-f1", "l3-f3", "*"])
+    # There shouldn't be duplicate results with multiple, overlapping patterns
+    assert len(set(paths)) == len(paths)
+    # All files should be found
+    filenames = [os.path.basename(p) for p in paths]
+    assert set(filenames) == {"l2-f1", "l3-f3", "l4-f1", "l4-f2"}
+    # They are ordered by first matching pattern (this is a bit of an implementation detail,
+    # and we could decide to change the exact order in the future)
+    assert filenames[0] == "l2-f1"
+    assert filenames[1] == "l3-f3"

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -6,6 +6,7 @@
 """Tests for ``llnl/util/filesystem.py``"""
 import filecmp
 import os
+import pathlib
 import shutil
 import stat
 import sys
@@ -14,7 +15,8 @@ from contextlib import contextmanager
 import pytest
 
 import llnl.util.filesystem as fs
-from llnl.util.symlink import islink, readlink, symlink
+import llnl.util.symlink
+from llnl.util.symlink import _windows_can_symlink, islink, readlink, symlink
 
 import spack.paths
 
@@ -1035,3 +1037,157 @@ def test_windows_sfn(tmpdir):
     assert "d\\LONGER~1" in fs.windows_sfn(d)
     assert "d\\LONGER~2" in fs.windows_sfn(e)
     shutil.rmtree(tmpdir.join("d"))
+
+
+@pytest.fixture
+def dir_structure_with_things_to_find(tmpdir):
+    """
+    <root>/
+        dir_one/
+            file_one
+        dir_two/
+        dir_three/
+            dir_four/
+                file_two
+            file_three
+        file_four
+    """
+    dir_one = tmpdir.join("dir_one").ensure(dir=True)
+    tmpdir.join("dir_two").ensure(dir=True)
+    dir_three = tmpdir.join("dir_three").ensure(dir=True)
+    dir_four = dir_three.join("dir_four").ensure(dir=True)
+
+    locations = {}
+    locations["file_one"] = str(dir_one.join("file_one").ensure())
+    locations["file_two"] = str(dir_four.join("file_two").ensure())
+    locations["file_three"] = str(dir_three.join("file_three").ensure())
+    locations["file_four"] = str(tmpdir.join("file_four").ensure())
+
+    return str(tmpdir), locations
+
+
+def test_find_max_depth(dir_structure_with_things_to_find):
+    root, locations = dir_structure_with_things_to_find
+
+    # Make sure the paths we use to verify are absolute
+    assert os.path.isabs(locations["file_one"])
+
+    assert set(fs.find_max_depth(root, "file_*", 0)) == {locations["file_four"]}
+    assert set(fs.find_max_depth(root, "file_*", 1)) == {
+        locations["file_one"],
+        locations["file_three"],
+        locations["file_four"],
+    }
+    assert set(fs.find_max_depth(root, "file_two", 2)) == {locations["file_two"]}
+    assert not set(fs.find_max_depth(root, "file_two", 1))
+    assert set(fs.find_max_depth(root, "file_two")) == {locations["file_two"]}
+    assert set(fs.find_max_depth(root, "file_*")) == set(locations.values())
+
+
+def test_find_max_depth_relative(dir_structure_with_things_to_find):
+    """find_max_depth should return absolute paths even if
+    the provided path is relative.
+    """
+    root, locations = dir_structure_with_things_to_find
+    with fs.working_dir(root):
+        assert set(fs.find_max_depth(".", "file_*", 0)) == {locations["file_four"]}
+        assert set(fs.find_max_depth(".", "file_two", 2)) == {locations["file_two"]}
+
+
+@pytest.mark.parametrize("recursive,max_depth", [(False, -1), (False, 1)])
+def test_max_depth_and_recursive_errors(tmpdir, recursive, max_depth):
+    root = str(tmpdir)
+    error_str = "cannot be set if recursive is False"
+    with pytest.raises(ValueError, match=error_str):
+        fs.find(root, ["some_file"], recursive=recursive, max_depth=max_depth)
+
+    with pytest.raises(ValueError, match=error_str):
+        fs.find_libraries(["some_lib"], root, recursive=recursive, max_depth=max_depth)
+
+
+def dir_structure_with_things_to_find_links(tmpdir, use_junctions=False):
+    """
+    "lx-dy" means "level x, directory y"
+    "lx-fy" means "level x, file y"
+    "lx-sy" means "level x, symlink y"
+
+    <root>/
+        l1-d1/
+            l2-d1/
+                l3-s1 -> l1-d2 # points to directory above l2-d1
+                l3-d2/
+                    l4-f1
+                l3-s3 -> l1-d1 # cyclic link
+                l3-d4/
+                    l4-f2
+        l1-d2/
+            l2-f1
+            l2-d2/
+                l3-f3
+            l2-s3 -> l2-d2
+        l1-s3 -> l3-d4 # a link that "skips" a directory level
+        l1-s4 -> l2-s3 # a link to a link to a dir
+    """
+    if sys.platform == "win32" and (not use_junctions) and (not _windows_can_symlink()):
+        pytest.skip("This Windows instance is not configured with symlink support")
+
+    l1_d1 = tmpdir.join("l1-d1").ensure(dir=True)
+    l2_d1 = l1_d1.join("l2-d1").ensure(dir=True)
+    l3_d2 = l2_d1.join("l3-d2").ensure(dir=True)
+    l3_d4 = l2_d1.join("l3-d4").ensure(dir=True)
+    l1_d2 = tmpdir.join("l1-d2").ensure(dir=True)
+    l2_d2 = l1_d2.join("l1-d2").ensure(dir=True)
+
+    if use_junctions:
+        link_fn = llnl.util.symlink._windows_create_junction
+    else:
+        link_fn = os.symlink
+
+    link_fn(l1_d2, pathlib.Path(l2_d1) / "l3-s1")
+    link_fn(l1_d1, pathlib.Path(l2_d1) / "l3-s3")
+    link_fn(l3_d4, pathlib.Path(tmpdir) / "l1-s3")
+    l2_s3 = pathlib.Path(l1_d2) / "l2-s3"
+    link_fn(l2_d2, l2_s3)
+    link_fn(l2_s3, pathlib.Path(tmpdir) / "l1-s4")
+
+    locations = {}
+    locations["l4-f1"] = str(l3_d2.join("l4-f1").ensure())
+    locations["l4-f2-full"] = str(l3_d4.join("l4-f2").ensure())
+    locations["l4-f2-link"] = str(pathlib.Path(tmpdir) / "l1-s3" / "l4-f2")
+    locations["l2-f1"] = str(l1_d2.join("l2-f1").ensure())
+    locations["l2-f1-link"] = str(pathlib.Path(tmpdir) / "l1-d1" / "l2-d1" / "l3-s1" / "l2-f1")
+    locations["l3-f3-full"] = str(l2_d2.join("l3-f3").ensure())
+    locations["l3-f3-link-l1"] = str(pathlib.Path(tmpdir) / "l1-s4" / "l3-f3")
+
+    return str(tmpdir), locations
+
+
+def _check_find_links(root, locations):
+    root = pathlib.Path(root)
+    assert set(fs.find_max_depth(root, "l4-f1")) == {locations["l4-f1"]}
+    assert set(fs.find_max_depth(root / "l1-s3", "l4-f2", 0)) == {locations["l4-f2-link"]}
+    assert set(fs.find_max_depth(root / "l1-d1", "l2-f1")) == {locations["l2-f1-link"]}
+    # File is accessible via symlink and subdir, the link path will be
+    # searched first, and the directory will not be searched again when
+    # it is encountered the second time (via not-link) in the traversal
+    assert set(fs.find_max_depth(root, "l4-f2")) == {locations["l4-f2-link"]}
+    # File is accessible only via the dir, so the full file path should
+    # be reported
+    assert set(fs.find_max_depth(root / "l1-d1", "l4-f2")) == {locations["l4-f2-full"]}
+    # Check following links to links
+    assert set(fs.find_max_depth(root, "l3-f3")) == {locations["l3-f3-link-l1"]}
+
+
+@pytest.mark.parametrize(
+    "use_junctions",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(sys.platform != "win32", reason="Only Windows has junctions"),
+        ),
+    ],
+)
+def test_find_max_depth_symlinks(tmpdir, use_junctions):
+    root, locations = dir_structure_with_things_to_find_links(tmpdir, use_junctions=use_junctions)
+    _check_find_links(root, locations)

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -1216,7 +1216,7 @@ def test_find_max_depth_multiple_and_repeated_entry_points(complex_dir_structure
 
 def test_multiple_patterns(complex_dir_structure):
     root, _ = complex_dir_structure
-    paths = fs.find(root, ["l2-f1", "l3-f3", "*"])
+    paths = fs.find(root, ["l2-f1", "l*-d*/l3-f3", "*", "*/*"])
     # There shouldn't be duplicate results with multiple, overlapping patterns
     assert len(set(paths)) == len(paths)
     # All files should be found
@@ -1253,6 +1253,11 @@ def test_find_input_types(tmp_path: pathlib.Path):
 
 def test_find_only_finds_files(tmp_path: pathlib.Path):
     """ensure that find only returns files even at max_depth"""
-    (tmp_path / "file.txt").write_text("")
-    (tmp_path / "dir").mkdir()
-    assert fs.find(tmp_path, "*", max_depth=0) == [str(tmp_path / "file.txt")]
+    (tmp_path / "subdir").mkdir()
+    (tmp_path / "subdir" / "dir").mkdir()
+    (tmp_path / "subdir" / "file.txt").write_text("")
+    assert (
+        fs.find(tmp_path, "*", max_depth=1)
+        == fs.find(tmp_path, "*/*", max_depth=1)
+        == [str(tmp_path / "subdir" / "file.txt")]
+    )

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -1099,9 +1099,7 @@ def test_find_max_depth(dir_structure_with_things_to_find):
 
 
 def test_find_max_depth_relative(dir_structure_with_things_to_find):
-    """find_max_depth should return absolute paths even if
-    the provided path is relative.
-    """
+    """find_max_depth should return absolute paths even if the provided path is relative."""
     root, locations = dir_structure_with_things_to_find
     with fs.working_dir(root):
         assert set(fs.find(".", "file_*", max_depth=0)) == {locations["file_four"]}

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -1211,3 +1211,26 @@ def test_multiple_patterns(complex_dir_structure):
     # and we could decide to change the exact order in the future)
     assert filenames[0] == "l2-f1"
     assert filenames[1] == "l3-f3"
+
+
+def test_find_input_types(tmp_path: pathlib.Path):
+    """test that find only accepts sequences and instances of pathlib.Path and str for root, and
+    only sequences and instances of str for patterns. In principle mypy catches these issues, but
+    it is not enabled on all call-sites."""
+    (tmp_path / "file.txt").write_text("")
+    assert (
+        fs.find(tmp_path, "file.txt")
+        == fs.find(str(tmp_path), "file.txt")
+        == fs.find([tmp_path, str(tmp_path)], "file.txt")
+        == fs.find((tmp_path, str(tmp_path)), "file.txt")
+        == fs.find(tmp_path, "file.txt")
+        == fs.find(tmp_path, ["file.txt"])
+        == fs.find(tmp_path, ("file.txt",))
+        == [str(tmp_path / "file.txt")]
+    )
+
+    with pytest.raises(TypeError):
+        fs.find(tmp_path, pathlib.Path("file.txt"))  # type: ignore
+
+    with pytest.raises(TypeError):
+        fs.find(1, "file.txt")  # type: ignore

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -1234,3 +1234,10 @@ def test_find_input_types(tmp_path: pathlib.Path):
 
     with pytest.raises(TypeError):
         fs.find(1, "file.txt")  # type: ignore
+
+
+def test_find_only_finds_files(tmp_path: pathlib.Path):
+    """ensure that find only returns files even at max_depth"""
+    (tmp_path / "file.txt").write_text("")
+    (tmp_path / "dir").mkdir()
+    assert fs.find(tmp_path, "*", max_depth=0) == [str(tmp_path / "file.txt")]

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -1076,7 +1076,11 @@ def test_find_path_glob_matches(dir_structure_with_things_to_find):
         == fs.find(root, "dir_t*/*/*two")
         == [locations["file_two"]]
     )
-    # file name matches but not the path
+    # ensure that * does not match directory separators
+    assert fs.find(root, "dir*file_two") == []
+    # ensure that file name matches after / are matched from the start of the file name
+    assert fs.find(root, "*/ile_two") == []
+    # file name matches exist, but not with these paths
     assert fs.find(root, "dir_one/*/*two") == fs.find(root, "*/*/*/*/file_two") == []
 
 

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -1071,7 +1071,6 @@ def test_find_path_glob_matches(dir_structure_with_things_to_find):
     # both file name and path match
     assert (
         fs.find(root, "file_two")
-        == fs.find(root, "**/file_two")
         == fs.find(root, "*/*/file_two")
         == fs.find(root, "dir_t*/*/*two")
         == [locations["file_two"]]

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -1066,6 +1066,20 @@ def dir_structure_with_things_to_find(tmpdir):
     return str(tmpdir), locations
 
 
+def test_find_path_glob_matches(dir_structure_with_things_to_find):
+    root, locations = dir_structure_with_things_to_find
+    # both file name and path match
+    assert (
+        fs.find(root, "file_two")
+        == fs.find(root, "**/file_two")
+        == fs.find(root, "*/*/file_two")
+        == fs.find(root, "dir_t*/*/*two")
+        == [locations["file_two"]]
+    )
+    # file name matches but not the path
+    assert fs.find(root, "dir_one/*/*two") == fs.find(root, "*/*/*/*/file_two") == []
+
+
 def test_find_max_depth(dir_structure_with_things_to_find):
     root, locations = dir_structure_with_things_to_find
 

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -373,3 +373,18 @@ def test_deprecated_property():
     _SomeClass.deprecated.error_lvl = 2
     with pytest.raises(AttributeError):
         _ = s.deprecated
+
+
+def test_fnmatch_multiple():
+    regex, groups = llnl.util.lang.fnmatch_translate_multiple(["libf*o.so", "libb*r.so"])
+
+    a = regex.match("libfoo.so")
+    assert a and a.group(groups[0]) == "libfoo.so"
+
+    b = regex.match("libbar.so")
+    assert b and b.group(groups[1]) == "libbar.so"
+
+    assert not regex.match("libfoo.so.1")
+    assert not regex.match("libbar.so.1")
+    assert not regex.match("libfoo.solibbar.so")
+    assert not regex.match("libbaz.so")

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -376,13 +376,14 @@ def test_deprecated_property():
 
 
 def test_fnmatch_multiple():
-    regex, groups = llnl.util.lang.fnmatch_translate_multiple(["libf*o.so", "libb*r.so"])
+    named_patterns = {"a": "libf*o.so", "b": "libb*r.so"}
+    regex = re.compile(llnl.util.lang.fnmatch_translate_multiple(named_patterns))
 
     a = regex.match("libfoo.so")
-    assert a and a.group(groups[0]) == "libfoo.so"
+    assert a and a.group("a") == "libfoo.so"
 
     b = regex.match("libbar.so")
-    assert b and b.group(groups[1]) == "libbar.so"
+    assert b and b.group("b") == "libbar.so"
 
     assert not regex.match("libfoo.so.1")
     assert not regex.match("libbar.so.1")

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -501,18 +501,20 @@ def test_find_required_file(tmpdir):
 
     # First just find a single path
     results = spack.install_test.find_required_file(
-        tmpdir.join("c"), filename, expected=1, recursive=True
+        str(tmpdir.join("c")), filename, expected=1, recursive=True
     )
     assert isinstance(results, str)
 
     # Ensure none file if do not recursively search that directory
     with pytest.raises(spack.install_test.SkipTest, match="Expected 1"):
         spack.install_test.find_required_file(
-            tmpdir.join("c"), filename, expected=1, recursive=False
+            str(tmpdir.join("c")), filename, expected=1, recursive=False
         )
 
     # Now make sure we get all of the files
-    results = spack.install_test.find_required_file(tmpdir, filename, expected=3, recursive=True)
+    results = spack.install_test.find_required_file(
+        str(tmpdir), filename, expected=3, recursive=True
+    )
     assert isinstance(results, list) and len(results) == 3
 
 

--- a/var/spack/repos/builtin.mock/packages/attributes-foo/package.py
+++ b/var/spack/repos/builtin.mock/packages/attributes-foo/package.py
@@ -44,7 +44,7 @@ class AttributesFoo(BundlePackage):
     # Header provided by the bar virutal package
     @property
     def bar_headers(self):
-        return find_headers("bar/bar", root=self.home.include, recursive=False)
+        return find_headers("bar", root=self.home.include, recursive=True)
 
     # Libary provided by the bar virtual package
     @property
@@ -59,7 +59,7 @@ class AttributesFoo(BundlePackage):
     # Header provided by the baz virtual package
     @property
     def baz_headers(self):
-        return find_headers("baz/baz", root=self.baz_home.include, recursive=False)
+        return find_headers("baz", root=self.baz_home.include, recursive=True)
 
     # Library provided by the baz virtual package
     @property


### PR DESCRIPTION
New attempt to land #41945 and #47436, with a few fixes:

1. `find(..., "dir/*.txt")` is allowed again, for finding files inside certain dirs. These "complex" patterns are delegated to `glob`, like they are on `develop`.
2. `find` consistently only finds non-dirs, also at `max_depth`
4. the `root` and `files` arguments both support generic sequences, and `root` allows both str and path types

The following is a list of known changes to `find` compared to `develop`:

1. Matching directories are no longer returned
2. Symlinked directories are followed (needed to support max_depth)
3. ~~`develop` always excluded hidden files when globbing, here they may be included.~~

This should be squash-merged to avoid unnecessary buggy commits on develop, which is annoying when running bisect.

