### PR TITLE
snakemake and py-snakemake-*: updates to latest versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-azure-batch/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-azure-batch/package.py
@@ -27,7 +27,7 @@ class PySnakemakeExecutorPluginAzureBatch(PythonPackage):
     depends_on(
         "py-snakemake-interface-executor-plugins@9.2.0:9", type=("build", "run"), when="@0.2:"
     )
-    depends_on("py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"))
+    depends_on("py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"), when="@:0.1")
 
     depends_on("py-azure-storage-blob@12.20:12", type=("build", "run"), when="@0.2:")
     depends_on("py-azure-storage-blob@12.17:12", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-azure-batch/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-azure-batch/package.py
@@ -35,7 +35,7 @@ class PySnakemakeExecutorPluginAzureBatch(PythonPackage):
     depends_on("py-azure-batch@14", type=("build", "run"))
     depends_on("py-azure-mgmt-batch@17", type=("build", "run"))
     depends_on("py-azure-identity@1.17.1:1", type=("build", "run"), when="@0.2:")
-    depends_on("py-azure-identity@1.14:1", type=("build", "run"))
+    depends_on("py-azure-identity@1.14:1", type=("build", "run"), when="@:0.1")
     depends_on("py-msrest@0.7.1:0.7", type=("build", "run"))
 
     depends_on("python@3.11:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-azure-batch/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-azure-batch/package.py
@@ -27,7 +27,9 @@ class PySnakemakeExecutorPluginAzureBatch(PythonPackage):
     depends_on(
         "py-snakemake-interface-executor-plugins@9.2.0:9", type=("build", "run"), when="@0.2:"
     )
-    depends_on("py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"), when="@:0.1")
+    depends_on(
+        "py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"), when="@:0.1"
+    )
 
     depends_on("py-azure-storage-blob@12.20:12", type=("build", "run"), when="@0.2:")
     depends_on("py-azure-storage-blob@12.17:12", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-azure-batch/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-azure-batch/package.py
@@ -24,7 +24,9 @@ class PySnakemakeExecutorPluginAzureBatch(PythonPackage):
 
     depends_on("py-snakemake-interface-common@1.17.2:1", type=("build", "run"), when="@0.2:")
     depends_on("py-snakemake-interface-common@1.15:1", type=("build", "run"))
-    depends_on("py-snakemake-interface-executor-plugins@9.2.0:9", type=("build", "run"), when="@0.2:")
+    depends_on(
+        "py-snakemake-interface-executor-plugins@9.2.0:9", type=("build", "run"), when="@0.2:"
+    )
     depends_on("py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"))
 
     depends_on("py-azure-storage-blob@12.20:12", type=("build", "run"), when="@0.2:")

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-azure-batch/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-azure-batch/package.py
@@ -37,7 +37,7 @@ class PySnakemakeExecutorPluginAzureBatch(PythonPackage):
     depends_on("py-azure-batch@14", type=("build", "run"))
     depends_on("py-azure-mgmt-batch@17", type=("build", "run"))
     depends_on("py-azure-identity@1.17.1:1", type=("build", "run"), when="@0.2:")
-    depends_on("py-azure-identity@1.14:1", type=("build", "run"), when="@:0.1")
+    depends_on("py-azure-identity@1.14:1", type=("build", "run"))
     depends_on("py-msrest@0.7.1:0.7", type=("build", "run"))
 
     depends_on("python@3.11:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-azure-batch/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-azure-batch/package.py
@@ -17,14 +17,22 @@ class PySnakemakeExecutorPluginAzureBatch(PythonPackage):
 
     license("MIT")
 
+    version("0.3.0", sha256="cafaa283ccabf9cb857c695eadf1dd8d47e9908a6497637b4bfa8e6c857a240c")
+    version("0.2.1", sha256="9f828b2c0fa1b62b7160b8790894d325ffda58adec029118a39ad8f677b9a89a")
+    version("0.2.0", sha256="5bfc6c63588595d9f815ab730b866940452999a677e2a5b7f474ede50125bff9")
     version("0.1.3", sha256="7883ecdc3983eb73ea0e1ae10010eeff1626510c7e99176203ee2050031f86e3")
 
+    depends_on("py-snakemake-interface-common@1.17.2:1", type=("build", "run"), when="@0.2:")
     depends_on("py-snakemake-interface-common@1.15:1", type=("build", "run"))
+    depends_on("py-snakemake-interface-executor-plugins@9.2.0:9", type=("build", "run"), when="@0.2:")
     depends_on("py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"))
 
+    depends_on("py-azure-storage-blob@12.20:12", type=("build", "run"), when="@0.2:")
     depends_on("py-azure-storage-blob@12.17:12", type=("build", "run"))
+    depends_on("py-azure-batch@14.2:14", type=("build", "run"), when="@0.2:")
     depends_on("py-azure-batch@14", type=("build", "run"))
     depends_on("py-azure-mgmt-batch@17", type=("build", "run"))
