### PR TITLE
mpifileutils%cce: add cflags -Wno-error=implicit-function-declaration

### DIFF
--- a/var/spack/repos/builtin/packages/mpifileutils/package.py
+++ b/var/spack/repos/builtin/packages/mpifileutils/package.py
@@ -66,7 +66,7 @@ class Mpifileutils(CMakePackage):
     def flag_handler(self, name, flags):
         spec = self.spec
         if name == "cflags":
-            if spec.satisfies("%oneapi"):
+            if spec.satisfies("%oneapi") or spec.satisfies("%cce"):
                 flags.append("-Wno-error=implicit-function-declaration")
         return (flags, None, None)
 


### PR DESCRIPTION
Fixes `%cce` build:
```
  >> 575     /tmp/eugenswalker/spack-stage/spack-stage-mpifileutils-0.11.1-b2y6mbelablkot37qqforpp4yr6lvkb5/spack-src/src/common/mfu_io.c:1509:18: error: call to undeclared function 'llistxattr'; ISO C99 and later do no
             t support implicit function declarations [-Wimplicit-function-declaration]
     576      1509 |     ssize_t rc = llistxattr(path, list, size);
     577           |                  ^
     578     |             ^~~~~~~
```