### PR TITLE
Avoid trailing slashes in strings

### DIFF
--- a/lib/spack/spack/bootstrap/core.py
+++ b/lib/spack/spack/bootstrap/core.py
@@ -548,10 +548,9 @@ def ensure_winsdk_external_or_raise() -> None:
             missing_packages_lst.append("win-sdk")
         missing_packages = " & ".join(missing_packages_lst)
         raise RuntimeError(
-            f"Unable to find the {missing_packages}, please install these packages \
-via the Visual Studio installer \
-before proceeding with Spack or provide the path to a non standard install with \
-'spack external find --path'"
+            f"Unable to find the {missing_packages}, please install these packages via the Visual "
+            "Studio installer before proceeding with Spack or provide the path to a non standard "
+            "install with 'spack external find --path'"
         )
     # wgl/sdk are not required for bootstrapping Spack, but
     # are required for building anything non trivial

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -234,7 +234,7 @@ class CDashHandler:
         if spec:
             build_name = (
                 f"{spec.name}@{spec.version}%{spec.compiler} "
-                "hash={spec.dag_hash()} arch={spec.architecture} ({self.build_group})"
+                f"hash={spec.dag_hash()} arch={spec.architecture} ({self.build_group})"
             )
             tty.debug(f"Generated CDash build name ({build_name}) from the {spec.name}")
             return build_name

--- a/lib/spack/spack/ci/common.py
+++ b/lib/spack/spack/ci/common.py
@@ -232,8 +232,10 @@ class CDashHandler:
 
         Returns: (str) given spec's CDash build name."""
         if spec:
-            build_name = f"{spec.name}@{spec.version}%{spec.compiler} \
-hash={spec.dag_hash()} arch={spec.architecture} ({self.build_group})"
+            build_name = (
+                f"{spec.name}@{spec.version}%{spec.compiler} "
+                "hash={spec.dag_hash()} arch={spec.architecture} ({self.build_group})"
+            )
             tty.debug(f"Generated CDash build name ({build_name}) from the {spec.name}")
             return build_name
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -279,8 +279,10 @@ def test_add_config_path(mutable_config):
     assert "gcc" in compilers
 
     # Try quotes to escape brackets
-    path = "config:install_tree:projections:cmake:\
-'{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+    path = (
+        "config:install_tree:projections:cmake:"
+        "'{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+    )
     spack.config.add(path)
     set_value = spack.config.get("config")["install_tree"]["projections"]["cmake"]
     assert set_value == "{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}"

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -1174,7 +1174,7 @@ def test_parse_specfile_dependency(default_mock_concretization, tmpdir):
         # Should also be accepted: "spack spec ../<cur-dir>/libelf.yaml"
         spec = SpecParser(
             f"libdwarf^..{os.path.sep}{specfile.dirpath().basename}"
-            "{os.path.sep}{specfile.basename}"
+            f"{os.path.sep}{specfile.basename}"
         ).next_spec()
         assert spec["libelf"] == s["libelf"]
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -1173,8 +1173,8 @@ def test_parse_specfile_dependency(default_mock_concretization, tmpdir):
 
         # Should also be accepted: "spack spec ../<cur-dir>/libelf.yaml"
         spec = SpecParser(
-            f"libdwarf^..{os.path.sep}{specfile.dirpath().basename}\
-{os.path.sep}{specfile.basename}"
+            f"libdwarf^..{os.path.sep}{specfile.dirpath().basename}"
+            "{os.path.sep}{specfile.basename}"
         ).next_spec()
         assert spec["libelf"] == s["libelf"]
 

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -259,8 +259,7 @@ def _system_7zip(archive_file):
     _7z = which("7z")
     if not _7z:
         raise CommandNotFoundError(
-            "7z unavailable,\
-unable to extract %s files. 7z can be installed via Spack"
+            "7z unavailable, unable to extract %s files. 7z can be installed via Spack"
             % llnl.url.extension_from_path(archive_file)
         )
     _7z.add_default_arg("e")

--- a/var/spack/repos/builtin/packages/abacus/package.py
+++ b/var/spack/repos/builtin/packages/abacus/package.py
@@ -68,7 +68,7 @@ NP      = 14
             spec["fftw"].prefix,
             spec["elpa"].prefix,
             inc_var,
-            f"{spec['elpa'].version}",
+            spec["elpa"].version,
             spec["cereal"].prefix,
         )
 

