### PR TITLE
occa: add v2.0.0, rewrite package for CMake support

### DIFF
--- a/var/spack/repos/builtin/packages/occa/occa-v1.2.0-cstdint.patch
+++ b/var/spack/repos/builtin/packages/occa/occa-v1.2.0-cstdint.patch
@@ -1,0 +1,12 @@
+diff --git a/src/occa/internal/modes/dpcpp/polyfill.hpp b/src/occa/internal/modes/dpcpp/polyfill.hpp
+index 6aab675b..cb1ff9f7 100644
+--- a/src/occa/internal/modes/dpcpp/polyfill.hpp
++++ b/src/occa/internal/modes/dpcpp/polyfill.hpp
+@@ -8,6 +8,7 @@
+ #include <CL/sycl.hpp>
+ #else
+ #include <vector>
++#include <cstdint>
+ namespace sycl
+ {
+   template <std::size_t N>

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -50,7 +50,6 @@ class Occa(CMakePackage, MakefilePackage, CudaPackage, ROCmPackage):
     )
 
     variant("openmp", default=False, description="Enable support for OpenMP")
-    variant("opencl", default=False, description="Enable support for OpenCL")
     variant("debug", default=False, description="Enable a build with debug symbols")
 
     conflicts("%gcc@6:", when="^cuda@:8")
@@ -101,7 +100,7 @@ class SetupEnvironment:
             env.set("CXXFLAGS", " ".join(cxxflags))
 
         # Following only apply to the make build. For each variant, set the
-        # environment variable OCCA_{CUDA,OPENMP,OPENCL}_ENABLED only if the
+        # environment variable OCCA_{CUDA,HIP,OPENMP}_ENABLED only if the
         # variant is enabled. We disable OCCA autodetect as it causes issues
         # on head nodes.
         if "+cuda" in spec:
@@ -125,10 +124,8 @@ class SetupEnvironment:
         else:
             env.set("OCCA_HIP_ENABLED", "0")
 
-        if "+opencl" in spec:
-            env.set("OCCA_OPENCL_ENABLED", "1")
-        else:
-            env.set("OCCA_OPENCL_ENABLED", "0")
+        # Turn-off OpenCL since it fails on some of the machines.
+        env.set("OCCA_OPENCL_ENABLED", "0")
 
         if "+openmp" in spec:
             env.set("OCCA_OPENMP_ENABLED", "1")
@@ -170,10 +167,8 @@ class CMakeBuilder(CMakeBuilder, SetupEnvironment):
         else:
             args.append("-DOCCA_ENABLE_HIP=OFF")
 
-        if "+opencl" in spec:
-            args.append("-DOCCA_ENABLE_OPENCL=ON")
-        else:
-            args.append("-DOCCA_ENABLE_OPENCL=OFF")
+        # Turn-off OpenCL since it fails on some of the machines.
+        args.append("-DOCCA_ENABLE_OPENCL=OFF")
 
         if "+openmp" in spec:
             args.append("-DOCCA_ENABLE_OPENMP=ON")

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -100,10 +100,10 @@ class SetupEnvironment:
         if cxxflags:
             env.set("CXXFLAGS", " ".join(cxxflags))
 
-        # Following only apply to the make build.
-        # For the cuda, openmp, and opencl variants, set the environment
-        # variable OCCA_{CUDA,OPENMP,OPENCL}_ENABLED only if the variant is
-        # disabled. Otherwise, let OCCA autodetect what is available.
+        # Following only apply to the make build. For each variant, set the
+        # environment variable OCCA_{CUDA,OPENMP,OPENCL}_ENABLED only if the
+        # variant is enabled. We disable OCCA autodetect as it causes issues
+        # on head nodes.
         if "+cuda" in spec:
             cuda_dir = spec["cuda"].prefix
             cuda_libs_list = ["libcuda", "libcudart", "libOpenCL"]
