### PR TITLE
parse_specs: special case for concretizing lookups quickly

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -9,7 +9,7 @@ import os
 import re
 import sys
 from collections import Counter
-from typing import Dict, List, Set, Union
+from typing import List, Union
 
 import llnl.string
 import llnl.util.tty as tty

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -184,17 +184,17 @@ def parse_specs(
 
     # Special case if every spec has an abstract spec
     if all(spec.concrete or spec.abstract_hash for spec in specs):
-        ret = [s.concretized() for s in specs]
+        ret = [s.lookup_hash() for s in specs]
 
         unify = spack.config.get("concretizer:unify", False)
         if unify is True:  # True, "when_possible", False are possible values
+            runtimes = spack.repo.PATH.packages_with_tags("runtime")
             specs_per_name = Counter(
                 spec.name
                 for spec in traverse.traverse_nodes(
                     ret, deptype=("link", "run"), key=traverse.by_dag_hash
                 )
-                # TODO: make this less special -- client code shouldn't need to know this.
-                if spec.name != "gcc-runtime"  # gcc runtime is special and allowed multiples
+                if spec.name not in runtimes  # runtimes are allowed multiple times
             )
 
             conflicts = sorted(name for name, count in specs_per_name.items() if count > 1)

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -184,7 +184,7 @@ def parse_specs(
 
     # Special case if every spec has an abstract spec
     if all(spec.concrete or spec.abstract_hash for spec in specs):
-        ret = [s.lookup_hash() for s in specs]
+        ret = [s if s.concrete else s.lookup_hash() for s in specs]
 
         unify = spack.config.get("concretizer:unify", False)
         if unify is True:  # True, "when_possible", False are possible values

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -189,10 +189,9 @@ def parse_specs(
         unify = spack.config.get("concretizer:unify", False)
         if unify is True:  # True, "when_possible", False are possible values
             specs_per_name = Counter(
-                dep.name
-                for spec in ret
-                for dep in spec.traverse(deptype=("link", "run"))
-                if dep.name != "gcc-runtime"  # gcc runtime is special and allowed multiples
+                spec.name
+                for spec in traverse.traverse_nodes(ret, deptype=("link", "run"))
+                if spec.name != "gcc-runtime"  # gcc runtime is special and allowed multiples
             )
             if any(count > 1 for count in specs_per_name.values()):
                 msg = "Specs conflict and `concretizer:unify` is configured true.\n"

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -180,7 +180,7 @@ def parse_specs(
 
     # Special case for concretizing a single spec
     if len(specs) == 1:
-        return specs[0].concretized()
+        return [specs[0].concretized()]
 
     # Special case if every spec has an abstract spec
     if all(spec.concrete or spec.abstract_hash for spec in specs):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -59,7 +59,7 @@ import platform
 import re
 import socket
 import warnings
-from typing import Any, Callable, Dict, List, Match, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Match, Optional, Set, Tuple, Union
 
 import archspec.cpu
 
@@ -2828,7 +2828,7 @@ class Spec:
             msg += "    For each package listed, choose another spec\n"
             raise SpecDeprecatedError(msg)
 
-    def concretize(self, tests: Union[bool, List[str]] = False) -> None:
+    def concretize(self, tests: Union[bool, Iterable[str]] = False) -> None:
         """Concretize the current spec.
 
         Args:
@@ -2956,7 +2956,7 @@ class Spec:
         for spec in self.traverse():
             spec._cached_hash(ht.dag_hash)
 
-    def concretized(self, tests: bool = False) -> "spack.spec.Spec":
+    def concretized(self, tests: Union[bool, Iterable[str]] = False) -> "spack.spec.Spec":
         """This is a non-destructive version of concretize().
 
         First clones, then returns a concrete version of this package

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2956,7 +2956,7 @@ class Spec:
         for spec in self.traverse():
             spec._cached_hash(ht.dag_hash)
 
-    def concretized(self, tests=False):
+    def concretized(self, tests: bool = False) -> "spack.spec.Spec":
         """This is a non-destructive version of concretize().
 
         First clones, then returns a concrete version of this package

--- a/lib/spack/spack/test/cmd/init_py_functions.py
+++ b/lib/spack/spack/test/cmd/init_py_functions.py
@@ -4,10 +4,15 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import pytest
 
+import spack.environment as ev
+import spack.error
+import spack.solver.asp as asp
 from spack.cmd import (
     CommandNameError,
     PythonNameError,
     cmd_name,
+    matching_specs_from_env,
+    parse_specs,
     python_name,
     require_cmd_name,
     require_python_name,
@@ -34,3 +39,99 @@ def test_require_cmd_name():
     with pytest.raises(CommandNameError):
         require_cmd_name("okey_dokey")
     require_cmd_name(cmd_name("okey_dokey"))
+
+
+@pytest.mark.parametrize(
+    "unify,spec_strs,error",
+    [
+        # single spec
+        (True, ["zmpi"], None),
+        (False, ["mpileaks"], None),
+        # multiple specs, some from hash some from file
+        (True, ["zmpi", "mpileaks^zmpi", "libelf"], None),
+        (True, ["mpileaks^zmpi", "mpileaks^mpich", "libelf"], spack.error.SpecError),
+        (False, ["mpileaks^zmpi", "mpileaks^mpich", "libelf"], None),
+    ],
+)
+def test_special_cases_concretization_parse_specs(
+    unify, spec_strs, error, monkeypatch, mutable_config, mutable_database, tmpdir
+):
+    """Test that special cases in parse_specs(concretize=True) bypass solver"""
+
+    # monkeypatch to ensure we do not call the actual concretizer
+    def _fail(*args, **kwargs):
+        assert False
+
+    monkeypatch.setattr(asp.SpackSolverSetup, "setup", _fail)
+
+    spack.config.set("concretizer:unify", unify)
+
+    args = [f"/{spack.store.STORE.db.query(s)[0].dag_hash()}" for s in spec_strs]
+    if len(args) > 1:
+        # We convert the last one to a specfile input
+        filename = tmpdir.join("spec.json")
+        spec = parse_specs(args[-1], concretize=True)[0]
+        with open(filename, "w") as f:
+            spec.to_json(f)
+        args[-1] = str(filename)
+
+    if error:
+        with pytest.raises(error):
+            parse_specs(args, concretize=True)
+    else:
+        # assertion error from monkeypatch above if test fails
+        parse_specs(args, concretize=True)
+
+
+@pytest.mark.parametrize(
+    "unify,spec_strs,error",
+    [
+        # single spec
+        (True, ["zmpi"], None),
+        (False, ["mpileaks"], None),
+        # multiple specs, some from hash some from file
+        (True, ["zmpi", "mpileaks^zmpi", "libelf"], None),
+        (True, ["mpileaks^zmpi", "mpileaks^mpich", "libelf"], spack.error.SpecError),
+        (False, ["mpileaks^zmpi", "mpileaks^mpich", "libelf"], None),
+    ],
+)
+def test_special_cases_concretization_matching_specs_from_env(
+    unify,
+    spec_strs,
+    error,
+    monkeypatch,
+    mutable_config,
+    mutable_database,
+    tmpdir,
+    mutable_mock_env_path,
+):
+    """Test that special cases in parse_specs(concretize=True) bypass solver"""
+
+    # monkeypatch to ensure we do not call the actual concretizer
+    def _fail(*args, **kwargs):
+        assert False
+
+    monkeypatch.setattr(asp.SpackSolverSetup, "setup", _fail)
+
+    spack.config.set("concretizer:unify", unify)
+
+    ev.create("test")
+    env = ev.read("test")
+
+    args = [f"/{spack.store.STORE.db.query(s)[0].dag_hash()}" for s in spec_strs]
+    if len(args) > 1:
+        # We convert the last one to a specfile input
+        filename = tmpdir.join("spec.json")
+        spec = parse_specs(args[-1], concretize=True)[0]
+        with open(filename, "w") as f:
+            spec.to_json(f)
+        args[-1] = str(filename)
+
+    with env:
+        specs = parse_specs(args, concretize=False)
+        if error:
+            with pytest.raises(error):
+                matching_specs_from_env(specs)
+        else:
+            # assertion error from monkeypatch above if test fails
+            matching_specs_from_env(specs)


### PR DESCRIPTION
#44843 added unification semantics for parsing specs from the CLI, but there are a couple special cases in which we can avoid calls to the concretizer for speed when the specs can all be resolved by lookups.

special case 1: solving a single spec

special case 2: all specs are either concrete (come from a file) or have an abstract hash. In this case if `concretizer:unify:true` we need an additional check to confirm the specs are compatible.

