### PR TITLE
Python package for venv's may find the wrong python executable as find_first will return first match. 

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -863,7 +863,10 @@ class Python(Package):
         file_extension = "" if sys.platform != "win32" else ".exe"
         patterns = [f"python{ver}{file_extension}" for ver in suffixes]
         root = self.prefix.bin if sys.platform != "win32" else self.prefix
-        path = find_first(root, files=patterns)
+        for pattern in patterns:
+            path = find_first(root, files=pattern)
+            if path is not None:
+                break
 
         if path is not None:
             return Executable(path)


### PR DESCRIPTION
Find - in order of importance - the python3 executable as find_first() return the first match.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
