### PR TITLE
hipsparselt, rocalution and omniperf: update hipsparselt and rocalutuion to 6.3.0 and fix omniperf typo

### DIFF
--- a/var/spack/repos/builtin/packages/hipsparselt/0001-update-llvm-path-add-hipsparse-include-dir-for-spack-6.3.patch
+++ b/var/spack/repos/builtin/packages/hipsparselt/0001-update-llvm-path-add-hipsparse-include-dir-for-spack-6.3.patch
@@ -1,0 +1,77 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1b48844..1d7ff86 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -202,7 +202,7 @@ else()
+         set( tensile_fork "ROCmSoftwarePlatform" CACHE STRING "Tensile fork to use" )
+         file (STRINGS "tensilelite_tag.txt" read_tensile_tag)
+         set( tensile_tag ${read_tensile_tag} CACHE STRING "Tensile tag to download" )
+-        virtualenv_install("git+https://github.com/${tensile_fork}/hipBLASLt.git@${tensile_tag}#subdirectory=tensilelite")
++        virtualenv_install("git+https://github.com/ROCm/hipBLASLt.git@modify-tensilelite-spack-6.3#subdirectory=tensilelite")
+ 
+         message (STATUS "using GIT Tensile fork=${tensile_fork} from branch=${tensile_tag}")
+       endif()
+diff --git a/clients/gtest/CMakeLists.txt b/clients/gtest/CMakeLists.txt
+index f85594b..d3a6599 100644
+--- a/clients/gtest/CMakeLists.txt
++++ b/clients/gtest/CMakeLists.txt
+@@ -53,6 +53,7 @@ target_include_directories( hipsparselt-test
+     $<BUILD_INTERFACE:${BLAS_INCLUDE_DIR}>
+     $<BUILD_INTERFACE:${BLIS_INCLUDE_DIR}> # may be blank if not used
+     $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
++    $<BUILD_INTERFACE:${HIPSPARSE_INCLUDE_DIRS}>
+ )
+ message("BLIS_INCLUDE_DIR=" ${BLIS_INCLUDE_DIR})
+ target_link_libraries( hipsparselt-test PRIVATE ${BLAS_LIBRARY} ${GTEST_BOTH_LIBRARIES} roc::hipsparselt )
+diff --git a/clients/samples/CMakeLists.txt b/clients/samples/CMakeLists.txt
+index 6b303d5..c6d608c 100644
+--- a/clients/samples/CMakeLists.txt
++++ b/clients/samples/CMakeLists.txt
+@@ -50,6 +50,11 @@ foreach( exe ${sample_list_all} )
+       $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
+       )
+ 
++  target_include_directories( ${exe}
++    SYSTEM PRIVATE
++      $<BUILD_INTERFACE:${HIPSPARSE_INCLUDE_DIRS}>
++      )
++
+   if( CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+     # GCC or hip-clang needs specific flags to turn on f16c intrinsics
+     target_compile_options( ${exe} PRIVATE -mf16c )
+diff --git a/library/CMakeLists.txt b/library/CMakeLists.txt
+index aac8506..e282268 100644
+--- a/library/CMakeLists.txt
++++ b/library/CMakeLists.txt
+@@ -58,6 +58,9 @@ include(src/CMakeLists.txt)
+ # Create hipSPARSELt library
+ add_library(hipsparselt ${hipsparselt_source} ${hipsparselt_headers_public})
+ add_library(roc::hipsparselt ALIAS hipsparselt)
++target_include_directories( hipsparselt PRIVATE ${HIPSPARSE_INCLUDE_DIRS} )
++target_include_directories( hipsparselt PRIVATE ${MSGPACK_DIR}/include )
++
+ 
+ # Target compile definitions
+ if(NOT BUILD_CUDA)
+diff --git a/library/src/CMakeLists.txt b/library/src/CMakeLists.txt
+index 97ad81e..b8f03b5 100755
+--- a/library/src/CMakeLists.txt
++++ b/library/src/CMakeLists.txt
+@@ -65,7 +65,7 @@ if(NOT BUILD_CUDA)
+     if(Tensile_CPU_THREADS MATCHES "^[0-9]+$")
+       # only including threads argument if number
+       TensileCreateLibraryFiles(
+-        "${CMAKE_CURRENT_SOURCE_DIR}/src/hcc_detail/rocsparselt/src/spmm/Tensile/Logic/${Tensile_LOGIC}"
++         "${CMAKE_CURRENT_SOURCE_DIR}/src/hcc_detail/rocsparselt/src/spmm/Tensile/Logic"
+         "${PROJECT_BINARY_DIR}/Tensile"
+         ARCHITECTURE        ${Tensile_ARCHITECTURE}
+         CODE_OBJECT_VERSION ${Tensile_CODE_OBJECT_VERSION}
+@@ -76,7 +76,7 @@ if(NOT BUILD_CUDA)
+       )
+     else()
+       TensileCreateLibraryFiles(
+-        "${CMAKE_CURRENT_SOURCE_DIR}/src/hcc_detail/rocsparselt/src/spmm/Tensile/Logic/${Tensile_LOGIC}"
++        "${CMAKE_CURRENT_SOURCE_DIR}/src/hcc_detail/rocsparselt/src/spmm/Tensile/Logic"
+         "${PROJECT_BINARY_DIR}/Tensile"
+         ARCHITECTURE        ${Tensile_ARCHITECTURE}
+         CODE_OBJECT_VERSION ${Tensile_CODE_OBJECT_VERSION}

--- a/var/spack/repos/builtin/packages/hipsparselt/package.py
+++ b/var/spack/repos/builtin/packages/hipsparselt/package.py
@@ -21,6 +21,7 @@ class Hipsparselt(CMakePackage, ROCmPackage):
     maintainers("srekolam", "afzpatel", "renjithravindrankannath")
 
     license("MIT")
+    version("6.3.0", sha256="f67ed4900101686596add37824d0628f1e71cf6a30d827a0519b3c3657f63ac3")
     version("6.2.4", sha256="7b007b346f89fac9214ad8541b3276105ce1cac14d6f95a8a504b5a5381c8184")
     version("6.2.1", sha256="a23287bc759442aebaccce0306f5e3938865240e13553847356c25c54214a0d4")
     version("6.2.0", sha256="a25a3ce0ed3cc616b1a4e38bfdd5e68463bb9fe791a56d1367b8a6373bb63d12")
@@ -46,9 +47,10 @@ class Hipsparselt(CMakePackage, ROCmPackage):
     )
     variant("asan", default=False, description="Build with address-sanitizer enabled or disabled")
 
-    for ver in ["6.0.0", "6.0.2", "6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.4"]:
+    for ver in ["6.0.0", "6.0.2", "6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.4", "6.3.0"]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"hipsparse@{ver}", when=f"@{ver}")
+        depends_on(f"llvm-amdgpu@{ver}", when=f"@{ver}")
         depends_on(f"rocm-openmp-extras@{ver}", when=f"@{ver}", type="test")
 
     depends_on("cmake@3.5:", type="build")
