### PR TITLE
config: code default for build_stage

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -672,11 +672,12 @@ class Configuration:
             return
 
         parts = process_config_path(path)
-        section = parts.pop(0)
+        section = parts[0]
 
         section_data = self.get_config(section, scope=scope)
 
-        data = section_data
+        full_data = {section: section_data}
+        data = full_data
         while len(parts) > 1:
             key = parts.pop(0)
 
@@ -699,7 +700,7 @@ class Configuration:
         # update new value
         data[parts[0]] = value
 
-        self.update_config(section, section_data, scope=scope)
+        self.update_config(section, full_data[section], scope=scope)
 
     def __iter__(self):
         """Iterate over scopes in this configuration."""

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -176,13 +176,14 @@ def _resolve_paths(candidates):
 
 # Cached stage path root
 _stage_root = None
+_default_stage_config = ["$tmpdir/$user/spack-stage", "$user_cache_path/stage"]
 
 
 def get_stage_root():
     global _stage_root
 
     if _stage_root is None:
-        candidates = spack.config.get("config:build_stage")
+        candidates = spack.config.get("config:build_stage", _default_stage_config)
         if isinstance(candidates, str):
             candidates = [candidates]
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1208,8 +1208,16 @@ def test_internal_config_list_override(mock_low_high_config, write_config_file):
 def test_set_section_override(mock_low_high_config, write_config_file):
     write_config_file("config", config_merge_list, "low")
     wanted_list = config_override_list["config"]["build_stage:"]
+
+    # Ensure test validity:
+    assert wanted_list != mock_low_high_config.get("config:build_stage")
+
+    # Test both bare section with full value and section override in path
     with spack.config.override("config::build_stage", wanted_list):
         assert mock_low_high_config.get("config:build_stage") == wanted_list
+    with spack.config.override("config::", {"build_stage": wanted_list}):
+        assert mock_low_high_config.get("config:build_stage") == wanted_list
+
     assert config_merge_list["config"]["build_stage"] == mock_low_high_config.get(
         "config:build_stage"
     )

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -754,6 +754,17 @@ class TestStage:
         # Make sure the cached stage path values are unchanged.
         assert spack.stage._stage_root is None
 
+    def test_get_stage_root_empty(self, clear_stage_root):
+        # build stage set to empty by user is respected and errors
+        with spack.config.override("config:build_stage::", []):
+            with pytest.raises(spack.stage.StageError):
+                spack.stage.get_stage_root()
+
+        # No build stage set (config section set to empty) uses default
+        expected = spack.stage._resolve_paths(spack.stage._default_stage_config)[0]
+        with spack.config.override("config::", {}):
+            assert spack.stage.get_stage_root() == expected
+
     @pytest.mark.parametrize(
         "path,purged",
         [

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -754,14 +754,15 @@ class TestStage:
         # Make sure the cached stage path values are unchanged.
         assert spack.stage._stage_root is None
 
-    def test_get_stage_root_empty(self, clear_stage_root):
+    def test_get_stage_root_empty(self, clear_stage_root, monkeypatch, tmpdir):
+        expected = str(tmpdir)
+        monkeypatch.setattr(spack.stage, "_default_stage_config", [expected])
         # build stage set to empty by user is respected and errors
         with spack.config.override("config:build_stage::", []):
             with pytest.raises(spack.stage.StageError):
                 spack.stage.get_stage_root()
 
         # No build stage set (config section set to empty) uses default
-        expected = spack.stage._resolve_paths(spack.stage._default_stage_config)[0]
         with spack.config.override("config::", {}):
             assert spack.stage.get_stage_root() == expected
 


### PR DESCRIPTION
Fixes #43019

Bug description: iteration error when `config:: {}` set in config section due to unset `config:build_stage` value expected to be iterable.

In process of testing this PR it was necessary to fix another bug in `config.set` that prevented overrides on section names like `spack.config.set("config::", {})`.

Both bugfixes have regression tests.