--- a/var/spack/repos/builtin/packages/abacus/package.py
+++ b/var/spack/repos/builtin/packages/abacus/package.py
@@ -52,26 +52,24 @@ class Abacus(MakefilePackage):
             inc_var = "-"
             system_var = "ELPA_LIB = -L${ELPA_LIB_DIR} -lelpa -Wl,-rpath=${ELPA_LIB_DIR}"
 
-        tempInc = (
-            "\
-FORTRAN = ifort\n\
-CPLUSPLUS = icpc\n\
-CPLUSPLUS_MPI = mpiicpc\n\
-LAPACK_DIR = $(MKLROOT)\n\
-FFTW_DIR = %s\n\
-ELPA_DIR = %s\n\
-ELPA_INCLUDE = -I${ELPA_DIR}/include/elpa%s%s\n\
-CEREAL_DIR = %s\n\
-OBJ_DIR = obj\n\
-OBJ_DIR_serial = obj\n\
-NP      = 14\n"
-            % (
-                spec["fftw"].prefix,
-                spec["elpa"].prefix,
-                inc_var,
-                f"{spec['elpa'].version}",
-                spec["cereal"].prefix,
-            )
+        tempInc = """
+FORTRAN = ifort
+CPLUSPLUS = icpc
+CPLUSPLUS_MPI = mpiicpc
+LAPACK_DIR = $(MKLROOT)
+FFTW_DIR = %s
+ELPA_DIR = %s
+ELPA_INCLUDE = -I${ELPA_DIR}/include/elpa%s%s
+CEREAL_DIR = %s
+OBJ_DIR = obj
+OBJ_DIR_serial = obj
+NP      = 14
+""" % (
+            spec["fftw"].prefix,
+            spec["elpa"].prefix,
+            inc_var,
+            f"{spec['elpa'].version}",
+            spec["cereal"].prefix,
         )
 
         with open(self.build_directory + "/Makefile.vars", "w") as f:

--- a/var/spack/repos/builtin/packages/axl/package.py
+++ b/var/spack/repos/builtin/packages/axl/package.py
@@ -75,8 +75,8 @@ class Axl(CMakePackage):
     variant(
         "bbapi_fallback",
         default=False,
-        description="Using BBAPI, if source or destination don't support \
-            file extents then fallback to pthreads",
+        description="Using BBAPI, if source or destination don't support "
+        "file extents then fallback to pthreads",
     )
 
     variant("dw", default=False, description="Enable Cray DataWarp support")

--- a/var/spack/repos/builtin/packages/babelstream/package.py
+++ b/var/spack/repos/builtin/packages/babelstream/package.py
@@ -86,16 +86,14 @@ class Babelstream(CMakePackage, CudaPackage, ROCmPackage, MakefilePackage):
         values=("cuda", "rocm"),
         default="cuda",
         when="+thrust",
-        description="Which THRUST implementation to use, supported options include option= \
-            - CUDA (via https://github.com/NVIDIA/thrust)\
-            - ROCM (via https://github.com/ROCmSoftwarePlatform/rocThrust)",
+        description="Which THRUST implementation to use",
     )
     variant(
         "thrust_backend",
         values=("cuda", "omp", "tbb"),
         default="cuda",
         when="+thrust",
-        description="Which THRUST implementation to use, supported options include option",
+        description="Which THRUST implementation to use",
     )
 
     # Kokkos variant
@@ -146,8 +144,8 @@ class Babelstream(CMakePackage, CudaPackage, ROCmPackage, MakefilePackage):
         values=("nvhpc", "none"),
         default="none",
         when="+std",
