### PR TITLE
CI: Move the build stage to the project root instead of tmp

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/config.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/config.yaml
@@ -5,4 +5,6 @@ config:
     padded_length: 256
     projections:
       all: '{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'
+  build_stage:
+  - $spack/tmp/stage
 


### PR DESCRIPTION
On MacOS the tmpdir fills up over time and isn't cleared properly. Move the build stage to a location it is cleared after each build.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
