### PR TITLE
fix extendee_spec for transitive dependencies on potential extendees

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -457,7 +457,7 @@ def extends(spec, when=None, type=("build", "run"), patches=None):
             _depends_on(pkg, spack.spec.Spec("python-venv"), when=when, type=("build", "run"))
 
         # TODO: the values of the extendees dictionary are not used. Remove in next refactor.
-        pkg.extendees[dep_spec.name] = (dep_spec, None)
+        pkg.extendees[dep_spec.name] = (dep_spec, when_spec)
 
     return _execute_extends
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -456,7 +456,6 @@ def extends(spec, when=None, type=("build", "run"), patches=None):
         if dep_spec.name == "python" and not pkg.name == "python-venv":
             _depends_on(pkg, spack.spec.Spec("python-venv"), when=when, type=("build", "run"))
 
-        # TODO: the values of the extendees dictionary are not used. Remove in next refactor.
         pkg.extendees[dep_spec.name] = (dep_spec, when_spec)
 
     return _execute_extends

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1416,12 +1416,13 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         if not self.extendees:
             return None
 
-        deps = []
-
         # If the extendee is in the spec's deps already, return that.
-        for dep in self.spec.dependencies(deptype=("link", "run")):
-            if dep.name in self.extendees:
-                deps.append(dep)
+        deps = [
+            dep
+            for dep in self.spec.dependencies(deptype=("link", "run"))
+            for d, when in self.extendees.values()
+            if dep.satisfies(d) and self.spec.satisfies(when)
+        ]
 
         if deps:
             assert len(deps) == 1

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1419,7 +1419,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         deps = []
 
         # If the extendee is in the spec's deps already, return that.
-        for dep in self.spec.traverse(deptype=("link", "run")):
+        for dep in self.spec.dependencies(deptype=("link", "run")):
             if dep.name in self.extendees:
                 deps.append(dep)
 

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -67,6 +67,13 @@ def test_extends_spec(config, mock_packages):
     assert extender.package.extends(extendee)
 
 
+@pytest.mark.regression("48024")
+def test_conditionally_extends_transitive_dep(config, mock_packages):
+    spec = spack.spec.Spec("extends-transitive-dep").concretized()
+
+    assert not spec.package.extendee_spec
+
+
 @pytest.mark.regression("34368")
 def test_error_on_anonymous_dependency(config, mock_packages):
     pkg = spack.repo.PATH.get_pkg_class("pkg-a")

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -69,7 +69,14 @@ def test_extends_spec(config, mock_packages):
 
 @pytest.mark.regression("48024")
 def test_conditionally_extends_transitive_dep(config, mock_packages):
-    spec = spack.spec.Spec("extends-transitive-dep").concretized()
+    spec = spack.spec.Spec("conditionally-extends-transitive-dep").concretized()
+
+    assert not spec.package.extendee_spec
+
+
+@pytest.mark.regression("48025")
+def test_conditionally_extends_direct_dep(config, mock_packages):
+    spec = spack.spec.Spec("conditionally-extends-direct-dep").concretized()
 
     assert not spec.package.extendee_spec
 

--- a/var/spack/repos/builtin.mock/packages/conditionally-extends-direct-dep/package.py
+++ b/var/spack/repos/builtin.mock/packages/conditionally-extends-direct-dep/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class ConditionallyExtendsDirectDep(Package):
+    """Package that tests if the extends directive supports a spec."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/example-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    extends("extendee", when="@2:")  # will not satisfy version
+    depends_on("extendee")

--- a/var/spack/repos/builtin.mock/packages/conditionally-extends-transitive-dep/package.py
+++ b/var/spack/repos/builtin.mock/packages/conditionally-extends-transitive-dep/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class ExtendsTransitiveDep(Package):
+class ConditionallyExtendsTransitiveDep(Package):
     """Package that tests if the extends directive supports a spec."""
 
     homepage = "http://www.example.com"

--- a/var/spack/repos/builtin.mock/packages/extends-transitive-dep/package.py
+++ b/var/spack/repos/builtin.mock/packages/extends-transitive-dep/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class ExtendsTransitiveDep(Package):
+    """Package that tests if the extends directive supports a spec."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/example-1.0.tar.gz"
+
+    version("1.0", md5="0123456789abcdef0123456789abcdef")
+
+    extends("extendee", when="@2:")  # will not satisfy version
+    depends_on("extension1")


### PR DESCRIPTION
fixes #48024

Only consider transitive dependencies in `extendee_spec()`.