### PR TITLE
Add OpenMP dependency to Kokkos and KokkosKernels

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -421,9 +421,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("kokkos-kernels@4.5.01", when="@master:")
         depends_on("kokkos-kernels@4.3.01", when="@16")
         depends_on("kokkos-kernels@4.2.01", when="@15.1:15")
-        depends_on("kokkos-kernels@4.1.00", when="@15.0")
         depends_on("kokkos+openmp", when="+openmp")
-        depends_on("kokkos-kernels+openmp", when="+openmp")
 
         for a in CudaPackage.cuda_arch_values:
             arch_str = f"+cuda cuda_arch={a}"
@@ -908,7 +906,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         # External Kokkos
         if spec.satisfies("@14.4.0: +kokkos"):
             options.append(define_tpl_enable("Kokkos"))
-        if spec.satisfies("@15.0: +kokkos"):
+        if spec.satisfies("@15.1: +kokkos"):
             options.append(define_tpl_enable("KokkosKernels", True))
 
         # MPI settings

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -422,6 +422,8 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("kokkos-kernels@4.3.01", when="@16")
         depends_on("kokkos-kernels@4.2.01", when="@15.1:15")
         depends_on("kokkos-kernels@4.1.00", when="@15.0")
+        depends_on("kokkos+openmp", when="+openmp")
+        depends_on("kokkos-kernels+openmp", when="+openmp")
 
         for a in CudaPackage.cuda_arch_values:
             arch_str = f"+cuda cuda_arch={a}"


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

When trying to build `trilinos@16 +openmp`, I got the compilation issue:
```
     8804                      from path-to-spack/var/spack/spack-stage/build-linux-rhel8-cascadelake-2025-01-07/spack-stage-trilinos-16.0.0-qyjktoci5syj656bikpf4vlmp6iwub4
              x/spack-src/packages/phalanx/src/Phalanx_DataLayout.cpp:45:
  >> 8805     path-to-spack/var/spack/spack-stage/build-linux-rhel8-cascadelake-2025-01-07/spack-stage-trilinos-16.0.0-qyjktoci5syj656bikpf4vlmp6iwub4x/spack-src/packages/p
              halanx/src/Phalanx_KokkosDeviceTypes.hpp:25:26: error: 'OpenMP' in namespace 'Kokkos' does not name a type
     8806        25 |   using Device = Kokkos::OpenMP;
     8807           |                          ^~~~~~
  >> 8808     path-to-spack/var/spack/spack-stage/build-linux-rhel8-cascadelake-2025-01-07/spack-stage-trilinos-16.0.0-qyjktoci5syj656bikpf4vlmp6iwub4x/spack-src/packages/p
              halanx/src/Phalanx_KokkosDeviceTypes.hpp:33:27: error: 'Device' in namespace 'PHX' does not name a type
     8809        33 |   using exec_space = PHX::Device::execution_space;
     8810           |                           ^~~~~~
  >> 8811     path-to-spack/var/spack/spack-stage/build-linux-rhel8-cascadelake-2025-01-07/spack-stage-trilinos-16.0.0-qyjktoci5syj656bikpf4vlmp6iwub4x/spack-src/packages/p
              halanx/src/Phalanx_KokkosDeviceTypes.hpp:34:27: error: 'Device' in namespace 'PHX' does not name a type
     8812        34 |   using mem_space  = PHX::Device::memory_space;
```

Then, I realized that currently `trilinos@16 +openmp` does not enforce `openmp` on `kokkos`:

```
$ spack install
==> Concretized 1 spec
 -   bmjembu  trilinos@16.0.0%gcc@12.1.1~adelus~adios2+amesos+amesos2+anasazi+aztec~basker+belos~boost+chaco~complex~cuda~cuda_constexpr~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran~gtest+hdf5~hypre+ifpack+ifpack2~intrepid+intrepid2~ipo~isorropia+kokkos~mesquite~minitensor+ml+mpi+muelu~mumps+nox+openmp~pamgen+panzer~pardiso-mkl+phalanx+piro~python~rocm~rocm_rdc~rol+rythmos+sacado~scorec+shards+shared~shylu+stk~stokhos+stratimikos~strumpack~suite-sparse~superlu~superlu-dist+teko+tempus~test~threadsafe+thyra+tpetra~trilinoscouplings~wrapper~x11+zoltan+zoltan2 build_system=cmake build_type=RelWithDebInfo cxxstd=17 generator=make gotype=long_long arch=linux-rhel8-cascadelake
 -   gevt2si      ^cgns@4.4.0%gcc@12.1.1~base_scope~fortran+hdf5~int64~ipo~legacy~mem_debug+mpi~pic+scoping+shared~static~testing~tools build_system=cmake build_type=Release generator=make arch=linux-rhel8-cascadelake
[e]  2nlghst      ^cmake@3.26.3%gcc@12.1.1~doc+ncurses+ownlibs~qtgui build_system=generic build_type=Release patches=dbc3892 arch=linux-rhel8-cascadelake
 -   hy4yldt      ^gcc-runtime@12.1.1%gcc@12.1.1 build_system=generic arch=linux-rhel8-cascadelake
[e]  tiduguk      ^glibc@2.28%gcc@12.1.1 build_system=autotools arch=linux-rhel8-cascadelake
[e]  dhzsszz      ^gmake@4.2.1%gcc@12.1.1~guile build_system=generic patches=ca60bd9,fe5b60d arch=linux-rhel8-cascadelake
 -   f2acv2n      ^hdf5@1.14.5%gcc@12.1.1~cxx~fortran+hl~ipo~java~map+mpi+shared~subfiling~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make arch=linux-rhel8-cascadelake
[e]  to3ey6g          ^pkg-config@1.4.2%gcc@12.1.1+internal_glib build_system=autotools arch=linux-rhel8-cascadelake
 -   7rvawct      ^hwloc@2.1.0%gcc@12.1.1~cairo~cuda~gl~level_zero~libudev+libxml2~netloc~nvml~opencl+pci~rocm build_system=autotools libs=shared,static arch=linux-rhel8-cascadelake
[e]  4fdh6wx          ^libpciaccess@0.14%gcc@12.1.1 build_system=autotools arch=linux-rhel8-cascadelake
[e]  naht3t7          ^libxml2@2.9.7%gcc@12.1.1~http+pic~python+shared build_system=autotools arch=linux-rhel8-cascadelake
[e]  4ujbzls          ^ncurses@6.1%gcc@12.1.1~symlinks~termlib abi=none build_system=autotools patches=7a351bc arch=linux-rhel8-cascadelake
[e]  m5cu7um      ^intel-oneapi-mkl@latest%gcc@12.1.1~cluster+envmods~gfortran~ilp64+shared build_system=generic mpi_family=none threads=none arch=linux-rhel8-cascadelake
 -   taozc5d      ^kokkos@4.3.01%gcc@12.1.1~aggressive_vectorization~cmake_lang~compiler_warnings~complex_align~cuda~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~hip_relocatable_device_code~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl~openmp~openmptarget~pic~rocm+serial+shared~sycl~tests~threads~tuning~wrapper build_system=cmake build_type=Release cxxstd=17 generator=make intel_gpu_arch=none arch=linux-rhel8-cascadelake
 -   f5ugake      ^kokkos-kernels@4.3.01%gcc@12.1.1~blas~cblas~cublas~cuda~cusolver~cusparse~ipo~lapack~lapacke~mkl~openmp~rocblas~rocsolver~rocsparse~serial+shared~superlu~threads build_system=cmake build_type=Release execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto generator=make layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double arch=linux-rhel8-cascadelake
 -   qsalhgu      ^matio@1.5.26%gcc@12.1.1+hdf5+shared+zlib build_system=autotools arch=linux-rhel8-cascadelake
 -   w4webll      ^metis@5.1.0%gcc@12.1.1~gdb~int64~ipo~no_warning~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903,b1225da arch=linux-rhel8-cascadelake
[e]  okv253k      ^mvapich2@2.3.7%gcc@12.1.1~alloca~cuda~debug~hwloc_graphics~hwlocv2+regcache+wrapperrpath build_system=autotools ch3_rank_bits=32 fabrics=mrail file_systems=auto patches=d98d8e7 process_managers=auto threads=multiple arch=linux-rhel8-cascadelake
[e]  3uslq4p      ^netcdf-c@4.9.0%gcc@12.1.1+blosc~byterange~dap~fsync~hdf4~jna~logging+mpi~nczarr_zip+optimize+parallel-netcdf+pic+shared+szip+zstd build_system=autotools patches=0161eb8 arch=linux-rhel8-cascadelake
[e]  moshrjk      ^parallel-netcdf@1.12.3%gcc@12.1.1~burstbuffer+cxx~examples+fortran+pic+shared build_system=autotools arch=linux-rhel8-cascadelake
 -   h46437n      ^parmetis@4.0.3%gcc@12.1.1~gdb~int64~ipo+shared build_system=cmake build_type=Release generator=make patches=4f89253,50ed208,704b84f arch=linux-rhel8-cascadelake
 -   2soucsx      ^zlib-ng@2.2.3%gcc@12.1.1+compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-rhel8-cascadelake
```
This PR fixes the build issue by adding `+openmp` on `kokkos` and `kokkos-kernels` when `trilinos +openmp`.