### PR TITLE
make level_zero variant consistent, add missing instances

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-oneapi/spack.yaml
@@ -223,7 +223,7 @@ spack:
   # - py-torch        # error
 
   # GPU
-  - aml +ze
+  - aml +level_zero
   - amrex +sycl
   - arborx +sycl ^kokkos +sycl +openmp cxxstd=17 +examples
   - cabana +sycl ^kokkos +sycl +openmp cxxstd=17 +examples

--- a/var/spack/repos/builtin/packages/aml/package.py
+++ b/var/spack/repos/builtin/packages/aml/package.py
@@ -47,7 +47,11 @@ class Aml(AutotoolsPackage):
     #############################
 
     variant("opencl", default=False, description="Support for memory operations on top of OpenCL.")
-    variant("ze", default=False, description="Support for memory operations on top of Level Zero.")
+    variant(
+        "level_zero",
+        default=False,
+        description="Support for memory operations on top of Level Zero.",
+    )
     variant("hip", default=False, description="Support for memory operations on top of HIP.")
     variant("cuda", default=False, description="Support for memory operations on top of CUDA.")
     variant("hwloc", default=True, description="Enable feature related to topology management")
@@ -70,7 +74,7 @@ class Aml(AutotoolsPackage):
     # - hip dependency. We use the environment variable HIP_PATH in the configure.
     depends_on("hip", when="+hip")
     # - level_zero loader is the dependency for the oneAPI variant
-    depends_on("oneapi-level-zero", when="+ze")
+    depends_on("oneapi-level-zero", when="+level_zero")
     # - hwloc >= 2.1 becomes a dependency when +hwloc variant is used.
     depends_on("hwloc@2.1:", when="+hwloc")
     # - ocl-icd >= 2.1 becomes a dependency when +opencl variant is used.
@@ -94,15 +98,19 @@ class Aml(AutotoolsPackage):
 
     # This is the function to overload to pass all hwloc flag.
     def configure_args(self):
-        config_args = []
-        for b in ["opencl", "hwloc", "ze", "hip", "cuda"]:
-            config_args.extend(self.with_or_without(b))
+        config_args = [
+            *self.with_or_without("opencl"),
+            *self.with_or_without("hwloc"),
+            *self.with_or_without("hip"),
+            *self.with_or_without("cuda"),
+            *self.with_or_without("ze", variant="level_zero"),
+        ]
         if self.spec.satisfies("%oneapi"):
-            config_args += ["--with-openmp-flags=-fiopenmp -fopenmp-targets=spir64"]
+            config_args.append("--with-openmp-flags=-fiopenmp -fopenmp-targets=spir64")
         if self.spec.variants["hip-platform"].value == "amd":
-            config_args += ["--with-hip-platform=amd"]
+            config_args.append("--with-hip-platform=amd")
         if self.spec.variants["hip-platform"].value == "nvidia":
-            config_args += ["--with-hip-platform=nvidia"]
+            config_args.append("--with-hip-platform=nvidia")
         return config_args
 
     # Tests

--- a/var/spack/repos/builtin/packages/double-batched-fft-library/package.py
+++ b/var/spack/repos/builtin/packages/double-batched-fft-library/package.py
@@ -32,12 +32,12 @@ class DoubleBatchedFftLibrary(CMakePackage):
 
     variant("shared", default=True, description="Shared library")
     variant("sycl", default=True, description="Build bbfft-sycl")
-    variant("level-zero", default=True, when="~sycl", description="Build bbfft-level-zero")
+    variant("level_zero", default=True, when="~sycl", description="Build bbfft-level-zero")
     variant("opencl", default=True, when="~sycl", description="Build bbfft-opencl")
 
     depends_on("cmake@3.23.0:", type="build")
     depends_on("oneapi-level-zero", when="+sycl")
-    depends_on("oneapi-level-zero", when="+level-zero")
+    depends_on("oneapi-level-zero", when="+level_zero")
     depends_on("opencl", when="+opencl")
 
     patch("0001-Add-CPATH-and-LIBRARY_PATHs-to-OpenCL-search-paths.patch", when="@:0.3.6")
@@ -50,7 +50,7 @@ class DoubleBatchedFftLibrary(CMakePackage):
         return [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("BUILD_SYCL", "sycl"),
-            self.define_from_variant("BUILD_LEVEL_ZERO", "level-zero"),
+            self.define_from_variant("BUILD_LEVEL_ZERO", "level_zero"),
             self.define_from_variant("BUILD_OPENCL", "opencl"),
             self.define("BUILD_BENCHMARK", False),
             self.define("BUILD_EXAMPLE", False),

--- a/var/spack/repos/builtin/packages/geopm-service/package.py
+++ b/var/spack/repos/builtin/packages/geopm-service/package.py
@@ -41,7 +41,7 @@ class GeopmService(AutotoolsPackage):
     )
     variant("gnu-ld", default=False, description="Assume C compiler uses gnu-ld")
 
