### PR TITLE
Improve package recipes for some HEP packages

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -174,32 +174,25 @@ class Dd4hep(CMakePackage):
             # However, with spack it is preferrable to have a proper external
             # dependency, so we disable it.
             self.define("DD4HEP_LOAD_ASSIMP", False),
-            "-DCMAKE_CXX_STANDARD={0}".format(cxxstd),
-            "-DBUILD_TESTING={0}".format(self.run_tests),
-            "-DBOOST_ROOT={0}".format(spec["boost"].prefix),
-            "-DBoost_NO_BOOST_CMAKE=ON",
+            self.define("CMAKE_CXX_STANDARD", cxxstd),
+            self.define("BUILD_TESTING", self.run_tests),
+            self.define("BOOST_ROOT", spec["boost"].prefix),
+            self.define("Boost_NO_BOOST_CMAKE", True),
         ]
-        subpackages = []
-        if spec.satisfies("+ddg4"):
-            subpackages += ["DDG4"]
-        if spec.satisfies("+ddcond"):
-            subpackages += ["DDCond"]
-        if spec.satisfies("+ddcad"):
-            subpackages += ["DDCAD"]
-        if spec.satisfies("+ddrec"):
-            subpackages += ["DDRec"]
-        if spec.satisfies("+dddetectors"):
-            subpackages += ["DDDetectors"]
-        if spec.satisfies("+ddalign"):
-            subpackages += ["DDAlign"]
-        if spec.satisfies("+dddigi"):
-            subpackages += ["DDDigi"]
-        if spec.satisfies("+ddeve"):
-            subpackages += ["DDEve"]
-        if spec.satisfies("+utilityapps"):
-            subpackages += ["UtilityApps"]
-        subpackages = " ".join(subpackages)
-        args += [self.define("DD4HEP_BUILD_PACKAGES", subpackages)]
+
+        packages = [
+            "DDG4",
+            "DDCond",
+            "DDCAD",
+            "DDRec",
+            "DDDetectors",
+            "DDAlign",
+            "DDDigi",
+            "DDEve",
+            "UtilityApps",
+        ]
+        enabled_packages = [p for p in packages if self.spec.variants[package.lower()]]
+        args.append(self.define("DD4HEP_BUILD_PACKAGES", " ".join(enabled_packages)))
         return args
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -191,7 +191,7 @@ class Dd4hep(CMakePackage):
             "DDEve",
             "UtilityApps",
         ]
-        enabled_packages = [p for p in packages if self.spec.variants[package.lower()]]
+        enabled_packages = [p for p in packages if self.spec.variants[package.lower()].value]
         args.append(self.define("DD4HEP_BUILD_PACKAGES", " ".join(enabled_packages)))
         return args
 

--- a/var/spack/repos/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/builtin/packages/edm4hep/package.py
@@ -92,12 +92,11 @@ class Edm4hep(CMakePackage):
     extends("python", when="@0.10.6:")
 
     def cmake_args(self):
-        args = []
-        # C++ Standard
-        args.append(self.define("CMAKE_CXX_STANDARD", self.spec.variants["cxxstd"].value))
-        args.append(self.define("BUILD_TESTING", self.run_tests))
-        if self.spec.satisfies("@0.99.2: +json"):
-            args.append(self.define_from_variant("EDM4HEP_WITH_JSON", "json"))
+        args = [
+            self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+            self.define("BUILD_TESTING", self.run_tests),
+            self.define_from_variant("EDM4HEP_WITH_JSON", "json"),
+        ]
         return args
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -167,8 +167,8 @@ class Gaudi(CMakePackage):
         # environment as in Gaudi.xenv
         env.prepend_path("PATH", self.prefix.scripts)
         env.prepend_path("PYTHONPATH", self.prefix.python)
-        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
-        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib64)
+        for d in self.libs.directories:
+            env.prepend_path("LD_LIBRARY_PATH", d)
 
     def url_for_version(self, version):
         major = str(version[0])

--- a/var/spack/repos/builtin/packages/opendatadetector/package.py
+++ b/var/spack/repos/builtin/packages/opendatadetector/package.py
@@ -31,8 +31,10 @@ class Opendatadetector(CMakePackage):
     depends_on("boost")
 
     def cmake_args(self):
-        args = []
-        args.append("-DCMAKE_CXX_STANDARD=%s" % self.spec["root"].variants["cxxstd"].value)
+        args = [
+            self.define("CMAKE_CXX_STANDARD",
+                        self.spec["root"].variants["cxxstd"].value),
+        ]
         return args
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/opendatadetector/package.py
+++ b/var/spack/repos/builtin/packages/opendatadetector/package.py
@@ -31,10 +31,7 @@ class Opendatadetector(CMakePackage):
     depends_on("boost")
 
     def cmake_args(self):
-        args = [
-            self.define("CMAKE_CXX_STANDARD",
-                        self.spec["root"].variants["cxxstd"].value),
-        ]
+        args = [self.define("CMAKE_CXX_STANDARD", self.spec["root"].variants["cxxstd"].value)]
         return args
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/opendatadetector/package.py
+++ b/var/spack/repos/builtin/packages/opendatadetector/package.py
@@ -36,5 +36,5 @@ class Opendatadetector(CMakePackage):
 
     def setup_run_environment(self, env):
         env.set("OPENDATADETECTOR_DATA", join_path(self.prefix.share, "OpenDataDetector"))
-        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
-        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib64)
+        for d in self.libs.directories:
+            env.prepend_path("LD_LIBRARY_PATH", d)


### PR DESCRIPTION
Following on to https://github.com/spack/spack/pull/37881#issuecomment-2549884646 I noticed a few places where the package recipes could use improvement: more standard use of `define` and `define_from_variant` , as well as some places where variant values/names can be directly used which is safer.

I ended up not changing any of the `LD_` to `ROOT_` since I don't know whether the packages *actually* can't load correctly without it (and I assume that would work only on Linux systems since that environment variable has no meaning on macos?)

@jmcarcell Since it seems that you've looked most carefully at the ROOT/LD question maybe you could help us understand where `ROOT_LIBRARY_PATH` would suffice?