### PR TITLE
mapl: add v2.51.0

### DIFF
--- a/var/spack/repos/builtin/packages/mapl/package.py
+++ b/var/spack/repos/builtin/packages/mapl/package.py
@@ -39,6 +39,8 @@ class Mapl(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("2.51.0", sha256="56213d845f5287e599213aab1dea60bf6b64c29cd8093313639304b270c45676")
+    version("2.50.3", sha256="506f73d511b6a63645bbf953bf04f663da06f5069cb559340786e9fe8eeb170f")
     version("2.50.2", sha256="1c72f8598cf01bab6ef30c1f461444ba5a13f55c61164b7b3c15efb0cd1096c0")
     version("2.50.1", sha256="26dd7a3ec82d484d60a559bb90a20ad9a2a717af52c25b6a752dd971aeeb5075")
     version("2.50.0", sha256="12282e547936f667f85c95d466273dcbaccbd600add72fa5981c0c734ccb1f7d")
@@ -160,8 +162,14 @@ class Mapl(CMakePackage):
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
+        tag="v3.55.0",
+        when="@2.51:",
+    )
+    resource(
+        name="esma_cmake",
+        git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v3.51.0",
-        when="@2.48:",
+        when="@2.48:2.50",
     )
     resource(
         name="esma_cmake",
@@ -240,6 +248,11 @@ class Mapl(CMakePackage):
     # builds with gcc 13 from that version onwards
     conflicts("%gcc@13:", when="@:2.44")
 
+    # MAPL can use ifx only from MAPL 2.51 onwards and only supports
+    # ifx 2025.0 and newer due to bugs in ifx
+    conflicts("%oneapi@:2024")
+    conflicts("%oneapi", when="@:2.50")
+
     variant("flap", default=False, description="Build with FLAP support", when="@:2.39")
     variant("pflogger", default=True, description="Build with pFlogger support")
     variant("fargparse", default=True, description="Build with fArgParse support")
@@ -261,7 +274,8 @@ class Mapl(CMakePackage):
     conflicts("+pflogger", when="@:2.40.3 %intel@2021.7:")
     conflicts("+extdata2g", when="@:2.40.3 %intel@2021.7:")
 
-    depends_on("cmake@3.23:", type="build", when="@2.50:")
+    depends_on("cmake@3.24:", type="build", when="@2.51:")
+    depends_on("cmake@3.23:", type="build", when="@2.50")
     depends_on("cmake@3.17:", type="build", when="@:2.49")
     depends_on("mpi")
     depends_on("hdf5")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Closes #47901 

This PR adds MAPL 2.51.0 (and 2.50.3 in case this gets in before #47901).

There are some added updates for MAPL 2.51:

1. Requires CMake 3.24
2. Has support for `ifx` 2025.0

That last one I'd like to ask a spack guru (e.g., @alalazo) to make sure I did this right. I have:

```python
    # MAPL can use ifx only from MAPL 2.51 onwards and only supports
    # ifx 2025.0 and newer due to bugs in ifx
    conflicts("%oneapi@:2024")
    conflicts("%oneapi", when="@:2.50")
```

What I'm hoping this means is:

1. MAPL can only use ifx 2025.0 and higher
2. MAPL does not support ifx at all when v2.50 or older