### PR TITLE
Fixing erroneous patch application for papi package

### DIFF
--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -101,7 +101,7 @@ class Papi(AutotoolsPackage, ROCmPackage):
     # 7.1.0 erroneously adds -ffree-form for all fortran compilers
     patch("sysdetect-free-form-fix.patch", when="@7.1.0")
     patch("crayftn-fixes.patch", when="@6.0.0:%cce@9:")
-    patch("intel-oneapi-compiler-fixes.patch", when="@6.0.0:%oneapi")
+    patch("intel-oneapi-compiler-fixes.patch", when="@6.0.0:7.0.1%oneapi")
     patch("intel-cray-freeform.patch", when="@7.0.1")
     patch("spack-hip-path.patch", when="@7.0.1")
 


### PR DESCRIPTION
The modified patch has been implemented in upstream PAPI version 7.1.0 and therefore doesn't need to be applied to this version. Restricting application of the patch to papi@6.0.0:7.0.1 .
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
