### PR TITLE
various pkgs: use https homepage when http redirects (github.io)

### DIFF
--- a/var/spack/repos/builtin/packages/freesasa/package.py
+++ b/var/spack/repos/builtin/packages/freesasa/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class Freesasa(AutotoolsPackage):
     """C-library for calculating Solvent Accessible Surface Areas"""
 
-    homepage = "http://freesasa.github.io"
+    homepage = "https://freesasa.github.io"
     url = "https://github.com/mittinatten/freesasa/releases/download/2.1.2/freesasa-2.1.2.zip"
     git = "https://github.com/mittinatten/freesasa.git"
     maintainers("RMeli")

--- a/var/spack/repos/builtin/packages/hypar/package.py
+++ b/var/spack/repos/builtin/packages/hypar/package.py
@@ -17,7 +17,7 @@ class Hypar(AutotoolsPackage):
     forms of the hyperbolic flux, parabolic flux, source terms, upwinding functions, etc.
     """
 
-    homepage = "http://hypar.github.io/"
+    homepage = "https://hypar.github.io/"
     url = "https://github.com/debog/hypar/archive/refs/tags/v4.1.tar.gz"
     git = "https://github.com/debog/hypar.git"
 

--- a/var/spack/repos/builtin/packages/pblat/package.py
+++ b/var/spack/repos/builtin/packages/pblat/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class Pblat(MakefilePackage):
     """Parallelized blat with multi-threads support"""
 
-    homepage = "http://icebert.github.io/pblat/"
+    homepage = "https://icebert.github.io/pblat/"
     url = "https://github.com/icebert/pblat/archive/refs/tags/2.5.1.tar.gz"
 
     # `pblat` shares the license for Jim Kent's `blat`. For-profit users must visit:

--- a/var/spack/repos/builtin/packages/py-gpyopt/package.py
+++ b/var/spack/repos/builtin/packages/py-gpyopt/package.py
@@ -13,7 +13,7 @@ class PyGpyopt(PythonPackage):
     Learning algorithms. It is able to handle large data sets via sparse
     Gaussian process models."""
 
-    homepage = "http://sheffieldml.github.io/GPyOpt/"
+    homepage = "https://sheffieldml.github.io/GPyOpt/"
     pypi = "GPyOpt/GPyOpt-1.2.6.tar.gz"
 
     license("BSD-3-Clause")

--- a/var/spack/repos/builtin/packages/py-h5io/package.py
+++ b/var/spack/repos/builtin/packages/py-h5io/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyH5io(PythonPackage):
     """Python Objects Onto HDF5."""
 
-    homepage = "http://h5io.github.io"
+    homepage = "https://h5io.github.io"
     pypi = "h5io/h5io-0.1.7.tar.gz"
     git = "https://github.com/h5io/h5io.git"
 

--- a/var/spack/repos/builtin/packages/py-h5io/package.py
+++ b/var/spack/repos/builtin/packages/py-h5io/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyH5io(PythonPackage):
     """Python Objects Onto HDF5."""
 
-    homepage = "https://h5io.github.io"
+    homepage = "https://github.com/h5io/h5io"
     pypi = "h5io/h5io-0.1.7.tar.gz"
     git = "https://github.com/h5io/h5io.git"
 

--- a/var/spack/repos/builtin/packages/py-owslib/package.py
+++ b/var/spack/repos/builtin/packages/py-owslib/package.py
@@ -11,7 +11,7 @@ class PyOwslib(PythonPackage):
     Consortium (OGC) web service (hence OWS) interface standards, and their
     related content models."""
 
-    homepage = "https://geopython.github.io/OWSLib/#installation"
+    homepage = "https://owslib.readthedocs.io/en/latest/"
     pypi = "OWSLib/OWSLib-0.16.0.tar.gz"
 
     license("BSD-3-Clause")

--- a/var/spack/repos/builtin/packages/py-owslib/package.py
+++ b/var/spack/repos/builtin/packages/py-owslib/package.py
@@ -11,7 +11,7 @@ class PyOwslib(PythonPackage):
     Consortium (OGC) web service (hence OWS) interface standards, and their
     related content models."""
 
-    homepage = "https://http://geopython.github.io/OWSLib/#installation"
+    homepage = "https://geopython.github.io/OWSLib/#installation"
     pypi = "OWSLib/OWSLib-0.16.0.tar.gz"
 
     license("BSD-3-Clause")

--- a/var/spack/repos/builtin/packages/py-owslib/package.py
+++ b/var/spack/repos/builtin/packages/py-owslib/package.py
@@ -11,7 +11,7 @@ class PyOwslib(PythonPackage):
     Consortium (OGC) web service (hence OWS) interface standards, and their
     related content models."""
 
-    homepage = "http://http://geopython.github.io/OWSLib/#installation"
+    homepage = "https://http://geopython.github.io/OWSLib/#installation"
     pypi = "OWSLib/OWSLib-0.16.0.tar.gz"
 
     license("BSD-3-Clause")

--- a/var/spack/repos/builtin/packages/py-phydms/package.py
+++ b/var/spack/repos/builtin/packages/py-phydms/package.py
@@ -13,7 +13,7 @@ class PyPhydms(PythonPackage):
     codon models (ExpCM) for phylogenetic inference and the detection of
     biologically interesting selection."""
 
-    homepage = "http://jbloomlab.github.io/phydms"
+    homepage = "https://jbloomlab.github.io/phydms"
     pypi = "phydms/phydms-2.4.1.tar.gz"
 
     license("GPL-3.0-or-later")


### PR DESCRIPTION
This PR fixes some `homepage` attributes where the http link redirects to https anyway. Also fixes py-owslib homepage.