### PR TITLE
Bugfix: Remove remaining use of deprecated test callbacks: docs and two packages

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -5137,7 +5137,7 @@ other checks.
      - Not applicable
    * - :ref:`PythonPackage <pythonpackage>`
      - Not applicable
-     - ``test`` (module imports)
+     - ``test_imports`` (module imports)
    * - :ref:`QMakePackage <qmakepackage>`
      - ``check`` (``make check``)
      - Not applicable
@@ -5146,7 +5146,7 @@ other checks.
      - Not applicable
    * - :ref:`SIPPackage <sippackage>`
      - Not applicable
-     - ``test`` (module imports)
+     - ``test_imports`` (module imports)
    * - :ref:`WafPackage <wafpackage>`
      - ``build_test`` (must be overridden)
      - ``install_test`` (must be overridden)

--- a/var/spack/repos/builtin/packages/py-anuga/package.py
+++ b/var/spack/repos/builtin/packages/py-anuga/package.py
@@ -50,7 +50,7 @@ class PyAnuga(PythonPackage):
         if self.run_tests:
             env.prepend_path("PATH", self.spec["mpi"].prefix.bin)
 
-    install_time_test_callbacks = ["test", "installtest"]
+    install_time_test_callbacks = ["test_imports", "installtest"]
 
     def installtest(self):
         python("runtests.py", "--no-build")

--- a/var/spack/repos/builtin/packages/py-datalad/package.py
+++ b/var/spack/repos/builtin/packages/py-datalad/package.py
@@ -133,7 +133,7 @@ class PyDatalad(PythonPackage):
     # for version @:0.17
     conflicts("~metadata-extra", when="+full")
 
-    install_time_test_callbacks = ["test", "installtest"]
+    install_time_test_callbacks = ["test_imports", "installtest"]
 
     def installtest(self):
         datalad = Executable(self.prefix.bin.datalad)


### PR DESCRIPTION
https://github.com/spack/spack/pull/45752 missed references to the deprecated "test" method in the table at https://spack.readthedocs.io/en/latest/packaging_guide.html#id27 and for a couple of python packages. This PR corrects those omissions.