### PR TITLE
docs: expand on `url_for_version`

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -782,7 +782,7 @@ in ``url_for_version()``. This behaviour is summarized in the table below:
 
 =================================== ===================== ==========================
  Command                              URL Source             Version Discovery       
-=================================== ===================== =========================
+=================================== ===================== ==========================
  ``spack checksum <package>``       ``url`` field only    | Crawls for all versions
  ``spack checksum <package>@3.12``  ``url`` field only    | Crawls for matching 
                                                                versions               

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -780,17 +780,15 @@ from the URL extrapolated from ``url`` and ``url_for_version`` package attribute
 to reflect the new naming scheme, allowing previously discovered package versions to be downloaded via the old url pattern given 
 in ``url_for_version()``. This behaviour is summarized in the table below:
 
-+----------------------------------+----------------------+-------------------------+
-| Command                          | URL Source          | Version Discovery       |
-+==================================+======================+=========================+
-| ``spack checksum <package>``     | ``url`` field only  | Crawls for all versions|
-+----------------------------------+----------------------+-------------------------+
-| ``spack checksum <package>@3.12``| ``url`` field only  | Crawls for matching    |
-|                                  |                      | versions               |
-+----------------------------------+----------------------+-------------------------+
-| ``spack checksum <package>       | Both ``url`` and    | Direct version fetch   |
-| 3.12.0 3.12.1``                 | ``url_for_version`` |                        |
-+----------------------------------+----------------------+-------------------------+
+=================================== ===================== ==========================
+ Command                              URL Source             Version Discovery       
+=================================== ===================== =========================
+ ``spack checksum <package>``       ``url`` field only    | Crawls for all versions
+ ``spack checksum <package>@3.12``  ``url`` field only    | Crawls for matching 
+                                                               versions               
+ ``spack checksum <package>         Both ``url`` and      | Direct version fetch   
+ 3.12.0 3.12.1``                    ``url_for_version``                         
+=================================== ===================== ==========================
 
 
 """""""""""""""""""""""

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -679,7 +679,14 @@ http://example.com/foo-8.2.1.tar.gz.
 
 If the URL is particularly complicated or changes based on the release,
 you can override the default URL generation algorithm by defining your
-own ``url_for_version()`` function. For example, the download URL for
+own ``url_for_version()`` function. 
+
+.. warning:
+
+   ``spack versions`` and ``spack checksum`` do not use the custom ``url_for_version()``.
+   See the end of this section for a further description.
+
+For example, the download URL for
 OpenMPI contains the major.minor version in one spot and the
 major.minor.patch version in another:
 
@@ -763,6 +770,12 @@ specify their own ``url``. Spack will use the nearest URL *before* the requested
 version. This is useful for packages that have an easy to extrapolate URL, but
 keep changing their URL format every few releases. With this method, you only
 need to specify the ``url`` when the URL changes.
+
+It is important to note that ``spack versions`` and ``spack checksum`` do not use the custom ``url_for_version()``
+for discovering new versions. These two commands use only the base ``url`` or ``pypi`` fields. Thus,
+these fields should always be updated to reflect the new naming scheme, allowing previously discovered package versions
+to be downloaded via the old url pattern given in ``url_for_version()``. ``spack checksum`` can be used in a non-autodiscovery
+mode which does use ``url_for_version()``. This usage is via ``spack checksum zlib 1.2.13``.
 
 """""""""""""""""""""""
 Mirrors of the main URL

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -771,11 +771,14 @@ version. This is useful for packages that have an easy to extrapolate URL, but
 keep changing their URL format every few releases. With this method, you only
 need to specify the ``url`` when the URL changes.
 
