### PR TITLE
resolve_shared_libraries.py: exclude libanl.so from glibc

### DIFF
--- a/lib/spack/spack/hooks/resolve_shared_libraries.py
+++ b/lib/spack/spack/hooks/resolve_shared_libraries.py
@@ -29,6 +29,7 @@ ALLOW_UNRESOLVED = [
     # glibc
     "ld-linux*.so.*",
     "ld64.so.*",
+    "libanl.so.*",
     "libc.so.*",
     "libdl.so.*",
     "libm.so.*",


### PR DESCRIPTION
fixes https://gitlab.spack.io/spack/spack/-/jobs/14244075