### PR TITLE
py-gosam: add v2.1.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-gosam/package.py
+++ b/var/spack/repos/builtin/packages/py-gosam/package.py
@@ -21,6 +21,11 @@ class PyGosam(Package):
     license("GPL-3.0-only")
 
     version(
+        "2.1.2",
+        url="https://github.com/gudrunhe/gosam/releases/download/2.1.2/gosam-2.1.2+c307997.tar.gz",
+        sha256="53601ab203c3d572764439018f976baff9c83b87abe1fcbbe15c07caf174680c",
+    )
+    version(
         "2.1.1",
         url="https://github.com/gudrunhe/gosam/releases/download/2.1.1/gosam-2.1.1-4b98559.tar.gz",
         sha256="4a2b9160d51e3532025b9579a4d17d0e0f8a755b8481aeb8271c1f58eb97ab01",


### PR DESCRIPTION
This PR adds `py-gosam`, v2.1.2. No changes needed to package recipe.

Test build:
```
==> Installing py-gosam-2.1.2-2qtk6moammio66kiodircfulxhmyjoml [29/29]
==> No binary for py-gosam-2.1.2-2qtk6moammio66kiodircfulxhmyjoml found: installing from source
==> Fetching https://github.com/gudrunhe/gosam/releases/download/2.1.2/gosam-2.1.2+c307997.tar.gz
==> No patches needed for py-gosam
==> py-gosam: Executing phase: 'install'
==> py-gosam: Successfully installed py-gosam-2.1.2-2qtk6moammio66kiodircfulxhmyjoml
  Stage: 1.12s.  Install: 0.39s.  Post-install: 0.35s.  Total: 1.94s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/py-gosam-2.1.2-2qtk6moammio66kiodircfulxhmyjoml
```