### PR TITLE
wayland: add v1.23.0, v1.23.1; wayland-protocols: add v1.38, v1.39

### DIFF
--- a/var/spack/repos/builtin/packages/wayland-protocols/package.py
+++ b/var/spack/repos/builtin/packages/wayland-protocols/package.py
@@ -10,8 +10,8 @@ class WaylandProtocols(MesonPackage, AutotoolsPackage):
     """wayland-protocols contains Wayland protocols that add functionality not
     available in the Wayland core protocol. Such protocols either add
     completely new functionality, or extend the functionality of some other
-    protocol either in Wayland core, or some other protocol i
-    n wayland-protocols."""
+    protocol either in Wayland core, or some other protocol in
+    wayland-protocols."""
 
     homepage = "https://wayland.freedesktop.org/"
     url = "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.20/wayland-protocols-1.20.tar.gz"
@@ -28,6 +28,8 @@ class WaylandProtocols(MesonPackage, AutotoolsPackage):
 
     license("MIT")
 
+    version("1.39", sha256="42c16435dfc83f320ff727b6d446bb0d4feb361dc11796a2c5d3c0fb6532a517")
+    version("1.38", sha256="a6069948458a1d86cea2b33a9735e67d7524118c32c388d75efb881a9e9d2cd9")
     version("1.37", sha256="c3b215084eb4cf318415533554c2c2714e58ed75847d7c3a8e50923215ffbbf3")
     version("1.36", sha256="c839dd4325565fd59a93d6cde17335357328f66983c2e1fb03c33e92d6918b17")
     version("1.35", sha256="6e62dfa92ce82487d107b76064cfe2d7ca107c87c239ea9036a763d79c09105a")
@@ -54,6 +56,7 @@ class WaylandProtocols(MesonPackage, AutotoolsPackage):
 
     with when("build_system=meson"):
         depends_on("meson@0.55:")
+        depends_on("meson@0.58:", when="@1.38:")
 
     depends_on("pkgconfig", type="build")
     depends_on("wayland")

--- a/var/spack/repos/builtin/packages/wayland/package.py
+++ b/var/spack/repos/builtin/packages/wayland/package.py
@@ -30,6 +30,8 @@ class Wayland(MesonPackage, AutotoolsPackage):
 
     license("MIT")
 
+    version("1.23.1", sha256="158ec49af498f2558c7fbf7e8b070d010d4e270cc6076003a18a6c813f87e244")
+    version("1.23.0", sha256="7c5c28fa73f22d1c5021e17e1148f29ab17bf8b776a406f1c4489d3e2992ec3a")
     version("1.22.0", sha256="bbca9c906a8fb8992409ebf51812f19e2a784b2c169d4b784cdd753b4bb448ef")
     version("1.21.0", sha256="53b7fa67142e653820030ec049971bcb5e84ac99e05cba5bcb9cb55f43fae4b3")
     version("1.20.0", sha256="20523cd6f2c18c3c86725467157c6221e19de76fbfad944042a2d494af3c7a92")
@@ -49,6 +51,7 @@ class Wayland(MesonPackage, AutotoolsPackage):
 
     with when("build_system=meson"):
         depends_on("meson@0.56.0:", type="build")
+        depends_on("meson@0.57.0:", type="build", when="@1.23:")
 
     depends_on("pkgconfig", type="build")
     depends_on("libxml2")


### PR DESCRIPTION
This PR adds `wayland-protocols`, v1.38 and v1.39 ([diff](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/compare/1.37...1.39)), which require a newer version of meson.

This PR adds `wayland`, v1.23.0 and v1.23.1 ([diff](https://gitlab.freedesktop.org/wayland/wayland/-/compare/1.22.0...1.23.1)), which requires a newer version of meson.