### PR TITLE
pipelines: simplify and lint aws-pcluster-*

### DIFF
--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -416,10 +416,12 @@ def dump_config(data, stream, *, default_flow_style=False, blame=False):
     if blame:
         handler = ConfigYAML(yaml_type=YAMLType.ANNOTATED_SPACK_CONFIG_FILE)
         handler.yaml.default_flow_style = default_flow_style
+        handler.yaml.width = maxint
         return _dump_annotated(handler, data, stream)
 
     handler = ConfigYAML(yaml_type=YAMLType.SPACK_CONFIG_FILE)
     handler.yaml.default_flow_style = default_flow_style
+    handler.yaml.width = maxint
     return handler.dump(data, stream)
 
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
@@ -18,8 +18,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07, entrypoint: [
-            '']}
+        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07, entrypoint: ['']}
         tags: [aarch64]
         before_script:
         - - . "./share/spack/setup-env.sh"
@@ -30,13 +29,8 @@ spack:
     - signing-job:
         before_script:
             # Do not distribute Intel & ARM binaries
-        - -
-            for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/
-            | grep intel-oneapi | awk '{print $4}' | sed -e 's?^.*build_cache/??g');
-            do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
-          - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/
-            | grep armpl | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws
-            s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+        - - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep intel-oneapi | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+          - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep armpl | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
   cdash:
     build-group: AWS Packages
   compilers:
@@ -69,7 +63,7 @@ spack:
   packages:
     acfl:
       require:
-      - target=aarch64
+      - '%gcc target=aarch64'
     gromacs:
       require:
       - gromacs@2024.3 %gcc ^armpl-gcc ^openmpi
@@ -84,20 +78,18 @@ spack:
       variants: ~lldb
     mpas-model:
       require:
-      - precision=single ^parallelio+pnetcdf
+      - precision=single %gcc ^parallelio+pnetcdf
     mpich:
       require:
       - mpich pmi=pmi2 device=ch4 netmod=ofi +slurm
     nvhpc:
       require:
-      - nvhpc target=aarch64
+      - nvhpc %gcc target=aarch64
     openfoam:
       require:
       - openfoam ^scotch@6.0.9
     openmpi:
-      variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers
-        ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi
-        schedulers=slurm
+      variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
       require: '@4:'
     # Palace does not build correctly with armpl until https://github.com/awslabs/palace/pull/207 is merged into a version.
     # palace:
@@ -107,7 +99,7 @@ spack:
       require: 'pmix@3:'
     quantum-espresso:
       require:
-      - quantum-espresso@6.6 ^armpl-gcc
+      - quantum-espresso@6.6 %gcc ^armpl-gcc
     slurm:
       buildable: false
       externals:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
@@ -1,105 +1,93 @@
 spack:
   view: false
-
   definitions:
-  - apps:
-    - gromacs
-    - mpas-model
-    - mpich
-    - openfoam
-    - quantum-espresso
-    - wrf
-
-  - targets:
-      - 'target=neoverse_v1'
-      - 'target=neoverse_n1'
-
+    - apps:
+        - gromacs
+        - mpas-model
+        - mpich
+        - openfoam
+        - quantum-espresso
+        - wrf
+    - targets:
+        - 'target=neoverse_v1'
+        - 'target=neoverse_n1'
   specs:
-  - matrix:
-      - [$apps]
-      - [$targets]
+    - matrix:
+        - [$apps]
+        - [$targets]
   ci:
     pipeline-gen:
-    - build-job:
-        image: { "name": "ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07", "entrypoint": [""] }
-        tags: ["aarch64"]
-        before_script:
-        - - . "./share/spack/setup-env.sh"
-          - . /etc/profile.d/modules.sh
-          - spack --version
-          - spack arch
-          - export PATH=/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/binutils-2.37-2yxz3xsjfmesxujxtlrgcctxlyilynmp/bin:$PATH
-    - signing-job:
-        before_script:
-          # Do not distribute Intel & ARM binaries
-          - - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep intel-oneapi | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
-            - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep armpl | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
-
+      - build-job:
+          image: {"name": "ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07", "entrypoint": [""]}
+          tags: ["aarch64"]
+          before_script:
+            - - . "./share/spack/setup-env.sh"
+              - . /etc/profile.d/modules.sh
+              - spack --version
+              - spack arch
+              - export PATH=/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/binutils-2.37-2yxz3xsjfmesxujxtlrgcctxlyilynmp/bin:$PATH
+      - signing-job:
+          before_script:
+            # Do not distribute Intel & ARM binaries
+            - - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep intel-oneapi | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+              - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep armpl | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
   cdash:
     build-group: AWS Packages
