### PR TITLE
pandora{pfa,sdk,monitoring}: add new versions and allow setting the C++ standard

### DIFF
--- a/var/spack/repos/builtin/packages/pandoramonitoring/package.py
+++ b/var/spack/repos/builtin/packages/pandoramonitoring/package.py
@@ -19,6 +19,7 @@ class Pandoramonitoring(CMakePackage):
     maintainers("jmcarcell", "wdconinc")
 
     version("master", branch="master")
+    version("3.6.0", sha256="5fc9574faa3e90d96e5d2a27dea46b55f844499cf21e39060acb1e4c080dec77")
     version("3.5.0", sha256="274562abb7c797194634d5460a56227444a1de07a240c88ae35ca806abcbaf60")
 
     depends_on("c", type="build")
@@ -39,7 +40,8 @@ class Pandoramonitoring(CMakePackage):
     def cmake_args(self):
         args = [
             self.define("CMAKE_MODULE_PATH", self.spec["pandorapfa"].prefix.cmakemodules),
-            self.define("CMAKE_CXX_FLAGS", "-std=c++17"),
+            self.define("CMAKE_CXX_FLAGS", "-Wno-error"),
+            self.define("CMAKE_CXX_STANDARD", self.spec["root"].variants["cxxstd"].value),
         ]
         return args
 

--- a/var/spack/repos/builtin/packages/pandorapfa/package.py
+++ b/var/spack/repos/builtin/packages/pandorapfa/package.py
@@ -20,6 +20,7 @@ class Pandorapfa(Package):
     maintainers("jmcarcell", "wdconinc")
 
     version("master", branch="master")
+    version("4.11.2", sha256="02b0e8c1844ec515055cb85f9d14d9d13eda28607c634611a59d767eb08a8b34")
     version("4.3.1", sha256="2f4757a6ed2e10d3effc300b330f67ba13c499dbf21ba720b29b50527332fcdb")
     version("4.3.0", sha256="a794022c33b3a5afc1272740ac385e0c4ab96a112733012e7dfcbe80b5a3b445")
     version("4.2.1", sha256="1d262417748d18e00466ae3f1714ab0d7452e903bd1430773a72c652cf4666e4")

--- a/var/spack/repos/builtin/packages/pandorasdk/package.py
+++ b/var/spack/repos/builtin/packages/pandorasdk/package.py
@@ -38,7 +38,9 @@ class Pandorasdk(CMakePackage):
     def cmake_args(self):
         args = [
             self.define("CMAKE_MODULE_PATH", self.spec["pandorapfa"].prefix.cmakemodules),
-            self.define("CMAKE_CXX_FLAGS", f"-Wno-error -std=c++{self.spec.variants['cxxstd'].value}"),
+            self.define(
+                "CMAKE_CXX_FLAGS", f"-Wno-error -std=c++{self.spec.variants['cxxstd'].value}"
+            ),
         ]
         return args
 

--- a/var/spack/repos/builtin/packages/pandorasdk/package.py
+++ b/var/spack/repos/builtin/packages/pandorasdk/package.py
@@ -22,6 +22,14 @@ class Pandorasdk(CMakePackage):
     version("3.4.1", sha256="9607bf52a9d79d88d28c45d4f3336e066338b36ab81b4d2d125226f4ad3a7aaf")
     version("3.4.0", sha256="1e30db056d4a43f8659fccdda00270af14593425d933f91e91d5c97f1e124c6b")
 
+    variant(
+        "cxxstd",
+        default="17",
+        values=("17", "20"),
+        multi=False,
+        description="Use the specified C++ standard when building.",
+    )
+
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
@@ -29,10 +37,8 @@ class Pandorasdk(CMakePackage):
 
     def cmake_args(self):
         args = [
-            self.define("LC_PANDORA_CONTENT", True),
-            self.define("LAR_PANDORA_CONTENT", True),
             self.define("CMAKE_MODULE_PATH", self.spec["pandorapfa"].prefix.cmakemodules),
-            self.define("CMAKE_CXX_FLAGS", "-std=c++17"),
+            self.define("CMAKE_CXX_FLAGS", f"-Wno-error -std=c++{self.spec.variants['cxxstd'].value}"),
         ]
         return args
 

--- a/var/spack/repos/builtin/packages/pandorasdk/package.py
+++ b/var/spack/repos/builtin/packages/pandorasdk/package.py
@@ -39,7 +39,7 @@ class Pandorasdk(CMakePackage):
         args = [
             self.define("CMAKE_MODULE_PATH", self.spec["pandorapfa"].prefix.cmakemodules),
             self.define("CMAKE_CXX_FLAGS", "-Wno-error"),
-            self.define("CMAKE_CXX_STANDARD", self.spec.variants['cxxstd'].value),
+            self.define("CMAKE_CXX_STANDARD", self.spec.variants["cxxstd"].value),
         ]
         return args
 

--- a/var/spack/repos/builtin/packages/pandorasdk/package.py
+++ b/var/spack/repos/builtin/packages/pandorasdk/package.py
@@ -38,9 +38,8 @@ class Pandorasdk(CMakePackage):
     def cmake_args(self):
         args = [
             self.define("CMAKE_MODULE_PATH", self.spec["pandorapfa"].prefix.cmakemodules),
-            self.define(
-                "CMAKE_CXX_FLAGS", f"-Wno-error -std=c++{self.spec.variants['cxxstd'].value}"
-            ),
+            self.define("CMAKE_CXX_FLAGS", "-Wno-error"),
+            self.define("CMAKE_CXX_STANDARD", self.spec.variants['cxxstd'].value),
         ]
         return args
 


### PR DESCRIPTION
- For pandorapfa there are lots of versions, if there is interest I can add them all
- These packages are built with `-Werror` by default and passing `-Wno-error` overrides it
  (which allows using another C++ standard)
- `PandoraSDK` hardcodes the standard but it can be overriden through `CMAKE_CXX_FLAGS`: 
https://github.com/PandoraPFA/PandoraSDK/blob/master/CMakeLists.txt#L27