### PR TITLE
root: only depends_on fortran when +fortran

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -93,9 +93,9 @@ class Root(CMakePackage):
     version("6.06.04", sha256="ab86dcc80cbd8e704099af0789e23f49469932ac4936d2291602301a7aa8795b")
     version("6.06.02", sha256="18a4ce42ee19e1a810d5351f74ec9550e6e422b13b5c58e0c3db740cdbc569d1")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build", when="+fortran")
 
     # ###################### Patches ##########################
 


### PR DESCRIPTION
This PR updates `root` to only require a fortran compiler when `+fortran` is enabled. Only `misc/minicern` contains fortran code, and only `hist/hbook/` and `main/` use it (`main/` for `g2root` and `h2root`). Verified that this is also true for v6.06.02, the oldest supported version in spack.

Note: dependence on `c` may only apply when `builtin_llvm` is True, but we don't expose that as a variant (yet).