### PR TITLE
Score-P: mpi and shmem fixes

### DIFF
--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -203,7 +203,8 @@ class Scorep(AutotoolsPackage):
         if "~shmem" in spec:
             config_args.append("--without-shmem")
         # Autodetect shmem in +shmem case
-        # Valid --with-shmem values are cray|openshmem|openmpi|openmpi3|sgimpt|sgimptwrapper|spectrum
+        # Valid --with-shmem values are cray|openshmem|openmpi|openmpi3|sgimpt|
+        # sgimptwrapper|spectrum
         # If autodetection fails for +shmem with one of these available to spack, please add
         # a "if spec.satisfies():" clause for said package.
 
@@ -220,9 +221,11 @@ class Scorep(AutotoolsPackage):
         elif "~mpi" in spec:
             config_args.append("--without-mpi")
         # Let any +mpi that gets here autodetect, which is default
-        # Valid values are bullxmpi|cray|hp|ibmpoe|intel|intel2|intel3|intelpoe|lam|mpibull2|mpich|mpich2
-        # |mpich3|mpich4|openmpi|openmpi3|platform|scali|sgimpt|sgimptwrapper|spectrum|sun
-        # Score-P does not care overly much as long as the MPI compilers are set (see end of function)
+        # Valid values are bullxmpi|cray|hp|ibmpoe|intel|intel2|intel3|intelpoe|lam|mpibull2
+        # |mpich|mpich2|mpich3|mpich4|openmpi|openmpi3|platform|scali|sgimpt|sgimptwrapper
+        # |spectrum|sun
+        # Score-P does not care overly much as long as the MPI compilers are set
+        # (see end of function)
         # but add similar spec.satisfies clauses for any that you need.
         # -- wrwilliams 12/2024
         if spec.satisfies("^binutils"):

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -207,7 +207,6 @@ class Scorep(AutotoolsPackage):
         # If autodetection fails for +shmem with one of these available to spack, please add
         # a "if spec.satisfies():" clause for said package.
 
-
         if spec.satisfies("^intel-mpi") or spec.satisfies("^intel-oneapi-mpi"):
             config_args.append("--with-mpi=intel3")
         elif (

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -200,10 +200,15 @@ class Scorep(AutotoolsPackage):
         if "+hip" in spec:
             config_args.append("--with-rocm=%s" % spec["hip"].prefix)
 
-        config_args += self.with_or_without("shmem")
-        config_args += self.with_or_without("mpi")
+        if "~shmem" in spec:
+            config_args.append("--without-shmem")
+        # Autodetect shmem in +shmem case
+        # Valid --with-shmem values are cray|openshmem|openmpi|openmpi3|sgimpt|sgimptwrapper|spectrum
+        # If autodetection fails for +shmem with one of these available to spack, please add
+        # a "if spec.satisfies():" clause for said package.
 
-        if spec.satisfies("^intel-mpi"):
+
+        if spec.satisfies("^intel-mpi") or spec.satisfies("^intel-oneapi-mpi"):
             config_args.append("--with-mpi=intel3")
         elif (
             spec.satisfies("^mpich")
@@ -213,7 +218,14 @@ class Scorep(AutotoolsPackage):
             config_args.append("--with-mpi=mpich3")
         elif spec.satisfies("^openmpi") or spec.satisfies("^hpcx-mpi"):
             config_args.append("--with-mpi=openmpi")
-
+        elif "~mpi" in spec:
+            config_args.append("--without-mpi")
+        # Let any +mpi that gets here autodetect, which is default
+        # Valid values are bullxmpi|cray|hp|ibmpoe|intel|intel2|intel3|intelpoe|lam|mpibull2|mpich|mpich2
+        # |mpich3|mpich4|openmpi|openmpi3|platform|scali|sgimpt|sgimptwrapper|spectrum|sun
+        # Score-P does not care overly much as long as the MPI compilers are set (see end of function)
+        # but add similar spec.satisfies clauses for any that you need.
+        # -- wrwilliams 12/2024
         if spec.satisfies("^binutils"):
             config_args.append("--with-libbfd-lib=%s" % spec["binutils"].prefix.lib)
             config_args.append("--with-libbfd-include=%s" % spec["binutils"].prefix.include)


### PR DESCRIPTION
Problem: Score-P cannot safely use a bare `with-or-without` for mpi or shmem, lest it pass a bare `--with-mpi` or `--with-shmem` to configure, which will fail.

Solution: make things more explicit, testing for disabled mpi/shmem, adding an explicit mapping for Intel OneAPI MPI, and allowing `+mpi` and `+shmem` to default to no argument auto detection.

Note to reviewers: this also adds documentation in comments for the various alternatives that are accepted by Score-P's `configure` for mpi and shmem arguments. Mostly this is not needed; Score-P is in practice agnostic about the MPI and SHMEM providers, as long as they exist and we pass the MPI compilers via `MPICC=<foo>` and similar based on the spec. 

I would be happy to see this mess of nested `if`s refactored into named variants, but that seems at odds with the spack norm of a boolean MPI value... It should in any event be simpler for other people in the future to add an explicit MPI or SHMEM specification as needed.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
