### PR TITLE
py-greenlet: add v3.0.3, v3.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-greenlet/package.py
+++ b/var/spack/repos/builtin/packages/py-greenlet/package.py
@@ -40,3 +40,4 @@ class PyGreenlet(PythonPackage):
         depends_on("python@:3.12", when="@:3.0")
 
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@40.8.0:", type="build", when="@3.0.2:")

--- a/var/spack/repos/builtin/packages/py-greenlet/package.py
+++ b/var/spack/repos/builtin/packages/py-greenlet/package.py
@@ -17,6 +17,8 @@ class PyGreenlet(PythonPackage):
 
     license("MIT AND PSF-2.0", checked_by="tgamblin")
 
+    version("3.1.1", sha256="4ce3ac6cdb6adf7946475d7ef31777c26d94bccc377e070a7986bd2d5c515467")
+    version("3.0.3", sha256="43374442353259554ce33599da8b692d5aa96f8976d567d4badf263371fbe491")
     version("3.0.0a1", sha256="1bd4ea36f0aeb14ca335e0c9594a5aaefa1ac4e2db7d86ba38f0be96166b3102")
     version(
         "2.0.2",


### PR DESCRIPTION
This PR adds `py-greenlet`, v3.0.3, v3.1.1 ([diff](https://github.com/python-greenlet/greenlet/compare/3.0.0a1...3.1.1)).

Test build:
```
-- linux-ubuntu24.10-skylake / gcc@14.2.0 -----------------------
oijumoq py-greenlet@3.1.1 build_system=python_pip
==> 1 installed package
```