### PR TITLE
fmt: add v11.1.{1,2}; spdlog: add v1.15.0

### DIFF
--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -17,6 +17,7 @@ class Fmt(CMakePackage):
 
     license("MIT")
 
+    version("11.1.2", sha256="ef54df1d4ba28519e31bf179f6a4fb5851d684c328ca051ce5da1b52bf8b1641")
     version("11.1.1", sha256="a25124e41c15c290b214c4dec588385153c91b47198dbacda6babce27edc4b45")
     version("11.0.2", sha256="40fc58bebcf38c759e11a7bd8fdc163507d2423ef5058bba7f26280c5b9c5465")
     version("11.0.1", sha256="62ca45531814109b5d6cef0cf2fd17db92c32a30dd23012976e768c685534814")

--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -17,6 +17,7 @@ class Fmt(CMakePackage):
 
     license("MIT")
 
+    version("11.1.1", sha256="a25124e41c15c290b214c4dec588385153c91b47198dbacda6babce27edc4b45")
     version("11.0.2", sha256="40fc58bebcf38c759e11a7bd8fdc163507d2423ef5058bba7f26280c5b9c5465")
     version("11.0.1", sha256="62ca45531814109b5d6cef0cf2fd17db92c32a30dd23012976e768c685534814")
     version("11.0.0", sha256="583ce480ef07fad76ef86e1e2a639fc231c3daa86c4aa6bcba524ce908f30699")

--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -13,6 +13,7 @@ class Spdlog(CMakePackage):
 
     license("MIT")
 
+    version("1.15.0", sha256="9962648c9b4f1a7bbc76fd8d9172555bad1871fdb14ff4f842ef87949682caa5
     version("1.14.1", sha256="1586508029a7d0670dfcb2d97575dcdc242d3868a259742b69f100801ab4e16b")
     version("1.13.0", sha256="534f2ee1a4dcbeb22249856edfb2be76a1cf4f708a20b0ac2ed090ee24cfdbc9")
     version("1.12.0", sha256="4dccf2d10f410c1e2feaff89966bfc49a1abb29ef6f08246335b110e001e09a9")

--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -74,7 +74,7 @@ class Spdlog(CMakePackage):
     # (with https://github.com/gabime/spdlog/pull/3301 as a prerequisite)
     patch(
         "https://github.com/gabime/spdlog/commit/276ee5f5c0eb13626bd367b006ace5eae9526d8a.patch?full_index=1",
-        sha256="7491e085df3f456b14d3df99629282e2d82105e2fe5d75024fb8f230affddd19",
+        sha256="fd4cbb10a795a03c7182a4070056c2b004d47b120a86e1958ff82316627bb565",
         when="@1.12.0:1.15.0",
     )
     patch(

--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -70,6 +70,14 @@ class Spdlog(CMakePackage):
         when="@1.11.0 ^fmt@10:",
     )
 
+    # spdlog@1.15.0 with fmt@11  https://github.com/gabime/spdlog/pull/3314
+    patch(
+        "https://github.com/gabime/spdlog/commit/96a8f6250cbf4e8c76387c614f666710a2fa9bad.patch?full_index=1",
+        sha256="5ed92f4c131fd31eb3d28390615ecff3ade3789cdecfd3db18cadb07cc8095e3",
+        when="@1.12.0:1.15.0",
+    )
+    conflicts("^fmt@11.1:", when="@:1.11")
+
     def cmake_args(self):
         args = []
 

--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -71,6 +71,12 @@ class Spdlog(CMakePackage):
     )
 
     # spdlog@1.15.0 with fmt@11  https://github.com/gabime/spdlog/pull/3314
+    # (with https://github.com/gabime/spdlog/pull/3301 as a prerequisite)
+    patch(
+        "https://github.com/gabime/spdlog/commit/276ee5f5c0eb13626bd367b006ace5eae9526d8a.patch?full_index=1",
+        sha256="7491e085df3f456b14d3df99629282e2d82105e2fe5d75024fb8f230affddd19",
+        when="@1.12.0:1.15.0",
+    )
     patch(
         "https://github.com/gabime/spdlog/commit/96a8f6250cbf4e8c76387c614f666710a2fa9bad.patch?full_index=1",
         sha256="5ed92f4c131fd31eb3d28390615ecff3ade3789cdecfd3db18cadb07cc8095e3",

--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -75,14 +75,14 @@ class Spdlog(CMakePackage):
     patch(
         "https://github.com/gabime/spdlog/commit/276ee5f5c0eb13626bd367b006ace5eae9526d8a.patch?full_index=1",
         sha256="fd4cbb10a795a03c7182a4070056c2b004d47b120a86e1958ff82316627bb565",
-        when="@1.12.0:1.15.0",
+        when="@1.13.0:1.15.0",
     )
     patch(
         "https://github.com/gabime/spdlog/commit/96a8f6250cbf4e8c76387c614f666710a2fa9bad.patch?full_index=1",
         sha256="5ed92f4c131fd31eb3d28390615ecff3ade3789cdecfd3db18cadb07cc8095e3",
-        when="@1.12.0:1.15.0",
+        when="@1.13.0:1.15.0",
     )
-    conflicts("^fmt@11.1:", when="@:1.11")
+    conflicts("^fmt@11.1:", when="@:1.12")
 
     def cmake_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -13,7 +13,7 @@ class Spdlog(CMakePackage):
 
     license("MIT")
 
-    version("1.15.0", sha256="9962648c9b4f1a7bbc76fd8d9172555bad1871fdb14ff4f842ef87949682caa5
+    version("1.15.0", sha256="9962648c9b4f1a7bbc76fd8d9172555bad1871fdb14ff4f842ef87949682caa5")
     version("1.14.1", sha256="1586508029a7d0670dfcb2d97575dcdc242d3868a259742b69f100801ab4e16b")
     version("1.13.0", sha256="534f2ee1a4dcbeb22249856edfb2be76a1cf4f708a20b0ac2ed090ee24cfdbc9")
     version("1.12.0", sha256="4dccf2d10f410c1e2feaff89966bfc49a1abb29ef6f08246335b110e001e09a9")


### PR DESCRIPTION
This PR adds `fmt`, v11.1.1 and v11.1.2 ([diff](https://github.com/fmtlib/fmt/compare/11.0.2...11.1.2)), no changes to build system.

This PR adds `spdlog`, v1.15.0 ([diff](https://github.com/gabime/spdlog/compare/v1.14.1...v1.15.0)), no changes to build system.

Combined since `spdlog` depends on `fmt` (in spack; at some point we should add support for the spdlog option to use only C++20 `std::format`, but not today).