### PR TITLE
py-wxpython: depends_on wxwidgets +gui

### DIFF
--- a/var/spack/repos/builtin/packages/py-wxpython/package.py
+++ b/var/spack/repos/builtin/packages/py-wxpython/package.py
@@ -17,7 +17,7 @@ class PyWxpython(PythonPackage):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
-    depends_on("wxwidgets")
+    depends_on("wxwidgets +gui")
 
     # Needed for the build.py script
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
This PR adds back the explicit gui requirement in `wxwidgets` for `py-wxpython` after it was removed in #47526. Default was still true but in come cases environments were concretizing with `~gui`.