### PR TITLE
boost: add v1.87.0, update depdendents' constraints

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -138,7 +138,6 @@ class Boost(Package):
         "math",
         "mpi",
         "nowide",
-        "parser",
         "program_options",
         "python",
         "random",
@@ -156,11 +155,7 @@ class Boost(Package):
     ]
 
     # Add any extra requirements for specific
-    all_libs_opts = {
-        "charconv": {"when": "@1.85.0:"},
-        "cobalt": {"when": "@1.84.0:"},
-        "parser": {"when": "@1.87.0:"},
-    }
+    all_libs_opts = {"charconv": {"when": "@1.85.0:"}, "cobalt": {"when": "@1.84.0:"}}
 
     for lib in all_libs:
         lib_opts = all_libs_opts.get(lib, {})

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -288,6 +288,9 @@ class Boost(Package):
     # boost-python in 1.72.0 broken with cxxstd=98
     conflicts("cxxstd=98", when="+mpi+python @1.72.0")
 
+    # boost-mpi depends on boost-python since 1.87.0
+    conflicts("~python", when="+mpi @1.87.0:")
+
     # Container's Extended Allocators were not added until 1.56.0
     conflicts("+container", when="@:1.55")
 

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -29,6 +29,7 @@ class Boost(Package):
     license("BSL-1.0")
 
     version("develop", branch="develop", submodules=True)
+    version("1.87.0", sha256="af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89")
     version("1.86.0", sha256="1bed88e40401b2cb7a1f76d4bab499e352fa4d0c5f31c0dbae64e24d34d7513b")
     version("1.85.0", sha256="7009fe1faa1697476bdc7027703a2badb84e849b7b0baad5086b087b971f8617")
     version("1.84.0", sha256="cc4b893acf645c9d4b698e9a0f08ca8846aa5d6c68275c14c3e7949c24109454")
@@ -137,6 +138,7 @@ class Boost(Package):
         "math",
         "mpi",
         "nowide",
+        "parser",
         "program_options",
         "python",
         "random",
@@ -154,7 +156,11 @@ class Boost(Package):
     ]
 
     # Add any extra requirements for specific
-    all_libs_opts = {"charconv": {"when": "@1.85.0:"}, "cobalt": {"when": "@1.84.0:"}}
+    all_libs_opts = {
+        "charconv": {"when": "@1.85.0:"},
+        "cobalt": {"when": "@1.84.0:"},
+        "parser": {"when": "@1.87.0:"},
+    }
 
     for lib in all_libs:
         lib_opts = all_libs_opts.get(lib, {})
@@ -438,6 +444,14 @@ class Boost(Package):
         "https://www.boost.org/patches/1_82_0/0002-filesystem-fix-win-smbv1-dir-iterator.patch",
         sha256="738ba8e0d7b5cdcf5fae4998f9450b51577bbde1bb0d220a0721551609714ca4",
         when="@1.82.0 platform=windows",
+    )
+
+    # https://github.com/boostorg/context/pull/280
+    patch(
+        "https://github.com/boostorg/context/commit/d11cbccc87da5d6d41c04f3949e18d49c43e62fc.patch?full_index=1",
+        sha256="e2d37f9e35e8e238977de9af32604a8e1c2648d153df1d568935a20216b5c67f",
+        when="@1.87.0",
+        working_dir="libs/context",
     )
 
     def patch(self):

--- a/var/spack/repos/builtin/packages/faodel/package.py
+++ b/var/spack/repos/builtin/packages/faodel/package.py
@@ -64,6 +64,7 @@ class Faodel(CMakePackage):
         "+program_options+exception+locale+system+chrono+log+serialization"
         "+atomic+container+regex+thread+date_time"
     )
+    depends_on("boost@:1.86", when="@:1.2108.1")
     depends_on("cmake@3.8.0:", type="build")
     depends_on("hdf5+mpi", when="+hdf5+mpi")
     depends_on("hdf5~mpi", when="+hdf5~mpi")

--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -92,6 +92,7 @@ class Precice(CMakePackage):
     depends_on("boost@:1.72", when="@:2.0.2")
     depends_on("boost@:1.74", when="@:2.1.1")
     depends_on("boost@:1.78", when="@:2.3.0")
+    depends_on("boost@:1.86", when="@:3.1.2")
 
     depends_on("eigen@3.2:")
     depends_on("eigen@3.4:", when="@3.2:")


### PR DESCRIPTION
This PR adds `boost`, v1.87.0 ([release notes](https://www.boost.org/users/history/version_1_87_0.html)), which requires a [patch](https://github.com/boostorg/context/pull/280) to set `context-impl` on the command line.

Test build results:
```
-- linux-ubuntu24.10-skylake / gcc@14.2.0 -----------------------
5y6tyyq boost@1.87.0+atomic~charconv+chrono~clanglibcpp~cobalt~container+context~contract~coroutine+date_time~debug+exception+fiber+filesystem+graph~graph_parallel+icu+iostreams~json+locale+log+math~mpi+multithreaded~nowide~numpy~pic+program_options+python+random+regex+serialization+shared+signals~singlethreaded~stacktrace+system~taggedlayout+test+thread+timer~type_erasure~url~versionedlayout+wave build_system=generic context-impl=fcontext cxxstd=20 patches=a440f96,b8569d7,e2d37f9 visibility=hidden
==> 1 installed package
```