### PR TITLE
gromacs: fix the value used for the ITT directory

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -27,6 +27,7 @@ class Gromacs(CMakePackage, CudaPackage):
     url = "https://ftp.gromacs.org/gromacs/gromacs-2022.2.tar.gz"
     list_url = "https://ftp.gromacs.org/gromacs"
     git = "https://gitlab.com/gromacs/gromacs.git"
+
     maintainers("mabraham", "eirrgang", "junghans")
 
     license("GPL-2.0-or-later", when="@:4.5")
@@ -627,7 +628,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             options.append("-DGMX_USE_ITT=on")
             options.append(
                 "-DITTNOTIFY_INCLUDE_DIR=%s"
-                % join_path(self.spec["intel-oneapi-vtune"].package.headers)
+                % self.spec["intel-oneapi-vtune"].package.headers.directories[0]
             )
 
         if self.spec.satisfies("~nblib"):


### PR DESCRIPTION
In the end the first comment here was correct https://github.com/spack/spack/pull/47764#discussion_r1856395556 Apologies for merging too quickly without double checking. 

Without this PR:
```
'-DGMX_USE_ITT=on' '-DITTNOTIFY_INCLUDE_DIR='
```
With this PR:
```
'-DGMX_USE_ITT=on' '-DITTNOTIFY_INCLUDE_DIR=/home/culpo/PycharmProjects/spack/opt/spack/linux-ubuntu20.04-icelake/gcc-10.5.0/intel-oneapi-vtune-2025.0.1-o6q2ihfgiu4olrt2mfho6cbfgg4txtex/vtune/2025.0/sdk/include'
```
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
