### PR TITLE
py-jedi: add v0.19.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-ipykernel/package.py
+++ b/var/spack/repos/builtin/packages/py-ipykernel/package.py
@@ -38,17 +38,61 @@ class PyIpykernel(PythonPackage):
     version("5.3.4", sha256="9b2652af1607986a1b231c62302d070bc0534f564c393a5d9d130db9abbbe89d")
     version("5.1.1", sha256="f0e962052718068ad3b1d8bcc703794660858f58803c3798628817f492a8769c")
     version("5.1.0", sha256="0fc0bf97920d454102168ec2008620066878848fcfca06c22b669696212e292f")
-    version("4.10.0", sha256="699103c8e64886e3ec7053f2a6aa83bb90426063526f63a818732ff385202bad")
-    version("4.5.0", sha256="245a798edb8fd751b95750d8645d736dd739a020e7fc7d5627dac4d1c35d8295")
-    version("4.4.1", sha256="6d48398b3112efb733b254edede4b7f3262c28bd19f665b64ef1acf6ec5cd74f")
-    version("4.4.0", sha256="d516427c3bd689205e6693c9616302ef34017b91ada3c9ea3fca6e90702b7ffe")
-    version("4.3.1", sha256="8219d3eaa3e4d4efc5f349114e41a40f0986c91a960846bb81d5da817fb7cc3f")
-    version("4.3.0", sha256="f214c661328c836e02b6f185f98f3eccd7ce396791937493ffa1babf5e3267ab")
-    version("4.2.2", sha256="a876da43e01acec2c305abdd8e6aa55f052bab1196171ccf1cb9a6aa230298b0")
-    version("4.2.1", sha256="081a5d4db33db58697be2d682b92f79b2c239493445f13dd457c15bc3e52c874")
-    version("4.2.0", sha256="723b3d4baac20f0c9cd91fc75c3e813636ecb6c6e303fb34d628c3df078985a7")
-    version("4.1.1", sha256="d8c5555386d0f18f1336dea9800f9f0fe96dcecc9757c0f980e11fdfadb661ff")
-    version("4.1.0", sha256="e0e150ad55e487e49054efc9a4b0e2e17f27e1de77444b26760789077b146d86")
+    version(
+        "4.10.0",
+        sha256="699103c8e64886e3ec7053f2a6aa83bb90426063526f63a818732ff385202bad",
+        deprecated=True,
+    )
+    version(
+        "4.5.0",
+        sha256="245a798edb8fd751b95750d8645d736dd739a020e7fc7d5627dac4d1c35d8295",
+        deprecated=True,
+    )
+    version(
+        "4.4.1",
+        sha256="6d48398b3112efb733b254edede4b7f3262c28bd19f665b64ef1acf6ec5cd74f",
+        deprecated=True,
+    )
+    version(
+        "4.4.0",
+        sha256="d516427c3bd689205e6693c9616302ef34017b91ada3c9ea3fca6e90702b7ffe",
+        deprecated=True,
+    )
+    version(
+        "4.3.1",
+        sha256="8219d3eaa3e4d4efc5f349114e41a40f0986c91a960846bb81d5da817fb7cc3f",
+        deprecated=True,
+    )
+    version(
+        "4.3.0",
+        sha256="f214c661328c836e02b6f185f98f3eccd7ce396791937493ffa1babf5e3267ab",
+        deprecated=True,
+    )
+    version(
+        "4.2.2",
+        sha256="a876da43e01acec2c305abdd8e6aa55f052bab1196171ccf1cb9a6aa230298b0",
+        deprecated=True,
+    )
+    version(
+        "4.2.1",
+        sha256="081a5d4db33db58697be2d682b92f79b2c239493445f13dd457c15bc3e52c874",
+        deprecated=True,
+    )
+    version(
+        "4.2.0",
+        sha256="723b3d4baac20f0c9cd91fc75c3e813636ecb6c6e303fb34d628c3df078985a7",
+        deprecated=True,
+    )
+    version(
+        "4.1.1",
+        sha256="d8c5555386d0f18f1336dea9800f9f0fe96dcecc9757c0f980e11fdfadb661ff",
+        deprecated=True,
+    )
+    version(
+        "4.1.0",
+        sha256="e0e150ad55e487e49054efc9a4b0e2e17f27e1de77444b26760789077b146d86",
+        deprecated=True,
+    )
 
     depends_on("py-hatchling@1.4:", when="@6.13.1:", type="build")
 
