### PR TITLE
heppdt: patch for broken test

### DIFF
--- a/var/spack/repos/builtin/packages/heppdt/package.py
+++ b/var/spack/repos/builtin/packages/heppdt/package.py
@@ -30,3 +30,7 @@ class Heppdt(AutotoolsPackage):
 
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
+
+    def patch(self):
+        # fix csh redirect in /bin/sh script
+        filter_file(r">&", ">", "tests/HepPDT/testPID.sh.in")

--- a/var/spack/repos/builtin/packages/heppdt/package.py
+++ b/var/spack/repos/builtin/packages/heppdt/package.py
@@ -15,6 +15,8 @@ class Heppdt(AutotoolsPackage):
     homepage = "https://cdcvs.fnal.gov/redmine/projects/heppdt/wiki"
     url = "https://lcgpackages.web.cern.ch/lcgpackages/tarFiles/sources/HepPDT-2.06.01.tar.gz"
 
+    maintainers("wdconinc")
+
     tags = ["hep"]
 
     version("3.04.01", sha256="2c1c39eb91295d3ded69e0d3f1a38b1cb55bc3f0cde37b725ffd5d722f63c0f6")


### PR DESCRIPTION
This PR fixes `heppdt` tests where a `#!/bin/sh` script writes `./testPID.sh  >& testPID.out`, which is a csh-ism for stdout-only redirect that trips up bash/dash/*ash. This PR replaces `>&` by `>` and will fail when there is stderr output (which there isn't in my tests).

Test build (which failed previously):
```
$ spack install --test root heppdt
[+] /usr (external glibc-2.40-knbhbyhfaognflcdbinxl2f7ryg5vly2)
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/gcc-runtime-14.2.0-2vh4wbb3h5kzm7iaxp6zynq4nzxmu3yk
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/gmake-4.4.1-cco2dkom6slhy5fb4cg366ednvlcv4r7
==> Installing heppdt-2.06.01-zyate4oh2phshlcd5xoxzpntiw2v2d5t [4/4]
==> No binary for heppdt-2.06.01-zyate4oh2phshlcd5xoxzpntiw2v2d5t found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/12/12a1b6ffdd626603fa3b4d70f44f6e95a36f8f3b6d4fd614bac14880467a2c2e.tar.gz
==> Ran patch() for heppdt
==> heppdt: Executing phase: 'autoreconf'
==> heppdt: Executing phase: 'configure'
==> heppdt: Executing phase: 'build'
==> heppdt: Executing phase: 'install'
==> heppdt: Successfully installed heppdt-2.06.01-zyate4oh2phshlcd5xoxzpntiw2v2d5t
  Stage: 0.04s.  Autoreconf: 0.00s.  Configure: 3.41s.  Build: 1.86s.  Install: 0.63s.  Post-install: 0.14s.  Total: 6.15s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/heppdt-2.06.01-zyate4oh2phshlcd5xoxzpntiw2v2d5t
```

This patch applies to all versions. No upstream report to link to since I don't think there's an upstream repository.