### PR TITLE
kokkos: add hip_relocatable_device_code variant

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -185,6 +185,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "cuda_lambda": [False, "Activate experimental lambda features"],
         "cuda_ldg_intrinsic": [False, "Use CUDA LDG intrinsics"],
         "cuda_relocatable_device_code": [False, "Enable RDC for CUDA"],
+        "hip_relocatable_device_code": [False, "Enable RDC for HIP"],
         "cuda_uvm": [False, "Enable unified virtual memory (UVM) for CUDA"],
         "debug": [False, "Activate extra debug features - may increase compiletimes"],
         "debug_bounds_check": [False, "Use bounds checking - will increase runtime"],

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -410,6 +410,10 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     with when("@14.4: +kokkos"):
         depends_on("kokkos+wrapper", when="+wrapper")
         depends_on("kokkos~wrapper", when="~wrapper")
+        depends_on("kokkos+cuda_relocatable_device_code~shared", when="+cuda_rdc")
+        depends_on("kokkos+hip_relocatable_device_code~shared", when="+rocm_rdc")
+        depends_on("kokkos-kernels~shared", when="+cuda_rdc")
+        depends_on("kokkos-kernels~shared", when="+rocm_rdc")
         depends_on("kokkos~complex_align")
         depends_on("kokkos@4.5.00", when="@master:")
         depends_on("kokkos@4.3.01", when="@16")


### PR DESCRIPTION
trilinos: kokkos should enable relocatable device code if requested for trilinos and it also requires the kokkos libraries be static.

I'm also finding it frustrating that AMD has two identifiers for its GPU language, because it's used by projects as a mix of each.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
