### PR TITLE
Hypre blas lapack

### DIFF
--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -74,8 +74,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
     variant(
         "superlu-dist", default=False, description="Activates support for SuperLU_Dist library"
     )
-    variant("blas", default=False, description="Use external blas")
-    variant("lapack", default=False, description="Use external lapack")
+    variant("lapack", default=False, description="Use external blas/lapack")
     variant("int64", default=False, description="Use 64bit integers")
     variant("mixedint", default=False, description="Use 64bit integers while reducing memory use")
     variant("complex", default=False, description="Use complex values")
@@ -125,7 +124,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
         filter_file("\tmake", "\t$(MAKE)", "src/seq_mv/Makefile")
 
     depends_on("mpi", when="+mpi")
-    depends_on("blas", when="+blas")
+    depends_on("blas", when="+lapack")
     depends_on("lapack", when="+lapack")
     depends_on("magma", when="+magma")
     depends_on("superlu-dist", when="+superlu-dist+mpi")
@@ -203,16 +202,14 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
         configure_args = [f"--prefix={prefix}"]
 
         # Note: --with-(lapack|blas)_libs= needs space separated list of names
-        if spec.satisfies("+blas"):
-            configure_args.append("--with-blas-libs=%s" % " ".join(spec["blas"].libs.names))
-            configure_args.append(
-                "--with-blas-lib-dirs=%s" % " ".join(spec["blas"].libs.directories)
-            )
-
         if spec.satisfies("+lapack"):
             configure_args.append("--with-lapack-libs=%s" % " ".join(spec["lapack"].libs.names))
+            configure_args.append("--with-blas-libs=%s" % " ".join(spec["blas"].libs.names))
             configure_args.append(
                 "--with-lapack-lib-dirs=%s" % " ".join(spec["lapack"].libs.directories)
+            )
+            configure_args.append(
+                "--with-blas-lib-dirs=%s" % " ".join(spec["blas"].libs.directories)
             )
 
         if spec.satisfies("+mpi"):

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -74,6 +74,8 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
     variant(
         "superlu-dist", default=False, description="Activates support for SuperLU_Dist library"
     )
+    variant("blas", default=False, description="Use external blas")
+    variant("lapack", default=False, description="Use external lapack")
     variant("int64", default=False, description="Use 64bit integers")
     variant("mixedint", default=False, description="Use 64bit integers while reducing memory use")
     variant("complex", default=False, description="Use complex values")
@@ -123,8 +125,8 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
         filter_file("\tmake", "\t$(MAKE)", "src/seq_mv/Makefile")
 
     depends_on("mpi", when="+mpi")
-    depends_on("blas")
-    depends_on("lapack")
+    depends_on("blas", when="+blas")
+    depends_on("lapack", when="+lapack")
     depends_on("magma", when="+magma")
     depends_on("superlu-dist", when="+superlu-dist+mpi")
     depends_on("rocsparse", when="+rocm")
@@ -198,17 +200,16 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     def configure_args(self):
         spec = self.spec
-        # Note: --with-(lapack|blas)_libs= needs space separated list of names
-        lapack = spec["lapack"].libs
-        blas = spec["blas"].libs
+        configure_args = [f"--prefix={prefix}"]
 
-        configure_args = [
-            "--prefix=%s" % prefix,
-            "--with-lapack-libs=%s" % " ".join(lapack.names),
-            "--with-lapack-lib-dirs=%s" % " ".join(lapack.directories),
-            "--with-blas-libs=%s" % " ".join(blas.names),
-            "--with-blas-lib-dirs=%s" % " ".join(blas.directories),
-        ]
+        # Note: --with-(lapack|blas)_libs= needs space separated list of names
+        if spec.satisfies("+blas"):
+            configure_args.append("--with-blas-libs=%s" % " ".join(spec["blas"].libs.names))
+            configure_args.append("--with-blas-lib-dirs=%s" % " ".join(spec["blas"].libs.directories))
+
+        if spec.satisfies("+lapack"):
+            configure_args.append("--with-lapack-libs=%s" % " ".join(spec["lapack"].libs.names))
+            configure_args.append("--with-lapack-lib-dirs=%s" % " ".join(spec["lapack"].libs.directories))
 
         if spec.satisfies("+mpi"):
             os.environ["CC"] = spec["mpi"].mpicc

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -251,7 +251,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
             configure_args.append("--without-mli")
             # FEI option was removed in hypre 2.17
             if self.version < Version("2.17.0"):
