### PR TITLE
acts dependencies: new versions as of 2024/12/08

### DIFF
--- a/var/spack/repos/builtin/packages/acts-algebra-plugins/package.py
+++ b/var/spack/repos/builtin/packages/acts-algebra-plugins/package.py
@@ -17,6 +17,7 @@ class ActsAlgebraPlugins(CMakePackage):
 
     license("MPL-2.0", checked_by="stephenswat")
 
+    version("0.26.0", sha256="301702e3d0a3d12e46ae6d949f3027ddebd0b1167cbb3004d9a4a5697d3adc7f")
     version("0.25.0", sha256="bb0cba6e37558689d780a6de8f749abb3b96f8cd9e0c8851474eb4532e1e98b8")
     version("0.24.0", sha256="f44753e62b1ba29c28ab86b282ab67ac6028a0f9fe41e599b7fc6fc50b586b62")
 

--- a/var/spack/repos/builtin/packages/acts-algebra-plugins/package.py
+++ b/var/spack/repos/builtin/packages/acts-algebra-plugins/package.py
@@ -23,13 +23,14 @@ class ActsAlgebraPlugins(CMakePackage):
 
     depends_on("cxx", type="build")  # generated
 
-    variant(
-        "cxxstd",
-        default="17",
-        values=("17", "20", "23"),
-        multi=False,
-        description="C++ standard used",
+    _cxxstd_values = (
+        conditional("17", when="@:0.25"),
+        conditional("20", when="@0:"),
+        conditional("23", when="@0:"),
     )
+    _cxxstd_common = {"values": _cxxstd_values, "multi": False, "description": "C++ standard used"}
+    variant("cxxstd", default="17", when="@:0.25", **_cxxstd_common)
+    variant("cxxstd", default="20", when="@0.26:", **_cxxstd_common)
     variant("eigen", default=False, description="Enables the Eigen plugin")
     variant("smatrix", default=False, description="Enables the SMatrix plugin")
     variant("vecmem", default=False, description="Enables the vecmem plugin")

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -430,6 +430,8 @@ class Acts(CMakePackage, CudaPackage):
     conflicts("%gcc@:9", when="cxxstd=20")
     # See https://github.com/acts-project/acts/pull/3512
     conflicts("^boost@1.85.0")
+    # See https://github.com/acts-project/acts/pull/3921
+    conflicts("^edm4hep@0.99:", when="@:37")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -41,6 +41,7 @@ class Acts(CMakePackage, CudaPackage):
     # Supported Acts versions
     version("main", branch="main")
     version("master", branch="main", deprecated=True)  # For compatibility
+    version("38.1.0", commit="8a20c88808f10bf4fcdfd7c6e077f23614c3ab90", submodules=True)
     version("38.0.0", commit="0a6b5155e29e3b755bf351b8a76067fff9b4214b", submodules=True)
     version("37.4.0", commit="4ae9a44f54c854599d1d753222ec36e0b5b4e9c7", submodules=True)
     version("37.3.0", commit="b3e856d4dadcda7d1a88a9b846ce5a7acd8410c4", submodules=True)

--- a/var/spack/repos/builtin/packages/covfie/package.py
+++ b/var/spack/repos/builtin/packages/covfie/package.py
@@ -25,6 +25,7 @@ class Covfie(CMakePackage, CudaPackage):
 
     depends_on("cxx", type="build")  # generated
 
+    depends_on("cmake@3.21:", type="build", when="@0.11:")
     depends_on("cmake@3.18:", type="build")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/covfie/package.py
+++ b/var/spack/repos/builtin/packages/covfie/package.py
@@ -20,6 +20,7 @@ class Covfie(CMakePackage, CudaPackage):
 
     maintainers("stephenswat")
 
+    version("0.11.0", sha256="39fcd0f218d3b4f3aacc6af497a8cda8767511efae7a72b47781f10fd4340f4f")
     version("0.10.0", sha256="d44142b302ffc193ad2229f1d2cc6d8d720dd9da8c37989ada4f23018f86c964")
 
     depends_on("cxx", type="build")  # generated

--- a/var/spack/repos/builtin/packages/covfie/package.py
+++ b/var/spack/repos/builtin/packages/covfie/package.py
@@ -25,15 +25,12 @@ class Covfie(CMakePackage, CudaPackage):
 
     depends_on("cxx", type="build")  # generated
 
-    variant("concepts", default=False, description="Enforce C++20 concepts")
-
     depends_on("cmake@3.18:", type="build")
 
     def cmake_args(self):
         args = [
             self.define("COVFIE_PLATFORM_CPU", True),
             self.define_from_variant("COVFIE_PLATFORM_CUDA", "cuda"),
-            self.define_from_variant("COVFIE_REQUIRE_CXX20", "concepts"),
             self.define("COVFIE_QUIET", True),
         ]
 

--- a/var/spack/repos/builtin/packages/detray/package.py
+++ b/var/spack/repos/builtin/packages/detray/package.py
@@ -20,6 +20,8 @@ class Detray(CMakePackage):
 
     license("MPL-2.0", checked_by="stephenswat")
 
+    version("0.85.0", sha256="a0121a27fd08243d4a6aab060e8ab379ad5129e96775b45f6a683835767fa8e7")
+    version("0.84.0", sha256="b1d133a97dc90b1513f8c1ef235ceaa542d80243028a41f59a79300c7d71eb25")
     version("0.83.0", sha256="c870a0459d1f9284750f6afbb97c759392e636b56d107f32b9bc891df717a0fe")
     version("0.82.0", sha256="48794d37496dd5013b755d5d401da7b9d1023fadff86b2a454e5c21e2aaf8c60")
     version("0.81.0", sha256="821313a7e3ea90fcf5c92153d28bba1f85844e03d7c6b6b98d0b3407adb86357")

--- a/var/spack/repos/builtin/packages/geomodel/package.py
+++ b/var/spack/repos/builtin/packages/geomodel/package.py
@@ -18,6 +18,7 @@ class Geomodel(CMakePackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("6.7.0", sha256="bfa69062ba191d0844d7099b28c0d6c3c0f87e726dacfaa21dba7a6f593d34bf")
     version("6.6.0", sha256="3cefeaa409177d45d3fa63e069b6496ca062991b0d7d71275b1748487659e91b")
     version("6.5.0", sha256="8a2f71493e54ea4d393f4c0075f3ca13df132f172c891825f3ab949cda052c5f")
     version("6.4.0", sha256="369f91f021be83d294ba6a9bdbe00077625e9fe798a396aceece8970e7dd5838")


### PR DESCRIPTION
This commit includes a new version of ACTS, as well as new versions of the ACTS algebra plugins, covfie, detray, and GeoModel.