### PR TITLE
binary_distribution.py: stop relocation old /bin/bash sbang shebang

### DIFF
--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -35,7 +35,6 @@ from llnl.util.tty.color import colorize
 
 import spack.config
 import spack.directory_layout
-import spack.paths
 import spack.projections
 import spack.relocate
 import spack.schema.projections
@@ -44,7 +43,6 @@ import spack.store
 import spack.util.spack_json as s_json
 import spack.util.spack_yaml as s_yaml
 from spack.error import SpackError
-from spack.hooks import sbang
 
 __all__ = ["FilesystemView", "YamlFilesystemView"]
 
@@ -94,12 +92,6 @@ def view_copy(
         spack.relocate.relocate_text_bin(binaries=[dst], prefixes=prefix_to_projection)
     else:
         prefix_to_projection[spack.store.STORE.layout.root] = view._root
-
-        # This is vestigial code for the *old* location of sbang.
-        prefix_to_projection[f"#!/bin/bash {spack.paths.spack_root}/bin/sbang"] = (
-            sbang.sbang_shebang_line()
-        )
-
         spack.relocate.relocate_text(files=[dst], prefixes=prefix_to_projection)
 
     # The os module on Windows does not have a chown function.

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -36,13 +36,13 @@ import spack.mirrors.mirror
 import spack.oci.image
 import spack.paths
 import spack.spec
-import spack.stage
 import spack.store
 import spack.util.gpg
 import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
 import spack.util.web as web_util
 from spack.binary_distribution import CannotListKeys, GenerateIndexError
+from spack.installer import PackageInstaller
 from spack.paths import test_path
 from spack.spec import Spec
 
@@ -492,74 +492,40 @@ def test_generate_indices_exception(monkeypatch, tmp_path, capfd):
     assert f"Encountered problem listing packages at {url}" in capfd.readouterr().err
 
 
-@pytest.mark.usefixtures("mock_fetch", "install_mockery")
-def test_update_sbang(tmpdir, temporary_mirror):
-    """Test the creation and installation of buildcaches with default rpaths
-    into the non-default directory layout scheme, triggering an update of the
-    sbang.
-    """
-    spec_str = "old-sbang"
-    # Concretize a package with some old-fashioned sbang lines.
-    old_spec = Spec(spec_str).concretized()
-    old_spec_hash_str = "/{0}".format(old_spec.dag_hash())
+def test_update_sbang(tmp_path, temporary_mirror, mock_fetch, install_mockery):
+    """Test relocation of the sbang shebang line in a package script"""
+    s = Spec("old-sbang").concretized()
+    PackageInstaller([s.package]).install()
+    old_prefix, old_sbang_shebang = s.prefix, sbang.sbang_shebang_line()
+    old_contents = f"""\
+{old_sbang_shebang}
+#!/usr/bin/env python3
 
-    # Need a fake mirror with *function* scope.
-    mirror_dir = temporary_mirror
-
-    # Assume all commands will concretize old_spec the same way.
-    install_cmd("--no-cache", old_spec.name)
+{s.prefix.bin}
+"""
+    with open(os.path.join(s.prefix.bin, "script.sh"), encoding="utf-8") as f:
+        assert f.read() == old_contents
 
     # Create a buildcache with the installed spec.
-    buildcache_cmd("push", "-u", mirror_dir, old_spec_hash_str)
-
-    # Need to force an update of the buildcache index
-    buildcache_cmd("update-index", mirror_dir)
-
-    # Uninstall the original package.
-    uninstall_cmd("-y", old_spec_hash_str)
+    buildcache_cmd("push", "--update-index", "--unsigned", temporary_mirror, f"/{s.dag_hash()}")
 
     # Switch the store to the new install tree locations
-    newtree_dir = tmpdir.join("newtree")
-    with spack.store.use_store(str(newtree_dir)):
-        new_spec = Spec("old-sbang").concretized()
-        assert new_spec.dag_hash() == old_spec.dag_hash()
+    with spack.store.use_store(str(tmp_path)):
+        s._prefix = None  # clear the cached old prefix
+        new_prefix, new_sbang_shebang = s.prefix, sbang.sbang_shebang_line()
+        assert old_prefix != new_prefix
+        assert old_sbang_shebang != new_sbang_shebang
+        PackageInstaller([s.package], cache_only=True).install()
 
-        # Install package from buildcache
-        buildcache_cmd("install", "-u", "-f", new_spec.name)
+        # Check that the sbang line refers to the new install tree
+        new_contents = f"""\
+{sbang.sbang_shebang_line()}
+#!/usr/bin/env python3
 
-        # Continue blowing away caches
-        bindist.clear_spec_cache()
-        spack.stage.purge()
-
-        # test that the sbang was updated by the move
-        sbang_style_1_expected = """{0}
-#!/usr/bin/env python
-
-{1}
-""".format(
-            sbang.sbang_shebang_line(), new_spec.prefix.bin
-        )
-        sbang_style_2_expected = """{0}
-#!/usr/bin/env python
-
-{1}
-""".format(
-            sbang.sbang_shebang_line(), new_spec.prefix.bin
-        )
-
-        installed_script_style_1_path = new_spec.prefix.bin.join("sbang-style-1.sh")
-        assert (
-            sbang_style_1_expected
-            == open(str(installed_script_style_1_path), encoding="utf-8").read()
-        )
-
-        installed_script_style_2_path = new_spec.prefix.bin.join("sbang-style-2.sh")
-        assert (
-            sbang_style_2_expected
-            == open(str(installed_script_style_2_path), encoding="utf-8").read()
-        )
-
-        uninstall_cmd("-y", "/%s" % new_spec.dag_hash())
+{s.prefix.bin}
+"""
+        with open(os.path.join(s.prefix.bin, "script.sh"), encoding="utf-8") as f:
+            assert f.read() == new_contents
 
 
 @pytest.mark.skipif(

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -515,7 +515,7 @@ def test_update_sbang(tmp_path, temporary_mirror, mock_fetch, install_mockery):
         new_prefix, new_sbang_shebang = s.prefix, sbang.sbang_shebang_line()
         assert old_prefix != new_prefix
         assert old_sbang_shebang != new_sbang_shebang
-        PackageInstaller([s.package], cache_only=True).install()
+        PackageInstaller([s.package], cache_only=True, unsigned=True).install()
 
         # Check that the sbang line refers to the new install tree
         new_contents = f"""\

--- a/var/spack/repos/builtin.mock/packages/old-sbang/package.py
+++ b/var/spack/repos/builtin.mock/packages/old-sbang/package.py
@@ -1,13 +1,14 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import spack.paths
-import spack.store
+import os
+
+from spack.hooks.sbang import sbang_shebang_line
 from spack.package import *
 
 
 class OldSbang(Package):
-    """Toy package for testing the old sbang replacement problem"""
+    """Package for testing sbang relocation"""
 
     homepage = "https://www.example.com"
     url = "https://www.example.com/old-sbang.tar.gz"
@@ -16,23 +17,11 @@ class OldSbang(Package):
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
+        contents = f"""\
+{sbang_shebang_line()}
+#!/usr/bin/env python3
 
-        sbang_style_1 = """#!/bin/bash {0}/bin/sbang
-#!/usr/bin/env python
-
-{1}
-""".format(
-            spack.paths.prefix, prefix.bin
-        )
-        sbang_style_2 = """#!/bin/sh {0}/bin/sbang
-#!/usr/bin/env python
-
-{1}
-""".format(
-            spack.store.STORE.unpadded_root, prefix.bin
-        )
-        with open("%s/sbang-style-1.sh" % self.prefix.bin, "w", encoding="utf-8") as f:
-            f.write(sbang_style_1)
-
-        with open("%s/sbang-style-2.sh" % self.prefix.bin, "w", encoding="utf-8") as f:
-            f.write(sbang_style_2)
+{prefix.bin}
+"""
+        with open(os.path.join(self.prefix.bin, "script.sh"), "w", encoding="utf-8") as f:
+            f.write(contents)


### PR DESCRIPTION
On top of #48488.

This PR removes old relocation of `#!/bin/bash <path to spack>/bin/sbang` shebang lines. Old sbang was basically not relocatable since it made packages have a dependency on Spack itself, not reflected in the DAG. This behavior was dropped 5 years ago in Spack v0.16, so it should be fine to drop by now.

That allows a big cleanup of the relocation logic, where relocation simplifies to a single, ordered prefix to prefix mapping.

