### PR TITLE
Upgraded version specs for ECMWF packages: eckit, atlas, ectrans, fckit, fiat

### DIFF
--- a/var/spack/repos/builtin/packages/eckit/package.py
+++ b/var/spack/repos/builtin/packages/eckit/package.py
@@ -20,6 +20,8 @@ class Eckit(CMakePackage):
 
     license("Apache-2.0")
 
+    version("1.28.3", sha256="24b2b8d9869849a646aa3fd9d95e4181a92358cd837d95b22e25d718a6ad7738")
+    version("1.28.2", sha256="d122db8bb5bcaadf3256a24f0f90d9bcedad35ef8f25e7eccd8c93c506dbdd24")
     version("1.27.0", sha256="499f3f8c9aec8d3f42369e3ceedc98b2b09ac04993cfd38dfdf7d38931703fe7")
     version("1.25.2", sha256="a611d26d50a9f2133b75100567a890eb0e0a48a96669b8c8475baf9d6f359397")
     version("1.24.5", sha256="2fd74e04c20a59f9e13635828d9da880e18f8a2cb7fd3bfd0201e07071d6ec41")

--- a/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
+++ b/var/spack/repos/builtin/packages/ecmwf-atlas/package.py
@@ -22,6 +22,8 @@ class EcmwfAtlas(CMakePackage):
 
     version("master", branch="master")
     version("develop", branch="develop")
+    version("0.40.0", sha256="9aa2c8945a04aff3d50f752147e2b7cf0992c33e7e5a0e7bcd6fe575b0f853b0")
+    version("0.39.0", sha256="bdfc37b5f3f871651b1bb47ae4742988b03858037e36fdca775e220e3abe3bd6")
     version("0.38.1", sha256="c6868deb483c1d6c241aae92f8af63f3351062c2611c9163e8a9bbf6c97a9798")
     version("0.38.0", sha256="befe3bfc045bc0783126efb72ed55db9f205eaf176e1b8a2059eaaaaacc4880a")
     version("0.36.0", sha256="39bf748aa7b22df80b9791fbb6b4351ed9a9f85587b58fc3225314278a2a68f8")

--- a/var/spack/repos/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/builtin/packages/ectrans/package.py
@@ -23,6 +23,8 @@ class Ectrans(CMakePackage):
 
     version("develop", branch="develop", no_cache=True)
     version("main", branch="main", no_cache=True)
+    version("1.5.0", sha256="8b2b24d1988b92dc3793b29142946614fca9e9c70163ee207d2a123494430fde")
+    version("1.4.0", sha256="1364827511a2eb11716aaee85062c3ab0e6b5d5dca7a7b9c364e1c43482b8691")
     version("1.2.0", sha256="2ee6dccc8bbfcc23faada1d957d141f24e41bb077c1821a7bc2b812148dd336c")
     version("1.1.0", sha256="3c9848bb65033fbe6d791084ee347b3adf71d5dfe6d3c11385000017b6469a3e")
 

--- a/var/spack/repos/builtin/packages/fckit/package.py
+++ b/var/spack/repos/builtin/packages/fckit/package.py
@@ -22,6 +22,8 @@ class Fckit(CMakePackage):
 
     version("master", branch="master")
     version("develop", branch="develop")
+    version("0.13.2", sha256="990623eb4eb999145f2d852da9fbd71a69e2e0be601c655c274e8382750dfda2")
+    version("0.13.1", sha256="89a067a7b5b1f2c7909739b567bd43b69f8a2d91e8cbcbac58655fb2d861db51")
     version("0.11.0", sha256="846f5c369940c0a3d42cd12932f7d6155339e79218d149ebbfdd02e759dc86c5")
     version("0.10.1", sha256="9cde04fefa50624bf89068ab793cc2e9437c0cd1c271a41af7d54dbd37c306be")
     version("0.10.0", sha256="f16829f63a01cdef5e158ed2a51f6d4200b3fe6dce8f251af158141a1afe482b")

--- a/var/spack/repos/builtin/packages/fiat/package.py
+++ b/var/spack/repos/builtin/packages/fiat/package.py
@@ -19,6 +19,8 @@ class Fiat(CMakePackage):
     license("Apache-2.0")
 
     version("main", branch="main", no_cache=True)
+    version("1.4.1", sha256="7d49316150e59afabd853df0066b457a268731633898ab51f6f244569679c84a")
+    version("1.4.0", sha256="5dc5a8bcac5463690529d0d96d2c805cf9c0214d125cd483ee69d36995ff15d3")
     version("1.2.0", sha256="758147410a4a3c493290b87443b4091660b915fcf29f7c4d565c5168ac67745f")
     version("1.1.0", sha256="58354e60d29a1b710bfcea9b87a72c0d89c39182cb2c9523ead76a142c695f82")
     version("1.0.0", sha256="45afe86117142831fdd61771cf59f31131f2b97f52a2bd04ac5eae9b2ab746b8")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR upgrades the version specs for the following ECMWF packages. These include the latest tag versions plus the next to the latest tag versions as of 11/22/24.
- ecmwf-atlas
- ectrans
- eckit
- fckit
- fiat

These changes are being added to help resolve: https://github.com/JCSDA/spack-stack/issues/1340