-
   compilers:
-  - compiler:
-      environment: {}
-      extra_rpaths: []
-      flags: {}
-      modules: []
-      operating_system: amzn2
-      paths:
-        cc: /usr/bin/gcc
-        cxx: /usr/bin/g++
-        f77: /usr/bin/gfortran
-        fc: /usr/bin/gfortran
-      spec: gcc@=7.3.1
-      target: aarch64
-  - compiler:
-      environment: {}
-      extra_rpaths: []
-      flags: {}
-      modules: []
-      operating_system: amzn2
-      paths:
-        cc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gcc
-        cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/g++
-        f77: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gfortran
-        fc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gfortran
-      spec: gcc@=12.4.0
-      target: aarch64
-
+    - compiler:
+        environment: {}
+        extra_rpaths: []
+        flags: {}
+        modules: []
+        operating_system: amzn2
+        paths:
+          cc: /usr/bin/gcc
+          cxx: /usr/bin/g++
+          f77: /usr/bin/gfortran
+          fc: /usr/bin/gfortran
+        spec: gcc@=7.3.1
+        target: aarch64
+    - compiler:
+        environment: {}
+        extra_rpaths: []
+        flags: {}
+        modules: []
+        operating_system: amzn2
+        paths:
+          cc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gcc
+          cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/g++
+          f77: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gfortran
+          fc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gfortran
+        spec: gcc@=12.4.0
+        target: aarch64
   packages:
     acfl:
       require:
-        - one_of: ["%gcc target=aarch64"]
-          message: "Clang based compilers need GCC libraries and they should be made available for the wide range of CPUs they actually support.
-                  Edit $SPACK_ROOT/etc/spack/packages.yaml to change this default."
+        - "target=aarch64"
     gromacs:
       require:
-        - one_of:
-            - "gromacs@2024.3 %arm ^fftw ^openmpi"
-            - "gromacs@2024.3 %gcc ^armpl-gcc ^openmpi"
+        - "gromacs@2024.3 %gcc ^armpl-gcc ^openmpi"
     libfabric:
       buildable: true
       externals:
         - prefix: /opt/amazon/efa/
           spec: libfabric@1.17.0
-      require: ['fabrics=shm,efa']
+      require:
+        - "fabrics=shm,efa"
     llvm:
       variants: ~lldb
     mpas-model:
       require:
-        - one_of:
-            - "precision=single make_target=llvm %arm ^parallelio+pnetcdf"
-            - "precision=single %gcc ^parallelio+pnetcdf"
+        - "precision=single ^parallelio+pnetcdf"
     mpich:
-      require: "mpich pmi=pmi2 device=ch4 netmod=ofi +slurm"
+      require:
+        - "mpich pmi=pmi2 device=ch4 netmod=ofi +slurm"
     nvhpc:
       require:
-        - one_of:
-            - "nvhpc %gcc target=aarch64"
-          message: "NVHPC should be built with GCC and should be made available for the wide range of CPUs they actually support.
-                  Edit $SPACK_ROOT/etc/spack/packages.yaml to change this default."
+        - "nvhpc target=aarch64"
     openfoam:
-      require: "openfoam %gcc ^scotch@6.0.9"
+      require:
+        - "openfoam ^scotch@6.0.9"
     openmpi:
       variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
       require: '@4:'
@@ -110,17 +98,13 @@ spack:
     pmix:
       require: "pmix@3:"
     quantum-espresso:
-      require: "quantum-espresso@6.6 %gcc ^armpl-gcc"
+      require:
+        - "quantum-espresso@6.6 ^armpl-gcc"
     slurm:
       buildable: false
       externals:
         - prefix: /opt/slurm
           spec: slurm@22.05.8 +pmix
-    wrf:
-      require:
-        - one_of:
-            - "wrf%arm"
-            - "wrf%gcc"
     all:
       compiler: [gcc, arm, nvhpc, clang]
       providers:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
@@ -1,110 +1,118 @@
 spack:
   view: false
   definitions:
