### PR TITLE
hep stack: build also with cuda and rocm where possible

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -101,15 +101,16 @@ spack:
   - yoda +root
 
   # CUDA NOARCH
-  - celeritas +cuda +vecgeom
   - root +cuda +cudnn +tmva-gpu
 
   # CUDA 80
   - acts +cuda +traccc cuda_arch=80
+  - celeritas +cuda +vecgeom cuda_arch=80
   - vecgeom +cuda cuda_arch=80
 
   # CUDA 90
   - acts +cuda +traccc cuda_arch=90
+  - celeritas +cuda +vecgeom cuda_arch=90
   - vecgeom +cuda cuda_arch=90
 
   # ROCm 90a

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -18,7 +18,8 @@ spack:
     celeritas:
       require: +geant4 +hepmc3 +openmp +root +shared cxxstd=20
     root:
-      require: +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +tmva-cpu +unuran +vc +vdt +veccore +webgui +x +xml +xrootd cxxstd=20
+      require: +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +tmva-cpu +unuran +vc +vdt +veccore +webgui +x +xml +xrootd # cxxstd=20
+      # note: root cxxstd=20 not concretizable within sherpa
     vecgeom:
       require: +gdml +geant4 +root +shared cxxstd=20
 
@@ -26,16 +27,16 @@ spack:
     geant4-data:
       buildable: false
       externals:
-        - spec: geant4-data@11.3.0
-          prefix: /usr
-        - spec: geant4-data@11.2.2
-          prefix: /usr
-        - spec: geant4-data@11.2.0
-          prefix: /usr
-        - spec: geant4-data@11.1.0
-          prefix: /usr
-        - spec: geant4-data@11.0.0
-          prefix: /usr
+      - spec: geant4-data@11.3.0
+        prefix: /usr
+      - spec: geant4-data@11.2.2
+        prefix: /usr
+      - spec: geant4-data@11.2.0
+        prefix: /usr
+      - spec: geant4-data@11.1.0
+        prefix: /usr
+      - spec: geant4-data@11.0.0
+        prefix: /usr
 
   specs:
   # CPU
@@ -100,26 +101,46 @@ spack:
   - xrootd +davix +http +krb5 +python +readline +scitokens-cpp
   - yoda +root
 
-  # CUDA NOARCH
-  - root +cuda +cudnn +tmva-gpu
-
-  # CUDA 80
+  # CUDA
   #- acts +cuda +traccc cuda_arch=80
   - celeritas +cuda +vecgeom cuda_arch=80
+  - root +cuda +cudnn +tmva-gpu
   - vecgeom +cuda cuda_arch=80
 
-  # CUDA 90
-  #- acts +cuda +traccc cuda_arch=90
-  - celeritas +cuda +vecgeom cuda_arch=90
-  - vecgeom +cuda cuda_arch=90
-
-  # ROCm 90a
+  # ROCm
   - celeritas +rocm amdgpu_target=gfx90a ~vecgeom  # only available with ORANGE
 
   ci:
     pipeline-gen:
     - build-job:
-        image: "ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4:2024.03.01"
+        image: ghcr.io/spack/spack/ubuntu22.04-runner-amd64-gcc-11.4:2024.03.01
 
   cdash:
     build-group: HEP
+  compilers:
+  - compiler:
+      spec: gcc@=9.4.0
+      paths:
+        cc: /usr/bin/gcc
+        cxx: /usr/bin/g++
+        f77: null
+        fc: null
+      flags: {}
+      operating_system: ubuntu20.04
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: clang@=10.0.0
+      paths:
+        cc: /usr/bin/clang
+        cxx: /usr/bin/clang++
+        f77: null
+        fc: null
+      flags: {}
+      operating_system: ubuntu20.04
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -105,7 +105,7 @@ spack:
 
   # CUDA
   #- acts +cuda +traccc cuda_arch=80
