### PR TITLE
python: limit number of parallel build processes

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -402,7 +402,7 @@ class Python(Package):
         # limit the number of processes to use for compileall in older Python versions
         # https://github.com/python/cpython/commit/9a7e9f9921804f3f90151ca42703e612697dd430
         if self.spec.satisfies("@:3.11"):
-            ff.filter("-j0 ", f"-j{jobs} ")
+            ff.filter("-j0 ", f"-j{make_jobs} ")
 
         # disable building the nis module (there is no flag to disable it).
         if self.spec.satisfies("@3.8:3.10"):

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -16,6 +16,7 @@ from llnl.util.lang import dedupe
 
 import spack.paths
 from spack.build_environment import dso_suffix, stat_suffix
+from spack.config import determine_number_of_jobs
 from spack.package import *
 
 
@@ -398,6 +399,10 @@ class Python(Package):
         ff.filter(
             r"^(.*)setup\.py(.*)((build)|(install))(.*)$", r"\1setup.py\2 --no-user-cfg \3\6"
         )
+
+        # limit the number of processes to use for compileall
+        jobs = determine_number_of_jobs(parallel=self.parallel)
+        ff.filter("-j0", f"-j{jobs}")
 
         # disable building the nis module (there is no flag to disable it).
         if self.spec.satisfies("@3.8:3.10"):


### PR DESCRIPTION
This PR patches a Python Makefile to limit the number of parallel build processes to the Spack default value (normally 16).

Python's build system by default uses all available threads to perform `make install`. On systems with large number of cores, or systems not properly configured for very high core count, the build process can use a significant number of file handles, breaching the system limit. When this happens, the Spack process will crash with `Too many open files` error.