-    - apps:
-        - gromacs
-        - mpas-model
-        - mpich
-        - openfoam
-        - quantum-espresso
-        - wrf
-    - targets:
-        - 'target=neoverse_v1'
-        - 'target=neoverse_n1'
+  - apps:
+    - gromacs
+    - mpas-model
+    - mpich
+    - openfoam
+    - quantum-espresso
+    - wrf
+  - targets:
+    - target=neoverse_v1
+    - target=neoverse_n1
   specs:
-    - matrix:
-        - [$apps]
-        - [$targets]
+  - matrix:
+    - [$apps]
+    - [$targets]
   ci:
     pipeline-gen:
-      - build-job:
-          image: {"name": "ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07", "entrypoint": [""]}
-          tags: ["aarch64"]
-          before_script:
-            - - . "./share/spack/setup-env.sh"
-              - . /etc/profile.d/modules.sh
-              - spack --version
-              - spack arch
-              - export PATH=/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/binutils-2.37-2yxz3xsjfmesxujxtlrgcctxlyilynmp/bin:$PATH
-      - signing-job:
-          before_script:
+    - build-job:
+        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07, entrypoint: [
+            '']}
+        tags: [aarch64]
+        before_script:
+        - - . "./share/spack/setup-env.sh"
+          - . /etc/profile.d/modules.sh
+          - spack --version
+          - spack arch
+          - export PATH=/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/binutils-2.37-2yxz3xsjfmesxujxtlrgcctxlyilynmp/bin:$PATH
+    - signing-job:
+        before_script:
             # Do not distribute Intel & ARM binaries
-            - - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep intel-oneapi | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
-              - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep armpl | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+        - -
+            for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/
+            | grep intel-oneapi | awk '{print $4}' | sed -e 's?^.*build_cache/??g');
+            do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+          - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/
+            | grep armpl | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws
+            s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
   cdash:
     build-group: AWS Packages
   compilers:
-    - compiler:
-        environment: {}
-        extra_rpaths: []
-        flags: {}
-        modules: []
-        operating_system: amzn2
-        paths:
-          cc: /usr/bin/gcc
-          cxx: /usr/bin/g++
-          f77: /usr/bin/gfortran
-          fc: /usr/bin/gfortran
-        spec: gcc@=7.3.1
-        target: aarch64
-    - compiler:
-        environment: {}
-        extra_rpaths: []
-        flags: {}
-        modules: []
-        operating_system: amzn2
-        paths:
-          cc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gcc
-          cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/g++
-          f77: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gfortran
-          fc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gfortran
-        spec: gcc@=12.4.0
-        target: aarch64
+  - compiler:
+      environment: {}
+      extra_rpaths: []
+      flags: {}
+      modules: []
+      operating_system: amzn2
+      paths:
+        cc: /usr/bin/gcc
+        cxx: /usr/bin/g++
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
+      spec: gcc@=7.3.1
+      target: aarch64
+  - compiler:
+      environment: {}
+      extra_rpaths: []
+      flags: {}
+      modules: []
+      operating_system: amzn2
+      paths:
+        cc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gcc
+        cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/g++
+        f77: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gfortran
+        fc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gfortran
+      spec: gcc@=12.4.0
+      target: aarch64
   packages:
     acfl:
       require:
-        - "target=aarch64"
+      - target=aarch64
     gromacs:
       require:
-        - "gromacs@2024.3 %gcc ^armpl-gcc ^openmpi"
+      - gromacs@2024.3 %gcc ^armpl-gcc ^openmpi
     libfabric:
       buildable: true
       externals:
-        - prefix: /opt/amazon/efa/
-          spec: libfabric@1.17.0
+      - prefix: /opt/amazon/efa/
+        spec: libfabric@1.17.0
       require:
-        - "fabrics=shm,efa"
+      - fabrics=shm,efa
     llvm:
       variants: ~lldb
     mpas-model:
       require:
-        - "precision=single ^parallelio+pnetcdf"
+      - precision=single ^parallelio+pnetcdf
     mpich:
       require:
-        - "mpich pmi=pmi2 device=ch4 netmod=ofi +slurm"
+      - mpich pmi=pmi2 device=ch4 netmod=ofi +slurm
     nvhpc:
       require:
-        - "nvhpc target=aarch64"
+      - nvhpc target=aarch64
     openfoam:
       require:
-        - "openfoam ^scotch@6.0.9"
+      - openfoam ^scotch@6.0.9
     openmpi:
