### PR TITLE
py-boto*: add v1.34.162

### DIFF
--- a/var/spack/repos/builtin/packages/py-boto3/package.py
+++ b/var/spack/repos/builtin/packages/py-boto3/package.py
@@ -12,6 +12,7 @@ class PyBoto3(PythonPackage):
     homepage = "https://github.com/boto/boto3"
     pypi = "boto3/boto3-1.10.44.tar.gz"
 
+    version("1.34.162", sha256="873f8f5d2f6f85f1018cbb0535b03cceddc7b655b61f66a0a56995238804f41f")
     version("1.34.44", sha256="86bcf79a56631609a9f8023fe8f53e2869702bdd4c9047c6d9f091eb39c9b0fa")
     version("1.26.26", sha256="a2349d436db6f6aa1e0def5501e4884572eb6f008f35063a359a6fa8ba3539b7")
     version("1.25.5", sha256="aec7db139429fe0f3fbe723170461192b0483b0070114a4b56351e374e0f294d")
@@ -37,7 +38,8 @@ class PyBoto3(PythonPackage):
     depends_on("python@2.6:", when="@1.9:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
 
-    depends_on("py-botocore@1.34.44:1.34", when="@1.34", type=("build", "run"))
+    depends_on("py-botocore@1.34.162:1.34", when="@1.34.162", type=("build", "run"))
+    depends_on("py-botocore@1.34.44:1.34", when="@1.34.44", type=("build", "run"))
     depends_on("py-botocore@1.29.26:1.29", when="@1.26", type=("build", "run"))
     depends_on("py-botocore@1.28.5:1.28", when="@1.25", type=("build", "run"))
     depends_on("py-botocore@1.27.96:1.27", when="@1.24", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-botocore/package.py
+++ b/var/spack/repos/builtin/packages/py-botocore/package.py
@@ -12,6 +12,7 @@ class PyBotocore(PythonPackage):
     homepage = "https://github.com/boto/botocore"
     pypi = "botocore/botocore-1.13.44.tar.gz"
 
+    version("1.34.162", sha256="adc23be4fb99ad31961236342b7cbf3c0bfc62532cd02852196032e8c0d682f3")
     version("1.34.44", sha256="b0f40c54477e8e0a5c43377a927b8959a86bb8824aaef2d28db7c9c367cdefaa")
     version("1.31.41", sha256="4dad7c5a5e70940de54ebf8de3955450c1f092f43cacff8103819d1e7d5374fa")
     version("1.29.84", sha256="a36f7f6f8eae5dbd4a1cc8cb6fc747f6315500541181eff2093ee0529fc8e4bc")
@@ -48,4 +49,5 @@ class PyBotocore(PythonPackage):
     depends_on("py-urllib3@1.25.4:1.25", type=("build", "run"), when="@1.19.0:1.19.15")
     depends_on("py-urllib3@1.25.4:1.26", type=("build", "run"), when="@1.19.16:1.31.61")
     depends_on("py-urllib3@1.25.4:1.26", type=("build", "run"), when="@1.31.62: ^python@:3.9")
-    depends_on("py-urllib3@1.25.4:2.0", type=("build", "run"), when="@1.31.62: ^python@3.10:")
+    depends_on("py-urllib3@1.25.4:2.0", type=("build", "run"), when="@1.31.62:1.34.62 ^python@3.10:")
+    depends_on("py-urllib3@1.25.4:2.1,2.2.1:2", type=("build", "run"), when="@1.34.63: ^python@3.10:")

--- a/var/spack/repos/builtin/packages/py-botocore/package.py
+++ b/var/spack/repos/builtin/packages/py-botocore/package.py
@@ -49,5 +49,9 @@ class PyBotocore(PythonPackage):
     depends_on("py-urllib3@1.25.4:1.25", type=("build", "run"), when="@1.19.0:1.19.15")
     depends_on("py-urllib3@1.25.4:1.26", type=("build", "run"), when="@1.19.16:1.31.61")
     depends_on("py-urllib3@1.25.4:1.26", type=("build", "run"), when="@1.31.62: ^python@:3.9")
-    depends_on("py-urllib3@1.25.4:2.0", type=("build", "run"), when="@1.31.62:1.34.62 ^python@3.10:")
-    depends_on("py-urllib3@1.25.4:2.1,2.2.1:2", type=("build", "run"), when="@1.34.63: ^python@3.10:")
+    depends_on(
+        "py-urllib3@1.25.4:2.0", type=("build", "run"), when="@1.31.62:1.34.62 ^python@3.10:"
+    )
+    depends_on(
+        "py-urllib3@1.25.4:2.1,2.2.1:2", type=("build", "run"), when="@1.34.63: ^python@3.10:"
+    )


### PR DESCRIPTION
This PR adds `py-botocore` and `py-boto3`, v1.34.162 (the last in the 1.34 series); botocore [setup.py diff](https://github.com/boto/botocore/compare/1.34.44...1.34.162#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7), boto3 [setup.py diff](https://github.com/boto/boto3/compare/1.34.44...1.34.162#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7).

Test build:
```
-- linux-ubuntu24.10-skylake / gcc@14.2.0 -----------------------
k7dn6pa py-boto3@1.34.162 build_system=python_pip
==> 1 installed package
```

Note: I elected to not add any  v1.35 release at this time.