### PR TITLE
py-mplhep: add v0.3.55

### DIFF
--- a/var/spack/repos/builtin/packages/py-mplhep-data/package.py
+++ b/var/spack/repos/builtin/packages/py-mplhep-data/package.py
@@ -8,13 +8,15 @@ from spack.package import *
 class PyMplhepData(PythonPackage):
     """Font (Data) sub-package for mplhep"""
 
-    homepage = "https://github.com/Scikit-HEP/mplhep_data"
+    homepage = "https://github.com/scikit-hep/mplhep_data"
     pypi = "mplhep_data/mplhep_data-0.0.3.tar.gz"
 
     license("MIT")
 
+    version("0.0.4", sha256="cd1f3ad3af9dbff33aef9e7406d2130d624a0bd1d5aa5970fc713a6421165a4e")
     version("0.0.3", sha256="b54d257f3f53c93a442cda7a6681ce267277e09173c0b41fd78820f78321772f")
 
     depends_on("python@3.7:", type=("build", "run"))
+    depends_on("python@3.8:", type=("build", "run"), when="@0.0.4:")
     depends_on("py-setuptools@42:", type="build")
     depends_on("py-setuptools-scm@3.4:+toml", type="build")

--- a/var/spack/repos/builtin/packages/py-mplhep/package.py
+++ b/var/spack/repos/builtin/packages/py-mplhep/package.py
@@ -11,17 +11,24 @@ class PyMplhep(PythonPackage):
     homepage = "https://github.com/scikit-hep/mplhep"
     pypi = "mplhep/mplhep-0.3.15.tar.gz"
 
-    license("MIT")
+    license("MIT", checked_by="wdconinc")
 
+    version("0.3.55", sha256="0fb87cd4b025225ba8fd5d82d58324cfb094fbcdd7929e5a9ea1ea7e22108814")
     version("0.3.26", sha256="d707a95ce59b0bac2fe4fe1c57fede14e15da639f3a7c732e7513a753fd9e9ac")
     version("0.3.15", sha256="595f796ea65930094e86a805214e0d44537ead267a7487ae16eda02d1670653e")
 
     depends_on("python@3.7:", type=("build", "run"))
-    depends_on("py-setuptools@39.2:", type="build")
-    depends_on("py-setuptools@42:", when="@0.3.26:", type="build")
-    depends_on("py-setuptools-scm@3.4:+toml", when="@0.3.2:", type="build")
+    depends_on("python@3.8:", type=("build", "run"), when="@0.3.29:")
+    with when("@0.3.53:"):
+        depends_on("py-hatchling", type="build")
+        depends_on("py-hatch-vcs", type="build")
+    with when("@:0.3.52"):
+        depends_on("py-setuptools@39.2:", type="build")
+        depends_on("py-setuptools@42:", when="@0.3.26:", type="build")
+        depends_on("py-setuptools-scm@3.4:+toml", when="@0.3.2:", type="build")
     depends_on("py-matplotlib@3.4:", type=("build", "run"))
     depends_on("py-mplhep-data", type=("build", "run"))
+    depends_on("py-mplhep-data@0.0.4:", type=("build", "run"), when="@0.3.54:")
     depends_on("py-numpy@1.16.0:", type=("build", "run"))
     depends_on("py-packaging", type=("build", "run"))
     depends_on("py-uhi@0.2.0:", type=("build", "run"))


### PR DESCRIPTION
This PR adds `py-mplhep`, v0.3.55 (and `py-mplhep-data`, v0.0.4), ([diff](https://github.com/scikit-hep/mplhep/compare/v0.3.26...v0.3.55)). Build system switched to hatchling.

Test build:
```
==> Installing py-mplhep-0.3.55-xrkfdw2oc3x3ztphxjxq7d3ibyk4k7we [132/132]
==> No binary for py-mplhep-0.3.55-xrkfdw2oc3x3ztphxjxq7d3ibyk4k7we found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/m/mplhep/mplhep-0.3.55.tar.gz
==> No patches needed for py-mplhep
==> py-mplhep: Executing phase: 'install'
==> py-mplhep: Successfully installed py-mplhep-0.3.55-xrkfdw2oc3x3ztphxjxq7d3ibyk4k7we
  Stage: 0.88s.  Install: 0.72s.  Post-install: 0.79s.  Total: 2.68s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/py-mplhep-0.3.55-xrkfdw2oc3x3ztphxjxq7d3ibyk4k7we
```