### PR TITLE
py-webcolors: add v24.8.0, v24.11.1 (switch to pdm-backend)

### DIFF
--- a/var/spack/repos/builtin/packages/py-webcolors/package.py
+++ b/var/spack/repos/builtin/packages/py-webcolors/package.py
@@ -13,6 +13,8 @@ class PyWebcolors(PythonPackage):
 
     license("BSD-3-Clause", checked_by="wdconinc")
 
+    version("24.11.1", sha256="ecb3d768f32202af770477b8b65f318fa4f566c22948673a977b00d589dd80f6")
+    version("24.8.0", sha256="08b07af286a01bcd30d583a7acadf629583d1f79bfef27dd2c2c5c263817277d")
     version("24.6.0", sha256="1d160d1de46b3e81e58d0a280d0c78b467dc80f47294b91b1ad8029d2cedb55b")
     version("1.13", sha256="c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a")
     version("1.12", sha256="16d043d3a08fd6a1b1b7e3e9e62640d09790dce80d2bdd4792a175b35fe794a9")
@@ -21,4 +23,6 @@ class PyWebcolors(PythonPackage):
     depends_on("python@3.5:", type=("build", "run"))
     depends_on("python@3.7:", type=("build", "run"), when="@1.12:")
     depends_on("python@3.8:", type=("build", "run"), when="@24.6:")
-    depends_on("py-setuptools@61:", type=("build"))
+    depends_on("python@3.9:", type=("build", "run"), when="@24.11:")
+    depends_on("py-setuptools@61:", type=("build"), when="@:24.10")
+    depends_on("py-pdm-backend", type=("build"), when="@24.11:")


### PR DESCRIPTION
This PR adds `py-wecolors`, v24.8.0 (last with setuptools) and v24.11.1 (now uses pdm-backend) ([full diff](https://github.com/ubernostrum/webcolors/compare/24.6.0...24.11.1)). Build system changes in https://github.com/ubernostrum/webcolors/commit/c55f147ec83deff9d7ee74077d9b181029a79732.

Test build:
```
-- linux-ubuntu24.10-skylake / gcc@14.2.0 -----------------------
x5atjrw py-webcolors@24.11.1 build_system=python_pip
==> 1 installed package
```