### PR TITLE
findutils: add v4.10.0; faketime: new package

### DIFF
--- a/var/spack/repos/builtin/packages/faketime/package.py
+++ b/var/spack/repos/builtin/packages/faketime/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Faketime(MakefilePackage):
+    """libfaketime modifies the system time for a single application."""
+
+    homepage = "https://github.com/wolfcw/libfaketime"
+    url = "https://github.com/wolfcw/libfaketime/archive/refs/tags/v0.9.10.tar.gz"
+
+    maintainers("wdconinc")
+
+    license("GPL-2.0-only", checked_by="wdconinc")
+
+    version("0.9.10", sha256="729ad33b9c750a50d9c68e97b90499680a74afd1568d859c574c0fe56fe7947f")
+
+    depends_on("c", type="build")
+
+    def edit(self, spec, prefix):
+        for makefile in ["Makefile", "man/Makefile", "src/Makefile"]:
+            FileFilter(makefile).filter("PREFIX .=.*", f"PREFIX = {prefix}")

--- a/var/spack/repos/builtin/packages/findutils/package.py
+++ b/var/spack/repos/builtin/packages/findutils/package.py
@@ -28,6 +28,7 @@ class Findutils(AutotoolsPackage, GNUMirrorPackage):
 
     license("GPL-3.0-or-later")
 
+    version("4.10.0", sha256="1387e0b67ff247d2abde998f90dfbf70c1491391a59ddfecb8ae698789f0a4f5")
     version("4.9.0", sha256="a2bfb8c09d436770edc59f50fa483e785b161a3b7b9d547573cb08065fd462fe")
     version("4.8.0", sha256="57127b7e97d91282c6ace556378d5455a9509898297e46e10443016ea1387164")
     version("4.7.0", sha256="c5fefbdf9858f7e4feb86f036e1247a54c79fc2d8e4b7064d5aaa1f47dfa789a")
@@ -51,7 +52,13 @@ class Findutils(AutotoolsPackage, GNUMirrorPackage):
     version("4.1.20", sha256="8c5dd50a5ca54367fa186f6294b81ec7a365e36d670d9feac62227cb513e63ab")
     version("4.1", sha256="487ecc0a6c8c90634a11158f360977e5ce0a9a6701502da6cb96a5a7ec143fac")
 
-    depends_on("c", type="build")  # generated
+    depends_on("c", type="build")
+
+    depends_on("gettext", type="build")
+    depends_on("gettext@0.19.8:", type="build")
+
+    depends_on("faketime", when="@4.5.13:", type="test")
+    depends_on("python", when="@4.5.13:", type="test")
 
     # The NVIDIA compilers do not currently support some GNU builtins.
     # Detect this case and use the fallback path.


### PR DESCRIPTION
This PR adds `findutils`, v4.10.0. It turns out that `gettext` is required too. For testing, this requires `faketime` (new package) and `python` as of v4.5.13.