### PR TITLE
dorado: fixing typo on version restriction for hdf5

### DIFF
--- a/var/spack/repos/builtin/packages/dorado/package.py
+++ b/var/spack/repos/builtin/packages/dorado/package.py
@@ -26,7 +26,7 @@ class Dorado(CMakePackage, CudaPackage):
     depends_on("git", type="build")
     depends_on("curl", type="build")
     depends_on("cuda")
-    depends_on("hdf5@1.17:+hl+cxx+szip")
+    depends_on("hdf5@:1+hl+cxx+szip")
     depends_on("htslib@1.15.1")
     depends_on("openssl")
     depends_on("zstd")


### PR DESCRIPTION
I am pretty sure this was some typo and it just wasn't noticed until the 2.x development version for hdf5 was added in. 

Fixes #48442