### PR TITLE
coverage.yml: set fail_ci_if_error = false again

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,4 +32,4 @@ jobs:
       uses: codecov/codecov-action@05f5a9cfad807516dbbef9929c4a42df3eb78766
       with:
         verbose: true
-        fail_ci_if_error: true
+        fail_ci_if_error: false


### PR DESCRIPTION
This reverts #47731 but leaves the option there explicitly to indicate the choice is intentional.

It seems that with this flag we get failure for the push commit into the develop branch which is detected as if it is on a fork :-\ See e.g. https://github.com/spack/spack/actions/runs/12227274670/job/34104695916.