### PR TITLE
unit-test: port changes from compiler as deps

### DIFF
--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import contextlib
 import filecmp
 import glob
 import io
@@ -208,6 +209,49 @@ def test_env_untrack_managed(tmp_path, capfd):
     # check that environment could not be untracked while active
     out, _ = capfd.readouterr()
     assert f"'{env_name}' is not a tracked env" in out
+
+
+@pytest.fixture()
+def installed_environment(tmp_path, mock_fetch, mock_packages, mock_archive, install_mockery):
+    spack_yaml = tmp_path / "spack.yaml"
+
+    @contextlib.contextmanager
+    def _installed_environment(content):
+        spack_yaml.write_text(content)
+        with fs.working_dir(tmp_path):
+            env("create", "test", "./spack.yaml")
+            with ev.read("test"):
+                install("--fake")
+
+            test = ev.read("test")
+            yield test
+
+    return _installed_environment
+
+
+@pytest.fixture()
+def template_combinatorial_env(tmp_path):
+    """Returns a template base environment for tests. Since the environment configuration is
+    extended using str.format, we need double '{' escaping for the projections.
+    """
+    view_dir = tmp_path / "view"
+    return f"""\
+    spack:
+      definitions:
+        - packages: [mpileaks, callpath]
+        - targets: ['target=x86_64', 'target=core2']
+      specs:
+        - matrix:
+            - [$packages]
+            - [$targets]
+
+      view:
+        combinatorial:
+          root: {view_dir}
+          {{view_config}}
+          projections:
+            'all': '{{{{architecture.target}}}}/{{{{name}}}}-{{{{version}}}}'
+    """
 
 
 def test_add():
@@ -455,7 +499,7 @@ def test_env_specs_partition(install_mockery, mock_fetch):
     assert roots_to_install[0].name == "cmake-client"
 
     # Single installed root.
-    e.install_all()
+    e.install_all(fake=True)
     roots_already_installed, roots_to_install = e._partition_roots_by_install_status()
     assert len(roots_already_installed) == 1
     assert roots_already_installed[0].name == "cmake-client"
@@ -475,7 +519,7 @@ def test_env_install_all(install_mockery, mock_fetch):
     e = ev.create("test")
     e.add("cmake-client")
     e.concretize()
-    e.install_all()
+    e.install_all(fake=True)
     env_specs = e._get_environment_specs()
     spec = next(x for x in env_specs if x.name == "cmake-client")
     assert spec.installed
@@ -487,7 +531,7 @@ def test_env_install_single_spec(install_mockery, mock_fetch):
 
     e = ev.read("test")
     with e:
-        install("--add", "cmake-client")
+        install("--fake", "--add", "cmake-client")
 
     e = ev.read("test")
     assert e.user_specs[0].name == "cmake-client"
