### PR TITLE
pixman: add missing MesonPackage

### DIFF
--- a/var/spack/repos/builtin/packages/pixman/package.py
+++ b/var/spack/repos/builtin/packages/pixman/package.py
@@ -8,7 +8,7 @@ import sys
 from spack.package import *
 
 
-class Pixman(AutotoolsPackage):
+class Pixman(AutotoolsPackage, MesonPackage):
     """The Pixman package contains a library that provides low-level
     pixel manipulation features such as image compositing and
     trapezoid rasterization."""


### PR DESCRIPTION
This PR fixes up #47529 which forgot to add `MesonPackage`.