### PR TITLE
Add an audit to prevent using the name "all" in packages

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -571,8 +571,13 @@ def _search_for_deprecated_package_methods(pkgs, error_cls):
 @package_properties
 def _ensure_all_package_names_are_lowercase(pkgs, error_cls):
     """Ensure package names are lowercase and consistent"""
+    reserved_names = ("all",)
     badname_regex, errors = re.compile(r"[_A-Z]"), []
     for pkg_name in pkgs:
+        if pkg_name in reserved_names:
+            error_msg = f"The name '{pkg_name}' is reserved, and cannot be used for packages"
+            errors.append(error_cls(error_msg, []))
+
         if badname_regex.search(pkg_name):
             error_msg = f"Package name '{pkg_name}' should be lowercase and must not contain '_'"
             errors.append(error_cls(error_msg, []))

--- a/var/spack/repos/builtin/packages/all-library/package.py
+++ b/var/spack/repos/builtin/packages/all-library/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class All(CMakePackage):
+class AllLibrary(CMakePackage):
     """A Load Balancing Library (ALL)
 
     The library aims to provide an easy way to include dynamic domain-based

--- a/var/spack/repos/builtin/packages/cabana/package.py
+++ b/var/spack/repos/builtin/packages/cabana/package.py
@@ -93,7 +93,7 @@ class Cabana(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("kokkos+cuda_lambda@4.1:", when="+cuda@0.7:")
 
     # Dependencies for subpackages
-    depends_on("all", when="@0.5.0:+all")
+    depends_on("all-library", when="@0.5.0:+all")
     depends_on("arborx", when="@0.3.0:+arborx")
     depends_on("hypre-cmake@2.22.0:", when="@0.4.0:+hypre")
     depends_on("hypre-cmake@2.22.1:", when="@0.5.0:+hypre")


### PR DESCRIPTION
Packages cannot be named like that, since we use "all" to indicate default settings under the "packages" section of the configuration.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
