### PR TITLE
doc: ensure getting_started has bootstrap list output in correct place

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -148,20 +148,22 @@ The first time you concretize a spec, Spack will bootstrap automatically:
    --------------------------------
    zlib@1.2.13%gcc@9.4.0+optimize+pic+shared build_system=makefile arch=linux-ubuntu20.04-icelake
 
+The default bootstrap behavior is to use pre-built binaries. You can verify the
+active bootstrap repositories with:
+
+.. command-output:: spack bootstrap list
+
 If for security concerns you cannot bootstrap ``clingo`` from pre-built
 binaries, you have to disable fetching the binaries we generated with Github Actions.
 
 .. code-block:: console
 
-   $ spack bootstrap disable github-actions-v0.4
-   ==> "github-actions-v0.4" is now disabled and will not be used for bootstrapping
-   $ spack bootstrap disable github-actions-v0.3
-   ==> "github-actions-v0.3" is now disabled and will not be used for bootstrapping
+   $ spack bootstrap disable github-actions-v0.6
+   ==> "github-actions-v0.6" is now disabled and will not be used for bootstrapping
+   $ spack bootstrap disable github-actions-v0.5
+   ==> "github-actions-v0.5" is now disabled and will not be used for bootstrapping
 
-You can verify that the new settings are effective with:
-
-.. command-output:: spack bootstrap list
-
+You can verify that the new settings are effective with ``spack bootstrap list``.
 
 .. note::
 


### PR DESCRIPTION
The docs contain a confusing sequence in https://spack.readthedocs.io/en/latest/getting_started.html#bootstrapping-clingo:
- "If for security concerns you cannot bootstrap clingo from pre-built binaries, you have to disable fetching the binaries we generated with Github Actions."
- code-block `spack bootstrap disable`
- "You can verify that the new settings are effective with:"
- command-output `spack bootstrap list`

Because the command-output is run, and the `spack bootstrap disable` is NOT run, this results in the `spack bootstrap list` showing the disabled resources as enabled.

This PR reorders the text so the `spack bootstrap list` output is introduced first (as command-output), and the verification step is a reference to the same command. (Also updated github-actions versions to current.)