### PR TITLE
matlab 2019b - 2024b, installer fixes

### DIFF
--- a/var/spack/repos/spack_repo/builtin/packages/matlab/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/matlab/package.py
@@ -5,7 +5,13 @@
 import os
 import subprocess
 
+import spack.deptypes as dt
 from spack.package import *
+from spack.util.environment import EnvironmentModifications, is_system_path
+
+
+def use_archive_values(v):
+    return v == "<file-uri>" or v.startswith("file://")
 
 
 class Matlab(Package):
@@ -25,8 +31,67 @@ class Matlab(Package):
     homepage = "https://www.mathworks.com/products/matlab.html"
     manual_download = True
 
-    version("R2019b", sha256="d60787263afb810283b7820c4c8d9cb1f854c7cb80f47e136643fd95bf5fbd59")
-    version("R2018b", sha256="8cfcddd3878d3a69371c4e838773bcabf12aaf0362cc2e1ae7e8820845635cac")
+    version(
+        "R2024b",
+        md5="7edcb80bd5a4a1a586c48056bbb3ee69",
+        sha256="ed83bc45f36189f9f645271c44635bfac8e592aa28a2777b55cb210e3f0a92ec",
+    )
+    version(
+        "R2024a",
+        md5="174abc8966e11fce8bb030cceac3434d",
+        sha256="e07f09ccb6430205b601c298a366ccbede0733a7d44b88a51c51cece946f27a1",
+    )
+    version(
+        "R2023b",
+        preferred=True,
+        md5="918e10896b6cec0c7940cf6fcdb7ddd8",
+        sha256="4964cec46f0f506b077579398d4fad5fd081de556014e3bf5c2622c42ab46ffc",
+    )
+    version(
+        "R2023a",
+        md5="56b86eef09f3938e162f67c29e2fbdf9",
+        sha256="586dcab53403e08aef6e1abea42fec5fa2a81cd7bd75607641cdad8c57c03259",
+    )
+    version(
+        "R2022b",
+        md5="a3328203a7c87dc87c456dbdbf633a0b",
+        sha256="f1a6b10f3d2435e301e9fad84df7355dc947b2f99ab2a338fe2144d0228c8dde",
+    )
+    version(
+        "R2022a",
+        md5="d4adde66e76e6314e95eb76a4479eb5a",
+        sha256="91baa0b652cf1705f264b28c62b06bc2be4fdfa034b941b6de59452d1cb6ee5f",
+    )
+    version(
+        "R2021b",
+        md5="47437cc62fb338354aa1cb76416124cb",
+        sha256="acf8c4ee617ac513313f764dc70f3fb916d2415972b254e0f463d24d746a71c2",
+    )
+    version(
+        "R2021a",
+        md5="28e6be6ca187f8456b4830ba25e8b97d",
+        sha256="53250f1e5ad67747fdc005e8494e04863cf133f6de8842c1d051c491dbe3c470",
+    )
+    version(
+        "R2020b",
+        md5="34fc14993b6a593ba5bd18ad68fc8939",
+        sha256="a30bf88388dc47cced375e646fde0aed9e4df2b59ac6899589728460b1ab6472",
+    )
+    version(
+        "R2020a",
+        md5="47cc405f2c10c3ae3f79bb25f4e58b64",
+        sha256="d16b0cfd798619d0a05d5443b6679e42dfa08ddd2b493cbb4ce7015ba9bd26b4",
+    )
+    version(
+        "R2019b",
+        sha256="d60787263afb810283b7820c4c8d9cb1f854c7cb80f47e136643fd95bf5fbd59",
+        md5="ab21180fcbf0c7a64ea50e51e2f740ba",
+    )
+    version(
+        "R2018b",
+        sha256="8cfcddd3878d3a69371c4e838773bcabf12aaf0362cc2e1ae7e8820845635cac",
+        md5="2dc9e0224a93a99ae6d514d0330c4ec9",
+    )
     version("R2016b", sha256="a3121057b1905b132e5741de9f7f8350378592d84c5525faf3ec571620a336f2")
     version("R2015b", sha256="dead402960f4ab8f22debe8b28a402069166cd967d9dcca443f6c2940b00a783")
 
@@ -36,9 +101,62 @@ class Matlab(Package):
         values=("interactive", "silent", "automated"),
         description="Installation mode (interactive, silent, or automated)",
     )
