### PR TITLE
added -omp flags to wps/package.py. 

### DIFF
--- a/var/spack/repos/builtin/packages/wps/package.py
+++ b/var/spack/repos/builtin/packages/wps/package.py
@@ -117,3 +117,12 @@ class Wps(Package):
     def install(self, spec, prefix):
         # Copy all of WPS staging dir to install dir
         install_tree(".", prefix)
+    #
+    #
+    # yoder:
+    #  WPS build system does not properly add the OMP flag, at least not for some compilers?
+    def flag_handler(self, name, flags):
+        #if name == "cxxflags":
+        if name in ('cxxflags', 'fflags', 'cflags', 'ldflags') and self.spec.satisfies('+dmpar'):
+            flags.append(self.compiler.openmp_flag)
+        return (flags, None, None)


### PR DESCRIPTION
This should fix a compile error where the WPS/WRF build system fails to add the OMP flag. Last I checked, the developers recommend manually adding the flag, mid-build.


Added flag_handler() at the end of package.py. Admittedly, I am open to feedback on how to specifically implement the fix.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
