### PR TITLE
python: add +jit and +freethread

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -265,8 +265,8 @@ class Python(Package):
     variant("tix", default=False, description="Build Tix module", when="+tkinter")
     variant("crypt", default=True, description="Build crypt module", when="@:3.12 platform=linux")
     variant("crypt", default=True, description="Build crypt module", when="@:3.12 platform=darwin")
-    variant("freethread", default=False, description="Build with experimental free-threading support (No GIL)", when="@:3.13")
-    variant("jit", default=False, description="Build with experimental JIT support", when="@:3.13")
+    variant("freethread", default=False, description="Build with experimental free-threading support (No GIL)", when="@3.13:")
+    variant("jit", default=False, description="Build with experimental JIT support", when="@3.13:")
 
     if sys.platform != "win32":
         depends_on("gmake", type="build")

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -224,6 +224,7 @@ class Python(Package):
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
+    depends_on("llvm", type="build")  # generated
 
     extendable = True
 
@@ -264,6 +265,8 @@ class Python(Package):
     variant("tix", default=False, description="Build Tix module", when="+tkinter")
     variant("crypt", default=True, description="Build crypt module", when="@:3.12 platform=linux")
     variant("crypt", default=True, description="Build crypt module", when="@:3.12 platform=darwin")
+    variant("freethread", default=False, description="Build with experimental free-threading support (No GIL)", when="@:3.13")
+    variant("jit", default=False, description="Build with experimental JIT support", when="@:3.13")
 
     if sys.platform != "win32":
         depends_on("gmake", type="build")
@@ -656,6 +659,12 @@ class Python(Package):
                     ),
                 ]
             )
+
+        if "+freethread" in spec:
+            config_args.append("--disable-gil")
+
+        if "+jit" in spec:
+            config_args.append("--enable-experimental-jit")
 
         # https://docs.python.org/3.8/library/sqlite3.html#f1
         if spec.satisfies("+sqlite3 ^sqlite+dynamic_extensions"):


### PR DESCRIPTION
With Python 3.13.0 comes both the `--disable-gil` as well as the new `--enable-experimental-jit` configuration options to the build. This PR adds the `+freethread` and `+jit` variants to the `python` package.