### PR TITLE
BF+ENH: Add wxwidgets 3.2.6 and py-wxpython 4.2.2, missing pkgconfig dep

### DIFF
--- a/var/spack/repos/builtin/packages/py-wxpython/package.py
+++ b/var/spack/repos/builtin/packages/py-wxpython/package.py
@@ -11,6 +11,7 @@ class PyWxpython(PythonPackage):
     homepage = "https://www.wxpython.org/"
     pypi = "wxPython/wxPython-4.0.6.tar.gz"
 
+    version("4.2.2", sha256="5dbcb0650f67fdc2c5965795a255ffaa3d7b09fb149aa8da2d0d9aa44e38e2ba")
     version("4.1.1", sha256="00e5e3180ac7f2852f342ad341d57c44e7e4326de0b550b9a5c4a8361b6c3528")
     version("4.0.6", sha256="35cc8ae9dd5246e2c9861bb796026bbcb9fb083e4d49650f776622171ecdab37")
 
@@ -18,10 +19,12 @@ class PyWxpython(PythonPackage):
     depends_on("cxx", type="build")  # generated
 
     depends_on("wxwidgets +gui")
+    depends_on("wxwidgets@3.2.6 +gui", when="@4.2.2")
 
     # Needed for the build.py script
     depends_on("py-setuptools", type="build")
     depends_on("py-pathlib2", type="build")
+    depends_on("pkgconfig", type="build")
 
     # Needed at runtime
     depends_on("py-numpy", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-wxpython/package.py
+++ b/var/spack/repos/builtin/packages/py-wxpython/package.py
@@ -24,9 +24,13 @@ class PyWxpython(PythonPackage):
     # Needed for the build.py script
     depends_on("py-setuptools", type="build")
     depends_on("py-pathlib2", type="build")
-    depends_on("pkgconfig", type="build")
 
     # Needed at runtime
     depends_on("py-numpy", type=("build", "run"))
     depends_on("pil", type=("build", "run"))
     depends_on("py-six", type=("build", "run"))
+
+    def setup_build_environment(self, env):
+        # By default wxWdigets is built as well instead of using spack provided version,
+        # this tells it to just build the python extensions
+        env.set("WXPYTHON_BUILD_ARGS", "build_py --use_syswx")

--- a/var/spack/repos/builtin/packages/py-wxpython/package.py
+++ b/var/spack/repos/builtin/packages/py-wxpython/package.py
@@ -23,6 +23,7 @@ class PyWxpython(PythonPackage):
 
     # Needed for the build.py script
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@:75", type="build", when="@:4.1")  # deprecated license-file
     depends_on("py-pathlib2", type="build")
 
     # Needed at runtime

--- a/var/spack/repos/builtin/packages/wxwidgets/package.py
+++ b/var/spack/repos/builtin/packages/wxwidgets/package.py
@@ -22,6 +22,7 @@ class Wxwidgets(AutotoolsPackage):
     git = "https://github.com/wxWidgets/wxWidgets.git"
 
     version("develop", branch="master")
+    version("3.2.6", sha256="939e5b77ddc5b6092d1d7d29491fe67010a2433cf9b9c0d841ee4d04acb9dce7")
     version("3.2.5", sha256="0ad86a3ad3e2e519b6a705248fc9226e3a09bbf069c6c692a02acf7c2d1c6b51")
     version("3.2.4", sha256="0640e1ab716db5af2ecb7389dbef6138d7679261fbff730d23845ba838ca133e")
     version("3.2.2.1", sha256="dffcb6be71296fff4b7f8840eb1b510178f57aa2eb236b20da41182009242c02")


### PR DESCRIPTION
Improves compat with newer Python (>3.9) and numpy.

Fix error during configure step (even on at least some older versions) by including 'pkgconfig' as a build dep so gtk+ is found.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
