### PR TITLE
py-pyvista: VTK 9.4 not yet supported

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyvista/package.py
+++ b/var/spack/repos/builtin/packages/py-pyvista/package.py
@@ -33,7 +33,8 @@ class PyPyvista(PythonPackage):
     depends_on("pil", type=("build", "run"))
     depends_on("py-pooch", when="@0.37:", type=("build", "run"))
     depends_on("py-scooby@0.5.1:", type=("build", "run"))
-    depends_on("vtk+python", type=("build", "run"))
+    # https://github.com/pyvista/pyvista/issues/6857
+    depends_on("vtk@:9.3+python", type=("build", "run"))
     depends_on("py-typing-extensions", when="^python@:3.7", type=("build", "run"))
 
     # Historical dependencies


### PR DESCRIPTION
Let's denote this before someone adds VTK 9.4.