### PR TITLE
ci devtools stack: update manylinux2014 image with stripped-out libcrypt.so

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -456,7 +456,7 @@ build_systems-build:
 
 developer-tools-manylinux2014-generate:
   extends: [ ".developer-tools-manylinux2014", ".generate-x86_64"]
-  image:  ghcr.io/spack/spack/centos7-builder-amd64-gcc10.2.1-glibc2.17-libcrypt1:2024.11.20
+  image:  ghcr.io/spack/spack/centos7-builder-amd64-gcc10.2.1-glibc2.17-libcrypt1:2024.12.09
 
 developer-tools-manylinux2014-build:
   extends: [ ".developer-tools-manylinux2014", ".build" ]

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -456,7 +456,7 @@ build_systems-build:
 
 developer-tools-manylinux2014-generate:
   extends: [ ".developer-tools-manylinux2014", ".generate-x86_64"]
-  image:  ghcr.io/spack/spack/manylinux2014:2024.03.28
+  image:  ghcr.io/spack/spack/centos7-builder-amd64-gcc10.2.1-glibc2.17-libcrypt1:2024.11.20
 
 developer-tools-manylinux2014-build:
   extends: [ ".developer-tools-manylinux2014", ".build" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/developer-tools-manylinux2014/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/developer-tools-manylinux2014/spack.yaml
@@ -94,7 +94,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ghcr.io/spack/spack/centos7-builder-amd64-gcc10.2.1-glibc2.17-libcrypt1:2024.11.20
+        image: ghcr.io/spack/spack/centos7-builder-amd64-gcc10.2.1-glibc2.17-libcrypt1:2024.12.09
 
   cdash:
     build-group: Developer Tools Manylinux2014

--- a/share/spack/gitlab/cloud_pipelines/stacks/developer-tools-manylinux2014/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/developer-tools-manylinux2014/spack.yaml
@@ -94,7 +94,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ghcr.io/spack/spack/manylinux2014:2024.03.28
+        image: ghcr.io/spack/spack/centos7-builder-amd64-gcc10.2.1-glibc2.17-libcrypt1:2024.11.20
 
   cdash:
     build-group: Developer Tools Manylinux2014


### PR DESCRIPTION
This updated image has `libcrypt.so` stripped to improve relocatability @haampie  @trws 

The recipe for the updated image is here:
* https://github.com/spack/gitlab-runners/pull/57
