### PR TITLE
darwin: preserve hardlinks on codesign/install_name_tool

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2848,12 +2848,13 @@ def edit_in_place_through_temporary_file(file_path: str) -> Generator[str, None,
     tmp_fd, tmp_path = tempfile.mkstemp(
         dir=os.path.dirname(file_path), prefix=f"{os.path.basename(file_path)}."
     )
+    # windows cannot replace a file with open fds, so close since the call site needs to replace.
+    os.close(tmp_fd)
     try:
         shutil.copyfile(file_path, tmp_path, follow_symlinks=True)
         yield tmp_path
         shutil.copyfile(tmp_path, file_path, follow_symlinks=True)
     finally:
-        os.close(tmp_fd)
         os.unlink(tmp_path)
 
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -2852,6 +2852,7 @@ def edit_in_place_through_temporary_file(file_path: str) -> Generator[str, None,
     try:
         with open(file_path, "rb") as f, os.fdopen(tmp_fd, "wb", closefd=False) as g:
             shutil.copyfileobj(f, g)
+            g.flush()
         yield tmp_path
         with open(tmp_path, "rb") as g, open(file_path, "wb") as f:
             shutil.copyfileobj(g, f)

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -1249,3 +1249,14 @@ def test_find_input_types(tmp_path: pathlib.Path):
 
     with pytest.raises(TypeError):
         fs.find(1, "file.txt")  # type: ignore
+
+
+def test_edit_in_place_through_temporary_file(tmp_path):
+    (tmp_path / "example.txt").write_text("Hello")
+    current_ino = os.stat(tmp_path / "example.txt").st_ino
+    with fs.edit_in_place_through_temporary_file(tmp_path / "example.txt") as temporary:
+        os.unlink(temporary)
+        with open(temporary, "w") as f:
+            f.write("World")
+    assert (tmp_path / "example.txt").read_text() == "World"
+    assert os.stat(tmp_path / "example.txt").st_ino == current_ino


### PR DESCRIPTION
closes #47691 

`codesign` and `install_name_tool` create a new inodes, which breaks hardlinks. So instead run it on a file copy and copy contents back to the original file.