### PR TITLE
py-scipy: Allow building with AOCC

### DIFF
--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -184,9 +184,6 @@ class PyScipy(PythonPackage):
     # https://github.com/spack/spack/issues/48243
     conflicts("%intel", when="@1.14:", msg="SciPy 1.14: Use Intel LLVM instead of Intel Classic")
 
-    # https://github.com/spack/spack/issues/45718
-    conflicts("%aocc", msg="SciPy doesn't compile with AOCC yet")
-
     # https://github.com/scipy/scipy/issues/19831
     conflicts("^openblas@0.3.26:", when="@:1.12")
 


### PR DESCRIPTION
There was a meson issue that prevented builds of scipy with some fortran compilers including AOCC.  We merged a fix for the meson problem in spack/spack#46922, but missed a roughly contemporaneous PR entirely disabling the AOCC compiler in spack/spack#46452.

We have been unable to reproduce the boost issue that was reported in spack/spack#45718 in any configuration that we have tested. These include the original `py-scipy@1.12.0 %aocc@4.0.0 ^meson@1.3.2` configuration, and all newer `py-scipy` versions with AOCC versions newer than `4.0` and default dependencies, as well as builds with older versions of numpy, meson and py-meson.  Note also this is a boost templating problem not an AOCC specific problem and can be fixed by a more targeted solution than disabling AOCC if it reappears.

Request that this conflict be removed, and we are happy to further investigate the boost issue if someone has a reproducer for us.