### PR TITLE
Add py-pytest-env package, update py-pytest to latest version

### DIFF
--- a/var/spack/repos/builtin/packages/py-pytest-env/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-env/package.py
@@ -36,4 +36,4 @@ class PyPytestEnv(PythonPackage):
     depends_on("py-pytest@8.3.3:", type=("build", "run"), when="@1.1.5:")
     depends_on("py-pytest@8.3.2:", type=("build", "run"), when="@1.1.4:")
 
-    depends_on("py-tomli", type=("build", "run"))
+    depends_on("py-tomli@2.0.1:", type=("build", "run"), when="^python@:3.10")

--- a/var/spack/repos/builtin/packages/py-pytest-env/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-env/package.py
@@ -1,0 +1,39 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPytestEnv(PythonPackage):
+    """Pytest plugin that enables you to set environment variables in a
+    pytest.ini or pyproject.toml file."""
+
+    homepage = "https://github.com/pytest-dev/pytest-env"
+    pypi = "pytest-env/pytest_env-1.1.5.tar.gz"
+
+    license("MIT")
+
+    version("1.1.5", sha256="91209840aa0e43385073ac464a554ad2947cc2fd663a9debf88d03b01e0cc1cf")
+    version("1.1.4", sha256="86653658da8f11c6844975db955746c458a9c09f1e64957603161e2ff93f5133")
+    version("1.1.3", sha256="fcd7dc23bb71efd3d35632bde1bbe5ee8c8dc4489d6617fb010674880d96216b")
+    version("1.1.2", sha256="8a7c46317d708407b0d6c38767f68a34155afe72cd42b74b4edd5c04c7851372")
+    version("1.1.1", sha256="1efb8acce1f6431196150f3b30673443ff05a6fabff64539a9495cd2248adf9e")
+    version("1.1.0", sha256="ea0a710f1b6a3571ed971fb6d6e5db05a2ae6b91b0fbcafe30fb5ea40e9987c4")
+
+    with when("@1.1.1:1.1.3"):
+        depends_on("python@3.8:3.12", type=("build", "run"))
+        depends_on("py-hatchling@1.18:", type=("build"))
+        depends_on("py-hatch-vcs@0.3:", type=("build"))
+        depends_on("py-pytest@7.4.2:", type=("build", "run"))
+
+    with when("@1.1.4:1.1.5"):
+        depends_on("python@3.8:3.13", type=("build", "run"))
+        depends_on("py-hatchling@1.25:", type=("build"))
+        depends_on("py-hatch-vcs@0.4", type=("build"))
+
+    depends_on("py-pytest@8.3.3:", type=("build", "run"), when="@1.1.5:")
+    depends_on("py-pytest@8.3.2:", type=("build", "run"), when="@1.1.4:")
+
+    depends_on("py-tomli", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pytest/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest/package.py
@@ -54,7 +54,6 @@ class PyPytest(PythonPackage):
         depends_on("py-setuptools-scm", when="@3.1:")
 
     with default_args(type=("build", "run")):
-        depends_on("python@3.8:3.12", when="@8.3.4")
         depends_on("python@3.8:", when="@8:")
         depends_on("python@3.7:", when="@7.1:")
         # see https://github.com/pytest-dev/pytest/releases/tag/8.2.1

--- a/var/spack/repos/builtin/packages/py-pytest/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest/package.py
@@ -42,13 +42,6 @@ class PyPytest(PythonPackage):
     version("3.0.7", sha256="b70696ebd1a5e6b627e7e3ac1365a4bc60aaf3495e843c1e70448966c5224cab")
     version("3.0.2", sha256="64d8937626dd2a4bc15ef0edd307d26636a72a3f3f9664c424d78e40efb1e339")
 
-    variant(
-        "dev",
-        description="Include optional dependencies, pluggy and tomli",
-        default=False,
-        when="@8.3.4:",
-    )
-
     with default_args(type="build"):
         depends_on("py-setuptools@61:", when="@8.1:")
         depends_on("py-setuptools@45:", when="@7:")
@@ -61,8 +54,7 @@ class PyPytest(PythonPackage):
         depends_on("py-setuptools-scm", when="@3.1:")
 
     with default_args(type=("build", "run")):
-        depends_on("python@3.9:", when="@8.3.4:")
-        depends_on("python@3.8:", when="@8:8.2.1")
+        depends_on("python@3.8:", when="@8:")
         depends_on("python@3.7:", when="@7.1:")
         # see https://github.com/pytest-dev/pytest/releases/tag/8.2.1
         depends_on("python@:3.12", when="@:8.2.0")
@@ -73,9 +65,8 @@ class PyPytest(PythonPackage):
         depends_on("py-exceptiongroup@1:", when="@7:^python@:3.10")
         depends_on("py-iniconfig", when="@6.0:")
         depends_on("py-packaging", when="@4.6:")
-        depends_on("py-pluggy@1.5:1", when="@8.3.4: +dev")
-        depends_on("py-pluggy@1.5:1", when="@8.2:8.3")
-        depends_on("py-pluggy@1.3:1", when="@8:8.3")
+        depends_on("py-pluggy@1.5:1", when="@8.2:")
+        depends_on("py-pluggy@1.3:1", when="@8:")
         depends_on("py-pluggy@0.12:1", when="@6.2:7")
         depends_on("py-pluggy@0.12:0", when="@4.6:6.1")
         depends_on("py-pluggy@0.9.0:0.9,0.11:0", when="@4.5.0:4.5")
@@ -84,8 +75,7 @@ class PyPytest(PythonPackage):
         depends_on("py-pluggy@0.7:", when="@3.7:4.3")
         depends_on("py-pluggy@0.5:0.7", when="@3.6.4:3.6")
         depends_on("py-pluggy@0.5:0.6", when="@:3.6.3")
-        depends_on("py-tomli@1:", when="@8.3.4: +dev ^python@:3.10")
-        depends_on("py-tomli@1:", when="@7.1:8.3 ^python@:3.10")
+        depends_on("py-tomli@1:", when="@7.1: ^python@:3.10")
         depends_on("py-tomli@1:", when="@7.0")
 
         # Historic dependencies

--- a/var/spack/repos/builtin/packages/py-pytest/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest/package.py
@@ -54,6 +54,7 @@ class PyPytest(PythonPackage):
         depends_on("py-setuptools-scm", when="@3.1:")
 
     with default_args(type=("build", "run")):
+        depends_on("python@3.8:3.12", when="@8.3.4")
         depends_on("python@3.8:", when="@8:")
         depends_on("python@3.7:", when="@7.1:")
         # see https://github.com/pytest-dev/pytest/releases/tag/8.2.1

--- a/var/spack/repos/builtin/packages/py-pytest/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest/package.py
@@ -16,6 +16,7 @@ class PyPytest(PythonPackage):
     license("MIT")
     maintainers("adamjstewart")
 
+    version("8.3.4", sha256="965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761")
     version("8.2.1", sha256="5046e5b46d8e4cac199c373041f26be56fdb81eb4e67dc11d4e10811fc3408fd")
     version("8.0.0", sha256="249b1b0864530ba251b7438274c4d251c58d868edaaec8762893ad4a0d71c36c")
     version("7.4.4", sha256="2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280")
@@ -41,6 +42,13 @@ class PyPytest(PythonPackage):
     version("3.0.7", sha256="b70696ebd1a5e6b627e7e3ac1365a4bc60aaf3495e843c1e70448966c5224cab")
     version("3.0.2", sha256="64d8937626dd2a4bc15ef0edd307d26636a72a3f3f9664c424d78e40efb1e339")
 
+    variant(
+        "dev",
+        description="Include optional dependencies, pluggy and tomli",
+        default=False,
+        when="@8.3.4:",
+    )
+
     with default_args(type="build"):
         depends_on("py-setuptools@61:", when="@8.1:")
         depends_on("py-setuptools@45:", when="@7:")
@@ -53,7 +61,8 @@ class PyPytest(PythonPackage):
         depends_on("py-setuptools-scm", when="@3.1:")
 
     with default_args(type=("build", "run")):
-        depends_on("python@3.8:", when="@8:")
+        depends_on("python@3.9:", when="@8.3.4:")
+        depends_on("python@3.8:", when="@8:8.2.1")
         depends_on("python@3.7:", when="@7.1:")
         # see https://github.com/pytest-dev/pytest/releases/tag/8.2.1
         depends_on("python@:3.12", when="@:8.2.0")
@@ -64,8 +73,9 @@ class PyPytest(PythonPackage):
         depends_on("py-exceptiongroup@1:", when="@7:^python@:3.10")
         depends_on("py-iniconfig", when="@6.0:")
         depends_on("py-packaging", when="@4.6:")
-        depends_on("py-pluggy@1.5:1", when="@8.2:")
-        depends_on("py-pluggy@1.3:1", when="@8:")
+        depends_on("py-pluggy@1.5:1", when="@8.3.4: +dev")
+        depends_on("py-pluggy@1.5:1", when="@8.2:8.3")
+        depends_on("py-pluggy@1.3:1", when="@8:8.3")
         depends_on("py-pluggy@0.12:1", when="@6.2:7")
         depends_on("py-pluggy@0.12:0", when="@4.6:6.1")
         depends_on("py-pluggy@0.9.0:0.9,0.11:0", when="@4.5.0:4.5")
@@ -74,7 +84,8 @@ class PyPytest(PythonPackage):
         depends_on("py-pluggy@0.7:", when="@3.7:4.3")
         depends_on("py-pluggy@0.5:0.7", when="@3.6.4:3.6")
         depends_on("py-pluggy@0.5:0.6", when="@:3.6.3")
-        depends_on("py-tomli@1:", when="@7.1: ^python@:3.10")
+        depends_on("py-tomli@1:", when="@8.3.4: +dev ^python@:3.10")
+        depends_on("py-tomli@1:", when="@7.1:8.3 ^python@:3.10")
         depends_on("py-tomli@1:", when="@7.0")
 
         # Historic dependencies


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This adds a `py-pytest-env` package to spack. The latest version of `pytest-env` depends on a newer version of `pytest` than is currently available on spack, so this includes a version bump to the `py-pytest` package as well.

tagging @adamjstewart RE: update to py-pytest 8.3.4 - I compared the contents of pytest's `pyproject.toml` from 8.2.1 to 8.3.4 to create the updates, but I would be happy to make changes to this PR or defer the update if you'd rather handle it. 