### PR TITLE
snakemake: skip_modules = snakemake.common.tests

### DIFF
--- a/var/spack/repos/builtin/packages/snakemake/package.py
+++ b/var/spack/repos/builtin/packages/snakemake/package.py
@@ -158,6 +158,9 @@ class Snakemake(PythonPackage):
     )
     depends_on("py-requests", when="+http", type=("build", "run"))
 
+    # snakemake.common.tests requires pytest
+    skip_modules = ["snakemake.common.tests"]
+
     def test_run(self):
         """Test if snakemake runs with the version option"""
         Executable(self.prefix.bin.snakemake)("--version")


### PR DESCRIPTION
This PR tells spack to ignore the module `snakemake.common.tests` which fails the automatic import test due to a [dependency on pytest](https://github.com/snakemake/snakemake/blob/main/snakemake/common/tests/__init__.py#L7) that is not need to be in the run dependencies. This is the only module that needs to be ignored (in snakemake).

Test build with testing enabled (and with #48394):
```
$ spack install --test all snakemake
...
==> Installing snakemake-8.26.0-7aozba555lgfwordyjlhqjhi2vnekwz5 [88/88]
==> No binary for snakemake-8.26.0-7aozba555lgfwordyjlhqjhi2vnekwz5 found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/b5/b52390cd6c3b591e5c4a0977df93d8f25a4a38a5c43dee4c7e2093393cb1f053.tar.gz
==> No patches needed for snakemake
==> snakemake: Executing phase: 'install'
==> snakemake: Successfully installed snakemake-8.26.0-7aozba555lgfwordyjlhqjhi2vnekwz5
  Stage: 0.10s.  Install: 38.67s.  Post-install: 2.08s.  Total: 41.05s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/snakemake-8.26.0-7aozba555lgfwordyjlhqjhi2vnekwz5
```