-  - celeritas +cuda ~openmp +vecgeom cuda_arch=80
+  #- celeritas +cuda ~openmp +vecgeom cuda_arch=80
   - root +cuda +cudnn +tmva-gpu
   - vecgeom +cuda cuda_arch=80
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -117,30 +117,3 @@ spack:
 
   cdash:
     build-group: HEP
-  compilers:
-  - compiler:
-      spec: gcc@=9.4.0
-      paths:
-        cc: /usr/bin/gcc
-        cxx: /usr/bin/g++
-        f77: null
-        fc: null
-      flags: {}
-      operating_system: ubuntu20.04
-      target: x86_64
-      modules: []
-      environment: {}
-      extra_rpaths: []
-  - compiler:
-      spec: clang@=10.0.0
-      paths:
-        cc: /usr/bin/clang
-        cxx: /usr/bin/clang++
-        f77: null
-        fc: null
-      flags: {}
-      operating_system: ubuntu20.04
-      target: x86_64
-      modules: []
-      environment: {}
-      extra_rpaths: []

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -112,8 +112,8 @@ spack:
   - acts +cuda +traccc cuda_arch=90
   - vecgeom +cuda cuda_arch=90
 
-  # ROCm NOARCH
-  - celeritas +rocm ~vecgeom  # only available with ORANGE
+  # ROCm 90a
+  - celeritas +rocm amdgpu_target=gfx90a ~vecgeom  # only available with ORANGE
 
   ci:
     pipeline-gen:

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -20,7 +20,7 @@ spack:
     root:
       require: +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +tmva-cpu +unuran +vc +vdt +veccore +webgui +x +xml +xrootd cxxstd=20
     vecgeom:
-      require: +gdml +geant4 +root
+      require: +gdml +geant4 +root +shared cxxstd=20
 
     # Mark geant4 data as external to prevent wasting bandwidth on GB-scale files
     geant4-data:

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -18,7 +18,7 @@ spack:
     celeritas:
       require: +geant4 +hepmc3 +openmp +root +shared cxxstd=20
     root:
-      require: +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +tmva-cpu +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
+      require: +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +tmva-cpu +unuran +vc +vdt +veccore +webgui +x +xml +xrootd cxxstd=20
     vecgeom:
       require: +gdml +geant4 +root
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -17,6 +17,8 @@ spack:
       require: +analysis +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +podio +pythia8 +python ~svg +tgeo cxxstd=20
     celeritas:
       require: +geant4 +hepmc3 +openmp +root +shared cxxstd=20
+    hip:
+      require: '@5.7.1 +rocm'
     root:
       require: +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +tmva-cpu +unuran +vc +vdt +veccore +webgui +x +xml +xrootd # cxxstd=20
       # note: root cxxstd=20 not concretizable within sherpa

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -13,9 +13,18 @@ spack:
         mpi: [mpich]
         tbb: [intel-tbb]
       variants: +mpi
+    acts:
+      require: +analysis +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +podio +pythia8 +python +tgeo cxxstd=20
+    celeritas:
+      require: +geant4 +hepmc3 +openmp +root +shared cxxstd=20
+    root:
+      require: +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +tmva-cpu +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
+    vecgeom:
+      require: +gdml +geant4 +root
 
     # Mark geant4 data as external to prevent wasting bandwidth on GB-scale files
     geant4-data:
+      buildable: false
       externals:
         - spec: geant4-data@11.3.0
           prefix: /usr
@@ -30,12 +39,12 @@ spack:
 
   specs:
   # CPU
-  - acts +analysis +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +podio +pythia8 +python +tgeo cxxstd=20
+  - acts ~cuda
   #- agile  # fails on c++>11 compiler
   - alpgen
   - ampt
   - apfel +lhapdf +python
-  - celeritas +geant4 +hepmc3 +openmp +root +shared +vecgeom cxxstd=20
+  - celeritas ~cuda ~rocm +vecgeom
   - cepgen
   - cernlib +shared
   - collier