@@ -61,6 +63,7 @@ class Hipsparselt(CMakePackage, ROCmPackage):
     depends_on("py-joblib")
     depends_on("googletest@1.10.0:", type="test")
     depends_on("netlib-lapack@3.7.1:", type="test")
+    depends_on("rocm-smi-lib@6.3.0", when="@6.3.0")
 
     patch("0001-update-llvm-path-add-hipsparse-include-dir-for-spack.patch", when="@6.0")
     # Below patch sets the proper path for clang++,lld and clang-offload-blunder inside the
@@ -68,9 +71,18 @@ class Hipsparselt(CMakePackage, ROCmPackage):
     # for 6.1.0 release.
     patch("0001-update-llvm-path-add-hipsparse-include-dir-for-spack-6.1.patch", when="@6.1")
     patch("0001-update-llvm-path-add-hipsparse-include-dir-for-spack-6.2.patch", when="@6.2")
+    patch("0001-update-llvm-path-add-hipsparse-include-dir-for-spack-6.3.patch", when="@6.3")
 
     def setup_build_environment(self, env):
         env.set("CXX", self.spec["hip"].hipcc)
+        env.set("TENSILE_ROCM_ASSEMBLER_PATH", f"{self.spec['llvm-amdgpu'].prefix}/bin/clang++")
+        env.set(
+            "TENSILE_ROCM_OFFLOAD_BUNDLER_PATH",
+            f"{self.spec['llvm-amdgpu'].prefix}/bin/clang-offload-bundler",
+        )
+        env.set("ROCM_AGENT_ENUMERATOR_PATH", f"{self.spec['rocminfo'].prefix}/bin/rocm_agent_enumerator")
+        env.set("ROCM_SMI_PATH", f"{self.spec['rocm-smi-lib'].prefix}/bin/rocm-smi")
+
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/hipsparselt/package.py
+++ b/var/spack/repos/builtin/packages/hipsparselt/package.py
@@ -80,9 +80,11 @@ class Hipsparselt(CMakePackage, ROCmPackage):
             "TENSILE_ROCM_OFFLOAD_BUNDLER_PATH",
             f"{self.spec['llvm-amdgpu'].prefix}/bin/clang-offload-bundler",
         )
