### PR TITLE
py-greenlet: remove preference for v2.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-greenlet/package.py
+++ b/var/spack/repos/builtin/packages/py-greenlet/package.py
@@ -20,11 +20,7 @@ class PyGreenlet(PythonPackage):
     version("3.1.1", sha256="4ce3ac6cdb6adf7946475d7ef31777c26d94bccc377e070a7986bd2d5c515467")
     version("3.0.3", sha256="43374442353259554ce33599da8b692d5aa96f8976d567d4badf263371fbe491")
     version("3.0.0a1", sha256="1bd4ea36f0aeb14ca335e0c9594a5aaefa1ac4e2db7d86ba38f0be96166b3102")
-    version(
-        "2.0.2",
-        sha256="e7c8dc13af7db097bed64a051d2dd49e9f0af495c26995c00a9ee842690d34c0",
-        preferred=True,
-    )
+    version("2.0.2", sha256="e7c8dc13af7db097bed64a051d2dd49e9f0af495c26995c00a9ee842690d34c0")
     version("1.1.3", sha256="bcb6c6dd1d6be6d38d6db283747d07fda089ff8c559a835236560a4410340455")
     version("1.1.2", sha256="e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a")
     version("1.1.0", sha256="c87df8ae3f01ffb4483c796fe1b15232ce2b219f0b18126948616224d3f658ee")

--- a/var/spack/repos/builtin/packages/py-greenlet/package.py
+++ b/var/spack/repos/builtin/packages/py-greenlet/package.py
@@ -37,3 +37,5 @@ class PyGreenlet(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@40.8.0:", type="build", when="@3.0.2:")
+
+    conflicts("%gcc@:7", when="@3.1.1:", msg="GCC-8 required as of 3.1.1")


### PR DESCRIPTION
This PR removes the preference for `py-greenlet`, v2.0.2. There is no documented reason, only historical:
- #39164 added an alpha release and marked the latest stable version as preferred,
- #47647 added stable releases and should have removed the preferred.