### PR TITLE
mlpack: add v4.5.1

### DIFF
--- a/var/spack/repos/builtin/packages/mlpack/package.py
+++ b/var/spack/repos/builtin/packages/mlpack/package.py
@@ -19,6 +19,7 @@ class Mlpack(CMakePackage):
 
     license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("4.5.1", sha256="58059b911a78b8bda91eef4cfc6278383b24e71865263c2e0569cf5faa59dda3")
     version("4.5.0", sha256="aab70aee10c134ef3fe568843fe4b3bb5e8901af30ea666f57462ad950682317")
     version("4.4.0", sha256="61c604026d05af26c244b0e47024698bbf150dfcc9d77b64057941d7d64d6cf6")
     version("4.3.0", sha256="08cd54f711fde66fc3b6c9db89dc26776f9abf1a6256c77cfa3556e2a56f1a3d")
@@ -29,8 +30,7 @@ class Mlpack(CMakePackage):
 
     depends_on("cxx", type="build")  # generated
 
-    # TODO: Go bindings are not supported due to the absence of gonum in spack
-    # variant("go", default=False, description="Build Go bindings")
+    variant("go", default=False, description="Build Go bindings")
     variant("julia", default=False, description="Build Julia bindings")
     variant("python", default=False, description="Build Ppython bindings")
     variant("r", default=False, description="Build R bindings")
@@ -47,11 +47,9 @@ class Mlpack(CMakePackage):
     conflicts("%gcc@:4", when="@4.0:", msg="mlpack 4.0+ requires at least gcc-5 with C++14")
     conflicts("%gcc@:7", when="@4.4:", msg="mlpack 4.4+ requires at least gcc-8 with C++17")
 
-    # TODO: Go bindings are not supported due to the absence of gonum in spack
-    # with when("+go"):
-    #    # ref: src/mlpack/bindings/go/CMakeLists.txt
-    #    depends_on("go@1.11.0:")
-    #    depends_on("gonum")
+    with when("+go"):
+        # ref: src/mlpack/bindings/go/CMakeLists.txt
+        depends_on("go@1.11.0:")
     with when("+julia"):
         # ref: src/mlpack/bindings/julia/CMakeLists.txt
         depends_on("julia@0.7.0:")
@@ -85,7 +83,7 @@ class Mlpack(CMakePackage):
     def cmake_args(self):
         args = [
             self.define("BUILD_CLI_EXECUTABLES", True),
-            # self.define_from_variant("BUILD_GO_BINDINGS", "go"),
+            self.define_from_variant("BUILD_GO_BINDINGS", "go"),
             self.define_from_variant("BUILD_JULIA_BINDINGS", "julia"),
             self.define_from_variant("BUILD_PYTHON_BINDINGS", "python"),
             self.define_from_variant("BUILD_R_BINDINGS", "r"),

--- a/var/spack/repos/builtin/packages/mlpack/package.py
+++ b/var/spack/repos/builtin/packages/mlpack/package.py
@@ -30,7 +30,7 @@ class Mlpack(CMakePackage):
 
     depends_on("cxx", type="build")  # generated
 
-    variant("go", default=False, description="Build Go bindings")
+    variant("go", default=False, description="Build Go bindings", when="@4.5.1:")
     variant("julia", default=False, description="Build Julia bindings")
     variant("python", default=False, description="Build Ppython bindings")
     variant("r", default=False, description="Build R bindings")


### PR DESCRIPTION
This PR adds `mlpack`, v4.5.1 ([diff](https://github.com/mlpack/mlpack/compare/4.5.0...4.5.1)). This removes the need for a `gonum` package, which allows the `+go` variant to enable go bindings.

Test build:
```
-- linux-ubuntu24.10-skylake / gcc@14.2.0 -----------------------
cs6zecx mlpack@4.5.1~go~ipo~julia+python~r+shared build_system=cmake build_type=Release generator=make
==> 1 installed package
```