### PR TITLE
flatbuffers: add v24.12.23

### DIFF
--- a/var/spack/repos/builtin/packages/flatbuffers/package.py
+++ b/var/spack/repos/builtin/packages/flatbuffers/package.py
@@ -14,6 +14,7 @@ class Flatbuffers(CMakePackage):
 
     license("Apache-2.0")
 
+    version("24.12.23", sha256="7e2ef35f1af9e2aa0c6a7d0a09298c2cb86caf3d4f58c0658b306256e5bcab10") 
     version("24.3.25", sha256="4157c5cacdb59737c5d627e47ac26b140e9ee28b1102f812b36068aab728c1ed")
     version("24.3.7", sha256="bfff9d2150fcff88f844e8c608b02b2a0e94c92aea39b04c0624783464304784")
     version("2.0.6", sha256="e2dc24985a85b278dd06313481a9ca051d048f9474e0f199e372fea3ea4248c9")

--- a/var/spack/repos/builtin/packages/flatbuffers/package.py
+++ b/var/spack/repos/builtin/packages/flatbuffers/package.py
@@ -14,7 +14,7 @@ class Flatbuffers(CMakePackage):
 
     license("Apache-2.0")
 
-    version("24.12.23", sha256="7e2ef35f1af9e2aa0c6a7d0a09298c2cb86caf3d4f58c0658b306256e5bcab10") 
+    version("24.12.23", sha256="7e2ef35f1af9e2aa0c6a7d0a09298c2cb86caf3d4f58c0658b306256e5bcab10")
     version("24.3.25", sha256="4157c5cacdb59737c5d627e47ac26b140e9ee28b1102f812b36068aab728c1ed")
     version("24.3.7", sha256="bfff9d2150fcff88f844e8c608b02b2a0e94c92aea39b04c0624783464304784")
     version("2.0.6", sha256="e2dc24985a85b278dd06313481a9ca051d048f9474e0f199e372fea3ea4248c9")


### PR DESCRIPTION
This PR adds `flatbuffers`, v24.12.23 ([diff](https://github.com/google/flatbuffers/compare/v24.3.25...v24.12.23)), which doesn't require any changes to the CMake build.

Test build:
```
[+] /opt/software/linux-ubuntu24.10-skylake/gcc-14.2.0/py-flatbuffers-24.12.23-ljreaywvpeswtxbjoiinxim2fmbu7bpm
```