### PR TITLE
ninja: support tests for 1.12 and later

### DIFF
--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -69,7 +69,7 @@ class Ninja(Package):
 
     def configure(self, spec, prefix):
         if self.run_tests and spec.satisfies("@1.12:"):
-            python("configure.py", "--bootstrap", f"--gtest-source-dir=gtest")
+            python("configure.py", "--bootstrap", "--gtest-source-dir=gtest")
         else:
             python("configure.py", "--bootstrap")
 

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -36,12 +36,26 @@ class Ninja(Package):
     version("1.7.2", sha256="2edda0a5421ace3cf428309211270772dd35a91af60c96f93f90df6bc41b16d9")
     version("1.6.0", sha256="b43e88fb068fe4d92a3dfd9eb4d19755dae5c33415db2e9b7b61b4659009cde7")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    # ninja@1.12: needs googletest source, but 1.12 itself needs a patch to use it
+    resource(
+        name="googletest",
+        url="https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz",
+        sha256="81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2",
+        placement="gtest",
+        when="@1.12:",
+    )
+    patch(
+        "https://github.com/ninja-build/ninja/commit/f14a949534d673f847c407644441c8f37e130ce9.patch?full_index=1",
+        sha256="93f4bb3234c3af04e2454c6f0ef2eca3107edd4537a70151ea66f1a1d4c22dad",
+        when="@1.12",
+    )
 
     variant(
         "re2c", default=not sys.platform == "win32", description="Enable buidling Ninja with re2c"
     )
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
 
     depends_on("python", type="build")
     depends_on("re2c@0.11.3:", type="build", when="+re2c")
@@ -54,7 +68,10 @@ class Ninja(Package):
         return output.strip()
 
     def configure(self, spec, prefix):
-        python("configure.py", "--bootstrap")
+        if self.run_tests and spec.satisfies("@1.12:"):
+            python("configure.py", "--bootstrap", f"--gtest-source-dir=gtest")
+        else:
+            python("configure.py", "--bootstrap")
 
     @run_after("configure")
     @on_package_attributes(run_tests=True)


### PR DESCRIPTION
This PR re-enables tests for `ninja`, in particular 1.12 and later, by backporting a master branch commit to the 1.12 releases.
- In https://github.com/ninja-build/ninja/pull/1562, ninja switched to using googletest instead of their own framework, but this was only supported in the cmake build, not the `configure.py` bootstrap used by spack.
- In https://github.com/ninja-build/ninja/pull/2448, `configure.py` was extended with the functionality to regenerate `ninja_test` again, but by then 1.12 had shipped without a way to build tests.

Test build:
```
==> Installing ninja-1.12.1-4452zgxfrbtcjztmztrjup2qua26jeqs [27/27]
==> No binary for ninja-1.12.1-4452zgxfrbtcjztmztrjup2qua26jeqs found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/82/821bdff48a3f683bc4bb3b6f0b5fe7b2d647cf65d52aeb63328c91a6c6df285a.tar.gz
==> Fetching https://mirror.spack.io/_source-cache/archive/81/81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2.tar.gz
==> Using cached archive: /opt/spack/cache/_source-cache/archive/93/93f4bb3234c3af04e2454c6f0ef2eca3107edd4537a70151ea66f1a1d4c22dad
==> Moving resource stage
        source: /opt/spack/stage/wdconinc/resource-googletest-4452zgxfrbtcjztmztrjup2qua26jeqs/spack-src/
        destination: /opt/spack/stage/wdconinc/spack-stage-ninja-1.12.1-4452zgxfrbtcjztmztrjup2qua26jeqs/spack-src/gtest
==> Applied patch https://github.com/ninja-build/ninja/commit/f14a949534d673f847c407644441c8f37e130ce9.patch?full_index=1
==> ninja: Executing phase: 'configure'
==> ninja: Executing phase: 'install'
==> ninja: Successfully installed ninja-1.12.1-4452zgxfrbtcjztmztrjup2qua26jeqs
  Stage: 0.36s.  Configure: 32.27s.  Install: 0.01s.  Post-install: 0.16s.  Total: 32.94s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/ninja-1.12.1-4452zgxfrbtcjztmztrjup2qua26jeqs
```
with logs containing:
```
==> ninja: Executing phase: 'configure'
==> [2025-01-02-18:26:20.042283] '/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/python-3.11.9-xuzuqzrwem4cvtgpj
jaz7zqtcu4jgsdq/bin/python' 'configure.py' '--bootstrap' '--gtest-source-dir=gtest'
...
[34/34] LINK ninja
bootstrapping ninja...
wrote build.ninja.
bootstrap complete.  rebuilding...
==> [2025-01-02-18:26:20.800994] './ninja' '-j8' 'ninja_test'
...
[21/21] LINK ninja_test
==> [2025-01-02-18:26:52.057312] './ninja_test'
[==========] Running 387 tests from 28 test suites.
...
[==========] 387 tests from 28 test suites ran. (244 ms total)
[  PASSED  ] 387 tests.
==> ninja: Executing phase: 'install'
==> [2025-01-02-18:26:52.318239] Installing ninja to /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/ninja-1.12.1-4452zgxfrbtcjztmztrjup2qua26jeqs/bin
==> [2025-01-02-18:26:52.323412] Installing misc to /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/ninja-1.12.1-4452zgxfrbtcjztmztrjup2qua26jeqs/misc
```

Note: Because ninja expects the googletest source directory (it looks for `gtest-all.cc`), we cannot use googletest as a dependency.