### PR TITLE
ci: add compiler toolchain stacks: {aarch64,x86_64_v3}-linux-gnu

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -474,6 +474,54 @@ developer-tools-darwin-build:
     - artifacts: True
       job: developer-tools-darwin-generate
 
+###########################################
+# Compilers
+###########################################
+.compilers-x86_64_v3-linux-gnu:
+  extends: [ ".linux_x86_64_v3" ]
+  variables:
+    SPACK_CI_STACK_NAME: compilers-x86_64_v3-linux-gnu
+
+compilers-x86_64_v3-linux-gnu-generate:
+  extends: [ ".compilers-x86_64_v3-linux-gnu", ".generate-x86_64"]
+  image:  ghcr.io/spack/x86_64_v3-linux-gnu:2024-12-12
+
+compilers-x86_64_v3-linux-gnu-build:
+  extends: [ ".compilers-x86_64_v3-linux-gnu", ".build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: compilers-x86_64_v3-linux-gnu-generate
+    strategy: depend
+  needs:
+    - artifacts: True
+      job: compilers-x86_64_v3-linux-gnu-generate
+
+###########################################
+# Compilers
+# aarch64
+###########################################
+.compilers-aarch64-linux-gnu:
+  extends: [ ".linux_aarch64" ]
+  variables:
+    SPACK_CI_STACK_NAME: compilers-aarch64-linux-gnu
+
+compilers-aarch64-linux-gnu-generate:
+  extends: [ ".compilers-aarch64-linux-gnu", ".generate-aarch64"]
+  image:  ghcr.io/spack/aarch64-linux-gnu:v2024-12-18
+
+compilers-aarch64-linux-gnu-build:
+  extends: [ ".compilers-aarch64-linux-gnu", ".build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: compilers-aarch64-linux-gnu-generate
+    strategy: depend
+  needs:
+    - artifacts: True
+      job: compilers-aarch64-linux-gnu-generate
+
+
 #########################################
 # RADIUSS
 #########################################

--- a/share/spack/gitlab/cloud_pipelines/stacks/compilers-aarch64-linux-gnu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/compilers-aarch64-linux-gnu/spack.yaml
@@ -4,7 +4,7 @@ spack:
     all:
       require: '%gcc target=aarch64'
   concretizer:
-    unify: true
+    unify: when_possible
     reuse: false
 
   specs:

--- a/share/spack/gitlab/cloud_pipelines/stacks/compilers-aarch64-linux-gnu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/compilers-aarch64-linux-gnu/spack.yaml
@@ -1,0 +1,22 @@
+spack:
+  view: false
+  packages:
+    all:
+      require: '%gcc target=aarch64'
+  concretizer:
+    unify: true
+    reuse: false
+
+  specs:
+  - gcc@13:13.9
+  - gcc@14:14.9
+  - llvm@18:18.9
+  - llvm@19:19.9 +flang
+
+  ci:
+    pipeline-gen:
+    - build-job:
+        image: ghcr.io/spack/aarch64-linux-gnu:v2024-12-18
+
+  cdash:
+    build-group: Developer Tools aarch64-linux-gnu

--- a/share/spack/gitlab/cloud_pipelines/stacks/compilers-x86_64_v3-linux-gnu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/compilers-x86_64_v3-linux-gnu/spack.yaml
@@ -1,0 +1,24 @@
+spack:
+  view: false
+  packages:
+    all:
+      require: '%gcc target=x86_64_v3'
+  concretizer:
+    unify: true
+    reuse: false
+
+  specs:
+  - gcc@11:11.9
+  - gcc@12:12.9
+  - gcc@13:13.9
+  - gcc@14:14.9
+  - llvm@18:18.9
+  - llvm@19:19.9 +flang
+
+  ci:
+    pipeline-gen:
+    - build-job:
+        image: ghcr.io/spack/x86_64_v3-linux-gnu:2024-12-12
+
+  cdash:
+    build-group: Developer Tools x86_64_v3-linux-gnu

--- a/share/spack/gitlab/cloud_pipelines/stacks/compilers-x86_64_v3-linux-gnu/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/compilers-x86_64_v3-linux-gnu/spack.yaml
@@ -4,7 +4,7 @@ spack:
     all:
       require: '%gcc target=x86_64_v3'
   concretizer:
-    unify: true
+    unify: when_possible
     reuse: false
 
   specs:


### PR DESCRIPTION
Let's build some compilers in CI? Maybe this should go into the respective `developer-tools` stacks, or else maybe we should use the concrete-environment include feature to include the developer stacks here? Thoughts @kwryankrattiger @haampie @trws ?