### PR TITLE
openPMD-api: add v0.16.1

### DIFF
--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -9,7 +9,7 @@ class OpenpmdApi(CMakePackage):
     """C++ & Python API for Scientific I/O"""
 
     homepage = "https://www.openPMD.org"
-    url = "https://github.com/openPMD/openPMD-api/archive/0.16.0.tar.gz"
+    url = "https://github.com/openPMD/openPMD-api/archive/0.16.1.tar.gz"
     git = "https://github.com/openPMD/openPMD-api.git"
 
     maintainers("ax3l", "franzpoeschel")
@@ -20,6 +20,7 @@ class OpenpmdApi(CMakePackage):
 
     # C++17 up until here
     version("develop", branch="dev")
+    version("0.16.1", sha256="a029a1779351949f41c1f36d0e75c698e59c5d284f080d5e4c2b8650779d2d58")
     version("0.16.0", sha256="b52222a4ab2511f9e3f6e21af222f57ab4fb6228623024fc5d982066333e104f")
     version("0.15.2", sha256="fbe3b356fe6f4589c659027c8056844692c62382e3ec53b953bed1c87e58ba13")
     version("0.15.1", sha256="0e81652152391ba4d2b62cfac95238b11233a4f89ff45e1fcffcc7bcd79dabe1")
@@ -60,6 +61,7 @@ class OpenpmdApi(CMakePackage):
     depends_on("mpark-variant@1.4.0:", when="@:0.14")  # pre C++17 releases
     depends_on("toml11@3.7.1:3", when="@0.15")
     depends_on("toml11@3.7.1:", when="@0.16:")
+    depends_on("toml11@4.2.0: cxx_std=17", when="@0.16.1:")
     with when("+hdf5"):
         depends_on("hdf5@1.8.13:")
         depends_on("hdf5@1.8.13: ~mpi", when="~mpi")

--- a/var/spack/repos/builtin/packages/toml11/package.py
+++ b/var/spack/repos/builtin/packages/toml11/package.py
@@ -17,6 +17,8 @@ class Toml11(CMakePackage):
 
     license("MIT")
 
+    version("4.3.0", sha256="af95dab1bbb9b05a597e73d529a7269e13f1869e9ca9bd4779906c5cd96e282b")
+    version("4.2.0", sha256="9287971cd4a1a3992ef37e7b95a3972d1ae56410e7f8e3f300727ab1d6c79c2c")
     version("4.0.2", sha256="d1bec1970d562d328065f2667b23f9745a271bf3900ca78e92b71a324b126070")
     version("4.0.1", sha256="96965cb00ca7757c611c169cd5a6fb15736eab1cd1c1a88aaa62ad9851d926aa")
     version("4.0.0", sha256="f3dc3095f22e38745a5d448ac629f69b7ee76d2b3e6d653e4ce021deb7f7266e")


### PR DESCRIPTION
Add the latest release of openPMD-api.

Add latest versions of TOML11, because openPMD-api depends on it.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
