### PR TITLE
py-dask: fix py-versioneer version pin

### DIFF
--- a/var/spack/repos/builtin/packages/py-dask/package.py
+++ b/var/spack/repos/builtin/packages/py-dask/package.py
@@ -61,6 +61,7 @@ class PyDask(PythonPackage):
     depends_on("py-partd@1.4.0:", type=("build", "run"), when="@2024.7.1:")
     depends_on("py-click@7.0:", type=("build", "run"), when="@2022.10.2:")
     depends_on("py-click@8.0:", type=("build", "run"), when="@2023.4.1:")
+    depends_on("py-click@8.1:", type=("build", "run"), when="@2023.11.0:")
     depends_on("py-importlib-metadata@4.13.0:", type=("build", "run"), when="@2023.4.0:")
 
     # Requirements for dask.array

--- a/var/spack/repos/builtin/packages/py-dask/package.py
+++ b/var/spack/repos/builtin/packages/py-dask/package.py
@@ -43,7 +43,8 @@ class PyDask(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@62.6:", type="build", when="@2023.4.1:")
-    depends_on("py-versioneer@0.28+toml", type="build", when="@2023.4.1:")
+    depends_on("py-versioneer@0.29+toml", type="build", when="@2023.10.1:")
+    depends_on("py-versioneer@0.28+toml", type="build", when="@2023.4.1:2023.10.0")
 
     # Common requirements
     depends_on("py-packaging@20:", type="build", when="@2022.10.2:")

--- a/var/spack/repos/builtin/packages/py-dask/package.py
+++ b/var/spack/repos/builtin/packages/py-dask/package.py
@@ -43,8 +43,8 @@ class PyDask(PythonPackage):
 
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools@62.6:", type="build", when="@2023.4.1:")
-    depends_on("py-versioneer@0.29+toml", type="build", when="@2023.10.1:")
     depends_on("py-versioneer@0.28+toml", type="build", when="@2023.4.1:2023.10.0")
+    depends_on("py-versioneer@0.29+toml", type="build", when="@2023.10.1:")
 
     # Common requirements
     depends_on("py-packaging@20:", type="build", when="@2022.10.2:")


### PR DESCRIPTION
This PR fixes the `py-dask` build dependency on `py-versioneer` for releases after https://github.com/dask/dask/pull/10575.