### PR TITLE
lhapdf: add v6.5.5

### DIFF
--- a/var/spack/repos/builtin/packages/lhapdf/package.py
+++ b/var/spack/repos/builtin/packages/lhapdf/package.py
@@ -22,6 +22,7 @@ class Lhapdf(AutotoolsPackage):
 
     license("GPL-3.0-or-later")
 
+    version("6.5.5", sha256="d20d8fb71936403274caec5bd584c891592b96c6319175df51d9bb69db869bd8")
     version("6.5.4", sha256="ace8913781044ad542e378697fcd95a8535d510818bb74a6665f9fd2b132ac0f")
     version("6.5.3", sha256="90fe7254d5a48a9b2d424fcbac1bf9708b0e54690efec4c78e9ad28b9203bfcd")
     version("6.5.2", sha256="23972ec46289c82a63df60b55b62f219418b4d80f94b8d570feb2b5e48014054")
@@ -40,6 +41,8 @@ class Lhapdf(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
 
+    depends_on("yaml-cpp", when="@6.5.5:")
+
     extends("python", when="+python")
     depends_on("py-cython", type="build", when="+python")
     depends_on("py-setuptools", type="build", when="+python")
@@ -56,6 +59,9 @@ class Lhapdf(AutotoolsPackage):
 
     def configure_args(self):
         args = ["FCFLAGS=-O3", "CFLAGS=-O3", "CXXFLAGS=-O3"]
+
+        if self.spec.satisfies("@6.5.5:"):
+            args.append(f"--with-yaml-cpp={self.spec.prefix['yaml-cpp']}")
 
         if self.spec.satisfies("+python"):
             args.append(

--- a/var/spack/repos/builtin/packages/lhapdf/package.py
+++ b/var/spack/repos/builtin/packages/lhapdf/package.py
@@ -61,7 +61,7 @@ class Lhapdf(AutotoolsPackage):
         args = ["FCFLAGS=-O3", "CFLAGS=-O3", "CXXFLAGS=-O3"]
 
         if self.spec.satisfies("@6.5.5:"):
-            args.append(f"--with-yaml-cpp={self.spec.prefix['yaml-cpp']}")
+            args.append(f"--with-yaml-cpp={self.spec['yaml-cpp'].prefix}")
 
         if self.spec.satisfies("+python"):
             args.append(


### PR DESCRIPTION
This PR adds `lhapdf`, v6.5.5 ([diff](https://gitlab.com/hepcedar/lhapdf/-/compare/lhapdf-6.5.4...lhapdf-6.5.5)), which adds the `--with-yaml-cpp` configure flag for external `yaml-cpp` installs.

Test build:
```
-- linux-ubuntu24.10-skylake / gcc@14.2.0 -----------------------
qzmhzzr lhapdf@6.5.5+python build_system=autotools
==> 1 installed package
```