### PR TITLE
py-waitress: add v3.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-waitress/package.py
+++ b/var/spack/repos/builtin/packages/py-waitress/package.py
@@ -14,6 +14,11 @@ class PyWaitress(PythonPackage):
 
     license("ZPL-2.1")
 
-    version("2.1.2", sha256="780a4082c5fbc0fde6a2fcfe5e26e6efc1e8f425730863c04085769781f51eba")
+    version("3.0.1", sha256="ef0c1f020d9f12a515c4ec65c07920a702613afcad1dbfdc3bcec256b6c072b3")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2024-49769
+        version("2.1.2", sha256="780a4082c5fbc0fde6a2fcfe5e26e6efc1e8f425730863c04085769781f51eba")
+
+    depends_on("python@3.8:", type=("build", "run"), when="@3:")
 
     depends_on("py-setuptools@41:", type="build")


### PR DESCRIPTION
This PR adds `py-waitress`, v3.0.1, which fixes CVE-2024-49769. Older versions marked as deprecated.

Test build:
```
==> Installing py-waitress-3.0.1-nwt33vct7xtt5iiiaxcpihx7xxeg3vut [29/29]
==> No binary for py-waitress-3.0.1-nwt33vct7xtt5iiiaxcpihx7xxeg3vut found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/w/waitress/waitress-3.0.1.tar.gz
==> No patches needed for py-waitress
==> py-waitress: Executing phase: 'install'
==> py-waitress: Successfully installed py-waitress-3.0.1-nwt33vct7xtt5iiiaxcpihx7xxeg3vut
  Stage: 0.79s.  Install: 1.13s.  Post-install: 0.19s.  Total: 2.24s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/py-waitress-3.0.1-nwt33vct7xtt5iiiaxcpihx7xxeg3vut
```