### PR TITLE
Docs/bugfix: correct return for Adding flags to configure

### DIFF
--- a/lib/spack/docs/build_systems/autotoolspackage.rst
+++ b/lib/spack/docs/build_systems/autotoolspackage.rst
@@ -272,9 +272,9 @@ often lists dependencies and the flags needed to locate them. The
 "environment variables" section lists environment variables that the
 build system uses to pass flags to the compiler and linker.
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-Addings flags to configure
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Adding flags to configure
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For most of the flags you encounter, you will want a variant to
 optionally enable/disable them. You can then optionally pass these
@@ -285,7 +285,7 @@ function like so:
 
    def configure_args(self):
        args = []
-
+       ...
        if self.spec.satisfies("+mpi"):
            args.append("--enable-mpi")
        else:
@@ -299,7 +299,10 @@ Alternatively, you can use the :ref:`enable_or_disable  <autotools_enable_or_dis
 .. code-block:: python
 
    def configure_args(self):
-       return [self.enable_or_disable("mpi")]
+       args = []
+       ...
+       args.extend(self.enable_or_disable("mpi"))
+       return args
 
 
 Note that we are explicitly disabling MPI support if it is not
@@ -344,7 +347,14 @@ typically used to enable or disable some feature within the package.
        default=False,
        description="Memchecker support for debugging [degrades performance]"
    )
-   config_args.extend(self.enable_or_disable("memchecker"))
+   ...
+
+   def configure_args(self):
+       args = []
+       ...
+       args.extend(self.enable_or_disable("memchecker"))
+
+       return args
 
 In this example, specifying the variant ``+memchecker`` will generate
 the following configuration options:


### PR DESCRIPTION
Correct the (subtitle and) return for `Adding flags to configure` section. The call to `self.enable_or_disable()` returns a list of strings so the example should either return the result of the call or make sure it extends the args list.

I chose the extends approach since most packages have multiple configuration options and it's nice to have a simple documentation example to link to in PR feedback.