### PR TITLE
gurobi: add v11.0.3, v12.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/gurobi/package.py
+++ b/var/spack/repos/builtin/packages/gurobi/package.py
@@ -23,6 +23,8 @@ class Gurobi(Package):
     homepage = "https://www.gurobi.com"
     manual_download = True
 
+    version("12.0.0", sha256="a2bdc9c1d6bf8eb4e551a184af1ce8d7b0435ea8e7d19a017cc7d53fd5efda12")
+    version("11.0.3", sha256="82a2c8671c234bbaa9dc64da22b1951abf41c62047fdf77004e65f24a91dfd13")
     version("10.0.0", sha256="91a9ce1464f5f948809fcdfbdeb55f77698ed8a6d6cfa6985295424b6ece2bd4")
     version("9.5.2", sha256="95d8ca18b7f86116ba834a27fd6228c5b1708ae67927e7ea0e954c09374a2d0f")
     version("9.5.1", sha256="fa82859d33f08fb8aeb9da66b0fbd91718ed573c534f571aa52372c9deb891da")
@@ -36,7 +38,9 @@ class Gurobi(Package):
     license_url = "http://www.gurobi.com/downloads/download-center"
 
     extends("python")
-    depends_on("python@2.7,3.6:")
+    depends_on("python@2.7,3.6:", when="@:10")
+    depends_on("python@3.8:", when="@11")
+    depends_on("python@3.9:", when="@12")
 
     def url_for_version(self, version):
         return "file://{0}/gurobi{1}_linux64.tar.gz".format(os.getcwd(), version)
@@ -50,10 +54,14 @@ class Gurobi(Package):
     def setup_run_environment(self, env):
         env.set("GUROBI_HOME", self.prefix)
         env.set("GRB_LICENSE_FILE", join_path(self.prefix, "gurobi.lic"))
+        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib),
 
     def install(self, spec, prefix):
         install_tree("linux64", prefix)
 
+    # the Python package installation was deprecated after version 10,
+    # to be superseded by pip/conda installs
+    @when("@:10")
     @run_after("install")
     def gurobipy(self):
         with working_dir("linux64"):


### PR DESCRIPTION
This also means removing the Python support for these versions, as the installation method was deprecated in favor of pip/conda

The sha256 hashes can be verified by downloading the packages from https://www.gurobi.com/downloads/

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