-    variant("levelzero", default=False, description="Enables the use of oneAPI Level Zero loader")
+    variant("level_zero", default=False, description="Enables the use of oneAPI Level Zero loader")
     variant("nvml", default=False, description="Enable NVML support")
 
     variant(
@@ -51,7 +51,7 @@ class GeopmService(AutotoolsPackage):
         when="@develop",
     )
 
-    conflicts("+nvml", when="+levelzero", msg="LevelZero and NVML support are mutually exclusive")
+    conflicts("+nvml", when="+level_zero", msg="LevelZero and NVML support are mutually exclusive")
 
     conflicts("%gcc@:7.2", msg="Requires C++17 support")
     conflicts("%clang@:4", msg="Requires C++17 support")
@@ -100,7 +100,7 @@ class GeopmService(AutotoolsPackage):
     depends_on("systemd", when="+systemd")
     depends_on("libcap", when="+libcap")
     depends_on("liburing", when="+liburing")
-    depends_on("oneapi-level-zero", when="+levelzero")
+    depends_on("oneapi-level-zero", when="+level_zero")
     depends_on("cuda", when="+nvml")
 
     extends("python")
@@ -129,19 +129,19 @@ class GeopmService(AutotoolsPackage):
     def configure_args(self):
         args = [
             "--with-bash-completion-dir="
-            + join_path(self.spec.prefix, "share", "bash-completion", "completions")
+            + join_path(self.spec.prefix, "share", "bash-completion", "completions"),
+            *self.enable_or_disable("debug"),
+            *self.enable_or_disable("docs"),
+            *self.enable_or_disable("systemd"),
+            *self.enable_or_disable("liburing"),
+            *self.with_or_without("liburing", activation_value="prefix"),
+            *self.enable_or_disable("libcap"),
+            *self.with_or_without("gnu-ld"),
+            *self.enable_or_disable("levelzero", variant="level_zero"),
+            *self.enable_or_disable("nvml"),
+            *self.enable_or_disable("rawmsr"),
         ]
 
-        args += self.enable_or_disable("debug")
-        args += self.enable_or_disable("docs")
-        args += self.enable_or_disable("systemd")
-        args += self.enable_or_disable("liburing")
-        args += self.with_or_without("liburing", activation_value="prefix")
-        args += self.enable_or_disable("libcap")
-        args += self.with_or_without("gnu-ld")
-
-        args += self.enable_or_disable("levelzero")
-        args += self.enable_or_disable("nvml")
         if self.spec.satisfies("+nvml"):
             args += [
                 "--with-nvml="
@@ -150,10 +150,8 @@ class GeopmService(AutotoolsPackage):
                 )
             ]
 
-        args += self.enable_or_disable("rawmsr")
-        with when("@develop"):
-            if self.spec.target.family != "x86_64":
-                args += ["--disable-cpuid"]
+        if self.spec.satisfies("@develop") and self.spec.target.family != "x86_64":
+            args.append("--disable-cpuid")
         return args
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -106,10 +106,9 @@ class Libfabric(AutotoolsPackage, CudaPackage):
     #   device file can only be opened once per process, however, and thus it
     #   frequently conflicts with MPI.
     variant("kdreg", default=False, description="Enable kdreg on supported Cray platforms")
-
     variant("debug", default=False, description="Enable debugging")
-
     variant("uring", default=False, when="@1.17.0:", description="Enable uring support")
+    variant("level_zero", default=False, description="Enable Level Zero support")
 
     # For version 1.9.0:
     # headers: fix forward-declaration of enum fi_collective_op with C++
@@ -132,6 +131,7 @@ class Libfabric(AutotoolsPackage, CudaPackage):
     depends_on("uuid", when="fabrics=opx")
     depends_on("numactl", when="fabrics=opx")
     depends_on("liburing@2.1:", when="+uring")
+    depends_on("oneapi-level-zero", when="+level_zero")
 
     depends_on("m4", when="@main", type="build")
     depends_on("autoconf", when="@main", type="build")
@@ -195,26 +195,19 @@ class Libfabric(AutotoolsPackage, CudaPackage):
         bash("./autogen.sh")
 
     def configure_args(self):
