### PR TITLE
acts: don't use system dfelibs for 35.1:36.0

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -514,6 +514,8 @@ class Acts(CMakePackage, CudaPackage):
         # Use dependencies provided by spack
         if spec.satisfies("@20.3:"):
             args.append("-DACTS_USE_SYSTEM_LIBS=ON")
+            if spec.satisfies("@35.1:36.0"):
+                args.append("-DACTS_USE_SYSTEM_DFELIBS=OFF")
         else:
             if spec.satisfies("+autodiff"):
                 args.append("-DACTS_USE_SYSTEM_AUTODIFF=ON")


### PR DESCRIPTION
For `acts@35.1:36.0` (between when `ACTS_USE_SYSTEM_DFELIBS` was set by default to `ACTS_USE_SYSTEM_LIBS` in https://github.com/acts-project/acts/commit/210b8979078704af25154b594071826f3dbb2a59, and when `dfelibs` was removed entirely in https://github.com/acts-project/acts/commit/d49e2f82564c89b872926dbd05d145c9e433efbf), there was no way to `find_package(dfelibs)` (which isn't in spack). Even if `dfelibs` was in spack, it has the wrong namespace alias.

This PR explicitly disables the finding of external `dfelibs` for the affected versions.