### PR TITLE
pythia8: correct with_or_without prefix for +openmpi

### DIFF
--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -180,7 +180,7 @@ class Pythia8(AutotoolsPackage):
 
         args += self.with_or_without("python", activation_value="prefix")
         args += self.with_or_without(
-            "openmp", activation_value=lambda x: self.spec["openmpi"].prefix, variant="openmpi",
+            "openmp", activation_value=lambda x: self.spec["openmpi"].prefix, variant="openmpi"
         )
         args += self.with_or_without("mpich", activation_value="prefix")
         args += self.with_or_without("hdf5", activation_value="prefix")

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -179,7 +179,11 @@ class Pythia8(AutotoolsPackage):
             args.append("--with-yoda=" + self.spec["yoda"].prefix)
 
         args += self.with_or_without("python", activation_value="prefix")
-        args += self.with_or_without("openmp", activation_value="prefix", variant="openmpi")
+        args += self.with_or_without(
+            "openmp",
+            activation_value=lambda x: self.spec["openmpi"].prefix,
+            variant="openmpi",
+        )
         args += self.with_or_without("mpich", activation_value="prefix")
         args += self.with_or_without("hdf5", activation_value="prefix")
 

--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -180,9 +180,7 @@ class Pythia8(AutotoolsPackage):
 
         args += self.with_or_without("python", activation_value="prefix")
         args += self.with_or_without(
-            "openmp",
-            activation_value=lambda x: self.spec["openmpi"].prefix,
-            variant="openmpi",
+            "openmp", activation_value=lambda x: self.spec["openmpi"].prefix, variant="openmpi",
         )
         args += self.with_or_without("mpich", activation_value="prefix")
         args += self.with_or_without("hdf5", activation_value="prefix")


### PR DESCRIPTION
This PR fixes `pythia8` when `+openmpi`, which until now was attempting to use the `openmp` prefix which does not exist in the spec.