@@ -508,7 +552,7 @@ def test_env_install_include_concrete_env(unify, install_mockery, mock_fetch, mu
     combined.write()
 
     with combined:
-        install()
+        install("--fake")
 
     test1_roots = test1.concretized_order
     test2_roots = test2.concretized_order
@@ -556,7 +600,7 @@ def test_env_modifications_error_on_activate(install_mockery, mock_fetch, monkey
 
     e = ev.read("test")
     with e:
-        install("--add", "cmake-client")
+        install("--fake", "--add", "cmake-client")
 
     def setup_error(pkg, env):
         raise RuntimeError("cmake-client had issues!")
@@ -625,12 +669,12 @@ spack:
 
     with ev.read("test"):
         with capsys.disabled():
-            out = install()
+            out = install("--fake")
 
     # Ensure both packages reach install phase processing and are installed
     out = str(out)
-    assert "depb: Executing phase:" in out
-    assert "a: Executing phase:" in out
+    assert "depb: Successfully installed" in out
+    assert "pkg-a: Successfully installed" in out
 
     depb = spack.store.STORE.db.query_one("depb", installed=True)
     assert depb, "Expected depb to be installed"
@@ -1649,9 +1693,7 @@ def test_stage(mock_stage, mock_fetch, install_mockery):
     def check_stage(spec):
         spec = Spec(spec).concretized()
         for dep in spec.traverse():
-            stage_name = "{0}{1}-{2}-{3}".format(
-                stage_prefix, dep.name, dep.version, dep.dag_hash()
-            )
+            stage_name = f"{stage_prefix}{dep.name}-{dep.version}-{dep.dag_hash()}"
             assert os.path.isdir(os.path.join(root, stage_name))
 
     check_stage("mpileaks")
@@ -2821,207 +2863,75 @@ spack:
         assert "zmpi" not in packages_lists[1]["packages"]
 
 
-def test_stack_combinatorial_view(
-    tmpdir, mock_fetch, mock_packages, mock_archive, install_mockery
-):
-    filename = str(tmpdir.join("spack.yaml"))
-    viewdir = str(tmpdir.join("view"))
-    with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
-spack:
-  definitions:
-    - packages: [mpileaks, callpath]
-    - compilers: ['%%gcc', '%%clang']
-  specs:
-    - matrix:
-        - [$packages]
-        - [$compilers]
-
-  view:
-    combinatorial:
-      root: %s
-      projections:
-        'all': '{name}/{version}-{compiler.name}'"""
-            % viewdir
-        )
-    with tmpdir.as_cwd():
-        env("create", "test", "./spack.yaml")
-        with ev.read("test"):
-            install()
-
-        test = ev.read("test")
+def test_stack_combinatorial_view(installed_environment, template_combinatorial_env, tmp_path):
+    """Tests creating a default view for a combinatorial stack."""
+    view_dir = tmp_path / "view"
+    with installed_environment(template_combinatorial_env.format(view_config="")) as test:
         for spec in test._get_environment_specs():
-            assert os.path.exists(
-                os.path.join(viewdir, spec.name, "%s-%s" % (spec.version, spec.compiler.name))
-            )
+            if spec.name == "gcc-runtime":
+                continue
+            current_dir = view_dir / f"{spec.architecture.target}" / f"{spec.name}-{spec.version}"
+            assert current_dir.exists() and current_dir.is_dir()
 
 
-def test_stack_view_select(tmpdir, mock_fetch, mock_packages, mock_archive, install_mockery):
-    filename = str(tmpdir.join("spack.yaml"))
-    viewdir = str(tmpdir.join("view"))
-    with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
-spack:
-  definitions:
-    - packages: [mpileaks, callpath]
-    - compilers: ['%%gcc', '%%clang']
-  specs:
-    - matrix:
-        - [$packages]
-        - [$compilers]
-
-  view:
-    combinatorial:
-      root: %s
-      select: ['%%gcc']
-      projections:
-        'all': '{name}/{version}-{compiler.name}'"""
-            % viewdir
-        )
-    with tmpdir.as_cwd():
-        env("create", "test", "./spack.yaml")
-        with ev.read("test"):
-            install()
-
-        test = ev.read("test")
+def test_stack_view_select(installed_environment, template_combinatorial_env, tmp_path):
+    view_dir = tmp_path / "view"
+    content = template_combinatorial_env.format(view_config="select: ['target=x86_64']\n")
+    with installed_environment(content) as test:
         for spec in test._get_environment_specs():
-            if spec.satisfies("%gcc"):
-                assert os.path.exists(
-                    os.path.join(viewdir, spec.name, "%s-%s" % (spec.version, spec.compiler.name))
-                )
-            else:
-                assert not os.path.exists(
-                    os.path.join(viewdir, spec.name, "%s-%s" % (spec.version, spec.compiler.name))
-                )
+            if spec.name == "gcc-runtime":
+                continue
+            current_dir = view_dir / f"{spec.architecture.target}" / f"{spec.name}-{spec.version}"
+            assert current_dir.exists() is spec.satisfies("target=x86_64")
 
 
-def test_stack_view_exclude(tmpdir, mock_fetch, mock_packages, mock_archive, install_mockery):
-    filename = str(tmpdir.join("spack.yaml"))
-    viewdir = str(tmpdir.join("view"))
-    with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
-spack:
-  definitions:
-    - packages: [mpileaks, callpath]
-    - compilers: ['%%gcc', '%%clang']
-  specs:
-    - matrix:
-        - [$packages]
-        - [$compilers]
-
-  view:
-    combinatorial:
-      root: %s
-      exclude: [callpath]
-      projections:
-        'all': '{name}/{version}-{compiler.name}'"""
-            % viewdir
-        )
-    with tmpdir.as_cwd():
-        env("create", "test", "./spack.yaml")
-        with ev.read("test"):
-            install()
-
-        test = ev.read("test")
+def test_stack_view_exclude(installed_environment, template_combinatorial_env, tmp_path):
+    view_dir = tmp_path / "view"
+    content = template_combinatorial_env.format(view_config="exclude: [callpath]\n")
+    with installed_environment(content) as test:
         for spec in test._get_environment_specs():
-            if not spec.satisfies("callpath"):
-                assert os.path.exists(
-                    os.path.join(viewdir, spec.name, "%s-%s" % (spec.version, spec.compiler.name))
-                )
-            else:
-                assert not os.path.exists(
-                    os.path.join(viewdir, spec.name, "%s-%s" % (spec.version, spec.compiler.name))
-                )
+            if spec.name == "gcc-runtime":
+                continue
+            current_dir = view_dir / f"{spec.architecture.target}" / f"{spec.name}-{spec.version}"
+            assert current_dir.exists() is not spec.satisfies("callpath")
 
 
 def test_stack_view_select_and_exclude(
-    tmpdir, mock_fetch, mock_packages, mock_archive, install_mockery
+    installed_environment, template_combinatorial_env, tmp_path
 ):
-    filename = str(tmpdir.join("spack.yaml"))
-    viewdir = str(tmpdir.join("view"))
-    with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
-spack:
-  definitions:
-    - packages: [mpileaks, callpath]
-    - compilers: ['%%gcc', '%%clang']
-  specs:
-    - matrix:
-        - [$packages]
-        - [$compilers]
-
-  view:
-    combinatorial:
-      root: %s
-      select: ['%%gcc']
-      exclude: [callpath]
-      projections:
-        'all': '{name}/{version}-{compiler.name}'"""
-            % viewdir
-        )
-    with tmpdir.as_cwd():
-        env("create", "test", "./spack.yaml")
-        with ev.read("test"):
-            install()
-
-        test = ev.read("test")
+    view_dir = tmp_path / "view"
+    content = template_combinatorial_env.format(
+        view_config="""select: ['target=x86_64']
+          exclude: [callpath]
+"""
+    )
+    with installed_environment(content) as test:
         for spec in test._get_environment_specs():
