### PR TITLE
openfoam: restrict the CGAL version compatible with C++14

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -375,7 +375,8 @@ class Openfoam(Package):
     # Earlier versions of OpenFOAM may not work with CGAL 5.6. I do
     # not know which OpenFOAM added support for 5.x and conservatively
     # use 2312 in the check.
-    depends_on("cgal", when="@2312:")
+    # cgal@6 needs c++17, but OpenFOAM forces c++14
+    depends_on("cgal@:5", when="@2312:")
     depends_on("cgal@:4", when="@:2306")
 
     # The flex restriction is ONLY to deal with a spec resolution clash

--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -376,7 +376,7 @@ class Openfoam(Package):
     # not know which OpenFOAM added support for 5.x and conservatively
     # use 2312 in the check.
     # cgal@6 needs c++17, but OpenFOAM forces c++14
-    depends_on("cgal@:5", when="@2312:")
+    depends_on("cgal@:5", when="@2312:2412")
     depends_on("cgal@:4", when="@:2306")
 
     # The flex restriction is ONLY to deal with a spec resolution clash


### PR DESCRIPTION
CGAL throws an [error](https://github.com/CGAL/cgal/blob/50219fc33bc53b5846e9a4257befc6baef3f395a/Installation/include/CGAL/config.h#L147) if C++ lower than 17 is used, while OpenFOAM [forces
C++14](https://develop.openfoam.com/Development/openfoam/-/blob/develop/wmake/rules/General/Gcc/c++?ref_type=heads#L9). This hard C++17 dependency was [introduced](https://github.com/CGAL/cgal/commit/e54408370b2583153dc923884a5ec1587bc7898e) to CGAL version 6.

-------

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->