### PR TITLE
R: ensure Makeconf has full libs directories

### DIFF
--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -77,6 +77,9 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
             flags.append(getattr(self.compiler, f"cxx{self.spec.variants['cxxstd'].value}_flag"))
         return (None, flags, None)
 
+    @property
+    def libs(self):
+        return find_libraries("libicu*", root=self.prefix, recursive=True)
 
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
 

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -81,6 +81,7 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
     def libs(self):
         return find_libraries("libicu*", root=self.prefix, recursive=True)
 
+
 class AutotoolsBuilder(spack.build_systems.autotools.AutotoolsBuilder):
 
     configure_directory = "source"

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -233,6 +233,20 @@ class R(AutotoolsPackage):
 
     @run_after("install")
     def copy_makeconf(self):
+        # Ensure full library flags are included in Makeconf
+        for _lib, _pkg in [
+            ("lzma", "xz"),
+            ("bz2", "bzip2"),
+            ("z", "zlib-api"),
+            ("tirpc", "libtirpc"),
+            ("icuuc", "icu4c"),
+        ]:
+            filter_file(
+                f"-l{_lib}",
+                f"-L{self.spec[_pkg].libs.directories[0]} -l{_lib}",
+                join_path(self.etcdir, "Makeconf"),
+            )
+
         # Make a copy of Makeconf because it will be needed to properly build R
         # dependencies in Spack.
         src_makeconf = join_path(self.etcdir, "Makeconf")


### PR DESCRIPTION
This PR ensures that `r` includes full `-L` library directory flags in the Makeconf that is used for dependent packages. Until now, R only uses pkgconfig for the `pcre2` dependency, and for other dependencies (e.g. `xz`/`lzma`) it just adds `-llzma` only. This leads to linker errors downstream (e.g. `r-rsamtools`) since those packages do not depend directly on `xz`/`lzma`, nor should they.

This modifies Makeconf from
```
LIBS = -L/project/6041615/spack/opt/spack/linux-almalinux8-skylake_avx512/gcc-8.5.0/pcre2-10.44-gjceu6xtqgtd4lihf6hzcyyfkzrqlz74/lib -lpcre2-8 -llzma -lbz2 -lz -ltirpc -lrt -ldl -lm -liconv -licuuc -licui18n
```
to
```
LIBS = -L/project/6041615/spack/opt/spack/linux-almalinux8-skylake_avx512/gcc-8.5.0/pcre2-10.44-gjceu6xtqgtd4lihf6hzcyyfkzrqlz74/lib -lpcre2-8 -L/project/6041615/spack/opt/spack/linux-almalinux8-skylake_avx512/gcc-8.5.0/xz-5.4.6-mu6ektqbbawuz2wxyfhnsipbjglokaqa/lib -llzma -L/project/6041615/spack/opt/spack/linux-almalinux8-skylake_avx512/gcc-8.5.0/bzip2-1.0.8-pabalreiw257fdgyttbr633s7pfqxth7/lib -lbz2 -L/project/6041615/spack/opt/spack/linux-almalinux8-skylake_avx512/gcc-8.5.0/zlib-ng-2.2.1-3qvevnj7uydxwtwu3eslzwgx5ye4hfzc/lib -lz -L/project/6041615/spack/opt/spack/linux-almalinux8-skylake_avx512/gcc-8.5.0/libtirpc-1.3.3-ccj4cekhxwnqbvmhstsyznu26f3obrh5/lib -ltirpc -lrt -ldl -lm -liconv -L/project/6041615/spack/opt/spack/linux-almalinux8-skylake_avx512/gcc-8.5.0/icu4c-74.2-sd5cfdrg6qj4st3btcalqfldvapxe3o6/lib -licuuc -licui18n
```