### PR TITLE
soci: add v4.0.3 (Fix compile issue wrt SIGSTKSZ no longer being a constant)

### DIFF
--- a/var/spack/repos/builtin/packages/soci/package.py
+++ b/var/spack/repos/builtin/packages/soci/package.py
@@ -10,10 +10,11 @@ class Soci(CMakePackage):
     """Official repository of the SOCI - The C++ Database Access Library"""
 
     homepage = "https://github.com/SOCI/soci"
-    url = "https://github.com/SOCI/soci/archive/v4.0.2.tar.gz"
+    url = "https://github.com/SOCI/soci/archive/v4.0.3.tar.gz"
 
     license("BSL-1.0")
 
+    version("4.0.3", sha256="4b1ff9c8545c5d802fbe06ee6cd2886630e5c03bf740e269bb625b45cf934928")
     version("4.0.2", sha256="f293192a412ed82693d17dfe46e2734b140bff835bc3259e3cbd7c315e5e2d74")
     version("4.0.0", sha256="359b988d8cbe81357835317821919f7e270c0705e41951a92ac1627cb9fe8faf")
     version(


### PR DESCRIPTION
Add this version for
- https://github.com/SOCI/soci/pull/886 when `^glibc@2.34:`

along with other changes 