### PR TITLE
armadillo: Disable the optional flexiblas support

### DIFF
--- a/var/spack/repos/builtin/packages/armadillo/package.py
+++ b/var/spack/repos/builtin/packages/armadillo/package.py
@@ -87,4 +87,9 @@ class Armadillo(CMakePackage):
             self.define("SuperLU_LIBRARY", spec["superlu"].libs.joined(";")),
             # HDF5 support
             self.define("DETECT_HDF5", "ON" if spec.satisfies("+hdf5") else "OFF"),
+            # disable flexiblas support because armadillo will possibly detect system
+            # flexiblas which causes problems. If this is removed, then SuperLU and ARPACK must
+            # also link with Flexiblas. As this does not seem to be needed with the spack
+            # blas and lapack, it is easier to disable
+            self.define("ALLOW_FLEXIBLAS_LINUX", "OFF"),
         ]


### PR DESCRIPTION
This disables the optional `flexiblas` support as `flexiblas` is not a depends and the entire build chain to support using`flexiblas` is not setup and can accidentally use system flexiblas . As `flexiblas` does not seem to be needed with the spack built `blas` and `lapack`, it is easier to disable. Without this fix:

```
-- *** options:
-- HEADER_ONLY               = OFF
-- STATIC_LIB                = OFF
-- OPENBLAS_PROVIDES_LAPACK  = OFF
-- ALLOW_FLEXIBLAS_LINUX     = ON
-- ALLOW_OPENBLAS_MACOS      = OFF
-- ALLOW_BLAS_LAPACK_MACOS   = OFF
-- BUILD_SMOKE_TEST          = ON
-- 
-- *** Looking for external libraries
-- Found FlexiBLAS: /usr/lib64/libflexiblas.so
-- Found BLAS: /home/chm003/project/spack/opt/spack/linux-centos9-zen2/gcc-14.1.0/openblas-0.3.28-kaxfh2ziv3ie6ffidkwal2bnmqwxxl6o/lib64/libopenblas.so
-- Found LAPACK: /home/chm003/project/spack/opt/spack/linux-centos9-zen2/gcc-14.1.0/openblas-0.3.28-kaxfh2ziv3ie6ffidkwal2bnmqwxxl6o/lib64/libopenblas.so
-- FlexiBLAS_FOUND = YES
--       MKL_FOUND = 
--  OpenBLAS_FOUND = 
--     ATLAS_FOUND = 
--      BLAS_FOUND = YES
--    LAPACK_FOUND = YES
-- 
-- *** Using FlexiBLAS to access BLAS and LAPACK functions.
-- *** https://www.mpi-magdeburg.mpg.de/projects/flexiblas
-- *** WARNING: SuperLU and ARPACK must also link with FlexiBLAS.
-- 
-- *** If using FlexiBLAS causes problems, 
-- *** rerun cmake with FlexiBLAS detection disabled:
-- *** cmake -D ALLOW_FLEXIBLAS_LINUX=false .
```