### PR TITLE
Refactor web to use pathlib

### DIFF
--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -384,12 +384,12 @@ def ssl_scrubbed_env(mutable_config, monkeypatch):
     "cert_path,cert_creator",
     [
         pytest.param(
-            lambda base_path: fs_path(abstract_path(base_path, "mock_cert.crt")),
+            lambda base_path: fs_path(base_path / "mock_cert.crt"),
             lambda cert_path: open(cert_path, "w", encoding="utf-8").close(),
             id="cert_file",
         ),
         pytest.param(
-            lambda base_path: fs_path(abstract_path(base_path, "mock_cert")),
+            lambda base_path: fs_path(base_path / "mock_cert"),
             lambda cert_path: concrete_path(cert_path).mkdir(),
             id="cert_directory",
         ),

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -413,7 +413,7 @@ def test_ssl_urllib(
 
     monkeypatch.setattr(ssl.SSLContext, "load_verify_locations", mock_verify_locations)
 
-    with working_dir(str(tmp_path)):
+    with working_dir(tmp_path):
         mock_cert = cert_path(tmp_path)
         cert_creator(mock_cert)
         spack.config.set("config:ssl_certs", mock_cert)
@@ -431,7 +431,7 @@ def test_ssl_curl_cert_file(cert_exists, tmp_path, ssl_scrubbed_env, mutable_con
     with CURL_CA_BUNDLE in the env
     """
     spack.config.set("config:url_fetch_method", "curl")
-    with working_dir(str(tmp_path)):
+    with working_dir(tmp_path):
         mock_cert = tmp_path / "mock_cert.crt"
         spack.config.set("config:ssl_certs", os.fspath(mock_cert))
         if cert_exists:

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -11,9 +11,8 @@ from pathlib import Path, PurePath
 
 import pytest
 
-from llnl.util.filesystem import working_dir
-
 import llnl.util.tty as tty
+from llnl.util.filesystem import working_dir
 
 import spack.config
 import spack.mirrors.mirror

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import collections
 import email.message
-import os
 import pickle
 import ssl
 import urllib.request
@@ -19,7 +18,7 @@ import spack.url
 import spack.util.s3
 import spack.util.url as url_util
 import spack.util.web
-from spack.util.path import fs_path, abstract_path, concrete_path 
+from spack.util.path import abstract_path, concrete_path, fs_path
 from spack.version import Version
 
 

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -200,9 +200,9 @@ def concrete_path(*path_strings):
 
 
 def fs_path(path_object):
-    """Cast path object to path underlying representation (str | bytes). 
-    
-    If str or byte is passed in, it is returned unchanged. If an input is not 
+    """Cast path object to path underlying representation (str | bytes).
+
+    If str or byte is passed in, it is returned unchanged. If an input is not
     a str, byte, or PathLike object it will return a TypeError."""
     return os.fspath(path_object)
 

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import tempfile
 from datetime import date
+from pathlib import Path, PurePath
 
 import llnl.util.tty as tty
 from llnl.util.lang import memoized
@@ -186,6 +187,24 @@ def substitute_config_variables(path):
 
     # Replace $var or ${var}.
     return re.sub(r"(\$\w+\b|\$\{\w+\})", repl, path)
+
+
+def abstract_path(*path_strings):
+    """Cast string path or combine parts of a path to a PurePath object"""
+    return PurePath(*path_strings)
+
+
+def concrete_path(*path_strings):
+    """Cast string path or combine parts of a path to a Path object"""
+    return Path(*path_strings)
+
+
+def fs_path(path_object):
+    """Cast path object to path underlying representation (str | bytes). 
+    
+    If str or byte is passed in, it is returned unchanged. If an input is not 
+    a str, byte, or PathLike object it will return a TypeError."""
+    return os.fspath(path_object)
 
 
 def substitute_path_variables(path):

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -14,7 +14,6 @@ import subprocess
 import sys
 import tempfile
 from datetime import date
-from pathlib import Path, PurePath
 
 import llnl.util.tty as tty
 from llnl.util.lang import memoized
@@ -187,24 +186,6 @@ def substitute_config_variables(path):
 
     # Replace $var or ${var}.
     return re.sub(r"(\$\w+\b|\$\{\w+\})", repl, path)
-
-
-def abstract_path(*path_strings):
-    """Cast string path or combine parts of a path to a PurePath object"""
-    return PurePath(*path_strings)
-
-
-def concrete_path(*path_strings):
-    """Cast string path or combine parts of a path to a Path object"""
-    return Path(*path_strings)
-
-
-def fs_path(path_object):
-    """Cast path object to path underlying representation (str | bytes).
-
-    If str or byte is passed in, it is returned unchanged. If an input is not
-    a str, byte, or PathLike object it will return a TypeError."""
-    return os.fspath(path_object)
 
 
 def substitute_path_variables(path):

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -11,10 +11,9 @@ import posixpath
 import re
 import urllib.parse
 import urllib.request
-from pathlib import Path, PurePath
 from typing import Optional
 
-from spack.util.path import sanitize_filename
+from spack.util.path import fs_path, concrete_path, sanitize_filename
 
 
 def validate_scheme(scheme):
@@ -41,9 +40,10 @@ def local_file_path(url):
 
 
 def path_to_file_url(path):
-    if not PurePath(path).is_absolute():
-        path = Path(path).resolve()
-    return urllib.parse.urljoin("file:", urllib.request.pathname2url(os.fspath(path)))
+    path = concrete_path(path)
+    if not path.is_absolute():
+        path = path.resolve()
+    return urllib.parse.urljoin("file:", urllib.request.pathname2url(fs_path(path)))
 
 
 def file_url_string_to_path(url):

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -6,14 +6,13 @@
 Utility functions for parsing, formatting, and manipulating URLs.
 """
 
-import os
 import posixpath
 import re
 import urllib.parse
 import urllib.request
 from typing import Optional
 
-from spack.util.path import fs_path, concrete_path, sanitize_filename
+from spack.util.path import concrete_path, fs_path, sanitize_filename
 
 
 def validate_scheme(scheme):

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -11,6 +11,7 @@ import posixpath
 import re
 import urllib.parse
 import urllib.request
+from pathlib import Path, PurePath
 from typing import Optional
 
 from spack.util.path import sanitize_filename
@@ -40,9 +41,9 @@ def local_file_path(url):
 
 
 def path_to_file_url(path):
-    if not os.path.isabs(path):
-        path = os.path.abspath(path)
-    return urllib.parse.urljoin("file:", urllib.request.pathname2url(path))
+    if not PurePath(path).is_absolute():
+        path = Path(path).resolve()
+    return urllib.parse.urljoin("file:", urllib.request.pathname2url(os.fspath(path)))
 
 
 def file_url_string_to_path(url):

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -6,13 +6,15 @@
 Utility functions for parsing, formatting, and manipulating URLs.
 """
 
+import os
 import posixpath
 import re
 import urllib.parse
 import urllib.request
+from pathlib import Path
 from typing import Optional
 
-from spack.util.path import concrete_path, fs_path, sanitize_filename
+from spack.util.path import sanitize_filename
 
 
 def validate_scheme(scheme):
@@ -39,10 +41,10 @@ def local_file_path(url):
 
 
 def path_to_file_url(path):
-    path = concrete_path(path)
+    path = Path(path)
     if not path.is_absolute():
         path = path.resolve()
-    return urllib.parse.urljoin("file:", urllib.request.pathname2url(fs_path(path)))
+    return urllib.parse.urljoin("file:", urllib.request.pathname2url(os.fspath(path)))
 
 
 def file_url_string_to_path(url):

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -15,7 +15,7 @@ import sys
 import traceback
 import urllib.parse
 from html.parser import HTMLParser
-from pathlib import Path, PurePath, PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import IO, Dict, Iterable, List, Optional, Set, Tuple, Union
 from urllib.error import HTTPError, URLError
 from urllib.request import HTTPSHandler, Request, build_opener
@@ -31,6 +31,7 @@ import spack.util.executable
 import spack.util.parallel
 import spack.util.path
 import spack.util.url as url_util
+from spack.util.path import abstract_path, concrete_path, fs_path
 
 from .executable import CommandNotFoundError, Executable
 from .gcs import GCSBlob, GCSBucket, GCSHandler
@@ -67,12 +68,12 @@ def custom_ssl_certs() -> Optional[Tuple[bool, str]]:
     ssl_certs = spack.config.get("config:ssl_certs")
     if not ssl_certs:
         return None
-    path = spack.util.path.substitute_path_variables(ssl_certs)
-    if not PurePath(path).is_absolute():
+    path = concrete_path(spack.util.path.substitute_path_variables(ssl_certs))
+    if not path.is_absolute():
         tty.debug(f"certs: relative path not allowed: {path}")
         return None
     try:
-        st = Path(path).stat()
+        st = path.stat()
     except OSError as e:
         tty.debug(f"certs: error checking path {path}: {e}")
         return None
@@ -83,7 +84,7 @@ def custom_ssl_certs() -> Optional[Tuple[bool, str]]:
         tty.debug(f"certs: not a file or directory: {path}")
         return None
 
-    return (file_type == stat.S_IFREG, path)
+    return (file_type == stat.S_IFREG, fs_path(path))
 
 
 def ssl_create_default_context():
@@ -231,9 +232,10 @@ def read_from_url(url, accept_content_type=None):
 
 def push_to_url(local_file_path, remote_path, keep_original=True, extra_args=None):
     remote_url = urllib.parse.urlparse(remote_path)
+    local_file_path = concrete_path(local_file_path)
     if remote_url.scheme == "file":
-        remote_file_path = url_util.local_file_path(remote_url)
-        mkdirp(PurePath(remote_file_path).parent)
+        remote_file_path = concrete_path(url_util.local_file_path(remote_url))
+        remote_file_path.parent.mkdir()
         if keep_original:
             shutil.copy(local_file_path, remote_file_path)
         else:
@@ -246,7 +248,7 @@ def push_to_url(local_file_path, remote_path, keep_original=True, extra_args=Non
                     # metadata), and then delete the original.  This operation
                     # needs to be done in separate steps.
                     shutil.copy2(local_file_path, remote_file_path)
-                    Path(local_file_path).unlink()
+                    local_file_path.unlink()
                 else:
                     raise
 
@@ -262,13 +264,13 @@ def push_to_url(local_file_path, remote_path, keep_original=True, extra_args=Non
         s3.upload_file(local_file_path, remote_url.netloc, remote_path, ExtraArgs=extra_args)
 
         if not keep_original:
-            Path(local_file_path).unlink()
+            local_file_path.unlink()
 
     elif remote_url.scheme == "gs":
         gcs = GCSBlob(remote_url)
         gcs.upload_to_blob(local_file_path)
         if not keep_original:
-            Path(local_file_path).unlink()
+            local_file_path.unlink()
 
     else:
         raise NotImplementedError(f"Unrecognized URL scheme: {remote_url.scheme}")
@@ -383,8 +385,8 @@ def fetch_url_text(url, curl: Optional[Executable] = None, dest_dir="."):
 
     tty.debug("Fetching text at {0}".format(url))
 
-    filename = PurePath(url).name
-    path = os.fsdecode(PurePath(dest_dir, filename))
+    filename = abstract_path(url).name
+    path = fs_path(abstract_path(dest_dir, filename))
 
     fetch_method = spack.config.get("config:url_fetch_method")
     tty.debug("Using '{0}' to fetch {1} into {2}".format(fetch_method, url, path))
@@ -476,10 +478,11 @@ def remove_url(url, recursive=False):
 
     local_path = url_util.local_file_path(url)
     if local_path:
+        local_path = concrete_path(local_path)
         if recursive:
             shutil.rmtree(local_path)
         else:
-            Path(local_path).unlink()
+            local_path.unlink()
         return
 
     if url.scheme == "s3":
@@ -534,7 +537,7 @@ def _iter_s3_contents(contents, prefix):
         if not key.startswith("/"):
             key = "/" + key
 
-        key = os.fsdecode(PurePath(key).relative_to(prefix))
+        key = fs_path(abstract_path(key).relative_to(prefix))
 
         if key == ".":
             continue
@@ -576,8 +579,9 @@ def _iter_s3_prefix(client, url, num_entries=1024):
 
 def _iter_local_prefix(path):
     for root, _, files in os.walk(path):
+        root = abstract_path(root)
         for f in files:
-            yield PurePath(root, f).relative_to(path)
+            yield (root / f).relative_to(path)
 
 
 def list_url(url, recursive=False):
@@ -585,13 +589,14 @@ def list_url(url, recursive=False):
     local_path = url_util.local_file_path(url)
 
     if local_path:
+        local_path = concrete_path(local_path)
         if recursive:
             # convert backslash to forward slash as required for URLs
-            return [os.fsdecode(PurePosixPath(p)) for p in _iter_local_prefix(local_path)]
+            return [fs_path(PurePosixPath(p)) for p in _iter_local_prefix(local_path)]
         return [
             subpath.name
-            for subpath in Path(local_path).iterdir()
-            if Path(local_path, subpath).is_file()
+            for subpath in local_path.iterdir()
+            if (local_path / subpath).is_file()
         ]
 
     if url.scheme == "s3":

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -15,14 +15,14 @@ import sys
 import traceback
 import urllib.parse
 from html.parser import HTMLParser
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
 from typing import IO, Dict, Iterable, List, Optional, Set, Tuple, Union
 from urllib.error import HTTPError, URLError
 from urllib.request import HTTPSHandler, Request, build_opener
 
 import llnl.url
 from llnl.util import lang, tty
-from llnl.util.filesystem import mkdirp, rename, working_dir
+from llnl.util.filesystem import rename, working_dir
 
 import spack
 import spack.config
@@ -594,9 +594,7 @@ def list_url(url, recursive=False):
             # convert backslash to forward slash as required for URLs
             return [fs_path(PurePosixPath(p)) for p in _iter_local_prefix(local_path)]
         return [
-            subpath.name
-            for subpath in local_path.iterdir()
-            if (local_path / subpath).is_file()
+            subpath.name for subpath in local_path.iterdir() if (local_path / subpath).is_file()
         ]
 
     if url.scheme == "s3":

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -22,7 +22,7 @@ from urllib.request import HTTPSHandler, Request, build_opener
 
 import llnl.url
 from llnl.util import lang, tty
-from llnl.util.filesystem import rename, working_dir
+from llnl.util.filesystem import mkdirp, rename, working_dir
 
 import spack
 import spack.config
@@ -234,8 +234,8 @@ def push_to_url(local_file_path, remote_path, keep_original=True, extra_args=Non
     remote_url = urllib.parse.urlparse(remote_path)
     local_file_path = concrete_path(local_file_path)
     if remote_url.scheme == "file":
-        remote_file_path = concrete_path(url_util.local_file_path(remote_url))
-        remote_file_path.parent.mkdir()
+        remote_file_path = abstract_path(url_util.local_file_path(remote_url))
+        mkdirp(remote_file_path.parent)
         if keep_original:
             shutil.copy(local_file_path, remote_file_path)
         else:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Aims to refactor the web module so it uses pathlib instead of os.path (and other os functionality).

str(Path()) is not advised as it could return null. Instead, it is recommended to use os.fspath() or os.fsdecode(). The former returns the file system representation of the path. This can either be a string or bytes. The later returns a string encoding of the Path object. Python docs reference: https://docs.python.org/3/library/os.html#os.fsencode

Here is Github comment I found regarding str(Path) vs. os.fspath() / os.fsdecode():
https://github.com/astral-sh/ruff/issues/3675#issuecomment-1494975508