### PR TITLE
improve build system api / signatures

### DIFF
--- a/lib/spack/docs/build_systems/custompackage.rst
+++ b/lib/spack/docs/build_systems/custompackage.rst
@@ -56,13 +56,13 @@ If you look at the ``perl`` package, you'll see:
 
 .. code-block:: python
 
-   phases = ["configure", "build", "install"]
+   phases = ("configure", "build", "install")
 
 Similarly, ``cmake`` defines:
 
 .. code-block:: python
 
-   phases = ["bootstrap", "build", "install"]
+   phases = ("bootstrap", "build", "install")
 
 If we look at the ``cmake`` example, this tells Spack's ``PackageBase``
 class to run the ``bootstrap``, ``build``, and ``install`` functions

--- a/lib/spack/spack/build_systems/aspell_dict.py
+++ b/lib/spack/spack/build_systems/aspell_dict.py
@@ -6,7 +6,9 @@ import os
 import llnl.util.filesystem as fs
 
 import spack.directives
+import spack.spec
 import spack.util.executable
+import spack.util.prefix
 
 from .autotools import AutotoolsBuilder, AutotoolsPackage
 
@@ -17,19 +19,18 @@ class AspellBuilder(AutotoolsBuilder):
     to the Aspell extensions.
     """
 
-    def configure(self, pkg, spec, prefix):
+    def configure(
+        self,
+        pkg: "AspellDictPackage",  # type: ignore[override]
+        spec: spack.spec.Spec,
+        prefix: spack.util.prefix.Prefix,
+    ):
         aspell = spec["aspell"].prefix.bin.aspell
         prezip = spec["aspell"].prefix.bin.prezip
         destdir = prefix
 
-        sh = spack.util.executable.which("sh")
-        sh(
-            "./configure",
-            "--vars",
-            "ASPELL={0}".format(aspell),
-            "PREZIP={0}".format(prezip),
-            "DESTDIR={0}".format(destdir),
-        )
+        sh = spack.util.executable.Executable("/bin/sh")
+        sh("./configure", "--vars", f"ASPELL={aspell}", f"PREZIP={prezip}", f"DESTDIR={destdir}")
 
 
 # Aspell dictionaries install their bits into their prefix.lib

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -534,7 +534,7 @@ To resolve this problem, please try the following:
         return build_dir
 
     @spack.phase_callbacks.run_before("autoreconf")
-    def delete_configure_to_force_update(self) -> None:
+    def _delete_configure_to_force_update(self) -> None:
         if self.force_autoreconf:
             fs.force_remove(self.configure_abs_path)
 
@@ -547,7 +547,7 @@ To resolve this problem, please try the following:
         return _autoreconf_search_path_args(self.spec)
 
     @spack.phase_callbacks.run_after("autoreconf")
-    def set_configure_or_die(self) -> None:
+    def _set_configure_or_die(self) -> None:
         """Ensure the presence of a "configure" script, or raise. If the "configure"
         is found, a module level attribute is set.
 
@@ -571,10 +571,7 @@ To resolve this problem, please try the following:
         return []
 
     def autoreconf(
-        self,
-        pkg: spack.package_base.PackageBase,
-        spec: spack.spec.Spec,
-        prefix: spack.util.prefix.Prefix,
+        self, pkg: AutotoolsPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
     ) -> None:
         """Not needed usually, configure should be already there"""
 
