### PR TITLE
⚠️DO NOT MERGE⚠️: Add paraview+qt to Windows gitlab CI

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -721,6 +721,8 @@ def set_package_py_globals(pkg, context: Context = Context.BUILD):
     # TODO: johnwparent: add package or builder support to define these build tools
     # for now there is no entrypoint for builders to define these on their
     # own
+    # TODO: johnwparent: Once compilers as nodes lands, make the three
+    # tools below DeprecatedExecutable
     if sys.platform == "win32":
         module.nmake = Executable("nmake")
         module.msbuild = Executable("msbuild")

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -162,6 +162,7 @@ pwd = getcwd
 configure: Executable
 make_jobs: int
 make: MakeExecutable
+nmake: Executable
 ninja: MakeExecutable
 python_include: str
 python_platlib: str

--- a/share/spack/gitlab/cloud_pipelines/stacks/windows-vis/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/windows-vis/spack.yaml
@@ -7,6 +7,7 @@ spack:
   view: false
   specs:
   - vtk~mpi
+  - paraview+qt~mpi
 
   cdash:
     build-group: Windows Visualization (Kitware)

--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -128,7 +128,6 @@ class Bzip2(Package, SourcewarePackage):
         # Build the static library and everything else
         if self.spec.satisfies("platform=windows"):
             # Build step
-            nmake = Executable("nmake.exe")
             nmake("-f", "makefile.msc")
             # Install step
             mkdirp(self.prefix.include)

--- a/var/spack/repos/builtin/packages/icu4c/ICU4C_NMAKE_NO_DOUBLE_QUOTE_VARS.patch
+++ b/var/spack/repos/builtin/packages/icu4c/ICU4C_NMAKE_NO_DOUBLE_QUOTE_VARS.patch
@@ -1,0 +1,13 @@
+diff --git a/source/test/testdata/testdata.mak b/source/test/testdata/testdata.mak
+index 2809efd..02f5b79 100644
+--- a/source/test/testdata/testdata.mak
++++ b/source/test/testdata/testdata.mak
+@@ -25,7 +25,7 @@ ALL : "$(TESTDATAOUT)\testdata.dat"
+ 
+ # old_e_testtypes.res is the same, but icuswapped to big-endian EBCDIC
+ 
+-TESTDATATMP="$(TESTDATAOUT)\testdata"
++TESTDATATMP=$(TESTDATAOUT)\testdata
+ 
+ CREATE_DIRS :
+ 	@if not exist "$(TESTDATAOUT)\$(NULL)" mkdir "$(TESTDATAOUT)"

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -53,6 +53,9 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
         depends_on("automake", type="build")
         depends_on("libtool", type="build")
 
+    with when("build_system=msbuild"):
+        patch("ICU4C_NMAKE_NO_DOUBLE_QUOTE_VARS.patch")
+
     conflicts(
         "%intel@:16",
         when="@60.1:",

--- a/var/spack/repos/builtin/packages/msvc/package.py
+++ b/var/spack/repos/builtin/packages/msvc/package.py
@@ -44,6 +44,13 @@ class Msvc(Package, CompilerPackage):
         extras["compilers"]["c"] = extras["compilers"]["cxx"]
         return spec, extras
 
+    def setup_dependent_package(self, module, dependent_spec):
+        """Populates dependent module with tooling available from VS"""
+        # We want these to resolve to the paths set by MSVC's VCVARs
+        # so no paths
+        module.nmake = MakeExecutable("nmake", jobs=1)
+        module.msbuild = MakeExecutable("msbuild", jobs=1)
+
     @property
     def cc(self):
         if self.spec.external:

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -95,4 +95,4 @@ class NetcdfCxx4(CMakePackage):
 
     def check(self):
         with working_dir(self.build_directory):
-            make("test", parallel=False)
+            ctest()

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -212,18 +212,20 @@ class Openssl(Package):  # Uses Fake Autotools, should subclass Package
 
         if spec.satisfies("platform=windows"):
             host_make = nmake
+            make_args = {}
         else:
             host_make = make
+            make_args = {"parallel": False}
 
         host_make()
 
         if self.run_tests:
-            host_make("test", parallel=False)  # 'VERBOSE=1'
+            host_make("test", **make_args)  # 'VERBOSE=1'
 
         install_tgt = "install" if self.spec.satisfies("+docs") else "install_sw"
 
         # See https://github.com/openssl/openssl/issues/7466#issuecomment-432148137
-        host_make(install_tgt, parallel=False)
+        host_make(install_tgt, **make_args)
 
     @run_after("install")
     def link_system_certs(self):

--- a/var/spack/repos/builtin/packages/pegtl/package.py
+++ b/var/spack/repos/builtin/packages/pegtl/package.py
@@ -49,4 +49,4 @@ class Pegtl(CMakePackage):
     @on_package_attributes(run_tests=True)
     def check(self):
         with working_dir(self.build_directory):
-            make("test", parallel=False)
+            ctest()

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -621,7 +621,10 @@ class Python(Package):
         copy_tree(tools_dir, prefix.Tools)
         lib_dir = os.path.join(proj_root, "Lib")
         copy_tree(lib_dir, prefix.Lib)
-        pyconfig = os.path.join(proj_root, "PC", "pyconfig.h")
+        if self.spec.satisfies("@3.13:"):
+            pyconfig = os.path.join(pcbuild_root, platform.machine().lower(), "pyconfig.h")
+        else:
+            pyconfig = os.path.join(proj_root, "PC", "pyconfig.h")
         copy(pyconfig, prefix.include)
         shared_libraries = []
         shared_libraries.extend(glob.glob("%s\\*.exe" % build_root))


### PR DESCRIPTION
Disables MPI support for paraview as that was previously causing issues with Windows CI.

Currently this branch wants to move faster than PR fixes for broken things on Windows in develop can land, so this PR contains changes from a number of other patch PRs. Only the HEAD commit of this PR is what the final change set should look like. If this PR doesn't only touch the pipeline file to add paraview, don't merge it.

Cannot be draft as we need gitlab testing.