### PR TITLE
netcdf-c: change check() to installcheck()

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -552,6 +552,6 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
     # It looks like the issues with running the tests in parallel were fixed around version 4.6.0
     # (see https://github.com/Unidata/netcdf-c/commit/812c2fd4d108cca927582c0d84049c0f271bb9e0):
     @when("@:4.5.0")
-    def check(self):
+    def installcheck(self):
         # h5_test fails when run in parallel
         make("check", parallel=False)


### PR DESCRIPTION
This PR changes `check()` to `installcheck()` in netcdf-c. Unless I'm missing something, it appears to be the case that the install-time tests (`spack install --test root netcdf-c`) do not run with `check()`, but do with `installcheck()`.