### PR TITLE
curl: disable docs to drop perl dep

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -222,7 +222,11 @@ class AutotoolsBuilder(AutotoolsBuilder):
             "--without-libgsasl",
             "--without-libpsl",
             "--without-zstd",
+            "--disable-manual",
         ]
+
+        if spec.satisfies("@8.7:"):
+            args.append("--disable-docs")
 
         args += self.enable_or_disable("libs")
 


### PR DESCRIPTION
Curl complains about it needing perl for the manual/docs, so disable explicitly.