### PR TITLE
amr-wind: remove unused cmake option

### DIFF
--- a/var/spack/repos/builtin/packages/amr-wind/package.py
+++ b/var/spack/repos/builtin/packages/amr-wind/package.py
@@ -141,7 +141,6 @@ class AmrWind(CMakePackage, CudaPackage, ROCmPackage):
         args = [self.define_from_variant("AMR_WIND_ENABLE_%s" % v.upper(), v) for v in vs]
 
         args += [
-            define("AMR_WIND_ENABLE_ALL_WARNINGS", True),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
         ]
 

--- a/var/spack/repos/builtin/packages/amr-wind/package.py
+++ b/var/spack/repos/builtin/packages/amr-wind/package.py
@@ -140,9 +140,7 @@ class AmrWind(CMakePackage, CudaPackage, ROCmPackage):
         ]
         args = [self.define_from_variant("AMR_WIND_ENABLE_%s" % v.upper(), v) for v in vs]
 
-        args += [
-            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
-        ]
+        args += [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]
 
         if spec.satisfies("+mpi"):
             args.append(define("MPI_HOME", spec["mpi"].prefix))


### PR DESCRIPTION
We removed this CMake option.