### PR TITLE
py-asdf: depends_on py-setuptools-scm@8:

### DIFF
--- a/var/spack/repos/builtin/packages/py-asdf/package.py
+++ b/var/spack/repos/builtin/packages/py-asdf/package.py
@@ -28,6 +28,8 @@ class PyAsdf(PythonPackage):
     with when("@3.5.0:"):
         depends_on("python@3.9:", type=("build", "run"))
 
+        depends_on("py-setuptools-scm@8: +toml", type="build")  # for version_file
+
         depends_on("py-asdf-standard@1.1.0:", type=("build", "run"))
         depends_on("py-importlib-metadata@4.11.4:", type=("build", "run"), when="^python@:3.11")
         depends_on("py-numpy@1.22:", type=("build", "run"))


### PR DESCRIPTION
This PR adds to `py-asdf` a stricter requirement on `py-setuptools-scm@8:`, since the project [switched](https://github.com/asdf-format/asdf/commit/9f4703407b96bdb58cb094d378dccfe42a308e27) to use `version_file` in `pyproject`, a feature only [available](https://github.com/pypa/setuptools-scm/blob/v8.0.4/CHANGELOG.md?plain=1#L62) as of v8.0.0.