### PR TITLE
gaudi: add v39.1; patch for failing test; properly support +examples

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -139,15 +139,6 @@ class Gaudi(CMakePackage):
     # The Intel VTune dependency is taken aside because it requires a license
     depends_on("intel-parallel-studio -mpi +vtune", when="+vtune")
 
-    def patch(self):
-        if self.spec.satisfies("@39:"):
-            # Disable a test that fails on pytest collection due to NameError
-            filter_file(
-                r"\(tests/pytest\)",
-                "(tests/pytest OPTIONS --ignore=tests/pytest/refs/RandomNumber.py)",
-                "GaudiTestSuite/CMakeLists.txt",
-            )
-
     def cmake_args(self):
         args = [
             # Note: gaudi only builds examples when testing enabled

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -144,7 +144,7 @@ class Gaudi(CMakePackage):
             # Disable a test that fails on pytest collection due to NameError
             filter_file(
                 r"\(tests/pytest\)",
-                "(tests/pytest --ignore=tests/pytest/refs/RandomNumber.py)",
+                "(tests/pytest OPTIONS --ignore=tests/pytest/refs/RandomNumber.py)",
                 "GaudiTestSuite/CMakeLists.txt",
             )
 

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -18,6 +18,7 @@ class Gaudi(CMakePackage):
     tags = ["hep"]
 
     version("master", branch="master")
+    version("39.1", sha256="acdeddcc2383a127b1ad4b0bdaf9f1c6699b64105e0c1d8095c560c96c157885")
     version("39.0", sha256="faa3653e2e6c769292c0592e3fc35cd98a2820bd6fc0c967cac565808b927262")
     version("38.3", sha256="47e8c65ea446656d2dae54a32205525e08257778cf80f9f029cd244d6650486e")
     version("38.2", sha256="08759b1398336987ad991602e37079f0744e8d8e4e3d5df2d253b8dedf925068")
@@ -138,10 +139,20 @@ class Gaudi(CMakePackage):
     # The Intel VTune dependency is taken aside because it requires a license
     depends_on("intel-parallel-studio -mpi +vtune", when="+vtune")
 
+    def patch(self):
+        if self.spec.satisfies("@39:"):
+            # Disable a test that fails on pytest collection due to NameError
+            filter_file(
+                r"\(tests/pytest\)",
+                "(tests/pytest --ignore=tests/pytest/refs/RandomNumber.py)",
+                "GaudiTestSuite/CMakeLists.txt",
+            )
+
     def cmake_args(self):
         args = [
             # Note: gaudi only builds examples when testing enabled
             self.define("BUILD_TESTING", self.run_tests or self.spec.satisfies("+examples")),
+            self.define_from_variant("GAUDI_BUILD_EXAMPLES", "examples"),
             self.define_from_variant("GAUDI_USE_AIDA", "aida"),
             self.define_from_variant("GAUDI_USE_CPPUNIT", "cppunit"),
             self.define_from_variant("GAUDI_ENABLE_GAUDIALG", "gaudialg"),


### PR DESCRIPTION
This PR adds `gaudi`, v39.1 ([diff](https://gitlab.cern.ch/gaudi/Gaudi/-/compare/v39r0...v39r1)), which does not require any changes to the recipe.

This PR also defines the CMake variable `GAUDI_BUILD_EXAMPLES` based on `+examples`, which is required as of 38.3 (https://gitlab.cern.ch/gaudi/Gaudi/-/commit/ed42ae5fabf7f1707f381dccda29712820384b84). There's no harm in defining the CMake variable for older versions.

Test build (without actually running the tests):
```
==> Installing gaudi-39.1-bex4eas3mbdpya6wpjwxlrc6ptrfkqww [143/143]
==> No binary for gaudi-39.1-bex4eas3mbdpya6wpjwxlrc6ptrfkqww found: installing from source
==> Fetching https://gitlab.cern.ch/gaudi/Gaudi/-/archive/v39r1/Gaudi-v39r1.tar.gz
==> Ran patch() for gaudi
==> gaudi: Executing phase: 'cmake'
==> gaudi: Executing phase: 'build'
==> gaudi: Executing phase: 'install'
==> gaudi: Successfully installed gaudi-39.1-bex4eas3mbdpya6wpjwxlrc6ptrfkqww
  Stage: 2.60s.  Cmake: 1.97s.  Build: 13m 20.61s.  Install: 2m 52.63s.  Post-install: 1.27s.  Total: 16m 19.61s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/gaudi-39.1-bex4eas3mbdpya6wpjwxlrc6ptrfkqww
```