@@ -82,14 +91,29 @@ spack:
   - py-vector
   - pythia8 +evtgen +fastjet +hdf5 +hepmc +hepmc3 +lhapdf ~madgraph5amc +python +rivet ~root # pythia8 and root circularly depend
   - rivet hepmc=3
-  - root +davix +dcache +examples +fftw +fits +fortran +gdml +graphviz +gsl +http +math +minuit +mlp +mysql +opengl +postgres +pythia8 +python +r +roofit +root7 +rpath ~shadow +spectrum +sqlite +ssl +tbb +threads +tmva +unuran +vc +vdt +veccore +webgui +x +xml +xrootd
+  - root ~cuda
   - sherpa +analysis ~blackhat +gzip +hepmc3 +hepmc3root +lhapdf +lhole +openloops +pythia ~python ~recola ~rivet +root +ufo cxxstd=20
   - tauola +hepmc3 +lhapdf cxxstd=20
   - thepeg hepmc=3 ~rivet
-  - vecgeom +gdml +geant4 +root
+  - vecgeom ~cuda
   - whizard +fastjet +gosam hepmc=3 +lcio +lhapdf +openloops +openmp +pythia8
   - xrootd +davix +http +krb5 +python +readline +scitokens-cpp
   - yoda +root
+
+  # CUDA NOARCH
+  - celeritas +cuda +vecgeom
+  - root +cuda +cudnn +tmva-gpu
+
+  # CUDA 80
+  - acts +cuda +traccc cuda_arch=80
+  - vecgeom +cuda cuda_arch=80
+
+  # CUDA 90
+  - acts +cuda +traccc cuda_arch=90
+  - vecgeom +cuda cuda_arch=90
+
+  # ROCm NOARCH
+  - celeritas +rocm ~vecgeom  # only available with ORANGE
 
   ci:
     pipeline-gen:

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -104,12 +104,12 @@ spack:
   - root +cuda +cudnn +tmva-gpu
 
   # CUDA 80
-  - acts +cuda +traccc cuda_arch=80
+  #- acts +cuda +traccc cuda_arch=80
   - celeritas +cuda +vecgeom cuda_arch=80
   - vecgeom +cuda cuda_arch=80
 
   # CUDA 90
-  - acts +cuda +traccc cuda_arch=90
+  #- acts +cuda +traccc cuda_arch=90
   - celeritas +cuda +vecgeom cuda_arch=90
   - vecgeom +cuda cuda_arch=90
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -14,7 +14,7 @@ spack:
         tbb: [intel-tbb]
       variants: +mpi
     acts:
-      require: +analysis +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +podio +pythia8 +python +tgeo cxxstd=20
+      require: +analysis +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +podio +pythia8 +python ~svg +tgeo cxxstd=20
     celeritas:
       require: +geant4 +hepmc3 +openmp +root +shared cxxstd=20
     root:

--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -16,7 +16,7 @@ spack:
     acts:
       require: +analysis +dd4hep +edm4hep +examples +fatras +geant4 +hepmc3 +podio +pythia8 +python ~svg +tgeo cxxstd=20
     celeritas:
-      require: +geant4 +hepmc3 +openmp +root +shared cxxstd=20
+      require: +geant4 +hepmc3 +root +shared cxxstd=20
     hip:
       require: '@5.7.1 +rocm'
     root:
@@ -47,7 +47,7 @@ spack:
   - alpgen
   - ampt
   - apfel +lhapdf +python
-  - celeritas ~cuda ~rocm +vecgeom
+  - celeritas ~cuda +openmp ~rocm +vecgeom
   - cepgen
   - cernlib +shared
   - collier
@@ -105,12 +105,12 @@ spack:
 
   # CUDA
   #- acts +cuda +traccc cuda_arch=80
-  - celeritas +cuda +vecgeom cuda_arch=80
+  - celeritas +cuda ~openmp +vecgeom cuda_arch=80
   - root +cuda +cudnn +tmva-gpu
   - vecgeom +cuda cuda_arch=80
 
   # ROCm
