### PR TITLE
gaudi: set GAUDI_PLUGIN_PATH for runtime on macos

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -183,7 +183,6 @@ class Gaudi(CMakePackage):
             # but may replace LD_LIBRARY_PATH in the future
             env.prepend_path("GAUDI_PLUGIN_PATH", lib_path)
 
-
     def url_for_version(self, version):
         major = str(version[0])
         minor = str(version[1])

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -179,6 +179,10 @@ class Gaudi(CMakePackage):
         # ...but Gaudi additionally requires a path variable about itself
         for lib_path in [self.prefix.lib, self.prefix.lib64]:
             env.prepend_path("LD_LIBRARY_PATH", lib_path)
+            # GAUDI_PLUGIN_PATH currently only used on macos
+            # but may replace LD_LIBRARY_PATH in the future
+            env.prepend_path("GAUDI_PLUGIN_PATH", lib_path)
+
 
     def url_for_version(self, version):
         major = str(version[0])


### PR DESCRIPTION
This PR is needed to for executing gaudirun.py on macos. Apple's SIP strips certain environment vars for processes running from /usr/, so `#!/usr/bin/env python` is different from `#!/opt/actual/path/to/python`.

Ideally Gaudi fully uses GAUDI_PLUGIN_PATH - actually I just see that the recipe hasn't been updated to use GAUDI_PLUGIN_PATH. Let me check if the patch is still needed when setting it

EDIT: indeed this workaround is not needed with GAUDI_PLUGIN_PATH :) - completely forgot to check if that has been added to the recipe already