### PR TITLE
py-yt: add 4.4.0 and dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-ewah-bool-utils/package.py
+++ b/var/spack/repos/builtin/packages/py-ewah-bool-utils/package.py
@@ -1,0 +1,24 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyEwahBoolUtils(PythonPackage):
+    """EWAH Bool Array utils for yt"""
+
+    homepage = "https://github.com/yt-project/ewah_bool_utils"
+    pypi = "ewah_bool_utils/ewah_bool_utils-1.2.2.tar.gz"
+
+    license("BSD-3-Clause", checked_by="lgarrison")
+
+    version("1.2.2", sha256="eb901f46caef189de3a0c1f5ca06287cfaba7976ddf76fa1c1f3bce1b60b7ac3")
+
+    depends_on("python@3.9:", type=("build", "run"))
+
+    depends_on("py-setuptools@61.2:", type="build")
+    depends_on("py-cython@3.0:", type="build")
+    depends_on("py-numpy@2.0.0:", type="build")
+
+    depends_on("py-numpy@1.19.3:2", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-extension-helpers/package.py
+++ b/var/spack/repos/builtin/packages/py-extension-helpers/package.py
@@ -12,14 +12,27 @@ class PyExtensionHelpers(PythonPackage):
     extensions. It is developed by the Astropy project but is intended
     to be general and usable by any Python package."""
 
-    homepage = "https://github.com/astropy/astropy-helpers"
-    pypi = "extension-helpers/extension-helpers-0.1.tar.gz"
+    homepage = "https://github.com/astropy/extension-helpers"
+    pypi = "extension-helpers/extension_helpers-1.2.0.tar.gz"
 
     license("BSD-3-Clause")
 
-    version("0.1", sha256="ac8a6fe91c6d98986a51a9f08ca0c7945f8fd70d95b662ced4040ae5eb973882")
+    version("1.2.0", sha256="e7d9c8f71804edd7ecd05b5d59a5b504f6e24867970abfc12771242eed76ebcc")
+    version(
+        "0.1",
+        sha256="ac8a6fe91c6d98986a51a9f08ca0c7945f8fd70d95b662ced4040ae5eb973882",
+        # 0.1 uses dash in the tarball name
+        url="https://files.pythonhosted.org/packages/81/78/056daee475dfc41cc0b62540388703cddcae4d4f6bef10c6ce1aea76ebaf/extension-helpers-0.1.tar.gz",
+    )
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("python@3.6:", type=("build", "run"))
+    depends_on("python@3.8:", type=("build", "run"), when="@1.2.0:")
+
     depends_on("py-setuptools@30.3:", type="build")
+    depends_on("py-setuptools@43.0.0:", type="build", when="@1.2.0:")
+    depends_on("py-setuptools-scm@6.2:", type="build", when="@1.2.0:")
+
+    depends_on("py-setuptools@40.2:", type=("build", "run"), when="@1.2.0:")
+    depends_on("py-tomli@1.0.0:", type=("build", "run"), when="@1.2.0: ^python@:3.10")

--- a/var/spack/repos/builtin/packages/py-pyerfa/package.py
+++ b/var/spack/repos/builtin/packages/py-pyerfa/package.py
@@ -21,19 +21,24 @@ class PyPyerfa(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("2.0.1.5", sha256="17d6b24fe4846c65d5e7d8c362dcb08199dc63b30a236aedd73875cc83e1f6c0")
     version("2.0.1.1", sha256="dbac74ef8d3d3b0f22ef0ad3bbbdb30b2a9e10570b1fa5a98be34c7be36c9a6b")
     version("2.0.0.1", sha256="2fd4637ffe2c1e6ede7482c13f583ba7c73119d78bef90175448ce506a0ede30")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     # From setup.cfg
     depends_on("python@3.7:", type=("build", "run"))
-    depends_on("py-numpy@1.25:2", when="@2.0.1.1", type=("build", "run"))
+    depends_on("python@3.9:", type=("build", "run"), when="@2.0.1.5:")
+    depends_on("py-numpy@2.0.0rc1:", when="@2.0.1.5:", type="build")
+    depends_on("py-numpy@1.19.3:", when="@2.0.1.5:", type=("build", "run"))
+    depends_on("py-numpy@1.25:1", when="@2.0.1.1", type=("build", "run"))
     depends_on("py-numpy@1.17:", type=("build", "run"))
-    depends_on("py-setuptools-scm@6.2:", when="@2.0.1.1", type="build")
+    depends_on("py-setuptools-scm@6.2:", when="@2.0.1.1:", type="build")
     depends_on("py-setuptools-scm@3.4:+toml", type="build")
 
     # From pyproject.toml
     depends_on("py-setuptools@42:", type="build")
+    depends_on("py-setuptools@61.2:", type="build", when="@2.0.1.5:")
     depends_on("py-packaging", type="build")
     depends_on("py-jinja2@2.10.3:", type="build")

--- a/var/spack/repos/builtin/packages/py-regions/package.py
+++ b/var/spack/repos/builtin/packages/py-regions/package.py
@@ -1,0 +1,34 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyRegions(PythonPackage):
+    """An Astropy coordinated package for region handling"""
+
+    homepage = "https://github.com/astropy/regions"
+    pypi = "regions/regions-0.10.tar.gz"
+
+    license("BSD-3-Clause", checked_by="lgarrison")
+
+    version("0.10", sha256="961c518ea044268de0003a17953de3d4984623e9d47ad5424c100f6967e69a81")
+
+    variant("all", default=False, description="Install all optional dependencies")
+
+    depends_on("c", type="build")
+
+    depends_on("python@3.10:", type=("build", "run"))
+
+    depends_on("py-setuptools@61.2:", type="build")
+    depends_on("py-setuptools-scm@6.2:", type="build")
+    depends_on("py-cython@3.0.0:3.0", type="build")
+    depends_on("py-numpy@2.0.0rc1:", type="build")
+    depends_on("py-extension-helpers@1", type="build")
+
+    depends_on("py-numpy@1.23:", type=("build", "run"))
+    depends_on("py-astropy@5.1:", type=("build", "run"))
+
+    depends_on("py-matplotlib@3.5:", type=("build", "run"), when="+all")
+    depends_on("py-shapely", type=("build", "run"), when="+all")

--- a/var/spack/repos/builtin/packages/py-yt/package.py
+++ b/var/spack/repos/builtin/packages/py-yt/package.py
@@ -23,6 +23,7 @@ class PyYt(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("4.4.0", sha256="0e15df9cb21abe582f8128bf0705a3bc0f4805f97efd6b4f883073703941c0d5")
     version("4.1.2", sha256="0ae03288b067721baad14c016f253dc791cd444a1f2dd5d804cf91da622a0c76")
     version("3.6.1", sha256="be454f9d05dcbe0623328b4df43a1bfd1f0925e516be97399710452931a19bb0")
     version("3.6.0", sha256="effb00536f19fd2bdc18f67dacd5550b82066a6adce5b928f27a01d7505109ec")
@@ -39,13 +40,122 @@ class PyYt(PythonPackage):
     version("3.2.3", sha256="4d6ccf345d9fab965335c9faf8708c7eea79366b81d77f0f302808be3e82c0ed")
     version("3.2.2", sha256="78866f51e4751534ad60987000f149a8295952b99b37ca249d45e4d11095a5df")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     variant("astropy", default=True, description="enable astropy support")
     variant("h5py", default=True, description="enable h5py support")
     variant("scipy", default=True, description="enable scipy support")
     variant("rockstar", default=False, description="enable rockstar support")
+
+    with when("@4.4.0:"):
+        # Build dependencies:
+        depends_on("py-setuptools@61.2:", type="build")
+        depends_on("py-cython@3.0.3:", type="build")
+        depends_on("py-numpy@2.0.0:", type="build")
+        depends_on("py-ewah-bool-utils@1.2.0:", type=("build", "run"))
+
+        # Main dependencies:
+        depends_on("py-cmyt@1.1.2:", type=("build", "run"))
+        depends_on("py-matplotlib@3.5:", type=("build", "run"))
+        depends_on("py-numpy@1.21:2", type=("build", "run"))
+        conflicts("^py-numpy@2.0.1", when="target=aarch64 platform=darwin")
+        depends_on("py-pillow@8.3.2:", type=("build", "run"))
+        depends_on("py-unyt@2.9.2:", type=("build", "run"))
+        depends_on("py-typing-extensions@4.4.0:", type=("build", "run"), when="^python@:3.11")
+
+        depends_on("py-h5py@3.1.0:", type=("build", "run"), when="+h5py")
+        conflicts("^py-h5py@3.12.0", when="platform=windows")
+
+        depends_on("py-netcdf4@1.5.3:", type=("build", "run"), when="+netCDF4")
+        conflicts("^py-netcdf4@1.6.1", when="+netCDF4")
+
+        depends_on("py-f90nml@1.1:", type=("build", "run"), when="+Fortran")
+        depends_on("py-astropy@4.0.1:", type=("build", "run"), when="+astropy")
+
+        # Extras:
+        variant("netCDF4", default=False, description="enable netCDF4 support")
+        variant("Fortran", default=False, description="enable Fortran support")
+
+        variant("adaptahop", default=False, description="enable adaptahop support (no-op)")
+        variant("ahf", default=False, description="enable ahf support (no-op)")
+        variant("amrex", default=False, description="enable amrex support (no-op)")
+        variant("amrvac", default=False, description="enable amrvac support")
+        variant("art", default=False, description="enable art support (no-op)")
+        variant("arepo", default=False, description="enable arepo support")
+        variant("artio", default=False, description="enable artio support (no-op)")
+        variant("athena", default=False, description="enable athena support (no-op)")
+        variant("athena_pp", default=False, description="enable athena-pp support (no-op)")
+        variant("boxlib", default=False, description="enable boxlib support (no-op)")
+        # variant("cf_radial", default=False, description="enable cf-radial support")
+        variant("chimera", default=False, description="enable chimera support")
+        variant("chombo", default=False, description="enable chombo support")
+        variant("cholla", default=False, description="enable cholla support")
+        variant("eagle", default=False, description="enable eagle support")
+        variant("enzo_e", default=False, description="enable enzo-e support")
+        variant("enzo", default=False, description="enable enzo support")
+        variant("exodus_ii", default=False, description="enable exodus-ii support")
+        variant("fits", default=False, description="enable fits support")
+        variant("flash", default=False, description="enable flash support")
+        variant("gadget", default=False, description="enable gadget support")
+        variant("gadget_fof", default=False, description="enable gadget-fof support")
+        variant("gamer", default=False, description="enable gamer support")
+        variant("gdf", default=False, description="enable gdf support")
+        variant("gizmo", default=False, description="enable gizmo support")
+        variant("halo_catalog", default=False, description="enable halo-catalog support")
+        variant("http_stream", default=False, description="enable http-stream support")
+        variant("idefix", default=False, description="enable idefix support")
+        variant("moab", default=False, description="enable moab support")
+        variant("nc4_cm1", default=False, description="enable nc4-cm1 support")
+        variant("open_pmd", default=False, description="enable open-pmd support")
+        variant("owls", default=False, description="enable owls support")
+        variant("owls_subfind", default=False, description="enable owls-subfind support")
+        variant("parthenon", default=False, description="enable parthenon support")
+        variant("ramses", default=False, description="enable ramses support")
+        variant("sdf", default=False, description="enable sdf support")
+        variant("stream", default=False, description="enable stream support (no-op)")
+        variant("swift", default=False, description="enable swift support")
+        variant("tipsy", default=False, description="enable tipsy support (no-op)")
+        variant("ytdata", default=False, description="enable ytdata support")
+
+        conflicts("~Fortran", when="+amrvac")
+
+        conflicts("~h5py", when="+arepo")
+        # depends_on("py-xarray@0.16.1:", when="+cf_radial", type=('build', 'run'))
+        # depends_on("py-arm-pyart@1.19.2:", when="+cf_radial", type=('build', 'run'))
+        conflicts("~h5py", when="+chimera")
+        conflicts("~h5py", when="+chombo")
+        conflicts("~h5py", when="+cholla")
+        conflicts("~h5py", when="+eagle")
+        conflicts("~h5py", when="+enzo_e")
+        depends_on("py-libconf@1.0.1:", when="+enzo_e", type=("build", "run"))
+        conflicts("~h5py", when="+enzo")
+        depends_on("py-libconf@1.0.1:", when="+enzo", type=("build", "run"))
+        conflicts("~netCDF4", when="+exodus_ii")
+        depends_on("py-astropy@4.0.1:", when="+fits", type=("build", "run"))
+        depends_on("py-regions@0.7:", when="+fits", type=("build", "run"))
+        conflicts("~h5py", when="+flash")
+        conflicts("~h5py", when="+gadget")
+        conflicts("~h5py", when="+gadget_fof")
+        conflicts("~h5py", when="+gamer")
+        conflicts("~h5py", when="+gdf")
+        conflicts("~h5py", when="+gizmo")
+        conflicts("~h5py", when="+halo_catalog")
+        depends_on("py-requests@2.20.0:", when="+http_stream", type=("build", "run"))
+        conflicts("~h5py", when="+idefix")
+        conflicts("~h5py", when="+moab")
+        conflicts("~netCDF4", when="+nc4_cm1")
+        conflicts("~h5py", when="+open_pmd")
+        conflicts("~h5py", when="+owls")
+        conflicts("~h5py", when="+owls_subfind")
+        conflicts("~h5py", when="+parthenon")
+        conflicts("~Fortran", when="+ramses")
+        depends_on("py-scipy", when="+ramses", type=("build", "run"))
+        depends_on("py-requests@2.20.0:", when="+sdf", type=("build", "run"))
+        conflicts("~h5py", when="+swift")
+        conflicts("~h5py", when="+ytdata")
+
+        # variant('full', default=False, description='Enable all optional dependencies')
 
     # Main dependencies:
     # See https://github.com/yt-project/yt/blob/yt-4.1.2/setup.cfg#L40
@@ -55,7 +165,7 @@ class PyYt(PythonPackage):
     depends_on("py-matplotlib@:3.2.2", type=("build", "run"), when="@:3.6.0")
     depends_on("py-matplotlib@3.1:", type=("build", "run"), when="@4.1.2:")
     conflicts("^py-matplotlib@3.4.2", when="@4.1.2:")
-    depends_on("py-more-itertools@8.4:", when="@4.1.2:")
+    depends_on("py-more-itertools@8.4:", type=("build", "run"), when="@4.1.2:")
     depends_on("py-numpy@1.10.4:", type=("build", "run"))
     depends_on("py-numpy@1.14.5:", type=("build", "run"), when="@4.1.2:")
     # https://github.com/yt-project/yt/pull/4859
@@ -64,7 +174,7 @@ class PyYt(PythonPackage):
     # PIL/pillow and pyparsing dependency is handled by matplotlib
     depends_on("py-tomli-w@0.4:", type=("build", "run"), when="@4.1.2:")
     depends_on("py-tqdm@3.4.0:", type=("build", "run"), when="@4.1.2:")
-    depends_on("py-unyt@2.8:2", type=("build", "run"), when="@4.1.2:")
+    depends_on("py-unyt@2.8:2", type=("build", "run"), when="@4.1.2")
     depends_on("py-importlib-metadata@1.4:", type=("build", "run"), when="@4.1.2: ^python@:3.7")
     depends_on("py-tomli@1.2.3:", type=("build", "run"), when="@4.1.2: ^python@:3.10")
     depends_on("py-typing-extensions@4.2:", type=("build", "run"), when="@4.1.2: ^python@:3.7")
@@ -73,15 +183,15 @@ class PyYt(PythonPackage):
 
     # Extras:
     # See https://github.com/yt-project/yt/blob/yt-4.1.2/setup.cfg#L80
-    depends_on("py-h5py@3.1:3", type=("build", "run"), when="+h5py")
+    depends_on("py-h5py@3.1:3", type=("build", "run"), when="@:4.1.2 +h5py")
     depends_on("py-scipy@1.5.0:", type=("build", "run"), when="+scipy")
     depends_on("rockstar@yt", type=("build", "run"), when="+rockstar")
-    depends_on("py-astropy@4.0.1:5", type=("build", "run"), when="+astropy")
+    depends_on("py-astropy@4.0.1:5", type=("build", "run"), when="@:4.1.2 +astropy")
 
     # Build dependencies:
     # See https://github.com/yt-project/yt/blob/yt-4.1.2/pyproject.toml#L2
     depends_on("py-cython@0.24:", type="build")
-    depends_on("py-cython@0.29.21:2", type="build", when="@4.1.2:")
+    depends_on("py-cython@0.29.21:2", type="build", when="@4.1.2")
     depends_on("py-wheel@0.36.2:", type="build", when="@4.1.2:")
     depends_on("py-setuptools@19.6:", type=("build", "run"))
     depends_on("py-setuptools@59.0.1:", type=("build", "run"), when="@4.1.2:")

--- a/var/spack/repos/builtin/packages/py-yt/package.py
+++ b/var/spack/repos/builtin/packages/py-yt/package.py
@@ -209,3 +209,6 @@ class PyYt(PythonPackage):
         # yt = Executable(join_path(prefix.bin, "yt"))
         # yt("--help")
         python(join_path(self.prefix.bin, "yt"), "--help")
+
+    def setup_build_environment(self, env):
+        env.set("MAX_BUILD_CORES", str(make_jobs))


### PR DESCRIPTION
This PR adds py-yt version 4.4.0 and updates some dependencies. The packages affected are:
- `py-yt`: added 4.4.0
- `py-ewah-bool-utils`: added new package at version 1.2.2
- `py-regions`: added new package at version 0.10
- `py-extension-helpers`: added version 1.2.0
- `py-pyerfa`: added version 2.0.1.5

py-yt has a complicated set of optional dependencies (see [pyproject.toml](https://github.com/yt-project/yt/blob/2625a1c613e61936189df3e5e1a69028580d5281/pyproject.toml#L78)). I added most of them as variants, with the idea that it's nice to have the variants match pip extras. But some of them are no-ops, and many are aliases for another variant/extra. If we think that this makes `package.py` too complicated, we could easily remove the aliases/no-ops.

The variants I didn't add are `cf_radial` and `full`, both of which require adding a number of new Spack packages.