-        args = []
-
-        args.extend(self.enable_or_disable("debug"))
-
-        if self.spec.satisfies("+kdreg"):
-            args.append("--with-kdreg=yes")
-        else:
-            args.append("--with-kdreg=no")
-
-        if self.spec.satisfies("+uring"):
-            args.append("--with-uring=yes")
+        args = [
+            *self.enable_or_disable("debug"),
+            *self.with_or_without("kdreg"),
+            *self.with_or_without("uring"),
+            *self.with_or_without("cuda", activation_value="prefix"),
+            *self.with_or_without("ze", variant="level_zero"),
+        ]
 
         for fabric in [f if isinstance(f, str) else f[0].value for f in self.fabrics]:
-            if "fabrics=" + fabric in self.spec:
-                args.append("--enable-{0}=yes".format(fabric))
+            if f"fabrics={fabric}" in self.spec:
+                args.append(f"--enable-{fabric}")
             else:
-                args.append("--enable-{0}=no".format(fabric))
-
-        if self.spec.satisfies("+cuda"):
-            args.append(f"--with-cuda={self.spec['cuda'].prefix}")
+                args.append(f"--disable-{fabric}")
 
         return args
 

--- a/var/spack/repos/builtin/packages/libquo/package.py
+++ b/var/spack/repos/builtin/packages/libquo/package.py
@@ -27,8 +27,8 @@ class Libquo(AutotoolsPackage):
     version("1.3", sha256="61b0beff15eae4be94b5d3cbcbf7bf757659604465709ed01827cbba45efcf90")
     version("1.2.9", sha256="0a64bea8f52f9eecd89e4ab82fde1c5bd271f3866c612da0ce7f38049409429b")
 
-    depends_on("c", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     depends_on("mpi")
 
@@ -43,4 +43,9 @@ class Libquo(AutotoolsPackage):
         bash("./autogen")
 
     def configure_args(self):
-        return [f"CC={self.spec['mpi'].mpicc}", f"FC={self.spec['mpi'].mpifc}"]
+        return [
+            f"CC={self.spec['mpi'].mpicc}",
+            f"FC={self.spec['mpi'].mpifc}",
+            # hwloc is vendored
+            "--disable-levelzero",
+        ]

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -58,10 +58,6 @@ class Mpich(AutotoolsPackage, CudaPackage, ROCmPackage):
     version("3.1", sha256="fcf96dbddb504a64d33833dc455be3dda1e71c7b3df411dfcf9df066d7c32c39")
     version("3.0.4", sha256="cf638c85660300af48b6f776e5ecd35b5378d5905ec5d34c3da7a27da0acf0b3")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build", when="+fortran")
-
     variant("hwloc", default=True, description="Use external hwloc package")
     variant("hydra", default=True, description="Build the hydra process manager")
     variant("romio", default=True, description="Enable ROMIO MPI I/O implementation")
@@ -134,11 +130,6 @@ supported, and netmod is ignored if device is ch3:sock.""",
             depends_on("yaksa+cuda", when="+cuda")
             depends_on("yaksa+rocm", when="+rocm")
 
-    conflicts("datatype-engine=yaksa", when="device=ch3")
-    conflicts("datatype-engine=yaksa", when="device=ch3:sock")
-    conflicts("datatype-engine=dataloop", when="+cuda")
-    conflicts("datatype-engine=dataloop", when="+rocm")
-
     variant(
         "hcoll",
         default=False,
@@ -146,9 +137,20 @@ supported, and netmod is ignored if device is ch3:sock.""",
         "collective operations library",
         when="@3.3: device=ch4 netmod=ucx",
     )
-    depends_on("hcoll", when="+hcoll")
 
     variant("xpmem", default=False, when="@3.4:", description="Enable XPMEM support")
+    variant("level_zero", default=False, description="Enable level zero support")
+
+    conflicts("datatype-engine=yaksa", when="device=ch3")
+    conflicts("datatype-engine=yaksa", when="device=ch3:sock")
+    conflicts("datatype-engine=dataloop", when="+cuda")
+    conflicts("datatype-engine=dataloop", when="+rocm")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build", when="+fortran")
+
+    depends_on("hcoll", when="+hcoll")
     depends_on("xpmem", when="+xpmem")
 
     # Todo: cuda can be a conditional variant, but it does not seem to work when
@@ -303,6 +305,7 @@ supported, and netmod is ignored if device is ch3:sock.""",
     depends_on("python@3.0:", when="@develop", type="build")
 
     depends_on("cray-pmi", when="pmi=cray")
+    depends_on("oneapi-level-zero", when="+level_zero")
 
     conflicts("device=ch4", when="@:3.2")
     conflicts("netmod=ofi", when="@:3.1.4")
@@ -523,7 +526,12 @@ supported, and netmod is ignored if device is ch3:sock.""",
             "--{0}-ibverbs".format("with" if "+verbs" in spec else "without"),
             "--enable-wrapper-rpath={0}".format("no" if "~wrapperrpath" in spec else "yes"),
             "--with-yaksa={0}".format(spec["yaksa"].prefix if "^yaksa" in spec else "embedded"),
