### PR TITLE
Add conflict for pixman with Intel Classic

### DIFF
--- a/var/spack/repos/builtin/packages/pixman/package.py
+++ b/var/spack/repos/builtin/packages/pixman/package.py
@@ -35,6 +35,9 @@ class Pixman(AutotoolsPackage, MesonPackage):
         default="meson",
     )
 
+    # https://github.com/spack/spack/issues/47917
+    conflicts("%intel")
+
     depends_on("c", type="build")
     with when("build_system=meson"):
         depends_on("meson@0.52:", type="build")


### PR DESCRIPTION
Resolves https://github.com/spack/spack/issues/47917. This is a pragmatic solution, because Intel Classic is deprecated and it's not worth the effort to try to fix the build.