### PR TITLE
hpctoolkit: Add `+docs` variant and manpages

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -118,6 +118,12 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
         when="build_system=autotools",
     )
     variant("viewer", default=True, description="Include hpcviewer.")
+    variant(
+        "docs",
+        default=False,
+        description="Include extra documentation (user's manual)",
+        when="@develop",
+    )
 
     variant(
         "python", default=False, description="Support unwinding Python source.", when="@2023.03:"
@@ -184,6 +190,10 @@ class Hpctoolkit(AutotoolsPackage, MesonPackage):
 
     depends_on("zlib-api")
     depends_on("zlib+shared", when="^[virtuals=zlib-api] zlib")
+
+    depends_on("py-docutils", type="build", when="@develop")
+    depends_on("py-sphinx", type="build", when="+docs")
+    depends_on("py-myst-parser@0.19:", type="build", when="+docs")
 
     depends_on("cuda", when="+cuda")
     depends_on("oneapi-level-zero", when="+level_zero")
@@ -402,6 +412,8 @@ class MesonBuilder(spack.build_systems.meson.MesonBuilder):
         spec = self.spec
 
         args = [
+            "-Dmanpages=enabled",
+            "-Dmanual=" + ("enabled" if spec.satisfies("+docs") else "disabled"),
             "-Dhpcprof_mpi=" + ("enabled" if spec.satisfies("+mpi") else "disabled"),
             "-Dpython=" + ("enabled" if spec.satisfies("+python") else "disabled"),
             "-Dpapi=" + ("enabled" if spec.satisfies("+papi") else "disabled"),

--- a/var/spack/repos/builtin/packages/py-mdit-py-plugins/package.py
+++ b/var/spack/repos/builtin/packages/py-mdit-py-plugins/package.py
@@ -11,17 +11,27 @@ class PyMditPyPlugins(PythonPackage):
 
     homepage = "https://github.com/executablebooks/mdit-py-plugins/"
     git = "https://github.com/executablebooks/mdit-py-plugins/"
-    pypi = "mdit-py-plugins/mdit-py-plugins-0.3.1.tar.gz"
+    pypi = "mdit-py-plugins/mdit_py_plugins-0.4.2.tar.gz"
 
     license("MIT")
 
+    version("0.4.2", sha256="5f2cd1fdb606ddf152d37ec30e46101a60512bc0e5fa1a7002c36647b09e26b5")
+    version("0.3.5", sha256="eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a")
     version("0.3.1", sha256="3fc13298497d6e04fe96efdd41281bfe7622152f9caa1815ea99b5c893de9441")
     version("0.2.8", sha256="5991cef645502e80a5388ec4fc20885d2313d4871e8b8e320ca2de14ac0c015f")
 
-    depends_on("py-flit-core@3.4:3", when="@0.3.1", type=("build", "run"))
-    depends_on("python@3.7:", when="@0.3.1", type=("build", "run"))
-    depends_on("py-markdown-it-py@1.0:2", when="@0.3.1", type=("build", "run"))
+    def url_for_version(self, version):
+        prefix = self.url.rsplit("/", maxsplit=1)[0]
+        package = "mdit-py-plugins" if version < Version("2.0.0") else "mdit_py_plugins"
+        return f"{prefix}/{package}-{version}.tar.gz"
+
+    depends_on("python@3.6:3", when="@:0.2", type=("build", "run"))
+    depends_on("python@3.7:3", when="@0.3", type=("build", "run"))
+    depends_on("python@3.8:3", when="@0.4:", type=("build", "run"))
 
     depends_on("py-setuptools", when="@:0.2", type="build")
-    depends_on("py-markdown-it-py@1.0:1", when="@0.2.8", type=("build", "run"))
-    depends_on("python@3.6:3", when="@0.2.8", type=("build", "run"))
+    depends_on("py-flit-core@3.4:3", when="@0.3:", type="build")
+
+    depends_on("py-markdown-it-py@1.0:1", when="@:0.2", type=("build", "run"))
+    depends_on("py-markdown-it-py@1.0:2", when="@0.3", type=("build", "run"))
+    depends_on("py-markdown-it-py@1.0:3", when="@0.4:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-myst-parser/package.py
+++ b/var/spack/repos/builtin/packages/py-myst-parser/package.py
@@ -11,18 +11,51 @@ class PyMystParser(PythonPackage):
     scientific documentation."""
 
     homepage = "https://github.com/executablebooks/MyST-Parser"
-    pypi = "myst-parser/myst-parser-0.18.1.tar.gz"
+    git = "https://github.com/executablebooks/MyST-Parser"
+    pypi = "myst-parser/myst_parser-4.0.0.tar.gz"
 
     license("MIT")
 
+    version("4.0.0", sha256="851c9dfb44e36e56d15d05e72f02b80da21a9e0d07cba96baf5e2d476bb91531")
+    version("3.0.1", sha256="88f0cb406cb363b077d176b51c476f62d60604d68a8dcdf4832e080441301a87")
+    version("3.0.0", sha256="0b4ae0b33a45800a748260cb40348c37089a8a456c35120609240bd1b32f9255")
+    version("2.0.0", sha256="ea929a67a6a0b1683cdbe19b8d2e724cd7643f8aa3e7bb18dd65beac3483bead")
+    version("1.0.0", sha256="502845659313099542bd38a2ae62f01360e7dd4b1310f025dd014dfc0439cdae")
+    version("0.19.1", sha256="f2dc168ed380e01d77973ad22a64fff1377cc72a3d1ac4bced423f28258d0a42")
+    version("0.19.0", sha256="5a278c02015ce89f282dfde2a6e43d0924d957ab57d83555fce1645448810577")
     version("0.18.1", sha256="79317f4bb2c13053dd6e64f9da1ba1da6cd9c40c8a430c447a7b146a594c246d")
 
+    def url_for_version(self, version):
+        prefix = self.url.rsplit("/", maxsplit=1)[0]
+        package = "myst-parser" if version < Version("2.0.0") else "myst_parser"
+        return f"{prefix}/{package}-{version}.tar.gz"
+
     depends_on("python@3.7:", type=("build", "run"))
+    depends_on("python@3.8:3", type=("build", "run"), when="@2:")
+    depends_on("python@3.10:3", type=("build", "run"), when="@4:")
+
     depends_on("py-flit-core@3.4:3", type="build")
-    depends_on("py-docutils@0.15:0.19", type=("build", "run"))
+
+    depends_on("py-docutils@0.15:0.19", type=("build", "run"), when="@:1")
+    depends_on("py-docutils@0.16:0.20", type=("build", "run"), when="@2:")
+    depends_on("py-docutils@0.18:0.21", type=("build", "run"), when="@3:")
+    depends_on("py-docutils@0.19:0.21", type=("build", "run"), when="@4:")
+
     depends_on("py-jinja2", type=("build", "run"))  # let sphinx decide version
-    depends_on("py-markdown-it-py@1.0.0:2", type=("build", "run"))
-    depends_on("py-mdit-py-plugins@0.3.1:0.3", type=("build", "run"))
+
+    depends_on("py-markdown-it-py@1:2", type=("build", "run"), when="@:1")
+    depends_on("py-markdown-it-py@3", type=("build", "run"), when="@2:")
+
+    depends_on("py-mdit-py-plugins@0.3.1:0.3", type=("build", "run"), when="@0.18")
+    depends_on("py-mdit-py-plugins@0.3.4:0.3", type=("build", "run"), when="@0.19:1")
+    depends_on("py-mdit-py-plugins@0.4", type=("build", "run"), when="@2:3")
+    depends_on("py-mdit-py-plugins@0.4.1:0.4", type=("build", "run"), when="@4:")
+
     depends_on("py-pyyaml", type=("build", "run"))
-    depends_on("py-sphinx@4.0.0:5", type=("build", "run"))
-    depends_on("py-typing-extensions", type=("build", "run"))
+
+    depends_on("py-sphinx@4:5", type=("build", "run"), when="@0.18")
+    depends_on("py-sphinx@5:6", type=("build", "run"), when="@0.19:1")
+    depends_on("py-sphinx@6:7", type=("build", "run"), when="@2:3")
+    depends_on("py-sphinx@7:8", type=("build", "run"), when="@4:")
+
+    depends_on("py-typing-extensions", type=("build", "run"), when="@:1")


### PR DESCRIPTION
HPCToolkit `@develop` requires new dependencies to build its documentation bits, this PR fixes the recipe to include these dependencies. Specifically, man pages for the HPCToolkit tools are now unconditionally installed (needs `py-docutils`), and a new `+docs` variant enables the installation of the user's manual (needs `py-sphinx` and `py-myst-parser`). These correspond respectively to the `-Dmanpages` and `-Dmanual` Meson arguments.

New versions of `py-myst-parser` and `py-mdit-py-plugins` are also included here, the versions available are not new enough to support HPCToolkit's manual build. The dependencies for these new versions are derived from the `pyproject.toml` for these projects at the new versions.

This PR fixes `hpctoolkit@develop` build errors when `sphinx-build` is present on the `PATH` but `myst_parser` is not installed.

Maintainer: @mwkrentel 