### PR TITLE
clinfo: add v3.0.23.01.25

### DIFF
--- a/var/spack/repos/builtin/packages/clinfo/package.py
+++ b/var/spack/repos/builtin/packages/clinfo/package.py
@@ -19,6 +19,9 @@ class Clinfo(MakefilePackage):
     license("CC0-1.0")
 
     version(
+        "3.0.23.01.25", sha256="6dcdada6c115873db78c7ffc62b9fc1ee7a2d08854a3bccea396df312e7331e3"
+    )
+    version(
         "3.0.21.02.21", sha256="e52f5c374a10364999d57a1be30219b47fb0b4f090e418f2ca19a0c037c1e694"
     )
     version(


### PR DESCRIPTION
This PR adds `clinfo`, v3.0.23.01.25, which doesn't add any build system changes ([diff](https://github.com/Oblomov/clinfo/compare/3.0.21.02.21...3.0.23.01.25)), but adds support.

Test build:
```
==> Installing clinfo-3.0.23.01.25-jxdehr22aqehzzpkbda3k7l2rpo22yax [13/13]
==> No binary for clinfo-3.0.23.01.25-jxdehr22aqehzzpkbda3k7l2rpo22yax found: installing from source
==> Fetching https://github.com/Oblomov/clinfo/archive/refs/tags/3.0.23.01.25.tar.gz
==> No patches needed for clinfo
==> clinfo: Executing phase: 'edit'
==> clinfo: Executing phase: 'build'
==> clinfo: Executing phase: 'install'
==> clinfo: Successfully installed clinfo-3.0.23.01.25-jxdehr22aqehzzpkbda3k7l2rpo22yax
  Stage: 1.22s.  Edit: 0.00s.  Build: 4.85s.  Install: 0.05s.  Post-install: 0.77s.  Total: 7.60s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/clinfo-3.0.23.01.25-jxdehr22aqehzzpkbda3k7l2rpo22yax
```

Test run (using #47643, but this PR is independent of that PR):
```
$ /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/clinfo-3.0.23.01.25-jxdehr22aqehzzpkbda3k7l2rpo22yax/bin/clinfo
Number of platforms                               1
  Platform Name                                   Portable Computing Language
  Platform Vendor                                 The pocl project
  Platform Version                                OpenCL 3.0 PoCL 6.0  Linux, Release, RELOC, LLVM 18.1.8, SLEEF, POCL_DEBUG
```