### PR TITLE
openloops: Fix configuration of cmodel setting for gfortran

### DIFF
--- a/var/spack/repos/builtin/packages/openloops/package.py
+++ b/var/spack/repos/builtin/packages/openloops/package.py
@@ -274,12 +274,16 @@ class Openloops(Package):
             f.write("fortran_compiler = {0}\n".format(env["SPACK_FC"]))
             if self.spec.satisfies("@1.3.1") and not is_intel:
                 f.write("gfortran_f_flags = -ffree-line-length-none\n")
-            if self.spec.satisfies("@2.1.1:") and not is_intel:
+            if self.spec.satisfies("@2.1.1") and not is_intel:
                 f.write("gfortran_f_flags = -ffree-line-length-none " + "-fdollar-ok ")
                 if self.spec.target.family == "aarch64":
                     f.write("-mcmodel=small\n")
                 else:
                     f.write("-mcmodel=medium\n")
+            if self.spec.satisfies("@2.1.2:") and not is_intel:
+                f.write("gfortran_f_flags = -ffree-line-length-none " + "-fdollar-ok\n")
+                if self.spec.target.family == "aarch64":
+                    f.write("cmodel = small\n")
 
         if self.spec.satisfies("@:1 processes=lcg.coll"):
             copy(join_path(os.path.dirname(__file__), "sft1.coll"), "lcg.coll")

--- a/var/spack/repos/builtin/packages/openloops/package.py
+++ b/var/spack/repos/builtin/packages/openloops/package.py
@@ -277,13 +277,13 @@ class Openloops(Package):
             if self.spec.satisfies("@2.1.1") and not is_intel:
                 f.write("gfortran_f_flags = -ffree-line-length-none " + "-fdollar-ok ")
                 if self.spec.target.family == "aarch64":
-                    f.write("-mcmodel=small\n")
+                    f.write("-mcmodel=large\n")
                 else:
                     f.write("-mcmodel=medium\n")
             if self.spec.satisfies("@2.1.2:") and not is_intel:
                 f.write("gfortran_f_flags = -ffree-line-length-none " + "-fdollar-ok\n")
                 if self.spec.target.family == "aarch64":
-                    f.write("cmodel = small\n")
+                    f.write("cmodel = large\n")
 
         if self.spec.satisfies("@:1 processes=lcg.coll"):
             copy(join_path(os.path.dirname(__file__), "sft1.coll"), "lcg.coll")


### PR DESCRIPTION
The openloops 2.1.2 package currently does not compile on `Aarch64` (ie: building a Docker image on a MacBook M3) due to the following error. It is also discussed in [openloops/OpenLoops!8](https://gitlab.com/openloops/OpenLoops/-/issues/8).

```
1 error found in build log:
     125    Copy("lib_src/olcommon/obj/cwrappers.c", "lib_src/olcommon/src/cwrappers.c")
     126    cpp --traditional-cpp -P -DUSE_RAMBO -DUSE_COLLIER -DUSE_CUTTOOLS -DUSE_TRRED -DUSE_OLCOMMON -DUSE_OPENLOOPS -DUSE_TRRED -DUSE_ONELOOP -DKIND_TYPES=kind_
            types -DDREALKIND=dp -DQREALKIND=qp -DUSE_GFORTRAN -DMAXSTRLEN=255 -DSING -Dcollierdd -DREALKIND= -DVERSION=\"beta\" -DPROCESSAPI=2 -DREVISION=\"none\" l
            ib_src/openloops/src/version.F90 lib_src/openloops/obj/version.f90
     127    Creating 'lib_src/openloops/obj/install_path.inc'
     128    scons: done reading SConscript files.
     129    scons: Building targets ...
     130    /usr/bin/gfortran -o lib_src/olcommon/obj/kind_types.os -c -ffree-line-length-none -fdollar-ok -mcmodel=small -mcmodel=medium -O2 -fPIC -Ilib_src/olcommo
            n/mod -Jlib_src/olcommon/mod lib_src/olcommon/obj/kind_types.f90
  >> 131    gfortran: error: unrecognized argument in option '-mcmodel=medium'
     132    gfortran: note: valid arguments to '-mcmodel=' are: large small tiny
     133    scons: *** [lib_src/olcommon/obj/kind_types.os] Error 1
     134    scons: building terminated because of errors.
```

Note the two appearances of `-mcmodel=...`. This is because it was added as a setting to the default build configuration file ([pyol/config/default.cfg](https://gitlab.com/openloops/OpenLoops/-/blob/OpenLoops-2.1.2/pyol/config/default.cfg?ref_type=tags#L48)) in 2.1.2 in addition to the custom application (via `gfortran_f_flags`) by Spack. This moves the setting of the `cmodel` setting directly via the user configuration file that overrides the default configuration.