-            if spec.satisfies("%gcc") and not spec.satisfies("callpath"):
-                assert os.path.exists(
-                    os.path.join(viewdir, spec.name, "%s-%s" % (spec.version, spec.compiler.name))
-                )
-            else:
-                assert not os.path.exists(
-                    os.path.join(viewdir, spec.name, "%s-%s" % (spec.version, spec.compiler.name))
-                )
+            if spec.name == "gcc-runtime":
+                continue
+            current_dir = view_dir / f"{spec.architecture.target}" / f"{spec.name}-{spec.version}"
+            assert current_dir.exists() is (
+                spec.satisfies("target=x86_64") and not spec.satisfies("callpath")
+            )
 
 
-def test_view_link_roots(tmpdir, mock_fetch, mock_packages, mock_archive, install_mockery):
-    filename = str(tmpdir.join("spack.yaml"))
-    viewdir = str(tmpdir.join("view"))
-    with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
-spack:
-  definitions:
-    - packages: [mpileaks, callpath]
-    - compilers: ['%%gcc', '%%clang']
-  specs:
-    - matrix:
-        - [$packages]
-        - [$compilers]
-
-  view:
-    combinatorial:
-      root: %s
-      select: ['%%gcc']
-      exclude: [callpath]
-      link: 'roots'
-      projections:
-        'all': '{name}/{version}-{compiler.name}'"""
-            % viewdir
-        )
-    with tmpdir.as_cwd():
-        env("create", "test", "./spack.yaml")
-        with ev.read("test"):
-            install()
-
-        test = ev.read("test")
+def test_view_link_roots(installed_environment, template_combinatorial_env, tmp_path):
+    view_dir = tmp_path / "view"
+    content = template_combinatorial_env.format(
+        view_config="""select: ['target=x86_64']
+          exclude: [callpath]
+          link: 'roots'
+    """
+    )
+    with installed_environment(content) as test:
         for spec in test._get_environment_specs():
-            if spec in test.roots() and (
-                spec.satisfies("%gcc") and not spec.satisfies("callpath")
-            ):
-                assert os.path.exists(
-                    os.path.join(viewdir, spec.name, "%s-%s" % (spec.version, spec.compiler.name))
-                )
-            else:
-                assert not os.path.exists(
-                    os.path.join(viewdir, spec.name, "%s-%s" % (spec.version, spec.compiler.name))
-                )
+            if spec.name == "gcc-runtime":
+                continue
+            current_dir = view_dir / f"{spec.architecture.target}" / f"{spec.name}-{spec.version}"
+            expected_exists = spec in test.roots() and (
+                spec.satisfies("target=x86_64") and not spec.satisfies("callpath")
+            )
+            assert current_dir.exists() == expected_exists
 
 
 def test_view_link_run(tmpdir, mock_fetch, mock_packages, mock_archive, install_mockery):
@@ -3065,169 +2975,84 @@ spack:
 
 
 @pytest.mark.parametrize("link_type", ["hardlink", "copy", "symlink"])
-def test_view_link_type(
-    link_type, tmpdir, mock_fetch, mock_packages, mock_archive, install_mockery
-):
-    filename = str(tmpdir.join("spack.yaml"))
-    viewdir = str(tmpdir.join("view"))
-    with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
+def test_view_link_type(link_type, installed_environment, tmp_path):
+    view_dir = tmp_path / "view"
+    with installed_environment(
+        f"""\
 spack:
   specs:
     - mpileaks
   view:
     default:
-      root: %s
-      link_type: %s"""
-            % (viewdir, link_type)
-        )
-    with tmpdir.as_cwd():
-        env("create", "test", "./spack.yaml")
-        with ev.read("test"):
-            install()
-
-        test = ev.read("test")
-
+      root: {view_dir}
+      link_type: {link_type}"""
+    ) as test:
         for spec in test.roots():
-            file_path = test.default_view.view()._root
-            file_to_test = os.path.join(file_path, spec.name)
-            assert os.path.isfile(file_to_test)
-            assert os.path.islink(file_to_test) == (link_type == "symlink")
+            # Assertions are based on the behavior of the "--fake" install
+            bin_file = pathlib.Path(test.default_view.view()._root) / "bin" / spec.name
+            assert bin_file.exists()
+            assert bin_file.is_symlink() == (link_type == "symlink")
 
 
-def test_view_link_all(tmpdir, mock_fetch, mock_packages, mock_archive, install_mockery):
-    filename = str(tmpdir.join("spack.yaml"))
-    viewdir = str(tmpdir.join("view"))
-    with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
-spack:
-  definitions:
-    - packages: [mpileaks, callpath]
-    - compilers: ['%%gcc', '%%clang']
-  specs:
-    - matrix:
-        - [$packages]
-        - [$compilers]
+def test_view_link_all(installed_environment, template_combinatorial_env, tmp_path):
+    view_dir = tmp_path / "view"
+    content = template_combinatorial_env.format(
+        view_config="""select: ['target=x86_64']
+          exclude: [callpath]
+          link: 'all'
+    """
+    )
 
