### PR TITLE
CI: reduce output from helper scripts

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/scripts/common/aggregate_package_logs.spack.py
+++ b/share/spack/gitlab/cloud_pipelines/scripts/common/aggregate_package_logs.spack.py
@@ -6,6 +6,8 @@ This script is meant to be run using:
 
 import os
 
+from llnl.util.tty import tty
+
 
 def find_logs(prefix, filename):
     for root, _, files in os.walk(prefix):
@@ -37,14 +39,12 @@ if __name__ == "__main__":
 
     # Look in the list of prefixes for logs
     for prefix in prefixes:
-        print(f"Walking {prefix}")
         logs = [log for log in find_logs(prefix, args.log)]
-        print(f"  * found {len(logs)} logs")
         for log in logs:
-            print(f"  * appending data for {log}")
+            tty.debug(f"appending data for {log}")
             with open(log, encoding="utf-8") as fd:
                 data.append(json.load(fd))
 
-    print(f"Writing {args.output_file}")
+    tty.info(f"Writing {len(data)} records to {args.output_file}")
     with open(args.output_file, "w", encoding="utf-8") as fd:
         json.dump(data, fd)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Drop extra output that was originally meant for debugging.