### PR TITLE
py-click: add v8.1.8 (switch to flit-core)

### DIFF
--- a/var/spack/repos/builtin/packages/py-click/package.py
+++ b/var/spack/repos/builtin/packages/py-click/package.py
@@ -14,6 +14,7 @@ class PyClick(PythonPackage):
 
     license("BSD-3-Clause")
 
+    version("8.1.8", sha256="ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a")
     version("8.1.7", sha256="ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de")
     version("8.1.3", sha256="7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e")
     version("8.0.3", sha256="410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b")
@@ -28,7 +29,10 @@ class PyClick(PythonPackage):
 
     # Needed to ensure that Spack can bootstrap black with Python 3.6
     depends_on("python@3.7:", when="@8.1:", type=("build", "run"))
-    depends_on("py-setuptools", type="build")
+    with when("@8.1.8:"):
+        depends_on("py-flit-core@:3", type="build")
+    with when("@:8.1.7"):
+        depends_on("py-setuptools", type="build")
 
     depends_on("py-importlib-metadata", when="@8: ^python@:3.7", type=("build", "run"))
     depends_on("py-colorama", when="@8: platform=windows", type=("build", "run"))


### PR DESCRIPTION
This PR adds `py-click`, v8.1.8 ([diff](https://github.com/pallets/click/compare/8.1.7...8.1.8)), which switched to flit-core for the build system.

Test build:
```
==> No binary for py-click-8.1.8-vrg6x5e5cpscudgcpnu3huvn2ke5fivq found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/ed/ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a.tar.gz
==> No patches needed for py-click
==> py-click: Executing phase: 'install'
==> py-click: Successfully installed py-click-8.1.8-vrg6x5e5cpscudgcpnu3huvn2ke5fivq
  Stage: 0.01s.  Install: 0.89s.  Post-install: 0.25s.  Total: 1.29s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/py-click-8.1.8-vrg6x5e5cpscudgcpnu3huvn2ke5fivq
```