-  view:
-    combinatorial:
-      root: %s
-      select: ['%%gcc']
-      exclude: [callpath]
-      link: 'all'
-      projections:
-        'all': '{name}/{version}-{compiler.name}'"""
-            % viewdir
-        )
-    with tmpdir.as_cwd():
-        env("create", "test", "./spack.yaml")
-        with ev.read("test"):
-            install()
-
-        test = ev.read("test")
+    with installed_environment(content) as test:
         for spec in test._get_environment_specs():
-            if spec.satisfies("%gcc") and not spec.satisfies("callpath"):
-                assert os.path.exists(
-                    os.path.join(viewdir, spec.name, "%s-%s" % (spec.version, spec.compiler.name))
-                )
-            else:
-                assert not os.path.exists(
-                    os.path.join(viewdir, spec.name, "%s-%s" % (spec.version, spec.compiler.name))
-                )
+            if spec.name == "gcc-runtime":
+                continue
+            current_dir = view_dir / f"{spec.architecture.target}" / f"{spec.name}-{spec.version}"
+            assert current_dir.exists() == (
+                spec.satisfies("target=x86_64") and not spec.satisfies("callpath")
+            )
 
 
 def test_stack_view_activate_from_default(
-    tmpdir, mock_fetch, mock_packages, mock_archive, install_mockery
+    installed_environment, template_combinatorial_env, tmp_path
 ):
-    filename = str(tmpdir.join("spack.yaml"))
-    viewdir = str(tmpdir.join("view"))
-    with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
-spack:
-  definitions:
-    - packages: [mpileaks, cmake]
-    - compilers: ['%%gcc', '%%clang']
-  specs:
-    - matrix:
-        - [$packages]
-        - [$compilers]
-
-  view:
-    default:
-      root: %s
-      select: ['%%gcc']"""
-            % viewdir
-        )
-    with tmpdir.as_cwd():
-        env("create", "test", "./spack.yaml")
-        with ev.read("test"):
-            install()
-
+    view_dir = tmp_path / "view"
+    content = template_combinatorial_env.format(view_config="select: ['target=x86_64']")
+    # Replace the name of the view
+    content = content.replace("combinatorial:", "default:")
+    with installed_environment(content):
         shell = env("activate", "--sh", "test")
-
-        assert "PATH" in shell
-        assert os.path.join(viewdir, "bin") in shell
+        assert "PATH" in shell, shell
+        assert str(view_dir / "bin") in shell
         assert "FOOBAR=mpileaks" in shell
 
 
 def test_stack_view_no_activate_without_default(
-    tmpdir, mock_fetch, mock_packages, mock_archive, install_mockery
+    installed_environment, template_combinatorial_env, tmp_path
 ):
-    filename = str(tmpdir.join("spack.yaml"))
-    viewdir = str(tmpdir.join("view"))
-    with open(filename, "w", encoding="utf-8") as f:
-        f.write(
-            """\
-spack:
-  definitions:
-    - packages: [mpileaks, cmake]
-    - compilers: ['%%gcc', '%%clang']
-  specs:
-    - matrix:
-        - [$packages]
-        - [$compilers]
-
-  view:
-    not-default:
-      root: %s
-      select: ['%%gcc']"""
-            % viewdir
-        )
-    with tmpdir.as_cwd():
-        env("create", "test", "./spack.yaml")
-        with ev.read("test"):
-            install()
-
+    view_dir = tmp_path / "view"
+    content = template_combinatorial_env.format(view_config="select: ['target=x86_64']")
+    with installed_environment(content):
         shell = env("activate", "--sh", "test")
         assert "PATH" not in shell
-        assert viewdir not in shell
+        assert str(view_dir) not in shell
 
 
 @pytest.mark.parametrize("include_views", [True, False, "split"])
-def test_stack_view_multiple_views(
-    tmp_path,
-    mock_fetch,
-    mock_packages,
-    mock_archive,
-    install_mockery,
-    mutable_config,
-    include_views,
-):
+def test_stack_view_multiple_views(installed_environment, tmp_path, include_views):
     """Test multiple views as both included views (True), as both environment
-    views (False), or as one included and the other in the environment."""
+    views (False), or as one included and the other in the environment.
+    """
     # Write the view configuration and or manifest file
     view_filename = tmp_path / "view.yaml"
     base_content = """\
   definitions:
     - packages: [mpileaks, cmake]
