### PR TITLE
warnings.showwarning: set earlier

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -510,6 +510,7 @@ def showwarning(message, category, filename, lineno, file=None, line=None):
     else:
         tty.warn(message)
 
+
 def setup_main_options(args):
     """Configure spack globals based on the basic options."""
     # Set up environment based on args.

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -503,19 +503,15 @@ def make_argument_parser(**kwargs):
     return parser
 
 
-def send_warning_to_tty(message, category, filename, lineno, file=None, line=None):
+def showwarning(message, category, filename, lineno, file=None, line=None):
     """Redirects messages to tty.warn."""
     if category is spack.error.SpackAPIWarning:
         tty.warn(f"{filename}:{lineno}: {message}")
     else:
         tty.warn(message)
 
-
 def setup_main_options(args):
     """Configure spack globals based on the basic options."""
-    # Assign a custom function to show warnings
-    warnings.showwarning = send_warning_to_tty
-
     # Set up environment based on args.
     tty.set_verbose(args.verbose)
     tty.set_debug(args.debug)
@@ -906,9 +902,10 @@ def _main(argv=None):
     # main() is tricky to get right, so be careful where you put things.
     #
     # Things in this first part of `main()` should *not* require any
-    # configuration. This doesn't include much -- setting up th parser,
+    # configuration. This doesn't include much -- setting up the parser,
     # restoring some key environment variables, very simple CLI options, etc.
     # ------------------------------------------------------------------------
+    warnings.showwarning = showwarning
 
     # Create a parser with a simple positional argument first.  We'll
     # lazily load the subcommand(s) we need later. This allows us to


### PR DESCRIPTION
Currently the handler is not set when running

```
spack -e <env> ...
```

and `<env>` has deprecated config triggering `warnings.warn`.