### PR TITLE
font-util: replace find with glob to find dirs

### DIFF
--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -253,7 +253,7 @@ class FontUtil(AutotoolsPackage, XorgPackage):
         autoreconf = which("autoreconf")
 
         for font in fonts:
-            fontroot = find(font, "*", recursive=False)
+            fontroot = gob.glob(join_path(font, "*"))
             with working_dir(fontroot[0]):
                 autoreconf(*autoconf_args)
                 configure = Executable("./configure")

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import glob
+
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -255,7 +255,7 @@ class FontUtil(AutotoolsPackage, XorgPackage):
         autoreconf = which("autoreconf")
 
         for font in fonts:
-            fontroot = gob.glob(join_path(font, "*"))
+            fontroot = glob.glob(join_path(font, "*"))
             with working_dir(fontroot[0]):
                 autoreconf(*autoconf_args)
                 configure = Executable("./configure")

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import glob
 from spack.package import *
 
 


### PR DESCRIPTION
This PR fixes a regression in `font-util` due to #47495, which stopped returning directories from `find`, resulting in https://gitlab.spack.io/spack/spack/-/jobs/13474310.

Instead of running a non-recursive `find`, this modifies the `font-util` package to use a `glob`.