-      variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
+      variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers
+        ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi
+        schedulers=slurm
       require: '@4:'
     # Palace does not build correctly with armpl until https://github.com/awslabs/palace/pull/207 is merged into a version.
     # palace:
     #   require:
     #     - one_of: ["palace cxxflags=\"-include cstdint\" ^fmt@9.1.0"]
     pmix:
-      require: "pmix@3:"
+      require: 'pmix@3:'
     quantum-espresso:
       require:
-        - "quantum-espresso@6.6 ^armpl-gcc"
+      - quantum-espresso@6.6 ^armpl-gcc
     slurm:
       buildable: false
       externals:
-        - prefix: /opt/slurm
-          spec: slurm@22.05.8 +pmix
+      - prefix: /opt/slurm
+        spec: slurm@22.05.8 +pmix
     all:
       compiler: [gcc, arm, nvhpc, clang]
       providers:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-neoverse_v1/spack.yaml
@@ -41,19 +41,6 @@ spack:
       modules: []
       operating_system: amzn2
       paths:
-        cc: /usr/bin/gcc
-        cxx: /usr/bin/g++
-        f77: /usr/bin/gfortran
-        fc: /usr/bin/gfortran
-      spec: gcc@=7.3.1
-      target: aarch64
-  - compiler:
-      environment: {}
-      extra_rpaths: []
-      flags: {}
-      modules: []
-      operating_system: amzn2
-      paths:
         cc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gcc
         cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/g++
         f77: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-aarch64/gcc-7.3.1/gcc-12.4.0-v6wxye6ijzrxnzxftcwnpu3psohsjl2b/bin/gfortran

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
@@ -75,7 +75,7 @@ spack:
       # Newer gettext cannot build with gcc@12 and old AL2 glibc headers
       # Older gettext versions do not build correctly with oneapi.
       require:
-      - '@:0.20 %oneapi'
+      - '@:0.20 %gcc'
     gromacs:
       require:
       - +intel_provided_gcc ^intel-oneapi-mkl

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
@@ -22,8 +22,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07, entrypoint: [
-            '']}
+        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07, entrypoint: ['']}
         before_script:
         - - . "./share/spack/setup-env.sh"
           - . /etc/profile.d/modules.sh
@@ -33,13 +32,8 @@ spack:
     - signing-job:
         before_script:
             # Do not distribute Intel & ARM binaries
-        - -
-            for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/
-            | grep intel-oneapi | awk '{print $4}' | sed -e 's?^.*build_cache/??g');
-            do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
-          - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/
-            | grep armpl | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws
-            s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+        - - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep intel-oneapi | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+          - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep armpl | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
   cdash:
     build-group: AWS Packages
   compilers:
@@ -75,7 +69,7 @@ spack:
       # Newer gettext cannot build with gcc@12 and old AL2 glibc headers
       # Older gettext versions do not build correctly with oneapi.
       require:
-      - '@:0.20 %gcc'
+      - one_of: ['@:0.20 %gcc', '%oneapi']
     gromacs:
       require:
       - +intel_provided_gcc ^intel-oneapi-mkl
@@ -83,8 +77,8 @@ spack:
       variants: +external-libfabric generic-names=True
     lammps:
       require:
-      - lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package
-        fft=mkl ^intel-oneapi-mkl
+      - lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package fft=mkl ^intel-oneapi-mkl
+      - one_of: [+intel target=x86_64_v4, target=x86_64_v3]
     libfabric:
       buildable: true
       externals:
@@ -94,9 +88,7 @@ spack:
       - fabrics=shm,efa
     mpas-model:
       require:
-      - one_of:
-        - precision=single ^parallelio+pnetcdf target=x86_64_v4
-        - precision=single ^parallelio+pnetcdf target=x86_64_v3
+      - spec: precision=single ^parallelio+pnetcdf
         when: '%oneapi'
     mpich:
       require:
@@ -105,9 +97,7 @@ spack:
       require:
       - openfoam %gcc ^scotch@6.0.9
     openmpi:
-      variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers
-        ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi
-        schedulers=slurm
+      variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
       require:
       - 'openmpi @4:'
     palace:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
@@ -1,181 +1,115 @@
 spack:
   view: false
-
   definitions:
