### PR TITLE
hepmc3: extend python when the python bindings are enabled

### DIFF
--- a/var/spack/repos/builtin/packages/hepmc3/package.py
+++ b/var/spack/repos/builtin/packages/hepmc3/package.py
@@ -58,6 +58,8 @@ class Hepmc3(CMakePackage):
     conflicts("%gcc@9.3.0", when="@:3.1.1")
     patch("ba38f14d8f56c16cc4105d98f6d4540c928c6150.patch", when="@3.1.2:3.2.1 %gcc@9.3.0")
 
+    extends("python", when="+python")
+
     @property
     def libs(self):
         return find_libraries(["libHepMC3", "libHepMC3Search"], root=self.prefix, recursive=True)


### PR DESCRIPTION
Otherwise `PYTHONPATH` is not set and it is not possible to do `import pyHepMC3`