### PR TITLE
style.py: add import-check for missing & redundant imports

### DIFF
--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -2908,9 +2908,9 @@ complete -c spack -n '__fish_spack_using_command style' -s f -l fix -d 'format a
 complete -c spack -n '__fish_spack_using_command style' -l root -r -f -a root
 complete -c spack -n '__fish_spack_using_command style' -l root -r -d 'style check a different spack instance'
 complete -c spack -n '__fish_spack_using_command style' -s t -l tool -r -f -a tool
-complete -c spack -n '__fish_spack_using_command style' -s t -l tool -r -d 'specify which tools to run (default: isort,black,flake8,mypy)'
+complete -c spack -n '__fish_spack_using_command style' -s t -l tool -r -d 'specify which tools to run (default: import-check, isort, black, flake8, mypy)'
 complete -c spack -n '__fish_spack_using_command style' -s s -l skip -r -f -a skip
-complete -c spack -n '__fish_spack_using_command style' -s s -l skip -r -d 'specify tools to skip (choose from isort,black,flake8,mypy)'
+complete -c spack -n '__fish_spack_using_command style' -s s -l skip -r -d 'specify tools to skip (choose from import-check, isort, black, flake8, mypy)'
 
 # spack tags
 set -g __fish_spack_optspecs_spack_tags h/help i/installed a/all


### PR DESCRIPTION
Add very basic tooling to find redundant and missing absolute `import spack.*` and `import llnl.*` statements, which mypy, flake8 and black don't error over.

One goal is to prevent issues like https://github.com/spack/spack/issues/47432, where an import was missing after a refactor, breaking concretization.

Another goal is to improve the usefulness of the separate `import-check` GitHub Action, which ensures that the size of a minimal set of import statements to remove which would break all cycles does not regress. In recent PRs that check alone proved to be insufficient, as import statement were forgotten, which happened to be unproblematic by accident.

Sometimes unused import statements are legitimate, and that's probably why flake8 doesn't error about them:
1. they are meant to execute module scoped code
2. they are meant to prevent cpython from erroring over circular imports (e.g. `spack/cmd/__init__.py` importing `spack.config`) -- this is obviously not great, but that's just how brittle things are right now :)

For those cases any `# comment` after the import statement is enough to make `import-check` skip them.

---

Implementation-wise it's mostly on the text level, less so AST:

1. unused imports: a regex matches import statements, and checks whether the module is referred to at least one more time.
2. missing imports: the file is filtered (ast parse -> replace all strings with empty strings -> unparse), and again a regex is run to find `(spack|llnl).*` names, the last `.<name>` component is dropped until an existing module is found, and then it's checked whether `import <module>` appears in the contents.

I guess I could do this entirely on the AST level since it's already used to "zero out" strings, but that would be rather branchy and these regexes are trivial, especially since black forces a certain code style.

---

The code was already used in various PRs of mine, the last of which is #47617.