### PR TITLE
nwchem: add NO_NWPWXC_VDW3A as suggested by error message

### DIFF
--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -41,9 +41,9 @@ class Nwchem(Package):
         url="https://github.com/nwchemgit/nwchem/releases/download/v7.0.2-release/nwchem-7.0.2-release.revision-b9985dfa-srconly.2020-10-12.tar.bz2",
     )
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
 
     variant("openmp", default=False, description="Enables OpenMP support")
     variant("f90allocatable", default=False, description="Use F90 allocatable instead of MA")
@@ -247,3 +247,7 @@ class Nwchem(Package):
     def setup_run_environment(self, env):
         env.set("NWCHEM_BASIS_LIBRARY", join_path(self.prefix, "share/nwchem/libraries/"))
         env.set("NWCHEM_NWPW_LIBRARY", join_path(self.prefix, "share/nwchem/libraryps/"))
+
+    def setup_build_environment(self, env):
+        # https://src.fedoraproject.org/rpms/nwchem/blob/epel9/f/nwchem.spec#_259
+        env.set("NO_NWPWXC_VDW3A", "1")


### PR DESCRIPTION
Extracted from #45189 

Build failure: https://gitlab.spack.io/spack/spack/-/jobs/13978736

Any better way to deal with this error is welcome.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
