### PR TITLE
rivet: patch to fix missing headers

### DIFF
--- a/var/spack/repos/builtin/packages/rivet/package.py
+++ b/var/spack/repos/builtin/packages/rivet/package.py
@@ -94,6 +94,13 @@ class Rivet(AutotoolsPackage):
 
     filter_compiler_wrappers("rivet-build", relative_root="bin")
 
+    # fix missing headers in 4.0.x
+    patch(
+        "https://gitlab.com/hepcedar/rivet/-/merge_requests/973.diff",
+        sha256="e1ff65c8dfe80c0b1bb8ad9960754932541064dd5334311a8bd5a377374a9926",
+        when="@4:4.0.2",
+    )
+
     patch("rivet-3.0.0.patch", when="@3.0.0", level=0)
     patch("rivet-3.0.1.patch", when="@3.0.1", level=0)
     patch("rivet-3.1.0.patch", when="@3.1.0", level=0)


### PR DESCRIPTION
There are missing headers in `analyses/pluginBES/BESIII_2024_I2779452.cc`, resulting in compilation failures such as https://gitlab.spack.io/spack/spack/-/jobs/14168795#L1116. This PR adds a patch for the missing headers from the [upstream merge request](https://gitlab.com/hepcedar/rivet/-/merge_requests/973).