### PR TITLE
celeritas: patch 0.5.0 for geant4@11.3.0:

### DIFF
--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -102,7 +102,9 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
         sha256="1161c4f1166860d35d2a3f103236a63acd6a35aee2d2c27561cb929941d1c170",
         when="@0.5.0 +geant4 ^geant4@11.3.0:",
     )
-    conflicts("^geant4@11.3.0:", when="@:0.4 +geant4", msg="geant4@11.3.0: requires at least 0.5.0")
+    conflicts(
+        "^geant4@11.3.0:", when="@:0.4 +geant4", msg="geant4@11.3.0: requires at least 0.5.0"
+    )
 
     def cmake_args(self):
         define = self.define

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -96,6 +96,14 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+rocm", when="+cuda", msg="AMD and NVIDIA accelerators are incompatible")
     conflicts("+rocm", when="+vecgeom", msg="HIP support is only available with ORANGE")
 
+    # geant4@11.3.0 now returns const G4Element::GetElementTable()
+    patch(
+        "https://github.com/celeritas-project/celeritas/commit/3c8ed9614fc695fba35e8a058bedb7bc1556f71c.patch?full_index=1",
+        sha256="1161c4f1166860d35d2a3f103236a63acd6a35aee2d2c27561cb929941d1c170",
+        when="@0.5.0 +geant4 ^geant4@11.3.0:",
+    )
+    conflicts("^geant4@11.3.0:", when="@:0.4 +geant4", msg="geant4@11.3.0: requires at least 0.5.0")
+
     def cmake_args(self):
         define = self.define
         from_variant = self.define_from_variant


### PR DESCRIPTION
This PR patches the latest release of `celeritas`, v0.5.0, for the latest release of `geant4@11.3.0:` which changed a function to const where `celeritas` doesn't expect that. The patch is already in main, but no new `celeritas` version has been released yet. This will prevent compilation errors when #47961 is merged.

Test build:
```
==> Installing celeritas-0.5.0-c56c3c5f36stic2cspal3qvwixgpvxsx [142/142]
==> No binary for celeritas-0.5.0-c56c3c5f36stic2cspal3qvwixgpvxsx found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/4a/4a8834224d96fd01897e5872ac109f60d91ef0bd7b63fac05a73dcdb61a5530e.tar.gz
==> Fetching https://github.com/celeritas-project/celeritas/commit/3c8ed9614fc695fba35e8a058bedb7bc1556f71c.patch?full_index=1
==> Applied patch https://github.com/celeritas-project/celeritas/commit/3c8ed9614fc695fba35e8a058bedb7bc1556f71c.patch?full_index=1
==> celeritas: Executing phase: 'cmake'
==> celeritas: Executing phase: 'build'
==> celeritas: Executing phase: 'install'
==> celeritas: Successfully installed celeritas-0.5.0-c56c3c5f36stic2cspal3qvwixgpvxsx
  Stage: 0.79s.  Cmake: 2.78s.  Build: 6m 40.13s.  Install: 0.64s.  Post-install: 0.81s.  Total: 6m 45.54s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/celeritas-0.5.0-c56c3c5f36stic2cspal3qvwixgpvxsx
```