### PR TITLE
spec.py: move lookup_hash and replace_hash to separate module

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -26,6 +26,7 @@ import spack.extensions
 import spack.paths
 import spack.repo
 import spack.spec
+import spack.spec_lookup
 import spack.spec_parser
 import spack.store
 import spack.traverse as traverse
@@ -211,7 +212,8 @@ def _concretize_spec_pairs(
     ):
         # Get all the concrete specs
         ret = [
-            concrete or (abstract if abstract.concrete else abstract.lookup_hash())
+            concrete
+            or (abstract if abstract.concrete else spack.spec_lookup.lookup_hash(abstract))
             for abstract, concrete in to_concretize
         ]
 

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -11,6 +11,7 @@ from llnl.util.tty.color import cprint, get_color_when
 import spack.cmd
 import spack.environment as ev
 import spack.solver.asp as asp
+import spack.spec_lookup
 import spack.util.spack_json as sjson
 from spack.cmd.common import arguments
 
@@ -210,7 +211,7 @@ def diff(parser, args):
     specs = []
     for spec in spack.cmd.parse_specs(args.specs):
         # If the spec has a hash, check it before disambiguating
-        spec.replace_hash()
+        spack.spec_lookup.replace_hash(spec)
         if spec.concrete:
             specs.append(spec)
         else:

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -199,10 +199,12 @@ def concretize_one(spec: Union[str, Spec], tests: TestsType = False) -> Spec:
             the packages in the list, if True activate 'test' dependencies for all packages.
     """
     from spack.solver.asp import Solver, SpecBuilder
+    from spack.spec_lookup import replace_hash
 
     if isinstance(spec, str):
         spec = Spec(spec)
-    spec = spec.lookup_hash()
+
+    replace_hash(spec)
 
     if spec.concrete:
         return spec.copy()

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -202,3 +202,10 @@ class MirrorError(SpackError):
 
     def __init__(self, msg, long_msg=None):
         super().__init__(msg, long_msg)
+
+
+class InvalidHashError(SpecError):
+    def __init__(self, spec, hash):
+        msg = f"No spec with hash {hash} could be found to match {spec}."
+        msg += " Either the hash does not exist, or it does not match other spec constraints."
+        super().__init__(msg)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -39,6 +39,7 @@ import spack.platforms
 import spack.repo
 import spack.solver.splicing
 import spack.spec
+import spack.spec_lookup
 import spack.store
 import spack.util.crypto
 import spack.util.libc
@@ -3774,7 +3775,7 @@ class SpecBuilder:
 
                     # The first iteration, we need to replace the abstract hash
                     if not replacement.concrete:
-                        replacement.replace_hash()
+                        spack.spec_lookup.replace_hash(replacement)
                     current_spec = current_spec.splice(replacement, transitive)
             new_key = NodeArgument(id=key.id, pkg=current_spec.name)
             specs[new_key] = current_spec
@@ -4133,7 +4134,7 @@ class Solver:
           setup_only (bool): if True, stop after setup and don't solve (default False).
           allow_deprecated (bool): allow deprecated version in the solve
         """
-        specs = [s.lookup_hash() for s in specs]
+        specs = [spack.spec_lookup.lookup_hash(s) for s in specs]
         reusable_specs = self._check_input_and_extract_concrete_specs(specs)
         reusable_specs.extend(self.selector.reusable_specs(specs))
         setup = SpackSolverSetup(tests=tests)
