### PR TITLE
qt5: patch internal RapidJSON

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -184,6 +184,16 @@ class Qt(Package):
     # causing qt to fail in ci.  This increases that limit to 1024.
     patch("qt59-qtbase-qtconfig256.patch", working_dir="qtbase", when="@5.9:5")
 
+    # with gcc@14: RapidJSON fails to build
+    # https://github.com/Tencent/rapidjson/issues/2277
+    # https://github.com/Tencent/rapidjson/pull/719
+    patch(
+        "https://patch-diff.githubusercontent.com/raw/Tencent/rapidjson/pull/719.patch",
+        sha256="8abc5c5ef033801ea99a9f289126e473ccf4ebdb9ab33fa8157f957fdeb03a2f",
+        working_dir="qtlocation/src/3rdparty/mapbox-gl-native/deps/rapidjson/1.1.0",
+        when="@5: %gcc@14:"
+    )
+
     conflicts("%gcc@10:", when="@5.9:5.12.6 +opengl")
     conflicts("%gcc@11:", when="@5.8")
     conflicts("%apple-clang@13:", when="@:5.13")

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -191,7 +191,7 @@ class Qt(Package):
         "https://patch-diff.githubusercontent.com/raw/Tencent/rapidjson/pull/719.patch?full_index=1",
         sha256="ce341a69d6c17852fddd5469b6aabe995fd5e3830379c12746a18c3ae858e0e1",
         working_dir="qtlocation/src/3rdparty/mapbox-gl-native/deps/rapidjson/1.1.0",
-        when="@5: %gcc@14:",
+        when="@5.9.2: %gcc@14:",
     )
 
     conflicts("%gcc@10:", when="@5.9:5.12.6 +opengl")

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -191,7 +191,7 @@ class Qt(Package):
         "https://patch-diff.githubusercontent.com/raw/Tencent/rapidjson/pull/719.patch",
         sha256="8abc5c5ef033801ea99a9f289126e473ccf4ebdb9ab33fa8157f957fdeb03a2f",
         working_dir="qtlocation/src/3rdparty/mapbox-gl-native/deps/rapidjson/1.1.0",
-        when="@5: %gcc@14:"
+        when="@5: %gcc@14:",
     )
 
     conflicts("%gcc@10:", when="@5.9:5.12.6 +opengl")

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -189,7 +189,7 @@ class Qt(Package):
     # https://github.com/Tencent/rapidjson/pull/719
     patch(
         "https://patch-diff.githubusercontent.com/raw/Tencent/rapidjson/pull/719.patch?full_index=1",
-        sha256="8abc5c5ef033801ea99a9f289126e473ccf4ebdb9ab33fa8157f957fdeb03a2f",
+        sha256="ce341a69d6c17852fddd5469b6aabe995fd5e3830379c12746a18c3ae858e0e1",
         working_dir="qtlocation/src/3rdparty/mapbox-gl-native/deps/rapidjson/1.1.0",
         when="@5: %gcc@14:",
     )

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -188,7 +188,7 @@ class Qt(Package):
     # https://github.com/Tencent/rapidjson/issues/2277
     # https://github.com/Tencent/rapidjson/pull/719
     patch(
-        "https://patch-diff.githubusercontent.com/raw/Tencent/rapidjson/pull/719.patch",
+        "https://patch-diff.githubusercontent.com/raw/Tencent/rapidjson/pull/719.patch?full_index=1",
         sha256="8abc5c5ef033801ea99a9f289126e473ccf4ebdb9ab33fa8157f957fdeb03a2f",
         working_dir="qtlocation/src/3rdparty/mapbox-gl-native/deps/rapidjson/1.1.0",
         when="@5: %gcc@14:",


### PR DESCRIPTION
qtlocation uses an internal RapidJSON 1.1.0. With `%gcc@14:`, this fails to build, e.g., https://github.com/Tencent/rapidjson/issues/2277.

This PR applies the RapidJSON patch that fixes this problem.