-  - apps:
-    - gromacs %oneapi
-    - lammps %oneapi
-    # earliest oneapi version with fix does not run on AmazonLinux2, see https://github.com/spack/spack/pull/46457
-    # - mpas-model %oneapi
-    - openfoam %gcc
-    - palace %oneapi ^superlu-dist%oneapi # hack: force fortran-rt provider through superlu-dist
-    # TODO: Find out how to make +ipo cmake flag work.
-    # - quantum-espresso %oneapi
-    - openmpi %oneapi
-    - wrf %oneapi
-
-  - targets:
-      - 'target=x86_64_v4'
-      - 'target=x86_64_v3'
-
+    - apps:
+        - gromacs %oneapi
+        - lammps %oneapi
+        # earliest oneapi version with fix does not run on AmazonLinux2, see https://github.com/spack/spack/pull/46457
+        # - mpas-model %oneapi
+        - openfoam %gcc
+        - palace %oneapi ^superlu-dist%oneapi # hack: force fortran-rt provider through superlu-dist
+        # TODO: Find out how to make +ipo cmake flag work.
+        # - quantum-espresso %oneapi
+        - openmpi %oneapi
+        - wrf %oneapi
+    - targets:
+        - 'target=x86_64_v4'
+        - 'target=x86_64_v3'
   specs:
-  - matrix:
-      - [$apps]
-      - [$targets]
+    - matrix:
+        - [$apps]
+        - [$targets]
   ci:
     pipeline-gen:
-    - build-job:
-        image: { "name": "ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07", "entrypoint": [""] }
-        before_script:
-        - - . "./share/spack/setup-env.sh"
-          - . /etc/profile.d/modules.sh
-          - spack --version
-          - spack arch
-          - export PATH=/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/binutils-2.37-qvccg7zpskturysmr4bzbsfrx34kvazo/bin:$PATH
-    - signing-job:
-        before_script:
-          # Do not distribute Intel & ARM binaries
-          - - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep intel-oneapi | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
-            - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep armpl | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
-
+      - build-job:
+          image: {"name": "ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07", "entrypoint": [""]}
+          before_script:
+            - - . "./share/spack/setup-env.sh"
+              - . /etc/profile.d/modules.sh
+              - spack --version
+              - spack arch
+              - export PATH=/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/binutils-2.37-qvccg7zpskturysmr4bzbsfrx34kvazo/bin:$PATH
+      - signing-job:
+          before_script:
+            # Do not distribute Intel & ARM binaries
+            - - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep intel-oneapi | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+              - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep armpl | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
   cdash:
     build-group: AWS Packages
-
   compilers:
-  - compiler:
-      environment: {}
-      extra_rpaths: []
-      flags: {}
-      modules: []
-      operating_system: amzn2
-      paths:
-        cc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/gcc
-        cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/g++
-        f77: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/gfortran
-        fc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/gfortran
-      spec: gcc@=12.4.0
-      target: x86_64
-  - compiler:
-      environment: {}
-      extra_rpaths:
-      - /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/lib64
-      flags: {}
-      modules: []
-      operating_system: amzn2
-      paths:
-        cc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/icx
-        cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/icpx
-        f77: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/ifx
-        fc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/ifx
-      spec: oneapi@=2024.1.0
-      target: x86_64
-
+    - compiler:
+        environment: {}
+        extra_rpaths: []
+        flags: {}
+        modules: []
+        operating_system: amzn2
+        paths:
+          cc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/gcc
+          cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/g++
+          f77: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/gfortran
+          fc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/gfortran
+        spec: gcc@=12.4.0
+        target: x86_64
+    - compiler:
+        environment: {}
+        extra_rpaths:
+          - /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/lib64
+        flags: {}
+        modules: []
+        operating_system: amzn2
+        paths:
+          cc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/icx
+          cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/icpx
+          f77: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/ifx
+          fc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/ifx
+        spec: oneapi@=2024.1.0
+        target: x86_64
   packages:
-    cpio:
-      require:
-        - one_of:
-            - "cflags=-std=c18 target=x86_64_v4"
-            - "cflags=-std=c18 target=x86_64_v3"
-          when: "%intel"
     gettext:
       # Newer gettext cannot build with gcc@12 and old AL2 glibc headers
       # Older gettext versions do not build correctly with oneapi.
       require:
-        - one_of:
-            - '@:0.20'
-            - '%oneapi'
+        - '@:0.20 %oneapi'
     gromacs:
       require:
