### PR TITLE
itk: use vendored googletest

### DIFF
--- a/var/spack/repos/builtin/packages/itk/package.py
+++ b/var/spack/repos/builtin/packages/itk/package.py
@@ -81,6 +81,7 @@ class Itk(CMakePackage):
             self.define("BUILD_TESTING", False),
             self.define("BUILD_SHARED_LIBS", True),
             self.define("ITK_USE_SYSTEM_LIBRARIES", True),
+            # https://github.com/InsightSoftwareConsortium/ITK/issues/303
             self.define("ITK_USE_SYSTEM_GOOGLETEST", False),
             self.define("ITK_USE_MKL", use_mkl),
             self.define_from_variant("Module_ITKReview", "review"),

--- a/var/spack/repos/builtin/packages/itk/package.py
+++ b/var/spack/repos/builtin/packages/itk/package.py
@@ -63,7 +63,6 @@ class Itk(CMakePackage):
     depends_on("eigen")
     depends_on("expat")
     depends_on("fftw-api")
-    depends_on("googletest")
     depends_on("hdf5+cxx+hl")
     depends_on("jpeg")
     depends_on("libpng")
@@ -79,8 +78,10 @@ class Itk(CMakePackage):
     def cmake_args(self):
         use_mkl = self.spec["fftw-api"].name in INTEL_MATH_LIBRARIES
         args = [
+            self.define("BUILD_TESTING", False),
             self.define("BUILD_SHARED_LIBS", True),
             self.define("ITK_USE_SYSTEM_LIBRARIES", True),
+            self.define("ITK_USE_SYSTEM_GOOGLETEST", False),
             self.define("ITK_USE_MKL", use_mkl),
             self.define_from_variant("Module_ITKReview", "review"),
             self.define_from_variant("Module_RTK", "rtk"),


### PR DESCRIPTION
external googletest breaks dependents because they end up with
ITK_LIBRARIES set to `GTest::GTest;GTest::Main`, which then end up
literally in a nonsensical link line `-lGTest::GtTest`.

the vendored googletest produces a cmake config file where
`ITKGoogleTest_LIBRARIES` is empty.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
