### PR TITLE
dftd4, mctc-lib: enable cmake builds and add multicharge package

### DIFF
--- a/var/spack/repos/builtin/packages/dftd4/package.py
+++ b/var/spack/repos/builtin/packages/dftd4/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems import cmake, meson
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/dftd4/package.py
+++ b/var/spack/repos/builtin/packages/dftd4/package.py
@@ -49,8 +49,9 @@ class Dftd4(MesonPackage, CMakePackage):
     depends_on("py-cffi", when="+python")
     depends_on("python@3.6:", when="+python")
 
-    depends_on("mctc-lib build_system=cmake", when="build_system=cmake")
-    depends_on("multicharge", when="build_system=cmake")
+    for build_system in ["cmake", "meson"]:
+        depends_on(f"mctc-lib build_system={build_system}", when=f"build_system={build_system}")
+        depends_on(f"multicharge build_system={build_system}", when=f"build_system={build_system}")
 
     extends("python", when="+python")
 

--- a/var/spack/repos/builtin/packages/dftd4/package.py
+++ b/var/spack/repos/builtin/packages/dftd4/package.py
@@ -5,7 +5,7 @@
 from spack.package import *
 
 
-class Dftd4(MesonPackage):
+class Dftd4(MesonPackage, CMakePackage):
     """Generally Applicable Atomic-Charge Dependent London Dispersion Correction"""
 
     homepage = "https://www.chemie.uni-bonn.de/pctc/mulliken-center/software/dftd4"
@@ -15,6 +15,8 @@ class Dftd4(MesonPackage):
     maintainers("awvwgk")
 
     license("LGPL-3.0-only")
+
+    build_system("cmake", "meson", default="mason")
 
     version("main", branch="main")
     version("3.7.0", sha256="4e8749df6852bf863d5d1831780a2d30e9ac4afcfebbbfe5f6a6a73d06d6c6ee")
@@ -26,22 +28,38 @@ class Dftd4(MesonPackage):
     version("3.1.0", sha256="b652aa7cbf8d087c91bcf80f2d5801459ecf89c5d4176ebb39e963ee740ed54b")
     version("3.0.0", sha256="a7539d68d48d851bf37b79e37ea907c9da5eee908d0aa58a0a7dc15f04f8bc35")
 
-    depends_on("c", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
 
     variant("openmp", default=True, description="Use OpenMP parallelisation")
-    variant("python", default=False, description="Build Python extension module")
+    variant(
+        "python",
+        default=False,
+        when="build_system=meson",
+        description="Build Python extension module",
+    )
+
+    depends_on("meson@0.57.1:", type="build", when="build_system=meson")  # mesonbuild/meson#8377
 
     depends_on("blas")
     depends_on("lapack")
-    depends_on("mctc-lib")
-    depends_on("meson@0.57.1:", type="build")  # mesonbuild/meson#8377
     depends_on("pkgconfig", type="build")
+
     depends_on("py-cffi", when="+python")
     depends_on("python@3.6:", when="+python")
 
+    depends_on("mctc-lib build_system=cmake", when="build_system=cmake")
+    depends_on("multicharge", when="build_system=cmake")
+
     extends("python", when="+python")
 
+    def url_for_version(self, version):
+        if version <= Version("3.6.0"):
+            return f"https://github.com/dftd4/dftd4/releases/download/v{version}/dftd4-{version}-source.tar.xz"
+        return super().url_for_version(version)
+
+
+class MesonBuilder(spack.build_systems.meson.MesonBuilder):
     def meson_args(self):
         lapack = self.spec["lapack"].libs.names[0]
         if lapack == "lapack":
@@ -57,7 +75,7 @@ class Dftd4(MesonPackage):
             "-Dpython={0}".format(str("+python" in self.spec).lower()),
         ]
 
-    def url_for_version(self, version):
-        if version <= Version("3.6.0"):
-            return f"https://github.com/dftd4/dftd4/releases/download/v{version}/dftd4-{version}-source.tar.xz"
-        return super().url_for_version(version)
+
+class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+    def cmake_args(self):
+        return [self.define_from_variant("WITH_OPENMP", "openmp")]

--- a/var/spack/repos/builtin/packages/dftd4/package.py
+++ b/var/spack/repos/builtin/packages/dftd4/package.py
@@ -60,7 +60,7 @@ class Dftd4(MesonPackage, CMakePackage):
         return super().url_for_version(version)
 
 
