### PR TITLE
geant4: patch typo in wroot

### DIFF
--- a/var/spack/repos/builtin/packages/geant4/columns.patch
+++ b/var/spack/repos/builtin/packages/geant4/columns.patch
@@ -1,0 +1,13 @@
+diff --git a/source/externals/g4tools/include/tools/wroot/columns.icc b/source/externals/g4tools/include/tools/wroot/columns.icc
+index 0df2c16620..af9b15e0ab 100644
+--- a/source/externals/g4tools/include/tools/wroot/columns.icc
++++ b/source/externals/g4tools/include/tools/wroot/columns.icc
+@@ -399,7 +399,7 @@
+   protected:
+     std_vector_column_ref(const std_vector_column_ref& a_from)
+     :icol(a_from)
+-    ,m_branch(a_from.m_barnch)
++    ,m_branch(a_from.m_branch)
+     ,m_ref(a_from.m_ref)
+     ,m_leaf(0)
+     ,m_leaf_count(0)

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -207,7 +207,7 @@ class Geant4(CMakePackage):
     # As released, 10.0.4 has inconsistently capitalised filenames
     # in the cmake files; this patch also enables cxxstd 14
     patch("geant4-10.0.4.patch", when="@10.0.4")
-    patch("columns.patch", when="@10.4")
+    patch("columns.patch", when="@10.4:")
     # As released, 10.03.03 has issues with respect to using external
     # CLHEP.
     patch("CLHEP-10.03.03.patch", level=1, when="@10.3")

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -207,7 +207,9 @@ class Geant4(CMakePackage):
     # As released, 10.0.4 has inconsistently capitalised filenames
     # in the cmake files; this patch also enables cxxstd 14
     patch("geant4-10.0.4.patch", when="@10.0.4")
-    patch("columns.patch", when="@10.4:")
+    # Fix member field typo in g4tools wroot
+    # See https://bugzilla-geant4.kek.jp/show_bug.cgi?id=2640
+    patch("columns.patch", when="@10.4:11.2.2")
     # As released, 10.03.03 has issues with respect to using external
     # CLHEP.
     patch("CLHEP-10.03.03.patch", level=1, when="@10.3")

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -207,6 +207,7 @@ class Geant4(CMakePackage):
     # As released, 10.0.4 has inconsistently capitalised filenames
     # in the cmake files; this patch also enables cxxstd 14
     patch("geant4-10.0.4.patch", when="@10.0.4")
+    patch("columns.patch", when="@10.4")
     # As released, 10.03.03 has issues with respect to using external
     # CLHEP.
     patch("CLHEP-10.03.03.patch", level=1, when="@10.3")


### PR DESCRIPTION
Hello again. There is a typo in geant4. Quite weird that it's not cathced for such a long time.

@drbenmorgan  @sethrj