@@ -4170,7 +4171,7 @@ class Solver:
             tests (bool): add test dependencies to the solve
             allow_deprecated (bool): allow deprecated version in the solve
         """
-        specs = [s.lookup_hash() for s in specs]
+        specs = [spack.spec_lookup.lookup_hash(s) for s in specs]
         reusable_specs = self._check_input_and_extract_concrete_specs(specs)
         reusable_specs.extend(self.selector.reusable_specs(specs))
         setup = SpackSolverSetup(tests=tests)

--- a/lib/spack/spack/spec_list.py
+++ b/lib/spack/spack/spec_list.py
@@ -5,6 +5,7 @@ import itertools
 from typing import List
 
 import spack.spec
+import spack.spec_lookup
 import spack.variant
 from spack.error import SpackError
 from spack.spec import Spec
@@ -230,7 +231,7 @@ def _expand_matrix_constraints(matrix_config):
             pass
 
         # Resolve abstract hashes for exclusion criteria
-        if any(test_spec.lookup_hash().satisfies(x) for x in excludes):
+        if any(spack.spec_lookup.lookup_hash(test_spec).satisfies(x) for x in excludes):
             continue
 
         if sigil:

--- a/lib/spack/spack/spec_lookup.py
+++ b/lib/spack/spack/spec_lookup.py
@@ -1,0 +1,79 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import spack.binary_distribution
+import spack.environment
+import spack.error
+import spack.spec
+import spack.store
+
+from .enums import InstallRecordStatus
+
+
+def _lookup_hash(spec: spack.spec.Spec):
+    """Lookup just one spec with an abstract hash, returning a spec from the the environment,
+    store, or finally, binary caches."""
+
+    active_env = spack.environment.active_environment()
+
+    # First env, then store, then binary cache
+    matches = (
+        (active_env.all_matching_specs(spec) if active_env else [])
+        or spack.store.STORE.db.query(spec, installed=InstallRecordStatus.ANY)
+        or spack.binary_distribution.BinaryCacheQuery(True)(spec)
+    )
+
+    if not matches:
+        raise spack.error.InvalidHashError(spec, spec.abstract_hash)
+
+    if len(matches) != 1:
+        raise AmbiguousHashError(
+            f"Multiple packages specify hash beginning '{spec.abstract_hash}'.", *matches
+        )
+
+    return matches[0]
+
+
+def lookup_hash(spec: spack.spec.Spec) -> spack.spec.Spec:
+    """Given a spec with an abstract hash, return a copy of the spec with all properties and
+    dependencies by looking up the hash in the environment, store, or finally, binary caches.
+    This is non-destructive."""
+    if spec.concrete or not any(node.abstract_hash for node in spec.traverse()):
+        return spec
+
+    spec = spec.copy(deps=False)
+    # root spec is replaced
+    if spec.abstract_hash:
+        spec._dup(_lookup_hash(spec))
+        return spec
+
+    # Get dependencies that need to be replaced
+    for node in spec.traverse(root=False):
+        if node.abstract_hash:
+            spec._add_dependency(_lookup_hash(node), depflag=0, virtuals=())
+
+    # reattach nodes that were not otherwise satisfied by new dependencies
+    for node in spec.traverse(root=False):
+        if not any(n.satisfies(node) for n in spec.traverse()):
+            spec._add_dependency(node.copy(), depflag=0, virtuals=())
+
+    return spec
+
+
+def replace_hash(spec: spack.spec.Spec) -> None:
+    """Given a spec with an abstract hash, attempt to populate all properties and dependencies
+    by looking up the hash in the environment, store, or finally, binary caches.
+    This is destructive."""
+
+    if not any(node for node in spec.traverse(order="post") if node.abstract_hash):
+        return
+
+    spec._dup(lookup_hash(spec))
+
+
+class AmbiguousHashError(spack.error.SpecError):
+    def __init__(self, msg, *specs):
+        spec_fmt = "{namespace}.{name}{@version}{%compiler}{compiler_flags}"
+        spec_fmt += "{variants}{ arch=architecture}{/hash:7}"
+        specs_str = "\n  " + "\n  ".join(spec.format(spec_fmt) for spec in specs)
+        super().__init__(msg + specs_str)

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -427,9 +427,9 @@ class TestSpecSemantics:
         """Test that Specs specified only by their incompatible hashes fail appropriately."""
         lhs = "/" + database.query_one("callpath ^mpich").dag_hash()
         rhs = "/" + database.query_one("callpath ^mpich2").dag_hash()
-        with pytest.raises(spack.spec.InvalidHashError):
+        with pytest.raises(spack.error.InvalidHashError):
             Spec(lhs).constrain(Spec(rhs))
-        with pytest.raises(spack.spec.InvalidHashError):
+        with pytest.raises(spack.error.InvalidHashError):
             Spec(lhs[:7]).constrain(Spec(rhs))
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes the circular import between `spack.spec` and `spack.binary_distribution`.