### PR TITLE
dbus: add v1.15.12

### DIFF
--- a/var/spack/repos/builtin/packages/dbus/package.py
+++ b/var/spack/repos/builtin/packages/dbus/package.py
@@ -31,6 +31,7 @@ class Dbus(AutotoolsPackage, MesonPackage):
     )
 
     # Note: odd minor versions are unstable, keep last stable version preferred
+    version("1.15.12", sha256="0589c9c707dd593e31f0709caefa5828e69c668c887a7c0d2e5ba445a86bae4d")
     version("1.15.10", sha256="f700f2f1d0473f11e52f3f3e179f577f31b85419f9ae1972af8c3db0bcfde178")
     version(
         "1.14.10",


### PR DESCRIPTION
This PR adds `dbus`, v1.15.12 ([diff](https://gitlab.freedesktop.org/dbus/dbus/-/compare/dbus-1.15.10...dbus-1.15.12)). No major changes, but [fixes](https://gitlab.freedesktop.org/dbus/dbus/-/issues/492) builds in containers.

Test build:
```
-- linux-ubuntu24.10-skylake / gcc@14.2.0 -----------------------
belmcjj dbus@1.15.12~strip~xml_docs build_system=meson buildtype=release default_library=shared system-socket=default
==> 1 installed package
```