### PR TITLE
mirrors: add missing init file

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -222,9 +222,6 @@ nitpick_ignore = [
     ("py:class", "spack.traverse.EdgeAndDepth"),
     ("py:class", "archspec.cpu.microarchitecture.Microarchitecture"),
     ("py:class", "spack.compiler.CompilerCache"),
-    ("py:class", "spack.mirrors.mirror.Mirror"),
-    ("py:class", "spack.mirrors.layout.MirrorLayout"),
-    ("py:class", "spack.mirrors.utils.MirrorStats"),
     # TypeVar that is not handled correctly
     ("py:class", "llnl.util.lang.T"),
 ]

--- a/lib/spack/spack/mirrors/__init__.py
+++ b/lib/spack/spack/mirrors/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -214,7 +214,9 @@ class MirrorStats:
         self.errors.add(self.current_spec)
 
 
-def create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats):
+def create_mirror_from_package_object(
+    pkg_obj, mirror_cache: "spack.caches.MirrorCache", mirror_stats: MirrorStats
+) -> bool:
     """Add a single package object to a mirror.
 
     The package object is only required to have an associated spec
@@ -222,8 +224,8 @@ def create_mirror_from_package_object(pkg_obj, mirror_cache, mirror_stats):
 
     Args:
         pkg_obj (spack.package_base.PackageBase): package object with to be added.
-        mirror_cache (spack.caches.MirrorCache): mirror where to add the spec.
-        mirror_stats (spack.mirror.MirrorStats): statistics on the current mirror
+        mirror_cache: mirror where to add the spec.
+        mirror_stats: statistics on the current mirror
 
     Return:
         True if the spec was added successfully, False otherwise


### PR DESCRIPTION
without this `spack.mirrors.*` is not considered in the import-check action and not part of docs.

adding v0.23.1 for the bug related to `traceback`.