+    depends_on("py-azure-identity@1.17.1:1", type=("build", "run"), when="@0.2:")
     depends_on("py-azure-identity@1.14:1", type=("build", "run"))
     depends_on("py-msrest@0.7.1:0.7", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-drmaa/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-drmaa/package.py
@@ -21,7 +21,9 @@ class PySnakemakeExecutorPluginDrmaa(PythonPackage):
 
     depends_on("py-snakemake-interface-common@1.13:1", type=("build", "run"))
     depends_on("py-snakemake-interface-executor-plugins@9", type=("build", "run"), when="@0.1.4:")
-    depends_on("py-snakemake-interface-executor-plugins@8.1:8", type=("build", "run"), when="@:0.1.3")
+    depends_on(
+        "py-snakemake-interface-executor-plugins@8.1:8", type=("build", "run"), when="@:0.1.3"
+    )
     depends_on("py-drmaa@0.7.9:0.7", type=("build", "run"))
 
     depends_on("python@3.11:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-drmaa/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-drmaa/package.py
@@ -21,7 +21,7 @@ class PySnakemakeExecutorPluginDrmaa(PythonPackage):
 
     depends_on("py-snakemake-interface-common@1.13:1", type=("build", "run"))
     depends_on("py-snakemake-interface-executor-plugins@9", type=("build", "run"), when="@0.1.4:")
-    depends_on("py-snakemake-interface-executor-plugins@8.1:8", type=("build", "run"))
+    depends_on("py-snakemake-interface-executor-plugins@8.1:8", type=("build", "run"), when="@:0.1.3")
     depends_on("py-drmaa@0.7.9:0.7", type=("build", "run"))
 
     depends_on("python@3.11:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-drmaa/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-drmaa/package.py
@@ -20,6 +20,7 @@ class PySnakemakeExecutorPluginDrmaa(PythonPackage):
     version("0.1.3", sha256="1250d0f307bf3db3aa3f26f85ea5ecc7ae00b2598ea1e1afceab7a457042fa12")
 
     depends_on("py-snakemake-interface-common@1.13:1", type=("build", "run"))
+    depends_on("py-snakemake-interface-executor-plugins@9", type=("build", "run"), when="@0.1.4:")
     depends_on("py-snakemake-interface-executor-plugins@8.1:8", type=("build", "run"))
     depends_on("py-drmaa@0.7.9:0.7", type=("build", "run"))
 

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-drmaa/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-drmaa/package.py
@@ -15,6 +15,8 @@ class PySnakemakeExecutorPluginDrmaa(PythonPackage):
 
     license("MIT")
 
+    version("0.1.5", sha256="24fe16fc1f1e7ef75bc213cdb960b674bb130ec918a9f6106511a667ffc661b2")
+    version("0.1.4", sha256="93ddefc3fcb5ee2241e4622d04fd1ffcfc58776ff9e723e958a0da2cc2c5fcb7")
     version("0.1.3", sha256="1250d0f307bf3db3aa3f26f85ea5ecc7ae00b2598ea1e1afceab7a457042fa12")
 
     depends_on("py-snakemake-interface-common@1.13:1", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-flux/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-flux/package.py
@@ -15,9 +15,11 @@ class PySnakemakeExecutorPluginFlux(PythonPackage):
 
     license("MIT")
 
+    version("0.1.1", sha256="26655bd1cf5d7db5dfcfdfbd006c1db35968c0ad1772e0b010e64e6f71b00163")
     version("0.1.0", sha256="92b1944dcf9ea163519a8879d4d638df2b3d0cd83ea6e8397d26046897811214")
 
     depends_on("py-snakemake-interface-common@1.14:1", type=("build", "run"))
+    depends_on("py-snakemake-interface-executor-plugins@9", type=("build", "run"), when="@0.1.1:")
     depends_on("py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"))
 
     depends_on("python@3.11:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-flux/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-flux/package.py
@@ -20,7 +20,7 @@ class PySnakemakeExecutorPluginFlux(PythonPackage):
 
     depends_on("py-snakemake-interface-common@1.14:1", type=("build", "run"))
     depends_on("py-snakemake-interface-executor-plugins@9", type=("build", "run"), when="@0.1.1:")
-    depends_on("py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"))
+    depends_on("py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"), when="@:0.1.0")
 
     depends_on("python@3.11:3", type=("build", "run"))
     depends_on("py-poetry-core", type="build")

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-flux/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-flux/package.py
@@ -20,7 +20,9 @@ class PySnakemakeExecutorPluginFlux(PythonPackage):
 
     depends_on("py-snakemake-interface-common@1.14:1", type=("build", "run"))
     depends_on("py-snakemake-interface-executor-plugins@9", type=("build", "run"), when="@0.1.1:")
-    depends_on("py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"), when="@:0.1.0")
+    depends_on(
+        "py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"), when="@:0.1.0"
+    )
 
     depends_on("python@3.11:3", type=("build", "run"))
     depends_on("py-poetry-core", type="build")

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-googlebatch/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-googlebatch/package.py
@@ -17,6 +17,11 @@ class PySnakemakeExecutorPluginGooglebatch(PythonPackage):
 
     license("MIT")
 
