### PR TITLE
cmake: ~ownlibs ^libarchive compression+=bz2lib,lzma,zstd

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -200,7 +200,7 @@ class Cmake(Package):
         # expat/zlib are used in CMake/CTest, so why not require them in libarchive.
         for plat in ["darwin", "linux", "freebsd"]:
             with when("platform=%s" % plat):
-                depends_on("libarchive@3.1.0: xar=expat compression=zlib")
+                depends_on("libarchive@3.1.0: xar=expat compression=bz2lib,lzma,zlib,zstd")
                 depends_on("libarchive@3.3.3:", when="@3.15.0:")
                 depends_on("libuv@1.0.0:1.10", when="@3.7.0:3.10.3")
                 depends_on("libuv@1.10.0:1.10", when="@3.11.0:3.11")


### PR DESCRIPTION
When `cmake` builds with the default `+ownlibs`, it includes vendored support. With `~ownlibs`, we pull in this support through external libraries built by spack. Ideally, the level of support in `~ownlibs` and `+ownlibs` is identical.

This PR adds `libarchive compression=bz2lib,lzma,zstd` to the dependencies of `cmake`.