### PR TITLE
ci: Disable broken specs list

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/ci.yaml
@@ -5,8 +5,6 @@ ci:
     - superlu-dist    # srun -n 4 hangs
     - papyrus
 
-  broken-specs-url: "https://dummy.io" # s3://spack-binaries/broken-specs"
-
   pipeline-gen:
   - build-job:
       before_script-:


### PR DESCRIPTION
Configuring the `broken-specs-url` to a phony value tells gitlab ci to please make requests to that url multiple times per pipeline.  Let's not do that, since these requests are doomed to fail and waste time, or even sometimes cause a job that successfully built and pushed a buildcache to fail:

https://gitlab.spack.io/spack/spack/-/jobs/14300953
