### PR TITLE
Update ectrans: add conflict for versions 1.5.x with oneapi@2025:

### DIFF
--- a/var/spack/repos/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/builtin/packages/ectrans/package.py
@@ -60,7 +60,7 @@ class Ectrans(CMakePackage):
     depends_on("fiat+mpi", when="+mpi")
 
     # https://github.com/ecmwf-ifs/ectrans/issues/194
-    conflicts("%oneapi@2025:", when="@1.5.0:1.5.1")
+    conflicts("%oneapi@2025:", when="@1.3.1:1.5.1")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/ectrans/package.py
+++ b/var/spack/repos/builtin/packages/ectrans/package.py
@@ -59,6 +59,9 @@ class Ectrans(CMakePackage):
     depends_on("fiat~mpi", when="~mpi")
     depends_on("fiat+mpi", when="+mpi")
 
+    # https://github.com/ecmwf-ifs/ectrans/issues/194
+    conflicts("%oneapi@2025:", when="@1.5.0:1.5.1")
+
     def cmake_args(self):
         args = [
             self.define_from_variant("ENABLE_MPI", "mpi"),


### PR DESCRIPTION
See https://github.com/ecmwf-ifs/ectrans/issues/194. According to the conversation there, the next release 1.6.0 will have the update to build with `oneapi@2025:`