-               configure_args.append("--without-fei")
+                configure_args.append("--without-fei")
 
         if spec.satisfies("+superlu-dist"):
             configure_args.append(

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -19,7 +19,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
     git = "https://github.com/hypre-space/hypre.git"
     tags = ["e4s", "radiuss"]
 
-    maintainers("ulrikeyang", "osborn9", "balay")
+    maintainers("ulrikeyang", "osborn9", "victorapm", "balay")
 
     test_requires_compiler = True
 

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -203,6 +203,8 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
 
         # Note: --with-(lapack|blas)_libs= needs space separated list of names
         if spec.satisfies("+lapack"):
+            configure_args.append("--with-lapack")
+            configure_args.append("--with-blas")
             configure_args.append("--with-lapack-libs=%s" % " ".join(spec["lapack"].libs.names))
             configure_args.append("--with-blas-libs=%s" % " ".join(spec["blas"].libs.names))
             configure_args.append(
@@ -247,7 +249,9 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
             configure_args.append("--without-superlu")
             # MLI and FEI do not build without superlu on Linux
             configure_args.append("--without-mli")
-            configure_args.append("--without-fei")
+            # FEI option was removed in hypre 2.17
+            if self.version < Version("2.17.0"):
+               configure_args.append("--without-fei")
 
         if spec.satisfies("+superlu-dist"):
             configure_args.append(

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -74,7 +74,7 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
     variant(
         "superlu-dist", default=False, description="Activates support for SuperLU_Dist library"
     )
-    variant("lapack", default=False, description="Use external blas/lapack")
+    variant("lapack", default=True, description="Use external blas/lapack")
     variant("int64", default=False, description="Use 64bit integers")
     variant("mixedint", default=False, description="Use 64bit integers while reducing memory use")
     variant("complex", default=False, description="Use complex values")

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -205,11 +205,15 @@ class Hypre(AutotoolsPackage, CudaPackage, ROCmPackage):
         # Note: --with-(lapack|blas)_libs= needs space separated list of names
         if spec.satisfies("+blas"):
             configure_args.append("--with-blas-libs=%s" % " ".join(spec["blas"].libs.names))
-            configure_args.append("--with-blas-lib-dirs=%s" % " ".join(spec["blas"].libs.directories))
+            configure_args.append(
+                "--with-blas-lib-dirs=%s" % " ".join(spec["blas"].libs.directories)
+            )
 
         if spec.satisfies("+lapack"):
             configure_args.append("--with-lapack-libs=%s" % " ".join(spec["lapack"].libs.names))
-            configure_args.append("--with-lapack-lib-dirs=%s" % " ".join(spec["lapack"].libs.directories))
+            configure_args.append(
+                "--with-lapack-lib-dirs=%s" % " ".join(spec["lapack"].libs.directories)
+            )
 
         if spec.satisfies("+mpi"):
             os.environ["CC"] = spec["mpi"].mpicc

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -697,8 +697,10 @@ class Mfem(Package, CudaPackage, ROCmPackage):
         if "+mpi" in spec:
             options += ["MPICXX=%s" % spec["mpi"].mpicxx]
             hypre = spec["hypre"]
-            # The hypre package always links with 'blas' and 'lapack'.
-            all_hypre_libs = hypre.libs + hypre["lapack"].libs + hypre["blas"].libs
+            all_hypre_libs = hypre.libs
+            if "+lapack" in spec:
+                all_hypre_libs += spec["lapack"].libs + spec["blas"].libs
+
             hypre_gpu_libs = ""
             if "+cuda" in hypre:
                 hypre_gpu_libs = " -lcusparse -lcurand -lcublas"

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -698,8 +698,8 @@ class Mfem(Package, CudaPackage, ROCmPackage):
             options += ["MPICXX=%s" % spec["mpi"].mpicxx]
             hypre = spec["hypre"]
             all_hypre_libs = hypre.libs
-            if "+lapack" in spec:
-                all_hypre_libs += spec["lapack"].libs + spec["blas"].libs
+            if "+lapack" in hypre:
+                all_hypre_libs += hypre["lapack"].libs + hypre["blas"].libs
 
             hypre_gpu_libs = ""
             if "+cuda" in hypre:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Updated the Hypre package to improve flexibility by adding blas and lapack variants, allowing users to link external BLAS/LAPACK implementations. By default, Hypre uses its own distribution of these libraries. Also, added myself as a maintainer.