### PR TITLE
ocaml: compile versions before 4.8.0 again - correct regression for old versions

### DIFF
--- a/var/spack/repos/builtin/packages/ocaml/package.py
+++ b/var/spack/repos/builtin/packages/ocaml/package.py
@@ -78,7 +78,10 @@ class Ocaml(Package):
                     string=True,
                 )
 
-        configure(*(base_args), f"CC={self.compiler.cc}")
+        if self.spec.satisfies("@4.8.0:"):
+            base_args += [f"CC={self.compiler.cc}"]
+
+        configure(*(base_args))
 
         make("world.opt")
         make("install", "PREFIX={0}".format(prefix))


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Strictly before version 4.8.0 "configure CC=..." was rejected.
This PR makes versions 4.03 to 4.07 installable again.
