### PR TITLE
Ascii filter output

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -33,6 +33,7 @@ import heapq
 import io
 import itertools
 import os
+import re
 import shutil
 import sys
 import time
@@ -2321,7 +2322,12 @@ class BuildProcessInstaller:
         # If we are using a padded path, filter the output to compress padded paths
         # The real log still has full-length paths.
         padding = spack.config.get("config:install_tree:padded_length", None)
-        self.filter_fn = spack.util.path.padding_filter if padding else None
+        padding_filter_fn = spack.util.path.padding_filter if padding else lambda ln: ln
+
+        # Filter out non-ascii characters from the output
+        ascii_filter_fn = lambda ln: re.sub(r"[^\x00-\x7f]+", "???", ln)
+
+        self.filter_fn = lambda ln: ascii_filter_fn(padding_filter_fn(ln))
 
         # info/debug information
         self.pre = _log_prefix(pkg.name)

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -198,6 +198,8 @@ class BuildInfoCollector(InfoCollector):
                 return f.read()
         except OSError:
             return f"Cannot open log for {pkg.spec.cshort_spec}"
+        except UnicodeDecodeError:
+            return f"Cannot read log for {pkg.spec.cshort_spec}"
 
     def extract_package_from_signature(self, instance, *args, **kwargs):
         return args[0].pkg


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Filter non-ascii unicode when printing build output.

Handle `UnicodeDecodeError` when fetching build logs in report that contain non-ascii characters.