### PR TITLE
Add tools variant in caliper

### DIFF
--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -101,6 +101,8 @@ class Caliper(CachedCMakePackage, CudaPackage, ROCmPackage):
     variant("vtune", default=False, description="Enable Intel Vtune support")
     variant("kokkos", default=True, when="@2.3.0:", description="Enable Kokkos profiling support")
     variant("tests", default=False, description="Enable tests")
+    variant("tools", default=True, description="Enable tools")
+
     # TODO change the 'when' argument for the next release of Caliper
     variant("python", default=False, when="@master", description="Build Python bindings")
 
@@ -156,6 +158,7 @@ class Caliper(CachedCMakePackage, CudaPackage, ROCmPackage):
 
         entries.append(cmake_cache_option("BUILD_SHARED_LIBS", spec.satisfies("+shared")))
         entries.append(cmake_cache_option("BUILD_TESTING", spec.satisfies("+tests")))
+        entries.append(cmake_cache_option("WITH_TOOLS", spec.satisfies("+tools")))
         entries.append(cmake_cache_option("BUILD_DOCS", False))
         entries.append(cmake_cache_path("PYTHON_EXECUTABLE", spec["python"].command.path))
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This pull request includes updates to the `caliper` package to add a new variant for enabling tools support. Note that tools support is currently enabled by default in caliper's `CMakeLists`