### PR TITLE
amblis: Restrict disable dynamic thread scaling only to 3.1 version

### DIFF
--- a/var/spack/repos/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/builtin/packages/amdblis/package.py
@@ -86,7 +86,7 @@ class Amdblis(BlisBase):
         elif spec.satisfies("@3.0.1: %aocc"):
             args.append("--complex-return=intel")
 
-        if spec.satisfies("@3.1:"):
+        if spec.satisfies("@3.1"):
             args.append("--disable-aocl-dynamic")
 
         if spec.satisfies("+logging"):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
