### PR TITLE
hevea: new version 2.36 accepts ocaml 5 series

### DIFF
--- a/var/spack/repos/builtin/packages/hevea/package.py
+++ b/var/spack/repos/builtin/packages/hevea/package.py
@@ -29,7 +29,7 @@ class Hevea(MakefilePackage):
     # Dependency demands ocamlbuild
     depends_on("ocaml")
     depends_on("ocamlbuild")
-    depends_on("ocaml@4.0.0:4.99.9", when="@:2.35")
+    depends_on("ocaml@4", when="@:2.35")
 
     def edit(self, spec, prefix):
         env["PREFIX"] = self.spec.prefix

--- a/var/spack/repos/builtin/packages/hevea/package.py
+++ b/var/spack/repos/builtin/packages/hevea/package.py
@@ -29,7 +29,7 @@ class Hevea(MakefilePackage):
     # Dependency demands ocamlbuild
     depends_on("ocaml")
     depends_on("ocamlbuild")
-    conflicts("ocaml@5.0.0:", when="@:2.35")
+    depends_on("ocaml@4.0.0:4.99.9", when="@:2.35")
 
     def edit(self, spec, prefix):
         env["PREFIX"] = self.spec.prefix

--- a/var/spack/repos/builtin/packages/hevea/package.py
+++ b/var/spack/repos/builtin/packages/hevea/package.py
@@ -18,6 +18,7 @@ class Hevea(MakefilePackage):
     license("LGPL-2.0-only")
 
     version("develop", branch="master")
+    version("2.36", sha256="9848359f935af24b6f962b2ed5d5ac32614bffeb37da374b0960cc0f58e69f0c")
     version("2.35", sha256="78f834cc7a8112ec59d0b8acdfbed0c8ac7dbb85f964d0be1f4eed04f25cdf54")
     version("2.34", sha256="f505a2a5bafdc2ea389ec521876844e6fdcb5c1b656396b7e8421c1631469ea2")
     version("2.33", sha256="122f9023f9cfe8b41dd8965b7d9669df21bf41e419bcf5e9de5314f428380d0f")
@@ -28,6 +29,7 @@ class Hevea(MakefilePackage):
     # Dependency demands ocamlbuild
     depends_on("ocaml")
     depends_on("ocamlbuild")
+    conflicts("ocaml@5.0.0:", when="@:2.35")
 
     def edit(self, spec, prefix):
         env["PREFIX"] = self.spec.prefix

--- a/var/spack/repos/builtin/packages/hevea/package.py
+++ b/var/spack/repos/builtin/packages/hevea/package.py
@@ -30,6 +30,7 @@ class Hevea(MakefilePackage):
     depends_on("ocaml")
     depends_on("ocamlbuild")
     depends_on("ocaml@4", when="@:2.35")
+    depends_on("ocaml@4.08.0:", when="@2.34:")
 
     def edit(self, spec, prefix):
         env["PREFIX"] = self.spec.prefix


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Hevea prior to 2.35 (included) demanded ocaml 4 series.