### PR TITLE
rocm-dbgapi: add pciutils dependency

### DIFF
--- a/var/spack/repos/builtin/packages/rocm-dbgapi/package.py
+++ b/var/spack/repos/builtin/packages/rocm-dbgapi/package.py
@@ -19,7 +19,7 @@ class RocmDbgapi(CMakePackage):
     url = "https://github.com/ROCm/ROCdbgapi/archive/rocm-6.1.2.tar.gz"
     tags = ["rocm"]
 
-    maintainers("srekolam", "renjithravindrankannath")
+    maintainers("srekolam", "renjithravindrankannath", "afzpatel")
     libraries = ["librocm-dbgapi"]
 
     license("MIT")

--- a/var/spack/repos/builtin/packages/rocm-dbgapi/package.py
+++ b/var/spack/repos/builtin/packages/rocm-dbgapi/package.py
@@ -53,6 +53,7 @@ class RocmDbgapi(CMakePackage):
     depends_on("cxx", type="build")  # generated
     depends_on("cmake@3:", type="build")
     depends_on("hwdata", when="@5.5.0:")
+    depends_on("pciutils", when="@5.5.0:")
 
     for ver in [
         "5.3.0",
@@ -123,4 +124,6 @@ class RocmDbgapi(CMakePackage):
         args = []
         if self.spec.satisfies("@5.3.0:"):
             args.append(self.define("CMAKE_INSTALL_LIBDIR", "lib"))
+        if self.spec.satisfies("@5.5.0:"):
+            args.append(self.define("PCI_IDS_PATH", self.spec["pciutils"].prefix.share))
         return args


### PR DESCRIPTION
This error is seen on rhel 9 when building rocm-dbgapi:
```
CMake Error at CMakeLists.txt:126 (message):
  Cannot found the pci.ids file.  Use PCI_IDS_PATH to specify known path.
```
This pr adds the pciutils dependency and sets PCI_IDS_PATH
