### PR TITLE
Testing-related refactor: clean up build-time test re-use and do_test

### DIFF
--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -21,7 +21,7 @@ from contextlib import contextmanager
 from multiprocessing.connection import Connection
 from threading import Thread
 from types import ModuleType
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 import llnl.util.tty as tty
 
@@ -1028,3 +1028,22 @@ def _retry(function):
 
 def _input_available(f):
     return f in select.select([f], [], [], 0)[0]
+
+
+LogType = Union[nixlog, winlog]
+
+
+def print_message(logger: LogType, msg: str, verbose: bool = False):
+    """Print the message to the log, optionally echoing.
+
+    Args:
+        logger: instance of the output logger (e.g. nixlog or winlog)
+        msg: message being output
+        verbose: ``True`` displays verbose output, ``False`` suppresses
+            it (``False`` is default)
+    """
+    if verbose:
+        with logger.force_echo():
+            tty.info(msg, format="g")
+    else:
+        tty.info(msg, format="g")

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -53,7 +53,6 @@ from urllib.request import urlopen
 import llnl.util.lang
 from llnl.string import plural
 
-import spack.builder
 import spack.config
 import spack.fetch_strategy
 import spack.patch
@@ -715,6 +714,8 @@ def _ensure_all_packages_use_sha256_checksums(pkgs, error_cls):
 @package_properties
 def _ensure_env_methods_are_ported_to_builders(pkgs, error_cls):
     """Ensure that methods modifying the build environment are ported to builder classes."""
+    import spack.builder
+
     errors = []
     for pkg_name in pkgs:
         pkg_cls = spack.repo.PATH.get_pkg_class(pkg_name)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -78,7 +78,6 @@ import spack.util.libc
 from spack import traverse
 from spack.context import Context
 from spack.error import InstallError, NoHeadersError, NoLibrariesError
