### PR TITLE
Port tests to Windows by removing pytest markers

### DIFF
--- a/lib/spack/spack/test/build_distribution.py
+++ b/lib/spack/spack/test/build_distribution.py
@@ -6,14 +6,10 @@
 import os
 import os.path
 
-import pytest
-
 import spack.binary_distribution as bd
 import spack.mirror
 import spack.spec
 from spack.installer import PackageInstaller
-
-pytestmark = pytest.mark.not_on_windows("does not run on windows")
 
 
 def test_build_tarball_overwrite(install_mockery, mock_fetch, monkeypatch, tmp_path):

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -29,7 +29,6 @@ def test_urlencode_string():
     assert ci._url_encode_string("Spack Test Project") == "Spack+Test+Project"
 
 
-@pytest.mark.not_on_windows("Not supported on Windows (yet)")
 def test_import_signing_key(mock_gnupghome):
     signing_key_dir = spack_paths.mock_gpg_keys_path
     signing_key_path = os.path.join(signing_key_dir, "package-signing-key")

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -26,8 +26,6 @@ install = SpackCommand("install")
 buildcache = SpackCommand("buildcache")
 uninstall = SpackCommand("uninstall")
 
-pytestmark = pytest.mark.not_on_windows("does not run on windows")
-
 
 @pytest.mark.disable_clean_stage_check
 @pytest.mark.regression("8083")
@@ -345,7 +343,7 @@ def test_mirror_destroy(
 ):
     # Create a temp mirror directory for buildcache usage
     mirror_dir = tmpdir.join("mirror_dir")
-    mirror_url = "file://{0}".format(mirror_dir.strpath)
+    mirror_url = "file:///{0}".format(mirror_dir.strpath)
     mirror("add", "atest", mirror_url)
 
     spec_name = "libdwarf"

--- a/lib/spack/spack/test/multimethod.py
+++ b/lib/spack/spack/test/multimethod.py
@@ -12,10 +12,7 @@ import spack.platforms
 import spack.spec
 from spack.multimethod import NoSuchMethodError
 
-pytestmark = [
-    pytest.mark.usefixtures("mock_packages", "config"),
-    pytest.mark.not_on_windows("Not running on windows"),
-]
+pytestmark = pytest.mark.usefixtures("mock_packages", "config")
 
 
 @pytest.fixture(scope="module", params=["multimethod", "multimethod-inheritor"])


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Enables tests on Windows by removing Windows pytest markers