### PR TITLE
Revert "CI: Move the build stage to the project root instead of tmp"

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/config.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/config.yaml
@@ -7,6 +7,4 @@ config:
     padded_length: 256
     projections:
       all: '{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'
-  build_stage:
-  - $spack/tmp/stage
 


### PR DESCRIPTION
Reverts spack/spack#47996

Putting the build dir inside of `$spack/` causes various packages to incorrectly detect Spack's version as their own when they run `git rev-parse`. What's worse, the git url used in CI contains an auth token.

One example is clang:

```
$ clang --version
clang version 19.1.5 (https://gitlab-ci-token:<some token>@gitlab.spack.io/spack/spack.git 3c64821c6445aa085848ecb19482ebddeea7b657)
```

Notice that 3c64821c6445aa085848ecb19482ebddeea7b657 is a Spack commit. Future LLVM actually [guards against this](https://github.com/llvm/llvm-project/commit/5904448ceb67d6a7bd752aa4b54d9acb64bcc533) and fails cmake configure.

