### PR TITLE
camp: restrict cub dependency to cuda versions older than 10 - as newer cuda versions already include cub

### DIFF
--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -63,7 +63,8 @@ class Camp(CMakePackage, CudaPackage, ROCmPackage):
     variant("omptarget", default=False, description="Build with OpenMP Target support")
     variant("sycl", default=False, description="Build with Sycl support")
 
-    depends_on("cub", when="+cuda")
+    with when("+cuda"):
+        depends_on("cub", when="^cuda@:10")
 
     depends_on("blt", type="build")
     depends_on("blt@0.6.2:", type="build", when="@2024.02.1:")


### PR DESCRIPTION
Adding an additional dependency on cub pulls in an in-compatible version of cub [than whats provided by cuda]

Ref:  https://github.com/spack/spack/pull/47848#issue-2705617962

Note similar usage: 
- https://github.com/spack/spack/blob/c23ffbbd7a459808d4b67645096743136797dd8d/var/spack/repos/builtin/packages/kaldi/package.py#L47
- https://github.com/spack/spack/blob/b6e4ff024262b7087d4f0b27804acf0e63a9e29a/var/spack/repos/builtin/packages/cusz/package.py#L33
- https://github.com/spack/spack/blob/b6e4ff024262b7087d4f0b27804acf0e63a9e29a/var/spack/repos/builtin/packages/aluminum/package.py#L99
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
