### PR TITLE
py-histoprint: add v2.5.0, v2.6.0 (switch to hatchling)

### DIFF
--- a/var/spack/repos/builtin/packages/py-histoprint/package.py
+++ b/var/spack/repos/builtin/packages/py-histoprint/package.py
@@ -11,14 +11,21 @@ class PyHistoprint(PythonPackage):
     homepage = "https://github.com/scikit-hep/histoprint"
     pypi = "histoprint/histoprint-2.2.0.tar.gz"
 
-    license("MIT")
+    license("MIT", checked_by="wdconinc")
 
+    version("2.6.0", sha256="e1df729350455b457e97f20883537ae74522879e7c33c609df12f247cca4a21d")
+    version("2.5.0", sha256="9097e7396ab3a9a83c916f7e53c462ea46e4f645c1ad91604738f2d8383efd4f")
     version("2.4.0", sha256="328f789d186e3bd76882d57b5aad3fa08c7870a856cc83bcdbad9f4aefbda94d")
     version("2.2.0", sha256="ef8b65f7926aaa989f076857b76291175245dd974804b408483091d1e28b00f6")
 
     depends_on("python@3.6:", type=("build", "run"))
-    depends_on("py-setuptools@42:", type="build")
-    depends_on("py-setuptools-scm@3.4:+toml", type="build")
+    depends_on("python@3.8:", type=("build", "run"), when="@2.6:")
+    with when("@2.6:"):
+        depends_on("py-hatchling", type="build")
+        depends_on("py-hatch-vcs", type="build")
+    with when("@:2.5"):
+        depends_on("py-setuptools@42:", type="build")
+        depends_on("py-setuptools-scm@3.4:+toml", type="build")
     depends_on("py-click@7.0.0:", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-uhi@0.2.1:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-histoprint/package.py
+++ b/var/spack/repos/builtin/packages/py-histoprint/package.py
@@ -11,6 +11,8 @@ class PyHistoprint(PythonPackage):
     homepage = "https://github.com/scikit-hep/histoprint"
     pypi = "histoprint/histoprint-2.2.0.tar.gz"
 
+    tags = ["hep"]
+
     license("MIT", checked_by="wdconinc")
 
     version("2.6.0", sha256="e1df729350455b457e97f20883537ae74522879e7c33c609df12f247cca4a21d")


### PR DESCRIPTION
This PR adds `py-histoprint`, v2.5.0 and v2.6.0 ([diff](https://github.com/scikit-hep/histoprint/compare/v2.4.0...v2.6.0)), which switches the build system to hatchling and requires python@3.8:, but no other changed dependencies.

Test build:
```
==> Installing py-histoprint-2.6.0-wz3lsdahkr5qtgbdjjdov35623rpr7lm [53/53]
==> No binary for py-histoprint-2.6.0-wz3lsdahkr5qtgbdjjdov35623rpr7lm found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/e1/e1df729350455b457e97f20883537ae74522879e7c33c609df12f247cca4a21d.tar.gz
==> No patches needed for py-histoprint
==> py-histoprint: Executing phase: 'install'
==> py-histoprint: Successfully installed py-histoprint-2.6.0-wz3lsdahkr5qtgbdjjdov35623rpr7lm
  Stage: 0.04s.  Install: 6.29s.  Post-install: 2.16s.  Total: 9.64s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/py-histoprint-2.6.0-wz3lsdahkr5qtgbdjjdov35623rpr7lm
```