### PR TITLE
acts: conflict ~svg ~json when +traccc

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -424,6 +424,10 @@ class Acts(CMakePackage, CudaPackage):
         for _scalar in _scalar_values:
             depends_on(f"detray scalar={_scalar}", when=f"scalar={_scalar}")
 
+    # ACTS enables certain options anyway based on other options
+    conflicts("~svg", when="+traccc")
+    conflicts("~json", when="+traccc")
+
     # ACTS has been using C++17 for a while, which precludes use of old GCC
     conflicts("%gcc@:7", when="@0.23:")
     # When using C++20, disable gcc 9 and lower.


### PR DESCRIPTION
This PR ensures that `acts` enables `+svg` and `+json` when `+traccc` since the [CMakeLists.txt](https://github.com/acts-project/acts/blob/v38.2.0/CMakeLists.txt#L165-L172) does that for us behind the scenes and we need to make sure dependencies are available.