-class MesonBuilder(spack.build_systems.meson.MesonBuilder):
+class MesonBuilder(meson.MesonBuilder):
     def meson_args(self):
         lapack = self.spec["lapack"].libs.names[0]
         if lapack == "lapack":
@@ -77,6 +77,6 @@ class MesonBuilder(spack.build_systems.meson.MesonBuilder):
         ]
 
 
-class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         return [self.define_from_variant("WITH_OPENMP", "openmp")]

--- a/var/spack/repos/builtin/packages/dftd4/package.py
+++ b/var/spack/repos/builtin/packages/dftd4/package.py
@@ -16,7 +16,7 @@ class Dftd4(MesonPackage, CMakePackage):
 
     license("LGPL-3.0-only")
 
-    build_system("cmake", "meson", default="mason")
+    build_system("cmake", "meson", default="meson")
 
     version("main", branch="main")
     version("3.7.0", sha256="4e8749df6852bf863d5d1831780a2d30e9ac4afcfebbbfe5f6a6a73d06d6c6ee")

--- a/var/spack/repos/builtin/packages/elsi/package.py
+++ b/var/spack/repos/builtin/packages/elsi/package.py
@@ -25,9 +25,9 @@ class Elsi(CMakePackage, CudaPackage):
     )
     version("master", branch="master")
 
-    depends_on("c", type="build")  # generated
-    depends_on("cxx", type="build")  # generated
-    depends_on("fortran", type="build")  # generated
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
 
     generator("ninja")
 

--- a/var/spack/repos/builtin/packages/mctc-lib/package.py
+++ b/var/spack/repos/builtin/packages/mctc-lib/package.py
@@ -5,16 +5,18 @@
 from spack.package import *
 
 
-class MctcLib(MesonPackage):
+class MctcLib(MesonPackage, CMakePackage):
     """Modular computation toolchain library for quantum chemistry file IO"""
 
     homepage = "https://github.com/grimme-lab/mctc-lib"
-    url = "https://github.com/grimme-lab/mctc-lib/releases/download/v0.3.0/mctc-lib-0.3.0.tar.xz"
+    url = "https://github.com/grimme-lab/mctc-lib/releases/download/v0.0.0/mctc-lib-0.0.0.tar.xz"
     git = "https://github.com/grimme-lab/mctc-lib"
 
     maintainers("awvwgk")
 
     license("Apache-2.0")
+
+    build_system("cmake", "meson", default="mason")
 
     version("main", branch="main")
     version("0.3.1", sha256="a5032a0bbbbacc952037c5215b71aa6b438767a84bafb60fda25ba43c8835513")
@@ -24,9 +26,17 @@ class MctcLib(MesonPackage):
 
     variant("json", default=False, description="Enable support for JSON")
 
-    depends_on("meson@0.57.2:", type="build")
+    depends_on("meson@0.57.2:", type="build", when="build_system=meson")
+
     depends_on("json-fortran@8:", when="+json")
     depends_on("pkgconfig", type="build")
 
+
+class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+    def cmake_args(self):
+        return [self.define_from_variant("WITH_JSON", "json")]
+
+
+class MesonBuilder(spack.build_systems.meson.MesonBuilder):
     def meson_args(self):
         return ["-Djson={0}".format("enabled" if "+json" in self.spec else "disabled")]

--- a/var/spack/repos/builtin/packages/mctc-lib/package.py
+++ b/var/spack/repos/builtin/packages/mctc-lib/package.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.buils_systems import cmake, meson
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/mctc-lib/package.py
+++ b/var/spack/repos/builtin/packages/mctc-lib/package.py
@@ -16,7 +16,7 @@ class MctcLib(MesonPackage, CMakePackage):
 
     license("Apache-2.0")
 
-    build_system("cmake", "meson", default="mason")
+    build_system("cmake", "meson", default="meson")
 
     version("main", branch="main")
     version("0.3.1", sha256="a5032a0bbbbacc952037c5215b71aa6b438767a84bafb60fda25ba43c8835513")

--- a/var/spack/repos/builtin/packages/mctc-lib/package.py
+++ b/var/spack/repos/builtin/packages/mctc-lib/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.buils_systems import cmake, meson
+from spack.build_systems import cmake, meson
 from spack.package import *
 
 
@@ -33,11 +33,11 @@ class MctcLib(MesonPackage, CMakePackage):
     depends_on("pkgconfig", type="build")
 
 
