### PR TITLE
Update ESMF to support clang with gfortran and clang with flang

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -270,13 +270,18 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
         elif self.pkg.compiler.name == "intel" or self.pkg.compiler.name == "oneapi":
             env.set("ESMF_COMPILER", "intel")
         elif self.pkg.compiler.name in ["clang", "apple-clang"]:
-            env.set("ESMF_COMPILER", "gfortranclang")
-            with self.pkg.compiler.compiler_environment():
-                gfortran_major_version = int(
-                    spack.compiler.get_compiler_version_output(
-                        self.pkg.compiler.fc, "-dumpversion"
-                    ).split(".")[0]
-                )
+            if "flang" in self.pkg.compiler.fc:
+                env.set("ESMF_COMPILER", "llvm")
+            elif "gfortran" in self.pkg.compiler.fc:
+                env.set("ESMF_COMPILER", "gfortranclang")
+                with self.pkg.compiler.compiler_environment():
+                    gfortran_major_version = int(
+                        spack.compiler.get_compiler_version_output(
+                            self.pkg.compiler.fc, "-dumpversion"
+                        ).split(".")[0]
+                    )
+            else:
+                raise InstallError("Unsupported C/C++/Fortran compiler combination")
         elif self.pkg.compiler.name == "nag":
             env.set("ESMF_COMPILER", "nag")
         elif self.pkg.compiler.name == "nvhpc":
@@ -309,6 +314,7 @@ class MakefileBuilder(spack.build_systems.makefile.MakefileBuilder):
 
         if (
             self.pkg.compiler.name in ["gcc", "clang", "apple-clang"]
+            and "gfortran" in self.pkg.compiler.fc
             and gfortran_major_version >= 10
             and (self.spec.satisfies("@:8.2.99") or self.spec.satisfies("@8.3.0b09"))
         ):


### PR DESCRIPTION
## Description

So far, the ESMF package recipe in spack assumes that the spack compilers `clang` and `apple-clang` are using `gfortran` as the Fortran compiler. But with the latest improvements to the LLVM compilers, we need to also support `clang` with `flang`.

This is the easiest approach I could come up with, and I was able to build a test version (ESMF 8.8.0 beta snapshot 09) with LLVM 19.1.4 (`clang`, `clang++`, `flang-new`) this way.

If there's a better way to identify the Fortran compiler in a spack compiler config, then I am eager to hear about it.