### PR TITLE
Fix typo in copyright in sbang

### DIFF
--- a/bin/sbang
+++ b/bin/sbang
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright sbang project developers. See COPYRIGHT file for details.
+# Copyright Spack project developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 


### PR DESCRIPTION
I just happened to notice this looking at recent PRs.