### PR TITLE
libxml2: add CMake builder and new version

### DIFF
--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -106,7 +106,12 @@ class Libxml2(AutotoolsPackage, CMakePackage, NMakePackage):
         sha256="5dc43fed02b443d2563a502a52caafe39477c06fc30b70f786d5ed3eb5aea88d",
         when="@2.9.11:2.9.14",
     )
-    build_system(conditional("nmake", when="platform=windows"), conditional("cmake", when="@2.11:"), "autotools", default="autotools")
+    build_system(
+        conditional("nmake", when="platform=windows"),
+        conditional("cmake", when="@2.11:"),
+        "autotools",
+        default="autotools",
+    )
 
     def flag_handler(self, name, flags):
         if name == "cflags" and self.spec.satisfies("+pic"):
@@ -267,7 +272,7 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
             self.define_from_variant("LIBXML2_WITH_PYTHON", "python"),
             self.define("LIBXML2_WITH_LZMA", True),
             self.define("LIBXML2_WITH_ZLIB", True),
-            self.define("LIBXML2_WITH_TESTS", True)
+            self.define("LIBXML2_WITH_TESTS", True),
         ]
         return args
 

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -29,7 +29,7 @@ class Libxml2(AutotoolsPackage, CMakePackage, NMakePackage):
 
     license("MIT")
 
-    version("2.13.5", sha256="65d042e1c8010243e617efb02afda20b85c2160acdbfbcb5b26b80cec6515650")
+    version("2.13.5", sha256="74fc163217a3964257d3be39af943e08861263c4231f9ef5b496b6f6d4c7b2b6")
     version("2.13.4", sha256="65d042e1c8010243e617efb02afda20b85c2160acdbfbcb5b26b80cec6515650")
     version("2.12.9", sha256="59912db536ab56a3996489ea0299768c7bcffe57169f0235e7f962a91f483590")
     version("2.11.9", sha256="780157a1efdb57188ec474dca87acaee67a3a839c2525b2214d318228451809f")

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -6,11 +6,11 @@ import os
 
 import llnl.util.filesystem as fs
 
-from spack.build_systems import autotools, nmake
+from spack.build_systems import autotools, cmake, nmake
 from spack.package import *
 
 
-class Libxml2(AutotoolsPackage, NMakePackage):
+class Libxml2(AutotoolsPackage, CMakePackage, NMakePackage):
     """Libxml2 is the XML C parser and toolkit developed for the Gnome
     project (but usable outside of the Gnome platform), it is free
     software available under the MIT License."""
@@ -29,6 +29,7 @@ class Libxml2(AutotoolsPackage, NMakePackage):
 
     license("MIT")
 
+    version("2.13.5", sha256="65d042e1c8010243e617efb02afda20b85c2160acdbfbcb5b26b80cec6515650")
     version("2.13.4", sha256="65d042e1c8010243e617efb02afda20b85c2160acdbfbcb5b26b80cec6515650")
     version("2.12.9", sha256="59912db536ab56a3996489ea0299768c7bcffe57169f0235e7f962a91f483590")
     version("2.11.9", sha256="780157a1efdb57188ec474dca87acaee67a3a839c2525b2214d318228451809f")
@@ -105,7 +106,7 @@ class Libxml2(AutotoolsPackage, NMakePackage):
         sha256="5dc43fed02b443d2563a502a52caafe39477c06fc30b70f786d5ed3eb5aea88d",
         when="@2.9.11:2.9.14",
     )
-    build_system(conditional("nmake", when="platform=windows"), "autotools", default="autotools")
+    build_system(conditional("nmake", when="platform=windows"), conditional("cmake", when="@2.11:"), "autotools", default="autotools")
 
     def flag_handler(self, name, flags):
         if name == "cflags" and self.spec.satisfies("+pic"):
@@ -256,6 +257,18 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
         # PIC setting is taken care of above by self.flag_handler()
         args.append("--without-pic")
 
+        return args
+
+
+class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("LIBXML2_WITH_PYTHON", "python"),
+            self.define("LIBXML2_WITH_LZMA", True),
+            self.define("LIBXML2_WITH_ZLIB", True),
+            self.define("LIBXML2_WITH_TESTS", True)
+        ]
         return args
 
 


### PR DESCRIPTION
Adds a CMake builder to libxml2 and adds the `2.13.5` release