### PR TITLE
openloops: use cmodel small on aarch64 instead of large

### DIFF
--- a/var/spack/repos/builtin/packages/openloops/package.py
+++ b/var/spack/repos/builtin/packages/openloops/package.py
@@ -277,13 +277,13 @@ class Openloops(Package):
             if self.spec.satisfies("@2.1.1") and not is_intel:
                 f.write("gfortran_f_flags = -ffree-line-length-none " + "-fdollar-ok ")
                 if self.spec.target.family == "aarch64":
-                    f.write("-mcmodel=large\n")
+                    f.write("-mcmodel=small\n")
                 else:
                     f.write("-mcmodel=medium\n")
             if self.spec.satisfies("@2.1.2:") and not is_intel:
                 f.write("gfortran_f_flags = -ffree-line-length-none " + "-fdollar-ok\n")
                 if self.spec.target.family == "aarch64":
-                    f.write("cmodel = large\n")
+                    f.write("cmodel = small\n")
 
         if self.spec.satisfies("@:1 processes=lcg.coll"):
             copy(join_path(os.path.dirname(__file__), "sft1.coll"), "lcg.coll")


### PR DESCRIPTION
Follow up on PR https://github.com/spack/spack/pull/48288 . The openloops package does not compile with the `-mcmodel=large` option currently set for aarch64 build. It fails with the following error. I believe the `-fPIC` is added automatically by openloops for gfortran ([here](https://gitlab.com/openloops/OpenLoops/-/blob/OpenLoops-2.1.2/scons-local/scons-local-3.0.5/SCons/Tool/gfortran.py?ref_type=tags), but no 100% sure as I didn't trace it) and I don't see a way to change it. This reverts it back to `small` that was previously set in spack.

```
scons: Building targets ...
/usr/bin/gfortran -o lib_src/olcommon/obj/kind_types.os -c -ffree-line-length-none -fdollar-ok -mcmodel=large -O2 -fPIC -Ilib_src/olcommon/mod -Jlib_src/olcommon/mod lib_src/olcommon/obj/kind_types.f90
f951: sorry, unimplemented: code model 'large' with '-fPIC'
scons: *** [lib_src/olcommon/obj/kind_types.os] Error 1
scons: building terminated because of errors.
```