### PR TITLE
py-pytz: add v2024.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-pytz/package.py
+++ b/var/spack/repos/builtin/packages/py-pytz/package.py
@@ -15,6 +15,7 @@ class PyPytz(PythonPackage):
 
     license("MIT")
 
+    version("2024.2", sha256="2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a")
     version("2023.3", sha256="1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588")
     version("2022.2.1", sha256="cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5")
     version("2021.3", sha256="acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326")


### PR DESCRIPTION
Previous version has deprecation warnings in Python 3.13