### PR TITLE
gromacs: remove dependency on Fortran

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -263,7 +263,7 @@ class Gromacs(CMakePackage, CudaPackage):
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
-    depends_on("fortran", type="build", when="@:4.5.5") # No core Fortran code since 4.6
+    depends_on("fortran", type="build", when="@:4.5.5")  # No core Fortran code since 4.6
 
     variant(
         "mpi", default=True, description="Activate MPI support (disable for Thread-MPI support)"

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -261,9 +261,9 @@ class Gromacs(CMakePackage, CudaPackage):
         deprecated=True,
     )
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build", when="@:4.5.5") # No core Fortran code since 4.6
 
     variant(
         "mpi", default=True, description="Activate MPI support (disable for Thread-MPI support)"
@@ -434,7 +434,7 @@ class Gromacs(CMakePackage, CudaPackage):
     # and switching tags.
 
     # Versions without minor release number, such as `2023` and `2021`,
-    # require exact specifcation using `@=`, starting from Spack v0.20.0,
+    # require exact specification using `@=`, starting from Spack v0.20.0,
     # see https://github.com/spack/spack/releases/tag/v0.20.0
 
     plumed_patches = {
@@ -913,7 +913,7 @@ class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
             options.append(f"-DNVSHMEM_ROOT={nvshmem_root}")
 
         if self.spec["lapack"].name in INTEL_MATH_LIBRARIES:
-            # fftw-api@3 is provided by intel-mkl or intel-parllel-studio
+            # fftw-api@3 is provided by intel-mkl or intel-parallel-studio
             # we use the mkl interface of gromacs
             options.append("-DGMX_FFT_LIBRARY=mkl")
             if self.spec.satisfies("@:2022"):


### PR DESCRIPTION
Fortran was removed from GROMACS core since 4.6.
There are a few contrib files around, but they are not built anyway.

Also fix a couple typos.