### PR TITLE
py-rucio-clients: add through v36.0.0.post2

### DIFF
--- a/var/spack/repos/builtin/packages/py-rucio-clients/package.py
+++ b/var/spack/repos/builtin/packages/py-rucio-clients/package.py
@@ -15,8 +15,12 @@ class PyRucioClients(PythonPackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
-    version("36.0.0.post2", sha256="48ac2e3217aac9aaa70133cbfff991560bbeb162165bcf3dd3425967c8a2f816")
-    version("36.0.0.post1", sha256="141aafdde66080d36708dedc9f06a72c55918ee1d138b8cd2f5d2fe43cbc504f")
+    version(
+        "36.0.0.post2", sha256="48ac2e3217aac9aaa70133cbfff991560bbeb162165bcf3dd3425967c8a2f816"
+    )
+    version(
+        "36.0.0.post1", sha256="141aafdde66080d36708dedc9f06a72c55918ee1d138b8cd2f5d2fe43cbc504f"
+    )
     version("36.0.0", sha256="80fbf3b2ec63c13ac1ce430d769fcc526a5f742ba3960ecc64560e0d4cd465b5")
     version("35.6.0", sha256="3c77dea0ce95b7649211da08cee7e93fa9ecb1a6c91bbe750b76b4c576a8b0dd")
     version("35.5.0", sha256="bc79602193e271f66c3fdb43e7abda7903026795d6f3c5d71afb5e52250f8d92")

--- a/var/spack/repos/builtin/packages/py-rucio-clients/package.py
+++ b/var/spack/repos/builtin/packages/py-rucio-clients/package.py
@@ -15,6 +15,12 @@ class PyRucioClients(PythonPackage):
 
     license("Apache-2.0", checked_by="wdconinc")
 
+    version("36.0.0.post2", sha256="48ac2e3217aac9aaa70133cbfff991560bbeb162165bcf3dd3425967c8a2f816")
+    version("36.0.0.post1", sha256="141aafdde66080d36708dedc9f06a72c55918ee1d138b8cd2f5d2fe43cbc504f")
+    version("36.0.0", sha256="80fbf3b2ec63c13ac1ce430d769fcc526a5f742ba3960ecc64560e0d4cd465b5")
+    version("35.6.0", sha256="3c77dea0ce95b7649211da08cee7e93fa9ecb1a6c91bbe750b76b4c576a8b0dd")
+    version("35.5.0", sha256="bc79602193e271f66c3fdb43e7abda7903026795d6f3c5d71afb5e52250f8d92")
+    version("35.4.1", sha256="d87405785776d7522100cda2ebc16892f94cda94d3c257896ee4817c4e03c06b")
     version("35.4.0", sha256="f8771ee39d0d496109586ddbb4000ce006a193fd33cdac8a654661ae0b7346c0")
 
     variant("ssh", default=False, description="Enable SSH2 protocol library")
@@ -31,6 +37,9 @@ class PyRucioClients(PythonPackage):
     depends_on("py-dogpile-cache@1.2.2:", type=("build", "run"))
     depends_on("py-tabulate@0.9.0:", type=("build", "run"))
     depends_on("py-jsonschema@4.20.0:", type=("build", "run"))
+    depends_on("py-packaging@24.1:", type=("build", "run"), when="@36:")
+    depends_on("py-rich@13.7.1:", type=("build", "run"), when="@36:")
+    depends_on("py-typing-extensions@4.12.2:", type=("build", "run"), when="@36:")
 
     with when("+ssh"):
         depends_on("py-paramiko@3.4.0:")


### PR DESCRIPTION
This PR adds `py-rucio-clients`, through v36.0.0.post2 ([diff](https://github.com/rucio/rucio/compare/35.4.0...36.0.0.post2)). Some extra requirements were added (some added only for post1 or post2, but should have applied to 36.0.0 as well).

Test build (with test_imports):
```
==> Installing py-rucio-clients-36.0.0.post2-eci6hicf6ddebssnancowqx62uk3zmvm [61/61]
==> No binary for py-rucio-clients-36.0.0.post2-eci6hicf6ddebssnancowqx62uk3zmvm found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/r/rucio_clients/rucio_clients-36.0.0.post2.tar.gz
==> No patches needed for py-rucio-clients
==> py-rucio-clients: Executing phase: 'install'
==> py-rucio-clients: Successfully installed py-rucio-clients-36.0.0.post2-eci6hicf6ddebssnancowqx62uk3zmvm
  Stage: 0.76s.  Install: 11.36s.  Post-install: 1.47s.  Total: 13.80s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/py-rucio-clients-36.0.0.post2-eci6hicf6ddebssnancowqx62uk3zmvm
```
