### PR TITLE
dcap: add v2.47.13, v2.47.14, avoid bash for sh script

### DIFF
--- a/var/spack/repos/builtin/packages/dcap/package.py
+++ b/var/spack/repos/builtin/packages/dcap/package.py
@@ -1,4 +1,4 @@
-h# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/dcap/package.py
+++ b/var/spack/repos/builtin/packages/dcap/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+h# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -12,11 +12,13 @@ class Dcap(AutotoolsPackage):
     homepage = "https://github.com/dCache/dcap"
     url = "https://github.com/dCache/dcap/archive/2.47.12.tar.gz"
 
-    license("LGPL-2.0-or-later")
+    license("LGPL-2.0-or-later", checked_by="wdconinc")
 
+    version("2.47.14", sha256="dda98990d93cded815ee425101674ad2f48438fff76b3d4d5d3f91e380e9cc49")
+    version("2.47.13", sha256="ae4a3845b7dd6bc32dc8ba445105e3ce72c1a25aa11da640404f63c89378876b")
     version("2.47.12", sha256="050a8d20c241abf358d5d72586f9abc43940e61d9ec9480040ac7da52ec804ac")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
@@ -30,5 +32,4 @@ class Dcap(AutotoolsPackage):
             filter_file("SUBDIRS = .*", "SUBDIRS = src", "Makefile.am")
 
     def autoreconf(self, spec, prefix):
-        bash = which("bash")
-        bash("./bootstrap.sh")
+        Executable("./bootstrap.sh")()


### PR DESCRIPTION
This PR updates `dcap` with v2.47.13 and v2.47.14, which fixes some autoconf-related issues. Removed the `bash` dependency since `bootstrap.sh` only wants `sh`.

Test build:
```
==> Installing dcap-2.47.14-pho2loyvwfztt3hr3vr5b5brbhotwnd7 [17/17]
==> No binary for dcap-2.47.14-pho2loyvwfztt3hr3vr5b5brbhotwnd7 found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/dd/dda98990d93cded815ee425101674ad2f48438fff76b3d4d5d3f91e380e9cc49.tar.gz
==> Ran patch() for dcap
==> dcap: Executing phase: 'autoreconf'
==> dcap: Executing phase: 'configure'
==> dcap: Executing phase: 'build'
==> dcap: Executing phase: 'install'
==> dcap: Successfully installed dcap-2.47.14-pho2loyvwfztt3hr3vr5b5brbhotwnd7
  Stage: 0.05s.  Autoreconf: 6.96s.  Configure: 26.49s.  Build: 8.99s.  Install: 2.51s.  Post-install: 0.41s.  Total: 45.67s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/dcap-2.47.14-pho2loyvwfztt3hr3vr5b5brbhotwnd7
```