### PR TITLE
xz: add v5.6.3 and v5.4.7

### DIFF
--- a/var/spack/repos/builtin/packages/libxml2/lzma_naming.patch
+++ b/var/spack/repos/builtin/packages/libxml2/lzma_naming.patch
@@ -1,0 +1,16 @@
+diff --git a/win32/Makefile.msvc b/win32/Makefile.msvc
+index 80e64e2..09e0249 100644
+--- a/win32/Makefile.msvc
++++ b/win32/Makefile.msvc
+@@ -82,7 +82,10 @@ LIBS = $(LIBS) icuuc.lib icuin.lib icudt.lib
+ LIBS = $(LIBS) zlib.lib
+ !endif
+ !if "$(WITH_LZMA)" == "1"
+-LIBS = $(LIBS) liblzma.lib
++!ifndef LIBLZMA
++LIBLZMA = liblzma.lib
++!endif
++LIBS = $(LIBS) $(LIBLZMA)
+ !endif
+ !if "$(WITH_THREADS)" == "posix"
+ LIBS = $(LIBS) pthreadVC.lib

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -106,6 +106,11 @@ class Libxml2(AutotoolsPackage, NMakePackage):
         sha256="5dc43fed02b443d2563a502a52caafe39477c06fc30b70f786d5ed3eb5aea88d",
         when="@2.9.11:2.9.14",
     )
+
+    # XZ is named liblzma or lzma on Windows depending on build parameters, libxml2s
+    # NMake build systems needs to be adapted to handle this
+    patch("lzma_naming.patch", when="platform=windows build_system=nmake")
+
     build_system(conditional("nmake", when="platform=windows"), "autotools", default="autotools")
 
     def flag_handler(self, name, flags):
@@ -300,4 +305,9 @@ class NMakeBuilder(AnyBuilder, nmake.NMakeBuilder):
                 opts.append("python=yes")
             if spec.satisfies("+http"):
                 opts.append("http=yes")
+            if spec["xz"].satisfies("build_system=cmake"):
+                lzma_name = "lzma.lib"
+            else:
+                lzma_name = "liblzma.lib"
+            opts += [f"LIBLZMA={lzma_name}"]
             cscript("configure.js", *opts)

--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -93,7 +93,7 @@ class Xz(MSBuildPackage, AutotoolsPackage, CMakePackage, SourceforgePackage):
     @property
     def libs(self):
         return find_libraries(
-            ["liblzma"],
+            ["liblzma", "lzma"],
             root=self.prefix,
             recursive=True,
             shared=self.spec.satisfies("libs=shared"),

--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -44,7 +44,7 @@ class Xz(MSBuildPackage, AutotoolsPackage, SourceforgePackage):
     version("5.2.1", sha256="679148f497e0bff2c1adce42dee5a23f746e71321c33ebb0f641a302e30c2a80")
     version("5.2.0", sha256="f7357d7455a1670229b3cca021da71dd5d13b789db62743c20624bdffc9cc4a5")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     variant("pic", default=False, description="Compile with position independent code.")
 

--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -70,7 +70,6 @@ class Xz(MSBuildPackage, AutotoolsPackage, CMakePackage, SourceforgePackage):
     conflicts("platform=windows", when="+pic")  # no pic on Windows
     # prior to 5.2.3, build system is for MinGW only, not currently supported by Spack
     conflicts("platform=windows", when="@:5.2.3")
-    conflicts("platform=windows", when="@5.6:")  # CMake is required
 
     patch(
         "nvhpc.patch",

--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -7,8 +7,8 @@ import os
 import re
 
 from spack.build_systems.autotools import AutotoolsBuilder
-from spack.build_systems.msbuild import MSBuildBuilder
 from spack.build_systems.cmake import CMakeBuilder
+from spack.build_systems.msbuild import MSBuildBuilder
 from spack.package import *
 
 
@@ -78,8 +78,12 @@ class Xz(MSBuildPackage, AutotoolsPackage, CMakePackage, SourceforgePackage):
         sha256="32228638c462651ec7dedab706d05aa352995f064ace2dee915f31c75cc995c0",
     )
 
-    build_system(conditional("msbuild", when="platform=windows"), "autotools", default="autotools")
-    build_system(conditional("msbuild", when="@:5.4.7 platform=windows"), conditional("cmake", when="@5.4.7:"), "autotools", default="autotools")
+    build_system(
+        conditional("msbuild", when="@:5.4.7 platform=windows"),
+        conditional("cmake", when="@5.4.7:"),
+        "autotools",
+        default="autotools",
+    )
 
     def flag_handler(self, name, flags):
         if name == "cflags" and "+pic" in self.spec:
@@ -116,7 +120,7 @@ class CMakeBuilder(CMakeBuilder):
     def cmake_args(self):
         build_shared = True if "shared" in self.spec else False
         return [self.define("BUILD_SHARED_LIBS", build_shared)]
-    
+
 
 class MSBuildBuilder(MSBuildBuilder):
     @property

--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -25,7 +25,14 @@ class Xz(MSBuildPackage, AutotoolsPackage, SourceforgePackage):
 
     executables = [r"^xz$"]
 
-    license("GPL-2.0-or-later AND Public-Domain AND LGPL-2.1-or-later", checked_by="tgamblin")
+    license(
+        "0BSD AND GPL-2.0-or-later AND LGPL-2.1-or-later", when="@5.6:", checked_by="drkrynstrng"
+    )
+    license(
+        "Public-Domain AND GPL-2.0-or-later AND LGPL-2.1-or-later",
+        when="@:5.4",
+        checked_by="tgamblin",
+    )
 
     version("5.6.3", sha256="a95a49147b2dbb5487517acc0adcd77f9c2032cf00664eeae352405357d14a6c")
     version("5.6.2", sha256="e12aa03cbd200597bd4ce11d97be2d09a6e6d39a9311ce72c91ac7deacde3171")

--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -8,10 +8,11 @@ import re
 
 from spack.build_systems.autotools import AutotoolsBuilder
 from spack.build_systems.msbuild import MSBuildBuilder
+from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
 
 
-class Xz(MSBuildPackage, AutotoolsPackage, SourceforgePackage):
+class Xz(MSBuildPackage, AutotoolsPackage, CMakePackage, SourceforgePackage):
     """XZ Utils is free general-purpose data compression software with
     high compression ratio. XZ Utils were written for POSIX-like systems,
     but also work on some not-so-POSIX systems. XZ Utils are the successor
@@ -78,6 +79,7 @@ class Xz(MSBuildPackage, AutotoolsPackage, SourceforgePackage):
     )
 
     build_system(conditional("msbuild", when="platform=windows"), "autotools", default="autotools")
+    build_system(conditional("msbuild", when="@:5.4.7 platform=windows"), conditional("cmake", when="@5.4.7:"), "autotools", default="autotools")
 
     def flag_handler(self, name, flags):
         if name == "cflags" and "+pic" in self.spec:
@@ -109,6 +111,12 @@ class AutotoolsBuilder(AutotoolsBuilder):
         if self.spec.satisfies("platform=darwin"):
             fix_darwin_install_name(self.prefix.lib)
 
+
+class CMakeBuilder(CMakeBuilder):
+    def cmake_args(self):
+        build_shared = True if "shared" in self.spec else False
+        return [self.define("BUILD_SHARED_LIBS", build_shared)]
+    
 
 class MSBuildBuilder(MSBuildBuilder):
     @property


### PR DESCRIPTION
Adding newer patch release v5.4.7 for xz.

Release notes for reference: https://github.com/tukaani-project/xz/releases/tag/v5.4.7

Also confirming c as a dependency.
