### PR TITLE
thepeg: restrict rivet versions; evtgen: new variant sherpa

### DIFF
--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -33,7 +33,7 @@ class Evtgen(CMakePackage):
     variant("pythia8", default=True, description="Build with pythia8")
     variant("tauola", default=False, description="Build with tauola")
     variant("photos", default=False, description="Build with photos")
-    variant("sherpa", defualt=False, description="build with sherpa")
+    variant("sherpa", default=False, description="build with sherpa")
     variant("hepmc3", default=False, description="Link with hepmc3 (instead of hepmc)")
 
     patch("g2c.patch", when="@01.07.00")

--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -16,6 +16,8 @@ class Evtgen(CMakePackage):
 
     maintainers("vvolkl")
 
+    version("02.02.03", sha256="b642700b703190e3304edb98ff464622db5d03c1cfc5d275ba4a628227d7d6d0")
+    version("02.02.02", sha256="e543d1213cd5003124139d0dc7eee9247b0b9d44154ff8a88bac52ba91c5dfc9")
     version("02.02.01", sha256="1fcae56c6b27b89c4a2f4b224d27980607442185f5570e961f6334a3543c6e77")
     version("02.02.00", sha256="0c626e51cb17e799ad0ffd0beea5cb94d7ac8a5f8777b746aa1944dd26071ecf")
     version("02.00.00", sha256="02372308e1261b8369d10538a3aa65fe60728ab343fcb64b224dac7313deb719")
@@ -31,6 +33,7 @@ class Evtgen(CMakePackage):
     variant("pythia8", default=True, description="Build with pythia8")
     variant("tauola", default=False, description="Build with tauola")
     variant("photos", default=False, description="Build with photos")
+    variant("sherpa", defualt=False, description="build with sherpa")
     variant("hepmc3", default=False, description="Link with hepmc3 (instead of hepmc)")
 
     patch("g2c.patch", when="@01.07.00")
@@ -44,6 +47,8 @@ class Evtgen(CMakePackage):
     depends_on("photos~hepmc3", when="+photos~hepmc3")
     depends_on("tauola+hepmc3", when="+tauola+hepmc3")
     depends_on("photos+hepmc3", when="+photos+hepmc3")
+    depends_on("sherpa@2:", when="@02.02.01: +sherpa")
+    depends_on("sherpa@:2", when="@:02 +sherpa")
 
     conflicts(
         "^pythia8+evtgen",
@@ -71,6 +76,7 @@ class Evtgen(CMakePackage):
         args.append(self.define_from_variant("EVTGEN_PYTHIA", "pythia8"))
         args.append(self.define_from_variant("EVTGEN_TAUOLA", "tauola"))
         args.append(self.define_from_variant("EVTGEN_PHOTOS", "photos"))
+        args.append(self.define_from_variant("EVTGEN_SHERPA", "sherpa"))
         args.append(self.define_from_variant("EVTGEN_HEPMC3", "hepmc3"))
 
         return args

--- a/var/spack/repos/builtin/packages/herwig3/package.py
+++ b/var/spack/repos/builtin/packages/herwig3/package.py
@@ -35,6 +35,10 @@ class Herwig3(AutotoolsPackage):
     depends_on("thepeg@2.2.3", when="@7.2.3")
     depends_on("thepeg@2.3.0", when="@7.3.0")
     depends_on("evtgen")
+    conflicts(
+        "evtgen ~photos ~pythia8 ~sherpa ~tauola",
+        msg="At least one external EvtGen component required",
+    )
 
     depends_on("boost +math+test")
     depends_on("python", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/herwig3/package.py
+++ b/var/spack/repos/builtin/packages/herwig3/package.py
@@ -36,7 +36,7 @@ class Herwig3(AutotoolsPackage):
     depends_on("thepeg@2.3.0", when="@7.3.0")
     depends_on("evtgen")
     conflicts(
-        "evtgen ~photos ~pythia8 ~sherpa ~tauola",
+        "^evtgen ~photos ~pythia8 ~sherpa ~tauola",
         msg="At least one external EvtGen component required",
     )
 

--- a/var/spack/repos/builtin/packages/thepeg/package.py
+++ b/var/spack/repos/builtin/packages/thepeg/package.py
@@ -70,8 +70,9 @@ class Thepeg(AutotoolsPackage):
     depends_on("hepmc3", when="hepmc=3")
     conflicts("hepmc=3", when="@:2.1", msg="HepMC3 support was added in 2.2.0")
     depends_on("fastjet", when="@2.0.0:")
-    depends_on("rivet@:3 hepmc=2", when="@2.0.3: +rivet hepmc=2")
-    depends_on("rivet@:3 hepmc=3", when="@2.0.3: +rivet hepmc=3")
+    depends_on("rivet hepmc=2", when="@2.0.3: +rivet hepmc=2")
+    depends_on("rivet hepmc=3", when="@2.0.3: +rivet hepmc=3")
+    depends_on("rivet@:3", when"@:2.2 +rivet")
     depends_on("boost +test", when="@2.1.1:")
 
     depends_on("autoconf", type="build")

--- a/var/spack/repos/builtin/packages/thepeg/package.py
+++ b/var/spack/repos/builtin/packages/thepeg/package.py
@@ -72,7 +72,7 @@ class Thepeg(AutotoolsPackage):
     depends_on("fastjet", when="@2.0.0:")
     depends_on("rivet hepmc=2", when="@2.0.3: +rivet hepmc=2")
     depends_on("rivet hepmc=3", when="@2.0.3: +rivet hepmc=3")
-    depends_on("rivet@:3", when"@:2.2 +rivet")
+    depends_on("rivet@:3", when="@:2.2 +rivet")
     depends_on("boost +test", when="@2.1.1:")
 
     depends_on("autoconf", type="build")


### PR DESCRIPTION
This PR adds that `thepeg` v2.3.0 [has support](https://phab.hepforge.org/rTHEPEGHG25282f2d81357b9dcc0dca6d18edd8df405a7b58) for `rivet` v4. This also ensures at least one external component for `evtgen` is included since `herwig3` detects the presence of `libEvtGenExternal.so` (see `src/CMakeLists.txt` in `evtgen`). Deprecated versions of `evtgen` are removed (and they were abusing spack to add multiple build system anyway). Two new versions of `evtgen` were added.