### PR TITLE
jsoncpp: add v1.9.6

### DIFF
--- a/var/spack/repos/builtin/packages/jsoncpp/package.py
+++ b/var/spack/repos/builtin/packages/jsoncpp/package.py
@@ -20,6 +20,7 @@ class Jsoncpp(CMakePackage, MesonPackage):
 
     license("Public-Domain")
 
+    version("1.9.6", sha256="f93b6dd7ce796b13d02c108bc9f79812245a82e577581c4c9aabe57075c90ea2")
     version("1.9.5", sha256="f409856e5920c18d0c2fb85276e24ee607d2a09b5e7d5f0a371368903c275da2")
     version("1.9.4", sha256="e34a628a8142643b976c7233ef381457efad79468c67cb1ae0b83a33d7493999")
     version("1.9.3", sha256="8593c1d69e703563d94d8c12244e2e18893eeb9a8a9f8aa3d09a327aa45c8f7d")
@@ -57,6 +58,7 @@ class Jsoncpp(CMakePackage, MesonPackage):
 
     with when("build_system=meson"):
         depends_on("meson@0.49.0:", type="build")
+        depends_on("meson@0.56.0:", type="build", when="@1.9.6:")
 
     depends_on("python", type="test")
 


### PR DESCRIPTION
This PR adds `jsoncpp`, v1.9.6 ([diff](https://github.com/open-source-parsers/jsoncpp/compare/1.9.5...1.9.6)). No changes to CMake build. Meson build requires more recent version, and supports now `default_library` parsing (but default of `shared` is what the CMake build does, so no change needed).

Test build:
```
==> Installing jsoncpp-1.9.6-6sm6utf75hdqm3fiyygx2f4reeq3zyrb [10/10]
==> No binary for jsoncpp-1.9.6-6sm6utf75hdqm3fiyygx2f4reeq3zyrb found: installing from source
==> Fetching https://github.com/open-source-parsers/jsoncpp/archive/1.9.6.tar.gz
==> No patches needed for jsoncpp
==> jsoncpp: Executing phase: 'cmake'
==> jsoncpp: Executing phase: 'build'
==> jsoncpp: Executing phase: 'install'
==> jsoncpp: Successfully installed jsoncpp-1.9.6-6sm6utf75hdqm3fiyygx2f4reeq3zyrb
  Stage: 0.81s.  Cmake: 1.47s.  Build: 1.81s.  Install: 0.18s.  Post-install: 0.25s.  Total: 4.99s
[+] /project/6041615/spack/opt/spack/linux-almalinux8-skylake_avx512/gcc-8.5.0/jsoncpp-1.9.6-6sm6utf75hdqm3fiyygx2f4reeq3zyrb
```