### PR TITLE
keepassxc: adding versions 2.7.8 and 2.7.9

### DIFF
--- a/var/spack/repos/builtin/packages/keepassxc/package.py
+++ b/var/spack/repos/builtin/packages/keepassxc/package.py
@@ -17,6 +17,8 @@ class Keepassxc(CMakePackage):
     license("GPL-2.0-only OR GPL-3.0-only")
 
     version("master", branch="master")
+    version("2.7.9", sha256="3c44e45f22c00ddac63d8bc11054b4b0ada0222ffac08d3ed70f196cb9ed46fd")
+    version("2.7.8", sha256="87d3101712b3c8656a24b908ad5b7e2529bc01717cb4156f53ba195fb81783a3")
     version("2.7.7", sha256="58fc45ae98e4b3ffb052103014f5b97a41fefd17102c7f56073934dd3a82ee67")
     version("2.7.6", sha256="a58074509fa8e90f152c6247f73e75e126303081f55eedb4ea0cbb6fa980d670")
     version("2.7.1", sha256="6001ba626c35c316dbda6de35736f012a2264f95139fcb4a094b8eb49b15d3e7")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
Improved versions, see release notes
https://github.com/keepassxreboot/keepassxc/releases/tag/2.7.8
https://github.com/keepassxreboot/keepassxc/releases/tag/2.7.9
