### PR TITLE
spack.package / builtin repo: fix exports/imports

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -11,7 +11,7 @@ Everything in this module is automatically imported into Spack package files.
 from os import chdir, environ, getcwd, makedirs, mkdir, remove, removedirs
 from shutil import move, rmtree
 
-from spack.error import InstallError
+from spack.error import InstallError, NoHeadersError, NoLibrariesError
 
 # Emulate some shell commands for convenience
 env = environ

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -12,7 +12,7 @@ from pathlib import Path, PurePath
 import llnl.util.tty as tty
 
 import spack.error
-from spack.util.environment import EnvironmentModifications
+import spack.util.environment
 
 __all__ = ["Executable", "which", "ProcessError"]
 
@@ -29,7 +29,7 @@ class Executable:
 
         self.default_env = {}
 
-        self.default_envmod = EnvironmentModifications()
+        self.default_envmod = spack.util.environment.EnvironmentModifications()
         self.returncode = None
         self.ignore_quotes = False
 
@@ -168,17 +168,15 @@ class Executable:
         self.default_envmod.apply_modifications(env)
         env.update(self.default_env)
 
-        from spack.util.environment import EnvironmentModifications  # no cycle
-
         # Apply env argument
-        if isinstance(env_arg, EnvironmentModifications):
+        if isinstance(env_arg, spack.util.environment.EnvironmentModifications):
             env_arg.apply_modifications(env)
         elif env_arg:
             env.update(env_arg)
 
         # Apply extra env
         extra_env = kwargs.get("extra_env", {})
-        if isinstance(extra_env, EnvironmentModifications):
+        if isinstance(extra_env, spack.util.environment.EnvironmentModifications):
             extra_env.apply_modifications(env)
         else:
             env.update(extra_env)

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -14,7 +14,7 @@ import llnl.util.tty as tty
 import spack.error
 import spack.util.environment
 
-__all__ = ["Executable", "which", "ProcessError"]
+__all__ = ["Executable", "which", "which_string", "ProcessError"]
 
 
 class Executable:

