### PR TITLE
netlib-scalapack %cce: add cflags -Wno-error=implicit-function-declar…

### DIFF
--- a/var/spack/repos/builtin/packages/netlib-scalapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-scalapack/package.py
@@ -42,6 +42,8 @@ class ScalapackBase(CMakePackage):
 
     def flag_handler(self, name, flags):
         if name == "cflags":
+            if self.spec.satisfies("%cce"):
+                flags.append("-Wno-error=implicit-function-declaration")
             if self.spec.satisfies("%gcc@14:"):
                 # https://bugzilla.redhat.com/show_bug.cgi?id=2178710
                 flags.append("-std=gnu89")


### PR DESCRIPTION
Fixes `%cce` build error:
```
  >> 200    /tmp/eugeneswalker/spack-stage/spack-stage-netlib-scalapack-2.2.0-yyk6vrfwiirg5kji7etbcgf6ekkwt3jf/spack-src/BLACS/SRC/sgsum2d_.c:154:7: error: call to undeclared function 'BI_smvcopy'; ISO C99 and later do n
            ot support implicit function declarations [-Wimplicit-function-declaration]
     201      154 |       BI_smvcopy(Mpval(m), Mpval(n), A, tlda, bp->Buff);
     202          |       ^
```