### PR TITLE
xfsprogs: package needs unzip at build time

### DIFF
--- a/var/spack/repos/builtin/packages/xfsprogs/package.py
+++ b/var/spack/repos/builtin/packages/xfsprogs/package.py
@@ -43,6 +43,7 @@ class Xfsprogs(AutotoolsPackage):
     depends_on("uuid")
     depends_on("util-linux")
     depends_on("liburcu", when="@6:")
+    depends_on("unzip", type="build")
 
     def flag_handler(self, name, flags):
         if name == "cflags":


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Found this trying to install xfsprogs on an Ubuntu 24.04 Docker image, which apparently doesn't have unzip natively.