### PR TITLE
Reinstalling from source when binary cache install failed, incorrectly implemented

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1106,12 +1106,13 @@ class Task:
             return self.request.install_args.get("package_use_cache", _use_cache)
         else:
             return self.request.install_args.get("dependencies_use_cache", _use_cache)
+
     @use_cache.setter
     def use_cache(self, v: bool) -> None:
         self._use_cache = v
         # force override also request
-        self.request.install_args['package_use_cache'] = v
-        self.request.install_args['dependencies_use_cache'] = v
+        self.request.install_args["package_use_cache"] = v
+        self.request.install_args["dependencies_use_cache"] = v
 
     @property
     def cache_only(self) -> bool:
@@ -2400,7 +2401,6 @@ class BuildProcessInstaller:
         fs.install_tree(pkg.stage.source_path, src_target)
 
     def _real_install(self) -> None:
-
         pkg = self.pkg
 
         # Do the real install in the source directory.

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1106,6 +1106,12 @@ class Task:
             return self.request.install_args.get("package_use_cache", _use_cache)
         else:
             return self.request.install_args.get("dependencies_use_cache", _use_cache)
+    @use_cache.setter
+    def use_cache(self, v: bool) -> None:
+        self._use_cache = v
+        # force override also request
+        self.request.install_args['package_use_cache'] = v
+        self.request.install_args['dependencies_use_cache'] = v
 
     @property
     def cache_only(self) -> bool:
@@ -2186,8 +2192,7 @@ class PackageInstaller:
                     f"Failed to install {pkg.name} from binary cache due "
                     f"to {str(exc)}: Requeueing to install from source."
                 )
-                # this overrides a full method, which is ugly.
-                task.use_cache = False  # type: ignore[misc]
+                task.use_cache = False
                 self._requeue_task(task, install_status)
                 continue
 


### PR DESCRIPTION
This PR fixes a problem, where installing from cache fails, and then installing from source fails too, because `use_cache` is a property without a setter, hence trying to override it fails.

Observed error in this pipeline: https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/4299042326928875/2985762570179115/-/jobs/8440788536#L272
Running the pipeline with this fix:
https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/4299042326928875/2985762570179115/-/jobs/8443911829#L282