### PR TITLE
Perl build system: add a dependency on gmake

### DIFF
--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -10,8 +10,9 @@ from llnl.util.lang import memoized
 import spack.builder
 import spack.package_base
 import spack.phase_callbacks
-from spack.directives import build_system, extends
+from spack.directives import build_system, depends_on, extends
 from spack.install_test import SkipTest, test_part
+from spack.multimethod import when
 from spack.util.executable import Executable
 
 from ._checks import BuilderWithDefaults, execute_build_time_tests
@@ -28,7 +29,9 @@ class PerlPackage(spack.package_base.PackageBase):
 
     build_system("perl")
 
-    extends("perl", when="build_system=perl")
+    with when("build_system=perl"):
+        extends("perl")
+        depends_on("gmake", type="build")
 
     @property
     @memoized

--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -13,6 +13,7 @@ spack:
       - openjpeg  # CMakePackage
       - r-rcpp  # RPackage
       - ruby-rake  # RubyPackage
+      - prel-data-dumper # PerlPackage
     - arch:
       - '%gcc'
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -13,7 +13,7 @@ spack:
       - openjpeg  # CMakePackage
       - r-rcpp  # RPackage
       - ruby-rake  # RubyPackage
-      - prel-data-dumper # PerlPackage
+      - perl-data-dumper # PerlPackage
     - arch:
       - '%gcc'
 


### PR DESCRIPTION
fixes #48312 

This might be more than strictly necessary (i.e. I think perl packages using Build.PL don't need `gmake`). 

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
