### PR TITLE
herwig, thepeg: Add latest version and specify rivet dependencies better

### DIFF
--- a/var/spack/repos/builtin/packages/herwig3/package.py
+++ b/var/spack/repos/builtin/packages/herwig3/package.py
@@ -16,6 +16,7 @@ class Herwig3(AutotoolsPackage):
 
     license("GPL-3.0-only")
 
+    version("7.3.0", sha256="2624819d2dff105ba952ea1b5cf12eb6f4926d4951774a41907699e2f567686c")
     version("7.2.3", sha256="5599899379b01b09e331a2426d78d39b7f6ec126db2543e9d340aefe6aa50f84")
     version("7.2.2", sha256="53e06b386df5bc20fe268b6c8ba50f1e62b6744e577d383ec836ea3fc672c383")
     version("7.2.1", sha256="d4fff32f21c5c08a4b2e563c476b079859c2c8e3b78d853a8a60da96d5eea686")
@@ -33,6 +34,7 @@ class Herwig3(AutotoolsPackage):
     depends_on("thepeg@2.2.1", when="@7.2.1")
     depends_on("thepeg@2.2.2", when="@7.2.2")
     depends_on("thepeg@2.2.3", when="@7.2.3")
+    depends_on("thepeg@2.3.0", when="@7.3.0")
     depends_on("evtgen")
 
     depends_on("boost +math+test")

--- a/var/spack/repos/builtin/packages/thepeg/package.py
+++ b/var/spack/repos/builtin/packages/thepeg/package.py
@@ -71,7 +71,7 @@ class Thepeg(AutotoolsPackage):
     depends_on("hepmc3", when="hepmc=3")
     conflicts("hepmc=3", when="@:2.1", msg="HepMC3 support was added in 2.2.0")
     depends_on("fastjet", when="@2.0.0:")
-    depends_on("rivet", when="@2.0.3: +rivet")
+    depends_on("rivet@:3", when="@2.0.3: +rivet")
     depends_on("boost +test", when="@2.1.1:")
 
     depends_on("autoconf", type="build")

--- a/var/spack/repos/builtin/packages/thepeg/package.py
+++ b/var/spack/repos/builtin/packages/thepeg/package.py
@@ -71,7 +71,8 @@ class Thepeg(AutotoolsPackage):
     depends_on("hepmc3", when="hepmc=3")
     conflicts("hepmc=3", when="@:2.1", msg="HepMC3 support was added in 2.2.0")
     depends_on("fastjet", when="@2.0.0:")
-    depends_on("rivet@:3", when="@2.0.3: +rivet")
+    depends_on("rivet@:3 hepmc=2", when="@2.0.3: +rivet hepmc=2")
+    depends_on("rivet@:3 hepmc=3", when="@2.0.3: +rivet hepmc=3")
     depends_on("boost +test", when="@2.1.1:")
 
     depends_on("autoconf", type="build")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Add the lastest version of herwig3 (7.3.0)

`thepeg` has not yet been updated to build against `rivet@4`. Additionally the `hepmc` variants have to be harmonzied to avoid build failures.