### PR TITLE
julia: fix forward compat with curl

### DIFF
--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import glob
 import os
 
 from spack.package import *
@@ -149,7 +150,7 @@ class Julia(MakefilePackage):
         depends_on("llvm@11.0.1")
         depends_on("mbedtls@2.24.0:2.24")
         depends_on("openlibm@0.7.0:0.7", when="+openlibm")
-        depends_on("curl@7.73.0:")
+        depends_on("curl@7.73.0:8.9")  # patch for forward compat with curl@8.10 does not apply
 
     # Patches for llvm
     depends_on("llvm", patches="llvm7-symver-jlprefix.patch", when="@:1.7")
@@ -298,6 +299,26 @@ class Julia(MakefilePackage):
     # which is creating symlinks to those libraries.
     patch("julia-1.10-rm-suite-sparse-cuda-stubs.patch", when="@1.10.0:1.10")
 
+    # Patches needed for curl 8.10 forward compatibility. They cannot be ordinary patches because
+    # they apply to files in embedded tarballs.
+    resource(
+        url="https://github.com/JuliaLang/Downloads.jl/commit/e692e77fb5427bf3c6e81514b323c39a88217eec.patch?full_index=1",
+        sha256="405044654ac2c5ee491c09496901f0538197201f06006c61779a4319045596eb",
+        name="downloads-patch-1",
+        placement="downloads-patch-1",
+        expand=False,
+        when="@1.7:1.11 ^curl@8.10:",
+    )
+
+    resource(
+        url="https://github.com/JuliaLang/Downloads.jl/commit/91a71b9597a5379735404af215035b5f5aa6b4d5.patch?full_index=1",
+        sha256="98e5ba550e957568c31fb2351b1623277a4514a830f2988bf37ebc3fd753d951",
+        name="downloads-jl-patch-2",
+        placement="downloads-patch-2",
+        expand=False,
+        when="@1.7:1.11 ^curl@8.10:",
+    )
+
     def patch(self):
         # The system-libwhich-libblastrampoline.patch causes a rebuild of docs as it
         # touches the main Makefile, so we reset the a/m-time to doc/_build's.
@@ -419,6 +440,19 @@ class Julia(MakefilePackage):
 
         with open("Make.user", "w") as f:
             f.write("\n".join(options) + "\n")
+
+    @run_before("build", when="@1.7:1.11 ^curl@8.10:")
+    def patch_downloads_stdlib(self):
+        # stdlibs are distributed as tarballs, which we need to unpack so we can patch Downloads.jl
+        # making it forward compatible with curl.
+        make("-C", "stdlib")
+
+        downloads_glob = glob.glob("stdlib/Downloads-*")
+        assert len(downloads_glob) == 1, "Expected exactly one stdlib/Downloads-* directory"
+        downloads_dir = downloads_glob[0]
+
+        for patch in sorted(glob.glob("downloads-patch-*/*")):
+            Executable("patch")("-s", "-p1", "-i", patch, "-d", downloads_dir)
 
     # julia's sys/package images are lacking rpaths, but this is fine because julia dlopen's them
     # at which point their dependencies are already loaded. ccalllazyfoo.so is from tests.

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -452,7 +452,7 @@ class Julia(MakefilePackage):
         downloads_dir = downloads_glob[0]
 
         for patch in sorted(glob.glob("downloads-patch-*/*")):
-            Executable("patch")("-s", "-p1", "-i", patch, "-d", downloads_dir)
+            Executable("patch")("-s", "-p1", "-i", os.path.abspath(patch), "-d", downloads_dir)
 
     # julia's sys/package images are lacking rpaths, but this is fine because julia dlopen's them
     # at which point their dependencies are already loaded. ccalllazyfoo.so is from tests.


### PR DESCRIPTION
Downloads.jl needs a patch for newer curl, but is an embedded tarball, so the patch is applied a bit ad-hoc.