### PR TITLE
bugfix/r: git property needs to be classproperty

### DIFF
--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -95,7 +95,7 @@ class RPackage(Package):
         if cls.cran:
             return f"https://cloud.r-project.org/src/contrib/Archive/{cls.cran}/"
 
-    @property
-    def git(self):
-        if self.bioc:
-            return f"https://git.bioconductor.org/packages/{self.bioc}"
+    @lang.classproperty
+    def git(cls):
+        if cls.bioc:
+            return f"https://git.bioconductor.org/packages/{cls.bioc}"


### PR DESCRIPTION
I was unable to confirm or stage commits for #48154 until I made the `r` implementation of `git` a class property. This change makes that method consistent with the rest of the properties in `r.py`.