### PR TITLE
ICON: Fix missing ocean variant logic handling

### DIFF
--- a/var/spack/repos/builtin/packages/icon/package.py
+++ b/var/spack/repos/builtin/packages/icon/package.py
@@ -129,6 +129,7 @@ class Icon(AutotoolsPackage):
             "atmo",
             "les",
             "upatmo",
+            "ocean",
             "jsbach",
             "waves",
             "aes",


### PR DESCRIPTION
Looks like this got missed out from the list, leading to it being always enabled and built regardless of the variant setting.