### PR TITLE
node-js: less strict python requirement for newer versions of node-js

### DIFF
--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -27,8 +27,12 @@ class NodeJs(Package):
     version("17.9.1", sha256="1102f5e0aafaab8014d19c6c57142caf2ba3ef69d88d7a7f0f82798051796027")
     version("15.3.0", sha256="cadfa384a5f14591b84ce07a1afe529f28deb0d43366fb0ae4e78afba96bfaf2")
     with default_args(deprecated=True):
-    	version("13.8.0", sha256="815b5e1b18114f35da89e4d98febeaba97555d51ef593bd5175db2b05f2e8be6")
-        version("13.5.0", sha256="4b8078d896a7550d7ed399c1b4ac9043e9f883be404d9b337185c8d8479f2db8")
+        version(
+            "13.8.0", sha256="815b5e1b18114f35da89e4d98febeaba97555d51ef593bd5175db2b05f2e8be6"
+        )
+        version(
+            "13.5.0", sha256="4b8078d896a7550d7ed399c1b4ac9043e9f883be404d9b337185c8d8479f2db8"
+        )
 
     # LTS (recommended for most users) - even major number
     version(
@@ -44,8 +48,12 @@ class NodeJs(Package):
     version("14.16.1", sha256="5f5080427abddde7f22fd2ba77cd2b8a1f86253277a1eec54bc98a202728ce80")
     version("14.15.1", sha256="a1120472bf55aea745287693a6651e16973e1008c9d6107df350126adf9716fe")
     with default_args(deprecated=True):
-        version("14.13.0", sha256="8538b2e76aa06ee0e6eb1c118426c3c5ca53b2e49d66591738eacf76e89edd61")
-        version("14.10.0", sha256="7e0d7a1aa23697415e3588a1ca4f1c47496e6c88b9cf37c66be90353d3e4ac3e")
+        version(
+            "14.13.0", sha256="8538b2e76aa06ee0e6eb1c118426c3c5ca53b2e49d66591738eacf76e89edd61"
+        )
+        version(
+            "14.10.0", sha256="7e0d7a1aa23697415e3588a1ca4f1c47496e6c88b9cf37c66be90353d3e4ac3e"
+        )
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated

--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -27,6 +27,7 @@ class NodeJs(Package):
     version("17.9.1", sha256="1102f5e0aafaab8014d19c6c57142caf2ba3ef69d88d7a7f0f82798051796027")
     version("15.3.0", sha256="cadfa384a5f14591b84ce07a1afe529f28deb0d43366fb0ae4e78afba96bfaf2")
     with default_args(deprecated=True):
+        # requires deprecated python versions
         version(
             "13.8.0", sha256="815b5e1b18114f35da89e4d98febeaba97555d51ef593bd5175db2b05f2e8be6"
         )

--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -81,8 +81,8 @@ class NodeJs(Package):
 
     # python requirements are based according to
     # https://github.com/spack/spack/pull/47942#discussion_r1875624177
-    depends_on("python@:3.7", when="@v13.0.0:v13.0.1", type="build")
-    depends_on("python@:3.8", when="@v13.1.0:v14.13.1", type="build")
+    depends_on("python@:3.7", when="@13.0.0:13.0.1", type="build")
+    depends_on("python@:3.8", when="@13.1.0:14.13.1", type="build")
     depends_on("python@:3.9", when="@14.14.0:14.18.1", type="build")
     depends_on("python@:3.10", when="@14.18.2:14.21.3", type="build")
     depends_on("python@:3.9", when="@15.0.0:15.14.0", type="build")

--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -79,6 +79,8 @@ class NodeJs(Package):
 
     # python requirements are based according to
     # https://github.com/spack/spack/pull/47942#discussion_r1875624177
+    depends_on("python@:3.7", when="@v13.0.0:v13.0.1", type="build")
+    depends_on("python@:3.8", when="@v13.1.0:v14.13.1", type="build")
     depends_on("python@:3.9", when="@14.14.0:14.18.1", type="build")
     depends_on("python@:3.10", when="@14.18.2:14.21.3", type="build")
     depends_on("python@:3.9", when="@15.0.0:15.14.0", type="build")

--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -48,6 +48,7 @@ class NodeJs(Package):
     version("14.16.1", sha256="5f5080427abddde7f22fd2ba77cd2b8a1f86253277a1eec54bc98a202728ce80")
     version("14.15.1", sha256="a1120472bf55aea745287693a6651e16973e1008c9d6107df350126adf9716fe")
     with default_args(deprecated=True):
+        # requires deprecated python versions
         version(
             "14.13.0", sha256="8538b2e76aa06ee0e6eb1c118426c3c5ca53b2e49d66591738eacf76e89edd61"
         )

--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -25,21 +25,10 @@ class NodeJs(Package):
     version("21.7.3", sha256="ce1f61347671ef219d9c2925313d629d3fef98fc8d7f5ef38dd4656f7d0f58e7")
     version("19.2.0", sha256="aac9d1a366fb57d68f4639f9204d1de5d6387656959a97ed929a5ba9e62c033a")
     version("17.9.1", sha256="1102f5e0aafaab8014d19c6c57142caf2ba3ef69d88d7a7f0f82798051796027")
-    version(
-        "15.3.0",
-        sha256="cadfa384a5f14591b84ce07a1afe529f28deb0d43366fb0ae4e78afba96bfaf2",
-        deprecated=True,
-    )
-    version(
-        "13.8.0",
-        sha256="815b5e1b18114f35da89e4d98febeaba97555d51ef593bd5175db2b05f2e8be6",
-        deprecated=True,
-    )
-    version(
-        "13.5.0",
-        sha256="4b8078d896a7550d7ed399c1b4ac9043e9f883be404d9b337185c8d8479f2db8",
-        deprecated=True,
-    )
+    version("15.3.0", sha256="cadfa384a5f14591b84ce07a1afe529f28deb0d43366fb0ae4e78afba96bfaf2")
+    with default_args(deprecated=True):
+    	version("13.8.0", sha256="815b5e1b18114f35da89e4d98febeaba97555d51ef593bd5175db2b05f2e8be6")
+        version("13.5.0", sha256="4b8078d896a7550d7ed399c1b4ac9043e9f883be404d9b337185c8d8479f2db8")
 
     # LTS (recommended for most users) - even major number
     version(
@@ -51,31 +40,12 @@ class NodeJs(Package):
     version("20.15.0", sha256="01e2c034467a324a33e778c81f2808dff13d289eaa9307d3e9b06c171e4d932d")
     version("18.12.1", sha256="ba8174dda00d5b90943f37c6a180a1d37c861d91e04a4cb38dc1c0c74981c186")
     version("16.18.1", sha256="3d24c9c3a953afee43edc44569045eda56cd45cd58b0539922d17da62736189c")
-    version(
-        "14.21.1",
-        sha256="76ba961536dc11e4dfd9b198c61ff3399e655eca959ae4b66d926f29bfcce9d3",
-        deprecated=True,
-    )
-    version(
-        "14.16.1",
-        sha256="5f5080427abddde7f22fd2ba77cd2b8a1f86253277a1eec54bc98a202728ce80",
-        deprecated=True,
-    )
-    version(
-        "14.15.1",
-        sha256="a1120472bf55aea745287693a6651e16973e1008c9d6107df350126adf9716fe",
-        deprecated=True,
-    )
-    version(
-        "14.13.0",
-        sha256="8538b2e76aa06ee0e6eb1c118426c3c5ca53b2e49d66591738eacf76e89edd61",
-        deprecated=True,
-    )
-    version(
-        "14.10.0",
-        sha256="7e0d7a1aa23697415e3588a1ca4f1c47496e6c88b9cf37c66be90353d3e4ac3e",
-        deprecated=True,
-    )
+    version("14.21.1", sha256="76ba961536dc11e4dfd9b198c61ff3399e655eca959ae4b66d926f29bfcce9d3")
+    version("14.16.1", sha256="5f5080427abddde7f22fd2ba77cd2b8a1f86253277a1eec54bc98a202728ce80")
+    version("14.15.1", sha256="a1120472bf55aea745287693a6651e16973e1008c9d6107df350126adf9716fe")
+    with default_args(deprecated=True):
+        version("14.13.0", sha256="8538b2e76aa06ee0e6eb1c118426c3c5ca53b2e49d66591738eacf76e89edd61")
+        version("14.10.0", sha256="7e0d7a1aa23697415e3588a1ca4f1c47496e6c88b9cf37c66be90353d3e4ac3e")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
@@ -98,12 +68,26 @@ class NodeJs(Package):
 
     # https://github.com/nodejs/node/blob/master/BUILDING.md#unix-and-macos
     depends_on("gmake@3.81:", type="build")
-    depends_on("python@3.6:3.11", when="@19.1:", type="build")
-    depends_on("python@3.6:3.10", when="@16.11:19.0", type="build")
-    depends_on("python@3.6:3.9", when="@16.0:16.10", type="build")
-    depends_on("python@2.7,3.5:3.8", when="@15", type="build")
-    depends_on("python@2.7,3.6:3.10", when="@14.18.2:14", type="build")
-    depends_on("python@2.7,3.5:3.8", when="@13.1:14.18.1", type="build")
+
+    # python requirements are based according to
+    # https://github.com/spack/spack/pull/47942#discussion_r1875624177
+    depends_on("python@:3.9", when="@14.14.0:14.18.1", type="build")
+    depends_on("python@:3.10", when="@14.18.2:14.21.3", type="build")
+    depends_on("python@:3.9", when="@15.0.0:15.14.0", type="build")
+    depends_on("python@:3.9", when="@16.0.0:16.10.0", type="build")
+    depends_on("python@:3.10", when="@16.11.0:16.18.1", type="build")
+    depends_on("python@:3.11", when="@16.19.0:16.20.2", type="build")
+    depends_on("python@:3.10", when="@17.0.0:18.12.1", type="build")
+    depends_on("python@:3.11", when="@18.13.0:18.19.1", type="build")
+    depends_on("python@:3.12", when="@18.20.0:18.20.5", type="build")
+    depends_on("python@:3.10", when="@19.0.0:19.0.1", type="build")
+    depends_on("python@:3.11", when="@19.1.0:20.10.0", type="build")
+    depends_on("python@:3.12", when="@20.11.0:20.15.1", type="build")
+    depends_on("python@:3.13", when="@20.16.0:20.18.1", type="build")
+    depends_on("python@:3.11", when="@21.0.0:21.1.0", type="build")
+    depends_on("python@:3.12", when="@21.2.0:22.2.0", type="build")
+    depends_on("python@:3.13", when="@22.3.0:22.7.0", type="build")
+
     depends_on("libtool", type="build", when=sys.platform != "darwin")
     depends_on("pkgconfig", type="build")
     # depends_on('bash-completion', when="+bash-completion")


### PR DESCRIPTION
FYI @adamjstewart

`node-js` documentation has a general statement about python requirements like
> [A supported version of Python](https://devguide.python.org/versions/) for building and testing.

while the spack package has a complex set of python requirements

https://github.com/spack/spack/blob/1f2a68f2b6da57f3a52c2ee9636f9a224df2abe0/var/spack/repos/builtin/packages/node-js/package.py#L69-L74

In the past it seems `node-js` was more specific with a range of python versions supported (e.g. `3.6 <= x <= 3.11`, `), but I don't have knowledge about it (e.g. it might be that they were trying to describe the current window of python supported versions). See also https://github.com/spack/spack/pull/34478#discussion_r1046323851

**The idea is to leave there the logic for older versions to be on the safe side, but update it to be less strict as the new `node-js` documentation states.**

I opted for starting from `node-js@22` which is the currently active (even) version, and which I was able to build on macOS using `pyhton@13`. Actually the discontinuity point is set to `node-js@21`:
- `node-js@:20` there is the old logic with the multiple directives
- `node-js@21:` the new simplified requirement is in place

So, starting from now, it should be possible to be more open with python requirement and going forward deprecating older versions also related old requirements can be dropped.

Still some open questions:
- [x] about maintainability: is it ok saying `python@3.9:` for representing the range of supported python versions in spack? or should we prefer `python@3`? the point here is: should we update this every time there is a PR about EOL deprecation of python versions in spack (e.g. https://github.com/spack/spack/pull/46913)?
- [x] somehow a followup question: do we want to keep there also `python@2.7` references?