### PR TITLE
ip: add cmake version requirement for @5.1:

### DIFF
--- a/var/spack/repos/builtin/packages/ip/package.py
+++ b/var/spack/repos/builtin/packages/ip/package.py
@@ -70,6 +70,7 @@ class Ip(CMakePackage):
     depends_on("sp precision=d", when="@4.1:4 precision=d")
     depends_on("sp precision=8", when="@4.1:4 precision=8")
     depends_on("lapack", when="@5.1:")
+    depends_on("cmake@3.18:", when="@5.1:")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
This PR adds a requirement of cmake@3.18: for ip@5.1:. ip@5.1: uses the LAPACK::LAPACK CMake target, which is only available in cmake@3.18:.