### PR TITLE
xyce: update +pymi related dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/xyce/package.py
+++ b/var/spack/repos/builtin/packages/xyce/package.py
@@ -102,7 +102,9 @@ class Xyce(CMakePackage):
 
     depends_on("python@3:", type=("build", "link", "run"), when="+pymi")
     depends_on("py-pip", type="run", when="+pymi")
-    depends_on("py-pybind11@2.6.1:", type=("build", "link"), when="+pymi")
+    depends_on("py-pybind11@2.6.1:", type=("build", "link"), when="@:7.8 +pymi")
+    depends_on("py-pybind11@2.13:", type=("build", "link"), when="@7.9: +pymi")
+    depends_on("python-venv", when="+pymi")
 
     depends_on(
         "trilinos"


### PR DESCRIPTION
Update `py-pybind11` dependency for what will soon need to be on the `develop` branch as well as version 7.9 onward (for +pymi). Also adds `python-venv` dependency when +pymi, ensuring consistency with `py-pip`, `python`, and `python-venv` after `python-venv` was added as a dependency for all `PythonPackages`.

