### PR TITLE
librdkafka: added missing dependency on curl

### DIFF
--- a/var/spack/repos/builtin/packages/librdkafka/package.py
+++ b/var/spack/repos/builtin/packages/librdkafka/package.py
@@ -31,3 +31,4 @@ class Librdkafka(AutotoolsPackage):
 
     depends_on("zstd")
     depends_on("lz4")
+    depends_on("curl")

--- a/var/spack/repos/builtin/packages/librdkafka/package.py
+++ b/var/spack/repos/builtin/packages/librdkafka/package.py
@@ -32,3 +32,5 @@ class Librdkafka(AutotoolsPackage):
     depends_on("zstd")
     depends_on("lz4")
     depends_on("curl")
+    depends_on("openssl")
+    depends_on("zlib")


### PR DESCRIPTION
This PR adds a missing dependency on curl in librdkafka.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
