### PR TITLE
ci: new image for developer-tools

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -455,7 +455,7 @@ build_systems-build:
 
 developer-tools-x86_64_v3-linux-gnu-generate:
   extends: [ ".developer-tools-x86_64_v3-linux-gnu", ".generate-x86_64"]
-  image:  ghcr.io/haampie/x86_64_v3-linux-gnu:2024-12-12
+  image:  ghcr.io/spack/x86_64_v3-linux-gnu:2024-12-12
 
 developer-tools-x86_64_v3-linux-gnu-build:
   extends: [ ".developer-tools-x86_64_v3-linux-gnu", ".build" ]

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -447,27 +447,26 @@ build_systems-build:
 
 ###########################################
 # Build tests for different developer tools
-# manylinux2014
 ###########################################
-.developer-tools-manylinux2014:
+.developer-tools-x86_64_v3-linux-gnu:
   extends: [ ".linux_x86_64_v3" ]
   variables:
-    SPACK_CI_STACK_NAME: developer-tools-manylinux2014
+    SPACK_CI_STACK_NAME: developer-tools-x86_64_v3-linux-gnu
 
-developer-tools-manylinux2014-generate:
-  extends: [ ".developer-tools-manylinux2014", ".generate-x86_64"]
-  image:  ghcr.io/spack/spack/manylinux2014:2024.03.28
+developer-tools-x86_64_v3-linux-gnu-generate:
+  extends: [ ".developer-tools-x86_64_v3-linux-gnu", ".generate-x86_64"]
+  image:  ghcr.io/haampie/x86_64_v3-linux-gnu:2024-12-12
 
-developer-tools-manylinux2014-build:
-  extends: [ ".developer-tools-manylinux2014", ".build" ]
+developer-tools-x86_64_v3-linux-gnu-build:
+  extends: [ ".developer-tools-x86_64_v3-linux-gnu", ".build" ]
   trigger:
     include:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-        job: developer-tools-manylinux2014-generate
+        job: developer-tools-x86_64_v3-linux-gnu-generate
     strategy: depend
   needs:
     - artifacts: True
-      job: developer-tools-manylinux2014-generate
+      job: developer-tools-x86_64_v3-linux-gnu-generate
 
 ###########################################
 # Build tests for different developer tools

--- a/share/spack/gitlab/cloud_pipelines/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
@@ -79,7 +79,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ghcr.io/haampie/x86_64_v3-linux-gnu:2024-12-12
+        image: ghcr.io/spack/x86_64_v3-linux-gnu:2024-12-12
 
   cdash:
     build-group: Developer Tools x86_64_v3-linux-gnu

--- a/share/spack/gitlab/cloud_pipelines/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
@@ -76,21 +76,6 @@ spack:
     - - $default_specs
     - - $arch
 
-  compilers:
-  - compiler:
-      spec: gcc@=10.5.0
-      paths:
-        cc: /spack/store/linux-centos7-x86_64_v3/gcc-10.5.0/gcc-10.5.0-jxwvpluevsb5xfmelfqa5vjnapbodaet/bin/gcc
-        cxx: /spack/store/linux-centos7-x86_64_v3/gcc-10.5.0/gcc-10.5.0-jxwvpluevsb5xfmelfqa5vjnapbodaet/bin/g++
-        f77: /spack/store/linux-centos7-x86_64_v3/gcc-10.5.0/gcc-10.5.0-jxwvpluevsb5xfmelfqa5vjnapbodaet/bin/gfortran
-        fc: /spack/store/linux-centos7-x86_64_v3/gcc-10.5.0/gcc-10.5.0-jxwvpluevsb5xfmelfqa5vjnapbodaet/bin/gfortran
-      flags: {}
-      operating_system: centos7
-      target: x86_64
-      modules: []
-      environment: {}
-      extra_rpaths: []
-
   ci:
     pipeline-gen:
     - build-job:

--- a/share/spack/gitlab/cloud_pipelines/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/developer-tools-x86_64_v3-linux-gnu/spack.yaml
@@ -78,12 +78,12 @@ spack:
 
   compilers:
   - compiler:
-      spec: gcc@=10.2.1
+      spec: gcc@=10.5.0
       paths:
-        cc: /opt/rh/devtoolset-10/root/usr/bin/gcc
-        cxx: /opt/rh/devtoolset-10/root/usr/bin/g++
-        f77: /opt/rh/devtoolset-10/root/usr/bin/gfortran
-        fc: /opt/rh/devtoolset-10/root/usr/bin/gfortran
+        cc: /spack/store/linux-centos7-x86_64_v3/gcc-10.5.0/gcc-10.5.0-jxwvpluevsb5xfmelfqa5vjnapbodaet/bin/gcc
+        cxx: /spack/store/linux-centos7-x86_64_v3/gcc-10.5.0/gcc-10.5.0-jxwvpluevsb5xfmelfqa5vjnapbodaet/bin/g++
+        f77: /spack/store/linux-centos7-x86_64_v3/gcc-10.5.0/gcc-10.5.0-jxwvpluevsb5xfmelfqa5vjnapbodaet/bin/gfortran
+        fc: /spack/store/linux-centos7-x86_64_v3/gcc-10.5.0/gcc-10.5.0-jxwvpluevsb5xfmelfqa5vjnapbodaet/bin/gfortran
       flags: {}
       operating_system: centos7
       target: x86_64
@@ -94,7 +94,7 @@ spack:
   ci:
     pipeline-gen:
     - build-job:
-        image: ghcr.io/spack/spack/manylinux2014:2024.03.28
+        image: ghcr.io/haampie/x86_64_v3-linux-gnu:2024-12-12
 
   cdash:
-    build-group: Developer Tools Manylinux2014
+    build-group: Developer Tools x86_64_v3-linux-gnu

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -222,7 +222,11 @@ class AutotoolsBuilder(AutotoolsBuilder):
             "--without-libgsasl",
             "--without-libpsl",
             "--without-zstd",
+            "--disable-manual",
         ]
+
+        if spec.satisfies("@8.7:"):
+            args.append("--disable-docs")
 
         args += self.enable_or_disable("libs")
 


### PR DESCRIPTION
Centos 7, but:

* GCC defaults to the C++11 ABI
* `libgfortran.so` does not redundantly depend on system `libz.so`
* only `glibc-devel` is installed with `yum`, the rest is spack installed
* `/lib64/libcrypt.so` is ripped out to work around the `perl` <-> `libxcrypt` circular dependency.

The image was built semi-automatic from https://github.com/spack/gitlab-runners/tree/main/x86_64_v3-linux-gnu

Rename the stack `developer-tools-manylinux2014` -> `developer-tools-x86_64_v3-linux-gnu` because of the C++ ABI change.