### PR TITLE
gromacs: conflict %apple-clang and +openmp

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -357,6 +357,9 @@ class Gromacs(CMakePackage, CudaPackage):
     )
 
     variant("openmp", default=True, description="Enables OpenMP at configure time")
+    conflicts(
+        "+openmp", when="%apple-clang", msg="OpenMP not available for the Apple clang compiler"
+    )
     variant("openmp_max_threads", default="none", description="Max number of OpenMP threads")
     conflicts(
         "+openmp_max_threads", when="~openmp", msg="OpenMP is off but OpenMP Max threads is set"


### PR DESCRIPTION
This combination does not generally work, and OpenMP support is not often needed on platforms that are supported by Apple clang compiler