### PR TITLE
edm4hep: Add lower clang version bounds

### DIFF
--- a/var/spack/repos/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/builtin/packages/edm4hep/package.py
@@ -90,6 +90,8 @@ class Edm4hep(CMakePackage):
     # Corresponding changes in EDM4hep landed with https://github.com/key4hep/EDM4hep/pull/314
     extends("python", when="@0.10.6:")
 
+    conflicts("%clang@:16", when="@0.99.1:")
+
     def cmake_args(self):
         args = [
             self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),

--- a/var/spack/repos/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/builtin/packages/edm4hep/package.py
@@ -90,7 +90,7 @@ class Edm4hep(CMakePackage):
     # Corresponding changes in EDM4hep landed with https://github.com/key4hep/EDM4hep/pull/314
     extends("python", when="@0.10.6:")
 
-    conflicts("%clang@:16", when="@0.99.1:")
+    conflicts("%clang@:16", when="@0.99.1:", msg="Incomplete consteval support in clang")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
EDM4hep 0.99.1 introduced usage of consteval. While this is technically supported in clang versions below 17, the implementation seems to be incomplete and fail compilation of EDM4hep 0.99.1 and up.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
