### PR TITLE
sysbench: update dependencies, build process, variants

### DIFF
--- a/var/spack/repos/builtin/packages/sysbench/package.py
+++ b/var/spack/repos/builtin/packages/sysbench/package.py
@@ -17,11 +17,29 @@ class Sysbench(AutotoolsPackage):
     version("1.0.19", sha256="39cde56b58754d97b2fe6a1688ffc0e888d80c262cf66daee19acfb2997f9bdd")
     version("1.0.18", sha256="c679b285e633c819d637bdafaeacc1bec13f37da5b3357c7e17d97a71bf28cb1")
 
+    variant("mysql", default=False, description="Compile with MySQL support")
+    variant("pgsql", default=False, description="Compile with PostgreSQL support")
+
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
+    depends_on("binutils+ld+gold", type="build")  # required when system doesn't provide zlib
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
-    depends_on("mysql-client")
+    depends_on("pkgconfig", type="build")
+    depends_on("mysql-client", when="+mysql")
+    depends_on("postgresql", when="+pgsql")
+    depends_on("zlib-api", type="build")
+
+    def configure_args(self):
+        args = []
+
+        args += self.with_or_without("mysql")
+        args += self.with_or_without("pgsql")
+
+        return args 
+
+    def autoreconf(self, spec, prefix):
+        which("bash")("./autogen.sh")

--- a/var/spack/repos/builtin/packages/sysbench/package.py
+++ b/var/spack/repos/builtin/packages/sysbench/package.py
@@ -53,4 +53,4 @@ class Sysbench(AutotoolsPackage):
         return args
 
     def autoreconf(self, spec, prefix):
-        which("bash")("./autogen.sh")
+        Executable("./autogen.sh")()

--- a/var/spack/repos/builtin/packages/sysbench/package.py
+++ b/var/spack/repos/builtin/packages/sysbench/package.py
@@ -50,7 +50,7 @@ class Sysbench(AutotoolsPackage):
         args += self.with_or_without("mysql")
         args += self.with_or_without("pgsql")
 
-        return args 
+        return args
 
     def autoreconf(self, spec, prefix):
         which("bash")("./autogen.sh")

--- a/var/spack/repos/builtin/packages/sysbench/package.py
+++ b/var/spack/repos/builtin/packages/sysbench/package.py
@@ -35,13 +35,10 @@ class Sysbench(AutotoolsPackage):
 
     phases = ["autoreconf", "configure", "build", "install"]
 
-    @property
-    def zlib_library_path(self):
-        return self.spec["zlib-api"].prefix.lib
-
     def flag_handler(self, name, flags):
         if name == "ldflags":
-            flags.append(f"-L{self.zlib_library_path}")
+            zlib_library_path = self.spec["zlib-api"].prefix.lib
+            flags.append(f"-L{zlib_library_path}")
         return flags, None, None
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/sysbench/package.py
+++ b/var/spack/repos/builtin/packages/sysbench/package.py
@@ -33,6 +33,17 @@ class Sysbench(AutotoolsPackage):
     depends_on("postgresql", when="+pgsql")
     depends_on("zlib-api", type="build")
 
+    phases = ["autoreconf", "configure", "build", "install"]
+
+    @property
+    def zlib_library_path(self):
+        return self.spec["zlib-api"].prefix.lib
+
+    def flag_handler(self, name, flags):
+        if name == "ldflags":
+            flags.append(f"-L{self.zlib_library_path}")
+        return flags, None, None
+
     def configure_args(self):
         args = []
 


### PR DESCRIPTION
Updates the `sysbench` package to work on systems where common dev tools are not provided but needed to build.

 - The autoreconf stage requires `pkgconfig`
 - The package requires `zlib` 
 - The linker doesn't get called with the `zlib` path and doesn't seem to honor `LDFLAGS` (`binutils` fixes this)

It also adds some variants to remove default build requirements for databases.