### PR TITLE
tcsh: add v6.24.10, v6.24.14

### DIFF
--- a/var/spack/repos/builtin/packages/tcsh/package.py
+++ b/var/spack/repos/builtin/packages/tcsh/package.py
@@ -26,7 +26,7 @@ class Tcsh(AutotoolsPackage):
 
     license("BSD-3-Clause")
 
-    version("6.24.14", sha256="36880f258a63fc11fe72a65098b585ebc4ecdee24388b8ebec97e6ae8e485318") 
+    version("6.24.14", sha256="36880f258a63fc11fe72a65098b585ebc4ecdee24388b8ebec97e6ae8e485318")
     version("6.24.10", sha256="13475c0fbeb74139d33ed793bf00ffbbb2ac2dc9fb1d44467a410760aba36664")
     version("6.24.00", sha256="60be2c504bd8f1fa6e424b1956495d7e7ced52a2ac94db5fd27f4b6bfc8f74f0")
     version("6.22.02", sha256="ed287158ca1b00ba477e8ea57bac53609838ebcfd05fcb05ca95021b7ebe885b")

--- a/var/spack/repos/builtin/packages/tcsh/package.py
+++ b/var/spack/repos/builtin/packages/tcsh/package.py
@@ -26,6 +26,7 @@ class Tcsh(AutotoolsPackage):
 
     license("BSD-3-Clause")
 
+    version("6.24.14", sha256="36880f258a63fc11fe72a65098b585ebc4ecdee24388b8ebec97e6ae8e485318") 
     version("6.24.10", sha256="13475c0fbeb74139d33ed793bf00ffbbb2ac2dc9fb1d44467a410760aba36664")
     version("6.24.00", sha256="60be2c504bd8f1fa6e424b1956495d7e7ced52a2ac94db5fd27f4b6bfc8f74f0")
     version("6.22.02", sha256="ed287158ca1b00ba477e8ea57bac53609838ebcfd05fcb05ca95021b7ebe885b")

--- a/var/spack/repos/builtin/packages/tcsh/package.py
+++ b/var/spack/repos/builtin/packages/tcsh/package.py
@@ -24,6 +24,7 @@ class Tcsh(AutotoolsPackage):
 
     license("BSD-3-Clause")
 
+    version("6.24.10", sha256="13475c0fbeb74139d33ed793bf00ffbbb2ac2dc9fb1d44467a410760aba36664")
     version("6.24.00", sha256="60be2c504bd8f1fa6e424b1956495d7e7ced52a2ac94db5fd27f4b6bfc8f74f0")
     version("6.22.02", sha256="ed287158ca1b00ba477e8ea57bac53609838ebcfd05fcb05ca95021b7ebe885b")
     version("6.21.00", sha256="c438325448371f59b12a4c93bfd3f6982e6f79f8c5aef4bc83aac8f62766e972")
@@ -103,7 +104,14 @@ class Tcsh(AutotoolsPackage):
     fedora_patch(
         "8a6066c901fb4fc75013dd488ba958387f00c74d",
         "tcsh-6.20.00-manpage-memoryuse.patch",
+        when="@:6.24.03",
         sha256="3a4e60fe56a450632140c48acbf14d22850c1d72835bf441e3f8514d6c617a9f",
+    )
+    fedora_patch(
+        "86b95ed7b23bbff37f7af7ca5da4260e7b2ac635",
+        "tcsh-6.24.07-manpage-memoryuse.patch",
+        when="@6.24.04:",
+        sha256="64b9218c201d26ab9eccb3535434d107bc1da120c4f74b838711161e7279fd41",
     )
 
     depends_on("ncurses+termlib")

--- a/var/spack/repos/builtin/packages/tcsh/package.py
+++ b/var/spack/repos/builtin/packages/tcsh/package.py
@@ -19,8 +19,10 @@ class Tcsh(AutotoolsPackage):
     syntax."""
 
     homepage = "https://www.tcsh.org/"
-    url = "http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/tcsh-6.20.00.tar.gz"
-    list_url = "https://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/old/"
+    urls = [
+        "https://astron.com/pub/tcsh/tcsh-6.24.14.tar.gz",
+        "https://astron.com/pub/tcsh/old/tcsh-6.23.02.tar.gz",
+    ]
 
     license("BSD-3-Clause")
 


### PR DESCRIPTION
This PR adds `tcsh`, v6.24.10 and v6.24.14 ([diff](https://github.com/tcsh-org/tcsh/compare/TCSH6_24_00...TCSH6_24_14)), which requires a slightly different fedora patch since the tcsh.man page was renamed to tcsh.man.in. The funet mirror does not appear to sync anymore beyond 6.24.10, so the list_url was replaced in favor of direct urls for new and old releases.

Test build, 6.24.10:
```
==> Installing tcsh-6.24.10-czylk2m47pfxl2snkpsnofjlohmvkpyr [6/6]
==> No binary for tcsh-6.24.10-czylk2m47pfxl2snkpsnofjlohmvkpyr found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/13/13475c0fbeb74139d33ed793bf00ffbbb2ac2dc9fb1d44467a410760aba36664.tar.gz
==> Fetching https://src.fedoraproject.org/rpms/tcsh/raw/86b95ed7b23bbff37f7af7ca5da4260e7b2ac635/f/tcsh-6.24.07-manpage-memoryuse.patch
==> Applied patch https://src.fedoraproject.org/rpms/tcsh/raw/86b95ed7b23bbff37f7af7ca5da4260e7b2ac635/f/tcsh-6.24.07-manpage-memoryuse.patch
==> tcsh: Executing phase: 'autoreconf'
==> tcsh: Executing phase: 'configure'
==> tcsh: Executing phase: 'build'
==> tcsh: Executing phase: 'install'
==> tcsh: Successfully installed tcsh-6.24.10-czylk2m47pfxl2snkpsnofjlohmvkpyr
  Stage: 0.76s.  Autoreconf: 0.00s.  Configure: 4.78s.  Build: 23.46s.  Install: 0.10s.  Post-install: 0.16s.  Total: 29.35s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/tcsh-6.24.10-czylk2m47pfxl2snkpsnofjlohmvkpyr
```

Test build, 6.24.14:
```
==> Installing tcsh-6.24.14-lu77eond5t6nxseyljroxatakmgherfx [6/6]
==> No binary for tcsh-6.24.14-lu77eond5t6nxseyljroxatakmgherfx found: installing from source
==> Fetching https://astron.com/pub/tcsh/tcsh-6.24.14.tar.gz
==> Using cached archive: /opt/spack/cache/_source-cache/archive/64/64b9218c201d26ab9eccb3535434d107bc1da120c4f74b838711161e7279fd41
==> Applied patch https://src.fedoraproject.org/rpms/tcsh/raw/86b95ed7b23bbff37f7af7ca5da4260e7b2ac635/f/tcsh-6.24.07-manpage-memoryuse.patch
==> tcsh: Executing phase: 'autoreconf'
==> tcsh: Executing phase: 'configure'
==> tcsh: Executing phase: 'build'
==> tcsh: Executing phase: 'install'
==> tcsh: Successfully installed tcsh-6.24.14-lu77eond5t6nxseyljroxatakmgherfx
  Stage: 1.45s.  Autoreconf: 0.00s.  Configure: 14.20s.  Build: 1m 9.33s.  Install: 0.30s.  Post-install: 0.41s.  Total: 1m 25.94s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/tcsh-6.24.14-lu77eond5t6nxseyljroxatakmgherfx
```