### PR TITLE
Request 35G of memory for building composable-kernel

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/linux/ci.yaml
@@ -18,6 +18,7 @@ ci:
           KUBERNETES_MEMORY_REQUEST: 48G
 
     - match:
+      - composable-kernel
       - rust
       build-job:
         tags: [ "spack", "huge" ]


### PR DESCRIPTION
This number was determined from the max memory usage recently recorded for this package in our analytics database.