+            *self.with_or_without("ze", variant="level_zero"),
         ]
+
+        # --without-ze does not propagate --disable-levelzero to hwloc's configure script
+        if self.spec.satisfies("~hwloc"):
+            config_args += self.enable_or_disable("levelzero", variant="level_zero")
 
         # see https://github.com/pmodels/mpich/issues/5530
         if spec.platform == "darwin":

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -529,8 +529,8 @@ supported, and netmod is ignored if device is ch3:sock.""",
             *self.with_or_without("ze", variant="level_zero"),
         ]
 
-        # --without-ze does not propagate --disable-levelzero to hwloc's configure script
-        if self.spec.satisfies("~hwloc"):
+        # https://github.com/pmodels/mpich/commit/bbfc4cab6ade0b75ef3803a83af1cad4a262a564
+        if self.spec.satisfies("@:4.2 ~hwloc"):
             config_args += self.enable_or_disable("levelzero", variant="level_zero")
 
         # see https://github.com/pmodels/mpich/issues/5530

--- a/var/spack/repos/builtin/packages/tiny-tensor-compiler/package.py
+++ b/var/spack/repos/builtin/packages/tiny-tensor-compiler/package.py
@@ -25,15 +25,15 @@ class TinyTensorCompiler(CMakePackage):
     depends_on("cxx", type="build")  # generated
 
     variant("shared", default=True, description="Shared library")
-    variant("level-zero", default=False, description="Build tinytc_ze (Level Zero runtime)")
+    variant("level_zero", default=False, description="Build tinytc_ze (Level Zero runtime)")
     variant("opencl", default=True, description="Build tintc_cl (OpenCL runtime)")
     variant("sycl", default=False, description="Build tinytc_sycl (SYCL runtime)")
 
-    requires("+opencl +level-zero", when="+sycl")
+    requires("+opencl +level_zero", when="+sycl")
 
     depends_on("cmake@3.23.0:", type="build")
-    depends_on("double-batched-fft-library ~sycl ~level-zero ~opencl@0.5.1:", type="link")
-    depends_on("oneapi-level-zero@1.13:", when="+level-zero")
+    depends_on("double-batched-fft-library ~sycl ~level_zero ~opencl@0.5.1:", type="link")
+    depends_on("oneapi-level-zero@1.13:", when="+level_zero")
     depends_on("opencl-c-headers@2022.01.04:", when="+opencl")
     depends_on("opencl-icd-loader@2022.01.04:", when="+opencl", type="link")
     depends_on("re2c@3.0:", type="build")
@@ -47,6 +47,6 @@ class TinyTensorCompiler(CMakePackage):
         return [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("BUILD_SYCL", "sycl"),
-            self.define_from_variant("BUILD_LEVEL_ZERO", "level-zero"),
+            self.define_from_variant("BUILD_LEVEL_ZERO", "level_zero"),
             self.define_from_variant("BUILD_OPENCL", "opencl"),
         ]

--- a/var/spack/repos/builtin/packages/yaksa/package.py
+++ b/var/spack/repos/builtin/packages/yaksa/package.py
@@ -29,7 +29,9 @@ class Yaksa(AutotoolsPackage, CudaPackage, ROCmPackage):
     version("0.3", sha256="c9e5291211bee8852831bb464f430ad5ba1541e31db5718a6fa2f2d3329fc2d9")
     version("0.2", sha256="9401cb6153dc8c34ddb9781bbabd418fd26b0a27b5da3294ecc21af7be9c86f2")
 
-    depends_on("c", type="build")  # generated
+    variant("level_zero", default=False, description="Enable Level Zero support")
+
+    depends_on("c", type="build")
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
@@ -43,9 +45,11 @@ class Yaksa(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     def configure_args(self):
         spec = self.spec
-        config_args = []
+        config_args = [
+            *self.with_or_without("cuda", activation_value="prefix"),
+            *self.with_or_without("ze", variant="level_zero"),
+        ]
 
-        config_args += self.with_or_without("cuda", activation_value="prefix")
         if "+cuda" in spec:
             cuda_archs = spec.variants["cuda_arch"].value
             if "none" not in cuda_archs:


### PR DESCRIPTION
Extracted from #47365 

* use `+/~level_zero` consistently
* add it to libfabric, yaksa, mpich
* some minor changes (e.g. make type inference of `args` work in some packages)