### PR TITLE
CI: Don't error in CI for missing libs

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/config.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/config.yaml
@@ -1,7 +1,7 @@
 config:
   db_lock_timeout: 120
   shared_linking:
-    missing_library_policy: error
+    missing_library_policy: warn
   install_tree:
     root: /home/software/spack
     padded_length: 256


### PR DESCRIPTION
There are still more fix ups required for the missing libs to work as expected in CI. Dropping the error requirement in favor of moving to a log scraping method until we can verify all package issues have been addressed correctly.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

CC: @scottwittenburg @zackgalbreath