### PR TITLE
cgal: update depends versions for 6.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/cgal/package.py
+++ b/var/spack/repos/builtin/packages/cgal/package.py
@@ -64,18 +64,13 @@ class Cgal(CMakePackage):
     variant("eigen", default=True, description="Build with Eigen support")
 
     # Starting with cgal 6, GMP/MPFR are no longer mandatory and Core library
-    # is based on on Boost.Multiprecision. However, either GMP backend or Boost backend can be used.
-    # Downstream cmake users must also set -DCGAL_DISABLE_GMP=1 or the macro
-    # CMAKE_OVERRIDDEN_DEFAULT_ENT_BACKEND if GMP is disabled. 
-    # This variant doesn't change how cgal is installed, but it does change spack to not depend on
-    # gmp & mpfr.
+    # is based on on Boost.Multiprecision. However, either GMP backend or Boost
+    # backend can be used. Downstream cmake users must also set -DCGAL_DISABLE_GMP=1
+    # or the macro CMAKE_OVERRIDDEN_DEFAULT_ENT_BACKEND if GMP is disabled.
+    # This variant doesn't change how cgal is installed, but it does change spack to
+    # not depend on gmp & mpfr.
     # More details here https://github.com/CGAL/cgal/issues/8606
-    variant(
-        "gmp",
-        default=True,
-        description="Enable the GMP backend",
-        when="@6:",
-    )
+    variant("gmp", default=True, description="Enable the GMP backend", when="@6:")
 
     # Upper bound follows CGAL's @6: CMakeLists.txt
     depends_on("cmake@3.12:3.29", type="build", when="@6:")
@@ -176,6 +171,6 @@ class Cgal(CMakePackage):
             cmake_args.append("-DCGAL_HEADER_ONLY:BOOL=%s" % variant_bool("+header_only"))
 
         if spec.satisfies("~gmp"):
-           cmake_args.append("-DCGAL_DISABLE_GMP:BOOL=1")
+            cmake_args.append("-DCGAL_DISABLE_GMP:BOOL=1")
 
         return cmake_args

--- a/var/spack/repos/builtin/packages/cgal/package.py
+++ b/var/spack/repos/builtin/packages/cgal/package.py
@@ -111,7 +111,8 @@ class Cgal(CMakePackage):
         # LLVM Clang version 15.0.7 or later (on Linux)
         conflicts("%clang @:15.0.6", when="platform=linux")
 
