### PR TITLE
Add json output option to `spack compiler info`

### DIFF
--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -14,6 +14,7 @@ from llnl.util.tty.color import colorize
 import spack.compilers
 import spack.config
 import spack.spec
+import spack.util.spack_json as sjson
 from spack.cmd.common import arguments
 
 description = "manage compilers"
@@ -74,6 +75,7 @@ def setup_parser(subparser):
     info_parser.add_argument(
         "--scope", action=arguments.ConfigScope, help="configuration scope to read from"
     )
+    info_parser.add_argument("--json", action="store_true", help="output info in JSON format")
 
 
 def compiler_find(args):
@@ -126,27 +128,30 @@ def compiler_info(args):
     if not compilers:
         tty.die("No compilers match spec %s" % cspec)
     else:
-        for c in compilers:
-            print(c.spec.display_str + ":")
-            print("\tpaths:")
-            for cpath in ["cc", "cxx", "f77", "fc"]:
-                print("\t\t%s = %s" % (cpath, getattr(c, cpath, None)))
-            if c.flags:
-                print("\tflags:")
-                for flag, flag_value in c.flags.items():
-                    print("\t\t%s = %s" % (flag, flag_value))
-            if len(c.environment) != 0:
-                if len(c.environment.get("set", {})) != 0:
-                    print("\tenvironment:")
-                    print("\t    set:")
-                    for key, value in c.environment["set"].items():
-                        print("\t        %s = %s" % (key, value))
-            if c.extra_rpaths:
-                print("\tExtra rpaths:")
-                for extra_rpath in c.extra_rpaths:
-                    print("\t\t%s" % extra_rpath)
-            print("\tmodules  = %s" % c.modules)
-            print("\toperating system  = %s" % c.operating_system)
+        if args.json:
+            print(sjson.dump([c.to_dict() for c in compilers]))
+        else:
+            for c in compilers:
+                print(c.spec.display_str + ":")
+                print("\tpaths:")
+                for cpath in ["cc", "cxx", "f77", "fc"]:
+                    print("\t\t%s = %s" % (cpath, getattr(c, cpath, None)))
+                if c.flags:
+                    print("\tflags:")
+                    for flag, flag_value in c.flags.items():
+                        print("\t\t%s = %s" % (flag, flag_value))
+                if len(c.environment) != 0:
+                    if len(c.environment.get("set", {})) != 0:
+                        print("\tenvironment:")
+                        print("\t    set:")
+                        for key, value in c.environment["set"].items():
+                            print("\t        %s = %s" % (key, value))
+                if c.extra_rpaths:
+                    print("\tExtra rpaths:")
+                    for extra_rpath in c.extra_rpaths:
+                        print("\t\t%s" % extra_rpath)
+                print("\tmodules  = %s" % c.modules)
+                print("\toperating system  = %s" % c.operating_system)
 
 
 def compiler_list(args):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -792,7 +792,7 @@ _spack_compiler_list() {
 _spack_compiler_info() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope"
+        SPACK_COMPREPLY="-h --help --scope --json"
     else
         _installed_compilers
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1114,12 +1114,14 @@ complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -f -
 complete -c spack -n '__fish_spack_using_command compiler list' -l scope -r -d 'configuration scope to read from'
 
 # spack compiler info
-set -g __fish_spack_optspecs_spack_compiler_info h/help scope=
+set -g __fish_spack_optspecs_spack_compiler_info h/help scope= json
 complete -c spack -n '__fish_spack_using_command_pos 0 compiler info' -f -a '(__fish_spack_installed_compilers)'
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command compiler info' -s h -l help -d 'show this help message and exit'
 complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -f -a '_builtin defaults system site user command_line'
 complete -c spack -n '__fish_spack_using_command compiler info' -l scope -r -d 'configuration scope to read from'
+complete -c spack -n '__fish_spack_using_command compiler info' -l json -f -a json
+complete -c spack -n '__fish_spack_using_command compiler info' -l json -d 'output info in JSON format'
 
 # spack compilers
 set -g __fish_spack_optspecs_spack_compilers h/help scope=


### PR DESCRIPTION
This PR adds the option `--json` to the `spack compiler info` command, which allows structured processing of the result using e.g. `jq`.