-        - one_of:
-            - "+intel_provided_gcc ^intel-oneapi-mkl target=x86_64_v4"
-            - "+intel_provided_gcc ^intel-oneapi-mkl target=x86_64_v3"
-          when: "%intel"
-        - one_of:
-            - "+intel_provided_gcc target=x86_64_v4 ^intel-oneapi-mkl"
-            - "+intel_provided_gcc target=x86_64_v3 ^intel-oneapi-mkl"
-          when: "%oneapi"
-    intel-oneapi-compilers:
-      require: "intel-oneapi-compilers %gcc target=x86_64_v3"
+        - "+intel_provided_gcc ^intel-oneapi-mkl"
     intel-oneapi-mpi:
       variants: +external-libfabric generic-names=True
     lammps:
       require:
-        - one_of:
-            - "lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package +intel fft=mkl ^intel-oneapi-mkl target=x86_64_v4"
-            - "lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package fft=mkl ^intel-oneapi-mkl target=x86_64_v3"
-          when: "%intel"
-        - one_of:
-            - "lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package +intel fft=mkl ^intel-oneapi-mkl target=x86_64_v4"
-            - "lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package fft=mkl ^intel-oneapi-mkl target=x86_64_v3"
-          when: "%oneapi"
-    libidn2:
-      require:
-        - one_of:
-            - "cflags=-std=c18 target=x86_64_v4"
-            - "cflags=-std=c18 target=x86_64_v3"
-          when: "%intel"
+        - "lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package fft=mkl ^intel-oneapi-mkl"
     libfabric:
       buildable: true
       externals:
         - prefix: /opt/amazon/efa/
           spec: libfabric@1.17.0
-      require: ['fabrics=shm,efa']
-    libunistring:
       require:
-        - one_of:
-            - "cflags=-std=c18 target=x86_64_v4"
-            - "cflags=-std=c18 target=x86_64_v3"
-          when: "%intel"
+        - "fabrics=shm,efa"
     mpas-model:
       require:
-        - one_of:
-            - "precision=single ^parallelio+pnetcdf target=x86_64_v4"
-            - "precision=single ^parallelio+pnetcdf target=x86_64_v3"
-          when: "%intel"
         - one_of:
             - "precision=single ^parallelio+pnetcdf target=x86_64_v4"
             - "precision=single ^parallelio+pnetcdf target=x86_64_v3"
           when: "%oneapi"
     mpich:
       require:
-        - one_of:
-            - "mpich pmi=pmi2 device=ch4 netmod=ofi +slurm target=x86_64_v4"
-            - "mpich pmi=pmi2 device=ch4 netmod=ofi +slurm target=x86_64_v3"
+        - "mpich pmi=pmi2 device=ch4 netmod=ofi +slurm"
     openfoam:
       require:
-        - one_of:
-            - "openfoam %gcc ^scotch@6.0.9 target=x86_64_v4"
-            - "openfoam %gcc ^scotch@6.0.9 target=x86_64_v3"
+        - "openfoam %gcc ^scotch@6.0.9"
     openmpi:
       variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
       require:
-        - one_of:
-            - "openmpi @4: target=x86_64_v4"
-            - "openmpi @4: target=x86_64_v3"
+        - "openmpi @4:"
     palace:
       require:
-        - one_of:
-            - "palace ^fmt@9.1.0 target=x86_64_v4"
-            - "palace ^fmt@9.1.0 target=x86_64_v3"
-          when: "%oneapi"
-        - one_of:
-            - "palace ^fmt@9.1.0"
-          when: "%gcc"
+        - "palace ^fmt@9.1.0"
     pmix:
       require:
-        - one_of:
-            - "pmix@3: target=x86_64_v4"
-            - "pmix@3: target=x86_64_v3"
+        - "pmix@3:"
     quantum-espresso:
       require:
-        - one_of:
-            - "quantum-espresso@6.6 ^intel-oneapi-mkl+cluster target=x86_64_v4"
-            - "quantum-espresso@6.6 ^intel-oneapi-mkl+cluster target=x86_64_v3"
-          when: "%intel"
-        - one_of:
-            - "quantum-espresso@6.6 ^intel-oneapi-mkl+cluster target=x86_64_v4"
-            - "quantum-espresso@6.6 ^intel-oneapi-mkl+cluster target=x86_64_v3"
-          when: "%oneapi"
+        - "quantum-espresso@6.6 ^intel-oneapi-mkl+cluster"
     slurm:
       buildable: false
       externals:
