### PR TITLE
tar: conditionally link iconv

### DIFF
--- a/etc/spack/defaults/linux/packages.yaml
+++ b/etc/spack/defaults/linux/packages.yaml
@@ -1,3 +1,0 @@
-packages:
-  iconv:
-    require: [libiconv]

--- a/etc/spack/defaults/linux/packages.yaml
+++ b/etc/spack/defaults/linux/packages.yaml
@@ -1,0 +1,3 @@
+packages:
+  iconv:
+    require: [libiconv]

--- a/var/spack/repos/builtin/packages/tar/package.py
+++ b/var/spack/repos/builtin/packages/tar/package.py
@@ -72,7 +72,7 @@ class Tar(AutotoolsPackage, GNUMirrorPackage):
         return match.group(1) if match else None
 
     def flag_handler(self, name, flags):
-        if name == "ldflags" and self.spec.satisfies("@1.35"):
+        if name == "ldflags" and self.spec.satisfies("@1.35 ^[virtuals=iconv] libiconv"):
             # https://savannah.gnu.org/bugs/?64441
             flags.append("-liconv")
         return (flags, None, None)


### PR DESCRIPTION
## Environment

  - rhel9.5
    ```shell-session
    ~]$ uname -a
    Linux dev.kf 5.14.0-503.15.1.el9_5.x86_64 #1 SMP PREEMPT_DYNAMIC
    ```
  - gnu-gcc/g++/gfortran from `dnf install gcc-toolset-14 gcc-toolset-14-*`
    - spack compiler config by `. /opt/rh/gcc-toolset-14/enable ; spack compiler find`
    ```
    ~]$ gcc --version
    gcc (GCC) 14.2.1 20240801 (Red Hat 14.2.1-1)
    ```
  - Spack 6aafefd43dbda58f76c6dd37ddbccf65aedf31e4

## Issue

  - `tar@1.35`: `./configure` failed with `-liconv` not found

See to related to
  - #44335
  - #45026
```

# v0.22.1 (2024-07-04)
Require libiconv for iconv (#44335, #45026). Notice that glibc/musl also provide iconv, but are not guaranteed to be complete. Set packages:iconv:require:[glibc] to restore the old behavior.

The file was patched once at #45026 but removed again at 1b967a9d981bde839c239f2b0d53a53023b89745

It does look to me that `packages:all:providers:iconv:[libiconv]` does not cover all use of iconv.

There are instances of configuring `--without-libiconv-prefix` and `-liconv` under various builtin packages, which I believe would be broken if `packages:all:providers:iconv:[libiconv]` or `packages:all:providers:iconv:[glibc]` is not explicitly stated.

```
builtin]$ grep -oRe "--without-libiconv-prefix" * | sort | uniq -c
      1 packages/bash/package.py:--without-libiconv-prefix
      1 packages/elfutils/package.py:--without-libiconv-prefix
      1 packages/gdal/package.py:--without-libiconv-prefix
      1 packages/gettext/package.py:--without-libiconv-prefix
      1 packages/gnupg/package.py:--without-libiconv-prefix
      1 packages/groff/package.py:--without-libiconv-prefix
      1 packages/lftp/package.py:--without-libiconv-prefix
      1 packages/libarchive/package.py:--without-libiconv-prefix
      1 packages/mono/package.py:--without-libiconv-prefix
      1 packages/procps/package.py:--without-libiconv-prefix
      1 packages/tar/package.py:--without-libiconv-prefix
```

```
builtin]$ grep -oRe "-liconv" * | sort | uniq -c
      4 packages/fsl/iconv.patch:-liconv
      1 packages/grass/package.py:-liconv
      4 packages/py-onnxruntime/libiconv-1.10.patch:-liconv
      4 packages/py-onnxruntime/libiconv.patch:-liconv
      1 packages/srilm/package.py:-liconv
      1 packages/tar/package.py:-liconv
```


## Suggested change

Add to default config `packages:iconv:require:[libiconv]`