### PR TITLE
py-non-regression-test-tools: add v1.1.6  & remove v1.1.2 (tag removed)

### DIFF
--- a/var/spack/repos/builtin/packages/py-non-regression-test-tools/package.py
+++ b/var/spack/repos/builtin/packages/py-non-regression-test-tools/package.py
@@ -23,4 +23,4 @@ class PyNonRegressionTestTools(PythonPackage):
 
     depends_on("py-numpy", type="run")
     depends_on("python@3.10:", type="run")
-    depends_on("py-setuptools@61.0.0:", type="build")
+    depends_on("py-setuptools@61:", type="build")

--- a/var/spack/repos/builtin/packages/py-non-regression-test-tools/package.py
+++ b/var/spack/repos/builtin/packages/py-non-regression-test-tools/package.py
@@ -18,9 +18,9 @@ class PyNonRegressionTestTools(PythonPackage):
 
     version("develop", branch="develop")
     version("main", branch="main")
+    version("1.1.6", tag="v1.1.6")
     version("1.1.4", tag="v1.1.4")
-    version("1.1.2", tag="v1.1.2")
 
     depends_on("py-numpy", type="run")
     depends_on("python@3.10:", type="run")
-    depends_on("py-setuptools@69.2.0:", type="build")
+    depends_on("py-setuptools@61.0.0:", type="build")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Is it possible to merge this PR?