-        # Apple Clang compiler versions 10.0.1, 12.0.5, and 15.0.0 (on macOS) (10+ has C++17 support)
+        # Apple Clang compiler versions 10.0.1, 12.0.5, and 15.0.0 (on macOS)
+        # (10+ has C++17 support)
         conflicts("%apple-clang @:10.0.0", when="platform=darwin")
 
     conflicts(

--- a/var/spack/repos/builtin/packages/cgal/package.py
+++ b/var/spack/repos/builtin/packages/cgal/package.py
@@ -86,8 +86,8 @@ class Cgal(CMakePackage):
     depends_on("gmp", when="@:5")
     depends_on("mpfr", when="@:5")
 
-    depends_on("gmp", when="@6: +gmp")
-    depends_on("mpfr", when="@6: +gmp")
+    # depends_on("gmp", when="@6: +gmp")
+    # depends_on("mpfr", when="@6: +gmp")
 
     # Required for CGAL_ImageIO
     # depends_on('opengl', when='+imageio') # not yet in Spack
@@ -112,7 +112,8 @@ class Cgal(CMakePackage):
     # depends_on('esbtl')
     # depends_on('intel-tbb')
 
-    # @6: requires C++17 or later
+    # @6: requires C++17 or later. The table gives tested
+    # compilers, but gives the lower limit
     # https://www.cgal.org/2024/10/22/cgal601/
     with when("@6:"):
         # Gnu g++ 11.4.0 or later (on Linux or macOS)
@@ -125,6 +126,9 @@ class Cgal(CMakePackage):
         # Apple Clang compiler versions 10.0.1, 12.0.5, and 15.0.0 (on macOS)
         # (10+ has C++17 support)
         conflicts("%apple-clang @:10.0.0", when="platform=darwin")
+
+        # Visual C++ 15.9 or later
+        conflicts("%msvc @:15.8", when="platform=windows")
 
     conflicts(
         "~header_only",

--- a/var/spack/repos/builtin/packages/cgal/package.py
+++ b/var/spack/repos/builtin/packages/cgal/package.py
@@ -64,17 +64,20 @@ class Cgal(CMakePackage):
     variant("eigen", default=True, description="Build with Eigen support")
 
     # Starting with cgal 6, GMP/MPFR are no longer mandatory and Core library
-    # is based on on Boost.Multiprecision. However,either GMP backend or Boost backend can be used.
-    # downstream users must also set -DCGAL_DISABLE_GMP=1 if GMP is diabled, thus prefer using gmp
-    # it seems like this is supposed to cache CGAL_DISABLE_GMP status in the install but
-    # it doesn't seem to work https://github.com/CGAL/cgal/issues/8606
-    # variant(
-    #     "gmp",
-    #     default=True,
-    #     description="Enable the GMP backend. Consumers must also set -DCGAL_DISABLE_GMP=1",
-    #     when="@6:",
-    # )
+    # is based on on Boost.Multiprecision. However, either GMP backend or Boost backend can be used.
+    # Downstream cmake users must also set -DCGAL_DISABLE_GMP=1 or the macro
+    # CMAKE_OVERRIDDEN_DEFAULT_ENT_BACKEND if GMP is disabled. 
+    # This variant doesn't change how cgal is installed, but it does change spack to not depend on
+    # gmp & mpfr.
+    # More details here https://github.com/CGAL/cgal/issues/8606
+    variant(
+        "gmp",
+        default=True,
+        description="Enable the GMP backend",
+        when="@6:",
+    )
 
+    # Upper bound follows CGAL's @6: CMakeLists.txt
     depends_on("cmake@3.12:3.29", type="build", when="@6:")
     depends_on("cmake@2.8.11:", type="build", when="@:5")
 
@@ -86,8 +89,8 @@ class Cgal(CMakePackage):
     depends_on("gmp", when="@:5")
     depends_on("mpfr", when="@:5")
 
-    # depends_on("gmp", when="@6: +gmp")
-    # depends_on("mpfr", when="@6: +gmp")
+    depends_on("gmp", when="@6: +gmp")
+    depends_on("mpfr", when="@6: +gmp")
 
     # Required for CGAL_ImageIO
     # depends_on('opengl', when='+imageio') # not yet in Spack
@@ -113,7 +116,7 @@ class Cgal(CMakePackage):
     # depends_on('intel-tbb')
 
     # @6: requires C++17 or later. The table gives tested
-    # compilers, but gives the lower limit
+    # compilers, so use the lwoer limit of that as the bounds
     # https://www.cgal.org/2024/10/22/cgal601/
     with when("@6:"):
         # Gnu g++ 11.4.0 or later (on Linux or macOS)
@@ -154,16 +157,6 @@ class Cgal(CMakePackage):
         if spec.satisfies("+eigen"):
             env.set("EIGEN3_INC_DIR", spec["eigen"].headers.directories[0])
 
-    # at the moment it is not clear how non-cmake consumers should deal with this variant
-    # as it requires setting -DCGAL_DISABLE_GMP:BOOL=1 for all consuming targets
-    # therefore, disable with non-cmake dependents and this should be revisited in the future
-    # def setup_dependent_package(self, module, dependent_spec):
-    #     if self.spec.satisfies("~gmp") and not dependent_spec.satisfies("build_system=cmake"):
-    #         raise RuntimeError(
-    #             "The boost multiprecision backend is currently only configurable "
-    #             "with cmake dependents."
-    #         )
-
     def cmake_args(self):
         # Installation instructions:
         # https://doc.cgal.org/latest/Manual/installation.html
@@ -182,7 +175,7 @@ class Cgal(CMakePackage):
         if spec.satisfies("@4.9:"):
             cmake_args.append("-DCGAL_HEADER_ONLY:BOOL=%s" % variant_bool("+header_only"))
 
-        # if spec.satisfies("~gmp"):
-        #    cmake_args.append("-DCGAL_DISABLE_GMP:BOOL=1")
+        if spec.satisfies("~gmp"):
+           cmake_args.append("-DCGAL_DISABLE_GMP:BOOL=1")
 
         return cmake_args

--- a/var/spack/repos/builtin/packages/cgal/package.py
+++ b/var/spack/repos/builtin/packages/cgal/package.py
@@ -53,7 +53,7 @@ class Cgal(CMakePackage):
     #      https://cs.nyu.edu/exact/core_pages/svn-core.html
     variant("core", default=False, description="Build the CORE library for algebraic numbers")
     variant("imageio", default=False, description="Build utilities to read/write image files")
-    variant("demos", default=False, description="Build CGAL demos")
+    variant("demos", default=False, description="Build CGAL demos", when="@:5")
     variant("eigen", default=True, description="Build with Eigen support")
 
     # Starting with cgal 6, GMP/MPFR are no longer mandatory and Core library
@@ -87,7 +87,9 @@ class Cgal(CMakePackage):
     # Optional to build CGAL_Qt5 (demos)
     # depends_on('opengl', when='+demos')   # not yet in Spack
     depends_on("qt@5:", when="@:5 +demos")
-    depends_on("qt@6:", when="@6: +demos")
+
+    # Demos are now based on qt6, but at the moment qt6 is not in spack
+    # depends_on("qt@6:", when="@6: +demos")
 
     # Optional Third Party Libraries
     depends_on("eigen", when="+eigen")


### PR DESCRIPTION
This extends PR https://github.com/spack/spack/pull/47285 to properly include some of the required version constrains of cgal 6 including the required C++17 standard. It also adds the new no-gmp backend as a variant. The no-gmp backend seems a bit fiddly and it is unclear how it interacts with non-cmake consumers, so I have kept the gmp backend as default, matching previous cgal versions.

/cc @lang-m 