### PR TITLE
coverage.yml: fail_ci_if_error = true

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,3 +32,4 @@ jobs:
       uses: codecov/codecov-action@05f5a9cfad807516dbbef9929c4a42df3eb78766
       with:
         verbose: true
+        fail_ci_if_error: true


### PR DESCRIPTION
Failing coverage CI runs are marked as success, e.g. in https://github.com/spack/spack/actions/runs/11943108426/job/33292879311?pr=47706#step:9:266 for #47706. This can lead to merging PRs that are actually breaking things.

This PR adds the `fail_ci_if_error` action argument and sets it to `true` (default = false).

Other considerations:
- Should this be restricted to `true` only when `github.repository == "spack/spack"` to avoid breaking workflows on forks? Edit: I don't think this is needed.