### PR TITLE
rsyslog: add v8.2410.0 (fix CVE)

### DIFF
--- a/var/spack/repos/builtin/packages/rsyslog/package.py
+++ b/var/spack/repos/builtin/packages/rsyslog/package.py
@@ -10,13 +10,16 @@ class Rsyslog(AutotoolsPackage):
     """The rocket-fast Syslog Server."""
 
     homepage = "https://www.rsyslog.com/"
-    url = "https://github.com/rsyslog/rsyslog/archive/v8.2006.0.tar.gz"
+    url = "https://github.com/rsyslog/rsyslog/archive/refs/tags/v8.2006.0.tar.gz"
 
     license("Apache-2.0 AND GPL-3.0-or-later AND LGPL-3.0-or-later", checked_by="tgamblin")
 
-    version("8.2006.0", sha256="dc30a2ec02d5fac91d3a4f15a00641e0987941313483ced46592ab0b0d68f324")
-    version("8.2004.0", sha256="b56b985fec076a22160471d389b7ff271909dfd86513dad31e401a775a6dfdc2")
-    version("8.2002.0", sha256="b31d56311532335212ef2ea7be4501508224cb21f1bef9d262c6d78e21959ea1")
+    version("8.2410.0", sha256="0e4e6fcb1d72a1cb65438d85dd2bbf37a8f82115d7e271788535d1e7fbcf6838")
+    with default_args(deprecated=True):
+        # https://nvd.nist.gov/vuln/detail/CVE-2022-24903
+        version("8.2006.0", sha256="dc30a2ec02d5fac91d3a4f15a00641e0987941313483ced46592ab0b0d68f324")
+        version("8.2004.0", sha256="b56b985fec076a22160471d389b7ff271909dfd86513dad31e401a775a6dfdc2")
+        version("8.2002.0", sha256="b31d56311532335212ef2ea7be4501508224cb21f1bef9d262c6d78e21959ea1")
 
     depends_on("c", type="build")  # generated
 
@@ -24,6 +27,7 @@ class Rsyslog(AutotoolsPackage):
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
+    depends_on("pkgconfig", type="build")
     depends_on("libestr")
     depends_on("libfastjson")
     depends_on("zlib-api")
@@ -35,6 +39,9 @@ class Rsyslog(AutotoolsPackage):
 
     def setup_run_environment(self, env):
         env.prepend_path("PATH", self.prefix.sbin)
+
+    def autoreconf(self, spec, prefix):
+        Executable("./autogen.sh")()
 
     def configure_args(self):
         args = ["--with-systemdsystemunitdir=" + self.spec["rsyslog"].prefix.lib.systemd.system]

--- a/var/spack/repos/builtin/packages/rsyslog/package.py
+++ b/var/spack/repos/builtin/packages/rsyslog/package.py
@@ -17,9 +17,15 @@ class Rsyslog(AutotoolsPackage):
     version("8.2410.0", sha256="0e4e6fcb1d72a1cb65438d85dd2bbf37a8f82115d7e271788535d1e7fbcf6838")
     with default_args(deprecated=True):
         # https://nvd.nist.gov/vuln/detail/CVE-2022-24903
-        version("8.2006.0", sha256="dc30a2ec02d5fac91d3a4f15a00641e0987941313483ced46592ab0b0d68f324")
-        version("8.2004.0", sha256="b56b985fec076a22160471d389b7ff271909dfd86513dad31e401a775a6dfdc2")
-        version("8.2002.0", sha256="b31d56311532335212ef2ea7be4501508224cb21f1bef9d262c6d78e21959ea1")
+        version(
+            "8.2006.0", sha256="dc30a2ec02d5fac91d3a4f15a00641e0987941313483ced46592ab0b0d68f324"
+        )
+        version(
+            "8.2004.0", sha256="b56b985fec076a22160471d389b7ff271909dfd86513dad31e401a775a6dfdc2"
+        )
+        version(
+            "8.2002.0", sha256="b31d56311532335212ef2ea7be4501508224cb21f1bef9d262c6d78e21959ea1"
+        )
 
     depends_on("c", type="build")  # generated
 


### PR DESCRIPTION
This PR adds `rsyslog`, v8.2410.0, which fixes CVE-2022-24903. Versions affected by CVE are deprecated.

Test build:
```
==> Installing rsyslog-8.2410.0-vcppcdex57f66fzgbmohsjdsvqxd3e64 [29/29]
==> No binary for rsyslog-8.2410.0-vcppcdex57f66fzgbmohsjdsvqxd3e64 found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/0e/0e4e6fcb1d72a1cb65438d85dd2bbf37a8f82115d7e271788535d1e7fbcf6838.tar.gz
==> No patches needed for rsyslog
==> rsyslog: Executing phase: 'autoreconf'
==> rsyslog: Executing phase: 'configure'
==> rsyslog: Executing phase: 'build'
==> rsyslog: Executing phase: 'install'
==> rsyslog: Successfully installed rsyslog-8.2410.0-vcppcdex57f66fzgbmohsjdsvqxd3e64
  Stage: 0.08s.  Autoreconf: 9.38s.  Configure: 8.97s.  Build: 4.06s.  Install: 1.00s.  Post-install: 0.20s.  Total: 23.81s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/rsyslog-8.2410.0-vcppcdex57f66fzgbmohsjdsvqxd3e64
```