### PR TITLE
Fix variant-related circular imports

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -714,9 +714,9 @@ def _ensure_env_methods_are_ported_to_builders(pkgs, error_cls):
     for pkg_name in pkgs:
         pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)
 
-        # values are either Value objects (for conditional values) or the values themselves
+        # values are either ConditionalValue objects or the values themselves
         build_system_names = set(
-            v.value if isinstance(v, spack.variant.Value) else v
+            v.value if isinstance(v, spack.variant.ConditionalValue) else v
             for _, variant in pkg_cls.variant_definitions("build_system")
             for v in variant.values
         )

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -64,6 +64,7 @@ __all__ = [
     "DirectiveMeta",
     "DisableRedistribute",
     "version",
+    "conditional",
     "conflicts",
     "depends_on",
     "extends",
@@ -575,6 +576,15 @@ def patch(
         cur_patches.append(patch)
 
     return _execute_patch
+
+
+def conditional(*values: List[Any], when: Optional[WhenType] = None):
+    """Conditional values that can be used in variant declarations."""
+    # _make_when_spec returns None when the condition is statically false.
+    when = _make_when_spec(when)
+    return spack.variant.ConditionalVariantValues(
+        spack.variant.Value(x, when=when) for x in values
+    )
 
 
 @directive("variants")

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -583,7 +583,7 @@ def conditional(*values: List[Any], when: Optional[WhenType] = None):
     # _make_when_spec returns None when the condition is statically false.
     when = _make_when_spec(when)
     return spack.variant.ConditionalVariantValues(
-        spack.variant.Value(x, when=when) for x in values
+        spack.variant.ConditionalValue(x, when=when) for x in values
     )
 
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -103,12 +103,7 @@ from spack.package_completions import *
 from spack.spec import InvalidSpecDetected, Spec
 from spack.util.executable import *
 from spack.util.filesystem import file_command, fix_darwin_install_name, mime_type
-from spack.variant import (
-    any_combination_of,
-    auto_or_any_combination_of,
-    conditional,
-    disjoint_sets,
-)
+from spack.variant import any_combination_of, auto_or_any_combination_of, disjoint_sets
 from spack.version import Version, ver
 
 # These are just here for editor support; they will be replaced when the build env

--- a/lib/spack/spack/test/variant.py
+++ b/lib/spack/spack/test/variant.py
@@ -762,7 +762,7 @@ def test_disjoint_set_fluent_methods():
 @pytest.mark.regression("32694")
 @pytest.mark.parametrize("other", [True, False])
 def test_conditional_value_comparable_to_bool(other):
-    value = spack.variant.Value("98", when="@1.0")
+    value = spack.variant.ConditionalValue("98", when=Spec("@1.0"))
     comparison = value == other
     assert comparison is False
 

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -775,18 +775,21 @@ def disjoint_sets(*sets):
 
 
 @functools.total_ordering
-class Value:
-    """Conditional value that might be used in variants."""
+class ConditionalValue:
+    """Conditional value for a variant."""
 
     value: Any
-    when: Optional["spack.spec.Spec"]  # optional b/c we need to know about disabled values
+
+    # optional because statically disabled values (when=False) are set to None
+    # when=True results in spack.spec.Spec()
+    when: Optional["spack.spec.Spec"]
 
     def __init__(self, value: Any, when: Optional["spack.spec.Spec"]):
         self.value = value
         self.when = when
 
     def __repr__(self):
-        return f"Value({self.value}, when={self.when})"
+        return f"ConditionalValue({self.value}, when={self.when})"
 
     def __str__(self):
         return str(self.value)

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -266,7 +266,7 @@ def _flatten(values) -> Collection:
 
     flattened: List = []
     for item in values:
-        if isinstance(item, _ConditionalVariantValues):
+        if isinstance(item, ConditionalVariantValues):
             flattened.extend(item)
         else:
             flattened.append(item)
@@ -884,15 +884,8 @@ def prevalidate_variant_value(
     )
 
 
-class _ConditionalVariantValues(lang.TypedMutableSequence):
+class ConditionalVariantValues(lang.TypedMutableSequence):
     """A list, just with a different type"""
-
-
-def conditional(*values: List[Any], when: Optional["spack.directives.WhenType"] = None):
-    """Conditional values that can be used in variant declarations."""
-    # _make_when_spec returns None when the condition is statically false.
-    when = spack.directives._make_when_spec(when)
-    return _ConditionalVariantValues([Value(x, when=when) for x in values])
 
 
 class DuplicateVariantError(error.SpecError):

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.variant import _ConditionalVariantValues
+from spack.variant import ConditionalVariantValues
 
 
 class Geant4(CMakePackage):
@@ -180,7 +180,7 @@ class Geant4(CMakePackage):
 
     def std_when(values):
         for v in values:
-            if isinstance(v, _ConditionalVariantValues):
+            if isinstance(v, ConditionalVariantValues):
                 for c in v:
                     yield (c.value, c.when)
             else:

--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -5,7 +5,7 @@
 
 
 from spack.package import *
-from spack.variant import _ConditionalVariantValues
+from spack.variant import ConditionalVariantValues
 
 
 class Vecgeom(CMakePackage, CudaPackage):
@@ -196,7 +196,7 @@ class Vecgeom(CMakePackage, CudaPackage):
 
     def std_when(values):
         for v in values:
-            if isinstance(v, _ConditionalVariantValues):
+            if isinstance(v, ConditionalVariantValues):
                 for c in v:
                     yield (c.value, c.when)
             else:


### PR DESCRIPTION
Closes #47468. Fixes two issues there:

1. `conditional()`, which defines conditional variant values, and the other ways to declare variant values should probably be in a layer above `spack.variant`. This does the simple thing and moves *just* `conditional()` to `spack.directives` to avoid a circular import. We can rethink what goes in the public package DSL soon (likely when we address #47480).

2. Variant definition code in the solver was calling `parser.quote_if_needed()` to make a spec, but it's not necessary. We can build it directly and avoid the circular import. Also rename `spack.variant.Value` to `spack.variant.ConditionalValue` to make some of the variant definition logic clearer.

This should be rebased, as it's two commits addressing two problems.