### PR TITLE
Windows: Improved SVN Checkout Support with Cross-Drive Operations

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1226,7 +1226,7 @@ class SvnFetchStrategy(VCSFetchStrategy):
                 # On Windows, ensure that the checkout is not set to read-only to prevent
                 # PermissionsError when shutil.move attempts to copy-then-delete the temp
                 # directory when working on muliple drives.
-                subprocess.run("attrib -r /d /s", check=True, shell=True)
+                subprocess.run("attrib -h -r /d /s", check=True, shell=True)
             repo_name = get_single_file(".")
             self.stage.srcdir = repo_name
             shutil.move(repo_name, self.stage.source_path)


### PR DESCRIPTION
This PR addresses an issue where Spack installations on Windows failed when the temporary directory is located on a different drive than the Spack installation. 

The error message shown was:
```
OSError: [WinError 17] The system cannot move the file to a different disk drive: 'trunk' -> 'D:\\spack\\.staging\\<pkg-name>\\spack-src'
```