### PR TITLE
Installer: allow packages to build concurrently 

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -215,6 +215,7 @@ nitpick_ignore = [
     ("py:class", "TextIO"),
     ("py:class", "hashlib._Hash"),
     ("py:class", "concurrent.futures._base.Executor"),
+    ("py:class", "multiprocessing.context.Process"),
     # Spack classes that are private and we don't want to expose
     ("py:class", "spack.provider_index._IndexBase"),
     ("py:class", "spack.repo._PrependFileLoader"),

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1030,6 +1030,7 @@ def replace_directory_transaction(directory_name):
     Returns:
         temporary directory where ``directory_name`` has been moved
     """
+
     # Check the input is indeed a directory with absolute path.
     # Raise before anything is done to avoid moving the wrong directory
     directory_name = os.path.abspath(directory_name)

--- a/lib/spack/spack/bootstrap/environment.py
+++ b/lib/spack/spack/bootstrap/environment.py
@@ -92,7 +92,7 @@ class BootstrapEnvironment(spack.environment.Environment):
             tty.msg(f"[BOOTSTRAPPING] Installing dependencies ({', '.join(colorized_specs)})")
             self.write(regenerate=False)
             with tty.SuppressOutput(msg_enabled=log_enabled, warn_enabled=log_enabled):
-                self.install_all()
+                self.install_all(fail_fast=True)
                 self.write(regenerate=True)
 
     def load(self) -> None:

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -97,7 +97,7 @@ class ConstraintAction(argparse.Action):
 class SetParallelJobs(argparse.Action):
     """Sets the correct value for parallel build jobs.
 
-    The value is is set in the command line configuration scope so that
+    The value is set in the command line configuration scope so that
     it can be retrieved using the spack.config API.
     """
 
@@ -111,6 +111,23 @@ class SetParallelJobs(argparse.Action):
         spack.config.set("config:build_jobs", jobs, scope="command_line")
 
         setattr(namespace, "jobs", jobs)
+
+
+class SetConcurrentPackages(argparse.Action):
+    """Sets the value for maximum number of concurrent package builds
+
+    The value is set in the command line configuration scope so that
+    it can be retrieved using the spack.config API.
+    """
+
+    def __call__(self, parser, namespace, concurrent_packages, option_string):
+        if concurrent_packages < 1:
+            msg = 'invalid value for argument "{0}" ' '[expected a positive integer, got "{1}"]'
+            raise ValueError(msg.format(option_string, concurrent_packages))
+
+        spack.config.set("config:concurrent_packages", concurrent_packages, scope="command_line")
+
+        setattr(namespace, "concurrent_packages", concurrent_packages)
 
 
 class DeptypeAction(argparse.Action):
@@ -374,6 +391,18 @@ def jobs():
         type=int,
         dest="jobs",
         help="explicitly set number of parallel jobs",
+    )
+
+
+@arg
+def concurrent_packages():
+    return Args(
+        "-p",
+        "--concurrent-packages",
+        action=SetConcurrentPackages,
+        type=int,
+        default=4,
+        help="maximum number of packages to build concurrently",
     )
 
 

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -10,14 +10,13 @@ from typing import List
 
 import llnl.util.filesystem as fs
 from llnl.string import plural
-from llnl.util import lang, tty
+from llnl.util import tty
 
 import spack.cmd
 import spack.concretize
 import spack.config
 import spack.environment as ev
 import spack.paths
-import spack.report
 import spack.spec
 import spack.store
 from spack.cmd.common import arguments
@@ -63,6 +62,7 @@ def install_kwargs_from_args(args):
         "unsigned": args.unsigned,
         "install_deps": ("dependencies" in args.things_to_install),
         "install_package": ("package" in args.things_to_install),
+        "concurrent_packages": args.concurrent_packages,
     }
 
 
@@ -84,6 +84,7 @@ def setup_parser(subparser):
         default=None,
         help="phase to stop after when installing (default None)",
     )
+    arguments.add_common_arguments(subparser, ["concurrent_packages"])
     arguments.add_common_arguments(subparser, ["jobs"])
     subparser.add_argument(
         "--overwrite",
@@ -329,16 +330,8 @@ def install(parser, args):
 
     arguments.sanitize_reporter_options(args)
 
-    def reporter_factory(specs):
-        if args.log_format is None:
-            return lang.nullcontext()
-
-        return spack.report.build_context_manager(
-            reporter=args.reporter(), filename=report_filename(args, specs=specs), specs=specs
-        )
-
+    reporter = args.reporter() if args.log_format else None
     install_kwargs = install_kwargs_from_args(args)
-
     env = ev.active_environment()
 
     if not env and not args.spec and not args.specfiles:
@@ -346,9 +339,9 @@ def install(parser, args):
 
     try:
         if env:
-            install_with_active_env(env, args, install_kwargs, reporter_factory)
+            install_with_active_env(env, args, install_kwargs, reporter)
         else:
-            install_without_active_env(args, install_kwargs, reporter_factory)
+            install_without_active_env(args, install_kwargs, reporter)
     except InstallError as e:
         if args.show_log_on_error:
             _dump_log_on_error(e)
@@ -382,7 +375,7 @@ def _maybe_add_and_concretize(args, env, specs):
         env.write(regenerate=False)
 
 
-def install_with_active_env(env: ev.Environment, args, install_kwargs, reporter_factory):
+def install_with_active_env(env: ev.Environment, args, install_kwargs, reporter):
     specs = spack.cmd.parse_specs(args.spec)
 
     # The following two commands are equivalent:
@@ -416,8 +409,10 @@ def install_with_active_env(env: ev.Environment, args, install_kwargs, reporter_
         install_kwargs["overwrite"] = [spec.dag_hash() for spec in specs_to_install]
 
     try:
-        with reporter_factory(specs_to_install):
-            env.install_specs(specs_to_install, **install_kwargs)
+        report_file = report_filename(args, specs_to_install)
+        install_kwargs["report_file"] = report_file
+        install_kwargs["reporter"] = reporter
+        env.install_specs(specs_to_install, **install_kwargs)
     finally:
         if env.views:
             with env.write_transaction():
@@ -461,18 +456,23 @@ def concrete_specs_from_file(args):
     return result
 
 
-def install_without_active_env(args, install_kwargs, reporter_factory):
+def install_without_active_env(args, install_kwargs, reporter):
     concrete_specs = concrete_specs_from_cli(args, install_kwargs) + concrete_specs_from_file(args)
 
     if len(concrete_specs) == 0:
         tty.die("The `spack install` command requires a spec to install.")
 
-    with reporter_factory(concrete_specs):
-        if args.overwrite:
-            require_user_confirmation_for_overwrite(concrete_specs, args)
-            install_kwargs["overwrite"] = [spec.dag_hash() for spec in concrete_specs]
+    if args.overwrite:
+        require_user_confirmation_for_overwrite(concrete_specs, args)
+        install_kwargs["overwrite"] = [spec.dag_hash() for spec in concrete_specs]
 
-        installs = [s.package for s in concrete_specs]
-        install_kwargs["explicit"] = [s.dag_hash() for s in concrete_specs]
+    installs = [s.package for s in concrete_specs]
+    install_kwargs["explicit"] = [s.dag_hash() for s in concrete_specs]
+
+    try:
         builder = PackageInstaller(installs, **install_kwargs)
         builder.install()
+    finally:
+        if reporter:
+            report_file = report_filename(args, concrete_specs)
+            reporter.build_report(report_file, list(builder.reports.values()))

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1629,7 +1629,7 @@ def determine_number_of_jobs(
     except ValueError:
         pass
 
-    return min(max_cpus, cfg.get("config:build_jobs", 16))
+    return min(max_cpus, cfg.get("config:build_jobs", 4))
 
 
 class ConfigSectionError(spack.error.ConfigError):

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -21,7 +21,6 @@ import contextlib
 import datetime
 import os
 import pathlib
-import socket
 import sys
 import time
 from json import JSONDecoder
@@ -53,7 +52,6 @@ except ImportError:
     pass
 
 import llnl.util.filesystem as fs
-import llnl.util.lang
 import llnl.util.tty as tty
 
 import spack.deptypes as dt
@@ -70,6 +68,7 @@ from spack.directory_layout import (
 )
 from spack.error import SpackError
 from spack.util.crypto import bit_length
+from spack.util.socket import _getfqdn
 
 from .enums import InstallRecordStatus
 
@@ -136,17 +135,6 @@ _INDEX_VERIFIER_FILE = "index_verifier"
 
 # Lockfile for the database
 _LOCK_FILE = "lock"
-
-
-@llnl.util.lang.memoized
-def _getfqdn():
-    """Memoized version of `getfqdn()`.
-
-    If we call `getfqdn()` too many times, DNS can be very slow. We only need to call it
-    one time per process, so we cache it here.
-
-    """
-    return socket.getfqdn()
 
 
 def reader(version: vn.StandardVersion) -> Type["spack.spec.SpecfileReaderBase"]:

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -284,7 +284,10 @@ class DirectoryLayout:
         Raised RemoveFailedError if something goes wrong.
         """
         path = self.path_for_spec(spec)
-        assert path.startswith(self.root)
+        assert path.startswith(
+            self.root
+        ), "Attempted to remove a directory outside Spack's install tree."
+        f"PATH: {path}, ROOT: {self.root}"
 
         if deprecated:
             if os.path.exists(path):

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -18,6 +18,7 @@ import spack.package_prefs
 import spack.paths
 import spack.spec
 import spack.store
+from spack.util.socket import _getfqdn
 
 #: OS-imposed character limit for shebang line: 127 for Linux; 511 for Mac.
 #: Different Linux distributions have different limits, but 127 is the
@@ -209,9 +210,7 @@ def install_sbang():
         os.chown(sbang_bin_dir, os.stat(sbang_bin_dir).st_uid, grp.getgrnam(group_name).gr_gid)
 
     # copy over the fresh copy of `sbang`
-    sbang_tmp_path = os.path.join(
-        os.path.dirname(sbang_path), ".%s.tmp" % os.path.basename(sbang_path)
-    )
+    sbang_tmp_path = os.path.join(sbang_bin_dir, f".sbang.{_getfqdn()}.{os.getpid()}.tmp")
     shutil.copy(spack.paths.sbang_script, sbang_tmp_path)
 
     # set permissions on `sbang` (including group if set in configuration)

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1662,10 +1662,11 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         if self.spec.versions.concrete:
             try:
                 source_id = fs.for_package_version(self).source_id()
-            except (fs.ExtrapolationError, fs.InvalidArgsError):
+            except (fs.ExtrapolationError, fs.InvalidArgsError, spack.error.NoURLError):
                 # ExtrapolationError happens if the package has no fetchers defined.
                 # InvalidArgsError happens when there are version directives with args,
                 #     but none of them identifies an actual fetcher.
+                # NoURLError happens if the package is external-only with no url
                 source_id = None
 
             if not source_id:

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -1,276 +1,172 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-"""Tools to produce reports of spec installations"""
+"""Tools to produce reports of spec installations or tests"""
 import collections
-import contextlib
-import functools
 import gzip
 import os
 import time
 import traceback
-from typing import Any, Callable, Dict, List, Type
 
-import llnl.util.lang
+import spack.error
 
-import spack.build_environment
-import spack.install_test
-import spack.installer
-import spack.package_base
-import spack.reporters
-import spack.spec
+reporter = None
+report_file = None
+
+Property = collections.namedtuple("Property", ["name", "value"])
 
 
-class InfoCollector:
-    """Base class for context manager objects that collect information during the execution of
-    certain package functions.
+class Record(dict):
+    """Data class that provides attr-style access to a dictionary
 
-    The data collected is available through the ``specs`` attribute once exited, and it's
-    organized as a list where each item represents the installation of one spec.
+    Attributes beginning with ``_`` are reserved for the Record class itself."""
 
+    def __getattr__(self, name):
+        # only called if no attribute exists
+        if name in self:
+            return self[name]
+        raise AttributeError(f"Record for {self.name} has no attribute {name}")
+
+    def __setattr__(self, name, value):
+        if name.startswith("_"):
+            super().__setattr__(name, value)
+        else:
+            self[name] = value
+
+
+class RequestRecord(Record):
+    """Data class for recording outcomes for an entire DAG
+
+    Each BuildRequest in the installer and each root spec in a TestSuite generates a
+    RequestRecord. The ``packages`` list of the RequestRecord is a list of SpecRecord
+    objects recording individual data for each node in the Spec represented by the
+    RequestRecord.
+
+    These data classes are collated by the reporters in lib/spack/spack/reporters
     """
 
-    wrap_class: Type
-    do_fn: str
-    _backup_do_fn: Callable
-    input_specs: List[spack.spec.Spec]
-    specs: List[Dict[str, Any]]
+    def __init__(self, spec):
+        super().__init__()
+        self._spec = spec
+        self.name = spec.name
+        self.nerrors = None
+        self.nfailures = None
+        self.npackages = None
+        self.time = None
+        self.timestamp = time.strftime("%a, %d %b %Y %H:%M:%S", time.gmtime())
+        self.properties = [
+            Property("architecture", spec.architecture),
+            # Property("compiler", spec.compiler),
+        ]
+        self.packages = []
 
-    def __init__(self, wrap_class: Type, do_fn: str, specs: List[spack.spec.Spec]):
-        #: Class for which to wrap a function
-        self.wrap_class = wrap_class
-        #: Action to be reported on
-        self.do_fn = do_fn
-        #: Backup of the wrapped class function
-        self._backup_do_fn = getattr(self.wrap_class, do_fn)
-        #: Specs that will be acted on
-        self.input_specs = specs
-        #: This is where we record the data that will be included in our report
-        self.specs: List[Dict[str, Any]] = []
+    def skip_installed(self):
+        """Insert records for all nodes in the DAG that are no-ops for this request"""
+        for dep in filter(lambda x: x.installed or x.external, self._spec.traverse()):
+            record = InstallRecord(dep)
+            record.skip(msg="Spec external or already installed")
+            self.packages.append(record)
 
-    def fetch_log(self, pkg: spack.package_base.PackageBase) -> str:
-        """Return the stdout log associated with the function being monitored
+    def append_record(self, record):
+        self.packages.append(record)
 
-        Args:
-            pkg: package under consideration
+    def summarize(self):
+        """Construct request-level summaries of the individual records"""
+        self.npackages = len(self.packages)
+        self.nfailures = len([r for r in self.packages if r.result == "failure"])
+        self.nerrors = len([r for r in self.packages if r.result == "error"])
+        self.time = sum(float(r.elapsed_time or 0.0) for r in self.packages)
+
+
+class SpecRecord(Record):
+    """Individual record for a single spec within a request"""
+
+    def __init__(self, spec):
+        super().__init__()
+        self._spec = spec
+        self._package = spec.package
+        self._start_time = None
+        self.name = spec.name
+        self.id = spec.dag_hash()
+        self.elapsed_time = None
+
+    def start(self):
+        self._start_time = time.time()
+
+    def skip(self, msg):
+        self.result = "skipped"
+        self.elapsed_time = 0.0
+        self.message = msg
+
+    def fail(self, exc):
+        """Record failure based on exception type
+
+        Errors wrapped by spack.error.InstallError are "failures"
+        Other exceptions are "errors".
         """
-        raise NotImplementedError("must be implemented by derived classes")
+        if isinstance(exc, spack.error.InstallError):
+            self.result = "failure"
+            self.message = exc.message or "Installation failure"
+            self.exception = exc.traceback
+        else:
+            self.result = "error"
+            self.message = str(exc) or "Unknown error"
+            self.exception = traceback.format_exc()
+        self.stdout = self.fetch_log() + self.message
+        assert self._start_time, "Start time is None"
+        self.elapsed_time = time.time() - self._start_time
 
-    def extract_package_from_signature(self, instance, *args, **kwargs):
-        """Return the package instance, given the signature of the wrapped function."""
-        raise NotImplementedError("must be implemented by derived classes")
-
-    def __enter__(self):
-        # Initialize the spec report with the data that is available upfront.
-        Property = collections.namedtuple("Property", ["name", "value"])
-        for input_spec in self.input_specs:
-            name_fmt = "{0}_{1}"
-            name = name_fmt.format(input_spec.name, input_spec.dag_hash(length=7))
-            spec_record = {
-                "name": name,
-                "nerrors": None,
-                "nfailures": None,
-                "npackages": None,
-                "time": None,
-                "timestamp": time.strftime("%a, %d %b %Y %H:%M:%S", time.gmtime()),
-                "properties": [],
-                "packages": [],
-            }
-            spec_record["properties"].append(Property("architecture", input_spec.architecture))
-            self.init_spec_record(input_spec, spec_record)
-            self.specs.append(spec_record)
-
-        def gather_info(wrapped_fn):
-            """Decorates a function to gather useful information for a CI report."""
-
-            @functools.wraps(wrapped_fn)
-            def wrapper(instance, *args, **kwargs):
-                pkg = self.extract_package_from_signature(instance, *args, **kwargs)
-
-                package = {
-                    "name": pkg.name,
-                    "id": pkg.spec.dag_hash(),
-                    "elapsed_time": None,
-                    "result": None,
-                    "message": None,
-                    "installed_from_binary_cache": False,
-                }
-
-                # Append the package to the correct spec report. In some
-                # cases it may happen that a spec that is asked to be
-                # installed explicitly will also be installed as a
-                # dependency of another spec. In this case append to both
-                # spec reports.
-                for current_spec in llnl.util.lang.dedupe([pkg.spec.root, pkg.spec]):
-                    name = name_fmt.format(current_spec.name, current_spec.dag_hash(length=7))
-                    try:
-                        item = next((x for x in self.specs if x["name"] == name))
-                        item["packages"].append(package)
-                    except StopIteration:
-                        pass
-
-                start_time = time.time()
-                try:
-                    value = wrapped_fn(instance, *args, **kwargs)
-                    package["stdout"] = self.fetch_log(pkg)
-                    package["installed_from_binary_cache"] = pkg.installed_from_binary_cache
-                    self.on_success(pkg, kwargs, package)
-                    return value
-
-                except spack.build_environment.InstallError as exc:
-                    # An InstallError is considered a failure (the recipe
-                    # didn't work correctly)
-                    package["result"] = "failure"
-                    package["message"] = exc.message or "Installation failure"
-                    package["stdout"] = self.fetch_log(pkg)
-                    package["stdout"] += package["message"]
-                    package["exception"] = exc.traceback
-                    raise
-
-                except (Exception, BaseException) as exc:
-                    # Everything else is an error (the installation
-                    # failed outside of the child process)
-                    package["result"] = "error"
-                    package["message"] = str(exc) or "Unknown error"
-                    package["stdout"] = self.fetch_log(pkg)
-                    package["stdout"] += package["message"]
-                    package["exception"] = traceback.format_exc()
-                    raise
-
-                finally:
-                    package["elapsed_time"] = time.time() - start_time
-
-            return wrapper
-
-        setattr(self.wrap_class, self.do_fn, gather_info(getattr(self.wrap_class, self.do_fn)))
-
-    def on_success(self, pkg: spack.package_base.PackageBase, kwargs, package_record):
-        """Add additional properties on function call success."""
-        raise NotImplementedError("must be implemented by derived classes")
-
-    def init_spec_record(self, input_spec: spack.spec.Spec, record):
-        """Add additional entries to a spec record when entering the collection context."""
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        # Restore the original method in PackageBase
-        setattr(self.wrap_class, self.do_fn, self._backup_do_fn)
-        for spec in self.specs:
-            spec["npackages"] = len(spec["packages"])
-            spec["nfailures"] = len([x for x in spec["packages"] if x["result"] == "failure"])
-            spec["nerrors"] = len([x for x in spec["packages"] if x["result"] == "error"])
-            spec["time"] = sum(float(x["elapsed_time"]) for x in spec["packages"])
+    def succeed(self):
+        """Record success for this spec"""
+        self.result = "success"
+        self.stdout = self.fetch_log()
+        assert self._start_time, "Start time is None"
+        self.elapsed_time = time.time() - self._start_time
 
 
-class BuildInfoCollector(InfoCollector):
-    """Collect information for the PackageInstaller._install_task method.
+class InstallRecord(SpecRecord):
+    """Record class with specialization for install logs."""
 
-    Args:
-        specs: specs whose install information will be recorded
-    """
+    def __init__(self, spec):
+        super().__init__(spec)
+        self.installed_from_binary_cache = None
 
-    def __init__(self, specs: List[spack.spec.Spec]):
-        super().__init__(spack.installer.PackageInstaller, "_install_task", specs)
-
-    def init_spec_record(self, input_spec, record):
-        # Check which specs are already installed and mark them as skipped
-        for dep in filter(lambda x: x.installed, input_spec.traverse()):
-            package = {
-                "name": dep.name,
-                "id": dep.dag_hash(),
-                "elapsed_time": "0.0",
-                "result": "skipped",
-                "message": "Spec already installed",
-            }
-            record["packages"].append(package)
-
-    def on_success(self, pkg, kwargs, package_record):
-        package_record["result"] = "success"
-
-    def fetch_log(self, pkg):
+    def fetch_log(self):
+        """Install log comes from install prefix on success, or stage dir on failure."""
         try:
-            if os.path.exists(pkg.install_log_path):
-                stream = gzip.open(pkg.install_log_path, "rt", encoding="utf-8")
+            if os.path.exists(self._package.install_log_path):
+                stream = gzip.open(self._package.install_log_path, "rt", encoding="utf-8")
             else:
-                stream = open(pkg.log_path, encoding="utf-8")
+                stream = open(self._package.log_path, encoding="utf-8")
             with stream as f:
                 return f.read()
         except OSError:
-            return f"Cannot open log for {pkg.spec.cshort_spec}"
+            return f"Cannot open log for {self._spec.cshort_spec}"
 
-    def extract_package_from_signature(self, instance, *args, **kwargs):
-        return args[0].pkg
+    def succeed(self):
+        super().succeed()
+        self.installed_from_binary_cache = self._package.installed_from_binary_cache
 
 
-class TestInfoCollector(InfoCollector):
-    """Collect information for the PackageBase.do_test method.
+class TestRecord(SpecRecord):
+    """Record class with specialization for test logs."""
 
-    Args:
-        specs: specs whose install information will be recorded
-        record_directory: record directory for test log paths
-    """
+    def __init__(self, spec, directory):
+        super().__init__(spec)
+        self.directory = directory
 
-    dir: str
-
-    def __init__(self, specs: List[spack.spec.Spec], record_directory: str):
-        super().__init__(spack.package_base.PackageBase, "do_test", specs)
-        self.dir = record_directory
-
-    def on_success(self, pkg, kwargs, package_record):
-        externals = kwargs.get("externals", False)
-        skip_externals = pkg.spec.external and not externals
-        if skip_externals:
-            package_record["result"] = "skipped"
-        package_record["result"] = "success"
-
-    def fetch_log(self, pkg: spack.package_base.PackageBase):
-        log_file = os.path.join(self.dir, spack.install_test.TestSuite.test_log_name(pkg.spec))
+    def fetch_log(self):
+        """Get output from test log"""
+        log_file = os.path.join(self.directory, self._package.test_suite.test_log_name(self._spec))
         try:
             with open(log_file, "r", encoding="utf-8") as stream:
                 return "".join(stream.readlines())
         except Exception:
-            return f"Cannot open log for {pkg.spec.cshort_spec}"
+            return f"Cannot open log for {self._spec.cshort_spec}"
 
-    def extract_package_from_signature(self, instance, *args, **kwargs):
-        return instance
+    def succeed(self, externals):
+        """Test reports skip externals by default."""
+        if self._spec.external and not externals:
+            return self.skip(msg="Skipping test of external package")
 
-
-@contextlib.contextmanager
-def build_context_manager(
-    reporter: spack.reporters.Reporter, filename: str, specs: List[spack.spec.Spec]
-):
-    """Decorate a package to generate a report after the installation function is executed.
-
-    Args:
-        reporter: object that generates the report
-        filename:  filename for the report
-        specs: specs that need reporting
-    """
-    collector = BuildInfoCollector(specs)
-    try:
-        with collector:
-            yield
-    finally:
-        reporter.build_report(filename, specs=collector.specs)
-
-
-@contextlib.contextmanager
-def test_context_manager(
-    reporter: spack.reporters.Reporter,
-    filename: str,
-    specs: List[spack.spec.Spec],
-    raw_logs_dir: str,
-):
-    """Decorate a package to generate a report after the test function is executed.
-
-    Args:
-        reporter: object that generates the report
-        filename:  filename for the report
-        specs: specs that need reporting
-        raw_logs_dir: record directory for test log paths
-    """
-    collector = TestInfoCollector(specs, raw_logs_dir)
-    try:
-        with collector:
-            yield
-    finally:
-        reporter.test_report(filename, specs=collector.specs)
+        super().succeed()

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -278,6 +278,8 @@ class CDash(Reporter):
         self.multiple_packages = False
         num_packages = 0
         for spec in specs:
+            spec.summarize()
+
             # Do not generate reports for packages that were installed
             # from the binary cache.
             spec["packages"] = [
@@ -362,6 +364,8 @@ class CDash(Reporter):
         """Generate reports for each package in each spec."""
         tty.debug("Processing test report")
         for spec in specs:
+            spec.summarize()
+
             duration = 0
             if "time" in spec:
                 duration = int(spec["time"])

--- a/lib/spack/spack/reporters/junit.py
+++ b/lib/spack/spack/reporters/junit.py
@@ -17,12 +17,16 @@ class JUnit(Reporter):
         pass
 
     def build_report(self, filename, specs):
+        for spec in specs:
+            spec.summarize()
+
         if not (os.path.splitext(filename))[1]:
             # Ensure the report name will end with the proper extension;
             # otherwise, it currently defaults to the "directory" name.
             filename = filename + ".xml"
 
         report_data = {"specs": specs}
+
         with open(filename, "w", encoding="utf-8") as f:
             env = spack.tengine.make_environment()
             t = env.get_template(self._jinja_template)

--- a/lib/spack/spack/util/socket.py
+++ b/lib/spack/spack/util/socket.py
@@ -1,0 +1,19 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Optimized Spack implementations of methods from socket module."""
+
+import socket
+
+import llnl.util.lang
+
+
+@llnl.util.lang.memoized
+def _getfqdn():
+    """Memoized version of `getfqdn()`.
+
+    If we call `getfqdn()` too many times, DNS can be very slow. We only need to call it
+    one time per process, so we cache it here.
+
+    """
+    return socket.getfqdn()

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1348,7 +1348,7 @@ _spack_info() {
 _spack_install() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --only -u --until -j --jobs --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --use-buildcache --include-build-deps --no-check-signature --show-log-on-error --source -n --no-checksum -v --verbose --fake --only-concrete --add --no-add -f --file --clean --dirty --test --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help --only -u --until -p --concurrent-packages -j --jobs --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --use-buildcache --include-build-deps --no-check-signature --show-log-on-error --source -n --no-checksum -v --verbose --fake --only-concrete --add --no-add -f --file --clean --dirty --test --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2032,7 +2032,7 @@ complete -c spack -n '__fish_spack_using_command info' -l variants-by-name -f -a
 complete -c spack -n '__fish_spack_using_command info' -l variants-by-name -d 'list variants in strict name order; don'"'"'t group by condition'
 
 # spack install
-set -g __fish_spack_optspecs_spack_install h/help only= u/until= j/jobs= overwrite fail-fast keep-prefix keep-stage dont-restage use-cache no-cache cache-only use-buildcache= include-build-deps no-check-signature show-log-on-error source n/no-checksum v/verbose fake only-concrete add no-add f/file= clean dirty test= log-format= log-file= help-cdash cdash-upload-url= cdash-build= cdash-site= cdash-track= cdash-buildstamp= y/yes-to-all U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_install h/help only= u/until= p/concurrent-packages= j/jobs= overwrite fail-fast keep-prefix keep-stage dont-restage use-cache no-cache cache-only use-buildcache= include-build-deps no-check-signature show-log-on-error source n/no-checksum v/verbose fake only-concrete add no-add f/file= clean dirty test= log-format= log-file= help-cdash cdash-upload-url= cdash-build= cdash-site= cdash-track= cdash-buildstamp= y/yes-to-all U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 install' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command install' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command install' -s h -l help -d 'show this help message and exit'
@@ -2040,6 +2040,8 @@ complete -c spack -n '__fish_spack_using_command install' -l only -r -f -a 'pack
 complete -c spack -n '__fish_spack_using_command install' -l only -r -d 'select the mode of installation'
 complete -c spack -n '__fish_spack_using_command install' -s u -l until -r -f -a until
 complete -c spack -n '__fish_spack_using_command install' -s u -l until -r -d 'phase to stop after when installing (default None)'
+complete -c spack -n '__fish_spack_using_command install' -s p -l concurrent-packages -r -f -a concurrent_packages
+complete -c spack -n '__fish_spack_using_command install' -s p -l concurrent-packages -r -d 'maximum number of packages to build concurrently'
 complete -c spack -n '__fish_spack_using_command install' -s j -l jobs -r -f -a jobs
 complete -c spack -n '__fish_spack_using_command install' -s j -l jobs -r -d 'explicitly set number of parallel jobs'
 complete -c spack -n '__fish_spack_using_command install' -l overwrite -f -a overwrite

--- a/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/msvc/package.py
@@ -30,6 +30,7 @@ class Msvc(Package, CompilerPackage):
     """
 
     homepage = "https://visualstudio.microsoft.com/vs/features/cplusplus/"
+    has_code = False
 
     has_code = False
 

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/externaltool/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/externaltool/package.py
@@ -9,10 +9,10 @@ from spack.package import *
 
 class Externaltool(Package):
     homepage = "http://somewhere.com"
-    url = "http://somewhere.com/tool-1.0.tar.gz"
+    has_code = False
 
-    version("1.0", md5="1234567890abcdef1234567890abcdef")
-    version("0.9", md5="1234567890abcdef1234567890abcdef")
-    version("0.8.1", md5="1234567890abcdef1234567890abcdef")
+    version("1.0")
+    version("0.9")
+    version("0.8.1")
 
     depends_on("externalprereq")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_a/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_a/package.py
@@ -1,0 +1,28 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import time
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from llnl.util.filesystem import touch
+
+from spack.package import *
+
+
+class ParallelPackageA(Package):
+    """This is a fake vtk-m package used to demonstrate virtual package providers
+    with dependencies."""
+
+    homepage = "http://www.example.com"
+    has_code = False
+
+    depends_on("parallel-package-b")
+    depends_on("parallel-package-c")
+
+    version("1.0")
+
+    def install(self, spec, prefix):
+        time.sleep(2)
+        touch(prefix.dummy_file)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_b/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_b/package.py
@@ -1,0 +1,25 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import time
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from llnl.util.filesystem import touch
+
+from spack.package import *
+
+
+class ParallelPackageB(Package):
+    """This is a fake vtk-m package used to demonstrate virtual package providers
+    with dependencies."""
+
+    homepage = "http://www.example.com"
+    has_code = False
+
+    version("1.0")
+
+    def install(self, spec, prefix):
+        time.sleep(6)
+        touch(prefix.dummy_file)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_c/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/parallel_package_c/package.py
@@ -1,0 +1,25 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import time
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from llnl.util.filesystem import touch
+
+from spack.package import *
+
+
+class ParallelPackageC(Package):
+    """This is a fake vtk-m package used to demonstrate virtual package providers
+    with dependencies."""
+
+    homepage = "http://www.example.com"
+    has_code = False
+
+    version("1.0")
+
+    def install(self, spec, prefix):
+        time.sleep(2)
+        touch(prefix.dummy_file)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/trivial_install_test_dependent/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/trivial_install_test_dependent/package.py
@@ -1,0 +1,21 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack_repo.builtin_mock.build_systems.generic import Package
+
+from spack.package import *
+
+
+class TrivialInstallTestDependent(Package):
+    """This package is a stub with a trivial install method.  It allows us
+    to test the install and uninstall logic of spack."""
+
+    homepage = "http://www.example.com/trivial_install"
+    url = "http://www.unit-test-should-replace-this-url/trivial_install-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    depends_on("trivial-install-test-package")
+
+    def install(self, spec, prefix):
+        touch(join_path(prefix, "an_installation_file"))


### PR DESCRIPTION
## Summary
Currently, Spack only builds one package at a time. This PR allows N packages to build concurrently through refactoring parts of `installer.py` and `build_environment.py` to allow more multiprocessing to occur. This feature improves the build process's parallelism, speeding up installation times for multi-package builds.

## Changes to Codebase
In the installer, the main while loop, `while self.peek_ready_task() or active_tasks:` continues to execute as long as there are items ready to be installed or `active_tasks`. The inner while loop for this condition, `while len(active_tasks) < self.max_active_tasks:`, ensures that there is space available for starting another process for a task. `max_active_tasks` is assigned the value of `-p/--concurrent-packages`. If the inner while loop's condition is met, the lowest priority task gets popped off of the queue and a child process is started. 

After breaking out of the inner-while loop, all of the active tasks are polled, checking that the child process has received information from the read pipe: `ready = [task for task in active_tasks if task.poll()]`. Once this occurs, the installation of the task is completed and the task gets removed from the `active_tasks` list, opening up space for another task to begin running.

* `installer.py`: BuildTask's `execute()` method has been split up into three new methods: `start()`, `poll()`, and `complete()`. 

* `build_environment.py`: The addition of `class BuildProcess`, which manages and monitors the state of a child process for a task used for building/installing a given package. 

## Usage

This PR adds the command line argument `-p/--nprocs` to `spack install <package>`, which allows users to specify the maximum number of packages that can be built concurrently when installing a given package. If `-p/--nprocs` is not specified, the default value is 4, meaning up to four packages could be built concurrently. 

## To-Do
- [x] Performance testing to decide what value to assign as the default for `-p/--concurrent-packages`.
- [x] Create and run unit-tests to exercise different build scenarios with new implementations.
- [x] Refactor code that handles binary installation, currently commented out. 
- [x] Make `-p/--nprocs` a config option.