### PR TITLE
gobject-introspection: patch to import setuptools before distutils

### DIFF
--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -100,7 +100,7 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     # - https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/361
     # - https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/395
     # for new enough versions we import setuptools first
-    patch("setuptools.patch", when="@1.78:")
+    patch("setuptools.patch", when="@1.78: ^python@3.12:")
     # for older versions we conflict with newer python
     conflicts(
         "@:1.77 ^python@3.12:",

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -57,7 +57,7 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     depends_on("libffi@:3.3", when="@:1.72")  # libffi 3.4 caused seg faults
     depends_on("python")
     with when("^python@3.12:"):
-        depends_on("py-setuptools")
+        depends_on("py-setuptools@48:")
         # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/490
         depends_on("py-setuptools@:73", when="@:1.81.0")
 

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -57,9 +57,9 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     depends_on("libffi@:3.3", when="@:1.72")  # libffi 3.4 caused seg faults
     depends_on("python")
     with when("^python@3.12:"):
-        depends_on("py-setuptools@48:")
+        depends_on("py-setuptools@48:", type=("build", "run"))
         # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/490
-        depends_on("py-setuptools@:73", when="@:1.81.0")
+        depends_on("py-setuptools@:73", type=("build", "run"), when="@:1.81.0")
 
     # This package creates several scripts from
     # toosl/g-ir-tool-template.in.  In their original form these

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -56,6 +56,10 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
     # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/283
     depends_on("libffi@:3.3", when="@:1.72")  # libffi 3.4 caused seg faults
     depends_on("python")
+    with when("^python@3.12:"):
+        depends_on("py-setuptools")
+        # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/490
+        depends_on("py-setuptools@:73", when="@:1.81.0")
 
     # This package creates several scripts from
     # toosl/g-ir-tool-template.in.  In their original form these
@@ -92,10 +96,14 @@ class GobjectIntrospection(MesonPackage, AutotoolsPackage):
         when="@:1.63.1",
     )
 
-    # https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/361
-    # https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/395
+    # g-ir-scanner uses distutils
+    # - https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/361
+    # - https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/395
+    # for new enough versions we import setuptools first
+    patch("setuptools.patch", when="@1.78:")
+    # for older versions we conflict with newer python
     conflicts(
-        "^python@3.12:",
+        "@:1.77 ^python@3.12:",
         msg="gobject-introspection still uses distutils which was removed in Python 3.12",
     )
     conflicts(

--- a/var/spack/repos/builtin/packages/gobject-introspection/setuptools.patch
+++ b/var/spack/repos/builtin/packages/gobject-introspection/setuptools.patch
@@ -1,0 +1,60 @@
+diff --git a/giscanner/ccompiler.py b/giscanner/ccompiler.py
+index 2f03fd85..8e7424b7 100644
+--- a/giscanner/ccompiler.py
++++ b/giscanner/ccompiler.py
+@@ -24,6 +24,7 @@ import subprocess
+ import tempfile
+ 
+ import sys
++import setuptools
+ import distutils
+ 
+ from distutils.unixccompiler import UnixCCompiler
+diff --git a/giscanner/msvccompiler.py b/giscanner/msvccompiler.py
+index e333a80f..5168930a 100644
+--- a/giscanner/msvccompiler.py
++++ b/giscanner/msvccompiler.py
+@@ -21,6 +21,7 @@
+ import os
+ from typing import Type
+ 
++import setuptools
+ from distutils.errors import DistutilsExecError, CompileError
+ from distutils.ccompiler import CCompiler, gen_preprocess_options, new_compiler
+ from distutils.dep_util import newer
+diff --git a/giscanner/scannermain.py b/giscanner/scannermain.py
+index 987df819..08cb432f 100644
+--- a/giscanner/scannermain.py
++++ b/giscanner/scannermain.py
+@@ -552,6 +552,7 @@ def scanner_main(args):
+     (options, args) = parser.parse_args(args)
+ 
+     if options.verbose:
++        import setuptools
+         import distutils
+         distutils.log.set_threshold(distutils.log.DEBUG)
+     if options.passthrough_gir:
+diff --git a/giscanner/utils.py b/giscanner/utils.py
+index 9840143c..6fbcbce4 100644
+--- a/giscanner/utils.py
++++ b/giscanner/utils.py
+@@ -382,6 +382,7 @@ def get_msvcr_overwrite():
+             return ['vcruntime140']
+ 
+ 
++import setuptools
+ import distutils.cygwinccompiler
+ orig_get_msvcr = distutils.cygwinccompiler.get_msvcr  # type: ignore
+ distutils.cygwinccompiler.get_msvcr = get_msvcr_overwrite  # type: ignore
+diff --git a/tests/scanner/test_ccompiler.py b/tests/scanner/test_ccompiler.py
+index 6c0674a1..248df21c 100644
+--- a/tests/scanner/test_ccompiler.py
++++ b/tests/scanner/test_ccompiler.py
+@@ -15,6 +15,7 @@
+ # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ # Boston, MA 02111-1307, USA.
+ 
++import setuptools
+ import distutils
+ import os
+ import shlex


### PR DESCRIPTION
This PR aims to address the restriction to `python@:3.11` due to the use of `distutils` in `gobject-introspection`.

Test build of `pango ^gobject-introspection ^python@3.12.5` (in codespaces):
```
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/python-3.12.5-ezfhbxj4vwapcerrfuvsjz2wnteidrnk
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/glib-2.82.2-ppalyekkn7czh2453rkhz5pyzwm3hsv5
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/python-venv-1.0-m3iijkitbl3rcp7jcz66sngomabh5aoo
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/cairo-1.16.0-vakhpwpymdmiqjodum372ndtwaljedv6
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/py-setuptools-69.2.0-j7xbypvex3crztmlfotkrcltdzqnwpcw
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/gobject-introspection-1.78.1-kyzps6pcr72tsoq5tcsspbqelvi57dcv
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/harfbuzz-10.1.0-cwfzsiitb6o6permmkzfsbx2lkz73oum
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/json-glib-1.6.6-dzcatkc4schfcmk7ghs62uv4nrmwbp2f
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/pango-1.54.0-b7qbhsckcheogd2dfvtv2axjzbl254v2
```