-It is important to note that ``spack versions`` and ``spack checksum`` do not use the custom ``url_for_version()``
-for discovering new versions. These two commands use only the base ``url`` or ``pypi`` fields. Thus,
-these fields should always be updated to reflect the new naming scheme, allowing previously discovered package versions
-to be downloaded via the old url pattern given in ``url_for_version()``. ``spack checksum`` can be used in a non-autodiscovery
-mode which does use ``url_for_version()``. This usage is via ``spack checksum zlib 1.2.13``.
+It is important to note that ``spack versions`` and ``spack checksum`` do not use a custom ``url_for_version()``
+for discovering new versions of a package. These two commands only use the base ``url`` field. Thus,
+this field should always be updated to reflect the new naming scheme, allowing previously discovered package versions
+to be downloaded via the old url pattern given in ``url_for_version()``. However, ``spack checksum`` can be used in a 
+non-autodiscovery mode which does use ``url_for_version()``. 
+This usage is via ``spack checksum <package> <version>``, e.g., ``spack checksum zlib 1.2.13``. This differs 
+from the autodiscovery mode ``spack checksum <package>@<version>``, e.g., ``spack checksum zlib@1.2``, which does not use 
+``url_for_version()``.
 
 """""""""""""""""""""""
 Mirrors of the main URL

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -681,9 +681,9 @@ If the URL is particularly complicated or changes based on the release,
 you can override the default URL generation algorithm by defining your
 own ``url_for_version()`` function. 
 
-.. warning:
+.. note:
 
-   ``spack versions`` and ``spack checksum`` do not use the custom ``url_for_version()``.
+   ``spack versions`` and ``spack checksum`` have nuance in how they use a custom ``url_for_version()``.
    See the end of this section for a further description.
 
 For example, the download URL for
@@ -771,14 +771,27 @@ version. This is useful for packages that have an easy to extrapolate URL, but
 keep changing their URL format every few releases. With this method, you only
 need to specify the ``url`` when the URL changes.
 
-It is important to note that ``spack versions`` and ``spack checksum`` do not use a custom ``url_for_version()``
-for discovering new versions of a package. These two commands only use the base ``url`` field. Thus,
-this field should always be updated to reflect the new naming scheme, allowing previously discovered package versions
-to be downloaded via the old url pattern given in ``url_for_version()``. However, ``spack checksum`` can be used in a 
-non-autodiscovery mode which does use ``url_for_version()``. 
-This usage is via ``spack checksum <package> <version>``, e.g., ``spack checksum zlib 1.2.13``. This differs 
-from the autodiscovery mode ``spack checksum <package>@<version>``, e.g., ``spack checksum zlib@1.2``, which does not use 
-``url_for_version()``.
+Lastly, ``spack versions`` and ``spack checksum`` have nuance in how a custom ``url_for_version()``
+is used for discovering new versions of a package. When running ``spack checksum <package>`` or ``spack checksum <package>@3.12``,
+spack crawls web pages discovering new versions matching 3.12 (e.g., 3.12.0, 3.12.1, ...). Small changes to the filename or url are 
+automatically detected, but larger changes such as ``_`` to ``-`` are not. When used in this way, only the ``url`` field is used 
+to determine the url pattern. When run as ``spack checksum python 3.12.0 3.12.1``, spack directly fetches these specific versions
+from the URL extrapolated from ``url`` and ``url_for_version`` package attributes. Thus, the ``url`` field should always be updated
+to reflect the new naming scheme, allowing previously discovered package versions to be downloaded via the old url pattern given 
+in ``url_for_version()``. This behaviour is summarized in the table below:
+
++----------------------------------+----------------------+-------------------------+
+| Command                          | URL Source          | Version Discovery       |
++==================================+======================+=========================+
+| ``spack checksum <package>``     | ``url`` field only  | Crawls for all versions|
++----------------------------------+----------------------+-------------------------+
+| ``spack checksum <package>@3.12``| ``url`` field only  | Crawls for matching    |
+|                                  |                      | versions               |
++----------------------------------+----------------------+-------------------------+
+| ``spack checksum <package>       | Both ``url`` and    | Direct version fetch   |
+| 3.12.0 3.12.1``                 | ``url_for_version`` |                        |
++----------------------------------+----------------------+-------------------------+
+
 
 """""""""""""""""""""""
 Mirrors of the main URL

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -780,15 +780,15 @@ from the URL extrapolated from ``url`` and ``url_for_version`` package attribute
 to reflect the new naming scheme, allowing previously discovered package versions to be downloaded via the old url pattern given 
 in ``url_for_version()``. This behaviour is summarized in the table below:
 
-=================================== ===================== ==========================
- Command                              URL Source             Version Discovery       
-=================================== ===================== ==========================
- ``spack checksum <package>``       ``url`` field only    | Crawls for all versions
- ``spack checksum <package>@3.12``  ``url`` field only    | Crawls for matching 
-                                                               versions               
- ``spack checksum <package>         Both ``url`` and      | Direct version fetch   
- 3.12.0 3.12.1``                    ``url_for_version``                         
-=================================== ===================== ==========================
+============================================== ===================== ==========================
+ Command                                           URL Source             Version Discovery       
+============================================== ===================== ==========================
+ ``spack checksum <package>``                    ``url`` field only   Crawls for all versions
+ ``spack checksum <package>@3.12``               ``url`` field only   Crawls for matching 
+                                                                           versions               
+ ``spack checksum <package>  3.12.0 3.12.1``    Both ``url`` and      Direct version fetch   
+                                                ``url_for_version``                         
+============================================== ===================== ==========================
 
 
 """""""""""""""""""""""


### PR DESCRIPTION
Clearly note that `url_for_version` is not used when running `spack checksum` or `spack versions`.

The goal is to call attention to it early in the doc section for someone skimming the usage and then expand upon it at the end of the section.

@haampie @adamjstewart this is per our slack discussion 
