### PR TITLE
upcxx %oneapi@2025: cxxflags add -Wno-error=missing-template-arg-list…

### DIFF
--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -164,7 +164,11 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
     depends_on("oneapi-level-zero@1.8.0:", when="+level_zero")
 
     # All flags should be passed to the build-env in autoconf-like vars
-    flag_handler = env_flags
+    def flag_handler(self, name, flags):
+        if name == "cxxflags":
+            if self.spec.satisfies("%oneapi@2025:"):
+                flags.append("-Wno-error=missing-template-arg-list-after-template-kw")
+        return (flags, None, None)
 
     def set_variables(self, env):
         env.set("UPCXX_INSTALL", self.prefix)


### PR DESCRIPTION
1. Fix build error:
* [upcxx@2023.9.0 /mz7rs6o %oneapi@2025.0.0 arch=linux-ubuntu22.04-x86_64_v3 E4S OneAPI ](https://gitlab.spack.io/spack/spack/-/jobs/13177769)
```
     1808    In file included from /tmp/root/spack-stage/spack-stage-upcxx-2023
             .9.0-mz7rs6oblz5ajjg7hcfvc674xxkglh7j/spack-src/bld/upcxx.assert1.
             optlev0.dbgsym1.gasnet_par.smp/include/upcxx/reduce.hpp:6:
  >> 1809    /tmp/root/spack-stage/spack-stage-upcxx-2023.9.0-mz7rs6oblz5ajjg7h
             cfvc674xxkglh7j/spack-src/bld/upcxx.assert1.optlev0.dbgsym1.gasnet
             _par.smp/include/upcxx/rpc.hpp:304:27: error: a template argument 
             list is expected after a name prefixed by the template keyword [-W
             missing-template-arg-list-after-template-kw]
     1810      304 |         backend::template send_awaken_lpc(
     1811          |                           ^
     1812    2 errors generated.
```

2. Needed to merge PR:
* https://github.com/spack/spack/pull/47317

FYI @rscohn2 