### PR TITLE
netcdf-cxx4: use https instead of ftp

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -12,7 +12,7 @@ class NetcdfCxx4(CMakePackage):
     sharing of array-oriented scientific data. This is the C++ distribution."""
 
     homepage = "https://www.unidata.ucar.edu/software/netcdf"
-    url = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-cxx4-4.3.1.tar.gz"
+    url = "https://downloads.unidata.ucar.edu/netcdf-cxx/4.3.1/netcdf-cxx4-4.3.1.tar.gz"
 
     maintainers("WardF")
 

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -19,7 +19,12 @@ class NetcdfCxx4(CMakePackage):
     license("Apache-2.0")
 
     version("4.3.1", sha256="6a1189a181eed043b5859e15d5c080c30d0e107406fbb212c8fb9814e90f3445")
-    version("4.3.0", sha256="e34fbc6aba243ec82c23e9ee99db2430555ada849c54c1f3ab081b0ddd0f5f30")
+    version(
+        "4.3.0",
+        sha256="25da1c97d7a01bc4cee34121c32909872edd38404589c0427fefa1301743f18f",
+        url="https://github.com/Unidata/netcdf-cxx4/archive/refs/tags/v4.3.0.tar.gz",
+        deprecated=True,
+    )
 
     variant("shared", default=True, description="Enable shared library")
     variant("pic", default=True, description="Produce position-independent code (for shared libs)")


### PR DESCRIPTION
Extracted from #45189 

Build failure: https://gitlab.spack.io/spack/spack/-/jobs/13897347

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
