### PR TITLE
mapl: add hpcx-mpi

### DIFF
--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -383,6 +383,7 @@ class Mapl(CMakePackage):
         # - MVAPICH --> mvapich
         # - HPE MPT --> mpt
         # - Cray MPICH --> mpich
+        # - HPC-X --> openmpi
 
         if self.spec.satisfies("^mpich"):
             args.append(self.define("MPI_STACK", "mpich"))
@@ -398,6 +399,8 @@ class Mapl(CMakePackage):
             args.append(self.define("MPI_STACK", "mpt"))
         elif self.spec.satisfies("^cray-mpich"):
             args.append(self.define("MPI_STACK", "mpich"))
+        elif self.spec.satisfies("^hpcx-mpi"):
+            args.append(self.define("MPI_STACK", "openmpi"))
         else:
             raise InstallError("Unsupported MPI stack")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

As found by a user on Azure, the ugly `MPI_STACK` bits I have were not handling HPC-X correctly. This PR tells the MAPL build that HPC-X is to treated as Open MPI.