### PR TITLE
xxhash: add v0.8.3

### DIFF
--- a/var/spack/repos/builtin/packages/xxhash/package.py
+++ b/var/spack/repos/builtin/packages/xxhash/package.py
@@ -18,6 +18,7 @@ class Xxhash(MakefilePackage):
 
     license("BSD-2-Clause")
 
+    version("0.8.3", sha256="aae608dfe8213dfd05d909a57718ef82f30722c392344583d3f39050c7f29a80")
     version("0.8.2", sha256="baee0c6afd4f03165de7a4e67988d16f0f2b257b51d0e3cb91909302a26a79c4")
     version("0.8.1", sha256="3bb6b7d6f30c591dd65aaaff1c8b7a5b94d81687998ca9400082c739a690436c")
     version("0.8.0", sha256="7054c3ebd169c97b64a92d7b994ab63c70dd53a06974f1f630ab782c28db0f4f")


### PR DESCRIPTION
This PR updates `xxhash` to v0.8.3, which is a maintenance release ([diff](https://github.com/Cyan4973/xxHash/compare/v0.8.2...v0.8.3)). No changes to the package required, but I have insufficient access to exotic compilers to verify how wide-spread the support for [`$(CC) -dumpmachine`](https://github.com/Cyan4973/xxHash/compare/v0.8.2...v0.8.3#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R58-R64) is. It works for gcc and clang.

Test build:
```
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/xxhash-0.8.3-kbxfp5rqgantvkkiam7n7jjrfo3ejls2
```