### PR TITLE
py-constantly: add v23.10.4

### DIFF
--- a/var/spack/repos/builtin/packages/arrow/package.py
+++ b/var/spack/repos/builtin/packages/arrow/package.py
@@ -17,6 +17,7 @@ class Arrow(CMakePackage, CudaPackage):
 
     license("Apache-2.0")
 
+    version("18.0.0", sha256="9c473f2c9914c59ab571761c9497cf0e5cfd3ea335f7782ccc6121f5cb99ae9b")
     version("16.1.0", sha256="9762d9ecc13d09de2a03f9c625a74db0d645cb012de1e9a10dfed0b4ddc09524")
     version("15.0.2", sha256="4735b349845bff1fe95ed11abbfed204eb092cabc37523aa13a80cb830fe5b5e")
     version("14.0.2", sha256="07cdb4da6795487c800526b2865c150ab7d80b8512a31793e6a7147c8ccd270f")

--- a/var/spack/repos/builtin/packages/py-constantly/package.py
+++ b/var/spack/repos/builtin/packages/py-constantly/package.py
@@ -18,4 +18,4 @@ class PyConstantly(PythonPackage):
     version("15.1.0", sha256="586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-versioneer@0.29", type="build", when="@23.10.4:")
+    depends_on("py-versioneer+toml@0.29", type="build", when="@23.10.4:")

--- a/var/spack/repos/builtin/packages/py-constantly/package.py
+++ b/var/spack/repos/builtin/packages/py-constantly/package.py
@@ -18,4 +18,4 @@ class PyConstantly(PythonPackage):
     version("15.1.0", sha256="586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-versioneer@0.29", type="build")
+    depends_on("py-versioneer@0.29", type="build", when="@23.10.4:")

--- a/var/spack/repos/builtin/packages/py-constantly/package.py
+++ b/var/spack/repos/builtin/packages/py-constantly/package.py
@@ -14,6 +14,8 @@ class PyConstantly(PythonPackage):
 
     license("MIT")
 
+    version("23.10.4", sha256="aa92b70a33e2ac0bb33cd745eb61776594dc48764b06c35e0efd050b7f1c7cbd")
     version("15.1.0", sha256="586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35")
 
     depends_on("py-setuptools", type="build")
+    depends_on("py-versioneer@0.29", type="build")

--- a/var/spack/repos/builtin/packages/thrift/package.py
+++ b/var/spack/repos/builtin/packages/thrift/package.py
@@ -65,6 +65,7 @@ class Thrift(Package):
     depends_on("ant", when="+java")
 
     extends("python", when="+python")
+    depends_on("python@:3.11.9", when="+python")
     depends_on("py-setuptools", type=("build", "run"), when="+python")
     depends_on("py-six@1.7.2:", type=("build", "run"), when="@0.10.0:+python")
     depends_on("py-tornado", type=("build", "run"), when="+python")

--- a/var/spack/repos/builtin/packages/xfsprogs/package.py
+++ b/var/spack/repos/builtin/packages/xfsprogs/package.py
@@ -14,6 +14,7 @@ class Xfsprogs(AutotoolsPackage):
 
     license("LGPL-2.1-or-later")
 
+    version("6.11.0", sha256="dae3bb432196f7b183b2e6bd5dc44bf33edbd7d0e85bd37d25c235df81b8100a")
     version("5.11.0", sha256="0e9c390fcdbb8a79e1b8f5e6e25fd529fc9f9c2ef8f2d5e647b3556b82d1b353")
     version("5.8.0", sha256="8ef46ed9e6bb927f407f541dc4324857c908ddf1374265edc910d23724048c6b")
     version("5.7.0", sha256="8f2348a68a686a3f4491dda5d62dd32d885fbc52d32875edd41e2c296e7b4f35")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds version 23.10.4. Note that version 15.1.0 fails to build (at least on my machine); I'm not going to dig into why, since 23.10.4 works fine.