### PR TITLE
ci: "summary" jobs should always run, and fail if any deps has status "fail" or "canceled"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,10 +83,17 @@ jobs:
 
   all-prechecks:
     needs: [ prechecks ]
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
     - name: Success
-      run: "true"
+      run: |
+        if [ "${{ needs.prechecks.result }}" == "failure" ] || [ "${{ needs.prechecks.result }}" == "canceled" ]; then
+          echo "Unit tests failed." 
+          exit 1
+        else
+          exit 0
+        fi
 
   coverage:
     needs: [ unit-tests, prechecks ]
@@ -94,8 +101,19 @@ jobs:
     secrets: inherit
 
   all:
-    needs: [ coverage, bootstrap ]
+    needs: [ unit-tests, coverage, bootstrap ]
+    if: ${{ always() }}
     runs-on: ubuntu-latest
+    # See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#needs-context
     steps:
-    - name: Success
-      run: "true"
+    - name: Status summary
+      run: |
+        if [ "${{ needs.unit-tests.result }}" == "failure" ] || [ "${{ needs.unit-tests.result }}" == "canceled" ]; then
+          echo "Unit tests failed." 
+          exit 1
+        elif [ "${{ needs.bootstrap.result }}" == "failure" ] || [ "${{ needs.bootstrap.result }}" == "canceled" ]; then
+          echo "Bootstrap tests failed." 
+          exit 1
+        else
+          exit 0
+        fi


### PR DESCRIPTION
This means they succeed when all deps have either status "success" or status "skipped"

Examples:
- Fails when style tests fail: https://github.com/spack/spack/actions/runs/11754231631/job/32748110056
- Fails when unit tests are failing: https://github.com/spack/spack/actions/runs/11754545867/job/32749210775?pr=47517
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
