### PR TITLE
Check path existence before tempfile creation

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -344,8 +344,6 @@ def filter_file(
         regex = re.escape(regex)
     regex_compiled = re.compile(regex)
     for path in path_to_os_path(*filenames):
-        fd, temp_path = tempfile.mkstemp(prefix=os.path.basename(path), dir=os.path.dirname(path))
-        os.close(fd)
 
         if ignore_absent and not os.path.exists(path):
             tty.debug(f'FILTER FILE: file "{path}" not found. Skipping to next file.')
@@ -353,6 +351,9 @@ def filter_file(
         else:
             tty.debug(f'FILTER FILE: {path} [replacing "{regex}"]')
 
+        fd, temp_path = tempfile.mkstemp(prefix=os.path.basename(path), dir=os.path.dirname(path))
+        os.close(fd)
+        
         shutil.copy(path, temp_path)
         errored = False
 


### PR DESCRIPTION
Fixes #48410 by only creating the temporary file after the existence of the path has been checked when `ignore_absent` is `True` 