### PR TITLE
node-js: always depend on some python, regardless of lower/upper limits

### DIFF
--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -82,6 +82,7 @@ class NodeJs(Package):
 
     # python requirements are based according to
     # https://github.com/spack/spack/pull/47942#discussion_r1875624177
+    depends_on("python", type="build")
     depends_on("python@:3.7", when="@13.0.0:13.0.1", type="build")
     depends_on("python@:3.8", when="@13.1.0:14.13.1", type="build")
     depends_on("python@:3.9", when="@14.14.0:14.18.1", type="build")


### PR DESCRIPTION
This PR hotfixes develop after #47942 and #48084 got merged in parallel: #47942 would have failed checks if #48084 had been rebased into it.

In #47942 we didn't add lower-bounds since they are all satisfied by spack's supported python versions, but inadvertently this removed the requirement for any python if there is no upper limit that applies.

This PR ensures that `node-js` always depends on at least some python.