### PR TITLE
py-pandas: build in parallel

### DIFF
--- a/var/spack/repos/builtin/packages/py-pandas/package.py
+++ b/var/spack/repos/builtin/packages/py-pandas/package.py
@@ -160,3 +160,6 @@ class PyPandas(PythonPackage):
             depends_on("py-xlsxwriter@3.0.3:", when="@2.1:")
             depends_on("py-xlsxwriter@1.4.3:", when="@1.5:")
             depends_on("py-xlsxwriter@1.2.2:", when="@1.4:")
+
+    def config_settings(self, spec, prefix):
+        return {"compile-args": f"-j{make_jobs}"}


### PR DESCRIPTION
sequential builds are terribly slow.