### PR TITLE
py-plac: add v1.4.3; restrict to python@:3.11 for older

### DIFF
--- a/var/spack/repos/builtin/packages/py-plac/package.py
+++ b/var/spack/repos/builtin/packages/py-plac/package.py
@@ -18,8 +18,10 @@ class PyPlac(PythonPackage):
 
     license("BSD-2-Clause")
 
+    version("1.4.3", sha256="d4cb3387b2113a28aebd509433d0264a4e5d9bb7c1a86db4fbd0a8f11af74eb3")
     version("1.3.5", sha256="38bdd864d0450fb748193aa817b9c458a8f5319fbf97b2261151cfc0a5812090")
     version("1.3.3", sha256="51e332dabc2aed2cd1f038be637d557d116175101535f53eaa7ae854a00f2a74")
     version("1.1.3", sha256="398cb947c60c4c25e275e1f1dadf027e7096858fb260b8ece3b33bcff90d985f")
 
+    depends_on("python@:3.11", type=("build", "run"), when="@:1.3")
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
This PR adds `py-plac`, v1.4.3, which supports python@3.12 (https://github.com/ialbert/plac/commit/af0c125e7e5bfb65f7eb29764a1f407e011a66d9). No other changes. The older versions are restricted to python@:3.11.