### PR TITLE
Windows: Update default config for stage location

### DIFF
--- a/etc/spack/defaults/windows/config.yaml
+++ b/etc/spack/defaults/windows/config.yaml
@@ -1,5 +1,5 @@
 config:
   locks: false
   build_stage::
-    - '$spack/.staging'
+    - '$user_cache_path/stage'
   stage_name: '{name}-{version}-{hash:7}'


### PR DESCRIPTION
Current location is within the Spack prefix, which causes builds to pollute VCS with stage artifacts and generally inflates the Spack install prefix. This PR moves it to the user cache location now that we can consistently support paths with spaces on Windows

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