@@ -183,17 +117,7 @@ spack:
           spec: slurm@22.05.8 +pmix
     wrf:
       require:
-        - one_of:
-            - "wrf@4 build_type=dm+sm target=x86_64_v4"
-            - "wrf@4 build_type=dm+sm target=x86_64_v3"
-            - "wrf@4.2.2 +netcdf_classic fflags=\"-fp-model fast=2 -no-heap-arrays -no-prec-div -no-prec-sqrt -fno-common\" build_type=dm+sm target=x86_64_v3"
-          when: "%intel"
-        - one_of:
-            - "wrf@4 build_type=dm+sm target=x86_64_v4"
-            - "wrf@4 build_type=dm+sm target=x86_64_v3"
-            - "wrf@4.2.2 +netcdf_classic fflags=\"-fp-model fast=2 -no-heap-arrays -no-prec-div -no-prec-sqrt -fno-common\" build_type=dm+sm target=x86_64_v3"
-          when: "%oneapi"
-
+        - "wrf@4 build_type=dm+sm"
     all:
       compiler: [oneapi, gcc]
       permissions:

--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-x86_64_v4/spack.yaml
@@ -1,123 +1,132 @@
 spack:
   view: false
   definitions:
-    - apps:
-        - gromacs %oneapi
-        - lammps %oneapi
+  - apps:
+    - gromacs %oneapi
+    - lammps %oneapi
         # earliest oneapi version with fix does not run on AmazonLinux2, see https://github.com/spack/spack/pull/46457
         # - mpas-model %oneapi
-        - openfoam %gcc
-        - palace %oneapi ^superlu-dist%oneapi # hack: force fortran-rt provider through superlu-dist
+    - openfoam %gcc
+    - palace %oneapi ^superlu-dist%oneapi     # hack: force fortran-rt provider through superlu-dist
         # TODO: Find out how to make +ipo cmake flag work.
         # - quantum-espresso %oneapi
-        - openmpi %oneapi
-        - wrf %oneapi
-    - targets:
-        - 'target=x86_64_v4'
-        - 'target=x86_64_v3'
+    - openmpi %oneapi
+    - wrf %oneapi
+  - targets:
+    - target=x86_64_v4
+    - target=x86_64_v3
   specs:
-    - matrix:
-        - [$apps]
-        - [$targets]
+  - matrix:
+    - [$apps]
+    - [$targets]
   ci:
     pipeline-gen:
-      - build-job:
-          image: {"name": "ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07", "entrypoint": [""]}
-          before_script:
-            - - . "./share/spack/setup-env.sh"
-              - . /etc/profile.d/modules.sh
-              - spack --version
-              - spack arch
-              - export PATH=/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/binutils-2.37-qvccg7zpskturysmr4bzbsfrx34kvazo/bin:$PATH
-      - signing-job:
-          before_script:
+    - build-job:
+        image: {name: ghcr.io/spack/pcluster-amazonlinux-2:v2024-10-07, entrypoint: [
+            '']}
+        before_script:
+        - - . "./share/spack/setup-env.sh"
+          - . /etc/profile.d/modules.sh
+          - spack --version
+          - spack arch
+          - export PATH=/home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/binutils-2.37-qvccg7zpskturysmr4bzbsfrx34kvazo/bin:$PATH
+    - signing-job:
+        before_script:
             # Do not distribute Intel & ARM binaries
-            - - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep intel-oneapi | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
-              - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/ | grep armpl | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+        - -
+            for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/
+            | grep intel-oneapi | awk '{print $4}' | sed -e 's?^.*build_cache/??g');
+            do aws s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
+          - for i in $(aws s3 ls --recursive ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/
+            | grep armpl | awk '{print $4}' | sed -e 's?^.*build_cache/??g'); do aws
+            s3 rm ${SPACK_REMOTE_MIRROR_OVERRIDE}/build_cache/$i; done
   cdash:
     build-group: AWS Packages
   compilers:
