### PR TITLE
root: add v6.32.08

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -34,6 +34,7 @@ class Root(CMakePackage):
     version("develop", branch="master")
 
     # Production version
+    version("6.32.08", sha256="29ad4945a72dff1a009c326a65b6fa5ee2478498823251d3cef86a2cbeb77b27")
     version("6.32.06", sha256="3fc032d93fe848dea5adb1b47d8f0a86279523293fee0aa2b3cd52a1ffab7247")
     version("6.32.04", sha256="132f126aae7d30efbccd7dcd991b7ada1890ae57980ef300c16421f9d4d07ea8")
     version("6.32.02", sha256="3d0f76bf05857e1807ccfb2c9e014f525bcb625f94a2370b455f4b164961602d")


### PR DESCRIPTION
This PR adds `root`, v6.32.08 ([release notes](https://root.cern/doc/v632/release-notes.html#release-6.32.08)). Just 4 bugfixes and no impact on patches applied within spack.

Test build:
```
==> Installing root-6.32.08-2y4jleb4o7phc2p6thn266i6vcfmix3d [83/87]
==> No binary for root-6.32.08-2y4jleb4o7phc2p6thn266i6vcfmix3d found: installing from source
==> Fetching https://root.cern/download/root_v6.32.08.source.tar.gz
==> Fetching https://github.com/wdconinc/root/commit/06db88c70f602c08c97c401b81afcf6adc2eb25e.diff?full_index=1
==> Applied patch /home/wdconinc/git/spack/var/spack/repos/builtin/packages/root/format-stringbuf-size.patch
==> Applied patch https://github.com/wdconinc/root/commit/06db88c70f602c08c97c401b81afcf6adc2eb25e.diff?full_index=1
==> Ran patch() for root
==> root: Executing phase: 'cmake'
==> root: Executing phase: 'build'
==> root: Executing phase: 'install'
==> root: Successfully installed root-6.32.08-2y4jleb4o7phc2p6thn266i6vcfmix3d
  Stage: 1m 27.91s.  Cmake: 39.75s.  Build: 1h 58m 49.25s.  Install: 24.25s.  Post-install: 7.36s.  Total: 2h 1m 30.07s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/root-6.32.08-2y4jleb4o7phc2p6thn266i6vcfmix3d
```