### PR TITLE
Apply environment modifications when using the `--env` or `--env-dir` program options

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -37,7 +37,7 @@ from llnl.util.tty.log import log_output
 import spack
 import spack.cmd
 import spack.config
-import spack.environment as ev
+import spack.environment.shell as ev_shell
 import spack.error
 import spack.modules
 import spack.paths
@@ -917,7 +917,8 @@ def _main(argv=None):
         try:
             env = spack.cmd.find_environment(args)
             if env:
-                ev.activate(env, args.use_env_repo)
+                env_mods = ev_shell.activate(env, args.use_env_repo)
+                env_mods.apply_modifications()
         except spack.config.ConfigFormatError as e:
             # print the context but delay this exception so that commands like
             # `spack config edit` can still work with a bad environment.


### PR DESCRIPTION
According to `spack help --all`, the `-e|--env` and `-D|--env-dir` program options state:

```console
$ spack help --all
  ...
  -D DIR, --env-dir DIR   run with an environment directory (ignore managed environments)
  ...
  -e ENV, --env ENV       run with a specific environment (see spack env)
```

However, running with either of these options does not apply the Spack environment's modifications to the user environment.  The consequence is that some commands (e.g.):

```console
$ spack env activate <some env>
$ spack <command>
$ spack env deactivate
```

cannot be replaced with the simpler `spack -e <some env> <command>`.  This PR addresses this limitation.