@@ -603,10 +600,7 @@ To resolve this problem, please try the following:
             self.pkg.module.autoreconf(*autoreconf_args)
 
     def configure(
-        self,
-        pkg: spack.package_base.PackageBase,
-        spec: spack.spec.Spec,
-        prefix: spack.util.prefix.Prefix,
+        self, pkg: AutotoolsPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
     ) -> None:
         """Run "configure", with the arguments specified by the builder and an
         appropriately set prefix.
@@ -619,10 +613,7 @@ To resolve this problem, please try the following:
             pkg.module.configure(*options)
 
     def build(
-        self,
-        pkg: spack.package_base.PackageBase,
-        spec: spack.spec.Spec,
-        prefix: spack.util.prefix.Prefix,
+        self, pkg: AutotoolsPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
     ) -> None:
         """Run "make" on the build targets specified by the builder."""
         # See https://autotools.io/automake/silent.html
@@ -632,10 +623,7 @@ To resolve this problem, please try the following:
             pkg.module.make(*params)
 
     def install(
-        self,
-        pkg: spack.package_base.PackageBase,
-        spec: spack.spec.Spec,
-        prefix: spack.util.prefix.Prefix,
+        self, pkg: AutotoolsPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
     ) -> None:
         """Run "make" on the install targets specified by the builder."""
         with fs.working_dir(self.build_directory):
@@ -832,7 +820,7 @@ To resolve this problem, please try the following:
             self.pkg._if_make_target_execute("installcheck")
 
     @spack.phase_callbacks.run_after("install")
-    def remove_libtool_archives(self) -> None:
+    def _remove_libtool_archives(self) -> None:
         """Remove all .la files in prefix sub-folders if the package sets
         ``install_libtool_archives`` to be False.
         """

--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -10,6 +10,8 @@ import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
 import spack.phase_callbacks
+import spack.spec
+import spack.util.prefix
 
 from .cmake import CMakeBuilder, CMakePackage
 
@@ -330,7 +332,9 @@ class CachedCMakeBuilder(CMakeBuilder):
         """This method is to be overwritten by the package"""
         return []
 
-    def initconfig(self, pkg, spec, prefix):
+    def initconfig(
+        self, pkg: "CachedCMakePackage", spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         cache_entries = (
             self.std_initconfig_entries()
             + self.initconfig_compiler_entries()

--- a/lib/spack/spack/build_systems/cargo.py
+++ b/lib/spack/spack/build_systems/cargo.py
@@ -7,6 +7,8 @@ import llnl.util.filesystem as fs
 import spack.builder
 import spack.package_base
 import spack.phase_callbacks
+import spack.spec
+import spack.util.prefix
 from spack.directives import build_system, depends_on
 from spack.multimethod import when
 
@@ -81,12 +83,16 @@ class CargoBuilder(BuilderWithDefaults):
     def setup_build_environment(self, env):
         env.set("CARGO_HOME", self.stage.path)
 
-    def build(self, pkg, spec, prefix):
+    def build(
+        self, pkg: CargoPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Runs ``cargo install`` in the source directory"""
         with fs.working_dir(self.build_directory):
             pkg.module.cargo("install", "--root", "out", "--path", ".", *self.build_args)
 
