### PR TITLE
py-mgmetis: rm constrains < 3.X for mpi4py & < 1.X for numpy depandancies

### DIFF
--- a/var/spack/repos/builtin/packages/py-mgmetis/package.py
+++ b/var/spack/repos/builtin/packages/py-mgmetis/package.py
@@ -19,8 +19,8 @@ class PyMgmetis(PythonPackage):
 
     depends_on("python@3.7:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-numpy@1.20.0:1.26.4", type=("build", "run"))
+    depends_on("py-numpy@1.20.0:", type=("build", "run"))
     depends_on("py-cython", type=("build"))
-    depends_on("py-mpi4py@3.0.3:3", type=("build", "run"))
+    depends_on("py-mpi4py@3.0.3:", type=("build", "run"))
     depends_on("py-pytest")
     depends_on("metis+shared", type="all")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Is it possible to merge this PR?