### PR TITLE
py-six: add v1.17.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-six/package.py
+++ b/var/spack/repos/builtin/packages/py-six/package.py
@@ -12,6 +12,7 @@ class PySix(PythonPackage):
 
     license("MIT")
 
+    version("1.17.0", sha256="ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81")
     version("1.16.0", sha256="1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926")
     version("1.15.0", sha256="30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259")
     version("1.14.0", sha256="236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a")
@@ -22,4 +23,5 @@ class PySix(PythonPackage):
     version("1.8.0", sha256="047bbbba41bac37c444c75ddfdf0573dd6e2f1fbd824e6247bb26fa7d8fa3830")
 
     depends_on("python@2.7:2.8,3.3:", type=("build", "run"))
+    depends_on("python@:3.13", type=("build", "run"), when="@:1.16")
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
This PR adds `py-six`, v1.17.0, which brings python3.14 support (https://github.com/benjaminp/six/pull/388).