### PR TITLE
icu4c: no cxxstd flag option on Windows

### DIFF
--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -125,7 +125,7 @@ class MSBuildBuilder(spack.build_systems.msbuild.MSBuildBuilder):
     @property
     def build_directory(self):
         solution_path = pathlib.Path(self.pkg.stage.source_path)
-        if self.spec.satsifies("@:67"):
+        if self.spec.satisfies("@:67"):
             solution_path = solution_path / "icu"
         solution_path = solution_path / "source" / "allinone"
         return str(solution_path)

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -72,7 +72,7 @@ class Icu4c(AutotoolsPackage, MSBuildPackage):
         return url.format(version.dashed, version.underscored)
 
     def flag_handler(self, name, flags):
-        if name == "cxxflags":
+        if name == "cxxflags" and not self.spec.platform == "windows":
             # Control of the C++ Standard is via adding the required "-std"
             # flag to CXXFLAGS in env
             flags.append(getattr(self.compiler, f"cxx{self.spec.variants['cxxstd'].value}_flag"))


### PR DESCRIPTION
The Windows build of icu4c does not provide the capacity to provide the cxx standard to the build so we don't offer the variant on the platform. We shouldn't attempt to reference it in the flag handler in that case.

This PR adds a platform check around the use of the cxx standard variant in the flag handler for ICU4C's package recipe