### PR TITLE
Move allocation override to the generate job

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -363,11 +363,12 @@ e4s-oneapi-build:
   extends: [".linux_power"]
   variables:
     SPACK_CI_STACK_NAME: e4s-power
-    # Override concretization pool for metal runners
-    SPACK_CONCRETIZE_JOBS: 16
 
 e4s-power-generate:
   extends: [ ".e4s-power", ".generate-x86_64", ".e4s-power-generate-tags-and-image"]
+  variables:
+    # Override concretization pool for metal runners
+    SPACK_CONCRETIZE_JOBS: 16
 
 e4s-power-build:
   extends: [ ".e4s-power", ".build" ]


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Try moving the parallel concretize override to the power generate job directly. Override in `extends` not working as expected.