### PR TITLE
xfsprogs: fix dependency on gettext

### DIFF
--- a/var/spack/repos/builtin/packages/xfsprogs/package.py
+++ b/var/spack/repos/builtin/packages/xfsprogs/package.py
@@ -24,7 +24,7 @@ class Xfsprogs(AutotoolsPackage):
     depends_on("c", type="build")  # generated
 
     depends_on("libinih")
-    depends_on("gettext")
+    depends_on("gettext@:0.21.1")
     depends_on("uuid")
     depends_on("util-linux")
 
@@ -32,7 +32,7 @@ class Xfsprogs(AutotoolsPackage):
         if name == "cflags":
             if self.spec.satisfies("@:5.4.0 %gcc@10:"):
                 flags.append("-fcommon")
-        elif name == "ldlibs":
+        elif name == "ldlibs" or name == "ldflags":
             if "intl" in self.spec["gettext"].libs.names:
                 flags.append("-lintl")
         return build_system_flags(name, flags)

--- a/var/spack/repos/builtin/packages/xfsprogs/package.py
+++ b/var/spack/repos/builtin/packages/xfsprogs/package.py
@@ -24,7 +24,8 @@ class Xfsprogs(AutotoolsPackage):
     depends_on("c", type="build")  # generated
 
     depends_on("libinih")
-    depends_on("gettext@:0.21.1")
+    depends_on("gettext")
+    depends_on("gettext@:0.21.1", when="@:6.3")
     depends_on("uuid")
     depends_on("util-linux")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

xfsprogs currently fails to build, complaining about not finding symbols from the gettext library (more specifically libintl). This PR fixes the problem by correctly adding the path to ldflags (the original package added it to ldlibs, but it doesn't seem to be sufficient). Additionally, xfsprogs fails to build with gettext versions 0.22.x (apparently due to a bug in gettext), so the PR also forces the version to be up to 0.21.1.