### PR TITLE
mepo: add v2.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/mepo/package.py
+++ b/var/spack/repos/builtin/packages/mepo/package.py
@@ -17,6 +17,7 @@ class Mepo(PythonPackage):
 
     license("Apache-2.0", checked_by="mathomp4")
 
+    version("2.2.0", sha256="d7cf2456ec2ae9e1724782152b6bf86e06cf071263dbe2eb8ad5b8765b419857")
     version("2.1.0", sha256="24f94f7fbc15f740e13ace695e204d6370bf4156eca08c24bcbeacaacb1b6c12")
     version("2.0.0", sha256="8ca4aabd8ca350183db3b8e117b0cd87d9a20277e39931e2799c86bfa910ae71")
     version("2.0.0rc4", sha256="5f6113be565c561c08114355570a259042b25222a9e8e1dc6e6e44448381cd36")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds [mepo v2.2.0](https://github.com/GEOS-ESM/mepo/releases/tag/v2.2.0)