### PR TITLE
add undeclared gmake dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/bwa/package.py
+++ b/var/spack/repos/builtin/packages/bwa/package.py
@@ -25,7 +25,7 @@ class Bwa(Package):
     )
 
     depends_on("c", type="build")  # generated
-
+    depends_on("gmake", type="build")
     depends_on("zlib-api")
     depends_on("sse2neon", when="target=aarch64:")
 

--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -62,6 +62,7 @@ class EnvironmentModules(Package):
 
     variant("X", default=True, description="Build with X functionality")
 
+    depends_on("gmake", type="build")
     depends_on("util-linux", type=("build", "run"), when="@5.5:")
     depends_on("less", type=("build", "run"), when="@4.1:")
     with when("@main"):

--- a/var/spack/repos/builtin/packages/gasnet/package.py
+++ b/var/spack/repos/builtin/packages/gasnet/package.py
@@ -72,11 +72,12 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
         deprecated=True,
         sha256="117f5fdb16e53d0fa8a47a1e28cccab1d8020ed4f6e50163d985dc90226aaa2c",
     )
+    # Do NOT add older versions here.
+    # GASNet-EX releases over 2 years old are not supported.
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
-    # Do NOT add older versions here.
-    # GASNet-EX releases over 2 years old are not supported.
+    depends_on("gmake", type="build")
 
     # The optional network backends:
     variant(

--- a/var/spack/repos/builtin/packages/ncdu/package.py
+++ b/var/spack/repos/builtin/packages/ncdu/package.py
@@ -33,7 +33,7 @@ class Ncdu(Package):
     version("1.7", sha256="70dfe10b4c0843050ee17ab27b7ad4d65714682f117079b85d779f83431fb333")
 
     depends_on("c", type="build")  # generated
-
+    depends_on("gmake", type="build")
     depends_on("ncurses")
     depends_on("pkgconfig", type="build")
 

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -51,6 +51,7 @@ class QuantumEspresso(CMakePackage, Package):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
+    depends_on("gmake", type="build")
 
     resource(
         name="environ",

--- a/var/spack/repos/builtin/packages/samtools/package.py
+++ b/var/spack/repos/builtin/packages/samtools/package.py
@@ -46,6 +46,7 @@ class Samtools(Package):
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
 
+    depends_on("gmake", type="build")
     depends_on("zlib-api")
     depends_on("ncurses")
     depends_on("perl", type="run")

--- a/var/spack/repos/builtin/packages/seqtk/package.py
+++ b/var/spack/repos/builtin/packages/seqtk/package.py
@@ -19,7 +19,7 @@ class Seqtk(Package):
     version("1.1", sha256="f01b9f9af6e443673a0105a7536a01957a4fc371826385a1f3dd1e417aa91d52")
 
     depends_on("c", type="build")  # generated
-
+    depends_on("gmake", type="build")
     depends_on("zlib-api")
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -100,7 +100,6 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
     )
     # Do NOT add older versions here.
     # UPC++ releases over 2 years old are not supported.
-    
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("gmake", type="build")

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -98,11 +98,12 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
         deprecated=True,
         sha256="01be35bef4c0cfd24e9b3d50c88866521b9cac3ad4cbb5b1fc97aea55078810f",
     )
-
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
     # Do NOT add older versions here.
     # UPC++ releases over 2 years old are not supported.
+    
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("gmake", type="build")
 
     patch("fix_configure_ldflags.patch", when="@2021.9.0:master")
 


### PR DESCRIPTION
Undeclared gmake dependencies [are now fatal](https://github.com/spack/spack/commit/8ab6f33eb64bf3442fa79dc803ffd67b93165a65). See e.g. https://gitlab.spack.io/spack/spack/-/jobs/14635743#L455.