### PR TITLE
dcap: depends_on openssl and zlib-api

### DIFF
--- a/var/spack/repos/builtin/packages/dcap/package.py
+++ b/var/spack/repos/builtin/packages/dcap/package.py
@@ -24,6 +24,7 @@ class Dcap(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
 
+    depends_on("openssl")
     depends_on("zlib-api")
 
     variant("plugins", default=True, description="Build plugins")

--- a/var/spack/repos/builtin/packages/dcap/package.py
+++ b/var/spack/repos/builtin/packages/dcap/package.py
@@ -24,6 +24,8 @@ class Dcap(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
 
+    depends_on("zlib-api")
+
     variant("plugins", default=True, description="Build plugins")
 
     def patch(self):


### PR DESCRIPTION
This PR adds to `dcap` the [explicit](https://github.com/dCache/dcap/blob/a1321a6ffba4e0924a21b78ca71ec92d8bc2b21c/configure.ac#L158) [dependencies](https://github.com/dCache/dcap/blob/a1321a6ffba4e0924a21b78ca71ec92d8bc2b21c/configure.ac#L135) on openssl and zlib. This should resolve warnings like https://gitlab.spack.io/spack/spack/-/jobs/14618974/viewer#L281.