### PR TITLE
Add prompt support for fish.

### DIFF
--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -64,9 +64,10 @@ def deactivate_header(shell):
     elif shell == "fish":
         cmds += "set -e SPACK_ENV;\n"
         cmds += "set -e SPACK_ENV_VIEW;\n"
+        cmds += "set -e SPACK_PROMPT;\n"
         cmds += "functions -e despacktivate;\n"
         #
-        # NOTE: Not changing fish_prompt (above) => no need to restore it here.
+        # NOTE: Unsetting SPACK_PROMPT environment variable which is used to avoid changing fish_prompt function.
         #
     elif shell == "bat":
         # TODO: Color

--- a/lib/spack/spack/prompt.py
+++ b/lib/spack/spack/prompt.py
@@ -42,7 +42,8 @@ def custom_prompt(prompt, shell):
         cmds += 'set prompt="%s ${prompt}";\n' % prompt
     elif shell == "fish":
         if "color" in os.getenv("TERM", ""):
-            prompt = colorize(f"@G{prompt} " % prompt, color=True)
+            prompt = colorize(f"@G{prompt}", color=True)
+        cmds += "set -gx SPACK_PROMPT '%s';\n" % prompt
     elif shell == "bat" or shell == "pwsh":
         # TODO
         pass


### PR DESCRIPTION
To avoid changing the fish_prompt function, create a SPACK_PROMPT environment variable, which users can then manually incorporate into their fish_prompt.fish function.