+    version("0.5.0", sha256="242ddb2348db1837a0676e991b257e0924791d3dab20aa8f89d63c548adfd1cd")
+    version("0.4.0", sha256="ad1ebf74d6558bc5ea9d1849570fb3c5991413265c771d944e99aeb8c49217d2")
+    version("0.3.3", sha256="fbc3f3dad6fca51f9d65cd66a6a1272b056213ed3ab03759523f27590c58bcd8")
+    version("0.3.2", sha256="9f861f0067d96e825796c0a3aa829581a22036bfeb2c6d481c5c42daeaf7fcbf")
+    version("0.3.1", sha256="292c024534e98aecf6a5a2be8a24db104d8038831b6a55fe50c87c1e4fdb28af")
     version("0.3.0", sha256="b143fcaeffceec682bc0f7e3f13eece3596a5d6faaf41fab94977f4a93948c16")
 
     depends_on("py-google-cloud-batch@0.17.1:0.17", type=("build", "run"))
@@ -27,6 +32,7 @@ class PySnakemakeExecutorPluginGooglebatch(PythonPackage):
     depends_on("py-google-cloud-logging@3.8:3", type=("build", "run"))
 
     depends_on("py-snakemake-interface-common@1.14:1", type=("build", "run"))
+    depends_on("py-snakemake-interface-executor-plugins@9", type=("build", "run"), when="@0.3.1:")
     depends_on("py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"))
 
     depends_on("python@3.11:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-googlebatch/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-googlebatch/package.py
@@ -33,7 +33,9 @@ class PySnakemakeExecutorPluginGooglebatch(PythonPackage):
 
     depends_on("py-snakemake-interface-common@1.14:1", type=("build", "run"))
     depends_on("py-snakemake-interface-executor-plugins@9", type=("build", "run"), when="@0.3.1:")
-    depends_on("py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"), when="@:0.3.0")
+    depends_on(
+        "py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"), when="@:0.3.0"
+    )
 
     depends_on("python@3.11:3", type=("build", "run"))
     depends_on("py-poetry-core", type="build")

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-googlebatch/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-googlebatch/package.py
@@ -33,7 +33,7 @@ class PySnakemakeExecutorPluginGooglebatch(PythonPackage):
 
     depends_on("py-snakemake-interface-common@1.14:1", type=("build", "run"))
     depends_on("py-snakemake-interface-executor-plugins@9", type=("build", "run"), when="@0.3.1:")
-    depends_on("py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"))
+    depends_on("py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"), when="@:0.3.0")
 
     depends_on("python@3.11:3", type=("build", "run"))
     depends_on("py-poetry-core", type="build")

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-kubernetes/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-kubernetes/package.py
@@ -15,11 +15,16 @@ class PySnakemakeExecutorPluginKubernetes(PythonPackage):
 
     license("MIT")
 
+    version("0.2.2", sha256="08f7ea92cc288f0830f7bfc38112c9e4a03d623d84f8f80b0105cc179458fc4c")
+    version("0.2.1", sha256="476c423cb33b71bff2ed11d2ec0aace8bb76e1b9667b408880bcbe2c7fdbe6ef")
+    version("0.2.0", sha256="83981ad405515880b1b311129fd442c1e17902ee0a673ca14bab5b8ba31d7fbf")
+    version("0.1.5", sha256="7984ef057c25ce1ff46ceac5839dfad01e2938faa649e59fa439e8154e8025eb")
     version("0.1.4", sha256="c3aeac87939ec5d038efdc3ba7dbbef5eeb3171c1b718b8af850b6287b9c54ff")
 
     depends_on("py-kubernetes@27.2:27", type=("build", "run"))
 
     depends_on("py-snakemake-interface-common@1.14.1:1", type=("build", "run"))
