### PR TITLE
mypy: (update->) remove python version to avoid error/warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ src_paths = "lib"
 honor_noqa = true
 
 [tool.mypy]
-python_version = 3.7
+python_version = 3.8
 files = ['lib/spack/llnl/**/*.py', 'lib/spack/spack/**/*.py', './var/spack/repos/builtin/packages/*/package.py']
 mypy_path = ['bin', 'lib/spack', 'lib/spack/external', 'var/spack/repos/builtin']
 allow_redefinition = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,6 @@ src_paths = "lib"
 honor_noqa = true
 
 [tool.mypy]
-python_version = 3.8
 files = ['lib/spack/llnl/**/*.py', 'lib/spack/spack/**/*.py', './var/spack/repos/builtin/packages/*/package.py']
 mypy_path = ['bin', 'lib/spack', 'lib/spack/external', 'var/spack/repos/builtin']
 allow_redefinition = true


### PR DESCRIPTION
This PR updates `pyproject.toml` entry for `mypy`'s python version since multiple PRs are getting the following output complaining about the python version:

```
==> Running mypy checks
/home/runner/work/spack/spack/pyproject.toml: [mypy]: python_version: Python 3.7 is not supported (must be 3.8 or higher). You may need to put quotes around your Python version
Success: no issues found in 634 source files
  mypy checks were clean
==> spack style checks were clean
```