### PR TITLE
cepgen: add v1.2.5

### DIFF
--- a/var/spack/repos/builtin/packages/cepgen/package.py
+++ b/var/spack/repos/builtin/packages/cepgen/package.py
@@ -15,6 +15,7 @@ class Cepgen(CMakePackage):
 
     license("GPL-3.0-or-later")
 
+    version("1.2.5", sha256="5016c5a9b505035f849f47bdf35ecfb8c98d45dd1e086fae64f264a30adb120d")
     version("1.1.0", sha256="2a4eaed161f007269516cbfb6e90421e657ab1922d4509de0165f08dde91bf3d")
     version(
         "1.0.2patch1", sha256="333bba0cb1965a98dec127e00c150eab1a515cd348a90f7b1d66d5cd8d206d21"


### PR DESCRIPTION
This PR adds `cepgen`, v1.2.5 ([release notes](https://github.com/cepgen/cepgen/releases/tag/1.2.5), [diff](https://github.com/cepgen/cepgen/compare/1.1.0...1.2.5)), which doesn't require any changes to the build system.

Test build:
```
-- linux-ubuntu24.10-skylake / gcc@14.2.0 -----------------------
cepgen@1.2.5
==> 1 installed package
```