-    def install(self, pkg, spec, prefix):
+    def install(
+        self, pkg: CargoPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Copy build files into package prefix."""
         with fs.working_dir(self.build_directory):
             fs.install_tree("out", prefix)

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -454,10 +454,7 @@ class CMakeBuilder(BuilderWithDefaults):
         return []
 
     def cmake(
-        self,
-        pkg: spack.package_base.PackageBase,
-        spec: spack.spec.Spec,
-        prefix: spack.util.prefix.Prefix,
+        self, pkg: CMakePackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
     ) -> None:
         """Runs ``cmake`` in the build directory"""
 
@@ -474,10 +471,7 @@ class CMakeBuilder(BuilderWithDefaults):
             pkg.module.cmake(*options)
 
     def build(
-        self,
-        pkg: spack.package_base.PackageBase,
-        spec: spack.spec.Spec,
-        prefix: spack.util.prefix.Prefix,
+        self, pkg: CMakePackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
     ) -> None:
         """Make the build targets"""
         with fs.working_dir(self.build_directory):
@@ -488,10 +482,7 @@ class CMakeBuilder(BuilderWithDefaults):
                 pkg.module.ninja(*self.build_targets)
 
     def install(
-        self,
-        pkg: spack.package_base.PackageBase,
-        spec: spack.spec.Spec,
-        prefix: spack.util.prefix.Prefix,
+        self, pkg: CMakePackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
     ) -> None:
         """Make the install targets"""
         with fs.working_dir(self.build_directory):

--- a/lib/spack/spack/build_systems/generic.py
+++ b/lib/spack/spack/build_systems/generic.py
@@ -7,6 +7,8 @@ import spack.builder
 import spack.directives
 import spack.package_base
 import spack.phase_callbacks
+import spack.spec
+import spack.util.prefix
 
 from ._checks import BuilderWithDefaults, apply_macos_rpath_fixups, execute_install_time_tests
 
@@ -48,3 +50,8 @@ class GenericBuilder(BuilderWithDefaults):
 
     # unconditionally perform any post-install phase tests
     spack.phase_callbacks.run_after("install")(execute_install_time_tests)
+
+    def install(
+        self, pkg: Package, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
+        raise NotImplementedError

--- a/lib/spack/spack/build_systems/go.py
+++ b/lib/spack/spack/build_systems/go.py
@@ -7,6 +7,8 @@ import llnl.util.filesystem as fs
 import spack.builder
 import spack.package_base
 import spack.phase_callbacks
+import spack.spec
+import spack.util.prefix
 from spack.directives import build_system, extends
 from spack.multimethod import when
 
@@ -88,12 +90,16 @@ class GoBuilder(BuilderWithDefaults):
         """Argument for ``go test`` during check phase"""
         return []
 
-    def build(self, pkg, spec, prefix):
+    def build(
+        self, pkg: GoPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Runs ``go build`` in the source directory"""
         with fs.working_dir(self.build_directory):
             pkg.module.go("build", *self.build_args)
 
-    def install(self, pkg, spec, prefix):
+    def install(
+        self, pkg: GoPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Install built binaries into prefix bin."""
         with fs.working_dir(self.build_directory):
             fs.mkdirp(prefix.bin)

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -98,29 +98,20 @@ class MakefileBuilder(BuilderWithDefaults):
         return self.pkg.stage.source_path
 
     def edit(
-        self,
-        pkg: spack.package_base.PackageBase,
-        spec: spack.spec.Spec,
-        prefix: spack.util.prefix.Prefix,
+        self, pkg: MakefilePackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
     ) -> None:
         """Edit the Makefile before calling make. The default is a no-op."""
         pass
 
     def build(
-        self,
-        pkg: spack.package_base.PackageBase,
-        spec: spack.spec.Spec,
-        prefix: spack.util.prefix.Prefix,
+        self, pkg: MakefilePackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
     ) -> None:
         """Run "make" on the build targets specified by the builder."""
         with fs.working_dir(self.build_directory):
             pkg.module.make(*self.build_targets)
 
     def install(
-        self,
-        pkg: spack.package_base.PackageBase,
-        spec: spack.spec.Spec,
-        prefix: spack.util.prefix.Prefix,
+        self, pkg: MakefilePackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
     ) -> None:
         """Run "make" on the install targets specified by the builder."""
         with fs.working_dir(self.build_directory):

--- a/lib/spack/spack/build_systems/maven.py
+++ b/lib/spack/spack/build_systems/maven.py
@@ -5,6 +5,8 @@ import llnl.util.filesystem as fs
 
 import spack.builder
 import spack.package_base
+import spack.spec
+import spack.util.prefix
 from spack.directives import build_system, depends_on
 from spack.multimethod import when
 from spack.util.executable import which
@@ -58,16 +60,20 @@ class MavenBuilder(BuilderWithDefaults):
         """List of args to pass to build phase."""
         return []
 
-    def build(self, pkg, spec, prefix):
+    def build(
+        self, pkg: MavenPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Compile code and package into a JAR file."""
         with fs.working_dir(self.build_directory):
-            mvn = which("mvn")
+            mvn = which("mvn", required=True)
             if self.pkg.run_tests:
                 mvn("verify", *self.build_args())
             else:
                 mvn("package", "-DskipTests", *self.build_args())
 
-    def install(self, pkg, spec, prefix):
+    def install(
+        self, pkg: MavenPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Copy to installation prefix."""
         with fs.working_dir(self.build_directory):
             fs.install_tree(".", prefix)

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -188,10 +188,7 @@ class MesonBuilder(BuilderWithDefaults):
         return []
 
     def meson(
-        self,
-        pkg: spack.package_base.PackageBase,
-        spec: spack.spec.Spec,
-        prefix: spack.util.prefix.Prefix,
+        self, pkg: MesonPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
     ) -> None:
         """Run ``meson`` in the build directory"""
         options = []
@@ -204,10 +201,7 @@ class MesonBuilder(BuilderWithDefaults):
             pkg.module.meson(*options)
 
     def build(
-        self,
-        pkg: spack.package_base.PackageBase,
-        spec: spack.spec.Spec,
-        prefix: spack.util.prefix.Prefix,
+        self, pkg: MesonPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
     ) -> None:
         """Make the build targets"""
         options = ["-v"]
@@ -216,10 +210,7 @@ class MesonBuilder(BuilderWithDefaults):
             pkg.module.ninja(*options)
 
     def install(
-        self,
-        pkg: spack.package_base.PackageBase,
-        spec: spack.spec.Spec,
-        prefix: spack.util.prefix.Prefix,
+        self, pkg: MesonPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
     ) -> None:
         """Make the install targets"""
         with fs.working_dir(self.build_directory):

--- a/lib/spack/spack/build_systems/msbuild.py
+++ b/lib/spack/spack/build_systems/msbuild.py
@@ -7,6 +7,8 @@ import llnl.util.filesystem as fs
 
 import spack.builder
 import spack.package_base
+import spack.spec
+import spack.util.prefix
 from spack.directives import build_system, conflicts
 
 from ._checks import BuilderWithDefaults
@@ -99,7 +101,9 @@ class MSBuildBuilder(BuilderWithDefaults):
         as `msbuild_args` by default."""
         return self.msbuild_args()
 
-    def build(self, pkg, spec, prefix):
+    def build(
+        self, pkg: MSBuildPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Run "msbuild" on the build targets specified by the builder."""
         with fs.working_dir(self.build_directory):
             pkg.module.msbuild(
@@ -108,7 +112,9 @@ class MSBuildBuilder(BuilderWithDefaults):
                 self.define_targets(*self.build_targets),
             )
 
-    def install(self, pkg, spec, prefix):
+    def install(
+        self, pkg: MSBuildPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Run "msbuild" on the install targets specified by the builder.
         This is INSTALL by default"""
         with fs.working_dir(self.build_directory):

--- a/lib/spack/spack/build_systems/nmake.py
+++ b/lib/spack/spack/build_systems/nmake.py
@@ -7,6 +7,8 @@ import llnl.util.filesystem as fs
 
 import spack.builder
 import spack.package_base
+import spack.spec
+import spack.util.prefix
 from spack.directives import build_system, conflicts
 
 from ._checks import BuilderWithDefaults
@@ -123,7 +125,9 @@ class NMakeBuilder(BuilderWithDefaults):
         Individual packages should override to specify NMake args to command line"""
         return []
 
-    def build(self, pkg, spec, prefix):
+    def build(
+        self, pkg: NMakePackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Run "nmake" on the build targets specified by the builder."""
         opts = self.std_nmake_args
         opts += self.nmake_args()
@@ -132,7 +136,9 @@ class NMakeBuilder(BuilderWithDefaults):
         with fs.working_dir(self.build_directory):
             pkg.module.nmake(*opts, *self.build_targets, ignore_quotes=self.ignore_quotes)
 
-    def install(self, pkg, spec, prefix):
+    def install(
+        self, pkg: NMakePackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Run "nmake" on the install targets specified by the builder.
         This is INSTALL by default"""
         opts = self.std_nmake_args

--- a/lib/spack/spack/build_systems/octave.py
+++ b/lib/spack/spack/build_systems/octave.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import spack.builder
 import spack.package_base
+import spack.spec
+import spack.util.prefix
 from spack.directives import build_system, extends
 from spack.multimethod import when
 
@@ -42,7 +44,9 @@ class OctaveBuilder(BuilderWithDefaults):
     #: Names associated with package attributes in the old build-system format
     legacy_attributes = ()
 
-    def install(self, pkg, spec, prefix):
+    def install(
+        self, pkg: OctavePackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Install the package from the archive file"""
         pkg.module.octave(
             "--quiet",

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -10,6 +10,8 @@ from llnl.util.lang import memoized
 import spack.builder
 import spack.package_base
 import spack.phase_callbacks
+import spack.spec
+import spack.util.prefix
 from spack.directives import build_system, depends_on, extends
 from spack.install_test import SkipTest, test_part
 from spack.multimethod import when
@@ -149,7 +151,9 @@ class PerlBuilder(BuilderWithDefaults):
         """
         return []
 
-    def configure(self, pkg, spec, prefix):
+    def configure(
+        self, pkg: PerlPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Run Makefile.PL or Build.PL with arguments consisting of
         an appropriate installation base directory followed by the
         list returned by :py:meth:`~.PerlBuilder.configure_args`.
@@ -173,7 +177,9 @@ class PerlBuilder(BuilderWithDefaults):
             repl = "#!/usr/bin/env perl"
             filter_file(pattern, repl, "Build", backup=False)
 
-    def build(self, pkg, spec, prefix):
+    def build(
+        self, pkg: PerlPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Builds a Perl package."""
         self.build_executable()
 
@@ -184,6 +190,8 @@ class PerlBuilder(BuilderWithDefaults):
         """Runs built-in tests of a Perl package."""
         self.build_executable("test")
 
-    def install(self, pkg, spec, prefix):
+    def install(
+        self, pkg: PerlPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Installs a Perl package."""
         self.build_executable("install")

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -28,6 +28,7 @@ import spack.platforms
 import spack.repo
 import spack.spec
 import spack.store
+import spack.util.prefix
 from spack.directives import build_system, depends_on, extends
 from spack.error import NoHeadersError, NoLibrariesError
 from spack.install_test import test_part

--- a/lib/spack/spack/build_systems/qmake.py
+++ b/lib/spack/spack/build_systems/qmake.py
@@ -6,6 +6,8 @@ from llnl.util.filesystem import working_dir
 import spack.builder
 import spack.package_base
 import spack.phase_callbacks
+import spack.spec
+import spack.util.prefix
 from spack.directives import build_system, depends_on
 
 from ._checks import BuilderWithDefaults, execute_build_time_tests
@@ -62,17 +64,23 @@ class QMakeBuilder(BuilderWithDefaults):
         """List of arguments passed to qmake."""
         return []
 
-    def qmake(self, pkg, spec, prefix):
+    def qmake(
+        self, pkg: QMakePackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Run ``qmake`` to configure the project and generate a Makefile."""
         with working_dir(self.build_directory):
             pkg.module.qmake(*self.qmake_args())
 
-    def build(self, pkg, spec, prefix):
+    def build(
+        self, pkg: QMakePackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Make the build targets"""
         with working_dir(self.build_directory):
             pkg.module.make()
 
-    def install(self, pkg, spec, prefix):
+    def install(
+        self, pkg: QMakePackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Make the install targets"""
         with working_dir(self.build_directory):
             pkg.module.make("install")

--- a/lib/spack/spack/build_systems/ruby.py
+++ b/lib/spack/spack/build_systems/ruby.py
@@ -5,6 +5,8 @@ import glob
 
 import spack.builder
 import spack.package_base
+import spack.spec
+import spack.util.prefix
 from spack.directives import build_system, extends, maintainers
 
 from ._checks import BuilderWithDefaults
@@ -42,7 +44,9 @@ class RubyBuilder(BuilderWithDefaults):
     #: Names associated with package attributes in the old build-system format
     legacy_attributes = ()
 
-    def build(self, pkg, spec, prefix):
+    def build(
+        self, pkg: RubyPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Build a Ruby gem."""
 
         # ruby-rake provides both rake.gemspec and Rakefile, but only
@@ -58,7 +62,9 @@ class RubyBuilder(BuilderWithDefaults):
             # Some Ruby packages only ship `*.gem` files, so nothing to build
             pass
 
-    def install(self, pkg, spec, prefix):
+    def install(
+        self, pkg: RubyPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Install a Ruby gem.
 
         The ruby package sets ``GEM_HOME`` to tell gem where to install to."""

--- a/lib/spack/spack/build_systems/scons.py
+++ b/lib/spack/spack/build_systems/scons.py
@@ -4,6 +4,8 @@
 import spack.builder
 import spack.package_base
 import spack.phase_callbacks
+import spack.spec
+import spack.util.prefix
 from spack.directives import build_system, depends_on
 
 from ._checks import BuilderWithDefaults, execute_build_time_tests
@@ -59,7 +61,9 @@ class SConsBuilder(BuilderWithDefaults):
         """Arguments to pass to build."""
         return []
 
-    def build(self, pkg, spec, prefix):
+    def build(
+        self, pkg: SConsPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Build the package."""
         pkg.module.scons(*self.build_args(spec, prefix))
 
@@ -67,7 +71,9 @@ class SConsBuilder(BuilderWithDefaults):
         """Arguments to pass to install."""
         return []
 
-    def install(self, pkg, spec, prefix):
+    def install(
+        self, pkg: SConsPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Install the package."""
         pkg.module.scons("install", *self.install_args(spec, prefix))
 

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -11,6 +11,8 @@ import spack.builder
 import spack.install_test
 import spack.package_base
 import spack.phase_callbacks
+import spack.spec
+import spack.util.prefix
 from spack.directives import build_system, depends_on, extends
 from spack.multimethod import when
 from spack.util.executable import Executable
@@ -130,7 +132,9 @@ class SIPBuilder(BuilderWithDefaults):
 
     build_directory = "build"
 
-    def configure(self, pkg, spec, prefix):
+    def configure(
+        self, pkg: SIPPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Configure the package."""
 
         # https://www.riverbankcomputing.com/static/Docs/sip/command_line_tools.html
@@ -148,7 +152,9 @@ class SIPBuilder(BuilderWithDefaults):
         """Arguments to pass to configure."""
         return []
 
-    def build(self, pkg, spec, prefix):
+    def build(
+        self, pkg: SIPPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Build the package."""
         args = self.build_args()
 
@@ -159,7 +165,9 @@ class SIPBuilder(BuilderWithDefaults):
         """Arguments to pass to build."""
         return []
 
-    def install(self, pkg, spec, prefix):
+    def install(
+        self, pkg: SIPPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Install the package."""
         args = self.install_args()
 

--- a/lib/spack/spack/build_systems/waf.py
+++ b/lib/spack/spack/build_systems/waf.py
@@ -6,6 +6,8 @@ from llnl.util.filesystem import working_dir
 import spack.builder
 import spack.package_base
 import spack.phase_callbacks
+import spack.spec
+import spack.util.prefix
 from spack.directives import build_system, depends_on
 
 from ._checks import BuilderWithDefaults, execute_build_time_tests, execute_install_time_tests
@@ -97,7 +99,9 @@ class WafBuilder(BuilderWithDefaults):
         with working_dir(self.build_directory):
             self.python("waf", "-j{0}".format(jobs), *args, **kwargs)
 
-    def configure(self, pkg, spec, prefix):
+    def configure(
+        self, pkg: WafPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Configures the project."""
         args = ["--prefix={0}".format(self.pkg.prefix)]
         args += self.configure_args()
@@ -108,7 +112,9 @@ class WafBuilder(BuilderWithDefaults):
         """Arguments to pass to configure."""
         return []
 
-    def build(self, pkg, spec, prefix):
+    def build(
+        self, pkg: WafPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Executes the build."""
         args = self.build_args()
 
@@ -118,7 +124,9 @@ class WafBuilder(BuilderWithDefaults):
         """Arguments to pass to build."""
         return []
 
-    def install(self, pkg, spec, prefix):
+    def install(
+        self, pkg: WafPackage, spec: spack.spec.Spec, prefix: spack.util.prefix.Prefix
+    ) -> None:
         """Installs the targets on the system."""
         args = self.install_args()
 


### PR DESCRIPTION
Edit: changed this PR to smth trivial: it only improves the signatures for builders. As a follow-up, for package classes themselves we could add `.pyi` files so we don't have to actually add an implementation to the Package class.

---

After introduction of builders, the packaging API got rather bad and ugly due to removal of phase functions in the package class. That's unfortunate cause the number of packages using dedicated builder classes is very limited (~1.3%) 

This is an initial PR in a series meant to add type hints back so packages get tab completion through the language server, without having to add type hints themselves. If users have to add type hints themselves, they will end up importing `spack.util.prefix` and depend on internal API.

the goal would to get

![image](https://github.com/user-attachments/assets/eb9a181e-7681-4ec6-b3f0-b28341a3f9b5)


whereas now it is 

![image](https://github.com/user-attachments/assets/8482e837-16c7-410f-9383-2479166a6a6f)