-    - compiler:
-        environment: {}
-        extra_rpaths: []
-        flags: {}
-        modules: []
-        operating_system: amzn2
-        paths:
-          cc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/gcc
-          cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/g++
-          f77: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/gfortran
-          fc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/gfortran
-        spec: gcc@=12.4.0
-        target: x86_64
-    - compiler:
-        environment: {}
-        extra_rpaths:
-          - /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/lib64
-        flags: {}
-        modules: []
-        operating_system: amzn2
-        paths:
-          cc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/icx
-          cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/icpx
-          f77: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/ifx
-          fc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/ifx
-        spec: oneapi@=2024.1.0
-        target: x86_64
+  - compiler:
+      environment: {}
+      extra_rpaths: []
+      flags: {}
+      modules: []
+      operating_system: amzn2
+      paths:
+        cc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/gcc
+        cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/g++
+        f77: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/gfortran
+        fc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/bin/gfortran
+      spec: gcc@=12.4.0
+      target: x86_64
+  - compiler:
+      environment: {}
+      extra_rpaths:
+      - /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-7.3.1/gcc-12.4.0-pttzchh7o54nhmycj4wgzw5mic6rk2nb/lib64
+      flags: {}
+      modules: []
+      operating_system: amzn2
+      paths:
+        cc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/icx
+        cxx: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/icpx
+        f77: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/ifx
+        fc: /home/software/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-amzn2-x86_64_v3/gcc-12.4.0/intel-oneapi-compilers-2024.1.0-f5u3psfhbwscasajkn324igtupn3blop/compiler/2024.1/bin/ifx
+      spec: oneapi@=2024.1.0
+      target: x86_64
   packages:
     gettext:
       # Newer gettext cannot build with gcc@12 and old AL2 glibc headers
       # Older gettext versions do not build correctly with oneapi.
       require:
-        - '@:0.20 %oneapi'
+      - '@:0.20 %oneapi'
     gromacs:
       require:
-        - "+intel_provided_gcc ^intel-oneapi-mkl"
+      - +intel_provided_gcc ^intel-oneapi-mkl
     intel-oneapi-mpi:
       variants: +external-libfabric generic-names=True
     lammps:
       require:
-        - "lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package fft=mkl ^intel-oneapi-mkl"
+      - lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package
+        fft=mkl ^intel-oneapi-mkl
     libfabric:
       buildable: true
       externals:
-        - prefix: /opt/amazon/efa/
-          spec: libfabric@1.17.0
+      - prefix: /opt/amazon/efa/
+        spec: libfabric@1.17.0
       require:
-        - "fabrics=shm,efa"
+      - fabrics=shm,efa
     mpas-model:
       require:
-        - one_of:
-            - "precision=single ^parallelio+pnetcdf target=x86_64_v4"
-            - "precision=single ^parallelio+pnetcdf target=x86_64_v3"
-          when: "%oneapi"
+      - one_of:
+        - precision=single ^parallelio+pnetcdf target=x86_64_v4
+        - precision=single ^parallelio+pnetcdf target=x86_64_v3
+        when: '%oneapi'
     mpich:
       require:
-        - "mpich pmi=pmi2 device=ch4 netmod=ofi +slurm"
+      - mpich pmi=pmi2 device=ch4 netmod=ofi +slurm
     openfoam:
       require:
-        - "openfoam %gcc ^scotch@6.0.9"
+      - openfoam %gcc ^scotch@6.0.9
     openmpi:
-      variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
+      variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers
+        ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi
+        schedulers=slurm
       require:
-        - "openmpi @4:"
+      - 'openmpi @4:'
     palace:
       require:
-        - "palace ^fmt@9.1.0"
+      - palace ^fmt@9.1.0
     pmix:
       require:
-        - "pmix@3:"
+      - 'pmix@3:'
     quantum-espresso:
       require:
-        - "quantum-espresso@6.6 ^intel-oneapi-mkl+cluster"
+      - quantum-espresso@6.6 ^intel-oneapi-mkl+cluster
     slurm:
       buildable: false
       externals:
-        - prefix: /opt/slurm
-          spec: slurm@22.05.8 +pmix
+      - prefix: /opt/slurm
+        spec: slurm@22.05.8 +pmix
     wrf:
       require:
-        - "wrf@4 build_type=dm+sm"
+      - wrf@4 build_type=dm+sm
     all:
       compiler: [oneapi, gcc]
       permissions:


### PR DESCRIPTION
Extracted from #45189 

This PR simplifies and lints the `spack.yaml` for the `pcluster` pipelines. It mainly removes requirements for compilers that are non-existing in the docker image, or not used.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
