### PR TITLE
environment-modules: add version 5.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -13,12 +13,13 @@ class EnvironmentModules(Package):
     """
 
     homepage = "https://cea-hpc.github.io/modules/"
-    url = "https://github.com/cea-hpc/modules/releases/download/v5.4.0/modules-5.4.0.tar.gz"
+    url = "https://github.com/cea-hpc/modules/releases/download/v5.5.0/modules-5.5.0.tar.gz"
     git = "https://github.com/cea-hpc/modules.git"
 
     maintainers("xdelaruelle")
 
     version("main", branch="main")
+    version("5.5.0", sha256="ad0e360c7adc2515a99836863d98499b3ad89cd7548625499b20293845b040cb")
     version("5.4.0", sha256="586245cbf9420866078d8c28fce8ef4f192530c69a0f368f51e848340dcf3b90")
     version("5.3.1", sha256="d02f9ce4f8baf6c99edceb7c73bfdd1e97d77bcc4725810b86efed9f58dda962")
     version("5.3.0", sha256="21b8daa0181044ef65097a1e3517af1f24e7c7343cc5bdaf70be11e3cb0edb51")
@@ -62,6 +63,7 @@ class EnvironmentModules(Package):
 
     variant("X", default=True, description="Build with X functionality")
 
+    depends_on("util-linux", type=("build", "run"), when="@5.5:")
     depends_on("less", type=("build", "run"), when="@4.1:")
     with when("@main"):
         depends_on("autoconf", type="build")
@@ -75,7 +77,8 @@ class EnvironmentModules(Package):
     # Dependencies:
     depends_on("tcl", type=("build", "link", "run"))
     depends_on("tcl@8.4:", type=("build", "link", "run"), when="@4.0.0:4.8")
-    depends_on("tcl@8.5:", type=("build", "link", "run"), when="@5.0.0:")
+    depends_on("tcl@8.5:8", type=("build", "link", "run"), when="@5.0.0:5.4.0")
+    depends_on("tcl@8.5:", type=("build", "link", "run"), when="@5.5.0:")
 
     def install(self, spec, prefix):
         tcl = spec["tcl"]
@@ -94,6 +97,9 @@ class EnvironmentModules(Package):
 
         if spec.satisfies("~X"):
             config_args = ["--without-x"] + config_args
+
+        if self.spec.satisfies("@5.5.0:"):
+            config_args.extend(["--enable-conflict-unload"])
 
         if self.spec.satisfies("@4.4.0:4.8"):
             config_args.extend(
@@ -139,6 +145,9 @@ class EnvironmentModules(Package):
                     "--disable-versioning",
                 ]
             )
+
+        if self.spec.satisfies("@5.5:"):
+            config_args.append(f"--with-logger={str(self.spec['util-linux'].prefix.bin.logger)}")
 
         if self.spec.satisfies("@4.1:"):
             config_args.append(f"--with-pager={str(self.spec['less'].prefix.bin.less)}")


### PR DESCRIPTION
New feature release in the v5 series.

Major new features included: https://modules.readthedocs.io/en/stable/MIGRATING.html#v5-5

This new version is compatible with Tcl 9.0. It also requires 'util-linux' for new logging capabilities.