### PR TITLE
hpl: build v2.3 with timers

### DIFF
--- a/var/spack/repos/builtin/packages/hpl/package.py
+++ b/var/spack/repos/builtin/packages/hpl/package.py
@@ -49,8 +49,7 @@ class Hpl(AutotoolsPackage):
     def force_autoreconf(self):
         return self.version == Version("2.3")
 
-    @when("@=2.3")
-    @run_before("autoreconf")
+    @run_before("autoreconf", when="@=2.3")
     def add_timer_to_libhpl(self):
         # Add HPL_timer_walltime to libhpl.a
         filter_file(

--- a/var/spack/repos/builtin/packages/hpl/package.py
+++ b/var/spack/repos/builtin/packages/hpl/package.py
@@ -30,14 +30,6 @@ class Hpl(AutotoolsPackage):
     depends_on("mpi@1.1:")
     depends_on("blas")
 
-    with when("@=2.3"):
-        depends_on("autoconf-archive", type="build")  # AX_PROG_CC_MPI
-        depends_on("autoconf", type="build")
-        depends_on("automake", type="build")
-        depends_on("m4", type="build")
-        depends_on("libtool", type="build")
-        force_autoreconf = True
-
     # 2.3 adds support for openmpi 4
     conflicts("^openmpi@4.0.0:", when="@:2.2")
 
@@ -45,6 +37,17 @@ class Hpl(AutotoolsPackage):
 
     arch = "{0}-{1}".format(platform.system(), platform.processor())
     build_targets = ["arch={0}".format(arch)]
+
+    with when("@=2.3"):
+        depends_on("autoconf-archive", type="build")  # AX_PROG_CC_MPI
+        depends_on("autoconf", type="build")
+        depends_on("automake", type="build")
+        depends_on("m4", type="build")
+        depends_on("libtool", type="build")
+
+    @property
+    def force_autoreconf(self):
+        return self.version == Version("2.3")
 
     @when("@=2.3")
     @run_before("autoreconf")

--- a/var/spack/repos/builtin/packages/hpl/package.py
+++ b/var/spack/repos/builtin/packages/hpl/package.py
@@ -31,7 +31,7 @@ class Hpl(AutotoolsPackage):
     depends_on("blas")
 
     with when("@=2.3"):
-        depends_on("autoconf-archive", type="build") # AX_PROG_CC_MPI
+        depends_on("autoconf-archive", type="build")  # AX_PROG_CC_MPI
         depends_on("autoconf", type="build")
         depends_on("automake", type="build")
         depends_on("m4", type="build")
@@ -50,7 +50,9 @@ class Hpl(AutotoolsPackage):
     @run_before("autoreconf")
     def add_timer_to_libhpl(self):
         # Add HPL_timer_walltime to libhpl.a
-        filter_file(r"(pgesv/HPL_perm.c)$", r"\1 ../testing/timer/HPL_timer_walltime.c", "src/Makefile.am")
+        filter_file(
+            r"(pgesv/HPL_perm.c)$", r"\1 ../testing/timer/HPL_timer_walltime.c", "src/Makefile.am"
+        )
 
     @when("@:2.2")
     def autoreconf(self, spec, prefix):


### PR DESCRIPTION
Building hpl 2.3 with autotools instead of Makefiles breaks when trying to add timers to the build.

This PR patches `libhpl.a` to include the missing `HPL_timer_walltime` dependency.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
