### PR TITLE
hermes-shm: remove duplicate line

### DIFF
--- a/var/spack/repos/builtin/packages/hermes-shm/package.py
+++ b/var/spack/repos/builtin/packages/hermes-shm/package.py
@@ -41,7 +41,6 @@ class HermesShm(CMakePackage):
     depends_on("catch2@3.0.1")
     depends_on("yaml-cpp")
     depends_on("doxygen@1.9.3:", type="build")
-    depends_on("pkgconfig", type="build")
     depends_on("libelf")
 
     # Machine variants


### PR DESCRIPTION
`depends_on("pkgconfig", type="build")` appears twice.

