### PR TITLE
thrift: depends_on gmake

### DIFF
--- a/var/spack/repos/builtin/packages/thrift/package.py
+++ b/var/spack/repos/builtin/packages/thrift/package.py
@@ -42,6 +42,7 @@ class Thrift(Package):
     variant("java", default=False, description="Build support for java")
     variant("python", default=True, description="Build support for python")
 
+    depends_on("gmake", type="build")
     depends_on("pkgconfig", type="build")
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")


### PR DESCRIPTION
This PR adds to `thrift` the build dependency on `gmake`.