### PR TITLE
verible: update install process and add v0.0.3864 and v0.0.3876

### DIFF
--- a/var/spack/repos/builtin/packages/verible/package.py
+++ b/var/spack/repos/builtin/packages/verible/package.py
@@ -35,6 +35,16 @@ class Verible(Package):
     version("master", branch="master")
 
     version(
+        "0.0.3876",
+        sha256="42b933b52cf394fa2cfcb841edb6cf3649f5453bf43178f8f630fc3e626f3e03",
+        url="https://github.com/chipsalliance/verible/archive/refs/tags/v0.0-3876-g2f99cdc9.tar.gz",
+    )
+    version(
+        "0.0.3864",
+        sha256="aa67a8f3f76828779d61ce35fedee0a9020a03214385c76abb18a7d4dabef081",
+        url="https://github.com/chipsalliance/verible/archive/refs/tags/v0.0-3864-g3d821c62.tar.gz",
+    )
+    version(
         "0.0.3841",
         sha256="fbc9cb32aa8a64ba60f24dc89e8573c8ea62c45d76113a0f2ab5b73babed5990",
         url="https://github.com/chipsalliance/verible/archive/refs/tags/v0.0-3841-g5eb8aa34.tar.gz",
@@ -95,6 +105,14 @@ class Verible(Package):
 
     conflicts("%gcc@:8", msg="Only works with gcc9 and above")
 
+    @when("@:0.0.3841")
     def install(self, spec, prefix):
         bazel("build", "-c", "opt", "//...")
         bazel("run", "-c", "opt", ":install", "--", prefix.bin)
+
+    @when("@0.0.3841:")
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        bash = which("bash")
+        bazel("build", "-c", "opt", ":install-binaries")
+        bash(".github/bin/simple-install.sh", prefix.bin)


### PR DESCRIPTION
Install process has been changed, made simpler, updated to handle the new way for new versions start after v0.0.3841. Also added versions v0.0.3864 and v0.0.3876
