### PR TITLE
gaudi: fix nonexisting 'libs'

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -169,8 +169,12 @@ class Gaudi(CMakePackage):
         # environment as in Gaudi.xenv
         env.prepend_path("PATH", self.prefix.scripts)
         env.prepend_path("PYTHONPATH", self.prefix.python)
-        for d in self.libs.directories:
-            env.prepend_path("LD_LIBRARY_PATH", d)
+
+        # Note: ROOT dependency automatically sets up ROOT environment vars
+
+        # ...but Gaudi additionally requires a path variable about itself
+        for lib_path in [self.prefix.lib, self.prefix.lib64]:
+            env.prepend_path("LD_LIBRARY_PATH", lib_path)
 
     def url_for_version(self, version):
         major = str(version[0])

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -869,6 +869,6 @@ class Root(CMakePackage):
         # automatically prepending dependent package library paths to
         # ROOT_LIBRARY_PATH (for @6.26:) or LD_LIBRARY_PATH (for older
         # versions).
-        for lib_path in (dependent_spec.prefix.lib, dependent_spec.prefix.lib64):
+        for lib_path in [dependent_spec.prefix.lib, dependent_spec.prefix.lib64]:
             if os.path.exists(lib_path):
                 env.prepend_path(self.root_library_path, lib_path)


### PR DESCRIPTION
This PR fixes #48266, by cherry-picking 728356b06ecf2f98440269d06581795d45905a52 from #48210 (rather than waiting for that PR to resolve the remaining discussion).

Note: The style change in `root` is unrelated to the fix, but picked up since it was part of the cherry-picked commit; removing the style fix would cause it to be dropped.

Note to @sethrj: When rebasing #48210 after merging this, you should only need to change the explicit `LD_LIBRARY_PATH` back to `self.gaudi_library_path`.