### PR TITLE
dbcsr: add v2.8.0

### DIFF
--- a/var/spack/repos/builtin/packages/dbcsr/package.py
+++ b/var/spack/repos/builtin/packages/dbcsr/package.py
@@ -21,6 +21,7 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
     license("GPL-2.0-or-later")
 
     version("develop", branch="develop")
+    version("2.8.0", sha256="d55e4f052f28d1ed0faeaa07557241439243287a184d1fd27f875c8b9ca6bd96")
     version("2.7.0", sha256="25c367b49fb108c5230bcfb127f05fc16deff2bb467f437023dfa6045aff66f6")
     version("2.6.0", sha256="c67b02ff9abc7c1f529af446a9f01f3ef9e5b0574f220259128da8d5ca7e9dc6")
     version("2.5.0", sha256="91fda9b2502e5d0a2a6cdd5a73ef096253cc7e75bd01ba5189a4726ad86aef08")

--- a/var/spack/repos/builtin/packages/dbcsr/package.py
+++ b/var/spack/repos/builtin/packages/dbcsr/package.py
@@ -16,7 +16,7 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
     url = "https://github.com/cp2k/dbcsr/releases/download/v2.2.0/dbcsr-2.2.0.tar.gz"
     list_url = "https://github.com/cp2k/dbcsr/releases"
 
-    maintainers("dev-zero", "mtaillefumier")
+    maintainers("dev-zero", "mtaillefumier", "RMeli")
 
     license("GPL-2.0-or-later")
 


### PR DESCRIPTION
https://github.com/cp2k/dbcsr/releases/tag/v2.8.0