### PR TITLE
Set CMake policy CMP0074 to the new behaviour in hip package

### DIFF
--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -600,6 +600,8 @@ class Hip(CMakePackage):
             # Use the new behaviour of the policy CMP0074
             # (https://cmake.org/cmake/help/latest/policy/CMP0074.html) which will search
             # "prefixes specified by the <PackageName>_ROOT CMake variable".
+            # From HIP 6.2 onwards the policy is set explicitly by HIP itself:
+            # https://github.com/ROCm/clr/commit/a2a8dad980b0fa1a6086e0c0f95847ae80f5a2c6.
             self.define("CMAKE_POLICY_DEFAULT_CMP0074", "NEW"),
         ]
         if self.spec.satisfies("+rocm"):

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -597,6 +597,10 @@ class Hip(CMakePackage):
             # should find llvm-amdgpu
             self.define("LLVM_ROOT", self.spec["llvm-amdgpu"].prefix),
             self.define("Clang_ROOT", self.spec["llvm-amdgpu"].prefix),
+            # Use the new behaviour of the policy CMP0074
+            # (https://cmake.org/cmake/help/latest/policy/CMP0074.html) which will search
+            # "prefixes specified by the <PackageName>_ROOT CMake variable".
+            self.define("CMAKE_POLICY_DEFAULT_CMP0074", "NEW"),
         ]
         if self.spec.satisfies("+rocm"):
             args.append(self.define("HSA_PATH", self.spec["hsa-rocr-dev"].prefix))


### PR DESCRIPTION
This makes sure CMake actually picks up the `Clang_ROOT` set in https://github.com/spack/spack/pull/47788.

After #47788 was merged builds of `hip` started failing with this during CMake configuration:
```
CMake Error at hipamd/src/hiprtc/CMakeLists.txt:126 (find_package):
  Found package configuration file:

    /opt/spack-04c76fab632817665395ee571038368aa2e297a0/opt/spack/linux-ubuntu24.04-zen3/gcc-12.4.0/llvm-amdgpu-6.1.0-7t373pojivbaali42pml7nhzrwh5yfks/lib/cmake/clang/C
langConfig.cmake

  but it set Clang_FOUND to FALSE so package "Clang" is considered to be NOT
  FOUND.  Reason given by package:

  The following imported targets are referenced, but are missing:
  LLVMHipStdPar
```

If useful I can also provide a reproducer for the failure before this PR. Curiously if I manually enter a `hip` build-env it fails identically the first time, but if I rerun the exact CMake command a second time the CMake configuration is successful... I suppose CMake managed to find and cache enough hints during the first run to make it find Clang on the second run.

With this PR CMake will actually consider the `Clang_ROOT` variable set during configuration and `hip` builds successfully.

I see there are some CMake policies already set by default to their new behaviour in https://github.com/spack/spack/blob/e42c76cccf9a98736b90c1831aefb5e2d8cdcb0c/lib/spack/spack/build_systems/cmake.py#L99, but I wasn't sure if this policy warrants the same behaviour. Slightly worried about having all the stacks break, so I've opted to keep the change local in this case.