### PR TITLE
root: Patch range restriction and gcc lower bound

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -142,7 +142,7 @@ class Root(CMakePackage):
     patch(
         "https://github.com/root-project/root/commit/2f00d6df258906c1f6fe848135a88b836db3077f.patch?full_index=1",
         sha256="8da36032082e65ae246c03558a4c3fd67b157d1d0c6d20adac9de263279d1db6",
-        when="@6.28:6.28.12",
+        when="@6.28.6:6.28.12",
     )
     patch(
         "https://github.com/root-project/root/commit/14838b35600b08278e69bc3d8d8669773bc11399.patch?full_index=1",

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -452,7 +452,7 @@ class Root(CMakePackage):
         "cxxstd=20", when="@:6.28.02", msg="C++20 support requires root version at least 6.28.04"
     )
 
-    conflicts("%gcc@10:", when="cxxstd=20")
+    conflicts("%gcc@:10", when="cxxstd=20")
 
     # See https://github.com/root-project/root/issues/11128
     conflicts("%clang@16:", when="@:6.26.07", msg="clang 16+ support was added in root 6.26.08")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -452,6 +452,8 @@ class Root(CMakePackage):
         "cxxstd=20", when="@:6.28.02", msg="C++20 support requires root version at least 6.28.04"
     )
 
+    conflicts("%gcc@10:", when="cxxstd=20")
+
     # See https://github.com/root-project/root/issues/11128
     conflicts("%clang@16:", when="@:6.26.07", msg="clang 16+ support was added in root 6.26.08")
 


### PR DESCRIPTION
This PR

- Fixes an incorrect patch range https://github.com/root-project/root/commit/2f00d6df258906c1f6fe848135a88b836db3077f.patch?full_index=1 which does not apply before `6.28.6`
- ROOT's polyfill for span does not actually seem to work in gcc10, since the detection logic seems to not correctly supply the type