### PR TITLE
podio: Refine catch2 dependency

### DIFF
--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -101,6 +101,7 @@ class Podio(CMakePackage):
     depends_on("sio", type=("build", "link"), when="+sio")
     depends_on("catch2@3.0.1:", type=("test"), when="@:0.16.5")
     depends_on("catch2@3.1:", type=("test"), when="@0.16.6:")
+    depends_on("catch2@3.4:", type="test", when="@0.17.1: ^cxxstd=20")
     depends_on("py-graphviz", type=("run"))
     depends_on("py-tabulate", type=("run", "test"), when="@0.16.6:")
 

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -101,7 +101,7 @@ class Podio(CMakePackage):
     depends_on("sio", type=("build", "link"), when="+sio")
     depends_on("catch2@3.0.1:", type=("test"), when="@:0.16.5")
     depends_on("catch2@3.1:", type=("test"), when="@0.16.6:")
-    depends_on("catch2@3.4:", type="test", when="@0.17.1: ^cxxstd=20")
+    depends_on("catch2@3.4:", type="test", when="@0.17.1: cxxstd=20")
     depends_on("py-graphviz", type=("run"))
     depends_on("py-tabulate", type=("run", "test"), when="@0.16.6:")
 


### PR DESCRIPTION
podio needs `catch2@3.4:` if it is built with c++20. The changes have been introduced with [this commit](https://github.com/AIDASoft/podio/commit/fe8481b68bb2ebc8e8b40abd250392717ada4745)

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
