### PR TITLE
aws buildcache stack: Use specific path in `compiler add`

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/scripts/pcluster/setup-pcluster.sh
+++ b/share/spack/gitlab/cloud_pipelines/scripts/pcluster/setup-pcluster.sh
@@ -91,18 +91,12 @@ install_compilers() {
         fi
 
         spack install /${gcc_hash}
-        (
-            spack load gcc
-            spack compiler add --scope site
-        )
+        spack compiler add --scope site "$(spack find -p --no-groups gcc | tail -n 1 | awk '{print $2}')"/bin
 
         if [ "x86_64" == "$(arch)" ]; then
             # 2024.1.0 is the last oneapi compiler that works on AL2 and is the one used to compile packages in the build cache.
             spack install intel-oneapi-compilers@2024.1.0
-            (
-                . "$(spack location -i intel-oneapi-compilers)"/setvars.sh; spack compiler add --scope site \
-                    || true
-            )
+            spack compiler add --scope site "$(spack location -i intel-oneapi-compilers@2024.1.0)"/compiler/latest/bin || true
         fi
     fi
 }

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
@@ -26,7 +26,7 @@ packages:
   intel-oneapi-compilers:
     require: "intel-oneapi-compilers %gcc target=x86_64_v3"
   intel-oneapi-mpi:
-    variants: +external-libfabric generic-names=True
+    require: "+external-libfabric generic-names=True"
   lammps:
     require:
       - one_of:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/packages.yaml
@@ -124,6 +124,7 @@ packages:
         when: "%oneapi"
 
   all:
+    conflict: ["^gcc-runtime@7"]
     compiler: [oneapi, gcc]
     permissions:
       read: world


### PR DESCRIPTION
Use the specific argument to identify which compiler should be added. This does
not change the behavior in the stack (other than speeding it up due to shorter
search path) but helps when running this script on other OSs which might have
incomplete compiler installation we do not wish to add.

Also, explicitly conflict all packages with gcc@7 libraries. These libraries can
really wreck havoc on a build (using a more modern compiler) if they are added
in e.g. C++ link line.

-------

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->