-        description="Enable offloading support (via the non-standard `-stdpar`)\
-                    for the new NVHPC SDK",
+        description="Enable offloading support (via the non-standard `-stdpar`) "
+        "for the new NVHPC SDK",
     )
     variant(
         "std_onedpl_backend",
@@ -161,16 +159,16 @@ class Babelstream(CMakePackage, CudaPackage, ROCmPackage, MakefilePackage):
         values=(True, False),
         default=False,
         when="+std",
-        description="No-op if ONE_TBB_DIR is set. Link against an in-tree oneTBB\
-                    via FetchContent_Declare, see top level CMakeLists.txt for details",
+        description="No-op if ONE_TBB_DIR is set. Link against an in-tree oneTBB "
+        "via FetchContent_Declare, see top level CMakeLists.txt for details",
     )
     variant(
         "std_use_onedpl",
         values=(True, False),
         default=False,
         when="+std",
-        description="Link oneDPL which implements C++17 executor policies\
-                    (via execution_policy_tag) for different backends",
+        description="Link oneDPL which implements C++17 executor policies "
+        "(via execution_policy_tag) for different backends",
     )
     # hip memory mode
     variant(
@@ -186,9 +184,9 @@ class Babelstream(CMakePackage, CudaPackage, ROCmPackage, MakefilePackage):
         values=(True, False),
         default=False,
         when="+tbb",
-        description="Whether to use std::vector<T> for storage or use aligned_alloc. \
-                     C++ vectors are *zero* initialised where as aligned_alloc is \
-                     uninitialised before first use.",
+        description="Whether to use std::vector<T> for storage or use aligned_alloc. "
+        "C++ vectors are *zero* initialised where as aligned_alloc is "
+        "uninitialised before first use.",
     )
 
     # Thrust Conflict
@@ -208,13 +206,7 @@ class Babelstream(CMakePackage, CudaPackage, ROCmPackage, MakefilePackage):
         values=("auto", "affinity", "static", "simple"),
         default="auto",
         when="+tbb",
-        description="Partitioner specifies how a loop template should partition its work among threads.\
-            Possible values are:\
-            AUTO     - Optimize range subdivision based on work-stealing events.\
-            AFFINITY - Proportional splitting that optimizes for cache affinity.\
-            STATIC   - Distribute work uniformly with no additional load balancing.\
-            SIMPLE   - Recursively split its range until it cannot be further subdivided.\
-            See https://spec.oneapi.com/versions/latest/elements/oneTBB/source/algorithms.html#partitioners",
+        description="Specifies how a loop template should partition its work among threads",
     )
 
     # Kokkos & RAJA Dependency

--- a/var/spack/repos/builtin/packages/berkeleygw/package.py
+++ b/var/spack/repos/builtin/packages/berkeleygw/package.py
@@ -137,10 +137,9 @@ class Berkeleygw(MakefilePackage):
         # use parallelization in tests
         filter_file(
             r"cd testsuite \&\& \$\(MAKE\) check$",
-            "cd testsuite && export BGW_TEST_MPI_NPROCS=2 OMP_NUM_THREADS=2 \
-             SAVETESTDIRS=yes TEMPDIRPATH=%s && \
-             $(MAKE) check-parallel"
-            % join_path(self.build_directory, "tmp"),
+            "cd testsuite && export BGW_TEST_MPI_NPROCS=2 OMP_NUM_THREADS=2 "
+            "SAVETESTDIRS=yes TEMPDIRPATH=%s && "
+            "$(MAKE) check-parallel" % join_path(self.build_directory, "tmp"),
             "Makefile",
         )
 

--- a/var/spack/repos/builtin/packages/breakdancer/package.py
+++ b/var/spack/repos/builtin/packages/breakdancer/package.py
@@ -52,8 +52,7 @@ class Breakdancer(CMakePackage):
     def edit(self):
         # perl tools end up in a silly lib subdirectory, fixing that
         filter_file(
-            r"set\(SUPPORT_LIBDIR lib\/breakdancer-max\$ \
-                    \{EXE_VERSION_SUFFIX\}\)",
+            r"set\(SUPPORT_LIBDIR lib\/breakdancer-max\$ \{EXE_VERSION_SUFFIX\}\)",
             "set(SUPPORT_LIBDIR lib)",
             join_path(self.stage.source_path, "perl", "CMakeLists.txt"),
         )

