### PR TITLE
py-torch-sparse: add a dependency on c

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch-sparse/package.py
+++ b/var/spack/repos/builtin/packages/py-torch-sparse/package.py
@@ -21,7 +21,8 @@ class PyTorchSparse(PythonPackage):
     version("0.6.8", sha256="312fb5ae6e4e575fca4bbc0bd092af85e7679d5b8e53459f24492fc2a073c7b6")
     version("0.6.7", sha256="f69b2ed35baf2a9853234756a2b19e6f7ce88d2c1f029d1c7ca166d91e1adbd0")
 
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
 
     depends_on("py-setuptools", type="build")
     depends_on("py-scipy", type=("build", "run"))


### PR DESCRIPTION
Extracted from #45189

Build failure: https://gitlab.spack.io/spack/spack/-/jobs/13870876

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
