### PR TITLE
py-gevent: add v24.2.1, v24.10.3, v24.11.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -15,6 +15,7 @@ class PyGevent(PythonPackage):
 
     license("MIT")
 
+    version("24.11.1", sha256="8bd1419114e9e4a3ed33a5bad766afff9a3cf765cb440a582a1b3a9bc80c1aca")
     version("24.10.3", sha256="aa7ee1bd5cabb2b7ef35105f863b386c8d5e332f754b60cfc354148bd70d35d1")
     version("24.2.1", sha256="432fc76f680acf7cf188c2ee0f5d3ab73b63c1f03114c7cd8a34cebbe5aa2056")
     version("23.7.0", sha256="d0d3630674c1b344b256a298ab1ff43220f840b12af768131b5d74e485924237")

--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -15,6 +15,8 @@ class PyGevent(PythonPackage):
 
     license("MIT")
 
+    version("24.10.3", sha256="aa7ee1bd5cabb2b7ef35105f863b386c8d5e332f754b60cfc354148bd70d35d1")
+    version("24.2.1", sha256="432fc76f680acf7cf188c2ee0f5d3ab73b63c1f03114c7cd8a34cebbe5aa2056")
     version("23.7.0", sha256="d0d3630674c1b344b256a298ab1ff43220f840b12af768131b5d74e485924237")
     version("21.12.0", sha256="f48b64578c367b91fa793bf8eaaaf4995cb93c8bc45860e473bf868070ad094e")
     version("21.8.0", sha256="43e93e1a4738c922a2416baf33f0afb0a20b22d3dba886720bc037cd02a98575")
@@ -22,15 +24,22 @@ class PyGevent(PythonPackage):
 
     depends_on("c", type="build")  # generated
 
+    depends_on("python@3.9:", when="@24.10.1:", type=("build", "run"))
     depends_on("python@3.8:", when="@23.7.0:", type=("build", "run"))
     depends_on("python@:3.10", when="@:21.12", type=("build", "run"))
 
     depends_on("py-setuptools@40.8:", when="@20.5.1:", type=("build", "run"))
     depends_on("py-setuptools@40.8:", when="@1.5:", type="build")
     depends_on("py-setuptools@24.2:", when="@:1.4", type="build")
+    depends_on("py-cython@3.0.11:", when="@24.10.1:", type="build")
+    depends_on("py-cython@3.0.8:", when="@24.2.1:", type="build")
+    depends_on("py-cython@3.0.2:", when="@23.9.0:", type="build")
     depends_on("py-cython@3:", when="@20.5.1:", type="build")
     depends_on("py-cython@0.29.14:", when="@1.5:", type="build")
+    depends_on("py-cffi@1.17.1:", when="@24.10.1:", type=("build", "run"))
     depends_on("py-cffi@1.12.3:", type=("build", "run"))
+    depends_on("py-greenlet@3.1.1:", when="@24.10.1:", type=("build", "run"))  # setup.py
+    depends_on("py-greenlet@3.0.3:", when="@24.2.1:", type=("build", "run"))
     depends_on("py-greenlet@3:", when="@23.7: ^python@3.12:", type=("build", "run"))
     depends_on("py-greenlet@2:", when="@22.10.2: ^python@:3.11", type=("build", "run"))
     depends_on("py-greenlet@1.1:1", when="@21.8:21.12.0", type=("build", "run"))


### PR DESCRIPTION
This PR adds `py-gevent`, v24.2.1, v24.10.3, v24.11.1 ([diff](https://github.com/gevent/gevent/compare/23.7.0...24.10.3), [pyproject.toml](https://github.com/gevent/gevent/compare/23.7.0...24.10.3#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711), [setup.py](https://github.com/gevent/gevent/compare/23.7.0...24.10.3#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7)). (24.11.1 added later, no diffs to setup.py or pyproject.py with 24.10.3)

Needs:
- [x] #47647

Test build:
```
==> Installing py-gevent-24.2.1-otiuw5we7w2bpf57unv5dwmv624ikrod [35/35]
==> No binary for py-gevent-24.2.1-otiuw5we7w2bpf57unv5dwmv624ikrod found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/g/gevent/gevent-24.2.1.tar.gz
==> Fetching https://github.com/gevent/gevent/pull/2034.diff?full_index=1
==> Applied patch https://github.com/gevent/gevent/pull/2034.diff?full_index=1
patch unexpectedly ends in middle of line
==> Applied patch /home/wdconinc/git/spack/var/spack/repos/builtin/packages/py-gevent/cython.patch
==> py-gevent: Executing phase: 'install'
==> py-gevent: Successfully installed py-gevent-24.2.1-otiuw5we7w2bpf57unv5dwmv624ikrod
  Stage: 2.23s.  Install: 2m 8.56s.  Post-install: 0.54s.  Total: 2m 11.51s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/py-gevent-24.2.1-otiuw5we7w2bpf57unv5dwmv624ikrod
==> Installing py-gevent-24.10.3-p3ml4rfqjko2dkmvjvru3a3v2i7cjlvp [34/34]
==> No binary for py-gevent-24.10.3-p3ml4rfqjko2dkmvjvru3a3v2i7cjlvp found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/g/gevent/gevent-24.10.3.tar.gz
==> No patches needed for py-gevent
==> py-gevent: Executing phase: 'install'
==> py-gevent: Successfully installed py-gevent-24.10.3-p3ml4rfqjko2dkmvjvru3a3v2i7cjlvp
  Stage: 1.31s.  Install: 2m 27.35s.  Post-install: 0.56s.  Total: 2m 29.31s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/py-gevent-24.10.3-p3ml4rfqjko2dkmvjvru3a3v2i7cjlvp
==> Installing py-gevent-24.11.1-dr76utkvfce4746pytiywqawqexx5i77 [35/35]
==> No binary for py-gevent-24.11.1-dr76utkvfce4746pytiywqawqexx5i77 found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/g/gevent/gevent-24.11.1.tar.gz
==> No patches needed for py-gevent
==> py-gevent: Executing phase: 'install'
==> py-gevent: Successfully installed py-gevent-24.11.1-dr76utkvfce4746pytiywqawqexx5i77
  Stage: 1.36s.  Install: 2m 1.59s.  Post-install: 0.50s.  Total: 2m 3.58s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/py-gevent-24.11.1-dr76utkvfce4746pytiywqawqexx5i77
```