### PR TITLE
py-cryptography: add v43.0.3 (switch to maturin)

### DIFF
--- a/var/spack/repos/builtin/packages/py-cryptography/package.py
+++ b/var/spack/repos/builtin/packages/py-cryptography/package.py
@@ -44,6 +44,10 @@ class PyCryptography(PythonPackage):
     depends_on("py-setuptools@11.3:", when="@:2.1", type="build")
     with when("@43:"):
         depends_on("py-maturin@1", type="build")
+        conflicts(
+            "^py-setuptools@74.0.0,74.1.0,74.1.1,74.1.2,74.1.3,75.0.0,75.1.0,75.2.0",
+            msg="some setuptools version are incompatible",
+        )
     with when("@:42"):
         depends_on("py-setuptools-rust@1.7.0:", when="@42:", type=("build", "run"))
         depends_on("py-setuptools-rust@0.11.4:", when="@3.4.2:", type="build")

--- a/var/spack/repos/builtin/packages/py-cryptography/package.py
+++ b/var/spack/repos/builtin/packages/py-cryptography/package.py
@@ -15,6 +15,7 @@ class PyCryptography(PythonPackage):
 
     license("Apache-2.0")
 
+    version("43.0.3", sha256="315b9001266a492a6ff443b61238f956b214dbec9910a081ba5b6646a055a805")
     version("42.0.8", sha256="8d09d05439ce7baa8e9e95b07ec5b6c886f548deb7e0f69ef25f64b3bce842f2")
     version("41.0.7", sha256="13f93ce9bea8016c253b34afc6bd6a75993e5c40672ed5405a9c832f0d4a00bc")
     version("41.0.3", sha256="6d192741113ef5e30d89dcb5b956ef4e1578f304708701b8b73d38e3e1461f34")
@@ -41,9 +42,12 @@ class PyCryptography(PythonPackage):
     depends_on("py-setuptools@40.6:", when="@2.7:36", type="build")
     depends_on("py-setuptools@18.5:", when="@2.2:2.6", type="build")
     depends_on("py-setuptools@11.3:", when="@:2.1", type="build")
-    depends_on("py-setuptools-rust@1.7.0:", when="@42:", type=("build", "run"))
-    depends_on("py-setuptools-rust@0.11.4:", when="@3.4.2:", type="build")
-    depends_on("py-setuptools-rust@0.11.4:", when="@3.4:3.4.1", type=("build", "run"))
+    with when("@43:"):
+        depends_on("py-maturin@1", type="build")
+    with when("@:42"):
+        depends_on("py-setuptools-rust@1.7.0:", when="@42:", type=("build", "run"))
+        depends_on("py-setuptools-rust@0.11.4:", when="@3.4.2:", type="build")
+        depends_on("py-setuptools-rust@0.11.4:", when="@3.4:3.4.1", type=("build", "run"))
     depends_on("rust@1.56:", when="@41:", type="build")
     depends_on("rust@1.48:", when="@38:", type="build")
     depends_on("rust@1.41:", when="@3.4.5:", type="build")

--- a/var/spack/repos/builtin/packages/py-cryptography/package.py
+++ b/var/spack/repos/builtin/packages/py-cryptography/package.py
@@ -49,7 +49,7 @@ class PyCryptography(PythonPackage):
             msg="some setuptools version are incompatible",
         )
     with when("@:42"):
-        depends_on("py-setuptools-rust@1.7.0:", when="@42:", type=("build", "run"))
+        depends_on("py-setuptools-rust@1.7.0:", when="@42", type=("build", "run"))
         depends_on("py-setuptools-rust@0.11.4:", when="@3.4.2:", type="build")
         depends_on("py-setuptools-rust@0.11.4:", when="@3.4:3.4.1", type=("build", "run"))
     depends_on("rust@1.56:", when="@41:", type="build")


### PR DESCRIPTION
This PR adds `py-cryptography`, v43.0.3 ([full diff](https://github.com/pyca/cryptography/compare/42.0.8...43.0.3), [pyproject.toml](https://github.com/pyca/cryptography/compare/42.0.8...43.0.3#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711)), which switches to using `py-maturin` for the rust build.

Test build:
```
==> Installing py-cryptography-43.0.3-4tybwshpuj5q633sb4t4oqg2mldwvzao [44/44]
==> No binary for py-cryptography-43.0.3-4tybwshpuj5q633sb4t4oqg2mldwvzao found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/31/315b9001266a492a6ff443b61238f956b214dbec9910a081ba5b6646a055a805.tar.gz
==> No patches needed for py-cryptography
==> py-cryptography: Executing phase: 'install'
==> py-cryptography: Successfully installed py-cryptography-43.0.3-4tybwshpuj5q633sb4t4oqg2mldwvzao
  Stage: 0.15s.  Install: 3m 37.80s.  Post-install: 1.56s.  Total: 3m 40.47s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/py-cryptography-43.0.3-4tybwshpuj5q633sb4t4oqg2mldwvzao
```