### PR TITLE
pnetcdf: New versions and examples option

### DIFF
--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -36,6 +36,8 @@ class ParallelNetcdf(AutotoolsPackage):
         return url
 
     version("master", branch="master")
+    version("1.14.0", sha256="575f189fb01c53f93b3d6ae0e506f46e19694807c81af0b9548e947995acf704")
+    version("1.13.0", sha256="aba0f1c77a51990ba359d0f6388569ff77e530ee574e40592a1e206ed9b2c491")
     version("1.12.3", sha256="439e359d09bb93d0e58a6e3f928f39c2eae965b6c97f64e67cd42220d6034f77")
     version("1.12.2", sha256="3ef1411875b07955f519a5b03278c31e566976357ddfc74c2493a1076e7d7c74")
     version("1.12.1", sha256="56f5afaa0ddc256791c405719b6436a83b92dcd5be37fe860dea103aee8250a2")
@@ -58,6 +60,7 @@ class ParallelNetcdf(AutotoolsPackage):
     variant("pic", default=True, description="Produce position-independent code (for shared libs)")
     variant("shared", default=True, description="Enable shared library")
     variant("burstbuffer", default=False, description="Enable burst buffer feature")
+    variant("examples", when="@1.13:", default=False, description="Install example programs")
 
     depends_on("mpi")
 
@@ -122,14 +125,14 @@ class ParallelNetcdf(AutotoolsPackage):
 
         flags = {"CFLAGS": [], "CXXFLAGS": [], "FFLAGS": [], "FCFLAGS": []}
 
-        if "+pic" in self.spec:
+        if self.spec.satisfies("+pic"):
             flags["CFLAGS"].append(self.compiler.cc_pic_flag)
             flags["CXXFLAGS"].append(self.compiler.cxx_pic_flag)
             flags["FFLAGS"].append(self.compiler.f77_pic_flag)
             flags["FCFLAGS"].append(self.compiler.fc_pic_flag)
 
         # https://github.com/Parallel-NetCDF/PnetCDF/issues/61
-        if self.spec.satisfies("%gcc@10:"):
+        if self.spec.satisfies("@:1.12") and self.spec.satisfies("%gcc@10:"):
             flags["FFLAGS"].append("-fallow-argument-mismatch")
             flags["FCFLAGS"].append("-fallow-argument-mismatch")
 
@@ -137,18 +140,21 @@ class ParallelNetcdf(AutotoolsPackage):
             if value:
                 args.append(f"{key}={' '.join(value)}")
 
-        if self.version >= Version("1.8"):
+        if self.spec.satisfies("@1.8:"):
             args.append("--enable-relax-coord-bound")
 
-        if self.version >= Version("1.9"):
+        if self.spec.satisfies("@1.9:"):
             args += self.enable_or_disable("shared")
             args.extend(["--enable-static", "--disable-silent-rules"])
 
         if self.spec.satisfies("%nag+fortran+shared"):
             args.extend(["ac_cv_prog_fc_v=-Wl,-v", "ac_cv_prog_f77_v=-Wl,-v"])
 
-        if "+burstbuffer" in self.spec:
+        if self.spec.satisfies("+burstbuffer"):
             args.append("--enable-burst-buffering")
+
+        if self.spec.satisfies("+examples"):
+            args.append("--enable-install-examples")
 
         return args
 

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -60,7 +60,8 @@ class ParallelNetcdf(AutotoolsPackage):
     variant("pic", default=True, description="Produce position-independent code (for shared libs)")
     variant("shared", default=True, description="Enable shared library")
     variant("burstbuffer", default=False, description="Enable burst buffer feature")
-    variant("examples", when="@1.13:", default=False, description="Install example programs")
+    variant("examples", default=False, description="Install example programs")
+    conflicts("+examples", when="@:1.12")
 
     depends_on("mpi")
 

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -132,7 +132,7 @@ class ParallelNetcdf(AutotoolsPackage):
             flags["FCFLAGS"].append(self.compiler.fc_pic_flag)
 
         # https://github.com/Parallel-NetCDF/PnetCDF/issues/61
-        if self.spec.satisfies("@:1.12") and self.spec.satisfies("%gcc@10:"):
+        if self.spec.satisfies("@:1.12.1%gcc@10:"):
             flags["FFLAGS"].append("-fallow-argument-mismatch")
             flags["FCFLAGS"].append("-fallow-argument-mismatch")
 


### PR DESCRIPTION
This PR adds the latest two pnetcdf versions - 1.13 and 1.14, and brings in support for the new examples configuration option via a new variant.