### PR TITLE
Limit PFLOTRAN Develop (6.0+) PETSc dependency to 3.21

### DIFF
--- a/var/spack/repos/builtin/packages/pflotran/package.py
+++ b/var/spack/repos/builtin/packages/pflotran/package.py
@@ -31,7 +31,7 @@ class Pflotran(AutotoolsPackage):
 
     depends_on("mpi")
     depends_on("hdf5@1.8.12:+mpi+fortran+hl")
-    depends_on("petsc@main:+hdf5+metis", when="@develop")
+    depends_on("petsc@3.21+hdf5+metis", when="@develop")
     depends_on("petsc@3.20:3.21+hdf5+metis", when="@5.0.0")
     depends_on("petsc@3.18:+hdf5+metis", when="@4.0.1")
     depends_on("petsc@3.16:+hdf5+metis", when="@3.0.2")


### PR DESCRIPTION
PFLOTRAN develop requires PETSc 3.21 ([see here](https://www.pflotran.org/documentation/user_guide/how_to/installation/linux.html#linux-install)). I encountered a build error pulling develop today and confirmed it installs and functions correctly after requiring PETSc 3.21 (PETSc main is now ahead at 3.22+). 