+    depends_on("py-snakemake-interface-executor-plugins@9", type=("build", "run"), when="@0.1.5:")
     depends_on("py-snakemake-interface-executor-plugins@8.0.2:8", type=("build", "run"))
 
     depends_on("python@3.11:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-kubernetes/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-kubernetes/package.py
@@ -28,7 +28,9 @@ class PySnakemakeExecutorPluginKubernetes(PythonPackage):
     depends_on("py-snakemake-interface-common@1.17.3:1", type=("build", "run"), when="@0.2.0:")
     depends_on("py-snakemake-interface-common@1.14.1:1", type=("build", "run"))
     depends_on("py-snakemake-interface-executor-plugins@9", type=("build", "run"), when="@0.1.5:")
-    depends_on("py-snakemake-interface-executor-plugins@8.0.2:8", type=("build", "run"), when="@:0.1.4")
+    depends_on(
+        "py-snakemake-interface-executor-plugins@8.0.2:8", type=("build", "run"), when="@:0.1.4"
+    )
 
     depends_on("python@3.11:3", type=("build", "run"))
     depends_on("py-poetry-core", type="build")

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-kubernetes/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-kubernetes/package.py
@@ -21,11 +21,14 @@ class PySnakemakeExecutorPluginKubernetes(PythonPackage):
     version("0.1.5", sha256="7984ef057c25ce1ff46ceac5839dfad01e2938faa649e59fa439e8154e8025eb")
     version("0.1.4", sha256="c3aeac87939ec5d038efdc3ba7dbbef5eeb3171c1b718b8af850b6287b9c54ff")
 
-    depends_on("py-kubernetes@27.2:27", type=("build", "run"))
+    depends_on("py-kubernetes@27.2:30", type=("build", "run"), when="@0.2.1:")
+    depends_on("py-kubernetes@27.2:29", type=("build", "run"), when="@0.1.5:0.2.0")
+    depends_on("py-kubernetes@27.2:27", type=("build", "run"), when="@:0.1.4")
 
+    depends_on("py-snakemake-interface-common@1.17.3:1", type=("build", "run"), when="@0.2.0:")
     depends_on("py-snakemake-interface-common@1.14.1:1", type=("build", "run"))
     depends_on("py-snakemake-interface-executor-plugins@9", type=("build", "run"), when="@0.1.5:")
-    depends_on("py-snakemake-interface-executor-plugins@8.0.2:8", type=("build", "run"))
+    depends_on("py-snakemake-interface-executor-plugins@8.0.2:8", type=("build", "run"), when="@:0.1.4")
 
     depends_on("python@3.11:3", type=("build", "run"))
     depends_on("py-poetry-core", type="build")

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-slurm/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-slurm/package.py
@@ -16,6 +16,11 @@ class PySnakemakeExecutorPluginSlurm(PythonPackage):
 
     license("MIT")
 
+    version("0.11.2", sha256="fca29038d78387c237afb4ec2b04638e6128d2456940dd7b96ac4205f319d7f3")
+    version("0.11.1", sha256="293a951dcf829400bf6197705d6c602faed95aaaae9ad0d661d23b0184074134")
+    version("0.11.0", sha256="bce1df57900da71175c1c384dbc8f04d8bf8572717c0aaf95c32945a4c7a08d3")
+    version("0.10.2", sha256="919beb114785545f3cc187988f9257a183f1a2c76593e8a8559b87962ebd2651")
+    version("0.10.1", sha256="0d117e3b6fb523b873bd04b7e0117a0c83c9b38dfef1b0a79535c7a084e982ea")
     version("0.10.0", sha256="d970bd08e00f1664adbd3c421c956b2ce926359ff10a4d7650c444c1179bec3f")
     version("0.3.2", sha256="3912f2895eab1270d7a42959a2e221ce53428dfffb847e03ec6bc4eead88e30b")
 

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-tes/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-tes/package.py
@@ -15,11 +15,13 @@ class PySnakemakeExecutorPluginTes(PythonPackage):
 
     license("MIT")
 
+    version("0.1.3", sha256="bbecd5c1e63a39e2ea84b752e8e4d68e64b16df686062f22e347cf97c7cd47b3")
     version("0.1.2", sha256="bec01801ae3f158cfe7ca406a513455bcffa36fa7f83e35b2c7cb93bec9b00e9")
 
     depends_on("py-py-tes@0.4.2:0.4", type=("build", "run"))
 
     depends_on("py-snakemake-interface-common@1.14:1", type=("build", "run"))
+    depends_on("py-snakemake-interface-executor-plugins@9", type=("build", "run"), when="@0.1.3:")
     depends_on("py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"))
 
     depends_on("python@3.11:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-tes/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-tes/package.py
@@ -22,7 +22,9 @@ class PySnakemakeExecutorPluginTes(PythonPackage):
 
     depends_on("py-snakemake-interface-common@1.14:1", type=("build", "run"))
     depends_on("py-snakemake-interface-executor-plugins@9", type=("build", "run"), when="@0.1.3:")
-    depends_on("py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"), when="@:0.1.2")
+    depends_on(
+        "py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"), when="@:0.1.2"
+    )
 
     depends_on("python@3.11:3", type=("build", "run"))
     depends_on("py-poetry-core", type="build")

--- a/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-tes/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-executor-plugin-tes/package.py
@@ -22,7 +22,7 @@ class PySnakemakeExecutorPluginTes(PythonPackage):
 
     depends_on("py-snakemake-interface-common@1.14:1", type=("build", "run"))
     depends_on("py-snakemake-interface-executor-plugins@9", type=("build", "run"), when="@0.1.3:")
-    depends_on("py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"))
+    depends_on("py-snakemake-interface-executor-plugins@8.1.1:8", type=("build", "run"), when="@:0.1.2")
 
     depends_on("python@3.11:3", type=("build", "run"))
     depends_on("py-poetry-core", type="build")

--- a/var/spack/repos/builtin/packages/py-snakemake-interface-common/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-interface-common/package.py
@@ -16,6 +16,7 @@ class PySnakemakeInterfaceCommon(PythonPackage):
 
     license("MIT")
 
