### PR TITLE
node-js: patch for %gcc@12.[1-2] when @22.2:22.5

### DIFF
--- a/var/spack/repos/builtin/packages/node-js/fix-broken-gcc12-pr53728.patch
+++ b/var/spack/repos/builtin/packages/node-js/fix-broken-gcc12-pr53728.patch
@@ -1,0 +1,25 @@
+diff --git a/deps/v8/src/base/macros.h b/deps/v8/src/base/macros.h
+index 210885af3c3c0a35111d9fcbbcce95e1570c7a23..d404b6120ab86ff598def668442b444afeb88ebd 100644
+--- a/deps/v8/src/base/macros.h
++++ b/deps/v8/src/base/macros.h
+@@ -173,7 +173,7 @@ namespace base {
+ // base::is_trivially_copyable will differ for these cases.
+ template <typename T>
+ struct is_trivially_copyable {
+-#if V8_CC_MSVC
++#if V8_CC_MSVC || (__GNUC__ == 12 && __GNUC_MINOR__ <= 2)
+   // Unfortunately, MSVC 2015 is broken in that std::is_trivially_copyable can
+   // be false even though it should be true according to the standard.
+   // (status at 2018-02-26, observed on the msvc waterfall bot).
+@@ -181,6 +181,11 @@ struct is_trivially_copyable {
+   // intended, so we reimplement this according to the standard.
+   // See also https://developercommunity.visualstudio.com/content/problem/
+   //          170883/msvc-type-traits-stdis-trivial-is-bugged.html.
++  //
++  // GCC 12.1 and 12.2 are broken too, they are shipped by some stable Linux
++  // distributions, so the same polyfill is also used.
++  // See
++  // https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=aeba3e009b0abfccaf01797556445dbf891cc8dc
+   static constexpr bool value =
+       // Copy constructor is trivial or deleted.
+       (std::is_trivially_copy_constructible<T>::value ||

--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -103,6 +103,14 @@ class NodeJs(Package):
     # See https://github.com/nodejs/node/issues/52223
     patch("fix-old-glibc-random-headers.patch", when="^glibc@:2.24")
 
+    # Work around gcc-12.[1-2] compiler bug
+    # See https://github.com/nodejs/node/pull/53728
+    patch(
+        "https://github.com/nodejs/node/commit/8027a7be93f85b48957df5c4ecd27292596151fc.patch?full_index=1",
+        sha256="e13c541c9405dea62754b76ae98264eba5b4d8fb6b2c504c828647f6061dd534",
+        when="@22.2:22",
+    )
+
     def setup_build_environment(self, env):
         # Force use of experimental Python 3 support
         env.set("PYTHON", self.spec["python"].command.path)

--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -105,11 +105,8 @@ class NodeJs(Package):
 
     # Work around gcc-12.[1-2] compiler bug
     # See https://github.com/nodejs/node/pull/53728
-    patch(
-        "https://github.com/nodejs/node/commit/8027a7be93f85b48957df5c4ecd27292596151fc.patch?full_index=1",
-        sha256="e13c541c9405dea62754b76ae98264eba5b4d8fb6b2c504c828647f6061dd534",
-        when="@22.2:22",
-    )
+    # and https://github.com/nodejs/node/issues/53633
+    patch("fix-broken-gcc12-pr53728.patch", when="@22.2:22.5")
 
     def setup_build_environment(self, env):
         # Force use of experimental Python 3 support


### PR DESCRIPTION
This PR patches a compilation error in `node-js` (in its vendored `v8`) that prevents compilation of `node-js@22.2:22.5` with `gcc@12.1:12.2` (default on Debian-12, stable, bookworm). See https://github.com/nodejs/node/pull/53728 and https://github.com/nodejs/node/issues/53633 (with comment identifying starting commit).