### PR TITLE
gaudi: touch pytest.ini

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -138,6 +138,11 @@ class Gaudi(CMakePackage):
     # The Intel VTune dependency is taken aside because it requires a license
     depends_on("intel-parallel-studio -mpi +vtune", when="+vtune")
 
+    def patch(self):
+        # ensure an empty pytest.ini is present to prevent finding one
+        # accidentally in a higher directory than the stage directory
+        touch("pytest.ini")
+
     def cmake_args(self):
         args = [
             # Note: gaudi only builds examples when testing enabled


### PR DESCRIPTION
This PR fixes (hopefully) an issue in CI where `pytest.ini` in `/builds/spack/spack` is found, causing failures in a gaudi test that shouldn't have been considered as one.