### PR TITLE
py-jedi: fix python dependency constraints

### DIFF
--- a/var/spack/repos/builtin/packages/py-jedi/package.py
+++ b/var/spack/repos/builtin/packages/py-jedi/package.py
@@ -96,11 +96,14 @@ class PyJedi(PythonPackage):
     )
 
     with default_args(type=("build", "run")):
-        depends_on("python@3.5:3.9", when="@0.17.1:")
-        depends_on("python@3.6:3.10", when="@0.18.1:")
-        depends_on("python@3.6:3.11", when="@0.19.0:")
-        depends_on("python@3.6:3.12", when="@0.19.1:")
-        depends_on("python@3.6:3.13", when="@0.19.2:")
+        depends_on("python@3.5:", when="@0.17.1:")
+        depends_on("python@3.6:", when="@0.18.1:")
+
+        depends_on("python@:3.9", when="@:0.17.1")
+        depends_on("python@:3.10", when="@:0.18.1")
+        depends_on("python@:3.11", when="@:0.19.0")
+        depends_on("python@:3.12", when="@:0.19.1")
+        depends_on("python@:3.13", when="@0.19.2:")
 
         depends_on("py-setuptools")
 


### PR DESCRIPTION
I'd messed up putting in these constraints originally, since the most constrained combination is what was actually applied to newer versions of jedi, instead of relaxing the max version of python.