### PR TITLE
py-blosc2: use external libblosc2

### DIFF
--- a/var/spack/repos/builtin/packages/py-blosc2/package.py
+++ b/var/spack/repos/builtin/packages/py-blosc2/package.py
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import shlex
+
+from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
 
 
@@ -18,16 +21,27 @@ class PyBlosc2(PythonPackage):
     version("2.2.8", sha256="59065aac5e9b01b0e9f3825d8e7f69f64b59bbfab148a47c54e4115f62a97474")
     version("2.0.0", sha256="f19b0b3674f6c825b490f00d8264b0c540c2cdc11ec7e81178d38b83c57790a1")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("python@3.9:3", when="@2.2:", type=("build", "link", "run"))
     depends_on("python@3.8:3", when="@2.0", type=("build", "link", "run"))
-    depends_on("py-setuptools", type="build")
-    depends_on("py-scikit-build", type="build")
-    depends_on("py-cython", type="build")
-    depends_on("cmake@3.11:", type="build")
-    depends_on("ninja", type="build")
     depends_on("py-numpy@1.20.3:", type=("build", "link", "run"))
     depends_on("py-ndindex@1.4:", when="@2.2:", type=("build", "run"))
     depends_on("py-msgpack", type=("build", "run"))
     depends_on("py-py-cpuinfo", when="@2.2:", type=("build", "run"))
+    depends_on("c-blosc2", type="link")
+
+    with default_args(type="build"):
+        depends_on("py-setuptools")
+        depends_on("py-scikit-build")
+        depends_on("py-cython")
+        depends_on("cmake@3.11:")
+        depends_on("ninja")
+
+        depends_on("pkgconfig", type="build")
+
+    def setup_build_environment(self, env):
+        cmake_args = [*CMakeBuilder.std_args(self), CMakeBuilder.define("USE_SYSTEM_BLOSC2", True)]
+        # scikit-build does not want a CMAKE_INSTALL_PREFIX
+        cmake_args = [arg for arg in cmake_args if "CMAKE_INSTALL_PREFIX" not in arg]
+        env.set("SKBUILD_CONFIGURE_OPTIONS", " ".join(shlex.quote(arg) for arg in cmake_args))

--- a/var/spack/repos/builtin/packages/py-blosc2/package.py
+++ b/var/spack/repos/builtin/packages/py-blosc2/package.py
@@ -37,8 +37,7 @@ class PyBlosc2(PythonPackage):
         depends_on("py-cython")
         depends_on("cmake@3.11:")
         depends_on("ninja")
-
-        depends_on("pkgconfig", type="build")
+        depends_on("pkgconfig")
 
     def setup_build_environment(self, env):
         cmake_args = [*CMakeBuilder.std_args(self), CMakeBuilder.define("USE_SYSTEM_BLOSC2", True)]

--- a/var/spack/repos/builtin/packages/py-tables/package.py
+++ b/var/spack/repos/builtin/packages/py-tables/package.py
@@ -31,8 +31,8 @@ class PyTables(PythonPackage):
     depends_on("cxx", type="build")  # generated
 
     variant("zlib", default=True, description="Support for zlib compression")
-    variant("bzip2", default=False, description="Support for bzip2 compression")
-    variant("lzo", default=False, description="Support for lzo compression")
+    variant("bzip2", default=True, description="Support for bzip2 compression")
+    variant("lzo", default=True, description="Support for lzo compression")
 
     # pyproject.toml
     depends_on("py-setuptools@61:", when="@3.9:", type="build")
@@ -64,6 +64,9 @@ class PyTables(PythonPackage):
     # problem in a multithreaded environment.
     depends_on("c-blosc@1.11.1:", when="@3.8:")
     depends_on("c-blosc@1.4.1:", when="@3.3:")
+
+    # blosc2 headers are directly included
+    depends_on("c-blosc2")
 
     depends_on("zlib-api", when="+zlib")
     depends_on("bzip2", when="+bzip2")


### PR DESCRIPTION
`py-blosc2` uses `scikit-build` to wrap the `cmake` build system, so we can easily pass our standard cmake arguments, and allows unvendoring of libblosc2.

