### PR TITLE
py-gosam: add setuptools dependency and patch

### DIFF
--- a/var/spack/repos/builtin/packages/py-gosam/package.py
+++ b/var/spack/repos/builtin/packages/py-gosam/package.py
@@ -31,6 +31,7 @@ class PyGosam(Package):
         sha256="4a2b9160d51e3532025b9579a4d17d0e0f8a755b8481aeb8271c1f58eb97ab01",
     )
 
+    patch("setuptools.patch", when="^python@3.12:")
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
@@ -39,6 +40,7 @@ class PyGosam(Package):
     depends_on("qgraf", type="run")
     depends_on("gosam-contrib", type="link")
     depends_on("python@3:", type=("build", "run"))
+    depends_on("py-setuptools")
 
     def setup_run_environment(self, env):
         gosam_contrib_lib_dir = self.spec["gosam-contrib"].prefix.lib

--- a/var/spack/repos/builtin/packages/py-gosam/setuptools.patch
+++ b/var/spack/repos/builtin/packages/py-gosam/setuptools.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index ad2256a..6571a38 100755
+--- a/setup.py
++++ b/setup.py
+@@ -2,6 +2,8 @@
+ # vim: ts=3:sw=3
+ import os
+ try:
++  # This is a hack to make builds on python >= 3.13 work
++  import _distutils_hack.override
+   from distutils.core import setup
+   from distutils.sysconfig import get_config_vars
+   from distutils.command.build_py import build_py as _build_py


### PR DESCRIPTION
This is needed for builds for python >= 3.12

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
