### PR TITLE
style.py: do not remove import spack in packages

### DIFF
--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -324,8 +324,6 @@ def run_isort(isort_cmd, file_list, args):
 
     packages_isort_args = (
         "--rm",
-        "spack",
-        "--rm",
         "spack.pkgkit",
         "--rm",
         "spack.package_defs",

--- a/var/spack/repos/builtin/packages/singularity-eos/package.py
+++ b/var/spack/repos/builtin/packages/singularity-eos/package.py
@@ -5,6 +5,7 @@
 
 import os
 
+import spack
 import spack.version
 from spack.package import *
 


### PR DESCRIPTION
singularity-eos uses `spack.spack_version` so it should `import spack`.