### PR TITLE
umf only avaiable with 2025

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -398,7 +398,7 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
         super().setup_run_environment(env)
 
         # umf is packaged with compiler and not available as a standalone
-        if "~envmods" not in self.spec:
+        if "~envmods" not in self.spec and self.spec.satisfies("@2025:"):
             env.extend(
                 EnvironmentModifications.from_sourcing_file(
                     self.prefix.umf.latest.env.join("vars.sh"), *self.env_script_args


### PR DESCRIPTION
2025 compiler needs to load umf. umf is not available with earlier installs. Thanks to @wspear for reporting it

fixes:

```
rscohn1@gkdse-dnp-23:spack$ spack load intel-oneapi-compilers-classic@2021.10.0
==> Error: Trying to source non-existing file: /shared/tpi0/users/rscohn1/projects/spack/spack/opt/spack/linux-ubuntu22.04-sapphirerapids/gcc-\
12.3.0/intel-oneapi-compilers-2023.2.4-d5taogfnfdxk3a3xhdz3fqwcoqgfzar5/umf/latest/env/vars.sh
```

