### PR TITLE
Explicitly disable Lustre when ~lustre is set

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -1115,6 +1115,10 @@ with '-Wl,-commons,use_dylibs' and without
         if "~romio" in spec:
             config_args.append("--disable-io-romio")
 
+        # Disable Lustre if requested
+        if "~lustre" in self.spec:
+            config_args.append("--without-lustre")
+
         if not spec.satisfies("romio-filesystem=none"):
             args = "+".join(spec.variants["romio-filesystem"].value)
             config_args.append(f"--with-io-romio-flags=--with-file-system={args}")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
@hppritcha, @naughtont3, @rhc54 
When `liblustreapi.so` is present on the system, OpenMPI uses it even when `~lustre` variant is disabled. To fix this, one has to explicitly set `--without-lustre` in the OpenMPI's configure options. This PR does that.

OpenPMIX has the same problem, I opened a separate Spack issue on that.

Thanks,
Martin