### PR TITLE
vbfnlo: add v3.0; depends on tcsh (build)

### DIFF
--- a/var/spack/repos/builtin/packages/vbfnlo/package.py
+++ b/var/spack/repos/builtin/packages/vbfnlo/package.py
@@ -55,6 +55,7 @@ class Vbfnlo(AutotoolsPackage):
     depends_on("autoconf", type="build")
     depends_on("m4", type="build")
     depends_on("libtool", type="build")
+    # needed as tcsh is hardcoded in m4/vbfnlo.m4, could be patched out in the future
     depends_on("tcsh", type="build")
 
     @when("@2.7.1")

--- a/var/spack/repos/builtin/packages/vbfnlo/package.py
+++ b/var/spack/repos/builtin/packages/vbfnlo/package.py
@@ -41,7 +41,6 @@ class Vbfnlo(AutotoolsPackage):
 
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
-    # version('2.7.0',      sha256='0e96c0912599e3000fffec5305700b947b604a7b06c7975851503f445311e4ef')
 
     # Documentation is broken on some systems:
     # See https://github.com/vbfnlo/vbfnlo/issues/2
@@ -55,6 +54,7 @@ class Vbfnlo(AutotoolsPackage):
     depends_on("autoconf", type="build")
     depends_on("m4", type="build")
     depends_on("libtool", type="build")
+    depends_on("tcsh", type="build")
 
     @when("@2.7.1")
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/vbfnlo/package.py
+++ b/var/spack/repos/builtin/packages/vbfnlo/package.py
@@ -20,6 +20,7 @@ class Vbfnlo(AutotoolsPackage):
     license("GPL-2.0-only")
 
     # The commented out versions exist, but are not tested
+    version("3.0", sha256="b9df02603e4f801f866360c720191a29afdb958d0bd4369ea7d810e761503e51")
     version(
         "3.0.0beta5", sha256="777a3dedb365ea9abc38848a60f30d325da3799cbad69fa308664b94a8c31a90"
     )


### PR DESCRIPTION
This PR adds to `vbfnlo` a build dependency on `tcsh` (because `tcsh -cf 'echo $HOSTTYPE'` couldn't just be `echo $HOSTTYPE` in https://github.com/vbfnlo/vbfnlo/blob/master/m4/vbfnlo.m4...). Also removed commented version.

Also added v3.0, while I was editing this package anyway.

Test build:
```
==> Installing vbfnlo-3.0-w3tffni2wtgkd4fwvejejxkgax5ec5fy [42/42]
==> No binary for vbfnlo-3.0-w3tffni2wtgkd4fwvejejxkgax5ec5fy found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/b9/b9df02603e4f801f866360c720191a29afdb958d0bd4369ea7d810e761503e51.tar.gz
==> No patches needed for vbfnlo
==> vbfnlo: Executing phase: 'autoreconf'
==> vbfnlo: Executing phase: 'configure'
==> vbfnlo: Executing phase: 'build'
==> vbfnlo: Executing phase: 'install'
==> vbfnlo: Successfully installed vbfnlo-3.0-w3tffni2wtgkd4fwvejejxkgax5ec5fy
  Stage: 0.35s.  Autoreconf: 13.77s.  Configure: 6.36s.  Build: 19m 46.22s.  Install: 6.61s.  Post-install: 0.42s.  Total: 20m 13.95s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/vbfnlo-3.0-w3tffni2wtgkd4fwvejejxkgax5ec5fy
```
