### PR TITLE
gxsview: making sure -lstdc++fs is added

### DIFF
--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -46,7 +46,7 @@ class Gxsview(QMakePackage):
     depends_on("vtk@9:+qt+opengl2", when="@2024.03.15:")
     conflicts("%gcc@:7.2.0", msg="Requires C++17 compiler support")  # need C++17 standard
     conflicts("qt@6:", msg="Qt 6 support is not yet achieved")
-    conflicts("qt-base@6:", msg="Qt 6 support is not yet achieved")  # required for clingo
+    conflicts("^qt-base@6:", msg="Qt 6 support is not yet achieved")  # required for clingo
 
     patch("vtk9.patch", when="^vtk@9:")
     # gcc11 compilation rule for std::numeric_limits,
@@ -76,7 +76,7 @@ class Gxsview(QMakePackage):
             ]
         )
         # Below to avoid undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
-        if self.spec.satisfies("%gcc@8.0:8.9") or self.spec.satisfies("%fj"):
+        if self.spec.satisfies("%gcc@:8.9") or self.spec.satisfies("%fj"):
             if self.spec.satisfies("^vtk@9:"):
                 fic = "vtk9.pri"
             else:

--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -82,7 +82,7 @@ class Gxsview(QMakePackage):
             else:
                 fic = "vtk8.pri"
             with open(fic, "a") as fh:
-                fh.write("-lstdc++fs\n")
+                fh.write("\nLIBS += -lstdc++fs\n")
         return args
 
     def install(self, spec, prefix):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Due to a change in vtk9.pri it is necessary to be more specific when adding -lstdc++fs for gcc 8.