--- a/var/spack/repos/builtin/packages/cbtf-argonavis/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-argonavis/package.py
@@ -27,8 +27,7 @@ class CbtfArgonavis(CMakePackage):
     variant(
         "crayfe",
         default=False,
-        description="build only the FE tool using the runtime_dir \
-                         to point to target build.",
+        description="build only the FE tool using the runtime_dir to point to target build.",
     )
     variant(
         "runtime", default=False, description="build only the runtime libraries and collectors."

--- a/var/spack/repos/builtin/packages/cbtf-krell/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-krell/package.py
@@ -48,8 +48,7 @@ class CbtfKrell(CMakePackage):
     variant(
         "crayfe",
         default=False,
-        description="build only the FE tool using the runtime_dir \
-                         to point to target build.",
+        description="build only the FE tool using the runtime_dir to point to target build.",
     )
 
     # Dependencies for cbtf-krell

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -278,9 +278,7 @@ class Charmpp(Package):
         if not ("backend=mpi" in self.spec) or not ("backend=netlrts" in self.spec):
             if self.spec.satisfies("+pthreads"):
                 raise InstallError(
-                    "The pthreads option is only\
-                                    available on the Netlrts and MPI \
-                                    network layers."
+                    "The pthreads option is only available on the Netlrts and MPI network layers."
                 )
 
         if (
@@ -290,10 +288,8 @@ class Charmpp(Package):
         ):
             if self.spec.satisfies("pmi=none"):
                 raise InstallError(
-                    "The UCX/OFI/GNI backends need \
-                                    PMI to run. Please add pmi=... \
-                                    Note that PMIx is the preferred \
-                                    option."
+                    "The UCX/OFI/GNI backends need PMI to run. Please add pmi=... "
+                    "Note that PMIx is the preferred option."
                 )
 
         if (
@@ -303,10 +299,8 @@ class Charmpp(Package):
         ):
             if self.spec.satisfies("^openmpi"):
                 raise InstallError(
-                    "To use any process management \
-                                    interface other than PMIx, \
-                                    a non OpenMPI based MPI must be \
-                                    present on the system"
+                    "To use any process management interface other than PMIx, "
+                    "a non OpenMPI based MPI must be present on the system"
                 )
 
         target = spec.variants["build-target"].value

--- a/var/spack/repos/builtin/packages/flamemaster/package.py
+++ b/var/spack/repos/builtin/packages/flamemaster/package.py
@@ -168,11 +168,10 @@ class Flamemaster(CMakePackage):
                 ]
             )
             if self.spec.satisfies("%icc"):
