### PR TITLE
Go build system: reduce resulting installation sizes

### DIFF
--- a/lib/spack/spack/build_systems/go.py
+++ b/lib/spack/spack/build_systems/go.py
@@ -7,9 +7,7 @@ import llnl.util.filesystem as fs
 import spack.builder
 import spack.package_base
 import spack.phase_callbacks
-import spack.spec
-import spack.util.prefix
-from spack.directives import build_system, extends
+from spack.directives import build_system, depends_on
 from spack.multimethod import when
 
 from ._checks import BuilderWithDefaults, execute_install_time_tests
@@ -28,9 +26,7 @@ class GoPackage(spack.package_base.PackageBase):
     build_system("go")
 
     with when("build_system=go"):
-        # TODO: this seems like it should be depends_on, see
-        # setup_dependent_build_environment in go for why I kept it like this
-        extends("go@1.14:", type="build")
+        depends_on("go", type="build")
 
 
 @spack.builder.builder("go")
@@ -73,6 +69,7 @@ class GoBuilder(BuilderWithDefaults):
     def setup_build_environment(self, env):
         env.set("GO111MODULE", "on")
         env.set("GOTOOLCHAIN", "local")
+        env.set("GOPATH", fs.join_path(self.pkg.stage.path, "go"))
 
     @property
     def build_directory(self):

--- a/lib/spack/spack/build_systems/go.py
+++ b/lib/spack/spack/build_systems/go.py
@@ -7,6 +7,8 @@ import llnl.util.filesystem as fs
 import spack.builder
 import spack.package_base
 import spack.phase_callbacks
+import spack.spec
+import spack.util.prefix
 from spack.directives import build_system, depends_on
 from spack.multimethod import when
 

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -121,28 +121,8 @@ class Go(Package):
 
         In most cases, extensions will only need to set GOPATH and use go::
 
-        env['GOPATH'] = self.source_path + ':' + env['GOPATH']
         go('get', '<package>', env=env)
         install_tree('bin', prefix.bin)
         """
         #  Add a go command/compiler for extensions
         module.go = self.spec["go"].command
-
-    def generate_path_components(self, dependent_spec):
-        if os.environ.get("GOROOT", False):
-            tty.warn("GOROOT is set, this is not recommended")
-
-        # Set to include paths of dependencies
-        path_components = [dependent_spec.prefix]
-        for d in dependent_spec.traverse():
-            if d.package.extends(self.spec):
-                path_components.append(d.prefix)
-        return ":".join(path_components)
-
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        # This *MUST* be first, this is where new code is installed
-        env.prepend_path("GOPATH", self.generate_path_components(dependent_spec))
-
-    def setup_dependent_run_environment(self, env, dependent_spec):
-        # Allow packages to find this when using module files
-        env.prepend_path("GOPATH", self.generate_path_components(dependent_spec))

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -117,8 +117,6 @@ class Go(Package):
     def setup_dependent_package(self, module, dependent_spec):
         """Called before go modules' build(), install() methods.
 
-        In most cases, extensions will only need to set GOPATH and use go::
-
         go('get', '<package>', env=env)
         install_tree('bin', prefix.bin)
         """

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -5,8 +5,6 @@
 import os
 import re
 
-from llnl.util import tty
-
 from spack.package import *
 
 # - vanilla CentOS 7, and possibly other systems, fail a test:


### PR DESCRIPTION
We currently store all of the go modules of a build in the resulting package with the idea of providing those dependencies. However we don't currently map go dependencies all the way down the stack, and there's ongoing debate about how we'll support offline Go installs. In the meantime we should only provide the resulting statically linked binaries.

As it currently stands GoPackage installs are huge because they're keeping around all of their intermediate dependencies. For example this makes `rclone` ~1GB instead of a few MBs.
