### PR TITLE
bug fix: updated warning message to reflect impending v1.0 release

### DIFF
--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -107,7 +107,7 @@ properties: Dict[str, Any] = {
                 "names": ["install_missing_compilers"],
                 "message": "The config:install_missing_compilers option has been deprecated in "
                 "Spack v0.23, and is currently ignored. It will be removed from config in "
-                "Spack v0.25.",
+                "Spack v1.0.",
                 "error": False,
             },
         ],

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -106,7 +106,7 @@ properties: Dict[str, Any] = {
             {
                 "names": ["install_missing_compilers"],
                 "message": "The config:install_missing_compilers option has been deprecated in "
-                "Spack v0.23, and is currently ignored. It will be removed from config in "
+                "Spack v0.23, and is currently ignored. It will be removed from config after "
                 "Spack v1.0.",
                 "error": False,
             },


### PR DESCRIPTION
This PR makes a tiny 1-line change to update the deprecation message on the `config:install_missing_compilers` config option to say it will be removed in v1.0 instead of v0.25. 

[This PR was motivated by a gripe in the Spack Slack.](https://spackpm.slack.com/archives/C01UZDL35C4/p1732893853695339)