### PR TITLE
dbus: add v1.16.0

### DIFF
--- a/var/spack/repos/builtin/packages/dbus/package.py
+++ b/var/spack/repos/builtin/packages/dbus/package.py
@@ -30,13 +30,14 @@ class Dbus(AutotoolsPackage, MesonPackage):
     )
 
     # Note: odd minor versions are unstable, keep last stable version preferred
-    version("1.15.12", sha256="0589c9c707dd593e31f0709caefa5828e69c668c887a7c0d2e5ba445a86bae4d")
-    version("1.15.10", sha256="f700f2f1d0473f11e52f3f3e179f577f31b85419f9ae1972af8c3db0bcfde178")
     version(
-        "1.14.10",
-        sha256="ba1f21d2bd9d339da2d4aa8780c09df32fea87998b73da24f49ab9df1e36a50f",
+        "1.16.0",
+        sha256="9f8ca5eb51cbe09951aec8624b86c292990ae2428b41b856e2bed17ec65c8849",
         preferred=True,
     )
+    version("1.15.12", sha256="0589c9c707dd593e31f0709caefa5828e69c668c887a7c0d2e5ba445a86bae4d")
+    version("1.15.10", sha256="f700f2f1d0473f11e52f3f3e179f577f31b85419f9ae1972af8c3db0bcfde178")
+    version("1.14.10", sha256="ba1f21d2bd9d339da2d4aa8780c09df32fea87998b73da24f49ab9df1e36a50f")
     version("1.13.6", sha256="b533693232d36d608a09f70c15440c1816319bac3055433300d88019166c1ae4")
     version("1.12.8", sha256="e2dc99e7338303393b6663a98320aba6a63421bcdaaf571c8022f815e5896eb3")
     version("1.11.2", sha256="5abc4c57686fa82669ad0039830788f9b03fdc4fff487f0ccf6c9d56ba2645c9")

--- a/var/spack/repos/builtin/packages/dbus/package.py
+++ b/var/spack/repos/builtin/packages/dbus/package.py
@@ -30,11 +30,7 @@ class Dbus(AutotoolsPackage, MesonPackage):
     )
 
     # Note: odd minor versions are unstable, keep last stable version preferred
-    version(
-        "1.16.0",
-        sha256="9f8ca5eb51cbe09951aec8624b86c292990ae2428b41b856e2bed17ec65c8849",
-        preferred=True,
-    )
+    version("1.16.0", sha256="9f8ca5eb51cbe09951aec8624b86c292990ae2428b41b856e2bed17ec65c8849")
     version("1.15.12", sha256="0589c9c707dd593e31f0709caefa5828e69c668c887a7c0d2e5ba445a86bae4d")
     version("1.15.10", sha256="f700f2f1d0473f11e52f3f3e179f577f31b85419f9ae1972af8c3db0bcfde178")
     version("1.14.10", sha256="ba1f21d2bd9d339da2d4aa8780c09df32fea87998b73da24f49ab9df1e36a50f")


### PR DESCRIPTION
This PR adds `dbus`, v1.16.0, the first in a new stable minor series ([release notes](https://gitlab.freedesktop.org/dbus/dbus/-/tags/dbus-1.16.0), [diff](https://gitlab.freedesktop.org/dbus/dbus/-/compare/dbus-1.15.12...dbus-1.16.0)). Only change are to the CMake build system which we do not support in spack (meson is recommended).

Test build:
```
-- linux-ubuntu24.10-skylake / gcc@14.2.0 -----------------------
[+]  xf5vbxq dbus@1.16.0~strip~xml_docs build_system=meson buildtype=release default_library=shared system-socket=default
==> 1 installed package
```