### PR TITLE
allow gcc to privies CXX env for cmake

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -1013,7 +1013,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage, CompilerPackage):
         if self.spec.satisfies("languages=c"):
             env.set("CC", self.cc)
 
-        if self.spec.satisfies("languages=cxx"):
+        if self.spec.satisfies("languages=c++"):
             env.set("CXX", self.cxx)
 
         if self.spec.satisfies("languages=fortran"):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
allow gcc to provide CXX environment variables. 

@alalazo @michaelkuhn 