### PR TITLE
Use `Literal` now that we have `typing_extensions` in Spack.

### DIFF
--- a/lib/spack/spack/deptypes.py
+++ b/lib/spack/spack/deptypes.py
@@ -5,6 +5,7 @@
 """Data structures that represent Spack's edge types."""
 
 from typing import Iterable, List, Tuple, Union
+from typing_extensions import Literal
 
 #: Type hint for the low-level dependency input (enum.Flag is too slow)
 DepFlag = int
@@ -13,7 +14,7 @@ DepFlag = int
 DepTypes = Union[str, List[str], Tuple[str, ...]]
 
 #: Individual dependency types
-DepType = str  # Python 3.8: Literal["build", "link", "run", "test"]
+DepType = Literal["build", "link", "run", "test"]
 
 # Flag values. NOTE: these values are not arbitrary, since hash computation imposes
 # the order (link, run, build, test) when depending on the same package multiple times,

--- a/lib/spack/spack/deptypes.py
+++ b/lib/spack/spack/deptypes.py
@@ -5,6 +5,7 @@
 """Data structures that represent Spack's edge types."""
 
 from typing import Iterable, List, Tuple, Union
+
 from typing_extensions import Literal
 
 #: Type hint for the low-level dependency input (enum.Flag is too slow)

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -11,6 +11,7 @@ import shutil
 import stat
 import sys
 from typing import Callable, Dict, Optional
+
 from typing_extensions import Literal
 
 from llnl.string import comma_or
@@ -96,9 +97,9 @@ def view_copy(
         prefix_to_projection[spack.store.STORE.layout.root] = view._root
 
         # This is vestigial code for the *old* location of sbang.
-        prefix_to_projection[f"#!/bin/bash {spack.paths.spack_root}/bin/sbang"] = (
-            sbang.sbang_shebang_line()
-        )
+        prefix_to_projection[
+            f"#!/bin/bash {spack.paths.spack_root}/bin/sbang"
+        ] = sbang.sbang_shebang_line()
 
         spack.relocate.relocate_text(files=[dst], prefixes=prefix_to_projection)
 

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -97,9 +97,9 @@ def view_copy(
         prefix_to_projection[spack.store.STORE.layout.root] = view._root
 
         # This is vestigial code for the *old* location of sbang.
-        prefix_to_projection[
-            f"#!/bin/bash {spack.paths.spack_root}/bin/sbang"
-        ] = sbang.sbang_shebang_line()
+        prefix_to_projection[f"#!/bin/bash {spack.paths.spack_root}/bin/sbang"] = (
+            sbang.sbang_shebang_line()
+        )
 
         spack.relocate.relocate_text(files=[dst], prefixes=prefix_to_projection)
 

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -11,6 +11,7 @@ import shutil
 import stat
 import sys
 from typing import Callable, Dict, Optional
+from typing_extensions import Literal
 
 from llnl.string import comma_or
 from llnl.util import tty
@@ -109,6 +110,9 @@ def view_copy(
             tty.debug(f"Can't change the permissions for {dst}")
 
 
+#: Type alias for link types
+LinkType = Literal["hardlink", "hard", "copy", "relocate", "add", "symlink", "soft"]
+
 #: supported string values for `link_type` in an env, mapped to canonical values
 _LINK_TYPES = {
     "hardlink": "hardlink",
@@ -123,7 +127,7 @@ _LINK_TYPES = {
 _VALID_LINK_TYPES = sorted(set(_LINK_TYPES.values()))
 
 
-def canonicalize_link_type(link_type: str) -> str:
+def canonicalize_link_type(link_type: LinkType) -> str:
     """Return canonical"""
     canonical = _LINK_TYPES.get(link_type)
     if not canonical:
@@ -133,7 +137,7 @@ def canonicalize_link_type(link_type: str) -> str:
     return canonical
 
 
-def function_for_link_type(link_type: str) -> LinkCallbackType:
+def function_for_link_type(link_type: LinkType) -> LinkCallbackType:
     link_type = canonicalize_link_type(link_type)
     if link_type == "hardlink":
         return view_hardlink
@@ -142,7 +146,7 @@ def function_for_link_type(link_type: str) -> LinkCallbackType:
     elif link_type == "copy":
         return view_copy
 
-    assert False, "invalid link type"  # need mypy Literal values
+    assert False, "invalid link type"
 
 
 class FilesystemView:
@@ -166,7 +170,7 @@ class FilesystemView:
         projections: Optional[Dict] = None,
         ignore_conflicts: bool = False,
         verbose: bool = False,
-        link_type: str = "symlink",
+        link_type: LinkType = "symlink",
     ):
         """
         Initialize a filesystem view under the given `root` directory with
@@ -292,7 +296,7 @@ class YamlFilesystemView(FilesystemView):
         projections: Optional[Dict] = None,
         ignore_conflicts: bool = False,
         verbose: bool = False,
-        link_type: str = "symlink",
+        link_type: LinkType = "symlink",
     ):
         super().__init__(
             root,

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -25,6 +25,7 @@ import time
 import traceback
 import typing
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, TypeVar, Union
+from typing_extensions import Literal
 
 import llnl.util.filesystem as fsys
 import llnl.util.tty as tty
@@ -1009,10 +1010,8 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
                 return False
         return True
 
-    # NOTE: return type should be Optional[Literal['all', 'specific', 'none']] in
-    # Python 3.8+, but we still support 3.6.
     @property
-    def keep_werror(self) -> Optional[str]:
+    def keep_werror(self) -> Optional[Literal["all", "specific", "none"]]:
         """Keep ``-Werror`` flags, matches ``config:flags:keep_werror`` to override config.
 
         Valid return values are:

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -25,6 +25,7 @@ import time
 import traceback
 import typing
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, TypeVar, Union
+
 from typing_extensions import Literal
 
 import llnl.util.filesystem as fsys


### PR DESCRIPTION
Improve our typing by updating some todo locations in the code to use `Literal` instead of a simple `str`.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
