### PR TITLE
[WIP] Assess unit tests sans builtin package repository

### DIFF
--- a/lib/spack/spack/bootstrap/clingo.py
+++ b/lib/spack/spack/bootstrap/clingo.py
@@ -146,6 +146,7 @@ class ClingoBootstrapConcretizer:
         return self._external_spec(result)
 
     def _external_spec(self, initial_spec) -> "spack.spec.Spec":
+        #TODO: Does this need to be changed?
         initial_spec.namespace = "builtin"
         initial_spec.compiler = self.host_compiler.spec
         initial_spec.architecture = self.host_architecture

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -958,6 +958,7 @@ class PackageBase(WindowsRPath, PackageViewMixin, metaclass=PackageMeta):
             namespace = getattr(cls, "namespace", None)
             if namespace:
                 fullnames.append("%s.%s" % (namespace, cls.name))
+            #TODO: Does this need to be changed?
             if namespace == "builtin":
                 # builtin packages cannot inherit from other repos
                 break

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -58,7 +58,10 @@ var_path = os.path.join(prefix, "var", "spack")
 
 # read-only things in $spack/var/spack
 repos_path = os.path.join(var_path, "repos")
+
+#TODO: How do we want to replace this?
 packages_path = os.path.join(repos_path, "builtin")
+
 mock_packages_path = os.path.join(repos_path, "builtin.mock")
 
 #

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -57,7 +57,7 @@ def python_package_for_repo(namespace):
 
     For instance:
 
-        python_package_for_repo('builtin') == 'spack.pkg.builtin'
+        python_package_for_repo('builtin.mock') == 'spack.pkg.builtin.mock'
 
     Args:
         namespace (str): repo namespace
@@ -70,7 +70,7 @@ def namespace_from_fullname(fullname):
 
     For instance:
 
-        namespace_from_fullname('spack.pkg.builtin.hdf5') == 'builtin'
+        namespace_from_fullname('spack.pkg.builtin.mock.hdf5') == 'builtin.mock'
 
     Args:
         fullname (str): full name for the Python module
@@ -183,7 +183,10 @@ def packages_path():
     try:
         return PATH.get_repo("builtin.mock").packages_path
     except UnknownNamespaceError:
-        return PATH.get_repo("builtin").packages_path
+        #TODO: Replace this with the approach needed to ensure using the new
+        #TODO: built-in repository option
+        #return PATH.get_repo("builtin").packages_path
+        return None
 
 
 class GitExe:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2266,6 +2266,7 @@ class Spec:
             )
         return d
 
+    #TODO: Does the example namespace need to change from builtin?
     def to_dict(self, hash=ht.dag_hash):
         """Create a dictionary suitable for writing this spec to YAML or JSON.
 

--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -114,7 +114,7 @@ _double_compiler_definition = [
         ),
     ],
 )
-def test_config_audits(config_section, data, failing_check):
+def test_config_audits(config_section, data, failing_check, mock_packages):
     with spack.config.override(config_section, data):
         reports = spack.audit.run_group("configs")
         assert any((check == failing_check) and errors for check, errors in reports)

--- a/var/spack/repos/builtin.mock/packages/openssl/package.py
+++ b/var/spack/repos/builtin.mock/packages/openssl/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Openssl(Package):
+    version("3.4.0")
+
+    #variant("internal-hwloc", default=False)
+    #variant("fabrics", values=any_combination_of("psm", "mxm"))
+
+    #depends_on("hwloc", when="~internal-hwloc")


### PR DESCRIPTION
Investigation related to #47480 

This PR is being used to identify changes needed to support core unit tests. When reasonable, changes are made to the unit tests as if `builtin` packages are no longer in the repository.
