### PR TITLE
neovim: add 0.10.2

### DIFF
--- a/var/spack/repos/builtin/packages/neovim/package.py
+++ b/var/spack/repos/builtin/packages/neovim/package.py
@@ -19,6 +19,7 @@ class Neovim(CMakePackage):
 
     version("master", branch="master")
     version("stable", tag="stable", commit="d772f697a281ce9c58bf933997b87c7f27428a60")
+    version("0.10.2", sha256="546cb2da9fffbb7e913261344bbf4cf1622721f6c5a67aa77609e976e78b8e89")
     version("0.10.0", sha256="372ea2584b0ea2a5a765844d95206bda9e4a57eaa1a2412a9a0726bab750f828")
     version("0.9.5", sha256="fe74369fc30a32ec7a086b1013acd0eacd674e7570eb1acc520a66180c9e9719")
     version("0.9.4", sha256="148356027ee8d586adebb6513a94d76accc79da9597109ace5c445b09d383093")


### PR DESCRIPTION
Just a patch-version bump for Neovim; fixes a [couple dozen small bugs](https://github.com/neovim/neovim/releases/tag/v0.10.2).

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
