### PR TITLE
node-js: gcc14 - fix comma swallowing

### DIFF
--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -134,6 +134,7 @@ class NodeJs(Package):
 
     # See https://github.com/nodejs/node/issues/52223
     patch("fix-old-glibc-random-headers.patch", when="^glibc@:2.24")
+    patch("use-va-opt-macro.patch", when="%gcc@14:")
 
     # Work around gcc-12.[1-2] compiler bug
     # See https://github.com/nodejs/node/pull/53728

--- a/var/spack/repos/builtin/packages/node-js/use-va-opt-macro.patch
+++ b/var/spack/repos/builtin/packages/node-js/use-va-opt-macro.patch
@@ -1,0 +1,84 @@
+diff --git a/deps/v8/src/codegen/interface-descriptors.h b/deps/v8/src/codegen/interface-descriptors.h
+index 370ad131a3..9d0fbaee25 100644
+--- a/deps/v8/src/codegen/interface-descriptors.h
++++ b/deps/v8/src/codegen/interface-descriptors.h
+@@ -658,8 +658,8 @@ constexpr EmptyDoubleRegisterArray DoubleRegisterArray() { return {}; }
+ #define DEFINE_RESULT_AND_PARAMETERS(return_count, ...)   \
+   static constexpr int kReturnCount = return_count;       \
+   enum ParameterIndices {                                 \
+-    __dummy = -1, /* to be able to pass zero arguments */ \
+-    ##__VA_ARGS__,                                        \
++    __dummy = -1 __VA_OPT__(,) /* to be able to pass zero arguments */	\
++    __VA_ARGS__,                                          \
+                                                           \
+     kParameterCount,                                      \
+     kContext = kParameterCount /* implicit parameter */   \
+@@ -674,13 +674,13 @@ constexpr EmptyDoubleRegisterArray DoubleRegisterArray() { return {}; }
+       StackArgumentOrder::kDefault;                         \
+   static constexpr int kReturnCount = 1;                    \
+   enum ParameterIndices {                                   \
+-    __dummy = -1, /* to be able to pass zero arguments */   \
+-    ##__VA_ARGS__,                                          \
++    __dummy = -1 __VA_OPT__(,) /* to be able to pass zero arguments */	\
++    __VA_ARGS__,                                            \
+                                                             \
+     kParameterCount                                         \
+   };
+ 
+-#define DEFINE_PARAMETERS(...) DEFINE_RESULT_AND_PARAMETERS(1, ##__VA_ARGS__)
++#define DEFINE_PARAMETERS(...) DEFINE_RESULT_AND_PARAMETERS(1 __VA_OPT__(,) __VA_ARGS__)
+ 
+ #define DEFINE_PARAMETERS_NO_CONTEXT(...) \
+   DEFINE_PARAMETERS(__VA_ARGS__)          \
+@@ -699,7 +699,7 @@ constexpr EmptyDoubleRegisterArray DoubleRegisterArray() { return {}; }
+       StackArgumentOrder::kJS;
+ 
+ #define DEFINE_RESULT_AND_PARAMETERS_NO_CONTEXT(return_count, ...) \
+-  DEFINE_RESULT_AND_PARAMETERS(return_count, ##__VA_ARGS__)        \
++  DEFINE_RESULT_AND_PARAMETERS(return_count __VA_OPT__(,) __VA_ARGS__) \
+   static constexpr bool kNoContext = true;
+ 
+ #define DEFINE_RESULT_AND_PARAMETER_TYPES(...)                                \
+@@ -713,8 +713,8 @@ constexpr EmptyDoubleRegisterArray DoubleRegisterArray() { return {}; }
+   }
+ 
+ #define DEFINE_PARAMETER_TYPES(...)                                        \
+-  DEFINE_RESULT_AND_PARAMETER_TYPES(MachineType::AnyTagged() /* result */, \
+-                                    ##__VA_ARGS__)
++  DEFINE_RESULT_AND_PARAMETER_TYPES(MachineType::AnyTagged() /* result */ __VA_OPT__(,) \
++                                    __VA_ARGS__)
+ 
+ // When the extra arguments described here are located in the stack, they are
+ // just above the return address in the frame (first arguments).
+@@ -726,8 +726,8 @@ constexpr EmptyDoubleRegisterArray DoubleRegisterArray() { return {}; }
+   enum ParameterIndices {                                   \
+     kTarget,                                                \
+     kNewTarget,                                             \
+-    kActualArgumentsCount,                                  \
+-    ##__VA_ARGS__,                                          \
++    kActualArgumentsCount __VA_OPT__(,)			    \
++    __VA_ARGS__,                                            \
+     kParameterCount,                                        \
+     kContext = kParameterCount /* implicit parameter */     \
+   };
+@@ -741,16 +741,16 @@ constexpr EmptyDoubleRegisterArray DoubleRegisterArray() { return {}; }
+   enum ParameterIndices {                                   \
+     kTarget,                                                \
+     kNewTarget,                                             \
+-    kActualArgumentsCount,                                  \
+-    ##__VA_ARGS__,                                          \
++    kActualArgumentsCount __VA_OPT__(,)			    \
++    __VA_ARGS__,                                            \
+     kParameterCount,                                        \
+   };
+ 
+ #define DEFINE_JS_PARAMETER_TYPES(...)                                         \
+   DEFINE_PARAMETER_TYPES(MachineType::AnyTagged(), /* kTarget */               \
+                          MachineType::AnyTagged(), /* kNewTarget */            \
+-                         MachineType::Int32(),     /* kActualArgumentsCount */ \
+-                         ##__VA_ARGS__)
++                         MachineType::Int32() __VA_OPT__(,)     /* kActualArgumentsCount */ \
++                         __VA_ARGS__)
+ 
+ // Code/Builtins using this descriptor are referenced from inside the sandbox
+ // through a code pointer and must therefore be exposed via the code pointer


### PR DESCRIPTION
This patch replaces gcc extensions with C++ 20 standard for comma swallowing.  This is necessary to compile with C++ 20 compilers.