### PR TITLE
slirp4netns: add v1.2.3, v1.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/slirp4netns/package.py
+++ b/var/spack/repos/builtin/packages/slirp4netns/package.py
@@ -14,6 +14,8 @@ class Slirp4netns(AutotoolsPackage):
 
     license("GPL-2.0-or-later")
 
+    version("1.3.1", sha256="a3b7c7b593b279c46d25a48b583371ab762968e98b6a46457d8d52a755852eb9")
+    version("1.2.3", sha256="acce648fab8fe5f113c41a8fd6d20177708519b4ddaa60f845e1998a17b22ca5")
     version("1.2.0", sha256="b584edde686d3cfbac210cbdb93c4b0ba5d8cc0a6a4d92b9dfc3c5baec99c727")
     version("1.1.12", sha256="279dfe58a61b9d769f620b6c0552edd93daba75d7761f7c3742ec4d26aaa2962")
 


### PR DESCRIPTION
Builds on Ubuntu 22.04.
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
