### PR TITLE
Make unit tests work on Ubuntu 24.04

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         on_develop:
         - ${{ github.ref == 'refs/heads/develop' }}
@@ -24,19 +24,19 @@ jobs:
           on_develop: ${{ github.ref == 'refs/heads/develop' }}
         exclude:
         - python-version: '3.7'
-          os: ubuntu-22.04
+          os: ubuntu-latest
           on_develop: false
         - python-version: '3.8'
-          os: ubuntu-22.04
+          os: ubuntu-latest
           on_develop: false
         - python-version: '3.9'
-          os: ubuntu-22.04
+          os: ubuntu-latest
           on_develop: false
         - python-version: '3.10'
-          os: ubuntu-22.04
+          os: ubuntu-latest
           on_develop: false
         - python-version: '3.11'
-          os: ubuntu-22.04
+          os: ubuntu-latest
           on_develop: false
 
     steps:
@@ -52,7 +52,13 @@ jobs:
           # Needed for unit tests
           sudo apt-get -y install \
               coreutils cvs gfortran graphviz gnupg2 mercurial ninja-build \
-              cmake bison libbison-dev kcov
+              cmake bison libbison-dev subversion
+    # On ubuntu 24.04, kcov was removed. It may come back in some future Ubuntu
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@40e9946c182a64b3db1bf51be0dcb915f7802aa9
+    - name: Install kcov with brew
+      run: "brew install kcov"
     - name: Install Python packages
       run: |
           pip install --upgrade pip setuptools pytest pytest-xdist pytest-cov
@@ -87,7 +93,7 @@ jobs:
         include-hidden-files: true
   # Test shell integration
   shell:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
@@ -99,7 +105,13 @@ jobs:
       run: |
           sudo apt-get -y update
           # Needed for shell tests
-          sudo apt-get install -y coreutils kcov csh zsh tcsh fish dash bash
+          sudo apt-get install -y coreutils csh zsh tcsh fish dash bash subversion
+    # On ubuntu 24.04, kcov was removed. It may come back in some future Ubuntu
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@40e9946c182a64b3db1bf51be0dcb915f7802aa9
+    - name: Install kcov with brew
+      run: "brew install kcov"
     - name: Install Python packages
       run: |
           pip install --upgrade pip setuptools pytest coverage[toml] pytest-xdist

--- a/share/spack/qa/run-shell-tests
+++ b/share/spack/qa/run-shell-tests
@@ -36,7 +36,7 @@ export QA_DIR=$(realpath $QA_DIR)
 cd "$SPACK_ROOT"
 
 # Run bash tests with coverage enabled, but pipe output to /dev/null
-# because it seems that kcov seems to undo the script's redirection
+# because it seems that kcov undoes the script's redirection
 if [ "$COVERAGE" = true ]; then
     kcov "$SPACK_ROOT/coverage" "$QA_DIR/setup-env-test.sh" &> /dev/null
     kcov "$SPACK_ROOT/coverage" "$QA_DIR/completion-test.sh" &> /dev/null


### PR DESCRIPTION
`kcov` was removed in Ubuntu 24.04, and it is no longer installable via `apt` in our CI images. Instal it via Linuxbrew instead, at least until it comes back to Ubuntu.

`subversion` is also not installed on ubuntu 24 by default, so we have to install it manually.

- [x] Add linuxbrew to linux tests
- [x] Install `kcov` with brew
- [x] Install subversion with `apt`
