### PR TITLE
pixman: add v0.44.0 (switch to meson)

### DIFF
--- a/var/spack/repos/builtin/packages/pixman/package.py
+++ b/var/spack/repos/builtin/packages/pixman/package.py
@@ -18,6 +18,7 @@ class Pixman(AutotoolsPackage):
 
     license("MIT")
 
+    version("0.44.0", sha256="89a4c1e1e45e0b23dffe708202cb2eaffde0fe3727d7692b2e1739fec78a7dac")
     version("0.42.2", sha256="ea1480efada2fd948bc75366f7c349e1c96d3297d09a3fe62626e38e234a625e")
     version("0.42.0", sha256="07f74c8d95e4a43eb2b08578b37f40b7937e6c5b48597b3a0bb2c13a53f46c13")
     version("0.40.0", sha256="6d200dec3740d9ec4ec8d1180e25779c00bc749f94278c8b9021f5534db223fc")
@@ -26,11 +27,19 @@ class Pixman(AutotoolsPackage):
     version("0.34.0", sha256="21b6b249b51c6800dc9553b65106e1e37d0e25df942c90531d4c3997aa20a88e")
     version("0.32.6", sha256="3dfed13b8060eadabf0a4945c7045b7793cc7e3e910e748a8bb0f0dc3e794904")
 
-    depends_on("c", type="build")  # generated
+    build_system(
+        conditional("autotools", when="@:0.42"),
+        conditional("meson", when="@0.38:"),
+        default="meson",
+    )
 
+    depends_on("c", type="build")
+    with when("build_system=meson"):
+        depends_on("meson@0.52:", type="build")
     depends_on("pkgconfig", type="build")
     depends_on("flex", type="build")
     depends_on("bison@3:", type="build")
+
     depends_on("libpng")
 
     variant("shared", default=True, description="Build shared library")
@@ -67,6 +76,32 @@ class Pixman(AutotoolsPackage):
         return find_libraries(
             "libpixman-1", self.prefix, shared=self.spec.satisfies("+shared"), recursive=True
         )
+
+
+class MesonBuilder(spack.build_systems.meson.MesonBuilder):
+
+    def meson_args(self):
+        args = ["-Dlibpng=enabled", "-Dgtk=disabled", "-Db_staticpic=true"]
+
+        if sys.platform == "darwin":
+            args += ["-Dmmx=disabled"]
+
+            # From homebrew, see:
+            #  https://gitlab.freedesktop.org/pixman/pixman/-/issues/59
+            #  https://gitlab.freedesktop.org/pixman/pixman/-/issues/69
+            if self.spec.target.family == "aarch64":
+                args.append("-Da64-neon=disabled")
+
+        # The Fujitsu compiler does not support assembler macros.
+        if self.spec.satisfies("%fj"):
+            args.append("-Da64-neon=disabled")
+
+        args.append("-Ddefault_library=" + ("shared" if self.spec.satisfies("+shared") else "static"))
+
+        return args
+
+
+class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
 
     def configure_args(self):
         args = ["--enable-libpng", "--disable-gtk", "--with-pic"]

--- a/var/spack/repos/builtin/packages/pixman/package.py
+++ b/var/spack/repos/builtin/packages/pixman/package.py
@@ -79,7 +79,6 @@ class Pixman(AutotoolsPackage):
 
 
 class MesonBuilder(spack.build_systems.meson.MesonBuilder):
-
     def meson_args(self):
         args = ["-Dlibpng=enabled", "-Dgtk=disabled", "-Db_staticpic=true"]
 
@@ -96,13 +95,14 @@ class MesonBuilder(spack.build_systems.meson.MesonBuilder):
         if self.spec.satisfies("%fj"):
             args.append("-Da64-neon=disabled")
 
-        args.append("-Ddefault_library=" + ("shared" if self.spec.satisfies("+shared") else "static"))
+        args.append(
+            "-Ddefault_library=" + ("shared" if self.spec.satisfies("+shared") else "static")
+        )
 
         return args
 
 
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
-
     def configure_args(self):
         args = ["--enable-libpng", "--disable-gtk", "--with-pic"]
 


### PR DESCRIPTION
This PR adds `pixman`, v0.44.0, which switches to meson exclusively (removes autotools).

Test build:
```
==> Installing pixman-0.44.0-dgb2iqztvg3aokxcio2cf4e3xnfvmyuc [34/34]
==> No binary for pixman-0.44.0-dgb2iqztvg3aokxcio2cf4e3xnfvmyuc found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/89/89a4c1e1e45e0b23dffe708202cb2eaffde0fe3727d7692b2e1739fec78a7dac.tar.gz
==> No patches needed for pixman
==> pixman: Executing phase: 'meson'
==> pixman: Executing phase: 'build'
==> pixman: Executing phase: 'install'
==> pixman: Successfully installed pixman-0.44.0-dgb2iqztvg3aokxcio2cf4e3xnfvmyuc
  Stage: 0.02s.  Meson: 2.23s.  Build: 14.34s.  Install: 0.26s.  Post-install: 0.22s.  Total: 17.23s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/pixman-0.44.0-dgb2iqztvg3aokxcio2cf4e3xnfvmyuc
```

Test builds (oldest major version with meson support):
```
==> Installing pixman-0.38.4-k6bhuve6x3teg424y4xlcaktr7uk6mj6 [34/34]
==> No binary for pixman-0.38.4-k6bhuve6x3teg424y4xlcaktr7uk6mj6 found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/da/da66d6fd6e40aee70f7bd02e4f8f76fc3f006ec879d346bae6a723025cfbdde7.tar.gz
==> No patches needed for pixman
==> pixman: Executing phase: 'meson'
==> pixman: Executing phase: 'build'
==> pixman: Executing phase: 'install'
==> pixman: Successfully installed pixman-0.38.4-k6bhuve6x3teg424y4xlcaktr7uk6mj6
  Stage: 0.02s.  Meson: 1.45s.  Build: 14.30s.  Install: 0.26s.  Post-install: 0.22s.  Total: 16.44s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/pixman-0.38.4-k6bhuve6x3teg424y4xlcaktr7uk6mj6
```