### PR TITLE
r: add v4.4.2

### DIFF
--- a/var/spack/repos/builtin/packages/r-rcpp/package.py
+++ b/var/spack/repos/builtin/packages/r-rcpp/package.py
@@ -22,6 +22,7 @@ class RRcpp(RPackage):
 
     cran = "Rcpp"
 
+    version("1.0.13-1", sha256="1d1fc623d27082b5749f9584a9204de410134b6412a192157a3e42e2ba43969a")
     version("1.0.13", sha256="21fec650c113e57935fd86c7d1be190811f1ae036c1ee203bfbbf3ad5cdb22ce")
     version("1.0.12", sha256="0c7359cc43beee02761aa3df2baccede1182d29d28c9cd49964b609305062bd0")
     version("1.0.11", sha256="df757c3068599c6c05367900bcad93547ba3422d59802dbaca20fd74d4d2fa5f")
@@ -53,3 +54,6 @@ class RRcpp(RPackage):
     # leave the r dependency also for newer versions
     # (not listed in Description for @1.0.5:)
     depends_on("r@3.0.0:", type=("build", "run"))
+
+    # https://github.com/RcppCore/Rcpp/issues/1341
+    conflicts("^r@4.4.2", when="@=1.0.13", msg="Rcpp@1.0.13 fails to compile under R@4.4.2")

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -23,6 +23,7 @@ class R(AutotoolsPackage):
 
     license("GPL-2.0-or-later")
 
+    version("4.4.2", sha256="1578cd603e8d866b58743e49d8bf99c569e81079b6a60cf33cdf7bdffeb817ec")
     version("4.4.1", sha256="b4cb675deaaeb7299d3b265d218cde43f192951ce5b89b7bb1a5148a36b2d94d")
     version("4.4.0", sha256="ace4125f9b976d2c53bcc5fca30c75e30d4edc401584859cbadb080e72b5f030")
     version("4.3.3", sha256="80851231393b85bf3877ee9e39b282e750ed864c5ec60cbd68e6e139f0520330")


### PR DESCRIPTION
This PR adds `r`, v4.4.2 ([release notes](https://cran.r-project.org/doc/manuals/r-release/NEWS.html)), which is a bugfix release.

Test build:
```
-- linux-ubuntu24.10-skylake / gcc@14.2.0 -----------------------
hcxkwrv r@4.4.2~X~memory_profiling~rmath build_system=autotools patches=abc572d
==> 1 installed package
```