### PR TITLE
Add patch to fix cmake config file when configured with autotools

### DIFF
--- a/var/spack/repos/builtin/packages/fftw/Fix-the-cmake-config-file-when-configured-with-autot.patch
+++ b/var/spack/repos/builtin/packages/fftw/Fix-the-cmake-config-file-when-configured-with-autot.patch
@@ -1,0 +1,13 @@
+diff --git a/FFTW3Config.cmake.in b/FFTW3Config.cmake.in
+index 6b1fbc2e..6e073f5c 100644
+--- a/FFTW3Config.cmake.in
++++ b/FFTW3Config.cmake.in
+@@ -10,7 +10,7 @@ set (FFTW3@PREC_SUFFIX@_LIBRARIES fftw3@PREC_SUFFIX@)
+ set (FFTW3@PREC_SUFFIX@_LIBRARY_DIRS @CMAKE_INSTALL_FULL_LIBDIR@)
+ set (FFTW3@PREC_SUFFIX@_INCLUDE_DIRS @CMAKE_INSTALL_FULL_INCLUDEDIR@)
+ 
+-include ("${CMAKE_CURRENT_LIST_DIR}/FFTW3LibraryDepends.cmake")
++include ("${CMAKE_CURRENT_LIST_DIR}/FFTW3LibraryDepends.cmake" OPTIONAL)
+ 
+ if (CMAKE_VERSION VERSION_LESS 2.8.3)
+   set (CMAKE_CURRENT_LIST_DIR)

--- a/var/spack/repos/builtin/packages/fftw/package.py
+++ b/var/spack/repos/builtin/packages/fftw/package.py
@@ -251,3 +251,4 @@ class Fftw(FftwBase):
     patch("pfft-3.3.5.patch", when="@3.3.5:3.3.8+pfft_patches", level=0)
     patch("pfft-3.3.4.patch", when="@3.3.4+pfft_patches", level=0)
     patch("intel-configure.patch", when="@3:3.3.8%intel", level=0)
+    patch("Fix-the-cmake-config-file-when-configured-with-autot.patch", when="@3.3.10", level=0)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Add a patch to FFTW 3.3.10 in order to remove a bug in CMake config generation when using autotools to build FFTW.
