### PR TITLE
zlib: Ensure correct lib name on Windows

### DIFF
--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -88,7 +88,9 @@ class Zlib(MakefilePackage, Package):
         libnames = ["libz"]
         if sys.platform == "win32":
             libnames.append("zdll" if shared else "zlib")
-        return find_libraries(libnames, root=self.prefix, recursive=True, shared=shared, runtime=False)
+        return find_libraries(
+            libnames, root=self.prefix, recursive=True, shared=shared, runtime=False
+        )
 
 
 class SetupEnvironment:

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -8,6 +8,7 @@
 import glob
 import os
 import re
+import sys
 
 import spack.build_systems.generic
 import spack.build_systems.makefile
@@ -84,7 +85,10 @@ class Zlib(MakefilePackage, Package):
     @property
     def libs(self):
         shared = "+shared" in self.spec
-        return find_libraries(["libz"], root=self.prefix, recursive=True, shared=shared)
+        libnames = ["libz"]
+        if sys.platform == "win32":
+            libnames.append("zdll" if shared else "zlib")
+        return find_libraries(libnames, root=self.prefix, recursive=True, shared=shared, runtime=False)
 
 
 class SetupEnvironment:

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -8,7 +8,6 @@
 import glob
 import os
 import re
-import sys
 
 import spack.build_systems.generic
 import spack.build_systems.makefile

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -86,7 +86,7 @@ class Zlib(MakefilePackage, Package):
     def libs(self):
         shared = "+shared" in self.spec
         libnames = ["libz"]
-        if sys.platform == "win32":
+        if self.spec.satisfies("platform=windows"):
             libnames.append("zdll" if shared else "zlib")
         return find_libraries(
             libnames, root=self.prefix, recursive=True, shared=shared, runtime=False


### PR DESCRIPTION
Zlib is named either `zdll` or `zlib` depending on the library type (or both if shared). Refactor the zlib package to use this correct name and remove the default search for a runtime artifact ("zdll").