### PR TITLE
embree: fix tests by building tutorial's embree_viewer for tests

### DIFF
--- a/var/spack/repos/builtin/packages/embree/package.py
+++ b/var/spack/repos/builtin/packages/embree/package.py
@@ -12,7 +12,7 @@ class Embree(CMakePackage):
     url = "https://github.com/embree/embree/archive/v3.7.0.tar.gz"
     maintainers("aumuell")
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked_by="wdconinc")
 
     version("4.3.3", sha256="8a3bc3c3e21aa209d9861a28f8ba93b2f82ed0dc93341dddac09f1f03c36ef2d")
     version("4.3.2", sha256="dc7bb6bac095b2e7bc64321435acd07c6137d6d60e4b79ec07bb0b215ddf81cb")
@@ -60,9 +60,10 @@ class Embree(CMakePackage):
         spec = self.spec
 
         args = [
-            "-DBUILD_TESTING=OFF",
-            "-DEMBREE_TUTORIALS=OFF",
-            "-DEMBREE_IGNORE_CMAKE_CXX_FLAGS=ON",
+            self.define("BUILD_TESTING", self.run_tests),
+            self.define("EMBREE_TUTORIALS", self.run_tests),
+            self.define("EMBREE_TUTORIALS_GLFW", False),
+            self.define("EMBREE_IGNORE_CMAKE_CXX_FLAGS", True),
             self.define_from_variant("EMBREE_ISPC_SUPPORT", "ispc"),
         ]
 


### PR DESCRIPTION
This PR fixes the testing of `embree` by building the tutorials when `self.run_tests` such that `embree_viewer` is avialable for the tests (e.g. https://github.com/RenderKit/embree/blob/3c9936cb6bfb21c572503438d7a10a432e885d2c/tests/CMakeLists.txt#L32).

Notes:
- `EMBREE_TUTORIALS` exists for all versions in spack (https://github.com/RenderKit/embree/commit/fc9c94993aa32727a23562a078867cbbed1fdbb3)
- `EMBREE_TUTORIALS_GLFW` exists since 3.11 (https://github.com/RenderKit/embree/commit/e55f7906dd159da6729a7e7587576a6d40d3acbf)
- `embree_viewer` use in tests introduced in 4.1.0 (https://github.com/RenderKit/embree/commit/619b0e5ea239dfefcb0abe85d9648b90e6476aa5)

I think even if the tutorials were not needed before 4.1.0, I didn't think it worth adding the complication of version checks to the testing functionality.

Test build (`spack install --test root embree`, which failed previously):
```
==> Installing embree-4.3.3-3gne2a6jvg2mizt26whsftlaulaooxte [14/14]
==> No binary for embree-4.3.3-3gne2a6jvg2mizt26whsftlaulaooxte found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/8a/8a3bc3c3e21aa209d9861a28f8ba93b2f82ed0dc93341dddac09f1f03c36ef2d.tar.gz
==> No patches needed for embree
==> embree: Executing phase: 'cmake'
==> embree: Executing phase: 'build'
==> embree: Executing phase: 'install'
==> embree: Successfully installed embree-4.3.3-3gne2a6jvg2mizt26whsftlaulaooxte
  Stage: 0.69s.  Cmake: 1.94s.  Build: 14m 41.34s.  Install: 1.87s.  Post-install: 0.42s.  Total: 14m 46.39s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/embree-4.3.3-3gne2a6jvg2mizt26whsftlaulaooxte
```
and
```
$ tail /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/embree-4.3.3-3gne2a6jvg2mizt26whsftlaulaooxte/.spack/install-time-test-log.txt 
268/271 Test #270: forest ....................................................   Passed   10.17 sec
269/271 Test #268: collide ...................................................   Passed   18.59 sec
270/271 Test #260: bvh_builder ...............................................   Passed   55.27 sec
271/271 Test #248: embree_verify .............................................   Passed   85.70 sec

100% tests passed, 0 tests failed out of 271

Total Test time (real) =  89.92 sec
==> [2025-01-03-14:55:28.872990] '/opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/gmake-4.4.1-cco2dkom6slhy5fb4cg366ednvlcv4r7/bin/make' '-j8' '-n' 'check'
==> [2025-01-03-14:55:28.875765] Target 'check' not found in Makefile
```
