### PR TITLE
py-pymongo: add v4.10.1 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/py-hatch-requirements-txt/package.py
+++ b/var/spack/repos/builtin/packages/py-hatch-requirements-txt/package.py
@@ -14,6 +14,7 @@ class PyHatchRequirementsTxt(PythonPackage):
 
     license("MIT")
 
+    version("0.4.1", sha256="2c686e5758fd05bb55fa7d0c198fdd481f8d3aaa3c693260f5c0d74ce3547d20")
     version("0.4.0", sha256="800509946e85d9e56d73242fab223ec36db50372e870a04e2dd1fd9bad98455d")
 
     depends_on("python@3.6.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pymongo/package.py
+++ b/var/spack/repos/builtin/packages/py-pymongo/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+    # Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -11,22 +11,29 @@ class PyPymongo(PythonPackage):
     MongoDB database from Python. The bson package is an implementation
     of the BSON format for Python. The pymongo package is a native
     Python driver for MongoDB. The gridfs package is a gridfs
-    implementation on top of pymongo.
-
-    PyMongo supports MongoDB 2.6, 3.0, 3.2, 3.4, 3.6, 4.0 and 4.2."""
+    implementation on top of pymongo."""
 
     pypi = "pymongo/pymongo-3.9.0.tar.gz"
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked_by="wdconinc")
 
-    version("4.2.0", sha256="72f338f6aabd37d343bd9d1fdd3de921104d395766bcc5cdc4039e4c2dd97766")
-    version("3.12.1", sha256="704879b6a54c45ad76cea7c6789c1ae7185050acea7afd15b58318fa1932ed45")
-    version("3.9.0", sha256="4249c6ba45587b959292a727532826c5032d59171f923f7f823788f413c2a5a3")
-    version("3.6.0", sha256="c6de26d1e171cdc449745b82f1addbc873d105b8e7335097da991c0fc664a4a8")
-    version("3.3.0", sha256="3d45302fc2622fabf34356ba274c69df41285bac71bbd229f1587283b851b91e")
+    version("4.10.1", sha256="a9de02be53b6bb98efe0b9eda84ffa1ec027fcb23a2de62c4f941d9a2f2f3330")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2024-5629
+        version("4.2.0", sha256="72f338f6aabd37d343bd9d1fdd3de921104d395766bcc5cdc4039e4c2dd97766")
+        version("3.12.1", sha256="704879b6a54c45ad76cea7c6789c1ae7185050acea7afd15b58318fa1932ed45")
+        version("3.9.0", sha256="4249c6ba45587b959292a727532826c5032d59171f923f7f823788f413c2a5a3")
+        version("3.6.0", sha256="c6de26d1e171cdc449745b82f1addbc873d105b8e7335097da991c0fc664a4a8")
+        version("3.3.0", sha256="3d45302fc2622fabf34356ba274c69df41285bac71bbd229f1587283b851b91e")
 
     depends_on("c", type="build")  # generated
 
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
-    depends_on("python@3.7:", when="@4.2.0:", type=("build", "run"))
+    depends_on("python@3.7:", when="@4.2    :", type=("build", "run"))
+    depends_on("python@3.8:", when="@4.8:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@63:", type="build", when="@4.5:")
+    depends_on("py-setuptools@65:", type="build", when="@4.8:")
+    depends_on("py-hatchling@1.24:", type="build", when="@4.8:")
+    depends_on("py-hatch-requirements-txt@0.4.1:", type="build", when="@4.8:")
+    depends_on("py-dnspython@1.16.0:2", type="build", when="@4.3:")

--- a/var/spack/repos/builtin/packages/py-pymongo/package.py
+++ b/var/spack/repos/builtin/packages/py-pymongo/package.py
@@ -21,7 +21,9 @@ class PyPymongo(PythonPackage):
     with default_args(deprecated=True):
         # https://nvd.nist.gov/vuln/detail/CVE-2024-5629
         version("4.2.0", sha256="72f338f6aabd37d343bd9d1fdd3de921104d395766bcc5cdc4039e4c2dd97766")
-        version("3.12.1", sha256="704879b6a54c45ad76cea7c6789c1ae7185050acea7afd15b58318fa1932ed45")
+        version(
+            "3.12.1", sha256="704879b6a54c45ad76cea7c6789c1ae7185050acea7afd15b58318fa1932ed45"
+        )
         version("3.9.0", sha256="4249c6ba45587b959292a727532826c5032d59171f923f7f823788f413c2a5a3")
         version("3.6.0", sha256="c6de26d1e171cdc449745b82f1addbc873d105b8e7335097da991c0fc664a4a8")
         version("3.3.0", sha256="3d45302fc2622fabf34356ba274c69df41285bac71bbd229f1587283b851b91e")

--- a/var/spack/repos/builtin/packages/py-pymongo/package.py
+++ b/var/spack/repos/builtin/packages/py-pymongo/package.py
@@ -31,7 +31,7 @@ class PyPymongo(PythonPackage):
     depends_on("c", type="build")  # generated
 
     depends_on("python@2.7:2.8,3.4:", type=("build", "run"))
-    depends_on("python@3.7:", when="@4.2    :", type=("build", "run"))
+    depends_on("python@3.7:", when="@4.2:", type=("build", "run"))
     depends_on("python@3.8:", when="@4.8:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@63:", type="build", when="@4.5:")

--- a/var/spack/repos/builtin/packages/py-pymongo/package.py
+++ b/var/spack/repos/builtin/packages/py-pymongo/package.py
@@ -1,4 +1,4 @@
-    # Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)


### PR DESCRIPTION
This PR adds `py-pymongo`, v4.10.1, which fixes CVE-2024-5629. Older versions deprecated.

Test build:
```
==> Installing py-pymongo-4.2.0-nexdodls7k7ojwbrfvk6zqp4rxesrtki [28/28]
==> No binary for py-pymongo-4.2.0-nexdodls7k7ojwbrfvk6zqp4rxesrtki found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/72/72f338f6aabd37d343bd9d1fdd3de921104d395766bcc5cdc4039e4c2dd97766.tar.gz
==> No patches needed for py-pymongo
==> py-pymongo: Executing phase: 'install'
==> py-pymongo: Successfully installed py-pymongo-4.2.0-nexdodls7k7ojwbrfvk6zqp4rxesrtki
  Stage: 1.93s.  Install: 3.89s.  Post-install: 0.27s.  Total: 6.23s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/py-pymongo-4.2.0-nexdodls7k7ojwbrfvk6zqp4rxesrtki
==> Updating view at /tmp/spack-w9wmqde0/.spack-env/view
10:12:21 wdconinc@menelaos ~/git/spack (develop *$%>) $ python 
Python 3.11.9 (main, Oct 31 2024, 08:14:23) [GCC 14.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pymongo
>>> 
```