-    - compilers: ['%gcc', '%clang']
+    - targets: ['target=x86_64', 'target=core2']
   specs:
     - matrix:
         - [$packages]
-        - [$compilers]
+        - [$targets]
 """
 
     include_content = f"  include:\n    - {view_filename}\n"
@@ -3237,17 +3062,17 @@ def test_stack_view_multiple_views(
     comb_view = """\
 {0}combinatorial:
 {0}  root: {1}
-{0}  exclude: [callpath%gcc]
+{0}  exclude: [target=core2]
 {0}  projections:
 """
 
-    projection = "    'all': '{name}/{version}-{compiler.name}'"
+    projection = "    'all': '{architecture.target}/{name}-{version}'"
 
     default_dir = tmp_path / "default-view"
     default_view = """\
 {0}default:
 {0}  root: {1}
-{0}  select: ['%gcc']
+{0}  select: ['target=x86_64']
 """
 
     content = "spack:\n"
@@ -3272,22 +3097,13 @@ def test_stack_view_multiple_views(
         content += default_view.format(indent, str(default_dir))
         content += comb_view.format(indent, str(comb_dir)) + indent + projection
 
-    filename = tmp_path / ev.manifest_name
-    filename.write_text(content)
-
-    env("create", "test", str(filename))
-    with ev.read("test"):
-        install()
-
-    with ev.read("test") as e:
+    with installed_environment(content) as e:
         assert os.path.exists(str(default_dir / "bin"))
         for spec in e._get_environment_specs():
-            spec_subdir = f"{spec.version}-{spec.compiler.name}"
-            comb_spec_dir = str(comb_dir / spec.name / spec_subdir)
-            if not spec.satisfies("callpath%gcc"):
-                assert os.path.exists(comb_spec_dir)
-            else:
-                assert not os.path.exists(comb_spec_dir)
+            if spec.name == "gcc-runtime":
+                continue
+            current_dir = comb_dir / f"{spec.architecture.target}" / f"{spec.name}-{spec.version}"
+            assert current_dir.exists() is not spec.satisfies("target=core2")
 
 
 def test_env_activate_sh_prints_shell_output(tmpdir, mock_stage, mock_fetch, install_mockery):
@@ -3656,12 +3472,10 @@ spack:
     assert spec.prefix not in contents
 
 
-def test_modules_exist_after_env_install(
-    environment_from_manifest, install_mockery, mock_fetch, monkeypatch
-):
+def test_modules_exist_after_env_install(installed_environment, monkeypatch):
     # Some caching issue
     monkeypatch.setattr(spack.modules.tcl, "configuration_registry", {})
-    environment_from_manifest(
+    with installed_environment(
         """
 spack:
   specs:
