### PR TITLE
package.py: expose types of common globals unconditionally

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -106,8 +106,16 @@ from spack.util.filesystem import fix_darwin_install_name
 from spack.variant import any_combination_of, auto_or_any_combination_of, disjoint_sets
 from spack.version import Version, ver
 
-# These are just here for editor support; they will be replaced when the build env
-# is set up.
-make = MakeExecutable("make", jobs=1)
-ninja = MakeExecutable("ninja", jobs=1)
-configure = Executable(join_path(".", "configure"))
+# These are just here for editor support; they may be set when the build env is set up.
+configure: Executable
+make_jobs: int
+make: MakeExecutable
+ninja: MakeExecutable
+python_include: str
+python_platlib: str
+python_purelib: str
+python: Executable
+spack_cc: str
+spack_cxx: str
+spack_f77: str
+spack_fc: str


### PR DESCRIPTION
We're moving towards setting these global conditionally, or maybe towards removing them altogether, but for now packaging is much easier and user friendlier if these magic globals have tab completion and types.