### PR TITLE
oxide-rs: new-package

### DIFF
--- a/lib/spack/spack/build_systems/cargo.py
+++ b/lib/spack/spack/build_systems/cargo.py
@@ -50,6 +50,17 @@ class CargoBuilder(BuilderWithDefaults):
 
     phases = ("build", "install")
 
+    #: Names associated with package methods in the old build-system format
+    legacy_methods = ("check", "installcheck")
+
+    #: Names associated with package attributes in the old build-system format
+    legacy_attributes = (
+        "build_args",
+        "check_args",
+        "build_directory",
+        "install_time_test_callbacks",
+    )
+
     #: Callback names for install-time test
     install_time_test_callbacks = ["check"]
 

--- a/var/spack/repos/builtin/packages/oxide-rs/package.py
+++ b/var/spack/repos/builtin/packages/oxide-rs/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class OxideRs(CargoPackage):
+    """The Oxide CLI"""
+
+    homepage = "https://github.com/oxidecomputer/oxide.rs"
+    git = "https://github.com/oxidecomputer/oxide.rs.git"
+
+    maintainers("alecbcs")
+
+    license("MPL-2.0", checked_by="alecbcs")
+
+    version("0.9.0", tag="v0.9.0+20241204.0.0", commit="cb25407df4e8bb4f33eb3b110d271cd8cd6dc16d")
+
+    build_directory = "cli"


### PR DESCRIPTION
Adding the Oxide Computer CLI!!

Additional changes were required to correctly allow `build_directory` to be defined for Cargo Packages.