### PR TITLE
mpi: remove unused monkey patched variable

### DIFF
--- a/var/spack/repos/builtin/packages/cray-mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/cray-mvapich2/package.py
@@ -53,11 +53,6 @@ class CrayMvapich2(Package):
         spec.mpifc = dependent_module.spack_fc
         spec.mpif77 = dependent_module.spack_f77
 
-        spec.mpicxx_shared_libs = [
-            join_path(self.prefix.lib, "libmpicxx.{0}".format(dso_suffix)),
-            join_path(self.prefix.lib, "libmpi.{0}".format(dso_suffix)),
-        ]
-
     def install(self, spec, prefix):
         raise InstallError(
             self.spec.format(

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -8,7 +8,6 @@ import re
 import sys
 
 import spack.compilers
-from spack.build_environment import dso_suffix
 from spack.package import *
 
 
@@ -481,11 +480,6 @@ supported, and netmod is ignored if device is ch3:sock.""",
         if "+fortran" in spec:
             spec.mpifc = join_path(self.prefix.bin, "mpif90")
             spec.mpif77 = join_path(self.prefix.bin, "mpif77")
-
-        spec.mpicxx_shared_libs = [
-            join_path(self.prefix.lib, "libmpicxx.{0}".format(dso_suffix)),
-            join_path(self.prefix.lib, "libmpi.{0}".format(dso_suffix)),
-        ]
 
     def autoreconf(self, spec, prefix):
         """Not needed usually, configure should be already there"""

--- a/var/spack/repos/builtin/packages/mvapich/package.py
+++ b/var/spack/repos/builtin/packages/mvapich/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import itertools
-import os.path
 import re
 import sys
 
@@ -242,10 +241,6 @@ class Mvapich(AutotoolsPackage):
         self.spec.mpicxx = join_path(self.prefix.bin, "mpicxx")
         self.spec.mpifc = join_path(self.prefix.bin, "mpif90")
         self.spec.mpif77 = join_path(self.prefix.bin, "mpif77")
-        self.spec.mpicxx_shared_libs = [
-            os.path.join(self.prefix.lib, "libmpicxx.{0}".format(dso_suffix)),
-            os.path.join(self.prefix.lib, "libmpi.{0}".format(dso_suffix)),
-        ]
 
     @run_before("configure")
     def die_without_fortran(self):

--- a/var/spack/repos/builtin/packages/mvapich2-gdr/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2-gdr/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
 import sys
 
 from spack.package import *
@@ -184,10 +183,6 @@ class Mvapich2Gdr(AutotoolsPackage):
         self.spec.mpicxx = join_path(self.prefix.bin, "mpicxx")
         self.spec.mpifc = join_path(self.prefix.bin, "mpif90")
         self.spec.mpif77 = join_path(self.prefix.bin, "mpif77")
-        self.spec.mpicxx_shared_libs = [
-            os.path.join(self.prefix.lib, "libmpicxx.{0}".format(dso_suffix)),
-            os.path.join(self.prefix.lib, "libmpi.{0}".format(dso_suffix)),
-        ]
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -399,10 +399,6 @@ class Mvapich2(AutotoolsPackage):
         self.spec.mpicxx = join_path(self.prefix.bin, "mpicxx")
         self.spec.mpifc = join_path(self.prefix.bin, "mpif90")
         self.spec.mpif77 = join_path(self.prefix.bin, "mpif77")
-        self.spec.mpicxx_shared_libs = [
-            os.path.join(self.prefix.lib, "libmpicxx.{0}".format(dso_suffix)),
-            os.path.join(self.prefix.lib, "libmpi.{0}".format(dso_suffix)),
-        ]
 
     @run_before("configure")
     def die_without_fortran(self):

--- a/var/spack/repos/builtin/packages/mvapich2x/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2x/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
 import sys
 
 from spack.package import *
@@ -239,10 +238,6 @@ class Mvapich2x(AutotoolsPackage):
         self.spec.mpicxx = join_path(self.prefix.bin, "mpicxx")
         self.spec.mpifc = join_path(self.prefix.bin, "mpif90")
         self.spec.mpif77 = join_path(self.prefix.bin, "mpif77")
-        self.spec.mpicxx_shared_libs = [
-            os.path.join(self.prefix.lib, "libmpicxx.{0}".format(dso_suffix)),
-            os.path.join(self.prefix.lib, "libmpi.{0}".format(dso_suffix)),
-        ]
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -931,10 +931,6 @@ with '-Wl,-commons,use_dylibs' and without
         self.spec.mpicxx = join_path(self.prefix.bin, "mpic++")
         self.spec.mpifc = join_path(self.prefix.bin, "mpif90")
         self.spec.mpif77 = join_path(self.prefix.bin, "mpif77")
-        self.spec.mpicxx_shared_libs = [
-            join_path(self.prefix.lib, "libmpi_cxx.{0}".format(dso_suffix)),
-            join_path(self.prefix.lib, "libmpi.{0}".format(dso_suffix)),
-        ]
 
     # Most of the following with_or_without methods might seem redundant
     # because Spack compiler wrapper adds the required -I and -L flags, which

--- a/var/spack/repos/tutorial/packages/mpich/package.py
+++ b/var/spack/repos/tutorial/packages/mpich/package.py
@@ -93,11 +93,6 @@ spack package at this time.""",
         self.spec.mpifc = join_path(self.prefix.bin, "mpif90")
         self.spec.mpif77 = join_path(self.prefix.bin, "mpif77")
 
-        self.spec.mpicxx_shared_libs = [
-            join_path(self.prefix.lib, "libmpicxx.{0}".format(dso_suffix)),
-            join_path(self.prefix.lib, "libmpi.{0}".format(dso_suffix)),
-        ]
-
     def autoreconf(self, spec, prefix):
         """Not needed usually, configure should be already there"""
         # If configure exists nothing needs to be done


### PR DESCRIPTION
`spec.mpicxx_shared_libraries` seems a relic of #1550, and is not currently used by any builtin package. Thus, cleanup the recipes, and avoid monkey-patching spec objects.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