-class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         return [self.define_from_variant("WITH_JSON", "json")]
 
 
-class MesonBuilder(spack.build_systems.meson.MesonBuilder):
+class MesonBuilder(meson.MesonBuilder):
     def meson_args(self):
         return ["-Djson={0}".format("enabled" if "+json" in self.spec else "disabled")]

--- a/var/spack/repos/builtin/packages/multicharge/package.py
+++ b/var/spack/repos/builtin/packages/multicharge/package.py
@@ -16,7 +16,7 @@ class Multicharge(CMakePackage):
 
     license("Apache-2.0", checked_by="RMeli")
 
-    version("0.3.0", md5="7586576a425e4f3c74e5644049d100d7")
+    version("0.3.0", sha256="e8f6615d445264798b12d2854e25c93938373dc149bb79e6eddd23fc4309749d")
 
     variant("openmp", default=True, description="Enable OpenMP support")
 

--- a/var/spack/repos/builtin/packages/multicharge/package.py
+++ b/var/spack/repos/builtin/packages/multicharge/package.py
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.build_systems import cmake, meson
 from spack.package import *
 
 
-class Multicharge(CMakePackage):
+class Multicharge(CMakePackage, MesonPackage):
     """Electronegativity equilibration model for atomic partial charges"""
 
     homepage = "https://github.com/grimme-lab/multicharge"
@@ -16,13 +17,34 @@ class Multicharge(CMakePackage):
 
     license("Apache-2.0", checked_by="RMeli")
 
+    build_system("cmake", "meson", default="meson")
+
     version("0.3.0", sha256="e8f6615d445264798b12d2854e25c93938373dc149bb79e6eddd23fc4309749d")
 
     variant("openmp", default=True, description="Enable OpenMP support")
 
     depends_on("lapack")
-    depends_on("mctc-lib")
+    depends_on("mctc-lib build_system=cmake", when="build_system=cmake")
+    depends_on("mctc-lib build_system=meson", when="build_system=meson")
 
+
+class CMakeBuilder(cmake.CMakeBuilder):
     def cmake_args(self):
         args = [self.define_from_variant("WITH_OpenMP", "openmp")]
         return args
+
+
+class MesonBuilder(meson.MesonBuilder):
+    def meson_args(self):
+        lapack = self.spec["lapack"].libs.names[0]
+        if lapack == "lapack":
+            lapack = "netlib"
+        elif lapack.startswith("mkl"):
+            lapack = "mkl"
+        elif lapack != "openblas":
+            lapack = "auto"
+
+        return [
+            "-Dopenmp={0}".format(str("+openmp" in self.spec).lower()),
+            "-Dlapack={0}".format(lapack),
+        ]

--- a/var/spack/repos/builtin/packages/multicharge/package.py
+++ b/var/spack/repos/builtin/packages/multicharge/package.py
@@ -1,0 +1,30 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Multicharge(CMakePackage):
+    """Electronegativity equilibration model for atomic partial charges"""
+
+    homepage = "https://github.com/grimme-lab/multicharge"
+    url = "https://github.com/grimme-lab/multicharge/releases/download/v0.0.0/multicharge-0.0.0.tar.xz"
+    git = "https://github.com/grimme-lab/multicharge.git"
+
+    maintainers("RMeli", "awvwgk")
+
+    license("Apache-2.0", checked_by="RMeli")
+
+    version("0.3.0", md5="7586576a425e4f3c74e5644049d100d7")
+
+    variant("openmp", default=True, description="Enable OpenMP support")
+
+    depends_on("lapack")
+    depends_on("mctc-lib")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("WITH_OpenMP", "openmp"),
+        ]
+        return args

--- a/var/spack/repos/builtin/packages/multicharge/package.py
+++ b/var/spack/repos/builtin/packages/multicharge/package.py
@@ -24,7 +24,5 @@ class Multicharge(CMakePackage):
     depends_on("mctc-lib")
 
     def cmake_args(self):
-        args = [
-            self.define_from_variant("WITH_OpenMP", "openmp"),
-        ]
+        args = [self.define_from_variant("WITH_OpenMP", "openmp")]
         return args


### PR DESCRIPTION
This PR adds CMake as an alternative build system for `dftd4` and `mctc-lib`, which makes it easier to integrate the projects in other CMake-based projects. It also adds the `multicharge` package.