### PR TITLE
gsoap: depends_on autoconf etc type build

### DIFF
--- a/var/spack/repos/builtin/packages/gsoap/package.py
+++ b/var/spack/repos/builtin/packages/gsoap/package.py
@@ -46,6 +46,10 @@ class Gsoap(AutotoolsPackage, SourceforgePackage):
     depends_on("pkgconfig", type="build")
     depends_on("bison", type="build")
     depends_on("flex", type="build")
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
 
     def configure_args(self):
         return ["--enable-ipv6"]


### PR DESCRIPTION
This PR adds to `gsoap` the build dependencies `automake`, etc, since they appear necessary. Fixes #48240.

Test build in codespaces:
```
==> Installing gsoap-2.8.135-i6k5zlhmu45mr35xoqyyct2uoyhwtm6v [30/30]
==> No binary for gsoap-2.8.135-i6k5zlhmu45mr35xoqyyct2uoyhwtm6v found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/b1/b11757e405d55d4674dfbf88c4fa6d7e24155cf64ed8ed578ccad2f2b555e98d.zip
==> No patches needed for gsoap
==> gsoap: Executing phase: 'autoreconf'
==> gsoap: Executing phase: 'configure'
==> gsoap: Executing phase: 'build'
==> gsoap: Executing phase: 'install'
==> gsoap: Successfully installed gsoap-2.8.135-i6k5zlhmu45mr35xoqyyct2uoyhwtm6v
  Stage: 2.07s.  Autoreconf: 0.00s.  Configure: 9.05s.  Build: 35.75s.  Install: 0.32s.  Post-install: 0.09s.  Total: 47.59s
[+] /workspaces/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.4.0/gsoap-2.8.135-i6k5zlhmu45mr35xoqyyct2uoyhwtm6v
```
