### PR TITLE
Bug fix for package cprnc: set install rpath for cprnc executable

### DIFF
--- a/var/spack/repos/builtin/packages/cprnc/install_rpath.patch
+++ b/var/spack/repos/builtin/packages/cprnc/install_rpath.patch
@@ -1,0 +1,18 @@
+--- a/CMakeLists.txt	2023-12-04 07:01:57.000000000 -0700
++++ b/CMakeLists.txt	2024-11-08 06:53:55.090900241 -0700
+@@ -21,6 +21,7 @@
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ set(CMAKE_MACOSX_RPATH 1)
++SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+ 
+ # Compiler-specific compile options
+ if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
+@@ -79,6 +80,7 @@
+ get_filename_component(netcdf_c_lib_location ${netcdf_c_lib} DIRECTORY)
+ #message (STATUS "netcdf_c_lib_location == ${netcdf_c_lib_location}")
+ 
++SET(CMAKE_INSTALL_RPATH "${netcdf_fortran_lib_location};${netcdf_c_lib_location}")
+ list(APPEND CMAKE_BUILD_RPATH ${netcdf_fortran_lib_location} ${netcdf_c_lib_location})
+ #message("CMAKE_BUILD_RPATH is ${CMAKE_BUILD_RPATH}")
+ add_executable (cprnc ${CPRNC_Fortran_SRCS} ${CPRNC_GenF90_SRCS})

--- a/var/spack/repos/builtin/packages/cprnc/package.py
+++ b/var/spack/repos/builtin/packages/cprnc/package.py
@@ -25,6 +25,8 @@ class Cprnc(CMakePackage):
     depends_on("netcdf-fortran")
     depends_on("cmake@3:", type="build")
 
