### PR TITLE
xtrans: add v1.5.2

### DIFF
--- a/var/spack/repos/builtin/packages/xtrans/package.py
+++ b/var/spack/repos/builtin/packages/xtrans/package.py
@@ -19,6 +19,7 @@ class Xtrans(AutotoolsPackage, XorgPackage):
 
     maintainers("wdconinc")
 
+    version("1.5.2", sha256="23031301f10fef5eaa55b438610fbd29294a70d2fa189355343bf0186bff8374")
     version("1.5.0", sha256="a806f8a92f879dcd0146f3f1153fdffe845f2fc0df9b1a26c19312b7b0a29c86")
     version("1.4.0", sha256="48ed850ce772fef1b44ca23639b0a57e38884045ed2cbb18ab137ef33ec713f9")
     version("1.3.5", sha256="b7a577c1b6c75030145e53b4793db9c88f9359ac49e7d771d4385d21b3e5945d")


### PR DESCRIPTION
This PR adds `xtrans`, v1.5.2. No major changes for this bug fix release, but ensuring that no one adds the [broken](https://gitlab.freedesktop.org/xorg/lib/libxtrans/-/merge_requests/22) v1.5.1.

Test build:
```
==> Installing xtrans-1.5.2-u4w5istfluw725lcyyvkif5662qms64z [6/6]
==> No binary for xtrans-1.5.2-u4w5istfluw725lcyyvkif5662qms64z found: installing from source
==> Fetching https://www.x.org/archive/individual/lib/xtrans-1.5.2.tar.gz
==> No patches needed for xtrans
==> xtrans: Executing phase: 'autoreconf'
==> xtrans: Executing phase: 'configure'
==> xtrans: Executing phase: 'build'
==> xtrans: Executing phase: 'install'
==> xtrans: Successfully installed xtrans-1.5.2-u4w5istfluw725lcyyvkif5662qms64z
  Stage: 0.88s.  Autoreconf: 0.00s.  Configure: 2.41s.  Build: 0.01s.  Install: 0.03s.  Post-install: 0.11s.  Total: 3.49s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/xtrans-1.5.2-u4w5istfluw725lcyyvkif5662qms64z
```