--- a/var/spack/repos/builtin/packages/acfl/package.py
+++ b/var/spack/repos/builtin/packages/acfl/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 
+import spack.platforms
 from spack.package import *
 
 _os_map_before_23 = {

--- a/var/spack/repos/builtin/packages/aqlprofile/package.py
+++ b/var/spack/repos/builtin/packages/aqlprofile/package.py
@@ -5,6 +5,7 @@
 
 import os
 
+import spack.platforms
 from spack.package import *
 
 _versions = {

--- a/var/spack/repos/builtin/packages/armpl-gcc/package.py
+++ b/var/spack/repos/builtin/packages/armpl-gcc/package.py
@@ -5,6 +5,8 @@
 
 import os
 
+import spack.error
+import spack.platforms
 from spack.package import *
 
 _os_map_before_23 = {

--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -9,7 +9,6 @@ import socket
 from os.path import join as pjoin
 
 from spack.package import *
-from spack.util.executable import which_string
 
 
 def get_spec_path(spec, package_name, path_replacements={}, use_bin=False):

--- a/var/spack/repos/builtin/packages/claw/package.py
+++ b/var/spack/repos/builtin/packages/claw/package.py
@@ -5,6 +5,8 @@
 
 import os
 
+import spack.compilers
+import spack.spec
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/codipack/package.py
+++ b/var/spack/repos/builtin/packages/codipack/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.generic
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/coin3d/package.py
+++ b/var/spack/repos/builtin/packages/coin3d/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.autotools
+import spack.build_systems.cmake
 from spack.package import *
 from spack.pkg.builtin.boost import Boost
 

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -7,7 +7,6 @@ import os
 import os.path
 import sys
 
-import spack.platforms
 import spack.util.environment
 from spack.build_environment import dso_suffix
 from spack.build_systems import cmake, makefile

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -9,7 +9,6 @@ import sys
 
 import spack.platforms
 import spack.util.environment
-import spack.util.executable
 from spack.build_environment import dso_suffix
 from spack.build_systems import cmake, makefile
 from spack.package import *

--- a/var/spack/repos/builtin/packages/cxx/package.py
+++ b/var/spack/repos/builtin/packages/cxx/package.py
@@ -5,6 +5,8 @@
 
 import os
 
+import spack.compilers
+import spack.spec
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/dbus/package.py
+++ b/var/spack/repos/builtin/packages/dbus/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.autotools
+import spack.build_systems.meson
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -302,7 +302,7 @@ class Eccodes(CMakePackage):
             return libs
 
         msg = "Unable to recursively locate {0} {1} libraries in {2}"
-        raise spack.error.NoLibrariesError(
+        raise NoLibrariesError(
             msg.format("shared" if shared else "static", self.spec.name, self.spec.prefix)
         )
 

--- a/var/spack/repos/builtin/packages/elsi/package.py
+++ b/var/spack/repos/builtin/packages/elsi/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os.path
 
-from spack.error import NoHeadersError
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -6,6 +6,9 @@
 import os
 import sys
 
+import spack.build_systems.makefile
+import spack.build_systems.python
+import spack.compiler
 from spack.build_environment import dso_suffix, stat_suffix
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -5,7 +5,6 @@
 
 import os
 
-import spack.util.executable
 from spack.package import *
 
 
@@ -156,7 +155,7 @@ class FluxCore(AutotoolsPackage):
                 git("fetch", "--unshallow")
                 git("config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
                 git("fetch", "origin")
-            except spack.util.executable.ProcessError:
+            except ProcessError:
                 git("fetch")
 
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -5,7 +5,6 @@
 
 import os
 
-import spack.util.executable
 from spack.build_systems.autotools import AutotoolsBuilder
 from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
@@ -139,7 +138,7 @@ class FluxSched(CMakePackage, AutotoolsPackage):
                 git("fetch", "--unshallow")
                 git("config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
                 git("fetch", "origin")
-            except spack.util.executable.ProcessError:
+            except ProcessError:
                 git("fetch")
 
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/flux-security/package.py
+++ b/var/spack/repos/builtin/packages/flux-security/package.py
@@ -5,7 +5,6 @@
 
 import os
 
-import spack.util.executable
 from spack.package import *
 
 
@@ -54,7 +53,7 @@ class FluxSecurity(AutotoolsPackage):
                 git("fetch", "--unshallow")
                 git("config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
                 git("fetch", "origin")
-            except spack.util.executable.ProcessError:
+            except ProcessError:
                 git("fetch")
 
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/fsl/package.py
+++ b/var/spack/repos/builtin/packages/fsl/package.py
@@ -6,6 +6,7 @@
 import glob
 import os
 
+import spack.util.environment
 from spack.package import *
 from spack.util.environment import EnvironmentModifications
 

--- a/var/spack/repos/builtin/packages/gasnet/package.py
+++ b/var/spack/repos/builtin/packages/gasnet/package.py
@@ -145,7 +145,7 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
             try:
                 git = which("git")
                 git("describe", "--long", "--always", output="version.git")
-            except spack.util.executable.ProcessError:
+            except ProcessError:
                 spack.main.send_warning_to_tty("Omitting version stamp due to git error")
 
         # The GASNet-EX library has a highly multi-dimensional configure space,

--- a/var/spack/repos/builtin/packages/gasnet/package.py
+++ b/var/spack/repos/builtin/packages/gasnet/package.py
@@ -5,6 +5,7 @@
 
 import os
 
+import spack.main
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/gaussian-view/package.py
+++ b/var/spack/repos/builtin/packages/gaussian-view/package.py
@@ -8,6 +8,7 @@ import os
 
 import llnl.util.tty as tty
 
+import spack.tengine
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -12,7 +12,6 @@ import llnl.util.tty as tty
 from llnl.util.symlink import readlink
 
 import spack.platforms
-import spack.util.executable
 import spack.util.libc
 from spack.operating_systems.mac_os import macos_sdk_path, macos_version
 from spack.package import *

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -11,6 +11,7 @@ import archspec.cpu
 import llnl.util.tty as tty
 from llnl.util.symlink import readlink
 
+import spack.compiler
 import spack.platforms
 import spack.util.libc
 from spack.operating_systems.mac_os import macos_sdk_path, macos_version

--- a/var/spack/repos/builtin/packages/gem5/package.py
+++ b/var/spack/repos/builtin/packages/gem5/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+import spack.config
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -6,6 +6,7 @@
 import os
 import re
 
+import spack.fetch_strategy
 from spack.package import *
 from spack.util.environment import is_system_path
 

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -5,6 +5,8 @@
 
 import os.path
 
+import spack.build_systems.autotools
+import spack.build_systems.meson
 from spack.package import *
 from spack.util.environment import is_system_path
 

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -7,6 +7,7 @@ import os
 
 import llnl.util.filesystem as fs
 
+import spack.build_systems.cmake
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.autotools
+import spack.build_systems.meson
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -127,7 +127,7 @@ class Hdf(AutotoolsPackage):
 
         if not libs:
             msg = "Unable to recursively locate {0} {1} libraries in {2}"
-            raise spack.error.NoLibrariesError(
+            raise NoLibrariesError(
                 msg.format("shared" if shared else "static", self.spec.name, self.spec.prefix)
             )
 

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -6,6 +6,7 @@
 import os
 import re
 
+import spack.build_environment
 from spack.hooks.sbang import filter_shebang
 from spack.package import *
 from spack.util.prefix import Prefix

--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -5,6 +5,7 @@
 
 import re
 
+import spack.variant
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/hipcub/package.py
+++ b/var/spack/repos/builtin/packages/hipcub/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.variant
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/hipfft/package.py
+++ b/var/spack/repos/builtin/packages/hipfft/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+import spack.variant
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/hiprand/package.py
+++ b/var/spack/repos/builtin/packages/hiprand/package.py
@@ -5,6 +5,7 @@
 
 import re
 
+import spack.variant
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/hipsolver/package.py
+++ b/var/spack/repos/builtin/packages/hipsolver/package.py
@@ -6,6 +6,7 @@
 import os
 import re
 
+import spack.variant
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/hipsparse/package.py
+++ b/var/spack/repos/builtin/packages/hipsparse/package.py
@@ -5,6 +5,7 @@
 
 import re
 
+import spack.variant
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/hipsparselt/package.py
+++ b/var/spack/repos/builtin/packages/hipsparselt/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+import spack.variant
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/hiredis/package.py
+++ b/var/spack/repos/builtin/packages/hiredis/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.cmake
+import spack.build_systems.makefile
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -9,6 +9,8 @@ import tempfile
 
 import llnl.util.tty as tty
 
+import spack.build_systems.autotools
+import spack.build_systems.meson
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -5,6 +5,8 @@
 
 import pathlib
 
+import spack.build_systems.autotools
+import spack.build_systems.msbuild
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -284,7 +284,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         try:
             if self.spec.satisfies("+cluster ^mpi"):
                 resolved_libs = resolved_libs + self.spec["mpi"].libs
-        except spack.error.NoLibrariesError:
+        except NoLibrariesError:
             pass
 
         if self.spec.satisfies("threads=openmp"):

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -240,7 +240,7 @@ class Intel(IntelPackage):
             match = version_regex.search(output)
             if match:
                 return match.group(1)
-        except spack.util.executable.ProcessError:
+        except ProcessError:
             pass
         except Exception as e:
             tty.debug(str(e))

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -6,6 +6,7 @@ import re
 
 import llnl.util.tty as tty
 
+import spack.compiler
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/ipm/package.py
+++ b/var/spack/repos/builtin/packages/ipm/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.util.executable import Executable
 
 
 class Ipm(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/jsoncpp/package.py
+++ b/var/spack/repos/builtin/packages/jsoncpp/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.cmake
+import spack.build_systems.meson
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -6,6 +6,7 @@ import os.path
 
 import llnl.util.lang as lang
 
+import spack.build_systems.cmake
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/lcms/package.py
+++ b/var/spack/repos/builtin/packages/lcms/package.py
@@ -5,6 +5,7 @@
 
 import pathlib
 
+import spack.build_systems.msbuild
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/libaec/package.py
+++ b/var/spack/repos/builtin/packages/libaec/package.py
@@ -48,7 +48,7 @@ class Libaec(CMakePackage):
 
         if not libs:
             msg = "Unable to recursively locate {0} {1} libraries in {2}"
-            raise spack.error.NoLibrariesError(
+            raise NoLibrariesError(
                 msg.format("shared" if shared else "static", self.spec.name, self.spec.prefix)
             )
         return libs

--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.autotools
+import spack.build_systems.meson
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/libdwarf/package.py
+++ b/var/spack/repos/builtin/packages/libdwarf/package.py
@@ -6,6 +6,8 @@
 import os
 import sys
 
+import spack.build_systems.cmake
+import spack.build_systems.generic
 from spack.package import *
 
 # Only build certain parts of dwarf because the other ones break.

--- a/var/spack/repos/builtin/packages/libepoxy/package.py
+++ b/var/spack/repos/builtin/packages/libepoxy/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.autotools
+import spack.build_systems.meson
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -5,6 +5,7 @@
 
 import sys
 
+import spack.build_systems.cmake
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/libssh2/package.py
+++ b/var/spack/repos/builtin/packages/libssh2/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.autotools
+import spack.build_systems.cmake
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/libszip/package.py
+++ b/var/spack/repos/builtin/packages/libszip/package.py
@@ -34,7 +34,7 @@ class Libszip(AutotoolsPackage):
 
         if not libs:
             msg = "Unable to recursively locate {0} {1} libraries in {2}"
-            raise spack.error.NoLibrariesError(
+            raise NoLibrariesError(
                 msg.format("shared" if shared else "static", self.spec.name, self.spec.prefix)
             )
         return libs

--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -5,6 +5,7 @@
 import sys
 
 import spack.build_systems
+import spack.build_systems.autotools
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -8,6 +8,7 @@ import os
 
 import llnl.util.tty as tty
 
+import spack.tengine
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/llvm-doe/package.py
+++ b/var/spack/repos/builtin/packages/llvm-doe/package.py
@@ -9,7 +9,6 @@ import sys
 
 import llnl.util.tty as tty
 
-import spack.util.executable
 from spack.build_systems.cmake import get_cmake_prefix_path
 from spack.package import *
 
@@ -258,7 +257,7 @@ class LlvmDoe(CMakePackage, CudaPackage):
             match = version_regex.search(output)
             if match:
                 return match.group(match.lastindex)
-        except spack.util.executable.ProcessError:
+        except ProcessError:
             pass
         except Exception as e:
             tty.debug(e)

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -10,6 +10,7 @@ import sys
 import llnl.util.tty as tty
 from llnl.util.lang import classproperty
 
+import spack.compilers
 from spack.build_systems.cmake import get_cmake_prefix_path
 from spack.package import *
 from spack.package_base import PackageBase

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -10,7 +10,6 @@ import sys
 import llnl.util.tty as tty
 from llnl.util.lang import classproperty
 
-import spack.util.executable
 from spack.build_systems.cmake import get_cmake_prefix_path
 from spack.package import *
 from spack.package_base import PackageBase
@@ -687,7 +686,7 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
             match = re.search(cls.compiler_version_regex, output)
             if match:
                 return match.group(match.lastindex)
-        except spack.util.executable.ProcessError:
+        except ProcessError:
             pass
         except Exception as e:
             tty.debug(e)

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -10,7 +10,6 @@ from llnl.util.symlink import readlink
 
 import spack.build_environment
 from spack.package import *
-from spack.util.executable import Executable
 
 # This is the template for a pkgconfig file for rpm
 # https://github.com/guix-mirror/guix/raw/dcaf70897a0bad38a4638a2905aaa3c46b1f1402/gnu/packages/patches/lua-pkgconfig.patch

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+import spack.util.environment
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -5,6 +5,7 @@
 
 import subprocess
 
+import spack.compiler
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -5,6 +5,7 @@
 import sys
 
 import spack.build_systems.meson
+import spack.variant
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/mmg/package.py
+++ b/var/spack/repos/builtin/packages/mmg/package.py
@@ -7,7 +7,6 @@ import os
 
 import spack.build_systems.cmake
 from spack.package import *
-from spack.util.executable import which
 
 
 class Mmg(CMakePackage):

--- a/var/spack/repos/builtin/packages/mpas-model/package.py
+++ b/var/spack/repos/builtin/packages/mpas-model/package.py
@@ -5,7 +5,6 @@
 import os
 
 from spack.package import *
-from spack.util.executable import Executable
 
 
 class MpasModel(MakefilePackage):

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -7,6 +7,7 @@ import os
 import re
 import sys
 
+import spack.compilers
 from spack.build_environment import dso_suffix
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/msvc/package.py
+++ b/var/spack/repos/builtin/packages/msvc/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import re
 
+import spack.compiler
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -7,6 +7,7 @@ import os.path
 import re
 import sys
 
+import spack.compilers
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/nasm/package.py
+++ b/var/spack/repos/builtin/packages/nasm/package.py
@@ -5,6 +5,7 @@
 import glob
 import os
 
+import spack.build_systems.generic
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -57,7 +57,7 @@ class NetcdfCxx4(CMakePackage):
             return libs
 
         msg = "Unable to recursively locate {0} {1} libraries in {2}"
-        raise spack.error.NoLibrariesError(
+        raise NoLibrariesError(
             msg.format("shared" if shared else "static", self.spec.name, self.spec.prefix)
         )
 

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -112,7 +112,7 @@ class NetcdfFortran(AutotoolsPackage):
             return libs
 
         msg = "Unable to recursively locate {0} {1} libraries in {2}"
-        raise spack.error.NoLibrariesError(
+        raise NoLibrariesError(
             msg.format("shared" if shared else "static", self.spec.name, self.spec.prefix)
         )
 

--- a/var/spack/repos/builtin/packages/ninja-fortran/package.py
+++ b/var/spack/repos/builtin/packages/ninja-fortran/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.util.executable import which_string
 
 
 class NinjaFortran(Package):

--- a/var/spack/repos/builtin/packages/ninja-fortran/package.py
+++ b/var/spack/repos/builtin/packages/ninja-fortran/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.version
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -5,7 +5,6 @@
 import sys
 
 from spack.package import *
-from spack.util.executable import which_string
 
 
 class Ninja(Package):

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -11,6 +11,8 @@ import sys
 
 import llnl.util.tty as tty
 
+import spack.compilers
+import spack.version
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -9,6 +9,7 @@ import sys
 
 import llnl.util.filesystem as fs
 
+import spack.util.environment
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -105,7 +105,7 @@ class ParallelNetcdf(AutotoolsPackage):
 
         msg = f"Unable to recursively locate {'shared' if shared else 'static'} \
 {self.spec.name} libraries in {self.spec.prefix}"
-        raise spack.error.NoLibrariesError(msg)
+        raise NoLibrariesError(msg)
 
     @when("@master")
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/pcre2/package.py
+++ b/var/spack/repos/builtin/packages/pcre2/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.autotools
+import spack.build_systems.cmake
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -264,7 +264,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
 
     @classmethod
     def determine_version(cls, exe):
-        perl = spack.util.executable.Executable(exe)
+        perl = Executable(exe)
         output = perl("--version", output=str, error=str)
         if output:
             match = re.search(r"perl.*\(v([0-9.]+)\)", output)
@@ -275,7 +275,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     @classmethod
     def determine_variants(cls, exes, version):
         for exe in exes:
-            perl = spack.util.executable.Executable(exe)
+            perl = Executable(exe)
             output = perl("-V", output=str, error=str)
             variants = ""
             if output:

--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -323,7 +323,7 @@ class Phist(CMakePackage):
                 tty.warn("========================== %s =======================" % hint)
                 try:
                     make("check")
-                except spack.util.executable.ProcessError:
+                except ProcessError:
                     raise InstallError("run-test of phist ^mpich: Hint: " + hint)
             else:
                 make("check")

--- a/var/spack/repos/builtin/packages/pixman/package.py
+++ b/var/spack/repos/builtin/packages/pixman/package.py
@@ -5,6 +5,8 @@
 
 import sys
 
+import spack.build_systems.autotools
+import spack.build_systems.meson
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -332,7 +332,7 @@ class PyMatplotlib(PythonPackage):
             include.extend(query.headers.directories)
             try:
                 library.extend(query.libs.directories)
-            except spack.error.NoLibrariesError:
+            except NoLibrariesError:
                 pass
 
         # Build uses a mix of Spack's compiler wrapper and the actual compiler,

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning-kokkos/package.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import spack.build_systems.cmake
 from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pennylane-lightning/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+import spack.build_systems.cmake
 from spack.build_systems.python import PythonPipBuilder
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1088,7 +1088,7 @@ print(json.dumps(config))
             if lib:
                 return lib
 
-        raise spack.error.NoLibrariesError(
+        raise NoLibrariesError(
             "Unable to find {} libraries with the following names:\n\n* ".format(self.name)
             + "\n* ".join(candidates)
         )
@@ -1114,7 +1114,7 @@ print(json.dumps(config))
                 config_h = headers[0]
                 break
         else:
-            raise spack.error.NoHeadersError(
+            raise NoHeadersError(
                 "Unable to locate {} headers in any of these locations:\n\n* ".format(self.name)
                 + "\n* ".join(candidates)
             )

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -16,6 +16,7 @@ from typing import Dict, List
 import llnl.util.tty as tty
 from llnl.util.lang import dedupe
 
+import spack.paths
 from spack.build_environment import dso_suffix, stat_suffix
 from spack.package import *
 from spack.util.prefix import Prefix

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -7,6 +7,7 @@
 import os
 import sys
 
+import spack.util.environment
 from spack.operating_systems.mac_os import macos_version
 from spack.package import *
 from spack.util.environment import is_system_path

--- a/var/spack/repos/builtin/packages/rpcsvc-proto/package.py
+++ b/var/spack/repos/builtin/packages/rpcsvc-proto/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.paths
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/sccache/package.py
+++ b/var/spack/repos/builtin/packages/sccache/package.py
@@ -7,6 +7,7 @@ import os
 import re
 
 import spack.build_systems
+import spack.build_systems.cargo
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/seqkit/package.py
+++ b/var/spack/repos/builtin/packages/seqkit/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.go
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/serialbox/package.py
+++ b/var/spack/repos/builtin/packages/serialbox/package.py
@@ -131,7 +131,7 @@ class Serialbox(CMakePackage):
             return libs
 
         msg = "Unable to recursively locate {0} libraries in {1}"
-        raise spack.error.NoLibrariesError(msg.format(self.spec.name, self.spec.prefix))
+        raise NoLibrariesError(msg.format(self.spec.name, self.spec.prefix))
 
     def flag_handler(self, name, flags):
         cmake_flags = []

--- a/var/spack/repos/builtin/packages/sherpa/package.py
+++ b/var/spack/repos/builtin/packages/sherpa/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.autotools
+import spack.build_systems.cmake
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/singularity-eos/package.py
+++ b/var/spack/repos/builtin/packages/singularity-eos/package.py
@@ -5,6 +5,7 @@
 
 import os
 
+import spack.version
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/singularityce/package.py
+++ b/var/spack/repos/builtin/packages/singularityce/package.py
@@ -8,6 +8,7 @@ import shutil
 
 import llnl.util.tty as tty
 
+import spack.tengine
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -5,6 +5,7 @@
 import os
 import re
 
+import spack.compilers
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -7,6 +7,8 @@ import re
 import sys
 from tempfile import NamedTemporaryFile
 
+import spack.build_systems.autotools
+import spack.build_systems.nmake
 import spack.platforms
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/strumpack/package.py
+++ b/var/spack/repos/builtin/packages/strumpack/package.py
@@ -9,7 +9,6 @@ import llnl.util.tty as tty
 
 from spack.package import *
 from spack.util.environment import set_env
-from spack.util.executable import ProcessError
 
 
 class Strumpack(CMakePackage, CudaPackage, ROCmPackage):

--- a/var/spack/repos/builtin/packages/szx/package.py
+++ b/var/spack/repos/builtin/packages/szx/package.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import spack.build_systems.autotools
+import spack.build_systems.cmake
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -8,6 +8,8 @@ import sys
 
 from llnl.util.filesystem import find_first
 
+import spack.build_systems.autotools
+import spack.build_systems.nmake
 from spack.package import *
 from spack.util.environment import is_system_path
 

--- a/var/spack/repos/builtin/packages/thrust/package.py
+++ b/var/spack/repos/builtin/packages/thrust/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.cmake
+import spack.build_systems.generic
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -9,7 +9,6 @@ import re
 import sys
 
 from spack.build_environment import dso_suffix
-from spack.error import NoHeadersError
 from spack.operating_systems.mac_os import macos_version
 from spack.package import *
 from spack.pkg.builtin.kokkos import Kokkos

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -6,6 +6,7 @@
 import os
 import re
 
+import spack.platforms
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/util-macros/package.py
+++ b/var/spack/repos/builtin/packages/util-macros/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.url
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/wayland-protocols/package.py
+++ b/var/spack/repos/builtin/packages/wayland-protocols/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import spack.build_systems.meson
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/yafyaml/package.py
+++ b/var/spack/repos/builtin/packages/yafyaml/package.py
@@ -6,6 +6,7 @@
 import os
 import re
 
+import spack.compiler
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/zziplib/package.py
+++ b/var/spack/repos/builtin/packages/zziplib/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import spack.build_systems.autotools
-import spack.build_systems.cmake
 from spack.package import *
 
 


### PR DESCRIPTION
* Add various missing imports in packages.
* Remove redundant imports
* Export `NoLibrariesError`, `NoHeadersError`, `which_string` in `spack.package`