### PR TITLE
Kokkos complex_align variant, Trilinos+PETSc enforcement for Kokkos~complex_align

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -179,6 +179,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     options_variants = {
         "aggressive_vectorization": [False, "Aggressively vectorize loops"],
         "compiler_warnings": [False, "Print all compiler warnings"],
+        "complex_align": [True, "Align complex numbers"],
         "cuda_constexpr": [False, "Activate experimental constexpr features"],
         "cuda_lambda": [False, "Activate experimental lambda features"],
         "cuda_ldg_intrinsic": [False, "Use CUDA LDG intrinsics"],

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -374,6 +374,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     depends_on("libyaml", when="+libyaml")
     depends_on("hwloc", when="+hwloc")
     depends_on("kokkos", when="+kokkos")
+    depends_on("kokkos~complex_align", when="+kokkos+complex")
     depends_on("kokkos-kernels", when="+kokkos")
     for cuda_arch in CudaPackage.cuda_arch_values:
         depends_on(

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -420,15 +420,12 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("kokkos-kernels@4.2.01", when="@15.1:15")
         depends_on("kokkos-kernels@4.1.00", when="@14.4:15.0")
 
-    for a in CudaPackage.cuda_arch_values:
-        arch_str = f"+cuda cuda_arch={a}"
-        kokkos_spec = f"kokkos {arch_str}"
-        depends_on(kokkos_spec, when=f"@14.4: +kokkos {arch_str}")
-
-    for a in ROCmPackage.amdgpu_targets:
-        arch_str = f"+rocm amdgpu_target={a}"
-        kokkos_spec = f"kokkos {arch_str}"
-        depends_on(kokkos_spec, when=f"@14.4: +kokkos {arch_str}")
+        for a in CudaPackage.cuda_arch_values:
+            arch_str = f"+cuda cuda_arch={a}"
+            depends_on(f"kokkos{arch_str}", when=arch_str)
+        for a in ROCmPackage.amdgpu_targets:
+            arch_str = f"+rocm amdgpu_target={a}"
+            depends_on(f"kokkos{arch_str}", when=arch_str)
 
     depends_on("adios2", when="+adios2")
     depends_on("binder@1.3:", when="@15: +python", type="build")

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -407,14 +407,16 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     # ###################### Dependencies ##########################
 
     # External Kokkos
-    depends_on("kokkos@4.4.01~complex_align", when="@master: +kokkos")
-    depends_on("kokkos@4.3.01~complex_align", when="@16.0:16 +kokkos")
-    depends_on("kokkos@4.2.01~complex_align", when="@15.1:15 +kokkos")
-    depends_on("kokkos@4.1.00~complex_align", when="@14.4:15.0 +kokkos")
-    depends_on("kokkos-kernels@4.4.01", when="@master: +kokkos")
-    depends_on("kokkos-kernels@4.3.01", when="@16.0:16 +kokkos")
-    depends_on("kokkos-kernels@4.2.01", when="@15.1:15 +kokkos")
-    depends_on("kokkos-kernels@4.1.00", when="@14.4:15.0 +kokkos")
+    with when("@14.4: +kokkos"):
+        depends_on("kokkos~complex_align")
+        depends_on("kokkos@4.4.01", when="@master:")
+        depends_on("kokkos@4.3.01", when="@16")
+        depends_on("kokkos@4.2.01", when="@15.1:15")
+        depends_on("kokkos@4.1.00", when="@14.4:15.0")
+        depends_on("kokkos-kernels@4.4.01", when="@master:")
+        depends_on("kokkos-kernels@4.3.01", when="@16")
+        depends_on("kokkos-kernels@4.2.01", when="@15.1:15")
+        depends_on("kokkos-kernels@4.1.00", when="@14.4:15.0")
 
     depends_on("kokkos +wrapper", when="trilinos@14.4.0: +kokkos +wrapper")
     depends_on("kokkos ~wrapper", when="trilinos@14.4.0: +kokkos ~wrapper")

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -407,10 +407,14 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     # ###################### Dependencies ##########################
 
     # External Kokkos
-    depends_on("kokkos@4.4.01", when="@master: +kokkos")
-    depends_on("kokkos@4.3.01", when="@16.0.0 +kokkos")
-    depends_on("kokkos@4.2.01", when="@15.1.0:15.1.1 +kokkos")
-    depends_on("kokkos@4.1.00", when="@14.4.0:15.0.0 +kokkos")
+    depends_on("kokkos@4.4.01~complex_align", when="@master: +kokkos")
+    depends_on("kokkos@4.3.01~complex_align", when="@16.0:16 +kokkos")
+    depends_on("kokkos@4.2.01~complex_align", when="@15.1:15 +kokkos")
+    depends_on("kokkos@4.1.00~complex_align", when="@14.4:15.0 +kokkos")
+    depends_on("kokkos-kernels@4.4.01", when="@master: +kokkos")
+    depends_on("kokkos-kernels@4.3.01", when="@16.0:16 +kokkos")
+    depends_on("kokkos-kernels@4.2.01", when="@15.1:15 +kokkos")
+    depends_on("kokkos-kernels@4.1.00", when="@14.4:15.0 +kokkos")
 
     depends_on("kokkos +wrapper", when="trilinos@14.4.0: +kokkos +wrapper")
     depends_on("kokkos ~wrapper", when="trilinos@14.4.0: +kokkos ~wrapper")
@@ -899,8 +903,9 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             define_tpl(tpl_name, dep_name, dep_name in spec)
 
         # External Kokkos
-        if spec.satisfies("@14.4.0 +kokkos"):
+        if spec.satisfies("@14.4.0: +kokkos"):
             options.append(define_tpl_enable("Kokkos"))
+            options.append(define_tpl_enable("KokkosKernels", True))
 
         # MPI settings
         options.append(define_tpl_enable("MPI"))

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -408,6 +408,8 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
 
     # External Kokkos
     with when("@14.4: +kokkos"):
+        depends_on("kokkos+wrapper", when="+wrapper")
+        depends_on("kokkos~wrapper", when="~wrapper")
         depends_on("kokkos~complex_align")
         depends_on("kokkos@4.4.01", when="@master:")
         depends_on("kokkos@4.3.01", when="@16")
@@ -418,18 +420,15 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("kokkos-kernels@4.2.01", when="@15.1:15")
         depends_on("kokkos-kernels@4.1.00", when="@14.4:15.0")
 
-    depends_on("kokkos +wrapper", when="trilinos@14.4.0: +kokkos +wrapper")
-    depends_on("kokkos ~wrapper", when="trilinos@14.4.0: +kokkos ~wrapper")
-
     for a in CudaPackage.cuda_arch_values:
-        arch_str = "+cuda cuda_arch={0}".format(a)
-        kokkos_spec = "kokkos {0}".format(arch_str)
-        depends_on(kokkos_spec, when="@14.4.0: +kokkos {0}".format(arch_str))
+        arch_str = f"+cuda cuda_arch={a}"
+        kokkos_spec = f"kokkos {arch_str}"
+        depends_on(kokkos_spec, when=f"@14.4: +kokkos {arch_str}")
 
     for a in ROCmPackage.amdgpu_targets:
-        arch_str = "+rocm amdgpu_target={0}".format(a)
-        kokkos_spec = "kokkos {0}".format(arch_str)
-        depends_on(kokkos_spec, when="@14.4.0: +kokkos {0}".format(arch_str))
+        arch_str = f"+rocm amdgpu_target={a}"
+        kokkos_spec = f"kokkos {arch_str}"
+        depends_on(kokkos_spec, when=f"@14.4: +kokkos {arch_str}")
 
     depends_on("adios2", when="+adios2")
     depends_on("binder@1.3:", when="@15: +python", type="build")


### PR DESCRIPTION
This PR tackles two problems, but I felt that I will add it to a single PR. Let me know if I must split it into two.
The first issue is the missing variant of `complex_align` on Kokkos. Trilinos, when built with the builtin kokkos version will set `complex_align` to OFF, which is the opposite of what the default in the Kokkos package is.
This PR adds the variant with default value true, but enforcing it to false, when building trilinos.
Also PETSc, when building for complex scalars and kokkos support enforces that the variant `complex_align` is set to false.

The second issue this PR tackles is the incorrect dependency on the external Kokkos package for trilinos. Basically this line
```
        if spec.satisfies("@14.4.0 +kokkos"):
```
This is missing the upper boundary, and only restricts on the very specific trilinos version.
This leads to trilinos pulling in the internal kokkos version, and one would end up with two kokkos libraries. One provided by kokkos (correct) and one provided by trilinos (incorrect).
Also I have the feeling that when we enable `trilinos+kokkos`, we actually also want to unbundle `kokkos-kernels` from trilinos, hence I added this too.
All in all, using this PR we can build a version of trilinos that links to `kokkos` and `kokkos-kernels` without pulling in the bundled versions inside trilinos.

Without this PR, building an environment with a view would lead to multiple `libkokkos_*.so`, provided by `trilinos`, `kokkos` and `kokkos-kernels`.