### PR TITLE
Fix circularities `spack.builder` / `spack.package_base` / `spack.directives` and add type hints to package API

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -210,7 +210,7 @@ nitpick_ignore = [
     # Spack classes that are private and we don't want to expose
     ("py:class", "spack.provider_index._IndexBase"),
     ("py:class", "spack.repo._PrependFileLoader"),
-    ("py:class", "spack.build_systems._checks.BaseBuilder"),
+    ("py:class", "spack.build_systems._checks.BuilderWithDefaults"),
     # Spack classes that intersphinx is unable to resolve
     ("py:class", "spack.version.StandardVersion"),
     ("py:class", "spack.spec.DependencySpec"),

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2967,9 +2967,9 @@ make sense during the build phase may not be needed at runtime, and vice versa. 
 it makes sense to let a dependency set the environment variables for its dependents. To allow all
 this, Spack provides four different methods that can be overridden in a package:
 
-1. :meth:`setup_build_environment <spack.builder.Builder.setup_build_environment>`
+1. :meth:`setup_build_environment <spack.builder.BaseBuilder.setup_build_environment>`
 2. :meth:`setup_run_environment <spack.package_base.PackageBase.setup_run_environment>`
-3. :meth:`setup_dependent_build_environment <spack.builder.Builder.setup_dependent_build_environment>`
+3. :meth:`setup_dependent_build_environment <spack.builder.BaseBuilder.setup_dependent_build_environment>`
 4. :meth:`setup_dependent_run_environment <spack.package_base.PackageBase.setup_dependent_run_environment>`
 
 The Qt package, for instance, uses this call:

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -56,7 +56,6 @@ from llnl.util.lang import dedupe, stable_partition
 from llnl.util.symlink import symlink
 from llnl.util.tty.color import cescape, colorize
 
-import spack.build_systems._checks
 import spack.build_systems.cmake
 import spack.build_systems.meson
 import spack.build_systems.python
@@ -1375,7 +1374,7 @@ def start_build_process(pkg, function, kwargs):
     return child_result
 
 
-CONTEXT_BASES = (spack.package_base.PackageBase, spack.build_systems._checks.BaseBuilder)
+CONTEXT_BASES = (spack.package_base.PackageBase, spack.builder.Builder)
 
 
 def get_package_context(traceback, context=3):

--- a/lib/spack/spack/build_systems/_checks.py
+++ b/lib/spack/spack/build_systems/_checks.py
@@ -128,8 +128,8 @@ def execute_install_time_tests(builder: spack.builder.Builder):
     builder.pkg.tester.phase_tests(builder, "install", builder.install_time_test_callbacks)
 
 
-class BaseBuilder(spack.builder.Builder):
-    """Base class for builders to register common checks"""
+class BuilderWithDefaults(spack.builder.Builder):
+    """Base class for all specific builders with common callbacks registered."""
 
     # Check that self.prefix is there after installation
     spack.phase_callbacks.run_after("install")(sanity_check_prefix)

--- a/lib/spack/spack/build_systems/_checks.py
+++ b/lib/spack/spack/build_systems/_checks.py
@@ -72,7 +72,7 @@ def ensure_build_dependencies_or_raise(
 
     Args:
         spec: concrete spec to be checked.
-        dependencies: list of abstract specs to be satisfied
+        dependencies: list of package names of required build dependencies
         error_msg: brief error message to be prepended to a longer description
 
     Raises:

--- a/lib/spack/spack/build_systems/_checks.py
+++ b/lib/spack/spack/build_systems/_checks.py
@@ -9,6 +9,7 @@ import llnl.util.lang
 
 import spack.builder
 import spack.error
+import spack.phase_callbacks
 import spack.relocate
 import spack.spec
 import spack.store
@@ -63,7 +64,7 @@ def apply_macos_rpath_fixups(builder: spack.builder.Builder):
 
 
 def ensure_build_dependencies_or_raise(
-    spec: spack.spec.Spec, dependencies: List[spack.spec.Spec], error_msg: str
+    spec: spack.spec.Spec, dependencies: List[str], error_msg: str
 ):
     """Ensure that some build dependencies are present in the concrete spec.
 
@@ -131,4 +132,4 @@ class BaseBuilder(spack.builder.Builder):
     """Base class for builders to register common checks"""
 
     # Check that self.prefix is there after installation
-    spack.builder.run_after("install")(sanity_check_prefix)
+    spack.phase_callbacks.run_after("install")(sanity_check_prefix)

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -25,7 +25,7 @@ from spack.util.executable import Executable
 from spack.version import Version
 
 from ._checks import (
-    BaseBuilder,
+    BuilderWithDefaults,
     apply_macos_rpath_fixups,
     ensure_build_dependencies_or_raise,
     execute_build_time_tests,
@@ -79,7 +79,7 @@ class AutotoolsPackage(spack.package_base.PackageBase):
 
 
 @spack.builder.builder("autotools")
-class AutotoolsBuilder(BaseBuilder):
+class AutotoolsBuilder(BuilderWithDefaults):
     """The autotools builder encodes the default way of installing software built
     with autotools. It has four phases that can be overridden, if need be:
 

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -6,7 +6,7 @@ import os
 import os.path
 import stat
 import subprocess
-from typing import List
+from typing import Callable, List, Optional, Set, Tuple, Union
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
@@ -15,6 +15,9 @@ import spack.build_environment
 import spack.builder
 import spack.error
 import spack.package_base
+import spack.phase_callbacks
+import spack.spec
+import spack.util.prefix
 from spack.directives import build_system, conflicts, depends_on
 from spack.multimethod import when
 from spack.operating_systems.mac_os import macos_version
@@ -157,7 +160,7 @@ class AutotoolsBuilder(BaseBuilder):
     install_libtool_archives = False
 
     @property
-    def patch_config_files(self):
+    def patch_config_files(self) -> bool:
         """Whether to update old ``config.guess`` and ``config.sub`` files
         distributed with the tarball.
 
@@ -177,7 +180,7 @@ class AutotoolsBuilder(BaseBuilder):
         )
 
     @property
-    def _removed_la_files_log(self):
+    def _removed_la_files_log(self) -> str:
         """File containing the list of removed libtool archives"""
         build_dir = self.build_directory
         if not os.path.isabs(self.build_directory):
@@ -185,15 +188,15 @@ class AutotoolsBuilder(BaseBuilder):
         return os.path.join(build_dir, "removed_la_files.txt")
 
     @property
-    def archive_files(self):
+    def archive_files(self) -> List[str]:
         """Files to archive for packages based on autotools"""
         files = [os.path.join(self.build_directory, "config.log")]
         if not self.install_libtool_archives:
             files.append(self._removed_la_files_log)
         return files
 
-    @spack.builder.run_after("autoreconf")
-    def _do_patch_config_files(self):
+    @spack.phase_callbacks.run_after("autoreconf")
+    def _do_patch_config_files(self) -> None:
         """Some packages ship with older config.guess/config.sub files and need to
         have these updated when installed on a newer architecture.
 
@@ -294,7 +297,7 @@ To resolve this problem, please try the following:
    and set the prefix to the directory containing the `config.guess` and
    `config.sub` files.
 """
-            raise spack.error.InstallError(msg.format(", ".join(to_be_found), self.name))
+            raise spack.error.InstallError(msg.format(", ".join(to_be_found), self.pkg.name))
 
         # Copy the good files over the bad ones
         for abs_path in to_be_patched:
@@ -304,8 +307,8 @@ To resolve this problem, please try the following:
             fs.copy(substitutes[name], abs_path)
             os.chmod(abs_path, mode)
 
-    @spack.builder.run_before("configure")
-    def _patch_usr_bin_file(self):
+    @spack.phase_callbacks.run_before("configure")
+    def _patch_usr_bin_file(self) -> None:
         """On NixOS file is not available in /usr/bin/file. Patch configure
         scripts to use file from path."""
 
@@ -316,8 +319,8 @@ To resolve this problem, please try the following:
             with fs.keep_modification_time(*x.filenames):
                 x.filter(regex="/usr/bin/file", repl="file", string=True)
 
-    @spack.builder.run_before("configure")
-    def _set_autotools_environment_variables(self):
+    @spack.phase_callbacks.run_before("configure")
+    def _set_autotools_environment_variables(self) -> None:
         """Many autotools builds use a version of mknod.m4 that fails when
         running as root unless FORCE_UNSAFE_CONFIGURE is set to 1.
 
@@ -330,8 +333,8 @@ To resolve this problem, please try the following:
         """
         os.environ["FORCE_UNSAFE_CONFIGURE"] = "1"
 
-    @spack.builder.run_before("configure")
-    def _do_patch_libtool_configure(self):
+    @spack.phase_callbacks.run_before("configure")
+    def _do_patch_libtool_configure(self) -> None:
         """Patch bugs that propagate from libtool macros into "configure" and
         further into "libtool". Note that patches that can be fixed by patching
         "libtool" directly should be implemented in the _do_patch_libtool method
@@ -358,8 +361,8 @@ To resolve this problem, please try the following:
             # Support Libtool 2.4.2 and older:
             x.filter(regex=r'^(\s*test \$p = "-R")(; then\s*)$', repl=r'\1 || test x-l = x"$p"\2')
 
-    @spack.builder.run_after("configure")
-    def _do_patch_libtool(self):
+    @spack.phase_callbacks.run_after("configure")
+    def _do_patch_libtool(self) -> None:
         """If configure generates a "libtool" script that does not correctly
         detect the compiler (and patch_libtool is set), patch in the correct
         values for libtool variables.
@@ -507,27 +510,64 @@ To resolve this problem, please try the following:
             )
 
     @property
-    def configure_directory(self):
+    def configure_directory(self) -> str:
         """Return the directory where 'configure' resides."""
         return self.pkg.stage.source_path
 
     @property
-    def configure_abs_path(self):
+    def configure_abs_path(self) -> str:
         # Absolute path to configure
         configure_abs_path = os.path.join(os.path.abspath(self.configure_directory), "configure")
         return configure_abs_path
 
     @property
-    def build_directory(self):
+    def build_directory(self) -> str:
         """Override to provide another place to build the package"""
         return self.configure_directory
 
-    @spack.builder.run_before("autoreconf")
-    def delete_configure_to_force_update(self):
+    @spack.phase_callbacks.run_before("autoreconf")
+    def delete_configure_to_force_update(self) -> None:
         if self.force_autoreconf:
             fs.force_remove(self.configure_abs_path)
 
-    def autoreconf(self, pkg, spec, prefix):
+    @property
+    def autoreconf_search_path_args(self) -> List[str]:
+        """Search path includes for autoreconf. Add an -I flag for all `aclocal` dirs
+        of build deps, skips the default path of automake, move external include
+        flags to the back, since they might pull in unrelated m4 files shadowing
+        spack dependencies."""
+        return _autoreconf_search_path_args(self.spec)
+
+    @spack.phase_callbacks.run_after("autoreconf")
+    def set_configure_or_die(self) -> None:
+        """Ensure the presence of a "configure" script, or raise. If the "configure"
+        is found, a module level attribute is set.
+
+        Raises:
+             RuntimeError: if the "configure" script is not found
+        """
+        # Check if the "configure" script is there. If not raise a RuntimeError.
+        if not os.path.exists(self.configure_abs_path):
+            msg = "configure script not found in {0}"
+            raise RuntimeError(msg.format(self.configure_directory))
+
+        # Monkey-patch the configure script in the corresponding module
+        globals_for_pkg = spack.build_environment.ModuleChangePropagator(self.pkg)
+        globals_for_pkg.configure = Executable(self.configure_abs_path)
+        globals_for_pkg.propagate_changes_to_mro()
+
+    def configure_args(self) -> List[str]:
+        """Return the list of all the arguments that must be passed to configure,
+        except ``--prefix`` which will be pre-pended to the list.
+        """
+        return []
+
+    def autoreconf(
+        self,
+        pkg: spack.package_base.PackageBase,
+        spec: spack.spec.Spec,
+        prefix: spack.util.prefix.Prefix,
+    ) -> None:
         """Not needed usually, configure should be already there"""
 
         # If configure exists nothing needs to be done
@@ -554,39 +594,12 @@ To resolve this problem, please try the following:
             autoreconf_args += self.autoreconf_extra_args
             self.pkg.module.autoreconf(*autoreconf_args)
 
-    @property
-    def autoreconf_search_path_args(self):
-        """Search path includes for autoreconf. Add an -I flag for all `aclocal` dirs
-        of build deps, skips the default path of automake, move external include
-        flags to the back, since they might pull in unrelated m4 files shadowing
-        spack dependencies."""
-        return _autoreconf_search_path_args(self.spec)
-
-    @spack.builder.run_after("autoreconf")
-    def set_configure_or_die(self):
-        """Ensure the presence of a "configure" script, or raise. If the "configure"
-        is found, a module level attribute is set.
-
-        Raises:
-             RuntimeError: if the "configure" script is not found
-        """
-        # Check if the "configure" script is there. If not raise a RuntimeError.
-        if not os.path.exists(self.configure_abs_path):
-            msg = "configure script not found in {0}"
-            raise RuntimeError(msg.format(self.configure_directory))
-
-        # Monkey-patch the configure script in the corresponding module
-        globals_for_pkg = spack.build_environment.ModuleChangePropagator(self.pkg)
-        globals_for_pkg.configure = Executable(self.configure_abs_path)
-        globals_for_pkg.propagate_changes_to_mro()
-
-    def configure_args(self):
-        """Return the list of all the arguments that must be passed to configure,
-        except ``--prefix`` which will be pre-pended to the list.
-        """
-        return []
-
-    def configure(self, pkg, spec, prefix):
+    def configure(
+        self,
+        pkg: spack.package_base.PackageBase,
+        spec: spack.spec.Spec,
+        prefix: spack.util.prefix.Prefix,
+    ) -> None:
         """Run "configure", with the arguments specified by the builder and an
         appropriately set prefix.
         """
@@ -597,7 +610,12 @@ To resolve this problem, please try the following:
         with fs.working_dir(self.build_directory, create=True):
             pkg.module.configure(*options)
 
-    def build(self, pkg, spec, prefix):
+    def build(
+        self,
+        pkg: spack.package_base.PackageBase,
+        spec: spack.spec.Spec,
+        prefix: spack.util.prefix.Prefix,
+    ) -> None:
         """Run "make" on the build targets specified by the builder."""
         # See https://autotools.io/automake/silent.html
         params = ["V=1"]
@@ -605,41 +623,49 @@ To resolve this problem, please try the following:
         with fs.working_dir(self.build_directory):
             pkg.module.make(*params)
 
-    def install(self, pkg, spec, prefix):
+    def install(
+        self,
+        pkg: spack.package_base.PackageBase,
+        spec: spack.spec.Spec,
+        prefix: spack.util.prefix.Prefix,
+    ) -> None:
         """Run "make" on the install targets specified by the builder."""
         with fs.working_dir(self.build_directory):
             pkg.module.make(*self.install_targets)
 
-    spack.builder.run_after("build")(execute_build_time_tests)
+    spack.phase_callbacks.run_after("build")(execute_build_time_tests)
 
-    def check(self):
+    def check(self) -> None:
         """Run "make" on the ``test`` and ``check`` targets, if found."""
         with fs.working_dir(self.build_directory):
             self.pkg._if_make_target_execute("test")
             self.pkg._if_make_target_execute("check")
 
     def _activate_or_not(
-        self, name, activation_word, deactivation_word, activation_value=None, variant=None
-    ):
+        self,
+        name: str,
+        activation_word: str,
+        deactivation_word: str,
+        activation_value: Optional[Union[Callable, str]] = None,
+        variant=None,
+    ) -> List[str]:
         """This function contain the current implementation details of
         :meth:`~spack.build_systems.autotools.AutotoolsBuilder.with_or_without` and
         :meth:`~spack.build_systems.autotools.AutotoolsBuilder.enable_or_disable`.
 
         Args:
-            name (str): name of the option that is being activated or not
-            activation_word (str): the default activation word ('with' in the
-                case of ``with_or_without``)
-            deactivation_word (str): the default deactivation word ('without'
-                in the case of ``with_or_without``)
-            activation_value (typing.Callable): callable that accepts a single
-                value. This value is either one of the allowed values for a
-                multi-valued variant or the name of a bool-valued variant.
+            name: name of the option that is being activated or not
+            activation_word: the default activation word ('with' in the case of
+                ``with_or_without``)
+            deactivation_word: the default deactivation word ('without' in the case of
+                ``with_or_without``)
+            activation_value: callable that accepts a single value. This value is either one of the
+                allowed values for a multi-valued variant or the name of a bool-valued variant.
                 Returns the parameter to be used when the value is activated.
 
-                The special value 'prefix' can also be assigned and will return
+                The special value "prefix" can also be assigned and will return
                 ``spec[name].prefix`` as activation parameter.
-            variant (str): name of the variant that is being processed
-                           (if different from option name)
+            variant: name of the variant that is being processed (if different from option name)
 
         Examples:
 
@@ -647,19 +673,19 @@ To resolve this problem, please try the following:
 
             .. code-block:: python
 
-                variant('foo', values=('x', 'y'), description='')
-                variant('bar', default=True, description='')
-                variant('ba_z', default=True, description='')
+                variant("foo", values=("x", "y"), description=")
+                variant("bar", default=True, description=")
+                variant("ba_z", default=True, description=")
 
             calling this function like:
 
             .. code-block:: python
 
                 _activate_or_not(
-                    'foo', 'with', 'without', activation_value='prefix'
+                    "foo", "with", "without", activation_value="prefix"
                 )
-                _activate_or_not('bar', 'with', 'without')
-                _activate_or_not('ba-z', 'with', 'without', variant='ba_z')
+                _activate_or_not("bar", "with", "without")
+                _activate_or_not("ba-z", "with", "without", variant="ba_z")
 
             will generate the following configuration options:
 
@@ -679,8 +705,8 @@ To resolve this problem, please try the following:
         Raises:
             KeyError: if name is not among known variants
         """
-        spec = self.pkg.spec
-        args = []
+        spec: spack.spec.Spec = self.pkg.spec
+        args: List[str] = []
 
         if activation_value == "prefix":
             activation_value = lambda x: spec[x].prefix
@@ -698,7 +724,7 @@ To resolve this problem, please try the following:
         # Create a list of pairs. Each pair includes a configuration
         # option and whether or not that option is activated
         vdef = self.pkg.get_variant(variant)
-        if set(vdef.values) == set((True, False)):
+        if set(vdef.values) == set((True, False)):  # type: ignore
             # BoolValuedVariant carry information about a single option.
             # Nonetheless, for uniformity of treatment we'll package them
             # in an iterable of one element.
@@ -709,14 +735,12 @@ To resolve this problem, please try the following:
             # package's build system. It excludes values which have special
             # meanings and do not correspond to features (e.g. "none")
             feature_values = getattr(vdef.values, "feature_values", None) or vdef.values
-            options = [(value, f"{variant}={value}" in spec) for value in feature_values]
+            options = [(v, f"{variant}={v}" in spec) for v in feature_values]  # type: ignore
 
         # For each allowed value in the list of values
         for option_value, activated in options:
             # Search for an override in the package for this value
-            override_name = "{0}_or_{1}_{2}".format(
-                activation_word, deactivation_word, option_value
-            )
+            override_name = f"{activation_word}_or_{deactivation_word}_{option_value}"
             line_generator = getattr(self, override_name, None) or getattr(
                 self.pkg, override_name, None
             )
@@ -725,19 +749,24 @@ To resolve this problem, please try the following:
 
                 def _default_generator(is_activated):
                     if is_activated:
-                        line = "--{0}-{1}".format(activation_word, option_value)
+                        line = f"--{activation_word}-{option_value}"
                         if activation_value is not None and activation_value(
                             option_value
                         ):  # NOQA=ignore=E501
-                            line += "={0}".format(activation_value(option_value))
+                            line = f"{line}={activation_value(option_value)}"
                         return line
-                    return "--{0}-{1}".format(deactivation_word, option_value)
+                    return f"--{deactivation_word}-{option_value}"
 
                 line_generator = _default_generator
             args.append(line_generator(activated))
         return args
 
-    def with_or_without(self, name, activation_value=None, variant=None):
+    def with_or_without(
+        self,
+        name: str,
+        activation_value: Optional[Union[Callable, str]] = None,
+        variant: Optional[str] = None,
+    ) -> List[str]:
         """Inspects a variant and returns the arguments that activate
         or deactivate the selected feature(s) for the configure options.
 
@@ -752,12 +781,11 @@ To resolve this problem, please try the following:
         ``variant=value`` is in the spec.
 
         Args:
-            name (str): name of a valid multi-valued variant
-            activation_value (typing.Callable): callable that accepts a single
-                value and returns the parameter to be used leading to an entry
-                of the type ``--with-{name}={parameter}``.
+            name: name of a valid multi-valued variant
+            activation_value: callable that accepts a single value and returns the parameter to be
+                used leading to an entry of the type ``--with-{name}={parameter}``.
 
-                The special value 'prefix' can also be assigned and will return
+                The special value "prefix" can also be assigned and will return
                 ``spec[name].prefix`` as activation parameter.
 
         Returns:
@@ -765,18 +793,22 @@ To resolve this problem, please try the following:
         """
         return self._activate_or_not(name, "with", "without", activation_value, variant)
 
-    def enable_or_disable(self, name, activation_value=None, variant=None):
+    def enable_or_disable(
+        self,
+        name: str,
+        activation_value: Optional[Union[Callable, str]] = None,
+        variant: Optional[str] = None,
+    ) -> List[str]:
         """Same as
         :meth:`~spack.build_systems.autotools.AutotoolsBuilder.with_or_without`
         but substitute ``with`` with ``enable`` and ``without`` with ``disable``.
 
         Args:
-            name (str): name of a valid multi-valued variant
-            activation_value (typing.Callable): if present accepts a single value
-                and returns the parameter to be used leading to an entry of the
-                type ``--enable-{name}={parameter}``
+            name: name of a valid multi-valued variant
+            activation_value: if present accepts a single value and returns the parameter to be
+                used leading to an entry of the type ``--enable-{name}={parameter}``
 
-                The special value 'prefix' can also be assigned and will return
+                The special value "prefix" can also be assigned and will return
                 ``spec[name].prefix`` as activation parameter.
 
         Returns:
@@ -784,15 +816,15 @@ To resolve this problem, please try the following:
         """
         return self._activate_or_not(name, "enable", "disable", activation_value, variant)
 
-    spack.builder.run_after("install")(execute_install_time_tests)
+    spack.phase_callbacks.run_after("install")(execute_install_time_tests)
 
-    def installcheck(self):
+    def installcheck(self) -> None:
         """Run "make" on the ``installcheck`` target, if found."""
         with fs.working_dir(self.build_directory):
             self.pkg._if_make_target_execute("installcheck")
 
-    @spack.builder.run_after("install")
-    def remove_libtool_archives(self):
+    @spack.phase_callbacks.run_after("install")
+    def remove_libtool_archives(self) -> None:
         """Remove all .la files in prefix sub-folders if the package sets
         ``install_libtool_archives`` to be False.
         """
@@ -814,12 +846,13 @@ To resolve this problem, please try the following:
             env.set("MACOSX_DEPLOYMENT_TARGET", "10.16")
 
     # On macOS, force rpaths for shared library IDs and remove duplicate rpaths
-    spack.builder.run_after("install", when="platform=darwin")(apply_macos_rpath_fixups)
+    spack.phase_callbacks.run_after("install", when="platform=darwin")(apply_macos_rpath_fixups)
 
 
-def _autoreconf_search_path_args(spec):
-    dirs_seen = set()
-    flags_spack, flags_external = [], []
+def _autoreconf_search_path_args(spec: spack.spec.Spec) -> List[str]:
+    dirs_seen: Set[Tuple[int, int]] = set()
+    flags_spack: List[str] = []
+    flags_external: List[str] = []
 
     # We don't want to add an include flag for automake's default search path.
     for automake in spec.dependencies(name="automake", deptype="build"):

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -72,10 +72,10 @@ class AutotoolsPackage(spack.package_base.PackageBase):
     # Legacy methods (used by too many packages to change them,
     # need to forward to the builder)
     def enable_or_disable(self, *args, **kwargs):
-        return self.builder.enable_or_disable(*args, **kwargs)
+        return spack.builder.create(self).enable_or_disable(*args, **kwargs)
 
     def with_or_without(self, *args, **kwargs):
-        return self.builder.with_or_without(*args, **kwargs)
+        return spack.builder.create(self).with_or_without(*args, **kwargs)
 
 
 @spack.builder.builder("autotools")

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -11,6 +11,7 @@ import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
 import spack.builder
+import spack.phase_callbacks
 
 from .cmake import CMakeBuilder, CMakePackage
 
@@ -332,7 +333,7 @@ class CachedCMakeBuilder(CMakeBuilder):
         args.extend(["-C", self.cache_path])
         return args
 
-    @spack.builder.run_after("install")
+    @spack.phase_callbacks.run_after("install")
     def install_cmake_cache(self):
         fs.mkdirp(self.pkg.spec.prefix.share.cmake)
         fs.install(self.cache_path, self.pkg.spec.prefix.share.cmake)

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -10,7 +10,6 @@ from typing import Tuple
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
-import spack.builder
 import spack.phase_callbacks
 
 from .cmake import CMakeBuilder, CMakePackage

--- a/lib/spack/spack/build_systems/cargo.py
+++ b/lib/spack/spack/build_systems/cargo.py
@@ -7,6 +7,7 @@ import llnl.util.filesystem as fs
 
 import spack.builder
 import spack.package_base
+import spack.phase_callbacks
 from spack.directives import build_system, depends_on
 from spack.multimethod import when
 
@@ -77,7 +78,7 @@ class CargoBuilder(BaseBuilder):
         with fs.working_dir(self.build_directory):
             fs.install_tree("out", prefix)
 
-    spack.builder.run_after("install")(execute_install_time_tests)
+    spack.phase_callbacks.run_after("install")(execute_install_time_tests)
 
     def check(self):
         """Run "cargo test"."""

--- a/lib/spack/spack/build_systems/cargo.py
+++ b/lib/spack/spack/build_systems/cargo.py
@@ -11,7 +11,7 @@ import spack.phase_callbacks
 from spack.directives import build_system, depends_on
 from spack.multimethod import when
 
-from ._checks import BaseBuilder, execute_install_time_tests
+from ._checks import BuilderWithDefaults, execute_install_time_tests
 
 
 class CargoPackage(spack.package_base.PackageBase):
@@ -28,7 +28,7 @@ class CargoPackage(spack.package_base.PackageBase):
 
 
 @spack.builder.builder("cargo")
-class CargoBuilder(BaseBuilder):
+class CargoBuilder(BuilderWithDefaults):
     """The Cargo builder encodes the most common way of building software with
     a rust Cargo.toml file. It has two phases that can be overridden, if need be:
 

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -25,7 +25,7 @@ from spack.directives import build_system, conflicts, depends_on, variant
 from spack.multimethod import when
 from spack.util.environment import filter_system_paths
 
-from ._checks import BaseBuilder, execute_build_time_tests
+from ._checks import BuilderWithDefaults, execute_build_time_tests
 
 # Regex to extract the primary generator from the CMake generator
 # string.
@@ -280,7 +280,7 @@ class CMakePackage(spack.package_base.PackageBase):
 
 
 @spack.builder.builder("cmake")
-class CMakeBuilder(BaseBuilder):
+class CMakeBuilder(BuilderWithDefaults):
     """The cmake builder encodes the default way of building software with CMake. IT
     has three phases that can be overridden:
 

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -347,7 +347,7 @@ class CMakeBuilder(BaseBuilder):
         if self.spec.satisfies("generator=ninja"):
             return "Ninja"
         raise ValueError(
-            f"{self.spec.format()} has an unsupported value " 'for the "generator" variant'
+            f'{self.spec.format()} has an unsupported value for the "generator" variant'
         )
 
     @property

--- a/lib/spack/spack/build_systems/generic.py
+++ b/lib/spack/spack/build_systems/generic.py
@@ -9,7 +9,7 @@ import spack.directives
 import spack.package_base
 import spack.phase_callbacks
 
-from ._checks import BaseBuilder, apply_macos_rpath_fixups, execute_install_time_tests
+from ._checks import BuilderWithDefaults, apply_macos_rpath_fixups, execute_install_time_tests
 
 
 class Package(spack.package_base.PackageBase):
@@ -27,7 +27,7 @@ class Package(spack.package_base.PackageBase):
 
 
 @spack.builder.builder("generic")
-class GenericBuilder(BaseBuilder):
+class GenericBuilder(BuilderWithDefaults):
     """A builder for a generic build system, that require packagers
     to implement an "install" phase.
     """

--- a/lib/spack/spack/build_systems/generic.py
+++ b/lib/spack/spack/build_systems/generic.py
@@ -7,6 +7,7 @@ from typing import Tuple
 import spack.builder
 import spack.directives
 import spack.package_base
+import spack.phase_callbacks
 
 from ._checks import BaseBuilder, apply_macos_rpath_fixups, execute_install_time_tests
 
@@ -44,7 +45,7 @@ class GenericBuilder(BaseBuilder):
     install_time_test_callbacks = []
 
     # On macOS, force rpaths for shared library IDs and remove duplicate rpaths
-    spack.builder.run_after("install", when="platform=darwin")(apply_macos_rpath_fixups)
+    spack.phase_callbacks.run_after("install", when="platform=darwin")(apply_macos_rpath_fixups)
 
     # unconditionally perform any post-install phase tests
-    spack.builder.run_after("install")(execute_install_time_tests)
+    spack.phase_callbacks.run_after("install")(execute_install_time_tests)

--- a/lib/spack/spack/build_systems/go.py
+++ b/lib/spack/spack/build_systems/go.py
@@ -11,7 +11,7 @@ import spack.phase_callbacks
 from spack.directives import build_system, extends
 from spack.multimethod import when
 
-from ._checks import BaseBuilder, execute_install_time_tests
+from ._checks import BuilderWithDefaults, execute_install_time_tests
 
 
 class GoPackage(spack.package_base.PackageBase):
@@ -33,7 +33,7 @@ class GoPackage(spack.package_base.PackageBase):
 
 
 @spack.builder.builder("go")
-class GoBuilder(BaseBuilder):
+class GoBuilder(BuilderWithDefaults):
     """The Go builder encodes the most common way of building software with
     a golang go.mod file. It has two phases that can be overridden, if need be:
 

--- a/lib/spack/spack/build_systems/go.py
+++ b/lib/spack/spack/build_systems/go.py
@@ -7,6 +7,7 @@ import llnl.util.filesystem as fs
 
 import spack.builder
 import spack.package_base
+import spack.phase_callbacks
 from spack.directives import build_system, extends
 from spack.multimethod import when
 
@@ -99,7 +100,7 @@ class GoBuilder(BaseBuilder):
             fs.mkdirp(prefix.bin)
             fs.install(pkg.name, prefix.bin)
 
-    spack.builder.run_after("install")(execute_install_time_tests)
+    spack.phase_callbacks.run_after("install")(execute_install_time_tests)
 
     def check(self):
         """Run ``go test .`` in the source directory"""

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -24,6 +24,7 @@ from llnl.util.filesystem import (
 
 import spack.builder
 import spack.error
+import spack.phase_callbacks
 from spack.build_environment import dso_suffix
 from spack.error import InstallError
 from spack.util.environment import EnvironmentModifications
@@ -1163,7 +1164,7 @@ class IntelPackage(Package):
         debug_print(license_type)
         return license_type
 
-    @spack.builder.run_before("install")
+    @spack.phase_callbacks.run_before("install")
     def configure(self):
         """Generates the silent.cfg file to pass to installer.sh.
 
@@ -1250,7 +1251,7 @@ class IntelPackage(Package):
         for f in glob.glob("%s/intel*log" % tmpdir):
             install(f, dst)
 
-    @spack.builder.run_after("install")
+    @spack.phase_callbacks.run_after("install")
     def validate_install(self):
         # Sometimes the installer exits with an error but doesn't pass a
         # non-zero exit code to spack. Check for the existence of a 'bin'
@@ -1258,7 +1259,7 @@ class IntelPackage(Package):
         if not os.path.exists(self.prefix.bin):
             raise InstallError("The installer has failed to install anything.")
 
-    @spack.builder.run_after("install")
+    @spack.phase_callbacks.run_after("install")
     def configure_rpath(self):
         if "+rpath" not in self.spec:
             return
@@ -1276,7 +1277,7 @@ class IntelPackage(Package):
             with open(compiler_cfg, "w") as fh:
                 fh.write("-Xlinker -rpath={0}\n".format(compilers_lib_dir))
 
-    @spack.builder.run_after("install")
+    @spack.phase_callbacks.run_after("install")
     def configure_auto_dispatch(self):
         if self._has_compilers:
             if "auto_dispatch=none" in self.spec:
@@ -1300,7 +1301,7 @@ class IntelPackage(Package):
                 with open(compiler_cfg, "a") as fh:
                     fh.write("-ax{0}\n".format(",".join(ad)))
 
-    @spack.builder.run_after("install")
+    @spack.phase_callbacks.run_after("install")
     def filter_compiler_wrappers(self):
         if ("+mpi" in self.spec or self.provides("mpi")) and "~newdtags" in self.spec:
             bin_dir = self.component_bin_dir("mpi")
@@ -1308,7 +1309,7 @@ class IntelPackage(Package):
                 f = os.path.join(bin_dir, f)
                 filter_file("-Xlinker --enable-new-dtags", " ", f, string=True)
 
-    @spack.builder.run_after("install")
+    @spack.phase_callbacks.run_after("install")
     def uninstall_ism(self):
         # The "Intel(R) Software Improvement Program" [ahem] gets installed,
         # apparently regardless of PHONEHOME_SEND_USAGE_DATA.
@@ -1340,7 +1341,7 @@ class IntelPackage(Package):
         debug_print(d)
         return d
 
-    @spack.builder.run_after("install")
+    @spack.phase_callbacks.run_after("install")
     def modify_LLVMgold_rpath(self):
         """Add libimf.so and other required libraries to the RUNPATH of LLVMgold.so.
 

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -22,7 +22,6 @@ from llnl.util.filesystem import (
     install,
 )
 
-import spack.builder
 import spack.error
 import spack.phase_callbacks
 from spack.build_environment import dso_suffix

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -8,6 +8,7 @@ import llnl.util.filesystem as fs
 
 import spack.builder
 import spack.package_base
+import spack.phase_callbacks
 from spack.directives import build_system, conflicts, depends_on
 from spack.multimethod import when
 
@@ -109,7 +110,7 @@ class MakefileBuilder(BaseBuilder):
         with fs.working_dir(self.build_directory):
             pkg.module.make(*self.install_targets)
 
-    spack.builder.run_after("build")(execute_build_time_tests)
+    spack.phase_callbacks.run_after("build")(execute_build_time_tests)
 
     def check(self):
         """Run "make" on the ``test`` and ``check`` targets, if found."""
@@ -117,7 +118,7 @@ class MakefileBuilder(BaseBuilder):
             self.pkg._if_make_target_execute("test")
             self.pkg._if_make_target_execute("check")
 
-    spack.builder.run_after("install")(execute_install_time_tests)
+    spack.phase_callbacks.run_after("install")(execute_install_time_tests)
 
     def installcheck(self):
         """Searches the Makefile for an ``installcheck`` target
@@ -127,4 +128,4 @@ class MakefileBuilder(BaseBuilder):
             self.pkg._if_make_target_execute("installcheck")
 
     # On macOS, force rpaths for shared library IDs and remove duplicate rpaths
-    spack.builder.run_after("install", when="platform=darwin")(apply_macos_rpath_fixups)
+    spack.phase_callbacks.run_after("install", when="platform=darwin")(apply_macos_rpath_fixups)

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -15,7 +15,7 @@ from spack.directives import build_system, conflicts, depends_on
 from spack.multimethod import when
 
 from ._checks import (
-    BaseBuilder,
+    BuilderWithDefaults,
     apply_macos_rpath_fixups,
     execute_build_time_tests,
     execute_install_time_tests,
@@ -39,7 +39,7 @@ class MakefilePackage(spack.package_base.PackageBase):
 
 
 @spack.builder.builder("makefile")
-class MakefileBuilder(BaseBuilder):
+class MakefileBuilder(BuilderWithDefaults):
     """The Makefile builder encodes the most common way of building software with
     Makefiles. It has three phases that can be overridden, if need be:
 

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -9,6 +9,8 @@ import llnl.util.filesystem as fs
 import spack.builder
 import spack.package_base
 import spack.phase_callbacks
+import spack.spec
+import spack.util.prefix
 from spack.directives import build_system, conflicts, depends_on
 from spack.multimethod import when
 
@@ -92,27 +94,42 @@ class MakefileBuilder(BaseBuilder):
     install_time_test_callbacks = ["installcheck"]
 
     @property
-    def build_directory(self):
+    def build_directory(self) -> str:
         """Return the directory containing the main Makefile."""
         return self.pkg.stage.source_path
 
-    def edit(self, pkg, spec, prefix):
+    def edit(
+        self,
+        pkg: spack.package_base.PackageBase,
+        spec: spack.spec.Spec,
+        prefix: spack.util.prefix.Prefix,
+    ) -> None:
         """Edit the Makefile before calling make. The default is a no-op."""
         pass
 
-    def build(self, pkg, spec, prefix):
+    def build(
+        self,
+        pkg: spack.package_base.PackageBase,
+        spec: spack.spec.Spec,
+        prefix: spack.util.prefix.Prefix,
+    ) -> None:
         """Run "make" on the build targets specified by the builder."""
         with fs.working_dir(self.build_directory):
             pkg.module.make(*self.build_targets)
 
-    def install(self, pkg, spec, prefix):
+    def install(
+        self,
+        pkg: spack.package_base.PackageBase,
+        spec: spack.spec.Spec,
+        prefix: spack.util.prefix.Prefix,
+    ) -> None:
         """Run "make" on the install targets specified by the builder."""
         with fs.working_dir(self.build_directory):
             pkg.module.make(*self.install_targets)
 
     spack.phase_callbacks.run_after("build")(execute_build_time_tests)
 
-    def check(self):
+    def check(self) -> None:
         """Run "make" on the ``test`` and ``check`` targets, if found."""
         with fs.working_dir(self.build_directory):
             self.pkg._if_make_target_execute("test")
@@ -120,7 +137,7 @@ class MakefileBuilder(BaseBuilder):
 
     spack.phase_callbacks.run_after("install")(execute_install_time_tests)
 
-    def installcheck(self):
+    def installcheck(self) -> None:
         """Searches the Makefile for an ``installcheck`` target
         and runs it if found.
         """

--- a/lib/spack/spack/build_systems/maven.py
+++ b/lib/spack/spack/build_systems/maven.py
@@ -10,7 +10,7 @@ from spack.directives import build_system, depends_on
 from spack.multimethod import when
 from spack.util.executable import which
 
-from ._checks import BaseBuilder
+from ._checks import BuilderWithDefaults
 
 
 class MavenPackage(spack.package_base.PackageBase):
@@ -34,7 +34,7 @@ class MavenPackage(spack.package_base.PackageBase):
 
 
 @spack.builder.builder("maven")
-class MavenBuilder(BaseBuilder):
+class MavenBuilder(BuilderWithDefaults):
     """The Maven builder encodes the default way to build software with Maven.
     It has two phases that can be overridden, if need be:
 

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -9,6 +9,9 @@ import llnl.util.filesystem as fs
 
 import spack.builder
 import spack.package_base
+import spack.phase_callbacks
+import spack.spec
+import spack.util.prefix
 from spack.directives import build_system, conflicts, depends_on, variant
 from spack.multimethod import when
 
@@ -112,7 +115,7 @@ class MesonBuilder(BaseBuilder):
         return [os.path.join(self.build_directory, "meson-logs", "meson-log.txt")]
 
     @property
-    def root_mesonlists_dir(self):
+    def root_mesonlists_dir(self) -> str:
         """Relative path to the directory containing meson.build
 
         This path is relative to the root of the extracted tarball,
@@ -121,7 +124,7 @@ class MesonBuilder(BaseBuilder):
         return self.pkg.stage.source_path
 
     @property
-    def std_meson_args(self):
+    def std_meson_args(self) -> List[str]:
         """Standard meson arguments provided as a property for convenience
         of package writers.
         """
@@ -132,7 +135,7 @@ class MesonBuilder(BaseBuilder):
         return std_meson_args
 
     @staticmethod
-    def std_args(pkg):
+    def std_args(pkg) -> List[str]:
         """Standard meson arguments for a generic package."""
         try:
             build_type = pkg.spec.variants["buildtype"].value
@@ -172,7 +175,7 @@ class MesonBuilder(BaseBuilder):
         """Directory to use when building the package."""
         return os.path.join(self.pkg.stage.path, self.build_dirname)
 
-    def meson_args(self):
+    def meson_args(self) -> List[str]:
         """List of arguments that must be passed to meson, except:
 
         * ``--prefix``
@@ -185,7 +188,12 @@ class MesonBuilder(BaseBuilder):
         """
         return []
 
-    def meson(self, pkg, spec, prefix):
+    def meson(
+        self,
+        pkg: spack.package_base.PackageBase,
+        spec: spack.spec.Spec,
+        prefix: spack.util.prefix.Prefix,
+    ) -> None:
         """Run ``meson`` in the build directory"""
         options = []
         if self.spec["meson"].satisfies("@0.64:"):
@@ -196,21 +204,31 @@ class MesonBuilder(BaseBuilder):
         with fs.working_dir(self.build_directory, create=True):
             pkg.module.meson(*options)
 
-    def build(self, pkg, spec, prefix):
+    def build(
+        self,
+        pkg: spack.package_base.PackageBase,
+        spec: spack.spec.Spec,
+        prefix: spack.util.prefix.Prefix,
+    ) -> None:
         """Make the build targets"""
         options = ["-v"]
         options += self.build_targets
         with fs.working_dir(self.build_directory):
             pkg.module.ninja(*options)
 
-    def install(self, pkg, spec, prefix):
+    def install(
+        self,
+        pkg: spack.package_base.PackageBase,
+        spec: spack.spec.Spec,
+        prefix: spack.util.prefix.Prefix,
+    ) -> None:
         """Make the install targets"""
         with fs.working_dir(self.build_directory):
             pkg.module.ninja(*self.install_targets)
 
-    spack.builder.run_after("build")(execute_build_time_tests)
+    spack.phase_callbacks.run_after("build")(execute_build_time_tests)
 
-    def check(self):
+    def check(self) -> None:
         """Search Meson-generated files for the target ``test`` and run it if found."""
         with fs.working_dir(self.build_directory):
             self.pkg._if_ninja_target_execute("test")

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -15,7 +15,7 @@ import spack.util.prefix
 from spack.directives import build_system, conflicts, depends_on, variant
 from spack.multimethod import when
 
-from ._checks import BaseBuilder, execute_build_time_tests
+from ._checks import BuilderWithDefaults, execute_build_time_tests
 
 
 class MesonPackage(spack.package_base.PackageBase):
@@ -65,7 +65,7 @@ class MesonPackage(spack.package_base.PackageBase):
 
 
 @spack.builder.builder("meson")
-class MesonBuilder(BaseBuilder):
+class MesonBuilder(BuilderWithDefaults):
     """The Meson builder encodes the default way to build software with Meson.
     The builder has three phases that can be overridden, if need be:
 

--- a/lib/spack/spack/build_systems/msbuild.py
+++ b/lib/spack/spack/build_systems/msbuild.py
@@ -10,7 +10,7 @@ import spack.builder
 import spack.package_base
 from spack.directives import build_system, conflicts
 
-from ._checks import BaseBuilder
+from ._checks import BuilderWithDefaults
 
 
 class MSBuildPackage(spack.package_base.PackageBase):
@@ -26,7 +26,7 @@ class MSBuildPackage(spack.package_base.PackageBase):
 
 
 @spack.builder.builder("msbuild")
-class MSBuildBuilder(BaseBuilder):
+class MSBuildBuilder(BuilderWithDefaults):
     """The MSBuild builder encodes the most common way of building software with
     Mircosoft's MSBuild tool. It has two phases that can be overridden, if need be:
 

--- a/lib/spack/spack/build_systems/nmake.py
+++ b/lib/spack/spack/build_systems/nmake.py
@@ -10,7 +10,7 @@ import spack.builder
 import spack.package_base
 from spack.directives import build_system, conflicts
 
-from ._checks import BaseBuilder
+from ._checks import BuilderWithDefaults
 
 
 class NMakePackage(spack.package_base.PackageBase):
@@ -26,7 +26,7 @@ class NMakePackage(spack.package_base.PackageBase):
 
 
 @spack.builder.builder("nmake")
-class NMakeBuilder(BaseBuilder):
+class NMakeBuilder(BuilderWithDefaults):
     """The NMake builder encodes the most common way of building software with
     Mircosoft's NMake tool. It has two phases that can be overridden, if need be:
 

--- a/lib/spack/spack/build_systems/octave.py
+++ b/lib/spack/spack/build_systems/octave.py
@@ -7,7 +7,7 @@ import spack.package_base
 from spack.directives import build_system, extends
 from spack.multimethod import when
 
-from ._checks import BaseBuilder
+from ._checks import BuilderWithDefaults
 
 
 class OctavePackage(spack.package_base.PackageBase):
@@ -29,7 +29,7 @@ class OctavePackage(spack.package_base.PackageBase):
 
 
 @spack.builder.builder("octave")
-class OctaveBuilder(BaseBuilder):
+class OctaveBuilder(BuilderWithDefaults):
     """The octave builder provides the following phases that can be overridden:
 
     1. :py:meth:`~.OctaveBuilder.install`

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -10,6 +10,7 @@ from llnl.util.lang import memoized
 
 import spack.builder
 import spack.package_base
+import spack.phase_callbacks
 from spack.directives import build_system, extends
 from spack.install_test import SkipTest, test_part
 from spack.util.executable import Executable
@@ -163,7 +164,7 @@ class PerlBuilder(BaseBuilder):
     # Build.PL may be too long causing the build to fail. Patching the shebang
     # does not happen until after install so set '/usr/bin/env perl' here in
     # the Build script.
-    @spack.builder.run_after("configure")
+    @spack.phase_callbacks.run_after("configure")
     def fix_shebang(self):
         if self.build_method == "Build.PL":
             pattern = "#!{0}".format(self.spec["perl"].command.path)
@@ -175,7 +176,7 @@ class PerlBuilder(BaseBuilder):
         self.build_executable()
 
     # Ensure that tests run after build (if requested):
-    spack.builder.run_after("build")(execute_build_time_tests)
+    spack.phase_callbacks.run_after("build")(execute_build_time_tests)
 
     def check(self):
         """Runs built-in tests of a Perl package."""

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -15,7 +15,7 @@ from spack.directives import build_system, extends
 from spack.install_test import SkipTest, test_part
 from spack.util.executable import Executable
 
-from ._checks import BaseBuilder, execute_build_time_tests
+from ._checks import BuilderWithDefaults, execute_build_time_tests
 
 
 class PerlPackage(spack.package_base.PackageBase):
@@ -85,7 +85,7 @@ class PerlPackage(spack.package_base.PackageBase):
 
 
 @spack.builder.builder("perl")
-class PerlBuilder(BaseBuilder):
+class PerlBuilder(BuilderWithDefaults):
     """The perl builder provides four phases that can be overridden, if required:
 
         1. :py:meth:`~.PerlBuilder.configure`

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -35,7 +35,7 @@ from spack.install_test import test_part
 from spack.spec import Spec
 from spack.util.prefix import Prefix
 
-from ._checks import BaseBuilder, execute_install_time_tests
+from ._checks import BuilderWithDefaults, execute_install_time_tests
 
 
 def _flatten_dict(dictionary: Mapping[str, object]) -> Iterable[str]:
@@ -426,7 +426,7 @@ class PythonPackage(PythonExtension):
 
 
 @spack.builder.builder("python_pip")
-class PythonPipBuilder(BaseBuilder):
+class PythonPipBuilder(BuilderWithDefaults):
     phases = ("install",)
 
     #: Names associated with package methods in the old build-system format

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -375,7 +375,7 @@ class PythonPackage(PythonExtension):
         return None
 
     @property
-    def python_spec(self):
+    def python_spec(self) -> Spec:
         """Get python-venv if it exists or python otherwise."""
         python, *_ = self.spec.dependencies("python-venv") or self.spec.dependencies("python")
         return python

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -24,6 +24,7 @@ import spack.deptypes as dt
 import spack.detection
 import spack.multimethod
 import spack.package_base
+import spack.phase_callbacks
 import spack.platforms
 import spack.repo
 import spack.spec
@@ -543,4 +544,4 @@ class PythonPipBuilder(BaseBuilder):
         with fs.working_dir(self.build_directory):
             pip(*args)
 
-    spack.builder.run_after("install")(execute_install_time_tests)
+    spack.phase_callbacks.run_after("install")(execute_install_time_tests)

--- a/lib/spack/spack/build_systems/qmake.py
+++ b/lib/spack/spack/build_systems/qmake.py
@@ -6,6 +6,7 @@ from llnl.util.filesystem import working_dir
 
 import spack.builder
 import spack.package_base
+import spack.phase_callbacks
 from spack.directives import build_system, depends_on
 
 from ._checks import BaseBuilder, execute_build_time_tests
@@ -81,4 +82,4 @@ class QMakeBuilder(BaseBuilder):
         with working_dir(self.build_directory):
             self.pkg._if_make_target_execute("check")
 
-    spack.builder.run_after("build")(execute_build_time_tests)
+    spack.phase_callbacks.run_after("build")(execute_build_time_tests)

--- a/lib/spack/spack/build_systems/qmake.py
+++ b/lib/spack/spack/build_systems/qmake.py
@@ -9,7 +9,7 @@ import spack.package_base
 import spack.phase_callbacks
 from spack.directives import build_system, depends_on
 
-from ._checks import BaseBuilder, execute_build_time_tests
+from ._checks import BuilderWithDefaults, execute_build_time_tests
 
 
 class QMakePackage(spack.package_base.PackageBase):
@@ -31,7 +31,7 @@ class QMakePackage(spack.package_base.PackageBase):
 
 
 @spack.builder.builder("qmake")
-class QMakeBuilder(BaseBuilder):
+class QMakeBuilder(BuilderWithDefaults):
     """The qmake builder provides three phases that can be overridden:
 
     1. :py:meth:`~.QMakeBuilder.qmake`

--- a/lib/spack/spack/build_systems/ruby.py
+++ b/lib/spack/spack/build_systems/ruby.py
@@ -8,7 +8,7 @@ import spack.builder
 import spack.package_base
 from spack.directives import build_system, extends, maintainers
 
-from ._checks import BaseBuilder
+from ._checks import BuilderWithDefaults
 
 
 class RubyPackage(spack.package_base.PackageBase):
@@ -28,7 +28,7 @@ class RubyPackage(spack.package_base.PackageBase):
 
 
 @spack.builder.builder("ruby")
-class RubyBuilder(BaseBuilder):
+class RubyBuilder(BuilderWithDefaults):
     """The Ruby builder provides two phases that can be overridden if required:
 
     #. :py:meth:`~.RubyBuilder.build`

--- a/lib/spack/spack/build_systems/scons.py
+++ b/lib/spack/spack/build_systems/scons.py
@@ -7,7 +7,7 @@ import spack.package_base
 import spack.phase_callbacks
 from spack.directives import build_system, depends_on
 
-from ._checks import BaseBuilder, execute_build_time_tests
+from ._checks import BuilderWithDefaults, execute_build_time_tests
 
 
 class SConsPackage(spack.package_base.PackageBase):
@@ -29,7 +29,7 @@ class SConsPackage(spack.package_base.PackageBase):
 
 
 @spack.builder.builder("scons")
-class SConsBuilder(BaseBuilder):
+class SConsBuilder(BuilderWithDefaults):
     """The Scons builder provides the following phases that can be overridden:
 
     1. :py:meth:`~.SConsBuilder.build`

--- a/lib/spack/spack/build_systems/scons.py
+++ b/lib/spack/spack/build_systems/scons.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import spack.builder
 import spack.package_base
+import spack.phase_callbacks
 from spack.directives import build_system, depends_on
 
 from ._checks import BaseBuilder, execute_build_time_tests
@@ -79,4 +80,4 @@ class SConsBuilder(BaseBuilder):
         """
         pass
 
-    spack.builder.run_after("build")(execute_build_time_tests)
+    spack.phase_callbacks.run_after("build")(execute_build_time_tests)

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -11,6 +11,7 @@ from llnl.util.filesystem import find, working_dir
 import spack.builder
 import spack.install_test
 import spack.package_base
+import spack.phase_callbacks
 from spack.directives import build_system, depends_on, extends
 from spack.multimethod import when
 from spack.util.executable import Executable
@@ -170,4 +171,4 @@ class SIPBuilder(BaseBuilder):
         """Arguments to pass to install."""
         return []
 
-    spack.builder.run_after("install")(execute_install_time_tests)
+    spack.phase_callbacks.run_after("install")(execute_install_time_tests)

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -16,7 +16,7 @@ from spack.directives import build_system, depends_on, extends
 from spack.multimethod import when
 from spack.util.executable import Executable
 
-from ._checks import BaseBuilder, execute_install_time_tests
+from ._checks import BuilderWithDefaults, execute_install_time_tests
 
 
 class SIPPackage(spack.package_base.PackageBase):
@@ -104,7 +104,7 @@ class SIPPackage(spack.package_base.PackageBase):
 
 
 @spack.builder.builder("sip")
-class SIPBuilder(BaseBuilder):
+class SIPBuilder(BuilderWithDefaults):
     """The SIP builder provides the following phases that can be overridden:
 
     * configure

--- a/lib/spack/spack/build_systems/waf.py
+++ b/lib/spack/spack/build_systems/waf.py
@@ -6,6 +6,7 @@ from llnl.util.filesystem import working_dir
 
 import spack.builder
 import spack.package_base
+import spack.phase_callbacks
 from spack.directives import build_system, depends_on
 
 from ._checks import BaseBuilder, execute_build_time_tests, execute_install_time_tests
@@ -136,7 +137,7 @@ class WafBuilder(BaseBuilder):
         """
         pass
 
-    spack.builder.run_after("build")(execute_build_time_tests)
+    spack.phase_callbacks.run_after("build")(execute_build_time_tests)
 
     def install_test(self):
         """Run unit tests after install.
@@ -146,4 +147,4 @@ class WafBuilder(BaseBuilder):
         """
         pass
 
-    spack.builder.run_after("install")(execute_install_time_tests)
+    spack.phase_callbacks.run_after("install")(execute_install_time_tests)

--- a/lib/spack/spack/build_systems/waf.py
+++ b/lib/spack/spack/build_systems/waf.py
@@ -9,7 +9,7 @@ import spack.package_base
 import spack.phase_callbacks
 from spack.directives import build_system, depends_on
 
-from ._checks import BaseBuilder, execute_build_time_tests, execute_install_time_tests
+from ._checks import BuilderWithDefaults, execute_build_time_tests, execute_install_time_tests
 
 
 class WafPackage(spack.package_base.PackageBase):
@@ -31,7 +31,7 @@ class WafPackage(spack.package_base.PackageBase):
 
 
 @spack.builder.builder("waf")
-class WafBuilder(BaseBuilder):
+class WafBuilder(BuilderWithDefaults):
     """The WAF builder provides the following phases that can be overridden:
 
     * configure

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -8,30 +8,16 @@ import copy
 import functools
 from typing import List, Optional, Tuple
 
-from llnl.util import lang
-
 import spack.error
 import spack.multimethod
+import spack.package_base
+import spack.phase_callbacks
 import spack.repo
+import spack.spec
+import spack.util.environment
 
 #: Builder classes, as registered by the "builder" decorator
 BUILDER_CLS = {}
-
-#: An object of this kind is a shared global state used to collect callbacks during
-#: class definition time, and is flushed when the class object is created at the end
-#: of the class definition
-#:
-#: Args:
-#:    attribute_name (str): name of the attribute that will be attached to the builder
-#:    callbacks (list): container used to temporarily aggregate the callbacks
-CallbackTemporaryStage = collections.namedtuple(
-    "CallbackTemporaryStage", ["attribute_name", "callbacks"]
-)
-
-#: Shared global state to aggregate "@run_before" callbacks
-_RUN_BEFORE = CallbackTemporaryStage(attribute_name="run_before_callbacks", callbacks=[])
-#: Shared global state to aggregate "@run_after" callbacks
-_RUN_AFTER = CallbackTemporaryStage(attribute_name="run_after_callbacks", callbacks=[])
 
 #: Map id(pkg) to a builder, to avoid creating multiple
 #: builders for the same package object.
@@ -59,7 +45,7 @@ def create(pkg):
     return the builder object that can install it.
 
     Args:
-         pkg (spack.package_base.PackageBase): package for which we want the builder
+         pkg: package for which we want the builder
     """
     if id(pkg) not in _BUILDERS:
         _BUILDERS[id(pkg)] = _create(pkg)
@@ -103,7 +89,7 @@ def _create(pkg):
     to look for build-related methods in the ``*Package``.
 
     Args:
-        pkg (spack.package_base.PackageBase): package object for which we need a builder
+        pkg: package object for which we need a builder
     """
     package_buildsystem = buildsystem_name(pkg)
     default_builder_cls = BUILDER_CLS[package_buildsystem]
@@ -213,99 +199,18 @@ def _create(pkg):
     return Adapter(pkg)
 
 
-def buildsystem_name(pkg):
+def buildsystem_name(pkg: spack.package_base.PackageBase) -> str:
     """Given a package object with an associated concrete spec,
-    return the name of its build system.
-
-    Args:
-         pkg (spack.package_base.PackageBase): package for which we want
-            the build system name
-    """
+    return the name of its build system."""
     try:
         return pkg.spec.variants["build_system"].value
     except KeyError:
         # We are reading an old spec without the build_system variant
-        return pkg.legacy_buildsystem
-
-
-class PhaseCallbacksMeta(type):
-    """Permit to register arbitrary functions during class definition and run them
-    later, before or after a given install phase.
-
-    Each method decorated with ``run_before`` or ``run_after`` gets temporarily
-    stored in a global shared state when a class being defined is parsed by the Python
-    interpreter. At class definition time that temporary storage gets flushed and a list
-    of callbacks is attached to the class being defined.
-    """
-
-    def __new__(mcs, name, bases, attr_dict):
-        for temporary_stage in (_RUN_BEFORE, _RUN_AFTER):
-            staged_callbacks = temporary_stage.callbacks
-
-            # Here we have an adapter from an old-style package. This means there is no
-            # hierarchy of builders, and every callback that had to be combined between
-            # *Package and *Builder has been combined already by _PackageAdapterMeta
-            if name == "Adapter":
-                continue
-
-            # If we are here we have callbacks. To get a complete list, we accumulate all the
-            # callbacks from base classes, we deduplicate them, then prepend what we have
-            # registered here.
-            #
-            # The order should be:
-            # 1. Callbacks are registered in order within the same class
-            # 2. Callbacks defined in derived classes precede those defined in base
-            #    classes
-            callbacks_from_base = []
-            for base in bases:
-                current_callbacks = getattr(base, temporary_stage.attribute_name, None)
-                if not current_callbacks:
-                    continue
-                callbacks_from_base.extend(current_callbacks)
-            callbacks_from_base = list(lang.dedupe(callbacks_from_base))
-            # Set the callbacks in this class and flush the temporary stage
-            attr_dict[temporary_stage.attribute_name] = staged_callbacks[:] + callbacks_from_base
-            del temporary_stage.callbacks[:]
-
-        return super(PhaseCallbacksMeta, mcs).__new__(mcs, name, bases, attr_dict)
-
-    @staticmethod
-    def run_after(phase, when=None):
-        """Decorator to register a function for running after a given phase.
-
-        Args:
-            phase (str): phase after which the function must run.
-            when (str): condition under which the function is run (if None, it is always run).
-        """
-
-        def _decorator(fn):
-            key = (phase, when)
-            item = (key, fn)
-            _RUN_AFTER.callbacks.append(item)
-            return fn
-
-        return _decorator
-
-    @staticmethod
-    def run_before(phase, when=None):
-        """Decorator to register a function for running before a given phase.
-
-        Args:
-           phase (str): phase before which the function must run.
-           when (str): condition under which the function is run (if None, it is always run).
-        """
-
-        def _decorator(fn):
-            key = (phase, when)
-            item = (key, fn)
-            _RUN_BEFORE.callbacks.append(item)
-            return fn
-
-        return _decorator
+        return pkg.legacy_buildsystem  # type: ignore
 
 
 class BuilderMeta(
-    PhaseCallbacksMeta,
+    spack.phase_callbacks.PhaseCallbacksMeta,
     spack.multimethod.MultiMethodMeta,
     type(collections.abc.Sequence),  # type: ignore
 ):
@@ -400,8 +305,12 @@ class _PackageAdapterMeta(BuilderMeta):
             )
 
         combine_callbacks = _PackageAdapterMeta.combine_callbacks
-        attr_dict[_RUN_BEFORE.attribute_name] = combine_callbacks(_RUN_BEFORE.attribute_name)
-        attr_dict[_RUN_AFTER.attribute_name] = combine_callbacks(_RUN_AFTER.attribute_name)
+        attr_dict[spack.phase_callbacks._RUN_BEFORE.attribute_name] = combine_callbacks(
+            spack.phase_callbacks._RUN_BEFORE.attribute_name
+        )
+        attr_dict[spack.phase_callbacks._RUN_AFTER.attribute_name] = combine_callbacks(
+            spack.phase_callbacks._RUN_AFTER.attribute_name
+        )
 
         return super(_PackageAdapterMeta, mcs).__new__(mcs, name, bases, attr_dict)
 
@@ -421,8 +330,8 @@ class InstallationPhase:
         self.name = name
         self.builder = builder
         self.phase_fn = self._select_phase_fn()
-        self.run_before = self._make_callbacks(_RUN_BEFORE.attribute_name)
-        self.run_after = self._make_callbacks(_RUN_AFTER.attribute_name)
+        self.run_before = self._make_callbacks(spack.phase_callbacks._RUN_BEFORE.attribute_name)
+        self.run_after = self._make_callbacks(spack.phase_callbacks._RUN_AFTER.attribute_name)
 
     def _make_callbacks(self, callbacks_attribute):
         result = []
@@ -489,9 +398,6 @@ class Builder(collections.abc.Sequence, metaclass=BuilderMeta):
 
     The builder behaves like a sequence, and when iterated over return the
     "phases" of the installation in the correct order.
-
-    Args:
-        pkg (spack.package_base.PackageBase): package object to be built
     """
 
     #: Sequence of phases. Must be defined in derived classes
@@ -511,16 +417,18 @@ class Builder(collections.abc.Sequence, metaclass=BuilderMeta):
     #: Matching artifacts found at the end of the build process will be
     #: copied in the same directory tree as _spack_build_logfile and
     #: _spack_build_envfile.
-    archive_files: List[str] = []
+    @property
+    def archive_files(self) -> List[str]:
+        return []
 
-    def __init__(self, pkg):
+    def __init__(self, pkg: spack.package_base.PackageBase):
         self.pkg = pkg
         self.callbacks = {}
         for phase in self.phases:
             self.callbacks[phase] = InstallationPhase(phase, self)
 
     @property
-    def spec(self):
+    def spec(self) -> spack.spec.Spec:
         return self.pkg.spec
 
     @property
@@ -531,53 +439,47 @@ class Builder(collections.abc.Sequence, metaclass=BuilderMeta):
     def prefix(self):
         return self.pkg.prefix
 
-    def setup_build_environment(self, env):
+    def setup_build_environment(
+        self, env: spack.util.environment.EnvironmentModifications
+    ) -> None:
         """Sets up the build environment for a package.
 
         This method will be called before the current package prefix exists in
         Spack's store.
 
         Args:
-            env (spack.util.environment.EnvironmentModifications): environment
-                modifications to be applied when the package is built. Package authors
+            env: environment modifications to be applied when the package is built. Package authors
                 can call methods on it to alter the build environment.
         """
         if not hasattr(super(), "setup_build_environment"):
             return
-        super().setup_build_environment(env)
+        super().setup_build_environment(env)  # type: ignore
 
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        """Sets up the build environment of packages that depend on this one.
+    def setup_dependent_build_environment(
+        self, env: spack.util.environment.EnvironmentModifications, dependent_spec: spack.spec.Spec
+    ) -> None:
+        """Sets up the build environment of a package that depends on this one.
 
-        This is similar to ``setup_build_environment``, but it is used to
-        modify the build environments of packages that *depend* on this one.
+        This is similar to ``setup_build_environment``, but it is used to modify the build
+        environment of a package that *depends* on this one.
 
-        This gives packages like Python and others that follow the extension
-        model a way to implement common environment or compile-time settings
-        for dependencies.
+        This gives packages the ability to set environment variables for the build of the
+        dependent, which can be useful to provide search hints for headers or libraries if they are
+        not in standard locations.
 
-        This method will be called before the dependent package prefix exists
-        in Spack's store.
-
-        Examples:
-            1. Installing python modules generally requires ``PYTHONPATH``
-            to point to the ``lib/pythonX.Y/site-packages`` directory in the
-            module's install prefix. This method could be used to set that
-            variable.
+        This method will be called before the dependent package prefix exists in Spack's store.
 
         Args:
-            env (spack.util.environment.EnvironmentModifications): environment
-                modifications to be applied when the dependent package is built.
+            env: environment modifications to be applied when the dependent package is built.
                 Package authors can call methods on it to alter the build environment.
 
-            dependent_spec (spack.spec.Spec): the spec of the dependent package
-                about to be built. This allows the extendee (self) to query
-                the dependent's state. Note that *this* package's spec is
+            dependent_spec: the spec of the dependent package about to be built. This allows the
+                extendee (self) to query the dependent's state. Note that *this* package's spec is
                 available as ``self.spec``
         """
         if not hasattr(super(), "setup_dependent_build_environment"):
             return
-        super().setup_dependent_build_environment(env, dependent_spec)
+        super().setup_dependent_build_environment(env, dependent_spec)  # type: ignore
 
     def __getitem__(self, idx):
         key = self.phases[idx]
@@ -593,8 +495,3 @@ class Builder(collections.abc.Sequence, metaclass=BuilderMeta):
     def __str__(self):
         msg = '"{0}" builder for "{1}"'
         return msg.format(type(self).build_system, self.pkg.spec.format("{name}/{hash:7}"))
-
-
-# Export these names as standalone to be used in packages
-run_after = PhaseCallbacksMeta.run_after
-run_before = PhaseCallbacksMeta.run_before

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -32,6 +32,7 @@ from llnl.util.tty.color import cescape, colorize
 
 import spack
 import spack.binary_distribution as bindist
+import spack.builder
 import spack.concretize
 import spack.config as cfg
 import spack.error
@@ -1387,7 +1388,11 @@ def copy_stage_logs_to_artifacts(job_spec: spack.spec.Spec, job_log_dir: str) ->
 
     stage_dir = job_pkg.stage.path
     tty.debug(f"stage dir: {stage_dir}")
-    for file in [job_pkg.log_path, job_pkg.env_mods_path, *job_pkg.builder.archive_files]:
+    for file in [
+        job_pkg.log_path,
+        job_pkg.env_mods_path,
+        *spack.builder.create(job_pkg).archive_files,
+    ]:
         copy_files_to_artifacts(file, job_log_dir)
 
 

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -11,6 +11,7 @@ import llnl.util.tty as tty
 import llnl.util.tty.color as color
 from llnl.util.tty.colify import colify
 
+import spack.builder
 import spack.deptypes as dt
 import spack.fetch_strategy as fs
 import spack.install_test
@@ -202,11 +203,13 @@ def print_namespace(pkg, args):
 def print_phases(pkg, args):
     """output installation phases"""
 
-    if hasattr(pkg.builder, "phases") and pkg.builder.phases:
+    builder = spack.builder.create(pkg)
+
+    if hasattr(builder, "phases") and builder.phases:
         color.cprint("")
         color.cprint(section_title("Installation Phases:"))
         phase_str = ""
-        for phase in pkg.builder.phases:
+        for phase in builder.phases:
             phase_str += "    {0}".format(phase)
         color.cprint(phase_str)
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -517,7 +517,7 @@ def can_splice(
             variants will be skipped by '*'.
     """
 
-    def _execute_can_splice(pkg: "spack.package_base.PackageBase"):
+    def _execute_can_splice(pkg: spack.package_base.PackageBase):
         when_spec = _make_when_spec(when)
         if isinstance(match_variants, str) and match_variants != "*":
             raise ValueError(

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -34,12 +34,13 @@ import collections
 import collections.abc
 import os.path
 import re
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import llnl.util.lang
 import llnl.util.tty.color
 
 import spack.deptypes as dt
+import spack.package_base
 import spack.patch
 import spack.spec
 import spack.util.crypto
@@ -56,13 +57,8 @@ from spack.version import (
     VersionLookupError,
 )
 
-if TYPE_CHECKING:
-    import spack.package_base
-
 __all__ = [
     "DirectiveError",
-    "DirectiveMeta",
-    "DisableRedistribute",
     "version",
     "conditional",
     "conflicts",
@@ -85,15 +81,15 @@ _patch_order_index = 0
 
 SpecType = str
 DepType = Union[Tuple[str, ...], str]
-WhenType = Optional[Union["spack.spec.Spec", str, bool]]
-Patcher = Callable[[Union["spack.package_base.PackageBase", Dependency]], None]
+WhenType = Optional[Union[spack.spec.Spec, str, bool]]
+Patcher = Callable[[Union[spack.package_base.PackageBase, Dependency]], None]
 PatchesType = Optional[Union[Patcher, str, List[Union[Patcher, str]]]]
 
 
 SUPPORTED_LANGUAGES = ("fortran", "cxx", "c")
 
 
-def _make_when_spec(value: WhenType) -> Optional["spack.spec.Spec"]:
+def _make_when_spec(value: WhenType) -> Optional[spack.spec.Spec]:
     """Create a ``Spec`` that indicates when a directive should be applied.
 
     Directives with ``when`` specs, e.g.:
@@ -138,7 +134,7 @@ def _make_when_spec(value: WhenType) -> Optional["spack.spec.Spec"]:
     return spack.spec.Spec(value)
 
 
-SubmoduleCallback = Callable[["spack.package_base.PackageBase"], Union[str, List[str], bool]]
+SubmoduleCallback = Callable[[spack.package_base.PackageBase], Union[str, List[str], bool]]
 directive = DirectiveMeta.directive
 
 
@@ -254,8 +250,8 @@ def _execute_version(pkg, ver, **kwargs):
 
 
 def _depends_on(
-    pkg: "spack.package_base.PackageBase",
-    spec: "spack.spec.Spec",
+    pkg: spack.package_base.PackageBase,
+    spec: spack.spec.Spec,
     *,
     when: WhenType = None,
     type: DepType = dt.DEFAULT_TYPES,
@@ -334,7 +330,7 @@ def conflicts(conflict_spec: SpecType, when: WhenType = None, msg: Optional[str]
         msg (str): optional user defined message
     """
 
-    def _execute_conflicts(pkg: "spack.package_base.PackageBase"):
+    def _execute_conflicts(pkg: spack.package_base.PackageBase):
         # If when is not specified the conflict always holds
         when_spec = _make_when_spec(when)
         if not when_spec:
@@ -375,17 +371,10 @@ def depends_on(
         assert type == "build", "languages must be of 'build' type"
         return _language(lang_spec_str=spec, when=when)
 
-    def _execute_depends_on(pkg: "spack.package_base.PackageBase"):
+    def _execute_depends_on(pkg: spack.package_base.PackageBase):
         _depends_on(pkg, dep_spec, when=when, type=type, patches=patches)
 
     return _execute_depends_on
-
-
-#: Store whether a given Spec source/binary should not be redistributed.
-class DisableRedistribute:
-    def __init__(self, source, binary):
-        self.source = source
-        self.binary = binary
 
 
 @directive("disable_redistribute")
@@ -404,7 +393,7 @@ def redistribute(source=None, binary=None, when: WhenType = None):
 
 
 def _execute_redistribute(
-    pkg: "spack.package_base.PackageBase", source=None, binary=None, when: WhenType = None
+    pkg: spack.package_base.PackageBase, source=None, binary=None, when: WhenType = None
 ):
     if source is None and binary is None:
         return
@@ -434,7 +423,7 @@ def _execute_redistribute(
         if not binary:
             disable.binary = True
     else:
-        pkg.disable_redistribute[when_spec] = DisableRedistribute(
+        pkg.disable_redistribute[when_spec] = spack.package_base.DisableRedistribute(
             source=not source, binary=not binary
         )
 
@@ -480,7 +469,7 @@ def provides(*specs: SpecType, when: WhenType = None):
         when: condition when this provides clause needs to be considered
     """
 
-    def _execute_provides(pkg: "spack.package_base.PackageBase"):
+    def _execute_provides(pkg: spack.package_base.PackageBase):
         import spack.parser  # Avoid circular dependency
 
         when_spec = _make_when_spec(when)
@@ -569,7 +558,7 @@ def patch(
             compressed URL patches)
     """
 
-    def _execute_patch(pkg_or_dep: Union["spack.package_base.PackageBase", Dependency]):
+    def _execute_patch(pkg_or_dep: Union[spack.package_base.PackageBase, Dependency]):
         pkg = pkg_or_dep
         if isinstance(pkg, Dependency):
             pkg = pkg.pkg
@@ -893,7 +882,7 @@ def requires(*requirement_specs: str, policy="one_of", when=None, msg=None):
         msg: optional user defined message
     """
 
-    def _execute_requires(pkg: "spack.package_base.PackageBase"):
+    def _execute_requires(pkg: spack.package_base.PackageBase):
         if policy not in ("one_of", "any_of"):
             err_msg = (
                 f"the 'policy' argument of the 'requires' directive in {pkg.name} is set "
@@ -918,7 +907,7 @@ def requires(*requirement_specs: str, policy="one_of", when=None, msg=None):
 def _language(lang_spec_str: str, *, when: Optional[Union[str, bool]] = None):
     """Temporary implementation of language virtuals, until compilers are proper dependencies."""
 
-    def _execute_languages(pkg: "spack.package_base.PackageBase"):
+    def _execute_languages(pkg: spack.package_base.PackageBase):
         when_spec = _make_when_spec(when)
         if not when_spec:
             return

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -23,7 +23,6 @@ from llnl.util.lang import nullcontext
 from llnl.util.tty.color import colorize
 
 import spack.build_environment
-import spack.builder
 import spack.config
 import spack.error
 import spack.package_base
@@ -353,9 +352,7 @@ class PackageTest:
         self.test_parts[part_name] = status
         self.counts[status] += 1
 
-    def phase_tests(
-        self, builder: spack.builder.Builder, phase_name: str, method_names: List[str]
-    ):
+    def phase_tests(self, builder, phase_name: str, method_names: List[str]):
         """Execute the builder's package phase-time tests.
 
         Args:

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -50,6 +50,7 @@ from llnl.util.tty.log import log_output
 
 import spack.binary_distribution as binary_distribution
 import spack.build_environment
+import spack.builder
 import spack.config
 import spack.database
 import spack.deptypes as dt
@@ -212,7 +213,7 @@ def _check_last_phase(pkg: "spack.package_base.PackageBase") -> None:
     Raises:
         ``BadInstallPhase`` if stop_before or last phase is invalid
     """
-    phases = pkg.builder.phases  # type: ignore[attr-defined]
+    phases = spack.builder.create(pkg).phases  # type: ignore[attr-defined]
     if pkg.stop_before_phase and pkg.stop_before_phase not in phases:  # type: ignore[attr-defined]
         raise BadInstallPhase(pkg.name, pkg.stop_before_phase)  # type: ignore[attr-defined]
 
@@ -661,7 +662,7 @@ def log(pkg: "spack.package_base.PackageBase") -> None:
             spack.store.STORE.layout.metadata_path(pkg.spec), "archived-files"
         )
 
-        for glob_expr in pkg.builder.archive_files:
+        for glob_expr in spack.builder.create(pkg).archive_files:
             # Check that we are trying to copy things that are
             # in the stage tree (not arbitrary files)
             abs_expr = os.path.realpath(glob_expr)
@@ -2394,7 +2395,6 @@ class BuildProcessInstaller:
         fs.install_tree(pkg.stage.source_path, src_target)
 
     def _real_install(self) -> None:
-        import spack.builder
 
         pkg = self.pkg
 

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -29,6 +29,7 @@ import spack.caches
 import spack.config
 import spack.error
 import spack.fetch_strategy
+import spack.mirror
 import spack.oci.image
 import spack.repo
 import spack.spec

--- a/lib/spack/spack/mixins.py
+++ b/lib/spack/spack/mixins.py
@@ -10,7 +10,7 @@ import os
 
 import llnl.util.filesystem
 
-import spack.builder
+import spack.phase_callbacks
 
 
 def filter_compiler_wrappers(*files, **kwargs):
@@ -111,4 +111,4 @@ def filter_compiler_wrappers(*files, **kwargs):
         if pkg.compiler.name == "nag":
             x.filter("-Wl,--enable-new-dtags", "", **filter_kwargs)
 
-    spack.builder.run_after(after)(_filter_compiler_wrappers_impl)
+    spack.phase_callbacks.run_after(after)(_filter_compiler_wrappers_impl)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -74,6 +74,7 @@ from spack.build_systems.sourceforge import SourceforgePackage
 from spack.build_systems.sourceware import SourcewarePackage
 from spack.build_systems.waf import WafPackage
 from spack.build_systems.xorg import XorgPackage
+from spack.builder import BaseBuilder
 from spack.config import determine_number_of_jobs
 from spack.deptypes import ALL_TYPES as all_deptypes
 from spack.directives import *

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -74,7 +74,6 @@ from spack.build_systems.sourceforge import SourceforgePackage
 from spack.build_systems.sourceware import SourcewarePackage
 from spack.build_systems.waf import WafPackage
 from spack.build_systems.xorg import XorgPackage
-from spack.builder import run_after, run_before
 from spack.config import determine_number_of_jobs
 from spack.deptypes import ALL_TYPES as all_deptypes
 from spack.directives import *
@@ -100,6 +99,7 @@ from spack.package_base import (
     on_package_attributes,
 )
 from spack.package_completions import *
+from spack.phase_callbacks import run_after, run_before
 from spack.spec import InvalidSpecDetected, Spec
 from spack.util.executable import *
 from spack.util.filesystem import file_command, fix_darwin_install_name, mime_type

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -54,7 +54,6 @@ import spack.util.web
 import spack.variant
 from spack.error import InstallError, NoURLError, PackageError
 from spack.filesystem_view import YamlFilesystemView
-from spack.install_test import PackageTest, TestSuite
 from spack.solver.version_order import concretization_version_order
 from spack.stage import DevelopStage, ResourceStage, Stage, StageComposite, compute_stage_name
 from spack.util.package_hash import package_hash
@@ -714,7 +713,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     test_requires_compiler: bool = False
 
     #: TestSuite instance used to manage stand-alone tests for 1+ specs.
-    test_suite: Optional["TestSuite"] = None
+    test_suite: Optional[Any] = None
 
     def __init__(self, spec):
         # this determines how the package should be built.
@@ -736,7 +735,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         # init internal variables
         self._stage: Optional[StageComposite] = None
         self._fetcher = None
-        self._tester: Optional["PackageTest"] = None
+        self._tester: Optional[Any] = None
 
         # Set up timing variables
         self._fetch_time = 0.0
@@ -1348,11 +1347,13 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
     @property
     def tester(self):
+        import spack.install_test
+
         if not self.spec.versions.concrete:
             raise ValueError("Cannot retrieve tester for package without concrete version.")
 
         if not self._tester:
-            self._tester = PackageTest(self)
+            self._tester = spack.install_test.PackageTest(self)
         return self._tester
 
     @property

--- a/lib/spack/spack/phase_callbacks.py
+++ b/lib/spack/spack/phase_callbacks.py
@@ -1,0 +1,105 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import collections
+
+import llnl.util.lang as lang
+
+#: An object of this kind is a shared global state used to collect callbacks during
+#: class definition time, and is flushed when the class object is created at the end
+#: of the class definition
+#:
+#: Args:
+#:    attribute_name (str): name of the attribute that will be attached to the builder
+#:    callbacks (list): container used to temporarily aggregate the callbacks
+CallbackTemporaryStage = collections.namedtuple(
+    "CallbackTemporaryStage", ["attribute_name", "callbacks"]
+)
+
+#: Shared global state to aggregate "@run_before" callbacks
+_RUN_BEFORE = CallbackTemporaryStage(attribute_name="run_before_callbacks", callbacks=[])
+#: Shared global state to aggregate "@run_after" callbacks
+_RUN_AFTER = CallbackTemporaryStage(attribute_name="run_after_callbacks", callbacks=[])
+
+
+class PhaseCallbacksMeta(type):
+    """Permit to register arbitrary functions during class definition and run them
+    later, before or after a given install phase.
+
+    Each method decorated with ``run_before`` or ``run_after`` gets temporarily
+    stored in a global shared state when a class being defined is parsed by the Python
+    interpreter. At class definition time that temporary storage gets flushed and a list
+    of callbacks is attached to the class being defined.
+    """
+
+    def __new__(mcs, name, bases, attr_dict):
+        for temporary_stage in (_RUN_BEFORE, _RUN_AFTER):
+            staged_callbacks = temporary_stage.callbacks
+
+            # Here we have an adapter from an old-style package. This means there is no
+            # hierarchy of builders, and every callback that had to be combined between
+            # *Package and *Builder has been combined already by _PackageAdapterMeta
+            if name == "Adapter":
+                continue
+
+            # If we are here we have callbacks. To get a complete list, we accumulate all the
+            # callbacks from base classes, we deduplicate them, then prepend what we have
+            # registered here.
+            #
+            # The order should be:
+            # 1. Callbacks are registered in order within the same class
+            # 2. Callbacks defined in derived classes precede those defined in base
+            #    classes
+            callbacks_from_base = []
+            for base in bases:
+                current_callbacks = getattr(base, temporary_stage.attribute_name, None)
+                if not current_callbacks:
+                    continue
+                callbacks_from_base.extend(current_callbacks)
+            callbacks_from_base = list(lang.dedupe(callbacks_from_base))
+            # Set the callbacks in this class and flush the temporary stage
+            attr_dict[temporary_stage.attribute_name] = staged_callbacks[:] + callbacks_from_base
+            del temporary_stage.callbacks[:]
+
+        return super(PhaseCallbacksMeta, mcs).__new__(mcs, name, bases, attr_dict)
+
+    @staticmethod
+    def run_after(phase, when=None):
+        """Decorator to register a function for running after a given phase.
+
+        Args:
+            phase (str): phase after which the function must run.
+            when (str): condition under which the function is run (if None, it is always run).
+        """
+
+        def _decorator(fn):
+            key = (phase, when)
+            item = (key, fn)
+            _RUN_AFTER.callbacks.append(item)
+            return fn
+
+        return _decorator
+
+    @staticmethod
+    def run_before(phase, when=None):
+        """Decorator to register a function for running before a given phase.
+
+        Args:
+           phase (str): phase before which the function must run.
+           when (str): condition under which the function is run (if None, it is always run).
+        """
+
+        def _decorator(fn):
+            key = (phase, when)
+            item = (key, fn)
+            _RUN_BEFORE.callbacks.append(item)
+            return fn
+
+        return _decorator
+
+
+# Export these names as standalone to be used in packages
+run_after = PhaseCallbacksMeta.run_after
+run_before = PhaseCallbacksMeta.run_before

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -38,7 +38,7 @@ import spack.caches
 import spack.compiler
 import spack.compilers
 import spack.config
-import spack.directives
+import spack.directives_meta
 import spack.environment as ev
 import spack.error
 import spack.modules.common
@@ -1754,7 +1754,7 @@ def clear_directive_functions():
     # Make sure any directive functions overidden by tests are cleared before
     # proceeding with subsequent tests that may depend on the original
     # functions.
-    spack.directives.DirectiveMeta._directives_to_be_executed = []
+    spack.directives_meta.DirectiveMeta._directives_to_be_executed = []
 
 
 @pytest.fixture

--- a/var/spack/repos/builder.test/packages/builder-and-mixins/package.py
+++ b/var/spack/repos/builder.test/packages/builder-and-mixins/package.py
@@ -2,7 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import spack.builder
+import spack.phase_callbacks
 from spack.build_systems import generic
 from spack.package import *
 
@@ -17,7 +17,7 @@ class BuilderAndMixins(Package):
     version("1.0", md5="0123456789abcdef0123456789abcdef")
 
 
-class BuilderMixin(metaclass=spack.builder.PhaseCallbacksMeta):
+class BuilderMixin(metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
     @run_before("install")
     def before_install(self):
         pass

--- a/var/spack/repos/builtin.mock/packages/py-test-callback/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-test-callback/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import spack.pkg.builtin.mock.python as mp
-from spack.build_systems._checks import BaseBuilder, execute_install_time_tests
+from spack.build_systems._checks import BuilderWithDefaults, execute_install_time_tests
 from spack.package import *
 
 
@@ -31,7 +31,7 @@ class PyTestCallback(mp.Python):
 
 
 @spack.builder.builder("testcallback")
-class MyBuilder(BaseBuilder):
+class MyBuilder(BuilderWithDefaults):
     phases = ("install",)
 
     #: Callback names for install-time test

--- a/var/spack/repos/builtin.mock/packages/py-test-callback/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-test-callback/package.py
@@ -40,7 +40,7 @@ class MyBuilder(BaseBuilder):
     def install(self, pkg, spec, prefix):
         pkg.install(spec, prefix)
 
-    spack.builder.run_after("install")(execute_install_time_tests)
+    spack.phase_callbacks.run_after("install")(execute_install_time_tests)
 
     def test_callback(self):
         self.pkg.test_callback()

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -6,6 +6,7 @@
 import os
 import tempfile
 
+from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
 
 
@@ -314,11 +315,11 @@ class Adios2(CMakePackage, CudaPackage, ROCmPackage):
 
         # hip support
         if spec.satisfies("+cuda"):
-            args.append(self.builder.define_cuda_architectures(self))
+            args.append(CMakeBuilder.define_cuda_architectures(self))
 
         # hip support
         if spec.satisfies("+rocm"):
-            args.append(self.builder.define_hip_architectures(self))
+            args.append(CMakeBuilder.define_hip_architectures(self))
 
         return args
 

--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -70,7 +70,7 @@ class Assimp(CMakePackage):
         return (None, None, flags)
 
     def check(self):
-        unit = Executable(join_path(self.builder.build_directory, "bin", "unit"))
+        unit = Executable(join_path(self.build_directory, "bin", "unit"))
         skipped_tests = [
             "AssimpAPITest_aiMatrix3x3.aiMatrix3FromToTest",
             "AssimpAPITest_aiMatrix4x4.aiMatrix4FromToTest",

--- a/var/spack/repos/builtin/packages/bacio/package.py
+++ b/var/spack/repos/builtin/packages/bacio/package.py
@@ -39,5 +39,5 @@ class Bacio(CMakePackage):
             filter_file(".+", "2.4.1", "VERSION")
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/blaspp/package.py
+++ b/var/spack/repos/builtin/packages/blaspp/package.py
@@ -117,8 +117,8 @@ class Blaspp(CMakePackage, CudaPackage, ROCmPackage):
 
     def check(self):
         # If the tester fails to build, ensure that the check() fails.
-        if os.path.isfile(join_path(self.builder.build_directory, "test", "tester")):
-            with working_dir(self.builder.build_directory):
+        if os.path.isfile(join_path(self.build_directory, "test", "tester")):
+            with working_dir(self.build_directory):
                 make("check")
         else:
             raise Exception("The tester was not built!")

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -830,18 +830,6 @@ class Boost(Package):
     def setup_run_environment(self, env):
         env.set("BOOST_ROOT", self.prefix)
 
-    def setup_dependent_package(self, module, dependent_spec):
-        # Disable find package's config mode for versions of Boost that
-        # didn't provide it. See https://github.com/spack/spack/issues/20169
-        # and https://cmake.org/cmake/help/latest/module/FindBoost.html
-        if self.spec.satisfies("boost@:1.69.0") and dependent_spec.satisfies("build_system=cmake"):
-            args_fn = type(dependent_spec.package.builder).cmake_args
-
-            def _cmake_args(self):
-                return ["-DBoost_NO_BOOST_CMAKE=ON"] + args_fn(self)
-
-            type(dependent_spec.package.builder).cmake_args = _cmake_args
-
     def setup_dependent_build_environment(self, env, dependent_spec):
         if "+context" in self.spec and "context-impl" in self.spec.variants:
             context_impl = self.spec.variants["context-impl"].value

--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -129,5 +129,5 @@ class Bufr(CMakePackage):
             self._setup_bufr_environment(env, suffix)
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -98,5 +98,5 @@ class G2(CMakePackage):
             env.set("G2_INC" + suffix, join_path(self.prefix, "include_" + suffix))
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/g2c/package.py
+++ b/var/spack/repos/builtin/packages/g2c/package.py
@@ -94,5 +94,5 @@ class G2c(CMakePackage):
         env.set("G2C_INC", join_path(self.prefix, "include"))
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/g2tmpl/package.py
+++ b/var/spack/repos/builtin/packages/g2tmpl/package.py
@@ -38,5 +38,5 @@ class G2tmpl(CMakePackage):
         return args
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/gfsio/package.py
+++ b/var/spack/repos/builtin/packages/gfsio/package.py
@@ -46,5 +46,5 @@ class Gfsio(CMakePackage):
         return (None, None, flags)
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -5,6 +5,7 @@
 
 import os.path
 
+import spack.phase_callbacks
 from spack.package import *
 from spack.util.environment import is_system_path
 
@@ -208,7 +209,7 @@ class Glib(MesonPackage, AutotoolsPackage):
         return find_libraries(["libglib*"], root=self.prefix, recursive=True)
 
 
-class BaseBuilder(metaclass=spack.builder.PhaseCallbacksMeta):
+class BaseBuilder(metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
     @property
     def dtrace_copy_path(self):
         return join_path(self.stage.source_path, "dtrace-copy")

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -5,7 +5,6 @@
 
 import os.path
 
-import spack.phase_callbacks
 from spack.package import *
 from spack.util.environment import is_system_path
 
@@ -209,7 +208,7 @@ class Glib(MesonPackage, AutotoolsPackage):
         return find_libraries(["libglib*"], root=self.prefix, recursive=True)
 
 
-class BaseBuilder(metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
+class AnyBuilder(BaseBuilder):
     @property
     def dtrace_copy_path(self):
         return join_path(self.stage.source_path, "dtrace-copy")
@@ -289,7 +288,7 @@ class BaseBuilder(metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
             filter_file(pattern, repl, myfile, backup=False)
 
 
-class MesonBuilder(BaseBuilder, spack.build_systems.meson.MesonBuilder):
+class MesonBuilder(AnyBuilder, spack.build_systems.meson.MesonBuilder):
     def meson_args(self):
         args = []
         if self.spec.satisfies("@2.63.5:"):
@@ -331,7 +330,7 @@ class MesonBuilder(BaseBuilder, spack.build_systems.meson.MesonBuilder):
         return args
 
 
-class AutotoolsBuilder(BaseBuilder, spack.build_systems.autotools.AutotoolsBuilder):
+class AutotoolsBuilder(AnyBuilder, spack.build_systems.autotools.AutotoolsBuilder):
     def configure_args(self):
         args = []
         if self.spec.satisfies("+libmount"):

--- a/var/spack/repos/builtin/packages/grib-util/package.py
+++ b/var/spack/repos/builtin/packages/grib-util/package.py
@@ -56,5 +56,5 @@ class GribUtil(CMakePackage):
         return args
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -145,7 +145,5 @@ class Hipblas(CMakePackage, CudaPackage, ROCmPackage):
         return args
 
     def check(self):
-        exe = Executable(
-            join_path(self.builder.build_directory, "clients", "staging", "hipblas-test")
-        )
+        exe = Executable(join_path(self.build_directory, "clients", "staging", "hipblas-test"))
         exe("--gtest_filter=-*known_bug*")

--- a/var/spack/repos/builtin/packages/hipsolver/package.py
+++ b/var/spack/repos/builtin/packages/hipsolver/package.py
@@ -119,7 +119,7 @@ class Hipsolver(CMakePackage, CudaPackage, ROCmPackage):
     patch("0001-suite-sparse-include-path-6.1.1.patch", when="@6.1.1:")
 
     def check(self):
-        exe = join_path(self.builder.build_directory, "clients", "staging", "hipsolver-test")
+        exe = join_path(self.build_directory, "clients", "staging", "hipsolver-test")
         exe = which(exe)
         exe(["--gtest_filter=-*known_bug*"])
 

--- a/var/spack/repos/builtin/packages/ip/package.py
+++ b/var/spack/repos/builtin/packages/ip/package.py
@@ -121,5 +121,5 @@ class Ip(CMakePackage):
 
     @when("@4:")
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/landsfcutil/package.py
+++ b/var/spack/repos/builtin/packages/landsfcutil/package.py
@@ -48,5 +48,5 @@ class Landsfcutil(CMakePackage):
         return (None, None, flags)
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/lapackpp/package.py
+++ b/var/spack/repos/builtin/packages/lapackpp/package.py
@@ -129,8 +129,8 @@ class Lapackpp(CMakePackage, CudaPackage, ROCmPackage):
 
     def check(self):
         # If the tester fails to build, ensure that the check() fails.
-        if os.path.isfile(join_path(self.builder.build_directory, "test", "tester")):
-            with working_dir(self.builder.build_directory):
+        if os.path.isfile(join_path(self.build_directory, "test", "tester")):
+            with working_dir(self.build_directory):
                 make("check")
         else:
             raise Exception("The tester was not built!")

--- a/var/spack/repos/builtin/packages/lc-framework/package.py
+++ b/var/spack/repos/builtin/packages/lc-framework/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
 
 
@@ -45,6 +46,6 @@ class LcFramework(CMakePackage, CudaPackage):
         args = [self.define_from_variant("LC_BUILD_LIBPRESSIO_PLUGIN", "libpressio")]
         if self.spec.satisfies("+cuda"):
             args.append(self.define_from_variant("LC_BUILD_CUDA", "cuda"))
-            args.append(self.builder.define_cuda_architectures(self))
+            args.append(CMakeBuilder.define_cuda_architectures(self))
 
         return args

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -7,6 +7,7 @@ import os
 import llnl.util.filesystem as fs
 
 import spack.builder
+import spack.phase_callbacks
 from spack.build_systems import autotools, nmake
 from spack.package import *
 
@@ -225,7 +226,7 @@ class Libxml2(AutotoolsPackage, NMakePackage):
             xmllint("--dtdvalid", dtd_path, data_dir.join("info.xml"))
 
 
-class BaseBuilder(metaclass=spack.builder.PhaseCallbacksMeta):
+class BaseBuilder(metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
     @run_after("install")
     @on_package_attributes(run_tests=True)
     def import_module_test(self):

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -6,7 +6,6 @@ import os
 
 import llnl.util.filesystem as fs
 
-import spack.phase_callbacks
 from spack.build_systems import autotools, nmake
 from spack.package import *
 
@@ -225,7 +224,7 @@ class Libxml2(AutotoolsPackage, NMakePackage):
             xmllint("--dtdvalid", dtd_path, data_dir.join("info.xml"))
 
 
-class BaseBuilder(metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
+class AnyBuilder(BaseBuilder):
     @run_after("install")
     @on_package_attributes(run_tests=True)
     def import_module_test(self):
@@ -234,7 +233,7 @@ class BaseBuilder(metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
                 python("-c", "import libxml2")
 
 
-class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
+class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
     def configure_args(self):
         spec = self.spec
 
@@ -260,7 +259,7 @@ class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
         return args
 
 
-class NMakeBuilder(BaseBuilder, nmake.NMakeBuilder):
+class NMakeBuilder(AnyBuilder, nmake.NMakeBuilder):
     phases = ("configure", "build", "install")
 
     @property

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -6,7 +6,6 @@ import os
 
 import llnl.util.filesystem as fs
 
-import spack.builder
 import spack.phase_callbacks
 from spack.build_systems import autotools, nmake
 from spack.package import *

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -423,7 +423,7 @@ class Mapl(CMakePackage):
     @run_after("build")
     @on_package_attributes(run_tests=True)
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             # The test suite contains a lot of tests. We select only those
             # that are cheap. Note this requires MPI and 6 processes
             ctest("--output-on-failure", "-L", "ESSENTIAL")

--- a/var/spack/repos/builtin/packages/mercury/package.py
+++ b/var/spack/repos/builtin/packages/mercury/package.py
@@ -160,5 +160,5 @@ class Mercury(CMakePackage):
     def check(self):
         """Unit tests fail when run in parallel."""
 
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test", parallel=False)

--- a/var/spack/repos/builtin/packages/ncio/package.py
+++ b/var/spack/repos/builtin/packages/ncio/package.py
@@ -36,5 +36,5 @@ class Ncio(CMakePackage):
         env.set("NCIO_LIBDIR", lib[0])
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/nemsio/package.py
+++ b/var/spack/repos/builtin/packages/nemsio/package.py
@@ -48,5 +48,5 @@ class Nemsio(CMakePackage):
         return args
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/nemsiogfs/package.py
+++ b/var/spack/repos/builtin/packages/nemsiogfs/package.py
@@ -26,5 +26,5 @@ class Nemsiogfs(CMakePackage):
     depends_on("nemsio")
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -9,7 +9,6 @@ import sys
 
 from llnl.util.lang import dedupe
 
-import spack.phase_callbacks
 from spack.build_systems import autotools, cmake
 from spack.package import *
 from spack.util.environment import filter_system_paths
@@ -305,7 +304,7 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
         return find_libraries("libnetcdf", root=self.prefix, shared=shared, recursive=True)
 
 
-class BaseBuilder(metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
+class AnyBuilder(BaseBuilder):
     def setup_dependent_build_environment(self, env, dependent_spec):
         # Some packages, e.g. ncview, refuse to build if the compiler path returned by nc-config
         # differs from the path to the compiler that the package should be built with. Therefore,
@@ -329,7 +328,7 @@ class BaseBuilder(metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
     filter_compiler_wrappers("nc-config", relative_root="bin")
 
 
-class CMakeBuilder(BaseBuilder, cmake.CMakeBuilder):
+class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
     def cmake_args(self):
         base_cmake_args = [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
@@ -376,7 +375,7 @@ class CMakeBuilder(BaseBuilder, cmake.CMakeBuilder):
         filter_file(f"hdf5_hl-{config}", "hdf5_hl", *files, ignore_absent=True)
 
 
-class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
+class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
     @property
     def force_autoreconf(self):
         return any(self.spec.satisfies(s) for s in self.pkg._force_autoreconf_when)

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -10,6 +10,7 @@ import sys
 from llnl.util.lang import dedupe
 
 import spack.builder
+import spack.phase_callbacks
 from spack.build_systems import autotools, cmake
 from spack.package import *
 from spack.util.environment import filter_system_paths
@@ -305,7 +306,7 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
         return find_libraries("libnetcdf", root=self.prefix, shared=shared, recursive=True)
 
 
-class BaseBuilder(metaclass=spack.builder.PhaseCallbacksMeta):
+class BaseBuilder(metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
     def setup_dependent_build_environment(self, env, dependent_spec):
         # Some packages, e.g. ncview, refuse to build if the compiler path returned by nc-config
         # differs from the path to the compiler that the package should be built with. Therefore,

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -292,7 +292,7 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
             env.append_path("HDF5_PLUGIN_PATH", self.prefix.plugins)
 
     def flag_handler(self, name, flags):
-        if self.builder.build_system == "autotools":
+        if self.spec.satisfies("build_system=autotools"):
             if name == "cflags":
                 if "+pic" in self.spec:
                     flags.append(self.compiler.cc_pic_flag)

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -9,7 +9,6 @@ import sys
 
 from llnl.util.lang import dedupe
 
-import spack.builder
 import spack.phase_callbacks
 from spack.build_systems import autotools, cmake
 from spack.package import *

--- a/var/spack/repos/builtin/packages/nimrod-aai/package.py
+++ b/var/spack/repos/builtin/packages/nimrod-aai/package.py
@@ -69,5 +69,5 @@ class NimrodAai(CMakePackage):
     @run_after("build")
     @on_package_attributes(run_tests=True)
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             ctest("--output-on-failure")

--- a/var/spack/repos/builtin/packages/prod-util/package.py
+++ b/var/spack/repos/builtin/packages/prod-util/package.py
@@ -34,5 +34,5 @@ class ProdUtil(CMakePackage):
     depends_on("w3emc", when="@2:")
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import spack.builder
+import spack.phase_callbacks
 from spack.build_systems import autotools, cmake
 from spack.package import *
 
@@ -145,7 +146,7 @@ class Proj(CMakePackage, AutotoolsPackage):
         env.set("PROJ_LIB", self.prefix.share.proj)
 
 
-class BaseBuilder(metaclass=spack.builder.PhaseCallbacksMeta):
+class BaseBuilder(metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
     def setup_build_environment(self, env):
         env.set("PROJ_LIB", join_path(self.pkg.stage.source_path, "nad"))
 

--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.phase_callbacks
 from spack.build_systems import autotools, cmake
 from spack.package import *
 
@@ -145,7 +144,7 @@ class Proj(CMakePackage, AutotoolsPackage):
         env.set("PROJ_LIB", self.prefix.share.proj)
 
 
-class BaseBuilder(metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
+class AnyBuilder(BaseBuilder):
     def setup_build_environment(self, env):
         env.set("PROJ_LIB", join_path(self.pkg.stage.source_path, "nad"))
 
@@ -154,7 +153,7 @@ class BaseBuilder(metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
         install_tree(join_path("share", "proj"), self.prefix.share.proj)
 
 
-class CMakeBuilder(BaseBuilder, cmake.CMakeBuilder):
+class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
     def cmake_args(self):
         shared_arg = "BUILD_SHARED_LIBS" if self.spec.satisfies("@7:") else "BUILD_LIBPROJ_SHARED"
         args = [
@@ -177,7 +176,7 @@ class CMakeBuilder(BaseBuilder, cmake.CMakeBuilder):
         return args
 
 
-class AutotoolsBuilder(BaseBuilder, autotools.AutotoolsBuilder):
+class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
     def configure_args(self):
         args = []
 

--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.builder
 import spack.phase_callbacks
 from spack.build_systems import autotools, cmake
 from spack.package import *

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -448,7 +448,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
     @property
     def build_relpath(self):
         """Relative path to the cmake build subdirectory."""
-        return join_path("..", self.builder.build_dirname)
+        return join_path("..", self.build_dirname)
 
     @run_after("install")
     def setup_build_tests(self):

--- a/var/spack/repos/builtin/packages/rocthrust/package.py
+++ b/var/spack/repos/builtin/packages/rocthrust/package.py
@@ -77,7 +77,7 @@ class Rocthrust(CMakePackage):
         depends_on(f"rocm-cmake@{ver}:", type="build", when=f"@{ver}")
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")
 
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/sfcio/package.py
+++ b/var/spack/repos/builtin/packages/sfcio/package.py
@@ -46,5 +46,5 @@ class Sfcio(CMakePackage):
         return (None, None, flags)
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/sigio/package.py
+++ b/var/spack/repos/builtin/packages/sigio/package.py
@@ -44,5 +44,5 @@ class Sigio(CMakePackage):
         return (None, None, flags)
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/sp/package.py
+++ b/var/spack/repos/builtin/packages/sp/package.py
@@ -66,5 +66,5 @@ class Sp(CMakePackage):
         return args
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/strumpack/package.py
+++ b/var/spack/repos/builtin/packages/strumpack/package.py
@@ -226,7 +226,7 @@ class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
             )
 
         with working_dir(test_dir):
-            opts = self.builder.std_cmake_args + self.cmake_args() + ["."]
+            opts = self.std_cmake_args + self.cmake_args() + ["."]
             cmake = self.spec["cmake"].command
             cmake(*opts)
 

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -743,7 +743,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     @on_package_attributes(run_tests=True)
     def check_test_install(self):
         """Perform test_install on the build."""
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test_install")
 
     @property

--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -6,7 +6,6 @@ import os
 
 import spack.build_systems.cmake
 import spack.build_systems.generic
-import spack.phase_callbacks
 from spack.package import *
 
 
@@ -85,7 +84,7 @@ class Superlu(CMakePackage, Package):
             superlu()
 
 
-class BaseBuilder(metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
+class AnyBuilder(BaseBuilder):
     @run_after("install")
     def setup_standalone_tests(self):
         """Set up and copy example source files after the package is installed
@@ -139,7 +138,7 @@ class BaseBuilder(metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
         ]
 
 
-class CMakeBuilder(BaseBuilder, spack.build_systems.cmake.CMakeBuilder):
+class CMakeBuilder(AnyBuilder, spack.build_systems.cmake.CMakeBuilder):
     def cmake_args(self):
         if self.pkg.version > Version("5.2.1"):
             _blaslib_key = "enable_internal_blaslib"
@@ -154,7 +153,7 @@ class CMakeBuilder(BaseBuilder, spack.build_systems.cmake.CMakeBuilder):
         return args
 
 
-class GenericBuilder(BaseBuilder, spack.build_systems.generic.GenericBuilder):
+class GenericBuilder(AnyBuilder, spack.build_systems.generic.GenericBuilder):
     def install(self, pkg, spec, prefix):
         """Use autotools before version 5"""
         # Define make.inc file

--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -6,6 +6,7 @@ import os
 
 import spack.build_systems.cmake
 import spack.build_systems.generic
+import spack.phase_callbacks
 from spack.package import *
 
 
@@ -84,7 +85,7 @@ class Superlu(CMakePackage, Package):
             superlu()
 
 
-class BaseBuilder(metaclass=spack.builder.PhaseCallbacksMeta):
+class BaseBuilder(metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
     @run_after("install")
     def setup_standalone_tests(self):
         """Set up and copy example source files after the package is installed

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -8,29 +8,26 @@ import sys
 
 from llnl.util.filesystem import find_first
 
-import spack.phase_callbacks
 from spack.package import *
 from spack.util.environment import is_system_path
 
 is_windows = sys.platform == "win32"
 
 
-class TclHelper:
-    @staticmethod
-    def find_script_dir(spec):
-        # Put more-specific prefixes first
-        check_prefixes = [
-            join_path(spec.prefix, "share", "tcl{0}".format(spec.package.version.up_to(2))),
-            spec.prefix,
-        ]
-        for prefix in check_prefixes:
-            result = find_first(prefix, "init.tcl")
-            if result:
-                return os.path.dirname(result)
-        raise RuntimeError("Cannot locate init.tcl")
+def find_script_dir(spec: Spec) -> str:
+    # Put more-specific prefixes first
+    check_prefixes = [
+        join_path(spec.prefix, "share", "tcl{0}".format(spec.package.version.up_to(2))),
+        spec.prefix,
+    ]
+    for prefix in check_prefixes:
+        result = find_first(prefix, "init.tcl")
+        if result:
+            return os.path.dirname(result)
+    raise RuntimeError("Cannot locate init.tcl")
 
 
-class Tcl(AutotoolsPackage, NMakePackage, SourceforgePackage, TclHelper):
+class Tcl(AutotoolsPackage, NMakePackage, SourceforgePackage):
     """Tcl (Tool Command Language) is a very powerful but easy to learn dynamic
     programming language, suitable for a very wide range of uses, including web and
     desktop applications, networking, administration, testing and many more. Open source
@@ -106,7 +103,7 @@ class Tcl(AutotoolsPackage, NMakePackage, SourceforgePackage, TclHelper):
         """
         # When using tkinter from within spack provided python+tkinter,
         # python will not be able to find Tcl unless TCL_LIBRARY is set.
-        env.set("TCL_LIBRARY", TclHelper.find_script_dir(self.spec))
+        env.set("TCL_LIBRARY", find_script_dir(self.spec))
 
     def setup_dependent_run_environment(self, env, dependent_spec):
         """Set TCLLIBPATH to include the tcl-shipped directory for
@@ -124,7 +121,7 @@ class Tcl(AutotoolsPackage, NMakePackage, SourceforgePackage, TclHelper):
                     env.prepend_path("TCLLIBPATH", tcllibpath, separator=" ")
 
 
-class BaseBuilder(TclHelper, metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
+class AnyBuilder(BaseBuilder):
     @run_after("install")
     def symlink_tclsh(self):
         # There's some logic regarding this suffix in the build system
@@ -152,7 +149,7 @@ class BaseBuilder(TclHelper, metaclass=spack.phase_callbacks.PhaseCallbacksMeta)
         * https://wiki.tcl-lang.org/page/TCL_LIBRARY
         * https://wiki.tcl-lang.org/page/TCLLIBPATH
         """
-        env.set("TCL_LIBRARY", TclHelper.find_script_dir(self.spec))
+        env.set("TCL_LIBRARY", find_script_dir(self.spec))
 
         # If we set TCLLIBPATH, we must also ensure that the corresponding
         # tcl is found in the build environment. This to prevent cases
@@ -183,7 +180,7 @@ class BaseBuilder(TclHelper, metaclass=spack.phase_callbacks.PhaseCallbacksMeta)
                     env.prepend_path("TCLLIBPATH", tcllibpath, separator=" ")
 
 
-class AutotoolsBuilder(BaseBuilder, spack.build_systems.autotools.AutotoolsBuilder):
+class AutotoolsBuilder(AnyBuilder, spack.build_systems.autotools.AutotoolsBuilder):
     configure_directory = "unix"
 
     def install(self, pkg, spec, prefix):
@@ -216,7 +213,7 @@ class AutotoolsBuilder(BaseBuilder, spack.build_systems.autotools.AutotoolsBuild
             make("clean")
 
 
-class NMakeBuilder(BaseBuilder, spack.build_systems.nmake.NMakeBuilder):
+class NMakeBuilder(AnyBuilder, spack.build_systems.nmake.NMakeBuilder):
     build_targets = ["all"]
     install_targets = ["install"]
 

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -8,6 +8,7 @@ import sys
 
 from llnl.util.filesystem import find_first
 
+import spack.phase_callbacks
 from spack.package import *
 from spack.util.environment import is_system_path
 
@@ -123,7 +124,7 @@ class Tcl(AutotoolsPackage, NMakePackage, SourceforgePackage, TclHelper):
                     env.prepend_path("TCLLIBPATH", tcllibpath, separator=" ")
 
 
-class BaseBuilder(TclHelper, metaclass=spack.builder.PhaseCallbacksMeta):
+class BaseBuilder(TclHelper, metaclass=spack.phase_callbacks.PhaseCallbacksMeta):
     @run_after("install")
     def symlink_tclsh(self):
         # There's some logic regarding this suffix in the build system

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -7,6 +7,7 @@
 import os
 import sys
 
+from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
 
 
@@ -249,7 +250,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
                 options.append("-DCMAKE_CUDA_HOST_COMPILER={0}".format(env["SPACK_CXX"]))
 
                 if spec.satisfies("@1.9.0:") and spec.satisfies("^cmake@3.18:"):
-                    options.append(self.builder.define_cuda_architectures(self))
+                    options.append(CMakeBuilder.define_cuda_architectures(self))
 
                 else:
                     # VTKm_CUDA_Architecture only accepts a single CUDA arch
@@ -269,7 +270,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
 
             # hip support
             if "+rocm" in spec:
-                options.append(self.builder.define_hip_architectures(self))
+                options.append(CMakeBuilder.define_hip_architectures(self))
 
         return options
 

--- a/var/spack/repos/builtin/packages/w3emc/package.py
+++ b/var/spack/repos/builtin/packages/w3emc/package.py
@@ -95,5 +95,5 @@ class W3emc(CMakePackage):
         return args
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/var/spack/repos/builtin/packages/xsdk-examples/package.py
+++ b/var/spack/repos/builtin/packages/xsdk-examples/package.py
@@ -101,5 +101,5 @@ class XsdkExamples(CMakePackage, CudaPackage, ROCmPackage):
         return args
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             ctest("--output-on-failure")


### PR DESCRIPTION
* Fix circular import between `spack.builder` and `spack.package_base`
* Fix circular import between `spack.directives` and `spack.package_base`

This allows type hints in `package_base` directives that are actually picked up by language servers, as well as in all builders, which massively improves completion in custom phase functions like `def build`, and other API like `setup_run_environment`.

A breaking change is that `PackageBase.builder` is deleted, which was the main blocker for adding typehints without causing circular import errors. Since that had a trivial implementation of `spack.builder.create(self)`, just ask the call site to write that then.

Notice that nothing improved in `ci / prechecks / import-check` because missing imports were added, offsetting what was removed.