### PR TITLE
visit: external find requires import re, license set

### DIFF
--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import re
 
 from spack.package import *
 
@@ -51,6 +52,7 @@ class Visit(CMakePackage):
     tags = ["radiuss"]
 
     maintainers("cyrush")
+    license("BSD-3-Clause")
 
     extendable = True
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Two changes :
1) determine_version uses re.match for "spack external find visit" to work properly.
Strange it worked at some time in the past.
2) added the license as stated in
https://github.com/visit-dav/visit/blob/develop/LICENSE