### PR TITLE
grads: Support newer hdf5 versions for grads

### DIFF
--- a/var/spack/repos/builtin/packages/grads/package.py
+++ b/var/spack/repos/builtin/packages/grads/package.py
@@ -41,7 +41,7 @@ class Grads(AutotoolsPackage):
     variant("hdf4", default=True, when="@2.2.2:", description="Enable HDF4 support")
     variant("netcdf", default=True, when="@2.2.2:", description="Enable NetCDF support")
 
-    depends_on("hdf5@:1.10", when="+hdf5")
+    depends_on("hdf5", when="+hdf5")
     depends_on("hdf", when="+hdf4")
     depends_on("netcdf-c", when="+netcdf")
     depends_on("g2c", when="+grib2")
@@ -73,6 +73,17 @@ class Grads(AutotoolsPackage):
             filter_file("grib2c", "g2c", "configure")
             if self.spec.satisfies("^g2c@1.8.0:"):
                 filter_file("G2_VERSION", "G2C_VERSION", "src/gacfg.c")
+
+    # Can use newer versions of HDF5, but 1.10 is the last API GrADS supports
+    def flag_handler(self, name, flags):
+        spec = self.spec
+
+        if name == "cflags":
+            if "+hdf5" in spec:
+                if "@1.12:" in spec["hdf5"]:
+                    flags.append("-DH5_USE_110_API")
+
+        return (flags, None, None)
 
     def setup_build_environment(self, env):
         env.set("SUPPLIBS", "/")

--- a/var/spack/repos/builtin/packages/grads/package.py
+++ b/var/spack/repos/builtin/packages/grads/package.py
@@ -64,21 +64,21 @@ class Grads(AutotoolsPackage):
             url = "ftp://cola.gmu.edu/grads/{}/grads-{}-src.tar.gz"
             return url.format(version.up_to(2), version)
 
-    # Name of grib2 C library has changed in recent versions
     def patch(self):
         if self.spec.satisfies("@:2.2.2"):
             filter_file("png15", "png", "configure")
 
+        # Name of grib2 C library has changed in recent versions
         if self.spec.satisfies("+grib2"):
             filter_file("grib2c", "g2c", "configure")
             if self.spec.satisfies("^g2c@1.8.0:"):
                 filter_file("G2_VERSION", "G2C_VERSION", "src/gacfg.c")
 
-    # Can use newer versions of HDF5, but 1.10 is the last API GrADS supports
     def flag_handler(self, name, flags):
         spec = self.spec
 
         if name == "cflags":
+            # Can use newer versions of HDF5, but 1.10 is the last API GrADS supports
             if "hdf5" in spec and spec["hdf5"].satisfies("@1.12:"):
                 flags.append("-DH5_USE_110_API")
 

--- a/var/spack/repos/builtin/packages/grads/package.py
+++ b/var/spack/repos/builtin/packages/grads/package.py
@@ -79,9 +79,8 @@ class Grads(AutotoolsPackage):
         spec = self.spec
 
         if name == "cflags":
-            if "+hdf5" in spec:
-                if "@1.12:" in spec["hdf5"]:
-                    flags.append("-DH5_USE_110_API")
+            if "hdf5" in spec and spec["hdf5"].satisfies("@1.12:"):
+                flags.append("-DH5_USE_110_API")
 
         return (flags, None, None)
 


### PR DESCRIPTION
This PR adapts code from the `silo` recipe to support newer hdf5 dependencies than 1.10 when building grads. It forces the use of the 1.10 API when building against newer hdf5 versions.