### PR TITLE
Add openfast FPE trap variant

### DIFF
--- a/var/spack/repos/builtin/packages/openfast/package.py
+++ b/var/spack/repos/builtin/packages/openfast/package.py
@@ -51,6 +51,7 @@ class Openfast(CMakePackage):
     variant("netcdf", default=False, description="Enable NetCDF support")
     variant("rosco", default=False, description="Build ROSCO controller")
     variant("fastfarm", default=False, description="Enable FAST.Farm capabilities")
+    variant("fpe-trap", default=False, description="Enable FPE trap in compiler options")
 
     depends_on("blas")
     depends_on("lapack")
@@ -80,6 +81,7 @@ class Openfast(CMakePackage):
                 self.define_from_variant("BUILD_OPENFAST_CPP_DRIVER", "cxx"),
                 self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
                 self.define_from_variant("BUILD_FASTFARM", "fastfarm"),
+                self.define_from_variant("FPE_TRAP_ENABLED", "fpe-trap"),
             ]
         )
 


### PR DESCRIPTION
Enable the FPE_TRAP_ENABLED cmake option in openfast. Defaults to false.