### PR TITLE
Camp: Fix syntax error

### DIFF
--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -110,9 +110,9 @@ class Camp(CMakePackage, CudaPackage, ROCmPackage):
             options.append("-DHIP_ROOT_DIR={0}".format(spec["hip"].prefix))
 
             archs = self.spec.variants["amdgpu_target"].value
-            options.append("-DCMAKE_HIP_ARCHITECTURES={0}".format(archs))
-            options.append("-DGPU_TARGETS={0}".format(archs))
-            options.append("-DAMDGPU_TARGETS={0}".format(archs))
+            options.append("-DCMAKE_HIP_ARCHITECTURES={0}".format(archs[0]))
+            options.append("-DGPU_TARGETS={0}".format(archs[0]))
+            options.append("-DAMDGPU_TARGETS={0}".format(archs[0]))
 
         if spec.satisfies("+omptarget"):
             options.append(cmake_cache_string("RAJA_DATA_ALIGN", 64))

--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -109,10 +109,10 @@ class Camp(CMakePackage, CudaPackage, ROCmPackage):
         if spec.satisfies("+rocm"):
             options.append("-DHIP_ROOT_DIR={0}".format(spec["hip"].prefix))
 
-            archs = self.spec.variants["amdgpu_target"].value
-            options.append("-DCMAKE_HIP_ARCHITECTURES={0}".format(archs[0]))
-            options.append("-DGPU_TARGETS={0}".format(archs[0]))
-            options.append("-DAMDGPU_TARGETS={0}".format(archs[0]))
+            archs = ";".join(self.spec.variants["amdgpu_target"].value)
+            options.append("-DCMAKE_HIP_ARCHITECTURES={0}".format(archs))
+            options.append("-DGPU_TARGETS={0}".format(archs))
+            options.append("-DAMDGPU_TARGETS={0}".format(archs))
 
         if spec.satisfies("+omptarget"):
             options.append(cmake_cache_string("RAJA_DATA_ALIGN", 64))


### PR DESCRIPTION
Fix syntax error in Camp package by providing first archs element instead of tuple to the CMake options