-                cxxflags = "-Ofast -ffast-math -DNDEBUG -march=native\
-                        -mtune=native -funroll-all-loops\
-                        -qopt-multi-version-aggressive -ipo -parallel"
-                cflags = "-Ofast -ffast-math -DNDEBUG -march=native\
-                        -mtune=native -funroll-all-loops -ipo -parallel"
+                cxxflags = "-Ofast -ffast-math -DNDEBUG -march=native -mtune=native "
+                cxxflags += "-funroll-all-loops -qopt-multi-version-aggressive -ipo -parallel"
+                cflags = "-Ofast -ffast-math -DNDEBUG -march=native -mtune=native "
+                cflags += "-funroll-all-loops -ipo -parallel"
                 fcflags = "-Ofast -march=native -mtune=native -ipo -parallel"
                 args.extend(
                     [

--- a/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-ssl2/package.py
@@ -25,8 +25,8 @@ class FujitsuSsl2(Package):
 
     def install(self, spec, prefix):
         raise InstallError(
-            "Fujitsu SSL2 is not installable; it is vendor supplied \
-             You need to specify it as an external package in packages.yaml"
+            "Fujitsu SSL2 is not installable; it is vendor supplied "
+            "You need to specify it as an external package in packages.yaml"
         )
 
     @property

--- a/var/spack/repos/builtin/packages/fxt/package.py
+++ b/var/spack/repos/builtin/packages/fxt/package.py
@@ -57,8 +57,7 @@ class Fxt(AutotoolsPackage):
                 subprocess.check_call("./autogen.sh")
             else:
                 raise RuntimeError(
-                    "Neither configure nor autogen.sh script exist.\
-                FxT Cannot configure."
+                    "Neither configure nor autogen.sh script exist. FxT Cannot configure."
                 )
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/graphblast/package.py
+++ b/var/spack/repos/builtin/packages/graphblast/package.py
@@ -42,8 +42,7 @@ class Graphblast(MakefilePackage, CudaPackage):
     conflicts(
         "cuda_arch=none",
         when="+cuda",
-        msg='Must specify CUDA compute capabilities of your GPU. \
-See "spack info graphblast"',
+        msg='Must specify CUDA compute capabilities of your GPU. See "spack info graphblast"',
     )
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/gunrock/package.py
+++ b/var/spack/repos/builtin/packages/gunrock/package.py
@@ -87,8 +87,7 @@ class Gunrock(CMakePackage, CudaPackage):
     conflicts(
         "cuda_arch=none",
         when="+cuda",
-        msg='Must specify CUDA compute capabilities of your GPU. \
-See "spack info gunrock"',
+        msg='Must specify CUDA compute capabilities of your GPU. See "spack info gunrock"',
     )
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/hermes-shm/package.py
+++ b/var/spack/repos/builtin/packages/hermes-shm/package.py
@@ -50,8 +50,7 @@ class HermesShm(CMakePackage):
     depends_on("mochi-thallium+cereal@0.10.1", when="+mochi")
     depends_on("cereal", when="+cereal")
     depends_on(
-        "boost@1.7: +context +fiber +coroutine +regex +system \
-    +filesystem +serialization +pic +math",
+        "boost@1.7:+context+fiber+coroutine+regex+system+filesystem+serialization+pic+math",
         when="+boost",
     )
     depends_on("mpi", when="+mpiio")

--- a/var/spack/repos/builtin/packages/isaac-server/package.py
+++ b/var/spack/repos/builtin/packages/isaac-server/package.py
@@ -29,8 +29,11 @@ class IsaacServer(CMakePackage):
 
     depends_on("cxx", type="build")  # generated
 
-    # variant('gstreamer', default=False, description= \
-    #         'Support for RTP streams, e.g. to Twitch or Youtube')
+    # variant(
+    #     "gstreamer",
+    #     default=False,
+    #     description="Support for RTP streams, e.g. to Twitch or Youtube"
+    # )
 
     depends_on("cmake@3.3:", type="build")
     depends_on("jpeg", type="link")

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -167,10 +167,7 @@ class Likwid(Package):
             supported_compilers = {"gcc": "GCCPOWER"}
         if self.compiler.name not in supported_compilers:
             raise RuntimeError(
-                "{0} is not a supported compiler \
-            to compile Likwid".format(
-                    self.compiler.name
-                )
+                "{0} is not a supported compiler to compile Likwid".format(self.compiler.name)
             )
 
         filter_file(

--- a/var/spack/repos/builtin/packages/llvm-openmp-ompt/package.py
+++ b/var/spack/repos/builtin/packages/llvm-openmp-ompt/package.py
@@ -31,8 +31,7 @@ class LlvmOpenmpOmpt(CMakePackage):
     variant(
         "standalone",
         default=False,
-        description="Build llvm openmpi ompt library as a \
-                         stand alone entity.",
+        description="Build llvm openmpi ompt library as a stand alone entity.",
     )
     # variant for building libomptarget
     variant(

--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -180,28 +180,20 @@ class Namd(MakefilePackage, CudaPackage, ROCmPackage):
                 if self.spec.satisfies("^charmpp@:6.10.1"):
                     optims_opts = {
                         "gcc": m64
-                        + "-O3 -fexpensive-optimizations \
-                                        -ffast-math -lpthread "
+                        + "-O3 -fexpensive-optimizations -ffast-math -lpthread "
                         + archopt,
                         "intel": "-O2 -ip -qopenmp-simd" + archopt,
                         "clang": m64 + "-O3 -ffast-math -fopenmp " + archopt,
-                        "aocc": m64
-                        + "-O3 -ffp-contract=fast -ffast-math \
-                                        -fopenmp "
-                        + archopt,
+                        "aocc": m64 + "-O3 -ffp-contract=fast -ffast-math -fopenmp " + archopt,
                     }
                 else:
                     optims_opts = {
                         "gcc": m64
-                        + "-O3 -fexpensive-optimizations \
-                                        -ffast-math -lpthread "
+                        + "-O3 -fexpensive-optimizations -ffast-math -lpthread "
                         + archopt,
                         "intel": "-O2 -ip " + archopt,
                         "clang": m64 + "-O3 -ffast-math -fopenmp " + archopt,
-                        "aocc": m64
-                        + "-O3 -ffp-contract=fast \
-                                        -ffast-math "
-                        + archopt,
+                        "aocc": m64 + "-O3 -ffp-contract=fast -ffast-math " + archopt,
                     }
 
                 if self.spec.satisfies("+avxtiles"):

--- a/var/spack/repos/builtin/packages/openradioss-engine/package.py
+++ b/var/spack/repos/builtin/packages/openradioss-engine/package.py
@@ -47,8 +47,8 @@ class OpenradiossEngine(CMakePackage):
         "%aocc",
         "%arm",
         policy="one_of",
-        msg="Openradioss-starter can be built using GNU Fortran, Intel Fortran, AOCC, \
-             or Armflang compilers only.",
+        msg="Openradioss-starter can be built using GNU Fortran, Intel Fortran, AOCC, "
+        "or Armflang compilers only.",
     )
 
     build_directory = "engine"

--- a/var/spack/repos/builtin/packages/openradioss-starter/package.py
+++ b/var/spack/repos/builtin/packages/openradioss-starter/package.py
@@ -46,8 +46,8 @@ class OpenradiossStarter(CMakePackage):
         "%aocc",
         "%arm",
         policy="one_of",
-        msg="Openradioss-starter can be built using GNU Fortran, Intel Fortran, AOCC, \
-             or Armflang compilers only.",
+        msg="Openradioss-starter can be built using GNU Fortran, Intel Fortran, AOCC, "
+        "or Armflang compilers only.",
     )
 
     build_directory = "starter"

--- a/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
@@ -47,8 +47,7 @@ class OpenspeedshopUtils(CMakePackage):
     variant(
         "crayfe",
         default=False,
-        description="build only the FE tool using the runtime_dir \
-                         to point to target build.",
+        description="build only the FE tool using the runtime_dir to point to target build.",
     )
     variant("cuda", default=False, description="build with cuda packages included.")
 
@@ -63,26 +62,22 @@ class OpenspeedshopUtils(CMakePackage):
     variant(
         "openmpi",
         default=False,
-        description="Build mpi collector for openmpi \
-                         MPI when variant is enabled.",
+        description="Build mpi collector for openmpi MPI when variant is enabled.",
     )
     variant(
         "mpt",
         default=False,
-        description="Build mpi collector for SGI \
-                         MPT MPI when variant is enabled.",
+        description="Build mpi collector for SGI MPT MPI when variant is enabled.",
     )
     variant(
         "mvapich2",
         default=False,
-        description="Build mpi collector for mvapich2\
-                         MPI when variant is enabled.",
+        description="Build mpi collector for mvapich2 MPI when variant is enabled.",
     )
     variant(
         "mpich2",
         default=False,
-        description="Build mpi collector for mpich2\
-                         MPI when variant is enabled.",
+        description="Build mpi collector for mpich2 MPI when variant is enabled.",
     )
 
     depends_on("cmake@3.0.2:", type="build")

--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -44,8 +44,7 @@ class Openspeedshop(CMakePackage):
     variant(
         "crayfe",
         default=False,
-        description="build only the FE tool using the runtime_dir \
-                         to point to target build.",
+        description="build only the FE tool using the runtime_dir to point to target build.",
     )
     variant("cuda", default=False, description="build with cuda packages included.")
 
@@ -67,26 +66,22 @@ class Openspeedshop(CMakePackage):
     variant(
         "openmpi",
         default=False,
-        description="Build mpi collector for openmpi \
-                         MPI when variant is enabled.",
+        description="Build mpi collector for openmpi MPI when variant is enabled.",
     )
     variant(
         "mpt",
         default=False,
-        description="Build mpi collector for SGI \
-                         MPT MPI when variant is enabled.",
+        description="Build mpi collector for SGI MPT MPI when variant is enabled.",
     )
     variant(
         "mvapich2",
         default=False,
-        description="Build mpi collector for mvapich2\
-                         MPI when variant is enabled.",
+        description="Build mpi collector for mvapich2 MPI when variant is enabled.",
     )
     variant(
         "mpich2",
         default=False,
-        description="Build mpi collector for mpich2\
-                         MPI when variant is enabled.",
+        description="Build mpi collector for mpich2 MPI when variant is enabled.",
     )
 
     depends_on("cmake@3.0.2:", type="build")

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -107,7 +107,7 @@ class ParallelNetcdf(AutotoolsPackage):
             return libs
 
         msg = f"Unable to recursively locate {'shared' if shared else 'static'} "
-        msg += "{self.spec.name} libraries in {self.spec.prefix}"
+        msg += f"{self.spec.name} libraries in {self.spec.prefix}"
         raise NoLibrariesError(msg)
 
     @when("@master")

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -106,8 +106,8 @@ class ParallelNetcdf(AutotoolsPackage):
         if libs:
             return libs
 
-        msg = f"Unable to recursively locate {'shared' if shared else 'static'} \
-{self.spec.name} libraries in {self.spec.prefix}"
+        msg = f"Unable to recursively locate {'shared' if shared else 'static'} "
+        msg += "{self.spec.name} libraries in {self.spec.prefix}"
         raise NoLibrariesError(msg)
 
     @when("@master")

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -612,8 +612,8 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             ("superlu-dist", "superlu_dist", True, True),
             ("scotch", "ptscotch", True, True),
             (
-                "suite-sparse:umfpack,klu,cholmod,btf,ccolamd,colamd,camd,amd, \
-                suitesparseconfig,spqr",
+                "suite-sparse:umfpack,klu,cholmod,btf,ccolamd,colamd,camd,amd,"
+                "suitesparseconfig,spqr",
                 "suitesparse",
                 True,
                 True,

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -81,11 +81,7 @@ class Pumi(CMakePackage):
     depends_on("zoltan+int64", when="+zoltan+int64")
     simbase = "+base"
     simkernels = simbase + "+parasolid+acis+discrete"
-    simfull = (
-        simkernels
-        + "+abstract+adv+advmodel\
-                            +import+paralleladapt+parallelmesh"
-    )
+    simfull = simkernels + "+abstract+adv+advmodel+import+paralleladapt+parallelmesh"
     depends_on("simmetrix-simmodsuite" + simbase, when="simmodsuite=base")
     depends_on("simmetrix-simmodsuite" + simkernels, when="simmodsuite=kernels")
     depends_on("simmetrix-simmodsuite" + simfull, when="simmodsuite=full")

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -112,8 +112,10 @@ class Qscintilla(QMakePackage):
                 # also add link statement to fix "undefined symbol _Z...Qsciprinter...
                 link_qscilibs = "LIBS += -L" + self.prefix.lib + " -lqscintilla2_" + qtx
                 tomlfile.write(
-                    f'\n[tool.sip.builder]\nqmake-settings = \
-                    ["QT += widgets", "QT += printsupport", "{link_qscilibs}"]\n'
+                    f"""
+[tool.sip.builder]
+qmake-settings = ["QT += widgets", "QT += printsupport", "{link_qscilibs}"]
+"""
                 )
 
             mkdirp(os.path.join(self.prefix.share.sip, pyqtx))

--- a/var/spack/repos/builtin/packages/riscv-gnu-toolchain/package.py
+++ b/var/spack/repos/builtin/packages/riscv-gnu-toolchain/package.py
@@ -169,9 +169,11 @@ class RiscvGnuToolchain(AutotoolsPackage):
         """
         with working_dir(self.stage.source_path):
             # modify Makefile not to git init submodules.
-            cmd = "/bin/sed -i.bak -r \
-            '/^# Rule for auto init submodules/,/git submodule update.*$/d' \
-            Makefile"
+            cmd = (
+                "/bin/sed -i.bak -r "
+                "'/^# Rule for auto init submodules/,/git submodule update.*$/d' "
+                "Makefile"
+            )
             p = Popen(shlex.split(cmd))
             p.wait()
             p.communicate()

--- a/var/spack/repos/builtin/packages/rocprofiler-dev/package.py
+++ b/var/spack/repos/builtin/packages/rocprofiler-dev/package.py
@@ -150,8 +150,7 @@ class RocprofilerDev(CMakePackage):
     def patch(self):
         filter_file(
             "${HSA_RUNTIME_LIB_PATH}/../include",
-            "${HSA_RUNTIME_LIB_PATH}/../include ${HSA_KMT_LIB_PATH}/..\
-                     /include",
+            "${HSA_RUNTIME_LIB_PATH}/../include ${HSA_KMT_LIB_PATH}/../include",
             "test/CMakeLists.txt",
             string=True,
         )

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -31,9 +31,9 @@ class Rocsolver(CMakePackage):
     variant(
         "optimal",
         default=True,
-        description="This option improves performance at the cost of increased binary \
-            size and compile time by adding specialized kernels \
-            for small matrix sizes",
+        description="This option improves performance at the cost of increased binary "
+        "size and compile time by adding specialized kernels "
+        "for small matrix sizes",
     )
     variant("asan", default=False, description="Build with address-sanitizer enabled or disabled")
 

--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -165,8 +165,8 @@ class Scr(CMakePackage):
         "bbapi_fallback",
         default=False,
         when="@3: +bbapi",
-        description="Using BBAPI, if source or destination don't support \
-            file extents then fallback to pthreads",
+        description="Using BBAPI, if source or destination don't support "
+        "file extents then fallback to pthreads",
     )
     depends_on("axl+bbapi+bbapi_fallback", when="@3: +bbapi_fallback")
 
@@ -189,8 +189,8 @@ class Scr(CMakePackage):
 
     # Enabling SCR logging is a WIP, for which this will be needed
     # MySQL currently having build issues
-    # variant('mysql', default=False, description='Build with MySQL to allow for \
-    #        capturing SCR and syslog messages in a database')
+    # variant('mysql', default=False, description='Build with MySQL to allow for '
+    #         'capturing SCR and syslog messages in a database')
     # depends_on('mysql', when='+mysql')
 
     variant("shared", default=True, when="@3:", description="Build with shared libraries")

--- a/var/spack/repos/builtin/packages/thornado-mini/package.py
+++ b/var/spack/repos/builtin/packages/thornado-mini/package.py
@@ -40,24 +40,19 @@ class ThornadoMini(MakefilePackage):
         file.write(
             "FLINKER_mymachine = %s %s\n" % (self.spec["mpi"].mpifc, self.compiler.openmp_flag)
         )
-        file.write(
-            "DEBUG_mymachine = -g -ffpe-trap=invalid,zero \
-        -fcheck=bounds\n"
-        )
+        file.write("DEBUG_mymachine = -g -ffpe-trap=invalid,zero -fcheck=bounds\n")
         file.write("OPTIMIZE_mymachine = -O2\n")
         file.write("INCLUDE_HDF5_mymachine = \n")
         file.write("INCLUDE_LAPACK_mymachine = \n")
         file.write("LIBRARIES_HDF5_mymachine = \n")
         file.write("LIBRARIES_LAPACK_mymachine = \n")
         file.write(
-            "export FORTRAN_mymachine FLINKER_mymachine \
-        DEBUG_mymachine OPTIMIZE_mymachine\n"
+            "export FORTRAN_mymachine FLINKER_mymachine DEBUG_mymachine OPTIMIZE_mymachine\n"
         )
 
         file.write("all:\n")
         file.write(
-            "\t@$(MAKE) -C $(THORNADO_DIR)/DeleptonizationProblem/Executables \
-        -f Makefile\n"
+            "\t@$(MAKE) -C $(THORNADO_DIR)/DeleptonizationProblem/Executables -f Makefile\n"
         )
 
         file.close()

--- a/var/spack/repos/builtin/packages/wgl/package.py
+++ b/var/spack/repos/builtin/packages/wgl/package.py
@@ -110,9 +110,7 @@ class Wgl(Package):
 
     def install(self, spec, prefix):
         raise RuntimeError(
-            "This package is not installable from Spack\
-            and should be installed on the system prior to Spack use.\
-                If not installed this package should be installed via\
-                    the Visual Studio installer in order to use the \
-                        MSVC compiler on Windows."
+            "This package is not installable from Spack and should be installed on the system "
+            "prior to Spack use. If not installed this package should be installed via the Visual "
+            "Studio installer in order to use the MSVC compiler on Windows."
         )

--- a/var/spack/repos/builtin/packages/win-sdk/package.py
+++ b/var/spack/repos/builtin/packages/win-sdk/package.py
@@ -81,12 +81,10 @@ class WinSdk(Package):
 
     def install(self, spec, prefix):
         raise RuntimeError(
-            "This package is not installable from Spack\
-            and should be installed on the system prior to Spack use.\
-                If not installed this package should be installed via\
-                    the Visual Studio installer in order to use the \
-                        MSVC compiler on Windows."
-            "If absolutely neccesary this SDK can be installed directly from Microsoft\
-                but this approach is not recommended unless you know what you're doing \
-                    or if you're on Windows 11 you have no choice for the moment."
+            "This package is not installable from Spack and should be installed on the system "
+            "prior to Spack use. If not installed this package should be installed via the Visual "
+            "Studio installer in order to use the MSVC compiler on Windows. If absolutely "
+            "necessary this SDK can be installed directly from Microsoft but this approach is not "
+            "recommended unless you know what you're doing or if you're on Windows 11 you have no "
+            "choice for the moment."
         )

--- a/var/spack/repos/builtin/packages/xdelta/package.py
+++ b/var/spack/repos/builtin/packages/xdelta/package.py
@@ -33,9 +33,6 @@ class Xdelta(AutotoolsPackage):
             bash = which("bash")
             bash(
                 "-c",
-                "aclocal && autoreconf --install \
-                    && libtoolize \
-                    && autoconf \
-                    && automake --add-missing \
-                    && automake",
+                "aclocal && autoreconf --install && libtoolize && autoconf && "
+                "automake --add-missing && automake",
             )


### PR DESCRIPTION
This PR removes most occurrences of trailing slashes in strings from Spack. The majority of them were done incorrectly, resulting in `spack info foo` containing extraneous whitespace.