### PR TITLE
Updates to AMR-Wind: adding new releases and an option to enable new spec option

### DIFF
--- a/var/spack/repos/builtin/packages/amr-wind/package.py
+++ b/var/spack/repos/builtin/packages/amr-wind/package.py
@@ -21,6 +21,11 @@ class AmrWind(CMakePackage, CudaPackage, ROCmPackage):
     license("BSD-3-Clause")
 
     version("main", branch="main", submodules=True)
+    version("3.3.1", tag="v3.3.1", submodules=True)
+    version("3.3.0", tag="v3.3.0", submodules=True)
+    version("3.2.3", tag="v3.2.3", submodules=True)
+    version("3.2.2", tag="v3.2.2", submodules=True)
+    version("3.2.1", tag="v3.2.1", submodules=True)
     version("3.2.0", tag="v3.2.0", submodules=True)
     version("3.1.7", tag="v3.1.7", submodules=True)
     version("3.1.6", tag="v3.1.6", submodules=True)

--- a/var/spack/repos/builtin/packages/amr-wind/package.py
+++ b/var/spack/repos/builtin/packages/amr-wind/package.py
@@ -82,6 +82,7 @@ class AmrWind(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "waves2amr", default=False, description="Enable Waves2AMR support for ocean wave input"
     )
+    variant("fftw", default=False, description="Enable FFT support for MAC projection")
 
     depends_on("mpi", when="+mpi")
     depends_on("hdf5~mpi", when="+hdf5~mpi")
@@ -107,6 +108,7 @@ class AmrWind(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("helics@:3.3.2", when="+helics")
     depends_on("helics@:3.3.2+mpi", when="+helics+mpi")
     depends_on("fftw", when="@2.1: +waves2amr")
+    depends_on("fftw", when="@3.3.1: +fftw")
 
     for arch in CudaPackage.cuda_arch_values:
         depends_on("hypre+cuda cuda_arch=%s" % arch, when="+cuda+hypre cuda_arch=%s" % arch)
@@ -176,6 +178,9 @@ class AmrWind(CMakePackage, CudaPackage, ROCmPackage):
         if spec.satisfies("+waves2amr"):
             args.append(self.define_from_variant("AMR_WIND_ENABLE_W2A", "waves2amr"))
             args.append(define("FFTW_DIR", spec["fftw"].prefix))
+
+        if spec.satisfies("+fftw"):
+            args.append(define("AMR_WIND_ENABLE_FFT", True))
 
         if spec.satisfies("+sycl"):
             args.append(define("AMR_WIND_ENABLE_SYCL", True))

--- a/var/spack/repos/builtin/packages/amr-wind/package.py
+++ b/var/spack/repos/builtin/packages/amr-wind/package.py
@@ -82,7 +82,7 @@ class AmrWind(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "waves2amr", default=False, description="Enable Waves2AMR support for ocean wave input"
     )
-    variant("fftw", default=False, description="Enable FFT support for MAC projection")
+    variant("fft", default=False, description="Enable FFT support for MAC projection")
 
     depends_on("mpi", when="+mpi")
     depends_on("hdf5~mpi", when="+hdf5~mpi")
@@ -108,7 +108,7 @@ class AmrWind(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("helics@:3.3.2", when="+helics")
     depends_on("helics@:3.3.2+mpi", when="+helics+mpi")
     depends_on("fftw", when="@2.1: +waves2amr")
-    depends_on("fftw", when="@3.3.1: +fftw")
+    depends_on("fftw", when="@3.3.1: +fft")
 
     for arch in CudaPackage.cuda_arch_values:
         depends_on("hypre+cuda cuda_arch=%s" % arch, when="+cuda+hypre cuda_arch=%s" % arch)
@@ -144,6 +144,10 @@ class AmrWind(CMakePackage, CudaPackage, ROCmPackage):
             "rocm",
             "tests",
             "tiny_profile",
+            "fft",
+            "helics",
+            "umpire",
+            "sycl",
         ]
         args = [self.define_from_variant("AMR_WIND_ENABLE_%s" % v.upper(), v) for v in vs]
 
@@ -168,22 +172,19 @@ class AmrWind(CMakePackage, CudaPackage, ROCmPackage):
             args.append("-DAMReX_AMD_ARCH=" + ";".join(str(x) for x in targets))
 
         if spec.satisfies("+umpire"):
-            args.append(self.define_from_variant("AMR_WIND_ENABLE_UMPIRE", "umpire"))
             args.append(define("UMPIRE_DIR", spec["umpire"].prefix))
 
         if spec.satisfies("+helics"):
-            args.append(self.define_from_variant("AMR_WIND_ENABLE_HELICS", "helics"))
             args.append(define("HELICS_DIR", spec["helics"].prefix))
 
         if spec.satisfies("+waves2amr"):
             args.append(self.define_from_variant("AMR_WIND_ENABLE_W2A", "waves2amr"))
             args.append(define("FFTW_DIR", spec["fftw"].prefix))
 
-        if spec.satisfies("+fftw"):
-            args.append(define("AMR_WIND_ENABLE_FFT", True))
+        if spec.satisfies("+fft"):
+            args.append(define("FFTW_DIR", spec["fftw"].prefix))
 
         if spec.satisfies("+sycl"):
-            args.append(define("AMR_WIND_ENABLE_SYCL", True))
             requires(
                 "%dpcpp",
                 "%oneapi",


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
This PR :

1. Adds new releases for AMR-Wind
2. Adds option to have FFT based MAC projections with `+fftw`