### PR TITLE
bugfix: associate nodes directly with specs for compiler flag reordering

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -3540,15 +3540,13 @@ class SpecBuilder:
         )
         cmd_specs = dict((s.name, s) for spec in self._command_line_specs for s in spec.traverse())
 
-        for spec in self._specs.values():
+        for node, spec in self._specs.items():
             # if bootstrapping, compiler is not in config and has no flags
             flagmap_from_compiler = {}
             if spec.compiler in compilers:
                 flagmap_from_compiler = compilers[spec.compiler].flags
 
             for flag_type in spec.compiler_flags.valid_compiler_flags():
-                node = SpecBuilder.make_node(pkg=spec.name)
-
                 ordered_flags = []
 
                 # 1. Put compiler flags first

--- a/lib/spack/spack/test/concretization/flag_mixing.py
+++ b/lib/spack/spack/test/concretization/flag_mixing.py
@@ -5,6 +5,7 @@ import pathlib
 
 import pytest
 
+import spack.concretize
 import spack.config
 import spack.environment as ev
 import spack.paths

--- a/lib/spack/spack/test/concretization/flag_mixing.py
+++ b/lib/spack/spack/test/concretization/flag_mixing.py
@@ -96,6 +96,18 @@ def test_mix_spec_and_compiler_cfg(concretize_scope, test_repo):
     assert s1.satisfies('cflags="-Wall -O2"')
 
 
+def test_pkg_flags_from_compiler_and_none(concretize_scope, mock_packages):
+    conf_str = _compiler_cfg_one_entry_with_cflags("-Wall")
+    update_concretize_scope(conf_str, "compilers")
+
+    s1 = Spec("cmake%gcc@12.100.100")
+    s2 = Spec("cmake-client^cmake%clang")
+    concrete = dict(spack.concretize.concretize_together([(s1, None), (s2, None)]))
+
+    assert concrete[s1].compiler_flags["cflags"] == ["-Wall"]
+    assert concrete[s2].compiler_flags["cflags"] == []
+
+
 @pytest.mark.parametrize(
     "cmd_flags,req_flags,cmp_flags,dflags,expected_order",
     [

--- a/var/spack/repos/builtin.mock/packages/cmake/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake/package.py
@@ -20,6 +20,8 @@ class Cmake(Package):
     homepage = "https://www.cmake.org"
     url = "https://cmake.org/files/v3.4/cmake-3.4.3.tar.gz"
 
+    tags = ["build-tools"]
+
     version(
         "3.23.1",
         md5="4cb3ff35b2472aae70f542116d616e63",


### PR DESCRIPTION
Currently, if there are duplicate specs and they are associated with compilers with different compiler flags, the concretizer fails with

```
Error: set() does not equal {'-Wall'}
```
(or whatever other set of flags the compiler is configured with).

This PR fixes it.

The issue in the code was that we dropped the information about which node was associated with which spec, and then synthetically created a node object. The new node object was always duplicate ID 0, regardless of which duplicate ID the spec originally came from, and therefore we picked up the wrong compiler flags. The fix is simple -- keep the original node associated with the spec, and we no longer construct a synthetic node object.

In order to test this successfully, we needed a build dependency in the mock repo that is tagged as a build tool. `cmake` is now tagged as a build tool to better mimic the behavior in the builtin repo.
