### PR TITLE
hip: hints for find_package llvm/clang

### DIFF
--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -531,12 +531,6 @@ class Hip(CMakePackage):
                 "clr/hipamd/hip-config-amd.cmake",
                 string=True,
             )
-            filter_file(
-                '"${ROCM_PATH}/llvm"',
-                self.spec["llvm-amdgpu"].prefix,
-                "clr/hipamd/src/hiprtc/CMakeLists.txt",
-                string=True,
-            )
         perl = self.spec["perl"].command
 
         if self.spec.satisfies("@:5.5"):
@@ -561,7 +555,12 @@ class Hip(CMakePackage):
                     filter_file(" -lnuma", f" -L{numactl} -lnuma", "hipBin_amd.h")
 
     def cmake_args(self):
-        args = []
+        args = [
+            # find_package(Clang) and find_package(LLVM) in clr/hipamd/src/hiprtc/CMakeLists.txt
+            # should find llvm-amdgpu
+            self.define("LLVM_ROOT", self.spec["llvm-amdgpu"].prefix),
+            self.define("Clang_ROOT", self.spec["llvm-amdgpu"].prefix),
+        ]
         if self.spec.satisfies("+rocm"):
             args.append(self.define("HSA_PATH", self.spec["hsa-rocr-dev"].prefix))
             args.append(self.define("HIP_COMPILER", "clang"))


### PR DESCRIPTION
Closes #42417

`llvm` can be a transitive link dependency of `hip` through `gl`'s dependency `mesa`, which uses it for software rendering. `llvm` is upstream LLVM, whereas `llvm-amdgpu` is a fork.

In case of two LLVMs make sure `llvm-amdgpu` is found by `find_package(LLVM)` and `find_package(Clang)` by setting `LLVM_ROOT` and `Clang_ROOT` resp.

That makes the original patch of `find_package`'s `HINTS` redundant, so remove that. It did not work anyways, because `CMAKE_PREFIX_PATH` has higher precedence than `HINTS` and `PATHS`.

An alternative would be to specify in hip that it depends on `libllvm`, so that there can only be one LLVM in the dag (namely `llvm-amdgpu`). But I think that's technically incorrect, since afaik `hip` does not link to `libllvm`, not even for hiprtc.