@@ -58,7 +102,7 @@ class PyIpykernel(PythonPackage):
         depends_on("python@3.6:3.9", when="@5.5:5")
         depends_on("python@3.5:3.8", when="@5.4")
         depends_on("python@3.5:3.7", when="@5:5.3")
-        depends_on("python@3.4:3.5", when="@4")
+        # depends_on("python@3.4:3.5", when="@4")
 
         with when("@6:"):
             depends_on("py-debugpy@1.6.5:", when="@6.22:")

--- a/var/spack/repos/builtin/packages/py-ipykernel/package.py
+++ b/var/spack/repos/builtin/packages/py-ipykernel/package.py
@@ -53,9 +53,12 @@ class PyIpykernel(PythonPackage):
     depends_on("py-hatchling@1.4:", when="@6.13.1:", type="build")
 
     with default_args(type=("build", "run")):
-        depends_on("python@3.8:", when="@6.22:")
-        # use of `imp` module
-        depends_on("python@:3.11", when="@:6.10")
+        depends_on("python@3.8:", when="@6.11:")
+        depends_on("python@3.8:3.11", when="@6:6.10")
+        depends_on("python@3.6:3.9", when="@5.5:5")
+        depends_on("python@3.5:3.8", when="@5.4")
+        depends_on("python@3.5:3.7", when="@5:5.3")
+        depends_on("python@3.4:3.5", when="@4")
 
         with when("@6:"):
             depends_on("py-debugpy@1.6.5:", when="@6.22:")
@@ -65,7 +68,8 @@ class PyIpykernel(PythonPackage):
             depends_on("py-matplotlib-inline@0.1:")
             depends_on("py-matplotlib-inline@:0.1", when="@:6.10")
 
-        depends_on("py-ipython@7.23.1:", when="@6:")
+        depends_on("py-ipython@7.23.1:", when="@6.5.1:")
+        depends_on("py-ipython@7.23.1:7", when="@6:6.5.0")
         depends_on("py-ipython@5:", when="@5:")
         depends_on("py-ipython@4:")
         depends_on("py-ipython@:7", when="@:6.5")

--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -61,7 +61,7 @@ class PyIpython(PythonPackage):
     depends_on("py-colorama", when="platform=windows", type=("build", "run"))
     depends_on("py-decorator", type=("build", "run"))
     depends_on("py-exceptiongroup", when="@8.15: ^python@:3.10", type=("build", "run"))
