### PR TITLE
lcio: add v2.22.3

### DIFF
--- a/var/spack/repos/builtin/packages/lcio/package.py
+++ b/var/spack/repos/builtin/packages/lcio/package.py
@@ -20,6 +20,7 @@ class Lcio(CMakePackage):
     license("BSD-3-Clause")
 
     version("master", branch="master")
+    version("2.22.3", sha256="5b9715786c5e953f8854881c5d0c4a48030a5491f1701232b82e960ac7980162")
     version("2.22.2", sha256="e5ad9690af85160ef52dd407fc0995451b4293f3aee415a8ea8a950de63d87a1")
     version("2.22.1", sha256="4bc3d2c83af7b1c65d6736dd14ee82f41af7ce9bfc7cfe779c5f47417e8dc326")
     version("2.22", sha256="95676977a0427f5ecc857e8504b13f332c2c2e5769dc00f6beecff3c73dab395")


### PR DESCRIPTION
This PR adds `lcio`, v2.22.3 ([diff](https://github.com/iLCSoft/LCIO/compare/v02-22-02...v02-22-03)). Fixes macos build (no macos system to test that).