### PR TITLE
`spack external find grep` on Linux AND macOS

### DIFF
--- a/var/spack/repos/builtin/packages/grep/package.py
+++ b/var/spack/repos/builtin/packages/grep/package.py
@@ -36,13 +36,17 @@ class Grep(AutotoolsPackage):
 
     @classmethod
     def determine_version(cls, exe):
-        version_string = Executable(exe)("--version", output=str, error=str).split('\n')[0]
+        version_string = Executable(exe)("--version", output=str, error=str).split("\n")[0]
+        # Linux
         if "GNU grep" in version_string:
             return version_string.lstrip("grep (GNU grep)").strip()
+        # macOS
         elif "BSD grep, GNU compatible" in version_string:
-            return version_string.lstrip("grep (BSD grep, GNU compatible)").rstrip("-FreeBSD").strip()
+            return (
+                version_string.lstrip("grep (BSD grep, GNU compatible)").rstrip("-FreeBSD").strip()
+            )
+        # Don't know how to handle this version of grep, don't add it
         else:
-            # Don't know how to handle this version of grep, don't add it
             return None
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/grep/package.py
+++ b/var/spack/repos/builtin/packages/grep/package.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import re
 
 from spack.package import *
 


### PR DESCRIPTION
## Description

Currently, can only do `spack external find grep` on Linux. This version finds `grep` on both Linux and macOS. No need for a fancy `re` in the package either in my opinion. I tested this on a bunch of HPCs, vanilla Linux distributions and macOS.