+    version("1.17.4", sha256="c2142e1b93cbc18c2cf41d15968ba8688f60b077c8284e5de057cccfc215d4d3")
     version("1.17.3", sha256="cca6e2c728072a285a8e750f00fdd98d9c50063912184c41f8b89e4cab66c7b0")
     version("1.17.1", sha256="555c8218d9b68ddc1046f94a517e7d0f22e15bdc839d6ce149608d8ec137b9ae")
 

--- a/var/spack/repos/builtin/packages/py-snakemake-interface-executor-plugins/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-interface-executor-plugins/package.py
@@ -17,12 +17,16 @@ class PySnakemakeInterfaceExecutorPlugins(PythonPackage):
 
     license("MIT")
 
+    version("9.3.2", sha256="19c50dc82989ff25d10386cfb3c99da9d2dc980d95ecd30bbb431374dcd390b3")
+    version("9.3.1", sha256="98e1b7a6c5e0997ac391812ab66a79822c38ac98ea9322f2fd8d6a1294e219a0")
+    version("9.3.0", sha256="11e70cf3d821d9f071b18b8a8147bc4dbad37f3ee68647f72aa3c80c4ab5c8dc")
     version("9.2.0", sha256="67feaf438a0b8b041ec5f1a1dd859f729036c70c07c9fdad895135f5b949e40a")
     version("8.2.0", sha256="4c74e3e1751bab6b266baf8688e854b8b4c5c5e10f5e34c581f42d69af4ff13b")
 
     depends_on("py-argparse-dataclass@2", type=("build", "run"))
     depends_on("py-throttler@1.2.2:1", type=("build", "run"))
 
