### PR TITLE
zlib-ng: add v2.2.2, v2.2.3

### DIFF
--- a/var/spack/repos/builtin/packages/zlib-ng/package.py
+++ b/var/spack/repos/builtin/packages/zlib-ng/package.py
@@ -19,6 +19,7 @@ class ZlibNg(AutotoolsPackage, CMakePackage):
 
     license("Zlib")
 
+    version("2.2.2", sha256="fcb41dd59a3f17002aeb1bb21f04696c9b721404890bb945c5ab39d2cb69654c")
     version("2.2.1", sha256="ec6a76169d4214e2e8b737e0850ba4acb806c69eeace6240ed4481b9f5c57cdf")
     version("2.1.7", sha256="59e68f67cbb16999842daeb517cdd86fc25b177b4affd335cd72b76ddc2a46d8")
     version("2.1.6", sha256="a5d504c0d52e2e2721e7e7d86988dec2e290d723ced2307145dedd06aeb6fef2")

--- a/var/spack/repos/builtin/packages/zlib-ng/package.py
+++ b/var/spack/repos/builtin/packages/zlib-ng/package.py
@@ -19,6 +19,7 @@ class ZlibNg(AutotoolsPackage, CMakePackage):
 
     license("Zlib")
 
+    version("2.2.3", sha256="f2fb245c35082fe9ea7a22b332730f63cf1d42f04d84fe48294207d033cba4dd")
     version("2.2.2", sha256="fcb41dd59a3f17002aeb1bb21f04696c9b721404890bb945c5ab39d2cb69654c")
     version("2.2.1", sha256="ec6a76169d4214e2e8b737e0850ba4acb806c69eeace6240ed4481b9f5c57cdf")
     version("2.1.7", sha256="59e68f67cbb16999842daeb517cdd86fc25b177b4affd335cd72b76ddc2a46d8")


### PR DESCRIPTION
This PR adds `zlib-ng`, v2.2.2, v2.2.3, bugfix releases (https://github.com/zlib-ng/zlib-ng/releases/tag/2.2.2, https://github.com/zlib-ng/zlib-ng/releases/tag/2.2.3). No build system changes.

Test build v2.2.2:
```
-- linux-ubuntu24.10-skylake / gcc@14.2.0 -----------------------
hvj4s2h zlib-ng@2.2.2+compat+new_strategies+opt+pic+shared build_system=autotools
==> 1 installed package
```

Test build v2.2.3:
```
-- linux-ubuntu24.10-skylake / gcc@14.2.0 -----------------------
f5tqdnw zlib-ng@2.2.3+compat+new_strategies+opt+pic+shared build_system=autotools
==> 1 installed package
```