### PR TITLE
Mesa: Update the Meson requirements for newer versions

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -54,6 +54,8 @@ class Mesa(MesonPackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("meson@0.52:", type="build")
+    depends_on("meson@0.54:", type="build", when="@23:")
+    depends_on("meson@0.60:", type="build", when="@23.1:")
 
     depends_on("pkgconfig", type="build")
     depends_on("bison", type="build")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Mesa has updated its minimum required versions for Meson.