### PR TITLE
Bug fix for package cprnc@1.0.8: set install rpath for cprnc executable

### DIFF
--- a/var/spack/repos/builtin/packages/cprnc/install_rpath_108.patch
+++ b/var/spack/repos/builtin/packages/cprnc/install_rpath_108.patch
@@ -1,0 +1,17 @@
+--- a/CMakeLists.txt	2024-12-03 16:22:56.474665264 -0700
++++ b/CMakeLists.txt	2024-12-03 16:23:47.304644596 -0700
+@@ -82,13 +82,13 @@
+ #message (STATUS "netcdf_fortran_lib == ${netcdf_fortran_lib}")
+ get_filename_component(netcdf_fortran_lib_location ${netcdf_fortran_lib} DIRECTORY)
+ #message (STATUS "netcdf_fortran_lib_location == ${netcdf_fortran_lib_location}")
+-SET(CMAKE_INSTALL_RPATH "${netcdf_fortran_lib_location};${netcdf_c_lib_location}")
+ 
+ find_library(netcdf_c_lib netcdf HINTS ${NetCDF_C_LIBRARY})
+ #message (STATUS "netcdf_c_lib == ${netcdf_c_lib}")
+ get_filename_component(netcdf_c_lib_location ${netcdf_c_lib} DIRECTORY)
+ #message (STATUS "netcdf_c_lib_location == ${netcdf_c_lib_location}")
+ 
++SET(CMAKE_INSTALL_RPATH "${netcdf_fortran_lib_location};${netcdf_c_lib_location}")
+ list(APPEND CMAKE_BUILD_RPATH ${netcdf_fortran_lib_location} ${netcdf_c_lib_location})
+ #message("CMAKE_BUILD_RPATH is ${CMAKE_BUILD_RPATH}")
+ add_executable (cprnc ${CPRNC_Fortran_SRCS} ${CPRNC_GenF90_SRCS})

--- a/var/spack/repos/builtin/packages/cprnc/package.py
+++ b/var/spack/repos/builtin/packages/cprnc/package.py
@@ -26,7 +26,9 @@ class Cprnc(CMakePackage):
     depends_on("netcdf-fortran")
     depends_on("cmake@3:", type="build")
 
+    # Still need a patch for 1.0.8 ...
     patch("install_rpath.patch", when="@:1.0.7")
+    patch("install_rpath_108.patch", when="@1.0.8")
 
     resource(
         name="genf90",


### PR DESCRIPTION
## Description

This PR is a "dejavu" of https://github.com/spack/spack/pull/47505. The install rpath is still missing for `cprnc@1.0.8`, but this time only for the netcdf-c library. The reason is that the command to set the install rpath in `CMakeLists.txt` is in the wrong location (before the neccdf-c library location is defined).

## Testing

Tested as part of https://github.com/JCSDA/spack-stack/pull/1392