### PR TITLE
dpmjet: add v19.3.6, v19.3.7; add to hep stack

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/hep/spack.yaml
@@ -34,6 +34,7 @@ spack:
   - celeritas +geant4 +hepmc3 +openmp +root +shared +vecgeom cxxstd=20
   - dd4hep +ddalign +ddcad +ddcond +dddetectors +dddigi +ddeve +ddg4 +ddrec +edm4hep +hepmc3 +lcio +utilityapps +xercesc
   - delphes +pythia8
+  - dpmjet
   - edm4hep
   - fastjet
   - fjcontrib

--- a/var/spack/repos/builtin/packages/dpmjet/package.py
+++ b/var/spack/repos/builtin/packages/dpmjet/package.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
 from spack.package import *
 
 
@@ -17,21 +16,43 @@ class Dpmjet(MakefilePackage):
 
     maintainers("wdconinc")
 
-    license("BSD-3-Clause")
+    license("BSD-3-Clause AND Pythia6", checked_by="wdconinc")
 
+    version("19.3.7", sha256="4ab22fa9925031a11cf3b82fff73226011da2cf6b2662f10523bc9850f85b8a5")
+    version("19.3.6", sha256="9453f1428eb41d59f0c951a48763b8f386eece39c4a73bdb07e759b2c5fdd4f5")
     version("19.3.5", sha256="5a546ca20f86abaecda1828eb5b577aee8a532dffb2c5e7244667d5f25777909")
     version("19.3.4", sha256="646f520aa67ef6355c45cde155a5dd55f7c9d661314358a7668f6ff472f5d5f9")
     version("19.3.3", sha256="4f449a36b48ff551beb4303d66bac18bebc52dbcac907f84ab7716c914ad6d8a")
     version("19.2.0", sha256="0f5c1af4419e1a8fa4b46cc24ae1da98abe5c119064275e1848538fe033f02cc")
     version("19.1.3", sha256="f2f7f9eee0fcd1e2770382fa6e3491418607e33de2272e04b6d75ebc97640474")
 
-    depends_on("python@3:")
+    depends_on("fortran", type="build")
+
+    depends_on("python@3:", when="@:19.3.5")
+
+    build_targets = ["exe"]
 
     def edit(self, spec, prefix):
-        makefile = FileFilter("Makefile")
-        makefile.filter(r"install: \$\(pylib\)", "install:")
+        # The spack prefix paths needed to point to the data files are too long
+        # and need to be wrapped at the maximum column for f77 source files.
+        columns = 72
+        datadir = str(join_path(prefix, "share/dpmjet/dpmdata", ""))
+        datini = FileFilter("src/phojet/PHO_DATINI.f")
+        continuation = "\n     &"
+        old = "^        DATDir = 'dpmdata/'"
+        new = f"        DATDir = '{datadir}'"
+        new_wrapped = [new[i:i+columns] for i in range(0, len(new), columns)]
+        datini.filter(old, continuation.join(new_wrapped))
+        datini.filter("LENDir = 8", f"LENDir = {len(datadir)}")
+
+        # The python components were extracted in later versions
+        if spec.satisfies("@:19.3.5"):
+            makefile = FileFilter("Makefile")
+            makefile.filter(r"install: \$\(pylib\)", "install:")
 
     def install(self, spec, prefix):
         install_tree("bin", prefix.bin)
         install_tree("lib", prefix.lib)
         install_tree("include", prefix.include)
+        install_tree("dpmdata", prefix.share.dpmjet.dpmdata)
+        install_tree("examples", prefix.share.dpmjet.examples)

--- a/var/spack/repos/builtin/packages/dpmjet/package.py
+++ b/var/spack/repos/builtin/packages/dpmjet/package.py
@@ -41,7 +41,7 @@ class Dpmjet(MakefilePackage):
         continuation = "\n     &"
         old = "^        DATDir = 'dpmdata/'"
         new = f"        DATDir = '{datadir}'"
-        new_wrapped = [new[i:i+columns] for i in range(0, len(new), columns)]
+        new_wrapped = [new[i : i + columns] for i in range(0, len(new), columns)]
         datini.filter(old, continuation.join(new_wrapped))
         datini.filter("LENDir = 8", f"LENDir = {len(datadir)}")
 


### PR DESCRIPTION
This PR adds `dpmjet`, v19.3.6 and v19.3.7. It also fixes the installation so it can be run from anywhere, instead of forcing to be run from a path where the datafiles are in relative path `dpmdata/`. That required some line reflowing and continuation due to the long spack prefix directories.

This PR adds `dpmjet` to the hep stack (no dependencies and quick build).

Test build:
```
==> Installing dpmjet-19.3.7-6rmx4feilb5ufocrgvwrvswy4pcedirk [26/26]
==> No binary for dpmjet-19.3.7-6rmx4feilb5ufocrgvwrvswy4pcedirk found: installing from source
==> Using cached archive: /opt/spack/cache/_source-cache/archive/4a/4ab22fa9925031a11cf3b82fff73226011da2cf6b2662f10523bc9850f85b8a5.zip
==> No patches needed for dpmjet
==> dpmjet: Executing phase: 'edit'
==> dpmjet: Executing phase: 'build'
==> dpmjet: Executing phase: 'install'
==> dpmjet: Successfully installed dpmjet-19.3.7-6rmx4feilb5ufocrgvwrvswy4pcedirk
  Stage: 0.36s.  Edit: 0.01s.  Build: 1m 10.65s.  Install: 0.09s.  Post-install: 0.48s.  Total: 1m 11.81s
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/dpmjet-19.3.7-6rmx4feilb5ufocrgvwrvswy4pcedirk
```

Test run:
```
$ DPMJET < $(spack location -i dpmjet)/share/dpmjet/examples/dpmjet/ppLHC.inp
...

     process (accepted,x-section internal/external) for IP:  2
   0 sum over processes           156          38    3.098E+01    0.000E+00
   1 G  +G  --> G  +G             123          24    1.957E+01    0.000E+00
   2 Q  +QB --> G  +G               0           0    0.000E+00    0.000E+00
   3 G  +Q  --> G  +Q              28          10    8.152E+00    0.000E+00
   4 G  +G  --> Q  +QB              4           4    3.261E+00    0.000E+00
   5 Q  +QB --> Q  +QB              0           0    0.000E+00    0.000E+00
   6 Q  +QB --> QP +QBP             0           0    0.000E+00    0.000E+00
   7 Q  +Q  --> Q  +Q               1           0    0.000E+00    0.000E+00
   8 Q  +QP --> Q  +QP              0           0    0.000E+00    0.000E+00
   9 resolved processes           156          38    3.098E+01    0.000E+00
  10 gam+Q  --> G  +Q               0           0    0.000E+00    0.000E+00
  11 gam+G  --> Q  +QB              0           0    0.000E+00    0.000E+00
  12 Q  +gam--> G  +Q               0           0    0.000E+00    0.000E+00
  13 G  +gam--> Q  +QB              0           0    0.000E+00    0.000E+00
  14 gam+gam--> Q  +QB              0           0    0.000E+00    0.000E+00
  15 direct processes               0           0    0.000E+00    0.000E+00
  16 gam+gam--> l+ +l-              0           0    0.000E+00    0.000E+00


 ======================================================
    ------- end of event generation summary --------
 ======================================================

```
