### PR TITLE
flag_mixing.py: add missing import

### DIFF
--- a/lib/spack/spack/test/concretization/flag_mixing.py
+++ b/lib/spack/spack/test/concretization/flag_mixing.py
@@ -10,6 +10,7 @@ import spack.config
 import spack.environment as ev
 import spack.paths
 import spack.repo
+import spack.spec
 import spack.util.spack_yaml as syaml
 from spack.spec import Spec
 
@@ -101,8 +102,8 @@ def test_pkg_flags_from_compiler_and_none(concretize_scope, mock_packages):
     conf_str = _compiler_cfg_one_entry_with_cflags("-Wall")
     update_concretize_scope(conf_str, "compilers")
 
-    s1 = Spec("cmake%gcc@12.100.100")
-    s2 = Spec("cmake-client^cmake%clang")
+    s1 = spack.spec.Spec("cmake%gcc@12.100.100")
+    s2 = spack.spec.Spec("cmake-client^cmake%clang")
     concrete = dict(spack.concretize.concretize_together([(s1, None), (s2, None)]))
 
     assert concrete[s1].compiler_flags["cflags"] == ["-Wall"]


### PR DESCRIPTION
merge order issue with 2447d16e55d800e6a9cb82a645ab9edfd24f08ac and e7c591a8b87f09ba89bdc37b9f2946b3d7ff3361