@@ -3677,16 +3491,15 @@ spack:
       roots:
         tcl: without_view
 """
-    )
-
-    with ev.read("test") as e:
-        install()
+    ) as e:
         specs = e.all_specs()
-
         for module_set in ("uses_view", "without_view"):
             modules = glob.glob(f"{e.path}/{module_set}/**/*/*")
             assert len(modules) == len(specs), "Not all modules were generated"
             for spec in specs:
+                if spec.external:
+                    continue
+
                 module = next((m for m in modules if os.path.dirname(m).endswith(spec.name)), None)
                 assert module, f"Module for {spec} not found"
 
@@ -3728,7 +3541,7 @@ spack:
         (mpileaks_spec,) = e.all_matching_specs("mpileaks")
         assert not os.path.exists(libelf_spec.package.stage.path)
         assert not os.path.exists(mpileaks_spec.package.stage.path)
-        install()
+        install("--fake")
         assert os.path.exists(libelf_spec.package.stage.path)
         assert not os.path.exists(mpileaks_spec.package.stage.path)
 
@@ -3938,7 +3751,7 @@ def test_environment_query_spec_by_hash(mock_stage, mock_fetch, install_mockery)
         concretize()
     with ev.read("test") as e:
         spec = e.matching_spec("libelf")
-        install("/{0}".format(spec.dag_hash()))
+        install("--fake", f"/{spec.dag_hash()}")
     with ev.read("test") as e:
         assert not e.matching_spec("libdwarf").installed
         assert e.matching_spec("libelf").installed
@@ -4401,7 +4214,7 @@ def test_env_include_packages_url(
         ev.activate(env)
 
         cfg = spack.config.get("packages")
-        assert "openmpi" in cfg["all"]["providers"]["mpi"]
+        assert "mpich" in cfg["all"]["providers"]["mpi"]
 
 
 def test_relative_view_path_on_command_line_is_made_absolute(tmp_path):
@@ -4525,7 +4338,7 @@ spack:
 
 
 def test_stack_view_multiple_views_same_name(
-    tmp_path, mock_fetch, mock_packages, mock_archive, install_mockery, mutable_config
+    installed_environment, template_combinatorial_env, tmp_path
 ):
     """Test multiple views with the same name combine settings with precedence
     given to the options in spack.yaml."""
@@ -4537,58 +4350,52 @@ def test_stack_view_multiple_views_same_name(
 view:
   default:
     root: {default_dir}
-    select: ['%gcc']
+    select: ['target=x86_64']
     projections:
-      all: '{{name}}/{{version}}-{{compiler.name}}'
+      all: '{{architecture.target}}/{{name}}-{{version}}-from-view'
 """
     view_filename.write_text(default_view)
 
     view_dir = tmp_path / "view"
-    content = f"""\
+    with installed_environment(
+        f"""\
 spack:
   include:
   - {view_filename}
   definitions:
     - packages: [mpileaks, cmake]
-    - compilers: ['%gcc', '%clang']
+    - targets: ['target=x86_64', 'target=core2']
+
   specs:
     - matrix:
         - [$packages]
-        - [$compilers]
+        - [$targets]
 
   view:
     default:
       root: {view_dir}
       exclude: ['cmake']
       projections:
-        all: '{{name}}/{{compiler.name}}-{{version}}'
+        all: '{{architecture.target}}/{{name}}-{{version}}'
 """
-
-    filename = tmp_path / ev.manifest_name
-    filename.write_text(content)
-
-    env("create", "test", str(filename))
-    with ev.read("test"):
-        install()
-
-    with ev.read("test") as e:
+    ) as e:
         # the view root in the included view should NOT exist
         assert not os.path.exists(str(default_dir))
 
         for spec in e._get_environment_specs():
             # no specs will exist in the included view projection
-            included_spec_subdir = f"{spec.version}-{spec.compiler.name}"
-            included_spec_dir = str(view_dir / spec.name / included_spec_subdir)
-            assert not os.path.exists(included_spec_dir)
+            base_dir = view_dir / f"{spec.architecture.target}"
+            included_dir = base_dir / f"{spec.name}-{spec.version}-from-view"
+            assert not included_dir.exists()
 
-            # only specs compiled with %gcc (selected in the included view) that
+            # only target=x86_64 specs (selected in the included view) that
             # are also not cmake (excluded in the environment view) should exist
-            env_spec_subdir = f"{spec.compiler.name}-{spec.version}"
-            env_spec_dir = str(view_dir / spec.name / env_spec_subdir)
-            if spec.satisfies("cmake") or spec.satisfies("%clang"):
-                assert not os.path.exists(env_spec_dir)
-            else:
-                assert os.path.exists(env_spec_dir)
+            if spec.name == "gcc-runtime":
+                continue
+            current_dir = view_dir / f"{spec.architecture.target}" / f"{spec.name}-{spec.version}"
+            assert current_dir.exists() is not (
+                spec.satisfies("cmake") or spec.satisfies("target=core2")
+            )
 
 
 def test_env_view_resolves_identical_file_conflicts(tmp_path, install_mockery, mock_fetch):


### PR DESCRIPTION
Extracted #45189

Common test setup has been extracted in fixtures. Some matrix dimensions moved from being "compiler" to be "targets".

Use --fake install for packages in test.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
