### PR TITLE
mlpack: depends_on py-setuptools

### DIFF
--- a/var/spack/repos/builtin/packages/mlpack/package.py
+++ b/var/spack/repos/builtin/packages/mlpack/package.py
@@ -65,6 +65,8 @@ class Mlpack(CMakePackage):
         # ref: src/mlpack/bindings/python/PythonInstall.cmake
         depends_on("py-pip")
         depends_on("py-wheel")
+        # ref: src/mlpack/bindings/python/setup.py.in
+        depends_on("py-setuptools")
     with when("+r"):
         # ref: src/mlpack/bindings/R/CMakeLists.txt
         depends_on("r@4.0:")

--- a/var/spack/repos/builtin/packages/mlpack/package.py
+++ b/var/spack/repos/builtin/packages/mlpack/package.py
@@ -66,7 +66,7 @@ class Mlpack(CMakePackage):
         depends_on("py-pip")
         depends_on("py-wheel")
         # ref: src/mlpack/bindings/python/setup.py.in
-        depends_on("py-setuptools")
+        depends_on("py-setuptools", type="build")
     with when("+r"):
         # ref: src/mlpack/bindings/R/CMakeLists.txt
         depends_on("r@4.0:")


### PR DESCRIPTION
This PR adds to `mlpack` a dependency on `py-setuptools`, needed in https://github.com/mlpack/mlpack/blob/master/src/mlpack/bindings/python/setup.py.in#L23. Applies for all versions.

Test build (well, the last half of it anyway):
```
15:59:41 wdconinc@menelaos /tmp $ fg
command spack $_sp_flags $_sp_subcommand "$@"   (wd: ~/git/epic)
==> mlpack: Executing phase: 'install'
==> mlpack: Successfully installed mlpack-4.5.0-6fsrbd7mvlein6fy5d6xbwzptjqcfh6x
  Stage: 0.62s.  Cmake: 9.92s.  Build: 56m 26.22s.  Install: 49m 7.10s.  Post-install: 1.00s.  Total: 1h 45m 46.08s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/mlpack-4.5.0-6fsrbd7mvlein6fy5d6xbwzptjqcfh6x
```