### PR TITLE
gromacs: Improve HeFFTe dependency

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -114,9 +114,11 @@ class Gromacs(CMakePackage, CudaPackage):
     variant(
         "heffte",
         default=False,
-        when="@2021: +sycl+mpi",
+        when="@2021: +mpi",
         description="Enable multi-GPU FFT support with HeFFTe",
     )
+    depends_on("heffte +cuda", when="+heffte +cuda")
+    depends_on("heffte +sycl", when="+heffte +sycl")
     variant("opencl", default=False, description="Enable OpenCL support")
     variant("sycl", default=False, when="@2021: %clang", description="Enable SYCL support")
     variant(


### PR DESCRIPTION
GROMACS supports HeFFTe with either SYCL or CUDA build and requires a matching HeFFTe build

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
