### PR TITLE
CI: Set the stage dir to avoid overloading /tmp

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/configs/config.yaml
+++ b/share/spack/gitlab/cloud_pipelines/configs/config.yaml
@@ -7,4 +7,5 @@ config:
     padded_length: 256
     projections:
       all: '{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'
-
+  build_stage:
+  - $CI_BUILDS_DIR/tmp/stage


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Redo changes from #47996 to point at the build root instead of the Spack root to avoid encoding temporary secrets into LLVM.

Note: Fixed in later version of LLVM here: https://github.com/llvm/llvm-project/commit/5904448ceb67d6a7bd752aa4b54d9acb64bcc533