### PR TITLE
traverse_topo_edges: keep list of visited edges

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -924,7 +924,9 @@ def effective_deptypes(
     in reverse so that dependents override dependencies, not the other way around."""
     topo_sorted_edges = traverse.traverse_topo_edges_generator(
         traverse.with_artificial_edges(specs),
-        visitor=EnvironmentVisitor(*specs, context=context),
+        visitor=traverse.CoverEdgesVisitor(
+            EnvironmentVisitor(*specs, context=context), key=traverse.by_dag_hash
+        ),
         key=traverse.by_dag_hash,
         root=True,
         all_edges=True,

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -400,8 +400,6 @@ def traverse_topo_edges_generator(edges, visitor, key=id, root=True, all_edges=F
     # maps parent identifier to a list of edges, where None is a special identifier
     # for the artificial root/source.
     node_to_edges = defaultdict(list)
-    # wrap supplied visitor to track visited edges
-    visitor = CoverEdgesVisitor(visitor, key=key, visited=None)
     for edge in traverse_breadth_first_edges_generator(edges, visitor, root=True, depth=False):
         in_edge_count[key(edge.spec)] += 1
         parent_id = key(edge.parent) if edge.parent is not None else None

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -382,7 +382,7 @@ def traverse_topo_edges_generator(edges, visitor, key=id, root=True, all_edges=F
 
     Arguments:
         edges (list): List of EdgeAndDepth instances
-        visitor: visitor instance that defines the sub-DAG to traverse
+        visitor: visitor that produces unique edges defining the (sub)DAG of interest.
         key: function that takes a spec and outputs a key for uniqueness test.
         root (bool): Yield the root nodes themselves
         all_edges (bool): When ``False`` only one in-edge per node is returned, when

--- a/lib/spack/spack/traverse.py
+++ b/lib/spack/spack/traverse.py
@@ -400,6 +400,8 @@ def traverse_topo_edges_generator(edges, visitor, key=id, root=True, all_edges=F
     # maps parent identifier to a list of edges, where None is a special identifier
     # for the artificial root/source.
     node_to_edges = defaultdict(list)
+    # wrap supplied visitor to track visited edges
+    visitor = CoverEdgesVisitor(visitor, key=key, visited=None)
     for edge in traverse_breadth_first_edges_generator(edges, visitor, root=True, depth=False):
         in_edge_count[key(edge.spec)] += 1
         parent_id = key(edge.parent) if edge.parent is not None else None


### PR DESCRIPTION
Closes #47888.

It appears that #47888 may be caused by the removal of visited edge tracking in #47720, when TopoVisitor was removed and EnvironmentVisitor was not given that functionality. See [diff](https://github.com/spack/spack/commit/cb3d6549c988cb914583e4d220a2d1c0b0aa6ae2).

This PR wraps the EnvironmentVisitor in a CoverEdgesVisitor and resolves at least my observations of the behavior in #47888. (Another solution could be to add visited edge tracking to EnvironmentVisitor.)