### PR TITLE
E4S: Allow building newer ParaView for Linux CI

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-rocm-external/spack.yaml
@@ -23,7 +23,7 @@ spack:
     paraview:
       # Don't build GUI support or GLX rendering for HPC/container deployments
       require:
-      - "@5.11 +examples ~qt ^[virtuals=gl] osmesa"
+      - "@5.11: +examples ~qt ^[virtuals=gl] osmesa"
       - 'target=x86_64_v3'
 
     # ROCm

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -61,8 +61,9 @@ spack:
     paraview:
       # Don't build GUI support or GLX rendering for HPC/container deployments
       require:
-      - "+examples ~qt ^[virtuals=gl] osmesa target=x86_64_v3"
-      - 'target=x86_64_v3 %gcc'
+      - "+examples"
+      - "~qt ^[virtuals=gl] osmesa" # Headless
+      - "target=x86_64_v3 %gcc"
 
   specs:
   # CPU

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -299,6 +299,8 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("zlib-api")
     depends_on("libcatalyst@2:", when="+libcatalyst")
     depends_on("hip@5.2:", when="+rocm")
+    # CUDA thrust is already include in the CUDA pkg
+    depends_on("rocthrust", when="@5.13: +rocm ^cmake@3.24:")
     for target in ROCmPackage.amdgpu_targets:
         depends_on(
             "kokkos@:3.7.01 +rocm amdgpu_target={0}".format(target),


### PR DESCRIPTION
5.11 was locked at a time when master was building by default. Allowing building newer paraview in CI

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
