### PR TITLE
add long_spec property to get fully enumerated spec string

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1936,6 +1936,20 @@ class Spec:
         return traverse.traverse_edges([self], **kwargs)
 
     @property
+    def long_spec(self):
+        """Returns a version of the spec with the dependencies completely
+        enumerated."""
+        root_str = [self.format()]
+        sorted_dependencies = sorted(
+            self.traverse(root=False), key=lambda x: (x.name, x.abstract_hash)
+        )
+        sorted_dependencies = [
+            d.format("{edge_attributes} " + DEFAULT_FORMAT) for d in sorted_dependencies
+        ]
+        spec_str = " ^".join(root_str + sorted_dependencies)
+        return spec_str.strip()
+
+    @property
     def short_spec(self):
         """Returns a version of the spec with the dependencies hashed
         instead of completely enumerated."""
@@ -4048,15 +4062,7 @@ class Spec:
         if not self._dependencies:
             return self.format()
 
-        root_str = [self.format()]
-        sorted_dependencies = sorted(
-            self.traverse(root=False), key=lambda x: (x.name, x.abstract_hash)
-        )
-        sorted_dependencies = [
-            d.format("{edge_attributes} " + DEFAULT_FORMAT) for d in sorted_dependencies
-        ]
-        spec_str = " ^".join(root_str + sorted_dependencies)
-        return spec_str.strip()
+        return self.long_spec
 
     @property
     def colored_str(self):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1937,7 +1937,7 @@ class Spec:
 
     @property
     def long_spec(self):
-        """Returns a version of the spec with the dependencies completely
+        """Returns a string of the spec with the dependencies completely
         enumerated."""
         root_str = [self.format()]
         sorted_dependencies = sorted(


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR adds a `long_spec` property to `Spec` (akin to `short_spec`) to recover functionality lost with the change in https://github.com/spack/spack/pull/46609. Before that PR, `str(spec)` would return (for both abstract and concrete specs) what `long_spec` will now return. 

CC @white238 