### PR TITLE
fetch: Add support for retries

### DIFF
--- a/lib/spack/spack/cmd/fetch.py
+++ b/lib/spack/spack/cmd/fetch.py
@@ -27,6 +27,9 @@ def setup_parser(subparser: argparse.ArgumentParser) -> None:
     subparser.add_argument(
         "-D", "--dependencies", action="store_true", help="also fetch all dependencies"
     )
+    subparser.add_argument(
+        "--retries", default=0, metavar="N", help="retry fetching N times before raising an error"
+    )
     arguments.add_concretizer_args(subparser)
     subparser.epilog = (
         "With an active environment, the specs "
@@ -71,4 +74,4 @@ def fetch(parser, args):
 
         pkg.stage.keep = True
         with pkg.stage:
-            pkg.do_fetch()
+            pkg.do_fetch(retries=args.retries)

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1556,7 +1556,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         )
         return f"{required}Refer to {self.homepage} for download instructions."
 
-    def do_fetch(self, mirror_only=False):
+    def do_fetch(self, mirror_only: bool = False, retries: int = 0):
         """
         Creates a stage directory and downloads the tarball for this package.
         Working directory will be set to the stage directory.
@@ -1620,7 +1620,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
         self.stage.create()
         err_msg = None if not self.manual_download else self.download_instr
         start_time = time.time()
-        self.stage.fetch(mirror_only, err_msg=err_msg)
+        self.stage.fetch(mirror_only, err_msg=err_msg, retries=retries)
         self._fetch_time = time.time() - start_time
 
         if checksum and self.version in self.versions:
@@ -1628,7 +1628,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         self.stage.cache_local()
 
-    def do_stage(self, mirror_only=False):
+    def do_stage(self, mirror_only: bool = False, retries: int = 0):
         """Unpacks and expands the fetched tarball."""
         # Always create the stage directory at this point.  Why?  A no-code
         # package may want to use the installation process to install metadata.
@@ -1636,7 +1636,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
 
         # Fetch/expand any associated code.
         if self.has_code and not self.spec.external:
-            self.do_fetch(mirror_only)
+            self.do_fetch(mirror_only, retries=retries)
             self.stage.expand_archive()
         else:
             # Support for post-install hooks requires a stage.source_path

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -520,7 +520,9 @@ class Stage(LockableStagingDir):
         if self.search_fn and not mirror_only:
             yield from self.search_fn()
 
-    def fetch(self, mirror_only: bool = False, err_msg: Optional[str] = None) -> None:
+    def fetch(
+        self, mirror_only: bool = False, retries: int = 0, err_msg: Optional[str] = None
+    ) -> None:
         """Retrieves the code or archive
 
         Args:
@@ -529,7 +531,9 @@ class Stage(LockableStagingDir):
                 fetch failure message
         """
         errors: List[str] = []
-        for fetcher in self._generate_fetchers(mirror_only):
+        for fetcher in (
+            f for f in self._generate_fetchers(mirror_only) for _ in range(retries + 1)
+        ):
             try:
                 fetcher.stage = self
                 self.fetcher = fetcher

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1223,7 +1223,7 @@ _spack_external_read_cray_manifest() {
 _spack_fetch() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -n --no-checksum -m --missing -D --dependencies -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated"
+        SPACK_COMPREPLY="-h --help -n --no-checksum -m --missing -D --dependencies -f --force -U --fresh --reuse --fresh-roots --reuse-deps --deprecated --retries"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.fish
+++ b/share/spack/spack-completion.fish
@@ -1808,7 +1808,7 @@ complete -c spack -n '__fish_spack_using_command external read-cray-manifest' -l
 complete -c spack -n '__fish_spack_using_command external read-cray-manifest' -l fail-on-error -d 'if a manifest file cannot be parsed, fail and report the full stack trace'
 
 # spack fetch
-set -g __fish_spack_optspecs_spack_fetch h/help n/no-checksum m/missing D/dependencies f/force U/fresh reuse fresh-roots deprecated
+set -g __fish_spack_optspecs_spack_fetch h/help n/no-checksum m/missing D/dependencies retries= f/force U/fresh reuse fresh-roots deprecated
 complete -c spack -n '__fish_spack_using_command_pos_remainder 0 fetch' -f -k -a '(__fish_spack_specs)'
 complete -c spack -n '__fish_spack_using_command fetch' -s h -l help -f -a help
 complete -c spack -n '__fish_spack_using_command fetch' -s h -l help -d 'show this help message and exit'
@@ -1818,6 +1818,8 @@ complete -c spack -n '__fish_spack_using_command fetch' -s m -l missing -f -a mi
 complete -c spack -n '__fish_spack_using_command fetch' -s m -l missing -d 'fetch only missing (not yet installed) dependencies'
 complete -c spack -n '__fish_spack_using_command fetch' -s D -l dependencies -f -a dependencies
 complete -c spack -n '__fish_spack_using_command fetch' -s D -l dependencies -d 'also fetch all dependencies'
+complete -c spack -n '__fish_spack_using_command fetch' -l retries -r -f -a retries
+complete -c spack -n '__fish_spack_using_command fetch' -l retries -r -d 'retry fetching N times before raising an error'
 complete -c spack -n '__fish_spack_using_command fetch' -s f -l force -f -a concretizer_force
 complete -c spack -n '__fish_spack_using_command fetch' -s f -l force -d 'allow changes to concretized specs in spack.lock (in an env)'
 complete -c spack -n '__fish_spack_using_command fetch' -s U -l fresh -f -a concretizer_reuse


### PR DESCRIPTION
This PR adds the optional flag `spack fetch --retries 2` which allows specifying additional retries per fetcher. If unspecified, no retries are performed.

```
spack fetch --retries 4 -Dm dealii
```

This is especially useful when dealing with an unstable internet connection as packages can now be downloaded more robustly in a separate step, making sure the potentially lengthy installation doesn't fail due to random timeouts.

I tried adding this functionality directly to `spack install` but backtracked due to the significantly longer calling chain and lack of use-case. If the connection stability is an issue, then fetching sources before installing is a pretty reasonable workflow.

```
spack fetch --retries 4 -Dm dealii
spack install dealii
```

A use-case not covered by `spack fetch` is the use of branches for `@develop` and `@master` versions. To my understanding, this requires retries to be integrated into the installation command.

Closes #16990

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
