### PR TITLE
Temporarily pin Ubuntu to v22.04, where we use kcov

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -24,19 +24,19 @@ jobs:
           on_develop: ${{ github.ref == 'refs/heads/develop' }}
         exclude:
         - python-version: '3.7'
-          os: ubuntu-latest
+          os: ubuntu-22.04
           on_develop: false
         - python-version: '3.8'
-          os: ubuntu-latest
+          os: ubuntu-22.04
           on_develop: false
         - python-version: '3.9'
-          os: ubuntu-latest
+          os: ubuntu-22.04
           on_develop: false
         - python-version: '3.10'
-          os: ubuntu-latest
+          os: ubuntu-22.04
           on_develop: false
         - python-version: '3.11'
-          os: ubuntu-latest
+          os: ubuntu-22.04
           on_develop: false
 
     steps:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         on_develop:
         - ${{ github.ref == 'refs/heads/develop' }}
@@ -87,7 +87,7 @@ jobs:
         include-hidden-files: true
   # Test shell integration
   shell:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:


### PR DESCRIPTION
Ubuntu doesn't package kcov in v24.04 Since GitHub started upgrading their runner images, this makes our CI fail, see e.g.

https://github.com/spack/spack/actions/runs/12366970840/job/34518012887?pr=47854

This is a temporary workaround, while we prepare a more stable fix.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