-
     variant(
         "key", default="<installation-key-here>", description="The file installation key to use"
+    )
+    variant(
+        "use_archive",
+        default="<file-uri>",
+        values=use_archive_values,
+        description="file:///path/to/archives.tar or compressed tar into archives "
+        + "in order to work with offline installs. "
+        + "The archive should contain in its root './common', './glnxa64' and other folders. "
+        + "Defaults to download from MathWorks, does not require an archive file."
+        + "Note: You will need to login to MathWorks to download the archive.",
+    )
+
+    depends_on("gtkplus-2@2")
+    depends_on("alsa-lib", type=dt.ALL_TYPES)
+    depends_on("atk", type=dt.ALL_TYPES)
+    depends_on("at-spi2-core", type=dt.ALL_TYPES)
+    depends_on("gdk-pixbuf", type=dt.ALL_TYPES)
+    depends_on("pango", type=dt.ALL_TYPES)
+
+    with when("@R2021b:"):
+        depends_on("cups", type=dt.ALL_TYPES)
+        depends_on("libxcomposite", type=dt.ALL_TYPES)
+        depends_on("libxcursor", type=dt.ALL_TYPES)
+        depends_on("libxdamage", type=dt.ALL_TYPES)
+        depends_on("libxinerama", type=dt.ALL_TYPES)
+        depends_on("libxrandr", type=dt.ALL_TYPES)
+        depends_on("libxt", type=dt.ALL_TYPES)
+        depends_on("nspr", type=dt.ALL_TYPES)
+        depends_on("nss", type=dt.ALL_TYPES)
+
+    with when("@:R2021a"):
+        depends_on("java", type=dt.ALL_TYPES)
+        depends_on("cairo", type=dt.ALL_TYPES)
+        depends_on("libffi", type=dt.ALL_TYPES)
+
+    with when("@:R2022a"):
+        depends_on("libxi", type=dt.ALL_TYPES)
+        depends_on("libxtst", type=dt.ALL_TYPES)
+
+    depends_on("libtiff", type=dt.ALL_TYPES, when="@R2022a")
+
+    with when("@R2024b"):
+        depends_on("fribidi", type=dt.ALL_TYPES)
+        depends_on("libmd", type=dt.ALL_TYPES)
+        depends_on("libxfont2", type=dt.ALL_TYPES)
+
+    conflicts(
+        "mode=silent use_archive=<file-uri>",
+        message="You must have all files required for offline installation in the archive.",
+    )
+    conflicts(
+        "mode=automated use_archive=<file-uri>",
+        message="You must have all files required for offline installation in the archive.",
+        when="@R2022a:",
     )
 
     # Licensing
@@ -51,7 +169,29 @@ class Matlab(Package):
     extendable = True
 
     def url_for_version(self, version):
+        if version >= Version("R2024"):
+            return "file://{0}/matlab_{1}_Linux.zip".format(os.getcwd(), version)
         return "file://{0}/matlab_{1}_glnxa64.zip".format(os.getcwd(), version)
+
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        super().setup_run_environment(env)
+        for spec in list(self.spec.traverse(order="topo", deptype=dt.BUILD)):
+            if spec.virtual or is_system_path(spec.prefix):
+                continue
+            if os.path.isdir(spec.prefix.lib):
+                env.prepend_path("LD_LIBRARY_PATH", spec.prefix.lib)
+            if os.path.isdir(spec.prefix.lib64):
+                env.prepend_path("LD_LIBRARY_PATH", spec.prefix.lib64)
+
+    def setup_build_environment(self, env):
+        super().setup_run_environment(env)
+        for spec in list(self.spec.traverse(order="topo", deptype=dt.BUILD)):
+            if spec.virtual or is_system_path(spec.prefix):
+                continue
+            if os.path.isdir(spec.prefix.lib):
+                env.prepend_path("LD_LIBRARY_PATH", spec.prefix.lib)
+            if os.path.isdir(spec.prefix.lib64):
+                env.prepend_path("LD_LIBRARY_PATH", spec.prefix.lib64)
 
     def install(self, spec, prefix):
         config = {
@@ -61,6 +201,8 @@ class Matlab(Package):
             "licensePath": self.global_license_file,
             "agreeToLicense": "yes",
         }
+        if self.spec.platform == "linux":
+            config["outputFile"] = "/dev/stdout"
 
         # Store values requested by the installer in a file
         with open("spack_installer_input.txt", "w") as input_file:
@@ -70,17 +212,16 @@ class Matlab(Package):
         # Run silent installation script
         # Full path required
         input_file = join_path(self.stage.source_path, "spack_installer_input.txt")
+
+        if len(self.spec.variants["use_archive"].value.split("file://")) == 2:
+            subprocess.call(
+                [
+                    "tar",
+                    "-C",
+                    join_path(self.stage.source_path, "archives"),
+                    "-xf",
+                    self.spec.variants["use_archive"].value.split("file://")[1],
+                ]
+            )
+
         subprocess.call(["./install", "-inputFile", input_file])
-
-    @run_after("install")
-    def post_install(self):
-        # Fix broken link
-        with working_dir(self.spec.prefix.bin.glnxa64):
-            os.unlink("libSDL2.so")
-            os.symlink("libSDL2-2.0.so.0.2.1", "libSDL2.so")
-
-        # Fix to random exceptions when changing display settings
-        # https://www.mathworks.com/matlabcentral/answers/373897-external-monitor-throws-java-exception
-        java_opts = os.path.join(self.spec.prefix.bin.glnxa64, "java.opts")
-        with open(java_opts, "w") as out:
-            out.write("-Dsun.java2d.xrender=false\n")


### PR DESCRIPTION
Update the matlab package until recent versions

- verified working for R2018b-R2024a
- hashes for `R{2020..2024}{a,b}`
- updated preferred to `R2023b`
- remove fixes that seem unnecessary
- add all known dependencies for GUI to work (tested on system without gtk2