### PR TITLE
PyTorch: remove +onnx_ml variant

### DIFF
--- a/var/spack/repos/builtin/packages/onnx/package.py
+++ b/var/spack/repos/builtin/packages/onnx/package.py
@@ -50,15 +50,23 @@ class Onnx(CMakePackage):
     )  # py-torch@1.6:1.7
     version("1.6.0_2020-02-16", commit="9fdae4c68960a2d44cd1cc871c74a6a9d469fa1f")  # py-torch@1.5
     version("1.6.0_2019-11-06", commit="fea8568cac61a482ed208748fdc0e1a8e47f62f5")  # py-torch@1.4
-    version("1.6.0_2019-09-26", commit="034921bd574cc84906b7996c07873454b7dd4135")  # py-torch@1.3
-    version("1.5.0_2019-07-25", commit="28ca699b69b5a31892619defca2391044a9a6052")  # py-torch@1.2
-    version("1.5.0_2019-04-25", commit="22662bfd4dcc6baebf29e3b823a051676f991001")  # py-torch@1.1
-    version("1.3.0_2018-12-04", commit="42804705bdbf179d1a98394008417e1392013547")  # py-torch@1.0
     version(
-        "1.2.2_2018-07-16", commit="b2817a682f25f960586f06caa539bbbd7a96b859"
+        "1.6.0_2019-09-26", commit="034921bd574cc84906b7996c07873454b7dd4135", deprecated=True
+    )  # py-torch@1.3
+    version(
+        "1.5.0_2019-07-25", commit="28ca699b69b5a31892619defca2391044a9a6052", deprecated=True
+    )  # py-torch@1.2
+    version(
+        "1.5.0_2019-04-25", commit="22662bfd4dcc6baebf29e3b823a051676f991001", deprecated=True
+    )  # py-torch@1.1
+    version(
+        "1.3.0_2018-12-04", commit="42804705bdbf179d1a98394008417e1392013547", deprecated=True
+    )  # py-torch@1.0
+    version(
+        "1.2.2_2018-07-16", commit="b2817a682f25f960586f06caa539bbbd7a96b859", deprecated=True
     )  # py-torch@0.4.1
     version(
-        "1.1.0_2018-04-19", commit="7e1bed51cc508a25b22130de459830b5d5063c41"
+        "1.1.0_2018-04-19", commit="7e1bed51cc508a25b22130de459830b5d5063c41", deprecated=True
     )  # py-torch@0.4.0
 
     depends_on("cxx", type="build")
@@ -75,7 +83,10 @@ class Onnx(CMakePackage):
             filter_file("CMAKE_CXX_STANDARD 11", f"CMAKE_CXX_STANDARD {cxxstd}", "CMakeLists.txt")
 
     def cmake_args(self):
+        # https://github.com/pytorch/pytorch/blob/main/cmake/Dependencies.cmake
         args = [
+            self.define("BUILD_SHARED_LIBS", False),
+            self.define("ONNXIFI_ENABLE_EXT", True),
             # Try to get ONNX to use the same version of python as the spec is using
             self.define("PY_VERSION", self.spec["python"].version.up_to(2)),
             self.define("ONNX_BUILD_TESTS", self.run_tests),

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -107,7 +107,6 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     variant("ucc", default=False, description="Use UCC", when="@1.13: +distributed")
     variant("gloo", default=True, description="Use Gloo", when="+distributed")
     variant("tensorpipe", default=True, description="Use TensorPipe", when="@1.6: +distributed")
-    variant("onnx_ml", default=True, description="Enable traditional ONNX ML API", when="@1.5:")
     variant(
         "breakpad",
         default=True,
@@ -217,16 +216,16 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
     depends_on("gloo+libuv", when="@1.6: platform=darwin")
     depends_on("nccl", when="+nccl+cuda")
     # https://github.com/pytorch/pytorch/issues/60331
-    # depends_on("onnx@1.16.0", when="@2.3:+onnx_ml")
-    # depends_on("onnx@1.15.0", when="@2.2+onnx_ml")
-    # depends_on("onnx@1.14.1", when="@2.1+onnx_ml")
-    # depends_on("onnx@1.13.1", when="@2.0+onnx_ml")
-    # depends_on("onnx@1.12.0", when="@1.13:1+onnx_ml")
-    # depends_on("onnx@1.11.0", when="@1.12+onnx_ml")
-    # depends_on("onnx@1.10.1_2021-10-08", when="@1.11+onnx_ml")
-    # depends_on("onnx@1.10.1", when="@1.10+onnx_ml")
-    # depends_on("onnx@1.8.0_2020-11-03", when="@1.8:1.9+onnx_ml")
-    # depends_on("onnx@1.7.0_2020-05-31", when="@1.6:1.7+onnx_ml")
+    # depends_on("onnx@1.16.0", when="@2.3:")
+    # depends_on("onnx@1.15.0", when="@2.2")
+    # depends_on("onnx@1.14.1", when="@2.1")
+    # depends_on("onnx@1.13.1", when="@2.0")
+    # depends_on("onnx@1.12.0", when="@1.13:1")
+    # depends_on("onnx@1.11.0", when="@1.12")
+    # depends_on("onnx@1.10.1_2021-10-08", when="@1.11")
+    # depends_on("onnx@1.10.1", when="@1.10")
+    # depends_on("onnx@1.8.0_2020-11-03", when="@1.8:1.9")
+    # depends_on("onnx@1.7.0_2020-05-31", when="@1.6:1.7")
     with when("~custom-protobuf"):
         depends_on("protobuf@3.13.0", when="@1.10:")
         depends_on("protobuf@3.11.4", when="@1.6:1.9")
@@ -622,11 +621,6 @@ class PyTorch(PythonPackage, CudaPackage, ROCmPackage):
             env.set("DEBUG", "ON")
         else:
             env.set("DEBUG", "OFF")
-
-        if "+onnx_ml" in self.spec:
-            env.set("ONNX_ML", "ON")
-        elif "~onnx_ml" in self.spec:
-            env.set("ONNX_ML", "OFF")
 
         if not self.spec.satisfies("@main"):
             env.set("PYTORCH_BUILD_VERSION", self.version)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Closes #40765 

Couldn't get this working with PyTorch, but wanted to keep as many changes as I could to avoid redoing the work again in the future.

- [x] Deprecated old versions of ONNX only needed by removed versions of PyTorch
- [x] Added same flags as PyTorch uses to build vendored ONNX
- [x] PyTorch: remove +onnx_ml variant

It turns out PyTorch always depends on ONNX, the `ONNX_ML` flag only controls how ONNX is built.