### PR TITLE
root: add v6.34.00, v6.34.02

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -101,12 +101,12 @@ class Dd4hep(CMakePackage):
     depends_on("root @6.08: +gdml +math +python")
     depends_on("root @6.12.2: +root7", when="@1.26:")  # DDCoreGraphics needs ROOT::ROOTHistDraw
     with when("+ddeve"):
-        depends_on("root @6.08: +x +opengl")
+        depends_on("root @6.08: +geom +opengl +x")
         depends_on("root @:6.27", when="@:1.23")
         conflicts("^root ~webgui", when="^root@6.28:")
         # For DD4hep >= 1.24, DDEve_Interface needs ROOT::ROOTGeomViewer only if ROOT >= 6.27
         requires("^root +root7 +webgui", when="@1.24: ^root @6.27:")
-    depends_on("root @6.08: +gdml +math +python +x +opengl", when="+utilityapps")
+    depends_on("root @6.08: +gdml +geom +math +python +x +opengl", when="+utilityapps")
 
     extends("python")
     depends_on("xerces-c", when="+xercesc")

--- a/var/spack/repos/builtin/packages/delphes/package.py
+++ b/var/spack/repos/builtin/packages/delphes/package.py
@@ -48,7 +48,7 @@ class Delphes(CMakePackage):
     variant("pythia8", default=True, description="build with pythia8")
 
     depends_on("cmake", type="build")
-    depends_on("root")
+    depends_on("root +geom +opengl")
     depends_on("pythia8", when="+pythia8")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/pandoramonitoring/package.py
+++ b/var/spack/repos/builtin/packages/pandoramonitoring/package.py
@@ -24,7 +24,7 @@ class Pandoramonitoring(CMakePackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
-    depends_on("root@6.18.04: +x +opengl")
+    depends_on("root@6.18.04: +geom +opengl +x")
     depends_on("pandorasdk")
 
     # https://github.com/PandoraPFA/PandoraMonitoring/pull/13

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -706,6 +706,8 @@ class Root(CMakePackage):
             define_from_variant("fitsio", "fits"),
             define_from_variant("ftgl", "opengl"),
             define_from_variant("gdml"),
+            define_from_variant("geom"),
+            define_from_variant("geombuilder"),
             define_from_variant("genvector", "math"),
             define("geocad", False),
             define("gfal", False),

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -268,10 +268,16 @@ class Root(CMakePackage):
         description="Build TMVA with CPU support for deep learning (requires BLAS)",
     )
     variant(
+        "tmva-cudnn",
+        when="@6.34.00:",
+        default=True,
+        description="Enable support for cuDNN in TMVA",
+    )
+    variant(
         "tmva-gpu",
         when="@6.15.02:",
         default=False,
-        description="Build TMVA with GPU support for deep learning (requries CUDA)",
+        description="Build TMVA with GPU support for deep learning (requires CUDA)",
     )
     variant(
         "tmva-pymva",
@@ -285,6 +291,12 @@ class Root(CMakePackage):
         default=False,
         description="Build TMVA with support for sofie - "
         "fast inference code generation (requires protobuf 3)",
+    )
+    variant(
+        "tpython",
+        when="@6.34.00: +python",
+        default=True,
+        description="Build the TPython class to run Python code from C++",
     )
     variant("unuran", default=True, description="Use UNURAN for random number generation")
     variant("vc", default=False, description="Enable Vc for adding new types for SIMD programming")
@@ -318,6 +330,7 @@ class Root(CMakePackage):
     depends_on("cmake@3.9:", type="build", when="@6.18.00:")
     depends_on("cmake@3.16:", type="build", when="@6.26.00:")
     depends_on("cmake@3.19:", type="build", when="@6.28.00: platform=darwin")
+    depends_on("cmake@3.20:", type="build", when="@6.34.00:")
     depends_on("pkgconfig", type="build")
 
     # 6.32.00 requires sys/random.h
@@ -363,6 +376,7 @@ class Root(CMakePackage):
     # Python
     depends_on("python@2.7:", when="+python", type=("build", "run"))
     depends_on("python@2.7:3.10", when="@:6.26.09 +python", type=("build", "run"))
+    depends_on("python@3.8:", when="@6.34.00: +python", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"), when="+tmva-pymva")
     # See: https://sft.its.cern.ch/jira/browse/ROOT-10626
     depends_on("py-numpy", type=("build", "run"), when="@6.20.00:6.20.05 +python")
@@ -777,6 +791,11 @@ class Root(CMakePackage):
 
         if self.spec.satisfies("@:6.30"):
             options.append(define_from_variant("minuit2", "minuit"))
+
+        if self.spec.satisfies("@6.34:"):
+            options.append(define_from_variant("tmva-cudnn", "tmva-cudnn"))
+            options.append(define_from_variant("tmva-cudnn", "cudnn"))
+            options.append(define_from_variant("tpython"))
 
         # #################### Compiler options ####################
 

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -208,6 +208,10 @@ class Root(CMakePackage):
         default=True,
         description="Ignore most of Root's feature defaults except for " "basic graphic options",
     )
