### PR TITLE
solver: add a timeout handle for users

### DIFF
--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -10,9 +10,6 @@
 # or by adding a `concretizer:` section to an environment.
 # -------------------------------------------------------------------------
 concretizer:
-  # Maximum time, in seconds, allowed to clingo for the 'solve' phase. If set
-  # to 0, there is no time limit.
-  timeout: 0
   # Whether to consider installed packages or packages from buildcaches when
   # concretizing specs. If `true`, we'll try to use as many installs/binaries
   # as possible, rather than building. If `false`, we'll always give you a fresh
@@ -58,3 +55,11 @@ concretizer:
   splice:
     explicit: []
     automatic: false
+  # Maximum time, in seconds, allowed for the 'solve' phase. If set to 0, there is no time limit.
+  timeout: 0
+  # If set to true, exceeding the timeout will always result in a concretization error. If false,
+  # the best (suboptimal) model computed before the timeout is used.
+  #
+  # Setting this to false yields unreproducible results, so we advise to use that value only
+  # for debugging purposes (e.g. check which constraints can help Spack concretize faster).
+  error_on_timeout: true

--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -11,8 +11,8 @@
 # -------------------------------------------------------------------------
 concretizer:
   # Maximum time, in seconds, allowed to clingo for the 'solve' phase. If set
-  # to -1, there is no time limit.
-  timeout: -1
+  # to 0, there is no time limit.
+  timeout: 0
   # Whether to consider installed packages or packages from buildcaches when
   # concretizing specs. If `true`, we'll try to use as many installs/binaries
   # as possible, rather than building. If `false`, we'll always give you a fresh

--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -10,6 +10,9 @@
 # or by adding a `concretizer:` section to an environment.
 # -------------------------------------------------------------------------
 concretizer:
+  # Maximum time, in seconds, allowed to clingo for the 'solve' phase. If set
+  # to -1, there is no time limit.
+  timeout: -1
   # Whether to consider installed packages or packages from buildcaches when
   # concretizing specs. If `true`, we'll try to use as many installs/binaries
   # as possible, rather than building. If `false`, we'll always give you a fresh

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -88,7 +88,7 @@ properties: Dict[str, Any] = {
                     "strategy": {"type": "string", "enum": ["none", "minimal", "full"]}
                 },
             },
-            "timeout": {"type": "integer", "minimum": -1},
+            "timeout": {"type": "integer", "minimum": 0},
             "os_compatible": {"type": "object", "additionalProperties": {"type": "array"}},
         },
     }

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -89,6 +89,7 @@ properties: Dict[str, Any] = {
                 },
             },
             "timeout": {"type": "integer", "minimum": 0},
+            "error_on_timeout": {"type": "boolean"},
             "os_compatible": {"type": "object", "additionalProperties": {"type": "array"}},
         },
     }

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -88,6 +88,7 @@ properties: Dict[str, Any] = {
                     "strategy": {"type": "string", "enum": ["none", "minimal", "full"]}
                 },
             },
+            "timeout": {"type": "integer", "minimum": -1},
             "os_compatible": {"type": "object", "additionalProperties": {"type": "array"}},
         },
     }

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -886,6 +886,9 @@ class PyclingoDriver:
 
         timer.start("solve")
         time_limit = spack.config.CONFIG.get("concretizer:timeout", -1)
+        # Spack uses 0 to set no time limit, clingo API uses -1
+        if time_limit == 0:
+            time_limit = -1
         with self.control.solve(**solve_kwargs, async_=True) as handle:
             finished = handle.wait(time_limit)
             if not finished:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -885,7 +885,17 @@ class PyclingoDriver:
             solve_kwargs["on_unsat"] = cores.append
 
         timer.start("solve")
-        solve_result = self.control.solve(**solve_kwargs)
+        time_limit = spack.config.CONFIG.get("concretizer:timeout", -1)
+        with self.control.solve(**solve_kwargs, async_=True) as handle:
+            finished = handle.wait(time_limit)
+            if not finished:
+                specs_str = ", ".join(llnl.util.lang.elide_list([str(s) for s in specs], 4))
+                warnings.warn(
+                    f"Spack is taking more than {time_limit} seconds to solve for {specs_str}, "
+                    f"using the best configuration found so far"
+                )
+                handle.cancel()
+            solve_result = handle.get()
         timer.stop("solve")
 
         # once done, construct the solve result


### PR DESCRIPTION
Extracted from #45189

This PR adds a configuration setting that sets a time limit for clingo "solve" phase. If that limit is exceeded, concretization will error by default. 

Users can opt-in to use the best configuration found within the limit, if that makes sense for their use case.

For backward compatibility, the default is to set no time limit.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