-        env.set("ROCM_AGENT_ENUMERATOR_PATH", f"{self.spec['rocminfo'].prefix}/bin/rocm_agent_enumerator")
+        env.set(
+            "ROCM_AGENT_ENUMERATOR_PATH",
+            f"{self.spec['rocminfo'].prefix}/bin/rocm_agent_enumerator",
+        )
         env.set("ROCM_SMI_PATH", f"{self.spec['rocm-smi-lib'].prefix}/bin/rocm-smi")
-
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/omniperf/package.py
+++ b/var/spack/repos/builtin/packages/omniperf/package.py
@@ -30,7 +30,7 @@ class Omniperf(CMakePackage):
     depends_on("py-pyyaml")
     depends_on("py-matplotlib")
     depends_on("py-pandas@1.4.3:")
-    depends_on("py-numpy@1.17.5")
+    depends_on("py-numpy@1.17.5:")
     depends_on("py-pymongo")
     depends_on("py-tabulate")
     depends_on("py-tqdm")

--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -21,10 +21,11 @@ class Rocalution(CMakePackage):
     url = "https://github.com/ROCm/rocALUTION/archive/rocm-6.1.2.tar.gz"
     tags = ["rocm"]
 
-    maintainers("cgmb", "srekolam", "renjithravindrankannath")
+    maintainers("cgmb", "srekolam", "renjithravindrankannath", "afzpatel")
     libraries = ["librocalution_hip"]
 
     license("MIT")
+    version("6.3.0", sha256="a7476e1ce79915cb8e01917de372ae6b15d7e51b1a25e15cde346dadf2391068")
     version("6.2.4", sha256="993c55e732d0ee390746890639486649f36ae806110cf7490b9bb5d49b0663c0")
     version("6.2.1", sha256="94f15add5316c81529ce84ae8bf2701e9a4df57d08eda04a2f70147d31b12632")
     version("6.2.0", sha256="fd9ad0aae5524d3995343d4d7c1948e7b21f0bdf5b1203d1de58548a814a9c39")
@@ -82,6 +83,7 @@ class Rocalution(CMakePackage):
         "6.2.0",
         "6.2.1",
         "6.2.4",
+        "6.3.0",
     ]:
         depends_on(f"hip@{ver}", when=f"@{ver}")
         depends_on(f"rocprim@{ver}", when=f"@{ver}")


### PR DESCRIPTION
fix typo with py-numpy dependecy in omniperf

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
