### PR TITLE
python: drop nis module also for < 3.13

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -254,7 +254,6 @@ class Python(Package):
     variant("ssl", default=True, description="Build ssl module")
     variant("sqlite3", default=True, description="Build sqlite3 module")
     variant("dbm", default=True, description="Build dbm module")
-    variant("nis", default=False, description="Build nis module")
     variant("zlib", default=True, description="Build zlib module")
     variant("bz2", default=True, description="Build bz2 module")
     variant("lzma", default=True, description="Build lzma module")
@@ -285,7 +284,12 @@ class Python(Package):
         # https://docs.python.org/3.10/whatsnew/3.10.html#build-changes
         depends_on("sqlite@3.7.15:", when="@3.10:+sqlite3")
         depends_on("gdbm", when="+dbm")  # alternatively ndbm or berkeley-db
-        depends_on("libnsl", when="+nis")
+        # nis module was removed in Python 3.13 and could not be disabled prior to that
+        with when("@:3.12"):
+            depends_on("libnsl", when="platform=linux")
+            depends_on("libnsl", when="platform=freebsd")
+            depends_on("libtirpc", when="platform=linux")
+            depends_on("libtirpc", when="platform=freebsd")
         depends_on("zlib-api", when="+zlib")
         depends_on("bzip2", when="+bz2")
         depends_on("xz libs=shared", when="+lzma")
@@ -387,7 +391,6 @@ class Python(Package):
             "readline",
             "sqlite3",
             "dbm",
-            "nis",
             "zlib",
             "bz2",
             "lzma",
@@ -786,10 +789,6 @@ class Python(Package):
             # Ensure that dbm module works
             if "+dbm" in spec:
                 self.command("-c", "import dbm")
-
-            # Ensure that nis module works
-            if "+nis" in spec:
-                self.command("-c", "import nis")
 
             # Ensure that zlib module works
             if "+zlib" in spec:

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -284,12 +284,6 @@ class Python(Package):
         # https://docs.python.org/3.10/whatsnew/3.10.html#build-changes
         depends_on("sqlite@3.7.15:", when="@3.10:+sqlite3")
         depends_on("gdbm", when="+dbm")  # alternatively ndbm or berkeley-db
-        # nis module was removed in Python 3.13 and could not be disabled prior to that
-        with when("@:3.12"):
-            depends_on("libnsl", when="platform=linux")
-            depends_on("libnsl", when="platform=freebsd")
-            depends_on("libtirpc", when="platform=linux")
-            depends_on("libtirpc", when="platform=freebsd")
         depends_on("zlib-api", when="+zlib")
         depends_on("bzip2", when="+bz2")
         depends_on("xz libs=shared", when="+lzma")
@@ -660,6 +654,12 @@ class Python(Package):
                     ),
                 ]
             )
+
+        # nis was removed in Python 3.13, and we disable it for all versions as it does not seemed
+        # to be used in general. There is not --disable-nis flag, so set an internal variable to
+        # the same effect.
+        if spec.satisfies("@:3.12"):
+            config_args.append("py_cv_module_nis=n/a")
 
         # https://docs.python.org/3.8/library/sqlite3.html#f1
         if spec.satisfies("+sqlite3 ^sqlite+dynamic_extensions"):

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -22,7 +22,7 @@ from spack.package import *
 from spack.util.prefix import Prefix
 
 
-def make_pyvenv_cfg(python_spec: "spack.spec.Spec", venv_prefix: str) -> str:
+def make_pyvenv_cfg(python_spec: Spec, venv_prefix: str) -> str:
     """Make a pyvenv_cfg file for a given (real) python command and venv prefix."""
     python_cmd = python_spec.command.path
     lines = [


### PR DESCRIPTION
`python` has a `+/~nis` variant, but 

1. we don't list all required dependencies (libtirpc was missing)
2. `~nis` (default) has no effect when system versions of dependencies are installed. There is no --disable-nis flag, and the module will automatically be built and linked to system libraries.
3. it was removed in python 3.13

since there are no packages that depend on `python +nis` or `python ~nis` explicitly, just disable nis unconditionally.

edit: converted to draft for now, since I the variable in the configure script only exists since 3.11 (?)