### PR TITLE
Fix import error in CI log aggregation script

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/scripts/common/aggregate_package_logs.spack.py
+++ b/share/spack/gitlab/cloud_pipelines/scripts/common/aggregate_package_logs.spack.py
@@ -6,7 +6,7 @@ This script is meant to be run using:
 
 import os
 
-from llnl.util.tty import tty
+from llnl.util import tty
 
 
 def find_logs(prefix, filename):


### PR DESCRIPTION
The CI log aggregation script is currently failing due to an import error.

Example jobs:
https://gitlab.spack.io/spack/spack/-/jobs/14324449
https://gitlab.spack.io/spack/spack/-/jobs/14324452 
https://gitlab.spack.io/spack/spack/-/jobs/14324811

It looks like the cause is an invalid import statement added in #48145; this PR fixes it.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