-  - celeritas +rocm amdgpu_target=gfx90a ~vecgeom  # only available with ORANGE
+  - celeritas +rocm amdgpu_target=gfx90a ~openmp ~vecgeom  # only available with ORANGE
 
   ci:
     pipeline-gen:

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -125,6 +125,9 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
         for pkg in ["CUDA", "Geant4", "HepMC3", "OpenMP", "ROOT", "SWIG", "VecGeom"]:
             args.append(from_variant("CELERITAS_USE_" + pkg, pkg.lower()))
 
+        if self.spec.satisfies("+cuda"):
+            args.append("CMAKE_CUDA_ARCHITECTURES", self.spec.variants["cuda_arch"].value)
+
         if self.version < Version("0.5"):
             # JSON is required for 0.5 and later
             args.append(define("CELERITAS_USE_JSON", True))

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -131,10 +131,10 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
         if self.spec.satisfies("+cuda"):
             args.append(CMakeBuilder.define_cuda_architectures(self))
         if self.spec.satisfies("+rocm"):
-            args.append(define("CMAKE_CXX_COMPILER", self.spec["hip"].prefix.bin.hipcc))
+            args.append(define("CMAKE_HIP_COMPILER", self.spec["hip"].prefix.bin.hipcc))
             args.append(
                 define(
-                    "CMAKE_CXX_FLAGS",
+                    "CMAKE_HIP_FLAGS",
                     " ".join(
                         [
                             f"-I{self.spec[p].prefix.include}"

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -132,7 +132,7 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
             args.append(CMakeBuilder.define_cuda_architectures(self))
         if self.spec.satisfies("+rocm"):
             args.append(define("CMAKE_CXX_COMPILER", self.spec["hip"].prefix.bin.hipcc))
-            args.append(define("CMAKE_CXX_FLAGS", f"-I{self.spec['rocthrust'].prefix.include}"))
+            args.append(define("CMAKE_CXX_FLAGS", f"-I{self.spec['rocprim'].prefix.include} -I{self.spec['rocrand'].prefix.include} -I{self.spec['rocthrust'].prefix.include}"))
             args.append(CMakeBuilder.define_hip_architectures(self))
 
         if self.version < Version("0.5"):

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -132,6 +132,7 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
             args.append(CMakeBuilder.define_cuda_architectures(self))
         if self.spec.satisfies("+rocm"):
             args.append(define("CMAKE_CXX_COMPILER", self.spec["hip"].prefix.bin.hipcc))
+            args.append(define("CMAKE_CXX_FLAGS", f"-I{self.spec['rocthrust'].prefix.include}"))
             args.append(CMakeBuilder.define_hip_architectures(self))
 
         if self.version < Version("0.5"):

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -131,7 +131,7 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
         if self.spec.satisfies("+cuda"):
             args.append(CMakeBuilder.define_cuda_architectures(self))
         if self.spec.satisfies("+rocm"):
-            args.append(define("CMAKE_HIP_COMPILER", self.spec["hip"].prefix.bin.hipcc))
+            args.append(CMakeBuilder.define_hip_architectures(self))
             args.append(
                 define(
                     "CMAKE_HIP_FLAGS",
@@ -143,7 +143,6 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
                     ),
                 )
             )
-            args.append(CMakeBuilder.define_hip_architectures(self))
 
         if self.version < Version("0.5"):
             # JSON is required for 0.5 and later

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -118,7 +118,7 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
             from_variant("CELERITAS_BUILD_DOCS", "doc"),
             define("CELERITAS_BUILD_DEMOS", False),
             define("CELERITAS_BUILD_TESTS", False),
-            from_variant("Celeritas_USE_HIP", "rocm"),
+            from_variant("CELERITAS_USE_HIP", "rocm"),
             define("CELERITAS_USE_MPI", False),
             define("CELERITAS_USE_Python", True),
         ]

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -135,7 +135,12 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
             args.append(
                 define(
                     "CMAKE_CXX_FLAGS",
-                    " ".join([f"-I{self.spec[p].prefix.include}" for p in ["rocprim", "rocrand", "rocthrust"]])
+                    " ".join(
+                        [
+                            f"-I{self.spec[p].prefix.include}"
+                            for p in ["rocprim", "rocrand", "rocthrust"]
+                        ]
+                    ),
                 )
             )
             args.append(CMakeBuilder.define_hip_architectures(self))

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -131,7 +131,7 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
         if self.spec.satisfies("+cuda"):
             args.append(CMakeBuilder.define_cuda_architectures(self))
         if self.spec.satisfies("+rocm"):
-            args.append(define("CMAKE_CXX_COMPILER", spec["hip"].prefix.bin.hipcc))
+            args.append(define("CMAKE_CXX_COMPILER", self.spec["hip"].prefix.bin.hipcc))
             args.append(CMakeBuilder.define_hip_architectures(self))
 
         if self.version < Version("0.5"):

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems.cmake import CMakeBuilder
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -125,8 +125,10 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
         for pkg in ["CUDA", "Geant4", "HepMC3", "OpenMP", "ROOT", "SWIG", "VecGeom"]:
             args.append(from_variant("CELERITAS_USE_" + pkg, pkg.lower()))
 
-        if self.spec.satisfies("+cuda"):
-            args.append("CMAKE_CUDA_ARCHITECTURES", self.spec.variants["cuda_arch"].value)
+        if spec.satisfies("+cuda"):
+            args.append(CMakeBuilder.define_cuda_architectures(self))
+        if spec.satisfies("+rocm"):
+            args.append(CMakeBuilder.define_hip_architectures(self))
 
         if self.version < Version("0.5"):
             # JSON is required for 0.5 and later

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -85,6 +85,7 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
     with when("+cuda"):
         depends_on("thrust")
     with when("+rocm"):
+        depends_on("hiprand")
         depends_on("rocprim")
         depends_on("rocrand")
         depends_on("rocthrust")
@@ -138,7 +139,7 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
                     " ".join(
                         [
                             f"-I{self.spec[p].prefix.include}"
-                            for p in ["rocprim", "rocrand", "rocthrust"]
+                            for p in ["hiprand", "rocprim", "rocrand", "rocthrust"]
                         ]
                     ),
                 )

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -130,6 +130,7 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
             args.append(CMakeBuilder.define_cuda_architectures(self))
         if self.spec.satisfies("+rocm"):
             args.append(CMakeBuilder.define_hip_architectures(self))
+            args.append(define("Thrust_ROOT", self.spec["rocthrust"].prefix))
 
         if self.version < Version("0.5"):
             # JSON is required for 0.5 and later

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -132,7 +132,12 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
             args.append(CMakeBuilder.define_cuda_architectures(self))
         if self.spec.satisfies("+rocm"):
             args.append(define("CMAKE_CXX_COMPILER", self.spec["hip"].prefix.bin.hipcc))
-            args.append(define("CMAKE_CXX_FLAGS", f"-I{self.spec['rocprim'].prefix.include} -I{self.spec['rocrand'].prefix.include} -I{self.spec['rocthrust'].prefix.include}"))
+            args.append(
+                define(
+                    "CMAKE_CXX_FLAGS",
+                    f"-I{self.spec['rocprim'].prefix.include} -I{self.spec['rocrand'].prefix.include} -I{self.spec['rocthrust'].prefix.include}",
+                )
+            )
             args.append(CMakeBuilder.define_hip_architectures(self))
 
         if self.version < Version("0.5"):

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -126,9 +126,9 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
         for pkg in ["CUDA", "Geant4", "HepMC3", "OpenMP", "ROOT", "SWIG", "VecGeom"]:
             args.append(from_variant("CELERITAS_USE_" + pkg, pkg.lower()))
 
-        if spec.satisfies("+cuda"):
+        if self.spec.satisfies("+cuda"):
             args.append(CMakeBuilder.define_cuda_architectures(self))
-        if spec.satisfies("+rocm"):
+        if self.spec.satisfies("+rocm"):
             args.append(CMakeBuilder.define_hip_architectures(self))
 
         if self.version < Version("0.5"):

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -81,13 +81,19 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("py-breathe", type="build", when="+doc")
     depends_on("py-sphinx", type="build", when="+doc")
 
+    with when("+cuda"):
+        depends_on("thrust")
+    with when("+rocm"):
+        depends_on("rocthrust")
+
     for _std in _cxxstd_values:
         depends_on("geant4 cxxstd=" + _std, when="+geant4 cxxstd=" + _std)
         depends_on("root cxxstd=" + _std, when="+root cxxstd=" + _std)
         depends_on("vecgeom cxxstd=" + _std, when="+vecgeom cxxstd=" + _std)
 
+    depends_on("vecgeom +cuda cuda_arch=none", when="+vecgeom +cuda cuda_arch=none")
     for _arch in CudaPackage.cuda_arch_values:
-        depends_on("vecgeom+cuda cuda_arch=" + _arch, when="+vecgeom +cuda cuda_arch=" + _arch)
+        depends_on(f"vecgeom +cuda cuda_arch={_arch}", when=f"+vecgeom +cuda cuda_arch={_arch}")
 
     conflicts("+rocm", when="+cuda", msg="AMD and NVIDIA accelerators are incompatible")
     conflicts("+rocm", when="+vecgeom", msg="HIP support is only available with ORANGE")

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -135,7 +135,7 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
             args.append(
                 define(
                     "CMAKE_CXX_FLAGS",
-                    f"-I{self.spec['rocprim'].prefix.include} -I{self.spec['rocrand'].prefix.include} -I{self.spec['rocthrust'].prefix.include}",
+                    " ".join([f"-I{self.spec[p].prefix.include}" for p in ["rocprim", "rocrand", "rocthrust"]])
                 )
             )
             args.append(CMakeBuilder.define_hip_architectures(self))

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -131,7 +131,7 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
         if self.spec.satisfies("+cuda"):
             args.append(CMakeBuilder.define_cuda_architectures(self))
         if self.spec.satisfies("+rocm"):
-            args.append(define("CMAKE_CXX_COMPILER", spec['hip'].prefix.bin.hipcc))
+            args.append(define("CMAKE_CXX_COMPILER", spec["hip"].prefix.bin.hipcc))
             args.append(CMakeBuilder.define_hip_architectures(self))
 
         if self.version < Version("0.5"):

--- a/var/spack/repos/builtin/packages/celeritas/package.py
+++ b/var/spack/repos/builtin/packages/celeritas/package.py
@@ -85,6 +85,8 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
     with when("+cuda"):
         depends_on("thrust")
     with when("+rocm"):
+        depends_on("rocprim")
+        depends_on("rocrand")
         depends_on("rocthrust")
 
     for _std in _cxxstd_values:
@@ -129,8 +131,8 @@ class Celeritas(CMakePackage, CudaPackage, ROCmPackage):
         if self.spec.satisfies("+cuda"):
             args.append(CMakeBuilder.define_cuda_architectures(self))
         if self.spec.satisfies("+rocm"):
+            args.append(define("CMAKE_CXX_COMPILER", spec['hip'].prefix.bin.hipcc))
             args.append(CMakeBuilder.define_hip_architectures(self))
-            args.append(define("Thrust_ROOT", self.spec["rocthrust"].prefix))
 
         if self.version < Version("0.5"):
             # JSON is required for 0.5 and later


### PR DESCRIPTION
This PR adds `cuda` and `rocm` builds to the hep stack where possible (`acts`, `celeritas`, `root`, `vecgeom`). Not all packages support `cuda_arch`. Kept the organization as in e4s stack.