### PR TITLE
Drop neoverse_v1 from aws-isc-aarch stack

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/aws-isc-aarch64/spack.yaml
@@ -113,7 +113,6 @@ spack:
 
   - target:
     - target=aarch64
-    - target=neoverse_n1
 
 
   specs:


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Dropping this to move away from `graviton2` runners.