-from spack.install_test import spack_install_test_log
 from spack.util.environment import (
     SYSTEM_DIR_CASE_ENTRY,
     EnvironmentModifications,
@@ -130,6 +129,9 @@ else:
     dso_suffix = "so"
 
 stat_suffix = "lib" if sys.platform == "win32" else "a"
+
+#: Name of the install phase-time test log file
+install_test_log = "install-time-test-log.txt"
 
 
 def jobserver_enabled():
@@ -1524,7 +1526,7 @@ class ChildError(InstallError):
 
         # Also output the test log path IF it exists
         if self.context != "test" and have_log:
-            test_log = join_path(os.path.dirname(self.log_name), spack_install_test_log)
+            test_log = join_path(os.path.dirname(self.log_name), install_test_log)
             if os.path.isfile(test_log):
                 out.write("\nSee test log for details:\n")
                 out.write("  {0}\n".format(test_log))

--- a/lib/spack/spack/build_systems/_checks.py
+++ b/lib/spack/spack/build_systems/_checks.py
@@ -112,7 +112,7 @@ def execute_build_time_tests(builder: spack.builder.Builder):
     if not builder.pkg.run_tests or not builder.build_time_test_callbacks:
         return
 
-    builder.pkg.tester.phase_tests(builder, "build", builder.build_time_test_callbacks)
+    builder.phase_tests("build", builder.build_time_test_callbacks)
 
 
 def execute_install_time_tests(builder: spack.builder.Builder):
@@ -125,7 +125,7 @@ def execute_install_time_tests(builder: spack.builder.Builder):
     if not builder.pkg.run_tests or not builder.install_time_test_callbacks:
         return
 
-    builder.pkg.tester.phase_tests(builder, "install", builder.install_time_test_callbacks)
+    builder.phase_tests("install", builder.install_time_test_callbacks)
 
 
 class BuilderWithDefaults(spack.builder.Builder):

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -8,6 +8,10 @@ import copy
 import functools
 from typing import Dict, List, Optional, Tuple, Type
 
+import llnl.util.tty as tty
+import llnl.util.tty.log as log
+
+import spack.config
 import spack.error
 import spack.multimethod
 import spack.package_base
@@ -481,7 +485,7 @@ class BaseBuilder(metaclass=BuilderMeta):
 
 class Builder(BaseBuilder, collections.abc.Sequence):
     """A builder is a class that, given a package object (i.e. associated with concrete spec),
-    knows how to install it.
+    knows how to install it and perform install-time checks.
 
     The builder behaves like a sequence, and when iterated over return the "phases" of the
     installation in the correct order.
@@ -518,3 +522,54 @@ class Builder(BaseBuilder, collections.abc.Sequence):
 
     def __len__(self):
         return len(self.phases)
+
+    def phase_tests(self, phase_name: str, method_names: List[str]):
+        """Execute the package's phase-time tests.
+
+        This process uses the same test setup and logging used for
+        stand-alone tests for consistency.
+
+        Args:
+            phase_name: the name of the build-time phase (e.g., ``build``, ``install``)
+            method_names: phase-specific callback method names
+        """
+        verbose = tty.is_verbose()
+        fail_fast = spack.config.get("config:fail_fast", False)
+
+        tester = self.pkg.tester
+        testsuite = self.pkg.test_suite
+        with tester.test_logger(verbose=verbose, externals=False) as logger:
+            # Report running each of the methods in the build log
+            log.print_message(logger, f"Running {phase_name}-time tests", verbose)
+            testsuite.current_test_spec = self.pkg.spec
+            testsuite.current_base_spec = self.pkg.spec
+
+            have_tests = any(name.startswith("test_") for name in method_names)
+            if have_tests:
+                spack.install_test.copy_test_files(self.pkg, self.pkg.spec)
+
+            for name in method_names:
+                try:
+                    # Prefer the method in the package over the builder's.
+                    # We need this primarily to pick up arbitrarily named test
+                    # methods but also some build-time checks.
+                    fn = getattr(self.pkg, name, getattr(self, name))
+
+                    msg = f"RUN-TESTS: {phase_name}-time tests [{name}]"
+                    log.print_message(logger, msg, verbose)
+
+                    fn()
+
+                except AttributeError as e:
+                    msg = f"RUN-TESTS: method not implemented [{name}]"
+                    log.print_message(logger, msg, verbose)
+
+                    tester.add_failure(e, msg)
+                    if fail_fast:
+                        break
+
+            if have_tests:
+                log.print_message(logger, "Completed testing", verbose)
+
+            # Raise exception if any failures encountered
+            tester.handle_failures()

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -13,6 +13,7 @@ import llnl.util.tty.log as log
 
 import spack.config
 import spack.error
+import spack.install_test
 import spack.multimethod
 import spack.package_base
 import spack.phase_callbacks

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -52,7 +52,6 @@ import spack.util.git
 import spack.util.url as url_util
 import spack.util.web as web_util
 import spack.version
-import spack.version.git_ref_lookup
 from spack.util.compression import decompressor_for
 from spack.util.executable import CommandNotFoundError, Executable, which
 
@@ -1574,6 +1573,7 @@ def _from_merged_attrs(fetcher, pkg, version):
 def for_package_version(pkg, version=None):
     """Determine a fetch strategy based on the arguments supplied to
     version() in the package description."""
+    import spack.version.git_ref_lookup
 
     # No-code packages have a custom fetch strategy to work around issues
     # with resource staging.

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -335,57 +335,14 @@ class PackageTest:
         self.test_parts[part_name] = status
         self.counts[status] += 1
 
-    def phase_tests(self, builder, phase_name: str, method_names: List[str]):
-        """Execute the builder's package phase-time tests.
+    def handle_failures(self):
+        """Raise exception if any failures were collected during testing
 
-        Args:
-            builder: builder for package being tested
-            phase_name: the name of the build-time phase (e.g., ``build``, ``install``)
-            method_names: phase-specific callback method names
+        Raises:
+            TestFailure: test failures were collected
         """
-        verbose = tty.is_verbose()
-        fail_fast = spack.config.get("config:fail_fast", False)
-
-        with self.test_logger(verbose=verbose, externals=False) as logger:
-            # Report running each of the methods in the build log
-            log.print_message(logger, f"Running {phase_name}-time tests", verbose)
-            builder.pkg.test_suite.current_test_spec = builder.pkg.spec
-            builder.pkg.test_suite.current_base_spec = builder.pkg.spec
-
-            have_tests = any(name.startswith("test_") for name in method_names)
-            if have_tests:
-                copy_test_files(builder.pkg, builder.pkg.spec)
-
-            for name in method_names:
-                try:
-                    # Prefer the method in the package over the builder's.
-                    # We need this primarily to pick up arbitrarily named test
-                    # methods but also some build-time checks.
-                    fn = getattr(builder.pkg, name, getattr(builder, name))
-
-                    msg = f"RUN-TESTS: {phase_name}-time tests [{name}]"
-                    log.print_message(logger, msg, verbose)
-
-                    fn()
-
-                except AttributeError as e:
-                    msg = f"RUN-TESTS: method not implemented [{name}]"
-                    log.print_message(logger, msg, verbose)
-
-                    self.add_failure(e, msg)
-                    if fail_fast:
-                        break
-                    continue
-
-                print_message(logger, f"RUN-TESTS: {phase_name}-time tests [{name}]", verbose)
-                fn()
-
-            if have_tests:
-                log.print_message(logger, "Completed testing", verbose)
-
-            # Raise any collected failures here
-            if self.test_failures:
-                raise TestFailure(self.test_failures)
+        if self.test_failures:
+            raise TestFailure(self.test_failures)
 
     def stand_alone_tests(self, kwargs):
         """Run the package's stand-alone tests.
@@ -687,10 +644,9 @@ def process_test_parts(pkg: Pb, test_specs: List[spack.spec.Spec], verbose: bool
                 ):
                     test_fn(pkg)
 
-        # If fail-fast was on, we error out above
-        # If we collect errors, raise them in batch here
-        if tester.test_failures:
-            raise TestFailure(tester.test_failures)
+        # If fail-fast was on, we errored out above
+        # If we collected errors, raise them in batch here
+        tester.handle_failures()
 
     finally:
         if tester.ran_tests():

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -17,7 +17,7 @@ from typing import Callable, List, Optional, Tuple, Type, TypeVar, Union
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
-import llnl.util.tty.log
+import llnl.util.tty.log as log
 from llnl.string import plural
 from llnl.util.lang import nullcontext
 from llnl.util.tty.color import colorize
@@ -50,7 +50,6 @@ spack_install_test_log = "install-time-test-log.txt"
 
 
 ListOrStringType = Union[str, List[str]]
-LogType = Union[llnl.util.tty.log.nixlog, llnl.util.tty.log.winlog]
 
 Pb = TypeVar("Pb", bound="spack.package_base.PackageBase")
 PackageObjectOrClass = Union[Pb, Type[Pb]]
@@ -207,22 +206,6 @@ def install_test_root(pkg: Pb):
     return os.path.join(pkg.metadata_dir, "test")
 
 
-def print_message(logger: LogType, msg: str, verbose: bool = False):
-    """Print the message to the log, optionally echoing.
-
-    Args:
-        logger: instance of the output logger (e.g. nixlog or winlog)
-        msg: message being output
-        verbose: ``True`` displays verbose output, ``False`` suppresses
-            it (``False`` is default)
-    """
-    if verbose:
-        with logger.force_echo():
-            tty.info(msg, format="g")
-    else:
-        tty.info(msg, format="g")
-
-
 def overall_status(current_status: "TestStatus", substatuses: List["TestStatus"]) -> "TestStatus":
     """Determine the overall status based on the current and associated sub status values.
 
@@ -285,10 +268,10 @@ class PackageTest:
         self._logger = None
 
     @property
-    def logger(self) -> Optional[LogType]:
+    def logger(self) -> Optional[log.LogType]:
         """The current logger or, if none, sets to one."""
         if not self._logger:
-            self._logger = llnl.util.tty.log.log_output(self.test_log_file)
+            self._logger = log.log_output(self.test_log_file)
 
         return self._logger
 
@@ -305,7 +288,7 @@ class PackageTest:
         fs.touch(self.test_log_file)  # Otherwise log_parse complains
         fs.set_install_permissions(self.test_log_file)
 
-        with llnl.util.tty.log.log_output(self.test_log_file, verbose) as self._logger:
+        with log.log_output(self.test_log_file, verbose) as self._logger:
             with self.logger.force_echo():  # type: ignore[union-attr]
                 tty.msg("Testing package " + colorize(r"@*g{" + self.pkg_id + r"}"))
 
@@ -365,7 +348,7 @@ class PackageTest:
 
         with self.test_logger(verbose=verbose, externals=False) as logger:
             # Report running each of the methods in the build log
-            print_message(logger, f"Running {phase_name}-time tests", verbose)
+            log.print_message(logger, f"Running {phase_name}-time tests", verbose)
             builder.pkg.test_suite.current_test_spec = builder.pkg.spec
             builder.pkg.test_suite.current_base_spec = builder.pkg.spec
 
@@ -375,10 +358,21 @@ class PackageTest:
 
             for name in method_names:
                 try:
-                    fn = getattr(builder, name, None) or getattr(builder.pkg, name)
+                    # Prefer the method in the package over the builder's.
+                    # We need this primarily to pick up arbitrarily named test
+                    # methods but also some build-time checks.
+                    fn = getattr(builder.pkg, name, getattr(builder, name))
+
+                    msg = f"RUN-TESTS: {phase_name}-time tests [{name}]"
+                    log.print_message(logger, msg, verbose)
+
+                    fn()
+
                 except AttributeError as e:
-                    print_message(logger, f"RUN-TESTS: method not implemented [{name}]", verbose)
-                    self.add_failure(e, f"RUN-TESTS: method not implemented [{name}]")
+                    msg = f"RUN-TESTS: method not implemented [{name}]"
+                    log.print_message(logger, msg, verbose)
+
+                    self.add_failure(e, msg)
                     if fail_fast:
                         break
                     continue
@@ -387,7 +381,7 @@ class PackageTest:
                 fn()
 
             if have_tests:
-                print_message(logger, "Completed testing", verbose)
+                log.print_message(logger, "Completed testing", verbose)
 
             # Raise any collected failures here
             if self.test_failures:
@@ -722,12 +716,12 @@ def test_process(pkg: Pb, kwargs):
 
     with pkg.tester.test_logger(verbose, externals) as logger:
         if pkg.spec.external and not externals:
-            print_message(logger, "Skipped tests for external package", verbose)
+            log.print_message(logger, "Skipped tests for external package", verbose)
             pkg.tester.status(pkg.spec.name, TestStatus.SKIPPED)
             return
 
         if not pkg.spec.installed:
-            print_message(logger, "Skipped not installed package", verbose)
+            log.print_message(logger, "Skipped not installed package", verbose)
             pkg.tester.status(pkg.spec.name, TestStatus.SKIPPED)
             return
 
@@ -876,6 +870,9 @@ class TestSuite:
             self._hash = b32_hash
         return self._hash
 
+    def _run_test(self, pkg, dirty, externals):
+        pkg.do_test(dirty=dirty, externals=externals)
+
     def __call__(self, *args, **kwargs):
         self.write_reproducibility_data()
 
@@ -905,7 +902,8 @@ class TestSuite:
                 fs.mkdirp(test_dir)
 
                 # run the package tests
-                spec.package.do_test(dirty=dirty, externals=externals)
+                # TLD spec.package.do_test(dirty=dirty, externals=externals)
+                self._run_test(spec.package, dirty=dirty, externals=externals)
 
                 # Clean up on success
                 if remove_directory:

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -46,9 +46,6 @@ test_suite_filename = "test_suite.lock"
 #: Name of the test suite results (summary) file
 results_filename = "results.txt"
 
-#: Name of the Spack install phase-time test log file
-spack_install_test_log = "install-time-test-log.txt"
-
 
 ListOrStringType = Union[str, List[str]]
 
@@ -263,7 +260,9 @@ class PackageTest:
             # Running phase-time tests for a single package whose results are
             # retained in the package's stage directory.
             self.pkg.test_suite = TestSuite([pkg.spec])
-            self.test_log_file = fs.join_path(pkg.stage.path, spack_install_test_log)
+            self.test_log_file = fs.join_path(
+                pkg.stage.path, spack.build_environment.install_test_log
+            )
             self.pkg_id = pkg.spec.format("{name}-{version}-{hash:7}")
 
         # Internal logger for test part processing
@@ -306,7 +305,7 @@ class PackageTest:
 
     @property
     def archived_install_test_log(self) -> str:
-        return fs.join_path(self.pkg.metadata_dir, spack_install_test_log)
+        return fs.join_path(self.pkg.metadata_dir, spack.build_environment.install_test_log)
 
     def archive_install_test_log(self, dest_dir: str):
         if os.path.exists(self.test_log_file):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1947,29 +1947,6 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         resource_stage_folder = "-".join(pieces)
         return resource_stage_folder
 
-    def do_test(self, dirty=False, externals=False):
-        if self.test_requires_compiler:
-            compilers = spack.compilers.compilers_for_spec(
-                self.spec.compiler, arch_spec=self.spec.architecture
-            )
-            if not compilers:
-                tty.error(
-                    "Skipping tests for package %s\n"
-                    % self.spec.format("{name}-{version}-{hash:7}")
-                    + "Package test requires missing compiler %s" % self.spec.compiler
-                )
-                return
-
-        kwargs = {
-            "dirty": dirty,
-            "fake": False,
-            "context": "test",
-            "externals": externals,
-            "verbose": tty.is_verbose(),
-        }
-
-        self.tester.stand_alone_tests(kwargs)
-
     def unit_test_check(self):
         """Hook for unit tests to assert things about package internals.
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -716,7 +716,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
     #: are available to build a custom test code.
     test_requires_compiler: bool = False
 
-    #: TestSuite instance used to manage stand-alone tests for 1+ specs.
+    #: The spec's TestSuite instance, which is used to manage its testing.
     test_suite: Optional[Any] = None
 
     def __init__(self, spec):

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -204,7 +204,7 @@ class BuildInfoCollector(InfoCollector):
 
 
 class TestInfoCollector(InfoCollector):
-    """Collect information for the PackageBase.do_test method.
+    """Collect information for the PackageTest.stand_alone_tests method.
 
     Args:
         specs: specs whose install information will be recorded
@@ -214,7 +214,7 @@ class TestInfoCollector(InfoCollector):
     dir: str
 
     def __init__(self, specs: List[spack.spec.Spec], record_directory: str):
-        super().__init__(spack.package_base.PackageBase, "do_test", specs)
+        super().__init__(spack.install_test.PackageTest, "stand_alone_tests", specs)
         self.dir = record_directory
 
     def on_success(self, pkg, kwargs, package_record):
@@ -233,7 +233,7 @@ class TestInfoCollector(InfoCollector):
             return f"Cannot open log for {pkg.spec.cshort_spec}"
 
     def extract_package_from_signature(self, instance, *args, **kwargs):
-        return instance
+        return instance.pkg
 
 
 @contextlib.contextmanager

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -17,7 +17,6 @@ import pytest
 
 import llnl.util.filesystem as fs
 
-import spack.compilers
 import spack.deptypes as dt
 import spack.error
 import spack.install_test
@@ -263,7 +262,7 @@ def test_package_tester_fails():
     s = spack.spec.Spec("pkg-a")
     pkg = BaseTestPackage(s)
     with pytest.raises(ValueError, match="without concrete version"):
-        pkg.tester()
+        pkg.tester
 
 
 def test_package_fetcher_fails():
@@ -271,18 +270,3 @@ def test_package_fetcher_fails():
     pkg = BaseTestPackage(s)
     with pytest.raises(ValueError, match="without concrete version"):
         pkg.fetcher
-
-
-def test_package_test_no_compilers(mock_packages, monkeypatch, capfd):
-    def compilers(compiler, arch_spec):
-        return None
-
-    monkeypatch.setattr(spack.compilers, "compilers_for_spec", compilers)
-
-    s = spack.spec.Spec("pkg-a")
-    pkg = BaseTestPackage(s)
-    pkg.test_requires_compiler = True
-    pkg.do_test()
-    error = capfd.readouterr()[1]
-    assert "Skipping tests for package" in error
-    assert "test requires missing compiler" in error

--- a/lib/spack/spack/version/git_ref_lookup.py
+++ b/lib/spack/spack/version/git_ref_lookup.py
@@ -11,7 +11,6 @@ from typing import Dict, Optional, Tuple
 from llnl.util.filesystem import mkdirp, working_dir
 
 import spack.caches
-import spack.fetch_strategy
 import spack.paths
 import spack.repo
 import spack.util.executable
@@ -86,6 +85,8 @@ class GitRefLookup(AbstractRefLookup):
 
     @property
     def fetcher(self):
+        import spack.fetch_strategy
+
         if not self._fetcher:
             # We require the full git repository history
             fetcher = spack.fetch_strategy.GitFetchStrategy(git=self.pkg.git)


### PR DESCRIPTION
Depends on #47956 🤞 

This PR is meant to "untangle" some of the imports related to re-use of stand-alone testing and reporting mechanisms in post-install (`spack install --test`) processes.