### PR TITLE
config: report file:line of deprecated config items

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -206,6 +206,7 @@ nitpick_ignore = [
     ("py:class", "TextIO"),
     ("py:class", "hashlib._Hash"),
     ("py:class", "concurrent.futures._base.Executor"),
+    ("py:class", "jsonschema.exceptions.ValidationError"),
     # Spack classes that are private and we don't want to expose
     ("py:class", "spack.provider_index._IndexBase"),
     ("py:class", "spack.repo._PrependFileLoader"),

--- a/lib/spack/spack/container/__init__.py
+++ b/lib/spack/spack/container/__init__.py
@@ -6,6 +6,8 @@ generate container recipes from a Spack environment
 """
 import warnings
 
+import jsonschema
+
 import spack.environment as ev
 import spack.schema.env as env
 import spack.util.spack_yaml as syaml
@@ -30,7 +32,6 @@ def validate(configuration_file):
     Returns:
         A sanitized copy of the configuration stored in the input file
     """
-    import jsonschema
 
     with open(configuration_file, encoding="utf-8") as f:
         config = syaml.load(f)

--- a/lib/spack/spack/schema/__init__.py
+++ b/lib/spack/spack/schema/__init__.py
@@ -6,6 +6,7 @@ import copy
 import typing
 
 import jsonschema
+import jsonschema.exceptions
 
 import llnl.util.lang
 
@@ -17,7 +18,7 @@ class DeprecationMessage(typing.NamedTuple):
     error: bool
 
 
-class NonFatalValidationError(jsonschema.ValidationError):
+class NonFatalValidationError(jsonschema.exceptions.ValidationError):
     """A validation error that should only produce a warning."""
 
 

--- a/lib/spack/spack/schema/__init__.py
+++ b/lib/spack/spack/schema/__init__.py
@@ -7,6 +7,7 @@ import typing
 
 import jsonschema
 import jsonschema.exceptions
+import jsonschema.validators
 
 import llnl.util.lang
 

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -9,6 +9,8 @@
 """
 from typing import Any, Dict
 
+import jsonschema
+
 #: Common properties for connection specification
 connection = {
     "url": {"type": "string"},
@@ -102,7 +104,6 @@ schema = {
 
 
 def update(data):
-    import jsonschema
 
     errors = []
 

--- a/lib/spack/spack/test/schema.py
+++ b/lib/spack/spack/test/schema.py
@@ -105,25 +105,22 @@ def test_schema_validation(meta_schema, config_name):
 
 def test_deprecated_properties(module_suffixes_schema):
     # Test that an error is reported when 'error: True'
-    msg_fmt = r"{name} is deprecated"
     module_suffixes_schema["deprecatedProperties"] = [
-        {"names": ["tcl"], "message": msg_fmt, "error": True}
+        {"names": ["tcl"], "message": r"{name} is deprecated", "error": True}
     ]
-    v = spack.schema.Validator(module_suffixes_schema)
     data = {"tcl": {"all": {"suffixes": {"^python": "py"}}}}
 
-    expected_match = "tcl is deprecated"
-    with pytest.raises(jsonschema.ValidationError, match=expected_match):
-        v.validate(data)
+    with pytest.raises(jsonschema.ValidationError, match="tcl is deprecated") as e:
+        assert not isinstance(e, spack.schema.NonFatalValidationError)
+        spack.schema.Validator(module_suffixes_schema).validate(data)
 
-    # Test that just a warning is reported when 'error: False'
+    # Test that just a non fatal error is reported when 'error: False'
     module_suffixes_schema["deprecatedProperties"] = [
-        {"names": ["tcl"], "message": msg_fmt, "error": False}
+        {"names": ["tcl"], "message": r"{name} is deprecated", "error": False}
     ]
-    v = spack.schema.Validator(module_suffixes_schema)
-    data = {"tcl": {"all": {"suffixes": {"^python": "py"}}}}
-    # The next validation doesn't raise anymore
-    v.validate(data)
+
+    with pytest.raises(spack.schema.NonFatalValidationError, match="tcl is deprecated"):
+        spack.schema.Validator(module_suffixes_schema).validate(data)
 
 
 def test_ordereddict_merge_order():


### PR DESCRIPTION
Previously Spack would report e.g. `config:install_missing_compilers` is deprecated, but it would be a pain to find the origin. Sometimes the origin is a generated ~/.spack/bootstrap config file.

Further move import of jsonschema to top level, since

> jsonschema is imported lazily as it is heavy to import
> and increases the start-up time

is unlikely to be true given that all commands read config, which triggers schema validation.

Edit: ok, this doesn't work cause jsonschema will throw one error, which could be from a parent `anyOf` in the tree.