### PR TITLE
Autotools archive files paths

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -182,10 +182,7 @@ class AutotoolsBuilder(BuilderWithDefaults):
     @property
     def _removed_la_files_log(self) -> str:
         """File containing the list of removed libtool archives"""
-        build_dir = self.build_directory
-        if not os.path.isabs(self.build_directory):
-            build_dir = os.path.join(self.pkg.stage.path, build_dir)
-        return os.path.join(build_dir, "removed_la_files.txt")
+        return os.path.join(self.build_directory, "removed_la_files.txt")
 
     @property
     def archive_files(self) -> List[str]:
@@ -523,7 +520,12 @@ To resolve this problem, please try the following:
     @property
     def build_directory(self) -> str:
         """Override to provide another place to build the package"""
-        return self.configure_directory
+        # Handle the case where the configure directory is set to a non-absolute path
+        # Non-absolute paths are always relative to the staging source path
+        build_dir = self.configure_directory
+        if not os.path.isabs(build_dir):
+            build_dir = os.path.join(self.pkg.stage.source_path, build_dir)
+        return build_dir
 
     @spack.phase_callbacks.run_before("autoreconf")
     def delete_configure_to_force_update(self) -> None:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Autotools packages were not uploading `archive_files` when the `configure_directory` was overridden with a relative path. If `configure_directory` is not absolute, compute the `build_directory` from the `stage.source_path / configure_directory`