### PR TITLE
gobject-introspection: Python 3.12 still not supported

### DIFF
--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -92,6 +92,12 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
         when="@:1.63.1",
     )
 
+    # https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/361
+    # https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/395
+    conflicts(
+        "^python@3.12:",
+        msg="gobject-introspection still uses distutils which was removed in Python 3.12",
+    )
     conflicts(
         "^python@3.11:",
         when="@:1.60",


### PR DESCRIPTION
Give them a few more years and they might catch up to 2022.