+    depends_on("py-snakemake-interface-common@1.17.4:1", type=("build", "run"), when="@9.3:")
     depends_on("py-snakemake-interface-common@1.12:1", type=("build", "run"))
 
     depends_on("python@3.11:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-interface-report-plugins/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-interface-report-plugins/package.py
@@ -15,6 +15,7 @@ class PySnakemakeInterfaceReportPlugins(PythonPackage):
 
     license("MIT")
 
+    version("1.1.0", sha256="b1ee444b2fca51225cf8a102f8e56633791d01433cd00cf07a1d9713a12313a5")
     version("1.0.0", sha256="02311cdc4bebab2a1c28469b5e6d5c6ac6e9c66998ad4e4b3229f1472127490f")
 
     depends_on("py-snakemake-interface-common@1.16:1", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-azure/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-azure/package.py
@@ -15,13 +15,27 @@ class PySnakemakeStoragePluginAzure(PythonPackage):
 
     license("MIT")
 
+    version("0.4.2", sha256="f1b0395e466fa2f6a20247a23c240b418240dbd6eaf7a55af3b34714594891f0")
+    version("0.4.1", sha256="5200670ee317a572aa8fe843847a3b9810da1584543b84f69b804b54802db11b")
+    version("0.4.0", sha256="7b3fd1479d3a2f3447891dbd27b84aeb7380f526b68147d7d8f7aceda14bda62")
+    version("0.3.0", sha256="95f58b2f355707a37fcf739a0e9172388acef8a1800242f2e0724154521a20e0")
+    version("0.2.2", sha256="df1f5740005dcdbe765f3f6c1b52b657dacaa5177a7a6e981a00aa5f5f2b0be7")
+    version("0.2.1", sha256="0fb2ccf234a6aa7d4ec1e17b2bb2ab9bf19b0bd00f49f587722504ba01ea7423")
+    version("0.2.0", sha256="6eea1bc5ff7ab7f5261981eca929a5576dfb76382f597d86ea4863a3e2bac7e7")
+    version("0.1.6", sha256="549e54daf878be652ac5a301b1aa2b4d63d48e21a3a1abe33c4c7b4da79cf8d6")
+    version("0.1.5", sha256="c200d5ffc1d593083028014becba83ace43749a666f394e567435b7299566568")
     version("0.1.4", sha256="dcfcf285c9f1b1aa89db359afbf02b28d9e57a97ddac66747d3e46832e7ddbff")
 
+    depends_on("py-azure-storage-blob@12.20:12", type=("build", "run"), when="@0.1.6:")
     depends_on("py-azure-storage-blob@12.19:12", type=("build", "run"))
+    depends_on("py-azure-core@1.30.2:1", type=("build", "run"), when="@0.1.6:")
     depends_on("py-azure-core@1.29.5:1", type=("build", "run"))
+    depends_on("py-azure-identity@1.17.1:1", type=("build", "run"), when="@0.1.6:")
     depends_on("py-azure-identity@1.15:1", type=("build", "run"))
 
+    depends_on("py-snakemake-interface-common@1.17.2:1", type=("build", "run"), when="@0.1.6:")
     depends_on("py-snakemake-interface-common@1.15:1", type=("build", "run"))
+    depends_on("py-snakemake-interface-storage-plugins@3.2.3:3", type=("build", "run"), when="@0.1.6:")
     depends_on("py-snakemake-interface-storage-plugins@3", type=("build", "run"))
 
     depends_on("python@3.11:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-azure/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-azure/package.py
@@ -35,7 +35,9 @@ class PySnakemakeStoragePluginAzure(PythonPackage):
 
     depends_on("py-snakemake-interface-common@1.17.2:1", type=("build", "run"), when="@0.1.6:")
     depends_on("py-snakemake-interface-common@1.15:1", type=("build", "run"))
-    depends_on("py-snakemake-interface-storage-plugins@3.2.3:3", type=("build", "run"), when="@0.1.6:")
+    depends_on(
+        "py-snakemake-interface-storage-plugins@3.2.3:3", type=("build", "run"), when="@0.1.6:"
+    )
     depends_on("py-snakemake-interface-storage-plugins@3", type=("build", "run"))
 
     depends_on("python@3.11:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-fs/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-fs/package.py
@@ -29,7 +29,9 @@ class PySnakemakeStoragePluginFs(PythonPackage):
     depends_on("py-reretry@0.11.8:0.11", type=("build", "run"))
 
     depends_on("py-snakemake-interface-common@1.17:1", type=("build", "run"))
-    depends_on("py-snakemake-interface-storage-plugins@3.2.2:3", type=("build", "run"), when="@1.0.3:")
+    depends_on(
+        "py-snakemake-interface-storage-plugins@3.2.2:3", type=("build", "run"), when="@1.0.3:"
+    )
     depends_on("py-snakemake-interface-storage-plugins@3.1:3", type=("build", "run"))
 
     depends_on("python@3.11:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-fs/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-fs/package.py
@@ -16,12 +16,20 @@ class PySnakemakeStoragePluginFs(PythonPackage):
 
     license("MIT")
 
+    version("1.0.6", sha256="8d8ead1883d7e670b1d34ea084f7c927bb4fab71fd8d221b7478680cc09a443e")
+    version("1.0.5", sha256="4f7ce1bf16d10510f8f4a2fde2ae22d047131020bd5efa603132dabfc85f444b")
+    version("1.0.4", sha256="d9467d2d8f00689c6af6478f67f693373ce3cb0404d10c6d783997465d5110a9")
+    version("1.0.3", sha256="36086fc8a2970fd89218683655c345907a5834f07416f6c1ddf370489398f9c8")
+    version("1.0.2", sha256="d9febf6acc3aea89c9e0e5f37c32e36f96bd5fda3a41b2e8f9925a250638cb84")
+    version("1.0.1", sha256="47f27d0dad307f36cdfa7e25fa5164d3e6d313aa1c2417922cc31388d7c9ecd4")
+    version("1.0.0", sha256="de4ed37232173b604fadbf93cd84b05a8c28fa3e1d3167426bef181c7256e22c")
     version("0.2.0", sha256="cad1859036cbf429ea6fdb97f242567ec54a36d0b6ff900ce0d3ecfb6a824ae7")
 
     depends_on("py-sysrsync@1.1.1:1", type=("build", "run"))
     depends_on("py-reretry@0.11.8:0.11", type=("build", "run"))
 
     depends_on("py-snakemake-interface-common@1.17:1", type=("build", "run"))
+    depends_on("py-snakemake-interface-storage-plugins@3.2.2:3", type=("build", "run"), when="@1.0.3:")
     depends_on("py-snakemake-interface-storage-plugins@3.1:3", type=("build", "run"))
 
     depends_on("python@3.11:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-gcs/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-gcs/package.py
@@ -27,7 +27,9 @@ class PySnakemakeStoragePluginGcs(PythonPackage):
 
     depends_on("py-snakemake-interface-common@1.14.2:1", type=("build", "run"), when="@0.1.4:")
     depends_on("py-snakemake-interface-common@1", type=("build", "run"))
-    depends_on("py-snakemake-interface-storage-plugins@3.3:3", type=("build", "run"), when="@1.1.1:")
+    depends_on(
+        "py-snakemake-interface-storage-plugins@3.3:3", type=("build", "run"), when="@1.1.1:"
+    )
     depends_on("py-snakemake-interface-storage-plugins@3", type=("build", "run"))
 
     depends_on("python@3.11:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-gcs/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-gcs/package.py
@@ -15,14 +15,19 @@ class PySnakemakeStoragePluginGcs(PythonPackage):
 
     license("MIT")
 
+    version("1.1.2", sha256="417f0dfdd6c28b3ceed609c2d29d18a135039e28433d45058eb8cb7b5a7e061a")
+    version("1.1.1", sha256="ac6fc6aaf63ec6ae7453e1cb080e07da346ad4497bd2a87947c352f0fb311d31")
+    version("1.1.0", sha256="841ef25be8fa7c6f13b45fd2428c71281e05ef28ce8235f7775e19820fa4564c")
+    version("1.0.0", sha256="a5ca15813a74ae18d41cc5dbde0792e2ec5bfc32e8615d458b41dded1b430e14")
+    version("0.1.4", sha256="f8c2ebbc2b44ff5a87f7507b26bd1176de98ae80e93339b2ae65f722d17dbc24")
     version("0.1.3", sha256="f0315596120160656b8c8afec66e3b31b4a2889b9d0cead2102f9d924ec0b326")
 
     depends_on("py-google-cloud-storage@2.12:2", type=("build", "run"))
     depends_on("py-google-crc32c@1.1.2:1", type=("build", "run"))
 
-    # This is not in the package definition, but I am pretty sure that it is needed
-    # https://github.com/snakemake/snakemake-storage-plugin-gcs/issues/19
+    depends_on("py-snakemake-interface-common@1.14.2:1", type=("build", "run"), when="@0.1.4:")
     depends_on("py-snakemake-interface-common@1", type=("build", "run"))
+    depends_on("py-snakemake-interface-storage-plugins@3.3:3", type=("build", "run"), when="@1.1.1:")
     depends_on("py-snakemake-interface-storage-plugins@3", type=("build", "run"))
 
     depends_on("python@3.11:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-s3/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-s3/package.py
@@ -15,13 +15,19 @@ class PySnakemakeStoragePluginS3(PythonPackage):
 
     license("MIT")
 
+    version("0.2.12", sha256="339bd425e18baabfb1404ab91dfe56a26499bf728fa3359fb4e0b17b287786a8")
+    version("0.2.11", sha256="edbac21ca22d2e674eaadf05f21c611891df37366d4fbd6a712d79172d788895")
     version("0.2.10", sha256="a4554d170b5621751aba20ee08e6357090471a0a68b173525b118580c287a12e")
 
+    depends_on("py-boto3@1.34.63:1", type=("build", "run"), when="@0.2.12:")
     depends_on("py-boto3@1.33:1", type=("build", "run"))
+    depends_on("py-botocore@1.34.63:1", type=("build", "run"), when="@0.2.12:")
     depends_on("py-botocore@1.33:1", type=("build", "run"))
-    depends_on("py-urllib3@2:2.1", type=("build", "run"))
+    depends_on("py-urllib3@2:2.1", type=("build", "run"), when="@:0.2.11")
 
     depends_on("py-snakemake-interface-common@1.14:1", type=("build", "run"))
+    depends_on("py-snakemake-interface-storage-plugins@3.2.4:3", type=("build", "run"), when="@0.2.12:")
+    depends_on("py-snakemake-interface-storage-plugins@3.2.2:3", type=("build", "run"), when="@0.2.11:")
     depends_on("py-snakemake-interface-storage-plugins@3", type=("build", "run"))
 
     depends_on("python@3.11:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-s3/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-s3/package.py
@@ -26,8 +26,12 @@ class PySnakemakeStoragePluginS3(PythonPackage):
     depends_on("py-urllib3@2:2.1", type=("build", "run"), when="@:0.2.11")
 
     depends_on("py-snakemake-interface-common@1.14:1", type=("build", "run"))
-    depends_on("py-snakemake-interface-storage-plugins@3.2.4:3", type=("build", "run"), when="@0.2.12:")
-    depends_on("py-snakemake-interface-storage-plugins@3.2.2:3", type=("build", "run"), when="@0.2.11:")
+    depends_on(
+        "py-snakemake-interface-storage-plugins@3.2.4:3", type=("build", "run"), when="@0.2.12:"
+    )
+    depends_on(
+        "py-snakemake-interface-storage-plugins@3.2.2:3", type=("build", "run"), when="@0.2.11:"
+    )
     depends_on("py-snakemake-interface-storage-plugins@3", type=("build", "run"))
 
     depends_on("python@3.11:3", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-zenodo/package.py
+++ b/var/spack/repos/builtin/packages/py-snakemake-storage-plugin-zenodo/package.py
@@ -15,6 +15,8 @@ class PySnakemakeStoragePluginZenodo(PythonPackage):
 
     license("MIT")
 
+    version("0.1.4", sha256="f9c13b4476c8002ec15dcce69819ed65e0cca86595f6ac3ece19020c012c9526")
+    version("0.1.3", sha256="ae72ab8f866c72a63912a353923d976a7b5c91658fd9534f670691963be98e53")
     version("0.1.2", sha256="3675e76ae5dc930664bbcc1132a957c6490199c366e4e1e607d1491a7a46cf3d")
 
     depends_on("py-requests@2.31:2", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/snakemake/package.py
+++ b/var/spack/repos/builtin/packages/snakemake/package.py
@@ -10,11 +10,12 @@ class Snakemake(PythonPackage):
     """Workflow management system to create reproducible and scalable data analyses."""
 
     homepage = "https://snakemake.readthedocs.io/en"
-    pypi = "snakemake/snakemake-8.18.2.tar.gz"
+    pypi = "snakemake/snakemake-8.25.2.tar.gz"
     maintainers("marcusboden", "w8jcik")
 
     license("MIT")
 
+    version("8.25.2", sha256="d5103ba37d9747bfea584b43ddcbe7255ab3f8e2aeb222e89bcb9a40c80ae603")
     version("8.18.2", sha256="7dc8cdc3c836444c2bc3d67a4a7f4d703557c1bf96a90da18f312f4df9daefc4")
     version("8.5.2", sha256="cc94876263182277e4a429e5d371c867400eeddc791c114dfd090d1bb3158975")
     version("7.32.4", sha256="fdc3f15dd7b06fabb7da30d460e0a3b1fba08e4ea91f9c32c47a83705cdc7b6e")
@@ -57,7 +58,8 @@ class Snakemake(PythonPackage):
     depends_on("py-nbformat", type=("build", "run"))
     depends_on("py-packaging", type=("build", "run"), when="@7.29.0:")
     depends_on("py-psutil", type=("build", "run"))
-    depends_on("py-pulp@2.3.1:2.8", type=("build", "run"), when="@8.1.2:")
+    depends_on("py-pulp@2.3.1:2.9", type=("build", "run"), when="@8.22.0:")
+    depends_on("py-pulp@2.3.1:2.8", type=("build", "run"), when="@8.1.2:8.21")
     depends_on("py-pulp@2:", type=("build", "run"), when="@:8.1.1")
     depends_on("py-pyyaml", type=("build", "run"))
 
@@ -71,6 +73,9 @@ class Snakemake(PythonPackage):
     depends_on("py-smart-open@3:6", type=("build", "run"), when="@8.4.12:8.7")
     depends_on("py-smart-open@3:", type=("build", "run"))
 
+    depends_on(
+        "py-snakemake-interface-executor-plugins@9.3.2:9", type=("build", "run"), when="@8.20.6:"
+    )
     depends_on(
         "py-snakemake-interface-executor-plugins@9.2:9", type=("build", "run"), when="@8.15.0:"
     )
@@ -96,12 +101,13 @@ class Snakemake(PythonPackage):
     )
     depends_on("py-snakemake-interface-storage-plugins@3", type=("build", "run"), when="@8:")
 
+    depends_on("py-snakemake-interface-report-plugins@1.1:1", type=("build", "run"), when="@8.22:")
     depends_on("py-snakemake-interface-report-plugins@1", type=("build", "run"), when="@8.5:")
-    depends_on("py-stopit", type=("build", "run"))
+    depends_on("py-stopit", type=("build", "run"), when="@:8.19.0")
     depends_on("py-tabulate", type=("build", "run"))
     depends_on("py-throttler", type=("build", "run"), when="@7:")
-    depends_on("py-toposort@1.10:1", type=("build", "run"), when="@8.4.12:")
-    depends_on("py-toposort@1.10:", type=("build", "run"), when="@7.24.0:")
+    depends_on("py-toposort@1.10:1", type=("build", "run"), when="@8.4.12:8.21")
+    depends_on("py-toposort@1.10:", type=("build", "run"), when="@7.24.0:8.21")
     depends_on("py-toposort", type=("build", "run"), when="@:7.23")
     depends_on("py-wrapt", type=("build", "run"))
     depends_on("py-yte@1.5.1:1", type=("build", "run"), when="@7.28.1:")

--- a/var/spack/repos/builtin/packages/snakemake/package.py
+++ b/var/spack/repos/builtin/packages/snakemake/package.py
@@ -103,12 +103,8 @@ class Snakemake(PythonPackage):
 
     depends_on("py-snakemake-interface-report-plugins@1.1:1", type=("build", "run"), when="@8.22:")
     depends_on("py-snakemake-interface-report-plugins@1", type=("build", "run"), when="@8.5:")
-    depends_on("py-stopit", type=("build", "run"), when="@:8.19.0")
     depends_on("py-tabulate", type=("build", "run"))
     depends_on("py-throttler", type=("build", "run"), when="@7:")
-    depends_on("py-toposort@1.10:1", type=("build", "run"), when="@8.4.12:8.21")
-    depends_on("py-toposort@1.10:", type=("build", "run"), when="@7.24.0:8.21")
-    depends_on("py-toposort", type=("build", "run"), when="@:7.23")
     depends_on("py-wrapt", type=("build", "run"))
     depends_on("py-yte@1.5.1:1", type=("build", "run"), when="@7.28.1:")
     depends_on("py-yte@1", type=("build", "run"), when="@7:7.28.0")
@@ -141,6 +137,10 @@ class Snakemake(PythonPackage):
         depends_on("py-azure-identity", type=("build", "run"))
         depends_on("py-azure-mgmt-batch", type=("build", "run"))
 
+    depends_on("py-stopit", type=("build", "run"), when="@:8.19.0")
+    depends_on("py-toposort@1.10:1", type=("build", "run"), when="@8.4.12:8.21")
+    depends_on("py-toposort@1.10:", type=("build", "run"), when="@7.24.0:8.21")
+    depends_on("py-toposort", type=("build", "run"), when="@:7.23")
     depends_on("py-msrest", type=("build", "run"), when="@7.28.0")
     depends_on("py-filelock", type=("build", "run"), when="@:6")
     depends_on("py-ratelimiter", type=("build", "run"), when="@:6")


### PR DESCRIPTION
This PR adds `snakemake`, v8.25.2, and updates the plugins to their latest versions.

Needs:
- [x] #47525
- [x] #47528