### PR TITLE
fix netcdf-c issue with seissol

### DIFF
--- a/var/spack/repos/builtin/packages/seissol/package.py
+++ b/var/spack/repos/builtin/packages/seissol/package.py
@@ -154,8 +154,8 @@ class Seissol(CMakePackage, CudaPackage, ROCmPackage):
 
     conflicts(
         "%intel",
-        when="@1.3:",
-        msg="The Intel compiler is unsupported from v1.3 onward. Please use e.g.gcc or oneapi",
+        when="@1.3",
+        msg="The Intel compiler is unsupported from v1.3. Please use e.g.gcc or oneapi",
     )
 
     variant(
@@ -196,7 +196,7 @@ class Seissol(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("hdf5 +shared +threadsafe +hl +mpi")
 
-    depends_on("netcdf-c@4.6: +shared +mpi", when="+netcdf")
+    depends_on("netcdf-c@4.6:4.8.1 +shared +mpi", when="+netcdf")
 
     depends_on("asagi +mpi +mpi3", when="+asagi")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
We add a max version for netcdf-c to fix issues with 4.9.2:
https://github.com/SeisSol/SeisSol/issues/1213
The conflict of intel compilers arising seissol@1.3 has been fixed on the master branch.
There is no new release yet, but newest release will be compatible with intel.