@@ -122,10 +122,10 @@ class SetupEnvironment:
         else:
             env.set("OCCA_OPENCL_ENABLED", "0")
 
-        if "~openmp" in spec:
-            env.set("OCCA_OPENMP_ENABLED", "0")
-        else:
+        if "+openmp" in spec:
             env.set("OCCA_OPENMP_ENABLED", "1")
+        else:
+            env.set("OCCA_OPENMP_ENABLED", "0")
 
         # Setup run-time environment for testing.
         env.set("OCCA_VERBOSE", "1")

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -41,11 +41,11 @@ class Occa(CMakePackage, MakefilePackage, CudaPackage, ROCmPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
-    depends_on("cmake@3.30:", type="build", when="build_system=cmake @1.1.10:")
+    depends_on("cmake@3.30:", type="build", when="build_system=cmake")
 
     build_system(
-        conditional("cmake", when="@2.0.0:"),
-        conditional("makefile", when="@:1.2.0"),
+        conditional("cmake", when="@1.1.0:"),
+        conditional("makefile", when="@:1.0.9"),
         default="makefile",
     )
 

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -164,9 +164,9 @@ class CMakeBuilder(CMakeBuilder, SetupEnvironment):
             cuda_libs = find_libraries(cuda_libs_list, cuda_dir, shared=True, recursive=True)
             include_dirs.append(cuda_dir.include)
             library_dirs.extend(cuda_libs.directories)
-            args.append("-DOCCA_ENABLE_CUDA=ON")
+            args.append(self.define("OCCA_ENABLE_CUDA", True))
         else:
-            args.append("-DOCCA_ENABLE_CUDA=OFF")
+            args.append(self.define("OCCA_ENABLE_CUDA", False))
 
         if "+rocm" in spec:
             hip_dir = spec["hip"].prefix
@@ -175,22 +175,23 @@ class CMakeBuilder(CMakeBuilder, SetupEnvironment):
             include_dirs.append(hip_dir.include)
             library_dirs.extend(hip_libs.directories)
             args.append("-DOCCA_ENABLE_HIP=ON")
+            args.append(self.define("OCCA_ENABLE_HIP", True))
         else:
-            args.append("-DOCCA_ENABLE_HIP=OFF")
+            args.append(self.define("OCCA_ENABLE_HIP", False))
 
         # Turn-off OpenCL since it fails on some of the machines.
-        args.append("-DOCCA_ENABLE_OPENCL=OFF")
+        args.append(self.define("OCCA_ENABLE_OPENCL", False))
 
         if "+openmp" in spec:
-            args.append("-DOCCA_ENABLE_OPENMP=ON")
+            args.append(self.define("OCCA_ENABLE_OPENMP", True))
         else:
-            args.append("-DOCCA_ENABLE_OPENMP=OFF")
+            args.append(self.define("OCCA_ENABLE_OPENMP", False))
 
         if "+debug" in spec:
-            args.append("-DCMAKE_BUILD_TYPE=Debug")
+            args.append(self.define_from_variant("CMAKE_BUILD_TYPE", "Debug"))
 
-        args.append("-DCMAKE_INCLUDE_PATH={0}".format(";".join(include_dirs)))
-        args.append("-DCMAKE_LIBRARY_PATH={0}".format(";".join(library_dirs)))
+        args.append(self.define("CMAKE_INCLUDE_PATH", ";".join(include_dirs)))
+        args.append(self.define("CMAKE_LIBRARY_PATH", ";".join(library_dirs)))
 
         return args
 

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack.build_systems.cmake import CMakeBuilder
 from spack.build_systems.makefile import MakefileBuilder
 from spack.package import *
@@ -68,10 +66,7 @@ class Occa(CMakePackage, MakefilePackage, CudaPackage, ROCmPackage):
 
     @run_after("install")
     def check_install(self):
-        version_cmd = join_path(self.prefix.bin, "occa") + " version"
-        val = os.system(version_cmd)
-        if val != 0:
-            raise RuntimeError("Calling `occa version` failed !")
+        Executable(join_path(self.prefix.bin, "occa"))("version", fail_on_error=True)
 
 
 class SetupEnvironment:

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -4,10 +4,12 @@
 
 import os
 
+from spack.build_systems.cmake import CMakeBuilder
+from spack.build_systems.makefile import MakefileBuilder
 from spack.package import *
 
 
-class Occa(CMakePackage, CudaPackage, ROCmPackage):
+class Occa(CMakePackage, MakefilePackage, CudaPackage, ROCmPackage):
     """OCCA is an open-source (MIT license) library used to program current
     multi-core/many-core architectures. Devices (such as CPUs, GPUs,
     Intel's Xeon Phi, FPGAs, etc) are abstracted using an offload-model
@@ -28,11 +30,24 @@ class Occa(CMakePackage, CudaPackage, ROCmPackage):
     version("2.0.0", tag="v2.0.0", commit="3cba0841b2b87678da53e0b311cb7e162d781181")
     version("1.2.0", tag="v1.2.0", commit="18379073b6497f677a20bfeced95b511f82c3355")
     version("1.1.0", tag="v1.1.0", commit="c8a587666a23e045f25dc871c3257364a5f6a7d5")
+    version("1.0.9", tag="v1.0.9", commit="ebdb659c804f91f1e0f32fd700f9fe229458033c")
+    version("1.0.8", tag="v1.0.8", commit="55264f6b3d426f160dcf1f768c42d16d3ec14676")
+    version(
+        "1.0.0-alpha.5", tag="v1.0.0-alpha.5", commit="882ed5f92a40e60a80721727c350557be0ce6373"
+    )
+    version("0.2.0", tag="v0.2.0", commit="2eceaa5706ad6cf3a1b153c1f2a8a2fffa2d5945")
+    version("0.1.0", tag="v0.1.0", commit="381e886886dc87823769c5f20d0ecb29dd117afa")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
-    depends_on("cmake@3.30:", type="build")  # generated
+    depends_on("cmake@3.30:", type="build", when="build_system=cmake @1.1.10:")
+
+    build_system(
+        conditional("cmake", when="@2.0.0:"),
+        conditional("makefile", when="@:1.2.0"),
+        default="makefile",
+    )
 
     variant("opencl", default=True, description="Enable support for OpenCL")
     variant("openmp", default=True, description="Enable support for OpenMP")
@@ -41,6 +56,83 @@ class Occa(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("%gcc@6:", when="^cuda@:8")
     conflicts("%gcc@7:", when="^cuda@:9")
 
+    @run_after("install")
+    def check_install(self):
+        version_cmd = join_path(self.prefix.bin, "occa") + " version"
+        val = os.system(version_cmd)
+        if val != 0:
+            raise RuntimeError("Calling `occa version` failed !")
+
+
+class SetupEnvironment:
+    def setup_run_environment(self, s_env):
+        # The 'env' is included in the Spack generated module files.
+        spec = self.spec
+        s_env.set("OCCA_DIR", self.prefix)
+        s_env.set("OCCA_CXX", spack_cxx)
+
+        # Run-time compiler flags:
+        cxxflags = spec.compiler_flags["cxxflags"]
+        if cxxflags:
+            s_env.set("OCCA_CXXFLAGS", " ".join(cxxflags))
+
+        # Setup run-time HIP/CUDA compilers:
+        if "+cuda" in spec:
+            cuda_dir = spec["cuda"].prefix
+            s_env.set("OCCA_CUDA_COMPILER", join_path(cuda_dir, "bin", "nvcc"))
+
+        if "+rocm" in spec:
+            hip_dir = spec["hip"].prefix
+            s_env.set("OCCA_HIP_COMPILER", join_path(hip_dir, "bin", "hipcc"))
+
+    def setup_build_environment(self, env):
+        # The environment variable CXX is automatically set to the Spack
+        # compiler wrapper.
+        # The cxxflags, if specified, will be set by the Spack compiler wrapper
+        # while the environment variable CXXFLAGS will remain undefined.
+        # We define CXXFLAGS in the environment to tell OCCA to use the user
+        # specified flags instead of its defaults. This way the compiler will
+        # get the cxxflags twice - once from the Spack compiler wrapper and
+        # second time from OCCA - however, only the second one will be seen in
+        # the verbose output, so we keep both.
+        spec = self.spec
+        cxxflags = spec.compiler_flags["cxxflags"]
+        if cxxflags:
+            env.set("CXXFLAGS", " ".join(cxxflags))
+
+        # Following only apply to the make build.
+        # For the cuda, openmp, and opencl variants, set the environment
+        # variable OCCA_{CUDA,OPENMP,OPENCL}_ENABLED only if the variant is
+        # disabled. Otherwise, let OCCA autodetect what is available.
+        if "+cuda" in spec:
+            cuda_dir = spec["cuda"].prefix
+            cuda_libs_list = ["libcuda", "libcudart", "libOpenCL"]
+            cuda_libs = find_libraries(cuda_libs_list, cuda_dir, shared=True, recursive=True)
+            env.set("OCCA_INCLUDE_PATH", cuda_dir.include)
+            env.set("OCCA_LIBRARY_PATH", ":".join(cuda_libs.directories))
+        else:
+            env.set("OCCA_CUDA_ENABLED", "0")
+
+        # Disable hip autodetection for now since it fails on some machines.
+        env.set("OCCA_HIP_ENABLED", "0")
+
+        if "~opencl" in spec:
+            env.set("OCCA_OPENCL_ENABLED", "0")
+
+        if "~openmp" in spec:
+            env.set("OCCA_OPENMP_ENABLED", "0")
+
+        # Setup run-time environment for testing.
+        env.set("OCCA_VERBOSE", "1")
+        self.setup_run_environment(env)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        # Export OCCA_* variables for everyone using this package from within
+        # Spack.
+        self.setup_run_environment(env)
+
+
+class CMakeBuilder(CMakeBuilder, SetupEnvironment):
     def cmake_args(self):
         spec = self.spec
         args, include_dirs, library_dirs = [], [], []
@@ -77,45 +169,13 @@ class Occa(CMakePackage, CudaPackage, ROCmPackage):
 
         return args
 
-    def _setup_runtime_flags(self, s_env):
-        spec = self.spec
-        s_env.set("OCCA_DIR", self.prefix)
-        s_env.set("OCCA_CXX", self.compiler.cxx)
 
-        # Run-time compiler flags:
-        cxxflags = spec.compiler_flags["cxxflags"]
-        if cxxflags:
-            s_env.set("OCCA_CXXFLAGS", " ".join(cxxflags))
+class MakefileBuilder(MakefileBuilder, SetupEnvironment):
+    def install(self, pkg, spec, prefix):
+        # The build environment is set by the 'setup_build_environment' method.
+        # Copy the source to the installation directory and build OCCA there.
+        install_tree(".", prefix)
+        make("-C", prefix)
 
-        # Setup run-time HIP/CUDA compilers:
-        if "+cuda" in spec:
-            cuda_dir = spec["cuda"].prefix
-            s_env.set("OCCA_CUDA_COMPILER", join_path(cuda_dir, "bin", "nvcc"))
-
-        if "+rocm" in spec:
-            hip_dir = spec["hip"].prefix
-            s_env.set("OCCA_HIP_COMPILER", join_path(hip_dir, "bin", "hipcc"))
-
-    def _setup_build_flags(self, env):
-        # Setup run-time environment for testing.
-        env.set("OCCA_VERBOSE", "1")
-        self._setup_runtime_flags(env)
-
-    def setup_build_environment(self, env):
-        self._setup_build_flags(env)
-
-    def setup_run_environment(self, env):
-        # The 'env' is included in the Spack generated module files.
-        self._setup_runtime_flags(env)
-
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        # Export OCCA_* variables for everyone using this package from within
-        # Spack.
-        self._setup_runtime_flags(env)
-
-    @run_after("install")
-    def check_install(self):
-        version_cmd = join_path(self.prefix.bin, "occa") + " version"
-        val = os.system(version_cmd)
-        if val != 0:
-            raise RuntimeError("Calling `occa version` failed !")
+        if self.run_tests:
+            make("-C", prefix, "test", parallel=False)

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -7,7 +7,7 @@ import os
 from spack.package import *
 
 
-class Occa(Package):
+class Occa(CMakePackage, CudaPackage, ROCmPackage):
     """OCCA is an open-source (MIT license) library used to program current
     multi-core/many-core architectures. Devices (such as CPUs, GPUs,
     Intel's Xeon Phi, FPGAs, etc) are abstracted using an offload-model
@@ -28,106 +28,81 @@ class Occa(Package):
     version("2.0.0", tag="v2.0.0", commit="3cba0841b2b87678da53e0b311cb7e162d781181")
     version("1.2.0", tag="v1.2.0", commit="18379073b6497f677a20bfeced95b511f82c3355")
     version("1.1.0", tag="v1.1.0", commit="c8a587666a23e045f25dc871c3257364a5f6a7d5")
-    version("1.0.9", tag="v1.0.9", commit="ebdb659c804f91f1e0f32fd700f9fe229458033c")
-    version("1.0.8", tag="v1.0.8", commit="55264f6b3d426f160dcf1f768c42d16d3ec14676")
-    version(
-        "1.0.0-alpha.5", tag="v1.0.0-alpha.5", commit="882ed5f92a40e60a80721727c350557be0ce6373"
-    )
-    version("0.2.0", tag="v0.2.0", commit="2eceaa5706ad6cf3a1b153c1f2a8a2fffa2d5945")
-    version("0.1.0", tag="v0.1.0", commit="381e886886dc87823769c5f20d0ecb29dd117afa")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
+    depends_on("cmake@3.30:", type="build")  # generated
 
-    variant("cuda", default=True, description="Activates support for CUDA")
-    variant("hip", default=True, description="Activates support for HIP")
-    variant("openmp", default=True, description="Activates support for OpenMP")
-    variant("opencl", default=True, description="Activates support for OpenCL")
-
-    depends_on("cuda", when="+cuda")
-    depends_on("gmake", type="build")
-    depends_on("hip", when="+hip")
+    variant("opencl", default=True, description="Enable support for OpenCL")
+    variant("openmp", default=True, description="Enable support for OpenMP")
+    variant("debug", default=False, description="Enable a build with debug symbols")
 
     conflicts("%gcc@6:", when="^cuda@:8")
     conflicts("%gcc@7:", when="^cuda@:9")
 
-    def install(self, spec, prefix):
-        # The build environment is set by the 'setup_build_environment' method.
-        # Copy the source to the installation directory and build OCCA there.
-        install_tree(".", prefix)
-        make("-C", prefix)
+    def cmake_args(self):
+        spec = self.spec
+        args, include_dirs, library_dirs = [], [], []
 
-        if self.run_tests:
-            make("-C", prefix, "test", parallel=False)
+        if "+cuda" in spec:
+            cuda_dir = spec["cuda"].prefix
+            cuda_libs_list = ["libcuda", "libcudart", "libOpenCL"]
+            cuda_libs = find_libraries(cuda_libs_list, cuda_dir, shared=True, recursive=True)
+            include_dirs.append(cuda_dir.include)
+            library_dirs.extend(cuda_libs.directories)
+        else:
+            args.append("-DOCCA_ENABLE_CUDA=0")
+
+        if "+rocm" in spec:
+            hip_dir = spec["hip"].prefix
+            hip_libs_list = ["amdhip64"]
+            hip_libs = find_libraries(hip_libs_list, hip_dir, shared=True, recursive=True)
+            include_dirs.append(hip_dir.include)
+            library_dirs.extend(hip_libs.directories)
+        else:
+            args.append("-DOCCA_ENABLE_HIP=0")
+
+        if "~opencl" in spec:
+            args.append("-DOCCA_ENABLE_OPENCL=0")
+
+        if "~openmp" in spec:
+            args.append("-DOCCA_ENABLE_OPENMP=0")
+
+        if "+debug" in spec:
+            args.append("-DCMAKE_BUILD_TYPE=Debug")
+
+        args.append("-DCMAKE_INCLUDE_PATH={0}".format(";".join(include_dirs)))
+        args.append("-DCMAKE_LIBRARY_PATH={0}".format(";".join(library_dirs)))
+
+        return args
 
     def _setup_runtime_flags(self, s_env):
         spec = self.spec
         s_env.set("OCCA_DIR", self.prefix)
         s_env.set("OCCA_CXX", self.compiler.cxx)
 
+        # Run-time compiler flags:
         cxxflags = spec.compiler_flags["cxxflags"]
         if cxxflags:
-            # Run-time compiler flags:
             s_env.set("OCCA_CXXFLAGS", " ".join(cxxflags))
 
+        # Setup run-time HIP/CUDA compilers:
         if "+cuda" in spec:
             cuda_dir = spec["cuda"].prefix
-            # Run-time CUDA compiler:
             s_env.set("OCCA_CUDA_COMPILER", join_path(cuda_dir, "bin", "nvcc"))
 
-        if "+hip" in spec:
+        if "+rocm" in spec:
             hip_dir = spec["hip"].prefix
-            # Run-time HIP compiler:
             s_env.set("OCCA_HIP_COMPILER", join_path(hip_dir, "bin", "hipcc"))
 
-    def setup_build_environment(self, env):
-        spec = self.spec
-        # The environment variable CXX is automatically set to the Spack
-        # compiler wrapper.
-
-        # The cxxflags, if specified, will be set by the Spack compiler wrapper
-        # while the environment variable CXXFLAGS will remain undefined.
-        # We define CXXFLAGS in the environment to tell OCCA to use the user
-        # specified flags instead of its defaults. This way the compiler will
-        # get the cxxflags twice - once from the Spack compiler wrapper and
-        # second time from OCCA - however, only the second one will be seen in
-        # the verbose output, so we keep both.
-        cxxflags = spec.compiler_flags["cxxflags"]
-        if cxxflags:
-            env.set("CXXFLAGS", " ".join(cxxflags))
-
-        # For the cuda, openmp, and opencl variants, set the environment
-        # variable OCCA_{CUDA,OPENMP,OPENCL}_ENABLED only if the variant is
-        # disabled. Otherwise, let OCCA autodetect what is available.
-
-        if "+cuda" in spec:
-            cuda_dir = spec["cuda"].prefix
-            cuda_libs_list = ["libcuda", "libcudart", "libOpenCL"]
-            cuda_libs = find_libraries(cuda_libs_list, cuda_dir, shared=True, recursive=True)
-            env.set("OCCA_INCLUDE_PATH", cuda_dir.include)
-            env.set("OCCA_LIBRARY_PATH", ":".join(cuda_libs.directories))
-        else:
-            env.set("OCCA_CUDA_ENABLED", "0")
-
-        if "+hip" in spec:
-            hip_dir = spec["hip"].prefix
-            hip_libs_list = ["amdhip64"]
-            hip_libs = find_libraries(hip_libs_list, hip_dir, shared=True, recursive=True)
-            env.set("OCCA_INCLUDE_PATH", hip_dir.include)
-            env.set("OCCA_LIBRARY_PATH", ":".join(hip_libs.directories))
-        else:
-            env.set("OCCA_HIP_ENABLED", "0")
-
-        if "~opencl" in spec:
-            env.set("OCCA_OPENCL_ENABLED", "0")
-
-        if "~openmp" in spec:
-            env.set("OCCA_OPENMP_ENABLED", "0")
-
+    def _setup_build_flags(self, env):
         # Setup run-time environment for testing.
         env.set("OCCA_VERBOSE", "1")
         self._setup_runtime_flags(env)
+
+    def setup_build_environment(self, env):
+        self._setup_build_flags(env)
 
     def setup_run_environment(self, env):
         # The 'env' is included in the Spack generated module files.

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -75,6 +75,8 @@ class SetupEnvironment:
         spec = self.spec
         s_env.set("OCCA_DIR", self.prefix)
         s_env.set("OCCA_CXX", spack_cxx)
+        # Run the tests serially:
+        s_env.set("CTEST_PARALLEL_LEVEL=1")
 
         # Run-time compiler flags:
         cxxflags = spec.compiler_flags["cxxflags"]
@@ -190,12 +192,6 @@ class CMakeBuilder(CMakeBuilder, SetupEnvironment):
 
         return args
 
-    @run_after("build")
-    @on_package_attributes(run_tests=True)
-    def check(self):
-        if self.pkg.run_tests:
-            make("-C", self.prefix, "test", parallel=False)
-
 
 class MakefileBuilder(MakefileBuilder, SetupEnvironment):
     def install(self, pkg, spec, prefix):
@@ -203,8 +199,3 @@ class MakefileBuilder(MakefileBuilder, SetupEnvironment):
         # Copy the source to the installation directory and build OCCA there.
         install_tree(".", prefix)
         make("-C", prefix)
-
-    @run_after("build")
-    @on_package_attributes(run_tests=True)
-    def check(self):
-        make("-C", self.prefix, "test", parallel=False)

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -115,7 +115,15 @@ class SetupEnvironment:
             env.set("OCCA_CUDA_ENABLED", "0")
 
         # Disable hip autodetection for now since it fails on some machines.
-        env.set("OCCA_HIP_ENABLED", "0")
+        if "+rocm" in spec:
+            hip_dir = spec["hip"].prefix
+            hip_libs_list = ["amdhip64"]
+            hip_libs = find_libraries(hip_libs_list, hip_dir, shared=True, recursive=True)
+            env.set("OCCA_INCLUDE_PATH", hip_dir.include)
+            env.set("OCCA_LIBRARY_PATH", ":".join(hip_libs.directories))
+            env.set("OCCA_HIP_ENABLED", "1")
+        else:
+            env.set("OCCA_HIP_ENABLED", "0")
 
         if "+opencl" in spec:
             env.set("OCCA_OPENCL_ENABLED", "1")

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -76,7 +76,7 @@ class SetupEnvironment:
         s_env.set("OCCA_DIR", self.prefix)
         s_env.set("OCCA_CXX", spack_cxx)
         # Run the tests serially:
-        s_env.set("CTEST_PARALLEL_LEVEL=1")
+        s_env.set("CTEST_PARALLEL_LEVEL", "1")
 
         # Run-time compiler flags:
         cxxflags = spec.compiler_flags["cxxflags"]

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -46,7 +46,7 @@ class Occa(CMakePackage, MakefilePackage, CudaPackage, ROCmPackage):
     build_system(
         conditional("cmake", when="@1.1.0:"),
         conditional("makefile", when="@:1.0.9"),
-        default="makefile",
+        default="cmake",
     )
 
     variant("openmp", default=False, description="Enable support for OpenMP")

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -180,6 +180,12 @@ class CMakeBuilder(CMakeBuilder, SetupEnvironment):
 
         return args
 
+    @run_after("build")
+    @on_package_attributes(run_tests=True)
+    def check(self):
+        if self.pkg.run_tests:
+            make("-C", self.prefix, "test", parallel=False)
+
 
 class MakefileBuilder(MakefileBuilder, SetupEnvironment):
     def install(self, pkg, spec, prefix):
@@ -188,5 +194,7 @@ class MakefileBuilder(MakefileBuilder, SetupEnvironment):
         install_tree(".", prefix)
         make("-C", prefix)
 
-        if self.run_tests:
-            make("-C", prefix, "test", parallel=False)
+    @run_after("build")
+    @on_package_attributes(run_tests=True)
+    def check(self):
+        make("-C", self.prefix, "test", parallel=False)

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -43,6 +43,7 @@ class Occa(CMakePackage, MakefilePackage, CudaPackage, ROCmPackage):
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
     depends_on("cmake@3.30:", type="build", when="build_system=cmake")
+    depends_on("gmake", type="build")
 
     build_system(
         conditional("cmake", when="@1.1.0:"),

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -49,7 +49,7 @@ class Occa(CMakePackage, MakefilePackage, CudaPackage, ROCmPackage):
         default="makefile",
     )
 
-    variant("openmp", default=False, description="Enable support for OpenMP")
+    variant("openmp", default=False, description="Enable support for OpenMP",  when="@1.1.0:")
     variant("debug", default=False, description="Enable a build with debug symbols")
 
     conflicts("%gcc@6:", when="^cuda@:8")

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -38,6 +38,7 @@ class Occa(CMakePackage, MakefilePackage, CudaPackage, ROCmPackage):
     version("0.2.0", tag="v0.2.0", commit="2eceaa5706ad6cf3a1b153c1f2a8a2fffa2d5945")
     version("0.1.0", tag="v0.1.0", commit="381e886886dc87823769c5f20d0ecb29dd117afa")
 
+    depends_on("hip", when="+rocm")
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
@@ -49,11 +50,20 @@ class Occa(CMakePackage, MakefilePackage, CudaPackage, ROCmPackage):
         default="makefile",
     )
 
-    variant("openmp", default=False, description="Enable support for OpenMP",  when="@1.1.0:")
+    variant("openmp", default=False, description="Enable support for OpenMP")
     variant("debug", default=False, description="Enable a build with debug symbols")
 
+    # HIP build fails with Make on some systems. So, we disable it when
+    # Make based build is used.
+    conflicts("+rocm", when="@:1.0.9")
+    # OpenMP build fails with Make on some systems. So, we disable it when
+    # Make based build is used.
+    conflicts("+openmp", when="@:1.0.9")
+    # gcc and cuda conflicts.
     conflicts("%gcc@6:", when="^cuda@:8")
     conflicts("%gcc@7:", when="^cuda@:9")
+
+    patch("occa-v1.2.0-cstdint.patch", when="@1.2.0")
 
     @run_after("install")
     def check_install(self):

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
@@ -135,3 +137,10 @@ class Occa(Package):
         # Export OCCA_* variables for everyone using this package from within
         # Spack.
         self._setup_runtime_flags(env)
+
+    @run_after("install")
+    def check_install(self):
+        version_cmd = join_path(self.prefix.bin, "occa") + " version"
+        val = os.system(version_cmd)
+        if val != 0:
+            raise RuntimeError("Calling `occa version` failed !")

--- a/var/spack/repos/builtin/packages/occa/package.py
+++ b/var/spack/repos/builtin/packages/occa/package.py
@@ -23,6 +23,7 @@ class Occa(Package):
     license("MIT")
 
     version("develop")
+    version("2.0.0", tag="v2.0.0", commit="3cba0841b2b87678da53e0b311cb7e162d781181")
     version("1.2.0", tag="v1.2.0", commit="18379073b6497f677a20bfeced95b511f82c3355")
     version("1.1.0", tag="v1.1.0", commit="c8a587666a23e045f25dc871c3257364a5f6a7d5")
     version("1.0.9", tag="v1.0.9", commit="ebdb659c804f91f1e0f32fd700f9fe229458033c")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Update OCCA package to use a CMake build and add a new release.
Also, we removed support for some of the older versions of OCCA.
