### PR TITLE
harfbuzz: add v10.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -24,6 +24,7 @@ class Harfbuzz(MesonPackage, AutotoolsPackage):
 
     license("MIT")
 
+    version("10.1.0", sha256="6ce3520f2d089a33cef0fc48321334b8e0b72141f6a763719aaaecd2779ecb82")
     version("10.0.1", sha256="b2cb13bd351904cb9038f907dc0dee0ae07127061242fe3556b2795c4e9748fc")
     version("10.0.0", sha256="c2dfe016ad833a5043ecc6579043f04e8e6d50064e02ad449bb466e6431e3e04")
     version("9.0.0", sha256="a41b272ceeb920c57263ec851604542d9ec85ee3030506d94662067c7b6ab89e")


### PR DESCRIPTION
This PR adds `harfbuzz`, v10.1.0 ([release notes](https://github.com/harfbuzz/harfbuzz/releases/tag/10.1.0)). No major changes.

Test build:
```
==> Installing harfbuzz-10.1.0-vmsoy4tyyfjjaprsowtnzhlz4tr6ft7r [47/47]
==> No binary for harfbuzz-10.1.0-vmsoy4tyyfjjaprsowtnzhlz4tr6ft7r found: installing from source
==> Fetching https://github.com/harfbuzz/harfbuzz/releases/download/10.1.0/harfbuzz-10.1.0.tar.xz
==> No patches needed for harfbuzz
==> harfbuzz: Executing phase: 'meson'
==> harfbuzz: Executing phase: 'build'
==> harfbuzz: Executing phase: 'install'
==> harfbuzz: Successfully installed harfbuzz-10.1.0-vmsoy4tyyfjjaprsowtnzhlz4tr6ft7r
  Stage: 5.06s.  Meson: 17.39s.  Build: 37.07s.  Install: 1.02s.  Post-install: 1.38s.  Total: 1m 2.58s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/harfbuzz-10.1.0-vmsoy4tyyfjjaprsowtnzhlz4tr6ft7r
```