### PR TITLE
hdf5-vol-cache %cce: add -Wno-error=incompatible-function-pointer-types

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5-vol-cache/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-vol-cache/package.py
@@ -27,7 +27,7 @@ class Hdf5VolCache(CMakePackage):
 
     def flag_handler(self, name, flags):
         if name == "cflags":
-            if self.spec.satisfies("%oneapi"):
+            if self.spec.satisfies("%oneapi") or self.spec.satisfies("%cce"):
                 flags.append("-Wno-error=incompatible-function-pointer-types")
         return (flags, None, None)
 


### PR DESCRIPTION
Fixes `%cce` build error:
```
  >> 60     /tmp/eugeneswalker/spack-stage/spack-stage-hdf5-vol-cache-v1.1-jadkf7d3up6nb6ijzy4gtyyr2yap6d2j/spack-src/src/H5VLcache_ext.c:580:9: error: incompatible function pointer types initializing 'herr_t (*)(const v
            oid *, uint64_t *)' (aka 'int (*)(const void *, unsigned long *)') with an expression of type 'herr_t (const void *, unsigned int *)' (aka 'int (const void *, unsigned int *)') [-Wincompatible-function-p
            ointer-types]
     61       580 |         H5VL_cache_ext_introspect_get_cap_flags,
     62           |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     ...
```

@hyoklee @lrknox 