+    patch("install_rpath.patch")
+
     resource(
         name="genf90",
         git="https://github.com/PARALLELIO/genf90",

--- a/var/spack/repos/builtin/packages/cprnc/package.py
+++ b/var/spack/repos/builtin/packages/cprnc/package.py
@@ -15,6 +15,7 @@ class Cprnc(CMakePackage):
 
     maintainers("jedwards4b", "billsacks")
 
+    version("1.0.8", sha256="94ee3b4e724bc06161e576d45f34401f1452acf738803528cb80726eed230cae")
     version("1.0.3", sha256="3e7400f9a13d5de01964d7dd95151d08e6e30818d2a1efa9a9c7896cf6646d69")
     version("1.0.2", sha256="02edfa8050135ac0dc4a74aea05d19b0823d769b22cafa88b9352e29723d4179")
     version("1.0.1", sha256="b8a8fd4ad7e2716968dfa60f677217c55636580807b1309276f4c062ee432ccd")
@@ -25,7 +26,7 @@ class Cprnc(CMakePackage):
     depends_on("netcdf-fortran")
     depends_on("cmake@3:", type="build")
 
-    patch("install_rpath.patch")
+    patch("install_rpath.patch", when="@:1.0.7")
 
     resource(
         name="genf90",


### PR DESCRIPTION
With the head of develop of spack, I get an error when I install `cprnc` from a binary cache during the spack relocation step:
```
WARNING: File /home/ubuntu/spack-stack/CI/actions-runner/_work/spack-stack/spack-stack/envs/ue-gcc-11.4.0/install/gcc/11.4.0/cprnc-1.0.3-3mepb3e/bin/cprnc contains the following missing libraries: libnetcdff.so.7
```
The problem is that the `rpath` logic in `CMakeLists.txt` is wrong, because it strips out the `rpath` during `make install`:
```
[  0%] Built target genf90
[100%] Built target cprnc
Install the project...
-- Install configuration: ""
-- Installing: /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/cache/build_stage/spack-stage-cprnc-1.0.3-4x6m6jhbzn3rtmai3qcgik75cxo27u2n/spack-src/build/install/bin/cprnc
-- Set runtime path of "/home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/cache/build_stage/spack-stage-cprnc-1.0.3-4x6m6jhbzn3rtmai3qcgik75cxo27u2n/spack-src/build/install/bin/cprnc" to ""
bash-5.1$ ldd install
install/              install_manifest.txt
bash-5.1$ ldd install/bin/cprnc
        linux-vdso.so.1 (0x00007ffde9de5000)
        libnetcdff.so.7 => not found
        libnetcdf.so.19 => not found
        libgfortran.so.5 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/gcc-runtime-13.3.0-3gtnokv/lib/libgfortran.so.5 (0x0000152b8aa7d000)
        libm.so.6 => /lib64/libm.so.6 (0x0000152b8a9a2000)
        libgcc_s.so.1 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/gcc-runtime-13.3.0-3gtnokv/lib/libgcc_s.so.1 (0x0000152b8a97c000)
        libc.so.6 => /lib64/libc.so.6 (0x0000152b8a773000)
        /lib64/ld-linux-x86-64.so.2 (0x0000152b8ad63000)
```
This PR adds a patch to fix `CMakeLists.txt`, and the result looks correct:
```
> ldd envs/ue-gcc-13.3.0/install/gcc/13.3.0/cprnc-1.0.3-perxqiy/bin/cprnc
        linux-vdso.so.1 (0x00007fff17bd5000)
        libnetcdff.so.7 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/netcdf-fortran-4.6.1-qc3doln/lib/libnetcdff.so.7 (0x0000152b62ad3000)
        libnetcdf.so.19 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/netcdf-c-4.9.2-a22m2ew/lib/libnetcdf.so.19 (0x0000152b628ca000)
        libgfortran.so.5 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/gcc-runtime-13.3.0-3gtnokv/lib/libgfortran.so.5 (0x0000152b625f0000)
        libm.so.6 => /lib64/libm.so.6 (0x0000152b6250d000)
        libgcc_s.so.1 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/gcc-runtime-13.3.0-3gtnokv/lib/libgcc_s.so.1 (0x0000152b624e7000)
        libc.so.6 => /lib64/libc.so.6 (0x0000152b622de000)
        libstdc++.so.6 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/gcc-runtime-13.3.0-3gtnokv/lib/libstdc++.so.6 (0x0000152b62079000)
        libhdf5_hl.so.310 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/hdf5-1.14.3-agvc2cg/lib/libhdf5_hl.so.310 (0x0000152b62053000)
        libhdf5.so.310 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/hdf5-1.14.3-agvc2cg/lib/libhdf5.so.310 (0x0000152b61ba4000)
        libz.so.1 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/zlib-ng-2.2.1-3zr2ias/lib/libz.so.1 (0x0000152b61b7e000)
        libbz2.so.1.0 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/bzip2-1.0.8-ymm7snk/lib/libbz2.so.1.0 (0x0000152b61b6b000)
        libzstd.so.1 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/zstd-1.5.2-tw3qcub/lib/libzstd.so.1 (0x0000152b61a86000)
        libblosc.so.1 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/c-blosc-1.21.5-mvku7ox/lib64/libblosc.so.1 (0x0000152b61a74000)
        libxml2.so.2 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/libxml2-2.10.3-slo6gsg/lib/libxml2.so.2 (0x0000152b6190e000)
        libcurl.so.4 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/curl-8.10.1-qxsx456/lib/libcurl.so.4 (0x0000152b61841000)
        libmpi.so.40 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/openmpi-5.0.5-xfsj2hi/lib/libmpi.so.40 (0x0000152b61524000)
        /lib64/ld-linux-x86-64.so.2 (0x0000152b62b79000)
        liblz4.so.1 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/lz4-1.10.0-d4xvjoi/lib/liblz4.so.1 (0x0000152b614e3000)
        liblzma.so.5 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/xz-5.4.6-cijaxgo/lib/liblzma.so.5 (0x0000152b614b2000)
        libiconv.so.2 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/libiconv-1.17-qsl3sdw/lib/libiconv.so.2 (0x0000152b613a5000)
        libnghttp2.so.14 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/nghttp2-1.63.0-f7lxinh/lib/libnghttp2.so.14 (0x0000152b61375000)
        libssl.so.3 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/openssl-3.4.0-dxbplj7/lib64/libssl.so.3 (0x0000152b6126c000)
        libcrypto.so.3 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/openssl-3.4.0-dxbplj7/lib64/libcrypto.so.3 (0x0000152b60cde000)
        libopen-pal.so.80 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/openmpi-5.0.5-xfsj2hi/lib/libopen-pal.so.80 (0x0000152b60ba6000)
        libevent_core-2.1.so.7 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/libevent-2.1.12-grbml4p/lib/libevent_core-2.1.so.7 (0x0000152b60b6f000)
        libevent_pthreads-2.1.so.7 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/libevent-2.1.12-grbml4p/lib/libevent_pthreads-2.1.so.7 (0x0000152b60b68000)
        libhwloc.so.15 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/hwloc-2.11.1-we7feaa/lib/libhwloc.so.15 (0x0000152b60b06000)
        libpmix.so.2 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/pmix-5.0.3-sr3upuz/lib/libpmix.so.2 (0x0000152b608c7000)
        libpciaccess.so.0 => /home/dom/work/spack-stack/update_from_spack_dev_20241031/spack-stack-update/envs/ue-gcc-13.3.0/install/gcc/13.3.0/libpciaccess-0.17-2fewxaq/lib/libpciaccess.so.0 (0x0000152b608bb000)
```
This should be fixed upstream in subsequent releases of `cprnc` (hopefully the package maintainers can take care of this).