### PR TITLE
Fix opensuse python build

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -684,6 +684,7 @@ class Python(Package):
             else:
                 options = getattr(self, "configure_flag_args", [])
                 options += ["--prefix={0}".format(prefix)]
+                options += ["--libdir={0}".format(prefix.lib)]
                 options += self.configure_args()
                 configure(*options)
 


### PR DESCRIPTION
Install python-venv in opensuse leads to this error:

```
==> python-venv: Executing phase: 'install'
==> [2025-01-14-22:11:14.544240] '/home/vicente/Projects/spack/spack/opt/spack/linux-opensuse15-skylake/gcc-13.3.0/python-3.13.0-vwfioycy3ssvuwlpd566ntrk4wkupocb/bin/python3' '-m' 'venv' '--without-pip' '/home/vicente/Projects/spack/spack/opt/spack/linux-opensuse15-skylake/gcc-13.3.0/python-venv-1.0-ockax24mkrbksjtbz5f3ty3tzisovdmx'
Could not find platform dependent libraries <exec_prefix>
Traceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
  File "<frozen runpy>", line 148, in _get_module_details
  File "<frozen runpy>", line 112, in _get_module_details
  File "/home/vicente/Projects/spack/spack/opt/spack/linux-opensuse15-skylake/gcc-13.3.0/python-3.13.0-vwfioycy3ssvuwlpd566ntrk4wkupocb/lib/python3.13/venv/__init__.py", line 10, in <module>
    import subprocess
  File "/home/vicente/Projects/spack/spack/opt/spack/linux-opensuse15-skylake/gcc-13.3.0/python-3.13.0-vwfioycy3ssvuwlpd566ntrk4wkupocb/lib/python3.13/subprocess.py", line 106, in <module>
    from _posixsubprocess import fork_exec as _fork_exec
ModuleNotFoundError: No module named '_posixsubprocess'
```

The reason of this is that some of Python libraries are installed in `python.prefix.lib` and others in `python.prefix.lib64`. The reason of this is that OpenSUSE and Fedora (AFAIK) expect arch dependent libs to be installed in `lib64`, for this reason it setup tools such as `autoconf` to default arch dependent libraries to `lib64`.

The workaround here is to force all Python libraries to be at `lib` which is where Python packages expect them.

After applying this change the build runs without any issue

Closes #37171
Closes #39551