### PR TITLE
Fix used ~/.spack when SPACK_DISABLE_LOCAL_CONFIG=1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 ##########################
 
 /var/spack/stage
+/var/spack/bootstrap
 /var/spack/cache
 /var/spack/environments
 /var/spack/repos/*/index.yaml

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -86,7 +86,10 @@ gpg_path = os.path.join(opt_path, "spack", "gpg")
 # setting `SPACK_USER_CACHE_PATH`. Otherwise it defaults to ~/.spack.
 #
 def _get_user_cache_path():
-    return os.path.expanduser(os.getenv("SPACK_USER_CACHE_PATH") or "~%s.spack" % os.sep)
+    default_cache_path = (
+        var_path if "SPACK_DISABLE_LOCAL_CONFIG" in os.environ else "~%s.spack" % os.sep
+    )
+    return os.path.expanduser(os.getenv("SPACK_USER_CACHE_PATH") or default_cache_path)
 
 
 user_cache_path = str(PurePath(_get_user_cache_path()))


### PR DESCRIPTION
# Issue

I suppose the intention of `SPACK_DISABLE_LOCAL_CONFIG` is to provide an isolated spack environment.

However, when working on multiple spack instances, switching between them, all used with `export SPACK_DISABLE_LOCAL_CONFIG=1` set
- found strange bug with only mention of `<package_name> cannot satisfy gcc@13.3.0` which is obviously wrong
- strace isolated to `~/.spack/cache/compilers/compilers.json`

In fact, the error is due to some non-working compiler in other instances, led to null in some cached compiler output, and concretizer consider the compiler not working.


## Patch 

This is a simple patch that fixes
- setting `SPACK_DISABLE_LOCAL_CONFIG=1` still depends on some directory other than `$SPACK_ROOT` and `$TMPDIR`

Noted the `TODO: make $spack/var/spack read-only`, this patch will move the cache directory together with moving of writable `$spack/var/spack`.

## Aside
For the todo, I suggest to use e.g. `$spack/{dist,build,generated}`, or a new gitignored folder at `$spack` to centralize writables.

`./dist ./build ./generated` etc. are conventionally to indicate generated artifacts that is not a part of the original source code, while another folder for persistent configs / built apps may be preferred.