### PR TITLE
llvm: minimal fix for `llvm_config` method

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -1144,12 +1144,12 @@ class Llvm(CMakePackage, CudaPackage, LlvmDetection, CompilerPackage):
                 with open(os.path.join(self.prefix.bin, cfg), "w") as f:
                     print(gcc_install_dir_flag, file=f)
 
-    def llvm_config(self, *args, **kwargs):
+    def llvm_config(self, *args, result=None, **kwargs):
         lc = Executable(self.prefix.bin.join("llvm-config"))
         if not kwargs.get("output"):
             kwargs["output"] = str
         ret = lc(*args, **kwargs)
-        if kwargs.get("result") == "list":
+        if result == "list":
             return ret.split()
         else:
             return ret


### PR DESCRIPTION
I think we can clean this up more, but in the meanwhile, it should fix the issue we got after #48468

Failures reported by @wdconinc 
- https://gitlab.spack.io/spack/spack/-/jobs/14588454#L1713
- https://gitlab.spack.io/spack/spack/-/jobs/14588457#L1360
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
