### PR TITLE
Modify CDash option parsing to query config for default values

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -452,13 +452,13 @@ def add_cdash_args(subparser, add_help):
         cdash_help["track"] = argparse.SUPPRESS
         cdash_help["buildstamp"] = argparse.SUPPRESS
 
-    subparser.add_argument("--cdash-upload-url", default=None, help=cdash_help["upload-url"])
-    subparser.add_argument("--cdash-build", default=None, help=cdash_help["build"])
-    subparser.add_argument("--cdash-site", default=None, help=cdash_help["site"])
+    subparser.add_argument("--cdash-upload-url", default=spack.config.get("cdash:upload-url"), help=cdash_help["upload-url"])
+    subparser.add_argument("--cdash-build", default=spack.config.get("cdash:build"), help=cdash_help["build"])
+    subparser.add_argument("--cdash-site", default=spack.config.get("cdash:site"), help=cdash_help["site"])
 
     cdash_subgroup = subparser.add_mutually_exclusive_group()
-    cdash_subgroup.add_argument("--cdash-track", default="Experimental", help=cdash_help["track"])
-    cdash_subgroup.add_argument("--cdash-buildstamp", default=None, help=cdash_help["buildstamp"])
+    cdash_subgroup.add_argument("--cdash-track", default=spack.config.get("cdash:track", "Experimental"), help=cdash_help["track"])
+    cdash_subgroup.add_argument("--cdash-buildstamp", default=spack.config.get("cdash:buildstamp"), help=cdash_help["buildstamp"])
 
 
 def print_cdash_help():

--- a/lib/spack/spack/schema/cdash.py
+++ b/lib/spack/spack/schema/cdash.py
@@ -14,14 +14,28 @@ properties: Dict[str, Any] = {
     "cdash": {
         "type": "object",
         "additionalProperties": False,
-        # "required": ["build-group", "url", "project", "site"],
-        "required": ["build-group"],
+        "required": ["upload-url"],
         "patternProperties": {
-            r"build-group": {"type": "string"},
-            r"url": {"type": "string"},
-            r"project": {"type": "string"},
+            r"buildstamp": {"type": "string"},
+            r"build": {"type": "string"},
+            r"upload-url": {"type": "string"},
             r"site": {"type": "string"},
+            r"track": {"type": "string"},
         },
+        "anyOf": [
+            {
+                "required": ["upload-url"],
+                "not": {"required": ["track", "buildstamp"]}
+            },
+            {
+                "required": ["upload-url", "track"],
+                "not": {"required": ["buildstamp"]}
+            },
+            {
+                "required": ["upload-url", "buildstamp"],
+                "not": {"required": ["track"]}
+            }
+        ]
     }
 }
 


### PR DESCRIPTION
Allow CDash configurations to be stored in config files. Also, update the CDash schema to be consistent with the CLI naming.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