+    variant("geom", default=True, description="Enable support for the geometry library")
+    conflicts("~geom", when="@:6.33", msg="geom is always enabled through 6.33")
+    variant("geombuilder", default=False, description="Enable support for the geombuilder library")
+    conflicts("~geombuilder", when="@:6.33", msg="geombuilder is always enabled through 6.33")
     variant("gsl", default=True, description="Enable linking against shared libraries for GSL")
     variant("http", default=False, description="Enable HTTP server support")
     variant(
@@ -557,6 +561,8 @@ class Root(CMakePackage):
         _add_variant(v, f, "fitsio", "+fits")
         _add_variant(v, f, ("ftgl", "opengl"), "+opengl")
         _add_variant(v, f, "gdml", "+gdml")
+        _add_variant(v, f, "geom", "+geom")
+        _add_variant(v, f, "geombuilder", "+geombuilder")
         _add_variant(v, f, "mathmore", "+math")
         _add_variant(v, f, "gviz", "+graphviz")
         _add_variant(v, f, "http", "+http")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -34,10 +34,18 @@ class Root(CMakePackage):
     # Development version (when more recent than production).
     version("develop", branch="master")
 
-    # Production version
+    # Please note that 6.34 is a short term support release. As such, it is not meant to
+    # be used for data taking. It will be superseded by the 6.36 release, which is foreseen
+    # in May 2025. Patch releases of 6.34 will be provided until June 30th 2025.
     version("6.34.02", sha256="166bec562e420e177aaf3133fa3fb09f82ecddabe8a2e1906345bad442513f94")
     version("6.34.00", sha256="f3b00f3db953829c849029c39d7660a956468af247efd946e89072101796ab03")
-    version("6.32.08", sha256="29ad4945a72dff1a009c326a65b6fa5ee2478498823251d3cef86a2cbeb77b27")
+
+    # Production version
+    version(
+        "6.32.08",
+        sha256="29ad4945a72dff1a009c326a65b6fa5ee2478498823251d3cef86a2cbeb77b27",
+        preferred=True,  # when 6.36 is released, this can be removed
+    )
     version("6.32.06", sha256="3fc032d93fe848dea5adb1b47d8f0a86279523293fee0aa2b3cd52a1ffab7247")
     version("6.32.04", sha256="132f126aae7d30efbccd7dcd991b7ada1890ae57980ef300c16421f9d4d07ea8")
     version("6.32.02", sha256="3d0f76bf05857e1807ccfb2c9e014f525bcb625f94a2370b455f4b164961602d")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -34,18 +34,10 @@ class Root(CMakePackage):
     # Development version (when more recent than production).
     version("develop", branch="master")
 
-    # Please note that 6.34 is a short term support release. As such, it is not meant to
-    # be used for data taking. It will be superseded by the 6.36 release, which is foreseen
-    # in May 2025. Patch releases of 6.34 will be provided until June 30th 2025.
+    # Production version
     version("6.34.02", sha256="166bec562e420e177aaf3133fa3fb09f82ecddabe8a2e1906345bad442513f94")
     version("6.34.00", sha256="f3b00f3db953829c849029c39d7660a956468af247efd946e89072101796ab03")
-
-    # Production version
-    version(
-        "6.32.08",
-        sha256="29ad4945a72dff1a009c326a65b6fa5ee2478498823251d3cef86a2cbeb77b27",
-        preferred=True,  # when 6.36 is released, this can be removed
-    )
+    version("6.32.08", sha256="29ad4945a72dff1a009c326a65b6fa5ee2478498823251d3cef86a2cbeb77b27")
     version("6.32.06", sha256="3fc032d93fe848dea5adb1b47d8f0a86279523293fee0aa2b3cd52a1ffab7247")
     version("6.32.04", sha256="132f126aae7d30efbccd7dcd991b7ada1890ae57980ef300c16421f9d4d07ea8")
     version("6.32.02", sha256="3d0f76bf05857e1807ccfb2c9e014f525bcb625f94a2370b455f4b164961602d")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -35,6 +35,8 @@ class Root(CMakePackage):
     version("develop", branch="master")
 
     # Production version
+    version("6.34.02", sha256="166bec562e420e177aaf3133fa3fb09f82ecddabe8a2e1906345bad442513f94")
+    version("6.34.00", sha256="f3b00f3db953829c849029c39d7660a956468af247efd946e89072101796ab03")
     version("6.32.08", sha256="29ad4945a72dff1a009c326a65b6fa5ee2478498823251d3cef86a2cbeb77b27")
     version("6.32.06", sha256="3fc032d93fe848dea5adb1b47d8f0a86279523293fee0aa2b3cd52a1ffab7247")
     version("6.32.04", sha256="132f126aae7d30efbccd7dcd991b7ada1890ae57980ef300c16421f9d4d07ea8")


### PR DESCRIPTION
As pointed out by @tmadlener in #47991, there is a new release for `root` (two even as of today), and this PR adds `root`, v6.34.00 ([release notes](https://github.com/root-project/root/releases/tag/v6-34-00), [diff](https://github.com/root-project/root/compare/v6-32-08...v6-34-00)) and v6.34.02 ([release notes](https://github.com/root-project/root/releases/tag/v6-34-02), [diff](https://github.com/root-project/root/compare/v6-34-00...v6-34-02)).

v6.34.00:
- ~~Not sure what is meant with "Please note that 6.34 is a short term support release. As such, it is not meant to be used for data taking." I guess it's not quite your usual stable release. Marking 6.32 as preferred.~~ Treating this release as just as stable as any other even number. 
- New deprecated default-off build option `html` to build THtml was not introduced as a variant.
- Build option `cudnn` renamed to `tmva-cudnn`, and propagated to variant. Not sure yet how to deprecate the older variant (or to just keep it).

v6.34.02: I don't think we are affected by the davix issue in 6.34.00 because `root` uses an external `davix`, and `davix` uses an external `rapidjson`, where we have a dated last version that works with `gcc@14`, and older versions explicitly conflict with `gcc@14` (as of #46007).