### PR TITLE
podio: add v1.2; conflicts +rntuple ^root@6.32: when @:0.99

### DIFF
--- a/var/spack/repos/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/builtin/packages/edm4hep/package.py
@@ -77,6 +77,7 @@ class Edm4hep(CMakePackage):
     depends_on("nlohmann-json@3.10.5:", when="@:0.99.1")
     depends_on("podio@1:", when="@0.99:")
     depends_on("podio@0.15:", when="@:0.10.5")
+    depends_on("podio@:1.1", when="@:0.99.0")
     for _std in _cxxstd_values:
         for _v in _std:
             depends_on(f"podio cxxstd={_v.value}", when=f"cxxstd={_v.value}")

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -107,6 +107,7 @@ class Podio(CMakePackage):
 
     conflicts("+rntuple", when="@:0.16", msg="rntuple support requires at least podio@0.17")
     conflicts("+rntuple ^root@6.32:", when="@:0.99", msg="rntuple API change requires podio@1:")
+    conflicts("+rntuple ^root@6.34:", when="@:1.1", msg="rntuple API change requires podio@1.2:")
 
     # See https://github.com/AIDASoft/podio/pull/600
     patch(

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -106,6 +106,7 @@ class Podio(CMakePackage):
     depends_on("py-tabulate", type=("run", "test"), when="@0.16.6:")
 
     conflicts("+rntuple", when="@:0.16", msg="rntuple support requires at least podio@0.17")
+    conflicts("+rntuple ^root@6.32:", when="@:0.99", msg="rntuple API change requires podio@1:")
 
     # See https://github.com/AIDASoft/podio/pull/600
     patch(

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -73,7 +73,7 @@ class Podio(CMakePackage):
 
     depends_on("cxx", type="build")  # generated
 
-    _cxxstd_values = (conditional("17", when="@"1.2"), conditional("20", when="@0.15:"))
+    _cxxstd_values = (conditional("17", when="@:1.2"), conditional("20", when="@0.15:"))
     variant(
         "cxxstd",
         default="17",

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -73,7 +73,7 @@ class Podio(CMakePackage):
 
     depends_on("cxx", type="build")  # generated
 
-    _cxxstd_values = (conditional("17", when="@:1.2"), conditional("20", when="@0.15:"))
+    _cxxstd_values = (conditional("17", when="@:1.2"), conditional("20", when="@0.14.1:"))
     variant(
         "cxxstd",
         default="17",

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -20,6 +20,7 @@ class Podio(CMakePackage):
     tags = ["hep", "key4hep"]
 
     version("master", branch="master")
+    version("1.2", sha256="bc97ba09ce908e55d4c5faa78d9739dde7daefd9337ae98351813b13708d0685")
     version("1.1", sha256="2cb5040761f3da4383e1f126da25d68e99ecd8398e0ff12e7475a3745a7030a6")
     version("1.0.1", sha256="915531a2bcf638011bb6cc19715bbc46d846ec8b985555a1afdcd6abc017e21b")
     version("1.0", sha256="491f335e148708e387e90e955a6150e1fc2e01bf6b4980b65e257ab0619559a9")
@@ -72,12 +73,22 @@ class Podio(CMakePackage):
 
     depends_on("cxx", type="build")  # generated
 
+    _cxxstd_values = (conditional("17", when="@"1.2"), conditional("20", when="@0.15:"))
     variant(
         "cxxstd",
         default="17",
-        values=("17", conditional("20", when="@0.15:")),
+        values=_cxxstd_values,
         multi=False,
         description="Use the specified C++ standard when building.",
+        when="@:1.1",
+    )
+    variant(
+        "cxxstd",
+        default="20",
+        values=_cxxstd_values,
+        multi=False,
+        description="Use the specified C++ standard when building.",
+        when="@1.2:",
     )
     variant("sio", default=False, description="Build the SIO I/O backend")
     variant("rntuple", default=False, description="Build the RNTuple backend")
@@ -102,6 +113,8 @@ class Podio(CMakePackage):
     depends_on("sio", type=("build", "link"), when="+sio")
     depends_on("catch2@3.0.1:", type=("test"), when="@:0.16.5")
     depends_on("catch2@3.1:", type=("test"), when="@0.16.6:")
+    depends_on("catch2@3.4:", type=("test"), when="@0.17.1: cxxstd=20")
+    depends_on("catch2@3.3:", type=("test"), when="@1.2: cxxstd=17")
     depends_on("py-graphviz", type=("run"))
     depends_on("py-tabulate", type=("run", "test"), when="@0.16.6:")
 


### PR DESCRIPTION
This PR adds a conflict to `podio`, such that an [API change](https://github.com/root-project/root/commit/ae8d9baee7cd5da5a9f1a5b24114de0f393850df) in `root@6.32:` does not break compilation for `podio` versions before this [was addressed](https://github.com/AIDASoft/podio/commit/14109ff746e5acb62f1cbd461bc526dd7ece5b93) in `podio@1.0`.

This PR also adds v1.2, which defaults to cxxstd=20 (and is last version to support cxxstd=17), and updates some catch2 version requirements (which were missing).

Test build:
```
==> Installing podio-1.2-h44cu4svmuivk5fztmjxhrgey3xf6dti [110/110]
==> No binary for podio-1.2-h44cu4svmuivk5fztmjxhrgey3xf6dti found: installing from source
==> No patches needed for podio
==> podio: Executing phase: 'cmake'
==> podio: Executing phase: 'build'
==> podio: Executing phase: 'install'
==> podio: Successfully installed podio-1.2-h44cu4svmuivk5fztmjxhrgey3xf6dti
  Stage: 0.00s.  Cmake: 2.82s.  Build: 1m 8.64s.  Install: 14.59s.  Post-install: 0.63s.  Total: 1m 27.12s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/podio-1.2-h44cu4svmuivk5fztmjxhrgey3xf6dti
```