### PR TITLE
vbfnlo: deprecated 3.0.0beta* since 3.0 < 3.0.0beta

### DIFF
--- a/var/spack/repos/builtin/packages/vbfnlo/package.py
+++ b/var/spack/repos/builtin/packages/vbfnlo/package.py
@@ -18,21 +18,23 @@ class Vbfnlo(AutotoolsPackage):
 
     license("GPL-2.0-only")
 
-    # The commented out versions exist, but are not tested
     version("3.0", sha256="b9df02603e4f801f866360c720191a29afdb958d0bd4369ea7d810e761503e51")
-    version(
-        "3.0.0beta5", sha256="777a3dedb365ea9abc38848a60f30d325da3799cbad69fa308664b94a8c31a90"
-    )
-    version(
-        "3.0.0beta4", sha256="511e84765e9634a75766a160eae1925812dacbb3943e7e3b4dc90e2eacac8a2c"
-    )
-    # version('3.0.0beta3', sha256='ab4cc3289051ab09ed94fa41d0eb1c5c4adcd9f39fa04e3c95a3867f256541bc')
-    version(
-        "3.0.0beta2", sha256="33dd0781e645a5baa664fc5aa81d43c12586bf095ef25895e86cb4192c22473b"
-    )
-    version(
-        "3.0.0beta1", sha256="19f0bf7e4c93b0f287d2531d6802c114a78eb46cde28ea820b2a074a5819c7ca"
-    )
+    with default_args(deprecated=True):
+        version(
+            "3.0.0beta5", sha256="777a3dedb365ea9abc38848a60f30d325da3799cbad69fa308664b94a8c31a90"
+        )
+        version(
+            "3.0.0beta4", sha256="511e84765e9634a75766a160eae1925812dacbb3943e7e3b4dc90e2eacac8a2c"
+        )
+        version(
+            "3.0.0beta3", sha256="ab4cc3289051ab09ed94fa41d0eb1c5c4adcd9f39fa04e3c95a3867f256541bc"
+        )
+        version(
+            "3.0.0beta2", sha256="33dd0781e645a5baa664fc5aa81d43c12586bf095ef25895e86cb4192c22473b"
+        )
+        version(
+            "3.0.0beta1", sha256="19f0bf7e4c93b0f287d2531d6802c114a78eb46cde28ea820b2a074a5819c7ca"
+        )
     version(
         "2.7.1",
         sha256="13e33d73d8a8ef64094621f87e6f94e01712e76cc19a86298d0b52cfcb9decca",

--- a/var/spack/repos/builtin/packages/vbfnlo/package.py
+++ b/var/spack/repos/builtin/packages/vbfnlo/package.py
@@ -20,6 +20,7 @@ class Vbfnlo(AutotoolsPackage):
 
     version("3.0", sha256="b9df02603e4f801f866360c720191a29afdb958d0bd4369ea7d810e761503e51")
     with default_args(deprecated=True):
+        # deprecate beta versions which are such that they are preferred over 3.0
         version(
             "3.0.0beta5", sha256="777a3dedb365ea9abc38848a60f30d325da3799cbad69fa308664b94a8c31a90"
         )
@@ -35,11 +36,7 @@ class Vbfnlo(AutotoolsPackage):
         version(
             "3.0.0beta1", sha256="19f0bf7e4c93b0f287d2531d6802c114a78eb46cde28ea820b2a074a5819c7ca"
         )
-    version(
-        "2.7.1",
-        sha256="13e33d73d8a8ef64094621f87e6f94e01712e76cc19a86298d0b52cfcb9decca",
-        preferred=True,
-    )
+    version("2.7.1", sha256="13e33d73d8a8ef64094621f87e6f94e01712e76cc19a86298d0b52cfcb9decca")
 
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated

--- a/var/spack/repos/builtin/packages/vbfnlo/package.py
+++ b/var/spack/repos/builtin/packages/vbfnlo/package.py
@@ -74,6 +74,6 @@ class Vbfnlo(AutotoolsPackage):
 
         return args
 
-    @when("@3.0.0beta3:~doc")
+    @when("@3: ~doc")
     def patch(self):
         filter_file("lib src doc", "lib src", "Makefile.am")


### PR DESCRIPTION
Since `vbfnlo` released `3.0` after `3.0.0beta5`, and since
```
$ spack python -c 'spack.version.Version("3.0") < spack.version.Version("3.0.0beta")'
True
```
this PR explicitly deprecates the betas so they don't get picked up accidentally. It also avoid preferring 2.7.1.

This PR also fixes the condition for `patch()` to `when("@3: ~doc")` so it is applied for 3.0 as well (and intentionally doesn't do anything for 3.0.0beta1 and 3.0.0beta2).

Test build (`patch` previously not called):
```
==> Installing vbfnlo-3.0-7uvhju22t4x7peg3cvr365n4aqtatb3s [40/40]
==> No binary for vbfnlo-3.0-7uvhju22t4x7peg3cvr365n4aqtatb3s found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/b9/b9df02603e4f801f866360c720191a29afdb958d0bd4369ea7d810e761503e51.tar.gz
==> Ran patch() for vbfnlo
==> vbfnlo: Executing phase: 'autoreconf'
==> vbfnlo: Executing phase: 'configure'
==> vbfnlo: Executing phase: 'build'
==> vbfnlo: Executing phase: 'install'
==> vbfnlo: Successfully installed vbfnlo-3.0-7uvhju22t4x7peg3cvr365n4aqtatb3s
  Stage: 0.22s.  Autoreconf: 7.55s.  Configure: 5.53s.  Build: 15m 35.53s.  Install: 5.37s.  Post-install: 0.28s.  Total: 15m 54.63s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/vbfnlo-3.0-7uvhju22t4x7peg3cvr365n4aqtatb3s
```