### PR TITLE
archive.py: fix include_parent_directories=True with path_to_name

### DIFF
--- a/lib/spack/spack/util/archive.py
+++ b/lib/spack/spack/util/archive.py
@@ -172,10 +172,10 @@ def reproducible_tarfile_from_prefix(
     hardlink_to_tarinfo_name: Dict[Tuple[int, int], str] = dict()
 
     if include_parent_directories:
-        parent_dirs = reversed(pathlib.Path(prefix).parents)
+        parent_dirs = reversed(pathlib.PurePosixPath(path_to_name(prefix)).parents)
         next(parent_dirs)  # skip the root: slices are supported from python 3.10
         for parent_dir in parent_dirs:
-            dir_info = tarfile.TarInfo(path_to_name(str(parent_dir)))
+            dir_info = tarfile.TarInfo(str(parent_dir))
             dir_info.type = tarfile.DIRTYPE
             dir_info.mode = 0o755
             tar.addfile(dir_info)


### PR DESCRIPTION
The parent dirs should be those of the prefix transformed under `path_to_name`.

Currently unused, but will as tarballs are relocated ahead of time.
