### PR TITLE
util-linux: add missing include for errno.h

### DIFF
--- a/var/spack/repos/builtin/packages/util-linux/missing-errno-header.patch
+++ b/var/spack/repos/builtin/packages/util-linux/missing-errno-header.patch
@@ -1,0 +1,11 @@
+diff -ruN spack-src/misc-utils/lsfd.c spack-src-patched/misc-utils/lsfd.c
+--- spack-src/misc-utils/lsfd.c	2024-07-04 07:54:41.236242042 +0000
++++ spack-src-patched/misc-utils/lsfd.c	2025-01-07 01:30:52.719740516 +0000
+@@ -37,6 +37,7 @@
+ #include <sys/uio.h>
+ #include <linux/sched.h>
+ #include <sys/syscall.h>
++#include <errno.h>
+ 
+ #ifdef HAVE_LINUX_KCMP_H
+ #  include <linux/kcmp.h>

--- a/var/spack/repos/builtin/packages/util-linux/package.py
+++ b/var/spack/repos/builtin/packages/util-linux/package.py
@@ -50,6 +50,8 @@ class UtilLinux(AutotoolsPackage):
 
     depends_on("bash", when="+bash", type="run")
 
+    patch("missing-errno-header.patch", when="@2.40.2")
+
     def url_for_version(self, version):
         url = "https://www.kernel.org/pub/linux/utils/util-linux/v{0}/util-linux-{1}.tar.gz"
         return url.format(version.up_to(2), version)


### PR DESCRIPTION
Fixes this:
```
misc-utils/lsfd.c: In function 'kcmp':
misc-utils/lsfd.c:66:2: error: 'errno' undeclared (first use in this function)
   66 |  errno = ENOSYS;
      |  ^~~~~
misc-utils/lsfd.c:40:1: note: 'errno' is defined in header '<errno.h>'; did you forget to '#include <errno.h>'?
   39 | #include <sys/syscall.h>
  +++ |+#include <errno.h>
   40 |
misc-utils/lsfd.c:66:2: note: each undeclared identifier is reported only once for each function it appears in
   66 |  errno = ENOSYS;
      |  ^~~~~
misc-utils/lsfd.c:66:10: error: 'ENOSYS' undeclared (first use in this function)
   66 |  errno = ENOSYS;
```