### PR TITLE
gromacs: Add itt variant

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -300,7 +300,8 @@ class Gromacs(CMakePackage, CudaPackage):
         "itt",
         default=False,
         when="@2024:",
-        description="Enable Instrumentation and Tracing Technology (ITT) profiling API (from Intel)",
+        description="Enable Instrumentation and Tracing Technology (ITT)"
+        + " profiling API (from Intel)",
     )
     depends_on("intel-oneapi-vtune", "+itt")
 

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -297,12 +297,12 @@ class Gromacs(CMakePackage, CudaPackage):
     )
 
     variant(
-        "intel_itt",
+        "itt",
         default=False,
         when="@2024:",
-        description="Enable Instrumentation and Tracing Technology (ITT) profiling API",
+        description="Enable Instrumentation and Tracing Technology (ITT) profiling API (from Intel)",
     )
-    depends_on("intel-oneapi-vtune", "+intel_itt")
+    depends_on("intel-oneapi-vtune", "+itt")
 
     depends_on("fftw-api@3")
     depends_on("cmake@2.8.8:3", type="build")
@@ -622,7 +622,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             options.append("-DGMX_GPU_NB_CLUSTER_SIZE=8")
             options.append("-DGMX_GPU_NB_NUM_CLUSTER_PER_CELL_X=1")
 
-        if "+intel_itt" in self.spec:
+        if "+itt" in self.spec:
             options.append("-DGMX_USE_ITT=on")
             options.append(
                 "-DITTNOTIFY_INCLUDE_DIR=%s"

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -296,6 +296,14 @@ class Gromacs(CMakePackage, CudaPackage):
         + "The g++ location is written to icp{c,x}.cfg",
     )
 
+    variant(
+        "intel_itt",
+        default=False,
+        when="@2024:",
+        description="Enable Instrumentation and Tracing Technology (ITT) profiling API",
+        )
+    depends_on("intel-oneapi-vtune", "+intel_itt")
+
     depends_on("fftw-api@3")
     depends_on("cmake@2.8.8:3", type="build")
     depends_on("cmake@3.4.3:3", type="build", when="@2018:")
@@ -613,6 +621,11 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
         if self.spec.satisfies("+intel-data-center-gpu-max"):
             options.append("-DGMX_GPU_NB_CLUSTER_SIZE=8")
             options.append("-DGMX_GPU_NB_NUM_CLUSTER_PER_CELL_X=1")
+
+        if "+intel_itt" in self.spec:
+            options.append("-DGMX_USE_ITT=on")
+            options.append("-DITTNOTIFY_INCLUDE_DIR=%s" %
+                           join_path(self.spec["intel-oneapi-vtune"].package.headers))
 
         if self.spec.satisfies("~nblib"):
             options.append("-DGMX_INSTALL_NBLIB_API=OFF")

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -301,7 +301,7 @@ class Gromacs(CMakePackage, CudaPackage):
         default=False,
         when="@2024:",
         description="Enable Instrumentation and Tracing Technology (ITT) profiling API",
-        )
+    )
     depends_on("intel-oneapi-vtune", "+intel_itt")
 
     depends_on("fftw-api@3")
@@ -624,8 +624,10 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
 
         if "+intel_itt" in self.spec:
             options.append("-DGMX_USE_ITT=on")
-            options.append("-DITTNOTIFY_INCLUDE_DIR=%s" %
-                           join_path(self.spec["intel-oneapi-vtune"].package.headers))
+            options.append(
+                "-DITTNOTIFY_INCLUDE_DIR=%s"
+                % join_path(self.spec["intel-oneapi-vtune"].package.headers)
+            )
 
         if self.spec.satisfies("~nblib"):
             options.append("-DGMX_INSTALL_NBLIB_API=OFF")


### PR DESCRIPTION
Permit configuring GROMACS with support for mdrun to trace its timing regions by calling the ITT API. This permits tools like VTune and unitrace to augment their analysis with GROMACS-specific annotation.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
