### PR TITLE
Slurm: extend spack external find support

### DIFF
--- a/var/spack/repos/builtin/packages/slurm/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/slurm/detection_test.yaml
@@ -1,0 +1,23 @@
+paths:
+- layout:
+  # SLES:
+  - executables:
+    - "bin/srun"
+    script: |
+      echo "slurm 22.05.8"
+  - executables:
+    - "bin/salloc"
+    script: |
+      echo "slurm 22.05.8"
+  # Debian:
+  - executables:
+    - "bin/srun"
+    script: |
+      echo "slurm-wlm 22.05.8"
+  - executables:
+    - "bin/salloc"
+    script: |
+       echo "slurm-wlm 22.05.8"
+  platforms: ["linux"]
+  results:
+  - spec: "slurm@22.05.8"

--- a/var/spack/repos/builtin/packages/slurm/package.py
+++ b/var/spack/repos/builtin/packages/slurm/package.py
@@ -178,8 +178,8 @@ class Slurm(AutotoolsPackage):
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)("--version", output=str).rstrip()
-        match = re.search(r"slurm\s*([0-9.]+)", output)
-        return match.group(1) if match else None
+        match = re.search(r"slurm\s*([0-9.]+)|slurm-wlm\s*([0-9.]+)", output)
+        return (match.group(1) or match.group(2)) if match else None
 
     def flag_handler(self, name, flags):
         wrapper_flags = None

--- a/var/spack/repos/builtin/packages/slurm/package.py
+++ b/var/spack/repos/builtin/packages/slurm/package.py
@@ -178,8 +178,8 @@ class Slurm(AutotoolsPackage):
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)("--version", output=str).rstrip()
-        match = re.search(r"slurm\s*([0-9.]+)|slurm-wlm\s*([0-9.]+)", output)
-        return (match.group(1) or match.group(2)) if match else None
+        match = re.search(r"slurm(?:-wlm)?\s*([0-9.]+)", output)
+        return match.group(1) if match else None
 
     def flag_handler(self, name, flags):
         wrapper_flags = None


### PR DESCRIPTION
On Debian srun/salloc --version returns 'slurm-wlm VERSION'. Check for both strings and return the first match.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