-    depends_on("py-jedi@0.16:", when="@7.18,7.20:", type=("build", "run"))
+    depends_on("py-jedi@0.16:0.18", when="@7.18,7.20:", type=("build", "run"))
     depends_on("py-jedi@0.10:", when="@7.5:7.17,7.19", type=("build", "run"))
     depends_on("py-matplotlib-inline", when="@7.23:", type=("build", "run"))
     depends_on("py-pexpect@4.4:", when="@7.18: platform=linux", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -51,6 +51,7 @@ class PyIpython(PythonPackage):
     version("5.8.0", sha256="4bac649857611baaaf76bc82c173aa542f7486446c335fe1a6c05d0d491c8906")
     version("5.1.0", sha256="7ef4694e1345913182126b219aaa4a0047e191af414256da6772cf249571b961")
 
+    depends_on("python@3.10:", when="@8.19:", type=("build", "run"))
     depends_on("python@3.9:", when="@8.13.1:", type=("build", "run"))
     depends_on("python@3.8: +sqlite3", when="@8:", type=("build", "run"))
     depends_on("py-setuptools@61.2:", when="@8.22:", type="build")

--- a/var/spack/repos/builtin/packages/py-jedi/package.py
+++ b/var/spack/repos/builtin/packages/py-jedi/package.py
@@ -12,40 +12,102 @@ class PyJedi(PythonPackage):
     homepage = "https://github.com/davidhalter/jedi"
     pypi = "jedi/jedi-0.9.0.tar.gz"
 
+    maintainers("alecbcs")
+
     license("MIT")
 
+    version("0.19.2", sha256="4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0")
     version("0.18.2", sha256="bae794c30d07f6d910d32a7048af09b5a39ed740918da923c6b780790ebac612")
     version("0.18.1", sha256="74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab")
     version("0.18.0", sha256="92550a404bad8afed881a137ec9a461fed49eca661414be45059329614ed0707")
     version("0.17.2", sha256="86ed7d9b750603e4ba582ea8edc678657fb4007894a12bcf6f4bb97892f31d20")
     version("0.17.1", sha256="807d5d4f96711a2bcfdd5dfa3b1ae6d09aa53832b182090b222b5efb81f52f63")
-    version("0.15.1", sha256="ba859c74fa3c966a22f2aeebe1b74ee27e2a462f56d3f5f7ca4a59af61bfe42e")
-    version("0.15.0", sha256="9f16cb00b2aee940df2efc1d7d7c848281fd16391536a3d4561f5aea49db1ee6")
-    version("0.14.1", sha256="53c850f1a7d3cfcd306cc513e2450a54bdf5cacd7604b74e42dd1f0758eaaf36")
-    version("0.14.0", sha256="49ccb782651bb6f7009810d17a3316f8867dde31654c750506970742e18b553d")
-    version("0.13.3", sha256="2bb0603e3506f708e792c7f4ad8fc2a7a9d9c2d292a358fbbd58da531695595b")
-    version("0.13.2", sha256="571702b5bd167911fe9036e5039ba67f820d6502832285cde8c881ab2b2149fd")
-    version("0.13.1", sha256="b7493f73a2febe0dc33d51c99b474547f7f6c0b2c8fb2b21f453eef204c12148")
-    version("0.13.0", sha256="e4db7a2e08980e48c6aec6588483629c81fdcf9b6d9e6a372b40ed7fec91f310")
-    version("0.12.1", sha256="b409ed0f6913a701ed474a614a3bb46e6953639033e31f769ca7581da5bd1ec1")
-    version("0.12.0", sha256="1972f694c6bc66a2fac8718299e2ab73011d653a6d8059790c3476d2353b99ad")
-    version("0.10.2", sha256="7abb618cac6470ebbd142e59c23daec5e6e063bfcecc8a43a037d2ab57276f4e")
-    version("0.10.1", sha256="2420daf6fd00e80caf1bc22903598b5bf5560c900113dcc120eaefc7b4d50e06")
+    version(
+        "0.15.1",
+        sha256="ba859c74fa3c966a22f2aeebe1b74ee27e2a462f56d3f5f7ca4a59af61bfe42e",
+        deprecated=True,
+    )
+    version(
+        "0.15.0",
+        sha256="9f16cb00b2aee940df2efc1d7d7c848281fd16391536a3d4561f5aea49db1ee6",
+        deprecated=True,
+    )
+    version(
+        "0.14.1",
+        sha256="53c850f1a7d3cfcd306cc513e2450a54bdf5cacd7604b74e42dd1f0758eaaf36",
+        deprecated=True,
+    )
+    version(
+        "0.14.0",
+        sha256="49ccb782651bb6f7009810d17a3316f8867dde31654c750506970742e18b553d",
+        deprecated=True,
+    )
+    version(
+        "0.13.3",
+        sha256="2bb0603e3506f708e792c7f4ad8fc2a7a9d9c2d292a358fbbd58da531695595b",
+        deprecated=True,
+    )
+    version(
+        "0.13.2",
+        sha256="571702b5bd167911fe9036e5039ba67f820d6502832285cde8c881ab2b2149fd",
+        deprecated=True,
+    )
+    version(
+        "0.13.1",
+        sha256="b7493f73a2febe0dc33d51c99b474547f7f6c0b2c8fb2b21f453eef204c12148",
+        deprecated=True,
+    )
+    version(
+        "0.13.0",
+        sha256="e4db7a2e08980e48c6aec6588483629c81fdcf9b6d9e6a372b40ed7fec91f310",
+        deprecated=True,
+    )
+    version(
+        "0.12.1",
+        sha256="b409ed0f6913a701ed474a614a3bb46e6953639033e31f769ca7581da5bd1ec1",
+        deprecated=True,
+    )
+    version(
+        "0.12.0",
+        sha256="1972f694c6bc66a2fac8718299e2ab73011d653a6d8059790c3476d2353b99ad",
+        deprecated=True,
+    )
+    version(
+        "0.10.2",
+        sha256="7abb618cac6470ebbd142e59c23daec5e6e063bfcecc8a43a037d2ab57276f4e",
+        deprecated=True,
+    )
+    version(
+        "0.10.1",
+        sha256="2420daf6fd00e80caf1bc22903598b5bf5560c900113dcc120eaefc7b4d50e06",
+        deprecated=True,
+    )
     # unfortunately pypi.io only offers a .whl for 0.10.0
     version(
         "0.10.0",
         sha256="d6a7344df9c80562c3f62199278004ccc7c5889be9f1a6aa5abde117ec085123",
         url="https://github.com/davidhalter/jedi/archive/v0.10.0.tar.gz",
+        deprecated=True,
     )
-    version("0.9.0", sha256="3b4c19fba31bdead9ab7350fb9fa7c914c59b0a807dcdd5c00a05feb85491d31")
+    version(
+        "0.9.0",
+        sha256="3b4c19fba31bdead9ab7350fb9fa7c914c59b0a807dcdd5c00a05feb85491d31",
+        deprecated=True,
+    )
 
-    depends_on("c", type="build")  # generated
+    with default_args(type=("build", "run")):
+        depends_on("python@3.5:3.9", when="@0.17.1:")
+        depends_on("python@3.6:3.10", when="@0.18.1:")
+        depends_on("python@3.6:3.11", when="@0.19.0:")
+        depends_on("python@3.6:3.12", when="@0.19.1:")
+        depends_on("python@3.6:3.13", when="@0.19.2:")
 
-    depends_on("py-setuptools", type=("build", "run"))
+        depends_on("py-setuptools")
 
-    depends_on("py-parso@0.8", when="@0.18.0:", type=("build", "run"))
-    depends_on("py-parso@0.7", when="@0.17", type=("build", "run"))
-    depends_on("py-parso@0.5.2:", when="@0.15.2:0.16", type=("build", "run"))
-    depends_on("py-parso@0.5.0:", when="@0.14.1:0.15.1", type=("build", "run"))
-    depends_on("py-parso@0.3.0:", when="@0.12.1:0.14.0", type=("build", "run"))
-    depends_on("py-parso@0.2.0:", when="@0.12.0", type=("build", "run"))
+        depends_on("py-parso@0.2.0:", when="@0.12.0")
+        depends_on("py-parso@0.3.0:", when="@0.12.1:0.14.0")
+        depends_on("py-parso@0.5.0:", when="@0.14.1:0.15.1")
+        depends_on("py-parso@0.5.2:", when="@0.15.2:0.16")
+        depends_on("py-parso@0.7", when="@0.17")
+        depends_on("py-parso@0.8", when="@0.18.0:")
+        depends_on("py-parso@0.8.4:0.8", when="@0.19.2:")

--- a/var/spack/repos/builtin/packages/py-parso/package.py
+++ b/var/spack/repos/builtin/packages/py-parso/package.py
@@ -30,4 +30,5 @@ class PyParso(PythonPackage):
         depends_on("python@:3.12", when="@:0.8.3")
         # https://github.com/davidhalter/parso/commit/285492f4ed25f145859630ee6c5625e60aff6e2e
         depends_on("python@:3.11", when="@:0.8.2")
+
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
Added py-jedi v0.19.2, dependencies on supported versions of python, and deprecated very old releases.

**Changelog:**
https://github.com/davidhalter/jedi/blob/master/CHANGELOG.rst#0192-2024-11-10