### PR TITLE
scitokens-cpp: add v1.1.2

### DIFF
--- a/var/spack/repos/builtin/packages/scitokens-cpp/package.py
+++ b/var/spack/repos/builtin/packages/scitokens-cpp/package.py
@@ -17,6 +17,7 @@ class ScitokensCpp(CMakePackage):
 
     license("Apache-2.0")
 
+    version("1.1.2", sha256="07d33cb51a3ccd8460f2acebb15b35393aeccfc70e3554a73c9e5cffed6edb39")
     version("1.1.1", sha256="a9091b888fc778282caf2a6808c86f685d2411557673152d58fe53932a6c7212")
     version("1.1.0", sha256="9c4afd6638e94855ede52ecfc3d4f05082f2bdf151a9ab8dafcc2bb7cd4d9039")
     version("1.0.2", sha256="cdc1e80e0cba9ca0e16de2efa10ec5e38765792bf5107024bfb66ddad5a16a85")


### PR DESCRIPTION
This PR adds `scitokens-cpp`, v1.1.2.

Test build:
```
==> Installing scitokens-cpp-1.1.2-vxbvzign4cqajd2obgqadlh2egbraeub [15/15]
==> No binary for scitokens-cpp-1.1.2-vxbvzign4cqajd2obgqadlh2egbraeub found: installing from source
==> Fetching https://github.com/scitokens/scitokens-cpp/archive/refs/tags/v1.1.2.tar.gz
==> No patches needed for scitokens-cpp
==> scitokens-cpp: Executing phase: 'cmake'
==> scitokens-cpp: Executing phase: 'build'
==> scitokens-cpp: Executing phase: 'install'
==> scitokens-cpp: Successfully installed scitokens-cpp-1.1.2-vxbvzign4cqajd2obgqadlh2egbraeub
  Stage: 1.70s.  Cmake: 0.33s.  Build: 13.92s.  Install: 0.06s.  Post-install: 0.13s.  Total: 16.22s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/scitokens-cpp-1.1.2-vxbvzign4cqajd2obgqadlh2egbraeub
```