### PR TITLE
otf2: add a dependency on Fortran

### DIFF
--- a/var/spack/repos/builtin/packages/otf2/package.py
+++ b/var/spack/repos/builtin/packages/otf2/package.py
@@ -58,8 +58,9 @@ class Otf2(AutotoolsPackage):
         deprecated=True,
     )
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
 
     def url_for_version(self, version):
         if version < Version("2.3"):


### PR DESCRIPTION
See https://gitlab.spack.io/spack/spack/-/jobs/14423941

From https://gitlab.com/score-p/scorep/-/blob/master/INSTALL?ref_type=heads

> Score-P requires a full compiler suite with language support for C99,
> C++11 and optionally Fortran 77 and Fortran 90.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
