### PR TITLE
Fix implicit dependency on distutils which breaks on recent python.

### DIFF
--- a/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
@@ -21,4 +21,6 @@ class PyEasybuildFramework(PythonPackage):
     version("4.0.0", sha256="f5c40345cc8b9b5750f53263ade6c9c3a8cd3dfab488d58f76ac61a8ca7c5a77")
 
     depends_on("python@3.5:", type=("build", "run"))
+    # NOTE: @:4.7.0 and older have a dependency on distutils.
+    depends_on("python@:3.11", type="build", when="@:4.7.0")
     depends_on("py-setuptools", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
+++ b/var/spack/repos/builtin/packages/py-easybuild-framework/package.py
@@ -21,6 +21,6 @@ class PyEasybuildFramework(PythonPackage):
     version("4.0.0", sha256="f5c40345cc8b9b5750f53263ade6c9c3a8cd3dfab488d58f76ac61a8ca7c5a77")
 
     depends_on("python@3.5:", type=("build", "run"))
-    # NOTE: @:4.7.0 and older have a dependency on distutils.
-    depends_on("python@:3.11", type="build", when="@:4.7.0")
+    # https://github.com/easybuilders/easybuild-framework/issues/3963
+    depends_on("python@:3.11", type=("build", "run"), when="@:4")
     depends_on("py-setuptools", type=("build", "run"))


### PR DESCRIPTION
```
$ spack install easybuild
 -   easybuild@4.7.0%gcc@13.2.0 build_system=python_pip arch=linux-rhel8-zen3
[+]      ^gcc-runtime@13.2.0%gcc@13.2.0 build_system=generic arch=linux-rhel8-zen3
[e]      ^glibc@2.28%gcc@13.2.0 build_system=autotools arch=linux-rhel8-zen3
 -       ^py-easybuild-easyblocks@4.7.0%gcc@13.2.0 build_system=python_pip arch=linux-rhel8-zen3
 -       ^py-easybuild-easyconfigs@4.7.0%gcc@13.2.0 build_system=python_pip arch=linux-rhel8-zen3
 -       ^py-easybuild-framework@4.7.0%gcc@13.2.0 build_system=python_pip arch=linux-rhel8-zen3
 -       ^py-pip@23.1.2%gcc@13.2.0 build_system=generic arch=linux-rhel8-zen3
 -       ^py-setuptools@69.2.0%gcc@13.2.0 build_system=generic arch=linux-rhel8-zen3
 -       ^py-wheel@0.41.2%gcc@13.2.0 build_system=generic arch=linux-rhel8-zen3
 -       ^python@3.13.0%gcc@13.2.0+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic arch=linux-rhel8-zen3
 - ...
```
will break.

@adamjstewart proposed the following fix: `depends_on("python@:3.11", type="build")`
@spackbot fix style