### PR TITLE
hep stack: add celeritas

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -31,6 +31,7 @@ spack:
   specs:
   # CPU
   - acts +analysis +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +podio +pythia8 +python +tgeo cxxstd=20
+  - celeritas +geant4 +hepmc3 +openmp +root +shared +vecgeom cxxstd=20
   - dd4hep +ddalign +ddcad +ddcond +dddetectors +dddigi +ddeve +ddg4 +ddrec +edm4hep +hepmc3 +lcio +utilityapps +xercesc
   - delphes +pythia8
   - edm4hep


### PR DESCRIPTION
This PR adds `celeritas` to the hep stack. Most options enabled (no docs, no cuda, no rocm).