### PR TITLE
build-containers: determine latest release tag and push that as latest

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -62,8 +62,7 @@ jobs:
       - name: Determine latest release tag
         id: latest
         run: |
-          git tag
-          #git tag --sort=-v:refname
+          git tag --sort=-v:refname
           #git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
           #echo "tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)" | tee -a $GITHUB_OUTPUT
 

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -60,10 +60,8 @@ jobs:
       - name: Determine latest release tag
         id: latest
         run: |
-          git fetch --tags
-          git tag --list --sort=-v:refname
-         # git tag --list --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
-          #echo "tag=$(git tag --list --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)" | tee -a $GITHUB_OUTPUT
+          git fetch --quiet --tags
+          echo "tag=$(git tag --list --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)" | tee -a $GITHUB_OUTPUT
 
       - uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96
         id: docker_meta

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Determine latest release tag
         id: latest
         run: |
+          git tag
           git tag --sort=-v:refname
           git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
           echo "tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)" | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -56,15 +56,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          fetch-tags: true
 
       - name: Determine latest release tag
         id: latest
         run: |
-          git tag --sort=-v:refname
-          #git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
-          #echo "tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)" | tee -a $GITHUB_OUTPUT
+          git fetch --tags
+          git tag --list --sort=-v:refname
+         # git tag --list --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
+          #echo "tag=$(git tag --list --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)" | tee -a $GITHUB_OUTPUT
 
       - uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96
         id: docker_meta

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -63,8 +63,8 @@ jobs:
         id: latest
         run: |
           git tag
-          git tag --sort=-v:refname
-          git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
+          #git tag --sort=-v:refname
+          #git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
           #echo "tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)" | tee -a $GITHUB_OUTPUT
 
       - uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -62,6 +62,8 @@ jobs:
       - name: Determine latest release tag
         id: latest
         run: |
+          git tag --sort=-v:refname
+          git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
           echo "tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)" | tee -a $GITHUB_OUTPUT
 
       - uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Determine latest release tag
         id: latest
         run: |
-          tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1) >> $GITHUB_OUTPUT
+          echo "tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)" >> $GITHUB_OUTPUT
 
       - uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96
         id: docker_meta

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -56,6 +56,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-tags: true
+
+      - name: Determine latest release tag
+        id: latest
+        run: |
+          tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1) >> $GITHUB_OUTPUT
 
       - uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96
         id: docker_meta
@@ -71,6 +78,7 @@ jobs:
               type=semver,pattern={{major}}
               type=ref,event=branch
               type=ref,event=pr
+              type=raw,value=latest,enable=${{ github.ref == format('refs/tags/{0}', steps.latest.outputs.tag) }}
 
       - name: Generate the Dockerfile
         env:

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -65,7 +65,7 @@ jobs:
           git tag
           git tag --sort=-v:refname
           git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
-          echo "tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)" | tee -a $GITHUB_OUTPUT
+          #echo "tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)" | tee -a $GITHUB_OUTPUT
 
       - uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96
         id: docker_meta

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Determine latest release tag
         id: latest
         run: |
-          echo "tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)" >> $GITHUB_OUTPUT
+          echo "tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)" | tee -a $GITHUB_OUTPUT
 
       - uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96
         id: docker_meta


### PR DESCRIPTION
Right now, the `latest` container tag is based on which release tag happens to have been published last. This is a [known issue](https://github.com/docker/metadata-action/issues/407).

This PR determines the latest release tag per our semver pattern, and only enables the `latest` tag when that is the tag we're on right now.