### PR TITLE
libjpeg-turbo: add v3.0.4

### DIFF
--- a/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
+++ b/var/spack/repos/builtin/packages/libjpeg-turbo/package.py
@@ -25,6 +25,7 @@ class LibjpegTurbo(CMakePackage, AutotoolsPackage):
 
     license("BSD-3-Clause AND IJG AND Zlib")
 
+    version("3.0.4", sha256="0270f9496ad6d69e743f1e7b9e3e9398f5b4d606b6a47744df4b73df50f62e38")
     version("3.0.3", sha256="a649205a90e39a548863a3614a9576a3fb4465f8e8e66d54999f127957c25b21")
     version("3.0.2", sha256="29f2197345aafe1dcaadc8b055e4cbec9f35aad2a318d61ea081f835af2eebe9")
     version("3.0.1", sha256="5b9bbca2b2a87c6632c821799438d358e27004ab528abf798533c15d50b39f82")
@@ -57,9 +58,6 @@ class LibjpegTurbo(CMakePackage, AutotoolsPackage):
         sha256="5008aeeac303ea9159a0ec3ccff295434f4e63b05aed4a684c9964d497304524",
         deprecated=True,
     )
-
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
 
     provides("jpeg")
 
@@ -97,12 +95,16 @@ class LibjpegTurbo(CMakePackage, AutotoolsPackage):
         when="@2.0.6 +partial_decoder",
     )
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     # Can use either of these. But in the current version of the package
     # only nasm is used. In order to use yasm an environmental variable
     # NASM must be set.
     # TODO: Implement the selection between two supported assemblers.
     # depends_on('yasm', type='build')
     depends_on("nasm", type="build")
+
     with when("build_system=autotools"):
         depends_on("autoconf", type="build")
         depends_on("automake", type="build")


### PR DESCRIPTION
Adding latest patch release v3.0.4 for libjpeg-turbo.

https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/3.0.4